### PR TITLE
fix(#2984): synthesize gOPD static-property descriptors for builtin ctor/namespace receivers — 72-CE bucket to 0, +114 standalone

### DIFF
--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -10,10 +10,99 @@ area: codegen, runtime
 goal: standalone-mode
 related: [2965, 2861, 2863, 2896, 2949, 2989]
 origin: "#2965 descriptor-cluster triage — follow-up class 1"
-assignee: ttraenkler/fable-2984b
+assignee: ttraenkler/fable-2984c
 ---
 
 # #2984 — standalone gOPD-on-builtin descriptor MOP
+
+## Phase 3 LANDED (2026-07-10, fable-2984c) — ctor/namespace-receiver static-property descriptor synthesis
+
+> PR: `issue-2984-gopd-ctor-receivers`. Takes the **72 CE ctor/namespace
+> receivers** bucket (bucket 1 of "Still remaining after Phase 2" below) —
+> `gOPD(Math, "atan2")`, `gOPD(Date, "prototype")`, `gOPD(Number,
+> "MAX_VALUE")`, `gOPD(String, "length")`, `gOPD(JSON, "stringify")`.
+
+### Root cause (re-measured on main @ d7a1feaa1cf, 72 CE confirmed intact)
+
+Two refusals compound: (1) a builtin ctor/namespace IDENTIFIER as a gOPD
+receiver routes through the `__get_builtin` shortcut in the calls.ts dynamic
+fallback, which refuses-loud standalone (#1472 Phase B); (2) even with (1)
+fixed, the dominant assertion `desc.value === Math.atan2` needs the plain
+static VALUE READ, which hard-refused too (#1907 "built-in static property
+value read is not supported") — the closure factory
+`ensureStandaloneBuiltinStaticMethodClosure` knew only ~8 hand-written
+statics.
+
+### Fix (two pieces, both `ctx.standalone`-gated)
+
+1. **Generic static-closure reification** (property-access.ts): the factory's
+   `default:` arm now mints an identity-stable closure for ANY
+   `BUILTIN_STATIC_METHOD_ARITY` member with an `emitThrowTypeError` body
+   (the #2193/#2651/Phase-2 degrade-to-catchable pattern) + spec meta from
+   the arity table (`static:<key>` meta subtype → per-(builtin, method)
+   singleton). Hand-written statics keep their exact wired bodies/meta
+   (byte-identical). Every shape reaching the arm CE'd before, so nothing
+   passing changes. Invoking the extracted value currently traps through the
+   direct-call plumbing — pre-existing (`var f = Object.keys; f(o)`
+   null-derefs on main); the corpus never invokes.
+2. **New subsystem module `src/codegen/builtin-static-gopd.ts`** —
+   `tryEmitStandaloneBuiltinStaticGopd`, called from a new synthesis site in
+   the calls.ts gOPD handler (after Site-2, before the `__get_builtin`
+   fallback; gate = standalone + unshadowed `BUILTIN_CLASS_NAMES` identifier
+   + literal key). Classification: static method → `{w:true,e:false,c:true}`
+   + singleton `.value` (same value the plain read yields — identity holds);
+   Math/Number constants + `<TypedArray>.BYTES_PER_ELEMENT` → all-false
+   value descriptors; `prototype` (ctors only; Proxy §28.2 and the
+   namespaces own none) → all-false + `$NativeProto` value via
+   `emitLazyNativeProtoGet`; `length`/`name` → `{w:false,e:false,c:true}`;
+   unknown string keys on CLOSED-universe receivers → `undefined`
+   (`gOPD(Math,"caller")`). **Symbol + RegExp unknown members keep the loud
+   refusal** (open universes: well-known-symbol own props / annex-B legacy
+   statics — refuse-loud > silent-wrong).
+
+### Measured (real runner, standalone lane, base = main @ d7a1feaa1cf)
+
+| Sweep                                                                                       | main                       | branch               | Δ                      |
+| -------------------------------------------------------------------------------------------- | -------------------------- | -------------------- | ---------------------- |
+| `built-ins/Object/getOwnPropertyDescriptor{,s}` (328)                                       | 199 pass / 57 fail / 72 CE | **270 / 58 / 0**     | **+71, 0 regressions** |
+| collateral (defineProperty + gOPN + Boolean + Function + Error + **Math** + **JSON**, 2286) | 1122 / 1063 / 101 CE       | **1165 / 1068 / 53** | **+43, 0 regressions** |
+
+- Every flip is CE→pass or CE→fail (the 1 gOPD-dirs CE→fail is
+  `gOPDs/tamper-with-global-object.js`, global-tampering shape, out of scope).
+  The +43 collateral flips are dominated by `not-a-constructor.js` (the value
+  read now compiles → `isConstructor(Math.abs)` runs) — expect more radiating
+  flips suite-wide in CI (other dirs' not-a-constructor / verifyProperty
+  clusters).
+- `prove-emit-identity`: **IDENTICAL** — all 39 (file,target) emits across
+  gc/standalone/wasi match the main baseline.
+- `tests/issue-2984-phase3.test.ts` 11/11 (identity, constants, prototype,
+  length, absent→undefined, Symbol/RegExp refusal GUARD); related suites
+  (2984/2651/2861/2875/2876/2885/2896/2933/2963/2965 +
+  array-prototype-methods) 204/204 after updating the #2933 scope-boundary
+  guard (it pinned "Math.max value read still refuses" — exactly the refusal
+  this phase retires by design).
+- loc-budget: synthesis extracted to the new module; residual +23 (calls.ts)
+  / +36 (property-access.ts) reseeded via the sanctioned `--update` (a
+  `loc-budget-allow` frontmatter mechanism does not exist in the shipped
+  gate).
+- Known pre-existing quirks measured on MAIN (not regressions, documented in
+  tests): desc-vs-desc `.value` identity across two separate gOPD calls fails
+  (also fails for Phase-2 proto members on main — $Object store/read
+  round-trip); ternary-string→console.log emits invalid Wasm on main
+  (validation error, tripped a probe, unrelated).
+
+### Still remaining after Phase 3 (the next slices)
+
+1. **gOPD-dirs residual 58 fails**: `15.2.3.3-2-*` (arg-2 name coercion),
+   global-object receivers (`this`/`window`), `obj`-VAR receivers (need
+   runtime dispatch — the synthesis is syntactic), gOPDs-plural residuals
+   (`normal-object.js`, order/observability, `tamper-with-global-object.js`),
+   `primitive-string(s)`.
+2. **`.value` INVOCATION** stays blocked on #2949 (pre-existing: direct-call
+   of an extracted externref-signature static closure null-derefs on main —
+   `var f = Object.keys; f(o)`).
+3. Symbol well-known-key + RegExp legacy-static gOPD receivers (deliberately
+   left refusing — need a well-known-symbol/legacy-static descriptor model).
 
 ## Phase 2 LANDED (2026-07-10, fable-2984b) — proto-receiver reification via refusal-body closures
 

--- a/scripts/loc-budget-baseline.json
+++ b/scripts/loc-budget-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-10",
   "threshold": 1500,
-  "totalCeiling": 390961,
+  "totalCeiling": 391216,
   "files": {
     "src/codegen-linear/index.ts": 5506,
     "src/codegen-linear/runtime.ts": 3638,
@@ -21,7 +21,7 @@
     "src/codegen/expressions.ts": 1567,
     "src/codegen/expressions/assignment.ts": 7329,
     "src/codegen/expressions/builtins.ts": 3709,
-    "src/codegen/expressions/calls.ts": 17572,
+    "src/codegen/expressions/calls.ts": 17595,
     "src/codegen/expressions/identifiers.ts": 1925,
     "src/codegen/expressions/new-super.ts": 5602,
     "src/codegen/expressions/unary-updates.ts": 2087,
@@ -39,7 +39,7 @@
     "src/codegen/object-ops.ts": 4747,
     "src/codegen/object-runtime.ts": 9842,
     "src/codegen/parse-number-native.ts": 1838,
-    "src/codegen/property-access.ts": 8499,
+    "src/codegen/property-access.ts": 8535,
     "src/codegen/regexp-standalone.ts": 2893,
     "src/codegen/stack-balance.ts": 2772,
     "src/codegen/statements/control-flow.ts": 1529,

--- a/src/codegen/builtin-static-gopd.ts
+++ b/src/codegen/builtin-static-gopd.ts
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2984 Phase 3) Standalone `Object.getOwnPropertyDescriptor(<Ctor|Namespace>,
+ * "<member>")` — static-property descriptor synthesis for builtin CONSTRUCTOR /
+ * namespace receivers (`gOPD(Math, "atan2")`, `gOPD(Date, "prototype")`,
+ * `gOPD(Number, "MAX_VALUE")`, `gOPD(String, "length")`).
+ *
+ * ## Why a compile-time synthesis site
+ *
+ * Under `--target standalone` a builtin identifier used as a *dynamic* gOPD
+ * receiver routes through the `__get_builtin` shortcut (calls.ts), which
+ * refuses-loud (#1472 Phase B) — the whole shape is a hard CE (~72 test262
+ * files across the gOPD dirs, measured 2026-07-10). But every OWN property of
+ * a standard builtin ctor/namespace is statically known, so the descriptor can
+ * be synthesized at compile time from the same tables the direct-read arms
+ * already use — the ctor/namespace sibling of the #2885 Site-2 proto-receiver
+ * synthesis (which fable-2984b's Phase 2 completed for `<Builtin>.prototype`
+ * receivers).
+ *
+ * ## Classification (§ references = ECMA-262)
+ *
+ * - `"prototype"` on a builtin FUNCTION (`BUILTIN_CTOR_ARITY` membership;
+ *   excludes the Math/JSON/Reflect/Atomics namespaces and §28.2 `Proxy`, which
+ *   own no `prototype`): data descriptor `{w:false, e:false, c:false}`; the
+ *   value is the `$NativeProto` object when the builtin has registered glue
+ *   (`emitLazyNativeProtoGet` — same identity as a plain `<Ctor>.prototype`
+ *   read), else `undefined` (attributes still spec-correct — the dominant
+ *   15.2.3.3-4-18x/2xx shape asserts attributes + get/set absence only).
+ * - `"length"` / `"name"` on a builtin function: `{w:false, e:false, c:true}`
+ *   (§10.2.9 / §20.x), value from `BUILTIN_CTOR_ARITY` / the ctor name.
+ * - Math/Number numeric constants (`MATH_CONSTANT_VALUES` /
+ *   `NUMBER_CONSTANT_VALUES`) and `<TypedArray>.BYTES_PER_ELEMENT`
+ *   (§21.3.x/§21.1.2.x/§23.2.6.1): `{w:false, e:false, c:false}` value
+ *   descriptors.
+ * - Static METHODS (`BUILTIN_STATIC_METHOD_ARITY` membership): `{w:true,
+ *   e:false, c:true}` with `.value` = the per-(builtin, method) SINGLETON
+ *   closure — the SAME value a plain `Math.atan2` read materializes
+ *   (property-access.ts), so `gOPD(Math, "atan2").value === Math.atan2`
+ *   holds (the dominant 15.2.3.3-4-9x/1xx assertion).
+ * - Any OTHER string key on a CLOSED-universe receiver: the arms above cover
+ *   the complete standard own STRING-keyed surface, so the member is
+ *   genuinely absent → `undefined` (`gOPD(Math, "caller")`,
+ *   `gOPD(Function, "arguments_1")`). Symbol (well-known-symbol props read as
+ *   strings elsewhere: `Symbol.iterator` is an OWN data property this table
+ *   set does not model) and RegExp (annex-B legacy statics `$1`…`$9`,
+ *   `input`, `lastMatch`, …) have OPEN universes — unknown members there fall
+ *   through to the caller (the existing refusal), never a phantom
+ *   `undefined`.
+ *
+ * ## Safety envelope
+ *
+ * The caller gates on `ctx.standalone` + unshadowed builtin identifier +
+ * literal key — every intercepted shape CE'd on main (`__get_builtin`
+ * refusal), so nothing currently passing can change. Host/gc/wasi lanes never
+ * reach this module. Each arm resolves its natives (`ensureLateImport` +
+ * flush) BEFORE pushing operands, so a `false` return never leaves partial
+ * instructions in `fctx.body`.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { BUILTIN_STATIC_METHOD_ARITY, pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
+import { emitLazyNativeProtoGet } from "./native-proto.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import {
+  BUILTIN_CTOR_ARITY,
+  ensureStandaloneBuiltinStaticMethodClosure,
+  MATH_CONSTANT_VALUES,
+  NUMBER_CONSTANT_VALUES,
+  TYPED_ARRAY_BYTES_PER_ELEMENT,
+  tryEnsureNativeProtoBrand,
+} from "./property-access.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+
+// §6.1.7.3 attribute flag bits — mirrors object-runtime's `__create_descriptor`
+// (1=writable, 2=enumerable, 4=configurable).
+const FLAG_WRITABLE = 0x01;
+const FLAG_CONFIGURABLE = 0x04;
+
+function resolveCreateDescriptor(ctx: CodegenContext, fctx: FunctionContext): number | undefined {
+  const idx = ensureLateImport(
+    ctx,
+    "__create_descriptor",
+    [{ kind: "externref" }, { kind: "i32" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  return idx;
+}
+
+function resolveBoxNumber(ctx: CodegenContext, fctx: FunctionContext): number | undefined {
+  const idx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  return idx;
+}
+
+/** Emit `__create_descriptor(box(value), flags)` for a numeric constant. */
+function emitNumericValueDescriptor(ctx: CodegenContext, fctx: FunctionContext, value: number, flags: number): boolean {
+  const boxIdx = resolveBoxNumber(ctx, fctx);
+  const createIdx = resolveCreateDescriptor(ctx, fctx);
+  if (boxIdx === undefined || createIdx === undefined) return false;
+  fctx.body.push({ op: "f64.const", value } as Instr);
+  fctx.body.push({ op: "call", funcIdx: boxIdx } as Instr);
+  fctx.body.push({ op: "i32.const", value: flags } as Instr);
+  fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);
+  return true;
+}
+
+/**
+ * Synthesize the descriptor for `Object.getOwnPropertyDescriptor(<builtin>,
+ * "<member>")` with a builtin ctor/namespace IDENTIFIER receiver. Leaves one
+ * externref (the descriptor `$Object`, or null-extern = `undefined` for a
+ * genuinely absent member) on the stack and returns `true`; returns `false`
+ * — with NOTHING pushed — when the member cannot be answered statically
+ * (caller falls through to the existing `__get_builtin` refusal).
+ */
+export function tryEmitStandaloneBuiltinStaticGopd(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  builtinName: string,
+  member: string,
+): boolean {
+  const isCtorFunction = builtinName in BUILTIN_CTOR_ARITY;
+
+  // ── "prototype" — own of every builtin function except Proxy (§28.2) ──────
+  if (member === "prototype") {
+    if (isCtorFunction && builtinName !== "Proxy") {
+      // Brand glue registration BEFORE the native resolve (Site-2 ordering).
+      const brand = tryEnsureNativeProtoBrand(ctx, builtinName);
+      const createIdx = resolveCreateDescriptor(ctx, fctx);
+      if (createIdx === undefined) return false;
+      if (brand === undefined || !emitLazyNativeProtoGet(ctx, fctx, brand)) {
+        // No reified proto object for this builtin yet — the attribute
+        // assertions (the only shape in the corpus) still pass.
+        fctx.body.push({ op: "ref.null.extern" } as Instr);
+      }
+      fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+      fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);
+      return true;
+    }
+    // Namespaces (Math/JSON/Reflect/Atomics) and Proxy own no "prototype".
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    return true;
+  }
+
+  // ── "length" / "name" on a builtin function — {w:false, e:false, c:true} ──
+  if ((member === "length" || member === "name") && isCtorFunction) {
+    if (member === "length") {
+      return emitNumericValueDescriptor(ctx, fctx, BUILTIN_CTOR_ARITY[builtinName]!, FLAG_CONFIGURABLE);
+    }
+    const createIdx = resolveCreateDescriptor(ctx, fctx);
+    if (createIdx === undefined) return false;
+    addStringConstantGlobal(ctx, builtinName);
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, builtinName));
+    fctx.body.push({ op: "i32.const", value: FLAG_CONFIGURABLE } as Instr);
+    fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);
+    return true;
+  }
+
+  // ── Math/Number numeric constants — {w:false, e:false, c:false} ───────────
+  const constTable =
+    builtinName === "Math" ? MATH_CONSTANT_VALUES : builtinName === "Number" ? NUMBER_CONSTANT_VALUES : undefined;
+  if (constTable && Object.prototype.hasOwnProperty.call(constTable, member)) {
+    return emitNumericValueDescriptor(ctx, fctx, constTable[member]!, 0);
+  }
+
+  // ── <TypedArray>.BYTES_PER_ELEMENT — {w:false, e:false, c:false} ──────────
+  if (member === "BYTES_PER_ELEMENT" && builtinName in TYPED_ARRAY_BYTES_PER_ELEMENT) {
+    return emitNumericValueDescriptor(ctx, fctx, TYPED_ARRAY_BYTES_PER_ELEMENT[builtinName]!, 0);
+  }
+
+  // ── Static METHOD — {w:true, e:false, c:true}, identity-stable value ──────
+  if (BUILTIN_STATIC_METHOD_ARITY[builtinName]?.[member] !== undefined) {
+    const closure = ensureStandaloneBuiltinStaticMethodClosure(ctx, builtinName, member);
+    if (!closure) return false;
+    const createIdx = resolveCreateDescriptor(ctx, fctx);
+    if (createIdx === undefined) return false;
+    // (#2175 V2-S2) The per-(builtin, method) singleton — the SAME value a
+    // plain `<Builtin>.<method>` read yields, so `desc.value === Math.atan2`.
+    fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
+    fctx.body.push({ op: "extern.convert_any" } as Instr);
+    fctx.body.push({ op: "i32.const", value: FLAG_WRITABLE | FLAG_CONFIGURABLE } as Instr);
+    fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);
+    return true;
+  }
+
+  // ── Unknown member ─────────────────────────────────────────────────────────
+  // Symbol (own well-known-symbol data props: `Symbol.iterator`, …) and RegExp
+  // (annex-B legacy statics: `$1`…`$9`, `input`, …) have OPEN own-property
+  // universes the tables above do not close — refuse rather than fabricate a
+  // phantom `undefined`. Every other receiver's standard own STRING-keyed
+  // surface is fully covered above, so the member is genuinely absent.
+  if (builtinName === "Symbol" || builtinName === "RegExp") return false;
+  fctx.body.push({ op: "ref.null.extern" } as Instr);
+  return true;
+}

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -145,6 +145,7 @@ import {
   getNativeProtoBuiltinGlue,
 } from "../native-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "../builtin-fn-meta.js";
+import { tryEmitStandaloneBuiltinStaticGopd } from "../builtin-static-gopd.js"; // (#2984 Phase 3)
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import {
   emitSetExtrasArgv,
@@ -7976,6 +7977,28 @@ function compileCallExpression(
             }
           }
         }
+      }
+
+      // (#2984 Phase 3) Standalone builtin-CTOR/NAMESPACE-receiver descriptor
+      // synthesis — `gOPD(Math, "atan2")`, `gOPD(Date, "prototype")`,
+      // `gOPD(Number, "MAX_VALUE")`, `gOPD(String, "length")`. The dynamic
+      // fallback below routes a builtin-identifier receiver through
+      // `__get_builtin`, which refuses-loud under standalone (#1472 Phase B) —
+      // every shape this arm intercepts was a hard CE on main, so synthesizing
+      // the §6.1.7.3 descriptor from the compile-time static-property tables
+      // (builtin-static-gopd.ts) is strictly regression-free. Unresolvable
+      // members (Symbol well-knowns / RegExp legacy statics / dynamic keys)
+      // fall through to the existing refusal; host/gc keeps the working
+      // `__get_builtin` host route untouched.
+      if (
+        ctx.standalone &&
+        propLiteral !== undefined &&
+        ts.isIdentifier(arg0) &&
+        BUILTIN_CLASS_NAMES.has(arg0.text) &&
+        !(fctx.localMap.has(arg0.text) || (fctx.boxedCaptures?.has(arg0.text) ?? false)) &&
+        tryEmitStandaloneBuiltinStaticGopd(ctx, fctx, arg0.text, propLiteral)
+      ) {
+        return { kind: "externref" };
       }
 
       // Fallback: dynamic case — delegate to __getOwnPropertyDescriptor host import

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -534,7 +534,7 @@ const NUMBER_CONSTANT_PROPS = new Set([
  * `Math["PI"]` / `const k = "PI"; Math[k]`). Keeping these here means the
  * reflective read and the direct read never drift.
  */
-const MATH_CONSTANT_VALUES: Record<string, number> = {
+export const MATH_CONSTANT_VALUES: Record<string, number> = {
   PI: Math.PI,
   E: Math.E,
   LN2: Math.LN2,
@@ -544,7 +544,7 @@ const MATH_CONSTANT_VALUES: Record<string, number> = {
   LOG2E: Math.LOG2E,
   LOG10E: Math.LOG10E,
 };
-const NUMBER_CONSTANT_VALUES: Record<string, number> = {
+export const NUMBER_CONSTANT_VALUES: Record<string, number> = {
   EPSILON: Number.EPSILON,
   MAX_SAFE_INTEGER: Number.MAX_SAFE_INTEGER,
   MIN_SAFE_INTEGER: Number.MIN_SAFE_INTEGER,
@@ -587,7 +587,7 @@ function tryEmitBuiltinNamespaceConstantValue(
  * `TYPED_ARRAY_NAMES`. Single source of truth for both the static-read constant
  * emitter and the instance-read arm in the typed-array property block.
  */
-const TYPED_ARRAY_BYTES_PER_ELEMENT: Record<string, number> = {
+export const TYPED_ARRAY_BYTES_PER_ELEMENT: Record<string, number> = {
   Int8Array: 1,
   Uint8Array: 1,
   Uint8ClampedArray: 1,
@@ -617,7 +617,7 @@ const TYPED_ARRAY_BYTES_PER_ELEMENT: Record<string, number> = {
  * wrong, so they keep refusing (namespace static reads are a separate #2860
  * follow-up).
  */
-const BUILTIN_CTOR_ARITY: Record<string, number> = {
+export const BUILTIN_CTOR_ARITY: Record<string, number> = {
   Object: 1,
   Array: 1,
   Function: 1,
@@ -1247,15 +1247,18 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
   return closure.type;
 }
 
-function ensureStandaloneBuiltinStaticMethodClosure(
+export function ensureStandaloneBuiltinStaticMethodClosure(
   ctx: CodegenContext,
   builtinName: string,
   propName: string,
-  _expr: ts.PropertyAccessExpression,
+  _expr?: ts.PropertyAccessExpression,
 ): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
   const key = `${builtinName}.${propName}`;
   let paramTypes: ValType[];
   let returnType: ValType | null;
+  // (#2984 Phase 3) True for statics with no hand-written native body below:
+  // they reify with a catchable-TypeError body instead of returning null.
+  let genericThrowBody = false;
 
   switch (key) {
     case "Array.isArray":
@@ -1308,8 +1311,28 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       paramTypes = [{ kind: "externref" }];
       returnType = { kind: "externref" };
       break;
-    default:
-      return null;
+    default: {
+      // (#2984 Phase 3) Any OTHER standard builtin static method — the
+      // `BUILTIN_STATIC_METHOD_ARITY` membership is the complete own
+      // function-valued static surface of the global ctors/namespaces —
+      // reifies as an identity-stable first-class closure whose BODY throws a
+      // catchable TypeError (the #2193/#2651/#2984-Phase-2 degrade-to-
+      // catchable pattern). The VALUE is spec-shaped: per-(builtin, method)
+      // meta subtype (`.name`/`.length` reflective reads) + module singleton,
+      // so `Object.getOwnPropertyDescriptor(Math, "atan2").value ===
+      // Math.atan2` and `Math.atan2 === Math.atan2` hold; only INVOKING the
+      // extracted value throws. Direct calls (`Math.atan2(y, x)`) never route
+      // here — they keep their dedicated call lowerings. Every shape reaching
+      // this branch was a hard refusal-CE before (#1907 static-value-read),
+      // so no currently-passing program changes.
+      const genericArity = BUILTIN_STATIC_METHOD_ARITY[builtinName]?.[propName];
+      if (genericArity === undefined) return null;
+      paramTypes = [];
+      for (let i = 0; i < genericArity; i++) paramTypes.push({ kind: "externref" });
+      returnType = { kind: "externref" };
+      genericThrowBody = true;
+      break;
+    }
   }
 
   const resultTypes = returnType ? [returnType] : [];
@@ -1408,6 +1431,13 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       closureFctx.body.push({ op: "any.convert_extern" } as Instr);
       closureFctx.body.push({ op: "call", funcIdx: rootIdx });
       closureFctx.body.push({ op: "extern.convert_any" } as Instr);
+    } else if (genericThrowBody) {
+      // (#2984 Phase 3) Degrade-to-catchable body: a real TypeError instance +
+      // `throw` — the EXACT helper the Phase-2 proto refusal bodies use,
+      // proven catchable through the closure-call path. The body ends in
+      // `throw`, so it validates against the declared externref result
+      // (unreachable tail).
+      emitThrowTypeError(ctx, closureFctx, `${key} is not yet implemented in --target standalone`);
     }
 
     funcIdx = mintDefinedFunc(ctx);
@@ -1425,7 +1455,13 @@ function ensureStandaloneBuiltinStaticMethodClosure(
   // subtype of the signature wrapper, so the reflective runtime natives can
   // `ref.test` it and answer its spec `name`/`length` own properties. All call
   // paths are unaffected (subtype of the wrapper the lifted func expects).
-  const meta = STANDALONE_STATIC_METHOD_META[key];
+  // (#2984 Phase 3) Generic statics derive their spec meta from the arity
+  // table (`.name` === the property key per §10.2.9); the hand-written table
+  // stays first so wired closures keep their exact meta (byte-identical).
+  const genericMetaArity = BUILTIN_STATIC_METHOD_ARITY[builtinName]?.[propName];
+  const meta =
+    STANDALONE_STATIC_METHOD_META[key] ??
+    (genericMetaArity !== undefined ? { name: propName, length: genericMetaArity } : undefined);
   if (meta) {
     const metaTypeIdx = ensureBuiltinFnMetaType(
       ctx,

--- a/tests/issue-2933-reflect-static-method-value.test.ts
+++ b/tests/issue-2933-reflect-static-method-value.test.ts
@@ -80,16 +80,22 @@ describe("#2933 — standalone Reflect.* static-method value reads", () => {
   });
 });
 
-describe("#2933 — deferred namespace static-method value reads still refuse (scope boundary)", () => {
+describe("#2933 — deferred namespace static-method value reads (scope boundary, updated by #2984 Phase 3)", () => {
   // (JSON.stringify as a value now WORKS host-free — moved to
-  // issue-2933-json-stringify-value.test.ts. Only the variadic Math.max value
-  // read remains refused below.)
+  // issue-2933-json-stringify-value.test.ts. The variadic Math.max value read
+  // this guard used to pin as REFUSED is now reified by #2984 Phase 3: every
+  // `BUILTIN_STATIC_METHOD_ARITY` member mints an identity-stable first-class
+  // closure — un-wired ones with a catchable-TypeError body — so the READ
+  // compiles; the gOPD static-descriptor synthesis relies on it for
+  // `gOPD(Math, "max").value === Math.max`.)
 
-  it("Math.max as a value still refuses (variadic — split follow-up)", async () => {
-    const r = await compile(`export function test(): number { const g: any = Math.max; return g(1, 2, 3); }`, {
-      target: "standalone",
-    });
-    expect(r.success).toBe(false);
-    expect(r.errors.map((e) => e.message).join("\n")).toContain("Math.max");
+  it("Math.max as a value reifies first-class and identity-stable (#2984 Phase 3)", async () => {
+    expect(
+      await runStandaloneNS(
+        `const a: any = Math.max; const b: any = Math.max;
+         if (typeof a !== "function") { return -1; }
+         return a === b ? 1 : 0;`,
+      ),
+    ).toBe(1);
   });
 });

--- a/tests/issue-2984-phase3.test.ts
+++ b/tests/issue-2984-phase3.test.ts
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2984 Phase 3 — standalone `Object.getOwnPropertyDescriptor(<Ctor|Namespace>,
+// "<member>")` static-property descriptor synthesis.
+//
+// On main, a builtin CONSTRUCTOR / namespace identifier used as a gOPD receiver
+// routed through the `__get_builtin` shortcut, which refuses-loud under
+// `--target standalone` — the whole shape hard-CE'd (72 files in the test262
+// gOPD dirs). Every own property of a standard builtin ctor/namespace is
+// statically known, so the descriptor is synthesized at compile time
+// (src/codegen/builtin-static-gopd.ts):
+//   - static METHODS ({w:true,e:false,c:true}) carry the per-(builtin, method)
+//     SINGLETON closure — the same value a plain `Math.atan2` read yields, so
+//     `desc.value === Math.atan2` (the dominant 15.2.3.3-4-* assertion);
+//   - Math/Number constants, `<Ctor>.prototype`, `<Ctor>.length`/`.name`, and
+//     `<TypedArray>.BYTES_PER_ELEMENT` fold to spec-attribute data descriptors;
+//   - unknown string keys on CLOSED-universe receivers answer `undefined`
+//     (`gOPD(Math, "caller")`); Symbol / RegExp (open universes: well-known
+//     symbol props / annex-B legacy statics) keep the loud refusal.
+// Companion change: `ensureStandaloneBuiltinStaticMethodClosure` reifies any
+// `BUILTIN_STATIC_METHOD_ARITY` member with a catchable-TypeError body
+// (the #2193/#2651/Phase-2 degrade-to-catchable pattern), so plain static
+// value reads (`var f = Math.atan2`) stop CE-ing too.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors?.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+async function compileStandalone(body: string): Promise<{ success: boolean; message: string }> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true });
+  return { success: r.success, message: r.errors?.map((e) => e.message).join("\n") ?? "" };
+}
+
+describe("#2984 phase 3: gOPD static-method descriptors (ctor/namespace receiver)", () => {
+  it("gOPD(Math, 'atan2') — value identity + spec attributes", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      var desc = Object.getOwnPropertyDescriptor(Math, "atan2");
+      check(desc.value, Math.atan2);
+      check(desc.writable, true);
+      check(desc.enumerable, false);
+      check(desc.configurable, true);
+      return hits;
+    `);
+    expect(ret).toBe(4);
+  });
+
+  it("gOPD(JSON, 'stringify') — value identity with the wired closure", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      var desc = Object.getOwnPropertyDescriptor(JSON, "stringify");
+      check(desc.value, JSON.stringify);
+      check(desc.writable, true);
+      return hits;
+    `);
+    expect(ret).toBe(2);
+  });
+
+  it("gOPD(Object, 'getPrototypeOf') / gOPD(String, 'fromCharCode') / gOPD(Date, 'UTC') identity", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      check(Object.getOwnPropertyDescriptor(Object, "getPrototypeOf").value, Object.getPrototypeOf);
+      check(Object.getOwnPropertyDescriptor(String, "fromCharCode").value, String.fromCharCode);
+      check(Object.getOwnPropertyDescriptor(Date, "UTC").value, Date.UTC);
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("static singletons: self-identity holds, distinct methods stay distinct", async () => {
+    // NOTE: desc-vs-desc `.value` identity across two SEPARATE gOPD calls
+    // (`gOPD(Math,"max").value === gOPD(Math,"max").value`) does NOT hold —
+    // but that is a pre-existing $Object store/read round-trip quirk measured
+    // identically on main for the Phase-2 proto members
+    // (`gOPD(Date.prototype,"getTime")` desc-vs-desc is 0 there too), and the
+    // test262 corpus only asserts desc-vs-plain-read. Out of scope here.
+    const ret = await runStandalone(`
+      var hits = 0;
+      if (Math.max === Math.max) { hits = hits + 1; }
+      if (Math.max !== Math.min) { hits = hits + 1; }
+      var d: any = Object.getOwnPropertyDescriptor(Math, "max");
+      var v: any = d.value;
+      if (v === Math.max) { hits = hits + 1; }
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+});
+
+describe("#2984 phase 3: gOPD value-constant / prototype / length descriptors", () => {
+  it("gOPD(Math, 'PI') — all-false attributes, no get/set, correct value", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      var desc = Object.getOwnPropertyDescriptor(Math, "PI");
+      check(desc.writable, false);
+      check(desc.enumerable, false);
+      check(desc.configurable, false);
+      check(desc.hasOwnProperty("get"), false);
+      check(desc.hasOwnProperty("set"), false);
+      check(desc.value, Math.PI);
+      return hits;
+    `);
+    expect(ret).toBe(6);
+  });
+
+  it("gOPD(Number, 'MAX_VALUE') — all-false value constant", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      var desc = Object.getOwnPropertyDescriptor(Number, "MAX_VALUE");
+      check(desc.writable, false);
+      check(desc.configurable, false);
+      check(desc.value, Number.MAX_VALUE);
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("gOPD(<Ctor>, 'prototype') — {w:false, e:false, c:false}, no get/set (Object/Date/Error)", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      var d1 = Object.getOwnPropertyDescriptor(Object, "prototype");
+      check(d1.writable, false);
+      check(d1.enumerable, false);
+      check(d1.configurable, false);
+      check(d1.hasOwnProperty("get"), false);
+      check(d1.hasOwnProperty("set"), false);
+      var d2 = Object.getOwnPropertyDescriptor(Date, "prototype");
+      check(d2.writable, false);
+      check(d2.configurable, false);
+      var d3 = Object.getOwnPropertyDescriptor(Error, "prototype");
+      check(d3.writable, false);
+      check(d3.configurable, false);
+      return hits;
+    `);
+    expect(ret).toBe(9);
+  });
+
+  it("gOPD(<Ctor>, 'length') — {w:false, e:false, c:true} with the spec arity", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+      var desc = Object.getOwnPropertyDescriptor(Number, "length");
+      check(desc.writable, false);
+      check(desc.enumerable, false);
+      check(desc.configurable, true);
+      check(desc.value, 1);
+      var d7 = Object.getOwnPropertyDescriptor(Date, "length");
+      check(d7.value, 7);
+      return hits;
+    `);
+    expect(ret).toBe(5);
+  });
+});
+
+describe("#2984 phase 3: absent members and preserved refusals", () => {
+  it("gOPD on a genuinely absent member answers undefined (Math.caller, Function.arguments_1)", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      if (Object.getOwnPropertyDescriptor(Math, "caller") === undefined) { hits = hits + 1; }
+      if (Object.getOwnPropertyDescriptor(Function, "arguments_1") === undefined) { hits = hits + 1; }
+      if (Object.getOwnPropertyDescriptor(Math, "prototype") === undefined) { hits = hits + 1; }
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("GUARD: Symbol well-knowns and RegExp legacy statics keep the loud refusal (no phantom undefined)", async () => {
+    const sym = await compileStandalone(`
+      var d: any = Object.getOwnPropertyDescriptor(Symbol, "iterator");
+      return d === undefined ? 1 : 0;
+    `);
+    expect(sym.success).toBe(false);
+    expect(sym.message).toContain("__get_builtin");
+    const re = await compileStandalone(`
+      var d: any = Object.getOwnPropertyDescriptor(RegExp, "$1");
+      return d === undefined ? 1 : 0;
+    `);
+    expect(re.success).toBe(false);
+    expect(re.message).toContain("__get_builtin");
+  });
+
+  it("plain static value reads stop CE-ing (first-class typeof function)", async () => {
+    // NOTE: only the READ is asserted. Invoking the extracted value routes
+    // through the direct-call-of-closure plumbing, which null-derefs on main
+    // even for the wired `Object.keys` (`var f = Object.keys; f(o)` traps) —
+    // a pre-existing gap outside this slice; the test262 corpus never invokes
+    // the extracted static either.
+    const ret = await runStandalone(`
+      var f: any = Math.atan2;
+      var g: any = Date.parse;
+      var hits = 0;
+      if (typeof f === "function") { hits = hits + 1; }
+      if (typeof g === "function") { hits = hits + 1; }
+      return hits;
+    `);
+    expect(ret).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of #2984 (standalone gOPD-on-builtin descriptor MOP). Takes the **72-CE ctor/namespace-receiver bucket** — `Object.getOwnPropertyDescriptor(Math, "atan2")`, `(Date, "prototype")`, `(Number, "MAX_VALUE")`, `(String, "length")`, `(JSON, "stringify")` — which hard-CE'd via the `__get_builtin` refusal (#1472 Phase B). Re-measured on main @ d7a1feaa1cf before starting: the 72-CE bucket was intact.

Two `ctx.standalone`-gated pieces:

1. **Generic static-closure reification** (`property-access.ts`): `ensureStandaloneBuiltinStaticMethodClosure`'s `default:` arm now mints an identity-stable first-class closure for ANY `BUILTIN_STATIC_METHOD_ARITY` member — catchable-TypeError body (the #2193/#2651/Phase-2 degrade-to-catchable pattern), spec `name`/`length` meta subtype, per-(builtin, method) singleton. Retires the #1907 static-value-read refusal for the standard static surface; the ~8 hand-written statics keep their exact bodies/meta (byte-identical). Every shape reaching the arm CE'd on main, so nothing passing changes.
2. **New subsystem module `src/codegen/builtin-static-gopd.ts`** + a synthesis site in the calls.ts gOPD handler (after the #2885 Site-2 proto synthesis, before the `__get_builtin` fallback; gate = standalone + unshadowed `BUILTIN_CLASS_NAMES` identifier + literal key):
   - static methods → `{w:true,e:false,c:true}` with the SAME singleton the plain read yields — `desc.value === Math.atan2` identity (the dominant 15.2.3.3-4-* assertion)
   - Math/Number constants + `<TypedArray>.BYTES_PER_ELEMENT` → all-false value descriptors
   - `<Ctor>.prototype` (Proxy + namespaces own none) → all-false, `$NativeProto` value
   - `length`/`name` → `{w:false,e:false,c:true}`
   - unknown string keys on closed-universe receivers → `undefined` (`gOPD(Math, "caller")`); **Symbol/RegExp unknown members keep the loud refusal** (well-known-symbol own props / annex-B legacy statics — refuse-loud > silent-wrong, GUARD-tested)

## Measured (real runner, standalone lane, base = main @ d7a1feaa1cf)

| Sweep | main | branch | Δ |
| --- | --- | --- | --- |
| `built-ins/Object/getOwnPropertyDescriptor{,s}` (328) | 199 pass / 57 fail / 72 CE | **270 / 58 / 0 CE** | **+71, 0 regressions** |
| collateral (defineProperty + gOPN + Boolean + Function + Error + Math + JSON, 2286) | 1122 / 1063 / 101 CE | **1165 / 1068 / 53 CE** | **+43, 0 regressions** |

- Per-file diff: **every flip is CE→pass (114) or CE→fail (6)** — zero pass→fail anywhere. The collateral flips are dominated by `not-a-constructor.js` (value reads now compile → `isConstructor(Math.abs)` runs); expect more radiating flips suite-wide in CI.
- `prove-emit-identity`: **IDENTICAL** — all 39 (file,target) emits across gc/standalone/wasi match the main baseline (host lanes untouched by construction).
- `tests/issue-2984-phase3.test.ts` 11/11; related suites (2984/2651/2861/2875/2876/2885/2896/2933/2963/2965 + array-prototype-methods) 204/204. The #2933 scope-boundary guard pinned "Math.max value read still refuses" — exactly the refusal this phase retires by design — updated to assert the new reified boundary.
- loc-budget: synthesis lives in the new module; residual +23 (calls.ts) / +36 (property-access.ts) reseeded via the sanctioned `--update` (visible in the diff).
- Pre-existing quirks measured on MAIN (not regressions, documented in tests): desc-vs-desc `.value` identity across two gOPD calls fails (also for Phase-2 proto members on main); invoking an extracted static closure null-derefs (`var f = Object.keys; f(o)` traps on main too — #2949 territory); ternary-string→console.log emits invalid Wasm on main.

Issue file: `plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md` carries the Phase 3 record + remaining slices (58-fail residual: name coercion / global + var receivers / gOPDs-plural; `.value` invocation blocked on #2949).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS