### PR TITLE
feat(#2906): async-generator producer core — host-free settleYield drive (slice 3d-i)

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -702,3 +702,83 @@ array of promises) that is NOT how real for-await / test262 for-await is written
 
 Until (1)+(2) land, for-await stays on AG0 (wrong for genuinely-pending
 sources). The 3a drive machine is confirmed ready to carry it.
+
+## Slice 3d-i — async-generator PRODUCER core (LANDED, host-free wasi lane, 2026-07-05, opus-2906-3di)
+
+**What shipped.** `async function* g(){ yield await Promise.resolve(1); yield 2 }`
+now drives **host-free** on the #2906 CFG resume machine. Direct-drive proof
+(next-helper → `__drain_microtasks` → read IteratorResult): the sequence
+`{1,false}`, `{2,false}`, `{undefined,true}` with **imports `[]`**, and a
+genuinely-pending awaited yield **suspends at kick (state=PENDING) and resumes
+on the drain**. Previously this hit the #680 native-generator gate
+(function-body.ts) and never reached the async machine.
+
+**How (all on the existing emitter substrate — two new terminators, no ABI churn):**
+
+- **`async-cps.ts`** — `planAsyncGenCfg(fn)` + `isBoundedAsyncGenBody(fn)`. Two
+  new `AsyncCfgTerminator` kinds: **`settleYield`** (`{value|fromSent,
+  resumeState}`) fulfils the current `next()`-promise `{value, done:false}` and
+  suspends (NO reaction registered — the next `next()` kick is the sole
+  resumption driver); **`settleDone`** fulfils `{undefined, done:true}` at body
+  end. `yield await P` lowers to `suspend(P) → settleYield(fromSent)`; the await
+  is the STOCK suspend terminator (genuine microtask suspension), the yield reads
+  the delivered `SENT_FIELD`. A rejected awaited yield re-throws via the resume
+  prelude's `MODE_THROW` arm → the outer catch settles the `next()`-promise
+  **rejected** (verified: state=REJECTED, not vacuously fulfilled).
+- **`async-frame.ts`** — `emitAsyncGenerator` builds the `$AsyncFrame` carrier and
+  returns it as a bare externref **WITHOUT kicking** (async gens are lazy — the
+  body starts on the first `next()`). The re-entrant driver
+  `__async_gen_next_<name>(frame) -> Promise<IteratorResult>` mints a FRESH
+  pending result promise per call, stores it into `frame.result_promise` (the
+  resume fn re-reads that field at entry, so each `next()`'s promise is the one
+  settled at the next yield), kicks resume, returns the promise. The Iterator
+  Result reuses `generators-native.ts` `ensureNativeGeneratorResultType`
+  (`{value,done}` — no frame-ABI fork). `AsyncFrameInfo.asyncGen` switches
+  `ensureAsyncResumeFunction` to `planAsyncGenCfg` and the `settleYield`/
+  `settleDone` emit arms; every other async fn is byte-untouched.
+- **`function-body.ts`** — intercepts a bounded async gen in the `isGenerator`
+  branch BEFORE the #680 gate, gated on `isAsyncGenDriveCandidate`.
+
+**Why one gate, matching the plain drive (the standalone trap avoided).** The
+candidate gate is `isStandalonePromiseActive` (currently **wasi-only**), NOT
+`isAsyncDriveActive` (standalone+wasi). The plain/for-await drive lanes activate
+under the same carrier gate (`decideAsyncActivation`): in non-wasi standalone the
+awaited operand does **not** lower to a native `$Promise`, so driving there would
+build a broken machine. The widen to `standalone` is the shared slice-1d carrier
+move — this slice does not touch it.
+
+**Bounded slice (everything else → legacy gen path / #680, never a wrong
+machine).** A FLAT body of `yield <E>` statements where `E` is plain / `await
+<P>` / absent; NO own-local declarations (a local crossing a yield needs the
+frame-spill widening the linear/loop drives already have — params ARE fine,
+captured in frame fields); no `yield*`, no yields nested in expressions/control
+flow. `next(v)`/`.throw()`/`.return()` sent-value handling + prototype-method
+dispatch are **3d-ii** (the for-await consumer). Own-locals/spills is the
+immediate 3d-i′ follow-up (reuse `computeAsyncSpills`).
+
+**Byte-inertness proof (the −16/−29 discipline).** sha256 of 5 representative
+programs (plainAsync / multiAwait / forAwait / syncGen / plain) × {gc, standalone,
+wasi} — **all 15 byte-identical to origin/main**. The async-gen program itself:
+**gc byte-identical** (`cb154a25…`, legacy `__create_async_generator`),
+**standalone byte-identical** (still the #680 CE — carrier-gated out), and only
+**wasi** changes (`a275a967…`, imports=0 — the intended unlock).
+
+**Verification.** `tests/issue-2906-3di-asyncgen-producer.test.ts` (7 host-free
+wasi tests: the 1,2,done proof; genuine pending-then-resume; plain-yield
+sequence; laziness; the rejected-await→reject inject-throw proof; param capture;
+gc/standalone inertness). Full async+generator blast radius (async-await /
+async-census / generators / issue-1042[-host-drive] / 2895[-drain-hook] /
+2906-3a/3b/multiawait/gap3 / 2864 / 2865 / 820 / 1672 / 2611 / 2635 / 3032 /
+symbol-async-iterator / 2174 / promise-combinators): the ONLY failures (3×
+gap3-tryfinally throw-path, 2× promise-combinators host, 2× issue-2865 AG0 wasi,
+1× generator-yield-contexts fn-expr, 2× symbol-async-iterator for-await) are
+**pre-existing on origin/main** — verified identical failure set in a base
+worktree. `tsc --noEmit` clean.
+
+**Unblocks 3d-ii + #2865.** The frame carrier + `__async_gen_next_<name>` driver
++ the settleYield/settleDone suspend-resume substrate are exactly what the
+`for await (x of g())` consumer (3d-ii) drives — that headline is now a
+consumer-side wiring slice (dispatch `g()[Symbol.asyncIterator]().next()` onto
+this producer) rather than a producer-machine problem. #2865 (standalone
+async-gen) shares the carrier widen (slice-1d). Issue stays `in-progress` for
+3d-ii + the own-local/`yield*`/nested-yield widenings.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1125,7 +1125,24 @@ export type AsyncCfgTerminator =
       readonly handler: number;
     }
   | { readonly kind: "settleSent" } // `return await P` — fulfil with SENT directly
-  | { readonly kind: "settleUndefined" }; // fall off the body — fulfil with undefined
+  | { readonly kind: "settleUndefined" } // fall off the body — fulfil with undefined
+  | {
+      // (#2906 slice 3d-i) Async-generator `yield E`: fulfil the CURRENT
+      // `next()`-promise (`frame.result_promise`, re-minted per `next()` call)
+      // with an IteratorResult `{value: E, done: false}`, set STATE=resumeState,
+      // and `return` — the machine SUSPENDS until the next `next()` kick, which
+      // re-mints the result promise and re-dispatches at `resumeState`. Unlike
+      // `suspend` it registers NO promise reaction (a yield does not await): the
+      // consumer's next `next()` is the sole resumption driver.
+      readonly kind: "settleYield";
+      /** The yielded value. `null` ⇒ `fromSent` (yield the delivered await value). */
+      readonly value: AsyncCfgOperand | null;
+      /** Yield `SENT_FIELD` directly (`yield await P` — the awaited value). */
+      readonly fromSent: boolean;
+      /** State entered on the next `next()` kick after this yield. */
+      readonly resumeState: number;
+    }
+  | { readonly kind: "settleDone" }; // async-gen body end — fulfil `{value: undefined, done: true}`
 
 /** One basic block of the async CFG. */
 export interface AsyncCfgState {
@@ -1780,6 +1797,163 @@ export function planForAwaitCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPl
       terminator: { kind: "settleUndefined" },
     },
   ];
+  return { states, handlers: [] };
+}
+
+// ---------------------------------------------------------------------------
+// async-generator PRODUCER core (#2906 slice 3d-i).
+//
+// `async function* g() { yield await P; yield E; … }` currently routes through
+// the generator-buffer path and fails at the #680 native-generator gate in
+// standalone/wasi — it never reaches the async drive machine. The PRODUCER core
+// intercepts a BOUNDED async-gen body BEFORE that gate and lowers it onto the
+// SAME CFG resume machine (`ensureAsyncResumeFunction`) the linear/while/
+// for-await drives already use, with two new terminators:
+//
+//   - `settleYield` — `yield E`: fulfil the current `next()`-promise with
+//     `{value: E, done: false}` and suspend (no reaction; the next `next()` kick
+//     resumes). `yield await P` splits into a `suspend` on `P` (the existing
+//     await terminator — genuine microtask suspension) followed by a
+//     `settleYield` that yields the delivered `SENT_FIELD` value (`fromSent`).
+//   - `settleDone` — body end: fulfil `{value: undefined, done: true}`.
+//
+// Bounded slice (everything else → the legacy gen path / #680 error, never a
+// wrong machine — the #2367 graveyard rule):
+//   - the body is a FLAT block whose every statement is `yield <E>` (an
+//     expression statement wrapping a non-delegating `YieldExpression`);
+//   - `E` is a plain expression, `await <P>`, or absent (`yield;`);
+//   - a plain `E` contains no nested `await`/`yield` (those need expression-level
+//     suspend-point numbering — a follow-up);
+//   - NO own-local declarations (var/let/const) in the body: a local that
+//     crosses a yield/await needs the frame-spill widening the linear/loop
+//     drives already have; the core keeps spills empty (params are captured in
+//     frame fields, so param-only bodies are fine). Own-locals are the immediate
+//     3d-i′ follow-up (reuse `computeAsyncSpills`).
+// Consumer-side `next(v)`/`.throw()`/`.return()` and prototype-method dispatch
+// are 3d-ii (the for-await consumer); the core proves the producer host-free via
+// direct `next()`-helper drive.
+// ---------------------------------------------------------------------------
+
+/** True when `node` contains an `await`/`yield` not inside a nested fn scope. */
+function containsAwaitOrYield(node: ts.Node): boolean {
+  let found = false;
+  const walk = (n: ts.Node): void => {
+    if (found || isNestedFunctionScope(n)) return;
+    if (ts.isAwaitExpression(n) || ts.isYieldExpression(n)) {
+      found = true;
+      return;
+    }
+    forEachChild(n, walk);
+  };
+  walk(node);
+  return found;
+}
+
+/** Does the async-gen body declare any own local (var/let/const)? (Conservative
+ *  — the 3d-i core rejects these; spill widening is the follow-up.) */
+function asyncGenBodyHasOwnLocals(fn: ts.FunctionLikeDeclaration): boolean {
+  const body = fn.body;
+  if (body === undefined) return false;
+  let found = false;
+  const walk = (n: ts.Node): void => {
+    if (found || isNestedFunctionScope(n)) return;
+    if (ts.isVariableDeclaration(n)) {
+      found = true;
+      return;
+    }
+    forEachChild(n, walk);
+  };
+  forEachChild(body, walk);
+  return found;
+}
+
+/** One bounded async-gen yield statement: `yield await <awaited>` OR `yield <plain>`
+ *  OR `yield;` (both null). */
+interface AsyncGenYield {
+  readonly awaited: ts.Expression | null;
+  readonly plain: ts.Expression | null;
+}
+
+/** Recognise the bounded 3d-i async-gen body; return its ordered yield list, or
+ *  `null` for anything outside the slice. */
+function analyzeAsyncGen(fn: ts.FunctionLikeDeclaration): AsyncGenYield[] | null {
+  const body = fn.body;
+  if (body === undefined || !ts.isBlock(body)) return null;
+  if (asyncGenBodyHasOwnLocals(fn)) return null;
+  const yields: AsyncGenYield[] = [];
+  for (const st of body.statements) {
+    if (!ts.isExpressionStatement(st)) return null;
+    const e = st.expression;
+    if (!ts.isYieldExpression(e)) return null;
+    if (e.asteriskToken !== undefined) return null; // `yield*` delegation — follow-up
+    const operand = e.expression;
+    if (operand === undefined) {
+      yields.push({ awaited: null, plain: null }); // `yield;`
+    } else if (ts.isAwaitExpression(operand)) {
+      // `yield await P` — reject a doubly-nested await/yield in the awaited operand.
+      if (containsAwaitOrYield(operand.expression)) return null;
+      yields.push({ awaited: operand.expression, plain: null });
+    } else {
+      if (containsAwaitOrYield(operand)) return null; // nested await/yield — follow-up
+      yields.push({ awaited: null, plain: operand });
+    }
+  }
+  if (yields.length === 0) return null; // an empty async-gen has no producer to prove
+  return yields;
+}
+
+/** True when `fn` is a bounded 3d-i async-generator body drivable host-free. */
+export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
+  return analyzeAsyncGen(fn) !== null;
+}
+
+/**
+ * Build the CFG for a bounded async-generator body. Dense ids in push order; a
+ * `yield await P` contributes TWO states (await-suspend + yield-from-sent), a
+ * plain `yield E` ONE, and a trailing `settleDone`:
+ *
+ *   yield await P:  Sk  suspend(P, resume→Sk+1)                (the await)
+ *                   Sk+1 (resumeFrom binding:null) settleYield(fromSent, →Sk+2)
+ *   yield E:        Sk  settleYield(value:E, →Sk+1)
+ *   <end>:          Sn  settleDone
+ *
+ * Only the yield-from-sent state carries a resume prelude (to re-throw a rejected
+ * await via the MODE_THROW arm — a rejected awaited yield rejects the current
+ * `next()` promise). Every other state is entered by a `next()` kick with
+ * MODE_NEXT, so needs no prelude. Returns `null` for a non-bounded body.
+ */
+export function planAsyncGenCfg(fn: ts.FunctionLikeDeclaration): AsyncCfgPlan | null {
+  const yields = analyzeAsyncGen(fn);
+  if (yields === null) return null;
+  const states: AsyncCfgState[] = [];
+  let id = 0;
+  for (const y of yields) {
+    if (y.awaited !== null) {
+      // await-suspend state → yield-from-sent state.
+      states.push({
+        id,
+        resumeFrom: null,
+        lead: [],
+        terminator: { kind: "suspend", awaited: y.awaited, resumeState: id + 1, handler: 0 },
+      });
+      states.push({
+        id: id + 1,
+        resumeFrom: { binding: null, handler: 0 }, // re-throw a rejected await
+        lead: [],
+        terminator: { kind: "settleYield", value: null, fromSent: true, resumeState: id + 2 },
+      });
+      id += 2;
+    } else {
+      states.push({
+        id,
+        resumeFrom: null,
+        lead: [],
+        terminator: { kind: "settleYield", value: y.plain, fromSent: false, resumeState: id + 1 },
+      });
+      id += 1;
+    }
+  }
+  states.push({ id, resumeFrom: null, lead: [], terminator: { kind: "settleDone" } });
   return { states, handlers: [] };
 }
 

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -40,15 +40,19 @@ import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint } from
 import {
   ASYNC_CPS_ENABLED,
   FORAWAIT_ITER_SPILL,
+  analyzeAsyncBody,
   asyncFnNeedsCps,
   awaitedExprIsPromiseCombinator,
   forAwaitNeedsDrive,
   forAwaitSpillInfo,
+  isBoundedAsyncGenBody,
   isEmitOperand,
   loopAsyncSpillInfo,
   planAsyncCfg,
+  planAsyncGenCfg,
   planLinearAwaits,
 } from "./async-cps.js";
+import { ensureNativeGeneratorResultType } from "./generators-native.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3 / #2710) stable-regime minting
 import {
   type AsyncDriveRuntime,
@@ -57,6 +61,7 @@ import {
   PROMISE_STATE_REJECTED,
   ensureAsyncDriveRuntime,
   getOrRegisterPromiseType,
+  isStandalonePromiseActive,
 } from "./async-scheduler.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
@@ -66,6 +71,8 @@ import {
   MODE_FIELD,
   MODE_THROW,
   PARAM_FIELD_OFFSET,
+  RESULT_DONE_FIELD,
+  RESULT_VALUE_FIELD,
   SENT_FIELD,
   STATE_FIELD,
   defaultSpillInstr,
@@ -76,7 +83,7 @@ import {
 import { ensureI32Condition, resolveWasmType } from "./index.js";
 import { ensureExnTag } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
-import { coerceType, compileExpression, compileStatement } from "./shared.js";
+import { coerceType, compileExpression, compileStatement, ensureLateImport } from "./shared.js";
 import { resolveSpillLocalValType } from "./statements/variables.js";
 
 /**
@@ -260,6 +267,15 @@ export interface AsyncFrameInfo {
   stepFulfillFuncIdx?: number;
   /** `__async_step_reject_f<name>(caps, value) -> externref` funcIdx — emitter slice. */
   stepRejectFuncIdx?: number;
+  /**
+   * (#2906 slice 3d-i) `true` when this frame drives an async GENERATOR producer:
+   * the resume machine is built from {@link planAsyncGenCfg} (not `planAsyncCfg`)
+   * and the `settleYield`/`settleDone` terminators fulfil the re-minted
+   * `next()`-promise with an IteratorResult instead of the async fn's raw value.
+   */
+  asyncGen?: boolean;
+  /** (#2906 slice 3d-i) `{value: externref, done: i32}` IteratorResult struct typeIdx (async-gen only). */
+  asyncGenResultTypeIdx?: number;
 }
 
 /**
@@ -640,6 +656,8 @@ function validateAsyncCfg(cfg: AsyncCfgPlan): string | null {
     if (st.id !== i) return `state ids not dense (states[${i}].id === ${st.id})`;
     const t = st.terminator;
     if (t.kind === "suspend" && !inRange(t.resumeState)) return `suspend.resumeState ${t.resumeState} out of range`;
+    if (t.kind === "settleYield" && !inRange(t.resumeState))
+      return `settleYield.resumeState ${t.resumeState} out of range`;
     if (t.kind === "goto" && !inRange(t.target)) return `goto.target ${t.target} out of range`;
     if (t.kind === "condGoto" && (!inRange(t.whenTrue) || !inRange(t.whenFalse))) {
       return `condGoto targets ${t.whenTrue}/${t.whenFalse} out of range`;
@@ -707,7 +725,10 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // into the loop CFG (head condGoto + body suspends + back-edge goto). The host
   // settle backend keeps the linear-only shape (loops there suspend on every
   // await — an N-round follow-up).
-  const cfg = planAsyncCfg(info.decl, plan, { allowLoops: !info.host });
+  // (#2906 slice 3d-i) An async GENERATOR builds its CFG from the yield-aware
+  // `planAsyncGenCfg` (settleYield/settleDone terminators); every other async fn
+  // uses the linear/while/for-await `planAsyncCfg`.
+  const cfg = info.asyncGen ? planAsyncGenCfg(info.decl) : planAsyncCfg(info.decl, plan, { allowLoops: !info.host });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
     info.resumeFuncIdx = -1;
@@ -909,6 +930,8 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   const reasonLocal = allocLocal(resumeFctx, "__async_reason", {
     kind: "externref",
   });
+  // (#2906 slice 3d-i) The yielded value slot for `settleYield` (async gen only).
+  const yieldValLocal = info.asyncGen ? allocLocal(resumeFctx, "__async_gen_yield", { kind: "externref" }) : -1;
 
   // (#2906 Gap 3 → slice 3) Handler regions. `inSrcTryLocal` (an i32
   // resume-local) records the id of the handler region control is currently in
@@ -1264,6 +1287,60 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
           out.push({ op: "return" });
           break;
         }
+        case "settleYield": {
+          // (#2906 slice 3d-i) `yield E`: fulfil the current `next()`-promise
+          // (`frame.result_promise`, re-minted per next() — already loaded into
+          // `resultPromiseLocal` at resume-fn entry) with an IteratorResult
+          // `{value: E, done: false}`, set STATE=resumeState, spill, and `return`.
+          // No reaction is registered (a yield does not await); the consumer's
+          // next `next()` kick re-dispatches at `resumeState`.
+          const resultTypeIdx = info.asyncGenResultTypeIdx!;
+          // Compute the yielded value (externref) into `yieldValLocal`.
+          if (term.fromSent) {
+            // `yield await P` — the awaited value delivered into SENT_FIELD.
+            out.push({ op: "local.get", index: frameLocal });
+            out.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr);
+          } else if (term.value === null) {
+            out.push({ op: "ref.null.extern" } as Instr); // `yield;` → undefined
+          } else {
+            const vt = isEmitOperand(term.value)
+              ? term.value.emit(ctx, resumeFctx)
+              : compileExpression(ctx, resumeFctx, term.value);
+            if (vt !== null && vt !== undefined) {
+              coerceType(ctx, resumeFctx, vt as ValType, { kind: "externref" });
+            } else {
+              out.push({ op: "ref.null.extern" } as Instr);
+            }
+          }
+          out.push({ op: "local.set", index: yieldValLocal });
+          // result_promise.fulfil( IteratorResult{value: yieldVal, done: 0} )
+          out.push({ op: "local.get", index: resultPromiseLocal });
+          out.push({ op: "local.get", index: yieldValLocal });
+          out.push({ op: "i32.const", value: 0 }); // done = false
+          out.push({ op: "struct.new", typeIdx: resultTypeIdx } as Instr);
+          out.push({ op: "extern.convert_any" } as Instr);
+          out.push({ op: "call", funcIdx: settleFulfillIdx });
+          out.push({ op: "drop" });
+          // Suspend: STATE=resumeState, persist spills, return (await the next kick).
+          out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.resumeState));
+          out.push(...storeSpills(info, resumeFctx, frameLocal));
+          out.push({ op: "return" });
+          break;
+        }
+        case "settleDone": {
+          // (#2906 slice 3d-i) Async-gen body end — fulfil the current
+          // `next()`-promise with `{value: undefined, done: true}`.
+          const resultTypeIdx = info.asyncGenResultTypeIdx!;
+          out.push({ op: "local.get", index: resultPromiseLocal });
+          out.push({ op: "ref.null.extern" } as Instr); // value = undefined
+          out.push({ op: "i32.const", value: 1 }); // done = true
+          out.push({ op: "struct.new", typeIdx: resultTypeIdx } as Instr);
+          out.push({ op: "extern.convert_any" } as Instr);
+          out.push({ op: "call", funcIdx: settleFulfillIdx });
+          out.push({ op: "drop" });
+          out.push({ op: "return" });
+          break;
+        }
       }
     } finally {
       resumeFctx.body = saved;
@@ -1557,4 +1634,210 @@ export function emitAsyncFrameStateMachine(
   fctx.body.push({ op: "local.get", index: resultPromiseLocal });
   if (!host) fctx.body.push({ op: "extern.convert_any" } as Instr);
   fctx.body.push({ op: "return" });
+}
+
+// ── async-generator PRODUCER core (#2906 slice 3d-i) ─────────────────────────
+
+/**
+ * Is `decl` a bounded async generator drivable host-free on the async-frame CFG
+ * machine? True only on a host-free target (`standalone`/`wasi`) for an async
+ * `function*` whose body is the bounded shape {@link isBoundedAsyncGenBody}
+ * accepts (a flat sequence of `yield <E>` / `yield await <P>` statements). The
+ * call-site routing (`function-body.ts`) uses this to intercept the async gen
+ * BEFORE the #680 native-generator gate; everything else stays on the legacy gen
+ * path (correct-or-legacy, the #2367 graveyard rule).
+ */
+export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
+  if (!ASYNC_CPS_ENABLED) return false;
+  // Gate on the native-`$Promise` CARRIER (`isStandalonePromiseActive`,
+  // currently wasi-only) — the SAME gate the plain/for-await drive lanes use
+  // (`decideAsyncActivation`). In non-wasi standalone the awaited operand does
+  // not lower to a native `$Promise`, so the drive machine would be broken; the
+  // widen to `standalone` is the shared slice-1d carrier move.
+  if (!isStandalonePromiseActive(ctx)) return false;
+  return isBoundedAsyncGenBody(decl);
+}
+
+/**
+ * (#2906 slice 3d-i) Emit an async-generator PRODUCER: `g()` builds a resumable
+ * `$AsyncFrame` (the generator carrier — a bare externref, NO prototype methods)
+ * and returns it WITHOUT running any body code (async generators are lazy: the
+ * body starts on the first `next()`). The re-entrant driver is the per-gen
+ * `__async_gen_next_<name>(frame) -> Promise<IteratorResult>` helper, which mints
+ * a FRESH pending result promise, stores it into the frame's `result_promise`
+ * field, kicks the resume machine (runs to the next `yield`/`await`-suspend), and
+ * returns that promise. `yield` settles it `{value, done:false}` and suspends;
+ * body-end settles `{value:undefined, done:true}`. Native drive lane only.
+ *
+ * The frame externref + `__async_gen_next_<name>` + the reader probes are the
+ * substrate 3d-ii (the `for await (x of g())` consumer) builds on.
+ */
+export function emitAsyncGenerator(ctx: CodegenContext, fctx: FunctionContext, decl: ts.FunctionLikeDeclaration): void {
+  const rt = ensureAsyncDriveRuntime(ctx);
+  const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+  const resultTypeIdx = ensureNativeGeneratorResultType(ctx, { kind: "externref" });
+  // Ensure the number (un)boxers used by the yield-value box + reader probe are
+  // registered up-front — under wasi these resolve to DEFINED (host-free) funcs.
+  ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
+
+  const plan = analyzeAsyncBody(ctx, decl);
+  const paramNames = fctx.params.map((p) => p.name);
+  const paramTypes = fctx.params.map((p) => p.type);
+  const info = buildAsyncFrameInfo(ctx, decl, plan, paramNames, paramTypes, promiseTypeIdx);
+  info.asyncGen = true;
+  info.asyncGenResultTypeIdx = resultTypeIdx;
+
+  const resumeFuncIdx = ensureAsyncResumeFunction(ctx, info, plan);
+  if (resumeFuncIdx < 0) {
+    reportError(ctx, decl, "internal: async-generator resume function unavailable (#2906 slice 3d-i)");
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    return;
+  }
+
+  // Per-gen re-entrant next() driver + the generic reader probes (once/module).
+  emitAsyncGenNextHelper(ctx, info, promiseTypeIdx);
+  ensureAsyncGenReaderProbes(ctx, promiseTypeIdx, resultTypeIdx);
+
+  // Build the frame WITHOUT kicking (lazy): state=0, sent/mode/abrupt/error inert,
+  // params, [no spills — bounded shape], result_promise = fresh pending.
+  fctx.body.push({ op: "i32.const", value: 0 }); // state
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // sent
+  fctx.body.push({ op: "i32.const", value: 0 }); // mode = MODE_NEXT
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // abrupt
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // error
+  for (let i = 0; i < info.paramTypes.length; i++) {
+    fctx.body.push({ op: "local.get", index: i });
+  }
+  for (let i = 0; i < info.spillNames.length; i++) {
+    fctx.body.push(defaultSpillInstr(info.spillTypes[i]!));
+  }
+  // result_promise: fresh pending $Promise (overwritten by the first next()).
+  fctx.body.push({ op: "i32.const", value: PROMISE_STATE_PENDING });
+  fctx.body.push({ op: "ref.null.extern" } as Instr);
+  fctx.body.push({ op: "ref.null.extern" } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: promiseTypeIdx } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: info.stateTypeIdx } as Instr);
+
+  // Return the frame as the async-gen object (externref carrier).
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  fctx.body.push({ op: "return" });
+  // Keep `rt` referenced (scheduler must be registered before the readers run).
+  void rt;
+}
+
+/**
+ * (#2906 slice 3d-i) Build + export the per-gen re-entrant driver
+ * `__async_gen_next_<name>(frame externref) -> Promise externref`: cast the
+ * carrier back to the typed frame, mint a fresh pending result promise, store it
+ * into `frame.result_promise`, kick the resume machine once, and return the
+ * promise. Exported so a direct-drive harness (the 3d-i self-proof) can advance
+ * the generator without the for-await consumer (3d-ii).
+ */
+function emitAsyncGenNextHelper(ctx: CodegenContext, info: AsyncFrameInfo, promiseTypeIdx: number): void {
+  const stem = sanitizeTypeName(info.functionName);
+  const name = `__async_gen_next_${stem}`;
+  if (ctx.funcMap.has(name)) return;
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], `${name}_type`);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set(name, funcIdx);
+  // Re-read the resume funcIdx by name — emitting the resume body may have added
+  // late imports that shifted defined indices (the shifter patches funcMap).
+  const resumeIdx = ctx.funcMap.get(`__async_resume_f${stem}`) ?? info.resumeFuncIdx!;
+  const frameRef: ValType = { kind: "ref", typeIdx: info.stateTypeIdx };
+  const promiseRef: ValType = { kind: "ref", typeIdx: promiseTypeIdx };
+  const fLocal = 1; // param 0 = carrier externref
+  const pLocal = 2;
+  const body: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: info.stateTypeIdx } as Instr,
+    { op: "local.set", index: fLocal },
+    // fresh pending result promise
+    { op: "i32.const", value: PROMISE_STATE_PENDING },
+    { op: "ref.null.extern" } as Instr,
+    { op: "ref.null.extern" } as Instr,
+    { op: "struct.new", typeIdx: promiseTypeIdx } as Instr,
+    { op: "local.set", index: pLocal },
+    // frame.result_promise = p
+    { op: "local.get", index: fLocal },
+    { op: "local.get", index: pLocal },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.resultPromiseFieldIdx } as Instr,
+    // kick the resume machine
+    { op: "local.get", index: fLocal },
+    { op: "call", funcIdx: resumeIdx },
+    // return p (as externref)
+    { op: "local.get", index: pLocal },
+    { op: "extern.convert_any" } as Instr,
+  ];
+  pushDefinedFunc(ctx, funcIdx, {
+    name,
+    typeIdx,
+    locals: [
+      { name: "$f", type: frameRef },
+      { name: "$p", type: promiseRef },
+    ],
+    body,
+    exported: false,
+  });
+  ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+}
+
+/**
+ * (#2906 slice 3d-i) Register + export the generic async-gen reader probes ONCE
+ * per module, letting a host-free direct-drive harness inspect a settled
+ * `next()`-promise's IteratorResult:
+ *   `__async_gen_p_state(p) -> i32`     — the promise state (0/1/2).
+ *   `__async_gen_result_done(p) -> i32` — the settled IteratorResult's `done`.
+ *   `__async_gen_result_value(p) -> f64`— the IteratorResult's numeric `value`.
+ * Both readers assume the promise is FULFILLED (drive + `__drain_microtasks`
+ * first, then check the state).
+ */
+function ensureAsyncGenReaderProbes(ctx: CodegenContext, promiseTypeIdx: number, resultTypeIdx: number): void {
+  if (ctx.funcMap.has("__async_gen_p_state")) return;
+  const unboxIdx = ctx.funcMap.get("__unbox_number");
+
+  const register = (name: string, result: ValType, body: Instr[]): void => {
+    const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [result], `${name}_type`);
+    const funcIdx = mintDefinedFunc(ctx);
+    ctx.funcMap.set(name, funcIdx);
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals: [], body, exported: false });
+    ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+  };
+
+  // promise → state (i32).
+  register("__async_gen_p_state", { kind: "i32" }, [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
+    { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 } as Instr, // state
+  ]);
+
+  // promise → (promise.value as IteratorResult).done (i32).
+  register("__async_gen_result_done", { kind: "i32" }, [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
+    { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 } as Instr, // value (IteratorResult, boxed)
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: resultTypeIdx } as Instr,
+    { op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_DONE_FIELD } as Instr,
+  ]);
+
+  // promise → unbox((promise.value as IteratorResult).value) (f64).
+  const valueBody: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
+    { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 } as Instr, // value (IteratorResult)
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: resultTypeIdx } as Instr,
+    { op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_VALUE_FIELD } as Instr, // element (boxed number)
+  ];
+  if (unboxIdx !== undefined) {
+    valueBody.push({ op: "call", funcIdx: unboxIdx });
+  } else {
+    valueBody.push({ op: "drop" }, { op: "f64.const", value: NaN });
+  }
+  register("__async_gen_result_value", { kind: "f64" }, valueBody);
 }

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -83,7 +83,7 @@ import {
 import { ensureI32Condition, resolveWasmType } from "./index.js";
 import { ensureExnTag } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
-import { coerceType, compileExpression, compileStatement, ensureLateImport } from "./shared.js";
+import { coerceType, compileExpression, compileStatement } from "./shared.js";
 import { resolveSpillLocalValType } from "./statements/variables.js";
 
 /**
@@ -1676,10 +1676,6 @@ export function emitAsyncGenerator(ctx: CodegenContext, fctx: FunctionContext, d
   const rt = ensureAsyncDriveRuntime(ctx);
   const promiseTypeIdx = getOrRegisterPromiseType(ctx);
   const resultTypeIdx = ensureNativeGeneratorResultType(ctx, { kind: "externref" });
-  // Ensure the number (un)boxers used by the yield-value box + reader probe are
-  // registered up-front — under wasi these resolve to DEFINED (host-free) funcs.
-  ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
-  ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
 
   const plan = analyzeAsyncBody(ctx, decl);
   const paramNames = fctx.params.map((p) => p.name);
@@ -1795,13 +1791,17 @@ function emitAsyncGenNextHelper(ctx: CodegenContext, info: AsyncFrameInfo, promi
  */
 function ensureAsyncGenReaderProbes(ctx: CodegenContext, promiseTypeIdx: number, resultTypeIdx: number): void {
   if (ctx.funcMap.has("__async_gen_p_state")) return;
-  const unboxIdx = ctx.funcMap.get("__unbox_number");
 
-  const register = (name: string, result: ValType, body: Instr[]): void => {
+  const register = (
+    name: string,
+    result: ValType,
+    body: Instr[],
+    locals: { name: string; type: ValType }[] = [],
+  ): void => {
     const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [result], `${name}_type`);
     const funcIdx = mintDefinedFunc(ctx);
     ctx.funcMap.set(name, funcIdx);
-    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals: [], body, exported: false });
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: false });
     ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
   };
 
@@ -1824,20 +1824,37 @@ function ensureAsyncGenReaderProbes(ctx: CodegenContext, promiseTypeIdx: number,
     { op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_DONE_FIELD } as Instr,
   ]);
 
-  // promise → unbox((promise.value as IteratorResult).value) (f64).
-  const valueBody: Instr[] = [
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" } as Instr,
-    { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
-    { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 } as Instr, // value (IteratorResult)
-    { op: "any.convert_extern" } as Instr,
-    { op: "ref.cast", typeIdx: resultTypeIdx } as Instr,
-    { op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_VALUE_FIELD } as Instr, // element (boxed number)
-  ];
-  if (unboxIdx !== undefined) {
-    valueBody.push({ op: "call", funcIdx: unboxIdx });
-  } else {
-    valueBody.push({ op: "drop" }, { op: "f64.const", value: NaN });
+  // promise → ToNumber((promise.value as IteratorResult).value) (f64). The
+  // externref→f64 unbox is routed through the single coercion engine
+  // (`coerceType`, #2108) rather than naming `__unbox_number` directly, so this
+  // probe adds no hand-rolled coercion vocabulary outside the engine.
+  const vfctx: FunctionContext = {
+    name: "__async_gen_result_value",
+    params: [{ name: "p", type: { kind: "externref" } }],
+    locals: [],
+    localMap: new Map([["p", 0]]),
+    returnType: { kind: "f64" },
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 } as Instr, // value (IteratorResult)
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.cast", typeIdx: resultTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_VALUE_FIELD } as Instr, // element (boxed number)
+    ],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+  const savedFunc = ctx.currentFunc;
+  ctx.currentFunc = vfctx;
+  try {
+    coerceType(ctx, vfctx, { kind: "externref" }, { kind: "f64" });
+  } finally {
+    ctx.currentFunc = savedFunc;
   }
-  register("__async_gen_result_value", { kind: "f64" }, valueBody);
+  register("__async_gen_result_value", { kind: "f64" }, vfctx.body, vfctx.locals);
 }

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -53,6 +53,7 @@ import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
 import { compileNativeGeneratorFunction } from "./generators-native.js";
 import { maybeActivateAsync } from "./async-activation.js";
+import { emitAsyncGenerator, isAsyncGenDriveCandidate } from "./async-frame.js";
 import {
   functionHasLinearU8Params,
   getLinearU8ParamIndicesForDeclaration,
@@ -1009,7 +1010,15 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
     );
   }
 
-  if (isGenerator) {
+  if (isGenerator && hasAsyncModifier(decl) && isAsyncGenDriveCandidate(ctx, decl)) {
+    // (#2906 slice 3d-i) Async-generator PRODUCER core. `async function* g(){
+    // yield await P; yield E }` routes through the generator-buffer path and
+    // fails at the #680 native-generator gate in standalone/wasi. Intercept a
+    // bounded async-gen body HERE — before that gate — and drive it host-free on
+    // the async-frame CFG machine (frame carrier + `__async_gen_next_<name>`).
+    // The generator returnType is already externref (the frame carrier).
+    emitAsyncGenerator(ctx, fctx, decl);
+  } else if (isGenerator) {
     const nativeGenerator = ctx.nativeGenerators.get(func.name);
     if (nativeGenerator) {
       compileNativeGeneratorFunction(ctx, fctx, decl, nativeGenerator);

--- a/tests/issue-2906-3di-asyncgen-producer.test.ts
+++ b/tests/issue-2906-3di-asyncgen-producer.test.ts
@@ -1,0 +1,150 @@
+// #2906 slice 3d-i — async-generator PRODUCER core (host-free drive).
+//
+// `async function* g(){ yield await P; yield E }` previously routed through the
+// generator-buffer path and failed at the #680 native-generator gate in
+// standalone/wasi — it never reached the async drive machine. Slice 3d-i
+// intercepts a BOUNDED async-gen body BEFORE that gate and drives it host-free on
+// the #2906 CFG resume machine with two new terminators:
+//   - `settleYield` — `yield E`: fulfil the current `next()`-promise with
+//     `{value: E, done: false}` and SUSPEND (no reaction; the next `next()` kick
+//     resumes). `yield await P` splits into a `suspend` on P (genuine microtask
+//     suspension) + a `settleYield` of the delivered value.
+//   - `settleDone` — body end: fulfil `{value: undefined, done: true}`.
+//
+// The producer object is the `$AsyncFrame` itself (a bare externref carrier — NO
+// prototype methods). The re-entrant driver is the per-gen
+// `__async_gen_next_<name>(frame) -> Promise<IteratorResult>` helper. This proves
+// the producer host-free via DIRECT drive (next-helper → __drain_microtasks →
+// read IteratorResult), WITHOUT the for-await consumer (3d-ii). Native (wasi)
+// drive lane only; gc/host + standalone stay byte-identical (legacy path).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface GenExports {
+  g: () => unknown;
+  __async_gen_next_g: (frame: unknown) => unknown;
+  __async_gen_p_state: (p: unknown) => number;
+  __async_gen_result_done: (p: unknown) => number;
+  __async_gen_result_value: (p: unknown) => number;
+  __drain_microtasks: () => void;
+}
+
+async function instantiateAsyncGen(src: string): Promise<GenExports> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // Host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as GenExports;
+}
+
+/** Drive one `next()`, drain microtasks, read the settled IteratorResult. */
+function step(ex: GenExports, frame: unknown): { pendingBeforeDrain: boolean; done: number; value: number } {
+  const p = ex.__async_gen_next_g(frame);
+  const pendingBeforeDrain = ex.__async_gen_p_state(p) === 0;
+  ex.__drain_microtasks();
+  expect(ex.__async_gen_p_state(p)).toBe(1); // FULFILLED
+  return { pendingBeforeDrain, done: ex.__async_gen_result_done(p), value: ex.__async_gen_result_value(p) };
+}
+
+describe("#2906 slice 3d-i — async-generator producer core", () => {
+  it("THE proof: async function* g(){ yield await P; yield 2 } drives host-free to 1, 2, done", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield await Promise.resolve(1);
+        yield 2;
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    expect([s1.done, s1.value]).toEqual([0, 1]); // {value: 1, done: false}
+    const s2 = step(ex, frame);
+    expect([s2.done, s2.value]).toEqual([0, 2]); // {value: 2, done: false}
+    const s3 = step(ex, frame);
+    expect(s3.done).toBe(1); // {value: undefined, done: true}
+  });
+
+  it("GENUINE suspension: a genuinely-pending awaited yield suspends at kick=0 and resumes on drain", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield await Promise.resolve(1).then((v: number) => v + 10);
+        yield await Promise.resolve(2).then((v: number) => v + 10);
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    expect(s1.pendingBeforeDrain).toBe(true); // suspended — value not present until the drain
+    expect([s1.done, s1.value]).toEqual([0, 11]);
+    const s2 = step(ex, frame);
+    expect(s2.pendingBeforeDrain).toBe(true);
+    expect([s2.done, s2.value]).toEqual([0, 12]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("plain (await-free) yields settle synchronously in sequence", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield 41;
+        yield 42;
+        yield 43;
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(41);
+    expect(step(ex, frame).value).toBe(42);
+    expect(step(ex, frame).value).toBe(43);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("LAZY: calling g() runs NO body code; the first next() produces the first yield", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield 7;
+        yield 8;
+      }
+    `);
+    const frame = ex.g();
+    // No next() yet → draining must not produce anything (body never ran).
+    ex.__drain_microtasks();
+    expect(step(ex, frame).value).toBe(7);
+  });
+
+  it("INJECT-THROW proof: a rejected awaited yield REJECTS the next() promise (suspend/reject arm exercised)", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield await Promise.reject(99);
+        yield 2;
+      }
+    `);
+    const frame = ex.g();
+    const p1 = ex.__async_gen_next_g(frame);
+    ex.__drain_microtasks();
+    expect(ex.__async_gen_p_state(p1)).toBe(2); // REJECTED — not vacuously fulfilled
+  });
+
+  it("params are captured in frame fields (no spill) and readable across yields", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(base: number): AsyncGenerator<number> {
+        yield base;
+        yield base;
+      }
+    `);
+    const frame = (ex.g as unknown as (b: number) => unknown)(100);
+    expect(step(ex, frame).value).toBe(100);
+    expect(step(ex, frame).value).toBe(100);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("byte-inert: gc + standalone lanes are unchanged (async gen stays on the legacy path)", async () => {
+    const src = `export async function* g(): AsyncGenerator<number> { yield await Promise.resolve(1); yield 2; }`;
+    // gc: compiles via the legacy __create_async_generator path (host imports).
+    const gc = await compile(src, { fileName: "test.ts" });
+    expect(gc.success).toBe(true);
+    expect((gc.imports ?? []).length).toBeGreaterThan(0); // legacy host-backed
+    // standalone (non-wasi): the native `$Promise` carrier is not active, so the
+    // drive is (correctly) NOT taken — stays on the legacy #680-gated path.
+    const standalone = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(standalone.success).toBe(false); // #680 native-generator gate (unchanged)
+  });
+});


### PR DESCRIPTION
## #2906 slice 3d-i — async-generator PRODUCER core (host-free)

Intercepts a **bounded async generator** — `async function* g(){ yield await P; yield E }` — BEFORE the #680 native-generator gate and drives it **host-free** on the existing #2906 CFG resume machine. This is the self-provable producer core the banked 3d contract (PR #2663) scheduled first; it de-risks the rest without needing the for-await consumer.

### What ships
Two new CFG terminators on the stock emitter (no ABI churn):
- **`settleYield`** — `yield E`: fulfil the current `next()`-promise `{value, done:false}` and **suspend** (no reaction registered; the next `next()` kick is the sole resumption driver). `yield await P` = stock `suspend(P)` + `settleYield(fromSent)` — the await is a genuine microtask suspension, the yield reads the delivered `SENT_FIELD`.
- **`settleDone`** — body end: fulfil `{value: undefined, done: true}`.

- `async-cps.ts`: `planAsyncGenCfg` + `isBoundedAsyncGenBody` + the terminators.
- `async-frame.ts`: `emitAsyncGenerator` (lazy `$AsyncFrame` carrier — a bare externref, **no prototype methods**, no kick) + per-gen `__async_gen_next_<name>` re-entrant driver (re-mints the result promise per call) + host-free reader probes; the `settleYield`/`settleDone` emit arms; `AsyncFrameInfo.asyncGen` switches the CFG to `planAsyncGenCfg`. Reuses `generators-native` IteratorResult struct (no frame-ABI fork).
- `function-body.ts`: routes bounded async gens to `emitAsyncGenerator`.

### Proof (host-free, `imports: []`)
`yield await Promise.resolve(1); yield 2` → `{1,false}`, `{2,false}`, `{undefined,true}` via `next()`-helper → `__drain_microtasks` → IteratorResult read. A **genuinely-pending** awaited yield suspends at kick (state=PENDING) and resumes on the drain. A **rejected** awaited yield rejects the `next()` promise (inject-throw proof — state=REJECTED, not vacuously fulfilled). Lazy: `g()` runs no body code.

### Byte-inertness (−16/−29 discipline)
15/15 program×lane sha256 hashes (plainAsync/multiAwait/forAwait/syncGen/plain × gc/standalone/wasi) **byte-identical to origin/main**. The async-gen program: gc + standalone byte-identical (standalone stays #680-gated — carrier-gated on `isStandalonePromiseActive`, wasi-only), only wasi changes (imports=0).

### Scope / bank
Flat `yield <E>` bodies, no own-locals/`yield*`/nested-yields (params OK). `next(v)`/`.throw()`/`.return()` + the concurrent-`next()` queue + prototype dispatch are **3d-ii** (the for-await consumer). Correct-or-legacy: anything outside the shape stays on the legacy gen path.

### Tests / blast radius
`tests/issue-2906-3di-asyncgen-producer.test.ts` (7 host-free wasi). Full async+generator suite: the only failures (gap3-tryfinally throw-path ×3, promise-combinators host ×2, issue-2865 AG0 wasi ×2, generator-yield-contexts fn-expr ×1, symbol-async-iterator for-await ×2) are **pre-existing on origin/main** (verified in a base worktree). `tsc --noEmit` clean.

**Unblocks** 3d-ii (`for await (x of g())` → [1,2]) + #2865 (standalone async-gen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8