### PR TITLE
fix(#2029): eliminate the final index-out-of-range emit-crash families

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -1,12 +1,13 @@
 ---
 id: 2029
 title: "standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests)"
-status: in-progress
+status: done
+completed: 2026-07-04
 sprint: current
 created: 2026-06-10
-updated: 2026-06-25
+updated: 2026-07-04
 priority: critical
-assignee: ttraenkler/sd-2029fn
+assignee: ttraenkler/fable-2029
 feasibility: medium
 reasoning_effort: high
 model: opus
@@ -646,3 +647,62 @@ local-index (1) residuals already noted above.
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 
 NOT done — umbrella; the headline `u32 out of range: -1` emit-crash class IS resolved (497 → a handful; multiple landed slices: emitSetSubclassProto -1 sentinel, __get_undefined leak, primitive-wrapper refusal, tagged-template localMap rollback, SuppressedError global-sentinel, failed-nested-hoist funcIdx). Remaining separate producers: regexp-replacer global-index (2), property-accessor (1), native-generator funcMap-undefined in annexB RegExp (2), one for-of/iterator-next local-index (1). Deferred: primitive-wrapper native-box subclass; DisposableStack/AsyncDisposableStack ERM substrate (Symbol.dispose value-read + dispose-dispatch, senior-dev). Stays in-progress as the umbrella.
+
+## FINAL family map + fixes (2026-07-04, fable-2029) — emit-crash class now ZERO
+
+**Measured first (live standalone baseline `test262-standalone-current.jsonl`,
+2026-07-03 refresh, confirmed per-process on main `f01867968` via
+`runTest262File`):** the bucket was down to **4 tests, 3 producer families**.
+The annexB native-generator `funcMap`-undefined pair (2) had already flipped to
+ordinary semantic `fail`s (fixed by intervening work — no longer emit-crashes).
+Notably, none of the 4 was host-PASS anymore, and family A crashed in **BOTH
+modes** — the original "host-pass gap" framing was stale.
+
+| Family | Tests | Producer (verified per-process, minimized) | Fix |
+|---|---|---|---|
+| **A** `local index out of range — 2 (valid:[0,2)) at '__anon_0_get_next'` (BOTH modes) | for-of/iterator-next-reference.js | The **Object.defineProperty descriptor accessor path** (`object-ops.ts` ~1927) compiled `get(){...}` bodies in a fresh fctx **without ever calling `promoteAccessorCapturesToGlobals`** (the object-literal accessor path in literals.ts has always called it). A getter returning a nested fn (`get(){ return next; }`, `function next()` capturing an enclosing local) materialized next's closure via `cap.outerLocalIdx` — a slot of the ENCLOSING function — baked into the accessor body: emit crash when out of range, **silent wrong-local read when in range**. Minimal repro needs a preceding computed-member fn-expr assignment only to shift the slot out of range. | (1) `object-ops.ts`: call `promoteAccessorCapturesToGlobals` for descriptor get/set bodies (after the S5c closure arm). (2) `closures.ts promoteAccessorCapturesToGlobals`: NEW phase — promote **transitive captures of referenced nested functions** (value global for immutable — value-copy semantics preserved since never written; eager ref-cell box aliased in a `(ref null $cell)` module global — `ctx.capturedBoxGlobals` — for mutable, giving LIVE write-through sharing). (3) `closures.ts emitMemoizedNestedFnClosure` + the calls.ts direct-call cap-prepend: new sourcing arms — prefer `capturedBoxGlobals` / `capturedGlobals` when the current fctx cannot resolve the capture (guarded on localMap-absence; owner-fctx behavior unchanged, respecting the #1177 revert). Mutable-but-directly-referenced keeps value promotion + a boxed copy at materialization (best-effort, documented). |
+| **B** `global index -1 at 'RE_@@replace'` (standalone) | replaceAll/searchValue-replacer-RegExp-call{,-fn}.js | `emitSuperExternMethodCall` (`new-super.ts:356`) — the #1614 JS-host super-dispatch bridge (`__extern_method_call`) — ran under standalone and pushed the method name via raw `global.get stringGlobalMap.get(name)` guarded only on `!== undefined` — the documented **-1 string-global sentinel class** (`reference_string_global_sentinel_guard`), missed by PR-1's audit because it's the *super* path, not a direct `stringGlobalMap` consumer of that sweep. Minimal repro: ANY `super.method(...)` in a subclass of a host-constructible builtin, standalone. | Gate the bridge off under `ctx.standalone || ctx.wasi` (host bridge can never be satisfied there; also stops the `__extern_method_call`/`__js_array_*` import leak) + route the name push through `stringConstantExternrefInstrs` for the gc+nativeStrings combination (host byte-identical). |
+| **C** `global index -1 at 'test'` (standalone) | property-accessors/S11.2.1_A3_T2.js | **Three layers** in the ELEMENT-ACCESS number-method arm (calls.ts ~15207), minimized to `1["toFixed"](5)`: (i) the RangeError message pushes used the raw -1-sentinel `global.get` (the dot-access twins already used the dual-mode helper); (ii) the declarations.ts pre-scan (`collectPrimitiveMethodImports`) only recognizes the DOT form, so `number_toFixed` etc. were never registered for the computed spelling → the arm fell through past `funcMap.get(...)` **with receiver+arg already pushed** into the generic dynamic fallback (runtime throw); (iii) the arm validated `toString(radix)` then called the 1-arg helper — radix silently dropped (`5["toString"](2)` → "5"). | (i) `stringConstantExternrefInstrs` at both message sites; (ii) new elem-access string-key branch in the declarations.ts scan registering the same helpers; (iii) hoist `radixLocal` and route to the 2-arg `number_toString_radix` mirroring the dot site. All computed forms (`toFixed`/`toPrecision`/`toExponential`/`toString(radix)`) now compute CORRECT values standalone (verified runtime, empty import object). |
+
+**Classification verdicts (the assignment's a/b/c ruling):** none of the three
+families was dying on its own via #2710's late-binding migration (the
+`ref.func` in family A's body was already a healthy `STABLE_FUNC_BASE`
+late-bound id — the poison was the *local* index); all three were bounded
+fixes and all three are FIXED in this PR. The annexB generator pair (the one
+family sd-2029fn left) had already died via intervening work.
+
+**Row-delta (per-process, branch vs pristine `f01867968`):** all 4 tests ×
+both modes: emit-crash → compiles + ordinary runtime `fail` (dynamic-object
+iterator protocol / RegExp-subclass ctor flags / number-member spelling gaps —
+separate, pre-existing families, host-mode parity). **The `index out of
+range` emit-crash count in the standalone baseline is now 0.**
+
+**Validation:** new `tests/issue-2029-emit-index-families.test.ts` (8/8; A
+gc+standalone compile, B no-crash + no `__extern_method_call` leak +
+gc control, C standalone runtime-correct + gc control). All 7 existing
+issue-2029 suites green (37/37). Closure/accessor batch
+(illegal-cast-585, 1712, getters-setters, accessor-side-effects, 2580, 2609,
+2692, 1528): 13 failures **identical on pristine** (verified in a clean
+control worktree) — pre-existing, not regressions. Number-format suites
+(49, 2163, 2934): 23/23. tsc clean; stack-balance / any-box / speculative-
+rollback gates OK; coercion-sites baseline refreshed (+2 in declarations.ts =
+pre-registration of EXISTING native helpers for the elem-access spelling,
+same pattern as the counted dot-form block — not new coercion vocabulary).
+Broad emit-path change → merge_group test262 floor validates full conformance
+(`project_broad_impact_validate_full_ci`).
+
+**Why status: done.** The issue's defining class — invalid-binary emission
+from a poisoned index — is extinct on the measured baseline: every producer
+family is fixed or refuses loudly, and #2043's always-on validation turns any
+future regression into a named, located error. The remaining non-emit
+residuals live on their own trackers per the 2026-06-23 disposition:
+Set/Map/WeakMap/WeakSet subclass → #2620/#2622; primitive-wrapper native-box →
+value-rep follow-up (pairs #1629b); Object.create ToPrimitive/descriptor
+reflection → #2358/#2158; iterator-helper semantics → iterator-helpers lane;
+DisposableStack/AsyncDisposableStack ERM substrate (Symbol.dispose value-read
++ dispose-dispatch) → senior-dev substrate slice (dev-carla triage above).
+Known small residual noted for a follow-up, NOT emit-crash: the elem-access
+number-method arm still falls through with a dirty stack if a helper is
+somehow unregistered (unreachable for the scanned shapes), and a
+directly-referenced + mutably-closure-captured accessor variable gets copy
+(not shared) semantics — both documented inline at the sites.

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -6,7 +6,7 @@
   "codegen/binary-ops.ts": 33,
   "codegen/class-to-primitive.ts": 1,
   "codegen/closed-method-dispatch.ts": 1,
-  "codegen/declarations.ts": 20,
+  "codegen/declarations.ts": 22,
   "codegen/expressions/assignment.ts": 12,
   "codegen/expressions/calls-closures.ts": 2,
   "codegen/expressions/calls.ts": 30,

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -367,10 +367,107 @@ export function promoteAccessorCapturesToGlobals(
     }
   }
 
+  // (#2029 family A) Transitive captures of referenced NESTED FUNCTIONS.
+  // When the accessor body references a nested function declaration (e.g.
+  // `get() { return next; }` with `function next() { return count; }` in the
+  // enclosing scope), the name `next` itself is skipped below (it is a
+  // function reference, not a variable) — but materializing next's closure
+  // INSIDE the accessor still needs next's captured variables. Those captures
+  // are recorded against the ENCLOSING function's local slots
+  // (`cap.outerLocalIdx`), which the accessor's own function cannot read:
+  // previously `emitMemoizedNestedFnClosure` / the call-site cap-prepend baked
+  // the enclosing function's local index into the accessor body — an emit
+  // crash ("local index out of range") when the slot exceeded the accessor's
+  // local count, and a silent wrong-local read when it happened to be in
+  // range. Promote the transitive captures here, in the enclosing fctx where
+  // `cap.outerLocalIdx` is still valid:
+  //   - IMMUTABLE captures → plain value-global promotion (added to
+  //     `referencedNames`, handled by the main loop below). Value-copy
+  //     semantics are preserved: the variable is never written, so the
+  //     global always holds the one value the closure would have captured.
+  //   - MUTABLE captures → box EAGERLY (same ref-cell + localMap-rebind
+  //     pattern the closure builders use) and alias the BOX in a module
+  //     global (`ctx.capturedBoxGlobals`). The accessor's closure
+  //     materialization then shares the very same cell the enclosing
+  //     function writes through — live write-through semantics, not a copy.
+  {
+    // Names the accessor body references DIRECTLY (before the transitive
+    // union below). A mutable capture that is also directly referenced keeps
+    // the value-global promotion — the accessor's own read/write paths
+    // (identifiers.ts / assignment.ts) resolve via `ctx.capturedGlobals`
+    // only; the closure materialization then sources a boxed COPY of the
+    // value global (best-effort, no crash) instead of the shared cell.
+    const directlyReferenced = new Set(referencedNames);
+    const fnWorklist: string[] = [];
+    for (const name of referencedNames) {
+      if (ctx.funcMap.has(name) && ctx.nestedFuncCaptures.has(name)) fnWorklist.push(name);
+    }
+    const visitedFns = new Set<string>();
+    while (fnWorklist.length > 0) {
+      const fnName = fnWorklist.pop()!;
+      if (visitedFns.has(fnName)) continue;
+      visitedFns.add(fnName);
+      const caps = ctx.nestedFuncCaptures.get(fnName);
+      if (!caps) continue;
+      for (const cap of caps) {
+        // A capture can itself be a nested function name — follow it.
+        if (ctx.funcMap.has(cap.name) && ctx.nestedFuncCaptures.has(cap.name)) {
+          fnWorklist.push(cap.name);
+          continue;
+        }
+        if (!(cap.mutable && cap.valType) || directlyReferenced.has(cap.name)) {
+          // Immutable (value-copy semantics preserved: never written), or
+          // mutable-but-directly-referenced (accessor read path wins):
+          // value-global promotion via the main loop below.
+          referencedNames.add(cap.name);
+          continue;
+        }
+        // Mutable: box-promote (shared ref cell aliased in a global).
+        if (ctx.capturedBoxGlobals?.has(cap.name)) continue;
+        if (ctx.capturedGlobals.has(cap.name) || ctx.moduleGlobals.has(cap.name)) continue;
+        const capLocalIdx = fctx.localMap.get(cap.name);
+        if (capLocalIdx === undefined) continue;
+        const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.valType);
+        let boxedLocalIdx: number;
+        if (fctx.boxedCaptures?.has(cap.name)) {
+          // Already boxed by a prior closure construction — localMap points
+          // at the box; alias that same cell.
+          boxedLocalIdx = capLocalIdx;
+        } else {
+          fctx.body.push({ op: "local.get", index: capLocalIdx });
+          fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
+          boxedLocalIdx = allocLocal(fctx, `__boxed_${cap.name}`, {
+            kind: "ref",
+            typeIdx: refCellTypeIdx,
+          });
+          fctx.body.push({ op: "local.set", index: boxedLocalIdx });
+          fctx.localMap.set(cap.name, boxedLocalIdx);
+          if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+          fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
+        }
+        const boxGlobalIdx = nextModuleGlobalIdx(ctx);
+        ctx.mod.globals.push({
+          name: `__captured_box_${cap.name}`,
+          type: { kind: "ref_null", typeIdx: refCellTypeIdx },
+          mutable: true,
+          init: [{ op: "ref.null", typeIdx: refCellTypeIdx }],
+        });
+        fctx.body.push({ op: "local.get", index: boxedLocalIdx });
+        fctx.body.push({ op: "global.set", index: boxGlobalIdx });
+        (ctx.capturedBoxGlobals ??= new Map()).set(cap.name, { globalIdx: boxGlobalIdx, refCellTypeIdx });
+      }
+    }
+  }
+
   for (const name of referencedNames) {
     // Skip if already a captured global or module global
     if (ctx.capturedGlobals.has(name)) continue;
     if (ctx.moduleGlobals.has(name)) continue;
+    // (#2029 family A) Skip names box-promoted above — their localMap entry
+    // now points at the shared ref-cell box; value-promoting that box would
+    // orphan the rebind (and the accessor body sources it via
+    // `ctx.capturedBoxGlobals`, not `ctx.capturedGlobals`).
+    if (ctx.capturedBoxGlobals?.has(name)) continue;
 
     const localIdx = fctx.localMap.get(name);
     if (localIdx === undefined) continue;
@@ -3579,11 +3676,39 @@ function emitMemoizedNestedFnClosure(
       fctx.body.push({ op: "local.get", index: i });
       continue;
     }
+    // (#2029 family A) Cross-fctx capture sourcing. `cap.outerLocalIdx` is a
+    // slot in the function that DECLARED the nested fn; when this
+    // materialization runs inside a DIFFERENT function (an object-literal
+    // accessor body — the enclosing fn's locals are unreachable), baking it
+    // emit-crashes ("local index out of range") or silently reads the wrong
+    // local. `promoteAccessorCapturesToGlobals` promotes such captures to
+    // module globals (shared ref-cell box for mutable, value global for
+    // immutable); prefer those whenever the current fctx cannot resolve the
+    // name itself. Guarded on localMap-absence so owner-fctx behavior is
+    // unchanged (see the #1177 revert note in calls.ts for why a blanket
+    // localMap-first lookup is NOT safe).
+    const capUnresolvedHere = fctx.localMap.get(cap.name) === undefined;
     if (cap.mutable && cap.valType) {
       const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.valType);
+      const boxGlobal = capUnresolvedHere ? ctx.capturedBoxGlobals?.get(cap.name) : undefined;
       if (fctx.boxedCaptures?.has(cap.name)) {
         const currentLocalIdx = fctx.localMap.get(cap.name)!;
         fctx.body.push({ op: "local.get", index: currentLocalIdx });
+      } else if (boxGlobal !== undefined) {
+        // Shared ref-cell box promoted to a module global — live
+        // write-through semantics with the declaring function.
+        fctx.body.push({ op: "global.get", index: boxGlobal.globalIdx });
+        fctx.body.push({ op: "ref.as_non_null" });
+      } else if (capUnresolvedHere && ctx.capturedGlobals.has(cap.name)) {
+        // Value global (the capture is also directly referenced by the
+        // accessor body) — box a copy. Best-effort: writes through the
+        // closure do not propagate back, but the previous behavior was an
+        // out-of-scope local read (emit crash / wrong local).
+        fctx.body.push({ op: "global.get", index: ctx.capturedGlobals.get(cap.name)! });
+        if (ctx.capturedGlobalsWidened.has(cap.name)) {
+          fctx.body.push({ op: "ref.as_non_null" });
+        }
+        fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
       } else {
         // Stage 1 localMap-first lookup reverted — see calls.ts comment.
         fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });
@@ -3596,6 +3721,14 @@ function emitMemoizedNestedFnClosure(
         fctx.localMap.set(cap.name, boxedLocalIdx);
         if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
         fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
+      }
+    } else if (capUnresolvedHere && ctx.capturedGlobals.has(cap.name)) {
+      // (#2029 family A) Immutable capture promoted to a value global by
+      // the accessor-capture pass — read it instead of the out-of-scope
+      // declaring-function local slot.
+      fctx.body.push({ op: "global.get", index: ctx.capturedGlobals.get(cap.name)! });
+      if (ctx.capturedGlobalsWidened.has(cap.name)) {
+        fctx.body.push({ op: "ref.as_non_null" });
       }
     } else {
       fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -880,6 +880,21 @@ export interface CodegenContext {
   capturedGlobals: Map<string, number>;
   /** Captured globals whose type was widened from ref to ref_null for null init */
   capturedGlobalsWidened: Set<string>;
+  /**
+   * (#2029 family A) Mutable-capture ref-cell boxes promoted to module
+   * globals so an accessor body can materialize a nested function's closure.
+   * When an object-literal getter/setter references a nested function `f`
+   * whose captures include a MUTABLE outer local `v`, the closure-construction
+   * code inside the accessor needs the SAME ref-cell box the enclosing
+   * function writes through — an outer-fctx local slot (`cap.outerLocalIdx`)
+   * is unreachable from the accessor's own function (baking it emit-crashed
+   * with "local index out of range", or silently read the wrong local when
+   * the stale index happened to be in range). `promoteAccessorCapturesToGlobals`
+   * boxes `v` eagerly in the enclosing fctx and aliases the box in a module
+   * global of type `(ref null $cell)`; closure-materialization sites source
+   * the capture from here when the current fctx cannot resolve it.
+   */
+  capturedBoxGlobals?: Map<string, { globalIdx: number; refCellTypeIdx: number }>;
   /** Set of class names (local classes compiled to Wasm GC structs) */
   classSet: Set<string>;
   /**

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -483,9 +483,13 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
     ts.isStringLiteral(node.expression.argumentExpression)
   ) {
     const elemMethodName = node.expression.argumentExpression.text;
-    const elemReceiverType = ctx.checker.getTypeAtLocation(node.expression.expression);
+    // Oracle-first (#1930): a primitive-number receiver reports `"number"`;
+    // a `new Number(x)` wrapper reports its declared symbol name "Number"
+    // (mirrors `isNumberWrapperType`'s Object+symbol check).
+    const elemRecvExpr = node.expression.expression;
     const isElemNumFmtRecv =
-      isNumberType(elemReceiverType) || (ctx.standalone && isNumberWrapperType(elemReceiverType));
+      ctx.oracle.staticJsTypeOf(elemRecvExpr) === "number" ||
+      (ctx.standalone && ctx.oracle.declaredNameOf(elemRecvExpr) === "Number");
     if (isElemNumFmtRecv) {
       if (elemMethodName === "toFixed") {
         state.primitiveNeeded.add("number_toFixed");

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -468,6 +468,42 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       }
     }
   }
+  // (#2029 family C) Element-access spelling of the number-format methods —
+  // `1["toFixed"](5)`, `5["toString"](2)` (test262
+  // property-accessors/S11.2.1_A3_T2). The dot-form scan above never sees
+  // these, so the native helpers were not registered; the codegen
+  // element-access arm (calls.ts) then found `funcMap.get("number_toFixed")`
+  // undefined and fell through past its already-pushed receiver+argument into
+  // the generic dynamic fallback — a dirty stack whose ref.null receiver threw
+  // "Cannot access property on null or undefined" at runtime standalone.
+  // Register the same helpers for a statically-resolvable string key.
+  if (
+    ts.isCallExpression(node) &&
+    ts.isElementAccessExpression(node.expression) &&
+    ts.isStringLiteral(node.expression.argumentExpression)
+  ) {
+    const elemMethodName = node.expression.argumentExpression.text;
+    const elemReceiverType = ctx.checker.getTypeAtLocation(node.expression.expression);
+    const isElemNumFmtRecv =
+      isNumberType(elemReceiverType) || (ctx.standalone && isNumberWrapperType(elemReceiverType));
+    if (isElemNumFmtRecv) {
+      if (elemMethodName === "toFixed") {
+        state.primitiveNeeded.add("number_toFixed");
+      } else if (elemMethodName === "toPrecision") {
+        state.primitiveNeeded.add("number_toPrecision");
+        // 0-arg toPrecision routes to plain toString (see the codegen arm).
+        state.primitiveNeeded.add("number_toString");
+      } else if (elemMethodName === "toExponential") {
+        state.primitiveNeeded.add("number_toExponential");
+      } else if (elemMethodName === "toString") {
+        if (node.arguments.length > 0) {
+          state.primitiveNeeded.add("number_toString_radix");
+        } else {
+          state.primitiveNeeded.add("number_toString");
+        }
+      }
+    }
+  }
   // Template expressions with number/boolean/bigint substitutions need number_toString
   if (ts.isTemplateExpression(node)) {
     for (const span of node.templateSpans) {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -13955,6 +13955,25 @@ function compileCallExpression(
                 valType: cap.valType,
               });
             }
+          } else if (fctx.localMap.get(cap.name) === undefined && ctx.capturedBoxGlobals?.has(cap.name)) {
+            // (#2029 family A) Cross-fctx capture: calling a nested fn from an
+            // object-literal accessor body. The declaring function's local
+            // slot (`cap.outerLocalIdx`) is unreachable here; the accessor-
+            // capture pass promoted the shared ref-cell box to a module
+            // global — source it from there (live write-through semantics).
+            // Guarded on localMap-absence so owner-fctx behavior is unchanged
+            // (see the #1177 revert note below).
+            fctx.body.push({ op: "global.get", index: ctx.capturedBoxGlobals.get(cap.name)!.globalIdx });
+            fctx.body.push({ op: "ref.as_non_null" });
+          } else if (fctx.localMap.get(cap.name) === undefined && ctx.capturedGlobals.has(cap.name)) {
+            // (#2029 family A) Value-global-promoted capture — box a copy.
+            // Best-effort (writes through the closure don't propagate back);
+            // the previous behavior was an out-of-scope local read.
+            fctx.body.push({ op: "global.get", index: ctx.capturedGlobals.get(cap.name)! });
+            if (ctx.capturedGlobalsWidened.has(cap.name)) {
+              fctx.body.push({ op: "ref.as_non_null" });
+            }
+            fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
           } else {
             // Create a ref cell, store the current value, keep ref on stack.
             // (Note: #1177 originally proposed `localMap.get(cap.name) ?? cap.outerLocalIdx`
@@ -13987,6 +14006,17 @@ function compileCallExpression(
             if (!valTypesMatch(refCellType, expectedMutCapType)) {
               coerceType(ctx, fctx, refCellType, expectedMutCapType);
             }
+          }
+        } else if (fctx.localMap.get(cap.name) === undefined && ctx.capturedGlobals.has(cap.name)) {
+          // (#2029 family A) Immutable capture promoted to a value global by
+          // the accessor-capture pass (cross-fctx call of a nested fn from an
+          // accessor body, or owner-fctx call after promotion) — read the
+          // global instead of the out-of-scope / stale local slot. The
+          // global's type matches the lifted param by construction (both
+          // derive from the same declaring-function local), so no coercion.
+          fctx.body.push({ op: "global.get", index: ctx.capturedGlobals.get(cap.name)! });
+          if (ctx.capturedGlobalsWidened.has(cap.name)) {
+            fctx.body.push({ op: "ref.as_non_null" });
           }
         } else {
           // (#1177: TDZ check moved above the mutable/non-mutable branch.
@@ -15183,11 +15213,15 @@ function compileCallExpression(
           methodName === "toExponential")
       ) {
         // RangeError validation for toString(radix) — radix must be integer 2-36
+        // (#2029 family C) Hoisted so the call below can PASS the radix — the
+        // old code validated it, then called the 1-arg `number_toString`
+        // (radix silently dropped → `5["toString"](2)` returned "5").
+        let radixLocal: number | undefined;
         if (methodName === "toString" && expr.arguments.length > 0) {
           compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
           // Floor the radix (ToInteger semantics)
           fctx.body.push({ op: "f64.floor" });
-          const radixLocal = allocLocal(fctx, `__radix_${fctx.locals.length}`, { kind: "f64" });
+          radixLocal = allocLocal(fctx, `__radix_${fctx.locals.length}`, { kind: "f64" });
           fctx.body.push({ op: "local.tee", index: radixLocal });
           fctx.body.push({ op: "f64.const", value: 2 });
           fctx.body.push({ op: "f64.lt" });
@@ -15202,13 +15236,17 @@ function compileCallExpression(
           fctx.body.push({ op: "i32.or" });
           {
             const rangeErrMsg = "RangeError: toString() radix must be between 2 and 36";
+            // (#2029 family C) Dual-mode message push — the raw
+            // `global.get stringGlobalMap.get(msg)!` baked the -1 sentinel
+            // under standalone/nativeStrings (`5["toString"](2)` emit-crashed
+            // with "global index out of range — -1"); the dot-access twin of
+            // this site already uses the helper. Host mode is byte-identical.
             addStringConstantGlobal(ctx, rangeErrMsg);
-            const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
             const tagIdx = ensureExnTag(ctx);
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
-              then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+              then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
               else: [],
             });
           }
@@ -15233,13 +15271,15 @@ function compileCallExpression(
           fctx.body.push({ op: "i32.or" });
           {
             const rangeErrMsg = "RangeError: toFixed() digits argument must be between 0 and 100";
+            // (#2029 family C) Dual-mode message push — see the toString()
+            // radix twin above (`1["toFixed"](5)` was the standalone
+            // emit-crash repro for property-accessors/S11.2.1_A3_T2).
             addStringConstantGlobal(ctx, rangeErrMsg);
-            const strIdx = ctx.stringGlobalMap.get(rangeErrMsg)!;
             const tagIdx = ensureExnTag(ctx);
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
-              then: [{ op: "global.get", index: strIdx } as Instr, { op: "throw", tagIdx } as Instr],
+              then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
               else: [],
             });
           }
@@ -15283,9 +15323,17 @@ function compileCallExpression(
               ? "number_toPrecision"
               : methodName === "toExponential"
                 ? "number_toExponential"
-                : "number_toString";
+                : radixLocal !== undefined
+                  ? "number_toString_radix"
+                  : "number_toString";
         const funcIdx = ctx.funcMap.get(funcName);
         if (funcIdx !== undefined) {
+          // (#2029 family C) The 2-arg radix helper takes (x, radix) — mirror
+          // the dot-access site: receiver is already on the stack, append the
+          // validated radix.
+          if (funcName === "number_toString_radix" && radixLocal !== undefined) {
+            fctx.body.push({ op: "local.get", index: radixLocal });
+          }
           fctx.body.push({ op: "call", funcIdx });
           return { kind: "externref" };
         }

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -307,6 +307,17 @@ function emitSuperExternMethodCall(
   }
   if (!externAncestor) return null;
 
+  // (#2029 family B) Standalone/WASI: this whole path is a JS-host bridge
+  // (`__extern_method_call` + `__js_array_*` — a dynamic `recv[name](args)`
+  // performed in JS land). With no host, the imports both leak (the module
+  // could never instantiate with an empty import object) AND the method-name
+  // string push below baked the `-1` string-global sentinel → the raw
+  // "global index out of range — -1" emit crash (e.g. `super[Symbol.replace]`
+  // in a `class RE extends RegExp`). Refuse here so the caller reports the
+  // clean, located "Cannot find method 'X' on parent class 'Y'" error —
+  // the #1888 dual-mode invariant (loud refusal, never a poisoned index).
+  if (ctx.standalone || ctx.wasi) return null;
+
   const selfIdx = fctx.localMap.get("this");
   if (selfIdx === undefined) return null;
 
@@ -353,13 +364,13 @@ function emitSuperExternMethodCall(
 
   // __extern_method_call(receiver, methodName, args)
   fctx.body.push({ op: "local.get", index: recvLocal });
+  // (#2029 family B) Route the name push through the dual-mode helper: a raw
+  // `global.get stringGlobalMap.get(name)` guarded only on `!== undefined`
+  // bakes the -1 sentinel under nativeStrings (gc + --nativeStrings; the
+  // standalone/wasi combination is refused above). Host mode is
+  // byte-identical (the helper emits the same `global.get`).
   addStringConstantGlobal(ctx, methodName);
-  const strIdx = ctx.stringGlobalMap.get(methodName);
-  if (strIdx !== undefined) {
-    fctx.body.push({ op: "global.get", index: strIdx } as Instr);
-  } else {
-    compileStringLiteral(ctx, fctx, methodName);
-  }
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
   fctx.body.push({ op: "local.get", index: argsLocal });
   const finalMcIdx = ctx.funcMap.get("__extern_method_call") ?? methodCallIdx;
   fctx.body.push({ op: "call", funcIdx: finalMcIdx });

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -13,6 +13,7 @@ import {
   collectWrittenIdentifiers,
   compileArrowAsCallback,
   compileArrowAsClosure,
+  promoteAccessorCapturesToGlobals,
 } from "./closures.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
@@ -1898,6 +1899,39 @@ export function compileObjectDefineProperty(
         }
       }
     }
+
+    // (#2029 family A) Promote outer-fctx captures referenced by the
+    // descriptor's get/set bodies BEFORE compiling the bare accessor fns
+    // below. The object-literal accessor path (literals.ts) has always done
+    // this; the defineProperty descriptor path never did — so a descriptor
+    // getter like `get() { loadNextCount++; return next; }` compiled its body
+    // in a fresh fctx with no way to reach the enclosing function's locals,
+    // and materializing the nested fn `next`'s closure baked the enclosing
+    // function's local slot into the accessor body (the
+    // for-of/iterator-next-reference.js "local index out of range" emit
+    // crash — BOTH modes). `promoteAccessorCapturesToGlobals` also promotes
+    // the transitive captures of referenced nested functions (value global
+    // for immutable, shared ref-cell box global for mutable). Placed AFTER
+    // the S5c closure-lift arm so the standalone closure path keeps its
+    // existing capture sourcing.
+    const promoteDescriptorAccessorBody = (
+      node:
+        | ts.MethodDeclaration
+        | ts.GetAccessorDeclaration
+        | ts.SetAccessorDeclaration
+        | ts.FunctionExpression
+        | ts.ArrowFunction
+        | undefined,
+    ): void => {
+      if (!node) return;
+      if (ts.isArrowFunction(node) && !ts.isBlock(node.body)) {
+        promoteAccessorCapturesToGlobals(ctx, fctx, undefined, [node.body]);
+      } else if (node.body) {
+        promoteAccessorCapturesToGlobals(ctx, fctx, node.body as ts.Block);
+      }
+    };
+    promoteDescriptorAccessorBody(getNode);
+    promoteDescriptorAccessorBody(setNode);
 
     // Helper to get body statements from a getter/setter node
     const getBodyStatements = (

--- a/tests/issue-2029-emit-index-families.test.ts
+++ b/tests/issue-2029-emit-index-families.test.ts
@@ -1,0 +1,155 @@
+/**
+ * #2029 — final `index out of range` emit-crash families (2026-07-04 harvest).
+ *
+ * The live standalone baseline was down to FOUR tests still dying in the
+ * encoder with the #2043 "index out of range" named error. Three producers:
+ *
+ *  A. `local index out of range — 2 (valid: [0,2)) at '__anon_0_get_next'`
+ *     (for-of/iterator-next-reference.js, BOTH modes): the
+ *     Object.defineProperty descriptor accessor path compiled `get(){...}`
+ *     bodies in a fresh fctx WITHOUT `promoteAccessorCapturesToGlobals`
+ *     (the object-literal accessor path has always called it). A getter body
+ *     returning a nested function (`get() { return next; }` where
+ *     `function next()` captures an enclosing local) materialized next's
+ *     closure with `cap.outerLocalIdx` — a slot of the ENCLOSING function —
+ *     baked into the accessor body. Fix: promote transitive captures of
+ *     referenced nested functions (value global for immutable captures,
+ *     shared ref-cell box global for mutable ones) and teach the two
+ *     closure-materialization sites to source from those globals when the
+ *     current fctx cannot resolve the name.
+ *
+ *  B. `global index out of range — -1 at 'RE_@@replace'`
+ *     (replaceAll/searchValue-replacer-RegExp-call{,-fn}.js, standalone):
+ *     `emitSuperExternMethodCall` — a pure JS-host bridge
+ *     (`__extern_method_call`) — ran under standalone and pushed the method
+ *     name via the raw `global.get stringGlobalMap.get(name)` (-1 sentinel).
+ *     Fix: refuse the host bridge standalone/wasi; dual-mode name push
+ *     (`stringConstantExternrefInstrs`) for the gc+nativeStrings combination.
+ *
+ *  C. `global index out of range — -1 at 'test'`
+ *     (property-accessors/S11.2.1_A3_T2.js, standalone): the
+ *     ELEMENT-ACCESS number-method arm (`1["toFixed"](5)`, `5["toString"](2)`)
+ *     pushed its RangeError message via the raw -1-sentinel `global.get`;
+ *     the dot-access twin already used `stringConstantExternrefInstrs`.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const FAMILY_A_SRC = `
+export function test(): number {
+  var iterable = {};
+  var iterator = {};
+  var iterationCount = 0;
+  var loadNextCount = 0;
+  iterable["foo"] = function() { return 1; };
+  function next() { return iterationCount; }
+  Object.defineProperty(iterator, 'next', {
+    get() { loadNextCount++; return next; },
+    configurable: true
+  });
+  return 1;
+}
+`;
+
+const FAMILY_B_SRC = `
+class RE extends RegExp {
+  [Symbol.replace](a: any, b: any): any {
+    return super[Symbol.replace](a, b);
+  }
+}
+export function test(): number { return 1; }
+`;
+
+const FAMILY_C_SRC = `export function test(): number { return 1["toFixed"](5) === "1.00000" ? 1 : 0; }`;
+const FAMILY_C_RADIX_SRC = `export function test(): number { return 5["toString"](2) === "101" ? 1 : 0; }`;
+
+describe("#2029 emit-index families — no more encoder index-out-of-range crashes", () => {
+  it("A: defineProperty getter returning a capture-carrying nested fn compiles (gc)", async () => {
+    const r = await compile(FAMILY_A_SRC, { fileName: "test.ts", skipSemanticDiagnostics: true });
+    expect(r.errors?.filter((e) => e.severity === "error")).toEqual([]);
+    expect(r.success).toBe(true);
+  });
+
+  it("A: same shape compiles under --target standalone", async () => {
+    const r = await compile(FAMILY_A_SRC, {
+      fileName: "test.ts",
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.errors?.filter((e) => e.severity === "error")).toEqual([]);
+    expect(r.success).toBe(true);
+  });
+
+  it("A: mutable transitive capture shares one cell (runtime, gc)", async () => {
+    // The getter is exercised indirectly: materializing `inc`'s closure inside
+    // the accessor must alias the SAME box the enclosing function writes
+    // through. Here we validate the enclosing-fn side still behaves (the
+    // box-promotion rewires test's own reads/writes through the ref cell).
+    const src = `
+export function test(): number {
+  var count = 0;
+  var obj = {};
+  obj["pad"] = function() { return 1; };
+  function reader() { return count; }
+  Object.defineProperty(obj, 'r', { get() { return reader; }, configurable: true });
+  count = count + 41;
+  count++;
+  return count;
+}
+`;
+    const r = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+  });
+
+  it("B: super[Symbol.replace] on a RegExp subclass no longer emit-crashes standalone", async () => {
+    const r = await compile(FAMILY_B_SRC, {
+      fileName: "test.ts",
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    // Either a clean compile or a loud located refusal is acceptable — the
+    // raw encoder RangeError is not.
+    const msgs = (r.errors ?? []).map((e) => e.message ?? "");
+    expect(msgs.join("\n")).not.toContain("out of range");
+    if (r.success) {
+      // The host `__extern_method_call` bridge must NOT leak standalone.
+      const m = new WebAssembly.Module(r.binary!);
+      const importNames = WebAssembly.Module.imports(m).map((i) => i.name);
+      expect(importNames).not.toContain("__extern_method_call");
+      expect(importNames).not.toContain("__js_array_new");
+    }
+  });
+
+  it("B: gc mode keeps the host super-dispatch (no regression)", async () => {
+    const r = await compile(FAMILY_B_SRC, { fileName: "test.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+  });
+
+  it("C: 1['toFixed'](5) compiles, instantiates host-free, and computes (standalone)", async () => {
+    const r = await compile(FAMILY_C_SRC, {
+      fileName: "test.ts",
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.errors?.filter((e) => e.severity === "error")).toEqual([]);
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary!, {});
+    expect((instance.exports as { test(): number }).test()).toBe(1);
+  });
+
+  it("C: 5['toString'](2) compiles and computes (standalone)", async () => {
+    const r = await compile(FAMILY_C_RADIX_SRC, {
+      fileName: "test.ts",
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary!, {});
+    expect((instance.exports as { test(): number }).test()).toBe(1);
+  });
+
+  it("C: gc mode unchanged (byte-equivalent global.get path)", async () => {
+    const r = await compile(FAMILY_C_SRC, { fileName: "test.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the #2029 umbrella: the standalone (and one dual-mode) `index out of range` emit-crash class is now ZERO on the live baseline.

## Measurement first

Fresh harvest of `test262-standalone-current.jsonl` (2026-07-03) + per-process re-run on main `f01867968`: the original 497-test bucket was down to **4 tests / 3 producer families** (the annexB native-generator pair had already flipped to semantic fails via intervening work). None of the 4 was host-pass anymore; one crashed in BOTH modes.

## Families and fixes

**A — `local index out of range` at `__anon_0_get_next` (BOTH modes)** — `for-of/iterator-next-reference.js`. The `Object.defineProperty` descriptor accessor path compiled `get(){}` bodies without `promoteAccessorCapturesToGlobals` (the object-literal accessor path always did). A getter returning a capture-carrying nested fn materialized that fn's closure via `cap.outerLocalIdx` — an ENCLOSING-function slot baked into the accessor body (emit crash out-of-range; silent wrong-local read in-range). Fix: promote transitive captures of referenced nested fns (value global for immutable; eager ref-cell box aliased in a `(ref null $cell)` module global for mutable → live write-through sharing) and add localMap-absence-guarded sourcing arms at both closure-materialization sites (`emitMemoizedNestedFnClosure` + the calls.ts cap-prepend). Owner-fctx behavior unchanged (respects the #1177 revert).

**B — `global index -1` at `RE_@@replace` (standalone)** — replaceAll RegExp-replacer pair. `emitSuperExternMethodCall` (the #1614 JS-host super-dispatch bridge) ran standalone and pushed the method name via the raw `-1` string-global sentinel (`reference_string_global_sentinel_guard` class). Fix: gate the bridge off under standalone/wasi (also stops the `__extern_method_call`/`__js_array_*` import leak) + dual-mode name push (`stringConstantExternrefInstrs`) for gc+nativeStrings; host byte-identical.

**C — `global index -1` at `test` (standalone)** — `property-accessors/S11.2.1_A3_T2.js`, minimized to `1["toFixed"](5)`. Three layers in the element-access number-method arm: (i) raw -1-sentinel RangeError message pushes (dot twins already used the helper); (ii) the declarations pre-scan only recognized the DOT spelling, so the native helpers were unregistered and the arm fell into a dirty-stack dynamic fallback at runtime; (iii) `toString(radix)` validated then DROPPED the radix (1-arg helper). Fixed all three; computed `toFixed`/`toPrecision`/`toExponential`/`toString(radix)` now compute correct values standalone (verified with an empty import object).

## Row-delta (branch vs pristine, per-process)

All 4 tests x both modes: emit-crash → compiles + ordinary runtime fail (separate pre-existing families with host parity). Standalone-baseline `index out of range` count: **4 → 0**. Any future poisoned index stays a named located error via #2043's always-on validation.

## Validation

- New `tests/issue-2029-emit-index-families.test.ts` — 8/8.
- All 7 existing issue-2029 suites — 37/37.
- Closure/accessor batch (585, 1712, getters-setters, accessor-side-effects, 2580, 2609, 2692, 1528): 13 failures **identical on a pristine control worktree** — pre-existing.
- Number-format suites (49, 2163, 2934): 23/23. tsc clean; lint clean.
- stack-balance / any-box / speculative-rollback gates OK. Coercion-sites baseline +2 in declarations.ts = pre-registration of EXISTING native helpers for the elem-access spelling (same pattern as the counted dot-form block), not new coercion vocabulary.
- Broad emit-path change → merge_group test262 floor validates full conformance.

Issue file carries the full family map, the a/b/c classification verdicts, and pointers for the migrated non-emit residuals (#2620/#2622, #2358/#2158, iterator-helpers, ERM substrate). Sets #2029 `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8