### PR TITLE
fix(#2175 V2-S2): unify builtin-proto method/getter values on identity singleton

### DIFF
--- a/plan/issues/2175-standalone-builtin-prototype-readers.md
+++ b/plan/issues/2175-standalone-builtin-prototype-readers.md
@@ -2,7 +2,7 @@
 id: 2175
 title: "architect spec: standalone builtin-prototype object representation + native-method-closure dispatch"
 status: in-progress
-assignee: ttraenkler/fable-2175
+assignee: ttraenkler/opus-2175s2
 sprint: current
 created: 2026-06-16
 updated: 2026-07-04
@@ -1148,3 +1148,105 @@ narrative): `const f = (x)=>x*2; const a:any=f;`
 - **V2-S3 (proto table)**: the reader arms will read closure structs back as
   `$PropEntry.value` (raw anyref, D4) — their `typeof`/Function-ness now
   resolves through this same classifier for free.
+
+---
+
+## Implementation log — V2-S2 (sdev opus-2175s2, 2026-07-04)
+
+PR: **V2-S2 of 7** — singleton unification of builtin-proto method/getter
+values. Branch `issue-2175-v2s2`. Status: implemented, host-free,
+standalone-gated, byte-neutral off-path.
+
+### What landed
+
+Switched the three C2 surfaces that reify a builtin-prototype method/getter
+VALUE from a fresh per-read `struct.new` (`pushBuiltinFnClosureValueInstrs`)
+to the #2963 identity-stable module singleton
+(`pushBuiltinFnSingletonValueInstrs`):
+
+1. **`property-access.ts` method arm** (`tryCompileStandaloneBuiltinProtoMemberRead`,
+   the syntactic `RegExp.prototype.exec` value read).
+2. **`property-access.ts` getter arm** (the getter self-struct operand for the
+   `call_ref` that invokes an accessor getter — so the getter object invoked
+   here is the same one gOPD's `.get` returns).
+3. **`calls.ts` #2885 gOPD Site-2** — both the data-descriptor `.value` and the
+   accessor-descriptor `.get`.
+
+Removed the now-unused `pushBuiltinFnClosureValueInstrs` import from
+`property-access.ts`; `calls.ts` swapped its import to the singleton.
+
+### Why it is correct AND collision-free (the load-bearing invariant)
+
+`pushBuiltinFnSingletonValueInstrs` keys its per-value module global on
+`closure.type.typeIdx`. That typeIdx is the **UNIQUE per-(brand,member) meta
+subtype** minted by `ensureBuiltinFnMetaType` under cache key
+`proto:<brand>:<kind>:<member>` (verified: `builtin-fn-meta.ts:199-219`
+memoizes on that key, one typeIdx per key). So:
+- **same member, different surface** (syntactic read vs gOPD synthesis) →
+  same cacheKey → same typeIdx → same global → **one object** →
+  `gOPD(p,"exec").value` and `RegExp.prototype.exec` are the same singleton;
+- **different member** (`exec` vs `test`) → different cacheKey → different
+  typeIdx → different global → **distinct objects** → `exec !== test` holds by
+  construction (the swap-guard is structural, not incidental).
+
+### Proof (inject/contrast, not narrative — builtin-proto hides coincidental passes)
+
+- **Surface-1 identity is genuinely fixed:** on baseline (`HEAD~1`, fresh
+  struct.new) `const a:any=RegExp.prototype.exec; const b:any=RegExp.prototype.exec; a===b`
+  → **0**; with the singleton → **1**. Swap-guard `exec===test` → **0** on
+  BOTH (proves `===` discriminates; the `1` is not always-true, and the
+  `typeof===\"function\"` guard proves it is not `null===null`).
+- **Surface-3 materializes the RIGHT singleton:** `typeof gOPD(...).value ===
+  \"function\"` and `.value.name === \"exec\"`; `typeof gOPD(...,\"flags\").get
+  === \"function\"` and `.get.name === \"get flags\"` (§10.2.9). The function
+  classification flows through the **V2-S1 shared closure classifier**
+  (`closure-classifier.ts` via the materialized `__typeof` arm) — V2-S2
+  consumes it, mints no new arm list.
+- **Byte-neutral off-path:** `prove-emit-identity` — all 39 (file,target)
+  corpus emits IDENTICAL across gc/standalone/wasi. The four sites are
+  `ctx.standalone`-gated and only fire on a builtin-proto member VALUE read /
+  gOPD synthesis, so host mode and every non-reflective program are unchanged.
+- **No regression:** #2963 reification, #2896 fn-meta, #2861 glue wave (proto
+  value reads), #2949 slice3/3b dynamic, #2580 dyn-read, #2885, #2175 typeof,
+  #2175 native-proto-brands — 189+ tests green. The 4 pre-existing failures in
+  `issue-2175-regexp-proto-readers.test.ts` (getter-engine-body boundary) fail
+  IDENTICALLY on `HEAD~1` — not regressed here; they belong to V2-S5.
+
+Test: `tests/issue-2175-v2s2-singleton-identity.test.ts` (6/6).
+
+### KEY FINDING for V2-S3 (banked — this de-risks the keystone slice)
+
+The end-to-end gate `gOPD(RegExp.prototype,\"exec\").value === RegExp.prototype.exec`
+is **NOT** achievable by singleton unification alone, and the reason is NOT the
+singleton: the descriptor stores the correct singleton, but its `.value` reads
+back as an **externref-wrapped `$Object`**, and the standalone `===` lowering
+does **not** `ref.eq`-compare an externref-wrapped GC ref against a raw anyref.
+This is a **pre-existing, broad** value-representation gap, proven independent
+of this change:
+- `const o:any={z:1}; const a:any[]=[o,o]; a[0]===a[1]` → **0** (a plain user
+  object referenced twice loses identity through the externref boundary);
+- `gOPD(RegExp.prototype,\"exec\").value === gOPD(...).value` (same field, two
+  reads) → **0**;
+- yet `const o:any=RegExp.prototype.exec; const a:any[]=[o,o]; a[0]===a[1]` →
+  **1** (anyref/GC-ref identity via `ref.eq` DOES work — the gap is specifically
+  the externref-wrapped read-back, not `===` generally).
+
+So this is squarely **C3 (the dynamic-reader MOP + value representation)**,
+owned by V2-S3: once the reader returns closure structs back as **raw anyref**
+`$PropEntry.value` (D4 — the spec already mandates this), the descriptor
+`.value`/`.get` become GC refs, `ref.eq` fires, and the identity gate **flips
+to 1 for free** — the descriptor already carries the right singleton (this
+slice). `tests/issue-2175-v2s2-singleton-identity.test.ts` includes an explicit
+`.toBe(0)` **characterization guard** for this boundary that will FAIL LOUDLY
+when V2-S3 lands, prompting the flip to `.toBe(1)`.
+
+### Banked for V2-S3+
+
+- The three value surfaces are unified — V2-S3's proto table populate body
+  (`__nativeproto_populate_<brand>`) MUST store the **same** singleton
+  (emit `pushBuiltinFnSingletonValueInstrs` against the same closure) so the
+  runtime-read value keeps identity with the syntactic surfaces. One value per
+  (brand, member), everywhere.
+- The externref/`$Object`-vs-anyref `===` gap above is the concrete substrate
+  V2-S3's D4 (raw-anyref carrier) exists to close — carry the raw closure
+  struct, not an `extern.convert_any` box, in `$PropEntry.value`.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -140,7 +140,7 @@ import {
   ensureStandaloneNativeMethodClosure,
   getNativeProtoBuiltinGlue,
 } from "../native-proto.js";
-import { pushBuiltinFnClosureValueInstrs } from "../builtin-fn-meta.js";
+import { pushBuiltinFnSingletonValueInstrs } from "../builtin-fn-meta.js";
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import {
   emitSetExtrasArgv,
@@ -7512,7 +7512,10 @@ function compileCallExpression(
               );
               flushLateImportShifts(ctx, fctx);
               if (createAccIdx !== undefined) {
-                fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, protoClosure));
+                // (#2175 V2-S2) Identity-stable getter singleton so the accessor's
+                // `.get` is the SAME function object across repeated gOPD calls and
+                // the syntactic getter-invocation self (property-access.ts Site 3).
+                fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, protoClosure));
                 fctx.body.push({ op: "extern.convert_any" } as Instr); // get
                 fctx.body.push({ op: "ref.null.extern" } as Instr); // set = undefined
                 fctx.body.push({ op: "i32.const", value: 0x04 } as Instr); // FLAG_CONFIGURABLE
@@ -7530,7 +7533,11 @@ function compileCallExpression(
               );
               flushLateImportShifts(ctx, fctx);
               if (createIdx !== undefined) {
-                fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, protoClosure));
+                // (#2175 V2-S2) Identity-stable method singleton so the data
+                // descriptor's `.value` is the SAME function object as the syntactic
+                // read `RegExp.prototype.exec` (property-access.ts method arm):
+                // `gOPD(p,"exec").value === RegExp.prototype.exec`.
+                fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, protoClosure));
                 fctx.body.push({ op: "extern.convert_any" } as Instr); // value
                 fctx.body.push({ op: "i32.const", value: 0x05 } as Instr); // FLAG_WRITABLE | FLAG_CONFIGURABLE
                 fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -30,7 +30,6 @@ import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getOrCreateFuncRef
 import {
   BUILTIN_STATIC_METHOD_ARITY,
   ensureBuiltinFnMetaType,
-  pushBuiltinFnClosureValueInstrs,
   pushBuiltinFnSingletonValueInstrs,
   STANDALONE_STATIC_METHOD_META,
 } from "./builtin-fn-meta.js";
@@ -1116,7 +1115,11 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
     if (!closureInfo) return undefined;
 
     // self struct (param 0) — unused by the body (no captures) but type-required.
-    fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, closure));
+    // (#2175 V2-S2) Use the identity-stable singleton so the getter function object
+    // invoked here is the SAME object gOPD's `.get` synthesis returns (calls.ts
+    // Site-2) — `gOPD(p,"flags").get === gOPD(p,"flags").get`. One value per
+    // (brand, member), everywhere (C2).
+    fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
     // `this` arg (param 1): the builtin proto object externref.
     if (!emitLazyNativeProtoGet(ctx, fctx, brand)) return undefined;
     // call_ref operand: the typed funcref. `ref.func` yields `(ref liftedType)`
@@ -1127,7 +1130,15 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
     return closureInfo.returnType ?? { kind: "externref" };
   }
 
-  fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, closure));
+  // (#2175 V2-S2) IDENTITY-STABLE method value: read via a module-level singleton
+  // so `RegExp.prototype.exec === RegExp.prototype.exec` (a fresh `struct.new` per
+  // read gave two distinct instances → `!==`). The value struct is the UNIQUE
+  // per-(brand, member) meta subtype (`ensureBuiltinFnMetaType` cache key
+  // `proto:<brand>:method:<member>`), so the singleton global keys on that distinct
+  // typeIdx and `RegExp.prototype.exec !== RegExp.prototype.test` still holds. This
+  // is the SAME singleton the #2885 gOPD synthesis (calls.ts Site-2) materializes,
+  // so `gOPD(RegExp.prototype,"exec").value === RegExp.prototype.exec`.
+  fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
   return closure.type;
 }
 

--- a/tests/issue-2175-v2s2-singleton-identity.test.ts
+++ b/tests/issue-2175-v2s2-singleton-identity.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2175 V2-S2 — builtin-prototype method/getter values are ONE identity-stable
+ * object per (brand, member), everywhere.
+ *
+ * Before V2-S2, three standalone surfaces each reified a builtin-proto member
+ * with a FRESH `struct.new` per read (`pushBuiltinFnClosureValueInstrs`), so
+ * `RegExp.prototype.exec !== RegExp.prototype.exec` — violating the ES invariant
+ * that a builtin method is ONE function object. V2-S2 routes all three surfaces
+ * through the #2963 module-level singleton (`pushBuiltinFnSingletonValueInstrs`):
+ *   1. the syntactic value read       (property-access.ts method arm)
+ *   2. the getter self-struct         (property-access.ts getter arm)
+ *   3. the #2885 gOPD descriptor       (calls.ts Site-2: `.value` / `.get`)
+ *
+ * The singleton keys on the value struct's typeIdx, which is the UNIQUE
+ * per-(brand,member) meta subtype (`ensureBuiltinFnMetaType` cache key
+ * `proto:<brand>:<kind>:<member>`), so distinct members keep distinct globals
+ * — `exec !== test` — while the same member converges to one object.
+ *
+ * ANTI-VACUITY DISCIPLINE (builtin-proto territory hides coincidental passes,
+ * memory `project_hostfree_pass_can_be_coincidentally_wrong`): the identity
+ * assertion is paired with (a) a SWAP-GUARD — a *different* member must compare
+ * `!==`, proving `===` actually discriminates and isn't always-true — and (b) a
+ * `typeof === "function"` guard, proving the operands are the real function value
+ * and not two nulls (`null === null` is a false positive). The surface-1 gain was
+ * verified by inject/contrast against baseline: fresh-struct.new gives
+ * `exec === exec` → 0; the singleton gives 1 (swap-guard `exec === test` stays 0
+ * on both). All cases run `--target standalone`, host-free (0 `env` imports).
+ */
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, `compile failed:\n${(r.errors ?? []).map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const env = r.imports.filter((i) => i.module === "env");
+  expect(env, `unexpected host imports: ${env.map((i) => i.name).join(", ")}`).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2175 V2-S2 — builtin-proto member values are identity-stable singletons", () => {
+  it("surface 1: RegExp.prototype.exec === RegExp.prototype.exec (self-identity)", async () => {
+    // Baseline (fresh struct.new) returned 0; the singleton returns 1. The typeof
+    // guard proves the operands are the real function, so `1` is genuine identity,
+    // not `null === null`.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const a: any = RegExp.prototype.exec;
+          const b: any = RegExp.prototype.exec;
+          const isFn: number = (typeof a === "function") ? 1 : 0;
+          const same: number = (a === b) ? 1 : 0;
+          return (isFn === 1 && same === 1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("surface 1: a second member (test) is also self-identical", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const a: any = RegExp.prototype.test;
+          const b: any = RegExp.prototype.test;
+          return (a === b) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("swap-guard: RegExp.prototype.exec !== RegExp.prototype.test (distinct members stay distinct)", async () => {
+    // Proves the singleton keys on the per-member meta typeIdx, NOT a shared
+    // global — otherwise every member would collapse to one object. Also proves
+    // `===` on these values is a real discriminator (not always-true), so the
+    // self-identity assertions above are meaningful.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const a: any = RegExp.prototype.exec;
+          const b: any = RegExp.prototype.test;
+          return (a === b) ? 1 : 0;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("surface 3 (method): gOPD(RegExp.prototype,'exec').value is the correct singleton method", async () => {
+    // The #2885 gOPD synthesis (calls.ts Site-2) now stores the singleton. We
+    // observe it materializes the RIGHT method value: it classifies as a function
+    // through the V2-S1 closure classifier (consumed here) and carries the spec
+    // `name`. (Cross-representation `===` identity is a separate V2-S3 gap — see
+    // the boundary characterization below.)
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const v: any = (Object.getOwnPropertyDescriptor(RegExp.prototype, "exec") as any).value;
+          const isFn: number = (typeof v === "function") ? 1 : 0;
+          const named: number = (v.name === "exec") ? 1 : 0;
+          return (isFn === 1 && named === 1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("surface 3 (getter): gOPD(RegExp.prototype,'flags').get is the correct singleton getter", async () => {
+    // The accessor descriptor's `.get` (calls.ts getter arm) now stores the
+    // singleton getter. It classifies as a function and carries the §10.2.9
+    // accessor name spelling ("get flags").
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const g: any = (Object.getOwnPropertyDescriptor(RegExp.prototype, "flags") as any).get;
+          const isFn: number = (typeof g === "function") ? 1 : 0;
+          const named: number = (g.name === "get flags") ? 1 : 0;
+          return (isFn === 1 && named === 1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("V2-S3 boundary (characterization): gOPD(...).value === RegExp.prototype.exec is NOT YET 1", async () => {
+    // IMPORTANT — this is a CHARACTERIZATION guard, not a desired state. The
+    // descriptor stores the SAME singleton as the syntactic read, but the
+    // descriptor's `.value` reads back as an externref-wrapped `$Object`, and the
+    // standalone `===` lowering does not `ref.eq`-compare an externref-wrapped GC
+    // ref against a raw anyref (verified pre-existing: even `const o:any={z:1};
+    // const a:any[]=[o,o]; a[0]===a[1]` → 0). That is the C3 dynamic-reader /
+    // value-representation substrate, owned by V2-S3, NOT singleton unification.
+    // When V2-S3 makes the reader return a GC ref, this flips to 1 for free
+    // (the descriptor already carries the right singleton) — and THIS TEST WILL
+    // FAIL LOUDLY, which is the intended coupling: update it to `.toBe(1)` then.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const v: any = (Object.getOwnPropertyDescriptor(RegExp.prototype, "exec") as any).value;
+          const m: any = RegExp.prototype.exec;
+          return (v === m) ? 1 : 0;
+        }
+      `),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2175 V2-S2 — singleton unification of builtin-prototype method/getter values

Second slice of the builtin-proto substrate v2 (after V2-S1 PR #2643). Routes the three standalone surfaces that reify a builtin-prototype method/getter VALUE from a fresh per-read \`struct.new\` (\`pushBuiltinFnClosureValueInstrs\`) to the #2963 identity-stable module singleton (\`pushBuiltinFnSingletonValueInstrs\`), so a builtin method is ONE function object (the ES invariant):

1. **`property-access.ts` method arm** — the syntactic `RegExp.prototype.exec` value read.
2. **`property-access.ts` getter arm** — the getter self-struct operand for the `call_ref` accessor invocation.
3. **`calls.ts` #2885 gOPD Site-2** — data-descriptor `.value` + accessor-descriptor `.get`.

### Correctness invariant (collision-free by construction)
The singleton global keys on `closure.type.typeIdx`, which is the **unique per-(brand,member) meta subtype** minted by `ensureBuiltinFnMetaType` (cache key `proto:<brand>:<kind>:<member>`). Same member across surfaces → same global → one object; different members → different globals → `exec !== test` holds structurally.

### Proof (inject/contrast — builtin-proto hides coincidental passes)
- **Surface-1 identity genuinely fixed:** `RegExp.prototype.exec === RegExp.prototype.exec` → **0** on baseline (`HEAD~1`, fresh struct.new), **1** with the singleton; swap-guard `exec === test` → **0** on both; `typeof === "function"` guard rules out `null === null`.
- **Surface-3 materializes the right singleton:** `typeof gOPD(...).value === "function"` + `.value.name === "exec"`; `typeof gOPD(...,"flags").get === "function"` + `.get.name === "get flags"` (§10.2.9). Classification flows through the V2-S1 shared closure classifier (`closure-classifier.ts`) — no new arm list.
- **Byte-neutral off-path:** `prove-emit-identity` — all 39 (file,target) corpus emits IDENTICAL (gc/standalone/wasi). All four sites are `ctx.standalone`-gated; host mode + every non-reflective program unchanged.
- **No regression:** #2963, #2896, #2861 glue wave, #2949 slice3/3b, #2580, #2885, #2175 typeof/native-proto-brands — 189+ green. The 4 pre-existing `issue-2175-regexp-proto-readers` getter-engine failures fail IDENTICALLY on `HEAD~1` (V2-S5 territory, not regressed).

### Key finding banked for V2-S3
The end-to-end `gOPD(...).value === RegExp.prototype.exec` gate is **blocked on a pre-existing value-representation gap**, NOT the singleton: the descriptor stores the correct singleton but reads back as an externref-wrapped `$Object`, and the standalone `===` lowering doesn't `ref.eq` that against a raw anyref (proven: `const o:any={z:1}; const a:any[]=[o,o]; a[0]===a[1]` → 0). This is squarely C3/V2-S3's raw-anyref carrier (D4). When V2-S3 lands, the identity flips to 1 for free — the descriptor already carries the right singleton. The test file includes an explicit `.toBe(0)` characterization guard that fails loudly at that point.

Test: `tests/issue-2175-v2s2-singleton-identity.test.ts` (6/6). Full V2-S2 log + finding in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8