### PR TITLE
ci(workflows): bump Node-20 actions to Node-24 majors to clear deprecation warnings

### DIFF
--- a/.github/workflows/approve-fork-runs.yml
+++ b/.github/workflows/approve-fork-runs.yml
@@ -38,12 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: |
             scripts/approve-fork-runs.mjs
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       - name: Approve trusted-fork action_required runs

--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -73,12 +73,12 @@ jobs:
   enqueue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: |
             scripts/enqueue-green-prs.mjs
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       # Mint a GitHub App installation token (#2523). Enqueuing via GITHUB_TOKEN

--- a/.github/workflows/auto-park-merge-group-failures.yml
+++ b/.github/workflows/auto-park-merge-group-failures.yml
@@ -55,12 +55,12 @@ jobs:
       github.event.workflow_run.event == 'merge_group' &&
       github.event.workflow_run.conclusion == 'failure'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: |
             scripts/auto-park-merge-group-failure.mjs
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       - name: Self-check the parking logic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
           PARTIAL_OUT: equiv-partial-${{ matrix.shard }}.json
         run: node scripts/equivalence-gate.mjs
       - name: Upload partial result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: equiv-partial-${{ matrix.shard }}
           path: equiv-partial-${{ matrix.shard }}.json
@@ -390,7 +390,7 @@ jobs:
           corepack prepare pnpm@10.30.2 --activate
       - run: pnpm install --frozen-lockfile
       - name: Download shard partials
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: equiv-partial-*
           path: equiv-partials

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Evaluate / record CLA acceptance
         if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           # Exposed so the gate module's own fetch()-based org-membership check
           # has a token. github-script also injects an authenticated `github`

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload diff-test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           retention-days: 1
@@ -62,7 +62,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload diff-test optimize report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           retention-days: 1
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload triage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           retention-days: 1
           name: diff-triage-report

--- a/.github/workflows/queue-unstick.yml
+++ b/.github/workflows/queue-unstick.yml
@@ -43,12 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           sparse-checkout: |
             scripts/unstick-merge-queue.mjs
           sparse-checkout-cone-mode: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
       # Mint a GitHub App token (#2523). The dequeue+re-enqueue this workflow


### PR DESCRIPTION
## What

GitHub Actions annotates every run of several workflows with the [Node.js 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This bumps the straggler actions still targeting Node 20 up to the Node-24 majors already used elsewhere in the repo:

| Action | Before | After | Workflows |
|---|---|---|---|
| `actions/upload-artifact` | v4 | v6 | ci.yml, diff-test.yml |
| `actions/download-artifact` | v4 | v7 | ci.yml |
| `actions/checkout` | v4 | v5 | approve-fork-runs, auto-enqueue, auto-park-merge-group-failures, queue-unstick |
| `actions/setup-node` | v4 | v6 | (same four) |
| `actions/github-script` | v7 | v8 | cla-check.yml |

## Why it's safe

- The target majors already run on **node24** (empirically: the many existing `checkout@v5` / `setup-node@v6` / `upload-artifact@v6` / `download-artifact@v7` usages in the repo emit **no** Node-20 warning).
- Only the `@vN` suffix on `uses:` lines changed — no structural workflow change (14 insertions / 14 deletions).
- All `setup-node` sites already pin `node-version` 24/25.
- The `ci.yml` upload→download pair (`equiv-partial-*`) is bumped to v6/v7 together, the same pairing proven in `test262-sharded.yml`.

## How verified

Warnings were confirmed by reading the live GitHub Actions run annotations (`/check-runs/<id>/annotations`) — this PR removes every actioned Node-20 emitter. The `##[error] exit code 1` seen in the `Differential test` run is **not** a failure: that step is `continue-on-error: true` (a known-informational bug-finding harness), left untouched.

## Not addressed

The `Input 'app-id' has been deprecated with message: Use 'client-id' instead` warning from `actions/create-github-app-token@v3` (auto-enqueue, queue-unstick, auto-refresh-prs) is **not** changed here — `app-id` and `client-id` are different values, and only the numeric `ENQUEUE_APP_ID` secret exists. Switching needs a new `client-id` secret the repo owner must add; the `app-id` input still functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)