### PR TITLE
feat(#2906): slice 3b — for-await-of native async-iterator carrier (host-free)

### DIFF
--- a/.claude/memory/project_2906_forawait_needs_asynciterator_carrier.md
+++ b/.claude/memory/project_2906_forawait_needs_asynciterator_carrier.md
@@ -41,3 +41,43 @@ pattern), or emit Wasm helpers directly.
 
 Landed for 3b: banking only (issue doc + this note); the drive machine stays
 ready, the carrier is the real next step.
+
+## UPDATE (2026-07-04): carrier BUILT — for-await works host-free.
+
+Both blockers are now closed (branch `issue-2906-asynciter-carrier`, opus-asynciter):
+`for await (x of [P.resolve(1),P.resolve(2),P.resolve(3)]) sum+=x` → **6, imports
+`[]`** (was NaN). The approach that WORKED — reuse the 3a machine, do NOT build a
+Promise-returning native next():
+
+1. **Implicit-await coupling.** `AsyncCpsPlan` gained `forAwaitPoints` (ForOf with
+   `awaitModifier`, collected in `analyzeAsyncBody`); `asyncFnNeedsDrive` accepts a
+   bounded for-await-only body (awaitPoints===0 && forAwaitPoints===1) as
+   suspending.
+2. **Carrier = the SYNC iterator + a per-element `await value`.** The dominant
+   sync-backed shape is spec-equivalent to `it = GetAsyncIterator(src); loop {
+   {done,value}=it.next(); if done break; x = await value; body }` — one suspend
+   per iteration = the 3a while machine. So NO native async-next()→$Promise was
+   needed. `ensureAsyncIterator` (destructuring.ts) already returns the native
+   `__iterator` in standalone; each element (a Promise) is awaited by the stock
+   suspend terminator (Await(P.resolve(1))=1). `planForAwaitCfg` (async-cps.ts)
+   builds the 5-state CFG (entry/head/body/resume/exit).
+3. **Emit-hook operands (the AST-free escape hatch).** `it.next()`, the done flag
+   and the element are runtime wasm-local ops, NOT checker-typed AST — so the
+   plan's `suspend.awaited` / `condGoto.cond` were widened to
+   `ts.Expression | {emit}` and states gained an `emit?` step hook. This is how we
+   sidestep the #2367 synthetic-AST wall WITHOUT synthesising any AST. Existing
+   linear/while plans use no hooks → byte-identical.
+4. **Drive gate = BOXED elements only.** `forAwaitNeedsDrive` checks
+   `srcType.getNumberIndexType()` → resolveWasmType: externref/ref ⇒ drive;
+   f64/i32 (number[]) ⇒ LEGACY (Await(v)=v is already correct, and the typed array
+   would trap the vec `__iterator` — driving it was a regression). Non-array/user-
+   iterable (undefined index type) ⇒ legacy (3b′). The synthetic iterator is a
+   frame spill (`FORAWAIT_ITER_SPILL`).
+
+Byte-inertness: gc+standalone identical for all; wasi identical except a
+for-await. `number[]` for-await byte-identical to main (legacy). **3d (async-gen)
+is unblocked** — same emit-hook carrier + forAwaitPoints coupling, planner-only.
+Files: `src/codegen/async-cps.ts` (forAwaitPoints, emit-hook types,
+analyzeForAwait/forAwaitNeedsDrive/forAwaitSpillInfo/planForAwaitCfg),
+`src/codegen/async-frame.ts` (asyncFnNeedsDrive branch, computeForAwaitSpills,
+suspend/condGoto/state emit-hook emitters), `tests/issue-2906-3b-forawait.test.ts`.

--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -2,7 +2,7 @@
 id: 2906
 title: "Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)"
 status: in-progress
-assignee: ttraenkler/opus-2906-3b
+assignee: ttraenkler/opus-asynciter
 created: 2026-07-01
 priority: high
 feasibility: hard
@@ -200,12 +200,12 @@ field default, so those fall back to legacy (a later slice can widen this).
 programs (single-await, 2×multi-await, plain) under gc(default) / standalone /
 wasi and sha256'd the binaries before vs after:
 
-| program     | gc | standalone | wasi |
-| ----------- | -- | ---------- | ---- |
-| singleAwait | identical | identical | CHANGED (general machine) |
-| multiAwait  | identical | identical | CHANGED (new drive) |
-| pendingMulti| identical | identical | CHANGED (new drive) |
-| plain       | identical | identical | identical |
+| program      | gc        | standalone | wasi                      |
+| ------------ | --------- | ---------- | ------------------------- |
+| singleAwait  | identical | identical  | CHANGED (general machine) |
+| multiAwait   | identical | identical  | CHANGED (new drive)       |
+| pendingMulti | identical | identical  | CHANGED (new drive)       |
+| plain        | identical | identical  | identical                 |
 
 gc/host + standalone are **byte-identical** — the drive branch is gated on
 `isStandalonePromiseActive` (wasi-only), so neither lane reaches the changed
@@ -275,10 +275,13 @@ change (the intended unlock). All Gap-3 machine instrs are guarded on
 slice-1 branch; enqueue after #2413 lands. Gap 5 (for-await / async-gen) builds on
 this same abrupt-completion machinery; the slice-1d widen stays LAST.
 
-
 ## Reconciliation note (shepherd, 2026-07-01)
 
 Landed slices: **slice 1** general N-state async resume machine (PR #2413), **slice 2 / Gap 3** try/finally-across-await on the N-state machine (PR #2416). Issue stays `in-progress` for the remaining slices.
+
+## Reconciliation note (2026-07-04)
+
+Landed since: **slice 3** CFG-aware machine core (PR #2413-follow), **slice 3a** while-with-await loop producer, **slice 3b** for-await-of async-iterator carrier (this PR — `planForAwaitCfg` + `forAwaitPoints` coupling + emit-hook operands). `for await (x of [P.resolve(1),…])` now works host-free (→ 6, imports `[]`). Issue stays `in-progress` for 3b′ (user async iterables / destructuring binding / break-continue via `it.return()`), **3c** (try/catch + return-through-finally + nested regions), and **3d** (async generators — now unblocked, reuses this carrier).
 
 ## Slice 3 — CFG-aware machine core (this PR, 2026-07-03)
 
@@ -326,6 +329,74 @@ they cannot be #2906-slice-3 regressions).
 byte-identical everywhere, so it neither constrains nor is constrained by the
 slice-1d carrier-widen decision — the widen simply flips which lanes reach this
 (unchanged-shape) machine.
+
+## Slice 3b — for-await-of: the native async-iterator carrier (LANDED, host-free wasi lane)
+
+**What shipped.** `for await (const x of source)` over a BOXED-element array (the
+dominant test262 shape — `for await (x of [P.resolve(1), …])` / object arrays) is
+now driven host-free on the 3a CFG machine. `for await (x of [P.resolve(1),
+P.resolve(2), P.resolve(3)]) sum += x` → **6, imports `[]`** (was NaN). Both
+blockers the 3b grounding (PR #2653) identified — which sat BELOW the drive
+machine — are closed:
+
+- **(1) implicit-await coupling.** A `for await` carries no `ts.AwaitExpression`,
+  so `analyzeAsyncBody` reported 0 await points and every `awaitPoints`-keyed gate
+  treated the fn as non-suspending (→ AG0 unwrap → the loop var held the
+  un-awaited Promise → NaN). `AsyncCpsPlan` now also carries **`forAwaitPoints`**
+  (`ForOfStatement`s with an `awaitModifier`), and `asyncFnNeedsDrive` recognises
+  a bounded for-await-only body as suspending.
+- **(2) the async-iterator carrier.** `planForAwaitCfg` (async-cps.ts) lowers the
+  loop onto the existing CFG machine as the spec-equivalent
+  `it = GetAsyncIterator(source); loop { {done,value} = it.next(); if (done)
+break; x = await value; <body> }` (§7.4.3 GetIterator(async) + §27.1.4.4
+  AsyncFromSyncIterator: `Await(value)` — a Promise element double-resolves to its
+  value). No NEW emitter machinery: the sync `it.next()` step, the `done` test and
+  the element are RUNTIME ops on wasm locals — not checker-typed AST — so they are
+  injected via two new **emit hooks** (`AsyncCfgStepEmit` / `AsyncCfgValueEmit`)
+  threaded through the stock `condGoto` (done → exit) + `suspend` (await value) +
+  back-edge `goto(head)` substrate. This deliberately avoids the #2367
+  synthetic-AST wall (a synthetic identifier the checker can't type mis-lowers
+  element access). The persisted iterator is a synthetic frame spill
+  (`FORAWAIT_ITER_SPILL`, reloaded on every resume); the element/done locals are
+  transient (recomputed each head, never crossing a suspend).
+
+**This is the reusable substrate async generators (3d) consume** — the same
+emit-hook carrier drives an async-gen's `next()` protocol.
+
+**Bounded slice (everything else → legacy/AG0, correct-or-legacy).** Exactly one
+top-level `for await`, no bare `await` in the body, simple `const`/`let x`
+identifier binding, linear-canonical body with NO `break`/`continue`/`return`/
+`try`/nested loop/labeled/`switch`. **Drive gate**: only BOXED-element sources
+(the source's `getNumberIndexType()` resolves to externref/GC-ref — Promise/object
+arrays). Unboxed-primitive arrays (`number[]`) settle immediately (`Await(v)=v`) so
+the legacy sync path is already correct — and their typed WasmGC representation
+would trap the vec-based `__iterator`, so driving them is (correctly) rejected.
+Non-array / user-iterable sources (unknown index type) stay on legacy — general
+`AsyncFromSyncIterator` / user-`@@asyncIterator` is the 3b′ follow-up (abrupt loop
+exit via `it.return()` — an async close — is also 3b′).
+
+**Byte-inertness proof (the −16/−29 discipline).** sha256 of 6 programs ×
+{gc, standalone, wasi} before (origin/main) vs after: **gc + standalone identical
+for ALL programs** (the drive is gated on `isStandalonePromiseActive`, wasi-only,
+so neither lane reaches the changed code); **wasi identical for every program
+except a for-await** (plainAsync / multiAwait / whileAwait / syncForOf / plain all
+byte-identical; only the for-await wasi bytes change — the intended unlock). A
+`number[]` for-await is byte-identical to main in BOTH gc and wasi (it stays on
+legacy — no regression).
+
+**Verification.** `tests/issue-2906-3b-forawait.test.ts` (7 host-free wasi tests:
+the settled-Promise proof → 6; the genuinely-pending drain proof → suspends at 0,
+resumes to 23; pre/post statements; zero-element source; bare-body count; a
+rejected element rejecting the result promise without trapping; and the
+`number[]` legacy-path parity). The full async suite (2895/2906-3a/multiawait/
+gap3) shows the SAME pass/fail set as origin/main — the 3 gap3-tryfinally
+throw-path failures are pre-existing (a `{}`-instantiation harness gap), verified
+identical on a `main` worktree.
+
+**Unblocks 3d (async generators):** the emit-hook async-iterator carrier + the
+`forAwaitPoints` suspension coupling are the substrate 3d reuses for the
+`next()`-queue protocol; 3d is now a planner-only follow-up (`settleYield`
+terminator + result-promise queue) on this same machine.
 
 ## Design (banked): how the remaining shapes map onto the CFG machine
 
@@ -385,7 +456,7 @@ Implementation notes (the hazards a cheaper model must not skip):
    inside iteration k>1 routes to the result promise. Plus the byte-hash probe
    for non-loop programs (must stay identical).
 
-### 3b — for-await-of (async-iterator drive on 3a machinery)
+### 3b — for-await-of (async-iterator drive on 3a machinery) — LANDED (see "Slice 3b" above)
 
 > **UPDATE (2026-07-04):** grounding for 3b found this design's `it.next()`→
 > `$Promise` step needs the native async-iterator **carrier**, which
@@ -421,14 +492,14 @@ The full ES completion semantics on the frame's EXISTING `MODE`/`ABRUPT`/
    to `block { loop { try { chain } catch $exn { route } } }` so an abrupt
    completion becomes a STATE TRANSITION: the catch routes by the region-id
    local — region has a `catchState` → `ERROR=reason; MODE=THROW;
-   STATE=catchState; br <loop>` (the catch body is ordinary states and MAY
+STATE=catchState; br <loop>` (the catch body is ordinary states and MAY
    await); no region → settle-reject + return (today's behaviour). NOTE: this
    moves every arm's `br`-to-loop depth by +1 (the try block wraps the chain)
    — change `loopDepth` in ONE place (`buildStateBody`) and re-prove the
-   byte-hash on a `main` control before/after is *expectedly different* here,
+   byte-hash on a `main` control before/after is _expectedly different_ here,
    so instead prove semantics via the full async test files + new tests.
 2. **Handler regions generalize**: `{ id, parent, catchState?, finallyState?,
-   finalizer? }`. A finally that must support replay becomes states
+finalizer? }`. A finally that must support replay becomes states
    (`finallyState` entry); its terminator is a new `replay` terminator: read
    MODE — NEXT → goto(normal successor); THROW → set region local to `parent`,
    re-throw ERROR (routes to the next outer region); RETURN → settle the
@@ -478,6 +549,7 @@ branch base: a while-await wasi fn was host-free-compilable but never completed
 across genuine suspensions with the accumulator surviving each spill/restore.
 
 **How** (planner + spill only — the emitter already had goto/condGoto):
+
 - `async-cps.ts` — `planAsyncCfg(fn, plan, {allowLoops})` is now the single CFG
   producer for the drive lane. Linear bodies **delegate** to the byte-identical
   `linearPlanToCfg(planLinearAwaits(...))` path (proven: the 69-test async drive
@@ -530,10 +602,16 @@ lands; this section banks the follow-up with a concrete contract.
 1. **The drive machine already handles the for-await loop-drive shape.** The
    spec-equivalent index lowering of `for await (const x of arr)`, written as
    real source —
+
    ```ts
-   const __src = arr; let __i = 0;
-   while (__i < __src.length) { const x = await __src[__i]; __i = __i + 1; /*body*/ }
+   const __src = arr;
+   let __i = 0;
+   while (__i < __src.length) {
+     const x = await __src[__i];
+     __i = __i + 1; /*body*/
+   }
    ```
+
    — compiles host-free (imports `[]`, valid Wasm) and runs correctly on the 3a
    while-with-await machine (`[P.resolve(1),P.resolve(2),P.resolve(3)]` → sum 6,
    both the fast-path advance and the `__drain_microtasks` resume). So the CFG
@@ -541,7 +619,7 @@ lands; this section banks the follow-up with a concrete contract.
    shipped are sufficient.
 
 2. **The user-facing gap is real and severe.** `for await (const x of
-   [Promise.resolve(1), …]) { sum += x }` compiles host-free today but yields
+[Promise.resolve(1), …]) { sum += x }` compiles host-free today but yields
    **NaN** — for-await produces **no `ts.AwaitExpression`** (the per-element
    suspension is implicit in `awaitModifier`), so `analyzeAsyncBody` reports
    **zero await points**, every gate (`asyncFnNeedsDrive` / `asyncFnNeedsCps` /

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -35,6 +35,7 @@ import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { resolveWasmType } from "./index.js";
 import { coerceType, compileExpression, compileStatement } from "./shared.js";
+import { ensureAsyncIterator } from "./statements/destructuring.js";
 
 /**
  * Master gate for the AST-side async CPS lowering.
@@ -66,6 +67,18 @@ export const ASYNC_CPS_ENABLED = true;
 export interface AsyncCpsPlan {
   /** Pre-order list of await points found in the body (by `ts.Node` identity). */
   readonly awaitPoints: readonly ts.AwaitExpression[];
+  /**
+   * (#2906 slice 3b) Top-level `for await (… of …)` loops in the body (not
+   * descending into nested fn scopes). A `for await` carries NO
+   * `ts.AwaitExpression` — the per-element suspension is implicit in the
+   * `awaitModifier` — so it never lands in `awaitPoints`; without this the whole
+   * `awaitPoints`-keyed suspension machinery treats a for-await-only body as
+   * non-suspending (AG0 unwrap → the loop var holds the un-awaited Promise → NaN
+   * for `for await (x of [P.resolve(1), …])`). The native drive lane
+   * (`asyncFnNeedsDrive` → `planForAwaitCfg`) keys off THIS list to recognise the
+   * fn as suspending and lower the async-iterator drive onto the CFG machine.
+   */
+  readonly forAwaitPoints: readonly ts.ForOfStatement[];
   /**
    * For each await point: the set of live local names that must be captured
    * into the continuation that resumes after the await. "Live" = referenced in
@@ -103,6 +116,7 @@ export interface AsyncCpsPlan {
  */
 export function analyzeAsyncBody(_ctx: CodegenContext, fn: ts.FunctionLikeDeclaration): AsyncCpsPlan {
   const awaitPoints: ts.AwaitExpression[] = [];
+  const forAwaitPoints: ts.ForOfStatement[] = [];
   const body = fn.body;
 
   // Collect await points in pre-order, WITHOUT descending into nested function
@@ -110,6 +124,7 @@ export function analyzeAsyncBody(_ctx: CodegenContext, fn: ts.FunctionLikeDeclar
   // awaits do not suspend the enclosing function.
   if (body !== undefined) {
     collectAwaitPoints(body, awaitPoints);
+    collectForAwaitPoints(body, forAwaitPoints);
   }
 
   // Live-after-await: for each await, the names referenced in the textual
@@ -149,6 +164,7 @@ export function analyzeAsyncBody(_ctx: CodegenContext, fn: ts.FunctionLikeDeclar
 
   return {
     awaitPoints,
+    forAwaitPoints,
     liveAfterAwait,
     hasTryAcrossAwait: awaitPoints.length > 0 && bodyHasTryAcrossAwait(body),
     hasUncaughtThrow: body !== undefined && bodyHasUncaughtThrow(body),
@@ -1008,6 +1024,34 @@ function statementContainsNode(stmt: ts.Node, node: ts.Node): boolean {
 // are PLANNER-ONLY follow-ups that never touch the emitter again.
 // ---------------------------------------------------------------------------
 
+/**
+ * (#2906 slice 3b) An emit escape hatch. A `for await` loop's iterator-protocol
+ * steps — `GetAsyncIterator(expr)`, the per-iteration `it.next()`, the `done`
+ * flag test, the element value — are RUNTIME operations on wasm locals, not
+ * checker-typed `ts.Expression`s, and synthesising the AST for them is the #2367
+ * wall (a synthetic identifier the checker cannot type mis-lowers property /
+ * element access). So the for-await planner injects those steps as raw
+ * instructions via these hooks; the CFG machine's state/terminator/suspend/
+ * back-edge substrate is otherwise unchanged, which is what makes this carrier
+ * reusable by async-generators (3d). Pre-existing (linear / while) plans use NO
+ * hooks, so their emitted machine is byte-identical.
+ *
+ * A `AsyncCfgValueEmit` pushes exactly ONE value and returns its `ValType`
+ * (consumed like a `compileExpression` result); a `AsyncCfgStepEmit` runs a
+ * side-effecting step and leaves the stack balanced. Both are invoked with the
+ * resume function's `(ctx, fctx)` at emit time.
+ */
+export type AsyncCfgValueEmit = (ctx: CodegenContext, fctx: FunctionContext) => ValType;
+export type AsyncCfgStepEmit = (ctx: CodegenContext, fctx: FunctionContext) => void;
+
+/** A terminator operand that is either a checker-typed AST node or an emit hook. */
+export type AsyncCfgOperand = ts.Expression | { readonly emit: AsyncCfgValueEmit };
+
+/** True when an operand is an injected emit hook rather than a `ts.Expression`. */
+export function isEmitOperand(op: AsyncCfgOperand): op is { readonly emit: AsyncCfgValueEmit } {
+  return typeof (op as { emit?: unknown }).emit === "function";
+}
+
 /** One handler-annotated statement of a state's straight-line lead. */
 export interface AsyncCfgStmt {
   readonly stmt: ts.Statement;
@@ -1033,8 +1077,13 @@ export interface AsyncResumePoint {
 export type AsyncCfgTerminator =
   | {
       readonly kind: "suspend";
-      /** The await operand (assimilated to a `$Promise` / host promise). */
-      readonly awaited: ts.Expression;
+      /**
+       * The await operand (assimilated to a `$Promise` / host promise). A
+       * `ts.Expression` for linear/while awaits; an emit hook for for-await,
+       * whose awaited value is the iterator's `next()` element held in a wasm
+       * local (#2906 slice 3b).
+       */
+      readonly awaited: AsyncCfgOperand;
       /** State entered on resume AND on the synchronous fulfilled/rejected advance. */
       readonly resumeState: number;
       /** Handler region the await executes in (0 = none). */
@@ -1043,8 +1092,12 @@ export type AsyncCfgTerminator =
   | { readonly kind: "goto"; readonly target: number }
   | {
       readonly kind: "condGoto";
-      /** Condition, compiled with `ensureI32Condition` truthiness. */
-      readonly cond: ts.Expression;
+      /**
+       * Condition, compiled with `ensureI32Condition` truthiness. A
+       * `ts.Expression` for while/if heads; an emit hook (pushing the i32 `done`
+       * flag) for the for-await loop head (#2906 slice 3b).
+       */
+      readonly cond: AsyncCfgOperand;
       readonly whenTrue: number;
       readonly whenFalse: number;
       /** Handler region the condition evaluates in (0 = none). */
@@ -1059,6 +1112,13 @@ export interface AsyncCfgState {
   readonly resumeFrom: AsyncResumePoint | null;
   readonly lead: readonly AsyncCfgStmt[];
   readonly terminator: AsyncCfgTerminator;
+  /**
+   * (#2906 slice 3b) Extra instructions emitted AFTER the resume prelude + lead
+   * and BEFORE the terminator — the for-await planner uses it to inject
+   * `it = GetAsyncIterator(source)` (entry) and `it.next()` → done/value locals
+   * (loop head). Must leave the stack balanced. `undefined` for all other plans.
+   */
+  readonly emit?: AsyncCfgStepEmit;
 }
 
 /**
@@ -1175,7 +1235,12 @@ export function planAsyncCfg(
 ): AsyncCfgPlan | null {
   const linear = planLinearAwaits(fn, plan);
   if (linear !== null) return linearPlanToCfg(linear);
-  if (opts.allowLoops) return planWhileLoopCfg(fn, plan);
+  if (opts.allowLoops) {
+    const whileCfg = planWhileLoopCfg(fn, plan);
+    if (whileCfg !== null) return whileCfg;
+    // (#2906 slice 3b) `for await (… of …)` — the async-iterator carrier drive.
+    return planForAwaitCfg(fn, plan);
+  }
   return null;
 }
 
@@ -1390,6 +1455,297 @@ export function loopAsyncSpillInfo(
 }
 
 // ---------------------------------------------------------------------------
+// for-await-of drive (#2906 slice 3b — the async-iterator carrier).
+//
+// A `for await (const x of source)` over a SYNC-backed async iterable (the
+// dominant test262 shape — `for await (x of [P.resolve(1), …])` / a sync
+// iterable) is spec-equivalent to
+//
+//     it = GetAsyncIterator(source)          // §7.4.3: use @@asyncIterator if
+//                                            // present, else wrap the sync one
+//     loop:  { done, value } = it.next()     // sync IteratorStep
+//            if (done) break
+//            x = await value                  // §27.1.4.4 AsyncFromSyncIterator
+//            <body>                           // Await(value): a Promise element
+//     exit:  <post statements>               //   double-resolves to its value
+//
+// which is a loop with ONE suspend per iteration — exactly the 3a while-with-
+// await machine. So no NEW emitter machinery is needed for the DRIVE; the gap
+// (per the #2906 3b grounding) was below the machine: (1) a `for await` carries
+// no `ts.AwaitExpression`, so the fn read as non-suspending (→ AG0 → NaN), and
+// (2) the iterator-protocol steps (`GetAsyncIterator`, `it.next()`, the done
+// flag, the element) are runtime ops on wasm locals — not checker-typed AST, and
+// synthesising that AST is the #2367 wall. `planForAwaitCfg` closes both: it is
+// gated on `plan.forAwaitPoints` (fix 1) and injects the protocol steps via the
+// `AsyncCfgStepEmit`/`AsyncCfgValueEmit` hooks (fix 2), reusing the CFG machine's
+// suspend + back-edge substrate verbatim. This is the same carrier async
+// generators (3d) consume.
+// ---------------------------------------------------------------------------
+
+/** Reserved spill-slot name for the persisted async-iterator (survives every
+ *  per-element suspend). Shared with `computeForAwaitSpills` in async-frame.ts. */
+export const FORAWAIT_ITER_SPILL = "__forawait_iter";
+
+/** The bounded `for await` shape `planForAwaitCfg`/`forAwaitSpillInfo` accept. */
+interface ForAwaitShape {
+  pre: ts.Statement[];
+  source: ts.Expression;
+  binding: { name: string; type: ts.TypeNode | undefined };
+  body: ts.Statement[];
+  post: ts.Statement[];
+  forStmt: ts.ForOfStatement;
+}
+
+/**
+ * Recognise an async body whose ONLY suspension is a single top-level
+ * `for await (const x of source) { … }`. Returns the pre-loop leads, the source
+ * expression, the (identifier) binding, the loop body, and the post-loop leads —
+ * or `null` when the body is outside the bounded slice.
+ *
+ * Bounded slice (everything else → legacy/AG0 fallback):
+ *   - NO bare `await` anywhere in the body (`awaitPoints` empty) and EXACTLY one
+ *     `for await` (multi/mixed suspension is a follow-up);
+ *   - the `for await` is a flat top-level statement of the fn body;
+ *   - a simple `const`/`let x` identifier binding (destructuring / expression
+ *     head is a follow-up — #2906 3b′);
+ *   - the loop body is linear-canonical with NO `break`/`continue`/`return`/
+ *     nested loop/`try`/labeled/`switch` (abrupt loop exit must call
+ *     `it.return()` — an async close, itself a suspend — banked as 3b′).
+ */
+function analyzeForAwait(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): ForAwaitShape | null {
+  if (plan.awaitPoints.length !== 0) return null; // mixed bare-await + for-await — follow-up
+  if (plan.forAwaitPoints.length !== 1) return null;
+  const body = fn.body;
+  if (body === undefined || !ts.isBlock(body)) return null;
+  const forStmt = plan.forAwaitPoints[0]!;
+
+  // Must be a top-level statement of the fn body (not nested in if/loop/try).
+  let forIdx = -1;
+  for (let i = 0; i < body.statements.length; i++) {
+    if (body.statements[i] === forStmt) {
+      forIdx = i;
+      break;
+    }
+  }
+  if (forIdx === -1) return null;
+
+  // Simple identifier binding: `for await (const x of …)`.
+  const init = forStmt.initializer;
+  if (!ts.isVariableDeclarationList(init) || init.declarations.length !== 1) return null;
+  const decl = init.declarations[0]!;
+  if (!ts.isIdentifier(decl.name)) return null;
+  if (decl.name.text === FORAWAIT_ITER_SPILL) return null; // reserved synthetic name collision
+  const binding = { name: decl.name.text, type: decl.type };
+
+  // Loop body: reuse the while-slice's abrupt-control rejection (also rejects a
+  // nested `for await`, since it is a `ForOfStatement`).
+  if (loopBodyHasUnsupportedControl(forStmt.statement)) return null;
+  const bodyStmts = ts.isBlock(forStmt.statement) ? [...forStmt.statement.statements] : [forStmt.statement];
+
+  return {
+    pre: [...body.statements.slice(0, forIdx)],
+    source: forStmt.expression,
+    binding,
+    body: bodyStmts,
+    post: [...body.statements.slice(forIdx + 1)],
+    forStmt,
+  };
+}
+
+/**
+ * (#2906 slice 3b) The own-locals a `for await` body must spill into the frame
+ * (they survive the per-element suspend), plus the loop binding for exclusion.
+ * Every own-local referenced anywhere in the `for await` statement is live across
+ * the loop-carried suspend (read before the await, read again after resume on the
+ * next iteration — the 3a loop-liveness rule), MINUS params and MINUS the loop
+ * binding itself (delivered fresh from `SENT_FIELD` on resume, never snapshotted).
+ * The synthetic async-iterator carrier local is appended by
+ * `computeForAwaitSpills`. Returns `null` when the body is not the bounded shape.
+ */
+export function forAwaitSpillInfo(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): { names: string[]; binding: { name: string; type: ts.TypeNode | undefined } } | null {
+  const shape = analyzeForAwait(fn, plan);
+  if (shape === null) return null;
+  const ownLocals = new Set<string>();
+  collectAllDeclaredNames(fn, ownLocals);
+  const paramNames = new Set<string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) paramNames.add(p.name.text);
+    else collectBindingPatternNames(p.name, paramNames);
+  }
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const walk = (node: ts.Node): void => {
+    if (isNestedFunctionScope(node)) return;
+    if (
+      ts.isIdentifier(node) &&
+      ownLocals.has(node.text) &&
+      !paramNames.has(node.text) &&
+      node.text !== shape.binding.name && // resume binding — delivered via SENT, not spilled
+      !seen.has(node.text)
+    ) {
+      seen.add(node.text);
+      names.push(node.text);
+    }
+    forEachChild(node, walk);
+  };
+  walk(shape.forStmt);
+  return { names, binding: shape.binding };
+}
+
+/**
+ * (#2906 slice 3b) Should a bounded `for await` take the native async-iterator
+ * DRIVE, or stay on the legacy path? This is the drive gate — `asyncFnNeedsDrive`
+ * calls it, so the routing and `planForAwaitCfg` stay consistent.
+ *
+ * Drive ONLY when the source's element type is BOXED (externref / GC-ref) — a
+ * Promise/thenable/object element whose `Await` can genuinely suspend, and whose
+ * runtime representation the native `__iterator` vec carrier consumes. Rationale:
+ *   - a source of UNBOXED primitives (`number[]`, `boolean[]`) settles
+ *     immediately (`Await(v) = v`), so the legacy sync-unwrap path is ALREADY
+ *     correct; and those arrays use a typed WasmGC representation the vec iterator
+ *     cannot `ref.cast` — driving them would trap (a regression);
+ *   - a non-array / user-iterable source (`getNumberIndexType() === undefined`)
+ *     may be a user ASYNC iterable whose `next()` the sync native iterator can't
+ *     drive — keep it on legacy for now (a 3b′ follow-up: general
+ *     `AsyncFromSyncIterator` / user-`@@asyncIterator`).
+ * So the driven set is exactly the proven case: an array whose elements are
+ * boxed (Promise arrays — the −32 for-await cluster — and object/string arrays).
+ * Returns `false` for a non-for-await / non-bounded body.
+ */
+export function forAwaitNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): boolean {
+  const shape = analyzeForAwait(fn, plan);
+  if (shape === null) return false;
+  const srcType = ctx.checker.getTypeAtLocation(shape.source);
+  const elem = srcType.getNumberIndexType();
+  if (elem === undefined) return false; // user iterable / unknown — legacy (3b′)
+  const wt = resolveWasmType(ctx, elem);
+  return wt.kind === "externref" || wt.kind === "ref" || wt.kind === "ref_null";
+}
+
+/**
+ * Build the CFG for a bounded `for await (const x of source) { body }` async
+ * body. Dense state ids in push order:
+ *   entry(0) : pre leads → emit `it = GetAsyncIterator(source)` → goto(head)
+ *   head(1)  : emit `{done,value} = it.next()` → condGoto(done, exit, body)
+ *   body(2)  : (empty) → suspend(await value, resume→resume)   ← the Await
+ *   resume(3): deliver x = SENT; body leads → goto(head)        ← the back-edge
+ *   exit(4)  : post leads → settleUndefined
+ * The iterator-protocol steps are injected via emit hooks (the element value and
+ * done flag live in wasm locals, not AST); the suspend + back-edge are the stock
+ * CFG machine. Returns `null` when the body is not the bounded shape.
+ */
+export function planForAwaitCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): AsyncCfgPlan | null {
+  const shape = analyzeForAwait(fn, plan);
+  if (shape === null) return null;
+  const { pre, source, binding, body, post } = shape;
+
+  // Wasm locals shared across the emit hooks, resolved at emit time. `iter` is
+  // the persisted spill slot (allocated by the resume-fn prologue from
+  // FORAWAIT_ITER_SPILL); `value`/`done` are transient (recomputed each
+  // iteration head, never crossing a suspend, so not spilled).
+  const L = { iter: -1, value: -1, done: -1 };
+
+  const asLead = (stmts: readonly ts.Statement[]): AsyncCfgStmt[] => stmts.map((stmt) => ({ stmt, handler: 0 }));
+
+  const entryId = 0;
+  const headId = 1;
+  const bodyId = 2;
+  const resumeId = 3;
+  const exitId = 4;
+
+  // entry emit: it = GetAsyncIterator(source), into the persisted spill slot.
+  const initIterator: AsyncCfgStepEmit = (ctx, fctx) => {
+    const iterSlot = fctx.localMap.get(FORAWAIT_ITER_SPILL);
+    L.iter = iterSlot !== undefined ? iterSlot : allocLocal(fctx, FORAWAIT_ITER_SPILL, { kind: "externref" });
+    const srcType = compileExpression(ctx, fctx, source);
+    if (srcType !== null && srcType !== undefined) {
+      coerceType(ctx, fctx, srcType as ValType, { kind: "externref" });
+    } else {
+      fctx.body.push({ op: "ref.null.extern" } as Instr);
+    }
+    const iterIdx = ensureAsyncIterator(ctx, fctx);
+    if (iterIdx === undefined) {
+      // Only reachable if the native iterator runtime is unavailable (not the
+      // standalone/wasi drive lane this planner runs on); leave iter null.
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "ref.null.extern" } as Instr);
+      fctx.body.push({ op: "local.set", index: L.iter });
+      return;
+    }
+    fctx.body.push({ op: "call", funcIdx: iterIdx });
+    fctx.body.push({ op: "local.set", index: L.iter });
+  };
+
+  // head emit: {done, value} = it.next() (multi-value: value on top, done below).
+  const stepNext: AsyncCfgStepEmit = (ctx, fctx) => {
+    if (L.value === -1) L.value = allocLocal(fctx, "__forawait_value", { kind: "externref" });
+    if (L.done === -1) L.done = allocLocal(fctx, "__forawait_done", { kind: "i32" });
+    const nextIdx = ctx.funcMap.get("__iterator_next");
+    if (nextIdx === undefined) {
+      // Native iterator runtime absent — deliver done=1 so the loop exits.
+      fctx.body.push({ op: "ref.null.extern" } as Instr);
+      fctx.body.push({ op: "local.set", index: L.value });
+      fctx.body.push({ op: "i32.const", value: 1 });
+      fctx.body.push({ op: "local.set", index: L.done });
+      return;
+    }
+    fctx.body.push({ op: "local.get", index: L.iter });
+    fctx.body.push({ op: "call", funcIdx: nextIdx });
+    fctx.body.push({ op: "local.set", index: L.value });
+    fctx.body.push({ op: "local.set", index: L.done });
+  };
+
+  const doneCond: AsyncCfgValueEmit = (_ctx, fctx) => {
+    fctx.body.push({ op: "local.get", index: L.done });
+    return { kind: "i32" };
+  };
+
+  const awaitValue: AsyncCfgValueEmit = (_ctx, fctx) => {
+    fctx.body.push({ op: "local.get", index: L.value });
+    return { kind: "externref" };
+  };
+
+  const states: AsyncCfgState[] = [
+    {
+      id: entryId,
+      resumeFrom: null,
+      lead: asLead(pre),
+      emit: initIterator,
+      terminator: { kind: "goto", target: headId },
+    },
+    {
+      id: headId,
+      resumeFrom: null,
+      lead: [],
+      emit: stepNext,
+      terminator: { kind: "condGoto", cond: { emit: doneCond }, whenTrue: exitId, whenFalse: bodyId, handler: 0 },
+    },
+    {
+      id: bodyId,
+      resumeFrom: null,
+      lead: [],
+      terminator: { kind: "suspend", awaited: { emit: awaitValue }, resumeState: resumeId, handler: 0 },
+    },
+    {
+      id: resumeId,
+      resumeFrom: { binding, handler: 0 },
+      lead: asLead(body),
+      terminator: { kind: "goto", target: headId },
+    },
+    {
+      id: exitId,
+      resumeFrom: null,
+      lead: asLead(post),
+      terminator: { kind: "settleUndefined" },
+    },
+  ];
+  return { states, handlers: [] };
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers (private to async-cps.ts)
 // ---------------------------------------------------------------------------
 
@@ -1445,6 +1801,19 @@ function collectAwaitPoints(node: ts.Node, out: ts.AwaitExpression[]): void {
     // Continue into the operand — `await (await x)` has two await points.
   }
   forEachChild(node, (child) => collectAwaitPoints(child, out));
+}
+
+/**
+ * Collect `for await (… of …)` loops (`ForOfStatement` with an `awaitModifier`)
+ * in pre-order, not descending into nested fn scopes — a nested async fn's
+ * for-await belongs to its own machine. (#2906 slice 3b)
+ */
+function collectForAwaitPoints(node: ts.Node, out: ts.ForOfStatement[]): void {
+  if (isNestedFunctionScope(node)) return;
+  if (ts.isForOfStatement(node) && node.awaitModifier !== undefined) {
+    out.push(node);
+  }
+  forEachChild(node, (child) => collectForAwaitPoints(child, out));
 }
 
 /**

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1614,15 +1614,32 @@ export function forAwaitSpillInfo(
  * So the driven set is exactly the proven case: an array whose elements are
  * boxed (Promise arrays — the −32 for-await cluster — and object/string arrays).
  * Returns `false` for a non-for-await / non-bounded body.
+ *
+ * Element-type query goes through `ctx.oracle.elementFactOf` (the #1930 type
+ * boundary — NOT the raw checker, per the oracle-ratchet gate).
  */
 export function forAwaitNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): boolean {
   const shape = analyzeForAwait(fn, plan);
   if (shape === null) return false;
-  const srcType = ctx.checker.getTypeAtLocation(shape.source);
-  const elem = srcType.getNumberIndexType();
-  if (elem === undefined) return false; // user iterable / unknown — legacy (3b′)
-  const wt = resolveWasmType(ctx, elem);
-  return wt.kind === "externref" || wt.kind === "ref" || wt.kind === "ref_null";
+  const elem = ctx.oracle.elementFactOf(shape.source);
+  switch (elem.kind) {
+    // Unboxed scalars settle immediately (`Await(v) = v`, legacy already
+    // correct) and their typed WasmGC arrays would trap the vec iterator.
+    case "number":
+    case "boolean":
+    case "bigint":
+    case "undefined":
+    case "null":
+    case "void":
+    // No element fact: a non-array / user-iterable source — keep on legacy (3b′).
+    case "unresolvable":
+      return false;
+    // Boxed element (Promise/object/class/builtin/string/array/tuple/function/
+    // any/unknown/union): the vec `__iterator` consumes it and `Await` can
+    // genuinely suspend.
+    default:
+      return true;
+  }
 }
 
 /**

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -39,8 +39,12 @@ import { forEachChild, ts } from "../ts-api.js";
 import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint } from "./async-cps.js";
 import {
   ASYNC_CPS_ENABLED,
+  FORAWAIT_ITER_SPILL,
   asyncFnNeedsCps,
   awaitedExprIsPromiseCombinator,
+  forAwaitNeedsDrive,
+  forAwaitSpillInfo,
+  isEmitOperand,
   loopAsyncSpillInfo,
   planAsyncCfg,
   planLinearAwaits,
@@ -423,7 +427,16 @@ function bindingLiveAcrossLaterAwait(name: string, k: number, plan: AsyncCpsPlan
  */
 export function asyncFnNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
-  if (plan.awaitPoints.length === 0) return false;
+  if (plan.awaitPoints.length === 0) {
+    // (#2906 slice 3b) `for await`-only body: no `ts.AwaitExpression`, but a
+    // `for await` genuinely suspends per element. Eligible when it is the
+    // bounded for-await shape and every widened spill local is spill-safe.
+    if (plan.forAwaitPoints.length === 0) return false;
+    if (!forAwaitNeedsDrive(ctx, fn, plan)) return false; // boxed-element sources only
+    const fa = computeForAwaitSpills(ctx, fn, plan);
+    if (fa === null) return false;
+    return fa.spillTypes.every(isSpillSafeType);
+  }
   const anyRealSuspension = plan.awaitPoints.some((a) => plan.awaitedStaticallyResolved.get(a) !== true);
   if (!anyRealSuspension) return false; // fully await-elidable → sync + resolved promise
   const linear = planLinearAwaits(fn, plan);
@@ -489,6 +502,36 @@ function computeLoopSpills(
 }
 
 /**
+ * (#2906 slice 3b) The spill layout for a `for await` drive: every loop own-local
+ * ({@link forAwaitSpillInfo}, resolved to its declared ValType, defaulting to
+ * externref) PLUS the synthetic async-iterator carrier local (externref), which
+ * is created once in the entry state and must survive every per-element suspend.
+ * Returns `null` when the body is not the bounded for-await shape.
+ */
+function computeForAwaitSpills(
+  ctx: CodegenContext,
+  decl: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): { spillNames: string[]; spillTypes: ValType[] } | null {
+  const info = forAwaitSpillInfo(decl, plan);
+  if (info === null) return null;
+  const declByName = collectVarDeclsByName(decl);
+  const spillNames: string[] = [];
+  const spillTypes: ValType[] = [];
+  for (const name of info.names) {
+    const declNode = declByName.get(name);
+    const resolved = declNode ? resolveSpillLocalValType(ctx, declNode) : null;
+    spillNames.push(name);
+    spillTypes.push(resolved ?? { kind: "externref" });
+  }
+  // The persisted async-iterator (`it`), reloaded on every resume, stored on
+  // every suspend. Must be LAST — the emitter looks it up by this reserved name.
+  spillNames.push(FORAWAIT_ITER_SPILL);
+  spillTypes.push({ kind: "externref" });
+  return { spillNames, spillTypes };
+}
+
+/**
  * The body locals that are live across ANY await and so must be spilled into the
  * frame (the multi-await generalization of the generator's `bodySpills`).
  *
@@ -514,8 +557,11 @@ function computeAsyncSpills(
   const linear = planLinearAwaits(decl, plan);
   if (linear === null) {
     // (#2906 slice 3a) `while`-with-await loop: widened spill set (all loop
-    // own-locals). Returns empty for any non-loop non-linear body.
-    return computeLoopSpills(ctx, decl, plan) ?? { spillNames: [], spillTypes: [] };
+    // own-locals). (#2906 slice 3b) for-await drive: loop own-locals + the
+    // synthetic async-iterator carrier local. Returns empty for any other body.
+    return (
+      computeLoopSpills(ctx, decl, plan) ?? computeForAwaitSpills(ctx, decl, plan) ?? { spillNames: [], spillTypes: [] }
+    );
   }
   const paramSet = new Set(paramNames);
 
@@ -956,6 +1002,12 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
         compileStatement(ctx, resumeFctx, stmt);
       }
 
+      // (#2906 slice 3b) State-level injected step — the for-await planner uses
+      // it for `it = GetAsyncIterator(source)` (entry) and `{done,value} =
+      // it.next()` (loop head). Emitted after the lead, before the terminator;
+      // leaves the stack balanced. `undefined` (no hook) for every other plan.
+      if (st.emit) st.emit(ctx, resumeFctx);
+
       const term = st.terminator;
       switch (term.kind) {
         case "suspend": {
@@ -963,7 +1015,12 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
             curHandler = term.handler;
             out.push(...setHandler(curHandler));
           }
-          const awaitedType = compileExpression(ctx, resumeFctx, term.awaited);
+          // (#2906 slice 3b) The awaited operand is a `ts.Expression`
+          // (linear/while) or an injected emit hook (for-await, whose element
+          // value lives in a wasm local, not AST).
+          const awaitedType = isEmitOperand(term.awaited)
+            ? term.awaited.emit(ctx, resumeFctx)
+            : compileExpression(ctx, resumeFctx, term.awaited);
           if (awaitedType !== null && awaitedType !== undefined) {
             coerceType(ctx, resumeFctx, awaitedType as ValType, {
               kind: "externref",
@@ -1160,7 +1217,11 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
             curHandler = term.handler;
             out.push(...setHandler(curHandler));
           }
-          const condType = compileExpression(ctx, resumeFctx, term.cond);
+          // (#2906 slice 3b) condition is a `ts.Expression` (while/if) or an
+          // emit hook pushing the i32 `done` flag (for-await loop head).
+          const condType = isEmitOperand(term.cond)
+            ? term.cond.emit(ctx, resumeFctx)
+            : compileExpression(ctx, resumeFctx, term.cond);
           ensureI32Condition(resumeFctx, condType, ctx);
           out.push({
             op: "if",

--- a/tests/issue-2906-3b-forawait.test.ts
+++ b/tests/issue-2906-3b-forawait.test.ts
@@ -1,0 +1,151 @@
+// #2906 slice 3b — `for await (… of …)` on the host-free async drive machine
+// (the native async-iterator carrier).
+//
+// A `for await` carries NO `ts.AwaitExpression` — the per-element suspension is
+// implicit in the `awaitModifier` — so before this slice the whole
+// `awaitPoints`-keyed suspension machinery treated a for-await-only body as
+// non-suspending (AG0 unwrap → the loop var held the un-awaited Promise → NaN
+// for `for await (x of [P.resolve(1), …])`). Slice 3b closes the two coupled
+// blockers that sat BELOW the drive machine:
+//   (1) implicit-await coupling — `analyzeAsyncBody` now reports `forAwaitPoints`
+//       and `asyncFnNeedsDrive` recognises a bounded for-await as suspending;
+//   (2) the async-iterator carrier — `planForAwaitCfg` lowers the loop onto the
+//       CFG machine as `it = GetAsyncIterator(source); loop { {done,value} =
+//       it.next(); if done break; x = await value; body }` (§7.4.3 +
+//       §27.1.4.4 AsyncFromSyncIterator: Await(value) — a Promise element
+//       double-resolves to its value). The iterator-protocol steps are injected
+//       via emit hooks because they are runtime ops on wasm locals, not
+//       checker-typed AST (synthesising that AST is the #2367 wall).
+//
+// Native (wasi) drive lane only — host-free (no imports). Gated on BOXED-element
+// sources (Promise/object arrays); unboxed-primitive arrays (`number[]`) stay on
+// the already-correct legacy sync path (Await(v)=v).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile a host-free async program and instantiate it (imports must be empty). */
+async function instantiateWasi(src: string): Promise<Record<string, () => number>> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // The drive layer is host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#2906 slice 3b — for-await-of async-iterator carrier", () => {
+  it("THE proof: for await over an array of settled Promises sums the resolved values host-free", async () => {
+    const ex = await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let sum: number = 0;
+        for await (const x of [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)]) { sum = sum + x; }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `);
+    expect(ex.kick()).toBe(6); // 1 + 2 + 3 — was NaN before 3b
+  });
+
+  it("GENUINELY-PENDING elements suspend each iteration; the drain resumes and the accumulator survives", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let sum: number = 0;
+        for await (const x of [
+          Promise.resolve(1).then((v: number) => v + 10),
+          Promise.resolve(2).then((v: number) => v + 10),
+        ]) { sum = sum + x; }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as Record<string, () => number> & { __drain_microtasks: () => void };
+    expect(ex.kick()).toBe(0); // suspended on the first pending element
+    ex.__drain_microtasks(); // resumes each iteration across the back-edge
+    expect(ex.getCap()).toBe(23); // 11 + 12 — sum survived every suspension (frame spill)
+  });
+
+  it("pre-loop and post-loop statements run in order around the driven loop", async () => {
+    const ex = await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let sum: number = 100;
+        for await (const x of [Promise.resolve(1), Promise.resolve(2)]) { sum = sum + x; }
+        sum = sum + 1000;
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `);
+    expect(ex.kick()).toBe(1103); // 100 + 1 + 2 + 1000
+  });
+
+  it("a zero-element source runs the exit directly, never suspends", async () => {
+    const ex = await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let sum: number = 7;
+        const arr: Promise<number>[] = [];
+        for await (const x of arr) { sum = sum + x; }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `);
+    expect(ex.kick()).toBe(7); // done true first → straight to exit
+  });
+
+  it("a bare body (no accumulator dependence) counts every element across suspensions", async () => {
+    const ex = await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let n: number = 0;
+        for await (const x of [
+          Promise.resolve(1), Promise.resolve(2), Promise.resolve(3), Promise.resolve(4),
+        ]) { n = n + 1; }
+        cap = n;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `);
+    expect(ex.kick()).toBe(4);
+  });
+
+  it("a rejected element rejects the async result and skips the post-loop assignment (no trap)", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = -1;
+      async function loop(): Promise<void> {
+        let sum: number = 0;
+        for await (const x of [Promise.resolve(1), Promise.reject(new Error("boom")) as any, Promise.resolve(3)]) {
+          sum = sum + x;
+        }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return 0; }
+      export function getCap(): number { return cap; }
+    `)) as Record<string, () => number> & { __drain_microtasks: () => void };
+    ex.kick();
+    ex.__drain_microtasks();
+    expect(ex.getCap()).toBe(-1); // loop rejected on element 2 → `cap = sum` never runs
+  });
+
+  it("a for-await over an array of PLAIN numbers stays on the legacy path and still works", async () => {
+    // Unboxed-primitive elements settle immediately (Await(v)=v), so the drive
+    // gate keeps them on the legacy sync path — must remain correct (byte-inert
+    // vs main), not regress to a vec-cast trap.
+    const ex = await instantiateWasi(`
+      let cap: number = 0;
+      async function loop(): Promise<void> {
+        let sum: number = 0;
+        for await (const x of [10, 20, 30]) { sum = sum + x; }
+        cap = sum;
+      }
+      export function kick(): number { loop() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `);
+    expect(ex.kick()).toBe(60);
+  });
+});


### PR DESCRIPTION
## #2906 slice 3b — for-await-of async-iterator carrier

`for await (const x of source)` over a boxed-element array now drives **host-free** on the 3a CFG machine:

```ts
for await (const x of [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)]) sum += x;
// → 6, imports []   (was NaN on main)
```

Closes the two blockers the 3b grounding (PR #2653) identified BELOW the drive machine:

1. **implicit-await coupling** — a `for await` carries no `ts.AwaitExpression`, so `analyzeAsyncBody` reported 0 await points and the fn read as non-suspending (→ AG0 unwrap → the loop var held the un-awaited Promise → NaN). `AsyncCpsPlan` now also carries **`forAwaitPoints`**, and `asyncFnNeedsDrive` recognises a bounded for-await-only body as suspending.
2. **the async-iterator carrier** — `planForAwaitCfg` lowers the loop to the spec-equivalent `it = GetAsyncIterator(src); loop { {done,value} = it.next(); if (done) break; x = await value; body }` (§7.4.3 + §27.1.4.4 AsyncFromSyncIterator). The iterator-protocol steps are runtime wasm-local ops — **not checker-typed AST** — so they are injected via new **emit hooks** (`AsyncCfgStepEmit` / `AsyncCfgValueEmit`) threaded through the stock `condGoto`/`suspend`/back-edge substrate, sidestepping the #2367 synthetic-AST wall. **This is the reusable carrier async generators (3d) consume.**

### Scope / gate
- **Drive gate**: boxed-element sources only (`getNumberIndexType()` → externref/ref — Promise/object arrays). `number[]` settles immediately (`Await(v)=v`) so it stays on the already-correct **legacy** path and is **byte-identical to main** (a typed array would also trap the vec `__iterator` — driving it would regress).
- **Bounded slice**: one top-level `for await`, identifier binding, no bare `await`/`break`/`continue`/`return`/`try` in the body. User async iterables / destructuring binding / `it.return()` close are banked as 3b′.

### Byte-inertness (−16/−29 discipline)
sha256 of 6 programs × {gc, standalone, wasi}, origin/main vs this branch:
- **gc + standalone: identical for ALL** programs (drive gated on `isStandalonePromiseActive`, wasi-only).
- **wasi: identical for every program except a for-await** (plainAsync / multiAwait / whileAwait / syncForOf / plain all unchanged) — the intended unlock.

### Tests
`tests/issue-2906-3b-forawait.test.ts` — 7 host-free wasi tests: the settled-Promise proof (→6), the **genuinely-pending drain proof** (suspends at 0 → resumes to 23, proving the drive actually suspends/resumes), pre/post statements, zero-element source, bare-body count, a rejected element rejecting the result promise without trapping, and `number[]` legacy-path parity. Full async suite (2895 / 2906-3a / multiawait / gap3) shows the SAME pass/fail set as origin/main (the 3 gap3-tryfinally throw-path failures are pre-existing — a `{}`-instantiation harness gap, verified on a `main` worktree).

Umbrella #2906 stays `in-progress` for 3b′ / 3c / **3d (async generators — now unblocked)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8