### PR TITLE
fix(#3026): rest element/parameter must be last (element after rest)

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -164,3 +164,29 @@ fields all remain valid.
 **Remaining:** the module-code / `import.meta` / top-level-await
 unenforced-`SyntaxError` samples are independent point-fixes (several need module
 linking/resolution) — issue stays open for follow-up slices.
+
+## Slice 4 landed — "rest must be last" completion (element after rest) (2026-07-05)
+
+**Delivered:** three additional early errors completing the "rest must be last"
+grammar rule — Slice 1 caught the trailing-comma-after-rest forms; this slice
+adds the **element-after-rest** forms that TS drops as semantic diagnostics under
+`skipSemanticDiagnostics`:
+
+- **Object binding pattern:** `const {...rest, b} = y` — a `BindingRestProperty`
+  must be the final element.
+- **Object assignment pattern:** `({...rest, b} = y)` — an `AssignmentRestProperty`
+  must be last.
+- **Rest parameter not last:** `function f(a, ...b, c) {}` / `(a, ...b, c) => …`
+  — a `BindingRestElement` in a `FormalParameterList` must be last.
+
+Covers `language/expressions/assignment/dstr/obj-rest-not-last-element-invalid`,
+`language/statements/for-of/dstr/obj-rest-not-last-element-invalid`, and
+`language/rest-parameters/position-invalid` (5/5 affected pass; 120/120 valid
+function/param/destructuring files regression-checked, 0 regressions).
+
+**Files:** `src/compiler/early-errors/node-checks.ts` (object-binding
+element-after-rest + rest-parameter-not-last), `src/compiler/early-errors/assignment.ts`
+(object-assignment spread-not-last). Tests: `tests/issue-3026.test.ts` (+4 reject,
++3 valid-control; 30 total pass). Byte-inert for valid programs — object rest as
+last element, rest param as last param, and object spread in a value position
+(`{...x, b: 1}`) all remain valid.

--- a/src/compiler/early-errors/assignment.ts
+++ b/src/compiler/early-errors/assignment.ts
@@ -81,8 +81,14 @@ export function validateObjectAssignmentPattern(
   obj: ts.ObjectLiteralExpression,
   strict: boolean,
 ): void {
+  const lastProperty = obj.properties[obj.properties.length - 1];
   for (const prop of obj.properties) {
     if (ts.isSpreadAssignment(prop)) {
+      // AssignmentRestProperty (`...rest`) must be LAST — no property may follow
+      // it (`({...rest, b} = y)`). TS accepts spread-not-last silently, so flag it.
+      if (prop !== lastProperty) {
+        ctx.addError(prop, "Rest element must be last in a destructuring pattern");
+      }
       // Rest in object: { ...rest } = x — valid, but rest may not have computed
       validateAssignmentTarget(ctx, prop.expression, strict);
       continue;

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -592,9 +592,21 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
     }
   }
 
-  // ES spec: Trailing comma after an object binding rest is a SyntaxError.
-  // e.g. const {...x,} = y;  BindingRestProperty must be last, no trailing comma.
+  // ES spec: an object binding rest (`{...x}`) must be last — no element may
+  // follow it (`const {...rest, b} = y`) and no trailing comma (`{...x,}`).
+  // BindingRestProperty must be the final BindingProperty. TS's parser accepts
+  // both forms silently under skipSemanticDiagnostics, so detect them here.
   if (ts.isObjectBindingPattern(node)) {
+    let foundRest = false;
+    for (const element of node.elements) {
+      if (foundRest) {
+        ctx.addError(element, "A rest element must be last in a destructuring pattern");
+        break;
+      }
+      if (ts.isBindingElement(element) && element.dotDotDotToken) {
+        foundRest = true;
+      }
+    }
     const lastEl = node.elements[node.elements.length - 1];
     if (node.elements.hasTrailingComma && lastEl && ts.isBindingElement(lastEl) && lastEl.dotDotDotToken) {
       ctx.addError(lastEl, "A rest element must be last in a destructuring pattern");
@@ -624,6 +636,15 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
       const textBetween = ctx.sourceFile.text.substring(paramEnd, parenClose);
       if (textBetween.includes(",")) {
         ctx.addError(lastParam, "A rest parameter or binding pattern may not have a trailing comma");
+      }
+    }
+    // ES spec: a rest parameter (`...b`) must be the LAST parameter — no
+    // parameter may follow it (`function f(a, ...b, c) {}`). TS drops this as a
+    // semantic diagnostic under skipSemanticDiagnostics, so re-detect it.
+    for (let i = 0; i < node.parameters.length - 1; i++) {
+      if (node.parameters[i]!.dotDotDotToken) {
+        ctx.addError(node.parameters[i]!, "A rest parameter must be last in a parameter list");
+        break;
       }
     }
   }

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -158,3 +158,43 @@ describe("#3026 — private name in class heritage / destructuring pattern", () 
     ).toBe(false);
   });
 });
+
+// Slice 4 — "rest must be last" completion: an element following a rest is a
+// SyntaxError. Slice 1 caught the trailing-comma-after-rest cases; this slice
+// adds the element-after-rest cases that TS's parser drops as semantic
+// diagnostics under skipSemanticDiagnostics:
+//   - object binding pattern:   const {...rest, b} = y
+//   - object assignment pattern: ({...rest, b} = y)
+//   - rest parameter not last:   function f(a, ...b, c) {}  /  (a, ...b, c) => 0
+// Covers test262 language/expressions/assignment/dstr/obj-rest-not-last-element-invalid,
+// language/statements/for-of/dstr/obj-rest-not-last-element-invalid, language/rest-parameters/position-invalid.
+describe("#3026 — rest element / parameter must be last (element after rest)", () => {
+  it("rejects an object binding rest followed by an element (`const {...rest, b} = y`)", async () => {
+    expect(await isRejected("const {...rest, b} = {};")).toBe(true);
+  });
+
+  it("rejects an object assignment rest followed by an element (`({...rest, b} = y)`)", async () => {
+    expect(await isRejected("var rest, b; 0, ({...rest, b} = {});")).toBe(true);
+  });
+
+  it("rejects a rest parameter that is not last (`function f(a, ...b, c) {}`)", async () => {
+    expect(await isRejected("function f(a, ...b, c) {}")).toBe(true);
+  });
+
+  it("rejects a non-last rest parameter in an arrow function (`(a, ...b, c) => a`)", async () => {
+    expect(await isRejected("const g = (a: any, ...b: any[], c: any) => a;")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts an object rest as the last element (`const {a, ...rest} = o`)", async () => {
+    expect(await isRejected("const {a, ...rest} = {a: 1};")).toBe(false);
+  });
+
+  it("accepts a rest parameter as the last parameter (`function f(a, ...b)`)", async () => {
+    expect(await isRejected("function f(a: any, ...b: any[]) { return b; }")).toBe(false);
+  });
+
+  it("accepts an object spread in a value position (`const o = {...x, b: 1}`)", async () => {
+    expect(await isRejected("const x = {}; const o = {...x, b: 1};")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 4 of #3026 (`negative_test_fail` early-error residual). Completes the "rest must be last" grammar rule — Slice 1 caught trailing-comma-after-rest; this slice adds the **element-after-rest** forms that TypeScript drops as semantic diagnostics under `skipSemanticDiagnostics` (the test262 harness mode):

- **Object binding pattern:** `const {...rest, b} = y` — `BindingRestProperty` must be the final element.
- **Object assignment pattern:** `({...rest, b} = y)` — `AssignmentRestProperty` must be last.
- **Rest parameter not last:** `function f(a, ...b, c) {}` / `(a, ...b, c) => …` — a rest parameter must be the last in the list.

## Validation

- Covers test262 `language/expressions/assignment/dstr/obj-rest-not-last-element-invalid`, `language/statements/for-of/dstr/obj-rest-not-last-element-invalid`, `language/rest-parameters/position-invalid` — 5/5 affected pass.
- **0 regressions** across 120 valid function/param/destructuring test262 files.
- `tests/issue-3026.test.ts`: +4 reject + 3 valid-control cases (30 total pass). Byte-inert for valid programs — object rest as last element, rest param as last param, and object spread in a value position (`{...x, b: 1}`) all remain valid.
- `tsc --noEmit` + `biome lint` clean.

**Files:** `src/compiler/early-errors/node-checks.ts` (object-binding element-after-rest + rest-param-not-last), `src/compiler/early-errors/assignment.ts` (object-assignment spread-not-last). Issue stays open (module-code / import.meta samples remain as follow-up slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS