### PR TITLE
feat(#2949 s3b): unify explicit `any` onto `dynamic` — one `any` ABI for both front-ends

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -636,6 +636,58 @@ externref there). Needs: the #1228 tests updated, a fast-mode cross-call
 probe (legacy caller → IR callee), and full CI. Do NOT fold into slice 3's
 lowering PR — separate, revertible.
 
+## Implementation Notes — Slice 3b (fable-2949s3, 2026-07-04, branch `issue-2949-slice3b-any-unification`, stacked on slice 3)
+
+Ships as planned: `resolvePositionType`'s AnyKeyword arm → `irDynamic()`
+(codegen/index.ts), the selector's AnyKeyword arms → `"dynamic"`, and the
+`"any"` ResolvedKind is DELETED. Findings beyond the plan:
+
+1. **`any[]` element preservation**: the AnyKeyword flip would have made
+   `resolvePositionType(any[])`'s element resolution return `dynamic` →
+   `null` elemVal → previously-claimed `any[]` functions silently drop to
+   legacy. Added an explicit `dynamic → externref` element arm in the
+   ArrayTypeNode case (element rep is #2379/#1852 territory, not 3b) —
+   byte-preserving, probe-verified. (Separately: the fast-mode any[]
+   IR-vs-legacy header divergence — legacy narrows to a different vec
+   type + i32 result — is PRE-EXISTING on main, probe-verified
+   side-by-side, untouched here.)
+2. **The plan's "fast-mode cross-call probe (legacy caller → IR callee)"
+   is unconstructible for top-level calls** — pinned in the tests: the
+   selector's call-graph-closure rule EVICTS a claimable any-callee when
+   a non-claimable function calls it, so mixed legacy→IR top-level edges
+   cannot exist. The ABI unification's cross-front-end exposure is the
+   export boundary, class-method claims (the typeIdx-parity guard now
+   MATCHES legacy in fast mode instead of demoting), and future producer
+   widenings. A future call-graph relaxation must revisit the ABI story —
+   the pinning test will fire.
+3. **Claim-then-demote channel closed**: the old `"any"` kind claimed
+   every any-param function unconditionally (from-ast threw on non-move
+   uses → post-claim demotion, NOT covered by gate 6 pre-3b since the
+   signature carried externref, not dynamic). Now any-annotated functions
+   run through `dynamicUsesAreMoveOnly` pre-claim (e.g. `a === b` on any
+   params: was claim→demote, now a clean `param-type-not-resolvable`
+   rejection) AND gate 6 covers the claims (dynamic signature ⇒
+   compile-twice under IR_FIRST).
+4. Byte-inert on the 39-hash corpus (no claimed any-functions there);
+   the behavior change is confined to any-annotated IR claims — fast-mode
+   signatures now equal legacy's (the FIX), host-mode bytes unchanged.
+
+## Test Results — Slice 3b (2026-07-04, fable-2949s3)
+
+- `tests/issue-2949-slice3b-any-dynamic.test.ts` — **8/8**: #1228 surface
+  stays claimed; `===`-on-any rejects PRE-claim with the scan's bucket;
+  mixed any/unannotated chains claim; host header parity (unchanged) and
+  **fast header parity — the FIX** (`func $f` == legacy's, NOT externref);
+  call-graph-closure eviction pinned; host-mode runtime identity across
+  number/string/null/undefined/bool/object; any[] claim + host header
+  parity + fast zero-demotion compile.
+- `tests/issue-1228.test.ts` 9/9 UNCHANGED (the `===` fallback test passes
+  via the new pre-claim rejection instead of post-claim demotion).
+- Slice 1/2/3 suites: 74/74 combined. `check:ir-fallbacks` OK, zero delta.
+- `prove-emit-identity` vs main baseline: IDENTICAL (39/39) — corpus has
+  no claimed any-functions; drift is confined to the intended population.
+- `npx tsc --noEmit` clean.
+
 ## Banked adoption slices (unlocked by this substrate; Opus-tier)
 
 ### A. #2963 Phase 2 — any-callable scalar-param dispatch

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -586,11 +586,17 @@ function resolvePositionType(
     if (node.kind === ts.SyntaxKind.NumberKeyword) return irVal({ kind: "f64" });
     if (node.kind === ts.SyntaxKind.BooleanKeyword) return irVal({ kind: "i32" });
     if (node.kind === ts.SyntaxKind.StringKeyword) return { kind: "string" };
-    // Slice 14 (#1228) — AnyKeyword lowers to externref. The IR's externref
-    // val type is the catch-all for host values; operations on `any`-typed
-    // SSA defs must be conservative (no field access, no arithmetic) but
-    // pass-through forwarding (return, parameter passing) is fine.
-    if (node.kind === ts.SyntaxKind.AnyKeyword) return irVal({ kind: "externref" });
+    // (#2949 slice 3b) AnyKeyword IS the dynamic type. The historical #1228
+    // mapping (externref in ALL modes) diverged from legacy's fast-mode
+    // `any` ABI — legacy `resolveWasmType` is mode-split (fast →
+    // `ref_null $AnyValue`, host → externref), so an IR-claimed
+    // `f(x: any)` had a DIFFERENT fast-mode signature than its legacy
+    // callers/callees (measured in the slice-2 session; class-method
+    // claims hit the typeIdx-parity guard for the same reason). `dynamic`
+    // lowers through `resolveDynamic()`, which mirrors that mode split
+    // exactly — one `any` ABI for both front-ends in both modes. Host-mode
+    // bytes are unchanged (dynamic lowers to externref there).
+    if (node.kind === ts.SyntaxKind.AnyKeyword) return irDynamic();
     // Slice 6 part 2 (#1181) — array type (T[] or Array<T>) resolves to a
     // vec ref. The legacy `getOrRegisterVecType` produces the same
     // (ref_null $vec_<elem>) struct ref the for-of vec fast path needs,
@@ -600,8 +606,17 @@ function resolvePositionType(
     // types throw and fall back to legacy.
     if (ts.isArrayTypeNode(node)) {
       const elemIr = resolvePositionType(node.elementType, undefined, ctx, classShapes);
+      // (#2949 slice 3b) `any[]` elements keep their historical externref
+      // vec representation — the AnyKeyword POSITION arm above now returns
+      // `dynamic`, but element storage is a vec-layout decision (the
+      // boxed-any element rep is #2379/#1852 territory, not this slice).
+      // Byte-preserving for every currently-claimed `any[]` shape.
       const elemVal =
-        elemIr.kind === "val" ? elemIr.val : elemIr.kind === "string" ? ({ kind: "externref" } as ValType) : null;
+        elemIr.kind === "val"
+          ? elemIr.val
+          : elemIr.kind === "string" || elemIr.kind === "dynamic"
+            ? ({ kind: "externref" } as ValType)
+            : null;
       if (!elemVal) {
         throw new Error(
           `array element TypeNode ${ts.SyntaxKind[node.elementType.kind]} could not be lowered to a primitive ValType`,

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -885,13 +885,13 @@ function isIrClaimable(
 //   JS-host: externref) — the SAME carrier legacy `resolveWasmType`'s
 //   any/unknown arm gives these positions, so IR-claimed and legacy functions
 //   agree on the ABI by construction. The claim is additionally gated by
-//   `dynamicUsesAreMoveOnly`: slice 2 has no box/unbox/tag.test lowering, so
-//   dynamic values may only MOVE. NOTE the deliberate asymmetry with the
-//   explicit `any` ANNOTATION, which keeps its historical externref mapping
-//   (the AnyKeyword arms): unifying `any` onto `dynamic` changes currently-
-//   claimed functions' fast-mode signatures and is deferred to slice 3 (where
-//   it fixes a real fast-mode ABI divergence — see the issue file).
-type ResolvedKind = "f64" | "bool" | "string" | "object" | "any" | "void" | "closure" | "dynamic" | null;
+//   `dynamicUsesAreMoveOnly`: producers are still move-only (box/unbox
+//   producer widening is the #2949 follow-up slice), so dynamic values may
+//   only MOVE. (#2949 slice 3b) The explicit `any` ANNOTATION now resolves
+//   "dynamic" too — the historical "any" kind (externref in all modes, no
+//   use gating) is deleted: it diverged from legacy's fast-mode `any` ABI
+//   and was the last claim-then-demote channel for non-move any-uses.
+type ResolvedKind = "f64" | "bool" | "string" | "object" | "void" | "closure" | "dynamic" | null;
 
 /**
  * #2859 — build an `IrClosureSignature` from an explicit function-type
@@ -933,11 +933,16 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
     if (p.type.kind === ts.SyntaxKind.NumberKeyword) return "f64";
     if (p.type.kind === ts.SyntaxKind.BooleanKeyword) return "bool";
     if (p.type.kind === ts.SyntaxKind.StringKeyword) return "string";
-    // Slice 14 (#1228) — `any` param lowers to externref. The IR's
-    // `resolvePositionType` returns `irVal({ kind: "externref" })` for
-    // AnyKeyword. JS spec leaves operations on `any` to runtime semantics,
-    // and externref is the catch-all that already accepts any host value.
-    if (p.type.kind === ts.SyntaxKind.AnyKeyword) return "any";
+    // (#2949 slice 3b) `any` IS the dynamic type. The historical #1228
+    // mapping ("any" kind → externref override) claimed EVERY any-param
+    // function unconditionally and relied on from-ast throwing for
+    // non-move uses — a claim-then-demote channel; it also pinned the
+    // fast-mode carrier to externref, diverging from legacy's mode-split
+    // `any` ABI (fast → ref_null $AnyValue). Resolving `dynamic` here
+    // routes any-params through the SAME move-only scan + carrier as
+    // unannotated dynamics: non-move uses now reject PRE-claim (no
+    // demotion), and the claimed ones share legacy's ABI in both modes.
+    if (p.type.kind === ts.SyntaxKind.AnyKeyword) return "dynamic";
     // #2859 — function-typed param (`fn: () => number`). Accepted when the
     // signature is expressible with the slice-3 closure surface; the param
     // lowers to the closure supertype struct and `fn()` dispatches through
@@ -988,8 +993,9 @@ function resolveReturnType(
     if (fn.type.kind === ts.SyntaxKind.StringKeyword) return "string";
     // Slice 14 (#1228) — `void` return: function has zero result types.
     if (fn.type.kind === ts.SyntaxKind.VoidKeyword) return "void";
-    // Slice 14 (#1228) — `any` return lowers to externref (same as for params).
-    if (fn.type.kind === ts.SyntaxKind.AnyKeyword) return "any";
+    // (#2949 slice 3b) `any` return IS the dynamic type (same rationale as
+    // the param arm — one `any` ABI, move-only-scanned).
+    if (fn.type.kind === ts.SyntaxKind.AnyKeyword) return "dynamic";
     if (ts.isTypeLiteralNode(fn.type) || ts.isTypeReferenceNode(fn.type) || ts.isArrayTypeNode(fn.type))
       return "object";
     return null;

--- a/tests/issue-2949-slice3b-any-dynamic.test.ts
+++ b/tests/issue-2949-slice3b-any-dynamic.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 slice 3b — unify the explicit `any` annotation onto `dynamic`.
+//
+// Before this slice, `x: any` mapped to externref in ALL modes (the #1228
+// "any" ResolvedKind + resolvePositionType's AnyKeyword arm), which had two
+// measured defects (slice-2 session, WAT-diff evidence in the issue file):
+//
+//   1. FAST-MODE ABI DIVERGENCE: legacy `resolveWasmType`'s any-arm is
+//      mode-split (fast → `ref_null $AnyValue`, host → externref), so an
+//      IR-claimed `f(x: any): any` had a DIFFERENT fast-mode signature than
+//      legacy callers/callees expect (and any-annotated class methods hit
+//      the typeIdx-parity guard for the same reason).
+//   2. CLAIM-THEN-DEMOTE: the "any" kind claimed every any-param function
+//      unconditionally and relied on from-ast throwing for non-move uses.
+//
+// Now AnyKeyword resolves `dynamic` in both the selector and
+// `resolvePositionType`: any-annotated positions share the unannotated
+// dynamics' carrier (legacy-ABI-lockstep via resolveDynamic), the move-only
+// scan gates uses PRE-claim, and gate 6 keeps the claims compile-twice under
+// JS2WASM_IR_FIRST. `any[]` ELEMENTS deliberately keep the externref vec
+// representation (element rep is #2379/#1852 territory) — byte-preserving.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/index.js";
+import { buildTypeMap } from "../src/ir/propagate.js";
+import { buildImports } from "../src/runtime.js";
+
+/** Selector verdict with a real checker-backed TypeMap (production shape —
+ *  same harness as the slice-2 tests; the unannotated-dynamic arms need the
+ *  propagation lattice, annotation-only sources don't). */
+function selectionFor(source: string): { claimed: Set<string>; fallbacks: Map<string, string> } {
+  const host = ts.createCompilerHost({});
+  const sfRaw = ts.createSourceFile("t.ts", source, ts.ScriptTarget.ES2022, true);
+  const program = ts.createProgram({
+    rootNames: ["t.ts"],
+    options: { allowJs: true },
+    host: {
+      ...host,
+      getSourceFile: (fn, lv) => (fn === "t.ts" ? sfRaw : host.getSourceFile(fn, lv)),
+      fileExists: (fn) => fn === "t.ts" || host.fileExists(fn),
+      readFile: (fn) => (fn === "t.ts" ? source : host.readFile(fn)),
+    },
+  });
+  const sf = program.getSourceFile("t.ts")!;
+  const typeMap = buildTypeMap(sf, program.getTypeChecker());
+  const sel = planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true }, typeMap);
+  const fallbacks = new Map<string, string>();
+  for (const fb of sel.fallbacks ?? []) fallbacks.set(fb.name, fb.reason);
+  return { claimed: new Set(sel.funcs), fallbacks };
+}
+
+async function compileStrict(source: string, opts: Record<string, unknown> = {}) {
+  const r = await compile(source, { fileName: "t.ts", ...opts });
+  expect(r.success, r.errors[0]?.message).toBe(true);
+  // Zero post-claim demotions — the any→dynamic unification must be
+  // exactly as build-proof as the unannotated dynamic path.
+  expect(r.irPostClaimErrors ?? []).toEqual([]);
+  return r;
+}
+
+async function instantiate(r: Awaited<ReturnType<typeof compile>>): Promise<Record<string, Function>> {
+  const built = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+/** The `(func $f …` header line (signature) from the WAT. */
+function funcHeader(wat: string, name: string): string | undefined {
+  return wat.split("\n").find((l) => l.includes(`(func $${name} `) || l.includes(`(func $${name}(`));
+}
+
+// ---------------------------------------------------------------------------
+// Selector — any-annotated shapes route through the dynamic gate
+// ---------------------------------------------------------------------------
+
+describe("#2949 s3b — selector: `any` is dynamic", () => {
+  it("move-shaped any functions stay claimed (the #1228 surface)", () => {
+    const { claimed } = selectionFor(`
+      export function takesAny(x: any): number { return 1; }
+      export function pass(x: any): any { return x; }
+      function noop(x: any): number { return 1; }
+      export function helper(x: any, y: any): void { noop(x); noop(y); }
+    `);
+    expect(claimed.has("takesAny")).toBe(true);
+    expect(claimed.has("pass")).toBe(true);
+    expect(claimed.has("noop")).toBe(true);
+    expect(claimed.has("helper")).toBe(true);
+  });
+
+  it("non-move any uses now reject PRE-claim (no claim-then-demote channel)", () => {
+    const { claimed, fallbacks } = selectionFor(`
+      export function isSame(a: any, b: any): number {
+        if (a === b) { return 1; }
+        return 0;
+      }
+    `);
+    expect(claimed.has("isSame")).toBe(false);
+    // The move-only scan's bucket, not a post-claim from-ast throw.
+    expect(fallbacks.get("isSame")).toBe("param-type-not-resolvable");
+  });
+
+  it("mixed any/unannotated pass-through chains claim (one dynamic world)", () => {
+    const { claimed } = selectionFor(`
+      function g(x) { return x; }
+      export function f(x: any): any { return g(x); }
+    `);
+    expect(claimed.has("g")).toBe(true);
+    expect(claimed.has("f")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ABI — the fast-mode divergence is FIXED
+// ---------------------------------------------------------------------------
+
+describe("#2949 s3b — `any` shares legacy's mode-split ABI", () => {
+  const src = `export function f(x: any): any { return x; }`;
+
+  it("host mode: same `func $f` header as experimentalIR:false (externref, unchanged)", async () => {
+    const ir = await compileStrict(src, { wat: true });
+    const legacy = await compile(src, { fileName: "t.ts", experimentalIR: false, wat: true });
+    expect(legacy.success).toBe(true);
+    expect(funcHeader(ir.wat, "f")).toBeDefined();
+    expect(funcHeader(ir.wat, "f")).toBe(funcHeader(legacy.wat, "f"));
+  });
+
+  it("fast mode: same `func $f` header as experimentalIR:false — the FIX (was externref, now $AnyValue ref)", async () => {
+    const ir = await compileStrict(src, { fast: true, wat: true });
+    const legacy = await compile(src, { fileName: "t.ts", fast: true, experimentalIR: false, wat: true });
+    expect(legacy.success).toBe(true);
+    const irHeader = funcHeader(ir.wat, "f");
+    expect(irHeader).toBeDefined();
+    expect(irHeader).toBe(funcHeader(legacy.wat, "f"));
+    // The pre-3b divergence was exactly this: externref where legacy had the
+    // $AnyValue carrier.
+    expect(irHeader).not.toContain("externref");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-front-end exposure — pinned facts
+// ---------------------------------------------------------------------------
+
+describe("#2949 s3b — mixed legacy/IR call edges", () => {
+  it("call-graph closure PREVENTS a legacy top-level caller of an IR any-callee (pinned)", () => {
+    // Probed during this slice: when a non-claimable function (`driver`,
+    // `===` on any) calls a claimable any-function, the selector's
+    // call-graph-closure rule evicts the callee too — so mixed
+    // legacy-caller → IR-callee TOP-LEVEL edges cannot exist. The fast-mode
+    // ABI unification's cross-front-end exposure is therefore at the
+    // EXPORT boundary, method claims (typeIdx parity), and future producer
+    // widenings — not top-level direct calls. Pin the eviction so a future
+    // call-graph relaxation revisits the ABI story consciously.
+    const { claimed, fallbacks } = selectionFor(`
+      export function pass(x: any): any { return x; }
+      export function driver(): number {
+        const v: any = 7;
+        const r: any = pass(v);
+        if (r === v) { return 1; }
+        return 0;
+      }
+    `);
+    expect(claimed.has("pass")).toBe(false);
+    expect(claimed.has("driver")).toBe(false);
+    expect(fallbacks.get("pass")).toBe("call-graph-closure");
+    // Without the legacy caller, the same callee claims.
+    const solo = selectionFor(`export function pass(x: any): any { return x; }`);
+    expect(solo.claimed.has("pass")).toBe(true);
+  });
+
+  it("claimed any-functions run identity in host mode; fast mode compiles with zero demotions", async () => {
+    // Same proof standard as slice 2: fast-mode RUNTIME entry into an
+    // any-signature export needs a JS-constructible carrier ($AnyValue is
+    // not), so fast mode is proven at compile + header level and host mode
+    // at runtime.
+    const src = `export function pass(x: any): any { return x; }`;
+    const host = await compileStrict(src);
+    const hx = await instantiate(host);
+    for (const v of [42, "hello", null, undefined, true]) {
+      expect((hx.pass as (v: unknown) => unknown)(v)).toBe(v);
+    }
+    const obj = { a: 1 };
+    expect((hx.pass as (v: unknown) => unknown)(obj)).toBe(obj);
+    await compileStrict(src, { fast: true }); // zero demotions asserted inside
+  });
+});
+
+// ---------------------------------------------------------------------------
+// any[] — element representation preserved
+// ---------------------------------------------------------------------------
+
+describe("#2949 s3b — any[] keeps the externref vec element rep", () => {
+  it("an any[]-param function still claims and keeps the legacy vec signature", async () => {
+    // (A runnable in-module caller is not IR-expressible yet — an `any[]`
+    // local declaration body-shape-rejects the caller and the call-graph
+    // closure then evicts `count` too — so the proof is claim + build +
+    // byte-level signature parity with legacy, which is what the element-rep
+    // preservation is about.)
+    const src = `export function count(xs: any[]): number { return xs.length; }`;
+    const { claimed } = selectionFor(src);
+    expect(claimed.has("count")).toBe(true);
+    // Host mode: IR and legacy agree on the vec-of-externref signature —
+    // unchanged by 3b.
+    const ir = await compileStrict(src, { wat: true });
+    const legacy = await compile(src, { fileName: "t.ts", experimentalIR: false, wat: true });
+    expect(legacy.success).toBe(true);
+    expect(funcHeader(ir.wat, "count")).toBeDefined();
+    expect(funcHeader(ir.wat, "count")).toBe(funcHeader(legacy.wat, "count"));
+    // Fast mode: compile + zero demotions. (The IR-vs-legacy fast-mode any[]
+    // header divergence — legacy narrows to (ref null $vec30)/i32 — is
+    // PRE-EXISTING on main, probe-verified side-by-side, and untouched by
+    // 3b; the elem-rep preservation is proven byte-level by the
+    // prove-emit-identity oracle staying IDENTICAL corpus-wide.)
+    await compileStrict(src, { fast: true });
+  });
+});


### PR DESCRIPTION
## #2949 slice 3b — `any` IS the dynamic type

Follow-up to #2632 (slice 3, merged). `resolvePositionType`'s AnyKeyword arm now returns `irDynamic()` and the selector's AnyKeyword arms resolve `"dynamic"`; the historical `"any"` ResolvedKind is deleted.

### What this fixes (both measured in the slice-2 session, WAT evidence in the issue file)
1. **Fast-mode ABI divergence**: legacy `resolveWasmType`'s any-arm is mode-split (fast → `ref_null $AnyValue`, host → externref) but the IR mapped `x: any` to externref in ALL modes — an IR-claimed `f(x: any): any` had a different fast-mode signature than legacy expects (and any-annotated class methods tripped the typeIdx-parity guard). `dynamic` lowers through `resolveDynamic()`, which mirrors the legacy split exactly. Host-mode bytes unchanged.
2. **Claim-then-demote channel**: the `"any"` kind claimed every any-param function unconditionally and relied on from-ast throwing for non-move uses (post-claim demotion, NOT covered by gate 6 since the signature carried externref). Any-annotated functions now run through the move-only scan PRE-claim (`a === b` on any params: clean `param-type-not-resolvable` rejection) and gate 6 covers the claims under `JS2WASM_IR_FIRST`.

### Guard rails
- `any[]` **elements keep the externref vec rep** (explicit element arm — element rep is #2379/#1852 territory); probe-verified byte-preserving, host header parity asserted.
- **Pinned fact**: the call-graph-closure rule evicts a claimable any-callee under a legacy caller, so mixed legacy→IR top-level call edges cannot exist — the ABI fix's exposure is the export boundary, method parity, and future producer widenings. A future call-graph relaxation trips the pinning test.

### Evidence
- `tests/issue-2949-slice3b-any-dynamic.test.ts` — 8/8: fast-mode header parity (the FIX — `func $f` byte-equal to legacy, NOT externref), host parity unchanged, pre-claim rejection buckets, host runtime identity across number/string/null/undefined/bool/object, any[] preservation.
- `tests/issue-1228.test.ts` 9/9 UNCHANGED; 74/74 across the #2949 suites; `check:ir-fallbacks` zero delta.
- `prove-emit-identity` vs main: IDENTICAL (39/39) — the corpus has no claimed any-functions; drift is confined to the intended population.
- Pre-existing divergences verified by side-by-side probes on clean main (fast-mode any[] header narrowing; `unknown class` method-driver demotion) — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8