### PR TITLE
fix(#3024): eval-var-promotion numeric/compound-assign operand desync (invalid Wasm)

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -143,3 +143,64 @@ localized `compileBinaryExpression` fix low-risk for a fresh window.
 ### Not started (roll forward)
 - The `__vec_from_extern_*` `array.set` bucket and async-gen `__closure_*` buckets
   (issue's approach steps 2–3) are un-investigated here.
+
+---
+
+## Landed: eval-var-promotion numeric-operand desync (dev-selfserve-1, 2026-07-04)
+
+**PR:** `issue-3024-numeric-slot-desync` — fixes the `testCompoundAssignment` /
+numeric-operator eval sub-cluster (the `x op eval("var x = …")` shape).
+
+### The banked "trust slot type at the numeric path" fix is UNSAFE — disproven
+The sr-interp banked plan (mirror the `in`-operator precedent: at the numeric
+emit, if an identifier operand's slot is externref, coerce) **cannot work as
+written**. Instrumentation on current `main` shows both the failing case
+(`x * eval("var x = 2;")`) and the passing control (`x * eval("var y = 2;")`)
+report `leftType = f64` at the numeric path, and in BOTH the slot is externref
+by the time the op emits. So slot-kind + reported-type at the emit point does
+**not** discriminate a stale-boxed operand from a genuinely-unboxed f64 — a naive
+"slot is externref ⇒ coerce" would double-unbox the already-correct unbox that
+`compileIdentifier` emits for a `number`-narrowed externref local.
+
+### True root cause (verified by WAT diff + `compileIdentifierCore` instrument)
+It is a **timing / mid-expression slot-promotion** bug, not a numeric-path bug:
+1. `x` starts as an `f64` local. In `x * eval("var x = 2;")`, the LEFT operand
+   `x` compiles first → emits a raw `local.get` of the f64 slot, no unbox.
+2. The RIGHT operand `eval("var x = 2;")` is a constant string, so
+   `tryStaticEvalInline` inlines the body. Compiling the inlined `var x = 2`
+   (a foreign `ts.createSourceFile` node the checker cannot type ⇒ `wasmType`
+   resolves to `externref`) hits the re-declaration re-type at
+   `statements/variables.ts` (~L1071–1072) and **flips `x`'s slot f64 → externref**.
+3. The already-emitted `local.get` now loads an externref, feeding `f64.mul`/
+   `f64.sub`/… → `expected fN, found externref`. Compound `x *= …` is worse: the
+   pre-RHS `local.get` (no coerce) AND the post-op `local.tee` (f64 into an
+   externref slot) are both invalidated.
+
+### The safe fix (byte-inert, proven)
+Detect the **primitive→externref slot flip across operand compilation** by
+snapshotting the identifier operand's slot kind before compiling and comparing
+after — a flip only ever happens on this eval-redeclaration path, so ordinary
+code is untouched.
+- `src/codegen/binary-ops.ts` (`compileBinaryExpression`): snapshot
+  `leftSlotBefore`/`rightSlotBefore`; if an operand flipped primitive→externref,
+  re-label its type `externref` so the existing numeric externref-unbox path
+  (~L2255) inserts the coercion.
+- `src/codegen/expressions/assignment.ts` (`compileCompoundAssignment`, local
+  path): re-read the slot after the RHS; on a flip, unbox the buried left
+  operand (save RHS / coerce left / restore RHS) and switch the writeback to the
+  externref re-box path.
+
+**Proofs:** repro + discriminators pass (`x*`, `x*=`, `x-`, `x/` eval-redeclare
+→ VALID; `var y` / `eval("2")` / plain arithmetic controls unchanged); runtime
+output matches Node (NaN/NaN, 21/21); inject-throw shows each guard fires ONLY on
+its promotion case and on NO control; a 10-program corpus (arithmetic, compound,
+loops, strings, objects, any, bitwise, for-of) is **byte-identical** (sha256) to
+`origin/main`; `issue-2923`, `compound-assignment-property/-unresolvable`,
+`issue-2045` suites (38 tests) pass.
+
+### Still open (roll forward — NOT this PR)
+- `{} << 0` / non-object numeric operands (`private-field-rhs-non-object.js`) —
+  a DISTINCT root cause (object left operand of a shift, no eval involved).
+- `__vec_from_extern_*` `array.set`, async-gen `__closure_*`, `struct.new` arg
+  count. The 131 bucket has multiple independent root causes; this PR clears the
+  eval-redeclaration numeric/compound sub-cluster only.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1844,6 +1844,33 @@ export function compileBinaryExpression(
   // not bitwise, so it would re-derive f64). Without this the whole pure chain
   // collapses back to the f64 round-trip the predicate was meant to eliminate.
   const useI32PureEmit = arithI32WithToInt32Wrap || bitwiseI32;
+  // (#3024) An identifier operand's local slot type can be PROMOTED to externref
+  // *mid-expression* — e.g. `x * eval("var x = 2;")`, where the direct-eval body
+  // redeclares `x`, forcing its slot from f64 to the dynamic externref
+  // representation (the re-declaration re-type in statements/variables.ts, whose
+  // `wasmType` resolves to externref because the inlined eval body is a foreign
+  // `ts.createSourceFile` node the checker cannot type). That promotion happens
+  // when the OTHER operand (the eval call) compiles — AFTER this identifier was
+  // already emitted as a raw `local.get` of the then-f64 slot with no unbox. The
+  // stale read now loads an externref, so a following `f64.mul`/`f64.sub`/… fails
+  // Wasm validation ("expected fN, found externref"). Snapshot each identifier
+  // operand's slot kind BEFORE compiling so a genuine mid-expression
+  // primitive→externref flip can be recognised below. (A slot that was ALREADY
+  // externref and that `compileIdentifier` unboxed to f64 keeps the same slot
+  // before/after, so it is left untouched — no double-unbox.)
+  const identSlotKind = (e: ts.Expression): ValType["kind"] | undefined => {
+    if (!ts.isIdentifier(e)) return undefined;
+    const idx = fctx.localMap.get(e.text);
+    if (idx === undefined) return undefined;
+    const entry = idx < fctx.params.length ? fctx.params[idx] : fctx.locals[idx - fctx.params.length];
+    const t =
+      entry && typeof entry === "object" && "type" in entry
+        ? (entry as { type: ValType }).type
+        : (entry as ValType | undefined);
+    return t?.kind;
+  };
+  const leftSlotBefore = identSlotKind(expr.left);
+  const rightSlotBefore = identSlotKind(expr.right);
   let leftType: ValType | null;
   let rightType: ValType | null;
   if (useI32PureEmit) {
@@ -1854,6 +1881,29 @@ export function compileBinaryExpression(
   } else {
     leftType = compileExpression(ctx, fctx, expr.left, numericHint);
     rightType = compileExpression(ctx, fctx, expr.right, numericHint);
+    // (#3024) If an identifier operand's slot flipped from a concrete primitive
+    // to externref while (or after) it was compiled, its emitted value is a raw
+    // externref `local.get` with no unbox, yet the reported operand type stayed
+    // primitive. Re-label it externref so the numeric externref-unbox path
+    // (~line 2255 below) inserts the `externref → f64` coercion. Guarded on an
+    // actual primitive→externref flip, so ordinary operands are byte-inert.
+    const isPrimKind = (k: ValType["kind"] | undefined): boolean => k === "f64" || k === "i32" || k === "i64";
+    if (
+      leftType &&
+      isPrimKind(leftType.kind) &&
+      isPrimKind(leftSlotBefore) &&
+      identSlotKind(expr.left) === "externref"
+    ) {
+      leftType = { kind: "externref" };
+    }
+    if (
+      rightType &&
+      isPrimKind(rightType.kind) &&
+      isPrimKind(rightSlotBefore) &&
+      identSlotKind(expr.right) === "externref"
+    ) {
+      rightType = { kind: "externref" };
+    }
   }
 
   if (!leftType || !rightType) return null;

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -6165,8 +6165,8 @@ export function compileCompoundAssignment(
     return boxed.valType;
   }
 
-  const localType = getLocalType(fctx, localIdx) ?? { kind: "f64" as const };
-  const needsLocalCoerce = localType.kind !== "f64";
+  let localType = getLocalType(fctx, localIdx) ?? { kind: "f64" as const };
+  let needsLocalCoerce = localType.kind !== "f64";
 
   fctx.body.push({ op: "local.get", index: localIdx });
   if (needsLocalCoerce) coerceType(ctx, fctx, localType, { kind: "f64" });
@@ -6179,6 +6179,28 @@ export function compileCompoundAssignment(
     return null;
   }
   if (compoundRhsType3.kind !== "f64") coerceType(ctx, fctx, compoundRhsType3, { kind: "f64" });
+
+  // (#3024) Compiling the RHS can PROMOTE this local's slot from a concrete
+  // primitive to externref mid-expression — e.g. `x *= eval("var x = 2;")`,
+  // where the direct-eval body redeclares `x` (the re-declaration re-type in
+  // statements/variables.ts). The left value was already emitted above as a raw
+  // `local.get` of the then-f64 slot with no coercion, so it is now a stale
+  // externref buried under the (f64) RHS on the stack — and the writeback below
+  // would `local.tee` an f64 into what is now an externref slot. Both are invalid
+  // Wasm. Detect the flip (slot was primitive when read, is externref now) and
+  // repair: unbox the buried left operand to f64 (save RHS, coerce left, restore
+  // RHS), then switch the writeback to re-box via the externref path. Guarded on
+  // an actual primitive→externref flip, so ordinary compound assignments are
+  // byte-inert.
+  const localTypeAfter = getLocalType(fctx, localIdx);
+  if (!needsLocalCoerce && localType.kind === "f64" && localTypeAfter?.kind === "externref") {
+    const tmpRhs = allocLocal(fctx, `__cmp3024_${fctx.locals.length}`, { kind: "f64" });
+    fctx.body.push({ op: "local.set", index: tmpRhs });
+    coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" }, "number");
+    fctx.body.push({ op: "local.get", index: tmpRhs });
+    localType = { kind: "externref" };
+    needsLocalCoerce = true;
+  }
 
   emitCompoundOp(ctx, fctx, op);
 


### PR DESCRIPTION
## What & why (#3024 — eval sub-cluster of the default-lane invalid-Wasm bucket)

`x op eval("var x = …")` and `x op= eval("var x = …")` compiled to **invalid
Wasm** (`f64.mul[0] expected type f64, found externref`). Root cause is a
**mid-expression slot promotion**, not a numeric-path bug:

1. `x` starts as an `f64` local; the LEFT operand `x` compiles first → a raw
   `local.get` of the f64 slot, no unbox.
2. The constant-string `eval("var x = 2;")` is inlined by `tryStaticEvalInline`;
   compiling the inlined `var x = 2` (a foreign `ts.createSourceFile` node the
   checker can't type ⇒ `externref`) hits the re-declaration re-type in
   `statements/variables.ts` and **flips `x`'s slot f64 → externref**.
3. The already-emitted `local.get` now loads an externref feeding `f64.mul` →
   invalid. Compound `x *= …` breaks twice (stale read + f64-into-externref
   writeback).

The banked "trust the slot type at the numeric emit" plan is **unsafe** — both
the failing and the passing control report `leftType = f64` with an externref
slot at emit time, so it can't discriminate a stale-boxed operand from an
already-unboxed f64 (would double-unbox). Instead this detects the genuine
**primitive→externref flip across operand compilation** and routes the operand
through the existing externref-unbox path.

## Changes
- `src/codegen/binary-ops.ts` — snapshot each identifier operand's slot kind
  before compiling; on a primitive→externref flip, re-label it `externref` so
  the numeric externref-unbox path coerces it.
- `src/codegen/expressions/assignment.ts` — compound-assign local path: re-read
  the slot after the RHS; on a flip, unbox the buried left operand and switch the
  writeback to the externref re-box path.

## Proofs
- Repro + discriminators: `x*`, `x*=`, `x-`, `x/` eval-redeclare → VALID; `var y`
  / `eval("2")` / plain arithmetic controls unchanged.
- Runtime matches Node (NaN/NaN, 21/21).
- Inject-throw: each guard fires ONLY on its promotion case, on NO control.
- 10-program corpus (arithmetic, compound, loops, strings, objects, any,
  bitwise, for-of) is **byte-identical (sha256)** to `origin/main`.
- `issue-2923-eval-const-broaden`, `compound-assignment-property/-unresolvable`,
  `issue-2045` suites (38 tests) pass; `tsc --noEmit` clean.

## Scope
Clears the **eval-redeclaration numeric/compound sub-cluster** only. The 131 bucket
has other independent root causes (`{} << 0` non-object operands, `__vec_from_extern`
`array.set`, `struct.new` arg count) that remain open — issue stays `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8