### PR TITLE
fix(#3063): implement legacy global escape() / unescape() in JS-host mode

### DIFF
--- a/plan/issues/3063-escape-unescape-host.md
+++ b/plan/issues/3063-escape-unescape-host.md
@@ -1,0 +1,73 @@
+---
+id: 3063
+title: "codegen: implement legacy global escape() / unescape() (§B.2.1/.2) — JS-host lowering"
+status: done
+completed: 2026-07-06
+sprint: current
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: low
+task_type: feature
+area: codegen
+language_feature: annexb, string-builtins
+goal: spec-completeness
+related: [1436]
+test262_bucket: annexb-escape-unescape
+test262_count: 33
+assignee: ttraenkler/dev-cycleC
+origin: "2026-07-06 harvest (dev-cycleC). origin/main; default (JS-host) lane. AnnexB self-contained builtin."
+---
+
+# #3063 — legacy `escape` / `unescape` return `undefined` (unimplemented)
+
+## Problem
+
+The legacy global functions `escape(string)` (§B.2.1) and `unescape(string)`
+(§B.2.2) resolve as identifiers (they exist in the TS lib) but have **no
+codegen lowering**, so every call silently returns `undefined`/`null`:
+
+```ts
+export function test(): string {
+  return escape("a b");   // spec: "a%20b"; was null
+}
+```
+
+~33 `annexB/built-ins/{escape,unescape}/*` test262 files fail on this
+(`assertion_fail` — comparing `null` to the expected escaped string), plus
+`escape`/`unescape` value assertions scattered elsewhere.
+
+## Fix
+
+Mirror the existing `encodeURI` / `encodeURIComponent` machinery (which already
+does host-import + call-site ToString-coercion, and has a pure-Wasm standalone
+lowering in `uri-encoding-native.ts`):
+
+1. **Collection** (`declarations.ts`, `collectParseImports`): recognise the
+   direct-call callees `escape` / `unescape` → `state.escapeNeeded`.
+2. **Emit** (`declarations.ts`): JS-host mode only — register an
+   `(externref) -> externref` `env.escape` / `env.unescape` host import (skipped
+   if a user already declared the name). The generic call-site routing
+   (`calls.ts` `funcMap.get(name)`) dispatches it and ToString-coerces the arg,
+   exactly like the URI globals — no `calls.ts` change needed.
+3. **Runtime host impl** (`runtime.ts`): `(s) => escape(s)` / `(s) => unescape(s)`
+   — direct pass-through so ToString throws TypeError on a Symbol arg per spec
+   step 1 (matches the URI globals' `#1436` discipline).
+
+Gated `!ctx.standalone && !ctx.wasi`, so the host-free lanes emit **no**
+unsatisfiable `env::escape` import (they keep the pre-existing behaviour). A
+pure-Wasm standalone `escape`/`unescape` (mirroring `uri-encoding-native.ts`) is
+a documented follow-up.
+
+## Acceptance criteria
+
+1. `escape("a b")` → `"a%20b"`; `escape("Ā")` → `"%u0100"` (host mode).
+2. `unescape("%41")` → `"A"`; `unescape("%u0041")` → `"A"`;
+   `unescape("%zz")` → `"%zz"` (non-hex left literal).
+3. Round-trip `unescape(escape(s)) === s` for representative strings.
+4. No regression for `encodeURI`/`encodeURIComponent` or a user-declared
+   `escape`/`unescape`.
+5. Regression test: `tests/issue-3063-escape-unescape-host.test.ts`.
+
+Flips `annexB/built-ins/escape/*` and `annexB/built-ins/unescape/*` value tests
+(`two.js`, `four.js`, `escape-below.js`, `argument_types.js`, …).

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -111,6 +111,8 @@ interface UnifiedCollectorState {
   dateParseHostNeeded: boolean;
   // -- collectURIImports --
   uriNeeded: Set<string>;
+  // -- collectEscapeImports (#3063) — legacy global escape/unescape (§B.2.1/.2) --
+  escapeNeeded: Set<string>;
   // -- collectStringStaticImports --
   needsFromCharCode: boolean;
   needsFromCodePoint: boolean;
@@ -214,6 +216,7 @@ export function createUnifiedCollectorState(sourceFile: ts.SourceFile): UnifiedC
     parseNeeded: new Set(),
     dateParseHostNeeded: false,
     uriNeeded: new Set(),
+    escapeNeeded: new Set(),
     needsFromCharCode: false,
     needsFromCodePoint: false,
     promiseNeeded: new Set(),
@@ -684,6 +687,14 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       name === "encodeURIComponent"
     ) {
       state.uriNeeded.add(name);
+    }
+    // (#3063) Legacy `escape` / `unescape` (§B.2.1 / §B.2.2) — pure string
+    // transforms. JS-host mode routes to the native JS globals via an env host
+    // import (registered in the emit phase, gated to host mode so standalone
+    // never leaks an unsatisfiable import). A pure-Wasm standalone lowering is a
+    // follow-up (mirrors the uri-encoding-native.ts machinery).
+    if (name === "escape" || name === "unescape") {
+      state.escapeNeeded.add(name);
     }
     if (name === "Number") {
       state.parseNeeded.add("parseFloat");
@@ -1479,6 +1490,22 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
     }
     if (needsNativeDecode) {
       emitNativeUriDecode(ctx);
+    }
+  }
+
+  // (#3063) Legacy `escape` / `unescape` (§B.2.1 / §B.2.2). JS-host mode only:
+  // register an `(externref) -> externref` env host import that delegates to the
+  // native JS `escape` / `unescape` (runtime.ts). The generic call-site routing
+  // (calls.ts `funcMap.get(name)`) then dispatches it and ToString-coerces the
+  // argument, exactly like the URI globals above. Standalone / WASI are left
+  // unhandled here (no native lowering yet — a follow-up), so no unsatisfiable
+  // `env::escape` import is emitted in the host-free lanes. A user-declared
+  // `escape` / `unescape` already sits in funcMap → the `has` guard skips it.
+  if (!ctx.standalone && !ctx.wasi) {
+    for (const name of state.escapeNeeded) {
+      if (ctx.funcMap.has(name)) continue;
+      const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
+      addImport(ctx, "env", name, { kind: "func", typeIdx });
     }
   }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13202,6 +13202,11 @@ assert._isSameValue = isSameValue;
       if (name === "decodeURIComponent") return (s: any) => decodeURIComponent(s as any);
       if (name === "encodeURI") return (s: any) => encodeURI(s as any);
       if (name === "encodeURIComponent") return (s: any) => encodeURIComponent(s as any);
+      // (#3063) Legacy `escape` / `unescape` (§B.2.1 / §B.2.2) — pure string
+      // transforms. Like the URI globals, direct pass-through so the native
+      // ToString step throws TypeError on Symbol per spec step 1 (? ToString).
+      if (name === "escape") return (s: any) => escape(s as any);
+      if (name === "unescape") return (s: any) => unescape(s as any);
       // #1500 — `fetch` host import: bridge to globalThis.fetch when available.
       // The compiler routes bare `fetch(url, init?)` identifier calls through
       // this builtin; the host call returns a real JS `Promise<Response>` that

--- a/tests/issue-3063-escape-unescape-host.test.ts
+++ b/tests/issue-3063-escape-unescape-host.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3063 — legacy global escape() / unescape() (§B.2.1 / §B.2.2) had no codegen
+// lowering and silently returned undefined. JS-host mode now registers an
+// env.escape / env.unescape host import that delegates to the native JS globals,
+// mirroring the encodeURI / encodeURIComponent machinery.
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as unknown as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!();
+}
+
+describe("#3063 host-mode escape / unescape", () => {
+  it("escape encodes a space to %20", async () => {
+    expect(await run(`export function test(): string { return escape("a b"); }`)).toBe("a%20b");
+  });
+
+  it("escape leaves the unescaped set unchanged", async () => {
+    expect(await run(`export function test(): string { return escape("@*_+-./"); }`)).toBe("@*_+-./");
+  });
+
+  it("escape emits %uXXXX for code units >= 256", async () => {
+    expect(await run(`export function test(): string { return escape("\\u0100"); }`)).toBe("%u0100");
+  });
+
+  it("escape emits %XX for a code unit < 256", async () => {
+    expect(await run(`export function test(): string { return escape("~"); }`)).toBe("%7E");
+  });
+
+  it("unescape decodes %41 to A", async () => {
+    expect(await run(`export function test(): string { return unescape("%41"); }`)).toBe("A");
+  });
+
+  it("unescape decodes %u0041 to A", async () => {
+    expect(await run(`export function test(): string { return unescape("%u0041"); }`)).toBe("A");
+  });
+
+  it("unescape leaves a non-hex escape literal", async () => {
+    expect(await run(`export function test(): string { return unescape("%zz"); }`)).toBe("%zz");
+  });
+
+  it("unescape(escape(s)) round-trips", async () => {
+    expect(await run(`export function test(): string { return unescape(escape("Hello, World! \\u00e9")); }`)).toBe(
+      "Hello, World! é",
+    );
+  });
+
+  it("does not shadow a user-declared escape function", async () => {
+    expect(
+      await run(
+        `function escape(x: number): number { return x + 1; } export function test(): number { return escape(41); }`,
+      ),
+    ).toBe(42);
+  });
+});


### PR DESCRIPTION
## Problem

The legacy globals `escape()` (§B.2.1) and `unescape()` (§B.2.2) resolve as identifiers (present in the TS lib) but had **no codegen lowering**, so every call silently returned `undefined` — ~33 `annexB/built-ins/{escape,unescape}` test262 files fail (`assertion_fail`, comparing `null` to the expected escaped string).

## Fix

Mirror the existing `encodeURI`/`encodeURIComponent` machinery:

- **declarations.ts**: recognise the direct-call callees `escape`/`unescape` (`state.escapeNeeded`); JS-host mode registers an `(externref) -> externref` `env.escape`/`env.unescape` host import (skipped if a user already declared the name). The generic call-site routing (`calls.ts` `funcMap.get(name)`) dispatches it and ToString-coerces the argument, exactly like the URI globals — **no calls.ts change**.
- **runtime.ts**: host impls `(s) => escape(s)` / `(s) => unescape(s)`, direct pass-through so ToString throws TypeError on a Symbol arg per spec step 1 (matches the `#1436` URI discipline).

Gated `!standalone && !wasi`, so the host-free lanes emit **no** unsatisfiable `env::escape` import (verified: standalone compiles with no leak, keeps its pre-existing behaviour). A pure-Wasm standalone lowering (mirroring `uri-encoding-native.ts`) is a documented follow-up.

## Test

`tests/issue-3063-escape-unescape-host.test.ts` (9 cases: %20/%uXXXX/%XX encode, %41/%u0041/non-hex decode, round-trip, and a user-declared-`escape` shadow guard). Verified: URI encoding tests still pass, `encodeURIComponent` unaffected, standalone emits no `env.escape`. The two pre-existing `issue-2045`/`issue-2660` escape-*analysis* test failures are identical on base (unrelated).

Flips `annexB/built-ins/escape/*` and `annexB/built-ins/unescape/*` value tests (`two.js`, `four.js`, `escape-below.js`, `argument_types.js`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS