### PR TITLE
docs(readme): workover — fix stale links, de-duplicate, tighten hedging

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,131 +3,57 @@
 Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC.
 
 > **Status: early-stage research prototype — a tech demo, not a production-ready compiler.**
-> `js2wasm` is an experimental ahead-of-time JavaScript/TypeScript-to-WasmGC compiler under active development. It explores one specific point in the design space: full ECMAScript backwards compatibility via direct AOT compilation, with no JavaScript engine or interpreter bundled into the output. It does **not** claim production readiness, full language coverage, or stable APIs — expect rough edges, gaps, and breaking changes. Live conformance and benchmark figures are in **[STATUS.md](./STATUS.md)** (numbers change frequently and are not duplicated in this README).
+> `js2wasm` is an experimental ahead-of-time JavaScript/TypeScript-to-WasmGC compiler under active development. It explores one specific point in the design space: full ECMAScript backwards compatibility via direct AOT compilation, with no JavaScript engine or interpreter bundled into the output. It does **not** claim production readiness, full language coverage, or stable APIs — expect rough edges, gaps, and breaking changes. Beyond the single auto-updated conformance figure below, live numbers live in **[STATUS.md](./STATUS.md)** (they change frequently and are not otherwise duplicated here).
 
 `js2wasm` compiles source code into WasmGC binaries without embedding a JavaScript interpreter or shipping a bundled runtime. That avoids the runtime tax common in the interpreter-based and engine-embedding approaches — where a JavaScript interpreter or full engine is compiled to Wasm and shipped inside every module — and keeps the output aligned with Wasm-native deployment models.
 
-`js2wasm` is a free and open-source project developed by **Loopdive GmbH** and released under the **Apache License 2.0 with LLVM Exceptions**. It is a freely-licensed, open-source technical foundation and reusable building block, developed fully in the open, including its agentic engineering workflow. The repository contains the compiler source, the complete planning surface (`plan/`), and the agent coordination infrastructure (`.claude/`) that a small team uses to ship fixes in parallel.
+`js2wasm` is a free and open-source project developed by **Loopdive GmbH** and released under the **Apache License 2.0 with LLVM Exceptions**. It is developed fully in the open, including its agentic engineering workflow: the repository contains the compiler source, the complete planning surface (`plan/`), and the agent coordination infrastructure (`.claude/`) that a small team uses to ship fixes in parallel.
+
+<!-- AUTO:conformance-start -->
+**test262 conformance**: 32,236 / 43,106 (74.8 %)
+<!-- AUTO:conformance-end -->
+
+Live figures, the trend graph, and the per-feature breakdown are in **[STATUS.md](./STATUS.md)**, the [Playground](https://js2.loopdive.com/playground/), and the [Roadmap](./ROADMAP.md). The auto-updated figure above (refreshed by CI on every merge) is the JS-host path. Standalone (no-JS-host) pass-rate and benchmark figures are intentionally omitted until the current standalone regression is fixed.
 
 ## Value Proposition
 
-Most JavaScript-on-Wasm systems work by putting a JavaScript engine inside a Wasm module. That approach inherits good compatibility, but it also inherits the cost of shipping and initializing the engine.
-
-`js2wasm` takes the opposite approach:
+Most JavaScript-on-Wasm systems work by putting a JavaScript engine inside a Wasm module. That approach inherits good compatibility, but it also inherits the cost of shipping and initializing the engine. `js2wasm` takes the opposite approach:
 
 - **Direct AOT compilation to WasmGC** instead of interpreter bundling
 - **No embedded JS engine** in the deployed module
 - **No bundled interpreter or engine tax** just to execute application code
 - **Wasm-native deployment model** for runtimes, serverless platforms, and embedded hosts
 
-This matters for infrastructure workloads where artifact size, cold start, density, and host integration are first-order constraints.
+This matters for infrastructure workloads where artifact size, cold start, density, and host integration are first-order constraints — edge and serverless runtimes, Wasm-first platforms, plugin and extension systems, embedders that want JavaScript semantics without shipping an interpreter, and desktop applications that want a lighter, safer alternative to Electron-style runtime bundling (e.g. shipping compiler output as executable Wasm artifacts under a host like Tauri instead of bundling a full browser-plus-JS-engine).
 
-It also matters for security boundaries. In browsers, Node.js, and other JavaScript-capable hosts, compiling modules to Wasm introduces an isolation boundary that can limit how much third-party dependencies and user-provided code can affect the surrounding process. That is relevant for supply-chain defense, plugin systems, and multi-tenant execution.
+It also matters for security boundaries. In browsers, Node.js, and other JavaScript-capable hosts, compiling modules to Wasm introduces an isolation boundary that can limit how much third-party dependencies and user-provided code can affect the surrounding process — relevant for supply-chain defense, plugin systems, and multi-tenant execution.
 
-## Why This Architecture
-
-`js2wasm` is being built for environments where bundling a JavaScript engine is the wrong tradeoff:
-
-- edge and serverless runtimes
-- Wasm-first infrastructure platforms
-- plugin and extension systems
-- embedders that want JavaScript semantics without shipping an interpreter
-- desktop applications that want a lighter and safer alternative to Electron-style runtime bundling
-
-That includes practical combinations with hosts like Tauri, where compiler output can be shipped as executable Wasm artifacts instead of bundling a full browser-plus-JS-engine runtime into the application.
-
-The current public benchmark and conformance work exists to test an open question: whether direct AOT compilation can become a viable alternative to bundling a runtime for these workloads. That has not been settled yet — it is what the project is investigating.
-
-Many alternatives in adjacent spaces solve the problem by narrowing the language instead:
-
-- supporting only a constrained subset of TypeScript or JavaScript
-- introducing a new language or dialect that compiles to Wasm more easily
-
-`js2wasm` is aimed at a harder target: targeting mainstream JavaScript semantics through direct compilation rather than changing the language model to fit the compiler.
-
-Projects in this category usually take years to reach meaningful semantic coverage. A large part of the Loopdive thesis is that an AI-native compiler workflow can compress that timeline substantially without giving up on the harder target.
-
-Current Test262 conformance and benchmark numbers are tracked in one place and
-change frequently — see **[STATUS.md](./STATUS.md)** for the live figures, the
-[Playground](https://js2.loopdive.com/playground/), and the
-[Roadmap](./ROADMAP.md). The single auto-updated conformance figure (refreshed
-by CI on every merge) is for the JS-host path; everything else links to
-STATUS.md rather than duplicating numbers that go stale. Standalone
-(no-JS-host) pass-rate and benchmark figures are intentionally omitted from the
-README until the current standalone regression is fixed.
-
-<!-- AUTO:conformance-start -->
-**test262 conformance**: 32,236 / 43,106 (74.8 %)
-<!-- AUTO:conformance-end -->
-
-## Current Status
-
-`js2wasm` is an early-stage research prototype: an experimental compiler under
-active development, not a production-ready tool. It is being explored as a
-public, in-the-open project, and the conformance story, runtime boundary, and
-standalone path are all still hardening. What exists today:
-
-- a JS-hosted compilation path passing a substantial subset of Test262 (see
-  [STATUS.md](./STATUS.md) for the current figure)
-- a public browser playground
-- continuous conformance and benchmark reporting on every change
-- a standalone (no-JS-host) path that is in progress; its public numeric
-  baselines are paused here until the current regression is fixed
-
-Treat it as a tech demo to evaluate the approach, not as something to deploy.
+The open question the project is testing is whether direct AOT compilation can become a viable alternative to bundling a runtime for these workloads. That is not settled — it is what the conformance and benchmark work is investigating.
 
 ## The AOT JavaScript compilation landscape
 
-There are several established ways to get JavaScript running on WebAssembly.
-Each makes a different, reasonable trade-off, and most have years of engineering
-behind them. The point of this map is not to rank them — it is to locate the
-specific gap `js2wasm` is exploring. Described by architecture rather than by
-product:
+There are several established ways to get JavaScript running on WebAssembly. Each makes a different, reasonable trade-off, and most have years of engineering behind them. The point of this map is not to rank them — it is to locate the specific gap `js2wasm` is exploring, described by architecture rather than by product:
 
-- **Interpreter-based approach** — compile a JavaScript *interpreter* to Wasm
-  and run the user's program on top of it. Gets broad ECMAScript compatibility
-  more or less for free, because a real interpreter is doing the work. The cost:
-  every deployed module ships and initializes the interpreter, which adds size
-  and startup overhead and means application code runs interpreted rather than
-  compiled.
+- **Interpreter-based approach** — compile a JavaScript *interpreter* to Wasm and run the user's program on top of it. Gets broad ECMAScript compatibility more or less for free, because a real interpreter is doing the work. The cost: every deployed module ships and initializes the interpreter, which adds size and startup overhead and means application code runs interpreted rather than compiled.
 
-- **Engine-embedding approach** — compile a full production JavaScript *engine*
-  to Wasm (optionally specialized per-script, e.g. via partial evaluation).
-  Inherits mature, battle-tested engine semantics and very high compatibility.
-  The cost: the engine is large, and even when specialized the engine itself is
-  still part of what ships.
+- **Engine-embedding approach** — compile a full production JavaScript *engine* to Wasm (optionally specialized per-script, e.g. via partial evaluation). Inherits mature, battle-tested engine semantics and very high compatibility. The cost: the engine is large, and even when specialized the engine itself is still part of what ships.
 
-- **Typed JS/TS subset languages** — a statically typed language with
-  JavaScript-like or TypeScript-like syntax that compiles ahead of time to
-  compact Wasm. Output is small and fast precisely *because* it deliberately
-  does **not** accept full ECMAScript: dynamic semantics are excluded by design
-  and the type system is the contract. Excellent when you can write to that
-  language; not a path to running existing JavaScript unchanged.
+- **Typed JS/TS subset languages** — a statically typed language with JavaScript-like or TypeScript-like syntax that compiles ahead of time to compact Wasm. Output is small and fast precisely *because* it deliberately does **not** accept full ECMAScript: dynamic semantics are excluded by design and the type system is the contract. Excellent when you can write to that language; not a path to running existing JavaScript unchanged.
 
-- **Linear-memory AOT compilers** — compile JavaScript ahead of time to Wasm
-  using linear memory, implementing object model, allocation, and (typically) a
-  garbage collector inside the module. This shares the "compile, don't embed a
-  runtime" goal; the distinguishing axis from `js2wasm` is the lowering target
-  (linear memory and a self-managed heap vs. host-managed WasmGC) and, in
-  current projects, how much of full ECMAScript compatibility is an explicit
-  goal.
+- **Linear-memory AOT compilers** — compile JavaScript ahead of time to Wasm using linear memory, implementing object model, allocation, and (typically) a garbage collector inside the module. This shares the "compile, don't embed a runtime" goal; the distinguishing axis from `js2wasm` is the lowering target (linear memory and a self-managed heap vs. host-managed WasmGC) and, in current projects, how much of full ECMAScript compatibility is an explicit goal.
 
-**Where `js2wasm` sits.** Direct AOT compilation to **WasmGC** (objects,
-closures, and arrays lower to host-managed GC structs/arrays/references), with
-**full ECMAScript backwards compatibility as the explicit goal**, and **no
-JavaScript engine or interpreter bundled into the output**. Where the compiler
-can prove stable types and shapes it lowers them directly; where JavaScript
-stays dynamic it inserts guards, boxed representations, or host fallbacks.
+**Where `js2wasm` sits.** Direct AOT compilation to **WasmGC** (objects, closures, and arrays lower to host-managed GC structs/arrays/references), with **full ECMAScript backwards compatibility as the explicit goal**, and **no JavaScript engine or interpreter bundled into the output**. Where the compiler can prove stable types and shapes it lowers them directly; where JavaScript stays dynamic it inserts guards, boxed representations, or host fallbacks.
 
-The structural observation behind the project is that this *combination* of
-trade-offs is largely unoccupied: the typed-subset languages excluded full
-ECMAScript compatibility on purpose; the linear-memory AOT compilers do not
-currently center it; and the interpreter-based and engine-embedding approaches
-reach compatibility only by shipping a runtime (paying in size and startup).
-Targeting WasmGC + full backwards compatibility + no bundled runtime is a point
-that has not been seriously attempted. `js2wasm` is testing whether it is
-viable — that is an open question, not a settled result, and the honest answer
-today is "we don't know yet."
+The structural observation behind the project is that this *combination* of trade-offs is largely unoccupied: the typed-subset languages excluded full ECMAScript compatibility on purpose; the linear-memory AOT compilers do not currently center it; and the interpreter-based and engine-embedding approaches reach compatibility only by shipping a runtime. Targeting WasmGC + full backwards compatibility + no bundled runtime is a point that has not been seriously attempted. Projects in this category usually take years to reach meaningful semantic coverage; a large part of the Loopdive thesis is that an AI-native compiler workflow can compress that timeline substantially without giving up on the harder target. Whether it is viable is an open question, not a settled result.
+
+## Current status
+
+`js2wasm` is an early-stage research prototype under active development — a tech demo to evaluate the approach, not something to deploy. What exists today:
+
+- a JS-hosted compilation path passing a substantial subset of Test262 (the figure above)
+- a public browser [Playground](https://js2.loopdive.com/playground/)
+- continuous conformance and benchmark reporting on every change
+- a standalone (no-JS-host) path that is in progress; its public numeric baselines are paused here until the current regression is fixed
 
 ## Quick Start
 
@@ -277,11 +203,12 @@ output, see [docs/standalone-io.md](./docs/standalone-io.md).
 In a JS host, `js2wasm` passes a substantial subset of Test262 — enough that a
 large, useful slice of the language works — but there are real gaps, and you
 will hit them. The current pass rate lives in [STATUS.md](./STATUS.md) and the
-full [Test262 report](./benchmarks/results/report.html); this section is the
-qualitative high-level shape, and the report is the authoritative per-feature
-detail. Note that Test262 measures conformance to the ECMAScript *language*
-specification — it does not cover Web APIs, Node.js host behavior, or whether an
-arbitrary real-world npm package runs unchanged.
+full [Test262 report](https://loopdive.github.io/js2wasm/benchmarks/report.html);
+this section is the qualitative high-level shape, and the report is the
+authoritative per-feature detail. Note that Test262 measures conformance to the
+ECMAScript *language* specification — it does **not** cover Web APIs, Node.js
+host behavior, or whether an arbitrary real-world npm package runs unchanged. A
+high pass rate is necessary but not sufficient for "runs real JavaScript."
 
 **Solid** (broadly works):
 
@@ -299,7 +226,7 @@ arbitrary real-world npm package runs unchanged.
   some methods are missing or only handle the common overloads
 - `Map`, `Set`, `RegExp`, `JSON` — present but not fully spec-complete
 - standalone (no-JS-host) mode — actively in progress; standalone numeric
-  baselines are temporarily omitted here while the current regression is fixed
+  baselines are temporarily omitted while the current regression is fixed
 - getters/setters and other highly dynamic patterns — limited
 
 **Not yet** (intentionally unsupported or out of scope today):
@@ -309,30 +236,13 @@ arbitrary real-world npm package runs unchanged.
 - `SharedArrayBuffer` / threads, `WeakRef` / `FinalizationRegistry`, `Temporal`
 - dropping in an arbitrary npm package unchanged
 
-If a pattern you rely on does not work, check the [Test262 report](./benchmarks/results/report.html)
-or open an issue. This is an actively developed compiler with a growing
+If a pattern you rely on does not work, check the
+[Test262 report](https://loopdive.github.io/js2wasm/benchmarks/report.html) or
+open an issue. This is an actively developed compiler with a growing
 compatibility baseline and a clear infrastructure target — but it is a research
 prototype, not yet a "drop in any npm package" story.
 
 ## FAQ
-
-**Why not embed an existing interpreter or engine?**
-That is the interpreter-based / engine-embedding approach, and it is a perfectly
-reasonable way to get compatibility — but every deployed module then ships and
-initializes a runtime, which is exactly the size and startup cost `js2wasm` is
-trying to avoid. The bet here is that *compiling* the code, rather than shipping
-something to run it, is worth pursuing for size- and cold-start-sensitive
-deployments. Whether that bet holds across enough real code is the open
-question.
-
-**Isn't the Test262 conformance still incomplete?**
-Yes, and the live figure is in [STATUS.md](./STATUS.md) and the
-[Test262 report](./benchmarks/results/report.html) rather than rounded up here.
-Two caveats matter more than the number: Test262 measures the ECMAScript
-*language* spec, **not** Web APIs, host/Node.js behavior, or whether an arbitrary
-npm package runs unchanged; and standalone (no-JS-host) figures are omitted here
-until the current regression is fixed. A high pass rate is necessary but not
-sufficient for "runs real JavaScript."
 
 **Won't you eventually re-implement a JavaScript engine?**
 That is the real risk, treated as an empirical question, not a solved one. The
@@ -342,15 +252,9 @@ corners (`eval`, dynamic `Function`) would need a small interpreter fallback tha
 runs only on those paths — not a full engine in every module. Whether that
 fallback stays small, and how much real code avoids it, is what the prototype is
 testing. If compatibility turns out to require shipping an engine, that is a
-negative result worth knowing.
-
-**Why not extend an existing typed JS/TS subset language?**
-Typed JS/TS subset languages produce small, fast Wasm *because* they deliberately
-exclude full ECMAScript — dynamic semantics are dropped by design and the static
-type system is the contract. Extending one toward full backwards compatibility
-means re-adding the dynamics it was built to avoid. `js2wasm` instead targets
-existing JavaScript semantics directly, so existing code is the input rather than
-a rewrite into a new dialect.
+negative result worth knowing. (For why *not* to just embed an interpreter or
+engine outright, or extend a typed subset, see
+[the landscape map above](#the-aot-javascript-compilation-landscape).)
 
 **Why WasmGC rather than linear memory?**
 WasmGC gives the compiler host-managed structs, arrays, references, and function
@@ -363,37 +267,23 @@ is a per-target choice rather than a one-way bet. See the
 [ADRs](./docs/adr/README.md) for the reasoning.
 
 **What is the realistic timeline to production-ready?**
-Unknown. This is research-stage work, and a firm date would be a guess dressed up
-as a commitment. The viability of the core bet — full ECMAScript backwards
-compatibility, AOT-compiled to WasmGC, no bundled runtime — is still being
-established. The conformance and benchmark trends are public so progress can be
-judged from data. Until they say otherwise, treat it as something to evaluate,
-not to deploy.
+Unknown, and a firm date would be a guess dressed up as a commitment. The
+viability of the core bet — full ECMAScript backwards compatibility, AOT-compiled
+to WasmGC, no bundled runtime — is still being established. The conformance and
+benchmark trends are public so progress can be judged from data. Until they say
+otherwise, treat it as something to evaluate, not to deploy.
 
 ## The Methodology
 
-Loopdive develops `js2wasm` with an **Automated Agile Team** model. The goal is not novelty for its own sake. The goal is to compress the feedback loop between product intent, compiler implementation, and conformance verification.
+Loopdive develops `js2wasm` with an **Automated Agile Team** model. The goal is not novelty for its own sake — it is to compress the feedback loop between product intent, compiler implementation, and conformance verification. This is a bet that a tight, automated feedback loop lets a small team iterate on a hard compatibility target faster than a conventional one would; whether that bet pays off is part of what this prototype is testing.
 
 ### Operating Roles
 
 - **Product Owner**: defines goals with the human stakeholder, plans sprints, prioritizes work, and keeps the backlog aligned with the product surface.
-- **Technical Delivery Lead**: orchestrates sprint execution, coordinates task flow, manages merge discipline, and keeps implementation work moving through the pipeline.
+- **Technical Delivery Lead**: orchestrates sprint execution, coordinates task flow, manages merge discipline, and owns process retrospectives.
 - **Compiler Engineer (AI)**: implements ECMA-262 behavior, compiler pipeline changes, WasmGC lowering, and code generation details.
 - **QA Engineer (Automated)**: runs CI-based conformance and regression feedback loops, especially around Test262 trend tracking and behavioral drift.
 - **Architect (Human / Loopdive)**: owns system design, strategic constraints, runtime boundaries, and platform-facing product decisions.
-
-### Why It Matters
-
-This model is a bet that a tight, automated feedback loop lets a small team
-iterate on a hard compatibility target faster than a conventional one would.
-Whether that bet pays off is part of what this prototype is testing.
-
-The workflow is optimized for:
-
-- short implementation-to-validation cycles
-- continuous spec-aligned compiler iteration
-- rapid backlog triage from conformance data
-- keeping product direction, engineering execution, and QA tightly coupled
 
 ### Open Agentic Development
 
@@ -402,18 +292,22 @@ The workflow is not hidden behind a consultancy. It is **in this repository**:
 - `plan/issues/` — architect-written implementation specs for every open and completed work item
 - `plan/log/dependency-graph.md` — current priorities and what's blocked on what
 - `plan/issues/sprints/` — sprint plans and retrospectives
-- `.claude/agents/` — agent role definitions (product owner, architect, developer, scrum master)
+- `.claude/agents/` — agent role definitions (product owner, architect, tech lead, developer, senior developer)
 - `.claude/hooks/` — safety scripts (pre-commit gates, path checks)
 - `.claude/skills/` — reusable workflow protocols (test-and-merge, self-merge, harvest-errors)
 - `.claude/memory/` — accumulated feedback and learnings shared across sessions
 
-Anyone with a [Claude Code](https://docs.claude.com/claude-code) subscription can clone the repo, spawn a `developer` agent from `.claude/agents/developer.md`, point it at a `status: ready` issue under `plan/issues/sprints/`, and contribute a real fix through the same pipeline the core team uses. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the agentic contribution path.
+Anyone with a [Claude Code](https://docs.claude.com/claude-code) subscription can clone the repo, spawn a `developer` agent from `.claude/agents/developer.md`, point it at a `status: ready` issue under `plan/issues/`, and contribute a real fix through the same pipeline the core team uses. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the agentic contribution path.
 
-### How this is built
+For a long-form, technical account of the methodology — how the team is structured, how correctness is anchored across multiple test suites, where the human/agent decision boundaries are drawn, what has gone wrong, and how the methodology has evolved — see [`docs/methodology.md`](./docs/methodology.md). It is written for senior engineers who are skeptical but curious, cites concrete numbers, names the failure modes the team has hit, and synthesizes the raw planning material in `plan/` (the primary source if the two ever diverge).
 
-For a long-form, technical account of the agentic development methodology — how the team is structured, how correctness is anchored across multiple test suites, where the decision boundaries between human and agent are drawn, what has gone wrong, and how the methodology has evolved — see [`docs/methodology.md`](./docs/methodology.md).
+## Testing
 
-The document is intended for senior engineers who are skeptical but curious. It cites concrete numbers (sprint count, PR count, test262 pass rate), names the failure modes the team has hit, and discusses honest tradeoffs versus a traditional engineering team. It synthesizes the raw planning material in `plan/` for an external reader without contradicting it; if the two ever diverge, `plan/` is the primary source.
+`js2wasm` validates correctness through three complementary test layers:
+
+- **Unit & equivalence tests** — `npm test` (vitest). Targeted regression coverage and JS↔Wasm equivalence assertions. See `tests/equivalence/`.
+- **Test262 conformance** — `pnpm run test:262` runs the official ECMAScript test suite (~43k tests run) and reports per-edition / per-path pass rates. CI runs this sharded on every PR; the [report](https://loopdive.github.io/js2wasm/benchmarks/report.html) is regenerated on each merge.
+- **Differential testing vs V8** — `pnpm run test:diff` (#1203). For each program in `tests/differential/corpus/`, the harness runs Node-V8 directly and the compiled `.wasm` and compares stdout. test262 measures spec compliance; differential testing measures whether real programs actually produce the right answer. CI gates each PR on a delta against `benchmarks/results/diff-test-baseline.json` — no new mismatches allowed. Use `pnpm run test:diff:triage` to bucket mismatches by category for follow-up filing.
 
 ## Licensing
 
@@ -421,16 +315,6 @@ This repository is licensed under the **Apache License 2.0 with LLVM Exceptions*
 
 - Source code in this repository is available under **Apache-2.0 WITH LLVM-exception**
 - Community contributions are accepted under the contributor terms described in [CONTRIBUTING.md](./CONTRIBUTING.md)
-
-## Testing
-
-`js2wasm` validates correctness through three complementary test layers:
-
-- **Unit & equivalence tests** — `npm test` (vitest). Targeted regression coverage and JS↔Wasm equivalence assertions. See `tests/equivalence/`.
-- **Test262 conformance** — `pnpm run test:262` runs the official ECMAScript test suite (~48k tests) and reports per-edition / per-path pass rates. CI runs this sharded on every PR; the [report](./benchmarks/results/report.html) is regenerated on each merge.
-- **Differential testing vs V8** — `pnpm run test:diff` (#1203). For each program in `tests/differential/corpus/`, the harness runs Node-V8 directly and the compiled `.wasm` and compares stdout. test262 measures spec compliance; differential testing measures whether real programs actually produce the right answer. CI gates each PR on a delta against `benchmarks/results/diff-test-baseline.json` — no new mismatches allowed. Use `pnpm run test:diff:triage` to bucket mismatches by category for follow-up filing.
-
-## Development
 
 Additional contributor workflow details, including CLA terms, are in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -441,6 +325,7 @@ The foundational design choices behind `js2wasm` — why WasmGC instead of linea
 ## Further Reading
 
 - [Playground](https://js2.loopdive.com/playground/)
+- [Status & live numbers](./STATUS.md)
 - [Roadmap](./ROADMAP.md)
 - [Architecture Decisions](./docs/adr/README.md)
 - [Architecture Notes](./CLAUDE.md)

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ For a long-form, technical account of the methodology — how the team is struct
 `js2wasm` validates correctness through three complementary test layers:
 
 - **Unit & equivalence tests** — `npm test` (vitest). Targeted regression coverage and JS↔Wasm equivalence assertions. See `tests/equivalence/`.
-- **Test262 conformance** — `pnpm run test:262` runs the official ECMAScript test suite (~43k tests run) and reports per-edition / per-path pass rates. CI runs this sharded on every PR; the [report](https://loopdive.github.io/js2wasm/benchmarks/report.html) is regenerated on each merge.
+- **Test262 conformance** — `pnpm run test:262` runs the ECMAScript test suite (~48k tests: ~43k official plus ~5k staging/proposal tests) and reports per-edition / per-path pass rates. The headline conformance figure is scored against the 43,106 official tests (proposals excluded); CI runs this sharded on every PR and the [report](https://loopdive.github.io/js2wasm/benchmarks/report.html) is regenerated on each merge.
 - **Differential testing vs V8** — `pnpm run test:diff` (#1203). For each program in `tests/differential/corpus/`, the harness runs Node-V8 directly and the compiled `.wasm` and compares stdout. test262 measures spec compliance; differential testing measures whether real programs actually produce the right answer. CI gates each PR on a delta against `benchmarks/results/diff-test-baseline.json` — no new mismatches allowed. Use `pnpm run test:diff:triage` to bucket mismatches by category for follow-up filing.
 
 ## Licensing


### PR DESCRIPTION
## Held for human review

Outward-facing content — **do not auto-enqueue.** Remove the \`hold\` label to merge.

## What this does

A review pass over \`README.md\` for staleness, duplication, and weak material. **55 insertions / 170 deletions** (451 → 336 lines, ~460 words trimmed). No substantive content dropped — the cuts are thematic repetition; the factual sections (Quick Start, Compile modes, Running compiled output, coverage tables) are unchanged.

### Factual staleness fixed
- **Broken links** — \`./benchmarks/results/report.html\` is a *generated* artifact not committed to the repo (only \`.gitkeep\` + JSON live in \`benchmarks/results/\`), so all 4 relative links 404 on GitHub. Repointed to the hosted report (\`loopdive.github.io/js2wasm/benchmarks/report.html\`), matching how STATUS.md links it.
- **Stale role** — dropped the retired "scrum master" from the agent-roles list (no \`scrum-master.md\` exists; CLAUDE.md folded it into Tech Lead) and added the actual \`tech-lead\` / \`senior-developer\` roles.
- **Self-contradiction** — the intro claimed figures are "not duplicated in this README" while the AUTO conformance block right below duplicates the figure. Softened to "beyond the single auto-updated figure below."
- **Test-count drift** — reconciled "~48k tests" with the ~43k actually run (STATUS.md).

### De-duplication
- Collapsed three overlapping status blocks (top blockquote, Value Proposition intro, "Current Status") into one.
- Merged the overlapping **Value Proposition** / **Why This Architecture** sections (both listed target environments + the no-engine argument).
- Trimmed the **FAQ**, which re-treaded the four-way landscape taxonomy in full — kept the genuinely-new Q&As, cross-linked the landscape map.
- Reduced repeated hedging ("open question / we don't know yet", 6× → once per section) and the standalone-regression caveat (4× → 2×).

### Reviewer note
The changes are editorial on a public-facing doc — worth a human eye on tone and on the two link/role fixes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)