### PR TITLE
docs(website): GC/full-ECMAScript differentiation + goal-framed IR (re-apply)

### DIFF
--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -444,11 +444,13 @@
           approaches accept only a small, statically-typed subset of the language. Others define a new Wasm-shaped
           language that looks like TypeScript but drops the prototype chain, dynamic values, and closures — which means
           existing code and npm packages have to be rewritten rather than compiled. Others ship an entire JS engine
-          inside every module, or hand-write a garbage collector in linear memory. JS² takes none of these: it compiles
-          the actual language, unchanged, so existing code and packages are the input rather than a porting target, and
-          it lowers objects to typed WasmGC structs so the host runtime owns the heap. What always blocked that direct
-          route was scope — full ECMAScript is thousands of built-ins and edge cases that have kept engine teams busy
-          for a decade.
+          inside every module; still others hand-write a garbage collector in linear memory, or skip garbage collection
+          altogether and simply leak. And across all of them, none targets the full ECMAScript language — or comes close
+          to passing it. JS² takes none of these shortcuts: it compiles the actual language, unchanged, so existing code
+          and packages are the input rather than a porting target; it lowers objects to typed WasmGC structs so the host
+          runtime owns the heap; and full ECMAScript conformance, measured against the complete Test262 suite, is the
+          explicit target. What always made that direct route hard was scope — full ECMAScript is thousands of built-ins
+          and edge cases that have kept engine teams busy for a decade.
         </p>
         <p>
           Two things changed the calculus.

--- a/website/index.html
+++ b/website/index.html
@@ -3738,10 +3738,12 @@ export function run(n) {
             module composition layer around compiled units.
           </p>
           <p>
-            Inside, the compiler is moving from ad-hoc, per-syntax translation onto a typed intermediate representation
-            (IR) &mdash; a checked middle layer between the source and the emitted Wasm. Lowering is written once and
-            reused instead of reinvented per feature, and one front-end can target more than one Wasm backend (WasmGC
-            today, a linear-memory backend in development). The migration is incremental, node kind by node kind.
+            The compiler is being built around a typed intermediate representation (IR) &mdash; a single checked layer
+            between the source and the emitted Wasm where it performs its own type analysis, reasoning about the
+            JavaScript that TypeScript cannot: plain code with no annotations, and the cases where TypeScript is unsound
+            and its declared types do not match what actually runs. Each construct is lowered once from those recovered
+            types, and that one description can target more than one Wasm backend (WasmGC today, a linear-memory backend
+            in development). The goal is a principled core rather than a pile of per-feature special cases.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
Re-applies two reviewed edits that were lost in branch juggling before #2692 shipped:
- **Blog "What makes it different":** notes that some AOT approaches skip garbage collection entirely and simply leak, and that **none targets the full ECMAScript language or comes close to passing it** — whereas JS² targets full conformance measured against the complete Test262 suite.
- **Landing `#approach`:** replaces the stale "IR migration" wording with the **goal** framing — the IR performs its own type analysis, reasoning about the JavaScript TypeScript cannot (plain untyped code) and the cases where TypeScript is unsound (ADR-009).

## Test plan
- [x] Both phrases present; landing old "migration" wording gone; 2 files only
- [ ] After deploy: blog shows the GC/full-ECMAScript differentiation; landing shows the goal-framed IR paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)