### PR TITLE
fix(#3036): deref boxed transitively-captured var in method/accessor bodies

### DIFF
--- a/plan/issues/3023-iterator-protocol-forof-abrupt-completion-residual.md
+++ b/plan/issues/3023-iterator-protocol-forof-abrupt-completion-residual.md
@@ -1,10 +1,11 @@
 ---
 id: 3023
 title: "iterator protocol: synthesized-iterator .next callability + for-of/for-await abrupt-completion residual (~508 default-lane fails)"
-status: ready
+status: done
 sprint: current
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-04
+completed: 2026-07-04
 priority: high
 horizon: m
 feasibility: medium
@@ -144,3 +145,64 @@ build a fix around it. Verified findings:
   robustness follow-up (wrap the `getSemanticDiagnostics` call so a TS-internal
   throw degrades to "no semantic diagnostics" instead of a hard process crash)
   — it does not move the test262 number and is out of scope for this issue.
+
+## Resolution (2026-07-04, dev-3023) — `.next is not a function` sub-bucket
+
+Landed the highest-value scoped slice: the **`.next is not a function`**
+destructuring bucket (recorded 114). Root cause confirmed by tracing the
+default (JS-host) lane: `var it = {}; it[Symbol.iterator] = function () {
+return { next(){…}, return(){…} } }` compiles the returned iterator object to a
+**closed nominal WasmGC struct** whose `.next` / `.return` are NOT native JS
+properties. Array destructuring materializes the source through the host import
+`__array_from_iter_n` → `_arrayFromIter` → (fall-through) `_drainIterable`,
+which did a naive `it.next()` and threw `it.next is not a function`. The robust
+protocol walk (resolving members via native → sidecar → `__sget_*` →
+wasm-closure `__call_fn_0`, with §7.4.6 IteratorClose on the bounded/abrupt
+stop) existed **only** for the case where `@@iterator` itself is a wasm
+closure, not for the (common) case where a native-function `@@iterator`
+*returns* a wasm-struct iterator.
+
+**Fix** (all in `src/runtime.ts`, JS-host runtime — no codegen change, so zero
+compile-time impact):
+- Extracted the robust walk into a shared `_walkWasmIterator(iteratorObj,
+  limit)` helper (bounded materialization + IteratorClose-on-cap; `limit ===
+  Infinity` drains to natural done without closing).
+- Routed the wasm-closure-`@@iterator` path through the helper (behaviour-
+  preserving refactor).
+- `_drainIterable` now diverts a wasm-struct iterator (`typeof it.next !==
+  "function"`) to `_walkWasmIterator`; plain JS iterators keep the existing
+  naive fast path unchanged.
+
+**Measured (default-lane in-process harness, 174-file set = the 114
+`.next is not a function` files + a 60-file currently-passing dstr/iter
+regression sample):** BEFORE 46 pass → AFTER 118 pass, **+72 newly passing, 0
+regressions**. Within the 114-file bucket specifically, **68 flip to pass**
+(114 → ~46), materially below the recorded 113 — acceptance criterion met.
+
+**Deliberately left for follow-up slices** (distinct code paths, not the
+iterator-protocol `.next` callability this slice scopes; all were already
+failing, none regressed):
+- **Default-parameter destructuring** over a custom iterable
+  (`static method([x] = iter)` — `destructure*Param*` path): now fails with
+  "Cannot destructure 'null' or 'undefined'" (the default-value application,
+  not the iterator protocol). ~32 files.
+- **Rest-binding codegen** for `[a, ...rest]` / `[...rest]` over a custom
+  iterable: the values now materialize correctly (`_walkWasmIterator` drains
+  them), but the rest-slice binding drops them (`rest` ends up empty). Separate
+  codegen bug in the array-destructuring rest-slice path.
+- **Generator-`yield`-inside-destructuring** + §7.4.6-step-9
+  (`return()` returns a non-object → TypeError), driven through the
+  generator-CPS `.return()` path (`array-elem-trlg-iter-list-rtrn-close-null`).
+- The remaining `for-of` / `for-await-of` abrupt-completion residual and the
+  `src/cli.ts` late-bound-symbol robustness follow-up.
+
+## Test Results
+
+`tests/issue-3023.test.ts` (5 cases, all pass): `const [x]` closes a not-done
+iterator (IteratorClose → `return()` once); `const [x]` over an already-`done`
+iterator does NOT close; multi-element `const [a, b]` binds each value and
+closes when still yielding; `for (const [x] of [iter])` inner destructuring;
+assignment destructuring `[_x] = iterable` over an exhausted iterator (no
+close). Broad regression sweep: 83/83 pass across 13 iterator/spread/
+destructuring suites (generators, rest-in-rest, spread, Array.from drivers,
+dstr-tdz). `tsc --noEmit` and `biome lint` clean.

--- a/plan/issues/3035-forawait-iterclose-closure-capture-versioning.md
+++ b/plan/issues/3035-forawait-iterclose-closure-capture-versioning.md
@@ -1,0 +1,169 @@
+---
+id: 3035
+title: "for-await/async-gen iterator-close side-effect invisible: two closure-capture bugs (NOT async-CPS versioning)"
+status: blocked
+blocked_on: [3036]
+assignee: ttraenkler/dev-asynccps
+created: 2026-07-04
+updated: 2026-07-04
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: closures, for-await-of, async-generator, iterators, destructuring
+goal: spec-completeness
+related: [3023, 2664, 3036]
+---
+
+# #3035 — for-await/async-gen iterator-close side-effect invisible
+
+## Context
+
+Blocks the #2664 (issue #3023 `.next`-callability slice, +68 test262) merge:
+#2664's runtime `_walkWasmIterator` diversion (`src/runtime.ts`) makes the
+JS-host iterator-close (`IteratorClose` → `return()`) actually fire for
+WasmGC-struct iterators. Its `merge_group` re-validation surfaced **19
+"regressions"** (mostly `language/statements/for-await-of/*ary-init-iter-close`
++ `async-generator/dstr` files) where the test asserts
+`doneCallCount === 1` (the close's side-effect) in the loop/generator body and
+reads **0**.
+
+dev-3023 root-caused this as an "async-CPS variable-versioning" bug in
+`async-cps.ts`/`async-frame.ts`. **That characterisation is incorrect.** The
+real root causes are two pre-existing **closure-capture** defects (verified sync
+too — nothing to do with the async state machine). `doneCallCount` is a captured
+variable shared between the iterator's `return()` closure (writer) and the
+loop/gen body (reader); the capture representation desyncs.
+
+## Critical reframing: the "regressions" are VACUOUS passes on main
+
+Measured (instrumented `bodyRan` flag): on **main**, the async-generator
+`for await (var [x] of [iter])` body **never runs** (`bodyRan=0`) — the
+async-gen for-await is effectively a no-op there, so these files pass
+**vacuously** (the harness scores `pass` without the assertion ever executing).
+#2664 makes the iterator-close actually run, which makes the body run and hit
+the real capture bugs. So #2664 is **not** regressing working behaviour; it is
+converting dead/vacuous passes into real executions that expose long-standing
+capture bugs. This matters for how #2664 is unblocked (see Recommendation).
+
+## Repro (faithful, `.tmp/`)
+
+Compile + run with `setExports` wired (host `__iterator` bridge), the way the
+test262 worker/equivalence harness do. Minimal, host-lane:
+
+```ts
+export function test(): number {
+  let dcc = 0;
+  const iter: any = {};
+  iter[Symbol.iterator] = function () {
+    return {
+      next() { return { value: 7, done: false }; },
+      return() { dcc += 1; return {}; },   // METHOD SHORTHAND
+    };
+  };
+  const [x] = iter;   // IteratorClose → return() → dcc should be 1
+  return dcc;         // reads 0  (BUG #2)
+}
+```
+
+- `return: function () { dcc += 1; }` (fn-expr property) → **1 (correct)**.
+- `return() { dcc += 1; }` (method shorthand) → **0 (BUG #2)**.
+
+## Root cause #1 — nested-fn-decl reader captured BY VALUE (FIXED)
+
+`src/codegen/statements/nested-declarations.ts`: a nested **function
+declaration** that only READS a captured variable computed `isMutable` from
+`writtenInBody` **only** (does THIS fn write it). When the variable is MUTATED
+by a *sibling* closure (which boxes it into a `struct (field $value (mut T))`
+ref-cell), the read-only nested-fn-decl captured it **by value** — a stale
+snapshot of the now-dead plain outer local — so it never observed the sibling's
+writes. The arrow/fn-expr path (`closures.ts` `writtenInOuter`) already handles
+this; the nested-fn-decl path did not.
+
+**Fix (landed on this branch):** mirror `writtenInOuter` —
+`collectNamesMutatedInNestedFunctions(enclosingBody)` collects names written
+inside ANY nested function scope of the enclosing function (respecting
+per-boundary shadowing via `collectWrittenIdentifiers`), and
+`isMutable = writtenInBody.has(name) || mutatedInSiblingScope.has(name)`.
+Verified: minimal repro matrix (sync/async × var/let × for-of/for-await) all
+flip BUG→OK; `tests/equivalence/` capture/async/generator/iterator subset shows
+**zero new failures** (the 8 failures in that subset are pre-existing on main:
+`tdz-reference-error` ×6, `optional-direct-closure-call` ×2 — confirmed against
+main). This fix alone flips the `async-generator/dstr/ary-init-iter-close.js`
+(fn-expr-property writer) test PASS. It does **not** fix the method-shorthand
+cluster (that is bug #2).
+
+## Root cause #2 — object/class method captured-write to a BOXED transitive var (PARKED → #3036)
+
+`return() {}` (object-literal **method shorthand**) — and equally **class
+methods and class get/set accessors** — that write a variable captured
+**transitively** from a grandparent scope, when that variable is BOXED (a
+sibling mutates it), emit **garbage**. WAT of the method body for `dcc += 1`:
+
+```
+global.get 11   ;; __captured_doneCallCount — holds the ref-cell BOX
+drop
+f64.const 0     ;; read of dcc: WRONG — never derefs the box (struct.get)
+f64.const 1
+f64.add
+drop            ;; the computed 1 is discarded
+ref.null 20
+global.set 11   ;; write of dcc: WRONG — NULLS the box global
+```
+
+Mechanism: method shorthand routes through
+`emitObjectLiteralMethodFn` → `compileArrowAsCallback` →
+`promoteAccessorCapturesToGlobals` (`closures.ts`). For a BOXED captured local
+it promotes the **box** into a `capturedGlobals`/`capturedBoxGlobals` entry
+whose global holds the ref-cell — but `identifiers.ts` (read) and
+`assignment.ts` (write) resolve `capturedGlobals`/never consult
+`capturedBoxGlobals` and treat the global as holding the VALUE, not the box, so
+they never `struct.get`/`struct.set`-deref it. The fn-expr-property form works
+because it routes through `compileArrowAsClosure` (closure-struct captures,
+box-aware).
+
+**Scope of bug #2 (verified):** direct object-method captured writes WORK
+(`const o = { bump() { c += 1 } }; o.bump()` → 2). The bug is specifically the
+**transitive** shape (method nested inside another closure, capturing a
+grandparent var that is boxed). Class methods (`= 0`) and class getters
+(`= NaN`) hit it too → **broad-impact** (`promoteAccessorCapturesToGlobals` is
+shared by object-literal methods + class methods + class accessors). Must be
+validated via full CI / `merge_group`, not a scoped sweep
+([[project_broad_impact_validate_full_ci]]).
+
+**Why parked (per the senior-dev STOP-AND-FLAG guard):** bug #2 is a broad
+capture-subsystem fix touching a heavily-accumulated area (`#2029`/`#2669`
+lineage: `capturedGlobals` / `capturedBoxGlobals` / `boxedCaptures`), affecting
+ALL class methods/accessors + object-literal methods that capture boxed
+transitive vars. A correct fix cannot be adequately verified with local scoped
+checks — it needs the full test262/`merge_group` regression signal — and a
+subtly-wrong capture fix silently miscompiles closures/methods. Split out as
+**#3036, Fable-reserved**, with a complete spec.
+
+## Recommendation for unblocking #2664
+
+Two viable paths:
+
+1. **Land #3036 (bug #2 fix) + this branch's bug #1 fix, stacked on #2664.**
+   That makes the 13 method-shorthand `*ary-init-iter-close` tests GENUINELY
+   pass (a real conformance win), and the fn-expr ones via bug #1, clearing the
+   `merge_group` regressions so #2664 merges. Preferred.
+2. **Vacuity route.** Because these files pass **vacuously** on main (body never
+   runs), the #2940 vacuity/reclassification mechanism arguably should excuse
+   them (the merge_group report showed "Excused vacuous reclassifications: 0",
+   i.e. it did NOT excuse them — a harness-vacuity-detection gap for the
+   async-gen-for-await-no-op shape). This is a PO/lead call, not a codegen fix.
+
+Do NOT blind-remove #2664's `hold`. Its 19 regressions are real (the assertion
+does execute under #2664) until #3036 lands or the vacuity route is chosen.
+
+## Branch / state
+
+Branch `issue-3035-async-cps-iterclose-version` (worktree
+`/workspace/.claude/worktrees/agent-a86d11230e58881bf`), stacked on #2664's
+`origin/issue-3023-iterator-next-callable` (predecessor-stacking; #2664's
+`src/runtime.ts` fix is required to EXPOSE — and to test — this cluster).
+Contains: bug #1 fix (`nested-declarations.ts`) + this doc + #3036. Not a merge
+candidate until #3036 lands on top.

--- a/plan/issues/3036-accessor-method-boxed-transitive-capture-write.md
+++ b/plan/issues/3036-accessor-method-boxed-transitive-capture-write.md
@@ -1,10 +1,12 @@
 ---
 id: 3036
 title: "object/class methods & accessors can't read/write a BOXED transitively-captured outer variable (emit garbage)"
-status: ready
+status: done
 sprint: current
 created: 2026-07-04
-updated: 2026-07-04
+updated: 2026-07-05
+completed: 2026-07-05
+assignee: ttraenkler/dev-3036
 priority: high
 horizon: l
 feasibility: hard
@@ -125,3 +127,82 @@ Stack on `issue-3035-async-cps-iterclose-version` (has #3035 bug #1 + #2664).
 Re-claim with `--force` if resuming that branch. Once #3036 lands there, the
 whole stack clears #2664's `merge_group` regressions and can merge, delivering
 #2664's +68 (`.next`-callability) win + the genuine iterator-close cluster.
+
+## Implementation (dev-3036, branch `issue-3036-accessor-method-boxed-capture`)
+
+Implemented the recommended fix. **Key design decision: ADDITIVE, not a
+move.** Rather than moving boxed names OUT of `ctx.capturedGlobals` into
+`ctx.capturedBoxGlobals` (which would silently change every unmodified
+consumer — closure materialization, the class-defer heuristic, var-init
+re-sync, `isUnresolvableIdent`), the boxed name is registered in **both**:
+the existing `capturedGlobals` entry is kept byte-identical, and the same
+global is **additionally** recorded in `capturedBoxGlobals` **with the inner
+`valType`**. The scalar read/write sites consult `capturedBoxGlobals` FIRST
+and deref; every other site is untouched. This makes unmodified paths provably
+regression-free (an unmodified site sees exactly the old map state) and lets
+the fix be added incrementally.
+
+The `capturedBoxGlobals` entry `valType` is present ONLY for direct boxed
+captures (a var the body reads/writes itself). The pre-existing transitive-fn
+box entries (used only by closure materialization in `calls.ts`) leave it
+undefined; `getCapturedBoxGlobal` returns `undefined` for those, so the scalar
+sites never deref a name they shouldn't.
+
+Files changed:
+- `context/types.ts` — added optional `valType` to the `capturedBoxGlobals`
+  entry type, with a doc note on the direct-vs-transitive distinction.
+- `closures.ts` (`promoteAccessorCapturesToGlobals`) — after the existing
+  value-global promotion, if the promoted local is boxed
+  (`fctx.boxedCaptures.has(name)`), additionally register the global in
+  `capturedBoxGlobals` with `refCellTypeIdx` + `valType`.
+- `property-access.ts` — three shared helpers: `getCapturedBoxGlobal`
+  (resolve, valType-gated), `emitCapturedBoxGlobalRead` (null-guarded
+  `global.get; struct.get 0`, mirrors the boxedCaptures local-box read),
+  `emitCapturedBoxGlobalWrite` (null-guarded `struct.set 0` from a temp local).
+- `identifiers.ts` — read branch before `capturedGlobals`.
+- `assignment.ts` — box-first branches at: simple `=`, the
+  destructuring/for-of write helper, the top of `compileCompoundAssignment`
+  (covers `+=`/`-=`/… numeric + externref string-concat via the shared
+  `emitCompoundOp`), and the logical-assign (`&&=`/`||=`/`??=`) storage
+  descriptor (new `capturedBox` kind).
+- `unary-updates.ts` — box branches at prefix `++`, prefix `--`, postfix
+  (`emitCapturedBoxGlobalIncDec`, f64-based, prefix→new / postfix→old).
+- `registry/imports.ts` (`fixupModuleGlobalIndices`) — shift each
+  `capturedBoxGlobals` entry's `globalIdx` on a late string-constant import.
+  **This was also a latent staleness bug for the existing transitive-fn box
+  global** (its object-valued entries were never shifted); fixing it here
+  covers both.
+
+### Verification
+
+- All #3036 read/write/increment repros (`.tmp/repro-3036.mts`) flip
+  garbage→correct: transitive object-method write (=2), class-method write
+  (=2), method-shorthand write, object-method `c++` (=2), class-method `--c`
+  (=-2), boxed-capture getter read under **static** dispatch (=5), class-method
+  read via `any` (=5), iterator-close `return(){}` (=1).
+- **The 12 method-shorthand `for-await-of/*ary-init-iter-close*` test262 files:
+  0/12 pass on the base (`3844b8a`, #3035+#2664 without #3036) → 12/12 pass on
+  this branch.** My fix is exactly what flips them (genuine executions, not
+  vacuous). (Spec estimated "13"; there are 12 with `return(){}` shorthand.)
+- Full `tests/equivalence/` suite (1638 tests): **identical failure set** on
+  this branch vs the base commit (15 files / 36 tests fail on BOTH; 1599 pass
+  on both) — zero regressions. Targeted closure/accessor/class/method/capture
+  files (`accessor-side-effects`, `getters-setters`, `classes`,
+  `class-methods`, `flatmap-closure`, `#1712`, `#1528`, `#1573`, `#2623`
+  capture-box-depth, `#2029` family) also identical to base. `tsc --noEmit`
+  clean.
+
+### Out of scope / caveat (separate pre-existing bug, NOT #3036)
+
+The spec's 4th repro — a getter read via an **`any`-typed receiver on a class
+declared inside a function** (`const o: any = make(); o.v`) — still returns
+`NaN`. This is a **separate, orthogonal dynamic-accessor-dispatch bug**: a
+getter returning a **constant** (no capture at all) also returns `NaN` through
+that exact dispatch shape (`class K { get v(){ return 42; } }` inside a fn,
+read via `any` → `NaN`). My additive branches are no-ops for non-boxed names,
+so that codegen is byte-identical to before. The #3036 capture fix for getter
+*reads* is proven correct by the static-dispatch case (→5) and the
+class-method-read-via-any case (→5). The `any`-receiver nested-class accessor
+dispatch gap should be filed as a follow-up; it is not the boxed-capture deref
+mechanism #3036 targets, and per the senior-dev STOP-AND-DOCUMENT guard I did
+not fold a second, unrelated dispatch redesign into this PR.

--- a/plan/issues/3036-accessor-method-boxed-transitive-capture-write.md
+++ b/plan/issues/3036-accessor-method-boxed-transitive-capture-write.md
@@ -1,0 +1,127 @@
+---
+id: 3036
+title: "object/class methods & accessors can't read/write a BOXED transitively-captured outer variable (emit garbage)"
+status: ready
+sprint: current
+created: 2026-07-04
+updated: 2026-07-04
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: closures, object-literal methods, class methods, accessors, iterators
+goal: spec-completeness
+owner: fable
+related: [3035, 3023, 2664, 2029, 2669]
+architect_spec: candidate
+---
+
+# #3036 — [FABLE-RESERVED] accessor/method write to a BOXED transitively-captured var emits garbage
+
+Split from #3035. This is the **broad-impact** half; validate via full CI /
+`merge_group`, never a scoped sweep ([[project_broad_impact_validate_full_ci]]).
+
+## Symptom
+
+An object-literal **method shorthand**, a **class method**, or a **class
+get/set accessor** that reads or writes a variable captured **transitively**
+from a grandparent scope — when that variable is BOXED (a sibling closure
+mutates it, so it lives in a `struct (field $value (mut T))` ref-cell) —
+emits garbage: reads yield the f64/ref default (0 / NaN / null), writes NULL
+the box global. The fn-expr-property form (`m: function(){}`) is CORRECT (it
+routes through `compileArrowAsClosure`, box-aware).
+
+Verified repros (host lane, `setExports` wired):
+
+```ts
+// BUG (=0): transitive object-literal METHOD write
+let c = 0;
+const make = function () { return { bump() { c += 1; } }; };
+const o = make(); o.bump(); o.bump();          // c === 0, want 2
+
+// OK (=2): same via fn-expr property
+const make2 = function () { return { bump: function(){ c += 1; } }; };
+
+// BUG (=0): transitive CLASS method write
+const make3 = function () { class K { bump() { c += 1; } } return new K(); };
+
+// BUG (=NaN): transitive CLASS getter read of boxed var
+const make4 = function () { class K { get v() { return c; } } return new K(); };
+```
+
+This is the dominant blocker for the #2664 `merge_group` regressions: the
+`for-await-of` / `async-generator` `*ary-init-iter-close` test262 files use a
+`return() {}` method shorthand whose `doneCallCount += 1` never reaches the
+shared box, so the loop/gen body reads `doneCallCount === 0` (want 1).
+
+## Root cause
+
+`{ m() {} }` method shorthand → `emitObjectLiteralMethodFn` (`literals.ts:842`)
+→ (non-standalone) `compileArrowAsCallback(..., { needsThis: true })` →
+`promoteAccessorCapturesToGlobals` (`closures.ts:353`). Class methods/accessors
+reach the same `promoteAccessorCapturesToGlobals` path. For a captured local
+that is already BOXED in the enclosing `fctx` (`fctx.boxedCaptures.has(name)`,
+`localType` = the ref-cell type), the promotion registers the **box** in
+`capturedGlobals` (global named `__captured_<name>`, type = ref-cell) — but the
+accessor/method body's identifier resolution never derefs it:
+
+- `identifiers.ts` read path (~L676): `capturedGlobals.get(name)` →
+  `global.get idx` and returns the ref-cell type as the value. No `struct.get`.
+- `assignment.ts` write paths (many sites — simple `=`, compound `+=`,
+  prefix/postfix `++`/`--`, ~L367/598/4446/5341/5401/5594/5931…): `global.set`
+  the box global with the raw value / null. No `struct.get`+`struct.set` deref.
+
+`capturedBoxGlobals` (the transitive-fn box-in-global alias, `closures.ts`
+~L462; consulted in `closures.ts` materialization + `calls.ts:13965`) is NEVER
+consulted by `identifiers.ts` / `assignment.ts`. So a boxed captured name in an
+accessor/method body is unhandled → garbage.
+
+## Fix approach (recommended)
+
+Make the accessor/method body deref the box for BOXED captured globals:
+
+1. In `promoteAccessorCapturesToGlobals`, when the captured local is boxed
+   (`fctx.boxedCaptures.has(name)` / `localType` is a registered ref-cell),
+   register the promoted global in `ctx.capturedBoxGlobals`
+   `{ globalIdx, refCellTypeIdx }` (NOT plain `capturedGlobals`), and store the
+   inner value type. (It already does this for the transitive-fn case; extend
+   to the direct-boxed-local case.)
+2. In `identifiers.ts` read resolution, add a `capturedBoxGlobals` branch
+   BEFORE `capturedGlobals`: `global.get boxIdx; struct.get refCellTypeIdx 0`,
+   return the inner value type.
+3. In `assignment.ts`, add a `capturedBoxGlobals` branch to EACH write site
+   (simple, compound, prefix/postfix, destructuring-assign): read =
+   `global.get boxIdx; struct.get`; write = `global.get boxIdx; <value>;
+   struct.set refCellTypeIdx 0`. Mirror the existing `boxedCaptures`
+   (local-box) deref emitters so the two stay in lockstep.
+
+Low-risk argument: a `capturedBoxGlobals`-body name currently ALWAYS
+miscompiles (no working path relies on it), so adding correct deref is
+garbage→correct; names NOT in `capturedBoxGlobals` are untouched. BUT the change
+touches `promoteAccessorCapturesToGlobals` (shared by object-literal methods +
+class methods + class accessors), so **full `merge_group` validation is
+mandatory** — a subtly-wrong capture fix silently miscompiles closures/methods.
+
+### Alternative (rejected as riskier)
+
+Route method shorthand through `compileArrowAsClosure` (like standalone +
+fn-expr-property) instead of `compileArrowAsCallback`. Rejected: changes the
+host-callback ABI (`needsThis` / host-invocability via `_walkWasmIterator`) for
+methods that use `this` — broad blast radius on host-callable methods.
+
+## Acceptance
+
+- All four repros above return their `want` value.
+- The 13 `for-await-of` / `async-generator` `*ary-init-iter-close` method-
+  shorthand test262 files pass GENUINELY (with #3035 bug #1 + #2664 stacked).
+- Full `merge_group` green (no new regressions in class-method / accessor /
+  object-literal / closure suites).
+
+## Handoff
+
+Stack on `issue-3035-async-cps-iterclose-version` (has #3035 bug #1 + #2664).
+Re-claim with `--force` if resuming that branch. Once #3036 lands there, the
+whole stack clears #2664's `merge_group` regressions and can merge, delivering
+#2664's +68 (`.next`-callability) win + the genuine iterator-close cluster.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -528,6 +528,28 @@ export function promoteAccessorCapturesToGlobals(
       ctx.capturedGlobalsWidened.add(name);
     }
 
+    // (#3036) When the promoted local is a BOXED mutable capture (a ref cell:
+    // a sibling closure mutates it, so `fctx.boxedCaptures.has(name)`), the
+    // global we just created holds the ref-cell BOX, not the scalar value.
+    // Register it ADDITIVELY in `capturedBoxGlobals` WITH the inner value type
+    // (`valType`), keeping the `capturedGlobals` entry above intact so every
+    // unmodified consumer (closure materialization, class-defer heuristic,
+    // var-init re-sync) behaves exactly as before. The accessor/method body's
+    // scalar read (identifiers.ts) and write (assignment.ts / unary-updates.ts)
+    // sites check `capturedBoxGlobals` FIRST and DEREF the box
+    // (`global.get; struct.get/struct.set field 0`). Without this, a
+    // method-shorthand / class-method / class-accessor that reads or writes a
+    // transitively-captured boxed var emits garbage (read → f64/ref default;
+    // write → computes the value, drops it, then NULLs the box global).
+    const boxedInfo = fctx.boxedCaptures?.get(name);
+    if (boxedInfo) {
+      (ctx.capturedBoxGlobals ??= new Map()).set(name, {
+        globalIdx,
+        refCellTypeIdx: boxedInfo.refCellTypeIdx,
+        valType: boxedInfo.valType,
+      });
+    }
+
     // If this variable has a local TDZ flag, also promote it to a global TDZ flag
     const tdzFlagLocalIdx = fctx.tdzFlagLocals?.get(name);
     if (tdzFlagLocalIdx !== undefined) {

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -945,8 +945,17 @@ export interface CodegenContext {
    * boxes `v` eagerly in the enclosing fctx and aliases the box in a module
    * global of type `(ref null $cell)`; closure-materialization sites source
    * the capture from here when the current fctx cannot resolve it.
+   *
+   * (#3036) `valType` (the ref cell's inner value type) is present ONLY for
+   * DIRECT boxed captures — a variable the accessor/method body reads or
+   * writes itself (not merely through a nested closure). When set, the
+   * read/write sites (identifiers.ts / assignment.ts / unary-updates.ts) must
+   * DEREF the box (`global.get; struct.get/struct.set field 0`) instead of
+   * treating the global as holding the value. Transitive-fn box entries leave
+   * `valType` undefined; they are consumed only by closure materialization
+   * (calls.ts), never by the scalar read/write sites.
    */
-  capturedBoxGlobals?: Map<string, { globalIdx: number; refCellTypeIdx: number }>;
+  capturedBoxGlobals?: Map<string, { globalIdx: number; refCellTypeIdx: number; valType?: ValType }>;
   /** Set of class names (local classes compiled to Wasm GC structs) */
   classSet: Set<string>;
   /**

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -36,7 +36,10 @@ import { reserveMemberSetDispatch } from "../member-set-dispatch.js"; // (#2681/
 import { reserveMemberGetDispatch } from "../member-get-dispatch.js"; // (#2681/#2686) symmetric struct read for compound
 import {
   emitAlternateStructSetDispatch,
+  emitCapturedBoxGlobalRead,
+  emitCapturedBoxGlobalWrite,
   emitNullGuardedStructGet,
+  getCapturedBoxGlobal,
   isProvablyNonNull,
   isSafeBoundsEliminated,
   tryEmitDeleteAwareDynamicSet,
@@ -363,6 +366,30 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
       emitMappedArgParamSync(ctx, fctx, localIdx, resultType);
       return resultType;
     }
+    // (#3036) Boxed captured global — write THROUGH the ref cell (struct.set
+    // field 0), not into the box global (which would replace the shared cell
+    // with the raw value / null). Mirrors the boxedCaptures local-box `=` path.
+    const capturedBoxSimple = getCapturedBoxGlobal(ctx, name);
+    if (capturedBoxSimple !== undefined) {
+      const resultType = compileExpression(ctx, fctx, expr.right, capturedBoxSimple.valType);
+      if (!resultType) {
+        reportError(ctx, expr, "Failed to compile assignment value");
+        return null;
+      }
+      if (!valTypesMatch(resultType, capturedBoxSimple.valType)) {
+        coerceType(ctx, fctx, resultType, capturedBoxSimple.valType);
+      }
+      const tmpVal = allocLocal(fctx, `__box_g_tmp_${fctx.locals.length}`, capturedBoxSimple.valType);
+      fctx.body.push({ op: "local.set", index: tmpVal });
+      // entry.globalIdx is read fresh inside the helper AFTER RHS compilation,
+      // and `capturedBoxGlobals` is shifted in the global-index fixup, so a
+      // string-constant global added while compiling the RHS can't stale it.
+      emitCapturedBoxGlobalWrite(fctx, capturedBoxSimple, tmpVal);
+      // Assignment expression result: the (coerced) assigned value.
+      fctx.body.push({ op: "local.get", index: tmpVal });
+      return capturedBoxSimple.valType;
+    }
+
     // Check captured globals
     const capturedIdx = ctx.capturedGlobals.get(name);
     if (capturedIdx !== undefined) {
@@ -592,6 +619,17 @@ function emitIdentifierWriteFromLocal(
     const localType = getLocalType(fctx, localIdx);
     pushRhsCoerced(localType);
     fctx.body.push({ op: "local.set", index: localIdx });
+    return;
+  }
+
+  // (#3036) Boxed captured global — destructuring / for-of style write through
+  // the ref cell rather than overwriting the box global.
+  const capturedBoxWrite = getCapturedBoxGlobal(ctx, name);
+  if (capturedBoxWrite !== undefined) {
+    pushRhsCoerced(capturedBoxWrite.valType);
+    const tmpVal = allocLocal(fctx, `__box_gw_${fctx.locals.length}`, capturedBoxWrite.valType);
+    fctx.body.push({ op: "local.set", index: tmpVal });
+    emitCapturedBoxGlobalWrite(fctx, capturedBoxWrite, tmpVal);
     return;
   }
 
@@ -4429,6 +4467,7 @@ export function compileLogicalAssignment(
   let storage:
     | { kind: "local"; index: number; type: ValType }
     | { kind: "captured"; index: number; type: ValType }
+    | { kind: "capturedBox"; box: { globalIdx: number; refCellTypeIdx: number; valType: ValType }; type: ValType }
     | { kind: "module"; index: number; type: ValType }
     | null = null;
 
@@ -4441,6 +4480,13 @@ export function compileLogicalAssignment(
       index: localIdx,
       type: localType ?? { kind: "f64" },
     };
+  }
+  if (!storage) {
+    // (#3036) Boxed captured global — read/write THROUGH the ref cell.
+    const capturedBoxLogical = getCapturedBoxGlobal(ctx, name);
+    if (capturedBoxLogical !== undefined) {
+      storage = { kind: "capturedBox", box: capturedBoxLogical, type: capturedBoxLogical.valType };
+    }
   }
   if (!storage) {
     const capturedIdx = ctx.capturedGlobals.get(name);
@@ -4486,12 +4532,24 @@ export function compileLogicalAssignment(
     return ctx.moduleGlobals.get(name)!;
   };
   const emitGet = () => {
-    if (storage!.kind === "local") fctx.body.push({ op: "local.get", index: getStorageIndex() });
-    else fctx.body.push({ op: "global.get", index: getStorageIndex() });
+    if (storage!.kind === "capturedBox") {
+      emitCapturedBoxGlobalRead(ctx, fctx, storage!.box);
+    } else if (storage!.kind === "local") {
+      fctx.body.push({ op: "local.get", index: getStorageIndex() });
+    } else {
+      fctx.body.push({ op: "global.get", index: getStorageIndex() });
+    }
   };
   const emitSet = () => {
-    if (storage!.kind === "local") fctx.body.push({ op: "local.tee", index: getStorageIndex() });
-    else {
+    if (storage!.kind === "capturedBox") {
+      // Value on stack → stash, write through the cell, re-read for the result.
+      const tmpVal = allocLocal(fctx, `__box_glog_${fctx.locals.length}`, storage!.box.valType);
+      fctx.body.push({ op: "local.set", index: tmpVal });
+      emitCapturedBoxGlobalWrite(fctx, storage!.box, tmpVal);
+      emitCapturedBoxGlobalRead(ctx, fctx, storage!.box);
+    } else if (storage!.kind === "local") {
+      fctx.body.push({ op: "local.tee", index: getStorageIndex() });
+    } else {
       const idx = getStorageIndex();
       fctx.body.push({ op: "global.set", index: idx });
       fctx.body.push({ op: "global.get", index: idx });
@@ -5876,6 +5934,69 @@ export function compileCompoundAssignment(
     emitThrowString(ctx, fctx, "TypeError: Assignment to constant variable.");
     fctx.body.push({ op: "unreachable" });
     return { kind: "f64" };
+  }
+
+  // (#3036) Boxed captured global compound-assign (`c += 1` in a method-
+  // shorthand / class-method / accessor body reading a transitively-captured
+  // boxed var). Read THROUGH the ref cell, apply the op, write back THROUGH the
+  // cell — never treat the box global as holding the scalar. Self-contained
+  // (sources the box from the global each time, no localMap rebind) to avoid a
+  // conditionally-set-local dominance hazard; mirrors the boxedCaptures
+  // local-box compound path below (string concat for externref cells, f64
+  // arithmetic with coerce-in/coerce-out for numeric cells).
+  const capturedBoxCompound = getCapturedBoxGlobal(ctx, name);
+  if (capturedBoxCompound !== undefined) {
+    const valType = capturedBoxCompound.valType;
+    // Read current value (null-guarded default for an uninitialized cell).
+    emitCapturedBoxGlobalRead(ctx, fctx, capturedBoxCompound);
+
+    // externref cell + `+=`: string concat when either side is string-typed.
+    if (valType.kind === "externref" && op === ts.SyntaxKind.PlusEqualsToken) {
+      const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
+      const rhsIsString = isStringType(rightTsType);
+      const lhsIsString = isStringType(ctx.checker.getTypeAtLocation(expr.left));
+      const varHasStringAssign = hasStringAssignment(name, expr) || hasStringAssignmentInParentScopes(name, expr);
+      if (rhsIsString || lhsIsString || varHasStringAssign) {
+        addStringImports(ctx);
+        const concatIdx = ctx.jsStringImports.get("concat");
+        if (concatIdx !== undefined) {
+          const compoundRhsStr = compileExpression(ctx, fctx, expr.right);
+          if (!compoundRhsStr) {
+            reportError(ctx, expr, "Failed to compile compound assignment RHS");
+            return null;
+          }
+          if (compoundRhsStr.kind === "f64" || compoundRhsStr.kind === "i32") {
+            if (compoundRhsStr.kind === "i32") fctx.body.push({ op: "f64.convert_i32_s" });
+            const toStr = ctx.funcMap.get("number_toString");
+            if (toStr !== undefined) fctx.body.push({ op: "call", funcIdx: toStr });
+          }
+          fctx.body.push({ op: "call", funcIdx: concatIdx });
+          const tmpStr = allocLocal(fctx, `__box_gcmp_${fctx.locals.length}`, valType);
+          fctx.body.push({ op: "local.set", index: tmpStr });
+          emitCapturedBoxGlobalWrite(fctx, capturedBoxCompound, tmpStr);
+          fctx.body.push({ op: "local.get", index: tmpStr });
+          return valType;
+        }
+      }
+    }
+
+    // Numeric / bitwise: the op switch is f64-based, so promote a non-f64 cell
+    // value (and the RHS) to f64 and coerce the result back on writeback.
+    const needsCoerce = valType.kind !== "f64";
+    if (needsCoerce) coerceType(ctx, fctx, valType, { kind: "f64" });
+    const compoundRhs = compileExpression(ctx, fctx, expr.right, needsCoerce ? { kind: "f64" } : valType);
+    if (!compoundRhs) {
+      reportError(ctx, expr, "Failed to compile compound assignment RHS");
+      return null;
+    }
+    if (needsCoerce && compoundRhs.kind !== "f64") coerceType(ctx, fctx, compoundRhs, { kind: "f64" });
+    emitCompoundOp(ctx, fctx, op);
+    if (needsCoerce) coerceType(ctx, fctx, { kind: "f64" }, valType);
+    const tmpRes = allocLocal(fctx, `__box_gcmp_${fctx.locals.length}`, valType);
+    fctx.body.push({ op: "local.set", index: tmpRes });
+    emitCapturedBoxGlobalWrite(fctx, capturedBoxCompound, tmpRes);
+    fctx.body.push({ op: "local.get", index: tmpRes });
+    return valType;
   }
 
   // String += : concat instead of numeric add.

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -27,7 +27,7 @@ import {
   localGlobalIdx,
   resolveWasmType,
 } from "../index.js";
-import { emitNullGuardedStructGet } from "../property-access.js";
+import { emitCapturedBoxGlobalRead, emitNullGuardedStructGet, getCapturedBoxGlobal } from "../property-access.js";
 import { coerceType, compileExpression } from "../shared.js";
 import { emitTdzCheck } from "../statements.js";
 import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
@@ -670,6 +670,22 @@ function compileIdentifierCore(ctx: CodegenContext, fctx: FunctionContext, id: t
     }
 
     return declaredType;
+  }
+
+  // (#3036) Check BOXED captured globals FIRST — a transitively-captured
+  // mutable var (ref cell) that a method-shorthand / class-method / accessor
+  // body reads. The promoted global holds the box; deref it (global.get;
+  // struct.get field 0) rather than returning the ref cell as if it were the
+  // value (which coerced ref→f64 to `f64.const 0` / ref→externref to garbage).
+  const capturedBox = getCapturedBoxGlobal(ctx, name);
+  if (capturedBox !== undefined) {
+    const tdzResult = ctx.tdzGlobals.has(name) ? analyzeTdzAccess(ctx, id) : "skip";
+    if (tdzResult === "check") {
+      emitTdzCheck(ctx, fctx, name);
+    } else if (tdzResult === "throw") {
+      emitStaticTdzThrow(ctx, fctx, id.text);
+    }
+    return emitCapturedBoxGlobalRead(ctx, fctx, capturedBox);
   }
 
   // Check captured globals (variables promoted from enclosing scope for callbacks)

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -25,6 +25,9 @@ import {
 import {
   emitAlternateStructSetDispatch,
   emitBoundsGuardedArraySet,
+  emitCapturedBoxGlobalRead,
+  emitCapturedBoxGlobalWrite,
+  getCapturedBoxGlobal,
   resolveInheritedStaticProp,
 } from "../property-access.js";
 import { reserveMemberGetDispatch } from "../member-get-dispatch.js"; // (#2681/#2686) symmetric struct read for inc/dec
@@ -909,6 +912,39 @@ function compileMemberIncDec(
  * Caller must have already established that `expr.operator` is either
  * `PlusPlusToken` or `MinusMinusToken`.
  */
+/**
+ * (#3036) `++x` / `--x` / `x++` / `x--` on a BOXED captured global — a
+ * transitively-captured mutable var an accessor/method body updates. Reads and
+ * writes THROUGH the ref cell (never the raw box global). Numeric-only: the
+ * cell value is promoted to f64, incremented, coerced back to the cell type.
+ * Returns f64 (prefix → new value, postfix → old value), matching the module /
+ * captured-global inc/dec sites.
+ */
+function emitCapturedBoxGlobalIncDec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  entry: { globalIdx: number; refCellTypeIdx: number; valType: ValType },
+  arithOp: "f64.add" | "f64.sub",
+  isPrefix: boolean,
+): ValType {
+  // Read the current cell value and promote to f64.
+  emitCapturedBoxGlobalRead(ctx, fctx, entry);
+  if (entry.valType.kind !== "f64") coerceType(ctx, fctx, entry.valType, { kind: "f64" });
+  const oldF64 = allocLocal(fctx, `__box_ginc_old_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.tee", index: oldF64 });
+  fctx.body.push({ op: "f64.const", value: 1 });
+  fctx.body.push({ op: arithOp });
+  const newF64 = allocLocal(fctx, `__box_ginc_new_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.tee", index: newF64 });
+  // Coerce the new f64 back to the cell type and write it through the box.
+  if (entry.valType.kind !== "f64") coerceType(ctx, fctx, { kind: "f64" }, entry.valType);
+  const newVal = allocLocal(fctx, `__box_ginc_val_${fctx.locals.length}`, entry.valType);
+  fctx.body.push({ op: "local.set", index: newVal });
+  emitCapturedBoxGlobalWrite(fctx, entry, newVal);
+  fctx.body.push({ op: "local.get", index: isPrefix ? newF64 : oldF64 });
+  return { kind: "f64" };
+}
+
 function compilePrefixUpdate(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -928,6 +964,11 @@ function compilePrefixUpdate(
         return { kind: "f64" };
       }
       if (ts.isIdentifier(ppOperand)) {
+        if (fctx.localMap.get(ppOperand.text) === undefined) {
+          // (#3036) ++x on a boxed captured global — update through the cell.
+          const ppBox = getCapturedBoxGlobal(ctx, ppOperand.text);
+          if (ppBox !== undefined) return emitCapturedBoxGlobalIncDec(ctx, fctx, ppBox, "f64.add", true);
+        }
         const idx = fctx.localMap.get(ppOperand.text);
         if (idx !== undefined) {
           const boxedPP = fctx.boxedCaptures?.get(ppOperand.text);
@@ -1139,6 +1180,11 @@ function compilePrefixUpdate(
         return { kind: "f64" };
       }
       if (ts.isIdentifier(mmOperand)) {
+        if (fctx.localMap.get(mmOperand.text) === undefined) {
+          // (#3036) --x on a boxed captured global — update through the cell.
+          const mmBox = getCapturedBoxGlobal(ctx, mmOperand.text);
+          if (mmBox !== undefined) return emitCapturedBoxGlobalIncDec(ctx, fctx, mmBox, "f64.sub", true);
+        }
         const idx = fctx.localMap.get(mmOperand.text);
         if (idx !== undefined) {
           const boxed = fctx.boxedCaptures?.get(mmOperand.text);
@@ -1372,6 +1418,10 @@ function compilePostfixUnary(
     }
     const idx = fctx.localMap.get(postOperand.text);
     if (idx === undefined) {
+      // (#3036) x++/x-- on a boxed captured global — update through the cell,
+      // returning the OLD numeric value (postfix semantics).
+      const postBox = getCapturedBoxGlobal(ctx, postOperand.text);
+      if (postBox !== undefined) return emitCapturedBoxGlobalIncDec(ctx, fctx, postBox, arithOp, false);
       // Check module globals for postfix ++/--
       const postModIdx = ctx.moduleGlobals.get(postOperand.text);
       if (postModIdx !== undefined) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2029,6 +2029,82 @@ export function emitNullGuardedStructGet(
 }
 
 /**
+ * (#3036) Resolve a name to a DIRECT boxed captured global — a
+ * transitively-captured mutable local that a method-shorthand / class-method /
+ * class-accessor body reads or writes itself. `promoteAccessorCapturesToGlobals`
+ * aliases the ref-cell BOX in a module global and records the inner value type
+ * in `ctx.capturedBoxGlobals`. Returns the entry only when `valType` is present:
+ * transitive-fn box entries (used only by closure materialization in calls.ts)
+ * leave it undefined and must NOT be dereferenced by the scalar read/write
+ * sites. The read/write sites (identifiers.ts / assignment.ts /
+ * unary-updates.ts) consult this FIRST — before `capturedGlobals` — so a boxed
+ * capture derefs the cell instead of treating the global as holding the value.
+ */
+export function getCapturedBoxGlobal(
+  ctx: CodegenContext,
+  name: string,
+): { globalIdx: number; refCellTypeIdx: number; valType: ValType } | undefined {
+  const e = ctx.capturedBoxGlobals?.get(name);
+  if (e && e.valType) {
+    return e as { globalIdx: number; refCellTypeIdx: number; valType: ValType };
+  }
+  return undefined;
+}
+
+/**
+ * (#3036) Emit a null-guarded READ of a boxed captured global. Leaves the inner
+ * value on the stack and returns its type. Mirrors the `boxedCaptures`
+ * (local-box) read in identifiers.ts, sourcing the box ref from a module global
+ * instead of a local slot. The box is initialised to null and set by the
+ * enclosing function at object/class construction, so an uninitialised cell
+ * yields the type default (never traps) — matching the local-box semantics.
+ */
+export function emitCapturedBoxGlobalRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  entry: { globalIdx: number; refCellTypeIdx: number; valType: ValType },
+): ValType {
+  fctx.body.push({ op: "global.get", index: entry.globalIdx });
+  emitNullGuardedStructGet(
+    ctx,
+    fctx,
+    { kind: "ref_null", typeIdx: entry.refCellTypeIdx },
+    entry.valType,
+    entry.refCellTypeIdx,
+    0,
+    undefined /* propName */,
+    false /* throwOnNull — ref cells use default for uninitialized captures */,
+  );
+  return entry.valType;
+}
+
+/**
+ * (#3036) Emit a null-guarded WRITE through a boxed captured global. The value
+ * to store must already sit in `valLocalIdx` (typed as `entry.valType`). Mirrors
+ * the `boxedCaptures` (local-box) write in assignment.ts: if the box ref is null
+ * the store is skipped (#702), otherwise `struct.set field 0` writes through the
+ * shared cell so the enclosing scope observes the mutation.
+ */
+export function emitCapturedBoxGlobalWrite(
+  fctx: FunctionContext,
+  entry: { globalIdx: number; refCellTypeIdx: number },
+  valLocalIdx: number,
+): void {
+  fctx.body.push({ op: "global.get", index: entry.globalIdx });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [] as Instr[],
+    else: [
+      { op: "global.get", index: entry.globalIdx } as Instr,
+      { op: "local.get", index: valLocalIdx } as Instr,
+      { op: "struct.set", typeIdx: entry.refCellTypeIdx, fieldIdx: 0 } as Instr,
+    ],
+  });
+}
+
+/**
  * Emit a struct.get from an externref value. The externref on the stack is
  * converted to anyref via any.convert_extern, then null-safely cast to the
  * target struct type. If the value is the expected struct type, use struct.get.

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -344,6 +344,19 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
   }
   shiftMap(ctx.moduleGlobals);
   shiftMap(ctx.capturedGlobals);
+  // (#3036) `capturedBoxGlobals` values are objects, not bare indices — shift
+  // each entry's `globalIdx` in place like `protoOverrides` below. The
+  // pre-existing transitive-fn box global shared this latent staleness; a
+  // late string-constant import between registration and the box's
+  // `global.get`/`struct.set` would otherwise leave the recorded index
+  // pointing at the wrong (shifted) slot.
+  if (ctx.capturedBoxGlobals) {
+    for (const entry of ctx.capturedBoxGlobals.values()) {
+      if (entry.globalIdx >= threshold) {
+        entry.globalIdx += delta;
+      }
+    }
+  }
   shiftMap(ctx.staticProps);
   shiftMap(ctx.protoGlobals);
   shiftMap(ctx.classObjectGlobals); // (#1395) — same shift discipline as protoGlobals

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -159,6 +159,68 @@ interface CompileNestedFunctionOptions {
   reuseReservedEntry?: WasmFunction;
 }
 
+/**
+ * (#3035) Cache of, per enclosing function/source body, the set of outer-scope
+ * variable names that are ASSIGNED inside SOME nested function/arrow/method
+ * within that body. Keyed by the enclosing body node so it's computed at most
+ * once per enclosing scope.
+ */
+const nestedFnMutatedNamesCache = new WeakMap<ts.Node, Set<string>>();
+
+/**
+ * (#3035) Collect the outer-scope names that are written inside a nested
+ * function scope of `enclosingBody`.
+ *
+ * Why this matters for CAPTURE representation: a variable written by a nested
+ * closure (a `function` decl, arrow, or object-literal method — e.g. an
+ * iterator's `return()` callback) is boxed into a shared ref-cell so the write
+ * propagates across the scope boundary. That boxing DISCONNECTS the variable
+ * from the plain outer local. A sibling nested FUNCTION DECLARATION that only
+ * READS the same variable was, historically, captured BY VALUE (a snapshot of
+ * the now-stale plain local) — so it never observed the writer's mutation.
+ * This is exactly the arrow path's `writtenInOuter` rule (closures.ts): a
+ * read-only capture of a variable mutated elsewhere in the enclosing scope must
+ * be captured BY REF (through the same cell). The nested-fn-decl path lacked
+ * it, which silently mis-compiled the for-await-of / async-generator
+ * iterator-close (`return()` → `doneCallCount`) test262 cluster and any
+ * two-sibling-closure shared-mutable-binding shape (verified sync too).
+ *
+ * `collectWrittenIdentifiers` already handles shadowing at each function
+ * boundary (a name re-declared as an own local of a deeper scope is excluded),
+ * so we only need to restrict collection to writes that occur strictly INSIDE
+ * a nested function scope. Top-level straight-line writes of the enclosing
+ * function stay unboxed — a by-value reader snapshots the live local at the
+ * direct call site, which is correct for those (a var written only in the
+ * enclosing straight-line body is never boxed).
+ */
+function collectNamesMutatedInNestedFunctions(enclosingBody: ts.Node): Set<string> {
+  const cached = nestedFnMutatedNamesCache.get(enclosingBody);
+  if (cached) return cached;
+  const out = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isConstructorDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
+    ) {
+      // Every assignment inside this nested scope (to a name it does not itself
+      // declare) mutates an enclosing/outer binding. `collectWrittenIdentifiers`
+      // descends with per-boundary shadowing, so no further recursion is needed
+      // for this subtree.
+      collectWrittenIdentifiers(node, out);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(enclosingBody, visit);
+  nestedFnMutatedNamesCache.set(enclosingBody, out);
+  return out;
+}
+
 export function compileNestedFunctionDeclaration(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -261,6 +323,39 @@ export function compileNestedFunctionDeclaration(
     collectWrittenIdentifiers(s, writtenInBody, ownLocals);
   }
 
+  // (#3035) Also detect captured variables that are mutated by a SIBLING nested
+  // scope (another `function` decl, arrow, or object-literal method) within the
+  // enclosing function — e.g. an iterator's `return()` callback doing
+  // `doneCallCount += 1`. Such a variable is boxed into a shared ref-cell by the
+  // writer's closure materialization; a read-only capture here MUST therefore be
+  // by-ref (through the same cell), not a stale by-value snapshot of the outer
+  // local. Mirrors the arrow path's `writtenInOuter` rule (closures.ts). Without
+  // it, the for-await-of / async-generator iterator-close cluster (and every
+  // two-sibling-closure shared-mutable-binding shape, sync included) read 0.
+  let mutatedInSiblingScope: Set<string> = writtenInBody;
+  {
+    let enclosing: ts.Node | undefined = stmt.parent;
+    while (
+      enclosing &&
+      !ts.isFunctionDeclaration(enclosing) &&
+      !ts.isFunctionExpression(enclosing) &&
+      !ts.isArrowFunction(enclosing) &&
+      !ts.isMethodDeclaration(enclosing) &&
+      !ts.isConstructorDeclaration(enclosing) &&
+      !ts.isGetAccessorDeclaration(enclosing) &&
+      !ts.isSetAccessorDeclaration(enclosing) &&
+      !ts.isSourceFile(enclosing)
+    ) {
+      enclosing = enclosing.parent;
+    }
+    const enclosingBody = enclosing
+      ? ts.isSourceFile(enclosing)
+        ? enclosing
+        : (enclosing as { body?: ts.Node }).body
+      : undefined;
+    if (enclosingBody) mutatedInSiblingScope = collectNamesMutatedInNestedFunctions(enclosingBody);
+  }
+
   const captures: {
     name: string;
     type: ValType;
@@ -360,7 +455,7 @@ export function compileNestedFunctionDeclaration(
     // (`localMap.get(cap.name) ?? cap.outerLocalIdx`) to be re-applied AND
     // the destructure-assign path to be box-aware. Both are out of scope
     // for this PR; the test is marked `.todo` until that follow-up lands.
-    const isMutable = writtenInBody.has(name);
+    const isMutable = writtenInBody.has(name) || mutatedInSiblingScope.has(name);
     // #2623 Slice A: detect a capture whose outer slot is already the canonical
     // ref cell (the outer scope boxed it). For such a name `type` above is the
     // cell ref type, so the generic mutable-capture path would re-box to a

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9227,6 +9227,92 @@ assert._isSameValue = isSameValue;
         // rather than fast-pathing the array — otherwise a throwing custom
         // @@iterator on Array.prototype is silently swallowed (#1454).
         const _origArrayIter: any = (Array.prototype as any)[Symbol.iterator];
+        // (#3023) Robust iterator-protocol walk for an ITERATOR OBJECT whose
+        // methods may be wasm closures. A compiled object-literal iterator
+        // (`{ next() {…}, return() {…} }`, e.g. from `it[Symbol.iterator] =
+        // function () { return { next, return } }`) lowers to a closed nominal
+        // WasmGC struct: its `.next` / `.return` are NOT native JS properties,
+        // so a plain `iteratorObj.next()` throws "next is not a function".
+        // Resolve each member through native → sidecar (`_safeGet`) → wasm
+        // struct getter (`__sget_*`) → wasm-closure call (`__call_fn_0`),
+        // collect at most `limit` values, and perform §7.4.6 IteratorClose
+        // (`.return()`) ONLY on an abrupt bounded/defensive-cap stop (never on
+        // natural `done:true`, a null result, or a missing `.next`). Shared by
+        // both the wasm-closure-`@@iterator` path and `_drainIterable` (a
+        // native `@@iterator` that RETURNS a wasm-struct iterator).
+        const _walkWasmIterator = (iteratorObj: any, limit: number): any[] => {
+          const exps = callbackState?.getExports();
+          const callFn0 = exps?.["__call_fn_0"];
+          const resolveProp = (target: any, key: string): any => {
+            const direct = target?.[key];
+            if (direct !== undefined) return direct;
+            const safe = _safeGet(target, key);
+            if (safe !== undefined) return safe;
+            const sget = exps?.[`__sget_${key}`];
+            if (typeof sget === "function") return sget(target);
+            return undefined;
+          };
+          const out: any[] = [];
+          // Defensive cap: a non-spec-compliant iterator that never sets
+          // `done:true` would otherwise hang. 64K is well above any reasonable
+          // destructuring source (#1219).
+          const MAX_ITER = 1 << 16;
+          let iterCount = 0;
+          let cappedOut = false;
+          while (true) {
+            // A no-rest binding pattern consumes EXACTLY `limit` IteratorStep
+            // calls; §8.5.3 then requires IteratorClose because the record's
+            // [[Done]] is still false. Rest/spread pass limit === Infinity and
+            // drain to natural done WITHOUT closing (dstr/*-iter-no-close).
+            if (out.length >= limit) {
+              cappedOut = true;
+              break;
+            }
+            if (iterCount++ >= MAX_ITER) {
+              cappedOut = true;
+              break;
+            }
+            const nextFn = resolveProp(iteratorObj, "next");
+            let result: any;
+            if (typeof nextFn === "function") {
+              result = nextFn.call(iteratorObj);
+            } else if (
+              nextFn != null &&
+              typeof nextFn === "object" &&
+              _isWasmStruct(nextFn) &&
+              typeof callFn0 === "function"
+            ) {
+              // Wasm closure — invoke via __call_fn_0. Spec-mandated throws
+              // from the user's `next()` propagate (dstr/*-iter-step-err).
+              result = callFn0(nextFn);
+            } else {
+              // No callable .next — malformed iterator. Spec says NOT to call
+              // return() here (dstr/*-ary-init-iter-no-close).
+              break;
+            }
+            if (result == null) break;
+            const done = resolveProp(result, "done");
+            if (done) break;
+            // §7.4.5 IteratorValue — a `.value` getter may throw; propagate.
+            const value = resolveProp(result, "value");
+            out.push(value);
+          }
+          if (cappedOut) {
+            const returnFn = resolveProp(iteratorObj, "return");
+            if (typeof returnFn === "function") {
+              returnFn.call(iteratorObj);
+            } else if (
+              returnFn != null &&
+              typeof returnFn === "object" &&
+              _isWasmStruct(returnFn) &&
+              typeof callFn0 === "function"
+            ) {
+              callFn0(returnFn);
+            }
+            // Else: no return method — spec §7.4.6 returns NormalCompletion.
+          }
+          return out;
+        };
         // Materialize an iterable/array-like to a real JS array, consuming AT
         // MOST `limit` iterator steps. `limit === Infinity` (the unbounded
         // case, used by rest patterns and spread) is byte-for-byte the legacy
@@ -9314,119 +9400,12 @@ assert._isSameValue = isSameValue;
                   // miss .next() throws (test262 dstr/*-iter-step-err). (#1016)
                   const iteratorObj = callFn0(iterFn);
                   if (iteratorObj != null && typeof iteratorObj === "object") {
-                    const out: any[] = [];
-                    // Cap iterations defensively — non-spec-compliant
-                    // iterators that never set .done would otherwise hang.
-                    // 64K is well above any reasonable destructuring source;
-                    // higher caps cost ~20µs per closure roundtrip and
-                    // produced 22-28 s test262 hangs at the prior 1M ceiling
-                    // (#1219). Real generators rarely yield more than a few
-                    // thousand values.
-                    const MAX_ITER = 1 << 16;
-                    let iterCount = 0;
-                    // Track whether we exited via the defensive MAX_ITER cap.
-                    // Per ECMA-262 §7.4.6 IteratorClose, `iterator.return()`
-                    // must only be called on ABRUPT termination — i.e. when
-                    // the consumer abandons an iterator that was still
-                    // yielding values. The defensive cap is the proxy for
-                    // that case here (a non-spec-compliant iterator that
-                    // never sets done:true; #1219 fixed 26 ary-init-iter-close
-                    // hangs by capping at 64K then closing). Other early
-                    // exits — natural `done:true`, `result == null`, missing
-                    // `.next` — must NOT trigger return() (test262
-                    // dstr/*-ary-init-iter-no-close.js fails otherwise).
-                    let cappedOut = false;
-                    // Resolve a property from the iterator/result object using
-                    // the same lookup order as _safeGet so JS-defined accessors
-                    // (set via Object.defineProperty) fire on read.
-                    const resolveProp = (target: any, key: string): any => {
-                      // Native access first — works for plain JS objects (e.g.
-                      // an iterator-result literal `{value, done}` from outside
-                      // the wasm world). For opaque wasm structs this returns
-                      // undefined and we fall through.
-                      const direct = target?.[key];
-                      if (direct !== undefined) return direct;
-                      // Sidecar accessor: Object.defineProperty(obj, key, {get})
-                      // installs `__get_<key>` in `_wasmStructProps[obj]`. Firing
-                      // it is required for spec compliance (test262
-                      // dstr/*-iter-val-err — the result.value getter throws,
-                      // and that throw must propagate). Use `_safeGet` so any
-                      // throw flows out unchanged.
-                      const safe = _safeGet(target, key);
-                      if (safe !== undefined) return safe;
-                      // Final fallback: wasm-exported struct getter.
-                      const sget = exps?.[`__sget_${key}`];
-                      if (typeof sget === "function") return sget(target);
-                      return undefined;
-                    };
-                    while (true) {
-                      // Bounded materialization (#1592): stop once we've
-                      // collected `limit` values. A no-rest array binding
-                      // pattern consumes EXACTLY `limit` IteratorStep calls;
-                      // §8.5.3 then requires IteratorClose because the iterator
-                      // record's [[Done]] is still false (we stopped while it
-                      // was still yielding). So this counts as an abrupt-from-
-                      // the-iterator's-view termination → set cappedOut to
-                      // trigger iterator.return() below. (This is the SAME
-                      // close path #1219 exercises for the single-element `[x]`
-                      // pattern over an infinite iterator.) Rest patterns pass
-                      // limit === Infinity and never take this branch, so they
-                      // drain to natural done and do NOT close — preserving the
-                      // dstr/*-ary-init-iter-no-close.js tuning. Checked before
-                      // MAX_ITER so a finite bound always wins.
-                      if (out.length >= limit) {
-                        cappedOut = true;
-                        break;
-                      }
-                      if (iterCount++ >= MAX_ITER) {
-                        cappedOut = true;
-                        break;
-                      }
-                      const nextFn = resolveProp(iteratorObj, "next");
-                      let result: any;
-                      if (typeof nextFn === "function") {
-                        result = nextFn.call(iteratorObj);
-                      } else if (nextFn != null && typeof nextFn === "object" && _isWasmStruct(nextFn)) {
-                        // Wasm closure — invoke via __call_fn_0. Throws here
-                        // (e.g. spec-mandated TypeError from the user's
-                        // `next: function() { throw … }`) propagate.
-                        result = callFn0(nextFn);
-                      } else {
-                        // No callable .next — malformed iterator. Spec says
-                        // not to call return() in this case (NormalCompletion
-                        // expected from the absence of .next).
-                        break;
-                      }
-                      // Iterator-result was null/undefined — treat as iterator
-                      // exhausted with NormalCompletion. Per spec we do not
-                      // invoke return() on a malformed result either; the
-                      // pre-#1219 behavior was a silent break.
-                      if (result == null) break;
-                      // Spec §7.4.4 IteratorComplete coerces .done to boolean.
-                      const done = resolveProp(result, "done");
-                      if (done) break;
-                      // Spec §7.4.5 IteratorValue reads .value (may throw via
-                      // a getter — propagated by resolveProp/_safeGet).
-                      const value = resolveProp(result, "value");
-                      out.push(value);
-                    }
-                    // Spec §7.4.6 IteratorClose: only call iterator.return()
-                    // when we abruptly terminated by hitting the defensive
-                    // cap (the iterator was still yielding but the consumer
-                    // gave up). For natural `done:true` or malformed results,
-                    // calling return() would violate spec — see
-                    // test262 dstr/*-ary-init-iter-no-close.js.
-                    if (cappedOut) {
-                      const returnFn = resolveProp(iteratorObj, "return");
-                      if (typeof returnFn === "function") {
-                        returnFn.call(iteratorObj);
-                      } else if (returnFn != null && typeof returnFn === "object" && _isWasmStruct(returnFn)) {
-                        callFn0(returnFn);
-                      }
-                      // Else: no return method — spec says "return normal
-                      // completion" (no-op).
-                    }
-                    return out;
+                    // (#3023) Robust protocol walk (bounded materialization +
+                    // §7.4.6 IteratorClose on the abrupt bounded stop). The
+                    // iterator's `.next` is typically ALSO a wasm closure, so a
+                    // plain `Array.from(iteratorObj)` would re-enter this fallback
+                    // and miss .next() throws (test262 dstr/*-iter-step-err).
+                    return _walkWasmIterator(iteratorObj, limit);
                   }
                 }
               }
@@ -9445,10 +9424,27 @@ assert._isSameValue = isSameValue;
         // / the .value getter propagate unchanged (#1150/#1454). With
         // limit === Infinity this matches Array.from's full drain.
         function _drainIterable(obj: any, limit: number): any[] {
-          if (!(limit < Infinity)) return Array.from(obj);
           const itFn = (obj as any)?.[Symbol.iterator];
+          // No callable @@iterator — let Array.from handle array-likes / the
+          // legacy unbounded shapes exactly as before.
           if (typeof itFn !== "function") return Array.from(obj);
           const it = itFn.call(obj);
+          // (#3023) A native `@@iterator` may still RETURN a wasm-struct
+          // iterator (a compiled object-literal `{ next() {…} }` lowers to a
+          // closed nominal WasmGC struct whose `.next` is not a native JS
+          // property). A plain `it.next()` — or `Array.from(obj)` for the
+          // unbounded rest/spread case — would throw "next is not a function";
+          // route such iterators through the robust walk, which resolves
+          // `.next`/`.value`/`.done`/`.return` via sidecar / `__sget_*` /
+          // `__call_fn_0` and performs §7.4.6 IteratorClose on the bounded stop
+          // (limit === Infinity drains to natural done WITHOUT closing).
+          if (it != null && typeof it === "object" && typeof (it as any).next !== "function") {
+            return _walkWasmIterator(it, limit);
+          }
+          // Plain JS iterator: step the iterator we already obtained. For the
+          // unbounded case this matches `Array.from`'s full drain; a finite
+          // `limit` stops early (Array.from can't be bounded). Throws from
+          // `.next()` / the `.value` getter propagate unchanged (#1150/#1454).
           const out: any[] = [];
           while (out.length < limit) {
             const r = it.next();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9299,17 +9299,32 @@ assert._isSameValue = isSameValue;
           }
           if (cappedOut) {
             const returnFn = resolveProp(iteratorObj, "return");
+            // §7.4.6 IteratorClose steps 6+9: call `return`, and if it returns
+            // a value whose Type is not Object, throw a TypeError. (The bounded
+            // stop is a NormalCompletion, so step 7's "outer throw wins" does not
+            // apply here — a non-object return result IS observable.) Absent
+            // return method → step 4 NormalCompletion, no call, no throw.
+            let innerResult: any;
+            let called = false;
             if (typeof returnFn === "function") {
-              returnFn.call(iteratorObj);
+              innerResult = returnFn.call(iteratorObj);
+              called = true;
             } else if (
               returnFn != null &&
               typeof returnFn === "object" &&
               _isWasmStruct(returnFn) &&
               typeof callFn0 === "function"
             ) {
-              callFn0(returnFn);
+              innerResult = callFn0(returnFn);
+              called = true;
             }
             // Else: no return method — spec §7.4.6 returns NormalCompletion.
+            if (
+              called &&
+              (innerResult === null || (typeof innerResult !== "object" && typeof innerResult !== "function"))
+            ) {
+              throw new TypeError("iterator close: return() did not return an Object");
+            }
           }
           return out;
         };

--- a/tests/issue-3023.test.ts
+++ b/tests/issue-3023.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3023 — iterator protocol: a custom iterable installed via a late-bound
+// `obj[Symbol.iterator] = function () { return { next(){}, return(){} } }`
+// lowers the returned iterator object to a closed nominal WasmGC struct whose
+// `.next` / `.return` are NOT native JS properties. The host-side array
+// materialization used by array destructuring (`__array_from_iter_n` →
+// `_arrayFromIter` → `_drainIterable`) previously did a naive `it.next()` and
+// threw "it.next is not a function". It now resolves the iterator methods via
+// the sidecar / `__sget_*` / `__call_fn_0` walk and performs §7.4.6
+// IteratorClose (`.return()`) on the bounded (abrupt) stop.
+async function compileAndRun(source: string): Promise<number> {
+  const result = await compile(source, { skipSemanticDiagnostics: true } as any);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  // Wire setExports so the host iterator bridge can call back into the
+  // WasmGC iterator struct's exported members (__sget_next / __call_fn_0).
+  const setExports = (imports as any).setExports;
+  if (typeof setExports === "function") setExports(instance.exports);
+  return (instance.exports as Record<string, Function>).test!() as number;
+}
+
+describe("#3023 — array destructuring over a custom (late-bound) iterable", () => {
+  it("const [x] consumes one value and closes the not-done iterator (IteratorClose)", async () => {
+    // Mirrors test262 for-of/dstr/const-ary-init-iter-close: next yields a
+    // value with done:false, so after one step the iterator is still open and
+    // §8.5.3 requires IteratorClose → return() called exactly once.
+    const ret = await compileAndRun(`
+      export function test(): number {
+        let nextCount = 0;
+        let returnCount = 0;
+        const iterator = {
+          next: function () { nextCount = nextCount + 1; return { value: 42, done: false }; },
+          return: function () { returnCount = returnCount + 1; return {}; },
+        };
+        const iterable: any = {};
+        iterable[Symbol.iterator] = function () { return iterator; };
+        const [x] = iterable;
+        if (x !== 42) return 100;
+        if (nextCount !== 1) return 200 + nextCount;
+        if (returnCount !== 1) return 300 + returnCount;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("const [x] over an already-done iterator does NOT call return() (no-close)", async () => {
+    // Mirrors *-iter-nrml-close-skip: next returns done:true immediately, so
+    // the iterator record is done → IteratorClose is skipped (returnCount 0).
+    const ret = await compileAndRun(`
+      export function test(): number {
+        let nextCount = 0;
+        let returnCount = 0;
+        const iterator = {
+          next: function () { nextCount = nextCount + 1; return { value: undefined, done: true }; },
+          return: function () { returnCount = returnCount + 1; return {}; },
+        };
+        const iterable: any = {};
+        iterable[Symbol.iterator] = function () { return iterator; };
+        const [_a] = iterable;
+        if (nextCount !== 1) return 200 + nextCount;
+        if (returnCount !== 0) return 300 + returnCount;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("multi-element pattern binds each value and closes when still yielding", async () => {
+    const ret = await compileAndRun(`
+      export function test(): number {
+        let nextCount = 0;
+        let returnCount = 0;
+        let i = 0;
+        const iterator = {
+          next: function () { nextCount = nextCount + 1; i = i + 1; return { value: i * 10, done: false }; },
+          return: function () { returnCount = returnCount + 1; return {}; },
+        };
+        const iterable: any = {};
+        iterable[Symbol.iterator] = function () { return iterator; };
+        const [a, b] = iterable;
+        if (a !== 10) return 400 + a;
+        if (b !== 20) return 500 + b;
+        if (nextCount !== 2) return 200 + nextCount;
+        if (returnCount !== 1) return 300 + returnCount;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("for-of with array destructuring over the custom iterable", async () => {
+    // for (const [x] of [iter]) — inner destructuring drives the same host path.
+    const ret = await compileAndRun(`
+      export function test(): number {
+        let doneCallCount = 0;
+        const iter: any = {};
+        iter[Symbol.iterator] = function () {
+          return {
+            next: function () { return { value: 7, done: false }; },
+            return: function () { doneCallCount = doneCallCount + 1; return {}; },
+          };
+        };
+        let iterCount = 0;
+        for (const [x] of [iter]) {
+          if (x !== 7) return 400;
+          if (doneCallCount !== 1) return 300 + doneCallCount;
+          iterCount = iterCount + 1;
+        }
+        if (iterCount !== 1) return 500 + iterCount;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("assignment destructuring over the custom iterable does not close an exhausted iterator", async () => {
+    // Mirrors test262 assignment/dstr/array-elem-iter-nrml-close-skip: the
+    // iterator reports done on the first step, so IteratorClose is skipped.
+    const ret = await compileAndRun(`
+      export function test(): number {
+        let nextCount = 0;
+        let returnCount = 0;
+        const iterator = {
+          next: function () { nextCount = nextCount + 1; return { done: true, value: undefined }; },
+          return: function () { returnCount = returnCount + 1; return {}; },
+        };
+        const iterable: any = {};
+        iterable[Symbol.iterator] = function () { return iterator; };
+        let _x: any;
+        [_x] = iterable;
+        if (nextCount !== 1) return 200 + nextCount;
+        if (returnCount !== 0) return 300 + returnCount;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+});

--- a/tests/issue-3035.test.ts
+++ b/tests/issue-3035.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3035 — for-await/async-gen iterator-close side-effect invisible.
+// Two closure-capture bugs (NOT async-CPS versioning):
+//   Bug #1 (FIXED here): a nested FUNCTION DECLARATION that only READS a
+//     variable mutated by a SIBLING closure captured it by-value (stale
+//     snapshot) instead of by-ref. Fix in nested-declarations.ts mirrors the
+//     arrow path's `writtenInOuter` rule.
+//   Bug #2 (#3036, FABLE-RESERVED): object-literal method shorthand / class
+//     method / class accessor writing a BOXED transitively-captured var emits
+//     garbage. The `*ary-init-iter-close` method-shorthand cluster needs #3036.
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { skipSemanticDiagnostics: true } as any);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  const setExports = (imports as { setExports?: (e: unknown) => void }).setExports;
+  if (typeof setExports === "function") setExports(instance.exports);
+  return (instance.exports as Record<string, () => number>).test!();
+}
+
+describe("#3035 bug #1 — nested-fn-decl reader of a sibling-mutated captured var (FIXED)", () => {
+  it("two sibling fn-decls sharing a mutable captured let: writer runs, reader sees it", async () => {
+    // Minimal reduction of the iterator-close shape: h writes c, g reads it in
+    // a separate top-level call. Read must observe the write (was: stale 0).
+    const ret = await run(`export function test(): number {
+      let c = 0;
+      function h(): void { c = c + 1; }
+      function g(): number { return c; }
+      h();
+      return g();
+    }`);
+    expect(ret).toBe(1);
+  });
+
+  it("nested reader fn observes a sibling closure's write via a shared var", async () => {
+    const ret = await run(`export function test(): number {
+      let c = 0;
+      let obs = -1;
+      function h(): void { c = c + 5; }
+      function g(): void { h(); obs = c; }
+      g();
+      return obs === 5 ? 1 : 300 + obs;
+    }`);
+    expect(ret).toBe(1);
+  });
+
+  it("iterator-close (fn-expr-property return) observed by a nested-fn reader body", async () => {
+    // fn-expr-property writer routes through the box-aware closure path; with
+    // bug #1's reader-by-ref fix a nested reader fn observes the close. Sync
+    // for-of so the assertion is self-contained (no microtask drain needed).
+    const ret = await run(`export function test(): number {
+      let doneCallCount = 0;
+      let obs = -1;
+      const iter: any = {};
+      iter[Symbol.iterator] = function () {
+        return {
+          next: function () { return { value: 7, done: false }; },
+          return: function () { doneCallCount = doneCallCount + 1; return {}; },
+        };
+      };
+      function fn(): void {
+        for (const [x] of [iter]) { obs = doneCallCount; }
+      }
+      fn();
+      return obs === 1 ? 1 : 300 + obs;
+    }`);
+    expect(ret).toBe(1);
+  });
+});
+
+describe.todo("#3035 bug #2 — method-shorthand/class boxed transitive capture write (#3036, FABLE-RESERVED)", () => {
+  it("transitive object-literal METHOD write reaches the boxed captured var", async () => {
+    const ret = await run(`export function test(): number {
+      let c = 0;
+      const make = function () { return { bump() { c += 1; } }; };
+      const o = make(); o.bump(); o.bump();
+      return c;
+    }`);
+    expect(ret).toBe(2);
+  });
+});


### PR DESCRIPTION
## #3036 — boxed transitively-captured var deref in method/accessor bodies

Object/class **method shorthand**, **class methods**, and **class get/set
accessors** that read or write a variable captured **transitively** from a
grandparent scope emitted garbage when that variable was **boxed** (a sibling
closure mutates it → it lives in a `struct (field $value (mut T))` ref cell).
`promoteAccessorCapturesToGlobals` value-promoted the **box** into a captured
global, but the read/write sites never deref'd it: reads yielded the f64/ref
default (0/NaN/null); writes nulled the box global.

### Fix (additive, low-risk)
Boxed captures are registered in `ctx.capturedBoxGlobals` **with the inner
`valType`** *in addition to* the existing `capturedGlobals` entry (kept
byte-identical, so every unmodified consumer is unchanged). The scalar
read/write sites (`identifiers.ts`, `assignment.ts`, `unary-updates.ts`)
consult `capturedBoxGlobals` **first** and deref (`global.get; struct.get/set
field 0`). Also fixes a latent `fixupModuleGlobalIndices` staleness (the
object-valued `capturedBoxGlobals` entries were never shifted — shared by the
pre-existing transitive-fn box).

Full design + file list + verification in
`plan/issues/3036-accessor-method-boxed-transitive-capture-write.md`.

### Verification
- All #3036 read/write/increment repros flip garbage→correct (object-method,
  class-method, method-shorthand writes; `c++`/`--c`; static-dispatch getter
  read →5; class-method read via `any` →5; iterator-close `return(){}` →1).
- **12/12 method-shorthand `for-await-of/*ary-init-iter-close*` test262 files:
  0 pass on base (`3844b8a`) → 12 pass here.** My fix is what flips them.
- Full `tests/equivalence/` (1638 tests): **identical failure set vs base**
  (15 files / 36 tests fail on both, 1599 pass) — zero regressions. `tsc` clean.

### ⚠️ Stacking + why DRAFT (needs lead sequencing)
This branch is **predecessor-stacked**: it contains #2664 (`#3023`, currently
**held**) + #3035 (bug #1) + this #3036 fix. Draft because:
1. It bundles the **held** PR #2664 — un-holding is a lead/coordination call.
2. The full stack still has **2 remaining regressions**, a **separate bug**
   (NOT #3036): the async-generator **expression** `dflt` variants
   (`dflt-ary-init-iter-close`, `named-dflt-ary-init-iter-close`) fail with
   "Cannot destructure null" — a **param-default-not-applied** bug
   (`async function*([x] = iter)` ignores the `= iter` default). These are
   fn-expr (not method-shorthand) and outside #3036's scope; they would park a
   bundled `merge_group`.

**#3036 itself is complete and verified.** The un-hold of #2664 needs the
param-default bug resolved (new issue) or a vacuity-excuse decision first.
