### PR TITLE
feat(#2949 S5.1): dynamic-value truthiness lowering (byte-inert mechanism slice)

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -2,10 +2,10 @@
 id: 2949
 title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)"
 status: in-progress
-assignee: ttraenkler/opus-s5-0
+assignee: ttraenkler/opus-s5-1
 sprint: current
 created: 2026-07-02
-updated: 2026-07-04
+updated: 2026-07-05
 priority: high
 horizon: xl
 feasibility: hard
@@ -1251,3 +1251,104 @@ Decisions and the WHY:
   arm (routing to `coercion-engine.emitToBoolean`) and the from-ast `if`/loop
   condition arm; the box/unbox/tag.test primitives it needs for the
   known-literal paths now exist.
+
+## Implementation Notes — S5.1 (opus-s5-1, 2026-07-05, branch `issue-2949-s5-1-truthiness`)
+
+S5.1 ships **dynamic-value truthiness** — `ToBoolean(dyn) → i32` for a boxed-any
+value in condition position. Mechanism slice: byte-inert by construction (the
+selector's move-only gate still rejects a dynamic condition, so from-ast never
+builds the node in a CLAIMED function). **prove-emit-identity: 39/39 IDENTICAL**
+vs the branch base (`82dd5552c`). Decisions and the WHY:
+
+1. **A dedicated `IrInstrDynTruthy{value}` node (→ i32), NOT `unbox{Boolean}`.**
+   The plan (§S5.1) is explicit: general JS `ToBoolean` (§7.1.2) is defined over
+   EVERY partition (`0`/`NaN`/`""`/`null`/`undefined` falsy), whereas
+   `unbox{Boolean}` reads a *proven boolean's* payload and is valid only under a
+   `tag.test(Boolean)` proof. Truthiness needs no proof and no partition switch,
+   so it is its own op. The node's blast radius is the usual `never`-exhaustive
+   IR switch set (nodes.ts `forEachNestedBuffer`/`mapNestedBuffers`/`directUses`,
+   lower.ts + verify.ts `collectUses`, effects.ts purity, monomorphize +
+   inline-small rename/uses) — tsc's exhaustiveness checks flagged each; all
+   covered.
+
+2. **Lowering routes to the CANONICAL `coercion-engine.emitToBoolean` (D4), via
+   a new `IrDynamicLowering.emitToBoolean()` handle arm** — NOT a hand-rolled
+   `tag.test`+`unbox` chain. gc (`$AnyValue` carrier) → `__any_unbox_bool`; host
+   (externref carrier) → `__is_truthy`. This is the SAME engine legacy `if (x)`
+   uses (`ensureI32Condition`), so an IR-claimed condition is byte-parity with
+   legacy. `tag.test`+`unbox` stays reserved for the known-literal fast paths
+   (e.g. `dyn === null`, S5.2). Registration is already covered:
+   `preregisterDynamicSupport` runs `ensureAnyHelpers` (gc, registers
+   `__any_unbox_bool`) / `addUnionImports` (host, registers `__is_truthy`)
+   up-front, so the internal `ensureAnyHelpers`/`ensureLateImport` inside
+   `emitToBoolean` are idempotent no-ops at emit time (no mid-emission funcIdx
+   shift). `isDynamicOp` gained a `dyn.truthy` arm so the preregister fires.
+
+3. **from-ast arms are the single choke point `coerceLoopCondToBool`** (covers
+   `if`/`while`/`for`/`do`) **plus `lowerConditional`** (ternary): when the
+   condition's IrType is `dynamic`, emit `emitDynTruthy` instead of the "must be
+   i32" throw. These are reachable ONLY once S5.P opens the selector scan; today
+   the move-only gate rejects a dynamic condition, so the corpus never hits them
+   → byte-inert (proven). They are exercised by hand-built-IR unit tests.
+
+4. **LOAD-BEARING byte-parity finding — gc mode inherits `__any_unbox_bool`'s
+   NaN-is-truthy quirk.** The canonical gc helper tests a NumberF64 payload with
+   `f64val != 0` (`any-helpers.ts` `__any_unbox_bool`), and `NaN != 0` is TRUE
+   in Wasm — so a boxed NaN reads **truthy** in gc mode. This is NOT a
+   regression I introduced: it is exactly what legacy `if (boxedAnyNaN)` does
+   today (same helper, same call site). The D4 mandate is byte-parity with the
+   ONE ToBoolean engine, so S5.1 faithfully inherits it rather than minting a
+   spec-corrected second policy. **Host mode IS spec-correct** (`__is_truthy`
+   gives `NaN → falsy`). The gc NaN divergence is a pre-existing
+   `__any_unbox_bool` gap (fixable only at the helper — `f64.ne 0` should be
+   `f64.abs; f64.const 0; f64.gt`, matching the coercion-engine f64 arm — but
+   that is a legacy-affecting change and belongs in its own issue, out of S5.1
+   scope). The S5.1 unit test asserts the ACTUAL behavior (`NaN → 1` gc,
+   `NaN → 0` host) with this rationale inline, so the quirk is pinned, not
+   hidden. Producers that admit numeric truthiness in S5.P should note this gc
+   edge (rare in practice; boxed-NaN conditions are unusual).
+
+5. **Verifier hard backstop**: `dyn.truthy` operand must be `dynamic`
+   (verify.ts structural check + a construction-time guard in `emitDynTruthy`).
+   A concrete scalar already has an inline ToBoolean via the existing
+   `coerceLoopCondToBool` numeric arm, so routing one through the carrier helper
+   is a producer bug — rejected loudly at build and verify. Result is i32,
+   already satisfying the if/loop `condValue`-must-be-i32 structural rules.
+
+## Test Results — S5.1 (2026-07-05, opus-s5-1)
+
+- `tests/issue-2949-s5-1-truthiness.test.ts` — **7/7 pass**: node shape +
+  i32 result + verifier-clean; construction-time non-dynamic-operand guard;
+  verifier rejection of a hand-crafted concrete-operand `dyn.truthy` (defense
+  in depth); handle→helper D4 routing (gc single `__any_unbox_bool` call, host
+  single `__is_truthy` call); and RUNTIME execution against the PRODUCTION
+  `makeDynamicLowering` over a real `CodegenContext` in BOTH strategies —
+  gc: boxed number (0/-0 falsy, NaN→1 byte-parity, finite non-zero truthy) +
+  Boolean-refined box; host: FULL JS-truthiness spectrum
+  (`0`/`NaN`/`""`/`null`/`undefined`/`{}`/`"a"`/`5`) via a dynamic externref
+  param + `__is_truthy`.
+- **Byte-inertness PROVEN**: `prove-emit-identity.mjs` baseline captured on a
+  clean worktree at the branch base (`82dd5552c`), `check` on this branch →
+  **IDENTICAL, all 39 (file,target) hashes** across gc/standalone/wasi.
+- `pnpm run check:ir-fallbacks` — OK, zero delta in every bucket, no post-claim
+  demotions (no selector/producer change, as designed).
+- Adjacent #2949 suites: S5.0 (`s5-0-emit-plumbing`) 8/8, slice 1
+  (`ir-dynamic-type`) 19/19, slice 2 (`slice2-dynamic-producers`) 22/22,
+  slice 3 (`slice3-dynamic-lowering`) 16/16, slice 3b (`slice3b-any-dynamic`)
+  8/8 — 73/73 combined. `tests/ir/` + `ir-frontend-widening` +
+  `ir-backend-emitter`: the only failures are the pre-existing 7
+  (`ir/passes` 4, `ir/inline-small` 3 — `__unbox_number` LinkError) that
+  reproduce with IDENTICAL counts on the clean base `82dd5552c` run
+  side-by-side (documented in the S5.0 / slice-3 notes).
+- `npx tsc --noEmit` clean; prettier clean.
+
+**S5.2 (equality lowering) is ready next** — the substrate it needs already
+exists: `emitBox{toType:dynamic}` (S5.0), the `coercion-engine`
+`__any_strict_eq`/`__any_eq` helpers, and the `tag.test{Null|Undefined}`
+fast-path primitives (S5.0). S5.2 adds `IrDynamicLowering.emitStrictEq`/
+`emitLooseEq` (routing to those helpers) + `emitDynEq` on the builder + the
+`lowerBinary` `===`/`!==`/`==`/`!=` dynamic arm, and lowers
+`dyn === null`/`dyn === undefined` via `tag.test` rather than the general
+helper. Mechanism slice, byte-inert, same prove-emit-identity + unit-test
+discipline. The claim-flip stays back-loaded onto S5.P (§4 anti-vacuity
+probe gates it).

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -258,6 +258,17 @@ export interface IrDynamicLowering {
    * see the issue notes + #2106).
    */
   emitTagTest(tag: JsTag, scratch: () => number): readonly Instr[];
+  /**
+   * Carrier on the stack → i32 (0/1): `ToBoolean(carrier)` (§7.1.2, #2949
+   * S5.1). Routes to the SAME `coercion-engine.emitToBoolean` legacy uses —
+   * `__any_unbox_bool` on the gc `$AnyValue` carrier, `__is_truthy` on the
+   * host externref carrier — so `0`/`NaN`/`""`/`null`/`undefined` are falsy
+   * in both strategies, byte-parity with legacy's condition lowering (one
+   * ToBoolean engine, June-audit D4). Unlike `emitUnbox(Boolean)` (which
+   * reads a PROVEN boolean's payload), this is defined over EVERY partition
+   * and needs no `tag.test` proof.
+   */
+  emitToBoolean(): readonly Instr[];
 }
 
 /**

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -413,6 +413,32 @@ export class IrFunctionBuilder {
     return result;
   }
 
+  /**
+   * Emit `dyn.truthy{value}` — `ToBoolean(value)` (§7.1.2) on a boxed-any
+   * carrier. Result is `i32` (1 = truthy, 0 = falsy), usable directly as an
+   * `if` / loop / ternary `condValue` (#2949 S5.1).
+   *
+   * The operand MUST be `dynamic` — this is the general JS-truthiness op, not
+   * a Boolean-partition read. Feeding a concrete scalar here is a producer
+   * bug (a concrete value already lowers ToBoolean inline via the existing
+   * `coerceLoopCondToBool` arms), so it is rejected at construction time
+   * rather than silently mis-lowering the carrier. Lowering routes through
+   * `IrDynamicLowering.emitToBoolean` → `coercion-engine.emitToBoolean`
+   * (`__any_unbox_bool` gc / `__is_truthy` host) — one ToBoolean engine (D4).
+   */
+  emitDynTruthy(value: IrValueId): IrValueId {
+    if (this.typeOf(value).kind !== "dynamic") {
+      throw new Error(
+        `IrFunctionBuilder: emitDynTruthy operand ${value} is not dynamic — general truthiness applies only to the boxed-any carrier (#2949 S5.1) (func ${this.name})`,
+      );
+    }
+    const resultType = irVal({ kind: "i32" });
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "dyn.truthy", value, result, resultType });
+    return result;
+  }
+
   // --- object ops (#1169b) ------------------------------------------------
 
   /**

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -119,6 +119,7 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy": // #2949 S5.1 — ToBoolean read on the carrier: pure (no heap/control effect)
     case "coerce.to_externref":
     case "string.concat":
     case "string.eq":

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -4125,7 +4125,18 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
  * buffer so the coercion instructions re-run each iteration.
  */
 function coerceLoopCondToBool(condValue: IrValueId, cx: LowerCtx, loopKind: "while" | "for" | "do" | "if"): IrValueId {
-  const kind = asVal(cx.builder.typeOf(condValue))?.kind;
+  const irType = cx.builder.typeOf(condValue);
+  // #2949 S5.1 — a boxed-any (dynamic) condition lowers ToBoolean via
+  // `dyn.truthy` (→ `__any_unbox_bool` gc / `__is_truthy` host), the same
+  // JS-truthiness the legacy condition path emits. Emitted INTO the current
+  // (cond) buffer so it re-runs each iteration, exactly like the numeric arm
+  // below. This arm is reachable only once the selector admits a dynamic
+  // condition (S5.P); until then the move-only gate rejects such functions,
+  // so it is exercised only by hand-built-IR unit tests (byte-inert).
+  if (irType.kind === "dynamic") {
+    return cx.builder.emitDynTruthy(condValue);
+  }
+  const kind = asVal(irType)?.kind;
   if (kind === "i32") return condValue;
   if (kind === "f64") {
     // ToBoolean(f64) = abs(x) > 0  (false for 0, -0, NaN; true otherwise).
@@ -4991,9 +5002,14 @@ function lowerIncrementDecrement(id: ts.Identifier, op: ts.SyntaxKind, cx: Lower
 }
 
 function lowerConditional(expr: ts.ConditionalExpression, cx: LowerCtx): IrValueId {
-  const cond = lowerExpr(expr.condition, cx, irVal({ kind: "i32" }));
-  const condType = cx.builder.typeOf(cond);
-  if (asVal(condType)?.kind !== "i32") {
+  const rawCond = lowerExpr(expr.condition, cx, irVal({ kind: "i32" }));
+  const condType = cx.builder.typeOf(rawCond);
+  // #2949 S5.1 — a boxed-any (dynamic) ternary condition lowers ToBoolean via
+  // `dyn.truthy`, emitted before the `if` so it evaluates once. Reachable only
+  // when the selector admits a dynamic condition (S5.P); exercised by
+  // hand-built-IR unit tests until then (byte-inert on the corpus).
+  const cond = condType.kind === "dynamic" ? cx.builder.emitDynTruthy(rawCond) : rawCond;
+  if (condType.kind !== "dynamic" && asVal(condType)?.kind !== "i32") {
     throw new Error(`ir/from-ast: ternary condition must be bool in ${cx.funcName}`);
   }
 

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -34,6 +34,8 @@ import {
   TYPED_ARRAY_NAMES,
 } from "../codegen/index.js";
 import { boxToAny } from "../codegen/value-tags.js"; // (#2949 slice 3) THE canonical boxing entry point (D4)
+// (#2949 S5.1) THE canonical ToBoolean engine — one truthiness path for legacy and IR (D4).
+import { emitToBoolean as emitCoercionToBoolean } from "../codegen/coercion-engine.js";
 import { JsTag, jsTagUnboxKind } from "../codegen/js-tag.js";
 import { ensureVecElemSet, VEC_ELEM_SET_PREFIX } from "../codegen/vec-elem-set.js"; // (#2856 C2) on-demand element-store helper
 import { classMemberFuncKey } from "../codegen/class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
@@ -1690,6 +1692,9 @@ function preregisterExceptionSupport(ctx: CodegenContext, fns: readonly BuiltFnR
 function isDynamicOp(instr: IrInstr): boolean {
   if (instr.kind === "box") return instr.toType.kind === "dynamic";
   if (instr.kind === "unbox" || instr.kind === "tag.test") return instr.jsTag !== undefined;
+  // #2949 S5.1 — dyn.truthy always consumes the boxed-any carrier, so its
+  // presence requires the dynamic backing (ensureAnyHelpers / addUnionImports).
+  if (instr.kind === "dyn.truthy") return true;
   return false;
 }
 
@@ -1878,6 +1883,15 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
           { op: "i32.eq" },
         ];
       },
+      emitToBoolean(): readonly Instr[] {
+        // #2949 S5.1 — ToBoolean(carrier) via THE canonical coercion-engine
+        // path (D4): for the `$AnyValue` carrier it emits `__any_unbox_bool`
+        // (proper JS truthiness — `0`/`NaN`/`""`/`null`/`undefined` falsy).
+        // `ensureAnyHelpers` already ran in `preregisterDynamicSupport`, so
+        // the internal `ensureAnyHelpers` here is an idempotent no-op — no
+        // mid-emission funcIdx shift.
+        return emitCoercionToBoolean(ctx, { kind: "ref_null", typeIdx: anyTypeIdx }, []);
+      },
     };
   }
 
@@ -1979,6 +1993,15 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
         default:
           throw new Error(`ir/integration: no host tag.test arm for ${JsTag[tag]} (#2949)`);
       }
+    },
+    emitToBoolean(): readonly Instr[] {
+      // #2949 S5.1 — ToBoolean(externref carrier) via the canonical
+      // coercion-engine path (D4): `__is_truthy` (0/NaN/null/undefined/""
+      // → falsy). `addUnionImports` already ran in
+      // `preregisterDynamicSupport` (which registers `__is_truthy`), so the
+      // internal `addUnionImports` / `ensureLateImport` here find the import
+      // by name and add nothing — no import shift mid-emission.
+      return emitCoercionToBoolean(ctx, { kind: "externref" }, []);
     },
   };
 }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1383,6 +1383,28 @@ export function lowerIrFunctionBody<S>(
         emitter.pushRaw(out, { op: "i32.eq" });
         return;
       }
+      case "dyn.truthy": {
+        // #2949 S5.1 — ToBoolean on a boxed-any carrier. The operand MUST be
+        // dynamic (verifier enforces); the op sequence comes from the
+        // `IrDynamicLowering` handle, which routes to the CANONICAL
+        // `coercion-engine.emitToBoolean` (`__any_unbox_bool` gc /
+        // `__is_truthy` host) — one ToBoolean engine, byte-parity with the
+        // legacy condition path (June-audit D4). Result is i32, directly
+        // usable as an if / loop / ternary condValue.
+        const valueIrType = typeOf(instr.value);
+        if (valueIrType.kind !== "dynamic") {
+          throw new Error(`ir/lower: dyn.truthy operand must be dynamic, got ${valueIrType.kind} (${func.name})`);
+        }
+        const dyn = resolver.resolveDynamicLowering?.();
+        if (!dyn) {
+          throw new Error(
+            `ir/lower: resolver cannot lower dyn.truthy (resolveDynamicLowering missing/null) (${func.name})`,
+          );
+        }
+        emitValue(instr.value, out);
+        for (const op of dyn.emitToBoolean()) emitter.pushRaw(out, op);
+        return;
+      }
       case "string.const": {
         const ops = resolver.emitStringConst?.(instr.value, instr.alloc);
         if (!ops) throw new Error(`ir/lower: resolver cannot emit string.const (${func.name})`);
@@ -2955,6 +2977,7 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy":
       return [instr.value];
     case "string.const":
       return [];

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -869,6 +869,28 @@ export interface IrInstrTagTest extends IrInstrBase {
   readonly jsTag?: JsTag;
 }
 
+/**
+ * `ToBoolean(value)` on a boxed-any carrier — the dynamic-value truthiness
+ * op (#2949 S5.1). `value` MUST be `IrType.dynamic`; result (via
+ * `IrInstrBase.result`) is `i32` (1 = truthy, 0 = falsy), suitable directly
+ * as an `if` / loop / ternary `condValue`.
+ *
+ * This is deliberately NOT `unbox{Boolean}`: unboxing reads the Boolean
+ * *partition* payload and is only valid on a proven boolean, whereas JS
+ * `ToBoolean` (§7.1.2) is defined over EVERY partition — `0`/`NaN`/`""`/
+ * `null`/`undefined` are falsy, every other value truthy. Lowering routes
+ * through the SAME `coercion-engine.emitToBoolean` legacy uses (`__any_
+ * unbox_bool` on the gc `$AnyValue` carrier / `__is_truthy` on the host
+ * externref carrier) via `IrDynamicLowering.emitToBoolean` — one ToBoolean
+ * engine (June-audit D4), byte-parity with legacy. The known-literal
+ * `tag.test`+`unbox` fast path is reserved for producers that statically
+ * know the partition; general truthiness is this node.
+ */
+export interface IrInstrDynTruthy extends IrInstrBase {
+  readonly kind: "dyn.truthy";
+  readonly value: IrValueId;
+}
+
 // ---------------------------------------------------------------------------
 // String operations (#1169a — IR Phase 4 Slice 1)
 // ---------------------------------------------------------------------------
@@ -2133,6 +2155,7 @@ export type IrInstr =
   | IrInstrBox
   | IrInstrUnbox
   | IrInstrTagTest
+  | IrInstrDynTruthy
   | IrInstrStringConst
   | IrInstrStringConcat
   | IrInstrStringEq
@@ -2444,6 +2467,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy":
     case "string.const":
     case "string.concat":
     case "string.eq":
@@ -2588,6 +2612,7 @@ export function mapNestedBuffers(
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy":
     case "string.const":
     case "string.concat":
     case "string.eq":
@@ -2682,6 +2707,7 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy":
       return [instr.value];
     case "string.concat":
     case "string.eq":

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -419,7 +419,8 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
     }
     case "box":
     case "unbox":
-    case "tag.test": {
+    case "tag.test":
+    case "dyn.truthy": {
       const v = mapId(rename, inst.value);
       if (v === inst.value) return inst;
       return { ...inst, value: v };

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -651,6 +651,7 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy":
       return [instr.value];
     case "string.const":
       return [];

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -598,6 +598,20 @@ function verifyBlock(
           }
         }
       }
+      // #2949 S5.1 — dyn.truthy is ToBoolean on the boxed-any carrier: the
+      // operand MUST be dynamic (a concrete scalar has an inline ToBoolean
+      // and must not route through the carrier helper). Result is i32,
+      // already enforced structurally by the loop/if condValue rules.
+      if (instr.kind === "dyn.truthy") {
+        const operandIr = operandIrType(func, block, instr.value, localDefs);
+        if (operandIr && operandIr.kind !== "dynamic") {
+          errors.push({
+            message: `dyn.truthy operand must be a dynamic IrType, got ${operandIr.kind} (#2949)`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+      }
 
       if (instr.result !== null) {
         if (defs.has(instr.result)) {
@@ -679,6 +693,7 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
     case "box":
     case "unbox":
     case "tag.test":
+    case "dyn.truthy":
       return [instr.value];
     case "string.const":
       return [];

--- a/tests/issue-2949-s5-1-truthiness.test.ts
+++ b/tests/issue-2949-s5-1-truthiness.test.ts
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 S5.1 — dynamic-value truthiness lowering.
+//
+// S5.0 (PR #2682) landed the builder emit vocabulary (emitBox/emitUnbox/
+// emitTagTest). S5.1 adds `ToBoolean` on a boxed-any carrier: a new
+// `emitDynTruthy` builder method + `IrInstrDynTruthy` node, lowered via the
+// new `IrDynamicLowering.emitToBoolean` handle arm, which ROUTES to the
+// canonical `coercion-engine.emitToBoolean` (`__any_unbox_bool` gc /
+// `__is_truthy` host) — one ToBoolean engine, byte-parity with the legacy
+// condition path (June-audit D4). It is NOT `unbox{Boolean}` (that reads a
+// PROVEN boolean's payload); general truthiness is defined over EVERY
+// partition.
+//
+// This slice is byte-inert by construction — the selector's move-only gate
+// still rejects a dynamic condition, so from-ast never builds `dyn.truthy`
+// in a claimed function (proven separately by prove-emit-identity, 39/39
+// IDENTICAL). These tests exercise the mechanism DIRECTLY: node shape +
+// result type, the construction-time operand guard, the handle→helper D4
+// routing, and — RAISED to full runtime execution per the slice-3 standard —
+// truthiness of hand-built IR lowered against the PRODUCTION handle over a
+// real CodegenContext, in BOTH the gc (fast) and host strategies, asserting
+// JS truthiness across 0 / NaN / "" / null / undefined / {} / "a" / 5.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { ensureAnyHelpers } from "../src/codegen/any-helpers.js";
+// Side-effect import: registers the `flushLateImportShifts` codegen delegate
+// that `addUnionImports` requires (same pattern as the S5.0 / slice-3 tests).
+import "../src/codegen/expressions.js";
+import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
+import { addFuncType } from "../src/codegen/registry/types.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import { JsTag } from "../src/codegen/js-tag.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
+import { peepholeOptimize } from "../src/codegen/peephole.js";
+import { stackBalance } from "../src/codegen/stack-balance.js";
+import {
+  IrFunctionBuilder,
+  irDynamic,
+  irVal,
+  lowerIrFunctionToWasm,
+  makeDynamicLowering,
+  verifyIrFunction,
+  type IrFunction,
+  type IrLowerResolver,
+  type IrType,
+} from "../src/ir/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import type { FuncTypeDef } from "../src/ir/types.js";
+
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+const DYN: IrType = irDynamic();
+
+// ---------------------------------------------------------------------------
+// Harness — real context, production handle, production encoder (S5.0 style)
+// ---------------------------------------------------------------------------
+
+function makeGcCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {
+    fast: true,
+    nativeStrings: false,
+  });
+  ensureAnyHelpers(ctx); // what preregisterDynamicSupport does for gc
+  return ctx;
+}
+
+function makeHostCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {});
+  addUnionImports(ctx); // what preregisterDynamicSupport does for host
+  return ctx;
+}
+
+function resolverFor(ctx: CodegenContext): IrLowerResolver {
+  const dyn = makeDynamicLowering(ctx);
+  return {
+    resolveFunc: (ref) => {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) throw new Error(`test resolver: unknown func ${ref.name}`);
+      return idx;
+    },
+    resolveGlobal: () => {
+      throw new Error("test resolver: no globals");
+    },
+    resolveType: () => {
+      throw new Error("test resolver: no type refs");
+    },
+    internFuncType: (t: FuncTypeDef) => addFuncType(ctx, t.params, t.results, t.name),
+    resolveDynamic: () => (dyn ? dyn.carrier : { kind: "externref" }),
+    resolveDynamicLowering: () => dyn,
+  };
+}
+
+function install(ctx: CodegenContext, fns: IrFunction[]): void {
+  const resolver = resolverFor(ctx);
+  for (const f of fns) {
+    const { func } = lowerIrFunctionToWasm(f, resolver);
+    const handle = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, handle, func);
+    ctx.mod.exports.push({ name: f.name, desc: { kind: "func", index: handle } });
+  }
+}
+
+async function instantiateCtx(
+  ctx: CodegenContext,
+  env: Record<string, unknown> = {},
+): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  repairStructTypeMismatches(ctx.mod);
+  peepholeOptimize(ctx.mod);
+  stackBalance(ctx.mod);
+  const binary = emitBinary(ctx.mod);
+  const jsString: Record<string, unknown> = {
+    concat: (a: string, b: string) => `${a}${b}`,
+    length: (s: string) => s.length,
+    equals: (a: unknown, b: unknown) => (a === b ? 1 : 0),
+    substring: (s: string, a: number, b: number) => s.substring(a, b),
+    charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+    fromCharCode: (c: number) => String.fromCharCode(c),
+  };
+  const { instance } = await WebAssembly.instantiate(binary as BufferSource, {
+    env,
+    "wasm:js-string": jsString,
+  });
+  return instance.exports as Record<string, (...args: unknown[]) => unknown>;
+}
+
+function hostEnvFor(ctx: CodegenContext): Record<string, unknown> {
+  const stub = (name: string): unknown => {
+    if (name.startsWith("__typeof_")) {
+      const t = name.slice("__typeof_".length);
+      // biome-ignore lint/suspicious/useValidTypeof: t derives from the import name — same dynamic dispatch src/runtime.ts uses
+      return (v: unknown) => (typeof v === t ? 1 : 0);
+    }
+    switch (name) {
+      case "__box_number":
+        return (v: number) => v;
+      case "__box_boolean":
+        return (v: number) => Boolean(v);
+      case "__unbox_number":
+        return (v: unknown) => Number(v);
+      case "__unbox_boolean":
+        return (v: unknown) => (v ? 1 : 0);
+      case "__is_truthy":
+        // Real JS ToBoolean — proves dyn.truthy routes here (not Boolean-unbox).
+        return (v: unknown) => (v ? 1 : 0);
+      default:
+        return () => 0;
+    }
+  };
+  const env: Record<string, unknown> = {};
+  for (const imp of ctx.mod.imports) {
+    if (imp.module === "env" && imp.desc.kind === "func") env[imp.name] = stub(imp.name);
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// Node shape + result type + construction-time operand guard
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.1 — emitDynTruthy emits a verifier-clean i32 dyn.truthy node", () => {
+  it("appends a dyn.truthy node with i32 result and registers typeOf", () => {
+    const b = new IrFunctionBuilder("truthy1", [I32], true);
+    const x = b.addParam("x", DYN);
+    b.openBlock();
+    const t = b.emitDynTruthy(x);
+    expect(b.typeOf(t)).toEqual(I32);
+    b.terminate({ kind: "return", values: [t] });
+    const fn = b.finish();
+    const [node] = fn.blocks[0].instrs;
+    expect(node).toMatchObject({ kind: "dyn.truthy", value: x, result: t, resultType: I32 });
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("rejects a non-dynamic operand at construction (general truthiness is carrier-only)", () => {
+    const b = new IrFunctionBuilder("truthyBad", [I32], true);
+    const c = b.addParam("c", F64);
+    b.openBlock();
+    expect(() => b.emitDynTruthy(c)).toThrow(/not dynamic/);
+  });
+
+  it("a dyn.truthy fed a concrete operand fails the verifier (defense in depth)", () => {
+    // Hand-craft a malformed node bypassing the builder guard to prove the
+    // verifier is the hard backstop, not just the constructor.
+    const b = new IrFunctionBuilder("truthyVerify", [I32], true);
+    const c = b.addParam("c", I32);
+    b.openBlock();
+    b.terminate({ kind: "return", values: [c] });
+    const fn = b.finish();
+    const bad: IrFunction = {
+      ...fn,
+      blocks: [
+        {
+          ...fn.blocks[0],
+          instrs: [{ kind: "dyn.truthy", value: c, result: 999, resultType: I32 } as never],
+        },
+      ],
+    };
+    const errs = verifyIrFunction(bad);
+    expect(errs.some((e) => /dyn\.truthy operand must be a dynamic/.test(e.message))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handle → helper routing (D4): one ToBoolean engine, both strategies
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.1 — IrDynamicLowering.emitToBoolean routes to the canonical helper", () => {
+  it("gc: emits a single call to __any_unbox_bool", () => {
+    const ctx = makeGcCtx();
+    const dyn = makeDynamicLowering(ctx);
+    expect(dyn).not.toBeNull();
+    const ops = dyn!.emitToBoolean();
+    const idx = ctx.funcMap.get("__any_unbox_bool");
+    expect(idx).toBeDefined();
+    expect(ops).toEqual([{ op: "call", funcIdx: idx }]);
+  });
+
+  it("host: emits a single call to __is_truthy", () => {
+    const ctx = makeHostCtx();
+    const dyn = makeDynamicLowering(ctx);
+    expect(dyn).not.toBeNull();
+    const ops = dyn!.emitToBoolean();
+    const idx = ctx.funcMap.get("__is_truthy");
+    expect(idx).toBeDefined();
+    expect(ops).toEqual([{ op: "call", funcIdx: idx }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime execution — hand-built if(x)-shaped IR, both strategies
+// ---------------------------------------------------------------------------
+
+/**
+ * `truthyF64(x: f64): f64` — box x into the carrier, ToBoolean via
+ * `dyn.truthy`, then `select(t, 1, 0)`: the `if (x) return 1; return 0`
+ * shape the S5.1 spec names, driving a number-partition carrier. Works in
+ * both strategies (gc `__any_unbox_bool` / host `__box_number`+`__is_truthy`).
+ */
+function truthyF64(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [F64], true);
+  const x = b.addParam("x", F64);
+  b.openBlock();
+  const d = b.emitBox(x, DYN);
+  const t = b.emitDynTruthy(d);
+  const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+  const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+  const r = b.emitSelect(t, one, zero, F64);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/**
+ * `truthyBool(x: i32): f64` — box a Boolean-refined i32, ToBoolean, select.
+ * Exercises the tag-4 boolean partition through the SAME truthiness path.
+ */
+function truthyBool(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [F64], true);
+  const x = b.addParam("x", I32);
+  b.openBlock();
+  const d = b.emitBox(x, irDynamic(JsTag.Boolean));
+  const t = b.emitDynTruthy(d);
+  const one = b.emitConst({ kind: "f64", value: 1 }, F64);
+  const zero = b.emitConst({ kind: "f64", value: 0 }, F64);
+  const r = b.emitSelect(t, one, zero, F64);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/**
+ * `truthyDyn(x: dynamic): i32` — the param IS the carrier (host: externref),
+ * ToBoolean directly. Host-only: a $AnyValue carrier cannot be constructed
+ * from JS to pass as a gc param, but an externref carrier accepts any JS
+ * value, so this drives the FULL JS-truthiness spectrum.
+ */
+function truthyDyn(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const x = b.addParam("x", DYN);
+  b.openBlock();
+  const t = b.emitDynTruthy(x);
+  b.terminate({ kind: "return", values: [t] });
+  return b.finish();
+}
+
+describe("#2949 S5.1 — gc runtime: dyn.truthy over the $AnyValue carrier", () => {
+  it("number + boolean partitions yield the canonical __any_unbox_bool truthiness", async () => {
+    const fns = [truthyF64("tF64"), truthyBool("tBool")];
+    for (const f of fns) expect(verifyIrFunction(f)).toEqual([]);
+    const ctx = makeGcCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx);
+    // 0 / -0 are falsy; every finite non-zero number is truthy. NaN is the
+    // one deliberate byte-parity inheritance: the canonical `__any_unbox_bool`
+    // tests a NumberF64 payload with `f64val != 0` (any-helpers.ts), and
+    // `NaN != 0` is TRUE in Wasm — so a boxed NaN reads truthy in gc mode,
+    // EXACTLY as legacy `if (boxedAnyNaN)` does today (this is the D4 point:
+    // S5.1 reuses the ONE ToBoolean engine and inherits its behavior, it does
+    // not mint a spec-corrected second policy). Host mode is spec-correct via
+    // `__is_truthy` (see the host test) — the NaN divergence is a pre-existing
+    // `__any_unbox_bool` gap, fixable only at the helper (a legacy-affecting
+    // change, out of S5.1 scope).
+    for (const [v, want] of [
+      [0, 0],
+      [-0, 0],
+      [NaN, 1], // byte-parity with legacy __any_unbox_bool (f64.ne 0), not spec ToBoolean
+      [1, 1],
+      [5, 1],
+      [-42, 1],
+      [Math.PI, 1],
+      [2 ** 40, 1],
+    ] as const) {
+      expect(ex.tF64(v)).toBe(want);
+    }
+    expect(ex.tBool(1)).toBe(1);
+    expect(ex.tBool(0)).toBe(0);
+  });
+});
+
+describe("#2949 S5.1 — host runtime: dyn.truthy over the externref carrier", () => {
+  it('full JS-truthiness spectrum (0/NaN/""/null/undefined/{}/"a"/5) via __is_truthy', async () => {
+    const fns = [truthyDyn("tDyn"), truthyF64("tF64"), truthyBool("tBool")];
+    const ctx = makeHostCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx, hostEnvFor(ctx));
+    // Directly pass JS values as the externref carrier and assert ToBoolean.
+    for (const [v, want] of [
+      [0, 0],
+      [NaN, 0],
+      ["", 0],
+      [null, 0],
+      [undefined, 0],
+      [{}, 1],
+      ["a", 1],
+      [5, 1],
+    ] as const) {
+      expect(ex.tDyn(v)).toBe(want);
+    }
+    // Boxed-number / boxed-boolean paths agree in host mode too.
+    for (const [v, want] of [
+      [0, 0],
+      [3.5, 1],
+      [-42, 1],
+    ] as const) {
+      expect(ex.tF64(v)).toBe(want);
+    }
+    expect(ex.tBool(1)).toBe(1);
+    expect(ex.tBool(0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2949 S5.1 — dynamic-value truthiness lowering

Adds `ToBoolean(dyn) → i32` for a boxed-any value in condition position, the next byte-inert mechanism slice of the IR claim-rate lever. Builds on S5.0 (PR #2682, merged) which landed the builder emit plumbing.

### What ships
- **`IrInstrDynTruthy{value}` node** (→ i32) + `IrFunctionBuilder.emitDynTruthy` with a construction-time dynamic-operand guard. Deliberately **not** `unbox{Boolean}` — general JS `ToBoolean` (§7.1.2) is defined over every partition (`0`/`NaN`/`""`/`null`/`undefined` falsy), whereas `unbox{Boolean}` reads a *proven* boolean's payload.
- **`IrDynamicLowering.emitToBoolean()`** handle arm routing to the **canonical** `coercion-engine.emitToBoolean` (`__any_unbox_bool` gc / `__is_truthy` host) — one ToBoolean engine, byte-parity with legacy `if (x)` (June-audit D4). `tag.test`+`unbox` stays reserved for known-literal fast paths (S5.2).
- **lower.ts** `dyn.truthy` arm; **verify.ts** structural rule (operand must be dynamic); **effects.ts** pure; nodes/monomorphize/inline-small exhaustive-switch arms; `isDynamicOp` fires the preregister so no mid-emission funcIdx shift.
- **from-ast** condition arms — `coerceLoopCondToBool` (if/while/for/do) + `lowerConditional` (ternary): a dynamic condition emits `dyn.truthy`. Reachable only once S5.P opens the move-only scan; the selector rejects it today, so from-ast never builds it in a claimed function.

### Discipline (byte-inert OFF-PATH mechanism slice)
Per the spec's conjunction finding, S5.1 alone claims ~0 more functions — it only changes emission for functions already claiming that happen to have a dynamic condition, and that set is empty on the corpus.
- **prove-emit-identity: 39/39 IDENTICAL** vs branch base `82dd5552c` (gc/standalone/wasi).
- **check:ir-fallbacks**: zero delta in every bucket, no post-claim demotions.
- **Unit test 7/7** (`tests/issue-2949-s5-1-truthiness.test.ts`): node shape + i32 result + verifier-clean; construction + verifier operand guards; handle→helper D4 routing; and runtime execution against the production `makeDynamicLowering` in **both gc + host** (gc numbers/boolean, host full JS-truthiness spectrum).
- **tsc + prettier clean.** Adjacent #2949 suites 73/73. The only `tests/ir/` failures are 7 pre-existing (`ir/passes` 4, `ir/inline-small` 3, `__unbox_number` LinkError) that reproduce identically on the clean base.

### Documented byte-parity finding
gc `__any_unbox_bool` reads a boxed **NaN as truthy** (`f64.ne 0`) — this is **inherited from legacy** (`if (boxedAnyNaN)` does the same today), NOT a new divergence. Host is spec-correct via `__is_truthy`. The helper-level fix (`|x|>0`) is legacy-affecting and out of S5.1 scope; the test pins the actual behavior with rationale inline.

**Next:** S5.2 (equality lowering) is ready — the substrate (`emitBox`, `__any_strict_eq`/`__any_eq`, `tag.test{Null|Undefined}`) already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8