### PR TITLE
fix(#3046): bind JSON.parse reviver this to the holder

### DIFF
--- a/plan/issues/3046-json-parse-reviver-this-binding.md
+++ b/plan/issues/3046-json-parse-reviver-this-binding.md
@@ -1,12 +1,14 @@
 ---
 id: 3046
 title: "JSON.parse reviver: `this` is not bound to the holder object (Object.defineProperty(this,…) in a reviver throws called-on-non-object)"
-status: ready
+status: done
 sprint: current
 priority: medium
 horizon: s
 feasibility: medium
 created: 2026-07-05
+completed: 2026-07-05
+assignee: ttraenkler/dev-3042
 task_type: bugfix
 area: runtime
 language_feature: json-parse
@@ -57,3 +59,39 @@ on the holder must observe the descriptor tombstone semantics (see #2726 c/d).
 ## Acceptance
 
 - The 4 reviver tests pass; `this` inside a reviver is the holder. Scope: **DEV**.
+
+## Resolution (2026-07-05, dev-3042)
+
+**Root cause.** A JSON.parse reviver that reads `this` was wrapped via the bare
+`__make_callback` bridge — an arrow that drops the JS receiver. The reviver body
+reads `this` from the `__current_this` module global, which nothing installs on
+that path, so `this` was a non-object and any `this.`-op
+(`Object.defineProperty(this,…)`, `this[k]`) threw "called on non-object".
+The runtime's `_invokeJsonCallable` already applies the holder as the JS
+receiver (`fn.apply(holder, …)`); the gap was purely codegen — the reviver
+needed the `this`-forwarding `__make_getter_callback` bridge (which the
+accessor path already uses).
+
+**Fix (two coordinated changes).**
+- `src/codegen/closures.ts` — `compileArrowFunction` passes `needsThis` for the
+  2nd argument of a `JSON.parse(...)` call whose body references `this`
+  (new `isJsonReviverArgument` + exported `functionBodyReferencesThis`,
+  gated so ordinary callbacks — `map`/`forEach` etc. — are untouched). This
+  routes the reviver through `__make_getter_callback`, so the host forwards
+  `holder` as the receiver and the `__cb` body binds `this` to it.
+- `src/codegen/declarations.ts` — the collect pre-pass registers the
+  `__make_getter_callback` import for such revivers. Without this the needsThis
+  emit referenced an unregistered import, leaving the reviver **silently
+  non-callable** (JSON.parse returned unfiltered) — a false pass that still
+  satisfied the 4 acceptance tests because they assert the *original* values.
+  The pre-pass wiring makes the reviver genuinely run.
+
+**Impact.** +8 `built-ins/JSON/parse` reviver rows flip to pass — the 4
+non-configurable create/delete acceptance tests plus
+`reviver-{array,object}-get-prop-from-prototype`, `reviver-object-own-keys-err`,
+`revived-proxy-revoked`. **0 regressions** across the JSON/parse suite.
+Correctness confirmed with `assertEquivalent` (wasm output matches native JS:
+`this.length` / `this[k]` observable inside the reviver, and reviver return
+values applied), not just test262 value-assertions.
+
+Tests: `tests/issue-3046.test.ts`.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1712,6 +1712,62 @@ function genBodyReferencesThis(node: ts.Node): boolean {
   return found;
 }
 
+/**
+ * (#3046) True when `node` is the **reviver** argument (2nd arg) of a
+ * `JSON.parse(text, reviver)` call. Per ECMA-262 §25.5.1.1
+ * `InternalizeJSONProperty`, the reviver is invoked as
+ * `Call(reviver, holder, «name, val»)` — `this` MUST be the holder. The host
+ * `JSON_parse` / `_invokeJsonCallable` bridge applies the holder as the JS
+ * receiver, so the reviver callback must route through the `this`-forwarding
+ * `__make_getter_callback` maker (needsThis) rather than the bare
+ * `__make_callback`, which drops the receiver and leaves `this` non-object
+ * (a `this.`-op such as `Object.defineProperty(this, …)` then throws
+ * "called on non-object").
+ */
+function isJsonReviverArgument(node: ts.Node): boolean {
+  const parent = node.parent;
+  if (!parent || !ts.isCallExpression(parent)) return false;
+  if (parent.arguments[1] !== node) return false; // must be the 2nd arg
+  const callee = parent.expression;
+  return (
+    ts.isPropertyAccessExpression(callee) &&
+    ts.isIdentifier(callee.expression) &&
+    callee.expression.text === "JSON" &&
+    callee.name.text === "parse"
+  );
+}
+
+/**
+ * (#3046) True when the function-expression / arrow `fn` references `this`
+ * from ITS OWN scope: descend through nested arrows (they inherit `fn`'s
+ * `this`), but stop at nested function expressions / declarations / methods /
+ * classes (they rebind `this`). Used to gate the reviver `this`-forwarding so
+ * a reviver that never touches `this` keeps the unchanged `__make_callback`
+ * path (zero-risk), and only `this`-using revivers take the getter-callback
+ * bridge.
+ */
+export function functionBodyReferencesThis(fn: ts.ArrowFunction | ts.FunctionExpression): boolean {
+  const walk = (node: ts.Node): boolean => {
+    if (node.kind === ts.SyntaxKind.ThisKeyword) return true;
+    if (
+      ts.isFunctionExpression(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isAccessor(node) ||
+      ts.isClassLike(node)
+    ) {
+      return false; // own `this` binding — does not inherit fn's receiver
+    }
+    let found = false;
+    forEachChild(node, (child) => {
+      if (!found && walk(child)) found = true;
+    });
+    return found;
+  };
+  // Inspect the body only (not `fn` itself, which is a function boundary).
+  return walk(fn.body);
+}
+
 export function compileArrowFunction(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1720,7 +1776,11 @@ export function compileArrowFunction(
   // If used as callback argument to a host call, use the __make_callback path
   if (isHostCallbackArgument(arrow, ctx)) {
     const deferredInvocation = isDeferredCallbackArgument(arrow, ctx);
-    return compileArrowAsCallback(ctx, fctx, arrow, { deferredInvocation });
+    // (#3046) A JSON.parse reviver that reads `this` must have the holder
+    // forwarded as its receiver (§25.5.1.1). Route it through the
+    // `this`-forwarding `__make_getter_callback` bridge.
+    const needsThis = isJsonReviverArgument(arrow) && functionBodyReferencesThis(arrow);
+    return compileArrowAsCallback(ctx, fctx, arrow, { deferredInvocation, needsThis });
   }
   // Otherwise, compile as a first-class closure value
   return compileArrowAsClosure(ctx, fctx, arrow);

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -23,7 +23,12 @@ import { ensureWrapperTypes } from "./any-helpers.js";
 import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps } from "./async-cps.js";
 import { asyncFnNeedsHostDrive } from "./async-frame.js";
 import { collectClassDeclaration, compileClassBodies } from "./class-bodies.js";
-import { collectBindingPatternNames, collectReferencedIdentifiers, emitCachedFuncClosureAccess } from "./closures.js";
+import {
+  collectBindingPatternNames,
+  collectReferencedIdentifiers,
+  emitCachedFuncClosureAccess,
+  functionBodyReferencesThis,
+} from "./closures.js";
 import { addFunctionOwnLocals } from "./binding-info.js"; // (#2103) memoized own-locals oracle
 import { reportError } from "./context/errors.js";
 import type { CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
@@ -916,6 +921,27 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
             }
           }
         }
+      }
+    }
+  }
+  // ── getterCallbackFound: JSON.parse(text, reviver) reviver that reads `this` (#3046) ──
+  // §25.5.1.1 InternalizeJSONProperty invokes the reviver with the holder as
+  // `this`. A reviver that touches `this` must route through the
+  // `this`-forwarding `__make_getter_callback` bridge (see
+  // `compileArrowFunction` in closures.ts). Register the import here so the
+  // needsThis emit at the call site has it available.
+  if (!state.getterCallbackFound && ts.isCallExpression(node)) {
+    const callee = node.expression;
+    if (
+      ts.isPropertyAccessExpression(callee) &&
+      ts.isIdentifier(callee.expression) &&
+      callee.expression.text === "JSON" &&
+      callee.name.text === "parse" &&
+      node.arguments.length >= 2
+    ) {
+      const reviver = node.arguments[1]!;
+      if ((ts.isFunctionExpression(reviver) || ts.isArrowFunction(reviver)) && functionBodyReferencesThis(reviver)) {
+        state.getterCallbackFound = true;
       }
     }
   }

--- a/tests/issue-3046.test.ts
+++ b/tests/issue-3046.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+// #3046 — JSON.parse reviver `this`-binding to the holder.
+//
+// Per ECMA-262 §25.5.1.1 InternalizeJSONProperty, the reviver is invoked as
+// Call(reviver, holder, «name, val») — `this` inside the reviver MUST be the
+// holder object/array. The reviver callback was wrapped via the bare
+// `__make_callback` bridge (arrow, drops the receiver), so `this` read a
+// non-object and any `this.`-op (e.g. `Object.defineProperty(this, …)`) threw
+// "called on non-object". A `this`-using reviver now routes through the
+// `this`-forwarding `__make_getter_callback` bridge (needsThis), gated to
+// JSON.parse's 2nd argument so ordinary callbacks are untouched.
+describe("#3046 JSON.parse reviver this-binding to holder", () => {
+  it("this is the holder array (this.length observable)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        var r: any = JSON.parse('[10,20]', function (k: any, v: any): any {
+          if (k === '0') return (this as any).length; // holder is [10,20] → 2
+          return v;
+        });
+        return r[0] + r[1]; // 2 + 20 = 22
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("Object.defineProperty(this, …) in a reviver does not throw (array holder)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        var arr: any = JSON.parse('[1,2]', function (k: any, v: any): any {
+          if (k === '0') {
+            Object.defineProperty(this, '1', { configurable: false });
+          }
+          if (k === '1') return 22;
+          return v;
+        });
+        // '1' made non-configurable at key '0'; the later CreateDataProperty(22)
+        // fails silently ⇒ arr[1] stays 2.
+        return arr[0] * 10 + arr[1]; // 12
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("this is the holder object (this[key] readable inside reviver)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        var r: any = JSON.parse('{"a":3,"b":4}', function (k: any, v: any): any {
+          if (k === 'a') {
+            // holder has both own keys at reviver time; read a sibling via this
+            return (this as any).b + v; // 4 + 3 = 7
+          }
+          return v;
+        });
+        return r.a + r.b; // 7 + 4 = 11
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("reviver without `this` is unchanged (value transform still routes normally)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        var r: any = JSON.parse('[1,2,3]', function (k: any, v: any): any {
+          return typeof v === 'number' ? v + 1 : v;
+        });
+        return r[0] + r[1] + r[2]; // 2 + 3 + 4 = 9
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the JSON.parse-reviver `this`-binding half of #3022's "called on non-object" cluster (#3046, dev-scoped).

Per ECMA-262 §25.5.1.1 `InternalizeJSONProperty`, the reviver is invoked as `Call(reviver, holder, «name, val»)` — `this` MUST be the holder. The reviver was wrapped via the bare `__make_callback` bridge (an arrow that drops the receiver), so its body read `this` from an unset `__current_this` ⇒ a non-object, and any `this.`-op (`Object.defineProperty(this, …)`, `this[k]`) threw "called on non-object".

## Fix (two coordinated changes)

- **`src/codegen/closures.ts`** — `compileArrowFunction` passes `needsThis` for the 2nd arg of a `JSON.parse(...)` call whose body references `this` (new `isJsonReviverArgument` + exported `functionBodyReferencesThis`; gated so ordinary `map`/`forEach` callbacks are untouched). This routes the reviver through the `this`-forwarding `__make_getter_callback` bridge — the runtime's `_invokeJsonCallable` already applies the holder as the JS receiver, so `this` now binds to it.
- **`src/codegen/declarations.ts`** — the collect pre-pass registers the `__make_getter_callback` import for such revivers. Without it the `needsThis` emit referenced an unregistered import, leaving the reviver **silently non-callable** (JSON.parse returned unfiltered) — a false pass the 4 value-assertion tests would have masked. The pre-pass wiring makes the reviver genuinely run.

## Validation

- **+8** `built-ins/JSON/parse` reviver rows flip to pass (57→65): the 4 non-configurable create/delete acceptance tests + `reviver-{array,object}-get-prop-from-prototype` + `reviver-object-own-keys-err` + `revived-proxy-revoked`.
- **0 regressions** across the full JSON/parse suite (clean-vs-fix diff: no new failures).
- Correctness confirmed by `assertEquivalent` (wasm output matches native JS): `this.length` / `this[k]` observable inside the reviver, and reviver return values applied — not just test262 value-assertions. New `tests/issue-3046.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS