### PR TITLE
fix(#3047): var/function same-name coexistence at var-scope top level

### DIFF
--- a/plan/issues/3047-block-nested-var-function-redeclare-false-ce.md
+++ b/plan/issues/3047-block-nested-var-function-redeclare-false-ce.md
@@ -1,7 +1,9 @@
 ---
 id: 3047
 title: "false CE — `var x; function x(){}` same-name coexistence inside a block wrongly rejected as 'Cannot redeclare block-scoped variable' (#1389 residual)"
-status: ready
+status: done
+assignee: ttraenkler/dev-3047
+completed: 2026-07-05
 sprint: current
 priority: high
 horizon: m
@@ -68,3 +70,48 @@ nested block scopes. Keep rejecting genuine `let`/`const`/class re-declarations.
 - No new false-negatives: real lexical re-declaration (`let x; let x;`,
   `let x; function x(){}` in a block) still errors.
 - No test262 regression.
+
+## Resolution (dev-3047, 2026-07-05)
+
+The harvest's hypothesis (a *block-nested* redeclaration bug, and that
+`if (true) { var x; function x(){} }` should compile) was **partly incorrect**.
+Verified against V8/Node:
+
+- `var f; function f(){}` at **Script / function-body top level** → **legal**
+  (a FunctionDeclaration is VAR-scoped there — `TopLevelLexicallyDeclaredNames`
+  excludes HoistableDeclarations).
+- `{ var f; function f(){} }` in a **genuine nested Block** (incl. `if`/`for`/
+  `try` blocks) → **SyntaxError in BOTH strict and sloppy mode**. Annex B relaxes
+  only the *duplicate-FunctionDeclaration* rule (B.3.3.5), never lexical-vs-var.
+  test262 carries **negative** parse tests for exactly this
+  (`language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-function.js`
+  et al.), so it must keep erroring.
+
+**True root cause of the ~50 harvested false CEs:** the test262 harness
+(`wrapTest`) places every test body inside `try { ... }`. A `try` block is a
+genuine nested Block, so a legal top-level `var f; function f(){}` becomes
+`try { var f; function f(){} }` — a real SyntaxError. Two complementary fixes:
+
+1. **Compiler** (`src/compiler/early-errors/duplicates.ts`,
+   `checkVarLexicalConflicts`): a FunctionDeclaration is treated as lexical
+   (var-conflicting) only inside a *genuine nested Block statement* — not at
+   SourceFile scope nor at a **function-body** top level (new
+   `isFunctionBodyBlock` predicate). Genuine nested-block cases still error.
+
+2. **Harness** (`tests/test262-runner.ts`, `wrapTest`): when a body's top-level
+   statements bind the same name as both a `var` and a `function`, hoist that
+   function declaration out of the `try` to the `test()` body top level
+   (functions hoist → runtime byte-preserved). Guarded strictly to the
+   coexistence pattern (byte-identical for every other test); equal-line padding
+   preserves error-line citations.
+
+**Recovers 50/52** harvested `Cannot redeclare block-scoped variable` files. The
+2 remaining are distinct root causes (out of scope, follow-ups):
+`language/statements/let/syntax/escaped-let.js` (escaped-`let` keyword parse) and
+`annexB/language/function-code/function-redeclaration-switch.js` (duplicate
+functions across switch clauses, blocked by a TS `Duplicate function
+implementation` checker diagnostic, not our early-error).
+
+Tests: `tests/issue-3047.test.ts` (12 cases — both fixes + nested-block
+regression guards). All acceptance-criteria negative cases (`let x; let x;`,
+`let x; function x(){}` in a block) still error.

--- a/src/compiler/early-errors/duplicates.ts
+++ b/src/compiler/early-errors/duplicates.ts
@@ -261,8 +261,45 @@ export function checkDuplicatePrivateNames(
   }
 }
 
+/**
+ * True when `block` is the *body* of a function-like node (function
+ * declaration/expression, arrow, method, constructor, or accessor).
+ *
+ * At the top level of such a body — exactly as at SourceFile (Script/Module)
+ * scope — a FunctionDeclaration is VAR-scoped, not lexical: the top-level
+ * statement list uses TopLevelLexicallyDeclaredNames, which excludes
+ * HoistableDeclarations (ES §15.2.2 / FunctionBody §10.2.11). So a same-name
+ * `var` and function declaration legally coexist there
+ * (`function test(){ var f; function f(){} }` is valid, matching V8).
+ *
+ * Only inside a *genuine nested Block statement* (parent is a statement — if /
+ * for / while / labeled / a `{ }` block, etc.) is a FunctionDeclaration
+ * lexically scoped (ES §14.2.1), where `{ var f; function f(){} }` IS a
+ * SyntaxError in both strict and sloppy mode — Annex B relaxes only the
+ * duplicate-FunctionDeclaration rule, never lexical-vs-var.
+ */
+function isFunctionBodyBlock(block: ts.Block | ts.SourceFile): boolean {
+  if (!ts.isBlock(block)) return false;
+  const parent = block.parent;
+  return (
+    !!parent &&
+    (ts.isFunctionDeclaration(parent) ||
+      ts.isFunctionExpression(parent) ||
+      ts.isArrowFunction(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isConstructorDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent))
+  );
+}
+
 /** Check for var/lexical declaration conflicts in a block or source file. */
 export function checkVarLexicalConflicts(ctx: EarlyErrorContext, block: ts.Block | ts.SourceFile): void {
+  // A FunctionDeclaration contributes a lexical binding (that a same-name `var`
+  // conflicts with) only inside a genuine nested Block statement — not at
+  // SourceFile scope nor at the top level of a function body, where it is
+  // var-scoped. See isFunctionBodyBlock.
+  const functionsAreLexical = ts.isBlock(block) && !isFunctionBodyBlock(block);
   // Collect lexically-declared names (let, const, function, class)
   const lexicalNames = new Set<string>();
   for (const stmt of block.statements) {
@@ -276,10 +313,12 @@ export function checkVarLexicalConflicts(ctx: EarlyErrorContext, block: ts.Block
         }
       }
     } else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
-      // At SourceFile scope, function declarations are var-scoped — no conflict with var
-      // (LexicallyDeclaredNames does not include VarDeclaredNames per ES §13.1.1).
-      // Only inside a Block are function declarations lexically scoped (ES §B.3.2).
-      if (ts.isBlock(block)) {
+      // At SourceFile scope AND at the top level of a function body, function
+      // declarations are var-scoped — no conflict with a same-name var
+      // (TopLevelLexicallyDeclaredNames excludes HoistableDeclarations,
+      // ES §15.2.2 / §10.2.11). Only inside a genuine nested Block are they
+      // lexically scoped (ES §14.2.1 + §B.3.2).
+      if (functionsAreLexical) {
         lexicalNames.add(stmt.name.text);
       }
     } else if (ts.isClassDeclaration(stmt) && stmt.name) {

--- a/tests/issue-3047.test.ts
+++ b/tests/issue-3047.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3047 — `var X; function X(){}` same-name coexistence must NOT be rejected as
+// "Cannot redeclare block-scoped variable" at Script / function-body top level.
+//
+// Two root causes were fixed:
+//   1. Compiler (`checkVarLexicalConflicts`): a FunctionDeclaration at the top
+//      level of a *function body* is VAR-scoped (TopLevelLexicallyDeclaredNames
+//      excludes HoistableDeclarations), exactly like at SourceFile scope — so a
+//      same-name `var` coexists with it. Previously any `ts.Block` (incl. a
+//      function body) treated the function as lexical → false CE.
+//   2. Harness (`wrapTest`): every test body is placed inside `try { ... }`; a
+//      *genuine nested Block* makes the function lexical, so top-level
+//      `var f; function f(){}` wrapped as `try { var f; function f(){} }`
+//      becomes a real SyntaxError (V8 agrees). The wrapper now hoists such a
+//      coexisting function declaration out of the `try` to the test() body top
+//      level, restoring the legal script scope.
+//
+// Genuine nested-block redeclarations (`{ var f; function f(){} }`, `{ let x;
+// function x(){} }`, `{ var f; { var f } }` with a lexical `f`) MUST still be
+// rejected — Annex B relaxes only the duplicate-FunctionDeclaration rule, never
+// lexical-vs-var. test262 carries negative (parse SyntaxError) tests for these.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapTest, parseMeta } from "./test262-runner.js";
+
+const REDECLARE = "Cannot redeclare block-scoped variable";
+
+async function errorMessages(source: string): Promise<string[]> {
+  const r = await compile(source, { fileName: "test.ts" });
+  return (r.errors ?? []).map((e) => e.message);
+}
+
+function hasRedeclareCE(msgs: string[]): boolean {
+  return msgs.some((m) => m.includes(REDECLARE));
+}
+
+describe("#3047 — var/function same-name coexistence at var-scope top level", () => {
+  it("does NOT emit a redeclare CE for `var f; function f(){}` at function-body top level", async () => {
+    const msgs = await errorMessages(`
+      function outer(): number {
+        var f;
+        function f() { return 7; }
+        return 1;
+      }
+    `);
+    expect(hasRedeclareCE(msgs)).toBe(false);
+  });
+
+  it("does NOT emit a redeclare CE for the reverse order (`function f(){} var f;`)", async () => {
+    const msgs = await errorMessages(`
+      function outer(): number {
+        function f() { return 7; }
+        var f;
+        return 1;
+      }
+    `);
+    expect(hasRedeclareCE(msgs)).toBe(false);
+  });
+
+  it("does NOT emit a redeclare CE inside a method body", async () => {
+    const msgs = await errorMessages(`
+      class C {
+        m(): number {
+          var x;
+          function x() { return 1; }
+          return 1;
+        }
+      }
+    `);
+    expect(hasRedeclareCE(msgs)).toBe(false);
+  });
+
+  it("does NOT emit a redeclare CE inside an arrow-function body", async () => {
+    const msgs = await errorMessages(`
+      const a = (): number => {
+        var x;
+        function x() { return 1; }
+        return 1;
+      };
+    `);
+    expect(hasRedeclareCE(msgs)).toBe(false);
+  });
+
+  it("still compiles `var f; function f(){}` at Script (SourceFile) top level", async () => {
+    const msgs = await errorMessages(`var f; function f() {} f();`);
+    expect(hasRedeclareCE(msgs)).toBe(false);
+  });
+
+  // ── Regression guards: genuine nested-block redeclarations MUST still error ──
+
+  it("STILL rejects `{ var f; function f(){} }` in a genuine nested block", async () => {
+    const msgs = await errorMessages(`{ var f; function f() {} }`);
+    expect(hasRedeclareCE(msgs)).toBe(true);
+  });
+
+  it("STILL rejects the reverse `{ function f(){} var f; }` in a nested block", async () => {
+    const msgs = await errorMessages(`{ function f() {} var f; }`);
+    expect(hasRedeclareCE(msgs)).toBe(true);
+  });
+
+  it("STILL rejects `if (true) { var f; function f(){} }`", async () => {
+    const msgs = await errorMessages(`if (true) { var f; function f() {} }`);
+    expect(hasRedeclareCE(msgs)).toBe(true);
+  });
+
+  it("STILL rejects an inner-block var against an outer-block function", async () => {
+    const msgs = await errorMessages(`{ function f() {} { var f; } }`);
+    expect(hasRedeclareCE(msgs)).toBe(true);
+  });
+
+  it("STILL rejects a genuine let/var conflict in a nested block", async () => {
+    const msgs = await errorMessages(`{ let x; { var x; } }`);
+    // any lexical-vs-var diagnostic is acceptable here; it must NOT silently compile
+    const r = await compile(`{ let x; { var x; } }`, { fileName: "test.ts" });
+    expect(r.success).toBe(false);
+    void msgs;
+  });
+});
+
+describe("#3047 — test262 harness hoists a coexisting top-level function out of try{}", () => {
+  it("removes the redeclare CE for a synthetic `var f; function f(){}` top-level test", async () => {
+    const src = `/*---\ndescription: var/function coexistence\n---*/\nvar f;\nfunction f() {}\n`;
+    const w = wrapTest(src, parseMeta(src));
+    const wrapped = typeof w === "string" ? w : w.source;
+    expect(wrapped).toContain("#3047: function declaration hoisted");
+    const msgs = await errorMessages(wrapped);
+    expect(hasRedeclareCE(msgs)).toBe(false);
+  });
+
+  it("leaves a body WITHOUT the coexistence pattern byte-unchanged (no hoist marker)", async () => {
+    const src = `/*---\ndescription: plain\n---*/\nvar a = 1;\nfunction g() { return a; }\nassert.sameValue(g(), 1);\n`;
+    const w = wrapTest(src, parseMeta(src));
+    const wrapped = typeof w === "string" ? w : w.source;
+    // `g` has no coexisting `var g`, so nothing is hoisted.
+    expect(wrapped).not.toContain("#3047: function declaration hoisted");
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -14,6 +14,7 @@ import { createHash } from "crypto";
 import { createContext, runInContext } from "node:vm";
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
+import { ts } from "../src/ts-api.js";
 
 // #1310: per-shard global isolation for test262.
 //
@@ -2654,12 +2655,70 @@ export function test(): number {
   const isAsyncTest = resolvedMeta.flags?.includes("async") || needsAsyncTest;
   const asyncDrainDecl = isAsyncTest ? `declare function __drain_microtasks(): void;\n` : "";
   const asyncDrainCall = isAsyncTest ? `  __drain_microtasks();\n` : "";
+
+  // (#3047) Sloppy/top-level `var X` + `function X(){}` coexistence.
+  //
+  // At Script / function-body top level a FunctionDeclaration is VAR-scoped
+  // (TopLevelLexicallyDeclaredNames excludes HoistableDeclarations), so a
+  // same-name `var` and function declaration legally coexist there — e.g.
+  // `var f; function f(){}` is valid in V8. But this wrapper places the test
+  // body inside `try { ... }`, and a *nested Block* makes the function
+  // *lexically* scoped, so `try { var f; function f(){} }` becomes a genuine
+  // SyntaxError (V8 agrees). That mis-wrapping was reported as ~50 false
+  // `Cannot redeclare block-scoped variable` compile errors (dynamic-import
+  // /syntax/valid, redeclaration-global, RegExp exec/test, S13*/S10* fn tests).
+  //
+  // Fix: when a body's TOP-LEVEL statements bind the same name as both a `var`
+  // and a `function`, hoist that function declaration out of the `try` to the
+  // `test()` body top level. FunctionDeclarations hoist, so runtime semantics
+  // are byte-preserved, and the function regains its legal function-body-top-
+  // level (var) scope. Guarded strictly to the coexistence pattern, so every
+  // other test is emitted unchanged. Line positions of the remaining body are
+  // preserved by replacing each hoisted declaration with an equal-line comment.
+  let hoistedFns = "";
+  try {
+    const bodySf = ts.createSourceFile("__body.ts", bodyForFunc, ts.ScriptTarget.Latest, /*setParentNodes*/ false);
+    const topLevelVarNames = new Set<string>();
+    const topLevelFnDecls: { name: string; start: number; end: number }[] = [];
+    for (const stmt of bodySf.statements) {
+      if (ts.isVariableStatement(stmt)) {
+        const flags = stmt.declarationList.flags;
+        if ((flags & ts.NodeFlags.Let) === 0 && (flags & ts.NodeFlags.Const) === 0) {
+          for (const decl of stmt.declarationList.declarations) {
+            if (ts.isIdentifier(decl.name)) topLevelVarNames.add(decl.name.text);
+          }
+        }
+      } else if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) {
+        topLevelFnDecls.push({ name: stmt.name.text, start: stmt.getStart(bodySf), end: stmt.end });
+      }
+    }
+    const toHoist = topLevelFnDecls.filter((f) => topLevelVarNames.has(f.name));
+    if (toHoist.length > 0) {
+      const hoisted: string[] = [];
+      // Splice out in reverse so earlier offsets stay valid.
+      let patched = bodyForFunc;
+      for (const f of [...toHoist].sort((a, b) => b.start - a.start)) {
+        const text = patched.slice(f.start, f.end);
+        hoisted.unshift(text);
+        const newlineCount = text.split("\n").length - 1;
+        const pad = "/* #3047: function declaration hoisted to test() body top level */" + "\n".repeat(newlineCount);
+        patched = patched.slice(0, f.start) + pad + patched.slice(f.end);
+      }
+      bodyForFunc = patched;
+      hoistedFns = hoisted.join("\n") + "\n";
+    }
+  } catch {
+    // Defensive: if the body cannot be parsed standalone, skip the hoist and
+    // emit the body unchanged (byte-identical to pre-#3047 behavior).
+    hoistedFns = "";
+  }
+
   const preBody = `${strictDirective}
 ${hoistedImports}${asyncDrainDecl}${preamble}
 ${hoistedDecls}
 export function test(): number {
   ${implicitDecls}
-  try {
+  ${hoistedFns}try {
     `;
   const postBody = `
   } catch (e) {


### PR DESCRIPTION
## Problem

#3047 (harvest of ~52 test262 files) reported false `Cannot redeclare
block-scoped variable 'X'` compile errors for `var X; function X(){}`
same-name coexistence.

## Root cause (corrected from the harvest hypothesis)

The harvest hypothesized a *block-nested* redeclaration bug. Verified against
V8/Node, that's only partly right:

- `var f; function f(){}` at **Script / function-body top level** → **legal**
  (a FunctionDeclaration is VAR-scoped there — `TopLevelLexicallyDeclaredNames`
  excludes HoistableDeclarations).
- `{ var f; function f(){} }` in a **genuine nested Block** (incl. `if`/`for`/
  `try`) → **SyntaxError in both strict and sloppy mode**. Annex B relaxes only
  the *duplicate-FunctionDeclaration* rule, never lexical-vs-var. test262 has
  **negative** parse tests for this, so it must keep erroring.

The ~50 false CEs actually came from the **test262 harness**: `wrapTest` places
every body inside `try { ... }`, and a nested Block makes a top-level function
lexical — so legal `var f; function f(){}` becomes `try { var f; function f(){} }`,
a real SyntaxError.

## Fix (two complementary changes)

1. **Compiler** — `src/compiler/early-errors/duplicates.ts`
   (`checkVarLexicalConflicts`): a FunctionDeclaration is treated as lexical
   (var-conflicting) only inside a *genuine nested Block statement* — not at
   SourceFile scope nor at a **function-body** top level (new
   `isFunctionBodyBlock` predicate). Genuine nested-block redeclarations still
   error.

2. **Harness** — `tests/test262-runner.ts` (`wrapTest`): when a body's
   top-level statements bind the same name as both a `var` and a `function`,
   hoist that function declaration out of the `try` to the `test()` body top
   level (functions hoist → runtime byte-preserved). **Guarded strictly** to the
   coexistence pattern, so every other test is emitted byte-identically;
   equal-line padding preserves error-line citations.

## Impact

- Recovers **50/52** harvested `Cannot redeclare block-scoped variable` files.
  The 2 remaining are distinct root causes (follow-ups): `escaped-let.js`
  (escaped-`let` parse) and `function-redeclaration-switch.js` (switch-clause
  duplicate functions, blocked by a TS checker diagnostic).
- Byte-inert for valid non-matching programs (harness hoist triggered 0× on a
  940-file sample; only the falsely-rejected programs newly compile).

## Validation

- `tests/issue-3047.test.ts` — 12 cases (both fixes + nested-block regression
  guards). All pass.
- Existing early-error/scope/hoisting suites (`var-hoisting`,
  `scope-and-error-handling`, `issue-2200-annexb-block-fn-hoist`,
  `finally-duplicate`, `issue-2705`) — 29 pass.
- Negative redeclaration tests (`{ var f; function f(){} }`, `let x; function
  x(){}` in a block, etc.) still compile-error.
- `tsc --noEmit`, `prettier --check`, `biome lint` all clean.

Closes #3047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS