### PR TITLE
feat(#2952): slice 2 — unlabeled break/continue via br.label + lowering-time depth resolver

### DIFF
--- a/plan/issues/2952-ir-multi-exit-control-flow.md
+++ b/plan/issues/2952-ir-multi-exit-control-flow.md
@@ -2,10 +2,10 @@
 id: 2952
 title: "IR multi-exit control flow: labeled break/continue, switch (br_table), do-while, for-in adoption"
 status: in-progress
-assignee: ttraenkler/sr-multiexit
+assignee: ttraenkler/fable-2952s2
 sprint: current
 created: 2026-07-02
-updated: 2026-07-03
+updated: 2026-07-04
 priority: medium
 horizon: l
 feasibility: hard

--- a/plan/issues/2952-ir-multi-exit-control-flow.md
+++ b/plan/issues/2952-ir-multi-exit-control-flow.md
@@ -315,9 +315,19 @@ frames already use. That plus `labeled.block` for non-loop labels and
 - Loop-heavy blast radius: `issue-1280` + `issue-2136` + `issue-1169n` +
   `issue-1169h` (try) + `issue-1182`/`issue-1183` (for-of iter/string) +
   `issue-1169e-bridge` — 108/108.
-- `npx tsc --noEmit` clean; `pnpm run check:ir-fallbacks` OK after bank.
+- `npx tsc --noEmit` clean (pre- and post-merge of origin/main);
+  `pnpm run check:ir-fallbacks` OK after bank.
 - test262 loop-statement dirs (break/continue/while/do-while/for/for-of,
-  1254 files): compile+run outcome diff main↔branch recorded below.
+  **1254 files**): compile+run outcome diff main↔branch = **ZERO lines** —
+  every file's CE/OK/EXN outcome identical, so the newly-IR-claimed loop
+  shapes are behavior-equivalent to legacy across the whole surface.
+- Standalone target (`target: "standalone"`): break / continue-with-update /
+  try-finally-break probes all pass (core-Wasm `br` is backend-identical).
+- Wider equivalence sweep (11 loop-relevant suites, 158 tests): 87 pass;
+  all 71 fails verified PRE-EXISTING on current origin/main (70 × the
+  `__unbox_number` harness import-stub gap in tests/ir-*-equivalence — the
+  same gap slice 1 documented; 1 × arguments-capture `expected 30 to be
+  33` in arguments-nested-and-loops) — reproduced identically on main.
 
 ## Test Results (slice 1)
 

--- a/plan/issues/2952-ir-multi-exit-control-flow.md
+++ b/plan/issues/2952-ir-multi-exit-control-flow.md
@@ -219,6 +219,106 @@ state is outer-scope slots/locals), so the cond-first walk order is correct
 for both pre-test and post-test loops. Only the lowering emission order
 differs.
 
+## Slice 2 — unlabeled break/continue, implemented (2026-07-04, fable-2952s2)
+
+Full A1+A2+A3 machinery per the Design-A spec above, plus one discovery the
+spec missed: **the loop-body statement grammar had no statement-`if` at all**
+(top-level `if` uses the block-CFG layer, which nested buffers cannot reach),
+so `if (c) break;` — the canonical multi-exit shape — was unclaimable without
+a new void statement-if node. Slice 2 therefore ships TWO instr kinds:
+
+- **`IrInstrBrLabel { label, mode }`** (A2) — buffer-terminating, no stored
+  depth. Verifier rules: label must be bound by an enclosing loop in the same
+  buffer-nesting chain (walk mirrors the lowering ctrlStack), and the instr
+  must be last in its buffer (from-ast stops emitting after break/continue).
+- **`IrInstrIfStmt { cond, then, else }`** — void statement-if; `else` may be
+  empty (encodes as bare `if…end`). Both arms are body-statement buffers.
+
+**A1**: `loopLabel?: IrLabelId` on `while.loop` / `for.loop` / `forof.vec` /
+`forof.iter` / `forof.string`; from-ast always synthesises one per loop
+(`IrFunctionBuilder.freshLoopLabel`) and threads it as `LowerCtx.loopLabel`
+(innermost wins; lifted-closure ctxs are built fresh so it never crosses a
+function boundary).
+
+**A3 (the depth resolver)**: `lower.ts` keeps a `ctrlStack: CtrlFrame[]` —
+one frame per structured Wasm frame the emitter opens (block/loop/if/try are
+each exactly one Wasm label). `resolveBrLabel` scans from the top counting
+frames until it finds `{kind: mode, label}` and emits `br <depth>`. Continue
+targets per loop shape:
+
+- pre-test `while`, `forof.iter` → the `loop` frame itself (br re-runs
+  cond / `__iterator_next`);
+- `for`, do-while, `forof.vec`, `forof.string` → a dedicated body-wrapping
+  `block` that falls into the update / cond / counter-advance — emitted
+  ONLY when `bufferHasBrLabel(body, label, "continue")` (labels are
+  per-function unique, so the deep scan is exact), keeping continue-free
+  loops byte-identical.
+- `forof.iter` break lands exactly at the `__iterator_return` call after
+  the wrapping block — spec-correct IteratorClose (§14.7.5) for free.
+
+**Finally interaction (the reason A is sound)**: a try frame carries its
+`finallyBody` while the try-body buffer is emitted; `resolveBrLabel` inlines
+each crossed finally (innermost first) before the `br`, masking the frame
+during its own inline so a finally never re-runs itself. The catch path's
+obligation is owned by the existing inner-try wrap (its frame carries the
+finally while the catch body emits). `try { break } finally { continue }`
+resolves correctly by construction: the finally's `br` (continue) is emitted
+before the break's `br`, which becomes dead code — ECMA-262 completion
+overriding without any CFG.
+
+**Exhaustiveness** (slice 1 dodged this via postCond; slice 2 could not) —
+every switch extended: `forEachNestedBuffer` / `mapNestedBuffers` /
+`directUses` (nodes.ts), `effectsOf` (br.label = full-barrier control like
+throw — `effectsConflict` only consults heap/slot facets; if.stmt =
+arm-buffer union) + `isSideEffecting` (both — keeps deep use-walks alive in
+DCE), verify.ts `collectUses` + label-env walk, lower.ts `collectIrUses` +
+`-1` use recording + `allocLocalForInstr`, monomorphize `collectUses`,
+inline-small `canInline` (conservative skip) + `renameInstrOperands` (honest
+deep rename), backend legality (linear allow-list — core-Wasm `br`/`if`,
+backend-identical per the #1852/#1527 axis rule; bytecode stays rejected).
+
+**Selector** (`select.ts`): `inLoop` flag threaded through
+`isPhase1BodyStatement` / `isPhase1TryStatement`; loop shape-checkers pass
+`true` for their bodies. New arms: statement-`if` (arms recurse as body
+statements; cond is Phase-1 shape + i32/f64 at lowering — ref/string conds
+demote, same discipline as loop conds per #2136) and unlabeled
+break/continue (labeled → `body-labeled-break-continue`, outside a loop →
+`body-break-continue-outside-loop`). Claims are backed by
+`lowerBreakContinueStatement` + `lowerIfBodyStatement` — parity holds.
+
+**Byte-inertness (measured)**: 13/13 playground examples byte-identical
+(sha256) main↔branch with identical claim sets; 8 already-claimed loop
+shapes (while/for/do/forof/nested/try-in-loop/forof-string) byte-identical.
+Ratchet: `body-shape-rejected` 23→22 but `call-graph-closure` 10→11 — ONE
+function (`joinNums` in js/algorithms.ts) reclassified because the shape
+gate no longer binds on its loop-body `if`; the later call-graph gate does.
+Bytes unchanged (still legacy); baseline banked in this PR.
+
+**Deliberately NOT taken (slice-3 bank, with what slice 2 taught us)**:
+labeled break/continue and switch. Labeled is NOT nearly-free: a labeled
+break crossing an inner `forof.iter` must run that loop's
+`__iterator_return` (the close call sits after the loop's wrapping block, so
+a crossing `br` skips it) — the for-of break frame needs a finally-like
+`iter.return` obligation on its CtrlFrame, exactly the mechanism the try
+frames already use. That plus `labeled.block` for non-loop labels and
+`IrInstrSwitch`/`br_table` are their own slice.
+
+## Test Results (slice 2)
+
+- `tests/issue-2952-slice2.test.ts` — 21/21 (selector claims incl. both
+  negative boundaries; runtime semantics for break/continue across all five
+  loop kinds; continue-target placement incl. the for-update infinite-loop
+  hazard; break/continue across try/finally with exact finally counts;
+  dead-code-after-break; verifier rules via builder-constructed IR).
+- `tests/issue-2952.test.ts` — 6/6 (slice-1 break-rejection test flipped to
+  claim+run per the lifted boundary; labeled-break negative added).
+- Loop-heavy blast radius: `issue-1280` + `issue-2136` + `issue-1169n` +
+  `issue-1169h` (try) + `issue-1182`/`issue-1183` (for-of iter/string) +
+  `issue-1169e-bridge` — 108/108.
+- `npx tsc --noEmit` clean; `pnpm run check:ir-fallbacks` OK after bank.
+- test262 loop-statement dirs (break/continue/while/do-while/for/for-of,
+  1254 files): compile+run outcome diff main↔branch recorded below.
+
 ## Test Results (slice 1)
 
 - `tests/issue-2952.test.ts` — 5/5 pass (selector claim, post-test-once,

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -40,28 +40,28 @@ bucket work #2856–#2859.
 
 ## Statements
 
-| Kind                  | Status      | Notes                                                                                                           | Tracking |
-| --------------------- | ----------- | --------------------------------------------------------------------------------------------------------------- | -------- |
-| `VariableStatement`   | mixed       | Single-binding `let/const/var` works. Destructuring init throws.                                                | #1372    |
-| `ExpressionStatement` | mixed       | Calls / assignments / pre-post `++ --` work. Other shapes throw.                                                | #1131    |
-| `IfStatement`         | ir-owned    | Both arms must be present in tail position; body-position `if` works.                                           | —        |
-| `ReturnStatement`     | ir-owned    | Must have an expression in Phase 1; `return;` (void) added in slice 14.                                         | #1228    |
-| `ForStatement`        | mixed       | Requires a condition; rejects bare `for(;;)`.                                                                   | #1131    |
-| `ForOfStatement`      | mixed       | Destructuring init throws (slice 6 sentinel).                                                                   | #1131    |
-| `WhileStatement`      | ir-owned    | —                                                                                                               | —        |
-| `TryStatement`        | mixed       | Basic try/catch lowered; finally + rethrow paths partial.                                                       | #1131    |
-| `ThrowStatement`      | ir-owned    | —                                                                                                               | —        |
-| `Block`               | ir-owned    | Plain statement lists; scope handling via LowerCtx.                                                             | —        |
-| `SwitchStatement`     | direct-only | No IR handler. Needs `br_table` + block-per-case (Design A, #2952 spec).                                        | #2952    |
-| `BreakStatement`      | direct-only | Labeled / unlabeled break — needs the `br_label` depth resolver (#2952).                                        | #2952    |
-| `ContinueStatement`   | direct-only | Same.                                                                                                           | #2952    |
-| `DoStatement`         | mixed       | Post-test loop claimed (reuses `while.loop` + `postCond`); break/continue bodies demote (shared #2952 blocker). | #2952    |
-| `LabeledStatement`    | direct-only | Needs labeled break/continue CFG support.                                                                       | #2952    |
-| `ForInStatement`      | direct-only | Object iteration host-import based today.                                                                       | #2952    |
-| `ClassDeclaration`    | mixed       | Methods adopted incrementally via #1370 (Phase B). Constructor in Phase C.                                      | #1370    |
-| `ImportDeclaration`   | deferred    | Module-level concern, not function-body.                                                                        | —        |
-| `ExportDeclaration`   | deferred    | Module-level concern.                                                                                           | —        |
-| `ExportAssignment`    | deferred    | Module-level concern.                                                                                           | —        |
+| Kind                  | Status      | Notes                                                                                                                                   | Tracking |
+| --------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `VariableStatement`   | mixed       | Single-binding `let/const/var` works. Destructuring init throws.                                                                        | #1372    |
+| `ExpressionStatement` | mixed       | Calls / assignments / pre-post `++ --` work. Other shapes throw.                                                                        | #1131    |
+| `IfStatement`         | ir-owned    | Tail / early-return via block CFG; statement-`if` inside loop/try body buffers via `if.stmt` (#2952 slice 2).                           | —        |
+| `ReturnStatement`     | ir-owned    | Must have an expression in Phase 1; `return;` (void) added in slice 14.                                                                 | #1228    |
+| `ForStatement`        | mixed       | Requires a condition; rejects bare `for(;;)`.                                                                                           | #1131    |
+| `ForOfStatement`      | mixed       | Destructuring init throws (slice 6 sentinel).                                                                                           | #1131    |
+| `WhileStatement`      | ir-owned    | —                                                                                                                                       | —        |
+| `TryStatement`        | mixed       | Basic try/catch lowered; finally + rethrow paths partial.                                                                               | #1131    |
+| `ThrowStatement`      | ir-owned    | —                                                                                                                                       | —        |
+| `Block`               | ir-owned    | Plain statement lists; scope handling via LowerCtx.                                                                                     | —        |
+| `SwitchStatement`     | direct-only | No IR handler. Needs `br_table` + block-per-case (Design A, #2952 spec).                                                                | #2952    |
+| `BreakStatement`      | mixed       | Unlabeled `break` claimed in all IR loop kinds via `br.label` + lowering-time depth resolver (#2952 slice 2); labeled break is slice 3. | #2952    |
+| `ContinueStatement`   | mixed       | Unlabeled `continue` claimed (dedicated continue-target frame per loop shape); labeled continue is slice 3.                             | #2952    |
+| `DoStatement`         | mixed       | Post-test loop claimed (reuses `while.loop` + `postCond`); unlabeled break/continue bodies claimed since slice 2.                       | #2952    |
+| `LabeledStatement`    | direct-only | Needs labeled break/continue CFG support.                                                                                               | #2952    |
+| `ForInStatement`      | direct-only | Object iteration host-import based today.                                                                                               | #2952    |
+| `ClassDeclaration`    | mixed       | Methods adopted incrementally via #1370 (Phase B). Constructor in Phase C.                                                              | #1370    |
+| `ImportDeclaration`   | deferred    | Module-level concern, not function-body.                                                                                                | —        |
+| `ExportDeclaration`   | deferred    | Module-level concern.                                                                                                                   | —        |
+| `ExportAssignment`    | deferred    | Module-level concern.                                                                                                                   | —        |
 
 ## Expressions
 

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -37,7 +37,12 @@ const SECTIONS = [
     rows: [
       ["`VariableStatement`", "mixed", "Single-binding `let/const/var` works. Destructuring init throws.", "#1372"],
       ["`ExpressionStatement`", "mixed", "Calls / assignments / pre-post `++ --` work. Other shapes throw.", "#1131"],
-      ["`IfStatement`", "ir-owned", "Both arms must be present in tail position; body-position `if` works.", "—"],
+      [
+        "`IfStatement`",
+        "ir-owned",
+        "Tail / early-return via block CFG; statement-`if` inside loop/try body buffers via `if.stmt` (#2952 slice 2).",
+        "—",
+      ],
       [
         "`ReturnStatement`",
         "ir-owned",
@@ -58,15 +63,20 @@ const SECTIONS = [
       ],
       [
         "`BreakStatement`",
-        "direct-only",
-        "Labeled / unlabeled break — needs the `br_label` depth resolver (#2952).",
+        "mixed",
+        "Unlabeled `break` claimed in all IR loop kinds via `br.label` + lowering-time depth resolver (#2952 slice 2); labeled break is slice 3.",
         "#2952",
       ],
-      ["`ContinueStatement`", "direct-only", "Same.", "#2952"],
+      [
+        "`ContinueStatement`",
+        "mixed",
+        "Unlabeled `continue` claimed (dedicated continue-target frame per loop shape); labeled continue is slice 3.",
+        "#2952",
+      ],
       [
         "`DoStatement`",
         "mixed",
-        "Post-test loop claimed (reuses `while.loop` + `postCond`); break/continue bodies demote (shared #2952 blocker).",
+        "Post-test loop claimed (reuses `while.loop` + `postCond`); unlabeled break/continue bodies claimed since slice 2.",
         "#2952",
       ],
       ["`LabeledStatement`", "direct-only", "Needs labeled break/continue CFG support.", "#2952"],

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,8 +1,8 @@
 {
-  "generated": "2026-07-03",
+  "generated": "2026-07-04",
   "unintended": {
-    "body-shape-rejected": 23,
-    "call-graph-closure": 10,
+    "body-shape-rejected": 22,
+    "call-graph-closure": 11,
     "class-method": 5
   },
   "deferred": {

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -111,6 +111,12 @@ function linearInstrError(instr: IrInstr): string | null {
     case "slot.write":
     case "while.loop":
     case "for.loop":
+    // #2952 slice 2 — br.label lowers to a core-Wasm `br` (depth derived by
+    // the shared ctrlStack resolver) and if.stmt to a core `if`/`block`;
+    // both are backend-identical structured control flow like the loop
+    // kinds above (#1852/#1527 axis rule).
+    case "br.label":
+    case "if.stmt":
       return null;
     default:
       return `linear backend does not support IR instruction '${instr.kind}' at the function-lowering boundary`;
@@ -301,6 +307,9 @@ function nestedInstrBuffers(instr: IrInstr): readonly (readonly IrInstr[])[] {
       if (instr.finallyBody) out.push(instr.finallyBody);
       return out;
     }
+    // #2952 slice 2 — statement-level if arms.
+    case "if.stmt":
+      return [instr.then, instr.else];
     default:
       return [];
   }

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -8,6 +8,7 @@
 
 import {
   asBlockId,
+  asLabelId,
   asValueId,
   irVal,
   AllocKind,
@@ -22,6 +23,7 @@ import {
   IrFunction,
   IrGlobalRef,
   IrInstr,
+  IrLabelId,
   IrObjectShape,
   IrParam,
   IrSiteId,
@@ -68,6 +70,10 @@ export class IrFunctionBuilder {
   // index of the `__gen_buffer` Wasm-local. Set when the generator
   // prologue is emitted in from-ast.
   private generatorBufferSlot: number | undefined = undefined;
+  // #2952 slice 2 — per-function loop-label allocator (see IrLabelId in
+  // nodes.ts). Labels identify loop frames for `br.label`; unlabeled
+  // break/continue resolve to the innermost loop's synthesised label.
+  private nextLabelId = 0;
 
   constructor(
     private readonly name: string,
@@ -976,6 +982,8 @@ export class IrFunctionBuilder {
     dataSlot: number;
     elementSlot: number;
     body: readonly IrInstr[];
+    /** #2952 slice 2 — loop identity for `br.label` targeting. */
+    loopLabel?: IrLabelId;
   }): void {
     this.pushInstr({
       kind: "forof.vec",
@@ -987,6 +995,7 @@ export class IrFunctionBuilder {
       dataSlot: args.dataSlot,
       elementSlot: args.elementSlot,
       body: args.body,
+      ...(args.loopLabel !== undefined ? { loopLabel: args.loopLabel } : {}),
       result: null,
       resultType: null,
     });
@@ -1062,6 +1071,8 @@ export class IrFunctionBuilder {
     resultSlot: number;
     elementSlot: number;
     body: readonly IrInstr[];
+    /** #2952 slice 2 — loop identity for `br.label` targeting. */
+    loopLabel?: IrLabelId;
   }): void {
     this.pushInstr({
       kind: "forof.iter",
@@ -1070,6 +1081,7 @@ export class IrFunctionBuilder {
       resultSlot: args.resultSlot,
       elementSlot: args.elementSlot,
       body: args.body,
+      ...(args.loopLabel !== undefined ? { loopLabel: args.loopLabel } : {}),
       result: null,
       resultType: null,
     });
@@ -1091,6 +1103,8 @@ export class IrFunctionBuilder {
     strSlot: number;
     elementSlot: number;
     body: readonly IrInstr[];
+    /** #2952 slice 2 — loop identity for `br.label` targeting. */
+    loopLabel?: IrLabelId;
   }): void {
     this.pushInstr({
       kind: "forof.string",
@@ -1100,6 +1114,7 @@ export class IrFunctionBuilder {
       strSlot: args.strSlot,
       elementSlot: args.elementSlot,
       body: args.body,
+      ...(args.loopLabel !== undefined ? { loopLabel: args.loopLabel } : {}),
       result: null,
       resultType: null,
     });
@@ -1159,6 +1174,8 @@ export class IrFunctionBuilder {
     body: readonly IrInstr[];
     /** #2952 slice 1 — set for `do { body } while (cond)` (post-test loop). */
     postCond?: boolean;
+    /** #2952 slice 2 — loop identity for `br.label` targeting. */
+    loopLabel?: IrLabelId;
   }): void {
     this.pushInstr({
       kind: "while.loop",
@@ -1166,6 +1183,7 @@ export class IrFunctionBuilder {
       condValue: args.condValue,
       body: args.body,
       ...(args.postCond ? { postCond: true } : {}),
+      ...(args.loopLabel !== undefined ? { loopLabel: args.loopLabel } : {}),
       result: null,
       resultType: null,
     });
@@ -1182,6 +1200,8 @@ export class IrFunctionBuilder {
     condValue: IrValueId;
     body: readonly IrInstr[];
     update: readonly IrInstr[];
+    /** #2952 slice 2 — loop identity for `br.label` targeting. */
+    loopLabel?: IrLabelId;
   }): void {
     this.pushInstr({
       kind: "for.loop",
@@ -1189,6 +1209,43 @@ export class IrFunctionBuilder {
       condValue: args.condValue,
       body: args.body,
       update: args.update,
+      ...(args.loopLabel !== undefined ? { loopLabel: args.loopLabel } : {}),
+      result: null,
+      resultType: null,
+    });
+  }
+
+  // --- multi-exit control flow (#2952 slice 2) -----------------------------
+
+  /**
+   * #2952 slice 2 — allocate a fresh per-function loop label. The from-ast
+   * layer calls this once per lowered loop; unlabeled `break` / `continue`
+   * emit `br.label` against the innermost loop's label.
+   */
+  freshLoopLabel(): IrLabelId {
+    return asLabelId(this.nextLabelId++);
+  }
+
+  /**
+   * #2952 slice 2 — emit a `br.label` (unlabeled `break` / `continue`
+   * targeting the loop identified by `label`). Buffer-terminating; the
+   * caller must not emit further instructions into the same buffer.
+   */
+  emitBrLabel(label: IrLabelId, mode: "break" | "continue"): void {
+    this.pushInstr({ kind: "br.label", label, mode, result: null, resultType: null });
+  }
+
+  /**
+   * #2952 slice 2 — emit a statement-level `if (cond) then [else]` inside a
+   * nested buffer. Both arms are pre-collected via `collectBodyInstrs`;
+   * `else` may be an empty array (plain if). Result is void.
+   */
+  emitIfStmt(args: { cond: IrValueId; then: readonly IrInstr[]; else: readonly IrInstr[] }): void {
+    this.pushInstr({
+      kind: "if.stmt",
+      cond: args.cond,
+      then: args.then,
+      else: args.else,
       result: null,
       resultType: null,
     });

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -166,7 +166,12 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
       break;
     // Control effects: throw is a control effect treated as a full heap
     // barrier; await / async completions suspend/complete observably.
+    // #2952 slice 2 — br.label is a pure control transfer (no heap access),
+    // but like throw it must never be re-ordered across OR dropped, and
+    // `effectsConflict` only consults the heap/slot facets, so it carries
+    // the same full-barrier classification.
     case "throw":
+    case "br.label":
     case "await":
     case "async.return":
     case "async.throw":
@@ -232,6 +237,12 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
       if (instr.finallyBody) mergeBuffer(instr.finallyBody);
       break;
     case "if":
+      mergeBuffer(instr.then);
+      mergeBuffer(instr.else);
+      break;
+    // #2952 slice 2 — statement-level if: effects are the union of both
+    // arm buffers (cond is a plain SSA use, surfaced via directUses).
+    case "if.stmt":
       mergeBuffer(instr.then);
       mergeBuffer(instr.else);
       break;
@@ -471,6 +482,12 @@ export function isSideEffecting(i: IrInstr): boolean {
     // (#1922 — fixes the ordinary `while (i < limit)` IR demotion.)
     i.kind === "while.loop" ||
     i.kind === "for.loop" ||
+    // #2952 slice 2 — br.label is a control transfer (must always run);
+    // if.stmt is statement-level control flow whose arm buffers must be
+    // use-walked so values referenced only inside an arm stay live (same
+    // rationale as while.loop / for.loop above).
+    i.kind === "br.label" ||
+    i.kind === "if.stmt" ||
     // Slice 10 (#1169i): extern class ops invoke host imports with
     // arbitrary side effects. Conservatively keep all five live so DCE
     // never strips a `RegExp_new` or `Uint8Array_set` whose result is

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -64,6 +64,7 @@ import {
   type IrClosureSignature,
   type IrFunction,
   type IrInstr,
+  type IrLabelId,
   type IrObjectShape,
   type IrType,
   type IrUnop,
@@ -972,6 +973,15 @@ interface LowerCtx {
    * unproven read falls to the SAFE bounds-checked read (no trap).
    */
   readonly safeIndexedArrays?: ReadonlySet<string>;
+  /**
+   * #2952 slice 2 — the innermost enclosing CLAIMED loop's label, threaded
+   * onto the body cx by every loop lowerer. `lowerBreakContinueStatement`
+   * emits `br.label` against it (unlabeled break/continue bind the
+   * innermost loop, ECMA-262 §14.8/§14.9). Absent outside loop bodies;
+   * lifted-closure contexts are constructed fresh, so it never leaks
+   * across function boundaries.
+   */
+  readonly loopLabel?: IrLabelId;
 }
 
 /**
@@ -3685,7 +3695,7 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
  * MUST be called inside the `collectBodyInstrs` closure that builds the cond
  * buffer so the coercion instructions re-run each iteration.
  */
-function coerceLoopCondToBool(condValue: IrValueId, cx: LowerCtx, loopKind: "while" | "for" | "do"): IrValueId {
+function coerceLoopCondToBool(condValue: IrValueId, cx: LowerCtx, loopKind: "while" | "for" | "do" | "if"): IrValueId {
   const kind = asVal(cx.builder.typeOf(condValue))?.kind;
   if (kind === "i32") return condValue;
   if (kind === "f64") {
@@ -3717,7 +3727,10 @@ function lowerWhileStatement(stmt: ts.WhileStatement, cx: LowerCtx): void {
   if (condResult === null || condResult === undefined) {
     throw new Error(`ir/from-ast: while cond produced no SSA value (${cx.funcName})`);
   }
-  const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
+  // #2952 slice 2 — synthesise the loop's label and thread it as the
+  // innermost loop for the body, so unlabeled break/continue resolve here.
+  const loopLabel = cx.builder.freshLoopLabel();
+  const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope), loopLabel };
   const bodyInstrs = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
   });
@@ -3725,6 +3738,7 @@ function lowerWhileStatement(stmt: ts.WhileStatement, cx: LowerCtx): void {
     cond: condInstrs,
     condValue: condResult,
     body: bodyInstrs,
+    loopLabel,
   });
 }
 
@@ -3744,8 +3758,11 @@ function lowerWhileStatement(stmt: ts.WhileStatement, cx: LowerCtx): void {
  */
 function lowerDoStatement(stmt: ts.DoStatement, cx: LowerCtx): void {
   // Body first (buffer built exactly as `while`, just emitted before cond
-  // at lower time). Scope mirrors the while path.
-  const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
+  // at lower time). Scope mirrors the while path. (#2952 slice 2) The
+  // synthesised label makes this loop the innermost break/continue target;
+  // a continue falls through to the cond (post-test semantics).
+  const loopLabel = cx.builder.freshLoopLabel();
+  const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope), loopLabel };
   const bodyInstrs = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
   });
@@ -3765,6 +3782,7 @@ function lowerDoStatement(stmt: ts.DoStatement, cx: LowerCtx): void {
     condValue: condResult,
     body: bodyInstrs,
     postCond: true,
+    loopLabel,
   });
 }
 
@@ -3899,9 +3917,12 @@ function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx): void {
   // keeps the fast unchecked `vec.get`. Thread the proven pair onto a body-scoped
   // cx (immutable copy → no leak to siblings; nested loops accumulate outward).
   const provenPair = detectCountedLoopSafeIndex(stmt);
+  // #2952 slice 2 — synthesise the loop's label; the body cx carries it as
+  // the innermost break/continue target (a continue jumps to the update).
+  const loopLabel = innerCx.builder.freshLoopLabel();
   const bodyCx: LowerCtx = provenPair
-    ? { ...innerCx, safeIndexedArrays: new Set([...(innerCx.safeIndexedArrays ?? []), provenPair]) }
-    : innerCx;
+    ? { ...innerCx, safeIndexedArrays: new Set([...(innerCx.safeIndexedArrays ?? []), provenPair]), loopLabel }
+    : { ...innerCx, loopLabel };
   const bodyInstrs = innerCx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
   });
@@ -3918,6 +3939,7 @@ function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx): void {
     condValue: condResult,
     body: bodyInstrs,
     update: updateInstrs,
+    loopLabel,
   });
 }
 
@@ -3982,7 +4004,9 @@ function lowerForOfIterFromExternrefValue(
   const elemIrT: IrType = irVal({ kind: "externref" });
   const bodyScope = new Map(cx.scope);
   bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
-  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+  // #2952 slice 2 — this loop is the innermost break/continue target.
+  const loopLabel = cx.builder.freshLoopLabel();
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope, loopLabel };
 
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
@@ -3994,6 +4018,7 @@ function lowerForOfIterFromExternrefValue(
     resultSlot,
     elementSlot,
     body,
+    loopLabel,
   });
 }
 
@@ -4042,7 +4067,9 @@ function lowerForOfString(stmt: ts.ForOfStatement, cx: LowerCtx, strV: IrValueId
     type: elemIrT,
     asType: { kind: "string" },
   });
-  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+  // #2952 slice 2 — this loop is the innermost break/continue target.
+  const loopLabel = cx.builder.freshLoopLabel();
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope, loopLabel };
 
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
@@ -4055,6 +4082,7 @@ function lowerForOfString(stmt: ts.ForOfStatement, cx: LowerCtx, strV: IrValueId
     strSlot,
     elementSlot,
     body,
+    loopLabel,
   });
 }
 
@@ -4104,7 +4132,9 @@ function lowerForOfVec(
 
   const bodyScope = new Map(cx.scope);
   bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
-  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+  // #2952 slice 2 — this loop is the innermost break/continue target.
+  const loopLabel = cx.builder.freshLoopLabel();
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope, loopLabel };
 
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
@@ -4119,6 +4149,7 @@ function lowerForOfVec(
     dataSlot,
     elementSlot,
     body,
+    loopLabel,
   });
 }
 
@@ -4190,6 +4221,10 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
     const childCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
     for (const s of stmt.statements) {
       lowerStmt(s, childCx);
+      // #2952 slice 2 — a break/continue terminates its buffer (the
+      // verifier requires br.label to be last); statements after it are
+      // dead code — skip them rather than emit unreachable instrs.
+      if (ts.isBreakStatement(s) || ts.isContinueStatement(s)) break;
     }
     return;
   }
@@ -4292,7 +4327,61 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
     lowerTryStatement(stmt, cx);
     return;
   }
+  // #2952 slice 2 — statement-level if inside a body buffer.
+  if (ts.isIfStatement(stmt)) {
+    lowerIfBodyStatement(stmt, cx);
+    return;
+  }
+  // #2952 slice 2 — unlabeled break / continue against the innermost loop.
+  if (ts.isBreakStatement(stmt) || ts.isContinueStatement(stmt)) {
+    lowerBreakContinueStatement(stmt, cx);
+    return;
+  }
   throw new Error(`ir/from-ast: unsupported body statement ${ts.SyntaxKind[stmt.kind]} in ${cx.funcName}`);
+}
+
+/**
+ * #2952 slice 2 — lower a statement-position `if (cond) then [else]` inside
+ * a body buffer to the void `if.stmt` IR instr. Unlike the top-level
+ * statement-list `if` (which uses the block-CFG layer), nested buffers have
+ * no CFG access, so this stays fully structured: cond is lowered INLINE in
+ * the current buffer (evaluated once), each arm is collected into its own
+ * sub-buffer with a cloned scope (arm-local `let`s don't leak).
+ */
+function lowerIfBodyStatement(stmt: ts.IfStatement, cx: LowerCtx): void {
+  const raw = lowerExpr(stmt.expression, cx, irVal({ kind: "i32" }));
+  // Numeric-truthiness conds coerce via the shared NaN-safe ToBoolean
+  // (#2136); ref/string conds throw → legacy fallback, same discipline as
+  // the loop conds.
+  const cond = coerceLoopCondToBool(raw, cx, "if");
+  const thenCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
+  const thenInstrs = cx.builder.collectBodyInstrs(() => {
+    lowerStmt(stmt.thenStatement, thenCx);
+  });
+  const elseInstrs = stmt.elseStatement
+    ? cx.builder.collectBodyInstrs(() => {
+        lowerStmt(stmt.elseStatement!, { ...cx, scope: new Map(cx.scope) });
+      })
+    : [];
+  cx.builder.emitIfStmt({ cond, then: thenInstrs, else: elseInstrs });
+}
+
+/**
+ * #2952 slice 2 — lower an unlabeled `break;` / `continue;` to `br.label`
+ * against the innermost enclosing loop's synthesised label (threaded on
+ * `cx.loopLabel` by every loop lowerer). The selector's `inLoop` gate
+ * guarantees a label is in scope and the statement is unlabeled; the
+ * throws are internal-invariant assertions, not fallback paths.
+ */
+function lowerBreakContinueStatement(stmt: ts.BreakStatement | ts.ContinueStatement, cx: LowerCtx): void {
+  const kind = ts.isBreakStatement(stmt) ? "break" : "continue";
+  if (stmt.label) {
+    throw new Error(`ir/from-ast: labeled ${kind} not in #2952 slice 2 (${cx.funcName})`);
+  }
+  if (cx.loopLabel === undefined) {
+    throw new Error(`ir/from-ast: ${kind} outside a claimed loop — selector gate failed (${cx.funcName})`);
+  }
+  cx.builder.emitBrLabel(cx.loopLabel, kind);
 }
 
 /**

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -63,11 +63,13 @@ import {
   type IrFunction,
   type IrGlobalRef,
   type IrInstr,
+  type IrLabelId,
   type IrObjectShape,
   type IrType,
   type IrTypeRef,
   type IrValueId,
   asVal,
+  forEachInstrDeep,
   forEachNestedBuffer,
 } from "./nodes.js";
 // #2134 — the unified IR effect model (formerly the private `SchedFx` table
@@ -501,6 +503,12 @@ export function lowerIrFunctionBody<S>(
         recordUse(instr.thenValue, -1);
         recordUse(instr.elseValue, -1);
       }
+      // #2952 slice 2 — statement-level if arms: same -1 convention (an
+      // outer value used inside an arm pre-materialises into a Wasm local).
+      if (instr.kind === "if.stmt") {
+        for (const u of collectForOfBodyUses(instr.then)) recordUse(u, -1);
+        for (const u of collectForOfBodyUses(instr.else)) recordUse(u, -1);
+      }
     }
     for (const u of collectTerminatorUses(block)) recordUse(u, blockId);
   }
@@ -715,6 +723,11 @@ export function lowerIrFunctionBody<S>(
       for (const sub of instr.then) allocLocalForInstr(sub);
       for (const sub of instr.else) allocLocalForInstr(sub);
     }
+    // #2952 slice 2 — statement-level if arms (same recursion as `if`).
+    if (instr.kind === "if.stmt") {
+      for (const sub of instr.then) allocLocalForInstr(sub);
+      for (const sub of instr.else) allocLocalForInstr(sub);
+    }
   };
   for (const block of func.blocks) {
     for (const instr of block.instrs) {
@@ -801,6 +814,90 @@ export function lowerIrFunctionBody<S>(
   // --- emission -----------------------------------------------------------
 
   const materialized = new Set<IrValueId>();
+
+  // --- #2952 slice 2 — lowering-time label→depth resolver (Design A3) ------
+  //
+  // `br.label{label, mode}` stores NO depth: the Wasm `br` immediate is
+  // derived HERE by counting structured frames between the branch site and
+  // the frame that binds `label`. Every structured Wasm frame the emitter
+  // opens (block / loop / if / try — each exactly ONE Wasm label) pushes one
+  // `CtrlFrame` for the duration of its interior emission and pops on close,
+  // so the stack mirrors the physical nesting at every emission point. This
+  // is what makes the depth robust under buffer re-nesting: the IR carries
+  // only the semantic label, and each emission point re-derives its own
+  // relative depth.
+  //
+  // Frame kinds:
+  //   - "break"    — the frame a `br.label{mode:"break"}` for this label
+  //                  exits to (the loop's outer `block`).
+  //   - "continue" — the frame whose br re-runs the loop's advance/cond
+  //                  (the Wasm `loop` for pre-test while / forof.iter, or a
+  //                  dedicated body-wrapping `block` for for / do-while /
+  //                  counter-advancing for-of — emitted only when the body
+  //                  actually contains a continue for this label, keeping
+  //                  continue-free loops byte-identical).
+  //   - "plain"    — any other frame (if / try / labeled-block later).
+  //                  A try frame carries its ACTIVE `finallyBody` while its
+  //                  try-body buffer is being emitted: a br.label that
+  //                  crosses it inlines the finally immediately before the
+  //                  br (the same inlining IrInstrTry lowering already does
+  //                  for normal completion). The field is masked (undefined)
+  //                  while the finally itself / the catch path is emitted so
+  //                  a break inside a finally never re-runs its own finally.
+  type CtrlFrame =
+    | { kind: "break"; label: IrLabelId }
+    | { kind: "continue"; label: IrLabelId }
+    | { kind: "plain"; finallyBody?: readonly IrInstr[] | undefined };
+  const ctrlStack: CtrlFrame[] = [];
+
+  /**
+   * Emit a nested buffer as a statement sequence with the standard SSA
+   * materialisation rules (void instrs emit in place; cross-block results
+   * emit + local.set; intra-buffer multi-use values tee at their use site).
+   * S-generic twin of the per-arm `emitBodyBuffer` helpers; used by the new
+   * if.stmt arm and by the br.label finally-inlining path.
+   */
+  const emitBufferAsStatements = (bodyInstrs: readonly IrInstr[], target: S): void => {
+    for (const bodyInstr of bodyInstrs) {
+      if (bodyInstr.result === null) {
+        emitInstrTree(bodyInstr, target);
+      } else if (crossBlock.has(bodyInstr.result)) {
+        emitInstrTree(bodyInstr, target);
+        emitter.emitLocalSet(localIdx.get(bodyInstr.result)!, target);
+        materialized.add(bodyInstr.result);
+      }
+      // Intra-buffer multi-use: handled at use site via the tee pattern.
+    }
+  };
+
+  /**
+   * Resolve a `br.label` at the current emission point: scan the ctrlStack
+   * from the innermost frame (depth 0), counting every frame; inline each
+   * crossed try-finally (innermost first — JS runs inner finallys before
+   * outer ones on an abrupt exit); emit `br <depth>` at the matching frame.
+   *
+   * A br.label inside an inlined finally resolves against the SAME stack
+   * (the code physically sits at the branch site), with the finally's own
+   * frame masked — so `try { break } finally { continue }` correctly lets
+   * the continue win (its br is emitted before the break's br, which
+   * becomes unreachable), matching ECMA-262 completion-value overriding.
+   */
+  const resolveBrLabel = (label: IrLabelId, mode: "break" | "continue", out: S): void => {
+    for (let i = ctrlStack.length - 1, depth = 0; i >= 0; i--, depth++) {
+      const frame = ctrlStack[i]!;
+      if (frame.kind === mode && frame.label === label) {
+        emitter.emitBr(depth, out);
+        return;
+      }
+      if (frame.kind === "plain" && frame.finallyBody) {
+        const saved = frame.finallyBody;
+        frame.finallyBody = undefined; // mask: a finally never re-runs itself
+        emitBufferAsStatements(saved, out);
+        frame.finallyBody = saved;
+      }
+    }
+    throw new Error(`ir/lower: br.label(${label as number}, ${mode}) has no enclosing frame in ${func.name}`);
+  };
 
   /**
    * #1303 — Defensive coercion for bitwise op operands.
@@ -1050,15 +1147,21 @@ export function lowerIrFunctionBody<S>(
         // 1. Emit cond.
         emitValue(instr.cond, out);
 
-        // 2. THEN arm.
+        // 2. THEN arm. (#2952 slice 2 — each arm is one structured Wasm
+        // frame; push a plain CtrlFrame so any br.label nested in the arm
+        // derives the correct depth. Byte-inert for arms without one.)
         const thenBody: S = emitter.newSink();
+        ctrlStack.push({ kind: "plain" });
         emitArmBody(instr.then, thenBody);
         emitValue(instr.thenValue, thenBody);
+        ctrlStack.pop();
 
         // 3. ELSE arm.
         const elseBody: S = emitter.newSink();
+        ctrlStack.push({ kind: "plain" });
         emitArmBody(instr.else, elseBody);
         emitValue(instr.elseValue, elseBody);
+        ctrlStack.pop();
 
         // 4. Wrap in `if (result T) ... else ... end`.
         emitter.emitIf(blockType, thenBody, elseBody, out);
@@ -1626,6 +1729,15 @@ export function lowerIrFunctionBody<S>(
           index: slotWasmIdx(instr.counterSlot),
         });
 
+        // #2952 slice 2 — frames: outer block = break target; loop frame is
+        // plain (the counter-advance runs AFTER the body, so a continue
+        // targets a dedicated body-wrapping block that falls into it —
+        // emitted only when the body contains a continue for this loop).
+        const label = instr.loopLabel;
+        const needsContinueBlock = label !== undefined && bufferHasBrLabel(instr.body, label, "continue");
+        ctrlStack.push(label !== undefined ? { kind: "break", label } : { kind: "plain" });
+        ctrlStack.push({ kind: "plain" });
+
         // Build loop body Wasm ops by recursively emitting body instrs.
         const loopBody: Instr[] = [];
         // if (counter >= length) br 1 (exit)
@@ -1655,19 +1767,15 @@ export function lowerIrFunctionBody<S>(
           index: slotWasmIdx(instr.elementSlot),
         });
 
-        // Body instrs
-        for (const bodyInstr of instr.body) {
-          if (bodyInstr.result === null) {
-            emitInstrTree(bodyInstr, loopBody as unknown as S);
-          } else if (crossBlock.has(bodyInstr.result)) {
-            emitInstrTree(bodyInstr, loopBody as unknown as S);
-            loopBody.push({
-              op: "local.set",
-              index: localIdx.get(bodyInstr.result)!,
-            });
-            materialized.add(bodyInstr.result);
-          }
-          // Intra-block multi-use: handled at use site via tee pattern.
+        // Body instrs (continue block falls through to the counter advance).
+        if (needsContinueBlock) {
+          const bodyOps: Instr[] = [];
+          ctrlStack.push({ kind: "continue", label: label! });
+          emitBufferAsStatements(instr.body, bodyOps as unknown as S);
+          ctrlStack.pop();
+          emitter.emitBlock({ kind: "empty" }, bodyOps as unknown as S, loopBody as unknown as S);
+        } else {
+          emitBufferAsStatements(instr.body, loopBody as unknown as S);
         }
 
         // counter = counter + 1
@@ -1684,6 +1792,8 @@ export function lowerIrFunctionBody<S>(
 
         // br 0 (continue)
         emitter.emitBr(0, loopBody as unknown as S);
+        ctrlStack.pop(); // loop frame
+        ctrlStack.pop(); // break frame
 
         // Wrap in block { loop { ... } } via the trait (#1584 a3).
         const loopWrap: Instr[] = [];
@@ -1775,6 +1885,16 @@ export function lowerIrFunctionBody<S>(
         wasmOut.push({ op: "call", funcIdx: iteratorIdx });
         wasmOut.push({ op: "local.set", index: slotWasmIdx(instr.iterSlot) });
 
+        // #2952 slice 2 — frames: outer block = break target (a break lands
+        // just past the block, i.e. AT the __iterator_return close call
+        // below — spec-correct IteratorClose on abrupt exit, §14.7.5); the
+        // loop frame is the continue target (br-to-loop re-runs
+        // __iterator_next — the advance happens at the loop top, so no
+        // body-wrapping block is needed).
+        const label = instr.loopLabel;
+        ctrlStack.push(label !== undefined ? { kind: "break", label } : { kind: "plain" });
+        ctrlStack.push(label !== undefined ? { kind: "continue", label } : { kind: "plain" });
+
         // Build loop body Wasm ops.
         const loopBody: Instr[] = [];
         // __iterator_next(iter) → (i32 done, externref value) [multi-value]
@@ -1792,30 +1912,21 @@ export function lowerIrFunctionBody<S>(
         emitter.emitBrIf(1, loopBody as unknown as S);
 
         // Body instrs (same materialisation pattern as forof.vec).
-        for (const bodyInstr of instr.body) {
-          if (bodyInstr.result === null) {
-            emitInstrTree(bodyInstr, loopBody as unknown as S);
-          } else if (crossBlock.has(bodyInstr.result)) {
-            emitInstrTree(bodyInstr, loopBody as unknown as S);
-            loopBody.push({
-              op: "local.set",
-              index: localIdx.get(bodyInstr.result)!,
-            });
-            materialized.add(bodyInstr.result);
-          }
-        }
+        emitBufferAsStatements(instr.body, loopBody as unknown as S);
 
         // br 0 (continue)
         emitter.emitBr(0, loopBody as unknown as S);
+        ctrlStack.pop(); // loop frame
+        ctrlStack.pop(); // break frame
 
         // block { loop { ... } } via the trait (#1584 a3).
         const loopWrap: Instr[] = [];
         emitter.emitLoop({ kind: "empty" }, loopBody as unknown as S, loopWrap as unknown as S);
         emitter.emitBlock({ kind: "empty" }, loopWrap as unknown as S, wasmOut as unknown as S);
 
-        // Normal-exit close: iter.return(iter). Note this runs only on
-        // normal loop exit (done=true). Abrupt exits (break/return)
-        // would need a try/finally — slice 6 step E (#1169h dependency).
+        // Loop-exit close: iter.return(iter). Runs on normal exit
+        // (done=true) AND on `break` (#2952 slice 2 — the break br targets
+        // the wrapping block, landing exactly here — IteratorClose §14.7.5).
         wasmOut.push({ op: "local.get", index: slotWasmIdx(instr.iterSlot) });
         wasmOut.push({ op: "call", funcIdx: iteratorReturnIdx });
         return;
@@ -1831,6 +1942,33 @@ export function lowerIrFunctionBody<S>(
         emitValue(instr.value, out);
         // #1584 (a4): throw routes through the trait.
         emitter.emitThrow(tagIdx, out);
+        return;
+      }
+      // #2952 slice 2 — unlabeled break/continue. Depth derived at emit time
+      // by the ctrlStack resolver; crossed try-finallys are inlined before
+      // the br. Verifier guarantees an enclosing loop binds the label.
+      case "br.label": {
+        resolveBrLabel(instr.label, instr.mode, out);
+        return;
+      }
+      // #2952 slice 2 — statement-level if (void arms, else may be empty).
+      // Each arm is one structured Wasm frame → one plain CtrlFrame so a
+      // br.label inside an arm counts it toward its depth.
+      case "if.stmt": {
+        emitValue(instr.cond, out);
+        const thenBody: S = emitter.newSink();
+        ctrlStack.push({ kind: "plain" });
+        emitBufferAsStatements(instr.then, thenBody);
+        ctrlStack.pop();
+        const elseBody: S = emitter.newSink();
+        if (instr.else.length > 0) {
+          ctrlStack.push({ kind: "plain" });
+          emitBufferAsStatements(instr.else, elseBody);
+          ctrlStack.pop();
+        }
+        // Empty-else encodes as a bare `if ... end` (binary.ts omits the
+        // else opcode for an empty arm under an empty blocktype).
+        emitter.emitIf({ kind: "empty" }, thenBody, elseBody, out);
         return;
       }
       case "try": {
@@ -1876,9 +2014,23 @@ export function lowerIrFunctionBody<S>(
           }
         };
 
+        // #2952 slice 2 — one CtrlFrame for the try op (it is exactly one
+        // Wasm label). The frame carries the ACTIVE finallyBody only while
+        // the try-body buffer is emitted: a br.label crossing out of the try
+        // body must inline the finally before its br. Everywhere else (the
+        // finally's own inline emissions, the catch path) it is masked —
+        // the catch path's finally obligations are owned by the dedicated
+        // inner-try frame below, and a finally must never re-run itself.
+        const tryFrame: { kind: "plain"; finallyBody?: readonly IrInstr[] | undefined } = {
+          kind: "plain",
+          finallyBody: instr.finallyBody,
+        };
+        ctrlStack.push(tryFrame);
+
         // Try body — emits user instrs + inlined finally on normal exit.
         const tryBody: Instr[] = [];
         emitBodyBuffer(instr.body, tryBody);
+        tryFrame.finallyBody = undefined; // mask for all remaining emissions
         if (instr.finallyBody) {
           emitBodyBuffer(instr.finallyBody, tryBody);
         }
@@ -1902,11 +2054,22 @@ export function lowerIrFunctionBody<S>(
             // Wrap user catch body in an inner try/catch_all so a throw
             // inside the catch body still runs finally before propagating.
             // #1584 (a4): the inner try + rethrow route through the trait.
+            // #2952 slice 2 — the inner try is one more Wasm label; its
+            // frame carries the finally while the catch body emits (a
+            // br.label out of the catch must run the finally), masked while
+            // the finally itself emits into the inner catch_all.
+            const innerFrame: { kind: "plain"; finallyBody?: readonly IrInstr[] | undefined } = {
+              kind: "plain",
+              finallyBody: instr.finallyBody,
+            };
+            ctrlStack.push(innerFrame);
             const innerBody: Instr[] = [];
             emitBodyBuffer(instr.catchClause.body, innerBody);
+            innerFrame.finallyBody = undefined;
             const innerCatchAll: Instr[] = [];
             emitBodyBuffer(instr.finallyBody, innerCatchAll);
             emitter.emitRethrow(0, innerCatchAll as unknown as S);
+            ctrlStack.pop();
             emitter.emitTry(
               { kind: "empty" },
               innerBody as unknown as S,
@@ -1937,6 +2100,8 @@ export function lowerIrFunctionBody<S>(
           emitter.emitRethrow(0, ca as unknown as S);
           catchAll = ca;
         }
+
+        ctrlStack.pop(); // tryFrame
 
         // #1584 (a4): the structured try routes through the trait.
         emitter.emitTry(
@@ -1979,6 +2144,15 @@ export function lowerIrFunctionBody<S>(
 
         // #1584 (a0-tail): out-of-subset (embeds an Instr[] loop body). S = Instr[].
         const wasmOut = requireInstrSink(out);
+
+        // #2952 slice 2 — frames: outer block = break target; loop frame is
+        // plain (the code-point cursor advance runs AFTER the body, so a
+        // continue targets a dedicated body-wrapping block — emitted only
+        // when the body contains a continue for this loop).
+        const label = instr.loopLabel;
+        const needsContinueBlock = label !== undefined && bufferHasBrLabel(instr.body, label, "continue");
+        ctrlStack.push(label !== undefined ? { kind: "break", label } : { kind: "plain" });
+        ctrlStack.push({ kind: "plain" });
 
         // <emit str>; local.set <strSlot>
         emitValue(instr.str, out);
@@ -2023,18 +2197,16 @@ export function lowerIrFunctionBody<S>(
           index: slotWasmIdx(instr.elementSlot),
         });
 
-        // Body instrs (same materialisation pattern as forof.vec/forof.iter).
-        for (const bodyInstr of instr.body) {
-          if (bodyInstr.result === null) {
-            emitInstrTree(bodyInstr, loopBody as unknown as S);
-          } else if (crossBlock.has(bodyInstr.result)) {
-            emitInstrTree(bodyInstr, loopBody as unknown as S);
-            loopBody.push({
-              op: "local.set",
-              index: localIdx.get(bodyInstr.result)!,
-            });
-            materialized.add(bodyInstr.result);
-          }
+        // Body instrs (same materialisation pattern as forof.vec/forof.iter;
+        // continue block falls through to the cursor advance below).
+        if (needsContinueBlock) {
+          const bodyOps: Instr[] = [];
+          ctrlStack.push({ kind: "continue", label: label! });
+          emitBufferAsStatements(instr.body, bodyOps as unknown as S);
+          ctrlStack.pop();
+          emitter.emitBlock({ kind: "empty" }, bodyOps as unknown as S, loopBody as unknown as S);
+        } else {
+          emitBufferAsStatements(instr.body, loopBody as unknown as S);
         }
 
         // counter = counter + element.len — the element is the whole code
@@ -2057,6 +2229,8 @@ export function lowerIrFunctionBody<S>(
 
         // br 0 (continue)
         emitter.emitBr(0, loopBody as unknown as S);
+        ctrlStack.pop(); // loop frame
+        ctrlStack.pop(); // break frame
 
         // block { loop { ... } } via the trait (#1584 a3).
         const loopWrap: Instr[] = [];
@@ -2168,10 +2342,37 @@ export function lowerIrFunctionBody<S>(
         // `block { loop { ... br 0 } }` and the `br_if 1` exit are identical.
         const postTest = instr.kind === "while.loop" && instr.postCond === true;
 
+        // #2952 slice 2 — CtrlFrames for the two frames this arm opens
+        // (outer `block` = break target; inner `loop`). For a pre-test
+        // `while`, br-to-loop re-evaluates the cond, so the loop frame IS
+        // the continue target. For post-test (do-while) and `for`, a
+        // continue must fall into the cond / update code that runs AFTER
+        // the body, so the body is wrapped in a dedicated `block` (the
+        // continue target) — emitted only when the body actually contains
+        // a continue for this loop, keeping continue-free loops
+        // byte-identical to the slice-1 emission.
+        const label = instr.loopLabel;
+        const preTestWhile = instr.kind === "while.loop" && !postTest;
+        const needsContinueBlock =
+          label !== undefined && !preTestWhile && bufferHasBrLabel(instr.body, label, "continue");
+        ctrlStack.push(label !== undefined ? { kind: "break", label } : { kind: "plain" });
+        ctrlStack.push(preTestWhile && label !== undefined ? { kind: "continue", label } : { kind: "plain" });
+        const emitLoopBodyStatements = (): void => {
+          if (needsContinueBlock) {
+            const bodyOps: Instr[] = [];
+            ctrlStack.push({ kind: "continue", label: label! });
+            emitBodyBuffer(instr.body, bodyOps);
+            ctrlStack.pop();
+            emitter.emitBlock({ kind: "empty" }, bodyOps as unknown as S, loopBody as unknown as S);
+          } else {
+            emitBodyBuffer(instr.body, loopBody);
+          }
+        };
+
         if (postTest) {
           // Post-test: body first, then evaluate cond and exit if falsy.
-          // 1. Body instructions.
-          emitBodyBuffer(instr.body, loopBody);
+          // 1. Body instructions (continue falls through to the cond).
+          emitLoopBodyStatements();
           // 2. Cond instructions (re-evaluated each iteration, after body).
           emitBodyBuffer(instr.cond, loopBody);
           // 3. Push the cond value, invert (i32.eqz), then br_if 1 to exit.
@@ -2189,8 +2390,8 @@ export function lowerIrFunctionBody<S>(
           loopBody.push({ op: "i32.eqz" });
           emitter.emitBrIf(1, loopBody as unknown as S);
 
-          // 3. Body instructions.
-          emitBodyBuffer(instr.body, loopBody);
+          // 3. Body instructions (for `for`, continue falls to the update).
+          emitLoopBodyStatements();
 
           // 4. Update instructions (for-loop only — empty array for while).
           if (instr.kind === "for.loop") {
@@ -2200,6 +2401,8 @@ export function lowerIrFunctionBody<S>(
 
         // 5. Continue back to the loop header.
         emitter.emitBr(0, loopBody as unknown as S);
+        ctrlStack.pop(); // loop frame
+        ctrlStack.pop(); // break frame
 
         // 6. Wrap in `block { loop { ... } }` via the trait (#1584 a3).
         const loopWrap: Instr[] = [];
@@ -2639,6 +2842,12 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [];
+    // #2952 slice 2 — br.label has no SSA operands; if.stmt surfaces only
+    // its cond (arm-buffer uses via `collectForOfBodyUses`, like `if`).
+    case "br.label":
+      return [];
+    case "if.stmt":
+      return [instr.cond];
     // (#1373 Phase B) Async / await IR nodes — type-only in this slice.
     // The lowering Phase C (#1373b) will inflate these into CPS-form
     // microtask-queue calls; until then they're never emitted by
@@ -2650,6 +2859,24 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "async.throw":
       return [instr.reason];
   }
+}
+
+/**
+ * #2952 slice 2 — does `body` (deeply) contain a `br.label` with the given
+ * label + mode? Used by the loop-lowering arms to decide whether to emit the
+ * dedicated continue-target block: labels are unique per function, so the
+ * deep scan is exact — a nested loop's own continues carry its own label and
+ * never match. Continue-free loops therefore stay byte-identical.
+ */
+export function bufferHasBrLabel(body: readonly IrInstr[], label: IrLabelId, mode: "break" | "continue"): boolean {
+  let found = false;
+  for (const instr of body) {
+    forEachInstrDeep(instr, (i) => {
+      if (i.kind === "br.label" && i.label === label && i.mode === mode) found = true;
+    });
+    if (found) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -446,6 +446,21 @@ export function asValueId(n: number): IrValueId {
 }
 
 /**
+ * #2952 slice 2 — per-function-unique identity of a loop (or, in slice 3, a
+ * labeled block) that `br.label` can target. Like {@link IrValueId} it is a
+ * branded number allocated by the builder; unlike an SSA value it names a
+ * CONTROL-FLOW frame, not a value. Labels are semantic: the Wasm `br` depth
+ * is NEVER stored in the IR — it is derived at lowering time by the
+ * `ctrlStack` frame counter in `lower.ts` (a stored depth would rot under
+ * any pass that re-nests buffers).
+ */
+export type IrLabelId = number & { readonly __brand: "IrLabelId" };
+
+export function asLabelId(n: number): IrLabelId {
+  return n as IrLabelId;
+}
+
+/**
  * Stable identity of an allocation site (#1586).
  *
  * Unlike {@link IrValueId} — which is a per-function SSA index that inlining
@@ -1284,6 +1299,8 @@ export interface IrInstrForOfVec extends IrInstrBase {
   readonly elementSlot: number;
   /** Body instrs emitted inside the loop. */
   readonly body: readonly IrInstr[];
+  /** #2952 slice 2 — loop identity for `br.label` (see IrInstrWhileLoop). */
+  readonly loopLabel?: IrLabelId;
 }
 
 // ---------------------------------------------------------------------------
@@ -1468,6 +1485,8 @@ export interface IrInstrForOfIter extends IrInstrBase {
   readonly elementSlot: number;
   /** Body instrs emitted inside the loop. */
   readonly body: readonly IrInstr[];
+  /** #2952 slice 2 — loop identity for `br.label` (see IrInstrWhileLoop). */
+  readonly loopLabel?: IrLabelId;
 }
 
 /**
@@ -1701,6 +1720,8 @@ export interface IrInstrForOfString extends IrInstrBase {
   readonly elementSlot: number;
   /** Body instrs emitted inside the loop. */
   readonly body: readonly IrInstr[];
+  /** #2952 slice 2 — loop identity for `br.label` (see IrInstrWhileLoop). */
+  readonly loopLabel?: IrLabelId;
 }
 
 // ---------------------------------------------------------------------------
@@ -1810,6 +1831,13 @@ export interface IrInstrWhileLoop extends IrInstrBase {
    * so the cond-first walk order is sound for both loop shapes.
    */
   readonly postCond?: boolean;
+  /**
+   * #2952 slice 2 — identity of this loop for `br.label` targeting. The
+   * from-ast layer always synthesises one (unlabeled break/continue resolve
+   * to the innermost loop's label); loops built directly by tests may omit
+   * it. Purely semantic — no pass reads it except the lowering resolver.
+   */
+  readonly loopLabel?: IrLabelId;
 }
 
 /**
@@ -1845,6 +1873,8 @@ export interface IrInstrForLoop extends IrInstrBase {
   readonly body: readonly IrInstr[];
   /** Update instructions executed after the body each iteration. */
   readonly update: readonly IrInstr[];
+  /** #2952 slice 2 — loop identity for `br.label` (see IrInstrWhileLoop). */
+  readonly loopLabel?: IrLabelId;
 }
 
 /**
@@ -1892,6 +1922,66 @@ export interface IrInstrTry extends IrInstrBase {
   };
   /** Optional finally body, inlined at every exit path. */
   readonly finallyBody?: readonly IrInstr[];
+}
+
+// ---------------------------------------------------------------------------
+// Multi-exit control flow (#2952 slice 2 — unlabeled break / continue)
+// ---------------------------------------------------------------------------
+
+/**
+ * #2952 slice 2 — branch to an enclosing loop frame identified by `label`.
+ *
+ * `mode` selects WHICH of the loop's Wasm frames the branch targets:
+ *   - `"break"`    → the loop's outer `block` (exit the loop);
+ *   - `"continue"` → the frame whose fall-through re-runs the loop's
+ *                    advance/cond (the Wasm `loop` frame for pre-test
+ *                    `while` / `forof.iter`, or a dedicated body-wrapping
+ *                    `block` for `for` / do-while / counter-advancing
+ *                    for-of shapes — the lowerer decides).
+ *
+ * NO depth is stored here (see the issue's Design-A spec): depth is a
+ * lowering-time artifact derived by scanning the emitter's `ctrlStack`.
+ * The verifier enforces (a) `label` is bound by an enclosing loop in the
+ * same buffer-nesting chain, and (b) the instr terminates its buffer
+ * (statements after it are dead code the from-ast layer never emits).
+ *
+ * A `br.label` that lexically crosses a `try` with a `finallyBody` makes
+ * the lowerer inline that finally buffer immediately before the `br` —
+ * the same inlining `IrInstrTry` already does for normal completion.
+ *
+ * Result is always void (`result: null`); control does not fall through.
+ */
+export interface IrInstrBrLabel extends IrInstrBase {
+  readonly kind: "br.label";
+  readonly label: IrLabelId;
+  readonly mode: "break" | "continue";
+}
+
+/**
+ * #2952 slice 2 — statement-level `if (cond) then [else]` inside a nested
+ * buffer (loop body / try body / another if-arm). UNLIKE the value-producing
+ * `IrInstrIf` (#1392) there are no carrier values and no result: both arms
+ * are void statement lists, and `else` may be empty (plain `if` without
+ * `else` — the lowerer emits a Wasm `if` with no else branch).
+ *
+ * This is the enabler for useful break/continue adoption: `if (c) break;`
+ * is the canonical multi-exit shape, and the loop-body statement grammar
+ * previously had no statement-`if` at all (top-level `if` uses the block
+ * CFG layer, which nested buffers cannot reach).
+ *
+ * Lowering:
+ *   <emit cond>            ;; i32
+ *   if                     ;; blocktype empty
+ *     <then instrs>
+ *   [else
+ *     <else instrs>]
+ *   end
+ */
+export interface IrInstrIfStmt extends IrInstrBase {
+  readonly kind: "if.stmt";
+  readonly cond: IrValueId;
+  readonly then: readonly IrInstr[];
+  readonly else: readonly IrInstr[];
 }
 
 export type IrInstr =
@@ -1954,6 +2044,9 @@ export type IrInstr =
   // Slice 12 (#1280) — generic structured loops.
   | IrInstrWhileLoop
   | IrInstrForLoop
+  // #2952 slice 2 — multi-exit control flow.
+  | IrInstrBrLabel
+  | IrInstrIfStmt
   // (#1373 Phase B) Async / await IR nodes. Currently type-only —
   // Phase C (CPS transform, follow-up #1373b) wires lowering.
   | IrInstrAwait
@@ -2189,6 +2282,13 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
       if (instr.catchClause) fn(instr.catchClause.body);
       if (instr.finallyBody) fn(instr.finallyBody);
       return;
+    // #2952 slice 2 — statement-level if. Both arms are plain buffers
+    // (else may be empty — still visited, mirroring `if`'s unconditional
+    // arm visit so pass behavior is uniform).
+    case "if.stmt":
+      fn(instr.then);
+      fn(instr.else);
+      return;
     // All remaining kinds carry no nested IrInstr[] buffer. The `never`
     // binding turns a newly-added buffer-bearing kind into a compile error
     // here — the single point that must know about every buffer.
@@ -2235,6 +2335,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "gen.epilogue":
     case "gen.yieldStar":
     case "throw":
+    case "br.label": // #2952 slice 2 — leaf (buffer-terminating branch)
     case "extern.new":
     case "extern.call":
     case "extern.prop":
@@ -2321,6 +2422,13 @@ export function mapNestedBuffers(
         finallyBody: instr.finallyBody && finallyBody ? finallyBody : instr.finallyBody,
       };
     }
+    // #2952 slice 2 — statement-level if.
+    case "if.stmt": {
+      const then_ = mapBuffer(instr.then);
+      const else_ = mapBuffer(instr.else);
+      if (then_ === instr.then && else_ === instr.else) return instr;
+      return { ...instr, then: then_, else: else_ };
+    }
     // Leaf kinds carry no nested buffer — returned unchanged. (Same exhaustive
     // set as forEachNestedBuffer; the never-check enforces parity.)
     case "const":
@@ -2366,6 +2474,7 @@ export function mapNestedBuffers(
     case "gen.epilogue":
     case "gen.yieldStar":
     case "throw":
+    case "br.label": // #2952 slice 2 — leaf
     case "extern.new":
     case "extern.call":
     case "extern.prop":
@@ -2485,6 +2594,13 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.value];
     case "try":
       return [];
+    // #2952 slice 2 — br.label carries no SSA operands (label is a control
+    // identity, not a value); if.stmt evaluates only its cond at its own
+    // level (arm-interior uses are reached via `collectUses(_, {deep:true})`).
+    case "br.label":
+      return [];
+    case "if.stmt":
+      return [instr.cond];
     case "extern.new":
       return instr.args;
     case "extern.call":

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -263,7 +263,13 @@ function canInline(callee: IrFunction, recursiveSet: ReadonlySet<string>): boole
       inst.kind === "forof.string" ||
       inst.kind === "try" ||
       inst.kind === "while.loop" ||
-      inst.kind === "for.loop"
+      inst.kind === "for.loop" ||
+      // #2952 slice 2 — if.stmt carries nested body buffers (same deep-SSA
+      // concern as the loop kinds above); br.label references a loop label
+      // scoped to the callee (and is verifier-invalid at a block's top
+      // level anyway). Both skip conservatively.
+      inst.kind === "if.stmt" ||
+      inst.kind === "br.label"
     ) {
       return false;
     }
@@ -729,6 +735,31 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       const cv = mapId(rename, inst.condValue);
       if (cv === inst.condValue) return inst;
       return { ...inst, condValue: cv };
+    }
+    // #2952 slice 2 — br.label carries no SSA operands (label is a control
+    // identity, untouched by value renames).
+    case "br.label":
+      return inst;
+    // #2952 slice 2 — if.stmt: rename the cond + recurse into both arm
+    // buffers (same pattern as `try` above), so a caller-scope rename
+    // reaches arm-interior uses of the redirected value.
+    case "if.stmt": {
+      const cv = mapId(rename, inst.cond);
+      let changed = cv !== inst.cond;
+      const newThen: IrInstr[] = [];
+      for (const sub of inst.then) {
+        const renamed = renameInstrOperands(sub, rename);
+        if (renamed !== sub) changed = true;
+        newThen.push(renamed);
+      }
+      const newElse: IrInstr[] = [];
+      for (const sub of inst.else) {
+        const renamed = renameInstrOperands(sub, rename);
+        if (renamed !== sub) changed = true;
+        newElse.push(renamed);
+      }
+      if (!changed) return inst;
+      return { ...inst, cond: cv, then: newThen, else: newElse };
     }
     case "for.loop": {
       const cv = mapId(rename, inst.condValue);

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -791,6 +791,22 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [instr.condValue];
+    // #2952 slice 2 — br.label has no SSA operands; if.stmt surfaces its
+    // cond plus arm-buffer uses (same deep pattern as `if` above, so the
+    // monomorphize use-counting sees outer values referenced in arms).
+    case "br.label":
+      return [];
+    case "if.stmt": {
+      const out: IrValueId[] = [instr.cond];
+      const walk = (instrs: readonly IrInstr[]): void => {
+        for (const sub of instrs) {
+          for (const u of collectUses(sub)) out.push(u);
+        }
+      };
+      walk(instr.then);
+      walk(instr.else);
+      return out;
+    }
     // (#1373 Phase B) Async / await IR nodes — single operand.
     case "await":
       return [instr.operand];

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1455,13 +1455,16 @@ function isPhase1TryStatement(
   stmt: ts.TryStatement,
   scope: ReadonlySet<string>,
   localClasses: ReadonlySet<string>,
+  // #2952 slice 2 — propagated so a break/continue inside a try nested in a
+  // loop is claimable (the lowerer inlines crossed finallys before the br).
+  inLoop: boolean = false,
 ): boolean {
   if (!stmt.catchClause && !stmt.finallyBlock) return false;
 
   // Try body: must be a Phase-1 body statement list.
   const tryScope = new Set(scope);
   for (const s of stmt.tryBlock.statements) {
-    if (!isPhase1BodyStatement(s, tryScope, localClasses)) return false;
+    if (!isPhase1BodyStatement(s, tryScope, localClasses, inLoop)) return false;
   }
 
   if (stmt.catchClause) {
@@ -1474,14 +1477,14 @@ function isPhase1TryStatement(
       catchScope.add(v.name.text);
     }
     for (const s of stmt.catchClause.block.statements) {
-      if (!isPhase1BodyStatement(s, catchScope, localClasses)) return false;
+      if (!isPhase1BodyStatement(s, catchScope, localClasses, inLoop)) return false;
     }
   }
 
   if (stmt.finallyBlock) {
     const finallyScope = new Set(scope);
     for (const s of stmt.finallyBlock.statements) {
-      if (!isPhase1BodyStatement(s, finallyScope, localClasses)) return false;
+      if (!isPhase1BodyStatement(s, finallyScope, localClasses, inLoop)) return false;
     }
   }
 
@@ -1513,7 +1516,7 @@ function isPhase1ForOf(stmt: ts.ForOfStatement, scope: Set<string>, localClasses
   if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
   const innerScope = new Set(scope);
   innerScope.add(decl.name.text);
-  return isPhase1BodyStatement(stmt.statement, innerScope, localClasses);
+  return isPhase1BodyStatement(stmt.statement, innerScope, localClasses, /* inLoop (#2952 s2) */ true);
 }
 
 /**
@@ -1528,17 +1531,18 @@ function isPhase1WhileStatement(
   localClasses: ReadonlySet<string>,
 ): boolean {
   if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-  return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses);
+  return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses, /* inLoop (#2952 s2) */ true);
 }
 
 /**
  * #2952 slice 1 — shape-check `do { body } while (cond)`. Identical
  * constraints to `while`: a Phase-1 condition expression and a Phase-1
  * body statement. The only runtime difference (body-before-cond) is a
- * lowering concern, not a shape concern — `break` / `continue` are still
- * rejected by `isPhase1BodyStatement` (no arm accepts them), so the
- * multi-exit-free subset is what's claimed. The claim is backed by
- * `lowerDoStatement` (postCond `while.loop`) — selector↔builder parity.
+ * lowering concern, not a shape concern. Slice 2 lifted the slice-1
+ * break/continue restriction: unlabeled break/continue in the body is
+ * claimable via the `inLoop` gate + `br.label` lowering. The claim is
+ * backed by `lowerDoStatement` (postCond `while.loop`) —
+ * selector↔builder parity.
  */
 function isPhase1DoStatement(
   stmt: ts.DoStatement,
@@ -1546,7 +1550,7 @@ function isPhase1DoStatement(
   localClasses: ReadonlySet<string>,
 ): boolean {
   if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-  return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses);
+  return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses, /* inLoop (#2952 s2) */ true);
 }
 
 /**
@@ -1610,7 +1614,7 @@ function isPhase1ForStatement(
   }
 
   // Body: single Phase-1 body statement.
-  return isPhase1BodyStatement(stmt.statement, innerScope, localClasses);
+  return isPhase1BodyStatement(stmt.statement, innerScope, localClasses, /* inLoop (#2952 s2) */ true);
 }
 
 /**
@@ -1662,11 +1666,21 @@ function isPhase1ForUpdateExpr(
  *     `<id> = <id> <op> <expr>`).
  *   - Nested `ForOfStatement`.
  */
-function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClasses: ReadonlySet<string>): boolean {
+function isPhase1BodyStatement(
+  stmt: ts.Statement,
+  scope: Set<string>,
+  localClasses: ReadonlySet<string>,
+  // #2952 slice 2 — true when an enclosing CLAIMED loop is in scope at this
+  // statement position. Loop shape-checkers pass true for their body walks;
+  // block/if/try arms propagate it. Gates the break/continue arm: an
+  // unlabeled break/continue binds the innermost loop, so it is claimable
+  // exactly when that innermost loop is itself on the IR path.
+  inLoop: boolean = false,
+): boolean {
   if (ts.isBlock(stmt)) {
     const inner = new Set(scope);
     for (const s of stmt.statements) {
-      if (!isPhase1BodyStatement(s, inner, localClasses)) return false;
+      if (!isPhase1BodyStatement(s, inner, localClasses, inLoop)) return false;
     }
     return true;
   }
@@ -1759,7 +1773,28 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
     return isPhase1ThrowStatement(stmt, scope, localClasses);
   }
   if (ts.isTryStatement(stmt)) {
-    return isPhase1TryStatement(stmt, scope, localClasses);
+    return isPhase1TryStatement(stmt, scope, localClasses, inLoop);
+  }
+  // #2952 slice 2 — statement-level `if` inside a body buffer (lowered as
+  // the void `if.stmt` IR instr — NOT the top-level block-CFG rewrite).
+  // Both arms are body statements; `inLoop` propagates so `if (c) break;`
+  // — the canonical multi-exit shape — is claimable.
+  if (ts.isIfStatement(stmt)) {
+    if (!isPhase1Expr(stmt.expression, scope, localClasses)) return shapeNo("body-if-cond", stmt.expression);
+    if (!isPhase1BodyStatement(stmt.thenStatement, new Set(scope), localClasses, inLoop)) return false;
+    if (stmt.elseStatement && !isPhase1BodyStatement(stmt.elseStatement, new Set(scope), localClasses, inLoop)) {
+      return false;
+    }
+    return true;
+  }
+  // #2952 slice 2 — unlabeled break / continue: claimable exactly when an
+  // enclosing CLAIMED loop binds them (labeled forms are slice 3). Backed
+  // by `lowerBreakContinueStatement` in from-ast (br.label against the
+  // innermost loop's synthesised label) — selector↔builder parity.
+  if (ts.isBreakStatement(stmt) || ts.isContinueStatement(stmt)) {
+    if (stmt.label) return shapeNo("body-labeled-break-continue", stmt);
+    if (!inLoop) return shapeNo("body-break-continue-outside-loop", stmt);
+    return true;
   }
   return shapeNo("body-unhandled-stmt", stmt);
 }

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -19,7 +19,7 @@
 // On failure, returns a list of `IrVerifyError`s rather than throwing, so
 // callers can decide whether to bail or fall back to the legacy path.
 
-import type { IrBlock, IrFunction, IrInstr, IrType, IrValueId } from "./nodes.js";
+import type { IrBlock, IrFunction, IrInstr, IrLabelId, IrType, IrValueId } from "./nodes.js";
 import { asVal, forEachInstrDeep, forEachNestedBuffer } from "./nodes.js";
 import type { ValType } from "./types.js";
 // #2949 slice 1 — canonical JsTag policy for the dynamic-operand rules
@@ -357,15 +357,30 @@ function verifyBlock(
       block: here,
     });
   };
-  const walkBuffer = (instrs: readonly IrInstr[]): void => {
-    for (const instr of instrs) {
+  // #2952 slice 2 — the label environment: the set of loop labels bound by
+  // enclosing loops IN THE SAME BUFFER-NESTING CHAIN. A `br.label` is valid
+  // iff its label is in scope here; this walk mirrors the lowering-time
+  // ctrlStack, so verifier acceptance implies the depth resolver finds a
+  // frame. Loop BODY buffers extend the environment with the loop's label;
+  // cond/update buffers do NOT (no statement can occur there), and try/if
+  // buffers inherit unchanged (break out of a try is legal — the lowerer
+  // inlines crossed finallys).
+  const walkBuffer = (instrs: readonly IrInstr[], labelsInScope: ReadonlySet<IrLabelId>): void => {
+    const withLabel = (l: IrLabelId | undefined): ReadonlySet<IrLabelId> => {
+      if (l === undefined) return labelsInScope;
+      const next = new Set(labelsInScope);
+      next.add(l);
+      return next;
+    };
+    for (let instrIdx = 0; instrIdx < instrs.length; instrIdx++) {
+      const instr = instrs[instrIdx]!;
       // `while.loop` / `for.loop` surface `condValue` in `collectUses`, but
       // that value is *produced by the cond buffer* (which `collectUses` for
       // these kinds does not contain). Walk the cond buffer first so its def
       // is registered before we validate the `condValue` use — otherwise it
       // would spuriously read as use-before-def. (#1844)
       if (instr.kind === "while.loop" || instr.kind === "for.loop") {
-        walkBuffer(instr.cond);
+        walkBuffer(instr.cond, labelsInScope);
         // The lowerer emits an unconditional `i32.eqz` on `condValue`, so a
         // non-i32 cond produces invalid Wasm that bricks the whole module.
         // Reject it here (the lowerer's #1980 fix throws a fallback before
@@ -375,6 +390,42 @@ function verifyBlock(
         if (condT && asVal(condT)?.kind !== "i32") {
           errors.push({
             message: `${instr.kind} condValue must be i32, got ${asVal(condT)?.kind ?? condT.kind}`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+      }
+
+      // #2952 slice 2 — br.label rules: (a) the label must be bound by an
+      // enclosing loop in this buffer-nesting chain, (b) the instr must
+      // terminate its buffer (control cannot fall through; from-ast stops
+      // emitting after a break/continue, so trailing instrs are a producer
+      // bug, not dead code to tolerate).
+      if (instr.kind === "br.label") {
+        if (!labelsInScope.has(instr.label)) {
+          errors.push({
+            message: `br.label(${instr.label as number}, ${instr.mode}) targets no enclosing loop label`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+        if (instrIdx !== instrs.length - 1) {
+          errors.push({
+            message: `br.label must be the last instruction in its buffer (found at ${instrIdx} of ${instrs.length})`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+      }
+
+      // #2952 slice 2 — if.stmt cond must be i32: the lowerer emits a Wasm
+      // `if` directly on it (same backstop rationale as the loop condValue
+      // check above).
+      if (instr.kind === "if.stmt") {
+        const condT = operandIrType(func, block, instr.cond, localDefs);
+        if (condT && asVal(condT)?.kind !== "i32") {
+          errors.push({
+            message: `if.stmt cond must be i32, got ${asVal(condT)?.kind ?? condT.kind}`,
             func: func.name,
             block: block.id as number,
           });
@@ -513,19 +564,24 @@ function verifyBlock(
       // for-of bodies, try/catch/finally). The nesting instr's own result is
       // registered before we descend so an arm body may reference it. The
       // loop `cond` buffer was already walked above, so skip it here.
+      // (#2952 slice 2) Loop BODY buffers extend the label environment with
+      // the loop's label; every other buffer inherits it unchanged.
       if (instr.kind === "while.loop") {
-        walkBuffer(instr.body);
+        walkBuffer(instr.body, withLabel(instr.loopLabel));
       } else if (instr.kind === "for.loop") {
-        walkBuffer(instr.body);
-        walkBuffer(instr.update);
+        walkBuffer(instr.body, withLabel(instr.loopLabel));
+        walkBuffer(instr.update, labelsInScope);
+      } else if (instr.kind === "forof.vec" || instr.kind === "forof.iter" || instr.kind === "forof.string") {
+        walkBuffer(instr.body, withLabel(instr.loopLabel));
       } else {
-        // Non-loop buffer-bearing kinds (if / for-of / try). Loops are handled
-        // above so their cond buffer (already walked) isn't re-walked here.
-        forEachNestedBuffer(instr, walkBuffer);
+        // Non-loop buffer-bearing kinds (if / if.stmt / try). Loops are
+        // handled above so their cond buffer (already walked) isn't
+        // re-walked here.
+        forEachNestedBuffer(instr, (buffer) => walkBuffer(buffer, labelsInScope));
       }
     }
   };
-  walkBuffer(block.instrs);
+  walkBuffer(block.instrs, new Set());
 
   // Terminator uses must resolve to params/blockargs/local defs, or to a value
   // defined in a block that dominates this one (#1850).
@@ -683,6 +739,12 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
     case "while.loop":
     case "for.loop":
       return [instr.condValue];
+    // #2952 slice 2 — br.label has no SSA operands; if.stmt surfaces only
+    // its cond (arm-buffer uses are walked via the buffer recursion).
+    case "br.label":
+      return [];
+    case "if.stmt":
+      return [instr.cond];
     // (#1373 Phase B) Async / await IR nodes — type-only in this slice.
     // The verifier sees their operands as plain SSA uses; lowering
     // (Phase C, #1373b) will define the per-arm SSA scope.

--- a/tests/issue-2952-slice2.test.ts
+++ b/tests/issue-2952-slice2.test.ts
@@ -1,0 +1,405 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2952 slice 2 — IR adoption of unlabeled `break` / `continue` via the
+// Design-A depth-resolver machinery, plus statement-level `if` inside loop
+// bodies (the enabler for the canonical `if (c) break;` shape).
+//
+//   - A1 loop identity:  `loopLabel` on while/for/forof.* nodes, synthesised
+//     per loop by from-ast (`IrFunctionBuilder.freshLoopLabel`).
+//   - A2 branch instr:   `IrInstrBrLabel { label, mode }` — NO depth stored
+//     in the IR (a stored depth would rot under buffer re-nesting).
+//   - A3 depth resolver: `lower.ts` threads a `ctrlStack` of CtrlFrames
+//     (one per structured Wasm frame) and derives each `br` immediate at
+//     emit time; crossed try-finallys are inlined before the br.
+//   - `if.stmt`:         void statement-if in nested buffers (both arms are
+//     body-statement buffers; else may be empty).
+//
+// Semantics matrix covered here: break/continue in all five claimed loop
+// kinds (while / do-while / for / for-of vec / nested), continue-target
+// placement (pre-test while re-runs cond; for runs update; do-while falls
+// to cond; forof.vec advances the counter), break-across-try/finally
+// (finally inlined exactly once), and the slice-3 boundaries (labeled
+// break/continue not claimed).
+
+import { describe, expect, it } from "vitest";
+
+import { ts } from "../src/ts-api.js";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { verifyIrFunction } from "../src/ir/verify.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { irVal, type IrType } from "../src/ir/nodes.js";
+
+async function runIr(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts", experimentalIR: true });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imps = buildImports(r.imports as never, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps as never);
+  if (typeof (imps as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imps as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  }
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+function selectionFor(source: string): Set<string> {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+  const sel = planIrCompilation(sf, { experimentalIR: true });
+  return new Set(sel.funcs);
+}
+
+describe("#2952 slice 2 — selector claims (claim-row backed by lowering)", () => {
+  it("claims while + if(c) break", () => {
+    const claimed = selectionFor(`
+      export function test(): number {
+        let i = 0;
+        while (i < 100) {
+          if (i >= 7) { break; }
+          i++;
+        }
+        return i;
+      }
+    `);
+    expect(claimed.has("test")).toBe(true);
+  });
+
+  it("claims statement-if/else inside a loop body (no break needed)", () => {
+    const claimed = selectionFor(`
+      export function test(): number {
+        let even = 0;
+        let odd = 0;
+        for (let i = 0; i < 10; i++) {
+          if (i % 2 === 0) { even++; } else { odd++; }
+        }
+        return even * 100 + odd;
+      }
+    `);
+    expect(claimed.has("test")).toBe(true);
+  });
+
+  it("does NOT claim labeled break (slice 3 boundary)", () => {
+    const claimed = selectionFor(`
+      export function test(): number {
+        let n = 0;
+        outer: for (let i = 0; i < 3; i++) {
+          for (let j = 0; j < 3; j++) {
+            if (j === 1) { break outer; }
+            n++;
+          }
+        }
+        return n;
+      }
+    `);
+    expect(claimed.has("test")).toBe(false);
+  });
+
+  it("does NOT claim break outside any loop (inLoop gate)", () => {
+    // A try body at function top level is a body-statement context with
+    // inLoop=false — a break there is invalid JS anyway, but the gate must
+    // reject the shape rather than claim-and-throw.
+    const claimed = selectionFor(`
+      export function test(): number {
+        let n = 0;
+        try {
+          break;
+        } finally {
+          n = 1;
+        }
+        return n;
+      }
+    `);
+    expect(claimed.has("test")).toBe(false);
+  });
+});
+
+describe("#2952 slice 2 — break/continue runtime semantics", () => {
+  it("while + break exits at the guard", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let i = 0;
+          while (i < 100) {
+            if (i >= 7) { break; }
+            i++;
+          }
+          return i;
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("pre-test while + continue re-evaluates the cond", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let i = 0;
+          let sum = 0;
+          while (i < 10) {
+            i++;
+            if (i % 2 === 1) { continue; }
+            sum += i;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(30);
+  });
+
+  it("for + continue still runs the update (no infinite loop)", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let sum = 0;
+          for (let i = 0; i < 10; i++) {
+            if (i % 2 === 0) { continue; }
+            sum += i;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(25);
+  });
+
+  it("for + break", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let sum = 0;
+          for (let i = 0; i < 1000; i++) {
+            if (i === 5) { break; }
+            sum += i;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(10);
+  });
+
+  it("do-while + break (post-test, body ran)", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let i = 0;
+          do {
+            if (i === 3) { break; }
+            i++;
+          } while (i < 100);
+          return i;
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("do-while + continue falls through to the cond", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let i = 0;
+          let sum = 0;
+          do {
+            i++;
+            if (i > 5) { continue; }
+            sum += i;
+          } while (i < 10);
+          return sum;
+        }
+      `),
+    ).toBe(15);
+  });
+
+  it("for-of (vec) + break", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          const arr = [10, 20, 30, 40, 50];
+          let sum = 0;
+          for (const x of arr) {
+            if (x > 30) { break; }
+            sum += x;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(60);
+  });
+
+  it("for-of (vec) + continue advances the element counter", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          const arr = [1, 2, 3, 4, 5];
+          let sum = 0;
+          for (const x of arr) {
+            if (x === 3) { continue; }
+            sum += x;
+          }
+          return sum;
+        }
+      `),
+    ).toBe(12);
+  });
+
+  it("nested loops: unlabeled break binds the INNER loop", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let count = 0;
+          for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 10; j++) {
+              if (j === 2) { break; }
+              count++;
+            }
+          }
+          return count;
+        }
+      `),
+    ).toBe(6);
+  });
+
+  it("nested loops: unlabeled continue binds the INNER loop", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let count = 0;
+          for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 4; j++) {
+              if (j === 1) { continue; }
+              count++;
+            }
+          }
+          return count;
+        }
+      `),
+    ).toBe(9);
+  });
+
+  it("break across try/finally runs the finally exactly once per exit", async () => {
+    // 4 normal iterations + 1 break iteration = finally runs 5 times.
+    expect(
+      await runIr(`
+        export function test(): number {
+          let fin = 0;
+          let i = 0;
+          while (i < 10) {
+            try {
+              if (i === 4) { break; }
+              i++;
+            } finally {
+              fin += 100;
+            }
+          }
+          return i + fin;
+        }
+      `),
+    ).toBe(504);
+  });
+
+  it("continue across try/finally runs the finally then re-loops", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let fin = 0;
+          let sum = 0;
+          for (let i = 0; i < 5; i++) {
+            try {
+              if (i % 2 === 0) { continue; }
+              sum += i;
+            } finally {
+              fin += 1;
+            }
+          }
+          return sum * 100 + fin;
+        }
+      `),
+    ).toBe(4 * 100 + 5); // sum = 1+3, finally every iteration
+  });
+
+  it("statement-if with else in a loop body (plain adoption, no exits)", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let even = 0;
+          let odd = 0;
+          for (let i = 0; i < 10; i++) {
+            if (i % 2 === 0) { even++; } else { odd++; }
+          }
+          return even * 100 + odd;
+        }
+      `),
+    ).toBe(505);
+  });
+
+  it("conditional slot write inside an if arm survives iterations", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let last = -1;
+          let i = 0;
+          while (i < 20) {
+            if (i % 7 === 0) { last = i; }
+            i++;
+          }
+          return last;
+        }
+      `),
+    ).toBe(14);
+  });
+
+  it("dead statements after break are skipped (buffer-termination rule)", async () => {
+    expect(
+      await runIr(`
+        export function test(): number {
+          let i = 0;
+          while (i < 100) {
+            i++;
+            break;
+            i = 999;
+          }
+          return i;
+        }
+      `),
+    ).toBe(1);
+  });
+});
+
+describe("#2952 slice 2 — verifier rules (A-design)", () => {
+  const f64: IrType = irVal({ kind: "f64" });
+
+  it("rejects br.label with no enclosing loop binding the label", () => {
+    const b = new IrFunctionBuilder("bad", [f64], false);
+    b.openBlock();
+    b.emitBrLabel(b.freshLoopLabel(), "break");
+    const v = b.emitConst({ kind: "f64", value: 0 }, f64);
+    b.terminate({ kind: "return", values: [v] });
+    const errors = verifyIrFunction(b.finish());
+    expect(errors.some((e) => e.message.includes("targets no enclosing loop label"))).toBe(true);
+  });
+
+  it("accepts br.label bound by the enclosing loop and rejects a mid-buffer one", () => {
+    // while (cond) { break; }  — built directly against the builder.
+    const build = (trailingDead: boolean) => {
+      const b = new IrFunctionBuilder("f", [f64], false);
+      b.openBlock();
+      const label = b.freshLoopLabel();
+      let condV: import("../src/ir/nodes.js").IrValueId | null = null;
+      const cond = b.collectBodyInstrs(() => {
+        condV = b.emitConst({ kind: "i32", value: 1 }, irVal({ kind: "i32" }));
+      });
+      const body = b.collectBodyInstrs(() => {
+        b.emitBrLabel(label, "break");
+        if (trailingDead) {
+          void b.emitConst({ kind: "f64", value: 9 }, f64);
+        }
+      });
+      b.emitWhileLoop({ cond, condValue: condV!, body, loopLabel: label });
+      const ret = b.emitConst({ kind: "f64", value: 0 }, f64);
+      b.terminate({ kind: "return", values: [ret] });
+      return b.finish();
+    };
+    expect(verifyIrFunction(build(false))).toEqual([]);
+    const errors = verifyIrFunction(build(true));
+    expect(errors.some((e) => e.message.includes("must be the last instruction"))).toBe(true);
+  });
+});

--- a/tests/issue-2952.test.ts
+++ b/tests/issue-2952.test.ts
@@ -111,11 +111,12 @@ describe("#2952 slice 1 — IR claims do-while (post-test loops)", () => {
     ).toBe(3 * 2);
   });
 
-  it("do-while whose body has `break` is NOT claimed (multi-exit subset boundary)", () => {
-    // break/continue remain the shared #2952 structural blocker — the
-    // selector must reject a do-while body containing them so the function
-    // demotes cleanly to legacy rather than mis-lowering.
-    const claimed = selectionFor(`
+  it("do-while whose body has `break` IS claimed (slice 2 lifted the boundary)", async () => {
+    // Slice 1 rejected break/continue bodies (the multi-exit-free subset);
+    // slice 2 adopts unlabeled break/continue via `br.label` + the
+    // lowering-time depth resolver, so the same shape now claims AND runs
+    // with post-test semantics (body executes once before the break).
+    const src = `
       export function test(): number {
         let x: number = 0;
         do {
@@ -123,6 +124,23 @@ describe("#2952 slice 1 — IR claims do-while (post-test loops)", () => {
           break;
         } while (x < 5);
         return x;
+      }
+    `;
+    expect(selectionFor(src).has("test")).toBe(true);
+    expect(await runIr(src)).toBe(1);
+  });
+
+  it("LABELED break is still NOT claimed (slice 3 boundary)", () => {
+    const claimed = selectionFor(`
+      export function test(): number {
+        let n: number = 0;
+        outer: do {
+          do {
+            n = n + 1;
+            break outer;
+          } while (n < 5);
+        } while (n < 5);
+        return n;
       }
     `);
     expect(claimed.has("test")).toBe(false);


### PR DESCRIPTION
## Summary

#2952 slice 2 — IR adoption of **unlabeled `break` / `continue`** in all five claimed loop kinds (while / do-while / for / for-of vec / for-of iter / for-of string), via the banked Design-A machinery:

- **A1** — `loopLabel?: IrLabelId` on the five loop nodes; from-ast synthesises one per loop and threads it as the innermost target (`LowerCtx.loopLabel`).
- **A2** — new `IrInstrBrLabel { label, mode }`: buffer-terminating, **no stored depth** (a stored depth would rot under buffer re-nesting). Verifier rules: label must be bound by an enclosing loop in the same buffer-nesting chain; instr must be last in its buffer.
- **A3** — lowering-time `ctrlStack` depth resolver in `lower.ts`: one `CtrlFrame` per structured Wasm frame (block/loop/if/try = one label each); `br` immediates derived at emit time. Crossed try-finallys are inlined before the `br` (innermost first, self-masked), so `try { break } finally { continue }` resolves per ECMA-262 completion overriding with no CFG.
- **Discovery**: the loop-body statement grammar had **no statement-`if` at all**, so `if (c) break;` was unclaimable. Ships `IrInstrIfStmt` (void statement-if, else may be empty) as the enabler.
- Continue targets per shape: pre-test while / forof.iter → the `loop` frame; for / do-while / forof.vec / forof.string → a dedicated body-wrapping `block` emitted **only** when the body contains a continue for that label (continue-free loops stay byte-identical). forof.iter break lands exactly at `__iterator_return` — IteratorClose (§14.7.5) for free.
- Exhaustiveness handled across every pass: forEachNestedBuffer / mapNestedBuffers / directUses / effectsOf / isSideEffecting / verify / lower use-counting + local alloc / monomorphize / inline-small / backend legality (linear allow-listed — core-Wasm, backend-identical; bytecode stays rejected).
- Selector: `inLoop` gate threaded through the body-statement grammar; labeled break/continue and switch stay unclaimed (slice 3 — with the learned requirement that a labeled break crossing a `forof.iter` needs an iter-close obligation on its break frame).

## Validation

- `tests/issue-2952-slice2.test.ts` 21/21 (semantics matrix incl. exact finally counts, for-update continue, nested-loop binding, verifier rules); slice-1 suite updated 6/6.
- Loop-heavy suites (1280 / 2136 / 1169n / 1169h / 1182 / 1183 / 1169e-bridge): **108/108**.
- **Byte-inertness**: 13/13 playground corpus sha-identical with identical claim sets; 8 already-claimed loop shapes sha-identical.
- **test262 loop-statement dirs (break/continue/while/do-while/for/for-of, 1254 files): compile+run outcome diff main↔branch = zero lines.**
- Standalone target probes pass (break / continue / try-finally-break).
- Equivalence sweep (158 tests): all 71 fails reproduced identically on current origin/main (70 × pre-existing `__unbox_number` harness-stub gap in tests/ir-*-equivalence, 1 × pre-existing arguments-capture fail).
- Ratchet: `body-shape-rejected` 23→22, `call-graph-closure` 10→11 — one honest reclassification (`joinNums`: shape gate no longer binds, later closure gate does; bytes unchanged); baseline banked.
- `tsc --noEmit` clean; `gen:ir-adoption` regenerated (Break/Continue rows → mixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8