### PR TITLE
feat(#2949 S5.2): dynamic strict/loose equality lowering (byte-inert)

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -1352,3 +1352,123 @@ fast-path primitives (S5.0). S5.2 adds `IrDynamicLowering.emitStrictEq`/
 helper. Mechanism slice, byte-inert, same prove-emit-identity + unit-test
 discipline. The claim-flip stays back-loaded onto S5.P (§4 anti-vacuity
 probe gates it).
+
+## Implementation Notes — S5.2 (opus-s5-2, 2026-07-05, branch `issue-2949-s5-2-eq`)
+
+S5.2 ships **dynamic-value strict/loose equality** — `dyn === x` / `dyn !== x`
+/ `dyn == x` / `dyn != x` (either or both operands boxed-any carriers) → `i32`.
+Mechanism slice: byte-inert by construction (the selector's move-only gate
+still rejects a dynamic-eq body, so from-ast never builds `dyn.eq` in a CLAIMED
+function). **prove-emit-identity: 39/39 IDENTICAL** vs the branch base
+(`bfa59bc68`). Decisions and the WHY:
+
+1. **A dedicated `IrInstrDynEq{lhs, rhs, loose, negate}` node (→ i32), not a
+   `binary`.** Verifier R4 forbids dynamic operands on `binary`/`unary`; carrier
+   equality is its own op (both operands MUST be dynamic — the producer boxes any
+   concrete operand into the carrier first). `loose` selects `==`/`!=` vs
+   `===`/`!==`; `negate` appends `i32.eqz` for the `!==`/`!=` half (the helper
+   always computes the positive form). Same `never`-exhaustive blast radius as
+   S5.1's `dyn.truthy` — nodes.ts (union + `forEachNestedBuffer` /
+   `mapNestedBuffers` leaf groups + `directUses`), lower.ts uses + case,
+   verify.ts (collectUses + operand-dynamic rule), effects.ts (pure), integration
+   `isDynamicOp`, monomorphize + inline-small rename/uses — tsc's exhaustiveness
+   flagged each. `dyn.eq` joins the two-operand `[lhs, rhs]` group (string.eq),
+   NOT the single-operand `dyn.truthy` group.
+
+2. **THE LOAD-BEARING FINDING — the equality engine is MODE-SPLIT; the spec's
+   `__any_strict_eq`/`__any_eq` is the gc/standalone path ONLY, NOT host.** The
+   spec said "route through `__any_strict_eq`/`__any_eq`". That is correct for
+   the **gc (fast/standalone)** carrier — there the operands ARE `$AnyValue`,
+   `emitEqOperand` is identity, and `__any_strict_eq`/`__any_eq` are exactly what
+   legacy `compileAnyBinaryDispatch` emits (byte-parity, and the tag-5 field-4
+   classifier owns cross-type falsity + numeric-class `5 === 5.0` + `NaN === NaN
+   → false` via `f64.eq`). **But for the host (non-fast) externref carrier it is
+   WRONG.** I verified against the real compiler (probe on `compileAndInstantiate`
+   of `function looseEq(a:any,b:any){return a==b?1:0}` in host mode): legacy host
+   `"5" == 5 → 1`, `null == undefined → 1` (spec-correct). Routing the host path
+   through `boxToAny(externref,"unknown")` + `__any_eq` (my first attempt,
+   mirroring `emitAnyEqOperands`) gives `"5" == 5 → 0`, `null == undefined → 0` —
+   a DIVERGENCE, because `boxToAny("unknown")` is a compile-time tag decision that
+   boxes every externref as opaque tag-5, so `__any_eq`'s §7.2.15 String⇄Number /
+   tag-1 null==undefined arms never fire. The `__any_*_eq` family is the
+   **standalone `noJsHost` branch** in `binary-ops.ts` (`emitAnyEqFromExternTemps`),
+   not host's. **Legacy host `any === any` compares the raw externrefs via
+   `__host_eq` (JS `===`) / `__host_loose_eq` (JS `==`).** So the host strategy
+   routes through those imports: `emitEqOperand` = `[]` (externref IS the
+   `__host_eq` operand shape), `emitStrictEq` = `__host_eq`, `emitLooseEq` =
+   `__host_loose_eq`. This is D4-faithful (one equality engine PER BACKEND — the
+   SAME the matching legacy lowering uses) and byte-parity with the legacy host
+   runtime result. `preregisterDynamicSupport` registers `__host_eq` /
+   `__host_loose_eq` (late imports, funcIdx-shift-safe up-front) for a host module
+   carrying a `dyn.eq`; the gc `ensureAnyHelpers` already covers `__any_*_eq`.
+   Standalone/wasi is the `gc` strategy (fast) → `__any_*_eq`, no host-import leak
+   into a host-free module.
+
+3. **`emitEqOperand` is a per-operand hook, emitted immediately after each
+   operand is pushed** (so no scratch local is needed), currently identity in
+   BOTH strategies. It exists so a future backend that needs real per-operand
+   marshalling has the seam; today gc-carrier == `$AnyValue` == `__any_*_eq`
+   shape, host-carrier == externref == `__host_*_eq` shape, both identity.
+
+4. **`dyn === null` / `dyn === undefined` (STRICT) use the exact
+   `tag.test{Null|Undefined}` fast path, NOT the general helper**, wired inside
+   from-ast's existing `tryFoldNullCompare` / `tryLowerUndefinedCompare` (they
+   already lower the "other" operand and branch on its IrType — the natural home
+   for a dynamic arm). LOOSE `== null` / `== undefined` is NOT a single tag test
+   (`== null` matches both null and undefined, §7.2.15), so it is left to legacy
+   (return null → demote), never folded. The general `dyn === x` / `dyn === dyn`
+   arm lives in `lowerBinary` after operand lowering, before the string-operand
+   path (a `dyn === "s"` mixes dynamic + string), and boxes the concrete operand
+   with a literal-kind refinement (numeric literal / f64 → NumberF64; `true`/
+   `false` → Boolean so it boxes tag-4, NOT the number default; string → String);
+   an un-refinable non-literal `i32` (number-vs-boolean-ambiguous) demotes cleanly
+   rather than mis-tagging. All from-ast arms are reachable only once S5.P opens
+   the scan; today the move-only gate rejects a dynamic-eq body, so they are
+   byte-inert (proven) and exercised only by hand-built-IR unit tests.
+
+5. **NaN respects `NaN !== NaN`** — the task's explicit concern. The gc
+   `__any_strict_eq` number arm is `f64.eq` (any-helpers.ts ~L2285), so
+   `NaN === NaN → 0`; host `__host_eq` is JS `===`, likewise `0`. Verified at
+   runtime in BOTH strategies. This is CLEANER than S5.1's inherited
+   `__any_unbox_bool` NaN-is-truthy quirk — equality gets NaN right in both modes
+   because both helpers compare numbers with the spec `f64.eq` semantics.
+
+## Test Results — S5.2 (2026-07-05, opus-s5-2)
+
+- `tests/issue-2949-s5-2-eq.test.ts` — **7/7 pass**: node shape + i32 result +
+  loose/negate flags + verifier-clean; construction-time non-dynamic-operand
+  guard (lhs AND rhs); verifier rejection of a hand-crafted concrete-operand
+  `dyn.eq`; handle→helper D4 routing (gc: `emitEqOperand` identity +
+  `__any_strict_eq`/`__any_eq` +eqz-on-negate; host: identity + `__host_eq`/
+  `__host_loose_eq`); and RUNTIME execution against the PRODUCTION
+  `makeDynamicLowering` over a real `CodegenContext` in BOTH strategies —
+  gc: strict/loose number eq incl. `NaN === NaN → 0` (spec-correct) and `0 ===
+  -0 → 1`, `!==` negation, numeric-CLASS (tag-2 i32 box === tag-3 f64 box),
+  cross-type strict falsity (boxed number vs boxed boolean → 0); host: full
+  spectrum via externref params — number/string/bool equality, cross-type
+  falsity (`"5" === 5`, `true === 1` → 0), `NaN === NaN → 0`, null/undefined
+  (`null === null → 1`, `null === undefined → 0` strict), LOOSE coercions
+  (`"5" == 5 → 1`, `null == undefined → 1`, `0 == false → 1`), and the strict
+  null/undefined `tag.test` FAST-PATH primitive.
+- **Byte-inertness PROVEN**: `prove-emit-identity.mjs` baseline captured on a
+  clean worktree at the branch base (`bfa59bc68`), `check` on this branch →
+  **IDENTICAL, all 39 (file,target) hashes** across gc/standalone/wasi.
+- `pnpm run check:ir-fallbacks` — OK, zero delta in every bucket, no post-claim
+  demotions (no selector/producer change, as designed).
+- Adjacent #2949 suites: S5.0 8/8, S5.1 7/7, slice 1 19/19, slice 2 22/22,
+  slice 3 16/16, slice 3b 8/8 — **87/87 combined with S5.2**. `tests/ir/` +
+  `issue-2104-value-tags`: the only failures are the pre-existing 7 (`ir/passes`
+  4, `ir/inline-small` 3 — `__unbox_number` harness LinkError) recorded
+  identically in the S5.0 / S5.1 / slice-3 notes.
+- `npx tsc --noEmit` clean; prettier + biome clean.
+
+**S5.3 (relational: `dyn </<=/>/>=`) is ready next** — the substrate it needs
+exists: `emitBox` (S5.0), and the coercion-engine `emitToNumber` (carrier →
+f64) is the target for a new `IrDynamicLowering.emitToNumber` arm + `emitDynToNumber`
+on the builder + the `lowerBinary` relational arm (ToNumber(dyn) → `f64.lt`/`gt`/…).
+Scope guard per the S5 plan §S5.3: numeric-abstract-relational only, admit a dyn
+operand only against a NUMERIC literal (string×string relational deferred — a
+dyn-string ToNumber = NaN gives all-false, spec-correct for `"a" > 0` but WRONG
+for `"b" > "a"`). Same mechanism-slice discipline: byte-inert, prove-emit-identity
+39/39, hand-built-IR unit tests over gc + host. The claim-flip stays back-loaded
+onto S5.P (§4 anti-vacuity probe).

--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -2,7 +2,7 @@
 id: 2949
 title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)"
 status: in-progress
-assignee: ttraenkler/opus-s5-1
+assignee: ttraenkler/opus-s5-2
 sprint: current
 created: 2026-07-02
 updated: 2026-07-05

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -269,6 +269,40 @@ export interface IrDynamicLowering {
    * and needs no `tag.test` proof.
    */
   emitToBoolean(): readonly Instr[];
+  /**
+   * One carrier on the stack → the operand shape this backend's equality
+   * helper takes (#2949 S5.2). Emitted once per operand, immediately after that
+   * operand is pushed:
+   *   - gc: the carrier IS `(ref null $AnyValue)`, exactly what
+   *     `__any_strict_eq`/`__any_eq` take → identity (`[]`).
+   *   - host: the carrier is `externref`, exactly what
+   *     `__host_eq`/`__host_loose_eq` take → identity (`[]`).
+   * (It exists as a hook because a future backend might need a real
+   * per-operand marshalling; today both are identity.)
+   */
+  emitEqOperand(): readonly Instr[];
+  /**
+   * Two operands on the stack (each run through {@link emitEqOperand}) → i32
+   * (0/1): STRICT equality `===` (§7.2.16), routed to the SAME helper the
+   * matching legacy backend uses (D4, byte-parity with the legacy runtime
+   * result). `negate` appends `i32.eqz` for `!==`.
+   *   - gc/fast/standalone: the native `__any_strict_eq` — its tag-5 field-4
+   *     classifier owns cross-type falsity, numeric-class `23 === 23.0`,
+   *     `NaN === NaN → false` (the helper's `f64.eq`), and reference identity.
+   *   - host: `__host_eq` (JS `===`). (The `__any_strict_eq` path is NOT
+   *     host's — legacy host `any === any` compares the raw externrefs; the
+   *     `__any_*_eq` helper family is the standalone/`noJsHost` branch.)
+   */
+  emitStrictEq(negate: boolean): readonly Instr[];
+  /**
+   * Two operands on the stack → i32 (0/1): LOOSE equality `==` (§7.2.15),
+   * routed to the matching legacy backend's helper (D4). `negate` appends
+   * `i32.eqz` for `!=`.
+   *   - gc/fast/standalone: `__any_eq` (String⇄Number / `null == undefined` /
+   *     ToPrimitive arms live in the helper body).
+   *   - host: `__host_loose_eq` (JS `==`).
+   */
+  emitLooseEq(negate: boolean): readonly Instr[];
 }
 
 /**

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -439,6 +439,40 @@ export class IrFunctionBuilder {
     return result;
   }
 
+  /**
+   * Emit `dyn.eq{lhs, rhs, loose, negate}` — strict/loose equality between two
+   * boxed-any carriers, result `i32` (0/1) (#2949 S5.2).
+   *
+   * BOTH operands MUST be `dynamic`. The producer boxes any concrete operand
+   * into the carrier first (`emitBox(v, irDynamic(...))`), leaving the dyn side
+   * as-is, so both operands are carriers by the time they reach here — exactly
+   * the `(ref null $AnyValue, ref null $AnyValue)` shape the canonical
+   * `__any_strict_eq` / `__any_eq` helpers take. A concrete operand slipping
+   * through is a producer bug (a concrete `===` has an inline scalar compare),
+   * rejected at construction rather than mis-lowered through the carrier.
+   *
+   * @param opts.loose  `true` = `==`/`!=` (`__any_eq`); `false` = `===`/`!==`
+   *                    (`__any_strict_eq`).
+   * @param opts.negate `true` = `!==`/`!=` — append `i32.eqz` at lowering.
+   */
+  emitDynEq(lhs: IrValueId, rhs: IrValueId, opts: { loose: boolean; negate: boolean }): IrValueId {
+    for (const [label, v] of [
+      ["lhs", lhs],
+      ["rhs", rhs],
+    ] as const) {
+      if (this.typeOf(v).kind !== "dynamic") {
+        throw new Error(
+          `IrFunctionBuilder: emitDynEq ${label} operand ${v} is not dynamic — carrier equality applies only to boxed-any operands; box concrete operands first (#2949 S5.2) (func ${this.name})`,
+        );
+      }
+    }
+    const resultType = irVal({ kind: "i32" });
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "dyn.eq", lhs, rhs, loose: opts.loose, negate: opts.negate, result, resultType });
+    return result;
+  }
+
   // --- object ops (#1169b) ------------------------------------------------
 
   /**

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -120,6 +120,7 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
     case "unbox":
     case "tag.test":
     case "dyn.truthy": // #2949 S5.1 — ToBoolean read on the carrier: pure (no heap/control effect)
+    case "dyn.eq": // #2949 S5.2 — equality read over two carriers: pure (no heap/control effect)
     case "coerce.to_externref":
     case "string.concat":
     case "string.eq":

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -54,9 +54,11 @@ import {
 } from "./capability.js";
 import type { IrLowerResolver, IrVecLowering } from "./lower.js";
 import { mathUnaryToIrOp } from "./select.js";
+import { JsTag } from "../codegen/js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
 import {
   asVal,
   closureSignatureEquals,
+  irDynamic,
   irTypeEquals,
   irVal,
   type IrBinop,
@@ -5323,6 +5325,22 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
   const lt = typeOfValue(lhs, cx);
   const rt = typeOfValue(rhs, cx);
 
+  // #2949 S5.2 — dynamic equality: `===`/`!==`/`==`/`!=` where either operand
+  // is a boxed-any carrier. The concrete operand is boxed into the carrier
+  // (refining the box tag from a literal's kind where known), the dyn operand
+  // is left as-is, and `dyn.eq` lowers through the CANONICAL
+  // `__any_strict_eq`/`__any_eq` helpers (D4). Must precede the string-operand
+  // path below (a `dyn === "s"` mixes dynamic + string). The payload-less
+  // STRICT `dyn === null`/`dyn === undefined` cases were already handled by
+  // `tryFoldNullCompare`/`tryLowerUndefinedCompare`'s dynamic arms (cheaper
+  // exact `tag.test`), so they never reach here. Reachable only once the S5.P
+  // selector scan admits dynamic-eq bodies; today the move-only gate rejects
+  // them, so this arm is byte-inert.
+  if (lt.kind === "dynamic" || rt.kind === "dynamic") {
+    const dynEq = tryLowerDynamicEq(expr, op, lhs, rhs, lt, rt, cx);
+    if (dynEq !== null) return dynEq;
+  }
+
   // String operand path (slice 1, #1169a) — `+`, `===`, `!==`, `==`, `!=`.
   // Any other operator with a string operand throws so the function falls
   // back to legacy.
@@ -5717,6 +5735,14 @@ function tryLowerUndefinedCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, 
   const other = leftU ? expr.right : expr.left;
   const v = lowerExpr(other, cx, irVal({ kind: "externref" }));
   const t = cx.builder.typeOf(v);
+  // #2949 S5.2 — a dynamic (boxed-any) operand: strict `=== undefined` /
+  // `!== undefined` is the exact Undefined-partition tag test (cheaper and
+  // more precise than boxing `undefined` into the carrier + the general
+  // helper). Only strict ops reach here (`isStrictEq`/`isStrictNeq` gate).
+  if (t.kind === "dynamic") {
+    const flag = cx.builder.emitTagTest(v, JsTag.Undefined);
+    return isStrictNeq ? cx.builder.emitUnary("i32.eqz", flag, irVal({ kind: "i32" })) : flag;
+  }
   const tv = asVal(t);
   const externrefShaped =
     (tv !== null && tv.kind === "externref") ||
@@ -5773,6 +5799,18 @@ function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Lo
   const v = lowerExpr(other, cx, irVal({ kind: "f64" }));
   const otherType = cx.builder.typeOf(v);
 
+  // #2949 S5.2 — a dynamic (boxed-any) operand: STRICT `=== null` / `!== null`
+  // is the exact Null-partition tag test. LOOSE `== null` / `!= null` matches
+  // BOTH null and undefined (§7.2.15) — NOT a single tag test — so it is left
+  // to legacy (return null → demote), NOT folded.
+  if (otherType.kind === "dynamic") {
+    if (op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken) {
+      const flag = cx.builder.emitTagTest(v, JsTag.Null);
+      return isNeq ? cx.builder.emitUnary("i32.eqz", flag, irVal({ kind: "i32" })) : flag;
+    }
+    return null;
+  }
+
   // Slice 1 only knows non-nullable types: `val<...>`, `string`, and
   // unions whose members are non-null (V1 unions only carry f64/i32).
   // `boxed` is deferred; bail so the caller errors cleanly.
@@ -5816,6 +5854,66 @@ function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Lo
   }
 
   return cx.builder.emitConst({ kind: "bool", value: isNeq }, irVal({ kind: "i32" }));
+}
+
+/**
+ * #2949 S5.2 — lower `dyn === x` / `dyn !== x` / `dyn == x` / `dyn != x` (either
+ * or both operands dynamic) to a `dyn.eq` node. Boxes the concrete operand into
+ * the boxed-any carrier (refining the box tag from a literal's kind where
+ * known) and leaves the dyn operand as-is, so `dyn.eq` sees two carriers — the
+ * `(ref null $AnyValue, ref null $AnyValue)` shape the canonical
+ * `__any_strict_eq`/`__any_eq` helpers take. Returns `null` (clean demote) for a
+ * concrete operand this slice cannot soundly box into the carrier (union / ref /
+ * an un-refinable non-literal `i32` whose number-vs-boolean brand is ambiguous),
+ * or for a non-equality operator.
+ */
+function tryLowerDynamicEq(
+  expr: ts.BinaryExpression,
+  op: ts.SyntaxKind,
+  lhs: IrValueId,
+  rhs: IrValueId,
+  lt: IrType,
+  rt: IrType,
+  cx: LowerCtx,
+): IrValueId | null {
+  const loose = op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken;
+  const strict = op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+  if (!loose && !strict) return null;
+  const negate = op === ts.SyntaxKind.ExclamationEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+
+  const dynL = lt.kind === "dynamic" ? lhs : boxConcreteToDynamic(lhs, lt, expr.left, cx);
+  if (dynL === null) return null;
+  const dynR = rt.kind === "dynamic" ? rhs : boxConcreteToDynamic(rhs, rt, expr.right, cx);
+  if (dynR === null) return null;
+  return cx.builder.emitDynEq(dynL, dynR, { loose, negate });
+}
+
+/**
+ * #2949 S5.2 — box a CONCRETE equality operand into the boxed-any carrier, tag-
+ * refined from its literal kind / IR type. Returns `null` when the operand has
+ * no sound carrier box in this slice, so the caller demotes cleanly rather than
+ * mis-tagging (e.g. a boxed boolean must carry tag-4, never the number default).
+ */
+function boxConcreteToDynamic(v: IrValueId, t: IrType, operand: ts.Expression, cx: LowerCtx): IrValueId | null {
+  if (t.kind === "string") {
+    return cx.builder.emitBox(v, irDynamic(JsTag.String));
+  }
+  const tv = asVal(t);
+  if (!tv) return null;
+  // Boolean literal (`true`/`false`) → tag-4 box; without the refinement the i32
+  // would box as a NUMBER and `dyn === true` would fail against a boxed boolean.
+  if (operand.kind === ts.SyntaxKind.TrueKeyword || operand.kind === ts.SyntaxKind.FalseKeyword) {
+    return cx.builder.emitBox(v, irDynamic(JsTag.Boolean));
+  }
+  // Numeric literal or an f64-typed value → number box (f64 hosts only the
+  // number brand).
+  if (tv.kind === "f64" || ts.isNumericLiteral(operand)) {
+    return cx.builder.emitBox(v, irDynamic(JsTag.NumberF64));
+  }
+  // A bare non-literal `i32` is number-vs-boolean-ambiguous with no cheap proof
+  // here — demote rather than risk a wrong tag. S5.P can refine with the
+  // checker (isProvablyBoolean) when it opens the scan.
+  return null;
 }
 
 /** Result-type hints aren't used in Phase 1 (we always know from the op). */

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -25,6 +25,7 @@
 import { ts } from "../ts-api.js";
 
 import { ensureAnyHelpers, ensureAnyValueType } from "../codegen/any-helpers.js"; // (#2949) boxed-any carrier for IrType.dynamic
+import { ensureLateImport } from "../codegen/shared.js"; // (#2949 S5.2) host __host_eq / __host_loose_eq registration
 import { getOrRegisterPromiseType } from "../codegen/async-scheduler.js";
 import {
   addGeneratorImports,
@@ -1695,7 +1696,21 @@ function isDynamicOp(instr: IrInstr): boolean {
   // #2949 S5.1 — dyn.truthy always consumes the boxed-any carrier, so its
   // presence requires the dynamic backing (ensureAnyHelpers / addUnionImports).
   if (instr.kind === "dyn.truthy") return true;
+  // #2949 S5.2 — dyn.eq consumes two carriers and calls the canonical equality
+  // helpers, so it too requires the dynamic backing pre-registered.
+  if (instr.kind === "dyn.eq") return true;
   return false;
+}
+
+/**
+ * #2949 S5.2 — does this instruction lower through the canonical any-equality
+ * helper family (`__any_strict_eq` / `__any_eq`, plus `__any_from_extern` in
+ * host mode)? These are DEFINED functions built by `ensureAnyHelpers`, which
+ * the host (non-fast) preregister path does NOT otherwise run — so a `dyn.eq`
+ * in a host module needs the extra registration below.
+ */
+function usesDynEq(instr: IrInstr): boolean {
+  return instr.kind === "dyn.eq";
 }
 
 /**
@@ -1745,23 +1760,39 @@ function jsTagToStaticType(
  */
 function preregisterDynamicSupport(ctx: CodegenContext, fns: readonly BuiltFnRef[]): void {
   let usesDynamicOps = false;
+  let usesEq = false;
   for (const entry of fns) {
     for (const block of entry.fn.blocks) {
       for (const instr of block.instrs) {
         forEachInstrDeep(instr, (i) => {
           if (isDynamicOp(i)) usesDynamicOps = true;
+          if (usesDynEq(i)) usesEq = true;
         });
-        if (usesDynamicOps) break;
+        if (usesDynamicOps && usesEq) break;
       }
-      if (usesDynamicOps) break;
+      if (usesDynamicOps && usesEq) break;
     }
-    if (usesDynamicOps) break;
+    if (usesDynamicOps && usesEq) break;
   }
   if (!usesDynamicOps) return;
   if (ctx.fast) {
+    // gc: ensureAnyHelpers registers $AnyValue + the __any_box_*/__any_unbox_*
+    // family AND the equality helpers (__any_strict_eq / __any_eq) — one call
+    // covers every gc dynamic op, dyn.eq included.
     ensureAnyHelpers(ctx);
   } else {
+    // host: the classifier / box import family for box/unbox/tag.test/truthy.
     addUnionImports(ctx);
+    // #2949 S5.2 — dyn.eq in host mode calls `__host_eq` (JS `===`) /
+    // `__host_loose_eq` (JS `==`) — the SAME host-import equality legacy
+    // `any === any` uses. Register them up-front (they are LATE IMPORTS that
+    // shift defined funcIdxs) so no emit can trigger a mid-emission shift
+    // (#329/#2078), exactly like `addUnionImports` above. Both are idempotent;
+    // only fired when a host module actually carries a dyn.eq.
+    if (usesEq) {
+      ensureLateImport(ctx, "__host_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+      ensureLateImport(ctx, "__host_loose_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+    }
   }
 }
 
@@ -1892,6 +1923,20 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
         // mid-emission funcIdx shift.
         return emitCoercionToBoolean(ctx, { kind: "ref_null", typeIdx: anyTypeIdx }, []);
       },
+      emitEqOperand(): readonly Instr[] {
+        // #2949 S5.2 — the gc carrier IS `(ref null $AnyValue)`, already the
+        // `__any_strict_eq`/`__any_eq` parameter shape. No marshalling.
+        return [];
+      },
+      emitStrictEq(negate: boolean): readonly Instr[] {
+        // Canonical `===` engine (D4): the tag-5 classifier — cross-type
+        // falsity, numeric-class `23 === 23.0`, `NaN === NaN → false`
+        // (`f64.eq`), reference identity — lives in `__any_strict_eq`'s body.
+        return negate ? [callHelper("__any_strict_eq"), { op: "i32.eqz" }] : [callHelper("__any_strict_eq")];
+      },
+      emitLooseEq(negate: boolean): readonly Instr[] {
+        return negate ? [callHelper("__any_eq"), { op: "i32.eqz" }] : [callHelper("__any_eq")];
+      },
     };
   }
 
@@ -2002,6 +2047,29 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
       // internal `addUnionImports` / `ensureLateImport` here find the import
       // by name and add nothing — no import shift mid-emission.
       return emitCoercionToBoolean(ctx, { kind: "externref" }, []);
+    },
+    emitEqOperand(): readonly Instr[] {
+      // #2949 S5.2 — the host carrier is `externref`, which is EXACTLY the
+      // `(externref, externref)` shape `__host_eq` / `__host_loose_eq` take.
+      // No marshalling — legacy host `any === any` compares the raw externrefs
+      // (verified: a `boxToAny`+`__any_eq` marshalling DIVERGES — it drops the
+      // §7.2.15 coercions, giving `"5" == 5 → false`; the `__any_eq` path is the
+      // STANDALONE `noJsHost` branch in binary-ops, not host's).
+      return [];
+    },
+    emitStrictEq(negate: boolean): readonly Instr[] {
+      // #2949 S5.2 — host STRICT `===` via the SAME `__host_eq` (JS `===`,
+      // §7.2.16) legacy host `any === any` uses (D4, byte-parity with the host
+      // runtime result). `__host_eq` is a host import in this (non-fast,
+      // JS-host) mode; standalone/wasi is the `gc` strategy, which uses the
+      // native `__any_strict_eq` instead — so there is no host-import leak into
+      // a host-free module.
+      return negate ? [callImport("__host_eq"), { op: "i32.eqz" }] : [callImport("__host_eq")];
+    },
+    emitLooseEq(negate: boolean): readonly Instr[] {
+      // Host LOOSE `==` via `__host_loose_eq` (JS `==`, §7.2.15) — the coercion
+      // arms (String⇄Number, `null == undefined`) are JS's, matching legacy.
+      return negate ? [callImport("__host_loose_eq"), { op: "i32.eqz" }] : [callImport("__host_loose_eq")];
     },
   };
 }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1405,6 +1405,33 @@ export function lowerIrFunctionBody<S>(
         for (const op of dyn.emitToBoolean()) emitter.pushRaw(out, op);
         return;
       }
+      case "dyn.eq": {
+        // #2949 S5.2 — strict/loose equality over two boxed-any carriers,
+        // routed through the CANONICAL `__any_strict_eq` / `__any_eq` helpers
+        // (June-audit D4). Both operands MUST be dynamic (verifier enforces);
+        // each is marshalled to the `(ref null $AnyValue)` eq-helper ABI by
+        // `emitEqOperand` (gc: identity; host: `__any_from_extern`) IMMEDIATELY
+        // after it is pushed, so no scratch local is needed. The tag-5
+        // classifier — incl. `NaN === NaN → false` — stays in the helper body.
+        const lt = typeOf(instr.lhs);
+        const rt = typeOf(instr.rhs);
+        if (lt.kind !== "dynamic" || rt.kind !== "dynamic") {
+          throw new Error(`ir/lower: dyn.eq operands must be dynamic, got ${lt.kind}/${rt.kind} (${func.name})`);
+        }
+        const dyn = resolver.resolveDynamicLowering?.();
+        if (!dyn) {
+          throw new Error(
+            `ir/lower: resolver cannot lower dyn.eq (resolveDynamicLowering missing/null) (${func.name})`,
+          );
+        }
+        emitValue(instr.lhs, out);
+        for (const op of dyn.emitEqOperand()) emitter.pushRaw(out, op);
+        emitValue(instr.rhs, out);
+        for (const op of dyn.emitEqOperand()) emitter.pushRaw(out, op);
+        const call = instr.loose ? dyn.emitLooseEq(instr.negate) : dyn.emitStrictEq(instr.negate);
+        for (const op of call) emitter.pushRaw(out, op);
+        return;
+      }
       case "string.const": {
         const ops = resolver.emitStringConst?.(instr.value, instr.alloc);
         if (!ops) throw new Error(`ir/lower: resolver cannot emit string.const (${func.name})`);
@@ -2979,6 +3006,8 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "tag.test":
     case "dyn.truthy":
       return [instr.value];
+    case "dyn.eq":
+      return [instr.lhs, instr.rhs];
     case "string.const":
       return [];
     case "string.concat":

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -891,6 +891,34 @@ export interface IrInstrDynTruthy extends IrInstrBase {
   readonly value: IrValueId;
 }
 
+/**
+ * `dyn.eq{lhs, rhs, loose, negate}` — strict/loose equality (§7.2.15 /
+ * §7.2.16) between two boxed-any carriers, result `i32` (0/1) (#2949 S5.2).
+ *
+ * BOTH operands MUST be `dynamic`: the producer boxes any concrete operand
+ * into the carrier first (via `box{toType: dynamic}`), leaving the dyn side
+ * as-is, so this node always sees two carriers — exactly the `(ref null
+ * $AnyValue, ref null $AnyValue)` shape the canonical equality helpers take.
+ * Lowering routes through the SAME `__any_strict_eq` (`===`/`!==`, `loose:
+ * false`) / `__any_eq` (`==`/`!=`, `loose: true`) helpers legacy's
+ * `compileAnyBinaryDispatch` uses — one equality engine, byte-parity with
+ * legacy, and the tag-5 field-4 classifier (incl. `NaN === NaN → false` via
+ * the helper's `f64.eq`) stays in the helper body, never re-implemented
+ * (June-audit D4). `negate` appends `i32.eqz` for the `!==`/`!=` form (the
+ * helper always computes the positive `===`/`==`). The payload-less
+ * `dyn === null` / `dyn === undefined` STRICT cases are NOT this node — the
+ * producer lowers those via the cheaper exact `tag.test{Null|Undefined}`.
+ */
+export interface IrInstrDynEq extends IrInstrBase {
+  readonly kind: "dyn.eq";
+  readonly lhs: IrValueId;
+  readonly rhs: IrValueId;
+  /** `true` = loose `==`/`!=` (`__any_eq`); `false` = strict `===`/`!==` (`__any_strict_eq`). */
+  readonly loose: boolean;
+  /** `true` = `!==`/`!=` — append `i32.eqz` to the helper's positive result. */
+  readonly negate: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // String operations (#1169a — IR Phase 4 Slice 1)
 // ---------------------------------------------------------------------------
@@ -2156,6 +2184,7 @@ export type IrInstr =
   | IrInstrUnbox
   | IrInstrTagTest
   | IrInstrDynTruthy
+  | IrInstrDynEq
   | IrInstrStringConst
   | IrInstrStringConcat
   | IrInstrStringEq
@@ -2468,6 +2497,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.eq":
     case "string.const":
     case "string.concat":
     case "string.eq":
@@ -2613,6 +2643,7 @@ export function mapNestedBuffers(
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.eq":
     case "string.const":
     case "string.concat":
     case "string.eq":
@@ -2709,6 +2740,7 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
     case "tag.test":
     case "dyn.truthy":
       return [instr.value];
+    case "dyn.eq":
     case "string.concat":
     case "string.eq":
       return [instr.lhs, instr.rhs];

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -427,6 +427,7 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
     }
     case "string.const":
       return inst;
+    case "dyn.eq":
     case "string.concat":
     case "string.eq": {
       const l = mapId(rename, inst.lhs);

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -653,6 +653,8 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
     case "tag.test":
     case "dyn.truthy":
       return [instr.value];
+    case "dyn.eq":
+      return [instr.lhs, instr.rhs];
     case "string.const":
       return [];
     case "string.concat":

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -612,6 +612,25 @@ function verifyBlock(
           });
         }
       }
+      // #2949 S5.2 — dyn.eq compares TWO boxed-any carriers via the canonical
+      // `__any_strict_eq`/`__any_eq` helpers (which take `(ref null $AnyValue,
+      // ref null $AnyValue)`). BOTH operands MUST be dynamic — the producer
+      // boxes any concrete operand into the carrier before this node, so a
+      // non-dynamic operand here is a producer bug (a concrete-vs-concrete
+      // `===` has an inline `i32.eq`/`f64.eq` and must never route through the
+      // carrier helper). Result is i32, satisfying downstream condValue rules.
+      if (instr.kind === "dyn.eq") {
+        for (const operand of [instr.lhs, instr.rhs]) {
+          const operandIr = operandIrType(func, block, operand, localDefs);
+          if (operandIr && operandIr.kind !== "dynamic") {
+            errors.push({
+              message: `dyn.eq operand must be a dynamic IrType, got ${operandIr.kind} (#2949)`,
+              func: func.name,
+              block: block.id as number,
+            });
+          }
+        }
+      }
 
       if (instr.result !== null) {
         if (defs.has(instr.result)) {
@@ -695,6 +714,8 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
     case "tag.test":
     case "dyn.truthy":
       return [instr.value];
+    case "dyn.eq":
+      return [instr.lhs, instr.rhs];
     case "string.const":
       return [];
     case "string.concat":

--- a/tests/issue-2949-s5-2-eq.test.ts
+++ b/tests/issue-2949-s5-2-eq.test.ts
@@ -1,0 +1,437 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 S5.2 — dynamic-value strict/loose equality lowering.
+//
+// S5.0 (PR #2682) landed the builder emit vocabulary (emitBox/emitUnbox/
+// emitTagTest). S5.1 (PR #2690) added `dyn.truthy`. S5.2 adds `dyn.eq`:
+// `===`/`!==`/`==`/`!=` between two boxed-any carriers via a new
+// `emitDynEq` builder method + `IrInstrDynEq` node, lowered through the new
+// `IrDynamicLowering.emitEqOperand` / `emitStrictEq` / `emitLooseEq` handle
+// arms, which ROUTE to the canonical `__any_strict_eq` / `__any_eq` helpers —
+// one equality engine, byte-parity with legacy's `compileAnyBinaryDispatch`
+// (June-audit D4). The tag-5 field-4 classifier (cross-type falsity,
+// numeric-class `23 === 23.0`, `NaN === NaN → false` via the helper's
+// `f64.eq`, reference identity) stays in the helper body, NEVER
+// re-implemented. Payload-less `dyn === null` / `dyn === undefined` STRICT
+// cases lower via the cheaper exact `tag.test{Null|Undefined}` primitive.
+//
+// This slice is byte-inert by construction — the selector's move-only gate
+// still rejects a dynamic-eq body, so from-ast never builds `dyn.eq` in a
+// CLAIMED function (proven separately by prove-emit-identity, 39/39
+// IDENTICAL). These tests exercise the mechanism DIRECTLY: node shape +
+// result type, the construction-time operand guard, the handle→helper D4
+// routing, and — per the slice-3 standard — RUNTIME execution of hand-built
+// IR lowered against the PRODUCTION handle over a real CodegenContext, in
+// BOTH the gc (fast) and host strategies, asserting SameValue / `===`
+// semantics incl. cross-type falsity, numeric-class, NaN, null/undefined.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { ensureAnyHelpers } from "../src/codegen/any-helpers.js";
+// Side-effect import: registers the `flushLateImportShifts` codegen delegate
+// that `addUnionImports` requires (same pattern as the S5.0 / S5.1 tests).
+import "../src/codegen/expressions.js";
+import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
+import { ensureLateImport } from "../src/codegen/shared.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
+import { addFuncType } from "../src/codegen/registry/types.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import { JsTag } from "../src/codegen/js-tag.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
+import { peepholeOptimize } from "../src/codegen/peephole.js";
+import { stackBalance } from "../src/codegen/stack-balance.js";
+import {
+  IrFunctionBuilder,
+  irDynamic,
+  irVal,
+  lowerIrFunctionToWasm,
+  makeDynamicLowering,
+  verifyIrFunction,
+  type IrFunction,
+  type IrLowerResolver,
+  type IrType,
+} from "../src/ir/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import type { FuncTypeDef } from "../src/ir/types.js";
+
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+const DYN: IrType = irDynamic();
+
+// ---------------------------------------------------------------------------
+// Harness — real context, production handle, production encoder (S5.1 style)
+// ---------------------------------------------------------------------------
+
+function makeGcCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {
+    fast: true,
+    nativeStrings: false,
+  });
+  ensureAnyHelpers(ctx); // what preregisterDynamicSupport does for gc
+  return ctx;
+}
+
+function makeHostCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {});
+  // What preregisterDynamicSupport does for a host module carrying a dyn.eq:
+  // the classifier/box imports PLUS the host equality imports (__host_eq / the
+  // JS `===`, __host_loose_eq / the JS `==`) — the SAME imports legacy host
+  // `any === any` uses.
+  addUnionImports(ctx);
+  ensureLateImport(ctx, "__host_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+  ensureLateImport(ctx, "__host_loose_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
+  return ctx;
+}
+
+function resolverFor(ctx: CodegenContext): IrLowerResolver {
+  const dyn = makeDynamicLowering(ctx);
+  return {
+    resolveFunc: (ref) => {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) throw new Error(`test resolver: unknown func ${ref.name}`);
+      return idx;
+    },
+    resolveGlobal: () => {
+      throw new Error("test resolver: no globals");
+    },
+    resolveType: () => {
+      throw new Error("test resolver: no type refs");
+    },
+    internFuncType: (t: FuncTypeDef) => addFuncType(ctx, t.params, t.results, t.name),
+    resolveDynamic: () => (dyn ? dyn.carrier : { kind: "externref" }),
+    resolveDynamicLowering: () => dyn,
+  };
+}
+
+function install(ctx: CodegenContext, fns: IrFunction[]): void {
+  const resolver = resolverFor(ctx);
+  for (const f of fns) {
+    const { func } = lowerIrFunctionToWasm(f, resolver);
+    const handle = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, handle, func);
+    ctx.mod.exports.push({ name: f.name, desc: { kind: "func", index: handle } });
+  }
+}
+
+async function instantiateCtx(
+  ctx: CodegenContext,
+  env: Record<string, unknown> = {},
+): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  repairStructTypeMismatches(ctx.mod);
+  peepholeOptimize(ctx.mod);
+  stackBalance(ctx.mod);
+  const binary = emitBinary(ctx.mod);
+  const jsString: Record<string, unknown> = {
+    concat: (a: string, b: string) => `${a}${b}`,
+    length: (s: string) => s.length,
+    equals: (a: unknown, b: unknown) => (a === b ? 1 : 0),
+    substring: (s: string, a: number, b: number) => s.substring(a, b),
+    charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+    fromCharCode: (c: number) => String.fromCharCode(c),
+  };
+  const { instance } = await WebAssembly.instantiate(binary as BufferSource, {
+    env,
+    "wasm:js-string": jsString,
+  });
+  return instance.exports as Record<string, (...args: unknown[]) => unknown>;
+}
+
+// Realistic host import stubs — the equality helpers reach the classifier /
+// host-eq family, so these must MEAN what the real runtime means (a `() => 0`
+// fallback would silently answer every equality `false`).
+function hostEnvFor(ctx: CodegenContext): Record<string, unknown> {
+  const stub = (name: string): unknown => {
+    if (name.startsWith("__typeof_")) {
+      const t = name.slice("__typeof_".length);
+      // biome-ignore lint/suspicious/useValidTypeof: t derives from the import name.
+      return (v: unknown) => (typeof v === t ? 1 : 0);
+    }
+    switch (name) {
+      case "__box_number":
+        return (v: number) => v;
+      case "__box_boolean":
+        return (v: number) => Boolean(v);
+      case "__unbox_number":
+        return (v: unknown) => Number(v);
+      case "__unbox_boolean":
+        return (v: unknown) => (v ? 1 : 0);
+      case "__is_truthy":
+        return (v: unknown) => (v ? 1 : 0);
+      case "__host_eq":
+        return (a: unknown, b: unknown) => (a === b ? 1 : 0);
+      case "__host_loose_eq":
+        // biome-ignore lint/suspicious/noDoubleEquals: modelling JS `==` deliberately.
+        return (a: unknown, b: unknown) => (a == b ? 1 : 0);
+      case "__extern_is_undefined":
+        return (v: unknown) => (v === undefined ? 1 : 0);
+      default:
+        return () => 0;
+    }
+  };
+  const env: Record<string, unknown> = {};
+  for (const imp of ctx.mod.imports) {
+    if (imp.module === "env" && imp.desc.kind === "func") env[imp.name] = stub(imp.name);
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// IR builders — hand-built dyn.eq functions
+// ---------------------------------------------------------------------------
+
+/** `eqNum(a,b: f64): i32` — box both f64 params, strict/loose eq. */
+function eqNum(name: string, opts: { loose: boolean; negate: boolean }): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", F64);
+  const c = b.addParam("c", F64);
+  b.openBlock();
+  const da = b.emitBox(a, irDynamic(JsTag.NumberF64));
+  const dc = b.emitBox(c, irDynamic(JsTag.NumberF64));
+  const r = b.emitDynEq(da, dc, opts);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/**
+ * `eqI32F64(a: i32, b: f64): i32` — box an i32 (as an unrefined NUMBER, tag-2)
+ * and an f64 (tag-3), strict-eq: exercises the numeric-CLASS arm (`5 === 5.0`).
+ */
+function eqI32F64(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", I32);
+  const c = b.addParam("c", F64);
+  b.openBlock();
+  const da = b.emitBox(a, DYN); // unrefined i32 → NUMBER box
+  const dc = b.emitBox(c, irDynamic(JsTag.NumberF64));
+  const r = b.emitDynEq(da, dc, { loose: false, negate: false });
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/** `eqNumBool(a: f64, b: i32): i32` — number vs Boolean-refined i32, strict. */
+function eqNumBool(name: string): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", F64);
+  const c = b.addParam("c", I32);
+  b.openBlock();
+  const da = b.emitBox(a, irDynamic(JsTag.NumberF64));
+  const dc = b.emitBox(c, irDynamic(JsTag.Boolean));
+  const r = b.emitDynEq(da, dc, { loose: false, negate: false });
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/** `eqDyn(a,b: dynamic): i32` — both params ARE carriers (host: externref). */
+function eqDyn(name: string, opts: { loose: boolean; negate: boolean }): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", DYN);
+  const c = b.addParam("c", DYN);
+  b.openBlock();
+  const r = b.emitDynEq(a, c, opts);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/** `isTag(x: dynamic): i32` — the strict null/undefined FAST-PATH primitive. */
+function isTag(name: string, tag: JsTag): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const x = b.addParam("x", DYN);
+  b.openBlock();
+  const r = b.emitTagTest(x, tag);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Node shape + result type + construction-time operand guard
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.2 — emitDynEq emits a verifier-clean i32 dyn.eq node", () => {
+  it("appends a dyn.eq node with i32 result, loose/negate flags, and registers typeOf", () => {
+    const b = new IrFunctionBuilder("eq1", [I32], true);
+    const x = b.addParam("x", DYN);
+    const y = b.addParam("y", DYN);
+    b.openBlock();
+    const r = b.emitDynEq(x, y, { loose: true, negate: true });
+    expect(b.typeOf(r)).toEqual(I32);
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    const [node] = fn.blocks[0].instrs;
+    expect(node).toMatchObject({
+      kind: "dyn.eq",
+      lhs: x,
+      rhs: y,
+      loose: true,
+      negate: true,
+      result: r,
+      resultType: I32,
+    });
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("rejects a non-dynamic operand at construction (carrier equality only)", () => {
+    const b = new IrFunctionBuilder("eqBad", [I32], true);
+    const x = b.addParam("x", DYN);
+    const c = b.addParam("c", F64);
+    b.openBlock();
+    expect(() => b.emitDynEq(x, c, { loose: false, negate: false })).toThrow(/rhs operand .* is not dynamic/);
+    expect(() => b.emitDynEq(c, x, { loose: false, negate: false })).toThrow(/lhs operand .* is not dynamic/);
+  });
+
+  it("a dyn.eq fed a concrete operand fails the verifier (defense in depth)", () => {
+    const b = new IrFunctionBuilder("eqVerify", [I32], true);
+    const x = b.addParam("x", DYN);
+    const c = b.addParam("c", I32);
+    b.openBlock();
+    b.terminate({ kind: "return", values: [c] });
+    const fn = b.finish();
+    const bad: IrFunction = {
+      ...fn,
+      blocks: [
+        {
+          ...fn.blocks[0],
+          instrs: [
+            { kind: "dyn.eq", lhs: x, rhs: c, loose: false, negate: false, result: 999, resultType: I32 } as never,
+          ],
+        },
+      ],
+    };
+    const errs = verifyIrFunction(bad);
+    expect(errs.some((e) => /dyn\.eq operand must be a dynamic/.test(e.message))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handle → helper routing (D4): one equality engine, both strategies
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.2 — IrDynamicLowering equality arms route to the canonical helpers", () => {
+  it("gc: emitEqOperand is identity; emitStrictEq/emitLooseEq call the __any_*_eq helpers (+eqz on negate)", () => {
+    const ctx = makeGcCtx();
+    const dyn = makeDynamicLowering(ctx);
+    expect(dyn).not.toBeNull();
+    expect(dyn!.emitEqOperand()).toEqual([]); // gc carrier IS $AnyValue
+    const strictIdx = ctx.funcMap.get("__any_strict_eq");
+    const looseIdx = ctx.funcMap.get("__any_eq");
+    expect(strictIdx).toBeDefined();
+    expect(looseIdx).toBeDefined();
+    expect(dyn!.emitStrictEq(false)).toEqual([{ op: "call", funcIdx: strictIdx }]);
+    expect(dyn!.emitStrictEq(true)).toEqual([{ op: "call", funcIdx: strictIdx }, { op: "i32.eqz" }]);
+    expect(dyn!.emitLooseEq(false)).toEqual([{ op: "call", funcIdx: looseIdx }]);
+    expect(dyn!.emitLooseEq(true)).toEqual([{ op: "call", funcIdx: looseIdx }, { op: "i32.eqz" }]);
+  });
+
+  it("host: emitEqOperand is identity; strict/loose call the host equality imports (__host_eq/__host_loose_eq)", () => {
+    const ctx = makeHostCtx();
+    const dyn = makeDynamicLowering(ctx);
+    expect(dyn).not.toBeNull();
+    // The host carrier (externref) IS the __host_eq operand shape → no marshalling.
+    expect(dyn!.emitEqOperand()).toEqual([]);
+    const strictIdx = ctx.funcMap.get("__host_eq");
+    const looseIdx = ctx.funcMap.get("__host_loose_eq");
+    expect(strictIdx).toBeDefined();
+    expect(looseIdx).toBeDefined();
+    expect(dyn!.emitStrictEq(false)).toEqual([{ op: "call", funcIdx: strictIdx }]);
+    expect(dyn!.emitStrictEq(true)).toEqual([{ op: "call", funcIdx: strictIdx }, { op: "i32.eqz" }]);
+    expect(dyn!.emitLooseEq(false)).toEqual([{ op: "call", funcIdx: looseIdx }]);
+    expect(dyn!.emitLooseEq(true)).toEqual([{ op: "call", funcIdx: looseIdx }, { op: "i32.eqz" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gc runtime — dyn.eq over the $AnyValue carrier (number / boolean partitions)
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.2 — gc runtime: dyn.eq over the $AnyValue carrier", () => {
+  it("strict/loose number equality incl. NaN (spec-correct: NaN === NaN → 0) and ±0", async () => {
+    const fns = [
+      eqNum("eqN", { loose: false, negate: false }),
+      eqNum("neN", { loose: false, negate: true }),
+      eqNum("looseN", { loose: true, negate: false }),
+      eqI32F64("eqIF"),
+      eqNumBool("eqNB"),
+    ];
+    for (const f of fns) expect(verifyIrFunction(f)).toEqual([]);
+    const ctx = makeGcCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx);
+    // strict === : the helper's number arm is `f64.eq`, so NaN === NaN → 0
+    // (spec-correct, UNLIKE S5.1's inherited truthiness NaN quirk).
+    expect(ex.eqN(5, 5)).toBe(1);
+    expect(ex.eqN(5, 6)).toBe(0);
+    expect(ex.eqN(NaN, NaN)).toBe(0);
+    expect(ex.eqN(0, -0)).toBe(1); // f64.eq(+0,-0) === true, matching JS `0 === -0`
+    // strict !== negation
+    expect(ex.neN(5, 6)).toBe(1);
+    expect(ex.neN(5, 5)).toBe(0);
+    expect(ex.neN(NaN, NaN)).toBe(1);
+    // loose == over two numbers is the same as ===
+    expect(ex.looseN(5, 5)).toBe(1);
+    expect(ex.looseN(5, 6)).toBe(0);
+    // numeric CLASS: a tag-2 i32 box === a tag-3 f64 box when numerically equal
+    expect(ex.eqIF(5, 5)).toBe(1);
+    expect(ex.eqIF(5, 6)).toBe(0);
+    // cross-type strict: a boxed number (tag-3) vs a boxed boolean (tag-4) →
+    // different tags → always false (no coercion under `===`).
+    expect(ex.eqNB(1, 1)).toBe(0);
+    expect(ex.eqNB(0, 0)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// host runtime — dyn.eq over the externref carrier (full spectrum)
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.2 — host runtime: dyn.eq over the externref carrier", () => {
+  it("strict/loose equality across number/string/bool/null/undefined incl. cross-type + NaN", async () => {
+    const fns = [
+      eqDyn("eqD", { loose: false, negate: false }),
+      eqDyn("neD", { loose: false, negate: true }),
+      eqDyn("looseD", { loose: true, negate: false }),
+      isTag("isNull", JsTag.Null),
+      isTag("isUndef", JsTag.Undefined),
+    ];
+    for (const f of fns) expect(verifyIrFunction(f)).toEqual([]);
+    const ctx = makeHostCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx, hostEnvFor(ctx));
+
+    // STRICT === : same-type equal, same-type unequal, cross-type false, NaN.
+    expect(ex.eqD(5, 5)).toBe(1);
+    expect(ex.eqD(5, 6)).toBe(0);
+    expect(ex.eqD("a", "a")).toBe(1);
+    expect(ex.eqD("a", "b")).toBe(0);
+    expect(ex.eqD("5", 5)).toBe(0); // cross-type: string vs number
+    expect(ex.eqD(true, true)).toBe(1);
+    expect(ex.eqD(true, 1)).toBe(0); // cross-type: boolean vs number
+    expect(ex.eqD(NaN, NaN)).toBe(0);
+    expect(ex.eqD(null, null)).toBe(1);
+    expect(ex.eqD(undefined, undefined)).toBe(1);
+    expect(ex.eqD(null, undefined)).toBe(0); // strict: distinct partitions
+
+    // STRICT !== negation.
+    expect(ex.neD(5, 6)).toBe(1);
+    expect(ex.neD(5, 5)).toBe(0);
+    expect(ex.neD(null, undefined)).toBe(1);
+
+    // LOOSE == : §7.2.15 coercions, owned by `__host_loose_eq` (JS `==`) — the
+    // SAME import legacy host `any == any` uses, so these are spec-correct AND
+    // byte-parity with legacy (verified: routing host loose through the
+    // standalone `__any_eq` instead would DROP these coercions to `false`).
+    expect(ex.looseD(1, 1)).toBe(1);
+    expect(ex.looseD("5", 5)).toBe(1); // string == number coercion
+    expect(ex.looseD(null, undefined)).toBe(1); // null == undefined
+    expect(ex.looseD(0, false)).toBe(1); // number == boolean coercion
+
+    // Null/undefined STRICT FAST-PATH primitive (what from-ast's dyn===null /
+    // dyn===undefined arm emits): an exact partition tag test.
+    expect(ex.isNull(null)).toBe(1);
+    expect(ex.isNull(undefined)).toBe(0);
+    expect(ex.isNull(5)).toBe(0);
+    expect(ex.isUndef(undefined)).toBe(1);
+    expect(ex.isUndef(null)).toBe(0);
+    expect(ex.isUndef(5)).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2949 S5.2 — dynamic-value strict/loose equality lowering

Mechanism slice of the IR claim-rate lever (follows S5.0 #2682 plumbing, S5.1 #2690 truthiness). Adds `dyn === x` / `dyn !== x` / `dyn == x` / `dyn != x` lowering for boxed-any carriers → `i32`.

### What lands
- `IrInstrDynEq{lhs, rhs, loose, negate}` node (+ every `never`-exhaustive switch site: nodes/lower/verify/effects/monomorphize/inline-small).
- `IrFunctionBuilder.emitDynEq(lhs, rhs, {loose, negate})` with construction-time dynamic-operand guard.
- `IrDynamicLowering.emitEqOperand` / `emitStrictEq` / `emitLooseEq` handle arms + the `lower.ts` `dyn.eq` case.
- `from-ast` `lowerBinary` dynamic arm + `dyn === null`/`dyn === undefined` STRICT `tag.test` fast path (wired inside `tryFoldNullCompare`/`tryLowerUndefinedCompare`).

### Routed through the canonical per-backend equality engine (D4)
- **gc/fast/standalone**: `__any_strict_eq` / `__any_eq` ($AnyValue carrier) — legacy `compileAnyBinaryDispatch`'s helpers; the tag-5 classifier owns cross-type falsity, numeric-class `5 === 5.0`, `NaN === NaN → false` (`f64.eq`).
- **host**: `__host_eq` / `__host_loose_eq` (externref carrier). **Verified against the real compiler** that legacy host `any`-equality uses these, NOT the standalone `__any_*_eq` path — that path drops the §7.2.15 coercions (`"5" == 5 → 0`, `null == undefined → 0`). Full rationale in the issue's *Implementation Notes — S5.2* §2.

`NaN === NaN` correctly yields `0` in both modes (cleaner than S5.1's inherited `__any_unbox_bool` NaN-truthy quirk).

### Byte-inert by construction
The move-only selector gate still rejects dynamic-eq bodies, so `from-ast` never builds `dyn.eq` in a claimed function → **zero compiled-output change**. The claim-flip stays back-loaded onto S5.P (§4 anti-vacuity probe).

### Verification
- `prove-emit-identity.mjs`: **39/39 IDENTICAL** vs base `bfa59bc68` (gc/standalone/wasi).
- `tests/issue-2949-s5-2-eq.test.ts`: **7/7** — node shape + guards, D4 routing (both strategies), and RUNTIME execution of hand-built IR over gc + host (number/string/bool/null/undefined, cross-type falsity, NaN, numeric-class, loose coercions, tag.test fast path).
- `check:ir-fallbacks`: OK, zero delta, zero post-claim demotions.
- Adjacent #2949 suites: 87/87 combined. `tsc` + prettier + biome clean.
- `tests/ir/` pre-existing 7 (`__unbox_number` harness LinkError) reproduce identically on base — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8