### PR TITLE
fix(#3118): new Object(primitive) ToObject-boxes to its wrapper (§20.1.1.1)

### DIFF
--- a/plan/issues/2978-async-scheduler-rejected-promise-forawait-loop.md
+++ b/plan/issues/2978-async-scheduler-rejected-promise-forawait-loop.md
@@ -1,10 +1,11 @@
 ---
 id: 2978
 title: "Standalone async scheduler: for-await over a sync iterator yielding rejected promises loops forever (3GB JS-heap OOM)"
-status: ready
+status: blocked
+depends_on: [2895]
 sprint: current
 created: 2026-07-02
-updated: 2026-07-05
+updated: 2026-07-09
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -19,6 +20,38 @@ horizon: l
 ---
 
 # Standalone async scheduler: rejected-promise for-await loops forever (OOM)
+
+## BLOCKED on #2895 (async-frame suspension) — do NOT re-pick as stale WIP (fable-3058, 2026-07-09)
+
+Two prior attempts parked here; both reached the **same root cause via WAT
+dump**, and I re-verified both load-bearing claims against **current main**
+before setting `status: blocked`. This is a **genuine architectural block**, not
+stale WIP — a re-merge + re-push parks a third time in the same defect.
+
+- The repro's `for await` over a **sync** struct-iterator routes to
+  `compileForOfDirectIterator` (`statements/loops.ts:~5115`), which drives the
+  loop **synchronously and never consults `stmt.awaitModifier`** (that check is
+  at `~:5199`, AFTER the direct-iterator path returns). There is **no async
+  state machine in the compiled function at all**.
+- Standalone promises are **host imports** (`env::Promise_reject/resolve`), not
+  native `$Promise` structs. `isStandalonePromiseActive` is **wasi-only**
+  (`async-scheduler.ts:~3298`; standalone only under the unset
+  `JS2WASM_ASYNC_CARRIER_WIDEN` measurement flag), so the native `$Promise`
+  reject machinery the architect's Part-B premise relies on **never runs** for
+  the scored standalone lane.
+- The OOM is therefore an **infinite synchronous loop** allocating host rejected
+  promises with no microtask yield → 3 GB JS-heap OOM. **No bounded synchronous
+  fix exists** (a host promise's rejection can't be observed synchronously). The
+  branch-2 1M step-cap band-aid changed OOM→loud-TypeError but isn't spec-correct
+  (test wants `returnCount===1`, `caught===true`, bounded mem).
+- Part A (the #2934-3b drop-arity validity fix) **cannot land alone** — making
+  the module valid is exactly what exposes the OOM to CI shard workers (the hard
+  pairing constraint).
+
+The correct fix is **real async-frame suspension for the sync-iterator
+for-await drive in the host-promise lane** (the #2895 machinery) or the #2980
+carrier widen. Unblock when #2895 lands; re-verify the two claims above still
+hold on that base first.
 
 ## Problem
 

--- a/plan/issues/3058-resizable-ta-proto-methods.md
+++ b/plan/issues/3058-resizable-ta-proto-methods.md
@@ -1,7 +1,8 @@
 ---
 id: 3058
 title: "Resizable-TA proto-methods over a dynamic `$__ta_dyn_view` receiver — runtime-kind method dispatch (materialize-into-f64-vec + OOB ValidateTypedArray + write-back)"
-status: ready
+status: done
+completed: 2026-07-09
 model: fable
 priority: high
 feasibility: hard

--- a/plan/issues/3118-new-object-primitive-wrapper.md
+++ b/plan/issues/3118-new-object-primitive-wrapper.md
@@ -1,0 +1,110 @@
+---
+id: 3118
+title: "new Object(primitive) ignores its argument — must ToObject to the Number/String/Boolean/BigInt wrapper (§20.1.1.1)"
+status: done
+completed: 2026-07-09
+assignee: ttraenkler/fable-3058
+model: fable
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: object-wrapper, tojobject
+es_edition: ES2015
+test262_category: built-ins/Object
+goal: conformance
+sprint: current
+horizon: s
+created: 2026-07-09
+related: [1129, 1110]
+---
+
+# `new Object(primitive)` ignores its argument
+
+## Problem (verify-first, main realm, 2026-07-09)
+
+The `new Object(...)` codegen path (`src/codegen/expressions/new-super.ts`,
+the `expr.expression.text === "Object"` arm) unconditionally emitted
+`__new_plain_object` and **dropped its argument**. So `new Object(42)` produced
+an empty object rather than a Number wrapper:
+
+```ts
+String(new Object(42)); // "[object Object]"  — should be "42"
+new Object(42).valueOf(); // null               — should be 42
+const i: any = new Object(42);
+i.charCodeAt = String.prototype.charCodeAt;
+i.charCodeAt(0); // 91 (reads "[object Object]"[0]) — should be 52
+```
+
+The **called** form `Object(42)` was already correct (`tryObjectCoercionCall`
+in `calls-guards.ts`, #1129) — it ToObject-boxes a primitive to its wrapper.
+Per §20.1.1.1 the `new` and call forms are spec-identical (both return
+`ToObject(value)` for a non-null/undefined value), so the two paths diverged.
+
+This is the genuine root of the S15.5.4.x String "method borrowed onto a boxed
+primitive" cluster (`__instance = new Object(42); __instance.charCodeAt =
+String.prototype.charCodeAt; …`) plus the Object/Function/RegExp variants.
+
+Discovered while harvesting the gc-lane long-tail for #3058's Fable window (the
+String/prototype cluster is otherwise scattered + dominated by CI vm-sandbox
+realm artifacts — see the #1310 note in the sprint log; this is the one clean,
+main-realm-reproducible, self-contained root in it).
+
+## Fix
+
+Unify both forms on one ToObject helper. Extracted the body of
+`tryObjectCoercionCall` into a shared exported `emitObjectCoercion(ctx, fctx,
+args)` (`calls-guards.ts`) — the call-form wrapper now just does the
+`Object`-identity check then delegates, so its output is **byte-identical**.
+The `new Object(...)` arm in `new-super.ts` now delegates to the same helper:
+
+- primitive arg → `__new_Number` / `__new_String` / `__new_Boolean` /
+  `__new_BigInt` native wrapper (already standalone-capable, object-runtime.ts);
+- object arg → identity (returned unchanged);
+- null / undefined / no-arg → `__new_plain_object` (unchanged behavior).
+
+## Blast radius (measured, worktree runner = branch compiler, 2026-07-09)
+
+Of the 32 baseline fails that exercise `new Object(primitive)` / `Object(prim)`,
+**18 flip fail→pass** with the fix:
+
+- 14 × `String/prototype/*` (charAt, charCodeAt, concat, indexOf, lastIndexOf,
+  match, replace, search, slice, substring, toLowerCase, toUpperCase,
+  toLocaleLowerCase, toLocaleUpperCase — the S15.5.4.x borrow tests);
+- 2 × `RegExp` (S15.10.4.1_A8_T9, exec/S15.10.6.2_A1_T3);
+- 1 × `Object/prototype/valueOf/S15.2.4.4_A1_T2`;
+- 1 × `Function/S15.3.2.1_A1_T7`.
+
+The remaining 13 fails + 1 pre-existing `compile_error`
+(`Array/prototype/toString/non-callable-join-string-tag.js`, unchanged on main)
+have DIFFERENT roots (BigInt==Object comparison, Object constructor
+same-value edge cases, Object.prototype.valueOf on a wrapper) — out of scope.
+
+## Guards
+
+- Byte-inert for programs that never call `new Object(...)`: verified by
+  compiling the playground corpus with vs without the change — **byte-identical**
+  (26 host+standalone compiles). The call-form refactor is a pure extraction
+  (identical emitted code).
+- Edge cases verified: `new Object()`→plain object, `new Object(obj)`/`(arr)`→
+  identity, `new Object(null)`→fresh object, `new Object(<var number>)`→"…",
+  `Object(7)` call unchanged.
+- Wrapper/coercion equivalence suites green (36 tests across wrapper-constructors,
+  #1910 boolean/string wrapper, #1910d loose-eq, #2029 subclass).
+
+## Acceptance criteria
+
+- `new Object(primitive)` returns the matching wrapper; `String(new Object(42))
+=== "42"`, `new Object(42).valueOf() === 42`, method-borrow reads the boxed
+  primitive's string. ✅
+- Zero regressions; byte-inert for non-`new Object` programs. ✅
+- The 18 floor-visible test262 flips confirmed via the branch compiler. ✅
+
+## Notes
+
+`emitObjectCoercion`'s `any`-typed-primitive-arg fallthrough returns the arg by
+identity (can't statically prove primitive-vs-object) — this matches the
+pre-existing call-form limitation (`Object(anyVar)` typeof may read the
+primitive's type, not "object"). Out of scope; a runtime `__to_object` helper
+would close it (noted in calls-guards.ts).

--- a/src/codegen/expressions/calls-guards.ts
+++ b/src/codegen/expressions/calls-guards.ts
@@ -195,8 +195,25 @@ export function tryObjectCoercionCall(
   if (!(!expr.questionDotToken && ts.isIdentifier(expr.expression) && expr.expression.text === "Object")) {
     return undefined;
   }
-  const args = expr.arguments ?? [];
+  return emitObjectCoercion(ctx, fctx, expr.arguments ?? []);
+}
 
+/**
+ * (#3118) Emit the ECMAScript §20.1.1.1 / §7.1.18 ToObject coercion for the
+ * arguments of an `Object(...)` **or** `new Object(...)` construct. Both forms
+ * are spec-identical: for a primitive first arg they return the matching
+ * wrapper object (Number/String/Boolean/BigInt), for null/undefined/no-arg a
+ * fresh plain object, and for an object the argument unchanged. Shared by
+ * `tryObjectCoercionCall` (the call form) and the `new Object(arg)` path in
+ * new-super.ts — before #3118 the `new` form ignored its argument and always
+ * built an empty object, so `new Object(42)` stringified to "[object Object]"
+ * instead of "42" (breaking every method-borrow-onto-boxed-primitive test).
+ */
+export function emitObjectCoercion(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  args: readonly ts.Expression[],
+): InnerResult {
   // Object() / Object(null) / Object(undefined) → fresh empty object via
   // `__new_plain_object`. Mirrors the `new Object()` path in new-super.ts so the
   // result is a real object with the ordinary `Object.prototype` (Boolean(...) ===

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -33,6 +33,7 @@ import {
   getOrRegisterDvWindowType,
 } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1/B2) shared-backing TA views + windowing; (#3054 D) dynamic ctor construct
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
+import { emitObjectCoercion } from "./calls-guards.js"; // (#3118) shared Object(...) / new Object(...) ToObject coercion
 import { ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
 import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
 import { ensureObjectRuntime } from "../object-runtime.js"; // (#1100) standalone Proxy native runtime
@@ -3322,14 +3323,16 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   // "[object Object]". Falls back to `ref.null.extern` only if the import
   // can't be registered.
   if (ts.isIdentifier(expr.expression) && expr.expression.text === "Object") {
-    const createIdx = ensureLateImport(ctx, "__new_plain_object", [], [{ kind: "externref" }]);
-    flushLateImportShifts(ctx, fctx);
-    if (createIdx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: createIdx });
-      return { kind: "externref" };
-    }
-    fctx.body.push({ op: "ref.null.extern" });
-    return { kind: "externref" };
+    // (#3118) `new Object(value)` is spec-identical to `Object(value)`
+    // (§20.1.1.1 step 1: if NewTarget is Object/undefined, return ToObject(value)).
+    // Previously this path ignored its argument and always built an empty object,
+    // so `new Object(42)` stringified to "[object Object]" instead of "42" and
+    // every String/Number/Boolean method-borrow-onto-`new Object(primitive)` test
+    // failed. Delegate to the shared ToObject coercion used by the call form so a
+    // primitive arg boxes to its Number/String/Boolean/BigInt wrapper, an object
+    // passes through unchanged, and null/undefined/no-arg build a fresh object.
+    const r = emitObjectCoercion(ctx, fctx, expr.arguments ?? []);
+    return r === null ? { kind: "externref" } : (r as ValType);
   }
 
   // Handle `new Proxy(target, handler)`.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3323,14 +3323,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   // "[object Object]". Falls back to `ref.null.extern` only if the import
   // can't be registered.
   if (ts.isIdentifier(expr.expression) && expr.expression.text === "Object") {
-    // (#3118) `new Object(value)` is spec-identical to `Object(value)`
-    // (§20.1.1.1 step 1: if NewTarget is Object/undefined, return ToObject(value)).
-    // Previously this path ignored its argument and always built an empty object,
-    // so `new Object(42)` stringified to "[object Object]" instead of "42" and
-    // every String/Number/Boolean method-borrow-onto-`new Object(primitive)` test
-    // failed. Delegate to the shared ToObject coercion used by the call form so a
-    // primitive arg boxes to its Number/String/Boolean/BigInt wrapper, an object
-    // passes through unchanged, and null/undefined/no-arg build a fresh object.
+    // (#3118) `new Object(v)` is spec-identical to `Object(v)` (§20.1.1.1:
+    // return ToObject(v)). This arm previously ignored its arg and built an
+    // empty object; delegate to the shared coercion so a primitive boxes to its
+    // wrapper (an object passes through, null/undefined/none → fresh object).
     const r = emitObjectCoercion(ctx, fctx, expr.arguments ?? []);
     return r === null ? { kind: "externref" } : (r as ValType);
   }

--- a/tests/issue-3118-new-object-primitive.test.ts
+++ b/tests/issue-3118-new-object-primitive.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+// #3118 — `new Object(primitive)` was ignoring its argument and always building
+// an empty object (`__new_plain_object`), so `new Object(42)` stringified to
+// "[object Object]" instead of "42". Per §20.1.1.1 the `new` and call forms are
+// spec-identical: both return ToObject(value). The fix routes `new Object(arg)`
+// through the same `emitObjectCoercion` helper the call form uses, so a
+// primitive arg boxes to its Number/String/Boolean/BigInt wrapper.
+//
+// Host lane (compileAndInstantiate = real host globals): these are the genuine
+// main-realm semantics a JS host observes.
+
+async function run<T>(src: string): Promise<T> {
+  const exports = await compileAndInstantiate(src);
+  return (exports as { f: () => T }).f();
+}
+
+describe("#3118 new Object(primitive) ToObject wrapper", () => {
+  describe("stringification reflects the boxed primitive", () => {
+    it("String(new Object(42)) === '42'", async () => {
+      expect(await run(`export function f(): string { return String(new Object(42)); }`)).toBe("42");
+    });
+
+    it("String(new Object(true)) === 'true'", async () => {
+      expect(await run(`export function f(): string { return String(new Object(true)); }`)).toBe("true");
+    });
+
+    it("String(new Object('hi')) === 'hi'", async () => {
+      expect(await run(`export function f(): string { return String(new Object("hi")); }`)).toBe("hi");
+    });
+
+    it("new Object(42).toString() === '42'", async () => {
+      expect(await run(`export function f(): string { const o: any = new Object(42); return o.toString(); }`)).toBe(
+        "42",
+      );
+    });
+  });
+
+  describe("wrapper identity + valueOf", () => {
+    it("new Object(42).valueOf() === 42", async () => {
+      expect(await run(`export function f(): number { const o: any = new Object(42); return o.valueOf(); }`)).toBe(42);
+    });
+
+    it("new Object(42) instanceof Number", async () => {
+      expect(
+        await run(
+          `export function f(): number { const o: any = new Object(42); return (o instanceof Number) ? 1 : 0; }`,
+        ),
+      ).toBe(1);
+    });
+
+    it("typeof new Object(42) === 'object'", async () => {
+      expect(await run(`export function f(): string { return typeof new Object(42); }`)).toBe("object");
+    });
+  });
+
+  describe("String.prototype method borrowed onto new Object(primitive) — the S15.5.4.x cluster", () => {
+    it("charCodeAt reads the boxed number's string (borrow)", async () => {
+      expect(
+        await run(`export function f(): number {
+          const i: any = new Object(42);
+          i.charCodeAt = String.prototype.charCodeAt;
+          return i.charCodeAt(false) * 100 + i.charCodeAt(true); // "42": '4'=52, '2'=50
+        }`),
+      ).toBe(5250);
+    });
+
+    it("toLowerCase on new Object('AB')", async () => {
+      expect(
+        await run(`export function f(): string {
+          const i: any = new Object("AB");
+          i.toLowerCase = String.prototype.toLowerCase;
+          return i.toLowerCase();
+        }`),
+      ).toBe("ab");
+    });
+
+    it("indexOf on new Object('abc')", async () => {
+      expect(
+        await run(`export function f(): number {
+          const i: any = new Object("abcb");
+          i.indexOf = String.prototype.indexOf;
+          return i.indexOf("b");
+        }`),
+      ).toBe(1);
+    });
+  });
+
+  describe("spec-identity with the call form + edge cases (no regressions)", () => {
+    it("new Object() (no arg) → fresh plain object", async () => {
+      expect(
+        await run(`export function f(): string { const o: any = new Object(); o.x = 5; return typeof o + ":" + o.x; }`),
+      ).toBe("object:5");
+    });
+
+    it("new Object(obj) returns the argument unchanged (identity)", async () => {
+      expect(
+        await run(`export function f(): number {
+          const a: any = { v: 7 };
+          const b: any = new Object(a);
+          return (a === b ? 1 : 0) * 10 + b.v;
+        }`),
+      ).toBe(17);
+    });
+
+    it("new Object(arr) returns the array unchanged", async () => {
+      expect(
+        await run(`export function f(): number {
+          const a: any = [1, 2, 3];
+          const o: any = new Object(a);
+          return (o === a ? 1 : 0) * 10 + o.length;
+        }`),
+      ).toBe(13);
+    });
+
+    it("new Object(null) → fresh plain object", async () => {
+      expect(
+        await run(
+          `export function f(): string { const o: any = new Object(null); o.y = 3; return typeof o + ":" + o.y; }`,
+        ),
+      ).toBe("object:3");
+    });
+
+    it("Object(7) call form still boxes to '7'", async () => {
+      expect(await run(`export function f(): string { return String(Object(7)); }`)).toBe("7");
+    });
+  });
+
+  describe("byte-inertness", () => {
+    it("a program with no new Object(...) compiles unaffected", async () => {
+      // Sanity: the change is scoped to the new Object(...) arm — a program
+      // that never constructs Object compiles and runs normally.
+      const r = await compile(`export function f(): number { return [1, 2, 3].map((x) => x * 2)[2]; }`, {});
+      expect(r.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `new Object(...)` codegen arm in `new-super.ts` **ignored its argument** — it unconditionally emitted `__new_plain_object` (empty object). So `new Object(42)` stringified to "[object Object]" instead of "42", `.valueOf()` returned null, and a String method borrowed onto it read the wrong string. The **called** form `Object(42)` was already correct (`tryObjectCoercionCall`, #1129); per §20.1.1.1 the `new` and call forms are spec-identical, so the paths had diverged.

Found while verify-first harvesting the gc-lane long-tail for the #3058 Fable window — the one clean, main-realm-reproducible, self-contained root in the otherwise-scattered String/prototype cluster (the rest are CI vm-sandbox realm artifacts, #1310).

## Fix

Extract `tryObjectCoercionCall`'s body into a shared `emitObjectCoercion(ctx, fctx, args)`; delegate **both** forms to it — primitive→Number/String/Boolean/BigInt wrapper, object→identity, null/undefined/none→plain object. The call-form change is a **pure extraction** (byte-identical output).

## Validation

- **18 baseline fails flip fail→pass**: 14 × `String/prototype/*` S15.5.4.x borrow tests + 2 × RegExp + `Object/prototype/valueOf` + `Function`. Remaining 13 (BigInt==Object, Object same-value edges) have different roots — out of scope.
- **Byte-inert** for non-`new Object` programs: playground corpus sha256-identical with vs without the change (26 host+standalone builds).
- Edge cases: no-arg→plain object; `new Object(obj)`/`(arr)`→identity; `new Object(null)`→fresh; `Object(7)` call unchanged.
- 16 new host-enforced unit tests; wrapper/coercion equivalence suites green (36 tests).

## Also carries two deferred frontmatter flips (prior Fable work)

- **#3058** (resizable-TA host lane, PR #2821 merged) → `status: done`.
- **#2978** (rejected-promise for-await OOM) → `status: blocked`, `depends_on: [2895]` — genuine architectural block on async-frame suspension (WAT-dump root cause re-confirmed on current main), blocked-reason documented so no looper re-diagnoses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS