### PR TITLE
fix(#2726): delete of inherited (non-own) property is a true no-op (group g)

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -25,9 +25,13 @@ updated: 2026-07-05
 > `this` as the global object) and `S11.4.1_A3.3_T1` (`x = 1; delete x; x` →
 > ReferenceError — implicit-global creation + real deletion + unresolved read).
 > **(e)** mapped-arguments delete now **DONE** (2026-07-05, opus-2726: +1 test262
-> `11.4.1-4.a-17`, 0 regressions — see `## Resolution — group (e)`); **(f)**/**(g)**
-> re-route to their owning feature issues. This issue stays open (`status: ready`)
-> for the 2 structural (b) tests — route to architect before further dispatch.
+> `11.4.1-4.a-17`, 0 regressions — see `## Resolution — group (e)`). **(g)**
+> prototype-chain (inherited) delete now **DONE** (2026-07-06, opus-2726fg: +1
+> test262 `S8.12.7_A2_T2`, 0 delete-dir regressions — see `## Resolution — group (g)`).
+> **(f)** (`11.4.1-5-a-27-s` — strict assign to a `preventExtensions`'d object)
+> re-routes to its owning strict-mode/preventExtensions feature issue. This issue
+> stays open (`status: ready`) for the 2 structural (b) tests — route to architect
+> before further dispatch.
 
 # #2726 — delete residual (non-throw) semantics
 
@@ -293,3 +297,45 @@ creation/real-deletion/unresolved-read) and need an architect spec first (NOT
 dev-claimable as-is). (e) mapped-arguments delete → #1726; (f)/(g) re-routed to
 owning feature issues. Stays `ready` for the 2 structural (b) tests — route to
 architect before further dispatch.
+
+## Resolution — group (g) (2026-07-06, opus-2726fg)
+
+**Scope.** `S8.12.7_A2_T2.js` — `delete __palette.red` where `red` is inherited
+from `Palette.prototype`, then the prototype-chain read `__palette.red` must
+still see the inherited value (CHECK#3). (The issue's original "fails at the
+inherited *read* before the delete" note is stale — CHECK#1's initial inherited
+read already passes on current main; the sole remaining failure is CHECK#3, the
+read *after* the delete.)
+
+**Root cause (g).** The WasmGC-struct arm of `__delete_property`
+(`src/runtime.ts`) unconditionally dropped the sidecar/descriptor entries **and
+recorded a tombstone** (`_wasmStructDeletedKeys`) for the key — even when the key
+is not an **own** property of the receiver. For `delete __palette.red`, `red`
+lives only on `Palette.prototype`, so the receiver owns nothing named `red`; the
+spurious tombstone then shadowed the still-present inherited value on the next
+`__palette.red` read (the read consults the tombstone before walking the
+prototype chain), returning `undefined` instead of `0xFF0000`.
+
+**Spec.** ECMA-262 §10.5.7 OrdinaryDelete step 2: `Let desc be
+O.[[GetOwnProperty]](P). If desc is undefined, return true.` — deleting a
+property the receiver does not **own** is a true no-op: return `true`, mutate
+nothing. (The delete still evaluates to `true`, so CHECK#2 was already passing;
+only the erroneous tombstone side-effect had to go.)
+
+**Fix (g).** Guard the struct delete arm with the existing own-property oracle
+`_wasmStructHasOwn(obj, k, exports)`: if the key is **not** own, `return 1`
+immediately without touching sidecar/descriptor/tombstone state. Own keys
+(struct field, sidecar, descriptor, class method) still `hasOwn === true` and
+fall through to the unchanged real delete, so groups (c)/(d)/(e) and every other
+own-delete case are untouched. `src/runtime.ts` (`__delete_property` struct arm).
+
+### Test Results — group (g) (host/gc lane, authoritative `runTest262File`)
+
+| cluster | baseline → fix |
+|---|---|
+| `language/expressions/delete` (full dir, 69 files) | 65 → **66** pass, **0 regressions** |
+
+Net **+1** test262. Flipped fail→pass: `S8.12.7_A2_T2`. The other 3 dir failures
+are unchanged: `11.4.1-5-a-27-s` (group (f), re-routed) and the 2 STRUCTURAL
+group-(b) tests (`S11.4.1_A3.1`, `S11.4.1_A3.3_T1`). Regression test:
+`tests/issue-2726-inherited-delete-noop.test.ts`.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11679,6 +11679,18 @@ assert._isSameValue = isSameValue;
           }
           // WasmGC struct — operate on the sidecar storage.
           const k = typeof key === "symbol" ? key : String(key);
+          // (#2726 g) §10.5.7 OrdinaryDelete step 2: if the receiver has no OWN
+          // property P, [[Delete]] is a true no-op — it must NOT tombstone or
+          // otherwise mutate the receiver. Without this guard, `delete o.p` of a
+          // key that lives only on the prototype chain (e.g. `delete
+          // __palette.red` where `red` is inherited from `Palette.prototype`)
+          // recorded a tombstone on `o`, which then shadowed the still-present
+          // inherited value on the next prototype-chain read (returning
+          // undefined instead of the inherited value). Return true, mutate
+          // nothing. Own properties fall through to the real delete below.
+          if (!_wasmStructHasOwn(obj, k, callbackState?.getExports())) {
+            return 1;
+          }
           // Check the descriptor table for an explicit non-configurable flag.
           const descs = _wasmPropDescs.get(obj);
           if (descs) {

--- a/tests/issue-2726-inherited-delete-noop.test.ts
+++ b/tests/issue-2726-inherited-delete-noop.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2726 group (g) — `delete o.p` where `p` is NOT an own property of `o` is a
+// spec-mandated true no-op.
+//
+// §10.5.7 OrdinaryDelete step 2: `Let desc be O.[[GetOwnProperty]](P); if desc
+// is undefined, return true.` — deleting a property the receiver does not own
+// (it lives only on the prototype chain) must return `true` and mutate nothing.
+//
+// Previously `__delete_property` unconditionally recorded a tombstone on the
+// receiver even when the key was inherited, so the next prototype-chain read of
+// that key returned `undefined` instead of the still-present inherited value
+// (test262 language/expressions/delete/S8.12.7_A2_T2.js CHECK#3 failed; this
+// fix flips it fail→pass, +1 conformance, 0 delete-dir regressions).
+//
+// The body is declared LOCAL to `test()` and compiled with
+// `skipSemanticDiagnostics: true` to mirror the test262 runner's `wrapTest`
+// envelope (the production conformance path).
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source, { skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: Record<string, (...a: unknown[]) => unknown>) => void }).setExports?.(
+    instance.exports as Record<string, (...a: unknown[]) => unknown>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+describe("#2726 (g) delete of an inherited (non-own) property is a true no-op", () => {
+  // Mirrors test262 S8.12.7_A2_T2: delete an inherited property, then the
+  // prototype-chain read must still see it (the delete must NOT tombstone the
+  // instance for a key it does not own).
+  const src = `export function test() {
+    function Palette() {}
+    Palette.prototype = { red: 0xff0000, green: 0x00ff00 };
+    var p = new Palette();
+    if (p.red !== 0xff0000) return 10;        // CHECK#1: inherited read
+    if ((delete p.red) !== true) return 11;   // CHECK#2: delete non-own -> true
+    if (p.red !== 0xff0000) return 12;         // CHECK#3: still inherited (no tombstone)
+    return 1;
+  }`;
+
+  it("delete of an inherited property returns true and does not shadow it (host)", async () => {
+    expect(await run(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves group **(g)** of #2726: `delete o.p` where `p` is **not an own property** of the receiver (it lives only on the prototype chain) must be a spec-mandated true no-op.

**Root cause.** The WasmGC-struct arm of `__delete_property` (`src/runtime.ts`) unconditionally recorded a tombstone (`_wasmStructDeletedKeys`) for the deleted key — even when the key was inherited, not own. That spurious tombstone then shadowed the still-present inherited value on the next prototype-chain read, returning `undefined`.

**Spec.** ECMA-262 §10.5.7 OrdinaryDelete step 2: `Let desc be O.[[GetOwnProperty]](P). If desc is undefined, return true.` — deleting a non-own property returns `true` and mutates nothing.

**Fix.** Guard the struct delete arm with the existing own-property oracle `_wasmStructHasOwn`: non-own keys `return 1` (true) immediately without touching sidecar/descriptor/tombstone state. Own keys (struct field / sidecar / descriptor / class method) still `hasOwn === true` and fall through to the unchanged real delete — groups (c)/(d)/(e) and every other own-delete case are untouched.

## Measured impact (host/gc lane, `runTest262File`)

| cluster | baseline → fix |
|---|---|
| `language/expressions/delete` (69 files) | 65 → **66** pass, **0 regressions** |

Net **+1** test262 (`S8.12.7_A2_T2` flips fail→pass). The remaining 3 dir failures are unchanged: `11.4.1-5-a-27-s` (group (f), re-routed to strict-mode/preventExtensions) and the 2 STRUCTURAL group-(b) tests.

Regression test: `tests/issue-2726-inherited-delete-noop.test.ts`. #2726 stays `ready` for the 2 structural (b) tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)