### PR TITLE
feat(#2906): slice 3 — CFG-aware resume-machine core (AsyncCfgPlan + generic terminator-driven emitter)

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -2,7 +2,7 @@
 id: 2906
 title: "Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)"
 status: in-progress
-assignee: ttraenkler/sendev-async-multistate
+assignee: ttraenkler/fable-2906
 created: 2026-07-01
 priority: high
 feasibility: hard
@@ -279,3 +279,185 @@ this same abrupt-completion machinery; the slice-1d widen stays LAST.
 ## Reconciliation note (shepherd, 2026-07-01)
 
 Landed slices: **slice 1** general N-state async resume machine (PR #2413), **slice 2 / Gap 3** try/finally-across-await on the N-state machine (PR #2416). Issue stays `in-progress` for the remaining slices.
+
+## Slice 3 — CFG-aware machine core (this PR, 2026-07-03)
+
+**What ships.** The drive-layer emitter is generalized from the implicit linear
+chain (state `s` always continues at `s+1`; try/finally = one boolean flag) to a
+**general CFG plan** — the durable substrate every remaining slice extends
+without touching the emitter again:
+
+- **`async-cps.ts`** — `AsyncCfgPlan`: `states` (basic blocks: optional
+  `resumeFrom` prelude + handler-annotated `lead` statements + exactly one
+  `terminator`) and `handlers` (try-region table). Terminators:
+  `suspend {awaited, resumeState, handler}` · `goto {target}` ·
+  `condGoto {cond, whenTrue, whenFalse, handler}` · `settleSent` ·
+  `settleUndefined`. The **emitter contract** (dense ids; goto/condGoto targets
+  have no resume prelude; handler ids 1-based dense, `parent === 0` until 3c) is
+  documented in the file's contract block. `linearPlanToCfg(linear)` converts a
+  `LinearAwaitPlan` into the trivial chain and is the ONLY producer this slice.
+- **`async-frame.ts`** — `ensureAsyncResumeFunction` now drives `AsyncCfgPlan`:
+  one generic `buildStateBody(state)` replaces
+  `buildAwaitSegment`/`buildFinalSegment`; the slice-2 `inSrcTry` boolean is now
+  the **handler-region-id local** (i32, 0 = none — single-region plans emit
+  byte-identical 0/1 toggles); the outer catch routes by region id (truthiness
+  guard for one region ≡ slice 2, id-equality guards for sibling regions).
+  `validateAsyncCfg` hard-fails (compile error, not a miscompile) any future
+  planner that violates the contract. **`br`-depth model**: from a state arm's
+  top level the re-dispatch loop is at depth `id + 2` (dispatch if-chain nesting
+  == id); `goto`/`condGoto` emit `STATE=<target>; br <loop>`, so a **back-edge
+  is just a target ≤ the current id** — loops need NO new emitter machinery.
+  `condGoto` compiles its condition with `ensureI32Condition` truthiness and
+  br's at `loopDepth + 1` (inside its own `if` arm).
+
+**Byte-inertness proof** (`.tmp/hash-async-lanes.mts`, 27 program×lane sha256
+hashes): plain / singleAwait / multiAwait / bareAwaits / returnAwait /
+tryFinally / syncFulfilledLocal / promiseAllHost / awaitArith, each under
+gc(default) + standalone + wasi — **all identical before vs after**, including
+the wasi drive lane and the #1042 host-drive lane (`linearPlanToCfg` reproduces
+the exact pre-CFG instruction stream; goto/condGoto are producer-unreachable
+this slice). Test control: the 10 async test files (89 tests) — 85 pass, the
+same 4 pre-existing failures as on `origin/main` (2× issue-2865 AG0 wasi, 2×
+promise-combinators host — their compiled binaries hash-identical to main's, so
+they cannot be #2906-slice-3 regressions).
+
+**#2980 coordination**: this slice does not touch either carrier gate
+(`isStandalonePromiseActive` / `isStandaloneThenChainNativeActive`) and is
+byte-identical everywhere, so it neither constrains nor is constrained by the
+slice-1d carrier-widen decision — the widen simply flips which lanes reach this
+(unchanged-shape) machine.
+
+## Design (banked): how the remaining shapes map onto the CFG machine
+
+The remaining slices are **planner-only** — each produces `AsyncCfgState[]` and
+the emitter (validated, byte-stable) does the rest. Written for execution by a
+non-Fable dev; read the emitter-contract block in `async-cps.ts` first.
+
+### 3a — while/do-while-with-await (the back-edge validation slice)
+
+Lowering for `while (cond) { body… (≥1 canonical await) }`:
+
+```
+state h   (loop head, resumeFrom: null): lead=[], terminator condGoto(cond, b, e)
+state b…  (body states, as linear lowering): last body state's terminator
+          suspends with resumeState → a continuation state whose terminator is
+          goto(h)   ← the back-edge
+state e   (exit): the statements after the loop (continues the outer chain)
+```
+
+Implementation notes (the hazards a cheaper model must not skip):
+
+1. **New producer, not a `LinearAwaitPlan` retrofit.** Introduce
+   `planAsyncCfg(fn, plan, opts): AsyncCfgPlan | null` in `async-cps.ts` that
+   subsumes `lowerLinearStatements` but builds states directly (keep
+   `planLinearAwaits` delegating to it or converting via `linearPlanToCfg` —
+   whichever keeps the linear byte-hash identical; PROVE with the probe).
+   Placeholder-patch forward targets (exit-state id unknown until the loop body
+   is lowered): build with `target: -1` + a patch list, resolve before
+   `validateAsyncCfg`.
+2. **Eligibility gates**: `asyncFnNeedsDrive`/`asyncFnNeedsHostDrive` +
+   `computeAsyncSpills` all call `planLinearAwaits` today — route them through
+   the new planner ONCE, not three divergent copies. Gate loop acceptance to
+   the **native drive lane first** (`opts.allowLoops` true only from
+   `asyncFnNeedsDrive`) so the gc/host lanes stay byte-identical; widen the
+   host lane in a follow-up with its own corpus check (the host lane suspends
+   on EVERY await — N iterations = N microtask rounds; correct but must be
+   tested with real drains).
+3. **Liveness across back-edges (the silent-miscompile trap).** The
+   `liveAfterAwait` sets are TEXTUAL-remainder based. For an await inside a
+   loop, a local read textually BEFORE the await is read again on the next
+   iteration AFTER the resume — so the live set for any await inside a loop
+   must be widened to include **every own-local referenced anywhere in the
+   loop statement** (∪ the textual remainder). Same rule for the spill set.
+4. **Resume bindings in a loop are self-live**: `bindingLiveAcrossLaterAwait`
+   must treat the binding's OWN await as "later" through the back-edge (spill
+   it; it round-trips the frame each iteration). Simplest correct rule: inside
+   a loop, every resume binding is spilled (still subject to the
+   spill-safe-type gate).
+5. **Reject and fall back (legacy/AG0) on**: `break`/`continue` targeting the
+   loop (until 3a′ adds them as `goto exit` / `goto head` — they are trivially
+   expressible, but each needs a test), `try` interacting with the loop,
+   awaits in the loop CONDITION (needs a condition-eval state — expressible,
+   separate follow-up), labeled statements.
+6. **Tests**: pending-then-fulfilled across ≥2 iterations via
+   `__drain_microtasks`; a binding carried across the back-edge; zero-iteration
+   loop (cond false first — straight to exit, no resume ever fires); rejection
+   inside iteration k>1 routes to the result promise. Plus the byte-hash probe
+   for non-loop programs (must stay identical).
+
+### 3b — for-await-of (async-iterator drive on 3a machinery)
+
+`for await (const x of expr) body` lowers to (all on existing terminators):
+
+```
+init:  it = GetAsyncIterator(expr)        — [Symbol.asyncIterator] ?? wrap the
+       sync iterator (each sync next() result is PromiseResolve'd); spill `it`.
+head:  r = it.next()                       — suspend(r, resume → chk)
+chk:   resumeFrom binds step (IteratorResult); condGoto(step.done, exit, bodyStart)
+body…: bind x = step.value; body states; last terminator goto(head)
+exit:  continue the outer chain
+```
+
+`step.done`/`step.value` reads go through the existing IteratorResult shape
+(`{value,done}` — `RESULT_VALUE_FIELD`/`RESULT_DONE_FIELD` for native frames,
+dynamic reads for host results). First slice: no `break`/`continue`/`throw`
+inside the body (abrupt loop exit must call `it.return()` — an async close,
+itself a suspend — bank as 3b′), no destructuring binding. Converges with the
+#2865/#2867 Gap-5 corpus (the −32 for-await/async-gen cluster in #2980).
+
+### 3c — try/catch + return-through-finally + nested regions (completion replay)
+
+The full ES completion semantics on the frame's EXISTING `MODE`/`ABRUPT`/
+`ERROR` fields (frame-core reserved them from the start):
+
+1. **Restructure the dispatcher** from `try { block { loop { chain } } } catch`
+   to `block { loop { try { chain } catch $exn { route } } }` so an abrupt
+   completion becomes a STATE TRANSITION: the catch routes by the region-id
+   local — region has a `catchState` → `ERROR=reason; MODE=THROW;
+   STATE=catchState; br <loop>` (the catch body is ordinary states and MAY
+   await); no region → settle-reject + return (today's behaviour). NOTE: this
+   moves every arm's `br`-to-loop depth by +1 (the try block wraps the chain)
+   — change `loopDepth` in ONE place (`buildStateBody`) and re-prove the
+   byte-hash on a `main` control before/after is *expectedly different* here,
+   so instead prove semantics via the full async test files + new tests.
+2. **Handler regions generalize**: `{ id, parent, catchState?, finallyState?,
+   finalizer? }`. A finally that must support replay becomes states
+   (`finallyState` entry); its terminator is a new `replay` terminator: read
+   MODE — NEXT → goto(normal successor); THROW → set region local to `parent`,
+   re-throw ERROR (routes to the next outer region); RETURN → settle the
+   result promise with ABRUPT (or route through the next enclosing finally).
+   `return` inside a try records `MODE=RETURN; ABRUPT=value; goto(finallyState)`
+   instead of settling directly (the `asyncDriveReturn` hook grows a
+   per-region indirection).
+3. **Nested regions**: `validateAsyncCfg` currently rejects `parent !== 0` —
+   lift that ONLY when the catch routing walks the parent chain. Sibling
+   regions (two sequential try/finallys, both parent 0) already route
+   correctly with the id-equality guards and may ship before full nesting.
+
+### 3d — async generators (AG2 `$Frame`/`$AsyncFrame` convergence)
+
+Sketch (own design pass before execution): an async-gen frame is an
+`$AsyncFrame` + a result-promise QUEUE. `yield` is a new `settleYield`
+terminator: fulfil the CURRENT `next()`-promise with `{value, done:false}` and
+`return`; `next(v)` allocates a fresh pending result promise, stores SENT=v,
+kicks resume. `await` inside the gen uses the existing suspend terminator
+against the awaited promise (resume writes SENT, NOT the result queue). The
+generator trampoline's yield-dispatch and this machine's await-dispatch share
+STATE — they compose because both are `br_table`-over-STATE with disjoint
+suspend kinds. Reuse `generators-native.ts` result-struct helpers; do NOT fork
+the frame ABI (both layouts already share frame-core).
+
+### Integration points (for the owning issues)
+
+- **#2957 phases 2-3 (async arrows/methods/fn-exprs)**: the drive branches in
+  `function-body.ts` (~L1163 and ~L1186) gate on `ts.isFunctionDeclaration` —
+  activation for other function kinds is a call-site/naming problem
+  (`asyncFnName` already synthesizes `anon_<pos>` names), NOT a machine
+  problem; the machine is shape-agnostic.
+- **#2967 (engine convergence)**: `asyncFnNeedsCps`'s single-tail-await JS-host
+  CPS lane can retire onto `asyncFnNeedsHostDrive` once the host lane accepts
+  every CPS shape — measure with the #1042 census, then delete
+  `emitAsyncStateMachine` (one machine, two settle backends).
+- **#2980 slice-1d (carrier widen)**: stays LAST, after 3a/3b land, gated on
+  the full merge_group standalone corpus measuring net-positive. This slice
+  changed nothing it depends on.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -21,20 +21,20 @@
 // The full lowering (segment emission, capture structs, Promise.then chaining)
 // lands in follow-up PRs. See plan/issues/backlog/1042-async-await-state-machine-lowering.md.
 
-import { ts, forEachChild } from "../ts-api.js";
-import { reportError } from "./context/errors.js";
-import type { CodegenContext, FunctionContext } from "./context/types.js";
-import type { Instr, ValType } from "../ir/types.js";
-import {
-  collectReferencedIdentifiers,
-  collectBindingPatternNames,
-  compileSyntheticAsyncContinuation,
-  type AsyncCapture,
-} from "./closures.js";
-import { compileExpression, compileStatement, coerceType } from "./shared.js";
-import { allocLocal } from "./context/locals.js";
-import { resolveWasmType } from "./index.js";
 import { isPromiseType } from "../checker/type-mapper.js";
+import type { Instr, ValType } from "../ir/types.js";
+import { forEachChild, ts } from "../ts-api.js";
+import {
+  type AsyncCapture,
+  collectBindingPatternNames,
+  collectReferencedIdentifiers,
+  compileSyntheticAsyncContinuation,
+} from "./closures.js";
+import { reportError } from "./context/errors.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { resolveWasmType } from "./index.js";
+import { coerceType, compileExpression, compileStatement } from "./shared.js";
 
 /**
  * Master gate for the AST-side async CPS lowering.
@@ -497,7 +497,11 @@ export function emitAsyncStateMachine(
 function emitMakeContinuationCallback(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  cont: { cbId: number; capStructTypeIdx: number; captures: readonly AsyncCapture[] },
+  cont: {
+    cbId: number;
+    capStructTypeIdx: number;
+    captures: readonly AsyncCapture[];
+  },
   makeCbIdx: number,
 ): void {
   // arg0: the callback id (i32) — __make_callback dispatches exports[`__cb_${id}`].
@@ -510,7 +514,10 @@ function emitMakeContinuationCallback(
     for (const cap of cont.captures) {
       fctx.body.push({ op: "local.get", index: cap.localIdx } as Instr);
     }
-    fctx.body.push({ op: "struct.new", typeIdx: cont.capStructTypeIdx } as Instr);
+    fctx.body.push({
+      op: "struct.new",
+      typeIdx: cont.capStructTypeIdx,
+    } as Instr);
     fctx.body.push({ op: "extern.convert_any" } as Instr);
   } else {
     fctx.body.push({ op: "ref.null.extern" } as Instr);
@@ -569,7 +576,10 @@ export function emitAsyncStateMachineFromIr(): boolean {
 export interface AwaitSplit {
   readonly prefix: readonly ts.Statement[];
   readonly awaitedExpr: ts.Expression;
-  readonly resumeBinding: { readonly name: string; readonly type: ts.TypeNode | undefined } | null;
+  readonly resumeBinding: {
+    readonly name: string;
+    readonly type: ts.TypeNode | undefined;
+  } | null;
   readonly suffix: readonly ts.Statement[];
   readonly isReturnAwait: boolean;
 }
@@ -615,7 +625,13 @@ export function splitBodyAtAwait(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsP
     // Shape 1: `return await P;`
     if (ts.isReturnStatement(stmt) && stmt.expression && stmt.expression === awaitNode) {
       if (suffix.length !== 0) return null; // dead code after return; reject for PR1
-      return { prefix, awaitedExpr: awaitNode.expression, resumeBinding: null, suffix: [], isReturnAwait: true };
+      return {
+        prefix,
+        awaitedExpr: awaitNode.expression,
+        resumeBinding: null,
+        suffix: [],
+        isReturnAwait: true,
+      };
     }
 
     // Shape 2: `const x = await P;` (single declarator, identifier name)
@@ -635,7 +651,13 @@ export function splitBodyAtAwait(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsP
 
     // Shape 3: `await P;` (bare expression statement)
     if (ts.isExpressionStatement(stmt) && stmt.expression === awaitNode) {
-      return { prefix, awaitedExpr: awaitNode.expression, resumeBinding: null, suffix, isReturnAwait: false };
+      return {
+        prefix,
+        awaitedExpr: awaitNode.expression,
+        resumeBinding: null,
+        suffix,
+        isReturnAwait: false,
+      };
     }
 
     // The await sits inside an unsupported position within this statement.
@@ -673,7 +695,10 @@ export interface LinearAwaitSegment {
    * `null` for a bare `await P;` / `return await P`. Delivered fresh from
    * `SENT_FIELD` on resume — never snapshotted at suspend time.
    */
-  readonly resumeBinding: { readonly name: string; readonly type: ts.TypeNode | undefined } | null;
+  readonly resumeBinding: {
+    readonly name: string;
+    readonly type: ts.TypeNode | undefined;
+  } | null;
   /** `return await P` — the resolved value settles the result promise directly. */
   readonly isReturnAwait: boolean;
   /**
@@ -750,7 +775,12 @@ export function planLinearAwaits(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsP
   // Every await must have been consumed into a segment (defensive; a stray await
   // in a `lead` statement would have made `awaitsHere > 0` and been handled).
   if (st.segments.length !== plan.awaitPoints.length) return null;
-  return { segments: st.segments, tail: st.lead, tailInTry: st.leadInTry, finalizer: st.theFinalizer };
+  return {
+    segments: st.segments,
+    tail: st.lead,
+    tailInTry: st.leadInTry,
+    finalizer: st.theFinalizer,
+  };
 }
 
 /** Mutable accumulator threaded through the recursive linear-await lowering. */
@@ -934,6 +964,175 @@ function statementContainsNode(stmt: ts.Node, node: ts.Node): boolean {
   };
   walk(stmt);
   return found;
+}
+
+// ---------------------------------------------------------------------------
+// CFG-aware resume-machine plan (#2906 slice 3 — the general state graph).
+//
+// `LinearAwaitPlan` above encodes control flow IMPLICITLY: state `s` always
+// continues at `s+1`, the tail runs last, and the single try/finally is a
+// per-statement boolean. That shape cannot express a loop back-edge (for-await /
+// while-with-await), a conditional branch between states, `try/catch` regions,
+// or completion replay through an awaited finally. `AsyncCfgPlan` is the general
+// contract between the PLANNER (which lowers an async body into states) and the
+// DRIVE-LAYER EMITTER (`async-frame.ts ensureAsyncResumeFunction`, which turns
+// states into the dispatch machine):
+//
+//   - a **state** is a basic block of the async CFG: an optional resume prelude
+//     (deliver the predecessor await's value / re-throw its rejection), a list
+//     of handler-annotated lead statements, and exactly one **terminator**;
+//   - a **terminator** transfers control: `suspend` (await → resume at
+//     `resumeState`), `goto` / `condGoto` (state transition, incl. back-edges —
+//     emitted as `STATE=<target>; br <re-dispatch loop>`, so a target ≤ the
+//     current id is a loop), and `settleSent` / `settleUndefined` (fulfil the
+//     result promise);
+//   - a **handler region** is a lexical try region; every statement/terminator
+//     carries the region id it executes in (0 = none). The emitter maintains a
+//     region-id local across the machine and the outer catch routes abrupt
+//     completions by it (slice-2 semantics: run the region's await-free
+//     finalizer, then reject).
+//
+// Emitter contract (MUST hold for every plan a planner produces):
+//   1. State ids are DENSE and equal to their index in `states` (the dispatch
+//      if-chain depth arithmetic depends on it).
+//   2. A state with `resumeFrom !== null` is entered ONLY through its await's
+//      resume/advance (it is exactly one suspend terminator's `resumeState`);
+//      `goto`/`condGoto` targets must have `resumeFrom: null`. State 0 (the
+//      entry) has `resumeFrom: null`.
+//   3. `suspend.resumeState` / `goto.target` / `condGoto.whenTrue|whenFalse`
+//      name existing state ids.
+//   4. Handler ids are 1-based and dense; `handlers[i].id === i + 1`.
+//
+// Slice 3 ships the emitter for this full contract plus `linearPlanToCfg` (the
+// trivial chain producer), so richer shapes — loops, try/catch, for-await —
+// are PLANNER-ONLY follow-ups that never touch the emitter again.
+// ---------------------------------------------------------------------------
+
+/** One handler-annotated statement of a state's straight-line lead. */
+export interface AsyncCfgStmt {
+  readonly stmt: ts.Statement;
+  /** Handler region this statement executes in (0 = none). */
+  readonly handler: number;
+}
+
+/**
+ * The resume prelude of a state that is some await's `resumeState`: re-throw a
+ * rejected predecessor (arming its handler region first so the finalizer runs),
+ * then bind the delivered `SENT_FIELD` value.
+ */
+export interface AsyncResumePoint {
+  readonly binding: {
+    readonly name: string;
+    readonly type: ts.TypeNode | undefined;
+  } | null;
+  /** Handler region the suspended await sat in (0 = none). */
+  readonly handler: number;
+}
+
+/** A state's single control-transfer. See the contract block above. */
+export type AsyncCfgTerminator =
+  | {
+      readonly kind: "suspend";
+      /** The await operand (assimilated to a `$Promise` / host promise). */
+      readonly awaited: ts.Expression;
+      /** State entered on resume AND on the synchronous fulfilled/rejected advance. */
+      readonly resumeState: number;
+      /** Handler region the await executes in (0 = none). */
+      readonly handler: number;
+    }
+  | { readonly kind: "goto"; readonly target: number }
+  | {
+      readonly kind: "condGoto";
+      /** Condition, compiled with `ensureI32Condition` truthiness. */
+      readonly cond: ts.Expression;
+      readonly whenTrue: number;
+      readonly whenFalse: number;
+      /** Handler region the condition evaluates in (0 = none). */
+      readonly handler: number;
+    }
+  | { readonly kind: "settleSent" } // `return await P` — fulfil with SENT directly
+  | { readonly kind: "settleUndefined" }; // fall off the body — fulfil with undefined
+
+/** One basic block of the async CFG. */
+export interface AsyncCfgState {
+  readonly id: number;
+  readonly resumeFrom: AsyncResumePoint | null;
+  readonly lead: readonly AsyncCfgStmt[];
+  readonly terminator: AsyncCfgTerminator;
+}
+
+/**
+ * A lexical try region whose completion routing the machine owns. Slice-3
+ * scope: an await-free `finalizer` run by the outer catch before rejecting
+ * (slice-2 semantics). The catch-body / replay-through-finally generalization
+ * (regions with `catchState`/`finallyState` entries that are themselves states)
+ * is the 3c planner+emitter follow-up — see the issue design notes.
+ */
+export interface AsyncHandlerRegion {
+  /** 1-based dense id (0 means "no region" everywhere else). */
+  readonly id: number;
+  /** Enclosing region id (0 = none). Single-region plans use 0. */
+  readonly parent: number;
+  /** Await-free finally body, compiled a second time into the outer catch. */
+  readonly finalizer: readonly ts.Statement[];
+}
+
+/** The full machine plan the drive-layer emitter consumes. */
+export interface AsyncCfgPlan {
+  readonly states: readonly AsyncCfgState[];
+  readonly handlers: readonly AsyncHandlerRegion[];
+}
+
+/**
+ * Lower a {@link LinearAwaitPlan} into the equivalent {@link AsyncCfgPlan}: the
+ * trivial chain 0 → 1 → … → N where state `k` suspends on await `k` and state
+ * `N` runs the tail (or settles SENT for `return await`). The single optional
+ * finalizer becomes handler region 1. Pure; emits nothing.
+ *
+ * This converter is deliberately the ONLY producer in slice 3, so the emitted
+ * machine is byte-identical to the pre-CFG emitter for every accepted shape —
+ * richer planners (loops, try/catch, for-await) plug in behind the same plan
+ * type without touching the emitter.
+ */
+export function linearPlanToCfg(linear: LinearAwaitPlan): AsyncCfgPlan {
+  const handlers: AsyncHandlerRegion[] =
+    linear.finalizer !== null ? [{ id: 1, parent: 0, finalizer: linear.finalizer }] : [];
+  const N = linear.segments.length;
+  const states: AsyncCfgState[] = [];
+  for (let k = 0; k < N; k++) {
+    const seg = linear.segments[k]!;
+    const prev = k > 0 ? linear.segments[k - 1]! : null;
+    states.push({
+      id: k,
+      resumeFrom: prev ? { binding: prev.resumeBinding, handler: prev.awaitInTry ? 1 : 0 } : null,
+      lead: seg.leadStmts.map((stmt, i) => ({
+        stmt,
+        handler: seg.leadInTry[i] ? 1 : 0,
+      })),
+      terminator: {
+        kind: "suspend",
+        awaited: seg.awaitedExpr,
+        resumeState: k + 1,
+        handler: seg.awaitInTry ? 1 : 0,
+      },
+    });
+  }
+  const last = linear.segments[N - 1]!;
+  states.push({
+    id: N,
+    resumeFrom: {
+      binding: last.resumeBinding,
+      handler: last.awaitInTry ? 1 : 0,
+    },
+    lead: last.isReturnAwait
+      ? []
+      : linear.tail.map((stmt, i) => ({
+          stmt,
+          handler: linear.tailInTry[i] ? 1 : 0,
+        })),
+    terminator: last.isReturnAwait ? { kind: "settleSent" } : { kind: "settleUndefined" },
+  });
+  return { states, handlers };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -1,3 +1,4 @@
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
  * Host-free async-frame substrate (#2895 PATH B, slice 1 — foundation).
@@ -34,38 +35,43 @@
  * `standalone` only *together with* that drive layer (re-widening it before the
  * drive layer exists is precisely the AG0 −31 regression).
  */
-import { ts, forEachChild } from "../ts-api.js";
-import type { CodegenContext, FunctionContext } from "./context/types.js";
-import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import { forEachChild, ts } from "../ts-api.js";
+import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint, LinearAwaitPlan } from "./async-cps.js";
 import {
-  PARAM_FIELD_OFFSET,
-  STATE_FIELD,
-  SENT_FIELD,
-  MODE_FIELD,
-  MODE_THROW,
-  ERROR_FIELD,
-  sanitizeTypeName,
-  storeSpills,
-  setStateI32FromConst,
-  defaultSpillInstr,
-} from "./frame-core.js";
-import { ensureExnTag } from "./registry/imports.js";
-import type { AsyncCpsPlan, LinearAwaitPlan } from "./async-cps.js";
-import { planLinearAwaits, awaitedExprIsPromiseCombinator, ASYNC_CPS_ENABLED, asyncFnNeedsCps } from "./async-cps.js";
-import { resolveSpillLocalValType } from "./statements/variables.js";
-import { allocLocal } from "./context/locals.js";
-import { addFuncType } from "./registry/types.js";
-import { compileExpression, compileStatement, coerceType } from "./shared.js";
-import { reportError } from "./context/errors.js";
-import { resolveWasmType } from "./index.js";
+  ASYNC_CPS_ENABLED,
+  asyncFnNeedsCps,
+  awaitedExprIsPromiseCombinator,
+  linearPlanToCfg,
+  planLinearAwaits,
+} from "./async-cps.js";
 import {
+  type AsyncDriveRuntime,
+  PROMISE_STATE_FULFILLED,
+  PROMISE_STATE_PENDING,
+  PROMISE_STATE_REJECTED,
   ensureAsyncDriveRuntime,
   getOrRegisterPromiseType,
-  type AsyncDriveRuntime,
-  PROMISE_STATE_PENDING,
-  PROMISE_STATE_FULFILLED,
-  PROMISE_STATE_REJECTED,
 } from "./async-scheduler.js";
+import { reportError } from "./context/errors.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import {
+  ERROR_FIELD,
+  MODE_FIELD,
+  MODE_THROW,
+  PARAM_FIELD_OFFSET,
+  SENT_FIELD,
+  STATE_FIELD,
+  defaultSpillInstr,
+  sanitizeTypeName,
+  setStateI32FromConst,
+  storeSpills,
+} from "./frame-core.js";
+import { ensureI32Condition, resolveWasmType } from "./index.js";
+import { ensureExnTag } from "./registry/imports.js";
+import { addFuncType } from "./registry/types.js";
+import { coerceType, compileExpression, compileStatement } from "./shared.js";
+import { resolveSpillLocalValType } from "./statements/variables.js";
 
 /**
  * Is the host-free async **drive layer** (#2895 PATH B) active for this module?
@@ -131,7 +137,14 @@ export function resolveHostAsyncImports(ctx: CodegenContext): HostAsyncImports |
   ) {
     return null;
   }
-  return { promiseResolveIdx, then2Idx, makeCbIdx, newPendingIdx, settleResolveIdx, settleRejectIdx };
+  return {
+    promiseResolveIdx,
+    then2Idx,
+    makeCbIdx,
+    newPendingIdx,
+    settleResolveIdx,
+    settleRejectIdx,
+  };
 }
 
 /**
@@ -291,13 +304,21 @@ export function buildAsyncFrameInfo(
   ];
 
   for (let i = 0; i < paramTypes.length; i++) {
-    stateFields.push({ name: `param_${paramNames[i] ?? i}`, type: paramTypes[i]!, mutable: false });
+    stateFields.push({
+      name: `param_${paramNames[i] ?? i}`,
+      type: paramTypes[i]!,
+      mutable: false,
+    });
   }
 
   const spillFieldOffset = PARAM_FIELD_OFFSET + paramTypes.length;
   const { spillNames, spillTypes } = computeAsyncSpills(ctx, decl, plan, paramNames);
   for (let i = 0; i < spillNames.length; i++) {
-    stateFields.push({ name: `spill_${spillNames[i]}`, type: spillTypes[i]!, mutable: true });
+    stateFields.push({
+      name: `spill_${spillNames[i]}`,
+      type: spillTypes[i]!,
+      mutable: true,
+    });
   }
 
   // Trailing result-promise field — after spills so `spillFieldOffset` is stable.
@@ -307,7 +328,11 @@ export function buildAsyncFrameInfo(
   const resultPromiseFieldType: ValType = hostImports
     ? { kind: "externref" }
     : { kind: "ref", typeIdx: promiseTypeIdx };
-  stateFields.push({ name: "result_promise", type: resultPromiseFieldType, mutable: true });
+  stateFields.push({
+    name: "result_promise",
+    type: resultPromiseFieldType,
+    mutable: true,
+  });
 
   const stateName = `$AsyncFrame_${sanitizeTypeName(functionName)}`;
   const stateTypeIdx = ctx.mod.types.length;
@@ -502,6 +527,42 @@ function isNestedScope(node: ts.Node): boolean {
   );
 }
 
+/**
+ * Defensive check of the {@link AsyncCfgPlan} emitter contract (see the
+ * contract block in async-cps.ts). Returns a human-readable violation, or
+ * `null` when the plan is emittable. Cheap (O(states)); run once per machine so
+ * a future planner bug becomes a hard compile error instead of an emitted
+ * machine with wrong `br` depths or a mis-routed abrupt completion.
+ */
+function validateAsyncCfg(cfg: AsyncCfgPlan): string | null {
+  const n = cfg.states.length;
+  const inRange = (id: number): boolean => id >= 0 && id < n;
+  for (let i = 0; i < n; i++) {
+    const st = cfg.states[i]!;
+    if (st.id !== i) return `state ids not dense (states[${i}].id === ${st.id})`;
+    const t = st.terminator;
+    if (t.kind === "suspend" && !inRange(t.resumeState)) return `suspend.resumeState ${t.resumeState} out of range`;
+    if (t.kind === "goto" && !inRange(t.target)) return `goto.target ${t.target} out of range`;
+    if (t.kind === "condGoto" && (!inRange(t.whenTrue) || !inRange(t.whenFalse))) {
+      return `condGoto targets ${t.whenTrue}/${t.whenFalse} out of range`;
+    }
+    // goto/condGoto targets must not carry a resume prelude (contract rule 2).
+    const targets: number[] = t.kind === "goto" ? [t.target] : t.kind === "condGoto" ? [t.whenTrue, t.whenFalse] : [];
+    for (const target of targets) {
+      if (cfg.states[target]!.resumeFrom !== null) {
+        return `goto/condGoto target ${target} has a resume prelude (only a suspend may enter it)`;
+      }
+    }
+  }
+  for (let i = 0; i < cfg.handlers.length; i++) {
+    const h = cfg.handlers[i]!;
+    if (h.id !== i + 1) return `handler ids not dense (handlers[${i}].id === ${h.id})`;
+    // Nested regions need parent-chain replay in the catch — 3c follow-up.
+    if (h.parent !== 0) return `nested handler region ${h.id} (parent ${h.parent}) not yet supported`;
+  }
+  return null;
+}
+
 // ── PATH B slice 1b: resume function + step adapters + call-site shim ─────────
 
 /**
@@ -544,6 +605,18 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   const linear = planLinearAwaits(info.decl, plan);
   if (linear === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1)");
+    info.resumeFuncIdx = -1;
+    return -1;
+  }
+
+  // (#2906 slice 3) Lower the linear plan into the general CFG plan the emitter
+  // drives. `linearPlanToCfg` is the only producer today, so the emitted machine
+  // is byte-identical to the pre-CFG emitter for every accepted shape; richer
+  // planners (loops, try/catch, for-await) plug in HERE without emitter changes.
+  const cfg = linearPlanToCfg(linear);
+  const cfgError = validateAsyncCfg(cfg);
+  if (cfgError !== null) {
+    reportError(ctx, info.decl, `internal: async CFG plan violates the emitter contract — ${cfgError} (#2906)`);
     info.resumeFuncIdx = -1;
     return -1;
   }
@@ -608,7 +681,10 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // walker patches `mod.exports` func indices, so pushing at reservation time
   // is safe.
   if (info.host) {
-    ctx.mod.exports.push({ name: stepFulfillName, desc: { kind: "func", index: stepFulfillFuncIdx } });
+    ctx.mod.exports.push({
+      name: stepFulfillName,
+      desc: { kind: "func", index: stepFulfillFuncIdx },
+    });
   }
 
   const stepRejectFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
@@ -622,7 +698,10 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     exported: info.host,
   });
   if (info.host) {
-    ctx.mod.exports.push({ name: stepRejectName, desc: { kind: "func", index: stepRejectFuncIdx } });
+    ctx.mod.exports.push({
+      name: stepRejectName,
+      desc: { kind: "func", index: stepRejectFuncIdx },
+    });
   }
 
   // ── Build the resume function body. ──
@@ -645,7 +724,11 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   for (let i = 0; i < info.paramNames.length; i++) {
     const idx = allocLocal(resumeFctx, info.paramNames[i]!, info.paramTypes[i]!);
     resumeFctx.body.push({ op: "local.get", index: frameLocal });
-    resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.paramFieldOffset + i });
+    resumeFctx.body.push({
+      op: "struct.get",
+      typeIdx: info.stateTypeIdx,
+      fieldIdx: info.paramFieldOffset + i,
+    });
     resumeFctx.body.push({ op: "local.set", index: idx });
   }
   // Load spills from the frame into locals (overwritten by a segment's lead on
@@ -653,7 +736,11 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   for (let i = 0; i < info.spillNames.length; i++) {
     const idx = allocLocal(resumeFctx, info.spillNames[i]!, info.spillTypes[i]!);
     resumeFctx.body.push({ op: "local.get", index: frameLocal });
-    resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
+    resumeFctx.body.push({
+      op: "struct.get",
+      typeIdx: info.stateTypeIdx,
+      fieldIdx: info.spillFieldOffset + i,
+    });
     resumeFctx.body.push({ op: "local.set", index: idx });
   }
   // Load the result promise into a local; wire the `return` settle hook. Both
@@ -667,7 +754,11 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     info.host ? { kind: "externref" } : { kind: "ref", typeIdx: info.promiseTypeIdx },
   );
   resumeFctx.body.push({ op: "local.get", index: frameLocal });
-  resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.resultPromiseFieldIdx });
+  resumeFctx.body.push({
+    op: "struct.get",
+    typeIdx: info.stateTypeIdx,
+    fieldIdx: info.resultPromiseFieldIdx,
+  });
   resumeFctx.body.push({ op: "local.set", index: resultPromiseLocal });
   const settleFulfillIdx = info.host ? hostImports!.settleResolveIdx : rt!.fulfillFuncIdx;
   const settleRejectIdx = info.host ? hostImports!.settleRejectIdx : rt!.rejectFuncIdx;
@@ -683,12 +774,13 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // its own continuation gets a fresh delivery-only local. Typed via
   // `resumeBindingValType` (== the spill field type for the spilled ones).
   const bindingLocal = new Map<string, { local: number; type: ValType }>();
-  for (const seg of linear.segments) {
-    if (!seg.resumeBinding) continue;
-    const t = resumeBindingValType(ctx, seg.resumeBinding);
-    const existing = resumeFctx.localMap.get(seg.resumeBinding.name);
-    const local = existing !== undefined ? existing : allocLocal(resumeFctx, seg.resumeBinding.name, t);
-    bindingLocal.set(seg.resumeBinding.name, { local, type: t });
+  for (const st of cfg.states) {
+    const rb = st.resumeFrom?.binding;
+    if (!rb) continue;
+    const t = resumeBindingValType(ctx, rb);
+    const existing = resumeFctx.localMap.get(rb.name);
+    const local = existing !== undefined ? existing : allocLocal(resumeFctx, rb.name, t);
+    bindingLocal.set(rb.name, { local, type: t });
   }
 
   // Transient locals reused across every state arm (only one await is processed
@@ -696,252 +788,353 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // needs the typed `$Promise` classification locals; the host backend cannot
   // inspect a host Promise synchronously (opaque externref), so it keeps only
   // an externref slot for the assimilated promise.
-  const awaitedLocal = allocLocal(resumeFctx, "__async_awaited", { kind: "externref" });
-  const pLocal = info.host ? -1 : allocLocal(resumeFctx, "__async_p", { kind: "ref", typeIdx: info.promiseTypeIdx });
+  const awaitedLocal = allocLocal(resumeFctx, "__async_awaited", {
+    kind: "externref",
+  });
+  const pLocal = info.host
+    ? -1
+    : allocLocal(resumeFctx, "__async_p", {
+        kind: "ref",
+        typeIdx: info.promiseTypeIdx,
+      });
   const suspendedLocal = info.host ? -1 : allocLocal(resumeFctx, "__async_suspended", { kind: "i32" });
   const pHostLocal = info.host ? allocLocal(resumeFctx, "__async_p_host", { kind: "externref" }) : -1;
   const exnTag = ensureExnTag(ctx);
-  const reasonLocal = allocLocal(resumeFctx, "__async_reason", { kind: "externref" });
-  const N = linear.segments.length;
+  const reasonLocal = allocLocal(resumeFctx, "__async_reason", {
+    kind: "externref",
+  });
 
-  // (#2906 Gap 3) try/finally-across-await. When the body has a single
-  // try/finally spanning an await, `inSrcTryLocal` (an i32 resume-local) records
-  // whether control is currently inside the try region. The outer catch runs the
-  // `finally` before rejecting when the flag is set (an abrupt completion — a
-  // throw or a rejected await — while inside the try); the `finally` also runs
-  // inline on the normal path (`planLinearAwaits` appends it to the post-try
-  // lead). The local + all associated instrs are emitted ONLY when a finalizer
-  // exists, so non-try async stays byte-identical to slice 1.
-  const theFinalizer = linear.finalizer;
-  const hasFinalizer = theFinalizer !== null;
-  const inSrcTryLocal = hasFinalizer ? allocLocal(resumeFctx, "__async_in_try", { kind: "i32" }) : -1;
-  const setInTry = (v: number): Instr[] => [
+  // (#2906 Gap 3 → slice 3) Handler regions. `inSrcTryLocal` (an i32
+  // resume-local) records the id of the handler region control is currently in
+  // (0 = none; slice-2's boolean is the single-region special case, so the
+  // emitted i32.const 0/1 toggles are byte-identical). The outer catch routes an
+  // abrupt completion by it: run the active region's await-free finalizer, then
+  // reject. The local + all associated instrs are emitted ONLY when the plan has
+  // handler regions, so non-try async stays byte-identical to slice 1.
+  const hasHandlers = cfg.handlers.length > 0;
+  const inSrcTryLocal = hasHandlers ? allocLocal(resumeFctx, "__async_in_try", { kind: "i32" }) : -1;
+  const setHandler = (v: number): Instr[] => [
     { op: "i32.const", value: v },
     { op: "local.set", index: inSrcTryLocal },
   ];
 
-  // Emit `SENT_FIELD → predecessor await's resume binding`, guarded by a
-  // MODE_THROW re-throw of a rejected predecessor. `s` is the state whose
-  // predecessor await is `s-1` (used by state s≥1 and the final state N).
-  const emitDeliverPrev = (out: Instr[], s: number): void => {
-    const prev = linear.segments[s - 1]!;
-    // A rejected predecessor await that sat inside a try must run the finally
-    // before the result promise rejects — arm `inSrcTry` so the outer catch does.
+  // Emit a state's resume prelude: re-throw a rejected predecessor await
+  // (MODE_THROW — arming its handler region first so the finalizer runs), then
+  // bind the delivered `SENT_FIELD` value to the await's resume binding.
+  // MUST be called while `resumeFctx.body === out` (coerceType pushes there).
+  const emitDeliver = (out: Instr[], rp: AsyncResumePoint): void => {
     const throwArm: Instr[] = [];
-    if (hasFinalizer && prev.awaitInTry) throwArm.push(...setInTry(1));
+    if (hasHandlers && rp.handler !== 0) throwArm.push(...setHandler(rp.handler));
     throwArm.push(
       { op: "local.get", index: frameLocal },
-      { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD } as Instr,
+      {
+        op: "struct.get",
+        typeIdx: info.stateTypeIdx,
+        fieldIdx: ERROR_FIELD,
+      } as Instr,
       { op: "throw", tagIdx: exnTag } as Instr,
     );
     out.push({ op: "local.get", index: frameLocal });
-    out.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: MODE_FIELD });
+    out.push({
+      op: "struct.get",
+      typeIdx: info.stateTypeIdx,
+      fieldIdx: MODE_FIELD,
+    });
     out.push({ op: "i32.const", value: MODE_THROW });
     out.push({ op: "i32.eq" });
-    out.push({ op: "if", blockType: { kind: "empty" }, then: throwArm } as Instr);
-    if (prev.resumeBinding) {
-      const bl = bindingLocal.get(prev.resumeBinding.name)!;
+    out.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: throwArm,
+    } as Instr);
+    if (rp.binding) {
+      const bl = bindingLocal.get(rp.binding.name)!;
       out.push({ op: "local.get", index: frameLocal });
-      out.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD });
+      out.push({
+        op: "struct.get",
+        typeIdx: info.stateTypeIdx,
+        fieldIdx: SENT_FIELD,
+      });
       coerceType(ctx, resumeFctx, { kind: "externref" }, bl.type);
       out.push({ op: "local.set", index: bl.local });
     }
   };
 
-  // State s (0 ≤ s < N): run await s, then advance (br to re-dispatch) or suspend.
-  const buildAwaitSegment = (s: number): Instr[] => {
-    const seg = linear.segments[s]!;
+  // One CFG state → its dispatch-arm body (#2906 slice 3). Every state emits:
+  // handler-region reset, the resume prelude (when this state is an await's
+  // `resumeState`), the handler-annotated lead statements, then its TERMINATOR.
+  // Suspend keeps the slice-1/2 emission verbatim (parameterized by
+  // `resumeState`); `goto`/`condGoto` are `STATE=<target>; br <re-dispatch
+  // loop>` — a target ≤ the current id is a loop back-edge, which is how
+  // while-await / for-await planners express iteration with NO emitter change.
+  const buildStateBody = (st: AsyncCfgState): Instr[] => {
     const saved = resumeFctx.body;
     ctx.liveBodies.add(saved);
     const out: Instr[] = [];
     resumeFctx.body = out;
+    // `br` depth of the re-dispatch loop from this arm's top level: br0 = this
+    // arm's own `if`, br1..br(st.id) = the enclosing if-chain arms, br(st.id+1)
+    // = if(state==0), br(st.id+2) = the loop. Valid because state ids are dense
+    // and equal to their if-chain nesting depth (validateAsyncCfg).
+    const loopDepth = st.id + 2;
     try {
-      // (#2906 Gap 3) Reset the in-try flag at arm entry (a resume enters here
-      // fresh; a fast-path advance re-dispatched from an earlier in-try state).
-      let curFlag = false;
-      if (hasFinalizer) out.push(...setInTry(0));
-      if (s >= 1) emitDeliverPrev(out, s);
+      // Reset the handler-region local at arm entry (a resume enters here
+      // fresh; a fast-path advance may re-dispatch from an in-region state).
+      let curHandler = 0;
+      if (hasHandlers) out.push(...setHandler(0));
+      if (st.resumeFrom) emitDeliver(out, st.resumeFrom);
 
-      // Compile the lead, toggling `inSrcTry` at each in-try/out-of-try boundary
-      // (`leadInTry[i]`) so a throw in an in-try statement (or the await eval)
-      // runs the finally; a throw in an out-of-try statement (or the inline
-      // finally itself) does not.
-      for (let i = 0; i < seg.leadStmts.length; i++) {
-        if (hasFinalizer && seg.leadInTry[i]! !== curFlag) {
-          curFlag = seg.leadInTry[i]!;
-          out.push(...setInTry(curFlag ? 1 : 0));
+      // Compile the lead, toggling the region local at each boundary so a throw
+      // in an in-region statement (or the terminator's own evaluation) runs the
+      // region's finalizer; a throw outside (or in the inline finally itself)
+      // does not.
+      for (const { stmt, handler } of st.lead) {
+        if (hasHandlers && handler !== curHandler) {
+          curHandler = handler;
+          out.push(...setHandler(curHandler));
         }
-        compileStatement(ctx, resumeFctx, seg.leadStmts[i]!);
-      }
-      if (hasFinalizer && seg.awaitInTry !== curFlag) {
-        curFlag = seg.awaitInTry;
-        out.push(...setInTry(curFlag ? 1 : 0));
+        compileStatement(ctx, resumeFctx, stmt);
       }
 
-      const awaitedType = compileExpression(ctx, resumeFctx, seg.awaitedExpr);
-      if (awaitedType !== null && awaitedType !== undefined) {
-        coerceType(ctx, resumeFctx, awaitedType as ValType, { kind: "externref" });
-      } else {
-        out.push({ op: "ref.null.extern" } as Instr);
-      }
-      out.push({ op: "local.set", index: awaitedLocal });
+      const term = st.terminator;
+      switch (term.kind) {
+        case "suspend": {
+          if (hasHandlers && term.handler !== curHandler) {
+            curHandler = term.handler;
+            out.push(...setHandler(curHandler));
+          }
+          const awaitedType = compileExpression(ctx, resumeFctx, term.awaited);
+          if (awaitedType !== null && awaitedType !== undefined) {
+            coerceType(ctx, resumeFctx, awaitedType as ValType, {
+              kind: "externref",
+            });
+          } else {
+            out.push({ op: "ref.null.extern" } as Instr);
+          }
+          out.push({ op: "local.set", index: awaitedLocal });
 
-      if (info.host) {
-        // (#1042 host settle backend) A host Promise is an opaque externref — no
-        // synchronous state inspection is possible, so EVERY await suspends:
-        // assimilate the awaited value via PromiseResolve (§27.7.5.3 — a
-        // non-thenable becomes an already-resolved Promise, a promise passes
-        // through unchanged), park the frame (STATE=s+1 + spills), register the
-        // two `__cb_<id>` step adapters as reactions via
-        // `Promise_then2(p, __make_callback(fulfillId, frame),
-        // __make_callback(rejectId, frame))`, and return. The HOST microtask
-        // queue resumes us — there is no synchronous fast-path advance, which
-        // also makes await timing spec-correct (every await yields ≥1 tick).
-        // The cbId constants are shift-immune (runtime dispatch is by export
-        // NAME); the five import indices are import-space stable.
-        out.push({ op: "local.get", index: awaitedLocal });
-        out.push({ op: "call", funcIdx: hostImports!.promiseResolveIdx });
-        out.push({ op: "local.set", index: pHostLocal });
-        out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, s + 1));
-        out.push(...storeSpills(info, resumeFctx, frameLocal));
-        out.push({ op: "local.get", index: pHostLocal });
-        out.push({ op: "i32.const", value: info.stepFulfillCbId! });
-        out.push({ op: "local.get", index: frameLocal });
-        out.push({ op: "extern.convert_any" } as Instr);
-        out.push({ op: "call", funcIdx: hostImports!.makeCbIdx });
-        out.push({ op: "i32.const", value: info.stepRejectCbId! });
-        out.push({ op: "local.get", index: frameLocal });
-        out.push({ op: "extern.convert_any" } as Instr);
-        out.push({ op: "call", funcIdx: hostImports!.makeCbIdx });
-        out.push({ op: "call", funcIdx: hostImports!.then2Idx });
-        out.push({ op: "drop" });
-        out.push({ op: "return" });
-        return out;
-      }
+          if (info.host) {
+            // (#1042 host settle backend) A host Promise is an opaque externref
+            // — no synchronous state inspection is possible, so EVERY await
+            // suspends: assimilate the awaited value via PromiseResolve
+            // (§27.7.5.3 — a non-thenable becomes an already-resolved Promise,
+            // a promise passes through unchanged), park the frame
+            // (STATE=resumeState + spills), register the two `__cb_<id>` step
+            // adapters as reactions via `Promise_then2(p,
+            // __make_callback(fulfillId, frame), __make_callback(rejectId,
+            // frame))`, and return. The HOST microtask queue resumes us — there
+            // is no synchronous fast-path advance, which also makes await
+            // timing spec-correct (every await yields ≥1 tick). The cbId
+            // constants are shift-immune (runtime dispatch is by export NAME);
+            // the five import indices are import-space stable.
+            out.push({ op: "local.get", index: awaitedLocal });
+            out.push({ op: "call", funcIdx: hostImports!.promiseResolveIdx });
+            out.push({ op: "local.set", index: pHostLocal });
+            out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.resumeState));
+            out.push(...storeSpills(info, resumeFctx, frameLocal));
+            out.push({ op: "local.get", index: pHostLocal });
+            out.push({ op: "i32.const", value: info.stepFulfillCbId! });
+            out.push({ op: "local.get", index: frameLocal });
+            out.push({ op: "extern.convert_any" } as Instr);
+            out.push({ op: "call", funcIdx: hostImports!.makeCbIdx });
+            out.push({ op: "i32.const", value: info.stepRejectCbId! });
+            out.push({ op: "local.get", index: frameLocal });
+            out.push({ op: "extern.convert_any" } as Instr);
+            out.push({ op: "call", funcIdx: hostImports!.makeCbIdx });
+            out.push({ op: "call", funcIdx: hostImports!.then2Idx });
+            out.push({ op: "drop" });
+            out.push({ op: "return" });
+            break;
+          }
 
-      // Classify the assimilated value; set suspendedLocal + SENT/ERROR/MODE.
-      // No `br` inside these nested ifs — the single advance/suspend `br`/`return`
-      // is emitted flat below at a known control depth.
-      out.push({ op: "i32.const", value: 0 });
-      out.push({ op: "local.set", index: suspendedLocal });
+          // Classify the assimilated value; set suspendedLocal + SENT/ERROR/MODE.
+          // No `br` inside these nested ifs — the single advance/suspend
+          // `br`/`return` is emitted flat below at a known control depth.
+          out.push({ op: "i32.const", value: 0 });
+          out.push({ op: "local.set", index: suspendedLocal });
 
-      const deliverFromP: Instr[] = [
-        { op: "local.get", index: frameLocal },
-        { op: "local.get", index: pLocal },
-        { op: "struct.get", typeIdx: info.promiseTypeIdx, fieldIdx: 1 } as Instr,
-        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
-      ];
-      const rejectFromP: Instr[] = [
-        { op: "local.get", index: frameLocal },
-        { op: "local.get", index: pLocal },
-        { op: "struct.get", typeIdx: info.promiseTypeIdx, fieldIdx: 1 } as Instr,
-        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD } as Instr,
-        ...setStateI32FromConst(info, frameLocal, MODE_FIELD, MODE_THROW),
-      ];
-      const markPending: Instr[] = [
-        { op: "i32.const", value: 1 },
-        { op: "local.set", index: suspendedLocal },
-      ];
-      const deliverPlain: Instr[] = [
-        { op: "local.get", index: frameLocal },
-        { op: "local.get", index: awaitedLocal },
-        { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
-      ];
-      const pendingOrRejected: Instr[] = [
-        { op: "local.get", index: pLocal },
-        { op: "struct.get", typeIdx: info.promiseTypeIdx, fieldIdx: 0 } as Instr,
-        { op: "i32.const", value: PROMISE_STATE_REJECTED },
-        { op: "i32.eq" },
-        { op: "if", blockType: { kind: "empty" }, then: rejectFromP, else: markPending } as Instr,
-      ];
-      out.push(
-        { op: "local.get", index: awaitedLocal },
-        { op: "any.convert_extern" } as Instr,
-        { op: "ref.test", typeIdx: info.promiseTypeIdx } as Instr,
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [
+          const deliverFromP: Instr[] = [
+            { op: "local.get", index: frameLocal },
+            { op: "local.get", index: pLocal },
+            {
+              op: "struct.get",
+              typeIdx: info.promiseTypeIdx,
+              fieldIdx: 1,
+            } as Instr,
+            {
+              op: "struct.set",
+              typeIdx: info.stateTypeIdx,
+              fieldIdx: SENT_FIELD,
+            } as Instr,
+          ];
+          const rejectFromP: Instr[] = [
+            { op: "local.get", index: frameLocal },
+            { op: "local.get", index: pLocal },
+            {
+              op: "struct.get",
+              typeIdx: info.promiseTypeIdx,
+              fieldIdx: 1,
+            } as Instr,
+            {
+              op: "struct.set",
+              typeIdx: info.stateTypeIdx,
+              fieldIdx: ERROR_FIELD,
+            } as Instr,
+            ...setStateI32FromConst(info, frameLocal, MODE_FIELD, MODE_THROW),
+          ];
+          const markPending: Instr[] = [
+            { op: "i32.const", value: 1 },
+            { op: "local.set", index: suspendedLocal },
+          ];
+          const deliverPlain: Instr[] = [
+            { op: "local.get", index: frameLocal },
+            { op: "local.get", index: awaitedLocal },
+            {
+              op: "struct.set",
+              typeIdx: info.stateTypeIdx,
+              fieldIdx: SENT_FIELD,
+            } as Instr,
+          ];
+          const pendingOrRejected: Instr[] = [
+            { op: "local.get", index: pLocal },
+            {
+              op: "struct.get",
+              typeIdx: info.promiseTypeIdx,
+              fieldIdx: 0,
+            } as Instr,
+            { op: "i32.const", value: PROMISE_STATE_REJECTED },
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: rejectFromP,
+              else: markPending,
+            } as Instr,
+          ];
+          out.push(
             { op: "local.get", index: awaitedLocal },
             { op: "any.convert_extern" } as Instr,
-            { op: "ref.cast", typeIdx: info.promiseTypeIdx } as Instr,
-            { op: "local.set", index: pLocal },
+            { op: "ref.test", typeIdx: info.promiseTypeIdx } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: awaitedLocal },
+                { op: "any.convert_extern" } as Instr,
+                { op: "ref.cast", typeIdx: info.promiseTypeIdx } as Instr,
+                { op: "local.set", index: pLocal },
+                { op: "local.get", index: pLocal },
+                {
+                  op: "struct.get",
+                  typeIdx: info.promiseTypeIdx,
+                  fieldIdx: 0,
+                } as Instr,
+                { op: "i32.const", value: PROMISE_STATE_FULFILLED },
+                { op: "i32.eq" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: deliverFromP,
+                  else: pendingOrRejected,
+                } as Instr,
+              ],
+              else: deliverPlain,
+            } as Instr,
+          );
+
+          // Advance-or-suspend. STATE = resumeState for both (suspend → the
+          // microtask resume enters it; advance → the re-dispatch enters it).
+          out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.resumeState));
+          const suspendArm: Instr[] = [
+            ...storeSpills(info, resumeFctx, frameLocal),
+            // promise.callbacks = $PromiseCallback{stepFulfill, frame, stepReject, frame, promise.callbacks}
             { op: "local.get", index: pLocal },
-            { op: "struct.get", typeIdx: info.promiseTypeIdx, fieldIdx: 0 } as Instr,
-            { op: "i32.const", value: PROMISE_STATE_FULFILLED },
-            { op: "i32.eq" },
-            { op: "if", blockType: { kind: "empty" }, then: deliverFromP, else: pendingOrRejected } as Instr,
-          ],
-          else: deliverPlain,
-        } as Instr,
-      );
-
-      // Advance-or-suspend. STATE = s+1 for both (suspend → resume enters s+1;
-      // advance → re-dispatch enters s+1).
-      out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, s + 1));
-      const suspendArm: Instr[] = [
-        ...storeSpills(info, resumeFctx, frameLocal),
-        // promise.callbacks = $PromiseCallback{stepFulfill, frame, stepReject, frame, promise.callbacks}
-        { op: "local.get", index: pLocal },
-        { op: "ref.func", funcIdx: info.stepFulfillFuncIdx! } as Instr,
-        { op: "local.get", index: frameLocal },
-        { op: "extern.convert_any" } as Instr,
-        { op: "ref.func", funcIdx: info.stepRejectFuncIdx! } as Instr,
-        { op: "local.get", index: frameLocal },
-        { op: "extern.convert_any" } as Instr,
-        { op: "local.get", index: pLocal },
-        { op: "struct.get", typeIdx: info.promiseTypeIdx, fieldIdx: 2 } as Instr,
-        { op: "struct.new", typeIdx: rt!.callbackTypeIdx } as Instr,
-        { op: "extern.convert_any" } as Instr,
-        { op: "struct.set", typeIdx: info.promiseTypeIdx, fieldIdx: 2 } as Instr,
-        { op: "return" },
-      ];
-      // Advance: `br` to the dispatch `loop` to re-enter at STATE=s+1. Control
-      // depth from inside this `else`: br0 = this if, br1 = if(state==s), … ,
-      // br(s+1) = if(state==0), br(s+2) = loop.
-      const advanceArm: Instr[] = [{ op: "br", depth: s + 2 } as Instr];
-      out.push({ op: "local.get", index: suspendedLocal });
-      out.push({ op: "if", blockType: { kind: "empty" }, then: suspendArm, else: advanceArm } as Instr);
-    } finally {
-      resumeFctx.body = saved;
-      ctx.liveBodies.delete(saved);
-    }
-    return out;
-  };
-
-  // State N (final): deliver the last await's value, then run the tail / settle.
-  const buildFinalSegment = (): Instr[] => {
-    const saved = resumeFctx.body;
-    ctx.liveBodies.add(saved);
-    const out: Instr[] = [];
-    resumeFctx.body = out;
-    try {
-      let curFlag = false;
-      if (hasFinalizer) out.push(...setInTry(0));
-      emitDeliverPrev(out, N);
-      const last = linear.segments[N - 1]!;
-      if (last.isReturnAwait) {
-        out.push({ op: "local.get", index: resultPromiseLocal });
-        out.push({ op: "local.get", index: frameLocal });
-        out.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD });
-        out.push({ op: "call", funcIdx: settleFulfillIdx });
-        out.push({ op: "drop" });
-        out.push({ op: "return" });
-      } else {
-        // Run the tail, toggling `inSrcTry` per statement (`tailInTry[i]`) —
-        // covers in-try post-await statements that precede the inline finally.
-        for (let i = 0; i < linear.tail.length; i++) {
-          if (hasFinalizer && linear.tailInTry[i]! !== curFlag) {
-            curFlag = linear.tailInTry[i]!;
-            out.push(...setInTry(curFlag ? 1 : 0));
-          }
-          compileStatement(ctx, resumeFctx, linear.tail[i]!);
+            { op: "ref.func", funcIdx: info.stepFulfillFuncIdx! } as Instr,
+            { op: "local.get", index: frameLocal },
+            { op: "extern.convert_any" } as Instr,
+            { op: "ref.func", funcIdx: info.stepRejectFuncIdx! } as Instr,
+            { op: "local.get", index: frameLocal },
+            { op: "extern.convert_any" } as Instr,
+            { op: "local.get", index: pLocal },
+            {
+              op: "struct.get",
+              typeIdx: info.promiseTypeIdx,
+              fieldIdx: 2,
+            } as Instr,
+            { op: "struct.new", typeIdx: rt!.callbackTypeIdx } as Instr,
+            { op: "extern.convert_any" } as Instr,
+            {
+              op: "struct.set",
+              typeIdx: info.promiseTypeIdx,
+              fieldIdx: 2,
+            } as Instr,
+            { op: "return" },
+          ];
+          // Advance: `br` to the dispatch `loop` to re-enter at STATE=resumeState.
+          const advanceArm: Instr[] = [{ op: "br", depth: loopDepth } as Instr];
+          out.push({ op: "local.get", index: suspendedLocal });
+          out.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: suspendArm,
+            else: advanceArm,
+          } as Instr);
+          break;
         }
-        out.push({ op: "local.get", index: resultPromiseLocal });
-        out.push({ op: "ref.null.extern" } as Instr);
-        out.push({ op: "call", funcIdx: settleFulfillIdx });
-        out.push({ op: "drop" });
-        out.push({ op: "return" });
+        case "goto": {
+          // Unconditional state transition (loop back-edge when target ≤ id).
+          out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.target));
+          out.push({ op: "br", depth: loopDepth } as Instr);
+          break;
+        }
+        case "condGoto": {
+          // Two-way state transition on a source condition (loop heads / ifs).
+          if (hasHandlers && term.handler !== curHandler) {
+            curHandler = term.handler;
+            out.push(...setHandler(curHandler));
+          }
+          const condType = compileExpression(ctx, resumeFctx, term.cond);
+          ensureI32Condition(resumeFctx, condType, ctx);
+          out.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              ...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.whenTrue),
+              // +1: the `br` sits inside this `if` arm, one level below the arm
+              // top where `loopDepth` is measured.
+              { op: "br", depth: loopDepth + 1 } as Instr,
+            ],
+            else: [
+              ...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.whenFalse),
+              { op: "br", depth: loopDepth + 1 } as Instr,
+            ],
+          } as Instr);
+          break;
+        }
+        case "settleSent": {
+          // `return await P` — fulfil the result promise with SENT directly.
+          out.push({ op: "local.get", index: resultPromiseLocal });
+          out.push({ op: "local.get", index: frameLocal });
+          out.push({
+            op: "struct.get",
+            typeIdx: info.stateTypeIdx,
+            fieldIdx: SENT_FIELD,
+          });
+          out.push({ op: "call", funcIdx: settleFulfillIdx });
+          out.push({ op: "drop" });
+          out.push({ op: "return" });
+          break;
+        }
+        case "settleUndefined": {
+          // Fall off the body — fulfil with undefined. (`return v` inside the
+          // lead already settles via the `asyncDriveReturn` hook and returns.)
+          out.push({ op: "local.get", index: resultPromiseLocal });
+          out.push({ op: "ref.null.extern" } as Instr);
+          out.push({ op: "call", funcIdx: settleFulfillIdx });
+          out.push({ op: "drop" });
+          out.push({ op: "return" });
+          break;
+        }
       }
     } finally {
       resumeFctx.body = saved;
@@ -950,46 +1143,66 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     return out;
   };
 
-  // Nested if-chain dispatch (`if(state==s){seg}else{…}`), mirroring the
-  // generator trampoline. Recursion depth == stateId, so each arm's `br`-to-loop
-  // depth is computed as `stateId + 2` inside `buildAwaitSegment`.
-  const buildStateArm = (s: number): Instr[] => {
-    if (s > N) return [{ op: "unreachable" } as Instr];
-    const then = s === N ? buildFinalSegment() : buildAwaitSegment(s);
+  // Nested if-chain dispatch (`if(state==s){body}else{…}`), mirroring the
+  // generator trampoline. Recursion depth == state id (dense, validated), so
+  // each arm's `br`-to-loop depth is `id + 2` inside `buildStateBody`.
+  const buildStateArm = (i: number): Instr[] => {
+    if (i >= cfg.states.length) return [{ op: "unreachable" } as Instr];
+    const st = cfg.states[i]!;
+    const then = buildStateBody(st);
     return [
       { op: "local.get", index: frameLocal },
       { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
-      { op: "i32.const", value: s },
+      { op: "i32.const", value: st.id },
       { op: "i32.eq" },
-      { op: "if", blockType: { kind: "empty" }, then, else: buildStateArm(s + 1) } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then,
+        else: buildStateArm(i + 1),
+      } as Instr,
     ];
   };
 
   const savedFunc = ctx.currentFunc;
   ctx.currentFunc = resumeFctx;
   let chain: Instr[];
-  // (#2906 Gap 3) The finally, compiled a SECOND time for the abrupt path (the
-  // first copy runs inline on the normal path via the post-try lead). Fresh
-  // Instr[] — never aliased with the inline copy. Guarded by `inSrcTry` in the
-  // catch so it runs only for a throw/rejected-await that crossed the try.
-  let catchFinallyInstrs: Instr[] = [];
+  // (#2906 Gap 3 → slice 3) Each handler region's finalizer, compiled a SECOND
+  // time for the abrupt path (the first copy runs inline on the normal path via
+  // the region's post-try lead). Fresh Instr[] — never aliased with the inline
+  // copy. Guarded in the catch by the region-id local so it runs only for a
+  // throw/rejected-await that crossed THAT try region. With a single region the
+  // guard is the slice-2 truthiness test (byte-identical); sibling regions get
+  // an id-equality guard each. Nested regions (parent !== 0) need parent-chain
+  // replay and are rejected by validateAsyncCfg until the 3c follow-up.
+  const catchFinallyInstrs: Instr[] = [];
   try {
     chain = buildStateArm(0);
-    if (hasFinalizer) {
+    for (const region of cfg.handlers) {
       const saved = resumeFctx.body;
       ctx.liveBodies.add(saved);
       const fbody: Instr[] = [];
       resumeFctx.body = fbody;
       try {
-        for (const f of theFinalizer!) compileStatement(ctx, resumeFctx, f);
+        for (const f of region.finalizer) compileStatement(ctx, resumeFctx, f);
       } finally {
         resumeFctx.body = saved;
         ctx.liveBodies.delete(saved);
       }
-      catchFinallyInstrs = [
-        { op: "local.get", index: inSrcTryLocal },
-        { op: "if", blockType: { kind: "empty" }, then: fbody } as Instr,
-      ];
+      if (cfg.handlers.length === 1) {
+        catchFinallyInstrs.push({ op: "local.get", index: inSrcTryLocal }, {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: fbody,
+        } as Instr);
+      } else {
+        catchFinallyInstrs.push(
+          { op: "local.get", index: inSrcTryLocal },
+          { op: "i32.const", value: region.id },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: fbody } as Instr,
+        );
+      }
     }
   } finally {
     ctx.currentFunc = savedFunc;
@@ -1058,7 +1271,11 @@ function buildStepAdapterBody(info: AsyncFrameInfo, resumeFuncIdx: number, rejec
     // SENT_FIELD = value (the settled awaited value the continuation reads).
     { op: "local.get", index: frameLocal },
     { op: "local.get", index: valueLocal },
-    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
+    {
+      op: "struct.set",
+      typeIdx: info.stateTypeIdx,
+      fieldIdx: SENT_FIELD,
+    } as Instr,
   ];
   if (reject) {
     // ERROR_FIELD = reason; MODE_FIELD = MODE_THROW (2). (Slice-1 surfaces the
@@ -1067,7 +1284,11 @@ function buildStepAdapterBody(info: AsyncFrameInfo, resumeFuncIdx: number, rejec
     body.push(
       { op: "local.get", index: frameLocal },
       { op: "local.get", index: valueLocal },
-      { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD } as Instr,
+      {
+        op: "struct.set",
+        typeIdx: info.stateTypeIdx,
+        fieldIdx: ERROR_FIELD,
+      } as Instr,
       ...setStateI32FromConst(info, frameLocal, MODE_FIELD, 2),
     );
   }
@@ -1155,7 +1376,10 @@ export function emitAsyncFrameStateMachine(
   }
   fctx.body.push({ op: "local.get", index: resultPromiseLocal });
   fctx.body.push({ op: "struct.new", typeIdx: info.stateTypeIdx } as Instr);
-  const frameLocal = allocLocal(fctx, "__async_frame", { kind: "ref", typeIdx: info.stateTypeIdx });
+  const frameLocal = allocLocal(fctx, "__async_frame", {
+    kind: "ref",
+    typeIdx: info.stateTypeIdx,
+  });
   fctx.body.push({ op: "local.set", index: frameLocal });
 
   // Kick the resume function once (runs the entry segment to the first real


### PR DESCRIPTION
## What

Keystone slice of #2906: generalizes the async drive-layer emitter from the implicit linear chain (state s always continues at s+1; try/finally = one boolean) to a **general CFG plan**, so every remaining async shape becomes a planner-only extension:

- **`async-cps.ts`** — `AsyncCfgPlan`: states (basic blocks with an optional resume prelude, handler-annotated leads, one terminator) + a handler-region table. Terminators: `suspend` / `goto` / `condGoto` / `settleSent` / `settleUndefined`. The emitter contract (dense ids, resume-prelude entry rule, handler-id rules) is documented in the contract block. `linearPlanToCfg` is the only producer this slice.
- **`async-frame.ts`** — `ensureAsyncResumeFunction` drives the CFG plan: one generic `buildStateBody` replaces the two hand-specialized segment builders; the slice-2 `inSrcTry` boolean becomes a handler-region-id local (single-region plans emit byte-identical toggles); `validateAsyncCfg` turns any future planner contract violation into a hard compile error instead of a wrong-`br`-depth miscompile. A loop back-edge is just `goto` with target ≤ id — **no emitter change needed for while-await / for-await**.

## Verification

- **Byte-inertness (the −16/−29 discipline)**: 27 program×lane sha256 hashes (9 async shapes incl. the host-drive and the 4 pre-existing-failure shapes × gc/standalone/wasi) — **all identical before vs after**.
- **Tests**: the 10 async test files (89 tests): 85 pass — the 4 failures (2× issue-2865, 2× promise-combinators) are pre-existing on origin/main and their compiled binaries are hash-identical to main's, so they cannot be regressions of this PR.
- tsc clean, prettier clean.

## Banked design (issue file)

Slice specs 3a–3d written into `plan/issues/2906-*.md` for follow-up execution: 3a while-await (back-edge validation + the loop-liveness rule), 3b for-await-of (async-iterator drive), 3c try/catch + return-through-finally via completion replay on MODE/ABRUPT/ERROR, 3d async-gen AG2 convergence — plus #2957/#2967/#2980 integration points. Consistent with the just-ratified #2980 no-flip decision (carrier gates untouched).

Issue stays `in-progress` (multi-slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8