### PR TITLE
feat(#2949 S5.0): builder emit plumbing for dynamic box/unbox/tag.test

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -2,7 +2,7 @@
 id: 2949
 title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)"
 status: in-progress
-assignee: ttraenkler/opus-2949s4
+assignee: ttraenkler/opus-s5-0
 sprint: current
 created: 2026-07-02
 updated: 2026-07-04
@@ -1181,3 +1181,73 @@ scan-flip is gated.
   rate delta at first, growing only as S5.4's substrate and the #1370/#2855
   shape surface widen. Do not promise a large delta from S5.1–S5.3 alone; the
   probe in §4 sets the expectation before the code is written.
+
+## Implementation Notes — S5.0 (opus-s5-0, 2026-07-05, branch `issue-2949-s5-0-emit-plumbing`)
+
+S5.0 ships the builder-level emit vocabulary for the dynamic carrier —
+`IrFunctionBuilder.emitBox` / `emitUnbox` / `emitTagTest` (`src/ir/builder.ts`).
+These are the ONLY missing piece #1 the §0 grounding named: the node-level
+LOWERING already landed in slices 2/3 (`lower.ts` box/unbox/tag.test cases →
+`resolveDynamicLowering` → `IrDynamicLowering`), but a producer had no way to
+CONSTRUCT the nodes. Now it does. **Pure plumbing, byte-inert by
+construction**: no producer calls the methods (select.ts/from-ast.ts
+untouched), so no compiled function changes.
+
+Decisions and the WHY:
+
+1. **Result-type mapping mirrors the node contracts (nodes.ts §box/unbox/
+   tag.test), not a new policy.** `emitBox → toType`; `emitTagTest → irVal
+   i32`; `emitUnbox → irVal(<payload ValType>)` where the payload kind comes
+   from the canonical `jsTagUnboxKind` (js-tag.ts): `i32` (NumberI32/Boolean),
+   `f64` (NumberF64), `ref` (String/Object/Function). This is the SAME table
+   the verifier (R2/R3) and the gc `payloadFieldIdx` use — one tag/payload
+   policy (D4), no second table.
+
+2. **The `ref` payload declares `externref` (deliberate, plumbing-level).**
+   The runtime ref ValType is mode-split — host: the externref carrier IS the
+   value (identity unbox); WasmGC: String rides `externval` (externref),
+   Object/Function ride `refval` (eqref) — so no single static ValType is
+   exactly right in both backends. `externref` is the host-universal and the
+   gc-String choice; the S5.4 member-read producer (the first ref-payload
+   consumer) refines it where a native ref is required (slice-3 hazard (b)).
+   S5.0 has no ref-payload consumer, so this is inert.
+
+3. **Two construction-time guards, matching verifier R1/R2, for a sharper
+   error than a downstream verify/lower failure**: `emitBox` throws on an
+   already-dynamic operand (re-box is redundant — R1); `emitUnbox` throws on
+   a payload-less singleton jsTag (Null/Undefined — R2; also, there is no
+   payload ValType to declare). Valid uses are unaffected — the guards only
+   fire on producer bugs, so byte-inertness holds.
+
+4. **Compose with the S5.1+ coercion-engine plan, not against it.** These
+   methods construct the RAW box/unbox/tag.test nodes; S5.1+ route the
+   general body-uses (truthiness/equality/relational) through the EXISTING
+   coercion-engine helpers (`emitToBoolean`/`__any_strict_eq`/`emitToNumber`)
+   exposed as new `IrDynamicLowering` methods (§1 of the S5 plan), reserving
+   `tag.test`+`unbox` for the known-literal fast paths. S5.0's vocabulary is
+   exactly those fast-path primitives plus the box every producer needs.
+
+## Test Results — S5.0 (2026-07-05, opus-s5-0)
+
+- `tests/issue-2949-s5-0-emit-plumbing.test.ts` — **8/8 pass**. Node-shape +
+  result-IrType assertions for all three methods (incl. the full
+  `jsTagUnboxKind` payload table), the R1 re-box guard and R2 singleton-unbox
+  guard, verifier-clean built functions, and — RAISED to full runtime
+  execution against the PRODUCTION `makeDynamicLowering` over a real
+  `CodegenContext` — `box → tag.test → unbox → select` round-trips executed
+  in BOTH strategies: gc ($AnyValue, pure module) and host (externref +
+  import family). f64 value round-trip (incl. −0/NaN/2^40), numeric-class
+  tag.test true, cross-tag (String) tag.test false → guarded 0,
+  Boolean-refined box round-trip, NumberI32 box round-trip.
+- **Byte-inertness PROVEN**: `prove-emit-identity.mjs` baseline captured on a
+  clean worktree at the base (`647cd6763`), `check` on this branch →
+  **IDENTICAL, all 39 (file,target) hashes** across gc/standalone/wasi.
+- Adjacent #2949 suites: slice 1 (`ir-dynamic-type`) 19/19, slice 2
+  (`slice2-dynamic-producers`) 22/22, slice 3 (`slice3-dynamic-lowering`)
+  16/16 — 65/65 combined with S5.0.
+- `npx tsc --noEmit` clean; prettier clean.
+- **S5.1 (truthiness) is ready to build on this**: it adds the
+  `emitDynTruthy` builder method + `IrDynamicLowering.emitToBoolean` handle
+  arm (routing to `coercion-engine.emitToBoolean`) and the from-ast `if`/loop
+  condition arm; the box/unbox/tag.test primitives it needs for the
+  known-literal paths now exist.

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -36,6 +36,7 @@ import {
 } from "./nodes.js";
 import type { AllocSiteRegistry } from "./alloc-registry.js";
 import type { Instr, ValType } from "./types.js";
+import { JsTag, jsTagUnboxKind } from "../codegen/js-tag.js";
 
 interface OpenBlock {
   readonly id: IrBlockId;
@@ -313,6 +314,102 @@ export class IrFunctionBuilder {
     const resultType: IrType = { kind: "val", val: { kind: "f64" } };
     this.valueTypes.set(result, resultType);
     this.pushInstr({ kind: "string.len", value, result, resultType });
+    return result;
+  }
+
+  // --- dynamic value ops (#2949 S5.0) -------------------------------------
+  //
+  // Builder-level emit vocabulary for the `IrType.dynamic` boxed-any carrier:
+  // `box` erases a concrete value into the carrier, `unbox` reads a proven
+  // partition's payload back out, and `tag.test` classifies the carrier's
+  // runtime JS tag. These are the plumbing the S5.1–S5.P dynamic-use-in-body
+  // producers consume; the node-level LOWERING already landed in slices 2/3
+  // (`lower.ts` box/unbox/tag.test cases → `resolveDynamicLowering` →
+  // `IrDynamicLowering`, backed by `$AnyValue` / `__any_box_*` on WasmGC and
+  // the `__box_number` / classifier import family on host).
+  //
+  // S5.0 is byte-inert by construction: these methods only APPEND verifier-
+  // clean nodes, and no producer calls them yet (from-ast/select unchanged),
+  // so no compiled function's Wasm changes (prove-emit-identity IDENTICAL).
+
+  /**
+   * Emit `box{value → toType}` — erase a concrete value into a boxed-any
+   * carrier (`toType.kind === "dynamic"`) or a scalar tagged union
+   * (`toType.kind === "union"`). Result type is `toType`.
+   *
+   * The operand must NOT itself be dynamic — a re-box is provably redundant
+   * (verifier R1); this is asserted here so a producer bug surfaces at
+   * construction time rather than as a malformed double-boxed carrier that
+   * only fails later in verify/lower.
+   *
+   * A `dynamic` `toType` may carry a `tag` refinement (`irDynamic(JsTag.X)`);
+   * lowering maps it onto the canonical boxing helper's representation hint
+   * (e.g. a Boolean-refined i32 boxes as tag-4, not an unbranded number),
+   * so producers that statically know the partition SHOULD refine the box
+   * target — see slice-3 note 4 in the #2949 issue file.
+   */
+  emitBox(value: IrValueId, toType: IrType): IrValueId {
+    if (this.typeOf(value).kind === "dynamic") {
+      throw new Error(
+        `IrFunctionBuilder: emitBox operand ${value} is already dynamic — re-boxing a dynamic value is invalid (#2949 R1) (func ${this.name})`,
+      );
+    }
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, toType);
+    this.pushInstr({ kind: "box", value, toType, result, resultType: toType });
+    return result;
+  }
+
+  /**
+   * Emit `unbox{value, jsTag}` — read the proven JS partition's payload off
+   * a boxed-any carrier. The caller MUST have proved the tag already (via an
+   * earlier `emitTagTest`, or a static refinement); lowering emits a payload
+   * read without a runtime re-check.
+   *
+   * `jsTag` must be payload-bearing: Null/Undefined are singleton partitions
+   * with no payload (`jsTagUnboxKind === null`, verifier R2) — their identity
+   * is observed via `emitTagTest` alone, so unboxing them is rejected here.
+   *
+   * Result type is the partition's payload ValType per `jsTagUnboxKind`:
+   * `i32` (NumberI32 / Boolean), `f64` (NumberF64), or a ref-shaped carrier
+   * for String/Object/Function. The exact ref ValType is a resolver/consumer
+   * decision at lowering (host: the externref carrier is the value; WasmGC:
+   * String rides `externval`, Object/Function ride `refval` — see slice-3
+   * hazard (b)); the plumbing declares the ref-shaped result as `externref`
+   * and the S5.4 member-read producer refines it where a native ref is
+   * needed.
+   */
+  emitUnbox(value: IrValueId, jsTag: JsTag): IrValueId {
+    const payload = jsTagUnboxKind(jsTag);
+    if (payload === null) {
+      throw new Error(
+        `IrFunctionBuilder: emitUnbox with payload-less JsTag ${JsTag[jsTag]} is invalid — use emitTagTest (#2949 R2) (func ${this.name})`,
+      );
+    }
+    const payloadVal: ValType =
+      payload === "i32" ? { kind: "i32" } : payload === "f64" ? { kind: "f64" } : { kind: "externref" };
+    const resultType = irVal(payloadVal);
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "unbox", value, jsTag, result, resultType });
+    return result;
+  }
+
+  /**
+   * Emit `tag.test{value, jsTag}` — does the carrier's runtime tag match the
+   * JS partition? Result is `i32` (1 if it matches, else 0).
+   *
+   * `jsTag` may be ANY partition, including the payload-less Null/Undefined
+   * (testing for them is the point — verifier R3). Per the V2 numeric-class
+   * invariant the two number partitions are ONE class, so `tag.test` against
+   * either `NumberI32` or `NumberF64` lowers to the same numeric-class test
+   * in both backends (see slice-3 note 3 in the #2949 issue file).
+   */
+  emitTagTest(value: IrValueId, jsTag: JsTag): IrValueId {
+    const resultType = irVal({ kind: "i32" });
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "tag.test", value, jsTag, result, resultType });
     return result;
   }
 

--- a/tests/issue-2949-s5-0-emit-plumbing.test.ts
+++ b/tests/issue-2949-s5-0-emit-plumbing.test.ts
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 S5.0 — builder-level box/unbox/tag.test emit plumbing.
+//
+// Slice 1 (PR #2486) put `{kind:"dynamic", tag?}` in the IrType lattice with
+// verifier rules R1–R6; slices 2/3 added the move-only producers and the
+// node-level LOWERING (lower.ts box/unbox/tag.test → `resolveDynamicLowering`
+// → `IrDynamicLowering`, backed by `$AnyValue` / `__any_box_*` on WasmGC and
+// the `__box_number` / classifier import family on host). What was MISSING
+// (the work of S5.0) is the BUILDER vocabulary the S5.1–S5.P dynamic-use-in-
+// body producers construct the nodes with: `emitBox` / `emitUnbox` /
+// `emitTagTest` on `IrFunctionBuilder`.
+//
+// This slice is byte-inert by construction — no producer calls the new
+// methods yet, so no compiled function's Wasm changes (proven separately by
+// prove-emit-identity, 39/39 IDENTICAL). These tests exercise the builder
+// methods DIRECTLY: they assert the emitted node shape + result IrType (the
+// `jsTagUnboxKind` payload mapping), that the built functions are verifier-
+// clean, and — RAISED to full runtime execution, per the slice-3 standard —
+// that a `box → tag.test → unbox` round-trip lowered against the PRODUCTION
+// handle over a real CodegenContext actually round-trips the value and
+// classifies the tag, in BOTH the gc (fast/standalone) and host strategies.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { ensureAnyHelpers } from "../src/codegen/any-helpers.js";
+// Side-effect import: registers the `flushLateImportShifts` codegen delegate
+// that `addUnionImports` requires (owned by expressions/late-imports.ts, which
+// expressions.ts registers on module load — same pattern as the slice-3 test).
+import "../src/codegen/expressions.js";
+import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
+import { addFuncType } from "../src/codegen/registry/types.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import { JsTag } from "../src/codegen/js-tag.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
+import { peepholeOptimize } from "../src/codegen/peephole.js";
+import { stackBalance } from "../src/codegen/stack-balance.js";
+import {
+  IrFunctionBuilder,
+  irDynamic,
+  irVal,
+  lowerIrFunctionToWasm,
+  makeDynamicLowering,
+  verifyIrFunction,
+  type IrFunction,
+  type IrLowerResolver,
+  type IrType,
+} from "../src/ir/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import type { FuncTypeDef } from "../src/ir/types.js";
+
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+const DYN: IrType = irDynamic();
+
+// ---------------------------------------------------------------------------
+// Harness — real context, production handle, production encoder
+// (identical to the slice-3 test; the box/unbox/tag.test lowering is shared)
+// ---------------------------------------------------------------------------
+
+function makeGcCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {
+    fast: true,
+    nativeStrings: false,
+  });
+  ensureAnyHelpers(ctx); // what preregisterDynamicSupport does for gc
+  return ctx;
+}
+
+function makeHostCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {});
+  addUnionImports(ctx); // what preregisterDynamicSupport does for host
+  return ctx;
+}
+
+function resolverFor(ctx: CodegenContext): IrLowerResolver {
+  const dyn = makeDynamicLowering(ctx);
+  return {
+    resolveFunc: (ref) => {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) throw new Error(`test resolver: unknown func ${ref.name}`);
+      return idx;
+    },
+    resolveGlobal: () => {
+      throw new Error("test resolver: no globals");
+    },
+    resolveType: () => {
+      throw new Error("test resolver: no type refs");
+    },
+    internFuncType: (t: FuncTypeDef) => addFuncType(ctx, t.params, t.results, t.name),
+    resolveDynamic: () => (dyn ? dyn.carrier : { kind: "externref" }),
+    resolveDynamicLowering: () => dyn,
+  };
+}
+
+function install(ctx: CodegenContext, fns: IrFunction[]): void {
+  const resolver = resolverFor(ctx);
+  for (const f of fns) {
+    const { func } = lowerIrFunctionToWasm(f, resolver);
+    const handle = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, handle, func);
+    ctx.mod.exports.push({ name: f.name, desc: { kind: "func", index: handle } });
+  }
+}
+
+async function instantiateCtx(
+  ctx: CodegenContext,
+  env: Record<string, unknown> = {},
+): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  repairStructTypeMismatches(ctx.mod);
+  peepholeOptimize(ctx.mod);
+  stackBalance(ctx.mod);
+  const binary = emitBinary(ctx.mod);
+  const jsString: Record<string, unknown> = {
+    concat: (a: string, b: string) => `${a}${b}`,
+    length: (s: string) => s.length,
+    equals: (a: unknown, b: unknown) => (a === b ? 1 : 0),
+    substring: (s: string, a: number, b: number) => s.substring(a, b),
+    charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+    fromCharCode: (c: number) => String.fromCharCode(c),
+  };
+  const { instance } = await WebAssembly.instantiate(binary as BufferSource, {
+    env,
+    "wasm:js-string": jsString,
+  });
+  return instance.exports as Record<string, (...args: unknown[]) => unknown>;
+}
+
+function hostEnvFor(ctx: CodegenContext): Record<string, unknown> {
+  const stub = (name: string): unknown => {
+    if (name.startsWith("__typeof_")) {
+      const t = name.slice("__typeof_".length);
+      // biome-ignore lint/suspicious/useValidTypeof: t is derived from the import name — same dynamic dispatch src/runtime.ts uses
+      return (v: unknown) => (typeof v === t ? 1 : 0);
+    }
+    switch (name) {
+      case "__box_number":
+        return (v: number) => v;
+      case "__box_boolean":
+        return (v: number) => Boolean(v);
+      case "__unbox_number":
+        return (v: unknown) => Number(v);
+      case "__unbox_boolean":
+        return (v: unknown) => (v ? 1 : 0);
+      case "__is_truthy":
+        return (v: unknown) => (v ? 1 : 0);
+      default:
+        return () => 0;
+    }
+  };
+  const env: Record<string, unknown> = {};
+  for (const imp of ctx.mod.imports) {
+    if (imp.module === "env" && imp.desc.kind === "func") env[imp.name] = stub(imp.name);
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// Node shape + result type — the emitted nodes and their result IrTypes
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.0 — builder emits verifier-clean box/unbox/tag.test nodes", () => {
+  it("emitBox appends a box node with resultType == toType and registers typeOf", () => {
+    const b = new IrFunctionBuilder("box1", [DYN], true);
+    const x = b.addParam("x", F64);
+    b.openBlock();
+    const d = b.emitBox(x, DYN);
+    expect(b.typeOf(d)).toEqual(DYN);
+    b.terminate({ kind: "return", values: [d] });
+    const fn = b.finish();
+    const [node] = fn.blocks[0].instrs;
+    expect(node).toMatchObject({ kind: "box", value: x, toType: DYN, result: d, resultType: DYN });
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("emitBox carries a refinement onto the box target (irDynamic(tag))", () => {
+    const b = new IrFunctionBuilder("boxRefined", [DYN], true);
+    const x = b.addParam("x", I32);
+    b.openBlock();
+    const refined = irDynamic(JsTag.Boolean);
+    const d = b.emitBox(x, refined);
+    expect(b.typeOf(d)).toEqual(refined);
+    b.terminate({ kind: "return", values: [d] });
+    expect(verifyIrFunction(b.finish())).toEqual([]);
+  });
+
+  it("emitUnbox result IrType follows jsTagUnboxKind (i32 / f64 / ref→externref)", () => {
+    // NumberF64 → f64, NumberI32 / Boolean → i32, String/Object/Function → externref.
+    const cases: Array<[JsTag, IrType]> = [
+      [JsTag.NumberF64, F64],
+      [JsTag.NumberI32, I32],
+      [JsTag.Boolean, I32],
+      [JsTag.String, irVal({ kind: "externref" })],
+      [JsTag.Object, irVal({ kind: "externref" })],
+      [JsTag.Function, irVal({ kind: "externref" })],
+    ];
+    for (const [tag, expected] of cases) {
+      const b = new IrFunctionBuilder(`unbox_${JsTag[tag]}`, [expected], true);
+      const x = b.addParam("x", F64);
+      b.openBlock();
+      const d = b.emitBox(x, DYN);
+      const u = b.emitUnbox(d, tag);
+      expect(b.typeOf(u)).toEqual(expected);
+      b.terminate({ kind: "return", values: [u] });
+      const node = b.finish().blocks[0].instrs[1];
+      expect(node).toMatchObject({ kind: "unbox", value: d, jsTag: tag, resultType: expected });
+    }
+  });
+
+  it("emitTagTest always yields an i32 node for ANY partition (incl. singletons)", () => {
+    for (const tag of [JsTag.NumberF64, JsTag.String, JsTag.Object, JsTag.Null, JsTag.Undefined]) {
+      const b = new IrFunctionBuilder(`tagtest_${JsTag[tag]}`, [I32], true);
+      const x = b.addParam("x", F64);
+      b.openBlock();
+      const d = b.emitBox(x, DYN);
+      const t = b.emitTagTest(d, tag);
+      expect(b.typeOf(t)).toEqual(I32);
+      b.terminate({ kind: "return", values: [t] });
+      const node = b.finish().blocks[0].instrs[1];
+      expect(node).toMatchObject({ kind: "tag.test", value: d, jsTag: tag, resultType: I32 });
+    }
+  });
+
+  it("emitBox rejects a re-box of an already-dynamic operand (verifier R1, at construction)", () => {
+    const b = new IrFunctionBuilder("rebox", [DYN], true);
+    const x = b.addParam("x", F64);
+    b.openBlock();
+    const d = b.emitBox(x, DYN);
+    expect(() => b.emitBox(d, DYN)).toThrow(/already dynamic/);
+  });
+
+  it("emitUnbox rejects a payload-less singleton partition (verifier R2, at construction)", () => {
+    const b = new IrFunctionBuilder("unboxSingleton", [I32], true);
+    const x = b.addParam("x", F64);
+    b.openBlock();
+    const d = b.emitBox(x, DYN);
+    expect(() => b.emitUnbox(d, JsTag.Null)).toThrow(/payload-less/);
+    expect(() => b.emitUnbox(d, JsTag.Undefined)).toThrow(/payload-less/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip execution — box → tag.test → unbox, real handle, both strategies
+// ---------------------------------------------------------------------------
+
+/**
+ * `boxTagUnbox(x): f64` — box x into the carrier, tag.test it against `tag`,
+ * unbox as NumberF64, and `select(t, u, 0)`. When the tag matches (`t==1`)
+ * the value round-trips; when it does not (`t==0`) the guard returns 0. This
+ * single function exercises ALL THREE builder methods and USES every value.
+ */
+function boxTagUnboxF64(name: string, tag: JsTag): IrFunction {
+  const b = new IrFunctionBuilder(name, [F64], true);
+  const x = b.addParam("x", F64);
+  b.openBlock();
+  const d = b.emitBox(x, DYN);
+  const t = b.emitTagTest(d, tag);
+  const u = b.emitUnbox(d, JsTag.NumberF64);
+  const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+  const r = b.emitSelect(t, u, zero, F64);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/** `boxUnboxBool(x: i32): i32` — box i32 with a Boolean refinement, unbox Boolean. */
+function boxUnboxBool(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const x = b.addParam("x", I32);
+  b.openBlock();
+  const d = b.emitBox(x, irDynamic(JsTag.Boolean));
+  const u = b.emitUnbox(d, JsTag.Boolean);
+  b.terminate({ kind: "return", values: [u] });
+  return b.finish();
+}
+
+/** `boxUnboxI32(x: i32): i32` — box i32 (NumberI32), unbox NumberI32. */
+function boxUnboxI32(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const x = b.addParam("x", I32);
+  b.openBlock();
+  const d = b.emitBox(x, DYN);
+  const u = b.emitUnbox(d, JsTag.NumberI32);
+  b.terminate({ kind: "return", values: [u] });
+  return b.finish();
+}
+
+function roundTripFns(): IrFunction[] {
+  return [
+    boxTagUnboxF64("matchNumber", JsTag.NumberF64), // t==1 → returns x
+    boxTagUnboxF64("mismatchString", JsTag.String), // t==0 → returns 0
+    boxUnboxBool("boolRoundTrip"),
+    boxUnboxI32("i32RoundTrip"),
+  ];
+}
+
+describe("#2949 S5.0 — gc runtime: builder-emitted box/tag.test/unbox round-trips", () => {
+  it("verifies + runs the round-trip functions ($AnyValue carrier)", async () => {
+    const fns = roundTripFns();
+    for (const f of fns) expect(verifyIrFunction(f)).toEqual([]);
+    const ctx = makeGcCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx);
+    // box(f64) → tag.test(number) proves true → unbox round-trips the value.
+    for (const v of [0, 1, -0, 3.5, -42, NaN, Math.PI, 2 ** 40]) {
+      expect(ex.matchNumber(v)).toBe(Object.is(v, -0) ? -0 : v);
+    }
+    // box(f64) → tag.test(String) proves false → the guard returns 0.
+    for (const v of [1, 7.25, -3]) expect(ex.mismatchString(v)).toBe(0);
+    // Boolean-refined box round-trips 0/1; NumberI32 box round-trips ints.
+    expect(ex.boolRoundTrip(1)).toBe(1);
+    expect(ex.boolRoundTrip(0)).toBe(0);
+    for (const v of [0, 1, 42, -7]) expect(ex.i32RoundTrip(v)).toBe(v);
+  });
+});
+
+describe("#2949 S5.0 — host runtime: builder-emitted box/tag.test/unbox round-trips", () => {
+  it("verifies + runs the round-trip functions (externref carrier, import family)", async () => {
+    const fns = roundTripFns();
+    const ctx = makeHostCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx, hostEnvFor(ctx));
+    for (const v of [0, 1, 3.5, -42, Math.PI]) {
+      expect(ex.matchNumber(v)).toBe(v);
+    }
+    for (const v of [1, 7.25, -3]) expect(ex.mismatchString(v)).toBe(0);
+    expect(ex.boolRoundTrip(1)).toBe(1);
+    expect(ex.boolRoundTrip(0)).toBe(0);
+    for (const v of [0, 1, 42, -7]) expect(ex.i32RoundTrip(v)).toBe(v);
+  });
+});


### PR DESCRIPTION
## #2949 S5.0 — builder emit plumbing (foundation, byte-inert)

First mechanism slice of the IR claim-rate lever (#2949 Slice 5 plan, arch-2949 / PR #2680). Adds the builder-level emit vocabulary — `IrFunctionBuilder.emitBox` / `emitUnbox` / `emitTagTest` (`src/ir/builder.ts`) — that the S5.1–S5.P dynamic-use-in-body producers construct the boxed-any carrier nodes with.

**Why this is the foundation:** the node-level LOWERING already landed in slices 2/3 (`lower.ts` box/unbox/tag.test → `resolveDynamicLowering` → `IrDynamicLowering`, backed by `$AnyValue`/`__any_box_*` on WasmGC and the `__box_number`/classifier import family on host). What was missing (§0 grounding item #1) is that a producer had **no way to construct** the nodes. Now it does.

### Design
- **Result types mirror the node contracts / `jsTagUnboxKind`** — `emitBox → toType`; `emitUnbox → irVal(i32/f64/externref payload)`; `emitTagTest → irVal i32`. One tag/payload table for codegen and IR (June-audit D4).
- **The `ref` payload declares `externref`** (host-universal + gc-String); the S5.4 member-read producer refines it where a native ref is needed. Inert here (no ref-payload consumer yet).
- **Two construction-time guards match verifier R1/R2** — reject re-boxing an already-dynamic operand; reject unboxing a payload-less singleton (Null/Undefined). Valid uses unaffected.
- **Composes with the S5.1+ coercion-engine routing** (`emitToBoolean`/`__any_strict_eq`/`emitToNumber`) per the S5 plan — these are the fast-path primitives plus the box every producer needs.

### Byte-inert by construction
No producer calls the new methods (`select.ts`/`from-ast.ts` untouched), so no compiled function's Wasm changes.
- **`prove-emit-identity.mjs`**: baseline captured on a clean worktree at base `647cd6763`, `check` on this branch → **IDENTICAL, all 39 (file,target) hashes** across gc/standalone/wasi.

### Tests
- `tests/issue-2949-s5-0-emit-plumbing.test.ts` — **8/8**. Node-shape + result-IrType assertions (full `jsTagUnboxKind` payload table), R1/R2 guards, verifier-clean built functions, and — RAISED to full runtime execution against the production `makeDynamicLowering` over a real `CodegenContext` — `box → tag.test → unbox → select` round-trips executed in **both** gc (`$AnyValue`) and host (externref) strategies (f64 incl. −0/NaN/2^40, numeric-class tag.test true, cross-tag String tag.test false → guarded 0, Boolean-refined box, NumberI32 box).
- #2949 slices 1/2/3 suites: **65/65** combined.
- `tsc --noEmit` clean; prettier clean.

S5.1 (truthiness) is ready to build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8