### PR TITLE
fix(deploy): refresh served standalone test262 report from baselines repo

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -67,6 +67,15 @@ jobs:
               mkdir -p .test262-cache
               cp /tmp/js2wasm-baselines/test262-standalone-current.jsonl .test262-cache/test262-standalone-current.jsonl
             fi
+            # Refresh the SERVED standalone report JSON, mirroring the host
+            # copy above. build-pages.js prefers the website/public copy, so
+            # without this the report page's Host/Standalone switch reads the
+            # stale committed test262-standalone-report.json (old corpus, no
+            # host_free field) while the host donut shows fresh numbers.
+            if [ -f /tmp/js2wasm-baselines/test262-standalone-current.json ]; then
+              cp /tmp/js2wasm-baselines/test262-standalone-current.json website/public/benchmarks/results/test262-standalone-report.json
+              cp /tmp/js2wasm-baselines/test262-standalone-current.json benchmarks/results/test262-standalone-report.json
+            fi
             [ -f /tmp/js2wasm-baselines/runs/index.json ] && \
               cp /tmp/js2wasm-baselines/runs/index.json benchmarks/results/runs/index.json
             echo "Fetched baseline data from js2wasm-baselines."


### PR DESCRIPTION
## Summary
- The Pages deploy fetch step refreshed the **host** report (`test262-current.json` → served `test262-report.json`) and the standalone **JSONL** (for edition regeneration), but never the standalone report **JSON**. `build-pages.js` therefore fell back to the stale committed `test262-standalone-report.json` (sha e6eedd68 — old 43,132-test corpus, no `host_free` field).
- With the report page's Host/Standalone mode-switch re-enabled in #2614, that stale file became user-visible: the standalone view showed 16,298/43,132 instead of the current baseline (fresh baselines-repo data: 24,954 pass / 18,427 host-free / 43,106 as of today).
- Fix mirrors the host copy: `test262-standalone-current.json` → `website/public/benchmarks/results/test262-standalone-report.json` (+ `benchmarks/results/` copy), guarded by the same existence check.

## Test plan
- [x] Verified fresh `test262-standalone-current.json` exists in `loopdive/js2wasm-baselines` (curl, generated 2026-07-03T22:51)
- [x] Verified `build-pages.js` source order prefers the `website/public` copy this step now refreshes
- [ ] After merge + deploy: `curl -s https://js2.loopdive.com/benchmarks/results/test262-standalone-report.json` shows current baseline_sha and `host_free_pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)