### PR TITLE
docs(website): reviewed blog revision — professional voice, IR goal, differentiation

### DIFF
--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -6,7 +6,7 @@
     <title>Lightweight sandboxing of untrusted JavaScript · JS² Blog</title>
     <meta
       name="description"
-      content="I'm building a compiler that turns JavaScript and TypeScript into WebAssembly with no JS engine inside the output, so you can run code you didn't write in a sandbox that can't touch anything you didn't hand it."
+      content="JS² is a compiler that turns JavaScript and TypeScript into WebAssembly with no JS engine in the output, so code no one has read can run in a sandbox that reaches nothing it was not explicitly handed."
     />
     <style>
       :root {
@@ -340,9 +340,9 @@
           <span class="eyebrow">JS² Blog</span>
           <h1>Lightweight sandboxing of untrusted JavaScript</h1>
           <p class="dek">
-            I'm building a compiler that turns JavaScript and TypeScript into WebAssembly with no JS engine inside the
-            output, so you can run a dependency, a plugin, or code you didn't write in a sandbox that can't touch
-            anything you didn't hand it.
+            JS² is a compiler that turns JavaScript and TypeScript into WebAssembly with no JS engine in the output — so
+            a dependency, a plugin, or code no one has read can run in a sandbox that reaches nothing it was not
+            explicitly handed.
           </p>
           <div class="byline">
             <span class="who">by Thomas Tränkler</span>
@@ -351,14 +351,14 @@
           </div>
         </header>
 
-        <h2>Why I started this</h2>
+        <h2>The problem</h2>
         <p>
           Every
           <code>npm install</code>
-          is a leap of faith. A typical app pulls in hundreds of packages, and each one runs with the full rights of
-          your process: your files, your network, your secrets, every other module's objects. When one of them gets
-          compromised, and one does every few months, it owns everything. I wanted a way to run untrusted JavaScript
-          where that's structurally impossible, not just discouraged by a policy.
+          is an act of trust. A typical application pulls in hundreds of packages, and each one runs with the full
+          rights of the process: the filesystem, the network, environment secrets, every other module's objects. When
+          one of them is compromised — and one is, every few months — it owns everything. The goal here is to run
+          untrusted JavaScript where that outcome is structurally impossible, not merely discouraged by policy.
         </p>
         <p>
           In the age of generative AI this scales by orders of magnitude. A lot of the code we ship now was never
@@ -381,16 +381,16 @@
           server runtimes already run.)
         </p>
         <p>
-          The security win falls out of how Wasm works. A compiled module starts with
+          The security property falls out of how Wasm works. A compiled module starts with
           <strong>zero ambient authority</strong>
-          : it can only reach a filesystem, a socket, or a global if I explicitly pass it in as an import. So isolating
-          one module from the next is the starting point, not something I bolt on later.
+          : it can reach a filesystem, a socket, or a global only if the host passes it in as an explicit import.
+          Isolating one module from the next is the starting point, not something bolted on afterward.
         </p>
 
         <h2>Where it actually stands</h2>
         <p>
-          I test against the full Test262 suite, the same conformance corpus the browser engines certify against, with
-          nothing cherry-picked. There are two numbers because they answer two different questions:
+          Progress is measured against the full Test262 suite — the same conformance corpus the browser engines certify
+          against, with nothing cherry-picked. There are two numbers, because they answer two different questions:
         </p>
 
         <div class="figure">
@@ -434,55 +434,61 @@
           <strong>Host mode</strong>
           is the number for sandboxing inside a browser or a Node app, where a JS runtime is around anyway.
           <strong>Standalone mode</strong>
-          is the harder goal: pure Wasm, no JavaScript in the loop at all, for WASI and the edge. It's the real research
-          frontier, and it's honestly still incomplete. This is a prototype, not something I'd tell you to put in
-          production yet.
+          is the harder goal: pure Wasm, no JavaScript in the loop at all, for WASI, edge, and embedded targets. That is
+          the real research frontier, and it is still incomplete. This is a research prototype, not production-ready.
         </p>
 
-        <h2>Why this is worth trying now</h2>
+        <h2>What makes it different</h2>
         <p>
-          People have compiled JavaScript to Wasm before. The usual escape hatches were to support only a static subset
-          of the language, or to ship an entire engine (QuickJS, SpiderMonkey) compiled to Wasm. What always blocked the
-          direct route was scope: full ECMAScript is thousands of built-ins and edge cases that have kept engine teams
-          busy for a decade.
+          Compiling JavaScript to Wasm has been tried before, and the recurring move is to give something up. Some
+          approaches accept only a small, statically-typed subset of the language. Others define a new Wasm-shaped
+          language that looks like TypeScript but drops the prototype chain, dynamic values, and closures — which means
+          existing code and npm packages have to be rewritten rather than compiled. Others ship an entire JS engine
+          inside every module, or hand-write a garbage collector in linear memory. JS² takes none of these: it compiles
+          the actual language, unchanged, so existing code and packages are the input rather than a porting target, and
+          it lowers objects to typed WasmGC structs so the host runtime owns the heap. What always blocked that direct
+          route was scope — full ECMAScript is thousands of built-ins and edge cases that have kept engine teams busy
+          for a decade.
         </p>
         <p>
-          Two things moved that.
+          Two things changed the calculus.
           <strong>WasmGC</strong>
-          , which browsers shipped over the last two years, lets me lean on the runtime's own garbage collector instead
-          of simulating a heap, which keeps modules small and makes the whole thing quick to validate inside a JS host.
-          And frontier language models let me grind through the long tail of the spec at a pace I could never manage by
-          hand. That second part is the one people are most skeptical about, so let me be upfront about it.
+          , which browsers shipped over the last two years, lets the compiler use the runtime's own garbage collector
+          instead of simulating a heap — which keeps modules small and makes the approach quick to validate inside a JS
+          host. And frontier language models make it feasible to work through the long tail of the spec at a pace that
+          would otherwise be out of reach. That second point draws the most skepticism, so it is worth being explicit
+          about.
         </p>
         <p>
-          There's an architecture bet inside the compiler too. The quick way to add a language feature is a one-off path
-          from syntax straight to Wasm — do that a few hundred times and you get a pile of special cases that fight each
-          other. So I'm moving the front end onto a typed
+          There is an architecture goal underneath it. The compiler is built around a typed
           <strong>intermediate representation (IR)</strong>
-          : a checked middle layer between the source and the Wasm, where lowering is written once and reused instead of
-          reinvented per feature, and where the same front end can target more than one Wasm backend (WasmGC today, a
-          linear-memory backend in development). It's a gradual migration, one syntax form at a time — and it's what
-          keeps the compiler honest as the language coverage climbs.
+          : a single checked layer between the source and the Wasm where it performs its own type analysis. The aim is
+          to reason about the JavaScript that TypeScript cannot — plain code with no annotations, and the cases where
+          TypeScript is unsound and its declared types do not match what actually runs. Annotations are treated as hints
+          to be verified, not as ground truth; the IR recovers real, flow-sensitive types from the code itself, so each
+          construct is lowered once and efficiently, and one description can target more than one Wasm backend (WasmGC
+          today, a linear-memory backend in development). It is the difference between a principled core and a pile of
+          per-feature special cases.
         </p>
 
-        <h2>How I build it</h2>
+        <h2>How it's built</h2>
         <p>
-          The compiler is written day to day by a small team of AI agents that I direct. One grooms the backlog, one
-          writes an implementation spec before any code gets written, one runs the sprint and the merge queue, and a few
-          write the actual code, each in its own isolated git worktree. If that reads like an ordinary software team,
-          good — I didn't invent a special process for AI. It's spec-first issues, test-driven changes, code review, a
-          merge queue. The same discipline that keeps a human team honest is what keeps the agents useful.
+          The compiler is built day to day by a small team of AI agents, directed by humans. One grooms the backlog, one
+          writes an implementation spec before any code is written, one runs the sprint and the merge queue, and several
+          write the code, each in an isolated git worktree. If that reads like an ordinary software team, that is the
+          point: no special process was invented for AI. Spec-first issues, test-driven changes, code review, a merge
+          queue — the same discipline that keeps a human team honest is what keeps the agents useful.
         </p>
         <p>
-          The bar for merging is high on purpose. Every pull request runs the full 48,088-test suite twice, once per
-          mode, plus about 3,400 hand-written tests that compare compiled Wasm against real JavaScript behavior. That's
+          The bar for merging is deliberately high. Every pull request runs the full 48,088-test suite twice, once per
+          mode, plus about 3,400 hand-written tests that compare compiled Wasm against real JavaScript behavior —
           roughly 100,000 checks before anything lands, and the merge queue re-runs them on the merged result so a
-          green-looking PR can't quietly break the tree. It's the same stance as the compiler itself: don't trust the
+          green-looking PR cannot quietly break the tree. It is the same stance as the compiler itself: don't trust the
           author, verify the output.
         </p>
 
         <h2>Why not an existing sandbox?</h2>
-        <p>Fair question, and it depends on the weight class you need:</p>
+        <p>It depends on the weight class:</p>
         <div class="tbl-wrap">
           <table>
             <thead>
@@ -534,14 +540,15 @@
           Containers and microVMs are the right tool for isolating whole tenants, but far too heavy to wrap around each
           of the hundreds of dependencies inside one app. V8 isolates are lighter, but the boundary is the engine
           itself, so every isolate shares one process and inherits its attack surface. Embedding QuickJS or SpiderMonkey
-          (what Javy and StarlingMonkey do, and they're good tools) keeps the whole engine in the binary, and since Wasm
-          has no JIT, that engine interprets your code — often an order of magnitude slower than compiled Wasm.
+          (what Javy and StarlingMonkey do, and they are good tools) keeps the whole engine in the binary, and since
+          Wasm has no JIT, that engine interprets the code — often an order of magnitude slower than compiled Wasm.
           <span style="font-size: 13px; color: var(--fg-faint)">*compute-heavy code pays the most.</span>
         </p>
 
-        <h2>Come help</h2>
+        <h2>How to contribute</h2>
         <p>
-          Getting from prototype to production is exactly the kind of work that scales with more hands, human or AI:
+          Getting from research prototype to production compiler is the kind of work that scales with more hands, human
+          or AI:
         </p>
         <ul>
           <li>
@@ -550,24 +557,24 @@
           </li>
           <li>
             <strong>Break it.</strong>
-            Run Test262 against a build, find a gap, send me a repro.
+            Run Test262 against a build, find a gap, and file a repro.
           </li>
           <li>
             <strong>Fix something.</strong>
-            Grab a ready issue from
+            Pick up a ready issue from
             <code>plan/issues/</code>
             — each is a real spec, not a vague TODO.
           </li>
           <li>
             <strong>Bring your own agent.</strong>
-            Point Claude Code (or similar) at the same public issues and workflow my agents use.
+            Point Claude Code (or a similar tool) at the same public issues and workflow the project's agents use.
           </li>
         </ul>
 
         <div class="cta">
           <p>
-            The playground compiles JavaScript and TypeScript to Wasm in your browser right now, and the issue queue is
-            open. If the idea of JavaScript that can't reach past its own sandbox sounds useful, come kick the tires.
+            The playground compiles JavaScript and TypeScript to Wasm in the browser, and the issue queue is open.
+            Contributions — human or agent — are welcome.
           </p>
           <p style="margin: 0; font-size: 14px; color: var(--fg-faint)">
             Everything is Apache 2.0 with the LLVM exception.

--- a/website/index.html
+++ b/website/index.html
@@ -3738,10 +3738,12 @@ export function run(n) {
             module composition layer around compiled units.
           </p>
           <p>
-            Inside, the compiler is moving from ad-hoc, per-syntax translation onto a typed intermediate representation
-            (IR) &mdash; a checked middle layer between the source and the emitted Wasm. Lowering is written once and
-            reused instead of reinvented per feature, and one front-end can target more than one Wasm backend (WasmGC
-            today, a linear-memory backend in development). The migration is incremental, node kind by node kind.
+            The compiler is being built around a typed intermediate representation (IR) &mdash; a single checked layer
+            between the source and the emitted Wasm where it performs its own type analysis, reasoning about the
+            JavaScript that TypeScript cannot: plain code with no annotations, and the cases where TypeScript is unsound
+            and its declared types do not match what actually runs. Each construct is lowered once from those recovered
+            types, and that one description can target more than one Wasm backend (WasmGC today, a linear-memory backend
+            in development). The goal is a principled core rather than a pile of per-feature special cases.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
Re-lands the **reviewed** blog + landing revision. (#2689 auto-merged an earlier draft before review because it carried no `hold`; this PR replaces that content with the approved version.)

- **Professional, third-person voice** throughout (drops the first-person "I"/marketing register); byline retained as attribution.
- **Typed IR framed as a goal:** the compiler performs its own type analysis, reasoning about the JavaScript TypeScript cannot — plain untyped code, and the cases where TypeScript is unsound and its declared types don't match runtime behavior (ADR-009).
- **New "What makes it different"** grounded in ADR-002, without naming any project: unlike the alternatives, JS² does not restrict the language, define a new Wasm-shaped dialect that forces rewrites, embed an engine, or hand-roll (or skip) a linear-memory GC; it compiles the actual language unchanged, lowers objects to typed WasmGC structs (host owns the heap), and targets **full ECMAScript conformance** — where the direct-compile approaches cover only a fraction of the spec.
- Landing `#approach` mirrors the IR-goal paragraph.

## Test plan
- [x] De-I check clean (only the byline remains first-person); tag balance OK; local serve 200
- [ ] After deploy: blog + landing render the professional copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)