### PR TITLE
feat(#2856): algorithms.ts whole-component IR slice — if/early-return in loops, element store, module-scope Map, retire #1804 guard (body-shape 22→18, call-graph 11→9)

### DIFF
--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -1,9 +1,9 @@
 ---
 id: 2856
 title: "IR: drive body-shape-rejected fallback bucket to zero (dominant unintended bucket)"
-status: blocked
-assignee: ttraenkler/sr-bodyshape2
-spec: needs-rescope
+status: in-progress
+assignee: ttraenkler/fable-2856exec
+spec: banked
 sprint: current
 created: 2026-06-30
 updated: 2026-07-03

--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -828,11 +828,12 @@ from the working `for-of` vec path). `main` has both `const sorted = [1,3,…]`
 
 ## Slice RESULTS — algorithms.ts whole-component (2026-07-04, fable-2856exec)
 
-**Gate: `body-shape-rejected` 23 → 18 (−5), `call-graph-closure` 10 → 9 (−1
-bonus), `class-method` unchanged, post-claim demotions ZERO.** Net unintended
-38 → 32, banked via `--update-on-decrease`. (The plan's "25→20" numbers were
-grounded pre-#3000; the private-field pair had already cleared, so the live
-baseline was 23/10/5 — the −5 is the same five algorithms.ts functions.)
+**Gate: `body-shape-rejected` → 18, `call-graph-closure` → 9, `class-method`
+unchanged, post-claim demotions ZERO.** Relative to the pre-slice base
+(23/10/5) that is −5/−1; relative to post-#2952-slice-2 main (22/11/5, which
+this branch merged mid-flight) it is −4/−2. Net unintended 38 → 32 either
+way, banked in `scripts/ir-fallback-baseline.json`. (The plan's "25→20"
+numbers were grounded pre-#3000; the private-field pair had already cleared.)
 Whole-file verification: `js/algorithms.ts` IR-vs-legacy **console output
 identical (20/20 lines)**, zero demotions; standalone + wasi compiles stay
 clean (host-gated arms defer → legacy, as designed).
@@ -931,3 +932,31 @@ chains), classes.ts main (`instanceof`), async delay (Promise executor).
 This slice (−5 algorithms.ts component + −1 call-graph bonus) is merged
 work; the next executable slice per the Step-2 ordering is the
 benchmark-harness cluster AFTER #2858.
+
+### Post-merge reconciliation with #2952 slice 2 (same-day upstream landing)
+
+#2952 slice 2 landed mid-flight with a CONVERGENT `if.stmt` design (identical
+node shape) plus `br.label` break/continue and a ctrlStack depth resolver.
+Reconciliation on this branch: upstream's `if.stmt` + `emitBufferAsStatements`
++ ctrlStack machinery adopted wholesale (their arm pushes the plain CtrlFrames
+br.label depth-derivation needs; their `lowerIfBodyStatement` also upgrades
+the cond to truthiness via `coerceLoopCondToBool`); my duplicate `if.stmt`
+implementation deleted at every layer; `early.return` (mine alone) kept and
+now rides their emission helper. The #2856 zero-use side-effect fix collapsed
+from seven emission-loop sites into upstream's single `emitBufferAsStatements`
+(+ the remaining per-arm loops). Early-return barriers and #2952's `inLoop`
+threading coexist: break/continue may cross a try (br.label inlines crossed
+finallys) while early-return stays barred there. Verified post-merge:
+gate 18/9/5, cluster suite 18/18, #2952 suite 27/27, and a combined probe
+(`continue` + early `return` + `break` in one loop) claims with legacy parity.
+
+### Post-slice regression caught by the equivalence sweep (fixed in-branch)
+
+`void x === undefined` — the undefined-compare constant-fold was initially
+REP-based (f64 can't hold undefined), but the IR erases `void x` (static type
+`undefined`) into f64 NaN, folding the comparison to false where JS says
+true. Fix: the fold now ALSO requires the checker's static type to exclude
+undefined/void/any/unknown; undefined-able static types demote to legacy
+(which tracks undefined-ness). Full `tests/equivalence/` sweep on the final
+tree matches the pristine-main baseline (all remaining failures pre-existing
+container-env issues, verified side-by-side).

--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -1,8 +1,8 @@
 ---
 id: 2856
 title: "IR: drive body-shape-rejected fallback bucket to zero (dominant unintended bucket)"
-status: in-progress
-assignee: ttraenkler/fable-2856exec
+status: blocked
+assignee:
 spec: banked
 sprint: current
 created: 2026-06-30
@@ -825,3 +825,109 @@ from the working `for-of` vec path). `main` has both `const sorted = [1,3,…]`
 - `tests/ir-algorithms-cluster.test.ts` (new) — per-capability claim tests +
   the mixed IR/legacy module-global round-trip equivalence test.
 - `scripts/ir-fallback-baseline.json` — ratchet `body-shape-rejected` 25→20.
+
+## Slice RESULTS — algorithms.ts whole-component (2026-07-04, fable-2856exec)
+
+**Gate: `body-shape-rejected` 23 → 18 (−5), `call-graph-closure` 10 → 9 (−1
+bonus), `class-method` unchanged, post-claim demotions ZERO.** Net unintended
+38 → 32, banked via `--update-on-decrease`. (The plan's "25→20" numbers were
+grounded pre-#3000; the private-field pair had already cleared, so the live
+baseline was 23/10/5 — the −5 is the same five algorithms.ts functions.)
+Whole-file verification: `js/algorithms.ts` IR-vs-legacy **console output
+identical (20/20 lines)**, zero demotions; standalone + wasi compiles stay
+clean (host-gated arms defer → legacy, as designed).
+
+### What landed, per capability (and WHY it's shaped that way)
+
+- **C1 — `if.stmt` + `early.return` IR instrs** (`nodes.ts`): statement-level
+  `if` (else optional, no carrier values — the #1392 value-`if` requires
+  both) and early-return (lowers to the Wasm `return` op, which natively
+  unwinds the `block{loop{…}}` nesting). Soundness scope is selector-enforced
+  and mirrored in from-ast (`cx.noEarlyReturn` / module-level
+  `earlyReturnLoopDepth`/`BarrierDepth` counters): early return is accepted
+  ONLY inside C-style `while`/`for`/`do` bodies with NO enclosing for-of
+  (iterator `return()` cleanup would be skipped), try/catch/finally (inlined
+  finally skipped), constructor (implicit `return this` synthesis), or
+  generator (buffer epilogue). A regression test pins the try/finally case to
+  legacy. Both kinds are excluded from `inline-small` (buffer-bearing /
+  caller-exit).
+- **C2 — element store** via an on-demand `__vec_elem_set_<vecTypeIdx>`
+  helper (`src/codegen/vec-elem-set.ts`, materialized through the
+  `resolveFunc` intercept like `ensureFmod`, #2945). NOT a new IR instr and
+  NOT a bare `array.set`: the helper carries the FULL legacy semantics
+  (null-guard → throw, grow-on-OOB with capacity doubling + copy, length
+  update) because the growing write (`a[i] = v` past the end) is common in
+  newly-claimable code — a bare store would trap. Pure WasmGC, no host
+  import (dual-mode clean). TypedArray-view receivers demote
+  (per-view ToUint8/clamp conversions stay legacy); selector restricts the
+  receiver to a plain in-scope identifier.
+- **C3 — module-scope Map** WITHOUT a Map-in-IR predecessor: module-level
+  statements always compile via legacy, so `const m = new Map()` already has
+  a legacy `__mod_<m>` externref global + `Map_new/Map_get/Map_set` extern
+  imports (JS-host lane). The IR side only needed: (a) a TDZ-checked
+  `global.get $__mod_<m>` branded `extern:Map` in the identifier arm
+  (storage-slot parity BY CONSTRUCTION — same global, name-resolved), after
+  which `.get`/`.set` ride the existing extern method-call machinery; (b)
+  `f64→externref` arg boxing via `__box_number` and `externref→f64` return
+  unboxing via `__unbox_number` in the coercion arms (exactly legacy's
+  emission for the same sites, so the imports are registered by legacy's own
+  compile of the function — dual-compile model); (c) strict undefined-compare
+  (`hit !== undefined`) → `__extern_is_undefined` on externref-shaped
+  operands, constant-fold on never-undefined representations. LOOSE `==
+  undefined` stays legacy (null == undefined needs a null check). Host lane
+  only — standalone's native Map runtime is NOT wired; fibMemo correctly
+  demotes there (the selector's Map-const set is empty outside the host
+  lane, so no claim-then-fail).
+- **C4 — #1804 guard retired**: the unsound shape it protected was fixed by
+  the slice-12 buffer machinery (synthetic −1 block-id use recording
+  materializes the constructed vec into a local before the loop op).
+  Verified with a 7-shape battery (read-in-body/cond, construct-in-body,
+  after-loop, nested, do-while, store-in-loop), each proven CLAIMED via
+  byte-diff (not vacuously green). Plus: call-arg `ref → ref_null` widening
+  (`irTypeArgAssignable` — a vec literal is `(ref $vec)`, params are
+  `(ref null $vec)`), and statement-position VOID direct calls
+  (`quicksort(arr, lo, p-1);` — `lowerCall(…, statementPosition)`).
+
+### Two latent lower.ts/passes bugs found & fixed en route
+
+1. **`inline-small` corrupted value-`if` arm buffers** — `renameAllInInstr`
+   doesn't deep-rename arm-buffer DEFS, so inlining a single-block callee
+   containing an `if` (any bounds-checked `a[i]` read emits one) produced
+   duplicate SSA defs → silent post-inline demote. Latent on main (the
+   ref/ref_null arg mismatch demoted such callers at build first); exposed by
+   C4's widening. Fix: `if` joins the buffer-bearing exclusion list in
+   `canInline`.
+2. **Nested-buffer emission silently DROPPED zero-use side-effecting
+   instrs** — all seven buffer-emission loops in `lower.ts` (loop bodies,
+   for-of bodies, try bodies, if arms) lacked `emitBlockBody`'s
+   "zero uses + side-effecting → eager emit + drop" arm, so a statement call
+   with an unused non-void result inside a loop body (e.g.
+   `shared.set(k, v)` — Map_set returns the map) emitted NOTHING. Caught by
+   the mixed-front-end storage-parity test (IR writer's write never
+   happened). Fix applied uniformly to all seven sites.
+
+### Verification record
+
+- `tests/ir-algorithms-cluster.test.ts` (new, 18 tests): per-capability
+  legacy/IR parity, each claim-proven via byte-diff (anti-vacuity); growing
+  store; mixed IR-writer/legacy-reader Map storage parity; try/finally
+  early-return negative; whole-component e2e console equality; standalone/
+  wasi cleanliness.
+- IR suite (`tests/ir-*`, issue-*-ir tests): per-file failure counts
+  IDENTICAL to pristine main (the ~81 container-env failures are
+  pre-existing; verified side-by-side) except `ir-scaffold`'s expected-claims
+  list, updated for `withWhile` (legitimate capability growth).
+- Byte-inertness for non-claimed programs: by construction — no legacy
+  codegen path was modified (the only `src/codegen/` change is the NEW
+  helper file, reachable only from the IR resolver).
+
+### Epic status after this slice
+
+`status: blocked` stands for the EPIC (bucket 18, not 0): the remaining
+clusters are the benchmark-harness 8 (hard-blocked BY #2858 cross-module
+calls + first-class function values), bench_array ×2 (ArrayType annotation +
+`.push` growable-array IR), calendar 5 (mutable module-scope bindings + DOM
+chains), classes.ts main (`instanceof`), async delay (Promise executor).
+This slice (−5 algorithms.ts component + −1 call-graph bonus) is merged
+work; the next executable slice per the Step-2 ordering is the
+benchmark-harness cluster AFTER #2858.

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,8 +1,8 @@
 {
-  "generated": "2026-07-03",
+  "generated": "2026-07-04",
   "unintended": {
-    "body-shape-rejected": 23,
-    "call-graph-closure": 10,
+    "body-shape-rejected": 18,
+    "call-graph-closure": 9,
     "class-method": 5
   },
   "deferred": {

--- a/src/codegen/vec-elem-set.ts
+++ b/src/codegen/vec-elem-set.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#2856 C2) On-demand `__vec_elem_set_<vecTypeIdx>` helper — the IR's
+// element-store dual of the legacy inline `compileElementAssignment` vec
+// path (src/codegen/expressions/assignment.ts). One defined function per
+// vec struct type, materialized lazily via the IR resolver's `resolveFunc`
+// interception (same append-only discipline as `ensureFmod`, #2945 — a
+// DEFINED function appended at mint time, never an import, so no existing
+// funcIdx shifts).
+//
+// Semantics — EXACT legacy parity (JS `arr[i] = v` on a growable vec):
+//   1. Null receiver → throw TypeError (`ref.null.extern` payload on the
+//      shared `__exn` tag) — the legacy null-guard shape (#441).
+//   2. idx >= capacity → grow the backing array to
+//      `max(idx + 1, oldCap * 2, 4)`, copy the old contents, and point the
+//      vec's `data` field at the new array (legacy grow sequence,
+//      assignment.ts:4094-4178).
+//   3. `data[idx] = val`.
+//   4. idx + 1 > vec.length → vec.length = idx + 1 (JS length update on
+//      OOB writes).
+//
+// The helper is pure WasmGC — no host import — so it works identically in
+// JS-host and standalone modes (the dual-mode rule).
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import type { CodegenContext } from "./context/types.js";
+import { addFuncType } from "./registry/types.js";
+import { ensureExnTag } from "./registry/imports.js";
+
+/** Reserved name prefix; the suffix is the vec STRUCT typeIdx. */
+export const VEC_ELEM_SET_PREFIX = "__vec_elem_set_";
+
+/**
+ * Ensure the element-store helper for the vec struct at `vecTypeIdx` exists
+ * and return its funcIdx. Idempotent (funcMap-cached by name).
+ *
+ * Signature: `((ref null $vec_<t>) vec, i32 idx, <elem> val) -> ()`.
+ *
+ * Returns `null` (no helper) when `vecTypeIdx` doesn't name a recognisable
+ * `{ length: i32, data: (ref $arr) }` vec struct — the caller treats that
+ * as a clean IR demotion.
+ */
+export function ensureVecElemSet(ctx: CodegenContext, vecTypeIdx: number): number | null {
+  const name = `${VEC_ELEM_SET_PREFIX}${vecTypeIdx}`;
+  const existing = ctx.funcMap.get(name);
+  if (existing !== undefined) return existing;
+
+  const vecDef = ctx.mod.types[vecTypeIdx];
+  if (!vecDef || vecDef.kind !== "struct" || vecDef.fields.length !== 2) return null;
+  if (vecDef.fields[0]?.name !== "length" || vecDef.fields[1]?.name !== "data") return null;
+  const dataField = vecDef.fields[1]!.type;
+  if (dataField.kind !== "ref" && dataField.kind !== "ref_null") return null;
+  const arrTypeIdx = (dataField as { typeIdx: number }).typeIdx;
+  const arrDef = ctx.mod.types[arrTypeIdx];
+  if (!arrDef || arrDef.kind !== "array") return null;
+  // Packed i8/i16 elements have no value-position encoding for the `val`
+  // param (#2159) — those vecs back TypedArrays, which the IR element-store
+  // arm refuses at from-ast time anyway. Refuse here too, defensively.
+  const elem = arrDef.element;
+  if (elem.kind === "i8" || elem.kind === "i16") return null;
+
+  const tagIdx = ensureExnTag(ctx);
+  const vecParam: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
+  const sigIdx = addFuncType(ctx, [vecParam, { kind: "i32" }, elem], [], `$${name}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+
+  // Params: 0=vec, 1=idx, 2=val. Locals: 3=data, 4=newCap, 5=newData, 6=oldCap.
+  const VEC = 0;
+  const IDX = 1;
+  const VAL = 2;
+  const DATA = 3;
+  const NCAP = 4;
+  const NDATA = 5;
+  const OCAP = 6;
+
+  const body: Instr[] = [
+    // ── Null guard (#441 parity): if (vec == null) throw TypeError ─────────
+    { op: "local.get", index: VEC },
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "ref.null.extern" } as Instr, { op: "throw", tagIdx } as Instr],
+      else: [],
+    } as Instr,
+    // ── data = vec.data ─────────────────────────────────────────────────────
+    { op: "local.get", index: VEC },
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.set", index: DATA },
+    // ── Grow when idx >= capacity (legacy sequence) ─────────────────────────
+    { op: "local.get", index: IDX },
+    { op: "local.get", index: DATA },
+    { op: "array.len" } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // oldCap = array.len(data)
+        { op: "local.get", index: DATA } as Instr,
+        { op: "array.len" } as Instr,
+        { op: "local.set", index: OCAP } as Instr,
+        // newCap = idx + 1
+        { op: "local.get", index: IDX } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.add" } as Instr,
+        { op: "local.set", index: NCAP } as Instr,
+        // if (oldCap * 2 > newCap) newCap = oldCap * 2
+        { op: "local.get", index: OCAP } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.shl" } as Instr,
+        { op: "local.get", index: NCAP } as Instr,
+        { op: "i32.gt_s" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: OCAP } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.shl" } as Instr,
+            { op: "local.set", index: NCAP } as Instr,
+          ],
+        } as Instr,
+        // if (4 > newCap) newCap = 4
+        { op: "i32.const", value: 4 } as Instr,
+        { op: "local.get", index: NCAP } as Instr,
+        { op: "i32.gt_s" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "i32.const", value: 4 } as Instr, { op: "local.set", index: NCAP } as Instr],
+        } as Instr,
+        // newData = array.new_default(newCap)
+        { op: "local.get", index: NCAP } as Instr,
+        { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+        { op: "local.set", index: NDATA } as Instr,
+        // array.copy newData[0..oldCap] = data[0..oldCap]
+        { op: "local.get", index: NDATA } as Instr,
+        { op: "i32.const", value: 0 } as Instr,
+        { op: "local.get", index: DATA } as Instr,
+        { op: "i32.const", value: 0 } as Instr,
+        { op: "local.get", index: OCAP } as Instr,
+        { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+        // vec.data = newData
+        { op: "local.get", index: VEC } as Instr,
+        { op: "local.get", index: NDATA } as Instr,
+        { op: "ref.as_non_null" } as Instr,
+        { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+        // data = newData
+        { op: "local.get", index: NDATA } as Instr,
+        { op: "local.set", index: DATA } as Instr,
+      ],
+    } as Instr,
+    // ── data[idx] = val ─────────────────────────────────────────────────────
+    { op: "local.get", index: DATA },
+    { op: "local.get", index: IDX },
+    { op: "local.get", index: VAL },
+    { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+    // ── if (idx + 1 > vec.length) vec.length = idx + 1 ─────────────────────
+    { op: "local.get", index: IDX },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.get", index: VEC },
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "i32.gt_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: VEC } as Instr,
+        { op: "local.get", index: IDX } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "i32.add" } as Instr,
+        { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+      ],
+    } as Instr,
+  ];
+
+  const fn: WasmFunction = {
+    name,
+    typeIdx: sigIdx,
+    locals: [
+      { name: "$data", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+      { name: "$ncap", type: { kind: "i32" } },
+      { name: "$ndata", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
+      { name: "$ocap", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  };
+  pushDefinedFunc(ctx, funcIdx, fn);
+  ctx.funcMap.set(name, funcIdx);
+  return funcIdx;
+}

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -1123,6 +1123,35 @@ export class IrFunctionBuilder {
   }
 
   /**
+   * (#2856) Emit a statement-level `if (cond) { then } [else { else }]`
+   * inside a body buffer. Both arms are pre-collected instruction buffers
+   * (via `collectBodyInstrs`); `elseInstrs` is the empty array when the
+   * source has no else clause. Produces no SSA value.
+   */
+  emitIfStmt(args: { cond: IrValueId; then: readonly IrInstr[]; else: readonly IrInstr[] }): void {
+    this.pushInstr({
+      kind: "if.stmt",
+      cond: args.cond,
+      then: args.then,
+      else: args.else,
+      result: null,
+      resultType: null,
+    });
+  }
+
+  /**
+   * (#2856) Emit an early `return [value]` from inside a nested body buffer
+   * (loop bodies / if.stmt arms). Lowers to the Wasm `return` op. `value`
+   * is null for a bare `return;` in a void function; otherwise it must
+   * already be coerced to the function's declared result type. See
+   * `IrInstrEarlyReturn` for the soundness scope (no try/finally, no
+   * iterator-protocol for-of, no generators — selector/from-ast enforced).
+   */
+  emitEarlyReturn(value: IrValueId | null): void {
+    this.pushInstr({ kind: "early.return", value, result: null, resultType: null });
+  }
+
+  /**
    * Slice 9 (#1169h): emit a `try` instruction with a body, optional catch
    * handler, and optional finally body. Mirrors the for-of declarative
    * shape — the caller pre-collects each buffer via `collectBodyInstrs`.

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -235,6 +235,18 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
       mergeBuffer(instr.then);
       mergeBuffer(instr.else);
       break;
+    // (#2856) Statement-level if — same buffer merge as the value form.
+    case "if.stmt":
+      mergeBuffer(instr.then);
+      mergeBuffer(instr.else);
+      break;
+    // (#2856) Early return is a control effect (like throw): never
+    // reordered, CSE'd, or dropped — treat as a full barrier.
+    case "early.return":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.control = true;
+      break;
     default: {
       // Future instruction kinds default to a full barrier so a new kind can
       // never silently become re-orderable.
@@ -492,6 +504,13 @@ export function isSideEffecting(i: IrInstr): boolean {
     // this — even unused-result awaits need to suspend.
     i.kind === "await" ||
     i.kind === "async.return" ||
-    i.kind === "async.throw"
+    i.kind === "async.throw" ||
+    // (#2856) Statement-level control flow: if.stmt runs its arm buffers for
+    // effect (result: null — the generic null-result rule also keeps it, but
+    // seeding here makes `collectUses(_, { deep: true })` walk its buffers,
+    // same rationale as while.loop/for.loop). early.return is a control
+    // transfer — never droppable.
+    i.kind === "if.stmt" ||
+    i.kind === "early.return"
   );
 }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -197,6 +197,34 @@ export interface IrFromAstResolver {
         resultClassName?: string;
       }
     | undefined;
+  /**
+   * (#2856 C2) True when `expr`'s checker type names a TypedArray-family
+   * view (Uint8Array, Int16Array, Uint8ClampedArray, …, or a subarray
+   * view). Element WRITES on those carry per-view conversion semantics
+   * (ToUint8 / ToUint8Clamp / packed-storage truncation — see the legacy
+   * `compileElementAssignment` view arms) that the plain vec store helper
+   * must not bypass, so `lowerElementStore` demotes them to legacy.
+   * Element READS are unaffected (value-identical to plain vec reads).
+   */
+  isTypedArrayViewExpr?(expr: ts.Expression): boolean;
+  /**
+   * (#2856 C3) Resolve a module-scope `const`/`let` binding to the Wasm
+   * global (and optional TDZ flag global) the legacy backend allocated for
+   * it, plus the extern-class brand of its value when the binding holds a
+   * host object (e.g. `const cache = new Map()` → className "Map").
+   * Returns `undefined` when the name isn't a registered module global or
+   * its value isn't an externref-shaped extern-class instance.
+   */
+  getModuleScopeExternBinding?(name: string):
+    | {
+        /** Name of the value global in `ctx.mod.globals` (`__mod_<name>`). */
+        globalName: string;
+        /** Name of the i32 TDZ flag global, or null when TDZ was elided. */
+        tdzGlobalName: string | null;
+        /** Registered extern class of the held value (e.g. "Map"). */
+        className: string;
+      }
+    | undefined;
 }
 
 export interface AstToIrOptions {
@@ -540,8 +568,9 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
         }
         // The result SSA value is unused; DCE strips it if pure.
         // closure.call and call are flagged side-effecting in dead-code
-        // so they stay live.
-        void lowerExpr(s.expression, cx, irVal({ kind: "f64" }));
+        // so they stay live. (#2856 C4) Statement position — a VOID direct
+        // call (`quicksort(arr, lo, p - 1);`) is legal here.
+        void lowerCall(s.expression, cx, /* statementPosition */ true);
         continue;
       }
       // Slice 7a (#1169f): `yield <expr>;` as a top-level statement.
@@ -558,6 +587,16 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
         ts.isPropertyAccessExpression(s.expression.left)
       ) {
         lowerPropertyAssignment(s.expression, cx);
+        continue;
+      }
+      // (#2856 C2) element store `arr[i] = v;` as a non-tail statement —
+      // quicksort's post-partition swap writes live here (outside any loop).
+      if (
+        ts.isBinaryExpression(s.expression) &&
+        s.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isElementAccessExpression(s.expression.left)
+      ) {
+        lowerElementStore(s.expression.left, s.expression.right, cx);
         continue;
       }
       throw new Error(`ir/from-ast: unsupported ExpressionStatement shape in ${cx.funcName}`);
@@ -972,6 +1011,17 @@ interface LowerCtx {
    * unproven read falls to the SAFE bounds-checked read (no trap).
    */
   readonly safeIndexedArrays?: ReadonlySet<string>;
+  /**
+   * (#2856) Early-return barrier. Set `true` for statement buffers where a
+   * Wasm-`return`-based early exit is UNSOUND: for-of bodies (an iterator-
+   * protocol drive would skip its `iter.return` cleanup) and try/catch/
+   * finally bodies (a Wasm return skips the inlined finally). `lowerStmt`'s
+   * ReturnStatement arm throws (→ clean legacy demote) when set. Plain
+   * while/for/do bodies inherit the surrounding value, so a loop nested
+   * inside a try correctly stays barred. Mirrored by the selector's
+   * `earlyReturnBarrierDepth` so accepted shapes always lower.
+   */
+  readonly noEarlyReturn?: boolean;
 }
 
 /**
@@ -1540,7 +1590,13 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
     return lowerConditional(expr, cx);
   }
   if (ts.isCallExpression(expr)) {
-    return lowerCall(expr, cx);
+    const callResult = lowerCall(expr, cx);
+    if (callResult === null) {
+      // Unreachable: expression position (statementPosition=false) throws
+      // before returning null.
+      throw new Error(`ir/from-ast: void call in expression position (${cx.funcName})`);
+    }
+    return callResult;
   }
   // Slice 4 (#1169d): class instantiation. Lookup must succeed against
   // the class registry seeded from `ctx.classShapes`; if not, the
@@ -2296,6 +2352,78 @@ function emitSafeVecGet(recv: IrValueId, idxI32: IrValueId, elemValType: ValType
  * out of slice 2's scope and throw, so the function falls back to
  * legacy.
  */
+/**
+ * (#2856 C2) Lower an element STORE `arr[i] = v;` in statement position —
+ * the write dual of `lowerElementAccess`'s vec arm. Dispatches to the
+ * per-vec-type `__vec_elem_set_<vecTypeIdx>` helper (materialized on demand
+ * by the resolver's `resolveFunc`, see src/codegen/vec-elem-set.ts), which
+ * carries the FULL legacy semantics: null-guard, grow-on-OOB (capacity
+ * doubling + data copy), the store, and the JS length update. A bare
+ * `array.set` would trap on the growing-write pattern (`a[i] = v` past the
+ * end), which is common in newly-claimed code — so the helper is the only
+ * sound lowering.
+ *
+ * Demotes (clean throw → legacy) for: TypedArray-view receivers (per-view
+ * conversion semantics — ToUint8/clamp/packing), non-vec receivers
+ * (externref objects, strings), packed/exotic element kinds, and value
+ * types that don't coerce to the element type.
+ */
+function lowerElementStore(lhs: ts.ElementAccessExpression, rhs: ts.Expression, cx: LowerCtx): void {
+  if (lhs.questionDotToken) {
+    throw new Error(`ir/from-ast: optional element store (a?.[i] = v) not in IR scope (${cx.funcName})`);
+  }
+  // TypedArray views need the legacy per-view value conversions.
+  if (cx.resolver?.isTypedArrayViewExpr?.(lhs.expression)) {
+    throw new Error(`ir/from-ast: element store on a TypedArray view not in IR scope (${cx.funcName})`);
+  }
+  const recv = lowerExpr(lhs.expression, cx, irVal({ kind: "f64" }));
+  const recvType = cx.builder.typeOf(recv);
+  const recvVal = asVal(recvType);
+  if (!recvVal || (recvVal.kind !== "ref" && recvVal.kind !== "ref_null")) {
+    throw new Error(`ir/from-ast: element store on ${describeIrType(recvType)} not in IR scope (${cx.funcName})`);
+  }
+  const vec = cx.resolver?.resolveVec?.(recvVal);
+  if (!vec) {
+    throw new Error(`ir/from-ast: element-store receiver is not a recognisable vec in ${cx.funcName}`);
+  }
+  const elem = vec.elementValType;
+  // Narrow slice: f64 vecs (number[]) and externref vecs (string[]/any[] in
+  // host mode). Native-string / packed / exotic element vecs demote.
+  if (elem.kind !== "f64" && elem.kind !== "externref") {
+    throw new Error(`ir/from-ast: element store into '${elem.kind}' vec not in IR scope (${cx.funcName})`);
+  }
+  // Index — the same f64-lower + trunc_sat discipline as the read path.
+  const idxRaw = lowerExpr(lhs.argumentExpression, cx, irVal({ kind: "f64" }));
+  const idxTy = asVal(cx.builder.typeOf(idxRaw));
+  let idxI32: IrValueId;
+  if (idxTy?.kind === "i32") {
+    idxI32 = idxRaw;
+  } else if (idxTy?.kind === "f64") {
+    idxI32 = cx.builder.emitUnary("i32.trunc_sat_f64_s", idxRaw, irVal({ kind: "i32" }));
+  } else {
+    throw new Error(`ir/from-ast: element-store index must be number or bool in ${cx.funcName}`);
+  }
+  // Value — lower with the element-type hint, then coerce.
+  const valRaw = lowerExpr(rhs, cx, irVal(elem));
+  let val: IrValueId;
+  if (elem.kind === "f64") {
+    const valTy = asVal(cx.builder.typeOf(valRaw));
+    if (valTy?.kind !== "f64") {
+      throw new Error(
+        `ir/from-ast: element-store value ${describeIrType(cx.builder.typeOf(valRaw))} into f64 vec ` +
+          `not in IR scope (${cx.funcName})`,
+      );
+    }
+    val = valRaw;
+  } else {
+    val = coerceToExpectedExtern(valRaw, elem, cx, `element-store value`);
+  }
+  // The helper name embeds the vec STRUCT typeIdx; the lower-time resolver
+  // intercepts the prefix and materializes the helper on demand (name-based
+  // resolution — funcIdx-shift safe by construction).
+  cx.builder.emitCall({ kind: "func", name: `__vec_elem_set_${vec.vecStructTypeIdx}` }, [recv, idxI32, val], null);
+}
+
 function lowerElementAccess(expr: ts.ElementAccessExpression, cx: LowerCtx): IrValueId {
   // #2713 — `a?.[i]` carries a `questionDotToken`: on a `null`/`undefined`
   // receiver the access must short-circuit to `undefined`, not index it.
@@ -2442,7 +2570,7 @@ function phase1PropertyName(name: ts.PropertyName): string | null {
  * or the propagation pass converged on a dynamic type that the selector
  * ignored — both are bugs.
  */
-function lowerCall(expr: ts.CallExpression, cx: LowerCtx): IrValueId {
+function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = false): IrValueId | null {
   // Optional call (`fn?.()` / `obj?.method()`, #1281). The IR has no
   // short-circuit primitive for nullable callees, and at this point we
   // haven't yet lowered the callee/receiver to inspect its IrType. The
@@ -2506,7 +2634,7 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx): IrValueId {
     const expected = calleeSig.params[i]!;
     const argVal = lowerExpr(argExpr, cx, expected);
     const argType = cx.builder.typeOf(argVal);
-    if (!irTypeEquals(argType, expected)) {
+    if (!irTypeArgAssignable(argType, expected)) {
       throw new Error(
         `ir/from-ast: arg ${i} of call to ${calleeName} is ${describeIrType(argType)}, expected ${describeIrType(expected)} in ${cx.funcName}`,
       );
@@ -2515,9 +2643,38 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx): IrValueId {
   }
   const result = cx.builder.emitCall({ kind: "func", name: calleeName }, args, calleeSig.returnType);
   if (result === null) {
+    // (#2856 C4) `quicksort(arr, lo, p - 1);` — a void direct call in
+    // STATEMENT position is legal (the recursion driver shape). Expression
+    // position keeps throwing.
+    if (statementPosition) return null;
     throw new Error(`ir/from-ast: call to ${calleeName} returned void used as expression in ${cx.funcName}`);
   }
   return result;
+}
+
+/**
+ * (#2856 C4) Wasm-level assignability for direct-call arguments. Exact
+ * IrType equality, plus the one sound widening the vec-literal-as-argument
+ * shape needs: a NON-NULL `(ref $T)` value passed where the callee's param
+ * is `(ref null $T)` — a Wasm subtype, so the call validates and the callee
+ * observes the identical value. (`const sorted = [1, 3, 5]` produces
+ * `(ref $vec_f64)` via `vec.new_fixed`; a `number[]` param resolves as
+ * `(ref null $vec_f64)`.) The reverse (ref_null → ref) stays rejected.
+ */
+function irTypeArgAssignable(actual: IrType, expected: IrType): boolean {
+  if (irTypeEquals(actual, expected)) return true;
+  const a = asVal(actual);
+  const e = asVal(expected);
+  if (
+    a !== null &&
+    e !== null &&
+    a.kind === "ref" &&
+    e.kind === "ref_null" &&
+    (a as { typeIdx: number }).typeIdx === (e as { typeIdx: number }).typeIdx
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -3982,7 +4139,7 @@ function lowerForOfIterFromExternrefValue(
   const elemIrT: IrType = irVal({ kind: "externref" });
   const bodyScope = new Map(cx.scope);
   bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
-  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope, noEarlyReturn: true };
 
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
@@ -4042,7 +4199,7 @@ function lowerForOfString(stmt: ts.ForOfStatement, cx: LowerCtx, strV: IrValueId
     type: elemIrT,
     asType: { kind: "string" },
   });
-  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope, noEarlyReturn: true };
 
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
@@ -4104,7 +4261,7 @@ function lowerForOfVec(
 
   const bodyScope = new Map(cx.scope);
   bodyScope.set(loopVarName, { kind: "slot", slotIndex: elementSlot, type: elemIrT });
-  const bodyCx: LowerCtx = { ...cx, scope: bodyScope };
+  const bodyCx: LowerCtx = { ...cx, scope: bodyScope, noEarlyReturn: true };
 
   const body = cx.builder.collectBodyInstrs(() => {
     lowerStmt(stmt.statement, bodyCx);
@@ -4230,6 +4387,11 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
           lowerPropertyAssignment(stmt.expression, cx);
           return;
         }
+        // (#2856 C2) element store `arr[i] = v;` in a body buffer.
+        if (ts.isElementAccessExpression(stmt.expression.left)) {
+          lowerElementStore(stmt.expression.left, stmt.expression.right, cx);
+          return;
+        }
       }
       // Compound assignment `<id> <op>= <expr>` — desugar to
       // `<id> = <id> <binop> <expr>`. The binop maps from the
@@ -4292,7 +4454,89 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
     lowerTryStatement(stmt, cx);
     return;
   }
+  // (#2856 C1) Statement-level `if` inside a body buffer — `if (arr[j] <=
+  // pivot) { ...swap... }` in a loop body, `if (i > 0) s = s + ","`, or the
+  // if/else halving step in binarySearch. Both arms are statement buffers;
+  // else is optional.
+  if (ts.isIfStatement(stmt)) {
+    lowerIfBodyStatement(stmt, cx);
+    return;
+  }
+  // (#2856 C1) Early `return` inside a body buffer — `if (v === target)
+  // return mid;` inside a while loop. Lowers to the Wasm `return` op via
+  // the `early.return` instr. Guarded against contexts where that is
+  // unsound (generators, try/finally, iterator-protocol for-of) — the
+  // selector mirrors these guards so accepted shapes always lower.
+  if (ts.isReturnStatement(stmt)) {
+    lowerEarlyReturn(stmt, cx);
+    return;
+  }
   throw new Error(`ir/from-ast: unsupported body statement ${ts.SyntaxKind[stmt.kind]} in ${cx.funcName}`);
+}
+
+/**
+ * (#2856 C1) Lower `if (cond) <then> [else <else>]` in body-statement
+ * position to the void `if.stmt` instr. Constant conditions fold to the
+ * live arm only (same #1043 --define elision the statement-list path has).
+ */
+function lowerIfBodyStatement(stmt: ts.IfStatement, cx: LowerCtx): void {
+  const constResult = evaluateConstantCondition(stmt.expression);
+  if (constResult !== undefined) {
+    if (constResult) {
+      lowerStmt(stmt.thenStatement, { ...cx, scope: new Map(cx.scope) });
+    } else if (stmt.elseStatement) {
+      lowerStmt(stmt.elseStatement, { ...cx, scope: new Map(cx.scope) });
+    }
+    return;
+  }
+  const cond = lowerExpr(stmt.expression, cx, irVal({ kind: "i32" }));
+  const condType = cx.builder.typeOf(cond);
+  if (asVal(condType)?.kind !== "i32") {
+    throw new Error(`ir/from-ast: body-if condition must be bool in ${cx.funcName}`);
+  }
+  const thenBody = cx.builder.collectBodyInstrs(() => {
+    lowerStmt(stmt.thenStatement, { ...cx, scope: new Map(cx.scope) });
+  });
+  const elseBody = stmt.elseStatement
+    ? cx.builder.collectBodyInstrs(() => {
+        lowerStmt(stmt.elseStatement!, { ...cx, scope: new Map(cx.scope) });
+      })
+    : [];
+  cx.builder.emitIfStmt({ cond, then: thenBody, else: elseBody });
+}
+
+/**
+ * (#2856 C1) Lower an early `return [expr]` in body-statement position.
+ * Mirrors `lowerTail`'s return handling (void discard, value coercion via
+ * `coerceReturnValue`) but emits the `early.return` instr instead of a
+ * block terminator — the buffer isn't a block, and the Wasm `return` op
+ * unwinds the enclosing loop blocks natively.
+ */
+function lowerEarlyReturn(stmt: ts.ReturnStatement, cx: LowerCtx): void {
+  if (cx.funcKind === "generator") {
+    // A generator's `return` routes through __gen_set_return / the buffer
+    // epilogue — a plain Wasm return would skip the generator wrap. The
+    // selector rejects the shape; this is the defensive mirror.
+    throw new Error(`ir/from-ast: early return inside a generator not in IR scope (${cx.funcName})`);
+  }
+  if (cx.noEarlyReturn) {
+    // Inside try/catch/finally (would skip inlined finally) or an
+    // iterator-protocol for-of body (would skip iter.return cleanup).
+    throw new Error(`ir/from-ast: early return inside try/for-of-iter not in IR scope (${cx.funcName})`);
+  }
+  if (cx.returnType === null) {
+    if (stmt.expression) {
+      // Lower for side effects but discard the value (void function).
+      lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
+    }
+    cx.builder.emitEarlyReturn(null);
+    return;
+  }
+  if (!stmt.expression) {
+    throw new Error(`ir/from-ast: early bare return in non-void function in ${cx.funcName}`);
+  }
+  const v = lowerExpr(stmt.expression, cx, cx.returnType);
+  cx.builder.emitEarlyReturn(coerceReturnValue(v, cx));
 }
 
 /**
@@ -5629,7 +5873,7 @@ function lowerThrowStatement(stmt: ts.ThrowStatement, cx: LowerCtx): void {
 function lowerTryStatement(stmt: ts.TryStatement, cx: LowerCtx): void {
   // ── Try body ────────────────────────────────────────────────────────
   const tryScope = new Map(cx.scope);
-  const tryCx: LowerCtx = { ...cx, scope: tryScope };
+  const tryCx: LowerCtx = { ...cx, scope: tryScope, noEarlyReturn: true };
   const tryBody = cx.builder.collectBodyInstrs(() => {
     for (const s of stmt.tryBlock.statements) {
       lowerStmt(s, tryCx);
@@ -5658,7 +5902,7 @@ function lowerTryStatement(stmt: ts.TryStatement, cx: LowerCtx): void {
       // Destructuring catch — selector should have rejected this.
       throw new Error(`ir/from-ast: destructuring catch param not in slice 9 (${cx.funcName})`);
     }
-    const catchCx: LowerCtx = { ...cx, scope: catchScope };
+    const catchCx: LowerCtx = { ...cx, scope: catchScope, noEarlyReturn: true };
     const catchBody = cx.builder.collectBodyInstrs(() => {
       for (const s of stmt.catchClause!.block.statements) {
         lowerStmt(s, catchCx);
@@ -5671,7 +5915,7 @@ function lowerTryStatement(stmt: ts.TryStatement, cx: LowerCtx): void {
   let finallyBody: readonly IrInstr[] | undefined;
   if (stmt.finallyBlock) {
     const finallyScope = new Map(cx.scope);
-    const finallyCx: LowerCtx = { ...cx, scope: finallyScope };
+    const finallyCx: LowerCtx = { ...cx, scope: finallyScope, noEarlyReturn: true };
     finallyBody = cx.builder.collectBodyInstrs(() => {
       for (const s of stmt.finallyBlock!.statements) {
         lowerStmt(s, finallyCx);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -5512,15 +5512,29 @@ function tryLowerUndefinedCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, 
     }
     return isStrictNeq ? cx.builder.emitUnary("i32.eqz", flag, irVal({ kind: "i32" })) : flag;
   }
-  // Never-undefined representations: fold. The lowered operand keeps its
-  // side effects; DCE strips the unused value only when pure.
-  const neverUndefined =
+  // Never-undefined representations: fold — but ONLY when the operand's TS
+  // static type proves the VALUE cannot be `undefined`. The Wasm-level rep
+  // alone is not enough: the IR erases `void x` (static type `undefined`)
+  // into an f64 NaN, so a rep-based fold would answer `void x === undefined`
+  // with false where JS says true (caught by
+  // tests/equivalence/logical-conditional-identity.test.ts). Types that
+  // include undefined/void/any/unknown demote to legacy, which tracks
+  // undefined-ness through its own lowering.
+  const staticTypeMayBeUndefined = (): boolean => {
+    if (!cx.checker) return true; // no checker — cannot prove; demote
+    const tsType = cx.checker.getTypeAtLocation(other);
+    const UNDEF_LIKE = ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.Any | ts.TypeFlags.Unknown;
+    if (tsType.flags & UNDEF_LIKE) return true;
+    if (tsType.isUnion() && tsType.types.some((m) => (m.flags & UNDEF_LIKE) !== 0)) return true;
+    return false;
+  };
+  const neverUndefinedRep =
     (tv !== null && (tv.kind === "f64" || tv.kind === "i32" || tv.kind === "ref" || tv.kind === "ref_null")) ||
     t.kind === "class" ||
     t.kind === "object" ||
     t.kind === "closure" ||
     t.kind === "string"; // native-strings mode only (host mode took the branch above)
-  if (neverUndefined) {
+  if (neverUndefinedRep && !staticTypeMayBeUndefined()) {
     return cx.builder.emitConst({ kind: "bool", value: isStrictNeq }, irVal({ kind: "i32" }));
   }
   throw new Error(`ir/from-ast: undefined-compare on ${describeIrType(t)} not in IR scope (${cx.funcName})`);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -803,6 +803,14 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
       cx.builder.terminate({ kind: "return", values: [] });
       return;
     }
+    // (#2856 C4) Direct-call tail in a void function — `quicksort(arr, p +
+    // 1, hi);` as the last statement. Statement position, so a void callee
+    // is legal.
+    if (ts.isCallExpression(stmt.expression) && ts.isIdentifier(stmt.expression.expression)) {
+      void lowerCall(stmt.expression, cx, /* statementPosition */ true);
+      cx.builder.terminate({ kind: "return", values: [] });
+      return;
+    }
     // Lower the expression for side effects, discard the value.
     lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
     cx.builder.terminate({ kind: "return", values: [] });
@@ -4362,7 +4370,8 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
         void lowerMethodCall(stmt.expression, cx, /* statementPosition */ true);
         return;
       }
-      void lowerExpr(stmt.expression, cx, irVal({ kind: "f64" }));
+      // (#2856 C4) Statement position — a VOID direct call is legal.
+      void lowerCall(stmt.expression, cx, /* statementPosition */ true);
       return;
     }
     // Slice 7a (#1169f): `yield <expr>;` inside a for-of body. The

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1555,6 +1555,38 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
         }
         return r;
       }
+      // (#2856 C3) Module-scope binding holding an extern-class instance
+      // (`const fibCache = new Map()` at module level). The legacy backend
+      // allocated a `__mod_<name>` externref global (module-level statements
+      // always compile via legacy — the IR only claims functions), so the IR
+      // read is a `global.get` against the SAME storage slot, branded with
+      // the binding's extern class so member calls dispatch through the
+      // extern arms. When legacy tracked a TDZ flag for the binding, emit
+      // the same read-site check legacy does: `if (__tdz_<name> == 0) throw`.
+      const mg = cx.resolver?.getModuleScopeExternBinding?.(expr.text);
+      if (mg) {
+        assertNotDeferred(
+          hostExternCapability(cx.resolver?.jsHostExterns?.() === true),
+          `module-scope extern binding "${expr.text}"`,
+          cx.funcName,
+        );
+        if (mg.tdzGlobalName) {
+          const tdz = cx.builder.emitGlobalGet({ kind: "global", name: mg.tdzGlobalName }, irVal({ kind: "i32" }));
+          const cond = cx.builder.emitUnary("i32.eqz", tdz, irVal({ kind: "i32" }));
+          const thenBody = cx.builder.collectBodyInstrs(() => {
+            const nullExt = cx.builder.emitConst(
+              { kind: "null", ty: irVal({ kind: "externref" }) },
+              irVal({ kind: "externref" }),
+            );
+            cx.builder.emitThrow(nullExt);
+          });
+          cx.builder.emitIfStmt({ cond, then: thenBody, else: [] });
+        }
+        return cx.builder.emitGlobalGet(
+          { kind: "global", name: mg.globalName },
+          { kind: "extern", className: mg.className },
+        );
+      }
     }
     if (!p) throw new Error(`ir/from-ast: identifier "${expr.text}" is not in scope in ${cx.funcName}`);
     // Slice 6 part 2 (#1181): slot-bound identifier (let mutated across
@@ -2984,6 +3016,18 @@ function coerceToExpectedExtern(value: IrValueId, expected: ValType, cx: LowerCt
   if (expected.kind === "externref" && t.kind === "extern") {
     return value;
   }
+  // (#2856 C3) f64 → externref: box through the `__box_number` host import —
+  // the exact coercion legacy's `coerceType` emits for the same site (so the
+  // import is registered by legacy's own compile of the function in the
+  // dual-compile model). JS-host lane only: standalone has no `__box_number`
+  // (its boxing is the `$AnyValue` family), so demote there.
+  if (expected.kind === "externref" && got !== null && got.kind === "f64" && cx.resolver?.nativeStrings?.() === false) {
+    const boxed = cx.builder.emitCall({ kind: "func", name: "__box_number" }, [value], irVal({ kind: "externref" }));
+    if (boxed === null) {
+      throw new Error(`ir/from-ast: __box_number produced no result in ${cx.funcName}`);
+    }
+    return boxed;
+  }
   throw new Error(`ir/from-ast: ${where} expects ${expected.kind} but got ${describeIrType(t)} (${cx.funcName})`);
 }
 
@@ -3694,6 +3738,25 @@ function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId 
  */
 function coerceReturnValue(value: IrValueId, cx: LowerCtx): IrValueId {
   const declared = cx.returnType;
+  // (#2856 C3) externref value into a NUMBER (f64) declared result —
+  // `return hit;` where `hit = cache.get(n)` is the externref Map_get
+  // result. Unbox through `__unbox_number`, exactly what legacy emits for
+  // the same site (import registered by legacy's own compile in the
+  // dual-compile model). Host lane only — standalone demotes. Before this
+  // arm such returns slipped to the verifier's #1798 gate and demoted;
+  // now they lower like legacy.
+  if (declared && declared.kind === "val" && declared.val.kind === "f64") {
+    const actualT = cx.builder.typeOf(value);
+    const actualV = asVal(actualT);
+    if (actualV && actualV.kind === "externref" && cx.resolver?.nativeStrings?.() === false) {
+      const unboxed = cx.builder.emitCall({ kind: "func", name: "__unbox_number" }, [value], irVal({ kind: "f64" }));
+      if (unboxed === null) {
+        throw new Error(`ir/from-ast: __unbox_number produced no result in ${cx.funcName}`);
+      }
+      return unboxed;
+    }
+    return value;
+  }
   // Only the externref (TS `any`) declared-result case can mismatch here;
   // native scalar / matching-ref returns already line up via the hint.
   if (!declared || declared.kind !== "val" || declared.val.kind !== "externref") {
@@ -4939,6 +5002,19 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
   const nullFold = tryFoldNullCompare(expr, op, cx);
   if (nullFold !== null) return nullFold;
 
+  // (#2856 C3) STRICT undefined-compare — `hit !== undefined`. Dispatch on
+  // the non-undefined operand's IrType (mirrors the selector's acceptance):
+  //   - externref-shaped (externref val / extern class / host string):
+  //     runtime `__extern_is_undefined(v)` (the legacy check for the same
+  //     shape), inverted for `!==`.
+  //   - representations that can never hold the JS `undefined` VALUE
+  //     (unboxed f64/i32 scalars, non-null WasmGC refs incl. vecs/classes/
+  //     native strings — strict equality: `null !== undefined` is true too):
+  //     constant fold, evaluating the operand for side effects.
+  //   - anything else (boxed / union / dynamic): clean demote.
+  const undefCompare = tryLowerUndefinedCompare(expr, op, cx);
+  if (undefCompare !== null) return undefCompare;
+
   // #2781 (hybrid Row 7) — `+` operand-type proof gate. Run BEFORE operand
   // lowering (mirrors #2780's pre-element widening gate), so no dead operand
   // instrs are emitted and the demotion cause is the explicit HI reason rather
@@ -5332,6 +5408,71 @@ function typeOfValue(v: IrValueId, cx: LowerCtx): IrType {
  * Returns `null` when this isn't a `null`-compare (so the caller
  * proceeds with the normal lowering).
  */
+/**
+ * (#2856 C3) Lower a STRICT undefined-compare — `<expr> !== undefined` /
+ * `<expr> === undefined` (`undefined` as a free identifier, not shadowed).
+ * Returns null when the expression isn't that shape (caller proceeds with
+ * the normal lowering).
+ *
+ * Dispatch by the non-undefined operand's IrType:
+ *   - externref-shaped (externref val / extern class / host-mode string) —
+ *     the runtime CAN hold the host `undefined`: emit the same
+ *     `__extern_is_undefined(v)` check legacy emits for this shape (import
+ *     registered by legacy's own lowering of the identical site in the
+ *     dual-compile model), `i32.eqz`-inverted for `!==`.
+ *   - representations that can never hold the JS `undefined` VALUE —
+ *     unboxed f64/i32 scalars and WasmGC refs (vecs, classes, objects,
+ *     closures, native strings; STRICT equality means even a null ref
+ *     compares false against undefined): constant-fold, keeping the
+ *     operand's side effects (DCE drops the value only when pure).
+ *   - anything else (boxed / union / dynamic) — clean demote to legacy.
+ *
+ * LOOSE `==`/`!=` never reach here (selector rejects them against
+ * `undefined`): `null == undefined` is true, so nullable-ref operands would
+ * need a runtime null check this slice doesn't emit.
+ */
+function tryLowerUndefinedCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: LowerCtx): IrValueId | null {
+  const isStrictEq = op === ts.SyntaxKind.EqualsEqualsEqualsToken;
+  const isStrictNeq = op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+  if (!isStrictEq && !isStrictNeq) return null;
+  const isUndefIdent = (e: ts.Expression): boolean =>
+    ts.isIdentifier(e) && e.text === "undefined" && !cx.scope.has("undefined");
+  const leftU = isUndefIdent(expr.left);
+  const rightU = isUndefIdent(expr.right);
+  if (!leftU && !rightU) return null;
+  if (leftU && rightU) {
+    // `undefined === undefined` → true / `!==` → false.
+    return cx.builder.emitConst({ kind: "bool", value: isStrictEq }, irVal({ kind: "i32" }));
+  }
+  const other = leftU ? expr.right : expr.left;
+  const v = lowerExpr(other, cx, irVal({ kind: "externref" }));
+  const t = cx.builder.typeOf(v);
+  const tv = asVal(t);
+  const externrefShaped =
+    (tv !== null && tv.kind === "externref") ||
+    t.kind === "extern" ||
+    (t.kind === "string" && cx.resolver?.nativeStrings?.() === false);
+  if (externrefShaped) {
+    const flag = cx.builder.emitCall({ kind: "func", name: "__extern_is_undefined" }, [v], irVal({ kind: "i32" }));
+    if (flag === null) {
+      throw new Error(`ir/from-ast: __extern_is_undefined produced no result in ${cx.funcName}`);
+    }
+    return isStrictNeq ? cx.builder.emitUnary("i32.eqz", flag, irVal({ kind: "i32" })) : flag;
+  }
+  // Never-undefined representations: fold. The lowered operand keeps its
+  // side effects; DCE strips the unused value only when pure.
+  const neverUndefined =
+    (tv !== null && (tv.kind === "f64" || tv.kind === "i32" || tv.kind === "ref" || tv.kind === "ref_null")) ||
+    t.kind === "class" ||
+    t.kind === "object" ||
+    t.kind === "closure" ||
+    t.kind === "string"; // native-strings mode only (host mode took the branch above)
+  if (neverUndefined) {
+    return cx.builder.emitConst({ kind: "bool", value: isStrictNeq }, irVal({ kind: "i32" }));
+  }
+  throw new Error(`ir/from-ast: undefined-compare on ${describeIrType(t)} not in IR scope (${cx.funcName})`);
+}
+
 function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: LowerCtx): IrValueId | null {
   const isEq = op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.EqualsEqualsToken;
   const isNeq = op === ts.SyntaxKind.ExclamationEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -26,7 +26,8 @@ import { ts } from "../ts-api.js";
 
 import { ensureAnyValueType } from "../codegen/any-helpers.js"; // (#2949) boxed-any carrier for IrType.dynamic
 import { getOrRegisterPromiseType } from "../codegen/async-scheduler.js";
-import { addGeneratorImports, addIteratorImports, addStringImports } from "../codegen/index.js";
+import { addGeneratorImports, addIteratorImports, addStringImports, TYPED_ARRAY_NAMES } from "../codegen/index.js";
+import { ensureVecElemSet, VEC_ELEM_SET_PREFIX } from "../codegen/vec-elem-set.js"; // (#2856 C2) on-demand element-store helper
 import { classMemberFuncKey } from "../codegen/class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import {
   ensureNativeStringHelpers,
@@ -177,7 +178,7 @@ export function compileIrPathFunctions(
   // Phase 3 once the registries exist; both share the same underlying
   // logic for the methods both expose.
   // -------------------------------------------------------------------------
-  const fromAstResolver = makeFromAstResolver(ctx);
+  const fromAstResolver = makeFromAstResolver(ctx, sourceFile);
 
   // -------------------------------------------------------------------------
   // Phase 1 — Build: lower every selected AST function to an IrFunction.
@@ -936,7 +937,7 @@ function externResultClassName(
   }
 }
 
-function makeFromAstResolver(ctx: CodegenContext): IrFromAstResolver {
+function makeFromAstResolver(ctx: CodegenContext, sourceFile?: ts.SourceFile): IrFromAstResolver {
   return {
     nativeStrings(): boolean {
       return ctx.nativeStrings;
@@ -980,6 +981,52 @@ function makeFromAstResolver(ctx: CodegenContext): IrFromAstResolver {
     // host-extern arms.
     jsHostExterns(): boolean {
       return !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports);
+    },
+    // (#2856 C2) TypedArray-view receiver detection for element STORES —
+    // the same checker walk as the legacy `elementAccessTypedArrayName`
+    // (assignment.ts): symbol name of the receiver's TS type against the
+    // TYPED_ARRAY_NAMES registry. Writes into those views carry per-view
+    // conversion semantics (ToUint8/ToUint8Clamp/packing) that the plain
+    // vec store helper must not bypass, so the IR demotes them.
+    isTypedArrayViewExpr(expr: ts.Expression): boolean {
+      const t = ctx.checker.getTypeAtLocation(expr);
+      let name = t.getSymbol()?.name ?? t.aliasSymbol?.name;
+      if ((!name || !TYPED_ARRAY_NAMES.has(name)) && ts.isNewExpression(expr) && ts.isIdentifier(expr.expression)) {
+        name = expr.expression.text;
+      }
+      return !!name && TYPED_ARRAY_NAMES.has(name);
+    },
+    // (#2856 C3) Module-scope binding → the Wasm global the legacy backend
+    // allocated (`__mod_<name>` in ctx.mod.globals, TDZ flag `__tdz_<name>`
+    // when tracked) + the extern-class brand of the held value from the
+    // checker at the DECLARATION site. Only externref-shaped extern-class
+    // instances resolve (e.g. `const cache = new Map()` → "Map"); plain
+    // scalars / non-extern values return undefined so the identifier arm
+    // demotes cleanly.
+    getModuleScopeExternBinding(name: string) {
+      if (!ctx.moduleGlobals.has(name)) return undefined;
+      const globalName = `__mod_${name}`;
+      const g = ctx.mod.globals.find((gl) => gl.name === globalName);
+      if (!g || g.type.kind !== "externref") return undefined;
+      // Brand from the checker: the module-level declaration's type symbol
+      // must name a REGISTERED extern class (host mode only — in
+      // standalone/nativeStrings the class isn't registered, so this
+      // resolves nothing and the function demotes to legacy, which has the
+      // native runtime interception).
+      const sf = sourceFile;
+      if (!sf) return undefined;
+      let className: string | undefined;
+      for (const stmt of sf.statements) {
+        if (!ts.isVariableStatement(stmt)) continue;
+        for (const d of stmt.declarationList.declarations) {
+          if (!ts.isIdentifier(d.name) || d.name.text !== name) continue;
+          const t = ctx.checker.getTypeAtLocation(d.name);
+          className = t.getSymbol()?.name ?? t.aliasSymbol?.name;
+        }
+      }
+      if (!className || !ctx.externClasses.has(className)) return undefined;
+      const tdzGlobalName = ctx.mod.globals.some((gl) => gl.name === `__tdz_${name}`) ? `__tdz_${name}` : null;
+      return { globalName, tdzGlobalName, className };
     },
     // (#2856) Variant selection for `console.<m>(arg)` — the SAME checker
     // predicates as the legacy `collectConsoleImports` registration scan
@@ -1100,6 +1147,18 @@ function makeResolver(
       // functions. On-demand keeps the helper out of modules that never use
       // `%` (parity with legacy, which also emits it lazily).
       if (ref.name === FMOD_FN) return ensureFmod(ctx);
+      // (#2856 C2) `__vec_elem_set_<vecTypeIdx>` — element-store helper with
+      // full legacy grow semantics. Materialized on demand, same append-only
+      // defined-function discipline as `ensureFmod` (never an import, no
+      // existing funcIdx shifts). Idempotent via funcMap.
+      if (ref.name.startsWith(VEC_ELEM_SET_PREFIX)) {
+        const vecTypeIdx = Number(ref.name.slice(VEC_ELEM_SET_PREFIX.length));
+        const helperIdx = Number.isInteger(vecTypeIdx) ? ensureVecElemSet(ctx, vecTypeIdx) : null;
+        if (helperIdx === null) {
+          throw new Error(`ir/integration: cannot materialize ${ref.name} (not a recognisable vec struct)`);
+        }
+        return helperIdx;
+      }
       const idx = ctx.funcMap.get(ref.name);
       if (idx !== undefined) return idx;
       // Slice 6 part 4 (#1183): native-string helpers (`__str_charAt`,

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -501,6 +501,12 @@ export function lowerIrFunctionBody<S>(
         recordUse(instr.thenValue, -1);
         recordUse(instr.elseValue, -1);
       }
+      // (#2856) Statement-level `if.stmt` arms — same `-1` convention as the
+      // value-producing form above (no carrier values to record).
+      if (instr.kind === "if.stmt") {
+        for (const u of collectForOfBodyUses(instr.then)) recordUse(u, -1);
+        for (const u of collectForOfBodyUses(instr.else)) recordUse(u, -1);
+      }
     }
     for (const u of collectTerminatorUses(block)) recordUse(u, blockId);
   }
@@ -712,6 +718,11 @@ export function lowerIrFunctionBody<S>(
     // emission mis-targets an unrelated local. (Same recursion the for-of /
     // try / loop buffers already get.)
     if (instr.kind === "if") {
+      for (const sub of instr.then) allocLocalForInstr(sub);
+      for (const sub of instr.else) allocLocalForInstr(sub);
+    }
+    // (#2856) Statement-level if — same arm recursion as the value form.
+    if (instr.kind === "if.stmt") {
       for (const sub of instr.then) allocLocalForInstr(sub);
       for (const sub of instr.else) allocLocalForInstr(sub);
     }
@@ -1062,6 +1073,39 @@ export function lowerIrFunctionBody<S>(
 
         // 4. Wrap in `if (result T) ... else ... end`.
         emitter.emitIf(blockType, thenBody, elseBody, out);
+        return;
+      }
+      // (#2856) Statement-level if — void `if (empty) <then> else <else> end`.
+      // Arm buffers follow the same SSA-materialisation rules as the
+      // value-producing form above, minus the carrier values.
+      case "if.stmt": {
+        const emitArmBody = (bodyInstrs: readonly IrInstr[], target: S): void => {
+          for (const bodyInstr of bodyInstrs) {
+            if (bodyInstr.result === null) {
+              emitInstrTree(bodyInstr, target);
+            } else if (crossBlock.has(bodyInstr.result)) {
+              emitInstrTree(bodyInstr, target);
+              emitter.emitLocalSet(localIdx.get(bodyInstr.result)!, target);
+              materialized.add(bodyInstr.result);
+            }
+            // Intra-arm multi-use: handled at use site via tee pattern.
+          }
+        };
+        emitValue(instr.cond, out);
+        const thenBody: S = emitter.newSink();
+        emitArmBody(instr.then, thenBody);
+        const elseBody: S = emitter.newSink();
+        emitArmBody(instr.else, elseBody);
+        emitter.emitIf({ kind: "empty" }, thenBody, elseBody, out);
+        return;
+      }
+      // (#2856) Early return from inside a nested buffer — the Wasm `return`
+      // op unwinds every enclosing block/loop and returns from the function.
+      // The value (when present) was coerced to the function's result type by
+      // from-ast (same `coerceReturnValue` the tail path uses).
+      case "early.return": {
+        if (instr.value !== null) emitValue(instr.value, out);
+        emitter.emitReturn(out);
         return;
       }
       case "raw.wasm":
@@ -2649,6 +2693,13 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.value];
     case "async.throw":
       return [instr.reason];
+    // (#2856) Statement-level if — arm-buffer uses are surfaced separately
+    // via `collectForOfBodyUses` (forEachNestedBuffer recursion); only the
+    // cond is a direct use here.
+    case "if.stmt":
+      return [instr.cond];
+    case "early.return":
+      return instr.value !== null ? [instr.value] : [];
   }
 }
 

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1053,6 +1053,13 @@ export function lowerIrFunctionBody<S>(
               emitInstrTree(bodyInstr, target);
               emitter.emitLocalSet(localIdx.get(bodyInstr.result)!, target);
               materialized.add(bodyInstr.result);
+            } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+              // (#2856) Zero-use side-effecting instr inside a nested buffer —
+              // same eager emit + drop contract as `emitBlockBody` (a
+              // statement-position extern/host call whose unused result would
+              // otherwise be silently SKIPPED, dropping its side effect).
+              emitInstrTree(bodyInstr, target);
+              emitter.emitDrop(target);
             }
             // Intra-arm multi-use: handled at use site via tee pattern.
           }
@@ -1087,6 +1094,13 @@ export function lowerIrFunctionBody<S>(
               emitInstrTree(bodyInstr, target);
               emitter.emitLocalSet(localIdx.get(bodyInstr.result)!, target);
               materialized.add(bodyInstr.result);
+            } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+              // (#2856) Zero-use side-effecting instr inside a nested buffer —
+              // same eager emit + drop contract as `emitBlockBody` (a
+              // statement-position extern/host call whose unused result would
+              // otherwise be silently SKIPPED, dropping its side effect).
+              emitInstrTree(bodyInstr, target);
+              emitter.emitDrop(target);
             }
             // Intra-arm multi-use: handled at use site via tee pattern.
           }
@@ -1710,6 +1724,11 @@ export function lowerIrFunctionBody<S>(
               index: localIdx.get(bodyInstr.result)!,
             });
             materialized.add(bodyInstr.result);
+          } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+            // (#2856) Zero-use side-effecting instr — eager emit + drop,
+            // same contract as `emitBlockBody` (see the if-arm variant).
+            emitInstrTree(bodyInstr, loopBody as unknown as S);
+            emitter.emitDrop(loopBody as unknown as S);
           }
           // Intra-block multi-use: handled at use site via tee pattern.
         }
@@ -1846,6 +1865,11 @@ export function lowerIrFunctionBody<S>(
               index: localIdx.get(bodyInstr.result)!,
             });
             materialized.add(bodyInstr.result);
+          } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+            // (#2856) Zero-use side-effecting instr — eager emit + drop,
+            // same contract as `emitBlockBody` (see the if-arm variant).
+            emitInstrTree(bodyInstr, loopBody as unknown as S);
+            emitter.emitDrop(loopBody as unknown as S);
           }
         }
 
@@ -1915,6 +1939,11 @@ export function lowerIrFunctionBody<S>(
                 index: localIdx.get(bodyInstr.result)!,
               });
               materialized.add(bodyInstr.result);
+            } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+              // (#2856) Zero-use side-effecting instr — eager emit + drop,
+              // same contract as `emitBlockBody` (see the if-arm variant).
+              emitInstrTree(bodyInstr, target as unknown as S);
+              emitter.emitDrop(target as unknown as S);
             }
             // Intra-block multi-use: handled via tee at use site.
           }
@@ -2078,6 +2107,11 @@ export function lowerIrFunctionBody<S>(
               index: localIdx.get(bodyInstr.result)!,
             });
             materialized.add(bodyInstr.result);
+          } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+            // (#2856) Zero-use side-effecting instr — eager emit + drop,
+            // same contract as `emitBlockBody` (see the if-arm variant).
+            emitInstrTree(bodyInstr, loopBody as unknown as S);
+            emitter.emitDrop(loopBody as unknown as S);
           }
         }
 
@@ -2200,6 +2234,11 @@ export function lowerIrFunctionBody<S>(
                 index: localIdx.get(bodyInstr.result)!,
               });
               materialized.add(bodyInstr.result);
+            } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
+              // (#2856) Zero-use side-effecting instr — eager emit + drop,
+              // same contract as `emitBlockBody` (see the if-arm variant).
+              emitInstrTree(bodyInstr, target as unknown as S);
+              emitter.emitDrop(target as unknown as S);
             }
             // Intra-block multi-use: handled at use site via tee pattern.
           }

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -1742,6 +1742,60 @@ export interface IrInstrThrow extends IrInstrBase {
   readonly value: IrValueId;
 }
 
+/**
+ * (#2856) Statement-level `if (cond) { then } [else { else }]` inside a
+ * nested body buffer (loop bodies, other if arms). UNLIKE `IrInstrIf`
+ * (the value-producing #1392 form), this produces NO value: both arms are
+ * self-contained statement buffers with no carrier values, and `else` may
+ * be empty (the source had no else clause). `result`/`resultType` are
+ * always null.
+ *
+ * Lowering: `<cond>; if (empty) <then instrs> else <else instrs> end` —
+ * each arm buffer follows the same SSA-materialisation rules as the
+ * value-producing `if` arms (cross-block defs materialise into locals,
+ * void instrs emit in place).
+ */
+export interface IrInstrIfStmt extends IrInstrBase {
+  readonly kind: "if.stmt";
+  readonly cond: IrValueId;
+  readonly then: readonly IrInstr[];
+  /** Empty array when the source `if` has no else clause. */
+  readonly else: readonly IrInstr[];
+}
+
+/**
+ * (#2856) Early `return` from inside a nested body buffer — the
+ * `if (v === target) return mid;` inside a `while` loop shape. The block
+ * TERMINATOR `return` can't express this (buffers aren't blocks), so this
+ * statement-level instr lowers to the Wasm `return` op, which unwinds all
+ * enclosing blocks/loops and returns from the function directly.
+ *
+ * `value` is null for a bare `return;` in a void function (the Wasm
+ * `return` then carries no operand). When non-null, the value is emitted
+ * onto the stack first and must match the function's single result type
+ * (from-ast routes it through the same `coerceReturnValue` the tail path
+ * uses).
+ *
+ * SOUNDNESS SCOPE (selector-enforced, mirrored in from-ast):
+ *   - NOT valid inside `try`/`catch`/`finally` buffers — a Wasm `return`
+ *     would skip the inlined finally blocks.
+ *   - NOT valid inside `forof.iter` bodies — the iterator protocol's
+ *     `iter.return` cleanup would be skipped (spec: `return` inside
+ *     for-of calls the iterator's return()).
+ *   - NOT valid in generators (their return routes through the buffer
+ *     epilogue, not a plain Wasm return).
+ *   Plain `while`/`for`/`do` bodies (and `if.stmt` arms nested in them)
+ *   are the supported contexts — a Wasm `return` there is exactly JS's
+ *   early-exit semantics.
+ *
+ * Like `throw`, it produces NO SSA value; instructions after it in the
+ * same buffer are dead but structurally valid.
+ */
+export interface IrInstrEarlyReturn extends IrInstrBase {
+  readonly kind: "early.return";
+  readonly value: IrValueId | null;
+}
+
 // ---------------------------------------------------------------------------
 // Generic structured loops (#1280 — IR Phase 4 Slice 12)
 // ---------------------------------------------------------------------------
@@ -1945,6 +1999,9 @@ export type IrInstr =
   // Slice 9 (#1169h) — exception handling.
   | IrInstrThrow
   | IrInstrTry
+  // (#2856) Statement-level if + early return inside body buffers.
+  | IrInstrIfStmt
+  | IrInstrEarlyReturn
   // Slice 10 (#1169i) — extern class ops.
   | IrInstrExternNew
   | IrInstrExternCall
@@ -2167,6 +2224,7 @@ export function isIrTypeRef(x: unknown): x is IrTypeRef {
 export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInstr[]) => void): void {
   switch (instr.kind) {
     case "if":
+    case "if.stmt":
       fn(instr.then);
       fn(instr.else);
       return;
@@ -2243,6 +2301,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "await":
     case "async.return":
     case "async.throw":
+    case "early.return":
       return;
     default: {
       const _exhaustive: never = instr;
@@ -2281,7 +2340,8 @@ export function mapNestedBuffers(
   mapBuffer: (buffer: readonly IrInstr[]) => readonly IrInstr[],
 ): IrInstr {
   switch (instr.kind) {
-    case "if": {
+    case "if":
+    case "if.stmt": {
       const then_ = mapBuffer(instr.then);
       const else_ = mapBuffer(instr.else);
       if (then_ === instr.then && else_ === instr.else) return instr;
@@ -2374,6 +2434,7 @@ export function mapNestedBuffers(
     case "await":
     case "async.return":
     case "async.throw":
+    case "early.return":
       return instr;
     default: {
       const _exhaustive: never = instr;
@@ -2502,6 +2563,12 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.value];
     case "async.throw":
       return [instr.reason];
+    // (#2856) if.stmt surfaces only its cond at top level (arm-buffer uses
+    // are reached via the deep walk, same as the value-producing `if`).
+    case "if.stmt":
+      return [instr.cond];
+    case "early.return":
+      return instr.value !== null ? [instr.value] : [];
     default: {
       const _exhaustive: never = instr;
       void _exhaustive;

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -263,7 +263,13 @@ function canInline(callee: IrFunction, recursiveSet: ReadonlySet<string>): boole
       inst.kind === "forof.string" ||
       inst.kind === "try" ||
       inst.kind === "while.loop" ||
-      inst.kind === "for.loop"
+      inst.kind === "for.loop" ||
+      // (#2856) if.stmt is buffer-bearing (same nested SSA def-space concern
+      // as the kinds above). early.return lowers to a Wasm `return` — spliced
+      // into a caller it would return from the CALLER, not simulate the
+      // callee's return, so it is never inlinable.
+      inst.kind === "if.stmt" ||
+      inst.kind === "early.return"
     ) {
       return false;
     }
@@ -752,6 +758,37 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       const r = mapId(rename, inst.reason);
       if (r === inst.reason) return inst;
       return { ...inst, reason: r };
+    }
+    // (#2856) Statement-level if — rename the cond + recurse both arm
+    // buffers (mirrors the value-producing `if` arm above, minus the
+    // carrier values, which if.stmt doesn't have).
+    case "if.stmt": {
+      const c = mapId(rename, inst.cond);
+      const newThen: IrInstr[] = [];
+      const newElse: IrInstr[] = [];
+      let armChanged = false;
+      for (const sub of inst.then) {
+        const r = renameInstrOperands(sub, rename);
+        if (r !== sub) armChanged = true;
+        newThen.push(r);
+      }
+      for (const sub of inst.else) {
+        const r = renameInstrOperands(sub, rename);
+        if (r !== sub) armChanged = true;
+        newElse.push(r);
+      }
+      if (c === inst.cond && !armChanged) return inst;
+      return { ...inst, cond: c, then: newThen, else: newElse };
+    }
+    // (#2856) Early return — rename the optional value. NB inlining a
+    // function CONTAINING an early.return is unsound (the return would
+    // exit the CALLER); the inline pass's eligibility check excludes it
+    // (see `hasEarlyReturnDeep` guard in the candidate filter).
+    case "early.return": {
+      if (inst.value === null) return inst;
+      const v = mapId(rename, inst.value);
+      if (v === inst.value) return inst;
+      return { ...inst, value: v };
     }
   }
 }

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -264,6 +264,14 @@ function canInline(callee: IrFunction, recursiveSet: ReadonlySet<string>): boole
       inst.kind === "try" ||
       inst.kind === "while.loop" ||
       inst.kind === "for.loop" ||
+      // (#2856) The value-producing `if` (#1392) carries then/else arm
+      // buffers with their OWN SSA defs, which `renameAllInInstr` does not
+      // deep-rename — splicing one into a caller produced duplicate SSA
+      // defs (post-inline verify failure → silent legacy demote). It was
+      // missed when #1392 added the kind; latent until #2856's call-arg
+      // ref→ref_null widening made single-block callees with bounds-checked
+      // vec reads (emitSafeVecGet emits an `if`) actually inlinable.
+      inst.kind === "if" ||
       // (#2856) if.stmt is buffer-bearing (same nested SSA def-space concern
       // as the kinds above). early.return lowers to a Wasm `return` — spliced
       // into a caller it would return from the CALLER, not simulate the

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -798,5 +798,20 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.value];
     case "async.throw":
       return [instr.reason];
+    // (#2856) Statement-level if — cond + uses inside both arm buffers
+    // (mirrors the value-producing `if` arm above, minus carrier values).
+    case "if.stmt": {
+      const out: IrValueId[] = [instr.cond];
+      const walk = (instrs: readonly IrInstr[]): void => {
+        for (const sub of instrs) {
+          for (const u of collectUses(sub)) out.push(u);
+        }
+      };
+      walk(instr.then);
+      walk(instr.else);
+      return out;
+    }
+    case "early.return":
+      return instr.value !== null ? [instr.value] : [];
   }
 }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -580,22 +580,9 @@ type IrClaimableSubject = ts.FunctionDeclaration | ts.MethodDeclaration | ts.Con
  * `deferred-feature`) cover them).
  */
 /**
- * #1804 regression guard: a `vec.new_fixed`-constructed vec read inside a
- * C-style `while`/`for` loop produces an invalid SSA program — the vec value
- * defined in the entry block is not threaded as a block-arg into the loop's
- * cond/body blocks (the `while.loop`/`for.loop` lowering, distinct from the
- * `forof.vec` path which handles it). So when the function body contains a
- * C-style loop, the array-literal selector arm withholds the claim and the
- * function reverts to the (correct) legacy path — exactly as it did before
- * #1804. `for...of` and non-loop array-literal uses are unaffected. The proper
- * fix (thread the constructed vec through the loop block-args) is a follow-up.
- */
-let currentFnHasCStyleLoop = false;
-
-/**
  * (#2856 C1) Early-return context for the CURRENT function's body walk.
  * Module-level for the same isPhase1* threading reason as
- * `currentFnHasCStyleLoop`. The `ReturnStatement` arm of
+ * `currentHostGlobalResolver`. The `ReturnStatement` arm of
  * `isPhase1BodyStatement` accepts an early return only when
  *   - `earlyReturnLoopDepth > 0` — we are inside a C-style `while`/`for`/
  *     `do` body (the Wasm `return` op is exactly JS's early exit there), AND
@@ -616,7 +603,7 @@ let currentFnIsVoidReturn = false;
 /**
  * (#2856) Host-extern resolution for the CURRENT `planIrCompilation` run.
  * Set (and cleared) at the selector entry from `IrSelectionOptions` —
- * module-level for the same reason as `currentFnHasCStyleLoop`: the
+ * module-level for the same reason as `currentHostGlobalResolver`: the
  * `isPhase1*` predicates are a deep recursion whose signatures are shared
  * with every in-flight selector slice, and threading a param through all of
  * them would conflict with each of those PRs for zero behavioural gain.
@@ -624,33 +611,6 @@ let currentFnIsVoidReturn = false;
  * see `hostExternCapability` in capability.ts).
  */
 let currentHostGlobalResolver: ((node: ts.Identifier) => string | undefined) | null = null;
-
-/** True if `node` (a function body) contains a `while`/`for` (C-style) loop
- *  anywhere, NOT descending into nested function/class scopes. */
-function bodyHasCStyleLoop(node: ts.Node): boolean {
-  let found = false;
-  const visit = (n: ts.Node): void => {
-    if (found) return;
-    // Don't descend into nested functions — their loops have their own scope.
-    if (
-      ts.isFunctionDeclaration(n) ||
-      ts.isFunctionExpression(n) ||
-      ts.isArrowFunction(n) ||
-      ts.isMethodDeclaration(n) ||
-      ts.isClassDeclaration(n) ||
-      ts.isClassExpression(n)
-    ) {
-      if (n !== node) return;
-    }
-    if (ts.isWhileStatement(n) || ts.isForStatement(n) || ts.isDoStatement(n)) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(n, visit);
-  };
-  ts.forEachChild(node, visit);
-  return found;
-}
 
 function whyNotIrClaimable(
   fn: IrClaimableSubject,
@@ -795,11 +755,6 @@ function whyNotIrClaimable(
 
   const body = fn.body;
   if (!body) return "body-shape-rejected";
-  // #1804 regression guard — record whether this function has a C-style loop,
-  // so the array-literal arm of isPhase1Expr withholds the vec.new_fixed claim
-  // (see bodyHasCStyleLoop). Scoped per-function; the body walk below runs
-  // synchronously so the flag is valid for the duration of this call.
-  currentFnHasCStyleLoop = bodyHasCStyleLoop(body);
   // (#2856 C1) Reset the early-return context for this function's walk.
   earlyReturnLoopDepth = 0;
   earlyReturnBarrierDepth = 0;
@@ -1024,7 +979,7 @@ function resolveReturnType(
  * All top-level FunctionDeclarations of the CURRENT `planIrCompilation` run,
  * pre-collected before Step 1 so the move-only scan can resolve CALLEE
  * param/return dynamic-ness regardless of declaration order. Module-level for
- * the same reason as `currentFnHasCStyleLoop` (threading a param through the
+ * the same reason as `currentHostGlobalResolver` (threading a param through the
  * shared `isPhase1*` recursion would conflict with every in-flight selector
  * slice). `null` outside a selector run — the scan then treats every callee
  * as non-dynamic (conservative: dyn args to it reject the claim).
@@ -1361,6 +1316,25 @@ function isPhase1StatementList(
         // RHS: any Phase-1 expression.
         if (!isPhase1Expr(s.expression.right, scope, localClasses))
           return shapeNo("nontail-assign-rhs", s.expression.right);
+        continue;
+      }
+      // (#2856 C2) element store `<id>[<idx>] = <rhs>;` as a NON-TAIL
+      // statement — quicksort's post-partition swap (`arr[i + 1] = arr[hi];
+      // arr[hi] = tmp;`). Same receiver restriction as the body-buffer arm:
+      // a plain in-scope identifier; the lowerer dispatches on its IrType.
+      if (
+        ts.isBinaryExpression(s.expression) &&
+        s.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isElementAccessExpression(s.expression.left)
+      ) {
+        const lhs = s.expression.left;
+        if (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text)) {
+          return shapeNo("nontail-elemstore-recv", lhs.expression);
+        }
+        if (!isPhase1Expr(lhs.argumentExpression, scope, localClasses))
+          return shapeNo("nontail-elemstore-idx", lhs.argumentExpression);
+        if (!isPhase1Expr(s.expression.right, scope, localClasses))
+          return shapeNo("nontail-elemstore-rhs", s.expression.right);
         continue;
       }
       // (#2856) Catch-all for ExpressionStatements outside the accepted set:
@@ -1768,6 +1742,19 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
           if (!ts.isIdentifier(stmt.expression.left.name) && !ts.isPrivateIdentifier(stmt.expression.left.name))
             return false;
           if (!isPhase1Expr(stmt.expression.left.expression, scope, localClasses)) return false;
+          return isPhase1Expr(stmt.expression.right, scope, localClasses);
+        }
+        // (#2856 C2) element store `<id>[<idx>] = <rhs>;` — receiver
+        // restricted to a plain in-scope identifier (quicksort's `arr[i] =
+        // arr[j]`); the lowerer dispatches on its IrType (vec → the
+        // __vec_elem_set helper with full legacy grow semantics; non-vec
+        // receivers demote cleanly).
+        if (ts.isElementAccessExpression(stmt.expression.left)) {
+          const lhs = stmt.expression.left;
+          if (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text)) {
+            return shapeNo("body-elemstore-recv", lhs.expression);
+          }
+          if (!isPhase1Expr(lhs.argumentExpression, scope, localClasses)) return false;
           return isPhase1Expr(stmt.expression.right, scope, localClasses);
         }
       }
@@ -2409,12 +2396,17 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
   // (mixed-type / non-scalar literals clean-fall-back there). Spread/sparse
   // stay out of scope (legacy fallback).
   if (ts.isArrayLiteralExpression(expr)) {
-    // #1804 regression guard: a constructed vec read inside a C-style
-    // while/for loop fails SSA hygiene (the vec value isn't threaded into the
-    // loop's cond/body blocks — distinct from the working forof.vec path). When
-    // this function contains such a loop, withhold the claim so the whole
-    // function reverts to the (correct) legacy path, as it did pre-#1804.
-    if (currentFnHasCStyleLoop) return shapeNo("expr-arraylit-cloop-guard-1804", expr);
+    // (#2856 C4) The #1804 guard (withhold the claim whenever the function
+    // contains a C-style loop) is RETIRED. The unsound shape it protected —
+    // a constructed vec read inside a `while`/`for` body whose SSA value
+    // wasn't threaded into the loop buffers — was fixed by the slice-12
+    // buffer machinery: uses inside loop cond/body buffers are recorded
+    // against the synthetic -1 block id, so any outer-defined value
+    // (including a `vec.new_fixed` result) is cross-block-materialized into
+    // a Wasm local before the loop op runs (see lower.ts use counting).
+    // Verified empirically: read-in-loop-body, read-in-cond, construct-in-
+    // body, nested-loop, and after-loop shapes all lower correctly and agree
+    // with legacy (tests/ir-algorithms-cluster.test.ts).
     for (const el of expr.elements) {
       if (ts.isSpreadElement(el)) return shapeNo("expr-arraylit-spread", el); // out of scope
       if (ts.isOmittedExpression(el)) return shapeNo("expr-arraylit-sparse", expr); // sparse — out of scope

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -593,6 +593,27 @@ type IrClaimableSubject = ts.FunctionDeclaration | ts.MethodDeclaration | ts.Con
 let currentFnHasCStyleLoop = false;
 
 /**
+ * (#2856 C1) Early-return context for the CURRENT function's body walk.
+ * Module-level for the same isPhase1* threading reason as
+ * `currentFnHasCStyleLoop`. The `ReturnStatement` arm of
+ * `isPhase1BodyStatement` accepts an early return only when
+ *   - `earlyReturnLoopDepth > 0` — we are inside a C-style `while`/`for`/
+ *     `do` body (the Wasm `return` op is exactly JS's early exit there), AND
+ *   - `earlyReturnBarrierDepth === 0` — NO enclosing for-of body (iterator
+ *     `return()` cleanup would be skipped), try/catch/finally body (inlined
+ *     finally would be skipped), or constructor body (returns route through
+ *     the implicit `return this` synthesis), AND
+ *   - the function is not a generator (`currentFnIsGenerator` — generator
+ *     returns route through the buffer epilogue).
+ * Mirrored by from-ast's `cx.noEarlyReturn` / `funcKind` guards so accepted
+ * shapes always lower (select↔build parity, #2138).
+ */
+let earlyReturnLoopDepth = 0;
+let earlyReturnBarrierDepth = 0;
+let currentFnIsGenerator = false;
+let currentFnIsVoidReturn = false;
+
+/**
  * (#2856) Host-extern resolution for the CURRENT `planIrCompilation` run.
  * Set (and cleared) at the selector entry from `IrSelectionOptions` —
  * module-level for the same reason as `currentFnHasCStyleLoop`: the
@@ -779,6 +800,11 @@ function whyNotIrClaimable(
   // (see bodyHasCStyleLoop). Scoped per-function; the body walk below runs
   // synchronously so the flag is valid for the duration of this call.
   currentFnHasCStyleLoop = bodyHasCStyleLoop(body);
+  // (#2856 C1) Reset the early-return context for this function's walk.
+  earlyReturnLoopDepth = 0;
+  earlyReturnBarrierDepth = 0;
+  currentFnIsGenerator = isGenerator;
+  currentFnIsVoidReturn = isVoidReturn;
   // #1370 Phase A: constructor bodies don't have a return-statement tail —
   // the legacy lowerer (and Phase C) synthesise the implicit `return this;`.
   // Accept the body as a list of Phase-1 body statements instead, which
@@ -786,8 +812,15 @@ function whyNotIrClaimable(
   // mirrors how try/catch/finally bodies are checked (see `isPhase1TryStatement`).
   if (ts.isConstructorDeclaration(fn)) {
     const ctorScope = new Set(scope);
-    for (const s of body.statements) {
-      if (!isPhase1BodyStatement(s, ctorScope, localClasses)) return "body-shape-rejected";
+    // (#2856 C1) Constructor bodies never take the early-return arm — their
+    // returns route through the implicit `return this` synthesis.
+    earlyReturnBarrierDepth++;
+    try {
+      for (const s of body.statements) {
+        if (!isPhase1BodyStatement(s, ctorScope, localClasses)) return "body-shape-rejected";
+      }
+    } finally {
+      earlyReturnBarrierDepth--;
     }
     return null;
   }
@@ -1458,34 +1491,41 @@ function isPhase1TryStatement(
 ): boolean {
   if (!stmt.catchClause && !stmt.finallyBlock) return false;
 
-  // Try body: must be a Phase-1 body statement list.
-  const tryScope = new Set(scope);
-  for (const s of stmt.tryBlock.statements) {
-    if (!isPhase1BodyStatement(s, tryScope, localClasses)) return false;
-  }
-
-  if (stmt.catchClause) {
-    const catchScope = new Set(scope);
-    if (stmt.catchClause.variableDeclaration) {
-      const v = stmt.catchClause.variableDeclaration;
-      // Slice 9 only accepts identifier bindings. Destructuring catch
-      // (`catch ({message})`) defers to slice 9.5.
-      if (!ts.isIdentifier(v.name)) return false;
-      catchScope.add(v.name.text);
+  // (#2856 C1) try/catch/finally bodies are early-return BARRIERS: a Wasm
+  // `return` inside them would skip the inlined finally blocks.
+  earlyReturnBarrierDepth++;
+  try {
+    // Try body: must be a Phase-1 body statement list.
+    const tryScope = new Set(scope);
+    for (const s of stmt.tryBlock.statements) {
+      if (!isPhase1BodyStatement(s, tryScope, localClasses)) return false;
     }
-    for (const s of stmt.catchClause.block.statements) {
-      if (!isPhase1BodyStatement(s, catchScope, localClasses)) return false;
-    }
-  }
 
-  if (stmt.finallyBlock) {
-    const finallyScope = new Set(scope);
-    for (const s of stmt.finallyBlock.statements) {
-      if (!isPhase1BodyStatement(s, finallyScope, localClasses)) return false;
+    if (stmt.catchClause) {
+      const catchScope = new Set(scope);
+      if (stmt.catchClause.variableDeclaration) {
+        const v = stmt.catchClause.variableDeclaration;
+        // Slice 9 only accepts identifier bindings. Destructuring catch
+        // (`catch ({message})`) defers to slice 9.5.
+        if (!ts.isIdentifier(v.name)) return false;
+        catchScope.add(v.name.text);
+      }
+      for (const s of stmt.catchClause.block.statements) {
+        if (!isPhase1BodyStatement(s, catchScope, localClasses)) return false;
+      }
     }
-  }
 
-  return true;
+    if (stmt.finallyBlock) {
+      const finallyScope = new Set(scope);
+      for (const s of stmt.finallyBlock.statements) {
+        if (!isPhase1BodyStatement(s, finallyScope, localClasses)) return false;
+      }
+    }
+
+    return true;
+  } finally {
+    earlyReturnBarrierDepth--;
+  }
 }
 
 /**
@@ -1513,7 +1553,16 @@ function isPhase1ForOf(stmt: ts.ForOfStatement, scope: Set<string>, localClasses
   if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
   const innerScope = new Set(scope);
   innerScope.add(decl.name.text);
-  return isPhase1BodyStatement(stmt.statement, innerScope, localClasses);
+  // (#2856 C1) A for-of body is an early-return BARRIER: the iterator-
+  // protocol drive would skip its `iter.return` cleanup on a Wasm return
+  // (whether the iterable resolves to the vec fast path is a lowering-time
+  // fact the shape walk can't see, so be conservative for all for-ofs).
+  earlyReturnBarrierDepth++;
+  try {
+    return isPhase1BodyStatement(stmt.statement, innerScope, localClasses);
+  } finally {
+    earlyReturnBarrierDepth--;
+  }
 }
 
 /**
@@ -1528,7 +1577,13 @@ function isPhase1WhileStatement(
   localClasses: ReadonlySet<string>,
 ): boolean {
   if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-  return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses);
+  // (#2856 C1) while bodies admit the early-return arm.
+  earlyReturnLoopDepth++;
+  try {
+    return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses);
+  } finally {
+    earlyReturnLoopDepth--;
+  }
 }
 
 /**
@@ -1546,7 +1601,13 @@ function isPhase1DoStatement(
   localClasses: ReadonlySet<string>,
 ): boolean {
   if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
-  return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses);
+  // (#2856 C1) do-while bodies admit the early-return arm.
+  earlyReturnLoopDepth++;
+  try {
+    return isPhase1BodyStatement(stmt.statement, new Set(scope), localClasses);
+  } finally {
+    earlyReturnLoopDepth--;
+  }
 }
 
 /**
@@ -1610,7 +1671,13 @@ function isPhase1ForStatement(
   }
 
   // Body: single Phase-1 body statement.
-  return isPhase1BodyStatement(stmt.statement, innerScope, localClasses);
+  // (#2856 C1) for bodies admit the early-return arm.
+  earlyReturnLoopDepth++;
+  try {
+    return isPhase1BodyStatement(stmt.statement, innerScope, localClasses);
+  } finally {
+    earlyReturnLoopDepth--;
+  }
 }
 
 /**
@@ -1760,6 +1827,28 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
   }
   if (ts.isTryStatement(stmt)) {
     return isPhase1TryStatement(stmt, scope, localClasses);
+  }
+  // (#2856 C1) Statement-level `if` inside a body buffer — cond must be a
+  // Phase-1 expression; both arms recurse as body statements (else optional,
+  // unlike the tail form which requires it).
+  if (ts.isIfStatement(stmt)) {
+    if (!isPhase1Expr(stmt.expression, scope, localClasses)) return shapeNo("body-if-cond", stmt.expression);
+    if (!isPhase1BodyStatement(stmt.thenStatement, new Set(scope), localClasses)) return false;
+    if (stmt.elseStatement && !isPhase1BodyStatement(stmt.elseStatement, new Set(scope), localClasses)) return false;
+    return true;
+  }
+  // (#2856 C1) Early `return` inside a body buffer. Sound only inside a
+  // C-style loop with no enclosing barrier (for-of / try / ctor) and never
+  // in a generator — see the module-state doc on `earlyReturnLoopDepth`.
+  if (ts.isReturnStatement(stmt)) {
+    if (currentFnIsGenerator) return shapeNo("body-return-generator", stmt);
+    if (earlyReturnLoopDepth === 0 || earlyReturnBarrierDepth > 0) {
+      return shapeNo("body-return-context", stmt);
+    }
+    if (!stmt.expression) {
+      return currentFnIsVoidReturn ? true : shapeNo("body-return-bare-nonvoid", stmt);
+    }
+    return isPhase1Expr(stmt.expression, scope, localClasses);
   }
   return shapeNo("body-unhandled-stmt", stmt);
 }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -303,6 +303,30 @@ export function planIrCompilation(
     options?.resolveHostGlobal && hostExternCapability(options?.jsHostExterns === true) !== "defer"
       ? options.resolveHostGlobal
       : null;
+  // (#2856 C3) Module-scope `const <m> = new Map(...)` bindings — the
+  // `<m>.get(k)` / `<m>.set(k, v)` method-call receiver arm of isPhase1Expr
+  // consults this set. JS-host lane only (same capability gate as the
+  // host-global resolver): in standalone/nativeStrings mode `Map` isn't a
+  // registered extern class, so from-ast couldn't lower the calls — the
+  // empty set keeps select↔build parity there.
+  currentModuleScopeMapConsts.clear();
+  if (hostExternCapability(options?.jsHostExterns === true) !== "defer") {
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isVariableStatement(stmt)) continue;
+      if (!(stmt.declarationList.flags & ts.NodeFlags.Const)) continue;
+      for (const d of stmt.declarationList.declarations) {
+        if (
+          ts.isIdentifier(d.name) &&
+          d.initializer &&
+          ts.isNewExpression(d.initializer) &&
+          ts.isIdentifier(d.initializer.expression) &&
+          d.initializer.expression.text === "Map"
+        ) {
+          currentModuleScopeMapConsts.add(d.name.text);
+        }
+      }
+    }
+  }
   const fallbackReasons = new Map<string, IrFallbackReason>();
   // (#2856 Step-1) Parallel to `fallbackReasons`: the opt-in reject-arm detail
   // for `body-shape-rejected` entries (populated only when JS2WASM_IR_SHAPE_DIAG=1).
@@ -611,6 +635,16 @@ let currentFnIsVoidReturn = false;
  * see `hostExternCapability` in capability.ts).
  */
 let currentHostGlobalResolver: ((node: ts.Identifier) => string | undefined) | null = null;
+
+/**
+ * (#2856 C3) Module-scope `const <m> = new Map(...)` binding names for the
+ * CURRENT `planIrCompilation` run (JS-host lane only — cleared/refilled at
+ * the selector entry). Receiver acceptance for `<m>.get(k)` / `<m>.set(k, v)`
+ * method calls; the from-ast identifier arm resolves the same binding via
+ * `resolver.getModuleScopeExternBinding` (the legacy `__mod_<name>` global +
+ * extern-class brand), so accepted shapes always lower.
+ */
+const currentModuleScopeMapConsts = new Set<string>();
 
 function whyNotIrClaimable(
   fn: IrClaimableSubject,
@@ -2245,8 +2279,25 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     return isPhase1Expr(expr.operand, scope, localClasses);
   }
   if (ts.isBinaryExpression(expr)) {
-    if (!isPhase1BinaryOp(expr.operatorToken.kind))
-      return shapeNo(`expr-binary-op-${ts.tokenToString(expr.operatorToken.kind) ?? expr.operatorToken.kind}`, expr);
+    const binOp = expr.operatorToken.kind;
+    // (#2856 C3) STRICT undefined-compare — `hit !== undefined` /
+    // `x === undefined`. The `undefined` identifier isn't in scope, so the
+    // generic operand recursion would reject it; accept it specially as one
+    // operand of a strict equality. The from-ast arm dispatches on the other
+    // operand's IrType (externref-shaped → runtime `__extern_is_undefined`;
+    // never-undefined representations → constant fold). LOOSE `==`/`!=` stay
+    // rejected: `null == undefined` is true, so a nullable-ref operand would
+    // need a runtime null check this slice doesn't emit.
+    if (binOp === ts.SyntaxKind.EqualsEqualsEqualsToken || binOp === ts.SyntaxKind.ExclamationEqualsEqualsToken) {
+      const isUndefIdent = (e: ts.Expression): boolean =>
+        ts.isIdentifier(e) && e.text === "undefined" && !scope.has("undefined");
+      const leftUndef = isUndefIdent(expr.left);
+      const rightUndef = isUndefIdent(expr.right);
+      if (leftUndef && rightUndef) return true;
+      if (rightUndef) return isPhase1Expr(expr.left, scope, localClasses);
+      if (leftUndef) return isPhase1Expr(expr.right, scope, localClasses);
+    }
+    if (!isPhase1BinaryOp(binOp)) return shapeNo(`expr-binary-op-${ts.tokenToString(binOp) ?? binOp}`, expr);
     return isPhase1Expr(expr.left, scope, localClasses) && isPhase1Expr(expr.right, scope, localClasses);
   }
   if (ts.isConditionalExpression(expr)) {
@@ -2276,6 +2327,28 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         !ts.isSpreadElement(expr.arguments[0]!)
       ) {
         return isPhase1Expr(expr.arguments[0]!, scope, localClasses);
+      }
+      // (#2856 C3) `<moduleMapConst>.get(k)` / `.set(k, v)` — the receiver is
+      // a module-scope `const <m> = new Map(...)` binding (never in the local
+      // scope set, so the generic receiver check below would reject it). The
+      // from-ast identifier arm lowers the receiver as a TDZ-checked
+      // `global.get $__mod_<m>` branded `extern:Map`; `.get`/`.set` then ride
+      // the existing extern method-call machinery (Map_get / Map_set host
+      // imports, registered by the legacy source scan). JS-host lane only —
+      // the set is empty otherwise.
+      if (
+        ts.isIdentifier(expr.expression.expression) &&
+        !scope.has(expr.expression.expression.text) &&
+        currentModuleScopeMapConsts.has(expr.expression.expression.text) &&
+        (expr.expression.name.text === "get" || expr.expression.name.text === "set")
+      ) {
+        const wantArgs = expr.expression.name.text === "get" ? 1 : 2;
+        if (expr.arguments.length !== wantArgs) return shapeNo("expr-modmap-arity", expr);
+        for (const arg of expr.arguments) {
+          if (ts.isSpreadElement(arg)) return shapeNo("expr-modmap-spread", arg);
+          if (!isPhase1Expr(arg, scope, localClasses)) return false;
+        }
+        return true;
       }
       if (!isPhase1Expr(expr.expression.expression, scope, localClasses)) return false;
       for (const arg of expr.arguments) {

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -253,6 +253,39 @@ export function verifyIrFunction(func: IrFunction): IrVerifyError[] {
     }
   }
 
+  // (#2856) Same #1798 gate for `early.return` instrs inside nested buffers —
+  // a Wasm `return` carries the function's result values, so a mis-typed
+  // early-return value would produce invalid Wasm at instantiate time. Flag
+  // it here so the function demotes to legacy instead.
+  for (const block of func.blocks) {
+    for (const instr of block.instrs) {
+      forEachInstrDeep(instr, (i) => {
+        if (i.kind !== "early.return") return;
+        const arity = i.value !== null ? 1 : 0;
+        if (arity !== func.resultTypes.length) {
+          errors.push({
+            message: `early.return arity ${arity} != declared result arity ${func.resultTypes.length}`,
+            func: func.name,
+            block: block.id as number,
+          });
+          return;
+        }
+        if (i.value === null) return;
+        const actual = operandIrType(func, block, i.value, new Set());
+        if (!actual) return; // not locally visible — SSA-scope check reports it
+        if (!returnTypeAssignable(actual, func.resultTypes[0]!)) {
+          errors.push({
+            message:
+              `early.return value type ${describeKind(actual)} not assignable to declared ` +
+              `result ${describeKind(func.resultTypes[0]!)}`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+      });
+    }
+  }
+
   return errors;
 }
 
@@ -692,6 +725,12 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       return [instr.value];
     case "async.throw":
       return [instr.reason];
+    // (#2856) Statement-level if — arm buffers are walked separately (same
+    // convention as the value-producing `if`); only the cond surfaces here.
+    case "if.stmt":
+      return [instr.cond];
+    case "early.return":
+      return instr.value !== null ? [instr.value] : [];
   }
 }
 

--- a/tests/ir-algorithms-cluster.test.ts
+++ b/tests/ir-algorithms-cluster.test.ts
@@ -1,0 +1,514 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2856 — algorithms.ts whole-component slice: the four capabilities that let
+// the `js/algorithms.ts` call-component (main → fibIter/fibMemo/joinNums/
+// binarySearch/quicksort) claim atomically on the IR path.
+//
+//   C1  statement-level `if` (+else) inside body buffers, and early `return`
+//       from inside a C-style loop (`early.return` → Wasm `return`).
+//   C2  element store `arr[i] = v` via the on-demand `__vec_elem_set_<t>`
+//       helper (full legacy parity: null-guard, grow-on-OOB, length update).
+//   C3  module-scope `const m = new Map()` receiver — TDZ-checked
+//       `global.get $__mod_<m>` branded `extern:Map`, `.get`/`.set` through
+//       the extern method-call machinery, strict undefined-compare, and the
+//       `__box_number`/`__unbox_number` coercion arms (JS-host lane).
+//   C4  the #1804 array-literal-under-C-loop guard retired (the slice-12
+//       buffer machinery already materializes the constructed vec into a
+//       local before the loop op), plus call-arg `ref → ref_null` widening
+//       and statement-position void direct calls.
+//
+// Every case asserts legacy/IR observable equality AND (where marked) that
+// the IR path was genuinely exercised — bytes must differ from the
+// `experimentalIR: false` compile, so a silent legacy demote fails the test
+// (the vacuous-pass hazard).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+const JS_STRING = {
+  concat: (a: string, b: string) => a + b,
+  length: (s: string) => s.length,
+  equals: (a: string, b: string) => (a === b ? 1 : 0),
+  substring: (s: string, start: number, end: number) => s.substring(start, end),
+  charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+  fromCharCode: (c: number) => String.fromCharCode(c),
+  cast: (s: unknown) => String(s),
+  test: (v: unknown) => (typeof v === "string" ? 1 : 0),
+};
+
+interface RunResult {
+  value: unknown;
+  binary: Uint8Array;
+  postClaim: unknown[];
+  logs: string[];
+}
+
+async function compileRun(source: string, fn: string, args: unknown[], experimentalIR: boolean): Promise<RunResult> {
+  const logs: string[] = [];
+  const r = await compile(source, { experimentalIR, trackFallbacks: true });
+  if (!r.success) {
+    throw new Error(`compile failed (${experimentalIR ? "IR" : "legacy"}): ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  built.env.console_log_string = (v: unknown) => logs.push(String(v));
+  built.env.console_log_number = (v: unknown) => logs.push(String(v));
+  built.env.console_log_bool = (v: unknown) => logs.push(String(!!v));
+  const imports: WebAssembly.Imports = { env: built.env, string_constants: built.string_constants };
+  imports["wasm:js-string"] = JS_STRING as unknown as WebAssembly.ModuleImports;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  const f = (instance.exports as Record<string, unknown>)[fn];
+  if (typeof f !== "function") throw new Error(`export ${fn} missing`);
+  return {
+    value: (f as (...a: unknown[]) => unknown)(...args),
+    binary: r.binary,
+    postClaim: r.irPostClaimErrors ?? [],
+    logs,
+  };
+}
+
+/**
+ * Assert legacy and IR agree on the observable result, the IR compile has
+ * ZERO post-claim demotions, and (when `expectClaimed`) the IR path was
+ * genuinely taken (bytes differ — not a vacuous legacy-vs-legacy pass).
+ */
+async function expectParity(
+  source: string,
+  fn: string,
+  args: unknown[],
+  expected: unknown,
+  opts: { expectClaimed?: boolean } = {},
+): Promise<void> {
+  const legacy = await compileRun(source, fn, args, false);
+  const ir = await compileRun(source, fn, args, true);
+  expect(legacy.value, "legacy value").toStrictEqual(expected);
+  expect(ir.value, "IR value matches legacy").toStrictEqual(legacy.value);
+  expect(ir.postClaim, "no post-claim demotions").toStrictEqual([]);
+  if (opts.expectClaimed !== false) {
+    expect(
+      Buffer.compare(Buffer.from(legacy.binary), Buffer.from(ir.binary)) !== 0,
+      "IR path exercised (bytes differ from legacy)",
+    ).toBe(true);
+  }
+}
+
+describe("#2856 C1 — if / early-return inside body buffers", () => {
+  it("if (no else) inside a for body", async () => {
+    await expectParity(
+      `export function main(): number {
+         let s = 0;
+         for (let i = 0; i < 10; i++) { if (i % 2 === 0) s = s + i; }
+         return s;
+       }`,
+      "main",
+      [],
+      20,
+    );
+  });
+
+  it("if/else inside a while body (binary search halving)", async () => {
+    await expectParity(
+      `function bs(arr: number[], target: number): number {
+         let lo = 0;
+         let hi = arr.length - 1;
+         while (lo <= hi) {
+           const mid = (lo + hi) >> 1;
+           const v = arr[mid];
+           if (v === target) return mid;
+           if (v < target) { lo = mid + 1; } else { hi = mid - 1; }
+         }
+         return -1;
+       }
+       export function main(): number {
+         const sorted = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144];
+         return bs(sorted, 13) * 100 + bs(sorted, 34) * 10 + (bs(sorted, 7) + 1);
+       }`,
+      "main",
+      [],
+      460,
+    );
+  });
+
+  it("early value return from inside a while loop", async () => {
+    await expectParity(
+      `function firstAbove(arr: number[], limit: number): number {
+         let i = 0;
+         while (i < arr.length) {
+           if (arr[i] > limit) return arr[i];
+           i++;
+         }
+         return -1;
+       }
+       export function main(): number {
+         const xs = [3, 9, 4, 17, 2];
+         return firstAbove(xs, 8) * 1000 + firstAbove(xs, 100);
+       }`,
+      "main",
+      [],
+      8999,
+    );
+  });
+
+  it("early bare return from a loop in a void function", async () => {
+    await expectParity(
+      `let seen = 0;
+       function scan(n: number): void {
+         for (let i = 0; i < n; i++) {
+           if (i === 3) return;
+           seen = seen + 1;
+         }
+       }
+       export function main(): number {
+         scan(10);
+         return seen;
+       }`,
+      "main",
+      [],
+      3,
+      // `seen` is a module-scope mutable binding — scan/main stay legacy;
+      // the point is behavior stays correct (no claim expected).
+      { expectClaimed: false },
+    );
+  });
+
+  it("early return inside try/finally stays on legacy (finally must run)", async () => {
+    // The selector must NOT claim an early return under a finally — a Wasm
+    // `return` would skip the inlined finally. Behavior parity is the bar.
+    await expectParity(
+      `function f(n: number): number {
+         let cleanup = 0;
+         for (let i = 0; i < n; i++) {
+           try {
+             if (i === 1) return 100 + cleanup;
+           } finally {
+             cleanup = cleanup + 1;
+           }
+         }
+         return cleanup;
+       }
+       export function main(): number { return f(5); }`,
+      "main",
+      [],
+      101,
+      { expectClaimed: false },
+    );
+  });
+});
+
+describe("#2856 C2 — element store arr[i] = v", () => {
+  it("in-place swap writes (quicksort) — whole component claims", async () => {
+    await expectParity(
+      `function quicksort(arr: number[], lo: number, hi: number): void {
+         if (lo >= hi) return;
+         const pivot = arr[hi];
+         let i = lo - 1;
+         for (let j = lo; j < hi; j++) {
+           if (arr[j] <= pivot) {
+             i++;
+             const tmp = arr[i];
+             arr[i] = arr[j];
+             arr[j] = tmp;
+           }
+         }
+         const tmp = arr[i + 1];
+         arr[i + 1] = arr[hi];
+         arr[hi] = tmp;
+         const p = i + 1;
+         quicksort(arr, lo, p - 1);
+         quicksort(arr, p + 1, hi);
+       }
+       export function main(): number {
+         const unsorted = [5, 2, 8, 1, 9, 3, 7, 4, 6, 0];
+         quicksort(unsorted, 0, unsorted.length - 1);
+         let acc = 0;
+         for (let i = 0; i < 10; i++) { acc = acc * 10 + unsorted[i]; }
+         return acc;
+       }`,
+      "main",
+      [],
+      123456789,
+    );
+  });
+
+  it("growing store — write past the end grows capacity and length", async () => {
+    await expectParity(
+      `export function main(): number {
+         const a = [9];
+         for (let i = 0; i < 6; i++) { a[i] = i + 1; }
+         return a.length * 1000000 + a[0] * 10 + a[5];
+       }`,
+      "main",
+      [],
+      6000016,
+    );
+  });
+
+  it("store through a param (possibly-null vec) round-trips", async () => {
+    await expectParity(
+      `function w(a: number[], i: number, v: number): number { a[i] = v; return a[i]; }
+       export function main(): number { const xs = [1, 2, 3]; return w(xs, 1, 42); }`,
+      "main",
+      [],
+      42,
+    );
+  });
+});
+
+describe("#2856 C3 — module-scope Map + strict undefined-compare (JS-host lane)", () => {
+  it("memoized fib through a module-scope Map claims and agrees", async () => {
+    await expectParity(
+      `const cache = new Map<number, number>();
+       function memo(n: number): number {
+         if (n < 2) return n;
+         const hit = cache.get(n);
+         if (hit !== undefined) return hit;
+         const v = memo(n - 1) + memo(n - 2);
+         cache.set(n, v);
+         return v;
+       }
+       export function main(): number { return memo(30); }`,
+      "main",
+      [],
+      832040,
+    );
+  });
+
+  it("mixed front-ends share the Map storage slot (IR writer, legacy reader)", async () => {
+    // `reader` uses a labeled block — a direct-only statement kind, so it
+    // stays on the LEGACY front-end while `writer` claims on the IR path.
+    // The two are separate exports with no local caller (a shared local
+    // `main` would contagion-demote writer alongside reader), driven from
+    // the harness: the value written by the IR-compiled function must be
+    // read back by the legacy-compiled one through the SAME `__mod_shared`
+    // global (storage-slot parity).
+    const src = `const shared = new Map<number, number>();
+       export function writer(k: number, v: number): number {
+         let i = 0;
+         while (i < 1) { shared.set(k, v); i++; }
+         return i;
+       }
+       export function reader(k: number): number {
+         outer: {
+           const hit = shared.get(k);
+           if (hit !== undefined) return hit;
+         }
+         return -1;
+       }`;
+    for (const experimentalIR of [false, true]) {
+      const r = await compile(src, { experimentalIR, trackFallbacks: true });
+      expect(r.success).toBe(true);
+      const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+      const imports: WebAssembly.Imports = { env: built.env, string_constants: built.string_constants };
+      imports["wasm:js-string"] = JS_STRING as unknown as WebAssembly.ModuleImports;
+      const { instance } = await WebAssembly.instantiate(r.binary, imports);
+      built.setExports?.(instance.exports as Record<string, Function>);
+      const ex = instance.exports as Record<string, (...a: number[]) => number>;
+      ex.writer!(7, 4200);
+      expect(ex.reader!(7), `read-back (${experimentalIR ? "IR" : "legacy"})`).toBe(4200);
+      expect(ex.reader!(8), `missing key (${experimentalIR ? "IR" : "legacy"})`).toBe(-1);
+      if (experimentalIR) {
+        expect(r.irPostClaimErrors ?? []).toStrictEqual([]);
+        // writer genuinely claimed: its IR compile must differ from legacy.
+        const legacyR = await compile(src, { experimentalIR: false });
+        expect(Buffer.compare(Buffer.from(legacyR.binary), Buffer.from(r.binary)) !== 0, "writer claimed").toBe(true);
+      }
+    }
+  });
+
+  it("strict undefined-compare folds on an f64 operand (matches legacy)", async () => {
+    await expectParity(
+      `function f(x: number): number {
+         if (x !== undefined) return 1;
+         return 0;
+       }
+       export function main(): number { return f(5); }`,
+      "main",
+      [],
+      1,
+      // Whether this claims depends on TypeMap details; the bar is parity.
+      { expectClaimed: false },
+    );
+  });
+});
+
+describe("#2856 C4 — array literal + C-style loop (retired #1804 guard)", () => {
+  it("constructed vec read inside a for body", async () => {
+    await expectParity(
+      `export function main(): number {
+         const a = [1, 2, 3, 4];
+         let s = 0;
+         for (let i = 0; i < 4; i++) { s = s + a[i]; }
+         return s;
+       }`,
+      "main",
+      [],
+      10,
+    );
+  });
+
+  it("constructed vec read in a while cond", async () => {
+    await expectParity(
+      `export function main(): number {
+         const a = [10, 20, 0, 5];
+         let i = 0;
+         let s = 0;
+         while (a[i] > 0) { s = s + a[i]; i++; }
+         return s;
+       }`,
+      "main",
+      [],
+      30,
+    );
+  });
+
+  it("vec constructed inside the loop body (fresh per iteration)", async () => {
+    await expectParity(
+      `export function main(): number {
+         let s = 0;
+         for (let i = 0; i < 3; i++) {
+           const a = [i, i * 2, i * 3];
+           s = s + a[0] + a[1] + a[2];
+         }
+         return s;
+       }`,
+      "main",
+      [],
+      18,
+    );
+  });
+
+  it("literal-after-loop passed as a ref arg into a ref_null param", async () => {
+    await expectParity(
+      `function g(xs: number[]): number { let t = 0; for (const x of xs) { t += x; } return t; }
+       export function main(): number {
+         let acc = 0;
+         for (let n = 0; n < 3; n++) { acc = acc + n; }
+         const sorted = [1, 3, 5];
+         return acc + g(sorted) + sorted.length;
+       }`,
+      "main",
+      [],
+      15,
+    );
+  });
+
+  it("nested loops + do-while over a constructed vec", async () => {
+    await expectParity(
+      `export function main(): number {
+         const a = [1, 2, 3];
+         let s = 0;
+         for (let i = 0; i < 3; i++) {
+           let j = 0;
+           while (j < 3) { s = s + a[i] * a[j]; j++; }
+         }
+         let k = 0;
+         do { s = s + a[k]; k++; } while (k < 3);
+         return s;
+       }`,
+      "main",
+      [],
+      42,
+    );
+  });
+});
+
+describe("#2856 — whole algorithms.ts component end-to-end", () => {
+  // A trimmed copy of website/playground/examples/js/algorithms.ts (the gate
+  // corpus file): the five-function call-component must claim atomically and
+  // produce console output identical to legacy.
+  const ALGORITHMS = `
+    function fibIter(n: number): number {
+      let a = 0;
+      let b = 1;
+      for (let i = 0; i < n; i++) {
+        const next = a + b;
+        a = b;
+        b = next;
+      }
+      return a;
+    }
+    const fibCache = new Map<number, number>();
+    function fibMemo(n: number): number {
+      if (n < 2) return n;
+      const hit = fibCache.get(n);
+      if (hit !== undefined) return hit;
+      const v = fibMemo(n - 1) + fibMemo(n - 2);
+      fibCache.set(n, v);
+      return v;
+    }
+    function binarySearch(arr: number[], target: number): number {
+      let lo = 0;
+      let hi = arr.length - 1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const v = arr[mid];
+        if (v === target) return mid;
+        if (v < target) {
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      return -1;
+    }
+    function quicksort(arr: number[], lo: number, hi: number): void {
+      if (lo >= hi) return;
+      const pivot = arr[hi];
+      let i = lo - 1;
+      for (let j = lo; j < hi; j++) {
+        if (arr[j] <= pivot) {
+          i++;
+          const tmp = arr[i];
+          arr[i] = arr[j];
+          arr[j] = tmp;
+        }
+      }
+      const tmp = arr[i + 1];
+      arr[i + 1] = arr[hi];
+      arr[hi] = tmp;
+      const p = i + 1;
+      quicksort(arr, lo, p - 1);
+      quicksort(arr, p + 1, hi);
+    }
+    function joinNums(arr: number[]): string {
+      let s = "";
+      for (let i = 0; i < arr.length; i++) {
+        if (i > 0) s = s + ",";
+        s = s + arr[i].toString();
+      }
+      return s;
+    }
+    export function main(): void {
+      console.log("fib(10) iter = " + fibIter(10).toString() + " memo = " + fibMemo(10).toString());
+      const sorted = [1, 3, 5, 8, 13, 21, 34, 55, 89, 144];
+      console.log("indexOf(13) = " + binarySearch(sorted, 13).toString());
+      console.log("indexOf(7)  = " + binarySearch(sorted, 7).toString());
+      const unsorted = [5, 2, 8, 1, 9, 3, 7, 4, 6, 0];
+      quicksort(unsorted, 0, unsorted.length - 1);
+      console.log("after = [" + joinNums(unsorted) + "]");
+    }`;
+
+  it("console output identical, component claimed, zero demotions", async () => {
+    const legacy = await compileRun(ALGORITHMS, "main", [], false);
+    const ir = await compileRun(ALGORITHMS, "main", [], true);
+    expect(ir.postClaim).toStrictEqual([]);
+    expect(ir.logs).toStrictEqual(legacy.logs);
+    expect(ir.logs.length).toBeGreaterThan(0);
+    expect(ir.logs[ir.logs.length - 1]).toBe("after = [0,1,2,3,4,5,6,7,8,9]");
+    expect(Buffer.compare(Buffer.from(legacy.binary), Buffer.from(ir.binary)) !== 0, "IR path exercised").toBe(true);
+  });
+
+  it("standalone / wasi compiles stay clean (host-gated Map arm defers)", async () => {
+    for (const extra of [{ standalone: true }, { target: "wasi" as const }]) {
+      const r = await compile(ALGORITHMS, { experimentalIR: true, trackFallbacks: true, ...(extra as object) });
+      expect(r.success, `compile ok under ${JSON.stringify(extra)}`).toBe(true);
+      expect(r.irPostClaimErrors ?? []).toStrictEqual([]);
+    }
+  });
+});

--- a/tests/ir-scaffold.test.ts
+++ b/tests/ir-scaffold.test.ts
@@ -89,6 +89,8 @@ describe("ir scaffold — phase 1", () => {
     // #1169a (Slice 1) widens the selector to accept `string` params and
     // `string` returns, plus string literals as expression leaves — so
     // `nonNumeric()` and `stringParam(s)` now also enter the IR path.
+    // (#2856 C1) `withWhile` — an early `return` directly as a while body —
+    // is now claimable (statement-level early-return inside C-style loops).
     expect([...sel.funcs].sort()).toEqual([
       "compound",
       "nonNumeric",
@@ -101,6 +103,7 @@ describe("ir scaffold — phase 1", () => {
       "withLet",
       "withLocal",
       "withParam",
+      "withWhile",
     ]);
   });
 


### PR DESCRIPTION
## What

The first executable slice of the re-scoped #2856 capability program: the **whole `js/algorithms.ts` call-component** (`main` → `fibIter`/`fibMemo`/`joinNums`/`binarySearch`/`quicksort`) claims the IR path **atomically** — per the Step-2 contagion analysis, partial landings are provably net-zero, so all four capabilities land in this one PR.

**Gate (vs current main): `body-shape-rejected` 22 → 18, `call-graph-closure` 11 → 9, `class-method` unchanged, post-claim demotions ZERO.** Net unintended 38 → 32, banked in `scripts/ir-fallback-baseline.json`.

## Capabilities

- **C1 — `early.return`** (new IR instr): early `return` inside C-style loop bodies, lowered to the Wasm `return` op. Selector-enforced soundness scope mirrored in from-ast: never under for-of (iterator `return()` cleanup), try/catch/finally (inlined finally), constructors, or generators. Statement-`if` in body buffers rides #2952 slice 2's `if.stmt` (this PR merged it and de-duplicated the two convergent implementations, keeping upstream's ctrlStack-aware arm).
- **C2 — element store `arr[i] = v`** via an on-demand `__vec_elem_set_<vecTypeIdx>` helper (`src/codegen/vec-elem-set.ts`, `resolveFunc`-materialized like `ensureFmod`): FULL legacy semantics — null-guard throw, grow-on-OOB (capacity doubling + copy), JS length update — because the growing write is common in newly-claimable code and a bare `array.set` would trap. Pure WasmGC, no host import. TypedArray-view receivers demote (per-view ToUint8/clamp conversions stay legacy).
- **C3 — module-scope `const m = new Map()`** without a Map-in-IR predecessor: module-level statements always compile via legacy, so the IR reads the SAME `__mod_<m>` global legacy allocated (TDZ-checked `global.get`, branded `extern:Map`) and `.get`/`.set` ride the existing extern method-call lane (`Map_get`/`Map_set` imports). Plus strict undefined-compare (`hit !== undefined` → `__extern_is_undefined` on externref-shaped operands, sound constant-fold on never-undefined reps; loose `==` stays legacy) and `__box_number`/`__unbox_number` coercion arms matching legacy's emission byte-for-byte at the same sites. JS-host lane only — standalone/wasi correctly defer to legacy (verified clean).
- **C4 — #1804 guard retired**: the slice-12 buffer machinery (synthetic −1 block-id use recording) already materializes constructed vecs into locals before loop ops; verified with a 7-shape battery, each claim proven by byte-diff. Plus call-arg `ref → ref_null` widening and statement-position void direct calls (`quicksort(arr, lo, p-1);`).

## Latent bugs found & fixed

1. **`inline-small` corrupted value-`if` arm buffers** (duplicate SSA defs — arm-buffer defs aren't deep-renamed). Latent on main; exposed by C4's arg widening. Fix: `if` joins `canInline`'s buffer-bearing exclusions.
2. **Nested-buffer emission silently DROPPED zero-use side-effecting instrs** (e.g. `map.set(k, v);` in a loop body — Map_set's unused non-void result meant the call was never emitted). Caught by the mixed-front-end storage-parity test. Fix: the `emitBlockBody` eager emit+drop contract now applies in `emitBufferAsStatements` and every remaining per-arm emission loop.

## Verification

- `tests/ir-algorithms-cluster.test.ts` (new, 18 tests): per-capability legacy/IR parity with **byte-diff claim proofs** (anti-vacuity), growing store, mixed IR-writer/legacy-reader Map storage parity, try/finally early-return negative, whole-component e2e **console-output equality (20/20 lines)**, standalone/wasi cleanliness.
- `js/algorithms.ts` end-to-end: IR vs legacy output identical, zero demotions, in both pre-merge and post-#2952-merge trees.
- IR suite parity with pristine main (pre-existing container failures verified side-by-side; only intended drift: `withWhile` joins ir-scaffold's expected claims).
- #2952 slice-2 tests green post-merge (27/27) + a break/continue/early-return interaction probe (all three in one loop: claimed, equal, zero demotions).
- Byte-inert for non-claimed programs by construction: no legacy codegen path modified (only a NEW helper file reachable from the IR resolver).

Closes nothing — #2856 stays a tracking epic (`status: blocked`; remaining clusters documented in the issue: benchmark-harness −8 behind #2858, bench_array, calendar, classes, async).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8