### PR TITLE
feat(#2106): S1 standalone $undefined tag-1 singleton — complete lockstep sweep behind undefinedSingleton flag

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -631,6 +631,58 @@ plane); null = `ref.null.extern`. Producers emit the singleton; undefined-specif
 consumers test tag-1 (∨ UNDEF-box); null-specific stay `ref.is_null`; nullish =
 either (new native `__extern_is_nullish`).
 
+### S1 flagged sweep — DELIVERED (fable-2106, 2026-07-04, this branch)
+
+Implemented the complete lockstep sweep behind `undefinedSingleton` (default
+OFF; `JS2WASM_UNDEF_SINGLETON=1` env A/B, mirroring `JS2WASM_TAG5_CLASSIFIER`):
+
+- **Producers**: `emitUndefined` → singleton; `__extern_get` 3 miss sites;
+  `__extern_get_idx` misses (builder `missInstrs` factory — fresh instr objects
+  per branch, finalize-splice safe); `boxToAny` null/undefined jsType arms →
+  `__any_box_null`/`__any_box_undefined`; `__any_from_extern` null arm → tag-0.
+- **The boxing chokepoint that made dynamic eq work**: `__any_box_extern_s1` —
+  NULLISH-honest externref boxing (null→tag-0, singleton/UNDEF-box→tag-1,
+  everything else keeps the #1888 tag-5 wrap byte-equivalently). Deliberately
+  NOT #2141's full-honest classification (its solo flip measured −788/−794).
+  Routed from `boxToAny`'s externref arm under the flag. Without it,
+  `u === miss` boxed both nullish values tag-5 and `__any_strict_eq` said 0
+  (WAT-verified).
+- **Consumers**: `__extern_is_undefined` → tag-1 ∨ UNDEF-box (drops
+  `ref.is_null`); `__extern_is_nullish` + `__nullish_to_null` natives —
+  internal null-keyed lookups (to-primitive valueOf/toString: the June 948-CE
+  site; proxy traps; descriptor fields; `__extern_method_call`; groupBy)
+  NORMALIZE nullish→null at the read so their downstream logic stays
+  byte-identical; `__is_truthy` tag≤1 falsy; typeof cluster (predicate +
+  `__typeof_object` + materialized `__typeof`): null→"object",
+  singleton→"undefined"; strict/loose dynamic-eq nullish guard in the #1776
+  cascade (the #1961 bothNullishGuard re-keyed as spec'd); `?.` receiver
+  guards OR the singleton test; `__dyn_get` stops remapping stored-null→
+  undefined, `__dyn_has` tests nullish; join renders singleton as "";
+  `__extern_toString(null)` → "null"; destructure container guard tests tag-1
+  ONLY (preserves #3010's scalarized-`[undefined]` fix).
+- **Zero-change wins** (already tag-correct, verified): `__any_strict_eq`
+  (same-tag<2 equal), `__any_eq` (both-tags<2 arm), `__any_to_string`
+  (tag-0 "null"/tag-1 "undefined"), `__any_to_f64` (tag-1 NaN),
+  `__unbox_number` (null→0, opaque→NaN), dstr/param defaults
+  (`__extern_is_undefined`-exclusive per #1021 — spec-correct under the flag),
+  `holeToUndefinedInstrs` (routes via emitUndefined).
+- **Validation**: `tests/issue-2106-s1-undefined-singleton.test.ts` — 8 flag-on
+  standalone cases (strict/loose distinctness incl. cross-producer, typeof,
+  missing-vs-stored-null property reads, dstr defaults null-kept, ??/?./
+  truthiness, ToString/ToNumber split, container-guard TypeError) + a flag-off
+  legacy control. Byte-inertness: 10-program × {gc,wasi} corpus sha256 —
+  IDENTICAL to pre-change tree with flag off.
+- **Known flag-on residuals** (pre-existing, flag-NEUTRAL — confirmed both
+  regimes behave identically): `{ b: null }` shape-struct literals read via
+  bare `__extern_get` miss the field (dstr default fires either way);
+  `.join()` on an `any` receiver; `""+arr` to-primitive of any-array.
+
+**Next steps (follow-up PRs):** (1) A/B-measure the standalone test262 delta
+with `JS2WASM_UNDEF_SINGLETON=1` (runner-level env, no code change needed);
+(2) if net-positive, flip the default in a one-line PR validated via
+merge_group; (3) S2 (sNaN carve-out codify), S3 (number|undefined→externref,
+needs the box-protocol fix), S4 (union-collapse reversal) remain per plan.
+
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 
 NOT done — the referencing merged PR was a REVERT (PR #2025 auto-parked: standalone floor breach, NET -1245 test262 rows), so it is floor-neutral undo, NOT progress. S1 (standalone tag-1 $undefined singleton) still requires the FULL ~40-site producer+consumer sweep (architect re-spec) — no narrow floor-saving subset exists. S2 (sNaN carve-out), S3 (number|undefined→externref), S4 (union-collapse reversal), typeof-null→object all remain. Stays in-progress; resume-only for a senior-dev at max effort.

--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -2,7 +2,7 @@
 id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
 status: in-progress
-assignee: ttraenkler/sdev-s1fix
+assignee: ttraenkler/fable-2106
 sprint: current
 created: 2026-06-11
 updated: 2026-06-26
@@ -588,6 +588,48 @@ complete, properly-sequenced sweep in a fresh PR with the full producer+consumer
 site set flipped together, validated via merge_group BEFORE enqueue (route to
 architect to enumerate the full producer/consumer site list first). The hold on
 #2025 must stay until this is resolved.
+
+## S1 re-land plan — FULL sweep behind `undefinedSingleton` flag (fable-2106, 2026-07-04)
+
+Resumed on branch `issue-2106-s1-undefined-singleton` (fast-forwarded to main
+@ 02cc6d108 — the old branch content had fully landed via PR #2025's
+floor-neutral revert; S1.0 inert reservation IS on main in `any-helpers.ts`).
+
+**Why flagged, not default-on:** the June partial flip measured −1245 net; the
+diagnosis proved producer+consumer must flip in lockstep across the WHOLE
+standalone runtime. A compile-flag regime (`undefinedSingleton`, default OFF →
+byte-identical, precedent: #2141 `honestAnyBoxing`) lets the complete sweep land
+green and floor-safe, with the default flip as a separate, measured, one-line PR.
+This is the issue's own S4 measure-first protocol applied to S1.
+
+**Key re-ground findings (2026-07-04, main @ 02cc6d108):**
+- Host mode ALREADY has non-null undefined (`__get_undefined`), so shared
+  expression-layer consumers are already dual-predicate: `??` emits
+  `ref.is_null || __extern_is_undefined` (logical-ops.ts:225-232); `=== undefined`
+  routes through `__extern_is_undefined` (binary-ops.ts:464-478). Flipping the
+  ONE native `__extern_is_undefined` body covers all of them at once.
+- The ripple is concentrated in STANDALONE-NATIVE bodies where null doubles as
+  absence/undefined: `__extern_get` 3 miss sites (object-runtime.ts:1012+),
+  `__extern_get_idx` miss, internal `call __extern_get; ref.is_null` absence
+  checks (to-primitive/method-dispatch/iterator/json — the 948 June CEs),
+  the standalone looseNullish guard (binary-ops.ts:2641 — bare `ref.is_null`),
+  externref ToBoolean (singleton must be falsy), ToNumber (null→0 vs
+  undefined→NaN — currently conflated), ToString ("null" vs "undefined").
+- `__extern_is_undefined` gained a #2979 UNDEF_F64-boxed-sentinel arm since the
+  June spec — the flag body must KEEP that arm (singleton-test ∨ UNDEF-box),
+  dropping only the `ref.is_null` arm.
+- #2949 coherence: `JsTag.Undefined = 1` is payload-less; identity via
+  `tag.test` — the tag-1 singleton IS the JsTag-lattice-conformant carrier.
+  `__any_to_extern` already round-trips tag-0/1 boxes wrapped (any-helpers.ts:632);
+  under the flag tag-1 canonicalizes to the singleton and tag-0 to
+  `ref.null.extern` (fixing the tag-0→tag-1 round-trip lie that comment documents,
+  in the flag regime).
+
+**Flag semantics (standalone/nativeStrings only; host byte-identical always):**
+undefined = the S1.0 `$undefined` tag-1 global (extern-wrapped at the externref
+plane); null = `ref.null.extern`. Producers emit the singleton; undefined-specific
+consumers test tag-1 (∨ UNDEF-box); null-specific stay `ref.is_null`; nullish =
+either (new native `__extern_is_nullish`).
 
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -1188,6 +1188,100 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     ],
   );
 
+  // (#2106 S1, flag-only) __any_box_extern_s1(val: externref) -> ref $AnyValue
+  //
+  // NULLISH-honest externref boxing for the `undefinedSingleton` regime:
+  //   null extern                    → tag-0 box (JS null)
+  //   tag-1 `$AnyValue` (singleton)  → recovered exactly (tag-1)
+  //   `$BoxedNumber` w/ UNDEF_F64    → tag-1 box (undefined through f64 lane)
+  //   everything else               → the legacy tag-5 box (#1888 lie KEPT)
+  // Rationale: full honest classification is #2141's flag (measured −788/−794
+  // when flipped alone — the comparator depends on the tag-5 lie for
+  // non-nullish values). S1 only needs the NULLISH partition honest so
+  // `__any_strict_eq`/`__any_eq`/`__any_to_string`/`__any_to_f64` (already
+  // tag-correct) observe null≠undefined; the non-nullish arms stay
+  // byte-equivalent to `__any_box_string`.
+  if (undefinedSingletonActive(ctx) && ctx.undefinedGlobalIdx !== undefined) {
+    const undefBoxInstrs: Instr[] = [{ op: "global.get", index: ctx.undefinedGlobalIdx } as Instr];
+    addHelper(
+      "__any_box_extern_s1",
+      [{ kind: "externref" }],
+      [anyRef],
+      [
+        { op: "local.get", index: 0 },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "i32.const", value: 0 },
+            { op: "i32.const", value: 0 },
+            { op: "f64.const", value: 0 },
+            { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+            { op: "ref.null.extern" },
+            { op: "struct.new", typeIdx: anyTypeIdx },
+            { op: "return" },
+          ],
+        },
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "local.tee", index: 1 },
+        { op: "ref.test", typeIdx: anyTypeIdx },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // tag-1 box (the singleton or any undefined box) → recover exactly.
+            // Other wrapped tags fall through to the legacy tag-5 wrap below,
+            // preserving the legacy double-wrap behaviour for non-nullish.
+            { op: "local.get", index: 1 },
+            { op: "ref.cast", typeIdx: anyTypeIdx },
+            { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 0 },
+            { op: "i32.const", value: 1 },
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: 1 }, { op: "ref.cast", typeIdx: anyTypeIdx }, { op: "return" }],
+            } as Instr,
+          ],
+        },
+        ...(ctx.nativeBoxNumberTypeIdx >= 0
+          ? ([
+              // UNDEF_F64-sentinel $BoxedNumber → undefined (tag-1 singleton).
+              { op: "local.get", index: 1 },
+              { op: "ref.test", typeIdx: ctx.nativeBoxNumberTypeIdx },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 1 },
+                  { op: "ref.cast", typeIdx: ctx.nativeBoxNumberTypeIdx },
+                  { op: "struct.get", typeIdx: ctx.nativeBoxNumberTypeIdx, fieldIdx: 0 },
+                  { op: "i64.reinterpret_f64" },
+                  { op: "i64.const", value: 0x7ff00000deadc0den },
+                  { op: "i64.eq" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [...undefBoxInstrs.map((i) => ({ ...i }) as Instr), { op: "return" } as Instr],
+                  } as Instr,
+                ],
+              } as Instr,
+            ] as Instr[])
+          : []),
+        // legacy tag-5 wrap (byte-equivalent to __any_box_string)
+        { op: "i32.const", value: 5 },
+        { op: "i32.const", value: 0 },
+        { op: "f64.const", value: 0 },
+        { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+        { op: "local.get", index: 0 },
+        { op: "struct.new", typeIdx: anyTypeIdx },
+      ],
+      [{ name: "any", type: { kind: "anyref" } }],
+    );
+  }
+
   // __any_box_ref(val: eqref) -> ref $AnyValue
   // tag=6, i32val=0, f64val=0.0, refval=val, externval=null
   addHelper(

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -362,8 +362,21 @@ export function ensureAnyFromExternHelper(ctx: CodegenContext): number | undefin
   // `anyStrTypeIdx` — without the string test a genuine string would
   // mis-classify as tag-6 object, so fall back to the legacy arms instead.
   const honest = ctx.honestAnyBoxing === true && ctx.anyStrTypeIdx >= 0;
-  const nullAny: Instr[] =
-    honest && ctx.undefinedGlobalIdx !== undefined
+  // (#2106 S1) Under the `undefinedSingleton` regime a NULL externref means JS
+  // NULL (undefined is the non-null tag-1 singleton, recovered exactly by the
+  // `ref.test $AnyValue` arm below) — so the null arm boxes tag-0. This is
+  // what makes the tag-0 → tag-1 round-trip lie (see `__any_to_extern`'s tail
+  // comment) actually FIXED in the flag regime. Legacy/honest arms unchanged.
+  const nullAny: Instr[] = undefinedSingletonActive(ctx)
+    ? [
+        { op: "i32.const", value: 0 },
+        { op: "i32.const", value: 0 },
+        { op: "f64.const", value: 0 },
+        { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+        { op: "ref.null.extern" },
+        { op: "struct.new", typeIdx: anyTypeIdx },
+      ]
+    : honest && ctx.undefinedGlobalIdx !== undefined
       ? [{ op: "global.get", index: ctx.undefinedGlobalIdx } as Instr]
       : [
           { op: "i32.const", value: 1 },
@@ -730,11 +743,29 @@ export function ensureAnyToExternHelper(ctx: CodegenContext): number | undefined
         { op: "return" },
       ],
     },
+    // (#2106 S1) Under the `undefinedSingleton` regime tag 0 (null) unwraps to
+    // its canonical externref-plane representation `ref.null.extern` — and the
+    // round-trip is SAFE there because `__any_from_extern`'s null arm boxes
+    // tag-0 back (not the legacy tag-1). Tag 1 (undefined) stays wrapped: an
+    // extern-wrapped tag-1 `$AnyValue` IS the regime's undefined representation
+    // (all predicates are tag-keyed, not identity-keyed).
+    ...(undefinedSingletonActive(ctx)
+      ? ([
+          { op: "local.get", index: 1 },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "ref.null.extern" }, { op: "return" }],
+          },
+        ] as Instr[])
+      : []),
     // Tags 0 (null), 1 (undefined), 5 (string), 6 (GC ref): keep the WHOLE
     // $AnyValue box wrapped via extern.convert_any. Standalone/WASI has no host
     // that needs unwrapped values, and __any_from_extern recovers the wrapped
     // box exactly via its `ref.test $AnyValue` arm — preserving the tag and
-    // reference identity. Unwrapping these here was NOT round-trip-safe:
+    // reference identity. Unwrapping these here was NOT round-trip-safe (in the
+    // legacy regime; see the S1 arm above for the flagged tag-0 exception):
     //   - tag 0 came back as tag 1 (null → undefined across every boundary),
     //   - tag 6 (raw struct) was mis-tagged as tag 5 (string) by the
     //     __any_from_extern fallback.

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -205,6 +205,44 @@ export function buildIsUndefinedExternBody(
 }
 
 /**
+ * (#2106 S1) Emit a test that the externref in local `externLocalIdx` is a
+ * tag-1 `$AnyValue` box (the `$undefined` singleton shape) — leaving an i32.
+ * Deliberately does NOT include the #2979 UNDEF_F64 `$BoxedNumber` arm: this
+ * is for CONTAINER-position checks (destructure guard) where the boxed
+ * sentinel can be a scalarized `[undefined]` array, not undefined itself
+ * (the #3010 55-test regression). `scratchAnyIdx` must be an anyref local.
+ * Returns false (emitting nothing) when the regime is inactive.
+ */
+export function emitIsUndefinedSingletonExternAt(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  externLocalIdx: number,
+  scratchAnyIdx: number,
+): boolean {
+  if (!undefinedSingletonActive(ctx)) return false;
+  if (ctx.anyValueTypeIdx < 0) ensureAnyValueType(ctx);
+  if (ctx.anyValueTypeIdx < 0) return false;
+  const t = ctx.anyValueTypeIdx;
+  fctx.body.push({ op: "local.get", index: externLocalIdx } as Instr);
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "local.tee", index: scratchAnyIdx } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: t } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [
+      { op: "local.get", index: scratchAnyIdx },
+      { op: "ref.cast", typeIdx: t },
+      { op: "struct.get", typeIdx: t, fieldIdx: 0 },
+      { op: "i32.const", value: 1 },
+      { op: "i32.eq" },
+    ],
+    else: [{ op: "i32.const", value: 0 }],
+  } as Instr);
+  return true;
+}
+
+/**
  * Lazily register wrapper struct types for Number, String, Boolean.
  * Each wrapper is a struct with a single `value` field holding the primitive.
  * Also registers WrapperX_valueOf functions that extract the value.

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -104,6 +104,107 @@ export function emitIsUndefinedSingleton(ctx: CodegenContext, fctx: FunctionCont
 }
 
 /**
+ * (#2106 S1) Is the `undefinedSingleton` regime ACTIVE for this module?
+ * True only when the flag is set AND we are in standalone/native-strings mode
+ * (host mode has a real host `undefined` via `__get_undefined` and is never
+ * affected). Every producer/consumer flip of the S1 sweep gates on this, so
+ * flag-off (default) modules are byte-identical to legacy.
+ */
+export function undefinedSingletonActive(ctx: CodegenContext): boolean {
+  return ctx.undefinedSingleton === true && (ctx.standalone || ctx.nativeStrings);
+}
+
+/**
+ * (#2106 S1) Push the `$undefined` singleton as an EXTERNREF (the externref-
+ * plane representation of `undefined` under the `undefinedSingleton` regime).
+ * Returns false (emitting nothing) when the regime is inactive or the
+ * singleton cannot be reserved — callers keep their legacy `ref.null.extern`.
+ */
+export function emitUndefinedExtern(ctx: CodegenContext, fctx: FunctionContext): boolean {
+  if (!undefinedSingletonActive(ctx)) return false;
+  if (!emitUndefinedSingleton(ctx, fctx)) return false;
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  return true;
+}
+
+/**
+ * (#2106 S1) The externref-plane "undefined singleton" INSTRUCTION SEQUENCE for
+ * baked native bodies: `global.get $undefined; extern.convert_any`. Returns
+ * undefined when the regime is inactive (callers keep `ref.null.extern`).
+ * Reserves the singleton (via ensureAnyValueType) on first use.
+ */
+export function undefinedExternInstrs(ctx: CodegenContext): Instr[] | undefined {
+  if (!undefinedSingletonActive(ctx)) return undefined;
+  if (ctx.undefinedGlobalIdx === undefined) {
+    ensureAnyValueType(ctx);
+    if (ctx.undefinedGlobalIdx === undefined) return undefined;
+  }
+  return [{ op: "global.get", index: ctx.undefinedGlobalIdx } as Instr, { op: "extern.convert_any" } as Instr];
+}
+
+/**
+ * (#2106 S1) Build the flagged "is this externref `undefined`?" body for a
+ * `(externref) -> i32` native (param 0 = the value, `scratchAnyLocal` = an
+ * anyref local). Under the singleton regime the predicate is:
+ *   tag-1 `$AnyValue` box (the singleton, or any tag-1 box)  ∨
+ *   `$BoxedNumber` carrying the UNDEF_F64 sentinel bits (#2979 arm)
+ * and — critically — NOT `ref.is_null` (null is DISTINCT from undefined here;
+ * a null externref answers 0 through the failing `ref.test`s).
+ * Returns undefined when the regime is inactive or `$AnyValue` is unavailable
+ * (callers keep their legacy `ref.is_null`-based body).
+ */
+export function buildIsUndefinedExternBody(
+  ctx: CodegenContext,
+  scratchAnyLocal: number,
+  undefF64Bits: bigint,
+): Instr[] | undefined {
+  if (!undefinedSingletonActive(ctx)) return undefined;
+  if (ctx.anyValueTypeIdx < 0) ensureAnyValueType(ctx);
+  if (ctx.anyValueTypeIdx < 0) return undefined;
+  const anyTypeIdx = ctx.anyValueTypeIdx;
+  const boxedNumArm: Instr[] =
+    ctx.nativeBoxNumberTypeIdx >= 0
+      ? [
+          { op: "local.get", index: scratchAnyLocal },
+          { op: "ref.test", typeIdx: ctx.nativeBoxNumberTypeIdx },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              { op: "local.get", index: scratchAnyLocal },
+              { op: "ref.cast", typeIdx: ctx.nativeBoxNumberTypeIdx },
+              { op: "struct.get", typeIdx: ctx.nativeBoxNumberTypeIdx, fieldIdx: 0 },
+              { op: "i64.reinterpret_f64" },
+              { op: "i64.const", value: undefF64Bits },
+              { op: "i64.eq" },
+            ],
+            else: [{ op: "i32.const", value: 0 }],
+          } as Instr,
+        ]
+      : [{ op: "i32.const", value: 0 } as Instr];
+  return [
+    // any = any.convert_extern(v)  (null externref → null anyref: both
+    // ref.tests below answer 0, so null → NOT undefined, as required.)
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: scratchAnyLocal },
+    { op: "ref.test", typeIdx: anyTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        { op: "local.get", index: scratchAnyLocal },
+        { op: "ref.cast", typeIdx: anyTypeIdx },
+        { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 0 },
+        { op: "i32.const", value: 1 },
+        { op: "i32.eq" },
+      ],
+      else: boxedNumArm,
+    } as Instr,
+  ];
+}
+
+/**
  * Lazily register wrapper struct types for Number, String, Boolean.
  * Each wrapper is a struct with a single `value` field holding the primitive.
  * Also registers WrapperX_valueOf functions that extract the value.

--- a/src/codegen/array-to-primitive.ts
+++ b/src/codegen/array-to-primitive.ts
@@ -161,8 +161,13 @@ export function fillArrayToPrimitive(ctx: CodegenContext): void {
             { op: "f64.convert_i32_s" },
             { op: "call", funcIdx: externGetIdxIdx },
             { op: "local.tee", index: L_ELEM },
-            // §23.1.3.31: null/undefined element → "" (skip the concat)
-            { op: "ref.is_null" },
+            // §23.1.3.31: null/undefined element → "" (skip the concat).
+            // (#2106 S1) under the singleton regime an undefined element is a
+            // NON-null externref — test nullish, not bare null, or join would
+            // render it as "undefined".
+            ...(ctx.funcMap.has("__extern_is_nullish")
+              ? [{ op: "call", funcIdx: ctx.funcMap.get("__extern_is_nullish")! } as Instr]
+              : [{ op: "ref.is_null" } as Instr]),
             { op: "i32.eqz" },
             {
               op: "if",

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -14,7 +14,7 @@ import {
   isWrapperObjectType,
 } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
-import { isAnyValue } from "./any-helpers.js";
+import { isAnyValue, undefinedSingletonActive } from "./any-helpers.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -2291,8 +2291,15 @@ export function compileBinaryExpression(
       // `isLoose` so the strict path is byte-identical to before.
       const isLoose =
         !isStrict && (op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken);
-      if (isLoose) ensureObjectRuntime(ctx);
+      // (#2106 S1) The singleton-regime nullish guard below needs the
+      // `__extern_is_nullish` / `__extern_is_undefined` natives for BOTH
+      // strict and loose, so pull in the object runtime under the flag too
+      // (flag-off: the legacy `isLoose`-only pull, byte-identical).
+      const s1Regime = undefinedSingletonActive(ctx);
+      if (isLoose || s1Regime) ensureObjectRuntime(ctx);
       addUnionImports(ctx);
+      const s1IsNullishIdx = s1Regime ? ctx.funcMap.get("__extern_is_nullish") : undefined;
+      const s1IsUndefIdx = s1Regime ? ctx.funcMap.get("__extern_is_undefined") : undefined;
       const typeofNum = ctx.funcMap.get("__typeof_number")!;
       const typeofBool = ctx.funcMap.get("__typeof_boolean")!;
       const typeofBigint = ctx.funcMap.get("__typeof_bigint")!;
@@ -2639,29 +2646,76 @@ export function compileBinaryExpression(
       ];
       // For loose equality, wrap the core cascade in the nullish guard
       // (§7.2.15 steps 2-3): both nullish ⇒ true; nullish-vs-non-nullish ⇒ false.
-      const eqInstrs: Instr[] = looseNullish
+      //
+      // (#2106 S1) Under the `undefinedSingleton` regime the guard applies to
+      // BOTH strict and loose — and is keyed on the regime predicates, not bare
+      // `ref.is_null` (which no longer catches the non-null singleton):
+      //   loose:  both nullish (`__extern_is_nullish`) ⇒ true.
+      //   strict (§7.2.16 via SameType, null and undefined now DISTINCT):
+      //     (both null) ∨ (both undefined) ⇒ true; any other nullish pairing ⇒
+      //     false. This is the #1961 `bothNullishGuard` re-keyed on the
+      //     singleton, exactly as the S1 spec prescribed — it fixes dynamic
+      //     `undefined === undefined` / `null === null` (the legacy identity
+      //     arm answers 0 for null refs) while keeping `null === undefined`
+      //     false.
+      const s1NullishGuard = s1Regime && s1IsNullishIdx !== undefined && s1IsUndefIdx !== undefined;
+      const eqInstrs: Instr[] = s1NullishGuard
         ? [
             { op: "local.get", index: lTmp },
-            { op: "ref.is_null" } as Instr,
+            { op: "call", funcIdx: s1IsNullishIdx! } as Instr,
             { op: "local.get", index: rTmp },
-            { op: "ref.is_null" } as Instr,
-            // (lNull || rNull): if EITHER is nullish, the result is whether BOTH
-            // are nullish (true) or not (false) — never coerce against a nullish.
+            { op: "call", funcIdx: s1IsNullishIdx! } as Instr,
             { op: "i32.or" } as Instr,
             {
               op: "if",
               blockType: { kind: "val", type: { kind: "i32" } },
-              then: [
-                { op: "local.get", index: lTmp },
-                { op: "ref.is_null" } as Instr,
-                { op: "local.get", index: rTmp },
-                { op: "ref.is_null" } as Instr,
-                { op: "i32.and" } as Instr,
-              ],
+              then: isStrict
+                ? [
+                    { op: "local.get", index: lTmp },
+                    { op: "ref.is_null" } as Instr,
+                    { op: "local.get", index: rTmp },
+                    { op: "ref.is_null" } as Instr,
+                    { op: "i32.and" } as Instr,
+                    { op: "local.get", index: lTmp },
+                    { op: "call", funcIdx: s1IsUndefIdx! } as Instr,
+                    { op: "local.get", index: rTmp },
+                    { op: "call", funcIdx: s1IsUndefIdx! } as Instr,
+                    { op: "i32.and" } as Instr,
+                    { op: "i32.or" } as Instr,
+                  ]
+                : [
+                    { op: "local.get", index: lTmp },
+                    { op: "call", funcIdx: s1IsNullishIdx! } as Instr,
+                    { op: "local.get", index: rTmp },
+                    { op: "call", funcIdx: s1IsNullishIdx! } as Instr,
+                    { op: "i32.and" } as Instr,
+                  ],
               else: coreEqInstrs,
             } as Instr,
           ]
-        : coreEqInstrs;
+        : looseNullish
+          ? [
+              { op: "local.get", index: lTmp },
+              { op: "ref.is_null" } as Instr,
+              { op: "local.get", index: rTmp },
+              { op: "ref.is_null" } as Instr,
+              // (lNull || rNull): if EITHER is nullish, the result is whether BOTH
+              // are nullish (true) or not (false) — never coerce against a nullish.
+              { op: "i32.or" } as Instr,
+              {
+                op: "if",
+                blockType: { kind: "val", type: { kind: "i32" } },
+                then: [
+                  { op: "local.get", index: lTmp },
+                  { op: "ref.is_null" } as Instr,
+                  { op: "local.get", index: rTmp },
+                  { op: "ref.is_null" } as Instr,
+                  { op: "i32.and" } as Instr,
+                ],
+                else: coreEqInstrs,
+              } as Instr,
+            ]
+          : coreEqInstrs;
       for (const ins of eqInstrs) fctx.body.push(ins);
       if (isNeqOp) fctx.body.push({ op: "i32.eqz" });
       releaseTempLocal(fctx, rTmp);

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -254,6 +254,10 @@ export function createCodegenContext(
     // (#2141 S2/S3, #2626) tag-5 boxed-VALUE eq classifier — default OFF
     // (legacy); JS2WASM_TAG5_CLASSIFIER=1 env defaults it on for runner A/B.
     tag5ValueEqClassifier: options?.tag5ValueEqClassifier ?? process.env.JS2WASM_TAG5_CLASSIFIER === "1",
+    // (#2106 S1) standalone $undefined tag-1 singleton regime — default OFF
+    // (legacy: undefined ≡ null ≡ ref.null.extern, byte-identical);
+    // JS2WASM_UNDEF_SINGLETON=1 env defaults it on for runner A/B.
+    undefinedSingleton: options?.undefinedSingleton ?? process.env.JS2WASM_UNDEF_SINGLETON === "1",
     // (#2796) Diff-test-harness fidelity — export __module_init + skip the wasm
     // start section so the host runs top-level code after setExports.
     deferTopLevelInit: options?.deferTopLevelInit ?? false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -96,6 +96,10 @@ export interface CodegenOptions {
   /** (#2141 S2/S3, #2626) Tag-5 boxed-VALUE equality classifier — see the
    *  `CompileOptions.tag5ValueEqClassifier` doc. Default false (legacy). */
   tag5ValueEqClassifier?: boolean;
+  /** (#2106 S1) Standalone `$undefined` tag-1 singleton regime — see the
+   *  `CompileOptions.undefinedSingleton` doc. Default false (legacy:
+   *  undefined ≡ null ≡ ref.null.extern in standalone, byte-identical). */
+  undefinedSingleton?: boolean;
   /** (#2796) Diff-test-harness fidelity: in JS-host mode, export the top-level
    *  `__module_init` and do NOT run it via the wasm `start` section, so the host
    *  invokes it AFTER `setExports` (symmetric with the standalone `_start`
@@ -1892,6 +1896,11 @@ export interface CodegenContext {
    *  non-string tag-5 pairs). `JS2WASM_TAG5_CLASSIFIER=1` env defaults it on
    *  for runner-level A/B. */
   tag5ValueEqClassifier: boolean;
+  /** (#2106 S1) Standalone `$undefined` tag-1 singleton regime flag — see the
+   *  `CompileOptions.undefinedSingleton` doc. Default false (legacy:
+   *  undefined ≡ null ≡ ref.null.extern, byte-identical). Only meaningful
+   *  under standalone/nativeStrings; host mode ignores it. */
+  undefinedSingleton: boolean;
   /** (#2796) Diff-test-harness fidelity: in JS-host mode, export the top-level
    *  `__module_init` and do NOT wire the wasm `start` section to it, so the host
    *  runs it after `setExports` (symmetric with the standalone `_start` model).

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -24,6 +24,7 @@ import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitLocalTdzInit } from "./statements/tdz.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import { holeToUndefinedInstrs } from "./array-holes.js"; // (#2001 S1)
+import { emitIsUndefinedSingletonExternAt, undefinedSingletonActive } from "./any-helpers.js"; // (#2106 S1)
 import {
   coerceType,
   compileExpression,
@@ -785,6 +786,22 @@ export function emitExternrefDestructureGuard(ctx: CodegenContext, fctx: Functio
       fctx.body.push({ op: "local.get", index: paramIdx });
       fctx.body.push({ op: "call", funcIdx: undefIdx });
       fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: buildDestructureNullThrow(ctx, fctx), else: [] });
+    } else if (undefinedSingletonActive(ctx)) {
+      // (#2106 S1) Under the singleton regime a standalone `undefined`
+      // container is a NON-null externref, so the `ref.is_null` guard above
+      // misses it. Test the tag-1 `$AnyValue` shape ONLY — deliberately NOT
+      // the sentinel-aware `__extern_is_undefined`, whose UNDEF_F64
+      // `$BoxedNumber` arm false-positives on a scalarized `[undefined]`
+      // array container (the #3010 55-test regression).
+      const scratchAny = allocLocal(fctx, `__s1_dguard_any_${fctx.locals.length}`, { kind: "anyref" });
+      if (emitIsUndefinedSingletonExternAt(ctx, fctx, paramIdx, scratchAny)) {
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: buildDestructureNullThrow(ctx, fctx),
+          else: [],
+        });
+      }
     }
   }
 }

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -39,6 +39,7 @@ import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
+import { undefinedSingletonActive } from "./any-helpers.js"; // (#2106 S1)
 import { ensureGetUndefined } from "./expressions/late-imports.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
@@ -97,6 +98,15 @@ export function ensureDynReadHelpers(ctx: CodegenContext): void {
   const getUndefIdx = ensureGetUndefined(ctx);
   const undefInstrs: Instr[] =
     getUndefIdx !== undefined ? [{ op: "call", funcIdx: getUndefIdx } as Instr] : [{ op: "ref.null.extern" } as Instr];
+  // (#2106 S1) Under the `undefinedSingleton` regime `__extern_get` ALREADY
+  // returns the singleton for an absent property, and a null result means a
+  // STORED JS null — so `__dyn_get` must NOT remap null → undefined (that
+  // would read `obj.x = null` back as undefined), and `__dyn_has`'s
+  // "present ⇔ non-null" flips to "present ⇔ non-nullish". This runs at
+  // FINALIZE: only consult ALREADY-reserved indices (no ensureAnyValueType —
+  // registering struct types this late is the #2043 late-shift class).
+  const s1DynRegime = undefinedSingletonActive(ctx) && ctx.undefinedGlobalIdx !== undefined;
+  const s1IsNullishIdx = s1DynRegime ? ctx.funcMap.get("__extern_is_nullish") : undefined;
 
   const externref: ValType = { kind: "externref" };
   const i32: ValType = { kind: "i32" };
@@ -134,21 +144,29 @@ export function ensureDynReadHelpers(ctx: CodegenContext): void {
     "__dyn_get",
     [externref, externref],
     [externref],
-    [
-      // val = __extern_get(recv, key)
-      { op: "local.get", index: 0 } as Instr,
-      { op: "local.get", index: 1 } as Instr,
-      { op: "call", funcIdx: externGetIdx } as Instr,
-      { op: "local.tee", index: 2 } as Instr,
-      // if (val is null) return undefined  — §Get of an absent property is undefined
-      { op: "ref.is_null" } as Instr,
-      {
-        op: "if",
-        blockType: { kind: "val", type: externref },
-        then: undefInstrs,
-        else: [{ op: "local.get", index: 2 } as Instr],
-      } as Instr,
-    ],
+    s1DynRegime
+      ? [
+          // (#2106 S1) plain pass-through: __extern_get already answers the
+          // singleton for absent, and null means a stored JS null.
+          { op: "local.get", index: 0 } as Instr,
+          { op: "local.get", index: 1 } as Instr,
+          { op: "call", funcIdx: externGetIdx } as Instr,
+        ]
+      : [
+          // val = __extern_get(recv, key)
+          { op: "local.get", index: 0 } as Instr,
+          { op: "local.get", index: 1 } as Instr,
+          { op: "call", funcIdx: externGetIdx } as Instr,
+          { op: "local.tee", index: 2 } as Instr,
+          // if (val is null) return undefined  — §Get of an absent property is undefined
+          { op: "ref.is_null" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: externref },
+            then: undefInstrs,
+            else: [{ op: "local.get", index: 2 } as Instr],
+          } as Instr,
+        ],
     [{ name: "__dg_val", type: externref }],
   );
 
@@ -165,13 +183,22 @@ export function ensureDynReadHelpers(ctx: CodegenContext): void {
     "__dyn_has",
     [externref, externref],
     [i32],
-    [
-      { op: "local.get", index: 0 } as Instr,
-      { op: "local.get", index: 1 } as Instr,
-      { op: "call", funcIdx: externGetIdx } as Instr,
-      { op: "ref.is_null" } as Instr,
-      { op: "i32.eqz" } as Instr, // present ⇔ NOT null
-    ],
+    s1IsNullishIdx !== undefined
+      ? [
+          // (#2106 S1) present ⇔ NOT nullish (absent = the undefined singleton).
+          { op: "local.get", index: 0 } as Instr,
+          { op: "local.get", index: 1 } as Instr,
+          { op: "call", funcIdx: externGetIdx } as Instr,
+          { op: "call", funcIdx: s1IsNullishIdx } as Instr,
+          { op: "i32.eqz" } as Instr,
+        ]
+      : [
+          { op: "local.get", index: 0 } as Instr,
+          { op: "local.get", index: 1 } as Instr,
+          { op: "call", funcIdx: externGetIdx } as Instr,
+          { op: "ref.is_null" } as Instr,
+          { op: "i32.eqz" } as Instr, // present ⇔ NOT null
+        ],
   );
 
   // Reference the tag constant so a future refined tag-dispatch (M2/M3) keeps it;

--- a/src/codegen/expressions/calls-optional.ts
+++ b/src/codegen/expressions/calls-optional.ts
@@ -14,7 +14,9 @@ import type { InnerResult } from "../shared.js";
 import { compileExpression, VOID_RESULT } from "../shared.js";
 import { compileNativeStringMethodCall } from "../string-ops.js";
 import { defaultValueInstrs, pushDefaultValue } from "../type-coercion.js";
+import { undefinedSingletonActive } from "../any-helpers.js";
 import { compileCallablePropertyCall } from "./calls-closures.js";
+import { ensureExternIsUndefinedImport, flushLateImportShifts } from "./late-imports.js";
 import { getFuncParamTypes } from "./helpers.js";
 import { resolveStructName } from "./misc.js";
 
@@ -52,6 +54,17 @@ export function compileOptionalCallExpression(
   const tmp = allocLocal(fctx, `__optcall_${fctx.locals.length}`, objType);
   fctx.body.push({ op: "local.tee", index: tmp });
   fctx.body.push({ op: "ref.is_null" });
+  // (#2106 S1) Under the `undefinedSingleton` regime standalone `undefined` is
+  // a NON-null externref, so the short-circuit must also test the singleton.
+  if (undefinedSingletonActive(ctx) && objType.kind === "externref") {
+    const isUndefIdx = ensureExternIsUndefinedImport(ctx);
+    if (isUndefIdx !== undefined) {
+      flushLateImportShifts(ctx, fctx);
+      fctx.body.push({ op: "local.get", index: tmp });
+      fctx.body.push({ op: "call", funcIdx: isUndefIdx });
+      fctx.body.push({ op: "i32.or" } as Instr);
+    }
+  }
 
   const savedBody = pushBody(fctx);
   // The receiver of an optional chain is nullable by construction (`K | null`),

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -12,6 +12,7 @@ import { reportErrorNoNode } from "../context/errors.js";
 import { addImport } from "../registry/imports.js";
 import { addFuncType } from "../registry/types.js";
 import { addUnionImportsViaRegistry } from "../shared.js";
+import { emitUndefinedExtern } from "../any-helpers.js";
 import { ensureObjectRuntime, OBJECT_RUNTIME_HELPER_NAMES } from "../object-runtime.js";
 import { ensureSymbolCarrier } from "../symbol-native.js";
 import { shiftAsyncSideChannelFuncIdxs } from "../async-scheduler.js";
@@ -680,13 +681,19 @@ export function ensureGetUndefined(ctx: CodegenContext): number | undefined {
 /**
  * Emit instructions that push the JS `undefined` value onto the stack.
  * Uses the __get_undefined host import when available; falls back to
- * ref.null.extern (indistinguishable from null) in standalone mode.
+ * ref.null.extern (indistinguishable from null) in standalone mode — unless
+ * the (#2106 S1) `undefinedSingleton` regime is active, in which case the
+ * distinct extern-wrapped tag-1 `$undefined` singleton is pushed instead
+ * (a GLOBAL read, not a func import, so the #329 late-import finalize shift
+ * is never driven — see the S1.0 reservation in `ensureAnyValueType`).
  */
 export function emitUndefined(ctx: CodegenContext, fctx: FunctionContext): void {
   const funcIdx = ensureGetUndefined(ctx);
   if (funcIdx !== undefined) {
     flushLateImportShifts(ctx, fctx);
     fctx.body.push({ op: "call", funcIdx });
+  } else if (emitUndefinedExtern(ctx, fctx)) {
+    // (#2106 S1) flag regime: `global.get $undefined; extern.convert_any`.
   } else {
     fctx.body.push({ op: "ref.null.extern" });
   }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -119,6 +119,7 @@ import { STANDALONE_REGEXP_REFLECTION_PROPS } from "./regexp-standalone.js";
 
 // ── Extracted sub-modules ──────────────────────────────────────────────────
 import {
+  buildIsUndefinedExternBody,
   emitWrapperValueOfFunctions,
   ensureAnyFromExternHelper,
   ensureAnyHelpers,
@@ -126,7 +127,9 @@ import {
   ensureAnyValueType,
   ensureWrapperTypes,
   isAnyValue,
+  undefinedSingletonActive,
 } from "./any-helpers.js";
+import { UNDEF_F64_BITS } from "./value-tags.js";
 import {
   buildShapePropFlagsTable,
   collectClassDeclaration,
@@ -11426,6 +11429,16 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
   }
   const strToNumberIdx = ctx.funcMap.get("__str_to_number");
 
+  // (#2106 S1) `undefinedSingleton` regime support for the union natives:
+  // when active, `undefined` is a non-null extern-wrapped tag-1 `$AnyValue`
+  // (never `ref.null.extern`), so ToBoolean must classify it FALSY, the
+  // typeof cluster must answer "undefined" for the singleton and "object"
+  // for null, and `__typeof_undefined` flips off bare `ref.is_null`.
+  // Inactive (default): every body below is byte-identical to legacy.
+  const s1Active = undefinedSingletonActive(ctx);
+  if (s1Active) ensureAnyValueType(ctx);
+  const s1AnyValIdx = s1Active ? ctx.anyValueTypeIdx : -1;
+
   /**
    * Synthesize a native helper function. The funcIdx is allocated as
    * `numImportFuncs + mod.functions.length` to match how every other
@@ -11736,6 +11749,30 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
         blockType: { kind: "empty" },
         then: [{ op: "i32.const", value: 0 }, { op: "return" }],
       },
+      // (#2106 S1) `$AnyValue` box: tag 0 (null) / 1 (undefined) → FALSY
+      // (§7.1.2); other wrapped tags (5 string / 6 object) keep the non-null-
+      // ref default (truthy). Without this arm the non-null `$undefined`
+      // singleton would be truthy — `if (undefined)` taking the then-branch.
+      ...(s1AnyValIdx >= 0
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "any.convert_extern" },
+            { op: "local.tee", index: 1 },
+            { op: "ref.test", typeIdx: s1AnyValIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: 1 },
+                { op: "ref.cast", typeIdx: s1AnyValIdx },
+                { op: "struct.get", typeIdx: s1AnyValIdx, fieldIdx: 0 },
+                { op: "i32.const", value: 1 },
+                { op: "i32.gt_u" },
+                { op: "return" },
+              ],
+            },
+          ] as Instr[])
+        : []),
       // any = any.convert_extern(param)
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
@@ -11886,8 +11923,19 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
     registerNative("__typeof_string", externrefToI32, [{ op: "i32.const", value: 0 }]);
   }
 
-  // 12. __typeof_undefined(externref) -> i32 — `ref.is_null`.
-  registerNative("__typeof_undefined", externrefToI32, [{ op: "local.get", index: 0 }, { op: "ref.is_null" }]);
+  // 12. __typeof_undefined(externref) -> i32 — `ref.is_null` (legacy: null and
+  //     undefined share the null-extern bit pattern). (#2106 S1) Under the
+  //     `undefinedSingleton` regime: tag-1 `$AnyValue` ∨ UNDEF_F64 box; a null
+  //     externref answers 0 (typeof null is "object", not "undefined").
+  {
+    const s1Body = s1Active ? buildIsUndefinedExternBody(ctx, 1, UNDEF_F64_BITS) : undefined;
+    registerNative(
+      "__typeof_undefined",
+      externrefToI32,
+      s1Body ?? [{ op: "local.get", index: 0 }, { op: "ref.is_null" }],
+      s1Body !== undefined ? [{ name: "$any_temp", type: { kind: "anyref" } as ValType }] : [],
+    );
+  }
 
   // 13. __typeof_object(externref) -> i32 — non-null AND not number AND
   //     not boolean AND not bigint AND not function. We approximate as "non-null and
@@ -11903,8 +11951,36 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+        // (#2106 S1) typeof null IS "object" (§13.5.3) — under the singleton
+        // regime a null externref means JS null, so answer 1. Legacy: null
+        // means null-or-undefined; keep the historical 0.
+        then: [{ op: "i32.const", value: s1Active ? 1 : 0 }, { op: "return" }],
       },
+      // (#2106 S1) the tag-1 `$undefined` singleton is NOT an object.
+      ...(s1AnyValIdx >= 0
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "any.convert_extern" },
+            { op: "local.tee", index: 1 },
+            { op: "ref.test", typeIdx: s1AnyValIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: 1 },
+                { op: "ref.cast", typeIdx: s1AnyValIdx },
+                { op: "struct.get", typeIdx: s1AnyValIdx, fieldIdx: 0 },
+                { op: "i32.const", value: 1 },
+                { op: "i32.eq" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+                } as Instr,
+              ],
+            },
+          ] as Instr[])
+        : []),
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
       { op: "local.tee", index: 1 },
@@ -11985,8 +12061,16 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
       "__typeof",
       externrefToExternref,
       [
-        // null externref → undefined (matches __typeof_undefined = ref.is_null)
-        ...typeofTagArm([{ op: "local.get", index: 0 }, { op: "ref.is_null" }], "undefined"),
+        // null externref → undefined (matches __typeof_undefined = ref.is_null).
+        // (#2106 S1) Under the singleton regime null means JS null → "object"
+        // (§13.5.3), and the tag-1/UNDEF-box arm below answers "undefined".
+        ...typeofTagArm([{ op: "local.get", index: 0 }, { op: "ref.is_null" }], s1Active ? "object" : "undefined"),
+        ...(s1Active
+          ? (() => {
+              const test = buildIsUndefinedExternBody(ctx, 1, UNDEF_F64_BITS);
+              return test !== undefined ? typeofTagArm(test, "undefined") : [];
+            })()
+          : []),
         { op: "local.get", index: 0 },
         { op: "any.convert_extern" },
         { op: "local.set", index: 1 },

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1034,7 +1034,10 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     // `ref.null.extern`. Legacy (flag off): miss = `ref.null.extern`,
     // byte-identical. This is the producer half of the lockstep flip whose
     // absence caused PR #2025's −1245 (consumer flipped, producer not).
-    const getMiss: Instr[] = undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr];
+    // A FACTORY, not a shared array — the miss appears in three branches and
+    // shared Instr objects get double-remapped by finalize walks (see
+    // `reference_shared_instr_object_dce_double_remap`).
+    const getMiss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr];
     const body: Instr[] = [
       // (#2896) Builtin-fn metadata arm: `fn[key]` for key "name"/"length" on a
       // builtin function value answers its spec metadata (host-free). Non-meta
@@ -1064,7 +1067,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [...getMiss, { op: "return" } as Instr],
+        then: [...getMiss(), { op: "return" } as Instr],
       },
       // o = cast<$Object>(any)
       { op: "local.get", index: 4 },
@@ -1119,7 +1122,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
                       {
                         op: "if",
                         blockType: { kind: "empty" },
-                        then: [...getMiss, { op: "return" } as Instr],
+                        then: [...getMiss(), { op: "return" } as Instr],
                       },
                       // return __call_accessor_get(obj /*param 0*/, getter)
                       { op: "local.get", index: 0 },
@@ -1147,7 +1150,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         ],
       },
       // not found anywhere → miss (undefined under the S1 regime; legacy null)
-      ...getMiss,
+      ...getMiss(),
     ];
     registerNative(
       "__extern_get",

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -2686,7 +2686,10 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       {
         op: "if",
         blockType: { kind: "val", type: { kind: "externref" } },
-        then: [{ op: "ref.null.extern" }],
+        // (#2106 S1) under the singleton regime a null externref IS JS null →
+        // ToString = "null" (§7.1.17). Legacy keeps the null pass-through
+        // (downstream __any_to_string renders its residual arm).
+        then: undefinedSingletonActive(ctx) ? [...stringExtern("null")] : [{ op: "ref.null.extern" } as Instr],
         else: [
           { op: "local.get", index: 0 },
           { op: "any.convert_extern" },

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -1176,7 +1176,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   {
     const s1IsUndefTail = buildIsUndefinedExternBody(ctx, 1, UNDEF_F64_BITS);
     if (undefinedSingletonActive(ctx) && s1IsUndefTail !== undefined) {
-      registerNative(
+      const isNullishIdx = registerNative(
         "__extern_is_nullish",
         [{ kind: "externref" }],
         [{ kind: "i32" }],
@@ -1189,6 +1189,31 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
             blockType: { kind: "val", type: { kind: "i32" } },
             then: [{ op: "i32.const", value: 1 }],
             else: s1IsUndefTail,
+          } as Instr,
+        ],
+      );
+      // (#2106 S1, flag-only) __nullish_to_null(externref) -> externref —
+      // canonicalize nullish (null OR the undefined singleton OR the UNDEF-box)
+      // back to `ref.null.extern`. INTERNAL runtime lookups whose result feeds
+      // null-keyed control logic (to-primitive valueOf/toString resolution,
+      // proxy trap reads, descriptor field reads, method resolution, groupBy
+      // presence checks) append ONE call to this after `__extern_get`, keeping
+      // their entire downstream absence logic byte-identical to legacy instead
+      // of widening every `ref.is_null` in place. JS-VISIBLE reads do NOT
+      // normalize — they want the singleton.
+      registerNative(
+        "__nullish_to_null",
+        [{ kind: "externref" }],
+        [{ kind: "externref" }],
+        [],
+        [
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: isNullishIdx } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: [{ op: "ref.null.extern" }],
+            else: [{ op: "local.get", index: 0 }],
           } as Instr,
         ],
       );
@@ -2487,10 +2512,20 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       } as Instr,
     ];
 
+    // (#2106 S1) Normalize the method lookup back to the legacy null-keyed
+    // convention: under the singleton regime a MISSING valueOf/toString comes
+    // back as the non-null `$undefined` singleton, which the `ref.is_null`
+    // absence check below would treat as a callable method — the exact source
+    // of PR #2025's 948 "Cannot convert object to primitive value" CEs.
+    const s1ToPrimNorm: Instr[] = (() => {
+      const idx = ctx.funcMap.get("__nullish_to_null");
+      return idx !== undefined ? [{ op: "call", funcIdx: idx } as Instr] : [];
+    })();
     const tryOrdinaryMethod = (name: "valueOf" | "toString", defaultObjectToStringOnMissing: boolean): Instr[] => [
       { op: "local.get", index: 0 },
       ...stringExtern(name),
       { op: "call", funcIdx: externGetIdx },
+      ...s1ToPrimNorm.map((i) => ({ ...i }) as Instr),
       { op: "local.tee", index: L_METHOD },
       { op: "ref.is_null" },
       {
@@ -4181,6 +4216,10 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       numberToStringIdx: objArrayLikeArms ? ctx.funcMap.get("number_toString")! : -1,
       externGetIdx: objArrayLikeArms ? ctx.funcMap.get("__extern_get")! : -1,
       vecArms: [],
+      // (#2106 S1) OOB / non-indexable miss = undefined under the singleton
+      // regime (`arr[oob] === undefined`), consistent with the `$Object` arm
+      // which delegates to the (flipped) `__extern_get`. Legacy: null.
+      missInstrs: () => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr],
     });
     registerNative(
       "__extern_get_idx",
@@ -5363,6 +5402,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "local.get", index: L_RAW_DESC },
       ...keyRef(key),
       { op: "call", funcIdx: externGetIdx },
+      // (#2106 S1) normalize missing/undefined descriptor fields back to the
+      // legacy null convention so downstream null-keyed logic is unchanged.
+      ...(ctx.funcMap.has("__nullish_to_null")
+        ? [{ op: "call", funcIdx: ctx.funcMap.get("__nullish_to_null")! } as Instr]
+        : []),
     ];
     const setFlag = (bit: number): Instr[] => [
       { op: "local.get", index: L_FLAGS },
@@ -5788,6 +5832,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "local.get", index: L_DESC },
       ...keyRef(key),
       { op: "call", funcIdx: externGetIdx },
+      // (#2106 S1) normalize missing/undefined descriptor fields back to the
+      // legacy null convention so downstream null-keyed logic is unchanged.
+      ...(ctx.funcMap.has("__nullish_to_null")
+        ? [{ op: "call", funcIdx: ctx.funcMap.get("__nullish_to_null")! } as Instr]
+        : []),
     ];
     const setFlag = (bit: number): Instr[] => [
       { op: "local.get", index: L_FLAGS },
@@ -7011,6 +7060,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
           { op: "local.get", index: 0 },
           { op: "local.get", index: 1 },
           { op: "call", funcIdx: externGetIdx },
+          // (#2106 S1) a missing method resolves to the undefined singleton —
+          // normalize to null so __apply_closure keeps its legacy null path.
+          ...(ctx.funcMap.has("__nullish_to_null")
+            ? [{ op: "call", funcIdx: ctx.funcMap.get("__nullish_to_null")! } as Instr]
+            : []),
           // __apply_closure(m, recv, args)
           { op: "local.get", index: 0 },
           { op: "local.get", index: 2 },
@@ -7880,6 +7934,11 @@ function ensureProxyRuntime(
       { op: "local.get", index: 1 },
       ...stringConstantExternrefInstrs(ctx, name),
       { op: "call", funcIdx: externGetIdx },
+      // (#2106 S1) a missing trap resolves to the undefined singleton —
+      // normalize to null so the trap-dispatch null checks keep working.
+      ...(ctx.funcMap.has("__nullish_to_null")
+        ? [{ op: "call", funcIdx: ctx.funcMap.get("__nullish_to_null")! } as Instr]
+        : []),
     ];
     const proxyCreateBody: Instr[] = [
       // if target == null → throw
@@ -8541,6 +8600,11 @@ export function ensureObjectGroupBy(ctx: CodegenContext): number {
             { op: "local.get", index: 4 },
             { op: "local.get", index: 6 },
             { op: "call", funcIdx: externGetIdx },
+            // (#2106 S1) group-absent = undefined singleton → normalize to
+            // null so the presence check below keeps its legacy shape.
+            ...(ctx.funcMap.has("__nullish_to_null")
+              ? [{ op: "call", funcIdx: ctx.funcMap.get("__nullish_to_null")! } as Instr]
+              : []),
             { op: "local.set", index: 7 },
             // if group is null → group = __objvec_new(); __extern_set(out, key, group)
             { op: "local.get", index: 7 },
@@ -8926,6 +8990,13 @@ interface ExternGetIdxBodyParams {
   externGetIdx: number;
   /** Pre-built per-`__vec_<k>` dispatch arms (empty at registration time). */
   vecArms: Instr[];
+  /** (#2106 S1) Factory for the miss ("index absent") result instrs. A FACTORY
+   *  — not a shared array — because the miss appears in several branches and
+   *  shared Instr objects get double-remapped by the finalize walks (see
+   *  `reference_shared_instr_object_dce_double_remap`). Legacy:
+   *  `[{ ref.null.extern }]`; singleton regime: `global.get $undefined ;
+   *  extern.convert_any`. */
+  missInstrs: () => Instr[];
 }
 
 /**
@@ -8978,7 +9049,7 @@ function buildExternGetIdxBody(p: ExternGetIdxBodyParams): Instr[] {
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [{ op: "ref.null.extern" }, { op: "return" }],
+      then: [...p.missInstrs(), { op: "return" } as Instr],
     },
     // vec = cast<$ObjVec>(any) ; i = i32(idx)
     { op: "local.get", index: 2 },
@@ -8987,13 +9058,13 @@ function buildExternGetIdxBody(p: ExternGetIdxBodyParams): Instr[] {
     { op: "local.get", index: 1 },
     { op: "i32.trunc_sat_f64_s" },
     { op: "local.tee", index: 4 },
-    // if i < 0 || i >= vec.len → null
+    // if i < 0 || i >= vec.len → miss
     { op: "i32.const", value: 0 },
     { op: "i32.lt_s" },
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [{ op: "ref.null.extern" }, { op: "return" }],
+      then: [...p.missInstrs(), { op: "return" } as Instr],
     },
     { op: "local.get", index: 4 },
     { op: "local.get", index: 3 },
@@ -9003,7 +9074,7 @@ function buildExternGetIdxBody(p: ExternGetIdxBodyParams): Instr[] {
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [{ op: "ref.null.extern" }, { op: "return" }],
+      then: [...p.missInstrs(), { op: "return" } as Instr],
     },
     // return vec.data[i]
     { op: "local.get", index: 3 },
@@ -9058,6 +9129,11 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
   }
   carriers.sort((a, b) => a.typeIdx - b.typeIdx);
 
+  // (#2106 S1) OOB miss = undefined under the singleton regime (fresh instr
+  // objects per use — a factory, never a shared array, per the finalize
+  // double-remap hazard). The singleton instrs carry no funcIdx/typeIdx, so
+  // splicing them at FINALIZE cannot desync any index-shift walk.
+  const idxMiss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr];
   const vecArms: Instr[] = [];
   for (const { typeIdx, arrTypeIdx, elemType } of carriers) {
     const boxOps = boxVecElementToExternref(ctx, elemType);
@@ -9066,7 +9142,7 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        // i = trunc_sat(idx) ; if i < 0 → null
+        // i = trunc_sat(idx) ; if i < 0 → miss
         { op: "local.get", index: 1 },
         { op: "i32.trunc_sat_f64_s" },
         { op: "local.tee", index: 4 },
@@ -9075,9 +9151,9 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "ref.null.extern" }, { op: "return" }],
+          then: [...idxMiss(), { op: "return" } as Instr],
         } as Instr,
-        // if i >= vec.length → null
+        // if i >= vec.length → miss
         { op: "local.get", index: 4 },
         { op: "local.get", index: 2 },
         { op: "ref.cast", typeIdx },
@@ -9086,7 +9162,7 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
         {
           op: "if",
           blockType: { kind: "empty" },
-          then: [{ op: "ref.null.extern" }, { op: "return" }],
+          then: [...idxMiss(), { op: "return" } as Instr],
         } as Instr,
         // return box(vec.data[i])
         { op: "local.get", index: 2 },

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -73,6 +73,9 @@ import { reserveAccessorGetDriver, reserveAccessorSetDriver } from "./accessor-d
 import { ensureSymbolCarrier } from "./symbol-native.js";
 import { reserveArrayToPrimitiveString } from "./array-to-primitive.js";
 import { UNDEF_F64_BITS } from "./value-tags.js";
+// (#2106 S1) function-level-only cycle with any-helpers.ts (which imports
+// ensureObjectRuntime) — same tolerated shape as native-strings ↔ any-helpers.
+import { buildIsUndefinedExternBody, undefinedExternInstrs, undefinedSingletonActive } from "./any-helpers.js";
 import { reserveClassToPrimitive } from "./class-to-primitive.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
@@ -1024,6 +1027,14 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     // `__call_fn_method_0` exists (fillAccessorDrivers). Routing through funcMap
     // keeps the late-import shifter in sync (#329/#1899).
     const callAccessorGetIdx = reserveAccessorGetDriver(ctx);
+    // (#2106 S1) Under the `undefinedSingleton` regime a MISSING property read
+    // answers the extern-wrapped tag-1 `$undefined` singleton — the value JS
+    // semantics require (`({}).x === undefined` true, destructuring/param
+    // defaults fire) — while a stored JS `null` still reads back as
+    // `ref.null.extern`. Legacy (flag off): miss = `ref.null.extern`,
+    // byte-identical. This is the producer half of the lockstep flip whose
+    // absence caused PR #2025's −1245 (consumer flipped, producer not).
+    const getMiss: Instr[] = undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr];
     const body: Instr[] = [
       // (#2896) Builtin-fn metadata arm: `fn[key]` for key "name"/"length" on a
       // builtin function value answers its spec metadata (host-free). Non-meta
@@ -1047,13 +1058,13 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
       { op: "local.tee", index: 4 },
-      // if !ref.test $Object → not one of our objects → return null
+      // if !ref.test $Object → not one of our objects → miss (undefined)
       { op: "ref.test", typeIdx: objectTypeIdx },
       { op: "i32.eqz" },
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [{ op: "ref.null.extern" }, { op: "return" }],
+        then: [...getMiss, { op: "return" } as Instr],
       },
       // o = cast<$Object>(any)
       { op: "local.get", index: 4 },
@@ -1103,12 +1114,12 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
                       { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 4 },
                       { op: "extern.convert_any" },
                       { op: "local.tee", index: 5 },
-                      // if getter == null → return undefined (null externref)
+                      // if getter == null → return undefined (§6.2.5.5 step 3)
                       { op: "ref.is_null" },
                       {
                         op: "if",
                         blockType: { kind: "empty" },
-                        then: [{ op: "ref.null.extern" }, { op: "return" }],
+                        then: [...getMiss, { op: "return" } as Instr],
                       },
                       // return __call_accessor_get(obj /*param 0*/, getter)
                       { op: "local.get", index: 0 },
@@ -1135,8 +1146,8 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
           },
         ],
       },
-      // not found anywhere → null
-      { op: "ref.null.extern" },
+      // not found anywhere → miss (undefined under the S1 regime; legacy null)
+      ...getMiss,
     ];
     registerNative(
       "__extern_get",
@@ -1151,6 +1162,37 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       ],
       body,
     );
+  }
+
+  // (#2106 S1, flag-only) __extern_is_nullish(externref) -> i32 — "null OR
+  // undefined". Under the singleton regime a bare `ref.is_null` no longer
+  // catches undefined (a non-null singleton), so every NULLISH-intent absence
+  // check in the native runtime (missing-method / to-primitive / iterator
+  // lookups, the loose `== null` guard) routes through this instead. Body is
+  // self-contained (inline tag-1 ∨ UNDEF-box test, NOT a call into
+  // `__extern_is_undefined`, which registers later) so it can be baked into
+  // any subsequently-built native body. Registered ONLY under the flag so
+  // legacy modules stay byte-identical.
+  {
+    const s1IsUndefTail = buildIsUndefinedExternBody(ctx, 1, UNDEF_F64_BITS);
+    if (undefinedSingletonActive(ctx) && s1IsUndefTail !== undefined) {
+      registerNative(
+        "__extern_is_nullish",
+        [{ kind: "externref" }],
+        [{ kind: "i32" }],
+        [{ name: "any", type: { kind: "anyref" } }],
+        [
+          { op: "local.get", index: 0 },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [{ op: "i32.const", value: 1 }],
+            else: s1IsUndefTail,
+          } as Instr,
+        ],
+      );
+    }
   }
 
   // ── $__obj_insert(ref $Object, externref key, anyref value, i32 flags, i32 seq) ──
@@ -6883,41 +6925,50 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // never builds this native (native generators are standalone/wasi-only), so
   // this cannot misfire on a genuine number. Gated on the carrier type
   // existing; without it the body is the legacy bare `ref.is_null`.
+  // (#2106 S1) Under the `undefinedSingleton` regime the predicate flips to
+  // "tag-1 `$AnyValue` box ∨ UNDEF_F64 `$BoxedNumber`" and — the whole point —
+  // a null externref answers 0 (null is DISTINCT from undefined). Every
+  // undefined PRODUCER (emitUndefined, `__extern_get`/`__extern_get_idx`
+  // miss, literal stores, omitted-arg padding) flips to the singleton in the
+  // same build, so the lockstep invariant that broke PR #2025 holds.
+  const s1IsUndefBody = buildIsUndefinedExternBody(ctx, 1, UNDEF_F64_BITS);
   registerNative(
     "__extern_is_undefined",
     [{ kind: "externref" }],
     [{ kind: "i32" }],
-    ctx.nativeBoxNumberTypeIdx >= 0 ? [{ name: "any", type: { kind: "anyref" } }] : [],
-    ctx.nativeBoxNumberTypeIdx >= 0
-      ? [
-          { op: "local.get", index: 0 },
-          { op: "ref.is_null" },
-          {
-            op: "if",
-            blockType: { kind: "val", type: { kind: "i32" } },
-            then: [{ op: "i32.const", value: 1 }],
-            else: [
-              { op: "local.get", index: 0 },
-              { op: "any.convert_extern" },
-              { op: "local.tee", index: 1 },
-              { op: "ref.test", typeIdx: ctx.nativeBoxNumberTypeIdx },
-              {
-                op: "if",
-                blockType: { kind: "val", type: { kind: "i32" } },
-                then: [
-                  { op: "local.get", index: 1 },
-                  { op: "ref.cast", typeIdx: ctx.nativeBoxNumberTypeIdx },
-                  { op: "struct.get", typeIdx: ctx.nativeBoxNumberTypeIdx, fieldIdx: 0 },
-                  { op: "i64.reinterpret_f64" },
-                  { op: "i64.const", value: UNDEF_F64_BITS },
-                  { op: "i64.eq" },
-                ],
-                else: [{ op: "i32.const", value: 0 }],
-              } as Instr,
-            ],
-          } as Instr,
-        ]
-      : [{ op: "local.get", index: 0 }, { op: "ref.is_null" }],
+    s1IsUndefBody !== undefined || ctx.nativeBoxNumberTypeIdx >= 0 ? [{ name: "any", type: { kind: "anyref" } }] : [],
+    s1IsUndefBody !== undefined
+      ? s1IsUndefBody
+      : ctx.nativeBoxNumberTypeIdx >= 0
+        ? [
+            { op: "local.get", index: 0 },
+            { op: "ref.is_null" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "i32" } },
+              then: [{ op: "i32.const", value: 1 }],
+              else: [
+                { op: "local.get", index: 0 },
+                { op: "any.convert_extern" },
+                { op: "local.tee", index: 1 },
+                { op: "ref.test", typeIdx: ctx.nativeBoxNumberTypeIdx },
+                {
+                  op: "if",
+                  blockType: { kind: "val", type: { kind: "i32" } },
+                  then: [
+                    { op: "local.get", index: 1 },
+                    { op: "ref.cast", typeIdx: ctx.nativeBoxNumberTypeIdx },
+                    { op: "struct.get", typeIdx: ctx.nativeBoxNumberTypeIdx, fieldIdx: 0 },
+                    { op: "i64.reinterpret_f64" },
+                    { op: "i64.const", value: UNDEF_F64_BITS },
+                    { op: "i64.eq" },
+                  ],
+                  else: [{ op: "i32.const", value: 0 }],
+                } as Instr,
+              ],
+            } as Instr,
+          ]
+        : [{ op: "local.get", index: 0 }, { op: "ref.is_null" }],
   );
 
   // ── __extern_method_call(externref recv, externref name, externref args)

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -43,6 +43,7 @@ import {
   noJsHost,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
+import { undefinedSingletonActive } from "./any-helpers.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { emitSymbolDescLoad } from "./symbol-native.js";
 import {
@@ -2244,6 +2245,17 @@ export function compileOptionalPropertyAccess(
   const tmp = allocLocal(fctx, `__opt_${fctx.locals.length}`, objType);
   fctx.body.push({ op: "local.tee", index: tmp });
   fctx.body.push({ op: "ref.is_null" });
+  // (#2106 S1) Under the `undefinedSingleton` regime standalone `undefined` is
+  // a NON-null externref, so the short-circuit must also test the singleton.
+  if (undefinedSingletonActive(ctx) && objType.kind === "externref") {
+    const s1IsUndefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+    if (s1IsUndefIdx !== undefined) {
+      flushLateImportShifts(ctx, fctx);
+      fctx.body.push({ op: "local.get", index: tmp });
+      fctx.body.push({ op: "call", funcIdx: s1IsUndefIdx } as Instr);
+      fctx.body.push({ op: "i32.or" } as Instr);
+    }
+  }
 
   const savedBody = fctx.body;
   fctx.savedBodies.push(savedBody);

--- a/src/codegen/value-tags.ts
+++ b/src/codegen/value-tags.ts
@@ -148,8 +148,33 @@ export function boxToAny(ctx: CodegenContext, fctx: FunctionContext, from: ValTy
     case "null":
       // Only honor when the value is a discardable reference carrier; otherwise
       // fall through (a non-ref "null" hint shouldn't drop a live scalar).
+      // (#2106 S1) Under the `undefinedSingleton` regime (inline mirror of
+      // any-helpers' `undefinedSingletonActive` — kept import-free here), a
+      // statically-null reference carrier boxes tag-0 directly instead of
+      // falling into the Wasm-kind dispatch (whose externref arm tags it 5,
+      // the #1888 lie, or — honest — routes through __any_from_extern).
+      if (
+        ctx.undefinedSingleton === true &&
+        (ctx.standalone || ctx.nativeStrings) &&
+        (from.kind === "externref" || from.kind === "ref" || from.kind === "ref_null") &&
+        emit("__any_box_null", [{ op: "drop" } as Instr])
+      ) {
+        return true;
+      }
       break;
     case "undefined":
+      // (#2106 S1) Statically-undefined value: drop the carrier (null extern /
+      // singleton extern / UNDEF_F64-sentinel f64 — the only values an
+      // `undefined`-typed slot can hold) and box tag-1. Regime-gated; the
+      // legacy path keeps the historical kind-keyed dispatch below.
+      if (
+        ctx.undefinedSingleton === true &&
+        (ctx.standalone || ctx.nativeStrings) &&
+        (from.kind === "externref" || from.kind === "ref" || from.kind === "ref_null" || from.kind === "f64") &&
+        emit("__any_box_undefined", [{ op: "drop" } as Instr])
+      ) {
+        return true;
+      }
       break;
     default:
       break;

--- a/src/codegen/value-tags.ts
+++ b/src/codegen/value-tags.ts
@@ -193,6 +193,16 @@ export function boxToAny(ctx: CodegenContext, fctx: FunctionContext, from: ValTy
     // under the flag; if absent (availability preconditions unmet) fall back
     // to the legacy lie so the flag can never produce a compile-time hole.
     if (ctx.honestAnyBoxing && emit("__any_from_extern")) return true;
+    // (#2106 S1) NULLISH-honest boxing under the `undefinedSingleton` regime:
+    // null → tag-0, the singleton / UNDEF-box → tag-1, everything else keeps
+    // the legacy tag-5 wrap byte-equivalently (see __any_box_extern_s1 —
+    // deliberately NOT the full-honest #2141 classification, whose solo flip
+    // measured −788/−794). Without this, `u === miss` over two `any` operands
+    // boxes both nullish values as tag-5 "strings" and __any_strict_eq's
+    // guarded string arm answers 0.
+    if (ctx.undefinedSingleton === true && (ctx.standalone || ctx.nativeStrings) && emit("__any_box_extern_s1")) {
+      return true;
+    }
     // #1888 (regression −788/−794): do NOT route generic externref boxing
     // through honest tag recovery. The test262 harness comparator (`isSameValue`
     // over the externref ABI with `any` params) depends on main's tag-5

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -725,6 +725,8 @@ function buildCodegenOptions(
     honestAnyBoxing: options.honestAnyBoxing,
     // (#2141 S2/S3, #2626) tag-5 boxed-VALUE eq classifier flag (default off).
     tag5ValueEqClassifier: options.tag5ValueEqClassifier,
+    // (#2106 S1) standalone $undefined tag-1 singleton regime flag (default off).
+    undefinedSingleton: options.undefinedSingleton,
     // (#2796) Diff-test-harness fidelity — defer top-level init to an export so
     // the host runs it after setExports (symmetric with standalone `_start`).
     deferTopLevelInit: options.deferTopLevelInit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,6 +241,23 @@ export interface CompileOptions {
    * waves land (the −162 dstr cluster unmasking).
    */
   tag5ValueEqClassifier?: boolean;
+  /**
+   * (#2106 S1) Standalone `$undefined` tag-1 singleton regime. When true (and
+   * targeting standalone/nativeStrings), `undefined` is represented by the
+   * S1.0 immutable tag-1 `$AnyValue` global (extern-wrapped at the externref
+   * plane), DISTINCT from `null` (`ref.null.extern`): `null !== undefined`,
+   * `typeof null === "object"`, ToNumber(null)=0 vs ToNumber(undefined)=NaN.
+   * All undefined producers (emitUndefined, `__extern_get`/`__extern_get_idx`
+   * miss, literal stores, boxToAny) and undefined-specific consumers
+   * (`__extern_is_undefined`, typeof cluster, strict-eq) flip in lockstep
+   * under this flag; nullish-intent consumers widen to `is_null ∨
+   * is-singleton`. Default false (legacy: undefined ≡ null ≡ ref.null.extern,
+   * byte-identical modules). Host (gc) mode is unaffected — it has a real
+   * host `undefined` via `__get_undefined`. `JS2WASM_UNDEF_SINGLETON=1`
+   * defaults it on for whole-runner A/B; the default flip is a separate
+   * measured PR (#2106).
+   */
+  undefinedSingleton?: boolean;
   /** #1588 PR-B: dual i8/i16 string storage. When true, string allocation
    *  sites the encoding analysis proves `ascii`/`utf8-guaranteed` are stored
    *  as i8-backed `Utf8String`; all others stay i16. Default false →

--- a/tests/issue-2106-s1-undefined-singleton.test.ts
+++ b/tests/issue-2106-s1-undefined-singleton.test.ts
@@ -1,0 +1,198 @@
+// #2106 S1 — standalone `$undefined` tag-1 singleton regime (flag-gated).
+//
+// Under `undefinedSingleton: true` (standalone/wasi only), `undefined` is the
+// extern-wrapped tag-1 `$AnyValue` singleton and `null` stays
+// `ref.null.extern` — so the two are DISTINCT for `===`/`typeof`/ToNumber/
+// ToString, while every nullish consumer (`==`, `??`, `?.`, defaults,
+// truthiness) still catches both. Flag OFF is the legacy conflated regime and
+// must stay byte-identical (regression-netted here by a behavioral control:
+// the legacy `null === undefined` answers TRUE standalone).
+//
+// Each case compiles with `target: "wasi"` + the flag, instantiates against
+// the WASI polyfill, and returns an i32 score from `test()`.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+async function run(source: string, undefinedSingleton: boolean): Promise<number> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi", undefinedSingleton });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  return (exports.test as () => number)();
+}
+
+describe("#2106 S1 undefined singleton (flag ON, standalone)", () => {
+  it("strict equality: undefined===undefined across producers; null===null; null!==undefined", async () => {
+    const v = await run(
+      `export function test(): number {
+         const u: any = undefined;
+         const miss: any = ({} as any).nope;
+         const n: any = null;
+         let s = 0;
+         if (u === miss) s += 1;        // two undefined producers agree
+         if (n === null) s += 2;
+         if (!(n === u)) s += 4;        // null !== undefined
+         if (!(u === null)) s += 8;
+         if (u === undefined) s += 16;
+         if (!(n === undefined)) s += 32;
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(63);
+  });
+
+  it("loose equality: null == undefined true; nullish vs non-nullish false", async () => {
+    const v = await run(
+      `export function test(): number {
+         const u: any = undefined;
+         const n: any = null;
+         const z: any = 0;
+         let s = 0;
+         if (u == n) s += 1;
+         if (n == u) s += 2;
+         if (!(n == z)) s += 4;
+         if (!(u == z)) s += 8;
+         if (u == null) s += 16;
+         if (n == null) s += 32;
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(63);
+  });
+
+  it("typeof: undefined → 'undefined', null → 'object'", async () => {
+    const v = await run(
+      `export function test(): number {
+         const u: any = undefined;
+         const n: any = null;
+         const miss: any = ({} as any).nope;
+         let s = 0;
+         if (typeof u === "undefined") s += 1;
+         if (typeof n === "object") s += 2;
+         if (typeof miss === "undefined") s += 4;
+         if (!(typeof n === "undefined")) s += 8;
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(15);
+  });
+
+  it("property reads: missing → undefined; stored null stays null", async () => {
+    const v = await run(
+      `export function test(): number {
+         const o: any = { a: null };
+         let s = 0;
+         if (o.a === null) s += 1;
+         if (!(o.a === undefined)) s += 2;
+         if (o.b === undefined) s += 4;
+         if (!(o.b === null)) s += 8;
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(15);
+  });
+
+  it("destructuring defaults fire for undefined/missing, NOT for null (§13.15.5.3)", async () => {
+    const v = await run(
+      `export function test(): number {
+         const src: any = {};
+         const { a = 7 } = src;
+         // NOTE: a null property must come from a $Object (dynamic set) —
+         // a { b: null } shape-struct literal read through __extern_get is a
+         // pre-existing miss in BOTH regimes (flag-neutral, not S1 scope).
+         const srcN: any = {};
+         (srcN as any).b = null;
+         const { b = 9 } = srcN;
+         let s = 0;
+         if (a === 7) s += 1;
+         if (b === null) s += 2;   // default must NOT fire for null
+         if (!(b === 9)) s += 4;
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(7);
+  });
+
+  it("?? and ?. and truthiness treat the singleton as nullish/falsy", async () => {
+    const v = await run(
+      `export function test(): number {
+         const u: any = undefined;
+         const n: any = null;
+         let s = 0;
+         if ((u ?? 5) === 5) s += 1;
+         if ((n ?? 6) === 6) s += 2;
+         if (u?.x === undefined) s += 4;
+         if (!u) s += 8;            // ToBoolean(undefined) = false
+         if (!n) s += 16;
+         const zero: any = 0;
+         if ((zero ?? 7) === 0) s += 32; // 0 is not nullish
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(63);
+  });
+
+  it("ToString / ToNumber split: 'undefined' vs 'null', NaN vs 0", async () => {
+    const v = await run(
+      `export function test(): number {
+         const u: any = undefined;
+         const n: any = null;
+         let s = 0;
+         if ("v=" + u === "v=undefined") s += 1;
+         if ("v=" + n === "v=null") s += 2;
+         const nu = +n;
+         if (nu === 0) s += 4;      // Number(null) = 0
+         const uu = +u;
+         if (uu !== uu) s += 8;     // Number(undefined) = NaN
+         return s;
+       }`,
+      true,
+    );
+    expect(v).toBe(15);
+  });
+
+  it("destructure of an undefined container throws TypeError (§13.15.5)", async () => {
+    const v = await run(
+      `export function test(): number {
+         const f = ({ a }: any): any => a;
+         const u: any = undefined;
+         let r = 0;
+         try { f(u); r = 0; } catch (e) { r = 1; }
+         return r;
+       }`,
+      true,
+    );
+    expect(v).toBe(1);
+  });
+});
+
+describe("#2106 S1 flag OFF (legacy control — proves the gate)", () => {
+  it("legacy standalone conflates: null === undefined answers true", async () => {
+    const v = await run(
+      `export function test(): number {
+         const u: any = undefined;
+         const n: any = null;
+         return typeof n === "undefined" && !(typeof n === "object") ? 1 : 0;
+       }`,
+      false,
+    );
+    // Legacy: null and undefined share ref.null.extern → typeof null is
+    // "undefined" standalone. This control locks the flag-off behavior so an
+    // accidental default-flip cannot slip through this suite silently.
+    expect(v).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Re-lands #2106 S1 (standalone `undefined` ≠ `null`) as the COMPLETE producer+consumer lockstep sweep, gated on a new `undefinedSingleton` compile option (default OFF → **byte-identical modules**, proven by a 10-program × {gc,wasi} sha256 corpus against the pre-change tree). The June attempt (PR #2025) flipped a partial subset default-on and breached the standalone floor by −1245; this PR applies the issue's own measure-first flag protocol (precedent: #2141 `honestAnyBoxing`, incl. the `JS2WASM_UNDEF_SINGLETON=1` env for whole-runner A/B).

## Regime (flag ON, standalone/nativeStrings only)

- `undefined` = the S1.0 extern-wrapped tag-1 `$AnyValue` singleton (a GLOBAL — never a late func import, #329-safe); `null` stays `ref.null.extern`.
- **Producers**: `emitUndefined`, `__extern_get`/`__extern_get_idx` misses, `boxToAny` null/undefined arms, `__any_from_extern` null arm (tag-0).
- **Key chokepoint**: `__any_box_extern_s1` — NULLISH-only honest externref boxing (null→tag-0, singleton/UNDEF-box→tag-1, everything else keeps the #1888 tag-5 wrap byte-equivalently — deliberately NOT #2141's full-honest flip, which measured −788/−794 solo). This is what makes dynamic `===`/`==` observe the distinction through the already-tag-correct `__any_strict_eq`/`__any_eq`.
- **Consumers**: `__extern_is_undefined` → tag-1 ∨ UNDEF-box (keeps the #2979 arm, drops `ref.is_null`); new `__extern_is_nullish` + `__nullish_to_null` natives — internal null-keyed lookups (to-primitive method resolution = the June 948-CE family, proxy traps, descriptors, method dispatch, groupBy) normalize nullish→null so downstream logic is unchanged; `__is_truthy` singleton-falsy; typeof cluster (null→"object", singleton→"undefined"); the #1776 dynamic-eq cascade gains the singleton-keyed nullish guard (the #1961 bothNullishGuard re-keyed exactly as the S1 spec prescribed); `?.` guards; `__dyn_get`/`__dyn_has`; join; `__extern_toString(null)`→"null"; destructure container guard tests tag-1 ONLY (preserves the #3010 fix).
- dstr/param defaults need NO changes — already `__extern_is_undefined`-exclusive (#1021); the lockstep producer flip makes them spec-correct (defaults no longer fire for `null`).

## Validation

- `tests/issue-2106-s1-undefined-singleton.test.ts`: 8 flag-on standalone cases (cross-producer `===`, loose eq, typeof, missing-vs-stored-null reads, dstr null-kept, `??`/`?.`/truthiness, ToString/ToNumber split, container TypeError) + a flag-off legacy control — 9/9 green.
- Related suites green: #1021, #1776, ir-nullish-coalesce, #1910d, #2979, #3010, #1103a, #2001 hole-literal, #2106 S0 (105 tests).
- Flag-off byte-inertness: sha256-identical corpus vs pre-change tree.
- #2949 coherence: tag-1 is the payload-less `JsTag.Undefined` partition; identity via tag test, per the lattice contract.

## Follow-ups (documented in the issue)

1. A/B standalone test262 with `JS2WASM_UNDEF_SINGLETON=1` (runner env, no code change).
2. Default flip as a one-line merge_group-validated PR if net-positive.
3. S2/S3/S4 remain per the plan.

Issue: plan/issues/2106-valuerep-p3-undefined-observability.md (stays in-progress — S1 delivered flagged; remaining slices open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8