### PR TITLE
feat(#2949): slice 2 — dynamic producers + selector (move-only surface)

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -2,10 +2,10 @@
 id: 2949
 title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)"
 status: in-progress
-assignee: ttraenkler/fable-1
+assignee: ttraenkler/fable-2949
 sprint: current
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-04
 priority: high
 horizon: xl
 feasibility: hard
@@ -281,3 +281,259 @@ returns null for non-val IrTypes, so any new per-op verifier rule must
 explicitly check `kind === "dynamic"` or it silently skips; (c)
 `prove-emit-identity.mjs` (baseline on main, check on branch) is the cheap
 byte-inertness oracle — use it on every producer-free slice.
+
+## Implementation Notes — Slice 2 (fable-2949, 2026-07-04, branch `issue-2949-jstag-dynamic`)
+
+Slice 2 ships the first **producers**: unannotated params/returns whose
+propagated lattice type is `unknown` (no evidence) or `dynamic` (top) now
+resolve to `IrType.dynamic` and CLAIM, instead of rejecting the whole
+function. The surface is deliberately **move-only** (no box/unbox/tag.test
+lowering exists until slice 3), enforced by a new selector gate.
+
+### What changed (and the WHY behind each decision)
+
+1. **`select.ts` — `ResolvedKind` gains `"dynamic"`.**
+   `resolveParamType`/`resolveReturnType` return it when: no annotation AND
+   the TypeMap entry EXISTS and its lattice kind is `unknown`/`dynamic`.
+   The `mapped !== undefined` requirement is load-bearing: class methods
+   don't participate in TypeMap propagation (`entry` is undefined there) and
+   must NOT silently become dynamic-claimable — method claiming carries the
+   typeIdx-parity contract with `class-bodies.ts`. Lattice `union` stays
+   rejected (that shape belongs to #2135's union rows, which have a real
+   V1 boxing path). Binding patterns with a dynamic verdict stay rejected
+   (destructuring a dynamic needs dynamic property access — slice 3+).
+   Generators with dynamic params stay rejected (no dynamic arm in the
+   gen prologue/yield machinery).
+
+2. **`select.ts` — `dynamicUsesAreMoveOnly` (the precision gate).** Claim
+   only when every dynamic value strictly MOVES:
+   - `return <dyn>` (iff the return resolved dynamic; dually, a dynamic
+     return REQUIRES every return argument to be dyn-shaped — a concrete
+     value there would need a box);
+   - dyn-arg → dyn-param of a DIRECT call to a local function, where the
+     callee's per-param verdict is computed by the SAME `resolveParamType`
+     the callee's own claim check uses (selector↔override drift is
+     impossible by construction);
+   - `const`/`let` alias (`const y = x`) — the alias joins the dyn set;
+     re-assignment `y = <expr>` scans the RHS against the LHS's dyn-ness;
+   - statement-position calls (a DROPPED dynamic result is fine — `drop`
+     of the carrier ref validates).
+   Everything else — arithmetic, truthiness, property access, calling the
+   dyn value, mixed concrete/dynamic returns, dyn-into-concrete-param,
+   spread over a dyn-param callee — keeps the EXISTING rejection bucket
+   (`param-type-not-resolvable` / `return-type-not-resolvable`).
+
+   **Why precision instead of claim-then-demote:** (a) under
+   `JS2WASM_IR_FIRST=1` a claimed+skipped function that build-demotes is a
+   HARD compile error (the #2138 skipped-slot contract); (b) the #1923
+   post-claim metering treats demotions as regressions-in-waiting; (c) the
+   unannotated population is the MAJORITY of JS code — claiming it all and
+   demoting most would double-compile the world for nothing. The scan
+   mirrors what from-ast can actually build; the demotion channel remains
+   as the backstop for scan bugs, and slice-2 testing shows ZERO demotions
+   across every claimed shape.
+
+3. **`codegen/index.ts` — `resolvePositionType` dynamic arm**, predicate-
+   identical to the selector arms (`!node && mapped && unknown|dynamic` →
+   `irDynamic()`). Positioned AFTER the concrete/object lattice arms so
+   nothing previously resolvable changes. Existing lowering from slice 1
+   (`lowerIrTypeToValType` → `resolveDynamic()`) does the rest.
+
+4. **`codegen/index.ts` — IR-first skip-set gate 6**: functions whose
+   override signature contains a dynamic type stay compile-twice under
+   `JS2WASM_IR_FIRST=1`. Insurance while the move-only scan is new — a
+   scan↔builder divergence demotes benignly instead of becoming a
+   skipped-slot hard error. Lift in slice 3/4 with an `ir_first`-lane
+   measurement.
+
+5. **from-ast / verify / lower: ZERO changes needed.** The move-shaped
+   surface is entirely type-driven through existing code: params take the
+   override (`resolveIrType` prefers override when no annotation),
+   identifier loads are type-agnostic, the direct-call path checks
+   `irTypeEquals(argType, expected)` (dynamic==dynamic exact),
+   `coerceReturnValue` passes non-`val` declared results through, and R6
+   `returnTypeAssignable` accepts dynamic→dynamic. This is the payoff of
+   slice 1 putting `dynamic` in the TYPE lattice instead of minting new
+   node kinds.
+
+### Measured facts worth keeping (probes on main @ 4f68ed670)
+
+- **The explicit-`any` annotation path has a REAL fast-mode ABI divergence
+  today**: `export function f(x: any): any { return x; }` compiled
+  `fast: true` emits `(param externref) (result externref)` on the IR path
+  but `(param (ref null $AnyValue))` on the legacy path (`experimentalIR:
+  false`) — `resolvePositionType`'s AnyKeyword arm predates the mode split.
+  WAT-diff evidence in the slice-2 session. `dynamic` does NOT inherit
+  this: `resolveDynamic()` mirrors `resolveWasmType`'s mode split, and the
+  slice-2 tests assert the claimed function's `func $f` header is
+  byte-equal to the legacy header in BOTH modes. Unifying `any` onto
+  `dynamic` (slice 3b below) fixes the divergence.
+- **The IR claim FIXES a live legacy miscompile**: host-mode legacy
+  compiles `function g(x){return x} export function f(x){return g(x)}`
+  such that `f("hello")` → null, `f(null)` → 0, `f({a:1})` → garbage
+  (legacy call-site/return coercion mangles non-number args through the
+  pass-through). The IR-claimed version returns identity for all six
+  test values. Expect small test262 IMPROVEMENTS from pass-through-shaped
+  helpers, not just neutrality.
+- Lattice facts: unannotated params sit at `unknown` unless call-site
+  evidence narrows them (propagation flows `g(1)` → g's param f64 — such
+  functions claim CONCRETELY, not dynamically, which is why
+  `f(){return g(1)}` still claims with zero dynamic involvement).
+
+## Test Results — Slice 2 (2026-07-04, fable-2949)
+
+- `tests/issue-2949-slice2-dynamic-producers.test.ts` — **22/22 pass**:
+  claims (identity / pass-through chain / const alias / unused param /
+  statement-position dyn call), precision rejections (arith, truthiness,
+  property access, mixed returns, dyn→concrete arg, dyn-callee call,
+  destructured dyn param — all keep their buckets), run-behavior identity
+  across number/string/null/bool/object in host mode, fast-mode compile
+  with zero demotions, ABI lockstep (IR `func $f` header == legacy header
+  in host AND fast mode; fast carrier is the $AnyValue ref, NOT externref),
+  IR-first gate 6 (dynamic claim not skipped, typed sibling still skipped).
+- **Zero post-claim demotions** on every claimed shape (asserted in every
+  compile test — `irPostClaimErrors` empty).
+- **Byte-identity vs main**: `prove-emit-identity.mjs` baseline on clean
+  main (4f68ed670), check on branch → IDENTICAL, all 39 (file,target)
+  hashes across gc/standalone/wasi. The playground corpus contains no
+  claimable unannotated move-only functions, so slice 2 is byte-inert
+  there by construction.
+- `pnpm run check:ir-fallbacks` — OK, zero delta in every bucket and no
+  post-claim entries.
+- Related suites: `issue-2949-ir-dynamic-type` (slice 1) 19/19,
+  `issue-1228` (any/void selector) 9/9, `ir-frontend-widening` +
+  `ir-backend-emitter` pass; `ir-scaffold` has the same 2 failures as
+  clean main (pre-existing, verified side-by-side).
+- `npx tsc --noEmit` clean; prettier + biome clean.
+
+---
+
+## Implementation Plan — Slice 3: dynamic op lowering (Opus-executable)
+
+**Goal**: lower `box{toType: dynamic}`, `unbox{jsTag}`, `tag.test{jsTag}`
+so producers can widen past move-only. This replaces the staged
+`"… lands in #2949 slice 3"` errors in `lower.ts`.
+
+1. **`IrDynamicLowering` handle** (shape ratified in §4 above): extend the
+   layout-handle union in `lower.ts` with
+   `{ carrier: ValType, anyValueTypeIdx: number, tagFieldIdx: 0, payloadFieldIdx(jsTag): number }`
+   provided by a new `IrLowerResolver.resolveDynamicLowering?()` in
+   `integration.ts`. WasmGC fast/standalone: derives from
+   `ensureAnyValueType` ($AnyValue = `{tag:i32, i32val, f64val, refval:eqref,
+   externval:externref}`; payload field by `jsTagUnboxKind`: i32→1, f64→2,
+   ref→3 for native refs / 4 for externref-shaped). Host (non-fast): the
+   carrier is externref — box/unbox route through the EXISTING
+   `__box_number`/`__unbox_number`/classifier import family, NOT struct
+   fields. Do not mint a second boxing engine (June-audit D4): every emit
+   goes through `emitBox`/`emitUnbox`/`emitTagLoad` on `BackendEmitter`
+   (promoted from optional; coordinate with #2953 if still unowned) or the
+   `__any_box_*` helper family.
+2. **`box(value, dynamic)`**: scalar f64/i32(+bool brand) → struct.new
+   $AnyValue with the right tag (fast) / `__box_number`-family (host).
+   String/object/closure refs → tag Function/Object/String + refval (fast)
+   / `extern.convert_any` (host). Null/undefined singletons per #2106.
+3. **`unbox(value, jsTag)`**: fast → `struct.get` payload field AFTER the
+   producer's `tag.test` proof (verifier R2 already enforces the field
+   discipline); host → `__unbox_number` / cast family.
+4. **`tag.test(value, jsTag)`**: fast → `struct.get tag` + `i32.eq`
+   (Null/Undefined test via tag too); host → classifier import
+   (`__typeof`-family) — reuse the tag-5 field-4 three-way classifier rules
+   (memory `reference_2040_tag5_field4_three_way_classifier`).
+5. **R6 hardening (REQUIRED before any producer emits ref→dynamic)**: the
+   verifier currently PASSES ref-shaped→dynamic returns (slice-1 doc), but
+   the LOWERING of that flow is only valid with an explicit box (a bare
+   `(ref $C)` is not a $AnyValue subtype; in host mode it needs
+   `extern.convert_any`). Slice 3 must either make the verifier reject
+   un-boxed ref→dynamic returns or teach `coerceReturnValue` a dynamic arm
+   that emits the box. Slice 2 never produces this flow (the move-only
+   scan rejects it) — do not widen the scan before this lands.
+6. **Producer widening** (same PR or a follow-up, each with its own
+   claim-rate delta): `if (x)` truthiness via tag.test+unbox; `x === lit`
+   via tag.test; `return <concrete>` under dynamic return via box;
+   concrete-arg → dyn-param via box; `typeof x` via tag read. Each widening
+   is a `dynamicUsesAreMoveOnly` arm flip + a from-ast lowering arm — keep
+   the scan and the builder in lockstep (they are the same capability row,
+   #2135).
+7. **Lift gate 6** (`computeIrFirstSkipSet`) only after an `ir_first`-lane
+   test262 run shows zero dynamic-claim build demotions.
+
+**Verification protocol**: prove-emit-identity (39-hash corpus) must stay
+IDENTICAL for any slice that adds only lowering arms (no producer change);
+each producer widening re-runs the claim sweep (below) + full CI.
+
+## Implementation Plan — Slice 3b: unify explicit `any` onto `dynamic`
+
+`resolvePositionType`'s AnyKeyword arm (`codegen/index.ts:592`) and the
+selector's `"any"` kind currently map `x: any` to **externref in ALL
+modes**, which diverges from legacy's fast-mode $AnyValue ABI (measured,
+see slice-2 notes — a claimed `f(x: any): any` has a DIFFERENT fast-mode
+signature than its legacy callers expect). Change both arms to `dynamic`
+(and delete the `"any"` ResolvedKind) once slice 3's box/unbox lands, so
+`any`-annotated and unannotated positions are the same type. **Blast
+radius**: currently-claimed any-functions change fast-mode signatures
+(that's the FIX) and host-mode stays byte-equal (dynamic lowers to
+externref there). Needs: the #1228 tests updated, a fast-mode cross-call
+probe (legacy caller → IR callee), and full CI. Do NOT fold into slice 3's
+lowering PR — separate, revertible.
+
+## Banked adoption slices (unlocked by this substrate; Opus-tier)
+
+### A. #2963 Phase 2 — any-callable scalar-param dispatch
+
+Phase 2 is blocked on value-call dispatch mis-selecting same-ARITY
+candidates for scalar-param reified builtins (`Number.isInteger` traps —
+see #2963 "value-call-path blocker"). The substrate fix: a function value
+held dynamically is a **Function-tagged dynamic value whose refval is the
+closure struct**; call sites recover it by `tag.test(Function)` +
+`unbox(Function)` + `ref.test` against candidate closure types keyed on
+the EXACT static closure type (param ValTypes), not arity. Land as: (1)
+key `__callable_param_*` candidate selection (`expressions/calls.ts`
+~13230–13640) on closure struct typeIdx recovered via `ref.test` chains;
+(2) once slice 3's unbox exists, route the externref-widened `const f = …`
+read through the dynamic carrier instead of raw externref so the tag is
+available. Acceptance: `const f = Number.isInteger; f(4)` → true,
+standalone, no trap, no `__get_builtin`.
+
+### B. #2984 buckets (1)+(2) — gOPD on builtins (method-value reification)
+
+Measured verdict in #2984: descriptor SHAPE is fixed; the residual gap is
+that `descriptor.value` for a builtin method is a **non-first-class
+placeholder** (path-dependent `typeof`, non-invocable, non-canonical).
+The substrate answer: a builtin method VALUE is the #2963 Phase-1
+singleton closure, carried as a Function-tagged dynamic value. Slices:
+(1) descriptor `.value` writes store the singleton (identity `===
+Array.prototype.forEach` holds by the singleton property); (2) `.value`
+reads produce the dynamic carrier so `typeof` reads the Function tag
+(fixes the inline-vs-const instability — same read path everywhere); (3)
+invocation `d.value.call(arr, cb)` = the same recovery as slice A +
+thisArg threading (slice C). Bucket (2)'s ctor-receiver CE retires when
+the `__get_builtin` fallthrough in `property-access.ts` can instead
+materialize the singleton value. Do NOT attempt a descriptor-layer-only
+fix (re-breeds the placeholder — #2984's explicit warning).
+
+### C. `.call`/`.apply` on a closure VALUE (the #3015/#3016 residual family)
+
+Two known concrete defects, both "function value lost its callable type":
+
+- `identifier.call(...)` handler (`src/codegen/expressions/calls.ts`
+  ~L4831): when the receiver identifier is a closure-typed local, the
+  lowering DROPS thisArg and mis-dispatches; with the dynamic carrier the
+  receiver read keeps the Function tag and `.call` lowers to unbox →
+  closure-struct invoke with explicit thisArg prepend.
+- property-access `.call` (e.g. `d.get.call(obj)` from a descriptor):
+  there is NO closure-value recovery path today — the value arrives as
+  opaque externref. Same recovery as slice A; the descriptor read (slice
+  B step 2) must produce the tagged carrier first.
+- #3015 (`arr.some(cb)` where cb is a dynamic function-typed param):
+  prefer its Direction 1 (preserve the closure struct through argument
+  evaluation) for the TYPED-param case — no dynamic carrier needed; the
+  dynamic carrier is the answer only for genuinely-untyped callbacks
+  (post-slice-3 unbox to closure). Don't conflate the two in one PR.
+
+### Sequencing
+
+slice 3 (lowering) → {slice 3b (any unification), A (#2963 P2)} → B/C in
+either order (both consume A's recovery helper). Producer widenings (step
+6) can proceed in parallel with A–C once slice 3 lands. Each slice: own
+PR, own claim-rate/CE-delta measurement, prove-emit-identity for
+untouched lanes.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -23,7 +23,7 @@ import {
 import type { FieldDef, Instr, StructTypeDef, ValType, WasmFunction, WasmModule } from "../ir/types.js";
 import { createEmptyModule } from "../ir/types.js";
 import { compileIrPathFunctions, type IrIntegrationError } from "../ir/integration.js";
-import { irVal, type IrType } from "../ir/nodes.js";
+import { irDynamic, isDynamic, irVal, type IrType } from "../ir/nodes.js";
 import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import { planIrCompilation, irClosureSignatureFromFunctionTypeNode, type IrFallbackReason } from "../ir/select.js";
 import { makeIrHostGlobalResolver } from "../ir/host-extern.js"; // (#2856)
@@ -736,6 +736,22 @@ function resolvePositionType(
     if (ir) return ir;
     throw new Error(`object position type — lattice shape not lowerable to IrType.object`);
   }
+  // #2949 slice 2 — UNANNOTATED position whose lattice converged to `unknown`
+  // (no evidence) or `dynamic` (top): the position is honestly dynamic. MUST
+  // stay predicate-identical to the selector's `resolveParamType` /
+  // `resolveReturnType` dynamic arms (select.ts) — the selector claims
+  // exactly the functions this resolver maps, so a drift here would either
+  // drop claimed functions at resolve time (kind "resolve" demotions) or
+  // hand the from-ast builder types the move-only scan never approved.
+  // Lowering: `lowerIrTypeToValType`'s dynamic arm → `resolveDynamic()` =
+  // legacy `resolveWasmType`'s any/unknown carrier (fast: ref_null $AnyValue,
+  // host: externref), so the claimed function's Wasm signature equals what
+  // legacy gives the same declaration. `node` is undefined here (annotated
+  // positions — including element/field recursion, which always passes a
+  // node — returned or threw above).
+  if (mapped && (mapped.kind === "unknown" || mapped.kind === "dynamic")) {
+    return irDynamic();
+  }
   throw new Error(`no concrete type (mapped=${mapped?.kind ?? "missing"})`);
 }
 
@@ -1197,6 +1213,19 @@ function computeIrFirstSkipSet(plan: IrOverlayPlan, sourceFile: ts.SourceFile): 
     if (!fn || fn.asteriskToken) continue; // gate 2 — generators
     if (irFirstBodyReadsHostNode(fn, moduleNames)) continue; // gate 4 — host nodes
     if (irFirstBodyReadsStringElement(fn)) continue; // gate 5 — string element read (#2972)
+    // Gate 6 (#2949 slice 2) — dynamic-signature functions stay compile-twice
+    // under IR-first while the dynamic surface is move-only (no box/unbox
+    // lowering yet). The selector's `dynamicUsesAreMoveOnly` scan is designed
+    // to make claims build-proof, but a scan↔builder divergence on this brand-
+    // new surface would otherwise become a skipped-slot HARD error; keep the
+    // legacy body as the demotion target until slice 3 lowering + an ir_first
+    // lane measurement prove the claims robust, then lift this gate.
+    {
+      const o = plan.overrideMap.get(name);
+      if (o && (o.params.some((p) => isDynamic(p)) || (o.returnType !== null && isDynamic(o.returnType)))) {
+        continue;
+      }
+    }
     if (!edges) continue; // no edge info (defensive) — stay conservative
     const callees = edges.get(name);
     let closed = true;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -319,6 +319,15 @@ export function planIrCompilation(
   // Track unnamed FunctionDeclarations too (rare but possible — `default`
   // export of an anonymous function, etc.) so callers can see them.
   let unnamedCount = 0;
+  // #2949 slice 2 — pre-collect ALL top-level FunctionDeclarations before the
+  // per-function claim loop so `dynamicUsesAreMoveOnly` can resolve CALLEE
+  // param/return dynamic-ness independent of declaration order (the loop
+  // below fills `declByName` incrementally, which would miss later-declared
+  // callees). Module-level for the usual isPhase1* threading reason.
+  for (const stmt of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) declByName.set(stmt.name.text, stmt);
+  }
+  currentDynScanDecls = declByName;
   for (const stmt of sourceFile.statements) {
     if (!ts.isFunctionDeclaration(stmt)) continue;
     if (!stmt.name) {
@@ -693,6 +702,9 @@ function whyNotIrClaimable(
   const entry = !isMethod && ts.isFunctionDeclaration(fn) && fn.name ? typeMap?.get(fn.name.text) : undefined;
 
   let isVoidReturn = false;
+  // #2949 slice 2 — true when the return position resolved `dynamic`
+  // (unannotated + lattice unknown/dynamic). Feeds the move-only scan below.
+  let isDynamicReturn = false;
   if (!isGenerator) {
     if (ts.isConstructorDeclaration(fn)) {
       // Constructors have no source-level return type — they always return
@@ -705,10 +717,16 @@ function whyNotIrClaimable(
       const returnResolved = resolveReturnType(fn, entry?.returnType);
       if (returnResolved === null) return "return-type-not-resolvable";
       isVoidReturn = returnResolved === "void";
+      isDynamicReturn = returnResolved === "dynamic";
     }
   }
 
   const scope = new Set<string>();
+  // #2949 slice 2 — names bound to DYNAMIC-typed values (unannotated params
+  // whose lattice type is unknown/dynamic; extended with const/let aliases by
+  // the move-only scan). Non-empty ⇒ the claim is additionally gated on
+  // `dynamicUsesAreMoveOnly` below.
+  const dynNames = new Set<string>();
   // Method bodies and constructor bodies see `this` as an implicit local;
   // mark it so a `return this;` / `this.field` reference passes the
   // identifier-in-scope check at Phase-1 expression position.
@@ -730,6 +748,10 @@ function whyNotIrClaimable(
       const mapped = entry?.params[i];
       const paramResolved = resolveParamType(p, mapped);
       if (paramResolved === null) return "param-type-not-resolvable";
+      // #2949 slice 2 — a DYNAMIC binding pattern (`function f({x}) …` with no
+      // annotation/evidence) would need dynamic property access to destructure;
+      // that's box/unbox territory (slice 3). Keep the honest rejection.
+      if (paramResolved === "dynamic") return "param-type-not-resolvable";
 
       collectPatternNames(p.name, scope);
       continue;
@@ -744,6 +766,8 @@ function whyNotIrClaimable(
     const mapped = entry?.params[i];
     const paramResolved = resolveParamType(p, mapped);
     if (paramResolved === null) return "param-type-not-resolvable";
+    // #2949 slice 2 — collect dynamic-typed param names for the move-only scan.
+    if (paramResolved === "dynamic") dynNames.add(p.name.text);
 
     scope.add(p.name.text);
   }
@@ -769,6 +793,31 @@ function whyNotIrClaimable(
   }
   if (!isPhase1StatementList(body.statements, scope, localClasses, isGenerator, isVoidReturn))
     return "body-shape-rejected";
+
+  // -------------------------------------------------------------------------
+  // #2949 slice 2 — dynamic move-only gate.
+  //
+  // A function whose params/return resolved `dynamic` is claimable ONLY when
+  // every dynamic value strictly MOVES (return position, dyn-arg → dyn-param
+  // of a local direct call, const/let alias). Slice 2 deliberately has no
+  // box/unbox/tag.test lowering, so any other use (arithmetic, truthiness,
+  // property access, mixed concrete/dynamic returns, …) cannot be built; the
+  // scan keeps such functions in their existing rejection buckets instead of
+  // claim-then-demote. Precision here is LOAD-BEARING for `JS2WASM_IR_FIRST`:
+  // a claimed+skipped function that later build-demotes is a hard compile
+  // error there (see `computeIrFirstSkipSet`; gate 6 additionally keeps
+  // dynamic-signature functions compile-twice as insurance while slice 3
+  // lowering is absent).
+  //
+  // Generators with dynamic params stay rejected — the generator prologue /
+  // yield machinery has no dynamic arm yet.
+  // -------------------------------------------------------------------------
+  if (dynNames.size > 0 && isGenerator) return "param-type-not-resolvable";
+  if (dynNames.size > 0 || isDynamicReturn) {
+    if (!dynamicUsesAreMoveOnly(fn, dynNames, isDynamicReturn, typeMap)) {
+      return dynNames.size > 0 ? "param-type-not-resolvable" : "return-type-not-resolvable";
+    }
+  }
 
   return null;
 }
@@ -807,7 +856,20 @@ function isIrClaimable(
 //   and return are all primitive-annotated (the same surface slice-3 closure
 //   literals support). Lowers to `IrType.closure`; calls through the param
 //   dispatch via `lowerClosureCall` exactly like a closure-typed local.
-type ResolvedKind = "f64" | "bool" | "string" | "object" | "any" | "void" | "closure" | null;
+// #2949 slice 2 — `dynamic`: an UNANNOTATED position whose propagated lattice
+//   type converged to `unknown` (no evidence) or `dynamic` (top). Lowers to
+//   `IrType.dynamic` → the module's boxed-any carrier via
+//   `IrLowerResolver.resolveDynamic()` (fast/standalone: `ref_null $AnyValue`;
+//   JS-host: externref) — the SAME carrier legacy `resolveWasmType`'s
+//   any/unknown arm gives these positions, so IR-claimed and legacy functions
+//   agree on the ABI by construction. The claim is additionally gated by
+//   `dynamicUsesAreMoveOnly`: slice 2 has no box/unbox/tag.test lowering, so
+//   dynamic values may only MOVE. NOTE the deliberate asymmetry with the
+//   explicit `any` ANNOTATION, which keeps its historical externref mapping
+//   (the AnyKeyword arms): unifying `any` onto `dynamic` changes currently-
+//   claimed functions' fast-mode signatures and is deferred to slice 3 (where
+//   it fixes a real fast-mode ABI divergence — see the issue file).
+type ResolvedKind = "f64" | "bool" | "string" | "object" | "any" | "void" | "closure" | "dynamic" | null;
 
 /**
  * #2859 — build an `IrClosureSignature` from an explicit function-type
@@ -879,6 +941,13 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
   if (mapped?.kind === "bool") return "bool";
   if (mapped?.kind === "string") return "string";
   if (mapped?.kind === "object") return "object";
+  // #2949 slice 2 — unannotated + lattice unknown (no evidence) or dynamic
+  // (top): the position is honestly DYNAMIC. `mapped` must be present (a
+  // TypeMap entry exists for every top-level FunctionDeclaration): class
+  // members don't participate in propagation (`entry` is undefined there) and
+  // must keep the null rejection, not silently become dynamic-claimable.
+  // Lattice `union` stays null: #2135's union rows own that shape.
+  if (mapped && (mapped.kind === "unknown" || mapped.kind === "dynamic")) return "dynamic";
   return null;
 }
 
@@ -907,7 +976,262 @@ function resolveReturnType(
   if (mapped?.kind === "bool") return "bool";
   if (mapped?.kind === "string") return "string";
   if (mapped?.kind === "object") return "object";
+  // #2949 slice 2 — same dynamic arm as `resolveParamType` (see the rationale
+  // there). A dynamic return is claimable only when every return statement
+  // returns a dynamic-typed MOVE (enforced by `dynamicUsesAreMoveOnly`).
+  if (mapped && (mapped.kind === "unknown" || mapped.kind === "dynamic")) return "dynamic";
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// #2949 slice 2 — dynamic move-only scan
+// ---------------------------------------------------------------------------
+
+/**
+ * All top-level FunctionDeclarations of the CURRENT `planIrCompilation` run,
+ * pre-collected before Step 1 so the move-only scan can resolve CALLEE
+ * param/return dynamic-ness regardless of declaration order. Module-level for
+ * the same reason as `currentFnHasCStyleLoop` (threading a param through the
+ * shared `isPhase1*` recursion would conflict with every in-flight selector
+ * slice). `null` outside a selector run — the scan then treats every callee
+ * as non-dynamic (conservative: dyn args to it reject the claim).
+ */
+let currentDynScanDecls: ReadonlyMap<string, ts.FunctionDeclaration> | null = null;
+
+/** Resolve whether param `argIdx` of local function `calleeName` is dynamic
+ *  (same `resolveParamType` verdict the callee's own claim check uses, so the
+ *  caller-side scan and the callee's signature can never drift). */
+function calleeParamIsDynamic(calleeName: string, argIdx: number, typeMap: TypeMap | undefined): boolean {
+  const decl = currentDynScanDecls?.get(calleeName);
+  if (!decl) return false;
+  const p = decl.parameters[argIdx];
+  if (!p || !ts.isIdentifier(p.name)) return false;
+  return resolveParamType(p, typeMap?.get(calleeName)?.params[argIdx]) === "dynamic";
+}
+
+function calleeHasAnyDynamicParam(calleeName: string, typeMap: TypeMap | undefined): boolean {
+  const decl = currentDynScanDecls?.get(calleeName);
+  if (!decl) return false;
+  for (let i = 0; i < decl.parameters.length; i++) {
+    if (calleeParamIsDynamic(calleeName, i, typeMap)) return true;
+  }
+  return false;
+}
+
+/** Resolve whether local function `calleeName`'s return is dynamic. */
+function calleeReturnIsDynamic(calleeName: string, typeMap: TypeMap | undefined): boolean {
+  const decl = currentDynScanDecls?.get(calleeName);
+  if (!decl || decl.asteriskToken) return false;
+  return resolveReturnType(decl, typeMap?.get(calleeName)?.returnType) === "dynamic";
+}
+
+/**
+ * True when the subtree contains NO value-use of a dynamic name. Property
+ * NAMES (`obj.<name>`, non-computed object-literal keys) are not value uses
+ * and are excluded; everything else that mentions a dyn name counts as a
+ * touch. Used as the conservative fallback for constructs the move-only scan
+ * doesn't model: untouched-by-dynamic subtrees are exactly as claimable as
+ * they were before slice 2.
+ */
+function subtreeTouchesDynamic(root: ts.Node, dynNames: ReadonlySet<string>): boolean {
+  let found = false;
+  const visit = (n: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(n) && dynNames.has(n.text)) {
+      found = true;
+      return;
+    }
+    if (ts.isPropertyAccessExpression(n)) {
+      visit(n.expression); // skip `.name` — not a value use
+      return;
+    }
+    if (ts.isPropertyAssignment(n)) {
+      if (ts.isComputedPropertyName(n.name)) visit(n.name);
+      visit(n.initializer); // skip the literal key
+      return;
+    }
+    forEachChild(n, visit);
+  };
+  visit(root);
+  return found;
+}
+
+/**
+ * #2949 slice 2 — verify every use of a dynamic value in `fn`'s body is a
+ * MOVE the from-ast builder can lower withOUT box/unbox/tag.test (which land
+ * in slice 3). Allowed sinks for a dynamic value:
+ *
+ *   - `return <dyn>` when the function's return resolved dynamic;
+ *   - argument position of a DIRECT call to a local function whose
+ *     corresponding param also resolved dynamic (`irTypeEquals` at the
+ *     from-ast call site then holds by construction);
+ *   - `const`/`let` initializer that is exactly a dyn identifier or a
+ *     dyn-returning local call — the declared name joins `dynNames`;
+ *   - re-assignment `<dynLocal> = <dyn move>`;
+ *   - statement-position calls (a dropped dynamic result is fine).
+ *
+ * Dually, a position that REQUIRES a dynamic value (dyn-param argument, dyn
+ * return) must receive one — a concrete value there would need a box.
+ * Everything else is rejected so the function keeps its existing rejection
+ * bucket (never claim-then-demote; see the IR-first hard-error contract).
+ *
+ * The walker mutates `dynNames` (alias tracking). Shadowing is already
+ * rejected by the Phase-1 scope rules, so a flat set is sound.
+ */
+function dynamicUsesAreMoveOnly(
+  fn: IrClaimableSubject,
+  dynNames: Set<string>,
+  returnIsDynamic: boolean,
+  typeMap: TypeMap | undefined,
+): boolean {
+  const body = fn.body;
+  if (!body) return false;
+
+  const unwrap = (e: ts.Expression): ts.Expression => {
+    while (ts.isParenthesizedExpression(e)) e = e.expression;
+    return e;
+  };
+
+  /** Is `e` shaped like a dynamic-typed value? (dyn name | dyn-returning local call) */
+  const isDynShaped = (e: ts.Expression): boolean => {
+    e = unwrap(e);
+    if (ts.isIdentifier(e)) return dynNames.has(e.text);
+    if (ts.isCallExpression(e) && ts.isIdentifier(e.expression) && !dynNames.has(e.expression.text)) {
+      return calleeReturnIsDynamic(e.expression.text, typeMap);
+    }
+    return false;
+  };
+
+  /** Scan a direct-call's arguments against the callee's per-param verdicts. */
+  const scanDirectCallArgs = (e: ts.CallExpression, calleeName: string): boolean => {
+    for (let i = 0; i < e.arguments.length; i++) {
+      const a = e.arguments[i]!;
+      if (ts.isSpreadElement(a)) {
+        // Spread shifts arg→param index mapping (`expandStaticSpreadArgs`);
+        // don't try to track it — safe only when the callee has no dynamic
+        // params and the spread source doesn't touch dynamic values.
+        if (calleeHasAnyDynamicParam(calleeName, typeMap)) return false;
+        if (subtreeTouchesDynamic(a, dynNames)) return false;
+        continue;
+      }
+      if (!scanExpr(a, calleeParamIsDynamic(calleeName, i, typeMap))) return false;
+    }
+    return true;
+  };
+
+  /**
+   * `expectDyn` is the type the POSITION requires: true ⇒ a dynamic value
+   * must flow here (box needed otherwise → reject); false ⇒ a concrete value
+   * must flow here (unbox needed otherwise → reject).
+   */
+  const scanExpr = (expr: ts.Expression, expectDyn: boolean): boolean => {
+    const e = unwrap(expr);
+    if (ts.isIdentifier(e)) {
+      return dynNames.has(e.text) === expectDyn;
+    }
+    if (ts.isCallExpression(e)) {
+      // Direct call to a (possibly) top-level function. A dyn-NAMED callee
+      // (`x()` where x is dynamic) is calling a dynamic value — slice 3.
+      if (ts.isIdentifier(e.expression)) {
+        if (dynNames.has(e.expression.text)) return false;
+        const calleeName = e.expression.text;
+        if (calleeReturnIsDynamic(calleeName, typeMap) !== expectDyn) return false;
+        return scanDirectCallArgs(e, calleeName);
+      }
+      // Method-shaped / other callees: no dynamic involvement allowed.
+      if (expectDyn) return false;
+      if (!scanExpr(e.expression, false)) return false;
+      for (const a of e.arguments) {
+        if (ts.isSpreadElement(a)) {
+          if (subtreeTouchesDynamic(a, dynNames)) return false;
+          continue;
+        }
+        if (!scanExpr(a, false)) return false;
+      }
+      return true;
+    }
+    if (ts.isBinaryExpression(e)) {
+      // Plain assignment re-binds; scan the RHS against the LHS's dyn-ness.
+      if (e.operatorToken.kind === ts.SyntaxKind.EqualsToken && ts.isIdentifier(e.left)) {
+        if (expectDyn) return false; // assignment-as-value in a dyn position — slice 3
+        return scanExpr(e.right, dynNames.has(e.left.text));
+      }
+      if (expectDyn) return false; // operator results are concrete-shaped
+      return scanExpr(e.left, false) && scanExpr(e.right, false);
+    }
+    if (ts.isPrefixUnaryExpression(e) || ts.isPostfixUnaryExpression(e)) {
+      if (expectDyn) return false;
+      const op = e.operand;
+      return scanExpr(op, false);
+    }
+    if (ts.isConditionalExpression(e)) {
+      // Dyn joins in cond-expr arms need refinement widening at the join —
+      // slice 3. Concrete conditional expressions pass through.
+      if (expectDyn) return false;
+      return scanExpr(e.condition, false) && scanExpr(e.whenTrue, false) && scanExpr(e.whenFalse, false);
+    }
+    if (ts.isPropertyAccessExpression(e)) {
+      if (expectDyn) return false;
+      return scanExpr(e.expression, false);
+    }
+    if (ts.isElementAccessExpression(e)) {
+      if (expectDyn) return false;
+      return scanExpr(e.expression, false) && scanExpr(e.argumentExpression, false);
+    }
+    // Everything else (literals, templates, object/array literals, closures,
+    // new-expressions, typeof, …): fine exactly when no dynamic value is
+    // involved AND the position doesn't require one.
+    return !expectDyn && !subtreeTouchesDynamic(e, dynNames);
+  };
+
+  const scanStmt = (s: ts.Statement): boolean => {
+    if (ts.isVariableStatement(s)) {
+      for (const d of s.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || !d.initializer) {
+          if (subtreeTouchesDynamic(d, dynNames)) return false;
+          continue;
+        }
+        const initIsDyn = isDynShaped(d.initializer);
+        if (!scanExpr(d.initializer, initIsDyn)) return false;
+        if (initIsDyn) dynNames.add(d.name.text);
+      }
+      return true;
+    }
+    if (ts.isReturnStatement(s)) {
+      if (!s.expression) return true;
+      return scanExpr(s.expression, returnIsDynamic);
+    }
+    if (ts.isExpressionStatement(s)) {
+      const e = unwrap(s.expression);
+      // Statement-position direct call: the result is DROPPED, so a dynamic
+      // return is fine here regardless of the callee's return verdict.
+      if (ts.isCallExpression(e) && ts.isIdentifier(e.expression) && !dynNames.has(e.expression.text)) {
+        return scanDirectCallArgs(e, e.expression.text);
+      }
+      return scanExpr(s.expression, false);
+    }
+    if (ts.isIfStatement(s)) {
+      return (
+        scanExpr(s.expression, false) && scanStmt(s.thenStatement) && (!s.elseStatement || scanStmt(s.elseStatement))
+      );
+    }
+    if (ts.isBlock(s)) {
+      for (const inner of s.statements) if (!scanStmt(inner)) return false;
+      return true;
+    }
+    if (ts.isWhileStatement(s)) {
+      return scanExpr(s.expression, false) && scanStmt(s.statement);
+    }
+    // For / for-of / for-in / switch / try / throw / nested functions /
+    // anything else: conservative — claimable exactly when the statement
+    // doesn't touch a dynamic value at all.
+    return !subtreeTouchesDynamic(s, dynNames);
+  };
+
+  for (const s of body.statements) {
+    if (!scanStmt(s)) return false;
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/issue-2949-slice2-dynamic-producers.test.ts
+++ b/tests/issue-2949-slice2-dynamic-producers.test.ts
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #2949 slice 2 — dynamic producers + selector (move-only surface).
+//
+// Slice 1 (merged, PR #2486) added the `{kind:"dynamic", tag?}` IrType leaf,
+// verifier rules R1–R4, and the `resolveDynamic()` lowering contract. This
+// slice adds the first PRODUCERS: unannotated params/returns whose propagated
+// lattice type is `unknown`/`dynamic` now resolve to `IrType.dynamic` instead
+// of rejecting the function (`param-type-not-resolvable` /
+// `return-type-not-resolvable`).
+//
+// The claim is gated by the MOVE-ONLY scan (`dynamicUsesAreMoveOnly` in
+// select.ts): slice 2 has no box/unbox/tag.test lowering, so a dynamic value
+// may only move — return position, dyn-arg → dyn-param of a local direct
+// call, const/let alias. Anything else keeps the existing rejection bucket.
+// Precision here is load-bearing: claim-then-demote would be a hard error
+// under JS2WASM_IR_FIRST (skipped-slot contract, #2138) and noise in the
+// #1923 post-claim metering. These tests pin BOTH sides: what claims must
+// build + run correctly with ZERO post-claim demotions, and what must NOT
+// claim.
+//
+// ABI: dynamic lowers through `resolveDynamic()` = legacy `resolveWasmType`'s
+// any/unknown arm (fast/standalone: `ref_null $AnyValue`; host: externref),
+// so IR-claimed and legacy-compiled functions agree on signatures by
+// construction — asserted below by comparing the emitted `func $f` header
+// against an `experimentalIR: false` compile of the same source.
+
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/index.js";
+import { buildTypeMap } from "../src/ir/propagate.js";
+import { buildImports } from "../src/runtime.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/** Selector verdict with a real checker-backed TypeMap (production shape). */
+function selectionFor(source: string): {
+  claimed: Set<string>;
+  fallbacks: Map<string, string>;
+} {
+  const host = ts.createCompilerHost({});
+  const sfRaw = ts.createSourceFile("t.ts", source, ts.ScriptTarget.ES2022, true);
+  const program = ts.createProgram({
+    rootNames: ["t.ts"],
+    options: { allowJs: true },
+    host: {
+      ...host,
+      getSourceFile: (fn, lv) => (fn === "t.ts" ? sfRaw : host.getSourceFile(fn, lv)),
+      fileExists: (fn) => fn === "t.ts" || host.fileExists(fn),
+      readFile: (fn) => (fn === "t.ts" ? source : host.readFile(fn)),
+    },
+  });
+  const sf = program.getSourceFile("t.ts")!;
+  const typeMap = buildTypeMap(sf, program.getTypeChecker());
+  const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true }, typeMap);
+  const fallbacks = new Map<string, string>();
+  for (const fb of sel.fallbacks ?? []) fallbacks.set(fb.name, fb.reason);
+  return { claimed: new Set(sel.funcs), fallbacks };
+}
+
+async function compileStrict(source: string, opts: Record<string, unknown> = {}) {
+  const r = await compile(source, { fileName: "t.ts", ...opts });
+  expect(r.success, r.errors[0]?.message).toBe(true);
+  // Zero post-claim demotions — the move-only scan must be build-proof.
+  expect(r.irPostClaimErrors ?? []).toEqual([]);
+  return r;
+}
+
+async function instantiate(r: Awaited<ReturnType<typeof compile>>): Promise<Record<string, Function>> {
+  const built = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+/** The `(func $f …` header line (signature) from the WAT. */
+function funcHeader(wat: string, name: string): string | undefined {
+  return wat.split("\n").find((l) => l.includes(`(func $${name} `) || l.includes(`(func $${name}(`));
+}
+
+// ---------------------------------------------------------------------------
+// Selector — what claims
+// ---------------------------------------------------------------------------
+
+describe("#2949 slice 2 — selector claims move-only dynamic shapes", () => {
+  it("unannotated identity claims (param + return dynamic)", () => {
+    const { claimed } = selectionFor(`export function f(x) { return x; }`);
+    expect(claimed.has("f")).toBe(true);
+  });
+
+  it("pass-through chain claims (dyn-arg → dyn-param, dyn return)", () => {
+    const { claimed } = selectionFor(`
+      function g(x) { return x; }
+      export function f(x) { return g(x); }
+    `);
+    expect(claimed.has("g")).toBe(true);
+    expect(claimed.has("f")).toBe(true);
+  });
+
+  it("const alias of a dynamic param claims", () => {
+    const { claimed } = selectionFor(`export function f(x) { const y = x; return y; }`);
+    expect(claimed.has("f")).toBe(true);
+  });
+
+  it("unused dynamic param with concrete return claims", () => {
+    const { claimed } = selectionFor(`export function f(x) { return 1; }`);
+    expect(claimed.has("f")).toBe(true);
+  });
+
+  it("statement-position dyn call (result dropped) claims", () => {
+    const { claimed } = selectionFor(`
+      function g(x) { return x; }
+      export function f(x): number { g(x); return 1; }
+    `);
+    expect(claimed.has("f")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selector — what must NOT claim (precision: no claim-then-demote)
+// ---------------------------------------------------------------------------
+
+describe("#2949 slice 2 — non-move dynamic uses keep their rejection buckets", () => {
+  const rejected: Array<[string, string, string]> = [
+    ["arithmetic on dyn param", `export function f(x) { return x + 1; }`, "param-type-not-resolvable"],
+    [
+      "truthiness test of dyn param",
+      `export function f(x) { if (x) { return x; } else { return x; } }`,
+      "param-type-not-resolvable",
+    ],
+    ["property access on dyn param", `export function f(x) { return x.foo; }`, "param-type-not-resolvable"],
+    [
+      "mixed dynamic/concrete returns",
+      `export function f(x) { if (x === 1) { return x; } else { return 0; } }`,
+      "param-type-not-resolvable",
+    ],
+    [
+      "dyn arg into a concrete (annotated) param",
+      `function g(n: number): number { return n; }
+       export function f(x) { return g(x); }`,
+      "param-type-not-resolvable",
+    ],
+    ["calling the dyn value itself", `export function f(x) { return x(); }`, "param-type-not-resolvable"],
+  ];
+  for (const [label, src, reason] of rejected) {
+    it(`${label} → ${reason}`, () => {
+      const { claimed, fallbacks } = selectionFor(src);
+      expect(claimed.has("f")).toBe(false);
+      expect(fallbacks.get("f")).toBe(reason);
+    });
+  }
+
+  it("destructured dynamic param stays rejected (needs dynamic property access)", () => {
+    const { claimed } = selectionFor(`export function f({ a }) { return a; }`);
+    expect(claimed.has("f")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Build + run — round-trip with zero demotions, JS-semantics-correct
+// ---------------------------------------------------------------------------
+
+describe("#2949 slice 2 — claimed shapes build (no demotions) and run correctly", () => {
+  const shapes: Array<[string, string]> = [
+    ["identity", `export function f(x) { return x; }`],
+    ["pass-through", `function g(x) { return x; }\nexport function f(x) { return g(x); }`],
+    ["const alias", `export function f(x) { const y = x; return y; }`],
+  ];
+
+  for (const [label, src] of shapes) {
+    it(`${label} — host mode: identity across number/string/null/undefined/object/bool`, async () => {
+      const r = await compileStrict(src);
+      const exports = await instantiate(r);
+      const obj = { a: 1 };
+      expect(exports.f!(42)).toBe(42);
+      expect(exports.f!("hello")).toBe("hello");
+      expect(exports.f!(null)).toBe(null);
+      expect(exports.f!(true)).toBe(true);
+      expect(exports.f!(obj)).toBe(obj);
+    });
+
+    it(`${label} — fast mode compiles with zero demotions`, async () => {
+      await compileStrict(src, { fast: true });
+    });
+  }
+
+  it("unused dyn param + concrete return runs", async () => {
+    const r = await compileStrict(`export function f(x) { return 1; }`);
+    const exports = await instantiate(r);
+    expect(exports.f!("whatever")).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ABI lockstep — IR-claimed signature equals the legacy signature
+// ---------------------------------------------------------------------------
+
+describe("#2949 slice 2 — dynamic carrier equals the legacy any/unknown ABI", () => {
+  const src = `export function f(x) { return x; }`;
+
+  it("host mode: same `func $f` header as experimentalIR:false", async () => {
+    const ir = await compileStrict(src);
+    const legacy = await compile(src, { fileName: "t.ts", experimentalIR: false });
+    expect(legacy.success).toBe(true);
+    expect(funcHeader(ir.wat, "f")).toBeDefined();
+    expect(funcHeader(ir.wat, "f")).toBe(funcHeader(legacy.wat, "f"));
+  });
+
+  it("fast mode: same `func $f` header as experimentalIR:false (ref_null $AnyValue, NOT externref)", async () => {
+    const ir = await compileStrict(src, { fast: true });
+    const legacy = await compile(src, { fileName: "t.ts", fast: true, experimentalIR: false });
+    expect(legacy.success).toBe(true);
+    const irHeader = funcHeader(ir.wat, "f");
+    expect(irHeader).toBeDefined();
+    expect(irHeader).toBe(funcHeader(legacy.wat, "f"));
+    // The carrier must be a concrete ref (the $AnyValue box), not externref —
+    // the explicit-`any` externref asymmetry must not leak into dynamic.
+    expect(irHeader).not.toContain("externref");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IR-first gate 6 — dynamic claims stay compile-twice under the flag
+// ---------------------------------------------------------------------------
+
+describe("#2949 slice 2 — IR-first skip-set gate 6", () => {
+  it("dynamic-signature functions are claimed but NOT legacy-skipped under JS2WASM_IR_FIRST=1", async () => {
+    const src = `export function f(x) { return x; }\nexport function t(n: number): number { return n + 1; }`;
+    vi.stubEnv("JS2WASM_IR_FIRST", "1");
+    try {
+      const r = await compile(src, { fileName: "t.ts" });
+      expect(r.success).toBe(true);
+      expect(r.irPostClaimErrors ?? []).toEqual([]);
+      const skipped = r.irFirstSkipped ?? [];
+      // gate 6: the dynamic function keeps its legacy body (compile-twice)…
+      expect(skipped).not.toContain("f");
+      // …while a typed function is still skipped (gate 6 is surgical).
+      expect(skipped).toContain("t");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of #2949 (JsTag-carrying `dynamic` IrType): the first **producers**. Unannotated params/returns whose propagated lattice type is `unknown`/`dynamic` now resolve to `IrType.dynamic` and the function CLAIMS, instead of whole-function rejection (`param-type-not-resolvable` / `return-type-not-resolvable`). This is the keystone step toward making untyped JS claimable by the IR front-end.

The claim is gated by a new **move-only scan** (`dynamicUsesAreMoveOnly` in select.ts): slice 2 has no box/unbox/tag.test lowering (slice 3), so dynamic values may only MOVE — return position, dyn-arg → dyn-param of local direct calls, const/let aliases, statement-position calls. Everything else keeps its existing rejection bucket. Precision is load-bearing: under `JS2WASM_IR_FIRST=1` a claimed+skipped function that build-demotes is a hard error (#2138 skipped-slot contract), and the #1923 post-claim metering must stay flat.

## Changes

- `src/ir/select.ts`: `ResolvedKind` gains `"dynamic"`; resolver arms (unannotated + lattice unknown/dynamic, TypeMap entry required — methods stay out); the move-only scan with callee param/return verdicts computed by the same resolvers the callee's own claim uses (no selector↔override drift possible).
- `src/codegen/index.ts`: `resolvePositionType` dynamic arm (predicate-identical to the selector); IR-first skip-set **gate 6** — dynamic-signature functions stay compile-twice under the flag until slice-3 lowering is proven.
- `tests/issue-2949-slice2-dynamic-producers.test.ts`: 22 tests — claims, precision rejections, run-behavior identity (number/string/null/bool/object), fast-mode zero-demotion compile, **ABI lockstep** (IR `func $f` header byte-equal to legacy in host AND fast mode — the dynamic carrier is legacy's `ref_null $AnyValue`/externref per mode, via slice-1's `resolveDynamic()`), ir-first gate 6.
- from-ast / verify / lower: **zero changes** — the move surface is entirely type-driven through slice-1 machinery.

## Verification

- **Byte-identity vs main**: `prove-emit-identity.mjs` — all 39 (file,target) hashes IDENTICAL across gc/standalone/wasi (baseline on clean main 4f68ed670).
- **Zero post-claim demotions** on every claimed shape (asserted per-test).
- `check:ir-fallbacks` — zero delta, no post-claim entries.
- Standalone lane: claimed shapes instantiate host-free (0 imports), branch == main.
- Related suites green (`issue-2949-ir-dynamic-type` 19/19, `issue-1228`, `ir-frontend-widening`, `ir-backend-emitter`); `ir-scaffold`'s 2 failures reproduce identically on clean main (pre-existing).
- Noteworthy: the IR claim **fixes a live legacy miscompile** — host-mode legacy mangles non-number args through `function g(x){return x}; f(x){return g(x)}` (returns null/0/garbage); the claimed version is identity-correct. Expect small net-positive test262 movement from pass-through-shaped helpers.

Issue file carries full implementation notes + banked Opus-executable specs for slice 3 (lowering), slice 3b (any→dynamic unification, fixes a measured fast-mode ABI divergence in the existing explicit-`any` path), the #2963 P2 unlock, #2984 buckets 1+2, and the .call/.apply closure-value family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8