### PR TITLE
fix(landing): FAQ question bold only when the item is open

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -737,6 +737,9 @@
         min-width: 0;
         font-size: 21px;
         line-height: 1.36;
+        font-weight: 400;
+      }
+      .approach-faq details[open] .approach-faq-question {
         font-weight: 600;
       }
       .approach-faq-answer {


### PR DESCRIPTION
FAQ questions were always semibold (`font-weight: 600`). Now normal weight (400) by default and bold only under `details[open]`, so a question reads as regular text until its answer is expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)