### PR TITLE
fix(#3079): stop claim-issue --allocate hanging under load; file #3080 follow-up

### DIFF
--- a/plan/issues/3079-claim-issue-allocate-hang.md
+++ b/plan/issues/3079-claim-issue-allocate-hang.md
@@ -1,0 +1,83 @@
+---
+id: 3079
+title: "claim-issue.mjs --allocate hangs/times out under load — O(N) git cat-file per reservation + unbounded gh scan"
+status: done
+completed: 2026-07-07
+sprint: current
+created: 2026-07-07
+updated: 2026-07-07
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: tooling
+goal: infra
+related: [2531, 2943, 2974]
+---
+
+# #3079 — `claim-issue.mjs --allocate` hangs under load (blocks issue filing for the whole team)
+
+## Problem
+
+`node scripts/claim-issue.mjs --allocate` (and `--allocate --dry-run`) routinely
+took **>60s** and appeared to hang under container load, blocking issue filing
+for the whole team (the canonical, collision-proof id reservation path per
+#2531). It was widely assumed to be the open-PR `gh` scan, but empirical tracing
+showed **two independent causes**, and the dominant one was NOT the gh scan.
+
+## Root cause (measured, not assumed)
+
+**Primary — `idsFromAssignRef` spawned O(N) `git cat-file` subprocesses.** The
+`issue-assignments` reservation ref holds one `<id>.json` per reservation (466
+and growing). The id-universe scan read each entry with its own
+`git cat-file -p <sha>:<file>` — i.e. **466 sequential subprocess spawns**.
+Timed in isolation on the loaded container: **>90s** (killed before completing).
+This ran on EVERY `--allocate` (even `--no-pr-scan --dry-run`), which is why the
+hang persisted with the PR scan disabled. The count grows with every allocation,
+so it only gets worse.
+
+**Secondary — unbounded network calls.** `execFileSync` has no default timeout,
+so a single stuck `gh` (open-PR GraphQL scan) or `git fetch` under API
+contention blocks indefinitely with no upper bound.
+
+## Fix
+
+`scripts/claim-issue.mjs`:
+
+1. **`idsFromAssignRef`** — replace the per-entry `git cat-file` loop with a
+   **single `git cat-file --batch`** process that reads every reservation blob
+   at once (~constant time). The `--batch` stream is byte-framed, so the buffer
+   is walked by the header-declared size (execFileSync returns a Buffer when
+   `encoding` is omitted — note `encoding: "buffer"` is invalid and throws
+   `ERR_UNKNOWN_ENCODING`). Faithful to the original `/^\d+$/` id filter
+   (verified: batch yields the identical 459 numeric ids, correctly excluding
+   non-numeric slice/sub-issue entries like `"1373b"`, `"1910-s2"`, `"983d"`).
+   A **filename-derivation fallback** (leading digits of `<id>.json` /
+   `<base>-<slice>.json`) keeps the id universe complete if the batch read fails
+   — fail-safe (over-includes low sub-issue bases at worst, never misses a high
+   reservation, so it can never hand out a used id).
+
+2. **Bounded network timeouts** (all env-overridable):
+   - `CLAIM_MAIN_FETCH_TIMEOUT_MS` (15s) on the allocate-time `git fetch main`.
+   - `CLAIM_PR_SCAN_CALL_TIMEOUT_MS` (12s) per `gh` call in the open-PR scan.
+   - `CLAIM_PR_SCAN_TOTAL_TIMEOUT_MS` (25s) overall wall-clock budget for the
+     whole open-PR scan; past it the scan degrades to the pre-existing fail-open
+     fallback (allocate against `main` ∪ reservations only — the PR-time
+     `check:issue-ids:against-main` gate remains the hard backstop).
+
+## Result (measured on the same loaded container)
+
+| invocation | before | after |
+| --- | --- | --- |
+| `--allocate --dry-run` | >60s (timeout) | **~9s** |
+| `--allocate --no-pr-scan --dry-run` | >60s (timeout) | **~7s** |
+| forced PR-scan timeout (`CLAIM_PR_SCAN_TOTAL_TIMEOUT_MS=1`) | >60s | **~6s**, degrades gracefully + still returns an id |
+
+## Acceptance criteria
+
+- `--allocate` completes in seconds (not minutes) under load. ✓
+- The id it returns is unchanged/correct (faithful to the prior content-read
+  semantics; verified against the live ref). ✓
+- On gh/network stall the scan degrades to the fail-open fallback within the
+  bounded budget instead of hanging. ✓

--- a/plan/issues/3080-private-method-value-identity.md
+++ b/plan/issues/3080-private-method-value-identity.md
@@ -1,0 +1,84 @@
+---
+id: 3080
+title: "private-method value identity: `this.#m === (()=>this)().#m` is false for class declarations (method-value-identity substrate)"
+status: ready
+sprint: current
+priority: low
+horizon: m
+feasibility: hard
+reasoning_effort: max
+model: fable
+task_type: bugfix
+area: codegen, runtime
+language_feature: class-private-methods
+es_edition: 6
+goal: spec-completeness
+created: 2026-07-07
+related: [3045, 2963, 3037]
+parent: 3045
+---
+
+# #3080 — private-method value identity (`this.#m === (()=>this)().#m`)
+
+Spun off from #3045 (class-expression enclosing-scope capture — DONE). #3045's
+"Corrected finding" flagged two residual private-method-feature gaps behind the
+8 harvested files. This issue records the **verify-first re-check on current
+main** — one of the two is already resolved, the other is a method-value-identity
+substrate instance.
+
+## Verified on current main (2026-07-07) — corrects #3045's residual list
+
+Empirically re-checked each residual #3045 named (compile + run, JS-host lane):
+
+- **`.name` on a private method — ALREADY RESOLVED. Do NOT re-file.** All of
+  `this.#m.name === '#m'`, name `.length`, a private **generator** method
+  (`*#g(){}`), a **static** private method (`C.#s`), and `.name` via a local var
+  (`let f = this.#m; f.name`) return the correct `'#m'` for **both** class
+  declarations AND class expressions. #3045's "returns wrong value for both"
+  no longer reproduces (fixed by intervening work).
+
+- **arrow-captured-`this` private-method IDENTITY — REPRODUCES (declarations
+  only).** The one real residual:
+
+  ```js
+  class C { #m() { return 1; }
+    probe() { return this.#m === (() => this)().#m; } }   // ← false (should be true)
+  new C().probe();
+  ```
+
+  `this.#m` and `(() => this)().#m` reference the SAME bound private method on
+  the SAME receiver, so `===` must be `true`. On main it returns `false` for a
+  class **declaration** (the class-**expression** form passes since #3045's
+  Bug-2 fix). Note the **call** parity is fine — `(() => this)().#m()` returns
+  the right value (`7`); only the function-VALUE identity comparison fails.
+
+## Root cause (narrowed)
+
+Not an arrow/`this`-capture bug (the arrow returns the correct receiver — method
+calls through it work). It is **method-value identity**: accessing a
+private method as a *value* (`this.#m`) materialises a **fresh, non-canonical
+function wrapper** on each access instead of returning one stable object, so two
+accesses of the same method on the same receiver are not `===`. This is the same
+root as the broader class-method identity gap (`c.m === C.prototype.m`, ~87
+test262 files) — methods lack stable first-class value identity.
+
+## Why this is substrate (not a bounded point-fix)
+
+Giving an accessed method a stable identity requires reifying methods as
+first-class values with canonicalisation — the **#2963** (reify builtins/methods
+as first-class values) / **#3037** (object-identity canonicalisation substrate)
+work. This is Fable/senior substrate territory, not a standalone slice. Filed
+here for tracking; the real fix lands with #2963/#3037.
+
+## Acceptance criteria
+
+- `this.#m === (() => this)().#m` is `true` for class declarations (and stays
+  `true` for class expressions), without regressing private-method calls or
+  `.name`.
+- Fold into / gate behind the #2963/#3037 method-value-identity substrate rather
+  than a bespoke wrapper-dedup hack.
+
+## Provenance
+
+Filed by dev-A after fixing the `claim-issue.mjs --allocate` hang (#3079) that
+had blocked dev-3045 from allocating an id for this follow-up.

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -86,9 +86,26 @@ function pickMainRemote() {
 }
 const MAIN_REMOTE = pickMainRemote();
 const MAIN_REF = `${MAIN_REMOTE}/main`;
+
+// --- bounded network timeouts (#3079) --------------------------------------
+// `--allocate` must NEVER hang indefinitely. `execFileSync` has no default
+// timeout, so a single stuck `gh`/`git` call under API contention (many
+// concurrent agents) previously blocked the WHOLE team's issue filing. Every
+// network call in the allocate path is now capped; the open-PR scan
+// additionally carries an overall wall-clock budget, after which it degrades to
+// the pre-existing fail-open fallback (allocate against main ∪ reservations
+// only — the PR-time `check:issue-ids:against-main` gate is the hard backstop).
+// All three are env-overridable for tuning under different load.
+const MAIN_FETCH_TIMEOUT_MS = Number(process.env.CLAIM_MAIN_FETCH_TIMEOUT_MS) || 15000;
+const PR_SCAN_CALL_TIMEOUT_MS = Number(process.env.CLAIM_PR_SCAN_CALL_TIMEOUT_MS) || 12000;
+const PR_SCAN_TOTAL_TIMEOUT_MS = Number(process.env.CLAIM_PR_SCAN_TOTAL_TIMEOUT_MS) || 25000;
+
 // Best-effort refresh of the main tip — only when allocating (frequent
-// --check/--list calls shouldn't pay a network round-trip).
-if (process.argv.includes("--allocate")) gitTry(["fetch", "--quiet", MAIN_REMOTE, "main"]);
+// --check/--list calls shouldn't pay a network round-trip). Bounded so a hung
+// fetch can't wedge the allocation before the id scan even starts.
+if (process.argv.includes("--allocate")) {
+  gitTry(["fetch", "--quiet", MAIN_REMOTE, "main"], { timeout: MAIN_FETCH_TIMEOUT_MS, killSignal: "SIGKILL" });
+}
 const MAX_RETRIES = 6;
 
 function git(args, opts = {}) {
@@ -257,10 +274,62 @@ function idsFromAssignRef(sha) {
   if (!sha) return out;
   const ls = gitTry(["ls-tree", "--name-only", sha]);
   if (!ls.ok) return out;
-  for (const f of ls.out.split("\n")) {
-    if (!f.endsWith(".json")) continue;
-    const e = readEntry(sha, f.replace(/\.json$/, ""));
-    if (e && e.id != null && /^\d+$/.test(String(e.id))) out.add(Number(e.id));
+  const files = ls.out.split("\n").filter((f) => f.endsWith(".json"));
+  if (files.length === 0) return out;
+
+  // (#3079) Read EVERY entry blob in a SINGLE `git cat-file --batch` process.
+  // The prior implementation spawned one `git cat-file` PER entry — O(N)
+  // subprocesses (466 and growing) that took >90s under container load and was
+  // the TRUE cause of `--allocate` hanging (previously mis-attributed to the
+  // open-PR gh scan). One batched process is ~constant-time and bounded.
+  const request = files.map((f) => `${sha}:${f}`).join("\n") + "\n";
+  let buf;
+  try {
+    // NOTE: omit `encoding` so execFileSync returns a Buffer — the `--batch`
+    // stream is byte-framed (header declares each object's exact byte size), so
+    // it must be walked as bytes. (`encoding: "buffer"` is NOT a valid option
+    // value — it throws ERR_UNKNOWN_ENCODING; the default already yields a
+    // Buffer.) `input` may still be a string.
+    buf = execFileSync("git", ["cat-file", "--batch"], {
+      input: request,
+      maxBuffer: 128 * 1024 * 1024,
+      timeout: MAIN_FETCH_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+  } catch {
+    // Fallback: derive the id from the FILENAME. Every entry is named
+    // `<id>.json` (reservation/allocation) or `<base>-<slice>.json` (slice
+    // claim) — the leading digits are the id (verified stable on the ref). This
+    // keeps the id universe complete even if the batch read fails.
+    for (const f of files) {
+      const m = f.match(/^(\d+)/);
+      if (m) out.add(Number(m[1]));
+    }
+    return out;
+  }
+
+  // Parse the `--batch` stream: "<oid> <type> <size>\n<content>\n" per object
+  // ("<request> missing\n" — no body — for an absent one). Byte-framed, so walk
+  // the buffer by the declared size rather than splitting on newlines.
+  const LF = 0x0a;
+  let pos = 0;
+  while (pos < buf.length) {
+    const nl = buf.indexOf(LF, pos);
+    if (nl === -1) break;
+    const header = buf.toString("utf8", pos, nl);
+    pos = nl + 1;
+    const parts = header.split(" ");
+    if (parts.length < 3 || parts[1] === "missing") continue; // no content body
+    const size = Number(parts[2]);
+    if (!Number.isFinite(size) || size < 0) break;
+    const content = buf.toString("utf8", pos, pos + size);
+    pos += size + 1; // content + trailing LF
+    try {
+      const e = JSON.parse(content);
+      if (e && e.id != null && /^\d+$/.test(String(e.id))) out.add(Number(e.id));
+    } catch {
+      /* unparseable entry — skip (filename fallback not needed; batch succeeded) */
+    }
   }
   return out;
 }
@@ -317,7 +386,33 @@ const PR_FILES_QUERY = `query($owner:String!,$name:String!,$cursor:String){
 function idsFromOpenPRs() {
   const repo = process.env.CLAIM_PR_REPO || "loopdive/js2";
   const [owner, name] = repo.split("/");
+  // Overall wall-clock budget for the whole scan (all attempts + pagination).
+  // Past this the scan bails to the fail-open fallback rather than hanging.
+  const deadline = Date.now() + PR_SCAN_TOTAL_TIMEOUT_MS;
+  // A single gh invocation, capped at min(per-call limit, remaining budget).
+  // On budget exhaustion it throws a tagged error so the loop bails cleanly;
+  // on a per-call timeout `execFileSync` throws ETIMEDOUT (process SIGKILLed),
+  // which the retry/backoff path below handles like any transient gh failure.
+  const ghBounded = (args) => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const e = new Error("open-PR scan budget exhausted");
+      e.scanBudgetExhausted = true;
+      throw e;
+    }
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: Math.min(PR_SCAN_CALL_TIMEOUT_MS, remaining),
+      killSignal: "SIGKILL",
+    });
+  };
+  let budgetExhausted = false;
   for (let attempt = 1; attempt <= 3; attempt++) {
+    if (Date.now() >= deadline) {
+      budgetExhausted = true;
+      break;
+    }
     try {
       const ids = new Set();
       const bigPRs = [];
@@ -325,7 +420,7 @@ function idsFromOpenPRs() {
       for (;;) {
         const args = ["api", "graphql", "-f", `query=${PR_FILES_QUERY}`, "-F", `owner=${owner}`, "-F", `name=${name}`];
         if (cursor) args.push("-F", `cursor=${cursor}`);
-        const raw = execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+        const raw = ghBounded(args);
         const prs = JSON.parse(raw)?.data?.repository?.pullRequests;
         if (!prs) throw new Error("unexpected GraphQL shape");
         for (const pr of prs.nodes || []) {
@@ -340,25 +435,28 @@ function idsFromOpenPRs() {
       }
       // >100-file PRs: fetch the full file list via REST pagination.
       for (const n of bigPRs) {
-        const raw = execFileSync(
-          "gh",
-          ["api", `repos/${repo}/pulls/${n}/files`, "--paginate", "--jq", ".[].filename"],
-          { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-        );
+        const raw = ghBounded(["api", `repos/${repo}/pulls/${n}/files`, "--paginate", "--jq", ".[].filename"]);
         for (const p of raw.split("\n")) {
           const m = p.match(ISSUE_ID_RE);
           if (m) ids.add(Number(m[1]));
         }
       }
       return { ids, complete: true };
-    } catch {
-      if (attempt < 3) sleepMs(attempt * 1000);
+    } catch (e) {
+      if (e && e.scanBudgetExhausted) {
+        budgetExhausted = true;
+        break;
+      }
+      // Per-call timeout (ETIMEDOUT/SIGKILL) or transient API error: back off
+      // and retry, but never sleep past the overall deadline.
+      const backoff = Math.min(attempt * 1000, Math.max(0, deadline - Date.now()));
+      if (attempt < 3 && backoff > 0) sleepMs(backoff);
     }
   }
   console.error(
-    "warning: open-PR id scan FAILED after 3 attempts (gh offline/unauthenticated/rate-limited). " +
-      "Allocating against main ∪ reservations ONLY — the id may collide with an in-flight PR's issue file " +
-      "(#2943). The CI gate check-issue-ids --against-main remains the hard backstop.",
+    `warning: open-PR id scan ${budgetExhausted ? `timed out (>${PR_SCAN_TOTAL_TIMEOUT_MS}ms)` : "FAILED after 3 attempts"} ` +
+      "(gh offline/unauthenticated/rate-limited/slow). Allocating against main ∪ reservations ONLY — the id may " +
+      "collide with an in-flight PR's issue file (#2943). The CI gate check-issue-ids --against-main remains the hard backstop.",
   );
   return { ids: new Set(), complete: false };
 }


### PR DESCRIPTION
## Summary

Fixes the team-blocking `scripts/claim-issue.mjs --allocate` hang, then uses the now-working allocator to file the #3045 private-method follow-up (#3080).

## #3079 — the allocate hang (measured, not the gh scan as assumed)

**Primary cause:** `idsFromAssignRef` read each reservation on the `issue-assignments` ref with its own `git cat-file` — **466+ sequential subprocess spawns** (>90s under container load), on **every** `--allocate` (even `--no-pr-scan`). Replaced with a **single `git cat-file --batch`** (byte-framed Buffer parse), faithful to the original `/^\d+$/` id filter — verified it yields the identical 459 numeric ids, correctly excluding non-numeric slice entries (`"1373b"`, `"1910-s2"`, `"983d"`) — plus a filename-derivation fallback if the batch read fails (fail-safe: never misses a high reservation).

**Secondary:** `execFileSync` had no timeout, so a stuck `gh`/`git` blocked indefinitely. Added bounded, env-overridable timeouts: `CLAIM_MAIN_FETCH_TIMEOUT_MS` (15s), `CLAIM_PR_SCAN_CALL_TIMEOUT_MS` (12s), and an overall `CLAIM_PR_SCAN_TOTAL_TIMEOUT_MS` (25s) budget after which the open-PR scan degrades to the existing fail-open fallback.

**Measured on the loaded container:** `--allocate --dry-run` 60s+timeout → ~9s; `--no-pr-scan` → ~7s; forced PR-scan timeout degrades gracefully in ~6s and still returns an id.

## #3080 — #3045 private-method follow-up (filed via the fixed allocator)

dev-3045 couldn't allocate an id for this (the allocator was hanging). Verify-first re-check on current main **corrects #3045's residual list**: private-method `.name` is **already resolved** (basic/generator/static/local all return `'#m'`); only **arrow-captured-`this` private-method value identity** (`this.#m === (()=>this)().#m`) still fails, for declarations — a method-value-identity substrate instance (folds into #2963/#3037), tagged `feasibility: hard model: fable`.

## Notes
- No merge of latest origin/main into the branch: the shared launch worktree carries **pre-existing unrelated uncommitted changes** (not part of these commits). The branch is 9 behind but **conflict-free** — origin/main never touched `claim-issue.mjs` and the two issue files are new. The merge queue re-validates on the merged state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS