### PR TITLE
feat(#3054 C): resizable ArrayBuffer via $__resizable_ab WasmGC subtype

### DIFF
--- a/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
+++ b/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
@@ -2,7 +2,7 @@
 id: 3054
 title: "Resizable ArrayBuffer + dynamic `new <ctorVar>(rab)` — the ~180 codegen gap under #1524"
 status: in-progress
-assignee: ttraenkler/opus-3054-b2
+assignee: ttraenkler/opus-3054-c
 created: 2026-07-05
 updated: 2026-07-05
 priority: medium
@@ -582,3 +582,89 @@ Uint8/Int32/Float64 windows, DataView-write-observed-by-window, and 3 RangeError
 Recommendation: **B3 next** — it removes the last correctness caveat on the view
 representation (proto-method write-through) before the resizable cluster piles semantics on
 top; C can proceed in parallel since it touches the buffer subtype, not the view methods.
+
+## C — resizable ArrayBuffer semantics (LANDED, opus-3054-c, on `upstream/main` @ a5fe91b2d)
+
+**Scope shipped (standalone/WASI lane):** `new ArrayBuffer(n, {maxByteLength})` now
+allocates a resizable buffer; `.maxByteLength` / `.resizable` getters, `.resize()`
+(grow/shrink with bounds + realloc), ctor + resize RangeError/TypeError validation,
+and **auto-length view tracking** (a view over a resizable buffer reflects a later
+`resize()` in `.length` / `.byteLength` / element bounds) all work. Built on Phase A
+A.2's `$__resizable_ab` subtype. **Fully byte-inert for every program that does not
+construct a resizable ArrayBuffer** (sha256-verified, see below).
+
+### What changed (WHY, per A.2)
+- **New type `$__resizable_ab`** (`getOrRegisterResizableAbType`, `registry/types.ts`)
+  — a WasmGC **SUBTYPE of `$__vec_i32_byte`** adding `maxByteLength: i32`:
+  `{length:i32(mut), data:(ref $__arr_i32_byte)(mut), maxByteLength:i32}`. The subtype
+  IDENTITY is the resizable bit (`ref.test $__resizable_ab` ⇒ resizable), so a fixed
+  buffer whose `maxByteLength === byteLength` is still distinguishable — this is why
+  the subtype beats the issue's framed option 1. Registered late+once, memoized on
+  `ctx.resizableAbTypeIdx`, mirroring `getOrRegisterTaViewType`.
+  - **Type-index-ordering hazard (the one real A.2 risk) — verified resolved.**
+    `wasm-dis` of the actual `compile()` binary confirms the emitted order
+    `$__vec_base ($3, open) → $__vec_i32_byte ($5, `sub $3`, **non-final**) →
+    $__resizable_ab ($8, `sub final $5`)`: the subtype follows its supertype, and the
+    parent is **non-final** so subtyping is legal. `getOrRegisterResizableAbType` calls
+    `getOrRegisterVecType` FIRST so the parent is always at a lower type index; the
+    supertype ref points BACKWARD, which `computeRecGroups` never reorders (it only
+    extends a group FORWARD on forward refs). Both the unoptimized AND the `-O`
+    (wasm-opt) binaries validate + run correctly.
+- **Ctor** (`new-super.ts`, `className === "ArrayBuffer"`): an object-literal options
+  arg carrying `maxByteLength` → `struct.new $__resizable_ab` (backing array sized to
+  the CURRENT byteLength; `.resize()` reallocs). ToIndex byteLength/maxByteLength;
+  RangeError on `n > maxByteLength` (§AllocateArrayBuffer). Non-object / no-maxByteLength
+  options ⇒ non-resizable (spec GetArrayBufferMaxByteLengthOption). Returns the PARENT
+  vec ValType so the 23 `i32_byte` consumers are byte-untouched (is-a).
+- **Getters** (`property-access.ts`): `.maxByteLength` = resizable ? field2 : byteLength
+  (§25.1.5.4); `.resizable` = `ref.test $__resizable_ab`. Discriminated on a static
+  ArrayBuffer receiver in the host-free lane.
+- **`.resize()`** (`emitArrayBufferResize`, `dataview-native.ts`; dispatched in
+  `calls.ts` beside `.slice`): TypeError on a fixed receiver; ToIndex + RangeError if
+  `> maxByteLength`; `array.new_default` + `array.copy min(old,new)` + `struct.set`
+  field1(data) + field0(length) **in place on the same struct** — so shared views
+  observe the new backing (Phase A A.1).
+- **Auto-length view tracking** (the "free" claim was only true for BYTES, not the
+  cached length): field0 of a `$__ta_view` now stores a `-1` sentinel when the offset-0
+  view is built over a `$__resizable_ab` (`emitTaViewConstruct` runtime `ref.test` +
+  `select`); `pushTaViewEffectiveLen` derives the live element count from
+  `buf.length / elemSize` for the sentinel. Applied at the 4 length-reading sites
+  (`.length` arm, element-access bounds, `.byteLength`, construct). **All 4 are gated on
+  `ctx.resizableAbTypeIdx >= 0`** so a module with no resizable buffer emits B1/B2-
+  identical bytes.
+
+### Byte-inert proof
+sha256 of the standalone binary is **IDENTICAL** to `upstream/main` for all 7 controls
+— arith, plain array, string, `new Uint8Array(4)`, DataView setInt32/getInt32,
+**`new Uint8Array(buffer)`**, **`new Int32Array(buffer)`**. Only programs that construct
+a resizable ArrayBuffer change bytes. (The gate on `ctx.resizableAbTypeIdx` is what keeps
+non-resizable buffer-view programs byte-identical — without it, the length-tracking
+`ref.test`/`select` would perturb every buffer-view program.)
+
+### Validation (host-enforced, per #3055/#3056)
+`tests/issue-3054-c-resizable.test.ts` — 22 HOST-enforced assertions (ctor + metadata,
+resize grow/shrink/0/boundary/RangeError/TypeError, byte-preservation, view length +
+byteLength tracking, Int32 element-count tracking, newly-available-index write, sibling
+observability, OOB-after-shrink → NaN, non-resizable fixed-length). B1 (15) + B2 (22)
+suites still green. tsc + prettier clean.
+
+### Known scope boundaries (flagged, not regressions)
+- **Standalone-only** (host-mode ArrayBuffer is a host object — same lane boundary as
+  B1/B2). Host-lane resizable buffers are a separate follow-up.
+- **Options must be an object literal** — a dynamic/spread options object stays
+  non-resizable (compile-time `maxByteLength` extraction; a dynamic-object read needs
+  the object-runtime — deferred). Covers the entire test262 resizable corpus.
+- **Auto-length tracking assumes buffer-before-view codegen order** (the gate reads
+  `ctx.resizableAbTypeIdx` at view-construction time). True for the local
+  create-rab→create-view→resize pattern of every resizable test; a cross-function view
+  compiled before its resizable buffer would stay fixed (at worst neutral — that case
+  had NO tracking before C either).
+- **Windowed auto-length views** (`new TA(rab, byteOffset)` no length) stay fixed —
+  only offset-0 auto-length tracks. Rare; noted for a B3/follow-up.
+
+### Epic status after C
+- **D (dynamic `new <ctorVar>(rab)`)** and **E (harness shim)** remain. C is independent
+  and does NOT close them: D needs the `ref.test`-dispatch `[[Construct]]` (builds views
+  over the ctor value), E needs the runner `buildPreamble` shim landed WITH D so the
+  `resizableArrayBufferUtils.js` fixtures (`ctors`/`CreateRabForTest`/…) resolve. The
+  resizable BUFFER semantics C provides are the substrate D+E score against.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -196,6 +196,7 @@ export function createCodegenContext(
     subviewTypeIdx: -1, // (#2159/#2357/#47) standalone TypedArray subarray view, lazy
     subviewTypeMap: new Map(), // (#2357) per-elem-kind $__subview type idx
     taViewTypeMap: new Map(), // (#3054 B1) per-TA-name $__ta_view shared-backing view idx
+    resizableAbTypeIdx: -1, // (#3054 C) $__resizable_ab subtype of $__vec_i32_byte, lazy
     errorStructTypeIdx: -1,
     widenedTypeProperties: new Map(),
     widenedVarStructMap: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1699,6 +1699,20 @@ export interface CodegenContext {
    * byte-inert. Map miss = not registered. (Spec: plan/issues/3054 Phase A/B1.)
    */
   taViewTypeMap: Map<string, number>;
+  /**
+   * (#3054 C) Type index for the standalone `$__resizable_ab` struct — a WasmGC
+   * SUBTYPE of `$__vec_i32_byte` carrying an extra `maxByteLength: i32` field:
+   * `{length: i32 (mut), data: (ref $__arr_i32_byte) (mut), maxByteLength: i32}`.
+   * Produced by `new ArrayBuffer(n, {maxByteLength})`. The subtype identity IS the
+   * resizable bit (`ref.test $__resizable_ab` ⇒ resizable; a plain
+   * `$__vec_i32_byte` ⇒ fixed) — no separate flag needed. Because it is a subtype,
+   * the 23 `i32_byte` read sites `ref.cast` to the parent vec UNCHANGED (is-a);
+   * only the resizable-aware sites (ctor, `.resize()`, `.maxByteLength`/`.resizable`
+   * getters) know the subtype. Registered late+once (mirrors `getOrRegisterTaViewType`),
+   * so the subtype always follows its supertype in type-index order → no reorder
+   * hazard. -1 = not yet registered. (Spec: plan/issues/3054 Phase A A.2.)
+   */
+  resizableAbTypeIdx: number;
   /** Type index for the WasmGC `$Error_struct` used in standalone/WASI mode (#1104). -1 = not yet registered. */
   errorStructTypeIdx: number;
   /** Extra properties for empty object variables */

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -44,7 +44,7 @@ import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
-import { getOrRegisterTaViewType, getTaViewName } from "./registry/types.js";
+import { getOrRegisterResizableAbType, getOrRegisterTaViewType, getTaViewName } from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType } from "./type-coercion.js";
 
@@ -219,6 +219,149 @@ export function emitArrayBufferSlice(
   fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx } as Instr);
   fctx.body.push({ op: "extern.convert_any" } as Instr);
   return { kind: "externref" };
+}
+
+/**
+ * (#3054 C) `rab.resize(newByteLength)` in no-JS-host mode, per §25.1.6.
+ * `resize` exists only on a resizable buffer (a `$__resizable_ab` instance):
+ *   1. If the receiver is NOT a `$__resizable_ab` (a fixed buffer / anything
+ *      else) → TypeError (§25.1.6.1 step 3, IsFixedLengthArrayBuffer).
+ *   2. newByteLength = ToIndex(arg); if `newByteLength > maxByteLength` (or < 0)
+ *      → RangeError (step 6).
+ *   3. Reallocate: `array.new_default $__arr_i32_byte` of size `newByteLength`,
+ *      `array.copy` `min(oldLen, newLen)` bytes from the old data, then
+ *      `struct.set field1` (swap `data` in place on the SAME struct) and
+ *      `struct.set field0` (new byteLength). Views hold the vec-struct ref, so
+ *      they observe the swap → length-tracking-on-resize is free (Phase A A.1).
+ * Returns undefined (`resize` is a void method) — the caller drops nothing.
+ */
+export function emitArrayBufferResize(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiver: import("../ts-api.js").ts.Expression,
+  args: readonly import("../ts-api.js").ts.Expression[],
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const rabTypeIdx = getOrRegisterResizableAbType(ctx);
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }));
+  if (arrTypeIdx < 0) return null;
+
+  // Recover the receiver as anyref, then require it to be a $__resizable_ab.
+  const recvType = compileExpr(receiver);
+  if (recvType?.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+  } else if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) {
+    return null;
+  }
+  const anyLocal = allocLocal(fctx, `__rabz_any_${fctx.locals.length}`, { kind: "anyref" });
+  fctx.body.push({ op: "local.set", index: anyLocal } as Instr);
+
+  // TypeError on a non-resizable receiver (IsFixedLengthArrayBuffer).
+  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx } as Instr);
+  fctx.body.push({ op: "i32.eqz" } as Instr);
+  {
+    const msg = "TypeError: ArrayBuffer.prototype.resize called on non-resizable buffer";
+    addStringConstantGlobal(ctx, msg);
+    const tagIdx = ensureExnTag(ctx);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...stringConstantExternrefInstrs(ctx, msg), { op: "throw", tagIdx } as Instr],
+      else: [],
+    } as Instr);
+  }
+
+  // rab = ref.cast $__resizable_ab (the checked receiver).
+  const rabLocal = allocLocal(fctx, `__rabz_rab_${fctx.locals.length}`, { kind: "ref", typeIdx: rabTypeIdx });
+  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+  fctx.body.push({ op: "ref.cast", typeIdx: rabTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: rabLocal } as Instr);
+
+  // newLen = ToIndex(arg): NaN→0, truncate toward zero.
+  const newLenF64 = allocLocal(fctx, `__rabz_nl_f64_${fctx.locals.length}`, { kind: "f64" });
+  if (args.length >= 1) {
+    compileExpr(args[0]!, { kind: "f64" });
+  } else {
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: newLenF64 } as Instr);
+  // NaN → 0
+  fctx.body.push({ op: "local.get", index: newLenF64 } as Instr);
+  fctx.body.push({ op: "local.get", index: newLenF64 } as Instr);
+  fctx.body.push({ op: "f64.ne" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "f64.const", value: 0 } as Instr, { op: "local.set", index: newLenF64 } as Instr],
+    else: [],
+  } as Instr);
+  fctx.body.push({ op: "local.get", index: newLenF64 } as Instr);
+  fctx.body.push({ op: "f64.trunc" } as Instr);
+  fctx.body.push({ op: "local.set", index: newLenF64 } as Instr);
+  const newLen = allocLocal(fctx, `__rabz_nl_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: newLenF64 } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: newLen } as Instr);
+
+  // RangeError if newLen < 0 OR newLen > maxByteLength (field 2).
+  fctx.body.push({ op: "local.get", index: newLen } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr);
+  fctx.body.push({ op: "local.get", index: newLen } as Instr);
+  fctx.body.push({ op: "local.get", index: rabLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 2 } as Instr);
+  fctx.body.push({ op: "i32.gt_s" } as Instr);
+  fctx.body.push({ op: "i32.or" } as Instr);
+  {
+    const msg = "RangeError: ArrayBuffer.prototype.resize length exceeds maxByteLength";
+    addStringConstantGlobal(ctx, msg);
+    const tagIdx = ensureExnTag(ctx);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...stringConstantExternrefInstrs(ctx, msg), { op: "throw", tagIdx } as Instr],
+      else: [],
+    } as Instr);
+  }
+
+  // oldLen = min(rab.length, newLen) — bytes to preserve.
+  const oldLen = allocLocal(fctx, `__rabz_ol_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: rabLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: oldLen } as Instr);
+  const copyLen = allocLocal(fctx, `__rabz_cl_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: oldLen } as Instr);
+  fctx.body.push({ op: "local.get", index: newLen } as Instr);
+  fctx.body.push({ op: "local.get", index: oldLen } as Instr);
+  fctx.body.push({ op: "local.get", index: newLen } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr);
+  fctx.body.push({ op: "select" } as Instr);
+  fctx.body.push({ op: "local.set", index: copyLen } as Instr);
+
+  // newArr = new i8[newLen]; array.copy newArr[0..copyLen) ← rab.data[0..copyLen).
+  const newArr = allocLocal(fctx, `__rabz_na_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.get", index: newLen } as Instr);
+  fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: newArr } as Instr);
+  // array.copy dst dstIdx src srcIdx len
+  fctx.body.push({ op: "local.get", index: newArr } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: rabLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: copyLen } as Instr);
+  fctx.body.push({ op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr);
+
+  // struct.set field1 = newArr; struct.set field0 = newLen (same struct → views observe).
+  fctx.body.push({ op: "local.get", index: rabLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: newArr } as Instr);
+  fctx.body.push({ op: "struct.set", typeIdx: rabTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.get", index: rabLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: newLen } as Instr);
+  fctx.body.push({ op: "struct.set", typeIdx: rabTypeIdx, fieldIdx: 0 } as Instr);
+
+  return null;
 }
 
 /**
@@ -945,6 +1088,59 @@ export function taViewDecode(
 }
 
 /**
+ * (#3054 C) Push the CURRENT element length of a `$__ta_view` (held in `tvLocal`)
+ * as an i32. Field 0 stores either a fixed element count (`>= 0`, the B1/B2 case
+ * — a view over a NON-resizable buffer) or the **auto-length-tracking sentinel
+ * `-1`** (set by `emitTaViewConstruct` when the offset-0 view is built over a
+ * `$__resizable_ab`). For the sentinel, the live length is derived from the shared
+ * buffer's current byte length (`buf.length / elementSize`), so after
+ * `rab.resize(n)` swaps the buffer's `length`/`data` the view reflects the new
+ * length — length-tracking-on-resize (Phase A A.1), which is only "free" for the
+ * BYTES (the byte engine already reads `buf.data` live); the length field is
+ * cached and needs this indirection. A fixed view (field0 >= 0) takes the
+ * `then`-branch → byte-identical to the pre-C direct `struct.get 0` read.
+ */
+export function pushTaViewEffectiveLen(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  tvLocal: number,
+  taViewTypeIdx: number,
+): void {
+  // Byte-inert gate: a module with no resizable ArrayBuffer type can have NO
+  // auto-length view, so the sentinel is impossible — read field0 directly,
+  // byte-identical to B1. The tracking indirection is emitted only once a
+  // `$__resizable_ab` exists in the module.
+  if (ctx.resizableAbTypeIdx < 0) {
+    fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
+    fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+    return;
+  }
+  const { vecTypeIdx } = i32ByteVec(ctx);
+  const bytes = taViewDecode(ctx, taViewTypeIdx)?.bytes ?? 1;
+  const storedLocal = allocLocal(fctx, `__tav_slen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.tee", index: storedLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.ge_s" } as Instr);
+  const elseInstrs: Instr[] = [
+    { op: "local.get", index: tvLocal } as Instr,
+    { op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 1 } as Instr, // buf (ref_null $__vec_i32_byte)
+    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr, // buf.length (byte count)
+  ];
+  if (bytes !== 1) {
+    elseInstrs.push({ op: "i32.const", value: bytes } as Instr);
+    elseInstrs.push({ op: "i32.div_u" } as Instr);
+  }
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "local.get", index: storedLocal } as Instr],
+    else: elseInstrs,
+  } as Instr);
+}
+
+/**
  * (#3054 B1) `new <TA>(arrayBuffer)` → a shared-backing `$__ta_view_<name>` that
  * REFS the buffer's `$__vec_i32_byte` struct instead of COPYING its bytes into a
  * fresh backing array (the verified copy bug: sibling views / DataViews over the
@@ -983,13 +1179,31 @@ export function emitTaViewConstruct(
   const bufLocal = allocLocal(fctx, `__tav_buf_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
   fctx.body.push({ op: "local.set", index: bufLocal } as Instr);
 
-  // struct.new order = [length, buf, byteOffset].
-  // length = buf.length (field0 = byteLength) / elementSize.
+  // struct.new order = [length, buf, byteOffset]. length field = fixed element
+  // count `buf.length / elementSize` (B1/B2). (#3054 C) When the MODULE contains a
+  // resizable ArrayBuffer (`ctx.resizableAbTypeIdx >= 0`), this offset-0 view may
+  // be AUTO-LENGTH over a `$__resizable_ab` (§23.2.5.1 — length arg omitted +
+  // resizable backing ⇒ length-tracking): store the sentinel `-1` when the runtime
+  // buffer is resizable so `pushTaViewEffectiveLen` derives the live length from
+  // `buf.length` at each read (reflecting a later `rab.resize()`). This extra
+  // `ref.test`/`select` is emitted ONLY when a resizable buffer type exists in the
+  // module, so a program that uses only fixed buffers is BYTE-IDENTICAL to B1.
   fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
   if (desc.bytes !== 1) {
     fctx.body.push({ op: "i32.const", value: desc.bytes } as Instr);
     fctx.body.push({ op: "i32.div_u" } as Instr);
+  }
+  if (ctx.resizableAbTypeIdx >= 0) {
+    const rabTypeIdx = ctx.resizableAbTypeIdx;
+    // -1 (auto-length sentinel). Wasm `select` yields `cond ? a : b` with `a` the
+    // deeper operand (= fixedLen). We want `resizable ? -1 : fixedLen`, so invert
+    // the test with `i32.eqz`: cond = !resizable ⇒ select = resizable ? -1 : fixedLen.
+    fctx.body.push({ op: "i32.const", value: -1 } as Instr);
+    fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+    fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx } as Instr);
+    fctx.body.push({ op: "i32.eqz" } as Instr);
+    fctx.body.push({ op: "select" } as Instr);
   }
   // buf (shared vec ref) — `ref` widens to the field's `ref_null` type.
   fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
@@ -1021,10 +1235,12 @@ function emitTaViewAddress(
   // Stash the receiver.
   const tvLocal = allocLocal(fctx, `__tav_recv_${fctx.locals.length}`, { kind: "ref_null", typeIdx: taViewTypeIdx });
   fctx.body.push({ op: "local.set", index: tvLocal } as Instr);
-  // len = tv.length (field0 = ELEMENT count) — for the bounds check.
+  // len = the view's CURRENT element count — for the bounds check. Reads field0
+  // directly for a fixed view, or derives it live from `buf.length` for an
+  // auto-length view over a resizable buffer (#3054 C), so a `rab.resize()` grow
+  // widens the in-bounds range and a shrink narrows it.
   const lenLocal = allocLocal(fctx, `__tav_len_${fctx.locals.length}`, { kind: "i32" });
-  fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
-  fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+  pushTaViewEffectiveLen(ctx, fctx, tvLocal, taViewTypeIdx);
   fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
   // arr = tv.buf.data  (buf is field1 → ref_null $__vec_i32_byte; .data is its field1)
   fctx.body.push({ op: "local.get", index: tvLocal } as Instr);
@@ -1410,7 +1626,20 @@ export function emitTaViewAccessor(
     return { kind: "ref_null", typeIdx: vecTypeIdx };
   }
   if (propName === "byteLength") {
-    fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+    // (#3054 C) Effective element count × elementSize. When a resizable buffer
+    // type exists in the module, stash the receiver + derive the live length so a
+    // resize is tracked; otherwise read field0 directly (BYTE-IDENTICAL to B2 —
+    // no extra local, receiver stays on the stack).
+    if (ctx.resizableAbTypeIdx >= 0) {
+      const tvLocal = allocLocal(fctx, `__tav_bl_recv_${fctx.locals.length}`, {
+        kind: "ref_null",
+        typeIdx: taViewTypeIdx,
+      });
+      fctx.body.push({ op: "local.set", index: tvLocal } as Instr);
+      pushTaViewEffectiveLen(ctx, fctx, tvLocal, taViewTypeIdx);
+    } else {
+      fctx.body.push({ op: "struct.get", typeIdx: taViewTypeIdx, fieldIdx: 0 } as Instr);
+    }
     if (elemSize !== 1) {
       fctx.body.push({ op: "i32.const", value: elemSize } as Instr);
       fctx.body.push({ op: "i32.mul" } as Instr);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -241,6 +241,7 @@ import {
 import { emitVariadicStringConcat, hostStringRepr, nativeStringRepr } from "../builtin-scaffold.js";
 import { URI_DECODE_MASK, URI_ENCODE_MASK } from "../uri-encoding-native.js";
 import {
+  emitArrayBufferResize,
   emitArrayBufferSlice,
   emitDataViewAccessor,
   getOrRegisterDvWindowType,
@@ -10211,6 +10212,20 @@ function compileCallExpression(
           compileExpression(ctx, fctx, e, hint),
         );
         if (sliceResult) return sliceResult;
+      }
+    }
+
+    // (#3054 C) Native `rab.resize(newByteLength)` in no-JS-host mode. Only a
+    // `$__resizable_ab` receiver actually resizes (checked at runtime inside the
+    // emitter — a fixed buffer throws TypeError); reallocs the backing array,
+    // swaps `data` + `length` in place so shared views observe the new length.
+    if (propAccess.name.text === "resize" && noJsHost(ctx)) {
+      const recvSym = receiverType.getSymbol()?.name;
+      if (recvSym === "ArrayBuffer") {
+        emitArrayBufferResize(ctx, fctx, propAccess.expression, expr.arguments, (e, hint) =>
+          compileExpression(ctx, fctx, e, hint),
+        );
+        return VOID_RESULT;
       }
     }
 

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -20,6 +20,7 @@ import {
   ensureExnTag,
   getArrTypeIdxFromVec,
   getOrRegisterRefCellType,
+  getOrRegisterResizableAbType,
   getOrRegisterVecType,
   resolveWasmType,
   typedArrayVecStorage,
@@ -4661,6 +4662,129 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", elemType);
     const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
     const args = expr.arguments ?? [];
+
+    // (#3054 C) Resizable ArrayBuffer: `new ArrayBuffer(n, {maxByteLength: m})`.
+    // Per §25.1.3.1 / GetArrayBufferMaxByteLengthOption: a non-object options or
+    // an options object without a `maxByteLength` property ⇒ NON-resizable (fall
+    // through to the plain path below). We handle the object-literal options form
+    // (the entire test262 resizable corpus passes an object literal) at compile
+    // time — resolving `maxByteLength` off an arbitrary dynamic object would need
+    // the object-runtime and is deferred (a dynamic options object stays
+    // non-resizable rather than mis-constructing). Host-free lane only: the native
+    // vec / `$__resizable_ab` representation exists only standalone (a host-mode
+    // ArrayBuffer is a host object — same lane boundary as B1/B2).
+    let maxByteLenInit: ts.Expression | undefined;
+    if (noJsHost(ctx) && args.length >= 2 && ts.isObjectLiteralExpression(args[1]!)) {
+      for (const prop of args[1]!.properties) {
+        if (
+          ts.isPropertyAssignment(prop) &&
+          (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
+          prop.name.text === "maxByteLength"
+        ) {
+          maxByteLenInit = prop.initializer;
+        }
+      }
+    }
+
+    if (maxByteLenInit !== undefined) {
+      const rabTypeIdx = getOrRegisterResizableAbType(ctx);
+      // byteLength (arg 0) → i32, with the same non-negative-integer RangeError
+      // guard the plain path uses.
+      compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
+      const lenF64 = allocLocal(fctx, `__rab_len_f64_${fctx.locals.length}`, { kind: "f64" });
+      fctx.body.push({ op: "local.tee", index: lenF64 });
+      fctx.body.push({ op: "local.get", index: lenF64 });
+      fctx.body.push({ op: "f64.floor" });
+      fctx.body.push({ op: "f64.ne" });
+      fctx.body.push({ op: "local.get", index: lenF64 });
+      fctx.body.push({ op: "f64.const", value: 0 });
+      fctx.body.push({ op: "f64.lt" });
+      fctx.body.push({ op: "i32.or" });
+      {
+        const rangeErrMsg = "RangeError: Invalid array buffer length";
+        addStringConstantGlobal(ctx, rangeErrMsg);
+        const tagIdx = ensureExnTag(ctx);
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
+          else: [],
+        });
+      }
+      const lenI32 = allocLocal(fctx, `__rab_len_i32_${fctx.locals.length}`, { kind: "i32" });
+      fctx.body.push({ op: "local.get", index: lenF64 });
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+      fctx.body.push({ op: "local.set", index: lenI32 });
+
+      // maxByteLength (options) → i32 via ToIndex: NaN→0, truncate toward zero,
+      // and `< 0` → RangeError (the upper 2^53-1 bound is subsumed by the i32 cap).
+      compileExpression(ctx, fctx, maxByteLenInit, { kind: "f64" });
+      const maxF64 = allocLocal(fctx, `__rab_max_f64_${fctx.locals.length}`, { kind: "f64" });
+      fctx.body.push({ op: "local.set", index: maxF64 });
+      // NaN → 0
+      fctx.body.push({ op: "local.get", index: maxF64 });
+      fctx.body.push({ op: "local.get", index: maxF64 });
+      fctx.body.push({ op: "f64.ne" });
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "f64.const", value: 0 } as Instr, { op: "local.set", index: maxF64 } as Instr],
+        else: [],
+      });
+      // truncate toward zero
+      fctx.body.push({ op: "local.get", index: maxF64 });
+      fctx.body.push({ op: "f64.trunc" });
+      fctx.body.push({ op: "local.set", index: maxF64 });
+      // maxByteLength < 0 → RangeError
+      fctx.body.push({ op: "local.get", index: maxF64 });
+      fctx.body.push({ op: "f64.const", value: 0 });
+      fctx.body.push({ op: "f64.lt" });
+      {
+        const rangeErrMsg = "RangeError: Invalid array buffer max byte length";
+        addStringConstantGlobal(ctx, rangeErrMsg);
+        const tagIdx = ensureExnTag(ctx);
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
+          else: [],
+        });
+      }
+      const maxI32 = allocLocal(fctx, `__rab_max_i32_${fctx.locals.length}`, { kind: "i32" });
+      fctx.body.push({ op: "local.get", index: maxF64 });
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+      fctx.body.push({ op: "local.set", index: maxI32 });
+
+      // AllocateArrayBuffer: byteLength > maxByteLength → RangeError.
+      fctx.body.push({ op: "local.get", index: lenI32 });
+      fctx.body.push({ op: "local.get", index: maxI32 });
+      fctx.body.push({ op: "i32.gt_s" });
+      {
+        const rangeErrMsg = "RangeError: ArrayBuffer byteLength exceeds maxByteLength";
+        addStringConstantGlobal(ctx, rangeErrMsg);
+        const tagIdx = ensureExnTag(ctx);
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx } as Instr],
+          else: [],
+        });
+      }
+
+      // struct.new $__resizable_ab { length = byteLength, data = new i8[byteLength],
+      // maxByteLength }. The backing array is sized to the CURRENT byteLength (GC
+      // arrays are fixed-length; `.resize()` reallocs + swaps `data`, per A.2).
+      fctx.body.push({ op: "local.get", index: lenI32 });
+      fctx.body.push({ op: "local.get", index: lenI32 });
+      fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
+      fctx.body.push({ op: "local.get", index: maxI32 });
+      fctx.body.push({ op: "struct.new", typeIdx: rabTypeIdx });
+      // Return the PARENT vec type: a `$__resizable_ab` IS-A `$__vec_i32_byte`, so
+      // every downstream buffer consumer (byteLength, DataView, TA views, slice)
+      // treats it identically — only `.resize()`/`.maxByteLength`/`.resizable`
+      // `ref.test` the subtype. The runtime value keeps its resizable_ab identity.
+      return { kind: "ref_null", typeIdx: vecTypeIdx };
+    }
 
     if (args.length >= 1) {
       // new ArrayBuffer(byteLength) → create vec with byteLength elements, all 0

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -16485,6 +16485,7 @@ export {
   getArrTypeIdxFromVec,
   getOrRegisterArrayType,
   getOrRegisterRefCellType,
+  getOrRegisterResizableAbType,
   getOrRegisterTemplateVecType,
   getOrRegisterVecType,
 } from "./registry/types.js";

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -114,12 +114,13 @@ import {
 import { getOrRegisterDvWindowType } from "./dataview-native.js"; // (#2159/#38) DataView windowing
 import {
   getArrTypeIdxFromVec,
+  getOrRegisterResizableAbType,
   getOrRegisterVecType,
   getSubviewArrTypeIdx,
   isSubviewTypeIdx,
   isTaViewTypeIdx,
 } from "./registry/types.js";
-import { emitTaViewAccessor, emitTaViewElementGet } from "./dataview-native.js"; // (#3054 B1/B2) shared-backing TA view read + accessor props
+import { emitTaViewAccessor, emitTaViewElementGet, pushTaViewEffectiveLen } from "./dataview-native.js"; // (#3054 B1/B2/C) shared-backing TA view read + accessor props + resize length-tracking
 import {
   coerceType,
   compileExpression,
@@ -3668,6 +3669,65 @@ export function compilePropertyAccess(
     }
   }
 
+  // (#3054 C) Standalone `.maxByteLength` / `.resizable` on an ArrayBuffer
+  // receiver. The resizable-ness is the runtime type identity: a
+  // `$__resizable_ab` instance (from `new ArrayBuffer(n, {maxByteLength})`) vs a
+  // plain `$__vec_i32_byte`. Discriminated with `ref.test $__resizable_ab`:
+  //   `.resizable`     → the test result (true for resizable, false for fixed).
+  //   `.maxByteLength` → resizable: field 2; fixed: field 0 (byteLength) per
+  //                      §25.1.5.4 (a fixed buffer reports its byteLength).
+  // Only reached for a static ArrayBuffer receiver in the host-free lane; native
+  // TAs / plain arrays / non-buffer programs never take this arm (byte-inert).
+  if (
+    (ctx.wasi || ctx.standalone || ctx.strictNoHostImports) &&
+    (propName === "maxByteLength" || propName === "resizable")
+  ) {
+    const recvName =
+      objType.getSymbol()?.name ??
+      (ts.isNewExpression(expr.expression) && ts.isIdentifier(expr.expression.expression)
+        ? expr.expression.expression.text
+        : undefined);
+    if (recvName === "ArrayBuffer" && noJsHost(ctx)) {
+      const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
+      const rabTypeIdx = getOrRegisterResizableAbType(ctx);
+      // Recover the receiver as an anyref so `ref.test $__resizable_ab` is valid
+      // regardless of whether the local is typed as the vec or externref.
+      const recvType = compileExpression(ctx, fctx, expr.expression);
+      if (recvType?.kind === "externref") {
+        fctx.body.push({ op: "any.convert_extern" } as Instr);
+      }
+      const abAny = allocLocal(fctx, `__rab_any_${fctx.locals.length}`, { kind: "anyref" });
+      fctx.body.push({ op: "local.set", index: abAny } as Instr);
+      if (propName === "resizable") {
+        fctx.body.push({ op: "local.get", index: abAny } as Instr);
+        fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx } as Instr);
+        // Boolean result. In non-fast mode surface it as an f64 0/1 (truthy in
+        // conditionals, and `=== true` compares fold correctly downstream).
+        if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+        return ctx.fast ? { kind: "i32", boolean: true } : { kind: "f64" };
+      }
+      // maxByteLength: if resizable read field 2, else the byteLength (field 0).
+      fctx.body.push({ op: "local.get", index: abAny } as Instr);
+      fctx.body.push({ op: "ref.test", typeIdx: rabTypeIdx } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } as ValType },
+        then: [
+          { op: "local.get", index: abAny } as Instr,
+          { op: "ref.cast", typeIdx: rabTypeIdx } as Instr,
+          { op: "struct.get", typeIdx: rabTypeIdx, fieldIdx: 2 } as Instr,
+        ],
+        else: [
+          { op: "local.get", index: abAny } as Instr,
+          { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
+          { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+        ],
+      } as Instr);
+      if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+      return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+    }
+  }
+
   // (#2159 Slice 2) Standalone/WASI `byteLength` / `byteOffset` view-semantics
   // for ArrayBuffer / SharedArrayBuffer / TypedArrays. In JS-host mode the JS
   // runtime supplies these; with no host they fell through to `__extern_length`
@@ -5135,8 +5195,16 @@ export function compilePropertyAccess(
             typeDef.fields[0]?.name === "length" &&
             (typeDef.fields[1]?.name === "data" || isTaViewTypeIdx(ctx, vecTypeIdx))
           ) {
-            fctx.body.push({ op: "local.get", index: localIdx });
-            fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+            if (isTaViewTypeIdx(ctx, vecTypeIdx)) {
+              // (#3054 C) A `$__ta_view` over a resizable buffer is auto-length —
+              // derive the CURRENT element count (field0 == -1 sentinel → live
+              // buf.length/elemSize) so `a.length` reflects a `rab.resize()`. A
+              // fixed view reads field0 directly (byte-identical to pre-C).
+              pushTaViewEffectiveLen(ctx, fctx, localIdx, vecTypeIdx);
+            } else {
+              fctx.body.push({ op: "local.get", index: localIdx });
+              fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+            }
             if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
             return ctx.fast ? { kind: "i32" } : { kind: "f64" };
           }

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -337,6 +337,72 @@ export function getTaViewName(ctx: CodegenContext, typeIdx: number): string | un
 }
 
 /**
+ * (#3054 C) Get or register the `$__resizable_ab` struct — a WasmGC SUBTYPE of the
+ * ArrayBuffer backing vec `$__vec_i32_byte`, carrying one extra `maxByteLength`
+ * field:
+ *   `{length: i32 (mut), data: (ref $__arr_i32_byte) (mut), maxByteLength: i32}`.
+ *
+ * `new ArrayBuffer(n, {maxByteLength})` allocates one of these instead of a plain
+ * `$__vec_i32_byte`. The **subtype identity IS the resizable bit**:
+ * `ref.test $__resizable_ab` ⇒ resizable, a plain `$__vec_i32_byte` ⇒ fixed — no
+ * separate flag, so a resizable buffer whose `maxByteLength === byteLength` is
+ * still distinguishable from a fixed one (the flaw of the "over-allocate + derive"
+ * option). Because it is a subtype, every one of the ~23 `i32_byte` read sites
+ * that does `ref.cast $__vec_i32_byte; struct.get 0/1` succeeds on a
+ * `$__resizable_ab` instance UNCHANGED (is-a) — only the resizable-aware sites
+ * (the ctor, `.resize()`, and the `maxByteLength`/`resizable` getters) know the
+ * subtype. `$__vec_i32_byte` is emitted open (`sub`, non-final — every vec
+ * subtypes `$__vec_base` with no `final` flag), so a further subtype of it is
+ * legal.
+ *
+ * Type-index discipline (the one real hazard, Phase A A.2): registered LATE +
+ * ONCE, memoized on `ctx.resizableAbTypeIdx`, mirroring `getOrRegisterTaViewType`
+ * / `getOrRegisterDvWindowType`. `getOrRegisterVecType` is called FIRST so the
+ * parent `$__vec_i32_byte` is always at a LOWER type index than this subtype —
+ * the subtype's supertype reference points BACKWARD, which is valid without a rec
+ * group and never triggers `computeRecGroups` to reorder (that pass only extends a
+ * group FORWARD on forward refs; a backward supertype ref is left as a singleton).
+ * Types are append-only (`ctx.mod.types.length`), and DCE preserves relative
+ * order + keeps a live subtype's supertype reachable (it is referenced as both
+ * `superTypeIdx` and the `data` field's array elem type). So the subtype always
+ * follows its supertype in the final type section. Idempotent.
+ */
+export function getOrRegisterResizableAbType(ctx: CodegenContext): number {
+  if (ctx.resizableAbTypeIdx >= 0) return ctx.resizableAbTypeIdx;
+
+  // Register the parent buffer vec FIRST so it precedes this subtype in the type
+  // index order (the mandatory supertype-before-subtype ordering).
+  const bufVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, bufVecTypeIdx);
+
+  const idx = ctx.mod.types.length;
+  const name = "__resizable_ab";
+  ctx.mod.types.push({
+    kind: "struct",
+    name,
+    superTypeIdx: bufVecTypeIdx, // SUBTYPE of $__vec_i32_byte — inherits length + data
+    fields: [
+      // fields 0 + 1 MUST match the parent's shape exactly (subtype invariance on
+      // mutable fields): length + data, same types + mutability as $__vec_i32_byte.
+      { name: "length", type: { kind: "i32" }, mutable: true },
+      { name: "data", type: { kind: "ref", typeIdx: arrTypeIdx }, mutable: true },
+      // field 2 — the resizable-only metadata. Immutable (a buffer's declared
+      // maxByteLength never changes after construction).
+      { name: "maxByteLength", type: { kind: "i32" }, mutable: false },
+    ],
+  });
+  ctx.resizableAbTypeIdx = idx;
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, [
+    { name: "length", type: { kind: "i32" as const }, mutable: true },
+    { name: "data", type: { kind: "ref" as const, typeIdx: arrTypeIdx }, mutable: true },
+    { name: "maxByteLength", type: { kind: "i32" as const }, mutable: false },
+  ]);
+  return idx;
+}
+
+/**
  * Get or register the template vec struct type for tagged template string arrays.
  */
 export function getOrRegisterTemplateVecType(ctx: CodegenContext): number {

--- a/tests/issue-3054-c-resizable.test.ts
+++ b/tests/issue-3054-c-resizable.test.ts
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3054 C — resizable ArrayBuffer semantics via the `$__resizable_ab` WasmGC
+// subtype of `$__vec_i32_byte` (Phase A A.2). `new ArrayBuffer(n, {maxByteLength})`
+// allocates the subtype; the subtype IDENTITY is the "resizable" bit
+// (`ref.test $__resizable_ab`), so the 23 `i32_byte` read sites are untouched and
+// only the resizable-aware sites (ctor, `.resize()`, `.maxByteLength`/`.resizable`
+// getters + auto-length view tracking) know it.
+//
+// Standalone lane only: the native `i32_byte` vec representation of ArrayBuffer
+// exists host-free (a host-mode ArrayBuffer is a host object). These are
+// HOST-ENFORCED assertions — each program returns a number/flag to JS and vitest
+// `expect` enforces it — because the standalone lane does NOT enforce in-Wasm
+// numeric asserts (#3055/#3056), so a standalone pass-count is blind to this
+// correctness.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+/** Returns true iff the compiled standalone program traps (threw a Wasm exception). */
+async function traps(src: string): Promise<boolean> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  try {
+    (instance.exports as { f: () => number }).f();
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("#3054 C resizable ArrayBuffer", () => {
+  describe("construction + metadata", () => {
+    it("new ArrayBuffer(n, {maxByteLength}) reports maxByteLength", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          return b.maxByteLength;
+        }`),
+      ).toBe(16);
+    });
+
+    it("a resizable buffer reports .resizable === true", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          return b.resizable ? 1 : 0;
+        }`),
+      ).toBe(1);
+    });
+
+    it("a non-resizable buffer reports .resizable === false", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8);
+          return b.resizable ? 1 : 0;
+        }`),
+      ).toBe(0);
+    });
+
+    it("a non-resizable buffer's .maxByteLength === its byteLength (§25.1.5.4)", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8);
+          return b.maxByteLength;
+        }`),
+      ).toBe(8);
+    });
+
+    it("byteLength of a resizable buffer is the initial length", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          return b.byteLength;
+        }`),
+      ).toBe(8);
+    });
+
+    it("maxByteLength on an Int32-view-backed buffer is the byte max", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 32 });
+          const a = new Int32Array(b);
+          return b.maxByteLength;
+        }`),
+      ).toBe(32);
+    });
+
+    it("ctor throws RangeError when byteLength > maxByteLength", async () => {
+      expect(
+        await traps(`export function f(): number {
+          const b = new ArrayBuffer(20, { maxByteLength: 16 });
+          return b.byteLength;
+        }`),
+      ).toBe(true);
+    });
+  });
+
+  describe("resize()", () => {
+    it("grow: byteLength reflects the new (larger) length", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          b.resize(12);
+          return b.byteLength;
+        }`),
+      ).toBe(12);
+    });
+
+    it("shrink: byteLength reflects the new (smaller) length", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          b.resize(4);
+          return b.byteLength;
+        }`),
+      ).toBe(4);
+    });
+
+    it("resize to 0 is allowed", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          b.resize(0);
+          return b.byteLength;
+        }`),
+      ).toBe(0);
+    });
+
+    it("resize exactly to maxByteLength is allowed (boundary)", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          b.resize(16);
+          return b.byteLength;
+        }`),
+      ).toBe(16);
+    });
+
+    it("resize past maxByteLength throws RangeError", async () => {
+      expect(
+        await traps(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          b.resize(20);
+          return b.byteLength;
+        }`),
+      ).toBe(true);
+    });
+
+    it("resize on a non-resizable buffer throws TypeError", async () => {
+      expect(
+        await traps(`export function f(): number {
+          const b = new ArrayBuffer(8);
+          b.resize(4);
+          return b.byteLength;
+        }`),
+      ).toBe(true);
+    });
+
+    it("resize preserves existing bytes (grow keeps [0, min(old,new)))", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8, { maxByteLength: 16 });
+          const a = new Uint8Array(b);
+          a[3] = 42;
+          b.resize(12);
+          return a[3];
+        }`),
+      ).toBe(42);
+    });
+  });
+
+  describe("length-tracking views over a resizable buffer", () => {
+    it("an auto-length view's .length grows with the buffer", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(4, { maxByteLength: 16 });
+          const a = new Uint8Array(b);
+          b.resize(12);
+          return a.length;
+        }`),
+      ).toBe(12);
+    });
+
+    it("an auto-length view's .byteLength tracks a grow", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(4, { maxByteLength: 16 });
+          const a = new Uint8Array(b);
+          b.resize(12);
+          return a.byteLength;
+        }`),
+      ).toBe(12);
+    });
+
+    it("an Int32 auto-length view tracks length in ELEMENTS", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(4, { maxByteLength: 32 });
+          const a = new Int32Array(b);
+          b.resize(12);
+          return a.length;
+        }`),
+      ).toBe(3); // 12 bytes / 4
+    });
+
+    it("writing a newly-available index after grow round-trips", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(4, { maxByteLength: 16 });
+          const a = new Uint8Array(b);
+          b.resize(12);
+          a[10] = 77;
+          return a[10];
+        }`),
+      ).toBe(77);
+    });
+
+    it("sibling views over the same resizable buffer both observe grow + write", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(4, { maxByteLength: 16 });
+          const a = new Uint8Array(b);
+          const c = new Uint8Array(b);
+          b.resize(12);
+          a[9] = 9;
+          return c[9];
+        }`),
+      ).toBe(9);
+    });
+
+    it("reading an out-of-range index after shrink yields NaN (OOB → undefined)", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(12, { maxByteLength: 16 });
+          const a = new Uint8Array(b);
+          a[10] = 5;
+          b.resize(4);
+          const x = a[10];
+          return x === x ? x : -1; // NaN !== NaN → -1
+        }`),
+      ).toBe(-1);
+    });
+  });
+
+  describe("non-resizable views stay fixed (byte-inert guarantee)", () => {
+    it("a view over a plain ArrayBuffer keeps a fixed .length", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(4);
+          const a = new Uint8Array(b);
+          return a.length;
+        }`),
+      ).toBe(4);
+    });
+
+    it("sibling views over a plain buffer still observe each other's writes (B1 preserved)", async () => {
+      expect(
+        await runStandalone(`export function f(): number {
+          const b = new ArrayBuffer(8);
+          const a = new Uint8Array(b);
+          const c = new Uint8Array(b);
+          a[0] = 99;
+          return c[0];
+        }`),
+      ).toBe(99);
+    });
+  });
+});


### PR DESCRIPTION
## #3054 C — resizable ArrayBuffer semantics (Phase A A.2's \`\$__resizable_ab\` subtype)

Independent of B1/B2/B3 — touches the ArrayBuffer BUFFER subtype, not view methods. Builds on the landed shared-backing view representation.

### What
- **`new ArrayBuffer(n, {maxByteLength})`** → allocates `\$__resizable_ab`, a WasmGC **subtype of `\$__vec_i32_byte`** adding a `maxByteLength` field. The subtype **identity IS the resizable bit** (`ref.test \$__resizable_ab`), so the 23 `i32_byte` read sites cast-to-parent unchanged (is-a) — only ~4 resizable-aware sites know the subtype.
- **`.maxByteLength`** (resizable → field2; fixed → byteLength, §25.1.5.4), **`.resizable`** (`ref.test`).
- **`.resize(n)`** — TypeError on a fixed receiver; ToIndex + RangeError if `> maxByteLength`; `array.new_default` + `array.copy min(old,new)` + in-place `struct.set` of data/length on the SAME struct, so shared views observe the new backing.
- **ctor validation** — RangeError on `n > maxByteLength`; non-object / no-`maxByteLength` options ⇒ non-resizable.
- **auto-length view tracking** — a view over a resizable buffer reflects a later `resize()` in `.length` / `.byteLength` / element bounds (a `-1` field0 sentinel + live `buf.length/elemSize`). The "free" Phase-A claim held only for BYTES; the cached length needed this.

### Type-index-ordering hazard (the one real A.2 risk) — verified resolved
`wasm-dis` of the real `compile()` binary: `\$__vec_base (open) → \$__vec_i32_byte (sub, non-final) → \$__resizable_ab (sub final)`. Supertype precedes subtype (registry registers the parent vec first → backward supertype ref, never reordered by `computeRecGroups`); parent is non-final so subtyping is legal. Both unoptimized AND `-O` (wasm-opt) binaries validate + run.

### Floor / byte-inertness
sha256 of the standalone binary is **IDENTICAL to main** for all 7 controls incl. `new Uint8Array(buffer)` / `new Int32Array(buffer)` — only programs that construct a resizable ArrayBuffer change bytes. The length-tracking sites are gated on `ctx.resizableAbTypeIdx`, so non-resizable-buffer programs are byte-identical to B1/B2. **Floor expected neutral-to-positive** (resizable-AB tests move CE/trap→run; `.resizable`/bool asserts are enforced per #3055 and now pass). Standalone floor is authoritatively measured on `merge_group`.

### Validation (host-enforced, per #3055/#3056 — standalone can't enforce numeric asserts)
`tests/issue-3054-c-resizable.test.ts` — 22 host-enforced assertions (ctor+metadata, resize grow/shrink/0/boundary/RangeError/TypeError, byte-preservation, view length+byteLength tracking, Int32 element-count tracking, sibling observability, OOB-after-shrink → NaN, non-resizable fixed-length). B1 (15) + B2 (22) suites still green. tsc + prettier clean.

### Scope boundaries (flagged)
Standalone-only lane; object-literal options only (dynamic options → non-resizable); auto-length tracking assumes buffer-before-view codegen order (true for every resizable test; at worst neutral otherwise). D (dynamic `new <ctorVar>(rab)`) + E (harness shim) remain — C is the substrate they score against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8