### PR TITLE
feat(#3054 B2): TypedArray view accessor props + windowing constructor

### DIFF
--- a/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
+++ b/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
@@ -2,7 +2,7 @@
 id: 3054
 title: "Resizable ArrayBuffer + dynamic `new <ctorVar>(rab)` — the ~180 codegen gap under #1524"
 status: in-progress
-assignee: ttraenkler/opus-3054-b1
+assignee: ttraenkler/opus-3054-b2
 created: 2026-07-05
 updated: 2026-07-05
 priority: medium
@@ -517,3 +517,68 @@ the buggy `any` path. **Implication:** a large fraction of numeric-heavy standal
 and the standalone-gap prioritization need recalibration. Fix directions: (a) harness-prelude
 `assert_sameValue_num(number,number)` routing (cheap, sidesteps the codegen bug), or (b) fix
 standalone `any === any`-on-boxed-numbers when an object-runtime/class is present.
+
+## B2 — view accessor props + windowing constructor (LANDED, opus-3054-b2)
+
+**Scope shipped, on B1's `$__ta_view {length, buf, byteOffset}` verbatim (no rework,
+exactly as B1 predicted):**
+1. **Accessor props on a `$__ta_view` receiver** — `.byteLength` (= field0 element
+   count × elementSize), `.byteOffset` (= field2), `.buffer` (= field1, the shared
+   buffer vec ref → **object IDENTITY**: `a.buffer === b.buffer` and `a.buffer === buf`
+   are `ref.eq`-true), `BYTES_PER_ELEMENT` (per-view constant). `.length` (B1) verified.
+2. **Windowing ctor** `new <TA>(buffer, byteOffset[, length])` — POPULATES the
+   byteOffset field (B1 pinned 0) and computes the windowed element `length`, with the
+   §23.2.5.1 RangeError validation (ToIndex offset/length; offset multiple-of-elemSize;
+   offset+length ≤ buffer; auto-length remainder multiple-of-elemSize).
+
+### What changed (WHY)
+- **`emitTaViewAccessor`** (`dataview-native.ts`) reads the props straight off the view
+  struct. It MUST run **before** the pre-existing name-discriminated accessor arms
+  (`property-access.ts` ~3621/3769): those key on the TS type NAME (`Uint8Array`…), so
+  for a B1 view local they `ref.cast` the view to a NATIVE vec — which read `.byteLength`
+  as **0** (ref.test miss) and synthesized a **fresh, non-identity** `.buffer`. The B2
+  arm is compile-time discriminated by the receiver's resolved LOCAL typeIdx
+  (`taViewReceiverTypeIdx` → `isTaViewTypeIdx`), so native TAs / plain arrays / non-buffer
+  programs never reach it (**byte-inert** — sha256 identical for 8 controls incl. native
+  `new Int32Array(4).byteLength`).
+- **`emitTaViewConstructWindowed`** (`dataview-native.ts`) mirrors `emitTaViewConstruct`'s
+  buffer-vec recovery, then `struct.new $__ta_view {length, buf, byteOffset}` with a
+  non-zero byteOffset. **The byte engine needed ZERO change**: element access already
+  addresses `byteOffset + i*width` and bounds-checks `i < length` (both view fields), so a
+  windowed view reads/writes the correct absolute buffer bytes and is mutually observable
+  with sibling views / DataViews. An offset-0 window is **byte-identical to B1**
+  (offsetLocal = 0). Wired into `new-super.ts`'s first TA path multi-arg branch (was an
+  empty-array fallback); `inferTaViewType` (`variables.ts`) widened 1→1..3 args so the
+  windowed local resolves to the view (ctor + infer gates stay in lock-step).
+- **Floor-safety (proto methods on a windowed view)**: B1's Option-A de-view
+  (`emitTaViewToVec`) already reads field2 (byteOffset) into its base offset, so a windowed
+  `$__ta_view` reaching array-method dispatch de-views correctly — **no new trap**.
+
+### Validation (the REAL validation — host-enforced, per #3055/#3056)
+The standalone floor does NOT enforce in-Wasm numeric asserts (#3055), so B2 correctness is
+INVISIBLE to a standalone pass-count. Validated instead by **`tests/issue-3054-b2-view-accessors.test.ts`**
+— 22 HOST-enforced assertions (each program returns a number to JS; vitest `expect` enforces
+it): all accessor values, sibling `.buffer` identity + identity-to-source, windowed
+read/write hitting the right absolute buffer bytes (both directions), auto-length window,
+Uint8/Int32/Float64 windows, DataView-write-observed-by-window, and 3 RangeError throw cases;
++ 2 DataView-windowing regression guards. All green. B1 suite (15) still green.
+- **Byte-inert proof**: sha256 of the standalone binary is IDENTICAL to upstream/main for 8
+  controls (arith, plain array, string, `new Uint8Array(4)`, `new Int32Array([…])`,
+  DataView setInt32/getInt32, class object, **native `new Int32Array(4).byteLength`**). Only
+  buffer-backed-view programs change bytes.
+- `tsc --noEmit` clean; prettier clean; no new biome violations (pre-existing `noExplicitAny`
+  + whole-file format disagreements only — CI `quality` uses prettier).
+- **Floor**: expected FLOOR-NEUTRAL (byte-inert off-path; windowed views de-view safely via
+  Option A). Authoritative standalone-floor delta confirmed on the `merge_group` re-run
+  (standalone floor is only measured there).
+
+### Next: B3 or C
+- **B3 (proto methods over a view receiver)** is the natural next slice and the true
+  floor-safety prereq — Option A currently de-view-materializes (copy) for mutating methods,
+  so `view.fill()/.set()/.sort()` don't write through to the buffer. B3 makes proto methods
+  operate on the view in place (write-through). Moderate risk (touches array-method dispatch).
+- **C (resizable ArrayBuffer)** is independent of B3 and builds on A.2's `$__resizable_ab`
+  subtype; the B1 vec-struct-ref means length-tracking-on-resize falls out for free.
+Recommendation: **B3 next** — it removes the last correctness caveat on the view
+representation (proto-method write-through) before the resizable cluster piles semantics on
+top; C can proceed in parallel since it touches the buffer subtype, not the view methods.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -1181,6 +1181,253 @@ export function emitTaViewElementSet(
   return { kind: "f64" };
 }
 
+// ---------------------------------------------------------------------------
+// (#3054 B2) View accessor props + windowing constructor on a `$__ta_view`.
+//
+// B1 populated a `$__ta_view {length, buf, byteOffset}` with byteOffset pinned
+// 0. B2 (a) reads the accessor props off that struct (`.byteLength`,
+// `.byteOffset`, `.buffer` identity, `BYTES_PER_ELEMENT`; `.length` stays on the
+// B1 arm) and (b) the `(buffer, byteOffset, length)` windowing ctor that
+// POPULATES byteOffset (byte offset) + a windowed element `length`. The byte
+// engine is offset-agnostic (it reads `buf.data` at `byteOffset + i*width` and
+// bounds-checks `i < length` — both fields the view already carries), so a
+// windowed view reads/writes the correct absolute buffer bytes with ZERO byte-
+// engine change. An offset-0 window is byte-identical to B1 (offsetLocal = 0).
+// ---------------------------------------------------------------------------
+
+/** Emit an `if (cond) throw RangeError(msg)` — the i32 condition is on the stack. */
+function emitThrowRangeErrorIf(ctx: CodegenContext, fctx: FunctionContext, msg: string): void {
+  addStringConstantGlobal(ctx, msg);
+  const tagIdx = ensureExnTag(ctx);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [...stringConstantExternrefInstrs(ctx, msg), { op: "throw", tagIdx } as Instr],
+    else: [],
+  } as Instr);
+}
+
+/**
+ * ToIndex (§7.1.22) into `outLocal` (i32): compile `expr` → f64, NaN → 0,
+ * truncate toward 0, RangeError if < 0 or > 2^53-1, then narrow to i32. Used by
+ * the windowing ctor for both byteOffset and (element) length args.
+ */
+function emitToIndexI32(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: import("../ts-api.js").ts.Expression,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+  outLocal: number,
+  rangeErrMsg: string,
+): void {
+  const f64Local = allocLocal(fctx, `__tav_ti_${fctx.locals.length}`, { kind: "f64" });
+  const vt = compileExpr(expr, { kind: "f64" });
+  if (vt && vt.kind !== "f64") coerceType(ctx, fctx, vt, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: f64Local } as Instr);
+  // NaN → 0 (v != v is true only for NaN).
+  fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+  fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+  fctx.body.push({ op: "f64.ne" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "f64.const", value: 0 } as Instr, { op: "local.set", index: f64Local } as Instr],
+    else: [],
+  } as Instr);
+  // Truncate toward zero (ToIntegerOrInfinity for finite non-NaN).
+  fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+  fctx.body.push({ op: "f64.trunc" } as Instr);
+  fctx.body.push({ op: "local.set", index: f64Local } as Instr);
+  // RangeError if < 0 or > 2^53-1.
+  fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+  fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+  fctx.body.push({ op: "f64.lt" } as Instr);
+  fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+  fctx.body.push({ op: "f64.const", value: 9007199254740991 } as Instr); // 2^53 - 1
+  fctx.body.push({ op: "f64.gt" } as Instr);
+  fctx.body.push({ op: "i32.or" } as Instr);
+  emitThrowRangeErrorIf(ctx, fctx, rangeErrMsg);
+  fctx.body.push({ op: "local.get", index: f64Local } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: outLocal } as Instr);
+}
+
+/**
+ * (#3054 B2) `new <TA>(buffer, byteOffset[, length])` → a windowed shared-backing
+ * `$__ta_view` that refs the buffer's vec (like `emitTaViewConstruct`) but with a
+ * non-zero `byteOffset` field and a windowed element `length`. Validates per
+ * §23.2.5.1 InitializeTypedArrayFromArrayBuffer: byteOffset is ToIndex'd and must
+ * be a multiple of the element size; with an explicit length, byteOffset +
+ * length*elemSize must fit the buffer; with the length omitted, the remaining
+ * byte span must be a multiple of the element size. `lengthExpr` undefined ⇒
+ * auto-length (2-arg form). Returns the view ValType, or null (stack balanced) if
+ * the buffer can't be recovered as a native vec.
+ */
+export function emitTaViewConstructWindowed(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  bufExpr: import("../ts-api.js").ts.Expression,
+  offsetExpr: import("../ts-api.js").ts.Expression,
+  lengthExpr: import("../ts-api.js").ts.Expression | undefined,
+  viewName: string,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const desc = TA_VIEW_DECODE[viewName];
+  if (!desc) return null;
+  const elemSize = desc.bytes;
+  const taViewTypeIdx = getOrRegisterTaViewType(ctx, viewName);
+  const { vecTypeIdx } = i32ByteVec(ctx);
+
+  // Recover the shared buffer vec struct (mirror emitTaViewConstruct exactly).
+  const bufType = compileExpr(bufExpr);
+  if (!bufType) return null;
+  if (bufType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+  } else if (bufType.kind === "ref" || bufType.kind === "ref_null") {
+    if ("typeIdx" in bufType && (bufType as { typeIdx: number }).typeIdx !== vecTypeIdx) {
+      fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+    }
+  } else {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const bufLocal = allocLocal(fctx, `__tavw_buf_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
+  fctx.body.push({ op: "local.set", index: bufLocal } as Instr);
+
+  // bufByteLen = buf.length (field0 = byte count for an ArrayBuffer vec).
+  const bufByteLenLocal = allocLocal(fctx, `__tavw_blen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: bufByteLenLocal } as Instr);
+
+  // byteOffset = ToIndex(offsetExpr).
+  const offsetLocal = allocLocal(fctx, `__tavw_off_${fctx.locals.length}`, { kind: "i32" });
+  emitToIndexI32(ctx, fctx, offsetExpr, compileExpr, offsetLocal, "RangeError: Invalid typed array offset");
+
+  // byteOffset must be a multiple of the element size (§23.2.5.1 step 11).
+  if (elemSize !== 1) {
+    fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: elemSize } as Instr);
+    fctx.body.push({ op: "i32.rem_u" } as Instr);
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "i32.ne" } as Instr);
+    emitThrowRangeErrorIf(ctx, fctx, `RangeError: start offset of ${viewName} should be a multiple of ${elemSize}`);
+  }
+
+  const lenLocal = allocLocal(fctx, `__tavw_len_${fctx.locals.length}`, { kind: "i32" });
+  if (lengthExpr) {
+    // Explicit element length. byteOffset + length*elemSize must fit the buffer.
+    emitToIndexI32(ctx, fctx, lengthExpr, compileExpr, lenLocal, "RangeError: Invalid typed array length");
+    fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    if (elemSize !== 1) {
+      fctx.body.push({ op: "i32.const", value: elemSize } as Instr);
+      fctx.body.push({ op: "i32.mul" } as Instr);
+    }
+    fctx.body.push({ op: "i32.add" } as Instr);
+    fctx.body.push({ op: "local.get", index: bufByteLenLocal } as Instr);
+    fctx.body.push({ op: "i32.gt_s" } as Instr);
+    emitThrowRangeErrorIf(ctx, fctx, "RangeError: Invalid typed array length");
+  } else {
+    // Auto length. byteOffset must not exceed the buffer, and the remaining byte
+    // span must be a whole number of elements. length = (bufByteLen - offset)/elemSize.
+    fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: bufByteLenLocal } as Instr);
+    fctx.body.push({ op: "i32.gt_s" } as Instr);
+    emitThrowRangeErrorIf(ctx, fctx, "RangeError: Start offset is outside the bounds of the buffer");
+    const remLocal = allocLocal(fctx, `__tavw_rem_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push({ op: "local.get", index: bufByteLenLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+    fctx.body.push({ op: "i32.sub" } as Instr);
+    fctx.body.push({ op: "local.set", index: remLocal } as Instr);
+    if (elemSize !== 1) {
+      fctx.body.push({ op: "local.get", index: remLocal } as Instr);
+      fctx.body.push({ op: "i32.const", value: elemSize } as Instr);
+      fctx.body.push({ op: "i32.rem_u" } as Instr);
+      fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+      fctx.body.push({ op: "i32.ne" } as Instr);
+      emitThrowRangeErrorIf(ctx, fctx, `RangeError: byte length of ${viewName} should be a multiple of ${elemSize}`);
+    }
+    fctx.body.push({ op: "local.get", index: remLocal } as Instr);
+    if (elemSize !== 1) {
+      fctx.body.push({ op: "i32.const", value: elemSize } as Instr);
+      fctx.body.push({ op: "i32.div_u" } as Instr);
+    }
+    fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+  }
+
+  // struct.new $__ta_view {length (elements), buf (shared vec), byteOffset (bytes)}.
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: taViewTypeIdx } as Instr);
+  return { kind: "ref_null", typeIdx: taViewTypeIdx };
+}
+
+/**
+ * (#3054 B2) Read an accessor prop off a `$__ta_view` receiver:
+ *   `.byteLength`   = length (field0, element count) × elementSize
+ *   `.byteOffset`   = byteOffset (field2)
+ *   `.buffer`       = the SHARED buffer vec (field1) itself — object IDENTITY, so
+ *                     `a.buffer === b.buffer` for sibling views is `ref.eq`-true
+ *   `BYTES_PER_ELEMENT` = the per-view element size (constant)
+ * `.length` is intentionally NOT handled here — the B1 local-type `.length` arm
+ * (property-access.ts) already reads field0. `receiverExpr` is the view receiver
+ * (compiled via `compileExpr`). Returns the result ValType, or null (declining).
+ */
+export function emitTaViewAccessor(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  taViewTypeIdx: number,
+  propName: string,
+  receiverExpr: import("../ts-api.js").ts.Expression,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const desc = taViewDecode(ctx, taViewTypeIdx);
+  if (!desc) return null;
+  const { vecTypeIdx } = i32ByteVec(ctx);
+  const elemSize = desc.bytes;
+
+  // BYTES_PER_ELEMENT is a compile-time constant — drop the (side-effecting) recv.
+  if (propName === "BYTES_PER_ELEMENT") {
+    const rt = compileExpr(receiverExpr);
+    if (rt !== null) fctx.body.push({ op: "drop" } as Instr);
+    fctx.body.push({ op: ctx.fast ? "i32.const" : "f64.const", value: elemSize } as Instr);
+    return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+  }
+
+  // Compile the receiver (the $__ta_view ref) onto the stack.
+  const rt = compileExpr(receiverExpr);
+  if (rt?.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: taViewTypeIdx } as Instr);
+  }
+
+  if (propName === "buffer") {
+    // Object identity: return the shared buffer vec (field1) directly.
+    fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 1 } as Instr);
+    return { kind: "ref_null", typeIdx: vecTypeIdx };
+  }
+  if (propName === "byteLength") {
+    fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+    if (elemSize !== 1) {
+      fctx.body.push({ op: "i32.const", value: elemSize } as Instr);
+      fctx.body.push({ op: "i32.mul" } as Instr);
+    }
+    if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+    return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+  }
+  if (propName === "byteOffset") {
+    fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 2 } as Instr);
+    if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+    return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+  }
+  // Unknown prop — leave the stack balanced and decline.
+  fctx.body.push({ op: "drop" } as Instr);
+  return null;
+}
+
 /**
  * (#3054 B1, Option A) Materialize a `$__ta_view` into a fresh NATIVE
  * `$__vec_<elem>` by byte-decoding every element little-endian, so consumers that

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -25,7 +25,7 @@ import {
   typedArrayVecStorage,
 } from "../index.js";
 import { coercionPlan } from "../coercion-plan.js"; // (#2934 1c) single coercion table for the copy-ctor element bridge
-import { emitTaViewConstruct, getOrRegisterDvWindowType } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1) shared-backing TA views
+import { emitTaViewConstruct, emitTaViewConstructWindowed, getOrRegisterDvWindowType } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1/B2) shared-backing TA views + windowing
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
 import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
@@ -3792,6 +3792,29 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
         fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
         return { kind: "ref_null", typeIdx: vecTypeIdx };
+      }
+
+      // (#3054 B2) `new <TA>(buffer, byteOffset[, length])` — windowed
+      // shared-backing view. Build a `$__ta_view` with the byteOffset field
+      // populated (B1 pinned it 0) so `a[i]` addresses `byteOffset + i*width`
+      // into the SHARED buffer (sibling/DataView windows mutually observable).
+      // Standalone/WASI only — host-mode buffers are host objects, not native
+      // vecs (#1670). MUST match `inferTaViewType`'s multi-arg gate so the
+      // local's type and the constructed value agree.
+      if (noJsHost(ctx) && args.length >= 2 && !ts.isNumericLiteral(args[0]!)) {
+        const winArgSymName = ctx.checker.getTypeAtLocation(args[0]!).getSymbol?.()?.name;
+        if (winArgSymName === "ArrayBuffer" || winArgSymName === "SharedArrayBuffer" || winArgSymName === "DataView") {
+          const winResult = emitTaViewConstructWindowed(
+            ctx,
+            fctx,
+            args[0]!,
+            args[1]!,
+            args[2],
+            expr.expression.text,
+            (e, h) => compileExpression(ctx, fctx, e, h),
+          );
+          if (winResult) return winResult;
+        }
       }
 
       // new TypedArray() with multiple args — shouldn't happen per spec, but handle gracefully

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3802,7 +3802,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // vecs (#1670). MUST match `inferTaViewType`'s multi-arg gate so the
       // local's type and the constructed value agree.
       if (noJsHost(ctx) && args.length >= 2 && !ts.isNumericLiteral(args[0]!)) {
-        const winArgSymName = ctx.checker.getTypeAtLocation(args[0]!).getSymbol?.()?.name;
+        // (#1930) Query the type-oracle boundary, not the raw checker — this
+        // also keeps the gate in lock-step with `inferTaViewType` (variables.ts),
+        // which resolves the buffer arg through the same oracle.
+        const winArgSymName = ctx.oracle.builtinReceiverOf(args[0]!);
         if (winArgSymName === "ArrayBuffer" || winArgSymName === "SharedArrayBuffer" || winArgSymName === "DataView") {
           const winResult = emitTaViewConstructWindowed(
             ctx,

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -119,7 +119,7 @@ import {
   isSubviewTypeIdx,
   isTaViewTypeIdx,
 } from "./registry/types.js";
-import { emitTaViewElementGet } from "./dataview-native.js"; // (#3054 B1) shared-backing TA view read
+import { emitTaViewAccessor, emitTaViewElementGet } from "./dataview-native.js"; // (#3054 B1/B2) shared-backing TA view read + accessor props
 import {
   coerceType,
   compileExpression,
@@ -3390,6 +3390,33 @@ function isGetProtoOfWiredViewProtoCall(expr: ts.Expression): boolean {
   );
 }
 
+/**
+ * (#3054 B2) If `recvExpr` is an identifier local whose resolved type is a
+ * registered `$__ta_view_<name>` (a shared-backing TypedArray-over-buffer view,
+ * B1), return that view's typeIdx; else undefined. Discriminates the B2 accessor
+ * arm at COMPILE time by the receiver's LOCAL ValType (set by `inferTaViewType`),
+ * so native TypedArrays / plain arrays / non-buffer programs never reach it.
+ */
+function taViewReceiverTypeIdx(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  recvExpr: ts.Expression,
+): number | undefined {
+  if (!ts.isIdentifier(recvExpr)) return undefined;
+  const localIdx = fctx.localMap.get(recvExpr.text);
+  if (localIdx === undefined) return undefined;
+  const localType =
+    localIdx < fctx.params.length ? fctx.params[localIdx]!.type : fctx.locals[localIdx - fctx.params.length]?.type;
+  if (
+    (localType?.kind === "ref" || localType?.kind === "ref_null") &&
+    localType.typeIdx !== undefined &&
+    isTaViewTypeIdx(ctx, localType.typeIdx)
+  ) {
+    return localType.typeIdx;
+  }
+  return undefined;
+}
+
 export function compilePropertyAccess(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3615,6 +3642,29 @@ export function compilePropertyAccess(
         fctx.body.push({ op: "i32.const", value: 0 } as Instr);
         return { kind: "i32" };
       }
+    }
+  }
+
+  // (#3054 B2) Accessor props on a shared-backing `$__ta_view` receiver
+  // (`.byteLength`, `.byteOffset`, `.buffer` identity, `BYTES_PER_ELEMENT`). Runs
+  // BEFORE the generic TypedArray accessor arms below, which discriminate on the
+  // TS type NAME and would `ref.cast` the view to a native vec (→ read 0 for
+  // `.byteLength`, synthesize a fresh non-identity buffer for `.buffer`). The view
+  // is discriminated by the receiver's resolved LOCAL typeIdx, so native TAs /
+  // plain arrays / non-buffer programs never reach this arm (byte-inert). `.length`
+  // stays on the B1 local-type arm further down.
+  if (
+    propName === "byteLength" ||
+    propName === "byteOffset" ||
+    propName === "buffer" ||
+    propName === "BYTES_PER_ELEMENT"
+  ) {
+    const tvIdx = taViewReceiverTypeIdx(ctx, fctx, expr.expression);
+    if (tvIdx !== undefined) {
+      const r = emitTaViewAccessor(ctx, fctx, tvIdx, propName, expr.expression, (e, h) =>
+        compileExpression(ctx, fctx, e, h),
+      );
+      if (r) return r;
     }
   }
 

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -346,8 +346,11 @@ const TA_VIEW_CTOR_NAMES = new Set([
  * picks the byte-decoding view lowering at compile time (rather than the native
  * vec type `resolveWasmType(Uint8Array)` would return, which would route
  * `a[i]`/`a[i]=v` through the plain-vec path and drop the aliasing). This MUST
- * mirror the ctor's own gating (`emitTaViewConstruct` in `new-super.ts`): single
- * non-numeric buffer arg (ArrayBuffer/SharedArrayBuffer/DataView), host-free lane.
+ * mirror the ctor's own gating (`emitTaViewConstruct` / `emitTaViewConstructWindowed`
+ * in `new-super.ts`): a non-numeric buffer arg (ArrayBuffer/SharedArrayBuffer/
+ * DataView), host-free lane. (#3054 B2) The multi-arg windowed form
+ * `new TA(buf, byteOffset[, length])` also resolves to a `$__ta_view` (with the
+ * byteOffset field populated), so 1..3 args are accepted here.
  */
 function inferTaViewType(ctx: CodegenContext, initializer: ts.Expression | undefined): ValType | null {
   if (!noJsHost(ctx) || !initializer) return null;
@@ -356,9 +359,10 @@ function inferTaViewType(ctx: CodegenContext, initializer: ts.Expression | undef
   const viewName = unwrapped.expression.text;
   if (!TA_VIEW_CTOR_NAMES.has(viewName)) return null;
   const args = unwrapped.arguments;
-  // B1 scope: single buffer arg, offset-0 window. Multi-arg windowed ctors
-  // (`new TA(buf, byteOffset, length)`) are B2 — leave them on the current path.
-  if (!args || args.length !== 1 || ts.isNumericLiteral(args[0]!)) return null;
+  // Buffer-backed view: single buffer arg (offset-0, B1) or windowed
+  // `new TA(buf, byteOffset[, length])` (B2). A numeric first arg is the
+  // count-ctor (native vec), not a view — leave it on the current path.
+  if (!args || args.length < 1 || args.length > 3 || ts.isNumericLiteral(args[0]!)) return null;
   // (#1930) Query the type-oracle boundary, not the raw checker.
   const argSymName = ctx.oracle.builtinReceiverOf(args[0]!);
   if (argSymName !== "ArrayBuffer" && argSymName !== "SharedArrayBuffer" && argSymName !== "DataView") return null;

--- a/tests/issue-3054-b2-view-accessors.test.ts
+++ b/tests/issue-3054-b2-view-accessors.test.ts
@@ -1,0 +1,328 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3054 B2 — TypedArray view accessor props + the windowing constructor, on B1's
+// shared-backing `$__ta_view {length, buf, byteOffset}` representation.
+//
+// B1 shipped `new <TA>(buffer)` as a shared-backing view (offset-0, byteOffset
+// pinned 0) with element read/write. B2 adds:
+//   (a) the accessor props on a view receiver — `.byteLength`, `.byteOffset`,
+//       `.buffer` (object IDENTITY — returns the same ArrayBuffer vec ref),
+//       `BYTES_PER_ELEMENT`, and verifies `.length` (B1);
+//   (b) the windowing ctor `new <TA>(buffer, byteOffset[, length])` — POPULATES
+//       the byteOffset field so the window offsets into the buffer, with the
+//       spec RangeError validation (§23.2.5.1).
+//
+// VALIDATION NOTE (#3055/#3056): the standalone lane does NOT enforce in-Wasm
+// numeric `assert.sameValue`, so B2 correctness is invisible to the standalone
+// test262 floor. These assertions are HOST-ENFORCED — each program RETURNS a
+// number to JS and vitest `expect(...).toBe(...)` enforces it. Standalone/WASI
+// lane only (host-mode ArrayBuffer is a host object, not a native vec — see B1).
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+/** True iff the compiled standalone program throws (a Wasm exception) when run. */
+async function throwsStandalone(src: string): Promise<boolean> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  try {
+    (instance.exports as { f: () => number }).f();
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("#3054 B2 view accessor props", () => {
+  it(".byteLength = element count × element size (Int32Array → 8)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          return a.byteLength;
+        }
+      `),
+    ).toBe(8);
+  });
+
+  it(".byteLength for Float64Array over a 24-byte buffer → 24", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(24);
+          const a = new Float64Array(buf);
+          return a.byteLength;
+        }
+      `),
+    ).toBe(24);
+  });
+
+  it(".byteOffset is 0 for an offset-0 (B1) view", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          return a.byteOffset;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it(".BYTES_PER_ELEMENT is the per-view element size (Int32Array → 4)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          return a.BYTES_PER_ELEMENT;
+        }
+      `),
+    ).toBe(4);
+  });
+
+  it(".BYTES_PER_ELEMENT for Float64Array → 8", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const a = new Float64Array(buf);
+          return a.BYTES_PER_ELEMENT;
+        }
+      `),
+    ).toBe(8);
+  });
+
+  it(".length is the element count (B1) — 8-byte buffer / 4 = 2", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          return a.length;
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it(".buffer is object-identical across sibling views (a.buffer === b.buffer)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf);
+          const b = new Uint8Array(buf);
+          return (a.buffer === b.buffer) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it(".buffer is object-identical to the source ArrayBuffer (a.buffer === buf)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf);
+          return (a.buffer === buf) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it(".buffer.byteLength reads the underlying buffer byte length", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf);
+          return a.buffer.byteLength;
+        }
+      `),
+    ).toBe(8);
+  });
+});
+
+describe("#3054 B2 windowing constructor new <TA>(buffer, byteOffset, length)", () => {
+  it("windowed write lands at the correct absolute buffer bytes (window→full-view)", async () => {
+    // Int32Array window at byte offset 4 covering 2 elements; a[0] maps to byte 4,
+    // which a full-buffer Int32Array sees at index 1.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const a = new Int32Array(buf, 4, 2);
+          a[0] = 9;
+          const b = new Int32Array(buf);
+          return b[1];
+        }
+      `),
+    ).toBe(9);
+  });
+
+  it("full-view write is observed through the window (full-view→window)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const b = new Int32Array(buf);
+          b[1] = 77;
+          const a = new Int32Array(buf, 4, 2);
+          return a[0];
+        }
+      `),
+    ).toBe(77);
+  });
+
+  it("windowed view reports its byteOffset", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const a = new Int32Array(buf, 4, 2);
+          return a.byteOffset;
+        }
+      `),
+    ).toBe(4);
+  });
+
+  it("windowed view reports its element length and byteLength", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const a = new Int32Array(buf, 4, 2);
+          return a.length * 100 + a.byteLength;
+        }
+      `),
+    ).toBe(208); // length 2, byteLength 8
+  });
+
+  it("auto-length (2-arg) window fills the remainder of the buffer", async () => {
+    // 16-byte buffer, Int32Array at offset 4 → (16-4)/4 = 3 elements.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const a = new Int32Array(buf, 4);
+          return a.length;
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("Uint8Array window (element size 1) writes through to the buffer", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf, 3, 2);
+          a[0] = 42;
+          const b = new Uint8Array(buf);
+          return b[3];
+        }
+      `),
+    ).toBe(42);
+  });
+
+  it("windowed Float64Array reads/writes 8-byte elements at the offset", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(24);
+          const a = new Float64Array(buf, 8, 2);
+          a[0] = 1.5;
+          a[1] = 1.5;
+          return a[0] + a[1];
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("a sibling window observes a DataView write into its byte range", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const dv = new DataView(buf);
+          dv.setUint8(4, 55);
+          const a = new Uint8Array(buf, 4, 4);
+          return a[0];
+        }
+      `),
+    ).toBe(55);
+  });
+
+  it("throws RangeError when byteOffset is not a multiple of the element size", async () => {
+    // Int32Array requires a 4-aligned offset; 2 is misaligned (§23.2.5.1 step 11).
+    expect(
+      await throwsStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const a = new Int32Array(buf, 2, 2);
+          return a[0];
+        }
+      `),
+    ).toBe(true);
+  });
+
+  it("throws RangeError when byteOffset + length exceeds the buffer", async () => {
+    expect(
+      await throwsStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf, 0, 10);
+          return a[0];
+        }
+      `),
+    ).toBe(true);
+  });
+
+  it("throws RangeError when the 2-arg byteOffset is outside the buffer", async () => {
+    expect(
+      await throwsStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf, 16);
+          return a.length;
+        }
+      `),
+    ).toBe(true);
+  });
+});
+
+describe("#3054 B2 DataView windowing (pre-B1 $__dv_window — regression guard)", () => {
+  it("windowed DataView reports byteOffset / byteLength", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const dv = new DataView(buf, 4, 8);
+          return dv.byteOffset * 100 + dv.byteLength;
+        }
+      `),
+    ).toBe(408); // byteOffset 4, byteLength 8
+  });
+
+  it("windowed DataView get/set is offset into the buffer (observed by a TA over the same buffer)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(16);
+          const dv = new DataView(buf, 4, 8);
+          dv.setUint8(0, 88);
+          const a = new Uint8Array(buf);
+          return a[4];
+        }
+      `),
+    ).toBe(88);
+  });
+});


### PR DESCRIPTION
## #3054 B2 — TypedArray view accessor props + windowing constructor

Builds on **B1** (#2736, merged) — the shared-backing `$__ta_view {length, buf, byteOffset}` view over an ArrayBuffer's vec. B1 pinned `byteOffset = 0`; B2 populates it and reads the accessor props off the view struct. **Zero rework** of the view struct or the byte engine, exactly as B1's handoff note predicted.

### Scope
**Accessor props on a `$__ta_view` receiver** (`emitTaViewAccessor`, `dataview-native.ts`):
- `.byteLength` = field0 (element count) × elementSize
- `.byteOffset` = field2
- `.buffer` = field1 (the shared buffer vec) itself → **object IDENTITY** (`a.buffer === b.buffer` and `a.buffer === buf` are `ref.eq`-true)
- `BYTES_PER_ELEMENT` = per-view constant; `.length` (B1) verified

Runs **before** the pre-existing name-discriminated accessor arms, which `ref.cast` a view to a native vec → `.byteLength` read **0** and `.buffer` synthesized a **fresh non-identity** buffer. Compile-time discriminated by the receiver's resolved **local typeIdx** (`taViewReceiverTypeIdx` → `isTaViewTypeIdx`), so native TAs / plain arrays / non-buffer programs never reach it (**byte-inert**).

**Windowing ctor** `new <TA>(buffer, byteOffset[, length])` (`emitTaViewConstructWindowed`): populate the byteOffset field + compute the windowed element length, with §23.2.5.1 RangeError validation (ToIndex; offset multiple-of-elemSize; offset+length ≤ buffer; auto-length remainder). **The byte engine needed zero change** — element access already addresses `byteOffset + i*width` and bounds-checks `i < length` (both view fields), so a windowed view hits the correct absolute buffer bytes and is mutually observable with sibling views / DataViews. Offset-0 is **byte-identical to B1**.

Floor-safety: B1's Option-A de-view (`emitTaViewToVec`) already reads field2, so a windowed view reaching array-method dispatch de-views correctly — **no new trap**.

### Validation (HOST-enforced — the standalone lane can't enforce this, #3055/#3056)
The standalone floor does NOT enforce in-Wasm numeric asserts, so B2 correctness is invisible to a standalone pass-count. Validated by **`tests/issue-3054-b2-view-accessors.test.ts`** — 22 host-enforced assertions (each returns a number to JS; vitest `expect` enforces it): all accessor values, `.buffer` identity both ways, windowed read/write both directions, auto-length window, Uint8/Int32/Float64 windows, DataView-write-observed-by-window, 3 RangeError throws + 2 DataView-windowing regression guards. **All green**; B1 suite (15) still green.

**Byte-inert proof**: sha256 of the standalone binary is IDENTICAL to `upstream/main` for 8 controls (arith, plain array, string, `new Uint8Array(4)`, `new Int32Array([…])`, DataView setInt32/getInt32, class object, **native `new Int32Array(4).byteLength`**). Only buffer-backed-view programs change bytes.

`tsc --noEmit` clean; prettier clean; no new biome violations (pre-existing `noExplicitAny` + whole-file format disagreements only — CI `quality` uses prettier).

**Floor**: expected FLOOR-NEUTRAL (byte-inert off-path; windowed views de-view safely via Option A). Authoritative standalone-floor delta is measured on the `merge_group` re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8