### PR TITLE
feat(#3054 B1): shared-backing TypedArray/DataView views over ArrayBuffer

### DIFF
--- a/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
+++ b/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
@@ -486,3 +486,34 @@ B2 (view accessor props `.byteLength`/`.byteOffset`/`.buffer` identity/
 this representation with no rework — the `$__ta_view` already carries a
 `byteOffset` field (pinned 0 in B1) that B2 populates, and the byte engine is
 offset-agnostic. B3 (proto methods over a view receiver) then follows.
+
+### B1 addendum — Option A (de-view materialization) + floor-neutral (opus-3054-b1)
+
+The first B1 cut regressed **-2** on the scoped standalone floor: 2 `resizable-arraybuffer`
+tests (`fill/absent-indices-…`, `includes/index-compared-…`) construct a TA over a buffer
+then call a prototype method; `.fill`/`.includes` `ref.cast` the receiver to the native
+element-typed vec, which **traps** on a `$__ta_view` (the B3 gap). Fixed **floor-neutral**:
+- **De-view materialization** (`emitTaViewToVec`): at `compileArrayMethodCall`, a
+  `$__ta_view` identifier-local receiver is byte-decoded into a fresh native vec and the
+  `localMap` is rebound for the call (restored after). De-aliasing — mutating-method writes
+  land in the copy, not the buffer (B1 never claimed proto-method write-through; that's B3).
+- **Bounds-checked view read/write**: OOB read → NaN (§10.4.5.15 undefined), OOB write →
+  no-op (§10.4.5.16), matching the native bounds-checked vec (no trap).
+- **Re-measured**: NET **0** (+0/-0) on built-ins/{TypedArray,DataView,ArrayBuffer} (2195
+  files) vs upstream/main. Byte-inert preserved (sha256 identical for array-method controls).
+
+### Measurement-integrity finding (surfaced to the lead — separate issue)
+While measuring, discovered the **standalone lane does not enforce NUMERIC equality
+assertions**. Reproduced through the real `wrapTest`: `assert.sameValue(1, 2)` → standalone
+`test()` returns **1 (pass)**, host returns 2 (fail); `assert.sameValue("a","b")` → 2 in
+BOTH (strings enforced). Trigger: the harness preamble **unconditionally** injects
+`class Test262Error`; with it present, the numeric assert path
+`assert_sameValue`→`isSameValue(a: any, b: any)`→`a === b` compiles the `any`-boxed number
+compare incorrectly in standalone (returns "equal" for unequal), so `__fail` is never set.
+String/bool asserts route to typed `assert_sameValue_str`/`_bool` (test262-runner.ts:1633/
+1651) and ARE enforced; there is **no `_num` specialization** so numeric asserts fall onto
+the buggy `any` path. **Implication:** a large fraction of numeric-heavy standalone
+"passes" (TypedArray/DataView/ArrayBuffer/Number/Math) are vacuous → the standalone floor %
+and the standalone-gap prioritization need recalibration. Fix directions: (a) harness-prelude
+`assert_sameValue_num(number,number)` routing (cheap, sidesteps the codegen bug), or (b) fix
+standalone `any === any`-on-boxed-numbers when an object-runtime/class is present.

--- a/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
+++ b/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
@@ -1,7 +1,8 @@
 ---
 id: 3054
 title: "Resizable ArrayBuffer + dynamic `new <ctorVar>(rab)` — the ~180 codegen gap under #1524"
-status: ready
+status: in-progress
+assignee: ttraenkler/opus-3054-b1
 created: 2026-07-05
 updated: 2026-07-05
 priority: medium
@@ -412,3 +413,76 @@ Probes (compile + instantiate via
 `src/runtime-instantiate.ts#compileAndInstantiate`, WAT via `compileToWat`)
 confirmed each gap above. Full probe transcript in the PR discussion / sendev
 report.
+
+## B1 — shared-backing views (LANDED, opus-3054-b1, on `upstream/main` @ ad61af55d)
+
+**Scope shipped:** `new <TA>(arrayBuffer)` / `new DataView(arrayBuffer)` now
+produce a SHARED-BACKING view that refs the buffer's vec struct instead of
+copying its bytes — offset-0, default-length window, element read + write. Fixes
+the exact verified bug (sibling TA + DataView write-observability). Standalone /
+WASI lane only (the native `i32_byte` vec representation of ArrayBuffer exists
+only host-free; host-mode buffers are host objects — see the lane note below).
+
+### What changed (WHY, per the A.1 decision)
+- **New type `$__ta_view_<name>`** (`getOrRegisterTaViewType`, `registry/types.ts`)
+  — `{length:i32 (elem count), buf:(ref null $__vec_i32_byte), byteOffset:i32}`,
+  subtype of `$__vec_base`. Registered **late + once, memoized on
+  `ctx.taViewTypeMap`**, keyed per TS view name (each kind needs a distinct
+  typeIdx so element decode — width / signedness / float / clamp — is recovered
+  purely from the receiver's static `ValType.typeIdx`, no runtime tag). Mirrors
+  `getOrRegisterSubviewType` / `getOrRegisterDvWindowType` exactly → no
+  type-index-shift hazard (types are append-only; the subtype follows its
+  supertype in the recgroup, same as `$__subview`). **`buf` refs the VEC STRUCT,
+  not the inner array** — the deliberate A.1 forward-compat choice so a future
+  Phase-C resize (swap `buf.data`) is observed by the view for free.
+- **Ctor swap** (`emitTaViewConstruct`, `dataview-native.ts`): replaced the copy
+  loop `emitTypedArrayFromByteBuffer` (deleted) with `struct.new $__ta_view
+  {length = buf.byteLength/elemSize, buf, byteOffset = 0}`. Wired at both ctor
+  sites (`new-super.ts` ~3603 / ~4600).
+- **Element arms** (`emitTaViewElementGet` / `emitTaViewElementSet`,
+  `dataview-native.ts`): `ta[i]` byte-decodes LE from `buf.data` at
+  `byteOffset + i*width` via the EXISTING `emitReadBytes` / `emitWriteBytes`
+  engine. Read arm in `property-access.ts` (before the `$__subview` arm), write
+  arm in `assignment.ts` (before the vec-struct-assign check). Uint8Clamped write
+  applies ToUint8Clamp (`f64.nearest` ties-to-even + `[0,255]` clamp; NaN→0 via
+  trunc_sat).
+- **Local-type inference** (`inferTaViewType`, `statements/variables.ts`): a
+  `const a = new <TA>(buffer)` binding resolves its LOCAL type to the
+  `$__ta_view` (mirroring `inferSubarraySubviewType`) so `a[i]` / `a[i]=v` /
+  `a.length` pick the view lowering at compile time. **Without this the local
+  took `resolveWasmType(Uint8Array)` = the native vec type and the arms were
+  bypassed** (the reason the first cut null-deref'd). Gate matches the ctor
+  exactly: host-free lane, single non-numeric buffer arg.
+- **`.length` arm** (`property-access.ts` ~5081): the local-type length reader
+  now also accepts a `$__ta_view` (its field0 is the element count) — was
+  keyed on `fields[1] === "data"`, which a view (`fields[1] === "buf"`) failed,
+  reading 0. Element count, not byte length.
+
+### Lane note (why standalone-only, corrects a premise)
+The task framed this as fixing the host lane too, but measurement showed
+host-mode `new ArrayBuffer(8).byteLength` → `NaN`: **host-mode ArrayBuffer is a
+host object, not a native `i32_byte` vec.** The view needs the native vec, so
+enabling it in host mode would `ref.cast`-trap on host buffers (the exact #1670
+class that gated the original copy path to `noJsHost`). B1 therefore stays
+host-free-lane; host buffer-view support is a separate follow-up (route through
+the runtime). The standalone floor is where B1's delta lands (CI merge_group).
+
+### Validation
+- **Reproduction fixed** — the verified probes now pass in standalone:
+  `a[0]=99;b[0]` → 99; DataView-over-buf → 7; Int32 sibling → 12345.
+- **`tests/issue-3054-b1-shared-views.test.ts`** — 15 standalone assertions
+  (sibling/DataView both directions, cross-width byte layout, sign-extend,
+  modular wrap, Uint32 > 2^31, Float32/64, Uint8Clamped clamp + ties-to-even,
+  `.length` element count, `.length`-loop iteration). All green.
+- **Byte-inert proof** — sha256 of the standalone binary is IDENTICAL between
+  `upstream/main` and this branch for 6 control programs (arith, plain array,
+  string, **TA count-ctor `new Uint8Array(4)`**, **DataView setInt32/getInt32**,
+  class object). Only `new <TA>(buffer)` programs change bytes.
+- `tsc --noEmit` clean; prettier clean.
+
+### Next: B2 is cleanly next
+B2 (view accessor props `.byteLength`/`.byteOffset`/`.buffer` identity/
+`BYTES_PER_ELEMENT` + `new TA(buf, byteOffset, length)` windowing) composes on
+this representation with no rework — the `$__ta_view` already carries a
+`byteOffset` field (pinned 0 in B1) that B2 populates, and the byte engine is
+offset-agnostic. B3 (proto methods over a view receiver) then follows.

--- a/plan/issues/3055-standalone-any-eq-boxed-number-class-present.md
+++ b/plan/issues/3055-standalone-any-eq-boxed-number-class-present.md
@@ -1,0 +1,93 @@
+---
+id: 3055
+title: "Standalone `any === any` on boxed numbers returns equal-for-unequal when an object-runtime/class is present"
+status: ready
+created: 2026-07-05
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: strict-equality, any-boxing, standalone
+es_edition: ES2015
+test262_category: (broad — numeric equality)
+goal: standalone-mode
+related: [3054, 3056]
+---
+
+# #3055 — Standalone boxed-number strict-equality miscompiles when a class is present
+
+## Summary
+
+In the **standalone / WASI lane**, `a === b` where both operands are `any`-typed
+(tag-boxed) **numbers** returns the WRONG result — it answers _equal_ for
+**unequal** numbers — **when the module also defines a class** (or otherwise
+pulls in the object-runtime / tag machinery). Two boxed numbers `1` and `2`
+compare `===` as `true`. This is a real correctness miscompile that affects **user
+programs**, not just the test harness — it was _discovered_ via the harness (see
+#3054 measurement-integrity finding) but is not harness-specific.
+
+## Reproduction (all on `upstream/main`, `--target standalone`)
+
+Verified via `compile(src, { target: "standalone" })` + `instantiateWasm`:
+
+```ts
+function eq(a: any, b: any): number {
+  return a === b ? 1 : 0;
+}
+export function test(): number {
+  return eq(1, 2);
+} // → 0 (CORRECT, no class)
+```
+
+```ts
+// The SAME with a class in the module regresses through the harness path:
+// via the real test262 wrapTest, `assert.sameValue(1, 2)` returns test()=1 (PASS)
+// in standalone but 2 (FAIL) in host. Bisection: removing the unconditionally
+// injected `class Test262Error { ... }` from the wrapped source flips standalone
+// 1 → 2. So: class present + any-boxed numeric `===` → equal-for-unequal.
+```
+
+- **Minimal `eq(1,2)` + a class** did NOT reproduce in isolation — the trigger
+  needs the fuller module shape the harness produces (class + the `isSameValue`/
+  `assert_sameValue` nest + the other `any`-param shims). The **robust, stable
+  repro** is: the real `tests/test262-runner.ts#wrapTest` output for
+  `assert.sameValue(1, 2)`, compiled `--target standalone`, returns `test()=1`;
+  delete `class Test262Error` → returns `2`. (Transcript in the #3054 discussion.)
+- **String** operands are unaffected: `assert.sameValue("a","b")` → 2 (FAIL) in
+  both lanes. Only the boxed-**number** `===` path miscompiles.
+
+## Suspected root cause (for the architect)
+
+The object-runtime / tag allocation (registered when a class exists) perturbs the
+**tag-boxed number strict-equality** path — likely the tag-5/tag-6 boxed-primitive
+`===` arm (see memory `reference_1629b_boxed_primitive_typeof_eq_layers`,
+`reference_2040_tag5_field4_three_way_classifier`, `reference_2583_any_strict_eq_tag5_host_only`).
+The hypothesis: with an object-runtime present, two boxed f64s route through a
+ref-identity / same-tag arm that answers identity (or a vacuous constant) instead
+of unboxing and comparing the f64 values. Needs a WAT-level trace of `any === any`
+on two boxed numbers with vs. without a class registered, to find the diverging arm.
+
+## Why this matters
+
+- **User-program correctness**: any standalone program that compares two
+  `any`/`unknown`-typed numbers with `===` (or `!==`) in a module that also has a
+  class can silently get the wrong answer.
+- **Measurement integrity**: it is the mechanism behind the standalone floor NOT
+  enforcing numeric assertions (#3056) — a large fraction of numeric-heavy
+  standalone "passes" are vacuous because the harness's `isSameValue` rides this
+  path. Fixing #3055 is the _correct_ fix; #3056 (harness `_num` routing) only
+  sidesteps it.
+
+## Acceptance criteria
+
+- `eq(a: any, b: any) => a === b` returns the correct result for two boxed numbers
+  in standalone **regardless of whether the module defines a class**.
+- The real `wrapTest` output for `assert.sameValue(1, 2)` returns `test()=2`
+  (FAIL) in standalone, matching host.
+- No regression to boxed-string / boxed-object / mixed `===` (tag-5/6 arms).
+- **Coordinated with #3056**: enforcing numeric asserts will turn currently-vacuous
+  numeric standalone "passes" into honest FAILS → the `host_free_pass` floor DROPS.
+  This is a deliberate measurement RE-BASELINE (the floor gate would auto-park it
+  as a false regression) and a **human decision** — do NOT land unilaterally under
+  the autonomous loop. See #3056.

--- a/plan/issues/3056-standalone-numeric-assert-vacuity-num-specialization.md
+++ b/plan/issues/3056-standalone-numeric-assert-vacuity-num-specialization.md
@@ -1,0 +1,89 @@
+---
+id: 3056
+title: "Standalone numeric assertions are vacuous — add `assert_sameValue_num` harness routing (measurement re-baseline)"
+status: ready
+created: 2026-07-05
+priority: high
+feasibility: medium
+task_type: measurement-integrity
+area: test-harness
+language_feature: test262-runner, standalone-floor
+goal: standalone-mode
+related: [3054, 3055]
+---
+
+# #3056 — Standalone numeric assertions are not enforced (vacuous host_free_pass)
+
+## Summary
+
+The **standalone lane does not enforce NUMERIC equality assertions**. A test whose
+only failing assertion is numeric (`assert.sameValue(x, y)` with number operands)
+is scored **pass** in standalone even when the assertion is FALSE — it "passes"
+merely by compiling + running to completion without an uncaught trap. **String**
+and **boolean** assertions ARE enforced. So a large fraction of numeric-heavy
+standalone "passes" (TypedArray / DataView / ArrayBuffer / Number / Math — nearly
+all assert on numbers) are **vacuous**, and the headline standalone
+`host_free_pass` floor % overstates real numeric conformance.
+
+## Reproduction (through the real `wrapTest`, `--target standalone`)
+
+- `assert.sameValue(1, 2)` → standalone `test()` returns **1 (PASS)**; host returns
+  **2 (FAIL)**.
+- `assert.sameValue("a","b")` → **2 (FAIL)** in BOTH lanes (strings enforced).
+
+## Mechanism (pinpointed)
+
+`tests/test262-runner.ts`:
+
+- Numeric `assert.sameValue` → `assert_sameValue(actual: any, expected: any)`
+  (~:1577) → `isSameValue(a: any, b: any)` (~:1571) → `a === b`. In standalone,
+  that boxed-number `any === any` miscompiles (**root cause: #3055**) so `__fail`
+  is never set → `test()` returns 1 → scored pass.
+- String / bool asserts DODGE it: `wrapTest` routes them to TYPED specializations
+  `assert_sameValue_str` (~:1633) and `assert_sameValue_bool` (~:1651) whose params
+  are `string` / `boolean` → a direct compare, no `any`-boxing. The routing block
+  (~:2219–2328) has `_str` / `_bool` / `typeof` cases but **no numeric case**, so
+  numeric asserts fall onto the buggy generic `any` path.
+
+## Proposed fix (cheap; sidesteps #3055)
+
+Add a typed numeric specialization mirroring `_str` / `_bool`:
+
+```ts
+function assert_sameValue_num(actual: number, expected: number): void {
+  __assert_count = __assert_count + 1;
+  // SameValue on numbers: equal, or both NaN.
+  if (!(actual === expected || (actual !== actual && expected !== expected))) {
+    if (!__fail) __fail = __assert_count;
+  }
+}
+```
+
+and route `assert_sameValue(numExpr, numLit | numExpr)` → `assert_sameValue_num`
+in `wrapTest` (same shape as the existing `_str` / `_bool` routing). `number`
+params compile to a direct f64 `===`, avoiding the any-boxing path. Do the same
+for `assert_notSameValue_num`.
+
+## CRITICAL — this is a measurement RE-BASELINE, not a normal PR
+
+Enforcing numeric asserts turns currently-vacuously-"passing" numeric tests into
+**honest FAILS** → the standalone `host_free_pass` floor **DROPS** (potentially by
+a lot). The floor gate will read that as a large regression and **auto-park** the
+PR. This is expected and correct — it is a deliberate re-baseline of a
+measurement that was over-counting. Therefore:
+
+- **Do NOT land under the autonomous loop.** This changes the headline standalone
+  conformance number and needs the **human's** sign-off + a coordinated floor
+  re-baseline (refresh `test262-current.jsonl` in `loopdive/js2wasm-baselines` and
+  the committed summary in the SAME change, and expect/allow the one-time floor
+  drop).
+- Preferably land **after or together with #3055** (the real codegen fix), so the
+  numbers reflect genuine post-fix conformance rather than harness-only masking.
+
+## Acceptance criteria
+
+- `assert.sameValue(1, 2)` (and arithmetic-derived numeric asserts) are scored
+  **fail** in standalone, matching host.
+- No change to string / bool / typeof assert enforcement.
+- The standalone floor is re-baselined in the same coordinated change, with the
+  one-time drop acknowledged (human-approved), not auto-parked as a false regression.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -30,7 +30,9 @@ import {
   getOrRegisterSubviewType,
   getOrRegisterVecType,
   getSubviewArrTypeIdx,
+  isTaViewTypeIdx,
 } from "./registry/types.js";
+import { emitTaViewToVec } from "./dataview-native.js"; // (#3054 B1 Option A) de-view materialization
 import { noJsHost } from "./expressions/helpers.js";
 import { ensureNativeIteratorRuntime, getOrRegisterIterRecType } from "./iterator-native.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
@@ -2910,6 +2912,12 @@ export function compileArrayMethodCall(
   // through `compileArrayJoinExtern` whenever this is set so the WasmGC-
   // native loop doesn't try to extract a vec struct from a JS array.
   let receiverIsExternref = false;
+  // (#3054 B1 Option A) When the receiver is a `$__ta_view` (shared-backing TA
+  // over a buffer), it can't be `ref.cast` to the native element-typed vec the
+  // method operates on. We materialize the view into a native vec and rebind the
+  // receiver identifier; these hold the rebind so we can restore it post-dispatch.
+  let taViewRebindName: string | undefined;
+  let taViewRebindSaved: number | undefined;
 
   // The receiver's actual Wasm type may differ from the TS type — e.g.
   // `[0, true].lastIndexOf(...)` infers i32 elements during construction,
@@ -2972,13 +2980,32 @@ export function compileArrayMethodCall(
       (actualType as { typeIdx: number }).typeIdx !== vecTypeIdx
     ) {
       const actualVecIdx = (actualType as { typeIdx: number }).typeIdx;
-      const actualArrIdx = getArrTypeIdxFromVec(ctx, actualVecIdx);
-      if (actualArrIdx >= 0) {
-        const actualArrDef = ctx.mod.types[actualArrIdx];
-        if (actualArrDef && actualArrDef.kind === "array") {
-          vecTypeIdx = actualVecIdx;
-          arrTypeIdx = actualArrIdx;
-          elemType = actualArrDef.element;
+      // (#3054 B1 Option A) `$__ta_view` receiver: materialize into the native
+      // element-typed vec (`vecTypeIdx`, from `resolveArrayInfo`) and rebind the
+      // identifier so the method's receiver re-compile loads the copy instead of
+      // ref.cast-trapping on the view. Only the identifier-local case (the
+      // measured regression: `ta.fill(...)`/`ta.includes(...)`); other receiver
+      // shapes are rarer and fall through unchanged.
+      if (isTaViewTypeIdx(ctx, actualVecIdx) && ts.isIdentifier(receiverExpr) && fctx.localMap.has(receiverExpr.text)) {
+        const matLocal = allocLocal(fctx, `__tav_mrecv_${fctx.locals.length}`, {
+          kind: "ref_null",
+          typeIdx: vecTypeIdx,
+        });
+        compileExpression(ctx, fctx, receiverExpr); // loads the view ref
+        emitTaViewToVec(ctx, fctx, actualVecIdx, vecTypeIdx); // → native vec
+        fctx.body.push({ op: "local.set", index: matLocal });
+        taViewRebindName = receiverExpr.text;
+        taViewRebindSaved = fctx.localMap.get(receiverExpr.text);
+        fctx.localMap.set(receiverExpr.text, matLocal);
+      } else {
+        const actualArrIdx = getArrTypeIdxFromVec(ctx, actualVecIdx);
+        if (actualArrIdx >= 0) {
+          const actualArrDef = ctx.mod.types[actualArrIdx];
+          if (actualArrDef && actualArrDef.kind === "array") {
+            vecTypeIdx = actualVecIdx;
+            arrTypeIdx = actualArrIdx;
+            elemType = actualArrDef.element;
+          }
         }
       }
     }
@@ -3230,6 +3257,15 @@ export function compileArrayMethodCall(
     if (ts.isIdentifier(propAccess.expression)) {
       fctx.localMap.delete(propAccess.expression.text);
     }
+  }
+
+  // (#3054 B1 Option A) Restore the receiver identifier's original binding after
+  // the method dispatched on the materialized native-vec copy. The original var
+  // is still the `$__ta_view` (its buffer aliasing is intact for later element
+  // access); only this method call saw the de-viewed copy.
+  if (taViewRebindName !== undefined) {
+    if (taViewRebindSaved !== undefined) fctx.localMap.set(taViewRebindName, taViewRebindSaved);
+    else fctx.localMap.delete(taViewRebindName);
   }
 
   return result;

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -195,6 +195,7 @@ export function createCodegenContext(
     dvWindowTypeIdx: -1, // (#2159/#38) standalone DataView windowing wrapper, lazy
     subviewTypeIdx: -1, // (#2159/#2357/#47) standalone TypedArray subarray view, lazy
     subviewTypeMap: new Map(), // (#2357) per-elem-kind $__subview type idx
+    taViewTypeMap: new Map(), // (#3054 B1) per-TA-name $__ta_view shared-backing view idx
     errorStructTypeIdx: -1,
     widenedTypeProperties: new Map(),
     widenedVarStructMap: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1687,6 +1687,18 @@ export interface CodegenContext {
   subviewTypeIdx: number;
   /** (#2357) Per-element-kind `$__subview` struct type indices, keyed by elemKind. */
   subviewTypeMap: Map<string, number>;
+  /**
+   * (#3054 B1) Per-TypedArray-name `$__ta_view_<name>` struct type indices, keyed
+   * by the TS view name (`"Uint8Array"`, `"Int32Array"`, …). A `$__ta_view` is a
+   * byte-backed TypedArray view that holds a ref to the source ArrayBuffer's
+   * `$__vec_i32_byte` struct (SHARED backing — sibling views and DataViews over
+   * the same buffer observe each other's writes) plus an element `byteOffset`.
+   * Element access byte-decodes little-endian via the dataview-native engine,
+   * discriminated at COMPILE time by the receiver's resolved ValType.typeIdx
+   * (mirroring `subviewTypeMap`), so plain-array / native-TA hot paths are
+   * byte-inert. Map miss = not registered. (Spec: plan/issues/3054 Phase A/B1.)
+   */
+  taViewTypeMap: Map<string, number>;
   /** Type index for the WasmGC `$Error_struct` used in standalone/WASI mode (#1104). -1 = not yet registered. */
   errorStructTypeIdx: number;
   /** Extra properties for empty object variables */

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -44,7 +44,9 @@ import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { getOrRegisterTaViewType, getTaViewName } from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+import { coerceType } from "./type-coercion.js";
 
 /** DataView accessor descriptor parsed from a method name like "getUint32". */
 interface DvAccessor {
@@ -904,6 +906,222 @@ function emitWriteBytes(
     then: storeAll(true),
     else: storeAll(false),
   });
+}
+
+// ---------------------------------------------------------------------------
+// (#3054 B1) Shared-backing TypedArray view element access.
+//
+// A `$__ta_view_<name>` is a byte-backed view over an ArrayBuffer's
+// `$__vec_i32_byte` struct (field1 `buf`). Element `ta[i]` byte-decodes from
+// `buf.data` at `byteOffset + i*width` using the SAME little/big-endian byte
+// engine the native DataView accessors use — pinned little-endian (TypedArrays
+// use native/platform endianness, and Wasm's is LE). Because the view holds a
+// ref to the SHARED buffer vec, sibling views and DataViews over the same buffer
+// observe each other's writes (the verified #3054 bug). Discriminated purely by
+// the receiver's static ValType.typeIdx at compile time, so plain-array /
+// native-TA element access never reaches these arms — byte-inert.
+// ---------------------------------------------------------------------------
+
+/** Per-view-name byte-decode descriptor (width, signedness, float, clamp-on-write). */
+const TA_VIEW_DECODE: Record<string, { bytes: number; signed: boolean; float: boolean; clamp: boolean }> = {
+  Int8Array: { bytes: 1, signed: true, float: false, clamp: false },
+  Uint8Array: { bytes: 1, signed: false, float: false, clamp: false },
+  Uint8ClampedArray: { bytes: 1, signed: false, float: false, clamp: true },
+  Int16Array: { bytes: 2, signed: true, float: false, clamp: false },
+  Uint16Array: { bytes: 2, signed: false, float: false, clamp: false },
+  Int32Array: { bytes: 4, signed: true, float: false, clamp: false },
+  Uint32Array: { bytes: 4, signed: false, float: false, clamp: false },
+  Float32Array: { bytes: 4, signed: false, float: true, clamp: false },
+  Float64Array: { bytes: 8, signed: false, float: true, clamp: false },
+};
+
+/** Resolve a `$__ta_view` typeIdx to its byte-decode descriptor, or undefined. */
+export function taViewDecode(
+  ctx: CodegenContext,
+  taViewTypeIdx: number,
+): { bytes: number; signed: boolean; float: boolean; clamp: boolean } | undefined {
+  const name = getTaViewName(ctx, taViewTypeIdx);
+  return name ? TA_VIEW_DECODE[name] : undefined;
+}
+
+/**
+ * (#3054 B1) `new <TA>(arrayBuffer)` → a shared-backing `$__ta_view_<name>` that
+ * REFS the buffer's `$__vec_i32_byte` struct instead of COPYING its bytes into a
+ * fresh backing array (the verified copy bug: sibling views / DataViews over the
+ * same buffer didn't observe writes). Offset-0, default-length window (B1 scope;
+ * B2 adds `(buffer, byteOffset, length)`). `viewName` is the TS TypedArray name.
+ * `compileExpr` compiles the buffer arg expression. Returns the view ValType, or
+ * null (leaving the stack balanced) when the buffer can't be recovered as a
+ * native vec — the caller then falls back to the numeric-length ctor path.
+ */
+export function emitTaViewConstruct(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  bufExpr: import("../ts-api.js").ts.Expression,
+  viewName: string,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const desc = TA_VIEW_DECODE[viewName];
+  if (!desc) return null;
+  const taViewTypeIdx = getOrRegisterTaViewType(ctx, viewName);
+  const { vecTypeIdx } = i32ByteVec(ctx);
+
+  // Compile the buffer expression and recover the shared i32_byte vec struct.
+  const bufType = compileExpr(bufExpr);
+  if (!bufType) return null;
+  if (bufType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+  } else if (bufType.kind === "ref" || bufType.kind === "ref_null") {
+    if ("typeIdx" in bufType && (bufType as { typeIdx: number }).typeIdx !== vecTypeIdx) {
+      fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+    }
+  } else {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const bufLocal = allocLocal(fctx, `__tav_buf_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
+  fctx.body.push({ op: "local.set", index: bufLocal } as Instr);
+
+  // struct.new order = [length, buf, byteOffset].
+  // length = buf.length (field0 = byteLength) / elementSize.
+  fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  if (desc.bytes !== 1) {
+    fctx.body.push({ op: "i32.const", value: desc.bytes } as Instr);
+    fctx.body.push({ op: "i32.div_u" } as Instr);
+  }
+  // buf (shared vec ref) — `ref` widens to the field's `ref_null` type.
+  fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+  // byteOffset = 0 (B1: offset-0 window).
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: taViewTypeIdx } as Instr);
+  return { kind: "ref_null", typeIdx: taViewTypeIdx };
+}
+
+/**
+ * Recover `buf.data` (the shared i8 backing array) and the absolute byte offset
+ * `byteOffset + index*width` for a `$__ta_view` receiver into the given locals.
+ * The receiver ref (ref/ref_null `$__ta_view`) must already be on the stack; it
+ * is consumed. `indexExpr` is compiled via `compileExpr`. Also sets `leLocal`
+ * to 1 (little-endian, TypedArray native endianness).
+ */
+function emitTaViewAddress(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  taViewTypeIdx: number,
+  bytes: number,
+  indexExpr: import("../ts-api.js").ts.Expression,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+  arrLocal: number,
+  offLocal: number,
+  leLocal: number,
+): void {
+  const { vecTypeIdx, arrTypeIdx } = i32ByteVec(ctx);
+  // Stash the receiver.
+  const tvLocal = allocLocal(fctx, `__tav_recv_${fctx.locals.length}`, { kind: "ref_null", typeIdx: taViewTypeIdx });
+  fctx.body.push({ op: "local.set", index: tvLocal } as Instr);
+  // arr = tv.buf.data  (buf is field1 → ref_null $__vec_i32_byte; .data is its field1)
+  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: arrLocal } as Instr);
+  // off = tv.byteOffset + index*bytes
+  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 2 } as Instr);
+  const it = compileExpr(indexExpr, { kind: "i32" });
+  if (it && it.kind !== "i32") coerceType(ctx, fctx, it, { kind: "i32" });
+  if (bytes !== 1) {
+    fctx.body.push({ op: "i32.const", value: bytes } as Instr);
+    fctx.body.push({ op: "i32.mul" } as Instr);
+  }
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "local.set", index: offLocal } as Instr);
+  // little-endian
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: leLocal } as Instr);
+  void arrTypeIdx;
+}
+
+/**
+ * `ta[i]` read for a `$__ta_view` receiver (already on the stack). Byte-decodes
+ * the element little-endian and leaves an f64 on the stack. Returns the result
+ * ValType, or null if `taViewTypeIdx` is not a registered view.
+ */
+export function emitTaViewElementGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  taViewTypeIdx: number,
+  indexExpr: import("../ts-api.js").ts.Expression,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const desc = taViewDecode(ctx, taViewTypeIdx);
+  if (!desc) return null;
+  const { arrTypeIdx } = i32ByteVec(ctx);
+  const arrLocal = allocLocal(fctx, `__tav_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const offLocal = allocLocal(fctx, `__tav_off_${fctx.locals.length}`, { kind: "i32" });
+  const leLocal = allocLocal(fctx, `__tav_le_${fctx.locals.length}`, { kind: "i32" });
+  emitTaViewAddress(ctx, fctx, taViewTypeIdx, desc.bytes, indexExpr, compileExpr, arrLocal, offLocal, leLocal);
+  emitReadBytes(
+    ctx,
+    fctx,
+    { kind: "get", bytes: desc.bytes, signed: desc.signed, float: desc.float },
+    arrLocal,
+    offLocal,
+    leLocal,
+    arrTypeIdx,
+  );
+  return { kind: "f64" };
+}
+
+/**
+ * `ta[i] = v` write for a `$__ta_view` receiver (already on the stack).
+ * Byte-encodes `v` little-endian into the shared buffer backing (true aliasing).
+ * Leaves the (coerced) value on the stack as the assignment-expression result.
+ */
+export function emitTaViewElementSet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  taViewTypeIdx: number,
+  indexExpr: import("../ts-api.js").ts.Expression,
+  valueExpr: import("../ts-api.js").ts.Expression,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const desc = taViewDecode(ctx, taViewTypeIdx);
+  if (!desc) return null;
+  const { arrTypeIdx } = i32ByteVec(ctx);
+  const arrLocal = allocLocal(fctx, `__tav_sarr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const offLocal = allocLocal(fctx, `__tav_soff_${fctx.locals.length}`, { kind: "i32" });
+  const leLocal = allocLocal(fctx, `__tav_sle_${fctx.locals.length}`, { kind: "i32" });
+  emitTaViewAddress(ctx, fctx, taViewTypeIdx, desc.bytes, indexExpr, compileExpr, arrLocal, offLocal, leLocal);
+  // value → f64
+  const valLocal = allocLocal(fctx, `__tav_sval_${fctx.locals.length}`, { kind: "f64" });
+  const vt = compileExpr(valueExpr, { kind: "f64" });
+  if (vt && vt.kind !== "f64") coerceType(ctx, fctx, vt, { kind: "f64" });
+  if (desc.clamp) {
+    // Uint8Clamped: ToUint8Clamp §7.1.11 — round-half-to-even then clamp [0,255].
+    // f64.nearest rounds ties-to-even; f64.max/min clamp; NaN propagates through
+    // max/min and `emitWriteBytes` (trunc_sat_f64_s(NaN)=0) → NaN maps to 0.
+    fctx.body.push({ op: "f64.nearest" } as Instr);
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+    fctx.body.push({ op: "f64.max" } as Instr);
+    fctx.body.push({ op: "f64.const", value: 255 } as Instr);
+    fctx.body.push({ op: "f64.min" } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: valLocal } as Instr);
+  emitWriteBytes(
+    ctx,
+    fctx,
+    { kind: "set", bytes: desc.bytes, signed: desc.signed, float: desc.float },
+    arrLocal,
+    offLocal,
+    valLocal,
+    leLocal,
+    arrTypeIdx,
+  );
+  // Assignment is an expression — re-push the coerced value as the result.
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  return { kind: "f64" };
 }
 
 /**

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -1016,21 +1016,30 @@ function emitTaViewAddress(
   arrLocal: number,
   offLocal: number,
   leLocal: number,
-): void {
+): { idxLocal: number; lenLocal: number } {
   const { vecTypeIdx, arrTypeIdx } = i32ByteVec(ctx);
   // Stash the receiver.
   const tvLocal = allocLocal(fctx, `__tav_recv_${fctx.locals.length}`, { kind: "ref_null", typeIdx: taViewTypeIdx });
   fctx.body.push({ op: "local.set", index: tvLocal } as Instr);
+  // len = tv.length (field0 = ELEMENT count) — for the bounds check.
+  const lenLocal = allocLocal(fctx, `__tav_len_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
   // arr = tv.buf.data  (buf is field1 → ref_null $__vec_i32_byte; .data is its field1)
   fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
   fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 1 } as Instr);
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
   fctx.body.push({ op: "local.set", index: arrLocal } as Instr);
-  // off = tv.byteOffset + index*bytes
-  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
-  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 2 } as Instr);
+  // idx = ToInt32(indexExpr) — kept for the bounds check.
+  const idxLocal = allocLocal(fctx, `__tav_idx_${fctx.locals.length}`, { kind: "i32" });
   const it = compileExpr(indexExpr, { kind: "i32" });
   if (it && it.kind !== "i32") coerceType(ctx, fctx, it, { kind: "i32" });
+  fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
+  // off = tv.byteOffset + idx*bytes
+  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 2 } as Instr);
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
   if (bytes !== 1) {
     fctx.body.push({ op: "i32.const", value: bytes } as Instr);
     fctx.body.push({ op: "i32.mul" } as Instr);
@@ -1041,12 +1050,16 @@ function emitTaViewAddress(
   fctx.body.push({ op: "i32.const", value: 1 } as Instr);
   fctx.body.push({ op: "local.set", index: leLocal } as Instr);
   void arrTypeIdx;
+  return { idxLocal, lenLocal };
 }
 
 /**
  * `ta[i]` read for a `$__ta_view` receiver (already on the stack). Byte-decodes
- * the element little-endian and leaves an f64 on the stack. Returns the result
- * ValType, or null if `taViewTypeIdx` is not a registered view.
+ * the element little-endian and leaves an f64 on the stack. An out-of-bounds
+ * index yields `NaN` (the f64 image of the spec's `undefined` — §10.4.5.15
+ * IntegerIndexedElementGet returns undefined for OOB) rather than trapping,
+ * matching the native bounds-checked vec read. Returns the result ValType, or
+ * null if `taViewTypeIdx` is not a registered view.
  */
 export function emitTaViewElementGet(
   ctx: CodegenContext,
@@ -1061,7 +1074,21 @@ export function emitTaViewElementGet(
   const arrLocal = allocLocal(fctx, `__tav_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
   const offLocal = allocLocal(fctx, `__tav_off_${fctx.locals.length}`, { kind: "i32" });
   const leLocal = allocLocal(fctx, `__tav_le_${fctx.locals.length}`, { kind: "i32" });
-  emitTaViewAddress(ctx, fctx, taViewTypeIdx, desc.bytes, indexExpr, compileExpr, arrLocal, offLocal, leLocal);
+  const { idxLocal, lenLocal } = emitTaViewAddress(
+    ctx,
+    fctx,
+    taViewTypeIdx,
+    desc.bytes,
+    indexExpr,
+    compileExpr,
+    arrLocal,
+    offLocal,
+    leLocal,
+  );
+  // if ((unsigned)idx < len) { decode } else { NaN }
+  const readInstrs: Instr[] = [];
+  const savedBody = fctx.body;
+  fctx.body = readInstrs;
   emitReadBytes(
     ctx,
     fctx,
@@ -1071,6 +1098,16 @@ export function emitTaViewElementGet(
     leLocal,
     arrTypeIdx,
   );
+  fctx.body = savedBody;
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "i32.lt_u" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "f64" } },
+    then: readInstrs,
+    else: [{ op: "f64.const", value: NaN } as Instr],
+  } as Instr);
   return { kind: "f64" };
 }
 
@@ -1093,8 +1130,18 @@ export function emitTaViewElementSet(
   const arrLocal = allocLocal(fctx, `__tav_sarr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
   const offLocal = allocLocal(fctx, `__tav_soff_${fctx.locals.length}`, { kind: "i32" });
   const leLocal = allocLocal(fctx, `__tav_sle_${fctx.locals.length}`, { kind: "i32" });
-  emitTaViewAddress(ctx, fctx, taViewTypeIdx, desc.bytes, indexExpr, compileExpr, arrLocal, offLocal, leLocal);
-  // value → f64
+  const { idxLocal, lenLocal } = emitTaViewAddress(
+    ctx,
+    fctx,
+    taViewTypeIdx,
+    desc.bytes,
+    indexExpr,
+    compileExpr,
+    arrLocal,
+    offLocal,
+    leLocal,
+  );
+  // value → f64 (evaluated for its side effects regardless of bounds)
   const valLocal = allocLocal(fctx, `__tav_sval_${fctx.locals.length}`, { kind: "f64" });
   const vt = compileExpr(valueExpr, { kind: "f64" });
   if (vt && vt.kind !== "f64") coerceType(ctx, fctx, vt, { kind: "f64" });
@@ -1109,6 +1156,11 @@ export function emitTaViewElementSet(
     fctx.body.push({ op: "f64.min" } as Instr);
   }
   fctx.body.push({ op: "local.set", index: valLocal } as Instr);
+  // OOB write is a silent no-op (§10.4.5.16 IntegerIndexedElementSet): guard the
+  // store on `(unsigned)idx < len` so an out-of-range write doesn't trap.
+  const writeInstrs: Instr[] = [];
+  const savedBody = fctx.body;
+  fctx.body = writeInstrs;
   emitWriteBytes(
     ctx,
     fctx,
@@ -1119,9 +1171,130 @@ export function emitTaViewElementSet(
     leLocal,
     arrTypeIdx,
   );
+  fctx.body = savedBody;
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "i32.lt_u" } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: writeInstrs } as Instr);
   // Assignment is an expression — re-push the coerced value as the result.
   fctx.body.push({ op: "local.get", index: valLocal } as Instr);
   return { kind: "f64" };
+}
+
+/**
+ * (#3054 B1, Option A) Materialize a `$__ta_view` into a fresh NATIVE
+ * `$__vec_<elem>` by byte-decoding every element little-endian, so consumers that
+ * expect a native typed-vec receiver (the shared array-method dispatch, which
+ * `ref.cast`s the receiver to the native vec type) work on a view without
+ * trapping. The view ref must already be on the stack; a `(ref null
+ * nativeVecTypeIdx)` is left on the stack. This is a de-aliasing COPY — writes by
+ * a mutating method (`.fill`/`.set`) land in the copy, NOT back in the buffer (B1
+ * never claimed proto-method write-through; B3 will teach the methods to operate
+ * on the view directly). `nativeVecTypeIdx` is the element-typed vec
+ * `resolveArrayInfo` picked for the receiver's TS type, and drives the element
+ * coercion (integer vecs truncate the decoded f64; f64 vecs keep it).
+ */
+export function emitTaViewToVec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  taViewTypeIdx: number,
+  nativeVecTypeIdx: number,
+): void {
+  const desc = taViewDecode(ctx, taViewTypeIdx);
+  const nativeArrTypeIdx = getArrTypeIdxFromVec(ctx, nativeVecTypeIdx);
+  const nativeArrDef = ctx.mod.types[nativeArrTypeIdx];
+  if (!desc || nativeArrTypeIdx < 0 || !nativeArrDef || nativeArrDef.kind !== "array") {
+    // Shouldn't happen for a registered view; leave the view ref as-is (a later
+    // ref.cast will surface the mismatch rather than silently miscompiling).
+    return;
+  }
+  const nativeElemKind = nativeArrDef.element.kind;
+  const { arrTypeIdx: bufArrTypeIdx } = i32ByteVec(ctx);
+
+  // view (on stack) → local
+  const vLocal = allocLocal(fctx, `__tav_mv_${fctx.locals.length}`, { kind: "ref_null", typeIdx: taViewTypeIdx });
+  fctx.body.push({ op: "local.set", index: vLocal } as Instr);
+  // len = view.length (field0)
+  const lenLocal = allocLocal(fctx, `__tav_mlen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: vLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+  // arr = view.buf.data ; base = view.byteOffset ; le = 1
+  const arrLocal = allocLocal(fctx, `__tav_marr_${fctx.locals.length}`, { kind: "ref", typeIdx: bufArrTypeIdx });
+  const { vecTypeIdx: bufVecTypeIdx } = i32ByteVec(ctx);
+  fctx.body.push({ op: "local.get", index: vLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: bufVecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: arrLocal } as Instr);
+  const baseLocal = allocLocal(fctx, `__tav_mbase_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: vLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 2 } as Instr);
+  fctx.body.push({ op: "local.set", index: baseLocal } as Instr);
+  const leLocal = allocLocal(fctx, `__tav_mle_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: leLocal } as Instr);
+  // nativeArr = array.new_default(len)
+  const nArrLocal = allocLocal(fctx, `__tav_mnarr_${fctx.locals.length}`, { kind: "ref", typeIdx: nativeArrTypeIdx });
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "array.new_default", typeIdx: nativeArrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: nArrLocal } as Instr);
+  // for (i = 0; i < len; i++) nativeArr[i] = coerce(decode(base + i*width))
+  const iLocal = allocLocal(fctx, `__tav_mi_${fctx.locals.length}`, { kind: "i32" });
+  const offLocal = allocLocal(fctx, `__tav_moff_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: iLocal } as Instr);
+  const isIntArr = nativeElemKind === "i8" || nativeElemKind === "i16" || nativeElemKind === "i32";
+  const decodeInstrs: Instr[] = [];
+  // offLocal = base + i*width
+  decodeInstrs.push({ op: "local.get", index: baseLocal } as Instr);
+  decodeInstrs.push({ op: "local.get", index: iLocal } as Instr);
+  if (desc.bytes !== 1) {
+    decodeInstrs.push({ op: "i32.const", value: desc.bytes } as Instr);
+    decodeInstrs.push({ op: "i32.mul" } as Instr);
+  }
+  decodeInstrs.push({ op: "i32.add" } as Instr);
+  decodeInstrs.push({ op: "local.set", index: offLocal } as Instr);
+  // nativeArr[i] = <decoded>
+  decodeInstrs.push({ op: "local.get", index: nArrLocal } as Instr);
+  decodeInstrs.push({ op: "local.get", index: iLocal } as Instr);
+  // NOTE: emitReadBytes pushes an f64 directly onto fctx.body; capture it by
+  // temporarily swapping the body so the read lands inside decodeInstrs.
+  const savedBody = fctx.body;
+  fctx.body = decodeInstrs;
+  emitReadBytes(
+    ctx,
+    fctx,
+    { kind: "get", bytes: desc.bytes, signed: desc.signed, float: desc.float },
+    arrLocal,
+    offLocal,
+    leLocal,
+    bufArrTypeIdx,
+  );
+  fctx.body = savedBody;
+  if (isIntArr) decodeInstrs.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  decodeInstrs.push({ op: "array.set", typeIdx: nativeArrTypeIdx } as Instr);
+  // i++
+  decodeInstrs.push({ op: "local.get", index: iLocal } as Instr);
+  decodeInstrs.push({ op: "i32.const", value: 1 } as Instr);
+  decodeInstrs.push({ op: "i32.add" } as Instr);
+  decodeInstrs.push({ op: "local.set", index: iLocal } as Instr);
+  decodeInstrs.push({ op: "br", depth: 0 } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "local.get", index: lenLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    ...decodeInstrs,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+  // struct.new nativeVec(len, nativeArr)
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: nArrLocal } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: nativeVecTypeIdx } as Instr);
 }
 
 /**

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -28,7 +28,8 @@ import {
   resolveWasmType,
   TYPED_ARRAY_NAMES,
 } from "../index.js";
-import { getSubviewArrTypeIdx, isSubviewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write
+import { getSubviewArrTypeIdx, isSubviewTypeIdx, isTaViewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write; (#3054 B1) TA view write
+import { emitTaViewElementSet } from "../dataview-native.js"; // (#3054 B1) shared-backing TA view write
 import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { resolveReceiverStruct } from "../fnctor-escape-gate.js"; // (#2681/#2686 A3) pinned-struct write dispatch
@@ -3880,6 +3881,19 @@ function compileElementAssignment(
   // 2-field `isVecStructAssign` test is false and the field path would mis-handle
   // it. Compile-time discriminated by the receiver typeIdx; plain vec arrays never
   // reach this arm. The receiver ref is already on the stack (from line ~2765).
+  // (#3054 B1) `$__ta_view` target (shared-backing TypedArray over an
+  // ArrayBuffer): byte-encode `ta[i] = v` little-endian into the SHARED buffer
+  // vec (true aliasing → sibling views / DataViews observe it). Must run BEFORE
+  // the 2-field vec-struct assign check (a `$__ta_view` is a 3-field struct).
+  // Compile-time discriminated by receiver typeIdx. Receiver ref already on the
+  // stack (from the `compileExpression(target.expression)` above).
+  if (typeDef?.kind === "struct" && isTaViewTypeIdx(ctx, typeIdx)) {
+    const r = emitTaViewElementSet(ctx, fctx, typeIdx, target.argumentExpression, value, (e, h) =>
+      compileExpression(ctx, fctx, e, h),
+    );
+    if (r) return r;
+  }
+
   if (typeDef?.kind === "struct" && isSubviewTypeIdx(ctx, typeIdx)) {
     const subArrTypeIdx = getSubviewArrTypeIdx(ctx, typeIdx);
     const subArrDef = ctx.mod.types[subArrTypeIdx];

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -25,7 +25,7 @@ import {
   typedArrayVecStorage,
 } from "../index.js";
 import { coercionPlan } from "../coercion-plan.js"; // (#2934 1c) single coercion table for the copy-ctor element bridge
-import { getOrRegisterDvWindowType } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper
+import { emitTaViewConstruct, getOrRegisterDvWindowType } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1) shared-backing TA views
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
 import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
@@ -3600,13 +3600,23 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         // handles the buffer arg correctly via the runtime, so skip the
         // native view path there.
         const argSymName = argSym?.name;
-        if (
+        // (#3054 B1) Build a SHARED-BACKING `$__ta_view` that refs the buffer's
+        // vec (not a copy) so sibling views / DataViews observe writes. Gated on
+        // `noJsHost` (standalone/WASI): the native `i32_byte` vec representation
+        // of ArrayBuffer/DataView only exists in the host-free lane. In JS-host
+        // mode an ArrayBuffer is a host object (no native vec), so the recover
+        // `any.convert_extern` + `ref.cast` would trap — host mode routes buffers
+        // through the runtime instead (#1670). This replaces the former copy loop
+        // (`emitTypedArrayFromByteBuffer`) that CLONED the bytes into a fresh
+        // backing array, which broke sibling/DataView observability.
+        const taViewOk =
           noJsHost(ctx) &&
-          (argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView") &&
-          !ts.isNumericLiteral(args[0]!) &&
-          emitTypedArrayFromByteBuffer(ctx, fctx, args[0]!, vecTypeIdx, arrTypeIdx)
-        ) {
-          return { kind: "ref_null", typeIdx: vecTypeIdx };
+          (argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView");
+        if (taViewOk && !ts.isNumericLiteral(args[0]!)) {
+          const viewResult = emitTaViewConstruct(ctx, fctx, args[0]!, expr.expression.text, (e, h) =>
+            compileExpression(ctx, fctx, e, h),
+          );
+          if (viewResult) return viewResult;
         }
         const isArrayLike =
           argSym?.name === "Array" ||
@@ -4587,15 +4597,21 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         // bytes into this TypedArray's backing vec.
         const argTsType = ctx.checker.getTypeAtLocation(args[0]!);
         const argSymName = argTsType.getSymbol?.()?.name;
-        // #1670 — gate on no-JS-host (see the matching guard above): the
-        // native byte-buffer view emits an unconditional `ref.cast` to the
-        // `i32_byte` vec that traps in JS-host mode, where the buffer is not
-        // that struct.
-        const isBufferArg =
+        // (#3054 B1) Shared-backing `$__ta_view` (see the matching guard above).
+        // Standalone/WASI only — host-mode buffers are host objects, not native
+        // vecs, so the recover cast would trap (#1670).
+        // B1: single buffer arg only (offset-0). Windowed `new TA(buf, off, len)`
+        // is B2 — MUST match `inferTaViewType`'s `args.length === 1` gate so the
+        // local's type and the constructed value agree.
+        const taViewOk =
           noJsHost(ctx) &&
+          args.length === 1 &&
           (argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer" || argSymName === "DataView");
-        if (isBufferArg && emitTypedArrayFromByteBuffer(ctx, fctx, args[0]!, vecTypeIdx, arrTypeIdx)) {
-          return { kind: "ref_null", typeIdx: vecTypeIdx };
+        if (taViewOk && !ts.isNumericLiteral(args[0]!)) {
+          const viewResult = emitTaViewConstruct(ctx, fctx, args[0]!, className, (e, h) =>
+            compileExpression(ctx, fctx, e, h),
+          );
+          if (viewResult) return viewResult;
         }
         // new Uint8Array(n) → array of size n, all zeros
         compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
@@ -5104,128 +5120,6 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
   reportError(ctx, expr, `Unsupported new expression for class: ${className}`);
   return null;
-}
-
-/**
- * #1654 — `new Uint8Array(arrayBuffer)`: copy the ArrayBuffer's bytes into the
- * TypedArray backing array.
- *
- * The ArrayBuffer / DataView is backed by an `i32_byte` vec (field 0 = length,
- * field 1 = array of i32, one byte per element). User code lowers ArrayBuffer
- * variables to externref, so recover the struct via any.convert_extern +
- * ref.cast, read its length, allocate a destination array of that length, and
- * copy byte-by-byte. Returns true on success; false to let the caller fall back
- * to the numeric-length path.
- */
-function emitTypedArrayFromByteBuffer(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  bufExpr: ts.Expression,
-  dstVecTypeIdx: number,
-  dstArrTypeIdx: number,
-): boolean {
-  const srcVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }); // (#2835) packed byte buffer
-  const srcArrTypeIdx = getArrTypeIdxFromVec(ctx, srcVecTypeIdx);
-  if (srcArrTypeIdx < 0 || dstArrTypeIdx < 0) return false;
-
-  // Compile the buffer expression and recover the i32_byte vec struct.
-  const bufType = compileExpression(ctx, fctx, bufExpr);
-  if (!bufType) return false;
-  if (bufType.kind === "externref") {
-    fctx.body.push({ op: "any.convert_extern" } as Instr);
-    fctx.body.push({ op: "ref.cast", typeIdx: srcVecTypeIdx } as Instr);
-  } else if (bufType.kind === "ref" || bufType.kind === "ref_null") {
-    if ("typeIdx" in bufType && bufType.typeIdx !== srcVecTypeIdx) {
-      fctx.body.push({ op: "ref.cast", typeIdx: srcVecTypeIdx } as Instr);
-    }
-  } else {
-    fctx.body.push({ op: "drop" } as Instr);
-    return false;
-  }
-  const srcVecLocal = allocLocal(fctx, `__tab_src_${fctx.locals.length}`, {
-    kind: "ref",
-    typeIdx: srcVecTypeIdx,
-  });
-  fctx.body.push({ op: "local.set", index: srcVecLocal });
-
-  // len = src.length (field 0)
-  const lenLocal = allocLocal(fctx, `__tab_len_${fctx.locals.length}`, {
-    kind: "i32",
-  });
-  fctx.body.push({ op: "local.get", index: srcVecLocal });
-  fctx.body.push({
-    op: "struct.get",
-    typeIdx: srcVecTypeIdx,
-    fieldIdx: 0,
-  } as Instr);
-  fctx.body.push({ op: "local.set", index: lenLocal });
-
-  // srcArr = src.data (field 1)
-  const srcArrLocal = allocLocal(fctx, `__tab_srcarr_${fctx.locals.length}`, {
-    kind: "ref",
-    typeIdx: srcArrTypeIdx,
-  });
-  fctx.body.push({ op: "local.get", index: srcVecLocal });
-  fctx.body.push({
-    op: "struct.get",
-    typeIdx: srcVecTypeIdx,
-    fieldIdx: 1,
-  } as Instr);
-  fctx.body.push({ op: "local.set", index: srcArrLocal });
-
-  const dstArrDef = ctx.mod.types[dstArrTypeIdx];
-  const dstElemKind = dstArrDef?.kind === "array" ? dstArrDef.element.kind : undefined;
-
-  // dstArr = new element[len]
-  const dstArrLocal = allocLocal(fctx, `__tab_dstarr_${fctx.locals.length}`, {
-    kind: "ref",
-    typeIdx: dstArrTypeIdx,
-  });
-  fctx.body.push({ op: "local.get", index: lenLocal });
-  fctx.body.push({ op: "array.new_default", typeIdx: dstArrTypeIdx } as Instr);
-  fctx.body.push({ op: "local.set", index: dstArrLocal });
-
-  // for (i = 0; i < len; i++) dstArr[i] = srcArr[i] converted to dst element type.
-  const iLocal = allocLocal(fctx, `__tab_i_${fctx.locals.length}`, {
-    kind: "i32",
-  });
-  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
-  fctx.body.push({ op: "local.set", index: iLocal });
-  const loopBody: Instr[] = [
-    // if (i >= len) break (br 1 out of loop)
-    { op: "local.get", index: iLocal } as Instr,
-    { op: "local.get", index: lenLocal } as Instr,
-    { op: "i32.ge_s" } as Instr,
-    { op: "br_if", depth: 1 } as Instr,
-    // dstArr[i] = converted srcArr[i] byte
-    { op: "local.get", index: dstArrLocal } as Instr,
-    { op: "local.get", index: iLocal } as Instr,
-    { op: "local.get", index: srcArrLocal } as Instr,
-    { op: "local.get", index: iLocal } as Instr,
-    // (#2835) packed i8 source byte → unsigned read.
-    { op: "array.get_u", typeIdx: srcArrTypeIdx } as Instr,
-    { op: "i32.const", value: 0xff } as Instr,
-    { op: "i32.and" } as Instr,
-    ...(dstElemKind === "f64" ? ([{ op: "f64.convert_i32_u" } as Instr] as Instr[]) : []),
-    { op: "array.set", typeIdx: dstArrTypeIdx } as Instr,
-    // i++
-    { op: "local.get", index: iLocal } as Instr,
-    { op: "i32.const", value: 1 } as Instr,
-    { op: "i32.add" } as Instr,
-    { op: "local.set", index: iLocal } as Instr,
-    { op: "br", depth: 0 } as Instr,
-  ];
-  fctx.body.push({
-    op: "block",
-    blockType: { kind: "empty" },
-    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
-  } as Instr);
-
-  // struct.new dstVec(len, dstArr)
-  fctx.body.push({ op: "local.get", index: lenLocal });
-  fctx.body.push({ op: "local.get", index: dstArrLocal });
-  fctx.body.push({ op: "struct.new", typeIdx: dstVecTypeIdx } as Instr);
-  return true;
 }
 
 export { compileClassExpression, compileNewExpression, compileSuperElementMethodCall, compileSuperMethodCall };

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -117,7 +117,9 @@ import {
   getOrRegisterVecType,
   getSubviewArrTypeIdx,
   isSubviewTypeIdx,
+  isTaViewTypeIdx,
 } from "./registry/types.js";
+import { emitTaViewElementGet } from "./dataview-native.js"; // (#3054 B1) shared-backing TA view read
 import {
   coerceType,
   compileExpression,
@@ -5076,10 +5078,12 @@ export function compilePropertyAccess(
         if ((localType?.kind === "ref" || localType?.kind === "ref_null") && localType.typeIdx !== undefined) {
           const vecTypeIdx = (localType as { typeIdx: number }).typeIdx;
           const typeDef = ctx.mod.types[vecTypeIdx];
+          // Plain vec ({length, data}) OR a `$__ta_view` ({length, buf, byteOffset},
+          // #3054 B1) — both keep the ELEMENT count at field 0.
           if (
             typeDef?.kind === "struct" &&
             typeDef.fields[0]?.name === "length" &&
-            typeDef.fields[1]?.name === "data"
+            (typeDef.fields[1]?.name === "data" || isTaViewTypeIdx(ctx, vecTypeIdx))
           ) {
             fctx.body.push({ op: "local.get", index: localIdx });
             fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
@@ -7528,6 +7532,19 @@ export function compileElementAccessBody(
   // `isVecStructAccess` (exactly 2 fields) is false and the tuple path would
   // mis-handle it. Compile-time discriminated by the receiver typeIdx, so plain
   // arrays (vec struct, not subview) never reach this arm.
+  // (#3054 B1) `$__ta_view` receiver (shared-backing TypedArray over an
+  // ArrayBuffer) — byte-decode `ta[i]` little-endian from the SHARED buffer vec
+  // at `byteOffset + i*width`. Must run BEFORE the tuple/struct-field check (a
+  // `$__ta_view` is a 3-field {length, buf, byteOffset} struct). Compile-time
+  // discriminated by receiver typeIdx, so plain arrays / native TAs never reach
+  // this arm.
+  if (typeDef?.kind === "struct" && isTaViewTypeIdx(ctx, typeIdx)) {
+    const r = emitTaViewElementGet(ctx, fctx, typeIdx, expr.argumentExpression, (e, h) =>
+      compileExpression(ctx, fctx, e, h),
+    );
+    if (r) return r;
+  }
+
   if (typeDef?.kind === "struct" && isSubviewTypeIdx(ctx, typeIdx)) {
     const subArrTypeIdx = getSubviewArrTypeIdx(ctx, typeIdx);
     const subArrDef = ctx.mod.types[subArrTypeIdx];

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -271,6 +271,72 @@ export function isSubviewTypeIdx(ctx: CodegenContext, typeIdx: number): boolean 
 }
 
 /**
+ * (#3054 B1) Get or register the `$__ta_view_<name>` struct — a byte-backed
+ * TypedArray view over an ArrayBuffer that SHARES the buffer's backing store:
+ *   `{length: i32, buf: (ref null $__vec_i32_byte), byteOffset: i32}`.
+ *
+ * Unlike `$__subview` (which pins the parent's raw *element* array), a
+ * `$__ta_view` holds a ref to the ArrayBuffer's `$__vec_i32_byte` **vec struct**
+ * and byte-decodes each element little-endian from `buf.data` at the element's
+ * byteOffset (via the dataview-native engine). This is mandatory because WasmGC
+ * array types are nominal per element kind — the buffer's packed-i8 array
+ * (`$__arr_i32_byte`) cannot be aliased/reinterpreted as an f64/i32 element
+ * array — so uniform byte-decoding is the only sound shared-backing scheme
+ * (Phase A A.1, option (c) impossible). Refing the *vec struct* (not the inner
+ * array) is a deliberate forward-compat choice: a future resize (Phase C) swaps
+ * the vec's `data` field in place and the view — which reads `buf.data` at each
+ * access — observes it, so length-tracking falls out for free.
+ *
+ * `length` is field 0 (subtypes `$__vec_base`) so uniform `.length` reads and the
+ * externref-length helper keep working. Keyed per TS view NAME (each view kind
+ * needs a distinct typeIdx so element access can recover its byte width /
+ * signedness / float / clamp behaviour purely from the receiver's static
+ * ValType.typeIdx — no runtime tag). Idempotent.
+ */
+export function getOrRegisterTaViewType(ctx: CodegenContext, viewName: string): number {
+  const existing = ctx.taViewTypeMap.get(viewName);
+  if (existing !== undefined) return existing;
+
+  const vecBaseIdx = getOrRegisterVecBaseType(ctx);
+  // The shared ArrayBuffer/DataView backing vec (packed i8 bytes, one per slot).
+  const bufVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
+
+  const idx = ctx.mod.types.length;
+  const name = `__ta_view_${viewName}`;
+  ctx.mod.types.push({
+    kind: "struct",
+    name,
+    superTypeIdx: vecBaseIdx, // length-prefix compatible with $__vec_base
+    fields: [
+      { name: "length", type: { kind: "i32" }, mutable: true },
+      { name: "buf", type: { kind: "ref_null", typeIdx: bufVecTypeIdx }, mutable: false },
+      { name: "byteOffset", type: { kind: "i32" }, mutable: false },
+    ],
+  });
+  ctx.taViewTypeMap.set(viewName, idx);
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, [
+    { name: "length", type: { kind: "i32" as const }, mutable: true },
+    { name: "buf", type: { kind: "ref_null" as const, typeIdx: bufVecTypeIdx }, mutable: false },
+    { name: "byteOffset", type: { kind: "i32" as const }, mutable: false },
+  ]);
+  return idx;
+}
+
+/** (#3054 B1) True iff `typeIdx` is a registered `$__ta_view_<name>` struct. */
+export function isTaViewTypeIdx(ctx: CodegenContext, typeIdx: number): boolean {
+  for (const v of ctx.taViewTypeMap.values()) if (v === typeIdx) return true;
+  return false;
+}
+
+/** (#3054 B1) The TS view name (`"Uint8Array"` …) for a `$__ta_view` typeIdx, or undefined. */
+export function getTaViewName(ctx: CodegenContext, typeIdx: number): string | undefined {
+  for (const [name, v] of ctx.taViewTypeMap.entries()) if (v === typeIdx) return name;
+  return undefined;
+}
+
+/**
  * Get or register the template vec struct type for tagged template string arrays.
  */
 export function getOrRegisterTemplateVecType(ctx: CodegenContext): number {

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -18,7 +18,12 @@ import {
 } from "../literals.js";
 import { ensureObjectRuntime } from "../object-runtime.js"; // (#3037 CS1a) $Object type idx for any-object carrier
 import { localGlobalIdx } from "../registry/imports.js";
-import { getOrRegisterArrayType, getOrRegisterSubviewType, getOrRegisterVecType } from "../registry/types.js";
+import {
+  getOrRegisterArrayType,
+  getOrRegisterSubviewType,
+  getOrRegisterTaViewType,
+  getOrRegisterVecType,
+} from "../registry/types.js";
 import { coerceType, compileExpression, valTypesMatch } from "../shared.js";
 import { emitGuardedRefCast } from "../type-coercion.js";
 import { emitLazyClassObjectGet } from "../expressions/extern.js";
@@ -318,6 +323,45 @@ function inferSubarraySubviewType(
   const elemKind = recvName?.replace(/^__vec_/, "").replace(/^__subview_/, "");
   if (elemKind === undefined || elemKind === recvName) return null;
   return { kind: "ref_null", typeIdx: getOrRegisterSubviewType(ctx, elemKind) };
+}
+
+const TA_VIEW_CTOR_NAMES = new Set([
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+]);
+
+/**
+ * (#3054 B1) A `const a = new <TA>(buffer)` binding in standalone/WASI mode holds
+ * a shared-backing `$__ta_view` that refs the ArrayBuffer's vec (not a copy), so
+ * sibling views / DataViews observe each other's writes. Resolve the binding's
+ * local type to that view HERE — at the variable-declaration site — so the local
+ * carries the `struct.new $__ta_view` the ctor emits, and element access on `a`
+ * picks the byte-decoding view lowering at compile time (rather than the native
+ * vec type `resolveWasmType(Uint8Array)` would return, which would route
+ * `a[i]`/`a[i]=v` through the plain-vec path and drop the aliasing). This MUST
+ * mirror the ctor's own gating (`emitTaViewConstruct` in `new-super.ts`): single
+ * non-numeric buffer arg (ArrayBuffer/SharedArrayBuffer/DataView), host-free lane.
+ */
+function inferTaViewType(ctx: CodegenContext, initializer: ts.Expression | undefined): ValType | null {
+  if (!noJsHost(ctx) || !initializer) return null;
+  const unwrapped = stripInferenceWrapper(initializer);
+  if (!ts.isNewExpression(unwrapped) || !ts.isIdentifier(unwrapped.expression)) return null;
+  const viewName = unwrapped.expression.text;
+  if (!TA_VIEW_CTOR_NAMES.has(viewName)) return null;
+  const args = unwrapped.arguments;
+  // B1 scope: single buffer arg, offset-0 window. Multi-arg windowed ctors
+  // (`new TA(buf, byteOffset, length)`) are B2 — leave them on the current path.
+  if (!args || args.length !== 1 || ts.isNumericLiteral(args[0]!)) return null;
+  const argSymName = ctx.checker.getTypeAtLocation(args[0]!).getSymbol?.()?.name;
+  if (argSymName !== "ArrayBuffer" && argSymName !== "SharedArrayBuffer" && argSymName !== "DataView") return null;
+  return { kind: "ref_null", typeIdx: getOrRegisterTaViewType(ctx, viewName) };
 }
 
 function nullishLiteralKind(expr: ts.Expression): "null" | "undefined" | null {
@@ -912,6 +956,8 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
 
     const standaloneRegExpMatchArrayType = inferStandaloneRegExpMatchArrayType(ctx, decl.initializer);
     const subarraySubviewType = inferSubarraySubviewType(ctx, fctx, decl.initializer);
+    // (#3054 B1) `new <TA>(buffer)` → shared-backing `$__ta_view` local type.
+    const taViewType = inferTaViewType(ctx, decl.initializer);
     // (#2615) `new Proxy(...)` initializer — the slot must be externref so reads
     // route through `__extern_get` (the Proxy MOP), not a static `struct.get`.
     // NARROWED (#2615 regression fix): only when the Proxy variable stays local
@@ -957,7 +1003,8 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
               ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
               : widenedTypeIdx !== undefined
                 ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
-                : (subarraySubviewType ??
+                : (taViewType ??
+                  subarraySubviewType ??
                   inferredVecType ??
                   standaloneRegExpMatchArrayType ??
                   (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -359,7 +359,8 @@ function inferTaViewType(ctx: CodegenContext, initializer: ts.Expression | undef
   // B1 scope: single buffer arg, offset-0 window. Multi-arg windowed ctors
   // (`new TA(buf, byteOffset, length)`) are B2 — leave them on the current path.
   if (!args || args.length !== 1 || ts.isNumericLiteral(args[0]!)) return null;
-  const argSymName = ctx.checker.getTypeAtLocation(args[0]!).getSymbol?.()?.name;
+  // (#1930) Query the type-oracle boundary, not the raw checker.
+  const argSymName = ctx.oracle.builtinReceiverOf(args[0]!);
   if (argSymName !== "ArrayBuffer" && argSymName !== "SharedArrayBuffer" && argSymName !== "DataView") return null;
   return { kind: "ref_null", typeIdx: getOrRegisterTaViewType(ctx, viewName) };
 }

--- a/tests/issue-3054-b1-shared-views.test.ts
+++ b/tests/issue-3054-b1-shared-views.test.ts
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3054 B1 — shared-backing TypedArray / DataView views over an ArrayBuffer.
+//
+// Before B1, `new <TA>(arrayBuffer)` COPIED the buffer's bytes into a fresh
+// backing array (standalone) / treated the buffer as a length (host), so
+// sibling views and DataViews over the same buffer did NOT observe each other's
+// writes. B1 replaces the copy with a `$__ta_view` struct that REFS the buffer's
+// vec and byte-decodes each element little-endian — true aliasing. This is a
+// standalone/WASI-lane change (the native i32_byte vec representation of
+// ArrayBuffer only exists host-free); host mode routes buffers through the
+// runtime and is out of scope here.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#3054 B1 shared-backing TypedArray/DataView views", () => {
+  it("sibling Uint8Array views observe each other's writes (the verified bug)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf);
+          const b = new Uint8Array(buf);
+          a[0] = 99;
+          return b[0];
+        }
+      `),
+    ).toBe(99);
+  });
+
+  it("a DataView over the same buffer sees a TypedArray write", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf);
+          a[0] = 7;
+          const dv = new DataView(buf);
+          return dv.getUint8(0);
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("a TypedArray over the same buffer sees a DataView write", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const dv = new DataView(buf);
+          dv.setUint8(0, 55);
+          const a = new Uint8Array(buf);
+          return a[0];
+        }
+      `),
+    ).toBe(55);
+  });
+
+  it("sibling Int32Array views alias (4-byte little-endian element)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          const b = new Int32Array(buf);
+          a[1] = 12345;
+          return b[1];
+        }
+      `),
+    ).toBe(12345);
+  });
+
+  it("a Uint8Array write is visible through an Int32Array view (byte layout)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const bytes = new Uint8Array(buf);
+          const words = new Int32Array(buf);
+          words[0] = 0;
+          bytes[0] = 1;
+          bytes[1] = 2;
+          return words[0]; // LE: 1 + 2*256
+        }
+      `),
+    ).toBe(513);
+  });
+
+  it("Int16Array over a buffer sign-extends on read", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Int16Array(buf);
+          a[0] = -1000;
+          return a[0];
+        }
+      `),
+    ).toBe(-1000);
+  });
+
+  it("Int8Array over a buffer wraps + sign-extends (200 -> -56)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Int8Array(buf);
+          a[0] = 200;
+          return a[0];
+        }
+      `),
+    ).toBe(-56);
+  });
+
+  it("Uint8Array element write is modular (257 -> 1)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          a[0] = 257;
+          return a[0];
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("Uint32Array over a buffer round-trips a value above 2^31", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint32Array(buf);
+          a[0] = 4000000000;
+          return a[0];
+        }
+      `),
+    ).toBe(4000000000);
+  });
+
+  it("Float64Array over a buffer round-trips a fractional value", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Float64Array(buf);
+          a[0] = 3.5;
+          return a[0];
+        }
+      `),
+    ).toBe(3.5);
+  });
+
+  it("Float32Array over a buffer stores two elements at width 4", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Float32Array(buf);
+          a[0] = 1.5;
+          a[1] = 2.5;
+          return a[0] + a[1];
+        }
+      `),
+    ).toBe(4);
+  });
+
+  it("Uint8ClampedArray clamps out-of-range writes ([0,255])", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8ClampedArray(buf);
+          a[0] = 300;
+          a[1] = -5;
+          return a[0] * 1000 + a[1]; // 255000 + 0
+        }
+      `),
+    ).toBe(255000);
+  });
+
+  it("Uint8ClampedArray rounds ties to even (2.5 -> 2, 127.6 -> 128)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8ClampedArray(buf);
+          a[0] = 2.5;
+          a[1] = 127.6;
+          return a[0] * 1000 + a[1]; // 2000 + 128
+        }
+      `),
+    ).toBe(2128);
+  });
+
+  it("view .length is the element count, not the byte length", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          return a.length; // 8 bytes / 4 = 2
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it("iterates a buffer-backed view with a .length loop (write then sum)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          for (let i = 0; i < a.length; i++) { a[i] = i * 10; }
+          let s = 0;
+          for (let i = 0; i < a.length; i++) { s = s + a[i]; }
+          return s; // 0 + 10 + 20 + 30
+        }
+      `),
+    ).toBe(60);
+  });
+});


### PR DESCRIPTION
## #3054 B1 — shared-backing TypedArray / DataView views (first slice of the resizable epic)

Fixes the **verified** correctness bug that independently blocks a slice of
non-resizable TypedArray/DataView test262: `new <TA>(arrayBuffer)` /
`new DataView(arrayBuffer)` **COPIED** the buffer's bytes into a fresh backing
array, so sibling views and DataViews over the same buffer did **not** observe
each other's writes.

```ts
const buf = new ArrayBuffer(8);
const a = new Int8Array(buf); const b = new Int8Array(buf);
a[0] = 99; b[0];                 // was NaN  → now 99
// DataView over same buf: dv.getUint8(0) after a[0]=7  was 0 → now 7
```

B1 replaces the copy with a **`$__ta_view` struct that refs the buffer's vec**
and byte-decodes each element little-endian (true aliasing), per the Phase A
architect decision (A.1 / A.5). **Standalone / WASI lane only** — the native
`i32_byte` vec representation of ArrayBuffer exists only host-free; host-mode
buffers are host objects, so enabling the view there would `ref.cast`-trap (the
#1670 class that gated the original copy path to `noJsHost`).

### How it composes existing machinery (not new infra)
- **`$__ta_view_<name>`** (`getOrRegisterTaViewType`) — `{length:i32 elem-count,
  buf:(ref null $__vec_i32_byte), byteOffset:i32}`, subtype of `$__vec_base`,
  registered **late + once**, keyed per view name so element decode
  (width/signed/float/clamp) is recovered from the static receiver `typeIdx` (no
  runtime tag). `buf` refs the **vec struct** (not the inner array) → free
  Phase-C resize tracking. Mirrors `$__subview` / `$__dv_window` → no
  type-index-shift hazard.
- **Ctor swap** (`emitTaViewConstruct`) — the copy loop
  (`emitTypedArrayFromByteBuffer`, deleted) → `struct.new $__ta_view`.
- **Element arms** — `ta[i]` / `ta[i]=v` byte-decode via the **existing**
  `dataview-native` `emitReadBytes`/`emitWriteBytes` engine (Uint8Clamped =
  ToUint8Clamp: `f64.nearest` ties-to-even + `[0,255]` clamp).
- **Local-type inference** (`inferTaViewType`) — `const a = new <TA>(buffer)`
  resolves the local to the view so `a[i]`/`a.length` pick the view lowering at
  compile time (mirrors `subarray`/`$__subview`).
- **`.length`** reads the view's field0 (element count, not byte length).

### Validation
- Verified probes fixed (sibling both directions, cross-width byte layout,
  sign-extend, modular wrap, Uint32 > 2^31, Float32/64, Uint8Clamped
  clamp + ties-to-even, `.length`, `.length`-loop iteration).
- `tests/issue-3054-b1-shared-views.test.ts` — 15 standalone assertions, green.
- **Byte-inert**: sha256 of the standalone binary is **identical** to
  `upstream/main` for 6 control programs (arith, plain array, string, **TA
  count-ctor**, **DataView get/set**, class object). Only `new <TA>(buffer)`
  programs change bytes.
- `tsc --noEmit` clean; prettier clean.

### Floor expectation
**Net-positive** on the standalone floor (an observability *fix*, byte-inert
elsewhere). Held for the **monitored merge_group floor enqueue** — any floor
regression means the view byte-decode mishandles a width/offset; diagnose, don't
force.

### Scope
B1 = shared-backing views, offset-0, read + write + `.length`. **B2** (accessor
props `.byteLength`/`.byteOffset`/`.buffer` identity/`BYTES_PER_ELEMENT` +
`(buf, byteOffset, length)` windowing) composes on this rep with no rework — the
`byteOffset` field is already present (pinned 0). Epic #3054 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8