### PR TITLE
docs(#3049,#3050,#3045,#3040,#3051): architect impl specs for Fable-reserved codegen bugs

### DIFF
--- a/plan/issues/3040-captured-iterable-param-default-destructure-null.md
+++ b/plan/issues/3040-captured-iterable-param-default-destructure-null.md
@@ -14,7 +14,8 @@ area: codegen
 language_feature: destructuring, parameter-defaults, iterators, closures, async-generator
 goal: spec-completeness
 related: [3038, 3039, 3023, 2664]
-architect_spec: candidate
+model: fable
+architect_spec: done
 ---
 
 # #3040 — array-destructured param with a CAPTURED custom-iterable default → "Cannot destructure null"
@@ -104,3 +105,152 @@ preferred over a vacuity excuse** (lead's note), but it is a fresh sub-project.
 - Cross-check against the non-default array-destructure param path (which works)
   and the body-position iterator destructure (which works) to see what the
   param-default path skips.
+
+## Implementation Plan (arch, 2026-07-05)
+
+Both defects located in source. Land as two commits (independent), validate the
+matrix after each, then the combined `merge_group`.
+
+### Defect 1 — captured name in a param default is not threaded (the `null` throw)
+
+**Exact site:** `src/codegen/statements/nested-declarations.ts:315-318`. The
+nested-function capture analysis builds `referencedNames` **only from the body**:
+
+```
+const referencedNames = new Set<string>();
+for (const s of stmt.body.statements) {
+  collectReferencedIdentifiers(s, referencedNames, ownLocals);
+}
+```
+
+Parameter **default initializers are never scanned**, so a name referenced ONLY
+in a default (`function*([x] = iter)` where `iter` is unused in the body) never
+enters `referencedNames` → never enters `captures` (nested-declarations.ts:359)
+→ is not threaded as a leading capture param → `emitDefaultParamInit`
+(nested-declarations.ts:942) reads it as a null/absent local → "Cannot
+destructure null".
+
+**Fix:** after the body scan, also scan each parameter's default initializer
+(and binding-pattern nested defaults) into `referencedNames` — and into
+`writtenInBody` only if the default writes (rare; a default rarely assigns an
+outer var). Precedent already in this file: the eager-call-box path scans
+`stmt.parameters` for callee names (nested-declarations.ts:918-921), and the
+class-method path scans param-defaults via `promoteAccessorCapturesToGlobals(ctx,
+fctx, member.body, paramInits)` (nested-declarations.ts:128-133). Mirror that:
+
+```
+for (const p of stmt.parameters) {
+  if (p.initializer) collectReferencedIdentifiers(p.initializer, referencedNames, ownLocals);
+  // also nested defaults inside a binding pattern element:
+  //   function f([x = outer] = iter)  → scan the pattern's element initializers
+}
+```
+
+Use `ownLocals` as the shadow set (a param default can reference an EARLIER
+param, which is a local, not a capture — `collectReferencedIdentifiers` already
+honors the shadow set). Make sure the scan also covers **nested defaults inside
+the binding pattern** (`[x = outer]`), not just the top-level `= iter`.
+
+**Cross-check the generator/async lifting variants.** #3040's matrix throws for
+sync-gen (#12), async-fn (#13), async-gen (#9). Confirm all three flow through
+this same `nested-declarations.ts` capture analysis (the generator path builds
+the buffer body at nested-declarations.ts:705-719 but reuses the SAME `captures`
+computed at 359). If a variant computes captures elsewhere, apply the same
+param-default scan there. Grep for other `collectReferencedIdentifiers(... body
+...)`-only sites that feed a capture set (closures.ts arrow path, literals.ts
+method path) and audit whether their param-defaults are scanned — out of scope
+to fix unless the matrix needs it, but note any gap.
+
+### Defect 2 — custom-iterable param default not driven through the iterator protocol (silent 0)
+
+**Symptom:** inline custom-iterable default (#11) returns 0, not the destructured
+value — the iterator protocol (`[Symbol.iterator]().next()`) is never driven; the
+typed-vec fast path reads a non-vec value and yields the type default.
+
+**Exact site:** `src/codegen/destructuring-params.ts:1184`
+(`destructureParamArray`). The externref arm (line 1226+) DOES drive the iterator
+protocol (`__array_from_iter` — see the comment at 1230-1236) and guards
+null/undefined (`emitExternrefDestructureGuard`, line 1228). But when the param's
+**static** type is a typed vec/tuple (`paramType.kind === "ref"` — the common
+case when the binding pattern element types are `number`/inferred), the function
+does **not** enter the externref arm; it falls to the typed-vec path (below line
+1221), which reads the vec backing store by index and never calls
+`[Symbol.iterator]`. A custom-iterable default value stored into that slot is not
+a real vec → reads defaults (0).
+
+**Root of the fast-path mismatch:** `emitDefaultParamInit`
+(`nested-declarations.ts:942` → `statements/nested-declarations.ts:1797`
+`emitDefaultParamInit`, and `param.initializer` compiled at ~line 1832) compiles
+the default to the param's **static** type. For an inline **array literal** `[7]`
+the default is a typed vec matching `paramType` → the typed-vec destructure path
+is correct and fast (why #1/#3/#8 pass). For a **custom iterable** the value is an
+object with `[Symbol.iterator]` — semantically it must be iterated, but the static
+`paramType` is still the typed vec, so the wrong path is taken.
+
+**Fix (design — this is the silently-wrong-code knob):** when a destructured
+param has a default whose (static or value) shape is a **custom iterable** (an
+object type carrying `[Symbol.iterator]`, i.e. NOT an array/tuple literal and NOT
+a real `Array<T>`/vec), the param-default + destructure must route through the
+**iterator-protocol drive** rather than the typed-vec fast path. Options, in
+order of preference:
+
+1. **Detect at the default-init site** (`emitDefaultParamInit`,
+   nested-declarations.ts:1797+): if `param.initializer` is a custom-iterable
+   expression (checker type has a `[Symbol.iterator]` member but is not an array
+   /tuple), materialize the default as an **externref** and force
+   `destructureParamArray` down the externref arm (which drives
+   `__array_from_iter`). This mirrors the note at destructuring-params.ts:1204-1219
+   (the `arrayDstrNeedsIdentity` + `arrayIteratorOverrideGlobalIdx` branch already
+   routes a real array through the host GetIterator read-drive when the
+   `@@iterator` override brand is set) — generalise that trigger from "override
+   brand set" to "value is a custom iterable".
+2. Or thread an `opts` flag into `destructureParamArray` that forces the
+   iterator-protocol drive for this param, set when the default is a custom
+   iterable.
+
+Prefer (1) — it keeps the fast path byte-identical for the common
+array-literal/typed-vec default (no regression to #1/#3/#8) and only diverts the
+custom-iterable case. **Confirm the body-position destructure of a custom iterable
+already works** (dev says it does) and reuse that exact drive (`__array_from_iter`
+/ the `compileArrayDestructuring` iterator path) so param position matches body
+position.
+
+### Coupling / ordering
+
+Defects 1 and 2 are independent but BOTH must land for #9/#11/#12/#13 to pass:
+#9/#12/#13 (captured) need Defect 1 (else `iter` is null before we even try to
+iterate); #11 (inline) needs Defect 2 (the value is present but not iterated).
+Land Defect 1 first (it's the smaller, well-precedented scan fix), retest the
+matrix (#9/#12/#13 should stop throwing but may still return 0 → that's Defect 2),
+then Defect 2.
+
+### Edge cases
+
+- **Default fires only when arg is `undefined`** (§ param default semantics) —
+  the iterator drive must be inside the "arg omitted/undefined" arm, not run
+  unconditionally (would iterate `iter` even when a real arg is provided — #10
+  passes today, must stay correct).
+- **IteratorClose on partial destructure**: `[x] = iter` where `iter` yields more
+  than consumed must call `iter.return()` per §8.5.2 — the externref/
+  `__array_from_iter` arm's existing IteratorClose handling covers this; verify the
+  two target files `async-generator/dstr/{dflt,named-dflt}-ary-init-iter-close.js`
+  (they specifically assert `iter.return()` is called).
+- **Empty pattern `[] = iter`**: must NOT drive the iterator body
+  (destructuring-params.ts:1244 `isPatternEmptyOnly` short-circuit) — preserve it.
+- **Nested pattern defaults** (`[[y] = inner] = iter`): both defects compound;
+  the Defect-1 scan must reach `inner`, and the Defect-2 drive must recurse.
+
+### Verification plan
+
+1. `.tmp/` — reproduce the 4 failing matrix rows #9/#11/#12/#13 (the dev's
+   `.tmp/probe-*paramdefault*.mts` shapes, host lane with `setExports` wired);
+   assert each returns its expected value after both fixes.
+2. The 2 gate files under the #2664 stack:
+   `language/expressions/async-generator/dstr/{dflt,named-dflt}-ary-init-iter-close.js`
+   — must pass so **#2664 fully un-holds with its genuine +68** (this is the
+   acceptance hinge; confirm by re-running the #2664 stack once #3040 lands).
+3. Regression sweep: `language/{statements,expressions}/*/dstr/*` default-param +
+   destructuring-param + iterator-close suites; the passing inline-array rows
+   (#1/#3/#5/#8/#10) must stay green (Defect-2 fast path preserved).
+4. Full `merge_group` — param-default handling is broad-impact (every defaulted
+   destructured param); no scoped sweep suffices. Standalone floor green.

--- a/plan/issues/3045-class-private-brand-check-reflect-has-non-object.md
+++ b/plan/issues/3045-class-private-brand-check-reflect-has-non-object.md
@@ -1,11 +1,14 @@
 ---
 id: 3045
 title: "class private-element brand check emits Reflect.has on a non-object receiver (private methods/generators/static-private)"
-status: blocked
+status: ready
 sprint: current
 priority: medium
 horizon: m
 feasibility: hard
+reasoning_effort: max
+model: fable
+architect_spec: done
 created: 2026-07-05
 task_type: bugfix
 area: codegen, runtime
@@ -103,3 +106,120 @@ Split: Bug 1 lands as a standalone partial fix (this PR — does NOT close #3045
 Re-scope #3045 (or a new senior issue) to Bug 2 (class-expression enclosing-scope
 capture), which also subsumes the pre-existing `instanceof` / `extends`-a-class-
 expression failures. `feasibility: hard`, route to senior/Fable.
+
+## Implementation Plan (arch, 2026-07-05) — Bug 2 only (Bug 1 has LANDED)
+
+**Bug 1 is on main** (`src/codegen/statements/variables.ts:709-741` now routes
+class-expression initializers through the materialize-and-store path — the old
+`if (isClassExpression) continue;` skip is gone). This spec is **Bug 2 only**:
+class-expression ctor/method bodies do not capture the enclosing function's
+scope. Re-scoped `status: ready` (was `blocked` on Bug 1).
+
+### Root cause (traced to the exact asymmetry)
+
+Class **declarations** and class **expressions** nested in a function are BOTH
+deferred at collection time (`src/codegen/declarations.ts`:
+decl → `ctx.deferredClassBodies.add(stmt.name.text)` at line 4826-4829;
+`var C = class{}` → `ctx.deferredClassBodies.add(decl.name.text)` at 4852-4854).
+The divergence is at **compile time**:
+
+- A deferred class **declaration** in statement position is re-reached by
+  `compileStatement` → `ts.isClassDeclaration(stmt)` →
+  `compileNestedClassDeclaration` (`src/codegen/statements.ts:272-273`). That
+  function (`src/codegen/statements/nested-declarations.ts:83`) runs
+  **`promoteAccessorCapturesToGlobals(ctx, fctx, member.body, paramInits)` for
+  every ctor/method/accessor** (nested-declarations.ts:126-139) **against the live
+  enclosing `fctx`**, THEN compiles the bodies (`compileClassBodies`, line 148).
+  Promotion of the captured enclosing locals to module globals is what lets the
+  separately-compiled ctor/method functions read/write the outer scope.
+
+- A class **expression** binding (`var C = class{}`) is a `ts.VariableStatement`,
+  **not** a `ts.isClassDeclaration` — so `compileStatement` never routes it to
+  `compileNestedClassDeclaration`. It goes through the variable path
+  (`statements/variables.ts`, the Bug-1 materialization), which stores the
+  BINDING value but **never calls `promoteAccessorCapturesToGlobals`** and never
+  compiles the class BODIES in-scope. The deferred entry for `C` is therefore
+  compiled (if at all) WITHOUT the enclosing-scope capture promotion → ctor/method
+  reads of enclosing locals resolve to null / stale globals, and writes are
+  dropped. `decl-ctor-closure` (declaration) works; `expr-ctor-closure`
+  (expression) does not — exactly dev-3047's finding.
+
+### The fix
+
+When `compileStatement` compiles a `VariableStatement` (or the variable path in
+`statements/variables.ts`) whose declarator initializer is a
+`ts.ClassExpression` **and we are inside a function** (enclosing `fctx` present /
+`ctx.deferredClassBodies` holds the synthetic name), run the **class-expression
+analog of `compileNestedClassDeclaration`** at that point, BEFORE/around the
+Bug-1 binding materialization:
+
+1. Resolve the synthetic class name: `ctx.anonClassExprNames.get(classExpr)`
+   (set in `declarations.ts:3394`) — the same key `deferredClassBodies` and
+   `compileClassBodies(ctx, classExpr, funcByName, syntheticName)` use.
+2. For each `ctor` / `method` / `get`/`set` accessor member of the class
+   expression, call `promoteAccessorCapturesToGlobals(ctx, fctx, member.body,
+   paramInits)` with `paramInits = member.parameters.map(p => p.initializer)
+   .filter(Boolean)` — **byte-for-byte the loop at
+   nested-declarations.ts:126-139**. `fctx` is the enclosing function, whose
+   locals are live at this statement.
+3. Compile the class bodies in-scope: `compileClassBodies(ctx, classExpr,
+   funcByName, syntheticName)` (funcByName rebuilt as at nested-declarations.ts:
+   142-145), then `ctx.deferredClassBodies.delete(syntheticName)`.
+
+**Cleanest implementation:** generalise `compileNestedClassDeclaration` to accept
+`ts.ClassDeclaration | ts.ClassExpression` + an explicit `syntheticName` (its
+callee `compileClassBodies` ALREADY accepts the union type and a syntheticName —
+class-bodies.ts:1477), and invoke it from the class-expression variable path. The
+`extendsReferencesClassName` TDZ guard (nested-declarations.ts:62) is
+declaration-shaped; guard it on `decl.name` presence for the anonymous-expression
+case.
+
+### Regression risk — #779a index-shift machinery (the reason this is `hard`)
+
+`promoteAccessorCapturesToGlobals` promotes captures to **module globals**, which
+adds globals and can add late imports → **shifts function/global indices**. Two
+guards, both already present but must be preserved for the new call site:
+
+1. `compileClassBodies` registers the enclosing func on
+   `ctx.funcStack`/`ctx.parentBodiesStack` (class-bodies.ts:1503-1507) so the
+   enclosing body's already-emitted `global.get`/`global.set` are shifted with the
+   maps — this fires for the expression path too (same function). Confirm the
+   Bug-1 binding-store instructions emitted into `fctx.body` (variables.ts:764-768)
+   are in the shift set: run the promotion+bodies compile at the SAME point they
+   are for declarations relative to the enclosing body edits — i.e. do the capture
+   promotion+body compile at the class-expression statement, so any global added
+   shifts the enclosing body that was emitted BEFORE this statement, exactly as the
+   declaration path relies on.
+2. Ordering vs the Bug-1 materialization: the binding store (`local.tee` /
+   `global.set` at variables.ts:764-768) reads the class ctor **value**. Decide
+   whether promotion+bodies must run before or after that store; declarations have
+   no binding store so this is the novel interaction — pick the order that keeps
+   `emitLazyClassObjectGet` (variables.ts:736) resolving to the same singleton the
+   ctor/method `this`/`constructor` uses, and that keeps the index-shift set
+   consistent. This is the silently-wrong-code-risk knob — validate with the WAT
+   diff (decl-ctor-closure vs expr-ctor-closure should converge).
+
+### Scope note — subsumes two pre-existing failures
+
+dev-3047: this also fixes the pre-existing `instanceof` / `extends`-a-class-
+expression failures (a class expression used as an `extends` heritage or
+`instanceof` RHS whose body captures enclosing scope). Add coverage for those.
+
+### Verification plan
+
+1. `.tmp/` repro mirroring the 8 harvested files: `function test(){ var seen;
+   function hasProp(o,k){ seen = k; return k in o; } var C = class { m(){ return
+   hasProp(this, 'x'); } }; ... }` — assert the ctor/method's call to the
+   enclosing `hasProp` gets correct args AND its write to the enclosing `seen`
+   propagates (main: wrong args / dropped write).
+2. The 8 files: `prod-private-{method,async-method,async-generator,generator,
+   method-initialize-order}.js`, `fields-multiple-definitions-static-private-
+   methods-proxy.js`, `static-private-{methods,fields}-proxy-default-handler-
+   throws.js` (all wrap the body in `export function test()` → nested class expr).
+3. `tests/issue-3045.test.ts` (Bug-1's 9 cases) stays green; add expr-ctor-closure
+   / expr-method-closure cases.
+4. Regression: the class vitest suites and the `−471` non-capturing-class-expr
+   shapes from PR #2335 (declarations.ts:4839-4840 comment) — non-capturing class
+   expressions must stay eager/unchanged.
+5. Full `merge_group` — class-expression scope capture is broad; standalone floor
+   green.

--- a/plan/issues/3049-iterator-prototype-helper-methods-not-a-function.md
+++ b/plan/issues/3049-iterator-prototype-helper-methods-not-a-function.md
@@ -5,7 +5,10 @@ status: ready
 sprint: current
 priority: medium
 horizon: m
-feasibility: medium
+feasibility: hard
+reasoning_effort: max
+model: fable
+architect_spec: done
 created: 2026-07-05
 task_type: bugfix
 area: codegen, runtime
@@ -121,3 +124,134 @@ files share the same resolution root — retest after the chain fix.
 **Status:** claim released; feasibility stays `medium` (bounded dev fix, just
 spans codegen↔runtime prototype identity). Not started as a code change — no PR
 beyond this findings note.
+
+## Implementation Plan (arch, 2026-07-05)
+
+**Bumped `feasibility: hard` / `reasoning_effort: max` / `model: fable`.** dev-3042's
+first read ("bounded medium") is right about the *mechanism* but understates the
+scope: the fix must make `getPrototypeOf(getPrototypeOf(arrayIter)) === the
+helper-bearing %IteratorPrototype%` hold **by object identity in BOTH lanes**
+(JS-host and standalone), for **four iterator kinds** (array / string / map /
+set), **without** regressing the already-shipped #3013 array-iterator-proto
+identity assertion or the generator-receiver path. That is a cross-lane
+prototype-identity change → silently-wrong-code risk if the two lanes disagree.
+
+### Root cause (confirmed, dev-3042)
+
+The 27 `*/this-plain-iterator.js` files call
+`Iterator.prototype.<helper>.call(plainIter, …)`, where the runner injects
+`Iterator.prototype = getPrototypeOf(getPrototypeOf([][Symbol.iterator]()))`
+(`tests/test262-runner.ts:1938`). The helper bodies are implemented and
+installed on `_getIteratorPrototype()` (runtime.ts:346) by
+`_installIteratorHelperPolyfills()` (runtime.ts:729). Generators reach that proto
+(`instance → GeneratorPrototype → _getIteratorPrototype()`, runtime.ts:403).
+**Array iterators do not** — `[][Symbol.iterator]()`'s 2-levels-up prototype is
+`Object.prototype`, one level shy of the helper proto, so `Iterator.prototype`
+resolves to a helper-less object and `<helper>` is `undefined`.
+
+### The two lanes need DIFFERENT fixes — do BOTH and keep them identity-consistent
+
+**Lane A — JS-host (default, the 27 harvested fails run here).**
+`[][Symbol.iterator]()` lowers to the `env::__iterator` host import
+(`src/runtime.ts` `__iterator`, runtime.ts:12438) which, for a compiled array
+(a WasmGC vec struct), dispatches `__call_@@iterator(obj)` → a compiled
+`$__IterRec` struct (`src/codegen/iterator-native.ts`, struct built via
+`getOrRegisterIterRecType`, iterator-native.ts:89). That struct is opaque to V8;
+`Object.getPrototypeOf` on it (via the `__getPrototypeOf` host import,
+`src/codegen/expressions/calls.ts:7073`) does not chain to the helper proto.
+
+- **Fix site:** in the `__iterator` host import (runtime.ts:12438), when the
+  result comes back from `__call_@@iterator` for a vec/array (the
+  `_isWasmStruct(obj)` arm, runtime.ts:12454-12461), the returned iterator must
+  be presented to the host with a `[[Prototype]]` chain reaching
+  `_getIteratorPrototype()`. Two viable shapes (pick one, document why):
+  1. **Wrap** the returned `$__IterRec` in a host proxy / plain object whose
+     `[[Prototype]]` is `Object.create(_getIteratorPrototype())` (a fresh
+     `%ArrayIteratorPrototype%`-analog, cached module-wide so identity is stable
+     across all array iterators) and that forwards `next`/`return`/`@@iterator`
+     to the struct's dispatchers (mirror the existing vec-fallback synthesis at
+     runtime.ts:12469-12486, which ALREADY does `Object.create(iterProto)` — but
+     with `iterProto = _getIteratorPrototype()`, NOT
+     `globalThis.Iterator.prototype`, and at ONE level below a stable
+     `%ArrayIteratorPrototype%` so the runner's DOUBLE `getPrototypeOf` lands on
+     the helper proto, not on `Object.prototype`). The current fallback is
+     one-level (`Object.create(iterProto)`), so `getPrototypeOf(getPrototypeOf(
+     it))` overshoots — build `Object.create(Object.create(_getIteratorPrototype()))`
+     so the 2-hop walk lands exactly on the helper proto. dev-3042 drafted+reverted
+     exactly this two-level fix in the fallback; it compiled clean but did not move
+     the 27 because `[][Symbol.iterator]()` takes the `__call_@@iterator` arm, NOT
+     the fallback — so apply the same two-level shape to the `__call_@@iterator`
+     RESULT (12454-12461), where the 27 actually flow.
+  2. Alternatively special-case the `__getPrototypeOf` host import to return the
+     stable `%ArrayIteratorPrototype%` singleton for an `$__IterRec` struct — but
+     this splits proto identity between "what getPrototypeOf reports" and "what the
+     object actually inherits", which breaks `.map` resolution on the iterator
+     itself. Prefer shape (1) (real inheritance) so `arrayIter.map(...)` ALSO works,
+     not just the `.call(plainIter)` form.
+
+**Lane B — standalone/WASI.** `Object.getPrototypeOf(<array iterator>)` routes to
+`emitArrayIteratorPrototypeSingleton` (`src/codegen/array-object-proto.ts:2001`,
+called from `src/codegen/expressions/calls.ts:7043` under
+`(ctx.standalone || ctx.wasi) && argTsType.getSymbol()?.name === "ArrayIterator"`).
+That singleton is built via `__new_plain_object()` and **never sets its
+`[[Prototype]]`**.
+
+- **Fix site:** in `emitArrayIteratorPrototypeSingleton` (array-object-proto.ts:2019),
+  after `call __new_plain_object` and before the `global.set`, set the new object's
+  `[[Prototype]]` to the standalone helper-bearing `%IteratorPrototype%`. This
+  requires a standalone `%IteratorPrototype%` that carries Wasm-native helper
+  methods — check whether one exists (grep `iterator_prototype` /
+  `%IteratorPrototype%` in `src/codegen/` and `src/runtime-standalone*`); if the
+  helpers are host-only today, standalone helper resolution is a **separate,
+  larger** slice — in that case scope Lane B to *chaining* to whatever standalone
+  `%IteratorPrototype%` object exists (even if helper-less) so the identity graph
+  is correct, and file a follow-up for standalone helper bodies. Use the same
+  `__set_prototype` / `Object.setPrototypeOf` runtime the class-proto singletons
+  use (`emitLazyProtoGet` path); confirm `__new_plain_object` results accept a
+  proto set.
+
+### Extend to string/map/set iterators
+
+The same 2-levels-up gap exists for `""[Symbol.iterator]()`,
+`new Map()[Symbol.iterator]()`, `new Set()[Symbol.iterator]()` (test262 has
+`this-plain-iterator` twins under those too, though the harvested 27 are
+array-keyed). Whatever wrap/chain Lane A applies in `__iterator` is kind-agnostic
+(it wraps the `__call_@@iterator` result), so it should cover all four for free —
+**verify** with the string/map/set `this-plain-iterator` files, don't assume.
+
+### Edge cases / regression guards
+
+- **#3013 identity assertion must still hold**: `getPrototypeOf([].values()) ===
+  getPrototypeOf([][Symbol.iterator]())` (same singleton) AND `!==
+  getPrototypeOf([1,2])` (distinct from Array.prototype). The Lane-A wrap must
+  cache the `%ArrayIteratorPrototype%`-analog module-wide (one object) so all
+  array iterators share it by identity — do NOT `Object.create` a fresh proto per
+  `[][Symbol.iterator]()` call.
+- **Generator receivers unaffected**: generators already chain correctly; the
+  Lane-A change only touches the array/vec `__call_@@iterator` arm, so confirm a
+  `function*(){}` iterator's `.map` still resolves (regression file: any
+  `Iterator/prototype/*/proto-from-ctor-realm.js` that uses a generator).
+- **`return()` forwarding** (`drop/return-is-forwarded.js`,
+  `filter/exhaustion-does-not-call-return.js`): once the helper resolves, its
+  body's `GetIteratorDirect` + IteratorClose runs on the plain-object receiver
+  (already implemented in `_installIteratorHelperPolyfills`, runtime.ts:765+). If
+  a wrap is used in Lane A, the wrapper's `return` MUST forward to the underlying
+  `$__IterRec`'s `return` dispatcher — else the `-does-not-call-return` files
+  regress the other way.
+- **flatMap `flattens-iterable` / `iterable-to-iterator-fallback`**: these drive
+  `GetIteratorFlattenable` (runtime.ts:795+) on the yielded value — should fall
+  out of the resolution fix; retest, do not special-case.
+
+### Verification plan
+
+1. Repro in `.tmp/`: compile a program doing
+   `Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]())).map` and
+   assert it is a function (host lane). Confirm it is `undefined` on main first.
+2. Local default-lane sweep of `built-ins/Iterator/prototype/*` before/after;
+   target: the 27 codegen-signature files (`this-plain-iterator`,
+   `return-is-forwarded`, `flattens-*`, `exhaustion-does-not-call-return`) flip to
+   pass, and the generator-receiver corpus is unchanged.
+3. Sweep `built-ins/Array/prototype/Symbol.iterator`, `String.prototype/@@iterator`,
+   `Map/Set` iterator suites for identity regressions (#3013 guard).
+4. Full `merge_group` (cross-lane prototype identity is broad-impact — no scoped
+   sweep suffices; standalone floor must stay green).

--- a/plan/issues/3050-generator-throw-through-try-finally-unreachable.md
+++ b/plan/issues/3050-generator-throw-through-try-finally-unreachable.md
@@ -6,6 +6,9 @@ sprint: current
 priority: medium
 horizon: m
 feasibility: hard
+reasoning_effort: max
+model: fable
+architect_spec: done
 created: 2026-07-05
 task_type: bugfix
 area: codegen
@@ -97,3 +100,142 @@ membership + a resume-mode router (reuse the existing `abruptResume` /
 `MODE_THROW` machinery, generalised from finally-only to catch + yield-in-finally),
 then remove the two `fail()` guards. TDD against the tight 6-file matrix
 (before/within/following × catch/finally).
+
+## Implementation Plan (arch, 2026-07-05)
+
+**Confirmed: this is the deferred generator-state-machine slice, not a bounded
+bug.** The eager fallback is architecturally incapable of `.throw()`-at-yield
+(no suspension point survives), so the fix is to extend the **lazy native**
+lowering in `src/codegen/generators-native.ts` to admit these two shapes, then
+let the two `fail()` guards fall away. Scope split cleanly into two independent
+sub-slices; land them separately (each is a distinct guard + distinct machinery).
+
+### Where the shapes are rejected today
+
+`lowerStatements` (generators-native.ts:511) handles `try` at case 3
+(generators-native.ts:554-567):
+
+```
+if (ts.isTryStatement(stmt)) {
+  if (stmt.catchClause || !stmt.finallyBlock) return fail();        // guard A
+  if (!statementsAreYieldFree(stmt.finallyBlock.statements)) return fail();  // guard B
+  ...
+}
+```
+
+- **Guard A** (`stmt.catchClause`) rejects the 3 `try-catch-*` files.
+- **Guard B** (`!statementsAreYieldFree(finally)`) rejects the 3 `try-finally-*`
+  files (each puts `yield 3` in the finally).
+
+The abrupt-resume machinery lives at generators-native.ts:2016-2074: on resume
+with `mode != MODE_NEXT`, it runs `state.abruptResume.finalizers` (the enclosing
+finally bodies, generators-native.ts:159 `abruptResume?: { finalizers }`), then
+for `MODE_THROW` (=2) **re-throws** the stored error field
+(generators-native.ts:2038-2042) and for `MODE_RETURN` (=1) completes with the
+`.return(v)` value. There is **no catch routing** and **no way for a finalizer to
+itself suspend on a yield**.
+
+### Sub-slice 1 — `try/catch` across a yield (guard A, the 3 `try-catch-*` files)
+
+Goal: a `.throw(e)` injected at a yield **inside a `try` that has a `catch`** must
+route control into the `catch` block (binding the error), not re-throw.
+
+**Design:** generalise `abruptResume` from a finalizer-only list to a **try-region
+membership model**. For each state (yield point), record the stack of enclosing
+try-regions with, per region: `{ catchClause?: {param, body}, finallyBlock?:
+Statement[] }` (today only `finalizers: Statement[][]` is tracked — extend the
+`NativeGeneratorState.abruptResume` shape at generators-native.ts:159).
+
+At the resume router (generators-native.ts:2062-2073, the `mode != MODE_NEXT`
+guard), replace the flat "run finalizers then re-throw" with a per-region walk
+from innermost to outermost:
+
+1. If the injected mode is `MODE_THROW` and the innermost enclosing region has a
+   `catchClause`: bind the stored `ERROR_FIELD` value to the catch param
+   (`local.set`/`struct.set` into the catch param's spill slot the same way
+   `resumeBindings` copies the sent value, generators-native.ts:2078-2088), clear
+   the throw mode to `MODE_NEXT`, and **branch into the catch block's entry
+   state** rather than executing `throwBody`. The catch body is lowered as ordinary
+   states (it can itself contain yields → recurse through `lowerStatements` with
+   the catch region popped).
+2. If the region has only a `finallyBlock` (no catch): run it then continue
+   propagating (existing behaviour) — but see sub-slice 2 for yield-in-finally.
+3. If no enclosing region catches: run all pending finalizers then re-throw
+   (existing `throwBody`, generators-native.ts:2038-2042).
+
+**Lowering change:** in `lowerStatements` case 3, when `stmt.catchClause` is
+present, DON'T `fail()` — instead lower the `try` block with the region pushed
+(carrying the catch), lower the catch block as successor states reachable only via
+the abrupt router, and (if present) the finally as the join. Mirror the existing
+`activeFinalizers` threading (generators-native.ts:558) but with a richer region
+descriptor. Reuse the `MODE_THROW` field + `ERROR_FIELD` already emitted at the
+`.throw()` entry (generators-native.ts:2865, 3022) — no new state field beyond the
+catch-param spill slot.
+
+### Sub-slice 2 — yield inside `finally` (guard B, the 3 `try-finally-*` files)
+
+Goal: `try { yield 2 } finally { yield 3; unreachable += 1 }` — `.throw()` at
+`yield 2` must run the finally, which **suspends at `yield 3`**, and only after
+the consumer resumes past it does `unreachable += 1` run (then the pending throw
+re-propagates). Spec: §27.5.3.4 GeneratorResumeAbrupt threads the abrupt
+completion THROUGH the finally, which can suspend.
+
+**Design:** the finally body must be lowered as **real states** (not replayed as a
+straight-line statement list the way generators-native.ts:562-565 does today for
+the normal path, nor compiled inline in `abruptBody` the way
+generators-native.ts:2027-2029 does for abrupt). Concretely:
+
+1. Drop guard B; lower `stmt.finallyBlock.statements` via `lowerStatements` so its
+   `yield 3` becomes a genuine suspension state.
+2. The finally must run on **all three** completion paths (normal fall-through,
+   `.return()` abrupt, `.throw()` abrupt) with a **pending-completion** carried in
+   state so that after the finally's states finish, the original completion
+   resumes: normal → continue; return → complete with the saved value; throw →
+   re-throw the saved error. This is the classic "finally with a saved completion
+   record" — model it with a small `pendingCompletion` state field (kind:
+   none/return/throw + value/error) set on entry to the finally region and
+   consumed at its exit state.
+3. The current straight-line replay of the finally on the normal path
+   (generators-native.ts:562-565) is subsumed by lowering it as states entered on
+   the normal path too — remove the duplicate replay so the finally is emitted
+   ONCE as a state subgraph, entered from all paths (avoid double-execution — the
+   #1 hazard here).
+
+### Interaction / ordering
+
+- Land **sub-slice 1** first (catch routing) — it needs no new suspension inside
+  finalizers and is a cleaner extension of the existing router.
+- **Sub-slice 2** (yield-in-finally) is the harder one (pending-completion +
+  finally-as-states + no-double-run). A combined `try/catch/finally` with a yield
+  in the finally is the union case — verify the matrix's `following-*` files hit
+  it.
+- Keep the `MODE_*` constants (generators-native.ts:54-61) and `ensureExnTag`
+  (generators-native.ts:2041) — reuse, don't reinvent.
+
+### Edge cases
+
+- **`.next()` resumption and the return path must be byte-identical** for
+  generators that DON'T use catch/yield-in-finally — gate the new machinery so a
+  finally-only, catch-free, yield-free-finally generator still takes the exact
+  current path (the guards falling away must not change already-passing shapes).
+- **Nested try** (`try-catch-within-catch.js`, `try-finally-within-finally.js`):
+  the region stack must handle a yield inside a catch/finally that is ITSELF inside
+  another try — the innermost-to-outermost walk covers it, but test it explicitly.
+- **`return()` inside a finally that yields**: a `.return()` during a suspended
+  yield-in-finally must not skip the rest of the finally — the pending-completion
+  model handles this; verify against `try-finally-following-finally.js`.
+- **Double-execution of the finally** — the single-subgraph rule (sub-slice 2
+  step 3) is the guard; a probe that counts finally-runs must show exactly 1.
+
+### Verification plan
+
+1. `.tmp/` minimal per the dev's confirmed repro: `try { yield 2 } finally {
+   yield 3; unreachable += 1 }`; `iter.throw()` after `iter.next()` → assert
+   `unreachable === 0` (main returns 1).
+2. The tight 6-file matrix: `built-ins/GeneratorPrototype/throw/try-{catch,finally}-{
+   before-try,within-{catch,finally},following-{catch,finally}}.js`.
+3. Regression: `built-ins/GeneratorPrototype/{next,return}/*` and the existing
+   native-generator vitest suites (search `tests/*generator*`), plus non-generator
+   try/finally (`language/statements/try/*`) — the eager→native promotion of these
+   shapes must not perturb them.
+4. Full `merge_group` (generator lowering is broad; standalone floor green).

--- a/plan/issues/3051-regexp-symbol-replace-split-coercion-protocol.md
+++ b/plan/issues/3051-regexp-symbol-replace-split-coercion-protocol.md
@@ -1,12 +1,14 @@
 ---
 id: 3051
 title: "RegExp.prototype[@@replace] / [@@split] coercion protocol: ToString/ToInteger/ToLength on result-array + lastIndex/limit/flags args (~48 fails)"
-status: in-progress
-assignee: ttraenkler/dev-3051b
+status: ready
 sprint: current
 priority: medium
 horizon: m
-feasibility: medium
+feasibility: hard
+reasoning_effort: max
+model: fable
+architect_spec: done
 created: 2026-07-05
 task_type: bugfix
 area: codegen, runtime
@@ -213,3 +215,127 @@ Not addressed by Slice 1 or Slice 2. Distinct mechanisms, all senior-depth:
 `tests/issue-3051.test.ts` — 5/5 pass. Local default-lane sweep of
 `built-ins/RegExp/prototype/Symbol.{replace,split}`: replace 54/69, split 28/43
 (was 39/69, 28/43).
+
+## Implementation Plan (arch, 2026-07-05) — Slice 3+ (senior-depth)
+
+**Slices 1 & 2 landed** (dev-3051 / dev-3051b). Re-scoped `status: ready`,
+`feasibility: hard`, `model: fable` for the four remaining clusters. These are
+distinct mechanisms; land each as its own commit. All four live in the JS-host
+lane's `__regex_symbol_call` (`src/runtime.ts:10587`) and the
+`_wrapForHost`/`_wrapExecReturnForHost` bridge (runtime.ts:2347). Standalone lane
+delegates to the native RegExp backend (#682) — verify each fix has a standalone
+story or is host-lane-gated so the standalone floor is unaffected.
+
+### Cluster 1 — `result-*-err` abrupt-throw through a throwing getter (the biggest)
+
+Files: `result-get-{index,length,matched}-err`, `result-get-groups-prop-err`,
+`result-coerce-groups-err`. The exec result object has `get index(){ throw new
+Test262Error() }`. V8's native `@@replace`/`@@split` reads it through the
+`_wrapForHost` proxy (`_wrapExecReturnForHost`, runtime.ts:2347) → invokes the
+compiled getter closure → the wasm `throw` must surface as a **JS exception V8
+propagates** back to the user's `try/catch`.
+
+**Mechanism to build:** the get-trap in `_wrapForHost` that dispatches a struct's
+accessor/getter closure (grep the get-trap accessor arm near runtime.ts:5278 and
+the `WebAssembly.RuntimeError` guards at runtime.ts:2941-3074) catches wasm traps
+today (`e instanceof WebAssembly.RuntimeError`) and converts them to a
+`_PRIM_ABSENT`/undefined sentinel (runtime.ts:3057). A user `throw new
+Test262Error()` in a compiled getter surfaces as a wasm exception (tag
+`ensureExnTag`), NOT a `WebAssembly.RuntimeError` — so it must be **re-thrown as
+the underlying JS error value**, not swallowed. The fix: in the getter-dispatch
+arm, when the caught exception is a wasm-thrown user exception (has the exn tag /
+carries a boxed JS error payload), extract the payload and `throw` it as a JS
+value so V8's protocol propagates it to the user catch. Confirm how compiled
+`throw new X()` is represented at the host boundary (does the module export a
+helper to unwrap the thrown externref? grep `ensureExnTag` consumers + any
+`__get_pending_exception`/`getArg` host-side unwrap). This is the reusable
+"wasm-exception → host → user-catch" bridge — once built it also helps #3050's
+host lane and any throwing-getter-through-native-protocol case.
+
+**Edge:** an actually-buggy wasm trap (real RuntimeError) must STILL be swallowed
+to the absent sentinel where it is today — only *user* throws propagate. Keep the
+two exception classes distinct.
+
+### Cluster 2 — `Cannot convert object to primitive value` (@@split object args)
+
+Files: `coerce-flags`, `limit-0-bail`, `str-coerce-lastindex`,
+`str-result-coerce-length`, `str-set-lastindex-{match,no-match}`. An object arg /
+`lastIndex` round-trip that must `ToString`/`ToLength`/`ToPrimitive` traps at the
+wasm boundary before reaching the protocol. Slice 2's data-struct guard fixed the
+*throwing-valueOf* subset (`coerce-limit-err`); these plain object-to-primitive
+cases still trap because the value is passed to V8 as an opaque wasm struct with
+no `[Symbol.toPrimitive]`/`valueOf`/`toString` visible.
+
+**Fix:** ensure EVERY object-typed arg into `__regex_symbol_call` (runtime.ts:
+10588 params `arg0`,`arg1`) and every `lastIndex`/`flags` value read from the
+compiled RegExp is routed through `_wrapForHost` (property proxy) **before** it
+reaches V8's native protocol, so native `ToPrimitive`/`ToString`/`ToLength`
+dispatches the struct's coercion closures — same treatment Slice 2 applied to the
+replaceValue via the `__is_data_struct` discriminator (runtime.ts:1809
+`wrapCallable`). Audit the arg-wrapping at runtime.ts:10599-10621 and the
+`flags`/`lastIndex` get/set host bindings (grep `str-set-lastindex`,
+`RegExp_set_lastindex`, the #2671 lastIndex-as-externref treatment referenced in
+Slice 2). The `@@split` splitter's `lastIndex` get/set protocol
+(`str-set-lastindex-*`) needs the compiled RegExp's `lastIndex` to round-trip as
+externref (mirror `.global`/`.unicode` retype from Slice 2, and the #2671
+`lastIndex`).
+
+### Cluster 3 — `SpeciesConstructor` for @@split
+
+Files: `species-ctor{,-y,-err}`, `species-ctor-non-obj`, `species-non-ctor`,
+`splitter-proto-from-ctor-realm`. §22.2.6.14 `[Symbol.split]`: `C = ?
+SpeciesConstructor(rx, %RegExp%)` then `splitter = ? Construct(C, [rx,
+newFlags])`. Our @@split delegates to V8's native `RegExp.prototype[Symbol.split]`
+via `__regex_symbol_call`, so **V8 already runs SpeciesConstructor** — but on the
+value it sees as `rx.constructor`. The failure is that a **user constructor**
+(`class MyRegExp extends RegExp` or a `Symbol.species` getter returning a compiled
+ctor) is a wasm closure/struct that V8's `Construct` can't invoke.
+
+**Fix:** the compiled RegExp handed to V8 must expose `constructor` /
+`Symbol.species` such that native `SpeciesConstructor` resolves to a
+host-callable constructor bridge. When `rx[Symbol.species]` / `rx.constructor` is
+a compiled class, wrap it via the callable-ctor host bridge (`_wrapCallableForHost`
+/ the `@@species` handling at runtime.ts:4223, 4374, 4451-4454) so
+`Construct(C, [rx, flags])` invokes the compiled constructor and returns a value
+whose `exec`/`lastIndex` V8 can drive. The `-non-obj`/`-non-ctor` variants must
+`TypeError` — ensure the bridge preserves the constructor-ness check (a
+non-constructor species must throw, not silently pass). `splitter-proto-from-
+ctor-realm` needs the constructed splitter's `[[Prototype]]` to come from the
+ctor's realm — verify the bridge doesn't flatten it to the base %RegExp%.prototype.
+This is the deepest cluster (user constructor through native split); may itself
+split into a sub-slice.
+
+### Cluster 4 — well-known-symbol method as a first-class value (`name.js`)
+
+`RegExp.prototype[Symbol.replace]` accessed as a **value** (to read its `.name`),
+not called. Codegen resolves the member to the protocol-id `i32.const 8`
+(`_symbolIdToKeys` id 8 = `@@replace`, runtime.ts:4377), so
+`verifyProperty(<the i32 8>, "name", …)` fails — the i32 is not the method
+function object.
+
+**Fix (codegen, distinct from the runtime clusters):** when a well-known-symbol
+method (`RegExp.prototype[Symbol.replace]` etc.) is accessed as a **value** (not
+in call position), the codegen must yield a first-class **function object** for
+that method (with correct `.name` = `"[Symbol.replace]"`, `.length`), not the
+bare protocol-id i32. Grep the member-access lowering that emits `i32.const 8` for
+`obj[Symbol.replace]` (property-access.ts / the `_symbolIdToKeys` producer in
+codegen) and split call-position (keep the `__regex_symbol_call` fast path) from
+value-position (materialize a host function wrapper via a `__get_wks_method`-style
+import that returns the native `RegExp.prototype[Symbol.replace]` with its real
+`.name`). This is a separate feature ("well-known-symbol method as first-class
+value") and could be its own issue if it doesn't fall out cheaply — scope it last.
+
+### Ordering & risk
+
+- Cluster 1 (throwing-getter bridge) is the highest-value and most reusable —
+  do it first; it is genuinely senior (wasm-exn→host propagation).
+- Cluster 2 (object-arg ToPrimitive) reuses Slice 2's `_wrapForHost` discipline —
+  medium within this set.
+- Cluster 3 (SpeciesConstructor) is the deepest; may sub-split.
+- Cluster 4 is a codegen value-vs-call feature, orthogonal to 1-3.
+
+Each cluster: verify **no regression** in the delegating corpus
+(`String.prototype.{replace,replaceAll,split,match,matchAll,search}` +
+`RegExp.prototype.{Symbol.match,Symbol.matchAll,Symbol.search}` — 459 files
+dev-3051b already swept) and in `tests/issue-3051.test.ts`. Full `merge_group`
+per cluster; standalone floor green (host-lane-gated).


### PR DESCRIPTION
## Summary

Plan-only PR (no code changes). Adds `## Implementation Plan` sections to three
Fable-reserved, senior-depth conformance bugs so Fable can execute them
efficiently. Each spec builds on the root cause the dev already documented and
adds exact `file:line` touchpoints, the Wasm/runtime pattern, edge cases, and a
verification plan. Frontmatter tagged `feasibility: hard`, `reasoning_effort: max`,
`model: fable`.

## Issues spec'd

- **#3049** — Iterator.prototype helper proto-chain identity (host + standalone
  lanes; `env::__iterator` `__call_@@iterator` arm + `emitArrayIteratorPrototypeSingleton`).
- **#3050** — generator `.throw()` through `try/finally`|`try/catch` (extend the
  lazy native state machine; catch-routing + yield-in-finally-as-states; drop the
  two `fail()` guards).
- **#3045 Bug 2** — class-expression ctor/method enclosing-scope capture (route
  `var C = class{}` through `promoteAccessorCapturesToGlobals`; Bug 1 already landed).

## Risk

Docs-only. No source touched; skips the heavy conformance gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS