### PR TITLE
docs(#2980): rule-1 confirmation measure incl. class-async sixth bucket — flip criterion MET

### DIFF
--- a/plan/issues/2980-async-carrier-widen-final-layers-decision-measure.md
+++ b/plan/issues/2980-async-carrier-widen-final-layers-decision-measure.md
@@ -10,6 +10,11 @@ status: ready
 # the full decision measure — released back to `ready` for the next dev to
 # claim class 3 (independent, next-largest, −12) or pick up once #2906
 # slices 3/4 land (classes 2+4). See "## Class 1 landed" below.
+# 2026-07-10 (fable-2938): MEASUREMENT COMPLETE — all six buckets (incl. the
+# class-async supplement) re-measured at main@d7a1feaa1c: total +20, no bucket
+# ≤ −2 → rule 1 MET. The flip PR is NOT opened yet: gated on the #2978/#2833
+# pairing (bot-park-held) + stakeholder sign-off. See the 07-10 section below.
+# Claim released; the flip is an S slice once both gates clear.
 created: 2026-07-02
 updated: 2026-07-05
 priority: high
@@ -317,3 +322,60 @@ needs explicit stakeholder sign-off before merge.
 plain `yield <promise>` must Await; currently yields NaN) — a real host-free
 async-gen conformance win, ORTHOGONAL to the flip (the −4 files are legacy, not
 driven), banked separately.
+
+## CONFIRMATION RE-MEASURE incl. the class-async SIXTH bucket — 2026-07-10 (fable-2938, main@d7a1feaa1c)
+
+The 07-09 record above declared VERDICT: FLIP but its table omits the
+**class-async supplement**, which `plan/log/2980-carrier-widen-tradeoff.md` §6
+point 5 makes an explicit **sixth blocking bucket** (it was −2 at the 07-09
+tradeoff measure — a rule-1 blocker on its own). This run re-measures ALL SIX
+buckets fresh at main@`d7a1feaa1c` (post #3120/#3125/#3121 and the
+conservative-fallback layer `b66d7e2ceb`, all landed):
+
+| bucket               | n   | off | on  | net     | +fixed/−regressed |
+| -------------------- | --- | --- | --- | ------- | ----------------- |
+| async-function       | 60  | 32  | 35  | +3      | +4 / −1           |
+| for-await-of         | 60  | 14  | 18  | +4      | +4 / −0           |
+| async-generator      | 60  | 43  | 43  | +0      | +0 / −0           |
+| promise-then-all     | 60  | 18  | 30  | +12     | +18 / −6          |
+| await-expr           | 22  | 9   | 10  | +1      | +1 / −0           |
+| class-async (suppl.) | 60  | 46  | 46  | **+0**  | +3 / −3           |
+| **TOTAL**            | 322 |     |     | **+20** | +30 / −10         |
+
+**Rule 1 across all six buckets: MET** — positive total (+20), no bucket
+≤ −2 (worst is 0). The class-async supplement's 07-09 blocker (−2,
+`yield-promise-reject-next*`) is cleared by the conservative fallback: its 3
+residual regressions are now `illegal cast in __then_fulfill_0` /
+static-async-method shapes (filed-forward known-negatives inside a net-0
+bucket — non-blocking per rule 1). Also non-blocking, filed forward:
+promise-then-all's 6 in-bucket regs (thenable-assimilation edges —
+`resolve-thenable`, `resolve-poisoned-then`, `rxn-handler-*` — the #3125
+class, partially landed) and async-function's `evaluation-body.js`
+(pre-existing).
+
+Harness: the `scripts/measure/` recipe. This PR banks the missing piece into
+`scripts/measure/corpus.mjs`: the `class-async` bucket
+(`language/{expressions,statements}/class` filtered `/async/`, cap 60, per
+the tradeoff-doc appendix) plus a `MEASURE_BUCKET` env filter for cheap
+single-bucket re-runs. (Run guards for escaping wasm traps were already in
+`arm.mts`; one off-arm async-function file does crash an unguarded runner
+via an escaping null-deref rejection, so keep the guards.)
+
+### Flip status after this measure
+
+The measurement precondition is FULLY met. The flip PR (the two predicates
+`isStandalonePromiseActive` + `isStandaloneThenChainNativeActive`, nothing
+else) remains gated on the two NON-measurement conditions of the 07-09
+record:
+
+1. **#2978/#2934-3b pairing (PR #2833)** — the tradeoff doc §6 point 4 says
+   the pairing lands "before or with the flip". PR #2833 is currently
+   **bot-park-held** (`auto-park-bot:merge-group-failure`, 3 park cycles on
+   2026-07-10) — a real merged-state regression owned by that PR's author;
+   the flip waits for it.
+2. **Explicit stakeholder sign-off** (scoreboard-affecting change, per the
+   07-09 record).
+
+Escalated to the tech lead with this measure; #2980 claim released — the
+flip PR is an S slice for whoever holds the pen when #2833 lands + sign-off
+arrives.

--- a/scripts/measure/corpus.mjs
+++ b/scripts/measure/corpus.mjs
@@ -71,12 +71,29 @@ const BUCKETS = [
     dirs: ["language/expressions/await"],
     category: "language/await",
   },
+  // (#2980, 2026-07-10) The class-async SUPPLEMENT — the tradeoff doc
+  // (plan/log/2980-carrier-widen-tradeoff.md §6 point 5) makes this a SIXTH
+  // blocking bucket for rule 1 (the historical −601 blast radius the five
+  // construct buckets undersample): class bodies filtered to async
+  // method/element shapes.
+  {
+    bucket: "class-async",
+    n: 60,
+    dirs: ["language/expressions/class", "language/statements/class"],
+    filter: "async",
+    category: "language/class-async",
+  },
 ];
+
+// Optional single-bucket run: MEASURE_BUCKET=<name> node scripts/measure/corpus.mjs
+const only = process.env.MEASURE_BUCKET;
 
 const corpus = [];
 for (const b of BUCKETS) {
+  if (only && b.bucket !== only) continue;
   let files = [];
   for (const d of b.dirs) files.push(...walk(join(ROOT, d)));
+  if (b.filter) files = files.filter((f) => f.includes(b.filter));
   const picked = spread(files, b.n);
   for (const f of picked) corpus.push({ file: f, bucket: b.bucket, category: b.category });
   console.error(`${b.bucket}: ${files.length} available -> ${picked.length} sampled`);


### PR DESCRIPTION
## Summary

Delivers the deferred #2980 rule-5 interim re-measure, closing the measurement gap in the 07-09 record: the issue file's FLIP verdict table omitted the **class-async supplement**, which `plan/log/2980-carrier-widen-tradeoff.md` §6 point 5 makes an explicit **sixth blocking bucket** (it was −2 = blocking at the 07-09 tradeoff measure).

Fresh six-bucket A/B at main@`d7a1feaa1c` (post #3120/#3125/#3121 + the `b66d7e2ceb` conservative async-gen fallback), `JS2WASM_ASYNC_CARRIER_WIDEN` off/on:

| bucket | n | off | on | net |
|---|---|---|---|---|
| async-function | 60 | 32 | 35 | +3 |
| for-await-of | 60 | 14 | 18 | +4 |
| async-generator | 60 | 43 | 43 | 0 |
| promise-then-all | 60 | 18 | 30 | +12 |
| await-expr | 22 | 9 | 10 | +1 |
| class-async (suppl.) | 60 | 46 | 46 | **0** |
| **TOTAL** | 322 | | | **+20** |

**Rule 1 (positive total, no bucket ≤ −2) is MET across all six buckets** — the class-async −2 blocker is cleared by the conservative fallback.

**The flip PR is deliberately NOT opened here.** Per the 07-09 record it remains gated on (1) the #2978/#2934-3b pairing — PR #2833, currently bot-park-held with a real merge_group regression — landing before/with the flip, and (2) explicit stakeholder sign-off (scoreboard-affecting). Escalated to the tech lead.

## Changes

- `plan/issues/2980-...md` — the recorded 07-10 measure + flip-status section + frontmatter note (claim released).
- `scripts/measure/corpus.mjs` — banks the `class-async` bucket (per the tradeoff-doc appendix) + a `MEASURE_BUCKET` single-bucket filter, so future re-runs include the sixth bucket by default. Smoke-tested (322-file corpus builds; filter works). No compiler-source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8