### PR TITLE
docs(#3022): decompose defineProperty tail into dispatchable sub-issues (#3042-#3046)

### DIFF
--- a/plan/issues/3022-defineproperty-descriptor-fidelity-tail-residual.md
+++ b/plan/issues/3022-defineproperty-descriptor-fidelity-tail-residual.md
@@ -1,23 +1,31 @@
 ---
 id: 3022
-title: "spec gap: Object.defineProperty(ies) descriptor fidelity tail + non-object receiver arm (~728 default-lane fails)"
-status: blocked
+title: "UMBRELLA: Object.defineProperty(ies) descriptor fidelity + non-object-receiver tail (~728 default-lane fails)"
+status: ready
 sprint: current
 created: 2026-07-03
-updated: 2026-07-04
+updated: 2026-07-05
 priority: high
 horizon: m
-feasibility: medium
+feasibility: hard
 reasoning_effort: medium
-task_type: bugfix
+task_type: umbrella
 area: runtime
 language_feature: object-defineproperty, property-descriptors
 es_edition: 5
 goal: spec-completeness
 test262_category: built-ins/Object/defineProperty, built-ins/Object/defineProperties
 test262_fail: 728
-related: [1334, 1629, 1629a, 1631]
+related: [1334, 1629, 1629a, 1631, 2726]
+children: [3042, 3043, 3044, 3045, 3046]
 ---
+
+> **UMBRELLA (decomposed 2026-07-05, dev-2726).** This 728-fail blob is NOT a
+> single dispatchable task — it fragments into distinct root causes across two
+> clusters (descriptor-fidelity ~600, non-object-receiver ~128). Filed
+> sub-issues + cause-scoped clusters are in `## Decomposition` below. Keep this
+> issue `ready` as the umbrella tracker; dispatch the **children**. Do NOT claim
+> #3022 itself for implementation.
 
 # #3022 — Object.defineProperty(ies): descriptor fidelity tail + non-object receiver
 
@@ -132,3 +140,60 @@ distinct senior-dev-sized fix in value-rep / array-exotic / #1712 machinery; 4 i
 a grab-bag). None is a low-regression-risk single `medium` PR. No code change is
 proposed here — shipping a partial fix to any one cause risks broad regressions
 across the host-mode object surface without a full-CI validation pass.
+
+## Decomposition (2026-07-05, dev-2726)
+
+Acting on the dev-3022 recommendation above (which analysed the causes but did
+not file them). Re-harvested both clusters from
+`.test262-cache/test262-current.jsonl` and cross-tabulated error string × feature
+to separate true root causes from shared symptoms.
+
+### Cluster 1 — descriptor-fidelity (~600, `built-ins/Object/define{Property,Properties}`)
+
+The dev-3022 causes 1–3 are the **senior** value-rep / exotic / closure clusters;
+the grab-bag (cause 4) splits into three cleaner pieces. Filed vs cause-scoped:
+
+| root cause | fails | scope | tracked as |
+|---|---|---|---|
+| **attribute round-trip fidelity** (writable/enumerable/configurable via `verifyProperty`, primitive values) | ~74 | **DEV** | **#3042** (filed) |
+| **illegal-transition + SameValue validation** (non-configurable redefine should-throw; +0/-0/NaN; false-positive Cannot-redefine) — dev-3022 cause 4 | ~50 | **SENIOR** | **#3043** (filed) |
+| **descriptor-shape codegen crashes** (invalid Wasm / illegal cast / op.endsWith / ctors-not-defined) | ~16 | **DEV** | **#3044** (filed) |
+| **value round-trip: struct-widening vs sidecar read** (`value: undefined`/object read returns struct default, `SameValue`-differs) — dev-3022 cause 1 | ~40+ | **SENIOR** (value-rep, #1629 S3 / #2106) | cause-scoped, file when a senior picks it up |
+| **array exotic `[[DefineOwnProperty]]`** (plural `defineProperties(arr,…)`, array-index/`length` §10.4.2) — dev-3022 cause 2 | ~83 | **SENIOR** (array-exotic, #2186 vec) | cause-scoped |
+| **prototype-chain descriptor-field read** (inherited `value`/`get` dropped; function-scope fnctor instance not registered) — dev-3022 cause 3 | ~33 | **SENIOR** (#1712 closure/global machinery) | cause-scoped |
+
+The three **cause-scoped** senior clusters keep their full repros in the dev-3022
+section above; they are deliberately NOT filed as separate issues yet (each is a
+senior-dev-sized value-rep/exotic fix — file on pickup to avoid stale un-owned
+issues). #3042/#3044 are the immediately **dev-dispatchable** wins.
+
+### Cluster 2 — non-object-receiver (~128, "called on non-object")
+
+Cross-tab (error string × feature) shows these are NOT one bug — they are
+internal `Object`/`Reflect` ops hitting a non-object receiver across ~7 features:
+
+| root cause | fails | scope | tracked as |
+|---|---|---|---|
+| **top-level `this` / global-object model** (`Object.defineProperty(this,…)` at script top level; global/eval var+func declaration binding) | ~89 | **ARCH/SENIOR** | folds into **#2726 (b)** — same structural root (top-level-`this`-as-global-object). Route to that issue's architect spec; do NOT dup. |
+| **class private-element brand check** (`Reflect.has` on non-object; private methods/generators/static-private) | ~8 | **DEV** | **#3045** (filed) |
+| **JSON.parse reviver `this`-binding** (reviver `this` must be the holder) | 4 | **DEV** | **#3046** (filed) |
+| **module namespace exotic object** (`Reflect.{has,deleteProperty,defineProperty,set,preventExtensions}` on `import * as ns`) | 10 | **SENIOR** (namespace-object representation) | cause-scoped, file on pickup |
+| **annexB `[[IsHTMLDDA]]`** (document.all emulation as `@@replace`/`@@match`) | 6 | DEFERRED (niche annexB) | note only |
+| **`$262.createRealm` cross-realm** (`create-proto-from-ctor-realm-*`; OArray undefined — realms unsupported) | 6 | DEFERRED (realm infra) | note only |
+| misc singletons (Date/Error/RegExp.prototype called-as-function, Proxy, typeof get-value, defineProperties edge) | ~5 | mixed | note only |
+
+**Big finding:** ~89 of the 128 "non-object" fails share the **top-level-`this`-
+as-global-object** root cause — the SAME structural gap as the two remaining
+#2726 group-(b) tests (`S11.4.1_A3.1` `delete this.y`, `S11.4.1_A3.3_T1`
+implicit-global). Fixing the global-object model (architect spec on #2726 (b))
+would clear ~89 defineProperty fails as a side effect. This is the single
+highest-leverage item in the whole #3022 tail and is architect-gated.
+
+### Dispatch summary
+
+- **DEV-dispatchable now:** #3042 (attribute fidelity), #3044 (codegen crashes),
+  #3045 (class private brand-check), #3046 (JSON reviver `this`).
+- **SENIOR:** #3043 (transition validation) + the 3 cause-scoped descriptor
+  clusters (value-round-trip, array-exotic, prototype-chain) + module-namespace.
+- **ARCH-gated:** the ~89-fail top-level-`this`/global-object model → #2726 (b).
+- **DEFERRED:** annexB `[[IsHTMLDDA]]`, `$262.createRealm` realms.

--- a/plan/issues/3042-defineproperty-attribute-roundtrip-fidelity.md
+++ b/plan/issues/3042-defineproperty-attribute-roundtrip-fidelity.md
@@ -1,0 +1,70 @@
+---
+id: 3042
+title: "Object.defineProperty: attribute round-trip fidelity (writable/enumerable/configurable not faithfully stored + reported)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: runtime, codegen
+language_feature: object-defineproperty, property-descriptors
+es_edition: 5
+goal: spec-completeness
+parent: 3022
+related: [3022, 1334, 1629]
+---
+
+# #3042 — defineProperty attribute round-trip fidelity
+
+Split from the #3022 umbrella (descriptor-fidelity tail). This is the
+**developer-scoped, locally-test262-validatable** slice.
+
+## Root cause
+
+After `Object.defineProperty(obj, k, desc)`, reading the property back via
+`Object.getOwnPropertyDescriptor` / `verifyProperty` (the test262 helper that
+mutates then restores each attribute) reports the wrong **attribute bits**
+(`writable` / `enumerable` / `configurable`) or the attributes are not
+*enforced* (e.g. a `writable:false` property is still writable, an
+`enumerable:false` property still shows in `for-in`). The descriptor-bit sidecar
+population at the defineProperty lowering / runtime helper and the
+`getOwnPropertyDescriptor` reader do not round-trip faithfully for the common
+struct-typed-receiver shapes.
+
+This is the **attribute-fidelity** half of the 600-fail descriptor tail; it is
+distinct from value/identity loss (see #3022 note DF-3) and from illegal-
+transition validation (#3043).
+
+## Failing files (74, `built-ins/Object/define{Property,Properties}`, `verifyProperty` failures)
+
+`15.2.3.7-6-a-249`, `15.2.3.6-4-79`, `15.2.3.7-6-a-253`, `15.2.3.6-4-243`,
+`15.2.3.6-4-81`, `15.2.3.6-4-289`, `15.2.3.7-6-a-215`, `15.2.3.6-4-73`, … (full
+set: harvest `verifyProperty` failures under `built-ins/Object/defineProperty`
++ `defineProperties` from `.test262-cache/test262-current.jsonl`).
+
+## Minimal repro
+
+```js
+var obj = {};
+Object.defineProperty(obj, "foo", { value: 1, enumerable: false });
+var d = Object.getOwnPropertyDescriptor(obj, "foo");
+// expected: d.enumerable === false, d.writable === false, d.configurable === false
+// also: for (var k in obj) — "foo" must NOT appear
+```
+
+## Layer to fix
+
+- `src/codegen/object-ops.ts` defineProperty lowering — ensure every descriptor
+  bit is recorded (the `_wasmPropDescs` / `definedPropertyFlags` sidecar), for
+  both the data and accessor fast paths and the runtime path.
+- `src/runtime.ts` `getOwnPropertyDescriptor` reader + enumeration
+  (`for-in` / `Object.keys`) — consult the recorded bits.
+
+## Acceptance
+
+- `verifyProperty`-based fails in `built-ins/Object/define{Property,Properties}`
+  drop materially (target: the 74 listed → near zero).
+- No regression in `Object/{freeze,seal,preventExtensions,getOwnPropertyDescriptor}`.
+- Scope: **DEV** — locally validatable via `runTest262File` on the cluster.

--- a/plan/issues/3043-defineproperty-illegal-transition-validation.md
+++ b/plan/issues/3043-defineproperty-illegal-transition-validation.md
@@ -1,0 +1,74 @@
+---
+id: 3043
+title: "Object.defineProperty: ValidateAndApplyPropertyDescriptor illegal-transition rules not enforced (should-throw + SameValue + false-positive Cannot-redefine)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: high
+created: 2026-07-05
+task_type: bugfix
+area: runtime
+language_feature: object-defineproperty, property-descriptors
+es_edition: 5
+goal: spec-completeness
+parent: 3022
+related: [3022, 3042, 1334, 1629]
+---
+
+# #3043 — defineProperty illegal-transition validation
+
+Split from the #3022 umbrella. **Senior-scoped** (Fable-reserved): spec-precise
+`ValidateAndApplyPropertyDescriptor` (ECMA-262 §10.1.6.3) with blast radius
+across `defineProperty` / `freeze` / `seal` / `Object.create`.
+
+## Root cause
+
+Two failure directions, same validate step:
+
+1. **Should-throw, doesn't (80 fails).** Redefining a **non-configurable**
+   property in a way the spec forbids must throw `TypeError`, but our impl
+   silently applies it:
+   - changing `value` of a non-configurable, non-writable data property
+     (with the `SameValue` rule: `+0`/`-0` differ, `NaN`/`NaN` are same —
+     e.g. `15.2.3.7-6-a-46`),
+   - toggling `enumerable` / `configurable`,
+   - data ↔ accessor conversion on a non-configurable property.
+2. **False-positive `Cannot redefine property` (~13 fails).** A **configurable**
+   property that the spec permits to be redefined is wrongly rejected
+   (`15.2.3.6-4-293-{1,3}`, `15.2.3.7-6-a-75`).
+
+## Failing files (36 primary + Cannot-redefine cluster)
+
+`15.2.3.7-6-a-245`, `15.2.3.7-6-a-46`, `15.2.3.6-4-293-3`, `15.2.3.7-6-a-93-3`,
+`15.2.3.7-6-a-75`, `15.2.3.7-6-a-76`, `15.2.3.7-6-a-81`, `15.2.3.7-6-a-77`, …
+(harvest `Expected TypeError` + `Cannot redefine property` under
+`built-ins/Object/defineProperty{,ies}`).
+
+## Minimal repro
+
+```js
+var obj = {};
+Object.defineProperty(obj, "foo", { value: +0 });          // configurable:false (default)
+// spec: SameValue(+0, -0) === false ⇒ this is a change on a non-writable,
+// non-configurable prop ⇒ must throw TypeError:
+Object.defineProperty(obj, "foo", { value: -0 });
+```
+
+## Layer to fix
+
+`src/runtime.ts` (and/or `src/codegen/object-ops.ts`) — the descriptor
+validate/apply step: implement the full §10.1.6.3 rejection matrix + `SameValue`
+comparison; ensure the configurable-redefine path does not over-reject.
+
+## Why senior
+
+Changes flow into `freeze`/`seal`/`preventExtensions` and every descriptor
+consumer; the +0/-0/NaN `SameValue` edges are subtle. **Must validate IN BATCH
+(full CI / merge_group), not a scoped sweep.**
+
+## Acceptance
+
+- Illegal non-configurable transitions throw `TypeError`; legal configurable
+  redefinitions succeed. No regression in `freeze`/`seal`/`create`.

--- a/plan/issues/3044-defineproperty-descriptor-shape-codegen-crashes.md
+++ b/plan/issues/3044-defineproperty-descriptor-shape-codegen-crashes.md
@@ -1,0 +1,57 @@
+---
+id: 3044
+title: "Object.defineProperty: compiler crashes on specific descriptor test shapes (invalid Wasm / illegal cast / op.endsWith / ctors-not-defined)"
+status: ready
+sprint: current
+priority: high
+horizon: s
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: codegen
+language_feature: object-defineproperty
+es_edition: 5
+goal: correctness
+parent: 3022
+related: [3022, 3024]
+---
+
+# #3044 — defineProperty descriptor-shape codegen crashes
+
+Split from the #3022 umbrella. **Developer-scoped** — each is a concrete,
+locally-reproducible compiler crash on a particular descriptor test shape (NOT a
+descriptor-semantics gap). These are correctness bugs (the compiler emits an
+invalid binary or throws internally) and can be picked off individually.
+
+## Failing files + crash signature (16)
+
+| file | crash |
+|---|---|
+| `15.2.3.6-4-255.js`, `15.2.3.6-4-256.js` | `invalid Wasm binary (WebAssembly.instantiate)` |
+| `15.2.3.7-6-a-17.js`, `15.2.3.6-4-587.js` | `Codegen error: op.endsWith is not a function` |
+| `15.2.3.7-6-a-113.js`, `15.2.3.6-4-117.js` | `illegal cast [in __closure_2()]` |
+| `15.2.3.7-6-a-114.js` | `array element access out of bounds` |
+| `typedarray-backed-by-resizable-buffer.js`, `coerced-P-grow/shrink.js` | `ctors is not defined` |
+| `S15.2.3.6_A1.js` | `Cannot read properties of …` |
+
+## Notes
+
+- The `op.endsWith is not a function` signature is a codegen-internal bug
+  (an `op` that is not a string reaches a `.endsWith` call) — likely shared
+  across the two files; fixing it once should clear both.
+- `illegal cast [in __closure_2()]` — a getter/setter descriptor compiled into a
+  closure hits a bad cast; overlaps the accessor-in-closure path.
+- `ctors is not defined` — resizable-ArrayBuffer-backed typed-array descriptor
+  tests reference a harness global we don't provide (may be a harness/skip issue,
+  verify before fixing).
+- Several overlap #3024 (invalid-Wasm-emission residual) — cross-check before
+  claiming so the fix lands in one place.
+
+## Layer to fix
+
+`src/codegen/*` — varies per crash; each has a minimal repro (the cited file).
+
+## Acceptance
+
+- The listed files compile to a valid binary (pass or a spec-correct runtime
+  result), no compiler-internal throw. Scope: **DEV**, pick individual files.

--- a/plan/issues/3045-class-private-brand-check-reflect-has-non-object.md
+++ b/plan/issues/3045-class-private-brand-check-reflect-has-non-object.md
@@ -1,0 +1,54 @@
+---
+id: 3045
+title: "class private-element brand check emits Reflect.has on a non-object receiver (private methods/generators/static-private)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: codegen, runtime
+language_feature: class-private-methods
+es_edition: 6
+goal: spec-completeness
+parent: 3022
+related: [3022]
+---
+
+# #3045 — class private brand-check `Reflect.has` on non-object
+
+Split from the #3022 umbrella (the "called on non-object" cluster — the
+`Reflect.has called on non-object` sub-group). **Developer-scoped.**
+
+## Root cause
+
+The private-element **brand check** (used for private methods/accessors — the
+`#m in obj` membership test and the implicit brand check on private-method
+access) lowers to an internal `Reflect.has(receiver, key)`. In the private-
+method / private-generator / static-private paths the `receiver` reaching that
+`Reflect.has` is a **non-object** in our representation (undefined / an unboxed
+value), so the runtime helper throws `Reflect.has called on non-object` instead
+of performing the brand check. `built-ins`/`language` class tests that install
+private *methods* (not just fields) hit this.
+
+## Failing files (8)
+
+`prod-private-async-method.js`, `prod-private-async-generator.js`,
+`prod-private-method.js`, `prod-private-method-initialize-order.js`,
+`fields-multiple-definitions-static-private-methods-proxy.js`,
+`prod-private-generator.js`,
+`static-private-methods-proxy-default-handler-throws.js`,
+`static-private-fields-proxy-default-handler-throws.js`.
+
+## Layer to fix
+
+`src/codegen` private-element brand-check lowering — ensure the receiver is the
+boxed object (or emit the brand check without routing through
+`Reflect.has` on a non-object). Check how private *methods* differ from private
+*fields* (fields work; methods don't) in the brand-check emit path.
+
+## Acceptance
+
+- The listed private-method/generator class tests pass; no regression in
+  private-field tests. Scope: **DEV**.

--- a/plan/issues/3046-json-parse-reviver-this-binding.md
+++ b/plan/issues/3046-json-parse-reviver-this-binding.md
@@ -1,0 +1,59 @@
+---
+id: 3046
+title: "JSON.parse reviver: `this` is not bound to the holder object (Object.defineProperty(this,…) in a reviver throws called-on-non-object)"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: runtime
+language_feature: json-parse
+es_edition: 5
+goal: spec-completeness
+parent: 3022
+related: [3022]
+---
+
+# #3046 — JSON.parse reviver `this`-binding to the holder
+
+Split from the #3022 umbrella (the "called on non-object" cluster — JSON/parse
+sub-group). **Developer-scoped, bounded.**
+
+## Root cause
+
+Per ECMA-262 `InternalizeJSONProperty`, the reviver is invoked as
+`Call(reviver, holder, «name, val»)` — i.e. `this` inside the reviver MUST be
+the **holder** object/array. Our `JSON.parse` reviver invocation does not bind
+`this` to the holder, so inside the reviver `this` is a non-object; a
+`Object.defineProperty(this, k, …)` (or any `this.`-op on the holder) throws
+`Object.defineProperty called on non-object`.
+
+## Failing files (4)
+
+`reviver-array-non-configurable-prop-delete.js`,
+`reviver-array-non-configurable-prop-create.js`,
+`reviver-object-non-configurable-prop-delete.js`,
+`reviver-object-non-configurable-prop-create.js`.
+
+## Minimal repro
+
+```js
+JSON.parse('[1,2]', function (key, value) {
+  if (key === '0') Object.defineProperty(this, '1', { configurable: false });
+  // `this` must be the holder array — currently non-object ⇒ throws
+  return value;
+});
+```
+
+## Layer to fix
+
+`src/runtime.ts` — the `JSON.parse` reviver call site: pass the holder as the
+`this` receiver of the reviver call (and make the holder a real object the
+reviver's `this.`-operations accept). The `[[Delete]]`/`[[DefineOwnProperty]]`
+on the holder must observe the descriptor tombstone semantics (see #2726 c/d).
+
+## Acceptance
+
+- The 4 reviver tests pass; `this` inside a reviver is the holder. Scope: **DEV**.


### PR DESCRIPTION
## Summary

Turns the un-dispatchable 728-fail **#3022** blob into a tracked **umbrella**
with filed, dev-vs-senior-scoped children, so the fleet can pick up bounded work
instead of one 728-fail monolith. Docs/plan only — no code.

Re-harvested both clusters from `.test262-cache/test262-current.jsonl` and
cross-tabulated error string × feature to separate true root causes from shared
symptoms (builds on the earlier dev-3022 root-cause analysis, which identified
the descriptor causes but never filed them).

## New sub-issues

| # | title | scope |
|---|---|---|
| #3042 | defineProperty attribute round-trip fidelity (writable/enumerable/configurable) | **DEV** |
| #3043 | defineProperty illegal-transition + SameValue validation (should-throw) | SENIOR |
| #3044 | defineProperty descriptor-shape codegen crashes (invalid Wasm / illegal cast / …) | **DEV** |
| #3045 | class private brand-check emits Reflect.has on non-object | **DEV** |
| #3046 | JSON.parse reviver `this` not bound to holder | **DEV** |

#3022 becomes `task_type: umbrella`, `status: ready`, `children: [3042-3046]`.

## Key findings baked into the umbrella

- **Non-object cluster (~128) is not one bug** — internal `Object`/`Reflect` ops
  on a non-object receiver across ~7 features. **~89 of the 128 share the
  top-level-`this`-as-global-object root cause** = the SAME structural gap as the
  remaining #2726 group-(b) tests. Fixing the global-object model (architect spec
  on #2726 b) clears ~89 defineProperty fails as a side effect — the single
  highest-leverage item, folded there (not duplicated).
- **Descriptor cluster (~600)** — the 3 big senior clusters (value-round-trip
  struct-widening, array-exotic `[[DefineOwnProperty]]`, prototype-chain
  descriptor read) are kept as **cause-scoped** with full repros (file on senior
  pickup); the DEV-dispatchable wins (#3042, #3044) + transition validation
  (#3043) are filed now.

## Dispatch summary

- DEV now: #3042, #3044, #3045, #3046
- SENIOR: #3043 + value-round-trip / array-exotic / prototype-chain / module-namespace (cause-scoped)
- ARCH-gated: ~89-fail top-level-`this` → #2726 (b)
- DEFERRED: annexB `[[IsHTMLDDA]]`, `$262.createRealm` realms

🤖 Generated with [Claude Code](https://claude.com/claude-code)