### PR TITLE
chore: file 4 fresh dev-sized conformance buckets from current-main harvest

### DIFF
--- a/plan/issues/3047-block-nested-var-function-redeclare-false-ce.md
+++ b/plan/issues/3047-block-nested-var-function-redeclare-false-ce.md
@@ -1,0 +1,70 @@
+---
+id: 3047
+title: "false CE — `var x; function x(){}` same-name coexistence inside a block wrongly rejected as 'Cannot redeclare block-scoped variable' (#1389 residual)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: codegen
+language_feature: hoisting, block-scope, var-function-coexistence
+goal: spec-completeness
+test262_category: language/block-scope, language/expressions/dynamic-import
+related: [1389]
+---
+
+# #3047 — block-nested `var` + function-declaration same-name → false "Cannot redeclare" CE
+
+## Source
+
+Fresh default-lane test262 harvest of current main
+(`.test262-cache/test262-current.jsonl`, 2026-07-02 promoted baseline). **31**
+`compile_error` files with the exact message
+`Cannot redeclare block-scoped variable 'X'` (excluding the ~21 that also carry
+the unrelated `import.source(...)` Stage-proposal error).
+
+## Root cause (reproduced on current main, dev-3025)
+
+`#1389` fixed the same-name `var` + function-declaration coexistence at
+**top-level** (sloppy mode legally allows `var f; function f(){}` — both bind the
+same name). But the fix does NOT cover the **block-nested** case:
+
+```ts
+// top-level — OK (fixed by #1389):
+var smoosh; function smoosh() {} smoosh();            // compiles
+
+// inside a block — STILL a false CE:
+if (true) { var smoosh; function smoosh() {} }
+// => CE: Cannot redeclare block-scoped variable 'smoosh'
+```
+
+A `var` hoists to the function/global scope while a block-level function
+declaration (Annex B sloppy semantics) also binds — they legally coexist; the
+compiler's block-scope redeclaration check wrongly treats the pair as a
+lexical (let/const-style) re-declaration and rejects it.
+
+## Sample failing files (31 total; see jsonl for the full set)
+
+- `language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-function-declaration-with-var.js`
+- `language/block-scope/syntax/redeclaration-global/allowed-to-redeclare-var-with-function-declaration.js`
+- `annexB/language/function-code/function-redeclaration-switch.js`
+- `built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T9.js`
+- `language/expressions/dynamic-import/syntax/valid/nested-async-function-script-code-valid.js` (many dynamic-import/syntax/valid twins — the redeclare CE is the primary/blocking error there)
+
+## Suggested approach
+
+Find the block-scope redeclaration diagnostic (grep `Cannot redeclare
+block-scoped variable`) and relax it to allow a `var`-declared name to coexist
+with a same-name **function declaration** (and vice-versa) in sloppy mode,
+mirroring whatever exemption #1389 added for the top-level scope — extend it to
+nested block scopes. Keep rejecting genuine `let`/`const`/class re-declarations.
+
+## Acceptance criteria
+
+- `if (true) { var x; function x(){} }` and the two
+  `language/block-scope/syntax/redeclaration-global/*` files compile.
+- No new false-negatives: real lexical re-declaration (`let x; let x;`,
+  `let x; function x(){}` in a block) still errors.
+- No test262 regression.

--- a/plan/issues/3048-missing-make-getter-callback-import-object-getters.md
+++ b/plan/issues/3048-missing-make-getter-callback-import-object-getters.md
@@ -1,0 +1,64 @@
+---
+id: 3048
+title: "codegen: 'Missing __make_getter_callback import' CE on object-literal getters / computed-property methods (#1027 resurgence, ~22 files)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: codegen
+language_feature: object-literals, accessors, computed-property-names
+goal: spec-completeness
+test262_category: language/expressions/object, language/computed-property-names
+related: [1027, 1239]
+---
+
+# #3048 — Missing `__make_getter_callback` late-import on object-literal getter / computed-method paths
+
+## Source
+
+Fresh default-lane test262 harvest of current main
+(`.test262-cache/test262-current.jsonl`, 2026-07-02). **22** `compile_error`
+files failing with `L#:# Missing __make_getter_callback import`.
+
+## Root cause hypothesis (#1027 resurgence)
+
+`#1027` (done, sprint 40) fixed a *missing `__make_getter_callback` late-import*
+in the PR-#43 accessor paths. The same class of failure has **resurged** on
+current main for a distinct set of object-literal getter / computed-property
+method paths: a code path emits a `call __make_getter_callback` (the accessor /
+method-value closure maker) without first registering the import, so the module
+references an import index that was never added → hard CE at emit/validate time.
+
+This is a **late-import registration miss** (the `*_funcidx_desync` /
+`ensure*-before-emit` family): the import must be registered — and its funcIdx
+resolved by name at emit time — on every path that lowers an object getter or a
+computed-property method value.
+
+## Sample failing files (22 total)
+
+- `language/expressions/object/11.1.5_6-3-1.js` (`o = {get foo(){return 1;}}`)
+- `language/expressions/object/11.1.5-0-1.js`, `11.1.5-0-2.js`, `11.1.5_4-4-b-1.js`
+- `language/computed-property-names/object/method/number.js` (+ `string.js`, `symbol.js`, `super.js`)
+- `language/computed-property-names/to-name-side-effects/object.js`
+- `built-ins/Function/prototype/toString/method-computed-property-name.js`
+
+## Suggested approach
+
+1. Grep `__make_getter_callback` (emit site + the `ensureLateImport`/registration
+   site) and identify which lowering path emits the `call` without the matching
+   registration. The computed-property-method and object-getter arms are the
+   prime suspects (the plain object-getter top-level path already works per
+   #1027, so this is a sibling arm the #1027 fix didn't cover).
+2. Register the import on that arm and resolve its funcIdx **by name at emit /
+   finalize** (never cache an index across an `ensure*` that adds a late import —
+   the funcIdx-shift hazard).
+
+## Acceptance criteria
+
+- The 22 files no longer `compile_error` with the missing-import message.
+- A focused test: `o = { get foo(){return 1;} }` and
+  `({ [Symbol.iterator]() {} })` compile and round-trip.
+- No test262 regression.

--- a/plan/issues/3049-iterator-prototype-helper-methods-not-a-function.md
+++ b/plan/issues/3049-iterator-prototype-helper-methods-not-a-function.md
@@ -1,0 +1,71 @@
+---
+id: 3049
+title: "Iterator.prototype helper methods (map/filter/take/drop/flatMap/…): 'X is not a function' + this-plain-iterator / return-forwarding residual (~27 fails)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: codegen, runtime
+language_feature: iterator-helpers
+goal: spec-completeness
+test262_category: built-ins/Iterator/prototype
+related: [3023]
+---
+
+# #3049 — Iterator.prototype helper methods residual
+
+## Source
+
+Fresh default-lane test262 harvest of current main
+(`.test262-cache/test262-current.jsonl`, 2026-07-02). Of the ~158 fails under
+`built-ins/Iterator/prototype/*`, **27** fail with a codegen/dispatch signature
+(`object is not a function` / `undefined is not a function` /
+`Cannot read properties of null`) rather than a pure assertion — i.e. the helper
+method itself isn't wired, not just a semantic edge.
+
+This is the **Iterator Helpers** surface (Stage-4: `map`/`filter`/`take`/`drop`/
+`flatMap`/`reduce`/`some`/`find`/`every`/`forEach`/`toArray`). Distinct from
+**#3023** (synthesized-iterator `.next` callability + for-of/for-await abrupt
+completion) — this is the built-in `%Iterator.prototype%` helper methods.
+
+## Root-cause hypothesis
+
+The failing subset clusters on:
+- **`this-plain-iterator`** twins across every helper — calling a helper with a
+  plain (non-generator) iterator receiver resolves the helper (or its inner
+  `next`) to a non-function.
+- **`return-is-forwarded` / `exhaustion-does-not-call-return`** — the helper's
+  wrapper iterator must forward/close the underlying iterator's `return`.
+- **`flattens-iterable` / `iterable-to-iterator-fallback`** (flatMap) — GetIterator
+  fallback on the flattened value.
+
+Likely a single root: the helper wrapper's `GetIteratorDirect(O)` / `next`
+resolution off a plain-object iterator receiver (vs a generator) yields
+undefined/non-callable. Verify whether the helpers are registered at all on
+`%Iterator.prototype%` for a non-generator receiver.
+
+## Sample failing files (27 in the codegen subset; ~158 total incl. assertions)
+
+- `built-ins/Iterator/prototype/map/this-plain-iterator.js` (+ filter/drop/find/every twins)
+- `built-ins/Iterator/prototype/drop/return-is-forwarded.js`
+- `built-ins/Iterator/prototype/filter/exhaustion-does-not-call-return.js`
+- `built-ins/Iterator/prototype/flatMap/flattens-iterable.js`, `iterable-to-iterator-fallback.js`
+- `built-ins/Iterator/prototype/Symbol.iterator/return-val.js`
+
+## Suggested approach
+
+Start with one helper (`map`) + its `this-plain-iterator` case; trace how
+`GetIteratorDirect` / the underlying `next` is resolved for a plain-object
+iterator receiver and fix the resolution, then confirm the sibling helpers
+inherit the fix. Coordinate with #3023 so the shared `.next`-callability path
+isn't double-fixed.
+
+## Acceptance criteria
+
+- The 27 codegen-signature files (`this-plain-iterator`, `return-is-forwarded`,
+  `flattens-*`) pass; helper `next`/`return` resolution works on a plain-object
+  iterator.
+- No regression in the generator-receiver helper paths or in #3023.

--- a/plan/issues/3050-generator-throw-through-try-finally-unreachable.md
+++ b/plan/issues/3050-generator-throw-through-try-finally-unreachable.md
@@ -1,0 +1,55 @@
+---
+id: 3050
+title: "GeneratorPrototype.throw() resumption through try/finally / try/catch hits `unreachable` (6 fails)"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+created: 2026-07-05
+task_type: bugfix
+area: codegen
+language_feature: generators, try-finally, abrupt-completion
+goal: spec-completeness
+test262_category: built-ins/GeneratorPrototype/throw
+related: []
+---
+
+# #3050 — generator `.throw()` resumption through try/finally / try/catch → `unreachable`
+
+## Source
+
+Fresh default-lane test262 harvest of current main
+(`.test262-cache/test262-current.jsonl`, 2026-07-02). **6** fails under
+`built-ins/GeneratorPrototype/throw/*` with `error_category: unreachable`
+(`returned # — assert ## at L#: assert.sameValue(unreachable, #, …)` — i.e. the
+generator resumed to a Wasm `unreachable` instead of the correct catch/finally
+target).
+
+## Root-cause hypothesis
+
+Calling `gen.throw(e)` must resume the suspended generator by **injecting the
+exception at the current yield point** and running the try/catch/finally
+resumption from there. The 6 failing files all exercise resumption where the
+`yield` sits inside (or adjacent to) a `try`/`catch`/`finally` block:
+
+- `try-catch-before-try.js`, `try-catch-following-catch.js`, `try-catch-within-catch.js`
+- `try-finally-before-try.js`, `try-finally-following-finally.js`, `try-finally-within-finally.js`
+
+The generator state-machine's throw-resumption path likely doesn't map the
+resume PC / exception into the correct try-region handler table entry when the
+suspension point is before/within/after a catch or finally clause — so control
+falls through to an `unreachable` guard instead of the handler.
+
+## Suggested approach
+
+Trace the generator lowering's `.throw()` entry: how the injected exception is
+routed to the resume point's enclosing try-region. Compare against the working
+`.next()` resumption path. The 6 files are a tight, self-contained matrix
+(before/within/following × catch/finally) — good for TDD.
+
+## Acceptance criteria
+
+- All 6 `GeneratorPrototype/throw/try-{catch,finally}-*` files pass.
+- `.next()` resumption and non-generator try/finally are unaffected.
+- No test262 regression.


### PR DESCRIPTION
Re-harvested the **current-main** test262 failure surface (promoted baseline jsonl, ~74.x%) to refill the dispatchable runway, since the standing queue predates recent conformance gains. Files 4 bounded, developer-scoped buckets — each a coherent shared root cause, ~5-50 files, reproduced/root-caused against current main:

| Issue | Bucket | ~files | Note |
|---|---|---|---|
| **#3047** | block-nested `var x; function x(){}` → false "Cannot redeclare" CE | 31 | #1389 fixed top-level only; block-nested residual (repro'd: `if(true){var x;function x(){}}` still CEs) |
| **#3048** | missing `__make_getter_callback` import (object getters / computed methods) | 22 | #1027 resurgence — late-import registration miss on a sibling arm |
| **#3049** | Iterator.prototype helper methods `this-plain-iterator` / return-forwarding | 27 | "X is not a function"; distinct from #3023 |
| **#3050** | generator `.throw()` through try/finally\|catch → `unreachable` | 6 | tight before/within/following × catch/finally matrix |

IDs reserved via `claim-issue.mjs --allocate` (issue-assignments ref). All `ready`, `sprint: current`, so `sync-current-tasklist` pulls them into the TaskList for cycling devs.

**Not filed (already tracked / senior / deferred), noted for the lead:**
- Array.prototype indexOf/lastIndexOf/slice/concat illegal-cast + OOB (~200) → mostly **#2001** (sparse arrays, ready/**hard**/s64) — candidate to promote to `sprint: current` for a senior.
- Promise resolve/reject-element callability (~45) → **#2614** (current, **blocked**).
- Unicode 16/17 identifier `Invalid character` (~14) → **#832** (Backlog — needs the TS-6 upgrade, infra-gated).
- Function.prototype apply/call null-deref (~42) → likely the K1 inbound-marshalling zone (#3031, senior).
- RegExp.prototype Symbol.replace/Symbol.split coercion (~46) → dev-sized medium bucket; not filed only because `--allocate` was contended/timing out — file list is in the harvest if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS