### PR TITLE
fix(website): standalone donut counts host-free passes; report page strict-off default

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -5177,15 +5177,38 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           }
           return null;
         };
+        // Standalone honesty (host-free): a "leaky pass" passed only because the
+        // compiled Wasm still reached for a JS-host import, so it is NOT a true
+        // standalone pass. Rewrite every summary-shaped node so `pass` counts
+        // host_free_pass, pushing leaky passes into fail. Keeps the standalone
+        // donut/headline consistent with the honest host-free number (matches
+        // the per-edition slider, already generated with --host-free).
+        const applyStandaloneHostFree = (node) => {
+          if (Array.isArray(node)) {
+            node.forEach(applyStandaloneHostFree);
+            return;
+          }
+          if (!node || typeof node !== "object") return;
+          if (typeof node.host_free_pass === "number" && typeof node.total === "number") {
+            const hf = node.host_free_pass;
+            const ce = Number(node.ce) || Number(node.compile_error || 0) + Number(node.compile_timeout || 0);
+            const skip = Number(node.skip) || 0;
+            node.pass = hf;
+            node.fail = Math.max(0, node.total - hf - ce - skip);
+          }
+          for (const key of Object.keys(node)) applyStandaloneHostFree(node[key]);
+        };
         const loadStandaloneReport = async (hostReport) => {
           const embedded = standalonePayloadFromHostReport(hostReport);
           if (embedded && hasUsableSummary(embedded.summary ?? embedded.official_summary)) {
+            applyStandaloneHostFree(embedded);
             return { report: embedded, source: "test262-current.json" };
           }
           for (const url of STANDALONE_TEST262_REPORT_URLS) {
             try {
               const report = await fetchJson(url);
               if (hasUsableSummary(report?.summary ?? report?.official_summary)) {
+                applyStandaloneHostFree(report);
                 return { report, source: url };
               }
             } catch {

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -1569,7 +1569,7 @@
         const controlsHost = el("div", { className: "filter-toggles", style: { marginTop: "1rem" } });
         // Strict mode toggle — checked by default, persisted in localStorage
         const strictToggle = el("label", { className: "filter-toggle" });
-        const strictDefault = localStorage.getItem("t262-strict-only") !== "false";
+        const strictDefault = localStorage.getItem("t262-strict-only") === "true";
         const strictCheckbox = el("input", { type: "checkbox" });
         if (strictDefault) strictCheckbox.setAttribute("checked", "checked");
         strictCheckbox.checked = strictDefault;
@@ -2589,6 +2589,25 @@
         }
       }
 
+      // Rewrite every summary-shaped node in a standalone report so `pass`
+      // counts only host-free passes (leaky passes → fail). Mutates in place;
+      // the standalone report object is not shared with the host report.
+      function applyStandaloneHostFree(node) {
+        if (Array.isArray(node)) {
+          node.forEach(applyStandaloneHostFree);
+          return;
+        }
+        if (!node || typeof node !== "object") return;
+        if (typeof node.host_free_pass === "number" && typeof node.total === "number") {
+          const hf = node.host_free_pass;
+          const ce = Number(node.ce) || Number(node.compile_error || 0) + Number(node.compile_timeout || 0);
+          const skip = Number(node.skip) || 0;
+          node.pass = hf;
+          node.fail = Math.max(0, node.total - hf - ce - skip);
+        }
+        for (const key of Object.keys(node)) applyStandaloneHostFree(node[key]);
+      }
+
       async function main() {
         const [conformance, standaloneReport, benchmarkHistory, snippets, conformanceRuns, categoryEditions] =
           await Promise.all([
@@ -2601,6 +2620,15 @@
           ]);
         const app = document.getElementById("app");
         app.textContent = "";
+
+        // Standalone honesty (host-free): a "leaky pass" passed only because the
+        // compiled Wasm still reached for a JS-host import, so it is NOT a true
+        // standalone pass. Count host_free_pass as pass across every
+        // summary-shaped node (overall / official / strict / full / per-scope /
+        // by_category), pushing leaky passes into fail. Keeps the standalone
+        // headline consistent with the honest host-free number (matches the
+        // per-edition slider, which is already generated with --host-free).
+        applyStandaloneHostFree(standaloneReport);
 
         if (conformance) {
           // (#2871 #1) Host (JS) vs Standalone (pure Wasm) views. Both share the


### PR DESCRIPTION
## Summary
Two conformance-display fixes so the landing and report pages agree with each other and with the published blog numbers.

**1. Standalone donut now counts host-free passes (42.7%, not 57.9%).**
The standalone donut/headline read `summary.pass` = 24,954 (**57.9%**), which includes ~6,527 *leaky passes* — tests that passed only because the compiled "standalone" Wasm still reached for a JS-host import, so they are **not** genuine standalone passes. This inflated the standalone headline ~15 points and contradicted the blog's stated 42.7%. A small in-place transform rewrites every summary-shaped node in the standalone report (overall / official / strict / full / per-scope / by_category) so `pass = host_free_pass` = 18,427 (**42.7%**), pushing leaky passes into `fail`. Host mode is untouched (74.0%). This also matches the per-edition slider, which is already generated with `--host-free`.

**2. Report page defaults strict-mode OFF.**
The report page defaulted strict ON while the landing defaults OFF, so the two showed different host numbers (75.2% vs 74.0%). Report now defaults strict OFF to match. (localStorage still persists an explicit user choice.)

Net: both pages, both modes, now show identical numbers — host **74.0%**, standalone **42.7%** — consistent with the blog.

## Test plan
- [x] Simulated the transform against the live standalone JSON: overall 18,427/43,106 = 42.7%, sanity `pass+fail+ce+skip == total`, per-category + strict summaries convert, host report unaffected
- [ ] After deploy: landing standalone donut and report standalone view both read 42.7%; host both read 74.0% with strict off by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)