### PR TITLE
feat(#2906): slice 3a — while-with-await on the multi-state async drive machine

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -461,3 +461,49 @@ the frame ABI (both layouts already share frame-core).
 - **#2980 slice-1d (carrier widen)**: stays LAST, after 3a/3b land, gated on
   the full merge_group standalone corpus measuring net-positive. This slice
   changed nothing it depends on.
+
+## Slice 3a landed — while-with-await (2026-07-04, opus-2957p2)
+
+**Done** (native host-free drive lane). `while (cond) { …≥1 canonical await… }`
+async bodies now drive on the multi-state CFG machine. Measure-first on the
+branch base: a while-await wasi fn was host-free-compilable but never completed
+(the loop CFG was producer-unreachable). After 3a the canonical loop resolves
+across genuine suspensions with the accumulator surviving each spill/restore.
+
+**How** (planner + spill only — the emitter already had goto/condGoto):
+- `async-cps.ts` — `planAsyncCfg(fn, plan, {allowLoops})` is now the single CFG
+  producer for the drive lane. Linear bodies **delegate** to the byte-identical
+  `linearPlanToCfg(planLinearAwaits(...))` path (proven: the 69-test async drive
+  blast radius stays green); when `allowLoops` (native lane only) and the body is
+  a canonical single-`while`-with-await, `planWhileLoopCfg` builds the loop CFG:
+  entry (pre-leads) → head `condGoto(cond, body0, exit)` → body suspend states →
+  continuation `goto(head)` back-edge → exit `settleUndefined`. Reuses
+  `lowerLinearStatements` for the loop body. `loopAsyncSpillInfo` exposes the
+  widened spill set.
+- `async-frame.ts` — routed the emitter + `asyncFnNeedsDrive` + `computeAsyncSpills`
+  through `planAsyncCfg`/`computeLoopSpills`. **Loop-liveness (the silent-miscompile
+  trap, contract rule 3/4):** every own-local referenced anywhere in the loop is
+  spilled (a local read before the await is read again after resume next
+  iteration); the drive gate falls back to legacy if any such local is not a
+  spill-safe type. Host settle backend keeps the linear-only shape (loops =
+  N-round follow-up).
+- **Emitter fix (latent, uncovered by 3a):** the never-exercised `goto`/`condGoto`
+  `br` depths were off by one. The re-dispatch `loop` is at `loopDepth` (id+2)
+  from ONE level inside an `if` arm (where the proven suspend fast-path advance br
+  sits) → `loopDepth-1` from a state-body top level. `goto` (top level) now uses
+  `loopDepth-1`; `condGoto` (br inside its `if(cond)` arm) uses `loopDepth`.
+
+**Scope / bank.** Bounded to a single `while` whose body is linear-canonical with
+no `break`/`continue`/`return`/labeled/nested-loop/`switch`/`try` and an
+await-free condition; anything richer falls back to legacy. Follow-ups (per the
+banked design): do-while, await-in-condition, break/continue as `goto exit`/
+`goto head` (3a′), for-await-of (3b), try/catch + return-through-finally (3c),
+host-lane loops. Issue stays `in-progress`.
+
+**Tests** `tests/issue-2906-3a-while-await.test.ts` (6): sync-settled full run,
+genuinely-pending across 3 iterations (accumulator survives spill), zero-iteration,
+prefix-local carried across the back-edge, bare-`await` side effects in order,
+and break→legacy-fallback. Blast radius green (async-await / issue-1042 /
+issue-1042-host-drive / issue-2895 / async-census + issue-2174/2611/1672); the
+2× issue-2865 and 3× issue-2906-gap3 failures are pre-existing on clean
+`origin/main`. `tsc --noEmit` clean.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1136,6 +1136,260 @@ export function linearPlanToCfg(linear: LinearAwaitPlan): AsyncCfgPlan {
 }
 
 // ---------------------------------------------------------------------------
+// CFG producer + while-loop planner (#2906 slice 3a).
+//
+// `planAsyncCfg` is the single entry point the drive lane uses to obtain an
+// `AsyncCfgPlan`. For a LINEAR body it delegates to the proven
+// `planLinearAwaits` → `linearPlanToCfg` path, so every non-loop program's
+// emitted machine is byte-identical to the pre-3a emitter. When `opts.allowLoops`
+// is set (native drive lane only, from `asyncFnNeedsDrive`) and the body is a
+// single canonical `while (cond) { …await… }` shape, `planWhileLoopCfg` builds
+// the loop CFG directly: a head state whose `condGoto` enters the body or the
+// exit, body suspend states, and a continuation state whose `goto(head)` is the
+// back-edge. The emitter already handles `goto`/`condGoto`/back-edges (a target
+// ≤ the current id is a loop), so this is planner-only.
+// ---------------------------------------------------------------------------
+
+/** Options for {@link planAsyncCfg}. */
+export interface AsyncCfgOptions {
+  /**
+   * Accept loop shapes (while-with-await). Set only on the native drive lane
+   * (`asyncFnNeedsDrive`); the JS-host lane keeps the linear-only shape until a
+   * follow-up widens it (the host lane suspends on EVERY await → N iterations =
+   * N microtask rounds; correct but needs its own corpus check).
+   */
+  readonly allowLoops: boolean;
+}
+
+/**
+ * The single CFG producer for the drive lane. Linear bodies delegate to the
+ * byte-identical `linearPlanToCfg(planLinearAwaits(...))` path; when loops are
+ * allowed, a canonical `while`-with-await body is lowered by
+ * {@link planWhileLoopCfg}. Returns `null` (→ legacy/AG0 fallback) for anything
+ * outside the accepted shapes.
+ */
+export function planAsyncCfg(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+  opts: AsyncCfgOptions,
+): AsyncCfgPlan | null {
+  const linear = planLinearAwaits(fn, plan);
+  if (linear !== null) return linearPlanToCfg(linear);
+  if (opts.allowLoops) return planWhileLoopCfg(fn, plan);
+  return null;
+}
+
+/**
+ * Structural analysis of a single-`while`-with-await async body. Returns the
+ * pre-loop leads, the loop condition, the lowered body (suspend segments + tail),
+ * and the post-loop leads — or `null` when the body is not the bounded 3a shape.
+ *
+ * Bounded slice (everything else → legacy/AG0 fallback):
+ *   - the body is a flat statement block whose ONLY awaiting statement is a
+ *     single `while` (pre/post statements are await-free);
+ *   - the `while` condition is await-free (an awaiting condition needs a
+ *     condition-eval state — a follow-up);
+ *   - the loop body is linear-canonical (the same per-statement await positions
+ *     `lowerLinearStatements` accepts) with ≥1 await and NO `return await`
+ *     (a function return through the loop is a follow-up);
+ *   - no `break`/`continue`/labeled statement/nested loop/`switch`/`try`/`return`
+ *     inside the loop body (abrupt loop/function exit — a follow-up).
+ */
+function analyzeWhileAsync(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): {
+  pre: ts.Statement[];
+  cond: ts.Expression;
+  segments: LinearAwaitSegment[];
+  tail: ts.Statement[];
+  post: ts.Statement[];
+  whileStmt: ts.WhileStatement;
+} | null {
+  if (plan.awaitPoints.length === 0) return null;
+  const body = fn.body;
+  if (body === undefined || !ts.isBlock(body)) return null;
+  const awaitSet = new Set<ts.AwaitExpression>(plan.awaitPoints);
+
+  // Find the single top-level statement carrying awaits; it must be a `while`.
+  let whileIdx = -1;
+  for (let i = 0; i < body.statements.length; i++) {
+    const c = countAwaitsInStatement(body.statements[i]!, awaitSet);
+    if (c === 0) continue;
+    if (whileIdx !== -1) return null; // awaits in >1 top-level statement — not this shape
+    if (!ts.isWhileStatement(body.statements[i]!)) return null; // await outside a while
+    whileIdx = i;
+  }
+  if (whileIdx === -1) return null;
+  const whileStmt = body.statements[whileIdx] as ts.WhileStatement;
+
+  // await in the condition → needs a condition-eval state (follow-up).
+  if (countAwaitsInStatement(whileStmt.expression, awaitSet) > 0) return null;
+
+  // Reject abrupt-exit / non-linear control inside the loop body.
+  if (loopBodyHasUnsupportedControl(whileStmt.statement)) return null;
+
+  const bodyStmts = ts.isBlock(whileStmt.statement) ? whileStmt.statement.statements : [whileStmt.statement];
+
+  // Lower the loop body into suspend segments via the shared linear lowering.
+  const st: LowerState = {
+    segments: [],
+    lead: [],
+    leadInTry: [],
+    finalizer: null,
+    theFinalizer: null,
+    usedFinally: false,
+    sawReturnAwait: false,
+  };
+  if (!lowerLinearStatements(bodyStmts, st, awaitSet)) return null;
+  if (st.segments.length === 0) return null; // no canonical await in the body
+  if (st.segments.length !== plan.awaitPoints.length) return null; // stray await elsewhere
+  for (const seg of st.segments) if (seg.isReturnAwait) return null; // return-await in loop — follow-up
+  if (st.theFinalizer !== null) return null; // try/finally in loop — follow-up
+
+  return {
+    pre: [...body.statements.slice(0, whileIdx)],
+    cond: whileStmt.expression,
+    segments: st.segments,
+    tail: st.lead,
+    post: [...body.statements.slice(whileIdx + 1)],
+    whileStmt,
+  };
+}
+
+/** True when the loop body contains control the bounded 3a slice cannot express. */
+function loopBodyHasUnsupportedControl(loopBody: ts.Statement): boolean {
+  let bad = false;
+  const walk = (node: ts.Node): void => {
+    if (bad) return;
+    if (isNestedFunctionScope(node)) return; // a nested fn's break/return is its own
+    if (
+      ts.isBreakStatement(node) ||
+      ts.isContinueStatement(node) ||
+      ts.isReturnStatement(node) ||
+      ts.isLabeledStatement(node) ||
+      ts.isSwitchStatement(node) ||
+      ts.isForStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isWhileStatement(node) ||
+      ts.isDoStatement(node) ||
+      ts.isTryStatement(node)
+    ) {
+      bad = true;
+      return;
+    }
+    forEachChild(node, walk);
+  };
+  walk(loopBody);
+  return bad;
+}
+
+/**
+ * Build the loop CFG for a bounded `while (cond) { …await… }` async body.
+ * State layout (dense ids in push order):
+ *   [entry]  pre-loop leads → goto(head)          (only when pre is non-empty)
+ *    head    lead=[]        → condGoto(cond, body0, exit)   ← back-edge target
+ *    body_k  seg_k leads    → suspend(seg_k.await, resume→next)   (k = 0..m-1)
+ *    cont    tail leads     → goto(head)                    (the back-edge)
+ *    exit    post leads     → settleUndefined
+ */
+function planWhileLoopCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): AsyncCfgPlan | null {
+  const shape = analyzeWhileAsync(fn, plan);
+  if (shape === null) return null;
+  const { pre, cond, segments, tail, post } = shape;
+  const m = segments.length;
+
+  const hasPre = pre.length > 0;
+  const headId = hasPre ? 1 : 0;
+  const body0Id = headId + 1;
+  const contId = body0Id + m; // continuation after the last body await
+  const exitId = contId + 1;
+
+  const asLead = (stmts: readonly ts.Statement[]): AsyncCfgStmt[] => stmts.map((stmt) => ({ stmt, handler: 0 }));
+
+  const states: AsyncCfgState[] = [];
+  if (hasPre) {
+    states.push({ id: 0, resumeFrom: null, lead: asLead(pre), terminator: { kind: "goto", target: headId } });
+  }
+  // Loop head: evaluate the condition, branch into the body or the exit.
+  states.push({
+    id: headId,
+    resumeFrom: null,
+    lead: [],
+    terminator: { kind: "condGoto", cond, whenTrue: body0Id, whenFalse: exitId, handler: 0 },
+  });
+  // Body suspend states (one per await).
+  for (let k = 0; k < m; k++) {
+    const seg = segments[k]!;
+    states.push({
+      id: body0Id + k,
+      resumeFrom: k === 0 ? null : { binding: segments[k - 1]!.resumeBinding, handler: 0 },
+      lead: asLead(seg.leadStmts),
+      terminator: {
+        kind: "suspend",
+        awaited: seg.awaitedExpr,
+        resumeState: k < m - 1 ? body0Id + k + 1 : contId,
+        handler: 0,
+      },
+    });
+  }
+  // Continuation: deliver the last await's value, run the tail, loop back.
+  states.push({
+    id: contId,
+    resumeFrom: { binding: segments[m - 1]!.resumeBinding, handler: 0 },
+    lead: asLead(tail),
+    terminator: { kind: "goto", target: headId },
+  });
+  // Exit: run the post-loop statements, settle undefined.
+  states.push({
+    id: exitId,
+    resumeFrom: null,
+    lead: asLead(post),
+    terminator: { kind: "settleUndefined" },
+  });
+
+  return { states, handlers: [] };
+}
+
+/**
+ * (#2906 slice 3a) The own-locals that must be spilled for a `while`-with-await
+ * body, plus the body's suspend segments (for resume-binding spill types). Every
+ * own-local (non-param) referenced anywhere in the loop statement is live across
+ * the loop-carried await — a local read textually BEFORE the await is read again
+ * AFTER the resume on the next iteration — so the whole set is spilled (rule 3/4
+ * of the 3a contract: widen to every loop own-local + every resume binding is
+ * self-live). Returns `null` when the body is not the bounded while shape.
+ */
+export function loopAsyncSpillInfo(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): { names: string[]; segments: readonly LinearAwaitSegment[] } | null {
+  const shape = analyzeWhileAsync(fn, plan);
+  if (shape === null) return null;
+  const ownLocals = new Set<string>();
+  collectAllDeclaredNames(fn, ownLocals);
+  const paramNames = new Set<string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) paramNames.add(p.name.text);
+    else collectBindingPatternNames(p.name, paramNames);
+  }
+  // Names referenced anywhere in the while statement that are own body locals.
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const walk = (node: ts.Node): void => {
+    if (isNestedFunctionScope(node)) return;
+    if (ts.isIdentifier(node) && ownLocals.has(node.text) && !paramNames.has(node.text) && !seen.has(node.text)) {
+      seen.add(node.text);
+      names.push(node.text);
+    }
+    forEachChild(node, walk);
+  };
+  walk(shape.whileStmt);
+  return { names, segments: shape.segments };
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers (private to async-cps.ts)
 // ---------------------------------------------------------------------------
 

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -36,12 +36,13 @@ import type { Instr, ValType, WasmFunction } from "../ir/types.js";
  * drive layer exists is precisely the AG0 −31 regression).
  */
 import { forEachChild, ts } from "../ts-api.js";
-import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint, LinearAwaitPlan } from "./async-cps.js";
+import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint } from "./async-cps.js";
 import {
   ASYNC_CPS_ENABLED,
   asyncFnNeedsCps,
   awaitedExprIsPromiseCombinator,
-  linearPlanToCfg,
+  loopAsyncSpillInfo,
+  planAsyncCfg,
   planLinearAwaits,
 } from "./async-cps.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3 / #2710) stable-regime minting
@@ -426,7 +427,15 @@ export function asyncFnNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclar
   const anyRealSuspension = plan.awaitPoints.some((a) => plan.awaitedStaticallyResolved.get(a) !== true);
   if (!anyRealSuspension) return false; // fully await-elidable → sync + resolved promise
   const linear = planLinearAwaits(fn, plan);
-  if (linear === null) return false;
+  if (linear === null) {
+    // (#2906 slice 3a) `while`-with-await loop shape (native drive lane only).
+    // Eligible when every widened loop spill local has a spill-safe type — a
+    // non-spill-safe field (e.g. a non-nullable ref with no inert default) would
+    // make the frame layout invalid, so those fall back to legacy.
+    const loop = computeLoopSpills(ctx, fn, plan);
+    if (loop === null) return false;
+    return loop.spillTypes.every(isSpillSafeType);
+  }
   // Parity with asyncFnNeedsCps: a lone `await Promise.all(...)`/`.race`/… already
   // yields a real Promise — keep it on the legacy identity path.
   if (linear.segments.length === 1 && awaitedExprIsPromiseCombinator(linear.segments[0]!.awaitedExpr)) return false;
@@ -439,6 +448,44 @@ export function asyncFnNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclar
     if (!isSpillSafeType(resumeBindingValType(ctx, rb))) return false;
   }
   return true;
+}
+
+/**
+ * (#2906 slice 3a) The widened spill layout for a `while`-with-await body: every
+ * own-local referenced anywhere in the loop statement is live across the
+ * loop-carried await (a local read before the await is read again after resume
+ * on the next iteration), so the whole set is spilled. Resume-binding names use
+ * their {@link resumeBindingValType} (matching the SENT-coercion target); other
+ * locals use `resolveSpillLocalValType`, defaulting to externref. Returns `null`
+ * when the body is not the bounded while shape.
+ */
+function computeLoopSpills(
+  ctx: CodegenContext,
+  decl: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): { spillNames: string[]; spillTypes: ValType[] } | null {
+  const loop = loopAsyncSpillInfo(decl, plan);
+  if (loop === null) return null;
+  const rbTypeByName = new Map<string, ValType>();
+  for (const seg of loop.segments) {
+    if (seg.resumeBinding) rbTypeByName.set(seg.resumeBinding.name, resumeBindingValType(ctx, seg.resumeBinding));
+  }
+  const declByName = collectVarDeclsByName(decl);
+  const spillNames: string[] = [];
+  const spillTypes: ValType[] = [];
+  for (const name of loop.names) {
+    const rbType = rbTypeByName.get(name);
+    if (rbType !== undefined) {
+      spillNames.push(name);
+      spillTypes.push(rbType);
+      continue;
+    }
+    const declNode = declByName.get(name);
+    const resolved = declNode ? resolveSpillLocalValType(ctx, declNode) : null;
+    spillNames.push(name);
+    spillTypes.push(resolved ?? { kind: "externref" });
+  }
+  return { spillNames, spillTypes };
 }
 
 /**
@@ -465,7 +512,11 @@ function computeAsyncSpills(
   paramNames: string[],
 ): { spillNames: string[]; spillTypes: ValType[] } {
   const linear = planLinearAwaits(decl, plan);
-  if (linear === null) return { spillNames: [], spillTypes: [] };
+  if (linear === null) {
+    // (#2906 slice 3a) `while`-with-await loop: widened spill set (all loop
+    // own-locals). Returns empty for any non-loop non-linear body.
+    return computeLoopSpills(ctx, decl, plan) ?? { spillNames: [], spillTypes: [] };
+  }
   const paramSet = new Set(paramNames);
 
   const rbTypeByName = new Map<string, ValType>();
@@ -603,18 +654,20 @@ function validateAsyncCfg(cfg: AsyncCfgPlan): string | null {
 export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameInfo, plan: AsyncCpsPlan): number {
   if (info.resumeFuncIdx !== undefined) return info.resumeFuncIdx;
 
-  const linear = planLinearAwaits(info.decl, plan);
-  if (linear === null) {
-    reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1)");
+  // (#2906 slice 3/3a) Build the general CFG plan the emitter drives.
+  // `planAsyncCfg` delegates linear bodies to the byte-identical
+  // `linearPlanToCfg(planLinearAwaits(...))` path, and — on the native drive lane
+  // only (`allowLoops: !info.host`) — lowers a canonical `while`-with-await body
+  // into the loop CFG (head condGoto + body suspends + back-edge goto). The host
+  // settle backend keeps the linear-only shape (loops there suspend on every
+  // await — an N-round follow-up).
+  const cfg = planAsyncCfg(info.decl, plan, { allowLoops: !info.host });
+  if (cfg === null) {
+    reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
     info.resumeFuncIdx = -1;
     return -1;
   }
 
-  // (#2906 slice 3) Lower the linear plan into the general CFG plan the emitter
-  // drives. `linearPlanToCfg` is the only producer today, so the emitted machine
-  // is byte-identical to the pre-CFG emitter for every accepted shape; richer
-  // planners (loops, try/catch, for-await) plug in HERE without emitter changes.
-  const cfg = linearPlanToCfg(linear);
   const cfgError = validateAsyncCfg(cfg);
   if (cfgError !== null) {
     reportError(ctx, info.decl, `internal: async CFG plan violates the emitter contract — ${cfgError} (#2906)`);
@@ -1090,8 +1143,15 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
         }
         case "goto": {
           // Unconditional state transition (loop back-edge when target ≤ id).
+          // (#2906 slice 3a) `loopDepth` (== id+2) is the depth that reaches the
+          // re-dispatch `loop` from ONE level inside an `if` arm — that is where
+          // the suspend fast-path `advanceArm` br sits (inside `if(suspended)`),
+          // the only pre-3a exerciser of the re-dispatch br. This `goto` br is
+          // emitted at the STATE-BODY TOP LEVEL (one level shallower), so the
+          // loop is one nearer: `loopDepth - 1`. (Fixes the off-by-one the
+          // producer-unreachable slice-3 goto shipped with.)
           out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.target));
-          out.push({ op: "br", depth: loopDepth } as Instr);
+          out.push({ op: "br", depth: loopDepth - 1 } as Instr);
           break;
         }
         case "condGoto": {
@@ -1107,13 +1167,14 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
             blockType: { kind: "empty" },
             then: [
               ...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.whenTrue),
-              // +1: the `br` sits inside this `if` arm, one level below the arm
-              // top where `loopDepth` is measured.
-              { op: "br", depth: loopDepth + 1 } as Instr,
+              // The br sits inside this `if(cond)` arm — one level deep, exactly
+              // like the suspend `advanceArm` br — so it reaches the loop at
+              // `loopDepth` (id+2), NOT loopDepth+1.
+              { op: "br", depth: loopDepth } as Instr,
             ],
             else: [
               ...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.whenFalse),
-              { op: "br", depth: loopDepth + 1 } as Instr,
+              { op: "br", depth: loopDepth } as Instr,
             ],
           } as Instr);
           break;

--- a/tests/issue-2906-3a-while-await.test.ts
+++ b/tests/issue-2906-3a-while-await.test.ts
@@ -1,0 +1,149 @@
+// #2906 slice 3a — `while`-with-await on the host-free async drive machine.
+//
+// The multi-state CFG resume machine (#2906 slice 3, PR #2413) shipped the
+// `goto`/`condGoto` terminators and back-edge br model but left them
+// producer-unreachable (`linearPlanToCfg` never emits them). Slice 3a adds the
+// FIRST loop producer — `planWhileLoopCfg` — lowering `while (cond) { …await… }`
+// into: an entry state (pre-loop leads), a head state whose `condGoto` enters
+// the body or the exit, body suspend states, and a continuation state whose
+// `goto(head)` is the back-edge. It also fixes the off-by-one `br` depth the
+// never-exercised `goto`/`condGoto` emitter shipped with (the re-dispatch loop
+// is `loopDepth-1` from a state-body top level, `loopDepth` from inside an `if`
+// arm — the latter matches the proven suspend fast-path advance br).
+//
+// Loop-liveness (the silent-miscompile trap): every own-local referenced
+// anywhere in the loop is live across the loop-carried await (read before the
+// await, read again after resume on the next iteration), so the whole set is
+// spilled into the frame — proven by the genuinely-pending tests, where the
+// accumulator survives real suspension across iterations.
+//
+// Native (wasi) drive lane only — host-free (no imports). The JS-host settle
+// backend keeps the linear-only shape (loops there are an N-round follow-up).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile a host-free async program and instantiate it (imports must be empty). */
+async function instantiateWasi(src: string): Promise<WebAssembly.Exports> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // The drive layer is host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports;
+}
+
+describe("#2906 slice 3a — while-with-await drive machine", () => {
+  it("synchronously-settled loop runs to completion in one call (fast-path advance through the back-edge)", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function step(n: number): Promise<number> { return n + 10; }
+      async function loop(): Promise<void> {
+        let i: number = 0;
+        let sum: number = 0;
+        while (i < 3) { const v = await step(i); sum = sum + v; i = i + 1; }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as { kick: () => number; getCap: () => number };
+    expect(ex.kick()).toBe(33); // 10 + 11 + 12, no suspension needed
+  });
+
+  it("GENUINELY-PENDING loop suspends each iteration; the drain resumes and the accumulator survives (frame spill)", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let i: number = 0;
+        let sum: number = 0;
+        while (i < 3) {
+          const v = await Promise.resolve(i).then((x: number) => x + 10);
+          sum = sum + v;
+          i = i + 1;
+        }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as { kick: () => number; getCap: () => number; __drain_microtasks: () => void };
+    expect(ex.kick()).toBe(0); // suspended on the first iteration's pending await
+    ex.__drain_microtasks(); // resumes each iteration in turn across the back-edge
+    expect(ex.getCap()).toBe(33); // 10 + 11 + 12 — sum + i survived every suspension
+  });
+
+  it("zero-iteration loop (condition false first) runs the exit directly, never suspends", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function step(n: number): Promise<number> { return n + 1; }
+      async function loop(): Promise<void> {
+        let i: number = 5;
+        while (i < 3) { const v = await step(i); i = i + 1; }
+        cap = 99;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as { kick: () => number; getCap: () => number };
+    expect(ex.kick()).toBe(99); // condGoto false → straight to exit, cap set synchronously
+  });
+
+  it("a prefix local is carried across the back-edge and combined with each resumed value", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        const base: number = 100;   // set once before the loop, read every iteration
+        let i: number = 0;
+        let acc: number = 0;
+        while (i < 2) {
+          const v = await Promise.resolve(i).then((x: number) => x + 1);
+          acc = acc + base + v;
+          i = i + 1;
+        }
+        cap = acc;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as { kick: () => number; getCap: () => number; __drain_microtasks: () => void };
+    expect(ex.kick()).toBe(0);
+    ex.__drain_microtasks();
+    // i=0: base(100)+v(1)=101; i=1: base(100)+v(2)=102 → 203
+    expect(ex.getCap()).toBe(203);
+  });
+
+  it("a bare `await P;` loop body (no resume binding) runs its side effects in order across iterations", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      let n: number = 0;
+      async function loop(): Promise<void> {
+        let i: number = 0;
+        while (i < 4) {
+          await Promise.resolve(i).then((x: number) => x);
+          n = n + 1;
+          i = i + 1;
+        }
+        cap = n;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as { kick: () => number; getCap: () => number; __drain_microtasks: () => void };
+    expect(ex.kick()).toBe(0);
+    ex.__drain_microtasks();
+    expect(ex.getCap()).toBe(4);
+  });
+
+  it("unsupported loop control (break inside the loop) falls back to the legacy path and still compiles", async () => {
+    // `break` targeting the loop is out of the bounded 3a slice — the drive gate
+    // rejects it and the fn takes the legacy path (may not host-free-drive, but
+    // must still compile without error).
+    const r = await compile(
+      `let cap: number = 0;
+       async function loop(): Promise<void> {
+         let i: number = 0;
+         while (i < 5) { const v = await Promise.resolve(i); if (v > 2) { break; } i = i + 1; }
+         cap = i;
+       }
+       export function kick(): number { loop() as any; return cap; }`,
+      { fileName: "test.ts", target: "wasi" },
+    );
+    expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  });
+});


### PR DESCRIPTION
## #2906 slice 3a — while-with-await

The CFG resume machine (slice 3, PR #2413) shipped the `goto`/`condGoto`
terminators + back-edge `br` model but left them **producer-unreachable**
(`linearPlanToCfg` never emits them). Slice 3a adds the first loop producer and
fixes the latent off-by-one the never-exercised `goto`/`condGoto` emitter shipped
with.

### Measure-first (branch base)
A `while`-with-await wasi async fn was host-free-compilable (drive lane activated,
empty imports) but **never completed** — the loop CFG had never been produced or
executed. After 3a the canonical loop resolves across genuine suspensions with
the accumulator surviving each spill/restore.

### Change (planner + spills only — the emitter already had goto/condGoto)
- **`async-cps.ts`** — `planAsyncCfg(fn, plan, {allowLoops})` is now the single
  drive-lane CFG producer. Linear bodies **delegate** to the byte-identical
  `linearPlanToCfg(planLinearAwaits(...))` path; when `allowLoops` (native lane
  only) and the body is a canonical single-`while`-with-await, `planWhileLoopCfg`
  builds the loop CFG: entry (pre-loop leads) → head `condGoto(cond, body0, exit)`
  → body suspend states → continuation `goto(head)` back-edge → exit
  `settleUndefined`. Reuses `lowerLinearStatements` for the loop body.
  `loopAsyncSpillInfo` exposes the widened spill set.
- **`async-frame.ts`** — routed the emitter + `asyncFnNeedsDrive` +
  `computeAsyncSpills` through `planAsyncCfg`/`computeLoopSpills`.
  **Loop-liveness (the silent-miscompile trap, contract rule 3/4):** every
  own-local referenced anywhere in the loop is spilled (a local read *before* the
  await is read again *after* resume on the next iteration); the drive gate falls
  back to legacy if a loop-live local is not a spill-safe type. Host settle
  backend keeps the linear-only shape (loops = N-round follow-up).
- **`async-frame.ts` br-depth fix (latent):** the never-exercised
  `goto`/`condGoto` `br` depths were off by one. The re-dispatch `loop` is at
  `loopDepth` (id+2) from ONE level inside an `if` arm — where the *proven*
  suspend fast-path advance br sits — so it is `loopDepth-1` from a state-body top
  level. `goto` (top level) now uses `loopDepth-1`; `condGoto` (br inside its
  `if(cond)` arm) uses `loopDepth` (was `+1`).

### Scope / bank
Bounded to a single `while` whose body is linear-canonical with no
`break`/`continue`/`return`/labeled/nested-loop/`switch`/`try` and an await-free
condition; anything richer falls back to legacy. Banked follow-ups: do-while,
await-in-condition, break/continue (3a′), for-await-of (3b), try/catch +
return-through-finally (3c), host-lane loops. Issue stays `in-progress`.

### Tests / blast radius
- `tests/issue-2906-3a-while-await.test.ts` (6): sync-settled full run,
  genuinely-pending across 3 iterations (accumulator survives spill),
  zero-iteration, prefix local carried across the back-edge, bare-`await`
  ordering, break→legacy fallback.
- Linear drive/CPS path is byte-identical by construction (goto/condGoto are
  unreachable for linear; `planAsyncCfg` returns exactly
  `linearPlanToCfg(planLinearAwaits(...))`) — confirmed by 69 green async drive
  tests (async-await / issue-1042 / issue-1042-host-drive / issue-2895 /
  async-census + issue-2174/2611/1672).
- Pre-existing on clean `origin/main` (NOT introduced): 2× `issue-2865` AG0 wasi,
  3× `issue-2906-gap3` try/finally throw.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8