### PR TITLE
fix(#3074): dispatch any-typed HOF callbacks on the gc/host lane (keystone: ~1487 TypedArray harness cluster)

### DIFF
--- a/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
+++ b/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
@@ -1,7 +1,8 @@
 ---
 id: 3074
 title: "TypedArray harness-wrapper callback never executes → vacuous fail (both lanes; persists after #2939/#2940)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-keystone
 sprint: Backlog
 priority: high
 feasibility: hard

--- a/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
+++ b/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
@@ -90,3 +90,72 @@ built-ins/TypedArrayConstructors/ctors/typedarray-arg/proto-from-ctor-realm.js
   materially in BOTH lanes (target: <200 default), i.e. the TypedArray harness
   wrapper actually invokes its callback and the body assertions run.
 - No net regression in either lane's pass count.
+
+## Root cause + fix (dev-keystone, 2026-07-07 — VERIFIED EMPIRICALLY)
+
+**Root cause (measured, not spec-derived).** #2939's nested-scope callback
+pre-registration in `ensureFuncValueWrappersRegistered`
+(`src/codegen/expressions/calls.ts`) was gated on `ctx.standalone`. So the
+gc/host (default) lane never registered the harness-wrapper callback as an
+inline-dispatch candidate. WAT-verified on current `main`: the higher-order
+body's `fn(constructors[i])` compiled to
+
+```
+local.get 1; struct.get 2 1; local.get 3; array.get 1  ;; evaluate constructors[i]
+drop                                                    ;; DROP the arg
+ref.null extern; drop                                   ;; the CALL itself is DROPPED — fn never loaded
+```
+
+i.e. `tryEmitInlineDynamicCall` saw ZERO candidates → returned `null` → the
+caller's graceful `ref.null.extern` drop ran. The callback body (holding every
+assertion) never executed, so the runner's `-262` vacuity gate fired.
+
+Probe result on current `main` (faithful harness wrap, `test()` returns
+`1`=executed / `-262`=vacuous): **gc = -262 (VACUOUS), standalone = 1
+(EXECUTED)** — the default lane is the broken one (the LARGER cluster, matching
+the 1,535 vs 448 harvest counts). The callback DOES compile to a real closure
+struct on the gc lane too (`ref.func; struct.new $__fn_wrap_*; extern.convert_any`
+— no `__make_callback`), so the runtime value IS a wrapper struct the inline
+dispatcher can handle; the only defect was the compile-order candidate gap.
+
+**Fix.** De-gate the pre-registration to run on BOTH lanes (keeping the
+all-externref param + externref/void-return restriction that prevents the
+over-arity numeric-param invalid-Wasm CE). Safe because: (a) the affected tests
+are ALL currently vacuous FAILS, so dispatch can only move them fail→pass or
+stay fail (never pass→fail); (b) a callback that instead flows through the
+`__make_callback` host path only pre-registers a wrapper TYPE (the struct.new
+stays lazy at the value site), whose extra dispatch arm never `ref.test`-matches
+a JS-function externref → falls through to the same drop as before.
+
+Verified (both lanes now EXECUTE): 1-arg + 2-arg harness shapes, arity tolerance
+(extra arg ignored), and genuine arg-correctness (sum of real per-iteration args
+= 100, not a body-runs-but-drops-args false positive). `tests/issue-3074.test.ts`
+(4 tests). Zero regressions in the existing closure/dispatch suite (identical
+7-fail/24-pass pre-existing count on `main` and branch).
+
+## Corrected scope — any[]-element dispatch (#3083) is a SEPARATE follow-up
+
+This PR fixes the **HOF-callback-invoke** site (`fn(...)` where `fn` is an
+`any`-typed parameter) — the ~1487-file TypedArray harness cluster, the keystone.
+
+It does **not** cover the **any[]-element-call** site
+(`validators[i](x)` where `validators` is `any[]`/`any` — the #3083 matchAll
+cluster, ~13 files). Root cause of THAT gap, verified: `arr[i](args)` routes to
+`compileCallableElementAccessCall`, which derives the wrapper struct from the
+element type's **static call signatures**. A **typed** `CB[]` element HAS
+signatures → dispatches correctly on both lanes (probe: returns 55). An
+`any[]`/`any` element has **no call signatures** → the function returns
+`undefined` → the drop-everything fallback. Unlike the identifier-callee path,
+the element-access path has **no runtime-`ref.test` dispatch fallback**
+(`tryEmitInlineDynamicCall` is only reached from the identifier-callee branch,
+gated on `isKnownVariable`).
+
+Closing #3083 needs a **bounded but distinct** change: a runtime-`ref.test`
+dispatch fallback in the element-access branch (mirroring
+`tryEmitInlineDynamicCall`) plus candidate pre-registration for array-literal
+element callbacks. It is deliberately NOT bundled here — the element-access
+call path is extremely hot, so adding a new dispatcher there carries a broad
+regression surface that would jeopardize the clean, high-value keystone win for
+only ~13 additional files. It is NOT #2773 substrate (that is about dynamic
+value READS returning NaN/null; this is dispatch), so it belongs to #3083's
+domain as a follow-up dispatch-shim generalization.

--- a/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
+++ b/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
@@ -159,3 +159,51 @@ regression surface that would jeopardize the clean, high-value keystone win for
 only ~13 additional files. It is NOT #2773 substrate (that is about dynamic
 value READS returning NaN/null; this is dispatch), so it belongs to #3083's
 domain as a follow-up dispatch-shim generalization.
+
+## Measured value + downstream gaps (VERIFY-FIRST — corrects the ~1800 estimate)
+
+Measured on real test262 via `runTest262File` (gc/host lane), branch vs current
+`main`:
+
+- **Zero regressions.** 113 currently-passing gc-lane callback tests (two
+  samples, non-harness): **0 pass→nonpass flips, 0 changes**. 24-file
+  TypedArray/fill+copyWithin + 30-file BigInt-TA harness samples: **0
+  pass→fail**. The fix is regression-safe against the current baseline.
+
+- **The keystone is the dispatch ENABLER + honest-classifier, not (yet) a large
+  pass-count jump.** The affected harness tests are already scored
+  `fail vacuous:true` in the default baseline, and after the fix they EXECUTE
+  and **honest-fail on a downstream gap** rather than pass. So the immediate
+  merge_group pass-count delta is modest; the durable win is (a) the general
+  gc-lane HOF-callback dispatch is now correct (a real compiler bug, benefits
+  any compiled higher-order code, not just TypedArray), and (b) ~1487 dishonest
+  vacuous scores become honest.
+
+Downstream gaps that gate the harness cluster's vacuous→**pass** realization
+(each a separate follow-up; the keystone is a prerequisite for all of them —
+without dispatch, none of these bodies run at all):
+
+1. **Dynamic `new TA(...)` on the gc/host lane.** Once the callback dispatches,
+   its body does `new TA(...)` where `TA` is an `any`-typed constructor value →
+   `No dependency provided for extern class "TA"` (the compiler treats a runtime
+   constructor value as a host extern class needing an import). This is the
+   dominant honest-fail after the fix (dynamic-constructor gap, #1679 area /
+   the "No dependency for extern class" class #812/#814). Standalone hits the
+   analogous native-construct gap.
+2. **Runner shim faithfulness — non-BigInt `testWithTypedArrayConstructors`
+   passes only 1 arg** (`fn(ctor)`), but the REAL test262 harness
+   (`testWithAllTypedArrayConstructors`) calls `f(constructor, boundArgFactory)`
+   — **2 args**. Many callbacks declare `function(TA, makeCtorArg)` (2 params,
+   void); called with 1 arg they are OVER-ARITY VOID candidates, which
+   `tryEmitInlineDynamicCall` intentionally SKIPS (#1837 — a void over-arity pad
+   makes a stack-invalid `call_ref`), so they stay vacuous even after the
+   de-gate (measured: 8/12 non-CE `fill/*.js` still vacuous). Making the
+   non-BigInt shim pass a `boundArgFactory` passthrough (mirroring the existing
+   BigInt shim) matches the real harness and lets the 2-param callbacks
+   dispatch. Deliberately NOT bundled here — it is coupled to the honest-baseline
+   rework (#3086/dev-honest is measuring against the current shim), and the
+   value is still gated on gap (1). A clean follow-up once the honest baseline
+   lands.
+3. **BigInt TypedArray i64 codegen CE** (`Binary emit error: RangeError: offset
+   is out of bounds`) — ~22/30 sampled BigInt-TA files; pre-existing, unrelated
+   to dispatch.

--- a/plan/issues/3087-dynamic-new-any-constructor-gc-lane.md
+++ b/plan/issues/3087-dynamic-new-any-constructor-gc-lane.md
@@ -1,0 +1,71 @@
+---
+id: 3087
+title: "codegen: dynamic `new TA(...)` on an any-typed constructor value fails on the gc/host lane (No dependency provided for extern class) — dominant honest-fail after #3074"
+status: ready
+sprint: Backlog
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: dynamic-construction, typed-arrays, closures
+goal: host-independence
+related: [3074, 2939, 2940, 1679, 812, 814]
+created: 2026-07-07
+origin: "2026-07-07 measured under #3074 keystone validation (dev-keystone): after the HOF-callback dispatch fix lands, the harness callback bodies EXECUTE and honest-fail here — the #1 remaining conversion of un-masked bodies to real passes."
+---
+
+# #3087 — dynamic `new TA(...)` on an `any`-typed constructor value (gc/host lane)
+
+## Problem
+
+Once #3074 makes the TypedArray harness-wrapper callback dispatch on the gc/host
+lane, the callback body runs `new TA(...)` where `TA` is the constructor value
+passed positionally into the `any`-typed callback parameter
+(`testWith*Constructors(function (TA) { new TA(3); … })`). The compiler treats a
+runtime constructor value used in a `NewExpression` callee position as a **host
+extern class** needing an import named after the local (`TA`), which does not
+exist, so instantiation/execution fails with:
+
+```
+No dependency provided for extern class "TA" in __closure_N() at source L..
+```
+
+This is the **dominant honest-fail** for the ~1487-file TypedArray harness
+cluster after #3074 — i.e. the biggest single remaining blocker to converting
+those (now-honestly-failing) bodies into real passes. Measured: every executing
+harness file in the #3074 validation samples honest-failed here.
+
+## Why it surfaced now
+
+#3074 (dispatch of an `any`-typed HOF callback on the gc lane) is a prerequisite:
+before it, the callback body never ran, so `new TA(...)` was never reached (the
+test was vacuous). #3074 makes the body execute; this construction gap is what
+it then hits.
+
+## Scope / approach (needs verification-first)
+
+`new (dynamicCtorValue)(args)` where the callee's static type is `any`/externref
+must construct via a runtime dispatch, not a static extern-class import:
+- Related dynamic-constructor work: #1679 (`compile-acorn-new-this-dynamic-constructor`).
+- Related "No dependency provided for extern class" class: #812 (Test262Error),
+  #814 (ArrayBuffer).
+- On the gc/host lane a host construct-bridge (`Reflect.construct`-style, or a
+  `__construct_dynamic(ctorExternref, args)` import) can invoke the real
+  constructor value. On standalone the analogous native-construct path is needed
+  (the substrate already special-cases some builtin ctors; a general
+  any-ctor `new` is the gap).
+
+## Acceptance
+
+- The #3074 keystone-validation harness files whose bodies do `new TA(...)` flip
+  from honest-fail ("No dependency provided for extern class TA") to genuine
+  pass (or an honest DIFFERENT failure for a truly-unsupported downstream
+  semantic), on the gc/host lane.
+- No regression in either lane's pass count.
+
+## Notes
+
+Blocks the TypedArray conformance realization gated behind #3074. This is the
+recommended highest-value next step after #3074 (#2790) lands.

--- a/plan/issues/3088-testwith-typedarray-shim-two-arg-faithfulness.md
+++ b/plan/issues/3088-testwith-typedarray-shim-two-arg-faithfulness.md
@@ -1,0 +1,64 @@
+---
+id: 3088
+title: "test262-runner: non-BigInt testWithTypedArrayConstructors shim passes 1 arg but the real harness passes 2 (constructor + boundArgFactory) — 2-param callbacks stay vacuous via the #1837 over-arity-void skip"
+status: ready
+sprint: Backlog
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bugfix
+area: test262-harness
+language_feature: typed-arrays, test262-harness, closures
+goal: host-independence
+related: [3074, 2939, 2940, 3086, 1837]
+created: 2026-07-07
+origin: "2026-07-07 measured under #3074 keystone validation (dev-keystone): 8/12 non-CE fill/*.js stay vacuous after the dispatch fix because their function(TA, makeCtorArg) callback is over-arity-void for the 1-arg shim."
+---
+
+# #3088 — non-BigInt `testWithTypedArrayConstructors` shim under-passes (1 arg vs real harness's 2)
+
+## Problem
+
+The runner shim (`tests/test262-runner.ts`) for the non-BigInt
+`testWithTypedArrayConstructors(fn)` calls `fn(constructors[i])` — **1 arg**. But
+the real test262 harness (`harness/testTypedArray.js` →
+`testWithAllTypedArrayConstructors`) calls `f(constructor, boundArgFactory)` —
+**2 args**. Many real tests declare `function (TA, makeCtorArg) { … }` (2 params,
+void) and use `makeCtorArg` in the body (`new TA(makeCtorArg([0,0,0]))`).
+
+Even after #3074 makes nested callbacks dispatch on the gc lane, a 2-param VOID
+callback invoked with 1 arg is an **over-arity void candidate**, which
+`tryEmitInlineDynamicCall` intentionally SKIPS (#1837 — a void closure padded
+past its arity marshals a stack-invalid `call_ref`). So those callbacks are
+still dropped → still vacuous. Measured under #3074: **8/12 non-CE
+`built-ins/TypedArray/prototype/fill/*.js` stay `vacuous:true`** for exactly this
+reason (e.g. `fill-values.js`, `fill-values-relative-end.js`).
+
+## Fix
+
+Make the non-BigInt shim pass a second `boundArgFactory` argument — a
+passthrough factory mirroring the existing BigInt shim's
+`__ta_makeCtorArgPassthrough` — so the 2-param callbacks are called with 2 args
+(arity matches → dispatches). This also makes the shim faithful to the real
+harness signature.
+
+- 1-param callbacks `function(TA)` called with 2 args: the extra arg is
+  truncated by the dispatcher (under-arity is fine) — unchanged behavior.
+- The BigInt variant already does this; this just brings the non-BigInt variant
+  to parity.
+
+## Sequencing
+
+Do this **after** the honest baseline (#3086 / dev-honest) lands — that work
+measures the vacuity signature against the CURRENT shim, so changing the shim
+mid-flight would perturb its baseline. Bounded, runner-only, low risk once
+unblocked. Value is still gated on #3087 (dynamic `new TA`) for the vacuous→pass
+conversion; this converts more vacuous→honest (executing) results.
+
+## Acceptance
+
+- The `fill/*.js` (and sibling) 2-param-callback harness tests no longer report
+  `vacuous: harness-wrapper callback never executed` — the callback executes
+  (then passes, or honest-fails on #3087, per its body).
+- Shim signature matches real test262 (`f(constructor, boundArgFactory)`).
+- No net regression.

--- a/plan/issues/3089-bigint-typedarray-i64-binary-emit-offset-out-of-bounds.md
+++ b/plan/issues/3089-bigint-typedarray-i64-binary-emit-offset-out-of-bounds.md
@@ -1,0 +1,57 @@
+---
+id: 3089
+title: "codegen: BigInt TypedArray tests fail to compile — 'Binary emit error: RangeError: offset is out of bounds' (i64 codegen, ~22/30 sampled, pre-existing)"
+status: ready
+sprint: Backlog
+priority: medium
+horizon: m
+feasibility: hard
+task_type: bugfix
+area: codegen
+language_feature: bigint, typed-arrays, i64
+goal: host-independence
+related: [3074, 1349, 1644]
+created: 2026-07-07
+origin: "2026-07-07 surfaced (not caused) during #3074 keystone validation (dev-keystone): the BigInt-TA harness sample is dominated by a compile-time binary-emit RangeError, independent of dispatch."
+---
+
+# #3089 — BigInt TypedArray compile error: `Binary emit error: RangeError: offset is out of bounds`
+
+## Problem
+
+A large fraction of `built-ins/TypedArray*/**/BigInt/**` and
+`ctors-bigint/**` tests fail at COMPILE time with:
+
+```
+L..:1 Binary emit error: RangeError: offset is out of bounds
+```
+
+Measured under #3074's keystone validation: **~22 of 30** sampled
+`testWithBigIntTypedArrayConstructors` files are `compile_error` with this exact
+signature — **independent of the closure-dispatch fix** (they were already
+`compile_error` on `main`; #3074 does not change them). Sample:
+`TypedArrayConstructors/from/BigInt/inherited.js`,
+`ctors-bigint/object-arg/iterating-throws.js`,
+`TypedArray/prototype/slice/BigInt/return-abrupt-from-start.js`.
+
+## Why filed now
+
+It is the **third downstream gap** (alongside #3087 dynamic-`new TA` and #3088
+runner-shim faithfulness) standing between the #3074 keystone and real BigInt
+TypedArray conformance. Tracked so the BigInt-TA cluster's blockers are
+enumerated. Pre-existing i64/BigInt codegen defect — NOT a #3074 regression.
+
+## Scope / approach
+
+The `Binary emit error: RangeError: offset is out of bounds` is a binary-encoder
+overflow (a LEB/section offset computed out of range) triggered on the i64/BigInt
+paths these tests exercise. Needs a verify-first trace of one minimal repro to
+localize the encoder site (likely an i64 constant / memory-offset / type-section
+index miscomputation on the BigInt TypedArray element path). Related BigInt i64
+work: #1349 / #1644 (i64-brand ValType).
+
+## Acceptance
+
+- The sampled BigInt-TA `compile_error` files compile (then pass or honest-fail
+  on downstream semantics), on both lanes as applicable.
+- No net regression.

--- a/plan/log/fable-window-worklist.md
+++ b/plan/log/fable-window-worklist.md
@@ -52,6 +52,38 @@ and the 13 matchAll files pass→honest **with no per-test work**. (Same
 closure-through-`externref` dispatch that Tier-1 **#3049** iterator-helpers and
 **#3050**/#3076 need — landing the keystone also unblocks those.)
 
+**UPDATE 2026-07-07 (dev-keystone, verify-first) — the keystone landed as
+`#3074`, corrected root cause + value:** The bug was NOT a missing dispatch
+shim. `#2939` already landed the nested-scope candidate registration but
+**gated it on `ctx.standalone`**, so the gc/HOST (default) lane never registered
+the harness callback → `fn(...)` dropped. The default lane is the broken one
+(1,535 default > 448 standalone). Fix = **de-gate to both lanes** (one line;
+`src/codegen/expressions/calls.ts` `ensureFuncValueWrappersRegistered`). Draft
+PR **#2790** (held for the `#3086` honest baseline). **0 regressions** measured
+(113 non-harness + 54 TypedArray real-corpus samples).
+
+**Corrected value (was ~1800 pass — optimistic):** the de-gate is the dispatch
+**ENABLER + honest-classifier**, not an immediate ~1800 pass jump. The un-masked
+harness bodies EXECUTE but then **honest-fail on downstream gaps**, so the
+immediate pass delta is modest; the durable wins are the general gc-lane
+HOF-dispatch bug fix + ~1487 dishonest-vacuous scores becoming honest. The
+vacuous→**pass** realization is gated on three filed follow-ups (keystone is a
+prerequisite for all):
+
+- **`#3087`** — dynamic `new TA(...)` on the gc/host lane ("No dependency
+  provided for extern class TA"). **Dominant honest-fail after #3074 → highest-
+  value next step.** (compiler; #1679/#812/#814 area)
+- **`#3088`** — non-BigInt `testWithTypedArrayConstructors` runner shim passes
+  1 arg vs the real harness's 2 → 2-param callbacks stay vacuous via the #1837
+  over-arity-void skip (runner, bounded; sequence AFTER the honest baseline).
+- **`#3089`** — BigInt-TA i64 `Binary emit error: offset out of bounds`
+  (~22/30, pre-existing CE, unrelated to dispatch).
+
+The `any[]`-element site (`validators[i](x)`, `#3083` matchAll ~13 files) is a
+DISTINCT dispatch path (needs a runtime-`ref.test` fallback in the hot
+element-access branch; a typed `CB[]` already dispatches) — deliberately not
+bundled with the keystone; belongs to `#3083`. It is NOT #2773 substrate.
+
 > **Caveat (measured — do not over-credit #2939):** the HOF-with-callback
 > cluster is **dual-root**. I verified one `map` file
 > (`15.4.4.19-8-c-ii-1.js`): the callback *did* dispatch but received **wrong

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2879,15 +2879,36 @@ function ensureFuncValueWrappersRegistered(ctx: CodegenContext, sf: ts.SourceFil
   // which is what the dispatch discriminates on) for every func-expr / arrow used
   // as a call argument or a variable initializer.
   //
-  // Standalone-gated: on the gc/host lane a callback may instead take the
-  // `__make_callback` host path and never materialize a closure wrapper, so
-  // pre-registering one there would add a module type that lazy compilation
-  // would not — a byte change on the default lane. In standalone there is no
-  // host `__make_callback`, so every func-expr/arrow value compiles to a closure
-  // and the wrapper type is created regardless; pre-creating it only reorders
-  // when (all references stay internally consistent — same discipline the
-  // declaration loop above already relies on).
-  if (ctx.standalone) {
+  // (#3074) Applied on BOTH lanes. It was originally standalone-gated for
+  // byte-inertness on the gc/host lane, but that left the DEFAULT lane's
+  // harness-wrapper cluster (`testWith*TypedArrayConstructors(function(TA){…})`)
+  // stuck vacuous — measured at 1,535 default records vs 448 standalone, i.e.
+  // the LARGER cluster (#3074). Empirically the harness callback compiles to a
+  // real closure struct on the gc lane too (`ref.func …; struct.new $__fn_wrap_*;
+  // extern.convert_any` — verified via WAT), so the runtime value flowing into
+  // the higher-order body IS a wrapper struct that `tryEmitInlineDynamicCall`
+  // dispatches correctly; the ONLY reason the gc lane dropped the call was the
+  // compile-order candidate gap this pre-registration closes (identical to the
+  // declaration loop above, which already runs un-gated on both lanes).
+  //
+  // Safety on the gc lane (the two reasons for the old gate, both addressed):
+  //  1. Byte change on the default lane — intended: #3074 wants the gc lane
+  //     fixed, and the affected tests are ALL currently VACUOUS FAILS
+  //     (`return -262`), so dispatch can only move them fail→pass or stay fail
+  //     (never a pass→fail regression). The caller's only alternative to a
+  //     successful inline dispatch is the graceful `ref.null.extern` drop, so
+  //     enabling dispatch is a strict improvement.
+  //  2. A callback that instead takes the `__make_callback` host path (passed
+  //     to a host builtin, e.g. `arr.map(cb)`) never materializes a wrapper
+  //     STRUCT — only the wrapper TYPE is pre-registered here (the trampoline /
+  //     struct.new stays lazy at the value site). So an extra dispatch arm for
+  //     that signature never `ref.test`-matches the JS-function externref at
+  //     runtime → falls through to the default → same drop as before. No
+  //     behavior change for `__make_callback` callbacks, only the harness /
+  //     compiled-HOF callbacks gain dispatch. `getOrCreateFuncRefWrapperTypes`
+  //     is signature-cached, so the value site reuses the same funcTypeIdx —
+  //     no index inconsistency (the declaration loop already relies on this).
+  {
     const seenFnNodes = new Set<ts.Node>();
     const usedAsValueFn = (node: ts.FunctionExpression | ts.ArrowFunction): void => {
       if (seenFnNodes.has(node)) return;

--- a/tests/issue-3074.test.ts
+++ b/tests/issue-3074.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3074 — TypedArray harness-wrapper callback stays vacuous in BOTH lanes.
+ *
+ * A closure/callback held in an `any`-typed PARAMETER and invoked from a
+ * higher-order function (`fn(x)`) must dispatch and run its body. #2939 fixed
+ * this for the STANDALONE lane by pre-registering nested-scope function-
+ * expression / arrow callbacks as inline-dispatch candidates, but the
+ * registration was gated on `ctx.standalone`, so the gc/host (default) lane
+ * still saw ZERO candidates and silently DROPPED the call (`drop; ref.null.
+ * extern`). That is the reopened #3074 cluster — the LARGER of the two
+ * (1,535 default vs 448 standalone).
+ *
+ * These tests mirror the exact test262 harness-wrapper wrap shape:
+ *   - the higher-order function lives at MODULE TOP LEVEL (the harness preamble)
+ *   - the callback function-expression is defined INSIDE `export function test()`
+ *   - `__assert_count` is bumped inside the callback; if the callback never
+ *     dispatches it stays at its initial value and `test()` returns the -262
+ *     vacuity sentinel (the runner's real vacuity gate).
+ */
+
+async function runBoth(src: string): Promise<Record<string, number | string>> {
+  const out: Record<string, number | string> = {};
+  for (const target of ["gc", "standalone"] as const) {
+    const r = await compile(src, { fileName: "test.ts", target });
+    if (!r.success) {
+      out[target] = "CE:" + (r.errors?.map((e) => e.message).join("; ") ?? "");
+      continue;
+    }
+    const impObj = r.importObject;
+    const { instance } = await WebAssembly.instantiate(r.binary, impObj);
+    (impObj as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+    out[target] = (instance.exports as { test?: () => number }).test?.() ?? NaN;
+  }
+  return out;
+}
+
+describe("#3074 harness-wrapper callback dispatches on both lanes", () => {
+  it("1-arg wrapper, 1-param nested callback executes (not vacuous)", async () => {
+    const src = `
+let __assert_count: number = 1;
+let __harness_cb_expected: number = 0;
+function testWithTypedArrayConstructors(fn: any): void {
+  const constructors = [Int8Array, Uint8Array, Int16Array, Uint16Array];
+  for (let i = 0; i < constructors.length; i++) {
+    __harness_cb_expected = __harness_cb_expected + 1;
+    fn(constructors[i]);
+  }
+}
+export function test(): number {
+  try {
+    testWithTypedArrayConstructors(function (TA: any) { __assert_count = __assert_count + 1; });
+  } catch (e) { return -1; }
+  if (__harness_cb_expected > 0 && __assert_count === 1) { return -262; }
+  return 1;
+}`;
+    const res = await runBoth(src);
+    expect(res.gc).toBe(1); // EXECUTED (was -262 vacuous before the fix)
+    expect(res.standalone).toBe(1);
+  });
+
+  it("2-arg wrapper, 2-param nested callback executes (BigInt / makeCtorArg shape)", async () => {
+    const src = `
+let __assert_count: number = 1;
+let __harness_cb_expected: number = 0;
+function __ta_makeCtorArgPassthrough(x: any): any { return x; }
+function testWithBigIntTypedArrayConstructors(fn: any): void {
+  const constructors = [BigInt64Array, BigUint64Array];
+  for (let i = 0; i < constructors.length; i++) {
+    __harness_cb_expected = __harness_cb_expected + 1;
+    fn(constructors[i], __ta_makeCtorArgPassthrough);
+  }
+}
+export function test(): number {
+  try {
+    testWithBigIntTypedArrayConstructors(function (TA: any, makeCtorArg: any) { __assert_count = __assert_count + 1; });
+  } catch (e) { return -1; }
+  if (__harness_cb_expected > 0 && __assert_count === 1) { return -262; }
+  return 1;
+}`;
+    const res = await runBoth(src);
+    expect(res.gc).toBe(1);
+    expect(res.standalone).toBe(1);
+  });
+
+  it("2-arg wrapper, 1-param callback: arity tolerance (extra arg ignored)", async () => {
+    const src = `
+let __assert_count: number = 1;
+let __harness_cb_expected: number = 0;
+function __ta_makeCtorArgPassthrough(x: any): any { return x; }
+function testWithBigIntTypedArrayConstructors(fn: any): void {
+  const constructors = [BigInt64Array, BigUint64Array];
+  for (let i = 0; i < constructors.length; i++) {
+    __harness_cb_expected = __harness_cb_expected + 1;
+    fn(constructors[i], __ta_makeCtorArgPassthrough);
+  }
+}
+export function test(): number {
+  try {
+    testWithBigIntTypedArrayConstructors(function (TA: any) { __assert_count = __assert_count + 1; });
+  } catch (e) { return -1; }
+  if (__harness_cb_expected > 0 && __assert_count === 1) { return -262; }
+  return 1;
+}`;
+    const res = await runBoth(src);
+    expect(res.gc).toBe(1);
+    expect(res.standalone).toBe(1);
+  });
+
+  it("callback receives CORRECT args through the dispatch (genuine execution, not just body-runs)", async () => {
+    // Sum of 10+20+30+40 = 100 proves the real per-iteration arg reaches the
+    // callback body (a false 'executed' that dropped the arg would sum wrong).
+    const src = `
+let __hits: number = 0;
+function harness(fn: any): void {
+  const vals = [10, 20, 30, 40];
+  for (let i = 0; i < vals.length; i++) { fn(vals[i]); }
+}
+export function test(): number {
+  harness(function (v: any) { __hits = __hits + (v as number); });
+  return __hits;
+}`;
+    const res = await runBoth(src);
+    expect(res.gc).toBe(100);
+    expect(res.standalone).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the **#1 keystone** conformance gap (#3074, reopened from #2939/#2940): a
closure/callback held in an `any`-typed **parameter** and invoked from a
higher-order function (`fn(...)`) was **not dispatched on the gc/host (default)
lane** — the call compiled to a graceful drop (`drop; ref.null.extern`), so the
callback body (holding every assertion) never ran and the runner's `-262`
vacuity gate fired. This is the largest default-lane failure cluster (**1,535
records**, TypedArray/TypedArrayConstructors harness wrappers) plus a large
standalone cluster (448).

## Root cause (verified empirically, not spec-derived)

#2939 pre-registered nested-scope function-expression / arrow callbacks as
inline-dispatch candidates (`ensureFuncValueWrappersRegistered`), but gated it on
`ctx.standalone`. So the **gc/host lane never registered** the harness callback
and `tryEmitInlineDynamicCall` saw ZERO candidates → dropped the call.

WAT-verified: the harness callback compiles to a **real closure struct** on the
gc lane too (`ref.func; struct.new $__fn_wrap_*; extern.convert_any` — no
`__make_callback`), so the runtime value is a wrapper struct the inline
dispatcher can handle; the only defect was the compile-order candidate gap.

Probe (`test()` returns `1`=executed / `-262`=vacuous):
before = **gc `-262`, standalone `1`**; after = **gc `1`, standalone `1`**.

## Fix

De-gate the nested-callback pre-registration to run on **both** lanes (keeping
the all-externref restriction that prevents the over-arity numeric-param
invalid-Wasm CE). One-line gate change + comment. See the issue file for the
full safety argument.

## Validation

- `tests/issue-3074.test.ts` (4 tests): 1-arg + 2-arg harness shapes, arity
  tolerance, and **genuine arg-correctness** (real per-iteration args reach the
  body, sum = 100) — all EXECUTE on both lanes.
- Zero regressions in the existing closure/dispatch suite (identical
  7-fail/24-pass pre-existing count on `main` and branch).
- Standalone lane behaviour is **unchanged** (it already ran this registration);
  only the gc/default lane gains it.

## ⚠️ DRAFT — do NOT enqueue until the honest default baseline lands

This fix converts default-lane **dishonest-vacuous** results into honest
pass/fail. The harness cluster is already scored vacuous-FAIL in the baseline
(so those are pure fail→{pass,fail} gains), but any non-harness dropped-callback
test that currently passes *vacuously* would flip to an honest fail and read as
a regression against the CURRENT (pre-honest) baseline. Per the keystone
sequencing plan this must be validated against the **honest default baseline**
(dev-honest) before merge. Held as draft so `auto-enqueue` skips it.

## Follow-up (out of scope, documented)

The **any[]-element-call** site (`validators[i](x)` on an `any[]` of closures —
the #3083 matchAll cluster, ~13 files) is a **separate** dispatch site: it routes
to `compileCallableElementAccessCall`, which needs static call signatures an
`any` element lacks (a typed `CB[]` already dispatches). Closing it needs a
runtime-`ref.test` fallback in the (hot) element-access branch — deliberately not
bundled with the keystone. Not #2773 substrate. Belongs to #3083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS