### PR TITLE
fix(#3026): duplicate binding name within a destructuring parameter

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -190,3 +190,28 @@ element-after-rest + rest-parameter-not-last), `src/compiler/early-errors/assign
 +3 valid-control; 30 total pass). Byte-inert for valid programs — object rest as
 last element, rest param as last param, and object spread in a value position
 (`{...x, b: 1}`) all remain valid.
+
+## Slice 5 landed — duplicate binding name within a destructuring parameter (2026-07-05)
+
+**Delivered:** an early error for a parameter list that binds the same name twice
+via a destructuring pattern — `BoundNames` of a `FormalParameterList` /
+`ArrowFormalParameters` must contain no duplicates. The pre-existing
+`checkDuplicateParams` caught INTER-parameter duplicates (`(x, x) => …`) but
+collapsed INTRA-parameter duplicates that a single destructuring parameter binds
+more than once (`([x, x]) => …`, `({y: x, x}) => …`) — a plain `Set` deduped
+`[x, x]` down to one `x`, so the duplicate was lost.
+
+**Root cause:** `collectBindingNames` accumulated each parameter's bound names
+into a fresh `Set`, which cannot represent an intra-pattern duplicate. Switched to
+the existing `collectBindingNamesWithDuplicateCheck(name, seen, dupes)` collector
+with a single `seen` set shared across all parameters — it flags both intra- and
+inter-parameter duplicates. Covers `language/expressions/arrow-function/syntax/early-errors/arrowparameters-cover-no-duplicates-{binding-array,binding-object}-*`
+(2/2 affected pass; 130/130 valid arrow/param/destructuring files regression-checked,
+0 regressions).
+
+**Files:** `src/compiler/early-errors/duplicates.ts` (`checkDuplicateParams`).
+Tests: `tests/issue-3026.test.ts` (+4 reject, +3 valid-control; 37 total pass).
+Byte-inert for valid programs — distinct names in a destructuring parameter, and
+the same name reused across two SEPARATE (non-parameter) destructuring bindings,
+all remain valid; sloppy-mode simple-parameter duplicates (`function f(x, x) {}`,
+still legal) are unaffected (the non-simple / arrow / strict gate is unchanged).

--- a/src/compiler/early-errors/duplicates.ts
+++ b/src/compiler/early-errors/duplicates.ts
@@ -8,7 +8,7 @@
 import { ts, forEachChild } from "../../ts-api.js";
 import type { EarlyErrorContext } from "./context.js";
 import {
-  collectBindingNames,
+  collectBindingNamesWithDuplicateCheck,
   collectSwitchClauseLexicalNames,
   collectStatementListBoundNames,
   findNameReference,
@@ -37,15 +37,18 @@ export function checkDuplicateParams(
       (node.asteriskToken !== undefined || node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword))) ||
     params.some((p) => p.initializer !== undefined || p.dotDotDotToken !== undefined || !ts.isIdentifier(p.name));
   if (!alwaysForbid && !isStrictMode(node)) return;
+  // `seen` is shared across every parameter so an INTER-param duplicate
+  // (`(x, x) => …`) is caught; `collectBindingNamesWithDuplicateCheck` also
+  // records INTRA-param duplicates that a single destructuring parameter binds
+  // more than once (`([x, x]) => …`, `({y: x, x}) => …`) — a plain Set collapses
+  // those, which is why the previous per-param Set missed them. BoundNames of a
+  // FormalParameterList / ArrowFormalParameters must contain no duplicates.
   const seen = new Set<string>();
   for (const param of params) {
-    const names = new Set<string>();
-    collectBindingNames(param.name, names);
-    for (const name of names) {
-      if (seen.has(name)) {
-        ctx.addError(param, `Duplicate parameter name '${name}' not allowed`);
-      }
-      seen.add(name);
+    const dupes = new Set<string>();
+    collectBindingNamesWithDuplicateCheck(param.name, seen, dupes);
+    for (const name of dupes) {
+      ctx.addError(param, `Duplicate parameter name '${name}' not allowed`);
     }
   }
 }

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -198,3 +198,42 @@ describe("#3026 — rest element / parameter must be last (element after rest)",
     expect(await isRejected("const x = {}; const o = {...x, b: 1};")).toBe(false);
   });
 });
+
+// Slice 5 — early error: a parameter list with a non-simple (destructuring /
+// default / rest) parameter, or any arrow/method/strict function, may not bind
+// the same name twice. BoundNames of the FormalParameterList must contain no
+// duplicates. The pre-existing check caught INTER-parameter duplicates
+// (`(x, x) => …`) but collapsed INTRA-parameter duplicates that a single
+// destructuring pattern binds twice — a plain Set deduped `([x, x])` down to one
+// `x`. Now uses the duplicate-aware collector so both are caught. Covers test262
+// language/expressions/arrow-function/syntax/early-errors/arrowparameters-cover-no-duplicates-*.
+describe("#3026 — duplicate binding names within a destructuring parameter", () => {
+  it("rejects a duplicate name in an array-pattern arrow parameter (`([x, x]) => 1`)", async () => {
+    expect(await isRejected("var af = ([x, x]) => 1;")).toBe(true);
+  });
+
+  it("rejects a duplicate name in an object-pattern arrow parameter (`({y: x, x}) => 1`)", async () => {
+    expect(await isRejected("var af = ({y: x, x}) => 1;")).toBe(true);
+  });
+
+  it("rejects a duplicate name in a destructuring function parameter (`function f([x, x]) {}`)", async () => {
+    expect(await isRejected("function f([x, x]) { return 1; }")).toBe(true);
+  });
+
+  it("rejects a duplicate across a simple + destructuring parameter (`function f(x, [x]) {}`)", async () => {
+    expect(await isRejected("function f(x, [x]) { return 1; }")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts distinct names in an array-pattern arrow parameter (`([x, y]) => x + y`)", async () => {
+    expect(await isRejected("var af = ([x, y]: any[]) => x + y;")).toBe(false);
+  });
+
+  it("accepts distinct names in an object-pattern arrow parameter (`({y, x}) => x`)", async () => {
+    expect(await isRejected("var af = ({y, x}: any) => x;")).toBe(false);
+  });
+
+  it("accepts the same name across two separate destructuring bindings (not params)", async () => {
+    expect(await isRejected("const [a] = [1]; const {a: b} = {a: 2}; void b;")).toBe(false);
+  });
+});


### PR DESCRIPTION
Slice 5 of the #3026 negative_test_fail early-error residual lane.

## What

BoundNames of a `FormalParameterList` / `ArrowFormalParameters` must contain no duplicates. `checkDuplicateParams` caught **inter**-param duplicates (`(x, x) => …`) but collapsed **intra**-param duplicates that a single destructuring parameter binds twice (`([x, x]) => …`, `({y: x, x}) => …`) — a plain `Set` deduped `[x, x]` to one `x`, losing the duplicate.

## Fix

Use the existing `collectBindingNamesWithDuplicateCheck(name, seen, dupes)` collector with a single `seen` set shared across parameters — flags both intra- and inter-parameter duplicates. One file: `src/compiler/early-errors/duplicates.ts`.

## Coverage / safety

- Covers test262 `arrow-function/syntax/early-errors/arrowparameters-cover-no-duplicates-*` (2/2 affected pass).
- 130/130 valid arrow/param/destructuring files regression-checked, 0 regressions.
- Byte-inert for valid programs: the change is additive to the duplicate-detection error path only — for a valid program `dupes` is empty, no diagnostic is added, codegen proceeds identically. Valid controls in `tests/issue-3026.test.ts` confirm valid programs still compile (37/37 pass).
- `(function f(x, x) {})` (sloppy-mode duplicate simple params, still legal) unaffected.

## Handoff note

Picked up from dev-3022 (hit model limit); its commit e10c9d3 is preserved. This PR is that commit merged up to current `origin/main` (clean merge, diff scoped to slice 5 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS