### PR TITLE
feat(#2864 R1): yield* completion-value binding + string-outer delegation gate + carrier-completion design

### DIFF
--- a/plan/issues/2173-standalone-generator-general-iterable-yield-star.md
+++ b/plan/issues/2173-standalone-generator-general-iterable-yield-star.md
@@ -1,11 +1,11 @@
 ---
 id: 2173
 title: "standalone: yield* over a general iterable (array / custom {next()}) in native generators (SF-3 slice-2 of #2157)"
-status: blocked
-blocked_by: [2106]
+status: ready
+blocked_by: []
 sprint: current
 created: 2026-06-16
-updated: 2026-06-24
+updated: 2026-07-04
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -17,7 +17,7 @@ parent: 2157
 depends_on: [2170, 1320]
 ---
 
-# #2173 — yield* over a general iterable (SF-3 slice-2 of #2157)
+# #2173 — yield\* over a general iterable (SF-3 slice-2 of #2157)
 
 ## Problem
 
@@ -27,8 +27,15 @@ larger case is delegation to an **arbitrary iterable**: an array literal, a
 canonical-vec value, or a custom `{ [Symbol.iterator]() { return { next() {…} } } }`.
 
 ```ts
-function* g(){ yield* [1, 2, 3]; yield 4; }   // standalone: #680 CE today
-export function test(): number { let s = 0; for (const x of g()) s += x; return s; } // want 10
+function* g() {
+  yield* [1, 2, 3];
+  yield 4;
+} // standalone: #680 CE today
+export function test(): number {
+  let s = 0;
+  for (const x of g()) s += x;
+  return s;
+} // want 10
 ```
 
 `buildNativeGeneratorPlan` still bails on a `yield*` whose subject is not a
@@ -97,7 +104,7 @@ dominant `yield* [1,2,3]`), and would regress the zero-host-import invariant:
 - Confirmed by WAT: standalone `for (const x of [1,2,3])` does **NOT** use
   `__iterator`/`__iterator_next` at all (0 mentions) — it uses a **direct array
   fast-path** that iterates the native vec's f64 `data` array directly, zero host
-  imports. The bridge is for the *generic/escaped* iterable case, not numeric
+  imports. The bridge is for the _generic/escaped_ iterable case, not numeric
   arrays.
 
 **Corrected approach (slice-2a, numeric arrays/vecs):** the yield-star
@@ -129,3 +136,65 @@ become a vec-ref + cursor instead, since the bridge is out). The native-gen arm
 table (needs the direct-vec drive + a 2-field/cursor slot). Best landed as its
 own focused pass on top of merged #1502 with the corrected design. The
 scaffolding compiles but the iterable runtime arm is unimplemented.
+
+## Re-scope + unblock (fable-gencarrier, 2026-07-04)
+
+**Slice-2a (numeric arrays/vecs via the direct-vec cursor) is NOT #2106-blocked**
+— the corrected design above never boxes: the cursor reads `vec.data[idx]` as
+f64 directly. Only the GENERIC escaped-iterable arm (custom `{next()}` objects,
+whose `value` rides externref and whose "missing value" needs a real undefined
+representation) has the #2106 value-rep dependency. Frontmatter unblocked
+accordingly; the generic arm is re-sliced as 2b below and carries the
+dependency inline.
+
+Fresh context to build against (all landed since the 2026-06-16 note):
+
+- The `yield-star` terminator now carries `bindResultTo` (#2864 R1) — the
+  done-arm of a delegation site delivers the completion value into a typed
+  spill. The iterable arm's done-arm must do the same (an array's completion
+  value is `undefined`; a custom iterator's is the `value` of its
+  `done:true` result).
+- **Latent-bug guard (#2864 R1)**: the delegation yield-arm re-yields raw f64
+  through the OUTER result struct; a string-carrier outer is bailed
+  (`elemIsString` gate in `emitYield`) because no fixups.ts repair exists for
+  f64→concrete-ref. The iterable arm MUST keep that gate; the boxed-any outer
+  works via the f64→externref `__box_number` repair, but prefer an explicit
+  conversion over relying on the repair pass for NEW emission.
+- The scaffolding described below (delegationKind discriminator) was never
+  merged — branch `issue-2173-general-yield-star` predates F1/F1b/F2 and the
+  #1916-S3b/#2941 funcIdx-discipline changes. Re-derive the small parts (kind
+  tag on `delegationSites`/`delegationSlots`) fresh on current main rather
+  than resurrecting the branch.
+
+### Slice 2a contract (numeric array/vec — dispatchable now)
+
+1. Plan: in `emitYield`'s asterisk branch (generators-native.ts), when
+   `nativeGeneratorDelegationName` returns undefined, try
+   `isNumericIterableDelegate(subject)`: an array literal / identifier whose
+   static type resolves to the numeric canonical vec. Tag the site
+   `kind: "vec"`.
+2. Struct: a vec-site's slot is TWO fields appended like today's deleg slots:
+   `ref null $F64Vec` + `mut i32` cursor (offset discipline identical to
+   spills — see `delegationSlots` in `buildResumeInfo`).
+3. Emit (yield-star arm, vec kind): first entry materializes the vec
+   (`compileExpression(subject)` → vec ref) into the slot, cursor=0. Each
+   entry: `idx >= vec.length` → done-arm (bindResultTo delivers the f64
+   undefined sentinel; document the #2106 residual exactly as R1 did);
+   else read `vec.data[idx]`, `idx++` (struct.set), re-yield staying in this
+   state. No boxing anywhere; outer f64 exact, any-outer boxes via the same
+   seam as R1 (explicit `__box_number` union-native preferred).
+4. Tests: `yield* [1,2,3]; yield 4` for-of sum 10 (the B1 probe); vec via
+   variable; `const x = yield* [1,2]` binding; zero-length array (straight to
+   successor, no suspension from the vec); byte-hash matrix unchanged for
+   non-yield\*-programs.
+
+### Slice 2b (generic `{next()}` / escaped iterable — carries the #2106 dependency inline)
+
+Drive the #1320 `__iterator`/`__iterator_next` bridge from an externref slot
+as originally designed, but ONLY for subjects that are not native-vec/native-
+gen; unbox via the union-native `__unbox_number` (standalone-defined) for f64
+outers, pass through for any-outers. `.return()` close forwarding must reuse
+the #2864 D2 abrupt-forwarding shape (write mode/error into the inner record,
+drive once, discard) — do not invent a second close path. Blocked-by-#2106
+only for undefined-observability of the final `value`; everything else is
+buildable.

--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -2,9 +2,9 @@
 id: 2864
 title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
 status: in-progress
-assignee: ttraenkler/sr-frame
+assignee: ttraenkler/fable-gencarrier
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-04
 priority: high
 feasibility: hard
 task_type: feature
@@ -306,7 +306,146 @@ propagate the error; `return()` through try/finally is unchanged.
 - `tests/issue-2864-standalone-generator-carrier.test.ts` — 5 F2 standalone cases
   (zero-host-import asserted).
 
-
 ## Reconciliation note (shepherd, 2026-07-01)
 
 Landed slices: **F1** heterogeneous boxed-any carrier (PR #2366), **F1b** typed live-across-yield local spills (PR #2372), **F2** `gen.throw()` abrupt completion (PR #2375). Issue stays `in-progress` for the remaining carrier phases.
+
+## Carrier-completion design (fable-gencarrier, 2026-07-04) — measured status + remaining protocol
+
+### Measured `return <value>` status (corrects the task framing)
+
+Probed on main (standalone, host-free asserted): `return <value>` routing in
+the NATIVE carrier is **already complete** — terminal `{value, done:true}`
+exactly once then `{undefined, done:true}` (11111 canary), for-of/spread
+exclude it (203 canary), mid-loop `return`, boxed-any `return {…}`,
+string-carrier `return "z"`, and `gen.return(v)` value round-trip (numeric +
+open dispatch) all pass. What was actually missing on the sync-carrier side:
+
+1. **`const x = yield* inner()`** — the delegation COMPLETION value
+   (§27.5.3.7: the yield\* expression's value is `innerRes.value` once
+   `innerRes.done`) had no binding path (plan bailed → #680 CE). → **R1, this
+   PR.**
+2. **`yield*` over a general iterable** — #2173 (design refreshed there;
+   slice-2a is NOT #2106-blocked).
+3. **IR front-end (js-host lane)**: IR generators still throw-defer any
+   `return <expr>` to legacy (#2035 note in `from-ast.ts lowerTail`) — blocks
+   the #2951 skip-set retirement. Exact Opus-executable contract banked in
+   #2951 ("gen.setReturn" section).
+
+### R1 (this PR) — yield\* completion-value binding + carrier-mismatch gate
+
+- **`const x = yield* inner()`**: the `yield-star` terminator gains
+  `bindResultTo`. The done-arm delivers `innerRes.value` (f64 — inners are
+  f64-gated) into the binding's pre-allocated local AND its spill field
+  BEFORE transitioning to the successor, inside the same resume call that
+  observed completion. Deliberately NOT a resume binding: resume bindings
+  re-read the `sent` field on every entry, which would clobber the completion
+  value with the next `.next(v)` argument. Spill typed f64 via a dedicated
+  `delegationBindingNames` set (the decl-shape cascade in
+  `resolveSpillLocalValType` doesn't model yield\* initializers; the
+  `sent`-carrier rule types `.next(v)` bindings — both wrong here).
+- **Latent invalid-wasm fix**: the #2170 delegation gate checked only the
+  INNER's elem type. A **string-carrier outer** delegating to an f64 inner
+  emitted a module that FAILED WASM VALIDATION at instantiation (f64 →
+  concrete-ref result field; `repairStructTypeMismatches` has no repair for
+  that pair — the boxed-any outer only works because fixups.ts repairs
+  f64→externref to `__box_number`). R1 bails `elemIsString` outers to the
+  host path → clean #680 refusal. Do NOT "fix" this by leaning further on the
+  repair pass; if string-outer delegation is wanted later, emit an explicit
+  elem conversion in the yield-arm.
+- **Byte-inertness**: 8-program × 3-lane sha256 matrix (numeric/any/string
+  gens, slice-1 delegation, any-outer delegation, spill gen, plain, host gen ×
+  gc/standalone/wasi) — all identical before/after; only programs using the
+  NEW shapes change.
+- **Known residual (pre-existing, NOT R1)**: an inner that completes without
+  an explicit `return` delivers the f64 carrier's undefined-as-NaN sentinel,
+  so `x === x` diverges from Node (`false` vs `true`). This is the #2106
+  value-rep undefined-observability class, same as `.next()`-with-no-arg
+  resume bindings today. Do not pin it in tests.
+
+### Remaining protocol gaps (banked slices, exact contracts)
+
+- **D2 — delegation abrupt forwarding (iterator close through yield\*)**:
+  `.return(v)` / `.throw(e)` on the OUTER while suspended in a `yield-star`
+  state must forward to the INNER (`inner.return`/`inner.throw`, §27.5.3.7
+  steps 7.b/7.c) so the inner's `finally` blocks run, then continue the
+  outer's abrupt path. Today the outer's per-state abrupt block completes the
+  outer WITHOUT closing the inner (inner finalizers silently skipped).
+  Contract: in the yield-star state's abrupt block (mode != 0), when the
+  delegation slot is non-null, drive the inner's resume once with the SAME
+  mode + abrupt/error payload (write inner's `MODE`/`ABRUPT`/`ERROR` fields,
+  call its resume fn), discard the inner's result, null the slot, then run the
+  outer's own finalizers as today. Wasm-level: mirrors F2's mode-2 wiring, one
+  extra call in the abrupt block, gated on `delegationSlots` non-empty —
+  byte-inert for non-delegating generators. Test: M3 probe shape
+  (`inner try/finally`, outer `.return()` mid-delegation → inner `log`
+  written + outer completes with the return value).
+- **D3 — general-iterable `yield*`**: lives in #2173 (vec-cursor for numeric
+  arrays — slice-2a there, NOT blocked by #2106; generic `{next()}` +
+  `.return()` close as slice-2b, which SHOULD reuse D2's forwarding shape).
+- **D4 — try/CATCH across yield** (F2 deferral): do NOT extend the ad-hoc
+  region modeling in `generators-native.ts` for this — see the alignment
+  decision below; catch-region routing is exactly what #2906 slice 3c builds
+  for async. Trigger point for the planner convergence.
+
+### Alignment decision: sync generators vs the #2906 AsyncCfgPlan machine
+
+**Question** (from the dispatch): should sync generators ride the #2906
+multi-state CFG machine rather than a parallel mechanism?
+
+**Answer: converge at the PLANNER, not the emitter, and only at the D4/W6
+trigger — do not port the sync carrier now.** Rationale:
+
+1. **The ABI layer is ALREADY converged.** `frame-core.ts` owns the shared
+   frame ABI (`STATE`/`SENT`/`MODE`/`ABRUPT`/`ERROR`, `storeSpills`,
+   `setStateInstrs`) consumed by BOTH `generators-native.ts` and
+   `async-frame.ts`. The #2618 interpreter's PC-in-`$Frame` bytecode
+   suspension is the same model (saved integer position + spilled locals in a
+   heap frame) — all three stories are coherent today.
+2. **The two machines differ ONLY in suspend/settle backends.** Generator
+   `yield` returns `{value, done}` synchronously to the caller; async
+   `suspend` registers a promise reaction and returns. `jump`≈`goto`,
+   `branch`≈`condGoto`, `return/done`≈`settle*` are already isomorphic.
+   What is DUPLICATED is the **statement-tree → state-graph planner**
+   (loops/ifs/try-region lowering exists in both files, independently).
+3. **Why not port now**: the sync planner+emitter is load-bearing for ~250
+   native-gen tests with byte-stability discipline; a port is pure churn with
+   zero functional win until a shape needs what only the CFG machine has.
+   #2906's planner is also still growing its region model (3c: catch-states,
+   completion replay, nested regions) — porting onto a moving substrate
+   re-derives the #2367 graveyard.
+4. **The convergence trigger is D4 (try/catch-across-yield) / #3032 W6
+   (buffer retirement).** Both need catch-region routing + replay — exactly
+   #2906 3c. When 3c has landed and proven in the async lane, add a **sync
+   settle backend** to the CFG emitter (`yield` terminator → build result
+   struct + return, instead of fulfil+microtask) and route NEW generator
+   shapes through `planAsyncCfg`; retire `generators-native`'s ad-hoc
+   structural lowering only when the CFG path's corpus is net-zero on the
+   native-gen suites. **#2865 (async generators) must NOT wait for that
+   retirement**: it stacks directly on #2906 3d (`settleYield` terminator +
+   result-promise queue), which is the designed convergence point of the two
+   frames — building async gens on `generators-native.ts` instead would be a
+   third machine. Rule of thumb going forward: **new control-flow capability →
+   CFG planner; carrier/value-rep capability → generators-native.**
+
+### Composition with #3032 lazy-first-resume thunks
+
+Disjoint lanes, one destination. The thunk model is the JS-HOST answer for
+expression/nested/method generators (eager buffer made lazy at creation); the
+native carrier is standalone-only (`noJsHostTarget`) and already truly lazy —
+nothing runs until the first resume, `return()`/`throw()` before start never
+run the body (F2), matching the thunk model's §27.5.3.2 behavior. No gating
+interaction exists today (verified: R1 touches only the native path; js-host
+bytes identical). The composition rules:
+
+- **#3032 W3 route (b) (#2203 capture slots in the state struct) is the
+  preferred endgame** over widening route (a) thunk-wraps: every generator
+  family that becomes a native candidate exits the buffer model entirely
+  (and with it the thunk hack) in standalone; W6 then widens the native
+  carrier to js-host, retiring both.
+- **Do not add new eager-buffer capabilities** beyond the #2951 IR
+  `gen.setReturn` unblock (needed for the IR-first flip in the js-host lane
+  regardless of W6 timing).
+- Any future js-host widening of the native carrier must preserve #3032's
+  observable contract: creation runs nothing; `next(v)` two-way communication
+  (impossible under the buffer) comes free with the carrier.

--- a/plan/issues/2951-ir-first-skip-set-generators-class-members.md
+++ b/plan/issues/2951-ir-first-skip-set-generators-class-members.md
@@ -56,3 +56,52 @@ needs them retired or explicitly carved out.
 - Flag-off byte-identity preserved; index-layout invariance test extended
   to a class+generator corpus.
 - Full merge_group net-zero with the flag on (feeds the #2950 gate).
+
+## Predecessor slice contract: IR `gen.setReturn` (fable-gencarrier, 2026-07-04, Opus-executable)
+
+The generator half of this issue has a hard prerequisite the audit missed:
+**IR generators throw-defer any `return <expr>` to legacy**
+(`src/ir/from-ast.ts lowerTail`, the #2035 arm, ~L763) — so a generator with a
+value-carrying return can never be IR-claimed, and no skip-set widening can
+cover it. Retire the deferral with a `gen.setReturn` IR instruction that
+mirrors the legacy routing (`compileReturnStatement`,
+`src/codegen/statements/control-flow.ts:140-170`: coerce to externref →
+`__gen_set_return(buffer, value)` → `br` out of the body block).
+
+Mechanical contract (mirror `gen.push` at every layer — `grep -rn
+'"gen.push"' src/ir/` enumerates the exact switch arms; there are ~12 across
+`nodes.ts` (type + 3 switches), `builder.ts` (emit method), `from-ast.ts`,
+`lower.ts` (2), `effects.ts` (2), `verify.ts`, `verify-alloc.ts`,
+`select.ts`, `integration.ts`, `passes/inline-small.ts`,
+`passes/monomorphize.ts`):
+
+1. **`nodes.ts`**: `IrGenSetReturn { kind: "gen.setReturn"; value: IrValueId;
+result: null }` — same shape as `gen.push`; add to the same unions/switches.
+2. **`builder.ts`**: `emitGenSetReturn(value)` guarded on
+   `funcKind === "generator"` + `generatorBufferSlot` set (copy the
+   `emitGenPush` guards).
+3. **`from-ast.ts lowerTail`** generator arm: replace the `#2035` throw with:
+   lower `stmt.expression` via the SAME dispatch `lowerYield` uses (f64 / i32 /
+   ref-coerced-to-externref), `emitGenSetReturn(v)`, then the existing
+   `emitGenEpilogue()` + return-terminator. Bare `return;` unchanged.
+4. **`lower.ts`** `case "gen.setReturn"`: `__gen_set_return` has signature
+   `(externref, externref) -> void` (registered in `addGeneratorImports`,
+   `src/codegen/index.ts`). The value must be BOXED:
+   - f64 → resolve `__box_number` exactly the way the `__unbox_number`
+     resolution does at lower.ts:940 (`resolveHostImport`-style; if the
+     resolver doesn't know it, THROW to defer — never emit a raw f64 arg);
+   - i32 → `f64.convert_i32_s` first, then box;
+   - ref/ref_null → `extern.convert_any`; externref → pass through.
+     Then push buffer slot + boxed value, `call __gen_set_return`.
+5. **Effects/verify/select/passes**: copy `gen.push`'s classification
+   verbatim (side-effecting, non-reorderable past buffer reads, not
+   inlinable-across… whatever `gen.push` declares — do not re-derive).
+
+Validation gate: `tests/issue-2035.test.ts` (9 cases) must pass with the IR
+path now CLAIMING the for-of program (assert via `trackFallbacks` that the
+generator no longer defers); `pnpm run check:ir-fallbacks` must not grow;
+js-host lane A/B on the dstr/generator corpus net-zero-or-positive. NOTE the
+#3032 W6 horizon: this invests in the eager-buffer model that W6 eventually
+retires — it is still worth landing because the IR-first flip (#2950) is
+gated on IR parity NOW, and the instr becomes dead code W6 can delete
+wholesale.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -94,7 +94,20 @@ type StateTerminator =
   // the state struct (see `delegationSites`). This is a SELF-suspending state:
   // each `.next()` re-enters it, driving the inner's resume until the inner is
   // done, then control transfers to `next`.
-  | { kind: "yield-star"; subject: ts.Expression; innerName: string; siteIndex: number; next: number };
+  // (#2864 R1) `bindResultTo` — for `const x = yield* inner()`: the name that
+  // receives the DELEGATION COMPLETION value (the inner's `return` value,
+  // §27.5.3.7 — `innerRes.value` once `innerRes.done`). It is delivered by the
+  // done-arm inside the SAME resume call that observed the inner's completion,
+  // NOT from the `sent` field — so it is deliberately NOT a resume binding (a
+  // resume binding would clobber it with the `.next(v)` argument on re-entry).
+  | {
+      kind: "yield-star";
+      subject: ts.Expression;
+      innerName: string;
+      siteIndex: number;
+      next: number;
+      bindResultTo?: string;
+    };
 
 interface NativeGeneratorState {
   /** Straight-line, yield-free statements to run on entering this state. */
@@ -311,6 +324,13 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   // (#2170) `yield*` delegation sites, allocated in source order; index into
   // this array is the terminator's `siteIndex`.
   const delegationSites: { innerName: string }[] = [];
+  // (#2864 R1) Names bound to a delegation COMPLETION value
+  // (`const x = yield* inner()`). Spilled at f64 — the delegation gate admits
+  // only f64-elem inners, and the inner's `return` value rides its result
+  // struct's f64 `value` field. Typed here (not via `resolveSpillLocalValType`,
+  // whose declaration-shape cascade doesn't model a yield* initializer, nor via
+  // the `sent`-carrier rule, which types `.next(v)` bindings).
+  const delegationBindingNames = new Set<string>();
   const spillSet = new Set<string>();
   // (#2864 F1b) The variable declaration that introduced each spilled name, so
   // the spill's wasm type can be resolved at its actual ValType.
@@ -496,11 +516,23 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
       const subject = yieldExpr.expression;
       const innerName = subject ? nativeGeneratorDelegationName(subject) : undefined;
       if (!subject || innerName === undefined) return fail();
-      // The successor after delegation finishes. Like a yield successor it may
-      // carry a resume binding (`x = yield* inner()` binds the inner's return
-      // value); slice-1 supports only the unbound expression-statement form, so
-      // require `bindSentTo === undefined`.
-      if (bindSentTo !== undefined) return fail();
+      // (#2864 R1) Carrier-mismatch gate: the delegation yield-arm re-yields the
+      // inner's f64 `value` through the OUTER result struct. For an f64 outer
+      // that is exact; for the boxed-any outer the f64→externref mismatch is
+      // repaired to a `__box_number` by `repairStructTypeMismatches`
+      // (fixups.ts). A STRING outer's result `value` is a concrete ref no
+      // repair can bridge — main emitted an INVALID module for that shape
+      // (wasm validation failure at instantiation, latent since #2170/#2171).
+      // Bail it to the host path (standalone: the clean #680 refusal) instead.
+      if (elemIsString) return fail();
+      // (#2864 R1) `const x = yield* inner()` — bind the delegation COMPLETION
+      // value (the inner's `return` value). The done-arm writes it inside the
+      // same resume call, so it is NOT a resume binding (see the terminator
+      // comment); it only needs a typed spill slot.
+      if (bindSentTo !== undefined) {
+        delegationBindingNames.add(bindSentTo);
+        addSpill(bindSentTo);
+      }
       const siteIndex = delegationSites.length;
       delegationSites.push({ innerName });
       const nextId = startStateAfterYield(undefined, activeFinalizers);
@@ -510,6 +542,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
         innerName,
         siteIndex,
         next: nextId,
+        bindResultTo: bindSentTo,
       });
       // Create the successor and make it current (mirrors finishCurrentAsYield).
       curId = reserveState();
@@ -828,6 +861,13 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   const carrierType = genCarrierFieldType(elemValType);
   const spillTypes = new Map<string, ValType>();
   for (const name of spills) {
+    // (#2864 R1) A delegation-completion binding (`const x = yield* inner()`)
+    // holds the inner's f64 `return` value — always f64 (only f64-elem inners
+    // are delegated), independent of the OUTER's carrier.
+    if (delegationBindingNames.has(name)) {
+      spillTypes.set(name, { kind: "f64" });
+      continue;
+    }
     if (resumeBindingNames.has(name)) {
       // A `let x = yield …` binding reads `.next(v)`'s value from the `sent`
       // carrier field. For numeric / native-string carriers (sent = f64 / string)
@@ -1771,12 +1811,39 @@ function compileState(
       body.push({ op: "call", funcIdx: innerResumeIdx });
       body.push({ op: "local.set", index: innerResLocal });
 
+      // (#2864 R1) `const x = yield* inner()` — on completion, deliver the
+      // inner's `return` value (§27.5.3.7: the yield* expression's value is
+      // `innerRes.value` once `innerRes.done`) into the binding's local AND its
+      // spill field, so it both flows into the successor state within this
+      // resume call and survives later suspensions. The inner is f64-gated, so
+      // the value and the binding's spill slot are both f64.
+      const bindInstrs: Instr[] = [];
+      if (term.bindResultTo !== undefined) {
+        const bindLocal = fctx.localMap.get(term.bindResultTo);
+        const bindSpillIdx = info.spillNames.indexOf(term.bindResultTo);
+        if (bindLocal !== undefined && bindSpillIdx >= 0) {
+          bindInstrs.push(
+            { op: "local.get", index: innerResLocal },
+            { op: "struct.get", typeIdx: innerInfo.resultTypeIdx, fieldIdx: RESULT_VALUE_FIELD },
+            { op: "local.set", index: bindLocal },
+            { op: "local.get", index: selfLocal },
+            { op: "local.get", index: bindLocal },
+            {
+              op: "struct.set",
+              typeIdx: info.stateTypeIdx,
+              fieldIdx: info.spillFieldOffset + bindSpillIdx,
+            } as Instr,
+          );
+        }
+      }
+
       // if (innerRes.done == 0) re-yield innerRes.value (stay in THIS state)
       const doneArm: Instr[] = [
         // inner done — clear the slot, advance to the successor state, re-enter.
         { op: "local.get", index: selfLocal },
         { op: "ref.null", typeIdx: innerInfo.stateTypeIdx },
         { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: slot.fieldIdx } as Instr,
+        ...bindInstrs,
         ...setStateInstrs(info, selfLocal, term.next),
         { op: "br", depth: loopDepth + 1 }, // +1 for the inner `if`
       ];

--- a/tests/issue-2864-standalone-generator-carrier.test.ts
+++ b/tests/issue-2864-standalone-generator-carrier.test.ts
@@ -278,3 +278,73 @@ export function test(): number {
     ).toBe(8);
   });
 });
+
+describe("#2864 R1 yield* completion-value binding (standalone)", () => {
+  it("verify-first: const x = yield* inner() binds the inner's return value", async () => {
+    expect(
+      await runStandalone(`function* inner() { yield 1; return 42; }
+function* g() { const x = yield* inner(); yield x; }
+export function test(): number {
+  let s = 0;
+  for (const v of g()) s += v;
+  return s; // 1 (delegated) + 42 (bound return value)
+}`),
+    ).toBe(43);
+  });
+
+  it("binding survives a later suspension (spill round-trip)", async () => {
+    expect(
+      await runStandalone(`function* inner() { yield 1; return 42; }
+function* g() { const x = yield* inner(); yield 7; yield x; }
+export function test(): number {
+  const it = g();
+  let s = 0;
+  let r = it.next();
+  while (!r.done) { s = s * 100 + (r.value as number); r = it.next(); }
+  return s; // 1, 7, 42 → 10742
+}`),
+    ).toBe(10742);
+  });
+
+  it("binding works in a boxed-any (mixed-yield) outer", async () => {
+    expect(
+      await runStandalone(`function* inner() { yield 1; return 5; }
+function* g() { const x = yield* inner(); yield {a: x}; }
+export function test(): number {
+  let s = 0;
+  for (const v of g()) { s += (typeof v === "number") ? (v as number) : (v as any).a; }
+  return s; // 1 + 5
+}`),
+    ).toBe(6);
+  });
+
+  it("two delegation sites, first one bound", async () => {
+    expect(
+      await runStandalone(`function* a() { yield 1; return 10; }
+function* b() { yield 2; }
+function* g() { const x = yield* a(); yield* b(); yield x; }
+export function test(): number {
+  let s = 0;
+  for (const v of g()) s = s * 100 + v;
+  return s; // 1, 2, 10 → 10210
+}`),
+    ).toBe(10210);
+  });
+
+  it("string-outer delegation refuses cleanly (#680) instead of emitting invalid wasm", async () => {
+    // Latent since #2170/#2171: a string-carrier outer delegating to an f64
+    // inner passed the plan gate (which only checked the INNER's elem type) and
+    // the emitted module FAILED WASM VALIDATION at instantiation (f64 value
+    // into the outer's concrete-ref result field — no fixups.ts repair exists
+    // for that pair). The R1 gate bails the shape to the host path, which under
+    // standalone is the scoped #680 compile refusal — correct-not-wrong.
+    const r = await compile(
+      `function* inner() { yield 1; }
+function* g() { yield* inner(); yield "s"; }
+export function test(): number { let n = 0; for (const x of g()) n++; return n; }`,
+      { fileName: "test.ts", target: "standalone" },
+    );
+    expect(r.success).toBe(false);
+    expect(r.errors?.[0]?.message ?? "").toContain("#680");
+  });
+});


### PR DESCRIPTION
## What

**R1 slice of #2864 (sync-generator carrier completion) + the completion design banked across #2864/#2173/#2951.**

### Code (standalone native carrier, `src/codegen/generators-native.ts`)

1. **`const x = yield* inner()` now binds the delegation completion value** (§27.5.3.7: the yield* expression's value is `innerRes.value` once `innerRes.done`). The `yield-star` terminator gains `bindResultTo`; the done-arm writes the inner's f64 return value into the binding's local **and** its spill field before transitioning — inside the same resume call that observed completion. Deliberately NOT a resume binding (resume bindings re-read the `sent` field on entry, which would clobber the completion value with the next `.next(v)` argument). Previously this shape was a #680 CE.
2. **Latent invalid-wasm fix**: the #2170 delegation gate checked only the INNER's elem type. A **string-carrier outer** delegating to an f64 inner emitted a module that failed wasm validation at instantiation (f64 into the outer's concrete-ref result field — `repairStructTypeMismatches` has no repair for that pair; the boxed-any outer only works because fixups.ts repairs f64→externref to `__box_number`). Now bails to the host path → clean #680 refusal.

### Verification

- 5 new standalone tests (zero-host-import asserted); full file 24/24 green.
- Controls green: issue-2035/2170/2171/1017/1665/2079/2172/2571/2581/3032/2157, generators, iterators (the one `generator-yield-contexts` failure reproduces identically on clean origin/main — pre-existing #3032 setExports harness gap, verified by stash A/B).
- **Byte-inertness**: 8-program × 3-lane (gc/standalone/wasi) sha256 matrix identical before/after — numeric/any/string generators, slice-1 delegation, any-outer delegation, spills, plain, host-gen. Only the NEW shapes change.
- Known residual documented (not pinned in tests): inner completing without explicit `return` delivers the f64 undefined-as-NaN sentinel (#2106 class, pre-existing).

### Design banked (issue files, exact contracts)

- **#2864**: measured status matrix — `return <value>` routing is already COMPLETE in all three carriers (11111/203 canaries; the task framing was stale); D2 delegation abrupt-forwarding (iterator close through yield*) contract; **#2906 alignment answer**: converge at the PLANNER, not the emitter — frame-core ABI is already shared; port sync gens to the CFG machine only at the D4 (try/catch-across-yield) / #3032-W6 trigger, after #2906-3c proves catch-region replay in the async lane; #2865 stacks on #2906-3d, NOT on generators-native; #3032 lazy/eager composition rules (disjoint lanes, W3-route-b capture slots as endgame).
- **#2173**: re-scoped — slice-2a (vec-cursor for `yield* [1,2,3]`) is NOT #2106-blocked, frontmatter unblocked, dispatchable contract written; generic arm re-sliced as 2b with the dependency inline.
- **#2951**: Opus-executable `gen.setReturn` contract (retires the IR `return <expr>` throw-defer from #2035 — the actual prerequisite for the generator skip-set retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8