### PR TITLE
fix(#3130): standalone native Error .constructor/.name identity — $Error_struct arm in __extern_get + constructor-via-tag seed

### DIFF
--- a/plan/issues/3130-standalone-error-constructor-name-identity.md
+++ b/plan/issues/3130-standalone-error-constructor-name-identity.md
@@ -1,0 +1,192 @@
+---
+id: 3130
+title: "Standalone: native Error objects lack `.constructor` / `.name` — blocks resolve-settled-*-self acceptance"
+status: done
+assignee: ttraenkler/fable-3130
+sprint: current
+created: 2026-07-10
+updated: 2026-07-10
+completed: 2026-07-10
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: errors
+goal: standalone-mode
+related: [3128, 3125, 2980]
+origin: "#3128 drill — after the assignment/capture fix (A+B) and the zero-arg resolve() dispatch fix (C), the resolve-settled-*-self files fail ONLY on `reason.constructor !== TypeError`"
+---
+
+# #3130 — native Error `.constructor` / `.name` identity (standalone)
+
+## Problem (measured on the #3128 branch, standalone, 2026-07-10)
+
+```ts
+export function test(): number {
+  var e: any = new TypeError("x");
+  return e.constructor === TypeError ? 1 : 0; // ← returns 0
+}
+```
+
+- `e.constructor` reads back `undefined` (probe: `.tmp/repro-3128-ctor2.mts`
+  in the #3128 worktree — recreate trivially from the snippet above).
+- `e.name === 'TypeError'` ALSO fails (returned r=11 in the
+  instanceof/name probe: instanceof TypeError ✓, instanceof Error ✓,
+  `.name` ✗).
+- `typeof e.constructor` throws "Cannot convert object to primitive value".
+- Same result for a CAUGHT TypeError (`try { null.foo } catch (e) {…}`).
+- `e instanceof TypeError` / `e instanceof Error` both work — the brand
+  chain is fine; only the property surface is missing.
+
+## Why it matters
+
+`test262/test/built-ins/Promise/prototype/then/resolve-settled-fulfilled-self.js`
+and `resolve-settled-rejected-self.js` (the #3128 acceptance files) assert the
+§27.2.1.3.2 self-resolution rejection via
+`reason.constructor !== TypeError`. After #3128 landed the capture/assignment
+fix and the zero-arg `resolve()` dispatch fix, the whole promise machinery is
+spec-correct on the widened standalone lane (verified: the reject handler runs
+with a TypeError instance, `instanceof` passes) — the ONLY remaining failure
+is this property read. The pattern (`err.constructor === XError`, `err.name`)
+is a common test262 idiom, so the fix likely flips more than these two files.
+
+## Acceptance
+
+- `new TypeError('x').constructor === TypeError` → true (standalone, and the
+  other native error ctors: Error/RangeError/ReferenceError/SyntaxError/
+  EvalError/URIError).
+- `new TypeError('x').name === 'TypeError'` → true; `.name` inherited
+  per spec (own property of the ctor prototype, not the instance).
+- Caught runtime-thrown errors (e.g. null deref TypeError) expose the same
+  `.constructor` / `.name`.
+- `resolve-settled-fulfilled-self.js` + `resolve-settled-rejected-self.js`
+  flip to pass on the widen arm (`JS2WASM_ASYNC_CARRIER_WIDEN=1`,
+  `runTest262File(..., "standalone")`).
+- No regressions in the error-object suites.
+
+## Notes
+
+- The identity requirement is two-sided: the error struct's `.constructor`
+  read must return the SAME function object the bare `TypeError` identifier
+  evaluates to (strict-equality on the binding, not just a same-named
+  function). Check how `instanceof` resolves the ctor brand — the fix can
+  likely reuse that anchor.
+- Related pre-existing gap seen in the same drill (do NOT conflate): `===`
+  identity on $Promise values routed through any-typed vars fails standalone
+  (`seen === p1` false even with no self-capture — the tag-5 host-only
+  strict-eq arm, see `reference_2583_any_strict_eq_tag5_host_only`).
+
+## Implementation notes (fable-3130, 2026-07-10)
+
+### Root cause — TWO dropped links, not one
+
+**Link 1 — `__extern_get` had no `$Error_struct` arm.** The universal dynamic
+property reader (`__extern_get` in `ensureObjectRuntime`,
+`src/codegen/object-runtime.ts`) — the terminal every `any`-receiver read
+routes through (`__dyn_get`, `__get_member_<name>` dispatcher fallbacks,
+generic property reads) — unwraps its receiver to `$Object` and answers a
+miss (undefined) for anything else. A native Error is an `$Error_struct`
+(fields: 0=tag, 1=message, 2=name, 3=stack, 4=userClassId, 5=props), NOT an
+`$Object`, so every dynamic read missed. The static fast path in
+property-access.ts only covers statically-Error-typed receivers and
+`catch`-clause bindings — a promise rejection-callback parameter is neither.
+
+**Link 2 — `tryEmitConstructorViaTag` null seed (the reason a first fix of
+link 1 alone did NOT flip the acceptance files).** For an `any`-typed
+`.constructor` read, `tryEmitConstructorViaTag`
+(`src/codegen/property-access.ts`) intercepts at COMPILE time whenever the
+module declares ≥1 tag-bearing user class — the test262 harness injects
+`class Test262Error`, so that is essentially every standalone test262
+program — and its standalone/WASI seed for the non-user-class case was a
+hard `ref.null.extern`: the read never reached `__extern_get` at all.
+(This is why bare probes outside the harness worked after fixing link 1,
+while the harness-wrapped acceptance files still failed with
+`typeof reason.constructor === "undefined"`.)
+
+### Fix
+
+1. **`fillExternGetErrorProps`** (`src/codegen/registry/error-types.ts`,
+   called from index.ts finalize after `fillBuiltinFnMeta`): finalize-time
+   fill that splices an `$Error_struct` arm into `__extern_get`, following
+   the `fillBuiltinFnMeta` shift-safety discipline (by-name funcIdx reads at
+   fill time, splice-not-rebuild, appended locals, runs before dead-elim).
+   Arm order: `$props` sidecar (recursive `__extern_get` — accessors/proto
+   resolve; nullish result falls through) → string-key dispatch (flatten
+   once + `__str_equals`): `message`→f1, `name`→f2, `stack`→f3 →
+   `constructor` → per-tag lazy `__builtin_<Name>` carrier global — the SAME
+   global the bare `TypeError` identifier reads (#2907
+   `emitBuiltinNamespaceObject`, same `ctx.builtinObjectGlobals` key), so
+   `===` is genuine object identity. Gated on `$userClassId == -1` (user
+   subclass instances keep today's miss rather than answering the WRONG
+   parent ctor); the shared "Error" tag additionally requires the `$name`
+   field to equal "Error" so a Test262Error (same tag, name
+   "Test262Error") keeps its miss. Carrier globals are get-or-created at
+   fill time (dead-elim never removes/renumbers globals; eager creation at
+   ctor-emit time changed bytes on error-free standalone modules because
+   the scaffold pre-registers `__new_TypeError` module-wide).
+2. **Seed fix** in `tryEmitConstructorViaTag`: under standalone/wasi, seed
+   the non-user-class result via the NATIVE `__extern_get`
+   (`ensureObjectRuntime` + funcMap read) instead of `ref.null.extern`.
+   Host/gc path unchanged (still the host `__extern_get` import); plain
+   `strictNoHostImports` gc mode keeps the null seed.
+
+### Measured (2026-07-10)
+
+- Acceptance: `resolve-settled-fulfilled-self.js` + `resolve-settled-rejected-self.js`
+  **fail → pass** on the widen arm (`JS2WASM_ASYNC_CARRIER_WIDEN=1`,
+  standalone) on a local merge of this branch + the #3128 branch (PR #2843).
+  On this branch alone they still fail (they need #3128's promise fixes —
+  expected; measured to isolate).
+- `new <Ctor>('x').constructor === <Ctor>` → true standalone for
+  Error/TypeError/RangeError/SyntaxError (family probe 7/7);
+  `.name === '<Ctor>'` → true; `typeof e.constructor` → "object" (no longer
+  throws); instanceof unchanged; cross-identity (`TypeError` instance ctor
+  `!== Error`) correct.
+- Emit identity: gc/host mode byte-identical on ALL probes (incl. an
+  error-using snippet); standalone byte-identical on error-free probes
+  (numeric/strings/arrays/closures/classes); only standalone modules with
+  BOTH the object runtime AND error ctors change (by design — errors are
+  reachable there).
+- Error-family test262 sweep (built-ins/NativeErrors + built-ins/Error,
+  152 files, standalone lane): see `## Test Results`.
+
+## Test Results (2026-07-10, local, standalone lane)
+
+- **Acceptance files (widen arm, combined tree with #3128 / PR #2843):**
+  `resolve-settled-fulfilled-self.js` fail→**pass**,
+  `resolve-settled-rejected-self.js` fail→**pass**.
+- **Error family** (built-ins/NativeErrors + built-ins/Error, 152 files, no
+  widen flag): main pass 49 / fail 92 / CE 11 → branch pass 50 / fail 91 /
+  CE 11. One flip: `built-ins/Error/message_property.js` fail→pass.
+  **Zero regressions.**
+- **Regression sweep** (built-ins/Promise/prototype/then +
+  language/statements/try, 276 files, widen arm): main == branch
+  (pass 180 / fail 91 / CE 5, per-file diff empty).
+- **Emit identity**: gc/host byte-identical on all probes (incl. an
+  error-throwing snippet); standalone byte-identical on error-free probes.
+- **vitest slice** (issue-1104-*, issue-1536*, issue-1597, issue-2029-*,
+  error-reporting*): 56 pass / 8 fail on branch — the SAME 8 fail on main
+  (pre-existing environmental WASI failures, not regressions).
+- tsc clean; prettier clean; loc-budget baseline regenerated for intended
+  growth (property-access +20 seed fix, index.ts +7 fill call).
+
+### Scoping notes / follow-ups (NOT fixed here)
+
+- **Runtime-thrown null-deref "TypeError" standalone is a plain STRING**
+  (`typeof e === "string"`, `instanceof` fails too — pre-existing, measured
+  on main): the acceptance bullet "caught runtime-thrown errors expose
+  `.constructor`/`.name`" holds for errors built via `__new_<Ctor>`
+  (`emitThrowJsError` sites, the promise machinery) but CANNOT hold for the
+  string-throwing sites until those construct real `$Error_struct`s —
+  separate issue.
+- `typeof TypeError === "function"` standalone reads "object" (the #2907
+  carrier is a plain `$Object`, not callable) — pre-existing carrier
+  property, unchanged.
+- `TypeError.name` / `.prototype` on the carrier object still miss —
+  carrier stays prop-less (#2907 scope), unchanged.
+- `__extern_has` / `__extern_set` (`'name' in e`, `e.name = ...`) still
+  have no `$Error_struct` arm — reads only in this fix.
+- User `class X extends Error` instances answer `.constructor` = miss
+  (undefined), not `X` — honest gap, requires the user-class singleton via
+  `$userClassId` dispatch (candidate follow-up).

--- a/scripts/loc-budget-baseline.json
+++ b/scripts/loc-budget-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-10",
   "threshold": 1500,
-  "totalCeiling": 390365,
+  "totalCeiling": 390662,
   "files": {
     "src/codegen-linear/index.ts": 5506,
     "src/codegen-linear/runtime.ts": 3638,
@@ -26,7 +26,7 @@
     "src/codegen/expressions/new-super.ts": 5602,
     "src/codegen/expressions/unary-updates.ts": 2087,
     "src/codegen/generators-native.ts": 4687,
-    "src/codegen/index.ts": 16618,
+    "src/codegen/index.ts": 16625,
     "src/codegen/iterator-native.ts": 1968,
     "src/codegen/json-codec-native.ts": 2859,
     "src/codegen/literals.ts": 4232,
@@ -39,7 +39,7 @@
     "src/codegen/object-ops.ts": 4747,
     "src/codegen/object-runtime.ts": 9842,
     "src/codegen/parse-number-native.ts": 1838,
-    "src/codegen/property-access.ts": 8478,
+    "src/codegen/property-access.ts": 8498,
     "src/codegen/regexp-standalone.ts": 2893,
     "src/codegen/stack-balance.ts": 2772,
     "src/codegen/statements/control-flow.ts": 1529,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2511,14 +2511,10 @@ export function generateModule(
     fillBuiltinFnMeta(ctx);
 
     // (#3130) Splice the `$Error_struct` arm into `__extern_get` so dynamic
-    // (`any`-receiver) reads of `err.message` / `err.name` / `err.stack` /
-    // `err.constructor` — and subclass own fields via the `$props` sidecar —
-    // resolve on native Error objects instead of missing to `undefined`.
-    // `err.constructor` answers the SAME `__builtin_<Name>` carrier global the
-    // bare `TypeError` identifier reads (#2907), so `reason.constructor ===
-    // TypeError` is genuine identity (the §27.2.1.3.2 resolve-settled-*-self
-    // acceptance shape). No-op unless the module constructs native errors
-    // (standalone/wasi only) — byte-identical otherwise.
+    // reads of `err.message`/`err.name`/`err.stack`/`err.constructor` resolve
+    // on native Error objects instead of missing to `undefined` (see the fill's
+    // doc in registry/error-types.ts). No-op unless the module constructs
+    // native errors (standalone/wasi only) — byte-identical otherwise.
     fillExternGetErrorProps(ctx);
 
     // (#2358 #10) Fill the reserved `__array_to_primitive_string` body now that

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { ts, forEachChild } from "../ts-api.js";
 import { emitToBoolean } from "./coercion-engine.js";
-import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { emitWasiErrorConstructor, fillExternGetErrorProps } from "./registry/error-types.js";
 import { analyzeLinearUint8 } from "./linear-uint8-analysis.js";
 import { analyzeFnctorEscapeGate, deriveFnctorFields } from "./fnctor-escape-gate.js";
 import { isLinearU8RepresentableNew } from "./linear-uint8-signatures.js";
@@ -2509,6 +2509,17 @@ export function generateModule(
     // value resolve its spec `name`/`length` at runtime, host-free. No-op when
     // no builtin closure was materialized (standalone only).
     fillBuiltinFnMeta(ctx);
+
+    // (#3130) Splice the `$Error_struct` arm into `__extern_get` so dynamic
+    // (`any`-receiver) reads of `err.message` / `err.name` / `err.stack` /
+    // `err.constructor` — and subclass own fields via the `$props` sidecar —
+    // resolve on native Error objects instead of missing to `undefined`.
+    // `err.constructor` answers the SAME `__builtin_<Name>` carrier global the
+    // bare `TypeError` identifier reads (#2907), so `reason.constructor ===
+    // TypeError` is genuine identity (the §27.2.1.3.2 resolve-settled-*-self
+    // acceptance shape). No-op unless the module constructs native errors
+    // (standalone/wasi only) — byte-identical otherwise.
+    fillExternGetErrorProps(ctx);
 
     // (#2358 #10) Fill the reserved `__array_to_primitive_string` body now that
     // `__extern_length`/`__extern_get_idx` (filled just above) and the native

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -3357,10 +3357,31 @@ function tryEmitConstructorViaTag(
   // undefined" — cascading to ~478 TypedArray tests (net -479). The fix restores
   // the pre-PR fall-through: no class-tag match ⇒ the original generic read.
   const resLocal = allocLocal(fctx, `__ctoridn_res_${fctx.locals.length}`, { kind: "externref" });
-  const externGetIdx =
-    ctx.standalone || ctx.wasi || ctx.strictNoHostImports
-      ? undefined
-      : ensureLateImport(ctx, "__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  // (#3130) Standalone/WASI seed via the NATIVE `__extern_get` (the object
+  // runtime's defined reader), not a hard null. This arm fires for EVERY
+  // `any`-typed `.constructor` read once the module declares one tag-bearing
+  // user class — the test262 harness injects `class Test262Error`, so that is
+  // essentially every standalone program — and the old null seed meant the
+  // read NEVER reached the runtime reader. With fillExternGetErrorProps the
+  // native reader answers `.constructor` on a native `$Error_struct` with the
+  // SAME `__builtin_<Name>` carrier the bare identifier reads, so
+  // `reason.constructor === TypeError` (§27.2.1.3.2 resolve-settled-*-self)
+  // is genuine identity. For every other receiver the native reader preserves
+  // the old behaviour ($Object without a `constructor` prop / non-object →
+  // miss), so nothing regresses. Plain strictNoHostImports (gc, no-host)
+  // keeps the null seed unchanged.
+  let externGetIdx: number | undefined;
+  if (ctx.standalone || ctx.wasi) {
+    ensureObjectRuntime(ctx);
+    externGetIdx = ctx.funcMap.get("__extern_get");
+  } else if (!ctx.strictNoHostImports) {
+    externGetIdx = ensureLateImport(
+      ctx,
+      "__extern_get",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+  }
   if (externGetIdx !== undefined) {
     flushLateImportShifts(ctx, fctx);
     // __extern_get(extern.convert_any(instLocal), "constructor")
@@ -3371,9 +3392,8 @@ function tryEmitConstructorViaTag(
     fctx.body.push({ op: "call", funcIdx: externGetIdx } as Instr);
     fctx.body.push({ op: "local.set", index: resLocal });
   } else {
-    // Standalone / WASI / no-host: no `__extern_get` import. Preserve the prior
-    // behaviour for a non-class receiver (null externref — there is no host
-    // constructor object to recover).
+    // No-host gc mode without the runtime reader: preserve the prior behaviour
+    // for a non-class receiver (null externref).
     fctx.body.push({ op: "ref.null.extern" } as Instr);
     fctx.body.push({ op: "local.set", index: resLocal });
   }

--- a/src/codegen/registry/error-types.ts
+++ b/src/codegen/registry/error-types.ts
@@ -48,7 +48,7 @@ import type { Instr, ValType } from "../../ir/types.js";
 import { BUILTIN_TYPE_TAGS } from "../builtin-tags.js";
 import { addFuncType, getOrRegisterErrorStructType } from "./types.js";
 import { addStringConstantGlobal } from "./imports.js";
-import { stringConstantExternrefInstrs } from "../native-strings.js";
+import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "../native-strings.js";
 
 // (#2962) `getOrRegisterErrorStructType` moved to registry/types.ts so
 // native-strings.ts can import it without an import cycle (this module imports
@@ -103,6 +103,38 @@ export function isWasiErrorName(name: string): name is WasiErrorName {
  */
 export function emitWasiErrorConstructor(ctx: CodegenContext, errorName: WasiErrorName, argCount: number): void {
   emitErrorStructConstructor(ctx, `__new_${errorName}`, errorName, BUILTIN_TYPE_TAGS[errorName], argCount);
+}
+
+/**
+ * (#3130) Get-or-create the `__builtin_<Name>` externref carrier global for an
+ * Error-family constructor. Mirrors the global-creation half of
+ * `emitBuiltinNamespaceObject` (builtin-static-globals.ts) byte-for-byte and
+ * shares its `ctx.builtinObjectGlobals` key space, so the bare-identifier read
+ * and the `err.constructor` runtime arm resolve to the SAME global. The global
+ * starts null; both readers guard with the same lazy `__new_plain_object`
+ * materialization, so first-read-wins and identity holds either way.
+ *
+ * Called from `fillExternGetErrorProps` at FINALIZE — deliberately NOT at
+ * ctor-emit time: the standalone scaffold pre-registers `__new_TypeError` for
+ * virtually every module, and an eager per-ctor global changed bytes on
+ * error-free standalone modules (measured). Appending a global at finalize is
+ * safe: dead-elim never removes/renumbers globals (it only remaps type/func
+ * indices inside inits), and no import globals are added after the fill phase
+ * in standalone/wasi mode, so `numImportGlobals + position` is final.
+ */
+function ensureErrorCtorCarrierGlobal(ctx: CodegenContext, name: string): number {
+  let globalIdx = ctx.builtinObjectGlobals.get(name);
+  if (globalIdx === undefined) {
+    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: `__builtin_${name}`,
+      type: { kind: "externref" },
+      mutable: true,
+      init: [{ op: "ref.null.extern" }],
+    });
+    ctx.builtinObjectGlobals.set(name, globalIdx);
+  }
+  return globalIdx;
 }
 
 /**
@@ -187,4 +219,242 @@ function emitErrorStructConstructor(
     body,
     exported: false,
   });
+}
+
+/**
+ * (#3130) Finalize-time fill: teach `__extern_get` — the universal dynamic
+ * property reader every `any`-receiver read terminally routes through
+ * (`__dyn_get`, the `__get_member_<name>` dispatcher fallbacks, typed reads
+ * with no fast path) — to answer property reads on a native `$Error_struct`
+ * receiver.
+ *
+ * WHY: `__extern_get` unwraps its receiver to `$Object` and answers a miss
+ * (undefined) for anything else. A thrown/constructed native Error is an
+ * `$Error_struct`, NOT an `$Object`, so `reason.constructor`, `err.name`,
+ * `err.message` on an `any`-typed value all read back `undefined` in
+ * standalone mode even though the struct carries the data and `instanceof`
+ * (tag-driven) passes. The static fast path in property-access.ts only
+ * covers statically-Error-typed receivers and `catch`-clause bindings — a
+ * promise rejection callback parameter (`reason`) is neither, which is
+ * exactly the `resolve-settled-*-self` §27.2.1.3.2 acceptance shape.
+ *
+ * The spliced arm, in shadowing order:
+ *   1. `$props` sidecar (fieldIdx 5, subclass own fields / dynamic writes):
+ *      recursive `__extern_get` — it holds a plain `$Object`, so accessors +
+ *      proto chain resolve normally; a nullish result falls through.
+ *   2. String-key dispatch (flatten once, `__str_equals` per candidate —
+ *      the fillBuiltinFnMeta pattern): `message`→field 1, `name`→field 2,
+ *      `stack`→field 3.
+ *   3. `constructor` → the per-name `__builtin_<Name>` bare-identifier
+ *      carrier global (#2907), lazily materialized with the SAME
+ *      `__new_plain_object` guard `emitBuiltinNamespaceObject` uses — so
+ *      `err.constructor === TypeError` is GENUINE object identity. Gated on
+ *      `$userClassId == -1` (a user subclass instance must NOT answer its
+ *      builtin parent's constructor) and, for the shared "Error" tag, on the
+ *      `$name` field equalling "Error" (a Test262Error shares the Error tag
+ *      but is a user harness class — it keeps today's miss).
+ *   4. Anything else falls through to the original body → the standard miss.
+ *
+ * Shift-safety (the fillBuiltinFnMeta discipline): runs at finalize BEFORE
+ * dead-elim; resolves every funcIdx BY NAME from the shift-maintained maps at
+ * fill time; splices into the existing body (never rebuilds it — see
+ * `reference_no_rebuild_helper_body_at_finalize`); `ref.test`/`ref.cast`/
+ * `struct.get` use type indices (append-only pre-emission). New locals are
+ * APPENDED so existing local indices are untouched.
+ *
+ * No-op (byte-identical) unless the module registered `$Error_struct`
+ * (i.e. actually constructs native errors) under wasi/standalone.
+ */
+export function fillExternGetErrorProps(ctx: CodegenContext): void {
+  if (!(ctx.wasi || ctx.standalone)) return;
+  const errTypeIdx = ctx.errorStructTypeIdx;
+  if (errTypeIdx < 0) return; // no native Error structs in this module
+  const fn = ctx.mod.functions.find((f) => f.name === "__extern_get");
+  if (!fn) return; // object runtime never emitted (nothing reads dynamically)
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
+  const newObjectIdx = ctx.funcMap.get("__new_plain_object");
+  if (
+    externGetIdx === undefined ||
+    strFlattenIdx === undefined ||
+    strEqualsIdx === undefined ||
+    newObjectIdx === undefined
+  ) {
+    return;
+  }
+  if (ctx.anyStrTypeIdx < 0 || ctx.nativeStrTypeIdx < 0) return;
+  // (#2106 S1) Under the undefined-singleton regime the recursive $props read
+  // answers the singleton on a miss (non-null), so presence is "non-nullish";
+  // legacy regime: miss = null.
+  const isNullishIdx = ctx.funcMap.get("__extern_is_nullish");
+
+  // __extern_get: params 0=obj 1=key; existing locals o(2) e(3) any(4)
+  // getter(5) bfmeta(6). Append ours — never renumber existing ones.
+  const anyL = 2 + fn.locals.length;
+  const fkeyL = anyL + 1;
+  const scratchL = anyL + 2;
+  fn.locals.push(
+    { name: "__err_any", type: { kind: "anyref" } },
+    { name: "__err_fkey", type: { kind: "ref_null", typeIdx: ctx.nativeStrTypeIdx } },
+    { name: "__err_scratch", type: { kind: "externref" } },
+  );
+
+  const errRef = (): Instr[] => [
+    { op: "local.get", index: anyL } as Instr,
+    { op: "ref.cast", typeIdx: errTypeIdx } as Instr,
+  ];
+  const keyEquals = (lit: string): Instr[] => [
+    { op: "local.get", index: fkeyL } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+    ...nativeStringLiteralInstrs(ctx, lit),
+    { op: "call", funcIdx: strEqualsIdx } as Instr,
+  ];
+  // key == "<lit>" → return struct field <fieldIdx> (externref, returned raw:
+  // the same value rep the typed fast path in property-access.ts yields).
+  const fieldArm = (lit: string, fieldIdx: number): Instr[] => [
+    ...keyEquals(lit),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...errRef(), { op: "struct.get", typeIdx: errTypeIdx, fieldIdx } as Instr, { op: "return" } as Instr],
+    } as Instr,
+  ];
+
+  // One `constructor` arm per builtin error ctor EMITTED in this module. The
+  // carrier global is get-or-created HERE (append-only; see
+  // ensureErrorCtorCarrierGlobal for why finalize-time creation is safe) —
+  // reusing the bare-identifier read's global when one exists.
+  const ctorArms: Instr[] = [];
+  for (const name of WASI_ERROR_NAMES) {
+    if (!ctx.funcMap.has(`__new_${name}`)) continue;
+    const globalIdx = ensureErrorCtorCarrierGlobal(ctx, name);
+    const answerCarrier: Instr[] = [
+      { op: "global.get", index: globalIdx } as Instr,
+      { op: "ref.is_null" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "call", funcIdx: newObjectIdx } as Instr, { op: "global.set", index: globalIdx } as Instr],
+      } as Instr,
+      { op: "global.get", index: globalIdx } as Instr,
+      { op: "return" } as Instr,
+    ];
+    // The "Error" tag is SHARED with Test262Error (emitStandaloneTest262Error
+    // constructs with the Error tag). Disambiguate by the immutable `$name`
+    // field: only a genuine `new Error(...)` (name === "Error") answers the
+    // Error carrier; Test262Error keeps today's miss.
+    const guarded: Instr[] =
+      name === "Error"
+        ? [
+            ...errRef(),
+            { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 2 } as Instr,
+            { op: "any.convert_extern" } as Instr,
+            { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "i32" } as ValType },
+              then: [
+                ...errRef(),
+                { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 2 } as Instr,
+                { op: "any.convert_extern" } as Instr,
+                { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+                { op: "call", funcIdx: strFlattenIdx } as Instr,
+                ...nativeStringLiteralInstrs(ctx, "Error"),
+                { op: "call", funcIdx: strEqualsIdx } as Instr,
+              ],
+              else: [{ op: "i32.const", value: 0 } as Instr],
+            } as Instr,
+            { op: "if", blockType: { kind: "empty" }, then: answerCarrier } as Instr,
+          ]
+        : answerCarrier;
+    ctorArms.push(
+      ...errRef(),
+      { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 0 } as Instr,
+      { op: "i32.const", value: BUILTIN_TYPE_TAGS[name] } as Instr,
+      { op: "i32.eq" } as Instr,
+      { op: "if", blockType: { kind: "empty" }, then: guarded } as Instr,
+    );
+  }
+
+  // "is the $props read a miss?" — leaves an i32 on the stack.
+  const propsMiss = (): Instr[] =>
+    isNullishIdx !== undefined
+      ? [{ op: "local.get", index: scratchL } as Instr, { op: "call", funcIdx: isNullishIdx } as Instr]
+      : [{ op: "local.get", index: scratchL } as Instr, { op: "ref.is_null" } as Instr];
+
+  const arm: Instr[] = [
+    { op: "local.get", index: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: anyL } as Instr,
+    { op: "ref.test", typeIdx: errTypeIdx } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // 1) $props sidecar first — subclass own fields / dynamic writes shadow
+        //    the builtin surface (JS shadowing order).
+        ...errRef(),
+        { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 5 } as Instr,
+        { op: "local.tee", index: scratchL } as Instr,
+        { op: "ref.is_null" } as Instr,
+        { op: "i32.eqz" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: scratchL } as Instr,
+            { op: "local.get", index: 1 } as Instr,
+            { op: "call", funcIdx: externGetIdx } as Instr, // recursive: $props IS a plain $Object
+            { op: "local.set", index: scratchL } as Instr,
+            ...propsMiss(),
+            { op: "i32.eqz" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: scratchL } as Instr, { op: "return" } as Instr],
+            } as Instr,
+          ],
+        } as Instr,
+        // 2) Named-key dispatch — string keys only. A Symbol / boxed-number key
+        //    skips this block and falls through to the standard miss, exactly
+        //    like today (no trap: the cast is guarded by the ref.test).
+        { op: "local.get", index: 1 } as Instr,
+        { op: "any.convert_extern" } as Instr,
+        { op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: 1 } as Instr,
+            { op: "any.convert_extern" } as Instr,
+            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+            { op: "call", funcIdx: strFlattenIdx } as Instr,
+            { op: "local.set", index: fkeyL } as Instr,
+            ...fieldArm("message", 1),
+            ...fieldArm("name", 2),
+            ...fieldArm("stack", 3),
+            ...keyEquals("constructor"),
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                // Builtin instances only: a user subclass ($userClassId != -1)
+                // keeps today's miss rather than answering the WRONG (parent)
+                // constructor.
+                ...errRef(),
+                { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 4 } as Instr,
+                { op: "i32.const", value: -1 } as Instr,
+                { op: "i32.eq" } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: ctorArms } as Instr,
+              ],
+            } as Instr,
+          ],
+        } as Instr,
+        // No match → fall through to the original body → standard miss.
+      ],
+    } as Instr,
+  ];
+
+  fn.body.splice(0, 0, ...arm);
 }


### PR DESCRIPTION
## Problem (#3130)

On `--target standalone`, a native Error object's property surface is invisible to dynamic (`any`-receiver) reads: `reason.constructor` / `err.name` / `err.message` all read `undefined` even though `instanceof` (tag-driven) passes. This is the residual #3128 isolated — it blocks the two §27.2.1.3.2 acceptance files (`resolve-settled-{fulfilled,rejected}-self.js`), which assert `reason.constructor !== TypeError`.

## Root cause — two dropped links

1. **`__extern_get` had no `$Error_struct` arm.** The universal dynamic reader (terminal for `__dyn_get`, `__get_member_*` fallbacks, generic reads) unwraps only `$Object` receivers; an `$Error_struct` always missed. The static fast path covers only statically-Error-typed receivers and catch bindings — a promise rejection-callback parameter is neither.
2. **`tryEmitConstructorViaTag` null seed.** For any-typed `.constructor` reads it intercepts at compile time whenever one tag-bearing user class exists (the test262 harness injects `class Test262Error` ⇒ essentially every program) and seeded the non-user-class result with a hard `ref.null.extern` in standalone/wasi — the read never reached the runtime reader at all.

## Fix

- **`fillExternGetErrorProps`** (registry/error-types.ts, finalize, `fillBuiltinFnMeta` shift-safety discipline): splices an `$Error_struct` arm into `__extern_get` — `$props` sidecar first, then `message`/`name`/`stack` struct fields, then `constructor` → the SAME per-name `__builtin_<Name>` carrier global the bare `TypeError` identifier reads (#2907) ⇒ genuine strict-eq identity. Gated on `$userClassId == -1`; the shared Error tag disambiguates Test262Error via the `$name` field.
- **Seed fix** in `tryEmitConstructorViaTag`: standalone/wasi seeds via the native `__extern_get` instead of null. Host/gc path unchanged.

## Measured

- **Acceptance**: both `resolve-settled-*-self.js` files **fail → pass** (widen arm, standalone) on a local merge with #3128's branch (PR #2843). On this branch alone they still need #2843's promise fixes — expected.
- **Error family** (NativeErrors + Error, 152 files, standalone): 49→50 pass, **zero regressions** (+ `Error/message_property.js` flips).
- **Regression sweep** (Promise/prototype/then + statements/try, 276 files, widen): per-file diff **empty** vs main.
- **Emit identity**: gc/host byte-identical on all probes incl. error-throwing code; standalone byte-identical on error-free code.
- vitest error-slice: same 8 pre-existing environmental WASI failures as main, 56 pass.
- tsc clean; LOC baseline regenerated for intended growth (+20 property-access seed, +7 index.ts fill call).

## Note for #2843 (fable-3128)

Both branches add `plan/issues/3130-*.md` — if this lands first, resolve the add/add by taking main's version (carries `status: done` + implementation notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS