### PR TITLE
docs(website): rewrite blog post — sandboxing-first framing, fair questions

### DIFF
--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Compiling JavaScript, in the open, with a team that never sleeps · JS² Blog</title>
+    <title>Lightweight sandboxing of untrusted JavaScript: ahead-of-time compilation to WebAssembly · JS² Blog</title>
     <meta
       name="description"
-      content="How JS² turns TypeScript and JavaScript straight into WebAssembly — and how it's built with a human-plus-AI engineering team running the same test-driven, agile process a strong human team already uses."
+      content="JS² compiles TypeScript and JavaScript ahead of time to WebAssembly with no engine in the binary — compiled modules run in sandboxes with no ambient authority. Built in the open by a team of AI agents directed by humans on a test-driven agile engineering playbook."
     />
     <style>
       :root {
@@ -80,16 +80,15 @@
 
       h1 {
         margin: 0 0 16px;
-        font-size: clamp(32px, 5vw, 48px);
-        line-height: 1.06;
+        font-size: clamp(30px, 5vw, 44px);
+        line-height: 1.08;
         letter-spacing: -0.03em;
         font-weight: 700;
       }
 
       .dek {
         margin: 0 0 20px;
-        max-width: 62ch;
-        font-size: 18px;
+        font-size: 17px;
         color: var(--fg-soft);
       }
 
@@ -125,11 +124,6 @@
         font-size: 16px;
       }
 
-      .post p.faint {
-        font-size: 14px;
-        color: var(--fg-faint);
-      }
-
       .post ul {
         margin: 0 0 16px;
         padding-left: 22px;
@@ -144,6 +138,10 @@
         color: var(--fg);
       }
 
+      .post em {
+        color: var(--fg);
+      }
+
       code {
         font-family: var(--mono);
         font-size: 0.88em;
@@ -155,10 +153,33 @@
         white-space: nowrap;
       }
 
-      hr.divider {
-        border: none;
-        border-top: 1px solid var(--line);
-        margin: 44px 0;
+      /* ── Scoreboard ── */
+      .scoreboard {
+        margin: 0 0 18px;
+        padding: 18px 22px;
+        border-radius: 12px;
+        background: var(--surface);
+        border: 1px solid var(--line);
+      }
+
+      .scoreboard ul {
+        margin: 0;
+      }
+
+      /* ── FAQ ── */
+      .faq {
+        margin: 0 0 16px;
+      }
+
+      .faq dt {
+        font-weight: 600;
+        color: var(--fg);
+        margin-top: 22px;
+      }
+
+      .faq dd {
+        margin: 6px 0 0 0;
+        color: var(--fg-soft);
       }
 
       /* ── CTA ── */
@@ -247,10 +268,15 @@
       <article class="post">
         <header class="post-header">
           <span class="eyebrow">JS² Blog</span>
-          <h1>Compiling JavaScript, in the open, with a team that never sleeps</h1>
+          <h1>Lightweight sandboxing of untrusted JavaScript: ahead-of-time compilation to WebAssembly</h1>
           <p class="dek">
-            How JS² turns TypeScript and JavaScript straight into WebAssembly — and how it's built with a human-plus-AI
-            engineering team running the same test-driven, agile process a strong human team already uses.
+            JS² is an open-source research compiler that turns TypeScript and JavaScript into WebAssembly with no engine
+            in the binary. Compiled modules run in sandboxes with no ambient authority — no container, no VM, no
+            embedded engine — which is a structural answer to unread dependencies and AI-generated code, not another
+            review process. Conformance today: 74% of the official ECMAScript suite with a JS host present (the
+            sandboxing case in browsers and Node), 42.7% as pure standalone Wasm (the engine-free case), both recomputed
+            on every merge. Built in the open by a team of AI agents directed by humans on a test-driven agile team
+            engineering playbook.
           </p>
           <div class="post-meta">
             <span class="tag">Announcement</span>
@@ -259,189 +285,262 @@
           </div>
         </header>
 
-        <h2>The idea</h2>
+        <h2>The problem JavaScript developers learned to live with</h2>
         <p>
-          JavaScript was never supposed to be "compiled ahead of time" — it's the dynamic, run-anywhere language of the
-          web, usually parsed and JIT-compiled by an engine that ships inside the browser.
-          <strong>JS²</strong>
-          starts from a different question: what if we compiled it
-          <em>directly</em>
-          to WebAssembly, with garbage collection, no bundled interpreter, and no JS engine hiding inside the output?
+          Every
+          <code>npm install</code>
+          is an act of trust. A modern app pulls in hundreds of transitive dependencies, and each one runs with the full
+          authority of your process — your filesystem, your network, your environment variables, every other module's
+          objects. Supply-chain attacks exploit exactly this: one compromised package anywhere in the tree owns
+          everything, and the ecosystem re-learns that lesson every few months.
         </p>
         <p>
-          That's the bet.
+          Generative AI raises the stakes. Code now enters the ecosystem faster than any human can read it — generated
+          by models, assembled by agents, published at machine speed. "Someone has surely audited this" was always
+          optimistic; at machine speed it stops being plausible at all. When more and more of what you run is code
+          nobody has read, review alone can't carry the trust model. Untrusted code has to be
+          <em>contained by construction</em>
+          , not just inspected.
+        </p>
+        <p>
+          There's a second, quieter cost. Outside the browser, running JavaScript means shipping an engine — V8,
+          JavaScriptCore, SpiderMonkey, QuickJS — an engine in a box: megabytes of runtime, slow cold starts, one shared
+          heap.
+        </p>
+        <p>
+          Both problems share a root cause. JavaScript doesn't run — an engine runs it, and everything in the process
+          shares that engine.
+        </p>
+
+        <h2>The experiment: compile the engine away</h2>
+        <p>
+          JS² starts from the root cause. Its compiler,
           <code>js2wasm</code>
-          is an ahead-of-time compiler that takes ordinary TypeScript or JavaScript and emits a
-          <code>.wasm</code>
-          binary using
-          <strong>WasmGC</strong>
-          — real structs, real arrays, real garbage collection, running on the host's own GC instead of a heap simulated
-          in linear memory. Code the compiler can fully resolve at compile time becomes native Wasm instructions. Only
-          the genuinely dynamic corners —
+          , takes ordinary TypeScript or JavaScript and compiles it
+          <strong>ahead of time</strong>
+          to WebAssembly — in essence, machine code for a portable virtual processor, implemented by every major browser
+          and by standalone runtimes on servers and edge. Whatever the compiler can resolve at compile time becomes
+          plain Wasm instructions. For genuine runtime code generation —
           <code>eval</code>
           ,
           <code>new Function</code>
-          — fall back to a small embedded interpreter for code generated at runtime.
+          — the design reserves a small embedded interpreter, scoped to just the code it creates; that fallback is on
+          the roadmap, not shipped yet.
         </p>
         <p>
-          Why bother? Because if it works, WebAssembly stops being a niche target for Rust and C++ and becomes a
-          <strong>drop-in deployment target for the JavaScript and npm ecosystem that already exists</strong>
-          — no rewrite into a restricted subset, no engine bundled into every module. That unlocks smaller, faster
-          modules; JavaScript sandboxed from other JavaScript inside the same application; and dependency isolation that
-          makes a compromised npm package a much smaller problem than it is today.
-        </p>
-        <p>The project runs in two modes on purpose:</p>
-        <ul>
-          <li>
-            <strong>JS host mode</strong>
-            — uses host imports where they buy real performance or completeness today.
-          </li>
-          <li>
-            <strong>Standalone mode</strong>
-            — pure Wasm, zero JS runtime required, for WASI and edge targets.
-          </li>
-        </ul>
-        <p>
-          Standalone is the harder, more interesting target, and it's where most of the current work is aimed: shrinking
-          the JS-host dependency until it's optional everywhere, not just in the common case.
-        </p>
-        <p>
-          <strong>Where it stands today:</strong>
-          JS² is an early-stage research prototype, not a production compiler yet — and it's honest about that on its
-          own landing page. In JS host mode it currently passes
-          <strong>31,874 of 43,106</strong>
-          Test262 conformance tests (
-          <strong>73.9%</strong>
-          ), up from a few hundred passing tests when the project started. In standalone mode — no JS engine, no host
-          GC, the harder and strategically more important target — it's at
-          <strong>18,415 of 43,106 (42.7%)</strong>
-          and climbing steadily as host-import dependencies get replaced with native Wasm implementations. That's the
-          real, unglamorous measure of "does this actually behave like JavaScript," and it moves every week.
+          Remove the engine and the benefits fall out of the architecture rather than being bolted on. A compiled Wasm
+          module has
+          <em>no ambient authority</em>
+          : filesystem, network, DOM, and globals exist only if the host hands them in as explicit imports. Today that
+          isolation holds between compilation units — compile a dependency separately, and it cannot reach anything you
+          didn't hand it. The goal is to push the boundary down to the individual JavaScript module, finer-grained than
+          an npm package, so that fencing off a dependency, a plugin, or a block of AI-generated code becomes the same
+          routine operation: don't hand it imports it shouldn't have. And with no engine to ship, modules are small and
+          start fast enough for edge and serverless targets where a bundled runtime never fit.
         </p>
 
-        <h2>The other idea: an engineering team, not a script</h2>
+        <h2>Why this is possible now</h2>
         <p>
-          Here's the part that's easy to undersell: JS² isn't being built by one person iterating in a loop. It's built
-          by a small
-          <strong>team of AI agents</strong>
-          , running the exact same engineering process a good human team would run — because that process turns out to
-          be exactly what makes agents effective too, not a workaround for using them.
+          Hasn't compiling JavaScript to Wasm been tried? Yes — and the history is why timing matters. For years the
+          practical options were to restrict the language to a statically-compilable subset, or to pack an entire engine
+          into the module — QuickJS or SpiderMonkey compiled to Wasm, as today's Wasm-native JavaScript toolchains do.
+          What kept the direct route — compiling the actual, unrestricted language — off the table was never one missing
+          feature. It was scope: full ECMAScript compatibility has consumed engine teams for years, sometimes decades —
+          thousands of built-ins, edge cases, and spec pages to grind through.
         </p>
-        <ul>
-          <li>
-            A
-            <strong>Product Owner</strong>
-            grooms the backlog, validates issues against the current codebase (closing ones that already got fixed
-            elsewhere), and prioritizes by value.
-          </li>
-          <li>
-            An
-            <strong>Architect</strong>
-            takes the hard issues — the ones that touch core codegen — and writes a real implementation spec into the
-            issue file: which functions, which Wasm patterns, which edge cases, before anyone writes code.
-          </li>
-          <li>
-            A
-            <strong>Tech Lead</strong>
-            runs the sprint: keeps a priority-ordered task queue full, dispatches work, and owns the merge queue.
-          </li>
-          <li>
-            <strong>Developers</strong>
-            pull tasks, branch, implement, and open pull requests — each in an isolated git worktree, so parallel agents
-            never collide.
-          </li>
-          <li>
-            A
-            <strong>PR-queue shepherd</strong>
-            watches CI end-to-end, handles conflicts, and makes sure green work actually lands instead of stranding in
-            review.
-          </li>
-        </ul>
         <p>
-          Every change is
-          <strong>test-driven against Test262</strong>
-          , the official ECMAScript conformance suite — not "does it compile," but "does it behave like real JavaScript
-          across tens of thousands of spec-derived cases." Concretely: every pull request runs
-          <strong>48,088 Test262 cases</strong>
-          — the full standard + Annex&nbsp;B + TC39-proposal corpus —
-          <strong>twice</strong>
-          , once against JS host mode and once against standalone mode, sharded across 114 parallel CI jobs. That's
-          roughly
-          <strong>96,000 conformance checks</strong>
-          , on top of our own hand-written unit and differential-equivalence suite (~3,400 cases comparing native-JS
-          output against compiled-Wasm output, sharded 8-way) — call it close to
+          That arithmetic is what changed. Recent advances in frontier language models make it possible to field a team
+          of AI agents, directed by humans and held to a hard test gate, that works the long tail of the spec around the
+          clock and at machine pace. Not because agents replace compiler engineers — but because the years-long grind is
+          exactly the part machines are now good at.
+        </p>
+        <p>
+          <strong>WasmGC</strong>
+          adds to it. The garbage-collection extension WebAssembly shipped in major browsers and runtimes over the past
+          two years lets a compiler emit real structs and arrays managed by the runtime's collector instead of
+          simulating a JavaScript heap inside linear memory. That makes the approach quick to validate inside a JS host
+          — compiled modules run right alongside the host's own objects in browsers and Node — and it makes the modules
+          lighter: no allocator or GC ships in the binary. A new generation of ahead-of-time JavaScript compilers is
+          forming around this bet; JS² is the WasmGC-native entry, with a linear-memory backend in development for hosts
+          without GC support as a second target behind the same compiler.
+        </p>
+        <p>
+          And if it holds, WebAssembly stops being a Rust-and-C++ club and opens to the largest code ecosystem ever
+          built — with the sandboxing and the engine-free footprint above coming along for free.
+        </p>
+
+        <h2>The honest scoreboard</h2>
+        <p>
+          JS² measures itself against the
+          <em>full</em>
+          official Test262 suite — all 43,106 tests, the same corpus browser engines certify against, with no curated
+          subset and no cherry-picked scope. Today:
+        </p>
+        <div class="scoreboard">
+          <ul>
+            <li>
+              <strong>JS-host mode: 31,874 / 43,106 — 73.9%.</strong>
+              Compiled Wasm may call host builtins. This is the number that matters for
+              <em>sandboxing</em>
+              : isolating modules inside a browser or Node app, where a JS host is present anyway.
+            </li>
+            <li>
+              <strong>Standalone mode: 18,415 / 43,106 — 42.7%.</strong>
+              Pure Wasm, no JavaScript anywhere in the loop. This is the number that matters for
+              <em>engine-free deployment</em>
+              : WASI, edge, and embedded targets with no JS runtime at all.
+            </li>
+            <li>Both up from a few hundred passes at project start; recomputed on every merge, published live.</li>
+          </ul>
+        </div>
+        <p>
+          The claim is deliberately
+          <em>not</em>
+          "production ready." The claim is: the number is real, it's public, and it moves every week. We publish the
+          number because the number is the argument.
+        </p>
+
+        <h2>The other story: an AI team on a human playbook</h2>
+        <p>
+          The compiler is built day-to-day by a team of AI agents: a
+          <strong>Product Owner</strong>
+          grooming the backlog and verifying each issue still reproduces; an
+          <strong>Architect</strong>
+          writing implementation specs before anyone writes code; a
+          <strong>Tech Lead</strong>
+          running the sprint and the merge queue;
+          <strong>Developers</strong>
+          claiming issues and opening PRs from isolated git worktrees; a
+          <strong>PR-queue shepherd</strong>
+          walking green work through CI so it lands instead of stranding.
+        </p>
+        <p>
+          If that org chart looks familiar, that's the point. Nothing here was invented for AI: spec-first issues,
+          test-driven changes, review, a merge queue. In this project's experience so far, the same discipline that
+          makes a strong human team work is what makes agents productive too — and it means a human contributor drops
+          into the identical workflow. Same issue files, same gates, same bar for merging. No AI track, no human track.
+        </p>
+        <p>
+          The gate is not casual. Every pull request runs
+          <strong>48,088 Test262 cases twice</strong>
+          — once per mode — across 114 parallel CI jobs, plus ~3,400 hand-written unit and differential tests comparing
+          compiled Wasm against native JavaScript behavior. Roughly
           <strong>100,000 automated checks</strong>
-          before a single PR is allowed to merge.
-        </p>
-        <p class="faint">
-          (Headline conformance percentages above are reported against the narrower "official" 43,106-test scope —
-          standard + Annex&nbsp;B, the conventional way to state a conformance number — while CI itself casts a wider
-          net and also gates on proposal regressions.)
-        </p>
-        <p>
-          The merge queue then re-validates the
+          stand between any change and
+          <code>main</code>
+          , and the merge queue re-validates the
           <em>merged</em>
-          result, not just the branch, so a clean-looking PR can't quietly break something else. Sprints are real
-          sprints — planned, executed, retro'd, and frozen into a record — not an unstructured chat log.
-        </p>
-        <p>
-          <strong>The point isn't "AI wrote a compiler."</strong>
-          It's that a rigorous, test-driven, spec-first, code-reviewed agile process — the same one a strong human team
-          already uses — works when the "engineers" are agents, and it works because the process was good discipline to
-          begin with, not because AI needed something special. Which also means the reverse is true: a human developer
-          can drop straight into this team using the exact same roles, the exact same issue files, the exact same PR and
-          CI gates. No separate track for "human contributions" and "AI contributions" — one workflow, one bar for
-          merging.
+          result, so a clean-looking PR can't quietly break the tree. It's the compiler's own thesis applied to its own
+          construction: don't trust the author — verify the output, and contain what you can't verify.
         </p>
 
-        <h2>Where you come in</h2>
+        <h2>Fair questions</h2>
+        <dl class="faq">
+          <dt>"AOT-compiling JavaScript is impossible."</dt>
+          <dd>
+            Fully general AOT of every dynamic corner is — which is why the design reserves a tiny embedded interpreter
+            for
+            <code>eval</code>
+            , scoped to the code it creates (planned, not yet shipped). The bet is that the overwhelming majority of
+            real-world JavaScript
+            <em>is</em>
+            compilable ahead of time, and Test262 is the referee. 73.9% says the bet is alive; the remaining 26.1% says
+            it isn't won.
+          </dd>
+          <dt>"Aren't others working on AOT JavaScript too?"</dt>
+          <dd>
+            Yes — and that's a good sign: independent teams converging on the same bet suggests it's worth making. Where
+            JS² differs: it is
+            <strong>WasmGC-native</strong>
+            (the platform collects garbage; no allocator or GC ships in the binary), with a linear-memory backend in
+            development as a second target behind the same compiler. It targets the
+            <strong>full language</strong>
+            , including
+            <code>eval</code>
+            , rather than a subset. It compiles plain JavaScript, and when the input is
+            <strong>TypeScript</strong>
+            it takes it directly and uses the types to emit faster code. It reports host and standalone numbers
+            <strong>separately</strong>
+            , against the full 43,106-test official corpus, recomputed on every merge — no single blended figure. And
+            <strong>containment comes first</strong>
+            : module isolation is the design center, not a side effect. Different projects will make different
+            trade-offs; ours are all in the open.
+          </dd>
+          <dt>"Isn't AI-written code slop?"</dt>
+          <dd>
+            Assume fallibility — that's what the process is for. Specs precede code; ~100,000 checks precede every
+            merge; the queue re-validates the merged state; the entire history is public. Judge the diffs, not the
+            author. Human review is welcome — it's one of the most valuable ways to contribute.
+          </dd>
+          <dt>"73.9% isn't production."</dt>
+          <dd>
+            Correct, and the site says so in bold: JS² is a research prototype. The interesting question is the slope,
+            not today's intercept — and the slope is public, recomputed on every merge.
+          </dd>
+          <dt>"Why not just embed a JS engine, like Javy or StarlingMonkey?"</dt>
+          <dd>
+            You can — Javy ships QuickJS inside the module, StarlingMonkey does the same with SpiderMonkey, and both are
+            solid tools that work today. It's also what JS²'s planned
+            <code>eval</code>
+            fallback will do in miniature. But an engine-in-a-box keeps the engine: the binary size, the startup cost,
+            and one shared heap. And because WebAssembly permits no JIT inside a module, the embedded engine runs your
+            code as an interpreter — for compute-heavy work that typically costs an order of magnitude or more, 90%+ of
+            the performance a JIT would deliver. It also gives up the per-module sandboxing and dependency isolation
+            that motivated this project in the first place. JS² bets on the other trade: compile once, run as native
+            Wasm instructions, keep the binary small, and let the dynamic remainder shrink release by release.
+          </dd>
+          <dt>"Why not sandbox with containers or V8 isolates?"</dt>
+          <dd>
+            Those work at a different weight class. A container or microVM isolates at the process or kernel level —
+            right for whole tenants, far too heavy to give each of the hundreds of dependencies inside one application
+            its own. V8 isolates are much lighter, but the isolation boundary is the engine itself: every isolate lives
+            inside one V8 process and inherits the engine's attack surface, and ad-hoc in-language sandboxes have a long
+            history of escapes. A compiled Wasm module sits at a different point on the curve: a sandbox with a formally
+            specified boundary, measured in kilobytes rather than megabytes, cheap enough to instantiate that every
+            dependency can have one.
+          </dd>
+        </dl>
+
+        <h2>Come build it</h2>
         <p>
-          JS² is genuinely early — that's not a hedge, it's an invitation. Getting from "73.9% conformant research
-          prototype" to "production grade" is exactly the kind of work that scales with more hands, human or AI:
+          Getting from research prototype to production compiler is exactly the kind of work that scales with more hands
+          — human or AI:
         </p>
         <ul>
           <li>
-            <strong>Review.</strong>
-            Read a pull request, read an implementation spec, poke at an architecture decision. Fresh eyes on compiler
-            internals are always in short supply.
+            <strong>Review</strong>
+            — read a PR or an implementation spec; fresh eyes on compiler internals are permanently scarce.
           </li>
           <li>
-            <strong>Test.</strong>
-            Run Test262 against a build, find a conformance gap, file it with a repro. The conformance dashboard shows
-            exactly what's failing and why.
+            <strong>Test</strong>
+            — run Test262 against a build, find a gap, file it with a repro. The dashboard shows what fails and why.
           </li>
           <li>
-            <strong>Build.</strong>
-            Pick up a ready issue from
-            <code>plan/issues/</code>
-            — each one is a real spec, not a vague TODO — and send a PR. Every issue tracks its own status, from
+            <strong>Build</strong>
+            — claim a
             <code>ready</code>
-            to
-            <code>done</code>
-            , in the open.
+            issue from
+            <code>plan/issues/</code>
+            ; each one is a real spec, not a TODO.
           </li>
           <li>
-            <strong>Bring your own agent.</strong>
-            If you use Claude Code or a similar tool, you can point it at the same issue files and the same contributor
-            workflow the project's own agents use — the instructions are public, in the repo, not internal tooling.
+            <strong>Bring your agent</strong>
+            — point Claude Code (or similar) at the same public issue files and workflow the project's own agents use.
           </li>
           <li>
-            <strong>Just talk to us.</strong>
-            Join the Discord, ask questions, tell us where the docs are unclear or the playground breaks.
+            <strong>Talk to us</strong>
+            — the Discord is open; tell us what's unclear, what breaks, and what you'd want first.
           </li>
         </ul>
         <p>
-          The source is Apache 2.0 with the LLVM exception. Contributions go through a short CLA (so the project can
-          stay sustainably maintained long-term) and land through the same PR + CI process described above — the same
-          gate for everyone.
+          Everything is Apache 2.0 with the LLVM exception; contributions go through a short CLA and the same PR + CI
+          gauntlet as everyone else's.
         </p>
 
         <div class="cta">
           <p>
-            If the idea of JavaScript running as real, GC-backed WebAssembly — with no engine smuggled inside — is
-            interesting to you, there's a live conformance dashboard, a playground that compiles TypeScript to Wasm in
-            your browser right now, and an open issue queue waiting for the next contributor.
-            <strong>Come help make it production grade.</strong>
+            If "JavaScript, compiled" still sounds like a contradiction — come help resolve it. The playground compiles
+            JavaScript and TypeScript to Wasm in your browser right now, and the issue queue is open.
           </p>
           <div class="cta-links">
             <a class="btn btn-solid" href="../getting-started/">Get started</a>


### PR DESCRIPTION
## Summary
- Replaces the launch blog post (`website/blog/index.html`) with the approved rewrite (iterated over ~20 revisions with the project lead):
  - Headline: "Lightweight sandboxing of untrusted JavaScript: ahead-of-time compilation to WebAssembly"
  - Benefit-led arc: npm trust problem → AI-generated code raises the stakes → containment by construction → compile the engine away
  - "Why now" leads with the agentic-workforce unlock; WasmGC as the additive enabler (quick JS-host validation, lighter modules)
  - Dual conformance numbers mapped to scenarios: 73.9% JS-host (sandboxing case) / 42.7% standalone (engine-free case), full 43,106-test corpus
  - "Fair questions" section: AOT skepticism, other AOT compilers (USP positioning), AI-code quality, engine embedding (Javy/StarlingMonkey), containers/V8 isolates
  - Claims audited: eval fallback and linear backend marked planned/in-development; module-granularity isolation stated as goal; no unverified performance claims
- Nav and page chrome unchanged; same shared site-nav component.

## Test plan
- [x] Tag-balance check on the generated HTML
- [x] Prettier/lint via pre-commit and pre-push hooks — green
- [ ] Visual check on js2.loopdive.com/blog/ after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)