### PR TITLE
docs(plan): import 7 labs-unique planning issues

### DIFF
--- a/plan/issues/1406-vm-sandbox-test262-isolation.md
+++ b/plan/issues/1406-vm-sandbox-test262-isolation.md
@@ -1,0 +1,41 @@
+---
+id: 1406
+renumbered_from: 1310
+title: "test262 global contamination: vm.createContext sandbox isolation"
+status: done
+priority: medium
+sprint: 50
+pr: 232
+---
+
+## Problem
+
+test262 tests compiled to Wasm can pollute the host JS globals through `__extern_set`
+host imports. When `resolveImport`'s `declared_global` case resolved names via
+`(globalThis as any)[name]`, a test that overwrote a built-in (e.g. `Array.prototype.push`)
+would corrupt the shared `globalThis`, causing subsequent tests to see mutated built-ins.
+
+This introduced flaky test-level contamination independent of the runner-pool contention
+drift fixed by PR #228.
+
+## Fix
+
+- `runtime.ts`: `buildImports` / `resolveImport` accept an optional `globalSandbox`
+  parameter; `declared_global` reads from `globalSandbox` when provided, otherwise falls
+  back to `globalThis`.
+- `tests/test262-runner.ts`: per-shard vm.createContext sandbox with sentinel dirty-check.
+  Five built-in method references (Array.prototype.push, Object.prototype.hasOwnProperty,
+  Function.prototype.call, String.prototype.slice, Promise.prototype.then) are captured at
+  sandbox creation. Before each test, sentinels are checked; sandbox is recycled only when
+  any sentinel differs. This avoids the cost of a fresh context per test while still
+  catching contamination as soon as it occurs.
+
+## Implementation notes
+
+`vm.createContext({})` does NOT auto-populate built-ins as properties — they must be
+materialized via `runInContext("Array", ctx)`. Dev confirmed this and handled it correctly
+in the implementation.
+
+## Merged
+
+PR #232 — 2026-05-07

--- a/plan/issues/1426-lodash-tier1-stress-test-refresh.md
+++ b/plan/issues/1426-lodash-tier1-stress-test-refresh.md
@@ -1,0 +1,71 @@
+---
+id: 1426
+renumbered_from: 1278
+title: "Update stale lodash-tier1 stress test — resolver fixed, clamp/add behavior changed"
+status: review
+created: 2026-05-02
+updated: 2026-05-02
+priority: low
+feasibility: easy
+reasoning_effort: low
+task_type: test
+area: tests
+language_feature: none
+goal: npm-library-support
+related: [1031, 1275, 1276, 1277]
+---
+# #1426 — Update stale lodash-tier1 stress test
+
+## Problem
+
+`tests/stress/lodash-tier1.test.ts` asserts *old broken behavior* that no longer exists.
+5/6 tests now fail because the behavior they document has changed:
+
+- **Tests 4, 5** (ModuleResolver @types, resolveAllImports @types): The resolver was fixed
+  — it now prefers real `.js` bodies over `@types/.d.ts` declarations. The tests assert
+  the broken behavior (`anyTypeDecl: true`, `anyRealJs: false`) which is now inverted.
+
+- **Tests 2, 3** (clamp Wasm validation, add undeclared-ref): Both tests assert that
+  `new WebAssembly.Module(result.binary)` throws a specific error. The actual behavior has
+  drifted — they no longer throw the same error (either validates now or throws differently).
+
+- **Test 1** (CJS no exports): Also now failing — behavior changed.
+
+## Fix
+
+For each failing test, determine the *current* actual behavior and update the assertion to
+match it. Tests documenting progress (fixed gaps) should flip to assert the correct behavior.
+Tests documenting remaining gaps (clamp, add) should be updated with the current error message
+or marked `.skip` with a comment pointing to the relevant issue (#1275, #1276).
+
+## Acceptance criteria
+
+1. `npm test -- tests/stress/lodash-tier1.test.ts` passes (all 6 tests)
+2. Tests 4, 5 assert the fixed resolver behavior (real .js resolved, not @types)
+3. Tests 2, 3 either assert new current error or are `.skip`-ped with issue refs
+4. No new logic added — test-only change
+
+## Implementation summary
+
+Test-only update to `tests/stress/lodash-tier1.test.ts` — flipped the 5
+stale assertions to match current actual behavior.
+
+Confirmed current behavior via direct probe (`compileProject` + Wasm
+instantiation):
+
+| Module | Pre-fix gap | Current state |
+|--------|-------------|---------------|
+| `lodash/identity.js` (CJS) | no exports | exports `identity`+`default`, both return arg |
+| `lodash-es/identity.js` (ESM) | already passing | unchanged |
+| `lodash-es/clamp.js` (ESM) | Wasm validation throws on toNumber | validates; exports `clamp`+`default`; instantiation gap remains |
+| `lodash-es/add.js` (ESM) | Wasm validation throws on undeclared fn ref | validates; HOF closure gap blocks export (#1276) |
+| `ModuleResolver` (lodash-es) | resolved `@types/.d.ts` | resolves real `.js` body |
+| `resolveAllImports` walk | walked `@types` only | walks real `.js`, no `@types` |
+
+Tests 1, 2, 5, 6 now assert the correct positive behavior. Tests 3, 4
+record the partial wins (Wasm validation passes — runtime instantiation
+gap tracked separately under #1276 / clamp follow-up). The test now
+exercises real lodash compilation as a forward-looking regression
+guard rather than a documented-gap snapshot.
+
+All 6 tests pass: `npx vitest run tests/stress/lodash-tier1.test.ts`.

--- a/plan/issues/1430-forof-dstr-obj-init-and-trlg.md
+++ b/plan/issues/1430-forof-dstr-obj-init-and-trlg.md
@@ -1,0 +1,135 @@
+---
+id: 1430
+renumbered_from: 1397
+sprint: 52
+title: "for-of/dstr: obj-ptrn-id-init undefined-key + array-elem-trlg iterator close"
+status: ready
+created: 2026-05-09
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: triage
+area: codegen, runtime
+language_feature: destructuring, iteration
+goal: spec-completeness
+---
+# #1430 — for-of/dstr remaining clusters
+
+Follow-on triage from task #50 / PR #335 (#1396 array-OOB undefined sentinel).
+Two highest-count remaining sub-clusters in `language/statements/for-of/dstr/`:
+
+## Cluster A — obj-ptrn-id-init (~42 fails)
+
+**Pattern**: `for (const {w = 99} of [{w: undefined}])` should fire default
+because `{w: undefined}` has `w === undefined`. Per spec §13.7.5.5, defaults
+fire when the value is `undefined`.
+
+**Current behavior**: default does NOT fire. `w` ends up as a non-undefined,
+non-99, non-null value (typeof check returns a string outside our
+"number"/"undefined"/"object" set).
+
+**Diagnostic probes** (all on origin/main HEAD):
+
+```ts
+// FAILS: w should be 99, but isn't
+for (const {w = 99} of [{w: undefined}] as any[]) {
+  // typeof w is something other than "number"/"undefined"/"object"
+}
+
+// PASSES: when key missing, default fires correctly
+for (const {w = 99} of [{}] as any[]) {
+  // w === 99 ✓
+}
+
+// PASSES: spec-correct null bypass (not a regression)
+for (const {w = 99} of [{w: null}] as any[]) {
+  // w === null ✓ (defaults fire only for undefined, not null)
+}
+```
+
+**Hypothesis on root cause**: object literal `{w: undefined}` doesn't
+store JS `undefined` in the externref-typed field — it stores something
+else (likely `ref.null.extern` = JS null, OR a non-externref representation).
+Then `__extern_get` returns that wrong value and `__extern_is_undefined`
+correctly returns 0 → default doesn't fire.
+
+**Where to investigate**:
+- `compileObjectLiteral` (or wherever object literals compile) — when
+  field type is externref and the property value is the `undefined`
+  identifier, the emitted code should call `__get_undefined()`, not
+  push `ref.null.extern`.
+- The CLAUDE.md note "null/undefined in f64 context: emit
+  f64.const 0 / f64.const NaN directly (avoids externref roundtrip)"
+  suggests this path exists for f64; need a parallel path for
+  externref that emits `__get_undefined()`.
+
+**Same root-cause pattern as #1396** but for object-literal field
+initialization rather than array-OOB destructuring.
+
+**Estimated impact**: ~42 fails (var-/let-/const-obj-ptrn-id-init-*
+subset).
+
+## Cluster B — array-elem-trlg (~23 fails)
+
+**Pattern**: `for ([x, ] of [iterable])` with trailing comma.
+ArrayBindingPattern with elision at the end — iterator should call
+`return()` after consuming the named elements.
+
+Sample test
+(`array-elem-trlg-iter-list-nrml-close.js`) uses a custom iterator
+with explicit `next()` and `return()` methods. Test asserts:
+
+- `nextCount === 1` (next called once for the bound element)
+- `returnCount === 1` (return called for the trailing elision close)
+
+**Hypothesis on root cause**: our codegen for `[x, ] of iterable` either:
+1. Calls `iterator.return()` zero times (no IteratorClose emitted) —
+   would show `returnCount === 0`.
+2. Calls `next()` more than once (greedy iterator drain instead of
+   stopping at the last bound element) — would show `nextCount > 1`.
+
+Need to compile the test, run, and inspect actual `nextCount`/
+`returnCount` values to discriminate.
+
+**Where to investigate**:
+- `compileForOfStatement` and `compileForOfDestructuring` in
+  `src/codegen/statements/loops.ts` — IteratorClose emission for
+  ArrayBindingPattern.
+- Per ECMA-262 §13.15.5.5 (IteratorBindingInitialization for
+  ArrayBindingPattern), elision elements participate in step-by-step
+  iteration; trailing elision still consumes (skips) one slot, and
+  abrupt completion (or normal completion at end of pattern) closes
+  the iterator.
+- Existing #1347 / #1348 fixes added IteratorClose for abrupt
+  completion in for-of bodies; this case is the *normal* completion
+  in destructuring patterns with trailing elision — separate code
+  path.
+
+**Estimated impact**: ~23 fails (`array-elem-trlg-*`).
+
+## Acceptance criteria
+
+1. `for (const {w = 99} of [{w: undefined}])` → `w === 99`.
+2. `for (const {w = 99} of [{w: null}])` → `w === null` (regression guard).
+3. `for ([x, ] of [iterable])` with custom iterator triggers
+   `iterator.return()` exactly once.
+4. Pre-existing for-of tests in `tests/equivalence/for-of-*.test.ts`
+   continue to pass.
+
+## Files likely touched
+
+For Cluster A:
+- `src/codegen/object-ops.ts` — object literal compilation, special-case
+  `undefined` identifier values to use `__get_undefined()` for externref
+  fields.
+
+For Cluster B:
+- `src/codegen/statements/loops.ts` — for-of array-pattern emission,
+  ensure IteratorClose call is emitted after binding the last
+  non-elision element, even when a trailing elision is present.
+
+## Related
+
+- #1396 (PR #335) — array-OOB undefined sentinel (parallel root cause)
+- #1347 / #1348 — IteratorClose on abrupt completion (#22, #43)
+- Task #52 (this triage)

--- a/plan/issues/backlog/1446-schema-driven-cli-options-custom-wasm-section.md
+++ b/plan/issues/backlog/1446-schema-driven-cli-options-custom-wasm-section.md
@@ -1,0 +1,77 @@
+---
+id: 1446
+title: "Schema-driven CLI options via custom Wasm section"
+status: backlog
+created: 2026-05-20
+updated: 2026-05-20
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: feature
+area: tooling
+language_feature: n/a
+depends_on: []
+related: []
+---
+
+# #1446 — Schema-driven CLI options via custom Wasm section
+
+## Problem
+
+Several runtime-shape options today live as ad-hoc CLI flags:
+
+- `--target wasi` vs JS host
+- `--nativeStrings` (string backend choice)
+- RegExp backend (#682)
+- WASI-shim presence/absence
+- Various optimisation flags
+
+Each is added by editing the CLI parser, and each ships independently
+in every artefact we build. There is no machine-readable record of
+which options apply to a given build, which makes both `--help`
+discoverability and host-side compatibility checking awkward.
+
+A cleaner pattern: emit a **custom Wasm section** in every artefact
+declaring the build's target descriptor (WASI shim set, string
+backend, RegExp backend, runtime-helper version). The CLI reads
+the schema from a compiler-side declaration and auto-derives the
+`--help` table. Hosts that consume our modules can introspect the
+custom section to refuse early if their environment cannot serve
+the declared runtime contract.
+
+## Proposed approach
+
+1. Define a small schema for "build target descriptor" — string
+   backend, RegExp backend, WASI version, runtime-helper version,
+   etc. Express as TypeScript types.
+2. Generate a CLI option group per descriptor field automatically.
+   `--help` shows them grouped under `--target` headings.
+3. Emit the descriptor as a custom Wasm section in every artefact.
+4. Document how a host can read the section and refuse to instantiate
+   a module whose runtime contract it cannot satisfy.
+
+## Acceptance criteria
+
+- Target descriptor schema defined in TypeScript with one source of
+  truth for both CLI parsing and custom-section emission.
+- CLI `--help` groups options under their descriptor field.
+- Built artefacts carry the custom section; `wasm-tools` can dump
+  it.
+- A short host-side example demonstrates reading the section and
+  failing gracefully on contract mismatch.
+- No regression in existing CLI behaviour.
+
+## Notes
+
+The pattern reduces by-hand CLI maintenance and gives hosts a
+real handshake before instantiation. Low risk, medium upside,
+fits comfortably in a one-week implementation window.
+
+Pattern observed in Javy (https://github.com/bytecodealliance/javy),
+specifically `crates/cli/src/commands.rs:60-70` and 305-352: the
+plugin's custom Wasm section advertises supported options; the CLI
+reflects them in `--help` automatically. Their `import_namespace`
+custom section additionally encodes ABI versioning. Two Bytecode
+Alliance projects (Javy + StarlingMonkey) use related patterns,
+suggesting the convention is worth codifying ecosystem-wide rather
+than reinvented locally.

--- a/plan/issues/backlog/1447-adr-013-interpreter-bytecode-design.md
+++ b/plan/issues/backlog/1447-adr-013-interpreter-bytecode-design.md
@@ -1,0 +1,90 @@
+---
+id: 1447
+title: "ADR-013 interpreter bytecode design — register-file + br_table dispatch"
+status: backlog
+created: 2026-05-20
+updated: 2026-05-20
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: runtime
+language_feature: eval
+depends_on: []
+related: [1520]
+---
+
+# #1447 — ADR-013 interpreter bytecode design — register-file + br_table dispatch
+
+## Problem
+
+ADR-013 proposes a lazy-loaded, opt-in WasmGC-native interpreter for
+the source-at-runtime family of features (`eval`, `new Function`,
+sloppy `with`). The architectural shape is settled. The **bytecode
+design itself** is not: stack-based vs register-based, dispatch via
+`call_indirect` vs `br_table`, opcode space allocation, how to
+encode wide operands, how to handle implicit-register conventions.
+
+The decisions made here determine both interpreter size and
+interpreter speed for the lifetime of the artefact. A bad choice
+compounds with every feature ADR-013 covers.
+
+## Proposed approach
+
+Adopt the design pattern that decades of production-grade engine
+work has converged on:
+
+1. **Accumulator + register-file**, not stack-based. One implicit
+   accumulator register holds the most recent value; a small
+   register-file (per-frame local slots) holds named bindings.
+   Reduces operand encoding overhead and matches WasmGC's local
+   register convention.
+
+2. **Short-form opcodes for hot patterns.** `LoadAccumulator0`–
+   `LoadAccumulator15`, `StoreAccumulator0`–`StoreAccumulator15`
+   as separate single-byte opcodes for the common case of
+   referring to one of the first 16 register-file slots.
+
+3. **Wide / extra-wide operand prefixes.** Two prefix bytes that
+   extend the next opcode's operand width. Keeps the common case
+   compact without capping the opcode set's expressive range.
+
+4. **Implicit-register-use declarations per opcode.** Each
+   opcode declares which registers it reads/writes; the
+   verifier and the (eventual) optimiser use this without
+   re-deriving it.
+
+5. **Dispatch via `br_table` inside one big function**, not via
+   `call_indirect` to per-opcode handler functions. `br_table` is
+   the closest thing WasmGC has to a computed-goto loop and
+   keeps the dispatch overhead near zero. `call_indirect` per
+   opcode incurs a function-call boundary on every bytecode.
+
+## Acceptance criteria
+
+- Bytecode design document drafted in `plan/issues/sprints/.../`
+  (or the appropriate location) with opcode table and operand
+  conventions.
+- Prototype interpreter implemented in TypeScript, compiled by
+  js2wasm itself, demonstrating the bytecode shape on a small
+  subset of JS (numeric expressions + variable access).
+- Measured: dispatch overhead per bytecode below a target
+  threshold on a representative benchmark.
+- Decision recorded in ADR-013 supplement on register-file +
+  br_table vs alternatives, with the trade-off explicit.
+
+## Notes
+
+This is the design-heaviest of the ADR-013 sub-issues and the one
+where premature commitment to the wrong shape will be expensive
+to undo. Take time to prototype before publishing.
+
+The accumulator + register-file design and the Star0–Star15
+short-form encoding are V8's Ignition interpreter pattern
+(https://github.com/v8/v8, `src/interpreter/bytecodes.h`). V8's
+interpreter is the most heavily-traffic-tested bytecode design in
+production; the shape is well-validated. The `br_table` dispatch
+decision is our adaptation: V8 dispatches via direct threading in
+native code, but in a WasmGC-compiled interpreter `br_table` is the
+closest semantic match — `call_indirect` adds a function-call
+boundary on every bytecode, which is the wrong primitive.

--- a/plan/issues/backlog/1449-wasmgc-compatibility-probe-host-ci-matrix.md
+++ b/plan/issues/backlog/1449-wasmgc-compatibility-probe-host-ci-matrix.md
@@ -1,0 +1,105 @@
+---
+id: 1449
+title: "WasmGC compatibility probe + serverless host CI matrix"
+status: backlog
+created: 2026-05-20
+updated: 2026-05-20
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+depends_on: []
+related: [1448]
+---
+
+# #1449 — WasmGC compatibility probe + serverless host CI matrix
+
+## Problem
+
+WasmGC support across serverless and WASI host runtimes is **not the same
+thing as stable**. The underlying Wasm engine (Wasmtime) classifies WasmGC
+as Tier 2: feature-complete from the spec perspective, on-by-default in
+`Config`, but spec-stability and backward-compat are not yet committed
+upstream and fuzzing/hardening is ongoing.
+
+The hosts that embed Wasmtime inherit this status — and additionally each
+host pins to a specific Wasmtime version, applies its own `Config`
+choices, and may or may not enable the GC proposal in production. Verified
+version pins as of 2026-05-20:
+
+- Fermyon Spin / Cloud: `wasmtime = "44.0.0"`
+- Fastly Viceroy (local dev runtime): `wasmtime = "39.0.2"`
+- Fastly production Compute@Edge runtime: proprietary, not publicly
+  documented
+
+Other production runtimes (Microsoft Hyperlight, AWS Lambda Wasm, custom
+embedded Wasmtime in vertical-specific products) have similar opacity.
+
+We compile WasmGC. **If the target host doesn't enable the proposal,
+nothing js2wasm produces will instantiate.** Today there is no
+operational discipline that catches this before the customer does.
+
+## Proposed approach
+
+1. **A small WasmGC probe module** — a 200-byte `.wasm` artefact that
+   uses `struct.new`, `struct.get`, `i31.new` and one `ref.cast`. If a
+   host instantiates and runs it, WasmGC is enabled; if instantiation
+   fails with `LinkError` / `CompileError` / `unsupported feature`,
+   it is not.
+
+   ```wat
+   (module
+     (type $box (struct (field $v i32)))
+     (func (export "probe") (result i32)
+       (struct.get $box $v
+         (struct.new $box (i32.const 42)))))
+   ```
+
+2. **A CI matrix** that deploys the probe to each supported serverless
+   / WASI host and reports pass/fail. Targets to cover initially:
+
+   - Cloudflare Workers (workerd)
+   - Fastly Compute@Edge (`fastly compute publish` to a free-tier
+     account)
+   - Fermyon Cloud (`spin deploy`)
+   - Wasmer Edge
+   - wasmCloud (if accessible)
+   - Local Wasmtime (`wasmtime run probe.wasm` — known-good baseline)
+   - Local Spin (`spin up probe.wasm` — known-good baseline)
+
+3. **Result publication.** Per-host pass/fail + Wasmtime version
+   detected, on a public status page (small static page in
+   `public/website/` or similar). Honest, reproducible, refreshes
+   nightly.
+
+4. **Regression alerting.** When a host that previously passed starts
+   failing — they bumped their Wasmtime to a version with breaking
+   GC changes, or they disabled the proposal — surface the regression
+   automatically.
+
+## Acceptance criteria
+
+- Probe module artefact (`.wat` source + built `.wasm`) committed to the
+  repo.
+- CI workflow runs the probe against each listed host and records
+  pass/fail.
+- Public status page (or `benchmarks/results/`-style JSON) records the
+  matrix.
+- Regression on any host's WasmGC support surfaces in CI within 24h.
+- The matrix is referenced from the host docs (`labs/docs/hosts/*.md`
+  and the public `public/website/docs/`-side host targeting page).
+
+## Notes
+
+This is the **single highest-leverage operational discipline** for our
+WASI / serverless deployment story. The architectural pitch ("KB-scale
+WasmGC modules, no engine") assumes the target host *runs* WasmGC. The
+probe + matrix turns that assumption into a verified, monitored
+property. Without it, every "supports WasmGC" claim in our public
+materials is a posture, not a measurement.
+
+Pairs naturally with #13 (public benchmark methodology RFC) — the
+benchmark methodology and the compatibility probe both belong to the
+"measurement before marketing" discipline.

--- a/plan/issues/backlog/module-sandbox.md
+++ b/plan/issues/backlog/module-sandbox.md
@@ -1,0 +1,305 @@
+---
+id: module-sandbox
+title: "Module sandbox — compile npm packages with explicit imports, no ambient host access"
+status: planned
+priority: high
+feasibility: hard
+reasoning_effort: max
+goal: security
+task_type: design+implementation
+area: codegen
+language_feature: module-system
+created: 2026-04-23
+---
+
+# Module sandbox — compile npm packages with explicit imports
+
+## Problem
+
+When js2wasm compiles an npm package to Wasm, the compiled module runs inside
+a host (browser or Node.js). The current JS-host mode grants the module broad
+access to host globals through the import mechanism and through the `eval`
+escape hatch. A malicious or compromised dependency could:
+
+- Access `window`, `document`, `localStorage`, cookies, DOM
+- Call `fetch`, `XMLHttpRequest`, arbitrary network APIs
+- Use `Function(...)` / `eval(...)` to generate and run arbitrary code
+- Access `process.env`, `require`, `__dirname`, Node.js internals
+- Exfiltrate secrets or sensitive data visible in JS global scope
+- Escalate to further code execution via prototype pollution
+
+The compiled Wasm binary **should** be a sandboxed capability boundary. Today
+it is not — any npm package compiled through js2wasm inherits the full JS
+global scope of its host.
+
+## Goal
+
+Define a compilation strategy and runtime import adapter so that:
+
+1. **All host access is explicit** — the compiled module's Wasm import section
+   declares every host capability it needs. Nothing is granted implicitly.
+2. **Dangerous APIs are denied by default** — `eval`, `Function`, dynamic
+   `import()`, `require`, `process`, `fetch`, `XMLHttpRequest`, DOM APIs are
+   blocked unless the host explicitly grants them.
+3. **npm imports are resolved at compile time** — `import { readFile } from 'fs'`
+   becomes an explicit Wasm import `(import "node:fs" "readFile" ...)`, not
+   ambient `globalThis.require('fs')`.
+4. **The import adapter is auditable** — a host instantiating the module passes
+   a typed `imports` object; any API not in that object is unavailable to the
+   module. The adapter can be statically analyzed for what it exposes.
+
+---
+
+## Part 1 — Import analysis: what does an npm package actually need?
+
+### 1.1 Categories of host access
+
+| Category | Examples | Risk level |
+|---|---|---|
+| Pure computation | Math, Date, JSON, TypedArray | Low — no side effects |
+| Console / logging | `console.log`, `process.stdout` | Low — write-only |
+| Filesystem | `node:fs`, `node:path` | Medium — read/write |
+| Network | `fetch`, `http`, `XMLHttpRequest` | High — exfiltration |
+| Environment | `process.env`, `os.homedir()` | High — secrets |
+| Crypto | `node:crypto`, `SubtleCrypto` | Medium — key material |
+| DOM | `document`, `window`, `localStorage` | High — ambient scope |
+| Code generation | `eval`, `Function`, dynamic `import()` | Critical — sandbox escape |
+| IPC / child process | `child_process`, `worker_threads` | Critical |
+
+### 1.2 Typical npm package import surface
+
+A survey of common npm packages (express, lodash, chalk, zod, date-fns, axios,
+uuid, etc.) shows most pure utility packages need only:
+
+- `Math.*`, `Date`, `JSON`, `Array`, `Object`, `String` — all pure
+- `console.*` — write-only, no secrets
+- `process.env.*` — only for config packages
+- `node:crypto` (uuid, bcrypt, etc.) — bounded, auditable
+- `node:fs` (config loaders, build tools) — bounded
+
+Very few utility packages need network or DOM access. A whitelist covering
+the above eliminates 95% of the attack surface.
+
+---
+
+## Part 2 — Compiler strategy: explicit import lowering
+
+### 2.1 Current behavior
+
+Today, when a compiled module calls `Math.random()`, the codegen emits a
+host import `(import "js" "Math.random" (func ...))`. This works but is
+**unstructured** — the import name is an opaque string, and there's no
+enforcement at instantiation time.
+
+For npm packages, `import { foo } from 'some-package'` is resolved by the
+bundler/TypeScript compiler before js2wasm sees it. The resulting code calls
+`foo()` as if it were a local function. js2wasm needs a strategy for
+cross-package imports.
+
+### 2.2 Proposed: module-scoped Wasm imports
+
+Each npm package import becomes a Wasm import namespace:
+
+```wat
+;; import { readFileSync } from 'node:fs'
+(import "node:fs" "readFileSync" (func $node_fs_readFileSync (param externref i32) (result externref)))
+
+;; import { createHash } from 'node:crypto'
+(import "node:crypto" "createHash" (func $node_crypto_createHash (param externref) (result externref)))
+```
+
+The host instantiates the module with an explicit `imports` object:
+
+```js
+const imports = {
+  "node:fs": {
+    readFileSync: (path, opts) => sandboxedFs.readFileSync(path, opts),
+  },
+  "node:crypto": {
+    createHash: (alg) => sandboxedCrypto.createHash(alg),
+  },
+  // "fetch" not present → any fetch call traps at the Wasm boundary
+};
+const instance = await WebAssembly.instantiate(binary, imports);
+```
+
+Any import not in the `imports` object causes `WebAssembly.instantiate` to
+throw — the module cannot be instantiated without explicitly granting each
+capability. This is enforced by the Wasm spec itself.
+
+### 2.3 Global scope interception
+
+The current codegen accesses `globalThis.*` implicitly. In sandbox mode, the
+compiler should:
+
+1. **Intercept known globals** — `Math`, `JSON`, `Date`, `console`, `Array`,
+   `Object`, `String`, `Number`, `Boolean` are imported explicitly as
+   `(import "globals" "Math" ...)` rather than accessed via `global.get`.
+2. **Deny unknown globals** — any `globalThis.X` access where X is not in the
+   allow-list emits a compile-time warning and a runtime trap.
+3. **Deny `eval` / `Function`** — compile-time error in sandbox mode (or
+   route through #1164's capability-gated eval shim).
+
+### 2.4 Compiler flag: `--sandbox`
+
+Add a `--sandbox` flag to the compiler CLI:
+
+```
+js2wasm input.ts --sandbox [--allow node:fs] [--allow node:crypto]
+```
+
+In sandbox mode:
+- All globals require explicit `--allow` or are denied
+- `eval` / `Function` / dynamic `import()` are blocked
+- Output includes a manifest of all declared imports (JSON sidecar)
+- The import manifest is machine-readable for policy enforcement
+
+---
+
+## Part 3 — Import adapter: capability-safe wrappers
+
+### 3.1 Node.js adapter
+
+A sandboxed Node.js host adapter wraps each allowed module:
+
+```ts
+// sandbox/adapters/node-fs.ts
+export function createNodeFsAdapter(options: {
+  allowedPaths: string[];     // path prefix allow-list
+  readonly: boolean;
+}): typeof import('node:fs') {
+  return {
+    readFileSync(path, opts) {
+      if (!options.allowedPaths.some(p => path.startsWith(p))) {
+        throw new Error(`sandbox: fs access denied: ${path}`);
+      }
+      return fs.readFileSync(path, opts);
+    },
+    writeFileSync(path, data, opts) {
+      if (options.readonly) throw new Error('sandbox: fs is readonly');
+      // ...
+    },
+    // unlisted methods throw by default
+  };
+}
+```
+
+### 3.2 Browser adapter
+
+```ts
+// sandbox/adapters/browser.ts
+export function createBrowserAdapter(options: {
+  allowConsole: boolean;
+  allowFetch: string[];   // URL prefix allow-list, [] = deny all
+}): Record<string, unknown> {
+  return {
+    console: options.allowConsole ? console : noopConsole,
+    fetch: options.allowFetch.length > 0
+      ? (url, init) => {
+          if (!options.allowFetch.some(p => url.startsWith(p))) {
+            throw new Error(`sandbox: fetch denied: ${url}`);
+          }
+          return fetch(url, init);
+        }
+      : () => { throw new Error('sandbox: fetch not allowed'); },
+    // eval / Function / document / window — always absent
+  };
+}
+```
+
+### 3.3 Adapter manifest
+
+Each adapter emits a static manifest of what it exposes:
+
+```json
+{
+  "granted": ["node:fs.readFileSync", "node:crypto.createHash", "console.log"],
+  "denied": ["fetch", "eval", "Function", "process.env", "document"],
+  "restricted": ["node:fs.writeFileSync (readonly mode)"]
+}
+```
+
+The manifest can be committed to a repo and reviewed in PRs — any capability
+expansion shows up as a diff.
+
+---
+
+## Part 4 — Escape prevention
+
+### 4.1 Known escape vectors
+
+| Vector | Mitigation |
+|---|---|
+| `eval(str)` | Compile-time error in `--sandbox` mode; or route through #1164 capability-gated shim |
+| `new Function(str)` | Same as eval |
+| `import(dynamic)` | Blocked at compile time in sandbox mode |
+| `require(dynamic)` | Blocked — require is not in the import adapter |
+| `globalThis[key]` | Dynamic property access on globalThis emits a compile-time warning; in strict sandbox, traps |
+| `Object.prototype.__proto__` | Prototype pollution — WasmGC structs have no JS prototype; not applicable |
+| `process.binding()` | process not in adapter → traps |
+| `Buffer.allocUnsafe` | Buffer not granted by default |
+| `XMLHttpRequest` | Not in browser adapter unless explicitly added |
+| `WebSocket` | Same |
+| `SharedArrayBuffer` + Atomics | Deny by default (side-channel risk) |
+
+### 4.2 Static analysis pass
+
+Add a compile-time `--sandbox-audit` flag that reports:
+- Every global access in the module (direct + transitive through imports)
+- Every import from the allow-list
+- Every blocked access (would trap at runtime)
+- Confidence level: "proved safe" / "dynamic (may escape)" / "unknown"
+
+---
+
+## Part 5 — npm package compilation workflow
+
+```
+npm install some-package
+js2wasm node_modules/some-package/dist/index.js \
+  --sandbox \
+  --allow node:fs \
+  --allow node:crypto \
+  --output some-package.wasm \
+  --manifest some-package.imports.json
+```
+
+The `.imports.json` manifest is shipped alongside the `.wasm` binary. At
+instantiation time, the host reads the manifest, constructs the adapter, and
+instantiates:
+
+```js
+import { createAdapter } from 'js2wasm/sandbox';
+import manifest from './some-package.imports.json';
+
+const adapter = createAdapter(manifest, {
+  'node:fs': { allowedPaths: ['/tmp/'], readonly: false },
+  'node:crypto': true,  // grant with defaults
+});
+const { instance } = await WebAssembly.instantiate(wasmBinary, adapter.imports);
+```
+
+---
+
+## Acceptance criteria
+
+1. `--sandbox` flag exists; in sandbox mode `eval` / `Function` / dynamic
+   `import()` are compile errors
+2. npm package imports lower to explicit Wasm import namespaces
+   (`"node:fs" "readFileSync"`) rather than ambient globals
+3. A module compiled with `--sandbox` cannot be instantiated without
+   explicitly providing every import it declares
+4. Reference adapters for Node.js (`node:fs`, `node:crypto`, `node:path`)
+   and browser (`console`, `fetch` with URL allow-list) ship in `src/sandbox/`
+5. `--sandbox-audit` outputs a capability manifest (JSON) listing granted,
+   denied, and dynamic-access imports
+6. Equivalence tests for a sandboxed uuid package and a sandboxed lodash
+   subset pass
+7. No regressions in `tests/equivalence.test.ts`
+
+## Related
+
+- #1164 — dynamic eval via Wasm JS API (eval escape hatch — sandbox mode gates this)
+- #1163 — static eval inlining (safe; inlined at compile time, no runtime escape)
+- CLAUDE.md "dual-mode" principle — sandbox adapter is the JS-host side of the capability boundary
+- Wasm Component Model / WIT — longer term, WIT interfaces formalize the capability surface


### PR DESCRIPTION
## What
Imports seven issue/design docs authored in the private labs repo that have **no equivalent in js2**, so the public repo carries them going forward.

| File | About |
|---|---|
| `backlog/1447-adr-013-interpreter-bytecode-design.md` | Register-file + `br_table` dispatch interpreter design (eval support) |
| `backlog/module-sandbox.md` | Capability-based npm sandbox — explicit Wasm imports, deny `eval`/`fetch`/`process` by default |
| `backlog/1446-schema-driven-cli-options-custom-wasm-section.md` | CLI options via a schema embedded in a custom Wasm section |
| `backlog/1449-wasmgc-compatibility-probe-host-ci-matrix.md` | WasmGC compat probe + serverless host CI matrix |
| `1406-vm-sandbox-test262-isolation.md` | vm.createContext test262 isolation |
| `1426-lodash-tier1-stress-test-refresh.md` | lodash tier-1 stress test refresh |
| `1430-forof-dstr-obj-init-and-trlg.md` | for-of/dstr obj-init trailing edge cases |

## Notes
- Issue numbers verified free in js2 — no collisions.
- `module-sandbox` frontmatter de-privatised (dropped `visibility: private` / `sprint: private`); content is a technical security design, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)