### PR TITLE
ci(release): install deps + allow-slow-types in JSR publish job

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -163,9 +163,21 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+          cache: "pnpm"
 
+      # `jsr publish` runs `deno publish --unstable-byonm` (bring-your-own-node-
+      # modules), which type-resolves the published source (src/**/*.ts). That
+      # source imports `typescript` (src/ts-api.ts), so node_modules must exist
+      # or Deno fails with "Could not find typescript in a node_modules folder".
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      # --allow-slow-types: the exported API has many inferred types; JSR's
+      # slow-type check would otherwise reject the publish.
       - name: Publish to JSR
-        run: npx jsr publish
+        run: npx jsr publish --allow-slow-types


### PR DESCRIPTION
## Why

The `v0.60.0` tag published `@loopdive/js2@0.60.0` to **npm** ✅ but the **JSR** job failed:

```
error: Could not find "typescript" in a node_modules folder.
    at file:///home/runner/work/js2/js2/src/ts-api.ts:48:16
Command: deno publish --unstable-bare-node-builtins --unstable-sloppy-imports --unstable-byonm --no-check
```

`jsr publish` runs `deno publish --unstable-byonm` (bring-your-own-node-modules), which resolves the published source (`src/**/*.ts`). That source imports `typescript` (`src/ts-api.ts`), so `node_modules` must exist — but the job only did checkout + `npx jsr publish`, with no install.

## Fix

`publish-jsr` job now:
- adds `pnpm/action-setup` + `pnpm install --frozen-lockfile` before publishing, and
- passes `--allow-slow-types` (the exported API has inferred types JSR's slow-type check would otherwise reject).

Workflow-only.

## After merge

`@loopdive/js2@0.60.0` is already on npm, so re-tagging isn't wanted (it'd duplicate-fail the npm job). Instead, re-run the JSR leg via **Actions → publish → Run workflow** with `dry-run=false` (publishes jsr.json's 0.60.0; the npm-canonical job will red on the duplicate version, which is harmless — the jobs are independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)