### PR TITLE
fix(#3085): host-mode Symbol.prototype.toString / String(symbol)

### DIFF
--- a/plan/issues/3085-host-symbol-tostring.md
+++ b/plan/issues/3085-host-symbol-tostring.md
@@ -1,0 +1,85 @@
+---
+id: 3085
+title: "Host mode: Symbol.prototype.toString / String(symbol) drop the symbol id"
+status: done
+sprint: current
+priority: medium
+assignee: ttraenkler/dev-B2
+created: 2026-07-07
+completed: 2026-07-07
+feasibility: medium
+reasoning_effort: low
+task_type: bug
+area: codegen
+language_feature: symbol
+goal: es-conformance
+related: [2163, 1467]
+horizon: s
+---
+
+# #3085 — Host mode: `Symbol.prototype.toString` / `String(symbol)` drop the symbol id
+
+## Problem
+
+In **host mode** (the default, `nativeStrings` off — which is how the test262
+conformance baseline runs):
+
+- `Symbol('66').toString()` returned `"[object Object]"` (generic
+  `Object.prototype.toString` fallback), not `"Symbol(66)"`.
+- `String(Symbol('66'))` returned `"101"` — it fell through to the i32→number
+  coercion path and stringified the raw internal symbol **id**.
+
+Both should produce the SymbolDescriptiveString `"Symbol(" + (desc ?? "") + ")"`
+(§20.4.3.3.1). The native-strings / standalone path already handled this via
+`emitSymbolToString` (#2163), but that branch was gated on `ctx.nativeStrings`,
+so host mode had no path at all.
+
+## Root cause
+
+The two call sites in `src/codegen/expressions/calls.ts` only implemented the
+descriptive-string lowering under `if (... && ctx.nativeStrings)`:
+
+- `Symbol.prototype.toString` on a symbol-typed receiver (`isSymbolType`).
+- `String(sym)` when `staticJsTypeOf(arg) === "symbol"`.
+
+With `nativeStrings` false there was no `else`, so `.toString()` fell to the
+generic object fallback and `String(sym)` fell to the numeric-argument path.
+
+The host machinery to fix this already existed: symbols are boxed to real JS
+`Symbol`s via `__box_symbol(id)`, and their descriptions are registered via
+`__symbol_register_desc` (#1467) — this is why `Symbol('66').description`
+already returned `"66"` in host mode.
+
+## Fix
+
+- **`src/runtime.ts`** — add a `__symbol_to_string` host import:
+  `(externref) → externref`, returning `Symbol.prototype.toString.call(sym)`
+  (transparently unwraps Symbol-wrapper objects via ToObject). Sits next to the
+  existing `__symbol_description` accessor.
+- **`src/codegen/expressions/calls.ts`** — add host-mode (`!ctx.nativeStrings`)
+  branches at both sites that box the symbol to `externref` (via the existing
+  `compileExpression(..., { kind: "externref" })` → `__box_symbol` path) and
+  call `__symbol_to_string`. Mirrors the `.description` host lowering in
+  `property-access.ts`. The native-strings `emitSymbolToString` branch stays as
+  the standalone fallback (dual-mode preserved — no new host import without a
+  standalone path).
+
+## Acceptance criteria
+
+- [x] `Symbol('66').toString() === "Symbol(66)"`, `Symbol().toString() ===
+    "Symbol()"` in host mode.
+- [x] `String(Symbol('66')) === "Symbol(66)"`, `String(Symbol()) ===
+    "Symbol()"` in host mode.
+- [x] `Symbol.prototype.valueOf` unchanged (returns the primitive).
+- [x] No regressions in the symbol/string equivalence suites.
+- [x] Regression test: `tests/equivalence/issue-3085-symbol-tostring.test.ts`.
+
+Flips the test262 `Symbol/prototype/toString/*` and `String(symbol)` cluster
+(e.g. `Symbol/prototype/toString/{toString,undefined,toString-default-attributes-non-strict}.js`).
+
+## Note (out of scope)
+
+Two pre-existing `symbol-basic.test.ts` failures ("Symbol.iterator is a
+constant", "well-known symbols are consistent") reproduce on clean `main` and
+are unrelated to this change (a well-known symbol flows into `Number()`
+coercion). Left for a separate issue.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -11384,6 +11384,28 @@ function compileCallExpression(
         emitSymbolToString(ctx, fctx);
         return nativeStringType(ctx);
       }
+      // (#3085) Host mode: box the symbol id to a JS Symbol and route through the
+      // host SymbolDescriptiveString (§20.4.3.3). Without this the generic
+      // `.toString()` fallback drops the id and emits "[object Object]". Mirrors
+      // the `.description` host path (property-access.ts); the native-strings path
+      // above is the standalone fallback.
+      if (method === "toString" && expr.arguments.length === 0 && !ctx.nativeStrings) {
+        const symToStrIdx = ensureLateImport(
+          ctx,
+          "__symbol_to_string",
+          [{ kind: "externref" }],
+          [{ kind: "externref" }],
+        );
+        if (symToStrIdx !== undefined) {
+          const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+          if (recvType && recvType.kind !== "externref") {
+            coerceType(ctx, fctx, recvType, { kind: "externref" });
+          }
+          flushLateImportShifts(ctx, fctx);
+          fctx.body.push({ op: "call", funcIdx: symToStrIdx });
+          return { kind: "externref" };
+        }
+      }
     }
 
     if (isNumberMethodReceiver(ctx, receiverType) && propAccess.name.text === "toFixed") {
@@ -13213,6 +13235,26 @@ function compileCallExpression(
         }
         emitSymbolToString(ctx, fctx);
         return nativeStringType(ctx);
+      }
+      // (#3085) Host-mode counterpart: box the symbol id and route through the
+      // host SymbolDescriptiveString. Without this `String(sym)` falls through to
+      // the i32→number path and stringifies the raw symbol id (e.g. "101").
+      if (!ctx.nativeStrings && ctx.oracle.staticJsTypeOf(strArg0) === "symbol") {
+        const symToStrIdx = ensureLateImport(
+          ctx,
+          "__symbol_to_string",
+          [{ kind: "externref" }],
+          [{ kind: "externref" }],
+        );
+        if (symToStrIdx !== undefined) {
+          const recvType = compileExpression(ctx, fctx, strArg0, { kind: "externref" });
+          if (recvType && recvType.kind !== "externref") {
+            coerceType(ctx, fctx, recvType, { kind: "externref" });
+          }
+          flushLateImportShifts(ctx, fctx);
+          fctx.body.push({ op: "call", funcIdx: symToStrIdx });
+          return { kind: "externref" };
+        }
       }
 
       // #2160 — String(arr) in standalone: route an array argument through its

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11334,6 +11334,13 @@ assert._isSameValue = isSameValue;
           // this, so we just call it through.
           return Object.getOwnPropertyDescriptor(Symbol.prototype, "description")!.get!.call(sym);
         };
+      // (#3085) Symbol.prototype.toString → SymbolDescriptiveString (§20.4.3.3 /
+      // §20.4.3.3.1): "Symbol(" + (desc ?? "") + ")". Host-mode companion to the
+      // native `emitSymbolToString` (nativeStrings) path. Without this the generic
+      // `.toString()` fallback emits "[object Object]", and `String(sym)`
+      // stringifies the raw i32 symbol id. `Symbol.prototype.toString.call`
+      // transparently unwraps Symbol-wrapper objects (ToObject on receiver).
+      if (name === "__symbol_to_string") return (sym: any): any => Symbol.prototype.toString.call(sym);
       // Error.isError(value) — ES2025 static method (#1467).
       // Spec §20.5.2.1: returns true for any value with an [[ErrorData]]
       // internal slot. Cross-realm safe because it checks the slot, not

--- a/tests/equivalence/issue-3085-symbol-tostring.test.ts
+++ b/tests/equivalence/issue-3085-symbol-tostring.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./helpers.js";
+
+// #3085 — Host-mode `Symbol.prototype.toString` (§20.4.3.3 →
+// SymbolDescriptiveString §20.4.3.3.1) and `String(symbol)` (§22.1.1.1 step 1).
+// Before the fix, host mode dropped the symbol id: `sym.toString()` fell through
+// to the generic `.toString()` and produced "[object Object]", and `String(sym)`
+// stringified the raw i32 symbol id (e.g. "101"). Both now route through the
+// `__symbol_to_string` host import, matching the native-strings path.
+describe("#3085 host-mode Symbol descriptive string", () => {
+  it("Symbol.prototype.toString yields Symbol(desc)", async () => {
+    const ex = await compileToWasm(`
+      export function withDesc(): string { return Symbol('66').toString(); }
+      export function noDesc(): string { return Symbol().toString(); }
+      export function viaVar(): string { let s = Symbol('abc'); return s.toString(); }
+    `);
+    expect(ex.withDesc()).toBe("Symbol(66)");
+    expect(ex.noDesc()).toBe("Symbol()");
+    expect(ex.viaVar()).toBe("Symbol(abc)");
+  });
+
+  it("String(symbol) yields Symbol(desc) without throwing", async () => {
+    const ex = await compileToWasm(`
+      export function s1(): string { return String(Symbol('66')); }
+      export function s2(): string { let s: symbol = Symbol('x'); return String(s); }
+      export function s3(): string { return String(Symbol()); }
+    `);
+    expect(ex.s1()).toBe("Symbol(66)");
+    expect(ex.s2()).toBe("Symbol(x)");
+    expect(ex.s3()).toBe("Symbol()");
+  });
+
+  it("valueOf still returns the symbol primitive (unchanged)", async () => {
+    const ex = await compileToWasm(`
+      export function same(): number { let s = Symbol('66'); return s.valueOf() === s ? 1 : 0; }
+    `);
+    expect(ex.same()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

In **host mode** (default, `nativeStrings` off — how the test262 conformance baseline runs):
- `Symbol('66').toString()` returned `"[object Object]"` instead of `"Symbol(66)"`.
- `String(Symbol('66'))` returned `"101"` — it fell through to the i32→number path and stringified the raw internal symbol **id**.

Both should produce the SymbolDescriptiveString `"Symbol(" + (desc ?? "") + ")"` (§20.4.3.3.1 / §22.1.1.1). The native-strings / standalone path already handled this via `emitSymbolToString` (#2163), but that branch was gated on `ctx.nativeStrings`, so host mode had no path.

## Fix

- **`src/runtime.ts`** — add a `__symbol_to_string` host import `(externref) → externref` returning `Symbol.prototype.toString.call(sym)` (transparently unwraps Symbol-wrapper objects). Sits next to the existing `__symbol_description` accessor.
- **`src/codegen/expressions/calls.ts`** — add host-mode (`!ctx.nativeStrings`) branches at both sites (`sym.toString()` and `String(sym)`) that box the symbol to `externref` via the existing `__box_symbol` path and call `__symbol_to_string`. Mirrors the `.description` host lowering in `property-access.ts`. The native-strings `emitSymbolToString` branch stays as the standalone fallback (**dual-mode preserved** — no new host import without a standalone path).

The host description registry (`__symbol_register_desc`, #1467) is already populated at symbol creation, which is why `Symbol('66').description` already returned `"66"`.

## Testing

- New regression test: `tests/equivalence/issue-3085-symbol-tostring.test.ts` ✓ (3 tests).
- No regressions in the symbol/string equivalence suites (the 2 pre-existing `symbol-basic.test.ts` failures reproduce on clean `main` and are unrelated — a well-known symbol flows into `Number()` coercion).

Flips the test262 `Symbol/prototype/toString/*` and `String(symbol)` cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS