### PR TITLE
fix(#3026): private-name grammar early errors (heritage + destructuring key)

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -4,8 +4,8 @@ title: "negative_test_fail: residual early-error / static-semantics gaps (~79 de
 status: ready
 sprint: current
 created: 2026-07-03
-updated: 2026-07-03
-status_note: "First slice landed (PR): trailing-comma-after-rest early error in destructuring patterns (all four forms). Issue stays open — remaining unenforced-SyntaxError samples decompose into further independent point-fixes per the issue's own triage note."
+updated: 2026-07-04
+status_note: "Slices 1–3 landed. Slice 3 (PR): private-name grammar early errors — (a) private name referenced in a class heritage clause, (b) private name as a destructuring-pattern key (10 test262 files). Issue stays open — remaining unenforced-SyntaxError samples (module-code, import.meta, top-level-await) decompose into further independent point-fixes per the issue's own triage note."
 priority: medium
 horizon: s
 feasibility: medium
@@ -34,13 +34,13 @@ coverage grows (expected pattern for this project — not a regression).
 
 ## Breakdown
 
-| pattern | count |
-|---|--:|
-| expected `SyntaxError`, compiled with no diagnostic (early error not detected) | 64 |
-| expected runtime `ReferenceError` but succeeded | 9 |
-| expected runtime `SyntaxError` but succeeded | 3 |
-| expected resolution `SyntaxError`, no diagnostic | 2 |
-| expected runtime `TypeError` but succeeded | 1 |
+| pattern                                                                        | count |
+| ------------------------------------------------------------------------------ | ----: |
+| expected `SyntaxError`, compiled with no diagnostic (early error not detected) |    64 |
+| expected runtime `ReferenceError` but succeeded                                |     9 |
+| expected runtime `SyntaxError` but succeeded                                   |     3 |
+| expected resolution `SyntaxError`, no diagnostic                               |     2 |
+| expected runtime `TypeError` but succeeded                                     |     1 |
 
 ## Sample failing files
 
@@ -81,7 +81,7 @@ a rest element in every destructuring-pattern position — an
 - `const {...x,} = y` (object binding pattern).
 
 **Root cause:** the pre-existing "rest must be last" check only fired when an
-*element* followed the rest (`[...x, y]`); TypeScript's parser accepts the bare
+_element_ followed the rest (`[...x, y]`); TypeScript's parser accepts the bare
 trailing comma `[...x,]` silently and does NOT insert a trailing
 `OmittedExpression`, so nothing detected it. Fix keys off the NodeArray's
 `hasTrailingComma` flag when the last element is the rest.
@@ -90,7 +90,7 @@ trailing comma `[...x,]` silently and does NOT insert a trailing
 patterns), `src/compiler/early-errors/node-checks.ts` (array + object binding
 patterns). Tests: `tests/issue-3026.test.ts` (5 reject + 5 valid-control
 cases). Byte-inert for all valid programs — spread-with-trailing-comma in an
-array/object literal *value* (`const v = [...x,]`, `{...x,}`) and a trailing
+array/object literal _value_ (`const v = [...x,]`, `{...x,}`) and a trailing
 comma after a non-rest element (`[a,]`, `{a,}`) all remain valid.
 
 **Remaining:** the other unenforced-`SyntaxError` samples (private-name grammar,
@@ -125,3 +125,42 @@ to the existing shorthand-property checks). Tests: `tests/issue-3026.test.ts`
 **Remaining:** further unenforced-`SyntaxError` samples (private-name grammar on
 class heritage, `array-rest-elision-invalid` residuals, etc.) remain independent
 point-fixes — issue stays open for follow-up slices.
+
+## Slice 3 landed — private-name (`#x`) grammar early errors (2026-07-04)
+
+**Delivered:** two precise parse-time early errors for private-name grammar
+rules, clearing all **10** `elements/syntax/early-errors` unenforced-`SyntaxError`
+samples (verified: 10/10 now pass, 0/113 related passing files regressed):
+
+- **(a) Private name in a class heritage clause.** `class C extends class { x =
+this.#foo; } { #foo; }` — per §15.7.14 ClassDefinitionEvaluation the
+  `ClassHeritage` is evaluated with the OUTER PrivateEnvironment, so `C`'s own
+  `#foo` is not yet in scope in `C`'s `extends` clause → SyntaxError. Covers
+  `grammar-private-environment-on-class-heritage{,-function-expression,-recursive,-chained-usage}`
+  (both class-expression and class-statement forms).
+- **(b) Private name as a destructuring-pattern key.** `const { #x: v } = this`
+  / `({ #x: v } = this)` — `ObjectBindingPattern` / `ObjectAssignmentPattern`
+  property names are `PropertyName`, which excludes `PrivateIdentifier` →
+  SyntaxError even when `#x` is declared in the enclosing class. Covers
+  `grammar-private-field-on-object-destructuring`.
+
+**Root cause:** (a) `isInsideClassWithPrivateName` walked ALL enclosing classes
+and counted a class's own private members even when the reference lived in that
+class's heritage clause — it now skips a class's members when the reference is
+within that class's `heritageClauses`. (b) the existing PrivateIdentifier check
+only enforced "must be declared in an enclosing class"; a private name used as a
+`BindingElement.propertyName` or an object-pattern property key was silently
+accepted by TS's parser (no diagnostic under `skipSemanticDiagnostics`) — a new
+additive branch flags it before the enclosing-class rule.
+
+**Files:** `src/compiler/early-errors/predicates.ts` (heritage-scoped
+`isInsideClassWithPrivateName` + `isNodeWithin` helper),
+`src/compiler/early-errors/node-checks.ts` (destructuring-pattern private-key
+branch). Tests: `tests/issue-3026.test.ts` (+4 reject, +3 valid-control cases).
+Byte-inert for all valid programs — private field reads (`this.#x`), `#x in o`,
+normal object/array destructuring, and sibling classes with independent private
+fields all remain valid.
+
+**Remaining:** the module-code / `import.meta` / top-level-await
+unenforced-`SyntaxError` samples are independent point-fixes (several need module
+linking/resolution) — issue stays open for follow-up slices.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -347,7 +347,23 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
 
   // Check private name (#x) used outside its declaring class
   if (ts.isPrivateIdentifier(node)) {
-    if (!isInsideClassWithPrivateName(node, node.escapedText as string)) {
+    // A PrivateIdentifier is only valid as a MemberExpression private reference
+    // (`this.#x`, `#x in obj`) or a class-member name. It cannot appear as a
+    // property key in a destructuring pattern — `const { #x: v } = o` /
+    // `({ #x: v } = o)` — because `ObjectBindingPattern` / `ObjectAssignmentPattern`
+    // property names are `PropertyName`, which does not include PrivateIdentifier.
+    // This is an early SyntaxError regardless of whether `#x` is declared in an
+    // enclosing class (so it must be checked before the enclosing-class rule).
+    if (ts.isBindingElement(node.parent) && node.parent.propertyName === node) {
+      ctx.addError(node, `Private field '${node.text}' is not allowed in a destructuring pattern`);
+    } else if (
+      (ts.isPropertyAssignment(node.parent) || ts.isShorthandPropertyAssignment(node.parent)) &&
+      node.parent.name === node &&
+      ts.isObjectLiteralExpression(node.parent.parent) &&
+      isAssignmentPatternContext(node.parent.parent)
+    ) {
+      ctx.addError(node, `Private field '${node.text}' is not allowed in a destructuring pattern`);
+    } else if (!isInsideClassWithPrivateName(node, node.escapedText as string)) {
       ctx.addError(node, `Private field '${node.text}' must be declared in an enclosing class`);
     }
   }

--- a/src/compiler/early-errors/predicates.ts
+++ b/src/compiler/early-errors/predicates.ts
@@ -725,11 +725,21 @@ export function isInsideClassWithPrivateName(node: ts.Node, privateName: string)
   let current: ts.Node | undefined = node.parent;
   while (current) {
     if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) {
-      // Check if this class declares the private name
-      for (const member of current.members) {
-        if (member.name && ts.isPrivateIdentifier(member.name)) {
-          if ((member.name.escapedText as string) === privateName) {
-            return true;
+      // §15.7.14 ClassDefinitionEvaluation: the ClassHeritage (the `extends`
+      // clause) is evaluated with the OUTER PrivateEnvironment — the class's own
+      // private names are NOT yet in scope there. So a private reference that
+      // lives inside this class's heritage clause must NOT resolve against this
+      // class's private members (it is an early SyntaxError unless an *enclosing*
+      // class declares the name). Only count this class's members when the
+      // reference is reached via its BODY, not its heritage.
+      const inHeritage = current.heritageClauses?.some((hc) => isNodeWithin(node, hc)) ?? false;
+      if (!inHeritage) {
+        // Check if this class declares the private name
+        for (const member of current.members) {
+          if (member.name && ts.isPrivateIdentifier(member.name)) {
+            if ((member.name.escapedText as string) === privateName) {
+              return true;
+            }
           }
         }
       }
@@ -738,6 +748,16 @@ export function isInsideClassWithPrivateName(node: ts.Node, privateName: string)
       // Continue searching outer classes.
     }
     current = current.parent;
+  }
+  return false;
+}
+
+/** True when `node` is `ancestor` or a descendant of it (walks `.parent`). */
+function isNodeWithin(node: ts.Node, ancestor: ts.Node): boolean {
+  let cur: ts.Node | undefined = node;
+  while (cur) {
+    if (cur === ancestor) return true;
+    cur = cur.parent;
   }
   return false;
 }

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -98,3 +98,63 @@ describe("#3026 — 'async' prefix on a shorthand property", () => {
     expect(await isRejected("({async: 1});")).toBe(false);
   });
 });
+
+// Slice 3 — early errors for two private-name (#x) grammar rules.
+//
+// (a) A private name referenced inside a class's ClassHeritage (the `extends`
+//     clause) is NOT in that class's own private environment — §15.7.14
+//     ClassDefinitionEvaluation evaluates the heritage with the OUTER
+//     PrivateEnvironment. So `class C extends class { x = this.#foo } { #foo }`
+//     is an early SyntaxError: `#foo` (declared in C) is out of scope in C's
+//     heritage. Covers test262
+//     language/{expressions,statements}/class/elements/syntax/early-errors/
+//     grammar-private-environment-on-class-heritage*.
+//
+// (b) A PrivateIdentifier cannot be a property key in a destructuring pattern —
+//     ObjectBindingPattern / ObjectAssignmentPattern property names are
+//     PropertyName, which excludes PrivateIdentifier. `const { #x: v } = o` is
+//     an early SyntaxError even when `#x` is declared in the enclosing class.
+//     Covers grammar-private-field-on-object-destructuring.
+//
+// TypeScript's parser accepts both silently under skipSemanticDiagnostics (the
+// test262 harness mode), so nothing detected them until this slice.
+describe("#3026 — private name in class heritage / destructuring pattern", () => {
+  it("rejects a private name used in the class heritage (`extends class { x = this.#foo }`)", async () => {
+    expect(await isRejected("class C extends class { x = this.#foo; } {\n  #foo;\n}")).toBe(true);
+  });
+
+  it("rejects a private name used in a nested/recursive heritage", async () => {
+    expect(
+      await isRejected("class Base {}\nclass C extends (class extends Base { x = this.#foo; }) {\n  #foo;\n}"),
+    ).toBe(true);
+  });
+
+  it("rejects a private name as an object binding-pattern key (`const { #x: v } = this`)", async () => {
+    expect(await isRejected("class C {\n  #x = 1;\n  m() { const { #x: v } = this; return v; }\n}")).toBe(true);
+  });
+
+  it("rejects a private name as an object assignment-pattern key (`({ #x: v } = this)`)", async () => {
+    expect(await isRejected("class C {\n  #x = 1;\n  m() { let v; ({ #x: v } = this); return v; }\n}")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts a private field read in the class body (`this.#x` in a method)", async () => {
+    expect(await isRejected("class C {\n  #x = 1;\n  m() { return this.#x; }\n}")).toBe(false);
+  });
+
+  it("accepts `#x in obj` and a normal object destructuring alongside a private class", async () => {
+    expect(
+      await isRejected(
+        "class C {\n  #x = 1;\n  has(o: any) { return #x in o; }\n  m(o: any) { const { a } = o; return a; }\n}",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts two sibling classes each with their own private field", async () => {
+    expect(
+      await isRejected(
+        "class A {\n  #p = 1;\n  m() { return this.#p; }\n}\nclass B {\n  #q = 2;\n  n() { return this.#q; }\n}",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 3 of #3026 (`negative_test_fail` early-error residual). Adds two precise parse-time `SyntaxError`s for private-name (`#x`) grammar rules, clearing **all 10** `class/elements/syntax/early-errors` unenforced-`SyntaxError` test262 samples.

## Rules

- **(a) Private name in a class heritage clause.** `class C extends class { x = this.#foo; } { #foo; }` — §15.7.14 ClassDefinitionEvaluation evaluates the `ClassHeritage` with the OUTER PrivateEnvironment, so `C`'s own `#foo` is not yet in scope in `C`'s `extends` clause → SyntaxError. Covers `grammar-private-environment-on-class-heritage{,-function-expression,-recursive,-chained-usage}` (expression + statement forms).
- **(b) Private name as a destructuring-pattern key.** `const { #x: v } = this` / `({ #x: v } = this)` — `ObjectBindingPattern`/`ObjectAssignmentPattern` property names are `PropertyName`, which excludes `PrivateIdentifier` → SyntaxError even when `#x` is declared in the enclosing class. Covers `grammar-private-field-on-object-destructuring`.

## Root cause

TypeScript's parser accepts both silently under `skipSemanticDiagnostics` (the test262 harness mode), so nothing detected them.
- (a) `isInsideClassWithPrivateName` walked all enclosing classes and counted a class's own private members even when the reference lived in that class's heritage — now skips a class's members when the reference is within its `heritageClauses`.
- (b) The existing PrivateIdentifier check only enforced "must be declared in an enclosing class"; added an additive branch for a private name used as a `BindingElement.propertyName` / object-pattern property key, checked before the enclosing-class rule.

## Validation

- 10/10 target test262 files now pass; **0/113** related passing files (private-name / class-heritage / destructuring) regressed.
- `tests/issue-3026.test.ts`: +4 reject + 3 valid-control cases (23 total pass). Byte-inert for valid programs — private reads (`this.#x`), `#x in o`, normal destructuring, sibling private classes all remain valid.
- `tsc --noEmit` + `biome lint` clean.

**Files:** `src/compiler/early-errors/predicates.ts`, `src/compiler/early-errors/node-checks.ts`. Issue stays open (module-code / import.meta / top-level-await samples remain as follow-up slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS