### PR TITLE
fix(landing): neutralize the warning badge on headline-only feature cards

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1428,6 +1428,13 @@
         color: #f87171;
       }
 
+      /* No isolated test262 metric for this feature (e.g. core language
+         features with no dedicated `features:` tag). Shown as a calm neutral
+         mark instead of a bare ⚠, which read as a broken/loading warning. */
+      .feat-badge.nodata {
+        color: rgba(255, 255, 255, 0.32);
+      }
+
       /* #1583 — explicit pass-rate percentage rendered next to a static
          `✓ full` badge when the live test262 pass rate is below 95%.
          Stays inside the 30px badge column by stacking under the glyph. */
@@ -5562,7 +5569,10 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           if (!badge) return 0;
           if (usesHost && !hostEnabled) return 0;
           if (badge.classList.contains("full")) return 1;
-          if (badge.classList.contains("partial")) return 0.5;
+          // `nodata` = a headline-only feature whose ⚠ was neutralized (no
+          // isolated test262 metric); score it like the `partial` it was so
+          // the edition passbar aggregate is unchanged by the cosmetic re-skin.
+          if (badge.classList.contains("partial") || badge.classList.contains("nodata")) return 0.5;
           return 0;
         };
 
@@ -5827,11 +5837,26 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           const badge = row.querySelector(".feat-badge");
 
           if (total <= 0) {
-            // No measurable test262 data — keep the static badge but flag
-            // the row so the gap is visible (and auditable) rather than a
-            // misleading auto-derived status.
+            // No measurable test262 data — flag the row so the gap is visible
+            // (and auditable) rather than a misleading auto-derived status.
             row.dataset.noT262Data = "";
             if (badge && paths.length === 0) row.dataset.noT262Category = "";
+            // A `partial` (⚠) badge with no measurable data reads as a broken
+            // or still-loading warning (the yellow sign with no percentage).
+            // Downgrade it to a neutral "not individually measured" mark.
+            // Author-set ✓ (full) and ✗ (none) badges are unambiguous and stay.
+            if (badge instanceof HTMLElement && badge.classList.contains("partial")) {
+              badge.classList.remove("partial");
+              badge.classList.add("nodata");
+              badge.dataset.glyph = "–";
+              const firstChild = badge.firstChild;
+              if (firstChild && firstChild.nodeType === Node.TEXT_NODE) {
+                firstChild.textContent = "–";
+              } else {
+                badge.insertBefore(document.createTextNode("–"), badge.firstChild);
+              }
+              badge.title = "No isolated test262 subset scores this feature individually.";
+            }
           } else {
             const ratio = pass / total;
             const tone = toneFor(ratio);


### PR DESCRIPTION
## Summary
Fixes the landing feature cards that showed a bare yellow ⚠ with no percentage or test numbers.

**Root cause (not a data bug — a rendering one):** Two mechanisms feed those cards. `testCategories` (the test paths + "View results" link) are path-indexed and populated for 37 of the 40 blank features. But `passCount`/`totalCount` are computed *separately* by `generate-editions.ts` via a **tag-based** map (`feature-t262-features.json`). Fundamentals that predate test262 `features:` tags (Operators, typeof, delete, Comma operator, …) aren't in that tag map, so per #2910 they're **intentionally set to 0/0 as "headline-only"** (counted in the section aggregate, not shown as a per-row number, to avoid phantom path-glob counts). The bug is only that the landing still rendered their static ⚠ (partial) badge → a warning with no numbers, which reads as broken/loading.

**Fix (pure visual):** for no-data rows, downgrade the ⚠ to a neutral "not individually measured" mark (`–`, muted grey). Author-set ✓/✗ badges are unambiguous and untouched. The edition-passbar `scoreRow` treats the new `nodata` state exactly like the `partial` it replaced (0.5), so all aggregates are unchanged. No counter/data change — the 0/0 stays by design.

## Test plan
- [x] Local serve (landing 200); edits: `.feat-badge.nodata` CSS, no-data neutralize in the `total<=0` branch, `scoreRow` preserves 0.5
- [ ] After deploy: the ~21 previously-⚠ headline-only cards (Operators, typeof, delete, …) show a calm neutral mark instead of a yellow warning; ✓/✗ cards unchanged; edition passbars unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)