### PR TITLE
feat(#3000-B): IR get/set accessor lowering in the class-member path

### DIFF
--- a/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
+++ b/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
@@ -110,18 +110,18 @@ was a bounded win. This carries the XL remainder.
 
 ## Implementation Notes — Phase 1a: private-field read/write substrate (2026-07-03, PR TBD)
 
-**Landed (this PR):** the private-field *shape gate + lowering* — the smallest
+**Landed (this PR):** the private-field _shape gate + lowering_ — the smallest
 independently-shippable slice of Phase 1. Clears the two class-member
 `body-shape-rejected` attributions on `classes.ts` (`Animal_new`,
 `Animal_speak`); `body-shape-rejected` corpus total 25 → 23.
 
 **Root cause of the rejection (verified on `upstream/main` @ bc8a1d4ca):** IR's
 Phase-1 shape gate and AST→IR lowerer both gated field access on
-`ts.isIdentifier(name)`. A `#x` name is a `ts.PrivateIdentifier`, *not* an
-`Identifier`, so `this.#x` read/write fell into `body-shape-rejected` *before*
+`ts.isIdentifier(name)`. A `#x` name is a `ts.PrivateIdentifier`, _not_ an
+`Identifier`, so `this.#x` read/write fell into `body-shape-rejected` _before_
 any `class.get`/`class.set` logic ran. Everything downstream was already in
 place: `buildIrClassShapes` (`src/codegen/index.ts`) reads fields straight from
-`ctx.structFields`, which *already includes* private slots, and
+`ctx.structFields`, which _already includes_ private slots, and
 `ClassRegistry.fieldIdx` (`src/ir/integration.ts`) resolves by the same
 `structFields` name → identical index. So the fix is purely at the gate + lower
 entry points.
@@ -130,10 +130,11 @@ entry points.
 (`src/codegen/class-bodies.ts:522`) stores a private field `#name` as
 `"__priv_name"` (strip `#`, prefix `__priv_`). The IR shape and `fieldIdx` both
 read that mangled name from `structFields`, so from-ast MUST mangle the
-`PrivateIdentifier` the *same* way (`irPrivateFieldName` in `from-ast.ts`) or the
+`PrivateIdentifier` the _same_ way (`irPrivateFieldName` in `from-ast.ts`) or the
 field lookup misses. Plain `Identifier` passes through unchanged.
 
 **Edits (5, all narrow):**
+
 - `src/ir/from-ast.ts` — `irPrivateFieldName` helper; `lowerPropertyAccess`
   (read) and `lowerPropertyAssignment` (write) accept `PrivateIdentifier` +
   mangle.
@@ -147,7 +148,7 @@ field lookup misses. Plain `Identifier` passes through unchanged.
 
 1. **Constructors are NOT emitted by Phase B integration.** `compileIrPathFunctions`
    only builds `MethodDeclaration`s (`integration.ts:304`); it never builds a
-   `ConstructorDeclaration`. So even though the selector now *claims* `Animal_new`
+   `ConstructorDeclaration`. So even though the selector now _claims_ `Animal_new`
    (clearing its `body-shape-rejected`), Phase B skips it → the **legacy ctor
    body still emits, byte-inert**. Real IR constructor emission (`struct.new` +
    `__self` epilogue + field-init) is a **separate substrate = the issue's
@@ -163,10 +164,10 @@ field lookup misses. Plain `Identifier` passes through unchanged.
    (WasmGC subtype of Animal); `class.get __priv_name` reads the correct
    parent-prefixed slot across the subtype boundary. Output matches legacy
    exactly. **Contrast with #2857**, whose static-method claim was byte-inert —
-   #3000 has *no* byte-inert reduction; every metric drop that reaches Phase B
+   #3000 has _no_ byte-inert reduction; every metric drop that reaches Phase B
    is a real emission change gated by test262.
 
-3. **Private-field *write* as a void-method tail is a pre-existing, non-private
+3. **Private-field _write_ as a void-method tail is a pre-existing, non-private
    gap.** `set(v){ this.#x = v }` is rejected at `isPhase1Tail` → `isPhase1Expr`
    (`select.ts:~1821`), which rejects **all** `=` expressions (public or
    private). Out of scope for this substrate; belongs to a general
@@ -186,29 +187,27 @@ test262 conformance is the CI gate.
 `body-shape-rejected` are cleared. The remainder splits into three
 independently-dispatchable slices, in dependency order:
 
-- **#3000-B — Accessors (get/set over the private slot)** [M].
-  Members: `Animal_name` (get+set), `Animal_age` (get), `Dog_breed` (get).
-  Needs: (a) selector — stop bucketing `GetAccessorDeclaration` /
-  `SetAccessorDeclaration` as `class-method` (`select.ts:411`) and claim them
-  like no-arg / one-arg methods over the (now-supported) private slot; note
-  get+set collapse to one `${Class}_${name}` funcMap key today. (b) Phase B
-  integration walk (`integration.ts:303`) currently only iterates
-  `MethodDeclaration`s — extend to accessor declarations, mapping to the legacy
-  accessor funcMap key. (c) the void-tail-assignment gap (finding 3 above) blocks
-  the *setter* body `set name(v){ this.#name = v }` — either lift the setter’s
-  lone assignment out of tail position in the gate, or land the general
-  void-tail-assignment slice first. **Depends on Phase 1a (this PR).**
-  `Dog_breed` additionally needs Phase E (it’s on the `extends` subclass).
+- **#3000-B — Accessors (get/set over the private slot)** [M]. **LANDED
+  (2026-07-04, opus-3000b)** — see the "#3000-B: accessors" Implementation Notes
+  below. Claimed `Animal_name` (get+set) + `Animal_age` (get); `class-method`
+  5 → 3. Correction to the original note: get and set do **not** collapse to one
+  funcMap key — the legacy path registers DISTINCT `${Class}_get_${prop}` /
+  `${Class}_set_${prop}` slots, and this PR claims each independently. The
+  void-tail-assignment gap (finding 3) is closed. `Dog_breed` stays Phase E.
+  **Caveat:** on `classes.ts` the claimed Animal accessors are byte-inert
+  (Animal's `string` field blocks `buildIrClassShapes` — see the notes' KEY
+  BLOCKER); genuine IR emission is proven on numeric-field classes and gated on
+  the banked string-field-shape follow-up.
 
 - **#3000-C — Constructor IR emission (Phase C)** [L]. Build
   `ConstructorDeclaration`s in Phase B: allocate the struct, run field
   initialisers + ctor body private/public writes, synthesise the `return this`
   epilogue, and register under the `${Class}_new` funcMap key. Only after this
-  does `Animal_new`'s claim become a *real* IR emission (today byte-inert).
+  does `Animal_new`'s claim become a _real_ IR emission (today byte-inert).
   Prerequisite for making the ctor claim honest and for Phase E's `super(...)`.
 
 - **#3000-E — Inheritance / `super` (Phase E)** [XL, the big rock]. `Dog extends
-  Animal`. Needs: parent-prefixed `IrClassShape` (today `buildIrClassShapes`
+Animal`. Needs: parent-prefixed `IrClassShape` (today `buildIrClassShapes`
   skips any `extends` class — `index.ts:874`; and Phase B integration skips them
   wholesale — `integration.ts:294`), `super(...)` ctor chaining (on top of
   Phase C), and `super.method()` dispatch to the parent slot. Members:
@@ -217,3 +216,76 @@ independently-dispatchable slices, in dependency order:
 
 `"class-method"` joins `STRICT_IR_REASONS` (`src/codegen/index.ts`) only once
 B + C + E all land and the bucket is 0.
+
+## Implementation Notes — #3000-B: accessors (get/set) (2026-07-04, opus-3000b)
+
+**Landed (this PR):** get/set accessor claiming + lowering in the IR class-member
+path. `class-method` on `classes.ts` drops **5 → 3** (baseline ratcheted):
+`Animal_name` (get+set) and `Animal_age` (get) are now claimed; `Dog_breed`,
+`Dog_new`, `Dog_speak` stay `class-method` (all three are Phase E / `extends`).
+
+**Edits (5, narrow):**
+
+- `src/ir/select.ts` — widen `IrClaimableSubject` + `resolveReturnType` to accept
+  accessors; a set accessor resolves as **void**; a new class-member arm claims
+  instance getters/setters under DISTINCT `${Class}_get_${prop}` /
+  `${Class}_set_${prop}` keys (static accessors + `extends`-subclass accessors
+  stay `class-method`); `isPhase1Tail` accepts a **void-tail property/element
+  store** (the setter body shape) — this closes Phase-1a "finding 3".
+- `src/ir/from-ast.ts` — `lowerFunctionAstToIr` accepts accessor nodes (setter
+  forced void); `lowerTail`'s void arm routes a tail `this.#x = v;` /
+  `arr[i] = v;` through the SAME `lowerPropertyAssignment` / `lowerElementStore`
+  the non-tail path uses (select↔build parity).
+- `src/ir/integration.ts` — the Phase B member walk builds accessor declarations
+  alongside methods, mapping to the legacy `_get_`/`_set_` funcMap key and
+  passing `returnTypeOverride: null` for setters.
+- `scripts/ir-fallback-baseline.json` — `class-method` 5 → 3.
+- `tests/issue-3000-b.test.ts` — selector claims (distinct keys, static/subclass
+  deferral), a **no-post-claim-demotion** emission assertion, and runtime get/set
+  round-trip + void-tail setter over a numeric class.
+
+**Non-vacuity (verified empirically).** For a class whose fields PROJECT into an
+`IrClassShape` (numeric / boolean / object), the accessor bodies genuinely
+IR-emit: instrumenting `compileIrPathFunctions` shows
+`Counter_get_value | Counter_set_value` in `report.compiled` (the patched-slot
+list), post-claim demotions are `(none)`, and the runtime tests exercise those
+patched slots (getter → 10, setter void-tail → 25, method private read → 42).
+
+**KEY BLOCKER FOUND — `classes.ts` accessors are byte-inert, and so was
+Phase-1a's `Animal_speak`.** `buildIrClassShapes` (`src/codegen/index.ts`) rejects
+a class if ANY field fails `valTypeToIrField`, which **returns `null` for every
+`string` field** ("Slice 4 defers string-typed class fields"). `Animal` has
+`#name: string`, so it gets **no `IrClassShape`** → the Phase B walk's
+`if (!classShape) continue;` (`integration.ts`) skips **every** Animal member
+(methods, ctor, AND accessors). So on `classes.ts`:
+
+- The three claimed Animal accessors are removed from the `class-method` bucket
+  (real selector progress) but their bodies stay on **legacy** — byte-inert, exactly
+  like the already-merged `Animal_new` ctor claim.
+- Phase-1a's stated "`Animal_speak` is a real IR emission" does **not** hold for
+  `classes.ts` — Animal never gets a shape there. (Phase-1a's runtime test passed
+  because the output is correct via legacy; the test asserts behaviour, not that IR
+  owned the slot. The vacuity is invisible to a behaviour-only test.)
+
+Projecting string fields is **not accessor-specific** — it blocks methods, the
+ctor, and accessors of every string-field class equally, and it is genuinely
+non-trivial: a string field is `externref` in JS-host (indistinguishable from any
+other `externref` field at the `ValType` level — which is _why_ it was deferred),
+so `buildIrClassShapes` must re-derive field IR types from the **AST/checker**
+(as it already does for method params) rather than from the legacy `structFields`
+`ValType`s, and the resulting `class.get`/`class.set` must preserve ValType parity
+across the JS-host (externref) and standalone (`ref $AnyString`) lanes. **Banked as
+a prerequisite follow-up** (call it Phase 1b / string-field-shape): it must land
+before `classes.ts` members — accessors, methods, or ctor — genuinely IR-emit, and
+before acceptance criterion #3 ("classes.ts compiles fully via IR") is reachable.
+The typeIdx parity guard (`integration.ts`) makes it safe: a mis-projected field
+type can only cause a byte-inert skip, never a miscompile.
+
+**Separate pre-existing gap — accessor CALL SITES.** A `c.value` read / `c.value =
+x` write inside an IR-claimed caller is lowered by `from-ast`'s
+`lowerPropertyAccess` / `lowerPropertyAssignment` as a **field** access, throwing
+`class ... has no field "value"` → the caller demotes to legacy (byte-inert, no
+miscompile). Unrelated to accessor DECLARATIONS (this PR) and harmless for
+`classes.ts` (its accessor call sites live in the unclaimed `main`). A future slice
+should teach the caller-side member lowering to emit an accessor CALL when the name
+resolves to a get/set accessor.

--- a/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
+++ b/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
@@ -1,10 +1,11 @@
 ---
 id: 3000
 title: "IR: class-member residual — private fields, accessors, inheritance/super (class-method → 0)"
-status: ready
+status: in-progress
+assignee: opus-3000b
 sprint: current
 created: 2026-07-02
-updated: 2026-07-03
+updated: 2026-07-04
 priority: medium
 horizon: xl
 feasibility: hard

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -3,7 +3,7 @@
   "unintended": {
     "body-shape-rejected": 18,
     "call-graph-closure": 9,
-    "class-method": 5
+    "class-method": 3
   },
   "deferred": {
     "async-function": 4

--- a/src/ir/capability.ts
+++ b/src/ir/capability.ts
@@ -251,7 +251,13 @@ export function stringIndexProvenBelow(argExpr: ts.Expression, len: number): boo
  * such functions are never claimed.
  */
 export function collectStringLiteralLens(
-  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration,
+  fn:
+    | ts.FunctionDeclaration
+    | ts.MethodDeclaration
+    | ts.ConstructorDeclaration
+    // #3000-B: accessors reach this via `lowerFunctionAstToIr`; only `.body` is read.
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration,
 ): ReadonlyMap<string, number> {
   const lens = new Map<string, number>();
   const declared = new Set<string>();

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -330,7 +330,16 @@ export interface LoweredFunctionResult {
 }
 
 export function lowerFunctionAstToIr(
-  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration,
+  fn:
+    | ts.FunctionDeclaration
+    | ts.MethodDeclaration
+    | ts.ConstructorDeclaration
+    // #3000-B: get/set accessors lower as no-arg / one-arg instance members
+    // over the (now-supported) private slot. A getter behaves like a no-param
+    // method whose return type is `fn.type`; a setter behaves like a one-param
+    // VOID method (setters carry no source-level return type).
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration,
   options: AstToIrOptions = {},
 ): LoweredFunctionResult {
   // #1370 Phase B: name resolution.
@@ -372,7 +381,10 @@ export function lowerFunctionAstToIr(
   // bare `return;` / fall-through tails.
   const isVoidReturn =
     !isGenerator &&
-    (options.returnTypeOverride === null ||
+    // #3000-B: a set accessor is inherently void (no source-level return type);
+    // treat it as void even if the caller forgot the explicit override.
+    (ts.isSetAccessorDeclaration(fn) ||
+      options.returnTypeOverride === null ||
       (options.returnTypeOverride === undefined && fn.type?.kind === ts.SyntaxKind.VoidKeyword));
   const returnType: IrType | null = isGenerator
     ? irVal({ kind: "externref" })
@@ -823,6 +835,32 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
       cx.builder.terminate({ kind: "return", values: [] });
       return;
     }
+    // #3000-B: property-store assignment as a void tail — the SET accessor
+    // body shape `set name(v) { this.#name = v; }`. Route through the SAME
+    // `lowerPropertyAssignment` the non-tail statement path uses (see
+    // `lowerStatementList`), so a setter's lone assignment produces bytes
+    // identical to the mid-body case, then synthesize the implicit return.
+    if (
+      ts.isBinaryExpression(stmt.expression) &&
+      stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(stmt.expression.left)
+    ) {
+      lowerPropertyAssignment(stmt.expression, cx);
+      cx.builder.terminate({ kind: "return", values: [] });
+      return;
+    }
+    // #3000-B: element-store assignment as a void tail (`arr[i] = v;` as the
+    // final statement of a void function) — mirror the non-tail element-store
+    // arm for select↔build parity.
+    if (
+      ts.isBinaryExpression(stmt.expression) &&
+      stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isElementAccessExpression(stmt.expression.left)
+    ) {
+      lowerElementStore(stmt.expression.left, stmt.expression.right, cx);
+      cx.builder.terminate({ kind: "return", values: [] });
+      return;
+    }
     // Lower the expression for side effects, discard the value.
     lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
     cx.builder.terminate({ kind: "return", values: [] });
@@ -1065,7 +1103,13 @@ interface LowerCtx {
  * to their own scope and don't influence the outer's slot decisions.
  */
 function collectMutatedLetNames(
-  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration,
+  fn:
+    | ts.FunctionDeclaration
+    | ts.MethodDeclaration
+    | ts.ConstructorDeclaration
+    // #3000-B: accessors reach this via `lowerFunctionAstToIr`; only `.body` is read.
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration,
 ): Set<string> {
   const writes = new Set<string>();
   if (!fn.body) return writes;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -312,11 +312,13 @@ export function compileIrPathFunctions(
       if (!classShape) continue;
 
       for (const member of stmt.members) {
-        if (!ts.isMethodDeclaration(member) || !member.name) continue;
-        // Phase B v1 — instance methods only. Static methods skip `self`
-        // injection and use a different funcMap entry shape; defer to a
-        // follow-up. Abstract methods have no body — Phase A already
+        // Phase B v1 — instance methods + (#3000-B) instance get/set accessors.
+        // Static members skip `self` injection and use a different funcMap
+        // entry shape; defer. Abstract methods have no body — Phase A already
         // rejected them as `class-method`.
+        const isAccessor = ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member);
+        if (!ts.isMethodDeclaration(member) && !isAccessor) continue;
+        if (!member.name) continue;
         const isStatic = member.modifiers?.some((m) => m.kind === ts.SyntaxKind.StaticKeyword) ?? false;
         if (isStatic) continue;
         if (member.modifiers?.some((m) => m.kind === ts.SyntaxKind.AbstractKeyword)) continue;
@@ -325,13 +327,26 @@ export function compileIrPathFunctions(
         // numeric-literal — replicate the dispatch here without re-importing
         // the helper (it's selector-private). The synthetic name format
         // mirrors `class-bodies.ts:275` exactly.
-        let methodNameRaw: string;
-        if (ts.isIdentifier(member.name)) methodNameRaw = member.name.text;
+        let memberBaseName: string;
+        if (ts.isIdentifier(member.name)) memberBaseName = member.name.text;
         else if (ts.isStringLiteral(member.name) || ts.isNumericLiteral(member.name)) {
-          methodNameRaw = member.name.text;
+          memberBaseName = member.name.text;
         } else continue; // computed / private name — skipped by selector
 
-        const memberName = `${className}_${methodNameRaw}`;
+        // #3000-B: accessors register under `${className}_get_${prop}` /
+        // `${className}_set_${prop}` funcMap keys (see `class-bodies.ts`); a
+        // setter is VOID (`returnTypeOverride: null`), a getter returns
+        // `member.type` unchanged. Methods keep `${className}_${name}`.
+        let memberName: string;
+        let returnTypeOverride: IrType | null | undefined;
+        if (ts.isGetAccessorDeclaration(member)) {
+          memberName = `${className}_get_${memberBaseName}`;
+        } else if (ts.isSetAccessorDeclaration(member)) {
+          memberName = `${className}_set_${memberBaseName}`;
+          returnTypeOverride = null; // set accessor bodies return void
+        } else {
+          memberName = `${className}_${memberBaseName}`;
+        }
         if (!selected.classMembers.has(memberName)) continue;
 
         try {
@@ -339,6 +354,7 @@ export function compileIrPathFunctions(
             exported: false, // class methods are not directly exported
             funcName: memberName,
             selfParam: { type: { kind: "class", shape: classShape } as IrType },
+            returnTypeOverride,
             calleeTypes,
             classShapes,
             resolver: fromAstResolver,

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -412,7 +412,12 @@ export function planIrCompilation(
     const hasParent = stmt.heritageClauses?.some((h) => h.token === ts.SyntaxKind.ExtendsKeyword) ?? false;
     for (const member of stmt.members) {
       let memberName: string;
-      let memberNode: ts.MethodDeclaration | ts.ConstructorDeclaration;
+      let memberNode:
+        | ts.MethodDeclaration
+        | ts.ConstructorDeclaration
+        // #3000-B: accessors join the claimable member kinds.
+        | ts.GetAccessorDeclaration
+        | ts.SetAccessorDeclaration;
       if (ts.isConstructorDeclaration(member)) {
         memberName = `${className}_new`;
         memberNode = member;
@@ -433,19 +438,37 @@ export function planIrCompilation(
         }
         memberName = `${className}_${methodNameRaw}`;
         memberNode = member;
-      } else {
-        // PropertyDeclaration (field), GetAccessorDeclaration,
-        // SetAccessorDeclaration, IndexSignatureDeclaration,
-        // SemicolonClassElement, ClassStaticBlockDeclaration — none are
-        // claimed by Phase A. Telemetry reasons:
-        //   - get/set → "class-method" (will be lowered with the rest of
-        //     the class member surface in a follow-up slice).
-        //   - PropertyDeclaration → not a function — out of IR's scope.
-        if (trackFallbacks && (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member))) {
-          const accessorName = member.name && phase1MemberName(member.name);
-          const key = `${className}_${accessorName ?? "<accessor>"}`;
-          fallbackReasons.set(key, "class-method");
+      } else if (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) {
+        // #3000-B: get/set accessors. The legacy path (`class-bodies.ts`)
+        // registers them under DISTINCT `${className}_get_${prop}` /
+        // `${className}_set_${prop}` funcMap keys — a getter and a setter of
+        // the same name are two separate slots, not a collapsed one. Claim
+        // each independently under the matching key so the Phase B walk and
+        // the funcMap slot patch agree.
+        const isGet = ts.isGetAccessorDeclaration(member);
+        const propName = member.name ? phase1MemberName(member.name) : null;
+        if (propName === null) {
+          // Computed / private accessor name — not claimed.
+          if (trackFallbacks) {
+            fallbackReasons.set(`${className}_${isGet ? "get" : "set"}_<computed>`, "class-method");
+          }
+          continue;
         }
+        const accessorKey = `${className}_${isGet ? "get" : "set"}_${propName}`;
+        // Static accessors use a different funcMap-entry shape (no `self`
+        // injection) — defer them alongside static-method internals, mirroring
+        // the instance-only restriction in the Phase B integration walk.
+        const isStaticAccessor = member.modifiers?.some((m) => m.kind === ts.SyntaxKind.StaticKeyword) ?? false;
+        if (isStaticAccessor) {
+          if (trackFallbacks) fallbackReasons.set(accessorKey, "class-method");
+          continue;
+        }
+        memberName = accessorKey;
+        memberNode = member;
+      } else {
+        // PropertyDeclaration (field), IndexSignatureDeclaration,
+        // SemicolonClassElement, ClassStaticBlockDeclaration — none are
+        // claimed (not functions — out of IR's scope).
         continue;
       }
       // (#2857 static-method slice) A `static` method compiles to an ordinary
@@ -585,7 +608,15 @@ export function planIrCompilation(
  * from MethodDeclaration / ConstructorDeclaration (class-owned, with
  * extra method-specific guards).
  */
-type IrClaimableSubject = ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration;
+type IrClaimableSubject =
+  | ts.FunctionDeclaration
+  | ts.MethodDeclaration
+  | ts.ConstructorDeclaration
+  // #3000-B: get/set accessors are claimable as no-arg / one-arg instance
+  // members over a private (or public) slot. A getter's return type comes from
+  // `fn.type`; a setter is inherently void (handled explicitly below).
+  | ts.GetAccessorDeclaration
+  | ts.SetAccessorDeclaration;
 
 /**
  * Variant of `isIrClaimable` that returns the rejection reason instead of a
@@ -728,6 +759,11 @@ function whyNotIrClaimable(
       // we accept the shape and treat the return resolution as "object"
       // implicitly; Phase B/C will use the className from the parent node
       // to produce the correct class-typed return.
+    } else if (ts.isSetAccessorDeclaration(fn)) {
+      // #3000-B: a set accessor carries no source-level return type — it is
+      // inherently void. Its body is a void tail (the lone `this.#x = v;`
+      // property store, accepted by `isPhase1Tail`'s void-tail arm).
+      isVoidReturn = true;
     } else {
       const returnResolved = resolveReturnType(fn, entry?.returnType);
       if (returnResolved === null) return "return-type-not-resolvable";
@@ -984,7 +1020,9 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
 // ts.ConstructorDeclaration is excluded — constructors don't carry a
 // source-level return type; the caller short-circuits before this.
 function resolveReturnType(
-  fn: ts.FunctionDeclaration | ts.MethodDeclaration,
+  // #3000-B: also accept a GET accessor — its return type is `fn.type` exactly
+  // like a method. (SET accessors are void and never reach here.)
+  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.GetAccessorDeclaration,
   mapped: LatticeType | undefined,
 ): ResolvedKind {
   if (fn.type) {
@@ -1949,7 +1987,39 @@ function isPhase1Tail(
   // return. The lowerer's void branch synthesizes the empty-values
   // terminator after the expression's side effects.
   if (isVoidReturn && ts.isExpressionStatement(stmt)) {
-    return isPhase1Expr(stmt.expression, scope, localClasses);
+    const expr = stmt.expression;
+    // #3000-B: a property-store assignment as the void tail — the SET
+    // accessor body shape `set name(v) { this.#name = v; }`. Mirror the
+    // NON-tail property-store arm exactly (receiver Phase-1, prop an
+    // Identifier or PrivateIdentifier, RHS Phase-1); from-ast's void-tail
+    // arm routes it through the same `lowerPropertyAssignment` used mid-body,
+    // preserving select↔build parity.
+    if (
+      ts.isBinaryExpression(expr) &&
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(expr.left)
+    ) {
+      if (!ts.isIdentifier(expr.left.name) && !ts.isPrivateIdentifier(expr.left.name))
+        return shapeNo("tail-assign-computedprop", expr);
+      if (!isPhase1Expr(expr.left.expression, scope, localClasses))
+        return shapeNo("tail-assign-recv", expr.left.expression);
+      return isPhase1Expr(expr.right, scope, localClasses);
+    }
+    // #3000-B: element-store assignment as the void tail (`arr[i] = v;` last).
+    // Same receiver restriction as the non-tail element-store arm.
+    if (
+      ts.isBinaryExpression(expr) &&
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isElementAccessExpression(expr.left)
+    ) {
+      const lhs = expr.left;
+      if (!ts.isIdentifier(lhs.expression) || !scope.has(lhs.expression.text))
+        return shapeNo("tail-elemstore-recv", lhs.expression);
+      if (!isPhase1Expr(lhs.argumentExpression, scope, localClasses))
+        return shapeNo("tail-elemstore-idx", lhs.argumentExpression);
+      return isPhase1Expr(expr.right, scope, localClasses);
+    }
+    return isPhase1Expr(expr, scope, localClasses);
   }
   return shapeNo("tail-unhandled", stmt);
 }

--- a/tests/issue-3000-b.test.ts
+++ b/tests/issue-3000-b.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3000-B — IR class-member accessors (get/set).
+//
+// Phase 1a (#3000, PR #2597) taught the selector + AST→IR lowerer to accept
+// `this.#x` private-field READ / WRITE. This slice claims + lowers get/set
+// ACCESSORS over that (now-supported) slot:
+//
+//   - Selector (`src/ir/select.ts`): a flat-class INSTANCE get/set accessor is
+//     no longer bucketed `class-method`. Each is claimed under the SAME
+//     `${Class}_get_${prop}` / `${Class}_set_${prop}` funcMap key the legacy
+//     `class-bodies.ts` pass registers (a getter and a setter of the same name
+//     are two DISTINCT slots, not a collapsed one). Static accessors and
+//     accessors on an `extends` subclass stay `class-method` (Phase E).
+//   - AST→IR (`src/ir/from-ast.ts`): `lowerFunctionAstToIr` accepts accessor
+//     nodes — a getter lowers like a no-arg method returning `fn.type`; a
+//     setter like a one-arg VOID method. The setter body's lone `this.#x = v;`
+//     is a void-tail property store, newly accepted by `isPhase1Tail` and
+//     lowered through the SAME `lowerPropertyAssignment` the non-tail path uses
+//     (select↔build parity).
+//   - Integration (`src/ir/integration.ts`): the Phase B member walk builds
+//     accessor declarations alongside methods, mapping to the legacy accessor
+//     funcMap key and forcing a void return for setters.
+//
+// Non-vacuity: for a class whose fields PROJECT into an `IrClassShape`
+// (numeric / boolean / object fields), the accessor bodies genuinely IR-emit
+// and the runtime tests below exercise those IR-emitted bodies (compileSource
+// defaults `experimentalIR` on). Classes with a `string` field do not yet get
+// an `IrClassShape` (`valTypeToIrField` defers string fields — index.ts) so
+// their members — accessors, methods AND the ctor alike — stay byte-inert on
+// legacy; that shape-substrate gap blocks all of #3000 for string-field
+// classes and is banked as a follow-up (see the issue's Implementation Notes).
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+function selection(source: string) {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+  return planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+}
+
+// Numeric-only flat class — every field projects, so `buildIrClassShapes`
+// produces a shape and the accessor bodies genuinely lower through IR.
+const COUNTER = `
+  class Counter {
+    #n: number;
+    constructor(start: number) { this.#n = start; }
+    get value(): number { return this.#n; }
+    set value(v: number) { this.#n = v; }
+    bump(): number { return this.#n + 1; }
+  }
+`;
+
+describe("#3000-B — IR accessor selection", () => {
+  it("claims a flat-class instance getter and setter under distinct get_/set_ keys", () => {
+    const sel = selection(COUNTER);
+    const claimed = new Set(sel.classMembers ?? []);
+    expect(claimed.has("Counter_get_value")).toBe(true);
+    expect(claimed.has("Counter_set_value")).toBe(true);
+  });
+
+  it("get+set of the same name claim independently (not collapsed)", () => {
+    const sel = selection(COUNTER);
+    const reasons = new Map<string, string>();
+    for (const fb of sel.fallbacks ?? []) reasons.set(fb.name, fb.reason);
+    // Neither survives as a `class-method` fallback.
+    expect(reasons.get("Counter_get_value")).toBeUndefined();
+    expect(reasons.get("Counter_set_value")).toBeUndefined();
+    expect(reasons.get("Counter_value")).toBeUndefined(); // no collapsed key
+  });
+
+  it("a getter-only accessor claims the getter and no phantom setter", () => {
+    const sel = selection(`
+      class Ro { #x: number; constructor(x: number) { this.#x = x; } get x(): number { return this.#x; } }
+    `);
+    const claimed = new Set(sel.classMembers ?? []);
+    expect(claimed.has("Ro_get_x")).toBe(true);
+    expect(claimed.has("Ro_set_x")).toBe(false);
+  });
+
+  it("defers a static accessor to class-method (no self-injection path yet)", () => {
+    const sel = selection(`
+      class S { static #c: number; static get count(): number { return S.#c; } }
+    `);
+    const claimed = new Set(sel.classMembers ?? []);
+    expect(claimed.has("S_get_count")).toBe(false);
+    const reasons = new Map<string, string>();
+    for (const fb of sel.fallbacks ?? []) reasons.set(fb.name, fb.reason);
+    expect(reasons.get("S_get_count")).toBe("class-method");
+  });
+
+  it("defers an accessor on an `extends` subclass to class-method (Phase E)", () => {
+    const sel = selection(`
+      class Base { #n: number; constructor(n: number) { this.#n = n; } get n(): number { return this.#n; } }
+      class Sub extends Base { #m: number; constructor(n: number, m: number) { super(n); this.#m = m; } get m(): number { return this.#m; } }
+    `);
+    const claimed = new Set(sel.classMembers ?? []);
+    // Flat Base getter is claimed; the subclass getter is deferred.
+    expect(claimed.has("Base_get_n")).toBe(true);
+    expect(claimed.has("Sub_get_m")).toBe(false);
+    const reasons = new Map<string, string>();
+    for (const fb of sel.fallbacks ?? []) reasons.set(fb.name, fb.reason);
+    expect(reasons.get("Sub_get_m")).toBe("class-method");
+  });
+});
+
+describe("#3000-B — IR accessor emission has no post-claim demotion", () => {
+  it("compiles the numeric accessor class with no post-claim error for the accessor slots", async () => {
+    const src = `${COUNTER}\n export function test(): number { const c = new Counter(3); return c.bump(); }`;
+    const r = await compile(src, { fileName: "test.ts", experimentalIR: true });
+    expect(r.success).toBe(true);
+    const bad = (r.irPostClaimErrors ?? []).filter(
+      (e) => e.func === "Counter_get_value" || e.func === "Counter_set_value",
+    );
+    // A CLAIMED accessor that failed build/verify/lower/parity would surface
+    // here; empty ⇒ both slots were patched with their IR-lowered bodies.
+    expect(bad).toEqual([]);
+  });
+});
+
+describe("#3000-B — IR accessor runtime behaviour", () => {
+  it("get + set round-trip through the IR-emitted accessor bodies", async () => {
+    // `test` reads via the getter, writes via the setter, reads again. The
+    // accessor bodies are IR-emitted (numeric field ⇒ IrClassShape exists);
+    // callers dispatch to those patched slots.
+    const exports = await compileAndInstantiate(`
+      ${COUNTER}
+      export function readInit(): number { const c = new Counter(10); return c.value; }
+      export function afterSet(): number { const c = new Counter(10); c.value = 25; return c.value; }
+      export function viaBump(): number { const c = new Counter(41); return c.bump(); }
+    `);
+    expect((exports.readInit as () => number)()).toBe(10); // getter
+    expect((exports.afterSet as () => number)()).toBe(25); // setter (void tail) then getter
+    expect((exports.viaBump as () => number)()).toBe(42); // private read in a method, same slot
+  });
+
+  it("setter with a computed RHS (void-tail property store) works", async () => {
+    const exports = await compileAndInstantiate(`
+      class Acc {
+        #total: number;
+        constructor() { this.#total = 0; }
+        get total(): number { return this.#total; }
+        set total(v: number) { this.#total = v * 2 + 1; }
+      }
+      export function run(): number { const a = new Acc(); a.total = 20; return a.total; }
+    `);
+    expect((exports.run as () => number)()).toBe(41); // 20*2+1
+  });
+});


### PR DESCRIPTION
## #3000-B — IR class-member accessors (get/set)

Third slice of #3000. Phase 1a (#2597) landed private-field read/write. This slice claims + lowers **flat-class instance get/set accessors** over that private (or public) slot. `class-method` on `classes.ts` drops **5 → 3** (`Animal` name get+set and age get claimed; `Dog_breed`, `Dog_new`, `Dog_speak` stay `class-method` — all Phase E / `extends`).

### Changes
- **`src/ir/select.ts`** — widen `IrClaimableSubject` + `resolveReturnType` to accessors; a set accessor resolves **void**; a new class-member arm claims instance getters/setters under **distinct** `${Class}_get_${prop}` / `${Class}_set_${prop}` keys (the legacy funcMap keys — get and set are separate slots, not collapsed). Static accessors and `extends`-subclass accessors stay `class-method`. `isPhase1Tail` now accepts a **void-tail property/element store** — closing Phase-1a "finding 3" (the setter body `set x(v){ this.#x = v }`).
- **`src/ir/from-ast.ts`** — `lowerFunctionAstToIr` accepts accessor nodes (setter forced void); `lowerTail`'s void arm routes a tail `this.#x = v;` / `arr[i] = v;` through the **same** `lowerPropertyAssignment` / `lowerElementStore` the non-tail path uses (select↔build parity). Two body-only helpers widened.
- **`src/ir/integration.ts`** — the Phase B member walk builds accessor declarations alongside methods, mapping to the legacy `_get_`/`_set_` funcMap key, `returnTypeOverride: null` for setters.
- **`scripts/ir-fallback-baseline.json`** — `class-method` 5 → 3.
- **`tests/issue-3000-b.test.ts`** — selector claims (distinct keys, static + subclass deferral), a no-post-claim-demotion emission assertion, and runtime get/set round-trip + void-tail setter over a numeric class.

### Non-vacuity (verified)
For a class whose fields **project** into an `IrClassShape` (numeric / boolean / object), the accessor bodies genuinely IR-emit: `report.compiled` includes `Counter_get_value | Counter_set_value`, post-claim demotions are `(none)`, and the runtime tests exercise those patched slots (getter → 10, void-tail setter → 25, method private read → 42).

### Known limitation (banked follow-up)
On `classes.ts` the claimed `Animal` accessors are **byte-inert**: `Animal` has a `string` field, and `buildIrClassShapes` rejects any class with a string field (`valTypeToIrField` defers strings). Without an `IrClassShape`, the Phase B walk skips **every** Animal member — so Phase-1a's `Animal_speak` was byte-inert on `classes.ts` too (its runtime test asserts behaviour, satisfied by legacy). String-field projection is not accessor-specific (it blocks methods + ctor + accessors of every string-field class) and needs AST/checker-driven field typing with cross-lane ValType parity — documented in the issue and banked as a prerequisite. The typeIdx parity guard makes it safe (a mis-projection can only cause a byte-inert skip, never a miscompile).

Separately: accessor **call sites** in an IR-claimed caller (`c.value`) still lower as field access → demote to legacy (pre-existing, harmless; noted for a future slice).

### Validation
- `check:ir-fallbacks`: class-method **5 → 3**, zero post-claim demotions, no unintended increases.
- `tsc --noEmit`: clean.
- `tests/issue-3000-b.test.ts` (8), `issue-3000` (5), `accessor-side-effects`, `ir-slice4-classes`, `private-class-members` — pass.
- Class-suite `{ env: {} }` / `__unbox_number` harness failures (class-methods, classes, getters-setters, ir/passes, ir/inline-small) are **pre-existing** — verified identical counts on base; tracked separately (#3034 for the unbox stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8