### PR TITLE
fix(deploy): materialize test262-standalone-current.json in sparse baselines clone

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -43,11 +43,14 @@ jobs:
           # Sparse + blob-filtered clone (#3028): the baselines repo carries a
           # large runs/ tree (~500 MB cap of per-SHA run JSONLs), so a plain
           # --depth=1 clone downloaded every tip blob and took 3-14 MINUTES.
-          # Materializing only the four files this step reads takes ~2-5s
+          # Materializing only the files this step reads takes ~2-5s
           # (same pattern as test262-sharded.yml's catastrophic-guard clone).
+          # NOTE: every file consumed by the copy blocks below MUST be listed
+          # here — a missing entry makes its `[ -f ]` guard silently skip
+          # (that's how the served standalone report stayed stale after #2619).
           { git clone --depth=1 --filter=blob:none --no-checkout https://github.com/loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines \
             && git -C /tmp/js2wasm-baselines sparse-checkout set --no-cone \
-              /test262-current.json /test262-current.jsonl /test262-standalone-current.jsonl /runs/index.json \
+              /test262-current.json /test262-current.jsonl /test262-standalone-current.json /test262-standalone-current.jsonl /runs/index.json \
             && git -C /tmp/js2wasm-baselines checkout main; } 2>/dev/null || true
           if [ -f /tmp/js2wasm-baselines/test262-current.json ]; then
             mkdir -p website/public/benchmarks/results benchmarks/results/runs


### PR DESCRIPTION
## Summary
- Follow-up to #2619, which added the copy of `test262-standalone-current.json` into the served standalone report path — but the concurrently-merged #3028 sparse-checkout narrowed the baselines clone to an explicit file list that does **not** include that json. The `[ -f ]` guard therefore silently skipped, and the post-#2619 deploy still served the stale standalone report (verified: served file shows baseline_sha e6eedd68 / old 43,132 corpus while the baselines repo has fresh fe252d7 data).
- Adds `/test262-standalone-current.json` to the sparse-checkout set and documents the coupling: every file consumed by the copy blocks must be listed, or its guard silently no-ops.

## Test plan
- [x] Confirmed root cause from the post-#2619 deploy run: workflow contained the copy block, but the sparse list never materialized the file
- [ ] After merge + deploy: `curl -s https://js2.loopdive.com/benchmarks/results/test262-standalone-report.json` shows current baseline_sha, total 43,106, and a `host_free_pass` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)