### PR TITLE
fix(landing): score headline-only feature rows by their test paths

### DIFF
--- a/scripts/generate-editions.ts
+++ b/scripts/generate-editions.ts
@@ -755,6 +755,11 @@ async function main() {
   // (#2910) Every classified, tagged test — the input to computeFeatureRowCounts
   // which patches the landing-page feature-row counts in feature-examples.json.
   const taggedTests: ClassifiedTest[] = [];
+  // Path-indexed pass/fail per classified test, for feature rows that predate
+  // `features:` tags (Operators, typeof, delete, …). These are headline-only
+  // under the tag map, but they carry precise `testCategories` paths, so we can
+  // still score them by path prefix (see patchFeatureExamples).
+  const pathTests: Array<{ file: string; status: StatusKey }> = [];
 
   let classified = 0;
   let unclassified = 0;
@@ -778,6 +783,10 @@ async function main() {
 
     const edition = classifyEdition(fm, file);
     const key = resolveStatusKey(record, hostFree);
+
+    // Every non-proposal standard test, indexed by file path (all editions),
+    // so headline-only feature rows can be scored by their `testCategories`.
+    pathTests.push({ file, status: key });
 
     if (edition === 0 || edition === -1) unclassified++;
     else classified++;
@@ -951,7 +960,7 @@ async function main() {
     !args.includes("--no-feature-examples") &&
     (outputPath === OUTPUT_PATH || getArg(args, "--feature-examples") != null);
   if (wantFeatureExamples) {
-    patchFeatureExamples(featureExamplesPath, taggedTests);
+    patchFeatureExamples(featureExamplesPath, taggedTests, pathTests);
   }
 }
 
@@ -965,7 +974,11 @@ async function main() {
  * set to 0/0 so the runtime treats them as headline-only (no phantom count).
  * Best-effort: a missing map or catalog leaves the file untouched.
  */
-function patchFeatureExamples(examplesPath: string, taggedTests: ClassifiedTest[]): void {
+function patchFeatureExamples(
+  examplesPath: string,
+  taggedTests: ClassifiedTest[],
+  pathTests: Array<{ file: string; status: StatusKey }>,
+): void {
   if (!existsSync(examplesPath)) {
     console.warn(`[#2910] feature-examples not found at ${examplesPath} — skipping row reconciliation.`);
     return;
@@ -1006,7 +1019,25 @@ function patchFeatureExamples(examplesPath: string, taggedTests: ClassifiedTest[
 
   const rowCounts = computeFeatureRowCounts(taggedTests, featureTags, featureEditionYear);
 
+  // Path-prefix scorer for feature rows that predate `features:` tags but carry
+  // precise `testCategories` paths (Operators, typeof, delete, …). Normalize
+  // each test's path once (strip leading "test/") so a row is scored by the
+  // same paths its "View test results" link already points at.
+  const normTests = pathTests.map((t) => ({
+    f: t.file.startsWith("test/") ? t.file.slice(5) : t.file,
+    s: t.status,
+  }));
+  const countByPaths = (prefixes: string[]): FeatureRowCount => {
+    const acc: Record<StatusKey, number> = { pass: 0, fail: 0, ce: 0, skip: 0 };
+    for (const t of normTests) {
+      if (prefixes.some((p) => t.f === p || t.f.startsWith(p + "/"))) acc[t.s]++;
+    }
+    const total = acc.pass + acc.fail + acc.ce + acc.skip;
+    return { ...acc, total, pct: total > 0 ? Math.round((acc.pass / total) * 100) : 0 };
+  };
+
   let reconciled = 0;
+  let pathScored = 0;
   let headlineOnly = 0;
   const unmapped: string[] = [];
   for (const f of examples.features) {
@@ -1017,11 +1048,23 @@ function patchFeatureExamples(examplesPath: string, taggedTests: ClassifiedTest[
       f.totalCount = c.total;
       reconciled++;
     } else {
-      // Not in the tag map → headline-only (no per-row live count). Zero out any
-      // path-glob population so the phantom count never reaches the page.
-      f.passCount = 0;
-      f.totalCount = 0;
-      headlineOnly++;
+      // Not in the tag map. If the row carries `testCategories` paths, score it
+      // by path prefix so core pre-`features:` rows still show a real number.
+      // Rows with no paths stay headline-only (0/0).
+      const paths = Array.isArray(f.testCategories)
+        ? f.testCategories.filter((p): p is string => typeof p === "string" && p.length > 0)
+        : [];
+      if (paths.length > 0) {
+        const c = countByPaths(paths);
+        f.passCount = c.pass;
+        f.totalCount = c.total;
+        if (c.total > 0) pathScored++;
+        else headlineOnly++;
+      } else {
+        f.passCount = 0;
+        f.totalCount = 0;
+        headlineOnly++;
+      }
       const yr = editionStringToYear(typeof f.edition === "string" ? f.edition : "");
       if (yr !== undefined && yr >= 2015 && nm) unmapped.push(nm);
     }
@@ -1029,7 +1072,7 @@ function patchFeatureExamples(examplesPath: string, taggedTests: ClassifiedTest[
 
   writeFileSync(examplesPath, JSON.stringify(examples, null, 2) + "\n");
   console.log(
-    `\n[#2910] Reconciled feature-examples row counts: ${reconciled} tag-sliced, ${headlineOnly} headline-only → ${examplesPath}`,
+    `\n[#2910] Reconciled feature-examples row counts: ${reconciled} tag-sliced, ${pathScored} path-scored, ${headlineOnly} headline-only → ${examplesPath}`,
   );
   if (unmapped.length > 0) {
     console.warn(


### PR DESCRIPTION
## Summary
Fixes the landing feature cards that showed a badge with **no percentage or test numbers**.

**Root cause:** two independent mechanisms feed those cards. A row's test **paths** (`testCategories`, the "View test results" link) are populated for most rows. But the **counts** (`passCount`/`totalCount`) are computed separately by `generate-editions.ts` via a **tag-based** map (`feature-t262-features.json`). Rows that predate test262 `features:` tags — Operators, typeof, delete, Comma operator, Primitive types, … — aren't in that tag map, so per #2910 they were set to `0/0` "headline-only," rendering blank.

**Fix:** collect every classified test with its file path, and for an untagged row that carries `testCategories` paths, score it by **path prefix** (the same paths its results link already points at). Rows with no paths stay headline-only.

**Verified locally** against the cached baseline JSONL — cards with counts go **41/81 → ~70/81**, with sensible numbers:
- Operators 908/1083, typeof/instanceof 42/59, delete 63/69, Comma operator 6/6, Primitive types 624/647, Labeled statements 22/24.

Only 8 truly test-less rows remain headline-only (handled by the existing neutral-badge treatment). Tag-mapped rows are unchanged. This is not the old #2774 phantom glob: a test is counted only under a row's own declared paths, and the numbers populate at deploy time when `generate-editions.ts` runs against the fresh baseline.

## Test plan
- [x] Ran `generate-editions.ts` on `.test262-cache/test262-current.jsonl` → 44 tag-sliced, 29 path-scored, 8 headline-only; spot-checked the numbers above
- [ ] After deploy: the previously-blank cards (Operators, typeof, delete, …) show real pass counts + auto-derived badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)