### PR TITLE
fix(#3026): early error for a line terminator between throw and its operand

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -215,3 +215,26 @@ Byte-inert for valid programs — distinct names in a destructuring parameter, a
 the same name reused across two SEPARATE (non-parameter) destructuring bindings,
 all remain valid; sloppy-mode simple-parameter duplicates (`function f(x, x) {}`,
 still legal) are unaffected (the non-simple / arrow / strict gate is unchanged).
+
+## Slice 7 landed — no line terminator between `throw` and its expression (2026-07-05)
+
+**Delivered:** an early error for the restricted production `ThrowStatement :
+throw [no LineTerminator here] Expression ;`. A LineTerminator right after
+`throw` triggers ASI, which would leave `throw;` (no operand) — a SyntaxError.
+Covers test262 `language/asi/S7.9_A4.js`.
+
+**Root cause:** unlike `return` / `break` / `continue` (where ASI produces a
+valid statement), TypeScript's parser silently reparses the expression after the
+newline as its own statement and synthesizes a **zero-width (missing)** throw
+operand, emitting no diagnostic — so nothing in the early-error pass detected it.
+The fix flags any `ThrowStatement` whose `expression` has `getFullWidth() === 0`
+(a missing operand). This also covers a bare `throw;` with no operand at all.
+
+**Files:** `src/compiler/early-errors/node-checks.ts` (one additive check in the
+per-node walk). Tests: `tests/issue-3026.test.ts` (+3 reject, +3 valid-control).
+Byte-inert for valid programs — verified via sha256: `throw <expr>` on the same
+line (including a `throw` whose operand itself wraps across lines, e.g.
+`throw new Error(\n …)`, and a `throw` inside a switch case) all compile to
+byte-identical Wasm against the pre-change compiler; only a `throw` with a
+missing operand (newline immediately after `throw`, or bare `throw;`) newly
+raises the early SyntaxError.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -917,6 +917,21 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
     checkSwitchCaseLexicalDuplicates(ctx, node);
   }
 
+  // ── throw [no LineTerminator here] Expression ─────────────────────
+  // ES spec: ThrowStatement : throw [no LineTerminator here] Expression ;
+  // `throw` requires an Expression on the SAME line. A LineTerminator right
+  // after `throw` triggers ASI — which would leave `throw;` (no operand), a
+  // SyntaxError — after which TS reparses the trailing expression as its own
+  // statement and synthesizes a zero-width (missing) throw operand. A bare
+  // `throw;` with no operand at all produces the same missing node. Either way,
+  // a ThrowStatement whose Expression is missing (zero width) is an early error;
+  // a valid `throw <expr>` always has a non-empty operand, even when the
+  // expression itself wraps across lines (`throw new Error(\n …)`). Covers
+  // test262 language/asi/S7.9_A4.js.
+  if (ts.isThrowStatement(node) && node.expression.getFullWidth() === 0) {
+    ctx.addError(node, "Illegal newline after throw / missing throw operand");
+  }
+
   // ── Class body: static prototype method/field ─────────────────────
   // ES spec: It is a SyntaxError if the PropName of a static method or
   // field is "prototype".

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -237,3 +237,37 @@ describe("#3026 — duplicate binding names within a destructuring parameter", (
     expect(await isRejected("const [a] = [1]; const {a: b} = {a: 2}; void b;")).toBe(false);
   });
 });
+
+// Slice 7 — restricted production: `throw [no LineTerminator here] Expression`.
+// A LineTerminator right after `throw` triggers ASI, leaving `throw;` (no
+// operand) — a SyntaxError. TypeScript reparses the trailing expression as its
+// own statement and synthesizes a zero-width (missing) throw operand, emitting no
+// diagnostic, so nothing detected it. Covers test262 language/asi/S7.9_A4.js.
+describe("#3026 — no line terminator between `throw` and its expression", () => {
+  it("rejects a newline immediately after `throw` (`throw\\n 1`)", async () => {
+    expect(await isRejected("try { throw\n 1; } catch (e) {}")).toBe(true);
+  });
+
+  it("rejects a CRLF after `throw`", async () => {
+    expect(await isRejected("try { throw\r\n new Error('x'); } catch (e) {}")).toBe(true);
+  });
+
+  it("rejects a comment-then-newline after `throw`", async () => {
+    expect(await isRejected("try { throw /* c */\n 1; } catch (e) {}")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts `throw` with its expression on the same line", async () => {
+    expect(await isRejected("function f(x: number) { if (x < 0) throw new Error('neg'); return x; } f(1);")).toBe(
+      false,
+    );
+  });
+
+  it("accepts `throw <string>` on the same line", async () => {
+    expect(await isRejected("function h(b: boolean) { if (b) throw 'bad'; return 1; } h(false);")).toBe(false);
+  });
+
+  it("accepts a `throw` whose expression wraps across lines (newline inside the operand)", async () => {
+    expect(await isRejected("function w() { throw new Error(\n  'multi'\n); } try { w(); } catch (e) {}")).toBe(false);
+  });
+});


### PR DESCRIPTION
Slice 7 of the #3026 negative_test_fail early-error residual lane.

## What

Restricted production `ThrowStatement : throw [no LineTerminator here] Expression ;`. A LineTerminator immediately after `throw` triggers ASI, which would leave `throw;` (no operand) — a SyntaxError.

## Root cause

Unlike `return` / `break` / `continue` (where ASI produces a *valid* statement), TypeScript's parser silently reparses the expression after the newline as its own statement and synthesizes a **zero-width (missing)** throw operand, emitting no diagnostic — so nothing in the early-error pass detected it.

## Fix

Flag any `ThrowStatement` whose `expression` has `getFullWidth() === 0` (a missing operand). This also correctly covers a bare `throw;` with no operand. One additive check in the per-node walk (`src/compiler/early-errors/node-checks.ts`). Covers test262 `language/asi/S7.9_A4.js`.

## Coverage / safety

- **Byte-inert for valid programs — verified via sha256**: `throw <expr>` on the same line (including a `throw` whose operand itself wraps across lines, e.g. `throw new Error(\n …)`, and a `throw` inside a switch case) all compile to byte-identical Wasm against the pre-change compiler; only a `throw` with a missing operand (newline right after `throw`, or bare `throw;`) newly raises the early SyntaxError.
- Tests: `tests/issue-3026.test.ts` (+3 reject, +3 valid-control; 43 total pass). Typecheck clean.

## Lane context

Continues the early-error slices (5 merged, 6 in flight #2673). Independent of slices 5/6 (touches only `node-checks.ts` throw handling). Will re-merge main once #2673 lands (trivial append-conflict in the test/issue files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS