### PR TITLE
feat(#2856): IR claims bench_array — number[] annotation, arr.push, sibling loop counters

### DIFF
--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -2,11 +2,11 @@
 id: 2856
 title: "IR: drive body-shape-rejected fallback bucket to zero (dominant unintended bucket)"
 status: blocked
-assignee:
+assignee: ttraenkler/fable-2856
 spec: banked
 sprint: current
 created: 2026-06-30
-updated: 2026-07-03
+updated: 2026-07-10
 priority: high
 horizon: l
 feasibility: hard
@@ -560,13 +560,13 @@ reduction is banked — the "reduction never happened" premise some dispatch not
 carried is stale). Fresh `JS2WASM_IR_SHAPE_DIAG=1 pnpm run check:ir-fallbacks -- --shape-diag`
 histogram of the current 25:
 
-| count | reject arm                                    | functions |
-| ----- | --------------------------------------------- | --------- |
-| 8 | `nontail-callstmt:CallExpression` | the 8 benchmark-harness `main`s (benchmarks.ts, benchmarks/{array,dom,fib,loop,string,style}.ts, js/builtins.ts) |
-| 4 | `unattributed-arm:helper-internal` | calendar `updFoot`, async `delay`, classes `Animal_new`/`Animal_speak` |
-| 3 | `body-unhandled-stmt:IfStatement` | algorithms `binarySearch`/`quicksort`/`joinNums` |
-| 2 | `vardecl-typenode:ArrayType` | benchmarks.ts + benchmarks/array.ts `bench_array` |
-| 1 each | `expr-unhandled:ArrowFunction` (helpers `addBenchCard`), `tail-unhandled:ExpressionStatement` (calendar `fdow`), `nontail-if-cond:BinaryExpression` (calendar `renderCal`), `nontail-unhandled-stmt:IfStatement` (calendar `onDay`), `nontail-assign-nonprop-lhs:BinaryExpression` (calendar `main`), `vardecl-init-expr:CallExpression` (algorithms `fibMemo`), `expr-arraylit-cloop-guard-1804:ArrayLiteralExpression` (algorithms `main`), `expr-binary-op-instanceof:BinaryExpression` (classes `main`) | — |
+| count  | reject arm                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | functions                                                                                                        |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 8      | `nontail-callstmt:CallExpression`                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | the 8 benchmark-harness `main`s (benchmarks.ts, benchmarks/{array,dom,fib,loop,string,style}.ts, js/builtins.ts) |
+| 4      | `unattributed-arm:helper-internal`                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | calendar `updFoot`, async `delay`, classes `Animal_new`/`Animal_speak`                                           |
+| 3      | `body-unhandled-stmt:IfStatement`                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | algorithms `binarySearch`/`quicksort`/`joinNums`                                                                 |
+| 2      | `vardecl-typenode:ArrayType`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | benchmarks.ts + benchmarks/array.ts `bench_array`                                                                |
+| 1 each | `expr-unhandled:ArrowFunction` (helpers `addBenchCard`), `tail-unhandled:ExpressionStatement` (calendar `fdow`), `nontail-if-cond:BinaryExpression` (calendar `renderCal`), `nontail-unhandled-stmt:IfStatement` (calendar `onDay`), `nontail-assign-nonprop-lhs:BinaryExpression` (calendar `main`), `vardecl-init-expr:CallExpression` (algorithms `fibMemo`), `expr-arraylit-cloop-guard-1804:ArrayLiteralExpression` (algorithms `main`), `expr-binary-op-instanceof:BinaryExpression` (classes `main`) | —                                                                                                                |
 
 ### The two structural blockers that make every "dev-sized arm" a dead end
 
@@ -574,8 +574,8 @@ histogram of the current 25:
 `call-graph-closure` fixpoint removes ANY shape-claimable function whose local
 caller OR callee is unclaimed. `buildLocalCallGraph` (`select.ts:2193-2198`) only
 creates edges for real `CallExpression`s with a local-decl callee — a function
-passed *by reference* (e.g. `addBenchCard(…, bench_fib)`) or called *inside a
-nested arrow* (`select.ts:2164` does not descend into nested function-likes) is
+passed _by reference_ (e.g. `addBenchCard(…, bench_fib)`) or called _inside a
+nested arrow_ (`select.ts:2164` does not descend into nested function-likes) is
 **not** an edge. Consequence: fixing a leaf statement/expression arm inside a
 function whose call-component root (`main`) stays unclaimed does not reduce the
 gated total — it **moves** the count from `body-shape-rejected` into
@@ -589,7 +589,7 @@ therefore genuinely **external**, landing in the `external-call` bucket.
 
 ### Empirical proof that the highest-value arm is net-zero
 
-Temporarily accepting *any* out-of-scope identifier in `isPhase1Expr` (the
+Temporarily accepting _any_ out-of-scope identifier in `isPhase1Expr` (the
 "top-level function passed as a `() => number` value" arm the 8 benchmark `main`s
 need) moved the gate to:
 
@@ -661,10 +661,10 @@ features in their own right and overlap #2858 (cross-module/`external-call`),
 1. Re-scope #2856 as a **tracking epic** under #2855, not an executable ticket.
 2. Cut capability sub-issues sized as whole-component slices, ordered by
    self-containment: **algorithms.ts** (pure-compute; `if`-in-body + element-store
-   + Map-global + arraylit-SSA) is the cleanest first real reduction (−5, all
-   contagion-internal to one file). The benchmark-harness cluster (−8) should be
-   sequenced **after** #2858's cross-module-call lowering, since it is a hard
-   dependency, not a dependent.
+   - Map-global + arraylit-SSA) is the cleanest first real reduction (−5, all
+     contagion-internal to one file). The benchmark-harness cluster (−8) should be
+     sequenced **after** #2858's cross-module-call lowering, since it is a hard
+     dependency, not a dependent.
 3. Do NOT dispatch the `ArrayType` / `if-in-body` / module-scope-binding arms as
    standalone dev tasks — each is provably net-zero-or-worse against the gate in
    isolation.
@@ -692,13 +692,13 @@ first).
 `binarySearch`, `quicksort`. `fibIter` already claims. The **five** functions
 that currently reject (verified `--shape-diag`), and the capability each needs:
 
-| function | reject arm (current main) | capability required |
-| --- | --- | --- |
-| `fibMemo` | `vardecl-init-expr:CallExpression` | **C3** module-scope `Map` global + `.get`/`.set` |
-| `binarySearch` | `body-unhandled-stmt:IfStatement` | **C1** if-in-body (+ early-`return`-in-loop) |
-| `quicksort` | `body-unhandled-stmt:IfStatement` | **C1** if-in-body **+ C2** element-store `arr[i]=e` |
-| `joinNums` | `body-unhandled-stmt:IfStatement` | **C1** if-in-body |
-| `main` | `expr-arraylit-cloop-guard-1804:ArrayLiteralExpression` | **C4** array-literal-under-C-loop SSA |
+| function       | reject arm (current main)                               | capability required                                 |
+| -------------- | ------------------------------------------------------- | --------------------------------------------------- |
+| `fibMemo`      | `vardecl-init-expr:CallExpression`                      | **C3** module-scope `Map` global + `.get`/`.set`    |
+| `binarySearch` | `body-unhandled-stmt:IfStatement`                       | **C1** if-in-body (+ early-`return`-in-loop)        |
+| `quicksort`    | `body-unhandled-stmt:IfStatement`                       | **C1** if-in-body **+ C2** element-store `arr[i]=e` |
+| `joinNums`     | `body-unhandled-stmt:IfStatement`                       | **C1** if-in-body                                   |
+| `main`         | `expr-arraylit-cloop-guard-1804:ArrayLiteralExpression` | **C4** array-literal-under-C-loop SSA               |
 
 ⚠ **Contagion (read `## ⚠ Sequencing constraint` above): all four capabilities
 must land in ONE PR.** The `call-graph-closure` fixpoint (`select.ts:492-518`)
@@ -786,7 +786,7 @@ from the working `for-of` vec path). `main` has both `const sorted = [1,3,…]`
   vec-identity fix). Once threaded, lift the guard for the threaded case.
 - If the SSA-threading fix is larger than this slice can absorb, an acceptable
   fallback that still claims `main`: hoist/represent the literal so it is not
-  read *through* the C-loop region — but the guard exists precisely because that
+  read _through_ the C-loop region — but the guard exists precisely because that
   is unsound in general, so **prefer the SSA-threading fix**; do not just delete
   the guard.
 
@@ -875,7 +875,7 @@ clean (host-gated arms defer → legacy, as designed).
   compile of the function — dual-compile model); (c) strict undefined-compare
   (`hit !== undefined`) → `__extern_is_undefined` on externref-shaped
   operands, constant-fold on never-undefined representations. LOOSE `==
-  undefined` stays legacy (null == undefined needs a null check). Host lane
+undefined` stays legacy (null == undefined needs a null check). Host lane
   only — standalone's native Map runtime is NOT wired; fibMemo correctly
   demotes there (the selector's Map-const set is empty outside the host
   lane, so no claim-then-fail).
@@ -914,7 +914,7 @@ clean (host-gated arms defer → legacy, as designed).
   store; mixed IR-writer/legacy-reader Map storage parity; try/finally
   early-return negative; whole-component e2e console equality; standalone/
   wasi cleanliness.
-- IR suite (`tests/ir-*`, issue-*-ir tests): per-file failure counts
+- IR suite (`tests/ir-*`, issue-\*-ir tests): per-file failure counts
   IDENTICAL to pristine main (the ~81 container-env failures are
   pre-existing; verified side-by-side) except `ir-scaffold`'s expected-claims
   list, updated for `withWhile` (legitimate capability growth).
@@ -938,17 +938,18 @@ benchmark-harness cluster AFTER #2858.
 #2952 slice 2 landed mid-flight with a CONVERGENT `if.stmt` design (identical
 node shape) plus `br.label` break/continue and a ctrlStack depth resolver.
 Reconciliation on this branch: upstream's `if.stmt` + `emitBufferAsStatements`
-+ ctrlStack machinery adopted wholesale (their arm pushes the plain CtrlFrames
-br.label depth-derivation needs; their `lowerIfBodyStatement` also upgrades
-the cond to truthiness via `coerceLoopCondToBool`); my duplicate `if.stmt`
-implementation deleted at every layer; `early.return` (mine alone) kept and
-now rides their emission helper. The #2856 zero-use side-effect fix collapsed
-from seven emission-loop sites into upstream's single `emitBufferAsStatements`
-(+ the remaining per-arm loops). Early-return barriers and #2952's `inLoop`
-threading coexist: break/continue may cross a try (br.label inlines crossed
-finallys) while early-return stays barred there. Verified post-merge:
-gate 18/9/5, cluster suite 18/18, #2952 suite 27/27, and a combined probe
-(`continue` + early `return` + `break` in one loop) claims with legacy parity.
+
+- ctrlStack machinery adopted wholesale (their arm pushes the plain CtrlFrames
+  br.label depth-derivation needs; their `lowerIfBodyStatement` also upgrades
+  the cond to truthiness via `coerceLoopCondToBool`); my duplicate `if.stmt`
+  implementation deleted at every layer; `early.return` (mine alone) kept and
+  now rides their emission helper. The #2856 zero-use side-effect fix collapsed
+  from seven emission-loop sites into upstream's single `emitBufferAsStatements`
+  (+ the remaining per-arm loops). Early-return barriers and #2952's `inLoop`
+  threading coexist: break/continue may cross a try (br.label inlines crossed
+  finallys) while early-return stays barred there. Verified post-merge:
+  gate 18/9/5, cluster suite 18/18, #2952 suite 27/27, and a combined probe
+  (`continue` + early `return` + `break` in one loop) claims with legacy parity.
 
 ### Post-slice regression caught by the equivalence sweep (fixed in-branch)
 
@@ -960,3 +961,59 @@ undefined/void/any/unknown; undefined-able static types demote to legacy
 (which tracks undefined-ness). Full `tests/equivalence/` sweep on the final
 tree matches the pristine-main baseline (all remaining failures pre-existing
 container-env issues, verified side-by-side).
+
+## Slice RESULTS — bench_array ×2 (2026-07-10, fable-2856): `number[]` annotation + `arr.push` + sibling-loop counters
+
+**Gate: `body-shape-rejected` 17 → 15 (−2); all other buckets unchanged;
+post-claim demotions ZERO.** Banked via `--update-on-decrease`. Grounded
+against `origin/main` @ d7a1feaa1c (post-#2858: `call-graph-closure` is 0 and
+the caller-direction demotion arm is gone, so leaf claims like `bench_array`
+are contagion-safe — the unclaimed `main`s no longer pin their callees).
+
+### What landed (three small capabilities, one PR)
+
+- **`number[]` type annotation** — `isPhase1TypeNode` accepts an
+  ArrayTypeNode with a NumberKeyword element; `lowerVarDecl` resolves it via
+  `resolveVecForElement(f64)` to the vec struct-ref IrType. That ref is the
+  hint an EMPTY literal initializer (`const arr: number[] = []`) needs to
+  type its `vec.new_fixed` (the machinery existed; only the hint threading
+  from an array annotation was missing). f64 element only — `string[]` /
+  `boolean[]` carriers are backend-dependent, deferred.
+- **`arr.push(v)`** (`lowerMethodCall` vec arm) — rides the C2
+  `__vec_elem_set_<vecTypeIdx>` helper: a store at index == length IS push
+  (null-guard, grow-on-capacity with doubling + copy, store, length update —
+  full legacy parity, pure WasmGC, dual-mode clean). Old length is read
+  BEFORE the store; expression position returns old + 1 (JS's new-length
+  result). Residuals that demote: multi-arg push, spread, non-f64/externref
+  element vecs, and NULLABLE receivers (`ref_null`, e.g. unnarrowed params —
+  `emitVecLen` struct-reads without a null guard, so those keep legacy's
+  runtime TypeError).
+- **Sibling `for (let i...)` loops** — the selector's flat scope set leaks
+  each for-init counter into the outer scope (so post-loop reads stay
+  claimable), which made a SECOND sibling `for (let i...)` a false
+  "duplicate" reject. from-ast scopes each for-init in its own `innerCx`
+  copy (`lowerForStatement`), so the shadow is build-safe. Fix: leaked names
+  are tracked (`forInitLeakedNames`, reset per function walk) and only
+  GENUINE outer bindings still reject — mirroring `lowerVarDecl`'s
+  redeclaration throw exactly (select↔build parity, #2138).
+
+### Verification record
+
+- `tests/issue-2856-vec-push.test.ts` (new, 9 tests): legacy/IR parity for
+  each capability, every positive claim proven via byte-diff
+  (anti-vacuity); grow path; expression-position push return value;
+  multi-arg-push clean demote; genuine-shadow negative; standalone + wasi
+  compile cleanliness (no host import — the helper is pure WasmGC).
+- bench_array e2e: IR-vs-legacy both return 49995000 (10k push + sum),
+  claimed (byte-diff), zero demotions.
+- `tests/ir-scaffold.test.ts` failure count IDENTICAL to pristine main at
+  d7a1feaa1c (2 pre-existing container-env failures, verified side-by-side);
+  `tests/ir-algorithms-cluster.test.ts` 18/18.
+
+### Remaining (13 after this slice, by cluster)
+
+benchmark-harness 8 `main`s + `addBenchCard` (first-class function values +
+arrow closure args + cross-module imported calls — the multi-capability
+program from Step-2), calendar 4 (module-scope MUTABLE bindings + DOM
+chains + if-shapes), classes.ts `main` (`instanceof`), async `delay`
+(Promise executor). Epic stays `blocked` on those capability programs.

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
-  "generated": "2026-07-06",
+  "generated": "2026-07-10",
   "unintended": {
-    "body-shape-rejected": 17
+    "body-shape-rejected": 15
   },
   "deferred": {
     "async-function": 4

--- a/scripts/loc-budget-baseline.json
+++ b/scripts/loc-budget-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-10",
   "threshold": 1500,
-  "totalCeiling": 391216,
+  "totalCeiling": 391320,
   "files": {
     "src/codegen-linear/index.ts": 5506,
     "src/codegen-linear/runtime.ts": 3638,
@@ -53,11 +53,11 @@
     "src/compiler/early-errors/node-checks.ts": 1865,
     "src/emit/binary.ts": 1989,
     "src/ir/builder.ts": 1587,
-    "src/ir/from-ast.ts": 6575,
+    "src/ir/from-ast.ts": 6648,
     "src/ir/integration.ts": 2610,
     "src/ir/lower.ts": 3532,
     "src/ir/nodes.ts": 2926,
-    "src/ir/select.ts": 3223,
-    "src/runtime.ts": 15707
+    "src/ir/select.ts": 3260,
+    "src/runtime.ts": 15701
   }
 }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1242,8 +1242,27 @@ function lowerVarDecl(stmt: ts.VariableStatement, cx: LowerCtx): void {
     // here without a TS checker. Defer those to inference from the
     // initializer — `typeNodeToIr` only fires for primitive type
     // keywords; everything else falls through to inference.
-    const annotated =
+    let annotated =
       d.type && isPrimitiveTypeNode(d.type) ? typeNodeToIr(d.type, `local ${name} of ${cx.funcName}`) : undefined;
+    // (#2856) `number[]` annotation → resolve the f64-element vec and use its
+    // struct ref as the annotated type. This is what gives an EMPTY literal
+    // initializer (`const arr: number[] = []`) the vec-typed hint
+    // `lowerArrayLiteral` needs to type its `vec.new_fixed`. Parity: the
+    // selector's `isPhase1TypeNode` accepts exactly this shape (ArrayTypeNode
+    // with a NumberKeyword element), so every claim reaches a hint here. A
+    // resolver that can't register the vec throws → clean demote to legacy.
+    if (annotated === undefined && d.type && ts.isArrayTypeNode(d.type)) {
+      if (d.type.elementType.kind !== ts.SyntaxKind.NumberKeyword) {
+        throw new Error(`ir/from-ast: array annotation on '${name}' must be number[] in ${cx.funcName}`);
+      }
+      const vec = cx.resolver?.resolveVecForElement?.({ kind: "f64" });
+      if (!vec) {
+        throw new Error(
+          `ir/from-ast: resolver cannot register vec for number[] annotation on '${name}' (${cx.funcName})`,
+        );
+      }
+      annotated = irVal({ kind: "ref", typeIdx: vec.vecStructTypeIdx });
+    }
     const hint: IrType = annotated ?? irVal({ kind: "f64" });
     const value = lowerExpr(d.initializer, cx, hint);
     const inferred = cx.builder.typeOf(value);
@@ -3483,6 +3502,60 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
       throw new Error(`ir/from-ast: extern.call produced no result in ${cx.funcName}`);
     }
     return r;
+  }
+
+  // (#2856) `arr.push(v)` on a growable vec receiver. Rides the C2
+  // element-store helper: `__vec_elem_set_<vecTypeIdx>(recv, len, v)` writes
+  // at index == length, which is EXACTLY the legacy push semantics (grow the
+  // backing array when at capacity, store, length = idx + 1 — see
+  // src/codegen/vec-elem-set.ts). The length is read BEFORE the store.
+  // Restricted to a NON-NULL `(ref $vec)` receiver: `emitVecLen` struct-reads
+  // the receiver without a null guard, so a nullable receiver (`ref_null`,
+  // e.g. an unnarrowed param) demotes to legacy, which carries the runtime
+  // TypeError null-guard. Single-arg only (multi-arg push demotes); f64 /
+  // externref element vecs only (mirrors `lowerElementStore`).
+  {
+    const vecRecvVal = asVal(recvType);
+    if (methodName === "push" && vecRecvVal && vecRecvVal.kind === "ref") {
+      const vec = cx.resolver?.resolveVec?.(vecRecvVal);
+      if (vec) {
+        if (expr.arguments.length !== 1 || ts.isSpreadElement(expr.arguments[0]!)) {
+          throw new Error(
+            `ir/from-ast: .push with ${expr.arguments.length} args / spread not in IR scope (single plain arg only) (${cx.funcName})`,
+          );
+        }
+        const elem = vec.elementValType;
+        if (elem.kind !== "f64" && elem.kind !== "externref") {
+          throw new Error(`ir/from-ast: .push into '${elem.kind}' vec not in IR scope (${cx.funcName})`);
+        }
+        // Old length — the store index. `emitVecLen` yields the f64 JS length.
+        const lenF64 = cx.builder.emitVecLen(recv);
+        const lenI32 = cx.builder.emitUnary("i32.trunc_sat_f64_s", lenF64, irVal({ kind: "i32" }));
+        const valRaw = lowerExpr(expr.arguments[0]!, cx, irVal(elem));
+        let val: IrValueId;
+        if (elem.kind === "f64") {
+          const valTy = asVal(cx.builder.typeOf(valRaw));
+          if (valTy?.kind !== "f64") {
+            throw new Error(
+              `ir/from-ast: .push value ${describeIrType(cx.builder.typeOf(valRaw))} into f64 vec ` +
+                `not in IR scope (${cx.funcName})`,
+            );
+          }
+          val = valRaw;
+        } else {
+          val = coerceToExpectedExtern(valRaw, elem, cx, `value of .push`);
+        }
+        cx.builder.emitCall(
+          { kind: "func", name: `__vec_elem_set_${vec.vecStructTypeIdx}` },
+          [recv, lenI32, val],
+          null,
+        );
+        if (statementPosition) return null;
+        // Expression position: JS `push` returns the NEW length = old + 1.
+        const one = cx.builder.emitConst({ kind: "f64", value: 1 }, irVal({ kind: "f64" }));
+        return cx.builder.emitBinary("f64.add", lenF64, one, irVal({ kind: "f64" }));
+      }
+    }
   }
 
   if (recvType.kind !== "class") {

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -744,6 +744,20 @@ let currentFnIsGenerator = false;
 let currentFnIsVoidReturn = false;
 
 /**
+ * (#2856) Names LEAKED into the flat scope set by a sibling for-init
+ * (`for (let i = ...)` adds `i` to the outer scope after the loop so
+ * later statements can reference the counter — the scope tracker is a
+ * flat set, not block-scoped). A SECOND sibling `for (let i = ...)`
+ * re-declaring such a leaked name is fine: from-ast scopes each for-init
+ * in its own `innerCx` copy (`lowerForStatement`), so the two loop
+ * counters never collide at build time. Genuine outer bindings (params,
+ * body-level locals) are NOT in this set, so shadowing THOSE still
+ * rejects — which mirrors `lowerVarDecl`'s redeclaration throw exactly
+ * (select↔build parity, #2138). Reset per function walk.
+ */
+let forInitLeakedNames = new Set<string>();
+
+/**
  * (#2856) Host-extern resolution for the CURRENT `planIrCompilation` run.
  * Set (and cleared) at the selector entry from `IrSelectionOptions` —
  * module-level for the same reason as `currentHostGlobalResolver`: the
@@ -926,6 +940,7 @@ function whyNotIrClaimable(
   // (#2856 C1) Reset the early-return context for this function's walk.
   earlyReturnLoopDepth = 0;
   earlyReturnBarrierDepth = 0;
+  forInitLeakedNames = new Set();
   currentFnIsGenerator = isGenerator;
   currentFnIsVoidReturn = isVoidReturn;
   // #1370 Phase A: constructor bodies don't have a return-statement tail —
@@ -1680,9 +1695,13 @@ function isPhase1StatementList(
       // statements can reference the loop counter (TypeScript would
       // narrow scope to the for-statement, but our scope tracker is
       // a flat set; the conservative addition is fine for shape check).
+      // (#2856) Record the leak so a SIBLING for-init may re-declare it.
       if (s.initializer && ts.isVariableDeclarationList(s.initializer)) {
         for (const d of s.initializer.declarations) {
-          if (ts.isIdentifier(d.name)) scope.add(d.name.text);
+          if (ts.isIdentifier(d.name) && !scope.has(d.name.text)) {
+            scope.add(d.name.text);
+            forInitLeakedNames.add(d.name.text);
+          }
         }
       }
       continue;
@@ -1925,7 +1944,11 @@ function isPhase1ForStatement(
         if (!ts.isIdentifier(d.name)) return false;
         if (!d.initializer) return false;
         if (!isPhase1Expr(d.initializer, innerScope, localClasses)) return false;
-        if (innerScope.has(d.name.text)) return false; // duplicate
+        // (#2856) A name a SIBLING for-init leaked into the flat scope set is
+        // NOT a genuine duplicate — from-ast scopes each for-init in its own
+        // innerCx copy, so `for (let i...) {} for (let i...) {}` builds fine.
+        // Genuine outer bindings still reject (build-side redeclaration).
+        if (innerScope.has(d.name.text) && !forInitLeakedNames.has(d.name.text)) return false; // duplicate
         innerScope.add(d.name.text);
       }
     } else {
@@ -2104,9 +2127,13 @@ function isPhase1BodyStatement(
   }
   if (ts.isForStatement(stmt)) {
     if (!isPhase1ForStatement(stmt, scope, localClasses)) return false;
+    // (#2856) Record the leak so a SIBLING for-init may re-declare it.
     if (stmt.initializer && ts.isVariableDeclarationList(stmt.initializer)) {
       for (const d of stmt.initializer.declarations) {
-        if (ts.isIdentifier(d.name)) scope.add(d.name.text);
+        if (ts.isIdentifier(d.name) && !scope.has(d.name.text)) {
+          scope.add(d.name.text);
+          forInitLeakedNames.add(d.name.text);
+        }
       }
     }
     return true;
@@ -2490,6 +2517,16 @@ function bodyReferencesIdentifier(body: ts.Block, name: string): boolean {
 }
 
 function isPhase1TypeNode(node: ts.TypeNode): boolean {
+  // (#2856) `number[]` array annotation — the from-ast vardecl arm resolves
+  // it to a vec-ref hint (`resolveVecForElement(f64)`), which is what lets an
+  // EMPTY initializer (`const arr: number[] = []`) type its `vec.new_fixed`.
+  // Kept in lockstep with `lowerVarDecl`'s ArrayTypeNode arm (parity: every
+  // annotation accepted here MUST produce a hint there). Only the f64 element
+  // is in scope — `string[]` / `boolean[]` element carriers are backend-
+  // dependent and stay deferred.
+  if (ts.isArrayTypeNode(node)) {
+    return node.elementType.kind === ts.SyntaxKind.NumberKeyword;
+  }
   return (
     node.kind === ts.SyntaxKind.NumberKeyword ||
     node.kind === ts.SyntaxKind.BooleanKeyword ||

--- a/tests/issue-2856-vec-push.test.ts
+++ b/tests/issue-2856-vec-push.test.ts
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2856 — bench_array slice: the three capabilities that let the two
+// `bench_array` corpus functions (benchmarks.ts / benchmarks/array.ts) claim
+// on the IR path.
+//
+//   A  `number[]` type annotation — `isPhase1TypeNode` accepts the
+//      ArrayTypeNode; `lowerVarDecl` resolves it to the f64-element vec ref,
+//      which is the hint an EMPTY literal initializer needs to type its
+//      `vec.new_fixed`.
+//   B  `arr.push(v)` — rides the C2 `__vec_elem_set_<t>` helper (store at
+//      index == length ⇒ grow + store + length update is EXACTLY push).
+//      Statement position drops the result; expression position returns the
+//      new length (old + 1). Single plain arg, f64/externref element vecs,
+//      non-null `(ref $vec)` receivers only — everything else demotes.
+//   C  Sibling `for (let i = ...)` loops re-declaring the SAME counter name —
+//      the selector's flat scope set leaked the first loop's counter and
+//      falsely rejected the second as a duplicate; from-ast scopes each
+//      for-init in its own innerCx copy, so the shadow is build-safe.
+//
+// Every positive case asserts legacy/IR observable equality, ZERO post-claim
+// demotions, AND that the IR path was genuinely exercised (bytes differ from
+// the `experimentalIR: false` compile) — a silent legacy demote fails the
+// test (the vacuous-pass hazard).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const JS_STRING = {
+  concat: (a: string, b: string) => a + b,
+  length: (s: string) => s.length,
+  equals: (a: string, b: string) => (a === b ? 1 : 0),
+  substring: (s: string, start: number, end: number) => s.substring(start, end),
+  charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+  fromCharCode: (c: number) => String.fromCharCode(c),
+  cast: (s: unknown) => String(s),
+  test: (v: unknown) => (typeof v === "string" ? 1 : 0),
+};
+
+interface RunResult {
+  value: unknown;
+  binary: Uint8Array;
+  postClaim: unknown[];
+}
+
+async function compileRun(source: string, fn: string, experimentalIR: boolean): Promise<RunResult> {
+  const r = await compile(source, { experimentalIR, trackFallbacks: true });
+  if (!r.success) {
+    throw new Error(`compile failed (${experimentalIR ? "IR" : "legacy"}): ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, {}, r.stringPool);
+  const imports: WebAssembly.Imports = { env: built.env, string_constants: built.string_constants };
+  imports["wasm:js-string"] = JS_STRING as unknown as WebAssembly.ModuleImports;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  const f = (instance.exports as Record<string, unknown>)[fn];
+  if (typeof f !== "function") throw new Error(`export ${fn} missing`);
+  return {
+    value: (f as (...a: unknown[]) => unknown)(),
+    binary: r.binary,
+    postClaim: r.irPostClaimErrors ?? [],
+  };
+}
+
+/**
+ * Assert legacy and IR agree on the observable result, the IR compile has
+ * ZERO post-claim demotions (unless `allowDemote`), and (when `expectClaimed`,
+ * the default) the IR path was genuinely taken (bytes differ).
+ */
+async function expectParity(
+  source: string,
+  fn: string,
+  expected: unknown,
+  opts: { expectClaimed?: boolean; allowDemote?: boolean } = {},
+): Promise<void> {
+  const legacy = await compileRun(source, fn, false);
+  const ir = await compileRun(source, fn, true);
+  expect(legacy.value, "legacy value").toStrictEqual(expected);
+  expect(ir.value, "IR value matches legacy").toStrictEqual(legacy.value);
+  if (!opts.allowDemote) {
+    expect(ir.postClaim, "no post-claim demotions").toStrictEqual([]);
+  }
+  const bytesDiffer = Buffer.compare(Buffer.from(legacy.binary), Buffer.from(ir.binary)) !== 0;
+  if (opts.expectClaimed !== false) {
+    expect(bytesDiffer, "IR path exercised (bytes differ from legacy)").toBe(true);
+  }
+}
+
+const BENCH_ARRAY = `export function bench_array(): number {
+  const arr: number[] = [];
+  for (let i = 0; i < 10000; i++) arr.push(i);
+  let total = 0;
+  for (let i = 0; i < arr.length; i++) total = total + arr[i];
+  return total;
+}`;
+
+describe("#2856 — number[] annotation + empty literal (A)", () => {
+  it("empty literal with number[] annotation reads back pushed values", async () => {
+    await expectParity(
+      `export function f(): number {
+         const arr: number[] = [];
+         arr.push(42);
+         return arr[0] * 10 + arr.length;
+       }`,
+      "f",
+      421,
+    );
+  });
+
+  it("non-empty literal with number[] annotation stays claimed", async () => {
+    await expectParity(
+      `export function f(): number {
+         const arr: number[] = [5, 6];
+         return arr[0] * 10 + arr[1];
+       }`,
+      "f",
+      56,
+    );
+  });
+});
+
+describe("#2856 — arr.push(v) on a growable vec (B)", () => {
+  it("push grows an empty vec across a C-style loop (bench_array shape, whole fn e2e)", async () => {
+    await expectParity(BENCH_ARRAY, "bench_array", 49995000);
+  });
+
+  it("push in expression position returns the NEW length", async () => {
+    await expectParity(
+      `export function f(): number {
+         const arr: number[] = [];
+         arr.push(7);
+         const n = arr.push(9);
+         return n * 100 + arr[0] * 10 + arr[1];
+       }`,
+      "f",
+      279,
+    );
+  });
+
+  it("push appends past a non-empty literal (grow-on-capacity path)", async () => {
+    await expectParity(
+      `export function f(): number {
+         const arr: number[] = [1, 2];
+         arr.push(3);
+         arr.push(4);
+         return arr[3] * 1000 + arr[2] * 100 + arr.length;
+       }`,
+      "f",
+      4304,
+    );
+  });
+
+  it("multi-arg push demotes cleanly to legacy (claim-partial residual)", async () => {
+    // The generic method-call arm claims the shape; the .push lowering throws
+    // its documented single-arg residual and the function demotes to legacy,
+    // which handles multi-arg push. Observable behavior must stay correct.
+    await expectParity(
+      `export function f(): number {
+         const arr: number[] = [];
+         arr.push(1, 2);
+         return arr.length;
+       }`,
+      "f",
+      2,
+      { expectClaimed: false, allowDemote: true },
+    );
+  });
+});
+
+describe("#2856 — sibling for-loops re-declaring the counter (C)", () => {
+  it("two sibling `for (let i...)` loops claim and agree with legacy", async () => {
+    await expectParity(
+      `export function f(): number {
+         let s = 0;
+         for (let i = 0; i < 5; i++) s = s + i;
+         for (let i = 0; i < 3; i++) s = s * 2;
+         return s;
+       }`,
+      "f",
+      80,
+    );
+  });
+
+  it("shadowing a GENUINE outer local still rejects (build-side parity)", async () => {
+    // `let i` at body level makes the for's `let i` a REAL redeclaration in
+    // from-ast's flat function scope — the selector must keep rejecting it
+    // (stays legacy; behavior correct, no post-claim demotion).
+    await expectParity(
+      `export function f(): number {
+         let i = 100;
+         let s = 0;
+         for (let i = 0; i < 3; i++) s = s + i;
+         return s + i;
+       }`,
+      "f",
+      103,
+      { expectClaimed: false },
+    );
+  });
+});
+
+describe("#2856 — mode cleanliness", () => {
+  it("standalone / wasi compiles stay clean (pure-WasmGC helper, no host import)", async () => {
+    for (const extra of [{ standalone: true }, { target: "wasi" as const }]) {
+      const r = await compile(BENCH_ARRAY, { experimentalIR: true, trackFallbacks: true, ...(extra as object) });
+      expect(r.success, `compile ok under ${JSON.stringify(extra)}`).toBe(true);
+      expect(r.irPostClaimErrors ?? []).toStrictEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## What

Next #2856 slice: the two `bench_array` corpus functions (benchmarks.ts / benchmarks/array.ts) claim on the IR path. **`body-shape-rejected` 17 → 15** (banked via `--update-on-decrease`); all other buckets unchanged; **post-claim demotions zero**. Contagion-safe leaves post-#2858 (the caller-direction demotion arm is gone, so the unclaimed `main`s no longer pin their callees).

## Three small capabilities

- **`number[]` type annotation** — `isPhase1TypeNode` accepts an ArrayTypeNode with a NumberKeyword element; `lowerVarDecl` resolves it via `resolveVecForElement(f64)` to the vec struct-ref IrType. That ref is the hint an EMPTY literal initializer (`const arr: number[] = []`) needs to type its `vec.new_fixed` (machinery existed; only the annotation→hint threading was missing). f64 element only — `string[]`/`boolean[]` carriers are backend-dependent, deferred.
- **`arr.push(v)`** (`lowerMethodCall` vec arm) — rides the #2856-C2 `__vec_elem_set_<vecTypeIdx>` helper: a store at index == length IS push (null-guard, grow-on-capacity, store, length update — full legacy parity, pure WasmGC, dual-mode clean, no host import). Old length read BEFORE the store; expression position returns old + 1 (JS's new-length result). Residuals demote to legacy: multi-arg/spread push, non-f64/externref element vecs, NULLABLE receivers (`emitVecLen` struct-reads without a null guard, so unnarrowed `ref_null` params keep legacy's runtime TypeError).
- **Sibling `for (let i...)` loops** — the selector's flat scope set leaks each for-init counter outward, which made a SECOND sibling `for (let i...)` a false 'duplicate' reject. from-ast scopes each for-init in its own `innerCx` copy (`lowerForStatement`), so the shadow is build-safe. Leaked names are now tracked (`forInitLeakedNames`, reset per function walk); GENUINE outer bindings still reject — mirroring `lowerVarDecl`'s redeclaration throw exactly (select↔build parity, #2138).

## Verification

- `tests/issue-2856-vec-push.test.ts` (new, 9 tests): legacy/IR parity per capability, every positive claim proven via **byte-diff** (anti-vacuity); grow path; expression-position push return; multi-arg clean demote; genuine-shadow negative; standalone + wasi compile cleanliness.
- bench_array e2e: IR == legacy == 49995000 (10k push + sum), claimed, zero demotions.
- `node scripts/equivalence-gate.mjs` (full suite): **36 failing = 36 known-failures baseline, 1602 passing — no new regressions**.
- IR equivalence suites (`ir-if-else`/`ir-let-const`/`ir-numeric-bool`/`ir-ternary`) 73/73; `ir-algorithms-cluster` 18/18; `ir-scaffold` failure count identical to pristine main (2 pre-existing container-env failures, verified side-by-side).
- tsc clean, prettier clean; gate re-verified after the pre-PR main merge.

## Remaining (13, tracked in the issue)

benchmark-harness 8 `main`s + `addBenchCard` (first-class fn values + arrows + cross-module calls), calendar 4 (mutable module-scope bindings + DOM chains), classes.ts `main` (`instanceof` + static-method calls), async `delay` (Promise executor). Epic stays `blocked` on those capability programs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8