### PR TITLE
fix(#3051): host-wrap RegExp exec-override result for @@replace/@@split coercion

### DIFF
--- a/plan/issues/3051-regexp-symbol-replace-split-coercion-protocol.md
+++ b/plan/issues/3051-regexp-symbol-replace-split-coercion-protocol.md
@@ -1,7 +1,8 @@
 ---
 id: 3051
 title: "RegExp.prototype[@@replace] / [@@split] coercion protocol: ToString/ToInteger/ToLength on result-array + lastIndex/limit/flags args (~48 fails)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-3051
 sprint: current
 priority: medium
 horizon: m
@@ -64,7 +65,7 @@ boxed Number must be `ToIntegerOrInfinity`'d).
   a value that must coerce, not trap).
 - `@@replace` `coerce-lastindex` / `g-pos-increment|decrement` — after a
   zero-length match with `global`, `lastIndex` is `? ToLength(? Get(rx,
-  "lastIndex"))` then `AdvanceStringIndex`.
+"lastIndex"))` then `AdvanceStringIndex`.
 - `@@split` `coerce-limit-err` / `toint32-limit-recompiles-source` — `limit` is
   `? ToUint32(limit)`; `limit-0-bail` — a `0` limit returns `[]` immediately.
 - `@@split` `coerce-flags` / `str-coerce-lastindex` / `str-get-lastindex-err` /
@@ -111,3 +112,69 @@ Net-positive slices; verify no regression in the passing
   `Symbol.replace` and `Symbol.split` files pass (materially below the 48
   recorded here).
 - No regression in currently-passing `RegExp`/`String` replace/split tests.
+
+## Landed Slice 1 (dev-3051) — result-array coercion via exec-return host-wrap
+
+**PR: exec-override result-object host-wrapping** (`src/runtime.ts`,
+`tests/issue-3051.test.ts`). Root cause found by regrounding: in the default
+(JS-host) lane, `re[Symbol.replace/split/match/search](...)` is delegated to the
+**native V8** protocol via the `__regex_symbol_call` host import. When a test
+overrides `regexp.exec = fn` (the bulk of the `result-*` cluster), the compiled
+`fn` returns a **compiled object literal** used as the match result. Object
+literals are opaque WasmGC structs, so when V8's native protocol did
+`Get(result, "0" | "index" | "length" | "groups")` on the returned struct it
+read `undefined` — the spec `ToString` / `ToIntegerOrInfinity` / `ToLength`
+coercions (and nested `valueOf`/`toString` on capture/index sub-objects) never
+ran. Fix: when `regexp.exec = fn` is stored (the `extern_set` / `extern_set_strict`
+host bindings, guarded on `key === "exec" && obj instanceof RegExp`), wrap `fn`'s
+**return value** in `_wrapForHost` (`_wrapExecReturnForHost`) so the native
+protocol observes the struct's fields and dispatches the nested closures.
+Arrays / non-struct returns pass through unchanged. Covers @@replace, @@split,
+@@match, @@search (all read exec's result the same way).
+
+**Impact (local default-lane, measured):**
+
+- `Symbol.replace`: 39 → 54 pass (**+15**); `Symbol.split`: 28 → 28 (unchanged).
+- Newly passing: `result-coerce-{index,index-undefined,matched,matched-global,capture,length,groups}` and their `-err` twins where the throw was already in the coercion arm, plus `coerce-lastindex`, `g-pos-increment`, `g-pos-decrement`.
+- No in-corpus regressions; `issue-1329-b3` / `issue-2161` still green. (`issue-682`'s 4 failures are **pre-existing** on `origin/main`, unrelated — standalone refusal tests.)
+
+## Remaining Work (Slice 2+ — several senior-depth)
+
+Not addressed by Slice 1 (still ~30 default-lane fails). Distinct mechanisms:
+
+1. **`result-*-err` abrupt-throw propagation** (`result-get-{index,length,matched}-err`,
+   `result-get-groups-prop-err`, `result-coerce-groups-err`): the result object
+   has a **throwing getter** (`get index(){ throw new Test262Error() }`). V8 reads
+   it through the `_wrapForHost` proxy → invokes the wasm getter closure → the
+   wasm `throw` must surface as a JS exception V8 propagates back to the user's
+   `try/catch`. Wasm-exception → host → user-catch bridging across the native
+   protocol is **senior-depth**.
+2. **replaceValue `ToString` (`arg-2-coerce{,-err}`)**: `re[@@replace](s, obj)`
+   where `obj` is a non-callable struct with `toString`. `__regex_symbol_call`'s
+   `wrapCallable(arg1)` wraps it via `_wrapForHost`, but `ToString(proxy)` returns
+   `"null"` instead of the struct's `toString` result — the `wrapCallable` /
+   `_wrapForHost` `toString`-field dispatch drops the value. Needs deeper look at
+   the non-closure-struct arm of `wrapCallable`.
+3. **`Cannot convert a Symbol value to a number` (`coerce-global`, `coerce-unicode`)**:
+   the test does `Object.defineProperty(r,'global',{writable:true}); r.global = Symbol.replace`
+   (and `= {}`, `= NaN`, …). Assigning arbitrary values to the **typed** `.global`/
+   `.unicode` boolean property makes codegen coerce the RHS Symbol → number →
+   throw. Static-type-coercion / property-write issue in codegen, not the protocol.
+4. **`Cannot convert object to primitive value` (@@split cluster:** `coerce-flags`,
+   `limit-0-bail`, `str-coerce-lastindex`, `str-result-coerce-length`,
+   `str-set-lastindex-{match,no-match}`): object args / lastIndex round-trips that
+   throw before reaching the protocol — same static-coercion family as (3).
+5. **`SpeciesConstructor` for @@split** (`species-ctor{,-y,-err,-ctor-non-obj,-species-non-ctor}`,
+   `splitter-proto-from-ctor-realm`): `C = SpeciesConstructor(rx, %RegExp%)` then
+   `Construct(C, [rx, flags])` — bridging a user constructor through the native
+   split. Deep.
+6. **method-as-value (`name.js`)**: `RegExp.prototype[Symbol.replace]` accessed as
+   a **value** (for `.name`) rather than called — the codegen resolves the member
+   to the protocol-id `i32.const 8`, so `verifyProperty(<8>, "name", …)` fails.
+   Separate feature (well-known-symbol method as first-class value).
+
+## Test Results (Slice 1)
+
+`tests/issue-3051.test.ts` — 5/5 pass. Local default-lane sweep of
+`built-ins/RegExp/prototype/Symbol.{replace,split}`: replace 54/69, split 28/43
+(was 39/69, 28/43).

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2329,6 +2329,35 @@ function _maybeWrapCallableUnknownArity(
 }
 
 /**
+ * (#3051) Wrap a callable stored as `regexp.exec` so its RETURN value — the
+ * match result object the RegExp protocol reads — is exposed to the native
+ * engine via `_wrapForHost`. The user overrides `exec` with a compiled
+ * function that returns a plain object literal (`{0: '…', index: {valueOf…},
+ * length: …, groups: …}`). Compiled object literals are opaque WasmGC structs;
+ * when V8's `RegExp.prototype[@@replace]` / `[@@split]` / `[@@match]` /
+ * `[@@search]` protocol does `Get(result, "0" | "index" | "length" | "groups")`
+ * on that struct it reads `undefined`, and the spec-mandated `ToString` /
+ * `ToIntegerOrInfinity` / `ToLength` coercions (including nested `valueOf` /
+ * `toString` on capture / index sub-objects) never run. Routing the return
+ * through `_wrapForHost` presents the struct as a host proxy whose get-trap
+ * surfaces the numeric / named fields and wraps nested closures, so the native
+ * protocol's Get + ToXxx chain observes the right values. Arrays and non-struct
+ * returns pass through unchanged (`_wrapForHost` is a no-op on them).
+ */
+function _wrapExecReturnForHost(
+  fn: (...args: any[]) => any,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): (...args: any[]) => any {
+  return function execReturnBridge(this: any, ...args: any[]): any {
+    const ret = fn.apply(this, args);
+    if (ret != null && typeof ret === "object" && _isWasmStruct(ret)) {
+      return _wrapForHost(ret, callbackState?.getExports());
+    }
+    return ret;
+  };
+}
+
+/**
  * (#2702) Tri-state result of `V instanceof target` per ECMA-262 §13.10.2
  * (InstanceofOperator) + §7.3.20 (OrdinaryHasInstance). The wasm caller turns
  * this into a value or a *wasm-thrown* `TypeError` (a host-thrown JS error
@@ -8391,7 +8420,15 @@ assert._isSameValue = isSameValue;
           // struct — `p1.then = fn; Promise.race([p1])` traps with
           // "object is not a function". Wrap it via __call_fn_<arity> so
           // host-driven invocation reaches the closure body.
-          const wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+          let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+          // (#3051) `regexp.exec = fn` override: the native RegExp protocol
+          // (@@replace/@@split/@@match/@@search) calls this and reads the
+          // returned match-result object via Get + ToXxx. A compiled result
+          // object literal is an opaque WasmGC struct, so wrap the return in a
+          // host proxy for the spec coercions to observe its fields.
+          if (typeof wrappedVal === "function" && key === "exec" && obj instanceof RegExp) {
+            wrappedVal = _wrapExecReturnForHost(wrappedVal, callbackState);
+          }
           _safeSet(obj, key, wrappedVal, undefined, callbackState);
         };
       // (#2017) Strict-mode property write — identical to `__extern_set` except a
@@ -8402,7 +8439,12 @@ assert._isSameValue = isSameValue;
       // throw catchable by the user's try/catch.
       if (name === "__extern_set_strict")
         return (obj: any, key: any, val: any) => {
-          const wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+          let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+          // (#3051) See __extern_set: wrap a `regexp.exec` override's return so
+          // the native RegExp protocol can read the compiled result object.
+          if (typeof wrappedVal === "function" && key === "exec" && obj instanceof RegExp) {
+            wrappedVal = _wrapExecReturnForHost(wrappedVal, callbackState);
+          }
           _safeSet(obj, key, wrappedVal, undefined, callbackState, /* strict */ true);
         };
       if (name === "__extern_length")
@@ -13473,7 +13515,13 @@ assert._isSameValue = isSameValue;
       return (obj: any, key: any, val: any) => {
         // (#860) Wrap closure-as-value before storing — see __extern_set
         // binding above. Mirrors the by-name path.
-        const wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+        let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+        // (#3051) `regexp.exec = fn` override — wrap the return so the native
+        // RegExp protocol (@@replace/@@split/@@match/@@search) can read the
+        // compiled match-result object (a WasmGC struct) via Get + ToXxx.
+        if (typeof wrappedVal === "function" && key === "exec" && obj instanceof RegExp) {
+          wrappedVal = _wrapExecReturnForHost(wrappedVal, callbackState);
+        }
         _safeSet(obj, key, wrappedVal, undefined, callbackState);
       };
     case "extern_set_strict":
@@ -13483,7 +13531,12 @@ assert._isSameValue = isSameValue;
       // `obj.k = v` accessor writes here (ESM is always strict); the throw is
       // catchable in the user's try/catch via the host-import exception bridge.
       return (obj: any, key: any, val: any) => {
-        const wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+        let wrappedVal = _maybeWrapCallableUnknownArity(val, callbackState);
+        // (#3051) See extern_set — wrap a `regexp.exec` override's return so the
+        // native RegExp protocol can read the compiled result object.
+        if (typeof wrappedVal === "function" && key === "exec" && obj instanceof RegExp) {
+          wrappedVal = _wrapExecReturnForHost(wrappedVal, callbackState);
+        }
         _safeSet(obj, key, wrappedVal, undefined, callbackState, /* strict */ true);
       };
     case "host_eq":

--- a/tests/issue-3051.test.ts
+++ b/tests/issue-3051.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #3051 — RegExp `[@@replace]` / `[@@split]` result-array coercion protocol.
+ *
+ * Mirrors the `built-ins/RegExp/prototype/Symbol.replace/result-coerce-*`
+ * cluster from test262. A user overrides `regexp.exec` with a compiled
+ * function that returns a plain object literal used as the match result:
+ *
+ *   r.exec = function() { return { 0: '…', index: {valueOf(){…}}, length: … }; };
+ *
+ * V8's native `RegExp.prototype[@@replace]` (which we delegate to via the
+ * `__regex_symbol_call` host import) reads the result through the ordinary
+ * `Get(result, "0" | "index" | "length" | "groups")` + `ToString` /
+ * `ToIntegerOrInfinity` / `ToLength` protocol (spec §22.2.6.11). The compiled
+ * object literal is an opaque WasmGC struct, so before #3051 V8 read every
+ * field as `undefined` and the coercions never ran. The fix wraps a
+ * `regexp.exec` override's RETURN value in `_wrapForHost` (see `__extern_set` /
+ * `extern_set_strict` in src/runtime.ts) so the native protocol observes the
+ * struct's fields and dispatches the nested `valueOf` / `toString` closures.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  if (typeof imports.setExports === "function") {
+    imports.setExports(instance.exports as Record<string, Function>);
+  }
+  return (instance.exports as never as Record<string, () => unknown>)[fn]!();
+}
+
+describe("#3051 — RegExp @@replace result-array coercion", { timeout: 30000 }, () => {
+  it("coerces result 'index' via ToIntegerOrInfinity (index is an object with valueOf)", async () => {
+    // test262: Symbol.replace/result-coerce-index.js
+    const out = await run(`
+      export function test(): string {
+        const coercibleIndex: any = {
+          length: 1,
+          0: "",
+          index: { valueOf: function(): number { return 2.9; } },
+        };
+        const r = /./;
+        (r as any).exec = function(): any { return coercibleIndex; };
+        const replacer = function(_m: string, position: number): number { return position; };
+        return (r as any)[Symbol.replace]("abcd", replacer) as string;
+      }
+    `);
+    expect(out).toBe("ab2cd");
+  });
+
+  it("coerces result[0] (matched) via ToString (matched is an object with toString)", async () => {
+    // test262: Symbol.replace/result-coerce-matched.js
+    const out = await run(`
+      export function test(): string {
+        const coercibleValue: any = {
+          length: 1,
+          0: { toString: function(): string { return "toString value"; } },
+          index: 0,
+        };
+        const r = /./;
+        (r as any).exec = function(): any { return coercibleValue; };
+        return (r as any)[Symbol.replace]("", "foo[$&]bar") as string;
+      }
+    `);
+    expect(out).toBe("foo[toString value]bar");
+  });
+
+  it("coerces result 'length' via ToLength (length is an object with valueOf)", async () => {
+    // test262: Symbol.replace/result-coerce-length.js
+    const out = await run(`
+      export function test(): string {
+        const coercibleIndex: any = {
+          length: { valueOf: function(): number { return 3.9; } },
+          0: "",
+          1: "foo",
+          2: "bar",
+          3: "baz",
+          index: 0,
+        };
+        const r = /./;
+        (r as any).exec = function(): any { return coercibleIndex; };
+        return (r as any)[Symbol.replace]("", "$1$2$3") as string;
+      }
+    `);
+    expect(out).toBe("foobar$3");
+  });
+
+  it("coerces each capture via ToString (result-coerce-capture)", async () => {
+    // test262: Symbol.replace/result-coerce-capture.js
+    const out = await run(`
+      export function test(): string {
+        const coercibleValue: any = {
+          length: 2,
+          0: "",
+          1: { toString: function(): string { return "toString value"; } },
+          index: 0,
+        };
+        const r = /./;
+        (r as any).exec = function(): any { return coercibleValue; };
+        return (r as any)[Symbol.replace]("", "[$1]") as string;
+      }
+    `);
+    expect(out).toBe("[toString value]");
+  });
+
+  it("reads an overridden exec result array back into wasm (round-trip)", async () => {
+    const out = await run(`
+      export function test(): string {
+        const r = /x/;
+        (r as any).exec = function(): any { return ["hello", "cap1"]; };
+        const m: any = (r as any).exec("xyz");
+        return (m[0] as string) + "|" + (m[1] as string) + "|len=" + (m.length as number);
+      }
+    `);
+    expect(out).toBe("hello|cap1|len=2");
+  });
+});


### PR DESCRIPTION
## #3051 — RegExp `[@@replace]` / `[@@split]` result-array coercion (Slice 1)

### Root cause
In the default (JS-host) lane, `re[Symbol.replace/split/match/search](...)` is delegated to the **native V8** protocol via the `__regex_symbol_call` host import. When a test overrides `regexp.exec = fn` (the bulk of the `result-*` cluster), the compiled `fn` returns a **compiled object literal** used as the match result. Object literals are opaque WasmGC structs, so when V8's native protocol did `Get(result, "0" | "index" | "length" | "groups")` on the returned struct it read `undefined` — the spec `ToString` / `ToIntegerOrInfinity` / `ToLength` coercions (and nested `valueOf`/`toString` on capture/index sub-objects) never ran.

### Fix
When `regexp.exec = fn` is stored (the `extern_set` / `extern_set_strict` host bindings, guarded on `key === "exec" && obj instanceof RegExp`), wrap `fn`'s **return value** in `_wrapForHost` (`_wrapExecReturnForHost`) so the native protocol observes the struct's fields and dispatches the nested closures. Arrays / non-struct returns pass through unchanged. Covers @@replace, @@split, @@match, @@search (all read exec's result the same way).

### Impact (local default-lane, measured)
- `Symbol.replace`: 39 → 54 pass (**+15**); `Symbol.split`: 28 → 28 (unchanged).
- Newly passing: `result-coerce-{index,index-undefined,matched,matched-global,capture,length,groups}` (+ `-err` twins in the coercion arm), `coerce-lastindex`, `g-pos-increment/decrement`.
- No in-corpus regressions; `issue-1329-b3` / `issue-2161` green. (`issue-682`'s 4 failures are **pre-existing** on `origin/main` — unrelated standalone refusal tests.)

### Scope
Cluster A (result-array coercion) landed as one net-positive slice. Remaining clusters (err-throw propagation through getters, replaceValue `ToString`, `.global`/`.unicode` Symbol coercion, `@@split` `SpeciesConstructor`, method-as-value) are documented in the issue file for Slice 2+ — several are senior-depth. Issue left `status: in-progress`.

### Tests
`tests/issue-3051.test.ts` — 5/5 pass. `tsc --noEmit` clean; prettier clean; no new biome lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS