### PR TITLE
fix(ci): guard baseline refresh against stale-checkout race (#3115)

### DIFF
--- a/.github/workflows/baseline-summary-sync.yml
+++ b/.github/workflows/baseline-summary-sync.yml
@@ -197,6 +197,17 @@ jobs:
               cp "$PROMOTE_SNAPSHOT/$f" "$f"
               git add -f "$f"
             done <<< "$PROMOTE_FILES"
+            # (#3115) STALE-CHECKOUT GUARD (same as promote-baseline). The coercion
+            # baseline is a pure src/codegen/** grep; the `--update` above computed
+            # it against this hourly job's checkout, but the re-anchor
+            # `git checkout -f -B _summary_sync_tmp deploykey/main` just replaced the
+            # working tree with main's current tip, which may have advanced. Banking
+            # the pre-re-anchor value over the advanced source wedges the required
+            # check:coercion-sites gate on main. Recompute against the re-anchored
+            # tree so the committed baseline always matches the tree it lands on.
+            node scripts/check-coercion-sites.mjs --update || \
+              echo "WARN: coercion-site baseline recompute on re-anchored tip failed (non-fatal)"
+            git add -f scripts/coercion-sites-baseline.json 2>/dev/null || true
             if git diff --cached --quiet; then
               echo "Summary already current on main after re-anchor — nothing to push."
               PUSHED=1

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1992,6 +1992,28 @@ jobs:
             # commit. The [skip ci] trailer prevents the push from re-triggering
             # the shard matrix (#1156).
             reapply_promote_files
+            # (#3115) STALE-CHECKOUT GUARD. The coercion-site baseline is the ONE
+            # promote file derived from the SOURCE TREE (a pure src/codegen/**
+            # grep) rather than from this run's test262 report. The `--update`
+            # above (and the snapshot re-applied by reapply_promote_files) computed
+            # it against THIS job's checkout (github.sha, "T"). But the re-anchor
+            # `git checkout -f -B _promote_tmp deploykey/main` just replaced the
+            # working tree with main's CURRENT tip ("T+k"), which may include a PR
+            # that merged after T and changed the coercion-site count. Banking the
+            # T-snapshot value over the T+k source commits an internally
+            # inconsistent pair (source count != committed baseline) and turns the
+            # REQUIRED check:coercion-sites gate RED on main, wedging the whole
+            # merge queue (the 2026-07-09 property-access.ts 16->17 incident: a
+            # promote for a pre-#2812 SHA clobbered the reviewed 17 back to 16).
+            # RECOMPUTE it against the re-anchored tree so the banked baseline is
+            # correct-by-construction for the exact tree being pushed. No-op when
+            # main is stable (T == T+k); self-heals a drifted baseline otherwise.
+            # Mirrors refresh-baseline.yml, which already regenerates its source-
+            # derived docs INSIDE the loop after re-anchor. Non-fatal — a transient
+            # grep failure must not strand the summary commit.
+            node scripts/check-coercion-sites.mjs --update || \
+              echo "WARN: coercion-site baseline recompute on re-anchored tip failed (non-fatal)"
+            git add -f scripts/coercion-sites-baseline.json 2>/dev/null || true
             if git diff --cached --quiet; then
               echo "Baseline already current on main (no delta after re-anchor) — nothing to push."
               PUSHED=1

--- a/plan/issues/3115-refresh-workflow-stale-checkout-guard.md
+++ b/plan/issues/3115-refresh-workflow-stale-checkout-guard.md
@@ -1,0 +1,117 @@
+---
+id: 3115
+title: "Refresh workflow stale-checkout guard: recompute source-derived baselines after re-anchor"
+status: in-progress
+sprint: current
+created: 2026-07-09
+updated: 2026-07-09
+priority: high
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: medium
+task_type: infrastructure
+area: ci
+language_feature: compiler-internals
+goal: maintainability
+related: [2108, 2178, 2942, 1861, 2812]
+---
+
+# Refresh workflow stale-checkout guard
+
+## Problem
+
+On 2026-07-09 the whole merge queue wedged: the required `check:coercion-sites`
+gate (part of the `quality` job) went RED on `main`. The committed
+`scripts/coercion-sites-baseline.json` said `codegen/property-access.ts: 16`
+while the merged source tree had **17** coercion sites — an internally
+inconsistent pair that fails the gate on every PR.
+
+Root cause — a **stale-checkout / moved-base race** in the post-merge
+baseline-refresh jobs (same class as the "banking whole-tree state computed on a
+base that moved under it" hazard):
+
+1. A push to `main` at commit **T** triggers `test262-sharded.yml`. Its
+   `promote-baseline` job checks out **T** (`actions/checkout@v5`,
+   `fetch-depth: 1` → `github.sha`).
+2. The job runs `node scripts/check-coercion-sites.mjs --update`, which
+   recomputes the coercion-site baseline from T's `src/codegen` source (a pure
+   grep — it has no dependency on the test262 run). At T the source had 16
+   sites, so `--update` banks **16**.
+3. By the time the job reaches the push step, `main` has advanced to **T+k**
+   because PR **#2812** merged in between (it bumped
+   `codegen/property-access.ts` 16 → 17 and, at PR time, correctly bumped the
+   committed baseline to 17). The push loop **re-anchors** onto the fresh tip:
+   `git checkout -f -B _promote_tmp deploykey/main` replaces the working tree
+   (including `src/codegen/**`, now 17 sites) with T+k, then re-applies the
+   **T-snapshot** baseline files (baseline = 16) wholesale and commits.
+4. Result on `main`: source = 17, committed baseline = 16 → the reviewed 17 is
+   **clobbered back to 16**, `check:coercion-sites` RED, queue wedged.
+
+`check-coercion-sites.mjs` is the **only** promote file derived from the
+**source tree**; every other refreshed artifact (test262 summary JSON,
+hard-error baseline, feature badges, standalone high-water) is derived from
+**this run's test262 report**, which is correctly the same regardless of which
+main tip it lands on. So the source-derived baseline is uniquely sensitive to
+the re-anchor moving the tree under it.
+
+The incident itself was unblocked separately (commit `d3b3f2cfba7` restored the
+baseline to 17, bundled into PR #2814). This issue is the **root-cause guard**
+so it cannot recur.
+
+## Affected jobs
+
+- `.github/workflows/test262-sharded.yml` → job **`promote-baseline`**, step
+  _"Commit refreshed summary JSON to main repo"_ — pre-loop
+  `check-coercion-sites.mjs --update` (against the T checkout) + re-anchor push
+  loop (`_promote_tmp`). **BUG.**
+- `.github/workflows/baseline-summary-sync.yml` — the hourly fallback; same
+  shape: pre-loop `--update` + re-anchor push loop (`_summary_sync_tmp`).
+  **BUG.**
+- `.github/workflows/refresh-baseline.yml` — already regenerates its
+  source-derived derivations (`sync-conformance-numbers.mjs`) **inside** the
+  loop after the re-anchor. This is the **correct template** the fix mirrors;
+  it does not refresh the coercion baseline, so it needed no change.
+
+## Fix (the guard)
+
+Enforce the invariant: **never commit a source-derived baseline computed on a
+base that is no longer main's tip.** The push loop already re-checks-out the
+fresh tip (`git checkout -f -B <tmp> deploykey/main`) on every attempt — the
+minimal robust fix (option (b) from the task: "re-checkout current main and
+recompute before committing") is to move the coercion recompute **into** that
+loop, after the re-anchor and before the commit:
+
+```sh
+reapply_promote_files                         # (or the snapshot re-apply loop)
+node scripts/check-coercion-sites.mjs --update || echo "WARN: ... (non-fatal)"
+git add -f scripts/coercion-sites-baseline.json 2>/dev/null || true
+if git diff --cached --quiet; then ... ; fi   # no-op guard unchanged
+git commit ...
+git push deploykey HEAD:main
+```
+
+Because `--update` reads `src/codegen/**` from the freshly re-anchored working
+tree, the banked baseline is **correct-by-construction for the exact tree being
+pushed**:
+
+- **main stable** (T == T+k): recompute yields the same value → no-op, legit
+  refresh path unaffected.
+- **main advanced** (a PR moved the count): recompute yields the tip's actual
+  count → committed pair is consistent; also **self-heals** a baseline that is
+  already drifted on the tip.
+
+Kept **non-fatal** (`|| echo WARN`), matching the surrounding style, so a
+transient grep failure can never strand the summary commit.
+
+## Validation
+
+- `tests/issue-3115-refresh-stale-checkout-guard.test.ts` — dependency-free
+  structural test pinning the ordering invariant in **both** refresh jobs: a
+  coercion `--update` recompute + re-stage must appear **after** the re-anchor
+  checkout and **before** the push commit. Fails if a refactor moves the
+  recompute back before the re-anchor (reintroducing the wedge).
+- Both edited workflows parse as valid YAML (the edits live entirely inside
+  `run: |` block scalars at the existing 12-space shell indentation, so YAML
+  structure is untouched).
+- No test262 conformance impact (CI/tooling only).

--- a/tests/issue-3115-refresh-stale-checkout-guard.test.ts
+++ b/tests/issue-3115-refresh-stale-checkout-guard.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3115 — refresh-workflow stale-checkout guard.
+ *
+ * Root cause (2026-07-09 wedge): the post-merge baseline-refresh jobs check out
+ * main@T (github.sha), recompute the coercion-site drift baseline
+ * (`scripts/coercion-sites-baseline.json`) from that checkout's source, then
+ * RE-ANCHOR onto main's *current* tip (T+k) before committing — because a PR may
+ * have merged in between. `scripts/check-coercion-sites.mjs` is a PURE
+ * src/codegen/** grep, so its correct value depends on the tree it lands on. When
+ * a PR that changed the coercion-site count merged between T and T+k (#2812 bumped
+ * codegen/property-access.ts 16 -> 17), banking the T-snapshot value (16) over the
+ * T+k source (17) committed an internally inconsistent pair and turned the REQUIRED
+ * `check:coercion-sites` gate RED on main, wedging the whole merge queue.
+ *
+ * The fix: recompute the coercion baseline INSIDE the re-anchor push loop, AFTER
+ * the `git checkout -f -B <tmp> deploykey/main` re-anchor, so the committed
+ * baseline is correct-by-construction for the exact tree being pushed. This pins
+ * that ordering invariant in both refresh jobs so a future refactor can't quietly
+ * move the recompute back before the re-anchor and reintroduce the wedge.
+ *
+ * Intentionally dependency-free (text-order assertions only) — no YAML parser or
+ * network — so it runs in any lane.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+
+/** Every refresh job that recomputes the source-derived coercion baseline and
+ *  re-anchors onto main's fresh tip before committing. Each entry pins the loop's
+ *  re-anchor checkout marker; the recompute MUST come after it. */
+const REFRESH_JOBS = [
+  {
+    file: ".github/workflows/test262-sharded.yml",
+    reAnchorMarker: "git checkout -f -B _promote_tmp deploykey/main",
+    // The `git commit` that lands the [skip ci] baseline refresh on main.
+    commitMarker: 'git commit -m "chore(test262): refresh sharded baseline',
+  },
+  {
+    file: ".github/workflows/baseline-summary-sync.yml",
+    reAnchorMarker: "git checkout -f -B _summary_sync_tmp deploykey/main",
+    commitMarker: 'git commit -m "chore(test262): scheduled baseline summary sync',
+  },
+] as const;
+
+const RECOMPUTE = "node scripts/check-coercion-sites.mjs --update";
+const RESTAGE = "git add -f scripts/coercion-sites-baseline.json";
+
+describe("#3115 — coercion baseline is recomputed after the re-anchor, not banked stale", () => {
+  for (const job of REFRESH_JOBS) {
+    describe(job.file, () => {
+      const text = readFileSync(resolve(ROOT, job.file), "utf8");
+
+      it("re-anchors the working tree onto main's fresh tip inside a push loop", () => {
+        expect(text).toContain(job.reAnchorMarker);
+        expect(text).toContain(job.commitMarker);
+      });
+
+      it("recomputes the source-derived coercion baseline AFTER the re-anchor checkout", () => {
+        // The invariant: at least one coercion `--update` recompute must run on
+        // the re-anchored tree — i.e. between the re-anchor checkout and the
+        // commit that pushes to main. A recompute that only runs BEFORE the
+        // re-anchor (against the stale github.sha checkout) is the bug.
+        const anchorIdx = text.lastIndexOf(job.reAnchorMarker);
+        const commitIdx = text.indexOf(job.commitMarker, anchorIdx);
+        expect(anchorIdx).toBeGreaterThanOrEqual(0);
+        expect(commitIdx).toBeGreaterThan(anchorIdx);
+
+        const inLoop = text.slice(anchorIdx, commitIdx);
+        expect(inLoop).toContain(RECOMPUTE);
+        // ...and the freshly recomputed baseline must be re-staged so it lands in
+        // the commit (otherwise the recompute is a no-op on the committed tree).
+        expect(inLoop).toContain(RESTAGE);
+      });
+
+      it("documents the guard so the ordering isn't silently undone", () => {
+        expect(text).toContain("#3115");
+        expect(text).toMatch(/STALE-CHECKOUT GUARD/);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Problem

On 2026-07-09 the merge queue wedged: the required `check:coercion-sites` gate (part of `quality`) went RED on `main` because the committed `scripts/coercion-sites-baseline.json` said `codegen/property-access.ts: 16` while the merged source had **17**.

**Root cause — stale-checkout / moved-base race** in the post-merge baseline-refresh jobs:

1. `test262-sharded.yml` `promote-baseline` checks out main@**T** (`github.sha`, `fetch-depth: 1`).
2. It recomputes the coercion baseline from **T**'s `src/codegen` source (a pure grep, banks 16).
3. By push time `main` advanced to **T+k** because #2812 merged (bumping property-access 16→17 and its baseline to 17). The push loop re-anchors the tree onto T+k (`git checkout -f -B _promote_tmp deploykey/main`) but re-applies the **T-snapshot** baseline (16) wholesale and commits.
4. Result on `main`: source 17, baseline 16 → gate RED, queue wedged.

`check-coercion-sites.mjs` is the **only** promote file derived from the source tree; every other refreshed artifact comes from this run's test262 report (identical regardless of the tip it lands on). So it is uniquely sensitive to the re-anchor moving the tree under it. (The incident itself was already restored by `d3b3f2cfba7` / #2814 — this PR is the recurrence guard.)

## Fix

Recompute `check-coercion-sites.mjs --update` **inside** the re-anchor push loop — after `git checkout -f -B <tmp> deploykey/main` and before the commit — then re-stage the baseline. The banked value is now correct-by-construction for the exact tree being pushed: a no-op when main is stable, self-healing when it drifted. Kept non-fatal. Applied to both **`promote-baseline`** (`test262-sharded.yml`) and **`baseline-summary-sync.yml`**; `refresh-baseline.yml` already regenerates its source-derived docs inside the loop and is the template.

Invariant: **never commit a source-derived baseline computed on a base that is no longer main's tip.**

## Validation

- `tests/issue-3115-refresh-stale-checkout-guard.test.ts` — dependency-free structural test pinning the ordering (recompute + re-stage must appear after the re-anchor checkout and before the push commit) in both jobs. 6/6 pass.
- Both edited workflows parse as valid YAML; edits live entirely inside `run: |` block scalars at existing indentation.
- No test262 conformance impact (CI/tooling only).

Issue: `plan/issues/3115-refresh-workflow-stale-checkout-guard.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS