### PR TITLE
refactor(#2957): extract maybeActivateAsync shared async-activation entry point (phase 1)

### DIFF
--- a/plan/issues/2957-async-activation-arrows-methods.md
+++ b/plan/issues/2957-async-activation-arrows-methods.md
@@ -1,10 +1,11 @@
 ---
 id: 2957
 title: "Async activation for arrows / methods / function expressions (both CPS + drive hooks are declaration-only)"
-status: ready
+status: in-progress
+assignee: ttraenkler/opus-2957p1
 sprint: current
 created: 2026-07-02
-updated: 2026-07-03
+updated: 2026-07-04
 priority: medium
 horizon: l
 feasibility: medium
@@ -146,3 +147,44 @@ edit `closures.ts` / `class-bodies.ts` and lean on `buildAsyncFrameInfo` /
 `ensureAsyncResumeFunction` — high collision surface. Recommend landing this
 **after** the #2895 async-frame series settles, and re-scoping to `horizon: l`
 (done). Slice 1 (the refactor) is safe to land now and de-risks the rest.
+
+## Phase 1 landed (2026-07-04, opus-2957p1) — shared entry point extracted
+
+Slice 1 (the byte-inert refactor) is complete. The two async activation
+blocks in `compileFunctionBody` (`function-body.ts`, formerly ~1160–1210)
+plus the local `rewriteFuncResultType` helper were extracted verbatim into a
+new shared module `src/codegen/async-activation.ts`, exporting:
+
+```ts
+export function maybeActivateAsync(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  decl: ts.FunctionLikeDeclaration,   // widened from FunctionDeclaration for phases 2–3
+  func: WasmFunction,
+): boolean            // true ⇒ caller skips its statement loop (body already emitted)
+```
+
+`compileFunctionBody` now calls it; the internal `ts.isFunctionDeclaration`
+guards are preserved unchanged, so **declaration** activation is untouched.
+
+**Byte-inert proof (acceptance gate):** compiling the full
+`website/playground/examples` + `examples` corpus (26 sources) × {gc, wasi,
+standalone} plus all four async shapes (`decl`/`arrow`/`fnexpr`/`method`) +
+multi-await, then sha256-ing every emitted binary, yields the identical
+`CORPUS_SHA256=161cd89fb5a298fb86c76af6fcdcd787f42f340ba6ce988fecaf08cc78a18d4b`
+before and after the change (62 compiles, 16 CE, all matching). `tsc --noEmit`
+clean.
+
+**Re-grounding note (#2906 hazard check):** the async-frame area was reshaped
+by #2906's multi-state CFG machine this week. Re-verified against current main
+(`1f77d0f70`): the two activation hooks are structurally intact (drive-lane +
+CPS/host-drive lane, both still `ts.isFunctionDeclaration`-gated), so phase 1
+remained a clean byte-identical extraction. No re-scope needed.
+
+**Phases 2–3 remain open** (the real behaviour change): wire
+`maybeActivateAsync` into `compileArrowFunction` (`closures.ts`) for
+fn-exprs+arrows, then class/object-literal methods (`class-bodies.ts` /
+`literals.ts`). These require the `envParam`/`selfParamCount` threading into
+`buildAsyncFrameInfo` described in the Implementation Plan above and interact
+with the still-active async-frame branches — higher risk, schedule after that
+series settles.

--- a/plan/issues/2957-async-activation-arrows-methods.md
+++ b/plan/issues/2957-async-activation-arrows-methods.md
@@ -59,12 +59,12 @@ subset; test262 async tests overwhelmingly use arrows and methods.
 Canonical single-tail-await body `await g(x)` in all four shapes, compiled
 host-mode, `f(1)` inspected in JS for `typeof result.then === 'function'`:
 
-| shape                    | `f(1)` returns        | activated? |
-| ------------------------ | --------------------- | ---------- |
-| `async function` decl    | real Promise (→ 2)    | YES        |
-| `const f = async () =>`  | sync number `2`       | **NO**     |
-| `const f = async fn(){}` | sync number `2`       | **NO**     |
-| class `async method`     | sync number `2`       | **NO**     |
+| shape                    | `f(1)` returns     | activated? |
+| ------------------------ | ------------------ | ---------- |
+| `async function` decl    | real Promise (→ 2) | YES        |
+| `const f = async () =>`  | sync number `2`    | **NO**     |
+| `const f = async fn(){}` | sync number `2`    | **NO**     |
+| class `async method`     | sync number `2`    | **NO**     |
 
 Confirms the bug for all three non-declaration shapes. (Note a naive probe
 that assigns the result into an `any`/externref slot and checks
@@ -102,7 +102,7 @@ Good news: the machinery is already shape-agnostic below the hook. All of
 `asyncFnNeedsHostDrive`, `emitAsyncStateMachine`, and
 `emitAsyncFrameStateMachine` already take `ts.FunctionLikeDeclaration` and
 build the frame from `fctx.params` + the body — no declaration assumption in
-the emitters themselves. The gap is purely that nobody *calls* them from the
+the emitters themselves. The gap is purely that nobody _calls_ them from the
 arrow/method paths.
 
 Recommended factoring: extract the activation block from `function-body.ts`
@@ -159,9 +159,9 @@ new shared module `src/codegen/async-activation.ts`, exporting:
 export function maybeActivateAsync(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  decl: ts.FunctionLikeDeclaration,   // widened from FunctionDeclaration for phases 2–3
+  decl: ts.FunctionLikeDeclaration, // widened from FunctionDeclaration for phases 2–3
   func: WasmFunction,
-): boolean            // true ⇒ caller skips its statement loop (body already emitted)
+): boolean; // true ⇒ caller skips its statement loop (body already emitted)
 ```
 
 `compileFunctionBody` now calls it; the internal `ts.isFunctionDeclaration`

--- a/src/codegen/async-activation.ts
+++ b/src/codegen/async-activation.ts
@@ -1,0 +1,113 @@
+// (#2957 phase 1) Shared async state-machine activation entry point.
+//
+// The async/await CPS + drive activation logic was previously inlined inside
+// `compileFunctionBody` and gated on `ts.isFunctionDeclaration`, so it was
+// unreachable from the arrow (`closures.ts`), class-method (`class-bodies.ts`)
+// and object-literal-method (`literals.ts`) body-compile paths — those shapes
+// silently fell through to the legacy synchronous pass-through and never
+// activated a state machine (#2957 root-cause).
+//
+// This module factors that block into a single reusable
+// `maybeActivateAsync(ctx, fctx, decl, func)` helper. Phase 1 is a **pure,
+// byte-inert extraction**: `compileFunctionBody` calls it and the internal
+// `ts.isFunctionDeclaration` guards are preserved verbatim, so no shape's
+// emitted bytes change. Phases 2–3 wire the same entry point into the three
+// other body-compile paths (the real behaviour change) and, at that point,
+// relax the declaration guards.
+
+import { ts } from "../ts-api.js";
+import type { ValType, WasmFunction } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { addFuncType } from "./registry/types.js";
+import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps, emitAsyncStateMachine } from "./async-cps.js";
+import { emitAsyncFrameStateMachine, asyncFnNeedsDrive, asyncFnNeedsHostDrive } from "./async-frame.js";
+import { isStandalonePromiseActive } from "./async-scheduler.js";
+
+/**
+ * Rewrite a compiled function's registered result type. An activated async
+ * function returns a real Promise object (externref), not the unwrapped value.
+ */
+function rewriteFuncResultType(ctx: CodegenContext, func: WasmFunction, result: ValType): void {
+  const ft = ctx.mod.types[func.typeIdx];
+  if (!ft || ft.kind !== "func") return;
+  func.typeIdx = addFuncType(ctx, ft.params.slice(), [result]);
+}
+
+/**
+ * Decide whether `decl` should be lowered to an async state machine, and if so
+ * emit it (rewriting the result type to externref and emitting the frame/CPS
+ * body). Returns `true` when the async machine was emitted — in which case the
+ * caller MUST skip its normal statement-compilation loop, because this helper
+ * has already produced the full function body.
+ *
+ * Byte-inert extraction of the two activation blocks from
+ * `compileFunctionBody` (#2957 phase 1). The `ts.isFunctionDeclaration` guards
+ * are intentionally preserved: phase 1 changes no shape's behaviour. The `decl`
+ * parameter is typed as `ts.FunctionLikeDeclaration` so phases 2–3 can call
+ * this from the arrow/method paths without a signature change.
+ */
+export function maybeActivateAsync(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  decl: ts.FunctionLikeDeclaration,
+  func: WasmFunction,
+): boolean {
+  const isAsync = ctx.asyncFunctions.has(func.name);
+
+  let asyncCpsHandled = false;
+  // (#2895 PATH B) Host-free async drive layer. Gated on the native-`$Promise`
+  // *carrier* (`isStandalonePromiseActive`, currently `wasi`-only): when the
+  // awaited operand resolves to a native `$Promise`, a genuinely-suspending
+  // async fn is driven by a real resumable `$AsyncFrame` (await → spill +
+  // reaction + return result-promise; microtask drain resumes). Gating the
+  // wiring on the carrier predicate makes the standalone re-widen (#2895 1d)
+  // flip the carrier AND the drive layer together — exactly the AG0-safe
+  // coupling. The result is a real `$Promise` (externref), not a sync value.
+  if (ASYNC_CPS_ENABLED && isAsync && isStandalonePromiseActive(ctx) && ts.isFunctionDeclaration(decl) && decl.body) {
+    const asyncPlan = analyzeAsyncBody(ctx, decl);
+    // (#2906) Drive-layer eligibility now accepts linear MULTI-await bodies,
+    // not just the single canonical await `asyncFnNeedsCps` gates on. For a
+    // single await the verdict is identical, so wasi single-await routing is
+    // unchanged; ≥2 sequential awaits (previously demoted to the AG0 unwrap)
+    // now get the general N-state resume machine.
+    if (asyncFnNeedsDrive(ctx, decl, asyncPlan)) {
+      rewriteFuncResultType(ctx, func, { kind: "externref" });
+      fctx.returnType = { kind: "externref" };
+      emitAsyncFrameStateMachine(ctx, fctx, decl, asyncPlan);
+      asyncCpsHandled = true;
+    }
+  }
+  if (
+    !asyncCpsHandled &&
+    ASYNC_CPS_ENABLED &&
+    isAsync &&
+    !ctx.wasi &&
+    !ctx.standalone &&
+    ts.isFunctionDeclaration(decl) &&
+    decl.body
+  ) {
+    const asyncPlan = analyzeAsyncBody(ctx, decl);
+    if (asyncFnNeedsCps(decl, asyncPlan)) {
+      // The async function returns a Promise object (externref), not the
+      // unwrapped value. Rewrite the registered signature's result + fctx.
+      rewriteFuncResultType(ctx, func, { kind: "externref" });
+      fctx.returnType = { kind: "externref" };
+      fctx.asyncCpsActive = true;
+      emitAsyncStateMachine(ctx, fctx, decl, asyncPlan);
+      asyncCpsHandled = true;
+    } else if (asyncFnNeedsHostDrive(ctx, decl, asyncPlan)) {
+      // (#1042 July re-scope) JS-host lane onto the #2906 N-state resume
+      // machine with HOST-Promise settle adapters. Claims only the linear
+      // shapes the single-tail-await CPS lane rejects (multi-await,
+      // try/finally-across-await) — those previously fell through to the
+      // legacy synchronous fakery and returned wrong values under genuine
+      // suspension. Same externref result contract as the CPS lane.
+      rewriteFuncResultType(ctx, func, { kind: "externref" });
+      fctx.returnType = { kind: "externref" };
+      emitAsyncFrameStateMachine(ctx, fctx, decl, asyncPlan, /*host*/ true);
+      asyncCpsHandled = true;
+    }
+  }
+
+  return asyncCpsHandled;
+}

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -28,7 +28,7 @@ import {
   resolveWasmType,
 } from "./index.js";
 import { ensureExnTag } from "./registry/imports.js";
-import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
   coerceType,
   compileExpression,
@@ -52,9 +52,7 @@ import { detectStringBuilders, type StringBuilderPresizeInfo } from "./string-bu
 import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
 import { compileNativeGeneratorFunction } from "./generators-native.js";
-import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps, emitAsyncStateMachine } from "./async-cps.js";
-import { emitAsyncFrameStateMachine, asyncFnNeedsDrive, asyncFnNeedsHostDrive } from "./async-frame.js";
-import { isStandalonePromiseActive } from "./async-scheduler.js";
+import { maybeActivateAsync } from "./async-activation.js";
 import {
   functionHasLinearU8Params,
   getLinearU8ParamIndicesForDeclaration,
@@ -129,12 +127,6 @@ function findTdzViolatingParamRef(decl: ts.FunctionLikeDeclarationBase, paramInd
  * CPS hook to switch an async function's result from its unwrapped value type
  * to `externref` (it returns a Promise object).
  */
-function rewriteFuncResultType(ctx: CodegenContext, func: WasmFunction, result: ValType): void {
-  const ft = ctx.mod.types[func.typeIdx];
-  if (!ft || ft.kind !== "func") return;
-  func.typeIdx = addFuncType(ctx, ft.params.slice(), [result]);
-}
-
 /** Set of instruction ops that disqualify a function body from inlining */
 export const INLINE_DISALLOWED_OPS = new Set([
   "block",
@@ -1136,77 +1128,15 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       // to be available before their textual position in the enclosing scope.
       hoistFunctionDeclarations(ctx, fctx, bodyStatements);
 
-      // (#1042/#1796) Async/await CPS state-machine activation hook. Gated by
-      // the per-function `asyncFnNeedsCps` predicate (#1936): a JS-host async
-      // function is CPS-lowered ONLY when it *genuinely suspends* — at least one
-      // await operand is not statically resolved AND the body matches a single
-      // tail-await canonical shape (no try-across-await / nested await). Fully
-      // await-elidable bodies (`return await Promise.resolve(42)`) fall through
-      // to the legacy synchronous path and keep returning the unwrapped value,
-      // preserving the `asyncFn() as any as number` "compile away" idiom
-      // (#1313/#1727). On a match we rewrite the result type to externref (the
-      // fn now returns a real Promise object), drive emitAsyncStateMachine, and
-      // skip the normal statement loop.
-      let asyncCpsHandled = false;
-      // (#2895 PATH B) Host-free async drive layer. Gated on the native-`$Promise`
-      // *carrier* (`isStandalonePromiseActive`, currently `wasi`-only): when the
-      // awaited operand resolves to a native `$Promise`, a genuinely-suspending
-      // async fn is driven by a real resumable `$AsyncFrame` (await → spill +
-      // reaction + return result-promise; microtask drain resumes). Gating the
-      // wiring on the carrier predicate makes the standalone re-widen (#2895 1d)
-      // flip the carrier AND the drive layer together — exactly the AG0-safe
-      // coupling. The result is a real `$Promise` (externref), not a sync value.
-      if (
-        ASYNC_CPS_ENABLED &&
-        isAsync &&
-        isStandalonePromiseActive(ctx) &&
-        ts.isFunctionDeclaration(decl) &&
-        decl.body
-      ) {
-        const asyncPlan = analyzeAsyncBody(ctx, decl);
-        // (#2906) Drive-layer eligibility now accepts linear MULTI-await bodies,
-        // not just the single canonical await `asyncFnNeedsCps` gates on. For a
-        // single await the verdict is identical, so wasi single-await routing is
-        // unchanged; ≥2 sequential awaits (previously demoted to the AG0 unwrap)
-        // now get the general N-state resume machine.
-        if (asyncFnNeedsDrive(ctx, decl, asyncPlan)) {
-          rewriteFuncResultType(ctx, func, { kind: "externref" });
-          fctx.returnType = { kind: "externref" };
-          emitAsyncFrameStateMachine(ctx, fctx, decl, asyncPlan);
-          asyncCpsHandled = true;
-        }
-      }
-      if (
-        !asyncCpsHandled &&
-        ASYNC_CPS_ENABLED &&
-        isAsync &&
-        !ctx.wasi &&
-        !ctx.standalone &&
-        ts.isFunctionDeclaration(decl) &&
-        decl.body
-      ) {
-        const asyncPlan = analyzeAsyncBody(ctx, decl);
-        if (asyncFnNeedsCps(decl, asyncPlan)) {
-          // The async function returns a Promise object (externref), not the
-          // unwrapped value. Rewrite the registered signature's result + fctx.
-          rewriteFuncResultType(ctx, func, { kind: "externref" });
-          fctx.returnType = { kind: "externref" };
-          fctx.asyncCpsActive = true;
-          emitAsyncStateMachine(ctx, fctx, decl, asyncPlan);
-          asyncCpsHandled = true;
-        } else if (asyncFnNeedsHostDrive(ctx, decl, asyncPlan)) {
-          // (#1042 July re-scope) JS-host lane onto the #2906 N-state resume
-          // machine with HOST-Promise settle adapters. Claims only the linear
-          // shapes the single-tail-await CPS lane rejects (multi-await,
-          // try/finally-across-await) — those previously fell through to the
-          // legacy synchronous fakery and returned wrong values under genuine
-          // suspension. Same externref result contract as the CPS lane.
-          rewriteFuncResultType(ctx, func, { kind: "externref" });
-          fctx.returnType = { kind: "externref" };
-          emitAsyncFrameStateMachine(ctx, fctx, decl, asyncPlan, /*host*/ true);
-          asyncCpsHandled = true;
-        }
-      }
+      // (#1042/#1796/#2895/#2906) Async/await state-machine activation. The
+      // CPS (host) + drive (standalone/host) gating, result-type rewrite, and
+      // emitter dispatch were extracted into `maybeActivateAsync` (#2957
+      // phase 1) so the arrow/method/object-literal body-compile paths can
+      // reuse the exact same entry point in phases 2–3. On a match the helper
+      // has already emitted the full body, so the normal statement loop below
+      // is skipped. Byte-inert: the internal `ts.isFunctionDeclaration` guards
+      // are preserved, so declaration activation is unchanged.
+      const asyncCpsHandled = maybeActivateAsync(ctx, fctx, decl, func);
 
       if (!asyncCpsHandled) {
         for (const stmt of bodyStatements) {


### PR DESCRIPTION
## #2957 phase 1 — byte-inert extraction

Extracts the two async state-machine activation blocks from
`compileFunctionBody` (`src/codegen/function-body.ts`, drive lane +
CPS/host-drive lane) plus the local `rewriteFuncResultType` helper into a
new shared module **`src/codegen/async-activation.ts`**, exporting:

```ts
maybeActivateAsync(ctx, fctx, decl: ts.FunctionLikeDeclaration, func): boolean
// true ⇒ caller skips its statement loop (async body already emitted)
```

`compileFunctionBody` now calls it. This is a **pure, byte-inert extraction**
(slice 1 of the banked 3-phase plan): the internal `ts.isFunctionDeclaration`
guards are preserved verbatim, so no shape's emitted bytes change. The `decl`
param is widened to `ts.FunctionLikeDeclaration` so **phases 2–3** can wire the
same entry point into the arrow (`closures.ts`) and method
(`class-bodies.ts` / `literals.ts`) body-compile paths — the actual behaviour
change that makes async arrows/methods/fn-exprs activate. Those remain open.

## Proof (acceptance gate: byte-identical)

Compiling the full `website/playground/examples` + `examples` corpus (26
sources) × {gc, wasi, standalone} plus all four async shapes
(`decl`/`arrow`/`fnexpr`/`method`) + multi-await, then sha256-ing every
emitted binary, yields the **identical**
`CORPUS_SHA256=161cd89fb5a298fb86c76af6fcdcd787f42f340ba6ce988fecaf08cc78a18d4b`
before and after the change (62 compiles, 16 CE, all matching). `tsc --noEmit`
clean.

## #2906 hazard re-grounding

The async-frame area was reshaped by #2906's multi-state CFG machine this
week. Re-verified against current main: no commit touched
`function-body.ts` / `async-cps.ts` / `async-frame.ts` in the merged range,
the two activation hooks are structurally intact, and phase 1 stayed a clean
byte-identical extraction. No re-scope needed.

Issue #2957 stays `in-progress` (phases 2–3 pending) — this PR does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)