### PR TITLE
test(#3037): CS1c getPrototypeOf — RE-PROBED, regression-lock + CS3 readiness verdict

### DIFF
--- a/plan/issues/3037-object-identity-canonicalization-substrate.md
+++ b/plan/issues/3037-object-identity-canonicalization-substrate.md
@@ -671,7 +671,9 @@ regression ⇒ a non-object leaked into tag-6 → diagnose, don't force.
 - **CS1b(ii) element access** — LANDED (opus-3037-cs1bii). See the section below.
 - **CS1b(iii) descriptor `.value`/`.get` producer** — RE-PROBED: no
   carrier-addressable descriptor-specific gap remains. See the section below.
-- **CS1c** getPrototypeOf/reflective producer carrier (case d).
+- **CS1c** getPrototypeOf/reflective producer — RE-PROBED: case (d) is a
+  null-canon stored-in-local symptom, no bounded carrier win (CS3-owned). See
+  the section below + the CS3 readiness assessment.
 
 ---
 
@@ -838,6 +840,8 @@ Site-2 synthesis can't silently regress descriptor `.value` identity), 3
 anti-vacuity invariants, and the 2 KNOWN-GAP rows pinned at `0` (descriptor +
 plain-read control) marked **CS3-owned** so the eventual universal-reader flip
 is auditable. No `src/` change; no floor movement expected.
+
+---
 
 ## CS1c (getPrototypeOf / reflective producer) — RE-PROBED (opus-3037-cs1c): case (d) is a null-canon symptom, no bounded carrier win
 

--- a/plan/issues/3037-object-identity-canonicalization-substrate.md
+++ b/plan/issues/3037-object-identity-canonicalization-substrate.md
@@ -767,3 +767,127 @@ Same as CS1b: the equality-operand scoping is the safety boundary. **NOT
 self-merged on PR-green alone** — flagged the lead for a monitored `merge_group`
 standalone `host_free_pass` floor enqueue (expect NET-POSITIVE — drives #3027).
 Any floor regression ⇒ a non-object leaked into tag-6 → diagnose, don't force.
+
+---
+
+## CS1c (getPrototypeOf / reflective producer) — RE-PROBED (opus-3037-cs1c): case (d) is a null-canon symptom, no bounded carrier win
+
+**PR:** byte-inert regression-LOCK test only (no `src/` change).
+`prove-emit-identity` **39/39 IDENTICAL**. The task framed CS1c as "apply the
+carrier at the getPrototypeOf result choke point, flipping CS0 case (d) 0→1". A
+per-choke-point re-probe against current `upstream/main` (7eb51a2c5) shows there
+is **no bounded, floor-safe operand-carrier win** here, and — crucially — that
+**CS0 case (d) is not an object-identity carrier target at all**.
+
+### What the re-probe measured (traced, not narrative)
+
+1. **Plain-object / array `[[Prototype]]` is NULL in standalone.**
+   `__getPrototypeOf` (`object-runtime.ts:2761`) returns
+   `struct.get $Object.$proto` for a `$Object`, else **NULL**. A plain object
+   literal's `$proto` is unset (Object.prototype is not modeled as a standalone
+   `$Object`), and an array `[1]` is a vec (not a `$Object`) so `ref.test
+   $Object` fails → NULL. Hence `Object.getPrototypeOf([1]) === null` **and**
+   `Object.getPrototypeOf({z:1}) === null` are BOTH `1`. **CS0 case (d)
+   (`const a:any=[1]; p1=gpo(a); p2=gpo(a); p1===p2`) is a null comparison, not
+   object identity.**
+
+2. **Case (d)'s residual 0 is a stored-in-local NULL-canonicalization symptom.**
+   A `null` LITERAL stored in two `any` locals compares `===` → **1** (it boxes
+   the null/undefined SINGLETON, tag-0/1 → `ref.eq`). But getPrototypeOf's
+   `ref.null.extern`, stored in an `any` local, is boxed **tag-5**
+   (externval-null) at the `===` operand seam → the guarded tag-5 same-tag arm →
+   **0**. This asymmetry is the **same reader-result-into-`any`-local defect as
+   CS1b(iii)'s residual** — the operand-scoped carrier cannot reach it (the
+   equality operands are LOCALS, not reads). Flipping case (d) = canonicalising a
+   reader/producer result INTO an `any` local independent of downstream use =
+   the **UNIVERSAL-reader carrier (CS3 / V2-S3b, the −299 minefield)**.
+
+3. **The genuine object-identity getPrototypeOf gaps are ALSO out of reach.** A
+   class instance has a real proto struct anchor (`emitLazyProtoGet` singleton):
+   `getPrototypeOf(f) === getPrototypeOf(f)` direct → already 1; stored in `any`
+   locals → **0** (the same stored-in-local CS3 problem); `getPrototypeOf(f) ===
+   Foo.prototype` → **0** and **NOT carrier-flippable** — `Foo.prototype` is
+   typed `Foo` (the instance type), not `any`, so the `isAnyEqualityOperand`
+   both-operands-`Any` gate never fires.
+
+### Verdict — the operand carrier has hit its coverage ceiling
+
+The operand-scoped carrier (CS1a → CS1b(i) → CS1b(ii)) can only fix a value that
+appears as a **DIRECT `any===any` operand**. Every remaining identity gap under
+#3027 — descriptor/member/element/getPrototypeOf results stored in a local,
+passed as a function arg / returned, or paired with a non-`any` operand — reduces
+to the **reader-result-INTO-`any` universal carrier = CS3**, the −299 minefield.
+**CS3 is not a bounded slice; it needs its own architect pass** (see the CS3
+readiness assessment below).
+
+### Deliverable
+
+`tests/issue-3037-cs1c-getprototypeof-carrier.test.ts` — a byte-inert
+**regression-LOCK**: the null-proto facts (`gpo([1])===null`, `gpo({})===null`,
+null-literal-stored identity, the coincidental direct null===null the #3013
+lesson warns about), the class-proto direct-operand pass, and 3 KNOWN-GAP rows
+(case (d) null-canon stored-in-local, class-proto stored-in-local CS3, and the
+non-`any`-operand `gpo(f)===Foo.prototype`) pinned at `0` so the eventual CS3
+flip is auditable. No `src/` change; no floor movement expected.
+
+---
+
+## CS3 readiness assessment (opus, 2026-07-05) — needs its own architect pass; NOT a bounded slice
+
+**Question posed:** now that CS1a–CS1c establish the identity carrier, is the
+V2-S3b reader-arm (CS3, the ~1,552-test #3027 driver) safe/dispatchable, or does
+the universal-reader ValType change still detonate the −299 consumer-breadth
+mine?
+
+**Verdict: CS3 still detonates the −299 mine. It is NOT a bounded slice and
+requires its own architect pass.** The evidence is the convergent finding across
+CS1b(iii) + CS1c (both re-probed on current main):
+
+- The landed carrier (CS1a/b) is **strictly operand-scoped**: it re-classifies a
+  reader result to tag-6 **only** when the read is a DIRECT operand of a
+  standalone `any===any`/`!==`/`==`/`!=` (the exact shape routing through
+  `emitAnyEqOperands`). That scoping is precisely what keeps it floor-safe — the
+  value can only ever flow into the equality helper's `isAnyValue` fast-path,
+  never into a subsequent read/store (a `$AnyValue` local breaks dynamic reads —
+  the CS1a finding; `__any_to_extern` keeps the box wrapped).
+- **Every remaining #3027 identity gap is OUTSIDE that scope.** Measured classes,
+  all reducing to one root cause (reader/producer result carried as externref
+  INTO an `any` slot, tag-5-boxed downstream): (i) result stored in an
+  intermediate `any` local (`const v=o.a; v===w`); (ii) result passed as a
+  function ARG and compared inside the callee — the `assert.sameValue`/
+  `isSameValue` harness comparator shape, which is the DOMINANT test262 form;
+  (iii) result paired with a non-`any` operand (`gpo(f)===Foo.prototype`);
+  (iv) getPrototypeOf/null-proto canonicalization. The operand carrier cannot
+  reach any of these.
+- Fixing them means changing the ValType a reader/producer hands to the any-flow
+  **independent of whether it is a direct `===` operand** — i.e. the UNIVERSAL
+  reader carrier (Mechanism A / V2-S3b), which lands on the harness-comparator
+  seam. That seam is the documented **−788 / −794 / −299** chokepoint: the
+  test262 comparator marshals ALL its `any` operands through the externref→
+  `$AnyValue` boxing arm and depends on main's tag-5 behaviour. #2661 and V2-S3b
+  both died here.
+
+**Why the substrate does NOT unblock it yet.** The #3037 thesis is that once
+objects reach `===` tag-6-canonical, the reader arm needs no `===` change. But
+CS1a–CS1c only make objects tag-6 at the *direct-operand* seam — they do NOT make
+a reader result tag-6 when it enters an `any` local/arg/return. The harness
+comparator receives its operands as `any` PARAMS (produced by the general
+externref→`$AnyValue` boxing, tag-5), not as direct reads. So the substrate the
+reader arm needs — objects tag-6 *at production into any*, universally — is
+exactly the piece CS1 deliberately did NOT build (it is the −788 arm). CS3 is
+that piece.
+
+**Recommendation (report to lead):**
+1. CS3 is a **hard, architect-owned** slice, not a dev carrier PR. It needs a
+   dedicated spec that solves the universal reader/producer → tag-6 carrier
+   WITHOUT touching the harness-comparator externref boxing arm — likely by
+   canonicalizing at the `$Object` dynamic-READER natives (`__extern_get` et al.)
+   returning a tag-6-carrying `$AnyValue` for object payloads while keeping
+   strings tag-5, gated so the comparator's own operand marshalling is untouched.
+   That is a genuinely different seam from the operand site and must be proven
+   against the full `merge_group` floor per micro-step.
+2. The carrier families (CS1a/b/ii) have banked their bounded wins; CS1b(iii)
+   and CS1c are **RE-PROBED no-ops** (regression-locks only) — the operand
+   carrier's coverage ceiling is reached. Do not spend further dev effort trying
+   to flip stored-in-local / harness-comparator cases with the operand carrier.
+3. Keep the CS1b(iii)/CS1c KNOWN-GAP test rows as the auditable CS3 flip targets.

--- a/tests/issue-3037-cs1c-getprototypeof-carrier.test.ts
+++ b/tests/issue-3037-cs1c-getprototypeof-carrier.test.ts
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3037 CS1c (getPrototypeOf / reflective-producer family) — RE-PROBED.
+//
+// The task framed CS1c as "apply the same equality-operand carrier at the
+// getPrototypeOf result choke point, flipping CS0 case (d) 0→1". Re-probing the
+// getPrototypeOf identity surface against current `upstream/main` (7eb51a2c5)
+// shows there is NO bounded, floor-safe, operand-carrier win here — and, more
+// importantly, that CS0 case (d) is NOT an object-identity carrier target at
+// all. This mirrors CS0 disproving the "reader production site" premise, CS1a
+// disproving the "`$AnyValue` carrier" premise, and CS1b(iii) disproving the
+// "descriptor producer" premise. The traced measurement (this suite pins it):
+//
+// 1. **Plain-object / array `[[Prototype]]` is NULL in standalone.**
+//    `__getPrototypeOf` (object-runtime.ts) returns `struct.get $Object.$proto`
+//    for a `$Object`, else NULL. A plain object literal's `$proto` is unset
+//    (Object.prototype is not modeled as a `$Object` standalone), and an array
+//    `[1]` is a vec, not a `$Object`, so `ref.test $Object` fails → NULL. Hence
+//    `Object.getPrototypeOf([1]) === null` and `Object.getPrototypeOf({z:1})
+//    === null` are BOTH `1`. CS0 case (d) (`const a:any=[1]; p1=gpo(a);
+//    p2=gpo(a); p1===p2`) is therefore a **null comparison**, not object
+//    identity.
+//
+// 2. **Case (d)'s residual 0 is a stored-in-local NULL-canonicalization
+//    symptom, not an identity defect.** A `null` LITERAL stored in two `any`
+//    locals compares `===` → **1** (`pure_null_stored`): the literal boxes the
+//    null/undefined SINGLETON (tag-0/1), so `ref.eq` answers identity. But
+//    getPrototypeOf's `ref.null.extern`, stored in an `any` local, is boxed
+//    **tag-5** (externval-null) at the `===` operand seam (the generic
+//    `boxToAny` externref arm) → the guarded tag-5 same-tag arm → **0**. The
+//    asymmetry is the SAME reader-result-into-`any`-local defect as CS1b(iii)'s
+//    residual — the value is externalized into the local and tag-5-boxed
+//    downstream, and the operand-scoped carrier (CS1a/b) cannot reach it (the
+//    equality operands are LOCALS, not reads). Flipping case (d) means
+//    canonicalising a reader/producer result INTO an `any` local independent of
+//    downstream use = the UNIVERSAL-reader carrier (CS3 / V2-S3b, the −299
+//    minefield), NOT a bounded operand-carrier slice.
+//
+// 3. **The genuine object-identity getPrototypeOf gaps are ALSO out of the
+//    operand-carrier's reach.** A class instance has a real materialized proto
+//    struct anchor (`emitLazyProtoGet` singleton):
+//      - `getPrototypeOf(f) === getPrototypeOf(f)` DIRECT operands → already 1.
+//      - `getPrototypeOf(f)` stored in `any` locals then compared → 0 — the
+//        SAME stored-in-local CS3 problem.
+//      - `getPrototypeOf(f) === Foo.prototype` → 0, and NOT carrier-flippable:
+//        `Foo.prototype` is typed `Foo` (the instance type), not `any`, so the
+//        `isAnyEqualityOperand` gate (both operands must be raw-checker `Any`)
+//        does not fire — extending the carrier to getPrototypeOf calls would not
+//        move it.
+//
+// **Verdict (recorded for the CS3 assessment):** the operand-scoped carrier
+// (CS1a → CS1b(i) → CS1b(ii)) has reached its COVERAGE CEILING. Every remaining
+// identity gap under #3027 — descriptor/member/element/getPrototypeOf results
+// stored in a local, passed as a function arg, or paired with a non-`any`
+// operand — reduces to the reader-result-INTO-`any` universal carrier = CS3,
+// the −299 minefield. CS3 is NOT a bounded slice; it needs its own architect
+// pass. This suite is BYTE-INERT (no `src/` change; `prove-emit-identity`
+// 39/39 IDENTICAL) — a REGRESSION-LOCK pinning the getPrototypeOf identity
+// surface (incl. the coincidental-null cases the #3013 lesson warns about) so
+// the eventual CS3 flip is auditable.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Host-free: a leaked `env` import would mean the case silently ran on a JS
+  // host fast-path and the result is not the standalone substrate's answer.
+  const leaked = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(leaked, `--target standalone leaked env imports: ${leaked.join(", ")}`).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#3037 CS1c — plain/array proto is NULL in standalone (case (d) is a null comparison)", () => {
+  it("Object.getPrototypeOf([1]) === null [1]", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const a: any = [1];
+        const p: any = Object.getPrototypeOf(a);
+        return (p === null) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Object.getPrototypeOf({z:1}) === null [1]", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const o: any = { z: 1 };
+        const p: any = Object.getPrototypeOf(o);
+        return (p === null) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("a null LITERAL stored in two `any` locals IS === (null singleton identity) [1]", async () => {
+    expect(
+      await runStandalone(`export function run(): number {
+        const p1: any = null;
+        const p2: any = null;
+        return (p1 === p2) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("getPrototypeOf([1]) === getPrototypeOf([1]) as DIRECT operands [1] (coincidental null)", async () => {
+    // #3013 lesson: direct null===null passes coincidentally. Pinned so a future
+    // proto-modeling change makes the flip DELIBERATE and auditable.
+    expect(
+      await runStandalone(`export function run(): number {
+        const a: any = [1];
+        return (Object.getPrototypeOf(a) === Object.getPrototypeOf(a)) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});
+
+describe("#3037 CS1c — class-instance getPrototypeOf (real proto anchor)", () => {
+  it("getPrototypeOf(instance) === getPrototypeOf(instance) DIRECT operands [1]", async () => {
+    expect(
+      await runStandalone(`class Foo { x: number = 1; }
+        export function run(): number {
+          const f: any = new Foo();
+          return (Object.getPrototypeOf(f) === Object.getPrototypeOf(f)) ? 1 : 0;
+        }`),
+    ).toBe(1);
+  });
+});
+
+describe("#3037 CS1c — KNOWN-GAPs beyond the operand carrier (CS3 / non-any-operand)", () => {
+  it("[KNOWN-GAP: null-canon stored-in-local] CS0 case (d) — gpo([1]) stored then === [0 today]", async () => {
+    // Both operands are null externref from getPrototypeOf, stored in `any`
+    // locals → boxed tag-5 at the operand seam → guarded same-tag arm → 0.
+    // A null LITERAL (above) is 1. The fix is the universal reader/producer
+    // carrier (CS3), not a bounded operand carrier.
+    expect(
+      await runStandalone(`export function run(): number {
+        const a: any = [1];
+        const p1: any = Object.getPrototypeOf(a);
+        const p2: any = Object.getPrototypeOf(a);
+        return (p1 === p2) ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+
+  it("[KNOWN-GAP: CS3 stored-in-local] class getPrototypeOf stored in `any` locals then === [0 today]", async () => {
+    expect(
+      await runStandalone(`class Foo { x: number = 1; }
+        export function run(): number {
+          const f: any = new Foo();
+          const p1: any = Object.getPrototypeOf(f);
+          const p2: any = Object.getPrototypeOf(f);
+          return (p1 === p2) ? 1 : 0;
+        }`),
+    ).toBe(0);
+  });
+
+  it("[KNOWN-GAP: non-any operand] getPrototypeOf(instance) === Foo.prototype [0 today]", async () => {
+    // `Foo.prototype` is typed `Foo`, not `any`, so the both-operands-`Any`
+    // carrier gate never fires — this is not operand-carrier-addressable.
+    expect(
+      await runStandalone(`class Foo { x: number = 1; }
+        export function run(): number {
+          const f: any = new Foo();
+          return (Object.getPrototypeOf(f) === Foo.prototype) ? 1 : 0;
+        }`),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## #3037 CS1c — getPrototypeOf / reflective-producer family: RE-PROBED

Continues the object-identity keystone under #3027, and delivers the **CS3 readiness assessment** (the key strategic input for the ~1,552-test driver).

### Finding (traced, not narrative)

Re-probing the getPrototypeOf identity surface on current `upstream/main` shows **no bounded operand-carrier win**, and that **CS0 case (d) is NOT an object-identity carrier target**:

1. **Plain/array `[[Prototype]]` is NULL in standalone.** `__getPrototypeOf` returns `$Object.$proto` else null; a plain object's proto is unset and an array is a vec (not a `$Object`). So `gpo([1])===null` and `gpo({})===null` are both `1` — case (d) is a **null comparison**.
2. **Case (d)'s residual 0 is a stored-in-local null-canonicalization symptom.** A `null` literal stored in two `any` locals compares `===` → 1 (null singleton, tag-0/1); getPrototypeOf's `ref.null.extern` stored in an `any` local boxes **tag-5** → guarded same-tag arm → 0. Same reader-into-`any`-local defect as CS1b(iii)'s residual; the operand-scoped carrier cannot reach it.
3. **Genuine class-proto gaps also out of reach:** `gpo(f)` stored → 0 (CS3 stored-in-local); `gpo(f) === Foo.prototype` → 0 and **not carrier-flippable** (`Foo.prototype` is typed `Foo`, not `any`, so the both-operands-`Any` gate never fires).

### CS3 readiness verdict (recorded in the issue file)

The operand-scoped carrier (CS1a → CS1b(i) → CS1b(ii)) has reached its **coverage ceiling**. Every remaining #3027 identity gap — reader/producer results stored in a local, passed as a function ARG (the dominant `assert.sameValue` harness shape), returned, or paired with a non-`any` operand — reduces to the **reader-result-INTO-`any` universal carrier = CS3 / V2-S3b**, which lands on the **−788/−299 harness-comparator seam** (where #2661 and V2-S3b died). **CS3 is NOT a bounded slice; it needs its own architect pass** — a spec that canonicalizes at the `$Object` dynamic-reader natives (object payload → tag-6 `$AnyValue`, strings stay tag-5) WITHOUT touching the comparator's externref boxing arm, proven per micro-step against the full `merge_group` floor.

### Deliverable — byte-inert regression LOCK

- **No `src/` change.** `prove-emit-identity` **39/39 IDENTICAL**.
- `tests/issue-3037-cs1c-getprototypeof-carrier.test.ts`: null-proto facts + coincidental direct null===null (#3013 lesson) + class-proto direct-operand pass + 3 KNOWN-GAP rows pinned at `0` as the auditable CS3 flip targets.
- Issue #3037 updated with the `CS1c — RE-PROBED` section and the full **CS3 readiness assessment**.

### Floor discipline

Byte-inert (test + doc only) → **no floor movement expected**. Not self-enqueuing; flagging the lead for the monitored `merge_group` floor enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8