### PR TITLE
docs(test262): harvest-errors 2026-07-06 — file #3074 (TypedArray vacuous, both lanes) + #3075 (standalone for-of dstr illegal cast)

### DIFF
--- a/plan/issues/2940-standalone-make-callback-harness-wrapper-vacuous.md
+++ b/plan/issues/2940-standalone-make-callback-harness-wrapper-vacuous.md
@@ -283,3 +283,12 @@ resizable-buffer fixture globals `is not defined` → the assertion callback
 throws before running → vacuous fail), not a #2940 codegen regression. Not
 reopening #2940; flagging for triage — the fix belongs in #1524 (harness
 fixture), which remains `backlog`.
+
+## 2026-07-06 harvest note — cluster PERSISTS, reopened as #3074
+
+`/harvest-errors` (default run 20260706-034320; standalone current 6.7.2026)
+finds the `vacuous: harness-wrapper callback never executed` signature STILL at
+**1,535 default + 448 standalone** even though the blocker #2939 (any-typed
+closure dynamic-dispatch arity/type tolerance) has since landed `done`. So
+either #2939 did not cover the harness-wrapper dispatch path or only a narrow
+case landed. Tracked forward in **#3074** (both lanes; largest default cluster).

--- a/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
+++ b/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
@@ -1,0 +1,91 @@
+---
+id: 3074
+title: "TypedArray harness-wrapper callback never executes → vacuous fail (both lanes; persists after #2939/#2940)"
+status: ready
+sprint: Backlog
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: research+bugfix
+area: codegen
+language_feature: closures, dynamic-dispatch, typed-arrays, test262-harness
+goal: host-independence
+related: [2939, 2940, 2903, 2879]
+created: 2026-07-06
+updated: 2026-07-06
+origin: "2026-07-06 /harvest-errors run against baselines @ default run 20260706-034320 (gitHash 2aa204b4) + standalone current.jsonl (6.7.2026)."
+---
+
+# #3074 — TypedArray harness-wrapper callback stays vacuous in BOTH lanes
+
+## Summary
+
+The single **largest default-lane failure cluster** and a large standalone
+cluster are the same signature:
+
+```
+other:vacuous: harness-wrapper callback never executed (##) — no assertion ran
+```
+
+- **Default (JS-host) lane: 1,535 records** — 927 `built-ins/TypedArray`,
+  553 `built-ins/TypedArrayConstructors`, 46 `built-ins/Atomics`, misc.
+- **Standalone lane: 448 records** — TypedArray prototype/ctor tests.
+
+These are test262 files wrapped in the harness helper
+`testWithTypedArrayConstructors(function(TA){ … })` /
+`testWithBigIntTypedArrayConstructors(function(TA){ … })`. The wrapper's
+callback (an `any`-typed closure parameter, invoked as `fn(TA)` inside the
+harness) is **never executed**, so no assertion in the body runs and the oracle
+correctly reports the test as **vacuous → fail** (the #2940 / de-vacuification
+machinery working as intended).
+
+## Why this is filed now (both tracking issues are CLOSED)
+
+- **#2940** (`status: done`) measured this exact cluster on the standalone lane
+  and concluded the fix was **blocked on #2939** (dynamic dispatch of an
+  `any`-typed closure param must tolerate arity mismatch + coerce arg
+  type-kinds). It was closed as a measurement/decision doc, not a fix.
+- **#2939** (`status: done`) — the closure-dispatch blocker — has since landed.
+
+**Yet the cluster persists at 1,535 (default) + 448 (standalone).** So either
+#2939's fix did not cover the harness-wrapper dispatch path, or a narrower case
+landed. Neither closed issue reflects an open feature gap, so these ~1,983
+records currently have **no open home**. This issue reopens the work.
+
+Note this is **NOT** a standalone-only / host-import problem: the default
+(JS-host) lane shows the *larger* count (1,535), so the harness-wrapper closure
+simply is not being invoked regardless of target. This is distinct from #2903
+(residual `__make_callback` = host-backed *builtin-method* closures), which is a
+separate standalone leak-front.
+
+## Sample files (default lane)
+
+```
+built-ins/TypedArray/prototype/fill/fill-values-relative-end.js
+built-ins/TypedArray/prototype/filter/callbackfn-return-does-not-change-instance.js
+built-ins/TypedArray/prototype/includes/return-abrupt-tointeger-fromindex.js
+built-ins/TypedArray/prototype/set/typedarray-arg-offset-tointeger.js
+built-ins/TypedArray/prototype/copyWithin/negative-start.js
+built-ins/TypedArrayConstructors/ctors/typedarray-arg/proto-from-ctor-realm.js
+```
+
+## Suggested investigation
+
+1. Reproduce one file (e.g. `fill/fill-values-relative-end.js`) on current main,
+   both `gc` and `standalone` targets, with `trackFallbacks`, and confirm the
+   `testWith*TypedArrayConstructors(fn)` closure is entered.
+2. Re-verify #2939's dynamic-dispatch fix (`calls-closures.ts`) against the
+   specific arity/type shape the harness wrapper uses (`fn(TA)` where `TA` is a
+   constructor value passed positionally; the callback declares one param). The
+   #2940 measurement noted many wrappers pass a **2-arg** `makeCtorArg` callback
+   — check the 2-arg path specifically.
+3. If the closure is invoked but the body still no-ops, trace where the
+   assertion counter stays at 0 (the vacuity detector keys on
+   "no assertion ran").
+
+## Acceptance
+
+- The `vacuous: harness-wrapper callback never executed` signature drops
+  materially in BOTH lanes (target: <200 default), i.e. the TypedArray harness
+  wrapper actually invokes its callback and the body assertions run.
+- No net regression in either lane's pass count.

--- a/plan/issues/3075-standalone-forof-dstr-illegal-cast-iterator.md
+++ b/plan/issues/3075-standalone-forof-dstr-illegal-cast-iterator.md
@@ -1,0 +1,77 @@
+---
+id: 3075
+title: "standalone: for-of / for-await-of destructuring throws 'illegal cast [in __iterator]' (residual after #1323)"
+status: ready
+sprint: Backlog
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: iterator-protocol, for-of, for-await-of, destructuring
+goal: standalone-mode
+related: [1781, 1323, 1454, 1347, 1471]
+created: 2026-07-06
+updated: 2026-07-06
+origin: "2026-07-06 /harvest-errors run against standalone current.jsonl (6.7.2026)."
+---
+
+# #3075 — standalone for-of/for-await destructuring: illegal cast in `__iterator`
+
+## Summary
+
+**468 standalone-lane records** (0 in the default lane) fail with:
+
+```
+illegal_cast:L#:## illegal cast [in __iterator() ← fn ← test]
+```
+
+Category breakdown:
+
+- **421 `language/statements`** — overwhelmingly `for-of/dstr/*` and
+  `for-await-of/*` destructuring patterns.
+- 11 `built-ins/Iterator`, 10 `built-ins/Array`, 8 `built-ins/TypedArray`,
+  4 `AsyncFromSyncIteratorPrototype`, misc.
+
+This is a **standalone-specific** iterator-protocol residual: the native
+`__iterator()` bridge performs a `ref.cast` that traps when the iterated value's
+runtime shape doesn't match the expected iterator-result / element type — most
+often in destructuring-binding for-of/for-await targets (array/object patterns,
+elision, rest holes, `iter-done` paths).
+
+## Why filed now
+
+`#1323` (Iterator protocol bridging — `$IteratorResult` struct in pure Wasm) is
+`status: done`, and `#1471` (host boxing/unboxing elimination) is done, yet
+this illegal-cast cluster persists at 468 in standalone. The residual is not
+tracked by an open issue. Related open/borderline issues #1454
+(iterator-protocol destructuring close) and #1347 (iterator-close-on-throw)
+touch adjacent surface but do not name this `illegal cast [in __iterator]`
+signature.
+
+## Sample files
+
+```
+language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-ary-empty-iter.js
+language/statements/for-of/iterator-next-error.js
+language/statements/for-of/iterator-close-via-continue.js
+language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-prop-obj.js
+language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-done.js
+```
+
+## Suggested investigation
+
+1. Compile one repro (e.g. `for-of/iterator-next-error.js`) with
+   `--target standalone --no-host-imports`, dump the WAT, and locate the
+   `ref.cast` inside the emitted `__iterator` helper that traps.
+2. Determine whether the cast assumes a concrete iterator-result struct shape
+   where the value is `any`/externref-shaped (native-string or boxed element)
+   — this mirrors the substrate value-read gaps
+   (`project_standalone_any_string_value_read_substrate`).
+3. Widen the cast to the correct supertype (or add a type-guarded slow path)
+   for the destructuring-target element read.
+
+## Acceptance
+
+- `illegal cast [in __iterator]` standalone count drops materially (<100).
+- No net regression in either lane.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -487,3 +487,24 @@ Existing covered issues pulled into sprint 66 (Backlog → 66): #1642 (for-of It
 Deprioritized (eval / new Function / dynamic-import — NOT scheduled first):
 ~219 ES5 + ~87 ES6 eval/dynamic-code fails; tracked by #1066, #1102, #1240,
 #1263-#1266 (eval tiers). Not added to the prioritized sprint-66 list.
+
+## 2026-07-06 /harvest-errors run (both lanes; standalone de-vacuified)
+
+Data: default baselines run 20260706-034320 (gitHash 2aa204b4, 32,514 pass);
+standalone `test262-standalone-current.jsonl` (6.7.2026), post #3055/#2757
+numeric-any-eq de-vacuification. New clusters filed:
+
+- [#3074](../3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md) —
+  TypedArray harness-wrapper callback never executes → vacuous fail in BOTH
+  lanes (**1,535 default** = largest default cluster, **448 standalone**).
+  Persists after #2939/#2940 both closed; reopens the feature gap.
+- [#3075](../3075-standalone-forof-dstr-illegal-cast-iterator.md) — standalone
+  for-of/for-await-of destructuring `illegal cast [in __iterator]` — **468**
+  standalone, residual after #1323 (done). goal: standalone-mode.
+
+Verdict on the de-vacuified numeric failures (#3055/#2757): **scattered, not a
+coherent numeric cluster.** Number assertion-fails = 100 (mostly toString radix),
+Math = 3. The ~1,958 newly-honest fails redistributed across general
+assertion_fail categories (language/expressions 2,317, language/statements
+1,927, Array 1,487, Object 1,358), not into a numeric-precision or
+specific-builtin bucket. No numeric-cluster issue warranted.


### PR DESCRIPTION
## /harvest-errors run — 2026-07-06 (both lanes)

Data: default baselines run `20260706-034320` (gitHash `2aa204b4`, 32,514 pass);
standalone `test262-standalone-current.jsonl` (6.7.2026), **after** the
#3055/#2757 numeric-any-eq de-vacuification re-seed.

### New issues filed (>50, un-homed)

- **#3074** — TypedArray harness-wrapper callback never executes → vacuous fail
  in **BOTH lanes** (1,535 default = largest default cluster; 448 standalone).
  Persists even though #2939 (blocker) and #2940 (measurement) are both `done`.
- **#3075** — standalone `for-of`/`for-await-of` destructuring
  `illegal cast [in __iterator]` — 468 records (0 in default), residual after
  closed #1323. `goal: standalone-mode`.

### De-vacuified numeric verdict

**Scattered, not a coherent cluster.** Number assertion-fails = 100 (mostly
`toString` radix), Math = 3. The ~1,958 newly-honest fails redistributed across
general assertion_fail categories (language/expressions, language/statements,
Array, Object), not a numeric-precision or specific-builtin bucket. No
numeric-cluster issue warranted.

Data/docs only (`plan/issues/*`) — no source changes; self-lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8