### PR TITLE
fix(#3071): landing page prefers same-origin test262 report (avoid raw.githubusercontent 429)

### DIFF
--- a/plan/issues/3071-landing-429-same-origin-test262-report.md
+++ b/plan/issues/3071-landing-429-same-origin-test262-report.md
@@ -1,0 +1,62 @@
+---
+id: 3071
+title: "Landing page hammers rate-limited raw.githubusercontent for test262 baseline (429) — prefer same-origin"
+status: done
+sprint: current
+priority: high
+horizon: s
+assignee: ttraenkler/agent-afc849ea5d2483a25
+completed: 2026-07-06
+---
+
+## Problem
+
+The landing page (`website/index.html`) fetches the test262 baseline JSON
+DIRECTLY from `https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/...`
+at five sites. `raw.githubusercontent.com` rate-limits and returns HTTP 429
+("Failed to load resource: 429") under normal visitor traffic, which
+intermittently breaks the conformance donut / headline stats.
+
+Identical, equally-fresh same-origin copies are already deployed to the Pages
+site:
+- JS-host: `./benchmarks/results/test262-report.json` (schema identical to the
+  raw `test262-current.json`: `summary`, `full_summary`, `strict_summary`,
+  `scope_summaries`, `categories`).
+- standalone: `./benchmarks/results/test262-standalone-report.json` (already a
+  fallback today).
+
+## Fix
+
+Fetch the same-origin copy FIRST at all five sites; keep the raw
+`raw.githubusercontent.com` URL as a resilience fallback everywhere.
+
+Sites changed in `website/index.html`:
+1. `<t262-donut src=...>` markup attribute → `./benchmarks/results/test262-report.json`.
+2. `hydrateCompatibilityStat` fetch → shared `fetchTest262ReportJson()` helper (same-origin first, raw fallback).
+3. `STANDALONE_TEST262_REPORT_URLS` array reordered so the same-origin standalone report is first, raw is fallback.
+4. Main JS-host donut fetch → `fetchTest262ReportJson()`.
+5. `hydrateFeatureCoverage` fetch → `fetchTest262ReportJson()`.
+
+A single shared helper `fetchTest262ReportJson(urls = JSHOST_TEST262_REPORT_URLS)`
+is defined at the top of the page's main `<script>` and tries the URLs in order,
+returning the first `ok` JSON and throwing only if all fail. URLs stay relative
+(`./benchmarks/results/...`) so they resolve against the dynamic `<base href>`
+(loopdive.github.io/js2wasm vs js2.loopdive.com vs local dev).
+
+## Freshness
+
+`test262-report.json` does NOT go stale: `.github/workflows/deploy-pages.yml`
+(the "materialize baselines" step) sparse-clones `loopdive/js2wasm-baselines`
+and copies `test262-current.json` → `website/public/benchmarks/results/test262-report.json`
+on every Pages deploy — the SAME source the raw URL points at.
+`scripts/build-pages.js` then copies it into the Pages dist. So the same-origin
+copy is regenerated from the identical baseline on each deploy; preferring it
+over the raw URL changes only the fetch host, not the data.
+
+## Validation
+
+- Same-origin 200 → primary path renders donut from `test262-report.json`.
+- Same-origin 404/network error → helper falls through to raw
+  `test262-current.json`; standalone loop falls through to the raw standalone URL.
+- `grep raw.githubusercontent.com website/index.html` → only the two fallback
+  occurrences remain (JS-host helper + standalone array); no bare raw fetch.

--- a/website/index.html
+++ b/website/index.html
@@ -1683,7 +1683,7 @@
           <div class="diagram-panel">
             <div id="conformance-donut-slot">
               <t262-donut
-                src="https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json"
+                src="./benchmarks/results/test262-report.json"
                 style="--t262-bg: var(--bg, #060a14)"
               ></t262-donut>
             </div>
@@ -4261,6 +4261,35 @@ console.log(instance.exports.run()); // &rarr; 55</pre
     <script src="./components/trend-chart.js"></script>
 
     <script>
+      // #3071 — Prefer the same-origin deployed copy of the JS-host test262
+      // report over raw.githubusercontent.com, which rate-limits (HTTP 429)
+      // under normal visitor traffic and intermittently broke the conformance
+      // donut. `./benchmarks/results/test262-report.json` is deployed to the
+      // Pages site with an identical schema; the raw baseline URL stays as a
+      // resilience fallback for the case where the same-origin file is missing
+      // from a build. URLs stay relative so they resolve against the dynamic
+      // <base href> (loopdive.github.io/js2wasm vs js2.loopdive.com vs local).
+      const JSHOST_TEST262_REPORT_URLS = [
+        "./benchmarks/results/test262-report.json",
+        "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",
+      ];
+      const fetchTest262ReportJson = async (urls = JSHOST_TEST262_REPORT_URLS) => {
+        let lastErr;
+        for (const url of urls) {
+          try {
+            const resp = await fetch(url);
+            if (!resp.ok) {
+              lastErr = new Error(`unavailable (${resp.status}): ${url}`);
+              continue;
+            }
+            return await resp.json();
+          } catch (err) {
+            lastErr = err;
+          }
+        }
+        throw lastErr ?? new Error("no test262 report URL available");
+      };
+
       (function hydrateFaqAccordions() {
         const items = document.querySelectorAll(".approach-faq details");
         if (!items.length) return;
@@ -4835,11 +4864,8 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         if (!rateEl || !labelEl) return;
         try {
           if (window.__conformanceHeadlineHydrated) return;
-          const resp = await fetch(
-            "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",
-          );
-          if (!resp.ok) return;
-          const report = await resp.json();
+          // #3071 — same-origin first, raw.githubusercontent fallback.
+          const report = await fetchTest262ReportJson();
           if (window.__conformanceHeadlineHydrated) return;
           // Use strict-mode summary (tests compatible with ES modules) when available
           const s = report?.strict_summary ?? report?.summary;
@@ -5077,9 +5103,11 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const rateLabelEl = document.getElementById("compat-pass-rate-label");
         if (!donutSlot || !(editionTimeline instanceof HTMLElement)) return;
 
+        // #3071 — same-origin first to avoid raw.githubusercontent 429s; the
+        // raw baseline URL stays as a resilience fallback.
         const STANDALONE_TEST262_REPORT_URLS = [
-          "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
           "./benchmarks/results/test262-standalone-report.json",
+          "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
         ];
         const donutStyle = "--t262-bg: var(--bg, #060a14)";
         const renderDonut = (summary, captionMain = "ECMAScript", captionSub = "conformance") => {
@@ -5348,12 +5376,8 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         };
 
         try {
-          const reportResp = await fetch(
-            "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",
-          );
-          if (!reportResp.ok) throw new Error("conformance data unavailable");
-
-          const report = await reportResp.json();
+          // #3071 — same-origin first, raw.githubusercontent fallback.
+          const report = await fetchTest262ReportJson();
           const overallSummary = report?.summary;
           if (!overallSummary) throw new Error("overall summary unavailable");
 
@@ -5748,11 +5772,8 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const labelEl = document.getElementById("feature-coverage-label");
         if (!coverageEl || !labelEl) return;
         try {
-          const resp = await fetch(
-            "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json",
-          );
-          if (!resp.ok) return;
-          const report = await resp.json();
+          // #3071 — same-origin first, raw.githubusercontent fallback.
+          const report = await fetchTest262ReportJson();
           const categories = report?.categories;
           if (!Array.isArray(categories) || categories.length === 0) return;
 


### PR DESCRIPTION
## Problem

The landing page (`website/index.html`) fetched the test262 baseline JSON DIRECTLY from `raw.githubusercontent.com/loopdive/js2wasm-baselines` at **five sites**. That host rate-limits and returns HTTP 429 ("Failed to load resource: 429") under normal visitor traffic, intermittently breaking the conformance donut / headline stats.

## Fix

Prefer the identical, equally-fresh **same-origin** deployed copies; keep the raw URL as a resilience fallback everywhere.

Five sites changed in `website/index.html`:
1. `<t262-donut src=...>` markup attribute → `./benchmarks/results/test262-report.json`
2. `hydrateCompatibilityStat` fetch → shared `fetchTest262ReportJson()` (same-origin first, raw fallback)
3. `STANDALONE_TEST262_REPORT_URLS` array reordered so same-origin standalone report is first, raw fallback second
4. Main JS-host donut fetch → `fetchTest262ReportJson()`
5. `hydrateFeatureCoverage` fetch → `fetchTest262ReportJson()`

A single shared helper `fetchTest262ReportJson(urls = JSHOST_TEST262_REPORT_URLS)` at the top of the page's main `<script>` tries the URLs in order and returns the first `ok` JSON, throwing only if all fail. The existing `catch` blocks already keep the build-time fallback when the report is unavailable.

URLs stay **relative** (`./benchmarks/results/...`) so they resolve against the dynamic `<base href>` (loopdive.github.io/js2wasm vs js2.loopdive.com vs local dev) — no hardcoded absolute host.

## Freshness (won't go stale)

`.github/workflows/deploy-pages.yml` sparse-clones `loopdive/js2wasm-baselines` and copies `test262-current.json` → `website/public/benchmarks/results/test262-report.json` on **every Pages deploy** — the same source the raw URL points at. `scripts/build-pages.js` then copies it into the Pages dist. So the same-origin copy is regenerated from the identical baseline on each deploy; this PR changes only the fetch host, not the data.

## Validation

- Same-origin 200 → primary path renders donut from `test262-report.json`.
- Same-origin 404 / network error → helper falls through to raw `test262-current.json`; standalone loop falls through to the raw standalone URL.
- `grep raw.githubusercontent.com website/index.html` → only two fallback occurrences remain (JS-host helper array + standalone array); no bare raw fetch.

Closes #3071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)