### PR TITLE
fix(#2175 V2-S1): materialized typeof function arm + shared closure classifier

### DIFF
--- a/plan/issues/2175-standalone-builtin-prototype-readers.md
+++ b/plan/issues/2175-standalone-builtin-prototype-readers.md
@@ -1051,3 +1051,100 @@ radius needs separate CI evidence.
   or generator/async-carrier residuals of #3027 — those stay with their
   owners; v2 is the representation + dispatch + visibility substrate they
   sit on.
+
+---
+
+## Implementation log — V2-S1 (sdev opus-2984s1, 2026-07-04)
+
+PR: **V2-S1 of 7** — `typeof` function arm + shared closure classifier.
+Branch `issue-2175-v2s1`. Status: implemented, host-free, standalone-gated.
+
+### Re-grounding correction to v2 fact 4 (IMPORTANT for later slices)
+
+The v2 spec (fact 4) states the standalone `__typeof` native has "**No
+function arm**". Verified against `origin/main @ 1b7632bda`, that is **half
+right and half stale** — the distinction is load-bearing:
+
+- The **PREDICATE** family `__typeof_function` / `__typeof_object` (used by
+  the INLINE `typeof x === "function"` compare) **already recognises closure
+  wrapper structs** — #1896 (`fillStandaloneTypeofClosureArms`,
+  `index.ts`) splices `ref.test`-over-closure-base-wrapper arms into both at
+  finalize. So `typeof x === "function"` was ALREADY correct standalone.
+- The **MATERIALIZED** `__typeof` native (the tag as a NativeString VALUE —
+  `const t = typeof x`, or `typeof` flowing through a param) had **no
+  function arm** and fell through to `"object"`. THIS is the actual #2984
+  path-dependence: inline said `"function"`, const-bound said `"object"`.
+
+Empirically confirmed on unmodified main (inject/contrast proof, not
+narrative): `const f = (x)=>x*2; const a:any=f;`
+- `typeof a === "function"` → **1** (predicate, #1896)
+- `const t:any = typeof a; t === "function"` → **0** (materialized, broken)
+- `RegExp.prototype.exec` const-bound typeof → **0** (broken) / inline → 1
+
+### What landed
+
+- **New leaf module `src/codegen/closure-classifier.ts`** — the SINGLE
+  home for the closure-base-wrapper list (`collectClosureBaseWrapperTypeIdxs`)
+  and a reusable arm-builder (`buildClosureRefTestArms(ctx, anyLocalIdx,
+  onMatch)`). It imports only types, so `index.ts` and `dyn-read.ts` (which
+  are in an import cycle) can both depend on it without re-introducing the
+  cycle. This retires the TWO divergent copies that existed:
+  `collectClosureBaseWrapperTypeIdxs` (index.ts) and the byte-identical
+  private `closureBaseWrapperTypeIdxs` (dyn-read.ts, added specifically to
+  dodge the cycle). **One predicate, all consumers** — the spec's "never two
+  closure-struct arm lists" invariant, now structurally enforced.
+- **`fillStandaloneTypeofClosureArms`** (`index.ts`) extended: after
+  patching `__typeof_function`/`__typeof_object` (unchanged, now via the
+  shared builder → **byte-identical**), it splices a closure `ref.test` →
+  `"function"` NativeString arm into the MATERIALIZED `__typeof` body,
+  before the terminal `"object"` sequence. Robust splice point: the terminal
+  is the last N instrs where N = `stringConstantExternrefInstrs(ctx,
+  "object").length` (deterministic); an op-shape tail check gates the splice
+  (skips the `ref.null.extern` stub when no native-string type). Finalize
+  timing is REQUIRED — closures aren't all registered at `__typeof`'s
+  registration point (same reason #1896 finalize-fills the predicates).
+
+### Why byte-neutral except the intended change
+
+- `buildClosureRefTestArms(ctx, i, [i32.const v, return])` emits IDENTICAL
+  instrs to the old local `closureTestArms(i, v)` (same list, same order) →
+  `__typeof_function`/`__typeof_object` bytes unchanged.
+- `dyn-read.ts` repoint is aliased to the prior local name; the shared
+  collector returns the same list (same algorithm, same Map iteration order)
+  → the `.length`-arity arm bytes unchanged. #2580 suite (57 tests) green.
+- Closure-FREE modules: empty list → `buildClosureRefTestArms` emits nothing
+  → `__typeof` unchanged. `prove-emit-identity` deterministic (exit 0).
+- Only NEW bytes: the `__typeof` function arm in closure-containing
+  standalone/wasi modules — the intended fix.
+
+### Gate — verified
+
+- `tests/issue-2175-typeof-function-arm.test.ts` (5/5): closure +
+  `RegExp.prototype.exec` report `"function"` inline AND const-bound;
+  swap-guard (materialized closure is NOT `"object"` — proves the arm fires,
+  not a coincidental pass); non-closure receivers keep their tag.
+- Regression: #1896 typeof-closure, typeof-expression/comparison,
+  #2104 value-tags, #2949 slices 1/2/3/3b (77), #2580 dyn-read (57) — all
+  green. `tsc --noEmit` clean. Host mode untouched (all arms
+  `ctx.nativeStrings`-gated).
+- **Pre-existing (NOT this slice):** 4 getter tests in
+  `issue-2175-regexp-proto-readers.test.ts` (`.flags`/`.source`/flag-bool
+  getter VALUE reads) fail on `origin/main` too (8/12 pass on both baseline
+  and this branch) — the S1 "getter engine body" boundary, unrelated to
+  typeof. Not regressed here; belongs to the V2-S5 RegExp instance-chain
+  slice.
+
+### Banked for V2-S2+ (consume the shared classifier)
+
+- **#2949 slice 3 / `$AnyValue` boxing classifier**: point `tag.test(Function)`
+  and the runtime-ref → `JsTag.Function` boxing at
+  `buildClosureRefTestArms` / `collectClosureBaseWrapperTypeIdxs`
+  (`closure-classifier.ts`) — do NOT mint a third arm list. The `__typeof`
+  arm and the boxing classifier are now guaranteed one predicate.
+- **V2-S2 (singleton unification)**: independent of S1; switch
+  `property-access.ts:~1130` method arm + `calls.ts` #2885 Site-2 to
+  `pushBuiltinFnSingletonValueInstrs` (identity). Note: once method values
+  are singletons, `typeof` of them is already correct via this S1 arm.
+- **V2-S3 (proto table)**: the reader arms will read closure structs back as
+  `$PropEntry.value` (raw anyref, D4) — their `typeof`/Function-ness now
+  resolves through this same classifier for free.

--- a/src/codegen/closure-classifier.ts
+++ b/src/codegen/closure-classifier.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2175 V2-S1) The single, shared standalone closure-struct classifier.
+ *
+ * A closure/function value under `--target standalone`/`--target wasi`
+ * (native strings) is a WasmGC wrapper struct produced by
+ * `getOrCreateFuncRefWrapperTypes`; concrete closure subtypes (with captures)
+ * share their funcref signature with the base wrapper post-V8
+ * canonicalisation, so a single `ref.test` against the deduped ROOT wrappers
+ * recognises every closure. Several runtime natives need to answer the
+ * question "is this externref a callable?" against exactly this set:
+ *
+ *   - `__is_closure` export (host bridge, #1308/#1504)
+ *   - `__typeof_function` / `__typeof_object` predicates (#1896)
+ *   - the MATERIALIZED `__typeof` result native (#2175 V2-S1 — this file's
+ *     reason for existing: a closure read back dynamically must classify as
+ *     `"function"`, not fall through to `"object"`)
+ *   - the `.length`-arity dynamic-read arm (dyn-read.ts, #2580)
+ *   - future: the `$AnyValue` boxing classifier + #2949 slice 3's
+ *     `tag.test(Function)` lowering (V1 tag fidelity — one predicate, many
+ *     consumers, NEVER two divergent arm lists).
+ *
+ * This module is a LEAF (it imports only types), so `index.ts` and
+ * `dyn-read.ts` — which participate in an import cycle — can both depend on
+ * the ONE list here without re-introducing that cycle. Before this file the
+ * list was duplicated: `collectClosureBaseWrapperTypeIdxs` in index.ts and a
+ * private byte-identical copy `closureBaseWrapperTypeIdxs` in dyn-read.ts
+ * (which existed specifically to dodge the cycle). Both now delegate here.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * The deduped set of closure base-wrapper struct type indices from
+ * `ctx.closureInfoByTypeIdx`. Walks each registered closure struct up its
+ * `superTypeIdx` chain to the root (superTypeIdx < 0), collecting each distinct
+ * root in first-seen (Map-insertion) order. Returns `[]` when the module has no
+ * closures.
+ */
+export function collectClosureBaseWrapperTypeIdxs(ctx: CodegenContext): number[] {
+  const mod = ctx.mod;
+  const baseTypeIdxs: number[] = [];
+  const seenBase = new Set<number>();
+  for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
+    if (!info) continue;
+    const typeDef = mod.types[typeIdx];
+    if (!typeDef || typeDef.kind !== "struct") continue;
+    // Walk up to the root struct in the chain.
+    let root = typeIdx;
+    let cur = typeDef;
+    while (cur && cur.kind === "struct" && cur.superTypeIdx !== undefined && cur.superTypeIdx >= 0) {
+      const superIdx: number = cur.superTypeIdx;
+      const parent = mod.types[superIdx];
+      if (!parent || parent.kind !== "struct") break;
+      root = superIdx;
+      cur = parent;
+    }
+    if (!seenBase.has(root)) {
+      seenBase.add(root);
+      baseTypeIdxs.push(root);
+    }
+  }
+  return baseTypeIdxs;
+}
+
+/**
+ * Build a chain of `ref.test`-over-closure-base-wrapper arms against the value
+ * held (as anyref) in local `anyLocalIdx`. On the FIRST matching closure type
+ * the arm runs `onMatch` (which is responsible for producing the arm's result
+ * and, typically, `return`-ing). Emits nothing when the module has no closures.
+ *
+ * Shape (per base type `t`):
+ *   local.get anyLocalIdx ; ref.test t ; if (empty) { ...onMatch }
+ *
+ * This is the ONE arm-builder every closure-classifying native should use so
+ * the predicate can never diverge between consumers (`__is_closure`,
+ * `__typeof*`, the `$AnyValue` classifier, #2949 slice 3).
+ */
+export function buildClosureRefTestArms(ctx: CodegenContext, anyLocalIdx: number, onMatch: Instr[]): Instr[] {
+  const arms: Instr[] = [];
+  for (const t of collectClosureBaseWrapperTypeIdxs(ctx)) {
+    arms.push({ op: "local.get", index: anyLocalIdx } as Instr);
+    arms.push({ op: "ref.test", typeIdx: t } as Instr);
+    arms.push({ op: "if", blockType: { kind: "empty" }, then: [...onMatch] } as Instr);
+  }
+  return arms;
+}

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -46,6 +46,7 @@ import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { allocLocal } from "./context/locals.js";
+import { collectClosureBaseWrapperTypeIdxs as closureBaseWrapperTypeIdxs } from "./closure-classifier.js"; // (#2175 V2-S1) shared list
 
 // `$AnyValue` tag constants (mirror any-helpers.ts box helpers).
 const TAG_NULL = 0;
@@ -422,33 +423,7 @@ export function emitDynGet(ctx: CodegenContext, fctx: FunctionContext, keyName: 
   return true;
 }
 
-/**
- * (#2580 M1a v2) The deduped root struct types of every registered closure
- * wrapper, for `ref.test`-discriminating a closure receiver. Mirrors index.ts's
- * private `collectClosureBaseWrapperTypeIdxs` (walking each closure struct up its
- * `superTypeIdx` chain to the root) but lives here to avoid a circular import
- * (`index.ts` already imports `ensureDynReadHelpers` from this module).
- */
-function closureBaseWrapperTypeIdxs(ctx: CodegenContext): number[] {
-  const mod = ctx.mod;
-  const out: number[] = [];
-  const seen = new Set<number>();
-  for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
-    if (!info) continue;
-    const typeDef = mod.types[typeIdx];
-    if (!typeDef || typeDef.kind !== "struct") continue;
-    let root = typeIdx;
-    let cur: typeof typeDef = typeDef;
-    while (cur && cur.kind === "struct" && cur.superTypeIdx !== undefined && cur.superTypeIdx >= 0) {
-      const parent = mod.types[cur.superTypeIdx];
-      if (!parent || parent.kind !== "struct") break;
-      root = cur.superTypeIdx;
-      cur = parent;
-    }
-    if (!seen.has(root)) {
-      seen.add(root);
-      out.push(root);
-    }
-  }
-  return out;
-}
+/* (#2175 V2-S1) The deduped closure-base-wrapper list now lives in the leaf
+ * `closure-classifier.ts` and is shared with index.ts's `__typeof*` natives —
+ * one predicate, never two divergent arm lists. Imported (aliased to the prior
+ * local name) at the top of this module. */

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -52,6 +52,7 @@ import { ensureMapRuntimeTypes } from "./map-runtime.js";
 import { scanForNewTarget } from "./new-target.js"; // (#2023)
 import { scanForArrayHoles, ensureHoleType } from "./array-holes.js"; // (#2001 S1)
 import { ensureDynReadHelpers } from "./dyn-read.js"; // (#2580 M0)
+import { collectClosureBaseWrapperTypeIdxs, buildClosureRefTestArms } from "./closure-classifier.js"; // (#2175 V2-S1)
 import { ensureNativeIteratorRuntime, fillNativeIteratorUserArms } from "./iterator-native.js";
 import { fillCombinatorToVec } from "./promise-combinators.js"; // (#2922) dynamic combinator-arg drain fill
 import { fillClosedMethodDispatch } from "./closed-method-dispatch.js";
@@ -4581,40 +4582,9 @@ function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number): void 
  * choose between callable-wrapping (#1308) and `_wasmToPlain` marshaling
  * (#1504). No-op when the module has no closures.
  */
-/**
- * Collect the deduped set of closure base-wrapper struct type indices from
- * `ctx.closureInfoByTypeIdx`. Concrete closure subtypes (with captures) share
- * their funcref signature with the base wrapper post-V8 canonicalisation, so a
- * `ref.test` against the base catches all of them. Walks each registered
- * closure struct up to its root (superTypeIdx === -1). (#1896 — shared by
- * `emitIsClosureExport` and the standalone `__typeof_function`/`__typeof_object`
- * closure-recognition arms.)
- */
-function collectClosureBaseWrapperTypeIdxs(ctx: CodegenContext): number[] {
-  const mod = ctx.mod;
-  const baseTypeIdxs: number[] = [];
-  const seenBase = new Set<number>();
-  for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
-    if (!info) continue;
-    const typeDef = mod.types[typeIdx];
-    if (!typeDef || typeDef.kind !== "struct") continue;
-    // Walk up to the root struct in the chain.
-    let root = typeIdx;
-    let cur = typeDef;
-    while (cur && cur.kind === "struct" && cur.superTypeIdx !== undefined && cur.superTypeIdx >= 0) {
-      const superIdx: number = cur.superTypeIdx;
-      const parent = mod.types[superIdx];
-      if (!parent || parent.kind !== "struct") break;
-      root = superIdx;
-      cur = parent;
-    }
-    if (!seenBase.has(root)) {
-      seenBase.add(root);
-      baseTypeIdxs.push(root);
-    }
-  }
-  return baseTypeIdxs;
-}
+/* (#2175 V2-S1) `collectClosureBaseWrapperTypeIdxs` moved to the leaf module
+ * `closure-classifier.ts` so `index.ts` and `dyn-read.ts` share ONE list (see
+ * that file). Imported at the top of this module. */
 
 function emitIsClosureExport(ctx: CodegenContext): void {
   const mod = ctx.mod;
@@ -4756,6 +4726,20 @@ function emitIsDataStructExport(ctx: CodegenContext): void {
  *   (a callable is `"function"`, never `"object"`) BEFORE the final non-null
  *   `i32.const 1`, so a wrapper read back from an open-object slot is not
  *   mis-classified as `"object"`.
+ * - (#2175 V2-S1) `__typeof`: the MATERIALIZED typeof-result native (the tag as
+ *   a NativeString VALUE, used by `const t = typeof x`). It classified
+ *   null/number/boolean/bigint/string and fell through to `"object"` — with NO
+ *   function arm, so a closure read back dynamically produced `"object"` while
+ *   the INLINE `typeof x === "function"` compare (via the `__typeof_function`
+ *   predicate above) produced `"function"`. That path-dependence is the #2984
+ *   `typeof` instability and contradicts `JsTag.Function` (#2949 V1 tag
+ *   fidelity). We splice a closure `ref.test` arm returning the `"function"`
+ *   NativeString before the terminal `"object"` sequence, using the SAME
+ *   closure base-wrapper list — one predicate, all three natives in lockstep.
+ *
+ * All three natives now share the single closure classifier
+ * (`buildClosureRefTestArms` / `collectClosureBaseWrapperTypeIdxs`,
+ * `closure-classifier.ts`) — never two divergent arm lists.
  *
  * No-op unless native-strings (the helpers only exist then) and at least one
  * closure base wrapper was registered.
@@ -4769,20 +4753,13 @@ function fillStandaloneTypeofClosureArms(ctx: CodegenContext): void {
     ctx.mod.functions.find((f) => (f as { name?: string }).name === name) as WasmFunction | undefined;
 
   // Chained `ref.test` arms over the anyref-converted param in local 0/1. Each
-  // arm returns `matchValue` on hit. Caller supplies the param→anyref local.
-  const closureTestArms = (anyLocalIdx: number, matchValue: number): Instr[] => {
-    const arms: Instr[] = [];
-    for (const t of baseTypeIdxs) {
-      arms.push({ op: "local.get", index: anyLocalIdx } as Instr);
-      arms.push({ op: "ref.test", typeIdx: t } as Instr);
-      arms.push({
-        op: "if",
-        blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: matchValue } as Instr, { op: "return" } as Instr],
-      } as Instr);
-    }
-    return arms;
-  };
+  // i32-predicate arm returns `matchValue` on hit. Builds from the ONE shared
+  // closure-base-wrapper list (`closure-classifier.ts`).
+  const closureI32Arms = (anyLocalIdx: number, matchValue: number): Instr[] =>
+    buildClosureRefTestArms(ctx, anyLocalIdx, [
+      { op: "i32.const", value: matchValue } as Instr,
+      { op: "return" } as Instr,
+    ]);
 
   // --- __typeof_function: param(0) externref → 1 if closure wrapper else 0.
   const tf = fnByName("__typeof_function");
@@ -4802,7 +4779,7 @@ function fillStandaloneTypeofClosureArms(ctx: CodegenContext): void {
       { op: "local.get", index: 0 } as Instr,
       { op: "any.convert_extern" } as Instr,
       { op: "local.set", index: 1 } as Instr,
-      ...closureTestArms(1, 1),
+      ...closureI32Arms(1, 1),
       { op: "i32.const", value: 0 } as Instr,
     ];
   }
@@ -4818,7 +4795,38 @@ function fillStandaloneTypeofClosureArms(ctx: CodegenContext): void {
     const lastIdx = b.length - 1;
     const last = b[lastIdx] as { op?: string; value?: number } | undefined;
     if (last && last.op === "i32.const" && last.value === 1) {
-      b.splice(lastIdx, 0, ...closureTestArms(1, 0));
+      b.splice(lastIdx, 0, ...closureI32Arms(1, 0));
+    }
+  }
+
+  // --- (#2175 V2-S1) __typeof (materialized result): splice a closure arm that
+  // returns the `"function"` NativeString before the terminal `"object"`
+  // sequence. The body converts param → anyref into local 1 (`$any_temp`)
+  // before its boxed-primitive guards, and local 1 still holds it at the
+  // terminal, so the arm reads local 1 exactly like the primitive guards.
+  //
+  // Robust splice point: the terminal is the last N instrs, where N is the
+  // length of `stringConstantExternrefInstrs(ctx, "object")` (deterministic —
+  // "object" was already registered when the body was built, so re-deriving it
+  // yields the same length). We verify the tail's op-shape matches before
+  // splicing; if `__typeof` is the `ref.null.extern` stub (no native-string
+  // type) the shape check fails and we skip — self-guarding.
+  const tt = fnByName("__typeof");
+  if (tt && ctx.nativeStrTypeIdx >= 0) {
+    const b = tt.body;
+    const objTerminal = stringConstantExternrefInstrs(ctx, "object");
+    const spliceAt = b.length - objTerminal.length;
+    const tailMatches =
+      spliceAt >= 0 &&
+      objTerminal.every(
+        (inst, i) => (b[spliceAt + i] as { op?: string } | undefined)?.op === (inst as { op?: string }).op,
+      );
+    if (tailMatches) {
+      const fnArm = buildClosureRefTestArms(ctx, 1, [
+        ...stringConstantExternrefInstrs(ctx, "function"),
+        { op: "return" } as Instr,
+      ]);
+      b.splice(spliceAt, 0, ...fnArm);
     }
   }
 }
@@ -12142,8 +12150,12 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
   //     EVERY tag and `t.length` trapped. Classify with the same dispatch the
   //     `__typeof_*` predicates above use (null → "undefined", box_number →
   //     "number", box_boolean → "boolean", $BigInt → "bigint", $AnyString →
-  //     "string", else → "object"; functions stay "object", matching the
-  //     conservative `__typeof_function` = 0 predicate) and return the tag as
+  //     "string", else → "object"). (#2175 V2-S1) A closure/function value read
+  //     back here would otherwise fall through to "object";
+  //     `fillStandaloneTypeofClosureArms` splices a closure `ref.test` →
+  //     "function" arm before the terminal at finalize (closures aren't all
+  //     registered yet at this registration point), so the materialized result
+  //     agrees with the `__typeof_function` predicate. The tag is returned as
   //     an inline NativeString (sentinel-safe, no funcidx baked — the #2515
   //     discipline; string literals here are type-index-only instructions, so
   //     the late-import finalize shift cannot desync this body). Falls back to

--- a/tests/issue-2175-typeof-function-arm.test.ts
+++ b/tests/issue-2175-typeof-function-arm.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2175 V2-S1 — the MATERIALIZED `__typeof` function-classifier arm.
+ *
+ * #1896 taught the standalone `__typeof_function` PREDICATE (the inline
+ * `typeof x === "function"` compare) to recognise closure wrapper structs, but
+ * the MATERIALIZED `__typeof` native — the tag as a NativeString VALUE, used by
+ * `const t = typeof x` / `typeof x` flowing through a param — had NO function
+ * arm and fell through to `"object"`. So `typeof` was path-dependent: inline
+ * said `"function"`, const-bound said `"object"` (the #2984 defect; it also
+ * contradicted `JsTag.Function`, #2949 V1 tag fidelity).
+ *
+ * `fillStandaloneTypeofClosureArms` now splices a closure `ref.test` →
+ * `"function"` arm into `__typeof` at finalize, using the SAME shared
+ * closure-base-wrapper list (`closure-classifier.ts`) as the predicate — one
+ * predicate, all three typeof natives in lockstep.
+ *
+ * All cases run under `--target standalone`, host-free (zero `env` imports).
+ */
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, `compile failed:\n${(r.errors ?? []).map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const env = r.imports.filter((i) => i.module === "env");
+  expect(env).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2175 V2-S1 — materialized typeof classifies closures as 'function'", () => {
+  it("closure: inline AND const-bound typeof both report 'function'", async () => {
+    // Inline form goes through the __typeof_function predicate (#1896); the
+    // const-bound form materializes the tag through __typeof (V2-S1). Both must
+    // agree — the fix eliminates the path-dependence.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const f = (x: number): number => x * 2;
+          const a: any = f;
+          const inlineFn: number = (typeof a === "function") ? 1 : 0;
+          const t: any = typeof a;
+          const boundFn: number = (t === "function") ? 1 : 0;
+          return (inlineFn === 1 && boundFn === 1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("capturing closure: materialized typeof is 'function'", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          let k = 7;
+          const f = (): number => k;
+          const a: any = f;
+          const t: any = typeof a;
+          return (t === "function") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("RegExp.prototype.exec: inline AND const-bound typeof both 'function'", async () => {
+    // The native-method-closure VALUE (a $NativeProto member read, #2175 S1)
+    // read back as `any` must classify as a function through the runtime native,
+    // not just the compile-time TS type.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const m: any = RegExp.prototype.exec;
+          const inlineFn: number = (typeof m === "function") ? 1 : 0;
+          const t: any = typeof m;
+          const boundFn: number = (t === "function") ? 1 : 0;
+          return (inlineFn === 1 && boundFn === 1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("swap-guard: a materialized closure typeof is NOT 'object'", async () => {
+    // Proves the function arm actually fires (diverts closures away from the
+    // "object" fallthrough) rather than the test passing coincidentally: if the
+    // arm were absent this returns 1 (closure → "object"); with the arm it is 0.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const f = (x: number): number => x;
+          const a: any = f;
+          const t: any = typeof a;
+          return (t === "object") ? 1 : 0;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("non-closure receivers keep their materialized tag (no over-broad diversion)", async () => {
+    // Guards that the new arm does not mis-classify plain objects / primitives.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const o: any = { x: 1 };
+          const n: any = 42;
+          const s: any = "hi";
+          const b: any = true;
+          const to: any = typeof o;
+          const tn: any = typeof n;
+          const ts: any = typeof s;
+          const tb: any = typeof b;
+          return (to === "object" && tn === "number" && ts === "string" && tb === "boolean") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2175 V2-S1 — `typeof` function arm + shared closure classifier

First slice of the banked builtin-prototype substrate v2 spec (issue #2175, `## Slice decomposition`). Standalone-only, host-free, `ctx.nativeStrings`-gated.

### The defect (re-grounded on current main)
The standalone **materialized** `__typeof` native (the tag as a NativeString VALUE — `const t = typeof x`) had **no function arm** and fell through to `"object"`, while the **inline** predicate `typeof x === "function"` was already correct via #1896's `__typeof_function` closure arms. That path-dependence is the #2984 `typeof` instability and contradicts `JsTag.Function` (#2949 V1 tag fidelity).

Confirmed empirically on unmodified `main` (`const f=(x)=>x*2; const a:any=f`):
- `typeof a === "function"` → `1` (inline predicate, #1896)
- `const t:any = typeof a; t === "function"` → `0` (materialized — broken)

> Note: v2 fact 4 said "no function arm" — that is only true of the **materialized** `__typeof`; the **predicate** family already had one (#1896). Corrected in the issue log for later slices.

### Change
- **New leaf module `src/codegen/closure-classifier.ts`** — the single home for the closure-base-wrapper list (`collectClosureBaseWrapperTypeIdxs`) + a reusable arm-builder (`buildClosureRefTestArms`). Retires the two divergent copies (index.ts + a private dyn-read.ts duplicate). **One predicate, all consumers** — the spec's "never two arm lists" invariant, structurally enforced. #2949 slice 3 / the `$AnyValue` classifier should consume this.
- **`fillStandaloneTypeofClosureArms`** splices a closure `ref.test` → `"function"` arm into `__typeof` at finalize (closures aren't all registered at `__typeof`'s registration point — same reason #1896 finalize-fills the predicates). Robust splice: before the terminal `"object"` sequence, gated by an op-shape tail check (skips the `ref.null.extern` stub).

### Byte-neutral except the intended change
- `__typeof_function`/`__typeof_object` bytes unchanged (shared builder emits identical instrs).
- `dyn-read.ts` `.length`-arity arm unchanged (aliased repoint; same list/order).
- Closure-free modules unchanged (`prove-emit-identity` deterministic, exit 0).

### Gate — verified
- `tests/issue-2175-typeof-function-arm.test.ts` (5/5): closure + `RegExp.prototype.exec` report `"function"` inline AND const-bound; **swap-guard** (materialized closure is NOT `"object"` — proves the arm fires); non-closure receivers keep their tag.
- Green: #1896 typeof-closure, typeof-expression/comparison, #2104 value-tags, #2949 slices 1/2/3/3b (77), #2580 dyn-read (57). `tsc --noEmit` clean.
- **Pre-existing (NOT this slice):** 4 getter-value tests in `issue-2175-regexp-proto-readers.test.ts` fail on `origin/main` too (8/12 both baseline and this branch) — the S1 getter-engine-body boundary, unrelated to typeof; belongs to V2-S5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8