### PR TITLE
fix(#3120): async-gen plain `yield <promise>` performs the implicit §27.6.3.8 Await(operand) on the carrier lane

### DIFF
--- a/plan/issues/3120-async-gen-implicit-yield-await.md
+++ b/plan/issues/3120-async-gen-implicit-yield-await.md
@@ -4,6 +4,7 @@ title: "Standalone async-generator: plain `yield <promise>` skips the §27.6.3.8
 status: done
 completed: 2026-07-10
 assignee: ttraenkler/fable-3120
+pr: 2841
 sprint: current
 model: fable
 created: 2026-07-09

--- a/plan/issues/3120-async-gen-implicit-yield-await.md
+++ b/plan/issues/3120-async-gen-implicit-yield-await.md
@@ -98,13 +98,15 @@ Promise-typed local (`const p = ...; yield p`) and a `.then()` chain.
 **The fix — WHY it is shaped this way:**
 
 1. `analyzeAsyncGen` (async-cps.ts) gained an `implicitYieldAwait` mode
-   (`{checker} | null`, `ImplicitYieldAwaitMode`). Non-null mode classifies a
+   (`{oracle} | null`, `ImplicitYieldAwaitMode`). Non-null mode classifies a
    plain `yield E` whose operand is statically Promise-typed
-   (`isPromiseType`, or a union with a Promise constituent) as an
-   `awaited: E` segment — riding the SAME proven suspend+settleYield(fromSent)
-   lane as `yield await E` (which already rejects the current next()-promise
-   on a rejected operand). No emitter changes at all; the fix is pure
-   classification.
+   (`ctx.oracle.builtinReceiverOf(operand) === "Promise"`, or a union with a
+   builtin-Promise part — the #1930 oracle boundary; a raw-checker first cut
+   failed the quality gate's oracle ratchet and was migrated, verified
+   byte-identical) as an `awaited: E` segment — riding the SAME proven
+   suspend+settleYield(fromSent) lane as `yield await E` (which already
+   rejects the current next()-promise on a rejected operand). No emitter
+   changes at all; the fix is pure classification.
 
 2. **The mode is carrier-lane-scoped — this is the load-bearing decision.**
    The first cut classified unconditionally and immediately broke the #2980

--- a/plan/issues/3120-async-gen-implicit-yield-await.md
+++ b/plan/issues/3120-async-gen-implicit-yield-await.md
@@ -155,3 +155,35 @@ explicit form (parity-tested in tests/issue-3120.test.ts).
 - test262 async-gen cluster (1008 files: expressions/statements
   async-generator + AsyncGeneratorFunction/Prototype + AsyncIteratorPrototype)
   A/B main-vs-branch on both CI lanes (host + standalone) — see Test Results.
+
+## Test Results (fable-3120, 2026-07-10)
+
+**wasi direct-drive (the fix):** `yield Promise.reject(99)` → next1 REJECTED
+(was FULFILLED NaN); `yield Promise.resolve(7)` → 7 (was NaN); Promise-typed
+local → 7; `.then`-chained pending operand → suspends at kick, resumes to 8;
+`yield await` and `yield 5` controls unchanged.
+
+**test262 async-gen cluster A/B (1008 files), standalone lane** (the only CI
+lane where async-gen drive codegen runs): main-vs-branch runs of
+`runTest262File(..., "standalone")` are **line-for-line IDENTICAL — every
+status AND every per-file wasm_sha** (639 pass / 353 fail / 16 CE on both
+sides). Zero flips, zero byte drift.
+
+**Host lane:** structurally inert — `isAsyncGenDriveCandidate` is false on
+gc/host, so the classification code is unreachable; confirmed by the
+39/39 emit-identity corpus + the 8-shape byte-diff. (A full in-process host
+A/B is infeasible locally: test262 dstr tests poison shared globals —
+`Array.prototype[Symbol.iterator]` — which kills any single-process loop;
+the sharded CI gate with fork isolation is the authoritative host-lane check.)
+
+**Vitest:** tests/issue-3120.test.ts 8/8; 2906-3di producer, 2906-3dii
+consumer, 2980 carrier-fallback all green post-merge of origin/main
+(incl. #3125 native-resolve assimilation). The 2 failures in 2865 unwrap
+(`await a sync-fulfilled local promise`, `await over an arithmetic
+expression`) fail IDENTICALLY with main's async-cps/async-frame — verified
+pre-existing by control runs on both the old and post-#3125 base.
+
+**Conformance delta on current CI lanes: 0 by design** — the win is wasi-lane
+correctness today, and it banks automatically for standalone the moment the
+#2980 carrier widen turns `isStandalonePromiseActive` on there (the bounded
+gate + awaited classification then activate for standalone too).

--- a/plan/issues/3120-async-gen-implicit-yield-await.md
+++ b/plan/issues/3120-async-gen-implicit-yield-await.md
@@ -1,7 +1,9 @@
 ---
 id: 3120
 title: "Standalone async-generator: plain `yield <promise>` skips the §27.6.3.8 implicit Await(operand) — yields the promise object (NaN) instead of awaiting; a rejecting operand doesn't reject"
-status: ready
+status: done
+completed: 2026-07-10
+assignee: ttraenkler/fable-3120
 sprint: current
 model: fable
 created: 2026-07-09
@@ -83,3 +85,73 @@ lane (native construction × host `.then` × legacy async-gen), NOT the drive;
 the −4 files are legacy function-expression gens the drive never touches. This
 is a pure host-free async-gen conformance win. `yield*` async delegation +
 method-form async-gen producers are separate (their own follow-ups).
+
+## Implementation Notes (fable-3120, 2026-07-10)
+
+**Repro confirmed on main first** (wasi direct drive, `.tmp` probe): all four
+proof shapes reproduced exactly as pinned — `yield Promise.reject(99)` →
+FULFILLED NaN, `yield Promise.resolve(7)` → FULFILLED NaN, explicit
+`yield await` control REJECTED ✓, `yield 5` control ✓. Also reproduced for a
+Promise-typed local (`const p = ...; yield p`) and a `.then()` chain.
+
+**The fix — WHY it is shaped this way:**
+
+1. `analyzeAsyncGen` (async-cps.ts) gained an `implicitYieldAwait` mode
+   (`{checker} | null`, `ImplicitYieldAwaitMode`). Non-null mode classifies a
+   plain `yield E` whose operand is statically Promise-typed
+   (`isPromiseType`, or a union with a Promise constituent) as an
+   `awaited: E` segment — riding the SAME proven suspend+settleYield(fromSent)
+   lane as `yield await E` (which already rejects the current next()-promise
+   on a rejected operand). No emitter changes at all; the fix is pure
+   classification.
+
+2. **The mode is carrier-lane-scoped — this is the load-bearing decision.**
+   The first cut classified unconditionally and immediately broke the #2980
+   fallback vitest (`tests/issue-2980-carrier-fallback.test.ts`): on the
+   carrier-off standalone drive lane, flipping a promise-yield body to
+   "has awaited segment" demotes it from the (compiling, driven) await-free
+   lane to the legacy path = #680 CE — a whole-module compile regression, and
+   a violation of this issue's own byte-inert-on-normal-standalone acceptance.
+   So the awaited classification fires ONLY where the suspend arm can
+   actually assimilate the operand: `isStandalonePromiseActive` (wasi today).
+   Both the admission gate (`isAsyncGenDriveCandidate`) and the planner
+   (`ensureAsyncResumeFunction` → `planAsyncGenCfg(decl, mode)`) derive the
+   mode from that same predicate, so gate and planner always see the same
+   segment split. Carrier-off standalone keeps the pre-#3120 plain
+   classification byte-identically; its value gap is the #2980 carrier
+   widen's to close, not a reason to stop compiling.
+
+3. `any`-typed operands stay on the plain fast path (deliberate): routing
+   every untyped operand through a suspend state would change bytes and
+   microtask timing for the huge untyped-non-promise yield population that
+   provably delivers correctly today. A runtime thenable behind `any` needs a
+   runtime thenable probe in the settle arm — follow-up, not static
+   classification.
+
+**Known inherited trait (pre-existing, NOT this issue):** after a rejected
+(implicitly or explicitly) awaited yield, the NEXT `next()` promise is also
+REJECTED rather than fulfilled `{undefined, done:true}` — the landed 3d-i
+machine behaves this way for `yield await Promise.reject` too (verified on
+main). Acceptance 1's "done=true on the next next()" parenthetical is
+therefore a property of the 3d-i settle machinery, tracked as its own
+follow-up if wanted; this fix makes the implicit form exactly match the
+explicit form (parity-tested in tests/issue-3120.test.ts).
+
+**Proofs run:**
+
+- `tests/issue-3120.test.ts` (new, 8 tests): reject→REJECTED, resolve→7,
+  promise-typed local, genuine suspension on a pending `.then` chain, mixed
+  promise+plain body, non-promise fast path settles synchronously
+  (pendingBeforeDrain=false), implicit≡explicit parity on reject, and
+  gc-legacy + standalone-compiles lane checks.
+- `scripts/prove-emit-identity.mjs`: 39/39 (file,target) sha-identical
+  across gc/standalone/wasi corpus (baseline from main's async-cps/async-frame).
+- Targeted 8-shape byte-diff (gc/standalone/wasi × promise-yield, await-yield,
+  plain, any-typed, mixed-leads, non-gen async): ONLY the three wasi
+  promise-yield shapes differ (the fix); everything else byte-identical.
+- Async suites green: 2906-3di producer, 2906-3dii consumer, 2980
+  carrier-fallback (the first-cut breaker), 2865 unwrap (its 2 failures
+  pre-exist on main — verified by control run).
+- test262 async-gen cluster (1008 files: expressions/statements
+  async-generator + AsyncGeneratorFunction/Prototype + AsyncIteratorPrototype)
+  A/B main-vs-branch on both CI lanes (host + standalone) — see Test Results.

--- a/scripts/loc-budget-baseline.json
+++ b/scripts/loc-budget-baseline.json
@@ -1,15 +1,15 @@
 {
   "generated": "2026-07-10",
   "threshold": 1500,
-  "totalCeiling": 390285,
+  "totalCeiling": 390365,
   "files": {
     "src/codegen-linear/index.ts": 5506,
     "src/codegen-linear/runtime.ts": 3638,
     "src/codegen/any-helpers.ts": 2645,
     "src/codegen/array-methods.ts": 9571,
     "src/codegen/array-object-proto.ts": 2028,
-    "src/codegen/async-cps.ts": 2455,
-    "src/codegen/async-frame.ts": 2016,
+    "src/codegen/async-cps.ts": 2527,
+    "src/codegen/async-frame.ts": 2024,
     "src/codegen/async-scheduler.ts": 3961,
     "src/codegen/binary-ops.ts": 4474,
     "src/codegen/class-bodies.ts": 3032,

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -2145,11 +2145,39 @@ function asyncGenBodyHasPatternLocals(fn: ts.FunctionLikeDeclaration): boolean {
 }
 
 /** One bounded async-gen yield statement: `yield await <awaited>` OR `yield <plain>`
- *  OR `yield;` (both null), plus the suspend-free LEAD statements preceding it. */
+ *  OR `yield;` (both null), plus the suspend-free LEAD statements preceding it.
+ *  (#3120) A plain `yield E` whose operand is STATICALLY Promise-typed is
+ *  classified `awaited: E` — §27.6.3.8 AsyncGeneratorYield performs
+ *  `Await(value)` on the operand before suspending, so a promise operand must
+ *  ride the suspend lane (settling the raw operand would deliver the promise
+ *  OBJECT, f64-coerced → NaN, and FULFIL where a rejecting operand must
+ *  reject). */
 interface AsyncGenYield {
   readonly leads: ts.Statement[];
   readonly awaited: ts.Expression | null;
   readonly plain: ts.Expression | null;
+}
+
+/**
+ * (#3120) Is the yield OPERAND statically Promise-typed? §27.6.3.8
+ * AsyncGeneratorYield awaits its operand implicitly, so a promise-typed plain
+ * `yield E` must route through the SAME suspend+settleYield(fromSent) lane as
+ * `yield await E`. Only the statically-known promise shape flips: a union
+ * with a Promise constituent awaits too (`Await` passes non-thenables through
+ * unchanged, so awaiting the union is always safe), while non-promise
+ * operands — and `any`-typed ones — stay on the plain fast path. Keeping
+ * `any` plain is deliberate: flipping it would demote every await-free
+ * `any`-yield body from the standalone carrier-off drive
+ * ({@link isAwaitFreeAsyncGenBody}, #2865) to the legacy path — a
+ * standalone-floor regression risk — for operands the direct-drive proof
+ * shows delivering correctly today. A runtime thenable hiding behind `any`
+ * is a follow-up (it needs a runtime thenable probe in the settle arm, not a
+ * static classification).
+ */
+function yieldOperandIsPromiseTyped(checker: ts.TypeChecker, operand: ts.Expression): boolean {
+  const type = checker.getTypeAtLocation(operand);
+  if (isPromiseType(type)) return true;
+  return type.isUnion() && type.types.some(isPromiseType);
 }
 
 /** The bounded async-gen body shape: ordered yield segments (each carrying its
@@ -2171,8 +2199,13 @@ interface AsyncGenShape {
  *  locals (spilled into the frame — see `computeAsyncGenSpills`). Still
  *  rejected (correct-or-legacy): `yield*`, yields nested inside expressions or
  *  control flow, `return` statements (need a settleReturn terminator),
- *  destructuring locals, and nested await/yield inside operands. */
-function analyzeAsyncGen(fn: ts.FunctionLikeDeclaration): AsyncGenShape | null {
+ *  destructuring locals, and nested await/yield inside operands.
+ *
+ *  (#3120) Classification needs the `checker`: a plain `yield E` with a
+ *  statically Promise-typed operand is an AWAITED segment (implicit
+ *  §27.6.3.8 `Await(operand)`), so all three consumers — the two gates and
+ *  {@link planAsyncGenCfg} — must see the SAME segment split. */
+function analyzeAsyncGen(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): AsyncGenShape | null {
   const body = fn.body;
   if (body === undefined || !ts.isBlock(body)) return null;
   if (asyncGenBodyHasPatternLocals(fn)) return null;
@@ -2191,7 +2224,13 @@ function analyzeAsyncGen(fn: ts.FunctionLikeDeclaration): AsyncGenShape | null {
         segments.push({ leads, awaited: operand.expression, plain: null });
       } else {
         if (containsAwaitOrYield(operand)) return null; // nested await/yield — follow-up
-        segments.push({ leads, awaited: null, plain: operand });
+        // (#3120) A Promise-typed plain operand carries the implicit
+        // AsyncGeneratorYield await — route it through the awaited lane.
+        if (yieldOperandIsPromiseTyped(checker, operand)) {
+          segments.push({ leads, awaited: operand, plain: null });
+        } else {
+          segments.push({ leads, awaited: null, plain: operand });
+        }
       }
       leads = [];
       continue;
@@ -2206,22 +2245,24 @@ function analyzeAsyncGen(fn: ts.FunctionLikeDeclaration): AsyncGenShape | null {
 }
 
 /** True when `fn` is a bounded 3d-i async-generator body drivable host-free. */
-export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
-  return analyzeAsyncGen(fn) !== null;
+export function isBoundedAsyncGenBody(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): boolean {
+  return analyzeAsyncGen(checker, fn) !== null;
 }
 
 /**
  * (#2865) True when `fn` is a bounded async-generator body that is ALSO
- * await-free (`yield <plain>` / `yield;` only — no `yield await P`). This is
- * the shape drivable under `--target standalone` while the native-`$Promise`
- * CARRIER gate is still wasi-only (#2980): with the carrier off, an awaited
- * operand does not lower to a native `$Promise`, so a `yield await P` would
- * deliver the un-awaited promise OBJECT (wrong value). An await-free body is
- * carrier-independent — every promise the machine touches is minted by its own
+ * await-free (`yield <plain>` / `yield;` only — no `yield await P` and, per
+ * #3120, no Promise-typed plain `yield P` either, since that carries the
+ * implicit §27.6.3.8 await). This is the shape drivable under
+ * `--target standalone` while the native-`$Promise` CARRIER gate is still
+ * wasi-only (#2980): with the carrier off, an awaited operand does not lower
+ * to a native `$Promise`, so an awaited segment would deliver the un-awaited
+ * promise OBJECT (wrong value). An await-free body is carrier-independent —
+ * every promise the machine touches is minted by its own
  * `__async_gen_next_<name>` driver.
  */
-export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
-  const shape = analyzeAsyncGen(fn);
+export function isAwaitFreeAsyncGenBody(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): boolean {
+  const shape = analyzeAsyncGen(checker, fn);
   if (shape === null) return false;
   return shape.segments.every((y) => y.awaited === null);
 }
@@ -2257,9 +2298,11 @@ export function asyncGenOwnLocalDecls(fn: ts.FunctionLikeDeclaration): Map<strin
 }
 
 /**
- * Build the CFG for a bounded async-generator body. Dense ids in push order; a
- * `yield await P` contributes TWO states (await-suspend + yield-from-sent), a
- * plain `yield E` ONE, and a trailing `settleDone`:
+ * Build the CFG for a bounded async-generator body. Dense ids in push order; an
+ * AWAITED segment (`yield await P`, or — #3120 — a Promise-typed plain
+ * `yield P`, which carries the implicit §27.6.3.8 await) contributes TWO
+ * states (await-suspend + yield-from-sent), a non-promise plain `yield E`
+ * ONE, and a trailing `settleDone`:
  *
  *   yield await P:  Sk  [leads] suspend(P, resume→Sk+1)         (the await)
  *                   Sk+1 (resumeFrom binding:null) settleYield(fromSent, →Sk+2)
@@ -2276,8 +2319,8 @@ export function asyncGenOwnLocalDecls(fn: ts.FunctionLikeDeclaration): Map<strin
  * `next()` promise). Every other state is entered by a `next()` kick with
  * MODE_NEXT, so needs no prelude. Returns `null` for a non-bounded body.
  */
-export function planAsyncGenCfg(fn: ts.FunctionLikeDeclaration): AsyncCfgPlan | null {
-  const shape = analyzeAsyncGen(fn);
+export function planAsyncGenCfg(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): AsyncCfgPlan | null {
+  const shape = analyzeAsyncGen(checker, fn);
   if (shape === null) return null;
   const asLead = (stmts: readonly ts.Statement[]): AsyncCfgStmt[] => stmts.map((stmt) => ({ stmt, handler: 0 }));
   const states: AsyncCfgState[] = [];

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -2146,17 +2146,32 @@ function asyncGenBodyHasPatternLocals(fn: ts.FunctionLikeDeclaration): boolean {
 
 /** One bounded async-gen yield statement: `yield await <awaited>` OR `yield <plain>`
  *  OR `yield;` (both null), plus the suspend-free LEAD statements preceding it.
- *  (#3120) A plain `yield E` whose operand is STATICALLY Promise-typed is
- *  classified `awaited: E` — §27.6.3.8 AsyncGeneratorYield performs
- *  `Await(value)` on the operand before suspending, so a promise operand must
- *  ride the suspend lane (settling the raw operand would deliver the promise
- *  OBJECT, f64-coerced → NaN, and FULFIL where a rejecting operand must
- *  reject). */
+ *  (#3120, carrier lane only — see {@link ImplicitYieldAwaitMode}) A plain
+ *  `yield E` whose operand is STATICALLY Promise-typed is classified
+ *  `awaited: E` — §27.6.3.8 AsyncGeneratorYield performs `Await(value)` on
+ *  the operand before suspending, so a promise operand must ride the suspend
+ *  lane (settling the raw operand would deliver the promise OBJECT,
+ *  f64-coerced → NaN, and FULFIL where a rejecting operand must reject). */
 interface AsyncGenYield {
   readonly leads: ts.Statement[];
   readonly awaited: ts.Expression | null;
   readonly plain: ts.Expression | null;
 }
+
+/**
+ * (#3120) Classification mode for the implicit §27.6.3.8 yield-operand await.
+ * Non-null (carrying the checker) ONLY on the native-`$Promise` CARRIER lane
+ * (`isStandalonePromiseActive` — wasi today), where the suspend arm can
+ * assimilate the awaited operand. `null` on the carrier-off standalone drive
+ * lane: there the operand is host-constructed, the suspend arm would
+ * mis-handle it, and — decisively — flipping the classification would demote
+ * every promise-yield body from the (compiling, driven) await-free lane to
+ * the legacy #680 CE, breaking the #2980 fallback's whole-module
+ * host-consistency. So carrier-off keeps the pre-#3120 plain classification
+ * byte-identically; the VALUE gap on that lane is the #2980 carrier widen's
+ * to close, not a reason to stop compiling.
+ */
+type ImplicitYieldAwaitMode = { readonly checker: ts.TypeChecker } | null;
 
 /**
  * (#3120) Is the yield OPERAND statically Promise-typed? §27.6.3.8
@@ -2166,12 +2181,11 @@ interface AsyncGenYield {
  * with a Promise constituent awaits too (`Await` passes non-thenables through
  * unchanged, so awaiting the union is always safe), while non-promise
  * operands — and `any`-typed ones — stay on the plain fast path. Keeping
- * `any` plain is deliberate: flipping it would demote every await-free
- * `any`-yield body from the standalone carrier-off drive
- * ({@link isAwaitFreeAsyncGenBody}, #2865) to the legacy path — a
- * standalone-floor regression risk — for operands the direct-drive proof
- * shows delivering correctly today. A runtime thenable hiding behind `any`
- * is a follow-up (it needs a runtime thenable probe in the settle arm, not a
+ * `any` plain is deliberate: routing every untyped operand through a suspend
+ * state would change bytes (and microtask timing) for the vast test262
+ * population of untyped non-promise yields the direct-drive proof shows
+ * delivering correctly today. A runtime thenable hiding behind `any` is a
+ * follow-up (it needs a runtime thenable probe in the settle arm, not a
  * static classification).
  */
 function yieldOperandIsPromiseTyped(checker: ts.TypeChecker, operand: ts.Expression): boolean {
@@ -2201,11 +2215,17 @@ interface AsyncGenShape {
  *  control flow, `return` statements (need a settleReturn terminator),
  *  destructuring locals, and nested await/yield inside operands.
  *
- *  (#3120) Classification needs the `checker`: a plain `yield E` with a
- *  statically Promise-typed operand is an AWAITED segment (implicit
- *  §27.6.3.8 `Await(operand)`), so all three consumers — the two gates and
- *  {@link planAsyncGenCfg} — must see the SAME segment split. */
-function analyzeAsyncGen(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): AsyncGenShape | null {
+ *  (#3120) `implicitYieldAwait` (see {@link ImplicitYieldAwaitMode}) controls
+ *  whether a statically Promise-typed plain `yield E` becomes an AWAITED
+ *  segment (implicit §27.6.3.8 `Await(operand)`). ACCEPTANCE is mode-neutral
+ *  (a promise-typed yield is accepted either way — only its segment
+ *  classification differs), so the admission gate and {@link planAsyncGenCfg}
+ *  stay consistent as long as both derive the mode from the same
+ *  carrier-lane predicate. */
+function analyzeAsyncGen(
+  fn: ts.FunctionLikeDeclaration,
+  implicitYieldAwait: ImplicitYieldAwaitMode,
+): AsyncGenShape | null {
   const body = fn.body;
   if (body === undefined || !ts.isBlock(body)) return null;
   if (asyncGenBodyHasPatternLocals(fn)) return null;
@@ -2224,9 +2244,9 @@ function analyzeAsyncGen(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration
         segments.push({ leads, awaited: operand.expression, plain: null });
       } else {
         if (containsAwaitOrYield(operand)) return null; // nested await/yield — follow-up
-        // (#3120) A Promise-typed plain operand carries the implicit
-        // AsyncGeneratorYield await — route it through the awaited lane.
-        if (yieldOperandIsPromiseTyped(checker, operand)) {
+        // (#3120) On the carrier lane, a Promise-typed plain operand carries
+        // the implicit AsyncGeneratorYield await — route it awaited.
+        if (implicitYieldAwait !== null && yieldOperandIsPromiseTyped(implicitYieldAwait.checker, operand)) {
           segments.push({ leads, awaited: operand, plain: null });
         } else {
           segments.push({ leads, awaited: null, plain: operand });
@@ -2244,25 +2264,30 @@ function analyzeAsyncGen(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration
   return { segments, tailLeads: leads };
 }
 
-/** True when `fn` is a bounded 3d-i async-generator body drivable host-free. */
-export function isBoundedAsyncGenBody(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): boolean {
-  return analyzeAsyncGen(checker, fn) !== null;
+/** True when `fn` is a bounded 3d-i async-generator body drivable host-free.
+ *  Acceptance is (#3120-)mode-neutral, so no checker is needed here. */
+export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
+  return analyzeAsyncGen(fn, null) !== null;
 }
 
 /**
  * (#2865) True when `fn` is a bounded async-generator body that is ALSO
- * await-free (`yield <plain>` / `yield;` only — no `yield await P` and, per
- * #3120, no Promise-typed plain `yield P` either, since that carries the
- * implicit §27.6.3.8 await). This is the shape drivable under
- * `--target standalone` while the native-`$Promise` CARRIER gate is still
- * wasi-only (#2980): with the carrier off, an awaited operand does not lower
- * to a native `$Promise`, so an awaited segment would deliver the un-awaited
- * promise OBJECT (wrong value). An await-free body is carrier-independent —
- * every promise the machine touches is minted by its own
+ * await-free (`yield <plain>` / `yield;` only — no `yield await P`). This is
+ * the shape drivable under `--target standalone` while the native-`$Promise`
+ * CARRIER gate is still wasi-only (#2980): with the carrier off, an awaited
+ * operand does not lower to a native `$Promise`, so a `yield await P` would
+ * deliver the un-awaited promise OBJECT (wrong value). An await-free body is
+ * carrier-independent — every promise the machine touches is minted by its own
  * `__async_gen_next_<name>` driver.
+ *
+ * (#3120) Deliberately classifies with the implicit yield-operand await OFF
+ * (`null` mode): this gate serves the carrier-off lane, where a Promise-typed
+ * plain `yield P` keeps its pre-#3120 plain classification (still driven,
+ * byte-identical) rather than demoting the body to the legacy #680 CE — see
+ * {@link ImplicitYieldAwaitMode}.
  */
-export function isAwaitFreeAsyncGenBody(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): boolean {
-  const shape = analyzeAsyncGen(checker, fn);
+export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
+  const shape = analyzeAsyncGen(fn, null);
   if (shape === null) return false;
   return shape.segments.every((y) => y.awaited === null);
 }
@@ -2299,9 +2324,9 @@ export function asyncGenOwnLocalDecls(fn: ts.FunctionLikeDeclaration): Map<strin
 
 /**
  * Build the CFG for a bounded async-generator body. Dense ids in push order; an
- * AWAITED segment (`yield await P`, or — #3120 — a Promise-typed plain
- * `yield P`, which carries the implicit §27.6.3.8 await) contributes TWO
- * states (await-suspend + yield-from-sent), a non-promise plain `yield E`
+ * AWAITED segment (`yield await P`, or — #3120, carrier lane only — a
+ * Promise-typed plain `yield P`, which carries the implicit §27.6.3.8 await)
+ * contributes TWO states (await-suspend + yield-from-sent), a plain `yield E`
  * ONE, and a trailing `settleDone`:
  *
  *   yield await P:  Sk  [leads] suspend(P, resume→Sk+1)         (the await)
@@ -2319,8 +2344,11 @@ export function asyncGenOwnLocalDecls(fn: ts.FunctionLikeDeclaration): Map<strin
  * `next()` promise). Every other state is entered by a `next()` kick with
  * MODE_NEXT, so needs no prelude. Returns `null` for a non-bounded body.
  */
-export function planAsyncGenCfg(checker: ts.TypeChecker, fn: ts.FunctionLikeDeclaration): AsyncCfgPlan | null {
-  const shape = analyzeAsyncGen(checker, fn);
+export function planAsyncGenCfg(
+  fn: ts.FunctionLikeDeclaration,
+  implicitYieldAwait: ImplicitYieldAwaitMode,
+): AsyncCfgPlan | null {
+  const shape = analyzeAsyncGen(fn, implicitYieldAwait);
   if (shape === null) return null;
   const asLead = (stmts: readonly ts.Statement[]): AsyncCfgStmt[] => stmts.map((stmt) => ({ stmt, handler: 0 }));
   const states: AsyncCfgState[] = [];

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -21,6 +21,7 @@
 // The full lowering (segment emission, capture structs, Promise.then chaining)
 // lands in follow-up PRs. See plan/issues/backlog/1042-async-await-state-machine-lowering.md.
 
+import type { TypeOracle } from "../checker/oracle.js";
 import { isPromiseType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { forEachChild, ts } from "../ts-api.js";
@@ -2160,18 +2161,18 @@ interface AsyncGenYield {
 
 /**
  * (#3120) Classification mode for the implicit §27.6.3.8 yield-operand await.
- * Non-null (carrying the checker) ONLY on the native-`$Promise` CARRIER lane
- * (`isStandalonePromiseActive` — wasi today), where the suspend arm can
- * assimilate the awaited operand. `null` on the carrier-off standalone drive
- * lane: there the operand is host-constructed, the suspend arm would
- * mis-handle it, and — decisively — flipping the classification would demote
- * every promise-yield body from the (compiling, driven) await-free lane to
- * the legacy #680 CE, breaking the #2980 fallback's whole-module
- * host-consistency. So carrier-off keeps the pre-#3120 plain classification
- * byte-identically; the VALUE gap on that lane is the #2980 carrier widen's
- * to close, not a reason to stop compiling.
+ * Non-null (carrying the type oracle — the #1930 type-query boundary) ONLY on
+ * the native-`$Promise` CARRIER lane (`isStandalonePromiseActive` — wasi
+ * today), where the suspend arm can assimilate the awaited operand. `null` on
+ * the carrier-off standalone drive lane: there the operand is
+ * host-constructed, the suspend arm would mis-handle it, and — decisively —
+ * flipping the classification would demote every promise-yield body from the
+ * (compiling, driven) await-free lane to the legacy #680 CE, breaking the
+ * #2980 fallback's whole-module host-consistency. So carrier-off keeps the
+ * pre-#3120 plain classification byte-identically; the VALUE gap on that
+ * lane is the #2980 carrier widen's to close, not a reason to stop compiling.
  */
-type ImplicitYieldAwaitMode = { readonly checker: ts.TypeChecker } | null;
+type ImplicitYieldAwaitMode = { readonly oracle: TypeOracle } | null;
 
 /**
  * (#3120) Is the yield OPERAND statically Promise-typed? §27.6.3.8
@@ -2188,10 +2189,10 @@ type ImplicitYieldAwaitMode = { readonly checker: ts.TypeChecker } | null;
  * follow-up (it needs a runtime thenable probe in the settle arm, not a
  * static classification).
  */
-function yieldOperandIsPromiseTyped(checker: ts.TypeChecker, operand: ts.Expression): boolean {
-  const type = checker.getTypeAtLocation(operand);
-  if (isPromiseType(type)) return true;
-  return type.isUnion() && type.types.some(isPromiseType);
+function yieldOperandIsPromiseTyped(oracle: TypeOracle, operand: ts.Expression): boolean {
+  if (oracle.builtinReceiverOf(operand) === "Promise") return true;
+  const parts = oracle.unionPartsOf(operand);
+  return parts !== undefined && parts.some((p) => p.kind === "builtin" && p.name === "Promise");
 }
 
 /** The bounded async-gen body shape: ordered yield segments (each carrying its
@@ -2246,7 +2247,7 @@ function analyzeAsyncGen(
         if (containsAwaitOrYield(operand)) return null; // nested await/yield — follow-up
         // (#3120) On the carrier lane, a Promise-typed plain operand carries
         // the implicit AsyncGeneratorYield await — route it awaited.
-        if (implicitYieldAwait !== null && yieldOperandIsPromiseTyped(implicitYieldAwait.checker, operand)) {
+        if (implicitYieldAwait !== null && yieldOperandIsPromiseTyped(implicitYieldAwait.oracle, operand)) {
           segments.push({ leads, awaited: operand, plain: null });
         } else {
           segments.push({ leads, awaited: null, plain: operand });

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -766,7 +766,7 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // `planAsyncGenCfg` (settleYield/settleDone terminators); every other async fn
   // uses the linear/while/for-await `planAsyncCfg`.
   const cfg = info.asyncGen
-    ? planAsyncGenCfg(info.decl)
+    ? planAsyncGenCfg(ctx.checker, info.decl)
     : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
@@ -1729,6 +1729,9 @@ export function emitAsyncFrameStateMachine(
  */
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
+  // (#3120) The shape gates classify Promise-typed plain yields as awaited
+  // segments (implicit §27.6.3.8 Await(operand)) — they need the checker.
+  const { checker } = ctx;
   // (#2865) Params must be plain identifiers: a binding-PATTERN param
   // (`f([...x] = v)`) destructures into derived LOCALS of the lifted fn's
   // prologue, which the fresh resume FunctionContext never sees — the body's
@@ -1755,7 +1758,7 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // Under the native-`$Promise` CARRIER (`isStandalonePromiseActive`, wasi
   // today): the full bounded shape, awaited yields included — the awaited
   // operand lowers to a native `$Promise` the suspend arm can assimilate.
-  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(decl) && spillsSafe();
+  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(checker, decl) && spillsSafe();
   // (#2865) `--target standalone` with the carrier gate still OFF (#2980):
   // drive the producer host-free ONLY for await-free bodies. With the carrier
   // off an awaited operand does not lower to a native `$Promise`, so
@@ -1763,7 +1766,9 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // — those bodies keep the legacy path (correct-or-legacy, #680 CE) until the
   // measured carrier widen. An await-free body is carrier-independent: every
   // promise the machine touches is minted by `__async_gen_next_<name>` itself.
-  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(decl) && spillsSafe();
+  // (#3120: a Promise-typed plain `yield P` counts as awaited here too — it
+  // is carrier-DEPENDENT for exactly the same reason as `yield await P`.)
+  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(checker, decl) && spillsSafe();
   return false;
 }
 

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -768,9 +768,10 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // (#3120) The implicit §27.6.3.8 yield-operand await is classified ONLY on
   // the native-`$Promise` CARRIER lane — the same predicate the admission gate
   // (`isAsyncGenDriveCandidate`) keyed the body's shape check on, so gate and
-  // planner always see the same segment split.
+  // planner always see the same segment split. Type queries go through
+  // `ctx.oracle` (the #1930 boundary), not the raw checker.
   const cfg = info.asyncGen
-    ? planAsyncGenCfg(info.decl, isStandalonePromiseActive(ctx) ? { checker: ctx.checker } : null)
+    ? planAsyncGenCfg(info.decl, isStandalonePromiseActive(ctx) ? { oracle: ctx.oracle } : null)
     : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -765,8 +765,12 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // (#2906 slice 3d-i) An async GENERATOR builds its CFG from the yield-aware
   // `planAsyncGenCfg` (settleYield/settleDone terminators); every other async fn
   // uses the linear/while/for-await `planAsyncCfg`.
+  // (#3120) The implicit §27.6.3.8 yield-operand await is classified ONLY on
+  // the native-`$Promise` CARRIER lane — the same predicate the admission gate
+  // (`isAsyncGenDriveCandidate`) keyed the body's shape check on, so gate and
+  // planner always see the same segment split.
   const cfg = info.asyncGen
-    ? planAsyncGenCfg(ctx.checker, info.decl)
+    ? planAsyncGenCfg(info.decl, isStandalonePromiseActive(ctx) ? { checker: ctx.checker } : null)
     : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
@@ -1729,9 +1733,6 @@ export function emitAsyncFrameStateMachine(
  */
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
-  // (#3120) The shape gates classify Promise-typed plain yields as awaited
-  // segments (implicit §27.6.3.8 Await(operand)) — they need the checker.
-  const { checker } = ctx;
   // (#2865) Params must be plain identifiers: a binding-PATTERN param
   // (`f([...x] = v)`) destructures into derived LOCALS of the lifted fn's
   // prologue, which the fresh resume FunctionContext never sees — the body's
@@ -1758,7 +1759,7 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // Under the native-`$Promise` CARRIER (`isStandalonePromiseActive`, wasi
   // today): the full bounded shape, awaited yields included — the awaited
   // operand lowers to a native `$Promise` the suspend arm can assimilate.
-  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(checker, decl) && spillsSafe();
+  if (isStandalonePromiseActive(ctx)) return isBoundedAsyncGenBody(decl) && spillsSafe();
   // (#2865) `--target standalone` with the carrier gate still OFF (#2980):
   // drive the producer host-free ONLY for await-free bodies. With the carrier
   // off an awaited operand does not lower to a native `$Promise`, so
@@ -1766,9 +1767,10 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // — those bodies keep the legacy path (correct-or-legacy, #680 CE) until the
   // measured carrier widen. An await-free body is carrier-independent: every
   // promise the machine touches is minted by `__async_gen_next_<name>` itself.
-  // (#3120: a Promise-typed plain `yield P` counts as awaited here too — it
-  // is carrier-DEPENDENT for exactly the same reason as `yield await P`.)
-  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(checker, decl) && spillsSafe();
+  // (#3120: a Promise-typed plain `yield P` deliberately stays PLAIN — and
+  // driven, byte-identically — on this lane; its implicit-await value gap is
+  // the carrier widen's to close. See ImplicitYieldAwaitMode in async-cps.ts.)
+  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(decl) && spillsSafe();
   return false;
 }
 

--- a/tests/issue-3120.test.ts
+++ b/tests/issue-3120.test.ts
@@ -1,0 +1,160 @@
+// #3120 — async-generator implicit AsyncGeneratorYield await of the operand.
+//
+// §27.6.3.8 AsyncGeneratorYield(value) performs `Await(value)` on the yield
+// OPERAND before suspending. The 3d-i drive machine implemented that await only
+// for the explicit `yield await P` shape; a plain `yield <promise>` settled the
+// RAW operand — the promise object f64-coerced to NaN, and a REJECTING operand
+// fulfilled-NaN instead of rejecting the current next()-promise.
+//
+// Fix: `analyzeAsyncGen` classifies a plain `yield E` whose operand is
+// statically Promise-typed as an AWAITED segment, riding the proven
+// suspend+settleYield(fromSent) lane — but ONLY on the native-`$Promise`
+// CARRIER lane (`isStandalonePromiseActive`, wasi today), where the suspend arm
+// can assimilate the operand. The carrier-off standalone drive lane keeps the
+// pre-#3120 plain classification byte-identically (its value gap is the #2980
+// carrier widen's to close — demoting those bodies to the legacy #680 CE would
+// break whole-module compiles). gc/host stays on the legacy path (drive off).
+//
+// Direct-drive proof harness mirrors tests/issue-2906-3di-asyncgen-producer.test.ts.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface GenExports {
+  g: () => unknown;
+  __async_gen_next_g: (frame: unknown) => unknown;
+  __async_gen_p_state: (p: unknown) => number;
+  __async_gen_result_done: (p: unknown) => number;
+  __async_gen_result_value: (p: unknown) => number;
+  __drain_microtasks: () => void;
+}
+
+async function instantiateAsyncGen(src: string): Promise<GenExports> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // Host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as GenExports;
+}
+
+/** Drive one `next()`, drain microtasks, read the settled IteratorResult. */
+function step(ex: GenExports, frame: unknown): { pendingBeforeDrain: boolean; done: number; value: number } {
+  const p = ex.__async_gen_next_g(frame);
+  const pendingBeforeDrain = ex.__async_gen_p_state(p) === 0;
+  ex.__drain_microtasks();
+  expect(ex.__async_gen_p_state(p)).toBe(1); // FULFILLED
+  return { pendingBeforeDrain, done: ex.__async_gen_result_done(p), value: ex.__async_gen_result_value(p) };
+}
+
+describe("#3120 — implicit §27.6.3.8 await of a plain promise yield operand (wasi carrier lane)", () => {
+  it("THE fix: `yield Promise.reject(99)` REJECTS the next()-promise (was: fulfilled NaN)", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield Promise.reject(99);
+      }
+    `);
+    const frame = ex.g();
+    const p1 = ex.__async_gen_next_g(frame);
+    ex.__drain_microtasks();
+    expect(ex.__async_gen_p_state(p1)).toBe(2); // REJECTED — not vacuously fulfilled
+  });
+
+  it("`yield Promise.resolve(7)` yields the AWAITED value 7 (was: NaN)", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield Promise.resolve(7);
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    expect([s1.done, s1.value]).toEqual([0, 7]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("a Promise-typed LOCAL rides the awaited lane too: `const p = ...; yield p`", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        const p = Promise.resolve(7);
+        yield p;
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(7);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("GENUINE suspension: a pending `.then`-chained operand suspends at kick=0 and resumes on drain", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield Promise.resolve(7).then((v: number) => v + 1);
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    expect(s1.pendingBeforeDrain).toBe(true); // suspended — value only after the drain
+    expect([s1.done, s1.value]).toEqual([0, 8]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("mixed body: promise yield then plain yield, in order", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield Promise.resolve(1);
+        yield 2;
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(1);
+    expect(step(ex, frame).value).toBe(2);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("FAST PATH preserved: a non-promise `yield 5` settles synchronously (no suspend state)", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield 5;
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    expect(s1.pendingBeforeDrain).toBe(false); // plain settleYield — no await round-trip
+    expect([s1.done, s1.value]).toEqual([0, 5]);
+  });
+
+  it("parity: plain `yield Promise.reject` behaves exactly like `yield await Promise.reject`", async () => {
+    const drive = async (src: string): Promise<number[]> => {
+      const ex = await instantiateAsyncGen(src);
+      const frame = ex.g();
+      const states: number[] = [];
+      for (let i = 0; i < 2; i++) {
+        const p = ex.__async_gen_next_g(frame);
+        ex.__drain_microtasks();
+        states.push(ex.__async_gen_p_state(p));
+      }
+      return states;
+    };
+    const implicit = await drive(`
+      export async function* g(): AsyncGenerator<number> { yield Promise.reject(99); yield 2; }
+    `);
+    const explicit = await drive(`
+      export async function* g(): AsyncGenerator<number> { yield await Promise.reject(99); yield 2; }
+    `);
+    expect(implicit).toEqual(explicit);
+  });
+
+  it("byte-inert lanes: gc stays legacy (host imports); carrier-off standalone still COMPILES the promise-yield body (driven, pre-#3120 classification — no #680 demotion)", async () => {
+    const src = `export async function* g(): AsyncGenerator<number> { yield Promise.resolve(7); }`;
+    // gc/host: legacy __create_async_generator path — host-backed.
+    const gc = await compile(src, { fileName: "test.ts" });
+    expect(gc.success).toBe(true);
+    expect((gc.imports ?? []).length).toBeGreaterThan(0);
+    // standalone (carrier OFF): the await-free gate must still classify the
+    // promise-typed plain yield as PLAIN — the body stays drivable and the
+    // module keeps compiling (demoting it to the legacy path would be a #680
+    // CE, breaking whole-module compiles — the first-cut regression the
+    // #2980 fallback test caught).
+    const standalone = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(standalone.success, standalone.success ? "" : `CE: ${standalone.errors?.[0]?.message}`).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (#3120)

§27.6.3.8 AsyncGeneratorYield(value) performs `Await(value)` on the yield OPERAND before suspending. The 3d-i drive machine implemented that await only for the explicit `yield await P` shape; a plain `yield <promise>` settled the RAW operand — the promise object f64-coerced to NaN, and a REJECTING operand fulfilled-NaN instead of rejecting the current next()-promise.

Direct-drive proof on main (wasi): `yield Promise.reject(99)` → FULFILLED value=NaN (want REJECTED); `yield Promise.resolve(7)` → FULFILLED value=NaN (want 7). Explicit `yield await` and non-promise `yield 5` controls were already correct.

## Fix

Pure classification — no emitter changes. `analyzeAsyncGen` (src/codegen/async-cps.ts) gains an `ImplicitYieldAwaitMode` (`{checker} | null`): non-null mode classifies a plain `yield E` whose operand is statically Promise-typed (`isPromiseType`, or a union with a Promise constituent) as an AWAITED segment, riding the proven suspend+settleYield(fromSent) lane that `yield await E` uses (which already rejects the current next()-promise on a rejected operand).

**The mode is carrier-lane-scoped (the load-bearing decision):** classification fires ONLY under `isStandalonePromiseActive` (wasi today), where the suspend arm can assimilate the operand. The carrier-off standalone drive lane keeps the pre-#3120 plain classification **byte-identically** — flipping it there would demote promise-yield bodies from the (compiling, driven) await-free lane to the legacy #680 CE, breaking whole-module compiles (caught by tests/issue-2980-carrier-fallback.test.ts during development). Gate (`isAsyncGenDriveCandidate`) and planner (`planAsyncGenCfg`) derive the mode from the same predicate, so both always see the same segment split. `any`-typed operands stay plain (documented follow-up: runtime thenable probe).

## Proof matrix

- **wasi direct drive**: reject→REJECTED, resolve→7, Promise-typed local→7, pending `.then` chain→genuine suspension then 8; implicit ≡ explicit reject parity; non-promise `yield 5` keeps the synchronous fast path (pendingBeforeDrain=false).
- **tests/issue-3120.test.ts**: 8/8 (mirrors the 3d-i producer harness).
- **Byte-inertness**: `prove-emit-identity` 39/39 (file,target) sha-identical across gc/standalone/wasi (baseline from main); targeted 8-shape byte-diff — ONLY the three wasi promise-yield shapes differ.
- **test262 async-gen cluster A/B (1008 files), standalone lane**: main-vs-branch line-for-line IDENTICAL — every status and every per-file wasm_sha (639 pass / 353 fail / 16 CE both sides). Host lane structurally inert (drive gate off on gc/host).
- **Suites green post-merge of origin/main (incl. #3125)**: 2906-3di, 2906-3dii, 2980 carrier-fallback. The 2 failures in 2865-unwrap are pre-existing on main (verified by control runs with main's codegen files).

**Conformance delta on current CI lanes: 0 by design** — the win is wasi-lane correctness today and banks automatically for standalone when the #2980 carrier widen activates `isStandalonePromiseActive` there.

Closes #3120 (plan/issues/3120-async-gen-implicit-yield-await.md — status: done in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS