### PR TITLE
chore(website): re-enable JS host toggle for test262 conformance donut

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1663,7 +1663,7 @@
                  baseline. Off by default so the headline number reflects
                  shipped ECMAScript only. -->
             <div class="feat-filter conformance-scope-toggle">
-              <label class="feat-toggle" style="display: none">
+              <label class="feat-toggle">
                 <input type="checkbox" id="host-support-toggle" checked />
                 <span>JS host</span>
               </label>

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -2625,13 +2625,13 @@
 
           // Mode switch (only shown when standalone data is available).
           const conformanceHost = el("div");
-          let activeMode = "host";
+          let activeMode = standaloneView && localStorage.getItem("t262-mode") === "standalone" ? "standalone" : "host";
           const renderActive = () => {
             conformanceHost.textContent = "";
             const view = activeMode === "standalone" && standaloneView ? standaloneView : hostView;
             renderConformance(view, conformanceHost, conformanceRuns);
           };
-          if (false) {
+          if (standaloneView) {
             const modeSwitch = el("div", { className: "mode-switch" });
             const mkBtn = (mode, main, sub) => {
               const b = el(


### PR DESCRIPTION
## Summary
- Reverts 1c31c7ec4 ("show host-mode conformance only on landing + report pages") per project-lead request:
  - **Landing page** (`website/index.html`): removes the inline `display: none` from the "JS host" scope checkbox next to the conformance donut. The checkbox and all its listeners were deliberately left wired when it was hidden, so unhiding restores full host/standalone donut switching.
  - **Report page** (`website/public/benchmarks/report.html`): restores the Host/Standalone mode-switch (`if (standaloneView)`) and the localStorage-persisted `t262-mode` selection instead of hard-locking to host mode.

## Test plan
- [x] Diff is an exact mirror-revert of 1c31c7ec4 (2 files, 3 insertions, 3 deletions)
- [x] Confirmed `hostToggle` listeners still present at `website/index.html:4779` / `:5406` (wiring never removed)
- [ ] Visual check on js2.loopdive.com after deploy: toggle visible next to donut, report page shows Host/Standalone switch when standalone data is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)