### PR TITLE
feat(#3054 D+E): dynamic new <ctorVar>(rab) + resizable-ctors harness shim

### DIFF
--- a/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
+++ b/plan/issues/3054-resizable-arraybuffer-dynamic-ctor.md
@@ -1,8 +1,9 @@
 ---
 id: 3054
 title: "Resizable ArrayBuffer + dynamic `new <ctorVar>(rab)` — the ~180 codegen gap under #1524"
-status: in-progress
-assignee: ttraenkler/opus-3054-c
+status: done
+assignee: ttraenkler/opus-3054-de
+completed: 2026-07-05
 created: 2026-07-05
 updated: 2026-07-05
 priority: medium
@@ -749,3 +750,90 @@ works) fully demonstrate write-through.
 - A small follow-up to fix native packed-TA `.sort`/`.reverse`/Uint32-`.fill`
   would let B3's write-through cover those methods too (currently gated by the
   pre-existing native bugs).
+
+## D + E — dynamic `new <ctorVar>(rab)` + harness shim (LANDED, opus-3054-de, on C base @ 66024ef0c)
+
+**Scope shipped:** first-class TypedArray CONSTRUCTOR values + a Wasm-native dynamic
+`new <ctorVar>(rab)` construct (no host import) + the runner harness shim — landed
+TOGETHER so the resizable-`ctors` cluster runs host-free.
+
+### Measure-first — the spec premise was wrong (decisive finding)
+The Phase-A/D spec assumed a "`ref.test`-dispatch over the TA-intrinsic singletons."
+**Measurement disproved it:** a TA constructor used as a VALUE (`const c = Uint8Array`)
+compiled to `ref.null.extern`, so `Uint8Array === Int8Array` was `true` — there were
+**no singletons to test against**. And B1's per-kind `$__ta_view_<K>` structs are
+**structurally identical → WasmGC canonicalizes them to ONE runtime type**, so a boxed
+view can't recover its kind via `ref.test` either (a naive dispatch read byteLength =
+64 = 8×8, always the last arm). D therefore needed two NEW representations the spec
+didn't anticipate, not a localized patch.
+
+### What changed (WHY)
+1. **`$__ta_ctor {kind:i32}`** (`getOrRegisterTaCtorType`, registry/types) — a
+   first-class value for a TA ctor in value position. `identifiers.ts` emits it for a
+   bare TA name used as a value (gated: `noJsHost`, not shadowed/class). `kind` indexes
+   `TA_CTOR_KINDS`. Fixes `Uint8Array === Int8Array` (now distinct) and lets a ctor be
+   stored in an `any[]`, passed to a param, and `ref.test`-dispatched.
+2. **`$__ta_dyn_view {length, buf, byteOffset, kind}`** (`getOrRegisterTaDynViewType`)
+   — a runtime-kinded shared-backing view built by the dynamic construct. Carries the
+   kind EXPLICITLY (B1's per-kind views can't — they canonicalize together). One
+   `struct.new`, not a 9-arm switch.
+3. **`emitDynamicTaViewConstruct`** (dataview-native) — `new ctor(rab[, off[, len]])`:
+   recover buffer vec once, read ctor `kind`, build one `$__ta_dyn_view` (auto-length
+   `-1` sentinel over a resizable buffer → length-tracking). Wired in `new-super.ts`'s
+   unknown-ctor block, gated to a statically-buffer-typed first arg (so `new c(5)`
+   count-ctors don't `ref.cast`-trap). A non-`$__ta_ctor` callee → null (declines).
+4. **`ctor.BYTES_PER_ELEMENT` + `view.BYTES_PER_ELEMENT`** (`emitTaCtorBytesPerElement`)
+   — runtime `ref.test` over `$__ta_ctor`/`$__ta_dyn_view` → kind → `select` chain over
+   `TA_CTOR_BYTES`. Placed at the TOP of `compilePropertyAccess` (the generic dynamic
+   dispatchers below return 0/throw); registers the type on demand (the read can compile
+   before the value that registers it — `CreateRabForTest` before the top-level `ctors`).
+5. **Dynamic `view.byteLength`** (`emitTaViewDynamicByteLength`) — a boxed dyn view read
+   back through an `any` receiver: `ref.test $__ta_dyn_view` → kind → `effectiveLen ×
+   elemSize` (resize-tracked); bare AB/DataView vec → its byte length; else 0. The
+   generic reader THREW on `.byteLength` before this.
+6. **E — runner shim** (`buildPreamble`, test262-runner) — adapted, eval-free
+   `resizableArrayBufferUtils.js`: `ctors`/`floatCtors`/`CreateResizableArrayBuffer`/
+   `CreateRabForTest`/`CollectValuesAndResize`/`TestIterationAndResize`/`MayNeedBigInt`/
+   `ToNumbers`. Helper returns typed **`ArrayBuffer`** so the dynamic construct's
+   static buffer-arg gate passes (an `any` buffer → ctor declines → null view). The
+   upstream `new Function('return class …')()` eval subclasses + BigInt/Float16 are
+   dropped. Include-gated → byte-inert for every other test.
+
+### Measured pass-count delta (the epic payoff)
+Scoped standalone lane over the **188** `resizableArrayBufferUtils.js`-including tests,
+this branch vs base C (main-equivalent), via the real runner (`runTest262File(…,
+"standalone")`):
+- **base C: 0 pass** / 181 fail / 4 compile_error / 3 skip.
+- **this branch: 17 pass** / 155 fail / 13 compile_error / 3 skip.
+- **NET = +17 standalone passes, 0 pass→non-pass regressions.** The 26 fail→(other)
+  and 9 fail→compile_error moves are all non-pass→non-pass (no floor loss). The 155
+  remaining fails + 13 CE are dominated by **element read/WRITE on a dynamic view**
+  (`ta[i]` / `ta[i]=v`), which is BANKED (see below) — those tests now RUN host-free but
+  their `assert.compareArray`/element-value checks need the byte-decode-by-runtime-kind
+  arm. Many of the 155 will flip once that lands.
+
+### Byte-inert proof
+sha256 of the standalone binary is **IDENTICAL** between base C and this branch for 7
+controls: arithmetic, plain array, native `Uint8Array` element+`BYTES_PER_ELEMENT`,
+static `Int32Array.BYTES_PER_ELEMENT`, DataView set/get, string `.length`, native
+`Int32Array.byteLength`. Only programs that use a TA ctor as a VALUE change bytes. All
+72 B1/B2/B3/C tests still green; `tests/issue-3054-de-dynctor.test.ts` (9 host-enforced)
+green; tsc/prettier/biome clean.
+
+### Banked follow-up (deliberate, per floor discipline) — element access on `$__ta_dyn_view`
+Element read/write on a *dynamically-constructed* view (`ta[i]` / `ta[i] = v` where
+`ta` is `any`) is NOT implemented: the boxed view's kind is only known at runtime, so it
+needs a runtime-kind byte-decode/encode arm in the dynamic INDEX path (the compile-time
+`$__ta_view` arms are typeIdx-gated and never fire for a boxed view). Currently such
+access falls to the generic index path, which emits an invalid `array.get` on the
+`$__ta_dyn_view` struct → those 13 tests are `compile_error` (they were **`fail`** on
+base — non-pass→non-pass, NOT a floor regression, confined to shim tests). A safe
+fall-through can't be added at the top (a boxed plain-array `values[i]` read shares the
+`any` receiver), so it belongs in the generic dispatch itself. **Recommend a scoped
+follow-up issue: "dynamic `$__ta_dyn_view` element get/set (runtime-kind byte codec)"** —
+it should flip a large share of the 155 fails and remove the 13 invalid-Wasm CE.
+
+### #3054 epic status
+B1 (#2736) · B2 (#2737) · B3 (#2738) · C (#2739) · **D+E (this PR)** all landed. The
+resizable-`ctors` cluster now runs host-free with +17 floor-positive passes; the
+element-access byte-codec is the one banked follow-up. Epic **closed**.

--- a/plan/issues/3057-dynamic-ta-view-element-codec.md
+++ b/plan/issues/3057-dynamic-ta-view-element-codec.md
@@ -1,0 +1,117 @@
+---
+id: 3057
+title: "Dynamic `$__ta_dyn_view` element get/set — runtime-kind byte codec on the generic dynamic index path"
+status: ready
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen
+language_feature: typed-array, resizable-arraybuffer, dynamic-index
+sprint: Backlog
+es_edition: ES2024
+test262_category: built-ins/TypedArray, built-ins/ArrayBuffer
+goal: standalone-mode
+related: [3054, 3055, 1781]
+---
+
+# Dynamic `$__ta_dyn_view` element get/set — runtime-kind byte codec on the generic dynamic index path
+
+## Problem
+
+Follow-up banked from #3054 D+E (PR #2740). D+E landed dynamic
+`new <ctorVar>(rab)` construction: a boxed `$__ta_dyn_view` view produced by
+`new <ctorVar>(rab)` where `ctorVar` is a TypedArray constructor held in a
+variable (typed `any`). The view is a real shared-backing window over the
+(possibly resizable) buffer, and `.length` / `.byteLength` / proto-method
+write-through all dispatch correctly on the view's **runtime** TA kind (stored
+in the struct field `kind`).
+
+What D+E did **not** wire up is **element access by index** on such a view when
+the receiver is statically `any`:
+
+```ts
+const ta = new ctorVar(rab); // ta : any, boxed $__ta_dyn_view, kind known only at runtime
+const x = ta[i];             // generic dynamic INDEX get — no runtime-kind codec arm
+ta[i] = v;                   // generic dynamic INDEX set — no runtime-kind codec arm
+```
+
+### Root cause
+
+The `$__ta_dyn_view` struct carries its TypedArray kind (Int8 / Uint8 /
+Uint8Clamped / Int16 / ... / Float64) **only at runtime**, in the `kind` field.
+The generic dynamic index dispatch (`ta[i]` / `ta[i] = v` for an `any`
+receiver) has **no arm that switches on that runtime `kind` byte** to decode /
+encode the element. As a result:
+
+- **155 of the 188** resizable-buffer test262 tests now **RUN host-free** (a D+E
+  win — they used to bail earlier) but **fail element-value asserts**: the
+  dynamic index path reads the wrong bytes / wrong element width because it does
+  not know the element size or signedness at that site.
+- **13** of them hit an **invalid `array.get`** against the new
+  `$__ta_dyn_view` struct (the generic path assumes a plain WasmGC array
+  backing) -> **CE**.
+
+This is **non-pass -> non-pass**, confined to the resizable-buffer shim tests --
+**no standalone floor regression** (verified in #2740: the +17 floor gain is
+independent of these still-failing element asserts).
+
+## Fix direction
+
+Add a **runtime-kind byte-codec arm** to the generic dynamic index dispatch
+(both get and set) that, when the receiver is a `$__ta_dyn_view`:
+
+1. Reads the runtime `kind` byte from the view struct.
+2. Computes the element address as `byteOffset + i * elemSize(kind)` (the view
+   already stores `byteOffset` and its shared-backing buffer handle).
+3. Byte-decodes (get) / byte-encodes (set) the element through the existing
+   **dataview-native little-endian engine** (`src/codegen/dataview-native.ts`,
+   the same LE codec D+E's proto-method write-through already uses), switching
+   on `kind` for width + signedness + float-vs-int (and the Uint8Clamped clamp
+   on set).
+
+This reuses the LE codec that B3 write-through and D+E already rely on, so the
+element path becomes consistent with the proto-method path.
+
+## Hazard (flagged by opus-3054-de)
+
+The generic dynamic index path is **shared** with boxed **plain-array**
+receivers -- e.g. a plain `values[i]` where `values` is also statically `any`.
+The new codec arm **MUST NOT hijack** those: a plain-array `any[i]` must keep
+its current array-backed behavior. **Gate the new arm on
+`ref.test $__ta_dyn_view` first** (structural runtime type test on the receiver)
+and only enter the byte-codec when the test passes; fall through to the existing
+array path otherwise. Do not switch on anything but the concrete
+`$__ta_dyn_view` ref type -- a looser gate (e.g. "has a `kind` field") risks
+false positives on other boxed shapes.
+
+## Acceptance criteria
+
+- `ta[i]` (get) on a boxed `$__ta_dyn_view` returns the correct element value
+  for every TA kind (Int8/Uint8/Uint8Clamped/Int16/Uint16/Int32/Uint32/
+  Float32/Float64), reading `byteOffset + i*elemSize` via the LE engine.
+- `ta[i] = v` (set) writes the correct little-endian bytes for every kind
+  (including the Uint8Clamped clamp), observable through a sibling view / the
+  backing buffer.
+- The 13 previously-CE tests no longer hit invalid `array.get` (no CE).
+- A plain-array `any` receiver `values[i]` get/set is **unchanged** (regression
+  guard test: mixed function that indexes both a `$__ta_dyn_view` and a plain
+  boxed array through `any`).
+- Standalone floor does not regress; a large share of the 155 element-assert
+  failures flip to pass.
+
+## Estimated impact
+
+Should flip a large share of the **155** now-running-but-failing resizable tests
+and remove the **13** CE. Completes the element-access half of the dynamic-view
+story #3054 D+E opened.
+
+## References
+
+- #3054 (D+E, PR #2740) -- dynamic `new <ctorVar>(rab)`, `$__ta_dyn_view`,
+  `.length`/`.byteLength`/write-through dispatch on runtime `kind`.
+- #3055 -- sibling resizable-buffer follow-up.
+- #1781 -- resizable ArrayBuffer umbrella.
+- `src/codegen/dataview-native.ts` -- the LE byte codec to reuse.
+- `src/codegen/property-access.ts` -- the generic dynamic index dispatch site
+  where the new `ref.test $__ta_dyn_view` codec arm lands.

--- a/scripts/oracle-ratchet-baseline.json
+++ b/scripts/oracle-ratchet-baseline.json
@@ -97,8 +97,8 @@
       "ctxChecker": 5
     },
     "src/codegen/expressions/new-super.ts": {
-      "getTypeAtLocation": 21,
-      "ctxChecker": 45
+      "getTypeAtLocation": 22,
+      "ctxChecker": 46
     },
     "src/codegen/expressions/unary-updates.ts": {
       "getTypeAtLocation": 4,

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -197,6 +197,9 @@ export function createCodegenContext(
     subviewTypeMap: new Map(), // (#2357) per-elem-kind $__subview type idx
     taViewTypeMap: new Map(), // (#3054 B1) per-TA-name $__ta_view shared-backing view idx
     resizableAbTypeIdx: -1, // (#3054 C) $__resizable_ab subtype of $__vec_i32_byte, lazy
+    taCtorTypeIdx: -1, // (#3054 D) $__ta_ctor {kind:i32} first-class TA constructor value, lazy
+    taCtorSingletonGlobals: new Map(), // (#3054 D) per-kind boxed $__ta_ctor singleton module-globals
+    taDynViewTypeIdx: -1, // (#3054 D) $__ta_dyn_view {length,buf,byteOffset,kind} runtime-kinded view, lazy
     errorStructTypeIdx: -1,
     widenedTypeProperties: new Map(),
     widenedVarStructMap: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1713,6 +1713,33 @@ export interface CodegenContext {
    * hazard. -1 = not yet registered. (Spec: plan/issues/3054 Phase A A.2.)
    */
   resizableAbTypeIdx: number;
+  /**
+   * (#3054 D) Type index for the standalone `$__ta_ctor` struct — a first-class
+   * runtime value for a TypedArray CONSTRUCTOR used in value position
+   * (`const c = Uint8Array`, `ctors = [Uint8Array, …]`, a `new ctor(rab)` callee).
+   * `{kind: i32}` where `kind` indexes `TA_CTOR_KINDS` (the 9 element kinds). Before
+   * this a bare TA name in value position degraded to `ref.null.extern`
+   * (indistinguishable — `Uint8Array === Int8Array` was `true`), so a dynamic
+   * `new ctor(rab)` dropped the ctor and produced null. The `kind` field drives the
+   * runtime-switch dynamic construct + `ctor.BYTES_PER_ELEMENT`. Registered
+   * late+once; -1 = not yet registered. Byte-inert: only emitted when a TA ctor is
+   * used as a value. (Spec: plan/issues/3054 Phase A/D.)
+   */
+  taCtorTypeIdx: number;
+  /** (#3054 D) Per-kind memoized singleton module-global holding the boxed `$__ta_ctor` value (identity via `ref.eq`). Key = kind index. */
+  taCtorSingletonGlobals: Map<number, number>;
+  /**
+   * (#3054 D) Type index for `$__ta_dyn_view` — a shared-backing TypedArray view
+   * whose element kind is only known at RUNTIME (built by a dynamic `new
+   * ctor(rab)`). Unlike B1's per-kind `$__ta_view_<K>` (which are structurally
+   * identical → WasmGC canonicalizes them to ONE runtime type, so `ref.test` can't
+   * recover the kind), this struct carries a `kind: i32` field:
+   * `{length: i32 (mut), buf: (ref null $__vec_i32_byte), byteOffset: i32, kind: i32}`,
+   * subtype of `$__vec_base`. All dynamic-view access (`.byteLength`, element
+   * get/set) dispatches on the stored `kind` (not `ref.test`). Registered late+once;
+   * -1 = not yet registered. Byte-inert: only emitted for a dynamic `new ctor(…)`.
+   */
+  taDynViewTypeIdx: number;
   /** Type index for the WasmGC `$Error_struct` used in standalone/WASI mode (#1104). -1 = not yet registered. */
   errorStructTypeIdx: number;
   /** Extra properties for empty object variables */

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -44,7 +44,16 @@ import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
-import { getOrRegisterResizableAbType, getOrRegisterTaViewType, getTaViewName } from "./registry/types.js";
+import {
+  getOrRegisterResizableAbType,
+  getOrRegisterTaCtorType,
+  getOrRegisterTaDynViewType,
+  getOrRegisterTaViewType,
+  getTaViewName,
+  TA_CTOR_BYTES,
+  TA_CTOR_KINDS,
+  taCtorKindOf,
+} from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType } from "./type-coercion.js";
 
@@ -1579,6 +1588,377 @@ export function emitTaViewConstructWindowed(
   fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
   fctx.body.push({ op: "struct.new", typeIdx: taViewTypeIdx } as Instr);
   return { kind: "ref_null", typeIdx: taViewTypeIdx };
+}
+
+/**
+ * (#3054 D) Emit a first-class TypedArray CONSTRUCTOR value for a bare TA name in
+ * value position (`const c = Uint8Array`, `[Uint8Array, …]`, a `new ctor(rab)`
+ * callee). Produces a `$__ta_ctor {kind}` struct boxed to externref — a distinct,
+ * non-null value whose runtime `kind` (index into `TA_CTOR_KINDS`) drives the
+ * dynamic `new ctor(…)` construct + `ctor.BYTES_PER_ELEMENT`. Before this the name
+ * degraded to `ref.null.extern` (all TA ctors indistinguishable). Returns the
+ * externref ValType, or null when `name` is not one of the 9 supported TA kinds.
+ * Standalone/WASI lane only (the caller gates on `noJsHost`).
+ */
+export function emitTaCtorValue(ctx: CodegenContext, fctx: FunctionContext, name: string): ValType | null {
+  const kind = taCtorKindOf(name);
+  if (kind < 0) return null;
+  const taCtorTypeIdx = getOrRegisterTaCtorType(ctx);
+  fctx.body.push({ op: "i32.const", value: kind } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: taCtorTypeIdx } as Instr);
+  // Box the struct ref to externref (ref → externref, per coerceType).
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  return { kind: "externref" };
+}
+
+/**
+ * (#3054 D) Read `ctor.BYTES_PER_ELEMENT` where `ctor` is a first-class
+ * `$__ta_ctor` value (dynamic — the ctor kind is only known at runtime). Compiles
+ * the receiver, `ref.test $__ta_ctor`, and on a match maps the runtime `kind` to
+ * its byte width via a `select` chain over `TA_CTOR_BYTES`; a non-ctor receiver
+ * yields `NaN`/`0` (declines gracefully). Returns the numeric ValType, or null if
+ * no `$__ta_ctor` type is registered in the module (byte-inert). `compileRecv`
+ * puts the receiver value on the stack as externref.
+ */
+export function emitTaCtorBytesPerElement(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  compileRecv: () => ValType | null,
+): ValType | null {
+  // Register the ctor type on demand: a dynamic `.BYTES_PER_ELEMENT` read may
+  // compile BEFORE the value-position TA name that would otherwise register it
+  // (e.g. `CreateRabForTest`'s body compiles before the top-level `ctors` array).
+  const taCtorTypeIdx = getOrRegisterTaCtorType(ctx);
+  const rt = compileRecv();
+  if (rt === null) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  } else if (rt.kind !== "externref") {
+    coerceType(ctx, fctx, rt, { kind: "externref" });
+  }
+  const anyLocal = allocLocal(fctx, `__tac_recv_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "local.set", index: anyLocal } as Instr);
+  // kind = ref.test $__ta_ctor ? ctor.kind : (ref.test $__ta_dyn_view ? view.kind : -1)
+  // — handles BOTH `ctor.BYTES_PER_ELEMENT` (a first-class ctor value) and
+  // `view.BYTES_PER_ELEMENT` (a dynamically-constructed view instance, §23.2.3.1).
+  const kindLocal = allocLocal(fctx, `__tac_kind_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: -1 } as Instr);
+  fctx.body.push({ op: "local.set", index: kindLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: taCtorTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: anyLocal } as Instr,
+      { op: "ref.cast", typeIdx: taCtorTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: taCtorTypeIdx, fieldIdx: 0 } as Instr,
+      { op: "local.set", index: kindLocal } as Instr,
+    ],
+    else: [],
+  } as Instr);
+  if (ctx.taDynViewTypeIdx >= 0) {
+    const dynIdx = ctx.taDynViewTypeIdx;
+    fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+    fctx.body.push({ op: "ref.test", typeIdx: dynIdx } as Instr);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: anyLocal } as Instr,
+        { op: "ref.cast", typeIdx: dynIdx } as Instr,
+        { op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 } as Instr, // kind
+        { op: "local.set", index: kindLocal } as Instr,
+      ],
+      else: [],
+    } as Instr);
+  }
+  // Map kind → byte width via a select chain (default 0 for a non-ctor receiver).
+  // `select` returns val1 (the deeper operand = running result) when cond≠0, so the
+  // condition is `kind != k`: (kind != k) ? prevResult : bytes[k] ≡ (kind == k) ?
+  // bytes[k] : prevResult.
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr); // running result = 0 (val1)
+  for (let k = 0; k < TA_CTOR_KINDS.length; k++) {
+    fctx.body.push({ op: "i32.const", value: TA_CTOR_BYTES[k]! } as Instr); // val2 = bytes[k]
+    fctx.body.push({ op: "local.get", index: kindLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: k } as Instr);
+    fctx.body.push({ op: "i32.ne" } as Instr); // cond = (kind != k)
+    fctx.body.push({ op: "select" } as Instr);
+  }
+  if (ctx.fast) return { kind: "i32" };
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * (#3054 D) Push the element byte width for a runtime `kind` (i32 in `kindLocal`,
+ * index into `TA_CTOR_KINDS`) via a `select` chain over `TA_CTOR_BYTES`. Leaves an
+ * i32 on the stack; a kind out of range yields 1 (harmless default).
+ */
+function pushElemSizeForKind(fctx: FunctionContext, kindLocal: number): void {
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr); // running result (val1) = 1
+  for (let k = 0; k < TA_CTOR_BYTES.length; k++) {
+    fctx.body.push({ op: "i32.const", value: TA_CTOR_BYTES[k]! } as Instr); // val2 = bytes[k]
+    fctx.body.push({ op: "local.get", index: kindLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: k } as Instr);
+    fctx.body.push({ op: "i32.ne" } as Instr); // cond = (kind != k) → (kind==k) ? bytes[k] : prev
+    fctx.body.push({ op: "select" } as Instr);
+  }
+}
+
+/**
+ * (#3054 D) Read `.byteLength` (or `.BYTES_PER_ELEMENT`) off a boxed `$__ta_dyn_view`
+ * at RUNTIME — a dynamically-constructed view read back through an `any`/union
+ * receiver (e.g. length-tracking-N's `for (ta of tas) … ta.byteLength`), where the
+ * compile-time-typeIdx accessor arm can't fire and the generic dynamic reader THROWS
+ * on `.byteLength`. The view's element kind is stored in the struct's `kind` field
+ * (B1's per-kind `$__ta_view_<K>` canonicalize together and can't be told apart by
+ * `ref.test`, which is exactly why the dynamic path uses `$__ta_dyn_view`).
+ * `byteLength = effectiveLen × elemSize(kind)`; a bare ArrayBuffer/DataView vec →
+ * its byte length; anything else → 0 (never throws). `wantElemSize` returns
+ * `elemSize(kind)` instead (for a dynamic `view.BYTES_PER_ELEMENT`). Returns the
+ * numeric ValType, or null when no `$__ta_dyn_view` type exists (byte-inert).
+ */
+export function emitTaViewDynamicByteLength(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  compileRecv: () => ValType | null,
+  wantElemSize = false,
+): ValType | null {
+  if (ctx.taDynViewTypeIdx < 0) return null;
+  const dynIdx = ctx.taDynViewTypeIdx;
+  const { vecTypeIdx } = i32ByteVec(ctx);
+  const rt = compileRecv();
+  if (rt === null) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  } else if (rt.kind !== "externref") {
+    coerceType(ctx, fctx, rt, { kind: "externref" });
+  }
+  const anyLocal = allocLocal(fctx, `__tvbl_recv_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "local.set", index: anyLocal } as Instr);
+  const resultLocal = allocLocal(fctx, `__tvbl_res_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: resultLocal } as Instr);
+
+  // $__ta_dyn_view arm: read kind → elemSize; result = elemSize (BYTES_PER_ELEMENT)
+  // or effectiveLen × elemSize (byteLength).
+  const dvLocal = allocLocal(fctx, `__tvbl_dv_${fctx.locals.length}`, { kind: "ref", typeIdx: dynIdx });
+  const kindLocal = allocLocal(fctx, `__tvbl_k_${fctx.locals.length}`, { kind: "i32" });
+  const esLocal = allocLocal(fctx, `__tvbl_es_${fctx.locals.length}`, { kind: "i32" });
+  const arm: Instr[] = [];
+  const saved = fctx.body;
+  fctx.body = arm;
+  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+  fctx.body.push({ op: "ref.cast", typeIdx: dynIdx } as Instr);
+  fctx.body.push({ op: "local.tee", index: dvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 } as Instr); // kind
+  fctx.body.push({ op: "local.set", index: kindLocal } as Instr);
+  pushElemSizeForKind(fctx, kindLocal);
+  fctx.body.push({ op: "local.set", index: esLocal } as Instr);
+  if (wantElemSize) {
+    fctx.body.push({ op: "local.get", index: esLocal } as Instr);
+    fctx.body.push({ op: "local.set", index: resultLocal } as Instr);
+  } else {
+    pushTaDynViewEffectiveLen(ctx, fctx, dvLocal, kindLocal, esLocal);
+    fctx.body.push({ op: "local.get", index: esLocal } as Instr);
+    fctx.body.push({ op: "i32.mul" } as Instr);
+    fctx.body.push({ op: "local.set", index: resultLocal } as Instr);
+  }
+  fctx.body = saved;
+  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: dynIdx } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: arm, else: [] } as Instr);
+
+  // Fallback (byteLength only): a bare ArrayBuffer/DataView vec → its byte length.
+  if (!wantElemSize) {
+    fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
+    fctx.body.push({ op: "ref.test", typeIdx: vecTypeIdx } as Instr);
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: anyLocal } as Instr,
+        { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "local.set", index: resultLocal } as Instr,
+      ],
+      else: [],
+    } as Instr);
+  }
+
+  fctx.body.push({ op: "local.get", index: resultLocal } as Instr);
+  if (ctx.fast) return { kind: "i32" };
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * (#3054 D) Push the CURRENT element length of a `$__ta_dyn_view` (`dvLocal`), given
+ * its `kind` and `elemSize`. Field0 holds either a fixed element count (`>= 0`) or
+ * the auto-length sentinel `-1` (a view built over a resizable buffer with no
+ * explicit length); for the sentinel the live length is `buf.length / elemSize`
+ * (length-tracking on resize, mirroring `pushTaViewEffectiveLen`).
+ */
+function pushTaDynViewEffectiveLen(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  dvLocal: number,
+  _kindLocal: number,
+  esLocal: number,
+): void {
+  const dynIdx = ctx.taDynViewTypeIdx;
+  const { vecTypeIdx } = i32ByteVec(ctx);
+  const storedLocal = allocLocal(fctx, `__tdvl_s_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: dvLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: dynIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.tee", index: storedLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.ge_s" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "local.get", index: storedLocal } as Instr],
+    else: [
+      { op: "local.get", index: dvLocal } as Instr,
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 1 } as Instr, // buf
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr, // buf.length (bytes)
+      { op: "local.get", index: esLocal } as Instr,
+      { op: "i32.div_u" } as Instr,
+    ],
+  } as Instr);
+}
+
+/**
+ * (#3054 D) Dynamic `new <ctorVal>(buffer[, byteOffset[, length]])` where
+ * `ctorVal` is a first-class `$__ta_ctor` value (the kind is only known at
+ * runtime — test262 `CreateRabForTest`, `for (ctor of ctors) new ctor(rab, …)`).
+ * Recovers the buffer vec ONCE, reads the ctor `kind`, then a runtime kind-switch
+ * builds the concrete per-kind `$__ta_view_<K>` (shared-backing, length-tracking
+ * over a resizable buffer via the `-1` auto-length sentinel) and boxes it to
+ * externref (the static result type is a TA union → externref). A non-`$__ta_ctor`
+ * callee, or a buffer that can't be recovered as a native vec, yields
+ * `ref.null.extern` (declines gracefully — same as the pre-D host-import drop).
+ *
+ * `ctorAnyLocal` is an anyref local already holding `any.convert_extern(ctorValue)`.
+ * Strict RangeError validation (offset alignment / bounds) is intentionally omitted
+ * on this dynamic path — B1's bounds-checked view read/write already degrades OOB
+ * to NaN/no-op, so an out-of-range window can't trap. Byte-inert: only reachable
+ * once a `$__ta_ctor` value exists in the module.
+ */
+export function emitDynamicTaViewConstruct(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  ctorAnyLocal: number,
+  bufExpr: import("../ts-api.js").ts.Expression,
+  offsetExpr: import("../ts-api.js").ts.Expression | undefined,
+  lengthExpr: import("../ts-api.js").ts.Expression | undefined,
+  compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
+): ValType | null {
+  const taCtorTypeIdx = getOrRegisterTaCtorType(ctx);
+  const { vecTypeIdx } = i32ByteVec(ctx);
+
+  // Result (boxed view) — default null so a non-ctor / unrecoverable buffer declines.
+  const resultLocal = allocLocal(fctx, `__dtav_res_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "ref.null.extern" } as Instr);
+  fctx.body.push({ op: "local.set", index: resultLocal } as Instr);
+
+  // Recover the shared buffer vec struct (mirror emitTaViewConstruct).
+  const bufType = compileExpr(bufExpr);
+  if (!bufType) return null;
+  if (bufType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+  } else if (bufType.kind === "ref" || bufType.kind === "ref_null") {
+    if ("typeIdx" in bufType && (bufType as { typeIdx: number }).typeIdx !== vecTypeIdx) {
+      fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+    }
+  } else {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const bufLocal = allocLocal(fctx, `__dtav_buf_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
+  fctx.body.push({ op: "local.set", index: bufLocal } as Instr);
+
+  // bufByteLen = buf.length (field0).
+  const bufByteLenLocal = allocLocal(fctx, `__dtav_blen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: bufByteLenLocal } as Instr);
+
+  // byteOffset = ToIndex(offsetExpr) (0 when omitted). Element-count length arg is
+  // kind-independent, so compute it ONCE (shared across all arms).
+  const offsetLocal = allocLocal(fctx, `__dtav_off_${fctx.locals.length}`, { kind: "i32" });
+  if (offsetExpr) {
+    emitToIndexI32(ctx, fctx, offsetExpr, compileExpr, offsetLocal, "RangeError: Invalid typed array offset");
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "local.set", index: offsetLocal } as Instr);
+  }
+  const lenGiven = lengthExpr !== undefined;
+  const lenElemsLocal = allocLocal(fctx, `__dtav_len_${fctx.locals.length}`, { kind: "i32" });
+  if (lengthExpr) {
+    emitToIndexI32(ctx, fctx, lengthExpr, compileExpr, lenElemsLocal, "RangeError: Invalid typed array length");
+  }
+
+  // kind = ref.test $__ta_ctor ? struct.get 0 : -1  (a non-ctor callee → -1 → the
+  // gate below leaves the null result).
+  const kindLocal = allocLocal(fctx, `__dtav_kind_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: -1 } as Instr);
+  fctx.body.push({ op: "local.set", index: kindLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: ctorAnyLocal } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: taCtorTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: ctorAnyLocal } as Instr,
+      { op: "ref.cast", typeIdx: taCtorTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: taCtorTypeIdx, fieldIdx: 0 } as Instr,
+      { op: "local.set", index: kindLocal } as Instr,
+    ],
+    else: [],
+  } as Instr);
+
+  // Build ONE `$__ta_dyn_view` carrying the runtime kind (B1's per-kind
+  // `$__ta_view_<K>` canonicalize together, so a boxed view can't recover its kind
+  // via `ref.test` — the dynamic path stores it). Only when `kind >= 0`.
+  const dynIdx = getOrRegisterTaDynViewType(ctx);
+  const resizable = ctx.resizableAbTypeIdx >= 0;
+  const buildArm: Instr[] = [];
+  const savedBody = fctx.body;
+  fctx.body = buildArm;
+  // length (field0):
+  if (lenGiven) {
+    fctx.body.push({ op: "local.get", index: lenElemsLocal } as Instr);
+  } else if (resizable) {
+    // Auto-length over a possibly-resizable buffer → -1 sentinel so the effective
+    // length is derived live from `buf.length / elemSize` (length-tracking).
+    fctx.body.push({ op: "i32.const", value: -1 } as Instr);
+  } else {
+    // Fixed auto length = (bufByteLen - offset) / elemSize(kind).
+    fctx.body.push({ op: "local.get", index: bufByteLenLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+    fctx.body.push({ op: "i32.sub" } as Instr);
+    pushElemSizeForKind(fctx, kindLocal);
+    fctx.body.push({ op: "i32.div_u" } as Instr);
+  }
+  // buf (shared vec ref) + byteOffset + kind.
+  fctx.body.push({ op: "local.get", index: bufLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: offsetLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: kindLocal } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: dynIdx } as Instr);
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  fctx.body.push({ op: "local.set", index: resultLocal } as Instr);
+  fctx.body = savedBody;
+
+  fctx.body.push({ op: "local.get", index: kindLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.ge_s" } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: buildArm, else: [] } as Instr);
+
+  fctx.body.push({ op: "local.get", index: resultLocal } as Instr);
+  return { kind: "externref" };
 }
 
 /**

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -38,6 +38,8 @@ import { getOrRegisterErrorStructType, isWasiErrorName } from "../registry/error
 import { allocLocal } from "../context/locals.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportSilentFallback } from "../fallback-telemetry.js";
+import { emitTaCtorValue } from "../dataview-native.js";
+import { taCtorKindOf } from "../registry/types.js";
 import { emitThrowReferenceError, emitThrowTypeError, noJsHost } from "./helpers.js";
 import { emitDynamicWithGet, emitWithBindingGet, resolveWithBinding } from "../with-scope.js";
 import {
@@ -1085,6 +1087,26 @@ function compileIdentifierCore(ctx: CodegenContext, fctx: FunctionContext, id: t
       fctx.body.push({ op: "throw", tagIdx });
     }
     return { kind: "externref" };
+  }
+
+  // (#3054 D) First-class TypedArray CONSTRUCTOR value. A bare TA name used as a
+  // VALUE (not `new TA()` / type position — those are handled syntactically in
+  // new-super / property-access) previously fell through to the null-externref
+  // default below, so every TA ctor was indistinguishable (`Uint8Array ===
+  // Int8Array` was `true`) and a dynamic `new ctor(rab)` dropped the ctor. Emit a
+  // `$__ta_ctor{kind}` so `ctors = [Uint8Array, …]`, `for (ctor of ctors)`, and
+  // dynamic `new ctor(rab)` / `ctor.BYTES_PER_ELEMENT` work. Standalone/WASI lane
+  // only (the view/construct substrate is host-free); gated on the name not being
+  // shadowed by a local/captured binding or a user class.
+  if (
+    noJsHost(ctx) &&
+    taCtorKindOf(name) >= 0 &&
+    fctx.localMap.get(name) === undefined &&
+    !(fctx.boxedCaptures?.has(name) ?? false) &&
+    !ctx.classSet.has(name)
+  ) {
+    const taCtorVt = emitTaCtorValue(ctx, fctx, name);
+    if (taCtorVt) return taCtorVt;
   }
 
   // Graceful fallback for known but unimplemented globals (Symbol, Object,

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -26,7 +26,12 @@ import {
   typedArrayVecStorage,
 } from "../index.js";
 import { coercionPlan } from "../coercion-plan.js"; // (#2934 1c) single coercion table for the copy-ctor element bridge
-import { emitTaViewConstruct, emitTaViewConstructWindowed, getOrRegisterDvWindowType } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1/B2) shared-backing TA views + windowing
+import {
+  emitDynamicTaViewConstruct,
+  emitTaViewConstruct,
+  emitTaViewConstructWindowed,
+  getOrRegisterDvWindowType,
+} from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1/B2) shared-backing TA views + windowing; (#3054 D) dynamic ctor construct
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
 import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
@@ -4409,6 +4414,30 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
             : (dynCallee as ts.NonNullExpression).expression;
       }
       if (ts.isIdentifier(dynCallee) && !ctx.classSet.has(dynCallee.text)) {
+        // (#3054 D) Dynamic `new <ctorVal>(buffer[, off[, len]])` where `ctorVal`
+        // is a first-class `$__ta_ctor` value (a TA constructor held in a var /
+        // array element — test262 `CreateRabForTest`, `for (ctor of ctors) new
+        // ctor(rab, …)`). The callee is `any`, so `className` is undefined and the
+        // static TA paths above are bypassed. Runtime kind-switch builds the right
+        // shared-backing `$__ta_view` in the standalone lane (no host import).
+        // Gated to a buffer-typed first arg so `new ctor(5)` (count ctor) is NOT
+        // captured here (a boxed number would `ref.cast`-trap).
+        if (noJsHost(ctx) && args.length >= 1 && !ts.isNumericLiteral(args[0]!)) {
+          const arg0Sym = ctx.checker.getTypeAtLocation(args[0]!).getSymbol?.()?.name;
+          if (arg0Sym === "ArrayBuffer" || arg0Sym === "SharedArrayBuffer" || arg0Sym === "DataView") {
+            // Compile the ctor value once into an anyref local to type-test.
+            const ctorTy = compileExpression(ctx, fctx, dynCallee, { kind: "externref" });
+            if (ctorTy && ctorTy.kind !== "externref") coerceType(ctx, fctx, ctorTy, { kind: "externref" });
+            else if (ctorTy === null) fctx.body.push({ op: "ref.null.extern" });
+            fctx.body.push({ op: "any.convert_extern" } as Instr);
+            const ctorAnyLocal = allocLocal(fctx, `__dynctor_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+            fctx.body.push({ op: "local.set", index: ctorAnyLocal });
+            const dtav = emitDynamicTaViewConstruct(ctx, fctx, ctorAnyLocal, args[0]!, args[1], args[2], (e, h) =>
+              compileExpression(ctx, fctx, e, h),
+            );
+            if (dtav) return dtav;
+          }
+        }
         if (emitDynamicNewFallback(ctx, fctx, expr, dynCallee, ctorName)) {
           return { kind: "externref" };
         }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -119,8 +119,15 @@ import {
   getSubviewArrTypeIdx,
   isSubviewTypeIdx,
   isTaViewTypeIdx,
+  taCtorKindOf,
 } from "./registry/types.js";
-import { emitTaViewAccessor, emitTaViewElementGet, pushTaViewEffectiveLen } from "./dataview-native.js"; // (#3054 B1/B2/C) shared-backing TA view read + accessor props + resize length-tracking
+import {
+  emitTaCtorBytesPerElement,
+  emitTaViewAccessor,
+  emitTaViewDynamicByteLength,
+  emitTaViewElementGet,
+  pushTaViewEffectiveLen,
+} from "./dataview-native.js"; // (#3054 B1/B2/C) shared-backing TA view read + accessor props + resize length-tracking; (#3054 D) dynamic ctor BYTES_PER_ELEMENT + dynamic view byteLength
 import {
   coerceType,
   compileExpression,
@@ -3436,6 +3443,52 @@ export function compilePropertyAccess(
 
   const objType = ctx.checker.getTypeAtLocation(expr.expression);
   const propName = ts.isPrivateIdentifier(expr.name) ? "__priv_" + expr.name.text.slice(1) : expr.name.text;
+
+  // (#3054 D) `ctor.BYTES_PER_ELEMENT` where `ctor` is a first-class `$__ta_ctor`
+  // value (the kind is only known at runtime — `for (c of ctors) … c.BYTES_PER_ELEMENT`,
+  // `CreateRabForTest(ctor)`'s `4 * ctor.BYTES_PER_ELEMENT`). Placed at the TOP so
+  // it wins over the generic dynamic-member dispatchers below (which return
+  // `undefined`/0 for a `$__ta_ctor` receiver — a param/loop-var typed `any`).
+  // Byte-inert: only when a `$__ta_ctor` type already exists in the module (it is
+  // registered when a TA name is used as a value, e.g. the `ctors` array). Excludes
+  // the static `Uint8Array.BYTES_PER_ELEMENT` NAME form (kept on its dedicated path)
+  // and native TypedArray/DataView/ArrayBuffer INSTANCES (their own instance arm).
+  if (
+    propName === "BYTES_PER_ELEMENT" &&
+    noJsHost(ctx) &&
+    !(ts.isIdentifier(expr.expression) && taCtorKindOf(expr.expression.text) >= 0)
+  ) {
+    const recvSym = objType.getSymbol()?.name;
+    const isNativeInstance =
+      recvSym !== undefined &&
+      (taCtorKindOf(recvSym) >= 0 || recvSym === "DataView" || recvSym === "ArrayBuffer" || recvSym === "TypedArray");
+    // A `$__ta_ctor` value only ever flows through an `any`/`unknown`/union-typed
+    // receiver (a concrete TA / native instance never holds one). Gate on that so
+    // non-dynamic reads stay byte-inert, and register the ctor type on demand (the
+    // read may compile before the value that would register it).
+    const isDynamicReceiver =
+      (objType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0 || objType.isUnion() || ctx.taCtorTypeIdx >= 0;
+    if (!isNativeInstance && isDynamicReceiver) {
+      const r = emitTaCtorBytesPerElement(ctx, fctx, () => compileExpression(ctx, fctx, expr.expression));
+      if (r) return r;
+    }
+  }
+
+  // (#3054 D) `.byteLength` on a boxed `$__ta_view` read back through an `any`/union
+  // receiver (a dynamically-constructed view stored in an `any[]`, e.g.
+  // length-tracking-N's `for (ta of tas) … ta.byteLength`). The compile-time-typeIdx
+  // `$__ta_view` accessor arm can't fire (the local is externref), and the generic
+  // dynamic reader THROWS on `.byteLength`. Runtime `ref.test` dispatch instead.
+  // Gated to a dynamic receiver + at least one registered `$__ta_view` type
+  // (byte-inert otherwise); a static ArrayBuffer/DataView/TA `.byteLength` keeps its
+  // own concrete arm below (its receiver type is not `any`/union).
+  if (propName === "byteLength" && noJsHost(ctx) && ctx.taDynViewTypeIdx >= 0) {
+    const isDynamicReceiver = (objType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0 || objType.isUnion();
+    if (isDynamicReceiver) {
+      const r = emitTaViewDynamicByteLength(ctx, fctx, () => compileExpression(ctx, fctx, expr.expression));
+      if (r) return r;
+    }
+  }
 
   // (#2743 a) `arguments.constructor.prototype` → %Object.prototype% (§10.4.4):
   // the arguments object's `.constructor` is %Object%, whose `.prototype` is

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -337,6 +337,89 @@ export function getTaViewName(ctx: CodegenContext, typeIdx: number): string | un
 }
 
 /**
+ * (#3054 D) Canonical ordered list of TypedArray element kinds a first-class
+ * `$__ta_ctor` value can name. The array INDEX is the runtime `kind` stored in the
+ * struct; every dynamic-construct / `BYTES_PER_ELEMENT` dispatch iterates this list
+ * so the ordering is the single source of truth. BigInt64/Float16 views are omitted
+ * (unsupported elsewhere in the standalone lane).
+ */
+export const TA_CTOR_KINDS: readonly string[] = [
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+];
+
+/** (#3054 D) Element byte width per `TA_CTOR_KINDS` entry (BYTES_PER_ELEMENT). */
+export const TA_CTOR_BYTES: readonly number[] = [1, 1, 1, 2, 2, 4, 4, 4, 8];
+
+/** (#3054 D) The `kind` index for a TS TypedArray name, or -1 if not a first-class TA ctor. */
+export function taCtorKindOf(name: string): number {
+  return TA_CTOR_KINDS.indexOf(name);
+}
+
+/**
+ * (#3054 D) Get or register the `$__ta_ctor` struct — `{kind: i32}` — the
+ * first-class runtime value for a TypedArray CONSTRUCTOR used in value position.
+ * A bare TA name in value position (`const c = Uint8Array`, `[Uint8Array, …]`,
+ * a `new ctor(rab)` callee) previously degraded to `ref.null.extern`
+ * (indistinguishable — `Uint8Array === Int8Array` was `true`), so a dynamic
+ * `new ctor(rab)` dropped the ctor and produced null. The immutable `kind` field
+ * (index into `TA_CTOR_KINDS`) drives the runtime-switch dynamic construct and
+ * `ctor.BYTES_PER_ELEMENT`. A plain struct (NOT a vec subtype) so it never collides
+ * with buffer/view `ref.test`s. Registered late+once, memoized on `ctx.taCtorTypeIdx`.
+ */
+export function getOrRegisterTaCtorType(ctx: CodegenContext): number {
+  if (ctx.taCtorTypeIdx >= 0) return ctx.taCtorTypeIdx;
+  const idx = ctx.mod.types.length;
+  const name = "__ta_ctor";
+  ctx.mod.types.push({
+    kind: "struct",
+    name,
+    fields: [{ name: "kind", type: { kind: "i32" }, mutable: false }],
+  });
+  ctx.taCtorTypeIdx = idx;
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, [{ name: "kind", type: { kind: "i32" as const }, mutable: false }]);
+  return idx;
+}
+
+/**
+ * (#3054 D) Get or register `$__ta_dyn_view` — a shared-backing TypedArray view
+ * whose element kind is carried in a runtime `kind` field (index into
+ * `TA_CTOR_KINDS`), for views built by a dynamic `new ctor(rab)` where the kind is
+ * only known at runtime. B1's per-kind `$__ta_view_<K>` are structurally identical
+ * → WasmGC canonicalizes them to ONE runtime type, so a boxed view can't recover
+ * its kind via `ref.test`; this struct stores it explicitly. Subtype of
+ * `$__vec_base` so `.length` reads field0 uniformly. Registered late+once.
+ */
+export function getOrRegisterTaDynViewType(ctx: CodegenContext): number {
+  if (ctx.taDynViewTypeIdx >= 0) return ctx.taDynViewTypeIdx;
+  const vecBaseIdx = getOrRegisterVecBaseType(ctx);
+  const bufVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
+  const idx = ctx.mod.types.length;
+  const name = "__ta_dyn_view";
+  const fields = [
+    { name: "length", type: { kind: "i32" as const }, mutable: true },
+    { name: "buf", type: { kind: "ref_null" as const, typeIdx: bufVecTypeIdx }, mutable: false },
+    { name: "byteOffset", type: { kind: "i32" as const }, mutable: false },
+    { name: "kind", type: { kind: "i32" as const }, mutable: false },
+  ];
+  ctx.mod.types.push({ kind: "struct", name, superTypeIdx: vecBaseIdx, fields });
+  ctx.taDynViewTypeIdx = idx;
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, fields);
+  return idx;
+}
+
+/**
  * (#3054 C) Get or register the `$__resizable_ab` struct — a WasmGC SUBTYPE of the
  * ArrayBuffer backing vec `$__vec_i32_byte`, carrying one extra `maxByteLength`
  * field:

--- a/tests/issue-3054-de-dynctor.test.ts
+++ b/tests/issue-3054-de-dynctor.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3054 D+E — dynamic `new <ctorVar>(rab)` over a resizable buffer + harness shim.
+//
+// A TypedArray constructor used as a VALUE (`const c = Uint8Array`, `[Uint8Array,
+// …]`, a `new ctor(rab)` callee) previously degraded to `ref.null.extern` — every
+// TA ctor was indistinguishable (`Uint8Array === Int8Array` was `true`) and a
+// dynamic `new ctor(rab)` dropped the ctor (null → trap). D gives TA ctors a
+// first-class `$__ta_ctor{kind}` value and lowers a dynamic `new ctor(…)` to a
+// runtime-kinded `$__ta_dyn_view`. Standalone/WASI lane only. Host-enforced (the
+// standalone floor doesn't enforce in-Wasm numeric asserts, #3055/#3056), so each
+// program returns a number to JS and vitest `expect` enforces it.
+
+async function run(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#3054 D+E dynamic TypedArray constructor", () => {
+  it("distinct TA ctors are distinguishable values (was: both null → ===)", async () => {
+    expect(
+      await run(`export function f(): number { const c = Uint8Array; const d = Int8Array; return c === d ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("ctor.BYTES_PER_ELEMENT reads the kind (var, narrowed)", async () => {
+    expect(await run(`export function f(): number { const c: any = Uint32Array; return c.BYTES_PER_ELEMENT; }`)).toBe(
+      4,
+    );
+    expect(await run(`export function f(): number { const c: any = Float64Array; return c.BYTES_PER_ELEMENT; }`)).toBe(
+      8,
+    );
+  });
+
+  it("ctor.BYTES_PER_ELEMENT works cross-function (param typed any)", async () => {
+    expect(
+      await run(`
+        function bpe(c: any): number { return c.BYTES_PER_ELEMENT; }
+        export function f(): number {
+          const ctors: any[] = [Uint8Array, Int16Array, Float64Array];
+          let s = 0;
+          for (const c of ctors) { s = s + bpe(c); }
+          return s; // 1 + 2 + 8
+        }`),
+    ).toBe(11);
+  });
+
+  it("static Uint8Array.BYTES_PER_ELEMENT and native-instance stay correct (byte-inert paths)", async () => {
+    expect(await run(`export function f(): number { return Int32Array.BYTES_PER_ELEMENT; }`)).toBe(4);
+    expect(await run(`export function f(): number { const a = new Int32Array(4); return a.BYTES_PER_ELEMENT; }`)).toBe(
+      4,
+    );
+  });
+
+  it("dynamic new ctor(buf) constructs a non-null shared-backing view (.length correct)", async () => {
+    // NOTE: element read/WRITE on a dynamically-constructed `$__ta_dyn_view` (the
+    // runtime-kinded view) is deliberately BANKED — the boxed view's kind is only
+    // known at runtime, so `a[i]`/`a[i]=v` need a runtime-kind byte-decode/encode
+    // arm in the dynamic index path (a follow-up). This asserts the construct itself
+    // runs host-free and the structural `.byteLength` is correct (kind-dispatched).
+    expect(
+      await run(`
+        export function f(): number {
+          const ctors: any[] = [Int32Array];
+          const buf = new ArrayBuffer(16);
+          let r = 0;
+          for (const c of ctors) { const a = new c(buf); r = a.byteLength; }
+          return r; // Int32 over 16 bytes → 16
+        }`),
+    ).toBe(16);
+  });
+
+  it("dynamic view .byteLength dispatches on the runtime kind", async () => {
+    expect(
+      await run(`
+        export function f(): number {
+          const ctors: any[] = [Uint8Array, Int32Array];
+          const buf = new ArrayBuffer(8);
+          let s = 0;
+          for (const c of ctors) { const ta = new c(buf); s = s + ta.byteLength; }
+          return s; // 8 + 8
+        }`),
+    ).toBe(16);
+  });
+
+  it("windowed dynamic ctor new ctor(buf, off, len) sizes byteLength per kind", async () => {
+    expect(
+      await run(`
+        function CreateResizableArrayBuffer(bl: number, mx: number): ArrayBuffer { return new ArrayBuffer(bl, { maxByteLength: mx }); }
+        export function f(): number {
+          const ctors: any[] = [Uint8Array, Int32Array];
+          let n = 0;
+          for (const ctor of ctors) { const rab = CreateResizableArrayBuffer(40, 80); const ta = new ctor(rab, 0, 3); n = n + ta.byteLength; }
+          return n; // 3*1 + 3*4
+        }`),
+    ).toBe(15);
+  });
+
+  it("length-tracking dynamic view over a resizable buffer reflects a resize (byteLength)", async () => {
+    expect(
+      await run(`
+        function CreateResizableArrayBuffer(bl: number, mx: number): ArrayBuffer { return new ArrayBuffer(bl, { maxByteLength: mx }); }
+        export function f(): number {
+          const ctors: any[] = [Uint8Array];
+          let r = 0;
+          for (const c of ctors) {
+            const rab = CreateResizableArrayBuffer(8, 16);
+            const ta = new c(rab); // auto-length, tracks resize
+            rab.resize(12);
+            r = ta.byteLength; // Uint8: tracks to 12 bytes
+          }
+          return r;
+        }`),
+    ).toBe(12);
+  });
+
+  it("the CreateRabForTest harness pattern compiles and runs host-free (E shim shape)", async () => {
+    // Mirrors the adapted resizableArrayBufferUtils.js shim: typed-ArrayBuffer
+    // helpers + dynamic construct + write loop + resize, iterating a ctor list.
+    expect(
+      await run(`
+        function CreateResizableArrayBuffer(bl: number, mx: number): ArrayBuffer { return new ArrayBuffer(bl, { maxByteLength: mx }); }
+        function CreateRabForTest(ctor: any): ArrayBuffer {
+          const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+          const taWrite = new ctor(rab);
+          for (let i = 0; i < 4; ++i) { taWrite[i] = 2 * i; }
+          return rab;
+        }
+        export function f(): number {
+          const ctors: any[] = [Uint8Array, Int32Array, Float64Array];
+          let count = 0;
+          for (const ctor of ctors) {
+            const rab = CreateRabForTest(ctor);
+            const ta = new ctor(rab);
+            const bl = ta.byteLength;
+            rab.resize(8 * ctor.BYTES_PER_ELEMENT);
+            count = count + 1;
+          }
+          return count;
+        }`),
+    ).toBe(3);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1534,6 +1534,7 @@ function buildPreamble(
   needsProxyTraps: boolean,
   needsTypedArrayCtorArrays: boolean,
   needsByteConversionValues: boolean,
+  needsResizableAbUtils: boolean,
 ): string {
   let p = `let __fail: number = 0;
 let __assert_count: number = 1;
@@ -2078,6 +2079,55 @@ const byteConversionValues: any = {
 };`;
   }
 
+  if (needsResizableAbUtils) {
+    // (#3054 E) Adapted resizableArrayBufferUtils.js. The upstream file builds
+    // `ctors` via `new Function('return class My… extends … {}')()` (eval), which
+    // this compiler can't run; we inline an eval-free version: the 9 builtin
+    // TypedArray constructors (BigInt64/BigUint64/Float16 and the `My*` eval
+    // subclasses dropped — unsupported here). Helper returns are typed `ArrayBuffer`
+    // so the dynamic `new <ctorVar>(rab)` construct (#3054 D) sees a statically-known
+    // buffer arg (an `any`-typed buffer makes the ctor decline → the view is null).
+    // `MayNeedBigInt` is a no-op passthrough (no BigInt typed arrays here).
+    p += `
+
+const ctors: any[] = [
+  Uint8Array, Int8Array, Uint16Array, Int16Array, Uint32Array, Int32Array,
+  Float32Array, Float64Array, Uint8ClampedArray,
+];
+const floatCtors: any[] = [Float32Array, Float64Array];
+function CreateResizableArrayBuffer(byteLength: number, maxByteLength: number): ArrayBuffer {
+  return new ArrayBuffer(byteLength, { maxByteLength: maxByteLength });
+}
+function Convert(item: any): any { return item; }
+function ToNumbers(array: any): any {
+  let result: any[] = [];
+  for (let i = 0; i < array.length; i++) { result.push(Convert(array[i])); }
+  return result;
+}
+function MayNeedBigInt(ta: any, n: number): any { return n; }
+function CreateRabForTest(ctor: any): ArrayBuffer {
+  const rab = CreateResizableArrayBuffer(4 * ctor.BYTES_PER_ELEMENT, 8 * ctor.BYTES_PER_ELEMENT);
+  const taWrite = new ctor(rab);
+  for (let i = 0; i < 4; ++i) { taWrite[i] = MayNeedBigInt(taWrite, 2 * i); }
+  return rab;
+}
+function CollectValuesAndResize(n: any, values: any, rab: any, resizeAfter: number, resizeTo: number): boolean {
+  values.push(Number(n));
+  if (values.length == resizeAfter) { rab.resize(resizeTo); }
+  return true;
+}
+function TestIterationAndResize(iterable: any, expected: any, rab: any, resizeAfter: number, newByteLength: number): void {
+  let values: any[] = [];
+  let resized = false;
+  for (let value of iterable) {
+    values.push(Number(value));
+    if (!resized && values.length == resizeAfter) { rab.resize(newByteLength); resized = true; }
+  }
+  assert.compareArray(values, expected, "TestIterationAndResize: list of iterated values");
+  assert(resized, "TestIterationAndResize: resize condition should have been hit");
+}`;
+  }
+
   if (needsProxyTraps) {
     // #2183: test262 harness/proxyTrapsHelper.js. Returns a Proxy handler where
     // every trap defaults to a stub that throws a Test262Error when invoked
@@ -2428,6 +2478,20 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   const needsByteConversionValues =
     includes.includes("byteConversionValues.js") && /\bbyteConversionValues\b/.test(body);
 
+  // (#3054 E) resizableArrayBufferUtils.js fixtures (`ctors`/`floatCtors`/
+  // `CreateResizableArrayBuffer`/`CreateRabForTest`/`CollectValuesAndResize`/
+  // `TestIterationAndResize`/`MayNeedBigInt`/`ToNumbers`). The upstream harness
+  // builds `ctors` via `new Function('return class …')()` (eval — unsupported), so
+  // we inject an ADAPTED, eval-free version (the 9 builtin TA ctors; BigInt/Float16
+  // and the eval subclasses dropped). Helper returns are typed `ArrayBuffer` so the
+  // dynamic `new <ctorVar>(rab)` construct (#3054 D) sees a statically-known buffer
+  // arg. Include-gated + name-gated so it's byte-inert for every other test.
+  const needsResizableAbUtils =
+    includes.includes("resizableArrayBufferUtils.js") &&
+    /\b(ctors|floatCtors|CreateResizableArrayBuffer|CreateRabForTest|CollectValuesAndResize|TestIterationAndResize|MayNeedBigInt|ToNumbers|Convert)\b/.test(
+      body,
+    );
+
   // #1523: test262 host-object `$262`. Tests use it as a precondition for
   // realm creation, ArrayBuffer detach, agent messaging, and global access.
   // We expose a minimal stub: createRealm returns a fresh global with eval,
@@ -2464,6 +2528,7 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
     needsProxyTraps,
     needsTypedArrayCtorArrays,
     needsByteConversionValues,
+    needsResizableAbUtils,
   ]
     .map((b) => (b ? "1" : "0"))
     .join("");
@@ -2498,6 +2563,7 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
       needsProxyTraps,
       needsTypedArrayCtorArrays,
       needsByteConversionValues,
+      needsResizableAbUtils,
     );
     preambleCache.set(cacheKey, preamble);
   }


### PR DESCRIPTION
Closes the #3054 epic: **D** (Wasm-native dynamic `new <ctorVar>(rab)`) + **E** (adapted `resizableArrayBufferUtils.js` runner shim), landed **together** so the resizable-`ctors` cluster runs host-free.

**⚠️ Stacked on C (#2739).** This branch contains C's commits (merged in). Enqueue only after C lands; re-merge origin/main once it does.

## Measure-first corrected the spec premise
The Phase-A/D spec assumed a `ref.test`-dispatch over "TA-intrinsic singletons." Measurement disproved it:
- TA ctors had **no first-class value** — `const c = Uint8Array` compiled to `ref.null.extern`, so `Uint8Array === Int8Array` was `true` (both null). No singletons to test against.
- B1's per-kind `$__ta_view_<K>` structs are **structurally identical → WasmGC canonicalizes them to one runtime type**, so a boxed view can't recover its kind via `ref.test`.

So D needed two new representations, not a localized patch.

## What changed
- **`$__ta_ctor {kind}`** — first-class TA constructor value (TA name in value position, `identifiers.ts`). Fixes identity + lets a ctor live in an `any[]` / param and be dispatched.
- **`$__ta_dyn_view {length, buf, byteOffset, kind}`** — runtime-kinded shared-backing view built by `emitDynamicTaViewConstruct` (auto-length `-1` sentinel → length-tracking on resize).
- **`ctor`/`view.BYTES_PER_ELEMENT` + dynamic `view.byteLength`** — runtime kind → elemSize (`select` chain); registered on demand (read can compile before the value).
- **E shim** — eval-free `ctors`/`CreateRabForTest`/… ; helpers return `ArrayBuffer` so the dynamic construct's static buffer-arg gate passes. Include-gated (byte-inert).

## Measured delta (the epic payoff)
Scoped standalone lane, 188 `resizableArrayBufferUtils`-including tests, via the real runner:
- base C: **0 pass** / 181 fail / 4 CE.
- this branch: **17 pass** / 155 fail / 13 CE.
- **NET +17 standalone passes, 0 pass→non-pass regressions.**

The 155 remaining fails + 13 fail→CE are dominated by **element read/write on a dynamic view** (banked follow-up: runtime-kind byte codec in the dynamic index path) — non-pass→non-pass, no floor regression, confined to shim tests.

## Safety
- **Byte-inert**: sha256 identical (base C vs branch) for 7 controls (arith, plain array, native TA element+BYTES, static BYTES, DataView, string, native TA byteLength).
- All 72 B1/B2/B3/C tests + 9 new host-enforced `tests/issue-3054-de-dynctor.test.ts` green. tsc/prettier/biome clean.

Please hold for the monitored `merge_group` standalone-floor enqueue (expect NET ≥ 0, measured +17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8