### PR TITLE
fix(#3127): trap-absent Proxy get on WasmGC-struct target — read through _resolveHostField; repair proxy-passthrough harness

### DIFF
--- a/plan/issues/3127-proxy-passthrough-test-missing-string-constants-import.md
+++ b/plan/issues/3127-proxy-passthrough-test-missing-string-constants-import.md
@@ -1,0 +1,124 @@
+---
+id: 3127
+title: "proxy-passthrough.test.ts broken on main (missing string_constants import) — masked a REAL bug: trap-absent Proxy get on a WasmGC-struct target reads undefined"
+status: done
+sprint: current
+created: 2026-07-10
+completed: 2026-07-10
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: tests, runtime
+language_feature: Proxy
+goal: standalone-mode
+related: [1667, 2180, 2618, 498]
+assignee: ttraenkler/fable-shepherd
+origin: "2026-07-10 fable-shepherd — found while drift-refreshing PR #2815 (#3031): tests/proxy-passthrough.test.ts fails 3/3 on pure origin/main (b6691942bd832), same on unrelated branches."
+---
+
+# #3127 — proxy-passthrough test rot masked a trap-absent Proxy [[Get]] bug
+
+## Problem (layer 1 — the latent test)
+
+All 3 tests in `tests/proxy-passthrough.test.ts` failed on `main` with:
+
+```
+WebAssembly.instantiate(): Import #0 "string_constants": module is not an object or function
+```
+
+The test's local `run()` helper instantiated with a hand-rolled `{ env: {} }`
+import object, which never supplies the `string_constants` namespace that
+every string-pooling module has required since #1667. The file sits at
+`tests/` root, which no CI job executes (`quality` runs lint/typecheck/gates
++ named files; the equivalence shards run `tests/equivalence/`; `linear-tests`
+runs `linear-*`/`c-abi`/`simd`), so it rotted silently. Same root cause and
+fix as `tests/functional-array-methods.test.ts` (see its header): use the
+shared `buildImports()` builder + `setExports` wiring.
+
+## Problem (layer 2 — what the throw was masking)
+
+With the harness fixed, 2 of 3 tests STILL failed — a real runtime bug:
+
+**A trap-absent `get` on a Proxy whose target is a raw WasmGC struct returns
+`undefined` for every field** (`new Proxy(structTarget, {}).x` → unboxed 0).
+
+Mechanism: `_hostProxyConstruct` (#2180) keeps the raw struct as
+[[ProxyTarget]] (identity-preserving). §7.3.10 "missing trap ⇒ target's
+ordinary internal method" then runs the HOST engine's ordinary [[Get]]
+against a struct that is **opaque to V8** — no visible fields — so the read
+misses. Trap-PRESENT reads were fine (the bridge fires user traps); only the
+forwarding default was broken. This is also the root cause of the baseline
+test262 failures `built-ins/Proxy/get/trap-is-undefined.js` and
+`trap-is-undefined-no-property.js` (verified locally: both shapes flip to
+pass with the fix; the trap-present shape still returns the trap result).
+
+Additionally, the old test 2 asserted the obsolete tier-0 semantics ("get
+trap is IGNORED, reads pass through") — since #2180 real traps fire, so the
+spec-correct expectation is the trap's return value. The test was updated,
+not the runtime.
+
+## Fix
+
+1. **Harness** (`tests/proxy-passthrough.test.ts`): `buildImports(result.imports,
+   undefined, result.stringPool)` + `imports.setExports?.(...)` — the canonical
+   pattern.
+2. **Runtime** (`src/runtime.ts`): `_hostProxyConstruct` /
+   `_hostProxyConstructRevocable` now pass `structTarget` (the user target,
+   only when it is a WasmGC struct kept as [[ProxyTarget]] — i.e. no callable
+   substitution) into both bridge builders. Both the eager and lazy builders
+   install a default `get` bridge trap for the trap-absent case that reads
+   through `_resolveHostField(structTarget, key, exports)` — the same
+   canonical precedence `_wrapForHost` uses (accessor getter → sidecar →
+   `__sget_*` field getter → well-known-symbol sidecar → vivified prototype).
+   NOTE: `_safeGet` was deliberately NOT used — its string-key struct arm does
+   not consult `__sget_<key>` (that lookup lives in `__extern_get` /
+   `_resolveHostField`), which is why a first cut with `_safeGet` still read
+   `undefined`.
+
+## Why this shape (implementation notes)
+
+- **Fix point = the bridge default, not `__extern_get`**: `_safeGet` line
+  ~4787 already routes user-proxy reads into the host MOP (`obj[key]`), so
+  installing the forwarding trap makes EVERY boundary read path correct at
+  once; patching `__extern_get` alone would leave other MOP entry points
+  broken and duplicate struct-read logic.
+- **Not `_wrapForHost` as [[ProxyTarget]]**: swapping the proxy target for a
+  readable wrapper would fix forwarding for ALL MOPs but breaks trap-arg
+  identity (`assert.sameValue(trapTarget, target)` in get/set/has traps) and
+  cannot be built at START-timing (exports unwired). Rejected.
+- **`get` only, this slice**: `has`/`set`/`ownKeys`/`getOwnPropertyDescriptor`
+  forwarding on struct targets has the same opaque-target gap (see baseline
+  `trap-is-undefined-target-is-proxy.js` etc.) but each has its own result
+  semantics and invariant interactions — follow-up material, tracked below.
+- **Invariants safe**: an explicit bridge `get` result is validated by V8
+  against the [[ProxyTarget]]'s own descriptors; the opaque struct exposes
+  none, so no §10.5.8 invariant conflicts can fire.
+- **Plain-JS handler + struct target** (host-created handler object) keeps the
+  old behavior — compiled programs produce WasmGC-struct handlers, so the
+  live shapes are covered; noted as a residual in the code comment.
+
+## Residual / follow-up
+
+- Trap-absent `has` / `set` / `deleteProperty` / `ownKeys` /
+  `getOwnPropertyDescriptor` forwarding on struct targets (baseline fails
+  `trap-is-undefined-target-is-proxy.js`, `trap-is-missing-target-is-proxy.js`,
+  `not-same-value-configurable-false-writable-false-throws.js`, …).
+- `tests/issue-2615.test.ts` (2 cases: set/delete "WebAssembly objects are
+  opaque") and `tests/struct-proxy-wrappers.test.ts` (1 case: `__sget_*`
+  "expected true to be 1") also fail on pure main — pre-existing, unrelated
+  to this change (verified by control runs on origin/main), same
+  latent-tests/-root-not-in-CI class.
+
+## Test Results
+
+- `tests/proxy-passthrough.test.ts`: 0/3 → **3/3** (probe/regression coverage
+  for the done-flip).
+- Proxy/Reflect sweep (`issue-2180`, `issue-2615`, `issue-2616`, `issue-2617`,
+  `issue-2618`, `issue-2933`, `struct-proxy-wrappers`, `issue-3031-proxy-apply`,
+  `proxy-passthrough`): 57 passed / 3 failed — the 3 failures are byte-identical
+  on pure `origin/main` (pre-existing, listed above). Net delta of this PR:
+  +3, no collateral.
+- test262 shapes probed locally: `trap-is-undefined.js` and
+  `trap-is-undefined-no-property.js` core shapes flip fail → pass (lazy
+  top-level bridge); trap-present lazy shape unchanged (returns trap result).

--- a/scripts/loc-budget-baseline.json
+++ b/scripts/loc-budget-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-10",
   "threshold": 1500,
-  "totalCeiling": 388977,
+  "totalCeiling": 389021,
   "files": {
     "src/codegen-linear/index.ts": 5506,
     "src/codegen-linear/runtime.ts": 3638,
@@ -58,6 +58,6 @@
     "src/ir/lower.ts": 3532,
     "src/ir/nodes.ts": 2926,
     "src/ir/select.ts": 3223,
-    "src/runtime.ts": 15663
+    "src/runtime.ts": 15707
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6709,7 +6709,14 @@ function _hostProxyConstruct(
   // non-callable target keeps the raw struct as before (identity-preserving, no
   // behavior change).
   const { proxyTarget, rawTarget } = _proxyTargetFor(target, callbackState);
-  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState, rawTarget);
+  // (#3127) When the [[ProxyTarget]] stays the RAW WasmGC struct (non-callable
+  // target, no wrapper substitution), the host engine's ordinary internal
+  // methods cannot see its fields — the struct is opaque to V8, so a
+  // trap-ABSENT `p.x` read `undefined` for every field (`new Proxy(t, {}).x`
+  // === 0 after unbox). Hand the struct to the bridge builder so it can
+  // install a struct-aware default `get` forwarder for that case.
+  const structTarget = rawTarget === undefined && _isWasmStruct(target) ? target : undefined;
+  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState, rawTarget, structTarget);
   const proxy = new Proxy(proxyTarget, bridgeHandler);
   _userProxies.add(proxy);
   return proxy;
@@ -6731,7 +6738,9 @@ function _hostProxyConstructRevocable(
   // proxy callable/constructable; use its JS wrapper as [[ProxyTarget]] and
   // restore the raw struct in the apply/construct traps.
   const { proxyTarget, rawTarget } = _proxyTargetFor(target, callbackState);
-  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState, rawTarget);
+  // (#3127) Same struct-aware trap-absent `get` forwarding as `_hostProxyConstruct`.
+  const structTarget = rawTarget === undefined && _isWasmStruct(target) ? target : undefined;
+  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState, rawTarget, structTarget);
   const rv = Proxy.revocable(proxyTarget, bridgeHandler);
   if (rv && typeof rv.proxy === "object" && rv.proxy !== null) _userProxies.add(rv.proxy);
   return rv;
@@ -6803,13 +6812,25 @@ function _buildProxyBridgeHandler(
   // `assert.sameValue(trapTarget, target)` holds. `undefined` ⇒ no substitution
   // (non-callable target, identity-preserving — the prior behavior).
   rawTarget?: any,
+  // (#3127) The user's target when it is a RAW WasmGC struct kept as the
+  // [[ProxyTarget]] (no callable substitution). Such a target is OPAQUE to the
+  // host engine's ordinary internal methods, so "missing trap ⇒ target's
+  // default behavior" (§7.3.10) silently reads `undefined` for every field —
+  // `new Proxy(structTarget, {}).x` returned 0 instead of the field value.
+  // When set, the builders install a struct-aware default `get` forwarder for
+  // the trap-absent case. `undefined` ⇒ non-struct target (host default is
+  // already correct) or substituted callable wrapper (readable by the host).
+  structTarget?: any,
 ): any {
   // Plain JS handler (created host-side, not a WasmGC struct) already exposes
   // its traps directly. BUT if the [[ProxyTarget]] is a substituted callable
   // wrapper, even a plain-JS handler's apply/construct trap would observe the
   // wrapper as `target` — so wrap just those two traps to restore the raw
   // target. With no substitution this returns the handler verbatim (identity /
-  // `this` untouched, exactly as before).
+  // `this` untouched, exactly as before). (#3127) Trap-absent struct-target
+  // forwarding for plain-JS handlers is a known residual gap — compiled
+  // programs produce WasmGC-struct handlers, so the struct-handler paths below
+  // cover the live shapes.
   if (!_isWasmStruct(handler)) {
     return rawTarget === undefined ? handler : _wrapPlainHandlerForRawTarget(handler, rawTarget);
   }
@@ -6840,13 +6861,27 @@ function _buildProxyBridgeHandler(
   // a proxy built inside an exported function) is unchanged: the eager branch
   // below is byte-for-byte the prior logic.
   if (!exports) {
-    return _buildLazyProxyBridgeHandler(handler, callbackState, rawTarget);
+    return _buildLazyProxyBridgeHandler(handler, callbackState, rawTarget, structTarget);
   }
 
   const bridge: Record<string, any> = {};
   for (const name of _PROXY_TRAP_NAMES) {
     const rawTrap = _structFieldRaw(handler, name, exports);
-    if (rawTrap == null) continue; // undefined/null → genuine absence, host forwards to target (§7.3.10)
+    if (rawTrap == null) {
+      // undefined/null → genuine absence, host forwards to target (§7.3.10).
+      // (#3127) EXCEPT `get` on a raw WasmGC-struct [[ProxyTarget]]: the host's
+      // ordinary [[Get]] cannot see the opaque struct's fields, so forward the
+      // read through the canonical struct-field resolution (`_resolveHostField`
+      // — accessor getter → sidecar → `__sget_*` field getter → well-known-
+      // symbol sidecar → vivified prototype; the same precedence `_wrapForHost`
+      // uses). Invariant validation still runs against the opaque target, which
+      // exposes no own descriptors — so no §10.5.8 conflicts arise.
+      if (name === "get" && structTarget !== undefined) {
+        bridge[name] = (_t: any, key: any, _receiver: any): any =>
+          _resolveHostField(structTarget, key, callbackState?.getExports());
+      }
+      continue;
+    }
     const callable = _maybeWrapCallableUnknownArity(rawTrap, callbackState);
     if (typeof callable !== "function") {
       // (#2616) §7.3.10 GetMethod: a present-but-non-callable trap value (`{}`,
@@ -6923,6 +6958,9 @@ function _buildLazyProxyBridgeHandler(
   handler: any,
   callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
   rawTarget?: any,
+  // (#3127) See `_buildProxyBridgeHandler` — the raw WasmGC-struct target kept
+  // as [[ProxyTarget]], for struct-aware trap-absent `get` forwarding.
+  structTarget?: any,
 ): any {
   const bridge: Record<string, any> = {};
   for (const name of _PROXY_TRAP_NAMES) {
@@ -6935,6 +6973,12 @@ function _buildLazyProxyBridgeHandler(
         // method. `args[0]` is the [[ProxyTarget]] (the callable WRAPPER when a
         // wasm-closure target was substituted) — forward through it unchanged so
         // a default apply/construct lands on a host-callable value.
+        // (#3127) EXCEPT `get` on a raw WasmGC-struct [[ProxyTarget]] — opaque
+        // to the host's ordinary [[Get]]; read through the canonical
+        // struct-field resolution (see the eager builder).
+        if (name === "get" && structTarget !== undefined) {
+          return _resolveHostField(structTarget, args[1], lateExports);
+        }
         return _proxyForwardDefault(name, args);
       }
       // (#2618) restore the raw target for apply/construct (see eager path) only

--- a/tests/proxy-passthrough.test.ts
+++ b/tests/proxy-passthrough.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
 
+/**
+ * Helper: compile TS source and instantiate with the shared buildImports()
+ * host-import builder so every runtime helper the binary declares is
+ * supplied — including the `string_constants` import namespace (#1667).
+ * The hand-rolled `{ env: {} }` this replaced was missing
+ * `string_constants`, which broke all three tests at instantiation time
+ * once string literals became imported constants (#3127 — same root cause
+ * and fix as tests/functional-array-methods.test.ts).
+ */
 async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
   const result = await compile(source);
   if (!result.success) {
@@ -8,7 +18,9 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const { instance } = await WebAssembly.instantiate(result.binary, { env: {} });
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
   return (instance.exports as any)[fn](...args);
 }
 
@@ -32,7 +44,11 @@ describe("Proxy pass-through (issue #498 tier 0)", () => {
     expect(await run(src, "test")).toBe(30);
   });
 
-  it("new Proxy(target, handler) with get trap compiles as pass-through", async () => {
+  it("new Proxy(target, handler) with get trap fires the trap (§10.5.8)", async () => {
+    // (#3127) This test originally asserted the tier-0 "pass-through" mode
+    // where the get trap was IGNORED (expected 42, the target's value). Since
+    // #2180 the compiler builds real host Proxies with working traps, so the
+    // spec-correct result is the trap's return value.
     const src = `
       class Box {
         value: number;
@@ -41,13 +57,13 @@ describe("Proxy pass-through (issue #498 tier 0)", () => {
       export function test(): number {
         const obj = new Box(42);
         const p = new Proxy(obj, {
-          get(t: Box, prop: string) { return 0; }
+          get(t: Box, prop: string) { return 7; }
         });
-        // In pass-through mode, the get trap is ignored — p.value reads from target directly
+        // Real Proxy semantics: the get trap fires — p.value is the trap result.
         return p.value;
       }
     `;
-    expect(await run(src, "test")).toBe(42);
+    expect(await run(src, "test")).toBe(7);
   });
 
   it("proxy of simple object passes through field reads", async () => {


### PR DESCRIPTION
## Summary

Found while drift-refreshing PR #2815: `tests/proxy-passthrough.test.ts` failed 3/3 on pure `origin/main` — and the instantiation throw was masking a real runtime bug.

**Layer 1 — latent test rot:** the file's hand-rolled `{ env: {} }` import object misses the `string_constants` namespace (#1667). Fixed with the shared `buildImports()` + `setExports` pattern (same fix as `functional-array-methods.test.ts`, which had this exact bug).

**Layer 2 — real bug:** a trap-absent `get` on a Proxy whose [[ProxyTarget]] is a raw WasmGC struct forwards to the host engine's ordinary [[Get]] — but the struct is opaque to V8, so every field read `undefined` (`new Proxy(t, {}).x` → 0). Both bridge builders (eager + lazy, #2180/#2618) now install a default `get` forwarder that reads through `_resolveHostField` (accessor → sidecar → `__sget_*` → symbol sidecar → vivified proto) when the user handler lacks a `get` trap and the target is a struct kept as [[ProxyTarget]]. Trap-present behavior unchanged.

Test 2 updated from obsolete tier-0 pass-through semantics (trap ignored) to spec semantics (trap fires, #2180).

## Expected test262 impact

Flips `built-ins/Proxy/get/trap-is-undefined.js` + `trap-is-undefined-no-property.js` shapes (verified locally, lazy top-level bridge). Possibly related `target-is-proxy` variants.

## Validation

- `tests/proxy-passthrough.test.ts`: 0/3 → 3/3
- Proxy/Reflect sweep (2180/2615/2616/2617/2618/2933/struct-proxy-wrappers/3031/passthrough): 57 pass, 3 fail — the 3 fails are byte-identical on pure origin/main (pre-existing, documented in the issue file)
- tsc --noEmit clean, prettier clean, loc-budget baseline refreshed per gate instruction

Issue: `plan/issues/3127-proxy-passthrough-test-missing-string-constants-import.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS