### PR TITLE
docs(plan): compiler consolidation audit — ranked refactoring plan + issues #3102–#3114

### DIFF
--- a/plan/issues/3102-loc-regrowth-ratchet-ci-gate.md
+++ b/plan/issues/3102-loc-regrowth-ratchet-ci-gate.md
@@ -1,0 +1,94 @@
+---
+id: 3102
+title: "LOC regrowth ratchet: check:loc-budget CI gate for god-files"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: high
+horizon: s
+feasibility: medium
+model: opus
+reasoning_effort: medium
+task_type: infrastructure
+area: ci, codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1013, 1172, 3103, 3104]
+---
+
+# #3102 — LOC regrowth ratchet: `check:loc-budget` CI gate
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+Splitting god-files does not stick. Every past split has regrown, because
+nothing structurally prevents new code from landing in the biggest file:
+
+| File                   | #1013 split (2026-04-10) | #1172 audit (2026-04-25) | 2026-06-27 | 2026-07-09 |
+| ---------------------- | ------------------------ | ------------------------ | ---------- | ---------- |
+| `src/codegen/index.ts` | 14,344 → split           | 6,368                    | 14,379     | **16,566** |
+
+`codegen/index.ts` regrew **2.6×** in ten weeks after the #1013 split.
+And in just the last 12 days (2026-06-27 → 2026-07-09, measured via
+`git show bf56e3060:<file> | wc -l` vs current):
+
+| File                               | Jun 27 | Jul 9  | Δ 12 days           |
+| ---------------------------------- | ------ | ------ | ------------------- |
+| `src/codegen/expressions/calls.ts` | 15,292 | 17,246 | **+1,954 (+12.8%)** |
+| `src/codegen/index.ts`             | 14,379 | 16,566 | **+2,187 (+15.2%)** |
+| `src/codegen/object-runtime.ts`    | 7,834  | 9,726  | **+1,892 (+24%)**   |
+| `src/runtime.ts`                   | 13,959 | 15,032 | **+1,073 (+7.7%)**  |
+
+Four files absorbed **+7.1k LOC in 12 days**. Current state: 246 `.ts` files in
+`src/` (309,130 LOC), **13 files >5,000 LOC**, 28 files >3,000 LOC, and 27
+top-level functions ≥1,000 lines (worst: `compileCallExpression` at 12,210).
+
+Every consolidation issue in this plan (#3103, #3104, …) is wasted effort
+without a regrowth brake. The project already has the exact mechanism proven:
+the IR fallback ratchet (#1376) — baseline JSON, CI fails on growth,
+`--update-on-decrease` banks shrinkage.
+
+## Fix
+
+Add `scripts/check-loc-budget.mjs` + `pnpm run check:loc-budget`, wired into
+the `quality` CI job (same slot as `check:ir-fallbacks`):
+
+1. **Baseline** `scripts/loc-budget-baseline.json`: `{ "<path>": <maxLines> }`
+   for every `src/**/*.ts` file currently over a threshold (propose **1,500
+   LOC**), captured from current main.
+2. **Gate**: fail when
+   - a baselined file exceeds its recorded ceiling (regrowth), or
+   - a NON-baselined src file crosses the threshold (new god-file).
+     Print the offending file, the delta, and a pointer to the consolidation
+     plan ("add code to the subsystem module, not the barrel/driver").
+3. **Ratchet**: `--update-on-decrease` rewrites lowered ceilings (call from the
+   post-merge CI job, same as the IR ratchet). `--update` for PRs that
+   deliberately grow a file (rare; requires the flag in the PR, visible in
+   review).
+4. Grandfather everything at current size — the gate blocks _growth_, it does
+   not demand immediate shrinkage, so it can merge with zero refactoring.
+
+Optional slice 2 (separate PR, same script): a per-function ceiling for the
+named god-functions (`compileCallExpression`, `ensureObjectRuntime`,
+`resolveImport`, `ensureNativeStringHelpers`, `compilePropertyAccess`) using a
+cheap top-level-function line scan, so those five can't grow either.
+
+## Safety
+
+Pure tooling — zero compiler-source changes, zero effect on emitted Wasm.
+No byte-identity proof needed. Risk is CI friction only; the grandfathered
+baseline plus `--update` escape hatch caps that.
+
+## Estimated LOC delta
+
++~200 (script) / prevents unbounded growth of ~75k LOC across the 13 giants.
+
+## Acceptance criteria
+
+1. `pnpm run check:loc-budget` passes on unmodified main.
+2. Adding 1 line to `src/codegen/index.ts` makes it fail with an actionable message.
+3. Shrinking a baselined file + `--update-on-decrease` rewrites the baseline.
+4. Wired into `quality` job; post-merge job banks decreases.

--- a/plan/issues/3103-split-runtime-ts-host-runtime-by-concern.md
+++ b/plan/issues/3103-split-runtime-ts-host-runtime-by-concern.md
@@ -1,0 +1,123 @@
+---
+id: 3103
+title: "Split src/runtime.ts (15,032 LOC) host runtime by concern; decompose resolveImport (6,517-line function)"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: high
+horizon: l
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: refactor
+area: runtime
+language_feature: compiler-internals
+goal: maintainability
+related: [1172, 3102, 3104]
+---
+
+# #3103 — Split `src/runtime.ts` by concern
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+`src/runtime.ts` is **15,032 LOC** in one file (266 top-level declarations),
+mixing at least eight concerns. The core offender is `resolveImport`
+(L7560–~L14076): a **6,517-line function** — one `switch (intent.type)` with 36
+cases (`string_literal`, `math`, `console_log`, `string_method`,
+`extern_class`, `builtin`, `callback_maker`, `await`, `dynamic_import`,
+`typeof_check`, `box`/`unbox`, `extern_get`/`extern_set`, `host_eq`,
+`date_*`, `node_*`, `timer_*`, `jsx_runtime`, `proxy_create`, …), each case a
+50–800-line inline closure. Other measured clusters:
+
+| Cluster                                               | approx. size | anchors                                                                                                      |
+| ----------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------ |
+| `resolveImport` intent dispatch                       | 6,517        | L7560                                                                                                        |
+| Iterator-helper polyfills                             | 792          | `_installIteratorHelperPolyfills` L744                                                                       |
+| Host wrapping layer                                   | ~700         | `_wrapForHost` L5640, `_wrapCallableForHost` L6009, `_wrapVecForHost` L5522, `_wrapWasmClosure*` L2013/L2110 |
+| ToPrimitive / coercion                                | ~500         | `_toPrimitive` L2924, `_hostToPrimitive` L3224, `_wasmToPlain` L3623                                         |
+| Sidecar property store + safe get/set                 | ~600         | `_safeSet` L4645, `_safeGet` L4502, descriptor helpers L1723+                                                |
+| WASI polyfill                                         | ~300         | `buildWasiPolyfill` L14279                                                                                   |
+| Public instantiation API                              | ~400         | `buildImports` L14559, `wrapExports` L14812, `instantiateWasm*` L14941+                                      |
+| Legacy RegExp statics, proxy bridge, generators proto | ~400         | L4367, L6322, L413/L553                                                                                      |
+
+Growth: +1,073 LOC in the last 12 days alone. 92 `as any` casts (highest
+count in src/).
+
+## Why this is the SAFEST big split available
+
+`src/runtime.ts` is **host-side JS**, not codegen — it is not in the Wasm emit
+path at all. Splitting it cannot change a single emitted byte _by
+construction_; `scripts/prove-emit-identity.mjs` is not even needed (run it
+once anyway as a belt-and-braces check — it must trivially pass). The real
+guardrails are the vitest suite (the 793 test files that call
+`instantiateWasm`/`buildImports` exercise this module heavily) and test262
+host-mode in CI.
+
+## Target structure
+
+Keep `src/runtime.ts` as the public entry (re-export barrel — the `/runtime`
+package export path and `buildImports`/`buildStringConstants`/
+`buildWasiPolyfill`/`instantiateWasm`/`instantiateWasmStreaming`/
+`compileAndInstantiate`/`wrapExports` signatures must not change). Move
+implementation into `src/runtime/`:
+
+```
+src/runtime/
+  sidecar.ts          — WeakMap sidecar store, _safeGet/_safeSet, descriptors
+  wrap-host.ts        — _wrapForHost/_wrapCallableForHost/_wrapVecForHost/_wrapWasmClosure*
+  to-primitive.ts     — _toPrimitive/_hostToPrimitive/_wasmToPlain
+  polyfills.ts        — iterator-helper polyfills, generator prototypes, legacy RegExp statics
+  wasi-polyfill.ts    — buildWasiPolyfill
+  instantiate.ts      — buildImports, wrapExports, instantiateWasm*, checkPolicy
+  imports/
+    index.ts          — resolveImport: intent.type -> handler-map dispatch
+    strings.ts        — string_literal/string_method/string statics
+    console.ts        — console_log variants
+    extern.ts         — extern_class/extern_get/extern_set/builtin
+    equality.ts       — host_eq/host_loose_eq/host_add/host_compare/same_value_zero
+    date-timers.ts    — date_*/timer_*
+    node.ts           — node_builtin/node_dirname/node_filename/node_builtin_fn/web_storage
+    async.ts          — await/callback_maker/getter_callback_maker/dynamic_import
+    misc.ts           — typeof_check/box/unbox/truthy_check/jsx_runtime/proxy_create/declared_global
+```
+
+`resolveImport` becomes a lookup in
+`Record<ImportIntent["type"], (intent, deps, callbackState, sandbox, state) => Function>`
+merged from the per-file handler maps — each case body moves verbatim.
+
+## Incremental steps (each its own PR-able commit)
+
+1. Extract leaf utilities with no intra-file cycles (`sidecar.ts`,
+   `to-primitive.ts`) — the closures inside `resolveImport` call these; pass
+   them via imports (they are module-scope today, so plain `import` works).
+2. Extract `wrap-host.ts`, `polyfills.ts` (depend on 1).
+3. Extract `wasi-polyfill.ts`, `instantiate.ts`.
+4. Convert `resolveImport` switch → handler map **in place** (same file), one
+   `case` = one map entry, verbatim bodies. Full test run.
+5. Move handler groups to `src/runtime/imports/*.ts`, one group per commit.
+6. Leave `src/runtime.ts` as re-exports; verify the package `exports` map and
+   `runtime-instantiate.ts`/`runtime-eval.ts` imports still resolve.
+
+Watch for: module-scope mutable state (`_nodeRequire` memo, legacy RegExp
+state, instance-state maps) — keep each piece of state in exactly one module
+and import accessors; never duplicate the state cell in two modules.
+
+## Estimated LOC delta
+
+Net ~0 (motion) minus dedup of the two closure-iterable drainers (#1849
+documents `runtime.ts:1626` vs `:1720`) and repeated coercion preambles ≈
+**−300 to −500**; `runtime.ts` 15,032 → <500 barrel + ~14k spread across
+~15 focused modules, largest ~1,500.
+
+## Acceptance criteria
+
+1. Full vitest suite green; test262 CI shows no regression (net_per_test ≥ 0).
+2. `src/runtime.ts` < 600 LOC (barrel + module docs); no new module > 2,000 LOC.
+3. Public API (`/runtime` entry) unchanged — verified by existing import sites
+   in tests and `src/index.ts`.
+4. `prove-emit-identity check` trivially passes (belt-and-braces).
+5. #3102's baseline updated (banked shrinkage) if it has landed.

--- a/plan/issues/3104-split-codegen-index-into-subsystem-modules.md
+++ b/plan/issues/3104-split-codegen-index-into-subsystem-modules.md
@@ -1,0 +1,110 @@
+---
+id: 3104
+title: "Re-split codegen/index.ts (16,566 LOC, regrown 2.6x) into subsystem modules; driver-only index"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: high
+horizon: l
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+depends_on: [2710]
+related: [1013, 1172, 3102, 3106]
+---
+
+# #3104 — Re-split `src/codegen/index.ts` into subsystem modules
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+`src/codegen/index.ts` is **16,566 LOC** — the #1013 split (done 2026-04-14,
+14,344 → 6,368) has fully regrown and overshot (+2,187 LOC in the last 12 days
+alone). It is simultaneously the module driver and a dumping ground for six
+unrelated subsystems. Measured regions (current main, line anchors from the
+top-level function map):
+
+| Region                                                | Lines       | Size       | Anchors                                                                                                                                                                                                             |
+| ----------------------------------------------------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IR-overlay glue (lattice→IR typing, overlay planning) | ~534–1683   | ~1,150     | `latticeToIr`, `buildIrClassShapes`, `planIrOverlay`                                                                                                                                                                |
+| Driver                                                | 1683–2986   | ~1,300     | `generateModule` (965 lines), `assertNoLeakedHostImports`, `addWasiStartExport`                                                                                                                                     |
+| Export emitters                                       | 2986–6884   | **~3,900** | `emitStructFieldGetters/Setters`, `emitIteratorMethodExport`, `emitToPrimitiveMethodExport(s)`, `emitClosureCallExport{1..N}`, `emitIsClosureExport`, `_emitVecAccessExportsInner` (629), `emitDataViewByteExports` |
+| Multi-module driver + console imports                 | 6884–7377   | ~490       | `generateMultiModule`                                                                                                                                                                                               |
+| WASI runtime helpers                                  | 7377–9684   | **~2,300** | `registerWasiImports` (550), `emitWasi*`, `ensureWasi*`, `buildWasiStringEncodeToScratch`                                                                                                                           |
+| Late-import collect/add suites                        | 9685–12894  | **~3,200** | `collect{String,Math,Parse,Promise,Json,Callback,Generator,FunctionalArray,Union,Iterator}Imports`, `addStringImports`, `addUnionImports`, `addUnionImportsAsNativeFuncs` (945)                                     |
+| Type registry                                         | 12895–13840 | ~950       | `getOrRegisterTupleType`, `resolveWasmType` (313), `ensureStructForType` (347)                                                                                                                                      |
+| Extern-class registry                                 | 13841–15525 | ~1,690     | `registerBuiltinExternClasses` (~400), `collectExternDeclarations`, `collectDeclaredGlobals`                                                                                                                        |
+| Hoisting / TDZ scan                                   | 15526–16363 | ~840       | `hoistVarDeclarations`, `walkStmtForVars`, `walkStmtForLetConst`, `hoistLetConstWithTdz`                                                                                                                            |
+| String-literal cache + modifier predicates            | 16363–16566 | ~200       | `cacheStringLiterals`, `hasExportModifier` …                                                                                                                                                                        |
+
+Consequences: every leaf module that imports one helper from `./index.js`
+pulls the 16.5k-line driver into its dependency graph; unrelated subsystems
+share one file's merge-conflict surface (this file is the top conflict site in
+`[CONFLICT]` tasks); and the late-import region hosts the index-shift bug
+class (#2710's target).
+
+## Target structure
+
+`src/codegen/index.ts` keeps ONLY: `generateModule`, `generateMultiModule`,
+the IR-overlay glue, and re-exports (one deprecation cycle). Moves:
+
+```
+src/codegen/wasi/helpers.ts          <- WASI region (~2,300)  [self-contained; imports registry]
+src/codegen/registry/late-import-suites.ts <- collect*/add*Imports (~3,200)
+src/codegen/registry/type-resolve.ts <- tuple/struct/wasm-type resolution (~950)
+src/codegen/extern-registry.ts       <- extern-class + declared-globals (~1,690)
+src/codegen/emit-exports.ts          <- export emitters (~3,900)
+src/codegen/hoist-scan.ts            <- hoisting/TDZ scanning (~840)
+src/codegen/builtins-tables.ts       <- STRING_METHODS, MATH_HOST_METHODS_*, KNOWN_CONSTRUCTORS, FUNCTIONAL_ARRAY_METHODS, WASI_* consts
+```
+
+This is #1172 Slices A/B/H re-grounded on the 2026-07-09 tree (the old line
+numbers are all stale; region boundaries above are current).
+
+## Safety story (byte-identity provable)
+
+Pure code MOTION: no function body changes, no reordering of emission. Proof
+protocol per region move:
+
+1. `npx tsx scripts/prove-emit-identity.mjs` (golden baseline) on the branch
+   BEFORE the move.
+2. Move one region; keep `index.ts` re-exporting the moved names (zero import
+   churn in the same commit; migrate importers in a follow-up commit).
+3. `npx tsx scripts/prove-emit-identity.mjs check` — must print IDENTICAL.
+4. `npx tsc --noEmit` + scoped vitest.
+
+One region per commit; any drift pinpoints the exact move that broke.
+Watch for module-scope state in the moved regions (memo Maps, counters):
+each state cell must move with its region, never be duplicated.
+
+**Ordering constraint / #2710:** the late-import suite region
+(`addUnionImports`, `addStringImports`, the in-place `shiftFuncIndices`
+blocks) is exactly what #2710 (late-bind module indices, in-progress) is
+rewriting. Do NOT move that region while #2710 is in flight — sequence this
+issue's region moves so `registry/late-import-suites.ts` lands AFTER #2710's
+producer-file slices, or coordinate with the #2710 owner. All other regions
+(WASI, extern registry, export emitters, hoist scan, type registry) are safe
+to move now.
+
+## Estimated LOC delta
+
+Net ≈ 0 (motion) − duplicate-block dedup opportunities inside the moved
+regions (index.ts has 1,594 lines inside duplicated 8-line windows — the
+`emitClosureCallExport{1,2,3,4}` family and getter/setter emitters are
+near-copies) ≈ **−400 to −800** in follow-ups. `index.ts` 16,566 → ~2,700.
+
+## Acceptance criteria
+
+1. `prove-emit-identity check` IDENTICAL after every region-move commit.
+2. `index.ts` < 3,000 LOC; no new module > 4,000 LOC.
+3. All moved names re-exported from `codegen/index.ts` for one cycle
+   (`@deprecated` JSDoc pointing at the new home).
+4. test262 CI: no regression.
+5. #3102 baseline updated (if landed).

--- a/plan/issues/3105-emit-idiom-builder-library-dedupe-instruction-scaffolds.md
+++ b/plan/issues/3105-emit-idiom-builder-library-dedupe-instruction-scaffolds.md
@@ -1,0 +1,108 @@
+---
+id: 3105
+title: "Emit-idiom builder library: dedupe repeated Wasm instruction scaffolds (throw-guard x17, counter-loop x21, proxy-guard x12, hash-probe x10)"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: high
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1849, 3104, 3108]
+---
+
+# #3105 — Emit-idiom builders: dedupe repeated instruction scaffolds
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+A windowed duplicate scan (8-line normalized windows, non-trivial only) over
+`src/` finds **21,389 lines (6.9% of 309k)** inside duplicated blocks. The
+top duplicated content is not business logic — it is hand-rolled Wasm
+instruction _scaffolds_, re-typed at each site. Named idioms with verified
+locations:
+
+| Idiom                                                                                                                                 | Copies          | Locations (sample)                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Throw-error guard** — `addStringConstantGlobal(msg)` + `ensureExnTag` + `{op:"if", then:[...stringConstantExternrefInstrs, throw]}` | ×17 in one file | `expressions/calls.ts:11253, 11356, 11455, 15600, …`                                                                                                                          |
+| **Counter-loop scaffold** — `block/loop` + `local.get i` / bound / `br_if` / body / `i+1` / `br 0`                                    | ×12 + ×9 + ×9   | `array-methods.ts:2338, 2425, 2568, 2690, …`; `json-runtime.ts:192, 343, 521, 602`; `json-codec-native.ts:1532+`                                                              |
+| **Proxy guard** — `local.get 0` / `any.convert_extern` / `ref.test $proxy` / `if`                                                     | ×12             | `object-runtime.ts:8211, 8233, 8260, 8288, …`                                                                                                                                 |
+| **Hash-probe advance** — `idx+1 % cap` open-addressing step                                                                           | ×10             | `codegen-linear/runtime.ts:2182, 2281, 2304, 2372, 2396, …` (map/set/numeric-map/numeric-set runtimes are 4 near-copies; the file is **24% duplicated lines**, worst in src/) |
+| **Long duplicated param lists** — `(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, …)`                                      | ×24             | `array-methods.ts:3694, 3833, 4143, 4248, …`                                                                                                                                  |
+
+Supporting counts: `addStringConstantGlobal` 186 sites,
+`stringConstantExternrefInstrs` 153 sites, `ensureExnTag` 85 sites across
+`src/codegen/`.
+
+Beyond LOC, hand-expanding these idioms is a bug surface: each copy re-derives
+branch depths and local indices by hand (the exact class of bug the peephole /
+stack-balance layers exist to catch).
+
+## Fix
+
+Create `src/codegen/emit-idioms.ts` (WasmGC) and
+`src/codegen-linear/emit-idioms.ts` (linear — backends stay separate per
+#1527; the _builders_ are per-backend, only genuinely rep-independent helpers
+may live in a shared file):
+
+```ts
+// returns the exact instruction sequence the sites hand-roll today
+throwErrorIfInstrs(ctx, cond: Instr[], msg: string, errorKind): Instr[]
+counterLoopInstrs(opts: {i: LocalIdx; bound: Instr[]; body: Instr[]; step?: number}): Instr[]
+proxyGuardInstrs(ctx, paramIdx: number, thenBody: Instr[]): Instr[]
+// linear:
+hashProbeAdvanceInstrs(idxLocal, capLocal): Instr[]
+```
+
+Plus one params-object type for the ×24 duplicated array-method signature
+(`interface VecCallSite { propAccess; callExpr; vecTypeIdx; arrTypeIdx; … }`).
+
+**Migration is per-idiom, per-file slices**: replace each hand-rolled copy
+with the builder call; the builder must return the byte-identical sequence
+(same ops, same operand order, same blockType).
+
+## Safety story (byte-identity provable)
+
+This is the canonical use case for `scripts/prove-emit-identity.mjs`:
+
+1. Baseline before each slice.
+2. Replace N copies of ONE idiom in ONE file.
+3. `check` must print IDENTICAL — any deviation (e.g. a copy that had locally
+   diverged) fails loudly; a diverged copy is then EXCLUDED from that slice
+   and documented (divergence is either a latent bug → file separately, or an
+   intentional variant → parameterize).
+4. `tsc --noEmit` + scoped vitest per slice.
+
+The linear-backend slices need coverage too: **first slice of this issue adds
+`linear` to the `TARGETS` matrix in `scripts/prove-emit-identity.mjs`** (the
+script currently proves gc/standalone/wasi only — measured 2026-07-09).
+
+## Estimated LOC delta
+
+Throw-guard ~17×10 + counter-loop ~30×12 + proxy-guard ~12×15 + hash-probe
+~10×10 + param-object ≈ **−1,200 to −1,800 LOC** in the first wave; the
+builders also stop the idioms from re-multiplying (compounding with #3102).
+
+## Dependencies / coordination
+
+- Independent of #2710 (no index-representation change; builders return
+  literal Instr arrays).
+- #1849 lists _diverged_ copy-paste (super-dispatch, closure drainers,
+  `resolveVec`, `__extern_has`) — keep it separate: this issue targets
+  _identical_ scaffolds provable byte-identical; #1849's diverged copies need
+  semantic reconciliation first.
+
+## Acceptance criteria
+
+1. `prove-emit-identity check` IDENTICAL per slice (incl. `linear` target once added).
+2. ≥ 40 hand-rolled idiom copies replaced by builder calls.
+3. `codegen-linear/runtime.ts` duplicated-line ratio drops below 15% (from 24%).
+4. No test262 regression.

--- a/plan/issues/3106-host-import-signature-registry.md
+++ b/plan/issues/3106-host-import-signature-registry.md
@@ -1,0 +1,118 @@
+---
+id: 3106
+title: "Central host-import signature registry: kill 514 inline ensureLateImport signature re-declarations"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+depends_on: [2710]
+related: [3104, 1839]
+---
+
+# #3106 — Host-import signature registry
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+`ensureLateImport(ctx, name, params, results)` has **514 call sites** across
+`src/codegen/` (calls.ts 134, property-access.ts 52, new-super.ts 34,
+array-methods.ts 32, assignment.ts 29, index.ts 27, object-ops.ts 22, …).
+Each site re-declares the import's Wasm signature inline:
+
+```ts
+const externGetIdx = ensureLateImport(
+  ctx,
+  "__extern_get",
+  [{ kind: "externref" }, { kind: "externref" }],
+  [{ kind: "externref" }],
+);
+flushLateImportShifts(ctx, fctx);
+```
+
+There are **1,463 `__extern_*` textual references** across 51 files for ~20
+distinct import names (`__extern_get` 481, `__extern_set` 218,
+`__extern_get_idx` 140, `__extern_length` 113, `__extern_is_undefined` 109,
+`__extern_method_call` 69, `__extern_has` 59, …). Consequences:
+
+1. **Signature drift is unchecked** — two sites can (and historically did)
+   declare different signatures for the same import name; whichever runs first
+   wins, the second gets a mismatched funcIdx. Nothing diffs them.
+2. ~5 lines of boilerplate × 514 sites ≈ 2,500 LOC of pure re-declaration.
+3. The paired `flushLateImportShifts` call is easy to forget (a known bug
+   pattern in the late-import family, see #1839 and the #2710 catalogue).
+
+## Fix
+
+Single typed table + thin wrapper in `src/codegen/registry/imports.ts` (the
+registry module already exists — 417 LOC):
+
+```ts
+export const HOST_IMPORT_SIGS = {
+  __extern_get: { params: [EXTERNREF, EXTERNREF], results: [EXTERNREF] },
+  __extern_set: { params: [EXTERNREF, EXTERNREF, EXTERNREF], results: [] },
+  __extern_length: { params: [EXTERNREF], results: [F64] },
+  // … every recurring name, harvested mechanically from the 514 sites
+} as const satisfies Record<string, HostImportSig>;
+
+export function ensureKnownImport(
+  ctx: CodegenContext,
+  fctx: FunctionContext | null,
+  name: keyof typeof HOST_IMPORT_SIGS,
+): number | undefined {
+  const s = HOST_IMPORT_SIGS[name];
+  const idx = ensureLateImport(ctx, name, s.params, s.results);
+  if (fctx !== undefined) flushLateImportShifts(ctx, fctx); // preserve today's pairing
+  return idx;
+}
+```
+
+Migration: mechanical, per-file — each
+`ensureLateImport(ctx, "<known name>", […], […])` + adjacent
+`flushLateImportShifts` pair becomes one `ensureKnownImport` call.
+**Harvest step first**: script-extract all 514 (name, params, results)
+triples; any name with >1 distinct signature is a **finding** (latent bug) —
+report it, do not silently unify (behavior-preservation rule).
+One-off names with a single site can stay on raw `ensureLateImport`.
+
+## Safety story
+
+Byte-identity provable: the wrapper performs the identical
+`ensureLateImport` + `flushLateImportShifts` sequence with identical
+arguments, so import order and indices are unchanged.
+`scripts/prove-emit-identity.mjs` baseline → migrate one file → `check`
+IDENTICAL → next file. Sites where today's code does NOT call
+`flushLateImportShifts` after `ensureLateImport` must use a no-flush variant
+(`ensureKnownImportNoFlush`) — do NOT add flush behavior during migration
+(that changes shift timing and can move indices).
+
+## Dependencies
+
+**Hard dependency on #2710 sequencing**: #2710 (in-progress) is re-plumbing
+late-import index resolution (`late-imports.ts`, `registry/imports.ts`).
+Land this AFTER #2710's producer slices to avoid double-churn in the same
+files — the registry table is then also the natural single place for #2710's
+handle-based resolution to hook into.
+
+## Estimated LOC delta
+
+≈ **−1,800 to −2,200** (4–5 lines saved × ~450 migratable sites), plus the
+type-checked `keyof` closing the signature-drift bug class.
+
+## Acceptance criteria
+
+1. Harvest report: every recurring import name has exactly ONE signature (or
+   discrepancies filed as separate bugs).
+2. `prove-emit-identity check` IDENTICAL per migrated file.
+3. ≥ 400 of the 514 sites migrated; remaining raw sites are single-use names.
+4. No test262 regression.

--- a/plan/issues/3107-as-instr-cast-elimination-codemod.md
+++ b/plan/issues/3107-as-instr-cast-elimination-codemod.md
@@ -1,0 +1,91 @@
+---
+id: 3107
+title: "Cast-debt codemod: eliminate 10,678 'as Instr' + 129 'as unknown as Instr' + shrink 579 'as any'"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: medium
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1095, 1172, 3105]
+---
+
+# #3107 — Cast-debt codemod (`as Instr` epidemic)
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured, current main)
+
+#1095 eliminated the `as unknown as Instr` double-casts, but the single-cast
+form has since exploded:
+
+| Pattern                         | Count      | Top files                                                                                                                |
+| ------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `as Instr` (single assert)      | **10,678** | builtins.ts 1,027 · index.ts 996 · array-methods.ts 869 · dataview-native.ts 839 · calls.ts 472 · property-access.ts 380 |
+| `as Instr[]`                    | 104        | object-runtime 14, index 11, any-helpers 11                                                                              |
+| `as unknown as Instr` (regrown) | 129        | —                                                                                                                        |
+| `as unknown as` (all types)     | 341        | —                                                                                                                        |
+| `as any`                        | 579        | runtime.ts 92 · fixups.ts 60 · stack-balance.ts 59 · calls.ts 39                                                         |
+
+Sample (representative — the op IS in the `Instr` union, the cast is
+cargo-cult): `fctx.body.push({ op: "extern.convert_any" } as Instr)`,
+`wasmOut.push({ op: "any.convert_extern" } as Instr)` (`ir/lower.ts:2826`).
+
+Why it matters: `as Instr` **suppresses excess-property and discriminant
+checking** — a typo'd field (`typeIdx` vs `typeidx`) or a field from the
+wrong variant silently type-checks and becomes a runtime emit bug. CLAUDE.md's
+own guidance ("the `Instr` union now covers every emitted opcode … `as Instr`
+single-assertions remain for the few computed-`op` sites") is contradicted by
+10.6k sites — this is exactly the drift the emitter's `never` exhaustiveness
+check was meant to prevent.
+
+## Fix (mechanical, phased)
+
+1. **Codemod**: strip `as Instr` / `as Instr[]` / `as unknown as Instr` where
+   the expression is an object/array literal with a constant `op` string —
+   a regex-assisted or ts-morph pass. One file (or file-cluster) per commit.
+2. `npx tsc --noEmit` after each file: three outcomes per site —
+   - compiles clean → cast was pure noise, done;
+   - **contextual-typing gap** (e.g. literal built in a `const` then pushed):
+     add `satisfies Instr` or type the variable `const x: Instr = …` — keeps
+     the check, drops the assertion;
+   - **genuine type error surfaced** → STOP for that site: record it in the
+     PR description, keep the cast, and file a bug. Do NOT "fix" emit logic
+     inside this refactor (behavior-preservation rule).
+3. Computed-`op` sites (op chosen at runtime) keep a documented cast — target
+   end-state ≤ ~50 asserted sites, each with a `// computed-op` comment.
+4. `as any` shrink is a stretch goal, scoped to `fixups.ts`/`stack-balance.ts`
+   walker typing (use `instrChildren`-style typed accessors from #1172 C3 if
+   landed); runtime.ts `as any` is host-JS interop and mostly legitimate.
+
+## Safety story
+
+Type assertions are **erased at compile time** — removing one cannot change
+the emitted JS, so the compiled compiler behaves identically as long as tsc
+passes. Byte-identity: trivially preserved; still run
+`prove-emit-identity check` once per batch as the cheap invariant. Danger is
+only in step-2c (surfaced real errors) — the protocol above quarantines those
+instead of hot-fixing them.
+
+## Estimated LOC delta
+
+≈ **−0 LOC** direct (casts are intra-line) but −10k assertion sites; real
+value is restoring compile-time checking to every instruction literal.
+Follow-on: newly-visible dead branches and mis-typed fields get their own
+issues.
+
+## Acceptance criteria
+
+1. `grep -rc 'as Instr' src` < 200 (from 10,782 incl. arrays).
+2. Zero new `as unknown as Instr`.
+3. Every retained cast has a `// computed-op` or `// TODO(#bug)` marker.
+4. `tsc --noEmit` clean, full vitest green, no test262 regression.
+5. Surfaced-real-error list attached to the PR (even if empty).

--- a/plan/issues/3108-decompose-giant-helper-emitter-functions.md
+++ b/plan/issues/3108-decompose-giant-helper-emitter-functions.md
@@ -1,0 +1,104 @@
+---
+id: 3108
+title: "Decompose giant runtime-helper emitter functions (ensureObjectRuntime 6,960; ensureNativeStringHelpers 4,851; ensureAnyHelpers 1,815; ensureProxyRuntime 1,273)"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: l
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [3104, 3105, 3114]
+---
+
+# #3108 — Decompose the giant `ensure*` runtime-emitter functions
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+The standalone runtime is emitted by a handful of monolithic functions that
+define dozens of Wasm helper functions each, in one linear body:
+
+| Function                    | Size            | File                                 |
+| --------------------------- | --------------- | ------------------------------------ |
+| `ensureObjectRuntime`       | **6,960 lines** | `src/codegen/object-runtime.ts:176`  |
+| `ensureNativeStringHelpers` | **4,851 lines** | `src/codegen/native-strings.ts:215`  |
+| `ensureAnyHelpers`          | 1,815 lines     | `src/codegen/any-helpers.ts:846`     |
+| `ensureProxyRuntime`        | 1,273 lines     | `src/codegen/object-runtime.ts:7270` |
+| `ensureRegexRun`            | 1,098 lines     | `src/codegen/native-regex.ts:251`    |
+
+`object-runtime.ts` (9,726 LOC, **+1,892 in the last 12 days**, 10%
+duplicated lines) and `native-strings.ts` (7,880 LOC, 12% duplicated) are the
+#4 and #7 largest files in src/. Inside these bodies, helper definitions are
+closures over dozens of shared locals (`anyStrTypeIdx`, flag constants,
+`emitHasOwn`-style local lambdas), so ADDING one helper means scrolling a 7k-
+line function to find the right insertion point — and the insertion point
+MATTERS because function-index assignment follows emission order.
+
+## Fix — mechanical section extraction, order-preserving
+
+Do NOT redesign the runtime. Split each monolith into per-concern emitter
+functions that the original calls **in the exact same order**:
+
+```
+object-runtime.ts        (orchestrator: ensureObjectRuntime — dep preamble +
+                          ordered calls + returns ObjectRuntimeTypes)
+object-runtime/
+  props-core.ts          — $Object struct, key classify/match, get/set/has/delete
+  descriptors.ts         — defineProperty/getOwnPropertyDescriptor/flags
+  integrity.ts           — freeze/seal/preventExtensions predicates + setters
+  enumeration.ts         — keys/values/entries/for-in order
+  wrappers.ts            — primitive-wrapper helpers
+  proxy.ts               — ensureProxyRuntime (already a separate function)
+```
+
+(analogous split for `native-strings.ts`: core flatten/equals/compare,
+concat/slice family, encode/decode, anyToString.)
+
+Shared state between sections travels in ONE explicit context object built at
+the top (`interface ObjectRuntimeEmit { anyStrTypeIdx; nativeStrTypeIdx;
+propsTypeIdx; …; emitHasOwn(name): void }`) — this makes today's implicit
+closure-capture graph visible and greppable.
+
+## Safety story (byte-identity provable — this is the critical part)
+
+Function indices in the emitted module depend on **definition order**. The
+refactor must preserve the exact sequence of `ctx.mod.functions.push` /
+`funcMap.set` calls. Protocol:
+
+1. `prove-emit-identity.mjs` golden baseline (all targets — these emitters
+   run mainly under `standalone`/`wasi`, which the matrix covers).
+2. Extract ONE section into a function called at the same position; shared
+   locals become fields of the emit-context object; commit.
+3. `check` → IDENTICAL required. Because helper emission order is the exact
+   bug surface here, any accidental reorder fails the hash immediately.
+4. Repeat per section (~6 commits per monolith).
+
+The corpus caveat: `website/playground/examples` (13 files) may not exercise
+every helper; before starting, extend the proof corpus with
+`--root tests/standalone-corpus` (a new directory of ~20 small .ts probes
+that force object-runtime/string-helper emission — Object.keys/freeze/
+defineProperty/Proxy/string concat+compare in standalone mode). The corpus
+addition is part of this issue's slice 0.
+
+## Estimated LOC delta
+
+Net ≈ 0 (motion); dedup of the repeated guard/scaffold blocks inside
+(object-runtime has 1,014 duplicated-window lines; proxy guard idiom alone is
+×12 — coordinate with #3105 builders) ≈ **−500 to −900** follow-up. Files:
+object-runtime.ts 9,726 → orchestrator ~600 + 6 modules ≤ 2,000 each.
+
+## Acceptance criteria
+
+1. `prove-emit-identity check` IDENTICAL per extraction commit (with extended corpus).
+2. No single emitter function > 1,500 lines afterwards.
+3. Emit-order documented: orchestrator body reads as an ordered call list.
+4. No test262 regression (standalone shard especially).

--- a/plan/issues/3109-test-helper-consolidation-compileandrun.md
+++ b/plan/issues/3109-test-helper-consolidation-compileandrun.md
@@ -1,0 +1,82 @@
+---
+id: 3109
+title: "Test-helper consolidation: 132 test files re-declare compileAndRun (10+ signature variants) across 292k test LOC"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: m
+feasibility: easy
+model: opus
+reasoning_effort: medium
+task_type: refactor
+area: tests
+language_feature: compiler-internals
+goal: maintainability
+related: [3102]
+---
+
+# #3109 — Consolidate duplicated test harness helpers
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+`tests/` is 1,923 files / **292,655 LOC** — comparable to src/ itself — with
+no shared compile-and-run harness:
+
+- **132 test files define their own local `compileAndRun`**, in at least 10
+  divergent signatures (`(source: string)` ×34, `: Promise<Record<string,
+Function>>` ×13, `: Promise<any>` ×11, `: Promise<number>` ×9, result-object
+  variants ×6, …).
+- **793 test files** hand-roll the `compile(...)` → `buildImports`/
+  `instantiateWasm` → export-call sequence inline.
+- `tests/helpers/` exists but contains only `ir-fallbacks.ts` (19 LOC).
+
+Each local copy re-implements the same 10–30 lines (compile, instantiate,
+maybe setExports wiring for host closures — a known trap, see memory
+`project_wrapforhost_setexports_harness`), and behavioral drift between
+copies means two tests can disagree on what "run" means (e.g. whether
+`callbackState.getExports` is wired), which produces confusing
+false-negative repros.
+
+## Fix
+
+1. Add `tests/helpers/compile.ts` with the ~4 canonical shapes:
+
+```ts
+export async function compileAndInstantiate(src: string, opts?: CompileOpts): Promise<WebAssembly.Exports>;
+export async function compileAndRun(src: string, entry = "main", opts?: CompileOpts): Promise<unknown>;
+export async function compileAndRunStandalone(src: string, entry?: string): Promise<unknown>;
+export async function compileExpectError(src: string): Promise<{ errors: string[] }>;
+```
+
+— implemented ONCE on top of `src/runtime.ts` `instantiateWasm`, with the
+setExports/callbackState wiring done correctly by default. 2. Migrate mechanically, in batches of ~20 files per commit: delete the local
+helper, import the shared one. **Only migrate files whose local copy is
+semantically equivalent to a canonical shape** — a file whose helper does
+something extra (custom import stubs, wasi polyfill knobs) keeps its local
+helper (or passes the extra via `opts`). 3. New-test guidance: one line in `tests/README` (or CLAUDE.md tests section)
+pointing at the helper.
+
+## Safety story
+
+Zero compiler-source changes — emitted Wasm untouched by construction. The
+risk is _test semantics drift_ during migration; guard: each batch must keep
+every migrated test green with **unchanged assertions** (vitest run scoped to
+the batch). A test that fails after migration reveals its local helper was
+NOT equivalent → revert that file from the batch and leave it local.
+
+## Estimated LOC delta
+
+≈ **−2,000 to −3,500** in tests/ (15–25 lines × 132 files, plus partial
+adoption by the 793 inline sites in new/touched tests). More valuable:
+one correct harness for host-closure wiring.
+
+## Acceptance criteria
+
+1. `tests/helpers/compile.ts` exists; ≥ 100 of the 132 local definitions removed.
+2. Full vitest suite green with unchanged assertions.
+3. No src/ changes in the PR(s).

--- a/plan/issues/3110-dead-export-sweep.md
+++ b/plan/issues/3110-dead-export-sweep.md
@@ -1,0 +1,80 @@
+---
+id: 3110
+title: "Dead-code sweep: 128 exported symbols referenced nowhere else in src/tests/scripts"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: s
+feasibility: easy
+model: opus
+reasoning_effort: medium
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1172, 3102]
+---
+
+# #3110 — Dead-export sweep
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+A cross-reference scan of all 1,440 named exports in `src/` against every
+`.ts` file in `src/`, `tests/`, and `scripts/` (textual name match — i.e.
+_over_-counting usage, so the dead list is conservative) finds **128 exported
+symbols referenced nowhere outside their defining file**. Top files:
+
+| File                                                                     | dead exports                                                                 |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `src/codegen/declarations.ts`                                            | 6                                                                            |
+| `src/codegen/native-proto.ts`                                            | 6                                                                            |
+| `src/codegen/regexp-standalone.ts`                                       | 6                                                                            |
+| `src/codegen/accessor-driver.ts`                                         | 5 (`CALL_ACCESSOR_GET/SET`, `CALL_REVIVER`, `CALL_TO_JSON`, `CALL_REPLACER`) |
+| `src/codegen/closures.ts`, `literals.ts`, `object-ops.ts`, `ir/nodes.ts` | 5 each                                                                       |
+
+Sample candidates: `buildDenoEnvDtsForSource` (checker/index.ts),
+`compileNestedAwait`/`emitAsyncStateMachineFromIr` (async-cps.ts),
+`emitUndefinedSingleton` (any-helpers.ts), `getFunctionOwnLocals`
+(binding-info.ts). Plus known-dead fields: `FunctionContext.hoistedFuncs`
+(#1172 Slice J, still present).
+
+Dead exports are not just noise — each one keeps its transitive callee graph
+alive through treeshake/DCE review and misleads greps during debugging
+("who calls this? …nobody").
+
+## Fix
+
+1. Re-verify each candidate mechanically at implementation time (the audit
+   list is a snapshot): confirm no reference via `export *` barrels
+   (`src/ir/index.ts` has 8 `export *` lines) and no public-API exposure via
+   `src/index.ts` / package `exports` (anything re-exported to consumers is
+   NOT dead regardless of internal use — skip it).
+2. Delete in batches by area: first demote `export` → module-private
+   (`tsc --noEmit` then proves in-file usage or none), then delete the truly
+   unreferenced along with now-orphaned callees.
+3. Include the dead-field sweep (`hoistedFuncs` etc.) as a final commit.
+
+## Safety story
+
+`tsc --noEmit` + full vitest is sufficient: deleting an unreferenced symbol
+cannot change emitted Wasm (it was never called). Run
+`prove-emit-identity check` once per batch as the free invariant. Anything
+that turns out referenced (tsc error) simply stays.
+
+## Estimated LOC delta
+
+≈ **−1,000 to −2,500** (128 symbols plus orphaned private callees; several
+are 50+-line functions).
+
+## Acceptance criteria
+
+1. ≤ 20 of the 128 candidates remain exported (each with a written reason —
+   public API, test-only fixture, upcoming consumer).
+2. `tsc --noEmit` clean; full vitest green; no test262 regression.
+3. `knip`/`ts-prune`-style scan (or the audit script) re-run in the PR shows
+   the residual count.

--- a/plan/issues/3111-decompose-compilecallexpression-call-shapes.md
+++ b/plan/issues/3111-decompose-compilecallexpression-call-shapes.md
@@ -1,0 +1,117 @@
+---
+id: 3111
+title: "Decompose compileCallExpression — a single 12,210-line function — into ordered call-shape modules"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: xl
+feasibility: hard
+model: fable
+reasoning_effort: max
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1172, 3102, 3105, 3112]
+---
+
+# #3111 — Decompose `compileCallExpression` (12,210-line function)
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+`src/codegen/expressions/calls.ts:4190–16400` — `compileCallExpression` is
+**12,210 lines**, the largest function in the codebase and growing fast
+(calls.ts overall: 15,292 → 17,246 LOC in the 12 days to 2026-07-09; the file
+is 17,246 LOC with 200 functions, 134 `ensureLateImport` sites, 65
+`ctx.standalone` branches). When #1172 audited it (2026-04-25) it was ~5,800
+lines — it has **more than doubled in 10 weeks**.
+
+It is one if-cascade dispatching on call shape (optional chain, RegExp, eval,
+dynamic import, super.method, builtin statics — Object/JSON/Math/Number/
+String/Date — array methods, `fn.bind().call()`, IIFE, element-access
+callee, conditional callee, closure calls, host-callable fallbacks …), each
+branch 50–800 lines mixing predicate logic, argument compilation,
+late-import registration, and body emission. Consequences: every new builtin
+lands another branch here (the growth data proves it); the branch ORDER is
+load-bearing and undocumented; and it is the top merge-conflict file among
+dev agents.
+
+## Why this is `feasibility: hard` (honest assessment)
+
+Unlike #3104/#3108 (pure motion), branches here share **mutable local state
+accumulated earlier in the function** (resolved receiver info, arg-count
+locals, memoized type lookups) and interleave `fctx.body` emission with
+predicate evaluation (a predicate that compiles a sub-expression to _inspect_
+it has already emitted code). A naive per-branch extraction breaks those
+data flows. This needs a design pass (fable), then mechanical execution.
+
+## Target structure
+
+```
+src/codegen/expressions/calls.ts        — dispatcher: ordered list of
+                                          tryCompileXxxCall(ctx, fctx, expr, shared) probes
+src/codegen/expressions/call-shapes/
+  optional-chain.ts
+  eval-dynamic-import.ts
+  super-calls.ts
+  builtin-statics.ts    (Object/JSON/Math/Number/String/Date statics)
+  bind-call-apply.ts
+  closure-calls.ts
+  host-fallback.ts
+  …
+```
+
+Contract per shape: `tryCompileXxxCall(...): InnerResult | NOT_THIS_SHAPE`,
+with the hard rule **a probe that declines MUST NOT have emitted into
+`fctx.body`** (predicate/emit separation). The `shared` parameter carries the
+formerly-function-local state, made explicit as a typed
+`CallSiteInfo` object built once at the top of the dispatcher.
+
+## Phasing (each phase independently mergeable + identity-proven)
+
+- **Phase 0 — corpus + baseline.** Extend `prove-emit-identity.mjs` corpus
+  with a `tests/call-shapes-corpus/` directory: ~40 small probes, one per
+  branch family (enumerate by reading the cascade top-down). Golden baseline.
+- **Phase 1 — peel from the TAIL.** The last branches in the cascade
+  (fallback paths) have the fewest state dependencies (everything before them
+  declined). Extract bottom-up: last branch → module; the cascade calls it.
+  `check` IDENTICAL per branch.
+- **Phase 2 — peel self-contained heads.** Branches that already start with a
+  cheap syntactic predicate and locally compute everything (e.g. the
+  `Math.*`/`JSON.*` static families — several already delegate to
+  `compileMathCall`/`tryEmitJsonStringifyPrimitive`) move next.
+- **Phase 3 — shared-state extraction.** Introduce `CallSiteInfo` for the
+  remaining entangled middle; move state reads onto it one field at a time.
+- **Phase 4 — enforce.** Add the per-function LOC ceiling for
+  `compileCallExpression` (#3102 slice 2) so the cascade cannot regrow.
+
+Any branch that cannot be extracted without changing emission order gets
+LEFT IN PLACE and documented — partial completion is acceptable; the
+dispatcher-with-modules shape is the goal, not 100% extraction.
+
+## Safety story
+
+`prove-emit-identity` per extracted branch, over the extended corpus, all
+targets. Additionally scoped vitest: `tests/` has extensive per-builtin
+call tests. Risk concentrates in Phase 3; Phases 0–2 are provable motion.
+If any phase can't prove identity, it stops there and re-plans — earlier
+phases still deliver value.
+
+## Estimated LOC delta
+
+Net ≈ 0 (motion) − duplicate throw-guard/arg-coercion scaffolds (calls.ts has
+1,261 duplicated-window lines; ×17 throw-guard idiom → #3105 builders) ≈
+**−600 to −1,000**; `compileCallExpression` 12,210 → dispatcher < 800.
+
+## Acceptance criteria
+
+1. IDENTICAL identity proof per extraction commit (extended corpus).
+2. `compileCallExpression` < 2,000 lines (stretch: < 800).
+3. Probe contract documented + enforced (decline ⇒ no emission) — add a
+   debug assertion on `fctx.body.length` around probes in dev builds.
+4. No test262 regression on any shard.

--- a/plan/issues/3112-decompose-member-access-binary-new-god-functions.md
+++ b/plan/issues/3112-decompose-member-access-binary-new-god-functions.md
@@ -1,0 +1,93 @@
+---
+id: 3112
+title: "Decompose the remaining lowering god-functions: compilePropertyAccess (3,183), compileBinaryExpression (3,015), compileNewExpression (2,930)"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: low
+horizon: xl
+feasibility: hard
+model: fable
+reasoning_effort: max
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+depends_on: [3111]
+related: [3102, 3105]
+---
+
+# #3112 — Decompose the remaining lowering god-functions
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+After `compileCallExpression` (#3111), the next tier of single-function
+monoliths, same shape-cascade disease:
+
+| Function                      | Size      | File                                        |
+| ----------------------------- | --------- | ------------------------------------------- |
+| `compilePropertyAccess`       | **3,183** | `src/codegen/property-access.ts:3458`       |
+| `compileBinaryExpression`     | **3,015** | `src/codegen/binary-ops.ts:253`             |
+| `compileNewExpression`        | **2,930** | `src/codegen/expressions/new-super.ts:2546` |
+| `coerceType`                  | 1,328     | `src/codegen/type-coercion.ts:1310`         |
+| `compileArrowAsClosure`       | 1,227     | `src/codegen/closures.ts:1818`              |
+| `compileDateMethodCall`       | 1,217     | `src/codegen/expressions/builtins.ts:1382`  |
+| `compileObjectDefineProperty` | 1,198     | `src/codegen/object-ops.ts:1287`            |
+
+(27 functions ≥ 1,000 lines exist in src/ total; this issue takes the
+lowering-cascade ones; #3108 takes the runtime-emitter ones.)
+
+`property-access.ts` also duplicates against `expressions/assignment.ts` (46
+duplicated 8-line windows — the read/write paths hand-copy the same
+receiver-resolution scaffolds), and `new-super.ts` contains the ~7×
+copy-pasted "emit typed default value" block plus the diverged
+`compileSuperMethodCall`/`compileSuperElementMethodCall` pair already
+catalogued in #1849.
+
+## Approach
+
+**Blocked on #3111 proving the pattern** (probe contract + `CallSiteInfo`
+shared-state object + tail-first peeling + identity-per-commit). Apply the
+identical recipe:
+
+- `compilePropertyAccess` → `property-shapes/` probes: builtin-proto reads,
+  native-string/array length fast paths, extern-class members, closed-struct
+  field access, dynamic `__extern_get` fallback. Shared
+  `MemberSiteInfo { receiverType, resolvedStruct, isOptional, … }`.
+  **Design win to evaluate (fable):** the read (property-access.ts) and write
+  (assignment.ts `compilePropertyAssignment`, 497 lines) paths should share
+  receiver-resolution probes — resolve-once, then read-or-write — which is
+  what eliminates the 46-window duplication class instead of just moving it.
+- `compileBinaryExpression` → operator-family modules (arith/compare/
+  equality/logical-assign/in-instanceof) — mostly already-clustered case arms;
+  nearest to pure motion of the three.
+- `compileNewExpression` → known-ctor table probes (builtin ctors, extern
+  classes, user classes, dynamic new) + fold the ×7 typed-default block into
+  the existing `defaultValueInstrs` helper (#1849 item, byte-identity
+  provable individually).
+
+## Safety story
+
+Same as #3111: extended identity corpus per shape family, IDENTICAL per
+commit, decline-means-no-emission probe contract, stop-and-document any
+branch that resists extraction. `coerceType` is on the list only for a
+cascade→table restructure IF provable; it is the most central function in
+codegen (every coercion flows through it) — lowest priority, highest care.
+
+## Estimated LOC delta
+
+Net ≈ 0 (motion) − shared receiver-resolution + typed-default dedup ≈
+**−500 to −900**. No function in the table above > 1,200 lines afterwards.
+
+## Acceptance criteria
+
+1. IDENTICAL identity proof per extraction commit.
+2. `compilePropertyAccess`, `compileBinaryExpression`, `compileNewExpression`
+   each < 1,200 lines.
+3. Read/write receiver-resolution sharing evaluated with a written decision
+   (do/don't + why) even if not implemented.
+4. No test262 regression.

--- a/plan/issues/3113-ir-codegen-layering-shared-vocab.md
+++ b/plan/issues/3113-ir-codegen-layering-shared-vocab.md
@@ -1,0 +1,101 @@
+---
+id: 3113
+title: "Fix IR->codegen reverse layering: move shared vocabulary (js-tag) below IR; contain the bridge to ir/integration.ts"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: medium
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: refactor
+area: ir, codegen
+language_feature: compiler-internals
+goal: ir-full-coverage
+related: [1172, 2855, 2949]
+---
+
+# #3113 — IR↔codegen layering: shared vocabulary below IR
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+The intended layering is `emit` ← `ir` ← `codegen` (codegen consumes IR, IR
+consumes nothing above it). Current main has **6 files in `src/ir/` importing
+from `src/codegen/` (25 import lines)**:
+
+| IR file                 | imports from codegen                                                                                                                                                                                                                          |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ir/integration.ts`     | **17 modules** — any-helpers, dyn-read, shared, async-scheduler, index, value-tags, coercion-engine, js-tag, vec-elem-set, class-member-keys, native-strings, registry/imports, registry/types, context/types, ir-tail-call, fmod, func-space |
+| `ir/from-ast.ts`        | fmod, statements/control-flow, statements/loops, js-tag                                                                                                                                                                                       |
+| `ir/nodes.ts`           | js-tag                                                                                                                                                                                                                                        |
+| `ir/verify.ts`          | js-tag                                                                                                                                                                                                                                        |
+| `ir/builder.ts`         | js-tag                                                                                                                                                                                                                                        |
+| `ir/backend/handles.ts` | (codegen types)                                                                                                                                                                                                                               |
+
+Two distinct problems:
+
+1. **`js-tag.ts` is mis-homed.** It is shared _vocabulary_ (JS type-tag
+   constants used by boxing/refinement) consumed by IR core files
+   (`nodes/verify/builder/from-ast`) — i.e. it sits BELOW the IR, but lives
+   in `src/codegen/`. Same likely true of `fmod`'s interface and the
+   `func-space` chokepoint types.
+2. **`ir/integration.ts` (2,610 LOC) is the IR→codegen bridge but lives on
+   the IR side**, which makes `import "src/ir"` transitively pull 17 codegen
+   modules — the exact inversion #1172 Slice E flagged (then 2 imports; now
+   17 — it is getting worse ~9× in 10 weeks).
+
+This matters MORE as #2855 (IR front-end migration) proceeds: the IR is
+supposed to become the primary front-end, and a front-end that imports the
+legacy path's internals can never let that path be deleted.
+
+## Fix (mechanical first, boundary second)
+
+1. **Move `src/codegen/js-tag.ts` → `src/ir/js-tag.ts`** (or `src/shared/`
+   if emit/ also needs it). Keep a re-export at the old path for one cycle.
+   Fixes 4 of the 6 inverted files in one pure-motion commit.
+2. **Move `ir/integration.ts` → `src/codegen/ir-bridge.ts`** (#1172 Slice E,
+   re-grounded). It is codegen machinery (it registers codegen helpers for
+   IR-lowered bodies); its 17 codegen imports become same-layer imports.
+   Update the importer(s) (`src/codegen/index.ts` + any tests).
+3. **`from-ast.ts`'s imports of `statements/control-flow`/`statements/loops`**
+   need case-by-case review (they may be borrowing legacy lowering helpers —
+   each is either (a) shared vocabulary to move down, or (b) a bridge call to
+   route through the bridge module). Deliverable: zero `../codegen/` imports
+   in `src/ir/` outside a single documented exception list.
+4. Add a cheap CI guard (grep-based, in the `quality` job or a unit test):
+   `src/ir/**` must not import `src/codegen/**` — the list above regrew 9×
+   since April precisely because nothing enforces the boundary.
+
+## Safety story
+
+Steps 1–2 are pure file motion + import-path rewrites — byte-identity
+provable (`prove-emit-identity check` IDENTICAL) and `tsc --noEmit`-verified.
+Step 3 is review-then-move, one import per commit, same proof. No emission
+logic changes anywhere.
+
+## Coordination
+
+- #2855/#2856 (IR migration) actively edits `from-ast.ts`/`integration.ts` —
+  land steps 1–2 at a quiet moment for those files (small diffs, so conflicts
+  are cheap; the import-path rewrite is mechanical for any in-flight branch).
+- #2949 boxing slices introduced several of the newer bridge imports
+  (value-tags, coercion-engine) — the bridge move keeps their call graph
+  intact, only the file's home changes.
+
+## Estimated LOC delta
+
+≈ 0 (motion). Value is the enforced boundary (step 4) + un-tangling `import
+"src/ir"` for future consumers (bytecode backend, linear-IR lowering).
+
+## Acceptance criteria
+
+1. `grep -rn 'from "\.\./codegen' src/ir/` → empty (or the documented
+   exception list, target ≤ 2 lines).
+2. CI guard in place and failing on a synthetic violation.
+3. `prove-emit-identity check` IDENTICAL; `tsc --noEmit` clean; no test262
+   regression.

--- a/plan/issues/3114-codegencontext-diet-helper-memo-registry.md
+++ b/plan/issues/3114-codegencontext-diet-helper-memo-registry.md
@@ -1,0 +1,106 @@
+---
+id: 3114
+title: "CodegenContext diet: 282 fields -> subsystem sub-contexts + one helper-memo registry for the 109 ensureXxx families"
+status: ready
+sprint: Backlog
+created: 2026-07-09
+updated: 2026-07-09
+priority: low
+horizon: l
+feasibility: hard
+model: fable
+reasoning_effort: max
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: maintainability
+related: [1172, 3104, 3108]
+---
+
+# #3114 — CodegenContext diet
+
+**Source:** 2026-07-09 compiler consolidation audit (fable-refactor). See
+`plan/log/compiler-consolidation-plan.md`.
+
+## Problem (measured)
+
+`CodegenContext` (`src/codegen/context/types.ts`) now has **282 fields**
+(#1172 counted 120 in April — **+135% in 10 weeks**); `FunctionContext` has 49. A large share of the growth is a repeating pattern: `src/codegen/` has
+**109 distinct exported `ensureXxx` helper-emitter families**
+(`ensureObjectRuntime`, `ensureNativeStringHelpers`, `ensureExnTag`,
+`ensureAnyHelpers`, `ensureRegexRun`, `ensureWasi*`, …), and each one hand-
+rolls the same memoization idiom — a nullable index/flag field (or several)
+on `CodegenContext`:
+
+```ts
+if (ctx.objectRuntimeTypes) return ctx.objectRuntimeTypes;   // object-runtime.ts:177
+if (ctx.nativeStrHelpersEmitted) …                            // native-strings
+ctx.wasiFdWriteIdx / wasiProcExitIdx / wasiPathOpenIdx / …    // 6+ WASI fields
+```
+
+Every new helper adds 1–4 context fields; nothing distinguishes "core
+compiler state" from "memo cell of one helper in one file". This is the god
+object #1172 flagged (Slices F/G, unlanded), 2.4× worse now. 226 direct
+`ctx.mod.*.push` sites also bypass any invariant point, but that
+(ModuleBuilder) stays deferred — #2710's handle model is the real fix there.
+
+## Fix (phased; design pass first — hence fable)
+
+**Phase 1 — helper-memo registry (mechanical bulk win).** One field replaces
+the long tail of memo cells:
+
+```ts
+// context/types.ts
+helperMemo: Map<string, unknown>;   // key = "<module>:<helper>"
+// helper side:
+const memo = getHelperMemo<ObjectRuntimeTypes>(ctx, "object-runtime:types");
+if (memo) return memo;
+…
+setHelperMemo(ctx, "object-runtime:types", result);
+```
+
+Migrate per helper family, ONLY the single-owner memo fields (a field read by
+multiple modules is shared state, not a memo — leave it). Target: −80 to
+−120 fields. Byte-identity: the memo value and check order are unchanged —
+pure representation swap, provable per commit.
+
+**Phase 2 — subsystem sub-contexts** (#1172 F/G re-grounded): group the
+remaining coherent clusters behind nullable sub-objects — `ctx.wasi:
+WasiCtx | null`, `ctx.nativeStr: NativeStringCtx | null`, `ctx.regex`,
+`ctx.asyncSched` — with TS narrowing replacing scattered boolean flags.
+One subsystem per PR, field-by-field within it.
+
+**Phase 3 — write an ownership map** (doc in the issue/PR): every remaining
+top-level field gets an owning module; fields with no identifiable owner are
+flagged for #3110-style dead-code review. This map is the input for any
+future context split and for FunctionContext (49 fields) if warranted.
+
+## Safety story
+
+Phase 1 is representation-only: same values, same check points, no emission
+reorder — `prove-emit-identity check` IDENTICAL per family; `tsc --noEmit`
+catches every missed read. Phase 2 is #1172's F/G recipe (narrowing improves
+safety). The risk is subtle aliasing: a "memo" field that some OTHER module
+mutates directly — the migration greps every field's write sites first, and
+any multi-writer field is excluded (documented in the ownership map instead).
+
+## Coordination
+
+- #3108 (giant emitter decomposition) introduces per-subsystem emit-context
+  objects — do Phase 2's clusters AFTER (or with) the corresponding #3108
+  split so the boundaries agree.
+- #2710 owns funcIdx representation — do not touch index-typed fields it is
+  migrating (its handle types subsume several `*Idx` fields naturally).
+
+## Estimated LOC delta
+
+≈ −300 direct (field decls + scattered init), but the real deliverable is a
+`CodegenContext` a reader can hold in their head: **< 120 top-level fields**
+with named subsystems.
+
+## Acceptance criteria
+
+1. `CodegenContext` < 150 top-level fields after Phases 1–2 (stretch < 120).
+2. IDENTICAL identity proof per migration commit.
+3. Ownership map written (module → fields) for whatever remains.
+4. No test262 regression.

--- a/plan/log/compiler-consolidation-plan.md
+++ b/plan/log/compiler-consolidation-plan.md
@@ -1,0 +1,206 @@
+# Compiler Consolidation Plan — structure / DRY / quality audit
+
+**Date:** 2026-07-09 · **Author:** fable-refactor (architecture audit) ·
+**Baseline:** `origin/main` @ `928c85179d105`
+**Companion issues:** #3102–#3114 (all `sprint: Backlog`)
+**Scope:** compiler STRUCTURE and quality only. Hard FEATURE problems are the
+parallel fable-arch audit's domain — no overlap intended.
+
+---
+
+## 0. The doctrine: behavior-preserving or it doesn't ship
+
+Every issue in this plan is bound by one constraint: **emitted Wasm stays
+byte-identical and test262 conformance does not regress.** The enforcement
+tool exists and is cheap: `scripts/prove-emit-identity.mjs` (#2710 slice 0)
+hashes `sha256(emitBinary)` per `(file, target)` over a corpus across the
+gc/standalone/wasi matrix. The protocol used throughout:
+
+```
+baseline → one mechanical slice → check must print IDENTICAL → commit → repeat
+```
+
+Two gaps in the tool, fixed as early slices inside the issues that need them:
+the default corpus is only **13 files** (`website/playground/examples`) —
+#3108/#3111 add targeted corpus roots; and the `linear` backend is **not in
+the target matrix** — #3105 adds it. Refactors that cannot be proven
+byte-identical (shared-state extraction in #3111 Phase 3, #3112, #3114
+Phase 2) are explicitly phased so the provable phases land first and the
+unprovable step can stop without stranding the rest.
+
+Note on `src/runtime.ts` and `tests/`: neither is in the Wasm emit path, so
+refactors there are byte-identical _by construction_ — the guardrail is the
+vitest suite + test262 CI, and those two are therefore the safest big wins.
+
+---
+
+## 1. What the code actually measures (2026-07-09)
+
+### 1.1 Size
+
+- `src/`: **246 files, 309,130 LOC**. 13 files > 5,000 LOC; 28 files > 3,000.
+- `tests/`: 1,923 files, **292,655 LOC**.
+- **27 top-level functions ≥ 1,000 lines.** The leaders:
+
+| Function                    | Lines      | File                                  |
+| --------------------------- | ---------- | ------------------------------------- |
+| `compileCallExpression`     | **12,210** | codegen/expressions/calls.ts:4190     |
+| `ensureObjectRuntime`       | **6,960**  | codegen/object-runtime.ts:176         |
+| `resolveImport`             | **6,517**  | runtime.ts:7560                       |
+| `ensureNativeStringHelpers` | **4,851**  | codegen/native-strings.ts:215         |
+| `compilePropertyAccess`     | 3,183      | codegen/property-access.ts:3458       |
+| `compileBinaryExpression`   | 3,015      | codegen/binary-ops.ts:253             |
+| `compileNewExpression`      | 2,930      | codegen/expressions/new-super.ts:2546 |
+| `ensureAnyHelpers`          | 1,815      | codegen/any-helpers.ts:846            |
+
+### 1.2 Regrowth (the meta-problem)
+
+Splits don't stick. `codegen/index.ts`: 14,344 (#1013, Apr 10) → **6,368**
+after the split (Apr 25, #1172 audit) → 14,379 (Jun 27) → **16,566** (Jul 9).
+Last-12-days growth of the four giants (`git show bf56e3060:<f> | wc -l`):
+
+| File                         | Jun 27 | Jul 9  | Δ      |
+| ---------------------------- | ------ | ------ | ------ |
+| codegen/expressions/calls.ts | 15,292 | 17,246 | +1,954 |
+| codegen/index.ts             | 14,379 | 16,566 | +2,187 |
+| codegen/object-runtime.ts    | 7,834  | 9,726  | +1,892 |
+| runtime.ts                   | 13,959 | 15,032 | +1,073 |
+
+**+7.1k LOC into god-files in 12 days.** `CodegenContext` grew 120 → **282
+fields** since April. The `compileCallExpression` cascade doubled (~5,800 →
+12,210). Conclusion: without a ratchet (#3102), every other issue here is a
+treadmill.
+
+### 1.3 Duplication
+
+Windowed scan (8-line normalized windows, comments/trivial excluded):
+**21,389 lines — 6.9% of src/ — sit inside duplicated blocks.** Worst
+self-duplication: `codegen-linear/runtime.ts` **24%** (map/set/numeric-map/
+numeric-set are 4 near-copies of one hash-probe runtime),
+`parse-number-native.ts` 26%, `array-methods.ts` 14%. Named idioms with
+copy-counts: throw-error guard ×17 (calls.ts), counter-loop scaffold ×12+9+9
+(array-methods, json-runtime, json-codec), proxy guard ×12 (object-runtime),
+hash-probe advance ×10 (codegen-linear). Cross-file pairs: declarations↔index
+55 windows, assignment↔property-access 46, literals↔object-ops 46.
+Supporting boilerplate: **514 `ensureLateImport` sites** re-declaring import
+signatures inline; 1,463 `__extern_*` refs across 51 files; 400
+`ctx.standalone` branches; 186/153/85 sites for the string-const/throw trio.
+
+### 1.4 Quality debt
+
+- Casts: **10,678 `as Instr`** single-asserts (CLAUDE.md still claims "few
+  computed-op sites"), 104 `as Instr[]`, 129 regrown `as unknown as Instr`,
+  341 `as unknown as` total, 579 `as any`.
+- **128 exported symbols referenced nowhere** else in src/tests/scripts
+  (conservative textual scan).
+- Layering: **6 `src/ir/` files import `src/codegen/`** (25 import lines;
+  `ir/integration.ts` alone imports 17 codegen modules — was 2 in April).
+- 109 distinct `ensureXxx` helper families each hand-rolling memoization onto
+  CodegenContext; 226 raw `ctx.mod.*.push` sites.
+- Tests: **132 files define a private `compileAndRun`** in ≥10 divergent
+  signatures; 793 files hand-roll instantiate boilerplate; `tests/helpers/`
+  contains one 19-line file.
+
+---
+
+## 2. Ranked plan
+
+Ranking = (LOC-impact × safety) / effort, with safety dominating per the
+behavior-preservation doctrine. Tier 1 is provably-safe motion/tooling with
+big payoff; Tier 3 needs design (model: fable) and is phased to stay safe.
+
+| Rank | Issue                                                                                                                               | Target                                                                                                           | Est. LOC delta                                        | Safety                                                                                                    | Effort / model |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------- |
+| 1    | **#3102** LOC regrowth ratchet (`check:loc-budget`)                                                                                 | CI gate + baseline; per-function ceilings for the 5 worst                                                        | +200 tooling; freezes ~75k of god-file growth         | trivial (tooling only)                                                                                    | S / opus       |
+| 2    | **#3103** Split `runtime.ts` (15,032) by concern; `resolveImport` (6,517-line switch) → handler maps                                | `src/runtime/{imports/*,wrap-host,to-primitive,polyfills,wasi-polyfill,instantiate}.ts`; barrel keeps public API | −300…−500; no module >2k                              | **not in emit path** — bytes identical by construction                                                    | L / opus       |
+| 3    | **#3104** Re-split `codegen/index.ts` (16,566) into subsystem modules                                                               | wasi/, registry/late-import-suites, extern-registry, emit-exports, hoist-scan; driver <3k                        | ~0 motion, −400…−800 follow-up                        | pure motion, identity-proven per region; **late-import region waits for #2710**                           | L / opus       |
+| 4    | **#3105** Emit-idiom builder library (throw-guard, counter-loop, proxy-guard, hash-probe, + linear target for the proof tool)       | `codegen/emit-idioms.ts` + linear twin                                                                           | **−1,200…−1,800**                                     | identity-proven per idiom×file slice                                                                      | M / opus       |
+| 5    | **#3106** Host-import signature registry (514 sites)                                                                                | `HOST_IMPORT_SIGS` table + `ensureKnownImport` in registry/imports.ts                                            | **−1,800…−2,200** + kills signature-drift bug class   | identity-proven; **after #2710**                                                                          | M / opus       |
+| 6    | **#3107** Cast-debt codemod (10,678 `as Instr` …)                                                                                   | `satisfies`/plain literals; ≤50 documented computed-op casts                                                     | ~0 LOC; restores type-checking on every instr literal | type-level only — erased at compile time                                                                  | M / opus       |
+| 7    | **#3108** Decompose giant `ensure*` emitters (6,960 / 4,851 / 1,815 / 1,273)                                                        | object-runtime/ + native-strings sections, ordered-call orchestrator + explicit emit-context                     | ~0 motion, −500…−900 dedup                            | emission-ORDER-sensitive → identity proof is precisely the right oracle; needs corpus extension (slice 0) | L / opus       |
+| 8    | **#3109** Test-helper consolidation (132 dup `compileAndRun`)                                                                       | `tests/helpers/compile.ts`, batch migration                                                                      | **−2,000…−3,500** (tests)                             | zero compiler changes                                                                                     | M / opus       |
+| 9    | **#3110** Dead-export sweep (128 candidates + dead fields)                                                                          | demote→delete in batches                                                                                         | **−1,000…−2,500**                                     | tsc + vitest sufficient                                                                                   | S / opus       |
+| 10   | **#3113** IR↔codegen layering (js-tag below IR; integration.ts → codegen/ir-bridge; CI boundary guard)                              | zero `codegen` imports in `src/ir/`                                                                              | ~0 motion; enforced boundary                          | pure motion + import rewrites, identity-proven                                                            | M / opus       |
+| 11   | **#3111** Decompose `compileCallExpression` (12,210-line fn) into ordered call-shape probes                                         | `expressions/call-shapes/*`; dispatcher <800                                                                     | ~0 motion, −600…−1,000 dedup                          | **hard**: phased tail-first peeling, identity per branch; Phase 3 (shared state) may stop early           | XL / **fable** |
+| 12   | **#3114** CodegenContext diet (282 fields; 109 memo families)                                                                       | helper-memo map (Phase 1, mechanical) + sub-contexts (Phase 2)                                                   | −300 + <150-field context                             | Phase 1 identity-provable; Phase 2 needs aliasing audit                                                   | L / **fable**  |
+| 13   | **#3112** Remaining lowering god-fns (`compilePropertyAccess` 3,183, `compileBinaryExpression` 3,015, `compileNewExpression` 2,930) | same probe recipe as #3111; read/write receiver-resolution sharing                                               | ~0 motion, −500…−900                                  | **hard**; depends on #3111's proven pattern                                                               | XL / **fable** |
+
+Aggregate direct LOC reduction across Tiers 1–2: ≈ **−7k to −11k** (src +
+tests), with the god-files capped by #3102 and `codegen/index.ts`,
+`runtime.ts`, `object-runtime.ts` each dropping to reviewable sizes. The
+larger payoff is structural: subsystem ownership (merge-conflict surface),
+type-checked instruction literals, an enforced ir/codegen boundary, and a
+call-shape dispatcher that new builtins extend by adding a module instead of
+another 300 lines to a 12k-line function.
+
+### Suggested sequencing
+
+```
+now:            #3102 (ratchet) → #3103 (runtime split) → #3105 → #3109 → #3110
+after #2710:    #3104 (index split) → #3106 (import registry)
+anytime:        #3107 (casts, per-file), #3113 (layering, at a quiet moment for from-ast)
+design first:   #3111 → then #3112; #3114 Phase 1 anytime, Phase 2 with #3108
+```
+
+---
+
+## 3. Coordination with in-flight work (do-not-collide map)
+
+- **#2710 — late-bind module indices (in-progress, senior-dev).** Owns
+  `expressions/late-imports.ts`, `registry/imports.ts`, and the index-shift
+  blocks inside `codegen/index.ts`. #3104's late-import region move and all
+  of #3106 are sequenced AFTER its producer slices. Everything else here
+  avoids index-representation changes entirely, and this plan adopts its
+  proof tool as the universal guardrail.
+- **#2855 / #2856 — IR front-end migration.** IR adoption is itself the
+  consolidation that retires the direct-AST hack layer — this plan
+  deliberately does NOT restructure direct-path lowering logic that the IR
+  will absorb (no semantic rewrites of statements/expressions lowering).
+  What this plan covers is what the IR migration does NOT: `runtime.ts`
+  (host JS), `codegen-linear/`, the emitter/registry/context substrate that
+  BOTH front-ends share, tests, and mechanical hygiene (casts, dead code,
+  duplication). #3113 actively helps #2855 by giving the IR a clean
+  downward-only dependency cone. #3111/#3112 are the one judgment call: the
+  call/member cascades are direct-path code the IR will eventually own —
+  but at +160 LOC/day growth and `external-call`/`body-shape-rejected`
+  buckets still >0, they will be load-bearing for quarters; tail-first
+  modularization keeps them maintainable without betting against the IR
+  (pure motion, no semantic investment).
+- **Prior art disposition.** #1172 (modularity audit, Apr 25): findings
+  directionally valid, ALL line anchors and counts stale (index.ts 2.6×,
+  context fields 2.4×, `ir/integration` imports 9× worse); its slices are
+  re-grounded and superseded by #3104 (A/B/H), #3107 (D), #3113 (E), #3114
+  (F/G), and its C (walk-instructions consolidation) is folded into #2710's
+  domain — recommend closing #1172 as superseded, pointing here. #1849
+  (diverged copy-paste) stays open and complementary: it lists _diverged_
+  duplicates needing semantic reconciliation; #3105 handles the _identical_
+  scaffolds that are provable byte-identical. #1098 (patch-layer audit)
+  remains a semantics-review issue, orthogonal to this structural plan.
+  #1013 is done-but-regrown; #3102 is the guard it lacked.
+
+---
+
+## 4. Measurement appendix (reproduction)
+
+All numbers gathered on `origin/main` @ `928c85179` (2026-07-09):
+
+- LOC: `find src -name '*.ts' | xargs wc -l | sort -rn`
+- 12-day deltas: `git show bf56e3060:<file> | wc -l` (oldest commit in the
+  shallow clone, 2026-06-27) vs current.
+- God functions: top-level `function` regex scan + brace-depth scan for
+  runtime.ts (`resolveImport` verified by depth; the naive scan misreports a
+  `$DONE` string artifact).
+- Duplication: 8-line sliding-window MD5 over trimmed/space-normalized lines,
+  windows <160 chars or containing comment lines excluded; per-file
+  duplicated-line sets deduplicate overlapping windows.
+- Casts: `grep -rnE 'as Instr[^[a-zA-Z]'` (10,678), `as Instr\[\]` (104),
+  `as unknown as Instr` (129), `as any` (579).
+- ensureLateImport sites: `grep -rc 'ensureLateImport(' src/codegen` (514).
+- Dead exports: name-based cross-reference of 1,440 `export
+function|const|class|let` decls against src+tests+scripts (over-counts
+  usage → conservative dead list of 128).
+- Context fields: field-line count inside `interface CodegenContext` (282)
+  and `FunctionContext` (49) in `codegen/context/types.ts`.
+- IR layering: `grep -rn 'from "\.\./codegen' src/ir` (25 lines / 6 files).
+- Test duplication: `grep -rl 'function compileAndRun' tests` (132);
+  signature histogram via `grep -rh 'function compileAndRun' | sort | uniq -c`.


### PR DESCRIPTION
## Summary

Structure/DRY/quality audit of the compiler (design-only PR: 13 issue files + 1 plan doc, **no src/ changes**). Companion to the parallel fable-arch feature audit — this one covers STRUCTURE/QUALITY only.

**Plan doc:** `plan/log/compiler-consolidation-plan.md` — full measurements + ranked plan.

### Headline measurements (main @ 928c85179, 2026-07-09)

- `src/`: 246 files / 309,130 LOC; 13 files >5k; **27 functions ≥1,000 lines** — `compileCallExpression` **12,210**, `ensureObjectRuntime` 6,960, `resolveImport` 6,517, `ensureNativeStringHelpers` 4,851
- **Regrowth is the meta-problem**: the 4 giants absorbed **+7.1k LOC in the last 12 days**; `codegen/index.ts` regrew 6,368 → 16,566 since the #1013 split; `CodegenContext` 120 → 282 fields since April
- Duplication: **21,389 lines (6.9%) inside duplicated 8-line windows**; named idioms: throw-guard ×17, counter-loop ×21, proxy-guard ×12, hash-probe ×10 (`codegen-linear/runtime.ts` is 24% duplicated)
- Quality debt: **10,678 `as Instr` casts**, 514 inline `ensureLateImport` signature re-declarations, 128 dead exports, 6 `src/ir` files importing `src/codegen` (25 lines), 132 test files with private `compileAndRun`

### Ranked issues (all `sprint: Backlog`; safety-first per the byte-identity doctrine)

| # | Target | Est. LOC delta | Safety | Model |
|---|--------|----------------|--------|-------|
| 3102 | LOC regrowth ratchet (`check:loc-budget`) | +200 tooling, caps ~75k | trivial | opus |
| 3103 | Split `runtime.ts` (15k) / `resolveImport` | −300…−500 | not in emit path | opus |
| 3104 | Re-split `codegen/index.ts` (16.5k) | −400…−800 | motion, identity-proven; after #2710 | opus |
| 3105 | Emit-idiom builders (+ `linear` proof target) | −1,200…−1,800 | identity-proven per slice | opus |
| 3106 | Host-import signature registry (514 sites) | −1,800…−2,200 | identity-proven; after #2710 | opus |
| 3107 | `as Instr` cast codemod (10.7k sites) | type-level only | erased at compile time | opus |
| 3108 | Decompose giant `ensure*` emitters | −500…−900 | order-sensitive → identity oracle | opus |
| 3109 | Test-helper consolidation | −2,000…−3,500 (tests) | zero compiler changes | opus |
| 3110 | Dead-export sweep (128) | −1,000…−2,500 | tsc + vitest | opus |
| 3113 | IR↔codegen layering (js-tag, ir-bridge) + CI guard | ~0, enforced boundary | pure motion | opus |
| 3111 | Decompose `compileCallExpression` (12,210-line fn) | dispatcher <800 | hard, phased, identity per branch | fable |
| 3114 | CodegenContext diet (282 fields) | <150 fields | Phase 1 provable | fable |
| 3112 | Remaining lowering god-fns (3.2k/3.0k/2.9k) | −500…−900 | hard; depends #3111 | fable |

### Safety doctrine

Every issue is bound to **byte-identical emitted Wasm** via `scripts/prove-emit-identity.mjs` (baseline → slice → IDENTICAL → commit), with two tool gaps fixed as early slices (13-file corpus extension; `linear` target). Unprovable phases are explicitly staged last and can stop without stranding the provable ones. Coordination map for #2710 (in-progress) and #2855/#2856 (IR migration) is in the plan doc; recommends closing #1172 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS