### PR TITLE
fix(#2161): recover boxed new String receiver/argument in standalone regexp/string methods (B1)

### DIFF
--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -72,6 +72,7 @@ helper `__regex_match_all` (regexp-standalone.ts:1106+) returns a vec of the
 `.index`, `.input`, named groups — i.e. a vec of capture-ARRAYS, not substrings.
 
 **Building blocks already on main (verified):**
+
 - `ensureRegexCaptureArray` / `__regex_capture_array` (regexp-standalone.ts:934)
   — builds the [0]+captures array for ONE exec result (used by `exec`/`match`).
 - `emitRegexExecArrayCall` (the exec driver) — runs one match from lastIndex.
@@ -79,6 +80,7 @@ helper `__regex_match_all` (regexp-standalone.ts:1106+) returns a vec of the
   template to copy, but collecting capture-arrays instead of substrings.
 
 **Implementation plan (focused, ~half-day):**
+
 1. New native helper `ensureRegexMatchAllArrays` — clone `__regex_match_all`'s
    eager loop (SetLastIndex 0; loop RegExpExec with AdvanceStringIndex on empty
    match), but per iteration call the capture-array builder and push the
@@ -149,22 +151,22 @@ Pulled the standalone-shard baseline (`loopdive/js2wasm-baselines`
 every RegExp-bucket failure. **1,120 RegExp failures: 843 compile_error + 277
 fail.** The 651 RegExp compile_errors by `error_signature`:
 
-| count | bucket | nature |
-|---:|---|---|
-| 126 | `RegExp.prototype.<prop>` built-in value read (#1907/#1888 S6-b) | **reflection** — `RegExp.prototype.test`/`.flags`/getter *descriptor* reads. Verified: **instance** `re.flags`/`re.source`/`re.global`/`re.ignoreCase`/`re.multiline` ALREADY compile + run in standalone — only the `RegExp.prototype`-as-receiver reflection form refuses (`property-access.ts:1975`, `ensureStandaloneBuiltinStaticMethodClosure` has no RegExp.prototype pairs). |
-| ~128 | `@@match`/`@@replace`/`@@split`/`@@matchAll` symbol-protocol calls (literal-substring backend refuses; `string-ops.ts`) | **native built-in prototype-method closures** — `re[Symbol.match](s)` etc. The String.prototype.matchAll *call* form is DONE (#1504); this is the explicit `re[Symbol.X]()` protocol form. |
-| ~64 | dynamic constructor patterns/flags (RegExp Phase 2a) | regex-engine feature work |
-| 33 | `\q{…}` string disjunction (Phase 2a) | unsupported regex feature (v-flag) |
-| 30 | `__get_builtin` dynamic-shape (Phase B) | not RegExp-specific; dynamic-object reflection |
-| 33 | `\\`-class / literal-substring backend gaps | regex-engine feature work |
-| 10 | `Cannot convert object to primitive value` (runtime) | a `_toPrimitiveSync`/key-coercion gap on a RegExp receiver |
+| count | bucket                                                                                                                  | nature                                                                                                                                                                                                                                                                                                                                                                               |
+| ----: | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|   126 | `RegExp.prototype.<prop>` built-in value read (#1907/#1888 S6-b)                                                        | **reflection** — `RegExp.prototype.test`/`.flags`/getter _descriptor_ reads. Verified: **instance** `re.flags`/`re.source`/`re.global`/`re.ignoreCase`/`re.multiline` ALREADY compile + run in standalone — only the `RegExp.prototype`-as-receiver reflection form refuses (`property-access.ts:1975`, `ensureStandaloneBuiltinStaticMethodClosure` has no RegExp.prototype pairs). |
+|  ~128 | `@@match`/`@@replace`/`@@split`/`@@matchAll` symbol-protocol calls (literal-substring backend refuses; `string-ops.ts`) | **native built-in prototype-method closures** — `re[Symbol.match](s)` etc. The String.prototype.matchAll _call_ form is DONE (#1504); this is the explicit `re[Symbol.X]()` protocol form.                                                                                                                                                                                           |
+|   ~64 | dynamic constructor patterns/flags (RegExp Phase 2a)                                                                    | regex-engine feature work                                                                                                                                                                                                                                                                                                                                                            |
+|    33 | `\q{…}` string disjunction (Phase 2a)                                                                                   | unsupported regex feature (v-flag)                                                                                                                                                                                                                                                                                                                                                   |
+|    30 | `__get_builtin` dynamic-shape (Phase B)                                                                                 | not RegExp-specific; dynamic-object reflection                                                                                                                                                                                                                                                                                                                                       |
+|    33 | `\\`-class / literal-substring backend gaps                                                                             | regex-engine feature work                                                                                                                                                                                                                                                                                                                                                            |
+|    10 | `Cannot convert object to primitive value` (runtime)                                                                    | a `_toPrimitiveSync`/key-coercion gap on a RegExp receiver                                                                                                                                                                                                                                                                                                                           |
 
 **Conclusion (honest scope call):** there is **no clean bounded point-fix** left
 in #2161. The matchAll concrete leak (the one named in the original triage) is
 already shipped via #1504. Each remaining bucket is a sub-project:
 
-1. **RegExp.prototype reflection (126)** — add native built-in *method/getter
-   closures* for the RegExp.prototype pairs to
+1. **RegExp.prototype reflection (126)** — add native built-in _method/getter
+   closures_ for the RegExp.prototype pairs to
    `ensureStandaloneBuiltinStaticMethodClosure`, backed by the native engine's
    flag fields (`RE_FIELD_*`) + the existing exec/test helpers. ~14 pairs
    (test/exec/compile/toString + 10 flag getters). Self-contained but meaty
@@ -183,7 +185,8 @@ closures` (~126 tests, self-contained, architect-spec'd), (b) `fix: standalone
 RegExp @@symbol protocol calls` (~128, reuses #1504), (c) `feat: standalone
 RegExp engine v-flag / dynamic-ctor features` (~97, regex backend). Each is a
 dispatchable issue with a concrete test gate; none is a tail-end slice. Sub (a)
-+ (b) together recover ~250 standalone tests.
+
+- (b) together recover ~250 standalone tests.
 
 ### Refinement on sub-bucket (a) — REVISED scope (2026-06-16, sdev5, #2161a)
 
@@ -198,7 +201,7 @@ is **no isolated slice** (not even `.length`/`.name`) that avoids it: every form
 chains off `RegExp.prototype`.
 
 Sub-categories of the 126 (by test form): 52 legacy `.call` (`RegExp.prototype.
-test.call(re, s)`), 57 Symbol.* protocol members, 31 this-val brand-check, 26
+test.call(re, s)`), 57 Symbol.\* protocol members, 31 this-val brand-check, 26
 `.length`/`.name`, 7 prop-desc reflection.
 
 **This means (a) is NOT self-contained** — it requires `RegExp.prototype` to be a
@@ -350,11 +353,11 @@ as noted above. **#2161 stays open.**
 route through the native RegExp.prototype.toString rendering, matching the
 already-working `re.toString()` method form. Confirmed against `2af57ffc0`:
 
-| form | before | after |
-|---|---|---|
-| `String(/abc/gi)` | runtime null-deref (null string) | `/abc/gi` |
-| `` `x${/abc/gi}y` `` | `x[object Object]y` | `x/abc/giy` |
-| `re.toString()` | `/abc/gi` (slice 7) | unchanged |
+| form                 | before                           | after       |
+| -------------------- | -------------------------------- | ----------- |
+| `String(/abc/gi)`    | runtime null-deref (null string) | `/abc/gi`   |
+| `` `x${/abc/gi}y` `` | `x[object Object]y`              | `x/abc/giy` |
+| `re.toString()`      | `/abc/gi` (slice 7)              | unchanged   |
 
 **Fix** — extracted a shared operand-explicit core from the slice-7 method
 helper, then wired it into the two coercion sites:
@@ -362,7 +365,7 @@ helper, then wired it into the two coercion sites:
 - `src/codegen/regexp-standalone.ts`: factored
   `emitStandaloneRegExpToStringFromExpr(ctx, fctx, regexpExpr)` out of
   `tryCompileStandaloneRegExpToString` (§22.2.6.14 → `"/" + source + "/" +
-  flags` via `__regex_flags_str` + `__str_concat`). The method helper now
+flags` via `__regex_flags_str` + `__str_concat`). The method helper now
   delegates to it; behaviour byte-identical for the `re.toString()` path. Gated
   on `ctx.standalone` + a static / backend-created RegExp receiver (dynamic
   externref receivers fall through unchanged).
@@ -412,12 +415,12 @@ standalone baseline `2026-06-19`, both from `loopdive/js2wasm-baselines`):
 (`--target standalone`, empty importObject) to find the **concrete, bounded,
 substrate-independent** wins. Sliced into 4 dispatch-ready dev issues:
 
-| # | slice | root cause (verified on main) | est. rows | feasibility |
-|---|---|---|---:|---|
-| **#2588** | named-groups result object `m.groups` + `$<name>` substitution | match-vec struct has no `groups` field; reader maps any non-`index` prop to `input`; `$<` is a literal stub. Numbered captures + `\k<name>` already work; only the result-object exposure + `$<name>` are missing. | ~40-50 | medium |
-| **#2589** | `d`-flag match `.indices` array | match-vec struct has no `indices` field; `m.indices` read leaks `env::__extern_get`. The `caps` i32 array already holds every start/end pair — just unmaterialised. | ~15-22 | medium |
-| **#2590** | `RegExp.escape(str)` static method (ES2025) | entirely unimplemented; leaks `env::__get_builtin` and fails to instantiate. Pure native string transform, no engine. | ~20-29 | medium |
-| **#2591** | `v`-flag `\q{…}` string disjunction | set ops `&&`/`--` already work; `\q{}` **traps at runtime** ("illegal cast") — the unicode.ts refusal guard is bypassed for some forms, lowering a malformed multi-char-in-class node. Implement (desugar to alternation) or complete the refusal. | ~25-39 | medium |
+| #         | slice                                                          | root cause (verified on main)                                                                                                                                                                                                                      | est. rows | feasibility |
+| --------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------: | ----------- |
+| **#2588** | named-groups result object `m.groups` + `$<name>` substitution | match-vec struct has no `groups` field; reader maps any non-`index` prop to `input`; `$<` is a literal stub. Numbered captures + `\k<name>` already work; only the result-object exposure + `$<name>` are missing.                                 |    ~40-50 | medium      |
+| **#2589** | `d`-flag match `.indices` array                                | match-vec struct has no `indices` field; `m.indices` read leaks `env::__extern_get`. The `caps` i32 array already holds every start/end pair — just unmaterialised.                                                                                |    ~15-22 | medium      |
+| **#2590** | `RegExp.escape(str)` static method (ES2025)                    | entirely unimplemented; leaks `env::__get_builtin` and fails to instantiate. Pure native string transform, no engine.                                                                                                                              |    ~20-29 | medium      |
+| **#2591** | `v`-flag `\q{…}` string disjunction                            | set ops `&&`/`--` already work; `\q{}` **traps at runtime** ("illegal cast") — the unicode.ts refusal guard is bypassed for some forms, lowering a malformed multi-char-in-class node. Implement (desugar to alternation) or complete the refusal. |    ~25-39 | medium      |
 
 **Sub-total ≈ 100-140 standalone rows** across the 4 slices. Each has ONE
 concrete root cause, is independently implementable (~1-2 days), and is pure
@@ -453,17 +456,18 @@ dynamic-receiver residuals once #2588-#2591 land.
 (empty importObject). The 4 architect slices are done; the dominant remaining
 buckets are #2175-gated reflection and the dynamic/`any`-typed receiver
 architecture — neither bounded. The **one genuinely bounded, substrate-independent
-win left** was the dynamic-constructor-pattern bucket, *narrowed to its
-compile-time-constant subset*.
+win left** was the dynamic-constructor-pattern bucket, _narrowed to its
+compile-time-constant subset_.
 
 **Root cause (pinned):** `compileStandaloneRegExpConstructor`
 (`regexp-standalone.ts`) recovered the pattern via the narrow `staticStringValue`,
 which only accepts a bare string literal. Patterns that ARE compile-time-constant
 and CAN be compiled to native bytecode were rejected → lowered to a placeholder
 that **runtime-traps** (the documented "dynamic ctor patterns illegal-cast"):
-  - `new RegExp("a" + "b")` — string-literal concatenation,
-  - `const p = "ab"; new RegExp(p)` — `const`-bound literal,
-  - `new RegExp(/ab/g)` / `new RegExp(/ab/, "i")` — §22.2.3.1 copy-constructor.
+
+- `new RegExp("a" + "b")` — string-literal concatenation,
+- `const p = "ab"; new RegExp(p)` — `const`-bound literal,
+- `new RegExp(/ab/g)` / `new RegExp(/ab/, "i")` — §22.2.3.1 copy-constructor.
 
 **Fix** (`regexp-standalone.ts`, +112 LoC, zero new host imports, zero substrate
 dep): new `staticConstStringValue` (recursively folds string literals, `const`-
@@ -487,6 +491,7 @@ slice — earlier slices (#1912) turned those static-invalid refusals into a
 runtime `throw`; not in this slice's scope and not in the CI equivalence gate).
 
 **Future architect-spec items (NOT this window — bounded budget call):**
+
 - **Dynamic / `any`-typed regex receivers** (`function f(re: RegExp){re.test(s)}`
   returns wrong / `re.exec` → "Cannot convert object to primitive value"; truly-
   runtime `new RegExp(runtimeString)` runtime-traps): needs a **runtime regex
@@ -507,17 +512,17 @@ families on current main; three had bounded fixes which THIS slice lands.
 
 ### Family map (510 rows, by root cause)
 
-| family | rows | root cause | verdict |
-|---|---:|---|---|
-| **B0 — null native-string ≠ undefined sentinel** | ~76 in-bucket ("deref null in test()" 73 + compareArray 3; **109 across ALL standalone categories**) | THREE sinks mishandled the null-string = `undefined` sentinel (non-strict checker ERASES `undefined` from `["a",undefined]` unions; unmatched capture groups are null slots): (a) `coerceType` `ref_null→ref` emitted a trapping `ref.as_non_null` for native-string targets (type-coercion.ts ~1468); (b) the mixed `any === string` #1914 eq-arm and the tag-cascade eqref identity arm returned 0 for null/null (`ref.test` is false for null); (c) `$__regexp_match_vec` → `any[]` param fell into struct-NARROWING (`getVecInfo` only matches `__vec_*` names), ref-casting the `__arr_ref_<anyStr>` data array to `$__arr_externref` → null → trap; (d) `s === undefined` on a `string`-typed local constant-folded to false (#1105 gate was `ref_null`-only). | **FIXED this slice** |
-| **B2 — split undefined separator/limit** | ~15-25 of the split 72 | §22.1.3.23: `s.split()` / `s.split(undefined)` fell past the string-like-separator gate to the host marshal path (no standalone `string_split`) → null deref; a statically-`undefined` LIMIT compiled to f64 NaN → ToUint32(NaN)=0 → `[]`. | **FIXED this slice** |
-| **B4 — never-reassigned `var` pattern fold** | ~15-20 of the 37 "illegal cast" | Slice 9's fold was `const`-only; sputnik binds patterns/flags with `var` (`var __re="d+"; RegExp(__re,"i")`), uses `void 0` / hoisted-uninitialised flags, `new RegExp(ctorCopy, "g")`, and diamond concat chains (the `seen` cycle-guard blocked same-binding re-references). | **FIXED this slice** |
-| B1 — boxed `new String(x)` receiver OR argument | ~40 (`__str_flatten` deref: every `instance-is-string-hello` split/search/match/replace test + `re.exec(new String(...))` — verified the ARG position hits the same site) | `new String()` builds a `$Object` wrapper (`__new_String`, object-runtime.ts:~1390, primitive under `WRAPPER_PRIMITIVE_KEY`); any externref→AnyString coercion (`coerceType`'s externref→ref arm, type-coercion.ts ~1743: `ref.test $AnyString` → else `ref.null`) drops the wrapper to null → flatten trap. **Exact contract:** for a NATIVE-STRING target, extend that else-arm with the wrapper-slot probe `__to_primitive` already implements INLINE (object-runtime.ts ~2544: `ref.cast $Object` → `__obj_find(WRAPPER_PRIMITIVE_KEY)` → FLAG_INTERNAL check → value): `ref.test $Object` → read the internal slot → `ref.test $AnyString` → cast, else null. Do NOT call full `__to_primitive` (it would pull OrdinaryToPrimitive semantics — valueOf/toString dispatch — into every string coercion); extract just the slot read, gated on the object runtime already being in the module (`ctx.funcMap.has("__obj_find")` — `new String` registration guarantees it). Watch late-registration ordering (funcIdx shifts — flushLateImportShifts discipline). | Opus point-fix (bounded, shared-coercion blast radius — needs the full string-suite battery this slice's `.tmp/battery-final` set established) |
-| B5 — annexB identity-escape fallbacks | ~6-10 | `/\x/`, `/\u/` (incomplete hex/unicode), `/\c1/`-class escapes: the pattern compiler refuses → placeholder trap. AnnexB says incomplete escapes fall through to IdentityEscape. **Exact contract:** in the bytecode pattern parser's escape handling, on failed `\x`/`\u` hex parse emit the literal char (annexB §B.1.4 ExtendedAtom); `\c` + non-letter → literal `\c`. Blocks `separator-regexp.js` (needs split-at-end-anchor fix too: our `__regex_split` matches at q==size — `"x".split(/$/)` → 2 elems, JS spec loops q<size → 1). | Opus point-fix (engine parser) |
-| F6 — reflection (`.name`/`.length`/prop-desc/`hasOwnProperty` on builtin methods, `RegExpStringIteratorPrototype`, legacy accessors `RegExp.$1`, cross-realm) | ~80+ (48 "Cannot access property" + hasOwnProperty clusters + 15 CE legacy-accessors) | Builtin-prototype-object representation. | dying via **#2175** (in-flight) — do NOT slice |
-| F7 — dynamic receivers / RegExpExec protocol observables (lastIndex-err tests, custom `exec`, `split.call(numberReceiver)`, ToPrimitive ctor args, `new RegExp(arr[i])`, 200-paren loop-built patterns) | ~120+ (38+8+5+4… clusters) | Needs the runtime regex compiler + runtime-externref receiver generalisation (documented Slice 9 "future architect-spec"). | architect-spec (NOT bounded) |
-| F8 — eval-based literal tests | 11 | `eval` unsupported by design. | wont-fix scope |
-| misc engine tail | ~30 | duplicate named groups (ES2025), regexp-modifiers, `\q{}` residue, step-limit (2), quantifier-integer-limit | separate small engine issues |
+| family                                                                                                                                                                                                  |                                                                                                                                                                      rows | root cause                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | verdict                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **B0 — null native-string ≠ undefined sentinel**                                                                                                                                                        |                                                                      ~76 in-bucket ("deref null in test()" 73 + compareArray 3; **109 across ALL standalone categories**) | THREE sinks mishandled the null-string = `undefined` sentinel (non-strict checker ERASES `undefined` from `["a",undefined]` unions; unmatched capture groups are null slots): (a) `coerceType` `ref_null→ref` emitted a trapping `ref.as_non_null` for native-string targets (type-coercion.ts ~1468); (b) the mixed `any === string` #1914 eq-arm and the tag-cascade eqref identity arm returned 0 for null/null (`ref.test` is false for null); (c) `$__regexp_match_vec` → `any[]` param fell into struct-NARROWING (`getVecInfo` only matches `__vec_*` names), ref-casting the `__arr_ref_<anyStr>` data array to `$__arr_externref` → null → trap; (d) `s === undefined` on a `string`-typed local constant-folded to false (#1105 gate was `ref_null`-only).                                                                                                                                                                                                                                                                                                | **FIXED this slice**                                                                                                                           |
+| **B2 — split undefined separator/limit**                                                                                                                                                                |                                                                                                                                                    ~15-25 of the split 72 | §22.1.3.23: `s.split()` / `s.split(undefined)` fell past the string-like-separator gate to the host marshal path (no standalone `string_split`) → null deref; a statically-`undefined` LIMIT compiled to f64 NaN → ToUint32(NaN)=0 → `[]`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | **FIXED this slice**                                                                                                                           |
+| **B4 — never-reassigned `var` pattern fold**                                                                                                                                                            |                                                                                                                                           ~15-20 of the 37 "illegal cast" | Slice 9's fold was `const`-only; sputnik binds patterns/flags with `var` (`var __re="d+"; RegExp(__re,"i")`), uses `void 0` / hoisted-uninitialised flags, `new RegExp(ctorCopy, "g")`, and diamond concat chains (the `seen` cycle-guard blocked same-binding re-references).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | **FIXED this slice**                                                                                                                           |
+| B1 — boxed `new String(x)` receiver OR argument                                                                                                                                                         | ~40 (`__str_flatten` deref: every `instance-is-string-hello` split/search/match/replace test + `re.exec(new String(...))` — verified the ARG position hits the same site) | `new String()` builds a `$Object` wrapper (`__new_String`, object-runtime.ts:~1390, primitive under `WRAPPER_PRIMITIVE_KEY`); any externref→AnyString coercion (`coerceType`'s externref→ref arm, type-coercion.ts ~1743: `ref.test $AnyString` → else `ref.null`) drops the wrapper to null → flatten trap. **Exact contract:** for a NATIVE-STRING target, extend that else-arm with the wrapper-slot probe `__to_primitive` already implements INLINE (object-runtime.ts ~2544: `ref.cast $Object` → `__obj_find(WRAPPER_PRIMITIVE_KEY)` → FLAG_INTERNAL check → value): `ref.test $Object` → read the internal slot → `ref.test $AnyString` → cast, else null. Do NOT call full `__to_primitive` (it would pull OrdinaryToPrimitive semantics — valueOf/toString dispatch — into every string coercion); extract just the slot read, gated on the object runtime already being in the module (`ctx.funcMap.has("__obj_find")` — `new String` registration guarantees it). Watch late-registration ordering (funcIdx shifts — flushLateImportShifts discipline). | Opus point-fix (bounded, shared-coercion blast radius — needs the full string-suite battery this slice's `.tmp/battery-final` set established) |
+| B5 — annexB identity-escape fallbacks                                                                                                                                                                   |                                                                                                                                                                     ~6-10 | `/\x/`, `/\u/` (incomplete hex/unicode), `/\c1/`-class escapes: the pattern compiler refuses → placeholder trap. AnnexB says incomplete escapes fall through to IdentityEscape. **Exact contract:** in the bytecode pattern parser's escape handling, on failed `\x`/`\u` hex parse emit the literal char (annexB §B.1.4 ExtendedAtom); `\c` + non-letter → literal `\c`. Blocks `separator-regexp.js` (needs split-at-end-anchor fix too: our `__regex_split` matches at q==size — `"x".split(/$/)` → 2 elems, JS spec loops q<size → 1).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Opus point-fix (engine parser)                                                                                                                 |
+| F6 — reflection (`.name`/`.length`/prop-desc/`hasOwnProperty` on builtin methods, `RegExpStringIteratorPrototype`, legacy accessors `RegExp.$1`, cross-realm)                                           |                                                                                     ~80+ (48 "Cannot access property" + hasOwnProperty clusters + 15 CE legacy-accessors) | Builtin-prototype-object representation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | dying via **#2175** (in-flight) — do NOT slice                                                                                                 |
+| F7 — dynamic receivers / RegExpExec protocol observables (lastIndex-err tests, custom `exec`, `split.call(numberReceiver)`, ToPrimitive ctor args, `new RegExp(arr[i])`, 200-paren loop-built patterns) |                                                                                                                                                ~120+ (38+8+5+4… clusters) | Needs the runtime regex compiler + runtime-externref receiver generalisation (documented Slice 9 "future architect-spec").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | architect-spec (NOT bounded)                                                                                                                   |
+| F8 — eval-based literal tests                                                                                                                                                                           |                                                                                                                                                                        11 | `eval` unsupported by design.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | wont-fix scope                                                                                                                                 |
+| misc engine tail                                                                                                                                                                                        |                                                                                                                                                                       ~30 | duplicate named groups (ES2025), regexp-modifiers, `\q{}` residue, step-limit (2), quantifier-integer-limit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | separate small engine issues                                                                                                                   |
 
 ### Shipped (this slice, all standalone, zero new host imports)
 
@@ -564,3 +569,62 @@ coercion-sites, any-box-sites, prettier all clean.
 
 **#2161 stays open (blocked on #2175)** for F6 reflection; F7 dynamic-receiver
 architecture and B1/B5 point-fix contracts above are the next pickups.
+
+## Slice 11 (2026-07-04, opus-2161b1) — family B1: boxed `new String` receiver/argument — LANDED
+
+**Landed** the banked B1 contract (slice-10 family map, row B1). Regrounded on
+current main: every `new String(...)` receiver/argument in a standalone
+RegExp/String-method context trapped **"dereferencing a null pointer"** — split /
+search / match / replace / matchAll on a boxed-String receiver, and
+`re.exec(new String(s))` / `re.test(new String(s))` in the argument position.
+
+**Root cause (verified).** `new String(x)` builds a `$Object` wrapper
+(`__new_String`, object-runtime.ts) carrying its [[StringData]] under the
+reserved FLAG_INTERNAL `WRAPPER_PRIMITIVE_KEY` slot. When that wrapper reached
+the externref → native-`$AnyString` coercion else-arm in `coerceType`
+(type-coercion.ts — the string-method subject / string-argument path both target
+`nativeStringType` = `ref $AnyString`), the generic `ref.test $AnyString` missed
+it (a wrapper is an object, not a string) and the value was dropped to
+`ref.null` → the downstream `__str_flatten` trapped on null.
+
+**Fix** (zero new host imports, standalone-only, byte-inert for non-boxing
+programs):
+
+- `src/codegen/object-runtime.ts`: new lazily-registered
+  `ensureWrapperStringValueHelper(ctx)` → defines
+  `__wrapper_string_value(externref) -> ref null $AnyString`. It extracts JUST
+  the wrapper's primitive-string slot — the SAME internal-slot read
+  `__to_primitive` performs inline (§7.1.1.1: `ref.test $Object` →
+  `__obj_find(WRAPPER_PRIMITIVE_KEY)` → FLAG_INTERNAL check → `ref.test
+$AnyString` on the slot value → cast, else null) — WITHOUT pulling in
+  OrdinaryToPrimitive (the valueOf/toString method dispatch). Returns the native
+  string for a boxed-String wrapper, null for every other value (plain object,
+  other wrapper kind, non-string slot). Registered on demand and idempotently, so
+  a module that never boxes a String stays byte-identical.
+- `src/codegen/type-coercion.ts`: the externref → `ref/ref_null` arm's failed-cast
+  else-branch, when the target is exactly `$AnyString` (`toIdx ===
+ctx.anyStrTypeIdx`) and the object runtime is present
+  (`ctx.objectRuntimeTypes` + `__obj_find`), now calls `__wrapper_string_value`
+  instead of dropping to null. Only the `$AnyString` supertype target qualifies —
+  the wrapper's stored string is a native-string subtype, so the helper's
+  `ref.cast $AnyString` never traps; narrower string-subtype targets keep the
+  prior null fallthrough. gc/host mode (anyStrTypeIdx = -1) and string-free
+  modules fall through unchanged.
+
+**Validation.** New `tests/issue-2161-b1-boxed-string.test.ts` (11 cases, all
+standalone + empty importObject asserting zero non-`wasm:js-string` import leak):
+the real test262 `instance-is-string-hello` split shape (length/`[0]`/`[1]`/`[2]`),
+split-by-string, search, match (global + numbered captures), replace, matchAll on
+a boxed receiver; `re.exec` / `re.test` with a boxed-String argument; plus
+no-regression controls (plain string receiver, plain-object argument stays a
+non-match). Byte-inertness confirmed: numeric / array / string / object programs
+compile to sha256-identical binaries vs clean main (helper is emitted only when a
+qualifying coercion needs it). Blast-radius battery (~35 files: regex #1539/#1911/
+#1912/#1913/#1914/#1474/#2161-_/#2175/#2588/#2591/#2671, wrapper #1910-_/#2029/
+#2160-wrapper-_, equality #2191/#2503b, string-coercion #1470-_/#2160/#2598/#2600/
+#2374, coercion #1917/call-arg/#2934) shows every failure is PRE-EXISTING on clean
+main (identical sets — the #1539/#2161 "expects-refusal" reds and the #2175
+in-flight / #2600 gc-mode reds) — my change adds **zero** new failures. tsc clean.
+
+**#2161 stays open (blocked on #2175)** for F6 reflection; F7 dynamic-receiver
+architecture and the B5 annexB-escape point-fix are the remaining pickups.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -7105,6 +7105,125 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   return types;
 }
 
+/**
+ * (#2161 B1) `__wrapper_string_value(externref) -> ref null $AnyString` —
+ * boxed-`new String(...)` receiver/argument primitive-string recovery.
+ *
+ * A `new String(x)` produces a `$Object` wrapper (`__new_String`) carrying its
+ * [[StringData]] under the reserved FLAG_INTERNAL `WRAPPER_PRIMITIVE_KEY` slot.
+ * When such a wrapper reaches an externref→native-`$AnyString` coercion (a string
+ * method's receiver-as-subject, e.g. `new String("hello").split(/l/)`, or a
+ * string-typed argument) the generic `ref.test $AnyString` misses it (a wrapper
+ * is an object, not a string) and the value was previously dropped to null →
+ * downstream `__str_flatten` trapped ("dereferencing a null pointer").
+ *
+ * This helper extracts JUST the wrapper's primitive-string slot — the same
+ * internal-slot read `__to_primitive` performs inline (§7.1.1.1: the wrapper's
+ * intrinsic valueOf/toString return the internal primitive) — WITHOUT pulling in
+ * OrdinaryToPrimitive (the valueOf/toString method dispatch), so it stays a pure
+ * bounded slot probe with no user-observable side effects. It returns the native
+ * string when the input is a boxed-String wrapper, else null (a plain object,
+ * another wrapper kind, or a non-string slot value), so the caller keeps its
+ * prior null fallthrough for every non-boxed-String value.
+ *
+ * Registered lazily and idempotently — only when a qualifying coercion actually
+ * needs it, so modules that never box a String stay byte-identical. Returns the
+ * func index, or -1 when the object runtime is absent (no `__obj_find`) or native
+ * strings are off (gc/host mode) — in which case the caller falls through to its
+ * prior null. `ensureObjectRuntime` has already run (a boxed String cannot exist
+ * otherwise), so `ctx.objectRuntimeTypes` and `__obj_find` are settled and no
+ * late-import shift is pending.
+ */
+export function ensureWrapperStringValueHelper(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__wrapper_string_value");
+  if (existing !== undefined) return existing;
+
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const objTypes = ctx.objectRuntimeTypes;
+  const objFindIdx = ctx.funcMap.get("__obj_find");
+  if (anyStrTypeIdx < 0 || objTypes === undefined || objFindIdx === undefined) {
+    return -1;
+  }
+  const { objectTypeIdx, propEntryTypeIdx } = objTypes;
+  const anyStrRefNull: ValType = { kind: "ref_null", typeIdx: anyStrTypeIdx };
+
+  const body: Instr[] = [
+    // a = any.convert_extern(x)
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: 1 },
+    { op: "ref.test", typeIdx: objectTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: anyStrRefNull },
+      then: [
+        // e = __obj_find(cast<$Object>(a), WRAPPER_PRIMITIVE_KEY)
+        { op: "local.get", index: 1 },
+        { op: "ref.cast", typeIdx: objectTypeIdx },
+        ...((): Instr[] => {
+          addStringConstantGlobal(ctx, WRAPPER_PRIMITIVE_KEY);
+          return stringConstantExternrefInstrs(ctx, WRAPPER_PRIMITIVE_KEY);
+        })(),
+        { op: "call", funcIdx: objFindIdx },
+        { op: "local.tee", index: 2 },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: anyStrRefNull },
+          then: [{ op: "ref.null", typeIdx: anyStrTypeIdx } as Instr],
+          else: [
+            // confirm the entry is the internal slot (FLAG_INTERNAL)
+            { op: "local.get", index: 2 },
+            { op: "ref.as_non_null" },
+            { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 }, // flags
+            { op: "i32.const", value: FLAG_INTERNAL },
+            { op: "i32.and" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: anyStrRefNull },
+              then: [
+                // v = entry.value (anyref); if it is a native string, return it
+                { op: "local.get", index: 2 },
+                { op: "ref.as_non_null" },
+                { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 }, // value
+                { op: "local.tee", index: 3 },
+                { op: "ref.test", typeIdx: anyStrTypeIdx },
+                {
+                  op: "if",
+                  blockType: { kind: "val", type: anyStrRefNull },
+                  then: [
+                    { op: "local.get", index: 3 },
+                    { op: "ref.cast", typeIdx: anyStrTypeIdx },
+                  ],
+                  else: [{ op: "ref.null", typeIdx: anyStrTypeIdx } as Instr],
+                } as Instr,
+              ],
+              else: [{ op: "ref.null", typeIdx: anyStrTypeIdx } as Instr],
+            } as Instr,
+          ],
+        } as Instr,
+      ],
+      else: [{ op: "ref.null", typeIdx: anyStrTypeIdx } as Instr],
+    } as Instr,
+  ];
+
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [anyStrRefNull]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__wrapper_string_value", funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: "__wrapper_string_value",
+    typeIdx,
+    locals: [
+      { name: "a", type: { kind: "anyref" } },
+      { name: "e", type: { kind: "ref_null", typeIdx: propEntryTypeIdx } },
+      { name: "v", type: { kind: "anyref" } },
+    ],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
 /** (#1100/#1355) Reserved trap-invoke driver names — filled by `fillProxyDispatch`. */
 const PROXY_CALL_GET = "__proxy_call_get";
 const PROXY_CALL_SET = "__proxy_call_set";

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -15,6 +15,7 @@ import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js
 import { addUnionImports, ensureAnyHelpers, ensureAnyToExternHelper, isAnyValue } from "./index.js";
 import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
+import { ensureWrapperStringValueHelper } from "./object-runtime.js";
 import { ensureNativeArrayFromIterN } from "./iterator-native.js";
 import { markNoBrandSiblingShapes } from "./shape-brand.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
@@ -1811,6 +1812,33 @@ export function coerceType(
       const tupleFields = getTupleFields(ctx, toIdx);
       if (tupleFields) {
         elseBranch = buildTupleFromExternref(ctx, fctx, tmpAnyLocal, toIdx, tupleFields, tmpExternLocal);
+      } else if (
+        // (#2161 B1) externref → native `$AnyString` where the cast failed: the
+        // source may be a boxed-`new String(...)` wrapper ($Object carrying its
+        // [[StringData]] under the FLAG_INTERNAL WRAPPER_PRIMITIVE_KEY slot). The
+        // generic `ref.test $AnyString` misses it (a wrapper is an object, not a
+        // string) so it was dropped to null → downstream `__str_flatten` trapped
+        // on `new String(s).split/search/match/replace`. Recover the wrapper's
+        // primitive string via `__wrapper_string_value` (the same internal-slot
+        // read `__to_primitive` does inline, WITHOUT the OrdinaryToPrimitive
+        // valueOf/toString dispatch — a bare slot probe). Gated on the object
+        // runtime already being present (`ensureWrapperStringValueHelper` returns
+        // -1 for gc/host mode or a string-free / object-free module) so string-
+        // free programs stay byte-identical. Only the `$AnyString` supertype
+        // target qualifies — the wrapper's stored string is a native-string
+        // subtype of it, so the helper's `ref.cast $AnyString` never traps;
+        // narrower string-subtype targets keep the prior null fallthrough.
+        toIdx === ctx.anyStrTypeIdx &&
+        ctx.anyStrTypeIdx >= 0 &&
+        ctx.objectRuntimeTypes !== undefined &&
+        ctx.funcMap.has("__obj_find") &&
+        ensureWrapperStringValueHelper(ctx) >= 0
+      ) {
+        const wrapperValIdx = ctx.funcMap.get("__wrapper_string_value")!;
+        elseBranch = [
+          { op: "local.get", index: tmpExternLocal },
+          { op: "call", funcIdx: wrapperValIdx },
+        ];
       } else {
         elseBranch = [{ op: "ref.null", typeIdx: toIdx } as Instr];
       }

--- a/tests/issue-2161-b1-boxed-string.test.ts
+++ b/tests/issue-2161-b1-boxed-string.test.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2161 family B1 — boxed `new String(...)` receiver / argument in a standalone
+ * RegExp / String-method context.
+ *
+ * `new String(x)` builds a `$Object` wrapper (`__new_String`) carrying its
+ * [[StringData]] under the reserved FLAG_INTERNAL WRAPPER_PRIMITIVE_KEY slot.
+ * When such a wrapper flowed into an externref → native-`$AnyString` coercion
+ * — the receiver-as-subject of `String.prototype.split/search/match/replace/
+ * matchAll`, or the string argument of `RegExp.prototype.exec/test` — the
+ * generic `ref.test $AnyString` missed it (a wrapper is an object, not a string)
+ * and the value was dropped to null → downstream `__str_flatten` trapped
+ * ("dereferencing a null pointer"). This is the `__str_flatten` deref family the
+ * #2161 fresh harvest banked as B1 (~40 rows: every `instance-is-string-hello`
+ * split/search/match/replace test plus `re.exec(new String(...))`).
+ *
+ * The fix teaches that coercion's else-arm to recover the wrapper's primitive
+ * string via `__wrapper_string_value` — the same internal-slot read
+ * `__to_primitive` performs inline (§7.1.1.1), WITHOUT the OrdinaryToPrimitive
+ * valueOf/toString method dispatch (a pure, side-effect-free slot probe). The
+ * helper is registered lazily and only when a qualifying coercion needs it, so
+ * modules that never box a String stay byte-identical.
+ *
+ * All standalone with an EMPTY importObject — a boxed-String recovery that
+ * leaked a host import (`env::__str_*` / `env::__extern_*`) would fail to
+ * instantiate. `skipSemanticDiagnostics` mirrors the test262 runner: sputnik
+ * sources are JS, so a `String`-wrapper receiver/argument flows into the native
+ * string-method paths exactly as it does under test262 (strict TS would reject
+ * `String` where `string` is wanted before codegen ever runs).
+ */
+async function runStandalone(src: string): Promise<{ leaks: string[]; main: () => unknown }> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const leaks = r.imports.map((i) => `${i.module}::${i.name}`).filter((l) => !l.startsWith("wasm:js-string::"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return { leaks, main: instance.exports.main as () => unknown };
+}
+
+describe("#2161 B1 — boxed new String receiver (standalone, host-free)", () => {
+  it("split(/re/) on a boxed String matches the real test262 instance-is-string-hello shape", async () => {
+    // mirrors built-ins/String/prototype/split/argument-is-regexp-l-and-instance-is-string-hello.js
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var __string = new String("hello");
+        var __split = __string.split(/l/);
+        var ok = 1;
+        if (__split.length !== 3) ok = 0;
+        if (__split[0] !== "he") ok = 0;
+        if (__split[1] !== "") ok = 0;
+        if (__split[2] !== "o") ok = 0;
+        return ok;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(1);
+  });
+
+  it("split(string) on a boxed String receiver does not trap", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = new String("a-b-c");
+        return s.split("-").length;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(3);
+  });
+
+  it("search(/re/) on a boxed String receiver returns the match index", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = new String("hello world");
+        return s.search(/wor/);
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(6);
+  });
+
+  it("match(/re/g) on a boxed String receiver returns all matches", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = new String("aXbXc");
+        var m = s.match(/X/g);
+        return m ? m.length : -1;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("match(/re/) on a boxed String exposes numbered capture groups", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = new String("2026-07");
+        var m = s.match(/(\\d+)-(\\d+)/);
+        return m ? Number(m[1]) + Number(m[2]) : -1;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2033);
+  });
+
+  it("replace(/re/g, str) on a boxed String receiver yields the right string", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = new String("aXbXc");
+        var r = s.replace(/X/g, "-");
+        // "a-b-c": length 5, char at index 1 is '-'
+        return r.length === 5 && r.charCodeAt(1) === 45 ? 1 : 0;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(1);
+  });
+
+  it("matchAll(/re/g) on a boxed String receiver iterates captures", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = new String("a1b2");
+        var sum = 0;
+        for (const m of s.matchAll(/(\\d)/g)) sum += Number(m[1]);
+        return sum;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(3);
+  });
+});
+
+describe("#2161 B1 — boxed new String argument (standalone, host-free)", () => {
+  it("re.exec(new String(...)) recovers the boxed subject", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var m = /b/.exec(new String("abc"));
+        return m ? m.index : -99;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(1);
+  });
+
+  it("re.test(new String(...)) recovers the boxed subject", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        return /i/.test(new String("hi")) ? 1 : 0;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(1);
+  });
+});
+
+describe("#2161 B1 — no-regression controls (standalone)", () => {
+  it("a plain string receiver still works (no wrapper involved)", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var s = "aXbXc";
+        var m = s.match(/X/g);
+        return m ? m.length : -1;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("a plain (non-wrapper) object argument does not spuriously become a string", async () => {
+    // A plain object is NOT a boxed-String wrapper: the helper returns null for
+    // it, so the prior null fallthrough is preserved — `.test` sees no match.
+    const { leaks, main } = await runStandalone(
+      `export function main(): number {
+        var o: any = { toString: 0 };
+        return /i/.test(o) ? 1 : 0;
+      }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2161 family B1 — boxed `new String(...)` receiver / argument (standalone)

Banked, HIGH-confidence slice from the fresh-harvest family map (slice 10, row B1).

### Root cause
`new String(x)` builds a `$Object` wrapper (`__new_String`) carrying its `[[StringData]]` under the reserved FLAG_INTERNAL `WRAPPER_PRIMITIVE_KEY` slot. When that wrapper flowed into the externref → native `$AnyString` coercion else-arm — the subject of `String.prototype.split/search/match/replace/matchAll`, or the argument of `RegExp.prototype.exec/test` — the generic `ref.test $AnyString` missed it (a wrapper is an object, not a string) and the value was dropped to `ref.null` → downstream `__str_flatten` trapped ("dereferencing a null pointer"). This is the `__str_flatten` deref family B1 (~40 rows: every `instance-is-string-hello` split/search/match/replace test plus `re.exec(new String(...))`).

### Fix (standalone-only, zero new host imports, byte-inert for non-boxing programs)
- **`src/codegen/object-runtime.ts`** — new lazily-registered `ensureWrapperStringValueHelper` → `__wrapper_string_value(externref) -> ref null $AnyString`. Extracts JUST the wrapper's primitive-string slot (the same internal-slot read `__to_primitive` performs inline per §7.1.1.1: `ref.test $Object` → `__obj_find(WRAPPER_PRIMITIVE_KEY)` → FLAG_INTERNAL → `ref.test $AnyString` → cast) **without** the OrdinaryToPrimitive valueOf/toString dispatch. Returns null for every non-boxed-String value. Registered on demand, so string-free / object-free modules stay byte-identical.
- **`src/codegen/type-coercion.ts`** — the externref→ref failed-cast else-branch, when the target is exactly `$AnyString` and the object runtime is present, calls the helper instead of dropping to null. gc/host mode (anyStrTypeIdx = -1) and string-free modules unchanged.

### Validation
- **`tests/issue-2161-b1-boxed-string.test.ts`** (11 cases, all standalone + empty importObject asserting zero non-`wasm:js-string` import leak): the real test262 `instance-is-string-hello` split shape, split/search/match/replace/matchAll on a boxed receiver, `re.exec`/`re.test` with a boxed argument, plus no-regression controls (plain string receiver, plain-object argument stays a non-match).
- **Byte-inertness**: numeric / array / string / object programs compile to sha256-identical binaries vs clean main (helper emitted only when a qualifying coercion needs it).
- **Blast-radius battery** (~35 files: regex #1539/#1911/#1912/#1913/#1914/#1474/#2161-*/#2175/#2588/#2591/#2671, wrapper #1910-*/#2029/#2160-wrapper-*, equality #2191/#2503b, string-coercion #1470-*/#2160/#2598/#2600/#2374, coercion #1917/call-arg/#2934): every failure is PRE-EXISTING on clean main (identical sets — the #1539/#2161 expects-refusal reds, the #2175 in-flight and #2600 gc-mode reds). **Zero new failures.** tsc clean.

`#2161` stays blocked on `#2175` for F6 reflection; F7 dynamic-receiver and B5 annexB-escape remain the next pickups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8