### PR TITLE
fix(pages): publish whitepaper.html to the deployed site

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -251,6 +251,10 @@ copyFile(join(WEBSITE, "getting-started", "index.html"), join(PAGES_DIST, "getti
 // entry point.
 copyFile(join(WEBSITE, "blog", "index.html"), join(PAGES_DIST, "blog", "index.html"));
 
+// Static whitepaper page — self-contained styled HTML, same pattern as the
+// "Get started" and blog pages above.
+copyFile(join(WEBSITE, "docs", "whitepaper.html"), join(PAGES_DIST, "docs", "whitepaper.html"));
+
 // Overwrite Vite-built report pages with the latest public/ versions (which include
 // web components like <t262-donut> that Vite doesn't process).
 const PUBLIC_REPORT = join(WEBSITE, "public", "benchmarks", "results", "report.html");


### PR DESCRIPTION
## What
`scripts/build-pages.js` copies each self-contained static page (`getting-started`, `blog`, reports) into `dist/pages` explicitly. The whitepaper page added in #2817 wasn't in that list, so it wouldn't deploy and the landing-page footer link (`./docs/whitepaper.html`) would **404** on the live site.

Adds the copy step, mirroring the existing getting-started/blog pattern → publishes `website/docs/whitepaper.html` to `dist/pages/docs/whitepaper.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)