### PR TITLE
fix(#3072): align donut orbit labels with ring; unclip mobile glow

### DIFF
--- a/plan/issues/3072-donut-orbit-label-align.md
+++ b/plan/issues/3072-donut-orbit-label-align.md
@@ -1,0 +1,94 @@
+---
+id: 3072
+title: "Fix <t262-donut> layout: orbit labels too high (desktop), glow clipped (mobile), legend centering"
+status: done
+assignee: ttraenkler/donut-layout
+sprint: current
+created: 2026-07-06
+updated: 2026-07-06
+completed: 2026-07-06
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: low
+task_type: chore
+area: website
+language_feature: n/a
+goal: developer-experience
+---
+
+# #3072 — `<t262-donut>` layout fixes
+
+Three CSS/layout issues in the `<t262-donut>` web component
+(`website/components/t262-charts.js`), reported by the project lead viewing the
+live site (landing page + report page).
+
+## Problems
+
+- **(A) — MOST IMPORTANT.** On desktop the orbit labels (Passed / Failed /
+  Compile Errors / Skipped) sit slightly TOO HIGH and don't align with the
+  donut ring.
+- **(B).** On mobile the donut's glow is clipped at the bottom.
+- **(C).** On desktop the "legend" looks offset — but on desktop the legend is
+  `display:none` and the orbit-stats ARE the labels, so (C) is the same vertical
+  offset as (A). Also sanity-check the `<440px` legend centering.
+
+## Root cause (A)
+
+The orbit-stat labels are positioned as children of `.gauge-orbit` with inline
+`left:50%;top:50%` plus `transform: translate(calc(-50% + labelDx), calc(-50% +
+labelDy))`, where `labelDy = lp.y - centerY = sin(angle)*radius` (the `centerY`
+constant CANCELS in the delta). So the labels orbit the geometric center of
+`.gauge-orbit` (its 50%,50% = y=190). BUT the ring does NOT sit at that center:
+`.gauge-core { inset: 45px 0 0 }` pushes the ring DOWN by half the top inset
+(≈22.5px) → ring center is at y=212.5, not 190. Net: labels orbit ~22.5px above
+the ring → "too high". The stale comment/`centerX,centerY` constants still
+described the old 380×320 geometry (`centerY=182`) after the box grew to
+380×380.
+
+## Root cause (B)
+
+On `@media (max-width:440px)` the orbit box is 280px tall (300px padding box,
+height 280 + padding-top 20) with orbit-stats hidden. But `.gauge-core` still
+carried the 45px top inset, so the 250px ring centered at y=172.5 (bottom at
+297.5). The `.gauge-glow` (`inset:-8px` + `blur(6px)`, ≈14px bleed) reached
+~311px — past the 300px box — and was clipped by `:host { overflow: clip }`.
+
+## Fix
+
+- Introduced a single source of truth: `--_donut-top-inset: 45px` on `:host`,
+  used BOTH by `.gauge-core { inset: var(--_donut-top-inset) 0 0 }` AND by the
+  orbit-stat anchor.
+- (A) Orbit-stat inline `top:50%` → `top: calc(50% + (var(--_donut-top-inset) /
+  2))` (190 + 22.5 = 212.5 = ring center). `left:50%` unchanged (ring is already
+  horizontally centered). Updated the stale comment + `centerY` (182 → 212.5) so
+  the constants match the real ring center (they feed collision detection via
+  absolute `lp` positions).
+- (B) Inside the mobile media query, override `.gauge-orbit {
+  --_donut-top-inset: 0px }`. Orbit labels are hidden on mobile, so the inset is
+  unneeded; zeroing it centers the 250px ring in the 300px box (~25px above and
+  below), so the ≈14px glow bleed renders fully instead of being clipped. Scoped
+  to the media query — desktop overflow protection is untouched.
+- (C) On desktop, (A)'s fix resolves the perceived "legend offset" (legend is
+  `display:none` ≥440px; orbit-stats are the labels). For `<440px`, constrained
+  `.legend` to `max-width:320px` + `margin-inline:auto` so the two-column legend
+  centers under the donut instead of stretching the full host width.
+
+## Geometric justification (A)
+
+`.gauge-orbit` padding box = height 360 + padding-top 20 = 380 tall; width 380.
+- Orbit anchor: `left:50%` = 190; `top: calc(50% + topInset/2)` = 190 + 22.5 =
+  212.5.
+- Ring center: `.gauge-core` top = 45, bottom = 0 → height 335 → 250px ring
+  centered at 45 + 335/2 = **212.5**.
+- Anchor (190, 212.5) == ring center (190, 212.5), and `centerX,centerY` =
+  (190, 212.5) == anchor, so each label's delta `(lp - center)` lands it exactly
+  on its computed orbit point on the ring.
+
+## Verification
+
+- `node --check` passes; `tests/issue-1777.test.ts` (the module's unit tests)
+  pass.
+- No browser in the container → pixel-level visual confirmation is deferred to
+  the deployed site (lead to eyeball desktop + mobile after deploy). Correctness
+  argued geometrically above.

--- a/website/components/t262-charts.js
+++ b/website/components/t262-charts.js
@@ -199,11 +199,18 @@ class T262Donut extends HTMLElement {
     const failDeg = passDeg + (fail / totalSafe) * 360;
     const ceDeg = failDeg + (ce / totalSafe) * 360;
 
-    // Orbit stats — positioned around the donut
-    // Container is 380x320, .gauge-core has inset: 45px 0 0 (height 275px from y=45)
-    // gauge-wrap is 250x250 centered in gauge-core, so donut center y = 45 + (275-250)/2 + 125 = 182.5
+    // Orbit stats — positioned around the donut.
+    // .gauge-orbit padding box is 380 wide × 380 tall (height:360 + padding-top:20).
+    // .gauge-core has inset: var(--_donut-top-inset)=45px 0 0, so it spans y=45..380
+    // (height 335); the 250px .gauge-wrap is centered in it → donut center
+    // y = 45 + 335/2 = 212.5. Horizontally the ring is centered → center x = 190.
+    // NOTE: these constants MUST match the orbit-stat anchor
+    // (left:50% = 190, top: calc(50% + topInset/2) = 190 + 22.5 = 212.5) so the
+    // label deltas (lp - center) land each label exactly on its computed point.
+    // They also feed collision detection via the absolute lp positions, so keep
+    // them consistent with the real ring center.
     const centerX = 190;
-    const centerY = 182;
+    const centerY = 212.5;
     const orbitPoint = (angle, radius) => {
       const rad = ((angle - 90) * Math.PI) / 180;
       return { x: centerX + Math.cos(rad) * radius, y: centerY + Math.sin(rad) * radius };
@@ -244,7 +251,7 @@ class T262Donut extends HTMLElement {
       const labelDx = lp.x - centerX;
       const labelDy = lp.y - centerY;
       return `
-        <div class="orbit-stat" style="left:50%;top:50%;transform:translate(calc(-50% + ${labelDx}px), calc(-50% + ${labelDy}px))">
+        <div class="orbit-stat" style="left:50%;top:calc(50% + (var(--_donut-top-inset) / 2));transform:translate(calc(-50% + ${labelDx}px), calc(-50% + ${labelDy}px))">
           <div class="orbit-value"${dataAttr} style="color:${color}">${id === "pass" ? "0" : Number(value).toLocaleString()}</div>
           <div class="orbit-label">${label}</div>
         </div>`;
@@ -277,6 +284,14 @@ class T262Donut extends HTMLElement {
           --_text: var(--t262-text, currentColor);
           --_text-muted: var(--t262-text-muted, rgba(139, 148, 158, 1));
           --_bg: var(--t262-bg, #0d1117);
+          /* Single source of truth for the donut's top inset. Used BOTH by
+             .gauge-core (which pushes the ring down from the top of the orbit
+             box) AND by the orbit-stat vertical anchor, so the labels always
+             orbit the ring's real center. Because .gauge-core has an asymmetric
+             inset (this value on top, 0 on the bottom), the ring center sits
+             exactly topInset/2 below the orbit box's 50% line — so the label
+             anchor adds that same topInset/2 to stay on the ring. */
+          --_donut-top-inset: 45px;
           font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
           color: var(--_text);
         }
@@ -343,7 +358,7 @@ class T262Donut extends HTMLElement {
         }
         .gauge-core {
           position: absolute;
-          inset: 45px 0 0;
+          inset: var(--_donut-top-inset) 0 0;
           display: grid;
           place-items: center;
         }
@@ -401,12 +416,28 @@ class T262Donut extends HTMLElement {
           grid-template-columns: 1fr 1fr;
           gap: 8px 16px;
           margin-top: 24px;
+          /* Only shown <440px (see media query). Constrain + auto-center so the
+             two-column legend sits centered under the 250px donut instead of
+             stretching the full host width. */
+          max-width: 320px;
+          margin-left: auto;
+          margin-right: auto;
         }
         /* Narrow viewports: orbit labels don't fit; rely on the legend below.
            The donut itself is 250px and fits comfortably in ~360px viewports. */
         @media (max-width: 440px) {
           .gauge-orbit {
             height: 280px;
+            /* Orbit labels are hidden on mobile, so the top inset that made room
+               for them above the ring is no longer needed. Zero it here so the
+               250px ring is CENTERED in the 300px padding box (height 280 +
+               padding-top 20). Centered leaves ~25px above and below the ring —
+               enough for the .gauge-glow (inset:-8px + blur(6px), ≈14px bleed)
+               to fully render instead of being clipped at the bottom by
+               :host { overflow: clip }. This override cascades to .gauge-core
+               (a descendant) and is scoped to the media query, so desktop
+               orbit-label overflow protection is unaffected. */
+            --_donut-top-inset: 0px;
           }
           .orbit-stat {
             display: none;


### PR DESCRIPTION
## Summary

Three CSS/layout fixes in the `<t262-donut>` web component
(`website/components/t262-charts.js`), reported by the project lead viewing the
live landing + report pages. Resolves #3072.

**(A) — desktop orbit labels too high (most important).** The orbit labels
(Passed / Failed / Compile Errors / Skipped) were anchored at the orbit box's
50% line (y=190), but `.gauge-core { inset: 45px 0 0 }` puts the ring center at
y=212.5 — so the labels rendered ~22.5px above the ring.

**(B) — mobile glow clipped.** On `<=440px` the 250px ring still carried the
45px top inset, so it centered low (bottom at 297.5) and the `.gauge-glow`
(`inset:-8px` + `blur(6px)`, ≈14px bleed) overran the 300px box and was clipped
by `:host { overflow: clip }`.

**(C) — desktop legend offset / mobile legend centering.** On desktop the legend
is `display:none` and the orbit-stats ARE the labels, so (A)'s fix resolves the
perceived offset. For `<440px` the two-column legend is now centered under the
donut.

## Changes

- New single source of truth `--_donut-top-inset: 45px` on `:host`, used by BOTH
  `.gauge-core { inset: var(--_donut-top-inset) 0 0 }` and the orbit-stat anchor
  — so the two can never silently drift apart again.
- (A) Orbit-stat inline `top:50%` → `top: calc(50% + (var(--_donut-top-inset) /
  2))` (190 + 22.5 = 212.5 = ring center). `left:50%` untouched. Refreshed the
  stale geometry comment and `centerY` (182 → 212.5) to match the real 380×380
  box / 212.5 ring center (these feed collision detection via absolute `lp`).
- (B) Mobile media query overrides `.gauge-orbit { --_donut-top-inset: 0px }` —
  centers the ring in the 300px box (~25px margin top/bottom) so the ≈14px glow
  fully renders. Scoped to the media query; desktop overflow protection intact.
- (C) `.legend { max-width: 320px; margin-inline: auto }` centers the `<440px`
  legend under the donut.

## Geometric justification (A)

`.gauge-orbit` padding box = height 360 + padding-top 20 = **380** tall.
- Orbit anchor: `left:50%`=190; `top: calc(50% + topInset/2)` = 190 + 22.5 = **212.5**.
- Ring center: `.gauge-core` top=45, bottom=0 → height 335 → 250px ring centered at 45 + 335/2 = **212.5**.
- Anchor == ring center, and `centerX,centerY` == anchor, so each label's delta `(lp - center)` lands it exactly on its ring point.

## Verification

- `node --check` passes; `tests/issue-1777.test.ts` (module unit tests) pass.
- No browser in the container → **pixel-level visual confirmation is deferred to
  the deployed site** (correctness argued geometrically above; please eyeball
  desktop + mobile after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)