### PR TITLE
fix(#3055): honest tag recovery for any-equality externref operands [HELD — floor re-baseline #3056]

### DIFF
--- a/plan/issues/3055-standalone-any-eq-boxed-number-class-present.md
+++ b/plan/issues/3055-standalone-any-eq-boxed-number-class-present.md
@@ -1,7 +1,8 @@
 ---
 id: 3055
 title: "Standalone `any === any` on boxed numbers returns equal-for-unequal when an object-runtime/class is present"
-status: ready
+status: in-progress
+assignee: opus-3055
 created: 2026-07-05
 priority: high
 feasibility: hard
@@ -91,3 +92,68 @@ on two boxed numbers with vs. without a class registered, to find the diverging 
   This is a deliberate measurement RE-BASELINE (the floor gate would auto-park it
   as a false regression) and a **human decision** — do NOT land unilaterally under
   the autonomous loop. See #3056.
+
+## Root cause (traced on upstream/main b3fa4a082c)
+
+The bug is in the **`any`-equality operand seam**, not in `__any_strict_eq`'s
+body. `emitAnyEqOperands` (`src/codegen/coercion-engine.ts`) marshals each
+operand of `a === b` into the `(ref null $AnyValue)` shape the helper takes. For
+an operand that did NOT naturally produce an `$AnyValue` — i.e. a bare
+`externref` (an `any` param reads as `externref` in standalone) — it called
+`coerceType(externref → $AnyValue)`. That path's externref default
+(`value-tags.ts` line ~213) is the **#1888 tag-5 "string" lie**:
+`return emit("__any_box_string")`. So a **boxed NUMBER** (`$BoxedNumber`
+externref produced by `__box_number`) was wrapped as a **tag-5 string** box.
+
+Two such operands then hit `__any_strict_eq` with tagA=tagB=5 → the guarded
+**tag-5 string-content arm** → it answers `equal-for-unequal` for two numbers:
+`isSameValue(1, 2)` returns `1`. Every numeric `assert.sameValue` in the
+standalone harness rides this exact path (`isSameValue(a: any, b: any)` →
+`a === b`), so every numeric assertion was **vacuous** — it could never fail.
+
+**Why a class flips it**: without a class the module keeps `a === b` on the IR
+path, which lowers the comparison with the honest tag machinery inline (correct).
+With a class/object-runtime present the function demotes to the legacy AST path
+(`compileAnyBinaryDispatch` → `emitStrictEq` → `emitAnyEqOperands`), which is the
+buggy seam. WAT bisection: with-class `isSameValue` emits
+`call $__any_box_string` (×2) then `call $__any_strict_eq`; without-class it
+inlines the correct numeric arm.
+
+Direct proof on the legacy path (harness shape), unequal number pairs:
+
+| case            | before | after |
+| --------------- | ------ | ----- |
+| isSameValue(1,2)| 1 (WRONG) | 0 ✓ |
+| isSameValue(1.5,2.5)| 1 (WRONG) | 0 ✓ |
+| isSameValue(100,200)| 1 (WRONG) | 0 ✓ |
+| isSameValue(3,3)| 1 ✓ | 1 ✓ |
+
+## Fix
+
+`emitAnyEqOperands` now recovers an `externref` operand's runtime tag via
+`__any_from_extern` (the tag-classifying helper the loose-eq externref tail —
+`emitAnyEqFromExternTemps` — already uses) instead of the blind
+`coerceType`→`__any_box_string`. The **default (non-honest) `__any_from_extern`
+already** classifies `$BoxedNumber` → tag-3 and `$BoxedBoolean` → tag-4
+honestly; only its string/object fallback keeps the tag-5 wrap **byte-for-byte**.
+So the fix repairs boxed numbers (and bools, and null → tag-1) while leaving
+string-content equality, object-operand equality, and the #3037 tag-6 identity
+carrier **unperturbed** (an object operand is a `ref`, not `externref`, and never
+enters this arm; an object *externref* keeps the same tag-5 fallback). Guarded to
+standalone/wasi (`__any_from_extern` is `undefined` in host mode → host lane keeps
+`coerceType`, so host-lane `===` and all equivalence tests are untouched).
+
+Bonus: closed two `#3037` `getPrototypeOf`-stored-in-`any`-local gaps (a null
+externref now boxes tag-1, so `null === null` → 1, the correct answer). See the
+updated `tests/issue-3037-cs1c-getprototypeof-carrier.test.ts`.
+
+Regression test: `tests/issue-3055-numeric-any-eq-class.test.ts`.
+
+## ⚠️ DO NOT LAND WITHOUT #3056 (floor re-baseline + human sign-off)
+
+This fix DE-VACUIFIES numeric asserts → previously-vacuous numeric standalone
+"passes" become honest FAILS → the `host_free_pass` floor DROPS. The merge_group
+floor gate will (correctly) read that as a regression and auto-park the PR. The
+PR is opened with `hold` + `do-not-merge` and MUST be coordinated with the #3056
+re-baseline under human decision. Measured floor-drop magnitude is reported on
+the PR.

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -34,10 +34,10 @@
 import { isBooleanType, isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
+import { ensureAnyFromExternHelper } from "./any-helpers.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { noJsHost } from "./expressions/helpers.js";
 import { addUnionImports, nativeStringType } from "./index.js";
-import { ensureAnyFromExternHelper } from "./any-helpers.js";
 import { ensureAnyToStringHelper } from "./native-strings.js";
 import {
   compileExpression,
@@ -453,16 +453,36 @@ export function emitToBoolean(ctx: CodegenContext, valType: ValType | null, sink
  */
 function emitAnyEqOperands(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): boolean {
   const anyValueTarget: ValType = { kind: "ref_null", typeIdx: ctx.anyValueTypeIdx };
+  // (#3055) An `externref` operand is a boxed value whose runtime tag must be
+  // RECOVERED, not assumed. `coerceType(externref → $AnyValue)` boxes it via the
+  // `__any_box_string` DEFAULT (value-tags.ts) — the #1888 tag-5 "string" lie —
+  // so two boxed NUMBERS (`$BoxedNumber` externrefs from `__box_number`) become
+  // two tag-5 boxes and `__any_strict_eq`'s string-content arm answers
+  // equal-for-unequal (`1 === 2` → true). That silently vacuified every numeric
+  // `assert.sameValue` in the standalone harness (isSameValue rides this exact
+  // path). `__any_from_extern` classifies by tag instead — `$BoxedNumber` → tag-3
+  // (numeric `f64.eq`), `$BoxedBoolean` → tag-4, and (in its non-honest default
+  // instance) strings/objects keep the SAME tag-5 fallback byte-for-byte — so the
+  // fix repairs numbers/bools without perturbing string/object equality or the
+  // #3037 tag-6 identity carrier. `emitAnyEqFromExternTemps` (the loose-eq
+  // externref tail) already marshals through this helper; this makes the
+  // freshly-compiled-operand path consistent. Only reachable in standalone/wasi
+  // (the helper is undefined otherwise → host lane keeps `coerceType`).
+  const fromExternIdx = ensureAnyFromExternHelper(ctx);
+  const marshal = (t: ValType): void => {
+    if (isAnyValue(t, ctx)) return;
+    if (fromExternIdx !== undefined && t.kind === "externref") {
+      fctx.body.push({ op: "call", funcIdx: fromExternIdx });
+      return;
+    }
+    coerceType(ctx, fctx, t, anyValueTarget);
+  };
   const leftType = compileExpression(ctx, fctx, expr.left);
   if (!leftType) return false;
-  if (!isAnyValue(leftType, ctx)) {
-    coerceType(ctx, fctx, leftType, anyValueTarget);
-  }
+  marshal(leftType);
   const rightType = compileExpression(ctx, fctx, expr.right);
   if (!rightType) return false;
-  if (!isAnyValue(rightType, ctx)) {
-    coerceType(ctx, fctx, rightType, anyValueTarget);
-  }
+  marshal(rightType);
   return true;
 }
 

--- a/tests/issue-3037-cs1c-getprototypeof-carrier.test.ts
+++ b/tests/issue-3037-cs1c-getprototypeof-carrier.test.ts
@@ -130,11 +130,14 @@ describe("#3037 CS1c — class-instance getPrototypeOf (real proto anchor)", () 
 });
 
 describe("#3037 CS1c — KNOWN-GAPs beyond the operand carrier (CS3 / non-any-operand)", () => {
-  it("[KNOWN-GAP: null-canon stored-in-local] CS0 case (d) — gpo([1]) stored then === [0 today]", async () => {
+  it("[CLOSED by #3055] CS0 case (d) — gpo([1]) stored then === [now 1]", async () => {
     // Both operands are null externref from getPrototypeOf, stored in `any`
-    // locals → boxed tag-5 at the operand seam → guarded same-tag arm → 0.
-    // A null LITERAL (above) is 1. The fix is the universal reader/producer
-    // carrier (CS3), not a bounded operand carrier.
+    // locals. Previously the operand seam boxed each via `__any_box_string`
+    // (tag-5 lie) → the guarded same-tag string arm answered 0. #3055 made the
+    // any-equality operand seam classify externrefs by tag via
+    // `__any_from_extern`: a null externref now boxes tag-1 (null), so
+    // `null === null` → 1 (the semantically correct answer — two reads of the
+    // same object's prototype ARE ===).
     expect(
       await runStandalone(`export function run(): number {
         const a: any = [1];
@@ -142,10 +145,12 @@ describe("#3037 CS1c — KNOWN-GAPs beyond the operand carrier (CS3 / non-any-op
         const p2: any = Object.getPrototypeOf(a);
         return (p1 === p2) ? 1 : 0;
       }`),
-    ).toBe(0);
+    ).toBe(1);
   });
 
-  it("[KNOWN-GAP: CS3 stored-in-local] class getPrototypeOf stored in `any` locals then === [0 today]", async () => {
+  it("[CLOSED by #3055] class getPrototypeOf stored in `any` locals then === [now 1]", async () => {
+    // Same as above for a class instance: honest tag-1 null boxing at the
+    // operand seam (#3055) makes the stored-in-local prototype `===` correct.
     expect(
       await runStandalone(`class Foo { x: number = 1; }
         export function run(): number {
@@ -154,7 +159,7 @@ describe("#3037 CS1c — KNOWN-GAPs beyond the operand carrier (CS3 / non-any-op
           const p2: any = Object.getPrototypeOf(f);
           return (p1 === p2) ? 1 : 0;
         }`),
-    ).toBe(0);
+    ).toBe(1);
   });
 
   it("[KNOWN-GAP: non-any operand] getPrototypeOf(instance) === Foo.prototype [0 today]", async () => {

--- a/tests/issue-3055-numeric-any-eq-class.test.ts
+++ b/tests/issue-3055-numeric-any-eq-class.test.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3055 — Standalone boxed-number strict-equality miscompiled when a class /
+// object-runtime is present.
+//
+// Root cause: the `any`-equality operand seam (`emitAnyEqOperands` in
+// coercion-engine.ts) marshalled each `externref` operand into the `$AnyValue`
+// box via `coerceType`, whose externref default is the `__any_box_string`
+// (tag-5 "string") lie (value-tags.ts). Two boxed NUMBERS (`$BoxedNumber`
+// externrefs from `__box_number`) therefore became two tag-5 boxes and
+// `__any_strict_eq`'s string-content arm answered equal-for-unequal
+// (`1 === 2` → true). This only surfaced when the module demoted `a === b`
+// to the legacy `__any_strict_eq` path (e.g. the full test262 harness shape:
+// a class + the `isSameValue`/`assert_sameValue` nest), silently vacuifying
+// EVERY numeric `assert.sameValue` in the standalone lane.
+//
+// Fix: the operand seam now recovers an externref's runtime tag via
+// `__any_from_extern` (`$BoxedNumber` → tag-3, `$BoxedBoolean` → tag-4;
+// strings/objects keep the same tag-5 fallback byte-for-byte), so boxed-number
+// `===` is correct regardless of class presence.
+
+import { compile } from "../src/index.js";
+import { describe, expect, it } from "vitest";
+
+async function runStandalone(source: string, fn = "run"): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const leaked = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  expect(leaked, `--target standalone leaked env imports: ${leaked.join(", ")}`).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>)[fn]();
+}
+
+// The harness-shape prelude that demotes `a === b` to the legacy
+// `__any_strict_eq` path (a class WITH a static method + an `isSameValue` nest).
+const HARNESS = `class Test262Error {
+  message: string;
+  constructor(msg: string = "") { this.message = msg; }
+  static thrower(msg: string = ""): void { throw new Test262Error(msg); }
+}
+function isSameValue(a: any, b: any): number {
+  if (a === b) { return 1; }
+  if (a !== a && b !== b) { return 1; }
+  return 0;
+}`;
+
+describe("#3055 — boxed-number any-eq with a class present (legacy __any_strict_eq path)", () => {
+  it("isSameValue(1, 2) is 0 (unequal) — the keystone vacuity bug", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number { return isSameValue(1, 2); }`),
+    ).toBe(0);
+  });
+
+  it("isSameValue(3, 3) is 1 (equal)", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number { return isSameValue(3, 3); }`),
+    ).toBe(1);
+  });
+
+  it("isSameValue(1.5, 2.5) is 0 (unequal fractionals)", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number { return isSameValue(1.5, 2.5); }`),
+    ).toBe(0);
+  });
+
+  it("isSameValue(100, 200) is 0 (unequal large ints)", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number { return isSameValue(100, 200); }`),
+    ).toBe(0);
+  });
+
+  it("isSameValue(NaN, NaN) is 1 via the a!==a && b!==b arm", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number { return isSameValue(0/0, 0/0); }`),
+    ).toBe(1);
+  });
+
+  it("boxed-number !== is honest: (1 !== 2) is true, (3 !== 3) is false", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        function neq(a: any, b: any): number { return a !== b ? 1 : 0; }
+        export function run(): number { return neq(1, 2) * 10 + neq(3, 3); }`),
+    ).toBe(10);
+  });
+
+  it("string operands stay correct with a class present (content equality)", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number {
+          const a: any = "abcd"; const b: any = "ab" + "cd"; return isSameValue(a, b);
+        }`),
+    ).toBe(1);
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number {
+          const a: any = "abcd"; const b: any = "abXd"; return isSameValue(a, b);
+        }`),
+    ).toBe(0);
+  });
+
+  it("#3055 leaves object-operand equality byte-unchanged (object externref keeps tag-5 fallback)", async () => {
+    // The fix reroutes ONLY boxed-primitive externrefs (number → tag-3, bool →
+    // tag-4, null → tag-1) through `__any_from_extern`; an OBJECT externref
+    // keeps the identical non-honest tag-5 fallback `__any_box_string` produced.
+    // So object-operand equality is unchanged by #3055. On this legacy
+    // harness path the object-runtime externalises the instance and the tag-5
+    // arm answers 1 for BOTH distinct and same instances — a PRE-EXISTING
+    // object-externalisation gap (verified identical before/after #3055), out of
+    // this issue's scope. Object identity on the ref-typed / IR path is correct
+    // and is guarded by tests/issue-3037-cs1c-getprototypeof-carrier.test.ts.
+    expect(
+      await runStandalone(`${HARNESS}
+        class Box { x: number = 0; }
+        export function run(): number { const a: any = new Box(); const b: any = a; return isSameValue(a, b); }`),
+    ).toBe(1);
+  });
+
+  it("mixed number-vs-string is strictly unequal", async () => {
+    expect(
+      await runStandalone(`${HARNESS}
+        export function run(): number { const a: any = 1; const b: any = "1"; return isSameValue(a, b); }`),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## ⚠️ HELD — DO NOT MERGE (needs #3056 re-baseline + human sign-off)

This is a **real correctness fix** that intentionally **drops the standalone
`host_free_pass` floor** by de-vacuifying numeric assertions. The merge_group
floor gate will (correctly) read the drop as a regression and auto-park it.
Landing it changes the headline standalone number — that is a coordinated
**human decision** via #3056. Labelled `hold` + `do-not-merge`; **do not enqueue.**

Fixes #3055 (code-wise). Coordinated with #3056.

## Root cause

Standalone `a === b` on two `any`-typed (externref-boxed) **NUMBERS** returned
**equal-for-unequal** whenever the module demoted `===` to the legacy
`__any_strict_eq` path (any module with a class / object-runtime — e.g. the full
test262 harness).

The bug is in the **operand seam**, not the helper body. `emitAnyEqOperands`
(`src/codegen/coercion-engine.ts`) marshalled each `externref` operand into the
`$AnyValue` box via `coerceType(externref → $AnyValue)`, whose externref default
(`value-tags.ts`) is the **#1888 tag-5 "string" lie** (`__any_box_string`). So a
`$BoxedNumber` externref (from `__box_number`) was tagged as a **string**, and
`__any_strict_eq`'s tag-5 string-content arm answered `1 === 2` → **true**.

`isSameValue(a: any, b: any) => a === b` rides this exact seam, so **every
numeric `assert.sameValue` in the standalone lane was vacuous** — it could never
fail.

WAT bisection (with-class vs no-class `isSameValue`):
- with-class: `call $__any_box_string` ×2 → `call $__any_strict_eq`  ← buggy
- no-class:   inlines the honest numeric arm (`f64.eq`)  ← correct

Direct proof (legacy harness path):

| case | before | after |
|---|---|---|
| `isSameValue(1, 2)` | **1 (WRONG)** | 0 ✓ |
| `isSameValue(1.5, 2.5)` | **1 (WRONG)** | 0 ✓ |
| `isSameValue(100, 200)` | **1 (WRONG)** | 0 ✓ |
| `isSameValue(3, 3)` | 1 ✓ | 1 ✓ |
| real `wrapTest(assert.sameValue(1,2))` → `test()` | **1 (vacuous pass)** | 2 (fail, = host) ✓ |

## Fix

`emitAnyEqOperands` now recovers an `externref` operand's runtime tag via
`__any_from_extern` (the classifier the loose-eq externref tail
`emitAnyEqFromExternTemps` **already** uses) instead of the blind
`coerceType`→`__any_box_string`. Its **default (non-honest)** instance already
maps `$BoxedNumber` → tag-3 and `$BoxedBoolean` → tag-4 honestly, and keeps the
string/object tag-5 fallback **byte-for-byte** — so numbers/bools/null are
repaired while string-content equality, object-operand equality, and the **#3037
tag-6 identity carrier are unperturbed** (an object operand is a `ref`, not
`externref`, and never enters this arm). Guarded to standalone/wasi (host lane
keeps `coerceType`, so host `===` + all equivalence tests are untouched).

Bonus: closes two #3037 `getPrototypeOf`-stored-in-`any`-local gaps (a null
externref now boxes tag-1 → `null === null` → 1, correct).

## Correctness verification

- `tests/issue-3055-numeric-any-eq-class.test.ts` (new, 9 cases): numeric
  `===`/`!==` correct with a class present; NaN, strings, mixed-type, object
  identity all intact.
- `tests/issue-3037-cs1c-getprototypeof-carrier.test.ts` (8/8): two `[0 today]`
  known-gaps now correctly `1`; tag-6 identity invariants hold.
- Identity invariant preserved: distinct objects `!==` (0), same ref `===` (1),
  string content eq/neq correct, mixed number-vs-string `!==`.
- tsc clean; prettier clean.

## 📉 Floor impact — the key deliverable (#3056)

Scoped standalone measurement, **before vs after** on a deterministic,
equal-weighted sample (≤100 files/category) of the numeric-heavy suites
**Number / Math / DataView / TypedArray / TypedArrayConstructors**, scored as
`host_free_pass` (`runTest262File(..., "standalone")`, status `pass`):

| metric | before | after | Δ |
|---|---|---|---|
| host_free_pass | 202 | 177 | **−25** |
| evaluated (non-skip) | 449 | 449 | — |
| apparent pass rate | 44.99% | **39.42%** | −5.57pp |

**Flip breakdown (before→after):**
- **pass→fail (de-vacuified): 25**
- fail→pass (collateral gains): **0**
- other flips: **0**

The zero-collateral result is expected and confirms the fix is *purely*
de-vacuifying: the bug only ever produced **false PASSES** (numeric asserts that
could not fail), never false fails — so repairing it can only convert
false-passes into honest fails.

**Vacuity magnitude:** 25/449 = **5.6%** of evaluated numeric tests were vacuous
passes; **~12.4%** of the pre-fix numeric "passes" (25/202) were vacuous.

**Estimated true numeric-assert pass rate (post-fix, sample): ~39.4%**
(vs the ~45.0% apparent/vacuous rate).

**Extrapolation:** these 5 categories hold **3,401** test files. At the measured
5.6% rate that is **~190 vacuous numeric passes in these suites alone**; the
whole-corpus floor drop is larger (numeric `assert.sameValue` appears well beyond
these categories). #3056's re-baseline should capture the exact whole-corpus
delta via a full standalone CI run.

## Why held
De-vacuifying is the *correct* fix (vs #3056's harness `_num` sidestep), but it
lowers the published floor number. Per #3055/#3056 that is a deliberate
measurement RE-BASELINE and a human call — not an autonomous-loop merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
