### PR TITLE
feat(#2865): Wasm-native async-generator carrier for --target standalone — nested/expr producers, .next() dispatch, .then bridge

### DIFF
--- a/plan/issues/2865-standalone-async-generator-carrier.md
+++ b/plan/issues/2865-standalone-async-generator-carrier.md
@@ -1,10 +1,11 @@
 ---
 id: 2865
 title: "Standalone: no Wasm-native async-generator / for-await carrier — leaks __create_async_generator + Promise_* host imports"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-2865
 model: fable
 created: 2026-06-30
-updated: 2026-07-08
+updated: 2026-07-09
 priority: high
 feasibility: hard
 task_type: feature
@@ -137,3 +138,104 @@ not a regression. arch-asyncgen's AG0–AG5 spec lives on `origin/async-gen-2865
 ## Reconciliation note (shepherd, 2026-07-01)
 
 Landed slice: **AG0** host-free await unwrap on native `$Promise` (PR #2380), reconciled net-neutral and **scoped to WASI**; the standalone async-generator drive is deferred to PATH B (#2895). Issue stays `in-progress`.
+
+## Standalone carrier landed (fable-2865, 2026-07-09) — the #2906 3d machinery activated for `--target standalone` + the real test262 shapes
+
+**What shipped (branch `issue-2865-standalone-asyncgen-carrier`).** The wasi-only
+3d-i/3d-ii async-gen machine now serves the STANDALONE lane and the shapes real
+test262 files are written in. Verify-first grounding: on main, `async function*`
+under `--target standalone` was a #680 CE (decls) or a null-returning fn-expr,
+and the 3d machinery was unreachable (`isStandalonePromiseActive` = wasi-only)
+AND unreachable for the real test shapes even on wasi (the runner wraps every
+test body inside `export function test()`, so gens are NESTED declarations /
+fn-exprs compiled by nested-declarations.ts / closures.ts — never the
+function-body.ts interception; and driving is `f().next().then(cb,$DONE)`, not
+for-await).
+
+### Layers (each probed on both lanes, host-free where noted)
+
+1. **Standalone activation, carrier-independent subset.** `isAsyncGenDriveCandidate`
+   accepts await-FREE bounded bodies under `isAsyncDriveActive` (standalone+wasi);
+   `yield await P` bodies stay legacy under standalone (with the carrier off the
+   awaited operand is not a native `$Promise` — driving would yield the un-awaited
+   promise object). `decideAsyncActivation` gains a standalone arm accepting ONLY
+   the for-await-over-async-gen consumer (every suspension awaits the machine's own
+   `__async_gen_next_*` promise — carrier-independent). This is deliberately NOT
+   the #2980 carrier widen (rule 2): `Promise.resolve`/statics/await lowering are
+   untouched. `__drain_microtasks` lowers to the real drain when the module
+   registered the native queue (still a no-op for machinery-free modules).
+2. **Producer body generalization.** `analyzeAsyncGen` accepts suspend-free lead
+   statements around top-level yields, ZERO-yield bodies (the forbidden-ext shape),
+   and own identifier locals — spilled into the frame under the 3a loop rule (every
+   yield is a suspend), typed via `resolveSpillLocalValType`, spill-safe-gated.
+   Rejected (correct-or-legacy): `yield*`, nested yields/awaits, `return`
+   statements (need a settleReturn terminator — 3d-iii), destructuring locals,
+   binding-pattern/rest PARAMS (pattern bindings live in lifted-prologue locals the
+   resume fn never sees — was invalid wasm on async-generator/dstr).
+3. **Nested + fn-expr producers.** Interception in nested-declarations.ts (both
+   capture branches) and closures.ts, before the `__create_async_generator` buffer
+   arms. Capture support: nested decls thread `boxedCaptures` (per-capture cell
+   params); closures record `selfCaptureLayout` (the `__self` struct layout) and
+   the resume prologue RE-MATERIALIZES capture locals from the frame-captured
+   `__self` — without this, capture resolution fell back to stale outer-scope
+   local indices (`call $f (ref.cast nullref (local.get $0))` — a miscompile).
+   TDZ-flagged captures stay legacy (their `boxedTdzFlags` store param indices).
+   Stem-collision guard: a second same-named gen rejects (would share the first's
+   typed next-helper → cast trap). `ctx.asyncGenProducers` registry added.
+4. **Closure-context consumer.** `planAsyncClosureActivation` narrowly admits the
+   for-await-over-async-gen drive through the #2646 phase-2 park (validated here;
+   every other drive/host-drive closure shape stays parked). Const-held fn-expr
+   producers resolve via the registry by INITIALIZER NODE (the anon stem never
+   matches the binding name).
+5. **`.next()` dispatch + `.then` bridge (the driving pattern).**
+   `tryEmitAsyncGenNextDispatch` ref.tests each producer frame → per-gen driver,
+   wired at the typed-AsyncGenerator site AND the any-receiver site. Miss arm:
+   standalone keeps the original `__gen_next` behavior; wasi bakes it only when a
+   legacy buffer gen exists (`ctx.asyncGenLegacyBufferEmitted`) so all-driven
+   modules stay ZERO-IMPORT (tests/issue-1326 green). `isStandaloneThenChainNativeActive`
+   widens to standalone WHEN the module registered the native scheduler: `.then`/
+   `.catch` compile the #3035 ref.test receiver bridge (native receivers chain
+   natively; host receivers keep the host path). Any-typed receivers route through
+   the bridge too; wasi uses a new `nullMiss` variant (no host-import registration).
+
+### Measured
+
+- forbidden-ext decl files (stmt+expr async-generator): **2 (partially-vacuous)
+  → 5 honest passes** under `runTest262File(..., "standalone")`; the distilled
+  `f().next().then(cb, done).then(done, done)` shape runs host-free on wasi
+  (`imports=[]`) and correct on standalone.
+- 145-file construct-sampled standalone sweep (stmt/expr async-gen, for-await-of,
+  AsyncGeneratorPrototype, AsyncGeneratorFunction, fromAsync): **zero per-file
+  regressions** vs the pre-change baseline (before/after jsonl diff); the sample
+  is dominated by shapes still out of scope (dstr, awaited yields, .throw/.return).
+- Byte-inertness: 8-program × 3-lane sha256 matrix vs main — identical everywhere
+  except the intended standalone async-gen cell (COMPILE_FAIL → host-free).
+- Blast radius: 137 async/generator/closure unit tests green; the 7 failures in
+  2865-AG0/2867-gap2/promise-combinators reproduce identically on clean main.
+
+### Residuals (filed forward, all fail→fail vs baseline)
+
+- **Self-referencing fn-expr producers** (`var f; f = async function*(){ ...f... }`
+  — 10 forbidden-ext fn-expr files): `f()` returns null via the pre-existing
+  void-trampoline dynamic-dispatch discard (#2939-family; the dispatch arm
+  `call_ref $void; ref.null` swallows the frame). Fix belongs to the
+  closure-value dispatch cluster (#2963/#3080), not the carrier.
+- **Async-gen METHOD producers** (class + object-literal — class-bodies.ts:~2328,
+  literals.ts:~2788 buffer arms): same interception pattern applies; needs
+  `this`-receiver threading. ~25 remaining forbidden-ext method files.
+- **`next(v)` sent-value delivery, `.throw()`/`.return()`** on driven gens
+  (#2906 3d-iii; AsyncGeneratorPrototype cluster).
+- **for-await INSIDE async-gen bodies** (the for-await-of dstr family) — needs
+  loop states in `planAsyncGenCfg` + dstr bindings.
+- **Awaited yields under standalone** — gated on the #2980 carrier widen
+  (measured decision; do NOT flip piecemeal).
+
+### #2895 / #2978 boundary
+
+No new frame-suspension mechanism was needed — the carrier composes the landed
+#2895/#2906 machine (suspend/settleYield/settleDone) unchanged; #2895's slice-1d
+widen remains the only blocker for awaited-yield bodies under standalone. #2978
+(for-await over a REJECTED promise, boxed-array source) stays blocked on the
+carrier widen: the 3b array for-await is deliberately NOT activated under
+standalone (its `Await(element)` operands are host promises with the carrier
+off — the suspend arm would mis-classify them as settled values).

--- a/src/codegen/async-activation.ts
+++ b/src/codegen/async-activation.ts
@@ -196,6 +196,17 @@ export function planAsyncClosureActivation(
   isAsync: boolean,
 ): AsyncActivationPlan | null {
   const decision = decideAsyncActivation(ctx, decl, isAsync, /*allowNonDeclaration*/ true);
+  // (#2865) Exception to the phase-2 park below: the for-await-over-async-
+  // GENERATOR consumer drive IS validated in the lifted-closure context (its
+  // machine is self-contained — every suspension awaits the producer's own
+  // `__async_gen_next_*` promise; no continuation capture-struct / `__self`
+  // interplay). Without this, an arrow/fn-expr consumer stays legacy while the
+  // producer returns the driven frame carrier — the legacy `__iterator` then
+  // ref.cast-traps on the frame. Every OTHER drive/host-drive closure shape
+  // stays parked (the #2646 33-regression class).
+  if (decision !== null && decision.lane === "drive" && asyncGenConsumerNeedsDrive(ctx, decl, decision.plan)) {
+    return decision;
+  }
   // Phase-2 scope: closures activate ONLY the single-tail-await CPS lane. The
   // host-drive ("host-drive") and native-drive ("drive") lanes activate
   // multi-await / try-finally-across-await shapes whose continuation

--- a/src/codegen/async-activation.ts
+++ b/src/codegen/async-activation.ts
@@ -27,7 +27,12 @@ import {
   emitAsyncStateMachine,
   splitBodyAtAwait,
 } from "./async-cps.js";
-import { emitAsyncFrameStateMachine, asyncFnNeedsDrive, asyncFnNeedsHostDrive } from "./async-frame.js";
+import {
+  emitAsyncFrameStateMachine,
+  asyncFnNeedsDrive,
+  asyncFnNeedsHostDrive,
+  asyncGenConsumerNeedsDrive,
+} from "./async-frame.js";
 import { isStandalonePromiseActive } from "./async-scheduler.js";
 
 /**
@@ -86,6 +91,20 @@ function decideAsyncActivation(
     // just the single canonical await `asyncFnNeedsCps` gates on. For a single
     // await the verdict is identical, so wasi single-await routing is unchanged.
     if (asyncFnNeedsDrive(ctx, decl, asyncPlan)) return { lane: "drive", plan: asyncPlan };
+    return null;
+  }
+
+  // (#2865) `--target standalone` with the native-`$Promise` CARRIER gate still
+  // OFF (#2980 — the measured widen decision): activate the drive lane ONLY for
+  // the for-await-over-async-GENERATOR consumer shape. Its every suspension
+  // awaits a promise MINTED by the machine itself (the producer's
+  // `__async_gen_next_<name>` next()-promise — a native `$Promise` on every
+  // lane), so it is carrier-independent. Plain awaits / Promise statics /
+  // boxed-array for-await stay on the legacy path until the carrier widen —
+  // widening those here would be exactly the piecemeal flip #2980 rule 2 declines.
+  if (ctx.standalone === true) {
+    const asyncPlan = analyzeAsyncBody(ctx, decl);
+    if (asyncGenConsumerNeedsDrive(ctx, decl, asyncPlan)) return { lane: "drive", plan: asyncPlan };
     return null;
   }
 

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -2145,6 +2145,22 @@ export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
 }
 
 /**
+ * (#2865) True when `fn` is a bounded async-generator body that is ALSO
+ * await-free (`yield <plain>` / `yield;` only — no `yield await P`). This is
+ * the shape drivable under `--target standalone` while the native-`$Promise`
+ * CARRIER gate is still wasi-only (#2980): with the carrier off, an awaited
+ * operand does not lower to a native `$Promise`, so a `yield await P` would
+ * deliver the un-awaited promise OBJECT (wrong value). An await-free body is
+ * carrier-independent — every promise the machine touches is minted by its own
+ * `__async_gen_next_<name>` driver.
+ */
+export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
+  const yields = analyzeAsyncGen(fn);
+  if (yields === null) return false;
+  return yields.every((y) => y.awaited === null);
+}
+
+/**
  * Build the CFG for a bounded async-generator body. Dense ids in push order; a
  * `yield await P` contributes TWO states (await-suspend + yield-from-sent), a
  * plain `yield E` ONE, and a trailing `settleDone`:

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1868,7 +1868,25 @@ function resolveAsyncGenNextHelperName(ctx: CodegenContext, source: ts.Expressio
   const callee = source.expression;
   if (!ts.isIdentifier(callee)) return null;
   const name = `__async_gen_next_${sanitizeTypeName(callee.text)}`;
-  return ctx.funcMap.has(name) ? name : null;
+  if (ctx.funcMap.has(name)) return name;
+  // (#2865) A const/var-held fn-EXPRESSION producer (`const f = async
+  // function* () {...}`) registers under its synthesized anon stem, not the
+  // binding name. Resolve the callee's declaration through the checker and
+  // match the producer registry by INITIALIZER NODE — exact, no naming games.
+  if (ctx.asyncGenProducers !== undefined) {
+    const { checker } = ctx;
+    const sym = checker.getSymbolAtLocation(callee);
+    const vd = sym?.valueDeclaration;
+    if (vd !== undefined && ts.isVariableDeclaration(vd) && vd.initializer !== undefined) {
+      for (const [stem, p] of ctx.asyncGenProducers) {
+        if (p.decl === vd.initializer) {
+          const exprName = `__async_gen_next_${stem}`;
+          if (ctx.funcMap.has(exprName)) return exprName;
+        }
+      }
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -2086,15 +2086,37 @@ function containsAwaitOrYield(node: ts.Node): boolean {
   return found;
 }
 
-/** Does the async-gen body declare any own local (var/let/const)? (Conservative
- *  — the 3d-i core rejects these; spill widening is the follow-up.) */
-function asyncGenBodyHasOwnLocals(fn: ts.FunctionLikeDeclaration): boolean {
+/** Does `stmt` contain a `return` statement in its own function scope? A lead
+ *  `return v` inside a driven async-GEN body would settle the current
+ *  `next()`-promise with the RAW value via the `asyncDriveReturn` hook, not the
+ *  §27.6-required IteratorResult `{value, done:true}` — so bodies with returns
+ *  stay on the legacy path until a settleReturn terminator exists (3d-iii). */
+function containsOwnScopeReturn(stmt: ts.Statement): boolean {
+  let found = false;
+  const walk = (n: ts.Node): void => {
+    if (found || isNestedFunctionScope(n)) return;
+    if (ts.isReturnStatement(n)) {
+      found = true;
+      return;
+    }
+    forEachChild(n, walk);
+  };
+  walk(stmt);
+  return found;
+}
+
+/** Does the async-gen body declare any own local via a NON-identifier binding
+ *  (destructuring)? Those cannot be pre-typed as frame spills
+ *  (`resolveSpillLocalValType` needs the declaration node per name and the
+ *  destructuring lowering allocates its own differently-typed locals), so the
+ *  body stays on the legacy path. */
+function asyncGenBodyHasPatternLocals(fn: ts.FunctionLikeDeclaration): boolean {
   const body = fn.body;
   if (body === undefined) return false;
   let found = false;
   const walk = (n: ts.Node): void => {
     if (found || isNestedFunctionScope(n)) return;
-    if (ts.isVariableDeclaration(n)) {
+    if (ts.isVariableDeclaration(n) && !ts.isIdentifier(n.name)) {
       found = true;
       return;
     }
@@ -2105,38 +2127,64 @@ function asyncGenBodyHasOwnLocals(fn: ts.FunctionLikeDeclaration): boolean {
 }
 
 /** One bounded async-gen yield statement: `yield await <awaited>` OR `yield <plain>`
- *  OR `yield;` (both null). */
+ *  OR `yield;` (both null), plus the suspend-free LEAD statements preceding it. */
 interface AsyncGenYield {
+  readonly leads: ts.Statement[];
   readonly awaited: ts.Expression | null;
   readonly plain: ts.Expression | null;
 }
 
-/** Recognise the bounded 3d-i async-gen body; return its ordered yield list, or
- *  `null` for anything outside the slice. */
-function analyzeAsyncGen(fn: ts.FunctionLikeDeclaration): AsyncGenYield[] | null {
+/** The bounded async-gen body shape: ordered yield segments (each carrying its
+ *  preceding leads) plus the trailing statements after the last yield. A body
+ *  with ZERO yields is valid (`segments: []` — pure leads, then done). */
+interface AsyncGenShape {
+  readonly segments: AsyncGenYield[];
+  readonly tailLeads: ts.Statement[];
+}
+
+/** Recognise the bounded async-gen body; return its segment list, or `null`
+ *  for anything outside the slice.
+ *
+ *  (#2865 — generalized from the 3d-i flat-yield core.) Accepted now:
+ *  arbitrary suspend-free LEAD statements before/between/after top-level
+ *  `yield <E>` statements (they compile as ordinary statements of the owning
+ *  state's arm), zero-yield bodies (leads → settleDone — e.g. the test262
+ *  `forbidden-ext` bodies, which only run assertions), and own identifier
+ *  locals (spilled into the frame — see `computeAsyncGenSpills`). Still
+ *  rejected (correct-or-legacy): `yield*`, yields nested inside expressions or
+ *  control flow, `return` statements (need a settleReturn terminator),
+ *  destructuring locals, and nested await/yield inside operands. */
+function analyzeAsyncGen(fn: ts.FunctionLikeDeclaration): AsyncGenShape | null {
   const body = fn.body;
   if (body === undefined || !ts.isBlock(body)) return null;
-  if (asyncGenBodyHasOwnLocals(fn)) return null;
-  const yields: AsyncGenYield[] = [];
+  if (asyncGenBodyHasPatternLocals(fn)) return null;
+  const segments: AsyncGenYield[] = [];
+  let leads: ts.Statement[] = [];
   for (const st of body.statements) {
-    if (!ts.isExpressionStatement(st)) return null;
-    const e = st.expression;
-    if (!ts.isYieldExpression(e)) return null;
-    if (e.asteriskToken !== undefined) return null; // `yield*` delegation — follow-up
-    const operand = e.expression;
-    if (operand === undefined) {
-      yields.push({ awaited: null, plain: null }); // `yield;`
-    } else if (ts.isAwaitExpression(operand)) {
-      // `yield await P` — reject a doubly-nested await/yield in the awaited operand.
-      if (containsAwaitOrYield(operand.expression)) return null;
-      yields.push({ awaited: operand.expression, plain: null });
-    } else {
-      if (containsAwaitOrYield(operand)) return null; // nested await/yield — follow-up
-      yields.push({ awaited: null, plain: operand });
+    const e = ts.isExpressionStatement(st) ? st.expression : null;
+    if (e !== null && ts.isYieldExpression(e)) {
+      if (e.asteriskToken !== undefined) return null; // `yield*` delegation — follow-up
+      const operand = e.expression;
+      if (operand === undefined) {
+        segments.push({ leads, awaited: null, plain: null }); // `yield;`
+      } else if (ts.isAwaitExpression(operand)) {
+        // `yield await P` — reject a doubly-nested await/yield in the awaited operand.
+        if (containsAwaitOrYield(operand.expression)) return null;
+        segments.push({ leads, awaited: operand.expression, plain: null });
+      } else {
+        if (containsAwaitOrYield(operand)) return null; // nested await/yield — follow-up
+        segments.push({ leads, awaited: null, plain: operand });
+      }
+      leads = [];
+      continue;
     }
+    // A LEAD statement: must be suspend-free (a yield/await nested in control
+    // flow needs expression-level suspend numbering) and return-free.
+    if (containsAwaitOrYield(st)) return null;
+    if (containsOwnScopeReturn(st)) return null;
+    leads.push(st);
   }
-  if (yields.length === 0) return null; // an empty async-gen has no producer to prove
-  return yields;
+  return { segments, tailLeads: leads };
 }
 
 /** True when `fn` is a bounded 3d-i async-generator body drivable host-free. */
@@ -2155,9 +2203,39 @@ export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
  * `__async_gen_next_<name>` driver.
  */
 export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
-  const yields = analyzeAsyncGen(fn);
-  if (yields === null) return false;
-  return yields.every((y) => y.awaited === null);
+  const shape = analyzeAsyncGen(fn);
+  if (shape === null) return false;
+  return shape.segments.every((y) => y.awaited === null);
+}
+
+/**
+ * (#2865) Every own identifier local a driven async-GEN body must spill into
+ * its `$AsyncFrame`. Every `yield` is a suspend point (the resume fn returns
+ * and re-enters on the next `next()` kick), so — mirroring the 3a loop rule —
+ * every own body local is conservatively treated as live-across-suspend and
+ * spilled. Typed via `resolveSpillLocalValType` (the fctx-independent subset of
+ * the var-decl type cascade), defaulting to externref; params are captured in
+ * param fields, never spilled. Returns the declaration node per name so the
+ * caller can apply the spill-safe type gate.
+ */
+export function asyncGenOwnLocalDecls(fn: ts.FunctionLikeDeclaration): Map<string, ts.VariableDeclaration> {
+  const out = new Map<string, ts.VariableDeclaration>();
+  const body = fn.body;
+  if (body === undefined) return out;
+  const paramNames = new Set<string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) paramNames.add(p.name.text);
+    else collectBindingPatternNames(p.name, paramNames);
+  }
+  const walk = (node: ts.Node): void => {
+    if (isNestedFunctionScope(node)) return;
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && !paramNames.has(node.name.text)) {
+      if (!out.has(node.name.text)) out.set(node.name.text, node);
+    }
+    forEachChild(node, walk);
+  };
+  forEachChild(body, walk);
+  return out;
 }
 
 /**
@@ -2165,10 +2243,15 @@ export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean
  * `yield await P` contributes TWO states (await-suspend + yield-from-sent), a
  * plain `yield E` ONE, and a trailing `settleDone`:
  *
- *   yield await P:  Sk  suspend(P, resume→Sk+1)                (the await)
+ *   yield await P:  Sk  [leads] suspend(P, resume→Sk+1)         (the await)
  *                   Sk+1 (resumeFrom binding:null) settleYield(fromSent, →Sk+2)
- *   yield E:        Sk  settleYield(value:E, →Sk+1)
- *   <end>:          Sn  settleDone
+ *   yield E:        Sk  [leads] settleYield(value:E, →Sk+1)
+ *   <end>:          Sn  [tail leads] settleDone
+ *
+ * (#2865) Each yield's suspend-free LEAD statements ride the owning state's
+ * `lead` array (the emitter compiles them via `compileStatement` before the
+ * terminator — the same mechanism every other CFG producer uses); a zero-yield
+ * body is a single settleDone state carrying all statements as leads.
  *
  * Only the yield-from-sent state carries a resume prelude (to re-throw a rejected
  * await via the MODE_THROW arm — a rejected awaited yield rejects the current
@@ -2176,17 +2259,18 @@ export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean
  * MODE_NEXT, so needs no prelude. Returns `null` for a non-bounded body.
  */
 export function planAsyncGenCfg(fn: ts.FunctionLikeDeclaration): AsyncCfgPlan | null {
-  const yields = analyzeAsyncGen(fn);
-  if (yields === null) return null;
+  const shape = analyzeAsyncGen(fn);
+  if (shape === null) return null;
+  const asLead = (stmts: readonly ts.Statement[]): AsyncCfgStmt[] => stmts.map((stmt) => ({ stmt, handler: 0 }));
   const states: AsyncCfgState[] = [];
   let id = 0;
-  for (const y of yields) {
+  for (const y of shape.segments) {
     if (y.awaited !== null) {
       // await-suspend state → yield-from-sent state.
       states.push({
         id,
         resumeFrom: null,
-        lead: [],
+        lead: asLead(y.leads),
         terminator: { kind: "suspend", awaited: y.awaited, resumeState: id + 1, handler: 0 },
       });
       states.push({
@@ -2200,13 +2284,13 @@ export function planAsyncGenCfg(fn: ts.FunctionLikeDeclaration): AsyncCfgPlan | 
       states.push({
         id,
         resumeFrom: null,
-        lead: [],
+        lead: asLead(y.leads),
         terminator: { kind: "settleYield", value: y.plain, fromSent: false, resumeState: id + 1 },
       });
       id += 1;
     }
   }
-  states.push({ id, resumeFrom: null, lead: [], terminator: { kind: "settleDone" } });
+  states.push({ id, resumeFrom: null, lead: asLead(shape.tailLeads), terminator: { kind: "settleDone" } });
   return { states, handlers: [] };
 }
 

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -1729,6 +1729,16 @@ export function emitAsyncFrameStateMachine(
  */
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
+  // (#2865) Params must be plain identifiers: a binding-PATTERN param
+  // (`f([...x] = v)`) destructures into derived LOCALS of the lifted fn's
+  // prologue, which the fresh resume FunctionContext never sees — the body's
+  // reads then mis-resolve (observed: invalid wasm, a null-repaired call arg).
+  // A rest param builds a derived array local the same way. Identifier params
+  // WITH defaults are fine (the default is applied to the param local before
+  // the frame captures it). Correct-or-legacy.
+  for (const p of decl.parameters) {
+    if (!ts.isIdentifier(p.name) || p.dotDotDotToken !== undefined) return false;
+  }
   // (#2865) Stem-collision guard: a SECOND same-named gen (different scope)
   // would share the first's `__async_gen_next_<stem>` helper — typed for the
   // FIRST frame struct — and trap on `ref.cast`. Correct-or-legacy: reject it.

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -279,6 +279,22 @@ export interface AsyncFrameInfo {
   asyncGen?: boolean;
   /** (#2906 slice 3d-i) `{value: externref, done: i32}` IteratorResult struct typeIdx (async-gen only). */
   asyncGenResultTypeIdx?: number;
+  /**
+   * (#2865) Capture-cell metadata of a NESTED producer (lifted with captures
+   * as leading params — nested-declarations.ts). The frame captures the cells
+   * as param fields; the resume body must deref reads/writes through them, so
+   * `ensureAsyncResumeFunction` copies this onto the resume FunctionContext.
+   */
+  boxedCaptures?: Map<string, { refCellTypeIdx: number; valType: ValType }>;
+  /** (#2865) Threaded from the producer fctx (nested `this`-referencing body). */
+  readsCurrentThis?: boolean;
+  /**
+   * (#2865) The `__self` capture-struct layout of a lifted CLOSURE body
+   * (closures.ts model: captures live in the `__self` struct, materialized
+   * into named locals by a body prologue). The resume fn re-runs that
+   * materialization from the frame-captured `__self` param field.
+   */
+  selfCaptureLayout?: FunctionContext["selfCaptureLayout"];
 }
 
 /**
@@ -867,6 +883,12 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     continueStack: [],
     labelMap: new Map(),
     savedBodies: [],
+    // (#2865) A NESTED producer captures outer locals as ref cells (leading
+    // params of the lifted fn, spilled into frame param fields). The resume
+    // body compiles the same identifiers, so it needs the same cell-deref
+    // routing the lifted body had.
+    boxedCaptures: info.boxedCaptures,
+    readsCurrentThis: info.readsCurrentThis,
   };
   const frameLocal = 0;
 
@@ -892,6 +914,34 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
       fieldIdx: info.spillFieldOffset + i,
     });
     resumeFctx.body.push({ op: "local.set", index: idx });
+  }
+  // (#2865) A lifted-CLOSURE body (arrow / fn-expr) keeps its captures in the
+  // `__self` struct — closures.ts materializes each into a NAMED local in the
+  // lifted body's prologue, and every identifier/call site in the body resolves
+  // them via localMap (cells deref through `boxedCaptures`). This resume fn
+  // compiles the SAME body statements, so re-run that materialization from the
+  // frame-captured `__self` param field. Without it, capture resolution falls
+  // back to STALE outer-scope local indices (the capture-arg push in calls.ts
+  // uses `localMap.get(name) ?? cap.outerLocalIdx`) — a guaranteed miscompile.
+  if (info.selfCaptureLayout) {
+    const layout = info.selfCaptureLayout;
+    const selfIdx = resumeFctx.localMap.get(layout.selfParamName);
+    if (selfIdx !== undefined) {
+      let selfForCaptures = selfIdx;
+      if (layout.castToTypeIdx !== null) {
+        const castLocal = allocLocal(resumeFctx, "__self_cast", { kind: "ref", typeIdx: layout.castToTypeIdx });
+        resumeFctx.body.push({ op: "local.get", index: selfIdx });
+        resumeFctx.body.push({ op: "ref.cast", typeIdx: layout.castToTypeIdx } as Instr);
+        resumeFctx.body.push({ op: "local.set", index: castLocal });
+        selfForCaptures = castLocal;
+      }
+      for (const entry of layout.entries) {
+        const idx = allocLocal(resumeFctx, entry.name, entry.localType);
+        resumeFctx.body.push({ op: "local.get", index: selfForCaptures });
+        resumeFctx.body.push({ op: "struct.get", typeIdx: layout.structTypeIdx, fieldIdx: entry.fieldIdx } as Instr);
+        resumeFctx.body.push({ op: "local.set", index: idx });
+      }
+    }
   }
   // Load the result promise into a local; wire the `return` settle hook. Both
   // backends settle through `call <fulfill>(promise, value) -> value; drop` —
@@ -1597,6 +1647,13 @@ export function emitAsyncFrameStateMachine(
   const paramNames = fctx.params.map((p) => p.name);
   const paramTypes = fctx.params.map((p) => p.type);
   const info = buildAsyncFrameInfo(ctx, decl, plan, paramNames, paramTypes, promiseTypeIdx, hostImports);
+  // (#2865) A CLOSURE consumer (arrow / fn-expr, #2957 phase 2) may capture
+  // outer locals as ref cells (leading params of the lifted fn). The cells ride
+  // into frame param fields like ordinary params; the resume body must deref
+  // reads/writes through them, so thread the cell metadata onto the resume fctx.
+  info.boxedCaptures = fctx.boxedCaptures;
+  info.readsCurrentThis = fctx.readsCurrentThis;
+  info.selfCaptureLayout = fctx.selfCaptureLayout;
   const resumeFuncIdx = ensureAsyncResumeFunction(ctx, info, plan);
   if (resumeFuncIdx < 0) {
     reportError(ctx, decl, "internal: async-frame resume function unavailable (#2895 slice 1)");
@@ -1672,6 +1729,11 @@ export function emitAsyncFrameStateMachine(
  */
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
+  // (#2865) Stem-collision guard: a SECOND same-named gen (different scope)
+  // would share the first's `__async_gen_next_<stem>` helper — typed for the
+  // FIRST frame struct — and trap on `ref.cast`. Correct-or-legacy: reject it.
+  const registered = ctx.asyncGenProducers?.get(sanitizeTypeName(asyncFnName(decl)));
+  if (registered !== undefined && registered.decl !== decl) return false;
   // (#2865) Own body locals become frame spills — every spill field must have a
   // spill-safe type (an inert `struct.new` default), or the layout is invalid.
   const spillsSafe = (): boolean => {
@@ -1747,6 +1809,11 @@ export function emitAsyncGenerator(ctx: CodegenContext, fctx: FunctionContext, d
   const info = buildAsyncFrameInfo(ctx, decl, plan, paramNames, paramTypes, promiseTypeIdx);
   info.asyncGen = true;
   info.asyncGenResultTypeIdx = resultTypeIdx;
+  // (#2865) Nested producers: thread the lifted fn's capture-cell metadata so
+  // the resume body derefs captured reads/writes through the cells.
+  info.boxedCaptures = fctx.boxedCaptures;
+  info.readsCurrentThis = fctx.readsCurrentThis;
+  info.selfCaptureLayout = fctx.selfCaptureLayout;
 
   const resumeFuncIdx = ensureAsyncResumeFunction(ctx, info, plan);
   if (resumeFuncIdx < 0) {
@@ -1758,6 +1825,21 @@ export function emitAsyncGenerator(ctx: CodegenContext, fctx: FunctionContext, d
   // Per-gen re-entrant next() driver + the generic reader probes (once/module).
   emitAsyncGenNextHelper(ctx, info, promiseTypeIdx);
   ensureAsyncGenReaderProbes(ctx, promiseTypeIdx, resultTypeIdx);
+
+  // (#2865) Register the producer so (a) the `.next()` runtime dispatch chain
+  // (calls.ts) can ref.test this frame type → its next helper, and (b) the
+  // stem-collision guard in `isAsyncGenDriveCandidate` rejects a SECOND,
+  // different gen with the same sanitized name (it would otherwise silently
+  // share this helper — typed for THIS frame — and trap on `ref.cast`).
+  const stem = sanitizeTypeName(info.functionName);
+  if (!ctx.asyncGenProducers) ctx.asyncGenProducers = new Map();
+  if (!ctx.asyncGenProducers.has(stem)) {
+    ctx.asyncGenProducers.set(stem, {
+      stateTypeIdx: info.stateTypeIdx,
+      nextHelperName: `__async_gen_next_${stem}`,
+      decl,
+    });
+  }
 
   // Build the frame WITHOUT kicking (lazy): state=0, sent/mode/abrupt/error inert,
   // params, [no spills — bounded shape], result_promise = fresh pending.

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -45,6 +45,7 @@ import {
   awaitedExprIsPromiseCombinator,
   forAwaitAsyncNeedsDrive,
   forAwaitNeedsDrive,
+  asyncGenOwnLocalDecls,
   forAwaitSpillInfo,
   isAwaitFreeAsyncGenBody,
   isBoundedAsyncGenBody,
@@ -576,6 +577,20 @@ function computeAsyncSpills(
   plan: AsyncCpsPlan,
   paramNames: string[],
 ): { spillNames: string[]; spillTypes: ValType[] } {
+  // (#2865) Async GENERATOR (`async function*` — the only asterisked shape that
+  // reaches the async frame): EVERY yield is a suspend point (the resume fn
+  // returns and re-enters on the next `next()` kick), so every own identifier
+  // local is conservatively treated as live-across-suspend and spilled — the
+  // same widened rule the 3a loop machine uses. Params live in param fields.
+  if (decl.asteriskToken !== undefined) {
+    const spillNames: string[] = [];
+    const spillTypes: ValType[] = [];
+    for (const [name, node] of asyncGenOwnLocalDecls(decl)) {
+      spillNames.push(name);
+      spillTypes.push(resolveSpillLocalValType(ctx, node) ?? { kind: "externref" });
+    }
+    return { spillNames, spillTypes };
+  }
   const linear = planLinearAwaits(decl, plan);
   if (linear === null) {
     // (#2906 slice 3a) `while`-with-await loop: widened spill set (all loop
@@ -1657,10 +1672,18 @@ export function emitAsyncFrameStateMachine(
  */
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
+  // (#2865) Own body locals become frame spills — every spill field must have a
+  // spill-safe type (an inert `struct.new` default), or the layout is invalid.
+  const spillsSafe = (): boolean => {
+    for (const node of asyncGenOwnLocalDecls(decl).values()) {
+      if (!isSpillSafeType(resolveSpillLocalValType(ctx, node) ?? { kind: "externref" })) return false;
+    }
+    return true;
+  };
   // Under the native-`$Promise` CARRIER (`isStandalonePromiseActive`, wasi
   // today): the full bounded shape, awaited yields included — the awaited
   // operand lowers to a native `$Promise` the suspend arm can assimilate.
-  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(decl);
+  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(decl) && spillsSafe();
   // (#2865) `--target standalone` with the carrier gate still OFF (#2980):
   // drive the producer host-free ONLY for await-free bodies. With the carrier
   // off an awaited operand does not lower to a native `$Promise`, so
@@ -1668,7 +1691,7 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // — those bodies keep the legacy path (correct-or-legacy, #680 CE) until the
   // measured carrier widen. An await-free body is carrier-independent: every
   // promise the machine touches is minted by `__async_gen_next_<name>` itself.
-  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(decl);
+  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(decl) && spillsSafe();
   return false;
 }
 

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -46,6 +46,7 @@ import {
   forAwaitAsyncNeedsDrive,
   forAwaitNeedsDrive,
   forAwaitSpillInfo,
+  isAwaitFreeAsyncGenBody,
   isBoundedAsyncGenBody,
   isEmitOperand,
   loopAsyncSpillInfo,
@@ -1656,13 +1657,46 @@ export function emitAsyncFrameStateMachine(
  */
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
-  // Gate on the native-`$Promise` CARRIER (`isStandalonePromiseActive`,
-  // currently wasi-only) — the SAME gate the plain/for-await drive lanes use
-  // (`decideAsyncActivation`). In non-wasi standalone the awaited operand does
-  // not lower to a native `$Promise`, so the drive machine would be broken; the
-  // widen to `standalone` is the shared slice-1d carrier move.
-  if (!isStandalonePromiseActive(ctx)) return false;
-  return isBoundedAsyncGenBody(decl);
+  // Under the native-`$Promise` CARRIER (`isStandalonePromiseActive`, wasi
+  // today): the full bounded shape, awaited yields included — the awaited
+  // operand lowers to a native `$Promise` the suspend arm can assimilate.
+  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(decl);
+  // (#2865) `--target standalone` with the carrier gate still OFF (#2980):
+  // drive the producer host-free ONLY for await-free bodies. With the carrier
+  // off an awaited operand does not lower to a native `$Promise`, so
+  // `yield await P` would deliver the un-awaited promise object (wrong value)
+  // — those bodies keep the legacy path (correct-or-legacy, #680 CE) until the
+  // measured carrier widen. An await-free body is carrier-independent: every
+  // promise the machine touches is minted by `__async_gen_next_<name>` itself.
+  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(decl);
+  return false;
+}
+
+/**
+ * (#2865) Standalone carrier-off analogue of {@link asyncFnNeedsDrive},
+ * restricted to the ONE shape that is carrier-independent: a bounded
+ * `for await (const x of g())` CONSUMER over a host-free async generator.
+ * Every suspension in that machine awaits a promise MINTED by the producer's
+ * own `__async_gen_next_<name>` driver (always a native `$Promise`, regardless
+ * of the carrier gate), so it drives correctly under `--target standalone`
+ * while plain awaits / Promise statics stay on the legacy path pending the
+ * #2980 carrier-widen decision. The 3b boxed-ARRAY for-await variant
+ * (`forAwaitNeedsDrive`) is deliberately NOT accepted here — its per-element
+ * `Await(value)` operands are host-backed promises under the un-widened
+ * carrier, which the suspend arm would mis-classify as settled plain values.
+ */
+export function asyncGenConsumerNeedsDrive(
+  ctx: CodegenContext,
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): boolean {
+  if (!ASYNC_CPS_ENABLED) return false;
+  if (plan.awaitPoints.length !== 0) return false; // bare awaits are carrier-dependent
+  if (plan.forAwaitPoints.length === 0) return false;
+  if (!forAwaitAsyncNeedsDrive(ctx, fn, plan)) return false;
+  const fa = computeForAwaitSpills(ctx, fn, plan);
+  if (fa === null) return false;
+  return fa.spillTypes.every(isSpillSafeType);
 }
 
 /**

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -3332,7 +3332,19 @@ const ASYNC_CARRIER_WIDEN_MEASURE = typeof process !== "undefined" && process.en
  */
 export function isStandaloneThenChainNativeActive(ctx: CodegenContext): boolean {
   if (ASYNC_CARRIER_WIDEN_MEASURE) return ctx.wasi === true || ctx.standalone === true;
-  return ctx.wasi === true;
+  if (ctx.wasi === true) return true;
+  // (#2865) `--target standalone` with the async-GENERATOR drive active: the
+  // driven producers mint native `$Promise`s (`__async_gen_next_*` results, the
+  // consumer's result promise), which the host `.then` path cannot chain (an
+  // opaque struct to the host). Once THIS module has registered the native
+  // scheduler (only driven machinery does), `.then`/`.catch` compile the #3035
+  // runtime `ref.test` receiver bridge: a native `$Promise` receiver chains
+  // natively, anything else keeps the exact host path. Modules with no driven
+  // machinery are byte-identical (the predicate stays false — the scheduler is
+  // never registered for them). This is receiver-directed dispatch, NOT the
+  // #2980 carrier widen: `Promise.resolve`/statics/await lowering are untouched
+  // (`isStandalonePromiseActive` remains wasi-only pending the measured flip).
+  return ctx.standalone === true && getDrainFuncIdxForWasiStart(ctx) !== null;
 }
 
 /**

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -2327,6 +2327,8 @@ function compileClassBodiesInner(
 
         // Return __create_generator or __create_async_generator depending on async flag
         const createGenName = isAsyncMethod ? "__create_async_generator" : "__create_generator";
+        // (#2865) Record legacy-buffer async gens so the .next() dispatch keeps a host miss arm.
+        if (createGenName === "__create_async_generator") ctx.asyncGenLegacyBufferEmitted = true;
         const createGenIdx = ctx.funcMap.get(createGenName)!;
         fctx.body.push({ op: "local.get", index: bufferLocal });
         fctx.body.push({ op: "local.get", index: pendingThrowLocal });

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2844,6 +2844,8 @@ export function compileArrowAsClosure(
 
     // Return __create_generator or __create_async_generator depending on async flag
     const createGenName = isAsync ? "__create_async_generator" : "__create_generator";
+    // (#2865) Record legacy-buffer async gens so the .next() dispatch keeps a host miss arm.
+    if (createGenName === "__create_async_generator") ctx.asyncGenLegacyBufferEmitted = true;
     const createGenIdx = ctx.funcMap.get(createGenName)!;
     liftedFctx.body.push({ op: "local.get", index: bufferLocal });
     liftedFctx.body.push({ op: "local.get", index: pendingThrowLocal });

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -81,6 +81,7 @@ import { addFunctionOwnLocals, registerOwnLocalsCollector } from "./binding-info
 // (a cycle), so it must evaluate after this module's other deps are loaded to
 // avoid perturbing the init order of the coercion-engine/string-ops chain.
 import { planAsyncClosureActivation, emitAsyncClosureBody } from "./async-activation.js";
+import { emitAsyncGenerator, isAsyncGenDriveCandidate } from "./async-frame.js"; // (#2865) async-gen fn-expr producer
 
 // ── Arrow function callbacks ──────────────────────────────────────────
 
@@ -2280,6 +2281,19 @@ export function compileArrowAsClosure(
     liftedFctx.body.push({ op: "local.set", index: castLocal });
     selfLocalForCaptures = castLocal;
   }
+  // (#2865) Record the capture layout so the async drive lane's FRESH resume
+  // FunctionContext can re-materialize these capture locals from the
+  // frame-captured `__self` (the materialization below lands only in THIS
+  // lifted body; a driven body compiles in the resume fn instead).
+  const selfCaptureLayoutEntries: { name: string; fieldIdx: number; localType: ValType }[] = [];
+  if (captures.length > 0) {
+    liftedFctx.selfCaptureLayout = {
+      selfParamName: "__self",
+      structTypeIdx,
+      castToTypeIdx: usesWrapperFuncType ? structTypeIdx : null,
+      entries: selfCaptureLayoutEntries,
+    };
+  }
   for (let i = 0; i < captures.length; i++) {
     const cap = captures[i]!;
     if (cap.mutable) {
@@ -2300,6 +2314,7 @@ export function compileArrowAsClosure(
       }
       const refCellType: ValType = { kind: "ref_null", typeIdx: refCellTypeIdx };
       const localIdx = allocLocal(liftedFctx, cap.name, refCellType);
+      selfCaptureLayoutEntries.push({ name: cap.name, fieldIdx: i + 1, localType: refCellType });
       liftedFctx.body.push({ op: "local.get", index: selfLocalForCaptures });
       liftedFctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: i + 1 });
       liftedFctx.body.push({ op: "local.set", index: localIdx });
@@ -2315,6 +2330,7 @@ export function compileArrowAsClosure(
       const valType = outerBoxed?.valType ?? { kind: "f64" as const };
       const refCellType: ValType = { kind: "ref_null", typeIdx: refCellTypeIdx };
       const localIdx = allocLocal(liftedFctx, cap.name, refCellType);
+      selfCaptureLayoutEntries.push({ name: cap.name, fieldIdx: i + 1, localType: refCellType });
       liftedFctx.body.push({ op: "local.get", index: selfLocalForCaptures });
       liftedFctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: i + 1 });
       liftedFctx.body.push({ op: "local.set", index: localIdx });
@@ -2322,6 +2338,7 @@ export function compileArrowAsClosure(
       liftedFctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType });
     } else {
       const localIdx = allocLocal(liftedFctx, cap.name, cap.type);
+      selfCaptureLayoutEntries.push({ name: cap.name, fieldIdx: i + 1, localType: cap.type });
       liftedFctx.body.push({ op: "local.get", index: selfLocalForCaptures });
       liftedFctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: i + 1 });
       liftedFctx.body.push({ op: "local.set", index: localIdx });
@@ -2728,7 +2745,24 @@ export function compileArrowAsClosure(
     hoistLetConstWithTdz(ctx, liftedFctx, body.statements);
   }
 
-  if (isGenerator && ts.isBlock(body)) {
+  if (
+    isGenerator &&
+    isAsync &&
+    ts.isBlock(body) &&
+    (liftedFctx.boxedTdzFlags === undefined || liftedFctx.boxedTdzFlags.size === 0) &&
+    isAsyncGenDriveCandidate(ctx, arrow)
+  ) {
+    // (#2865) Async-generator function EXPRESSION producer (`const f = async
+    // function* () {...}` — the test262 forbidden-ext fn-expr family, which
+    // previously compiled to a null-returning shape under standalone). Same
+    // interception as the top-level / nested-declaration paths: build the lazy
+    // `$AsyncFrame` carrier + the per-gen `__async_gen_next_<name>` driver on
+    // the async-frame CFG machine. Capture cells (leading params of the lifted
+    // closure) ride into frame param fields; `boxedCaptures` is threaded onto
+    // the resume fn. TDZ-flagged captures store PARAM indices in
+    // `boxedTdzFlags` (wrong in the resume fn's local layout) → legacy path.
+    emitAsyncGenerator(ctx, liftedFctx, arrow);
+  } else if (isGenerator && ts.isBlock(body)) {
     // Generator function expression: eagerly evaluate body, collect yields
     // into a buffer, then wrap with __create_generator.
     // The body is wrapped in try/catch so that exceptions thrown before any yields

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1458,6 +1458,15 @@ export interface CodegenContext {
    */
   asyncGenProducers?: Map<string, { stateTypeIdx: number; nextHelperName: string; decl: ts.Node }>;
   /**
+   * (#2865) True once ANY async generator was emitted on the LEGACY buffer path
+   * (`__create_async_generator`). The `.next()` runtime dispatch chain uses this
+   * to decide its miss arm: with legacy receivers possible it must fall back to
+   * the host `__gen_next`; in an all-driven module it emits a plain null instead
+   * — referencing `__gen_next` there would force an otherwise-dead host import
+   * and break the zero-import (host-free) contract.
+   */
+  asyncGenLegacyBufferEmitted?: boolean;
+  /**
    * Function declarations pre-registered during module-pass eager class body
    * compilation. The entry has a reserved `mod.functions` slot and signature,
    * but its body still belongs to the normal nested-function hoist pass.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -376,6 +376,22 @@ export interface FunctionContext {
   /** Map from variable name → ref cell info (for mutable closure captures) */
   boxedCaptures?: Map<string, { refCellTypeIdx: number; valType: ValType }>;
   /**
+   * (#2865) The `__self` capture-struct layout of a LIFTED CLOSURE body
+   * (closures.ts materializes each capture from `__self` field `i+1` into a
+   * named local in the body prologue). The async drive lane compiles the body
+   * in a FRESH resume FunctionContext whose frame captured only the closure's
+   * PARAMS — so the resume prologue must re-materialize these capture locals
+   * from the frame-captured `__self` before any body statement compiles.
+   * `castToTypeIdx` is set when `__self`'s param type is the wrapper base
+   * struct (needs a `ref.cast` to the concrete capture struct first).
+   */
+  selfCaptureLayout?: {
+    selfParamName: string;
+    structTypeIdx: number;
+    castToTypeIdx: number | null;
+    entries: { name: string; fieldIdx: number; localType: ValType }[];
+  };
+  /**
    * (#2976) Per-activation memo locals for capture-carrying nested function
    * declarations referenced as VALUES: funcName → local holding the
    * `(ref null $__fn_cap_<name>_struct)` closure instance. Every reference
@@ -1431,6 +1447,16 @@ export interface CodegenContext {
   nativeGeneratorResultTypeIdx: number;
   /** Function declarations lowered to Wasm-native generator state machines (#680). */
   nativeGenerators: Map<string, NativeGeneratorInfo>;
+  /**
+   * (#2865) Async-generator PRODUCERS driven on the async-frame machine, keyed
+   * by sanitized stem (the `__async_gen_next_<stem>` suffix). Populated by
+   * `emitAsyncGenerator`; consumed by (a) the `.next()` runtime dispatch chain
+   * in calls.ts and (b) the stem-collision guard in `isAsyncGenDriveCandidate`
+   * (two same-named gens in different scopes would otherwise share one
+   * `__async_gen_next_<stem>` helper typed for the FIRST gen's frame — a
+   * guaranteed `ref.cast` trap for the second).
+   */
+  asyncGenProducers?: Map<string, { stateTypeIdx: number; nextHelperName: string; decl: ts.Node }>;
   /**
    * Function declarations pre-registered during module-pass eager class body
    * compilation. The entry has a reserved `mod.functions` slot and signature,

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -18,6 +18,7 @@ import type { Instr, ValType } from "../ir/types.js";
 import {
   emitStandalonePromiseReject,
   emitStandalonePromiseResolve,
+  getDrainFuncIdxForWasiStart,
   getOrRegisterPromiseType,
   isStandalonePromiseActive,
   emitDrainMicrotasks,
@@ -1244,10 +1245,20 @@ function compileExpressionInner(
     if (ts.isIdentifier(expr.expression) && expr.expression.text === "__drain_microtasks") {
       // Gate on the native-`$Promise` CARRIER (not merely `isAsyncDriveActive`):
       // emit the real drain only where the drive layer actually produces native
-      // promises. With the carrier `wasi`-only today, `--target standalone` and
-      // the gc lane get a void no-op (no microtask infra registered, output
-      // unchanged); the #2895-1d carrier re-widen auto-activates it for standalone.
-      if (isStandalonePromiseActive(ctx)) emitDrainMicrotasks(ctx, fctx);
+      // promises. With the carrier `wasi`-only today the gc lane gets a void
+      // no-op (no microtask infra registered, output unchanged).
+      //
+      // (#2865) `--target standalone` addendum: the async-GENERATOR drive is now
+      // active under standalone (carrier-independent — its promises are minted
+      // by `__async_gen_next_*`), so when THIS module has already registered the
+      // native microtask queue, emit the real drain too. Modules with no driven
+      // machinery keep the byte-identical no-op (`getDrainFuncIdxForWasiStart`
+      // is null when the queue was never registered). Function bodies compile in
+      // source order, so a harness-appended `__drain_microtasks()` call compiles
+      // after every producer/consumer registration.
+      if (isStandalonePromiseActive(ctx) || getDrainFuncIdxForWasiStart(ctx) !== null) {
+        emitDrainMicrotasks(ctx, fctx);
+      }
       return VOID_RESULT;
     }
     const callStart = fctx.body.length;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3622,6 +3622,72 @@ function emitHostPromiseThenFallback(
  * BEFORE reaching here and keep the original unconditional-cast lowering
  * for wasi untouched.
  */
+
+/**
+ * (#2865) Zero-arg `.next()` on a possibly-DRIVEN async-generator receiver.
+ * `g()` on a driven producer returns the `$AsyncFrame` carrier (a bare
+ * externref); source-level `g().next()` / `it.next()` must route to the
+ * per-gen re-entrant driver `__async_gen_next_<stem>(frame) ->
+ * Promise<IteratorResult>`. The receiver is dispatched at RUNTIME by
+ * `ref.test`ing each registered producer's frame struct (the chain shape
+ * `buildNativeGeneratorDispatch` uses for sync gens).
+ *
+ * Miss arm (a receiver that is none of the driven frames):
+ *  - under `--target standalone`, the legacy host `__gen_next` whenever the
+ *    module has it registered — EXACTLY what this receiver got before #2865
+ *    (buffer async gens, sync host gens, and the user-object `.next()` hijack
+ *    all keep their behavior; the in-process runner stubs the import);
+ *  - under `--target wasi` (zero-import contract, no stubs — a host fallback
+ *    can never succeed), only when a legacy buffer async gen was actually
+ *    emitted (`asyncGenLegacyBufferEmitted`); otherwise a plain null result,
+ *    so an all-driven module stays host-free.
+ *
+ * Returns null (no emission) when the module has no driven producers or the
+ * target is the JS-host lane — the caller falls through to its original
+ * lowering, byte-identical.
+ */
+function tryEmitAsyncGenNextDispatch(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiverExpr: ts.Expression,
+): ValType | null {
+  const producers = ctx.asyncGenProducers;
+  if (ctx.standalone !== true && ctx.wasi !== true) return null;
+  if (producers === undefined || producers.size === 0) return null;
+  // Evaluate the receiver ONCE into an externref local (it may be a call).
+  const recvLocal = allocLocal(fctx, `__agen_recv_${fctx.locals.length}`, { kind: "externref" });
+  const rt = compileExpression(ctx, fctx, receiverExpr, { kind: "externref" });
+  if (rt !== null && rt !== undefined && (rt as ValType).kind !== "externref") {
+    coerceType(ctx, fctx, rt as ValType, { kind: "externref" });
+  }
+  fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
+  // funcMap lookups happen AFTER the receiver compile (which may register late
+  // imports and shift defined indices).
+  const wantHostFallback = ctx.wasi === true ? ctx.asyncGenLegacyBufferEmitted === true : true;
+  const hostGenNext = wantHostFallback ? ctx.funcMap.get("__gen_next") : undefined;
+  let chain: Instr[] =
+    hostGenNext !== undefined
+      ? [{ op: "local.get", index: recvLocal } as Instr, { op: "call", funcIdx: hostGenNext } as Instr]
+      : [{ op: "ref.null.extern" } as Instr];
+  for (const p of [...producers.values()].reverse()) {
+    const nextIdx = ctx.funcMap.get(p.nextHelperName);
+    if (nextIdx === undefined) continue;
+    chain = [
+      { op: "local.get", index: recvLocal } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.test", typeIdx: p.stateTypeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: [{ op: "local.get", index: recvLocal } as Instr, { op: "call", funcIdx: nextIdx } as Instr],
+        else: chain,
+      } as Instr,
+    ];
+  }
+  fctx.body.push(...chain);
+  return { kind: "externref" };
+}
+
 function emitStandaloneThenWithNativeFallback(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3629,6 +3695,11 @@ function emitStandaloneThenWithNativeFallback(
   method: "then" | "catch",
   onFulfilledArg: ts.Expression | undefined,
   onRejectedArg: ts.Expression | undefined,
+  // (#2865) `nullMiss` replaces the HOST miss arm with a plain null result —
+  // for `--target wasi` any-receiver dispatch, where the zero-import contract
+  // forbids registering `Promise_then*`/`__make_callback` and a host arm could
+  // never succeed anyway (no stubs). Native receivers are unaffected.
+  opts?: { nullMiss?: boolean },
 ): void {
   const liveBuffers: Instr[][] = [];
   try {
@@ -3659,15 +3730,19 @@ function emitStandaloneThenWithNativeFallback(
     }
 
     const hostArm: Instr[] = [];
-    ctx.liveBodies.add(hostArm);
-    liveBuffers.push(hostArm);
-    fctx.savedBodies.push(outerBody);
-    fctx.body = hostArm;
-    try {
-      emitHostPromiseThenFallback(ctx, fctx, recvLocal, method, onFulfilledArg, onRejectedArg);
-    } finally {
-      fctx.savedBodies.pop();
-      fctx.body = outerBody;
+    if (opts?.nullMiss === true) {
+      hostArm.push({ op: "ref.null.extern" } as Instr);
+    } else {
+      ctx.liveBodies.add(hostArm);
+      liveBuffers.push(hostArm);
+      fctx.savedBodies.push(outerBody);
+      fctx.body = hostArm;
+      try {
+        emitHostPromiseThenFallback(ctx, fctx, recvLocal, method, onFulfilledArg, onRejectedArg);
+      } finally {
+        fctx.savedBodies.pop();
+        fctx.body = outerBody;
+      }
     }
 
     const promiseTypeIdx = getOrRegisterPromiseType(ctx);
@@ -10271,6 +10346,20 @@ function compileCallExpression(
       if (externResult !== undefined) return externResult;
     }
 
+    // (#2865) `.next()` on a DRIVEN async-generator object (typed receiver).
+    // `next(v)` sent-value delivery + `.throw()`/`.return()` are 3d-iii.
+    {
+      const recvSymName = receiverType.getSymbol()?.name;
+      if (
+        propAccess.name.text === "next" &&
+        expr.arguments.length === 0 &&
+        (recvSymName === "AsyncGenerator" || recvSymName === "AsyncIterableIterator" || recvSymName === "AsyncIterator")
+      ) {
+        const dispatched = tryEmitAsyncGenNextDispatch(ctx, fctx, propAccess.expression);
+        if (dispatched !== null) return dispatched;
+      }
+    }
+
     // Generator method calls: gen.next(), gen.return(value), gen.throw(error)
     if (isGeneratorType(receiverType)) {
       const methodName = propAccess.name.text;
@@ -10334,6 +10423,36 @@ function compileCallExpression(
         const recvSym = receiverTsType.getSymbol()?.name;
         const apparentSym = ctx.checker.getApparentType(receiverTsType).getSymbol()?.name;
         const isPromiseReceiver = recvSym === "Promise" || apparentSym === "Promise";
+
+        // (#2865) ANY-typed receiver under ACTIVE native chaining: the value
+        // may be a native `$Promise` minted by the driven async-gen machinery
+        // (`var f; f = async function*(){…}; f().next().then(cb, $DONE)` — the
+        // dominant test262 driving shape holds everything as `any`). Route
+        // through the runtime `ref.test` receiver bridge: a native `$Promise`
+        // chains natively; a miss keeps the host path under standalone
+        // (behavior-preserving — the generic any-path used the same host
+        // imports) and yields null under wasi (zero-import contract; a host
+        // arm could never succeed there). Only fires when the module has
+        // native machinery (`isStandaloneThenChainNativeActive` — wasi, or
+        // standalone with the scheduler registered), so every other module is
+        // byte-identical.
+        if (
+          !isPromiseReceiver &&
+          (method === "then" || method === "catch") &&
+          (receiverTsType.flags & ts.TypeFlags.Any) !== 0 &&
+          isStandaloneThenChainNativeActive(ctx)
+        ) {
+          emitStandaloneThenWithNativeFallback(
+            ctx,
+            fctx,
+            propAccess.expression,
+            method,
+            method === "then" ? expr.arguments[0] : undefined,
+            method === "then" ? expr.arguments[1] : expr.arguments[0],
+            { nullMiss: ctx.wasi === true },
+          );
+          return { kind: "externref" };
+        }
 
         if (isPromiseReceiver) {
           // (#2980 class 1) `.then` on native chaining. WASI's ZERO-host-
@@ -12216,6 +12335,15 @@ function compileCallExpression(
         // Generator protocol: .next(), .return(value), .throw(error) on any/externref
         // These are very common in test262 generator tests where variables are typed as `any`.
         if (methodName === "next") {
+          // (#2865) An any-typed receiver may hold a DRIVEN async-gen frame
+          // (`var f; f = async function*(){…}; f().next()` — the dominant
+          // test262 shape). Runtime ref.test-dispatch to the per-gen driver;
+          // the miss arm preserves this site's original `__gen_next` behavior
+          // (see tryEmitAsyncGenNextDispatch). Zero-arg only.
+          if (expr.arguments.length === 0) {
+            const dispatched = tryEmitAsyncGenNextDispatch(ctx, fctx, propAccess.expression);
+            if (dispatched !== null) return dispatched;
+          }
           const genNextIdx = ctx.funcMap.get("__gen_next");
           if (genNextIdx !== undefined) {
             compileExpression(ctx, fctx, propAccess.expression, {

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -1117,6 +1117,8 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       // the AST node directly to detect async function* declarations.
       const isAsyncGenerator = hasAsyncModifier(decl);
       const createGenName = isAsyncGenerator ? "__create_async_generator" : "__create_generator";
+      // (#2865) Record legacy-buffer async gens so the .next() dispatch keeps a host miss arm.
+      if (createGenName === "__create_async_generator") ctx.asyncGenLegacyBufferEmitted = true;
       const createGenIdx = ctx.funcMap.get(createGenName)!;
       fctx.body.push({ op: "local.get", index: bufferLocal });
       fctx.body.push({ op: "local.get", index: pendingThrowLocal });

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -2787,6 +2787,8 @@ export function compileObjectLiteralForStruct(
 
         // Return __create_generator or __create_async_generator depending on async flag
         const createGenName = isAsyncMethod ? "__create_async_generator" : "__create_generator";
+        // (#2865) Record legacy-buffer async gens so the .next() dispatch keeps a host miss arm.
+        if (createGenName === "__create_async_generator") ctx.asyncGenLegacyBufferEmitted = true;
         const createGenIdx = ctx.funcMap.get(createGenName)!;
         methodFctx.body.push({ op: "local.get", index: bufferLocal });
         methodFctx.body.push({ op: "local.get", index: pendingThrowLocal });

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -34,6 +34,7 @@ import {
   extractConstantDefault,
   resolveWasmType,
 } from "../index.js";
+import { emitAsyncGenerator, isAsyncGenDriveCandidate } from "../async-frame.js"; // (#2865) nested async-gen producer
 import { ensureExnTag, nextModuleGlobalIdx } from "../registry/imports.js";
 import {
   addFuncType,
@@ -672,6 +673,15 @@ export function compileNestedFunctionDeclaration(
       // Wasm-native generator factory (builds + returns the state struct), the
       // same body the top-level path emits. No host imports, no JS buffer.
       compileNativeGeneratorFunction(ctx, liftedFctx, stmt, nativeGenInfo);
+    } else if (isGenerator && isAsync && isAsyncGenDriveCandidate(ctx, stmt)) {
+      // (#2865) NESTED async-generator producer (the dominant test262 shape —
+      // the runner wraps every test body inside `export function test()`, so
+      // the gen declaration is nested). Same interception the top-level
+      // `function-body.ts` path applies BEFORE the buffer/#680 arm: build the
+      // lazy `$AsyncFrame` carrier + the per-gen `__async_gen_next_<name>`
+      // driver on the async-frame CFG machine. No captures in this branch, so
+      // the frame captures the declared params only.
+      emitAsyncGenerator(ctx, liftedFctx, stmt);
     } else if (isGenerator) {
       // Generator function: eagerly evaluate body, collect yields into a JS array,
       // then wrap it with __create_generator to return a Generator-like object.
@@ -982,7 +992,18 @@ export function compileNestedFunctionDeclaration(
       if (liftedFctx.mappedArgsInfo) ctx.mappedArgsInfoByFunc.set(stmt, liftedFctx.mappedArgsInfo);
     }
 
-    if (isGenerator) {
+    if (isGenerator && isAsync && tdzFlaggedCaptures.length === 0 && isAsyncGenDriveCandidate(ctx, stmt)) {
+      // (#2865) NESTED async-generator producer WITH captures — the dominant
+      // real test262 shape (`var callCount = 0; async function* f() {
+      // callCount++; ... }` inside the runner's `test()` wrapper: callCount is
+      // a test() local, so the gen captures it as a mutable ref cell). The
+      // lifted fn's leading capture-cell params are captured into `$AsyncFrame`
+      // param fields like ordinary params; `emitAsyncGenerator` threads
+      // `liftedFctx.boxedCaptures` onto the resume fn so body reads/writes
+      // deref the cells. TDZ-flagged captures store PARAM indices in
+      // `boxedTdzFlags` (wrong in the resume fn's local layout) → legacy.
+      emitAsyncGenerator(ctx, liftedFctx, stmt);
+    } else if (isGenerator) {
       // Generator function: eagerly evaluate body, collect yields into a JS array,
       // then wrap it with __create_generator to return a Generator-like object.
       // The body is wrapped in try/catch so that exceptions thrown before any yields

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -734,6 +734,8 @@ export function compileNestedFunctionDeclaration(
 
       // Return __create_generator or __create_async_generator depending on async flag
       const createGenName = isAsync ? "__create_async_generator" : "__create_generator";
+      // (#2865) Record legacy-buffer async gens so the .next() dispatch keeps a host miss arm.
+      if (createGenName === "__create_async_generator") ctx.asyncGenLegacyBufferEmitted = true;
       const createGenIdx = ctx.funcMap.get(createGenName)!;
       liftedFctx.body.push({ op: "local.get", index: bufferLocal });
       liftedFctx.body.push({ op: "local.get", index: pendingThrowLocal });
@@ -1055,6 +1057,8 @@ export function compileNestedFunctionDeclaration(
 
       // Return __create_generator or __create_async_generator depending on async flag
       const createGenName = isAsync ? "__create_async_generator" : "__create_generator";
+      // (#2865) Record legacy-buffer async gens so the .next() dispatch keeps a host miss arm.
+      if (createGenName === "__create_async_generator") ctx.asyncGenLegacyBufferEmitted = true;
       const createGenIdx = ctx.funcMap.get(createGenName)!;
       liftedFctx.body.push({ op: "local.get", index: bufferLocal });
       liftedFctx.body.push({ op: "local.get", index: pendingThrowLocal });


### PR DESCRIPTION
## Summary

#2865 (Tier-0 substrate root): standalone async generators had NO Wasm-native carrier — `async function*` was a #680 CE (decls) or a null-returning fn-expr, and the landed #2906 3d-i/3d-ii machinery was (a) gated wasi-only and (b) unreachable for the shapes real test262 files are written in (nested/fn-expr gens inside the runner's `test()` wrapper, driven by `f().next().then(cb, $DONE)`).

Five layers, each byte-inert off-lane and probed on both host-free lanes:

1. **Standalone activation (carrier-independent subset)**: await-free bounded gen bodies drive under `--target standalone`; the for-await-over-async-gen consumer activates (its every suspension awaits a machine-minted native $Promise). Explicitly NOT the #2980 carrier widen — Promise statics / await lowering untouched.
2. **Producer body generalization**: lead statements, zero-yield bodies, own-local frame spills (3a loop rule, spill-safe-gated). `yield*`/return/dstr-locals/pattern-params stay correct-or-legacy.
3. **Nested + fn-expr producers** (the real test262 shape) with capture support: nested decls thread `boxedCaptures`; closures record `selfCaptureLayout` and the resume prologue re-materializes capture locals from the frame-captured `__self` (without this, capture resolution used stale outer indices — a miscompile).
4. **Closure-context consumer drive** narrowly admitted through the #2646 phase-2 park (self-contained machine, validated); const-held fn-expr producers resolve via the new `ctx.asyncGenProducers` registry by initializer node.
5. **`.next()` runtime dispatch + `.then` native-receiver bridge**: ref.test chain to per-gen `__async_gen_next_*` at both the typed and any-receiver sites; `isStandaloneThenChainNativeActive` widens to standalone only when the module registered the native scheduler; any-typed receivers use the #3035 bridge (wasi: new nullMiss variant — zero-import contract preserved, issue-1326 green).

## Validation

- **Repro→fixed**: `for await (x of g())` standalone was #680 CE → runs host-free (imports=[], correct values); the distilled forbidden-ext driving shape (`f().next().then(cb,done).then(done,done)`) passes on both lanes, wasi zero-import.
- **Measured (runTest262File standalone)**: forbidden-ext decl files 2 (partially-vacuous) → 5 honest passes; **zero per-file regressions** across a 145-file construct-bucketed sweep (before/after jsonl diff).
- **Byte-inertness**: 8-program × {gc, standalone, wasi} sha256 matrix vs main — identical except the intended standalone async-gen cell (CE → host-free).
- **Blast radius**: 137 async/generator/closure unit tests green; the 7 pre-existing failures (2865-AG0 / 2867-gap2 / promise-combinators) reproduce identically on clean main.
- Residuals (all fail→fail vs baseline) + the #2895/#2978 boundary are documented in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS