### PR TITLE
fix(#2726 b): delete of configurable built-in global returns true

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -11,20 +11,22 @@ es_edition: ES5
 language_feature: delete
 task_type: bug
 created: 2026-06-26
-updated: 2026-07-02
+updated: 2026-07-05
 ---
 
-> **Partial resolution (2026-06-29, del2726).** Group **(a)** is now DONE
-> (sloppy `delete <unresolvable identifier>` → `true`; +4 test262, 0
-> regressions — see `## Resolution — group (a)`). Groups **(c)** and **(d)**
-> were DONE earlier (+6 test262 incl. siblings, 0 regressions — see
-> `## Resolution — groups (c) + (d)`). Remaining open scope: **(b)** sloppy
-> global-object model (now 3/4 — `S11.4.1_A3.2_T1` implicit-global was carried
-> by the (a) oracle as a bonus; `S11.4.1_A3.1`, `S11.4.1_A3.3_T1`,
-> `11.4.1-4.a-8` remain) is STRUCTURAL (architect-spec first); **(e)**
-> mapped-arguments delete is DEFERRED to #1726; **(f)**/**(g)** re-route to
-> their owning feature issues (not delete bugs). This issue stays open
-> (`status: ready`) for (b) — route to architect before further dispatch.
+> **Partial resolution (2026-07-05, dev-2726).** Group **(a)** DONE (sloppy
+> `delete <unresolvable identifier>` → `true`; +4 test262). Groups **(c)** and
+> **(d)** DONE earlier (+6 test262). Group **(b)** is now **2/4**: the
+> configurable-built-in-global case **`11.4.1-4.a-8`** (`delete JSON === true`)
+> is DONE (+1 test262, 0 regressions — see `## Resolution — group (b) 11.4.1-4.a-8`),
+> alongside `S11.4.1_A3.2_T1` (carried earlier by the (a) oracle). The **2
+> remaining (b) tests are STRUCTURAL** and need the global-object model
+> (architect-spec first): `S11.4.1_A3.1` (`delete this.y === false` — top-level
+> `this` as the global object) and `S11.4.1_A3.3_T1` (`x = 1; delete x; x` →
+> ReferenceError — implicit-global creation + real deletion + unresolved read).
+> **(e)** mapped-arguments delete DEFERRED to #1726; **(f)**/**(g)** re-route to
+> their owning feature issues. This issue stays open (`status: ready`) for the 2
+> structural (b) tests — route to architect before further dispatch.
 
 # #2726 — delete residual (non-throw) semantics
 
@@ -142,6 +144,49 @@ Net **+4** test262. Flipped fail→pass: `S11.4.1_A2.2_T1`, `S11.4.1_A3.3_T6`,
 `x = 1; delete x === true`, carried by the same oracle). Regression test:
 `tests/issue-2726-sloppy-unresolvable-delete.test.ts`.
 
+## Resolution — group (b) `11.4.1-4.a-8` (2026-07-05, dev-2726)
+
+**Scope.** The configurable-built-in-global slice of group (b) —
+`11.4.1-4.a-8.js` (`delete JSON === true`). The other two (b) tests
+(`S11.4.1_A3.1`, `S11.4.1_A3.3_T1`) remain STRUCTURAL and out of this slice
+(see the top note / Residual).
+
+**Root cause.** After group (a) flipped only the *unresolvable* bare-identifier
+`delete` to `true`, every *resolvable* bare identifier still emitted `false`
+("variables are not deletable"). But §13.5.1.2 step 5 makes `delete` of a
+**configurable** property of the global object return `true`. Per ECMA-262 §19
+**every** built-in global (`JSON`/`Object`/`Math`/`parseInt`/…) is
+`{[[Configurable]]: true}`; only `NaN`/`Infinity`/`undefined` are
+non-configurable. So `delete JSON` must be `true`, not `false`.
+
+**Oracle.** Distinguish a configurable built-in global from a user-declared
+`var`/`function` (whose global binding is non-configurable ⇒ `false`) by TS
+**symbol provenance**: a built-in's `symbol.declarations` are ALL in ambient
+`.d.ts` lib files (`decl.getSourceFile().isDeclarationFile`), whereas a user
+binding is declared in the program's own source. Two guards make it precise:
+- name-exclude the three non-configurable intrinsics
+  `NON_CONFIGURABLE_GLOBALS = {NaN, Infinity, undefined}` (all three are
+  ambient-declared, so provenance alone wouldn't separate them);
+- require `decls.length > 0`, which keeps `undefined`/`globalThis`/`arguments`
+  (empty `declarations`) out of the `true` branch.
+Eval-body nodes never reach this branch (their symbol is `undefined`, already
+handled by the group-(a) arm). Front-end constant flip (`i32.const 1`), so the
+host and standalone lanes agree — **no new host import**.
+`src/codegen/typeof-delete.ts` (bare-identifier arm + `NON_CONFIGURABLE_GLOBALS`).
+
+### Test Results — group (b) 11.4.1-4.a-8 (host/gc lane, authoritative `runTest262File`)
+
+| cluster | baseline → fix |
+|---|---|
+| `language/expressions/delete` (full dir, 69 files) | 63 → **64** pass, **0 regressions** |
+| collateral (`delete <builtin>` elsewhere: `built-ins/undefined`, `staging/sm`) | no change (0 collateral) |
+
+Net **+1** test262. Flipped fail→pass: `11.4.1-4.a-8`. Guards verified unchanged:
+`delete NaN`/`delete undefined`/`delete <user var|func>` stay `false`
+(`11.4.1-4.a-4`, `built-ins/undefined/S15.1.1.3_A3_T2`, `11.4.1-4.a-5/-13/-16`).
+Regression test: `tests/issue-2726-configurable-global-delete.test.ts` (+ the
+corrected JSON/Object assertion in `tests/issue-2726-sloppy-unresolvable-delete.test.ts`).
+
 ## Resolution — groups (c) + (d) (2026-06-27, dev2)
 
 **Root cause (c).** `var o = {}` infers an empty struct type, so the receiver
@@ -194,16 +239,18 @@ flipped fail→pass: `11.4.1-4.a-1`, `11.4.1-4.a-2`, `11.4.1-4-a-4-s` (c),
 `Object/seal/object-seal-inherited-accessor-properties-are-ignored`.
 Regression test: `tests/issue-2726.test.ts`.
 
-## Residual (as of #2199, PO reconcile 2026-06-28; updated 2026-06-29 del2726)
+## Residual (as of #2199, PO reconcile 2026-06-28; updated 2026-07-05 dev-2726)
 
 NOT done — partially resolved. DONE so far: (a) sloppy unresolvable-identifier
 oracle (+4 test262, 0 regressions, 2026-06-29, **PR #2296**), (c) hasOwnProperty-
 after-configurable-delete + (d) non-configurable accessor delete (+6 test262, 0
-regressions, **PR #2177**). Remaining OPEN: **(b) sloppy global-object model** — now 3/4
-(`S11.4.1_A3.2_T1` implicit-global was carried by the (a) oracle; still failing:
-`S11.4.1_A3.1` `delete this.y === false`, `S11.4.1_A3.3_T1` `delete x; x` →
-ReferenceError, `11.4.1-4.a-8` `delete JSON === true`). (b) is STRUCTURAL (needs
-top-level-`this`-as-global-object + configurable-global tracking) and needs an
-architect spec first (NOT dev-claimable as-is). (e) mapped-arguments delete →
-#1726; (f)/(g) re-routed to owning feature issues. Stays `in-progress` for (b) —
-route to architect before further dispatch.
+regressions, **PR #2177**), (b-partial) configurable-built-in-global
+`11.4.1-4.a-8` `delete JSON === true` (+1 test262, 0 regressions, 2026-07-05,
+dev-2726). Remaining OPEN: **(b) sloppy global-object model** — now **2/4**
+(`S11.4.1_A3.2_T1` + `11.4.1-4.a-8` done; still failing: `S11.4.1_A3.1`
+`delete this.y === false`, `S11.4.1_A3.3_T1` `delete x; x` → ReferenceError).
+These 2 are STRUCTURAL (need top-level-`this`-as-global-object + implicit-global
+creation/real-deletion/unresolved-read) and need an architect spec first (NOT
+dev-claimable as-is). (e) mapped-arguments delete → #1726; (f)/(g) re-routed to
+owning feature issues. Stays `ready` for the 2 structural (b) tests — route to
+architect before further dispatch.

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -24,6 +24,12 @@ import { compileExpression, ensureAnyHelpers, isAnyValue } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
 import { emitDynamicWithDelete, findWithBinding, resolveWithBinding } from "./with-scope.js";
 
+// (#2726 group (b), partial) The only value properties of the global object with
+// `[[Configurable]]: false` (ECMA-262 §19.1). `delete <bareIdentifier>` of any of
+// these must evaluate to `false`; every OTHER built-in global property
+// (`JSON`/`Object`/`Math`/`parseInt`/…) is configurable ⇒ `delete` returns `true`.
+const NON_CONFIGURABLE_GLOBALS = new Set(["NaN", "Infinity", "undefined"]);
+
 /**
  * (#2703) Emit an unconditional `throw` of a string-valued exception, used for
  * the spec error cases of `delete` (§13.5.1.2): a super reference, a null/
@@ -298,15 +304,36 @@ export function compileDeleteExpression(
     // such nodes, so fall through to the existing `false` (the prior behaviour,
     // correct for the resolvable-outer-binding case `11.4.1-4.a-7.js`). Precise
     // eval-scope delete resolution is out of scope (eval-substrate lane).
-    if (
-      ctx.checker.getSymbolAtLocation(ident) === undefined &&
-      ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME
-    ) {
+    const identSym = ctx.checker.getSymbolAtLocation(ident);
+    const notEvalBody = ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME;
+    if (identSym === undefined && notEvalBody) {
       fctx.body.push({ op: "i32.const", value: 1 });
       return { kind: "i32" };
     }
-    // A resolvable binding (var/let/const/param/function/intrinsic global) is
-    // not deletable — return false.
+    // (#2726 group (b), partial) §13.5.1.2 step 5: a `delete IdentifierReference`
+    // that resolves to a CONFIGURABLE property of the global object evaluates to
+    // `true` in sloppy mode (the property is deletable). Per ECMA-262 §19 every
+    // built-in global (`JSON`/`Object`/`Math`/`parseInt`/…) is
+    // `{[[Configurable]]: true}` EXCEPT the three intrinsics `NaN`/`Infinity`/
+    // `undefined`. Distinguish a built-in global from a user-declared
+    // var/function (whose global binding is non-configurable ⇒ `false`) by
+    // symbol provenance: a built-in's declarations are ALL in ambient `.d.ts`
+    // lib files, whereas a user binding is declared in the program's own source.
+    //   - `undefined`/`globalThis`/`arguments` have NO declarations (empty
+    //     `declarations`), so the `decls.length > 0` guard keeps them out — and
+    //     `undefined` is name-excluded anyway.
+    //   - eval-body nodes never reach here (their symbol is `undefined`, handled
+    //     above), so no explicit eval guard is needed for this branch.
+    if (identSym !== undefined && notEvalBody && !NON_CONFIGURABLE_GLOBALS.has(ident.text)) {
+      const decls = identSym.declarations ?? [];
+      const allAmbient = decls.length > 0 && decls.every((d) => d.getSourceFile().isDeclarationFile);
+      if (allAmbient) {
+        fctx.body.push({ op: "i32.const", value: 1 });
+        return { kind: "i32" };
+      }
+    }
+    // A resolvable non-configurable binding (var/let/const/param/function, or a
+    // non-configurable intrinsic global) is not deletable — return false.
     fctx.body.push({ op: "i32.const", value: 0 });
     return { kind: "i32" };
   }

--- a/tests/issue-2726-configurable-global-delete.test.ts
+++ b/tests/issue-2726-configurable-global-delete.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2726 group (b), partial — sloppy-mode `delete <configurable built-in global>`
+// returns `true`.
+//
+// §13.5.1.2 (Runtime Semantics: Evaluation of `delete UnaryExpression`) step 5:
+// a `delete IdentifierReference` that resolves to a CONFIGURABLE property of the
+// global object evaluates to `true` in sloppy mode (the property is deletable).
+// Per ECMA-262 §19 every built-in global property (`JSON`/`Object`/`Math`/
+// `parseInt`/…) is `{[[Configurable]]: true}` EXCEPT the three intrinsics
+// `NaN`/`Infinity`/`undefined`.
+//
+// Previously the bare-identifier delete arm returned `false` for every resolvable
+// name, so `delete JSON` wrongly returned `false` (test262 11.4.1-4.a-8 failed).
+//
+// Oracle: a built-in global's TS-checker symbol has declarations that are ALL in
+// ambient `.d.ts` lib files, whereas a user var/function is declared in the
+// program's own source (non-configurable global binding ⇒ `false`). Combined
+// with the `NaN`/`Infinity`/`undefined` name-exclusion, this cleanly separates
+// configurable built-ins (→ true) from non-configurable intrinsics and user
+// bindings (→ false). This is a front-end constant flip (`i32.const 1`), so both
+// the host and standalone lanes agree with no new host import.
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: Record<string, (...a: unknown[]) => unknown>) => void }).setExports?.(
+    instance.exports as Record<string, (...a: unknown[]) => unknown>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { target: "standalone" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+describe("#2726 (b) sloppy delete of a configurable built-in global", () => {
+  // Mirrors test262 11.4.1-4.a-8: `delete JSON === true`.
+  const deleteJsonSrc = `
+    export function test(): number {
+      if ((delete JSON) !== true) return 10;
+      return 1;
+    }`;
+
+  it("delete JSON returns true (host)", async () => {
+    expect(await run(deleteJsonSrc)).toBe(1);
+  });
+
+  it("delete JSON returns true (standalone)", async () => {
+    expect(await runStandalone(deleteJsonSrc)).toBe(1);
+  });
+
+  it("delete of other configurable built-ins returns true", async () => {
+    const src = `
+      export function test(): number {
+        if ((delete Object) !== true) return 11;
+        if ((delete Math) !== true) return 12;
+        if ((delete parseInt) !== true) return 13;
+        if ((delete Array) !== true) return 14;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Guard: the three non-configurable intrinsics MUST stay false — the fix must
+  // not over-flip them (they are name-excluded / have no ambient declarations).
+  it("delete of NaN / Infinity / undefined stays false", async () => {
+    const src = `
+      export function test(): number {
+        if ((delete NaN) !== false) return 11;
+        if ((delete Infinity) !== false) return 12;
+        if ((delete undefined) !== false) return 13;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Guard: a user-declared var / function is a non-configurable global binding —
+  // its symbol has a non-ambient declaration, so `delete` stays false.
+  it("delete of a user-declared var / function stays false", async () => {
+    const src = `
+      export function test(): number {
+        var userVar = 1;
+        function userFunc() {}
+        if ((delete userVar) !== false) return 11;
+        if ((delete userFunc) !== false) return 12;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+});

--- a/tests/issue-2726-sloppy-unresolvable-delete.test.ts
+++ b/tests/issue-2726-sloppy-unresolvable-delete.test.ts
@@ -18,10 +18,13 @@ import { buildImports } from "../src/runtime.js";
 //
 // Root-cause / oracle: an unresolvable identifier yields NO symbol from the TS
 // checker (`getSymbolAtLocation === undefined`). The non-configurable intrinsic
-// globals that MUST stay `false` (`undefined`, `arguments`, `globalThis`) and
-// all lib-declared globals (`NaN`, `Infinity`, `JSON`, …) DO return a symbol, so
-// they correctly remain `false`. Symbol-presence — not the weaker
-// `!valueDeclaration` heuristic — is what keeps those intrinsics out of `true`.
+// globals that MUST stay `false` (`undefined`, `arguments`, `globalThis`,
+// `NaN`, `Infinity`) DO return a symbol (or are name-excluded), so they correctly
+// remain `false`. Symbol-presence — not the weaker `!valueDeclaration` heuristic
+// — is what keeps those intrinsics out of `true`. (#2726 (b) later refined this:
+// the OTHER lib-declared globals — `JSON`/`Object`/`Math`/… — are CONFIGURABLE
+// global properties, so `delete` of them returns `true`; see the dedicated
+// group-(b) test file.)
 
 async function run(source: string): Promise<unknown> {
   const result = await compile(source);
@@ -97,11 +100,15 @@ describe("#2726 (a) sloppy delete of unresolvable identifier", () => {
     expect(await run(src)).toBe(1);
   });
 
-  it("delete of a lib-declared global (JSON / Object) stays false", async () => {
+  // (#2726 (b) refinement) JSON / Object are CONFIGURABLE global properties
+  // (ECMA-262 §19) ⇒ `delete` returns true (test262 11.4.1-4.a-8). This
+  // corrects the group-(a) conservative placeholder that kept them false;
+  // only NaN / Infinity / undefined are non-configurable (guarded above).
+  it("delete of a configurable built-in global (JSON / Object) returns true", async () => {
     const src = `
       export function test(): number {
-        if ((delete JSON) !== false) return 11;
-        if ((delete Object) !== false) return 12;
+        if ((delete JSON) !== true) return 11;
+        if ((delete Object) !== true) return 12;
         return 1;
       }`;
     expect(await run(src)).toBe(1);


### PR DESCRIPTION
## Summary

Group **(b)** partial for #2726 — the configurable-built-in-global slice
`11.4.1-4.a-8` (`delete JSON === true`).

§13.5.1.2 step 5: a `delete <bareIdentifier>` that resolves to a **configurable**
property of the global object evaluates to `true` in sloppy mode. Per ECMA-262
§19 every built-in global (`JSON`/`Object`/`Math`/`parseInt`/…) is
`{[[Configurable]]: true}` EXCEPT the three intrinsics `NaN`/`Infinity`/
`undefined`. The bare-identifier `delete` arm previously emitted `false` for
every resolvable name, so `delete JSON` wrongly returned `false`.

## Oracle

Distinguish a configurable built-in (symbol declarations ALL in ambient `.d.ts`
lib files) from a user-declared var/function (non-ambient decl ⇒ non-configurable
global binding ⇒ `false`). Two guards keep it precise:
- name-exclude `NON_CONFIGURABLE_GLOBALS = {NaN, Infinity, undefined}`;
- require `decls.length > 0` (keeps `undefined`/`globalThis`/`arguments`, which
  have empty `declarations`, out of the `true` branch).

Front-end constant flip (`i32.const 1`) — host and standalone lanes agree, **no
new host import**.

## Test results (host/gc lane, `runTest262File`)

- `language/expressions/delete` full dir (69 files): **63 → 64 pass, 0 regressions**
- Flipped fail→pass: `11.4.1-4.a-8`
- Guards verified unchanged: `delete NaN`/`delete undefined`/`delete <user var|func>`
  stay `false` (`11.4.1-4.a-4`, `built-ins/undefined/S15.1.1.3_A3_T2`,
  `11.4.1-4.a-5/-13/-16`); `staging/sm` `delete Function`/`delete eval` are
  skipped (result discarded, no assertion).

## Scope note

The **2 remaining group-(b) tests** (`S11.4.1_A3.1` `delete this.y === false`,
`S11.4.1_A3.3_T1` `x = 1; delete x; x` → ReferenceError) are **structural** —
they need the top-level-`this`-as-global-object model + implicit-global
creation/real-deletion. Issue stays `status: ready` for those; route to
architect. (e) → #1726; (f)/(g) re-routed.

## Tests

- `tests/issue-2726-configurable-global-delete.test.ts` (new, host + standalone)
- corrected the now-stale JSON/Object assertion in
  `tests/issue-2726-sloppy-unresolvable-delete.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)