### PR TITLE
docs(website): add a note on the typed IR migration (landing + blog)

### DIFF
--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -454,6 +454,16 @@
           And frontier language models let me grind through the long tail of the spec at a pace I could never manage by
           hand. That second part is the one people are most skeptical about, so let me be upfront about it.
         </p>
+        <p>
+          There's an architecture bet inside the compiler too. The quick way to add a language feature is a one-off path
+          from syntax straight to Wasm — do that a few hundred times and you get a pile of special cases that fight each
+          other. So I'm moving the front end onto a typed
+          <strong>intermediate representation (IR)</strong>
+          : a checked middle layer between the source and the Wasm, where lowering is written once and reused instead of
+          reinvented per feature, and where the same front end can target more than one Wasm backend (WasmGC today, a
+          linear-memory backend in development). It's a gradual migration, one syntax form at a time — and it's what
+          keeps the compiler honest as the language coverage climbs.
+        </p>
 
         <h2>How I build it</h2>
         <p>

--- a/website/index.html
+++ b/website/index.html
@@ -3737,6 +3737,12 @@ export function run(n) {
             The goal is 100% compatibility with the JavaScript and npm ecosystem while adding a module security and
             module composition layer around compiled units.
           </p>
+          <p>
+            Inside, the compiler is moving from ad-hoc, per-syntax translation onto a typed intermediate representation
+            (IR) &mdash; a checked middle layer between the source and the emitted Wasm. Lowering is written once and
+            reused instead of reinvented per feature, and one front-end can target more than one Wasm backend (WasmGC
+            today, a linear-memory backend in development). The migration is incremental, node kind by node kind.
+          </p>
         </div>
 
         <div class="how-sidebyside">


### PR DESCRIPTION
## Summary
Adds a short, honest paragraph about the compiler's typed **intermediate representation (IR)** migration to two places:
- **Landing** `#approach` intro — the compiler is moving from ad-hoc per-syntax translation onto a typed IR (a checked middle layer between source and emitted Wasm; lowering written once and reused; one front-end can target more than one Wasm backend — WasmGC today, linear-memory in development), incremental node-kind by node-kind.
- **Blog** "Why this is worth trying now" — a first-person version of the same, framed as the architecture bet that keeps the compiler honest as language coverage climbs.

Both are framed as an in-progress migration, not a shipped state (per the #2855 fallback-retirement direction).

## Test plan
- [x] Both IR notes present; blog tag balance OK; local serve (landing + blog return 200)
- [ ] After deploy: paragraphs render in the landing #approach section and the blog

🤖 Generated with [Claude Code](https://claude.com/claude-code)