### PR TITLE
fix(#3027): standalone computed string property/method access dispatch

### DIFF
--- a/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
+++ b/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
@@ -78,13 +78,23 @@ single fix flips directly.
 
 ### Not-yet-issued follow-ons (tracked here)
 
-- **$Object dynamic-object-property reader** (`__extern_get`/`__extern_rest_object`
-  leak) — now filed as **[#3027](3027-standalone-dynamic-object-property-reader-residual.md)**
-  (2026-07-03 harvest re-measurement, post #2861/#2863 landing: residual is
-  **1,552**, larger than the original ~669 estimate). The known substrate root
-  (`project_standalone_any_string_value_read_substrate`). Heavily overlapped
-  clusters 2/3 — #2861 and #2863 are both `done`; #3027 is the promised
-  post-landing re-measurement.
+- **$Object dynamic-object-property reader** — **[#3027](3027-standalone-dynamic-object-property-reader-residual.md)
+  is `done` (2026-07-05)**, superseding this note. Re-measurement found the
+  originally-hypothesized root cause
+  (`project_standalone_any_string_value_read_substrate`, the dynamic `any`
+  reader dropping native-string VALUES) was already fixed by #2861/#2863 — it
+  is NOT why the residual read 1,552. That residual is a **heterogeneous
+  long tail**, not one root cause: TypedArray(Constructors) internals/
+  prototype (~350), `Temporal` (~230+, a whole deferred feature area, not a
+  codegen bug), `Object.getOwnPropertyDescriptor` (124, itself 3 unrelated
+  shapes — built-in/global descriptors, `ToPropertyKey` coercion, array-
+  element descriptors), the already-tracked eval/Function-shim gaps
+  (#3005/#3017), and many smaller one-off gaps. #3027 fixed the one
+  genuinely-addressable codegen bug found during the trace (computed/
+  bracket string property+method access never dispatching to the native
+  string engine in `--nativeStrings` mode — ~5-9 tests) and recommends the
+  PO/tech-lead triage the remaining clusters into separately-sized follow-on
+  issues (TypedArray internals, ~350, is the next-largest single slice).
 - **spread / `Array.from(iter, n)`** (`__array_from_iter_n`) — ~321 tests.
   Depends on the iterator-protocol carrier (#2864).
 - **Namespace static reads** (`Math.PI`, `JSON.stringify`, `Reflect.get`,

--- a/plan/issues/3027-standalone-dynamic-object-property-reader-residual.md
+++ b/plan/issues/3027-standalone-dynamic-object-property-reader-residual.md
@@ -1,10 +1,12 @@
 ---
 id: 3027
 title: "standalone: \\$Object dynamic-object-property reader residual — null/undefined property access on unmodeled shapes (~1,552 host-free fails)"
-status: ready
+status: done
+assignee: ttraenkler/dev-3027
 sprint: current
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-05
+completed: 2026-07-05
 priority: high
 horizon: l
 feasibility: hard
@@ -71,3 +73,142 @@ own tracked issue rather than an umbrella footnote.
   count in the standalone lane drops materially below 1,552.
 - The umbrella #2860's "not-yet-issued follow-on" note is updated/removed
   once this issue supersedes it.
+
+## Investigation (2026-07-05)
+
+Re-measured against `.test262-cache/test262-standalone-current.jsonl`
+(fetched fresh this session) following the "Suggested approach" above:
+
+1. **The originally-hypothesized root cause
+   (`project_standalone_any_string_value_read_substrate` — the `$Object`
+   dynamic/`any`-typed reader dropping native-string VALUES) is already
+   FIXED**, confirmed by direct repro against current `main`:
+   `const o: any = {v: "hi"}; o.v.length === 2` and
+   `const o: any = {v: "hi"}; o.v === "hi"` both compile and run correctly
+   standalone. #2861/#2863 (both `done`) closed this. The umbrella's ~669→1,552
+   growth is NOT this bug regrowing — it is the residual now being dominated by
+   OTHER, unrelated causes that happen to share the same generic error text.
+2. Of the 1,552 official-harvest fails with this error signature, **1,320
+   carry zero `imports`** (pure standalone runtime failures, not gated behind
+   a host-import/generator-carrier leak) — this is the "count a standalone
+   codegen fix flips directly" the suggested approach asked for.
+3. **The 1,320-pure subset is heterogeneous, not one root cause.** Sampling
+   ~40 files at random and tracing several by category shows at least these
+   *distinct* clusters, each its own bug/feature gap:
+   - `TypedArray(Constructors)/prototype`/`internals` (~350 combined) —
+     inherited-prototype-method / detached-buffer internal-slot checks.
+   - `Object/getOwnPropertyDescriptor` (124) — itself split into at least 3
+     unrelated shapes on inspection: descriptors for BUILT-IN globals/
+     `Date.prototype` methods (needs global-object/intrinsic-prototype
+     descriptor modeling — see #2988 area), `ToPropertyKey` coercion of a
+     non-primitive key argument (`Object.getOwnPropertyDescriptor(obj,
+     {toString(){...}})`), and array-element descriptors
+     (`Object.getOwnPropertyDescriptor(arr, "0")`).
+   - `Temporal/*` (~230+: ZonedDateTime/PlainDateTime/Instant/PlainDate/…) —
+     an entire unimplemented/deferred feature area (see the project skip-list
+     policy for Temporal), not a codegen bug.
+   - `Function.prototype`/eval-code (~50+) — the poison-pill `.caller`/
+     `.arguments` accessors and the eval/Function-shim free-variable capture
+     gaps, **already tracked** in #3017 (and #3005's eval-as-any-callee work).
+   - Class/accessor `fn-name` descriptor tests, `SharedArrayBuffer`, `Map`/
+     `Set` prototype getters, module namespace reads, etc. — each a handful,
+     each its own narrow gap.
+   4. **One concrete, narrow, genuinely-fixable bug WAS found and fixed this
+   session** (verified via direct trace of the
+   `language/expressions/property-accessors/S11.2.1_A3_T3.js` sample named in
+   this issue): **computed (bracket) property/method access on a
+   string-typed or String-wrapper-typed receiver never dispatched to the
+   native `__str_*` string engine in `--nativeStrings` mode** (standalone/
+   wasi). Repro (all standalone, pre-fix):
+   - `"abc123"["length"]` → `0` (wrong; dot form `"abc123".length` → `6` ✓)
+   - `"abc123"["charAt"](0)` → threw (dot form `.charAt(0)` → `"a"` ✓)
+   - `new String("abc123")["charAt"](2)` → threw (dot form → `"c"` ✓)
+
+   Root cause: the ElementAccessExpression codegen paths for both plain
+   property reads (`compileElementAccess` /
+   `compileElementAccessBody` in `src/codegen/property-access.ts`) and
+   computed method CALLS (`compileCallExpression`'s
+   `ts.isElementAccessExpression(expr.expression)` branch in
+   `src/codegen/expressions/calls.ts`) never special-cased a string-typed
+   receiver the way the dot form does:
+   - The property-read path fell to the generic "non-vec, non-tuple struct"
+     fallback, which `extern.convert_any`s the native `$NativeString`
+     struct (fields `len`/`off`/`data`) and calls the host `__extern_get` —
+     which finds nothing (there is no host, and no field named "length") and
+     returns null.
+   - The computed-call path only ever tried
+     `ctx.funcMap.get("string_" + methodName)` — the HOST string-method
+     import, which native-strings mode never registers (the dot form
+     dispatches natively via `compileNativeStringMethodCall`/
+     `__str_*` helpers instead, bypassing host imports entirely) — so
+     `funcIdx` was always `undefined` and the call fell through to a generic
+     dynamic-dispatch fallback that produces a non-callable/null value.
+
+   **Fix**: in both paths, when the receiver is string-typed
+   (`isStringType`) and native-strings mode is active
+   (`ctx.nativeStrings`), recompile the access/call as the equivalent DOT
+   form (same receiver, same statically-resolved key/method name, same
+   arguments) via a synthetic `ts.factory.createPropertyAccessExpression`,
+   and delegate to the existing (already-correct) dot-form dispatch
+   (`compilePropertyAccess` / `compileCallExpression` recursion). This reuses
+   the mature dot-form logic — including the String-wrapper
+   `__to_primitive` unwrap — instead of duplicating it, so wrapper receivers
+   work correctly too. Gated identically to the dot form
+   (`ctx.nativeStrings`, independent of `ctx.standalone`/`ctx.wasi`), so host/
+   gc-mode without `--nativeStrings` is untouched (verified: an unrelated,
+   PRE-EXISTING gc-mode dereference bug on this same source shape reproduces
+   identically before and after this change — not caused or fixed by it,
+   out of scope here).
+
+   A separate, PRE-EXISTING, unrelated gap was found and left out of scope:
+   a plain NUMERIC computed index on a bare string primitive
+   (`"abc"[1]`) returns `0`/wrong standalone (only the String-*wrapper*
+   numeric-indexed read, #1910 R4, was ever fixed) — confirmed present
+   identically before this change. Worth its own follow-on issue if picked up.
+
+## Test Results
+
+- New test file `tests/issue-3027.test.ts` (7 cases) — all pass: computed
+  `["length"]` read, computed `["charAt"](i)` call (literal AND
+  runtime-resolved key), String-wrapper computed call/length, dot-form
+  regression guard, and the full `S11.2.1_A3_T3.js` repro shape.
+- The exact test262 sample named in this issue,
+  `language/expressions/property-accessors/S11.2.1_A3_T3.js`, now passes
+  standalone (was: `fail`, `TypeError: Cannot access property on null or
+  undefined`).
+- Re-ran the full 1,320-file pure (no-import) subset sharing this error
+  signature through the standalone harness with the fix applied: **5 flip to
+  `pass`**; 1,137 still fail with the same signature (the heterogeneous
+  clusters above — each needs its own separately-scoped fix, not addressable
+  by a codegen change to the dynamic-property reader); 178 report `skip`
+  under the current harness/submodule state (unrelated to this fix — present
+  both before and after; likely submodule/skip-filter drift since the
+  2026-07-03 harvest, not investigated further here). A broader source-text
+  heuristic scan across ALL 17,788 standalone fails (any error signature) for
+  bracket-notation string-method/length usage found only 4 additional
+  candidates beyond the measured 5 — this specific bug's total yield in the
+  current corpus is genuinely small (~single digits), even though it was a
+  real, distinct, correctly-diagnosed and fixed codegen gap.
+- No regression observed in adjacent string-codegen equivalence suites
+  (`tests/issue-1910-string-wrapper-index.test.ts`,
+  `tests/issue-2600-string-index-tointeger.test.ts`,
+  `tests/issue-2192b-caught-error-string-methods.test.ts`,
+  `tests/issue-2161-b1-boxed-string.test.ts` — the 2 pre-existing gc-mode
+  failures in the #2600 suite reproduce identically on `main` without this
+  change, confirmed via `git stash`).
+
+## Disposition
+
+This issue's acceptance criterion 1 ("drops materially below 1,552") is
+**not** achieved by a single codegen fix, because the residual is no longer
+one root cause — it is a heterogeneous long tail across TypedArray
+internals, `Temporal` (a whole deferred feature area), global-object/
+intrinsic-prototype property-descriptor modeling, `ToPropertyKey` coercion,
+and the already-tracked eval/Function-shim gaps (#3005/#3017). This issue
+delivers the concrete, verified, in-scope slice found during the
+re-measurement (computed string property/method access) and **supersedes
+the umbrella's stale "not-yet-issued follow-on" note** (acceptance criterion
+2) with this accurate, re-scoped picture — see the umbrella #2860 update.
+Recommend the PO/tech-lead triage the clusters above into separately-sized
+follow-on issues (the TypedArray-internals cluster, at ~350, is the next
+largest single addressable slice).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -15180,6 +15180,29 @@ function compileCallExpression(
 
       // Try string method: string_methodName
       if (isStringType(receiverType)) {
+        // (#3027) Native-strings mode (standalone/wasi `--nativeStrings`)
+        // never registers the host `string_<method>` import looked up right
+        // below — a computed-key string method call (`"str"["charAt"](i)`,
+        // `new String(x)["slice"](i)`) always found `funcIdx === undefined`
+        // and fell through every later branch to the generic dynamic-call
+        // fallback, which produces a null/non-callable value for a native
+        // string or wrapper receiver (there is no host `$Object` to ask) —
+        // manifesting downstream as "Cannot access property on null or
+        // undefined". The dot form (`"str".charAt(i)`) already dispatches
+        // correctly through the native `__str_*` engine (incl. the String-
+        // wrapper `__to_primitive` unwrap) earlier in this same function;
+        // recompile this call as the equivalent dot form (same receiver, same
+        // method, same arguments) so it takes that exact path instead of
+        // duplicating the logic here.
+        if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+          const syntheticProp = ts.factory.createPropertyAccessExpression(elemAccess.expression, methodName);
+          ts.setTextRange(syntheticProp, elemAccess);
+          (syntheticProp as unknown as { parent: ts.Node }).parent = expr;
+          const syntheticCall = ts.factory.createCallExpression(syntheticProp, expr.typeArguments, expr.arguments);
+          ts.setTextRange(syntheticCall, expr);
+          (syntheticCall as unknown as { parent: ts.Node }).parent = expr.parent;
+          return compileCallExpression(ctx, fctx, syntheticCall as ts.CallExpression);
+        }
         const importName = `string_${methodName}`;
         const funcIdx = ctx.funcMap.get(importName);
         if (funcIdx !== undefined) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -7042,7 +7042,13 @@ export function compileElementAccess(
     ctx.nativeStrings &&
     ctx.anyStrTypeIdx >= 0 &&
     !isNumericIndexExpression(ctx, expr.argumentExpression) &&
-    isStringType(ctx.checker.getTypeAtLocation(expr.expression))
+    // (#1930) Query the receiver's static string-ness via the TypeOracle, not
+    // the raw checker. `isStringType` matched BOTH a primitive string and the
+    // `String` wrapper object; the oracle equivalents are
+    // `staticJsTypeOf === "string"` (primitive) OR `builtinReceiverOf ===
+    // "String"` (`new String(x)` wrapper), which together cover the same set.
+    (ctx.oracle.staticJsTypeOf(expr.expression) === "string" ||
+      ctx.oracle.builtinReceiverOf(expr.expression) === "String")
   ) {
     const key = resolveComputedKeyExpression(ctx, expr.argumentExpression);
     if (key !== undefined) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -6954,6 +6954,34 @@ export function compileElementAccess(
     }
   }
 
+  // (#3027) Computed non-numeric key on a string/String-wrapper-typed
+  // receiver — `"str"["length"]`, `new String("x")["length"]`. Native-strings
+  // mode has no `$Object` sidecar for a bare string or wrapper receiver, so
+  // the generic "non-vec, non-tuple struct" fallback further below
+  // (`extern.convert_any` + host `__extern_get`) always returns null for a
+  // computed string-property read — there is no host to ask, and the struct
+  // shape (len/off/data) never matches a property name like "length". The
+  // dot form (`"str".length`) already dispatches correctly through
+  // `compilePropertyAccess`; recompile this access as the equivalent dot form
+  // (same receiver, same statically-resolved key) so it takes that exact path
+  // instead of duplicating the logic here. Numeric keys are handled above
+  // (#1910 R4) or by the array/vec paths below; only fires for a
+  // non-numeric, statically-resolvable key.
+  if (
+    ctx.nativeStrings &&
+    ctx.anyStrTypeIdx >= 0 &&
+    !isNumericIndexExpression(ctx, expr.argumentExpression) &&
+    isStringType(ctx.checker.getTypeAtLocation(expr.expression))
+  ) {
+    const key = resolveComputedKeyExpression(ctx, expr.argumentExpression);
+    if (key !== undefined) {
+      const syntheticProp = ts.factory.createPropertyAccessExpression(expr.expression, key);
+      ts.setTextRange(syntheticProp, expr);
+      (syntheticProp as unknown as { parent: ts.Node }).parent = expr.parent;
+      return compilePropertyAccess(ctx, fctx, syntheticProp);
+    }
+  }
+
   const objType = compileExpression(ctx, fctx, expr.expression);
   if (!objType) return null;
 

--- a/tests/issue-3027.test.ts
+++ b/tests/issue-3027.test.ts
@@ -1,0 +1,109 @@
+// #3027 — standalone: `$Object` dynamic-object-property reader residual.
+//
+// Root cause (narrower than the umbrella hypothesis): the ORIGINAL "$Object
+// dynamic reader drops native-string values" substrate bug
+// (project_standalone_any_string_value_read_substrate) was already fixed by
+// #2861/#2863 — plain `const o: any = {v: "hi"}; o.v.length` and
+// `o.v === "hi"` both work correctly standalone as of this issue.
+//
+// Re-measuring the "Cannot access property on null or undefined" residual
+// (test262 standalone lane, host-import-free subset) turned up a genuinely
+// DISTINCT, narrower bug sharing the same error text: COMPUTED (bracket)
+// property/method access on a string-typed OR String-wrapper-typed receiver
+// never dispatches to the native `__str_*` string engine in
+// `--nativeStrings` mode (standalone/wasi):
+//   - `"str"["length"]` (element read)         → returned 0 instead of the
+//     real length (fell through to a generic struct fallback that can't
+//     match "length" against the native string struct's len/off/data
+//     fields).
+//   - `"str"["charAt"](i)` (computed call)      → threw, because the
+//     computed-call dispatcher only tries the HOST `string_<method>` import
+//     (`ctx.funcMap.get("string_charAt")`), which native-strings mode never
+//     registers — so `funcIdx` was always `undefined` and the call fell
+//     through to the generic dynamic-dispatch fallback (null receiver call).
+//   - `new String("x")["charAt"](i)` (wrapper + computed call) → same throw.
+//
+// The dot form (`"str".charAt(i)`, `"str".length`) already dispatched
+// correctly through the native engine; the fix recompiles a computed
+// string-receiver access/call as the equivalent dot form (same receiver, same
+// statically-resolved key, same arguments) so it takes that exact,
+// already-correct path instead of duplicating the logic.
+//
+// See `src/codegen/property-access.ts` (`compileElementAccess`, the #3027
+// note right before the `objType = compileExpression(...)` line) and
+// `src/codegen/expressions/calls.ts` (`compileCallExpression`'s
+// ElementAccessExpression-callee branch, the "Try string method" section).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("; ")).toBe(true);
+  if (!r.success) return undefined;
+  const envImports = r.imports.filter((i) => i.module === "env");
+  expect(envImports, `unexpected env imports: ${envImports.map((i) => i.name).join(",")}`).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#3027 standalone computed string property/method access", () => {
+  it('computed element read: "abc123"["length"] === 6', async () => {
+    const src = `export function test(): number {
+      return "abc123"["length"] === 6 ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it('computed method call: "abc123"["charAt"](0) === "a"', async () => {
+    const src = `export function test(): number {
+      return "abc123"["charAt"](0) === "a" ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it('computed method call with a runtime-resolved key: "abc123"[k](5) === "3"', async () => {
+    const src = `export function test(): number {
+      const k = "charAt";
+      return "abc123"[k](5) === "3" ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it('String-wrapper computed call: new String("abc123")["charAt"](2) === "c"', async () => {
+    const src = `export function test(): number {
+      return new String("abc123")["charAt"](2) === "c" ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it('String-wrapper computed length read: new String("abc123")["length"] === 6', async () => {
+    const src = `export function test(): number {
+      return new String("abc123")["length"] === 6 ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("dot-form access is unaffected (regression guard)", async () => {
+    const src = `export function test(): number {
+      const dotCharAt = "abc123".charAt(5) === "3";
+      const dotLength = "abc123".length === 6;
+      return dotCharAt && dotLength ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  // The exact test262 repro named in the issue (property-accessors/S11.2.1_A3_T3.js).
+  it("test262 S11.2.1_A3_T3 repro shape passes standalone", async () => {
+    const src = `export function test(): number {
+      let fail = 0;
+      if ("abc123".charAt(5) !== "3") fail = 1;
+      if ("abc123"["charAt"](0) !== "a") fail = 1;
+      if ("abc123".length !== 6) fail = 1;
+      if ("abc123"["length"] !== 6) fail = 1;
+      if (new String("abc123").length !== 6) fail = 1;
+      if (new String("abc123")["charAt"](2) !== "c") fail = 1;
+      return fail === 0 ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Re-measures the "$Object dynamic-object-property reader residual" umbrella
follow-on (#2860) and fixes a concrete, distinct bug found during the trace.

- **Root cause re-check**: the originally-hypothesized root cause
  (`project_standalone_any_string_value_read_substrate` — the dynamic `any`
  reader dropping native-string VALUES) was already fixed by #2861/#2863.
  Confirmed via direct repro: `const o: any = {v: "hi"}; o.v.length` works
  correctly standalone. The 1,552-test residual is NOT this bug regrowing.
- **Re-measurement**: of the 1,552 official fails sharing this error
  signature, 1,320 carry zero host imports (the "pure" count a codegen fix
  could flip directly). Sampling and tracing this subset shows it is a
  **heterogeneous long tail** — TypedArray internals (~350), `Temporal`
  (~230+, a deferred feature area), `Object.getOwnPropertyDescriptor` (124,
  itself 3 unrelated shapes), the already-tracked eval/Function-shim gaps
  (#3005/#3017), and many smaller one-off gaps — not one root cause.
- **Concrete fix**: traced the exact test262 sample named in the issue
  (`property-accessors/S11.2.1_A3_T3.js`) and found computed (bracket)
  property/method access on a string-typed or String-wrapper-typed receiver
  never dispatched to the native `__str_*` string engine in
  `--nativeStrings` mode (standalone/wasi):
  - `"str"["length"]` returned `0` (dot form `"str".length` worked)
  - `"str"["charAt"](i)` threw (dot form worked)
  - `new String(x)["charAt"](i)` threw (dot form worked)

  Both codegen paths (`compileElementAccess` in
  `src/codegen/property-access.ts`, and the ElementAccessExpression-callee
  branch of `compileCallExpression` in `src/codegen/expressions/calls.ts`)
  now recompile the access/call as the equivalent dot form (same receiver,
  same statically-resolved key, same arguments) and delegate to the
  already-correct dot-form dispatch, instead of falling through to a
  host-import fallback that has nothing to call in standalone/wasi mode.

- Updates the #2860 umbrella's stale "not-yet-issued follow-on" note with
  the accurate, re-scoped picture, and recommends the PO/tech-lead triage
  the remaining clusters into separately-sized follow-on issues.

## Test plan

- [x] New `tests/issue-3027.test.ts` (7 cases): computed `["length"]` read,
      computed `["charAt"](i)` call (literal + runtime-resolved key),
      String-wrapper computed call/length, dot-form regression guard, full
      `S11.2.1_A3_T3.js` repro shape — all pass.
- [x] The named test262 sample `property-accessors/S11.2.1_A3_T3.js` now
      passes standalone (was `fail`).
- [x] Re-ran the full 1,320-file pure-fail subset sharing this error
      signature through the standalone harness: 5 flip to `pass`; documented
      the rest as separate, out-of-scope clusters in the issue file.
- [x] No regression in adjacent string-codegen suites (`issue-1910-*`,
      `issue-2600-*`, `issue-2192b-*`, `issue-2161-b1-*`) — the 2
      pre-existing gc-mode failures in `issue-2600-*` reproduce identically
      on `main` without this change (verified via `git stash`).
- [x] `pnpm run typecheck`, `check:issues`, `check:codegen-fallbacks`,
      `check:coercion-sites` all clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>