### PR TITLE
docs(#2787): re-measure diff corpus — 20→9 failing, map remaining to clusters

### DIFF
--- a/plan/issues/2787-differential-test-corpus-failures.md
+++ b/plan/issues/2787-differential-test-corpus-failures.md
@@ -114,6 +114,44 @@ The binary validates but throws during instantiation/execution:
 
 ---
 
+## Re-measure (2026-07-06) — corpus improved 20→9 failing
+
+Re-ran `scripts/diff-test.ts` against current `upstream/main`
+(`07ad889185`). **Current set: 95 match / 7 mismatch / 2 runtime_error /
+0 malformed_wasm** — down from the 20 failing catalogued in the
+2026-06-28 triage below. The following 2026-06-28 entries now **pass** and
+are resolved by intervening work: `builtins/01-json-stringify`,
+`builtins/03-map-set`, `builtins/12-arraybuffer`, `builtins/15-tag-template`,
+`array/11-flat-flatMap`, `control/12-for-in-object`, `object/02-spread`,
+`object/12-assign`, `closures/09-callback`, `classes/10-toString-impl`, and
+`closures/10-mutual` (booleans now render `true`/`false` correctly at the
+`console.log` boundary — the stale "renders as 1" note no longer holds).
+
+**Remaining 9 failing — each maps to an open feature cluster (all
+substrate-level, no cheap localized codegen fix available):**
+
+| program                     | kind          | cluster / target issue                                                                                                    |
+| --------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `builtins/04-symbol`        | mismatch      | #2795 — value→string rendering (`Symbol.prototype.toString`)                                                               |
+| `object/06-delete`          | mismatch      | #2796 — object literal is a fixed nominal struct; `delete o.a` can't drop a struct field (needs dynamic property bag)      |
+| `array/12-from-of`          | mismatch      | #2796 — `Array.from({length:3}, mapFn)` array-like host interop: native `Array.from` reads the wasm struct `.length` as 0 |
+| `closures/07-arrow-this`    | mismatch      | #2797 — arrow lexical `this` via `.call({})` → NaN                                                                         |
+| `builtins/07-promise-basic` | mismatch      | #1042 — Promise `.then` callback never runs                                                                                |
+| `builtins/08-promise-chain` | mismatch      | #1042 — promise chain callbacks never run                                                                                  |
+| `builtins/09-async-await`   | mismatch      | #1042 — `await`/async no-op → empty                                                                                        |
+| `builtins/14-spread-args`   | runtime_error | #2797 — `f(...arr)` / `Math.max(...arr)` illegal cast                                                                      |
+| `closures/08-method-chain`  | runtime_error | #2797 — dynamic method dispatch on returned object literal traps                                                           |
+
+Mechanisms pinned this pass (measure-first): `object/06-delete` — the object
+literal `{a:1,b:2}` lowers to a nominal struct with fixed fields, so
+`__delete_property` cannot remove `a` and `Object.keys` still enumerates it
+(`["a,b","1"]` vs V8 `["b","undefined"]`); `array/12-from-of` — `__array_from`
+(src/runtime.ts) hands the raw wasm array-like struct to native `Array.from`,
+which reads `.length` as 0 (no dynamic-reader bridge for the array-like host
+path). Both are #2796/#2797 substrate items, correctly deferred — no cheap
+floor-visible slice remains in the corpus (the earlier cheap wins — the ANSI
+harness fix and the two `malformed_wasm` cases — already landed).
+
 ## Triage (2026-06-28) — full A/B/C classification + fix plan
 
 Re-ran `scripts/diff-test.ts` against current main. **Current set: 84 match /


### PR DESCRIPTION
## Summary

Measure-first pass on the #2787 differential-test-corpus umbrella. Re-ran `scripts/diff-test.ts` against current `upstream/main` (`07ad889185`): **95 match / 7 mismatch / 2 runtime_error / 0 malformed_wasm** — down from the 20 failing catalogued in the 2026-06-28 triage. 11 previously-failing programs now pass (JSON.stringify, Map/Set, arraybuffer, tag-template, flat/flatMap, for-in, spread, assign, callback, toString-impl, mutual-recursion booleans).

## What this PR does

Doc-only refresh of the umbrella issue: adds a dated current-state section mapping each of the **9 remaining** failures to its open feature cluster (#2795 value→string, #2796 dyn-object bag, #2797 untyped arrow/dispatch, #1042 async/Promise). Satisfies the issue's acceptance criterion 2 (triage each remaining case to a feature issue).

## Mechanisms pinned (measure-first)

- `object/06-delete` — object literal lowers to a **fixed nominal struct**, so `delete o.a` can't drop a field; `Object.keys` still enumerates it (`["a,b","1"]` vs V8 `["b","undefined"]`). → #2796
- `array/12-from-of` — `__array_from` hands the raw wasm array-like struct to native `Array.from`, which reads `.length` as 0 (no dynamic-reader bridge for the array-like host path). → #2796/#2797

No cheap floor-visible codegen slice remains in the corpus — the earlier cheap wins (ANSI harness fix, 2 `malformed_wasm` cases) already landed. Remaining work is substrate-level, correctly deferred to the cluster issues.

**No source touched** — a single doc edit to the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8