### PR TITLE
fix(#2933): standalone JSON.stringify static value read (host-free)

### DIFF
--- a/plan/issues/2933-standalone-namespace-static-value-read.md
+++ b/plan/issues/2933-standalone-namespace-static-value-read.md
@@ -3,7 +3,8 @@ id: 2933
 title: "Standalone: Math/JSON/Reflect/Atomics namespace static VALUE reads refuse — fold constants / native static-method closures"
 status: ready
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-06
+assignee: ttraenkler/opus-2933
 priority: medium
 feasibility: medium
 task_type: feature
@@ -138,6 +139,50 @@ scope-boundary refusal assertions). `tsc --noEmit` + `biome` clean; existing
    variadic-closure support. Recommended to split into its own follow-up.
 3. `Reflect.ownKeys(o).length` reflective-read-of-result and `globalThis.Math.PI`
    (niche trap) also remain.
+
+## Progress (2026-07-06, opus-2933) — JSON.stringify value read landed
+
+Sub-part 1's remaining `JSON.stringify` value read now works host-free under
+`--target standalone`. `const f: any = JSON.stringify; f({a:1})` previously
+refused with the `#1907`/`#1888 S6-b` "built-in static property value read is not
+supported" compile error; it now reifies a native static-method closure that
+serialises via the existing 1-arg native `__json_stringify_root`
+(`anyref -> ref $AnyString`, `json-codec-native.ts`) — the SAME entry the direct
+`JSON.stringify(o)` call path uses.
+
+**Mechanism** — added a `JSON.stringify` case to
+`ensureStandaloneBuiltinStaticMethodClosure` (`src/codegen/property-access.ts`)
++ `STANDALONE_STATIC_METHOD_META` (`src/codegen/builtin-fn-meta.ts`). The value
+closure is fixed 1-arg (externref value in): `local.get; any.convert_extern;
+call __json_stringify_root; extern.convert_any`. It calls `emitJsonStringifyValue`
+(idempotent) to register the codec, then boxes the `$AnyString` result back to
+externref at the any-call boundary. Standalone-gated; identity is singleton-stable
+via `pushBuiltinFnSingletonValueInstrs` (#2963). Objects / numbers / strings /
+nested objects serialise correctly and reify **zero host imports** (a
+standalone-floor-visible CE-to-run flip).
+
+**Known limitation (inherited, NOT a regression):** an array reaching the closure
+through `any`-boxing serialises to `"null"` — but this is the SAME pre-existing
+substrate gap the DIRECT `const x:any=[1,2,3]; JSON.stringify(x)` path already
+has on main (verified). The closure is observationally identical to that direct
+any-path, so it introduces no new divergence; the top-level any-boxed-array gap
+belongs to the separate $Object/array dynamic-reader substrate work. Replacer /
+space args remain out of scope (matching the standalone call-path narrowing).
+
+Covered by `tests/issue-2933-json-stringify-value.test.ts` (9 cases) + the
+`JSON.stringify`-refusal assertion in
+`tests/issue-2933-reflect-static-method-value.test.ts` retargeted to the new
+"now works" behaviour. `tsc --noEmit` + prettier clean; `#2933` / reflect suites
+green.
+
+**Remaining (this issue stays open):**
+
+1. `Math.max` / `Math.min` **as a value** — genuinely VARIADIC (value-closures
+   are fixed-arity); needs variadic-closure support. Split follow-up.
+2. Top-level `any`-boxed **array** → JSON.stringify serialises `"null"`
+   (substrate: $Object/array dynamic reader) — shared with the direct any-path,
+   tracked separately.
+3. `globalThis.Math.PI` still TRAPs (niche).
 
 ## Notes
 

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -56,6 +56,13 @@ export const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; lengt
   "Reflect.has": { name: "has", length: 2 },
   "Reflect.set": { name: "set", length: 3 },
   "Reflect.ownKeys": { name: "ownKeys", length: 1 },
+  // (#2933) JSON.stringify as a VALUE — the fixed 1-arg compact form. The value
+  // closure serialises via the native `__json_stringify_root` (host-free), the
+  // SAME entry the direct `JSON.stringify(o)` call path uses. Spec `.length` is
+  // 3 (value, replacer, space); the host-free closure supports only the leading
+  // value arg (replacer/space out of scope, matching the standalone call-path
+  // narrowing), but `.length` reports the spec arity.
+  "JSON.stringify": { name: "stringify", length: 3 },
 };
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -54,6 +54,7 @@ import {
   typedArrayPackedSignedness,
   typedArrayVecStorage,
 } from "./index.js";
+import { emitJsonStringifyValue } from "./json-codec-native.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
 import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
@@ -1297,6 +1298,15 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       paramTypes = [{ kind: "externref" }];
       returnType = { kind: "externref" };
       break;
+    // (#2933) JSON.stringify as a VALUE — fixed 1-arg compact form. Serialises
+    // host-free via the native `__json_stringify_root` (the SAME entry the
+    // direct `JSON.stringify(o)` call uses); returns the JSON `$AnyString`
+    // coerced to an externref at the any-call boundary. Replacer/space args are
+    // out of scope (matching the standalone call-path narrowing).
+    case "JSON.stringify":
+      paramTypes = [{ kind: "externref" }];
+      returnType = { kind: "externref" };
+      break;
     default:
       return null;
   }
@@ -1378,6 +1388,25 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       if (idx === undefined) return null;
       closureFctx.body.push({ op: "local.get", index: 1 });
       closureFctx.body.push({ op: "call", funcIdx: idx });
+    } else if (key === "JSON.stringify") {
+      // Ensure the native codec (`__json_stringify_value` + its 1-arg entry
+      // `__json_stringify_root`, `anyref -> ref $AnyString`) is registered; the
+      // helper is idempotent. The value arg reaches the closure as an externref
+      // (any-boundary); recover the internal ref (`any.convert_extern`), call
+      // root, then box the `$AnyString` result back to externref for the
+      // fixed-arity value-closure return — same coercion the call path applies.
+      // OBSERVATIONALLY IDENTICAL to the direct `JSON.stringify(anyVar)` path:
+      // objects/numbers/strings serialise correctly; an array reaching this via
+      // `any`-boxing inherits the SAME pre-existing substrate limitation the
+      // direct any-path has (top-level any-boxed array → "null"), so the closure
+      // introduces no new divergence — it is not a fresh correctness landmine.
+      emitJsonStringifyValue(ctx);
+      const rootIdx = ctx.funcMap.get("__json_stringify_root");
+      if (rootIdx === undefined) return null;
+      closureFctx.body.push({ op: "local.get", index: 1 });
+      closureFctx.body.push({ op: "any.convert_extern" } as Instr);
+      closureFctx.body.push({ op: "call", funcIdx: rootIdx });
+      closureFctx.body.push({ op: "extern.convert_any" } as Instr);
     }
 
     funcIdx = mintDefinedFunc(ctx);

--- a/tests/issue-2933-json-stringify-value.test.ts
+++ b/tests/issue-2933-json-stringify-value.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2933 — standalone `JSON.stringify` as a VALUE (fixed 1-arg compact form).
+//
+// Reading `JSON.stringify` AS A VALUE under `--target standalone`
+// (`const f: any = JSON.stringify; f({a:1})`) previously refused with the
+// `#1907`/`#1888 S6-b` "built-in static property value read is not supported"
+// compile error. The standalone CALL path already serialises host-free via the
+// native `__json_stringify_root` (`anyref -> ref $AnyString`); this slice wires
+// that SAME entry into `ensureStandaloneBuiltinStaticMethodClosure` so the
+// reified value calls identically. Objects/numbers/strings serialise correctly;
+// an array reaching the closure through `any`-boxing inherits the SAME
+// pre-existing substrate limitation the direct `JSON.stringify(anyVar)` path
+// has (top-level any-boxed array -> "null") — the closure adds no new divergence.
+//
+// The value read reifies zero host imports (asserted below), so it is a
+// standalone-floor-visible flip: CE (refusal) -> runs and returns the JSON
+// string.
+
+async function lenStandalone(body: string): Promise<number> {
+  const r = await compile(`export function test(): number { ${body} }`, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No host imports — pure standalone Wasm.
+  expect((r.imports ?? []).map((i) => `${i.module}::${i.name}`).filter((l) => l.startsWith("env::"))).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function idStandalone(body: string): Promise<number> {
+  // nativeStrings harness (matches #2963) for identity / ref-equality checks —
+  // reads keep their inferred builtin-fn ref type (no `any`-boxing, which would
+  // round-trip through externref and defeat ref identity).
+  const r = await compile(`export function test(): number { ${body} }`, {
+    target: "standalone",
+    nativeStrings: true,
+  });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function compilesHost(body: string): Promise<void> {
+  // Sanity that the SAME read under gc/host still compiles (dual-mode intact).
+  const r = await compile(`export function test(): string { ${body} }`, {});
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+}
+
+describe("#2933 — standalone JSON.stringify static value read", () => {
+  it("JSON.stringify as a value serialises an object (was a compile refusal)", async () => {
+    // {"a":1} -> 7 chars.
+    expect(await lenStandalone(`const f: any = JSON.stringify; const s: string = f({ a: 1 }); return s.length;`)).toBe(
+      7,
+    );
+  });
+
+  it("value read produces the SAME string as the direct call", async () => {
+    // First char '{' === 123.
+    expect(
+      await lenStandalone(`const f: any = JSON.stringify; const s: string = f({ a: 1 }); return s.charCodeAt(0);`),
+    ).toBe(123);
+  });
+
+  it("serialises a nested object", async () => {
+    // {"a":{"b":2}} -> 13 chars.
+    expect(
+      await lenStandalone(`const f: any = JSON.stringify; const s: string = f({ a: { b: 2 } }); return s.length;`),
+    ).toBe(13);
+  });
+
+  it("serialises a number argument", async () => {
+    // "42" -> 2 chars.
+    expect(await lenStandalone(`const f: any = JSON.stringify; const s: string = f(42); return s.length;`)).toBe(2);
+  });
+
+  it("serialises a string argument (quotes added)", async () => {
+    // '"hi"' -> 4 chars.
+    expect(await lenStandalone(`const f: any = JSON.stringify; const s: string = f("hi"); return s.length;`)).toBe(4);
+  });
+
+  it("identity is singleton-stable (=== holds across reads)", async () => {
+    // Inferred typing keeps the builtin-fn ref (no `any`-boxing) so `===` is a
+    // ref compare against the module-level singleton (#2963).
+    expect(await idStandalone(`const a = JSON.stringify, b = JSON.stringify; return a === b ? 1 : 0;`)).toBe(1);
+  });
+
+  it("the reified value is distinct from a different builtin static method", async () => {
+    expect(await idStandalone(`const a: any = JSON.stringify, b: any = Reflect.get; return a === b ? 1 : 0;`)).toBe(0);
+  });
+
+  it("does not disturb the direct JSON.stringify call path", async () => {
+    // {"a":1} -> 7 chars via the direct call (regression guard).
+    expect(await lenStandalone(`const s: string = JSON.stringify({ a: 1 }); return s.length;`)).toBe(7);
+  });
+
+  it("host mode still compiles the value read (dual-mode intact)", async () => {
+    await compilesHost(`const f: any = JSON.stringify; return f({ a: 1 });`);
+  });
+});

--- a/tests/issue-2933-reflect-static-method-value.test.ts
+++ b/tests/issue-2933-reflect-static-method-value.test.ts
@@ -11,9 +11,10 @@ import { compile } from "../src/index.js";
 // `Reflect.get`/`has`/`set`/`ownKeys` with a simple externref/i32 native
 // (`__extern_get` / `__extern_has` / `__reflect_set` / `__object_keys`); this
 // slice wires those SAME natives into `ensureStandaloneBuiltinStaticMethodClosure`
-// so the reified value calls identically. The variadic (`Math.max`) and
-// native-`$AnyValue`-return (`JSON.stringify`) methods stay refused (need
-// variadic / anyref-boundary closure work — tracked on #2933's remaining scope).
+// so the reified value calls identically. `JSON.stringify` as a value now works
+// too (host-free via `__json_stringify_root` — see
+// issue-2933-json-stringify-value.test.ts). The variadic `Math.max` value read
+// stays refused (needs variadic-closure work — split follow-up on #2933).
 
 async function runStandalone(body: string): Promise<number> {
   const r = await compile(`export function test(): number { ${body} }`, { target: "standalone" });
@@ -80,16 +81,9 @@ describe("#2933 — standalone Reflect.* static-method value reads", () => {
 });
 
 describe("#2933 — deferred namespace static-method value reads still refuse (scope boundary)", () => {
-  it("JSON.stringify as a value still refuses (needs anyref-boundary closure)", async () => {
-    const r = await compile(
-      `export function test(): number { const f: any = JSON.stringify; return f({ a: 1 }) ? 1 : 0; }`,
-      {
-        target: "standalone",
-      },
-    );
-    expect(r.success).toBe(false);
-    expect(r.errors.map((e) => e.message).join("\n")).toContain("JSON.stringify");
-  });
+  // (JSON.stringify as a value now WORKS host-free — moved to
+  // issue-2933-json-stringify-value.test.ts. Only the variadic Math.max value
+  // read remains refused below.)
 
   it("Math.max as a value still refuses (variadic — split follow-up)", async () => {
     const r = await compile(`export function test(): number { const g: any = Math.max; return g(1, 2, 3); }`, {


### PR DESCRIPTION
## Summary

Reading `JSON.stringify` **as a VALUE** under `--target standalone`
(`const f: any = JSON.stringify; f({a:1})`) previously refused with the
`#1907`/`#1888 S6-b` "built-in static property value read is not supported"
compile error. It now reifies a native static-method closure that serialises
host-free via the existing 1-arg native `__json_stringify_root`
(`anyref -> ref $AnyString`) — the **same** entry the direct `JSON.stringify(o)`
call path uses, so the value form is observationally identical.

Split-out remaining sub-part of umbrella #2933 (follows the landed reflective
numeric-read + fixed-arity `Reflect.*` value-closure slices).

## Mechanism

- `JSON.stringify` case added to `ensureStandaloneBuiltinStaticMethodClosure`
  (`src/codegen/property-access.ts`) + `STANDALONE_STATIC_METHOD_META`
  (`src/codegen/builtin-fn-meta.ts`).
- Fixed-1-arg closure body: `local.get; any.convert_extern;
  call __json_stringify_root; extern.convert_any`. Calls the idempotent
  `emitJsonStringifyValue` to register the codec, then boxes the `$AnyString`
  result to externref at the any-call boundary.
- Standalone-gated (host/gc untouched); identity singleton-stable (#2963).

## Measured (current main, `--target standalone`)

- Before: `const f:any = JSON.stringify; f({a:1})` → **CE** (refusal).
- After: serialises objects / numbers / strings / nested objects correctly,
  **zero host imports** — a standalone-floor-visible **CE→run** flip.

## Known inherited limitation (NOT a regression)

A top-level `any`-boxed **array** serialises to `"null"` — but this is the
**same pre-existing substrate gap** the direct
`const x:any=[1,2,3]; JSON.stringify(x)` path already has on main (verified).
The closure is observationally identical to that direct any-path, so it adds no
new divergence; the array gap belongs to the separate $Object/array
dynamic-reader substrate work. `Math.max` (variadic) and `globalThis.Math.PI`
(niche trap) remain, tracked on #2933 (issue stays open).

## Tests

- `tests/issue-2933-json-stringify-value.test.ts` — 9 cases (object/number/
  string/nested serialisation, host-import-free assertion, singleton identity,
  distinct-method inequality, direct-call regression guard, host dual-mode).
- Retargeted the stale `JSON.stringify`-refusal assertion in
  `tests/issue-2933-reflect-static-method-value.test.ts` to the new "now works"
  behaviour (Math.max refusal kept).
- `tsc --noEmit` + prettier clean; `#2933` / reflect / reflective suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8