### PR TITLE
fix(#3123): class-extends-fnctor instances resolve the live F.prototype chain — clean re-derivation off main

### DIFF
--- a/plan/issues/3123-class-extends-shimmed-fnctor-prototype-chain.md
+++ b/plan/issues/3123-class-extends-shimmed-fnctor-prototype-chain.md
@@ -1,0 +1,183 @@
+---
+id: 3123
+title: "class C extends F (plain fnctor with runtime-assigned .prototype): instance member lookup does not reach F.prototype — Iterator-helper exhaustion/return-forwarding cluster"
+status: done
+completed: 2026-07-11
+assignee: ttraenkler/fable-reconcile
+sprint: current
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: max
+model: fable
+created: 2026-07-09
+task_type: bugfix
+area: codegen, runtime
+language_feature: class-extends, iterator-helpers
+goal: spec-completeness
+test262_category: built-ins/Iterator/prototype
+related: [3049, 3124, 3129]
+loc-budget-allow:
+  - src/codegen/index.ts
+  - src/runtime.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/class-bodies.ts
+  - src/codegen/class-member-keys.ts
+  - src/codegen/declarations.ts
+  - src/codegen/context/types.ts
+  - src/codegen/statements/variables.ts
+---
+
+# #3123 — `class C extends F` over a runtime-assigned fnctor prototype
+
+## Source
+
+Split out of #3049 (fable-proto, 2026-07-09). After main's #3049 landed via
+PR #2860 (spec chain depth + iterator-record shim, +14), a large
+`built-ins/Iterator/prototype/*` residual stayed red with a DIFFERENT root:
+
+```js
+class TestIterator extends Iterator {
+  next() { return { done: false, value: 1 }; }
+  return() { ++returnCount; return {}; }
+}
+let iterator = new TestIterator().drop(0); // "Cannot read properties of null (reading 'drop')"
+```
+
+where `Iterator` is the test262-runner harness shim — a plain top-level
+`function Iterator(){}` whose `.prototype` is ASSIGNED AT RUNTIME (module
+init) to the helper-bearing `%IteratorPrototype%`:
+
+```ts
+function Iterator(this: any): void {}
+(Iterator as any).prototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+```
+
+The compiled `class TestIterator extends Iterator` wires its prototype chain
+statically and never observes the runtime re-assignment of `F.prototype`, so
+inherited helper reads (`.drop`, `.take`, `.filter`, …) resolve nowhere.
+
+## Provenance — re-derivation of the parked stack (PRs #2835/#2839, both closed)
+
+A previous implementation existed as a 2-PR stack that was auto-parked in the
+merge queue with a REAL 99-file merged-baseline regression (bucket signature
+`5c449d888de7d030`). Diagnosis of both merge_group runs (29079931503 for
+#2835, 29063671945 for #2839) established:
+
+- **The regression cluster came entirely from the STACK'S #3049 base**
+  (#2835: net −43 on its own, +65/−99), not from the #3123 delta — #2839
+  (stack + #3123) carried the IDENTICAL 99-file signature while adding +116
+  improvements and no new regressions.
+- The two regression roots in #2835, **deliberately NOT ported here**:
+  1. **Bridge-exit marshaling wired into the generic `__call_fn` /
+     `__cb_<id>` exits** (`_marshalBridgeResult` on every closure-bridge
+     return) — implicated in ~85 dstr `*-ary-init-iter-close` double-close
+     failures (`doneCallCount` 1→2). This port calls `_marshalBridgeResult`
+     ONLY from the new fnctor-subclass member resolution, gated on the
+     `_fnctorInstanceCtor` registration WeakMap.
+  2. **`deferTopLevelInit` applied to the multi-module FIXTURE compile** —
+     each linked module exported `__module_init`, so one binary carried two
+     same-named exports → V8 "Duplicate export name" CompileError (6
+     `language/module-code/*` files). This port gates the defer flag OFF for
+     module-goal compiles at every harness site.
+- Main's independent #3049 (PR #2860) captured only 14 of the stack's 181
+  merged-run improvements; the rest of the cluster (105 files under
+  `built-ins/Iterator/prototype` on the then-current baseline) remained red
+  on main — the prize this re-derivation targets.
+
+## What shipped (clean port off origin/main 12c45a7c)
+
+Five codegen/runtime walls, each empirically re-verified on current main
+before porting (the failure modes had shifted since the stack: main's #3074
+keystones + #2860 changed the substrate):
+
+1. **Layer-1 init keep (`src/codegen/declarations.ts`,
+   `collectDeclarations`)** — top-level DIRECT `F.prototype = …` writes on a
+   top-level function are now KEPT in `__module_init` for host/GC (the old
+   exclusion assumed the standalone-only fnctor-prototype lift consumed them;
+   in host mode they were silently elided, so the harness shim never ran).
+   Receiver unwrapped through parens/`as`-casts (`(Iterator as any).prototype`).
+2. **Host-side instance registration (`class-bodies.ts` +
+   `class-member-keys.ts`)** — `${className}_init` tails a
+   `__register_fnctor_instance(self, F_closure)` call (host lane, classes
+   with a fnctor ancestor only — `fnctorAncestorOfClass`); the runtime records
+   it in the existing #1712 `_fnctorInstanceCtor` WeakMap so
+   `_fnctorProtoLookup` serves inherited reads through F's LIVE prototype.
+   The lookup also gained a `__sget_prototype` struct-field fallback (the
+   #2664 `__set_member_prototype` dispatcher can store the write in the
+   closure struct's typed field slot, invisible to the sidecar read).
+3. **Compiled methods/getters host-visible on instances (`index.ts`
+   `emitClassMemberKindExports` + `runtime.ts`
+   `_resolveClassMemberOnInstance`)** — per-module `__member_kind_<k>`
+   (0 none / 1 method / 2 getter) + `__call_get_<k>` dispatch exports, gated
+   on `moduleHasFnctorSubclass` so all other modules stay byte-identical.
+   `_safeGet` / `_resolveHostField` consult them (arm gated on registration);
+   getter reads run per-[[Get]] (the exhaustion tests' `get next()` mints a
+   fresh generator per read — §27.1.4). Results marshal through a PRIVATE
+   `_marshalBridgeResult` port (see provenance note 1). The
+   `__gen_next/return/throw` dispatchers gained a registration-gated
+   `_safeGet` miss-arm.
+4. **Dynamic dispatch on fnctor-subclass method MISSES + widened bindings
+   (`calls.ts`, `index.ts` pre-hoist, `statements/variables.ts`)** — a
+   method MISS on a fnctor-subclass receiver routes through
+   `emitFnctorSubclassDynamicMethodCall` (`__extern_method_call` mirror of
+   the #799 WI3 arm) instead of the graceful-null tail; the any-receiver
+   class-inference scan SKIPS fnctor subclasses; `let` bindings typed as a
+   fnctor subclass with a foreign-typed reassignment
+   (`iterator = iterator.drop(0)`) pre-hoist-widen to externref
+   (`fnctorWidenedLocals`) and dispatch dynamically. Never-reassigned
+   bindings keep static dispatch (guard test locked).
+5. **#2818 carve-out flip (host defers derived capturers,
+   `declarations.ts`)** — an EAGER capturing derived class nested in control
+   flow (the try-block every test262 body sits in) compiled before the
+   block-`let` exists, so `++returnCount` in a method lowered to a silent
+   no-op. The standalone-protecting carve-out is now gated
+   `ctx.standalone || ctx.wasi`; host defers derived capturers like base-less
+   ones. (Also from the stack; unit-guarded by issue-2818/3128 suites, 62/62
+   green.)
+
+Plus the harness C1 model (from the stack, with the dup-export fix):
+host-lane test262 compiles use `deferTopLevelInit` (export `__module_init`,
+no `(start)` section) and the exec paths call it right after `setExports`,
+so top-level code like the shim assignment runs against a fully-wired
+runtime (`__sget_*` / `__vec_*`). **Module-goal compiles are excluded** at
+every site (see provenance note 2).
+
+## Measured (in-process runTest262File, my tree vs pristine-main control)
+
+- **8-file target cluster: 6/8 flip to pass** (`{map,filter,drop}/
+  exhaustion-does-not-call-return`, `{drop,take,filter}/return-is-forwarded`).
+- **Natural home cluster (built-ins/Iterator/prototype +
+  built-ins/Object/create, 693 files): base 447 → fixed 490, +66 fail→pass /
+  −1 real pass→fail** (22 further chunked-run "downs" all pass in
+  fresh-process isolation — the known #1957 realm-contamination artifact of
+  the local in-process runner; CI's realm canary recycles workers on exactly
+  this class).
+- **Stack-regression corpus (the 99 non-CT files the parked stack broke):
+  93/99 pass; all 6 fails are `language/module-code/*` local-runner
+  artifacts reproduced byte-identically on pristine main** (module-goal
+  compiles are defer-exempt, so their binaries are unchanged by this PR).
+- Unit guards: issue-{3049,2818,3128,2628,2015,3123} — 62/62;
+  issue-1712 family green except `capture-closure-dispatch` #3, reproduced
+  UNCHANGED on pristine main (local Node-25 environment, documented by the
+  stack too). tsc clean.
+
+## Known residual (documented, not chased here)
+
+- **flatMap inner-iterable flattening (3 files)**:
+  `flatMap/exhaustion-does-not-call-return`,
+  `flatMap/iterable-to-iterator-fallback`, and
+  `flatMap/get-return-method-throws` (the −1 above — it "passed" on main
+  only vacuously, via the unresolved-helper null path; with the helpers now
+  real, the honest wall shows). Root: the native helper's
+  GetIteratorFlattenable reads `Symbol.iterator`/`next` off the RAW wasm
+  struct the compiled mapper returns. The stack fixed this with the generic
+  bridge-exit marshaling — the exact change that double-closed ~85 dstr
+  files. Needs a NARROW mapper-result marshal (follow-up), not the generic
+  wiring.
+- The kind-1 method bridge dispatches on the captured instance and ignores a
+  re-bound `this` (`const f = it.next; f.call(other)`); parameterized
+  methods report kind 0 and fall back (0-arg dispatchers only).
+- #3124 (inherited reads over `Object.create(<struct>)` chains) remains a
+  separate, measured-zero-yield substrate issue — see its notes on the
+  closed PR #2842's branch.

--- a/scripts/compiler-fork-worker.mjs
+++ b/scripts/compiler-fork-worker.mjs
@@ -38,6 +38,14 @@ function createFreshCompiler() {
       sourceMapUrl: "test.wasm.map",
       emitWat: false,
       skipSemanticDiagnostics: true,
+      // (#3049 C1) Defer top-level init in the host test262 lane: export
+      // `__module_init` instead of wiring the wasm `(start)` section, so
+      // top-level code runs AFTER `setExports` has wired the runtime
+      // (`__sget_*` / `__vec_*` exports). The executor
+      // (scripts/wasm-exec-worker.mjs) calls the exported `__module_init()`
+      // right after `setExports` — the #2796 diff-test model. This fork
+      // worker is host-lane only (it never receives a `target`).
+      deferTopLevelInit: true,
     });
   } catch (e) {
     incrementalCompiler = null;
@@ -66,6 +74,9 @@ process.on("message", async (msg) => {
             emitWat: false,
             skipSemanticDiagnostics: true,
             inferModuleStrictArguments,
+            // (#3049 C1) See createFreshCompiler — host lane defers top-level
+            // init; wasm-exec-worker calls __module_init() after setExports.
+            deferTopLevelInit: true,
           });
       const compileMs = performance.now() - start;
 

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -849,8 +849,21 @@ async function doCompile(source, sourceMapUrl, target, inferModuleStrictArgument
     throw makeWorkerRecycleError(`worker built-ins poisoned before compile: ${preCleanup.reason}`);
   }
   const compileFn = incrementalCompiler ? incrementalCompiler.compile : compile;
+  // (#3049 C1 / #3123) Host lane (no target) defers top-level init:
+  // `__module_init` is exported instead of wired to the wasm `(start)`
+  // section, and the exec path below calls it right after `setExports` so
+  // top-level code runs against a fully-wired runtime. Aligned with
+  // compiler-fork-worker.mjs + tests/test262-runner.ts (#1251 both-paths
+  // rule). Standalone/wasi/linear targets keep their own `_start` init model.
+  // MODULE-GOAL tests (`inferModuleStrictArguments` is exactly the
+  // module-goal flag) are EXCLUDED: the multi-module FIXTURE link already
+  // synthesizes per-module init plumbing, and the flag added a SECOND
+  // `__module_init` export in one binary — V8's "Duplicate export name"
+  // CompileError, the 6-file `language/module-code/*` regression that parked
+  // the stack PR #2835/#2839.
+  const deferOpt = target || inferModuleStrictArguments ? {} : { deferTopLevelInit: true };
   return incrementalCompiler
-    ? compileFn(source, { sourceMapUrl: sourceMapUrl || "test.wasm.map", target, inferModuleStrictArguments })
+    ? compileFn(source, { sourceMapUrl: sourceMapUrl || "test.wasm.map", target, inferModuleStrictArguments, ...deferOpt })
     : (await compile(source, {
               fileName: "test.ts",
               sourceMap: true,
@@ -859,6 +872,7 @@ async function doCompile(source, sourceMapUrl, target, inferModuleStrictArgument
               skipSemanticDiagnostics: true,
               target,
               inferModuleStrictArguments,
+              ...deferOpt,
             }));
 }
 
@@ -1335,6 +1349,36 @@ process.on("message", async (msg) => {
     // Wire up setExports for callback support
     if (typeof importObj.setExports === "function") {
       importObj.setExports(instance.exports);
+    }
+
+    // (#3049 C1) Deferred top-level init (host lane): run the exported
+    // `__module_init` now that `setExports` has wired the runtime. A throw
+    // here keeps the classification the same code had when it surfaced from
+    // the `(start)` section during instantiate: runtime-negative → pass,
+    // anything else → an honest runtime fail (never malformed-wasm
+    // compile_error). Standalone/wasi modules don't export `__module_init`
+    // (they keep `_start`), so this is a no-op for them.
+    const moduleInit = instance.exports.__module_init;
+    if (typeof moduleInit === "function") {
+      try {
+        moduleInit();
+      } catch (initErr) {
+        const execMs = performance.now() - execStart;
+        if (isRuntimeNegative) {
+          sendResult({ id, status: "pass", compileMs, execMs, runtimeNegativePass: true, ...buildResultMetadata(result, true) });
+          return;
+        }
+        sendResult({
+          id,
+          status: "fail",
+          error: extractWasmExceptionMessage(initErr, instance),
+          isException: true,
+          compileMs,
+          execMs,
+          ...buildResultMetadata(result, true),
+        });
+        return;
+      }
     }
 
     const testFn = instance.exports.test;

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -1358,6 +1358,12 @@ process.on("message", async (msg) => {
     // anything else → an honest runtime fail (never malformed-wasm
     // compile_error). Standalone/wasi modules don't export `__module_init`
     // (they keep `_start`), so this is a no-op for them.
+    // oracle-version-exempt: this arm re-hosts the EXISTING instantiate-throw
+    // classification (runtime-negative → pass, else fail+isException) at the
+    // explicit __module_init call site under deferTopLevelInit (#3123); the
+    // scoring RULE is byte-identical to the pre-defer catch below, so no
+    // existing row is re-scored by policy — row flips come only from the
+    // compiler changes, which the ordinary baseline diff scores normally.
     const moduleInit = instance.exports.__module_init;
     if (typeof moduleInit === "function") {
       try {

--- a/scripts/wasm-exec-worker.mjs
+++ b/scripts/wasm-exec-worker.mjs
@@ -105,6 +105,36 @@ parentPort.on("message", async (msg) => {
       importObj.setExports(instance.exports);
     }
 
+    // (#3049 C1) Deferred top-level init: the fork worker compiles with
+    // `deferTopLevelInit: true`, so the module's top-level code did NOT run
+    // during instantiate — run the exported `__module_init` now that
+    // `setExports` has wired the runtime (`__sget_*` / `__vec_*` exports),
+    // mirroring the #2796 diff-test host lane. Classification mirrors the
+    // pre-defer behavior where the same throw surfaced from the `(start)`
+    // section inside `WebAssembly.instantiate`: a runtime-negative test's
+    // top-level throw is the expected error (pass); any other top-level
+    // throw is an honest runtime exception (fail), NOT a malformed-wasm
+    // compile_error.
+    const moduleInit = instance.exports.__module_init;
+    if (typeof moduleInit === "function") {
+      try {
+        moduleInit();
+      } catch (initErr) {
+        if (isRuntimeNegative) {
+          reply({ ok: true, runtimeNegativePass: true });
+          return;
+        }
+        const info = extractWasmExceptionInfo(initErr, instance);
+        reply({
+          ok: false,
+          error: info.message,
+          isException: true,
+          exceptionPayload: info.stack,
+        });
+        return;
+      }
+    }
+
     const testFn = instance.exports.test;
     if (typeof testFn !== "function") {
       reply({ ok: false, error: "no test export", noTestExport: true });

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -13,7 +13,8 @@ import {
   isPrimitiveWrapperSubclassUnsupported,
 } from "./builtin-tags.js";
 import { isStandalonePromiseActive } from "./async-scheduler.js"; // (#2637 B2) host-only Promise-subclass ctor gate
-import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
+import { classMemberFuncKey, fnctorAncestorOfClass } from "./class-member-keys.js"; // (#1983 / #3123)
+import { emitCachedFuncClosureAccess } from "./closures.js"; // (#3123) fnctor parent closure for instance registration
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 import { absoluteFuncIndex } from "../emit/resolve-layout.js"; // (#1916 S3b) resolve handles for order-stable declaredFuncRefs sort
 import { getOrAssignClassNewTargetId } from "./new-target.js"; // (#2023)
@@ -1974,6 +1975,48 @@ function compileClassBodiesInner(
           fctx.body.push({ op: "ref.null.extern" });
         }
         fctx.body.push({ op: "call", funcIdx: tagIdx });
+      }
+    }
+
+    // (#3123) `class C extends F` where F is a top-level PLAIN FUNCTION
+    // (fnctor): register the instance with the host runtime so member reads
+    // that MISS the compiled surface resolve through F's LIVE `.prototype`
+    // chain (`_fnctorInstanceCtor` → `_fnctorProtoLookup`). The test262
+    // harness `Iterator` shim assigns `F.prototype` at module init; the
+    // Iterator-helper methods the instance inherits live only on that runtime
+    // object. Host lane only — standalone/wasi have no host MOP (the import
+    // would leak). Runs at the tail of the ctor body (the `_init` body for
+    // split classes), so every construction path — `new C()` and `super()`
+    // from a subclass — registers (WeakMap set, idempotent).
+    if (!isExternrefBacked && !(ctx.wasi || ctx.standalone)) {
+      const fnctorParent = fnctorAncestorOfClass(ctx, className);
+      if (fnctorParent !== undefined) {
+        const regIdx = ensureLateImport(
+          ctx,
+          "__register_fnctor_instance",
+          [{ kind: "externref" }, { kind: "externref" }],
+          [],
+        );
+        flushLateImportShifts(ctx, fctx);
+        // Read F's funcIdx AFTER the late-import flush — the import add above
+        // shifts every defined-func index.
+        const fnctorFuncIdx = ctx.funcMap.get(fnctorParent);
+        if (regIdx !== undefined && fnctorFuncIdx !== undefined) {
+          fctx.body.push({ op: "local.get", index: selfLocal });
+          fctx.body.push({ op: "extern.convert_any" } as Instr);
+          // F's canonical cached closure — identity-stable with the receiver
+          // the top-level `F.prototype = …` write resolved to, so the host
+          // lookup reads the SAME sidecar/field slot.
+          const closTy = emitCachedFuncClosureAccess(ctx, fctx, fnctorParent, fnctorFuncIdx);
+          if (closTy !== null) {
+            fctx.body.push({ op: "extern.convert_any" } as Instr);
+            const finalRegIdx = ctx.funcMap.get("__register_fnctor_instance") ?? regIdx;
+            fctx.body.push({ op: "call", funcIdx: finalRegIdx });
+          } else {
+            // Closure signature unresolvable — drop the self externref, skip.
+            fctx.body.push({ op: "drop" });
+          }
+        }
       }
     }
 

--- a/src/codegen/class-member-keys.ts
+++ b/src/codegen/class-member-keys.ts
@@ -70,6 +70,55 @@ export function classMemberFuncKey(ctx: CodegenContext, fullName: string): strin
  * `any`-receiver method reads) resolves the IDENTICAL owner → identical
  * cache global → `c.m === C.prototype.m` holds across both read paths.
  */
+/**
+ * (#3123) Resolve the top-level PLAIN-FUNCTION ("fnctor") ancestor of a class,
+ * if any. `class C extends F` where `F` is a top-level `function F() {}` (the
+ * test262 harness `Iterator` shim shape) inherits through F's LIVE
+ * `.prototype` object — assigned at RUNTIME (module init), invisible to the
+ * static class-method dispatch. Three consumers key off this predicate:
+ *   - the ctor fill (class-bodies.ts) registers each instance with the host
+ *     (`__register_fnctor_instance`) so `_fnctorProtoLookup` walks F's live
+ *     prototype chain for inherited member reads;
+ *   - the method-call ladder (expressions/calls.ts) routes method MISSES on
+ *     such classes through the dynamic `__extern_method_call` host ladder
+ *     instead of the graceful-null tail;
+ *   - the any-receiver class-INFERENCE scan (expressions/calls.ts) skips such
+ *     classes, because an any-typed receiver may hold a HOST object (e.g. an
+ *     Iterator-helper wrapper) that the static tag-dispatch would mis-bind.
+ *
+ * Walks the classParentMap chain: the nearest ancestor that is NOT a compiled
+ * class must be a top-level function name of THIS module to qualify. Builtins
+ * (`Error`, `Object`, …) are not in `topLevelFunctionNames`, so builtin-parent
+ * chains return undefined — unless the user genuinely shadowed the builtin
+ * with a top-level function, in which case fnctor semantics are correct.
+ */
+export function fnctorAncestorOfClass(ctx: CodegenContext, className: string): string | undefined {
+  let cur: string | undefined = className;
+  const seen = new Set<string>();
+  while (cur !== undefined && !seen.has(cur)) {
+    seen.add(cur);
+    const parent: string | undefined = ctx.classParentMap.get(cur);
+    if (parent === undefined) return undefined;
+    if (!ctx.classSet.has(parent)) {
+      return ctx.topLevelFunctionNames.has(parent) && ctx.funcMap.has(parent) ? parent : undefined;
+    }
+    cur = parent;
+  }
+  return undefined;
+}
+
+/**
+ * (#3123) True when ANY class in the module has a fnctor ancestor — the gate
+ * for emitting the member-kind / getter dispatch exports so modules without
+ * the pattern stay byte-identical.
+ */
+export function moduleHasFnctorSubclass(ctx: CodegenContext): boolean {
+  for (const className of ctx.classParentMap.keys()) {
+    if (fnctorAncestorOfClass(ctx, className) !== undefined) return true;
+  }
+  return false;
+}
+
 export function resolveMethodOwnerClass(ctx: CodegenContext, start: string, propName: string): string {
   const startFull = `${start}_${propName}`;
   const startIdx = ctx.funcMap.get(classMemberFuncKey(ctx, startFull));

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -580,6 +580,18 @@ export interface FunctionContext {
    */
   i32CoercedLocals?: Set<string>;
   /**
+   * (#3123) let-bindings declared as a fnctor-subclass class instance
+   * (`class C extends F`, F a top-level plain function) that are REASSIGNED
+   * with a value of another static type — at runtime they can hold a HOST
+   * object (e.g. `iterator = iterator.drop(0)` stores the Iterator-helper
+   * wrapper minted by F's live prototype methods). The pre-hoist allocator
+   * widens their slot to externref (a `(ref $C)` slot would null the host
+   * value through the guarded cast), and the class-method-call ladder
+   * dispatches member calls on them DYNAMICALLY (`__extern_method_call`) so
+   * the runtime value — struct instance or host object — decides.
+   */
+  fnctorWidenedLocals?: Set<string>;
+  /**
    * #1197: Set of let/const locals declared as `number[]` whose element
    * storage can safely lower to `i32` instead of `f64` (every write site is
    * provably i32-shaped, every use is a whitelisted access pattern, no

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -4547,21 +4547,46 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         // write from inside a function already worked; only the top-level
         // collection dropped it. Scoped narrowly:
         //   - DIRECT `F.<name> = …` only (bare-identifier receiver);
-        //     `F.prototype = …` / `F.prototype.m = …` chains stay excluded —
-        //     those are consumed by the compile-time fnctor-prototype lift,
-        //     and re-running them at init would double-apply.
+        //     `F.prototype.m = …` chains stay excluded (non-identifier
+        //     receiver — the generic check below still drops them).
+        //   - (#3049 Layer 1 / #3123) DIRECT `F.prototype = …` is now ALSO
+        //     kept for host/GC. The old exclusion claimed the compile-time
+        //     fnctor-prototype lift consumes it, but
+        //     `tryCompileFnctorPrototypeAssign` opens with
+        //     `if (!ctx.standalone) return undefined` — the lift is
+        //     STANDALONE-ONLY, so in host mode nothing consumed the statement
+        //     and it was silently elided. `F.prototype` reads then fell back
+        //     to the auto-vivified #1712 sidecar object (non-null but
+        //     empty), dropping the assigned prototype object and its whole
+        //     chain. This elision is what kept the test262-runner harness
+        //     shim `Iterator.prototype = getPrototypeOf(getPrototypeOf(
+        //     [][Symbol.iterator]()))` from ever running, so `class C
+        //     extends Iterator` instances could not reach the ES2025
+        //     Iterator-helper prototype (#3123). No double-apply is possible
+        //     in host mode; standalone keeps its own #2660 S2 arm above and
+        //     stays byte-identical.
         //   - Host/GC lanes only: standalone's write-arm for fnctor statics
         //     is separate work (its prototype case has its own #2660 S2 keep
         //     above); standalone codegen stays byte-identical.
-        if (
-          !ctx.standalone &&
-          ts.isPropertyAccessExpression(expr.left) &&
-          ts.isIdentifier(expr.left.expression) &&
-          expr.left.name.text !== "prototype" &&
-          ctx.topLevelFunctionNames.has(expr.left.expression.text)
-        ) {
-          ctx.moduleInitStatements.push(stmt);
-          continue;
+        //   - The receiver is unwrapped through parens / `as`-casts /
+        //     non-null assertions (the harness shim writes
+        //     `(Iterator as any).prototype = …`; the cast must not hide the
+        //     top-level-function receiver — same unwrap
+        //     getAssignmentRootIdentifier applies).
+        if (!ctx.standalone && ts.isPropertyAccessExpression(expr.left)) {
+          let receiver: ts.Expression = expr.left.expression;
+          while (
+            ts.isParenthesizedExpression(receiver) ||
+            ts.isAsExpression(receiver) ||
+            ts.isNonNullExpression(receiver) ||
+            ts.isTypeAssertionExpression(receiver)
+          ) {
+            receiver = receiver.expression;
+          }
+          if (ts.isIdentifier(receiver) && ctx.topLevelFunctionNames.has(receiver.text)) {
+            ctx.moduleInitStatements.push(stmt);
+            continue;
+          }
         }
         const targetName = getAssignmentRootIdentifier(expr.left);
         if (targetName && ctx.moduleGlobals.has(targetName)) {
@@ -4808,23 +4833,29 @@ export function compileDeclarations(
   // that is already global (a false-positive defer only churns codegen order).
   function classDeclCapturesNames(decl: ts.ClassDeclaration, names: ReadonlySet<string>): boolean {
     if (names.size === 0) return false;
-    // (#2818 standalone follow-up) NEVER defer a class that has a base class
-    // (`extends …`). A derived class routes its constructor through a
-    // `super(...)` call; the deferred, block-recompiled path lowers that
-    // super-constructor invocation + any spread/getter in the arguments
-    // *correctly in the WasmGC (host) lane* but produces a **desynced** result
-    // in the standalone lane (the promoted-global read of a captured `let`
-    // resolves to a stale/empty value through the super/spread machinery). The
-    // *eager* path — which is exactly how `origin/main` compiled these — is
-    // correct in the standalone lane, so we keep every derived class eager.
-    // This regressed 6 standalone test262 files (all `class X extends Iterator`
-    // / `extends Parent` capturers: the `Iterator.prototype.{map,flatMap,take,
-    // drop,filter}` `return-is-forwarded*` tests + `super/call-spread-obj-
-    // getter-init`). Base-less capturers (the genuine #2818 target — a plain
-    // `class C { m(){ return s; } }` reading a block-`let`) still defer and are
-    // fixed; they have no super-constructor path and lower identically in both
-    // lanes.
-    if (decl.heritageClauses?.some((h) => h.token === ts.SyntaxKind.ExtendsKeyword)) {
+    // (#2818 standalone follow-up) In the STANDALONE/WASI lane, NEVER defer a
+    // class that has a base class (`extends …`). A derived class routes its
+    // constructor through a `super(...)` call; the deferred, block-recompiled
+    // path lowers that super-constructor invocation + any spread/getter in the
+    // arguments *correctly in the WasmGC (host) lane* but produces a
+    // **desynced** result in the standalone lane (the promoted-global read of
+    // a captured `let` resolves to a stale/empty value through the super/
+    // spread machinery). The *eager* path — which is exactly how `origin/main`
+    // compiled these — is correct in the standalone lane, so standalone keeps
+    // every derived class eager. This had regressed 6 standalone test262 files
+    // (all `class X extends Iterator` / `extends Parent` capturers: the
+    // `Iterator.prototype.{map,flatMap,take,drop,filter}`
+    // `return-is-forwarded*` tests + `super/call-spread-obj-getter-init`).
+    //
+    // (#3123) The HOST lane takes the opposite branch: an EAGER capturing
+    // derived class compiles before the block-`let` initialises, so
+    // `promoteAccessorCapturesToGlobals` never fires and the method body's
+    // capture read/write lowers to a silent no-op (`f64.const NaN; drop` —
+    // verified via WAT on the `class TestIterator extends Iterator {
+    // return() { ++returnCount; } }`-in-`try` shape of the Iterator-helper
+    // `return-is-forwarded` files). The deferred path is documented correct
+    // for host above, so host defers derived capturers like base-less ones.
+    if ((ctx.standalone || ctx.wasi) && decl.heritageClauses?.some((h) => h.token === ts.SyntaxKind.ExtendsKeyword)) {
       return false;
     }
     const wouldPromote = (name: string): boolean => {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -24,7 +24,7 @@ import { emitGlobalThisGopdFold } from "../dyn-read.js"; // (#2984)
 import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
 import { emitCollectionIteratorVec } from "../map-runtime.js"; // (#42) native Set/Map → vec, shared with spread / Array.from
 import { isSetReflectiveCallShape, tryCompileSetReflectiveCall } from "../set-runtime.js"; // (#2604) Set.prototype.METHOD.call brand-check
-import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
+import { classMemberFuncKey, fnctorAncestorOfClass } from "../class-member-keys.js"; // (#1983 / #3123)
 import { ensureNativeIteratorRuntime } from "../iterator-native.js"; // (#2169c) native Array.from drain
 import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "../closed-method-dispatch.js";
 import { emitNativeDateParse } from "../date-parse-native.js"; // (#2164) pure-Wasm Date.parse / new Date(str)
@@ -11019,6 +11019,16 @@ function compileCallExpression(
         const recvPropNames = new Set(recvProps.map((p) => p.name));
         for (const className of ctx.classSet) {
           if (!ctx.funcMap.has(`${className}_${methodName}`)) continue;
+          // (#3123) Never INFER a fnctor-subclass (`class C extends F`, F a
+          // top-level plain function) for an any/unknown-typed receiver: the
+          // runtime value may be a HOST object (e.g. an Iterator-helper
+          // wrapper minted by F.prototype's live methods), and the static
+          // tag-dispatch would run the class method with a null self instead
+          // of forwarding to the host object. The any-receiver ladder below
+          // (__gen_next/__gen_return/__extern_method_call) dispatches on the
+          // runtime value for BOTH host objects and struct instances (the
+          // struct arm resolves via _safeGet → __member_kind_* exports).
+          if (fnctorAncestorOfClass(ctx, className) !== undefined) continue;
           // Quick heuristic: check that the class has at least the same property names
           // as the interface (structural compatibility check)
           const classFields = ctx.structFields.get(className);
@@ -11046,6 +11056,31 @@ function compileCallExpression(
       const methodName = ts.isPrivateIdentifier(propAccess.name)
         ? "__priv_" + propAccess.name.text.slice(1)
         : propAccess.name.text;
+      // (#3123) A WIDENED fnctor-subclass binding (`let iterator = new C();
+      // iterator = iterator.drop(0)`) may hold a HOST object at runtime — the
+      // static tag-dispatch below would guarded-cast it to null and run the
+      // class method/getter with a null self. Dispatch member calls on such
+      // bindings dynamically: the runtime value (struct instance or host
+      // wrapper) decides, via __extern_method_call + the host-side
+      // member-kind resolution.
+      {
+        let recvInner: ts.Expression = propAccess.expression;
+        while (
+          ts.isParenthesizedExpression(recvInner) ||
+          ts.isAsExpression(recvInner) ||
+          ts.isNonNullExpression(recvInner)
+        ) {
+          recvInner = recvInner.expression;
+        }
+        if (
+          ts.isIdentifier(recvInner) &&
+          fctx.fnctorWidenedLocals?.has(recvInner.text) &&
+          fnctorAncestorOfClass(ctx, receiverClassName) !== undefined
+        ) {
+          const dynResult = emitFnctorSubclassDynamicMethodCall(ctx, fctx, expr, propAccess, methodName);
+          if (dynResult !== undefined) return dynResult;
+        }
+      }
       let fullName = `${receiverClassName}_${methodName}`;
       let funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName)); // (#1983)
       // Walk inheritance chain to find the method in a parent class
@@ -11158,6 +11193,18 @@ function compileCallExpression(
           methodName,
         );
         if (objProtoResult !== undefined) return objProtoResult;
+      }
+      // (#3123) Method MISS on a fnctor-subclass (`class C extends F`, F a
+      // top-level plain function): the method may live on F's LIVE
+      // `.prototype` — assigned at RUNTIME (module init; the test262 harness
+      // `Iterator` shim installs the ES2025 Iterator-helper prototype there),
+      // which no static dispatch can see. Route through the generic
+      // `__extern_method_call` host ladder (the ctor registered the instance
+      // in `_fnctorInstanceCtor`, so the host resolves the member through the
+      // live prototype chain) instead of falling to the graceful-null tail.
+      if (funcIdx === undefined && fnctorAncestorOfClass(ctx, receiverClassName) !== undefined) {
+        const dynResult = emitFnctorSubclassDynamicMethodCall(ctx, fctx, expr, propAccess, methodName);
+        if (dynResult !== undefined) return dynResult;
       }
       if (funcIdx !== undefined) {
         const isStaticMethod = ctx.staticMethodSet.has(fullName);
@@ -16818,6 +16865,78 @@ function compileCallExpression(
     fctx.body.push({ op: "ref.null.extern" });
     return { kind: "externref" };
   }
+}
+
+/**
+ * (#3123) Generic dynamic method dispatch for a method MISS on a
+ * fnctor-subclass receiver (`class C extends F`, F a top-level plain
+ * function). The member may live on F's runtime-assigned `.prototype`
+ * (host-side), so compile the receiver as externref (extern.convert_any for
+ * the struct instance), marshal the args into a host JS array (native $ObjVec
+ * under standalone), and call `__extern_method_call(recv, "<name>", args)` —
+ * mirroring the any-receiver generic ladder (#799 WI3) so both entry points
+ * behave identically. Helper indices are re-read from funcMap at each use so
+ * late-import shifts during arg compilation cannot bake stale call targets.
+ */
+function emitFnctorSubclassDynamicMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  methodName: string,
+): InnerResult | undefined {
+  let arrNewIdx: number | undefined;
+  let arrPushIdx: number | undefined;
+  const arrNewName = ctx.standalone ? "__objvec_new" : "__js_array_new";
+  const arrPushName = ctx.standalone ? "__objvec_push" : "__js_array_push";
+  if (ctx.standalone) {
+    const b = ensureObjVecBuilders(ctx);
+    arrNewIdx = b.newIdx;
+    arrPushIdx = b.pushIdx;
+  } else {
+    arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+    arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+  }
+  const methodCallIdx = ensureLateImport(
+    ctx,
+    "__extern_method_call",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  // The fallback's method-name string constant, materialized BEFORE any body
+  // instructions so the global index is settled.
+  addStringConstantGlobal(ctx, methodName);
+  flushLateImportShifts(ctx, fctx);
+  if (methodCallIdx === undefined || arrNewIdx === undefined || arrPushIdx === undefined) return undefined;
+
+  const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+  if (recvType === null) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (recvType.kind !== "externref") {
+    fctx.body.push({ op: "extern.convert_any" } as Instr);
+  }
+  const recvLocal = allocLocal(fctx, `__fsd_recv_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: recvLocal });
+
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get(arrNewName) ?? arrNewIdx });
+  const argsLocal = allocLocal(fctx, `__fsd_args_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: argsLocal });
+  for (const arg of expr.arguments) {
+    fctx.body.push({ op: "local.get", index: argsLocal });
+    const argType = compileExpression(ctx, fctx, arg, { kind: "externref" });
+    if (argType && argType.kind !== "externref") {
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+    }
+    if (argType === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get(arrPushName) ?? arrPushIdx });
+  }
+  fctx.body.push({ op: "local.get", index: recvLocal });
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, methodName));
+  fctx.body.push({ op: "local.get", index: argsLocal });
+  fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__extern_method_call") ?? methodCallIdx });
+  return { kind: "externref" };
 }
 
 /**

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -140,7 +140,7 @@ import {
   collectDeclaredFuncRefs,
   compileClassBodies,
 } from "./class-bodies.js";
-import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983)
+import { classMemberFuncKey, fnctorAncestorOfClass, moduleHasFnctorSubclass } from "./class-member-keys.js"; // (#1983 / #3123)
 import {
   applyShapeInference,
   collectDeclarations,
@@ -3951,6 +3951,159 @@ function emitIteratorMethodExport(ctx: CodegenContext): void {
   emitMethodDispatch("@@iterator", "__call_@@iterator");
   emitMethodDispatch("next", "__call_next");
   emitMethodDispatch("return", "__call_return"); // (#3100 S5) IteratorClose §7.4.9 USER-arm dispatcher
+
+  // (#3123) Host-side class-member resolution surface for fnctor-subclass
+  // instances (`class C extends F`, F a top-level plain function — the test262
+  // Iterator-shim shape). The runtime's `_resolveClassMemberOnInstance` reads
+  // `inst.next` / `inst.return` through these:
+  //   __member_kind_<key>(recv) -> i32 : 0 none / 1 method / 2 getter
+  //   __call_get_<key>(recv) -> externref : runs the compiled getter
+  // (the plain-method CALL goes through the existing __call_<key> dispatchers
+  // above). Gated on the module actually containing a fnctor subclass so every
+  // other module's emitted bytes are IDENTICAL.
+  if (!ctx.standalone && !ctx.wasi && moduleHasFnctorSubclass(ctx)) {
+    // The iterator protocol keys plus every instance method / accessor name
+    // of the module's fnctor-subclass classes (a widened binding dispatches
+    // ALL its member calls dynamically — see fnctorWidenedLocals).
+    const keys = new Set<string>(["next", "return"]);
+    for (const className of ctx.classParentMap.keys()) {
+      if (fnctorAncestorOfClass(ctx, className) === undefined) continue;
+      for (const m of ctx.classMethodNames.get(className) ?? []) keys.add(m);
+      const accPrefix = `${className}_`;
+      for (const acc of ctx.classAccessorSet) {
+        if (acc.startsWith(accPrefix)) keys.add(acc.slice(accPrefix.length));
+      }
+    }
+    emitClassMemberKindExports(ctx, dispatchTypeIdx, [...keys].sort());
+  }
+}
+
+/**
+ * (#3123) Emit, per member key, the `__member_kind_<key>` discriminator and
+ * (when any struct carries a getter of that name) the `__call_get_<key>`
+ * getter dispatcher. Mirrors `emitIteratorMethodExport`'s per-struct
+ * ref.test cascade. Only 1-param (self-only) methods/getters are reported —
+ * that is what the 0-arg `__call_<key>` / `__call_get_<key>` dispatchers can
+ * actually invoke; a parameterized `next(v)` stays unreported (kind 0) so the
+ * host falls back instead of emitting an arity-invalid call.
+ */
+function emitClassMemberKindExports(ctx: CodegenContext, dispatchTypeIdx: number, keys: string[]): void {
+  const mod = ctx.mod;
+  const skipStruct = (structName: string): boolean =>
+    structName.startsWith("Wrapper") ||
+    structName === "$AnyValue" ||
+    structName.startsWith("__vec_") ||
+    structName.startsWith("__arr_");
+
+  type KindEntry = { typeIdx: number; funcIdx: number; resultType: ValType };
+  const collect = (nameOf: (structName: string) => string): KindEntry[] => {
+    const entries: KindEntry[] = [];
+    for (const [structName] of ctx.structFields) {
+      const typeIdx = ctx.structMap.get(structName);
+      if (typeIdx === undefined || skipStruct(structName)) continue;
+      const fullName = nameOf(structName);
+      if (ctx.staticMethodSet.has(fullName)) continue; // instance surface only
+      const funcIdx = ctx.funcMap.get(classMemberFuncKey(ctx, fullName));
+      if (funcIdx === undefined) continue;
+      const funcDef = definedFuncAt(ctx, funcIdx);
+      const funcType = funcDef ? mod.types[funcDef.typeIdx] : undefined;
+      if (!funcType || funcType.kind !== "func") continue;
+      if (funcType.params.length !== 1) continue; // self-only (0-arg dispatch)
+      const resultType: ValType = funcType.results.length > 0 ? funcType.results[0]! : { kind: "externref" };
+      entries.push({ typeIdx, funcIdx, resultType });
+    }
+    return entries;
+  };
+
+  const kindTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }], "$member_kind_type");
+
+  for (const key of keys) {
+    if (ctx.funcMap.has(`__member_kind_${key}`)) continue; // idempotent
+    const methodEntries = collect((s) => `${s}_${key}`);
+    const getterEntries = collect((s) => `${s}_get_${key}`);
+    if (methodEntries.length === 0 && getterEntries.length === 0) continue;
+
+    // __member_kind_<key>: ref.test cascade → 1 (method) / 2 (getter) / 0.
+    {
+      const funcIdx = ctx.numImportFuncs + mod.functions.length;
+      let current: Instr[] = [{ op: "i32.const", value: 0 } as Instr];
+      const arm = (typeIdx: number, kind: number, tail: Instr[]): Instr[] => [
+        { op: "local.get", index: 1 } as Instr,
+        { op: "ref.test", typeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [{ op: "i32.const", value: kind } as Instr],
+          else: tail,
+        } as Instr,
+      ];
+      for (const e of methodEntries) current = arm(e.typeIdx, 1, current);
+      for (const e of getterEntries) current = arm(e.typeIdx, 2, current);
+      const exportName = `__member_kind_${key}`;
+      mod.functions.push({
+        name: exportName,
+        typeIdx: kindTypeIdx,
+        locals: [{ name: "__any", type: { kind: "anyref" } }],
+        body: [
+          { op: "local.get", index: 0 } as Instr,
+          { op: "any.convert_extern" } as Instr,
+          { op: "local.set", index: 1 } as Instr,
+          ...current,
+        ],
+        exported: true,
+      } as WasmFunction);
+      mod.exports.push({ name: exportName, desc: { kind: "func", index: funcIdx } });
+      ctx.funcMap.set(exportName, funcIdx);
+    }
+
+    // __call_get_<key>: run the compiled getter, box-coerce to externref.
+    if (getterEntries.length > 0) {
+      const funcIdx = ctx.numImportFuncs + mod.functions.length;
+      let current: Instr[] = [{ op: "ref.null.extern" } as Instr];
+      for (const e of getterEntries) {
+        const callArm: Instr[] = [
+          { op: "local.get", index: 1 } as Instr,
+          { op: "ref.cast", typeIdx: e.typeIdx } as Instr,
+          { op: "call", funcIdx: e.funcIdx } as Instr,
+        ];
+        if (e.resultType.kind === "ref" || e.resultType.kind === "ref_null") {
+          callArm.push({ op: "extern.convert_any" } as Instr);
+        } else if (e.resultType.kind === "f64") {
+          const boxIdx = ctx.funcMap.get("__box_number");
+          if (boxIdx !== undefined) callArm.push({ op: "call", funcIdx: boxIdx } as Instr);
+        } else if (e.resultType.kind === "i32") {
+          callArm.push({ op: "f64.convert_i32_s" } as Instr);
+          const boxIdx = ctx.funcMap.get("__box_number");
+          if (boxIdx !== undefined) callArm.push({ op: "call", funcIdx: boxIdx } as Instr);
+        }
+        current = [
+          { op: "local.get", index: 1 } as Instr,
+          { op: "ref.test", typeIdx: e.typeIdx } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: callArm,
+            else: current,
+          } as Instr,
+        ];
+      }
+      const exportName = `__call_get_${key}`;
+      mod.functions.push({
+        name: exportName,
+        typeIdx: dispatchTypeIdx,
+        locals: [{ name: "__any", type: { kind: "anyref" } }],
+        body: [
+          { op: "local.get", index: 0 } as Instr,
+          { op: "any.convert_extern" } as Instr,
+          { op: "local.set", index: 1 } as Instr,
+          ...current,
+        ],
+        exported: true,
+      } as WasmFunction);
+      mod.exports.push({ name: exportName, desc: { kind: "func", index: funcIdx } });
+      ctx.funcMap.set(exportName, funcIdx);
+    }
+  }
 }
 
 /**
@@ -14779,6 +14932,81 @@ function inferLetConstInitializerWasmType(
   return { kind: "ref_null", typeIdx: receiverType.typeIdx };
 }
 
+/**
+ * (#3123) When `varType` names a fnctor-subclass class (`class C extends F`,
+ * F a top-level plain function), return the compiled class name; else
+ * undefined. Class-expression synthetic names resolve through
+ * `classExprNameMap` like the method-call ladder does.
+ */
+function fnctorSubclassNameOfType(ctx: CodegenContext, varType: ts.Type): string | undefined {
+  let clsName = varType.getSymbol()?.name;
+  if (clsName !== undefined && !ctx.classSet.has(clsName)) {
+    clsName = ctx.classExprNameMap.get(clsName) ?? clsName;
+  }
+  if (clsName === undefined || !ctx.classSet.has(clsName)) return undefined;
+  return fnctorAncestorOfClass(ctx, clsName) !== undefined ? clsName : undefined;
+}
+
+/**
+ * (#3123) True when the let-binding `decl` (named `name`, declared as class
+ * `clsName`) is re-assigned somewhere in its containing FUNCTION with a RHS
+ * whose declared type is NOT that class — i.e. the slot can hold a foreign
+ * (usually host-object) value at runtime. Oracle-based (#1930): the RHS type
+ * name comes from `ctx.oracle.declaredNameOf`. Name-matched but scoped to the
+ * SAME function (nested function bodies are not descended), so an inner
+ * function's same-named binding cannot false-positive; same-function shadows
+ * are already excluded by the pre-hoist caller (`localMap.has(name)` skip).
+ */
+function bindingHasForeignReassignment(
+  ctx: CodegenContext,
+  decl: ts.VariableDeclaration,
+  name: string,
+  clsName: string,
+): boolean {
+  const declFunc = getContainingFunctionForTdz(decl);
+  const funcBody = declFunc && "body" in declFunc ? (declFunc as { body?: ts.Node }).body : undefined;
+  const scope = funcBody ?? decl.getSourceFile();
+  let foreign = false;
+  const visit = (node: ts.Node): void => {
+    if (foreign) return;
+    // Do not descend into nested functions — their own `name` bindings are a
+    // different variable (and a capture-reassignment of the outer binding is
+    // out of this analysis' scope; the static-dispatch skip must not widen on
+    // it because dynamic dispatch only covers the kind-export surface).
+    if (
+      node !== scope &&
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node) ||
+        ts.isConstructorDeclaration(node))
+    ) {
+      return;
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left) &&
+      node.left.text === name &&
+      node.left !== decl.name
+    ) {
+      let rhsName = ctx.oracle.declaredNameOf(node.right);
+      if (rhsName !== undefined && !ctx.classSet.has(rhsName)) {
+        rhsName = ctx.classExprNameMap.get(rhsName) ?? rhsName;
+      }
+      if (rhsName !== clsName) {
+        foreign = true;
+        return;
+      }
+    }
+    forEachChild(node, visit);
+  };
+  if (scope) forEachChild(scope, visit);
+  return foreign;
+}
+
 function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.Statement): void {
   if (ts.isVariableStatement(stmt)) {
     const list = stmt.declarationList;
@@ -14869,7 +15097,7 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
         if (initIsAccessorLiteral || initIsHostSpreadLiteral) {
           ctx.externrefAccessorVars.add(name);
         }
-        const wasmType: ValType =
+        let wasmType: ValType =
           initIsAccessorLiteral || initIsHostSpreadLiteral
             ? { kind: "externref" }
             : isI32Coerced
@@ -14877,6 +15105,29 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
               : isNullablePrimitiveType(varType)
                 ? { kind: "externref" }
                 : (inferLetConstInitializerWasmType(ctx, fctx, decl.initializer) ?? resolveWasmType(ctx, varType));
+        // (#3123) A let-binding declared as a FNCTOR-SUBCLASS class instance
+        // (`class C extends F`, F a top-level plain function) that is
+        // REASSIGNED with another static type can hold a HOST object at
+        // runtime (`iterator = iterator.drop(0)` — the Iterator-helper
+        // wrapper minted by F's live prototype methods). A `(ref $C)` slot
+        // would NULL that host value through the guarded cast — widen the
+        // slot to externref and record the name so the method-call ladder
+        // dispatches on it dynamically. Host lane only (standalone has no
+        // host objects to hold). Typed use sites still recover the struct
+        // through their own guarded casts, so a never-host value is
+        // unaffected beyond the extra cast.
+        if (
+          (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
+          !ctx.standalone &&
+          !ctx.wasi &&
+          (list.flags & ts.NodeFlags.Let) !== 0
+        ) {
+          const fnctorCls = fnctorSubclassNameOfType(ctx, varType);
+          if (fnctorCls !== undefined && bindingHasForeignReassignment(ctx, decl, name, fnctorCls)) {
+            wasmType = { kind: "externref" };
+            (fctx.fnctorWidenedLocals ??= new Set()).add(name);
+          }
+        }
         const valueSlot = allocLocal(fctx, name, wasmType);
         // (#2814) Record the pre-hoisted slot for THIS declaration so
         // compileVariableStatement can reuse it when saveBlockScopedShadows later

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -1030,41 +1030,48 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       objectLiteralIsStandaloneAnyObjectCarrier(ctx, decl.initializer);
     const anyObjectCarrierTypeIdx = initIsAnyObjectCarrier ? ensureObjectRuntime(ctx).objectTypeIdx : -1;
     const wasmType: ValType =
-      initIsAccessorLiteral || initIsHostSpreadLiteral || initIsGrowableObjectLiteral
+      // (#3123) A widened fnctor-subclass binding (pre-hoist recorded it in
+      // `fnctorWidenedLocals` — reassigned with a foreign/host value) must
+      // keep its externref slot even when the block-scoped shadow machinery
+      // re-allocates here (the pre-hoisted slot reuse below is gated on
+      // plain-fn capture and does not fire for uncaptured bindings).
+      fctx.fnctorWidenedLocals?.has(name)
         ? { kind: "externref" as const }
-        : initIsAnyObjectCarrier && anyObjectCarrierTypeIdx >= 0
-          ? { kind: "ref_null" as const, typeIdx: anyObjectCarrierTypeIdx }
-          : isI32CoercedLocal
-            ? { kind: "i32" }
-            : isI32SpecializedArray
-              ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
-              : widenedTypeIdx !== undefined
-                ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
-                : (taViewType ??
-                  subarraySubviewType ??
-                  inferredVecType ??
-                  standaloneRegExpMatchArrayType ??
-                  (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
-                    ? { kind: "externref" as const }
-                    : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
+        : initIsAccessorLiteral || initIsHostSpreadLiteral || initIsGrowableObjectLiteral
+          ? { kind: "externref" as const }
+          : initIsAnyObjectCarrier && anyObjectCarrierTypeIdx >= 0
+            ? { kind: "ref_null" as const, typeIdx: anyObjectCarrierTypeIdx }
+            : isI32CoercedLocal
+              ? { kind: "i32" }
+              : isI32SpecializedArray
+                ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
+                : widenedTypeIdx !== undefined
+                  ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
+                  : (taViewType ??
+                    subarraySubviewType ??
+                    inferredVecType ??
+                    standaloneRegExpMatchArrayType ??
+                    (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
                       ? { kind: "externref" as const }
-                      : // (#2615) `new Proxy(target, handler)` returns a host/native
-                        // Proxy externref. The checker types it as the TARGET's
-                        // struct (ProxyConstructor returns T), so the default slot
-                        // would `ref.test` the Proxy against that struct, fail, null
-                        // it, and trap every read via a direct `struct.get`. Force an
-                        // externref local so reads route through `__extern_get` (the
-                        // only path that runs the Proxy MOP / trap). Both modes emit
-                        // a Proxy externref, so this is mode-agnostic.
-                        initIsProxy
+                      : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
                         ? { kind: "externref" as const }
-                        : // (#1337) `fn.bind(...)` / `Function.prototype.bind.call(...)`
-                          // returns a host bound-function externref in JS-host mode;
-                          // force an externref local so the value isn't ref.cast to
-                          // the target's closure struct (which traps → null binding).
-                          decl.initializer && !ctx.standalone && !noJsHost(ctx) && isBindHostCall(decl.initializer)
+                        : // (#2615) `new Proxy(target, handler)` returns a host/native
+                          // Proxy externref. The checker types it as the TARGET's
+                          // struct (ProxyConstructor returns T), so the default slot
+                          // would `ref.test` the Proxy against that struct, fail, null
+                          // it, and trap every read via a direct `struct.get`. Force an
+                          // externref local so reads route through `__extern_get` (the
+                          // only path that runs the Proxy MOP / trap). Both modes emit
+                          // a Proxy externref, so this is mode-agnostic.
+                          initIsProxy
                           ? { kind: "externref" as const }
-                          : localTypeForDeclaration(ctx, varType, decl)));
+                          : // (#1337) `fn.bind(...)` / `Function.prototype.bind.call(...)`
+                            // returns a host bound-function externref in JS-host mode;
+                            // force an externref local so the value isn't ref.cast to
+                            // the target's closure struct (which traps → null binding).
+                            decl.initializer && !ctx.standalone && !noJsHost(ctx) && isBindHostCall(decl.initializer)
+                            ? { kind: "externref" as const }
+                            : localTypeForDeclaration(ctx, varType, decl)));
 
     // (#2814) Bug C: re-align a block-scoped let/const with its OWN pre-hoisted
     // slot. `saveBlockScopedShadows` removed this name's localMap (and TDZ-flag)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -129,7 +129,23 @@ function _fnctorProtoLookup(
   if (!_canBeWeakKey(obj)) return undefined;
   const ctor = _fnctorInstanceCtor.get(obj);
   if (ctor == null) return undefined;
-  const proto = _sidecarGet(ctor, "prototype");
+  let proto = _sidecarGet(ctor, "prototype");
+  // (#3123) A top-level `F.prototype = <expr>` write may land in the closure
+  // STRUCT's typed `prototype` field slot (the #2664 `__set_member_prototype`
+  // dispatcher's struct arm) instead of the sidecar. Read the field through
+  // the compiled `__sget_prototype` getter so the live prototype the compiled
+  // side reads back is the SAME object the host walk starts from.
+  if (proto === undefined && exports !== undefined && _isWasmStruct(ctor)) {
+    const sgetProto = exports.__sget_prototype as ((v: any) => any) | undefined;
+    if (typeof sgetProto === "function") {
+      try {
+        const v = sgetProto(ctor);
+        if (v != null) proto = v;
+      } catch {
+        /* not a field of this struct shape */
+      }
+    }
+  }
   if (proto == null || typeof proto !== "object") return undefined;
   let cur: any = proto;
   let guard = 0;
@@ -4792,7 +4808,30 @@ function _safeGet(obj: any, key: any, callbackState?: { getExports: () => Record
       if (wasmKey) {
         const sc2 = _sidecarGet(obj, wasmKey);
         if (sc2 !== undefined) return sc2;
+        // (#3123) A computed well-known-symbol property in an object LITERAL
+        // (`{ [Symbol.iterator]: 0 }`) compiles to a typed struct FIELD named
+        // "@@iterator" — invisible to the sidecar read above. Read it through
+        // the per-shape `__sget_@@<name>` getter so a NON-CALLABLE @@iterator
+        // (the flatMap iterable-to-iterator-fallback shape, which must make
+        // GetMethod throw TypeError) is observable host-side.
+        const exports2 = callbackState?.getExports();
+        const fieldGetter = exports2?.[`__sget_${wasmKey}`];
+        if (typeof fieldGetter === "function") {
+          try {
+            const v = fieldGetter(obj);
+            if (v !== undefined && v !== null) return v;
+          } catch {
+            /* not a field of this struct shape */
+          }
+        }
       }
+    }
+    // (#3123) Compiled class methods/getters on a registered fnctor-subclass
+    // instance — the own-C.prototype level, shadowing the fnctor parent's
+    // prototype chain below.
+    {
+      const v = _resolveClassMemberOnInstance(obj, key, callbackState?.getExports());
+      if (v !== _MISS) return v;
     }
     // (#1712) fnctor instances: resolve through the constructor's vivified
     // prototype object before giving up. Accessors run with the instance
@@ -5650,6 +5689,99 @@ function _ownStructKeys(obj: any, exports: Record<string, Function> | undefined)
  * non-callable object — #1627) need the unmasked underlying value. Returns
  * `undefined` when nothing resolves.
  */
+/**
+ * (#3123, ported from the #3049-stack's bridge-exit marshaling — ONLY the
+ * function, not the stack's wiring of it into the generic `__call_fn` bridge
+ * exits, which regressed ~85 dstr iterator-close files in the parked #2835)
+ * Marshal a Wasm-struct value host-usably: vec / data-struct → `_wrapForHost`
+ * live mirror; closure struct → cached host-callable wrapper; anything
+ * already host-usable passes through untouched. Called exclusively from the
+ * fnctor-subclass member resolution below, so every other path keeps its
+ * pre-#3123 bytes-for-bytes behavior.
+ */
+function _marshalBridgeResult(v: any, callbackState?: { getExports: () => Record<string, Function> | undefined }): any {
+  if (v == null || typeof v !== "object" || !_isWasmStruct(v)) return v;
+  const exports = callbackState?.getExports();
+  if (!exports) return v;
+  try {
+    // Positive data-struct / vec discrimination FIRST (#2794 —
+    // `__is_closure` can false-positive on layout-canonicalization
+    // collisions; the data/vec markers cannot).
+    const isVec = exports.__is_vec as unknown as ((x: any) => number) | undefined;
+    if (typeof isVec === "function" && isVec(v) === 1) return _wrapForHost(v, exports);
+    const isData = exports.__is_data_struct as unknown as ((x: any) => number) | undefined;
+    if (typeof isData === "function" && isData(v) === 1) return _wrapForHost(v, exports);
+    const isCl = exports.__is_closure as unknown as ((x: any) => number) | undefined;
+    if (typeof isCl === "function" && isCl(v) === 1) {
+      return _wrapWasmClosureUnknownArity(v, callbackState) ?? v;
+    }
+  } catch {
+    /* discriminators unavailable — fall through to the generic proxy */
+  }
+  return _wrapForHost(v, exports);
+}
+
+/**
+ * (#3123) Cached host bridges for compiled class methods resolved on
+ * registered fnctor-subclass instances — identity-stable per (instance, key).
+ */
+const _classMethodHostBridges = new WeakMap<object, Map<string, Function>>();
+
+/**
+ * (#3123) Resolve a compiled CLASS method/getter on a registered
+ * fnctor-subclass instance (`class C extends F`, F a top-level plain function)
+ * via the module's dispatch exports:
+ *   - `__member_kind_<key>(recv)` → 0 none / 1 method / 2 getter;
+ *   - kind 1 → an identity-stable host function bridging to the 0-arg tag
+ *     dispatcher `__call_<key>(recv)` (the iterator protocol: `next()` /
+ *     `return()`);
+ *   - kind 2 → the getter's RESULT per [[Get]], marshaled host-usably (the
+ *     map/filter `get next()` exhaustion shape returns a FRESH closure per
+ *     read — do NOT cache).
+ * Returns `_MISS` when the exports are absent or the struct carries neither.
+ * The method bridge dispatches on the CAPTURED instance (correct for
+ * `Call(nextMethod, iterator)` where nextMethod was read from that instance;
+ * an extracted re-bind `f.call(other)` is out of scope — documented #3123).
+ */
+function _resolveClassMemberOnInstance(obj: any, key: any, exports: Record<string, Function> | undefined): any {
+  if (exports === undefined || typeof key !== "string") return _MISS;
+  if (obj == null || typeof obj !== "object" || !_canBeWeakKey(obj)) return _MISS;
+  if (!_fnctorInstanceCtor.has(obj)) return _MISS;
+  const kindFn = exports[`__member_kind_${key}`] as unknown as ((v: any) => number) | undefined;
+  if (typeof kindFn !== "function") return _MISS;
+  let kind = 0;
+  try {
+    kind = kindFn(obj);
+  } catch {
+    return _MISS;
+  }
+  const cbState = { getExports: () => exports };
+  if (kind === 2) {
+    const getFn = exports[`__call_get_${key}`] as unknown as ((v: any) => any) | undefined;
+    if (typeof getFn !== "function") return _MISS;
+    return _marshalBridgeResult(getFn(obj), cbState);
+  }
+  if (kind === 1) {
+    const callFn = exports[`__call_${key}`] as unknown as ((v: any) => any) | undefined;
+    if (typeof callFn !== "function") return _MISS;
+    let map = _classMethodHostBridges.get(obj);
+    if (!map) {
+      map = new Map();
+      _classMethodHostBridges.set(obj, map);
+    }
+    let fn = map.get(key);
+    if (!fn) {
+      fn = function classMethodHostBridge(this: any) {
+        return _marshalBridgeResult(callFn(obj), cbState);
+      };
+      Object.defineProperty(fn, "name", { value: key, configurable: true });
+      map.set(key, fn);
+    }
+    return fn;
+  }
+  return _MISS;
+}
+
 function _resolveHostField(obj: any, key: any, exports: Record<string, Function> | undefined): any {
   // #1336 — accessor properties (Object.defineProperty(obj, k, {get})) must
   // INVOKE the getter, not return a descriptor. Sidecar stores the descriptor
@@ -5703,7 +5835,27 @@ function _resolveHostField(obj: any, key: any, exports: Record<string, Function>
     if (wasmKey !== undefined) {
       const v = _sidecarGet(obj, wasmKey);
       if (v !== undefined) return v;
+      // (#3123) Computed well-known-symbol LITERAL property → typed struct
+      // FIELD named "@@<name>" — read via the per-shape `__sget_@@<name>`
+      // getter (see the matching arm in `_safeGet`). Makes a non-callable
+      // `{ [Symbol.iterator]: 0 }` observable so native GetMethod throws.
+      const fieldGetter = exports?.[`__sget_${wasmKey}`];
+      if (typeof fieldGetter === "function") {
+        try {
+          const fv = fieldGetter(obj);
+          if (fv !== undefined && fv !== null) return fv;
+        } catch {
+          /* not a field of this struct shape */
+        }
+      }
     }
+  }
+  // (#3123) Compiled class methods/getters on a registered fnctor-subclass
+  // instance — the own-C.prototype level, which must SHADOW the fnctor
+  // parent's prototype chain below.
+  {
+    const v = _resolveClassMemberOnInstance(obj, key, exports);
+    if (v !== _MISS) return v;
   }
   // (#1712) fnctor instances: resolve through the constructor's vivified
   // prototype object. Accessors run with the live-mirror proxy as the receiver.
@@ -13324,21 +13476,32 @@ assert._isSameValue = isSameValue;
           _AsyncGeneratorState.set(obj, { buf, index: 0, pendingThrow });
           return obj;
         };
+      // (#3123) Shared miss-arm for the __gen_* dispatchers: a registered
+      // fnctor-subclass instance's `next`/`return`/`throw` is a compiled class
+      // method/getter invisible to a native property read — resolve it through
+      // the wasm-aware reader (class-member kind dispatch + fnctor prototype
+      // walk). Gated on the registration WeakMap so every other receiver keeps
+      // the exact pre-#3123 behavior.
+      const genMemberFallback = (gen: any, key: string): any => {
+        if (gen == null || typeof gen !== "object") return undefined;
+        if (!_isWasmStruct(gen) || !_canBeWeakKey(gen) || !_fnctorInstanceCtor.has(gen)) return undefined;
+        return _safeGet(gen, key, callbackState);
+      };
       if (name === "__gen_next")
         return (gen: any) => {
-          const next = gen.next ?? _sidecarGet(gen, "next");
+          const next = gen.next ?? _sidecarGet(gen, "next") ?? genMemberFallback(gen, "next");
           if (typeof next === "function") return next.call(gen);
           throw new TypeError("generator.next is not a function");
         };
       if (name === "__gen_return")
         return (gen: any, val: any) => {
-          const ret = gen.return ?? _sidecarGet(gen, "return");
+          const ret = gen.return ?? _sidecarGet(gen, "return") ?? genMemberFallback(gen, "return");
           if (typeof ret === "function") return ret.call(gen, val);
           return { value: val, done: true };
         };
       if (name === "__gen_throw")
         return (gen: any, err: any) => {
-          const thr = gen.throw ?? _sidecarGet(gen, "throw");
+          const thr = gen.throw ?? _sidecarGet(gen, "throw") ?? genMemberFallback(gen, "throw");
           if (typeof thr === "function") return thr.call(gen, err);
           throw err;
         };
@@ -14020,6 +14183,19 @@ assert._isSameValue = isSameValue;
           if (!userClassParents.has(className)) {
             userClassParents.set(className, parentName == null ? null : parentName);
           }
+        };
+      // (#3123) `class C extends F` where F is a top-level PLAIN FUNCTION
+      // (fnctor — the test262 harness `Iterator` shim shape): the ctor
+      // registers each instance → F's closure struct so host-side member
+      // resolution (`_fnctorProtoLookup` via `_safeGet` / `_resolveHostField` /
+      // `__extern_method_call`) walks F's LIVE `.prototype` chain for
+      // inherited reads (`inst.drop` → the runtime-assigned helper proto).
+      if (name === "__register_fnctor_instance")
+        return (instance: any, ctorClosure: any): void => {
+          if (instance == null || typeof instance !== "object") return;
+          if (ctorClosure == null || typeof ctorClosure !== "object") return;
+          if (!_canBeWeakKey(instance)) return;
+          _fnctorInstanceCtor.set(instance, ctorClosure);
         };
       // (#1455) Subclasses of host builtins: after `__new_<Parent>(args)`
       // returns the bare host instance whose [[Prototype]] is Parent.prototype,

--- a/tests/issue-3123.test.ts
+++ b/tests/issue-3123.test.ts
@@ -1,0 +1,198 @@
+/**
+ * #3123 — `class C extends F` where F is a top-level PLAIN FUNCTION (fnctor)
+ * with a runtime-assigned `.prototype` (the test262 harness `Iterator` shim).
+ *
+ * Five stacked fixes, mirroring the residual Iterator-helper cluster
+ * (`exhaustion-does-not-call-return` / `return-is-forwarded` /
+ * `iterable-to-iterator-fallback`, ~8 files):
+ *  1. ctor registration (`__register_fnctor_instance`) — instances resolve
+ *     INHERITED members through F's live `.prototype` chain host-side
+ *     (`_fnctorInstanceCtor` → `_fnctorProtoLookup`).
+ *  2. class-member kind exports (`__member_kind_<k>` / `__call_get_<k>`) —
+ *     the host reads compiled class methods (`next`/`return`) and getters
+ *     (`get next()`) off the instance, marshaled via the #3049 bridges.
+ *  3. calls.ts dynamic routes — a method MISS on a fnctor-subclass receiver
+ *     (`.drop(0)`) and every member call on a WIDENED binding dispatch via
+ *     `__extern_method_call` instead of the graceful-null / null-self-static
+ *     paths; the any-receiver class-INFERENCE scan skips fnctor subclasses.
+ *  4. slot widening — a `let` binding of fnctor-subclass type reassigned
+ *     with a foreign value (`iterator = iterator.drop(0)`) gets an externref
+ *     slot so the host wrapper is not nulled by the guarded cast.
+ *  5. host-lane deferral of capturing DERIVED classes (#2818 gate narrowed to
+ *     standalone) — a try-block `class C extends F { m() { ++captured; } }`
+ *     promotes its captures instead of silently compiling `++captured` to a
+ *     no-op (`f64.const NaN; drop`).
+ * Plus: computed well-known-symbol struct FIELDS (`{ [Symbol.iterator]: 0 }`)
+ * are host-readable via `__sget_@@<name>`, so GetIteratorFlattenable throws
+ * TypeError on a non-callable @@iterator per spec.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result = await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    deferTopLevelInit: true,
+  });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    new Uint8Array(result.binary),
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  const ex: any = instance.exports;
+  if (imports.setExports) imports.setExports(ex);
+  const mi = ex.__module_init;
+  if (typeof mi === "function") mi();
+  return ex.test();
+}
+
+const SHIM = `
+function Iterator(this: any): void {}
+(Iterator as any).prototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+`;
+
+describe("#3123 — class extends fnctor: live-prototype member resolution", () => {
+  it("instance resolves own methods AND inherited helpers dynamically", async () => {
+    const src = `${SHIM}
+class TestIterator extends Iterator {
+  next(): any { return { done: false, value: 1 }; }
+  return(): any { return {}; }
+}
+export function test(): number {
+  const it: any = new TestIterator();
+  if (it == null) return -1;
+  if (typeof it.next !== "function") return -2;
+  if (typeof it.drop !== "function") return -3;
+  return 1;
+}
+`;
+    await expect(run(src)).resolves.toBe(1);
+  });
+
+  it("return-is-forwarded: helper wrapper forwards return() to the instance ONCE", async () => {
+    const src = `${SHIM}
+let returnCount = 0;
+class TestIterator extends Iterator {
+  next(): any { return { done: false, value: 1 }; }
+  return(): any { ++returnCount; return {}; }
+}
+export function test(): number {
+  let iterator: any = new TestIterator().drop(0);
+  const c0: number = returnCount;
+  iterator.return();
+  const c1: number = returnCount;
+  iterator.return();
+  const c2: number = returnCount;
+  return c0 * 100 + c1 * 10 + c2; // expect 0/1/1 → 11
+}
+`;
+    await expect(run(src)).resolves.toBe(11);
+  });
+
+  it("captured block-local in a try-scoped fnctor subclass increments (host defer)", async () => {
+    const src = `${SHIM}
+export function test(): number {
+  let out = -100;
+  try {
+    let returnCount = 0;
+    class TestIterator extends Iterator {
+      next() {
+        return { done: false, value: 1 };
+      }
+      return() {
+        ++returnCount;
+        return {};
+      }
+    }
+    let iterator = new TestIterator().drop(0);
+    const c0 = returnCount;
+    iterator.return();
+    const c1 = returnCount;
+    iterator.return();
+    const c2 = returnCount;
+    out = c0 * 100 + c1 * 10 + c2;
+  } catch (e) {
+    return -1;
+  }
+  return out; // expect 0/1/1 → 11
+}
+`;
+    await expect(run(src)).resolves.toBe(11);
+  });
+
+  it("widened binding: reassigned fnctor-subclass let holds the host wrapper (getter next)", async () => {
+    const src = `${SHIM}
+export function test(): number {
+  try {
+    let calls = 0;
+    class TestIterator extends Iterator {
+      get next() {
+        return function (): any {
+          ++calls;
+          return calls <= 2 ? { done: false, value: calls } : { done: true, value: undefined };
+        };
+      }
+      return() {
+        throw new Error("return must NOT be called on exhaustion");
+      }
+    }
+    let iterator = new TestIterator();
+    iterator = iterator.drop(0);
+    iterator.next();
+    iterator.next();
+    iterator.next();
+    iterator.next(); // exhausted — must not call return()
+    return 1;
+  } catch (e) {
+    return -1;
+  }
+}
+`;
+    await expect(run(src)).resolves.toBe(1);
+  });
+
+  it("non-callable computed @@iterator field is host-visible (GetMethod throws TypeError)", async () => {
+    const src = `
+function* g(): any {
+  yield 0;
+}
+export function test(): number {
+  const iter: any = g().flatMap(function (v: any): any {
+    return { [Symbol.iterator]: 0, next: function (): any { return { done: true, value: undefined }; } };
+  });
+  try {
+    iter.next();
+    return -1; // should have thrown TypeError
+  } catch (e) {
+    return 1;
+  }
+}
+`;
+    await expect(run(src)).resolves.toBe(1);
+  });
+
+  it("static dispatch on a never-reassigned fnctor-subclass binding is unaffected", async () => {
+    const src = `${SHIM}
+export function test(): number {
+  let n = 0;
+  class A extends Iterator {
+    bump(): void {
+      ++n;
+    }
+  }
+  const a = new A();
+  a.bump();
+  a.bump();
+  return n; // typed static dispatch — 2
+}
+`;
+    await expect(run(src)).resolves.toBe(2);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -3742,7 +3742,18 @@ export async function runTest262File(
       // wrapper. Matches `test262-shared.ts`.
       inferModuleStrictArguments: isModuleGoal(category, meta, source),
       // (#2095) standalone lane for the baseline validator (default host/gc).
-      ...(target ? { target } : {}),
+      // (#3049 C1 / #3123) Host lane defers top-level init (export
+      // `__module_init`, no wasm `(start)` section) so top-level code runs
+      // AFTER `setExports` has wired the runtime — aligned with
+      // `scripts/compiler-fork-worker.mjs` (#1251 both-paths rule). The
+      // standalone/wasi lane keeps its own `_start` model and is untouched.
+      // MODULE-GOAL tests are EXCLUDED: the multi-module (FIXTURE) link
+      // already synthesizes per-module init plumbing, and adding the
+      // deferred-export flag there emitted a SECOND `__module_init` export in
+      // one binary — V8 rejects it ("Duplicate export name '__module_init'"),
+      // which is exactly the 6-file `language/module-code/*` regression that
+      // parked the stack PR #2835/#2839 in the merge queue.
+      ...(target ? { target } : isModuleGoal(category, meta, source) ? {} : { deferTopLevelInit: true }),
       // #1251: align with the sharded runner — both `scripts/compiler-fork-worker.mjs`
       // (the production path that records the committed JSONL) and `tests/test262-vitest.test.ts`
       // FIXTURE multi-compile pass `skipSemanticDiagnostics: true`. Without this flag,
@@ -3889,6 +3900,15 @@ export async function runTest262File(
     // Provide exports back to the runtime so __sget_* getters are discoverable
     if (typeof importResult.setExports === "function") {
       importResult.setExports(instance.exports as any);
+    }
+    // (#3049 C1) Deferred top-level init (host lane): run the exported
+    // `__module_init` now that `setExports` has wired the runtime. Inside the
+    // same try as instantiate + test(), so a top-level throw keeps the exact
+    // classification it had when it surfaced from the `(start)` section
+    // (runtime-negative → pass, else fail — see the catch below).
+    const moduleInit = (instance.exports as any).__module_init;
+    if (typeof moduleInit === "function") {
+      moduleInit();
     }
     const testFn = (instance.exports as any).test;
     if (typeof testFn !== "function") {

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -616,6 +616,16 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   skipSemanticDiagnostics: true,
                   target: TEST262_TARGET,
                   inferModuleStrictArguments,
+                  // (#3049 C1 / #3123) NO deferTopLevelInit here — this is the
+                  // multi-module FIXTURE compile, which already synthesizes
+                  // per-module init plumbing; adding the deferred-export flag
+                  // emitted a SECOND `__module_init` export in one binary
+                  // (V8 "Duplicate export name '__module_init'" CompileError —
+                  // the 6-file `language/module-code/*` regression that parked
+                  // the stack PR #2835/#2839 in the merge queue). Single-file
+                  // compiles (the worker path) still defer; the exec block
+                  // calls the exported __module_init after setExports when
+                  // present, and is a no-op for this `(start)`-model binary.
                   // (#2932) Without allowJs, TypeScript excludes the `.js`
                   // _FIXTURE root files from the program entirely — their
                   // top-level declarations are never codegen'd and every
@@ -667,6 +677,14 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
                   if (typeof (importObj as any).setExports === "function") {
                     (importObj as any).setExports(instance.exports);
+                  }
+                  // (#3049 C1) Deferred top-level init (host lane): run the
+                  // exported __module_init now that setExports has wired the
+                  // runtime. Same try as instantiate + test(), so a top-level
+                  // throw keeps its pre-defer classification.
+                  const moduleInit = (instance.exports as any).__module_init;
+                  if (typeof moduleInit === "function") {
+                    moduleInit();
                   }
                   const testFn = (instance.exports as any).test;
                   if (typeof testFn !== "function") {


### PR DESCRIPTION
## Summary

Re-derives **#3123** (the Iterator-helper `class C extends Iterator` cluster) as a **clean branch off current origin/main**, replacing the parked 2-PR stack (#2835/#2839, both closed). The stack was auto-parked with a real 99-file merged-baseline regression (signature `5c449d888de7d030`); diagnosis of both merge_group runs showed the entire cluster came from the stack's #3049 base, not the #3123 delta (#2835 alone: net −43; stack+delta: same 99 signature, +116 improvements). This port deliberately **excludes the two regression roots**:

1. **Generic `__call_fn` bridge-exit marshaling** (~85 dstr `*-ary-init-iter-close` double-close failures, `doneCallCount` 1→2). `_marshalBridgeResult` is ported as a private helper called ONLY from the new fnctor-subclass member resolution, gated on the `_fnctorInstanceCtor` registration WeakMap — every other path keeps byte-for-byte pre-#3123 behavior.
2. **`deferTopLevelInit` on multi-module FIXTURE compiles** (6 `language/module-code/*` files failing V8 validation with `Duplicate export name '__module_init'` — each linked module exported the same name). The C1 deferred-host-init model is kept for single-file host-lane compiles but **gated OFF for module-goal tests at every harness site** (module-goal binaries stay byte-identical to main).

## What it fixes

`class TestIterator extends Iterator { next(){...} return(){...} }` — the test262-harness `Iterator` shim is a plain top-level function whose `.prototype` is assigned at RUNTIME to `%IteratorPrototype%`. Five walls, each empirically re-verified on current main before porting (details + WHY in `plan/issues/3123-*.md`): Layer-1 init keep for top-level `F.prototype = …` writes (previously silently elided in host mode); ctor-tail `__register_fnctor_instance` so `_fnctorProtoLookup` walks F's live prototype; `__member_kind_<k>`/`__call_get_<k>` dispatch exports (gated on `moduleHasFnctorSubclass`) making compiled methods/getters host-visible; dynamic dispatch for method-MISSes + externref widening for reassigned fnctor-subclass bindings; the #2818 carve-out flip (host defers derived capturers; standalone keeps eager).

## Measured (in-process `runTest262File`, this tree vs pristine-main control)

- 8-file target cluster: **6/8 flip to pass**.
- 693-file home cluster (Iterator/prototype + Object/create): **447 → 490 (+66 fail→pass, −1 real pass→fail)** — 22 further chunked-run downs all pass in fresh-process isolation (the #1957 realm-contamination artifact of the local runner; CI's realm canary recycles workers on exactly this class).
- **The stack's 99-file regression corpus: 93 pass**; all 6 fails are `language/module-code/*` local-runner artifacts reproduced identically on pristine main.
- Unit guards: issue-{3049,2818,3128,2628,2015,3123} 62/62; 1712-family delta-free vs main (one pre-existing local Node-25 failure reproduced on pristine main). tsc, prettier, loc-budget (allow-listed in the issue file), coercion-sites, ir-fallback gates all green.

## Known residual (documented in the issue file)

3 flatMap inner-flattening files (incl. the −1 above, which passed on main only vacuously via the unresolved-helper null path). Root: GetIteratorFlattenable reads off the RAW struct the compiled mapper returns; the stack's fix was the generic bridge marshaling that double-closed dstr — needs a narrow mapper-result marshal as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS