### PR TITLE
fix(#3084): defer RegExp lastIndex coercion during protocol calls (spec §22.2.6.8/11/14) — unblocks #2777

### DIFF
--- a/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
+++ b/plan/issues/3074-typedarray-harness-wrapper-callback-vacuous-both-lanes.md
@@ -1,8 +1,9 @@
 ---
 id: 3074
 title: "TypedArray harness-wrapper callback never executes → vacuous fail (both lanes; persists after #2939/#2940)"
-status: in-progress
+status: done
 assignee: ttraenkler/dev-keystone
+completed: 2026-07-08
 sprint: Backlog
 priority: high
 feasibility: hard
@@ -207,3 +208,12 @@ without dispatch, none of these bodies run at all):
 3. **BigInt TypedArray i64 codegen CE** (`Binary emit error: RangeError: offset
    is out of bounds`) — ~22/30 sampled BigInt-TA files; pre-existing, unrelated
    to dispatch.
+
+## Status reconcile (fable-3084, 2026-07-10)
+
+Frontmatter flipped `in-progress` → `done` retroactively: the implementation
+PR **#2790** (`fix(#3074): dispatch any-typed HOF callbacks on the gc/host
+lane`) MERGED 2026-07-08 but did not carry the status flip (the pre-#2786-era
+watcher died before the post-merge cleanup). Follow-ups all resolved: #3087
+done (PRs #2800 + #2802), #3088 done (PR #2796), #3089 wont-fix, #3083
+wont-fix.

--- a/plan/issues/3084-regexp-lastindex-eager-coerce-protocol.md
+++ b/plan/issues/3084-regexp-lastindex-eager-coerce-protocol.md
@@ -1,7 +1,8 @@
 ---
 id: 3084
 title: "RegExp @@match/@@replace/@@split eager lastIndex coercion during protocol violates §22.2.6.8 (fires valueOf on non-empty match)"
-status: ready
+status: done
+assignee: ttraenkler/fable-3084
 sprint: current
 priority: high
 horizon: m
@@ -14,6 +15,7 @@ model: fable
 related: [3051, 2777, 2671]
 blocks: [2777]
 created: 2026-07-07
+completed: 2026-07-10
 origin: "2026-07-07 — surfaced by PR #2777 (#3051 accessor-only exec-result marshaling). Verified on main f426ef61 (PASS) vs #2777 branch (FAIL) via runTest262File."
 ---
 
@@ -136,3 +138,45 @@ fable`**.
   that is *this* pre-existing bug). #2777 is held (option B, cluster-gated with
   #2774/#3076 on the owner's vacuity-metric decision), not excused, until this
   lands.
+
+## Resolution (fable-3084, 2026-07-10 — MEASURED)
+
+**Fix landed:** delete the eager `_regexProtocolDepth > 0` coercion branch in
+the `RegExp.lastIndex` set handler (`src/runtime.ts`) — a struct assignment now
+ALWAYS stores the deferred `_makeLastIndexShim`, protocol or not. The
+now-dead `_regexProtocolDepth` counter (decl + inc/dec around
+`__regex_symbol_call`) was removed with it.
+
+**Why the issue's "correct fix" section over-scoped.** It proposed re-implementing
+the three protocol loops to read the JS-visible `lastIndex` per spec, on the
+premise (inherited from #2671's comment) that *"native @@replace does not
+ToLength the JS-visible lastIndex"*. **Measured: that premise is false.** A
+pure-V8 control (overridden `exec`, no compiler involved) shows V8's slow
+(modified-RegExp) protocol path is spec-compliant: an EMPTY match fires the
+stored object's `valueOf` via the §22.2.6.8/11 `ToLength(? Get(rx,"lastIndex"))`
+advance read; a NON-empty match never reads it. So the deferred shim alone is
+sufficient — V8's own protocol loop fires its `Symbol.toPrimitive` exactly when
+the spec mandates. No custom protocol loops needed.
+
+**Measured on the branch (gc/host lane):**
+
+- Compiled probes: non-empty @@match — throwing `valueOf` NOT fired (was:
+  fired, the bug); empty @@match — `valueOf` fired exactly once; empty
+  @@replace — throwing `valueOf` still propagates (the #2671:108 shape, now via
+  the shim instead of the eager hack); non-empty @@replace — object identity
+  preserved (`r.lastIndex === marker`), zero coercions, correct result.
+- `tests/issue-2671-regexp.test.ts`: 8/8 pass (incl. the :108 empty-advance
+  throw).
+- Full RegExp protocol sweep, `built-ins/RegExp/prototype/Symbol.{match,replace,split,search}`
+  (189 files, `poisoned-stdlib.js` excluded as an in-process-harness hazard),
+  branch vs main: **identical 152 pass / 37 fail — zero flips in either
+  direction**. All 37 fails pre-exist on main (dominated by the #3051/#2777
+  accessor-exec-result masking, e.g. `g-match-empty-coerce-lastindex-err.js`).
+- `g-match-no-coerce-lastindex.js` passes on the branch. Note its baseline flip
+  is currently masked (on main it passes VACUOUSLY because the accessor `get 0()`
+  result marshals to null); the honest flip realizes when #2777 lands — which
+  this fix unblocks (acceptance: #2777's sole "regression" was this bug's
+  unmask).
+
+New regression tests: `tests/issue-3084.test.ts` (4 tests, incl. the
+data-property variant of the masked test262 shape).

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5168,16 +5168,18 @@ const _hostProxyReverse = new WeakMap<object, any>();
 // unwraps the shim to the raw struct so an explicit `r.lastIndex` read keeps
 // object identity (`assert.sameValue(r.lastIndex, obj)`).
 //
-// Exception — a set that happens DURING a regex protocol call (`_regexProtocolDepth
-// > 0`), i.e. inside a user-overridden `exec` invoked by
-// RegExp.prototype[@@replace/@@split/…]: the native protocol then does NOT coerce
-// the JS-visible `lastIndex` (V8's @@replace skips the empty-match ToLength of
-// the property), so a deferred shim would never fire valueOf. Coerce eagerly
-// here so a throwing `valueOf` surfaces at the assignment (matching the spec's
-// "abrupt completion during coercion of lastIndex"), storing the resulting
-// number. Primitive numbers are always stored verbatim.
+// (#3084) A set DURING a regex protocol call (inside a user-overridden `exec`
+// invoked by RegExp.prototype[@@match/@@replace/@@split]) ALSO defers.
+// §22.2.6.8/11/14 store the assigned value verbatim; the property is only read
+// as `ToLength(? Get(rx, "lastIndex"))` in the EMPTY-match advance branch, and
+// V8's slow (modified-RegExp) protocol path performs exactly that read —
+// measured: empty match fires the shim's valueOf via the native ToLength;
+// non-empty match never reads it (so a throwing valueOf must NOT fire,
+// Symbol.match/g-match-no-coerce-lastindex.js). The former eager
+// protocol-depth coercion here fired valueOf unconditionally at assignment
+// time, which was spec-incorrect for the non-empty-match case.
+// Primitive numbers are always stored verbatim.
 const _lastIndexShimRaw = new WeakMap<object, any>();
-let _regexProtocolDepth = 0;
 function _makeLastIndexShim(
   struct: any,
   callbackState?: { getExports: () => Record<string, Function> | undefined },
@@ -8438,13 +8440,22 @@ function resolveImport(
           return (self: any, v: any) => {
             if (!_isWasmStruct(v)) {
               _safeSet(self, "lastIndex", v);
-            } else if (_regexProtocolDepth > 0) {
-              // Set during a regex protocol method (overridden exec): the native
-              // protocol won't coerce the JS-visible lastIndex, so fire valueOf
-              // eagerly (a throw surfaces as the program's own error) and store
-              // the number.
-              _safeSet(self, "lastIndex", Number(_hostToPrimitive(v, "number", callbackState)));
             } else {
+              // (#3084) ALWAYS defer — including during a regex protocol call
+              // (`r.lastIndex = {valueOf(){…}}` inside a user-overridden `exec`
+              // invoked by @@match/@@replace/@@split). §22.2.6.8/11/14 store
+              // the assigned value verbatim and only READ it as
+              // `ToLength(? Get(rx, "lastIndex"))` in the EMPTY-match advance
+              // branch. V8's slow (modified-RegExp) protocol path is
+              // spec-compliant here — measured: with an overridden `exec`, an
+              // empty match fires the stored object's valueOf via that ToLength
+              // read; a non-empty match never reads it. The shim's
+              // Symbol.toPrimitive bridges that native read to the struct's
+              // compiled valueOf (a throw propagates as the program's own
+              // error), so the previous eager `_regexProtocolDepth > 0`
+              // coercion was both unnecessary (empty match: the shim fires) and
+              // spec-incorrect (non-empty match: valueOf must NOT fire —
+              // Symbol.match/g-match-no-coerce-lastindex.js).
               _safeSet(self, "lastIndex", _makeLastIndexShim(v, callbackState));
             }
           };
@@ -11412,44 +11423,39 @@ assert._isSameValue = isSameValue;
           // ToString(arg) coercion finds the struct's toString/valueOf
           // closures via the host proxy.
           const wrappedArg0 = _isWasmStruct(arg0) ? _wrapForHost(arg0, exports) : arg0;
-          // (#2671) Track regex-protocol nesting so a `lastIndex` set performed
-          // by a user-overridden `exec` invoked from here coerces eagerly (the
-          // native protocol won't ToLength the JS-visible property). A counter,
-          // not a flag, so nested protocol calls (a replace callback that calls
-          // .match) restore the depth correctly; `finally` covers every return
-          // and any thrown abrupt completion.
-          _regexProtocolDepth++;
-          try {
-            // @@match/@@matchAll/@@search are 1-arg (string).
-            // @@replace is 2-arg: (string, replaceValue) — replaceValue may
-            //   be a function or a string.
-            // @@split is 2-arg: (string, limit) — limit is a number.
-            if (symbolId === 7 || symbolId === 9 || symbolId === 15) {
-              return fn.call(regex, wrappedArg0);
-            }
-            if (symbolId === 8) {
-              // Treat missing arg1 (null from ref.null.extern padding) as
-              // undefined → ToString gives "undefined" per spec, matching
-              // `regex[Symbol.replace](str)` with no replaceValue.
-              if (arg1 == null) return fn.call(regex, wrappedArg0, undefined);
-              return fn.call(regex, wrappedArg0, wrapCallable(arg1));
-            }
-            if (symbolId === 10) {
-              // split: missing limit (null padding) → call without second arg
-              // so the spec default 2^32-1 applies. JS `splitter.call(rx, S, null)`
-              // would coerce null to 0 and return [] — wrong.
-              if (arg1 == null) return fn.call(regex, wrappedArg0);
-              // The limit goes through ToUint32 → ToNumber → ToPrimitive; when
-              // it's a wasmGC struct (e.g. `{valueOf(){…}}`), wrap it so the
-              // host proxy exposes the struct's valueOf/toString closure (#1331).
-              return fn.call(regex, wrappedArg0, wrapCallable(arg1));
-            }
-            // Generic fallback
-            if (arg1 == null) return fn.call(regex, wrappedArg0);
-            return fn.call(regex, wrappedArg0, arg1);
-          } finally {
-            _regexProtocolDepth--;
+          // (#3084) No protocol-depth tracking here anymore: a `lastIndex` set
+          // performed by a user-overridden `exec` invoked from these protocols
+          // now ALWAYS stores the deferred shim; V8's spec-compliant slow path
+          // fires it via `ToLength(? Get(rx, "lastIndex"))` exactly in the
+          // empty-match advance branch (§22.2.6.8/11/14) and never otherwise.
+          //
+          // @@match/@@matchAll/@@search are 1-arg (string).
+          // @@replace is 2-arg: (string, replaceValue) — replaceValue may
+          //   be a function or a string.
+          // @@split is 2-arg: (string, limit) — limit is a number.
+          if (symbolId === 7 || symbolId === 9 || symbolId === 15) {
+            return fn.call(regex, wrappedArg0);
           }
+          if (symbolId === 8) {
+            // Treat missing arg1 (null from ref.null.extern padding) as
+            // undefined → ToString gives "undefined" per spec, matching
+            // `regex[Symbol.replace](str)` with no replaceValue.
+            if (arg1 == null) return fn.call(regex, wrappedArg0, undefined);
+            return fn.call(regex, wrappedArg0, wrapCallable(arg1));
+          }
+          if (symbolId === 10) {
+            // split: missing limit (null padding) → call without second arg
+            // so the spec default 2^32-1 applies. JS `splitter.call(rx, S, null)`
+            // would coerce null to 0 and return [] — wrong.
+            if (arg1 == null) return fn.call(regex, wrappedArg0);
+            // The limit goes through ToUint32 → ToNumber → ToPrimitive; when
+            // it's a wasmGC struct (e.g. `{valueOf(){…}}`), wrap it so the
+            // host proxy exposes the struct's valueOf/toString closure (#1331).
+            return fn.call(regex, wrappedArg0, wrapCallable(arg1));
+          }
+          // Generic fallback
+          if (arg1 == null) return fn.call(regex, wrappedArg0);
+          return fn.call(regex, wrappedArg0, arg1);
         };
       // Type.prototype.method.call(receiver, ...args) dispatch for built-in types.
       // Used when e.g. Array.prototype.every.call(functionObj, fn) — the receiver

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8441,21 +8441,9 @@ function resolveImport(
             if (!_isWasmStruct(v)) {
               _safeSet(self, "lastIndex", v);
             } else {
-              // (#3084) ALWAYS defer — including during a regex protocol call
-              // (`r.lastIndex = {valueOf(){…}}` inside a user-overridden `exec`
-              // invoked by @@match/@@replace/@@split). §22.2.6.8/11/14 store
-              // the assigned value verbatim and only READ it as
-              // `ToLength(? Get(rx, "lastIndex"))` in the EMPTY-match advance
-              // branch. V8's slow (modified-RegExp) protocol path is
-              // spec-compliant here — measured: with an overridden `exec`, an
-              // empty match fires the stored object's valueOf via that ToLength
-              // read; a non-empty match never reads it. The shim's
-              // Symbol.toPrimitive bridges that native read to the struct's
-              // compiled valueOf (a throw propagates as the program's own
-              // error), so the previous eager `_regexProtocolDepth > 0`
-              // coercion was both unnecessary (empty match: the shim fires) and
-              // spec-incorrect (non-empty match: valueOf must NOT fire —
-              // Symbol.match/g-match-no-coerce-lastindex.js).
+              // (#3084) ALWAYS defer, protocol call or not — §22.2.6.8/11/14
+              // store the value verbatim; only the empty-match advance reads it
+              // (ToLength → shim fires). See the _makeLastIndexShim doc block.
               _safeSet(self, "lastIndex", _makeLastIndexShim(v, callbackState));
             }
           };

--- a/tests/issue-2671-regexp.test.ts
+++ b/tests/issue-2671-regexp.test.ts
@@ -102,9 +102,13 @@ describe("#2671 — RegExp lastIndex value-preserving slot", () => {
   // Mirrors built-ins/RegExp/prototype/Symbol.replace/coerce-lastindex-err.js.
   // A lastIndex set with a throwing `valueOf` performed INSIDE a user-overridden
   // `exec` (invoked by RegExp.prototype[@@replace]'s empty-match advance) must
-  // surface the abrupt completion. Native @@replace does not ToLength the
-  // JS-visible lastIndex, so this set is coerced eagerly (protocol-depth > 0) and
-  // the throw propagates out of @@replace.
+  // surface the abrupt completion. (#3084) The set stores the deferred coercion
+  // shim VERBATIM per §22.2.6.11; V8's slow protocol path then performs the
+  // spec's `ToLength(? Get(rx, "lastIndex"))` read in the empty-match advance
+  // branch, which fires the shim's valueOf and propagates the throw out of
+  // @@replace. (The former eager protocol-depth coercion at assignment time was
+  // retired by #3084 — it fired valueOf even for NON-empty matches, violating
+  // Symbol.match/g-match-no-coerce-lastindex.js.)
   it("propagates a throwing lastIndex valueOf set during @@replace (overridden exec)", async () => {
     const exp = await run(`
       const r = /./g;

--- a/tests/issue-3084.test.ts
+++ b/tests/issue-3084.test.ts
@@ -1,0 +1,120 @@
+// #3084 — RegExp @@match/@@replace/@@split must NOT eagerly coerce a
+// `lastIndex` assigned during the protocol (inside a user-overridden `exec`).
+//
+// §22.2.6.8 (@@match), §22.2.6.11 (@@replace), §22.2.6.14 (@@split) store an
+// assigned `lastIndex` VERBATIM (plain data property write). The property is
+// only READ as `ToLength(? Get(rx, "lastIndex"))` in the EMPTY-match advance
+// branch (e.g. §22.2.6.8 step 8.g.iv.5). So for a NON-empty match the stored
+// object's `valueOf` must never fire; for an empty match it must fire (and a
+// throw propagates as the program's own error).
+//
+// The bug: the host-side `RegExp.lastIndex` set handler in `src/runtime.ts`
+// eagerly coerced a WasmGC-struct assignment whenever a regex protocol was on
+// the stack (`_regexProtocolDepth > 0`), firing `valueOf` unconditionally at
+// assignment time — spec-incorrect for the non-empty-match case
+// (test262: Symbol.match/g-match-no-coerce-lastindex.js, currently masked on
+// the default baseline by the #3051/#2777 accessor-result marshaling gap).
+//
+// The fix: always store the deferred `_makeLastIndexShim`. Measured (P1/P3
+// below + pure-V8 control): V8's slow (modified-RegExp) protocol path performs
+// the spec's ToLength read of the JS-visible property in the empty-match
+// branch, which fires the shim's Symbol.toPrimitive → the struct's compiled
+// valueOf — so the empty-match throw of tests/issue-2671-regexp.test.ts:108
+// still propagates without the eager hack.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#3084 — no eager lastIndex coercion during RegExp protocol calls", () => {
+  // Mirrors Symbol.match/g-match-no-coerce-lastindex.js (data-property variant:
+  // the real test sets lastIndex inside `get 0()`, which is masked until #2777;
+  // setting it inside `exec` itself exercises the identical protocol-depth set).
+  it("@@match with a NON-empty match never fires the assigned lastIndex valueOf", async () => {
+    const exp = await run(`
+      const r = /./g;
+      let state = 0;
+      (r as any).exec = function(): any {
+        if (state > 0) { return null; }
+        state = 1;
+        r.lastIndex = { valueOf: function(): number { throw new Error('SHOULD-NOT-FIRE'); } } as any;
+        return { length: 1, 0: 'a non-empty string', index: 0 };
+      };
+      let out = 'no-throw';
+      try { (r as any)[Symbol.match](''); } catch (e: any) { out = 'threw:' + e.message; }
+      return out;
+    `);
+    expect(exp.test()).toBe("no-throw");
+  });
+
+  // Empty-match advance: the spec's ToLength(Get(rx, "lastIndex")) read fires
+  // the deferred shim exactly once (§22.2.6.8 step 8.g.iv.5).
+  it("@@match with an EMPTY match fires the assigned lastIndex valueOf exactly once", async () => {
+    const exp = await run(`
+      const r = /./g;
+      let calls = 0;
+      let n = 0;
+      (r as any).exec = function(): any {
+        if (n > 0) { return null; }
+        n = 1;
+        r.lastIndex = { valueOf: function(): number { calls++; return 0; } } as any;
+        return { length: 1, 0: '', index: 0 };
+      };
+      (r as any)[Symbol.match]('');
+      return calls;
+    `);
+    expect(exp.test()).toBe(1);
+  });
+
+  // The #2671:108 companion — a THROWING valueOf set during @@replace with an
+  // empty match must still propagate (now via the shim's deferred ToLength read
+  // instead of the retired eager assignment-time coercion).
+  it("@@replace empty-match advance still propagates a throwing lastIndex valueOf", async () => {
+    const exp = await run(`
+      const r = /./g;
+      let execWasCalled = false;
+      const coercibleIndex = { valueOf: function(): number { throw new Error('T262'); } };
+      const result: any = { length: 1, 0: '', index: 0 };
+      (r as any).exec = function(): any {
+        if (execWasCalled) { return null; }
+        r.lastIndex = coercibleIndex as any;
+        execWasCalled = true;
+        return result;
+      };
+      let threw = 'no';
+      try { (r as any)[Symbol.replace]('', ''); } catch (e: any) { threw = 'yes'; }
+      return threw;
+    `);
+    expect(exp.test()).toBe("yes");
+  });
+
+  // Non-empty @@replace: the assigned object must survive un-coerced (verbatim
+  // store + no read), and the replace result must be correct.
+  it("@@replace with a NON-empty match neither fires nor loses the assigned lastIndex object", async () => {
+    const exp = await run(`
+      const r = /./g;
+      let gets = 0;
+      const marker = { valueOf: function(): number { gets++; return 0; } };
+      let n = 0;
+      (r as any).exec = function(): any {
+        if (n > 0) { return null; }
+        n = 1;
+        r.lastIndex = marker as any;
+        return { length: 1, 0: 'abc', index: 0 };
+      };
+      const out: any = (r as any)[Symbol.replace]('abc', 'X');
+      const identityOk = (r.lastIndex as any) === marker;
+      return out === 'X' && identityOk && gets === 0 ? 'ok' : 'out=' + out + ' identityOk=' + identityOk + ' gets=' + gets;
+    `);
+    expect(exp.test()).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **#3084** — the host-side `RegExp.lastIndex` set handler eagerly coerced a WasmGC-struct assignment whenever a regex protocol call was on the stack (`_regexProtocolDepth > 0`), firing the assigned object's `valueOf` unconditionally at assignment time. Per §22.2.6.8 (@@match) / §22.2.6.11 (@@replace) / §22.2.6.14 (@@split) the value must be stored **verbatim** and only read as `ToLength(? Get(rx, "lastIndex"))` in the **empty-match** advance branch — so for a non-empty match a throwing `valueOf` must NOT fire (`Symbol.match/g-match-no-coerce-lastindex.js`).

## Fix (measure-first)

- **Always store the deferred `_makeLastIndexShim`** — the eager branch is deleted, and the now-dead `_regexProtocolDepth` counter (decl + inc/dec around `__regex_symbol_call`) is removed.
- The issue's proposed fix (re-implementing the three protocol loops) was **over-scoped on a false premise**: measured with a pure-V8 control (overridden `exec`, no compiler), V8's slow (modified-RegExp) protocol path IS spec-compliant — an empty match fires the stored object's `valueOf` via the native ToLength read; a non-empty match never reads it. The deferred shim's `Symbol.toPrimitive` bridges that native read to the struct's compiled `valueOf`, so the empty-advance throw of `tests/issue-2671-regexp.test.ts:108` still propagates with no eager hack and no custom protocol loops.

## Measured validation

- `tests/issue-3084.test.ts` (**new**, 4 tests): non-empty @@match — throwing `valueOf` NOT fired (the bug); empty @@match — `valueOf` exactly once; empty @@replace — throw still propagates; non-empty @@replace — object identity preserved, zero coercions, correct result.
- `tests/issue-2671-regexp.test.ts`: 8/8 pass.
- Full `built-ins/RegExp/prototype/Symbol.{match,replace,split,search}` sweep (189 files, fresh-process batches), **branch vs main: identical 152 pass / 37 fail — zero flips either direction**. All 37 fails pre-exist (dominated by the #3051/#2777 accessor-exec-result masking).
- Adjacent protocol suites (issue-1439/2161/1330/1329-b3/1830): 35/35.
- tsc clean, prettier clean.

## Notes

- The #3084 baseline flip is currently **masked** (on main `g-match-no-coerce-lastindex.js` passes vacuously via the accessor-marshaling gap); the honest flip realizes when **#2777** lands — which this PR unblocks (its sole "regression" was this bug's unmask).
- Also reconciles **#3074** frontmatter to `done` (impl PR #2790 merged 2026-07-08; the flip was dropped when the authoring dev's watcher died) — as flagged to the tech lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8