### PR TITLE
docs(#2955): re-measured IR string-op de-polymorph decomposition (bank)

### DIFF
--- a/plan/issues/2955-ir-string-ops-depolymorph.md
+++ b/plan/issues/2955-ir-string-ops-depolymorph.md
@@ -57,16 +57,16 @@ be implemented twice at IR-build time.
 Measured against `origin/main` @ e29c8c5b2. The five `nativeStrings` reads in
 `from-ast.ts` are **not one uniform "5 abstract string ops" set** (the Approach
 section's op list — `IrInstrStrConcat`/`StrCompare`/… — does not match these
-sites; those ops are already abstract elsewhere). Each read is a *different
-kind* of polymorphism, with a different byte-inert path to lower time:
+sites; those ops are already abstract elsewhere). Each read is a _different
+kind_ of polymorphism, with a different byte-inert path to lower time:
 
-| site | function | polymorphism kind | de-polymorph blocker |
-| ---- | -------- | ----------------- | -------------------- |
-| ~2792 | `coerceToExpectedExtern` | string→externref host-call arg coercion; **native throws (demote)** | native string CANNOT flow into a host-string externref position, so the throw is a **claim/demote decision** — must move to `select.ts` capability (#2135), not lower time. Not byte-inert as a plain "always coerce". |
-| ~2912 | number `.toString()` host import | claims `f64.toString()` **only in host mode** | native has no native number formatter yet; the mode read is a real capability gate. Needs native number-format feature before it can move. |
-| ~3142 | `lowerStringMethodCall` | helper name `__str_X` vs `string_X` + i32/f64 arg reps + native-mode bails + sentinel padding | large mode-specific decision table; a faithful move relocates the whole table (incl. #2002/#1248 special-cases) to `lower.ts`. Own slice. |
-| **3467** | **`coerceYieldValueToExternref`** | **string→externref coercion for generator-yield / iter-host** | **NONE — cleanly byte-inert. DONE in Slice 1.** |
-| ~3603 | `lowerForOfStatement` string arm | native char-loop vs iter-host for-of strategy | both strategies are big loop builders living in from-ast; moving the *selection* to lower time means the lowerer owns both loop builders. Own slice. |
+| site     | function                          | polymorphism kind                                                                             | de-polymorph blocker                                                                                                                                                                                                   |
+| -------- | --------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ~2792    | `coerceToExpectedExtern`          | string→externref host-call arg coercion; **native throws (demote)**                           | native string CANNOT flow into a host-string externref position, so the throw is a **claim/demote decision** — must move to `select.ts` capability (#2135), not lower time. Not byte-inert as a plain "always coerce". |
+| ~2912    | number `.toString()` host import  | claims `f64.toString()` **only in host mode**                                                 | native has no native number formatter yet; the mode read is a real capability gate. Needs native number-format feature before it can move.                                                                             |
+| ~3142    | `lowerStringMethodCall`           | helper name `__str_X` vs `string_X` + i32/f64 arg reps + native-mode bails + sentinel padding | large mode-specific decision table; a faithful move relocates the whole table (incl. #2002/#1248 special-cases) to `lower.ts`. Own slice.                                                                              |
+| **3467** | **`coerceYieldValueToExternref`** | **string→externref coercion for generator-yield / iter-host**                                 | **NONE — cleanly byte-inert. DONE in Slice 1.**                                                                                                                                                                        |
+| ~3603    | `lowerForOfStatement` string arm  | native char-loop vs iter-host for-of strategy                                                 | both strategies are big loop builders living in from-ast; moving the _selection_ to lower time means the lowerer owns both loop builders. Own slice.                                                                   |
 
 ### Slice 1 (landed by this PR) — the coercion-elision site (3467)
 
@@ -86,7 +86,7 @@ elides the convert in host mode and emits it in native mode.
   Elision is dead for existing callers (from-ast guarded every site), so no
   other `coerce.to_externref` site changes.
 - **Validation**: `issue-1374-ir-string-iter-inline`, `issue-1665-standalone-
-  generator-forof` (native-strings `(ref $AnyString)`→convert_any path),
+generator-forof` (native-strings `(ref $AnyString)`→convert_any path),
   `ir-frontend-widening`, `issue-1470-string-iteration-standalone`,
   `issue-2157`/`2162` iterators — 63 tests green.
 
@@ -99,3 +99,59 @@ the method-dispatch table and the for-of strategy builders). This is why the
 issue as a whole is `reasoning_effort: high`, not a uniform refactor. `status`
 stays `ready` — Slice 1 removes one of the five reads and establishes the
 lower-time-resolution pattern the rest follow.
+
+## Re-measured decomposition (2026-07-06, senior-dev, opus-2955)
+
+Measured against `upstream/main` @ `07ad889185`. The Slice-1 table above has
+**drifted** — there are now **7 functional `nativeStrings` reads** in
+`from-ast.ts` (grep `cx.resolver?.nativeStrings?.()` → lines 3233, 3245, 3402,
+3641, 4018, 4124, 5815), and reading each one shows they are **not one
+problem**. They split into two distinct classes the original Approach section
+conflated. This is the corrected map for whoever picks up slices 2+.
+
+| line | function                              | class                                  | what the read gates                                                                                                                                               | why it's not a byte-inert one-liner                                                                                                                                                                                         |
+| ---- | ------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3233 | `coerceToExpectedExtern`              | **string-rep**                         | host-mode string is already externref → return as-is; native string (`(ref $AnyString)`) CANNOT flow into an externref host-arg → falls to the throw (**demote**) | the guard is load-bearing for the native demote; de-polymorph = capability decision → move to `select.ts` (#2135), not lower time                                                                                           |
+| 3245 | `coerceToExpectedExtern`              | **number-box capability** (NOT string) | f64→externref via `__box_number`, **host lane only**; standalone has no `__box_number` (boxes via `$AnyValue`) → demote                                           | `nativeStrings === false` is a **proxy for "JS-host lane has the box helpers"**. De-polymorph = route through a capability query + emit `$AnyValue` boxing in standalone; touches number-boxing → **standalone-floor risk** |
+| 3402 | string→externref coercion arm         | string-rep                             | same host-externref rep assumption                                                                                                                                | abstract-op introduction                                                                                                                                                                                                    |
+| 3641 | `lowerStringMethodCall` (`useNative`) | **string-rep, largest**                | `__str_<m>` native helper vs `string_<m>` host import + i32/f64 arg reps + native bails + sentinel padding (#2002/#1248)                                          | relocates the **entire mode-specific dispatch table** to `lower.ts`. Own slice, biggest.                                                                                                                                    |
+| 4018 | `coerceReturnValue`                   | **number-box capability** (NOT string) | externref→f64 via `__unbox_number`, **host lane only**; standalone demotes                                                                                        | same proxy as 3245; mirror slice (box + unbox move together)                                                                                                                                                                |
+| 4124 | string arm                            | string-rep                             | host-mode string rep                                                                                                                                              | abstract-op introduction                                                                                                                                                                                                    |
+| 5815 | undefined-test on operand             | string-rep                             | host-mode string is externref-shaped → `__extern_is_undefined`; native rep takes the fold path below                                                              | needs an abstract "is-undefined-on-string" IR op that resolves rep at lower time; not a plain guard removal                                                                                                                 |
+
+**Key correction for the next picker:** sites **3245 and 4018 are not string
+polymorphism at all** — they read `nativeStrings === false` only as a stand-in
+for "are we in the JS-host lane that owns `__box_number`/`__unbox_number`?". The
+clean fix for those two is a **capability predicate** (e.g.
+`resolver.hasHostNumberBox?()`), moved together as one mirror slice, and
+validated against the **standalone floor** (not just equivalence) because the
+standalone demote arm is load-bearing. They arguably belong in a separate
+capability-model issue rather than being counted against #2955's string
+de-polymorph.
+
+**Recommended slice order (each its own PR):**
+
+- **Slice 2 — number-box capability (3245 + 4018 together).** Introduce a
+  `resolver.hasHostNumberBox()` capability; from-ast emits an abstract
+  `coerce.f64↔externref` box/unbox op unconditionally; `lower.ts` resolves
+  host-box vs standalone-`$AnyValue`-box vs demote. Byte-inert per mode.
+  **Must validate the standalone floor** (`merge_group`), not just equivalence.
+- **Slice 3 — string-rep coercion sites (3233 + 3402 + 4124).** Following the
+  Slice-1 pattern: abstract string→externref coerce op, lower-time rep
+  resolution; the native demote decision moves to `select.ts` capability
+  (#2135 coordination). Byte-inert per mode.
+- **Slice 4 — undefined-test on string (5815).** New abstract
+  "is-undefined-on-string" IR op; lowerer picks `__extern_is_undefined` (host,
+  externref-shaped) vs the native fold path.
+- **Slice 5 — `lowerStringMethodCall` dispatch table (3641).** Largest;
+  relocate the whole `__str_<m>`/`string_<m>` decision table (incl. #2002/#1248
+  arg-rep + sentinel special-cases) to `lower.ts`. Own slice, do last.
+
+**Why no code slice landed this pass (senior-dev, final-budget):** every
+remaining site requires either an abstract-IR-op introduction (op-union +
+verifier signature + `lower.ts` case + per-mode byte-identity proof over a
+string corpus) or a new capability predicate touching the standalone floor —
+none is a sub-25-min byte-inert land like Slice 1 was (Slice 1 exploited an
+already-abstract `coerce.to_externref` op whose new elision arm was dead for
+all existing callers). Banking this corrected map instead of sinking final
+budget into a half-finished op introduction. `status` stays `ready`.


### PR DESCRIPTION
## What

Doc-only. Re-measures #2955 against `upstream/main` @ `07ad889185` and banks a **corrected decomposition** for the remaining slices. No source/test/behavior change.

## Why

The issue's existing Slice-1 table had drifted. There are now **7 functional `nativeStrings` reads** in `from-ast.ts` (3233, 3245, 3402, 3641, 4018, 4124, 5815), and reading each shows they are **not one problem** — they split into two classes the original Approach conflated:

- **Genuine string-rep polymorphism** (3233 / 3402 / 3641 / 4124 / 5815): native `(ref $AnyString)` vs host externref. Each needs an abstract IR op introduced (op-union + verifier signature + `lower.ts` case).
- **Number-box capability proxies (3245 / 4018)** — *not string ops at all*: `nativeStrings === false` is only a stand-in for "JS-host lane owns `__box_number`/`__unbox_number`; standalone demotes." The clean fix is a capability predicate, and it **touches the standalone floor**, so it must validate on `merge_group`, not just equivalence.

The banked section adds the corrected site map + recommended slice order (2–5) so the next picker doesn't re-derive it.

## Why no code slice this pass

Final-budget senior-dev pass. Every remaining site needs an abstract-IR-op introduction or a capability predicate touching the standalone floor — none is a sub-25-min byte-inert land like Slice 1 was (Slice 1 exploited an already-abstract `coerce.to_externref` op whose new arm was dead for all existing callers). Banking the measured map is the correct outcome over a half-finished op introduction.

## Validation

Doc-only — no compiler surface touched. `status` stays `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8