### PR TITLE
fix(runtime): don't access Symbol.<method> on primitive String method args (#3095)

### DIFF
--- a/plan/issues/3095-string-method-primitive-symbol-skip.md
+++ b/plan/issues/3095-string-method-primitive-symbol-skip.md
@@ -1,0 +1,66 @@
+---
+id: 3095
+title: "String.prototype.{match,search,replace,replaceAll,split} must not access Symbol.<method> on primitive search values"
+status: done
+completed: 2026-07-08
+created: 2026-07-08
+updated: 2026-07-08
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: runtime
+language_feature: string-symbol-dispatch
+goal: spec-completeness
+sprint: current
+horizon: s
+related: [1443, 1439]
+---
+
+# #3095 - String.prototype methods must not observably access Symbol.<method> on primitive search values
+
+## Problem
+
+Per ECMA-262, `String.prototype.{match,matchAll,search,replace,replaceAll,split}`
+only look up the argument's well-known `Symbol.<method>` (`@@match`, `@@replace`,
+etc.) when the search value **is an Object**. When it is a primitive
+(number/string/boolean/bigint) they go straight to the "regexp is not an Object"
+branch and must NOT observably access the property.
+
+js2wasm delegates these methods to the JS host (`recvStr[method](arg)`). The host
+(Node) still runs `GetMethod` on the primitive's wrapper prototype, so a
+user-defined `Number.prototype[Symbol.match]` / `String.prototype[Symbol.replace]`
+/ etc. accessor gets triggered — failing 23 test262 `cstm-*-on-*-primitive`
+tests with `should not be called`.
+
+Failing cluster (harvested from baseline):
+`test/built-ins/String/prototype/{match,matchAll,search,replace,replaceAll,split}/cstm-*-on-{bigint,boolean,number,string}-primitive.js`
+
+## Fix
+
+In the `string_method` host shim (`src/runtime.ts`), when the first arg is a
+primitive whose prototype chain actually defines the relevant well-known Symbol
+(checked with `in`/HasProperty, which does **not** trigger getters), pre-build
+the RegExp the spec's not-Object branch would create and hand _that_ to the host
+method. The host then dispatches on the built-in `RegExp.prototype` Symbol
+methods and never touches the primitive's prototype:
+
+- `match` / `matchAll` / `search`: primitive is a **pattern** → `new RegExp(String(v)[, "g"])`
+- `replace` / `replaceAll` / `split`: primitive is a **literal string** → `new RegExp(escape(String(v))[, "g"])`
+
+The reroute only engages when the Symbol property actually exists on the
+primitive's prototype, so the common no-override case is byte-identical to
+before (zero behavior change on the hot path).
+
+## Scope
+
+Fixes match/search/replace/replaceAll/split (20 tests). `matchAll` on a string
+receiver (3 tests) takes a **different codegen path** (dynamic `Cache_matchAll`
+dispatch, not the `string_method` host shim), so this host-shim fix does not
+reach it — left as a follow-up (no regression: still fails as before).
+
+## Verification
+
+- 20 real test262 `cstm-*` files pass via `runTest262File` (per-test isolation).
+- No regression across regexp / string-split / Symbol-protocol (#1439/#1443/#2161)
+  equivalence suites.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4229,6 +4229,71 @@ let _symbolCache: Map<number, symbol> | undefined;
 const _symbolDescRegistry: Map<number, string | null> = new Map();
 const _asyncDisposeSym: symbol = (Symbol as any).asyncDispose ?? Symbol.for("Symbol.asyncDispose");
 
+/** Escape a literal string so it matches itself when used as a RegExp source. */
+function _escapeRegExpLiteral(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * #3095 — The well-known Symbol each `String.prototype` symbol-dispatch method
+ * looks up on its search value (per ECMA-262). `replaceAll` dispatches on
+ * `@@replace` (there is no `@@replaceAll`).
+ */
+const _stringMethodDispatchSymbol: Record<string, symbol | undefined> = {
+  match: Symbol.match,
+  matchAll: Symbol.matchAll,
+  search: Symbol.search,
+  replace: Symbol.replace,
+  replaceAll: Symbol.replace,
+  split: Symbol.split,
+};
+
+/**
+ * #3095 — For `String.prototype.{match,matchAll,search,replace,replaceAll,
+ * split}` with a **primitive** (non-Object) search value, ECMA-262 does NOT
+ * observably access the value's `Symbol.<method>` property; it goes straight to
+ * the "regexp is not an Object" branch. The JS host (`recvStr[method](arg)`)
+ * would instead run GetMethod on the primitive's wrapper prototype, triggering
+ * any user-defined `Number.prototype[Symbol.match]` (etc.) accessor.
+ *
+ * To preserve host delegation while suppressing that observable access, we
+ * pre-build the RegExp the spec's not-Object branch would create and hand
+ * *that* to the host method — the host then dispatches on the built-in
+ * `RegExp.prototype` symbol methods and never touches the primitive's
+ * prototype. match/matchAll/search treat the primitive as a **pattern**
+ * (RegExpCreate); replace/replaceAll/split treat it as a **literal string**
+ * (so we escape it; `replaceAll` needs the global flag).
+ *
+ * Returns the replacement RegExp, or `undefined` to leave the arg unchanged.
+ * Only engaged when the relevant Symbol property actually exists on the
+ * primitive's prototype chain (checked with `in`/HasProperty, which does not
+ * call getters) — so the common no-override case is byte-identical to before.
+ */
+function _rerouteStringSymbolMethodPrimitive(method: string, first: unknown): RegExp | undefined {
+  const t = typeof first;
+  if (t !== "number" && t !== "string" && t !== "boolean" && t !== "bigint") return undefined;
+  const sym = _stringMethodDispatchSymbol[method];
+  if (sym === undefined) return undefined;
+  // HasProperty (no getter side effect). Object(first) boxes the primitive so
+  // the prototype chain (Number/String/Boolean/BigInt.prototype) is visible.
+  if (!(sym in (Object(first) as object))) return undefined;
+  const str = String(first as number | string | boolean | bigint);
+  switch (method) {
+    case "match":
+    case "search":
+      return new RegExp(str);
+    case "matchAll":
+      return new RegExp(str, "g");
+    case "replaceAll":
+      return new RegExp(_escapeRegExpLiteral(str), "g");
+    case "replace":
+    case "split":
+      return new RegExp(_escapeRegExpLiteral(str));
+    default:
+      return undefined;
+  }
+}
+
 /** Map from JS well-known Symbols to Wasm "@@name" keys (and vice-versa). */
 const _symbolToWasm: Map<symbol, string> = new Map([
   [Symbol.iterator, "@@iterator"],
@@ -7563,7 +7628,24 @@ function resolveImport(
           // can dispatch on Symbol.<method> via the wasm-struct proxy (#1443).
           const first = a[0];
           let wrapped: any;
-          if (first != null && typeof first === "object" && _isWasmStruct(first)) {
+          const primReroute = _rerouteStringSymbolMethodPrimitive(method, first);
+          if (primReroute !== undefined) {
+            // #3095 — per spec (ECMA-262 String.prototype.{match,matchAll,
+            // search,replace,replaceAll,split}), when the search value is NOT
+            // an Object, its Symbol.<method> property must NOT be observably
+            // accessed. The JS host (Node) still walks the primitive's wrapper
+            // prototype via GetMethod, so a user-defined `Number.prototype[
+            // Symbol.match]` etc. getter would be triggered. Replicate the
+            // "regexp is not an Object" branch by pre-building the RegExp the
+            // spec would create: match/matchAll/search treat the primitive as a
+            // *pattern*, replace/replaceAll/split as a *literal string*. Passing
+            // a real RegExp makes Node dispatch on RegExp.prototype's built-in
+            // Symbol methods, never touching the primitive's prototype. Only
+            // engaged when the Symbol property actually exists on the primitive
+            // (checked via `in`, which does not trigger getters), so the common
+            // no-override case is byte-identical to before.
+            wrapped = primReroute;
+          } else if (first != null && typeof first === "object" && _isWasmStruct(first)) {
             wrapped = _wrapForHost(first, callbackState?.getExports?.());
           } else {
             wrapped = first;


### PR DESCRIPTION
## Problem

Per ECMA-262, `String.prototype.{match,matchAll,search,replace,replaceAll,split}` only look up the argument's well-known `Symbol.<method>` when the search value **is an Object**. For a primitive (number/string/boolean/bigint) they go straight to the "regexp is not an Object" branch and must NOT observably access the property.

js2wasm delegates these methods to the JS host (`recvStr[method](arg)`). The host (Node) still runs `GetMethod` on the primitive's wrapper prototype, triggering a user-defined `Number.prototype[Symbol.match]` / `String.prototype[Symbol.replace]` / etc. accessor — failing the test262 `cstm-*-on-*-primitive` cluster with `should not be called`.

## Fix

In the `string_method` host shim (`src/runtime.ts`), when the first arg is a primitive whose prototype chain actually defines the relevant well-known Symbol (checked with `in`/HasProperty — which does **not** trigger getters), pre-build the RegExp the spec's not-Object branch would create and hand *that* to the host method. The host then dispatches on the built-in `RegExp.prototype` Symbol methods and never touches the primitive's prototype.

- `match` / `matchAll` / `search`: primitive is a **pattern** → `new RegExp(String(v)[, "g"])`
- `replace` / `replaceAll` / `split`: primitive is a **literal string** → `new RegExp(escape(String(v))[, "g"])`

The reroute only engages when the Symbol property actually exists on the primitive's prototype, so the common no-override case is **byte-identical** to before (zero behavior change on the hot path).

## Scope

Fixes **match/search/replace/replaceAll/split** (20 test262 files). `matchAll` on a string receiver (3 tests) takes a different codegen path (dynamic `Cache_matchAll` dispatch, not the `string_method` host shim), so this host-shim fix does not reach it — left as a follow-up (no regression: still fails as before).

## Verification

- 20 real test262 `cstm-*` files pass via `runTest262File` (per-test isolation)
- No regression across regexp / string-split / Symbol-protocol (#1439 / #1443 / #2161) equivalence suites
- `tsc --noEmit` clean, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS