### PR TITLE
fix(#3036): regression-test late allSettled().then microtask closure-bridge no-crash

### DIFF
--- a/plan/issues/3036-standalone-allsettled-then-callback-late-microtask-nullderef.md
+++ b/plan/issues/3036-standalone-allsettled-then-callback-late-microtask-nullderef.md
@@ -1,8 +1,10 @@
 ---
 id: 3036
 title: "Standalone: Promise.allSettled(...).then(cb) callback null-derefs on a late real-Promise microtask (pre-existing, discovered while landing #3035)"
-status: ready
+status: done
+assignee: ttraenkler/fable-rescue
 created: 2026-07-05
+completed: 2026-07-10
 priority: low
 horizon: s
 feasibility: medium
@@ -113,3 +115,56 @@ load-bearing spot).
       per-call-instance state that outlives the synchronous call") that
       prevents this class of crash.
 - [ ] Regression test using the minimal repro above (no widen needed).
+
+## Resolution (2026-07-10, fable-rescue)
+
+**Already resolved on current `origin/main` (32bae1f48f) — verified, not
+re-fixed.** The closure-bridge null-deref described above no longer
+reproduces via ANY of the routes in this issue:
+
+1. the minimal single-instance repro (`Promise.allSettled([]).then(() => { out = 1; })`,
+   `--target standalone`) — `run()` returns and the late microtask sets
+   `out === 1` cleanly, no crash;
+2. three back-to-back instances in one process, each calling `setExports`
+   (so the module-level `callbackState.getExports()` points at the LAST
+   instance) — the earlier instances' late `.then` microtasks still fire
+   cleanly and set their own `out === 1`, no stale-closure null-deref;
+3. the two named test262 files run back-to-back through
+   `runTest262File(..., "standalone")`
+   (`built-ins/Promise/allSettled/resolved-immed.js`,
+   `.../reject-ignored-deferred.js`) — both record a (failing) verdict, and
+   NO `uncaughtException`/`unhandledRejection` fires in the late-microtask
+   window.
+
+**Attribution:** the crash was live when #3035 landed (2026-07-05) — that
+PR's test (`tests/issue-3035.test.ts`) had to install
+`process.on("uncaughtException", () => {})` to swallow exactly this crash so
+it would not look like a regression. It was fixed incidentally by the
+post-#3035 async-carrier / closure-lifetime hardening line (#2978/#2980/#3035
+area) that landed afterward; there is no single attributable commit and a
+bisect was not warranted for a low-priority, already-degraded path.
+
+**What this PR does:** adds `tests/issue-3036-late-microtask-closure.test.ts`,
+a regression test that drives the exact original trigger (including the
+multi-instance `setExports`-swap that made the bridge resolve the WRONG
+instance's exports) and asserts the late callback fires with NO closure-bridge
+crash. It deliberately does NOT swallow `uncaughtException`, so a reintroduced
+null-deref surfaces as a captured error and fails the assertion.
+
+**Follow-up (not done here, out of lane):** the now-unnecessary
+`process.on("uncaughtException", () => {})` / `unhandledRejection` swallow in
+`tests/issue-3035.test.ts` can be removed now that this crash is gone — left
+in place to avoid touching another issue's test file.
+
+### Acceptance criteria
+
+- [x] Root-cause understood: the lazy closure bridge
+      (`wasmClosureBridge`, `src/runtime.ts`) resolves `__call_fn_*` against
+      the module-level `callbackState` exports at call time, so a late,
+      detached real-Promise microtask from an earlier instance dispatched
+      against a later instance's exports with a stale closure ref. No longer
+      reachable on current main.
+- [x] Fix / invariant in place: callbacks handed to the deferred combinators
+      now survive a late, detached microtask (verified across all three
+      original routes).
+- [x] Regression test added (`tests/issue-3036-late-microtask-closure.test.ts`).

--- a/tests/issue-3036-late-microtask-closure.test.ts
+++ b/tests/issue-3036-late-microtask-closure.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3036 — a callback handed to a REAL host Promise (via the DEFERRED
+ * combinators `Promise.allSettled`/`Promise.any`, which have no native
+ * lowering in `src/codegen/promise-combinators.ts`) fires on a genuine Node
+ * microtask AFTER the synchronous `run()` window has already returned. At the
+ * time #3036 was filed (2026-07-05, base 7f90320ea) that late invocation
+ * null-dereferenced the WASM closure-bridge trampoline
+ * (`wasmClosureBridge`, src/runtime.ts): the bridge resolves exports lazily
+ * via a module-level `callbackState.getExports()`, so once a SECOND instance
+ * had called `setExports`, the first instance's late microtask invoked the
+ * wrong instance's `__call_fn_*` with a stale closure ref →
+ * `RuntimeError: dereferencing a null pointer` inside `__closure_*`.
+ *
+ * The #3035 test (`tests/issue-3035.test.ts`) had to install
+ * `process.on("uncaughtException", () => {})` to SWALLOW exactly this crash so
+ * it would not look like a regression that PR introduced.
+ *
+ * This crash no longer reproduces on current `origin/main` — it was resolved
+ * incidentally by the post-#3035 async-carrier / closure-lifetime hardening
+ * line (#2978/#2980/#3035). This regression test locks the fix in: it drives
+ * the exact original trigger (a late `Promise.allSettled(...).then` microtask,
+ * including the multi-instance export-swap that made the bridge resolve the
+ * WRONG instance's exports) and asserts the callback fires cleanly with NO
+ * closure-bridge crash. It deliberately does NOT swallow uncaughtException —
+ * a reintroduced null-deref surfaces as a captured error and fails the assert.
+ *
+ * No `JS2WASM_ASYNC_CARRIER_WIDEN` is needed (issue: "no widen needed").
+ */
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+const SRC = `
+  let out = 0;
+  export function run(): void { Promise.allSettled([]).then(() => { out = 1; }); }
+  export function getOut(): number { return out; }
+`;
+
+async function makeInstance(): Promise<{ run: () => void; getOut: () => number }> {
+  const r = await compile(SRC, { fileName: "t.ts", target: "standalone" });
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  // Point the module-level callback bridge at THIS instance's exports — the
+  // very act that, before the fix, let a prior instance's late microtask
+  // dispatch against the wrong instance's `__call_fn_*`.
+  (imports as { setExports?: (e: unknown) => void }).setExports?.(instance.exports);
+  return instance.exports as unknown as { run: () => void; getOut: () => number };
+}
+
+/**
+ * Run `body`, then drain microtasks + a real macrotask window, capturing any
+ * late `uncaughtException` / `unhandledRejection` that fires OUTSIDE the
+ * synchronous call — that is precisely where the #3036 crash landed.
+ */
+async function runCapturingLateErrors(body: () => Promise<void> | void): Promise<Error[]> {
+  const captured: Error[] = [];
+  const onUncaught = (e: Error) => captured.push(e);
+  const onRejected = (e: unknown) => captured.push(e instanceof Error ? e : new Error(String(e)));
+  process.on("uncaughtException", onUncaught);
+  process.on("unhandledRejection", onRejected);
+  try {
+    await body();
+    // Late real-Promise microtask fires here (after the sync window). Give it
+    // both a microtask flush and a generous macrotask window.
+    await new Promise((res) => setTimeout(res, 200));
+  } finally {
+    process.off("uncaughtException", onUncaught);
+    process.off("unhandledRejection", onRejected);
+  }
+  return captured;
+}
+
+describe("#3036 — late allSettled().then microtask must not null-deref the closure bridge", () => {
+  it("single instance: the late callback fires cleanly and sets the module global", async () => {
+    let inst!: { run: () => void; getOut: () => number };
+    const errors = await runCapturingLateErrors(async () => {
+      inst = await makeInstance();
+      inst.run();
+    });
+    expect(errors, `late microtask crashed the closure bridge: ${errors[0]?.message}`).toHaveLength(0);
+    // The callback actually ran (out flipped 0 -> 1), i.e. it was invoked and
+    // did not silently no-op.
+    expect(inst.getOut()).toBe(1);
+  });
+
+  it("back-to-back instances: an earlier instance's late microtask survives a later instance's setExports swap", async () => {
+    const instances: Array<{ run: () => void; getOut: () => number }> = [];
+    const errors = await runCapturingLateErrors(async () => {
+      // Create + run three instances in one process. Each `makeInstance`
+      // re-points the global callback bridge at the newest instance, so the
+      // earlier instances' still-pending `.then` microtasks would, under the
+      // original bug, dispatch against the LAST instance's exports with a
+      // stale closure ref.
+      for (let i = 0; i < 3; i++) {
+        const inst = await makeInstance();
+        inst.run();
+        instances.push(inst);
+      }
+    });
+    expect(errors, `a detached late microtask crashed the closure bridge: ${errors[0]?.message}`).toHaveLength(0);
+    // Every instance's own callback ran against its own module global.
+    for (const inst of instances) expect(inst.getOut()).toBe(1);
+  });
+});


### PR DESCRIPTION
## #3036 — late `Promise.allSettled(...).then` microtask must not null-deref the closure bridge

**Verify-first outcome: already resolved on current `origin/main`; this PR locks it in with a regression test.**

The closure-bridge null-deref described in #3036 (a callback handed to the deferred combinator `Promise.allSettled`/`Promise.any` fires on a late real-Promise microtask AFTER the synchronous `run()` window, and the lazy `wasmClosureBridge` trampoline null-derefs invoking it) **no longer reproduces on current main (32bae1f48f)** via any of the three routes named in the issue:

1. minimal single-instance repro (`Promise.allSettled([]).then(() => { out = 1; })`, `--target standalone`) — late callback sets `out === 1` cleanly, no crash;
2. three back-to-back instances in one process each calling `setExports` (module-level `callbackState.getExports()` points at the LAST instance) — earlier instances' late microtasks still fire cleanly, no stale-closure null-deref;
3. the two named test262 files back-to-back via `runTest262File(..., "standalone")` — both record a (failing) verdict, no `uncaughtException`/`unhandledRejection` in the late-microtask window.

**Attribution:** the crash was live when #3035 landed (2026-07-05) — that PR's test had to `process.on("uncaughtException", () => {})` to swallow exactly this crash. Fixed incidentally by the post-#3035 async-carrier / closure-lifetime hardening; no single attributable commit, and a bisect was not warranted for a low-priority already-degraded path.

## Changes
- **`tests/issue-3036-late-microtask-closure.test.ts`** — regression test driving the exact original trigger (including the multi-instance `setExports`-swap that made the bridge resolve the WRONG instance's exports). Asserts the late callback fires with NO closure-bridge crash; deliberately does NOT swallow `uncaughtException`, so a reintroduced null-deref fails the assert. Both cases green locally.
- **`plan/issues/3036-*.md`** — `status: done`, resolution note, acceptance criteria checked.

## Follow-up (out of lane, noted not done)
The now-unnecessary `uncaughtException`/`unhandledRejection` swallow in `tests/issue-3035.test.ts` can be removed now that this crash is gone — left untouched to avoid editing another issue's test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)