### PR TITLE
release: v0.60.0 — publish js2wasm npm proxy + @loopdive/js2 on JSR

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -106,12 +106,14 @@ jobs:
         if: github.event_name == 'push' || inputs.dry-run == 'false'
         run: npm publish --provenance --access public
 
-      # DISABLED: the unscoped js2wasm proxy is unpublished, has no trusted
-      # publisher, and pins @loopdive/js2 at a stale 0.52.0. Re-enable (and add
-      # its own trusted publisher + a dep bump) once you want `npm install
-      # js2wasm` to resolve. See loopdive/js2#389.
+      # The unscoped js2wasm proxy re-exports @loopdive/js2 for discoverability
+      # (`npm install js2wasm`). Its package.json version tracks the canonical
+      # package in lockstep (scripts/release.mjs) and its dependency pins the
+      # matching @loopdive/js2 version. Requires an npm trusted publisher
+      # configured for the `js2wasm` package (same GitHub OIDC provider as
+      # @loopdive/js2). See loopdive/js2#389.
       - name: Publish js2wasm proxy
-        if: false
+        if: github.event_name == 'push' || inputs.dry-run == 'false'
         working-directory: packages/js2wasm
         run: npm publish --provenance --access public
 
@@ -119,9 +121,13 @@ jobs:
     name: JSR publish (@loopdive/js2)
     runs-on: ubuntu-latest
     needs: publish-npm
-    # DISABLED: JSR publishing needs its own OIDC link (jsr.io ↔ this repo) set
-    # up separately. Re-enable once the JSR package + GitHub link are configured.
-    if: false
+    # Tokenless OIDC — jsr publish authenticates via the workflow's id-token
+    # (id-token: write is granted at the workflow level). Requires the JSR
+    # package `@loopdive/js2` to exist and be linked to this GitHub repo on
+    # jsr.io (Settings → link a GitHub repository) so OIDC publishing is
+    # authorized. jsr.json carries the version (kept in lockstep with the npm
+    # packages by scripts/release.mjs).
+    if: github.event_name == 'push' || inputs.dry-run == 'false'
     steps:
       - uses: actions/checkout@v5
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.52.0",
+  "version": "0.60.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.59.5",
+  "version": "0.60.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.59.5",
+  "version": "0.60.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.52.0"
+    "@loopdive/js2": "0.60.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
## What

Cut release **v0.60.0** and enable two previously-disabled publish paths so that, on the `v0.60.0` tag push, CI publishes:

1. the **`js2wasm`** unscoped npm proxy (first publish — re-exports `@loopdive/js2` for discoverability), and
2. **`@loopdive/js2`** on **JSR** (first publish).

The canonical `@loopdive/js2` npm package also publishes at 0.60.0 as usual.

## Changes

- **Lockstep version bump → 0.60.0** via `scripts/release.mjs 0.60.0`: root `package.json` + `packages/js2wasm/package.json`, plus annotated tag `v0.60.0` (pushed after merge, not now).
- **`packages/js2wasm/package.json`**: `@loopdive/js2` dependency `0.52.0 → 0.60.0` (was stale).
- **`jsr.json`**: `version 0.52.0 → 0.60.0`.
- **`.github/workflows/publish-npm.yml`**: flipped the `js2wasm` proxy npm-publish step and the `@loopdive/js2` JSR job from `if: false` to the same push/non-dry-run guard as the canonical publish.

## ⚠️ One-time registry setup required before the tag will publish

Both new targets use tokenless OIDC (no secrets). They will **fail** on the tag push unless configured first on the registry side:

1. **npm trusted publisher for `js2wasm`** — configure a trusted publisher on npmjs.com for the (new) `js2wasm` package, GitHub provider = this repo + `publish-npm.yml`. (A brand-new npm package may need a first token-based `npm publish` to create it before a trusted publisher can be attached — confirm on npm's side.)
2. **JSR package + GitHub link** — create/confirm `@loopdive/js2` under the existing `@loopdive` JSR scope and link this GitHub repo on jsr.io so OIDC publishing is authorized.

## Release procedure (per `docs/releasing.md`)

1. Merge this PR (do **not** push the tag yet).
2. Complete the two registry setup steps above.
3. Push the tag to trigger publish: `git push origin v0.60.0`.
   - `verify-version` confirms tag == both `package.json` versions before publishing.
   - Optional dry-run first: `workflow_dispatch` on `publish` with `dry-run=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)