### PR TITLE
fix(#3073): remove deprecated --platform CLI alias (#2736 follow-up)

### DIFF
--- a/plan/issues/3073-remove-platform-cli-alias.md
+++ b/plan/issues/3073-remove-platform-cli-alias.md
@@ -1,0 +1,52 @@
+---
+id: 3073
+title: remove deprecated --platform CLI alias (#2736 follow-up)
+status: done
+sprint: current
+priority: medium
+horizon: s
+assignee: ttraenkler/agent-dev
+completed: 2026-07-06
+---
+
+# remove deprecated `--platform` CLI alias (#2736 follow-up)
+
+## Problem
+
+`--platform` was introduced in #2736 as a DEPRECATED alias for the unified
+`--target {web,node,deno}` host axis, printing a one-line deprecation warning
+and feeding the internal `platform` field. The project lead wants the alias
+spelling removed now that `--target` is the supported spelling.
+
+## Scope
+
+Remove the js2wasm CLI `--platform` flag alias only. The INTERNAL host-scoping
+mechanism (`platform` variable + `...(platform ? { platform } : {})` spread and
+the `--target {web,node,deno}` handling that feeds it) is untouched — only the
+`--platform` alias spelling is gone.
+
+### Removed (`src/cli.ts`)
+
+- The `--platform <p>` help-text block.
+- The `--platform` / `--platform=` argument-parsing branch (incl. its
+  deprecation-warning `console.error`). `--platform` now falls through to the
+  CLI's `Unknown option` handler (non-zero exit).
+- Stale comments describing `--platform` as a live/deprecated alias — reworded
+  to describe only `--target {web,node,deno}` as the host-axis flag.
+
+### Kept
+
+- `let platform: "web" | "node" | "deno" | undefined;` and the
+  `...(platform ? { platform } : {})` spread — the internal host-scoping field.
+- `--target {web,node,deno}` handling that routes host values into `platform`.
+
+Unrelated esbuild `--platform=node` bundler flags (package.json,
+scripts/\*) are left untouched.
+
+## Test
+
+`tests/issue-2736-target-axis.test.ts` — the `--target node/deno/web` and
+unknown-`--target` tests pass unchanged; the former `--platform node`
+deprecation test now asserts `--platform` is REJECTED as an unknown flag
+(non-zero exit / `Unknown option: --platform`), mirroring
+`tests/issue-2783.test.ts`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,12 +95,6 @@ Options:
                     Auto-enabled (type-level only) when the source imports a
                     'node:' builtin (use 'none' to disable that); otherwise off,
                     and using process warns to add this flag (#2603).
-  --platform <p>    DEPRECATED (#2736): alias for --target {web,node,deno}.
-                    'web' = DOM globals (window/document/…) in scope (today's
-                    default); 'node'/'deno' = DOM globals NOT in scope (so
-                    window.stop is a type error) and Node-style API emulation on
-                    (implies --emulate node). Prefer --target; this prints a
-                    deprecation warning. Unset preserves today's behaviour.
   --no-host-imports Strict dual-mode: reject JS-host 'env' imports not on
                     the allowlist (#1524). Implied by --target wasi.
   --allow-host-imports
@@ -172,9 +166,9 @@ const linkedNamespaces = new Set<string>();
 let emulateNode = false;
 let emulateExplicit = false;
 // #2528/#2645/#2736 — the host environment, scoping the AMBIENT global surface
-// (DOM vs node) and node/deno emulation. Now driven by the unified `--target
-// {web,node,deno}` axis; `--platform` is a deprecated alias. `undefined`
-// preserves today's behaviour exactly (DOM ambient surface loaded, byte-neutral).
+// (DOM vs node) and node/deno emulation. Driven by the unified `--target
+// {web,node,deno}` axis. `undefined` preserves today's behaviour exactly
+// (DOM ambient surface loaded, byte-neutral).
 let platform: "web" | "node" | "deno" | undefined;
 const defines: Record<string, string> = {};
 
@@ -183,8 +177,7 @@ for (let i = 0; i < args.length; i++) {
   if (arg === "-o" || arg === "--out") {
     outDir = args[++i];
   } else if (arg === "--target" || arg.startsWith("--target=")) {
-    // #2736 — `--target` is now the SINGLE host/output axis (unifying the
-    // retired `--platform`). It accepts:
+    // #2736 — `--target` is the SINGLE host/output axis. It accepts:
     //   - the host environments: `web` (default), `node`, `deno` — these select
     //     the ambient global surface (#2528/#2645) and leave the backend at its
     //     WasmGC/JS-host default;
@@ -269,20 +262,6 @@ for (let i = 0; i < args.length; i++) {
       emulateExplicit = true;
     } else {
       console.error(`Unknown --emulate value: ${env ?? "(missing)"} (expected: node | none)`);
-      process.exit(1);
-    }
-  } else if (arg === "--platform" || arg.startsWith("--platform=")) {
-    // #2736 — DEPRECATED alias for `--target {web,node,deno}`. `--platform`
-    // selected the ambient global surface (#2528): `node`/`deno` drop the DOM
-    // globals and imply Node-style emulation (#2645); `web` keeps the DOM
-    // surface. The host axis is now unified under `--target`; this alias maps
-    // onto the same internal `platform` field and emits a one-line deprecation.
-    const p = arg.startsWith("--platform=") ? arg.slice("--platform=".length) : args[++i];
-    if (p === "node" || p === "web" || p === "deno") {
-      platform = p;
-      console.error(`warning: --platform is deprecated; use --target ${p} instead.`);
-    } else {
-      console.error(`Unknown --platform value: ${p ?? "(missing)"} (expected: node | web | deno)`);
       process.exit(1);
     }
   } else if (arg === "--no-host-imports") {

--- a/tests/issue-2736-target-axis.test.ts
+++ b/tests/issue-2736-target-axis.test.ts
@@ -8,10 +8,11 @@
 // the same node-emulation / no-DOM ambient surface as `node` for now.
 //
 // Two surfaces are exercised:
-//   - the programmatic `platform` option (the internal host field `--target`
-//     and the deprecated `--platform` alias both feed), and
-//   - the CLI flag parsing (`--target node|deno|web` + the deprecated
-//     `--platform` alias with its one-line deprecation warning).
+//   - the programmatic `platform` option (the internal host field that
+//     `--target {web,node,deno}` feeds), and
+//   - the CLI flag parsing (`--target node|deno|web`). The `--platform` alias
+//     that #2736 added as deprecated was removed in #3073 and is now rejected
+//     as an unknown flag.
 
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
@@ -93,7 +94,7 @@ describe("#2736 — byte-neutrality of the host axis (ES-only program)", () => {
   });
 });
 
-describe("#2736 — CLI `--target {web,node,deno}` flag parsing + deprecated `--platform` alias", () => {
+describe("#2736 — CLI `--target {web,node,deno}` flag parsing (`--platform` alias removed, #3073)", () => {
   const NODE_PROC = `process.exit(0);\nexport function test(): number { return 1; }\n`;
 
   it("--target node compiles and suppresses the `process` TS2580 (emulation implied)", async () => {
@@ -131,21 +132,16 @@ describe("#2736 — CLI `--target {web,node,deno}` flag parsing + deprecated `--
     });
   });
 
-  it("--platform node still works but prints a one-line deprecation pointing at --target", async () => {
+  // #3073 — the deprecated `--platform` alias (introduced in #2736) has been
+  // removed; `--target {web,node,deno}` is the only host-axis spelling. The
+  // alias is now rejected by the CLI's unknown-flag handler (non-zero exit).
+  it("--platform is rejected as an unknown flag (removed; was deprecated in #2736)", async () => {
     await withTempTs(`export function test(): number { return 1; }\n`, async (dir, path) => {
-      const { stderr } = await execFileAsync("npx", [
-        "tsx",
-        CLI,
-        path,
-        "--platform",
-        "node",
-        "-o",
-        dir,
-        "--no-wat",
-        "--no-dts",
-        "-q",
-      ]);
-      expect(stderr).toMatch(/--platform is deprecated; use --target node/);
+      await expect(
+        execFileAsync("npx", ["tsx", CLI, path, "--platform", "node", "-o", dir, "-q"]),
+      ).rejects.toMatchObject({
+        stderr: expect.stringMatching(/Unknown option: --platform/),
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Removes the DEPRECATED `--platform` CLI flag alias from the js2wasm compiler CLI. It was introduced in #2736 as an alias for `--target {web,node,deno}` (with a one-line deprecation warning); now that `--target` is the supported spelling, the alias is removed.

## Changes

`src/cli.ts`:
- Removed the `--platform <p>` help-text block.
- Removed the `--platform` / `--platform=` argument-parsing branch (including its deprecation-warning `console.error`). `--platform` now falls through to the CLI's `Unknown option` handler (non-zero exit).
- Reworded the stale comments that described `--platform` as a live/deprecated alias so they describe only `--target {web,node,deno}` as the host axis.

**Kept (the internal host-scoping mechanism is untouched):**
- `let platform: "web" | "node" | "deno" | undefined;` and the `...(platform ? { platform } : {})` compile-option spread.
- `--target {web,node,deno}` still routes host values into the internal `platform` field exactly as before (byte-neutral).

Unrelated esbuild `--platform=node` bundler flags (package.json, scripts/*) are left untouched.

## Test

`tests/issue-2736-target-axis.test.ts`: the `--target node/deno/web` and unknown-`--target` tests pass unchanged. The former `--platform node` deprecation test now asserts `--platform` is REJECTED as an unknown flag (non-zero exit / `Unknown option: --platform`), mirroring `tests/issue-2783.test.ts`. All 8 tests pass locally.

Scoped smoke checks: `--target node` compiles + applies node platform scoping (DOM globals out of scope); `--platform node` now errors as unknown (exit 1).

Closes #3073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)