### PR TITLE
fix(#1524): test262 byteConversionValues + TA constructor-list harness globals

### DIFF
--- a/plan/issues/1524-test262-harness-resizable-buffer-ctors-fixture.md
+++ b/plan/issues/1524-test262-harness-resizable-buffer-ctors-fixture.md
@@ -1,9 +1,11 @@
 ---
 id: 1524
 title: "test262 harness: TypedArray `ctors` fixture not visible in resizable-buffer tests"
-status: backlog
+status: done
+assignee: sendev-1524
 created: 2026-05-20
-updated: 2026-05-20
+updated: 2026-07-05
+completed: 2026-07-05
 priority: medium
 feasibility: easy
 reasoning_effort: medium
@@ -99,6 +101,64 @@ count bumped to 259 (default); still `feasibility: easy`, still `backlog`.
 Flagging as a good candidate for promotion to `sprint: current` — cheap,
 well-scoped, and now confirmed to unblock **259 + 175 = 434** combined
 test262 fails across both lanes (PO call, not made here).
+
+## Resolution — 2026-07-05 (measure-first, sendev-1524)
+
+**The harvest mis-characterized this as a single uniform "easy: provide the
+global" win.** Measured on current `upstream/main` (b8dc61ba3), the 259-fail
+bucket is really three sub-buckets with very different feasibility:
+
+1. **Resizable `ctors` / `floatCtors` (~180, the DOMINANT sub-bucket) — NOT
+   easy, deliberately NOT shipped.** These are the `built-ins/{Array,TypedArray}
+   /**/resizable-buffer-*.js` tests. Providing `ctors` gets past the
+   `ReferenceError`, but the harness helper `CreateRabForTest` then does
+   `new ctor(rab)` where `ctor` is a *dynamic* constructor variable and `rab`
+   is an untyped (`any`/externref) resizable ArrayBuffer. That fails **Wasm
+   validation inside the helper function** (`call[0] expected type (ref null 2),
+   found externref`), turning every one of the ~180 `fail`s into a
+   `compile_error` with **zero** new passes — a lateral move that would also
+   risk tripping the `single bucket >50` regression gate. Root cause is a real
+   codegen gap: **dynamic `new <ctorVar>(<resizable-buffer>)` + resizable
+   ArrayBuffer semantics** (`new ArrayBuffer(n, {maxByteLength})` / `.resize()`
+   are recognized member names but have no native bodies yet — see
+   `src/codegen/array-object-proto.ts` ARRAYBUFFER_PROTO_METHODS, "degrade to a
+   catchable TypeError until per-member native bodies land"). **Split out as a
+   follow-up** (needs #2940-class dispatch + resizable-buffer support, not a
+   harness shim).
+
+2. **`byteConversionValues` (~17) — genuinely easy, SHIPPED.** Ported the
+   `byteConversionValues.js` fixture (values + per-type expected arrays) as a
+   preamble shim gated on the include. Flips the fill/map/set conversion tests
+   and several TypedArrayConstructors internals + DataView set-values tests.
+
+3. **`typedArrayConstructors` / `floatArrayConstructors` /
+   `nonClampedIntArrayConstructors` / `intArrayConstructors` (~47) — SHIPPED
+   the constant-list shim.** These constants live in `testTypedArray.js` (the
+   runner previously shimmed only the `testWith*` wrapper *functions*, not the
+   bare arrays). Providing them flips the Atomics `validate-arraytype-*` tests
+   to pass and unblocks the rest to reach the **#2940** harness-wrapper vacuity
+   fix (they currently land on `vacuous: harness-wrapper callback never
+   executed (#2940)` rather than the ReferenceError — same non-pass status, no
+   regression, but on the critical path to #2940).
+
+**Measured net delta** (83 tests referencing the target globals, run through
+the real runner, before vs after): **0 → 18 passes, zero regressions.** The
+18: 7 Atomics `validate-arraytype`, 5 TypedArray fill/map/set conversion, 3
+TypedArrayConstructors internals conversion, 2 DataView set-values, 1 harness
+self-test.
+
+**Byte-inertness:** all three shims are gated on `includes.includes(<file>.js)`
+plus a body-reference regex, so any program (test or non-test) that does not
+declare the include keeps a byte-identical preamble.
+
+**Fix location:** `tests/test262-runner.ts` `buildPreamble` — two new
+include-gated shim blocks (`needsTypedArrayCtorArrays`,
+`needsByteConversionValues`) + their gate computations, cache-key entries, and
+call-site args. No compiler/`src` change.
+
+The remaining ~180 resizable-`ctors` tests stay open under a **follow-up**
+(dynamic-ctor-over-resizable-buffer codegen), which is where the bulk of the
+259 (and the #2940 downstream vacuous cluster's resizable slice) actually live.
 
 **Harvest 2026-07-05 re-confirm:** still 259 default-lane `is not defined`
 records (`ctors` / `floatArrayConstructors` / `byteConversionValues` /

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1532,6 +1532,8 @@ function buildPreamble(
   needsDetachBuffer: boolean,
   needs262: boolean,
   needsProxyTraps: boolean,
+  needsTypedArrayCtorArrays: boolean,
+  needsByteConversionValues: boolean,
 ): string {
   let p = `let __fail: number = 0;
 let __assert_count: number = 1;
@@ -1983,6 +1985,99 @@ let $262: any = {
 };`;
   }
 
+  if (needsTypedArrayCtorArrays) {
+    // (#1524) test262 harness/testTypedArray.js also DEFINES the constructor-list
+    // constants (`typedArrayConstructors`, `floatArrayConstructors`,
+    // `nonClampedIntArrayConstructors`, `intArrayConstructors`) that many tests
+    // reference directly (not via a testWith* wrapper). The runner previously
+    // shimmed only the wrapper functions, so bodies iterating these bare arrays
+    // threw `… is not defined`. Values mirror the upstream file.
+    p += `
+
+const floatArrayConstructors: any[] = [Float64Array, Float32Array];
+const nonClampedIntArrayConstructors: any[] = [
+  Int32Array, Int16Array, Int8Array, Uint32Array, Uint16Array, Uint8Array,
+];
+const intArrayConstructors: any[] = [
+  Int32Array, Int16Array, Int8Array, Uint32Array, Uint16Array, Uint8Array, Uint8ClampedArray,
+];
+const typedArrayConstructors: any[] = [
+  Float64Array, Float32Array,
+  Int32Array, Int16Array, Int8Array, Uint32Array, Uint16Array, Uint8Array, Uint8ClampedArray,
+];`;
+  }
+
+  if (needsByteConversionValues) {
+    // (#1524) test262 harness/byteConversionValues.js. Tests reference the
+    // `byteConversionValues` object (a `values` array + per-type `expected`
+    // arrays) at top level; without the include inlined they threw
+    // `byteConversionValues is not defined`. Ported verbatim from the harness.
+    p += `
+
+const byteConversionValues: any = {
+  values: [
+    127, 128, 32767, 32768, 2147483647, 2147483648,
+    255, 256, 65535, 65536, 4294967295, 4294967296,
+    9007199254740991, 9007199254740992,
+    1.1, 0.1, 0.5, 0.50000001, 0.6, 0.7, undefined,
+    -1, -0, -0.1, -1.1, NaN,
+    -127, -128, -32767, -32768, -2147483647, -2147483648,
+    -255, -256, -65535, -65536, -4294967295, -4294967296,
+    -9007199254740991, -9007199254740992,
+    Infinity, -Infinity,
+  ],
+  expected: {
+    Int8: [
+      127, -128, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0, -1, 0,
+      1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0,
+      -127, -128, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0,
+    ],
+    Uint8: [
+      127, 128, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0,
+      1, 0, 0, 0, 0, 0, 0, 255, 0, 0, 255, 0,
+      129, 128, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0,
+    ],
+    Uint8Clamped: [
+      127, 128, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+      1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 0,
+    ],
+    Int16: [
+      127, 128, 32767, -32768, -1, 0, 255, 256, -1, 0, -1, 0, -1, 0,
+      1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0,
+      -127, -128, -32767, -32768, 1, 0, -255, -256, 1, 0, 1, 0, 1, 0, 0, 0,
+    ],
+    Uint16: [
+      127, 128, 32767, 32768, 65535, 0, 255, 256, 65535, 0, 65535, 0, 65535, 0,
+      1, 0, 0, 0, 0, 0, 0, 65535, 0, 0, 65535, 0,
+      65409, 65408, 32769, 32768, 1, 0, 65281, 65280, 1, 0, 1, 0, 1, 0, 0, 0,
+    ],
+    Int32: [
+      127, 128, 32767, 32768, 2147483647, -2147483648, 255, 256, 65535, 65536, -1, 0, -1, 0,
+      1, 0, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0,
+      -127, -128, -32767, -32768, -2147483647, -2147483648, -255, -256, -65535, -65536, 1, 0, 1, 0, 0, 0,
+    ],
+    Uint32: [
+      127, 128, 32767, 32768, 2147483647, 2147483648, 255, 256, 65535, 65536, 4294967295, 0, 4294967295, 0,
+      1, 0, 0, 0, 0, 0, 0, 4294967295, 0, 0, 4294967295, 0,
+      4294967169, 4294967168, 4294934529, 4294934528, 2147483649, 2147483648, 4294967041, 4294967040, 4294901761, 4294901760, 1, 0, 1, 0, 0, 0,
+    ],
+    Float32: [
+      127, 128, 32767, 32768, 2147483648, 2147483648, 255, 256, 65535, 65536, 4294967296, 4294967296, 9007199254740992, 9007199254740992,
+      1.100000023841858, 0.10000000149011612, 0.5, 0.5000000149011612, 0.6000000238418579, 0.699999988079071, NaN,
+      -1, -0, -0.10000000149011612, -1.100000023841858, NaN,
+      -127, -128, -32767, -32768, -2147483648, -2147483648, -255, -256, -65535, -65536, -4294967296, -4294967296, -9007199254740992, -9007199254740992, Infinity, -Infinity,
+    ],
+    Float64: [
+      127, 128, 32767, 32768, 2147483647, 2147483648, 255, 256, 65535, 65536, 4294967295, 4294967296, 9007199254740991, 9007199254740992,
+      1.1, 0.1, 0.5, 0.50000001, 0.6, 0.7, NaN,
+      -1, -0, -0.1, -1.1, NaN,
+      -127, -128, -32767, -32768, -2147483647, -2147483648, -255, -256, -65535, -65536, -4294967295, -4294967296, -9007199254740991, -9007199254740992, Infinity, -Infinity,
+    ],
+  },
+};`;
+  }
+
   if (needsProxyTraps) {
     // #2183: test262 harness/proxyTrapsHelper.js. Returns a Proxy handler where
     // every trap defaults to a stub that throws a Test262Error when invoked
@@ -2322,6 +2417,17 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   // includes this helper failed at construction.
   const needsProxyTraps = includes.includes("proxyTrapsHelper.js") && /\ballowProxyTraps\b/.test(body);
 
+  // (#1524) testTypedArray.js constructor-list constants referenced directly
+  // (not via a testWith* wrapper).
+  const needsTypedArrayCtorArrays =
+    includes.includes("testTypedArray.js") &&
+    /\b(typedArrayConstructors|floatArrayConstructors|nonClampedIntArrayConstructors|intArrayConstructors)\b/.test(
+      body,
+    );
+  // (#1524) byteConversionValues.js fixture object.
+  const needsByteConversionValues =
+    includes.includes("byteConversionValues.js") && /\bbyteConversionValues\b/.test(body);
+
   // #1523: test262 host-object `$262`. Tests use it as a precondition for
   // realm creation, ArrayBuffer detach, agent messaging, and global access.
   // We expose a minimal stub: createRealm returns a fresh global with eval,
@@ -2356,6 +2462,8 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
     needsDetachBuffer,
     needs262,
     needsProxyTraps,
+    needsTypedArrayCtorArrays,
+    needsByteConversionValues,
   ]
     .map((b) => (b ? "1" : "0"))
     .join("");
@@ -2388,6 +2496,8 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
       needsDetachBuffer,
       needs262,
       needsProxyTraps,
+      needsTypedArrayCtorArrays,
+      needsByteConversionValues,
     );
     preambleCache.set(cacheKey, preamble);
   }


### PR DESCRIPTION
## Summary

The test262 runner hand-shims harness helpers in `buildPreamble` (it does not inline the include files). Two commonly-referenced harness fixtures were never shimmed, so tests referencing them at top level threw `… is not defined` before their first assertion:

- **`byteConversionValues.js`** — the `byteConversionValues` object (values + per-type expected arrays).
- **`testTypedArray.js` constructor-list constants** — `typedArrayConstructors`, `floatArrayConstructors`, `nonClampedIntArrayConstructors`, `intArrayConstructors`. The runner previously shimmed only the `testWith*` wrapper *functions*, not the bare arrays.

This PR adds two **include-gated** preamble shims (`needsByteConversionValues`, `needsTypedArrayCtorArrays`).

## Measured impact (measure-first)

Ran the 83 tests referencing these globals through the real runner, before vs after:

**0 → 18 passes, zero regressions.** The 18: 7 Atomics `validate-arraytype-*`, 5 TypedArray fill/map/set conversion, 3 TypedArrayConstructors internals conversion, 2 DataView set-values, 1 harness self-test.

Both shims are **byte-inert** for any program that does not declare the include (gated on `includes.includes(<file>.js)` + a body-reference regex).

## Scope note — the harvest mis-characterized #1524

The 259-fail harvest bucket is **not** one uniform easy win. Measure-first split it into three:

1. **Resizable `ctors`/`floatCtors` (~180, dominant) — NOT easy, deliberately NOT shipped.** Providing `ctors` only moves the failure to a **Wasm-validation compile_error** inside the harness helper `CreateRabForTest` — `new ctorVar(resizableBuffer)` (dynamic constructor over an untyped resizable ArrayBuffer) + unimplemented resizable-ArrayBuffer semantics (`.resize()` / `new ArrayBuffer(n,{maxByteLength})`). Zero passes, and would risk the `bucket >50` gate. Split out as a **codegen follow-up**.
2. **`byteConversionValues` (~17) — shipped, genuine passes.**
3. **TA constructor-list arrays (~47) — shipped;** flips the Atomics tests and unblocks the rest toward the **#2940** vacuity fix (they now land on `#2940 vacuous`, same non-pass status, no regression).

Full per-bucket breakdown is in the issue file.

Touches only `tests/test262-runner.ts` (no `src/` change) + the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)