### PR TITLE
fix(#3026): early error for more than one default clause in a switch

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -190,3 +190,29 @@ element-after-rest + rest-parameter-not-last), `src/compiler/early-errors/assign
 +3 valid-control; 30 total pass). Byte-inert for valid programs — object rest as
 last element, rest param as last param, and object spread in a value position
 (`{...x, b: 1}`) all remain valid.
+
+## Slice 6 landed — at most one `default` clause in a switch (2026-07-05)
+
+**Delivered:** an early error for a switch statement whose `CaseBlock` contains
+more than one `DefaultClause`. ES `CaseBlock : { CaseClauses_opt DefaultClause
+CaseClauses_opt }` Static Semantics: Early Errors — it is a Syntax Error if a
+CaseBlock contains more than one `DefaultClause`. Covers test262
+`language/statements/switch/S12.11_A2_T1.js`.
+
+**Root cause:** TypeScript's parser accepts a second `default:` clause with no
+diagnostic (it parses two `DefaultClause` nodes into the same `CaseBlock`), so
+nothing in the early-error pass detected it. The fix adds
+`checkDuplicateDefaultClause` — a linear scan of `caseBlock.clauses` that flags
+the second and any later `DefaultClause` — wired into the existing
+`ts.isCaseBlock(node)` branch of the per-node walk (so it fires for nested
+switches too).
+
+**Files:** `src/compiler/early-errors/duplicates.ts` (new
+`checkDuplicateDefaultClause`), `src/compiler/early-errors/node-checks.ts` (import
+
+- one call in the `CaseBlock` branch). Tests: `tests/issue-3026.test.ts` (+3
+  reject, +4 valid-control). Byte-inert for valid programs — verified: a switch
+  with a single default, no default, a default-before-cases, a nested switch, and
+  fallthrough all compile to byte-identical Wasm (sha256-compared against the
+  pre-change compiler); only a switch with two-or-more default clauses newly
+  raises the early SyntaxError.

--- a/src/compiler/early-errors/duplicates.ts
+++ b/src/compiler/early-errors/duplicates.ts
@@ -86,6 +86,27 @@ export function checkDuplicateLexicalDeclarations(ctx: EarlyErrorContext, block:
   }
 }
 
+/**
+ * A switch CaseBlock may contain at most one DefaultClause. ES2015+
+ * (`SwitchStatement` → `CaseBlock`) Static Semantics: Early Errors —
+ * `CaseBlock : { CaseClauses_opt DefaultClause CaseClauses_opt }` — it is a
+ * Syntax Error if a CaseBlock contains more than one DefaultClause. TypeScript's
+ * parser accepts a second `default:` clause with no diagnostic, so nothing else
+ * detects it. Covers test262 `language/statements/switch/S12.11_A2_T1.js`.
+ */
+export function checkDuplicateDefaultClause(ctx: EarlyErrorContext, caseBlock: ts.CaseBlock): void {
+  let seenDefault = false;
+  for (const clause of caseBlock.clauses) {
+    if (ts.isDefaultClause(clause)) {
+      if (seenDefault) {
+        ctx.addError(clause, "More than one default clause in switch statement");
+      } else {
+        seenDefault = true;
+      }
+    }
+  }
+}
+
 /** Check duplicate lexical declarations across switch case clauses. */
 export function checkSwitchCaseLexicalDuplicates(ctx: EarlyErrorContext, caseBlock: ts.CaseBlock): void {
   const lexNames = new Map<string, ts.Node>(); // name -> first declaration

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -37,6 +37,7 @@ import {
 } from "./predicates.js";
 import { validateArrayAssignmentPattern, validateObjectAssignmentPattern } from "./assignment.js";
 import {
+  checkDuplicateDefaultClause,
   checkDuplicateLexicalDeclarations,
   checkDuplicateParams,
   checkDuplicatePrivateNames,
@@ -915,6 +916,7 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
   // contains any duplicate entries.
   if (ts.isCaseBlock(node)) {
     checkSwitchCaseLexicalDuplicates(ctx, node);
+    checkDuplicateDefaultClause(ctx, node);
   }
 
   // ── Class body: static prototype method/field ─────────────────────

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -198,3 +198,50 @@ describe("#3026 — rest element / parameter must be last (element after rest)",
     expect(await isRejected("const x = {}; const o = {...x, b: 1};")).toBe(false);
   });
 });
+
+describe("#3026 — at most one default clause in a switch", () => {
+  // ES CaseBlock : { CaseClauses_opt DefaultClause CaseClauses_opt } — a
+  // SyntaxError if a CaseBlock contains more than one DefaultClause. TypeScript's
+  // parser accepts a second `default:` silently. Covers test262
+  // language/statements/switch/S12.11_A2_T1.js.
+  it("rejects two default clauses in one switch", async () => {
+    expect(await isRejected("switch (0) { case 1: break; default: break; default: break; }")).toBe(true);
+  });
+
+  it("rejects two default clauses inside a function body", async () => {
+    expect(
+      await isRejected("function f(v: number) { switch (v) { default: return 1; default: return 2; } } f(0);"),
+    ).toBe(true);
+  });
+
+  it("rejects adjacent duplicate default clauses", async () => {
+    expect(await isRejected("switch (0) { default: default: }")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts a switch with a single default clause", async () => {
+    expect(
+      await isRejected("function f(v: number) { switch (v) { case 0: return 1; default: return 2; } } f(0);"),
+    ).toBe(false);
+  });
+
+  it("accepts a switch with no default clause", async () => {
+    expect(
+      await isRejected("function f(v: number) { switch (v) { case 0: return 1; case 1: return 2; } return 0; } f(0);"),
+    ).toBe(false);
+  });
+
+  it("accepts a default clause before case clauses (single default)", async () => {
+    expect(
+      await isRejected("function f(v: number) { switch (v) { default: return 9; case 0: return 1; } } f(0);"),
+    ).toBe(false);
+  });
+
+  it("accepts separate switches that each have their own default", async () => {
+    expect(
+      await isRejected(
+        "function f(v: number) { switch (v) { default: break; } switch (v) { default: break; } return 1; } f(0);",
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Slice 6 of the #3026 negative_test_fail early-error residual lane.

## What

A switch `CaseBlock : { CaseClauses_opt DefaultClause CaseClauses_opt }` may contain **at most one** `DefaultClause` (Static Semantics: Early Errors — Syntax Error if more than one). TypeScript's parser accepts a second `default:` clause with no diagnostic (it parses two `DefaultClause` nodes into the same `CaseBlock`), so nothing in the early-error pass detected it.

## Fix

New `checkDuplicateDefaultClause` linearly scans `caseBlock.clauses` and flags the second and any later `DefaultClause`, wired into the existing `ts.isCaseBlock(node)` branch of the per-node walk (so it fires for nested switches too). Two files: `src/compiler/early-errors/duplicates.ts` (new function) and `node-checks.ts` (import + one call).

## Coverage / safety

- Covers test262 `language/statements/switch/S12.11_A2_T1.js` (duplicate `default`).
- **Byte-inert for valid programs — verified via sha256**: a switch with a single default, no default, default-before-cases, a nested switch, and fallthrough all compile to byte-identical Wasm against the pre-change compiler; only a switch with two-or-more default clauses newly raises the early SyntaxError.
- Tests: `tests/issue-3026.test.ts` (+3 reject, +4 valid-control). Typecheck clean.

## Lane context

Continues dev-3022's early-error slices (3/4/5). Independent of slice 5 (PR #2672, in flight) — that touches destructuring-param duplicates, this touches switch default clauses; no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS