### PR TITLE
fix(donut): remove leader lines from number labels to arc segments

### DIFF
--- a/website/components/t262-charts.js
+++ b/website/components/t262-charts.js
@@ -239,18 +239,11 @@ class T262Donut extends HTMLElement {
     // (left:50%) so they track the donut when the orbit container is narrower
     // than its 380px design width (i.e. on mobile, min(100%, 380px)).
     const makeOrbitStat = (stat) => {
-      const { value, label, color, angle, radius, id, lp } = stat;
-      const ls = orbitPoint(angle, 126);
-      const dx = lp.x - ls.x;
-      const dy = lp.y - ls.y;
-      const lineLen = Math.max(Math.sqrt(dx * dx + dy * dy) - 34, 0);
+      const { value, label, color, id, lp } = stat;
       const dataAttr = id ? ` data-stat="${id}"` : "";
       const labelDx = lp.x - centerX;
       const labelDy = lp.y - centerY;
-      const lineDx = ls.x - centerX;
-      const lineDy = ls.y - centerY;
       return `
-        <div class="orbit-connector" style="left:50%;top:50%;width:${lineLen}px;transform:translate(${lineDx}px,${lineDy}px) rotate(${angle - 90}deg)"></div>
         <div class="orbit-stat" style="left:50%;top:50%;transform:translate(calc(-50% + ${labelDx}px), calc(-50% + ${labelDy}px))">
           <div class="orbit-value"${dataAttr} style="color:${color}">${id === "pass" ? "0" : Number(value).toLocaleString()}</div>
           <div class="orbit-label">${label}</div>
@@ -384,13 +377,6 @@ class T262Donut extends HTMLElement {
           font-size: 0.78rem;
           letter-spacing: 0.08em;
         }
-        .orbit-connector {
-          position: absolute;
-          height: 1px;
-          background: rgba(255,255,255,0.06);
-          transform-origin: left center;
-          pointer-events: none;
-        }
         .orbit-stat {
           position: absolute;
           display: grid;
@@ -422,7 +408,6 @@ class T262Donut extends HTMLElement {
           .gauge-orbit {
             height: 280px;
           }
-          .orbit-connector,
           .orbit-stat {
             display: none;
           }


### PR DESCRIPTION
The `.orbit-connector` leader lines pointed from each donut stat (the number labels orbiting the ring) to their arc segment, but the anchor offset was visibly off, so they added noise rather than clarity. This removes the connector `div`, its now-dead line-geometry math, and the `.orbit-connector` CSS. Labels still orbit the donut; only the connecting lines are gone.

Shared component, so it applies everywhere the donut renders: landing, blog, conformance report, and the new benchmarks page. `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)