### PR TITLE
fix(#3078): Number.toExponential/toPrecision(undefined) behaves as no-arg

### DIFF
--- a/plan/issues/3078-number-toexp-toprec-undefined-arg.md
+++ b/plan/issues/3078-number-toexp-toprec-undefined-arg.md
@@ -1,0 +1,65 @@
+---
+id: 3078
+title: "Number.prototype.toExponential(undefined) / toPrecision(undefined) must behave as no-arg, not ToInteger(undefined)=0"
+status: done
+completed: 2026-07-07
+assignee: ttraenkler/dev-B
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+language_feature: number-builtins
+goal: conformance
+related: [1735, 1321, 49]
+---
+
+# #3078 — `toExponential(undefined)` / `toPrecision(undefined)` ≡ no-arg
+
+## Problem
+
+Per ECMA-262, an explicit `undefined` fractionDigits/precision is spec-equivalent
+to omitting the argument:
+
+- §21.1.3.3 `toExponential(undefined)` → variable-precision exponential (as many
+  digits as needed), same as `toExponential()`. e.g. `(123.456).toExponential(undefined)`
+  === `"1.23456e+2"`.
+- §21.1.3.5 step 2 `toPrecision(undefined)` → `! ToString(x)`, same as
+  `toPrecision()`. e.g. `(39).toPrecision(undefined)` === `"39"`.
+
+Pre-fix, codegen gated only on `arguments.length > 0`, so an explicit `undefined`
+compiled through the ToNumber funnel → f64 NaN → normaliseNaN→0. Result:
+`toExponential(undefined)` returned `"1e+2"` (0 digits) and `toPrecision(undefined)`
+**threw RangeError** (0 ∉ [1,100]).
+
+## Root cause + fix
+
+`undefined` and `NaN` both compile to f64 NaN and are indistinguishable at the
+value site — and they must differ (`toExponential(NaN)` → 0 digits via
+ToIntegerOrInfinity; `toExponential(undefined)` → variable). So the fix detects
+the **static** `undefined` literal at the AST level (`isStaticUndefinedArg`,
+exported from `string-ops.ts`) and routes it to the existing no-argument branch
+(NaN "no-arg" sentinel for `number_toExponential` / ToString path for
+`number_toPrecision`). Applied to **both** the typed-receiver path and the
+computed-member (`n["toExponential"](undefined)`) path in
+`src/codegen/expressions/calls.ts`. `toFixed` is deliberately unchanged
+(§21.1.3.3: `toFixed(undefined)` IS ToInteger(undefined)=0).
+
+An explicit `NaN` argument still maps to 0 (regression-guarded) because
+`isStaticUndefinedArg` matches only the `undefined` / `void 0` literal.
+
+## Acceptance
+
+- [x] `built-ins/Number/prototype/toExponential/undefined-fractiondigits.js` passes.
+- [x] `built-ins/Number/prototype/toPrecision/undefined-precision-arg.js` passes.
+- [x] No regression: `(123.456).toExponential(NaN)` → `"1e+2"`;
+      `(1.5).toPrecision(NaN)` still throws; no-arg + numeric-arg unchanged
+      (tests/issue-1735, issue-1321, issue-49 green).
+- [x] Unit coverage: `tests/issue-3078-number-undefined-arg.test.ts` (8 cases).
+
+## Notes
+
+Only the STATIC `undefined` literal is routed to no-arg; a dynamically-`undefined`
+value stays on the current (NaN→0) path — vanishingly rare and not covered by the
+target tests. The sibling `tointeger-fractiondigits` / `tointeger-precision`
+failures are a SEPARATE pre-existing gap (ToNumber of boolean/array args, e.g.
+`toPrecision(true)` / `toPrecision([2])`), out of scope here.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -154,6 +154,7 @@ import {
   compileNativeStringMethodCall,
   compileStringLiteral,
   emitBoolToString,
+  isStaticUndefinedArg,
 } from "../string-ops.js";
 import { tryCompileNodeFsCall, tryCompileNodeProcessCall } from "../node-fs-api.js";
 import { tryCompileDenoStdioCall } from "../deno-api.js";
@@ -11417,7 +11418,14 @@ function compileCallExpression(
     if (isNumberMethodReceiver(ctx, receiverType) && propAccess.name.text === "toPrecision") {
       // (#2160 number-wrapper) f64 receiver recovery (primitive or wrapper).
       emitNumberMethodReceiverF64(ctx, fctx, propAccess, receiverType);
-      if (expr.arguments.length > 0) {
+      // (#3078) §21.1.3.5 step 2: an explicit `undefined` precision is
+      // spec-equivalent to no argument → `return ! ToString(x)`. It is NOT
+      // ToIntegerOrInfinity(undefined)=0 (which would trip the [1,100] RangeError
+      // gate). undefined and NaN both compile to f64 NaN, so they are
+      // indistinguishable at the value site — route the STATIC undefined literal
+      // to the no-arg branch (NaN sentinel) at the AST level.
+      // test262 toPrecision/undefined-precision-arg.js.
+      if (expr.arguments.length > 0 && !isStaticUndefinedArg(expr.arguments[0])) {
         // (#49) Spec §21.1.3.5 step 4 says: if x is non-finite, return
         // Number::toString(x) BEFORE the precision range check. Save the
         // receiver into a local, check finiteness, and only run the
@@ -11506,7 +11514,14 @@ function compileCallExpression(
     if (isNumberMethodReceiver(ctx, receiverType) && propAccess.name.text === "toExponential") {
       // (#2160 number-wrapper) f64 receiver recovery (primitive or wrapper).
       emitNumberMethodReceiverF64(ctx, fctx, propAccess, receiverType);
-      if (expr.arguments.length > 0) {
+      // (#3078) §21.1.3.3 step 2: an explicit `undefined` fractionDigits is
+      // spec-equivalent to no argument → variable-precision exponential (as many
+      // digits as needed), NOT ToIntegerOrInfinity(undefined)=0 (which gives
+      // fixed 0 digits). undefined and NaN both compile to f64 NaN and are
+      // indistinguishable at the value site — route the STATIC undefined literal
+      // to the no-arg branch (NaN sentinel) at the AST level.
+      // test262 toExponential/undefined-fractiondigits.js.
+      if (expr.arguments.length > 0 && !isStaticUndefinedArg(expr.arguments[0])) {
         // (#49) Spec §21.1.3.3 step 3: if x is non-finite, return
         // Number::toString(x) BEFORE the fractionDigits range check.
         // Save receiver, run range check only when x is finite. The
@@ -15551,7 +15566,9 @@ function compileCallExpression(
         } else if (methodName === "toFixed") {
           fctx.body.push({ op: "f64.const", value: 0 });
         }
-        if (methodName === "toPrecision" && expr.arguments.length > 0) {
+        if (methodName === "toPrecision" && expr.arguments.length > 0 && !isStaticUndefinedArg(expr.arguments[0])) {
+          // (#3078) explicit `undefined` precision ≡ no arg (§21.1.3.5 step 2) —
+          // route to the `toString`-equivalent else branch, not ToInteger→0.
           // ToNumber funnel — Symbol args must throw TypeError (#1564).
           coerceNumberMethodArgToF64(ctx, fctx, compileExpression(ctx, fctx, expr.arguments[0]!));
           // (#49) See `number.toPrecision` site above — the precision
@@ -15566,7 +15583,10 @@ function compileCallExpression(
             return { kind: "externref" };
           }
         }
-        if (methodName === "toExponential" && expr.arguments.length > 0) {
+        if (methodName === "toExponential" && expr.arguments.length > 0 && !isStaticUndefinedArg(expr.arguments[0])) {
+          // (#3078) explicit `undefined` fractionDigits ≡ no arg (§21.1.3.3
+          // step 2) — route to the NaN-sentinel else branch (variable digits),
+          // not ToInteger→0.
           // ToNumber funnel — Symbol args must throw TypeError (#1564).
           coerceNumberMethodArgToF64(ctx, fctx, compileExpression(ctx, fctx, expr.arguments[0]!));
           // (#49) See `number.toExponential` site above — the

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -67,7 +67,7 @@ function valueExprTsType(ctx: CodegenContext, node: ts.Expression): ts.Type {
  * wrong. Detect the statically-undefined forms so callers can treat the arg as
  * absent. Unwraps paren/as/!-assertion wrappers.
  */
-function isStaticUndefinedArg(arg: ts.Expression | undefined): boolean {
+export function isStaticUndefinedArg(arg: ts.Expression | undefined): boolean {
   if (arg === undefined) return false;
   let cur: ts.Expression = arg;
   while (

--- a/tests/issue-3078-number-undefined-arg.test.ts
+++ b/tests/issue-3078-number-undefined-arg.test.ts
@@ -1,0 +1,86 @@
+/**
+ * #3078 — Number.prototype.toExponential(undefined) / toPrecision(undefined)
+ * must be spec-equivalent to the NO-ARGUMENT call, NOT to
+ * ToIntegerOrInfinity(undefined) = 0.
+ *
+ * ECMA-262:
+ *   §21.1.3.3 Number.prototype.toExponential(fractionDigits) — an explicit
+ *     `undefined` yields the variable-precision exponential (as many digits as
+ *     needed), identical to `toExponential()`. NOT 0 fixed digits.
+ *   §21.1.3.5 Number.prototype.toPrecision(precision) step 2 — "If precision is
+ *     undefined, return ! ToString(x)." NOT ToInteger(undefined)=0 (which would
+ *     trip the [1,100] RangeError gate).
+ *
+ * Pre-fix bug: codegen gated only on `arguments.length > 0`, so an explicit
+ * `undefined` argument compiled through the ToNumber funnel → f64 NaN →
+ * normaliseNaN→0. `toExponential(undefined)` therefore returned "1e+2" (0
+ * digits) and `toPrecision(undefined)` THREW RangeError (0 ∉ [1,100]).
+ *
+ * `undefined` and `NaN` both compile to f64 NaN and are indistinguishable at
+ * the value site, so the fix detects the STATIC `undefined` literal at the AST
+ * level (`isStaticUndefinedArg`) and routes it to the no-argument branch (the
+ * NaN "no-arg" sentinel / ToString path). An EXPLICIT NaN argument still maps
+ * to 0 (regression-guarded here + in tests/issue-1735.test.ts).
+ *
+ * Test262 fixed:
+ *   - built-ins/Number/prototype/toExponential/undefined-fractiondigits.js
+ *   - built-ins/Number/prototype/toPrecision/undefined-precision-arg.js
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runFn(source: string, exportName: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message ?? "?"}`);
+  const importResult = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, importResult as any);
+  importResult.setExports?.(instance.exports as any);
+  return (instance.exports as any)[exportName]();
+}
+
+describe("#3078 — Number.prototype.toExponential/toPrecision(undefined) ≡ no-arg", () => {
+  it("(123.456).toExponential(undefined) → '1.23456e+2' (variable digits, like no-arg)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(undefined); }`;
+    expect(await runFn(src, "r")).toBe("1.23456e+2");
+  });
+
+  it("(123.456).toPrecision(undefined) → '123.456' (ToString, like no-arg)", async () => {
+    const src = `export function r(): string { return (123.456).toPrecision(undefined); }`;
+    expect(await runFn(src, "r")).toBe("123.456");
+  });
+
+  it("(39).toPrecision(undefined) → '39'", async () => {
+    const src = `export function r(): string { return (39).toPrecision(undefined); }`;
+    expect(await runFn(src, "r")).toBe("39");
+  });
+
+  it("computed member — (123.456)['toExponential'](undefined) → '1.23456e+2'", async () => {
+    const src = `export function r(): string { return (123.456)["toExponential"](undefined); }`;
+    expect(await runFn(src, "r")).toBe("1.23456e+2");
+  });
+
+  it("computed member — (123.456)['toPrecision'](undefined) → '123.456'", async () => {
+    const src = `export function r(): string { return (123.456)["toPrecision"](undefined); }`;
+    expect(await runFn(src, "r")).toBe("123.456");
+  });
+
+  // Regression guards: an EXPLICIT NaN is NOT undefined — it maps to 0
+  // (ToIntegerOrInfinity), NOT the no-arg sentinel. `isStaticUndefinedArg`
+  // matches only the literal `undefined` / `void 0`, so these are untouched.
+  it("(123.456).toExponential(NaN) → '1e+2' (NaN→0, still distinct from undefined)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(Number.NaN); }`;
+    expect(await runFn(src, "r")).toBe("1e+2");
+  });
+
+  it("(1.5).toPrecision(NaN) STILL throws RangeError (NaN→0, 0 ∉ [1,100])", async () => {
+    const src = `export function r(): string { return (1.5).toPrecision(Number.NaN); }`;
+    await expect(runFn(src, "r")).rejects.toThrow();
+  });
+
+  // The genuine no-arg call is unchanged.
+  it("(123.456).toExponential() (no arg) → '1.23456e+2' (unchanged)", async () => {
+    const src = `export function r(): string { return (123.456).toExponential(); }`;
+    expect(await runFn(src, "r")).toBe("1.23456e+2");
+  });
+});


### PR DESCRIPTION
## Problem

Per ECMA-262 §21.1.3.3 / §21.1.3.5 step 2, an explicit `undefined` fractionDigits/precision is spec-equivalent to omitting the argument, NOT `ToIntegerOrInfinity(undefined) = 0`:
- `(123.456).toExponential(undefined)` must be `"1.23456e+2"` (variable digits), was `"1e+2"`.
- `(39).toPrecision(undefined)` must be `"39"` — pre-fix it **threw RangeError** (0 not in [1,100]).

## Fix

`undefined` and `NaN` both compile to f64 NaN and must differ (`toExponential(NaN)` -> 0 digits), so the static `undefined` literal is detected at the AST level (`isStaticUndefinedArg`, now exported from `string-ops.ts`) and routed to the existing no-argument branch, in **both** the typed-receiver and computed-member (`n["toExponential"](undefined)`) paths. `toFixed` is deliberately unchanged (§21.1.3.3: `toFixed(undefined)` IS 0). Explicit `NaN` still maps to 0 (regression-guarded).

## Validation

- Fixes test262 `toExponential/undefined-fractiondigits.js` + `toPrecision/undefined-precision-arg.js` (both flip fail->pass, verified via runner).
- Zero regressions: `tests/issue-1735` / `issue-1321` / `issue-49` green (incl. `toExponential(NaN)`->`1e+2`, `toPrecision(NaN)` still throws).
- New: `tests/issue-3078-number-undefined-arg.test.ts` (8 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS