### PR TITLE
feat(#2933): standalone fixed-arity Reflect.* static-method value reads

### DIFF
--- a/plan/issues/2933-standalone-namespace-static-value-read.md
+++ b/plan/issues/2933-standalone-namespace-static-value-read.md
@@ -97,6 +97,48 @@ members (`Math["max"]`) fall through unchanged. Covered by `tests/issue-2933.tes
 3. `Reflect.ownKeys(o).length` reflective-read-of-result and `globalThis.Math.PI`
    (niche trap) also remain.
 
+## Progress (2026-07-04, dev-3023) — fixed-arity `Reflect.*` value closures landed
+
+Sub-part 1 is now landed for the **fixed-arity `Reflect.*`** methods
+(`Reflect.get`, `Reflect.has`, `Reflect.set`, `Reflect.ownKeys`). Reading any of
+these as a VALUE under `--target standalone` (`const f: any = Reflect.get;
+f(o, "k")`) previously refused with the `#1907`/`#1888 S6-b` "built-in static
+property value read is not supported" compile error; it now reifies a native
+static-method closure and calls host-free.
+
+**Mechanism** — the standalone CALL path already backs these four with a simple
+externref/i32 native (`calls.ts` §"Reflect API": `__extern_get` / `__extern_has`
+/ `__reflect_set` / `__object_keys`). This slice adds the matching cases to
+`ensureStandaloneBuiltinStaticMethodClosure` (`src/codegen/property-access.ts`)
++ `STANDALONE_STATIC_METHOD_META` (`src/codegen/builtin-fn-meta.ts`), so the
+value closure calls the SAME native → observationally identical to the call
+form. `Reflect.get`/`set` are fixed at arity 2/3 (no explicit-receiver slot),
+matching the call path which already refuses the receiver form under standalone
+(#2046). Standalone-gated only — host mode (which reads the real JS `Reflect.get`
+via `__get_builtin`/`__extern_get`) is untouched; identity is singleton-stable
+via the existing `pushBuiltinFnSingletonValueInstrs` path (#2963).
+
+Covered by `tests/issue-2933-reflect-static-method-value.test.ts` (10 cases:
+get/has/set/ownKeys value calls, identity stability, distinct-method
+inequality, call-path regression guard, and JSON.stringify/Math.max
+scope-boundary refusal assertions). `tsc --noEmit` + `biome` clean; existing
+`#2933` / `#2963` / `#2896` suites green.
+
+**Remaining (this issue stays open):**
+
+1. Static-method VALUE reads (`const f = JSON.stringify; f(o)`,
+   `Reflect.ownKeys` as a value) — needs the `ensureStandaloneBuiltinStaticMethodClosure`
+   value-closure wiring. `JSON.stringify` carries a native-`$AnyString`-return →
+   externref coercion at the any-call boundary + a 7-arg `__json_stringify_value`
+   call, so it is not a one-line switch add; scope carefully.
+   **(Partially addressed 2026-07-04: the fixed-arity `Reflect.get`/`has`/`set`/
+   `ownKeys` value reads now work — see Progress above. `JSON.stringify` remains.)**
+2. `Math.max` / `Math.min` **as a value** (`const g = Math.max; g(1,2,3)`) is
+   genuinely VARIADIC — value-closures are fixed-arity, so it needs
+   variadic-closure support. Recommended to split into its own follow-up.
+3. `Reflect.ownKeys(o).length` reflective-read-of-result and `globalThis.Math.PI`
+   (niche trap) also remain.
+
 ## Notes
 
 Umbrella #2860. Follows #2861 (ctor/prototype value reads + `<Ctor>.length`/

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -50,6 +50,12 @@ export const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; lengt
   "Array.isArray": { name: "isArray", length: 1 },
   "Object.keys": { name: "keys", length: 1 },
   "Object.getOwnPropertyDescriptor": { name: "getOwnPropertyDescriptor", length: 2 },
+  // (#2933) Fixed-arity Reflect.* namespace static-method value reads. Spec
+  // `length` per §28.1 (receiver arg is optional and not counted).
+  "Reflect.get": { name: "get", length: 2 },
+  "Reflect.has": { name: "has", length: 2 },
+  "Reflect.set": { name: "set", length: 3 },
+  "Reflect.ownKeys": { name: "ownKeys", length: 1 },
 };
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1168,6 +1168,32 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       paramTypes = [{ kind: "externref" }, { kind: "externref" }];
       returnType = { kind: "externref" };
       break;
+    // (#2933) Namespace static-method VALUE reads for the fixed-arity `Reflect.*`
+    // methods that the standalone CALL path already backs with a simple
+    // externref/i32 native (calls.ts §"Reflect API"). The value closure calls
+    // the SAME native, so `const f: any = Reflect.get; f(o, "k")` is
+    // observationally identical to `Reflect.get(o, "k")`. The variadic
+    // (`Math.max`) and native-`$AnyValue`-return (`JSON.stringify`, `JSON.parse`)
+    // methods stay refused — they need variadic / anyref-boundary closure work
+    // (see the issue's remaining scope). `Reflect.get`/`set` fix the arity at 2/3
+    // (no explicit-receiver slot), matching the call path which refuses the
+    // receiver form under standalone (#2046).
+    case "Reflect.get":
+      paramTypes = [{ kind: "externref" }, { kind: "externref" }];
+      returnType = { kind: "externref" };
+      break;
+    case "Reflect.has":
+      paramTypes = [{ kind: "externref" }, { kind: "externref" }];
+      returnType = { kind: "i32" };
+      break;
+    case "Reflect.set":
+      paramTypes = [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }];
+      returnType = { kind: "i32" };
+      break;
+    case "Reflect.ownKeys":
+      paramTypes = [{ kind: "externref" }];
+      returnType = { kind: "externref" };
+      break;
     default:
       return null;
   }
@@ -1204,6 +1230,51 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       closureFctx.body.push({ op: "local.get", index: 1 });
       closureFctx.body.push({ op: "local.get", index: 2 });
       closureFctx.body.push({ op: "call", funcIdx: gopdIdx });
+    } else if (key === "Reflect.get") {
+      // (#2933) Same native the 2-arg standalone `Reflect.get(target, key)` call
+      // path uses (calls.ts). The value closure is fixed 2-arg — the optional
+      // receiver form is unsupported in standalone (#2046), consistent there.
+      const idx = ensureLateImport(
+        ctx,
+        "__extern_get",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      if (idx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "local.get", index: 2 });
+      closureFctx.body.push({ op: "call", funcIdx: idx });
+    } else if (key === "Reflect.has") {
+      const idx = ensureLateImport(
+        ctx,
+        "__extern_has",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "i32" }],
+      );
+      if (idx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "local.get", index: 2 });
+      closureFctx.body.push({ op: "call", funcIdx: idx });
+    } else if (key === "Reflect.set") {
+      const idx = ensureLateImport(
+        ctx,
+        "__reflect_set",
+        [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+        [{ kind: "i32" }],
+      );
+      if (idx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "local.get", index: 2 });
+      closureFctx.body.push({ op: "local.get", index: 3 });
+      closureFctx.body.push({ op: "call", funcIdx: idx });
+    } else if (key === "Reflect.ownKeys") {
+      // Native __object_keys — string own keys of the $Object hash-map, per the
+      // standalone `Reflect.ownKeys(target)` call path (Symbol/non-enumerable
+      // keys are out of scope for the open-object runtime, consistent with it).
+      const idx = ensureLateImport(ctx, "__object_keys", [{ kind: "externref" }], [{ kind: "externref" }]);
+      if (idx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "call", funcIdx: idx });
     }
 
     funcIdx = mintDefinedFunc(ctx);

--- a/tests/issue-2933-reflect-static-method-value.test.ts
+++ b/tests/issue-2933-reflect-static-method-value.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2933 — standalone namespace static-METHOD VALUE reads (fixed-arity Reflect.*).
+//
+// Reading a `Reflect.*` static method AS A VALUE under `--target standalone`
+// (`const f: any = Reflect.get; f(o, "k")`) previously refused with the
+// `#1907`/`#1888 S6-b` "built-in static property value read is not supported"
+// compile error. The standalone CALL path already backs the fixed-arity
+// `Reflect.get`/`has`/`set`/`ownKeys` with a simple externref/i32 native
+// (`__extern_get` / `__extern_has` / `__reflect_set` / `__object_keys`); this
+// slice wires those SAME natives into `ensureStandaloneBuiltinStaticMethodClosure`
+// so the reified value calls identically. The variadic (`Math.max`) and
+// native-`$AnyValue`-return (`JSON.stringify`) methods stay refused (need
+// variadic / anyref-boundary closure work — tracked on #2933's remaining scope).
+
+async function runStandalone(body: string): Promise<number> {
+  const r = await compile(`export function test(): number { ${body} }`, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No host imports — pure standalone Wasm.
+  expect((r.imports ?? []).map((i) => `${i.module}::${i.name}`).filter((l) => l.startsWith("env::"))).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function runStandaloneNS(body: string): Promise<number> {
+  // nativeStrings harness (matches #2963) for identity / ref-equality checks.
+  const r = await compile(`export function test(): number { ${body} }`, {
+    target: "standalone",
+    nativeStrings: true,
+  });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2933 — standalone Reflect.* static-method value reads", () => {
+  it("Reflect.get as a value reads the property (was a compile refusal)", async () => {
+    expect(await runStandalone(`const o: any = { k: 42 }; const f: any = Reflect.get; return f(o, "k");`)).toBe(42);
+  });
+
+  it("Reflect.has as a value returns true for a present key", async () => {
+    expect(await runStandalone(`const o: any = { k: 42 }; const f: any = Reflect.has; return f(o, "k") ? 1 : 0;`)).toBe(
+      1,
+    );
+  });
+
+  it("Reflect.has as a value returns false for an absent key", async () => {
+    expect(await runStandalone(`const o: any = { k: 42 }; const f: any = Reflect.has; return f(o, "z") ? 1 : 0;`)).toBe(
+      0,
+    );
+  });
+
+  it("Reflect.set as a value writes the property", async () => {
+    expect(await runStandalone(`const o: any = { k: 1 }; const f: any = Reflect.set; f(o, "k", 7); return o.k;`)).toBe(
+      7,
+    );
+  });
+
+  it("Reflect.ownKeys as a value returns the own keys", async () => {
+    expect(
+      await runStandalone(
+        `const o: any = { a: 1, b: 2 }; const f: any = Reflect.ownKeys; const ks: any = f(o); return ks.length;`,
+      ),
+    ).toBe(2);
+  });
+
+  it("the Reflect.get CALL path is unregressed", async () => {
+    expect(await runStandalone(`const o: any = { k: 5 }; return Reflect.get(o, "k");`)).toBe(5);
+  });
+
+  it("reified Reflect.get is identity-stable (single function object)", async () => {
+    expect(await runStandaloneNS(`const a = Reflect.get, b = Reflect.get; return a === b ? 1 : 0;`)).toBe(1);
+  });
+
+  it("distinct Reflect methods are NOT identity-equal", async () => {
+    expect(await runStandaloneNS(`const a: any = Reflect.get, b: any = Reflect.has; return a === b ? 0 : 1;`)).toBe(1);
+  });
+});
+
+describe("#2933 — deferred namespace static-method value reads still refuse (scope boundary)", () => {
+  it("JSON.stringify as a value still refuses (needs anyref-boundary closure)", async () => {
+    const r = await compile(
+      `export function test(): number { const f: any = JSON.stringify; return f({ a: 1 }) ? 1 : 0; }`,
+      {
+        target: "standalone",
+      },
+    );
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toContain("JSON.stringify");
+  });
+
+  it("Math.max as a value still refuses (variadic — split follow-up)", async () => {
+    const r = await compile(`export function test(): number { const g: any = Math.max; return g(1, 2, 3); }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toContain("Math.max");
+  });
+});


### PR DESCRIPTION
## #2933 (slice) — standalone `Reflect.*` static-method VALUE reads

Reading a fixed-arity `Reflect.*` static method AS A VALUE under `--target standalone` (`const f: any = Reflect.get; f(o, "k")`) refused with the #1907 / #1888 S6-b *'built-in static property value read is not supported'* compile error.

### Mechanism
The standalone CALL path already backs `Reflect.get`/`has`/`set`/`ownKeys` with a simple externref/i32 native (`__extern_get` / `__extern_has` / `__reflect_set` / `__object_keys`; `calls.ts` §"Reflect API"). This slice wires those **same natives** into `ensureStandaloneBuiltinStaticMethodClosure` (`src/codegen/property-access.ts`) + `STANDALONE_STATIC_METHOD_META` (`src/codegen/builtin-fn-meta.ts`), so the reified value closure calls **identically** to the call form.

- `Reflect.get`/`set` fixed at arity 2/3 (no explicit-receiver slot) — matches the call path, which refuses the receiver form under standalone (#2046).
- **Standalone-gated**: host mode (which reads the real JS `Reflect.get` via `__get_builtin`/`__extern_get`) is untouched.
- Identity is singleton-stable via the existing #2963 `pushBuiltinFnSingletonValueInstrs` path.

### Tests
`tests/issue-2933-reflect-static-method-value.test.ts` (10 cases): get/has/set/ownKeys value calls, identity stability, distinct-method inequality, call-path regression guard, and `JSON.stringify`/`Math.max` scope-boundary refusal assertions. `tsc --noEmit` + `biome` clean; existing `#2933` / `#2963` / `#2896` suites green.

### Scope
Partial slice of #2933 — **the issue stays open**. Deferred sub-parts (untouched): `JSON.stringify`/`JSON.parse` (native-`$AnyValue`-return coercion at the any-call boundary), variadic `Math.max`/`Math.min` (split follow-up), `Atomics.*` (TypedArray-typed args), `Reflect.ownKeys(o).length` reflective-read-of-result, `globalThis.Math.PI`. See the issue's Progress section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)