### PR TITLE
docs(website): blog — 'directed by humans' → 'directed by me'

### DIFF
--- a/website/blog/index.html
+++ b/website/blog/index.html
@@ -475,7 +475,7 @@
 
         <h2>How it's built</h2>
         <p>
-          The compiler is built day to day by a small team of AI agents, directed by humans. One grooms the backlog, one
+          The compiler is built day to day by a small team of AI agents, directed by me. One grooms the backlog, one
           writes an implementation spec before any code is written, one runs the sprint and the merge queue, and several
           write the code, each in an isolated git worktree. If that reads like an ordinary software team, that is the
           point: no special process was invented for AI. Spec-first issues, test-driven changes, code review, a merge


### PR DESCRIPTION
Small wording change in the blog "How it's built" section, per request: the AI-agent team is "directed by me" (consistent with the byline) rather than "directed by humans".

🤖 Generated with [Claude Code](https://claude.com/claude-code)