### PR TITLE
fix(#3038): nested-fn-decl reader captures sibling-mutated var by-ref (bug #1)

### DIFF
--- a/plan/issues/3038-forawait-iterclose-closure-capture-versioning.md
+++ b/plan/issues/3038-forawait-iterclose-closure-capture-versioning.md
@@ -1,0 +1,169 @@
+---
+id: 3038
+title: "for-await/async-gen iterator-close side-effect invisible: two closure-capture bugs (NOT async-CPS versioning)"
+status: done
+assignee: ttraenkler/dev-3036
+created: 2026-07-04
+updated: 2026-07-05
+completed: 2026-07-05
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: closures, for-await-of, async-generator, iterators, destructuring
+goal: spec-completeness
+related: [3023, 2664, 3039]
+---
+
+# #3038 — for-await/async-gen iterator-close side-effect invisible
+
+## Context
+
+Blocks the #2664 (issue #3023 `.next`-callability slice, +68 test262) merge:
+#2664's runtime `_walkWasmIterator` diversion (`src/runtime.ts`) makes the
+JS-host iterator-close (`IteratorClose` → `return()`) actually fire for
+WasmGC-struct iterators. Its `merge_group` re-validation surfaced **19
+"regressions"** (mostly `language/statements/for-await-of/*ary-init-iter-close`
++ `async-generator/dstr` files) where the test asserts
+`doneCallCount === 1` (the close's side-effect) in the loop/generator body and
+reads **0**.
+
+dev-3023 root-caused this as an "async-CPS variable-versioning" bug in
+`async-cps.ts`/`async-frame.ts`. **That characterisation is incorrect.** The
+real root causes are two pre-existing **closure-capture** defects (verified sync
+too — nothing to do with the async state machine). `doneCallCount` is a captured
+variable shared between the iterator's `return()` closure (writer) and the
+loop/gen body (reader); the capture representation desyncs.
+
+## Critical reframing: the "regressions" are VACUOUS passes on main
+
+Measured (instrumented `bodyRan` flag): on **main**, the async-generator
+`for await (var [x] of [iter])` body **never runs** (`bodyRan=0`) — the
+async-gen for-await is effectively a no-op there, so these files pass
+**vacuously** (the harness scores `pass` without the assertion ever executing).
+#2664 makes the iterator-close actually run, which makes the body run and hit
+the real capture bugs. So #2664 is **not** regressing working behaviour; it is
+converting dead/vacuous passes into real executions that expose long-standing
+capture bugs. This matters for how #2664 is unblocked (see Recommendation).
+
+## Repro (faithful, `.tmp/`)
+
+Compile + run with `setExports` wired (host `__iterator` bridge), the way the
+test262 worker/equivalence harness do. Minimal, host-lane:
+
+```ts
+export function test(): number {
+  let dcc = 0;
+  const iter: any = {};
+  iter[Symbol.iterator] = function () {
+    return {
+      next() { return { value: 7, done: false }; },
+      return() { dcc += 1; return {}; },   // METHOD SHORTHAND
+    };
+  };
+  const [x] = iter;   // IteratorClose → return() → dcc should be 1
+  return dcc;         // reads 0  (BUG #2)
+}
+```
+
+- `return: function () { dcc += 1; }` (fn-expr property) → **1 (correct)**.
+- `return() { dcc += 1; }` (method shorthand) → **0 (BUG #2)**.
+
+## Root cause #1 — nested-fn-decl reader captured BY VALUE (FIXED)
+
+`src/codegen/statements/nested-declarations.ts`: a nested **function
+declaration** that only READS a captured variable computed `isMutable` from
+`writtenInBody` **only** (does THIS fn write it). When the variable is MUTATED
+by a *sibling* closure (which boxes it into a `struct (field $value (mut T))`
+ref-cell), the read-only nested-fn-decl captured it **by value** — a stale
+snapshot of the now-dead plain outer local — so it never observed the sibling's
+writes. The arrow/fn-expr path (`closures.ts` `writtenInOuter`) already handles
+this; the nested-fn-decl path did not.
+
+**Fix (landed on this branch):** mirror `writtenInOuter` —
+`collectNamesMutatedInNestedFunctions(enclosingBody)` collects names written
+inside ANY nested function scope of the enclosing function (respecting
+per-boundary shadowing via `collectWrittenIdentifiers`), and
+`isMutable = writtenInBody.has(name) || mutatedInSiblingScope.has(name)`.
+Verified: minimal repro matrix (sync/async × var/let × for-of/for-await) all
+flip BUG→OK; `tests/equivalence/` capture/async/generator/iterator subset shows
+**zero new failures** (the 8 failures in that subset are pre-existing on main:
+`tdz-reference-error` ×6, `optional-direct-closure-call` ×2 — confirmed against
+main). This fix alone flips the `async-generator/dstr/ary-init-iter-close.js`
+(fn-expr-property writer) test PASS. It does **not** fix the method-shorthand
+cluster (that is bug #2).
+
+## Root cause #2 — object/class method captured-write to a BOXED transitive var (PARKED → #3039)
+
+`return() {}` (object-literal **method shorthand**) — and equally **class
+methods and class get/set accessors** — that write a variable captured
+**transitively** from a grandparent scope, when that variable is BOXED (a
+sibling mutates it), emit **garbage**. WAT of the method body for `dcc += 1`:
+
+```
+global.get 11   ;; __captured_doneCallCount — holds the ref-cell BOX
+drop
+f64.const 0     ;; read of dcc: WRONG — never derefs the box (struct.get)
+f64.const 1
+f64.add
+drop            ;; the computed 1 is discarded
+ref.null 20
+global.set 11   ;; write of dcc: WRONG — NULLS the box global
+```
+
+Mechanism: method shorthand routes through
+`emitObjectLiteralMethodFn` → `compileArrowAsCallback` →
+`promoteAccessorCapturesToGlobals` (`closures.ts`). For a BOXED captured local
+it promotes the **box** into a `capturedGlobals`/`capturedBoxGlobals` entry
+whose global holds the ref-cell — but `identifiers.ts` (read) and
+`assignment.ts` (write) resolve `capturedGlobals`/never consult
+`capturedBoxGlobals` and treat the global as holding the VALUE, not the box, so
+they never `struct.get`/`struct.set`-deref it. The fn-expr-property form works
+because it routes through `compileArrowAsClosure` (closure-struct captures,
+box-aware).
+
+**Scope of bug #2 (verified):** direct object-method captured writes WORK
+(`const o = { bump() { c += 1 } }; o.bump()` → 2). The bug is specifically the
+**transitive** shape (method nested inside another closure, capturing a
+grandparent var that is boxed). Class methods (`= 0`) and class getters
+(`= NaN`) hit it too → **broad-impact** (`promoteAccessorCapturesToGlobals` is
+shared by object-literal methods + class methods + class accessors). Must be
+validated via full CI / `merge_group`, not a scoped sweep
+([[project_broad_impact_validate_full_ci]]).
+
+**Why parked (per the senior-dev STOP-AND-FLAG guard):** bug #2 is a broad
+capture-subsystem fix touching a heavily-accumulated area (`#2029`/`#2669`
+lineage: `capturedGlobals` / `capturedBoxGlobals` / `boxedCaptures`), affecting
+ALL class methods/accessors + object-literal methods that capture boxed
+transitive vars. A correct fix cannot be adequately verified with local scoped
+checks — it needs the full test262/`merge_group` regression signal — and a
+subtly-wrong capture fix silently miscompiles closures/methods. Split out as
+**#3039, Fable-reserved**, with a complete spec.
+
+## Recommendation for unblocking #2664
+
+Two viable paths:
+
+1. **Land #3039 (bug #2 fix) + this branch's bug #1 fix, stacked on #2664.**
+   That makes the 13 method-shorthand `*ary-init-iter-close` tests GENUINELY
+   pass (a real conformance win), and the fn-expr ones via bug #1, clearing the
+   `merge_group` regressions so #2664 merges. Preferred.
+2. **Vacuity route.** Because these files pass **vacuously** on main (body never
+   runs), the #2940 vacuity/reclassification mechanism arguably should excuse
+   them (the merge_group report showed "Excused vacuous reclassifications: 0",
+   i.e. it did NOT excuse them — a harness-vacuity-detection gap for the
+   async-gen-for-await-no-op shape). This is a PO/lead call, not a codegen fix.
+
+Do NOT blind-remove #2664's `hold`. Its 19 regressions are real (the assertion
+does execute under #2664) until #3039 lands or the vacuity route is chosen.
+
+## Branch / state
+
+Branch `issue-3038-async-cps-iterclose-version` (worktree
+`/workspace/.claude/worktrees/agent-a86d11230e58881bf`), stacked on #2664's
+`origin/issue-3023-iterator-next-callable` (predecessor-stacking; #2664's
+`src/runtime.ts` fix is required to EXPOSE — and to test — this cluster).
+Contains: bug #1 fix (`nested-declarations.ts`) + this doc + #3039. Not a merge
+candidate until #3039 lands on top.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -159,6 +159,68 @@ interface CompileNestedFunctionOptions {
   reuseReservedEntry?: WasmFunction;
 }
 
+/**
+ * (#3038) Cache of, per enclosing function/source body, the set of outer-scope
+ * variable names that are ASSIGNED inside SOME nested function/arrow/method
+ * within that body. Keyed by the enclosing body node so it's computed at most
+ * once per enclosing scope.
+ */
+const nestedFnMutatedNamesCache = new WeakMap<ts.Node, Set<string>>();
+
+/**
+ * (#3038) Collect the outer-scope names that are written inside a nested
+ * function scope of `enclosingBody`.
+ *
+ * Why this matters for CAPTURE representation: a variable written by a nested
+ * closure (a `function` decl, arrow, or object-literal method — e.g. an
+ * iterator's `return()` callback) is boxed into a shared ref-cell so the write
+ * propagates across the scope boundary. That boxing DISCONNECTS the variable
+ * from the plain outer local. A sibling nested FUNCTION DECLARATION that only
+ * READS the same variable was, historically, captured BY VALUE (a snapshot of
+ * the now-stale plain local) — so it never observed the writer's mutation.
+ * This is exactly the arrow path's `writtenInOuter` rule (closures.ts): a
+ * read-only capture of a variable mutated elsewhere in the enclosing scope must
+ * be captured BY REF (through the same cell). The nested-fn-decl path lacked
+ * it, which silently mis-compiled the for-await-of / async-generator
+ * iterator-close (`return()` → `doneCallCount`) test262 cluster and any
+ * two-sibling-closure shared-mutable-binding shape (verified sync too).
+ *
+ * `collectWrittenIdentifiers` already handles shadowing at each function
+ * boundary (a name re-declared as an own local of a deeper scope is excluded),
+ * so we only need to restrict collection to writes that occur strictly INSIDE
+ * a nested function scope. Top-level straight-line writes of the enclosing
+ * function stay unboxed — a by-value reader snapshots the live local at the
+ * direct call site, which is correct for those (a var written only in the
+ * enclosing straight-line body is never boxed).
+ */
+function collectNamesMutatedInNestedFunctions(enclosingBody: ts.Node): Set<string> {
+  const cached = nestedFnMutatedNamesCache.get(enclosingBody);
+  if (cached) return cached;
+  const out = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isConstructorDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
+    ) {
+      // Every assignment inside this nested scope (to a name it does not itself
+      // declare) mutates an enclosing/outer binding. `collectWrittenIdentifiers`
+      // descends with per-boundary shadowing, so no further recursion is needed
+      // for this subtree.
+      collectWrittenIdentifiers(node, out);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(enclosingBody, visit);
+  nestedFnMutatedNamesCache.set(enclosingBody, out);
+  return out;
+}
+
 export function compileNestedFunctionDeclaration(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -261,6 +323,39 @@ export function compileNestedFunctionDeclaration(
     collectWrittenIdentifiers(s, writtenInBody, ownLocals);
   }
 
+  // (#3038) Also detect captured variables that are mutated by a SIBLING nested
+  // scope (another `function` decl, arrow, or object-literal method) within the
+  // enclosing function — e.g. an iterator's `return()` callback doing
+  // `doneCallCount += 1`. Such a variable is boxed into a shared ref-cell by the
+  // writer's closure materialization; a read-only capture here MUST therefore be
+  // by-ref (through the same cell), not a stale by-value snapshot of the outer
+  // local. Mirrors the arrow path's `writtenInOuter` rule (closures.ts). Without
+  // it, the for-await-of / async-generator iterator-close cluster (and every
+  // two-sibling-closure shared-mutable-binding shape, sync included) read 0.
+  let mutatedInSiblingScope: Set<string> = writtenInBody;
+  {
+    let enclosing: ts.Node | undefined = stmt.parent;
+    while (
+      enclosing &&
+      !ts.isFunctionDeclaration(enclosing) &&
+      !ts.isFunctionExpression(enclosing) &&
+      !ts.isArrowFunction(enclosing) &&
+      !ts.isMethodDeclaration(enclosing) &&
+      !ts.isConstructorDeclaration(enclosing) &&
+      !ts.isGetAccessorDeclaration(enclosing) &&
+      !ts.isSetAccessorDeclaration(enclosing) &&
+      !ts.isSourceFile(enclosing)
+    ) {
+      enclosing = enclosing.parent;
+    }
+    const enclosingBody = enclosing
+      ? ts.isSourceFile(enclosing)
+        ? enclosing
+        : (enclosing as { body?: ts.Node }).body
+      : undefined;
+    if (enclosingBody) mutatedInSiblingScope = collectNamesMutatedInNestedFunctions(enclosingBody);
+  }
+
   const captures: {
     name: string;
     type: ValType;
@@ -360,7 +455,7 @@ export function compileNestedFunctionDeclaration(
     // (`localMap.get(cap.name) ?? cap.outerLocalIdx`) to be re-applied AND
     // the destructure-assign path to be box-aware. Both are out of scope
     // for this PR; the test is marked `.todo` until that follow-up lands.
-    const isMutable = writtenInBody.has(name);
+    const isMutable = writtenInBody.has(name) || mutatedInSiblingScope.has(name);
     // #2623 Slice A: detect a capture whose outer slot is already the canonical
     // ref cell (the outer scope boxed it). For such a name `type` above is the
     // cell ref type, so the generic mutable-capture path would re-box to a

--- a/tests/issue-3038.test.ts
+++ b/tests/issue-3038.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3038 — for-await/async-gen iterator-close side-effect invisible.
+// Two closure-capture bugs (NOT async-CPS versioning):
+//   Bug #1 (FIXED here): a nested FUNCTION DECLARATION that only READS a
+//     variable mutated by a SIBLING closure captured it by-value (stale
+//     snapshot) instead of by-ref. Fix in nested-declarations.ts mirrors the
+//     arrow path's `writtenInOuter` rule.
+//   Bug #2 (#3039, FABLE-RESERVED): object-literal method shorthand / class
+//     method / class accessor writing a BOXED transitively-captured var emits
+//     garbage. The `*ary-init-iter-close` method-shorthand cluster needs #3039.
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { skipSemanticDiagnostics: true } as any);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  const setExports = (imports as { setExports?: (e: unknown) => void }).setExports;
+  if (typeof setExports === "function") setExports(instance.exports);
+  return (instance.exports as Record<string, () => number>).test!();
+}
+
+describe("#3038 bug #1 — nested-fn-decl reader of a sibling-mutated captured var (FIXED)", () => {
+  it("two sibling fn-decls sharing a mutable captured let: writer runs, reader sees it", async () => {
+    // Minimal reduction of the iterator-close shape: h writes c, g reads it in
+    // a separate top-level call. Read must observe the write (was: stale 0).
+    const ret = await run(`export function test(): number {
+      let c = 0;
+      function h(): void { c = c + 1; }
+      function g(): number { return c; }
+      h();
+      return g();
+    }`);
+    expect(ret).toBe(1);
+  });
+
+  it("nested reader fn observes a sibling closure's write via a shared var", async () => {
+    const ret = await run(`export function test(): number {
+      let c = 0;
+      let obs = -1;
+      function h(): void { c = c + 5; }
+      function g(): void { h(); obs = c; }
+      g();
+      return obs === 5 ? 1 : 300 + obs;
+    }`);
+    expect(ret).toBe(1);
+  });
+
+  // Skipped in the STANDALONE #3038 landing: this integration scenario needs
+  // #2664 (#3023)'s runtime `_walkWasmIterator` diversion for the JS-host
+  // iterator-close (`return()`) to actually FIRE for a WasmGC-struct iterator.
+  // Without #2664 on main the close is a no-op, so `obs` stays -1 (the body
+  // never observes a close to read). Bug #1's fix (nested-fn reader-by-ref) is
+  // validated standalone by the two sibling-capture cases above; this case
+  // re-enables (→ `it`) once #2664 lands. (#3038 / #2664)
+  it.skip("iterator-close (fn-expr-property return) observed by a nested-fn reader body", async () => {
+    // fn-expr-property writer routes through the box-aware closure path; with
+    // bug #1's reader-by-ref fix a nested reader fn observes the close. Sync
+    // for-of so the assertion is self-contained (no microtask drain needed).
+    const ret = await run(`export function test(): number {
+      let doneCallCount = 0;
+      let obs = -1;
+      const iter: any = {};
+      iter[Symbol.iterator] = function () {
+        return {
+          next: function () { return { value: 7, done: false }; },
+          return: function () { doneCallCount = doneCallCount + 1; return {}; },
+        };
+      };
+      function fn(): void {
+        for (const [x] of [iter]) { obs = doneCallCount; }
+      }
+      fn();
+      return obs === 1 ? 1 : 300 + obs;
+    }`);
+    expect(ret).toBe(1);
+  });
+});
+
+describe.todo("#3038 bug #2 — method-shorthand/class boxed transitive capture write (#3039, FABLE-RESERVED)", () => {
+  it("transitive object-literal METHOD write reaches the boxed captured var", async () => {
+    const ret = await run(`export function test(): number {
+      let c = 0;
+      const make = function () { return { bump() { c += 1; } }; };
+      const o = make(); o.bump(); o.bump();
+      return c;
+    }`);
+    expect(ret).toBe(2);
+  });
+});


### PR DESCRIPTION
## #3038 — nested-fn-decl reader captures a sibling-mutated var by-ref (bug #1)

A nested function **declaration** that only READS an outer captured variable
computed `isMutable` from `writtenInBody` only. When the variable is mutated by
a **sibling** closure (which boxes it into a ref cell), the read-only
nested-fn-decl captured it **by value** — a stale snapshot of the now-dead plain
outer local — so it never observed the sibling's writes. The arrow/fn-expr path
(`closures.ts` `writtenInOuter`) already handled this; the nested-fn-decl path
did not.

### Fix
`collectNamesMutatedInNestedFunctions(enclosingBody)` mirrors `writtenInOuter`:
`isMutable = writtenInBody.has(name) || mutatedInSiblingScope.has(name)`.

### Standalone / de-risk landing
- **Independent of #2664** (pure codegen correctness). Renumbered from 3035
  (cross-session id collision with the already-merged
  `3035-standalone-native-receiver-fallback`).
- Two sibling-capture **unit** tests pass standalone (`tests/issue-3038.test.ts`).
- The iterator-close **integration** test is `it.skip`-ped until #2664 (#3023)
  lands to make the JS-host `return()` close actually fire for WasmGC-struct
  iterators — it's a no-op on main without #2664.
- Sibling of #3039 (bug #2, boxed transitive capture in method/accessor bodies),
  which stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
