### PR TITLE
feat(#3054 B3): proto-method write-through on TypedArray view receivers

### DIFF
--- a/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
+++ b/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
@@ -2,7 +2,7 @@
 id: 3054
 title: "Resizable ArrayBuffer + dynamic `new <ctorVar>(rab)` — the ~180 codegen gap under #1524"
 status: in-progress
-assignee: ttraenkler/opus-3054-b2
+assignee: ttraenkler/opus-3054-b3
 created: 2026-07-05
 updated: 2026-07-05
 priority: medium
@@ -582,3 +582,85 @@ Uint8/Int32/Float64 windows, DataView-write-observed-by-window, and 3 RangeError
 Recommendation: **B3 next** — it removes the last correctness caveat on the view
 representation (proto-method write-through) before the resizable cluster piles semantics on
 top; C can proceed in parallel since it touches the buffer subtype, not the view methods.
+
+## B3 — proto-method WRITE-THROUGH on view receivers (LANDED, opus-3054-b3, on `upstream/main` @ bb239d65b)
+
+**Scope shipped:** a mutating TypedArray prototype method (`.fill` / `.set` /
+`.copyWithin`, and structurally `.sort` / `.reverse`) on a `$__ta_view`
+identifier-local receiver now WRITES THROUGH to the underlying ArrayBuffer — the
+mutation is observable by sibling views and DataViews over the same buffer. This
+closes B1's Option-A de-alias caveat (proto-method writes landed in the throwaway
+copy and were LOST).
+
+### What changed (WHY — write-back copy, not method-rewrites)
+B1's Option-A de-view (`emitTaViewToVec`, `dataview-native.ts`) byte-decodes a
+`$__ta_view` receiver into a fresh native `$__vec_<elem>` so the shared
+array-method dispatch (which `ref.cast`s to the native element-typed vec) doesn't
+trap. That copy was **de-aliased** — a mutating method mutated the copy, never
+the buffer.
+
+B3 makes the de-viewed path write-through by the **reverse** of `emitTaViewToVec`,
+NOT by rewriting each method to operate on the view:
+- **`emitTaViewWriteBack`** (`dataview-native.ts`, new export): after the method
+  runs, for each element `i` reads the native copy `matArr[i]` → f64 (native vec
+  element opcode; signedness per the TA kind = `desc.signed`; **packed i8/i16 use
+  `array.get_s`/`_u`, non-packed i32_elem uses plain `array.get` then
+  `f64.convert_i32_s/_u`** — `array.get_s/_u` are illegal on a full-width i32
+  element), then byte-encodes it back into `view.buf.data` at
+  `view.byteOffset + i*width` via the SAME `emitWriteBytes` LE engine
+  `emitTaViewElementSet` uses. Encode ∘ decode is bit-exact, so the round trip is
+  faithful. Reads `view.byteOffset` (field2, B2-populated) → windowed views write
+  the correct absolute bytes.
+- **Dispatch wiring** (`array-methods.ts`, `compileArrayMethodCall`): the de-view
+  block now also records `{taViewWbTypeIdx, taViewWbViewLocal (= the original
+  view local), taViewWbMatLocal (= the native copy), taViewWbNativeVecIdx}`.
+  After the switch, gated **exactly like the existing module-global write-back**
+  (`MUTATING.has(methodName) && result !== null && result !== undefined`), it
+  calls `emitTaViewWriteBack`. Read-only methods (`.includes`/`.indexOf`/`.reduce`
+  /…) are NOT in `MUTATING` → no write-back (nothing to propagate) → B1's de-view
+  stays a pure copy for them.
+
+Why write-back over method-rewrites: it confines B3 to the already-de-viewed
+mutating path (additive, one new helper + a gated call), avoiding a rewrite of
+the whole array-method dispatch — the exact broad-blast move the floor discipline
+forbids. Standalone/WASI lane only (mirrors B1/B2 — host-mode buffers are host
+objects, not native `i32_byte` vecs).
+
+### Validation (host-enforced — standalone doesn't enforce numeric asserts, #3055/#3056)
+- **`tests/issue-3054-b3-writethrough.test.ts`** — 13 host-run standalone
+  assertions, all green: `.fill`→sibling; `.set`→buffer; `.set` with offset;
+  `.copyWithin`→buffer; read-only `.includes`/`.indexOf` do NOT clobber the
+  buffer; Int32 `.fill` cross-width LE bytes; Int16 negative LE; Float32
+  round-trip; **Uint32 unsigned i32_elem read path** (value ≤2^31); **Int32
+  negative signed i32_elem read path**; window-offset `.fill` hits the right
+  absolute bytes; subsequent element-read reflects the mutation.
+- **Byte-inert proof** — sha256 of the standalone binary is IDENTICAL between
+  `upstream/main` (@ bb239d65b) and this branch for 6 controls: arith, **plain
+  array `.fill`**, **plain array `.sort`**, native `Uint8Array` count-ctor,
+  **native `Uint8Array.fill`**, DataView setInt32/getInt32. Only
+  `new <TA>(buffer)` de-view mutating-method programs change bytes (the write-back
+  is unreachable unless a `$__ta_view` de-view already happened → floor-safe).
+- B1 (15) + B2 (22) suites still green (37/37).
+- `tsc --noEmit`, prettier `--check`, `biome lint --diagnostic-level=error` clean.
+
+### Pre-existing native-method gaps (NOT B3 regressions — flagged, separate)
+Verified on this SAME base with NO views / NO B3 code:
+- native `new Uint8Array(4).sort()` is a **no-op** (returns input order);
+- native `Uint8Array.reverse()` **leaks a packed `i8`** into a value position at
+  binary emit (`encodeValType` throw);
+- native `Uint32Array.fill(v)` for `v > 2^31` **saturates** to 2^31-1 (via
+  `i32.trunc_sat_f64_s` in the native fill).
+B3's write-back is DOWNSTREAM of the method and faithfully propagates whatever the
+method produced, so `.sort`/`.reverse` write-through can't be validated through a
+broken native method. These packed-TA native-method fixes are a **separate
+pre-existing issue** — recommend a follow-up (they also affect plain native TAs,
+no views involved). `.fill`/`.set`/`.copyWithin` (whose native packed lowering
+works) fully demonstrate write-through.
+
+### Next
+- **C (resizable ArrayBuffer)** remains independent of B3 (it touches the buffer
+  `$__resizable_ab` subtype, not the view methods) — **ready to dispatch in
+  parallel**.
+- A small follow-up to fix native packed-TA `.sort`/`.reverse`/Uint32-`.fill`
+  would let B3's write-through cover those methods too (currently gated by the
+  pre-existing native bugs).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -32,7 +32,7 @@ import {
   getSubviewArrTypeIdx,
   isTaViewTypeIdx,
 } from "./registry/types.js";
-import { emitTaViewToVec } from "./dataview-native.js"; // (#3054 B1 Option A) de-view materialization
+import { emitTaViewToVec, emitTaViewWriteBack } from "./dataview-native.js"; // (#3054 B1 Option A) de-view; (B3) write-through
 import { noJsHost } from "./expressions/helpers.js";
 import { ensureNativeIteratorRuntime, getOrRegisterIterRecType } from "./iterator-native.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
@@ -2918,6 +2918,14 @@ export function compileArrayMethodCall(
   // receiver identifier; these hold the rebind so we can restore it post-dispatch.
   let taViewRebindName: string | undefined;
   let taViewRebindSaved: number | undefined;
+  // (#3054 B3) write-through: after a MUTATING method runs on the de-viewed
+  // native-vec copy, byte-encode it back into the view's shared buffer. Capture
+  // the view typeIdx, the original view local, the native-vec copy local and its
+  // vec typeIdx so `emitTaViewWriteBack` can round-trip the mutation.
+  let taViewWbTypeIdx: number | undefined;
+  let taViewWbViewLocal: number | undefined;
+  let taViewWbMatLocal: number | undefined;
+  let taViewWbNativeVecIdx: number | undefined;
 
   // The receiver's actual Wasm type may differ from the TS type — e.g.
   // `[0, true].lastIndexOf(...)` infers i32 elements during construction,
@@ -2997,6 +3005,13 @@ export function compileArrayMethodCall(
         taViewRebindName = receiverExpr.text;
         taViewRebindSaved = fctx.localMap.get(receiverExpr.text);
         fctx.localMap.set(receiverExpr.text, matLocal);
+        // (#3054 B3) remember the pieces needed to write the copy back through
+        // the view's buffer after a mutating method. `taViewRebindSaved` is the
+        // original view local (the shared-backing `$__ta_view` ref).
+        taViewWbTypeIdx = actualVecIdx;
+        taViewWbViewLocal = taViewRebindSaved;
+        taViewWbMatLocal = matLocal;
+        taViewWbNativeVecIdx = vecTypeIdx;
       } else {
         const actualArrIdx = getArrTypeIdxFromVec(ctx, actualVecIdx);
         if (actualArrIdx >= 0) {
@@ -3257,6 +3272,24 @@ export function compileArrayMethodCall(
     if (ts.isIdentifier(propAccess.expression)) {
       fctx.localMap.delete(propAccess.expression.text);
     }
+  }
+
+  // (#3054 B3) WRITE-THROUGH: a mutating method (`.fill`/`.set`/`.sort`/
+  // `.copyWithin`/`.reverse`) ran on the de-viewed native-vec copy — byte-encode
+  // the (mutated) copy back into the view's shared buffer so sibling views /
+  // DataViews observe it. Gated exactly like the module-global write-back above:
+  // only for MUTATING methods that actually ran (result present). Read-only
+  // methods skip this (nothing to propagate); B1's de-view stays a pure copy.
+  if (
+    taViewWbTypeIdx !== undefined &&
+    taViewWbViewLocal !== undefined &&
+    taViewWbMatLocal !== undefined &&
+    taViewWbNativeVecIdx !== undefined &&
+    MUTATING.has(methodName) &&
+    result !== null &&
+    result !== undefined
+  ) {
+    emitTaViewWriteBack(ctx, fctx, taViewWbTypeIdx, taViewWbViewLocal, taViewWbMatLocal, taViewWbNativeVecIdx);
   }
 
   // (#3054 B1 Option A) Restore the receiver identifier's original binding after

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -1545,6 +1545,157 @@ export function emitTaViewToVec(
 }
 
 /**
+ * (#3054 B3) WRITE-THROUGH — the reverse of {@link emitTaViewToVec}. After a
+ * mutating TypedArray prototype method (`.fill` / `.set` / `.sort` /
+ * `.copyWithin` / `.reverse`) has run on the DE-VIEWED native `$__vec_<elem>`
+ * copy (`matLocalIdx`), byte-encode every (possibly-mutated) element back into
+ * the view's SHARED buffer (`view.buf.data`) at `byteOffset + i*width`,
+ * little-endian — so the mutation is observable through the underlying buffer
+ * and every sibling view / DataView over it (per §23.2/§25 IntegerIndexed
+ * element semantics).
+ *
+ * WHY a write-back copy, not method-rewrites: B1's Option-A de-view is a
+ * de-ALIASING copy — writes by a mutating method landed in the copy and were
+ * LOST (never reached the buffer). Rewriting each TA method to operate directly
+ * on the view would touch the whole array-method dispatch (high floor risk). The
+ * write-back confines B3 to the already-de-viewed path: the copy round-trips
+ * back into the buffer, restoring shared-backing semantics with a bounded,
+ * additive change.
+ *
+ * Bit-exact round trip: the value read out of the native copy is the exact
+ * numeric value the method computed (sort permutes, fill sets a constant, set
+ * writes new values, copyWithin/reverse move existing ones — all already coerced
+ * to the view's element domain). It is read with the native vec's element opcode
+ * (signedness per the TA kind = `desc.signed`) and re-encoded through the SAME
+ * {@link emitWriteBytes} engine {@link emitTaViewElementSet} uses, so encode ∘
+ * decode is identity. `viewLocalIdx` holds the `$__ta_view` ref (the receiver
+ * identifier's ORIGINAL local, saved before the de-view rebind) — reading
+ * `view.byteOffset` (field2, B2-populated) makes windowed views write to the
+ * correct absolute bytes. Read-only methods MUST NOT call this (the caller gates
+ * on the mutating-method set).
+ */
+export function emitTaViewWriteBack(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  taViewTypeIdx: number,
+  viewLocalIdx: number,
+  matLocalIdx: number,
+  nativeVecTypeIdx: number,
+): void {
+  const desc = taViewDecode(ctx, taViewTypeIdx);
+  const nativeArrTypeIdx = getArrTypeIdxFromVec(ctx, nativeVecTypeIdx);
+  const nativeArrDef = ctx.mod.types[nativeArrTypeIdx];
+  if (!desc || nativeArrTypeIdx < 0 || !nativeArrDef || nativeArrDef.kind !== "array") {
+    // Shouldn't happen for a registered view + resolved native vec. Skipping the
+    // write-back merely reverts to B1's lost-write behaviour (correctness-safe),
+    // never a miscompile.
+    return;
+  }
+  const nativeElemKind = nativeArrDef.element.kind;
+  const { vecTypeIdx: bufVecTypeIdx, arrTypeIdx: bufArrTypeIdx } = i32ByteVec(ctx);
+
+  // len = view.length (field0 = ELEMENT count; == native copy length).
+  const lenLocal = allocLocal(fctx, `__tav_wblen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: viewLocalIdx } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+  // bufArr = view.buf.data  (buf field1 → $__vec_i32_byte; .data is its field1).
+  const bufArrLocal = allocLocal(fctx, `__tav_wbarr_${fctx.locals.length}`, { kind: "ref", typeIdx: bufArrTypeIdx });
+  fctx.body.push({ op: "local.get", index: viewLocalIdx } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: bufVecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: bufArrLocal } as Instr);
+  // base = view.byteOffset (field2) — non-zero for a windowed view (B2).
+  const baseLocal = allocLocal(fctx, `__tav_wbbase_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: viewLocalIdx } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 2 } as Instr);
+  fctx.body.push({ op: "local.set", index: baseLocal } as Instr);
+  // matArr = matLocal.data (native vec field1).
+  const matArrLocal = allocLocal(fctx, `__tav_wbmarr_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: nativeArrTypeIdx,
+  });
+  fctx.body.push({ op: "local.get", index: matLocalIdx } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: nativeVecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: matArrLocal } as Instr);
+  const leLocal = allocLocal(fctx, `__tav_wble_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: leLocal } as Instr);
+
+  const iLocal = allocLocal(fctx, `__tav_wbi_${fctx.locals.length}`, { kind: "i32" });
+  const offLocal = allocLocal(fctx, `__tav_wboff_${fctx.locals.length}`, { kind: "i32" });
+  const valLocal = allocLocal(fctx, `__tav_wbval_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: iLocal } as Instr);
+
+  const stepInstrs: Instr[] = [];
+  // off = base + i*width
+  stepInstrs.push({ op: "local.get", index: baseLocal } as Instr);
+  stepInstrs.push({ op: "local.get", index: iLocal } as Instr);
+  if (desc.bytes !== 1) {
+    stepInstrs.push({ op: "i32.const", value: desc.bytes } as Instr);
+    stepInstrs.push({ op: "i32.mul" } as Instr);
+  }
+  stepInstrs.push({ op: "i32.add" } as Instr);
+  stepInstrs.push({ op: "local.set", index: offLocal } as Instr);
+  // val = f64(matArr[i]) — read the native element with the TA kind's signedness.
+  stepInstrs.push({ op: "local.get", index: matArrLocal } as Instr);
+  stepInstrs.push({ op: "local.get", index: iLocal } as Instr);
+  if (nativeElemKind === "f64") {
+    stepInstrs.push({ op: "array.get", typeIdx: nativeArrTypeIdx } as Instr);
+  } else if (nativeElemKind === "f32") {
+    stepInstrs.push({ op: "array.get", typeIdx: nativeArrTypeIdx } as Instr);
+    stepInstrs.push({ op: "f64.promote_f32" } as Instr);
+  } else if (nativeElemKind === "i8" || nativeElemKind === "i16") {
+    // PACKED int element (i8/i16): `array.get_s`/`array.get_u` sign/zero-extend
+    // the sub-word storage per the view's signedness, then convert to f64.
+    stepInstrs.push({ op: desc.signed ? "array.get_s" : "array.get_u", typeIdx: nativeArrTypeIdx } as Instr);
+    stepInstrs.push({ op: desc.signed ? "f64.convert_i32_s" : "f64.convert_i32_u" } as Instr);
+  } else {
+    // NON-packed i32 element (Int32/Uint32 `i32_elem`): `array.get_s`/`_u` are
+    // illegal on a full-width type — read with plain `array.get`, then apply the
+    // signedness at the f64 convert. Uint32 needs `convert_i32_u` so a high-bit-
+    // set i32 image maps to the >2^31 double.
+    stepInstrs.push({ op: "array.get", typeIdx: nativeArrTypeIdx } as Instr);
+    stepInstrs.push({ op: desc.signed ? "f64.convert_i32_s" : "f64.convert_i32_u" } as Instr);
+  }
+  stepInstrs.push({ op: "local.set", index: valLocal } as Instr);
+  // bufArr[off .. off+width] = encode(val)  — same LE engine as element set.
+  // emitWriteBytes pushes onto fctx.body, so redirect it into stepInstrs.
+  const savedBody = fctx.body;
+  fctx.body = stepInstrs;
+  emitWriteBytes(
+    ctx,
+    fctx,
+    { kind: "set", bytes: desc.bytes, signed: desc.signed, float: desc.float },
+    bufArrLocal,
+    offLocal,
+    valLocal,
+    leLocal,
+    bufArrTypeIdx,
+  );
+  fctx.body = savedBody;
+  // i++
+  stepInstrs.push({ op: "local.get", index: iLocal } as Instr);
+  stepInstrs.push({ op: "i32.const", value: 1 } as Instr);
+  stepInstrs.push({ op: "i32.add" } as Instr);
+  stepInstrs.push({ op: "local.set", index: iLocal } as Instr);
+  stepInstrs.push({ op: "br", depth: 0 } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: iLocal } as Instr,
+    { op: "local.get", index: lenLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    ...stepInstrs,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+}
+
+/**
  * (#2639) Stage a native DataView's bytes into the linear write scratch so
  * `node:fs` `writeSync(fd, dv)` can hand the shim a (ptr, len) pair.
  *

--- a/tests/issue-3054-b3-writethrough.test.ts
+++ b/tests/issue-3054-b3-writethrough.test.ts
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3054 B3 — proto-method WRITE-THROUGH on TypedArray view receivers.
+//
+// B1 gave `new <TA>(arrayBuffer)` a shared-backing `$__ta_view` (element
+// read/write alias the buffer). B1's Option-A de-view materializes the view into
+// a fresh native vec for prototype-method dispatch (so `.fill`/`.sort`/… don't
+// `ref.cast`-trap on the view), but that copy was DE-ALIASED: a mutating
+// method's writes landed in the copy and were LOST — never reached the buffer,
+// so sibling views / DataViews over the same buffer didn't observe them.
+//
+// B3 makes the de-viewed path WRITE-THROUGH: after a mutating method
+// (`.fill`/`.set`/`.sort`/`.copyWithin`/`.reverse`) runs on the copy, the copy
+// is byte-encoded back into the view's buffer at `byteOffset`, restoring
+// shared-backing semantics. Read-only methods (`.includes`/`.indexOf`/…) do NOT
+// write back (nothing to propagate). Standalone/WASI lane (native i32_byte vec).
+//
+// Validation is HOST-enforced: standalone does not enforce numeric asserts
+// (#3055/#3056), so we run the compiled `f()` on the JS host and assert its
+// numeric return directly.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#3054 B3 TypedArray proto-method write-through", () => {
+  it(".fill writes through to a sibling view", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint8Array(buf);
+          const b = new Uint8Array(buf);
+          a.fill(9);
+          return b[0] + b[7]; // 9 + 9
+        }
+      `),
+    ).toBe(18);
+  });
+
+  it(".set writes reach the buffer (observed by a sibling)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          const b = new Uint8Array(buf);
+          a.set([10, 20, 30, 40]);
+          return b[2];
+        }
+      `),
+    ).toBe(30);
+  });
+
+  it(".set with an offset writes the right window of the buffer", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          const b = new Uint8Array(buf);
+          a.set([7, 8], 2);
+          return b[2] * 10 + b[3];
+        }
+      `),
+    ).toBe(78);
+  });
+
+  // NOTE — `.sort()` / `.reverse()` write-through is NOT asserted here because
+  // the NATIVE packed-typed-array `.sort`/`.reverse` implementations are
+  // independently broken for the de-view target vec (verified on this same base
+  // with NO views / NO B3 code): native `new Uint8Array(4).sort()` is a no-op
+  // and native `.reverse()` leaks a packed `i8` into a value position at binary
+  // emit. B3's write-back sits DOWNSTREAM of the method — it faithfully
+  // propagates whatever the method produced — so it cannot be validated through a
+  // broken native method. Those native packed-TA method fixes are a separate,
+  // pre-existing gap (flagged in the PR); B3 is complete for the methods whose
+  // native packed lowering already works (`.fill` / `.set` / `.copyWithin`).
+
+  it(".copyWithin writes through to the buffer", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          a[0] = 1; a[1] = 2; a[2] = 3; a[3] = 4;
+          const b = new Uint8Array(buf);
+          a.copyWithin(0, 2); // [3,4,3,4]
+          return b[0] * 10 + b[1];
+        }
+      `),
+    ).toBe(34);
+  });
+
+  it("read-only .includes does NOT clobber the buffer", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          a[0] = 5; a[1] = 6;
+          const b = new Uint8Array(buf);
+          const has = a.includes(6);
+          // buffer must be untouched: b[0]=5, b[1]=6; has must be true
+          return b[0] * 10 + b[1] + (has ? 0 : 100);
+        }
+      `),
+    ).toBe(56);
+  });
+
+  it("read-only .indexOf does NOT clobber the buffer", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          a[0] = 8; a[1] = 9;
+          const b = new Uint8Array(buf);
+          const idx = a.indexOf(9);
+          return b[0] * 10 + b[1] + idx; // 89 + 1
+        }
+      `),
+    ).toBe(90);
+  });
+
+  it("Int32Array .fill writes correct little-endian bytes (cross-width)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const w = new Int32Array(buf);
+          const by = new Uint8Array(buf);
+          w.fill(513); // 0x0201 → LE bytes [1, 2, 0, 0]
+          return by[0] * 100 + by[1];
+        }
+      `),
+    ).toBe(102);
+  });
+
+  it("Int16Array .fill of a negative value writes correct LE bytes", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const w = new Int16Array(buf);
+          const by = new Uint8Array(buf);
+          w.fill(-1); // both int16 slots = 0xFFFF → all bytes 255
+          return by[0] + by[1] + by[2] + by[3];
+        }
+      `),
+    ).toBe(1020);
+  });
+
+  it("Float32Array .fill round-trips through the buffer to a sibling", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Float32Array(buf);
+          const b = new Float32Array(buf);
+          a.fill(1.5);
+          return b[0] + b[1]; // 3.0
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("Uint32Array .fill write-through reads back unsigned (i32_elem)", async () => {
+    // Exercises the NON-packed i32_elem read path (`array.get` + convert_i32_u).
+    // Values > 2^31 saturate in the PRE-EXISTING native fill path (a separate
+    // gap, verified without B3), so use a value in range to validate the
+    // write-through round trip itself.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Uint32Array(buf);
+          const b = new Uint32Array(buf);
+          a.fill(70000);
+          return b[1];
+        }
+      `),
+    ).toBe(70000);
+  });
+
+  it("Int32Array .fill of a negative value writes through (signed i32_elem)", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const a = new Int32Array(buf);
+          const b = new Int32Array(buf);
+          a.fill(-5);
+          return b[0];
+        }
+      `),
+    ).toBe(-5);
+  });
+
+  it("window-offset .fill writes the right absolute bytes", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(8);
+          const full = new Uint8Array(buf);
+          const win = new Uint8Array(buf, 4); // window at byteOffset 4
+          win.fill(7);
+          // bytes 0..3 untouched (0), bytes 4..7 = 7
+          return full[3] * 100 + full[4] + full[7]; // 0 + 7 + 7
+        }
+      `),
+    ).toBe(14);
+  });
+
+  it("write-through then a subsequent element read reflects the mutation", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const buf = new ArrayBuffer(4);
+          const a = new Uint8Array(buf);
+          a.fill(5);
+          // read back through the SAME view (element read hits the buffer)
+          return a[0] + a[3]; // 10
+        }
+      `),
+    ).toBe(10);
+  });
+});


### PR DESCRIPTION
## #3054 B3 — proto-method WRITE-THROUGH on TypedArray/DataView view receivers

Closes the last shared-backing-view caveat from B1's Option-A de-view. A mutating TypedArray prototype method (`.fill` / `.set` / `.copyWithin`) on a `$__ta_view` receiver now **writes through** to the underlying ArrayBuffer — observable by sibling views and DataViews over the same buffer, per spec.

### Root cause
B1's Option-A (`emitTaViewToVec`) byte-decodes a `$__ta_view` proto-method receiver into a fresh native `$__vec_<elem>` copy so `.fill`/`.sort`/… don't `ref.cast`-trap on the view. That copy was **de-aliased** — a mutating method mutated the copy, and the writes were **lost** (never reached the buffer).

### Fix (write-back copy, not method-rewrites)
New `emitTaViewWriteBack` (the reverse of `emitTaViewToVec`): after a mutating method runs on the copy, each native element is read back to f64 and byte-encoded into `view.buf.data` at `view.byteOffset + i*width` via the same LE `emitWriteBytes` engine `emitTaViewElementSet` uses (bit-exact round trip). Element read-op honors the storage: **packed i8/i16 → `array.get_s`/`_u`; non-packed i32_elem → plain `array.get` + `f64.convert_i32_s/_u`** (`array.get_s/_u` are illegal on a full-width i32 element). Wired in `compileArrayMethodCall`, gated **exactly like the existing module-global write-back** (`MUTATING` set, `result` present); read-only methods (`.includes`/`.indexOf`/…) skip it. Windowed views (B2 `byteOffset`) write the correct absolute bytes. Standalone/WASI lane only (mirrors B1/B2).

Chose write-back over rewriting each method to operate on the view: it confines B3 to the already-de-viewed mutating path (one helper + a gated call), avoiding a rewrite of the whole array-method dispatch.

### Validation (host-enforced — standalone doesn't enforce numeric asserts, #3055/#3056)
- `tests/issue-3054-b3-writethrough.test.ts` — **13 green**: `.fill`/`.set`/`.set`-offset/`.copyWithin` write-through to a sibling; read-only `.includes`/`.indexOf` do **not** clobber the buffer; cross-width Int32 LE / Int16 negative / Float32 round-trip / Uint32 unsigned-i32_elem / Int32 negative-i32_elem; window-offset `.fill` hits the right absolute bytes; subsequent element read reflects the mutation.
- **Byte-inert**: sha256 of the standalone binary **identical** vs `upstream/main` (@ bb239d65b) for 6 controls incl. **plain-array `.fill`/`.sort`** and **native `Uint8Array.fill`** — only `new <TA>(buffer)` de-view mutating programs change bytes (write-back is unreachable otherwise → floor-safe).
- B1 (15) + B2 (22) suites still green (37/37). `tsc --noEmit`, prettier `--check`, `biome lint --diagnostic-level=error` clean.

### Floor
Scoped built-ins/{TypedArray,DataView}: the write-back is on the already-de-viewed path (B1 measured NET 0 there) and is byte-inert off it — expected **NET ≥ 0**. This PR changes emitted behavior for view proto-methods (not fully byte-inert off-path), so it wants the **monitored `merge_group` floor** run.

### Pre-existing native-method gaps (NOT B3 regressions — flagged, separate follow-up)
Verified on this same base with **no views / no B3 code**: native `Uint8Array.sort()` is a no-op, native `Uint8Array.reverse()` leaks a packed `i8` at binary emit, `Uint32Array.fill(>2^31)` saturates to 2^31−1. B3's write-back is downstream and faithfully propagates whatever the method produced, so `.sort`/`.reverse` write-through can't be validated through a broken native method. These packed-TA native-method fixes are a separate pre-existing issue (they affect plain native TAs too).

**C (resizable ArrayBuffer subtype) is independent of B3 and ready to dispatch in parallel.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8