### PR TITLE
feat(#2949 S5.3): dynamic numeric-abstract relational lowering (byte-inert)

### DIFF
--- a/plan/issues/2949-ir-dynamic-value-representation.md
+++ b/plan/issues/2949-ir-dynamic-value-representation.md
@@ -2,7 +2,7 @@
 id: 2949
 title: "IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)"
 status: in-progress
-assignee: ttraenkler/opus-s5-2
+assignee: ttraenkler/opus-s5-3
 sprint: current
 created: 2026-07-02
 updated: 2026-07-05
@@ -1472,3 +1472,133 @@ dyn-string ToNumber = NaN gives all-false, spec-correct for `"a" > 0` but WRONG
 for `"b" > "a"`). Same mechanism-slice discipline: byte-inert, prove-emit-identity
 39/39, hand-built-IR unit tests over gc + host. The claim-flip stays back-loaded
 onto S5.P (§4 anti-vacuity probe).
+
+## Implementation Notes — S5.3 (opus-s5-3, 2026-07-05, branch `issue-2949-s5-3-relational`)
+
+S5.3 ships **dynamic-value numeric-abstract relational** — `dyn </<=/>/>= x`
+(either or both operands boxed-any carriers) → `i32`, via a new single-operand
+`dyn.to_number{value}` node (ToNumber → f64) feeding the EXISTING `f64.lt`/`gt`/
+`le`/`ge` compare path. Mechanism slice, byte-inert by construction (the move-only
+selector gate still rejects a dynamic-relational body, so from-ast never builds
+`dyn.to_number` in a CLAIMED function). **prove-emit-identity: 39/39 IDENTICAL**
+vs the branch base (`e66b066d4`). Decisions and the WHY:
+
+1. **A single-operand `IrInstrDynToNumber` node → f64 (the `dyn.truthy` shape,
+   NOT the two-operand `dyn.eq` shape).** Unlike equality — where the WHOLE
+   comparison routes through one helper (`__any_strict_eq`/`__host_eq`) — the
+   relational mechanism per the S5 plan is `ToNumber(dyn) → f64` + the existing
+   numeric compare. So the node is a ToNumber PRIMITIVE (like `dyn.truthy` is a
+   ToBoolean primitive), and from-ast emits `emitBinary("f64.lt", …)` on the
+   converted operands. Same `never`-exhaustive blast radius as S5.1's
+   `dyn.truthy`: nodes.ts (union + the two no-nested-buffer switch groups +
+   `directUses`), lower.ts (case + `collectIrUses`), verify.ts (operand-dynamic
+   rule + `collectUses`), effects.ts (pure), integration `isDynamicOp`,
+   monomorphize + inline-small single-operand rename/uses — tsc's exhaustiveness
+   flagged each; `dyn.to_number` joins the single-operand `[instr.value]` group.
+
+2. **THE LOAD-BEARING FINDING — legacy `any < any` is a FULL Abstract Relational
+   Comparison (§7.2.11), mode-split THREE ways, NONE of them a bare ToNumber.**
+   The task asked, mirroring S5.2's `__host_eq` lesson, whether legacy host
+   `any < any` routes through a `__host_*` JS-relational helper. It DOES — and
+   there are three distinct legacy lowerings (verified against the REAL compiler,
+   `compileToWat` of `function f(a:any,b:any){return a<b?1:0}` in each mode):
+   - **host (default)**: `a < b` → `call __host_compare(a, b)` then compare the
+     result to `-1` — a JS-relational IMPORT (full ARC incl. string×string
+     lexicographic). This is the exact analog of S5.2's `__host_eq`.
+   - **fast (JS-host, WasmGC rep)**: relational FALLS THROUGH
+     `compileAnyBinaryDispatch` (only `+`/equality dispatch through it —
+     `binary-ops.ts:1091-1096`) to "compile with numeric hint" → `__unbox_number`
+     (`Number(v)`) per operand + numeric compare. String-correct via `Number()`.
+   - **standalone**: a pure-Wasm runtime branch — `if both-are-strings →
+     lexicographic string compare, else → __any_to_f64 each + f64.lt` (the full
+     ARC in Wasm; the else arm reads the box's f64 slot for a string → 0, a known
+     legacy mixed-string/number gap).
+   The `__any_lt`/`__any_gt`/`__any_le`/`__any_ge` helper family EXISTS
+   (`any-helpers.ts:2466`, `__any_to_f64` both operands + `f64.op`) but is NOT the
+   path `a < b` on two `any` operands actually takes (relational falls through
+   dispatch). So there is no single "legacy relational helper" for me to route the
+   whole comparison through — the S5-plan design (ToNumber(dyn) + f64 compare) is
+   the numeric ARM of this ARC, deliberately implementing ONLY the numeric case.
+
+3. **Per-backend ToNumber routing (D4-faithful, byte-parity with each backend's
+   ToNumber engine):**
+   - **gc/fast/standalone** → `__any_to_f64` — THE canonical boxed-any→f64 helper
+     legacy's `__any_lt` family + the arithmetic helpers use (null→0, undefined→
+     NaN, boolean→0/1, number→value). Chosen DIRECTLY, deviating from the plan's
+     "route through `coercion-engine.emitToNumber`", because that function's
+     `$AnyValue` arm goes through `coerceType(…,"number")`, which allocates a
+     temp local via `allocTempLocal` (verified — it crashes on a body-only shim);
+     the handle's pure `readonly Instr[]` contract cannot supply the function
+     locals. `__any_to_f64` is the single-call, no-locals, D4-canonical
+     equivalent (registered by `ensureAnyHelpers`, resolved by NAME at emit time).
+   - **host** → `coercion-engine.emitToNumber` on the externref carrier →
+     `__unbox_number` (`Number(v)`, §7.1.4). The externref arm is a clean single
+     call with NO local allocation (verified), so the body-only `FunctionContext`
+     shim is sound (same pattern as the gc `emitBox`). `addUnionImports` (run
+     up-front in `preregisterDynamicSupport` — `isDynamicOp` gained a
+     `dyn.to_number` arm) registers `__unbox_number`, so the internal
+     `addUnionImports` is an idempotent no-op — no mid-emission funcIdx shift.
+
+4. **String relational is DEFERRED (scope), and the numeric-literal restriction
+   makes the numeric arm spec-complete.** A boxed-string operand ToNumbers (host
+   `Number("5")=5`; gc `__any_to_f64` reads the box's f64 slot → 0, matching
+   legacy `__any_lt`). ARC only takes the both-strings lexicographic branch when
+   BOTH operands are strings; against a NUMBER, ARC does ToNumber both — so
+   `dyn <rel> numericLiteral` is spec-correct under the numeric arm even when
+   `dyn` is a string (host: `Number(dyn)`; the gc string→0 gap matches legacy
+   `__any_lt` and is the documented deferred imperfection). Hence the S5.P scan
+   admits a dynamic relational operand ONLY against a numeric literal/concrete.
+   The `from-ast` `relOperandToF64` helper enforces the mechanism side: a dynamic
+   operand ToNumbers via `dyn.to_number`; a concrete `f64` is used as-is; ANY
+   other concrete kind (i32/ref/string) returns `null` → clean demote (no
+   i32/string→number coercion added here; numeric literals lower to `f64` under
+   the f64 operand hint, covering `dyn > 0` / `dyn <= 10`).
+
+5. **NaN is correct in both modes** — the numeric arm is a plain `f64.{lt,gt,le,
+   ge}`, and every relational compare with a NaN operand is `false` (§7.2.11).
+   `undefined` ToNumbers to NaN → all relational false; `null` → 0; boolean →
+   0/1. Verified at runtime in BOTH strategies (no S5.1-style inherited quirk —
+   relational never touches `__any_unbox_bool`).
+
+6. **Verifier hard backstop**: `dyn.to_number` operand must be `dynamic`
+   (verify.ts structural rule + a construction-time guard in `emitDynToNumber`).
+   A concrete numeric operand already converts to f64 inline, so routing one
+   through the carrier ToNumber helper is a producer bug — rejected loudly at
+   build and verify. Result is f64, consumed by the numeric compare.
+
+## Test Results — S5.3 (2026-07-05, opus-s5-3)
+
+- `tests/issue-2949-s5-3-relational.test.ts` — **7/7 pass**: node shape + f64
+  result + verifier-clean; construction-time non-dynamic-operand guard; verifier
+  rejection of a hand-crafted concrete-operand `dyn.to_number` (defense in
+  depth); handle→helper D4 routing (gc single `__any_to_f64`, host single
+  `__unbox_number`); and RUNTIME execution against the PRODUCTION
+  `makeDynamicLowering` over a real `CodegenContext` in BOTH strategies —
+  gc ($AnyValue): dyn(number) vs concrete + dyn<dyn for `</<=/>/>=`, fractional
+  f64 compare (not i32 truncation), boolean partition (`true`→1/`false`→0),
+  `NaN → false`; host (externref): number/bool/null(→0)/undefined(→NaN→false)/
+  string(`Number()`, spec-correct against a numeric operand) across
+  `</>/>=`, plus dyn<dyn.
+- **Byte-inertness PROVEN**: `prove-emit-identity.mjs` baseline captured on a
+  clean worktree at the branch base (`e66b066d4`), `check` on this branch →
+  **IDENTICAL, all 39 (file,target) hashes** across gc/standalone/wasi.
+- `pnpm run check:ir-fallbacks` — OK, zero delta in every bucket, no post-claim
+  demotions (no selector/producer change, as designed).
+- Adjacent #2949 suites: S5.0 8/8, S5.1 7/7, S5.2 7/7, slice 1 19/19, slice 2
+  22/22, slice 3 16/16 — **86/86 combined with S5.3**.
+- `npx tsc --noEmit` clean; prettier clean; biome introduces ZERO new errors
+  (the per-file counts are byte-identical at the base `e66b066d4` — pre-existing
+  IR-codebase biome-vs-prettier style deltas; prettier is the CI quality gate).
+
+**S5.4 (dynamic member read: `dyn[i]` / `dyn.p`) is ready next — but it is the
+HEAVIEST sub-slice and substrate-adjacent** (per §S5.4). Unlike S5.1–S5.3, the
+`$Object` dynamic-reader has NO clean single-helper carrier op today (memory
+`project_standalone_any_string_value_read_substrate` — the reader drops
+native-string values). The next agent MUST first identify whether a legacy
+any-member reader in `property-access.ts` / `object-ops.ts` is cleanly reusable
+(route through it, D4) or whether S5.4 is BLOCKED on a substrate helper — in
+which case file the dependency and do NOT hand-roll (per the §S5.4 "BLOCKED on a
+substrate helper" clause). If S5.4 blocks, S5.P proceeds WITHOUT property-access
+and its §4 reachability probe re-runs on the reduced form set. The S5.1–S5.3
+mechanism substrate (truthiness / equality / relational ToNumber) is complete and
+consumed by both S5.P and the banked #2963/#2984/#3015 adoption slices regardless.

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -270,6 +270,28 @@ export interface IrDynamicLowering {
    */
   emitToBoolean(): readonly Instr[];
   /**
+   * Carrier on the stack → f64: `ToNumber(carrier)` (§7.1.4, #2949 S5.3), the
+   * single-operand ToNumber that the numeric-abstract relational lowering
+   * (`< > <= >=`) applies to a dynamic operand before the existing `f64.lt`/
+   * `gt`/`le`/`ge` compare.
+   *   - gc/fast/standalone: `__any_to_f64` — the SAME boxed-any→f64 helper
+   *     legacy's `__any_lt`/`__any_gt`/… + the arithmetic helpers use (null→0,
+   *     undefined→NaN, boolean→0/1, number→value). It is chosen directly (not
+   *     via `coercion-engine.emitToNumber`, whose `$AnyValue` arm routes through
+   *     `coerceType` and REQUIRES temp-local allocation the handle's pure
+   *     `Instr[]` contract cannot provide).
+   *   - host: `coercion-engine.emitToNumber` on the externref carrier →
+   *     `__unbox_number` (`Number(v)`) — the canonical host ToNumber, single
+   *     call, no locals.
+   * SCOPE — numeric-abstract only; string×string lexicographic relational is
+   * DEFERRED (legacy `any < any` is a full ARC, mode-split three ways: host
+   * `__host_compare`, standalone runtime both-strings-else-numeric branch, fast
+   * numeric-hint). Spec-correct only when the OTHER relational operand is a
+   * number — the S5.P producer admits a dynamic relational operand ONLY against
+   * a numeric literal/concrete.
+   */
+  emitToNumber(): readonly Instr[];
+  /**
    * One carrier on the stack → the operand shape this backend's equality
    * helper takes (#2949 S5.2). Emitted once per operand, immediately after that
    * operand is pushed:

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -440,6 +440,34 @@ export class IrFunctionBuilder {
   }
 
   /**
+   * Emit `dyn.to_number{value}` — `ToNumber(value)` (§7.1.4) on a boxed-any
+   * carrier. Result is `f64`, feeding the existing `f64.lt`/`gt`/`le`/`ge`
+   * numeric-abstract relational compare path (#2949 S5.3).
+   *
+   * The operand MUST be `dynamic` — this is the carrier ToNumber, not a
+   * concrete-scalar conversion (a concrete numeric operand converts to f64
+   * inline). Feeding a concrete value here is a producer bug, rejected at
+   * construction time rather than mis-lowering the carrier. Lowering routes
+   * through `IrDynamicLowering.emitToNumber` — `__any_to_f64` (gc, the SAME
+   * boxed-any→f64 helper legacy's `__any_lt` family uses) / `__unbox_number`
+   * (host, `Number(v)`) — one ToNumber engine (D4). SCOPE: numeric-abstract
+   * only; string×string lexicographic relational is DEFERRED (see the
+   * `IrInstrDynToNumber` node doc).
+   */
+  emitDynToNumber(value: IrValueId): IrValueId {
+    if (this.typeOf(value).kind !== "dynamic") {
+      throw new Error(
+        `IrFunctionBuilder: emitDynToNumber operand ${value} is not dynamic — carrier ToNumber applies only to the boxed-any carrier (#2949 S5.3) (func ${this.name})`,
+      );
+    }
+    const resultType = irVal({ kind: "f64" });
+    const result = this.allocator.fresh();
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "dyn.to_number", value, result, resultType });
+    return result;
+  }
+
+  /**
    * Emit `dyn.eq{lhs, rhs, loose, negate}` — strict/loose equality between two
    * boxed-any carriers, result `i32` (0/1) (#2949 S5.2).
    *

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -120,6 +120,7 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
     case "unbox":
     case "tag.test":
     case "dyn.truthy": // #2949 S5.1 — ToBoolean read on the carrier: pure (no heap/control effect)
+    case "dyn.to_number": // #2949 S5.3 — ToNumber read on the carrier: pure (no heap/control effect)
     case "dyn.eq": // #2949 S5.2 — equality read over two carriers: pure (no heap/control effect)
     case "coerce.to_externref":
     case "string.concat":

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -5339,6 +5339,17 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
   if (lt.kind === "dynamic" || rt.kind === "dynamic") {
     const dynEq = tryLowerDynamicEq(expr, op, lhs, rhs, lt, rt, cx);
     if (dynEq !== null) return dynEq;
+    // #2949 S5.3 — dynamic relational: `<`/`>`/`<=`/`>=` where either operand
+    // is a boxed-any carrier. Each dynamic operand is ToNumber'd to f64 via
+    // `dyn.to_number` (routing to the CANONICAL `__any_to_f64` gc /
+    // `__unbox_number` host — D4), then the existing `f64.lt`/`gt`/`le`/`ge`
+    // compare runs. SCOPE — numeric-abstract only: a non-f64 concrete operand
+    // (and hence the string×string lexicographic case) demotes cleanly. Same
+    // byte-inertness as the eq arm — reachable only once the S5.P scan admits
+    // dynamic-relational bodies (restricted to a numeric-literal counter-
+    // operand, where ARC never takes the both-strings branch).
+    const dynRel = tryLowerDynamicRelational(op, lhs, rhs, lt, rt, cx);
+    if (dynRel !== null) return dynRel;
   }
 
   // String operand path (slice 1, #1169a) — `+`, `===`, `!==`, `==`, `!=`.
@@ -5913,6 +5924,65 @@ function boxConcreteToDynamic(v: IrValueId, t: IrType, operand: ts.Expression, c
   // A bare non-literal `i32` is number-vs-boolean-ambiguous with no cheap proof
   // here — demote rather than risk a wrong tag. S5.P can refine with the
   // checker (isProvablyBoolean) when it opens the scan.
+  return null;
+}
+
+/**
+ * #2949 S5.3 — lower `dyn < x` / `dyn > x` / `dyn <= x` / `dyn >= x` (either or
+ * both operands dynamic) as a NUMERIC-ABSTRACT relational compare: each dynamic
+ * operand is ToNumber'd to `f64` via `dyn.to_number`, then the existing
+ * `f64.lt`/`gt`/`le`/`ge` compare (result `i32`) runs. Returns `null` (clean
+ * demote) for a non-relational operator, or for a concrete operand this slice
+ * cannot feed the f64 compare (see {@link relOperandToF64}) — including the
+ * string×string lexicographic case, which is DEFERRED (a boxed-string operand
+ * ToNumbers to NaN in gc / `Number(s)` in host: spec-correct ONLY against a
+ * numeric counter-operand, which is why the S5.P scan restricts admission to a
+ * numeric-literal counter-operand).
+ */
+function tryLowerDynamicRelational(
+  op: ts.SyntaxKind,
+  lhs: IrValueId,
+  rhs: IrValueId,
+  lt: IrType,
+  rt: IrType,
+  cx: LowerCtx,
+): IrValueId | null {
+  let binop: IrBinop;
+  switch (op) {
+    case ts.SyntaxKind.LessThanToken:
+      binop = "f64.lt";
+      break;
+    case ts.SyntaxKind.LessThanEqualsToken:
+      binop = "f64.le";
+      break;
+    case ts.SyntaxKind.GreaterThanToken:
+      binop = "f64.gt";
+      break;
+    case ts.SyntaxKind.GreaterThanEqualsToken:
+      binop = "f64.ge";
+      break;
+    default:
+      return null;
+  }
+  const lf = relOperandToF64(lhs, lt, cx);
+  if (lf === null) return null;
+  const rf = relOperandToF64(rhs, rt, cx);
+  if (rf === null) return null;
+  return cx.builder.emitBinary(binop, lf, rf, irVal({ kind: "i32" }));
+}
+
+/**
+ * #2949 S5.3 — coerce ONE relational operand to `f64` for the numeric-abstract
+ * compare: a dynamic carrier ToNumbers via `dyn.to_number`; a concrete `f64` is
+ * used as-is. Any other concrete kind (i32/ref/string) returns `null` so the
+ * caller demotes cleanly — this slice only converts the dynamic side, and adds
+ * no i32/string→number coercion (numeric literals lower to `f64` under the f64
+ * hint the operands were lowered with, so `dyn > 0` / `dyn <= 10` are covered).
+ */
+function relOperandToF64(v: IrValueId, t: IrType, cx: LowerCtx): IrValueId | null {
+  if (t.kind === "dynamic") return cx.builder.emitDynToNumber(v);
+  const tv = asVal(t);
+  if (tv && tv.kind === "f64") return v;
   return null;
 }
 

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -36,7 +36,10 @@ import {
 } from "../codegen/index.js";
 import { boxToAny } from "../codegen/value-tags.js"; // (#2949 slice 3) THE canonical boxing entry point (D4)
 // (#2949 S5.1) THE canonical ToBoolean engine — one truthiness path for legacy and IR (D4).
-import { emitToBoolean as emitCoercionToBoolean } from "../codegen/coercion-engine.js";
+import {
+  emitToBoolean as emitCoercionToBoolean,
+  emitToNumber as emitCoercionToNumber,
+} from "../codegen/coercion-engine.js";
 import { JsTag, jsTagUnboxKind } from "../codegen/js-tag.js";
 import { ensureVecElemSet, VEC_ELEM_SET_PREFIX } from "../codegen/vec-elem-set.js"; // (#2856 C2) on-demand element-store helper
 import { classMemberFuncKey } from "../codegen/class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
@@ -1696,6 +1699,10 @@ function isDynamicOp(instr: IrInstr): boolean {
   // #2949 S5.1 — dyn.truthy always consumes the boxed-any carrier, so its
   // presence requires the dynamic backing (ensureAnyHelpers / addUnionImports).
   if (instr.kind === "dyn.truthy") return true;
+  // #2949 S5.3 — dyn.to_number consumes the carrier and calls the canonical
+  // ToNumber helper (`__any_to_f64` gc / `__unbox_number` host), so it requires
+  // the dynamic backing pre-registered too.
+  if (instr.kind === "dyn.to_number") return true;
   // #2949 S5.2 — dyn.eq consumes two carriers and calls the canonical equality
   // helpers, so it too requires the dynamic backing pre-registered.
   if (instr.kind === "dyn.eq") return true;
@@ -1923,6 +1930,19 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
         // mid-emission funcIdx shift.
         return emitCoercionToBoolean(ctx, { kind: "ref_null", typeIdx: anyTypeIdx }, []);
       },
+      emitToNumber(): readonly Instr[] {
+        // #2949 S5.3 — ToNumber(carrier) for the gc `$AnyValue` carrier via
+        // `__any_to_f64`: THE canonical boxed-any→f64 helper legacy's
+        // `__any_lt`/`__any_gt`/… + arithmetic helpers use (null→0, undefined→
+        // NaN, boolean→0/1, number→value) — one ToNumber engine (D4). Chosen
+        // directly rather than through `coercion-engine.emitToNumber`, whose
+        // `$AnyValue` arm routes to `coerceType(…,"number")` and allocates a
+        // temp local (via `allocTempLocal`), which the handle's pure `Instr[]`
+        // contract cannot supply. `ensureAnyHelpers` (run up-front in
+        // `preregisterDynamicSupport`) registers `__any_to_f64`, so `callHelper`
+        // resolves it by name with no mid-emission funcIdx shift.
+        return [callHelper("__any_to_f64")];
+      },
       emitEqOperand(): readonly Instr[] {
         // #2949 S5.2 — the gc carrier IS `(ref null $AnyValue)`, already the
         // `__any_strict_eq`/`__any_eq` parameter shape. No marshalling.
@@ -2047,6 +2067,20 @@ export function makeDynamicLowering(ctx: CodegenContext): IrDynamicLowering | nu
       // internal `addUnionImports` / `ensureLateImport` here find the import
       // by name and add nothing — no import shift mid-emission.
       return emitCoercionToBoolean(ctx, { kind: "externref" }, []);
+    },
+    emitToNumber(): readonly Instr[] {
+      // #2949 S5.3 — ToNumber(externref carrier) via THE canonical
+      // `coercion-engine.emitToNumber` (D4): for the externref carrier it emits
+      // a single `__unbox_number` (`Number(v)`, §7.1.4 — string→StringToNumber,
+      // null→0, undefined→NaN, boolean→0/1). No temp-local allocation for the
+      // externref arm (unlike the gc `$AnyValue` arm), so the body-only
+      // `FunctionContext` shim is sound (same pattern as the gc `emitBox`).
+      // `addUnionImports` already ran in `preregisterDynamicSupport` (which
+      // registers `__unbox_number`), so the internal `addUnionImports` here
+      // finds it by name and adds nothing — no import shift mid-emission.
+      const shim = { body: [] as Instr[] } as unknown as FunctionContext;
+      emitCoercionToNumber(ctx, shim, { kind: "externref" });
+      return shim.body;
     },
     emitEqOperand(): readonly Instr[] {
       // #2949 S5.2 — the host carrier is `externref`, which is EXACTLY the

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1405,6 +1405,29 @@ export function lowerIrFunctionBody<S>(
         for (const op of dyn.emitToBoolean()) emitter.pushRaw(out, op);
         return;
       }
+      case "dyn.to_number": {
+        // #2949 S5.3 — ToNumber on a boxed-any carrier → f64 (the numeric-
+        // abstract relational operand conversion). The operand MUST be dynamic
+        // (verifier enforces); the op sequence comes from the
+        // `IrDynamicLowering` handle, which routes to the CANONICAL per-backend
+        // ToNumber (`__any_to_f64` gc / `__unbox_number` host) — one ToNumber
+        // engine (June-audit D4). String×string lexicographic relational is
+        // DEFERRED (see the `dyn.to_number` node doc); this arm implements only
+        // the numeric path.
+        const valueIrType = typeOf(instr.value);
+        if (valueIrType.kind !== "dynamic") {
+          throw new Error(`ir/lower: dyn.to_number operand must be dynamic, got ${valueIrType.kind} (${func.name})`);
+        }
+        const dyn = resolver.resolveDynamicLowering?.();
+        if (!dyn) {
+          throw new Error(
+            `ir/lower: resolver cannot lower dyn.to_number (resolveDynamicLowering missing/null) (${func.name})`,
+          );
+        }
+        emitValue(instr.value, out);
+        for (const op of dyn.emitToNumber()) emitter.pushRaw(out, op);
+        return;
+      }
       case "dyn.eq": {
         // #2949 S5.2 — strict/loose equality over two boxed-any carriers,
         // routed through the CANONICAL `__any_strict_eq` / `__any_eq` helpers
@@ -3005,6 +3028,7 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.to_number":
       return [instr.value];
     case "dyn.eq":
       return [instr.lhs, instr.rhs];

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -892,6 +892,38 @@ export interface IrInstrDynTruthy extends IrInstrBase {
 }
 
 /**
+ * `dyn.to_number{value}` — `ToNumber(value)` (§7.1.4) on a boxed-any carrier,
+ * result `f64` (#2949 S5.3). The single-operand ToNumber primitive that the
+ * numeric-abstract relational lowering (`< > <= >=`) uses: from-ast converts a
+ * dynamic relational operand to `f64` with this node, then feeds the existing
+ * `f64.lt`/`gt`/`le`/`ge` compare path (a concrete numeric operand is used
+ * as-is — no node).
+ *
+ * Lowering routes to the CANONICAL per-backend ToNumber engine via
+ * `IrDynamicLowering.emitToNumber` — one ToNumber policy (June-audit D4):
+ *   - gc/fast/standalone: `__any_to_f64` (the SAME boxed-any→f64 helper legacy's
+ *     `__any_lt`/`__any_gt`/… + the arithmetic helpers use — null→0,
+ *     undefined→NaN, boolean→0/1, number→value).
+ *   - host: `__unbox_number` (`Number(v)`, §7.1.4 — the canonical host ToNumber
+ *     `coercion-engine.emitToNumber` emits for the externref carrier).
+ *
+ * SCOPE — numeric-abstract only. Legacy `any < any` is a FULL Abstract
+ * Relational Comparison (§7.2.11) that is mode-split three ways (host
+ * `__host_compare`; standalone a runtime both-strings-lexicographic-else-numeric
+ * branch; fast numeric-hint) — NOT a bare ToNumber. This node deliberately
+ * implements only the numeric arm; string×string lexicographic relational is
+ * DEFERRED. A boxed-string operand ToNumbers (host: `Number("5")=5`; gc:
+ * `__any_to_f64` reads the box's f64 slot, matching legacy `__any_lt`), which is
+ * spec-correct ONLY when the OTHER operand is a number (ARC never takes the
+ * both-strings branch) — hence the S5.P producer admits a dynamic relational
+ * operand ONLY against a numeric literal/concrete.
+ */
+export interface IrInstrDynToNumber extends IrInstrBase {
+  readonly kind: "dyn.to_number";
+  readonly value: IrValueId;
+}
+
+/**
  * `dyn.eq{lhs, rhs, loose, negate}` — strict/loose equality (§7.2.15 /
  * §7.2.16) between two boxed-any carriers, result `i32` (0/1) (#2949 S5.2).
  *
@@ -2184,6 +2216,7 @@ export type IrInstr =
   | IrInstrUnbox
   | IrInstrTagTest
   | IrInstrDynTruthy
+  | IrInstrDynToNumber
   | IrInstrDynEq
   | IrInstrStringConst
   | IrInstrStringConcat
@@ -2497,6 +2530,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.to_number":
     case "dyn.eq":
     case "string.const":
     case "string.concat":
@@ -2643,6 +2677,7 @@ export function mapNestedBuffers(
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.to_number":
     case "dyn.eq":
     case "string.const":
     case "string.concat":
@@ -2739,6 +2774,7 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.to_number":
       return [instr.value];
     case "dyn.eq":
     case "string.concat":

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -420,7 +420,8 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
     case "box":
     case "unbox":
     case "tag.test":
-    case "dyn.truthy": {
+    case "dyn.truthy":
+    case "dyn.to_number": {
       const v = mapId(rename, inst.value);
       if (v === inst.value) return inst;
       return { ...inst, value: v };

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -652,6 +652,7 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.to_number":
       return [instr.value];
     case "dyn.eq":
       return [instr.lhs, instr.rhs];

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -612,6 +612,20 @@ function verifyBlock(
           });
         }
       }
+      // #2949 S5.3 — dyn.to_number is ToNumber on the boxed-any carrier → f64:
+      // the operand MUST be dynamic (a concrete numeric operand converts to f64
+      // inline and must not route through the carrier ToNumber helper). Result
+      // is f64, consumed by the numeric-abstract relational compare.
+      if (instr.kind === "dyn.to_number") {
+        const operandIr = operandIrType(func, block, instr.value, localDefs);
+        if (operandIr && operandIr.kind !== "dynamic") {
+          errors.push({
+            message: `dyn.to_number operand must be a dynamic IrType, got ${operandIr.kind} (#2949)`,
+            func: func.name,
+            block: block.id as number,
+          });
+        }
+      }
       // #2949 S5.2 — dyn.eq compares TWO boxed-any carriers via the canonical
       // `__any_strict_eq`/`__any_eq` helpers (which take `(ref null $AnyValue,
       // ref null $AnyValue)`). BOTH operands MUST be dynamic — the producer
@@ -713,6 +727,7 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
     case "unbox":
     case "tag.test":
     case "dyn.truthy":
+    case "dyn.to_number":
       return [instr.value];
     case "dyn.eq":
       return [instr.lhs, instr.rhs];

--- a/tests/issue-2949-s5-3-relational.test.ts
+++ b/tests/issue-2949-s5-3-relational.test.ts
@@ -1,0 +1,430 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2949 S5.3 — dynamic-value NUMERIC-ABSTRACT relational lowering.
+//
+// S5.0 (PR #2682) landed the builder emit vocabulary; S5.1 (PR #2690) added
+// `dyn.truthy`; S5.2 (PR #2694) added `dyn.eq`. S5.3 adds `dyn.to_number`:
+// `ToNumber(carrier) → f64`, the single-operand conversion the numeric-abstract
+// relational lowering (`< > <= >=`) applies to a dynamic operand before the
+// existing `f64.lt`/`gt`/`le`/`ge` compare — via a new `emitDynToNumber` builder
+// method + `IrInstrDynToNumber` node, lowered through the new
+// `IrDynamicLowering.emitToNumber` handle arm, which ROUTES to the canonical
+// per-backend ToNumber (gc: `__any_to_f64`, the SAME boxed-any→f64 helper legacy
+// `__any_lt` uses; host: `__unbox_number` = `Number(v)`) — one ToNumber engine
+// (June-audit D4).
+//
+// SCOPE — numeric-abstract only. Legacy `any < any` is a FULL Abstract
+// Relational Comparison (§7.2.11) mode-split three ways (host `__host_compare`,
+// standalone runtime both-strings-else-numeric branch, fast numeric-hint); this
+// slice implements ONLY the numeric arm. String×string lexicographic relational
+// is DEFERRED: a boxed-string operand ToNumbers (host `Number("5")=5`, gc
+// `__any_to_f64` reads the box's f64 slot), which is spec-correct only against a
+// numeric counter-operand — hence the S5.P scan admits a dynamic relational
+// operand only against a numeric literal.
+//
+// Byte-inert by construction: the move-only selector gate still rejects a
+// dynamic-relational body, so from-ast never builds `dyn.to_number` in a CLAIMED
+// function (proven separately by prove-emit-identity, 39/39 IDENTICAL). These
+// tests exercise the mechanism DIRECTLY: node shape + result type, the
+// construction-time + verifier operand guards, the handle→helper D4 routing, and
+// — per the slice-3 standard — RUNTIME execution of hand-built IR lowered against
+// the PRODUCTION handle over a real CodegenContext, in BOTH the gc (fast) and
+// host strategies, asserting numeric relational semantics incl. bool→0/1,
+// null→0, undefined→NaN→false, and NaN → false.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { ensureAnyHelpers } from "../src/codegen/any-helpers.js";
+// Side-effect import: registers the `flushLateImportShifts` codegen delegate
+// that `addUnionImports` requires (same pattern as the S5.0–S5.2 tests).
+import "../src/codegen/expressions.js";
+import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
+import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
+import { addFuncType } from "../src/codegen/registry/types.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import { JsTag } from "../src/codegen/js-tag.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
+import { peepholeOptimize } from "../src/codegen/peephole.js";
+import { stackBalance } from "../src/codegen/stack-balance.js";
+import {
+  IrFunctionBuilder,
+  irDynamic,
+  irVal,
+  lowerIrFunctionToWasm,
+  makeDynamicLowering,
+  verifyIrFunction,
+  type IrBinop,
+  type IrFunction,
+  type IrLowerResolver,
+  type IrType,
+} from "../src/ir/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import type { FuncTypeDef } from "../src/ir/types.js";
+
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+const DYN: IrType = irDynamic();
+
+// ---------------------------------------------------------------------------
+// Harness — real context, production handle, production encoder (S5.2 style)
+// ---------------------------------------------------------------------------
+
+function makeGcCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {
+    fast: true,
+    nativeStrings: false,
+  });
+  ensureAnyHelpers(ctx); // what preregisterDynamicSupport does for gc (registers __any_to_f64)
+  return ctx;
+}
+
+function makeHostCtx(): CodegenContext {
+  const ctx = createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker, {});
+  // What preregisterDynamicSupport does for a host module carrying dyn.to_number:
+  // the classifier/box/__unbox_number import family (dyn.to_number needs NO extra
+  // host-eq imports — its host ToNumber is `__unbox_number`, already in the union
+  // family, unlike S5.2's __host_eq).
+  addUnionImports(ctx);
+  return ctx;
+}
+
+function resolverFor(ctx: CodegenContext): IrLowerResolver {
+  const dyn = makeDynamicLowering(ctx);
+  return {
+    resolveFunc: (ref) => {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) throw new Error(`test resolver: unknown func ${ref.name}`);
+      return idx;
+    },
+    resolveGlobal: () => {
+      throw new Error("test resolver: no globals");
+    },
+    resolveType: () => {
+      throw new Error("test resolver: no type refs");
+    },
+    internFuncType: (t: FuncTypeDef) => addFuncType(ctx, t.params, t.results, t.name),
+    resolveDynamic: () => (dyn ? dyn.carrier : { kind: "externref" }),
+    resolveDynamicLowering: () => dyn,
+  };
+}
+
+function install(ctx: CodegenContext, fns: IrFunction[]): void {
+  const resolver = resolverFor(ctx);
+  for (const f of fns) {
+    const { func } = lowerIrFunctionToWasm(f, resolver);
+    const handle = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, handle, func);
+    ctx.mod.exports.push({ name: f.name, desc: { kind: "func", index: handle } });
+  }
+}
+
+async function instantiateCtx(
+  ctx: CodegenContext,
+  env: Record<string, unknown> = {},
+): Promise<Record<string, (...args: unknown[]) => unknown>> {
+  repairStructTypeMismatches(ctx.mod);
+  peepholeOptimize(ctx.mod);
+  stackBalance(ctx.mod);
+  const binary = emitBinary(ctx.mod);
+  const jsString: Record<string, unknown> = {
+    concat: (a: string, b: string) => `${a}${b}`,
+    length: (s: string) => s.length,
+    equals: (a: unknown, b: unknown) => (a === b ? 1 : 0),
+    substring: (s: string, a: number, b: number) => s.substring(a, b),
+    charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+    fromCharCode: (c: number) => String.fromCharCode(c),
+  };
+  const { instance } = await WebAssembly.instantiate(binary as BufferSource, {
+    env,
+    "wasm:js-string": jsString,
+  });
+  return instance.exports as Record<string, (...args: unknown[]) => unknown>;
+}
+
+// Realistic host import stubs — dyn.to_number reaches `__unbox_number`, which
+// MUST mean `Number(v)` (a `() => 0` fallback would silently answer 0 for
+// everything and hide the ToNumber semantics under test).
+function hostEnvFor(ctx: CodegenContext): Record<string, unknown> {
+  const stub = (name: string): unknown => {
+    if (name.startsWith("__typeof_")) {
+      const t = name.slice("__typeof_".length);
+      // biome-ignore lint/suspicious/useValidTypeof: t derives from the import name.
+      return (v: unknown) => (typeof v === t ? 1 : 0);
+    }
+    switch (name) {
+      case "__box_number":
+        return (v: number) => v;
+      case "__box_boolean":
+        return (v: number) => Boolean(v);
+      case "__unbox_number":
+        return (v: unknown) => Number(v);
+      case "__unbox_boolean":
+        return (v: unknown) => (v ? 1 : 0);
+      case "__is_truthy":
+        return (v: unknown) => (v ? 1 : 0);
+      default:
+        return () => 0;
+    }
+  };
+  const env: Record<string, unknown> = {};
+  for (const imp of ctx.mod.imports) {
+    if (imp.module === "env" && imp.desc.kind === "func") env[imp.name] = stub(imp.name);
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// IR builders — hand-built dyn.to_number relational functions
+// ---------------------------------------------------------------------------
+
+const RELOP: Record<string, IrBinop> = {
+  "<": "f64.lt",
+  "<=": "f64.le",
+  ">": "f64.gt",
+  ">=": "f64.ge",
+};
+
+/**
+ * gc: `f(a: f64, b: f64): i32` — box `a` as a NumberF64 carrier, ToNumber it,
+ * compare against the CONCRETE f64 `b`. Exercises `dyn(number) <rel> concrete`.
+ */
+function gcRelBoxNum(name: string, op: keyof typeof RELOP): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", F64);
+  const c = b.addParam("c", F64);
+  b.openBlock();
+  const da = b.emitBox(a, irDynamic(JsTag.NumberF64));
+  const na = b.emitDynToNumber(da);
+  const r = b.emitBinary(RELOP[op], na, c, I32);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/**
+ * gc: `f(a: i32, b: f64): i32` — box `a` as a Boolean (tag-4) carrier, ToNumber
+ * it (`true`→1 / `false`→0), compare against concrete `b`. Exercises the
+ * boolean-partition ToNumber arm.
+ */
+function gcRelBoxBool(name: string, op: keyof typeof RELOP): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", I32);
+  const c = b.addParam("c", F64);
+  b.openBlock();
+  const da = b.emitBox(a, irDynamic(JsTag.Boolean));
+  const na = b.emitDynToNumber(da);
+  const r = b.emitBinary(RELOP[op], na, c, I32);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/**
+ * gc: `f(a: f64, b: f64): i32` — box BOTH as NumberF64 carriers, ToNumber both,
+ * compare. Exercises `dyn <rel> dyn` (both carriers).
+ */
+function gcRelDynDyn(name: string, op: keyof typeof RELOP): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", F64);
+  const c = b.addParam("c", F64);
+  b.openBlock();
+  const da = b.emitBox(a, irDynamic(JsTag.NumberF64));
+  const dc = b.emitBox(c, irDynamic(JsTag.NumberF64));
+  const na = b.emitDynToNumber(da);
+  const nc = b.emitDynToNumber(dc);
+  const r = b.emitBinary(RELOP[op], na, nc, I32);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/**
+ * host: `f(a: dynamic, b: f64): i32` — ToNumber the dynamic `a`, compare against
+ * concrete f64 `b`. `a` is an externref (a real JS value passed from the test).
+ * Exercises `dyn(<any JS value>) <rel> numericLiteral`.
+ */
+function hostRelDynConc(name: string, op: keyof typeof RELOP): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", DYN);
+  const c = b.addParam("c", F64);
+  b.openBlock();
+  const na = b.emitDynToNumber(a);
+  const r = b.emitBinary(RELOP[op], na, c, I32);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+/** host: `f(a: dynamic, b: dynamic): i32` — ToNumber BOTH, compare. */
+function hostRelDynDyn(name: string, op: keyof typeof RELOP): IrFunction {
+  const b = new IrFunctionBuilder(name, [I32], true);
+  const a = b.addParam("a", DYN);
+  const c = b.addParam("c", DYN);
+  b.openBlock();
+  const na = b.emitDynToNumber(a);
+  const nc = b.emitDynToNumber(c);
+  const r = b.emitBinary(RELOP[op], na, nc, I32);
+  b.terminate({ kind: "return", values: [r] });
+  return b.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Node shape + result type + construction-time operand guard
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.3 — emitDynToNumber emits a verifier-clean f64 dyn.to_number node", () => {
+  it("appends a dyn.to_number node with f64 result and registers typeOf", () => {
+    const b = new IrFunctionBuilder("tn1", [F64], true);
+    const x = b.addParam("x", DYN);
+    b.openBlock();
+    const r = b.emitDynToNumber(x);
+    expect(b.typeOf(r)).toEqual(F64);
+    b.terminate({ kind: "return", values: [r] });
+    const fn = b.finish();
+    const [node] = fn.blocks[0].instrs;
+    expect(node).toMatchObject({ kind: "dyn.to_number", value: x, result: r, resultType: F64 });
+    expect(verifyIrFunction(fn)).toEqual([]);
+  });
+
+  it("rejects a non-dynamic operand at construction (carrier ToNumber only)", () => {
+    const b = new IrFunctionBuilder("tnBad", [F64], true);
+    const c = b.addParam("c", F64);
+    b.openBlock();
+    expect(() => b.emitDynToNumber(c)).toThrow(/operand .* is not dynamic/);
+  });
+
+  it("a dyn.to_number fed a concrete operand fails the verifier (defense in depth)", () => {
+    const b = new IrFunctionBuilder("tnVerify", [F64], true);
+    const c = b.addParam("c", F64);
+    b.openBlock();
+    b.terminate({ kind: "return", values: [c] });
+    const fn = b.finish();
+    const bad: IrFunction = {
+      ...fn,
+      blocks: [
+        {
+          ...fn.blocks[0],
+          instrs: [{ kind: "dyn.to_number", value: c, result: 999, resultType: F64 } as never],
+        },
+      ],
+    };
+    const errs = verifyIrFunction(bad);
+    expect(errs.some((e) => /dyn\.to_number operand must be a dynamic/.test(e.message))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handle → helper routing (D4): one ToNumber engine, both strategies
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.3 — IrDynamicLowering.emitToNumber routes to the canonical ToNumber helper", () => {
+  it("gc: emitToNumber calls __any_to_f64 (the boxed-any→f64 helper legacy __any_lt uses)", () => {
+    const ctx = makeGcCtx();
+    const dyn = makeDynamicLowering(ctx);
+    expect(dyn).not.toBeNull();
+    const idx = ctx.funcMap.get("__any_to_f64");
+    expect(idx).toBeDefined();
+    expect(dyn!.emitToNumber()).toEqual([{ op: "call", funcIdx: idx }]);
+  });
+
+  it("host: emitToNumber calls __unbox_number (Number(v)) — the canonical host ToNumber", () => {
+    const ctx = makeHostCtx();
+    const dyn = makeDynamicLowering(ctx);
+    expect(dyn).not.toBeNull();
+    const idx = ctx.funcMap.get("__unbox_number");
+    expect(idx).toBeDefined();
+    expect(dyn!.emitToNumber()).toEqual([{ op: "call", funcIdx: idx }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gc runtime — dyn.to_number over the $AnyValue carrier (number/bool partitions)
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.3 — gc runtime: numeric-abstract relational over the $AnyValue carrier", () => {
+  it("dyn(number) <rel> concrete, dyn<dyn, bool→0/1, NaN → false", async () => {
+    const fns = [
+      gcRelBoxNum("ltN", "<"),
+      gcRelBoxNum("gtN", ">"),
+      gcRelBoxNum("leN", "<="),
+      gcRelBoxNum("geN", ">="),
+      gcRelBoxBool("gtB", ">"),
+      gcRelDynDyn("ltDD", "<"),
+    ];
+    for (const f of fns) expect(verifyIrFunction(f)).toEqual([]);
+    const ctx = makeGcCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx);
+
+    // dyn(number) vs concrete
+    expect(ex.ltN(3, 5)).toBe(1);
+    expect(ex.ltN(5, 3)).toBe(0);
+    expect(ex.ltN(5, 5)).toBe(0);
+    expect(ex.gtN(5, 3)).toBe(1);
+    expect(ex.gtN(3, 5)).toBe(0);
+    expect(ex.leN(5, 5)).toBe(1);
+    expect(ex.leN(6, 5)).toBe(0);
+    expect(ex.geN(5, 5)).toBe(1);
+    expect(ex.geN(4, 5)).toBe(0);
+    // fractional operands go through f64 compare (not an i32 truncation)
+    expect(ex.ltN(1.5, 1.6)).toBe(1);
+    expect(ex.ltN(1.6, 1.5)).toBe(0);
+    // NaN comparisons are always false (spec §7.2.11)
+    expect(ex.ltN(NaN, 5)).toBe(0);
+    expect(ex.gtN(NaN, 5)).toBe(0);
+    expect(ex.geN(NaN, 5)).toBe(0);
+
+    // boolean partition: ToNumber(true)=1, ToNumber(false)=0
+    expect(ex.gtB(1, 0.5)).toBe(1); // true(1) > 0.5
+    expect(ex.gtB(0, 0.5)).toBe(0); // false(0) > 0.5
+
+    // dyn < dyn (both boxed numbers)
+    expect(ex.ltDD(3, 5)).toBe(1);
+    expect(ex.ltDD(5, 3)).toBe(0);
+    expect(ex.ltDD(NaN, 5)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// host runtime — dyn.to_number over the externref carrier (full ToNumber spectrum)
+// ---------------------------------------------------------------------------
+
+describe("#2949 S5.3 — host runtime: numeric-abstract relational over the externref carrier", () => {
+  it("dyn(JS value) <rel> numeric: number/bool/null(→0)/undefined(→NaN→false)/string(Number())", async () => {
+    const fns = [
+      hostRelDynConc("ltH", "<"),
+      hostRelDynConc("gtH", ">"),
+      hostRelDynConc("geH", ">="),
+      hostRelDynDyn("ltHDD", "<"),
+    ];
+    for (const f of fns) expect(verifyIrFunction(f)).toEqual([]);
+    const ctx = makeHostCtx();
+    install(ctx, fns);
+    const ex = await instantiateCtx(ctx, hostEnvFor(ctx));
+
+    // number
+    expect(ex.ltH(3, 5)).toBe(1);
+    expect(ex.ltH(5, 3)).toBe(0);
+    expect(ex.gtH(5, 3)).toBe(1);
+    expect(ex.geH(5, 5)).toBe(1);
+    // boolean → 0/1
+    expect(ex.gtH(true, 0.5)).toBe(1); // Number(true)=1 > 0.5
+    expect(ex.gtH(false, 0.5)).toBe(0); // Number(false)=0 > 0.5
+    // null → 0 (ToNumber(null)=0)
+    expect(ex.ltH(null, 5)).toBe(1); // 0 < 5
+    expect(ex.gtH(null, 5)).toBe(0); // 0 > 5 → false
+    // undefined → NaN → every relational false
+    expect(ex.ltH(undefined, 5)).toBe(0);
+    expect(ex.gtH(undefined, 5)).toBe(0);
+    expect(ex.geH(undefined, 5)).toBe(0);
+    // string ToNumbers via Number() (spec-correct against a numeric operand —
+    // ARC does NOT take the both-strings lexicographic branch here)
+    expect(ex.ltH("3", 5)).toBe(1); // Number("3")=3 < 5
+    expect(ex.gtH("7", 5)).toBe(1); // Number("7")=7 > 5
+    expect(ex.ltH("abc", 5)).toBe(0); // Number("abc")=NaN → false
+
+    // dyn < dyn, both JS values
+    expect(ex.ltHDD(3, 5)).toBe(1);
+    expect(ex.ltHDD(5, 3)).toBe(0);
+    expect(ex.ltHDD(undefined, 5)).toBe(0); // NaN → false
+    expect(ex.ltHDD(null, 5)).toBe(1); // 0 < 5
+  });
+});


### PR DESCRIPTION
## #2949 S5.3 — dynamic-value numeric-abstract relational lowering

Adds `dyn </<=/>/>= x` (either or both operands boxed-any carriers) → `i32` as a **mechanism slice** (byte-inert, no selector/producer change). A dynamic relational operand is ToNumber'd to `f64` via a new single-operand `dyn.to_number` node, then the EXISTING `f64.lt`/`gt`/`le`/`ge` compare runs.

### What lands
- `IrInstrDynToNumber{value}` node (→ f64) — the `dyn.truthy` single-operand shape (nodes/lower/verify/effects/monomorphize/inline-small).
- `IrFunctionBuilder.emitDynToNumber(value)`.
- `IrDynamicLowering.emitToNumber()` handle arm.
- `from-ast` `lowerBinary` relational dynamic arm (`tryLowerDynamicRelational` + `relOperandToF64`).

### Per-backend ToNumber routing (D4 — one ToNumber engine)
- **gc/fast/standalone** → `__any_to_f64` (the SAME boxed-any→f64 helper legacy's `__any_lt` family + arithmetic helpers use). Chosen directly over `coercion-engine.emitToNumber`, whose `$AnyValue` arm routes through `coerceType` and REQUIRES temp-local allocation the handle's pure `Instr[]` contract cannot supply.
- **host** → `coercion-engine.emitToNumber(externref)` → `__unbox_number` (`Number(v)`), single call, no locals.

### Load-bearing finding (heeding S5.2's mode-split lesson)
Verified against the **real compiler** that legacy `any < any` is a FULL Abstract Relational Comparison (§7.2.11), mode-split **three ways** — NONE a bare ToNumber:
- **host**: `call __host_compare(a,b)` then compare to `-1` — a JS-relational IMPORT (full ARC incl. string×string lexicographic). The exact analog of S5.2's `__host_eq`.
- **fast**: relational FALLS THROUGH `compileAnyBinaryDispatch` (only `+`/equality dispatch) to numeric-hint → `__unbox_number` per operand.
- **standalone**: pure-Wasm runtime `both-strings → lexicographic, else __any_to_f64 + f64.lt` branch.

So there is no single legacy relational helper to route the whole comparison through — the S5-plan design (ToNumber(dyn) + f64 compare) is the **numeric arm** of this ARC. **String×string lexicographic relational is DEFERRED**; the numeric arm is spec-complete against a numeric counter-operand (the S5.P scan admits a dynamic relational operand only against a numeric literal — ARC never takes the both-strings branch there). NaN → false; null→0; undefined→NaN→false; boolean→0/1.

### Verification
- **prove-emit-identity: 39/39 IDENTICAL** vs base `e66b066d4` (byte-inert).
- `check:ir-fallbacks` — OK, zero delta, zero post-claim demotions.
- `tests/issue-2949-s5-3-relational.test.ts` — **7/7**, incl. RUNTIME execution of hand-built IR over gc + host against the production lowering (dyn<lit, dyn<dyn, bool→0/1, null→0, undefined→NaN→false, string via `Number()`, NaN → false).
- Adjacent #2949 suites: 86/86 combined (S5.0/S5.1/S5.2/slice1/slice2/slice3 + S5.3).
- `tsc --noEmit` clean; prettier clean; zero new biome errors (pre-existing IR-codebase style deltas only; prettier is the CI quality gate).

The claim-flip stays back-loaded onto S5.P (§4 anti-vacuity probe). S5.4 (dynamic member read) is the heaviest, substrate-adjacent sub-slice next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8