### PR TITLE
feat(#3029/#3030): freeze five-part backend contract (S1+S4) + IR interchange contract v1.0 (T1)

### DIFF
--- a/docs/architecture/target-architecture.md
+++ b/docs/architecture/target-architecture.md
@@ -58,6 +58,13 @@ Rules the stack implies:
 
 ## The backend contract (what a NEW backend implements)
 
+> **Frozen as code (#3029-S1/S4, 2026-07-04):**
+> [`src/ir/backend/contract.ts`](../../src/ir/backend/contract.ts) declares
+> the five interfaces (ModuleAssembler invariants A1–A7 inline);
+> [`src/ir/backend/README.md`](../../src/ir/backend/README.md) is the
+> ownership/rules README; `src/ir/backend/contract-conformance.ts` is the
+> tsc-enforced conformance skeleton.
+
 A backend — WasmGC, linear, bytecode, or a future MLIR/Cranelift lowering —
 is **five declared parts**, all consulted through interfaces, none through
 imports of another backend's internals:
@@ -121,6 +128,11 @@ The size threshold is deliberately generous (the field's "understood in
 isolation" bar is 1–2k); the point is the _ratchet_, not the number.
 
 ## The IR interchange contract (summary — #3030 is normative)
+
+> **Frozen (#3030-T1, 2026-07-04):** [`docs/ir/ir-contract.md`](../ir/ir-contract.md)
+> (normative D1–D5 + node inventory + type rules) +
+> [`docs/ir/ir-module.schema.json`](../ir/ir-module.schema.json) +
+> `IR_FORMAT_VERSION` in `src/ir/contract.ts`.
 
 What an external consumer (other engine, out-of-tree backend, analysis tool)
 may rely on, once #3030 lands:

--- a/docs/ir/ir-contract.md
+++ b/docs/ir/ir-contract.md
@@ -1,0 +1,365 @@
+# The IR interchange contract — v1.0
+
+> **Normative.** The #3030 contract is the union of this document,
+> [`ir-module.schema.json`](ir-module.schema.json), and the exported
+> `IR_FORMAT_VERSION` in [`src/ir/contract.ts`](../../src/ir/contract.ts).
+> Ratified 2026-07-04 (Fable, #3030-T1). The umbrella issue
+> `plan/issues/3030-ir-interchange-contract.md` tracks the implementation
+> slices (T2 index purge, T3 serializer, T4 verifier rules, T5 schema gate,
+> T6 example consumer). Architecture context:
+> [`../architecture/target-architecture.md`](../architecture/target-architecture.md)
+> — this contract is the L3/L4 interchange boundary.
+
+**Audience:** external consumers — other engines (e.g. SpiderMonkey deriving
+types statically ahead-of-time instead of warming inline caches), analysis
+tools, and out-of-tree backends (MLIR-class) — plus the in-tree slices that
+implement the serializer/verifier against this text.
+
+---
+
+## D1 — Format: canonical JSON
+
+One JSON document per compiled module.
+
+- Top-level field `irVersion` (string, semver `MAJOR.MINOR`).
+- **Deterministic serialization**: object keys in the fixed order the schema
+  lists them; object-shape field lists are name-sorted (already canonical in
+  the IR); arrays preserve program order. Re-serializing a deserialized
+  module MUST be byte-identical (the T3 round-trip property).
+- No floating-point canonicalization surprises: numbers serialize via JS
+  `JSON.stringify` semantics; non-finite f64 constants serialize as the
+  strings `"NaN"`, `"Infinity"`, `"-Infinity"` (JSON has no literals for
+  them); negative zero serializes as the string `"-0"`.
+- `i64` constants serialize as **decimal strings** (JSON numbers cannot carry
+  64-bit integers losslessly).
+- A binary encoding is an explicit **v2 non-goal** (JSON gzips well; modules
+  are per-file).
+
+## D2 — Versioning
+
+`IR_FORMAT_VERSION = "1.0"` (exported from `src/ir/contract.ts`).
+
+- **Additive** (minor bump): new instruction kinds, new optional fields, new
+  enum members appended at the END of their table.
+- **Breaking** (major bump): removing/renaming a field or kind, reordering
+  an enum table, changing any serialized representation.
+- All enum tables in §"Frozen enum tables" are **append-only, frozen-order**
+  (the #1852 linear-tag-enum discipline).
+- The T5 CI snapshot gate fails any PR that changes the serialized shape
+  without bumping `IR_FORMAT_VERSION`.
+- A consumer MUST reject a document whose major version it does not know,
+  and MAY accept an unknown minor version (ignoring unknown kinds/fields is
+  NOT safe for analysis soundness — a consumer that needs soundness treats
+  unknown instruction kinds as "function not analyzable").
+
+## D3 — Guarantees (what a consumer may rely on)
+
+1. **Typed block-argument SSA.** Every function is a list of basic blocks;
+   block 0 is the entry and its block args are exactly the function params.
+   Every SSA value has a single defining site (a block arg or an
+   instruction `result`), definitions dominate uses, and every block ends
+   with exactly one terminator. There are no Φ nodes — branches pass values
+   into target block-arg slots.
+2. **Symbolic names only.** Functions, globals, and types are referenced by
+   name (`IrFuncRef`/`IrGlobalRef`/`IrTypeRef`). No funcIdx / globalIdx /
+   typeIdx appears anywhere in a serialized document (D5 closes the one
+   historical leak inside `IrType`; see T2).
+3. **Verified per-instruction `resultType`.** Every value-producing
+   instruction carries its result type, and the verifier **re-derives** it
+   from operand types per the §"Node inventory" rules (#1924).
+   ⚠ _Effectivity:_ this guarantee is **effective from verifier ≥ T4**. At
+   T1 the rules are normative text; until T4 lands, `resultType` is
+   producer-claimed and a consumer requiring soundness must not build on it.
+4. **Explicit dynamic boundaries.** A value is either statically typed or
+   `dynamic`. Every crossing is a serialized `box` / `unbox` / `tag.test`
+   instruction carrying its `JsTag` partition (#2949 R1–R6). This is the
+   AOT-type-derivation payload: a consumer reads exactly where dynamism
+   enters and which partition proof guards each unbox.
+5. **Ordered effects.** The per-kind effect classification (§"Effect
+   classification") is part of this contract; instruction order within a
+   block is program order, and any reordering the compiler performed
+   respected the classification (#2134). Effects are _derived_ (published
+   table), not serialized per instruction in v1.0.
+6. **Source positions.** Instructions and terminators may carry
+   `site: {line, column}` (1-based line, 0-based column, in the `source`
+   file named by the header). Alloc-site provenance rides on `alloc`
+   (module-global stable id, ADR-0013).
+7. **Honest coverage manifest.** The document header lists EVERY function
+   in the module with `carrier: "ir" | "legacy"`. Only `"ir"` functions
+   have serialized bodies; the contract ships at partial coverage and grows
+   (#2855/#2950/#2949) — it does not lie about what it covers.
+
+## D4 — Exclusions (never serialized)
+
+Layout handles (`IrVecLowering` etc.), `BackendLegality` sets, the Wasm
+`Instr` union, resolver/lowering state — anything below the L4 legalization
+line. A consumer never sees a WasmGC struct index or a linear memory offset.
+
+**The `raw.wasm` rule (serializability predicate).** The in-memory IR has an
+escape-hatch instruction `raw.wasm` embedding backend `Instr` ops. Because
+D4 forbids serializing those ops, **a function whose body (including nested
+buffers) contains `raw.wasm` is NOT serializable**: it appears in the
+coverage manifest as `carrier: "legacy"`, `reason: "raw-wasm-bridge"`, with
+no body. `raw.wasm` therefore does NOT appear in the serialized instruction
+inventory below.
+
+**The slot-type rule.** Wasm-local slots (`IrSlotDef.type`) are restricted to
+the closed scalar `val` set of D5 in serialized documents. A function whose
+slots carry module-relative ref types is not serializable until T2
+symbolizes them.
+
+## D5 — The type story (serialized `IrType`)
+
+The serialized `IrType` carries **no module-relative index**. Grammar
+(discriminated on `kind`):
+
+| kind      | payload                                                  | meaning                                                                             |
+| --------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `val`     | `val: ScalarVal`, `signed?: boolean`                     | one concrete Wasm-level scalar/opaque-ref slot                                      |
+| `string`  | —                                                        | backend-agnostic string                                                             |
+| `object`  | `shape: {fields: [{name, type}]}` (name-sorted)          | structural object shape                                                             |
+| `closure` | `signature: {params: IrType[], returnType: IrType}`      | callable value; captures are NOT a type property                                    |
+| `class`   | `shape: {className, fields, methods, constructorParams}` | nominal class instance (`className` is the identity)                                |
+| `extern`  | `className: string`                                      | opaque host-class reference (RegExp, Map, Date, …)                                  |
+| `union`   | `members: IrType[]`                                      | tagged scalar union (v1: homogeneous-width scalar members)                          |
+| `boxed`   | `inner: IrType`                                          | single-field heap cell (mutable-capture ref cell)                                   |
+| `dynamic` | `tag?: JsTag`                                            | statically-unknown JS value; optional proven partition refinement (erased at joins) |
+
+`ScalarVal` is the **closed** set of non-indexed leaves (append-only table):
+
+```
+i32 (+ optional boolean / symbol brands) · i64 (+ optional bigint brand)
+f32 · f64 · v128 · i8 · i16 · funcref · externref · ref_extern · eqref · anyref
+```
+
+`ref` / `ref_null` leaves — which in the in-memory compiler still carry a
+module-relative `typeIdx` (the #1926 residue) — serialize as **symbolic type
+names**: `{"kind": "ref" | "ref_null", "name": "<IrTypeRef name>"}`. Indices
+are resolved only at lowering, on the compiler side. Executing this purge in
+the in-memory `IrType` is **T2**; until T2 lands, functions whose types
+contain a `ref`/`ref_null` leaf are manifest-listed as `carrier: "legacy"`
+(reason `"module-relative-type"`) rather than serialized with an index.
+Brands (`signed`, `boolean`, `symbol`, `bigint`) serialize explicitly when
+present.
+
+## Name namespaces
+
+Three flat, module-scoped namespaces, each owned by the module assembler
+(#3029-S4 invariant A6) and shared with the in-memory compiler's
+`ctx.funcMap` / global map / `ctx.typeNames`:
+
+- **func** — targeted by `IrFuncRef` (`call.target`, `closure.new.liftedFunc`).
+- **global** — targeted by `IrGlobalRef` (`global.get/set.target`).
+- **type** — targeted by `IrTypeRef` (D5 symbolic `ref` leaves).
+
+Names are unique within their namespace. Class-derived names follow the
+legacy conventions (`<className>_new`, `<className>_<methodName>`) — a
+consumer treats them as opaque.
+
+## Document layout
+
+```
+IrModuleDocument
+├─ irVersion: "1.0"
+├─ source?: string
+├─ coverage: [{name, carrier: "ir"|"legacy", exported, reason?}]   (D3.7)
+└─ functions: [IrFunctionDoc]           (exactly the carrier:"ir" entries)
+   ├─ name, exported, funcKind?: "regular"|"generator"|"async"
+   ├─ params: [{value: ValueId, name, type: IrType}]
+   ├─ resultTypes: [IrType]
+   ├─ slots?: [{index, name, type: ScalarVal-only ValType}]        (D4)
+   ├─ valueCount: number
+   └─ blocks: [IrBlock]                 (blocks[0] = entry)
+      ├─ id, blockArgs: [ValueId], blockArgTypes: [IrType]
+      ├─ instrs: [IrInstr]              (§ Node inventory)
+      └─ terminator: return | br | br_if | unreachable
+```
+
+`ValueId`, `BlockId`, `LabelId`, `AllocSiteId` are non-negative integers.
+`ValueId` scope is one function; `AllocSiteId` is module-global and stable
+across transformations (ADR-0013).
+
+**Constants** (`const.value`): `{kind: "i32"|"f32"|"f64", value: number}`
+(f64 non-finite/−0 per D1), `{kind: "i64", value: "<decimal string>"}`,
+`{kind: "bool", value: boolean}`, `{kind: "null", ty: IrType}`,
+`{kind: "undefined"}`.
+
+**Terminators:**
+
+| kind          | fields                                           | rule                                                         |
+| ------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| `return`      | `values: [ValueId]`                              | value types must equal `resultTypes` (arity + per-slot type) |
+| `br`          | `branch: {target, args}`                         | arg types must equal the target block's `blockArgTypes`      |
+| `br_if`       | `condition`, `ifTrue: branch`, `ifFalse: branch` | condition is `val:i32`; both branches type-check as `br`     |
+| `unreachable` | —                                                | —                                                            |
+
+## Node inventory + type rules
+
+Notation: operands are SSA `ValueId`s; `τ(v)` is the (verified) type of `v`;
+`⇒` gives the required `resultType`; `∅` = void (`result: null`). _Effects_
+column keys into §"Effect classification". _Buffers_ lists nested
+`IrInstr[]` regions (structured-IR, ADR-0018) in evaluation order. These
+tables are the single source the T4 verifier implements — doc and verifier
+must not diverge (T4 acceptance).
+
+### Values, scalars, control expressions
+
+| kind     | operands                             | immediates     | result rule                                                                                                                                                | effects         | buffers        |
+| -------- | ------------------------------------ | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | -------------- |
+| `const`  | —                                    | `value: Const` | i32⇒`val:i32` · i64⇒`val:i64` · f32⇒`val:f32` · f64⇒`val:f64` · bool⇒`val:i32` · null⇒`value.ty` · undefined⇒producer-declared carrier (pinned by T4)      | pure            | —              |
+| `binary` | `lhs`, `rhs`                         | `op: IrBinop`  | per-op: `f64.*` arith⇒`val:f64`; all comparisons⇒`val:i32`; `i32.and/or`⇒`val:i32`; `js.*`⇒`val:f64` (or `val:i32` when both operands i32-narrowed, #1126) | pure            | —              |
+| `unary`  | `rand`                               | `op: IrUnop`   | `f64.*`⇒`val:f64` · `i32.eqz`⇒`val:i32` · `i32.trunc_sat_f64_s`⇒`val:i32` · `ref.is_null`⇒`val:i32`                                                        | pure            | —              |
+| `select` | `condition`, `whenTrue`, `whenFalse` | —              | `τ(whenTrue) = τ(whenFalse)` ⇒ that type; condition `val:i32`; both arms evaluated (no short-circuit)                                                      | pure            | —              |
+| `if`     | `cond`, `thenValue`, `elseValue`     | —              | short-circuiting value if; `τ(thenValue) = τ(elseValue) = resultType`; carrier values defined inside the matching arm                                      | join of buffers | `then`, `else` |
+
+### Calls and module state
+
+| kind         | operands | immediates          | result rule                                            | effects      |
+| ------------ | -------- | ------------------- | ------------------------------------------------------ | ------------ |
+| `call`       | `args[]` | `target: FuncRef`   | the named function's declared return type (∅ for void) | full barrier |
+| `global.get` | —        | `target: GlobalRef` | the named global's declared type                       | reads heap   |
+| `global.set` | `value`  | `target: GlobalRef` | ∅; `τ(value)` = global's type                          | writes heap  |
+| `slot.read`  | —        | `slotIndex`         | `val` of the slot's declared ValType                   | slot-read    |
+| `slot.write` | `value`  | `slotIndex`         | ∅; `τ(value)` = slot's declared type                   | slot-write   |
+
+### Dynamic boundary (D3.4 — the AOT payload)
+
+| kind       | operands | immediates                       | result rule                                                                                                                                                                 | effects |
+| ---------- | -------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `box`      | `value`  | `toType: IrType`                 | ⇒ `toType`. union target: `τ(value)`'s ValType ∈ members. dynamic target: `τ(value)` NOT dynamic (re-box rejected)                                                          | pure    |
+| `unbox`    | `value`  | `tag?: ValType`, `jsTag?: JsTag` | union operand: `tag` REQUIRED, ⇒ `val:tag`. dynamic operand: `jsTag` REQUIRED with a payload partition, ⇒ the partition's payload type. Caller must hold a `tag.test` proof | pure    |
+| `tag.test` | `value`  | `tag?: ValType`, `jsTag?: JsTag` | ⇒ `val:i32` (1 = runtime tag matches). union operand: `tag` REQUIRED. dynamic operand: `jsTag` REQUIRED (any partition, incl. Null/Undefined)                               | pure    |
+
+### Strings
+
+| kind            | operands     | immediates        | result rule                              | effects |
+| --------------- | ------------ | ----------------- | ---------------------------------------- | ------- |
+| `string.const`  | —            | `value: string`   | ⇒ `string`                               | pure    |
+| `string.concat` | `lhs`, `rhs` | —                 | operands `string` ⇒ `string`             | pure    |
+| `string.eq`     | `lhs`, `rhs` | `negate: boolean` | operands `string` ⇒ `val:i32`            | pure    |
+| `string.len`    | `value`      | —                 | operand `string` ⇒ `val:f64` (JS Number) | pure    |
+
+### Objects, closures, ref cells, classes
+
+| kind           | operands             | immediates                                                | result rule                                                                    | effects      |
+| -------------- | -------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------ |
+| `object.new`   | `values[]`           | `shape`                                                   | `values` parallel to `shape.fields` (arity + per-field type) ⇒ `object{shape}` | pure (alloc) |
+| `object.get`   | `value`              | `name`                                                    | `τ(value)=object`, `name ∈ shape` ⇒ the field's type                           | reads heap   |
+| `object.set`   | `value`, `newValue`  | `name`                                                    | ∅; `τ(newValue)` = field's type                                                | writes heap  |
+| `closure.new`  | `captures[]`         | `liftedFunc: FuncRef`, `signature`, `captureFieldTypes[]` | `captures` parallel to `captureFieldTypes` ⇒ `closure{signature}`              | pure (alloc) |
+| `closure.cap`  | `self`               | `index`                                                   | valid only in lifted bodies w/ `closureSubtype`; ⇒ `captureFieldTypes[index]`  | reads heap   |
+| `closure.call` | `callee`, `args[]`   | —                                                         | `τ(callee)=closure`; args match `signature.params` ⇒ `signature.returnType`    | full barrier |
+| `refcell.new`  | `value`              | —                                                         | ⇒ `boxed{inner: τ(value)}`                                                     | pure (alloc) |
+| `refcell.get`  | `cell`               | —                                                         | `τ(cell)=boxed` ⇒ `cell.inner`                                                 | reads heap   |
+| `refcell.set`  | `cell`, `value`      | —                                                         | ∅; `τ(value)` = `cell.inner`                                                   | writes heap  |
+| `class.new`    | `args[]`             | `shape`                                                   | args match `shape.constructorParams` ⇒ `class{shape}`                          | full barrier |
+| `class.get`    | `value`              | `fieldName`                                               | `τ(value)=class`, field ∈ shape ⇒ field type                                   | reads heap   |
+| `class.set`    | `value`, `newValue`  | `fieldName`                                               | ∅; `τ(newValue)` = field type                                                  | writes heap  |
+| `class.call`   | `receiver`, `args[]` | `methodName`                                              | method ∈ shape; args match method params ⇒ method returnType (∅ if null)       | full barrier |
+
+### Vectors (arrays)
+
+| kind            | operands       | immediates            | result rule                                                             | effects      |
+| --------------- | -------------- | --------------------- | ----------------------------------------------------------------------- | ------------ |
+| `vec.len`       | `vec`          | —                     | ⇒ `val:f64` (JS Number semantics)                                       | reads heap   |
+| `vec.get`       | `vec`, `index` | —                     | `τ(index)=val:i32` ⇒ the vec's element type (= `resultType`)            | reads heap   |
+| `vec.new_fixed` | `elements[]`   | `elementType: IrType` | every `τ(element)` = `elementType` ⇒ the vec ref type for `elementType` | pure (alloc) |
+
+### Iteration + structured statement loops (buffers per ADR-0018)
+
+| kind           | operands    | immediates                                    | result rule                                           | effects         | buffers                  |
+| -------------- | ----------- | --------------------------------------------- | ----------------------------------------------------- | --------------- | ------------------------ |
+| `forof.vec`    | `vec`       | `elementType`, slot indices, `loopLabel?`     | ∅                                                     | join of body    | `body`                   |
+| `forof.iter`   | `iterable`  | slot indices, `loopLabel?`                    | ∅                                                     | full barrier    | `body`                   |
+| `forof.string` | `str`       | slot indices, `loopLabel?`                    | ∅                                                     | join of body    | `body`                   |
+| `while.loop`   | `condValue` | `loopLabel?`                                  | ∅; `τ(condValue)=val:i32`, defined in `cond`          | join of buffers | `cond`, `body`           |
+| `for.loop`     | `condValue` | `loopLabel?`                                  | ∅; as `while.loop`                                    | join of buffers | `cond`, `body`, `update` |
+| `br.label`     | —           | `label: LabelId`, `mode: "break"\|"continue"` | ∅; label must name an enclosing loop/labeled frame    | control         | —                        |
+| `if.stmt`      | `cond`      | —                                             | ∅; `τ(cond)=val:i32`                                  | join of arms    | `then`, `else`           |
+| `iter.new`     | `iterable`  | `async: boolean`                              | ⇒ `val:externref` (iterator object)                   | full barrier    | —                        |
+| `iter.next`    | `iter`      | —                                             | ⇒ `val:externref` (IterResult); advances the iterator | full barrier    | —                        |
+| `iter.done`    | `resultObj` | —                                             | ⇒ `val:i32`                                           | reads heap      | —                        |
+| `iter.value`   | `resultObj` | —                                             | ⇒ `val:externref`                                     | reads heap      | —                        |
+| `iter.return`  | `iter`      | —                                             | ∅ (protocol close)                                    | full barrier    | —                        |
+
+### Generators / async
+
+| kind            | operands  | result rule                                | effects      |
+| --------------- | --------- | ------------------------------------------ | ------------ |
+| `gen.push`      | `value`   | ∅ (yield one element into the buffer slot) | slot/heap    |
+| `gen.epilogue`  | —         | ⇒ `val:externref` (the Generator object)   | full barrier |
+| `gen.yieldStar` | `inner`   | delegated yield; per producer declaration  | full barrier |
+| `await`         | `operand` | ⇒ the settled value's declared type        | control      |
+| `async.return`  | `value`   | ∅ (wraps in resolved Promise)              | control      |
+| `async.throw`   | `reason`  | ∅ (wraps in rejected Promise)              | control      |
+
+### Extern (host-class) ops
+
+| kind             | operands             | immediates              | result rule                         | effects                                                            |
+| ---------------- | -------------------- | ----------------------- | ----------------------------------- | ------------------------------------------------------------------ |
+| `extern.new`     | `args[]`             | `className`             | ⇒ `extern{className}`               | full barrier                                                       |
+| `extern.call`    | `receiver`, `args[]` | `className`, `method`   | per method table; producer-declared | full barrier                                                       |
+| `extern.prop`    | `receiver`           | `className`, `property` | producer-declared                   | reads heap                                                         |
+| `extern.propSet` | `receiver`, `value`  | `className`, `property` | ∅                                   | writes heap                                                        |
+| `extern.regex`   | —                    | `pattern`, `flags`      | ⇒ `extern{RegExp}`                  | pure (alloc; may throw on bad pattern — see #2134 divergence note) |
+
+### Exceptions, early exit, coercion
+
+| kind                  | operands | immediates                                    | result rule                                      | effects         | buffers                                     |
+| --------------------- | -------- | --------------------------------------------- | ------------------------------------------------ | --------------- | ------------------------------------------- |
+| `throw`               | `value`  | —                                             | ∅ (does not fall through)                        | control         | —                                           |
+| `try`                 | —        | `catchClause?: {payloadSlot}`, `finallyBody?` | ∅                                                | join of buffers | `body`, `catchClause.body?`, `finallyBody?` |
+| `early.return`        | `value?` | —                                             | ∅; `τ(value)` matches `resultTypes` when present | control         | —                                           |
+| `coerce.to_externref` | `value`  | —                                             | ⇒ `val:externref`                                | pure            | —                                           |
+
+## Effect classification (D3.5 — published, derived)
+
+The per-kind classification lives in code at `src/ir/effects.ts`
+(`effectsOf`) and is part of this contract. Facets:
+
+| facet                                   | meaning                                                                 |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| `readsHeap`                             | reads mutable heap state (fields, globals, elements, host objects)      |
+| `writesHeap`                            | writes heap state or has arbitrary effects (calls, iterator advance)    |
+| `control`                               | throw / await / async completion — may neither be reordered NOR dropped |
+| `allSlots` / `readSlots` / `writeSlots` | Wasm-local slot conflicts, precise per index                            |
+
+Guarantee: within a block, the serialized instruction order is a valid
+program order under this classification. A consumer scheduling or reasoning
+about the IR must respect the same table. Adding a facet or reclassifying a
+kind is a versioned change (D2).
+
+## Conformance
+
+- **Syntax:** [`ir-module.schema.json`](ir-module.schema.json) (JSON Schema
+  2020-12). It pins the document/coverage/function/block/type/const/
+  terminator shapes precisely, and instructions to the frozen `kind` table +
+  base shape (per-kind operand arity/typing is normative HERE and checked by
+  the verifier — the schema is the cheap gate, the verifier the real one).
+- **Semantics:** `verifyIrFunction` (`src/ir/verify.ts`) is the boundary's
+  conformance checker; T4 makes it re-derive every rule in §"Node inventory"
+  and runs it identically on deserialized modules. What the verifier
+  enforces is exactly what a consumer may rely on.
+
+## Frozen enum tables (append-only, frozen order — D2)
+
+- **JsTag** (`src/codegen/js-tag.ts`): `Null=0, Undefined=1, NumberI32=2,
+NumberF64=3, Boolean=4, String=5, Object=6, Function=7`.
+- **IrBinop / IrUnop**: the unions in `src/ir/nodes.ts` (order as declared).
+- **Instruction kinds**: the `IrInstr` union in `src/ir/nodes.ts` minus
+  `raw.wasm` (D4), as enumerated in the schema's `kind` table.
+- **IrType kinds**: `val, string, object, closure, class, extern, union,
+boxed, dynamic`.
+- **ScalarVal**: the D5 closed set.
+- **Effect facets**: the table above.
+
+## Slice status
+
+| Slice | What                                                        | Status at v1.0 freeze                                        |
+| ----- | ----------------------------------------------------------- | ------------------------------------------------------------ |
+| T1    | this document + schema + `IR_FORMAT_VERSION`                | **frozen** (2026-07-04)                                      |
+| T2    | purge module-relative indices from in-memory `IrType` (D5)  | open — until then, affected functions are `carrier:"legacy"` |
+| T3    | `serializeIrModule`/`deserializeIrModule` + `--emit-ir`     | open                                                         |
+| T4    | verifier re-derivation of the §Node-inventory rules (#1924) | open — D3.3 effective from here                              |
+| T5    | schema snapshot CI gate                                     | open                                                         |
+| T6    | `scripts/ir-type-summary.mjs` example consumer              | open                                                         |

--- a/docs/ir/ir-module.schema.json
+++ b/docs/ir/ir-module.schema.json
@@ -1,0 +1,494 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loopdive.github.io/js2wasm/ir/ir-module.schema.json",
+  "title": "js2wasm IR interchange module (v1.0)",
+  "description": "One serialized IR module (#3030 D1). Normative companion: docs/ir/ir-contract.md — the schema is the syntax gate; per-instruction operand/result typing is enforced by the IR verifier (the semantic conformance checker). Enum tables are append-only with frozen order (D2); any shape change requires an IR_FORMAT_VERSION bump.",
+  "type": "object",
+  "properties": {
+    "irVersion": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+$" },
+    "source": { "type": "string" },
+    "coverage": { "type": "array", "items": { "$ref": "#/$defs/coverageEntry" } },
+    "functions": { "type": "array", "items": { "$ref": "#/$defs/function" } }
+  },
+  "required": ["irVersion", "coverage", "functions"],
+  "additionalProperties": false,
+  "$defs": {
+    "valueId": { "type": "integer", "minimum": 0 },
+    "blockId": { "type": "integer", "minimum": 0 },
+    "labelId": { "type": "integer", "minimum": 0 },
+    "allocSiteId": { "type": "integer", "minimum": 0 },
+    "site": {
+      "type": "object",
+      "properties": { "line": { "type": "integer", "minimum": 1 }, "column": { "type": "integer", "minimum": 0 } },
+      "required": ["line", "column"],
+      "additionalProperties": false
+    },
+    "scalarValKind": {
+      "description": "D5 closed scalar set — append-only, frozen order.",
+      "enum": ["i32", "i64", "f32", "f64", "v128", "i8", "i16", "funcref", "externref", "ref_extern", "eqref", "anyref"]
+    },
+    "valType": {
+      "description": "A serialized backend-level value type: either a D5 scalar leaf (with optional brands) or a SYMBOLIC ref leaf (no module-relative typeIdx — D5/T2).",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "$ref": "#/$defs/scalarValKind" },
+            "boolean": { "const": true },
+            "symbol": { "const": true },
+            "bigint": { "type": "boolean" }
+          },
+          "required": ["kind"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "enum": ["ref", "ref_null"] },
+            "name": { "type": "string", "description": "Symbolic type-namespace name (IrTypeRef)." }
+          },
+          "required": ["kind", "name"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "irType": {
+      "description": "Serialized IrType (D5). Kind table is append-only, frozen order: val, string, object, closure, class, extern, union, boxed, dynamic.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "val" },
+            "val": { "$ref": "#/$defs/valType" },
+            "signed": { "type": "boolean" }
+          },
+          "required": ["kind", "val"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "string" } },
+          "required": ["kind"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "object" }, "shape": { "$ref": "#/$defs/objectShape" } },
+          "required": ["kind", "shape"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "closure" }, "signature": { "$ref": "#/$defs/closureSignature" } },
+          "required": ["kind", "signature"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "class" }, "shape": { "$ref": "#/$defs/classShape" } },
+          "required": ["kind", "shape"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "extern" }, "className": { "type": "string" } },
+          "required": ["kind", "className"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "union" },
+            "members": { "type": "array", "items": { "$ref": "#/$defs/irType" }, "minItems": 2 }
+          },
+          "required": ["kind", "members"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "boxed" }, "inner": { "$ref": "#/$defs/irType" } },
+          "required": ["kind", "inner"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "dynamic" }, "tag": { "$ref": "#/$defs/jsTag" } },
+          "required": ["kind"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "jsTag": {
+      "description": "JsTag partition ids (frozen, append-only): Null=0, Undefined=1, NumberI32=2, NumberF64=3, Boolean=4, String=5, Object=6, Function=7.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 7
+    },
+    "objectShape": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "type": "array",
+          "description": "Name-sorted (canonical order — D1 determinism).",
+          "items": {
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "type": { "$ref": "#/$defs/irType" } },
+            "required": ["name", "type"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["fields"],
+      "additionalProperties": false
+    },
+    "closureSignature": {
+      "type": "object",
+      "properties": {
+        "params": { "type": "array", "items": { "$ref": "#/$defs/irType" } },
+        "returnType": { "$ref": "#/$defs/irType" }
+      },
+      "required": ["params", "returnType"],
+      "additionalProperties": false
+    },
+    "classShape": {
+      "type": "object",
+      "properties": {
+        "className": { "type": "string" },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "type": { "$ref": "#/$defs/irType" } },
+            "required": ["name", "type"],
+            "additionalProperties": false
+          }
+        },
+        "methods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "params": { "type": "array", "items": { "$ref": "#/$defs/irType" } },
+              "returnType": { "oneOf": [{ "$ref": "#/$defs/irType" }, { "type": "null" }] }
+            },
+            "required": ["name", "params", "returnType"],
+            "additionalProperties": false
+          }
+        },
+        "constructorParams": { "type": "array", "items": { "$ref": "#/$defs/irType" } }
+      },
+      "required": ["className", "fields", "methods", "constructorParams"],
+      "additionalProperties": false
+    },
+    "funcRef": {
+      "type": "object",
+      "properties": { "kind": { "const": "func" }, "name": { "type": "string" } },
+      "required": ["kind", "name"],
+      "additionalProperties": false
+    },
+    "globalRef": {
+      "type": "object",
+      "properties": { "kind": { "const": "global" }, "name": { "type": "string" } },
+      "required": ["kind", "name"],
+      "additionalProperties": false
+    },
+    "const": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "enum": ["i32", "f32"] },
+            "value": { "type": "number" }
+          },
+          "required": ["kind", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "f64" },
+            "value": {
+              "description": "Number, or the D1 strings for non-finite / negative-zero values.",
+              "oneOf": [{ "type": "number" }, { "enum": ["NaN", "Infinity", "-Infinity", "-0"] }]
+            }
+          },
+          "required": ["kind", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "i64" },
+            "value": {
+              "type": "string",
+              "pattern": "^-?[0-9]+$",
+              "description": "Decimal string (D1 — JSON numbers cannot carry i64)."
+            }
+          },
+          "required": ["kind", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "bool" }, "value": { "type": "boolean" } },
+          "required": ["kind", "value"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "null" }, "ty": { "$ref": "#/$defs/irType" } },
+          "required": ["kind", "ty"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "undefined" } },
+          "required": ["kind"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "instrKind": {
+      "description": "Frozen instruction-kind table (append-only, frozen order). `raw.wasm` is deliberately ABSENT — a body containing it is not serializable (D4).",
+      "enum": [
+        "const",
+        "call",
+        "global.get",
+        "global.set",
+        "binary",
+        "unary",
+        "select",
+        "if",
+        "box",
+        "unbox",
+        "tag.test",
+        "string.const",
+        "string.concat",
+        "string.eq",
+        "string.len",
+        "object.new",
+        "object.get",
+        "object.set",
+        "closure.new",
+        "closure.cap",
+        "closure.call",
+        "refcell.new",
+        "refcell.get",
+        "refcell.set",
+        "class.new",
+        "class.get",
+        "class.set",
+        "class.call",
+        "slot.read",
+        "slot.write",
+        "vec.len",
+        "vec.get",
+        "vec.new_fixed",
+        "forof.vec",
+        "coerce.to_externref",
+        "iter.new",
+        "iter.next",
+        "iter.done",
+        "iter.value",
+        "iter.return",
+        "forof.iter",
+        "gen.push",
+        "gen.epilogue",
+        "gen.yieldStar",
+        "forof.string",
+        "throw",
+        "try",
+        "early.return",
+        "extern.new",
+        "extern.call",
+        "extern.prop",
+        "extern.propSet",
+        "extern.regex",
+        "while.loop",
+        "for.loop",
+        "br.label",
+        "if.stmt",
+        "await",
+        "async.return",
+        "async.throw"
+      ]
+    },
+    "instr": {
+      "description": "Base instruction shape. Per-kind operand fields ride as additional properties; their arity/typing rules are normative in ir-contract.md §'Node inventory' and enforced by the verifier (T4). Key discriminating payloads are pinned below via conditionals.",
+      "type": "object",
+      "properties": {
+        "kind": { "$ref": "#/$defs/instrKind" },
+        "result": { "oneOf": [{ "$ref": "#/$defs/valueId" }, { "type": "null" }] },
+        "resultType": { "oneOf": [{ "$ref": "#/$defs/irType" }, { "type": "null" }] },
+        "site": { "$ref": "#/$defs/site" },
+        "alloc": { "$ref": "#/$defs/allocSiteId" }
+      },
+      "required": ["kind", "result", "resultType"],
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "const" } } },
+          "then": { "properties": { "value": { "$ref": "#/$defs/const" } }, "required": ["value"] }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "call" } } },
+          "then": {
+            "properties": {
+              "target": { "$ref": "#/$defs/funcRef" },
+              "args": { "type": "array", "items": { "$ref": "#/$defs/valueId" } }
+            },
+            "required": ["target", "args"]
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "enum": ["global.get", "global.set"] } } },
+          "then": { "properties": { "target": { "$ref": "#/$defs/globalRef" } }, "required": ["target"] }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "box" } } },
+          "then": {
+            "properties": { "value": { "$ref": "#/$defs/valueId" }, "toType": { "$ref": "#/$defs/irType" } },
+            "required": ["value", "toType"]
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "enum": ["unbox", "tag.test"] } } },
+          "then": {
+            "properties": {
+              "value": { "$ref": "#/$defs/valueId" },
+              "tag": { "$ref": "#/$defs/valType" },
+              "jsTag": { "$ref": "#/$defs/jsTag" }
+            },
+            "required": ["value"]
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "closure.new" } } },
+          "then": { "properties": { "liftedFunc": { "$ref": "#/$defs/funcRef" } }, "required": ["liftedFunc"] }
+        }
+      ]
+    },
+    "branch": {
+      "type": "object",
+      "properties": {
+        "target": { "$ref": "#/$defs/blockId" },
+        "args": { "type": "array", "items": { "$ref": "#/$defs/valueId" } }
+      },
+      "required": ["target", "args"],
+      "additionalProperties": false
+    },
+    "terminator": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "return" },
+            "values": { "type": "array", "items": { "$ref": "#/$defs/valueId" } },
+            "site": { "$ref": "#/$defs/site" }
+          },
+          "required": ["kind", "values"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "br" },
+            "branch": { "$ref": "#/$defs/branch" },
+            "site": { "$ref": "#/$defs/site" }
+          },
+          "required": ["kind", "branch"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": { "const": "br_if" },
+            "condition": { "$ref": "#/$defs/valueId" },
+            "ifTrue": { "$ref": "#/$defs/branch" },
+            "ifFalse": { "$ref": "#/$defs/branch" },
+            "site": { "$ref": "#/$defs/site" }
+          },
+          "required": ["kind", "condition", "ifTrue", "ifFalse"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": { "kind": { "const": "unreachable" }, "site": { "$ref": "#/$defs/site" } },
+          "required": ["kind"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "block": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/blockId" },
+        "blockArgs": { "type": "array", "items": { "$ref": "#/$defs/valueId" } },
+        "blockArgTypes": { "type": "array", "items": { "$ref": "#/$defs/irType" } },
+        "instrs": { "type": "array", "items": { "$ref": "#/$defs/instr" } },
+        "terminator": { "$ref": "#/$defs/terminator" }
+      },
+      "required": ["id", "blockArgs", "blockArgTypes", "instrs", "terminator"],
+      "additionalProperties": false
+    },
+    "slotDef": {
+      "type": "object",
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "name": { "type": "string" },
+        "type": {
+          "description": "D4 slot-type rule: scalar leaves only in serialized documents.",
+          "type": "object",
+          "properties": {
+            "kind": { "$ref": "#/$defs/scalarValKind" },
+            "boolean": { "const": true },
+            "symbol": { "const": true },
+            "bigint": { "type": "boolean" }
+          },
+          "required": ["kind"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["index", "name", "type"],
+      "additionalProperties": false
+    },
+    "function": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "exported": { "type": "boolean" },
+        "funcKind": { "enum": ["regular", "generator", "async"] },
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": { "$ref": "#/$defs/valueId" },
+              "name": { "type": "string" },
+              "type": { "$ref": "#/$defs/irType" }
+            },
+            "required": ["value", "name", "type"],
+            "additionalProperties": false
+          }
+        },
+        "resultTypes": { "type": "array", "items": { "$ref": "#/$defs/irType" } },
+        "slots": { "type": "array", "items": { "$ref": "#/$defs/slotDef" } },
+        "valueCount": { "type": "integer", "minimum": 0 },
+        "blocks": { "type": "array", "items": { "$ref": "#/$defs/block" }, "minItems": 1 }
+      },
+      "required": ["name", "exported", "params", "resultTypes", "valueCount", "blocks"],
+      "additionalProperties": false
+    },
+    "coverageEntry": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "carrier": { "enum": ["ir", "legacy"] },
+        "exported": { "type": "boolean" },
+        "reason": { "type": "string" }
+      },
+      "required": ["name", "carrier", "exported"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/plan/issues/3029-clean-compiler-architecture-umbrella.md
+++ b/plan/issues/3029-clean-compiler-architecture-umbrella.md
@@ -1,7 +1,8 @@
 ---
 id: 3029
 title: "Clean compiler architecture umbrella: layered module map, five-part backend contract, reviewability ratchets"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-arch-slices
 sprint: current
 created: 2026-07-04
 updated: 2026-07-04
@@ -128,3 +129,118 @@ continuous; S9 after #3030's serializer exists.
 - **Duplication with in-flight issues**: #2953 (S2), #2956 (S3 overlap),
   #742 (S8) keep their own issue files and owners; this umbrella sequences
   them and must not double-dispatch. Check assignees before claiming.
+
+## S4 — ModuleAssembler design (RATIFIED, Fable 2026-07-04)
+
+The interface body lives in `src/ir/backend/contract.ts` (part 5) with the
+invariants A1–A7 inline. This section records the design rationale and the
+convergence map — the WHY, so the S5 implementer and the #2710 waves don't
+re-litigate it.
+
+### The design in one sentence
+
+**A consumer of the assembler never sees a module index**: identity is a
+stable handle minted at declaration; indices come into existence exactly
+once, inside `finalize()` (= `resolveLayout`), and are consumed only by the
+serializer.
+
+### Why this shape (root cause of the regression class)
+
+The bug class is definitionally "a concrete index baked into instruction X
+went stale when the index space changed" (#2710). Every prior mitigation —
+shifters, fixups, `?? funcIdx` repoints, cached-field chases — is REACTIVE:
+it repairs concrete indices after churn, so every new emit site / cached
+field is a fresh opportunity to forget the repair (the 2026-07 tag-5 PR's
+stale cached `__gen_eager_mode` global index is the newest instance; #2078
+`currentThisGlobalIdx` the canonical one). The assembler contract is the
+STRUCTURAL fix: with no index in circulation before finalize, there is
+nothing a late import can invalidate. This is the same dual lesson #1899
+proved — identity must ride in the reference; the only sound resolution
+point is after all churn.
+
+### Key decisions
+
+1. **Two-phase declare/define (mint/push), not define-returns-handle.**
+   Producers routinely need the handle BEFORE the body exists (self-calls,
+   mutual recursion, helper bodies that reference each other, bake-into-
+   immediate-then-build). func-space.ts's `mintDefinedFunc`/`pushDefinedFunc`
+   proved the protocol under nested emission; the contract generalizes it to
+   globals. Declared-but-never-defined fails loudly at finalize (mirrors
+   `absoluteFuncIndex`'s NaN-ordinal throw).
+2. **Imports mint handles too, at any pre-finalize time.** This is the
+   member that makes late imports FREE and retires the shift regime. The
+   import/defined distinction becomes a finalize-time ordering concern
+   (imports first, registration order), not a producer-visible index-space
+   split — `isImportFuncIdx` arithmetic disappears with it.
+3. **`finalize()` returns `ModuleLayout` and is the ONLY index authority
+   (single-shot).** It corresponds to today's `indexSpaceFrozen = true`
+   point in `generateModule`. Post-finalize mutation throws — the fail-loud
+   twin of today's freeze flag.
+4. **Type interning is the assembler's; layout-handle memoization is the
+   LayoutResolver's.** Two different dedup concerns that today blur through
+   `ctx`: "one canonical TypeDef entry per structural definition" (index
+   identity — assembler) vs "one struct registration per IR shape"
+   (lowering memoization — resolver). Splitting them keeps part 4
+   backend-neutral.
+5. **DCE marks dead, finalize skips.** Dead-elimination stops renumbering
+   instructions (its remap is where the type-index remove-and-renumber
+   factory lives, `project_type_index_shift_and_deadelim`); it only marks.
+   The layout skips dead handles. One mechanism for funcs/globals/types.
+6. **Definition payloads are generic.** `ModuleAssembler<FuncDefT,
+GlobalDefT, TypeDefT>` defaults to the `src/ir/types.ts` Wasm records;
+   an MLIR assembler's payloads are dialect ops and its finalize produces an
+   `mlir::ModuleOp`-shaped layout. The handle protocol is representation-
+   independent — that is what makes part 5 a _contract_ rather than a
+   WasmGC refactor.
+
+### Convergence map (today's mechanism → contract member)
+
+| Today (live)                                                                                                 | Contract member                   | Migration vehicle             |
+| ------------------------------------------------------------------------------------------------------------ | --------------------------------- | ----------------------------- |
+| `mintDefinedFunc` / `pushDefinedFunc` (func-space.ts, #1916 S3 stable regime)                                | `declareFunc` / `defineFunc`      | already aligned               |
+| `ctx.numImportFuncs + mod.functions.length` eager minting (legacy live regime)                               | `declareFunc` / `defineFunc`      | #1916 S3 / #2710 s4b          |
+| `addUnionImports` / `addStringImports` / `ensureLateImport` + 4 shifters + `reconcileNativeStrFinalizeShift` | `importFunc` (shift-free by A3)   | #2710 slice 4b/4c             |
+| `addStringConstantGlobal` + `fixupModuleGlobalIndices` + ~25 cached global-idx chases                        | `importGlobal` / `declareGlobal`  | #2710 slice 4a (globals wave) |
+| `ctx.funcMap` / `moduleGlobals` / `ctx.typeNames`                                                            | `lookupFunc/Global/Type` (A6)     | S5 adapter                    |
+| `addFuncType` / struct registration index minting                                                            | `internType`                      | #2710 slice 4d (types wave)   |
+| `eliminateDeadImports` remove-and-renumber                                                                   | dead-marking + finalize skip (A7) | #2710 slice 4d                |
+| `resolveLayout` (src/emit/resolve-layout.ts) at `indexSpaceFrozen`                                           | `finalize()`                      | already the seam              |
+| `WasmExport` / `startFuncIdx` records                                                                        | `exportFunc/Global`, `setStart`   | S5 adapter                    |
+
+Remaining positional-read surface at freeze time (#2710 slice 3 residue):
+`index.ts` ×39 + `integration.ts` ×1, plus the globals/types waves — those
+are exactly the reads the S5 adapter converts. **S5 is adapter-first over
+the existing `ctx.mod` (byte-identity gated via
+`scripts/prove-emit-identity.mjs`), never a rewrite** — the WasmGC
+`ModuleAssembler` wraps the live registries; the linear twin wraps
+`generateLinearModule`'s module state.
+
+### Executable spec
+
+`tests/backend-contract.test.ts` encodes A2/A3/A4/A5/A6 against the stub
+assembler (`src/ir/backend/contract-conformance.ts`) — including the
+headline property: a handle minted before a late import resolves correctly
+after it, with zero fixup.
+
+## Progress log
+
+### S1 + S4 landed (fable-arch-slices, 2026-07-04)
+
+- **S1 — contract freeze**: `src/ir/backend/contract.ts` declares/re-exports
+  all five parts (`TypeConverter<Slot>`, `BackendLegality` + `legalityFor`,
+  `BackendEmitter<Sink>` re-export — the sink was already generic since
+  #1584, so S1 banks it as contract surface — `LayoutResolver` as the
+  canonical name of `IrLowerResolver`, `ModuleAssembler`, and the
+  `BackendContract` bundle). Contract README at `src/ir/backend/README.md`
+  (ownership table, operand-order rules, memoization ownership, R-ESCAPE,
+  R-DEP declaration). Conformance skeleton
+  `src/ir/backend/contract-conformance.ts`: tsc-enforced proof that the
+  three emitters satisfy `BackendEmitter<Sink>` with their own sinks + a
+  from-scratch stub backend implementing all five parts over a foreign
+  `string[]` sink. Byte-inert: new files + type-only re-exports + one
+  unused-by-callers factory; no call site changed.
+- **S4 — ModuleAssembler design**: ratified above; interface body in
+  contract.ts; invariants executable in tests/backend-contract.test.ts.
+- Open slices: S2 (#2953, owned), S3, S5–S9 (Opus lanes per the tier
+  ruling). Umbrella stays in-progress; claim released on merge so the next
+  slice can dispatch.

--- a/plan/issues/3030-ir-interchange-contract.md
+++ b/plan/issues/3030-ir-interchange-contract.md
@@ -1,7 +1,8 @@
 ---
 id: 3030
 title: "Stable serializable IR contract (interchange v1): versioned canonical JSON + schema, verified types, external-consumer ready"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-arch-slices
 sprint: current
 created: 2026-07-04
 updated: 2026-07-04
@@ -135,3 +136,46 @@ parallel with T2/T3.
   types in the interim.
 - **Drift between doc and code**: T5's schema snapshot + T4's shared rule
   tables are the anti-drift mechanisms; the doc alone would rot.
+
+## Progress log
+
+### T1 landed — v1.0 frozen (fable-arch-slices, 2026-07-04)
+
+Artifacts (all normative):
+
+- `docs/ir/ir-contract.md` — D1–D5 as normative text; the seven D3
+  guarantees (D3.3 explicitly marked "effective from verifier ≥ T4"); name
+  namespaces; document layout; the full node inventory with per-kind
+  operand/result type rules + effect classification (the tables T4
+  implements); frozen enum tables; versioning policy; per-slice status.
+- `docs/ir/ir-module.schema.json` — JSON Schema 2020-12. Precise shapes for
+  module/coverage/function/block/IrType/Const/terminators; instructions
+  pinned to the frozen 59-kind table + base shape, with conditionals for the
+  key discriminating payloads (const/call/global.\*/box/unbox/tag.test/
+  closure.new). The verifier is the semantic conformance gate (contract
+  §Conformance); T5 may deepen the schema.
+- `src/ir/contract.ts` — `IR_FORMAT_VERSION = "1.0"` (D2) + the
+  coverage-manifest / document-header types (D3.7). Nothing imports it yet;
+  T3 implements against it.
+- `tests/backend-contract.test.ts` — smoke: version constant, schema
+  parses, frozen tables (no `raw.wasm`, no indexed `ref` in the scalar set).
+
+Additional ratifications made at freeze time (T1 decisions the D-text
+implied but didn't pin):
+
+- **The `raw.wasm` serializability predicate (D4):** a function whose body
+  contains `raw.wasm` is manifest-listed `carrier: "legacy"`,
+  `reason: "raw-wasm-bridge"`, body not serialized — because `raw.wasm`
+  embeds backend `Instr` ops that D4 forbids.
+- **Pre-T2 honesty rule (D5):** until T2 lands, functions whose types carry
+  a module-relative `ref`/`ref_null` leaf are `carrier: "legacy"`
+  (`reason: "module-relative-type"`) instead of leaking a typeIdx.
+- **D1 details:** `i64` consts as decimal strings; f64 NaN/±Infinity/−0 as
+  strings; `ref_extern` added to the D5 closed scalar set (exists in
+  `ValType`, non-indexed, was missing from the issue's list).
+- **Slot-type rule (D4):** serialized `IrSlotDef.type` restricted to the
+  scalar set.
+- **Effects (D3.5):** derived, not serialized in v1.0 — the per-kind table
+  is published contract; serializing them is a possible additive minor.
+
+Open: T2–T6 (Opus lanes). Issue stays in-progress; claim released on merge.

--- a/src/ir/backend/README.md
+++ b/src/ir/backend/README.md
@@ -1,0 +1,56 @@
+# `src/ir/backend/` — the backend contract (R-OWN)
+
+**Responsibility:** the five-part contract a backend implements (#3029-S1
+freeze, `contract.ts`) plus the in-tree realizations: the `BackendEmitter`
+trait (`emitter.ts`) with its WasmGC / linear / bytecode implementations,
+the per-backend legality checker (`legality.ts`), and the layout-handle
+shapes (`handles.ts`).
+
+Normative background: `docs/architecture/target-architecture.md` ("The
+backend contract"). Target home after #3029-S6: `src/backend/contract/`.
+
+## The five parts and what each OWNS
+
+| Part                     | File                                    | Owns                                                                                                                         | Must NOT do                                                                   |
+| ------------------------ | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| 1 `TypeConverter`        | `contract.ts` (decl; #1851 L3 promotes) | IR type → backend value slot(s). Slot COUNT is backend policy (GC: always 1; linear dynamic: value+tag pair, #1852 §1)       | memoize layouts (that's part 4); inspect instructions                         |
+| 2 `BackendLegality`      | `legality.ts` (+ `legalityFor`)         | The pre-lowering "can I lower this function?" verdict; localized diagnostics                                                 | mutate the IR; emit anything                                                  |
+| 3 `BackendEmitter<Sink>` | `emitter.ts` + `*-emitter.ts`           | Terminal op emission per IR intent, onto an opaque `Sink`                                                                    | evaluate operands (caller's job); own layout handles; resolve names/indices   |
+| 4 `LayoutResolver`       | decl in `lower.ts` (`IrLowerResolver`)  | Shape → memoized layout handle; string/boxing emission helpers. **All memoization lives here** (one struct per shape/module) | emit per-instruction ops (part 3); assign module indices (part 5)             |
+| 5 `ModuleAssembler`      | `contract.ts` (decl; #3029-S5 impls)    | Function slots, imports/exports, globals, type interning, start — **index identity** (invariants A1–A7 in `contract.ts`)     | expose a module index before `finalize()`; permit index arithmetic on handles |
+
+## Operand-order rules (part 3, load-bearing)
+
+- The **caller** (`lower.ts`) emits operand subtrees onto the sink BEFORE
+  invoking an emitter primitive; the primitive pushes only the TERMINAL
+  op(s). The emitter never calls back into value emission.
+- Multi-region primitives (`emitIf`, `emitBlock`, `emitLoop`, `emitTry`)
+  receive pre-lowered regions built via `newSink()`; branch depths inside a
+  region are De Bruijn (count block/loop nesting outward).
+- Stack conventions per primitive are documented on the method in
+  `emitter.ts` (e.g. `emitVecNewFixed`: e0 deepest … eN on top).
+
+## Escape hatches (R-ESCAPE)
+
+`pushRaw` is the ONE sanctioned bypass of part 3, and it is ratcheted:
+#2953 migrates the remaining families (74 sites in `lower.ts` at freeze
+time) behind typed primitives and adds the `// pushraw-ok(#issue)` tag +
+count check. New `pushRaw` sites without a tag are a review reject.
+
+## Freeze rules (#3029-S1)
+
+- Adding a method to a contract interface: **allowed** (additive).
+- Removing/re-typing a frozen member: breaking — needs an issue + wave.
+- A new backend implements the five interfaces (in-tree) or consumes the
+  serialized IR (#3030, out-of-tree). Never a fourth hand-rolled path.
+- Conformance: `contract-conformance.ts` must keep compiling — it proves
+  the three emitters satisfy `BackendEmitter<Sink>` with their own sinks
+  and that a from-scratch stub can implement all five parts.
+
+## Dependencies (R-DEP)
+
+May import: `src/ir/` (nodes, types), `src/emit/resolve-layout.ts`
+(`ModuleLayout` — the finalize output type). Must NOT import:
+`src/codegen/**` (the WasmGC context is BELOW the contract — adapters
+implementing these interfaces over `ctx.mod` live on the codegen side,
+#3029-S5), `src/codegen-linear/**`.

--- a/src/ir/backend/contract-conformance.ts
+++ b/src/ir/backend/contract-conformance.ts
@@ -1,0 +1,389 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ---------------------------------------------------------------------------
+// Backend-contract conformance skeleton (#3029-S1).
+//
+// Two jobs, both COMPILE-TIME enforced (this file lives under src/** so the
+// `quality` gate's `pnpm run typecheck` checks it; vitest does not typecheck):
+//
+//   1. Prove the three existing emitters satisfy `BackendEmitter<Sink>` with
+//      their own sink types (the S1 acceptance criterion). They already
+//      declare `implements`, but the checks here go through the CONTRACT
+//      module's re-export, so a drift between contract.ts and emitter.ts is
+//      a compile error in this file.
+//   2. Provide a STUB BACKEND implementing all five contract parts against a
+//      sink that is neither `Instr[]` nor `BytecodeSink` (`string[]`) —
+//      proving the interfaces are implementable from scratch with no
+//      knowledge of another backend's internals. The stub's ModuleAssembler
+//      is a real (minimal) implementation of the mint/define/finalize
+//      protocol so tests/backend-contract.test.ts can exercise the
+//      index-identity invariants (A1–A5) at runtime.
+//
+// The stub is NOT a compilation path. Nothing in the compiler imports it.
+// ---------------------------------------------------------------------------
+
+import type { IrFunction, IrInstr, IrType } from "../nodes.js";
+import type { BlockType, FuncHandle, FuncTypeDef, GlobalHandle, Instr, TypeHandle, ValType } from "../types.js";
+import type { ModuleLayout } from "../../emit/resolve-layout.js";
+import {
+  type BackendContract,
+  type BackendEmitter,
+  type BackendLegality,
+  type IrBackendKind,
+  type IrLowerResolver,
+  type ModuleAssembler,
+  type TypeConverter,
+  legalityFor,
+} from "./contract.js";
+import type { IrBinop, IrUnop } from "../nodes.js";
+import type {
+  IrClassLowering,
+  IrObjectStructLowering,
+  IrRefCellLowering,
+  IrVecLowering,
+  LinearVecLowering,
+} from "./handles.js";
+import type { WasmGcEmitter } from "./wasmgc-emitter.js";
+import type { LinearEmitter } from "./linear-emitter.js";
+import type { BytecodeEmitter, BytecodeSink } from "./bytecode-emitter.js";
+
+// ---------------------------------------------------------------------------
+// 1 — the three in-tree emitters conform (type-level; no runtime cost)
+// ---------------------------------------------------------------------------
+
+type Conforms<Impl, Contract> = Impl extends Contract ? true : never;
+
+// Each of these lines FAILS TO COMPILE if the emitter stops satisfying the
+// contract surface (assigning `true` to `never` is a type error).
+const wasmGcEmitterConforms: Conforms<WasmGcEmitter, BackendEmitter<Instr[]>> = true;
+const linearEmitterConforms: Conforms<LinearEmitter, BackendEmitter<Instr[]>> = true;
+const bytecodeEmitterConforms: Conforms<BytecodeEmitter, BackendEmitter<BytecodeSink>> = true;
+export const emittersConform: boolean = wasmGcEmitterConforms && linearEmitterConforms && bytecodeEmitterConforms;
+
+// ---------------------------------------------------------------------------
+// 2 — the stub backend
+// ---------------------------------------------------------------------------
+
+/** The stub's sink: a flat trace of op names (proves Sink generality). */
+export type StubSink = string[];
+
+/**
+ * The stub reuses an in-tree kind tag: `IrBackendKind` is itself append-only
+ * (a real fourth backend ADDS a union member — additive, per the freeze
+ * rules), but a conformance stub must not widen the enum for production
+ * legality checks.
+ */
+const STUB_KIND: IrBackendKind = "bytecode";
+
+type StubVecLayout = IrVecLowering | LinearVecLowering;
+
+class StubEmitter implements BackendEmitter<StubSink> {
+  readonly backend: IrBackendKind = STUB_KIND;
+  newSink(): StubSink {
+    return [];
+  }
+  pushRaw(out: StubSink, instr: Instr): void {
+    out.push(`raw:${instr.op}`);
+  }
+  emitVecLen(_layout: StubVecLayout, out: StubSink): void {
+    out.push("vec.len");
+  }
+  emitVecDataPtr(_layout: StubVecLayout, out: StubSink): void {
+    out.push("vec.dataptr");
+  }
+  emitElemGet(_layout: StubVecLayout, out: StubSink): void {
+    out.push("elem.get");
+  }
+  emitVecNewFixed(_layout: StubVecLayout, count: number, _scratch: number, out: StubSink): void {
+    out.push(`vec.new_fixed:${count}`);
+  }
+  emitConst(instr: Extract<IrInstr, { kind: "const" }>, _funcName: string, out: StubSink): void {
+    out.push(`const:${instr.value.kind}`);
+  }
+  emitBinary(op: IrBinop, out: StubSink): void {
+    out.push(`binary:${op}`);
+  }
+  emitUnary(op: IrUnop, out: StubSink): void {
+    out.push(`unary:${op}`);
+  }
+  emitLocalGet(index: number, out: StubSink): void {
+    out.push(`local.get:${index}`);
+  }
+  emitLocalSet(index: number, out: StubSink): void {
+    out.push(`local.set:${index}`);
+  }
+  emitLocalTee(index: number, out: StubSink): void {
+    out.push(`local.tee:${index}`);
+  }
+  emitGlobalGet(index: number, out: StubSink): void {
+    out.push(`global.get:${index}`);
+  }
+  emitGlobalSet(index: number, out: StubSink): void {
+    out.push(`global.set:${index}`);
+  }
+  emitDrop(out: StubSink): void {
+    out.push("drop");
+  }
+  emitSelect(out: StubSink): void {
+    out.push("select");
+  }
+  emitReturn(out: StubSink): void {
+    out.push("return");
+  }
+  emitUnreachable(out: StubSink): void {
+    out.push("unreachable");
+  }
+  emitIf(_blockType: BlockType, then: StubSink, els: StubSink, out: StubSink): void {
+    out.push("if", ...then, "else", ...els, "end");
+  }
+  emitBr(depth: number, out: StubSink): void {
+    out.push(`br:${depth}`);
+  }
+  emitBrIf(depth: number, out: StubSink): void {
+    out.push(`br_if:${depth}`);
+  }
+  emitBlock(_blockType: BlockType, body: StubSink, out: StubSink): void {
+    out.push("block", ...body, "end");
+  }
+  emitLoop(_blockType: BlockType, body: StubSink, out: StubSink): void {
+    out.push("loop", ...body, "end");
+  }
+  emitCall(funcIdx: FuncHandle, out: StubSink): void {
+    out.push(`call:${funcIdx}`);
+  }
+  emitCallRef(funcTypeIdx: TypeHandle, out: StubSink): void {
+    out.push(`call_ref:${funcTypeIdx}`);
+  }
+  emitAggregateNew(_layout: IrObjectStructLowering, fieldCount: number, out: StubSink): void {
+    out.push(`aggregate.new:${fieldCount}`);
+  }
+  emitFieldGet(_layout: IrObjectStructLowering | IrClassLowering, name: string, out: StubSink): void {
+    out.push(`field.get:${name}`);
+  }
+  emitFieldSet(_layout: IrObjectStructLowering | IrClassLowering, name: string, out: StubSink): void {
+    out.push(`field.set:${name}`);
+  }
+  emitThrow(tagIdx: number, out: StubSink): void {
+    out.push(`throw:${tagIdx}`);
+  }
+  emitRethrow(depth: number, out: StubSink): void {
+    out.push(`rethrow:${depth}`);
+  }
+  emitTry(
+    _blockType: BlockType,
+    body: StubSink,
+    catches: { tagIdx: number; body: StubSink }[],
+    catchAll: StubSink | undefined,
+    out: StubSink,
+  ): void {
+    out.push("try", ...body);
+    for (const c of catches) out.push(`catch:${c.tagIdx}`, ...c.body);
+    if (catchAll) out.push("catch_all", ...catchAll);
+    out.push("end");
+  }
+  emitRefCellNew(_layout: IrRefCellLowering, out: StubSink): void {
+    out.push("refcell.new");
+  }
+  emitRefCellGet(_layout: IrRefCellLowering, out: StubSink): void {
+    out.push("refcell.get");
+  }
+  emitRefCellSet(_layout: IrRefCellLowering, out: StubSink): void {
+    out.push("refcell.set");
+  }
+}
+
+class StubTypeConverter implements TypeConverter<string> {
+  readonly backend: IrBackendKind = STUB_KIND;
+  convertType(t: IrType): readonly string[] {
+    // One symbolic slot per value; a real backend returns its slot shapes
+    // (the linear dynamic residue would return TWO slots — value + tag).
+    return [`slot:${t.kind}`];
+  }
+}
+
+class StubLayoutResolver implements IrLowerResolver {
+  private nextFunc = 0;
+  private nextGlobal = 0;
+  private nextType = 0;
+  private readonly funcs = new Map<string, number>();
+  private readonly globals = new Map<string, number>();
+  private readonly types = new Map<string, number>();
+  resolveFunc(ref: { readonly name: string }): number {
+    let idx = this.funcs.get(ref.name);
+    if (idx === undefined) {
+      idx = this.nextFunc++;
+      this.funcs.set(ref.name, idx);
+    }
+    return idx;
+  }
+  resolveGlobal(ref: { readonly name: string }): number {
+    let idx = this.globals.get(ref.name);
+    if (idx === undefined) {
+      idx = this.nextGlobal++;
+      this.globals.set(ref.name, idx);
+    }
+    return idx;
+  }
+  resolveType(ref: { readonly name: string }): number {
+    let idx = this.types.get(ref.name);
+    if (idx === undefined) {
+      idx = this.nextType++;
+      this.types.set(ref.name, idx);
+    }
+    return idx;
+  }
+  internFuncType(_type: FuncTypeDef): number {
+    return this.nextType++;
+  }
+}
+
+/** Minimal but REAL implementation of the mint/define/finalize protocol. */
+export class StubModuleAssembler implements ModuleAssembler<string, string, string> {
+  readonly backend: IrBackendKind = STUB_KIND;
+  private finalized = false;
+  private readonly funcNames = new Map<string, FuncHandle>();
+  private readonly globalNames = new Map<string, GlobalHandle>();
+  private readonly typeNames = new Map<string, TypeHandle>();
+  private readonly funcDefs = new Map<FuncHandle, string | null>(); // null = declared, not defined (A2)
+  private readonly funcImports: FuncHandle[] = [];
+  private readonly globalDefs = new Map<GlobalHandle, string | null>();
+  private readonly globalImports: GlobalHandle[] = [];
+  private readonly typeDefs: string[] = [];
+  readonly exports: { name: string; kind: "func" | "global"; handle: number }[] = [];
+  startHandle: FuncHandle | undefined;
+  private nextHandle = 1000; // arbitrary base — handles are opaque ids, not positions (A1)
+
+  private mutate(): void {
+    if (this.finalized) throw new Error("stub assembler: mutation after finalize (A4)");
+  }
+  declareFunc(name: string): FuncHandle {
+    this.mutate();
+    const h = this.nextHandle++ as FuncHandle;
+    this.funcNames.set(name, h);
+    this.funcDefs.set(h, null);
+    return h;
+  }
+  defineFunc(handle: FuncHandle, def: string): void {
+    this.mutate();
+    const existing = this.funcDefs.get(handle);
+    if (existing === undefined) throw new Error(`stub assembler: defineFunc on undeclared handle ${handle}`);
+    if (existing !== null) throw new Error(`stub assembler: double define for handle ${handle} (A2)`);
+    this.funcDefs.set(handle, def);
+  }
+  importFunc(_module: string, _field: string, _typeHandle: TypeHandle, name: string): FuncHandle {
+    this.mutate(); // legal at ANY pre-finalize time (A3) — no shift pass exists
+    const h = this.nextHandle++ as FuncHandle;
+    this.funcNames.set(name, h);
+    this.funcImports.push(h);
+    return h;
+  }
+  lookupFunc(name: string): FuncHandle | undefined {
+    return this.funcNames.get(name);
+  }
+  declareGlobal(name: string): GlobalHandle {
+    this.mutate();
+    const h = this.nextHandle++ as GlobalHandle;
+    this.globalNames.set(name, h);
+    this.globalDefs.set(h, null);
+    return h;
+  }
+  defineGlobal(handle: GlobalHandle, def: string): void {
+    this.mutate();
+    const existing = this.globalDefs.get(handle);
+    if (existing === undefined) throw new Error(`stub assembler: defineGlobal on undeclared handle ${handle}`);
+    if (existing !== null) throw new Error(`stub assembler: double define for global handle ${handle} (A2)`);
+    this.globalDefs.set(handle, def);
+  }
+  importGlobal(_module: string, _field: string, _type: ValType, _mutable: boolean, name: string): GlobalHandle {
+    this.mutate();
+    const h = this.nextHandle++ as GlobalHandle;
+    this.globalNames.set(name, h);
+    this.globalImports.push(h);
+    return h;
+  }
+  lookupGlobal(name: string): GlobalHandle | undefined {
+    return this.globalNames.get(name);
+  }
+  internType(def: string, name?: string): TypeHandle {
+    this.mutate();
+    let pos = this.typeDefs.indexOf(def); // structural dedup
+    if (pos < 0) {
+      pos = this.typeDefs.length;
+      this.typeDefs.push(def);
+    }
+    const h = pos as TypeHandle; // stub: type handles are intern positions (stable — never removed)
+    if (name !== undefined) this.typeNames.set(name, h);
+    return h;
+  }
+  lookupType(name: string): TypeHandle | undefined {
+    return this.typeNames.get(name);
+  }
+  exportFunc(exportName: string, handle: FuncHandle): void {
+    this.mutate();
+    this.exports.push({ name: exportName, kind: "func", handle });
+  }
+  exportGlobal(exportName: string, handle: GlobalHandle): void {
+    this.mutate();
+    this.exports.push({ name: exportName, kind: "global", handle });
+  }
+  setStart(handle: FuncHandle): void {
+    this.mutate();
+    this.startHandle = handle;
+  }
+  finalize(): ModuleLayout {
+    if (this.finalized) throw new Error("stub assembler: finalize called twice (A4)");
+    this.finalized = true;
+    // Canonical ordering: imports in registration order first, then defined
+    // entries in DEFINE order. Indices exist only from this point on.
+    const funcIndex = new Map<number, number>();
+    let fi = 0;
+    for (const h of this.funcImports) funcIndex.set(h, fi++);
+    for (const [h, def] of this.funcDefs) {
+      if (def === null) throw new Error(`stub assembler: handle ${h} declared but never defined (A2)`);
+      funcIndex.set(h, fi++);
+    }
+    const globalIndex = new Map<number, number>();
+    let gi = 0;
+    for (const h of this.globalImports) globalIndex.set(h, gi++);
+    for (const [h, def] of this.globalDefs) {
+      if (def === null) throw new Error(`stub assembler: global handle ${h} declared but never defined (A2)`);
+      globalIndex.set(h, gi++);
+    }
+    const lookup = (map: Map<number, number>, h: number, what: string): number => {
+      const idx = map.get(h);
+      if (idx === undefined) throw new Error(`stub assembler: unknown ${what} handle ${h}`);
+      return idx;
+    };
+    return {
+      func: (h: FuncHandle): number => lookup(funcIndex, h, "func"),
+      global: (h: GlobalHandle): number => lookup(globalIndex, h, "global"),
+      type: (h: TypeHandle): number => h, // intern position IS the final index in the stub
+    };
+  }
+}
+
+/**
+ * Assemble the full five-part stub. `tests/backend-contract.test.ts`
+ * exercises the assembler protocol + emitter sink behavior at runtime; the
+ * declaration below is itself the compile-time proof that the five parts
+ * fit the `BackendContract` bundle.
+ */
+export function makeStubBackend(): BackendContract<StubSink, string, string, string, string> {
+  const legality: BackendLegality = {
+    backend: STUB_KIND,
+    // The stub accepts everything — legality POLICY belongs to real
+    // backends; the conformance skeleton only freezes the shape.
+    checkFunction: (_func: IrFunction) => [],
+  };
+  return {
+    backend: STUB_KIND,
+    types: new StubTypeConverter(),
+    legality,
+    emitter: new StubEmitter(),
+    layouts: new StubLayoutResolver(),
+    assembler: new StubModuleAssembler(),
+  };
+}
+
+// The in-tree production legality factory also satisfies the contract shape.
+export const wasmGcLegality: BackendLegality = legalityFor("wasmgc");

--- a/src/ir/backend/contract.ts
+++ b/src/ir/backend/contract.ts
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ---------------------------------------------------------------------------
+// The five-part backend contract — v1 FREEZE (#3029-S1 / #3029-S4).
+//
+// Normative companion: docs/architecture/target-architecture.md ("The backend
+// contract") and src/ir/backend/README.md (ownership + operand-order rules).
+//
+// A backend — WasmGC, linear, bytecode, or a future MLIR/Cranelift lowering —
+// is exactly FIVE declared parts, all consulted through the interfaces in
+// this file, none through imports of another backend's internals:
+//
+//   1. TypeConverter        IR type        → backend value slots
+//   2. BackendLegality      IR function    → "is this legal for me?"
+//   3. BackendEmitter<Sink> IR instruction → terminal backend ops on a sink
+//   4. LayoutResolver       IR shape       → memoized layout handles
+//   5. ModuleAssembler      module records → index identity + final layout
+//
+// WHAT "FREEZE" MEANS (and does not mean)
+// ---------------------------------------
+// This file freezes the SHAPE of the seam, not its completeness:
+//   - Methods may be ADDED to any of the five interfaces (additive change,
+//     as #2953/#2956 discover needs). Removing or re-typing a frozen member
+//     is a breaking change and needs an issue + migration wave.
+//   - What the freeze forbids is new BYPASSES around the seam: new backend
+//     work must be expressible as an implementation of (a subset of) these
+//     five interfaces, never as a fourth hand-rolled path.
+//   - The freeze is call-site-neutral: nothing in this file changes any
+//     existing behavior. Where a live interface already realizes a contract
+//     part (`BackendEmitter`, `IrLowerResolver`), the contract re-exports it
+//     as the canonical name rather than duplicating it (duplication would
+//     drift; see the per-part notes below).
+//
+// Conformance: src/ir/backend/contract-conformance.ts compiles a stub
+// backend against every interface here (tsc-enforced via the `quality`
+// gate's `pnpm run typecheck`; tsconfig covers src/**). Runtime smoke lives
+// in tests/backend-contract.test.ts.
+// ---------------------------------------------------------------------------
+
+import type { IrFunction, IrType } from "../nodes.js";
+import type { FuncHandle, GlobalDef, GlobalHandle, TypeDef, TypeHandle, ValType, WasmFunction } from "../types.js";
+import type { ModuleLayout } from "../../emit/resolve-layout.js";
+import type { BackendEmitter } from "./emitter.js";
+import type { IrLowerResolver } from "../lower.js";
+import { type IrBackendKind, type IrBackendLegalityError, verifyIrBackendLegality } from "./legality.js";
+
+// ---------------------------------------------------------------------------
+// Part 3 — BackendEmitter<Sink> (already live; re-exported as contract surface)
+// ---------------------------------------------------------------------------
+// The instruction-level half of a backend: typed emission *intents*
+// (`emitVecGet`, `emitBox`, `emitClosureNew`, …) pushing terminal ops onto an
+// opaque `Sink`. The sink is the ONE representation-specific seam (#1715):
+// WasmGC/linear use `Instr[]`, bytecode uses `BytecodeSink`, an MLIR backend
+// would use a builder. Operand evaluation order is the CALLER's job (lower.ts
+// emits operand subtrees before calling a primitive); the emitter never calls
+// back into value emission. `pushRaw` is the audited escape hatch, ratcheted
+// down by #2953 (R-ESCAPE).
+export type { BackendEmitter } from "./emitter.js";
+
+// The backend identity enum shared by legality, emitters, and assemblers.
+export type { IrBackendKind, IrBackendLegalityError } from "./legality.js";
+
+// ---------------------------------------------------------------------------
+// Part 4 — LayoutResolver (live as `IrLowerResolver`; canonical contract name)
+// ---------------------------------------------------------------------------
+// The layout-handle factory: resolves IR shapes (vec / object / closure /
+// refcell / union / boxed / class / string / dynamic) to memoized layout
+// handles (`IrVecLowering`, `IrObjectStructLowering`, … — see handles.ts) and
+// owns the string/boxing emission helpers. MEMOIZATION LIVES HERE and only
+// here: one WasmGC struct per shape per module, shared with the legacy path
+// via the registries in integration.ts.
+//
+// The interface is frozen under its contract name here; `IrLowerResolver` is
+// the same type (the today-name). #3029-S3 extracts the *implementation* out
+// of integration.ts so `src/ir/` stops importing `src/codegen/`; the shape a
+// backend implements is already exactly this. Layout handles are per-backend
+// data and are NEVER serialized (#3030 D4).
+export type { IrLowerResolver, IrLowerResolver as LayoutResolver } from "../lower.js";
+export type {
+  IrBoxedLowering,
+  IrClassLowering,
+  IrClosureLowering,
+  IrObjectStructLowering,
+  IrRefCellLowering,
+  IrUnionLowering,
+  IrVecLowering,
+  LinearVecLowering,
+} from "./handles.js";
+
+// ---------------------------------------------------------------------------
+// Part 1 — TypeConverter (declared here; #1851 L3 promotes the free function)
+// ---------------------------------------------------------------------------
+
+/**
+ * Backend value-slot conversion: how one IR type is carried as backend
+ * value(s).
+ *
+ * - WasmGC: `Slot = ValType`, and every IR type converts to EXACTLY ONE slot
+ *   (the current realization is the free function `lowerIrTypeToValType` in
+ *   lower.ts, which delegates the symbolic kinds — string/object/closure/
+ *   class/union/boxed/dynamic — to the LayoutResolver and wraps the result).
+ * - Linear: scalar IR types are one slot; the DYNAMIC residue is a
+ *   value+tag slot PAIR (`[f64 value, i32 tag]` — the ratified #1852 §1
+ *   representation), which is why the contract returns `readonly Slot[]`
+ *   and not a single slot.
+ * - Bytecode: everything is one f64-shaped VM slot.
+ *
+ * The converter is TOTAL over the IR types its `BackendLegality` admits: if
+ * legality accepts a function, `convertType` must not throw on any type in
+ * it. Conversely it MAY throw (loudly, with the type kind in the message) on
+ * types legality rejects — callers are expected to have gated already.
+ *
+ * Purity: `convertType` may register backend types as a side effect (the GC
+ * realization lazily registers structs via the LayoutResolver), but must be
+ * idempotent — converting the same IrType twice yields identical slots and
+ * at most one registration (memoization is the LayoutResolver's job).
+ */
+export interface TypeConverter<Slot = ValType> {
+  readonly backend: IrBackendKind;
+  /** IR type → the backend value slot(s) that carry one value of it. */
+  convertType(t: IrType): readonly Slot[];
+}
+
+// ---------------------------------------------------------------------------
+// Part 2 — BackendLegality (promotes legality.ts onto the contract)
+// ---------------------------------------------------------------------------
+
+/**
+ * The per-backend legality declaration: which IR functions this backend can
+ * lower at its function-lowering boundary. "Lowering finished" for a backend
+ * means *only ops it declares legal remain* — checked before lowering so an
+ * unsupported surface is a localized diagnostic, not a late raw-emitter
+ * throw or malformed output (#1850/#1851 L4).
+ *
+ * The frozen surface is the whole-function check. Per-instruction /
+ * per-type predicates stay implementation details of legality.ts today; if
+ * a consumer needs them they are ADDED here (additive), not reached around.
+ */
+export interface BackendLegality {
+  readonly backend: IrBackendKind;
+  /** Empty array = the function is fully legal for this backend. */
+  checkFunction(func: IrFunction): readonly IrBackendLegalityError[];
+}
+
+/**
+ * The canonical `BackendLegality` for one of the three in-tree backends,
+ * realized over the existing `verifyIrBackendLegality` free function
+ * (call-site-neutral: lower.ts keeps calling the free function directly;
+ * new consumers and out-of-tree backends use this interface form).
+ */
+export function legalityFor(backend: IrBackendKind): BackendLegality {
+  return {
+    backend,
+    checkFunction: (func: IrFunction): readonly IrBackendLegalityError[] => verifyIrBackendLegality(func, backend),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Part 5 — ModuleAssembler (#3029-S4: the index-identity design)
+// ---------------------------------------------------------------------------
+//
+// The module-level half of a backend: ownership of function slots,
+// import/export registration, type registration, globals, and the start
+// record — with NAME/HANDLE-BASED identity. This is the compiler's #1
+// historical regression surface (≥7 numbered regressions from
+// absolute-index baking: #618, #1109, #1384, #1525b, #1666, #1677, #2191,
+// #2193, #2918, #2078; freshly re-confirmed 2026-07 by a stale cached
+// `__gen_eager_mode` global index). The assembler contract makes the bug
+// class unrepresentable: A CONSUMER OF THIS INTERFACE NEVER SEES A MODULE
+// INDEX. Indices exist only inside the `ModuleLayout` returned by
+// `finalize()`, and only the serializer dereferences them.
+//
+// INVARIANTS (normative — the ratified S4 spec lives in
+// plan/issues/3029-clean-compiler-architecture-umbrella.md §"S4 —
+// ModuleAssembler design (ratified)"):
+//
+//   A1  Handles are minted once, never renumbered, never reused. A handle is
+//       the identity of the entity for the whole compile.
+//   A2  Two-phase declare/define: `declareFunc` mints the handle BEFORE the
+//       body exists; `defineFunc` binds the definition exactly once, possibly
+//       after arbitrary nested emission (other declares/defines in between).
+//       This is the proven mint/push protocol of src/codegen/func-space.ts
+//       (#1916 S3). Declared-but-never-defined handles fail loudly at
+//       finalize, never silently mis-emit.
+//   A3  Imports may be registered AT ANY TIME before finalize — a late
+//       import is FREE. No shift pass exists in this contract; late-import
+//       index shifting is a transitional implementation detail of the
+//       WasmGC adapter that #2710 slice 4 deletes.
+//   A4  Index assignment happens EXACTLY ONCE, inside `finalize()`, after
+//       all registration + DCE churn (today's `indexSpaceFrozen = true`
+//       point in generateModule). `finalize` is single-shot; any mutation
+//       after it throws.
+//   A5  Caching a handle is always safe. Caching a resolved index anywhere
+//       outside the emit phase is a contract violation (the #2078 /
+//       `__gen_eager_mode` class). The branded handle types (#2710 slice 1)
+//       make positional arithmetic on a handle a compile error once flipped
+//       to real brands.
+//   A6  Name → handle lookup is the assembler's; the namespaces (func /
+//       global / type) are exactly the namespaces the IR's symbolic refs
+//       (`IrFuncRef`/`IrGlobalRef`/`IrTypeRef`, #3030 D3.2) resolve against.
+//       One owner: today's `ctx.funcMap` / `moduleGlobals` / `typeNames`
+//       become views over the assembler.
+//   A7  Dead-code elimination marks handles dead; `finalize` skips dead
+//       handles when assigning indices. Nothing ever renumbers instructions
+//       (DCE's remove-and-renumber remap is subsumed — #2710 slice 4d).
+//
+// Definition payloads are generic (`FuncDefT`/`GlobalDefT`/`TypeDefT`)
+// because they are backend-shaped: the in-tree Wasm backends use the
+// `src/ir/types.ts` records (the defaults); an MLIR assembler's payloads
+// would be dialect ops and its `finalize` would produce an `mlir::ModuleOp`
+// layout. The handle model is identical either way.
+export interface ModuleAssembler<FuncDefT = WasmFunction, GlobalDefT = GlobalDef, TypeDefT = TypeDef> {
+  readonly backend: IrBackendKind;
+
+  // ---- function index space ---------------------------------------------
+  /**
+   * Mint the stable handle for a defined function under `name` (A1/A2/A6).
+   * MUST be paired with exactly one later `defineFunc` for the handle.
+   * Convergence: `mintDefinedFunc` (src/codegen/func-space.ts).
+   */
+  declareFunc(name: string): FuncHandle;
+  /**
+   * Bind the definition for a previously declared handle (A2). Throws on a
+   * double-define or an undeclared handle. Convergence: `pushDefinedFunc`.
+   */
+  defineFunc(handle: FuncHandle, def: FuncDefT): void;
+  /**
+   * Register a function import and mint its handle. Legal at ANY point
+   * before `finalize` (A3) — this is the member that retires
+   * `addUnionImports`/`addStringImports`/`ensureLateImport`'s shift regime.
+   * `name` is the in-module symbolic name (one namespace with defined
+   * functions, A6).
+   */
+  importFunc(module: string, field: string, typeHandle: TypeHandle, name: string): FuncHandle;
+  /** Name → handle (A6). The `ctx.funcMap` successor. */
+  lookupFunc(name: string): FuncHandle | undefined;
+
+  // ---- global index space -------------------------------------------------
+  /** Mint the stable handle for a defined global (A1/A2/A6). */
+  declareGlobal(name: string): GlobalHandle;
+  /** Bind the definition for a previously declared global handle (A2). */
+  defineGlobal(handle: GlobalHandle, def: GlobalDefT): void;
+  /**
+   * Register a global import (e.g. host string constants) and mint its
+   * handle. Legal at any time before finalize (A3) — retires
+   * `fixupModuleGlobalIndices` + its ~25 cached-field chases (#2710 4a).
+   */
+  importGlobal(module: string, field: string, type: ValType, mutable: boolean, name: string): GlobalHandle;
+  /** Name → handle (A6). */
+  lookupGlobal(name: string): GlobalHandle | undefined;
+
+  // ---- type index space ---------------------------------------------------
+  /**
+   * Intern a type definition, returning the handle of the structurally
+   * canonical entry (dedup is the assembler's — one entry per distinct
+   * definition; layout-handle memoization stays with the LayoutResolver).
+   * `name` (optional) additionally registers the handle in the type
+   * namespace for `lookupType`/`IrTypeRef` resolution (A6).
+   */
+  internType(def: TypeDefT, name?: string): TypeHandle;
+  /** Name → handle (A6). The `ctx.typeNames` successor. */
+  lookupType(name: string): TypeHandle | undefined;
+
+  // ---- module records -------------------------------------------------------
+  /** Record a function export by handle (never by index). */
+  exportFunc(exportName: string, handle: FuncHandle): void;
+  /** Record a global export by handle. */
+  exportGlobal(exportName: string, handle: GlobalHandle): void;
+  /** Record the start function by handle. */
+  setStart(handle: FuncHandle): void;
+
+  // ---- the single index authority (A4) --------------------------------------
+  /**
+   * Freeze the module: verify every declared handle is defined (A2), skip
+   * dead handles (A7), compute the canonical layout (imports in
+   * registration order first, then live defined entries in define order —
+   * reproducing today's final layout exactly, per the #2710 flip
+   * preconditions), and return the ONE `handle → final index` authority.
+   * Single-shot: a second call, or any mutation afterwards, throws.
+   * Convergence: `resolveLayout` (src/emit/resolve-layout.ts) is the live
+   * seam this contract's finalize is built on.
+   */
+  finalize(): ModuleLayout;
+}
+
+// ---------------------------------------------------------------------------
+// The bundle — what "a backend" is, as one value
+// ---------------------------------------------------------------------------
+
+/**
+ * A complete backend: the five parts under one roof. In-tree backends may
+ * keep implementing the parts separately (the contract is the seam, not a
+ * class hierarchy); the bundle type exists so a NEW backend has a single
+ * concrete answer to "what do I implement", and so conformance tests can
+ * range over the whole contract at once.
+ *
+ * `Sink` is the emitter's output representation (part 3); `Slot` the value
+ * representation (part 1); the three `*DefT` payloads the module-record
+ * shapes (part 5).
+ */
+export interface BackendContract<
+  Sink = unknown,
+  Slot = ValType,
+  FuncDefT = WasmFunction,
+  GlobalDefT = GlobalDef,
+  TypeDefT = TypeDef,
+> {
+  readonly backend: IrBackendKind;
+  readonly types: TypeConverter<Slot>;
+  readonly legality: BackendLegality;
+  readonly emitter: BackendEmitter<Sink>;
+  readonly layouts: IrLowerResolver;
+  readonly assembler: ModuleAssembler<FuncDefT, GlobalDefT, TypeDefT>;
+}

--- a/src/ir/contract.ts
+++ b/src/ir/contract.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// ---------------------------------------------------------------------------
+// The IR interchange contract — v1.0 surface (#3030-T1).
+//
+// NORMATIVE artifacts (this module is their code-side anchor):
+//   - docs/ir/ir-contract.md          the contract: D1–D5, guarantees,
+//                                     node inventory + type rules,
+//                                     versioning policy
+//   - docs/ir/ir-module.schema.json   JSON Schema for one serialized module
+//
+// This module deliberately contains ONLY the version constant and the
+// document-header / coverage-manifest types — the parts every consumer and
+// the (T3) serializer share. The serializer itself (`serializeIrModule` /
+// `deserializeIrModule`, `--emit-ir`) is #3030-T3; the verifier-side type
+// re-derivation is #3030-T4. Nothing in the compiler imports this module
+// yet; it is the frozen surface those slices implement against.
+// ---------------------------------------------------------------------------
+
+/**
+ * The IR interchange format version (#3030 D2).
+ *
+ * - ADDITIVE changes (new node kinds, new optional fields, new enum members
+ *   appended at the END of their table) bump the MINOR version.
+ * - BREAKING changes (removing/renaming a field or kind, reordering an enum
+ *   table, changing a serialized representation) bump the MAJOR version.
+ * - Every enum table in the contract (`JsTag`, `IrBinop`/`IrUnop`, effect
+ *   facets, IrType kinds, instruction kinds) is APPEND-ONLY with FROZEN
+ *   ORDER (the #1852 linear-tag-enum discipline).
+ * - The (T5) CI schema snapshot fails any PR that changes the serialized
+ *   shape without bumping this constant.
+ */
+export const IR_FORMAT_VERSION = "1.0";
+
+/**
+ * Which pipeline compiled a function's body (#3030 D3.7 — the honest
+ * coverage manifest). `"ir"` bodies are serialized under the full contract
+ * guarantees; `"legacy"` bodies are compiled by the direct AST→Wasm path
+ * (or contain a `raw.wasm` bridge, which embeds backend ops that D4 forbids
+ * serializing) and appear in the manifest WITHOUT a serialized body, so a
+ * consumer knows exactly what it can analyze. Coverage grows with
+ * #2855/#2950/#2949; the contract does not wait for 100%.
+ */
+export type IrCarrier = "ir" | "legacy";
+
+/** One function's row in the module coverage manifest (#3030 D3.7). */
+export interface IrCoverageEntry {
+  /** Function name — unique within the module's function namespace. */
+  readonly name: string;
+  readonly carrier: IrCarrier;
+  readonly exported: boolean;
+  /**
+   * Present iff `carrier === "legacy"`: the machine-readable reason the body
+   * is not IR-carried (an ir-fallback bucket name from
+   * scripts/ir-fallback-baseline.json, or `"raw-wasm-bridge"` for IR bodies
+   * excluded by the D4 raw.wasm rule).
+   */
+  readonly reason?: string;
+}
+
+/**
+ * The serialized module document's header (#3030 D1). The `functions` array
+ * (IR bodies for every `carrier: "ir"` manifest entry) is typed by the T3
+ * serializer; its shape is normative in docs/ir/ir-module.schema.json.
+ */
+export interface IrModuleDocumentHeader {
+  /** MUST equal the emitting compiler's `IR_FORMAT_VERSION`. */
+  readonly irVersion: string;
+  /** Source file the module was compiled from (diagnostic, not identity). */
+  readonly source?: string;
+  /** Every function in the module — IR-carried or not (D3.7). */
+  readonly coverage: readonly IrCoverageEntry[];
+}

--- a/tests/backend-contract.test.ts
+++ b/tests/backend-contract.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3029-S1/S4 + #3030-T1 — backend-contract + IR-interchange freeze smoke.
+//
+// The COMPILE-TIME conformance proof lives in
+// src/ir/backend/contract-conformance.ts (tsc-checked via `pnpm run
+// typecheck`; vitest does not typecheck). This file exercises the runtime
+// behaviors the freeze pins down:
+//   - the stub ModuleAssembler's index-identity protocol (invariants A1–A5),
+//     including the headline property: a LATE IMPORT never invalidates a
+//     handle minted earlier (the #2078 / __gen_eager_mode bug class is
+//     unrepresentable through the contract);
+//   - legalityFor() as the contract form of the legality checker;
+//   - the IR interchange surface (IR_FORMAT_VERSION, schema file validity).
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { StubModuleAssembler, emittersConform, makeStubBackend } from "../src/ir/backend/contract-conformance.js";
+import { legalityFor } from "../src/ir/backend/contract.js";
+import { IR_FORMAT_VERSION } from "../src/ir/contract.js";
+import type { TypeHandle } from "../src/ir/types.js";
+
+const TYPE_H = 0 as TypeHandle;
+
+describe("ModuleAssembler index identity (#3029-S4 invariants)", () => {
+  it("A3/A5 — a late import never invalidates an earlier handle", () => {
+    const asm = new StubModuleAssembler();
+    // Producer mints a handle and "bakes" it (e.g. into a call immediate)
+    // long before the import exists — the historical bug setup.
+    const fMain = asm.declareFunc("main");
+    asm.defineFunc(fMain, "body:main");
+    // LATE import — under eager index binding this shifted every defined
+    // function index (+1) and required a body-walking fixup pass.
+    const fImp = asm.importFunc("env", "late_helper", TYPE_H, "late_helper");
+    const layout = asm.finalize();
+    // Imports occupy the front of the index space; the handle minted BEFORE
+    // the import still resolves correctly with zero fixup.
+    expect(layout.func(fImp)).toBe(0);
+    expect(layout.func(fMain)).toBe(1);
+  });
+
+  it("A2 — declare/define is two-phase and exactly-once", () => {
+    const asm = new StubModuleAssembler();
+    const h = asm.declareFunc("f");
+    // Nested emission between mint and define is legal.
+    const inner = asm.declareFunc("g");
+    asm.defineFunc(inner, "body:g");
+    asm.defineFunc(h, "body:f");
+    expect(() => asm.defineFunc(h, "body:f2")).toThrow(/double define/);
+    // Declared-but-never-defined fails loudly at finalize.
+    const asm2 = new StubModuleAssembler();
+    asm2.declareFunc("never-defined");
+    expect(() => asm2.finalize()).toThrow(/never defined/);
+  });
+
+  it("A4 — finalize is single-shot and freezes mutation", () => {
+    const asm = new StubModuleAssembler();
+    const h = asm.declareFunc("f");
+    asm.defineFunc(h, "body");
+    asm.finalize();
+    expect(() => asm.finalize()).toThrow(/twice/);
+    expect(() => asm.declareFunc("late")).toThrow(/after finalize/);
+    expect(() => asm.importFunc("env", "x", TYPE_H, "x")).toThrow(/after finalize/);
+  });
+
+  it("A6 — name lookup returns handles, and globals/types mirror the protocol", () => {
+    const asm = new StubModuleAssembler();
+    const g = asm.declareGlobal("counter");
+    asm.defineGlobal(g, "global:counter");
+    const gImp = asm.importGlobal("env", "str0", { kind: "externref" }, false, "str0");
+    expect(asm.lookupGlobal("counter")).toBe(g);
+    const t1 = asm.internType("struct{a}", "$A");
+    const t2 = asm.internType("struct{a}");
+    expect(t2).toBe(t1); // structural dedup
+    expect(asm.lookupType("$A")).toBe(t1);
+    const layout = asm.finalize();
+    expect(layout.global(gImp)).toBe(0); // imports first
+    expect(layout.global(g)).toBe(1);
+  });
+});
+
+describe("five-part contract surface (#3029-S1)", () => {
+  it("compile-time emitter conformance is banked", () => {
+    expect(emittersConform).toBe(true);
+  });
+
+  it("the stub backend assembles all five parts and its emitter drives a foreign sink", () => {
+    const backend = makeStubBackend();
+    expect(backend.types.convertType({ kind: "string" })).toEqual(["slot:string"]);
+    const out = backend.emitter.newSink();
+    backend.emitter.emitBinary("f64.add", out);
+    const inner = backend.emitter.newSink();
+    backend.emitter.emitUnary("f64.neg", inner);
+    backend.emitter.emitBlock({ kind: "empty" }, inner, out);
+    expect(out).toEqual(["binary:f64.add", "block", "unary:f64.neg", "end"]);
+  });
+
+  it("legalityFor wraps the production legality checker per backend", () => {
+    for (const kind of ["wasmgc", "linear", "bytecode"] as const) {
+      const legality = legalityFor(kind);
+      expect(legality.backend).toBe(kind);
+      expect(typeof legality.checkFunction).toBe("function");
+    }
+  });
+});
+
+describe("IR interchange contract surface (#3030-T1)", () => {
+  it("exports the frozen format version", () => {
+    expect(IR_FORMAT_VERSION).toBe("1.0");
+    expect(IR_FORMAT_VERSION).toMatch(/^\d+\.\d+$/);
+  });
+
+  it("ships a parseable JSON Schema whose frozen tables match the contract", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const schema = JSON.parse(readFileSync(join(here, "../docs/ir/ir-module.schema.json"), "utf-8"));
+    expect(schema.$schema).toContain("2020-12");
+    expect(schema.required).toEqual(["irVersion", "coverage", "functions"]);
+    const kinds: string[] = schema.$defs.instrKind.enum;
+    // D4: raw.wasm is never serialized.
+    expect(kinds).not.toContain("raw.wasm");
+    // Spot-check the dynamic-boundary trio (D3.4 — the AOT payload).
+    expect(kinds).toContain("box");
+    expect(kinds).toContain("unbox");
+    expect(kinds).toContain("tag.test");
+    // D5: the scalar set is closed and index-free.
+    const scalars: string[] = schema.$defs.scalarValKind.enum;
+    expect(scalars).toContain("externref");
+    expect(scalars).not.toContain("ref");
+    expect(scalars).not.toContain("ref_null");
+  });
+});


### PR DESCRIPTION
## What

The three Fable-tier architecture cut-lines from the target-architecture spec (#2617), as one byte-inert code+docs PR:

### #3029-S1 — backend contract v1 freeze
- `src/ir/backend/contract.ts` — the five interfaces as code: `TypeConverter<Slot>`, `BackendLegality` (+ `legalityFor` factory over the existing `verifyIrBackendLegality`), `BackendEmitter<Sink>` (re-exported — the sink has been generic since #1584; S1 banks it as contract surface), `LayoutResolver` (canonical contract name of `IrLowerResolver` — type re-export, no drift-prone duplication), `ModuleAssembler`, and the `BackendContract` bundle.
- `src/ir/backend/README.md` — R-OWN contract README: per-part ownership, operand-order rules, memoization ownership, R-ESCAPE, R-DEP declaration.
- `src/ir/backend/contract-conformance.ts` — tsc-enforced skeleton (lives under `src/**` so `quality`'s typecheck gates it): the three emitters proven assignable to `BackendEmitter<Sink>` with their own sinks; a from-scratch stub backend implementing all five parts over a foreign `string[]` sink.

### #3029-S4 — ModuleAssembler index-identity design (ratified)
- Interface body in contract.ts with invariants A1–A7: mint-once handles, two-phase declare/define (the proven `mintDefinedFunc`/`pushDefinedFunc` protocol), **shift-free late imports**, single-shot `finalize()` (= `resolveLayout`) as the ONE place indices exist, cached-index prohibition (the #2078 / stale `__gen_eager_mode` class).
- Ratified spec section + convergence map in the #3029 issue file: how the four late-import shifters, `fixupModuleGlobalIndices`, `eliminateDeadImports`' renumber, and #2710's remaining waves (index.ts ×39 + integration.ts ×1, globals/types) converge into the assembler. S5 is adapter-first over `ctx.mod`, byte-identity gated.
- Invariants are **executable**: `tests/backend-contract.test.ts` encodes A2–A6 against the stub assembler, including "a late import never invalidates an earlier handle".

### #3030-T1 — IR interchange contract v1.0 freeze
- `docs/ir/ir-contract.md` — normative: D1–D5, the seven consumer guarantees (D3.3 marked effective-from-T4), full node inventory with per-kind operand/result type rules + effect classification, frozen enum tables, versioning policy.
- `docs/ir/ir-module.schema.json` — JSON Schema 2020-12 (syntax gate; the verifier is the semantic gate per the contract).
- `src/ir/contract.ts` — `IR_FORMAT_VERSION = "1.0"` + coverage-manifest/header types.
- Freeze-time ratifications recorded in the issue: raw.wasm serializability predicate, pre-T2 module-relative-type honesty rule, i64-as-string + non-finite-f64 encodings, slot-type rule, `ref_extern` added to the D5 scalar set.

## Call-site neutrality (byte-inert)

New files + type-only re-exports + one factory nothing calls yet. **Zero existing call sites changed**; no compile path is affected. `lower.ts`/`integration.ts`/emit are untouched.

## Verification

- `tsc --noEmit` clean (conformance file now part of the typecheck surface)
- `biome lint` + `prettier --check` clean on all touched files
- `tests/backend-contract.test.ts`: 9/9
- Equivalence suite running locally; CI is authoritative

Slices left open (Opus lanes): #3029 S2/S3/S5–S9, #3030 T2–T6. Both issues stay `in-progress`; claims released on merge so next-phase dispatch isn't blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8