### PR TITLE
fix(#2726): clear mapped-arguments slot on delete arguments[i] (group e)

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -24,9 +24,10 @@ updated: 2026-07-05
 > (architect-spec first): `S11.4.1_A3.1` (`delete this.y === false` — top-level
 > `this` as the global object) and `S11.4.1_A3.3_T1` (`x = 1; delete x; x` →
 > ReferenceError — implicit-global creation + real deletion + unresolved read).
-> **(e)** mapped-arguments delete DEFERRED to #1726; **(f)**/**(g)** re-route to
-> their owning feature issues. This issue stays open (`status: ready`) for the 2
-> structural (b) tests — route to architect before further dispatch.
+> **(e)** mapped-arguments delete now **DONE** (2026-07-05, opus-2726: +1 test262
+> `11.4.1-4.a-17`, 0 regressions — see `## Resolution — group (e)`); **(f)**/**(g)**
+> re-route to their owning feature issues. This issue stays open (`status: ready`)
+> for the 2 structural (b) tests — route to architect before further dispatch.
 
 # #2726 — delete residual (non-throw) semantics
 
@@ -77,11 +78,12 @@ on its throw-semantics scope.
   (host `__delete_property` does not see the accessor's `configurable:false`
   flag). Runtime descriptor-storage fix in `src/runtime.ts`.
 
-### (e) Mapped-arguments delete (1)
+### (e) Mapped-arguments delete (1) — DONE (2026-07-05)
 `11.4.1-4.a-17.js`
 - `delete arguments[0]` in a mapped-arguments function: `=== true` and the slot
   reads `undefined` afterward. Routes through the `mappedArgsInfo` bookkeeping in
   `compileDeleteExpression` plus the element-delete on `arguments`.
+- **Resolved** — see `## Resolution — group (e)`.
 
 ### (f) preventExtensions interaction (1)
 `11.4.1-5-a-27-s.js`
@@ -186,6 +188,43 @@ Net **+1** test262. Flipped fail→pass: `11.4.1-4.a-8`. Guards verified unchang
 (`11.4.1-4.a-4`, `built-ins/undefined/S15.1.1.3_A3_T2`, `11.4.1-4.a-5/-13/-16`).
 Regression test: `tests/issue-2726-configurable-global-delete.test.ts` (+ the
 corrected JSON/Object assertion in `tests/issue-2726-sloppy-unresolvable-delete.test.ts`).
+
+## Resolution — group (e) (2026-07-05, opus-2726)
+
+**Scope.** `11.4.1-4.a-17.js` — `delete arguments[0]` in a mapped-arguments
+function returns `true` AND `arguments[0]` reads `undefined` afterward.
+
+**Root cause (e).** The mapped-`arguments[i]` delete arm in
+`compileDeleteExpression` (`src/codegen/typeof-delete.ts`) recorded the
+sever-bookkeeping (`unmappedIndices.add(argIndex)`) and then **fell through to
+the generic `__delete_property` path**. That path reports `true` for a mapped
+arguments object but never clears the **WasmGC-vec backing slot** — the vec's
+indices carry no sidecar descriptor — so a subsequent `arguments[i]` read still
+returned the original argument. (The arguments object is vec-backed:
+`arguments[i]` reads array field 1 of the vec directly; param writes
+forward-sync into it, slot writes reverse-sync into the param. §10.4.4.5.)
+
+**Fix (e).** In the mapped, configurable-index arm, after recording the sever,
+write the canonical `undefined` externref into the backing slot
+(`vec.data[argIndex]`, null-guarded, mirroring `emitMappedArgParamSync`'s slot
+write) and emit `i32.const 1` (`true`), **short-circuiting the generic path**.
+The already-present `unmappedIndices` entry stops a later parameter write from
+resurrecting the slot (§10.4.4.2). The non-configurable arm (returns `false`) is
+untouched. Front-end only — no new host import; standalone and host lanes agree.
+`src/codegen/typeof-delete.ts`.
+
+### Test Results — group (e) (host/gc lane, authoritative `runTest262File`)
+
+| cluster | baseline → fix |
+|---|---|
+| `language/expressions/delete` (69 files) | 64 → **65** pass, **0 regressions** |
+| `language/arguments-object/mapped` (43 files) | 39 → 39 (no change; 4 pre-existing defineProperty fails unchanged) |
+
+Net **+1** test262. Flipped fail→pass: `11.4.1-4.a-17`. Remaining `delete`-dir
+fails are all out-of-scope: `S11.4.1_A3.1` + `S11.4.1_A3.3_T1` (structural (b),
+architect-first), `11.4.1-5-a-27-s` (f, preventExtensions), `S8.12.7_A2_T2`
+(g, prototype-chain read). Regression test:
+`tests/issue-2726-mapped-args-delete.test.ts`.
 
 ## Resolution — groups (c) + (d) (2026-06-27, dev2)
 

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -11,7 +11,12 @@ import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.j
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { isStrictContext } from "./expressions/assignment.js";
 import { EVAL_SOURCE_FILENAME } from "./expressions/eval-inline.js";
-import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./expressions/late-imports.js";
+import {
+  emitUndefined,
+  ensureLateImport,
+  flushLateImportShifts,
+  shiftLateImportIndices,
+} from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
 import { addUnionImports, parseRegExpLiteral, resolveWasmType } from "./index.js";
 import { emitExternrefDestructureGuard } from "./destructuring-params.js";
@@ -365,7 +370,44 @@ export function compileDeleteExpression(
         fctx.body.push({ op: "i32.const", value: 0 });
         return { kind: "i32" };
       }
-      (fctx.mappedArgsInfo.unmappedIndices ??= new Set<number>()).add(argIndex);
+      // (#2726 group (e)) A *successful* `delete arguments[i]` on a mapped,
+      // configurable index (§10.4.4.5 → OrdinaryDelete) does two things:
+      //   1. severs the param↔arguments map so later parameter writes no longer
+      //      mirror into `arguments[i]` (`unmappedIndices`), and
+      //   2. actually removes the slot — a subsequent `arguments[i]` read
+      //      observes `undefined`.
+      // The generic `__delete_property` path below reports `true` but never
+      // clears the WasmGC-vec-backed slot (indices carry no sidecar
+      // descriptor), so the read still returns the original argument. Clear the
+      // backing slot here (write the canonical `undefined` externref, mirroring
+      // `emitMappedArgParamSync`'s slot write) and report `true`,
+      // short-circuiting the generic path.
+      const info = fctx.mappedArgsInfo;
+      (info.unmappedIndices ??= new Set<number>()).add(argIndex);
+      // val = undefined (canonical externref), stashed for the null-guarded slot
+      // write below.
+      emitUndefined(ctx, fctx);
+      const undefLocal = allocLocal(fctx, `__del_arg_undef_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: undefLocal });
+      // arguments vec slot write: vec.data[argIndex] = undefined (null-guarded;
+      // the slot exists since argIndex < paramCount, so no grow is needed).
+      fctx.body.push({ op: "local.get", index: info.argsLocalIdx });
+      fctx.body.push({ op: "ref.is_null" });
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [] as Instr[],
+        else: [
+          { op: "local.get", index: info.argsLocalIdx } as Instr,
+          { op: "struct.get", typeIdx: info.vecTypeIdx, fieldIdx: 1 } as Instr,
+          { op: "i32.const", value: argIndex } as Instr,
+          { op: "local.get", index: undefLocal } as Instr,
+          { op: "array.set", typeIdx: info.arrTypeIdx } as Instr,
+        ],
+      });
+      // OrdinaryDelete succeeded → `delete` evaluates to `true`.
+      fctx.body.push({ op: "i32.const", value: 1 });
+      return { kind: "i32" };
     }
   }
 

--- a/tests/issue-2726-mapped-args-delete.test.ts
+++ b/tests/issue-2726-mapped-args-delete.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2726 group (e) — `delete arguments[i]` on a mapped, configurable index.
+//
+// ECMA-262 §10.4.4.5 (mapped-arguments [[Delete]]) → OrdinaryDelete: a
+// SUCCESSFUL `delete arguments[i]` of a configurable mapped index both
+//   (1) severs the param↔arguments map (later parameter writes no longer
+//       mirror into `arguments[i]`), and
+//   (2) removes the slot — a subsequent `arguments[i]` read observes
+//       `undefined`.
+//
+// Previously only (1) was implemented (the `unmappedIndices` bookkeeping): the
+// delete returned `true` (via the generic `__delete_property` path) but the
+// WasmGC-vec-backed slot was never cleared, so `arguments[i]` still read the
+// original argument. This flips test262 `11.4.1-4.a-17` fail→pass.
+//
+// Mapped arguments require a SIMPLE parameter list in SLOPPY mode; the synthetic
+// `export function test()` wrapper makes TypeScript flag the source as a module
+// (strict), so `inferModuleStrictArguments: false` restores the script-goal
+// sloppy strictness the test262 harness uses for `noStrict` tests.
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source, { inferModuleStrictArguments: false });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+describe("#2726 (e) — delete arguments[i] on a mapped configurable index", () => {
+  // test262 11.4.1-4.a-17: `delete arguments[0]` returns true AND the slot then
+  // reads `undefined`.
+  it("returns true and the slot reads undefined afterward", async () => {
+    const src = `
+      export function test(): number {
+        function foo(a, b) {
+          var d = delete arguments[0];
+          if (d !== true) return 10;
+          if (arguments[0] !== undefined) return 20;
+          return 1;
+        }
+        return foo(1, 2);
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // A delete of one index must not disturb the sibling mapped slots.
+  it("leaves other mapped slots intact", async () => {
+    const src = `
+      export function test(): number {
+        function foo(a, b) {
+          delete arguments[0];
+          if (arguments[1] !== 2) return 10;
+          return 1;
+        }
+        return foo(1, 2);
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // After a successful delete the map is severed: a later parameter write must
+  // NOT resurrect the deleted arguments slot (§10.4.4.2).
+  it("severs the param->arguments map so a later param write does not resurrect the slot", async () => {
+    const src = `
+      export function test(): number {
+        function foo(a, b) {
+          delete arguments[0];
+          a = 99;
+          if (arguments[0] !== undefined) return 10;
+          return 1;
+        }
+        return foo(1, 2);
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

#2726 group **(e)** — `delete arguments[i]` on a mapped, configurable index.

A successful `delete arguments[i]` on a mapped index (§10.4.4.5 → OrdinaryDelete) must both **sever** the param↔arguments map AND **remove the slot**, so a later `arguments[i]` read observes `undefined`. The mapped-delete arm only recorded the sever (`unmappedIndices`) and fell through to the generic `__delete_property` path — which reports `true` for the vec-backed arguments object but never clears the backing slot, so the read still returned the original argument.

**Fix:** in the mapped configurable-index arm, write the canonical `undefined` externref into the backing vec slot (null-guarded, mirroring `emitMappedArgParamSync`'s slot write) and emit `true`, short-circuiting the generic path. Front-end only — no new host import; host and standalone lanes agree. The non-configurable arm (returns `false`) is untouched.

## test262 (authoritative `runTest262File`, host/gc lane)

| cluster | baseline → fix |
|---|---|
| `language/expressions/delete` (69) | 64 → **65** pass, **0 regressions** |
| `language/arguments-object/mapped` (43) | 39 → 39 (4 pre-existing defineProperty fails unchanged) |

Net **+1** (`11.4.1-4.a-17` fail→pass). Default lane, floor-visible.

## Banked (issue stays `ready`)
- Group **(b)** 2 structural tests (`S11.4.1_A3.1`, `S11.4.1_A3.3_T1`) — need the global-object model; architect-first.
- (f) preventExtensions / (g) prototype-read — re-routed to owning feature issues.

## Tests
- `tests/issue-2726-mapped-args-delete.test.ts` (3 cases: returns-true+slot-undefined, siblings intact, sever-not-resurrected). tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8