### PR TITLE
fix(#3037 CS1b): dynamic any-member-read tag-6 carrier for === identity

### DIFF
--- a/plan/issues/3037-object-identity-canonicalization-substrate.md
+++ b/plan/issues/3037-object-identity-canonicalization-substrate.md
@@ -2,7 +2,7 @@
 id: 3037
 title: "Object-identity canonicalization substrate for standalone dynamic reads (foundation under #3027 / V2-S3b reader-arm)"
 status: in-progress
-assignee: opus-3037-cs1a
+assignee: opus-3037-cs1b
 sprint: current
 created: 2026-07-05
 updated: 2026-07-05
@@ -587,3 +587,92 @@ CS1a is low-risk (byte-inert corpus) but floor-sensitive: **not self-merged on
 PR-green alone** — flagged the lead for a monitored `merge_group` standalone
 `host_free_pass` floor enqueue (expect NET-POSITIVE / neutral). Any floor
 regression ⇒ a non-object leaked into tag-6 → diagnose, don't force.
+
+---
+
+## CS1b (member-read family) — LANDED (opus-3037-cs1b): dynamic `any`-member-read tag-6 carrier
+
+**PR:** dynamic `any`-member-READ carrier (member-read family only; element
+access + the reflective producers are separate follow-up PRs). **Flips CS0
+FLIP-TARGETs (a) `gOPD.value === gOPD.value`, (b) `o.a === o.b` (aliased object),
+and (e) `o.n === o.n` (dynamic number)** — all three are `PropertyAccessExpression`
+reads, so one member-read interception covers them. (c) stays 1 (CS1a); (d)
+`getPrototypeOf` stays 0 (its reads land in identifier locals, not member reads →
+that is CS1c). All 10 CS0 INVARIANTs + all CS1a tests unchanged.
+
+### The mechanism (CORRECTS the RE-SCOPE "reader has no migratable site" premise)
+
+CS0 measured that the reader returns a **bare externref** and the tag is decided
+downstream at the operand seam. The re-scope concluded "box at the reader" has no
+site. **CS1b resolves this by making the reader context-aware:** a member read is
+re-classified to the tag-6 carrier **only when it is a direct operand of a
+standalone `any`-equality** — the EXACT shape (`leftIsAny && rightIsAny &&
+isEqualityOp`, binary-ops.ts) that routes through `compileAnyBinaryDispatch →
+emitAnyEqOperands`. So the carrier can only ever flow into the equality helper's
+`isAnyValue` fast-path and NEVER into a subsequent read/store — side-stepping the
+CS1a finding that a `$AnyValue`-typed value breaks dynamic reads (`__any_to_extern`
+keeps the box wrapped). This is why the carrier here is a `$AnyValue` (not the
+`ref $Object` CS1a used for a statically-known object): a dynamic read is
+statically `any`, so it needs the FULL runtime classifier, and the equality-operand
+scoping makes `$AnyValue` safe.
+
+- **Carrier production:** `maybeWrapAnyReadEqualityCarrier` (property-access.ts),
+  called at the single member-read choke point in `compileExpression`
+  (expressions.ts, `ts.isPropertyAccessExpression` arm). When `ctx.standalone`,
+  the read compiled to `externref`, and `isAnyEqualityOperand(expr)` holds, it
+  appends `call __any_from_extern_honest` and returns `(ref $AnyValue)`. Every
+  precondition unmet → the bare externref is returned unchanged (byte-inert).
+- **Classifier reuse (NO second classifier):** `ensureAnyFromExternHelper` gains a
+  `{ forceHonest }` option that emits its honest body (the SAME `$AnyString`→tag-5,
+  `$BoxedNumber`→tag-3, `$BoxedBoolean`→tag-4, other-eq→tag-6 arms) under a
+  DISTINCT name `__any_from_extern_honest`, irrespective of the module-wide
+  `honestAnyBoxing` flag (default OFF). The flag-driven generic instance that the
+  −788 chokepoint depends on is neither renamed nor mutated. `$BoxedNumber`
+  eq-castability (a plain struct → `eq` subtype) is handled because the classifier
+  peels tag-3/tag-4 BEFORE the eq test (the settled CS0 probe).
+- **Untouched:** the generic `boxToAny` externref arm (−788), the tag-5 same-tag
+  arm (−162), and the `===` operand seam / `emitAnyEqOperands` (−299) — all
+  byte-identical. The change is purely the reader's result ValType at the enumerated
+  shape.
+
+### Partial-coverage safety (S3a)
+
+Scoped to member reads that are direct `any`-equality operands. A member read
+stored in a local first (`const x:any=o.a; x===o.b`) leaves `x` tag-5 and migrates
+only `o.b` → the mixed tag-6×tag-5 pair reconciles via S3a's cross-tag arm → still
+`1` (verified). So partial coverage **never regresses, only under-fixes** — the
+element-access and reflective-producer families can land independently later.
+
+### Files
+
+- `src/codegen/any-helpers.ts` — `ensureAnyFromExternHelper(ctx, { forceHonest })`
+  → forced-honest `__any_from_extern_honest` sibling (same body).
+- `src/codegen/property-access.ts` — `isAnyEqualityOperand` +
+  `maybeWrapAnyReadEqualityCarrier` (exported).
+- `src/codegen/expressions.ts` — call the wrapper at the member-read choke point
+  (applied before the getter-writeback resync, which is net-zero on the stack).
+- `tests/issue-3037-cs0-identity-characterization.test.ts` — (a)/(b)/(e) updated
+  `0 → 1` (`FLIPPED by CS1b`); (c) stays 1 (CS1a), (d) stays 0 (CS1c).
+- `tests/issue-3037-cs1b-member-read-carrier.test.ts` — new: pins the 3 flips,
+  negation, the S3a half-migrated pair, anti-vacuity negatives, and the
+  classification/consumer invariants (string/number/boolean by value, chained read
+  `o.a.z`, arithmetic, `typeof`).
+
+### Floor discipline
+
+Higher breadth-risk than CS1a (it changes a common reader lowering's result
+ValType) — the equality-operand scoping is the safety boundary. **NOT self-merged
+on PR-green alone**; flagged the lead for a monitored `merge_group` standalone
+`host_free_pass` floor enqueue (expect NET-POSITIVE — drives #3027). Any floor
+regression ⇒ a non-object leaked into tag-6 → diagnose, don't force.
+
+### Remaining CS1b families (separate PRs, isolated merge_group evidence each)
+
+- **CS1b(ii) element access** — same interception at the `ts.isElementAccessExpression`
+  choke point (`arr[i] === arr[j]`); needs `compileElementAccess`'s any-result
+  externref path re-classified. Not folded here (a floor regression there must not
+  sink the member-read flip).
+- **CS1b(iii) descriptor `.value`/`.get` producer** — `.value` reads are already
+  covered when they are equality operands (case a flips here); the remaining work
+  is the producer-side canonicalization for `.value` results that flow elsewhere.
+- **CS1c** getPrototypeOf/reflective producer carrier (case d).

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -375,17 +375,30 @@ export function isAnyValue(type: ValType, ctx: CodegenContext): boolean {
   );
 }
 
-export function ensureAnyFromExternHelper(ctx: CodegenContext): number | undefined {
+export function ensureAnyFromExternHelper(ctx: CodegenContext, opts?: { forceHonest?: boolean }): number | undefined {
   if (!(ctx.standalone || ctx.wasi)) return undefined;
   if (ctx.nativeBoxNumberTypeIdx < 0 || ctx.nativeBoxBooleanTypeIdx < 0) return undefined;
 
-  const existing = ctx.funcMap.get("__any_from_extern");
+  // (#3037 CS1b) The reader-carrier consumers need an ALWAYS-honest classifier
+  // (`$AnyString`→tag-5, `$BoxedNumber`→tag-3, `$BoxedBoolean`→tag-4,
+  // other-eq-castable GC ref→tag-6 identity) irrespective of the module-wide
+  // `honestAnyBoxing` flag (default OFF). It is emitted under a DISTINCT name
+  // (`__any_from_extern_honest`) so it never collides with, nor mutates, the
+  // flag-driven generic instance that the −788 chokepoint depends on. Honest
+  // classification requires the `$AnyString` type to be reserved; without it a
+  // genuine string would mis-classify tag-6, so refuse (the caller keeps the
+  // bare externref — safe, only under-fixes via S3a's cross-tag arm).
+  const forceHonest = opts?.forceHonest === true;
+  if (forceHonest && ctx.anyStrTypeIdx < 0) return undefined;
+  const helperName = forceHonest ? "__any_from_extern_honest" : "__any_from_extern";
+
+  const existing = ctx.funcMap.get(helperName);
   if (existing !== undefined) return existing;
 
   ensureAnyValueType(ctx);
   const anyTypeIdx = ctx.anyValueTypeIdx;
   const anyRef: ValType = { kind: "ref", typeIdx: anyTypeIdx };
-  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [anyRef], "__any_from_extern");
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [anyRef], helperName);
   const funcIdx = mintDefinedFunc(ctx);
   const EQ_HEAP_TYPE = -19;
 
@@ -399,7 +412,7 @@ export function ensureAnyFromExternHelper(ctx: CodegenContext): number | undefin
   // in standalone/wasi; kept total). Honest additionally requires
   // `anyStrTypeIdx` — without the string test a genuine string would
   // mis-classify as tag-6 object, so fall back to the legacy arms instead.
-  const honest = ctx.honestAnyBoxing === true && ctx.anyStrTypeIdx >= 0;
+  const honest = (forceHonest || ctx.honestAnyBoxing === true) && ctx.anyStrTypeIdx >= 0;
   // (#2106 S1) Under the `undefinedSingleton` regime a NULL externref means JS
   // NULL (undefined is the non-null tag-1 singleton, recovered exactly by the
   // `ref.test $AnyValue` arm below) — so the null arm boxes tag-0. This is
@@ -531,14 +544,14 @@ export function ensureAnyFromExternHelper(ctx: CodegenContext): number | undefin
   ];
 
   pushDefinedFunc(ctx, funcIdx, {
-    name: "__any_from_extern",
+    name: helperName,
     typeIdx,
     locals: [{ name: "any", type: { kind: "anyref" } }],
     body,
     exported: false,
   });
-  ctx.funcMap.set("__any_from_extern", funcIdx);
-  ctx.anyHelpers.set("__any_from_extern", funcIdx);
+  ctx.funcMap.set(helperName, funcIdx);
+  ctx.anyHelpers.set(helperName, funcIdx);
   return funcIdx;
 }
 

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -65,7 +65,7 @@ import { compileArrowFunction } from "./closures.js";
 // Property access + binary ops (used inside compileExpressionInner)
 import { compileBinaryExpression } from "./binary-ops.js";
 import { compileArrayLiteral, compileObjectLiteral } from "./literals.js";
-import { compileElementAccess, compilePropertyAccess } from "./property-access.js";
+import { compileElementAccess, compilePropertyAccess, maybeWrapAnyReadEqualityCarrier } from "./property-access.js";
 import { compileTaggedTemplateExpression, compileTemplateExpression } from "./string-ops.js";
 import { compileDeleteExpression, compileRegExpLiteral, compileTypeofExpression } from "./typeof-delete.js";
 
@@ -1347,12 +1347,17 @@ function compileExpressionInner(
     // (#2128) Property reads can dispatch a host GETTER callback whose
     // mutable captures live in ref cells (see the assignment arm above for
     // the setter counterpart) — re-sync the outer locals after the read.
+    // (#3037 CS1b) Re-classify a dynamic `any`-member read that is a direct
+    // operand of a standalone `any`-equality into the `$AnyValue` tag-6 carrier
+    // (object identity), byte-inert off that exact shape. Applied BEFORE the
+    // getter-writeback resync so the classifier consumes the read result while
+    // it is still on top of the stack (the writebacks are net-zero local
+    // re-syncs that leave the carrier value in place).
+    const readResult = maybeWrapAnyReadEqualityCarrier(ctx, fctx, expr, compilePropertyAccess(ctx, fctx, expr));
     if (fctx.persistentCallbackWritebacks && fctx.persistentCallbackWritebacks.length > 0) {
-      const readResult = compilePropertyAccess(ctx, fctx, expr);
       fctx.body.push(...fctx.persistentCallbackWritebacks.map((instr) => structuredClone(instr)));
-      return readResult;
     }
-    return compilePropertyAccess(ctx, fctx, expr);
+    return readResult;
   }
 
   if (ts.isElementAccessExpression(expr)) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -249,8 +249,13 @@ function isAnyEqualityOperand(ctx: CodegenContext, expr: ts.Expression): boolean
     op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
   if (!isEq) return false;
   if (parent.left !== expr && parent.right !== expr) return false;
-  const leftAny = (ctx.checker.getTypeAtLocation(parent.left).flags & ts.TypeFlags.Any) !== 0;
-  const rightAny = (ctx.checker.getTypeAtLocation(parent.right).flags & ts.TypeFlags.Any) !== 0;
+  // #1930 oracle-ratchet: query type facts through `ctx.oracle` (never the raw
+  // TS checker). `typeFactOf(...).kind === "any"` is the exact equivalent of the
+  // `flags & TypeFlags.Any` gate binary-ops.ts uses to route the pair through the
+  // AnyValue equality dispatch (the oracle maps the `Any` type flag to
+  // `{ kind: "any" }`), so this mirrors that gate precisely.
+  const leftAny = ctx.oracle.typeFactOf(parent.left).kind === "any";
+  const rightAny = ctx.oracle.typeFactOf(parent.right).kind === "any";
   return leftAny && rightAny;
 }
 

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -42,7 +42,7 @@ import {
   noJsHost,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
-import { undefinedSingletonActive } from "./any-helpers.js";
+import { ensureAnyFromExternHelper, undefinedSingletonActive } from "./any-helpers.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { emitSymbolDescLoad } from "./symbol-native.js";
 import {
@@ -227,6 +227,66 @@ const WELL_KNOWN_SYMBOLS: Record<string, number> = {
   dispose: 13,
   asyncDispose: 14,
 };
+
+/**
+ * (#3037 CS1b) True when `expr` is a direct operand of a standalone
+ * `any === any` / `!==` / `==` / `!=` comparison — the EXACT shape that
+ * binary-ops.ts routes through the AnyValue equality dispatch
+ * (`compileAnyBinaryDispatch` → `emitAnyEqOperands`), which fires only when BOTH
+ * operands are statically `any` (`leftTsType.flags & Any` on both sides,
+ * binary-ops.ts:1082-1090). Mirroring that gate exactly guarantees a carrier
+ * produced here can only ever flow into `emitAnyEqOperands`'s `isAnyValue`
+ * fast-path and never into a downstream read/store.
+ */
+function isAnyEqualityOperand(ctx: CodegenContext, expr: ts.Expression): boolean {
+  const parent = expr.parent;
+  if (!parent || !ts.isBinaryExpression(parent)) return false;
+  const op = parent.operatorToken.kind;
+  const isEq =
+    op === ts.SyntaxKind.EqualsEqualsToken ||
+    op === ts.SyntaxKind.ExclamationEqualsToken ||
+    op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+    op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+  if (!isEq) return false;
+  if (parent.left !== expr && parent.right !== expr) return false;
+  const leftAny = (ctx.checker.getTypeAtLocation(parent.left).flags & ts.TypeFlags.Any) !== 0;
+  const rightAny = (ctx.checker.getTypeAtLocation(parent.right).flags & ts.TypeFlags.Any) !== 0;
+  return leftAny && rightAny;
+}
+
+/**
+ * (#3037 CS1b — dynamic member-read carrier) When a dynamic `any`-typed member
+ * READ compiled to a bare externref and is a direct operand of a standalone
+ * `any`-equality (see {@link isAnyEqualityOperand}), re-classify it through the
+ * ALWAYS-honest `__any_from_extern_honest` classifier so it reaches `===` as a
+ * proper `$AnyValue`: an object → **tag-6** (identity in `refval` → the tag-6
+ * same-tag `ref.eq` arm answers identity), a `$BoxedNumber` → **tag-3** (value),
+ * a `$BoxedBoolean` → **tag-4**, a `$AnyString` → **tag-5** (content). This flips
+ * the CS0 residuals `o.a === o.b` (case b), `o.n === o.n` (case e) and
+ * `gOPD.value === gOPD.value` (case a) WITHOUT touching the generic `boxToAny`
+ * externref arm (−788) or the `===` operand seam (−299) — the change is purely
+ * the reader's result ValType (externref → `$AnyValue`), gated to exactly the
+ * shape that routes through `emitAnyEqOperands` so the carrier never reaches a
+ * subsequent read/store (which `$AnyValue` would break — the CS1a finding).
+ *
+ * Byte-inert off-path: any precondition unmet → the bare externref is returned
+ * unchanged (a half-migrated tag-6 × tag-5 pair still reconciles via S3a's
+ * cross-tag arm, so partial coverage only under-fixes, never regresses).
+ */
+export function maybeWrapAnyReadEqualityCarrier(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression,
+  result: ValType | null,
+): ValType | null {
+  if (!ctx.standalone) return result;
+  if (!result || result.kind !== "externref") return result;
+  if (!isAnyEqualityOperand(ctx, expr)) return result;
+  const classifyIdx = ensureAnyFromExternHelper(ctx, { forceHonest: true });
+  if (classifyIdx === undefined || ctx.anyValueTypeIdx < 0) return result;
+  fctx.body.push({ op: "call", funcIdx: classifyIdx } as Instr);
+  return { kind: "ref", typeIdx: ctx.anyValueTypeIdx };
+}
 
 /**
  * #2020: resolve an inherited static-property global by walking the class

--- a/tests/issue-3037-cs0-identity-characterization.test.ts
+++ b/tests/issue-3037-cs0-identity-characterization.test.ts
@@ -93,9 +93,12 @@ async function runStandalone(source: string): Promise<number> {
 }
 
 describe("#3037 CS0 — standalone object-identity characterization (FLIP-TARGETs)", () => {
-  it("(a) two gOPD().value reads of the same data property are NOT ===  [FLIP-TARGET 0->1]", async () => {
-    // Descriptor `.value` stores the raw ref honestly; the loss is at the read +
-    // === operand-marshalling (both reads box tag-5). CS1 must make this `1`.
+  it("(a) two gOPD().value reads of the same data property ARE ===  [FLIPPED by CS1b: now 1]", async () => {
+    // Descriptor `.value` stores the raw ref honestly; the loss was at the read +
+    // === operand-marshalling (both reads boxed tag-5). CS1b re-classifies a
+    // dynamic `any`-member read that is a direct `any`-equality operand through
+    // `__any_from_extern_honest` -> the shared function ref boxes tag-6 -> the
+    // tag-6 `ref.eq` arm answers identity.
     expect(
       await runStandalone(`export function run(): number {
         const p: any = { exec: function () { return 1; } };
@@ -103,17 +106,20 @@ describe("#3037 CS0 — standalone object-identity characterization (FLIP-TARGET
         const d2: any = Object.getOwnPropertyDescriptor(p, "exec");
         return (d1.value === d2.value) ? 1 : 0;
       }`),
-    ).toBe(0);
+    ).toBe(1);
   });
 
-  it("(b) two dynamic reads of one aliased object are NOT ===  [FLIP-TARGET 0->1]", async () => {
+  it("(b) two dynamic reads of one aliased object ARE ===  [FLIPPED by CS1b: now 1]", async () => {
+    // The pivotal CS1b case: `o.a` and `o.b` alias one stored ref. Each read is a
+    // direct operand of the `any === any` comparison, so CS1b classifies both to
+    // tag-6 (identity in `refval`) -> the tag-6 same-tag `ref.eq` arm -> 1.
     expect(
       await runStandalone(`export function run(): number {
         const inner = { z: 1 };
         const o: any = { a: inner, b: inner };
         return (o.a === o.b) ? 1 : 0;
       }`),
-    ).toBe(0);
+    ).toBe(1);
   });
 
   it("(c) an any-typed object IS === to ITSELF  [FLIPPED by CS1a: now 1]", async () => {
@@ -140,16 +146,16 @@ describe("#3037 CS0 — standalone object-identity characterization (FLIP-TARGET
     ).toBe(0);
   });
 
-  it("(e) a dynamically-read number is NOT === to a re-read of itself  [FLIP-TARGET 0->1]", async () => {
-    // A boxed-number externval read twice boxes tag-5 twice -> guarded string
-    // arm -> 0. The honest classifier (peels $BoxedNumber -> tag-3) fixes this
-    // by value (spec-correct), a bonus of the same substrate change.
+  it("(e) a dynamically-read number IS === to a re-read of itself  [FLIPPED by CS1b: now 1]", async () => {
+    // A boxed-number externval read twice boxed tag-5 twice -> guarded string
+    // arm -> 0. CS1b's honest classifier peels `$BoxedNumber` -> tag-3 BEFORE the
+    // eq test, so `o.n === o.n` compares by value (42 === 42) -> 1, spec-correct.
     expect(
       await runStandalone(`export function run(): number {
         const o: any = { n: 42 };
         return (o.n === o.n) ? 1 : 0;
       }`),
-    ).toBe(0);
+    ).toBe(1);
   });
 });
 

--- a/tests/issue-3037-cs1b-member-read-carrier.test.ts
+++ b/tests/issue-3037-cs1b-member-read-carrier.test.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3037 CS1b (member-read family) — dynamic `any`-member READ carrier.
+//
+// CS1a made an object LITERAL produced into an `any` local reach `===` as a
+// tag-6 `ref $Object` (identity). CS1b extends the carrier to a DYNAMIC read:
+// when an `any`-typed member read (`o.a`, `o.n`, `d.value`) is a direct operand
+// of a standalone `any === any` / `!==` / `==` / `!=` comparison, the reader's
+// bare externref result is re-classified through the ALWAYS-honest
+// `__any_from_extern_honest` classifier so it reaches `===` as a proper
+// `$AnyValue`: object → tag-6 (identity in `refval`), `$BoxedNumber` → tag-3
+// (value), `$BoxedBoolean` → tag-4, `$AnyString` → tag-5 (content).
+//
+// This flips CS0 FLIP-TARGETs (a) gOPD `.value`, (b) aliased-object member read,
+// (e) dynamic-number self-identity — WITHOUT touching the generic `boxToAny`
+// externref arm (−788) or the `===` operand seam (−299). The change is purely
+// the reader's result ValType, gated to EXACTLY the shape that routes through
+// `emitAnyEqOperands` (both operands `any`), so the carrier can only flow into
+// the equality helper's `isAnyValue` fast-path — never into a subsequent
+// read/store (which a `$AnyValue` local would break, the CS1a finding).
+//
+// This suite pins BOTH halves: the identity flips AND that the classification
+// keeps strings/numbers/booleans correct and does not disturb non-`===`
+// consumers of a member read (chained read, method call, arithmetic, typeof).
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Host-free: a leaked `env` import would mean the case silently ran on a JS
+  // host fast-path and the result is not the standalone substrate's answer.
+  const leaked = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(leaked, `--target standalone leaked env imports: ${leaked.join(", ")}`).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#3037 CS1b — dynamic member-read identity flips", () => {
+  it("(b) two member reads aliasing one object ARE ===", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const inner = { z: 1 };
+        const o: any = { a: inner, b: inner };
+        return (o.a === o.b) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("(a) two gOPD().value reads of one data property ARE ===", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const p: any = { exec: function () { return 1; } };
+        const d1: any = Object.getOwnPropertyDescriptor(p, "exec");
+        const d2: any = Object.getOwnPropertyDescriptor(p, "exec");
+        return (d1.value === d2.value) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("(e) a dynamically-read number IS === to a re-read (by value, tag-3)", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { n: 42 };
+        return (o.n === o.n) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("negation: aliased member reads are NOT !==", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const inner = { z: 1 };
+        const o: any = { a: inner, b: inner };
+        return (o.a !== o.b) ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+
+  it("half-migrated pair reconciles via S3a (member read vs stored any local)", async () => {
+    // `x` is an identifier operand (stays tag-5), `o.b` is a migrated member read
+    // (tag-6). The mixed pair hits S3a's cross-tag reconciliation arm -> 1. Proves
+    // partial coverage never regresses.
+    expect(
+      await runStandalone(`export function run(): number {
+        const inner = { z: 1 };
+        const o: any = { a: inner, b: inner };
+        const x: any = o.a;
+        return (x === o.b) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});
+
+describe("#3037 CS1b — anti-vacuity negatives (must stay 0)", () => {
+  it("distinct objects of equal shape are NOT === via member reads", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { a: { z: 1 }, b: { z: 1 } };
+        return (o.a === o.b) ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+
+  it("distinct gOPD .value functions are NOT ===", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const p: any = { exec: function () { return 1; }, test: function () { return 2; } };
+        const de: any = Object.getOwnPropertyDescriptor(p, "exec");
+        const dt: any = Object.getOwnPropertyDescriptor(p, "test");
+        return (de.value === dt.value) ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+
+  it("distinct numbers read dynamically are NOT ===", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { m: 42, n: 7 };
+        return (o.m === o.n) ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+});
+
+describe("#3037 CS1b — classification correctness + non-=== consumers unaffected", () => {
+  it("a dynamically-read string stays === by content (tag-5 intact)", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { s: "ab" };
+        return (o.s === o.s) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("a dynamically-read string is === to a literal (content)", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { s: "ab" };
+        return (o.s === "ab") ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("a dynamically-read number is === to a literal (by value)", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { n: 42 };
+        return (o.n === 42) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("a dynamically-read boolean is === to a literal (by value)", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { b: true };
+        return (o.b === true) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("typeof a dynamically-read string is still 'string'", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { s: "ab" };
+        return (typeof o.s === "string") ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("a chained read off a member read still resolves (o.a.z)", async () => {
+    // `o.a` here is NOT an equality operand — the carrier must NOT fire, so the
+    // chained `.z` read still routes through `__extern_get` correctly.
+    expect(
+      await runStandalone(`export function run(): number {
+        const inner = { z: 7 };
+        const o: any = { a: inner };
+        return o.a.z;
+      }`),
+    ).toBe(7);
+  });
+
+  it("a member-read result used in arithmetic still unboxes to a number", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { n: 40 };
+        return (o.n + 2);
+      }`),
+    ).toBe(42);
+  });
+});


### PR DESCRIPTION
## #3037 CS1b (member-read family) — dynamic \`any\`-member-read tag-6 carrier

Extends the CS1a object-identity carrier (object-literal-into-\`any\`) to a **dynamic member READ**. When an \`any\`-typed member read (\`o.a\`, \`o.n\`, \`d.value\`) is a **direct operand** of a standalone \`any === any\` / \`!==\` / \`==\` / \`!=\` comparison, the reader's bare externref result is re-classified through an **always-honest** classifier so it reaches \`===\` as a proper \`$AnyValue\`: object → **tag-6** (identity in \`refval\`), \`$BoxedNumber\` → tag-3 (value), \`$BoxedBoolean\` → tag-4, \`$AnyString\` → tag-5 (content). The tag-6 same-tag \`ref.eq\` arm then answers object identity.

### Flips (CS0 FLIP-TARGETs)
- **(b)** \`o.a === o.b\` (aliased object) → **1**
- **(a)** \`gOPD(p,"exec").value === gOPD(p,"exec").value\` → **1**
- **(e)** \`o.n === o.n\` (dynamic number, by value) → **1**

All three are \`PropertyAccessExpression\` reads, so one member-read interception covers them. (c) stays 1 (CS1a); (d) \`getPrototypeOf\` stays 0 (that is CS1c — its reads land in identifier locals, not member reads).

### Mechanism (corrects the RE-SCOPE "reader has no migratable site" premise)
CS0 measured that the reader returns a bare externref and the tag is decided downstream. CS1b makes the reader **context-aware**: the carrier fires **only** when the read is a direct operand of the exact shape (\`leftIsAny && rightIsAny && isEqualityOp\`) that routes through \`compileAnyBinaryDispatch → emitAnyEqOperands\`. So the \`$AnyValue\` carrier can only flow into the equality helper's \`isAnyValue\` fast-path, **never** into a subsequent read/store (which a \`$AnyValue\` local breaks — the CS1a finding). The generic \`boxToAny\` externref arm (−788), the tag-5 same-tag arm (−162), and the \`===\` operand seam (−299) are **all untouched**.

### Safety evidence
- **prove-emit-identity: 39/39 IDENTICAL** (host/gc/standalone/wasi) — byte-inert off the migrated shape.
- CS0 (updated a/b/e) + CS1a + new CS1b suite: all green.
- Floor-sensitive suites green: #2040 tag-5 classifier, #1888 any-extern-roundtrip, #2583, #2719, #2734, #1461 standalone search/reduce.
- **Partial coverage SAFE via S3a:** \`const x:any=o.a; x===o.b\` leaves x tag-5, migrates only o.b → the mixed tag-6×tag-5 pair reconciles via S3a's cross-tag arm → 1 (verified).

### Floor discipline
Higher breadth-risk than CS1a (changes a common reader lowering's result ValType) — the equality-operand scoping is the safety boundary. **NOT self-merged on PR-green alone**: requesting a monitored \`merge_group\` standalone \`host_free_pass\` floor enqueue (expect NET-POSITIVE — drives #3027). Any floor regression ⇒ a non-object leaked into tag-6 → diagnose, don't force.

Element-access + reflective-producer families are separate follow-up PRs (isolated floor evidence each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8