### PR TITLE
chore(#2097): re-seed standalone high-water to honest 19210 (post #3055 admin-merge) — unblocks queue

### DIFF
--- a/benchmarks/results/test262-standalone-highwater.json
+++ b/benchmarks/results/test262-standalone-highwater.json
@@ -1,9 +1,10 @@
 {
-  "pass": 21188,
-  "host_free_pass": 21188,
+  "pass": 19210,
+  "host_free_pass": 19210,
   "official_pass": 20819,
   "official_total": 43106,
   "sha": "f20fb32f0265d719495e941a0a345a03a5caf252",
   "generated_at": "2026-07-06T02:31:53Z",
-  "tolerance": 50
+  "tolerance": 50,
+  "note": "Honest re-baseline after #3055/#2757 (numeric any-eq de-vacuification) admin-merged; host_free_pass 21188->19210 (-1978, intentional). Next promote --update re-seeds exactly. See #3056/#2097."
 }


### PR DESCRIPTION
**Unblocks the merge queue.** #3055/#2757 (honest numeric any-equality; de-vacuifies numeric asserts) was admin-merged, intentionally dropping standalone host_free_pass **21188 → 19210** (−1978, 0 collateral). The committed high-water was stale-high, so the required **#2097 high-water floor** (merge shard reports) now FAILS on main and parks every subsequent **code** PR (#2764, #2751 already blocked; doc PRs skip the shards, which is why main still advanced).

This re-seeds the committed mark to the honest measured floor **19210** (exact value from failed run 28766341905: `current pass=19210, mark=21188`). Data-only; the next successful `promote-baseline --update` regenerates all fields precisely and re-seeds the external #1897 baseline. See #3056 for the full honest-re-baseline record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)