### PR TITLE
fix(#3096): capture free vars referenced only in a param-default initializer

### DIFF
--- a/plan/issues/3096-param-default-capture-closure.md
+++ b/plan/issues/3096-param-default-capture-closure.md
@@ -1,0 +1,88 @@
+---
+id: 3096
+title: "Free variables referenced only in a parameter-default initializer are not captured by arrow/function-expression closures"
+status: done
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+model: opus
+task_type: bugfix
+area: codegen
+language_feature: destructuring, default-parameters, closures
+es_edition: 6
+goal: spec-completeness
+created: 2026-07-08
+completed: 2026-07-08
+related: [1161]
+---
+
+## Problem
+
+An arrow function / function expression that references an enclosing-scope
+variable **only** inside a parameter default initializer failed to capture that
+variable. The closure capture analysis in `compileArrowAsClosure` (and the
+callback-closure path) scanned only the function **body** for free variables —
+never the parameter defaults — so the default compiled against a missing
+capture and lowered to `ref.null extern`.
+
+For a destructuring parameter this then threw at runtime:
+
+```js
+var iter = [7];
+var f = function ([x] = iter) { return x; };
+f();   // TypeError: Cannot destructure 'null' or 'undefined'
+```
+
+The default `= iter` should have supplied the value when the argument is
+omitted, but `iter` (referenced nowhere in the body) was not captured, so it
+read as `null` and the array-destructure null-guard threw. Simple (non-pattern)
+parameters had the same root defect but degraded silently to a wrong value
+(`null`/`NaN`) instead of throwing.
+
+This surfaced as the test262 `assertion_fail`/`runtime_error` signature
+`Cannot destructure 'null' or 'undefined'` across the `dstr` families
+(`dflt-*`, `ary-ptrn-elem-ary-empty-init`, …).
+
+## Root cause
+
+`src/codegen/closures.ts` — both closure capture-analysis sites built
+`referencedNames` by walking only the closure `body`:
+
+```ts
+collectReferencedIdentifiers(body, referencedNames, ownLocals);
+```
+
+Parameter default initializers (`param.initializer`) and binding-pattern
+element defaults / computed keys (inside `param.name`) were never scanned, so
+their free variables were absent from the capture set.
+
+## Fix
+
+Added a shared helper `collectParamDefaultReferences(parameters, names,
+shadowed)` that scans, per parameter, both `param.name` (binding-pattern element
+defaults + computed keys) and `param.initializer` (top-level default), using the
+function's own-locals as the shadow set so the parameters' own binding names
+stay excluded. Called it right after the body scan at both closure sites
+(`compileArrowAsClosure` and the callback-closure path).
+
+Scope is intentionally limited to arrow functions and function expressions.
+Function **declarations**, object/class **methods**, **generators**, and
+`for-of` destructuring have their own separate capture analyses that share the
+same underlying gap and are left for a follow-up (they need capture-**set**
+builder changes, not just a predicate tweak).
+
+## Validation
+
+- 18 test262 files (`language/expressions/function/dstr/*`,
+  `language/expressions/arrow-function/dstr/*` with the destructure-null
+  signature) flip pass.
+- 40 currently-passing `expressions/{function,arrow-function}` +
+  `statements/function` files still pass (no regression).
+- Edge cases verified: nested element defaults `([x = outer]) => x`, later
+  param referencing earlier param `(a, b = a) => b` (correctly NOT captured),
+  default not fired when arg present, object-pattern default capture.
+- The two pre-existing failing vitest suites
+  (`null-destructure-param-object`, `issue-1712-capture-closure-dispatch`)
+  fail identically on the unmodified base.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -286,6 +286,34 @@ export function collectReferencedIdentifiers(node: ts.Node, names: Set<string>, 
 }
 
 /**
+ * (#3096) Collect free-variable references that appear in a parameter list's
+ * default initializers — both top-level param defaults (`param.initializer`,
+ * e.g. `(a, b = outer) => ...`) and defaults / computed keys nested inside a
+ * binding pattern (`param.name`, e.g. `([x = outer]) => ...`, `({ [k]: v }) =>
+ * ...`). These are part of the function's scope but are NOT reached by scanning
+ * the body, so a closure whose ONLY use of an outer variable is in a parameter
+ * default would fail to capture it. The `shadowed` set (the function's own
+ * locals) excludes the parameters' own binding names, so only genuine outer
+ * references are added.
+ */
+export function collectParamDefaultReferences(
+  parameters: ts.NodeArray<ts.ParameterDeclaration>,
+  names: Set<string>,
+  shadowed: ReadonlySet<string>,
+): void {
+  for (const param of parameters) {
+    // Binding patterns can hold element defaults (`[x = e]`) and computed keys
+    // (`{ [k]: v }`) — walk the whole BindingName; own binding names are shadowed.
+    if (!ts.isIdentifier(param.name)) {
+      collectReferencedIdentifiers(param.name, names, shadowed);
+    }
+    if (param.initializer) {
+      collectReferencedIdentifiers(param.initializer, names, shadowed);
+    }
+  }
+}
+
+/**
  * Collect identifiers that are WRITTEN to within a node tree.
  * Detects: assignment (=, +=, etc.), ++, --.
  *
@@ -1872,6 +1900,16 @@ export function compileArrowAsClosure(
   } else {
     collectReferencedIdentifiers(body, referencedNames, ownLocals);
   }
+  // (#3096) Free variables referenced ONLY in a parameter default initializer
+  // — or in a binding-pattern element default / computed key — must be
+  // captured too. The body scan above misses them, so a default like
+  // `([x] = iter) => {}` (where `iter` is an outer var referenced nowhere in
+  // the body) never captured `iter`; the default then compiled to `ref.null`,
+  // and array destructuring threw "Cannot destructure null/undefined". Scan
+  // `param.name` (catches binding-pattern element defaults + computed keys) and
+  // `param.initializer` (top-level param default) with the same own-locals
+  // shadow set, so the param's own binding names stay excluded.
+  collectParamDefaultReferences(arrow.parameters, referencedNames, ownLocals);
 
   // Transitively add captures needed by called nested functions.
   // E.g. if this closure calls g() and g has nestedFuncCaptures {first, second},
@@ -3069,6 +3107,10 @@ export function compileArrowAsCallback(
   } else {
     collectReferencedIdentifiers(body, referencedNames, ownLocals);
   }
+  // (#3096) Also capture free variables referenced only in a parameter default
+  // initializer / binding-pattern element default / computed key (see the
+  // rationale on the identical scan in `compileArrowAsClosure`).
+  collectParamDefaultReferences(arrow.parameters, referencedNames, ownLocals);
 
   // Detect which captured variables are written inside the callback body (#859)
   const writtenInCallback = new Set<string>();


### PR DESCRIPTION
## Problem

An arrow function / function expression that references an enclosing-scope variable **only** inside a parameter default initializer failed to capture it. The closure capture analysis scanned only the function **body**, never the parameter defaults, so the default compiled against a missing capture and lowered to `ref.null extern`.

For a destructuring parameter this threw at runtime:

```js
var iter = [7];
var f = function ([x] = iter) { return x; };
f();   // TypeError: Cannot destructure 'null' or 'undefined'
```

Simple (non-pattern) params had the same defect but degraded silently to a wrong value (`null`/`NaN`).

## Fix

Added `collectParamDefaultReferences(parameters, names, shadowed)` — scans each param's binding-pattern element defaults / computed keys (`param.name`) and top-level default (`param.initializer`), shadowed by the function's own locals so the params' own binding names stay excluded. Called after the body scan at both closure capture-analysis sites (`compileArrowAsClosure` + callback-closure path).

Scope is intentionally limited to arrow + function-expression closures. Function declarations, methods, generators, and for-of destructuring share the same gap through separate capture-**set** builders and are left for a follow-up.

## Validation

- **18 test262 files** (`language/expressions/{function,arrow-function}/dstr/*` with the destructure-null signature) flip pass.
- **40** currently-passing `expressions/{function,arrow-function}` + `statements/function` files still pass — no regression.
- Edge cases verified: nested element defaults `([x = outer]) => x`, later param referencing earlier param `(a, b = a) => b` (correctly not captured), default-not-fired when arg present, object-pattern default capture.
- The two pre-existing failing vitest suites (`null-destructure-param-object`, `issue-1712-capture-closure-dispatch`) fail identically on the unmodified base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS