### PR TITLE
docs(#3090): Phase 0 audit — legacy front-end reachability delete-list

### DIFF
--- a/plan/issues/3090-shrink-codegen-delete-dormant-legacy-handlers.md
+++ b/plan/issues/3090-shrink-codegen-delete-dormant-legacy-handlers.md
@@ -1,8 +1,11 @@
 ---
 id: 3090
 title: "Shrink codegen: delete dormant legacy direct-codegen handlers superseded by IR (~40–55K net LOC)"
-status: in-progress
-assignee: ttraenkler/fable-6th
+status: ready
+# Phase 0 (audit) landed 2026-07-10 by ttraenkler/fable-6th — see
+# "## Phase 0 audit landed" below. Umbrella stays open: next claimable slice
+# is Phase 2 (knip + unreferenced deletions, ~2.1K); handler deletions are
+# GATED (see the audit doc's G1–G4) — do not start Phase 1 before the gates.
 sprint: current
 created: 2026-07-08
 updated: 2026-07-10
@@ -31,7 +34,7 @@ That duplication is the single biggest reason the compiler is ~6.4× the
 size of a comparable linear-memory TS→Wasm compiler (Porffor: ~32K code
 vs our ~207K).
 
-`#2855` (+ `#2856`–`#2859`) drives the *fallback buckets* to zero and
+`#2855` (+ `#2856`–`#2859`) drives the _fallback buckets_ to zero and
 promotes reasons into `STRICT_IR_REASONS` — but it **does not delete** the
 now-dead legacy bodies. This issue is the complementary **subtraction**
 pass: actually remove the dormant code so the tree shrinks.
@@ -40,11 +43,11 @@ pass: actually remove the dormant code so the tree shrinks.
 
 `src/codegen/` = **154,938** code lines / 150 files. Three-way split:
 
-| Bucket | Code | Disposition |
-| --- | --: | --- |
-| **STAYS** — substrate/orchestrator the IR reuses (`index.ts`, `coercion-engine`, `js-tag`, `value-tags`, `native-strings`, `registry/`, `context/`, `regex/`, `statements/{loops,control-flow}`…) | ~35,221 | keep |
-| **RUNTIME** — stdlib *behavior* emission (`object-runtime`, `array-methods`, `property-access`, `native-regex`, `map-runtime`, `dataview`, generators…) — the IR backend calls it; a front-end swap does not remove the need to emit an array `.map` loop or a regex matcher | ~39,635 | **keep** |
-| **FRONTEND** — AST→Wasm dispatch & lowering that `from-ast.ts`/`lower.ts` replace (`expressions/`, operator/closure/literal/object lowering, statement lowering…) | ~80,082 | **deletable** |
+| Bucket                                                                                                                                                                                                                                                                       |    Code | Disposition   |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------: | ------------- |
+| **STAYS** — substrate/orchestrator the IR reuses (`index.ts`, `coercion-engine`, `js-tag`, `value-tags`, `native-strings`, `registry/`, `context/`, `regex/`, `statements/{loops,control-flow}`…)                                                                            | ~35,221 | keep          |
+| **RUNTIME** — stdlib _behavior_ emission (`object-runtime`, `array-methods`, `property-access`, `native-regex`, `map-runtime`, `dataview`, generators…) — the IR backend calls it; a front-end swap does not remove the need to emit an array `.map` loop or a regex matcher | ~39,635 | **keep**      |
+| **FRONTEND** — AST→Wasm dispatch & lowering that `from-ast.ts`/`lower.ts` replace (`expressions/`, operator/closure/literal/object lowering, statement lowering…)                                                                                                            | ~80,082 | **deletable** |
 
 **Net estimate: ~40–55K code lines removed** after (a) subtracting ~8–10K
 of FRONTEND-classified files that are really shared emission passes
@@ -52,7 +55,7 @@ of FRONTEND-classified files that are really shared emission passes
 (b) offsetting ~15–25K of IR growth needed to finish the remaining
 `mixed`/`direct-only` kinds. That takes `src/` from ~207K → **~155–165K
 code (~20–27% smaller compiler)** with **no capability change** for the
-Phase‑1 slice. It does *not* close the gap to Porffor — RUNTIME (~40K) and
+Phase‑1 slice. It does _not_ close the gap to Porffor — RUNTIME (~40K) and
 WasmGC substrate (~35K) are intrinsic to targeting WasmGC with a full
 stdlib.
 
@@ -63,6 +66,7 @@ already `ir-owned` in `plan/log/ir-adoption.md` (22 kinds today), i.e. the
 FRONTEND-bucket lowering that is unreachable when `experimentalIR: true`.
 
 **Never touch:**
+
 - Any file in **STAYS** or **RUNTIME** (substrate + stdlib behavior).
 - **Deferred** kinds (`eval`, `with`, `Proxy`, `for-in`, async-generator…) —
   they remain direct-only by design; their handlers (e.g. `with-scope.ts`)
@@ -103,10 +107,34 @@ work), **delete its legacy handler in the same PR** rather than leaving it
 dormant. Add a "legacy LOC deleted" metric alongside the `#2855` ratchet so
 retirement is tracked as subtraction, not just bucket-zeroing.
 
+## Phase 0 audit landed (2026-07-10)
+
+Deliverables: `scripts/audit-legacy-reachability.mjs` (call-graph
+reachability, re-runnable, `--why` path tracing) +
+`plan/log/3090-phase0-legacy-delete-list.md` (ranked delete-list, hard
+numbers, kind→file mapping).
+
+**Hard numbers:** FRONTEND legacy-only = **59,976 fn-lines** across 35 files
+(ranked list in the doc); deletable-NOW (unreferenced) ≈ **2.1K fn-lines**
+(index.ts `collect*Imports` family ~1.4K, regex/vm.ts 245, strays).
+
+**Premise correction — handler deletion is GATED, not free:** (G1) the
+default pipeline legacy-compiles EVERY function and the IR merely overlays
+bodies (IR-first #2138 is flag-gated, not default); (G2) the whole-function
+claim unit means any rejected function needs the legacy handler for every
+kind it contains — `ir-owned` status does NOT make a handler dead; (G3)
+top-level statements always compile via legacy; (G4) ~47K fn-lines of
+RUNTIME stdlib emission are reachable ONLY via legacy dispatch — the IR
+needs its own entry points before front-end retirement. Revised phase order
+in the audit doc: Phase 2 (knip + unreferenced) first; handler deletions
+couple to gate-clearing slices (IR-first default, module-level adoption,
+per-kind bucket closure, IR→runtime entry points).
+
 ## Acceptance criteria
 
-- [ ] Phase 0 audit doc committed with a hard deletable-LOC number + ranked
-      per-file/per-kind delete-list.
+- [x] Phase 0 audit doc committed with a hard deletable-LOC number + ranked
+      per-file/per-kind delete-list. (2026-07-10,
+      `plan/log/3090-phase0-legacy-delete-list.md`)
 - [ ] `src/codegen/` shrinks by **≥ 30K code lines** net across Phases 1–2
       (stretch: ≥ 45K), measured by `tokei src` before/after (baseline
       `src` = 206,674 code; `src/codegen` = 154,938).
@@ -126,7 +154,7 @@ retirement is tracked as subtraction, not just bucket-zeroing.
 - **Don't confuse RUNTIME with FRONTEND** — `array-methods`/`object-runtime`/
   `native-regex` have zero IR imports today but emit behavior both paths
   need; deleting them breaks features. Only delete what Phase 0 proves is
-  reachable *solely* via the legacy front-end dispatch.
+  reachable _solely_ via the legacy front-end dispatch.
 - **Late-import funcidx discipline** — codegen is sensitive to function-index
   shifts; deleting a handler that registered helper imports can shift
   indices. Re-run the standalone floor on `merge_group` for any slice that

--- a/plan/issues/3090-shrink-codegen-delete-dormant-legacy-handlers.md
+++ b/plan/issues/3090-shrink-codegen-delete-dormant-legacy-handlers.md
@@ -1,10 +1,11 @@
 ---
 id: 3090
 title: "Shrink codegen: delete dormant legacy direct-codegen handlers superseded by IR (~40–55K net LOC)"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-6th
 sprint: current
 created: 2026-07-08
-updated: 2026-07-08
+updated: 2026-07-10
 priority: high
 horizon: xl
 feasibility: medium

--- a/plan/log/3090-phase0-legacy-delete-list.md
+++ b/plan/log/3090-phase0-legacy-delete-list.md
@@ -1,0 +1,186 @@
+# #3090 Phase 0 — legacy front-end delete-list (reachability audit)
+
+**Date:** 2026-07-10 · **Author:** fable-6th · **Baseline:** `origin/main` @ `8d86b2c4fd`
+**Tool:** `node scripts/audit-legacy-reachability.mjs` (re-run any time; writes
+per-function detail to `.tmp/legacy-reachability.json`, prints the tables below)
+
+## What was measured
+
+Call-graph reachability over every top-level function in `src/` (function
+declarations + `const x = fn/arrow`, plus a `<module>` pseudo-node per file
+for top-level tables). Two reachability passes:
+
+- **Survivor pass** — roots = every function in `src/` **outside**
+  `src/codegen/` (IR front-end/backend, runtime, cli, linear backend,
+  orchestration entry), with the legacy body-dispatch pair
+  **`compileStatement`/`compileExpression` removed from the graph**. What
+  this pass reaches survives legacy front-end retirement ("shared").
+- **Full pass** — same roots + the dispatch pair. Reachable here but not in
+  the survivor pass = **dies with the legacy front-end** ("legacy-only").
+  Reachable in neither = **unreferenced** (dead today).
+
+Edges are identifier references (call, callback, table entry) resolved via
+same-file definitions and import/re-export chains — conservative: any
+reference marks a function shared, so "legacy-only" is an under- not
+over-estimate, and "unreferenced" excludes anything a live table mentions.
+Known blind spot: consumers outside `src/` (tests import some codegen
+internals) — Phase 2 must confirm each "unreferenced" entry with `knip`
+before deleting.
+
+## Hard numbers (fn-lines, 2026-07-10)
+
+| Bucket                                               | files | legacy-only | shared | unreferenced |
+| ---------------------------------------------------- | ----: | ----------: | -----: | -----------: |
+| **frontend** (delete candidates)                     |    35 |  **59,976** |  7,413 |          288 |
+| **deferred** (`eval`/`with`/async-CPS — never touch) |     3 |       1,473 |  1,408 |           12 |
+| **runtime** (stdlib behavior emission — keep)        |    58 |  **46,979** | 29,032 |          280 |
+| **stays** (substrate/orchestrator — keep)            |    57 |       4,136 | 45,802 |        1,573 |
+
+The FRONTEND delete-set is a hard **~60.0K fn-lines** (the issue's ±10K band
+was 70–80K file-lines; per-function attribution excludes the shared slices
+that live inside FRONTEND files, e.g. 3.2K of `closures.ts` the class/decl
+machinery reuses).
+
+## Ground-truth gates — what "dormant" actually means (premise corrections)
+
+The issue's Phase 1 assumed handlers for `ir-owned` kinds are "unreachable
+when `experimentalIR: true`". The pipeline disproves this; deletion is gated
+on four structural facts:
+
+- **G1 — legacy compiles EVERYTHING first.** By default the IR is an
+  _overlay_: "The legacy path has already produced a working `body` for every
+  function before `compileIrPathFunctions` runs" (`src/codegen/index.ts`,
+  overlay block at ~:2096). IR-compiled bodies _replace_ legacy bodies after
+  the fact. Only under `JS2WASM_IR_FIRST=1` (#2138, flag-gated, NOT default)
+  is legacy emission skipped for claimed functions. **Deleting any live
+  handler breaks compilation until IR-first is the default.**
+- **G2 — whole-function claim unit keeps every handler live.** The selector
+  claims `FunctionDeclaration`s; any rejection (every non-zero bucket in
+  `plan/log/ir-adoption.md`, every `mixed`/`direct-only`/`deferred` kind in
+  the body, class-method gaps) demotes the _whole function_ to legacy — which
+  then needs the legacy handler for every kind it contains, including
+  `ir-owned` ones. An `IfStatement` inside a function with a `switch` is
+  compiled by the legacy `IfStatement` handler. **A kind being `ir-owned`
+  does NOT make its legacy handler dead.**
+- **G3 — top-level statements are always legacy.** Module-level code is not
+  claimable (the claim unit is function declarations / class members), so
+  `compileStatement` and the statement handlers stay reachable for top-level
+  code until the IR adopts module-level lowering.
+- **G4 — runtime emission enters through legacy dispatch.** ~47K fn-lines of
+  stdlib behavior emission (`array-methods`, `property-access`, `object-ops`,
+  `native-regex`, `string-ops`, `json-*`, `dataview`, `map-runtime`…) are
+  reachable **only** via `compileExpression`/`compileStatement` today; the IR
+  path shares just 29K (coercion, strings, async/generator machinery,
+  `object-runtime`). Retiring the front-end requires the IR to grow its own
+  call-paths into this emission (per-kind adoption), not deletion.
+
+**Consequence:** "deletable today with zero capability change" =
+the **unreferenced set (~2.1K fn-lines)** — everything else is conditional.
+The ~60K FRONTEND number is the size of the eventual win, banked per-kind as
+gates clear (revised phases below).
+
+## Ranked FRONTEND delete-list (dies with the legacy front-end)
+
+Ranked by legacy-only fn-lines; "shared" fn-lines inside these files must
+be kept (or relocated) when the file is deleted.
+
+| File                              | file lines | legacy-only fn-lines | shared fn-lines | unreferenced |
+| --------------------------------- | ---------: | -------------------: | --------------: | -----------: |
+| expressions/calls.ts              |      17573 |                16210 |               0 |            0 |
+| expressions/assignment.ts         |       7330 |                 6853 |               0 |            0 |
+| statements/loops.ts               |       6221 |                 5645 |             105 |            0 |
+| expressions/new-super.ts          |       5603 |                 5153 |               0 |            0 |
+| binary-ops.ts                     |       4475 |                 4187 |               0 |            0 |
+| expressions/builtins.ts           |       3710 |                 3494 |               0 |            0 |
+| literals.ts                       |       4233 |                 3364 |             434 |            0 |
+| expressions/unary-updates.ts      |       2088 |                 1700 |               0 |          204 |
+| expressions/identifiers.ts        |       1926 |                 1507 |             167 |            0 |
+| typeof-delete.ts                  |       1590 |                 1417 |               0 |            0 |
+| statements/control-flow.ts        |       1530 |                 1305 |              49 |            0 |
+| expressions.ts                    |       1568 |                 1217 |               3 |           59 |
+| closures.ts                       |       5023 |                 1147 |            3229 |            0 |
+| statements/variables.ts           |       1529 |                 1142 |             198 |            0 |
+| expressions/calls-closures.ts     |       1102 |                 1012 |               0 |            0 |
+| statements/destructuring.ts       |       1424 |                  639 |             532 |            0 |
+| statements/exceptions.ts          |        638 |                  550 |               0 |            0 |
+| expressions/misc.ts               |        563 |                  490 |               0 |            0 |
+| expressions/extern.ts             |        578 |                  481 |               0 |            0 |
+| statements/nested-declarations.ts |       2729 |                  443 |            1909 |           20 |
+| expressions/logical-ops.ts        |        451 |                  403 |               0 |            0 |
+| expressions/helpers.ts            |        533 |                  272 |              27 |            0 |
+| statements.ts                     |        311 |                  230 |               0 |            0 |
+| expressions/calls-guards.ts       |        300 |                  223 |               0 |            0 |
+| expressions/calls-optional.ts     |        240 |                  209 |               0 |            0 |
+| expressions/unary.ts              |        179 |                  146 |               0 |            0 |
+| statements/shared.ts              |        174 |                  111 |              13 |            0 |
+| expressions/late-imports.ts       |        856 |                  102 |             571 |            0 |
+| expressions/promise-subclass.ts   |        200 |                   98 |               0 |            0 |
+| expressions/fnctor-prototype.ts   |        222 |                   83 |              43 |            0 |
+| expressions/proto-override.ts     |        288 |                   71 |             100 |            0 |
+| statements/tdz.ts                 |        125 |                   49 |              14 |            5 |
+| new-target.ts                     |         98 |                   23 |              19 |            0 |
+
+Per-function names/spans: `.tmp/legacy-reachability.json` (regenerate with
+the script).
+
+### Kind → file mapping (cross-check vs `ir-adoption.md` `ir-owned` rows)
+
+| ir-owned kind(s)                                                                                                    | Legacy handler home                               | Gate     |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------- |
+| `IfStatement`, `Block`, `ThrowStatement`, `ReturnStatement`                                                         | statements/control-flow.ts, statements.ts         | G1+G2+G3 |
+| `WhileStatement` (+ mixed for/for-of/do)                                                                            | statements/loops.ts                               | G1+G2+G3 |
+| `Identifier`                                                                                                        | expressions/identifiers.ts                        | G1+G2    |
+| `NumericLiteral`, `StringLiteral`, `NoSubstitutionTemplateLiteral`, `True/FalseKeyword`, `RegularExpressionLiteral` | literals.ts, string-ops.ts (runtime)              | G1+G2    |
+| `PostfixUnaryExpression`                                                                                            | expressions/unary-updates.ts                      | G1+G2    |
+| `ConditionalExpression`, `ParenthesizedExpression`                                                                  | expressions.ts                                    | G1+G2    |
+| `TypeOfExpression`, `DeleteExpression`, `VoidExpression`                                                            | typeof-delete.ts, expressions/unary.ts            | G1+G2    |
+| `FunctionDeclaration` (claim unit)                                                                                  | declarations.ts (stays), function-body.ts (stays) | —        |
+
+No `ir-owned` kind's handler is deletable in isolation today (G2); the
+per-kind coupling lands in Phase 3 as buckets zero out.
+
+## Deletable NOW — unreferenced functions (Phase 2, knip-confirmed)
+
+~2.1K fn-lines dead today (top items; full list in the script output):
+
+- `src/codegen/index.ts` — the superseded host-import scan family
+  (`collectConsoleImports`, `collectMathImports`, `collectPrimitiveMethodImports`,
+  `collectStringMethodImports`, `collectString*`/`collectPromise*`/
+  `collectJson*`/`collectGenerator*`/`collectIterator*`/`collectUnion*`/… —
+  ~1,400 lines): re-implemented as fused scans in `declarations.ts` (see the
+  `// -- collectXImports --` section markers there); the originals in
+  index.ts are referenced by nothing.
+- `regex/vm.ts` — 245 lines unreferenced (regex VM superseded by
+  `regex/bytecode.ts` + `native-regex.ts` paths; verify with knip).
+- `expressions/unary-updates.ts` — `compilePrefixIncrementProperty` (:1650, 65 ln),
+  `compilePrefixIncrementElement` (:1719, 139 ln).
+- `expressions.ts` — `emitCoercedLocalSet`/`updateLocalType`/`widenLocalToNullable` (~59 ln).
+- Assorted ≤20-line strays (see report).
+
+Caveat: the audit graph does not include `tests/` — confirm zero test-side
+imports (or move the helper) before each deletion; wiring `knip` into
+`quality` (issue Phase 2) automates exactly this.
+
+## Revised phase plan
+
+1. **Phase 2 first (reordered):** knip wiring + delete the unreferenced set
+   (~2.1K, immediate, zero-risk after knip confirmation).
+2. **Gate-clearing prerequisites for any handler deletion** (each its own
+   issue/slice):
+   a. Make IR-first (`JS2WASM_IR_FIRST=1`, #2138) the default — clears G1.
+   b. Module-level (top-level statement) IR adoption — clears G3.
+   c. Per-kind fallback closure (#2855/#2856-family, STRICT_IR_REASONS) —
+   clears G2 kind by kind.
+   d. IR-side entry points into RUNTIME emission (per builtin family) —
+   clears G4 file by file.
+3. **Phase 1/3 (merged):** delete each FRONTEND file's legacy-only set in
+   the same PR that closes its last gate, largest first per the ranked list
+   (calls.ts 16.2K → assignment.ts 6.9K → loops.ts 5.6K → …). Validate every
+   slice on full CI / `merge_group` (standalone floor only runs there).
+
+## Regenerate
+
+```bash
+node scripts/audit-legacy-reachability.mjs            # tables + JSON
+node scripts/audit-legacy-reachability.mjs --why 'calls.ts#compileCallExpression'  # survivor-path trace
+```

--- a/scripts/audit-legacy-reachability.mjs
+++ b/scripts/audit-legacy-reachability.mjs
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+// #3090 Phase 0 — legacy front-end reachability audit.
+//
+// Classifies every top-level function in `src/` as SURVIVOR (still reachable
+// when the legacy direct AST→Wasm *body dispatch* is deleted) or LEGACY-ONLY
+// (reachable exclusively through the legacy dispatch pair
+// `compileStatement` / `compileExpression`), by call-graph reachability.
+//
+// Model (see plan/log/3090-phase0-legacy-delete-list.md for the full
+// write-up and caveats):
+//
+//   - Nodes: top-level function declarations + top-level `const x = fn/arrow`
+//     in every `src/**/*.ts` file, plus one `<module>` pseudo-node per file
+//     for top-level (table/side-effect) code.
+//   - Edges: identifier references inside a node's span that resolve to a
+//     same-file top-level function or to an imported name (named, default,
+//     namespace `ns.foo`, and `export ... from` re-exports are followed).
+//     Any reference counts (call, callback, table entry) — conservative:
+//     over-approximates SHARED, never LEGACY-ONLY.
+//   - Survivor roots: every node in `src/` OUTSIDE `src/codegen/`
+//     (ir front-end/backend, runtime, cli, linear backend, index) — an
+//     over-approximation of "code that outlives the legacy front-end".
+//   - Cut: the legacy body-dispatch entries (`compileStatement` in
+//     codegen/statements.ts, `compileExpression` in codegen/expressions.ts)
+//     are REMOVED from the graph for the survivor pass. What the survivor
+//     pass cannot reach, but full reachability can, dies with the legacy
+//     front-end ("legacy-only").
+//
+// Output: per-file and per-function attribution as JSON
+// (`.tmp/legacy-reachability.json`) + a ranked markdown table on stdout.
+//
+// Usage: node scripts/audit-legacy-reachability.mjs [--json <path>] [--md]
+
+import ts from "typescript";
+import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync } from "fs";
+import path from "path";
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const SRC = path.join(ROOT, "src");
+
+// The legacy front-end body-dispatch pair — the cut set.
+const CUT = new Set(["src/codegen/statements.ts#compileStatement", "src/codegen/expressions.ts#compileExpression"]);
+
+// ---------------------------------------------------------------------------
+// File walk
+// ---------------------------------------------------------------------------
+function walk(dir, out = []) {
+  for (const e of readdirSync(dir)) {
+    const p = path.join(dir, e);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (e.endsWith(".ts") && !e.endsWith(".d.ts")) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(SRC);
+const rel = (p) => path.relative(ROOT, p);
+
+// ---------------------------------------------------------------------------
+// Parse each file: top-level callables, imports, re-exports
+// ---------------------------------------------------------------------------
+/** @type {Map<string, {sf: import("typescript").SourceFile, fns: Map<string,{start:number,end:number,exported:boolean}>, imports: Map<string,{file:string,name:string}>, nsImports: Map<string,string>, reexports: {from:string,names:Map<string,string>|null}[], moduleRefs: Set<string>}>} */
+const fileInfo = new Map();
+
+function resolveModule(fromFile, spec) {
+  if (!spec.startsWith(".")) return null; // external package
+  let base = path.resolve(path.dirname(fromFile), spec.replace(/\.js$/, ""));
+  for (const cand of [base + ".ts", path.join(base, "index.ts")]) {
+    try {
+      if (statSync(cand).isFile()) return cand;
+    } catch {
+      /* keep trying */
+    }
+  }
+  return null;
+}
+
+for (const file of files) {
+  const text = readFileSync(file, "utf-8");
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  const fns = new Map();
+  const imports = new Map();
+  const nsImports = new Map();
+  const reexports = [];
+
+  const lineOf = (pos) => sf.getLineAndCharacterOfPosition(pos).line + 1;
+
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      fns.set(stmt.name.text, {
+        start: lineOf(stmt.getStart()),
+        end: lineOf(stmt.end),
+        exported: !!stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword),
+        node: stmt,
+      });
+    } else if (ts.isVariableStatement(stmt)) {
+      const exported = !!stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+      for (const decl of stmt.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          decl.initializer &&
+          (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer))
+        ) {
+          fns.set(decl.name.text, {
+            start: lineOf(stmt.getStart()),
+            end: lineOf(stmt.end),
+            exported,
+            node: stmt,
+          });
+        }
+      }
+    } else if (ts.isImportDeclaration(stmt) && stmt.importClause && ts.isStringLiteral(stmt.moduleSpecifier)) {
+      const target = resolveModule(file, stmt.moduleSpecifier.text);
+      if (!target) continue;
+      const t = rel(target);
+      const ic = stmt.importClause;
+      if (ic.name) imports.set(ic.name.text, { file: t, name: "default" });
+      if (ic.namedBindings) {
+        if (ts.isNamespaceImport(ic.namedBindings)) nsImports.set(ic.namedBindings.name.text, t);
+        else
+          for (const el of ic.namedBindings.elements)
+            imports.set(el.name.text, { file: t, name: (el.propertyName ?? el.name).text });
+      }
+    } else if (ts.isExportDeclaration(stmt) && stmt.moduleSpecifier && ts.isStringLiteral(stmt.moduleSpecifier)) {
+      const target = resolveModule(file, stmt.moduleSpecifier.text);
+      if (!target) continue;
+      const names = stmt.exportClause && ts.isNamedExports(stmt.exportClause) ? new Map() : null;
+      if (names && stmt.exportClause && ts.isNamedExports(stmt.exportClause))
+        for (const el of stmt.exportClause.elements) names.set(el.name.text, (el.propertyName ?? el.name).text);
+      reexports.push({ from: rel(target), names });
+    }
+  }
+
+  fileInfo.set(rel(file), { sf, fns, imports, nsImports, reexports, text });
+}
+
+// ---------------------------------------------------------------------------
+// Export resolution (follows re-export chains)
+// ---------------------------------------------------------------------------
+const exportCache = new Map();
+function resolveExport(fileRel, name, seen = new Set()) {
+  const key = fileRel + "#" + name;
+  if (exportCache.has(key)) return exportCache.get(key);
+  if (seen.has(key)) return null;
+  seen.add(key);
+  const info = fileInfo.get(fileRel);
+  let result = null;
+  if (info) {
+    if (info.fns.has(name)) result = key;
+    else {
+      // re-exported from another module?
+      for (const re of info.reexports) {
+        if (re.names) {
+          const orig = re.names.get(name);
+          if (orig) {
+            result = resolveExport(re.from, orig, seen);
+            if (result) break;
+          }
+        } else {
+          result = resolveExport(re.from, name, seen);
+          if (result) break;
+        }
+      }
+      // import-then-export (export { x } where x imported) — handled via imports
+      if (!result && info.imports.has(name)) {
+        const im = info.imports.get(name);
+        result = resolveExport(im.file, im.name, seen);
+      }
+    }
+  }
+  exportCache.set(key, result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Edge extraction
+// ---------------------------------------------------------------------------
+/** @type {Map<string, Set<string>>} */
+const edges = new Map();
+const addEdge = (from, to) => {
+  if (!edges.has(from)) edges.set(from, new Set());
+  edges.get(from).add(to);
+};
+
+for (const [fileRel, info] of fileInfo) {
+  const { sf, fns, imports, nsImports } = info;
+
+  const refsOf = (node, out) => {
+    const visit = (n) => {
+      if (ts.isIdentifier(n)) out.add(n.text);
+      if (ts.isPropertyAccessExpression(n) && ts.isIdentifier(n.expression) && nsImports.has(n.expression.text)) {
+        const target = resolveExport(nsImports.get(n.expression.text), n.name.text);
+        if (target) out.add("\0resolved:" + target);
+      }
+      ts.forEachChild(n, visit);
+    };
+    visit(node);
+  };
+
+  const linkRefs = (fromId, refs) => {
+    for (const r of refs) {
+      if (r.startsWith("\0resolved:")) {
+        addEdge(fromId, r.slice("\0resolved:".length));
+        continue;
+      }
+      if (fns.has(r)) addEdge(fromId, fileRel + "#" + r);
+      if (imports.has(r)) {
+        const im = imports.get(r);
+        const target = resolveExport(im.file, im.name);
+        if (target) addEdge(fromId, target);
+        else addEdge(fromId, im.file + "#<module>"); // value/table import — keep module alive
+      }
+    }
+  };
+
+  // function nodes
+  for (const [name, fn] of fns) {
+    const refs = new Set();
+    refsOf(fn.node, refs);
+    refs.delete(name);
+    linkRefs(fileRel + "#" + name, refs);
+  }
+
+  // module pseudo-node: top-level statements that are not function/import decls
+  const modRefs = new Set();
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) || ts.isImportDeclaration(stmt)) continue;
+    // Export lists (`export { x }`, `export { x } from "y"`) are re-export
+    // surface, not invocations — resolveExport() handles them for consumers.
+    if (ts.isExportDeclaration(stmt)) continue;
+    if (ts.isVariableStatement(stmt)) {
+      // skip bodies already attributed to const-fn nodes
+      let attributed = false;
+      for (const decl of stmt.declarationList.declarations)
+        if (ts.isIdentifier(decl.name) && fns.has(decl.name.text)) attributed = true;
+      if (attributed) continue;
+    }
+    refsOf(stmt, modRefs);
+  }
+  linkRefs(fileRel + "#<module>", modRefs);
+  // a live module implies its top-level tables can invoke what they reference,
+  // and any function of the file being live implies the module executed:
+  for (const name of fns.keys()) addEdge(fileRel + "#" + name, fileRel + "#<module>");
+}
+
+// ---------------------------------------------------------------------------
+// Reachability
+// ---------------------------------------------------------------------------
+function reach(roots, cut) {
+  const seen = new Set();
+  const stack = [...roots].filter((r) => !cut.has(r));
+  while (stack.length) {
+    const n = stack.pop();
+    if (seen.has(n)) continue;
+    seen.add(n);
+    for (const m of edges.get(n) ?? []) if (!cut.has(m) && !seen.has(m)) stack.push(m);
+  }
+  return seen;
+}
+
+const allNodes = [];
+for (const [fileRel, info] of fileInfo) {
+  allNodes.push(fileRel + "#<module>");
+  for (const name of info.fns.keys()) allNodes.push(fileRel + "#" + name);
+}
+
+const survivorRoots = allNodes.filter((n) => !n.startsWith("src/codegen/"));
+const rSurvive = reach(survivorRoots, CUT);
+const rFull = reach([...survivorRoots, ...CUT], new Set());
+
+// --why <substr>: print a shortest survivor-path to each matching node.
+const whyIdx = process.argv.indexOf("--why");
+if (whyIdx > -1) {
+  const needle = process.argv[whyIdx + 1];
+  // BFS with parents from survivor roots (cut applied)
+  const parent = new Map();
+  const queue = survivorRoots.filter((r) => !CUT.has(r));
+  for (const r of queue) parent.set(r, null);
+  while (queue.length) {
+    const n = queue.shift();
+    for (const m of edges.get(n) ?? []) {
+      if (CUT.has(m) || parent.has(m)) continue;
+      parent.set(m, n);
+      queue.push(m);
+    }
+  }
+  for (const n of allNodes) {
+    if (!n.includes(needle) || !parent.has(n)) continue;
+    const chain = [];
+    for (let c = n; c; c = parent.get(c)) chain.push(c);
+    console.log(chain.reverse().join("\n  -> "));
+    console.log("");
+  }
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Bucket classification (#3090 three-way split, refined)
+//   frontend — AST→Wasm dispatch/lowering the IR front-end replaces (delete
+//              candidates, gated; see the Phase 0 doc)
+//   deferred — lowering for kinds the IR will never adopt (eval/with/async
+//              CPS) — never touch while the feature is supported
+//   runtime  — stdlib *behavior* emission (incl. builtin-call dispatch) the
+//              IR backend still needs — keep
+//   stays    — substrate/orchestrator (module emission, type/import
+//              registries, coercion, strings substrate, backend passes) — keep
+// ---------------------------------------------------------------------------
+const BUCKET_PREFIX = [
+  ["src/codegen/context/", "stays"],
+  ["src/codegen/registry/", "stays"],
+  ["src/codegen/helpers/", "stays"],
+  ["src/codegen/regex/", "runtime"],
+  ["src/codegen/expressions/", "frontend"],
+  ["src/codegen/statements/", "frontend"],
+];
+const BUCKET_FILE = {
+  "expressions/eval-inline.ts": "deferred",
+  "with-scope.ts": "deferred",
+  "async-cps.ts": "deferred",
+  "expressions.ts": "frontend",
+  "statements.ts": "frontend",
+  "binary-ops.ts": "frontend",
+  "literals.ts": "frontend",
+  "typeof-delete.ts": "frontend",
+  "closures.ts": "frontend",
+  "new-target.ts": "frontend",
+  // stdlib behavior emission + builtin-call dispatch (issue puts
+  // property-access here; object-ops/string-ops are the same shape)
+  "array-element-typing.ts": "runtime",
+  "array-holes.ts": "runtime",
+  "array-methods.ts": "runtime",
+  "array-object-proto.ts": "runtime",
+  "array-reduce-fusion.ts": "runtime",
+  "array-to-primitive.ts": "runtime",
+  "async-activation.ts": "runtime",
+  "async-frame.ts": "runtime",
+  "async-scheduler.ts": "runtime",
+  "builtin-fn-meta.ts": "runtime",
+  "builtin-scaffold.ts": "runtime",
+  "builtin-static-globals.ts": "runtime",
+  "case-convert-native.ts": "runtime",
+  "case-tables.ts": "runtime",
+  "class-to-primitive.ts": "runtime",
+  "custom-iterable.ts": "runtime",
+  "dataview-native.ts": "runtime",
+  "date-parse-native.ts": "runtime",
+  "deno-api.ts": "runtime",
+  "escape-native.ts": "runtime",
+  "generators-native.ts": "runtime",
+  "hof-native.ts": "runtime",
+  "html-wrapper-native.ts": "runtime",
+  "iterator-native.ts": "runtime",
+  "json-codec-native.ts": "runtime",
+  "json-runtime.ts": "runtime",
+  "json-standalone.ts": "runtime",
+  "map-runtime.ts": "runtime",
+  "math-helpers.ts": "runtime",
+  "native-proto-value-read.ts": "runtime",
+  "native-proto.ts": "runtime",
+  "native-regex.ts": "runtime",
+  "node-fs-api.ts": "runtime",
+  "number-format-native.ts": "runtime",
+  "number-ryu.ts": "runtime",
+  "object-ops.ts": "runtime",
+  "object-runtime.ts": "runtime",
+  "parse-number-native.ts": "runtime",
+  "promise-combinators.ts": "runtime",
+  "promise-executor.ts": "runtime",
+  "property-access.ts": "runtime",
+  "raw-wasi-api.ts": "runtime",
+  "regexp-standalone.ts": "runtime",
+  "set-algebra.ts": "runtime",
+  "set-runtime.ts": "runtime",
+  "string-ops.ts": "runtime",
+  "symbol-native.ts": "runtime",
+  "temporal-native.ts": "runtime",
+  "timsort.ts": "runtime",
+  "uri-encoding-native.ts": "runtime",
+  "weak-collections-runtime.ts": "runtime",
+  "wellformed-native.ts": "runtime",
+};
+function bucketOf(fileRel) {
+  const short = fileRel.replace("src/codegen/", "");
+  if (BUCKET_FILE[short]) return BUCKET_FILE[short];
+  for (const [pre, b] of BUCKET_PREFIX) if (fileRel.startsWith(pre)) return b;
+  return "stays";
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+const perFile = [];
+for (const [fileRel, info] of fileInfo) {
+  if (!fileRel.startsWith("src/codegen/") || fileRel.startsWith("src/codegen-linear/")) continue;
+  let legacyLoc = 0,
+    sharedLoc = 0,
+    deadLoc = 0;
+  const fns = [];
+  for (const [name, fn] of info.fns) {
+    const id = fileRel + "#" + name;
+    const loc = fn.end - fn.start + 1;
+    const cls = CUT.has(id) ? "dispatch" : rSurvive.has(id) ? "shared" : rFull.has(id) ? "legacy-only" : "unreferenced";
+    if (cls === "legacy-only" || cls === "dispatch") legacyLoc += loc;
+    else if (cls === "shared") sharedLoc += loc;
+    else deadLoc += loc;
+    fns.push({ name, loc, cls, exported: fn.exported, start: fn.start });
+  }
+  const totalLines = info.text.split("\n").length;
+  perFile.push({ file: fileRel, bucket: bucketOf(fileRel), totalLines, legacyLoc, sharedLoc, deadLoc, fns });
+}
+
+perFile.sort((a, b) => b.legacyLoc - a.legacyLoc);
+
+const jsonIdx = process.argv.indexOf("--json");
+const jsonPath = jsonIdx > -1 ? process.argv[jsonIdx + 1] : path.join(ROOT, ".tmp", "legacy-reachability.json");
+mkdirSync(path.dirname(jsonPath), { recursive: true });
+writeFileSync(jsonPath, JSON.stringify({ cut: [...CUT], perFile }, null, 1));
+
+const byBucket = { frontend: [], deferred: [], runtime: [], stays: [] };
+for (const f of perFile) byBucket[f.bucket].push(f);
+
+const sum = (arr, k) => arr.reduce((a, f) => a + f[k], 0);
+
+console.log(`# Legacy front-end reachability (src/codegen, ${perFile.length} files)`);
+console.log(`# JSON: ${rel(jsonPath)}  (per-function detail)`);
+console.log("");
+console.log("| Bucket | files | legacy-only fn-lines | shared fn-lines | unreferenced fn-lines |");
+console.log("| --- | --: | --: | --: | --: |");
+for (const b of ["frontend", "deferred", "runtime", "stays"]) {
+  const fs = byBucket[b];
+  console.log(`| ${b} | ${fs.length} | ${sum(fs, "legacyLoc")} | ${sum(fs, "sharedLoc")} | ${sum(fs, "deadLoc")} |`);
+}
+console.log("");
+for (const b of ["frontend", "deferred", "runtime"]) {
+  console.log(`## ${b}`);
+  console.log("| File | file lines | legacy-only fn-lines | shared fn-lines | unreferenced |");
+  console.log("| --- | --: | --: | --: | --: |");
+  for (const f of byBucket[b]) {
+    if (f.legacyLoc === 0 && f.deadLoc === 0) continue;
+    console.log(
+      `| ${f.file.replace("src/codegen/", "")} | ${f.totalLines} | ${f.legacyLoc} | ${f.sharedLoc} | ${f.deadLoc} |`,
+    );
+  }
+  console.log("");
+}
+console.log("## unreferenced functions (knip/Phase-2 candidates, all buckets)");
+console.log("| File | function | lines |");
+console.log("| --- | --- | --: |");
+for (const f of perFile)
+  for (const fn of f.fns)
+    if (fn.cls === "unreferenced")
+      console.log(`| ${f.file.replace("src/codegen/", "")} | ${fn.name} (:${fn.start}) | ${fn.loc} |`);


### PR DESCRIPTION
## Summary

Phase 0 of #3090 (shrink codegen): the ranked delete-list audit, with a reproducible tool.

- **`scripts/audit-legacy-reachability.mjs`** — call-graph reachability over every top-level function in `src/`, cutting the legacy body-dispatch pair (`compileStatement`/`compileExpression`); classifies each function as shared / legacy-only / unreferenced, with a curated four-way file bucket map (frontend/deferred/runtime/stays) and a `--why` survivor-path tracer.
- **`plan/log/3090-phase0-legacy-delete-list.md`** — the Phase 0 deliverable: hard numbers, ranked per-file delete-list, kind→file mapping vs `ir-adoption.md`, revised phase plan.
- Issue file: acceptance box 1 checked, Phase-0 findings summarized, status back to `ready` for the next slice (umbrella continues).

## Hard numbers

| Bucket | files | legacy-only fn-lines | shared | unreferenced |
| --- | --: | --: | --: | --: |
| frontend (delete candidates) | 35 | **59,976** | 7,413 | 288 |
| deferred (never touch) | 3 | 1,473 | 1,408 | 12 |
| runtime (keep) | 58 | **46,979** | 29,032 | 280 |
| stays (keep) | 57 | 4,136 | 45,802 | 1,573 |

## Premise corrections (the load-bearing finding)

Handler deletion is **gated**, not free: (G1) the IR is an *overlay* — legacy compiles every function first, IR patches bodies after (IR-first #2138 is flag-gated, not default); (G2) whole-function claim unit — any rejected function needs legacy handlers for every kind it contains, so `ir-owned` ≠ dead handler; (G3) top-level statements always compile via legacy; (G4) ~47K fn-lines of runtime stdlib emission are reachable ONLY via legacy dispatch — the IR needs its own entry points first. Deletable **today**: the unreferenced set (~2.1K, e.g. the superseded `collect*Imports` family in `index.ts`, ~1.4K). Revised order: Phase 2 (knip + unreferenced) first; handler deletions couple to gate-clearing slices.

## Validation

- Docs/plan + a new standalone audit script only — no compiler source touched, zero Wasm-emit impact.
- Script runs clean on this branch; prettier/biome pass (lint-staged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8