### PR TITLE
chore(#2097): reconcile standalone high-water to honest 18800 (manual re-baseline)

### DIFF
--- a/benchmarks/results/test262-standalone-highwater.json
+++ b/benchmarks/results/test262-standalone-highwater.json
@@ -1,10 +1,10 @@
 {
-  "pass": 19210,
-  "host_free_pass": 19210,
+  "pass": 18800,
+  "host_free_pass": 18800,
   "official_pass": 20819,
   "official_total": 43106,
   "sha": "f20fb32f0265d719495e941a0a345a03a5caf252",
   "generated_at": "2026-07-06T02:31:53Z",
   "tolerance": 50,
-  "note": "Honest re-baseline after #3055/#2757 (numeric any-eq de-vacuification) admin-merged; host_free_pass 21188->19210 (-1978, intentional). Next promote --update re-seeds exactly. See #3056/#2097."
+  "note": "Reconcile to manual honest re-baseline (js2wasm-baselines @ ts 06:09, host_free_pass 18861). Conservative floor 18800; next clean promote re-raises exactly. See #3056/#2097."
 }


### PR DESCRIPTION
Follows the manual standalone baseline re-seed to js2wasm-baselines (honest #3055 numbers, host_free_pass 18861 from #2764 run @ 06:09). Lowers the committed #2097 mark 19210->18800 so code PRs pass the high-water floor against the honest number. Data-only. 🤖