### PR TITLE
fix(#3051): RegExp @@replace/@@split arg + flag coercion (Slice 2)

### DIFF
--- a/plan/issues/3051-regexp-symbol-replace-split-coercion-protocol.md
+++ b/plan/issues/3051-regexp-symbol-replace-split-coercion-protocol.md
@@ -2,7 +2,7 @@
 id: 3051
 title: "RegExp.prototype[@@replace] / [@@split] coercion protocol: ToString/ToInteger/ToLength on result-array + lastIndex/limit/flags args (~48 fails)"
 status: in-progress
-assignee: ttraenkler/dev-3051
+assignee: ttraenkler/dev-3051b
 sprint: current
 priority: medium
 horizon: m
@@ -138,9 +138,52 @@ Arrays / non-struct returns pass through unchanged. Covers @@replace, @@split,
 - Newly passing: `result-coerce-{index,index-undefined,matched,matched-global,capture,length,groups}` and their `-err` twins where the throw was already in the coercion arm, plus `coerce-lastindex`, `g-pos-increment`, `g-pos-decrement`.
 - No in-corpus regressions; `issue-1329-b3` / `issue-2161` still green. (`issue-682`'s 4 failures are **pre-existing** on `origin/main`, unrelated — standalone refusal tests.)
 
-## Remaining Work (Slice 2+ — several senior-depth)
+## Landed Slice 2 (dev-3051b) — replaceValue ToString bridge + flag Symbol-coercion
 
-Not addressed by Slice 1 (still ~30 default-lane fails). Distinct mechanisms:
+**PR: `src/runtime.ts` (`wrapCallable` data-struct guard) + `src/codegen/index.ts`
+(RegExp `.global`/`.unicode` externref retype) + `tests/issue-3051.test.ts`.**
+Two dev-doable clusters from the Slice-1 remaining list:
+
+- **replaceValue `ToString` (cluster 2 — `arg-2-coerce{,-err}`):** in
+  `__regex_symbol_call`, the second @@replace/@@split arg was routed through
+  `wrapCallable`, whose `_wrapWasmClosure` probe **false-positives on ANY struct**
+  when the module exports `__call_fn_N` (it checks dispatcher existence, not
+  closure-ness). So a non-callable object-literal replaceValue
+  (`{toString(){…}}`) got wrapped as a callable bridge → V8 saw
+  `functionalReplace = true`, INVOKED it, and `ToString` of the bogus return was
+  `"null"`. Fix: gate `wrapCallable` on the **positive `__is_data_struct`
+  discriminator** (same marker `_wrapForHost`'s get-trap uses) — a data struct
+  routes straight to `_wrapForHost` (property proxy) so native `ToString` /
+  `ToPrimitive` reaches its `toString`/`valueOf` closure fields; genuine closures
+  are never in the data-struct set, so functional replace is unchanged.
+- **flag Symbol-coercion (cluster 3 — `coerce-global`, `coerce-unicode`):**
+  test262 re-marks the spec-readonly `.global`/`.unicode` writable
+  (`Object.defineProperty(r,'global',{writable:true})`) then assigns arbitrary
+  values (`r.global = Symbol.replace`). The extern property typed `boolean` made
+  the generated `RegExp_set_global(externref, i32)` setter eagerly ToNumber the
+  RHS → a Symbol trapped at the wasm boundary before storing. Fix: **retype
+  `.global`/`.unicode` to `externref` in host mode** (mirroring the #2671
+  `lastIndex` treatment) so the raw value round-trips onto the native RegExp and
+  the native @@replace/@@split protocol performs the spec `ToBoolean` itself;
+  explicit `r.global` reads coerce externref→boolean at the use site (verified a
+  boxed `false` still unboxes falsy, and `=== true`/`=== false` still work).
+
+**Impact (local default-lane, isolated per-file sweep of
+`built-ins/RegExp/prototype/Symbol.{replace,split}`, apples-to-apples vs the
+same runner on `origin/main`): 83 → 88 pass (+5), zero regressions.** Flips:
+`arg-2-coerce`, `arg-2-coerce-err`, `coerce-global`, `coerce-unicode`, and
+`Symbol.split/coerce-limit-err` (bonus — the same `wrapCallable` data-struct
+guard lets the @@split `limit` object's throwing `valueOf` propagate).
+Broader validation: isolated sweep of the delegating corpus (459 files across
+`String.prototype.{replace,replaceAll,split,match,matchAll,search}` +
+`RegExp.prototype.{global,unicode,Symbol.match,Symbol.matchAll,Symbol.search}`)
+showed **0 regressions**; regex vitest suites (issue-1329-b3 / 1539 / 1911 /
+1912 / 2161) unchanged (the 2 pre-existing standalone-refusal fails are on
+`origin/main` too). `tests/issue-3051.test.ts` — 10/10 pass.
+
+## Remaining Work (Slice 3+ — senior-depth)
+
+Not addressed by Slice 1 or Slice 2. Distinct mechanisms, all senior-depth:
 
 1. **`result-*-err` abrupt-throw propagation** (`result-get-{index,length,matched}-err`,
    `result-get-groups-prop-err`, `result-coerce-groups-err`): the result object
@@ -149,26 +192,18 @@ Not addressed by Slice 1 (still ~30 default-lane fails). Distinct mechanisms:
    wasm `throw` must surface as a JS exception V8 propagates back to the user's
    `try/catch`. Wasm-exception → host → user-catch bridging across the native
    protocol is **senior-depth**.
-2. **replaceValue `ToString` (`arg-2-coerce{,-err}`)**: `re[@@replace](s, obj)`
-   where `obj` is a non-callable struct with `toString`. `__regex_symbol_call`'s
-   `wrapCallable(arg1)` wraps it via `_wrapForHost`, but `ToString(proxy)` returns
-   `"null"` instead of the struct's `toString` result — the `wrapCallable` /
-   `_wrapForHost` `toString`-field dispatch drops the value. Needs deeper look at
-   the non-closure-struct arm of `wrapCallable`.
-3. **`Cannot convert a Symbol value to a number` (`coerce-global`, `coerce-unicode`)**:
-   the test does `Object.defineProperty(r,'global',{writable:true}); r.global = Symbol.replace`
-   (and `= {}`, `= NaN`, …). Assigning arbitrary values to the **typed** `.global`/
-   `.unicode` boolean property makes codegen coerce the RHS Symbol → number →
-   throw. Static-type-coercion / property-write issue in codegen, not the protocol.
-4. **`Cannot convert object to primitive value` (@@split cluster:** `coerce-flags`,
+2. **`Cannot convert object to primitive value` (@@split cluster:** `coerce-flags`,
    `limit-0-bail`, `str-coerce-lastindex`, `str-result-coerce-length`,
    `str-set-lastindex-{match,no-match}`): object args / lastIndex round-trips that
-   throw before reaching the protocol — same static-coercion family as (3).
-5. **`SpeciesConstructor` for @@split** (`species-ctor{,-y,-err,-ctor-non-obj,-species-non-ctor}`,
+   throw before reaching the protocol. Note `coerce-limit-err` (a *throwing*
+   valueOf) was fixed by Slice 2's data-struct guard, but these plain
+   object-to-primitive cases still trap — a deeper static-coercion / value-read
+   family. **Senior-depth.**
+3. **`SpeciesConstructor` for @@split** (`species-ctor{,-y,-err,-ctor-non-obj,-species-non-ctor}`,
    `splitter-proto-from-ctor-realm`): `C = SpeciesConstructor(rx, %RegExp%)` then
    `Construct(C, [rx, flags])` — bridging a user constructor through the native
-   split. Deep.
-6. **method-as-value (`name.js`)**: `RegExp.prototype[Symbol.replace]` accessed as
+   split. Deep. **Senior-depth.**
+4. **method-as-value (`name.js`)**: `RegExp.prototype[Symbol.replace]` accessed as
    a **value** (for `.name`) rather than called — the codegen resolves the member
    to the protocol-id `i32.const 8`, so `verifyProperty(<8>, "name", …)` fails.
    Separate feature (well-known-symbol method as first-class value).

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -14640,6 +14640,33 @@ function collectInterfaceMembers(
       if (info.className === "RegExp" && propName === "lastIndex" && !ctx.standalone && !ctx.wasi) {
         wasmType = { kind: "externref" };
       }
+      // (#3051 Slice 2) `RegExp.prototype.global` / `.unicode` are spec-readonly
+      // booleans, but test262's @@replace/@@split coercion tests redefine them as
+      // writable data properties (`Object.defineProperty(r,'global',{writable:true})`)
+      // and then assign arbitrary values (`r.global = Symbol.replace`, `= {}`,
+      // `= NaN`, …). §22.2.6.11/§22.2.6.14 read the flag back through
+      // `ToBoolean(? Get(rx, "global"|"unicode"))` — i.e. any value coerces at
+      // read time, it is NOT constrained to a boolean on write. Typing the extern
+      // property `boolean` makes the generated `RegExp_set_global(externref, i32)`
+      // setter eagerly ToNumber the assigned value: a Symbol RHS traps ("Cannot
+      // convert a Symbol value to a number") and an object RHS traps ("Cannot
+      // convert object to primitive value") at the wasm boundary, before the value
+      // is ever stored. Carry the slot as `externref` in host mode (mirroring the
+      // #2671 `lastIndex` treatment) so the raw value round-trips onto the native
+      // RegExp and the native @@replace/@@split protocol performs the spec
+      // ToBoolean itself; explicit `r.global` reads coerce externref→boolean at the
+      // use site (a boxed `false` unboxes correctly — see the Slice 2 controls).
+      // Standalone / WASI keep their native struct-field RegExp path (the
+      // `RegExp_*_global` extern import is never emitted there), so only host mode
+      // is retyped.
+      if (
+        info.className === "RegExp" &&
+        (propName === "global" || propName === "unicode") &&
+        !ctx.standalone &&
+        !ctx.wasi
+      ) {
+        wasmType = { kind: "externref" };
+      }
       const isReadonly = member.modifiers?.some((m) => m.kind === ts.SyntaxKind.ReadonlyKeyword) ?? false;
       info.properties.set(propName, { type: wasmType, readonly: isReadonly });
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10620,6 +10620,31 @@ assert._isSameValue = isSameValue;
             if (!_isWasmStruct(a)) return a;
             // Try arities 4 → 1; pick the first emitted dispatcher.
             const exps = callbackState?.getExports();
+            // (#3051 Slice 2) A non-callable DATA struct passed as the second
+            // @@replace/@@split arg — `re[@@replace]("s", {toString(){…}})` /
+            // `re[@@split]("s", {valueOf(){…}})` — must NOT be wrapped as a
+            // callable. §22.2.6.11 does `IsCallable(replaceValue)` (false here)
+            // then `ToString(replaceValue)`; §22.2.6.14 does `ToUint32(limit)`.
+            // But `_wrapWasmClosure` false-positives on ANY struct whenever the
+            // module exports `__call_fn_N` (it checks dispatcher existence, not
+            // closure-ness), so the object-literal arg got wrapped as a callable
+            // `replacerBridge`, V8 saw `functionalReplace = true`, INVOKED it,
+            // and `ToString` of the bogus return produced "null" (the
+            // `arg-2-coerce` failure). Gate on the positive `__is_data_struct`
+            // discriminator (the same marker `_wrapForHost`'s get-trap uses):
+            // a data struct routes straight to `_wrapForHost` (property proxy)
+            // so native `ToString` / `ToPrimitive` reaches its `toString` /
+            // `valueOf` closure fields. Genuine function closures are never in
+            // the data-struct set, so they still fall through to the callable
+            // bridge below unchanged.
+            try {
+              const isDataFn = exps?.__is_data_struct as ((v: any) => number) | undefined;
+              if (typeof isDataFn === "function" && isDataFn(a) === 1) {
+                return _wrapForHost(a, exps);
+              }
+            } catch {
+              // discriminator unavailable — fall through to the closure-bridge path
+            }
             if (exps) {
               for (const ar of [4, 3, 2, 1] as const) {
                 if (typeof exps[`__call_fn_${ar}`] === "function") {

--- a/tests/issue-3051.test.ts
+++ b/tests/issue-3051.test.ts
@@ -34,6 +34,26 @@ async function run(source: string, fn = "test"): Promise<unknown> {
   return (instance.exports as never as Record<string, () => unknown>)[fn]!();
 }
 
+// Slice 2 cases assign arbitrary values to RegExp's spec-readonly flag
+// properties (`r.global = Symbol.replace`) after `Object.defineProperty`
+// re-marks them writable — code TypeScript rejects at type-check time
+// (`Cannot assign to 'global' because it is a read-only property`). The
+// production test262 runner compiles every test with `skipSemanticDiagnostics:
+// true` (see tests/test262-runner.ts), so mirror that here to exercise the same
+// codegen path (the typed `RegExp_set_global` setter) the conformance run does.
+async function runLoose(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  if (typeof imports.setExports === "function") {
+    imports.setExports(instance.exports as Record<string, Function>);
+  }
+  return (instance.exports as never as Record<string, () => unknown>)[fn]!();
+}
+
 describe("#3051 — RegExp @@replace result-array coercion", { timeout: 30000 }, () => {
   it("coerces result 'index' via ToIntegerOrInfinity (index is an object with valueOf)", async () => {
     // test262: Symbol.replace/result-coerce-index.js
@@ -118,5 +138,96 @@ describe("#3051 — RegExp @@replace result-array coercion", { timeout: 30000 },
       }
     `);
     expect(out).toBe("hello|cap1|len=2");
+  });
+});
+
+describe("#3051 Slice 2 — arg / flag coercion", { timeout: 30000 }, () => {
+  it("ToString's a non-callable replaceValue (arg-2-coerce)", async () => {
+    // test262: Symbol.replace/arg-2-coerce.js — replaceValue is a non-callable
+    // object; §22.2.6.11 step 7a does `replaceValue = ? ToString(replaceValue)`
+    // (its `toString`, not `valueOf`, since ToString hints "string"). Before the
+    // fix `wrapCallable` wrapped the object as a callable bridge, V8 saw
+    // functionalReplace=true, invoked it, and ToString of the return was "null".
+    const out = await run(`
+      export function test(): string {
+        const arg: any = {
+          valueOf: function(): number { throw new Error("valueOf must not run"); },
+          toString: function(): string { return "toString value"; },
+        };
+        return (/./ as any)[Symbol.replace]("string", arg) as string;
+      }
+    `);
+    expect(out).toBe("toString valuetring");
+  });
+
+  it("propagates a throwing toString on the replaceValue (arg-2-coerce-err)", async () => {
+    // test262: Symbol.replace/arg-2-coerce-err.js — the replaceValue's toString
+    // throws; the abrupt completion must surface as the program's own error.
+    const out = await run(`
+      export function test(): number {
+        const arg: any = {
+          toString: function(): string { throw new Error("boom"); },
+        };
+        try {
+          (/./ as any)[Symbol.replace]("string", arg);
+          return 0;
+        } catch (e) {
+          return 1;
+        }
+      }
+    `);
+    expect(out).toBe(1);
+  });
+
+  it("coerces a Symbol assigned to a writable .global to ToBoolean=true (coerce-global)", async () => {
+    // test262: Symbol.replace/coerce-global.js — `r.global = Symbol.replace`
+    // after re-marking .global writable. §22.2.6.11 step 8 reads it as
+    // `ToBoolean(? Get(rx,"global"))` → truthy → exec loops (called twice).
+    const out = await runLoose(`
+      export function test(): number {
+        const r = /a/;
+        let execCount = 0;
+        Object.defineProperty(r, "global", { writable: true });
+        r.exec = function (): any {
+          execCount += 1;
+          if (execCount === 1) { return ["a"]; }
+          return null;
+        };
+        execCount = 0;
+        r.global = Symbol.replace;
+        r[Symbol.replace]("aa", "b");
+        return execCount;
+      }
+    `);
+    expect(out).toBe(2);
+  });
+
+  it("coerces falsy values assigned to a writable .global to ToBoolean=false", async () => {
+    // test262: Symbol.replace/coerce-global.js — `r.global = undefined|false`
+    // → non-global replace (only the first match is replaced).
+    const out = await runLoose(`
+      export function test(): string {
+        const r = /a/g;
+        Object.defineProperty(r, "global", { writable: true });
+        r.lastIndex = 0;
+        r.global = false;
+        return r[Symbol.replace]("aa", "b");
+      }
+    `);
+    expect(out).toBe("ba");
+  });
+
+  it("coerces a Symbol assigned to a writable .unicode without trapping (coerce-unicode)", async () => {
+    // test262: Symbol.replace/coerce-unicode.js — assigning a Symbol to a
+    // writable .unicode must coerce via ToBoolean, not ToNumber (which traps).
+    const out = await runLoose(`
+      export function test(): string {
+        const r = /a/;
+        Object.defineProperty(r, "unicode", { writable: true });
+        r.unicode = Symbol.replace;
+        return r[Symbol.replace]("a", "b");
+      }
+    `);
+    expect(out).toBe("b");
   });
 });


### PR DESCRIPTION
## #3051 Slice 2 — RegExp `@@replace`/`@@split` arg & flag coercion

Two **dev-doable** clusters from the #3051 Slice-1 remaining-work list (senior-depth clusters deferred to Slice 3+).

### Cluster 2 — replaceValue `ToString` (`arg-2-coerce{,-err}`)
`re[@@replace](s, obj)` with a non-callable `{toString(){…}}` replaceValue must do `ToString(replaceValue)` (§22.2.6.11 step 7a). In `__regex_symbol_call`, `wrapCallable` probed the arg with `_wrapWasmClosure`, which **false-positives on ANY struct** when the module exports `__call_fn_N` (it checks dispatcher existence, not closure-ness). So the object-literal arg got wrapped as a callable bridge → V8 saw `functionalReplace = true`, invoked it, and `ToString` of the bogus return was `"null"`. **Fix:** gate `wrapCallable` on the positive `__is_data_struct` discriminator (same marker `_wrapForHost`'s get-trap uses) — a data struct routes straight to `_wrapForHost` so native `ToString`/`ToPrimitive` reaches its `toString`/`valueOf`; genuine closures are never in the data-struct set, so functional replace is unchanged.

### Cluster 3 — flag Symbol-coercion (`coerce-global`, `coerce-unicode`)
test262 re-marks spec-readonly `.global`/`.unicode` writable then assigns arbitrary values (`r.global = Symbol.replace`). The extern property typed `boolean` made the generated `RegExp_set_global(externref, i32)` setter eagerly `ToNumber` the RHS → a Symbol trapped at the wasm boundary. **Fix:** retype `.global`/`.unicode` to `externref` in host mode (mirrors #2671 `lastIndex`) so the raw value round-trips onto the native RegExp and the native protocol performs the spec `ToBoolean`; explicit reads coerce externref→boolean at the use site (verified boxed `false` unboxes falsy, `=== true`/`=== false` work).

### Validation (local, isolated per-file, apples-to-apples vs `origin/main`)
- `built-ins/RegExp/prototype/Symbol.{replace,split}`: **83 → 88 pass (+5)**, zero regressions. Flips: `arg-2-coerce`, `arg-2-coerce-err`, `coerce-global`, `coerce-unicode`, `Symbol.split/coerce-limit-err` (bonus).
- Delegating corpus (459 files: `String.prototype.{replace,replaceAll,split,match,matchAll,search}` + `RegExp.prototype.{global,unicode,Symbol.match,Symbol.matchAll,Symbol.search}`): **0 regressions**.
- Regex vitest suites (issue-1329-b3 / 1539 / 1911 / 1912 / 2161): unchanged (2 pre-existing standalone-refusal fails are on `origin/main` too).
- `tests/issue-3051.test.ts`: **10/10** (5 new Slice-2 cases).

Issue #3051 stays `in-progress` — remaining clusters (result-`*-err` abrupt-throw bridging, @@split object-arg ToPrimitive, `SpeciesConstructor`, method-as-value) are senior-depth (documented in the issue file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS