### PR TITLE
fix(test262-harness): pass boundArgFactory to non-BigInt TA shim (#3088)

### DIFF
--- a/plan/issues/3088-testwith-typedarray-shim-two-arg-faithfulness.md
+++ b/plan/issues/3088-testwith-typedarray-shim-two-arg-faithfulness.md
@@ -1,8 +1,8 @@
 ---
 id: 3088
 title: "test262-runner: non-BigInt testWithTypedArrayConstructors shim passes 1 arg but the real harness passes 2 (constructor + boundArgFactory) — 2-param callbacks stay vacuous via the #1837 over-arity-void skip"
-status: ready
-sprint: Backlog
+status: done
+sprint: current
 priority: medium
 horizon: s
 feasibility: medium
@@ -12,6 +12,7 @@ language_feature: typed-arrays, test262-harness, closures
 goal: host-independence
 related: [3074, 2939, 2940, 3086, 1837]
 created: 2026-07-07
+completed: 2026-07-08
 origin: "2026-07-07 measured under #3074 keystone validation (dev-keystone): 8/12 non-CE fill/*.js stay vacuous after the dispatch fix because their function(TA, makeCtorArg) callback is over-arity-void for the 1-arg shim."
 ---
 
@@ -62,3 +63,25 @@ conversion; this converts more vacuous→honest (executing) results.
   (then passes, or honest-fails on #3087, per its body).
 - Shim signature matches real test262 (`f(constructor, boundArgFactory)`).
 - No net regression.
+
+## Resolution (2026-07-08, dev-ta)
+
+Fixed in `tests/test262-runner.ts`: extracted the identity
+`__ta_makeCtorArgPassthrough` helper (previously emitted only inside the BigInt
+block) to a shared block emitted when EITHER wrapper is referenced, and changed
+the non-BigInt `testWithTypedArrayConstructors` shim from `fn(constructors[i])`
+to `fn(constructors[i], __ta_makeCtorArgPassthrough)` so 2-param
+`function(TA, makeCtorArg)` callbacks match arity and dispatch (instead of being
+skipped as over-arity-void per #1837).
+
+Scoped verification (via `runTest262File`, gc lane):
+
+- `fill/fill-values.js`, `fill/fill-values-relative-end.js`,
+  `fill/fill-values-non-numeric.js`: `vacuous:true` → **`vacuous:false`**, now
+  honest-fail on #3087 (`No dependency provided for extern class "TA"`) —
+  exactly the vacuous→honest transition this issue promised.
+- `fill/fill-values-conversion-operations.js` stays vacuous, but it uses a
+  *different* harness (`testTypedArrayConversions`, 4-param callback) outside
+  this issue's scope — correctly unchanged.
+
+tsc + prettier clean. Full vacuous→pass conversion still gated on #3087.

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1879,6 +1879,26 @@ function $DETACHBUFFER(buf: any): void {
 }`;
   }
 
+  // (#3088) Identity `makeCtorArg`/`boundArgFactory` passthrough shared by both
+  // the non-BigInt and BigInt harness shims. Emitted once when EITHER wrapper is
+  // referenced (guarding against a duplicate top-level definition when both are).
+  if (needsTestTypedArray || needsTestBigIntTypedArray) {
+    p += `
+
+function __ta_makeCtorArgPassthrough(x: any): any {
+  return x;
+}`;
+  }
+
+  // (#3088) The real test262 harness (`testTypedArray.js` →
+  // `testWithAllTypedArrayConstructors`) invokes the callback as
+  // `f(constructor, boundArgFactory)` — 2 ARGS. Many non-BigInt tests declare
+  // `function (TA, makeCtorArg) { … }` (2 params, void) and use `makeCtorArg` in
+  // the body. The old 1-arg shim (`fn(constructors[i])`) left those callbacks as
+  // over-arity-void candidates, which `tryEmitInlineDynamicCall` SKIPS (#1837),
+  // so they stayed vacuous even after the #3074 dispatch fix. Pass the second
+  // `boundArgFactory` arg (identity passthrough) so 2-param callbacks match arity
+  // and dispatch; 1-param callbacks truncate the extra arg (under-arity is fine).
   if (needsTestTypedArray) {
     p += `
 
@@ -1887,7 +1907,7 @@ function testWithTypedArrayConstructors(fn: any): void {
   for (let i = 0; i < constructors.length; i++) {
     __harness_cb_expected = __harness_cb_expected + 1;
     const __ac_before = __assert_count;
-    fn(constructors[i]);
+    fn(constructors[i], __ta_makeCtorArgPassthrough);
     if (__assert_count === __ac_before) { __harness_cb_dead = __harness_cb_dead + 1; }
   }
 }`;
@@ -1899,17 +1919,13 @@ function testWithTypedArrayConstructors(fn: any): void {
   // is typically `function (TA, makeCtorArg) { … }`. Passing only the ctor
   // left `makeCtorArg` undefined; combined with the (now-fixed) nested-scope
   // dispatch gap the whole callback body was dead (a vacuous host-free pass,
-  // ~814 tests). Shim the 2-arg signature with an identity `makeCtorArg`
+  // ~814 tests). Shim the 2-arg signature with the shared identity `makeCtorArg`
   // passthrough (maps a length/iterable straight to the ctor's first arg).
-  // Only emitted when the body actually references the BigInt variant, so the
-  // non-BigInt corpus preamble is byte-unchanged. Requires the #2939 dispatch
-  // fix to land in lockstep — else it produces dishonest vacuous passes.
+  // Requires the #2939 dispatch fix to land in lockstep — else it produces
+  // dishonest vacuous passes.
   if (needsTestBigIntTypedArray) {
     p += `
 
-function __ta_makeCtorArgPassthrough(x: any): any {
-  return x;
-}
 function testWithBigIntTypedArrayConstructors(fn: any): void {
   const constructors = [BigInt64Array, BigUint64Array];
   for (let i = 0; i < constructors.length; i++) {


### PR DESCRIPTION
## #3088 — non-BigInt `testWithTypedArrayConstructors` shim passes 1 arg, real harness passes 2

The real test262 harness (`testTypedArray.js` → `testWithAllTypedArrayConstructors`) invokes callbacks as `f(constructor, boundArgFactory)` — **2 args**. The runner's non-BigInt `testWithTypedArrayConstructors` shim passed only `fn(constructors[i])` — 1 arg. Many non-BigInt tests declare `function (TA, makeCtorArg) { … }` (2 params, void); with 1 arg those are over-arity-void candidates that `tryEmitInlineDynamicCall` intentionally skips (#1837), so they stayed **vacuous** even after the #3074 dispatch fix landed.

## Fix (runner-only, `tests/test262-runner.ts`)

- Extract the identity `__ta_makeCtorArgPassthrough` helper (previously emitted only inside the BigInt block) to a shared block emitted when **either** wrapper is referenced (guards against duplicate top-level definition).
- Change the non-BigInt shim to `fn(constructors[i], __ta_makeCtorArgPassthrough)`, matching the BigInt variant and the real harness signature. 1-param callbacks truncate the extra arg (under-arity is fine).

## Verification (gc lane, `runTest262File`)

- `fill/fill-values.js`, `fill-values-relative-end.js`, `fill-values-non-numeric.js`: `vacuous:true` → **`vacuous:false`** — the callback now executes and honest-fails on #3087 (`No dependency provided for extern class "TA"`), exactly the vacuous→honest transition intended.
- `fill/fill-values-conversion-operations.js` stays vacuous — it uses a *different* harness (`testTypedArrayConversions`, 4-param), outside this issue's scope; correctly unchanged.
- tsc + prettier clean.

Full vacuous→**pass** conversion remains gated on #3087 (dynamic `new TA`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS