### PR TITLE
docs(website): blog intro expansion + chart layout fix (no box, uncut donuts)

### DIFF
--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -133,19 +133,24 @@
         color: var(--fg);
       }
 
-      /* ── Conformance charts (landing donut + timeline components) ── */
+      /* ── Conformance charts (landing donut + timeline components) ──
+         No surrounding box. The chart block breaks out wider than the text
+         column so both donuts get their full ~380px orbit without clipping. */
       .figure {
-        margin: 26px 0;
-        padding: 24px 22px 20px;
-        background: var(--surface);
-        border: 1px solid var(--line);
-        border-radius: 12px;
+        margin: 34px 0;
+        padding: 0;
+        background: none;
+        border: none;
+        width: min(860px, calc(100vw - 32px));
+        margin-left: 50%;
+        transform: translateX(-50%);
       }
 
       .donut-pair {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        gap: 16px;
+        gap: 20px;
+        align-items: center;
       }
 
       .donut-cell {
@@ -157,13 +162,14 @@
 
       .donut-cell t262-donut {
         width: 100%;
-        max-width: 240px;
+        max-width: 400px;
       }
 
       .trend-wrap {
-        margin-top: 24px;
-        padding-top: 22px;
+        margin: 20px auto 0;
+        padding-top: 26px;
         border-top: 1px solid var(--line);
+        max-width: 720px;
       }
 
       .trend-title {
@@ -179,13 +185,14 @@
       .figure .foot {
         font-size: 12px;
         color: var(--fg-faint);
-        margin: 20px 0 0;
+        margin: 18px auto 0;
+        max-width: 720px;
       }
 
-      @media (max-width: 560px) {
+      @media (max-width: 640px) {
         .donut-pair {
           grid-template-columns: 1fr;
-          gap: 24px;
+          gap: 8px;
         }
       }
 

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -360,8 +360,10 @@
           code at a granular level, and make code modular and reusable so that less code has to be generated, reviewed,
           and maintained in the first place. Small WebAssembly modules also make review — by a human or a machine — far
           easier: fine-grained modularization keeps each piece small and self-contained instead of one giant one-off
-          monolithic codebase. WebAssembly lends itself as a lightweight, portable, modular, and safe substrate for
-          building a new, trustworthy foundation for computing in the age of untrusted code.
+          monolithic codebase. That same fine granularity, along with portability across hosts and language-independent
+          module APIs, makes these modules far more reusable — write a piece once and compose it anywhere, in any
+          language. WebAssembly lends itself as a lightweight, portable, modular, and safe substrate for building a new,
+          trustworthy foundation for computing in the age of untrusted code.
         </p>
 
         <h2>The idea in a nutshell</h2>

--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -354,9 +354,14 @@
           where that's structurally impossible, not just discouraged by a policy.
         </p>
         <p>
-          AI makes the problem sharper. A lot of the code we ship now was written faster than anyone can read it.
-          "Someone probably reviewed this" was always optimistic; at machine speed it's wishful thinking. If I can't
-          read all of it, I at least want to box it in.
+          In the age of generative AI this scales by orders of magnitude. A lot of the code we ship now was never
+          reviewed, written faster than anyone can read it. "Someone probably reviewed this" was always optimistic; at
+          machine speed it's wishful thinking. We need to contain the problem by limiting the blast radius of untrusted
+          code at a granular level, and make code modular and reusable so that less code has to be generated, reviewed,
+          and maintained in the first place. Small WebAssembly modules also make review — by a human or a machine — far
+          easier: fine-grained modularization keeps each piece small and self-contained instead of one giant one-off
+          monolithic codebase. WebAssembly lends itself as a lightweight, portable, modular, and safe substrate for
+          building a new, trustworthy foundation for computing in the age of untrusted code.
         </p>
 
         <h2>The idea in a nutshell</h2>


### PR DESCRIPTION
## Summary
Follow-ups to the blog post (#2636/#2639):

1. **Intro framing (author's wording).** Rewrites the AI/untrusted-code paragraph: generative AI scales unread code by orders of magnitude, so we limit the blast radius of untrusted code at a granular level and make code modular/reusable so less is generated at all. Adds that small Wasm modules make review (human or machine) easier via fine-grained modularization instead of one monolithic codebase, and that the same granularity + portability + language-independent module APIs make them far more reusable.
2. **Chart layout.** The two conformance donuts were clipped (a max-width:240px cap in the 720px text column; each donut needs ~380px for its orbit labels) and sat inside a surface box. Remove the box and break the chart block out to ~860px so both donuts render full-size and uncut; keep the timeline + caption at text width below, centered. Donuts stack on narrow screens.

(The `type="module"` donut-load fix landed separately in #2639.)

## Test plan
- [x] Tag balance + local serve (blog 200), box removed, donut max-width lifted
- [ ] After deploy: both donuts render uncut (host 74.2%, standalone 46.4%), timeline visible below, no box

🤖 Generated with [Claude Code](https://claude.com/claude-code)