### PR TITLE
docs(#3029/#3030): target architecture — backend contract + serializable IR interchange spec

### DIFF
--- a/docs/architecture/codegen-axes.md
+++ b/docs/architecture/codegen-axes.md
@@ -208,6 +208,13 @@ fallback budget (`pnpm run check:ir-fallbacks`).
 
 ## See also
 
+- [`target-architecture.md`](target-architecture.md) — the **end-state
+  module architecture** (layer stack, the five-part backend contract a new
+  backend — MLIR or others — would implement, reviewability rules with CI
+  ratchets, migration map) and the serializable IR interchange contract for
+  external consumers. Umbrella issues #3029/#3030. This doc (codegen-axes)
+  stays authoritative for "which axis is my change on"; that one answers
+  "where does the code end up".
 - `plan/log/ir-adoption.md` — table of AST node kinds × IR status. The
   ratchet's source of truth. Updated when a kind moves between
   `direct-only`, `mixed`, and `ir-owned`.

--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -1,0 +1,173 @@
+# Target architecture: the layered compiler & the backend contract
+
+> The **end-state module architecture** this compiler is migrating toward,
+> ratified 2026-07-04 (architect, Fable). Umbrella issues: **#3029** (clean
+> architecture / backend extensibility) and **#3030** (stable serializable IR
+> contract for external consumers). Companion to
+> [`codegen-axes.md`](codegen-axes.md) (the two-axes doctrine — still
+> authoritative for "which axis is my change on"),
+> [`compiler-quality-review-2026-06.md`](compiler-quality-review-2026-06.md)
+> (the evidence), and
+> [`hybrid-soundness-ir-roadmap.md`](hybrid-soundness-ir-roadmap.md) (the
+> soundness invariant). This doc does not replace them; it gives the _target
+> picture_ they all point at, plus the rules that make the tree reviewable
+> and the contract a new backend implements.
+
+## Non-negotiables carried forward
+
+1. **Two orthogonal axes** (codegen-axes.md): WasmGC vs linear is a backend
+   _choice_ — both stay; direct-AST vs IR front-end is a _migration_ — the
+   direct front-ends are deprecation-tracked remainders (#2855/#2950).
+2. **Hybrid invariant** (hybrid-soundness-ir-roadmap.md): SAFE lowering by
+   default; FAST lowering only behind a discharged proof.
+3. **Dual mode**: no new host import without a standalone fallback.
+4. **Fail-loud**: no silent fallthrough, no lossy fixup (#1858 family).
+
+## The layer stack (dependency direction is strictly downward)
+
+```
+ L1  frontend      parse (TS reuse) · check · ES early errors · single
+                   pipeline driver (#1927) · TypeOracle facade (#1930)
+ L2  ir-build      from-ast · propagate (type lattice) · select (capability
+                   predicate, #2135)
+ L3  ir-mid        backend-NEUTRAL typed SSA (block args, symbolic refs,
+                   explicit effects #2134, explicit dynamic boundaries #2949)
+                   + passes + verifier between every pass
+ ════════════════  IR INTERCHANGE BOUNDARY — serializable, versioned (#3030)
+ L4  legalize      per-backend: legality declaration + declared type-
+                   converter + BackendEmitter intents (#1851/#1852/#2953)
+ L5  backend       gc/ · linear/ · bytecode/ · (mlir/…): layouts, module
+                   assembly, backend-specific runtime glue
+ L6  emit + link   Wasm binary encoding · object files · linker
+ L7  runtime/host  runtime.ts host imports (allowlisted) · WASI shims
+```
+
+Rules the stack implies:
+
+- A layer may import **only from layers below it** (and its own layer).
+  `src/ir/nodes.ts` is a pure leaf. Nothing in `src/ir/` may import from
+  `src/codegen/` (today `integration.ts` imports 8 codegen modules — that
+  inversion is the #3029-S3/S4 extraction). Nothing above L4 may name a
+  Wasm op, a `typeIdx`, or a `funcIdx`.
+- Everything **above** the interchange boundary is backend-agnostic and
+  serializable; everything **below** it is per-backend and never serializes
+  (layout handles, legality sets, the `Instr` union, lowering state).
+- The verifier is the boundary's conformance checker: what it enforces is
+  exactly what an external consumer may rely on (#1924 closes the
+  instruction-level type-rule gap).
+
+## The backend contract (what a NEW backend implements)
+
+A backend — WasmGC, linear, bytecode, or a future MLIR/Cranelift lowering —
+is **five declared parts**, all consulted through interfaces, none through
+imports of another backend's internals:
+
+| #   | Interface                  | Contract                                                                                                                                                                           | Today                                                                                         | Gap                                                                                               |
+| --- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 1   | **TypeConverter**          | `convertType(t: IrType): readonly Slot[]` — IR type → backend value slots (1 slot on GC; the linear dynamic residue is a value+tag pair, #1852 §1)                                 | `lowerIrTypeToValType` free function, GC-shaped                                               | promote onto the trait (#1851 L3)                                                                 |
+| 2   | **BackendLegality**        | `legalOps` / `loweredOps` sets per IrInstr kind; "lowering finished" = _only legal ops remain_, verifier-checked                                                                   | `src/ir/backend/legality.ts` exists                                                           | wire as the post-lower predicate (#1851 L4/L5)                                                    |
+| 3   | **BackendEmitter\<Sink\>** | instruction-level _intents_ (`emitVecGet`, `emitBox`, `emitClosureNew`, …); caller owns operand order; emitter pushes terminal ops onto an opaque `Sink`                           | `src/ir/backend/emitter.ts`, sink hardwired to `Instr[]`; 74 `pushRaw` bypasses in `lower.ts` | generalize `Sink` (bytecode already strains it; MLIR needs a builder sink); close pushRaw (#2953) |
+| 4   | **LayoutResolver**         | layout-handle factory (vec/object/closure/refcell/union/dynamic) + string/boxing helpers; memoization lives here                                                                   | `IrLowerResolver` built in `integration.ts`, hardwired to the WasmGC `CodegenContext`         | extract the context-facing surface into a backend-neutral interface (#2956 item 1, #3029-S3)      |
+| 5   | **ModuleAssembler**        | module-level ownership: function slots, import/export registration, type registration, globals, data, start — with **name-based identity** (no absolute-index baking, #1916/#2710) | implicit in WasmGC `ctx.mod` mutation and `generateLinearModule`                              | declare it (#3029-S4/S5); this is where the late-import index-shift regime (#2043) goes to die    |
+
+**Two ways to add a backend:**
+
+- **In-tree**: implement the five interfaces. An MLIR backend's `Sink` is an
+  MLIR builder; its ModuleAssembler produces an `mlir::ModuleOp`; legality
+  declares which IrInstr kinds map to dialect ops vs need legalization
+  rewrites. The IR's block-argument SSA maps 1:1 onto MLIR regions/block
+  arguments — no Φ translation needed (this is why block args were chosen;
+  see compiler-design-lessons.md §2).
+- **Out-of-tree**: consume the **serialized IR** (#3030) — no TypeScript
+  required, no in-repo code. This is the recommended path for MLIR-class
+  experiments and for engines (e.g. SpiderMonkey) deriving types
+  ahead-of-time from our verified type annotations.
+
+## Target directory layout (migration map)
+
+Neutral naming resolves the #1860 asymmetry ("codegen/" reads as the unmarked
+default); the moves are mechanical `git mv` waves once the interfaces exist.
+
+| Today                                                                                                                   | Target                                                                                                                          | Vehicle           |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `src/checker/`, `src/compiler/`, `src/compiler.ts`, `src/ts-api.ts`, `src/shape-inference.ts`, `src/import-resolver.ts` | `src/frontend/` (one pipeline driver, #1927; TypeOracle, #1930)                                                                 | #3029-S6          |
+| `src/ir/`                                                                                                               | `src/ir/` (unchanged home; `nodes.ts`/`verify.ts`/`effects.ts` become the #3030 contract surface)                               | #3030             |
+| `src/ir/backend/`                                                                                                       | `src/backend/contract/` (the five interfaces + conformance tests)                                                               | #3029-S1/S6       |
+| `src/codegen/`                                                                                                          | WasmGC lowering knowledge → `src/backend/gc/`; its _front-end_ role is deleted per-kind (ratchet #2855, flip #2950) — not moved | #2855/#2950/#2953 |
+| `src/codegen-linear/`                                                                                                   | `src/backend/linear/`, consuming IR via the contract                                                                            | #2956             |
+| `src/ir/backend/bytecode-*.ts`                                                                                          | `src/backend/bytecode/`                                                                                                         | #3029-S6          |
+| `src/emit/`, `src/link/`                                                                                                | unchanged (already clean layers)                                                                                                | —                 |
+| `src/runtime*.ts`                                                                                                       | `src/runtime/` (decomposed per #1934; versioned ABI #1932)                                                                      | existing issues   |
+
+**What is NOT proposed:** no rewrite, no big-bang rename before the
+interfaces exist, no third front-end, no in-repo MLIR backend commitment
+(feasibility memo first, #3029-S9).
+
+## "Reviewable", concretely (rules + enforcement)
+
+Every rule has a CI mechanism, following the project's ratchet pattern —
+rules without enforcement decay.
+
+| Rule           | Statement                                                                                                                                              | Enforcement                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| **R-SIZE**     | New files ≤ 1,500 lines; existing over-limit files are a frozen baseline that may only shrink                                                          | `scripts/file-size-baseline.json` ratchet (like `ir-fallback-baseline.json`), in `quality` |
+| **R-DEP**      | Layer imports point downward only; `ir/nodes.ts` stays a value-import-free leaf; `src/ir/` never imports `src/codegen/` (after #3029-S3)               | import-graph check script in `quality` (like `check:issue-ids`)                            |
+| **R-DISPATCH** | No new dispatch chain > 20 arms; use table-driven registries (the #742 pattern: `Map<key, handler>` where a handler returns `undefined` = not-my-case) | lint heuristic + review checklist                                                          |
+| **R-ESCAPE**   | Every trait bypass carries `// pushraw-ok(#issue)`; count is ratcheted                                                                                 | #2953's count check                                                                        |
+| **R-OWN**      | Every `src/` subdir has a README stating its responsibility + what it may/may not depend on                                                            | #1859; R-DEP script reads the README's declared deps                                       |
+| **R-LOUD**     | Every dispatcher/encoder has a throwing/`never` default arm                                                                                            | #1858 family (#1937/#1939 done-or-tracked)                                                 |
+
+The size threshold is deliberately generous (the field's "understood in
+isolation" bar is 1–2k); the point is the _ratchet_, not the number.
+
+## The IR interchange contract (summary — #3030 is normative)
+
+What an external consumer (other engine, out-of-tree backend, analysis tool)
+may rely on, once #3030 lands:
+
+- **Format**: canonical JSON, one document per module, `irVersion` field,
+  deterministic serialization; published JSON Schema. Binary encoding is an
+  explicit v2 non-goal.
+- **Guarantees**: typed block-argument SSA; **symbolic names only** (no
+  func/global/type indices); per-instruction `resultType` that the verifier
+  _re-derives_ (not trusts — #1924); explicit `box`/`unbox`/`tag.test` at
+  every static↔dynamic boundary with `JsTag` partitions (#2949); ordered
+  effect annotations (#2134); alloc-site provenance; source positions.
+- **Honest coverage**: a module-level manifest of which functions are
+  IR-carried vs legacy-compiled, so consumers know exactly what they can
+  analyze. Coverage grows with #2855/#2950/#2949 — the contract does not
+  wait for 100%.
+- **Exclusions**: layout handles, legality sets, the Wasm `Instr` union,
+  anything below L4.
+
+## Sequencing (see the issues for slice detail)
+
+```
+#3029-S1 backend contract v1 (Fable)     #3030-T1 IR contract freeze (Fable)
+        │                                        │
+   S2/S3 pushRaw + LayoutResolver (Opus)    T2 purge typeIdx from IrType (Opus)
+        │                                        │
+   S4 ModuleAssembler design (Fable)        T3 serializer + round-trip (Opus)
+        │                                        │
+   S5 assembler impls (Opus)                T4 verifier type rules #1924 (Opus)
+        │                                        │
+   S6 directory re-layout (Opus) ←──────── T5 schema gate (Opus)
+   S7 CI ratchets (Opus, early, parallel)   T6 example consumer (Opus)
+```
+
+The two Fable slices per track are the **cut-lines** (interface freezes);
+everything else is mechanical movement behind frozen interfaces and is
+Opus-executable with byte-identity / equivalence gates.
+
+## See also
+
+- #3029 / #3030 — the umbrella issues (slice detail, acceptance criteria).
+- [`codegen-axes.md`](codegen-axes.md) — which axis is my change on.
+- [`compiler-quality-review-2026-06.md`](compiler-quality-review-2026-06.md)
+  — the June 2026 evidence base (#1916–#1950).
+- [`compiler-design-lessons.md`](compiler-design-lessons.md) — the field's
+  patterns (R1 verifier discipline, R4 legalization, R5 value rep).
+- #1851/#1852 (ratified legalization + value-rep specs), #2953 (pushRaw),
+  #2956 (linear-consumes-IR), #2949 (IrType.dynamic), #2950 (IR-first flip),
+  #2855 (fallback ratchet), #742 (calls decomposition), #1916 (symbolic
+  function refs), #1930 (TypeOracle), #1927 (one pipeline driver).

--- a/plan/issues/3029-clean-compiler-architecture-umbrella.md
+++ b/plan/issues/3029-clean-compiler-architecture-umbrella.md
@@ -1,0 +1,130 @@
+---
+id: 3029
+title: "Clean compiler architecture umbrella: layered module map, five-part backend contract, reviewability ratchets"
+status: ready
+sprint: current
+created: 2026-07-04
+updated: 2026-07-04
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: fable
+task_type: architecture
+area: ir, codegen, codegen-linear, compiler
+language_feature: compiler-internals
+goal: maintainability
+related: [3030, 742, 1851, 1852, 1916, 1927, 1930, 1859, 1860, 2043, 2710, 2855, 2949, 2950, 2953, 2956]
+origin: "2026-07-04 user directive: refactor into a clean architecture humans can review/extend, open to new backends (MLIR or others)"
+---
+
+# #3029 — Refactor into a reviewable, extensible, backend-open architecture
+
+**Normative target picture:**
+[`docs/architecture/target-architecture.md`](../../docs/architecture/target-architecture.md)
+(written with this issue). This umbrella tracks the sequenced slices; each
+slice PRs independently. Sibling: **#3030** (the serializable IR contract —
+the interchange boundary this architecture is layered around).
+
+## Problem
+
+The compiler ships 73.9% test262 but has accumulated organically:
+
+- `compileCallExpression` is ~9.1k lines with ~125 string-matched dispatch
+  arms (#742); `src/codegen/index.ts` is 15.9k lines. Review cost and
+  merge-conflict rate scale with these files, not with the change.
+- The `BackendEmitter` trait exists (#1713/#1714) but 74 `pushRaw` sites in
+  `src/ir/lower.ts` bypass it (#2953), its output sink is hardwired to the
+  Wasm `Instr[]` shape, and there is **no declared contract at all** for the
+  module-level half of a backend (function slots, imports, type
+  registration) — that lives as WasmGC `ctx.mod` mutation. A new backend
+  (MLIR, Cranelift, a different Wasm strategy) today has no interface to
+  implement; it would have to be a fourth hand-rolled path.
+- Layer boundaries exist in the docs but not in the import graph:
+  `src/ir/integration.ts` imports 8 `src/codegen/` modules, so the
+  "backend-neutral" middle-end is compile-time coupled to one backend.
+- "Reviewable" has no enforcement: no file-size ceiling, no
+  dependency-direction check, dispatch chains keep growing.
+
+The June 2026 quality review (B− overall, C− codegen core) and the two-axes
+doctrine already diagnose all of this; what has been missing is the **target
+module architecture** and the ordered cut-lines to get there. That is this
+issue.
+
+## Target (summary — the doc is normative)
+
+1. **Layer stack** L1 frontend → L2 ir-build → L3 backend-neutral IR (the
+   serializable waist, #3030) → L4 legalization → L5 backends → L6 emit/link
+   → L7 runtime. Imports point strictly downward, CI-checked.
+2. **Five-part backend contract** — a new backend implements exactly:
+   `TypeConverter` (#1851 L3), `BackendLegality` (#1851 L4),
+   `BackendEmitter<Sink>` (sink generalized off `Instr[]`),
+   `LayoutResolver` (extracted from `integration.ts`, #2956 item 1), and
+   `ModuleAssembler` (new — name-based module assembly, no absolute-index
+   baking; converges with #1916/#2710/#2043).
+3. **Out-of-tree backends are first-class** via the serialized IR (#3030) —
+   the recommended route for MLIR-class consumers.
+4. **Reviewability rules with ratchets**: R-SIZE (file-size baseline,
+   shrink-only), R-DEP (import-direction check), R-DISPATCH (table-driven
+   registries), R-ESCAPE (pushraw-ok tags, #2953), R-OWN (subdir README
+   contracts, #1859), R-LOUD (#1858).
+5. **Neutral directory layout**: `src/frontend/`, `src/ir/`,
+   `src/backend/{contract,gc,linear,bytecode}/`, `src/emit/`, `src/link/`,
+   `src/runtime/` (resolves #1860).
+
+## Slices
+
+Tier ruling (user, 2026-07-04): **structural cut-lines = Fable-required**
+(interface freezes, contract definitions, index-identity design);
+**mechanical waves = Opus-executable** (file splits, moving code behind
+frozen interfaces, call-site migration), each gated by byte-identity /
+equivalence / full CI.
+
+| Slice                                        | Tier      | Size               | What                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Depends on                                                    |
+| -------------------------------------------- | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| **S1 — Backend contract v1**                 | **Fable** | M                  | Freeze the five interfaces as code: `src/ir/backend/contract.ts` (or split files) declaring `TypeConverter`, `BackendLegality` (promote `legality.ts`), `BackendEmitter<Sink>` with the sink made a type parameter (bytecode's `number[]` sink is the existing proof it must generalize; an MLIR builder is the future one), `LayoutResolver`, `ModuleAssembler` (declaration only — implementation is S4/S5). Includes the contract README (what each part owns, operand-order rules, memoization ownership) and a conformance test skeleton per interface. Byte-inert. | —                                                             |
+| **S2 — pushRaw families behind the trait**   | Opus      | L                  | Finish #2953's remaining families (unions/boxing, closures, coercions/null, funcref, Promise-or-declared-deferred) + its count ratchet. Already sliced and in-progress there — this umbrella just sequences it.                                                                                                                                                                                                                                                                                                                                                          | S1 (trait surface)                                            |
+| **S3 — LayoutResolver extraction**           | Opus      | M                  | Move `integration.ts`'s resolver construction behind the S1 interface: the context-facing surface (funcMap/typeIdx lookup, slot patching, import registration) becomes an interface the WasmGC context implements. Kills the `ir → codegen` import direction (then flip R-DEP to enforcing for `src/ir/`). Byte-identity gate. This is also #2956's prerequisite item 1 — coordinate; do it once, here.                                                                                                                                                                  | S1                                                            |
+| **S4 — ModuleAssembler design**              | **Fable** | M                  | The one genuinely dangerous cut: who owns function slots, import/export/type registration, and index identity per backend. Must be designed against the live index-shift regime (`addUnionImports`, `late-imports.ts`, ≥7 historical regressions) and the in-flight symbolic-func-refs direction (#1916) + late-bound indices (#2710) + #2043 — the assembler is where those converge instead of three coexisting relocation regimes. Deliverable: ratified spec section here + the interface body in contract.ts.                                                       | S1; read #1916/#2710 state first                              |
+| **S5 — Assembler implementations**           | Opus      | M–L                | WasmGC `ModuleAssembler` implementing S4 over the existing `ctx.mod` (adapter first, migration second); linear twin over `generateLinearModule`'s module state. Byte-identity + full CI per step.                                                                                                                                                                                                                                                                                                                                                                        | S4                                                            |
+| **S6 — Directory re-layout + READMEs**       | Opus      | M                  | `git mv` waves per the migration map in the target doc (+ `src/backend/{gc,linear,bytecode}` naming, #1860) + per-subdir contract READMEs (#1859). Pure mechanics but high conflict surface: schedule in a quiet merge-queue window, one directory per PR, coordinate with the lead so no in-flight branch is stranded.                                                                                                                                                                                                                                                  | S1–S3 landed (so the moved code is already behind interfaces) |
+| **S7 — CI reviewability ratchets**           | Opus      | S–M                | `scripts/check-file-sizes.mjs` (baseline JSON, shrink-only, like ir-fallback-baseline) + `scripts/check-layer-imports.mjs` (R-DEP; reads per-subdir README declared deps) wired into `quality`. Land EARLY — it locks the rules before the waves. R-DEP starts warn-only for known violations (the baseline lists them), enforcing per-directory as S3/S6 clear them.                                                                                                                                                                                                    | rules in the doc (done)                                       |
+| **S8 — calls.ts decomposition continuation** | Opus      | L (many small PRs) | #742 under the new rules: keep extracting self-contained guard/dispatch blocks with the WAT-hash oracle, then the table-driven callee registry. Counts against the R-SIZE baseline (each PR shrinks it).                                                                                                                                                                                                                                                                                                                                                                 | S7 (ratchet banks the progress)                               |
+| **S9 — MLIR feasibility memo**               | **Fable** | S                  | One-pager: map IR (block-arg SSA, symbolic refs, effects) onto an MLIR dialect; decide in-tree emitter vs out-of-tree consumer of #3030's serialized IR (expected answer: out-of-tree first). Explicitly a memo, not a commitment.                                                                                                                                                                                                                                                                                                                                       | #3030 T1–T3                                                   |
+
+Sequencing: S1 → {S2, S3} → S4 → S5 → S6; S7 immediately (parallel); S8
+continuous; S9 after #3030's serializer exists.
+
+## Acceptance criteria (umbrella)
+
+- [ ] `docs/architecture/target-architecture.md` merged and linked from
+      `codegen-axes.md` (this PR).
+- [ ] S1 contract merged; the three existing emitters (`WasmGcEmitter`,
+      `LinearEmitter`, `BytecodeEmitter`) type-check against
+      `BackendEmitter<Sink>` with their own sink types.
+- [ ] `src/ir/` has zero imports from `src/codegen/` (S3), enforced by R-DEP.
+- [ ] `ModuleAssembler` spec ratified (S4) and implemented for WasmGC +
+      linear (S5) with no test262 regression.
+- [ ] R-SIZE and R-DEP checks live in `quality` with committed baselines
+      that only shrink (S7).
+- [ ] Directory layout matches the migration map (S6); every `src/` subdir
+      has a contract README.
+- [ ] A design-only "how to add a backend" section exists (target doc) whose
+      five interfaces are all real code — verified by the conformance test
+      skeleton compiling against a stub backend.
+
+## Risks
+
+- **Index identity (S4/S5)** is the compiler's #1 historical regression
+  class (≥7 numbered regressions from absolute-index baking). That is why
+  S4 is Fable-tier and why S5 lands as adapter-first with byte-identity
+  gates, never a rewrite.
+- **Directory moves (S6)** conflict with every in-flight branch. One
+  directory per PR, lead-scheduled, `git mv` only (history follows), no
+  logic changes in move PRs.
+- **Contract freeze too early**: S1 freezes _shape_, not completeness —
+  methods may be added (additive) as #2953/#2956 discover needs; what S1
+  forbids is new bypasses around the seam.
+- **Duplication with in-flight issues**: #2953 (S2), #2956 (S3 overlap),
+  #742 (S8) keep their own issue files and owners; this umbrella sequences
+  them and must not double-dispatch. Check assignees before claiming.

--- a/plan/issues/3030-ir-interchange-contract.md
+++ b/plan/issues/3030-ir-interchange-contract.md
@@ -1,0 +1,137 @@
+---
+id: 3030
+title: "Stable serializable IR contract (interchange v1): versioned canonical JSON + schema, verified types, external-consumer ready"
+status: ready
+sprint: current
+created: 2026-07-04
+updated: 2026-07-04
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: fable
+task_type: architecture
+area: ir
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+related: [3029, 1924, 1926, 2134, 2949, 2952, 1852, 2956]
+origin: "2026-07-04 user directive: make the IR standalone-suitable for other engines (e.g. SpiderMonkey deriving types statically AOT from our IR)"
+---
+
+# #3030 — the IR as a product: a contract other engines can consume
+
+**Normative target picture:**
+[`docs/architecture/target-architecture.md`](../../docs/architecture/target-architecture.md)
+(the interchange boundary between L3 and L4). Sibling umbrella: #3029.
+
+## Problem
+
+The typed IR (`src/ir/`) is an internal data structure: it lives only in
+memory, its invariants live in code comments, `IrType`'s leaf still embeds
+module-relative backend data (`{kind:"val", val:{kind:"ref", typeIdx}}` —
+the #1926 residue), and the verifier does not re-derive per-instruction
+result types (#1924), so `resultType` is a claim, not a guarantee.
+
+The user's directive: the IR should be consumable by **other engines** —
+the concrete example being SpiderMonkey (or any JS engine / analysis tool /
+out-of-tree backend) reading our compiler's output to derive types
+**statically, ahead of time**, instead of warming up inline caches at
+runtime. Our IR already contains exactly what such a consumer wants: typed
+block-argument SSA, symbolic names, explicit `box`/`unbox`/`tag.test` at
+every static↔dynamic boundary with `JsTag` partitions (#2949), ordered
+effects (#2134), alloc-site provenance. What's missing is a **stable,
+serializable, documented, versioned contract** — the difference between a
+data structure and a product.
+
+This also gives #3029 its cheapest backend-extension path: an out-of-tree
+backend (MLIR etc.) consumes the serialized IR without touching this repo.
+
+## Decisions (ratified here, Fable 2026-07-04)
+
+- **D1 — Format: canonical JSON.** One JSON document per module, top-level
+  `irVersion`, deterministic serialization (stable key order; object-shape
+  fields are already name-sorted). Rationale: debuggable, diffable,
+  schema-checkable, universally parseable — the right v1 for a contract
+  whose first consumers are analysis tools. A binary encoding is an
+  explicit **v2 non-goal** (revisit only if size measured as a problem;
+  JSON gzips well and modules are per-file).
+- **D2 — Versioning:** `IR_FORMAT_VERSION = "1.0"` exported from the
+  contract module. Additive changes (new node kinds, new optional fields)
+  bump minor; breaking changes bump major. All enum tables (`JsTag`,
+  `IrBinop`/`IrUnop`, effect kinds, type kinds) are **append-only,
+  frozen-order** (the #1852 linear-tag-enum discipline). A CI schema
+  snapshot fails any PR that changes the serialized shape without a
+  version bump.
+- **D3 — Guarantees (what a consumer may rely on):**
+  1. Typed **block-argument SSA**; the entry block's args are the function
+     params; single definition, use-after-def, one terminator per block.
+  2. **Symbolic names only** — no funcIdx/globalIdx/typeIdx anywhere
+     (verifier-enforced today; D5 closes the IrType leak).
+  3. Per-instruction `resultType` that the verifier **re-derives** from
+     operand types per the T1 rule tables (#1924) — types a consumer can
+     trust, not author claims.
+  4. **Explicit dynamic boundaries**: a value is static-typed or `dynamic`;
+     every crossing is a serialized `box`/`unbox`/`tag.test` node carrying
+     its `JsTag` partition (#2949 R1–R6). This is the AOT-type-derivation
+     payload: an engine reads exactly where dynamism enters and what
+     partition proofs guard each unbox.
+  5. **Ordered effects** (#2134) and alloc-site provenance (ADR-0013).
+  6. Source positions per instruction (file/line/col).
+  7. **Honest coverage manifest**: the module header lists every function
+     with `carrier: "ir" | "legacy"` — consumers know exactly which bodies
+     the contract covers. The contract ships at today's partial coverage
+     and grows with #2855/#2950/#2949; it does NOT wait for 100%.
+- **D4 — Exclusions (never serialized):** layout handles, `BackendLegality`
+  sets, the Wasm `Instr` union, resolver/lowering state, anything below the
+  L4 legalization line. Consumers must not see a WasmGC struct index or a
+  linear memory offset.
+- **D5 — Type story:** the serializable `IrType` must not carry
+  module-relative indices. `val` leaves are the closed scalar set (i32
+  (+boolean/symbol brands), i64 (+bigint brand), f32, f64, v128, i8, i16,
+  funcref, externref, eqref, anyref); `ref`/`ref_null` leaves serialize as
+  **symbolic type names** (`IrTypeRef`), resolved to indices only at
+  lowering. Brands serialize explicitly.
+
+## Slices
+
+Tier ruling: contract freeze = **Fable**; implementation behind the frozen
+contract = **Opus**.
+
+| Slice                                              | Tier      | Size | What                                                                                                                                                                                                                                                                                                                                                                                                         | Depends on                                                    |
+| -------------------------------------------------- | --------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| **T1 — Contract freeze**                           | **Fable** | M    | Normative `docs/ir/ir-contract.md`: node-kind inventory with per-instruction operand/result **type rule tables** (written once, consumed twice: by the doc and by T4's verifier rules), effect kinds, name-namespace ownership (func/global/type — same namespaces as `ctx.funcMap`/`globalMap`/`typeNames`), D1–D5 as normative text, the coverage manifest shape, and the versioning policy. Freezes v1.0. | #2949 slice 1–2 landed (they are — dynamic is in the lattice) |
+| **T2 — Purge module-relative indices from IrType** | Opus      | M    | Execute the #1926 residue per D5: `ref`/`ref_null` **inside IrType** become symbolic (`IrTypeRef` name), with the resolver mapping name→typeIdx at the lowering boundary. Mechanical but wide (every `asVal` consumer); byte-identity gate on the 39-hash corpus + full CI.                                                                                                                                  | T1                                                            |
+| **T3 — Serializer + deserializer + CLI**           | Opus      | M    | `src/ir/serialize.ts`: `serializeIrModule` / `deserializeIrModule`; `--emit-ir <file>` CLI flag (and `emitIr` compile option) writing the module JSON incl. coverage manifest. Round-trip property test: build → serialize → deserialize → **verify** → re-serialize **byte-identical**, over the playground corpus + equivalence suite shapes.                                                              | T1, T2                                                        |
+| **T4 — Verifier as conformance checker**           | Opus      | M    | Implement T1's per-instruction type rules in `verify.ts` (#1924 — operand types re-derived, `resultType` checked, branch args type-checked not just arity). Runs on deserialized modules too (same function), making the verifier the consumer-side conformance tool. Hard-fail lane stays on.                                                                                                               | T1                                                            |
+| **T5 — Schema + CI gate**                          | Opus      | S    | `docs/ir/ir-module.schema.json` (JSON Schema, generated or hand-maintained + validated in tests); CI snapshot check: serialized-shape change without `IR_FORMAT_VERSION` bump fails `quality`.                                                                                                                                                                                                               | T3                                                            |
+| **T6 — Example external consumer**                 | Opus      | S    | `scripts/ir-type-summary.mjs`: reads a serialized module (JSON only — must not import compiler internals; that's the point) and emits a per-function report: param/return types, dynamic-boundary sites with JsTag partitions, effect summary. This is the SpiderMonkey-style AOT probe and the documentation-by-example for the contract.                                                                   | T3, T5                                                        |
+
+Sequencing: T1 → T2 → T3 → {T4, T5} → T6. T4 can start from T1's tables in
+parallel with T2/T3.
+
+## Acceptance criteria
+
+- [ ] `docs/ir/ir-contract.md` merged (T1): every serialized node kind has
+      operand/result type rules; D1–D5 normative; versioning policy stated.
+- [ ] `IrType` contains no module-relative index (T2); grep-gate in CI.
+- [ ] `compile(..., {emitIr})` / `--emit-ir` produce schema-valid JSON;
+      round-trip is byte-identical and verifier-clean on the corpus (T3).
+- [ ] Verifier re-derives per-instruction types (T4, closes #1924) and
+      accepts every serialized corpus module.
+- [ ] Schema snapshot gate live (T5); `IR_FORMAT_VERSION` exported.
+- [ ] `ir-type-summary.mjs` produces a correct report for a dynamic-boundary
+      example **without importing any compiler module** (T6).
+
+## Risks
+
+- **Freezing too much too early.** v1 freezes the _shape and guarantees_,
+  not the node inventory — kinds are append-only, and the coverage manifest
+  makes partial coverage honest instead of a compatibility lie.
+- **T2's blast radius**: IrType is touched by from-ast/propagate/select/
+  lower/verify/passes. Pure-mechanical rule: name in, index out at the
+  resolver boundary only; byte-identity is the oracle.
+- **`resultType` trust gap until T4**: the contract doc must mark guarantee
+  D3.3 as "effective from verifier ≥ T4" so no consumer builds on unverified
+  types in the interim.
+- **Drift between doc and code**: T5's schema snapshot + T4's shared rule
+  tables are the anti-drift mechanisms; the doc alone would rot.


### PR DESCRIPTION
## Summary

Docs-only PR delivering the clean-architecture refactoring spec (user directive 2026-07-04), grounded in and unifying the existing material (codegen-axes, June 2026 quality review, hybrid-soundness roadmap, #1851/#1852/#2953/#2956/#2949/#2950) rather than restarting.

- **`docs/architecture/target-architecture.md`** (new, normative): the end-state layer stack (frontend → ir-build → backend-neutral IR waist → legalization → backends → emit/link → runtime) with strictly-downward CI-checked imports; the **five-part backend contract** a new backend (MLIR, Cranelift, …) implements — TypeConverter, BackendLegality, BackendEmitter\<Sink\>, LayoutResolver, **ModuleAssembler** (the previously-undeclared module-level half); concrete reviewability rules with ratchet enforcement (R-SIZE/R-DEP/R-DISPATCH/R-ESCAPE/R-OWN/R-LOUD); migration map from today's layout (resolves #1860 naming via `src/backend/{gc,linear,bytecode}`).
- **#3029** (new umbrella issue): 9 sequenced slices, each marked **Fable-required vs Opus-executable** per the ruling — structural cut-lines (S1 backend contract freeze, S4 ModuleAssembler/index-identity design, S9 MLIR memo) are Fable; mechanical waves (pushRaw closure, LayoutResolver extraction, directory moves, CI ratchets, #742 continuation) are Opus with byte-identity gates.
- **#3030** (new issue): the IR as a product — **versioned canonical JSON + published JSON Schema** interchange format; guarantees = verified per-instruction types (#1924), symbolic names only (finishing the #1926 typeIdx residue), explicit dynamic boundaries with JsTag partitions (#2949), ordered effects (#2134), honest per-function coverage manifest. 6 slices (T1 contract freeze = Fable; T2–T6 = Opus), ending in an external-consumer example (SpiderMonkey-style AOT type derivation reading the JSON without importing compiler internals).
- `codegen-axes.md`: See-also pointer (that doc stays authoritative for "which axis is my change on").

Issue ids #3029/#3030 allocated via `claim-issue.mjs --allocate`.

## Test plan

- Docs + issue files only; no source changes. Prettier-formatted; `quality` gate validates issue-id uniqueness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8