### PR TITLE
fix(#3075): standalone for-of/for-await dstr over host-buffer generators — illegal cast in __iterator

### DIFF
--- a/plan/issues/3075-standalone-forof-dstr-illegal-cast-iterator.md
+++ b/plan/issues/3075-standalone-forof-dstr-illegal-cast-iterator.md
@@ -1,8 +1,8 @@
 ---
 id: 3075
 title: "standalone: for-of / for-await-of destructuring throws 'illegal cast [in __iterator]' (residual after #1323)"
-status: ready
-sprint: Backlog
+status: done
+sprint: current
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -12,7 +12,9 @@ language_feature: iterator-protocol, for-of, for-await-of, destructuring
 goal: standalone-mode
 related: [1781, 1323, 1454, 1347, 1471]
 created: 2026-07-06
-updated: 2026-07-06
+updated: 2026-07-10
+completed: 2026-07-10
+assignee: ttraenkler/fable-3075
 origin: "2026-07-06 /harvest-errors run against standalone current.jsonl (6.7.2026)."
 ---
 
@@ -75,3 +77,76 @@ language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-iter-
 
 - `illegal cast [in __iterator]` standalone count drops materially (<100).
 - No net regression in either lane.
+
+## Root cause (measured, 2026-07-10)
+
+The 468-record cluster is dominated by the 390 for-await-of `dstr-*-async-*`
+files, and **every one of them uses `yield*`** in the async-generator
+producer. Under `--target standalone` a `yield*`-carrying generator body is
+NOT a native-generator candidate (`isNativeGeneratorCandidate` rejects the
+`async` modifier categorically, and function *expressions* are not wired to
+the native factory at all), so it bails to the **legacy eager-buffer HOST
+runtime** (`sourceNeedsGeneratorHostImports` → `addGeneratorImports`
+`allowNoJsHost` bundle). Two stacked breaks followed:
+
+1. **`__iterator` had no arm for a host external.** The generator object
+   returned by host `__create_async_generator` internalizes outside every GC
+   subhierarchy (not struct / array / i31), so the native GetIterator ladder
+   fell through to the hard-cast tail → `illegal cast [in __iterator]`. (The
+   bounded 3d-ii consumer drive doesn't apply: the tests bind a
+   *destructuring pattern*, which `analyzeForAwait` rejects, and the source
+   is an identifier, which `resolveAsyncGenNextHelperName` rejects.)
+2. **`__gen_yield_star`'s host impl silently drained ZERO values** for a
+   WasmGC `$Vec` operand (no `Symbol.iterator` on an opaque struct), so even
+   with (1) fixed the buffered generator reported done immediately.
+
+## Fix (PR)
+
+- `src/codegen/iterator-native.ts` — new `ITER_KIND_HOSTGEN` IterRec arm,
+  filled at finalize **only when the module already carries the legacy
+  `__gen_*` imports** (no new host import; every other module is
+  byte-identical). Classification: subject fails `ref.test` for the abstract
+  `struct`/`array`/`i31` heap types ⇒ host external ⇒ it is its own iterator
+  (GetIterator identity on generators). `__iterator_next` drives it via
+  `__gen_next` + `__gen_result_done`/`__gen_result_value` (the buffered
+  async-gen `next()` thenable exposes `value`/`done` synchronously —
+  runtime.ts `mkResult`); `__iterator_return` closes via `__gen_return`;
+  `__iterator_rest` drains through the shared step arm.
+- `src/runtime.ts` — `__gen_yield_star` materializes a WasmGC vec operand
+  through the module's `__vec_len`/`__vec_get` exports
+  (`_materializeIterable`) before iterating; host arrays pass through
+  unchanged (default lane byte-identical behavior).
+
+## Test Results (2026-07-10, sample = every 7th of the 390-file cluster, n=56)
+
+| lane | state | result |
+| --- | --- | --- |
+| standalone | upstream/main (control) | 51 illegal-cast / 5 pass |
+| standalone | fixed | **0 illegal-cast / 33 pass** / 8 vacuous / 15 fail-other |
+| default (n=14) | control vs fixed | identical (13 pass / 1 pre-existing fail) |
+
+Adjacent-area standalone scans (for-of/dstr n=72, for-of n=30, generators
+n=9, Iterator.prototype.toArray n=18) are **exactly identical** to control.
+`tests/issue-3075.test.ts` (6 cases) passes; issue-2038/3100(s4,s5)/3119
+suites pass (65/65); the 3 failures in `issue-1320*.test.ts` reproduce
+identically on control (pre-existing, environment-related).
+
+Extrapolated: ~355 of the 468 illegal-cast records eliminated, ~195 flip to
+pass — acceptance (<100 residual) met.
+
+## Residual decomposition (banked, out of scope here)
+
+- **Vacuous (~14% of cluster)**: `$DONE` async-callback plumbing under
+  standalone — the fn() promise chain's callback never runs in the harness
+  wrapper. Same-shaped code returning counts via `test()` passes, so this is
+  the standalone async-completion class (#2980 territory), not iterator
+  protocol.
+- **fail-other (~27%)**: eager-buffer semantic limits — per-step iterator
+  side-effect counts (elision must call `next()` exactly once; the eager
+  buffer drains everything at creation), `iter-close` observable ordering.
+  Fixing these requires lazy generator semantics (native state machine for
+  async gens / #3032-style lazy-first-resume for the async path).
+- **Driven-producer frame carriers** (plain-yield async gens consumed via an
+  identifier, e.g. `var it = (async function*(){ yield 1 })()`): still trap —
+  an ASYNCGEN IterRec arm dispatching per-producer `__async_gen_next_<stem>`
+  over `ctx.asyncGenProducers` is the natural follow-up slice.

--- a/scripts/loc-budget-baseline.json
+++ b/scripts/loc-budget-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-10",
   "threshold": 1500,
-  "totalCeiling": 391216,
+  "totalCeiling": 391409,
   "files": {
     "src/codegen-linear/index.ts": 5506,
     "src/codegen-linear/runtime.ts": 3638,
@@ -27,7 +27,7 @@
     "src/codegen/expressions/unary-updates.ts": 2087,
     "src/codegen/generators-native.ts": 4687,
     "src/codegen/index.ts": 16625,
-    "src/codegen/iterator-native.ts": 1968,
+    "src/codegen/iterator-native.ts": 2159,
     "src/codegen/json-codec-native.ts": 2859,
     "src/codegen/literals.ts": 4232,
     "src/codegen/map-runtime.ts": 2118,
@@ -58,6 +58,6 @@
     "src/ir/lower.ts": 3532,
     "src/ir/nodes.ts": 2926,
     "src/ir/select.ts": 3223,
-    "src/runtime.ts": 15707
+    "src/runtime.ts": 15709
   }
 }

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -97,6 +97,58 @@ const ITER_KIND_USER = 1;
 const ITER_KIND_OBJ = 4;
 
 /**
+ * (#3075) IterRec kind tag for a HOST generator object: the externref returned
+ * by the legacy eager-buffer generator runtime (`__create_generator` /
+ * `__create_async_generator` — the host fallback that `yield*`-and-friends
+ * sync/async generator bodies still take even under `--target standalone`, see
+ * `sourceNeedsGeneratorHostImports`). Such a value internalizes OUTSIDE every
+ * GC heap subhierarchy (not struct / array / i31), so no native arm can read
+ * it — before this arm it hit the hard-cast tail (`illegal cast [in
+ * __iterator]`, the 468-record standalone for-of/for-await dstr cluster). A
+ * generator object is its own iterator (`[Symbol.iterator]` /
+ * `[Symbol.asyncIterator]` return `this`), so GetIterator is the identity; the
+ * step arm drives it through the ALREADY-IMPORTED host helpers (`__gen_next` /
+ * `__gen_result_done` / `__gen_result_value`) — no new host import is added,
+ * the module carries the whole legacy bundle regardless. The buffered
+ * async-gen `next()` returns a thenable that exposes `value`/`done`
+ * synchronously (runtime.ts `mkResult`), so the sync drive reads the settled
+ * result directly — exactly the sync-backed degenerate Await the standalone
+ * for-await lowering layers around the loop body (see `ensureAsyncIterator`).
+ */
+const ITER_KIND_HOSTGEN = 5;
+
+/**
+ * (#3075) Abstract heap-type codes for the host-external `ref.test`
+ * classification (binary s33 heap-type positions — see `vHeapType` in
+ * emit/binary.ts: negative values are abstract heap-type codes encoding as one
+ * signed-LEB byte). Never present in any DCE type-remap map (those key on
+ * concrete indices ≥ 0), so bodies carrying them survive type compaction
+ * unchanged.
+ */
+const HEAP_TYPE_STRUCT = -21; // 0x6B
+const HEAP_TYPE_ARRAY = -22; // 0x6A
+const HEAP_TYPE_I31 = -20; // 0x6C
+
+/**
+ * (#3075) Resolved fill-time deps of the HOSTGEN arm — the legacy eager-buffer
+ * generator HOST IMPORTS (`addGeneratorImports` bundle), present exactly when
+ * some generator body in the module bailed to the host path
+ * (`sourceNeedsGeneratorHostImports`). All are IMPORT funcIdxs resolved from
+ * funcMap at fill time; later import shifts walk the rebuilt bodies like any
+ * other defined function (same discipline as the USER/vec-family arms).
+ */
+interface HostGenDeps {
+  /** `__gen_next(gen externref) -> externref` — gen.next(), the step. */
+  genNextIdx: number;
+  /** `__gen_result_done(res externref) -> i32` — reads res.done. */
+  genResultDoneIdx: number;
+  /** `__gen_result_value(res externref) -> externref` — reads res.value. */
+  genResultValueIdx: number;
+  /** `__gen_return(gen, value externref) -> externref` — IteratorClose. */
+  genReturnIdx?: number;
+}
+
+/**
  * Resolved funcIdx of the closed-struct dispatchers the USER arm calls. All four
  * are emitted at FINALIZE; `fillNativeIteratorLateArms` looks them up then.
  */
@@ -938,9 +990,30 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
     }
   }
 
+  // (#3075) HOSTGEN-arm deps — the legacy eager-buffer generator HOST imports.
+  // Present exactly when some generator body bailed to the host path under
+  // standalone/wasi (`sourceNeedsGeneratorHostImports`) — the module already
+  // carries the imports, so driving them adds no new host dependency. Without
+  // them (the common zero-import standalone module) every body below is
+  // byte-identical.
+  let hostDeps: HostGenDeps | undefined;
+  if (ctx.standalone || ctx.wasi) {
+    const genNextIdx = ctx.funcMap.get("__gen_next");
+    const genResultDoneIdx = ctx.funcMap.get("__gen_result_done");
+    const genResultValueIdx = ctx.funcMap.get("__gen_result_value");
+    if (genNextIdx !== undefined && genResultDoneIdx !== undefined && genResultValueIdx !== undefined) {
+      hostDeps = {
+        genNextIdx,
+        genResultDoneIdx,
+        genResultValueIdx,
+        genReturnIdx: ctx.funcMap.get("__gen_return"),
+      };
+    }
+  }
+
   const types = iterRuntimeTypes(ctx);
   const familyArms = buildVecFamilyArms(ctx, types);
-  if (!deps && !objDeps && familyArms.length === 0) return; // nothing to fill — byte-identical
+  if (!deps && !objDeps && !hostDeps && familyArms.length === 0) return; // nothing to fill — byte-identical
 
   const iteratorIdx = ctx.funcMap.get("__iterator");
   const iteratorNextIdx = ctx.funcMap.get("__iterator_next");
@@ -948,8 +1021,9 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
 
   const iteratorFn = definedFuncAt(ctx, iteratorIdx);
   const iteratorNextFn = definedFuncAt(ctx, iteratorNextIdx);
-  if (iteratorFn) iteratorFn.body = buildIteratorBody(types, deps, familyArms, objDeps);
-  if ((deps || objDeps) && iteratorNextFn) iteratorNextFn.body = buildIteratorNextBody(types, deps, objDeps);
+  if (iteratorFn) iteratorFn.body = buildIteratorBody(types, deps, familyArms, objDeps, hostDeps);
+  if ((deps || objDeps || hostDeps) && iteratorNextFn)
+    iteratorNextFn.body = buildIteratorNextBody(types, deps, objDeps, hostDeps);
 
   // (#3100 S5) `__iterator_rest` was VEC-only — a USER record (custom iterable)
   // drained EMPTY under `[...iterable]` / `Array.from(iterable)`. Rebuild it
@@ -960,10 +1034,11 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
   // (#3119) OBJ records drain through the SAME step-to-exhaustion arm (the
   // kind dispatch lives inside `__iterator_next`), so the guard admits every
   // step-driven kind the GetIterator ladder can produce in this module.
-  if (deps || objDeps) {
+  if (deps || objDeps || hostDeps) {
     const stepKinds: number[] = [];
     if (deps) stepKinds.push(ITER_KIND_USER);
     if (objDeps) stepKinds.push(ITER_KIND_OBJ);
+    if (hostDeps) stepKinds.push(ITER_KIND_HOSTGEN); // (#3075) drain via __iterator_next
     const iteratorRestIdx = ctx.funcMap.get("__iterator_rest");
     const iteratorRestFn = iteratorRestIdx !== undefined ? definedFuncAt(ctx, iteratorRestIdx) : undefined;
     if (iteratorRestFn) {
@@ -989,7 +1064,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
   // (#3119) The OBJ close arm (`__extern_get(iterObj, "return")` +
   // `__apply_closure`) fills independently — a plain-object iterator's
   // `return` is a PROPERTY, reachable without any closed-struct dispatcher.
-  if ((deps && deps.callReturnIdx !== undefined) || objDeps) {
+  if ((deps && deps.callReturnIdx !== undefined) || objDeps || hostDeps?.genReturnIdx !== undefined) {
     const iteratorReturnIdx = ctx.funcMap.get("__iterator_return");
     const iteratorReturnFn = iteratorReturnIdx !== undefined ? definedFuncAt(ctx, iteratorReturnIdx) : undefined;
     if (iteratorReturnFn) {
@@ -999,7 +1074,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
         // (#3119) `ret` scratch for the OBJ close arm — harmless when unused.
         ...(objDeps ? [{ name: "ret", type: { kind: "externref" as const } }] : []),
       ];
-      iteratorReturnFn.body = buildIteratorReturnBody(types, deps?.callReturnIdx, objDeps);
+      iteratorReturnFn.body = buildIteratorReturnBody(types, deps?.callReturnIdx, objDeps, hostDeps);
     }
   }
 
@@ -1083,8 +1158,37 @@ function buildIteratorReturnBody(
   types: IterRuntimeTypes,
   callReturnIdx: number | undefined,
   objDeps: ObjCarrierDeps | undefined,
+  hostDeps?: HostGenDeps,
 ): Instr[] {
   const { iterRecTypeIdx } = types;
+  // (#3075) kind == HOSTGEN → IteratorClose via the host `__gen_return`
+  // import (gen.return(undefined), result dropped — marks the buffered
+  // generator exhausted). Absent import ⇒ arm not filled ⇒ NormalCompletion
+  // no-op, matching the USER/OBJ discipline.
+  const hostClose: Instr[] =
+    hostDeps?.genReturnIdx !== undefined
+      ? [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: iterRecTypeIdx },
+          { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 0 },
+          { op: "i32.const", value: ITER_KIND_HOSTGEN },
+          { op: "i32.eq" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 1 } as Instr,
+              { op: "ref.cast", typeIdx: iterRecTypeIdx } as Instr,
+              { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 3 } as Instr,
+              { op: "ref.null.extern" } as Instr,
+              { op: "call", funcIdx: hostDeps.genReturnIdx } as Instr,
+              { op: "drop" } as Instr,
+              { op: "return" } as Instr,
+            ],
+            else: [],
+          } as Instr,
+        ]
+      : [];
   // (#3119) kind == OBJ → property-read close. Placed BEFORE the USER-kind
   // early-return so both arms coexist; empty when the OBJ arm is not filled
   // (byte-identical to the #3100 S5 body).
@@ -1177,6 +1281,7 @@ function buildIteratorReturnBody(
     { op: "ref.test", typeIdx: iterRecTypeIdx } as Instr,
     { op: "i32.eqz" },
     { op: "if", blockType: { kind: "empty" }, then: [{ op: "return" } as Instr], else: [] } as Instr,
+    ...hostClose,
     ...objClose,
     ...userClose,
   ];
@@ -1216,6 +1321,7 @@ function buildIteratorBody(
   deps: UserCarrierDeps | undefined,
   familyArms: Instr[] = [],
   objDeps?: ObjCarrierDeps,
+  hostDeps?: HostGenDeps,
 ): Instr[] {
   const { iterRecTypeIdx, vecTypeIdx } = types;
   // VEC arm: $IterRec{VEC, vec, 0, userIter:null}. Field order/arity is
@@ -1237,6 +1343,44 @@ function buildIteratorBody(
     { op: "struct.new", typeIdx: iterRecTypeIdx },
     { op: "extern.convert_any" } as Instr,
   ];
+
+  // (#3075) HOSTGEN arm — a HOST-created external (legacy eager-buffer
+  // generator object). Classification: `objAny` internalizes outside every GC
+  // heap subhierarchy — NOT struct, NOT array, NOT i31 — so none of the later
+  // arms (vec-family `ref.test`s, the `$Object` reader, the closed-struct
+  // dispatchers) can ever match it; divert it to a HOSTGEN record BEFORE they
+  // run. GetIterator on a generator object is the identity (`@@iterator` /
+  // `@@asyncIterator` return `this`). All Instr objects fresh per build
+  // (#2169b). Placed after the vec/family arms (internal carriers keep their
+  // exact current routing) and before the OBJ/USER arms.
+  const hostArm: Instr[] = hostDeps
+    ? [
+        { op: "local.get", index: 1 },
+        { op: "ref.test", typeIdx: HEAP_TYPE_STRUCT } as Instr,
+        { op: "local.get", index: 1 },
+        { op: "ref.test", typeIdx: HEAP_TYPE_ARRAY } as Instr,
+        { op: "i32.or" } as Instr,
+        { op: "local.get", index: 1 },
+        { op: "ref.test", typeIdx: HEAP_TYPE_I31 } as Instr,
+        { op: "i32.or" } as Instr,
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // $IterRec{HOSTGEN, vec:null, idx:0, userIter: obj (param 0)}
+            { op: "i32.const", value: ITER_KIND_HOSTGEN } as Instr,
+            { op: "ref.null", typeIdx: vecTypeIdx } as Instr,
+            { op: "i32.const", value: 0 } as Instr,
+            { op: "local.get", index: 0 } as Instr,
+            { op: "struct.new", typeIdx: iterRecTypeIdx } as Instr,
+            { op: "extern.convert_any" } as Instr,
+            { op: "return" } as Instr,
+          ],
+          else: [],
+        } as Instr,
+      ]
+    : [];
 
   // (#3119) OBJ arm — post-hoc `o[Symbol.iterator] = fn`. All Instr objects
   // fresh per build (#2169b); baked funcIdxs are fill-time funcMap lookups.
@@ -1315,6 +1459,7 @@ function buildIteratorBody(
       else: [],
     },
     ...familyArms,
+    ...hostArm,
     ...objArm,
     ...tail,
   ];
@@ -1497,6 +1642,7 @@ function buildIteratorNextBody(
   types: IterRuntimeTypes,
   deps: UserCarrierDeps | undefined,
   objDeps?: ObjCarrierDeps,
+  hostDeps?: HostGenDeps,
 ): Instr[] {
   const { iterRecTypeIdx, vecTypeIdx, arrTypeIdx } = types;
 
@@ -1546,7 +1692,7 @@ function buildIteratorNextBody(
     },
   ];
 
-  if (!deps && !objDeps) {
+  if (!deps && !objDeps && !hostDeps) {
     // Vec-only carrier: kind is always VEC, so emit the vec step directly with no
     // kind branch — byte-identical to the pre-#2038 runtime.
     return [
@@ -1561,6 +1707,35 @@ function buildIteratorNextBody(
       { op: "local.get", index: 5 },
     ];
   }
+
+  // (#3075) HOSTGEN step — drive the legacy host generator object through the
+  // already-imported bundle: res = __gen_next(rec.userIter); done =
+  // __gen_result_done(res); value = done ? undefined : __gen_result_value(res).
+  // The buffered async-gen `next()` thenable exposes value/done synchronously
+  // (runtime.ts `mkResult`), so the settled read is exact — a genuinely-pending
+  // host promise has no `done` and reports done=0/value=undefined host-side.
+  const hostStep: Instr[] = hostDeps
+    ? [
+        // res = __gen_next(rec.userIter)
+        { op: "local.get", index: 1 },
+        { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 3 },
+        { op: "call", funcIdx: hostDeps.genNextIdx } as Instr,
+        { op: "local.set", index: 6 },
+        // done = __gen_result_done(res)
+        { op: "local.get", index: 6 },
+        { op: "call", funcIdx: hostDeps.genResultDoneIdx } as Instr,
+        { op: "local.set", index: 4 },
+        // value = done ? undefined : __gen_result_value(res)
+        { op: "local.get", index: 4 },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [{ op: "ref.null.extern" } as Instr],
+          else: [{ op: "local.get", index: 6 } as Instr, { op: "call", funcIdx: hostDeps.genResultValueIdx } as Instr],
+        } as Instr,
+        { op: "local.set", index: 5 },
+      ]
+    : [];
 
   // (#3119) The OBJ-carrier step: property reads + the open-`any` closure
   // bridge (see the function doc). Fresh Instr objects per build (#2169b).
@@ -1683,15 +1858,28 @@ function buildIteratorNextBody(
       ]
     : vecStep;
 
+  // (#3075) Wrap a step chain in the kind==HOSTGEN dispatch when the host-gen
+  // arm is filled; pass-through otherwise (byte-identical).
+  const withHostDispatch = (inner: Instr[]): Instr[] =>
+    hostDeps
+      ? [
+          { op: "local.get", index: 1 },
+          { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 0 },
+          { op: "i32.const", value: ITER_KIND_HOSTGEN },
+          { op: "i32.eq" },
+          { op: "if", blockType: { kind: "empty" }, then: hostStep, else: inner } as Instr,
+        ]
+      : inner;
+
   if (!deps) {
-    // OBJ + VEC kinds only (no closed-struct USER carrier in this module).
+    // OBJ/HOSTGEN + VEC kinds only (no closed-struct USER carrier in this module).
     return [
       // rec = cast(any.convert_extern(recExt))
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" } as Instr,
       { op: "ref.cast", typeIdx: iterRecTypeIdx },
       { op: "local.set", index: 1 },
-      ...vecOrObjStep,
+      ...withHostDispatch(vecOrObjStep),
       // results in ABI order: (done, value)
       { op: "local.get", index: 4 },
       { op: "local.get", index: 5 },
@@ -1727,17 +1915,20 @@ function buildIteratorNextBody(
     { op: "any.convert_extern" } as Instr,
     { op: "ref.cast", typeIdx: iterRecTypeIdx },
     { op: "local.set", index: 1 },
+    // (#3075: outermost kind==HOSTGEN dispatch when filled)
     // if (rec.kind == USER) { userStep } else { vecStep | kind==OBJ dispatch }
-    { op: "local.get", index: 1 },
-    { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 0 },
-    { op: "i32.const", value: ITER_KIND_USER },
-    { op: "i32.eq" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: userStep,
-      else: vecOrObjStep,
-    },
+    ...withHostDispatch([
+      { op: "local.get", index: 1 },
+      { op: "struct.get", typeIdx: iterRecTypeIdx, fieldIdx: 0 },
+      { op: "i32.const", value: ITER_KIND_USER },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: userStep,
+        else: vecOrObjStep,
+      },
+    ]),
     // results in ABI order: (done, value)
     { op: "local.get", index: 4 },
     { op: "local.get", index: 5 },

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13065,13 +13065,21 @@ assert._isSameValue = isSameValue;
           buf.push(v);
         };
       if (name === "__gen_yield_star")
-        return (buf: any[], iterable: any) => {
+        return (buf: any[], rawIterable: any) => {
           // Iterate the inner iterable and push all values into the outer buffer.
           // Per §27.5.3 yield* output, the inner generator's RETURN value is the
           // value of the `yield*` expression and must NOT leak into the outer
           // stream — `for...of`/manual iteration already stops at the inner
           // `done:true` result, so only the yielded (`done:false`) values are
           // pushed here. (#2035)
+          // (#3075) Under `--target standalone`/`wasi` the `yield*` operand is
+          // an opaque WasmGC `$Vec` struct, not a JS iterable — it has no
+          // `Symbol.iterator`, so this push loop silently drained ZERO values
+          // (the buffered generator then reported done immediately, the vacuous
+          // half of the for-await dstr cluster). Materialize it into a real JS
+          // array through the module's `__vec_len`/`__vec_get` exports first;
+          // non-vec / host iterables pass through unchanged.
+          const iterable = _materializeIterable(rawIterable, callbackState);
           if (iterable != null && typeof iterable[Symbol.iterator] === "function") {
             for (const v of iterable) {
               if (buf.length >= __EAGER_GEN_LIMIT) {

--- a/tests/issue-3075.test.ts
+++ b/tests/issue-3075.test.ts
@@ -1,0 +1,126 @@
+// #3075 — standalone for-of/for-await destructuring over legacy host-buffer
+// generator objects: `illegal cast [in __iterator]`.
+//
+// Under `--target standalone`, a `yield*`-carrying (async) generator body
+// bails to the legacy eager-buffer HOST runtime (`__create_generator` /
+// `__create_async_generator` — see `sourceNeedsGeneratorHostImports`), so the
+// generator object is a host-created external. The native `__iterator`
+// GetIterator ladder had no arm for it: the value fell through every
+// `ref.test` to the hard-cast tail and trapped `illegal cast` — 468 standalone
+// records, dominated by the for-await-of `dstr-*-async-*` family (390 files).
+//
+// Fix (two halves):
+//  1. iterator-native.ts — a HOSTGEN IterRec arm, filled at finalize exactly
+//     when the module already carries the legacy `__gen_*` imports: a subject
+//     that internalizes outside every GC subhierarchy (not struct/array/i31)
+//     is its own iterator; `__iterator_next` drives it via `__gen_next` +
+//     `__gen_result_done`/`__gen_result_value`, `__iterator_return` closes via
+//     `__gen_return`. No new host import — the module has the bundle already.
+//  2. runtime.ts — `__gen_yield_star` materializes a WasmGC `$Vec` operand
+//     through the module's `__vec_len`/`__vec_get` exports before iterating
+//     (it silently pushed ZERO values for a wasm-struct operand, so the fixed
+//     iterator then drained an empty buffer).
+//
+// The module-level generator creation is deferred into `test()`-called code so
+// `setExports` wiring (which `_materializeIterable` needs) is in place before
+// the eager buffer builds — same ordering the test262 harness wrapper gives.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.errors ?? []).toEqual([]);
+  const imports = buildImports(result.imports, undefined, result.stringPool, {}) as unknown as {
+    setExports?: (e: unknown) => void;
+  } & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports);
+  const testFn = instance.exports.test as () => number;
+  return testFn();
+}
+
+describe("#3075 standalone for-await dstr over host-buffer async generators", () => {
+  it("array pattern, single binding", async () => {
+    const ret = await runStandalone(`
+      let n = 0;
+      function go() {
+        var it = (async function*(){ yield* [[7]]; })();
+        async function fn() { for await (const [v] of it) { n = v; } }
+        fn();
+      }
+      export function test() { go(); return n; }
+    `);
+    expect(ret).toBe(7);
+  });
+
+  it("array pattern, binding past the element's end reads undefined", async () => {
+    const ret = await runStandalone(`
+      let n = 0; let xok = 0;
+      function go() {
+        var it = (async function*(){ yield* [[]]; })();
+        async function fn() {
+          for await (const [_, x] of it) { if (x === undefined) xok = 1; n += 1; }
+        }
+        fn();
+      }
+      export function test() { go(); return n * 10 + xok; }
+    `);
+    expect(ret).toBe(11); // one iteration, x === undefined
+  });
+
+  it("array rest pattern drains the element", async () => {
+    const ret = await runStandalone(`
+      let n = 0;
+      function go() {
+        var it = (async function*(){ yield* [[1,2,3]]; })();
+        async function fn() { for await (const [...xs] of it) { n = xs.length; } }
+        fn();
+      }
+      export function test() { go(); return n; }
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("object pattern over a yielded object", async () => {
+    const ret = await runStandalone(`
+      let n = 0;
+      function go() {
+        var it = (async function*(){ yield* [{ w: 7 }]; })();
+        async function fn() { for await (const { w } of it) { n = w; } }
+        fn();
+      }
+      export function test() { go(); return n; }
+    `);
+    expect(ret).toBe(7);
+  });
+
+  it("plain (non-destructuring) for-await over the host gen iterates every element", async () => {
+    const ret = await runStandalone(`
+      let n = 0;
+      function go() {
+        var it = (async function*(){ yield* [7, 8]; })();
+        async function fn() { for await (const v of it) { n += v; } }
+        fn();
+      }
+      export function test() { go(); return n; }
+    `);
+    expect(ret).toBe(15);
+  });
+
+  it("control: canonical array for-of destructuring is unchanged", async () => {
+    const ret = await runStandalone(`
+      let n = 0;
+      export function test() {
+        for (const [v] of [[1],[2]]) { n += v; }
+        return n;
+      }
+    `);
+    expect(ret).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Closes plan issue #3075 (468 standalone-lane records: `illegal cast [in __iterator]`, dominated by the 390-file for-await-of `dstr-*-async-*` family — every one a `yield*` producer).

**Root cause (measured):** a `yield*`-carrying (async) generator is not a native-generator candidate under `--target standalone`, so it bails to the legacy eager-buffer HOST runtime (`__create_async_generator` + the `__gen_*` env-import bundle). Two stacked breaks:

1. **No `__iterator` arm for a host external** — the host generator object internalizes outside every GC subhierarchy (not struct/array/i31), fell through the GetIterator ladder to the hard-cast tail → `illegal cast`.
2. **Host `__gen_yield_star` silently drained ZERO values** for a WasmGC `$Vec` operand (opaque struct, no `Symbol.iterator`) — even past (1) the buffer was empty.

## Fix

- `src/codegen/iterator-native.ts` — new `ITER_KIND_HOSTGEN` IterRec arm, filled at finalize **only when the module already carries the legacy `__gen_*` imports** (no new host import; every other module is byte-identical). Classification via abstract-heap-type `ref.test` (struct=-21/array=-22/i31=-20 s33 codes — encoder-validated range). `__iterator_next` drives `__gen_next` + `__gen_result_done/__gen_result_value` (the buffered async-gen `next()` thenable exposes `value`/`done` synchronously); `__iterator_return` closes via `__gen_return`; `__iterator_rest` drains via the shared step arm.
- `src/runtime.ts` — `__gen_yield_star` materializes a wasm vec operand via the module's `__vec_len`/`__vec_get` exports (`_materializeIterable`); host arrays pass through unchanged.

## Measurements (n=56 sample of the 390-file cluster, vs upstream/main control worktree)

| lane | control | fixed |
| --- | --- | --- |
| standalone | 51 illegal-cast / 5 pass | **0 illegal-cast / 33 pass** / 8 vacuous / 15 fail-other |
| default (n=14) | 13 pass / 1 fail | identical |

Adjacent standalone scans (for-of/dstr n=72, for-of n=30, generators n=9, Iterator.prototype.toArray n=18): **exactly identical** to control. Extrapolated: ~355 of 468 illegal-cast records eliminated, ~195 flips to pass — acceptance (<100 residual) met. This only ADDS standalone passes; the standalone floor should move UP.

Residual decomposition (vacuous $DONE plumbing, eager-buffer step-count semantics, driven-frame-carrier arm) banked in the issue file.

## Tests

- `tests/issue-3075.test.ts` — 6 cases (array/obj/rest patterns, past-end binding, plain for-await, canonical-vec control), all pass.
- issue-2038 / 3100(s4,s5) / 3119 suites: 65/65 pass. `issue-1320*` has 3 pre-existing failures that reproduce identically on control.
- tsc clean, prettier clean, biome lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8