### PR TITLE
fix(pages): deploy dashboard issue.html so kanban card links resolve

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -263,6 +263,9 @@ copyFileIfExists(PUBLIC_REPORT_SHORT, join(PAGES_DIST, "benchmarks", "report.htm
 // them.
 if (hasDashboardBundle) {
   copyFile(join(DASHBOARD_DIR, "index.html"), join(PAGES_DIST, "dashboard", "index.html"));
+  // issue.html is the detail page every kanban card links to
+  // (issue.html?slug=…); without it, those links 404 on the deployed site.
+  copyFile(join(DASHBOARD_DIR, "issue.html"), join(PAGES_DIST, "dashboard", "issue.html"));
   copyDirectory(join(DASHBOARD_DIR, "data"), join(PAGES_DIST, "dashboard", "data"));
   copyFile(join(DASHBOARD_DIR, "data.js"), join(PAGES_DIST, "dashboard", "data.js"));
 }


### PR DESCRIPTION
## Summary
Roadmap kanban board issue links were broken — every card links to `issue.html?slug=<slug>`, but **`dashboard/issue.html` was never deployed**. `scripts/build-pages.js` copied the dashboard's `index.html`, `data/`, and `data.js` but omitted `issue.html`, so clicking any board card 404'd.

The issue `.md` files and `/plan/issues/index.json` (the bare-id→filename fallback) were already shipped — only the page that renders them was missing. One-line fix: add the `copyFile` for `issue.html`.

## Verified
- Live: `/plan/issues/<slug>.md` → 200 and `/plan/issues/index.json` → 200, but `/dashboard/issue.html` → **404** (the bug).
- After this: the same `issue.html` will deploy alongside `index.html`, resolving the card links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)