### PR TITLE
docs(jsr): module + symbol docs — 0.60.1 (JSR score cheap wins)

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.60.0"
+    "@loopdive/js2": "0.60.1"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -21,6 +21,11 @@ function getBundledLibFiles(): Record<string, string> | undefined {
   return files && typeof files === "object" ? (files as Record<string, string>) : undefined;
 }
 
+/**
+ * Pre-seed the TypeScript lib files (e.g. `lib.d.ts`) the checker uses, so
+ * environments without filesystem access can still type-check. Merges into any
+ * previously registered lib files.
+ */
 export function preloadLibFiles(files: Record<string, string>): void {
   const globalObject = globalThis as TsLibGlobal;
   globalObject.__js2wasmTsLibFiles = {

--- a/src/emit/canonical-recgroup.ts
+++ b/src/emit/canonical-recgroup.ts
@@ -216,8 +216,11 @@ export function canonicalHashOfTypeGroup(group: readonly FlatTypeDef[], absIndic
 
 /** A member of the extracted runtime group: its name + absolute index + def. */
 export interface RuntimeGroupMember {
+  /** Type name within the runtime rec-group. */
   name: string;
+  /** Absolute type index of the member in the module's type table. */
   absIndex: number;
+  /** Flattened structural definition of the member type. */
   def: FlatTypeDef;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,41 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * `@loopdive/js2` — an ahead-of-time compiler from JavaScript and TypeScript to
+ * WebAssembly GC.
+ *
+ * This is the package's main entry point. Use {@link compile} to turn source
+ * text into a {@link CompileResult} (a Wasm binary plus a `.d.ts`, host import
+ * helpers, and diagnostics), or the higher-level {@link compileFiles} /
+ * {@link compileProject} for multi-file and on-disk projects. The full option
+ * surface — target backend (`gc` / `linear` / `wasi` / `standalone`), native
+ * strings, wasm-opt optimization, WIT generation, source maps, and more — is
+ * documented on {@link CompileOptions}.
+ *
+ * @example
+ * ```ts
+ * import { compile } from "@loopdive/js2";
+ *
+ * const result = await compile(`
+ *   export function add(a: number, b: number): number {
+ *     return a + b;
+ *   }
+ * `);
+ * const { instance } = await WebAssembly.instantiate(result.binary, result.importObject);
+ * console.log((instance.exports.add as (a: number, b: number) => number)(2, 3)); // 5
+ * ```
+ *
+ * @module
+ */
+
+/**
+ * A single host capability an emitted module may need from its import object.
+ *
+ * The compiler analyzes the source and, for every JS-host operation it cannot
+ * lower to pure Wasm (string ops, `console.log`, `Math.*`, boxing/unboxing,
+ * `typeof`, extern property get/set, timers, Node builtins, the JSX runtime,
+ * …), records an `ImportIntent`. The runtime ({@link buildImports}) reads these
+ * to synthesize the matching host functions. Discriminated on the `type` field.
+ */
 export type ImportIntent =
   | { type: "string_literal"; value: string }
   | { type: "math"; method: string }
@@ -52,16 +89,28 @@ export type ImportIntent =
       specifier: string;
     };
 
+/**
+ * Describes one import the compiled module declares, so the host runtime can
+ * build the matching entry in the Wasm import object.
+ */
 export interface ImportDescriptor {
+  /** Wasm import namespace the entry lives in. */
   module: "env" | "wasm:js-string" | "string_constants";
+  /** Import field name within {@link ImportDescriptor.module}. */
   name: string;
+  /** Whether the import is a function or a global. */
   kind: "func" | "global";
+  /** The host capability this import provides (see {@link ImportIntent}). */
   intent: ImportIntent;
 }
 
 export type { ExportSignature, TypedArrayKind } from "./ir/types.js";
 import type { ExportSignature } from "./ir/types.js";
 
+/**
+ * The output of a `compile*` call: the compiled Wasm binary plus the artifacts
+ * and metadata needed to instantiate, type, and debug it.
+ */
 export interface CompileResult {
   /** Wasm binary with GC proposal */
   binary: Uint8Array;
@@ -163,10 +212,15 @@ export interface CompileResult {
   irFirstSkipped?: readonly string[];
 }
 
+/** A single compile diagnostic (error or warning) with its source position. */
 export interface CompileError {
+  /** Human-readable diagnostic message. */
   message: string;
+  /** 1-based line number in the source. */
   line: number;
+  /** 1-based column number in the source. */
   column: number;
+  /** Whether the diagnostic is fatal (`"error"`) or advisory (`"warning"`). */
   severity: "error" | "warning";
   /** TS diagnostic code (if from TypeScript diagnostics) */
   code?: number;
@@ -180,14 +234,27 @@ export interface CompileError {
   file?: string;
 }
 
+/** Restricts DOM access of compiled code to a subtree (safe-mode containment). */
 export interface DomContainmentOptions {
+  /** Root element or shadow root that scopes all DOM access. */
   domRoot: Element | ShadowRoot;
 }
 
+/**
+ * Policy controlling which host imports a module is allowed to use
+ * (see {@link checkPolicy}).
+ */
 export interface ImportPolicy {
+  /** Set of import names that are disallowed. */
   blocked: Set<string>;
 }
 
+/**
+ * Options controlling a compile: target backend, string representation,
+ * optimization, diagnostics, host/platform surface, and output artifacts.
+ * Every field is optional; the defaults produce a browser-oriented WasmGC
+ * module.
+ */
 export interface CompileOptions {
   /** Emit WAT debug output (default: true) */
   emitWat?: boolean;

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -122,8 +122,11 @@ export interface WasmModule {
 /** TS-level kind hint for a single export parameter or result (#1700). */
 export type TypedArrayKind = "uint8array" | "typed-array" | "other";
 
+/** TS-level TypedArray classification of one export's params and result (#1700). */
 export interface ExportSignature {
+  /** Per-parameter TypedArray kind, positionally. */
   params: TypedArrayKind[];
+  /** TypedArray kind of the return value. */
   result: TypedArrayKind;
 }
 

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -7,6 +7,12 @@
  * 2. A system `wasm-opt` binary on PATH
  *
  * If neither is available, returns the original binary unchanged and emits a warning.
+ *
+ * This is the `/optimize` entry point of `@loopdive/js2`: call
+ * {@link optimizeBinaryAsync} with a compiled Wasm binary and
+ * {@link OptimizeOptions} to get an {@link OptimizeResult}.
+ *
+ * @module
  */
 
 // Dynamic imports to avoid vite bundling node-only modules for the browser.
@@ -108,6 +114,7 @@ function getNodeImportsSync() {
   }
 }
 
+/** Settings for {@link optimizeBinaryAsync} (Binaryen wasm-opt configuration). */
 export interface OptimizeOptions {
   /** Optimization level: 1 (-O1), 2 (-O2), 3 (-O3), 4 (-O4). Default: 3 */
   level?: 1 | 2 | 3 | 4;
@@ -119,7 +126,9 @@ export interface OptimizeOptions {
   exceptionHandling?: boolean;
 }
 
+/** Result of {@link optimizeBinaryAsync}. */
 export interface OptimizeResult {
+  /** The optimized binary, or the original bytes if optimization was skipped. */
   binary: Uint8Array;
   /** true if optimization was applied */
   optimized: boolean;

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -26,6 +26,12 @@ export class ModuleResolver {
   private extensions: string[];
   private resolveCache = new Map<string, string | null>();
 
+  /**
+   * Create a resolver rooted at a directory.
+   *
+   * @param rootDir - Directory that bare and relative specifiers resolve against.
+   * @param options - Compile options; reads `externals` and `resolve.*`.
+   */
   constructor(
     private rootDir: string,
     options?: CompileOptions,
@@ -227,6 +233,7 @@ export class ModuleResolver {
     return null;
   }
 
+  /** True if `p` exists and is a directory. */
   private tryStatDir(p: string): boolean {
     const fs = getFs();
     if (!fs) return false;
@@ -237,6 +244,7 @@ export class ModuleResolver {
     }
   }
 
+  /** True if `p` exists and is a file. */
   private tryStatFile(p: string): boolean {
     const fs = getFs();
     if (!fs) return false;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,19 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Host runtime and instantiation helpers for `@loopdive/js2` (the `/runtime`
+ * entry point).
+ *
+ * In the default JS-host (WasmGC) target a compiled binary needs an import
+ * object wiring up strings, number boxing, and other host capabilities. This
+ * module builds those imports ({@link buildImports},
+ * {@link buildStringConstants}, {@link buildWasiPolyfill}) and offers one-call
+ * instantiation helpers ({@link instantiateWasm},
+ * {@link instantiateWasmStreaming}, {@link compileAndInstantiate}), plus
+ * {@link wrapExports} for marshalling `Uint8Array` (and other TypedArray)
+ * arguments and returns across the JS↔Wasm boundary.
+ *
+ * @module
+ */
 import { compileSource } from "./compiler.js";
 import type { ImportDescriptor, ImportIntent, ImportPolicy } from "./index.js";
 import { createEvalShim, createNewFunctionShim } from "./runtime-eval.js";
@@ -14567,7 +14582,9 @@ export function buildImports(
  * (b) wrap the returned plain `Array<number>` back into a `Uint8Array`.
  */
 export interface WrapExportsSignature {
+  /** Per-parameter TypedArray kind, positionally. */
   params: ("uint8array" | "typed-array" | "other")[];
+  /** TypedArray kind of the return value. */
   result: "uint8array" | "typed-array" | "other";
 }
 
@@ -14622,6 +14639,14 @@ function marshalTypedArrayArgs(
   return out;
 }
 
+/**
+ * Wrap a Wasm instance's exports so `Uint8Array` (and other TypedArray)
+ * arguments and return values marshal correctly across the JS↔Wasm boundary.
+ *
+ * Pass the per-export type metadata from {@link CompileResult.exportSignatures}
+ * as `options.signatures`; without it the wrapper is a passthrough. Returns a
+ * new exports object; the original is left untouched.
+ */
 export function wrapExports(
   rawExports: WebAssembly.Exports,
   options?: {

--- a/src/wit-generator.ts
+++ b/src/wit-generator.ts
@@ -22,6 +22,7 @@ import { ts } from "./ts-api.js";
 import type { TypedAST } from "./checker/index.js";
 import type { Import, TypeDef, ValType } from "./ir/types.js";
 
+/** Options for {@link generateWit} — controls the generated WIT world's naming. */
 export interface WitGeneratorOptions {
   /** Package name for the WIT world (default: derived from the source filename) */
   packageName?: string;


### PR DESCRIPTION
## What

Docs-only patch release **0.60.1** raising the JSR package score's **cheap wins** for `@loopdive/js2` (currently 52%). No slow-types work (that's the separate expensive lever).

### JSR criteria addressed
- **Module docs in all entrypoints: 0/1 → 1/1** — added `@module` JSDoc to all three JSR entrypoints (`src/index.ts`, `src/runtime.ts`, `src/optimize.ts`), with a usage `@example` on the main entry.
- **Docs for most symbols: 3/5 (61%) → 5/5** — documented every remaining undocumented exported symbol + interface member across the reachable public API. `deno doc --lint` missing-jsdoc: **13 → 0**.

Symbols documented include: `ImportIntent`, `ImportDescriptor`, `CompileResult`/`CompileError`/`CompileOptions` (interface-level), `DomContainmentOptions`, `ImportPolicy`, `OptimizeOptions`/`OptimizeResult`, `wrapExports`, `WrapExportsSignature`, `WitGeneratorOptions`, `ExportSignature`, `RuntimeGroupMember`, `preloadLibFiles`, and the `ModuleResolver` constructor.

### Not in scope
`no slow types (0/5)` and `provenance (0/1)` are untouched here — slow-types requires annotating the public API's inferred types (a real code change affecting the npm package too), and provenance should attest on this normal tagged release.

## Verification
- `deno doc --lint … missing-jsdoc: 0`.
- Diff is **docs-only**: no non-comment source lines changed (verified) — no types/signatures/exports/runtime behavior touched.
- Lockstep bump to **0.60.1**: root + `packages/js2wasm` `package.json`, `jsr.json`, and the proxy's `@loopdive/js2` dependency; annotated `v0.60.1` tag cut (pushed after merge).

## Release
After merge, push `v0.60.1` to trigger publish (npm canonical + proxy + JSR). The proxy now has its trusted publisher, so it publishes automatically this time; the JSR job re-publishes with the improved docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)