### PR TITLE
feat(#3065): IR claim non-terminating if-guard at non-void body position

### DIFF
--- a/plan/issues/3065-ir-nonterminating-if-guard.md
+++ b/plan/issues/3065-ir-nonterminating-if-guard.md
@@ -1,0 +1,132 @@
+---
+id: 3065
+title: "IR: claim non-terminating `if (cond) <stmt>;` guard at non-void body position (select↔builder parity, follow-on #1979)"
+status: done
+assignee: ttraenkler/sendev-irbucket
+sprint: current
+created: 2026-07-06
+updated: 2026-07-06
+completed: 2026-07-06
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+parent: 2855
+related: [1979, 2856, 1228, 1131]
+---
+
+# #3065 — IR: non-terminating `if (cond) <stmt>;` guard at a non-void body position
+
+Child slice of the IR front-end migration epic **#2855** (drive the unintended
+IR fallback buckets to zero). Reduces the dominant `body-shape-rejected` bucket
+by **−1** (18 → 17) and closes a **select↔builder parity gap** that #1979 left
+open.
+
+## Root cause (why the selector rejected a shape the builder can already lower)
+
+`#1979` (DONE, PR #1434) fixed `from-ast.ts` so a **non-terminating** then-arm
+of a no-`else` `if` no longer incorrectly short-circuits the rest of the body.
+`lowerStatementList` (`src/ir/from-ast.ts` ~759-782) forks on
+`thenArmTerminates(thenStmt)`:
+
+- **terminating** then-arm (`return`/`throw`) → the early-return rewrite
+  `if (cond) <tail> else { <rest> }`;
+- **non-terminating** then-arm (a side-effecting statement) → a converging
+  guard: `br_if` to a `then` block that runs `lowerStmt(thenArm)` then falls
+  through to a continuation block holding `<rest>`.
+
+The builder's non-terminating arm accepts **any** statement `lowerStmt` handles
+(`isPhase1BodyStatement`-shaped: assignment, call, nested guard, block, …). But
+the **selector** (`isPhase1StatementList` in `src/ir/select.ts`) only let a
+non-terminating then-arm through when it was a valid **void tail** — the
+`isVoidReturn && ExpressionStatement` arm of `isPhase1Tail`. For a **non-void**
+function whose guard is followed by more statements and a value return — the
+canonical day-of-week `fdow` shape:
+
+```ts
+function fdow(y: number, m: number): number {
+  const t = [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
+  let yr = y;
+  if (m < 2) yr = yr - 1; // non-terminating guard, non-void fn
+  const d = (yr + ((yr / 4) | 0) - ((yr / 100) | 0) + ((yr / 400) | 0) + t[m] + 1) % 7;
+  return (d + 6) % 7;
+}
+```
+
+`isPhase1Tail(yr = yr - 1, isVoidReturn=false)` fell through to
+`shapeNo("tail-unhandled", …)`, demoting `fdow` to legacy even though the
+builder could lower it end-to-end. Under **#2138 IR-first** a select↔builder
+drift like this is worse than a demote — a claimed-but-unlowerable shape traps
+as `unreachable`. Here the drift was the _opposite_ direction (builder ahead of
+selector), so it only cost a claim, but it is exactly the parity the migration
+must close.
+
+## Why this is now a clean, mergeable −1 (contagion no longer blocks it)
+
+The #2856 Step-2 analysis (2026-07-03) concluded "no incremental PR can reduce
+this bucket" because the `call-graph-closure` fixpoint demoted any leaf whose
+**caller** was unclaimed — moving the count into `call-graph-closure` (net-zero,
+gate fails on that growth). That was pre-#2858. **#2858 (PR #2752, merged
+2026-07-06) disabled the caller-direction demotion in JS-host mode** for
+functions without a callable param (`demoteOnLegacyCaller = jsHostExterns !==
+true`, `select.ts` ~596). The gate runs in host mode, so a **pure leaf** like
+`fdow` (no callees, no callable param) now stays claimed regardless of its
+unclaimed caller `renderCal`. Verified empirically: `body-shape-rejected`
+18 → 17, `call-graph-closure` stays **0**, **zero** post-claim demotions.
+
+## Fix (selector-only, mirrors the builder exactly)
+
+`src/ir/select.ts`:
+
+1. Added a `thenArmTerminates(stmt)` helper — an **exact** mirror of the
+   identically-named helper in `from-ast.ts` (return/throw, or block/if-else
+   whose every path terminates). Keeping the two in lockstep is the whole point:
+   the selector must agree with the builder on the terminating/non-terminating
+   fork.
+2. Split the non-tail `if (cond)`-no-`else` arm of `isPhase1StatementList` on
+   `thenArmTerminates`:
+   - terminating → unchanged (Phase-1 **tail** then-arm + `<rest>` as the else
+     list);
+   - non-terminating → require the then-arm to be an `isPhase1BodyStatement`
+     (the exact set `lowerStmt` accepts), with a cloned scope so arm-local
+     `let`s don't leak, `inLoop=false` (a `break`/`continue` in the guard stays
+     rejected; a `return` makes `thenArmTerminates` true and takes the other
+     arm), then `continue` so the outer loop validates `<rest>` through to the
+     tail — matching from-ast's `lowerStatementList(rest)` in the continuation
+     block.
+
+No `from-ast.ts` change was needed — the #1979 converging-guard path already
+lowers this shape; it was simply unreachable from the selector for non-void
+functions.
+
+## Verification
+
+- `pnpm run check:ir-fallbacks`: `body-shape-rejected` **18 → 17**,
+  `call-graph-closure` 0 (unchanged), post-claim demotions **0**. Baseline
+  ratcheted in `scripts/ir-fallback-baseline.json`.
+- `JS2WASM_IR_SHAPE_DIAG=1 … --shape-diag`: `fdow` leaves the rejection set; no
+  other function shifts and no new arm appears (a pure −1, not a relabel).
+- New `tests/issue-2856-nonterminating-if-guard.test.ts` (8 cases): legacy/IR
+  value parity + zero post-claim demotions + **IR-path-exercised** (bytes
+  differ from the `experimentalIR:false` compile — no vacuous legacy pass) for
+  the minimal guard, both guard arms, the full `fdow` Zeller computation across
+  5 (y,m) pairs, block then-arm, consecutive guards, nested guard, guard +
+  following loop, and a REGRESSION case proving the terminating early-return
+  rewrite still fires.
+- `tests/ir-algorithms-cluster.test.ts`, `ir-if-else-equivalence.test.ts`,
+  `issue-1979.test.ts`, `issue-1228.test.ts` — 55 pass, no regression.
+- Equivalence gate shards green (no new regressions vs baseline).
+- `tsc` / prettier / biome clean.
+
+## Notes for the bucket owner (#2856, ttraenkler/fable-2856exec)
+
+This slice is independent of the algorithms.ts whole-component work: it only
+touches the non-tail if-no-else arm of `isPhase1StatementList` + a new helper,
+and ratchets the baseline by 1. If both land, the baseline number reconciles to
+whatever the merged corpus produces (re-run `--update-on-decrease`). The
+capability (non-terminating guard in non-void bodies) is broadly reusable beyond
+the corpus.

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
-  "generated": "2026-07-05",
+  "generated": "2026-07-06",
   "unintended": {
-    "body-shape-rejected": 18
+    "body-shape-rejected": 17
   },
   "deferred": {
     "async-function": 4

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1473,6 +1473,34 @@ function dynamicUsesAreMoveOnly(
 // Shape check
 // ---------------------------------------------------------------------------
 
+/**
+ * Does `stmt` unconditionally terminate its control flow (return / throw, or a
+ * block / if-else whose every path does)? EXACT mirror of the identically-named
+ * helper in `from-ast.ts` (#1979) — the selector MUST agree with the builder on
+ * which non-tail `if (cond) <then>; <rest>` shapes are early-return rewrites
+ * (terminating then-arm → the then-arm is reinterpreted as a tail and `<rest>`
+ * becomes the else) versus non-terminating guards (side-effecting then-arm →
+ * `<rest>` runs afterward, lowered by the converging-guard path in
+ * `lowerStatementList`). Drift here re-introduces select↔builder mismatch —
+ * under #2138 IR-first that is a live `unreachable` trap, not a silent demote.
+ */
+function thenArmTerminates(stmt: ts.Statement): boolean {
+  if (ts.isReturnStatement(stmt) || ts.isThrowStatement(stmt)) {
+    return true;
+  }
+  if (ts.isBlock(stmt)) {
+    const last = stmt.statements[stmt.statements.length - 1];
+    return last !== undefined && thenArmTerminates(last);
+  }
+  if (ts.isIfStatement(stmt)) {
+    // An `if` terminates only when it has an else and BOTH arms terminate.
+    return (
+      stmt.elseStatement !== undefined && thenArmTerminates(stmt.thenStatement) && thenArmTerminates(stmt.elseStatement)
+    );
+  }
+  return false;
+}
+
 function isPhase1StatementList(
   stmts: ReadonlyArray<ts.Statement>,
   scope: Set<string>,
@@ -1601,16 +1629,34 @@ function isPhase1StatementList(
       }
       return shapeNo(arm, es);
     }
-    // Phase 2 extension: an `if (cond) <tail>` with NO else and the rest
-    // of the statements forming a tail. This is the classic early-return
-    // pattern: `if (base) return x; <recursive body>`. We structurally
-    // reinterpret as `if (cond) <tail> else { <rest> }`.
+    // Phase 2 extension: an `if (cond)` with NO else, split by whether the
+    // then-arm unconditionally terminates — mirroring `lowerStatementList`'s
+    // `thenArmTerminates` fork in `from-ast.ts` exactly (#1979).
     if (ts.isIfStatement(s) && !s.elseStatement) {
       if (!isPhase1Expr(s.expression, scope, localClasses)) return shapeNo("nontail-if-cond", s.expression);
-      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator, isVoidReturn))
-        return shapeNo("nontail-if-then", s.thenStatement);
-      const rest = stmts.slice(i + 1);
-      return isPhase1StatementList(rest, new Set(scope), localClasses, isGenerator, isVoidReturn);
+      if (thenArmTerminates(s.thenStatement)) {
+        // Early-return rewrite: `if (cond) <tail>; <rest>` ≡
+        // `if (cond) <tail> else { <rest> }`. The then-arm must be a Phase-1
+        // tail (terminates on every path); the rest becomes the else block.
+        if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator, isVoidReturn))
+          return shapeNo("nontail-if-then", s.thenStatement);
+        const rest = stmts.slice(i + 1);
+        return isPhase1StatementList(rest, new Set(scope), localClasses, isGenerator, isVoidReturn);
+      }
+      // (#1979) Non-terminating guard: `if (cond) <side-effecting-stmt>;` where
+      // the then-arm is a plain body statement (assignment, call, nested guard,
+      // …). `from-ast.ts` lowers this via the converging-guard path
+      // (`lowerStatementList` lines ~759-782 → `lowerStmt(thenArm)`), so the
+      // shape-check for the then-arm mirrors `lowerStmt`'s accepted set exactly
+      // (`isPhase1BodyStatement`, not a tail). `<rest>` runs afterward — the
+      // outer loop continues validating it (ending in the tail), matching
+      // from-ast's `lowerStatementList(rest)` in the continuation block. The
+      // then-arm scope is cloned so arm-local `let`s don't leak into `<rest>`.
+      // Not in a loop here → `inLoop=false` (break/continue in the guard stay
+      // rejected; a `return` would have made `thenArmTerminates` true above).
+      if (!isPhase1BodyStatement(s.thenStatement, new Set(scope), localClasses, /* inLoop */ false))
+        return shapeNo("nontail-if-then-guard", s.thenStatement);
+      continue;
     }
     // Slice 6 part 2 (#1181) — for-of statement (always non-tail). The
     // body is itself shape-checked. The bridge in `from-ast.ts` lowers

--- a/tests/issue-2856-nonterminating-if-guard.test.ts
+++ b/tests/issue-2856-nonterminating-if-guard.test.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2856 (follow-on to #1979) — non-terminating `if (cond) <stmt>;` guard at a
+// NON-void, non-tail body position.
+//
+// #1979 fixed the `from-ast.ts` lowering so a non-terminating then-arm no
+// longer skips the rest of the body (`lowerStatementList`'s converging-guard
+// path). But the SELECTOR only let such guards through for VOID functions (via
+// the `isVoidReturn && ExpressionStatement` void-tail arm in `isPhase1Tail`).
+// A NON-void function whose non-tail `if (cond) x = e;` guard is followed by
+// more statements + a value return (the canonical `fdow` day-of-week shape)
+// stayed `body-shape-rejected: tail-unhandled`, even though from-ast could
+// already lower it. This slice extends the selector's non-tail if-no-else arm
+// to mirror from-ast's `thenArmTerminates` fork: terminating then-arm → tail
+// rewrite; non-terminating then-arm → `isPhase1BodyStatement` guard.
+//
+// Every case asserts legacy/IR observable equality, ZERO post-claim demotions,
+// and that the IR path was genuinely exercised (bytes differ from the
+// `experimentalIR: false` compile — a silent legacy demote fails the test).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+const JS_STRING = {
+  concat: (a: string, b: string) => a + b,
+  length: (s: string) => s.length,
+  equals: (a: string, b: string) => (a === b ? 1 : 0),
+  substring: (s: string, start: number, end: number) => s.substring(start, end),
+  charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+  fromCharCode: (c: number) => String.fromCharCode(c),
+  cast: (s: unknown) => String(s),
+  test: (v: unknown) => (typeof v === "string" ? 1 : 0),
+};
+
+interface RunResult {
+  value: unknown;
+  binary: Uint8Array;
+  postClaim: unknown[];
+}
+
+async function compileRun(source: string, fn: string, args: unknown[], experimentalIR: boolean): Promise<RunResult> {
+  const r = await compile(source, { experimentalIR, trackFallbacks: true });
+  if (!r.success) {
+    throw new Error(`compile failed (${experimentalIR ? "IR" : "legacy"}): ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const imports: WebAssembly.Imports = { env: built.env, string_constants: built.string_constants };
+  imports["wasm:js-string"] = JS_STRING as unknown as WebAssembly.ModuleImports;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  const f = (instance.exports as Record<string, unknown>)[fn];
+  if (typeof f !== "function") throw new Error(`export ${fn} missing`);
+  return {
+    value: (f as (...a: unknown[]) => unknown)(...args),
+    binary: r.binary,
+    postClaim: r.irPostClaimErrors ?? [],
+  };
+}
+
+async function expectParity(
+  source: string,
+  fn: string,
+  args: unknown[],
+  expected: unknown,
+  opts: { expectClaimed?: boolean } = {},
+): Promise<void> {
+  const legacy = await compileRun(source, fn, args, false);
+  const ir = await compileRun(source, fn, args, true);
+  expect(legacy.value, "legacy value").toStrictEqual(expected);
+  expect(ir.value, "IR value matches legacy").toStrictEqual(legacy.value);
+  expect(ir.postClaim, "no post-claim demotions").toStrictEqual([]);
+  if (opts.expectClaimed !== false) {
+    expect(
+      Buffer.compare(Buffer.from(legacy.binary), Buffer.from(ir.binary)) !== 0,
+      "IR path exercised (bytes differ from legacy)",
+    ).toBe(true);
+  }
+}
+
+describe("#2856 — non-terminating if-guard at non-void body position", () => {
+  it("simple `if (cond) x = e;` guard then value return", async () => {
+    // The minimal fdow shape: a mutation guard followed by more statements.
+    await expectParity(
+      `export function f(m: number, y: number): number {
+         let yr = y;
+         if (m < 2) yr = yr - 1;
+         return yr * 10 + m;
+       }`,
+      "f",
+      [1, 2000],
+      // m=1 < 2 → yr = 1999; 1999*10 + 1 = 19991
+      19991,
+    );
+  });
+
+  it("guard NOT taken — rest still runs with the unmutated value", async () => {
+    await expectParity(
+      `export function f(m: number, y: number): number {
+         let yr = y;
+         if (m < 2) yr = yr - 1;
+         return yr * 10 + m;
+       }`,
+      "f",
+      [5, 2000],
+      // m=5 ≥ 2 → yr stays 2000; 2000*10 + 5 = 20005
+      20005,
+    );
+  });
+
+  it("Zeller-style day-of-week (the `fdow` corpus function)", async () => {
+    const src = `export function fdow(y: number, m: number): number {
+      const t = [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
+      let yr = y;
+      if (m < 2) yr = yr - 1;
+      const d = (yr + ((yr / 4) | 0) - ((yr / 100) | 0) + ((yr / 400) | 0) + t[m] + 1) % 7;
+      return (d + 6) % 7;
+    }`;
+    // Verify across a range of (y, m) pairs to exercise both guard arms.
+    const oracle = (y: number, m: number): number => {
+      let yr = y;
+      if (m < 2) yr = yr - 1;
+      const d =
+        (yr + ((yr / 4) | 0) - ((yr / 100) | 0) + ((yr / 400) | 0) + [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4][m]! + 1) % 7;
+      return (d + 6) % 7;
+    };
+    for (const [y, m] of [
+      [2026, 0],
+      [2026, 1],
+      [2026, 6],
+      [2000, 11],
+      [1999, 2],
+    ] as const) {
+      await expectParity(src, "fdow", [y, m], oracle(y, m));
+    }
+  });
+
+  it("block then-arm with multiple mutations", async () => {
+    await expectParity(
+      `export function f(a: number): number {
+         let x = 1;
+         let y = 2;
+         if (a > 0) { x = x + a; y = y + a; }
+         return x * 100 + y;
+       }`,
+      "f",
+      [5],
+      // x=6, y=7 → 607
+      607,
+    );
+  });
+
+  it("multiple consecutive guards before the tail", async () => {
+    await expectParity(
+      `export function f(a: number, b: number): number {
+         let acc = 0;
+         if (a > 0) acc = acc + 10;
+         if (b > 0) acc = acc + 1;
+         return acc;
+       }`,
+      "f",
+      [1, 0],
+      10,
+    );
+  });
+
+  it("nested non-terminating guard `if (c1) if (c2) x = e;`", async () => {
+    await expectParity(
+      `export function f(a: number, b: number): number {
+         let x = 0;
+         if (a > 0) if (b > 0) x = a + b;
+         return x;
+       }`,
+      "f",
+      [3, 4],
+      7,
+    );
+  });
+
+  it("guard followed by a loop that reads the mutated local", async () => {
+    await expectParity(
+      `export function f(n: number): number {
+         let base = 0;
+         if (n > 5) base = 100;
+         let s = base;
+         for (let i = 0; i < n; i++) s = s + i;
+         return s;
+       }`,
+      "f",
+      [10],
+      // base=100; sum 0..9 = 45 → 145
+      145,
+    );
+  });
+
+  it("REGRESSION: terminating then-arm (early return) still rewrites", async () => {
+    await expectParity(
+      `export function f(n: number): number {
+         if (n < 0) return -1;
+         return n * 2;
+       }`,
+      "f",
+      [21],
+      42,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes a **select↔builder parity gap** #1979 left open, and ratchets the IR-migration `body-shape-rejected` bucket **18 → 17** (part of #2855 / #2856).

#1979 (PR #1434) fixed `from-ast.ts`'s `lowerStatementList` so a **non-terminating** `if (cond) <stmt>;` guard no longer skips the rest of the body (the converging-guard path). But the **selector** only let such guards through for **void** functions (the `isVoidReturn && ExpressionStatement` void-tail arm). A **non-void** function whose guard is followed by more statements + a value return — the canonical `fdow` day-of-week shape — stayed `body-shape-rejected: tail-unhandled`, even though from-ast could already lower it end-to-end.

## Fix (selector-only)

`src/ir/select.ts`:
1. Add `thenArmTerminates(stmt)` — an **exact** mirror of the identically-named `from-ast.ts` helper.
2. Split the non-tail `if`-no-`else` arm of `isPhase1StatementList` on it:
   - **terminating** then-arm → unchanged early-return tail rewrite;
   - **non-terminating** then-arm → shape-check via `isPhase1BodyStatement` (the exact set `lowerStmt` accepts), cloned scope, `inLoop=false`, then `continue` to validate `<rest>` — mirroring from-ast's `lowerStatementList(rest)` in the continuation block.

No `from-ast.ts` change needed — the #1979 lowering already handles this shape; it was simply unreachable from the selector for non-void functions.

## Why it's a clean incremental win now

The #2856 Step-2 analysis (pre-#2858) concluded no incremental PR could reduce this bucket because the `call-graph-closure` fixpoint demoted any leaf whose caller was unclaimed. **#2858 (PR #2752) disabled the caller-direction demotion in JS-host mode** (`demoteOnLegacyCaller = jsHostExterns !== true`), so the pure leaf `fdow` (no callees, no callable param) now stays claimed despite its unclaimed caller `renderCal`.

## Verification

- `check:ir-fallbacks`: **body-shape-rejected 18 → 17**, `call-graph-closure` **0** (unchanged), **post-claim demotions 0**. Baseline ratcheted.
- `--shape-diag`: `fdow` leaves the reject set; no other function shifts, no new arm (pure −1, not a relabel).
- New `tests/issue-2856-nonterminating-if-guard.test.ts` — 8 cases asserting legacy/IR value parity + zero post-claim demotions + **IR-path-exercised** (bytes differ), incl. the full `fdow` Zeller computation and a terminating-early-return regression case.
- 55 related IR tests green (`ir-algorithms-cluster`, `ir-if-else-equivalence`, `issue-1979`, `issue-1228`); equivalence-gate shards green; `tsc`/prettier/biome-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8