### PR TITLE
feat(#2106): flip $undefined singleton default ON (standalone/nativeStrings)

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -683,6 +683,28 @@ with `JS2WASM_UNDEF_SINGLETON=1` (runner-level env, no code change needed);
 merge_group; (3) S2 (sNaN carve-out codify), S3 (number|undefined→externref,
 needs the box-protocol fix), S4 (union-collapse reversal) remain per plan.
 
+### S1 default-flip — A/B MEASUREMENT (dev-selfserve-2, 2026-07-04, PR #2655)
+
+Executes next-steps (1)+(2). Flips the `undefinedSingleton` default OFF→ON in
+`create-context.ts` (default now `process.env.JS2WASM_UNDEF_SINGLETON !== "0"`;
+`=0` forces the legacy regime for control/rollback). Branch
+`issue-2106-undef-default-flip`.
+
+- **Blast radius**: host (gc) mode BYTE-IDENTICAL regardless of the flag —
+  `undefinedSingletonActive()` also gates on `standalone||nativeStrings`.
+  Byte-diff proof (sha256, 10-op corpus): gc `default==off==on`; wasi
+  `default==on` and `on != off`. So the flip is active ONLY in
+  standalone/wasi/nativeStrings, exactly as intended.
+- **Local validation**: `tests/issue-2106-s1-undefined-singleton.test.ts` 9/9
+  (flag-off legacy control passes `undefinedSingleton:false` explicitly, so it
+  is unaffected by the default flip).
+- **The PR IS the A/B**: CI test262 regression gate measures the standalone
+  delta vs main (flag-off baseline). MERGE only if net-positive AND
+  standalone-floor-safe (the June partial flip PR #2025 breached the floor at
+  −1245 because producers/consumers were out of lockstep; PR #2633's complete
+  sweep is what this measures as the default). If net-negative or floor-breach:
+  close PR, keep default OFF, document the finding here.
+
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 
 NOT done — the referencing merged PR was a REVERT (PR #2025 auto-parked: standalone floor breach, NET -1245 test262 rows), so it is floor-neutral undo, NOT progress. S1 (standalone tag-1 $undefined singleton) still requires the FULL ~40-site producer+consumer sweep (architect re-spec) — no narrow floor-saving subset exists. S2 (sNaN carve-out), S3 (number|undefined→externref), S4 (union-collapse reversal), typeof-null→object all remain. Stays in-progress; resume-only for a senior-dev at max effort.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -255,10 +255,15 @@ export function createCodegenContext(
     // (#2141 S2/S3, #2626) tag-5 boxed-VALUE eq classifier — default OFF
     // (legacy); JS2WASM_TAG5_CLASSIFIER=1 env defaults it on for runner A/B.
     tag5ValueEqClassifier: options?.tag5ValueEqClassifier ?? process.env.JS2WASM_TAG5_CLASSIFIER === "1",
-    // (#2106 S1) standalone $undefined tag-1 singleton regime — default OFF
-    // (legacy: undefined ≡ null ≡ ref.null.extern, byte-identical);
-    // JS2WASM_UNDEF_SINGLETON=1 env defaults it on for runner A/B.
-    undefinedSingleton: options?.undefinedSingleton ?? process.env.JS2WASM_UNDEF_SINGLETON === "1",
+    // (#2106 S1 default-flip) standalone $undefined tag-1 singleton regime —
+    // default ON. The complete lockstep producer+consumer sweep landed behind
+    // this flag in PR #2633; this flip makes the singleton the default
+    // standalone/nativeStrings `undefined` representation so undefined is
+    // observable to ===/??/?./typeof/ToString instead of aliasing null.
+    // Host mode is unaffected (`undefinedSingletonActive` also gates on
+    // standalone||nativeStrings). Set JS2WASM_UNDEF_SINGLETON=0 to force the
+    // legacy (undefined ≡ null ≡ ref.null.extern) regime for A/B control.
+    undefinedSingleton: options?.undefinedSingleton ?? process.env.JS2WASM_UNDEF_SINGLETON !== "0",
     // (#2796) Diff-test-harness fidelity — export __module_init + skip the wasm
     // start section so the host runs top-level code after setExports.
     deferTopLevelInit: options?.deferTopLevelInit ?? false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -97,8 +97,9 @@ export interface CodegenOptions {
    *  `CompileOptions.tag5ValueEqClassifier` doc. Default false (legacy). */
   tag5ValueEqClassifier?: boolean;
   /** (#2106 S1) Standalone `$undefined` tag-1 singleton regime — see the
-   *  `CompileOptions.undefinedSingleton` doc. Default false (legacy:
-   *  undefined ≡ null ≡ ref.null.extern in standalone, byte-identical). */
+   *  `CompileOptions.undefinedSingleton` doc. Default TRUE (#2106
+   *  default-flip); `JS2WASM_UNDEF_SINGLETON=0` forces the legacy
+   *  (undefined ≡ null ≡ ref.null.extern) regime. */
   undefinedSingleton?: boolean;
   /** (#2796) Diff-test-harness fidelity: in JS-host mode, export the top-level
    *  `__module_init` and do NOT run it via the wasm `start` section, so the host
@@ -1923,9 +1924,10 @@ export interface CodegenContext {
    *  for runner-level A/B. */
   tag5ValueEqClassifier: boolean;
   /** (#2106 S1) Standalone `$undefined` tag-1 singleton regime flag — see the
-   *  `CompileOptions.undefinedSingleton` doc. Default false (legacy:
-   *  undefined ≡ null ≡ ref.null.extern, byte-identical). Only meaningful
-   *  under standalone/nativeStrings; host mode ignores it. */
+   *  `CompileOptions.undefinedSingleton` doc. Default TRUE (#2106
+   *  default-flip); `JS2WASM_UNDEF_SINGLETON=0` forces the legacy
+   *  (undefined ≡ null ≡ ref.null.extern) regime. Only meaningful under
+   *  standalone/nativeStrings; host mode ignores it. */
   undefinedSingleton: boolean;
   /** (#2796) Diff-test-harness fidelity: in JS-host mode, export the top-level
    *  `__module_init` and do NOT wire the wasm `start` section to it, so the host

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,11 +251,12 @@ export interface CompileOptions {
    * miss, literal stores, boxToAny) and undefined-specific consumers
    * (`__extern_is_undefined`, typeof cluster, strict-eq) flip in lockstep
    * under this flag; nullish-intent consumers widen to `is_null ∨
-   * is-singleton`. Default false (legacy: undefined ≡ null ≡ ref.null.extern,
-   * byte-identical modules). Host (gc) mode is unaffected — it has a real
-   * host `undefined` via `__get_undefined`. `JS2WASM_UNDEF_SINGLETON=1`
-   * defaults it on for whole-runner A/B; the default flip is a separate
-   * measured PR (#2106).
+   * is-singleton`. Default TRUE (#2106 default-flip): the singleton is the
+   * standalone/nativeStrings `undefined` representation. Host (gc) mode is
+   * unaffected — it has a real host `undefined` via `__get_undefined`, and
+   * `undefinedSingletonActive` also gates on standalone||nativeStrings. Set
+   * `JS2WASM_UNDEF_SINGLETON=0` to force the legacy (undefined ≡ null ≡
+   * ref.null.extern, byte-identical) regime for A/B control / rollback.
    */
   undefinedSingleton?: boolean;
   /** #1588 PR-B: dual i8/i16 string storage. When true, string allocation


### PR DESCRIPTION
## What

Flips the default of the `undefinedSingleton` compile flag from OFF to **ON**. The complete lockstep producer+consumer $undefined tag-1 singleton sweep landed behind this flag in PR #2633 (validated byte-inert with the flag off + 8 flag-on behavioral tests). This is the **A/B default-flip** step: make the singleton the default standalone/nativeStrings representation of `undefined`, so `undefined` is observable to `===`/`??`/`?.`/`typeof`/`ToString` instead of aliasing `null` (both were `ref.null.extern`).

## Scope / blast radius

- **Host (gc) mode: byte-identical, unaffected.** `undefinedSingletonActive()` also gates on `standalone||nativeStrings`, so the flag is a no-op in host mode. Byte-diff proof (10-op corpus, sha256): gc `default==off==on`.
- **Standalone / wasi / nativeStrings: flip active.** Byte-diff proof: wasi `default==on`, `on != off`.
- `JS2WASM_UNDEF_SINGLETON=0` forces the legacy (undefined ≡ null ≡ ref.null.extern) regime for A/B control / rollback.

## Why this is the measurement vehicle

The only change is the one-line flag default + doc comments. CI's test262 regression gate measures the standalone delta vs main (the flag-off baseline). **This PR should be kept only if net-positive and standalone-floor-safe** — the June partial flip (PR #2025) breached the floor at −1245 because producers/consumers were out of lockstep; PR #2633 re-landed the *complete* sweep, and this measures it as the default.

## Local proofs

- `tests/issue-2106-s1-undefined-singleton.test.ts`: 9/9 pass (8 flag-on behavioral + flag-off legacy control). The control passes `undefinedSingleton: false` explicitly, so it is unaffected by the default flip.
- Byte-inertness proof (host inert; wasi flip active) — see Scope above.

Closes the step-1/step-2 A/B item in #2106's next-steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)