### PR TITLE
docs(plan): hard-problems architecture audit — Fable specs #3098–#3101, #2956 architect spec, #3031 re-verification

### DIFF
--- a/plan/issues/2956-linear-backend-consumes-ir.md
+++ b/plan/issues/2956-linear-backend-consumes-ir.md
@@ -4,7 +4,7 @@ title: "Linear backend consumes the IR front-end: wire the selector + LinearEmit
 status: ready
 sprint: current
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-09
 priority: medium
 horizon: xl
 feasibility: hard
@@ -61,3 +61,140 @@ Mirror the WasmGC overlay pattern (#2138 shape), not a big-bang port:
   parity.
 - Linear fallback reasons bucketed against a baseline (clone of
   check-ir-fallbacks), so parity progress banks.
+
+## Implementation Plan (fable-arch, 2026-07-09 — the requested architect spec)
+
+> Verified against `origin/main @ 928c85179`. Re-grep symbol anchors before
+> editing (`generateLinearModule`, `compileIrPathFunctions`,
+> `IrLowerResolver`, `LinearEmitter`). #2954 (LinearEmitter core-op
+> coverage) is **done**; #2953 (pushRaw gap) is **in-progress** — slice L2
+> below depends on the refcell/aggregate groups it moves behind the trait,
+> but L0/L1 do not: they can start once #2953's _vec + core_ groups are
+> stable (already true today).
+
+### Current seam, precisely
+
+- **Fork point**: `src/compiler.ts` (`useLinear = options.target ===
+"linear"`, ~line 871) → `generateLinearModule(ast, opts)`
+  (`src/codegen-linear/index.ts:74`). The IR planner never runs on this
+  path.
+- **The WasmGC integration** (`src/ir/integration.ts:131`
+  `compileIrPathFunctions(ctx: CodegenContext, …)`) is hardwired to the
+  WasmGC context: it imports ~20 `src/codegen/*` modules, and its
+  `IrLowerResolver` implementation delegates every `resolve*` hook to the
+  legacy WasmGC registries (`getOrRegisterVecType`, `ensureAnyValueType`,
+  boxing/closure/refcell/class registries), then patches
+  `ctx.mod.functions[localIdx].body` in place.
+- **`IrLowerResolver`** (`src/ir/lower.ts:99-200`) is ALREADY the right
+  abstraction boundary: `lower.ts` reaches the module exclusively through
+  it (+ the `BackendEmitter` for op emission). Nothing in `lower.ts` needs
+  to change for linear — what is missing is (a) a **linear implementation**
+  of the resolver's Phase-1 subset, (b) a **slot/patch surface** on the
+  linear module, and (c) a **capability gate** narrowing claims to what
+  `LinearEmitter` can lower.
+- **`LinearContext`** (`src/codegen-linear/context.ts:7`) already has the
+  pieces the integration needs: `funcMap: Map<string, number>`,
+  `numImportFuncs`, `mod.functions[]` (name-keyed slots registered at
+  `index.ts:100-170`).
+
+### Design decision: ONE integration, TWO context adapters (not a twin)
+
+Do **not** clone `integration.ts` into a linear twin (2.6k lines of
+selection/typeMap/report logic that would drift — the exact #2713 parity
+bug class). Instead split `compileIrPathFunctions` into:
+
+1. **Backend-neutral core** (stays in `integration.ts`): selection
+   consumption, calleeTypes map, per-function `lowerFunctionAstToIr` →
+   verify → passes → `lowerIrFunction`, error/report handling.
+2. **A `IrBackendIntegration` adapter interface** — the context-facing
+   surface the core calls:
+
+```ts
+export interface IrBackendIntegration {
+  /** Backend identity — picks the BackendEmitter + legality profile (#1851). */
+  readonly backend: IrBackendKind; // "wasmgc" | "linear"
+  /** The resolver lower.ts consumes. Linear: Phase-1 subset (below). */
+  readonly resolver: IrFromAstResolver & IrLowerResolver;
+  /** Pre-allocated slot lookup (name → funcIdx); mirrors ctx.funcMap. */
+  lookupFunc(name: string): number | undefined;
+  numImportFuncs(): number;
+  /** Replace the body/locals of a pre-allocated slot (the overwrite step). */
+  patchFunction(localIdx: number, patch: { body: Instr[]; locals: ValType[] }): void;
+  /** Late helper/import registration (linear: runtime.ts helpers; must
+   *  follow the name-based repoint discipline — funcIdx shifts, #2710). */
+  ensureHelper(name: string): number;
+}
+```
+
+The existing WasmGC behavior becomes `WasmGcIntegration` (a thin wrapper
+over today's code — behavior-identical, byte-identical refactor, proven
+by the corpus hash harness `scripts/byte-diff-corpus.mts` from #2138).
+
+3. **`LinearIntegration`** implements the adapter over `LinearContext`:
+   - `resolver`: Phase-1 linear subset — `resolveFunc/resolveGlobal/
+resolveType/internFuncType` over the linear module tables;
+     `resolveString()` returns the linear string rep; **every optional
+     hook (`resolveUnion/Boxed/Object/Closure/RefCell/Class/Vec…`) is
+     initially ABSENT** — per the documented resolver contract, a function
+     whose IR demands a missing hook fails at lowering, and the gate
+     (below) must have rejected it first.
+   - `patchFunction` writes `mod.functions[localIdx]` exactly like the
+     WasmGC patch site (`integration.ts:718` family).
+
+### The linear capability gate (what slice 1 claims)
+
+Reuse two EXISTING mechanisms — do not write a new predicate family
+(#2135's lesson):
+
+- **Per-backend legality verifier (#1851, `src/ir/backend/legality.ts`)**:
+  run the claimed function's IR through the linear legality profile
+  _before_ lowering; any instr outside the profile → structured reject.
+- **Reject reasons bucketed** into a NEW `scripts/linear-ir-baseline.json`
+  ratchet (clone of `check:ir-fallbacks` — acceptance criterion 3), reason
+  = the first illegal instr kind. This measures parity progress per family.
+
+Slice-1 legal set = exactly what `LinearEmitter` implements post-#2954:
+const/binary/unary/locals/globals/drop/select/return/unreachable/
+if/br/br_if/block/loop/direct-call + vec len/get (reads). Everything else
+(vec construction #1804-linear, aggregates, refcells, exceptions,
+call_ref/closures, strings, dynamic/boxed) rejects to the linear direct
+path — which remains the module driver and default.
+
+### Slice map (each independently landable)
+
+| #      | Slice                                                                                                                                                                                                                    | Scope                                                                                                | Gate                                                                                                                                                 |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **L0** | Adapter extraction (`IrBackendIntegration` + `WasmGcIntegration`) — refactor only                                                                                                                                        | `src/ir/integration.ts`; no linear code                                                              | byte-identical corpus hash (2,692-compile harness); full merge_group                                                                                 |
+| **L1** | `LinearIntegration` + overlay wiring in `generateLinearModule` (after slot registration ≈ `index.ts:170`, before body finalization) behind `JS2WASM_LINEAR_IR=1`; legality-gated numeric/CF claims; the ratchet baseline | `codegen-linear/index.ts`, new `src/ir/backend/linear-integration.ts`, `scripts/check-linear-ir.mjs` | flag-off byte-identical; flag-on: cross-backend corpus rows (#1854 harness) flip `expectLinearUnsupported` → executed parity for claimed numeric fns |
+| **L2** | Widen: vec construction (#1804 linear arm), refcells (needs #2953's group), aggregates via `codegen-linear/layout.ts`                                                                                                    | `linear-emitter.ts`, `linear-integration.ts`                                                         | ratchet decreases bank; differential harness rows                                                                                                    |
+| **L3** | Strings (blocked on #2955 de-polymorph — the IR front-end currently builds string-mode-specific IR at 5 from-ast sites; linear must not inherit that fork)                                                               | after #2955                                                                                          | corpus string rows                                                                                                                                   |
+| **L4** | Default-ON for the claimed families + fold the linear direct path's per-function reject list into the same ratchet                                                                                                       | `compiler.ts`                                                                                        | one soak window on main, then flip                                                                                                                   |
+
+**Explicitly deferred (do not promise here):** closures/`call_ref` (linear
+dispatches through a table — needs a table-based `emitCallRef` design),
+exceptions (no linear EH lowering), async/Promise (no linear runtime),
+dynamic/boxed-any (#1852-G4 f64+tag cell is the design seed, but it is a
+value-rep decision that must be made jointly with #2949's dynamic IrType —
+file separately when L2 lands).
+
+### Risks / edge cases
+
+- **funcIdx shifts**: linear registers runtime helpers up-front
+  (`index.ts:100-116`) then user funcs — the overlay must patch
+  pre-allocated slots only, never append (same placeholder discipline as
+  #2138). `ensureHelper` additions before finalize follow the name-based
+  repoint rule (#2710, memory `project_standalone_hostimport_gate_index_shift`).
+- **Two type-numbering passes do not exist on linear** (no hoist pass) —
+  simpler than WasmGC; but `internFuncType` must dedupe against the linear
+  module's type section, not grow it per call.
+- **Multi-module linear** (`generateLinearMultiModule`, second context at
+  `index.ts:235`) — out of scope for L1 (single-module only), mirror later.
+- **The linear backend's own fail-louds** (typeof/await/spread/regex) are
+  UNCHANGED — the IR overlay only ever _adds_ capability; a claim the gate
+  rejects lands exactly where it lands today.
+
+### Effort
+
+XL total; L0+L1 ≈ one senior-dev budget window (Fable for L0's interface
+cut + L1's gate; the LinearIntegration itself is mechanical); L2+ are
+M-sized Opus slices banked by the ratchet.

--- a/plan/issues/3031-dynamic-mop-extensions-spec.md
+++ b/plan/issues/3031-dynamic-mop-extensions-spec.md
@@ -4,7 +4,7 @@ title: "architect spec: dynamic MOP extensions — Proxy trap dispatch, mutable 
 status: ready
 sprint: Backlog
 created: 2026-07-04
-updated: 2026-07-04
+updated: 2026-07-09
 priority: high
 horizon: xl
 feasibility: hard
@@ -32,7 +32,7 @@ The #2175 spec (merged PR #2616) defines the **static** MOP substrate:
 `$NativeProto` (one shared heap type, brand-discriminated), the
 `BUILTIN_BRAND_TABLE`, the brand-keyed native-method-closure factory
 (`ensureStandaloneNativeMethodClosure`), and the brand-recovery prologue.
-Contracts C1–C3 there cover *reading* prototype objects and *dispatching*
+Contracts C1–C3 there cover _reading_ prototype objects and _dispatching_
 members on dynamic receivers when the chain is the **default, immutable**
 one.
 
@@ -42,7 +42,7 @@ and mutable**:
 1. **Proxy** — user-defined internal methods (§10.5), both lanes.
 2. **Dynamic prototype chains** — mutable `[[Prototype]]`
    (`Object.setPrototypeOf`, `__proto__`, `Object.create(p|null)`),
-   with mutation *visibility* in subsequent lookups.
+   with mutation _visibility_ in subsequent lookups.
 3. **`with`** — the scope-object form of the same ladder
    (HasBinding/Get/Set are literally MOP operations, §9.1.1.2).
 
@@ -61,14 +61,14 @@ getOwnPropertyDescriptor / defineProperty / getPrototypeOf /
 setPrototypeOf / apply / construct / with-HasBinding) classifies its
 receiver in this order:
 
-| # | Test | Route |
-|---|------|-------|
-| 1 | `ref.test $Proxy` | trap dispatch (`__proxy_*_dispatch`) — **always first**; a Proxy must intercept everything, including chain walks and `with` bindings |
-| 2 | `ref.test $Object` | own `$PropEntry` props → miss → chain walk via `$proto` (field 0), §0.2 |
-| 3 | `ref.test $NativeProto` | brand → #2175 member-closure table → miss → `$parent` chain walk |
-| 4 | closed WasmGC struct (typed user object) | shape-table reader (the #3027 substrate direction; until it lands, refusal/fallthrough per current behavior) |
-| 5 | host externref (js-host lane only) | host-import boundary (`__extern_*`) — the host runs its own MOP incl. host Proxies |
-| 6 | primitive box | wrapper-prototype route per #2175 |
+| #   | Test                                     | Route                                                                                                                                 |
+| --- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `ref.test $Proxy`                        | trap dispatch (`__proxy_*_dispatch`) — **always first**; a Proxy must intercept everything, including chain walks and `with` bindings |
+| 2   | `ref.test $Object`                       | own `$PropEntry` props → miss → chain walk via `$proto` (field 0), §0.2                                                               |
+| 3   | `ref.test $NativeProto`                  | brand → #2175 member-closure table → miss → `$parent` chain walk                                                                      |
+| 4   | closed WasmGC struct (typed user object) | shape-table reader (the #3027 substrate direction; until it lands, refusal/fallthrough per current behavior)                          |
+| 5   | host externref (js-host lane only)       | host-import boundary (`__extern_*`) — the host runs its own MOP incl. host Proxies                                                    |
+| 6   | primitive box                            | wrapper-prototype route per #2175                                                                                                     |
 
 **Mechanism ruling:** the existing **front-guard pattern** — `ref.test
 $Proxy` prepended to the shared native helpers (`__extern_get/set/has`,
@@ -120,8 +120,8 @@ relevant chain. Ruling (compile-away philosophy — pay only when used):
     the key is a literal; whole-brand otherwise).
   - `Object.setPrototypeOf(x, …)` / `x.__proto__ = …` where `x`'s static
     type maps to a brand → that brand dirty; receiver un-typeable → `"all"`.
-- A **dirty** `(brand, member)` demotes the static fast path *for that
-  member* to a `__chain_lookup` dynamic read. Clean programs (the
+- A **dirty** `(brand, member)` demotes the static fast path _for that
+  member_ to a `__chain_lookup` dynamic read. Clean programs (the
   overwhelming majority) stay **byte-identical** — this is the same S0
   acceptance discipline as #2175.
 - `Proxy` never enters the static path at all: a `new Proxy(...)` value has
@@ -136,10 +136,10 @@ relevant chain. Ruling (compile-away philosophy — pay only when used):
 
 ### 1.1 Current state (verified against upstream/main `8e8eb9832`, 2026-07-04)
 
-| Lane | Done | Missing |
-|------|------|---------|
+| Lane       | Done                                                                                                                                                                                                        | Missing                                                                                                                                                                                                                                                                                           |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | standalone | `$Proxy`/`$ProxyTraps` (12 fields) + dispatch for get/set/has/apply-base, deleteProperty, gOPD, getPrototypeOf, setPrototypeOf, isExtensible, preventExtensions, ownKeys, defineProperty (#1100, #1355 A–F) | **construct** trap; **revocable** synthesis; **Reflect.\*** wiring (setPrototypeOf/defineProperty/construct/getPrototypeOf/apply/isExtensible/preventExtensions CE before any trap runs); **§10.5 result-invariants** (slice G); present-but-non-callable-trap TypeError; trap-abrupt propagation |
-| host (gc) | #2615 (externref slot type), #2616 (non-callable trap TypeError), #2617 (boundary propagation), #2618 Slice 1 (lazy bridge + callable-target wrap, PR #1984) | apply rows (`p.call(a,b)`, `p(args)` with struct-typed trap params) + construct rows — **all bottlenecked on one keystone**, K1 below |
+| host (gc)  | #2615 (externref slot type), #2616 (non-callable trap TypeError), #2617 (boundary propagation), #2618 Slice 1 (lazy bridge + callable-target wrap, PR #1984)                                                | apply rows (`p.call(a,b)`, `p(args)` with struct-typed trap params) + construct rows — **all bottlenecked on one keystone**, K1 below                                                                                                                                                             |
 
 **Stale-doc note:** `built-ins/Proxy` is **already run** by the test262
 harness (`TEST_CATEGORIES`, `tests/test262-runner.ts:2753`; blanket skip
@@ -281,13 +281,13 @@ Because §0.1 front-guards live in the shared helpers:
 
 ### 2.1 Representation ruling — where the mutable slot lives **[FABLE]**
 
-| Value kind | [[Prototype]] slot | Mutable? |
-|---|---|---|
-| dynamic object (`$Object`) | `$proto` (field 0, already `mut`) | yes — `__object_setPrototypeOf` writes it (exists, round-trips host-free; verified in #3013) |
-| builtin/class prototype object (`$NativeProto`) | `$parent` (already `mut externref`) | yes — `Object.setPrototypeOf(RegExp.prototype, x)` is legal (§10.1.2); setPrototypeOf on a `$NativeProto` receiver writes `$parent` **and marks the brand dirty** (§0.3) |
-| closed WasmGC struct instance | none — its [[Prototype]] is its class's `__proto_<Name>` singleton, *by representation* | **not directly.** Ruling below |
-| `Proxy` | via `getPrototypeOf`/`setPrototypeOf` traps | trap-governed |
-| host externref (gc lane) | host object | host-governed |
+| Value kind                                      | [[Prototype]] slot                                                                      | Mutable?                                                                                                                                                                 |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| dynamic object (`$Object`)                      | `$proto` (field 0, already `mut`)                                                       | yes — `__object_setPrototypeOf` writes it (exists, round-trips host-free; verified in #3013)                                                                             |
+| builtin/class prototype object (`$NativeProto`) | `$parent` (already `mut externref`)                                                     | yes — `Object.setPrototypeOf(RegExp.prototype, x)` is legal (§10.1.2); setPrototypeOf on a `$NativeProto` receiver writes `$parent` **and marks the brand dirty** (§0.3) |
+| closed WasmGC struct instance                   | none — its [[Prototype]] is its class's `__proto_<Name>` singleton, _by representation_ | **not directly.** Ruling below                                                                                                                                           |
+| `Proxy`                                         | via `getPrototypeOf`/`setPrototypeOf` traps                                             | trap-governed                                                                                                                                                            |
+| host externref (gc lane)                        | host object                                                                             | host-governed                                                                                                                                                            |
 
 **Closed-struct ruling:** a closed struct has no proto slot; full per-object
 mutability requires the object to be **represented dynamically**. The
@@ -300,7 +300,7 @@ hack here. Sequencing: until #2949's demotion exists, `setPrototypeOf` on a
 provably-closed-struct receiver keeps current behavior (host lane: works —
 host object; standalone: routes to `__object_setPrototypeOf`, which
 requires `$Object` and misses). This spec defines the **target contract**;
-the closed-struct arm is marked *sequenced-behind-#2949*, not a slice here.
+the closed-struct arm is marked _sequenced-behind-#2949_, not a slice here.
 
 **Identity (#2585):** the chain representation is identity-correct —
 `$proto` holds the same GC ref, `__getPrototypeOf` returns it. What loses
@@ -365,7 +365,7 @@ host):
 - **Mutation visibility** — no caching layer exists on the dynamic read
   path today, and §0.2 keeps it that way: every dynamic lookup re-walks
   from the receiver, so `setPrototypeOf` is visible on the next lookup by
-  construction. The only visibility hazard is the *static* fast path,
+  construction. The only visibility hazard is the _static_ fast path,
   handled by §0.3's dirty demotion.
 
 ---
@@ -402,11 +402,11 @@ host):
    `compileWithStatement` / `compileClosedObjectLiteralTarget`. Bounded,
    no substrate dependency, ~55 files.
 2. **Substrate [owned by #3027, NOT here]: teach the dynamic reader to see
-   closed-struct fields.** The Tier-2 gap is *exactly* #3027's
+   closed-struct fields.** The Tier-2 gap is _exactly_ #3027's
    `$Object`-dynamic-reader gap (and #2580's family). Ruling: **no
    with-local struct-reflection hack** — when the #3027 shape-table reader
    lands, Tier-2 inherits it for free because it already routes through
-   `__extern_has`/the dynamic getter. `with` is a *consumer* of that
+   `__extern_has`/the dynamic getter. `with` is a _consumer_ of that
    substrate, never a second implementation.
 
 **Which wins at a given site:** Tier-1 whenever provable (faster,
@@ -427,7 +427,7 @@ soundness bug; a fall-through is only a perf/coverage loss.
   statically skip the check when no symbol-keyed member exists — document
   that proof).
 - Abrupt completions from the `has`/`get` steps (`unscopables-prop-get-err
-  .js`, `has-property-err.js`) must **propagate**, not be swallowed into
+.js`, `has-property-err.js`) must **propagate**, not be swallowed into
   the miss arm — audit `emitDynamicWithGet`'s fallback select for a
   catch-all that eats throws.
 
@@ -454,7 +454,7 @@ the **compile path already handles most of the `with` lane**. Ruling:
   compile-path counterpart). The @@unscopables filter (§3.3) lives in that
   shared surface so both consumers inherit it.
 - **IR note:** `with` stays in the IR `deferred-feature` bucket for the IR
-  *front-end* (the direct-AST path owns it) — the bucket exit #2929
+  _front-end_ (the direct-AST path owns it) — the bucket exit #2929
   mentions applies to interpreted code, not to a claim over compiled
   `with`. If the peer's interpreter spec rules otherwise, reconcile before
   either implements: one owner per execution context, one MOP surface.
@@ -463,23 +463,23 @@ the **compile path already handles most of the `with` lane**. Ruling:
 
 ## Slice table (dispatchable units, tier + sequencing)
 
-| Slice | Tier | Depends on | Files (primary) | Gate |
-|---|---|---|---|---|
-| **K1** inbound arg-marshalling keystone (2623-A) | FABLE | check #56 state first | `src/codegen/index.ts` (buildArgConversion, externToClosureParamRef), `src/runtime.ts` | full merge_group; host `Proxy/{apply,construct}` rows; hot-callback no-regression |
-| K1b host construct guard + constructable-forwarder (prototyped in #2618) | OPUS | K1 | `new-super.ts`, `calls.ts`, `runtime.ts` | host `construct/*` non-realm |
-| **K2** standalone `__construct_dispatch` + construct trap | FABLE | — (composes with K1 conceptually, independent code) | `object-runtime.ts`, `new-super.ts` | standalone `Proxy/construct/*`; `apply/*` via TRAP_APPLY |
-| P3 `Proxy.revocable` standalone (S0) | OPUS | — | `object-runtime.ts`, `calls.ts` | `revocable/**` (~14 CEs) |
-| P4 standalone `Reflect.*` wiring (S1) | OPUS | K2 for `Reflect.construct`; else — | `calls.ts` | `built-ins/Reflect` standalone CE bucket |
-| P5 §10.5 invariants + descriptor bits (G) | FABLE (bit-model ruling w/ #1460/#1462 owner) + OPUS (predicates) | #797/#1460/#1462 coordination | `object-runtime.ts`, `registry/proxy.ts` | `Proxy/**` invariant rows |
-| **C1** `__chain_lookup` walker + refactor for-in/`in`/getPrototypeOf onto it | FABLE (contract) / OPUS (refactor) | — | `object-runtime.ts` | miss-through-chain, null-proto, Proxy-in-chain equivalence tests |
-| C2 per-brand MOP-dirty demotion (§0.3) | FABLE | C1, #2175 S1 | `property-access.ts`, `native-proto.ts` | builtin-proto-member-overwrite tests; clean programs byte-identical |
-| C3 distinct native proto per externref subclass (#3013-B) | OPUS (design ratified in §2.2) | #2175 S1; C1 helpful | `class-bodies.ts`, `array-object-proto.ts` pattern | `regular-subclassing.js` + `__new_Object` cluster host-free; subclass-of-builtin matrix |
-| C4 `__proto__` literal/read/write + `Object.create(null)` termination | OPUS | C1 | `property-access.ts`, `object-runtime.ts`, `expressions.ts` | annexB `__proto__` + `Object/create` rows |
-| **W1** Tier-1 `with` over closed-struct targets | OPUS | — | `with-scope.ts` | ~55-file struct-target bucket in `language/statements/with`; soundness fall-throughs |
-| W2 @@unscopables + abrupt propagation in shared HasBinding | OPUS | — | `with-scope.ts`, `object-runtime.ts` | `unscopables-*`, `has-property-err.js` |
-| W3 `with (proxy)` verification (should be free) | OPUS | K2/P-slices as they land | tests only | `*-using-with.js` twins |
-| — closed-struct setPrototypeOf demotion | (sequenced behind **#2949**; not a slice here) | #2949/#2580 | — | — |
-| — tag-5 identity | (owned by **#2626**; do not touch) | value-rep substrate | — | — |
+| Slice                                                                        | Tier                                                              | Depends on                                          | Files (primary)                                                                        | Gate                                                                                    |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **K1** inbound arg-marshalling keystone (2623-A)                             | FABLE                                                             | check #56 state first                               | `src/codegen/index.ts` (buildArgConversion, externToClosureParamRef), `src/runtime.ts` | full merge_group; host `Proxy/{apply,construct}` rows; hot-callback no-regression       |
+| K1b host construct guard + constructable-forwarder (prototyped in #2618)     | OPUS                                                              | K1                                                  | `new-super.ts`, `calls.ts`, `runtime.ts`                                               | host `construct/*` non-realm                                                            |
+| **K2** standalone `__construct_dispatch` + construct trap                    | FABLE                                                             | — (composes with K1 conceptually, independent code) | `object-runtime.ts`, `new-super.ts`                                                    | standalone `Proxy/construct/*`; `apply/*` via TRAP_APPLY                                |
+| P3 `Proxy.revocable` standalone (S0)                                         | OPUS                                                              | —                                                   | `object-runtime.ts`, `calls.ts`                                                        | `revocable/**` (~14 CEs)                                                                |
+| P4 standalone `Reflect.*` wiring (S1)                                        | OPUS                                                              | K2 for `Reflect.construct`; else —                  | `calls.ts`                                                                             | `built-ins/Reflect` standalone CE bucket                                                |
+| P5 §10.5 invariants + descriptor bits (G)                                    | FABLE (bit-model ruling w/ #1460/#1462 owner) + OPUS (predicates) | #797/#1460/#1462 coordination                       | `object-runtime.ts`, `registry/proxy.ts`                                               | `Proxy/**` invariant rows                                                               |
+| **C1** `__chain_lookup` walker + refactor for-in/`in`/getPrototypeOf onto it | FABLE (contract) / OPUS (refactor)                                | —                                                   | `object-runtime.ts`                                                                    | miss-through-chain, null-proto, Proxy-in-chain equivalence tests                        |
+| C2 per-brand MOP-dirty demotion (§0.3)                                       | FABLE                                                             | C1, #2175 S1                                        | `property-access.ts`, `native-proto.ts`                                                | builtin-proto-member-overwrite tests; clean programs byte-identical                     |
+| C3 distinct native proto per externref subclass (#3013-B)                    | OPUS (design ratified in §2.2)                                    | #2175 S1; C1 helpful                                | `class-bodies.ts`, `array-object-proto.ts` pattern                                     | `regular-subclassing.js` + `__new_Object` cluster host-free; subclass-of-builtin matrix |
+| C4 `__proto__` literal/read/write + `Object.create(null)` termination        | OPUS                                                              | C1                                                  | `property-access.ts`, `object-runtime.ts`, `expressions.ts`                            | annexB `__proto__` + `Object/create` rows                                               |
+| **W1** Tier-1 `with` over closed-struct targets                              | OPUS                                                              | —                                                   | `with-scope.ts`                                                                        | ~55-file struct-target bucket in `language/statements/with`; soundness fall-throughs    |
+| W2 @@unscopables + abrupt propagation in shared HasBinding                   | OPUS                                                              | —                                                   | `with-scope.ts`, `object-runtime.ts`                                                   | `unscopables-*`, `has-property-err.js`                                                  |
+| W3 `with (proxy)` verification (should be free)                              | OPUS                                                              | K2/P-slices as they land                            | tests only                                                                             | `*-using-with.js` twins                                                                 |
+| — closed-struct setPrototypeOf demotion                                      | (sequenced behind **#2949**; not a slice here)                    | #2949/#2580                                         | —                                                                                      | —                                                                                       |
+| — tag-5 identity                                                             | (owned by **#2626**; do not touch)                                | value-rep substrate                                 | —                                                                                      | —                                                                                       |
 
 **Suggested order:** K1 → K1b (host Proxy lane closes) ∥ W1+W2 (independent,
 bounded) ∥ C1 → {C3, C4, K2} → P3/P4 → C2 → P5. K1 and C1 are the two
@@ -501,3 +501,28 @@ schedule-critical Fable slices; everything else fans out.
 - The host lane gets §10.5 invariants free from the engine; every
   standalone invariant slice must be `ctx.standalone`-gated so gc stays
   byte-inert (the #1355 slice-F pattern).
+
+## Re-verification (fable-arch, 2026-07-09 @ origin/main 928c85179)
+
+State advances since this spec was written — re-ground before dispatching:
+
+1. **P5's descriptor-bit dependency is SATISFIED.** `$PropEntry.$flags`
+   (writable/enumerable/configurable bits + internal-slot marker) exists
+   (`object-runtime.ts:90`), and native defineProperty already enforces the
+   non-configurable redefine TypeErrors (`object-runtime.ts:4988-5035`).
+   The §10.5 result-invariant predicates (P5) are now executable without
+   waiting on #797/#1460/#1462 — coordinate only with #2042's in-progress
+   descriptor work.
+2. **NEW GATE ahead of every P-slice: #3099.** Probe-verified: standalone
+   Proxy traps written in **method-shorthand** style (`{ get(t,k){…} }`,
+   test262's dominant shape) silently forward — the any-context object
+   literal never materializes shorthand methods as runtime own properties
+   on `$Object`, so `__proxy_create`'s trap read misses. Arrow-property
+   handlers fire correctly. Land #3099 FIRST, then re-measure standalone
+   Proxy before scoping K2/P3/P4/P5 — current standalone Proxy numbers
+   understate the substrate.
+3. Confirmed still open: `$ProxyTraps` has 12 fields, no `construct` (K2);
+   `Proxy.revocable` standalone is a CE (P3); `Reflect.construct`/
+   `Reflect.getPrototypeOf`-on-proxy standalone CE/trap (P4). K1's locus
+   (inbound arg-marshalling) is adjacent to the in-flight #3087 (dynamic
+   `new` on the gc lane) — claim-check #3087's branch before starting K1.

--- a/plan/issues/3098-standalone-native-callback-dispatch-retire-make-callback.md
+++ b/plan/issues/3098-standalone-native-callback-dispatch-retire-make-callback.md
@@ -1,0 +1,187 @@
+---
+id: 3098
+title: "Standalone native callback-dispatch substrate: retire `env.__make_callback` on the dynamic-receiver lane (top-3 host-import leak root)"
+status: ready
+sprint: Backlog
+model: fable
+created: 2026-07-09
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, standalone
+language_feature: callbacks, higher-order-functions, dynamic-dispatch
+goal: standalone-mode
+umbrella: 2860
+related: [2939, 3074, 3083, 3015, 3016, 2151, 2864, 2928, 3058, 1382]
+origin: "2026-07-09 fable-arch hard-problems audit (domain 1/3) — __make_callback is the #2 leaked host import by file count (7,519 files in the 2026-06-26 standalone JSONL) and the E5/G3 prerequisite of the #2928 interpreter"
+---
+
+# #3098 — retire `env.__make_callback`: native callback dispatch for dynamic receivers
+
+## Problem (verified against origin/main @ 928c85179, 2026-07-09)
+
+A callback passed to a method on a **dynamic (`any`/externref) receiver** is
+routed through the `env.__make_callback` host bridge instead of the native
+closure-struct dispatch. Standalone (no host), the import leaks and the module
+either fails the honest host-free metric or traps.
+
+Probe (this audit, `compileSource(..., { target: "standalone", nativeStrings: true })`):
+
+```ts
+// typed receiver — NATIVE, host-free, correct:
+const a: number[] = [1, 2, 3];
+a.map((x: number) => x * 2)[2]; // = 6, no env imports
+
+// any receiver — HOST BRIDGE, leaks + traps standalone:
+const a: any = [1, 2, 3];
+a.map((x: any) => x * 2)[2]; // TRAP, LEAK: __make_callback
+const a: any = [1, 2, 3];
+a.filter((x: any) => x > 1).length; // wrong (0), LEAK: __make_callback
+```
+
+Scale: `env.__make_callback` is the **#2 leaked import by file count** in the
+last full standalone JSONL (7,519 files @ 2026-06-26, behind only
+`__get_caught_exception`, whose #2962 fix has since landed). It appears in the
+top-10 of every leak class (`iterator_protocol` 3,486, `dynamic_object_property`
+622, `dynamic_code` 248). The number needs re-measuring on a fresh standalone
+run, but the per-shape probe above proves the emission path is live today.
+
+## Why this is a substrate root, not a per-method bug
+
+`__make_callback(cbId, capsExternref) -> jsFunction` is the host-side
+factory: the runtime looks up `exports.__cb_<id>` **by export name** and
+returns a JS function wrapping it. Three consumer families emit it:
+
+1. **Dynamic-receiver array/TypedArray HOFs** — `map`/`filter`/`forEach`/
+   `reduce`/`reduceRight`/`find*`/`every`/`some`/`sort(cmp)` when the receiver
+   is externref/`any` (the typed-receiver arms are already native). See the
+   BANKED list in `src/codegen/array-methods.ts:2876` (#3058 dyn-view bucket)
+   and `src/codegen/closures.ts:1225`.
+2. **Async CPS step adapters** — `src/codegen/async-cps.ts:395-525`,
+   `src/codegen/async-frame.ts:95-140` (`__cb_<id>` continuation wrappers,
+   settle via `Promise_then2`). These retire with the #2864/#2867/#1042
+   carrier convergence, NOT here — but the ABI decision below must not
+   conflict with the `$AsyncFrame` step-adapter shape.
+3. **Host-API callback args** (`addEventListener`, host `Promise_then2`,
+   `JSON.stringify` replacer, …) — legitimately host-lane; stays.
+
+This issue owns family 1 (and the generic "callback crossing a dynamic
+dispatch boundary" mechanism); family 2 is the async carriers' job; family 3
+is out of scope (host-lane by definition).
+
+**The standalone-native ingredients already exist** — this is wiring, not
+invention:
+
+- Every compiled function expression/arrow already lowers to a **GC closure
+  struct** (wrapper struct + funcref + captures) — the same value the Proxy
+  trap dispatch invokes via `__apply_closure` (`object-runtime.ts`, #1100).
+- `__apply_closure(closure, thisArg, argsVec) -> externref` exists standalone
+  and is the ratified "reuse the closure→funcref bridge, don't invent a
+  calling convention" mechanism (#1355 slices A–F all use it).
+- The gc-lane twin of this bug was #2939/#3074 (closure candidate
+  registration de-gated to both lanes, PR #2790 lineage): callbacks held in
+  `any` containers now REGISTER; what standalone lacks is the **dispatch**
+  arm that invokes them natively at a dynamic call boundary.
+- #3016 (done) proved the pattern for `Function.prototype.call/apply`:
+  route a func-expr VALUE to the closure struct, not `__make_callback`.
+  #3015 (ready, low) is the same pattern for one predicate-method site.
+
+## Design — one native dispatch arm at the callback-consuming boundary
+
+### Invariant
+
+> A callback value that is a **compiled closure** (its runtime rep passes
+> `ref.test` against the closure-wrapper family) is invoked natively via
+> `__apply_closure` — on every lane, at every dynamic dispatch boundary.
+> Only a callback value that is a **genuine host function** (host-lane
+> externref that is not a GC closure) routes to the host bridge; standalone,
+> that residual arm is a catchable TypeError, never a silent no-op.
+
+### Mechanism (mirror of the Proxy trap dispatch)
+
+At each dynamic-receiver HOF lowering site that currently calls
+`__make_callback`:
+
+1. Compile the callback arg to its uniform externref rep (already done — the
+   closure struct crosses as `extern.convert_any(closureStruct)`).
+2. Replace the `__make_callback` call with a **`__invoke_cb_n(cb, this, a0..an) ->
+externref`** family of native helpers (n = 1..4, arity-tolerant per the
+   #2939 lesson: pass what the loop has; `__apply_closure` already handles
+   the arity/coercion at the boundary; over-arity must NOT void-skip — that
+   is the #1837/#3088 vacuity trap):
+   - `any.convert_extern(cb)`, `ref.test` closure-wrapper → `__apply_closure`
+     with a native argsVec.
+   - else host lane → the existing host-callable invoke (`__call_1_f64`
+     family / host `Function.call`) — byte-preserving for host callbacks.
+   - else standalone → throw catchable `TypeError: not a function` (reuse the
+     WASI error-ctor + exn tag pattern, `object-runtime.ts:7293`).
+3. The element loop itself must be native for the dynamic receiver: reuse the
+   receiver-classification ladder (#3031 Part 0) — `ref.test $Object` /
+   vec-struct / `$ObjVec` arms read elements natively; the host-externref arm
+   stays host-lane. #2151's any-receiver dispatch slices already classify the
+   receiver at these sites; this issue adds the CALLBACK arm to the loops
+   those slices select.
+
+### Result-rep
+
+`__apply_closure` returns externref. Each HOF coerces per its contract:
+`filter`/`every`/`some`/`find*` via `__is_truthy` (i32); `map` stores the
+externref result into the output vec's element rep (boxed-any element per
+#2379 — do NOT unbox to f64, heterogeneous results are legal); `reduce`
+threads the externref accumulator unchanged.
+
+## Slices (each independently landable, merge_group-gated)
+
+| #   | Slice                                                                                                                                                          | Scope                                                                                               |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| S1  | `__invoke_cb_n` helper family + the classifier arm (no call-site changes; byte-inert)                                                                          | `object-runtime.ts` (beside `__apply_closure`), reserve-then-fill per #1719; unit repros in `.tmp/` |
+| S2  | Dynamic-receiver `map`/`filter`/`forEach` flip to S1                                                                                                           | `array-methods.ts` dynamic arms; the probe cases above flip pass + host-free                        |
+| S3  | `reduce`/`reduceRight`/`find`/`findIndex`/`findLast*`/`every`/`some`                                                                                           | same mechanism, more sites; includes the #3058 BANKED TypedArray dyn-view callback methods          |
+| S4  | `sort(cmp)` (comparator ABI: 2 args, f64-able result) + `Array.from(x, mapFn)`                                                                                 | `array-methods.ts`                                                                                  |
+| S5  | Audit sweep: grep remaining `__make_callback` emission sites outside async (`closures.ts:1225-1306` guidance comment), route or defer each with a named reason | telemetry: standalone JSONL `__make_callback` count → the async-only residual                       |
+
+**Sequencing / non-collision:** #2864/#2867 own the async `__cb_<id>` uses —
+do not touch `async-cps.ts`/`async-frame.ts` here. #3087 (dynamic `new` on
+gc lane) is adjacent but disjoint (construct, not call). #2151/#3053 own the
+receiver classification — S2+ consume, never re-implement. Check #3015's
+one-site slice before S3 (fold or supersede it explicitly).
+
+## Edge cases
+
+- **Arity tolerance** (#2939 keystone lesson): a 1-param callback invoked by
+  a 3-arg loop (`value, index, array`) must receive value and ignore extras;
+  a 3-param callback must receive all three (the #3088 lesson: never
+  void-skip on over-arity — that produces vacuous passes).
+- **`this` arg** (`map(cb, thisArg)`): thread as `__apply_closure`'s thisArg;
+  absent → undefined singleton.
+- **Callback mutates the array during iteration**: match the per-method spec
+  (ES2025 §23.1.3.18 etc. — length snapshot for `map`/`forEach`, live reads);
+  the native loop must read length ONCE where the spec says HowMany is fixed.
+- **Sparse/holey receivers**: holes skip per spec on the `$Object`-backed
+  array arm (reuse the `$Hole` mapping, not a fabricated `undefined` call).
+- **Non-callable callback**: TypeError BEFORE the loop (§23.1.3.18 step 3),
+  catchable, both lanes.
+- **A host function stored into an `any` var, standalone**: impossible by
+  construction (no host) — the TypeError arm is correct.
+
+## Acceptance criteria
+
+1. The three probe programs above run correct + host-free standalone
+   (`a.map` → 6 with `a: any`; `filter` → 2; plus `forEach`/`reduce`
+   equivalents), and identically on the gc lane.
+2. Fresh standalone JSONL: `__make_callback` leak count drops to the
+   async-carrier residual only (measure before/after; the 2026-06-26 count
+   was 7,519 files).
+3. No gc-lane regression on the hot typed-receiver HOF paths (byte-identical
+   WAT for a typed `a.map` — the new arm is gated on the dynamic receiver
+   classification).
+4. Full merge_group + standalone floor (broad-impact: touches the HOF family
+   — never a scoped sweep).
+
+## Effort estimate
+
+L (5 slices, each S–M; S1+S2 together are the keystone ~1 senior-dev budget
+window; S3–S5 are mechanical from the S2 template). Fable for S1/S2 (ABI +
+classifier design), Opus-executable for S3–S5.

--- a/plan/issues/3099-object-literal-method-shorthand-runtime-own-property.md
+++ b/plan/issues/3099-object-literal-method-shorthand-runtime-own-property.md
@@ -1,0 +1,152 @@
+---
+id: 3099
+title: "any-context object-literal METHOD-SHORTHAND props are compile-time-only — never materialized as runtime own properties on `$Object` (silently drops every shorthand Proxy trap, iterator `next()`, Object.keys entry)"
+status: ready
+sprint: Backlog
+model: opus
+created: 2026-07-09
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen, standalone
+language_feature: object-literals, proxy, iterators
+goal: standalone-mode
+related: [1355, 3031, 1100, 2358, 3023, 2964]
+origin: "2026-07-09 fable-arch hard-problems audit (domain 4) — root-caused why standalone Proxy traps written in test262's dominant method-shorthand style silently forward to the target while arrow-property handlers fire"
+---
+
+# #3099 — method-shorthand props missing from the runtime `$Object`
+
+## Problem (verified against origin/main @ 928c85179, 2026-07-09)
+
+An object literal compiled on the **any-context `$Object` route** stores
+`PropertyAssignment` props (including arrow-function values) as runtime own
+properties via `__extern_set`, but **skips `MethodDeclaration` (method
+shorthand) props entirely**. The skip is documented in the code:
+
+> `src/codegen/literals.ts:322-326` (`compileObjectLiteralAsExternref`):
+> "MethodDeclaration is not reached here for the any-context route — object
+> literals with methods take compileObjectLiteralWithAccessors (accessors) or
+> emitObjectMethodAsClosure on the struct path. A plain method in an
+> any-context literal falls through (skipped) — covered by S2 follow-on."
+
+**That "S2 follow-on" is tracked nowhere** (grep of `plan/issues/` finds no
+owner). This issue is that follow-on.
+
+Probes (standalone, `nativeStrings`):
+
+```ts
+const h: any = {
+  m() {
+    return 3;
+  },
+};
+h.m(); // 3   — static access-site resolution works
+const f: any = h.m;
+f(); // 3   — static
+const k: any = "m";
+h[k]; // undefined — RUNTIME read misses
+Object.keys(h).length; // 0   — not an own property at runtime
+// arrow-property control:
+const h2: any = { m: () => 3 };
+const k2: any = "m";
+h2[k2](); // 3 — arrow props ARE materialized
+```
+
+## Highest-leverage consequence: standalone Proxy traps silently no-op
+
+`__proxy_create` (#1100) reads traps **at runtime** off the handler `$Object`
+(`__extern_get(handler, "get")`, …). test262 writes handlers almost
+exclusively in method-shorthand style — so the trap read misses and every
+dispatch silently forwards to the target:
+
+```ts
+new Proxy(
+  { a: 1 },
+  {
+    get(t, k) {
+      return 42;
+    },
+  },
+).a; // 1 (trap DROPPED)  ✗
+new Proxy({ a: 1 }, { get: (t, k) => 42 }).a; // 42 (trap fires)   ✓
+new Proxy(
+  {},
+  {
+    has(t, k) {
+      return true;
+    },
+  },
+); // "z" in p → false  ✗
+new Proxy({}, { has: (t, k) => true }); // "z" in p → true   ✓
+```
+
+The entire #1100/#1355 trap-dispatch substrate (12 wired traps) is therefore
+**dark for the dominant test262 handler shape**. This single bug caps
+standalone `built-ins/Proxy` regardless of how many traps are wired, and it
+also hides shorthand-defined iterator protocols (`{ next() {…} }`,
+`return()`/`throw()` on manual iterators), shorthand members in `with`
+targets, spread/`Object.assign` copies, and for-in/`Object.keys` enumeration
+of method-bearing literals.
+
+## Root cause
+
+Two divergent lowerings of the same literal:
+
+- **Struct path / accessor path**: methods become closures
+  (`emitObjectMethodAsClosure`, `literals.ts:640+` has a full
+  MethodDeclaration arm that compiles the method as a callback closure and
+  `__extern_set`s it, incl. well-known-Symbol computed names, #1433/#1695).
+- **Any-context `$Object` route** (`compileObjectLiteralAsExternref`,
+  `literals.ts:205+`): iterates props, handles `PropertyAssignment` +
+  accessors, and **falls through on MethodDeclaration** — the method exists
+  only in the compiler's static member-resolution tables, never in the
+  runtime `$PropMap`.
+
+Static call/value sites resolve through the compile-time table (why `h.m()`
+works); every runtime-keyed consumer (`__extern_get`, `Object.keys`,
+`__proxy_create`, spread, for-in) sees a hole.
+
+## Fix
+
+In `compileObjectLiteralAsExternref`, add the MethodDeclaration arm by
+**reusing the existing closure-materialization used at `literals.ts:640+`**
+(same helper, same `__extern_set` store, same well-known-Symbol handling via
+`__box_symbol` for `[Symbol.iterator]() {}`-style names). Do not invent a
+second lowering. Key requirements:
+
+1. The stored value must be the SAME closure value the static access-site
+   path resolves to (one closure per literal-evaluation, not per read) —
+   otherwise `h.m === h.m` across a runtime and a static read diverges
+   (identity: coordinate with #2963/#3037; storing the closure once at
+   literal construction satisfies it).
+2. Generator/async shorthand methods (`*gen() {}`, `async m() {}`) follow
+   whatever the arrow-property lowering does for generator/async function
+   expressions today; if unsupported, keep the current behavior for those
+   two shapes and note it — do NOT block the plain-method fix on them.
+3. `get`/`set` accessors are already handled (probe passes) — untouched.
+4. gc/host lane: verify the host-lane any-context literal already stores
+   shorthand methods (host object literal) — the fix is likely
+   standalone-visible only, but apply it lane-agnostically at the `$Object`
+   route so both stay symmetric.
+
+## Acceptance criteria
+
+1. All four probe divergences above flip (`h[k]` → callable, `Object.keys`
+   → 1, both Proxy shorthand handlers fire).
+2. `built-ins/Proxy` standalone: measurable pass-rate jump with ZERO trap
+   changes (re-run the #1355 acceptance files — `get/return-trap-result.js`
+   class).
+3. A shorthand `{ next() {...} }` manual iterator drives `for-of` standalone.
+4. Full merge_group + standalone floor green (object-literal lowering is
+   broad-impact).
+
+## Effort estimate
+
+M, Opus-executable (the arm to copy exists 300 lines below the skip site).
+Filed from the Fable audit because it is the **highest-leverage single fix in
+the Proxy domain** — land it BEFORE any further trap/invariant work (#3031
+P3–P5, K2), then re-measure the standalone Proxy baseline so those slices
+are scoped against honest numbers.

--- a/plan/issues/3100-standalone-dynamic-iterable-getiterator-dispatch.md
+++ b/plan/issues/3100-standalone-dynamic-iterable-getiterator-dispatch.md
@@ -1,0 +1,154 @@
+---
+id: 3100
+title: "Standalone dynamic-iterable substrate: native GetIterator/IteratorStep dispatch for externref/any iterables (for-of over `Object.keys(any)` traps illegal_cast today)"
+status: ready
+sprint: Backlog
+model: fable
+created: 2026-07-09
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, standalone
+language_feature: iterators, for-of, destructuring, spread
+goal: standalone-mode
+umbrella: 2860
+related: [2864, 2865, 3023, 3099, 3098, 2157, 1323, 3031, 2949]
+origin: "2026-07-09 fable-arch hard-problems audit (domain 3) — iterator_protocol is the largest standalone leak class (8,156 files @ 2026-06-26 JSONL); probe pinned the dynamic-iterable arm as the live gap on current main"
+---
+
+# #3100 — native GetIterator dispatch for dynamic iterables
+
+## Problem (verified against origin/main @ 928c85179, 2026-07-09)
+
+Iteration is native standalone for **statically-typed** iterables, but a
+**dynamically-produced / `any`-typed** iterable has no native GetIterator
+dispatch — the lowering either bakes a wrong `ref.cast` (trap) or leans on
+host imports (`__array_from_iter_n`, `__gen_*`).
+
+Probes (standalone, `nativeStrings`):
+
+```ts
+// typed — all native + correct:
+for (const s of ["ab","c"]) …           // ✓ 3
+const a: string[] = ["ab","c"]; for (const s of a) …  // ✓ 3
+const o = {a:5,b:6}; for (const k of Object.keys(o)) …  // ✓ 2  (typed literal receiver)
+
+// dynamic — traps:
+const o: any = {a:5,b:6};
+for (const k of Object.keys(o)) { n += 1; }        // TRAP: illegal cast (even without touching k)
+for (const [k,v] of Object.entries(o)) …           // TRAP: illegal cast
+// control: index loop over the same value works:
+const ks = Object.keys(o); for (let i=0;i<ks.length;i++) n += o[ks[i]];  // ✓ 11
+```
+
+The `iterator_protocol` leak class is the **largest standalone bucket**:
+8,156 files in the 2026-06-26 standalone JSONL (4,783 leaky-pass + 2,724
+fail + 649 CE), carried by `__gen_*` (generator carrier — #2864, staffed),
+`__array_from_iter_n` (4,348), and `__make_callback` (#3098). The generator
+carrier work retires the `__gen_*` share; **nothing staffed owns the
+"iterate a value whose static type is `any`/externref" dispatch** — this
+issue.
+
+## Root cause
+
+The for-of lowering forks on the STATIC type of the iterated expression:
+
+- typed vec struct → native indexed loop (fast path, correct);
+- string → native char iteration;
+- generator → carrier (native standalone since #2864 lane);
+- **externref/`any` → there is no runtime classification arm.** The lowering
+  picks a vec typeIdx from unreliable static info and emits
+  `ref.cast $vec<T>` on a value that is actually a different carrier
+  (`$ObjVec` keys array, boxed-any vec, host-shaped array) → `illegal cast`.
+  `Object.keys(<any>)`'s result is exactly this shape, which is why the
+  typed-receiver control passes and the `any` receiver traps.
+
+This is the iteration twin of the #3053 reader-carrier convergence: the
+_read_ side got a unified `__dyn_member_get`; the _iterate_ side still has
+per-shape baked casts.
+
+## Design — `__get_iterator` / `__iter_step`: one native iteration ladder
+
+One pair of runtime helpers (standalone; host lane keeps its host protocol),
+mirroring §7.4 GetIterator/IteratorStep and the #3031 Part-0 ladder order:
+
+```
+__get_iterator(v externref) -> externref   ;; an IterState carrier
+  1. ref.test $Proxy        → trap-aware Get(v, @@iterator) → call → validate
+  2. ref.test $vec family   → native index-iterator state {vec, i}  (incl. $ObjVec, boxed-any vec, string[] carrier)
+  3. ref.test $Object       → Get(v, @@iterator) via __extern_get (finds user
+                               iterators incl. shorthand `[Symbol.iterator]() {}` — needs #3099);
+                               callable → invoke via __apply_closure; result must be Object else TypeError (§7.4.3)
+  4. native string          → char iterator state
+  5. generator/asyncgen carrier → the #2864/#2865 frame (already native)
+  6. null/undefined         → TypeError "is not iterable" (catchable)
+  7. else (host externref, gc lane only) → host GetIterator import (unchanged)
+
+__iter_step(state externref) -> externref  ;; {done,value} carrier or done-sentinel
+  fast arms for the index-iterator states (no per-step allocation for arm 2/4);
+  protocol arm calls next() via __apply_closure and reads .done/.value through
+  the dynamic reader (carrier-correct per #3053 — tag-6 for objects).
+```
+
+Consumers (each currently duplicating shape logic): for-of lowering
+(`statements.ts` for-of externref arm), array destructuring from `any`,
+spread of `any` (`[...x]`, `f(...x)`), `Array.from(x)` (retiring
+`__array_from_iter_n` for GC-native carriers), `for await` (via the #2865
+carrier), yield\*. Migrate them one consumer per slice; the helper is the
+single place the ladder order and TypeError shapes live (same discipline as
+#3031's `__chain_lookup`: one walker, refactor consumers onto it).
+
+### Perf discipline
+
+The typed fast paths are UNTOUCHED (the ladder is emitted only on the
+externref/`any` arm that today traps or leaks). Arm 2 keeps iteration
+allocation-free by reusing a mutable `{vec, i}` state struct; only the
+protocol arm (3) pays per-step `__apply_closure`.
+
+## Slices
+
+| #   | Slice                                                                                                                                 | Scope                                             | Gate                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ------------------- |
+| S1  | `__get_iterator`/`__iter_step` + arm 2 (vec-family) + arm 6; wire ONLY the for-of externref arm                                       | the probe traps flip; byte-inert for typed for-of | merge_group + floor |
+| S2  | `Object.entries`/destructuring consumer (`for (const [k,v] of …)`)                                                                    | entries probe flips                               | same                |
+| S3  | Arm 3 protocol dispatch (user iterators; depends #3099 for shorthand `@@iterator`)                                                    | manual-iterator for-of standalone                 | same                |
+| S4  | Spread + `Array.from` consumers; retire `__array_from_iter_n` on GC-native carriers                                                   | leak count drop (4,348 files @ stale baseline)    | same                |
+| S5  | Proxy arm (1) + IteratorClose on abrupt completion (§7.4.9 — coordinate with #3023's landed abrupt-completion work, do not duplicate) | `iterator-close` rows                             | same                |
+
+## Edge cases
+
+- **IteratorClose** on break/throw/return out of the loop body (§7.4.9) —
+  call `return()` when present; the #3023 residual landed this for the
+  existing lanes; the new ladder must route through the same close helper.
+- `next()` returning a non-object → TypeError (§7.4.6); `done` coercion via
+  truthiness; `value` absent → undefined singleton.
+- Re-entrant iteration (nested for-of over the same vec) — per-loop state,
+  never a shared global.
+- Boxed-any vec elements must come back carrier-correct (tag-6 objects keep
+  identity — #3037/#3053 contract), NOT re-proxied externref.
+- Strings iterate by code point (§22.1.5.1), not code unit — reuse the
+  existing native string-iteration arm.
+
+## Dependencies / non-collision
+
+Depends on #3099 (shorthand `@@iterator` visibility) for S3 only. #2864/#2865
+own generator/async-generator carriers (arm 5 consumes their public shape;
+do not modify). #3053 owns the read-carrier contract used by `__iter_step`'s
+protocol arm. #3098 is independent (callback vs iteration) but shares the
+`__apply_closure` invoke arm — land S1 of whichever goes first and reuse.
+
+## Acceptance criteria
+
+1. The three probe traps flip to correct results, host-free.
+2. Spread/`Array.from` over dynamic GC-native iterables host-free (S4);
+   fresh standalone JSONL shows `__array_from_iter_n` reduced to host-shaped
+   receivers only.
+3. Typed for-of paths byte-identical (WAT-diff a typed `for (x of arr)`).
+4. Full merge_group + standalone floor (iteration is broad-impact).
+
+## Effort estimate
+
+L–XL total; S1/S3 are the Fable-grade design slices (ladder + protocol ABI),
+S2/S4/S5 Opus-executable from the S1 template.

--- a/plan/issues/3101-bytecode-isa-frame-abi-prespec.md
+++ b/plan/issues/3101-bytecode-isa-frame-abi-prespec.md
@@ -1,0 +1,191 @@
+---
+id: 3101
+title: "Bytecode interpreter ISA + `$Frame`/`$EnvRec` ABI pre-spec (E1 executable-cold): opcode set, encoding, exception table, AOT↔interp call protocol"
+status: ready
+sprint: Backlog
+model: fable
+created: 2026-07-09
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: architecture
+area: runtime, ir
+language_feature: eval
+goal: runtime-eval
+parent: 2928
+depends_on: []
+related: [2928, 2929, 2927, 1715, 2864, 1584, 3017]
+origin: "2026-07-09 fable-arch hard-problems audit (domain 5) — E1's opcode ADR is the one unwritten design artifact on the interpreter critical path; pre-speccing it lets E1 (the interpreter library, Node-testable, zero substrate risk) start in any budget window"
+---
+
+# #3101 — the bytecode ISA, concretely
+
+## Why this issue exists
+
+The runtime-eval architecture is settled
+(`docs/architecture/runtime-eval-interpreter.md` Part II): 4-tier ladder,
+**bytecode over tree-walking (ADR'd §13)**, register+accumulator machine,
+unified `$EnvRec` name resolution (§14), slices E0–E6 (#2928). E1 —
+"interpreter library, developed in Node" — is fully parallelizable **today**
+(no compiled-acorn dependency, no substrate risk), but its first deliverable
+is the opcode ADR, a design-taste artifact. This issue IS that design, so an
+Opus dev can execute E1 cold: implement, don't decide. Deliverable of E1
+remains committing this as `docs/adr/0019-bytecode-isa.md` (next free ADR
+number — verify) + the `src/interp/` library.
+
+## Design constraints (inherited, normative)
+
+1. **Values are the AOT boxed-any substrate** — every operand register holds
+   the same `anyref` rep AOT code produces (tag classifier, `$Object`,
+   native strings, undefined/null singletons). No interpreter-private value
+   kinds. `ref.eq` identity crosses the boundary (roadmap §4.2).
+2. **Two producers, one consumer** (§12.1): runtime ESTree→bytecode emitter
+   (Phase 1) and, later, build-time IR→bytecode (#1715). No opcode may
+   assume "parsed at runtime".
+3. **Suspension-ready**: PC + registers live in a heap `$Frame`; the
+   dispatch loop caches hot fields in Wasm locals and writes back only at
+   suspension/call boundaries (generators/async are #2929, but the frame
+   layout must not need a v2).
+4. Typed fast paths are a **non-goal** — AOT owns performance.
+
+## The machine
+
+Register + accumulator (Ignition-style). One implicit accumulator `acc`
+(boxed-any) + a per-frame register file `regs[0..R)` (boxed-any, mutable
+array). Most ops read/write `acc`; binary ops take one register operand.
+
+### Types (WasmGC; authored in the js2wasm-compilable TS subset)
+
+```
+$FuncMeta = struct {
+  code:      (ref $BcArray)        ;; array (mut i32) — the bytecode
+  consts:    (ref $ConstPool)      ;; array (mut anyref) — literals, names, nested $FuncMeta
+  regCount:  i32
+  paramCount:i32
+  exnTable:  (ref null $ExnTable)  ;; array (mut i32), rows of 4: [startPC, endPC, handlerPC, handlerReg]
+  name:      anyref                ;; string or undefined (Function.prototype.name)
+  flags:     i32                   ;; bit0 strict, bit1 isGenerator*, bit2 isAsync* (*#2929)
+}
+$Frame = struct {
+  meta:   (ref $FuncMeta)
+  pc:     (mut i32)
+  regs:   (ref $Regs)              ;; array (mut anyref), length = regCount
+  envRec: (ref null $EnvRec)       ;; §14 chain head (Phase 1: the global record)
+  parent: (ref null $Frame)        ;; caller frame (debug/stack traces; NOT control flow)
+}
+$EnvRec = struct {                 ;; doc §14, shared with #2925/#2864 — coordinate, do not fork
+  kind:    i32                     ;; 0 declarative | 1 object | 2 global
+  parent:  (ref null $EnvRec)
+  names:   anyref                  ;; declarative: name→slot map carrier; object/global: null
+  slots:   (ref null $Regs)        ;; declarative: mutable boxed slots
+  backing: anyref                  ;; object/global: the backing $Object (globalThis for global)
+}
+```
+
+### Encoding
+
+- `code` is an **i32 array**; one instruction = `op | (a << 8) | (b << 20)`
+  packed, with `op` an 8-bit opcode, `a`/`b` 12-bit unsigned operands
+  (register index / const-pool index / jump-target low bits). Ops needing a
+  wider immediate (jump targets, big const indices) use a trailing extension
+  word (op flag bit 7). Rationale: dense `br_table` dispatch on `op & 0x7f`,
+  no variable-length decode in the hot loop beyond one optional extra word.
+- Jumps are **absolute PCs** (not relative) — simpler patching in the
+  emitter; the emitter back-patches forward references.
+- The **disassembler** (E1 deliverable) renders `pc: OpName a, b  ;; const`
+  and is the debugging contract — no blind-in-Wasm debugging.
+
+### Phase-1 opcode set (34 ops)
+
+| Group      | Ops                                                                                                                             | Semantics (all values boxed-any)                                                                                                                                                                                                                                                                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| const/reg  | `LdaConst c` · `LdaUndef` · `LdaNull` · `LdaTrue` · `LdaFalse` · `LdaZero` · `Star r` · `Ldar r` · `Mov r1,r2`                  | pool load → acc; acc↔reg moves                                                                                                                                                                                                                                                                                                                                              |
+| arith/cmp  | `Add r` · `Sub r` · `Mul r` · `Div r` · `Mod r` · `Neg` · `Not` · `TypeOf` · `Eq r` (==) · `StrictEq r` (===) · `Lt r` · `Le r` | `acc = op(regs[r], acc)`; delegates to the EXISTING generic runtime ops (`__any_add`-family / coercion-engine siblings — the #2927 generic-built-in audit surface). ToPrimitive/ToNumber live in those helpers, NOT in the loop                                                                                                                                             |
+| property   | `GetProp c` (named, key from pool) · `GetElem r` (dynamic key in regs[r]) · `SetProp c, r` · `SetElem rK, rV`                   | route through `__dyn_member_get` (#3053) / `__extern_set` — the SAME dynamic MOP the AOT path uses; Proxy/chain semantics come free per #3031 §0.1                                                                                                                                                                                                                          |
+| variables  | `LdGlobal c` · `StGlobal c` · `LdName c` · `StName c`                                                                           | Phase 1: `LdName/StName` walk the `$EnvRec` chain rooted at global (root miss ⇒ typed ReferenceError, §14); `LdGlobal/StGlobal` are the root-only fast case                                                                                                                                                                                                                 |
+| calls      | `Call rArgsBase, argc` (callee in acc, receiver = argsBase[0]) · `Construct rArgsBase, argc` · `CallBuiltin c, rArgsBase, argc` | contiguous register windows for args (the emitter allocates arg windows; avoids per-call array alloc). Callee dispatch = the #3098 classifier: compiled closure → `__apply_closure`; interpreted callee ($FuncMeta-backed closure) → push new `$Frame`, iterate (NO host stack recursion for interp→interp calls — loop-with-frame-stack, suspension-ready); else TypeError |
+| control    | `Jump t` · `JumpIfTrue t` · `JumpIfFalse t` (ToBoolean via `__is_truthy`) · `Return` (acc = result)                             | absolute PC                                                                                                                                                                                                                                                                                                                                                                 |
+| exceptions | `Throw` · (no TryStart/TryEnd ops — see below)                                                                                  | `Throw` raises the same Wasm exn tag AOT throw uses                                                                                                                                                                                                                                                                                                                         |
+
+**Exception regions are a side table, not opcodes** (deviation from the
+#2928 sketch's `TryStart/TryEnd`, deliberate): the dispatch loop wraps
+opcode execution in a Wasm `try_table`; on catch it consults
+`meta.exnTable` for the innermost row containing `pc`, stores the caught
+value into `regs[handlerReg]`, sets `pc = handlerPC`, continues; no row →
+write back frame state and rethrow across the boundary (E4). Rationale:
+zero cost on the non-throwing path, no paired-opcode invariants for the
+emitter to break, and it matches how the AOT lane already uses EH tags.
+`finally` compiles to duplicated/jump-threaded blocks (the standard
+bytecode answer; revisit only if size measurements object).
+
+### Call protocol (AOT ↔ interpreted, E2's contract)
+
+An interpreted function value is an ordinary **closure struct** whose code
+pointer is the single exported trampoline `__interp_enter(meta, envRec,
+thisArg, argsVec) -> anyref` and whose capture slot holds the `$FuncMeta`.
+Consequence: to every AOT call site (and to #3098's `__invoke_cb_n`
+classifier), an interpreted function is _indistinguishable_ from a compiled
+closure — call dispatch needs **zero** interpreter-awareness anywhere in
+codegen. `__interp_enter` allocates the `$Frame` (regs from `regCount`),
+copies args into the param registers, runs the loop, returns `acc`.
+Interp→AOT calls go through `Call`'s classifier arm (`__apply_closure`).
+Both directions preserve `ref.eq` identity by construction (one value rep).
+
+### Dispatch loop shape (E1; perf notes for the ADR)
+
+`while (true) { const w = code[pc]; switch (w & 0x7f) { … } }` — js2wasm
+lowers dense switches to `br_table` (#1715 proof). `pc`, `code`, `consts`,
+`regs` cached in typed locals; `$Frame.pc` written back only at `Call`/
+`Throw`-across-boundary/`Return` (and, later, suspension). Every opcode
+handler is a small straight-line block; helpers (`__any_add`, truthiness,
+MOP calls) are direct calls. Record observed hot-path boxing in the ADR
+(acceptance from #2928).
+
+## Emitter notes (ESTree→bytecode, Phase 1 coverage)
+
+Expression statements, var/let/const (Phase 1: all function-scoped to
+registers; TDZ = later), if/else, while/for/do, break/continue (to jump
+targets; labels = emitter bookkeeping, no opcode), binary/unary/logical
+(short-circuit via JumpIf\*), member get/set, calls/new, object/array
+literals (emit via `CallBuiltin %ObjectLiteral%`/`%ArrayLiteral%` runtime
+helpers rather than dedicated opcodes — fewer ops, same cost class),
+`throw`, try/catch/finally (exn table), function declarations/expressions
+(nested `$FuncMeta` in the pool + closure creation via `CallBuiltin
+%MakeClosure%`; capture semantics Phase 1 = **none** — Function-ctor bodies
+and indirect eval are global-scope, §20.2.1.1; declarative records land
+with #2929). Register allocation: trivial stack-discipline allocator
+(expression temporaries pushed/popped; locals pinned low), `regCount`
+finalized at emit end.
+
+## What this issue does NOT decide
+
+- Generator/async opcodes + frame suspension encoding (#2929; the `$Frame`
+  layout above is the agreed carrier, coordinate with #2864's `$Frame`
+  before freezing field order).
+- The `$EnvRec` declarative-record internals (#2925 owns the name-map
+  carrier; §14 is the contract).
+- Tier-up / inline caches / profiling — non-goals (doc §9).
+
+## Acceptance criteria
+
+1. This spec (amended by review) lands as `docs/adr/0019-bytecode-isa.md`
+   in the E1 PR, with the encoding + opcode table + exn-table format +
+   trampoline contract exactly as implemented.
+2. E1 library (`src/interp/`: opcodes, encoder, emitter, loop,
+   disassembler) runs the fixture corpus in **Node against node-acorn**
+   (no Wasm): arithmetic/control/property/call/try fixtures + a
+   differential check vs `eval` on ≥50 sampled constant-string test262
+   eval bodies.
+3. The loop + emitter typecheck in the js2wasm-compilable strict subset
+   (`tsc` project gate), ready for E2 self-compile.
+4. No opcode carries a runtime-type assumption (audit: every operand is
+   boxed-any; the generic-runtime-op delegation list is complete).
+
+## Effort estimate
+
+L: the ISA freeze + encoder/loop skeleton is the Fable-grade half (this
+spec cuts it to review + implement); the emitter coverage + fixtures are
+Opus-executable grind. Fully parallel to all substrate work — the ideal
+"budget-window filler" XL-adjacent rock with zero merge-conflict surface
+(new directory).

--- a/plan/log/hard-problems-architecture-audit.md
+++ b/plan/log/hard-problems-architecture-audit.md
@@ -1,0 +1,294 @@
+# Hard-problems architecture audit — the five domains, ranked (2026-07-09)
+
+> fable-arch deep audit against `origin/main @ 928c85179` (2026-07-09).
+> Method: verify-first — every claim below was re-probed against current
+> main via `compileSource(..., {target:"standalone", nativeStrings:true})`
+>
+> - instantiate-and-run, or grep of the live source; several written
+>   findings from earlier sessions turned out stale (noted inline). Scope
+>   per the lead's brief: audit the five hard domains BEYOND the in-flight
+>   work (#2773 / #2963 / #3037 / #3087 / #2865 / #3050 are being
+>   implemented right now and are NOT re-spec'd here).
+>
+> New issues filed by this audit: **#3098, #3099, #3100, #3101** + the
+> requested architect spec written into **#2956** + a verified-state
+> addendum in **#3031**.
+
+## Executive ranking (by leverage per budget token)
+
+| Rank | Domain                                                  | Verdict                                                                                                                                                            | This audit's delta                                                                         |
+| ---- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| 1    | **Dynamic features** (any/dynamic value rep + dispatch) | Substrate is FAR further along than the docs/memories say; the remaining roots are dispatch arms, not representation                                               | #3098 (native callback dispatch), #3100 (dynamic-iterable iteration)                       |
+| 2    | **Standalone** (pure-Wasm parity)                       | Floor 19,219 host-free and climbing; carriers staffed; the two biggest UNSTAFFED leak roots are #3098/#3100's                                                      | leak-root map below; #3098/#3100                                                           |
+| 3    | **IR** (`ir-full-coverage`)                             | Machinery essentially built (inversion done, effect model done, capability tables in flight); the wall is untyped-JS claiming (#2949, in flight) + the linear seam | #2956 architect spec (the one requested-but-unwritten keystone spec)                       |
+| 4    | **Proxy**                                               | 12 traps wired but DARK for test262's dominant handler shape — one bounded bug caps the whole lane                                                                 | #3099 (the keystone enabler) + #3031 re-verification (P5 unblocked: descriptor bits exist) |
+| 5    | **eval / new Function**                                 | Architecture fully decided (4-tier ladder, bytecode ADR'd); Tiers 0/1/3 shipped; only the ISA design artifact blocked cold-start of the interpreter build          | #3101 (ISA + $Frame ABI pre-spec → E1 is now Opus-executable)                              |
+
+Ranking rationale: domains 1 and 2 share their two biggest roots (callback
+dispatch, dynamic iteration) — landing #3098+#3100 moves BOTH the gc-lane
+honest-fail tail (post-#3074) and the standalone leak classes. Domain 3 is
+architecturally on rails; its highest-leverage unwritten artifact was the
+#2956 spec, now written. Domain 4 is gated on a single M-sized bug (#3099)
+before any of its planned Fable slices are worth scoping. Domain 5 is
+deliberately last: superbly planned, zero-conflict, and now cold-startable
+— ideal budget-window filler, not the critical path.
+
+---
+
+## Domain 1 — Dynamic features (any/dynamic value rep + dispatch substrate)
+
+### Verified current state (probes, standalone lane)
+
+The standalone dynamic MOP is much stronger than recorded. All of these
+work host-free on current main (several memory notes claiming otherwise
+are STALE — e.g. `reference_standalone_any_string_value_read_substrate`,
+fixed by the #3027 lineage):
+
+- `(o: any).v` for number AND string values (`o.v.length` → 2 ✓); the
+  native-string drop is FIXED.
+- Computed keys `o[k]`, incl. `o[Object.keys(o)[0]]`; `delete`; set of a
+  new string-valued prop; accessors (`get p(){…}`); prototype walk via
+  `Object.create(p)`; symbol-keyed props (`o[s]`, no host import!);
+  dynamic `this` (`o.m()` reading `this.v`); `with (o) { a }`;
+  `instanceof` on a class instance; for-in with `o[k]` reads.
+
+### Verified live gaps (each pinned to a shape)
+
+| Gap                                                          | Probe                                                                                                                                       | Owner                                                                      |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Callback through a dynamic dispatch boundary → host bridge   | `(a: any).map(cb)` → TRAP + LEAK `__make_callback` (typed receiver is native)                                                               | **#3098 (new)**                                                            |
+| Iterating a dynamically-produced iterable → baked wrong cast | `for (k of Object.keys(o: any))` → illegal_cast; `Object.entries` destructuring → illegal_cast; index loop over same value works            | **#3100 (new)**                                                            |
+| `Function.prototype.bind` standalone                         | `f.bind({v:8})()` → null deref                                                                                                              | small, unfiled (note for PO; likely folds into #2963's reification family) |
+| `console.log(e.message)` of a dynamic-read native string     | wasm compile error (`(ref null 6)` where externref expected) — the VALUE path is fine (`e.message.length` ✓), only console_log arg coercion | small, unfiled (note for PO)                                               |
+
+### End-state substrate + migration path (the brief's question)
+
+The end state is already implicitly ratified across four in-flight specs;
+stated here in one place:
+
+1. **One value ABI**: boxed-any carrier + tag classifier (tag-5/tag-6
+   discipline), `$Object` for open shapes, `$NativeProto` for builtin
+   protos, `$Proxy` at ladder step 1, native i16-array strings, undefined
+   singleton. Owner: #2773 (rep) + #3037 (identity) + #3053 (reader
+   carrier) + #2949 (the same ABI inside the IR's type system).
+2. **One MOP spine**: front-guarded shared helpers + `__chain_lookup` +
+   receiver-classification ladder (#3031 Part 0). Every new dynamic
+   consumer (with, Proxy, interpreter opcodes, destructuring) routes
+   through it; none re-implements classification.
+3. **One dispatch arm for callable values**: compiled-closure `ref.test` →
+   `__apply_closure`, arity-tolerant (#2939 lesson). #3098 builds it for
+   HOF callbacks; #3100 reuses it for `next()`; the #3101 interpreter
+   trampoline makes interpreted functions indistinguishable from compiled
+   closures under the SAME classifier — after which "dynamic dispatch"
+   is one mechanism everywhere.
+4. **Migration**: land in-flight #2773-tail/#3037/#3053/#2949 → #3098 S1/S2
+   → #3100 S1–S3 → the #3031 C-slices (chain walker refactors). Each step
+   retires per-shape baked casts in favor of the ladder.
+
+---
+
+## Domain 2 — IR (`ir-full-coverage` north star)
+
+### Verified current state
+
+- **Fallback baseline is down to `body-shape-rejected: 17`** (+4 deferred
+  async) — from 33 on 2026-07-02. The residual is fully characterized in
+  #2856's landed diagnostics: it is NOT missing statement kinds; it is
+  entangled capability clusters (cross-module imported calls #2858 +
+  first-class function values + `.push` + C-style-loop vec SSA + `#private`
+  - module-scope mutables). #2856 is correctly `blocked` on that
+    capability program; nothing to re-spec.
+- **Keystones**: #2138 compile-once inversion **done** (flag-gated, full
+  test262 measured: −15/48,088, all attributed, fail-loud held); #2134
+  effect model **done** (slices 1+2, `src/ir/effects.ts` + schedule
+  verifier); #2135 capability table **in-progress** (operators landed);
+  #1930 TypeOracle **in-progress**; #2953 pushRaw gap **in-progress**;
+  #2954 LinearEmitter core ops **done**; #2952 multi-exit CF
+  **in-progress**; #2949 dynamic IrType **in-progress** (slices ratified,
+  U0–U2 of #3053 landed); #2950 default flip **backlog** (correctly gated
+  on #2138-S3 divergence fixes #2972/#2973 + #2135 families + #2951).
+- **The honest wall** (from the July audit, still true): IR claim rate on
+  untyped JS is ~3% — zeroing the playground-corpus buckets is necessary
+  but NOT sufficient; #2949 (dynamic IrType) is the true critical path and
+  is staffed.
+
+### The sequenced retirement plan (consolidated)
+
+```
+NOW (in flight): #2949 slices · #2135 families · #2953 · #2952 · #1930
+  → #2972/#2973 (the two #2138-S3 divergences) → #2951 (gens+class-members skip)
+  → #2950 slice 1 (IR-first default-ON, one soak window)
+  → #2950 slice 2 (delete flag + compile-twice; demote channel dies for
+     claimed code — #2855 AC4)
+  → capability program unblocks #2856/#2857/#2858 buckets → 0 →
+     STRICT_IR_REASONS promotions → #2855 closes
+PARALLEL (backend axis): #2953 → L0/L1 of #2956 (spec now written) → L2+
+  → #2955 (string de-polymorph) → linear families widen via the ratchet
+LATER: #1373b (IR async, AFTER #1042 engine convergence — one engine rule)
+END STATE: src/codegen/ = WasmGcEmitter + registries (backend library);
+  src/codegen-linear/ = LinearEmitter + layout/runtime; one front-end.
+```
+
+**This audit's delta**: the #2956 architect spec (adapter-interface design
+`IrBackendIntegration`, ONE integration core + two context adapters — NOT
+a cloned twin — plus the legality-gated slice map L0–L4 and a
+`check:linear-ir` ratchet). It was the one keystone explicitly awaiting an
+architect spec ("Architect spec recorded here ... before dev dispatch").
+
+---
+
+## Domain 3 — Standalone (pure Wasm, no JS host)
+
+### Verified current state
+
+- Honest floor: **19,219 host-free pass** (`test262-standalone-highwater.json`
+  @ 2026-07-06) — up from 18,157 on 2026-07-02 and 12,551 on 2026-06-29.
+  The carrier lane (#2864/#2865/#2867, all in-progress) is landing.
+- The last full standalone JSONL with leak attribution is **2026-06-26**
+  (stale — 12 days, pre-#2962/#2902/#2959): leak classes `host_import`
+  10,209 · `iterator_protocol` 8,156 · `dynamic_object_property` 5,167 ·
+  `dynamic_code` 387. Top leaked imports and their owners:
+
+| Import (files @ 06-26)                       | Root                               | Owner                                                                                         |
+| -------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `__get_caught_exception` 8,807               | error identity                     | #2962 **done** — expect a large drop on refresh                                               |
+| `__make_callback` 7,519                      | dynamic-receiver callback dispatch | **#3098 (new)** (async share → carriers)                                                      |
+| `__gen_*` ≈7.4k+5.6k                         | generator carrier                  | #2864 in-progress                                                                             |
+| `__new_Test262Error` 6,402                   | harness error ctor                 | #2902 **done**                                                                                |
+| `__extern_get` 4,354                         | dynamic reader                     | #3027 done / #3053 in-progress                                                                |
+| `__array_from_iter_n` 4,348                  | iteration of dynamic iterables     | **#3100 (new)** S4                                                                            |
+| `Promise_*` ≈4.1k×2+4k                       | promise carrier                    | #2867/#2959 (2959 done)                                                                       |
+| `__create_async_generator` 4,065             | async-gen carrier                  | #2865 in-flight                                                                               |
+| `__box_symbol` 2,748                         | symbol boxing at host boundary     | native symbol keys already work (probe ✓); residual shapes need a fresh harvest before filing |
+| `global_<TypedArray>` ~780×8                 | TA ctors as host globals           | #2651 blocked / #3087 in-flight adjacent                                                      |
+| `__extern_eval` 682 / `__dynamic_import` 433 | dynamic code                       | runtime-eval ladder (domain 5)                                                                |
+
+- **Action for the lead**: schedule a fresh standalone JSONL harvest —
+  every number above predates 5 merged leak-root fixes; scoping new
+  slices against the 06-26 file would misallocate budget.
+
+### Path to close (the brief's question)
+
+The gap decomposes into: (a) carriers (staffed, landing), (b) the two
+unstaffed dispatch roots this audit filed (#3098 callbacks, #3100
+iteration), (c) dynamic-code (domain 5's Tier 2), (d) a long tail of
+bounded bugs (bind, console-log coercion, catch-payload shapes) that
+should be harvested AFTER (a)+(b) land, against a fresh baseline. The
+structural guarantee gap (#2961, strict leak-scan for `--target
+standalone`) remains blocked and is worth unblocking once #3098/#3100
+retire their import families — at that point the allowlist shrinks enough
+for the scan to be enforceable.
+
+---
+
+## Domain 4 — Proxy
+
+### Verified current state (probes + grep)
+
+- Standalone substrate (#1100 + #1355 A–F): `$Proxy` + `$ProxyTraps` with
+  **12 trap fields** (get/set/has/apply/deleteProperty/gOPD/getPrototypeOf/
+  setPrototypeOf/isExtensible/preventExtensions/ownKeys/defineProperty);
+  `construct` absent. Arrow-property handlers fire (get/set/has verified ✓).
+- **THE FINDING — #3099 (new)**: method-shorthand handlers (`{ get(t,k)
+{…} }` — test262's dominant shape) **silently never fire**: the
+  any-context object-literal route skips MethodDeclaration props entirely
+  (`literals.ts:322` — a documented "S2 follow-on" that was tracked
+  nowhere). `Object.keys` of a shorthand-method literal returns 0;
+  `__proxy_create`'s runtime trap read misses. Every standalone Proxy
+  measurement to date understates the wired substrate. **Land #3099 first;
+  re-measure; then scope the rest.**
+- **P5 unblocked**: the §10.5 invariant slices were "sequenced behind
+  descriptor-attribute bits" — those bits EXIST now (`$PropEntry.$flags` +
+  native non-configurable redefine TypeErrors). Recorded in #3031's
+  re-verification addendum.
+- Still open, unchanged: K2 (standalone `construct` + `__construct_dispatch`
+  — spec'd in #3031 §1.3), P3 (`Proxy.revocable` standalone — CE today),
+  P4 (`Reflect.*` standalone wiring — CE today), K1 (host inbound
+  arg-marshalling — coordinate with in-flight #3087, adjacent locus).
+
+### Sequenced path
+
+#3099 (M, Opus) → re-measure standalone `built-ins/Proxy` → P3+P4 (Opus,
+bounded) → K2 (Fable) → P5 invariants (now executable; predicates are
+mechanical from fetched §10.5 text) → K1/K1b host lane (after #3087
+lands). The trap-dispatch mechanism and exotic-object representation
+questions the brief asked are ANSWERED and ratified in #3031 Part 0
+(front-guarded shared helpers; `$Proxy` as a standalone struct,
+storage-typed externref, ladder step 1) — no new representation design is
+needed; execution is.
+
+---
+
+## Domain 5 — eval / new Function
+
+### Verified current state
+
+The architecture is the most complete of the five domains
+(`docs/architecture/runtime-eval-interpreter.md` Parts I+II):
+
+- **Tier 0** (constant-string compile-away) — shipped + broadened (#1163/
+  #2923/#2924); 91.7% of test262 eval call-sites are constant-string.
+- **Tier 1** (host meta-circular shim) — shipped (#1164/#2960); known gaps
+  #2925 (direct-eval scope reification, backlog) + #3017 gap 2 (eval-code
+  linkage / ReferenceError shape).
+- **Tier 3** (refuse-loudly) — shipped (#2960); invariant L1 (no silent
+  wrong values) holds.
+- **Tier 2** (standalone bytecode interpreter) — DECIDED (bytecode over
+  tree-walking, §13 ADR; self-compiled TS, strategy 2a) but NOT built.
+  Parser prerequisites: #2853 **done**; #2927 ready; #2928 sliced
+  (E0–E6) with E1 (interpreter library, Node-tested, zero substrate risk)
+  startable in any window.
+- The user-floated "bytecode interpreter" IS the committed direction; the
+  alternatives (compile-at-runtime meta-circular standalone, QuickJS
+  bridge, tree-walker) were evaluated and rejected with recorded rationale
+  (doc §3, §13) — no need to relitigate.
+
+### This audit's delta — #3101 (new)
+
+The one artifact between "fully planned" and "an Opus dev can build it
+cold" was the opcode ADR (E1's first deliverable, design-taste work).
+#3101 pre-specs it concretely: 34-op register+accumulator ISA with packed
+i32 encoding, side exception TABLE instead of TryStart/TryEnd opcodes
+(zero-cost non-throwing path), `$FuncMeta`/`$Frame`/`$EnvRec` layouts
+(coordinated with #2864/#2925/§14), and — the load-bearing decision — the
+**closure-struct trampoline call protocol** that makes interpreted
+functions indistinguishable from compiled closures to every AOT call site
+(zero interpreter-awareness in codegen, `ref.eq` identity free, and
+direct reuse of #3098's callable classifier).
+
+### Sequencing
+
+E0 (in-Wasm AST probe) ∥ E1 via #3101 → E2 (self-compile; the risk
+concentration) → E3/E4/E5 → #2929 (direct eval + with + MOP convergence —
+whose MOP surface is #3031's, single-sourced). Independent Tier-1 work
+(#2925, #3017-g2) schedulable anytime.
+
+---
+
+## Consolidated new-issue list (this audit)
+
+| Id        | Domain   | Title (short)                                                                                   | Effort                      | Model      | Priority |
+| --------- | -------- | ----------------------------------------------------------------------------------------------- | --------------------------- | ---------- | -------- |
+| **#3098** | 1+2      | Native callback dispatch — retire `__make_callback` on the dynamic-receiver lane                | L (S1/S2 Fable, S3–S5 Opus) | fable      | high     |
+| **#3099** | 4 (+1,3) | Method-shorthand props never materialize on `$Object` — un-darks the wired Proxy trap substrate | M                           | opus       | high     |
+| **#3100** | 3+1      | Dynamic-iterable substrate — native GetIterator/IteratorStep ladder                             | L–XL (S1/S3 Fable)          | fable      | high     |
+| **#3101** | 5        | Bytecode ISA + `$Frame` ABI pre-spec — E1 executable cold                                       | L (spec cuts design out)    | fable→opus | medium   |
+| **#2956** | 2        | (spec added to existing issue) linear backend consumes IR — adapter interface + L0–L4 slice map | XL (L0+L1 first window)     | fable      | medium   |
+
+Suggested queue insertion: #3099 immediately (`sprint: current`
+candidate — it re-baselines the whole Proxy domain for cheap); #3098 S1/S2
+and #3100 S1 as the next Fable rocks after the in-flight #2773/#3037/#3087
+wave lands (they share the classifier arm — build once); #2956 L0/L1 and
+#3101/E1 as parallel, conflict-free window fillers; refresh the standalone
+JSONL before scoping anything else in domain 3.
+
+## Stale-knowledge corrections (recorded so nobody re-chases)
+
+1. `reference_standalone_any_string_value_read_substrate` (memory) — FIXED
+   on main; dynamic any-typed string reads work (probe ✓). Do not re-mine.
+2. #3031's "P5 needs #797/#1460/#1462 descriptor bits" — bits EXIST now;
+   P5 is executable.
+3. The 2026-06-26 standalone JSONL leak counts predate #2962/#2902/#2959/
+   #3027 — treat as upper bounds only; refresh before scoping.
+4. CLAUDE.md "Skip filters: eval, with, Proxy…" remains stale doc (already
+   flagged in #3031) — these categories RUN; the gap is pass-rate.


### PR DESCRIPTION
Plan-only PR (no `src/` changes) from the fable-arch five-domain deep audit against `origin/main @ 928c85179`, verify-first (compile+run probes for every claim).

## New issue specs
- **#3098** — standalone native callback-dispatch substrate: retire `env.__make_callback` on the dynamic-receiver lane (probe-verified live: `(a: any).map(cb)` traps + leaks; typed receiver native). Top-3 leak root.
- **#3099** — any-context object-literal **method-shorthand** props never materialize as runtime own properties on `$Object` (untracked "S2 follow-on" at `literals.ts:322`). Probe-pinned as the reason standalone Proxy traps in test262's dominant handler shape silently forward — the keystone enabler for the whole Proxy lane.
- **#3100** — standalone dynamic-iterable substrate: native GetIterator/IteratorStep ladder (`for (k of Object.keys(o: any))` → illegal_cast today; largest leak class).
- **#3101** — bytecode interpreter ISA + `$Frame`/`$EnvRec` ABI pre-spec (34-op register+accumulator, exn side-table, closure-trampoline call protocol) so #2928 E1 is executable cold.

## Specs added to existing issues
- **#2956** — the explicitly-requested architect spec (`IrBackendIntegration` adapter: ONE integration core + two context adapters, legality-gated slice map L0–L4, linear-IR ratchet).
- **#3031** — verified-state addendum: `$PropEntry.$flags` descriptor bits EXIST on main → P5 invariants unblocked; #3099 gates all P-slices; construct/revocable/Reflect wiring confirmed still open.

## Summary doc
- `plan/log/hard-problems-architecture-audit.md` — five domains ranked by leverage, standalone leak-root→owner map, IR retirement sequencing, stale-knowledge corrections (incl. the native-string dynamic-read memory note being FIXED on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS