### PR TITLE
feat(#2980): FLIP the async carrier widen — standalone takes the native $Promise lane

### DIFF
--- a/plan/issues/2980-async-carrier-widen-final-layers-decision-measure.md
+++ b/plan/issues/2980-async-carrier-widen-final-layers-decision-measure.md
@@ -1,7 +1,8 @@
 ---
 id: 2980
 title: "Standalone async widen — FINAL layers (async-fn drive −16 residual, Gap 5 for-await/async-gen −32) + the slice-1d carrier-widen DECISION MEASURE"
-status: ready
+status: done
+completed: 2026-07-10
 # measure phase delivered by ttraenkler/fable-5 (2026-07-02) — the four residual classes are the remaining work.
 # NB the 07-02 claim release had NOT landed on the issue-assignments ref; force-released
 # 2026-07-03 by the architect (`claim-issue.mjs --release 2980 ... --force`). Claimable now.
@@ -379,3 +380,44 @@ record:
 Escalated to the tech lead with this measure; #2980 claim released — the
 flip PR is an S slice for whoever holds the pen when #2833 lands + sign-off
 arrives.
+
+## ✅ THE FLIP — 2026-07-10 (fable-2938, stakeholder sign-off granted)
+
+Both non-measurement gates cleared on 2026-07-10: **PR #2833** (the
+#2978/#2934-3b pairing) merged at 15:16, and **explicit stakeholder
+sign-off** was granted (relayed by the tech lead). Per rule 1, the flip PR
+carries exactly the two predicates + this record:
+
+- `isStandalonePromiseActive` / `isStandaloneThenChainNativeActive` →
+  `ctx.wasi === true || (ctx.standalone === true && !widenAsyncGenFallback(ctx))`
+  — verbatim the MEASURED on-arm semantics (the conservative async-gen
+  fallback `b66d7e2ceb` included). The `JS2WASM_ASYNC_CARRIER_WIDEN`
+  instrument is retired (on-arm == production now); the harness stays in
+  `scripts/measure/` for future re-measures.
+- The former #2865 receiver-directed arm of the then-chain predicate
+  (`getDrainFuncIdxForWasiStart(ctx) !== null`) is subsumed: the widened arm
+  is a superset for every non-async-gen standalone module, and async-gen
+  modules measured host-clean (bucket net 0, zero regressions) with the
+  whole lane host per the fallback.
+- One consequential test update: `tests/issue-2978-forawait-rejected.test.ts`
+  "standalone carrier-off" case — post-flip that lane is carrier-ON, so the
+  rejected-promise for-await now delivers the ORIGINAL rejection reason
+  (spec-correct, identical to its wasi case) instead of the bounded-cap
+  TypeError. Expectation updated with provenance comment.
+- Production-behavior probe (no env): plain async module compiles host-free
+  (no `Promise_resolve` import); async-gen module keeps the host lane
+  (`Promise_reject` import present) — exactly the measured arms.
+- Local validation: issue-2978/2979/2980-carrier-fallback suites green;
+  tsc/prettier clean. NB `tests/issue-2865-standalone-async-await-unwrap.test.ts`
+  has 2 WASI-lane failures locally that reproduce IDENTICALLY on unmodified
+  main (pre-existing local-env artifact; wasi arm untouched by this flip;
+  green in CI on main) — not a flip effect.
+- The authoritative gate is the `merge_group` standalone lane (48k) — this
+  PR is scoreboard-affecting (~+20 construct-sampled; population estimate
+  per the tradeoff doc §4). `auto-park` catches any residual.
+
+**#2980 is DONE with this flip.** The #2867/#2895/#2906 async program now
+scores on the standalone lane. Filed-forward known-negatives (inside
+net-positive buckets): thenable-assimilation edges (#3125 class, 6 sampled
+files), `evaluation-body.js`, the 3 class-async static-async illegal-cast
+shapes. Follow-ups belong to their own issues.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -3788,25 +3788,29 @@ export function emitStandalonePromiseThen(
  * #1326 — Check whether host-free Promise codegen (native `$Promise` carrier:
  * construction, async-fn return wrap, `await` unwrap) is active.
  *
- * **Gated on `ctx.wasi` only.** AG0 (#2865) briefly widened this to
- * `ctx.standalone` too, but ground-truth measurement (#2895 reconcile, against
- * the #2384 frame-core base) showed that widening is a NET REGRESSION on
- * standalone: the `flags:[async]` test262 harness uses synchronous-settlement
- * (`asyncTest(fn)` calls `fn()` then `$DONE()` with no microtask drain), so an
- * async fn that returns a native `$Promise` is observed as an undrained struct,
- * not a value → 32/202 async tests that PASS on baseline regress to FAIL, with
- * **no** offsetting await-unwrap gain (the await/async-function area itself went
- * 71→42 pass under the broad gate). The host-free standalone await win is
- * coupled to a real async drive layer (result `$Promise` + microtask drain that
- * the harness can settle), which is **PATH B (#2895)** — not bankable in a
- * bounded gate flip. So standalone reverts to baseline here (net-0, no
- * regression); WASI keeps the genuine native-`$Promise` behaviour + the await
- * NaN-fix. PATH B re-widens this (and {@link isStandaloneThenChainNativeActive})
- * once the drive layer makes native async results observable.
+ * **THE #2980 CARRIER WIDEN IS FLIPPED (2026-07-10, stakeholder-approved):**
+ * `--target standalone` now takes the native `$Promise` lane too, except for
+ * modules containing an async generator ({@link widenAsyncGenFallback} keeps
+ * their whole promise pipeline host-consistent). This is exactly the semantics
+ * the ratified rule-1 decision measure validated (plan/issues/2980):
+ * 07-09 full A/B net **+18** with the fallback (async-generator bucket
+ * −4→+0), 07-10 six-bucket confirmation net **+20** with NO bucket ≤ −2
+ * (class-async supplement included). The pairing constraint (#2978/#2934-3b,
+ * PR #2833) landed 2026-07-10 before this flip, per the tradeoff doc
+ * (plan/log/2980-carrier-widen-tradeoff.md §6.4).
+ *
+ * History (why this was wasi-only for so long): AG0 (#2865) widened
+ * prematurely and measured **−31** — the `flags:[async]` harness settles
+ * synchronously, so a native `$Promise` result was an undrained struct. The
+ * PATH-B drive layers (#2895/#2906 slices, #2483 host-drive, #3035 `.then`
+ * receiver bridge, #2979 value carrier) landed since; the 07-02 measure was
+ * still −51, and the residual classes were then fixed one by one (#3035,
+ * #2906 3d-i/ii/iii, the async-gen fallback) until the sign flipped. Both
+ * carrier gates flip TOGETHER (the AG0-safe coupling — no per-construct
+ * gating; see #2980 rule 2).
  */
 export function isStandalonePromiseActive(ctx: CodegenContext): boolean {
-  if (ASYNC_CARRIER_WIDEN_MEASURE) return ctx.wasi === true || (ctx.standalone === true && !widenAsyncGenFallback(ctx));
-  return ctx.wasi === true;
+  return ctx.wasi === true || (ctx.standalone === true && !widenAsyncGenFallback(ctx));
 }
 
 /**
@@ -3825,52 +3829,33 @@ function widenAsyncGenFallback(ctx: CodegenContext): boolean {
   return ctx.moduleHasAsyncGen === true;
 }
 
-/**
- * (#2980) MEASUREMENT INSTRUMENT for the slice-1d carrier widen decision — NOT
- * the widen itself. When the `JS2WASM_ASYNC_CARRIER_WIDEN` env var is `"1"`,
- * both carrier gates ({@link isStandalonePromiseActive} +
- * {@link isStandaloneThenChainNativeActive}) include `--target standalone`, so
- * the full-corpus A/B (gate on vs off) can be measured WITHOUT committing the
- * flip. Unset (the default, including all of CI), both gates are exactly
- * `ctx.wasi === true` — behaviour and output are unchanged. The real widen
- * lands as its own tiny PR ONLY on a measured net-positive corpus result
- * (#2867 slice-1d protocol; flipping both together is the AG0-safe coupling).
- */
-const ASYNC_CARRIER_WIDEN_MEASURE = typeof process !== "undefined" && process.env?.JS2WASM_ASYNC_CARRIER_WIDEN === "1";
+// (#2980) The `JS2WASM_ASYNC_CARRIER_WIDEN` measurement instrument is RETIRED
+// with the flip (2026-07-10): the measured on-arm IS now the production
+// behaviour of both carrier gates, so the env toggle would be a no-op. The
+// recorded A/B protocol + harness stay in `scripts/measure/` and
+// plan/issues/2980 for any future re-measure need.
 
 /**
- * (#2895) Gate for the **native `.then` / `.catch` chaining** lowering
- * (`emitStandalonePromiseThen`) specifically — narrower than
- * {@link isStandalonePromiseActive}.
+ * (#2895/#2980) Gate for the **native `.then` / `.catch` chaining** lowering
+ * (`emitStandalonePromiseThen`) — flipped WITH {@link isStandalonePromiseActive}
+ * (the AG0-safe coupling; #2980 rule 2: one gate, one flip, one measure).
  *
- * That lowering has a stack-imbalance at corpus scale under `--target
- * standalone` in async-method-in-class contexts
- * (`Promise.all(...).then(arrow).then($DONE, $DONE)` → "not enough arguments on
- * the stack for call"; a −601 standalone regression caught only in the
- * `merge_group`). It is superseded by the PATH B async result/drive rewrite
- * (#2895), so rather than deepen it now we scope it back to **WASI only** (where
- * it was validated) and let `--target standalone` fall through to the host-import
- * `.then` path — exactly the pre-AG0 standalone behaviour (fails to instantiate
- * cleanly, no invalid-Wasm), so no regression. The broad
- * {@link isStandalonePromiseActive} still keeps the host-free
- * `Promise.resolve`/`reject` construction + `await`-unwrap wins for standalone.
- * PATH B re-enables native chaining for standalone by widening this predicate.
+ * Widen safety, measured: the historical −601 stack-imbalance hazard of this
+ * lowering on `--target standalone` is retired by #3035's runtime `ref.test`
+ * receiver bridge (non-native receivers keep the exact host `.then` path) —
+ * the promise-then-all bucket measured **+12** under the widen (07-10
+ * confirmation A/B), with zero invalid-Wasm anywhere in the 322-file sample.
+ *
+ * Async-generator modules take {@link widenAsyncGenFallback} to the HOST lane
+ * entirely — including the former #2865 receiver-directed arm
+ * (`getDrainFuncIdxForWasiStart(ctx) !== null`), which this widened predicate
+ * subsumes for every other standalone module (the widen is a superset of
+ * "driven machinery registered"). That exact semantics — bridge off for
+ * async-gen modules, on for everything else — is what the rule-1 measure
+ * validated (async-generator bucket net 0, zero regressions).
  */
 export function isStandaloneThenChainNativeActive(ctx: CodegenContext): boolean {
-  if (ASYNC_CARRIER_WIDEN_MEASURE) return ctx.wasi === true || (ctx.standalone === true && !widenAsyncGenFallback(ctx));
-  if (ctx.wasi === true) return true;
-  // (#2865) `--target standalone` with the async-GENERATOR drive active: the
-  // driven producers mint native `$Promise`s (`__async_gen_next_*` results, the
-  // consumer's result promise), which the host `.then` path cannot chain (an
-  // opaque struct to the host). Once THIS module has registered the native
-  // scheduler (only driven machinery does), `.then`/`.catch` compile the #3035
-  // runtime `ref.test` receiver bridge: a native `$Promise` receiver chains
-  // natively, anything else keeps the exact host path. Modules with no driven
-  // machinery are byte-identical (the predicate stays false — the scheduler is
-  // never registered for them). This is receiver-directed dispatch, NOT the
-  // #2980 carrier widen: `Promise.resolve`/statics/await lowering are untouched
-  // (`isStandalonePromiseActive` remains wasi-only pending the measured flip).
-  return ctx.standalone === true && getDrainFuncIdxForWasiStart(ctx) !== null;
+  return ctx.wasi === true || (ctx.standalone === true && !widenAsyncGenFallback(ctx));
 }
 
 /**

--- a/tests/issue-2978-forawait-rejected.test.ts
+++ b/tests/issue-2978-forawait-rejected.test.ts
@@ -75,7 +75,16 @@ describe("#2978/#2934-3b: for-await over rejected-promise sync iterator", () => 
     expect(ex.readReasonOk()).toBe(1); // e === "reject"
   });
 
-  it("standalone carrier-off (scored lane today): bounded loud abort, close exactly once", async () => {
+  it("standalone (native carrier since the #2980 flip): rejection lands in catch, close exactly once", async () => {
+    // Pre-flip this lane was carrier-OFF: the rejected promise was an opaque
+    // host value, the bounded step cap aborted with its own TypeError, and
+    // this test asserted `readReasonOk() === 0`. The 2026-07-10 #2980 carrier
+    // widen puts standalone on the native `$Promise` lane (this module has no
+    // async generator, so `widenAsyncGenFallback` does not fire), which
+    // upgrades the shape to the FULL spec semantics — identical to the wasi
+    // case above: the ORIGINAL rejection reason reaches the user catch and
+    // IteratorClose runs exactly once. Still bounded wall-clock (pre-#2978
+    // this OOM'd at ~3 GB / ~14 s).
     const r = await compile(REPRO, { fileName: "t.ts", target: "standalone" });
     expect(r.success).toBe(true);
     const t0 = Date.now();
@@ -85,12 +94,9 @@ describe("#2978/#2934-3b: for-await over rejected-promise sync iterator", () => 
     );
     const elapsed = Date.now() - t0;
     const ex = instance.exports as unknown as Ex;
-    // The step cap fires: abrupt completion observed by the user catch, and
-    // IteratorClose ran exactly once. Bounded wall-clock (well under the 15 s
-    // runner timeout; pre-fix this OOM'd at ~3 GB / ~14 s).
     expect(ex.readCaught()).toBe(1);
     expect(ex.readReturnCount()).toBe(1);
-    expect(ex.readReasonOk()).toBe(0); // TypeError from the cap, not "reject" — host promise is opaque here
+    expect(ex.readReasonOk()).toBe(1); // e === "reject" — the real reason, not the cap TypeError
     expect(elapsed).toBeLessThan(10_000);
   });
 


### PR DESCRIPTION
## Summary

**The two-predicate flip prescribed by the #2980 rule-1 decision protocol — stakeholder-approved 2026-07-10.** `isStandalonePromiseActive` + `isStandaloneThenChainNativeActive` both become:

```ts
ctx.wasi === true || (ctx.standalone === true && !widenAsyncGenFallback(ctx))
```

— verbatim the **measured on-arm semantics**: `--target standalone` takes the native `$Promise` lane (construction, async-fn return wrap, await unwrap, native `.then`/`.catch` chaining via the #3035 receiver bridge), except modules containing an async generator, which keep the whole promise pipeline host-consistent (the `b66d7e2ceb` conservative fallback).

## Evidence chain (rule 1, all recorded in `plan/issues/2980-...md`)

| Gate | Status |
|---|---|
| Measured positive net, no bucket ≤ −2 | 07-09 A/B **+18** (async-gen −4→0 via fallback); 07-10 six-bucket confirmation **+20** at main@d7a1feaa1c, worst bucket 0 (class-async supplement included) |
| #2978/#2934-3b pairing (tradeoff doc §6.4) | PR #2833 merged 2026-07-10 15:16 |
| Stakeholder sign-off (scoreboard-affecting) | granted 2026-07-10 |

## What rides along (nothing else)

- `JS2WASM_ASYNC_CARRIER_WIDEN` measurement instrument retired (on-arm == production now; harness remains in `scripts/measure/`).
- The #2865 receiver-directed then-chain arm is **subsumed** (the widened arm is a superset for every non-async-gen standalone module; async-gen modules measured host-clean, bucket net 0, zero regressions).
- One consequential test update: `tests/issue-2978-forawait-rejected.test.ts` standalone case — the lane is carrier-ON now, so the rejected-promise for-await delivers the **original rejection reason** (spec-correct, identical to its wasi case) instead of the bounded-cap TypeError.
- The flip record appended to the issue; `status: done`.

## Validation

- Production-behavior probe (no env): plain async module compiles **host-free** (no `Promise_resolve` import); async-gen module keeps the host lane — exactly the measured arms.
- `issue-2978` / `issue-2979` / `issue-2980-carrier-fallback` suites green; tsc + prettier clean.
- Known pre-existing: 2 local WASI failures in `issue-2865-standalone-async-await-unwrap` reproduce identically on unmodified main (local-env artifact; the wasi arm is untouched by this flip).
- **The authoritative gate is the `merge_group` standalone lane (48k)** — scoreboard-affecting (~+20 construct-sampled; population upside per `plan/log/2980-carrier-widen-tradeoff.md` §4). `auto-park` catches any residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8