### PR TITLE
fix(#3061): compute ArrayBuffer.byteLength/byteOffset natively in JS-host mode

### DIFF
--- a/plan/issues/3061-host-buffer-bytelength.md
+++ b/plan/issues/3061-host-buffer-bytelength.md
@@ -1,0 +1,76 @@
+---
+id: 3061
+title: "codegen: ArrayBuffer.byteLength / byteOffset return NaN in JS-host mode (native accessor gated to standalone only)"
+status: done
+completed: 2026-07-06
+sprint: current
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: arraybuffer, typed-arrays
+goal: spec-completeness
+related: [2159, 2595, 1359]
+test262_bucket: arraybuffer-bytelength-host
+test262_count: 18
+assignee: ttraenkler/dev-cycleB
+origin: "2026-07-06 harvest (dev-cycleB). origin/main; default (JS-host) lane."
+---
+
+# #3061 — `ArrayBuffer.byteLength` / `byteOffset` NaN in JS-host mode
+
+## Problem
+
+`ab.byteLength` and `ab.byteOffset` on an ArrayBuffer return **NaN** in JS-host
+(`gc`) mode. The native accessor computation in `property-access.ts` (read the
+`i32_byte` byte-vec's field-0) was gated to `(ctx.wasi || ctx.standalone ||
+ctx.strictNoHostImports)`. In host mode the read falls through to the generic
+`__extern_get(struct, "byteLength")`, which returns `undefined` for the opaque
+WasmGC byte-vec struct (byteLength/byteOffset are not real struct fields and no
+`__sget_byteLength` export exists) → `NaN`.
+
+```ts
+export function test(): number {
+  const b = new ArrayBuffer(8);
+  return b.byteLength; // was NaN, spec wants 8
+}
+```
+
+Verified at the WAT level: `b.byteLength` lowered to `__extern_get(b,
+"byteLength")`, and calling that host helper directly on a compiled ArrayBuffer
+struct returns `undefined`.
+
+## Fix
+
+Enable the existing native accessor arm for **plain ArrayBuffer** in JS-host
+mode too. The `i32_byte` backing (field-0 = byte count, element size 1) is
+**identical** across host and standalone, so the ArrayBuffer arm is
+representation-safe in both. Scope kept deliberately narrow:
+
+- **ArrayBuffer** — fixed in host mode (byteLength = field-0, byteOffset = 0).
+- **SharedArrayBuffer** — host-mode backing differs (a bare `i32_byte`
+  `ref.test` misses → a wrong `0`), so SAB stays gated to no-host, falling
+  through to the generic reader exactly as before (no change).
+- **TypedArray / DataView** — element-scaled / windowed backings diverge in host
+  mode; left standalone-only (follow-up: DataView host windowing + TypedArray
+  host byteLength; `any`-typed buffer receivers also still fall through since
+  `recvName` can't be resolved — a pre-existing shared limitation).
+
+Single-file change: `src/codegen/property-access.ts` — relax the byteLength/
+byteOffset outer gate with a `hostBufferByteAttr` predicate and gate
+`isBuffer`/`isTypedArr` on `noJsHost` so only the ArrayBuffer arm runs in host
+mode.
+
+## Acceptance criteria
+
+1. `new ArrayBuffer(n).byteLength === n`, `.byteOffset === 0` in host mode. ✓
+2. `ArrayBuffer.prototype.slice` result reports correct byteLength. ✓
+3. No regression for TypedArray/DataView/SharedArrayBuffer or plain objects
+   with an own `byteLength` property. ✓
+4. Regression test: `tests/issue-3061-host-buffer-bytelength.test.ts` (7 cases). ✓
+
+Flips the ArrayBuffer byteLength-value cluster (`built-ins/ArrayBuffer/*` —
+`return-bytelength.js`, `zero-length.js`, several `slice/*` result.byteLength
+checks) plus byteLength-value assertions spread across other ArrayBuffer tests.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -3794,8 +3794,19 @@ export function compilePropertyAccess(
   // is always 0 for our non-offset views (a fresh backing store per view), which
   // already reads correctly today — handled here only for the externref-receiver
   // case so it doesn't leak `__extern_get`.
+  // (#3061) `.byteLength` / `.byteOffset` on an ArrayBuffer / SharedArrayBuffer
+  // are ALSO computed natively in JS-host mode. The host `__extern_get` fallback
+  // returns `undefined` for these accessors on the opaque WasmGC byte-vec struct
+  // (they are not real struct fields and no `__sget_byteLength` export exists), so
+  // `ab.byteLength` / `ab.byteOffset` read back NaN (~45 test262 fails). The
+  // `i32_byte` backing (field-0 = byte count, element size 1) is IDENTICAL across
+  // host and standalone, so the `isBuffer` arm below is representation-safe in both
+  // modes. TypedArray / DataView stay standalone-only here (their backings are
+  // element-scaled / windowed and diverge in host mode — see #3060 follow-up).
+  const hostBufferByteAttr =
+    !noJsHost(ctx) && !ctx.strictNoHostImports && (propName === "byteLength" || propName === "byteOffset");
   if (
-    (ctx.wasi || ctx.standalone || ctx.strictNoHostImports) &&
+    (ctx.wasi || ctx.standalone || ctx.strictNoHostImports || hostBufferByteAttr) &&
     (propName === "byteLength" || propName === "byteOffset" || propName === "BYTES_PER_ELEMENT")
   ) {
     const recvName =
@@ -3803,8 +3814,14 @@ export function compilePropertyAccess(
       (ts.isNewExpression(expr.expression) && ts.isIdentifier(expr.expression.expression)
         ? expr.expression.expression.text
         : undefined);
-    const isBuffer = recvName === "ArrayBuffer" || recvName === "SharedArrayBuffer";
-    const isTypedArr = recvName !== undefined && TYPED_ARRAY_NAMES.has(recvName);
+    // (#3061) In JS-host mode only the plain ArrayBuffer arm is
+    // representation-safe (`i32_byte`, field-0 = byte count, identical to
+    // standalone). SharedArrayBuffer's host-mode backing differs (a bare
+    // `i32_byte` `ref.test` misses → a wrong `0`), so keep SAB — like
+    // TypedArray — gated to no-host; both fall through to the generic reader in
+    // host mode exactly as before.
+    const isBuffer = recvName === "ArrayBuffer" || (recvName === "SharedArrayBuffer" && noJsHost(ctx));
+    const isTypedArr = recvName !== undefined && TYPED_ARRAY_NAMES.has(recvName) && noJsHost(ctx);
     const isDataView = recvName === "DataView";
     // (#2159/#38) DataView `byteOffset` / `byteLength` honour the constructor's
     // window. The receiver is either a `$__dv_window` wrapper (windowed view) or

--- a/tests/issue-3061-host-buffer-bytelength.test.ts
+++ b/tests/issue-3061-host-buffer-bytelength.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3061 — `.byteLength` / `.byteOffset` on an ArrayBuffer returned NaN in
+// JS-host mode: the native accessor computation was gated to standalone/WASI
+// only, and the host `__extern_get` fallback returns `undefined` for these on
+// the opaque WasmGC byte-vec struct. Enable the representation-safe ArrayBuffer
+// arm (`i32_byte`, field-0 = byte count) in host mode too.
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as unknown as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!();
+}
+
+describe("#3061 host-mode ArrayBuffer byteLength/byteOffset", () => {
+  it("new ArrayBuffer(n).byteLength returns n", async () => {
+    expect(await run(`export function test(): number { const b = new ArrayBuffer(8); return b.byteLength; }`)).toBe(8);
+  });
+
+  it("new ArrayBuffer(42).byteLength returns 42", async () => {
+    expect(await run(`export function test(): number { const b = new ArrayBuffer(42); return b.byteLength; }`)).toBe(
+      42,
+    );
+  });
+
+  it("new ArrayBuffer(0).byteLength returns 0", async () => {
+    expect(await run(`export function test(): number { const b = new ArrayBuffer(0); return b.byteLength; }`)).toBe(0);
+  });
+
+  it("new ArrayBuffer(n).byteOffset returns 0", async () => {
+    expect(await run(`export function test(): number { const b = new ArrayBuffer(8); return b.byteOffset; }`)).toBe(0);
+  });
+
+  it("ArrayBuffer.prototype.slice result has correct byteLength", async () => {
+    expect(
+      await run(
+        `export function test(): number { const b = new ArrayBuffer(4); const r = b.slice(0, 2); return r.byteLength; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("byteLength used in a comparison (test262 idiom) is exact", async () => {
+    expect(
+      await run(
+        `export function test(): number { const b = new ArrayBuffer(16); if (b.byteLength === 16) { return 1; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("does not intercept a plain object's own byteLength property", async () => {
+    expect(await run(`export function test(): number { const o: any = { byteLength: 5 }; return o.byteLength; }`)).toBe(
+      5,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`ab.byteLength` / `ab.byteOffset` returned **NaN** in JS-host (`gc`) mode. The native accessor arm in `property-access.ts` (reads the `i32_byte` byte-vec's field-0) was gated to `(ctx.wasi || ctx.standalone || ctx.strictNoHostImports)`, so host mode fell through to the generic `__extern_get(struct, "byteLength")` — which returns `undefined` for the opaque WasmGC byte-vec struct → NaN. Verified at the WAT level and by calling `__extern_get` directly on a compiled ArrayBuffer struct.

## Fix

Enable the existing native arm for **plain ArrayBuffer** in host mode too — its `i32_byte` backing (field-0 = byte count, element size 1) is **identical** across host and standalone, so it's representation-safe in both. Deliberately narrow:

- **ArrayBuffer** → fixed (byteLength = field-0, byteOffset = 0), incl. `slice()` results.
- **SharedArrayBuffer** → host-mode backing differs (bare `i32_byte` `ref.test` misses → wrong `0`); kept gated to no-host, falls through to the generic reader as before — **no change**.
- **TypedArray / DataView** → element-scaled / windowed backings diverge in host mode; left standalone-only (documented follow-up). `any`-typed buffer receivers also still fall through (pre-existing shared limitation — `recvName` unresolvable).

Single source change (`property-access.ts`, +20/-3): a `hostBufferByteAttr` predicate on the outer gate + `noJsHost` guards on `isBuffer`/`isTypedArr` so only the ArrayBuffer arm runs in host mode.

## Testing

- New `tests/issue-3061-host-buffer-bytelength.test.ts` — 7 cases (byteLength/byteOffset/slice-result/comparison-idiom/plain-object-passthrough), all green.
- Scoped typed-array/dataview/array suites: **62/62 green**, no regression.
- The 6 pre-existing `arraybuffer-dataview.test.ts` failures (hand-rolled env missing `string_constants`) fail identically on base — unrelated.

Flips the ArrayBuffer byteLength-value cluster (`return-bytelength.js`, `zero-length.js`, several `slice/*` result.byteLength checks) plus byteLength-value assertions spread across other ArrayBuffer tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS