### PR TITLE
feat(#3137): native Promise.allSettled/any combinators — clears the vacuous native-into-host boundary class (+12 flips, 18 de-leaks, compounds #2903)

### DIFF
--- a/plan/issues/3137-standalone-native-allsettled-any-combinators.md
+++ b/plan/issues/3137-standalone-native-allsettled-any-combinators.md
@@ -1,0 +1,100 @@
+---
+id: 3137
+title: "Standalone: native Promise.allSettled / Promise.any combinators — clears the 99-file vacuous native-into-host boundary class + compounds the #2903 de-leak"
+status: in-progress
+assignee: ttraenkler/fable-harvest1
+sprint: current
+created: 2026-07-11
+updated: 2026-07-11
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen
+language_feature: promises, combinators, aggregate-error
+goal: standalone
+umbrella: 2860
+related: [2860, 2919, 2867, 2980, 2903, 3036]
+depends_on: [2903]
+origin: "2026-07-11 post-#2980-flip built-ins/Promise standalone harvest (fable-harvest1) — measured from the 2026-07-10 post-flip standalone baseline @ main 34e3812"
+---
+
+# #3137 — native `Promise.allSettled` / `Promise.any` (standalone)
+
+## Problem (measured, post-flip standalone baseline 2026-07-10)
+
+`Promise.all`/`race` are native since #2919/#2867-Gap-4, but `allSettled`/
+`any` still lower to the **host imports** `Promise_allSettled`/`Promise_any`.
+Post-#2980-flip every promise a standalone module mints is a **native
+`$Promise` struct** — opaque to the host combinator (no host-side `.then`),
+so the aggregate promise **never settles**:
+
+- **~99 `built-ins/Promise` fails are `vacuous`** (harness callback never
+  ran), almost all in `allSettled/**` + `any/**` — the native-into-host
+  boundary class. This class is **standalone-specific** (js-host passes these
+  shapes) — unlike the shared capability-protocol fails.
+- Standalone dir counts: `allSettled` 83 fail / 21 pass (15 leaky) / 6 CE;
+  `any` 81 fail / 10 pass (5 leaky) / 3 CE.
+- js-host ceiling (same dirs): `allSettled` 37/110, `any` 21/94 — the
+  shared-protocol fails (capability/resolve-element fidelity, the 69-file
+  "Promise resolve or reject function is not callable" cluster) are **NOT
+  claimed by this issue**.
+- `Promise.allSettled`/`Promise.any` syntactic presence also **flags the
+  whole module as a host-promise source** under #2903's de-leak gate, so
+  every `.then` bridge in such modules keeps its host arm. Landing native
+  combinators removes them from the producer sets — a compounding de-leak.
+
+**Realistic target: ≈ +60–120 standalone `host_free_pass`** (vacuous class
+flips + leaky passes de-leaked + standalone pass counts converging toward the
+host-lane ceiling), zero gc/host movement.
+
+## Design (extend the #2919 machinery, `src/codegen/promise-combinators.ts`)
+
+The module is cleanly factored (subscribe / per-combinator fulfill / reject
+builders over a shared count-down runtime). Extension:
+
+1. **`allSettled`** (§27.2.4.2): like `all`, but each element's reactions are
+   settle-wrappers that write a **status object** into the results vec —
+   `{ status: "fulfilled", value }` / `{ status: "rejected", reason }`
+   (plain `$Object` via the `__new_plain_object` runtime) — and the aggregate
+   **never rejects**; the remaining-count decrement fires on BOTH arms.
+2. **`any`** (§27.2.4.3): mirror of `all` with roles swapped — first
+   fulfillment resolves the aggregate; each rejection stores its reason into
+   an errors vec and decrements; count reaching zero rejects with a native
+   **`AggregateError`** (`errors` array own property, §20.5.7.1 — reuse the
+   `emitWasiErrorConstructor` family / `$Error_struct` brand machinery; check
+   what `AggregateError` support already exists before inventing).
+3. **Routing**: add both to `isNativeCombinatorMethod` +
+   `emitStandalonePromiseCombinator`; skip the upfront
+   `Promise_allSettled`/`Promise_any` registration in the
+   `collectPromiseImports` finalize under `isStandalonePromiseActive` (the
+   exact #2867-Gap-4 pattern used for `all`/`race`).
+4. **Compounding de-leak (#2903)**: remove `allSettled`/`any` from
+   `HOST_PROMISE_SOURCE_METHOD_NAMES` (declarations.ts) — they no longer mint
+   host promises. `allKeyed`/`allSettledKeyed`/`fromAsync`/`finally`/subclass
+   `all`/`race` stay flagged.
+5. **Lanes**: gc/host byte-identical (all changes behind
+   `isStandalonePromiseActive`); wasi inherits the native path (it already
+   takes native `all`/`race`).
+
+## Acceptance criteria
+
+- The vacuous `allSettled/**` + `any/**` standalone class drops materially
+  (target: standalone dir pass counts ≥ the js-host ceiling shapes that are
+  not capability-protocol-blocked), measured via `runTest262File` over both
+  dirs before/after.
+- Modules using `allSettled`/`any` (and nothing else host-routed) become
+  **host-free** (instantiate with `{}`), compounding the #2903 gate.
+- `prove-emit-identity`: gc lane byte-identical; existing native `all`/`race`
+  suites + `tests/issue-2903.test.ts` (updated: the allSettled producer
+  control flips to host-free) stay green.
+- Zero regressions on the 662/217-file #2903 measure sets.
+
+## Notes
+
+- Stacked on `issue-2903-then-chain-deleak` (PR #2877, in queue) — same
+  producer-set files; enqueue only after #2877 lands.
+- The 69-file capability cluster ("Promise resolve or reject function is not
+  callable", custom-capability `Promise.all.call(C, …)` shapes) is a separate
+  mechanism (#2671's standalone twin) — file separately if it survives this.

--- a/plan/issues/3137-standalone-native-allsettled-any-combinators.md
+++ b/plan/issues/3137-standalone-native-allsettled-any-combinators.md
@@ -1,7 +1,8 @@
 ---
 id: 3137
 title: "Standalone: native Promise.allSettled / Promise.any combinators — clears the 99-file vacuous native-into-host boundary class + compounds the #2903 de-leak"
-status: in-progress
+status: done
+completed: 2026-07-11
 assignee: ttraenkler/fable-harvest1
 sprint: current
 created: 2026-07-11
@@ -18,6 +19,17 @@ umbrella: 2860
 related: [2860, 2919, 2867, 2980, 2903, 3036]
 depends_on: [2903]
 origin: "2026-07-11 post-#2980-flip built-ins/Promise standalone harvest (fable-harvest1) — measured from the 2026-07-10 post-flip standalone baseline @ main 34e3812"
+# (#3102/#3131) intended growth: the new allSettled/any wrappers + reaction
+# selection (promise-combinators), the tuple-param widen for the then-callback
+# ABI (closures/context/calls), the lockstep shift keys (async-scheduler), and
+# the producer-scan re-tier (declarations).
+loc-budget-allow:
+  - src/codegen/closures.ts
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/async-scheduler.ts
+  - src/codegen/declarations.ts
+  - src/codegen/promise-combinators.ts
 ---
 
 # #3137 — native `Promise.allSettled` / `Promise.any` (standalone)
@@ -98,3 +110,74 @@ builders over a shared count-down runtime). Extension:
 - The 69-file capability cluster ("Promise resolve or reject function is not
   callable", custom-capability `Promise.all.call(C, …)` shapes) is a separate
   mechanism (#2671's standalone twin) — file separately if it survives this.
+
+---
+
+## Landed (fable-harvest1, 2026-07-11)
+
+**PR:** `issue-3137-native-allsettled-any` (stacked on #2877, which merged).
+
+### What landed
+
+1. **Native `allSettled`/`any`** on the #2919 machinery
+   (`promise-combinators.ts`): `NativeCombinator` widened to all four; three
+   new lazily-minted wrappers (`__combinator_allsettled_fulfill`/`_reject`
+   build `{status, value|reason}` plain-`$Object` results and only ever
+   FULFILL; `__combinator_any_reject` collects reasons and rejects with a
+   native AggregateError) + `__combinator_new_aggregate_error(errorsVec)` (a
+   tag-branded `$Error_struct`, `.errors` on `$props` — readable, `instanceof
+   AggregateError` works; deliberately NOT named `__new_AggregateError`, which
+   is the 3-param host-import contract). `any` fulfills via the shared race
+   wrapper. Registration is a separate `ensureSettledAnyCombinators` so
+   all/race-only modules are **byte-identical** (prove-emit-identity 39/39);
+   new funcIdx fields added to `COMBINATOR_FUNC_IDX_KEYS` (#2918 lockstep).
+   Zero-input arms: allSettled([]) fulfills `[]`; any([]) rejects with an
+   empty-`.errors` AggregateError (both emitters, literal + runtime-loop).
+2. **Upfront-import skip** (declarations.ts `collectPromiseImports` finalize)
+   extended to allSettled/any under `isStandalonePromiseActive` (the Gap-4
+   pattern) — exotic shapes still lazily register at the host fallthrough.
+3. **#2903 producer-scan re-tier**: `allSettled`/`any` moved off the
+   unconditional producer set to the subclass-receiver-only rule (like
+   all/race) — the compounding de-leak (allSettled/any modules now take the
+   native then-bridge miss arm and go fully host-free).
+4. **Tuple-param widen for the then-callback ABI** (the trap this exposed):
+   TS contextually types combinator callbacks over tuple inputs as TUPLES
+   (`rs: [PromiseSettledResult<unknown>]` → a concrete 1-field struct), but
+   `emitThenWrapperFunction`'s ABI always delivers externref — the unguarded
+   `ref.cast` trapped (`illegal cast in __then_fulfill_N`, 8 harness files).
+   Fix: `ctx.widenTupleCallbackParams` set only in the
+   `compileStandalonePromiseThenCallback` window; `computeClosureWrapperSig`
+   widens tuple-typed params to externref there (body reads go through the
+   dynamic reader — representation-correct for the results vec AND genuine
+   tuples). Every other closure compile byte-identical.
+
+### Measured (allSettled+any dirs, 197 comparable files)
+
+| transition | n |
+|---|--:|
+| fail(leaky) → **pass** | **+12** |
+| pass(leaky) → pass (now host-free) | 18 |
+| pass → pass | 10 |
+| fail(leaky) → fail (shared-protocol residue) | 142 |
+| fail(leaky) → fail(vacuous) (string-arg/host residue) | 9 |
+| CE → CE | 5 |
+| pass(leaky) → fail — **accepted, documented** | 2 |
+
+The 2 accepted flips are observable-resolution-protocol exotics
+(`resolve-poisoned-then.js` — poisoned `Array.prototype.then` getter must
+reject the aggregate at result-array resolution; `invoke-resolve-error-reject.js`
+— poisoned per-element resolve): the leak-satisfied host lane implemented the
+full protocol, the native lane doesn't yet. They were never host-free-credited
+(`host_free_pass` unchanged); implementing observable resolution steps is the
+same follow-on class as the 69-file capability cluster.
+
+### Regression proofs
+
+- #2903 662-set: **unchanged** (625 host-free pass / 36 leaky / 1 pre-existing
+  ret=2). Near-miss 217-set: 215 pass + the 2 documented exotics.
+- prove-emit-identity 39/39 vs post-#2877 main (gc + wasi + non-combinator
+  standalone byte-identical).
+- Suites: issue-3137 (9), issue-2903 (9, one control updated — allSettled
+  modules are host-free now by design), issue-1326 wasi contract,
+  issue-2919 native combinators, async-await, 2918, 2980, 2895 all green.
+- lint/typecheck/dead-exports/loc-budget (granted) green.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -3904,6 +3904,12 @@ const COMBINATOR_FUNC_IDX_KEYS = [
   "allFulfillFuncIdx",
   "raceFulfillFuncIdx",
   "rejectFuncIdx",
+  // (#3137) allSettled/any wrappers — lazily minted (undefined on all/race-only
+  // modules; the shifter's typeof-number guard skips them).
+  "allSettledFulfillFuncIdx",
+  "allSettledRejectFuncIdx",
+  "anyRejectFuncIdx",
+  "aggErrNewFuncIdx",
 ] as const;
 
 /**

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -43,6 +43,7 @@ import {
   getOrRegisterVecType,
   hoistLetConstWithTdz,
   hoistVarDeclarations,
+  isTupleType,
   nextModuleGlobalIdx,
   resolveWasmType,
 } from "./index.js";
@@ -1630,6 +1631,25 @@ export function computeClosureWrapperSig(
       wasmType = { kind: "externref" };
     }
     if (ctx.forceExternrefCallbackParams && isVecOrArrayRefType(ctx, wasmType)) {
+      wasmType = { kind: "externref" };
+    }
+    // (#3137) TUPLE-typed params of a native `.then`/`.catch` callback widen to
+    // externref. TS contextually types combinator callbacks over tuple inputs
+    // as tuples (`Promise.allSettled([x]).then((rs) => …)` ⇒ rs:
+    // `[PromiseSettledResult<…>]`, lowered to a concrete 1-field struct), but
+    // the native then-wrapper ABI always delivers externref — the combinator
+    // results vec can never BE that tuple struct, so the wrapper's `ref.cast`
+    // trapped (illegal cast in __then_fulfill_N). Widened, the body reads the
+    // value through the dynamic reader (vec length/index + status objects),
+    // which is representation-correct for both the combinator vec and a
+    // genuine tuple value. Scoped to the then-callback compile window
+    // (`widenTupleCallbackParams`, set in compileStandalonePromiseThenCallback)
+    // so every other closure compile is byte-identical.
+    if (
+      ctx.widenTupleCallbackParams === true &&
+      (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
+      isTupleType(paramType)
+    ) {
       wasmType = { kind: "externref" };
     }
     arrowParams.push(wasmType);

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1455,6 +1455,16 @@ export interface CodegenContext {
    * upstream), so the typed `arr.forEach(cb)` hot path is never touched.
    */
   forceExternrefCallbackParams?: boolean;
+  /**
+   * (#3137) True while compiling a native `.then`/`.catch` callback closure
+   * (`compileStandalonePromiseThenCallback` window). TUPLE-typed callback
+   * params widen to externref in `computeClosureWrapperSig`: the native
+   * then-wrapper ABI always delivers externref, and a combinator results vec
+   * can never be the contextually-inferred tuple struct — the unguarded
+   * `ref.cast` trapped (illegal cast in `__then_fulfill_N`, the #3137
+   * allSettled harness class). Every other closure compile is unaffected.
+   */
+  widenTupleCallbackParams?: boolean;
   /** Map from local variable name → closure metadata (for call_ref dispatch) */
   closureMap: Map<string, ClosureInfo>;
   /** Map from closure struct type index → closure metadata (for anonymous closures) */

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -170,20 +170,15 @@ const CONSOLE_METHODS_SET = new Set(["log", "warn", "error", "info", "debug"]);
 
 // (#2903) Method names whose CALL can mint a HOST promise in a standalone
 // module even while the native `$Promise` chain is active — the host-routed
-// combinators/instance methods (`Promise_allSettled`/`Promise_any`/
-// `Promise_finally`/`__array_from_async` imports). Matched on ANY receiver
-// (conservative: a false positive only preserves the pre-#2903 host fallback
-// arm). Plain `Promise.all`/`Promise.race` are NOT listed — those lower to the
-// host-free native combinators (#2919/#2867 Gap 4); only the
-// subclass-receiver form is flagged (inline check at the scan site).
-const HOST_PROMISE_SOURCE_METHOD_NAMES = new Set([
-  "finally",
-  "allSettled",
-  "any",
-  "allKeyed",
-  "allSettledKeyed",
-  "fromAsync",
-]);
+// combinators/instance methods (`Promise_finally`/`__array_from_async`
+// imports). Matched on ANY receiver (conservative: a false positive only
+// preserves the pre-#2903 host fallback arm). Plain `Promise.all`/`race`/
+// (#3137) `allSettled`/`any` are NOT listed — those lower to the host-free
+// native combinators (#2919/#2867 Gap 4/#3137); only the subclass-receiver
+// form is flagged (inline check at the scan site — exotic shapes that fall to
+// the host path lazily register their `Promise_*` import, which the bridge's
+// funcMap producer check catches).
+const HOST_PROMISE_SOURCE_METHOD_NAMES = new Set(["finally", "allKeyed", "allSettledKeyed", "fromAsync"]);
 
 /**
  * (#1700) Record TypedArray classifications for a user-exported function so
@@ -1133,7 +1128,10 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       if (
         calleeName !== undefined &&
         (HOST_PROMISE_SOURCE_METHOD_NAMES.has(calleeName) ||
-          ((calleeName === "all" || calleeName === "race") && !recvIsPromiseIdent))
+          // (#3137) native-combinator names: only the subclass-receiver form
+          // (`MyP.all(...)`) is host-routed; plain `Promise.<m>(...)` is native.
+          ((calleeName === "all" || calleeName === "race" || calleeName === "allSettled" || calleeName === "any") &&
+            !recvIsPromiseIdent))
       ) {
         ctx.moduleHasHostPromiseSource = true;
       }
@@ -1647,7 +1645,12 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
     // import). Skip the unsatisfiable `Promise_all`/`Promise_race` pre-registration
     // here; the host path (generic iterables / subclass receivers) still
     // lazily `ensureLateImport`s it at the call site when actually needed.
-    if (isStandalonePromiseActive(ctx) && (method === "all" || method === "race")) continue;
+    // (#3137) `allSettled`/`any` are native on the same machinery now — same skip.
+    if (
+      isStandalonePromiseActive(ctx) &&
+      (method === "all" || method === "race" || method === "allSettled" || method === "any")
+    )
+      continue;
     const importName = `Promise_${method}`;
     if (!ctx.funcMap.has(importName)) {
       const isAggregator = method === "all" || method === "race" || method === "allSettled" || method === "any";

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3673,6 +3673,12 @@ function compileStandalonePromiseThenCallback(
   const savedBody = fctx.body;
   fctx.savedBodies.push(savedBody);
   fctx.body = instrs;
+  // (#3137) Widen TUPLE-typed callback params to externref for this compile
+  // window — the native then-wrapper ABI delivers externref, and the
+  // contextually-inferred tuple struct (combinator over a tuple input) can
+  // never match the runtime results vec (see computeClosureWrapperSig).
+  const savedWidenTuple = ctx.widenTupleCallbackParams;
+  ctx.widenTupleCallbackParams = true;
   try {
     const type =
       ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)
@@ -3694,6 +3700,7 @@ function compileStandalonePromiseThenCallback(
     }
     return { instrs, closureInfo };
   } finally {
+    ctx.widenTupleCallbackParams = savedWidenTuple;
     fctx.savedBodies.pop();
     fctx.body = savedBody;
   }
@@ -9520,9 +9527,10 @@ function compileCallExpression(
         // compile-time collection projection; everything else except strings,
         // `number[]` vecs, and native-generator subjects takes the (#2922 arms
         // 2+3) dynamic `__combinator_to_vec` path (custom iterables drain,
-        // non-iterables reject with a native TypeError). `allSettled`/`any`
-        // and subclass capability-ctor receivers still fall through to the
-        // host path (follow-ups).
+        // non-iterables reject with a native TypeError). (#3137) `allSettled`/
+        // `any` take the same native arms (status objects / AggregateError via
+        // ensureSettledAnyCombinators); subclass capability-ctor receivers
+        // still fall through to the host path (follow-ups).
         const arg0 = expr.arguments[0];
         const nativeCombinatorEligible =
           isStandalonePromiseActive(ctx) &&

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -20,10 +20,14 @@
 // `any`-typed values, and statically-non-iterable primitives — normalized at
 // runtime by `__combinator_to_vec` (vec passthrough / user-iterable drain /
 // null = not-iterable → the result promise rejects with a native TypeError).
-// The `allSettled` / `any` combinators (which additionally need per-element
-// status objects / `AggregateError`), string arguments, f64-backed `number[]`
-// vecs (the Gap-4 output-representation escalation), and generator-state
-// arguments still fall through to the existing host path (follow-ups).
+// (#3137) The `allSettled` / `any` combinators lower natively on the same
+// machinery: per-element status objects (`$Object` via the object runtime) and
+// a native `AggregateError` (`$Error_struct`, `.errors` on `$props`), lazily
+// registered ONLY when a module compiles one (ensureSettledAnyCombinators) so
+// all/race-only modules stay byte-identical. String arguments, f64-backed
+// `number[]` vecs (the Gap-4 output-representation escalation), and
+// generator-state arguments still fall through to the existing host path
+// (follow-ups).
 //
 // **Inert until the widen.** Every emission site is gated on
 // `isStandalonePromiseActive(ctx)`, which is `ctx.wasi`-only today, so the
@@ -34,9 +38,24 @@
 
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { Instr, LocalDef, ValType } from "../ir/types.js";
-import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import {
+  addFuncType,
+  getArrTypeIdxFromVec,
+  getOrRegisterErrorStructType,
+  getOrRegisterVecType,
+} from "./registry/types.js";
 import { allocLocal } from "./context/locals.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable mint/push
+// (#3137) allSettled/any additions: status objects live on the object runtime
+// ($Object via __new_plain_object/__extern_set), the AggregateError is a native
+// $Error_struct (tag from builtin-tags), and the "status"/"fulfilled"/… keys are
+// interned native-string constants. All lazily pulled ONLY when a module
+// actually compiles a native allSettled/any (see ensureSettledAnyCombinators) so
+// all/race-only modules stay byte-identical.
+import { ensureObjectRuntime } from "./object-runtime.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { BUILTIN_TYPE_TAGS } from "./builtin-tags.js";
 import {
   ensureAsyncDriveRuntime,
   getOrRegisterPromiseType,
@@ -49,11 +68,11 @@ const EXTERNREF: ValType = { kind: "externref" };
 
 type AsyncDriveRuntimeT = ReturnType<typeof ensureAsyncDriveRuntime>;
 
-/** The combinators this module lowers natively. `allSettled`/`any` are deferred. */
-export type NativeCombinator = "all" | "race";
+/** The combinators this module lowers natively (#2867 Gap 4 `all`/`race`; #3137 `allSettled`/`any`). */
+export type NativeCombinator = "all" | "race" | "allSettled" | "any";
 
 export function isNativeCombinatorMethod(method: string): method is NativeCombinator {
-  return method === "all" || method === "race";
+  return method === "all" || method === "race" || method === "allSettled" || method === "any";
 }
 
 interface CombinatorRuntime {
@@ -75,6 +94,20 @@ interface CombinatorRuntime {
   raceFulfillFuncIdx: number;
   /** `__combinator_reject(caps, reason) -> reason` (shared all/race). */
   rejectFuncIdx: number;
+  // ── (#3137) allSettled/any wrappers — lazily minted by
+  // ensureSettledAnyCombinators ONLY when a module compiles a native
+  // allSettled/any, so all/race-only modules stay byte-identical. Every field
+  // MUST also be listed in COMBINATOR_FUNC_IDX_KEYS (async-scheduler.ts) — the
+  // late-import lockstep shift (#2918) — because emit sites bake
+  // `ref.func`/`call` from these long after registration.
+  /** `__combinator_allsettled_fulfill(caps, value) -> value` — stores `{status:"fulfilled", value}`. */
+  allSettledFulfillFuncIdx?: number;
+  /** `__combinator_allsettled_reject(caps, reason) -> reason` — stores `{status:"rejected", reason}`; never rejects the aggregate. */
+  allSettledRejectFuncIdx?: number;
+  /** `__combinator_any_reject(caps, reason) -> reason` — stores the reason; last rejection rejects with an AggregateError. */
+  anyRejectFuncIdx?: number;
+  /** `__combinator_new_aggregate_error(errorsVec) -> externref` — native $Error_struct with tag AggregateError + `.errors` on $props. */
+  aggErrNewFuncIdx?: number;
 }
 
 type CtxWithCombinators = CodegenContext & { __promiseCombinators?: CombinatorRuntime };
@@ -197,6 +230,143 @@ export function ensureCombinatorFunctions(ctx: CodegenContext): CombinatorRuntim
 
   (ctx as CtxWithCombinators).__promiseCombinators = ids;
   return ids;
+}
+
+/** (#3137) CombinatorRuntime with the allSettled/any wrapper fields guaranteed present. */
+type SettledAnyCombinatorRuntime = CombinatorRuntime &
+  Required<
+    Pick<
+      CombinatorRuntime,
+      "allSettledFulfillFuncIdx" | "allSettledRejectFuncIdx" | "anyRejectFuncIdx" | "aggErrNewFuncIdx"
+    >
+  >;
+
+/**
+ * (#3137) Lazily mint the allSettled/any reaction wrappers on top of the shared
+ * combinator runtime. Kept OUT of ensureCombinatorFunctions so `all`/`race`-only
+ * modules never pull the object runtime / error struct / key-string constants —
+ * their emitted bytes stay identical to pre-#3137 output.
+ *
+ * Registration discipline mirrors ensureCombinatorFunctions: all dependencies
+ * (object runtime for `__new_plain_object`/`__extern_set`, the `$Error_struct`,
+ * the interned key strings) are ensured BEFORE the wrappers are minted/built, so
+ * no dependency append can shift a baked index mid-build. The minted funcIdxs
+ * are stored on `ctx.__promiseCombinators` and listed in
+ * COMBINATOR_FUNC_IDX_KEYS (async-scheduler.ts) for the #2918 late-import
+ * lockstep shift.
+ */
+function ensureSettledAnyCombinators(ctx: CodegenContext): SettledAnyCombinatorRuntime {
+  const ids = ensureCombinatorFunctions(ctx);
+  if (ids.allSettledFulfillFuncIdx !== undefined && ids.anyRejectFuncIdx !== undefined) {
+    return ids as SettledAnyCombinatorRuntime;
+  }
+  const rt = ensureAsyncDriveRuntime(ctx);
+  ensureObjectRuntime(ctx);
+  const errStructTypeIdx = getOrRegisterErrorStructType(ctx);
+
+  // Intern every key/message string BEFORE building bodies (the same
+  // "register, then materialize" order emitErrorStructConstructor uses).
+  const STRINGS = [
+    "status",
+    "fulfilled",
+    "rejected",
+    "value",
+    "reason",
+    "errors",
+    "AggregateError",
+    ANY_REJECT_MESSAGE,
+  ];
+  for (const s of STRINGS) addStringConstantGlobal(ctx, s);
+
+  const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
+  const externSetIdx = ctx.funcMap.get("__extern_set");
+  if (newPlainObjIdx === undefined || externSetIdx === undefined) {
+    // Structurally impossible after ensureObjectRuntime; keep the invariant loud.
+    throw new Error("#3137: object runtime did not register __new_plain_object/__extern_set");
+  }
+
+  const aggErrNewFuncIdx = mintDefinedFunc(ctx);
+  const allSettledFulfillFuncIdx = mintDefinedFunc(ctx);
+  const allSettledRejectFuncIdx = mintDefinedFunc(ctx);
+  const anyRejectFuncIdx = mintDefinedFunc(ctx);
+
+  const wrapperTypeIdx = addFuncType(ctx, [EXTERNREF, EXTERNREF], [EXTERNREF]);
+  const aggErrTypeIdx = addFuncType(ctx, [EXTERNREF], [EXTERNREF]);
+
+  pushDefinedFunc(ctx, aggErrNewFuncIdx, {
+    name: "__combinator_new_aggregate_error",
+    typeIdx: aggErrTypeIdx,
+    locals: [{ name: "$props", type: EXTERNREF }],
+    body: buildNewAggregateErrorBody(ctx, errStructTypeIdx, newPlainObjIdx, externSetIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_new_aggregate_error", aggErrNewFuncIdx);
+
+  pushDefinedFunc(ctx, allSettledFulfillFuncIdx, {
+    name: "__combinator_allsettled_fulfill",
+    typeIdx: wrapperTypeIdx,
+    locals: buildSettledWrapperLocals(ids),
+    body: buildAllSettledBody(ctx, ids, rt, "fulfilled", newPlainObjIdx, externSetIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_allsettled_fulfill", allSettledFulfillFuncIdx);
+
+  pushDefinedFunc(ctx, allSettledRejectFuncIdx, {
+    name: "__combinator_allsettled_reject",
+    typeIdx: wrapperTypeIdx,
+    locals: buildSettledWrapperLocals(ids),
+    body: buildAllSettledBody(ctx, ids, rt, "rejected", newPlainObjIdx, externSetIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_allsettled_reject", allSettledRejectFuncIdx);
+
+  pushDefinedFunc(ctx, anyRejectFuncIdx, {
+    name: "__combinator_any_reject",
+    typeIdx: wrapperTypeIdx,
+    locals: buildAllFulfillLocals(ids),
+    body: buildAnyRejectBody(ids, rt, aggErrNewFuncIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_any_reject", anyRejectFuncIdx);
+
+  ids.aggErrNewFuncIdx = aggErrNewFuncIdx;
+  ids.allSettledFulfillFuncIdx = allSettledFulfillFuncIdx;
+  ids.allSettledRejectFuncIdx = allSettledRejectFuncIdx;
+  ids.anyRejectFuncIdx = anyRejectFuncIdx;
+  return ids as SettledAnyCombinatorRuntime;
+}
+
+/** (#3137) V8-compatible `Promise.any` total-rejection message (§27.2.4.3 AggregateError). */
+const ANY_REJECT_MESSAGE = "All promises were rejected";
+
+/**
+ * (#3137) Per-method reaction-wrapper selection for the two combinator
+ * emitters. MUST be called at the TOP of an emitter (before element buffers /
+ * loop code splice into fctx.body) — the settled/any arm lazily registers
+ * functions, and the emitters' ordering contract requires every registration
+ * to precede the copy (see the #2919 liveBodies note at the literal call site).
+ */
+function combinatorReactionFns(
+  ctx: CodegenContext,
+  ids: CombinatorRuntime,
+  method: NativeCombinator,
+): { fulfillIdx: number; rejectIdx: number } {
+  switch (method) {
+    case "all":
+      return { fulfillIdx: ids.allFulfillFuncIdx, rejectIdx: ids.rejectFuncIdx };
+    case "race":
+      return { fulfillIdx: ids.raceFulfillFuncIdx, rejectIdx: ids.rejectFuncIdx };
+    case "allSettled": {
+      const e = ensureSettledAnyCombinators(ctx);
+      return { fulfillIdx: e.allSettledFulfillFuncIdx, rejectIdx: e.allSettledRejectFuncIdx };
+    }
+    case "any": {
+      // First fulfillment settles the aggregate — exactly the race fulfill
+      // wrapper; only the rejection side (collect + AggregateError) is new.
+      const e = ensureSettledAnyCombinators(ctx);
+      return { fulfillIdx: e.raceFulfillFuncIdx, rejectIdx: e.anyRejectFuncIdx };
+    }
+  }
 }
 
 // ── __combinator_subscribe ───────────────────────────────────────────────────
@@ -416,6 +586,211 @@ function buildRejectBody(ids: CombinatorRuntime, rt: AsyncDriveRuntimeT): Instr[
   return buildSettleResultBody(ids, rt.rejectFuncIdx);
 }
 
+// ── (#3137) __combinator_allsettled_fulfill / _reject ────────────────────────
+// params: 0 caps externref, 1 value externref.
+// locals: 2 c (ref $CombinatorElemCaps), 3 st (ref $CombinatorState), 4 rem i32,
+//         5 obj externref (the {status, value|reason} result object).
+
+function buildSettledWrapperLocals(ids: CombinatorRuntime): LocalDef[] {
+  return [
+    { name: "$c", type: { kind: "ref", typeIdx: ids.elemCapsTypeIdx } },
+    { name: "$st", type: { kind: "ref", typeIdx: ids.stateTypeIdx } },
+    { name: "$rem", type: { kind: "i32" } },
+    { name: "$obj", type: EXTERNREF },
+  ];
+}
+
+/**
+ * (#3137) `allSettled` reaction wrapper body (§27.2.4.2.2/.3): build the
+ * `{ status: "fulfilled", value }` / `{ status: "rejected", reason }` result
+ * object as a plain `$Object`, store it at the element index, and — this is the
+ * allSettled-defining difference from `all` — count down on BOTH arms and only
+ * ever FULFILL the aggregate. Insertion order status→value|reason matches the
+ * spec's CreateDataProperty order.
+ */
+function buildAllSettledBody(
+  ctx: CodegenContext,
+  ids: CombinatorRuntime,
+  rt: AsyncDriveRuntimeT,
+  status: "fulfilled" | "rejected",
+  newPlainObjIdx: number,
+  externSetIdx: number,
+): Instr[] {
+  const CAPS = 0;
+  const VALUE = 1;
+  const C = 2;
+  const ST = 3;
+  const REM = 4;
+  const OBJ = 5;
+  return [
+    // obj = __new_plain_object(); obj.status = <status>; obj.<value|reason> = value
+    { op: "call", funcIdx: newPlainObjIdx },
+    { op: "local.set", index: OBJ },
+    { op: "local.get", index: OBJ },
+    ...stringConstantExternrefInstrs(ctx, "status"),
+    ...stringConstantExternrefInstrs(ctx, status),
+    { op: "call", funcIdx: externSetIdx },
+    { op: "local.get", index: OBJ },
+    ...stringConstantExternrefInstrs(ctx, status === "fulfilled" ? "value" : "reason"),
+    { op: "local.get", index: VALUE },
+    { op: "call", funcIdx: externSetIdx },
+
+    { op: "local.get", index: CAPS },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ids.elemCapsTypeIdx } as Instr,
+    { op: "local.set", index: C },
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: ST },
+
+    // results[index] = obj
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.get", index: OBJ },
+    { op: "array.set", typeIdx: ids.arrTypeIdx } as Instr,
+
+    // remaining -= 1
+    { op: "local.get", index: ST },
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 3 } as Instr,
+    { op: "i32.const", value: 1 },
+    { op: "i32.sub" },
+    { op: "local.tee", index: REM },
+    { op: "struct.set", typeIdx: ids.stateTypeIdx, fieldIdx: 3 } as Instr,
+
+    // if remaining == 0: FULFILL the aggregate with the results vec (never reject).
+    { op: "local.get", index: REM },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 2 } as Instr,
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 1 } as Instr,
+        { op: "struct.new", typeIdx: ids.vecTypeIdx } as Instr,
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: rt.fulfillFuncIdx },
+        { op: "drop" },
+      ],
+    } as Instr,
+
+    { op: "local.get", index: VALUE },
+  ];
+}
+
+// ── (#3137) __combinator_any_reject ──────────────────────────────────────────
+// params: 0 caps externref, 1 reason externref. Locals as buildAllFulfillLocals.
+
+/**
+ * (#3137) `Promise.any` rejection wrapper (§27.2.4.3.2): store the reason at the
+ * element index, count down; when the LAST input rejects, reject the aggregate
+ * with a native AggregateError carrying the reasons vec as `.errors`.
+ * Fulfillment settles via the shared race-fulfill wrapper (first value wins).
+ */
+function buildAnyRejectBody(ids: CombinatorRuntime, rt: AsyncDriveRuntimeT, aggErrNewFuncIdx: number): Instr[] {
+  const CAPS = 0;
+  const VALUE = 1;
+  const C = 2;
+  const ST = 3;
+  const REM = 4;
+  return [
+    { op: "local.get", index: CAPS },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ids.elemCapsTypeIdx } as Instr,
+    { op: "local.set", index: C },
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: ST },
+
+    // errors[index] = reason
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.get", index: VALUE },
+    { op: "array.set", typeIdx: ids.arrTypeIdx } as Instr,
+
+    // remaining -= 1
+    { op: "local.get", index: ST },
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 3 } as Instr,
+    { op: "i32.const", value: 1 },
+    { op: "i32.sub" },
+    { op: "local.tee", index: REM },
+    { op: "struct.set", typeIdx: ids.stateTypeIdx, fieldIdx: 3 } as Instr,
+
+    // if remaining == 0: reject the aggregate with AggregateError(errorsVec).
+    { op: "local.get", index: REM },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 2 } as Instr,
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 1 } as Instr,
+        { op: "struct.new", typeIdx: ids.vecTypeIdx } as Instr,
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: aggErrNewFuncIdx },
+        { op: "call", funcIdx: rt.rejectFuncIdx },
+        { op: "drop" },
+      ],
+    } as Instr,
+
+    { op: "local.get", index: VALUE },
+  ];
+}
+
+// ── (#3137) __combinator_new_aggregate_error ─────────────────────────────────
+// params: 0 errorsVec externref. locals: 1 props externref.
+
+/**
+ * (#3137) Build a native AggregateError `$Error_struct` (§20.5.7.1 semantics
+ * for the combinator's internal use): tag = BUILTIN_TYPE_TAGS.AggregateError
+ * (so `instanceof AggregateError` discriminates), message = the V8-compatible
+ * total-rejection message, and `.errors` stored on the `$props` own-field
+ * backing object (#2101a R5 — reads route through `__extern_get`'s error arm).
+ * Deliberately NOT named `__new_AggregateError`: that funcMap name is the
+ * 3-param HOST import contract (#1467, new-super.ts) and must not be shadowed
+ * with a different arity.
+ */
+function buildNewAggregateErrorBody(
+  ctx: CodegenContext,
+  errStructTypeIdx: number,
+  newPlainObjIdx: number,
+  externSetIdx: number,
+): Instr[] {
+  const ERRVEC = 0;
+  const PROPS = 1;
+  return [
+    // props = __new_plain_object(); props.errors = errorsVec
+    { op: "call", funcIdx: newPlainObjIdx },
+    { op: "local.set", index: PROPS },
+    { op: "local.get", index: PROPS },
+    ...stringConstantExternrefInstrs(ctx, "errors"),
+    { op: "local.get", index: ERRVEC },
+    { op: "call", funcIdx: externSetIdx },
+    // struct.new $Error_struct { tag, message, name, stack, userClassId, props }
+    { op: "i32.const", value: BUILTIN_TYPE_TAGS.AggregateError },
+    ...stringConstantExternrefInstrs(ctx, ANY_REJECT_MESSAGE),
+    ...stringConstantExternrefInstrs(ctx, "AggregateError"),
+    { op: "ref.null.extern" },
+    { op: "i32.const", value: -1 },
+    { op: "local.get", index: PROPS },
+    { op: "struct.new", typeIdx: errStructTypeIdx } as Instr,
+    { op: "extern.convert_any" },
+  ];
+}
+
 /**
  * Emit a native `Promise.all([...])` / `Promise.race([...])`. `elementInstrs` is
  * the pre-compiled list of element expressions (each already coerced to
@@ -429,6 +804,10 @@ export function emitStandalonePromiseCombinator(
 ): ValType {
   const ids = ensureCombinatorFunctions(ctx);
   const rt = ensureAsyncDriveRuntime(ctx);
+  // (#3137) MUST run before any element buffer splices into fctx.body — the
+  // allSettled/any arm lazily registers wrapper functions (see the ordering
+  // note above about ensure* preceding the buffer copy).
+  const reaction = combinatorReactionFns(ctx, ids, method);
   const n = elementInstrs.length;
 
   const resultLocal = allocLocal(fctx, `__comb_result_${fctx.locals.length}`, {
@@ -465,9 +844,12 @@ export function emitStandalonePromiseCombinator(
   fctx.body.push({ op: "local.set", index: stateLocal });
 
   if (n === 0) {
-    // `Promise.all([])` fulfills immediately with an empty array. `Promise.race([])`
-    // stays pending forever (spec) — emit nothing.
-    if (method === "all") {
+    // `Promise.all([])` / `Promise.allSettled([])` fulfill immediately with an
+    // empty array. `Promise.any([])` rejects immediately with an AggregateError
+    // whose `.errors` is empty (§27.2.4.3 step 4 via the remaining-count
+    // reaching zero with no fulfillment). `Promise.race([])` stays pending
+    // forever (spec) — emit nothing.
+    if (method === "all" || method === "allSettled") {
       fctx.body.push({ op: "local.get", index: resultLocal });
       fctx.body.push({ op: "i32.const", value: 0 });
       fctx.body.push({ op: "local.get", index: arrLocal });
@@ -475,16 +857,24 @@ export function emitStandalonePromiseCombinator(
       fctx.body.push({ op: "extern.convert_any" });
       fctx.body.push({ op: "call", funcIdx: rt.fulfillFuncIdx });
       fctx.body.push({ op: "drop" });
+    } else if (method === "any") {
+      fctx.body.push({ op: "local.get", index: resultLocal });
+      fctx.body.push({ op: "i32.const", value: 0 });
+      fctx.body.push({ op: "local.get", index: arrLocal });
+      fctx.body.push({ op: "struct.new", typeIdx: ids.vecTypeIdx } as Instr);
+      fctx.body.push({ op: "extern.convert_any" });
+      fctx.body.push({ op: "call", funcIdx: ids.aggErrNewFuncIdx! });
+      fctx.body.push({ op: "call", funcIdx: rt.rejectFuncIdx });
+      fctx.body.push({ op: "drop" });
     }
   } else {
-    const fulfillFn = method === "all" ? ids.allFulfillFuncIdx : ids.raceFulfillFuncIdx;
     for (let i = 0; i < n; i++) {
       for (const instr of elementInstrs[i]!) fctx.body.push(instr);
       fctx.body.push({ op: "local.get", index: stateLocal });
       fctx.body.push({ op: "extern.convert_any" });
       fctx.body.push({ op: "i32.const", value: i });
-      fctx.body.push({ op: "ref.func", funcIdx: fulfillFn } as Instr);
-      fctx.body.push({ op: "ref.func", funcIdx: ids.rejectFuncIdx } as Instr);
+      fctx.body.push({ op: "ref.func", funcIdx: reaction.fulfillIdx } as Instr);
+      fctx.body.push({ op: "ref.func", funcIdx: reaction.rejectIdx } as Instr);
       fctx.body.push({ op: "call", funcIdx: ids.subscribeFuncIdx });
     }
   }
@@ -562,6 +952,9 @@ export function emitStandalonePromiseCombinatorRuntime(
 ): ValType {
   const ids = ensureCombinatorFunctions(ctx);
   const rt = ensureAsyncDriveRuntime(ctx);
+  // (#3137) Lazily registers the allSettled/any wrappers; must precede all
+  // emission below (registration-before-bake, same contract as the literal arm).
+  const reaction = combinatorReactionFns(ctx, ids, method);
 
   const resultLocal = allocLocal(fctx, `__comb_result_${fctx.locals.length}`, {
     kind: "ref",
@@ -623,10 +1016,13 @@ export function emitStandalonePromiseCombinatorRuntime(
     } as Instr);
   }
 
-  // `Promise.all(<empty>)` fulfills immediately with the empty results vec;
+  // `Promise.all(<empty>)` / `Promise.allSettled(<empty>)` fulfill immediately
+  // with the empty results vec; `Promise.any(<empty>)` rejects immediately with
+  // an empty-`.errors` AggregateError (one-shot settle keeps the opts
+  // not-iterable TypeError reject above authoritative when both fire);
   // `Promise.race(<empty>)` stays pending forever (spec). The subscribe loop
   // below runs zero iterations either way.
-  if (method === "all") {
+  if (method === "all" || method === "allSettled") {
     fctx.body.push({ op: "local.get", index: nLocal });
     fctx.body.push({ op: "i32.eqz" });
     fctx.body.push({
@@ -642,13 +1038,29 @@ export function emitStandalonePromiseCombinatorRuntime(
         { op: "drop" },
       ],
     } as Instr);
+  } else if (method === "any") {
+    fctx.body.push({ op: "local.get", index: nLocal });
+    fctx.body.push({ op: "i32.eqz" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: resultLocal },
+        { op: "i32.const", value: 0 },
+        { op: "local.get", index: arrLocal },
+        { op: "struct.new", typeIdx: ids.vecTypeIdx } as Instr,
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: ids.aggErrNewFuncIdx! },
+        { op: "call", funcIdx: rt.rejectFuncIdx },
+        { op: "drop" },
+      ],
+    } as Instr);
   }
 
   // for (i = 0; i < n; i++) __combinator_subscribe(argVec.data[i], state, i,
   //                                                fulfillFn, rejectFn)
   // Subscribe never settles synchronously (already-settled inputs only ENQUEUE),
   // so `remaining` stays == n through the whole loop — no mid-loop settle race.
-  const fulfillFn = method === "all" ? ids.allFulfillFuncIdx : ids.raceFulfillFuncIdx;
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "local.set", index: iLocal });
   fctx.body.push({
@@ -674,8 +1086,8 @@ export function emitStandalonePromiseCombinatorRuntime(
           { op: "local.get", index: stateLocal },
           { op: "extern.convert_any" },
           { op: "local.get", index: iLocal },
-          { op: "ref.func", funcIdx: fulfillFn } as Instr,
-          { op: "ref.func", funcIdx: ids.rejectFuncIdx } as Instr,
+          { op: "ref.func", funcIdx: reaction.fulfillIdx } as Instr,
+          { op: "ref.func", funcIdx: reaction.rejectIdx } as Instr,
           { op: "call", funcIdx: ids.subscribeFuncIdx },
 
           // i++

--- a/tests/issue-2903.test.ts
+++ b/tests/issue-2903.test.ts
@@ -138,7 +138,12 @@ export function test(): number {
     expect(names).toContain("Promise_then");
   });
 
-  it("Promise.allSettled in the module keeps the host arm", async () => {
+  it("(#3137 update) Promise.allSettled is native now — the module goes fully host-free", async () => {
+    // Pre-#3137 this control asserted the host arm stayed (allSettled was a
+    // host-promise producer). #3137 lowers allSettled natively on the
+    // combinator machinery, so the producer flag no longer fires and the
+    // then-bridge miss arm is native too: zero imports (the compounding
+    // de-leak this gate was designed to enable).
     const result = await compileStandalone(
       DRAIN +
         `
@@ -148,10 +153,7 @@ export function test(): number {
   return 1;
 }`,
     );
-    const names = importNames(result);
-    expect(names).toContain("Promise_allSettled");
-    // then-chain host fallback stays because allSettled mints a HOST promise.
-    expect(names.some((n) => n === "Promise_then" || n === "Promise_then2")).toBe(true);
+    expect(importNames(result)).toEqual([]);
   });
 });
 

--- a/tests/issue-3137.test.ts
+++ b/tests/issue-3137.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3137 — native Promise.allSettled / Promise.any combinators (standalone).
+//
+// Post-#2980-flip every standalone-minted promise is a native `$Promise`
+// struct, which the host `Promise_allSettled`/`Promise_any` imports cannot
+// await — the aggregate never settled (the ~99-file vacuous class in
+// built-ins/Promise). This extends the #2919/#2867-Gap-4 native combinator
+// machinery: allSettled builds `{status, value|reason}` result objects (plain
+// `$Object`) and never rejects; any resolves on the first fulfillment and
+// rejects with a native AggregateError (tag-discriminated `$Error_struct`,
+// `.errors` on `$props`) when every input rejects. All wrappers register
+// lazily (ensureSettledAnyCombinators) so all/race-only modules stay
+// byte-identical (prove-emit-identity 39/39 vs main).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const DRAIN = "declare function __drain_microtasks(): void;\n";
+
+async function runStandaloneHostFree(source: string): Promise<number> {
+  const result = await compile(DRAIN + source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success).toBe(true);
+  // Host-free: the whole point — no Promise_allSettled/Promise_any/then-chain imports.
+  expect((result.imports ?? []).map((i) => i.name)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3137 — native Promise.allSettled (standalone, host-free)", () => {
+  it("mixed fulfilled/rejected inputs produce {status, value|reason} objects in order", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  const p1 = Promise.resolve(3);
+  const p2 = Promise.reject(new Error("boom"));
+  Promise.allSettled([p1, p2]).then((rs: any) => {
+    if (rs.length !== 2) { ok = -1; return; }
+    const a = rs[0], b = rs[1];
+    ok = a.status === "fulfilled" && a.value === 3 && b.status === "rejected" ? 1 : -2;
+  });
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("never rejects the aggregate; empty input fulfills with []", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  Promise.allSettled([]).then((rs: any) => { ok = rs.length === 0 ? 1 : -1; }, (e: any) => { ok = -2; });
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("non-promise elements count as fulfilled with their value", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  Promise.allSettled([1, "x"]).then((rs: any) => {
+    ok = rs[0].status === "fulfilled" && rs[0].value === 1 && rs[1].value === "x" ? 1 : -1;
+  });
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("array-typed (non-literal) argument takes the runtime loop", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  const arr: Promise<number>[] = [Promise.resolve(4), Promise.resolve(5)];
+  Promise.allSettled(arr).then((rs: any) => { ok = rs.length === 2 && rs[1].value === 5 ? 1 : -1; });
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+});
+
+describe("#3137 — native Promise.any (standalone, host-free)", () => {
+  it("first fulfillment wins over earlier rejections", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  Promise.any([Promise.reject(new Error("a")), Promise.resolve(7), Promise.resolve(8)]).then(
+    (v: any) => { ok = v === 7 ? 1 : -1; },
+    (e: any) => { ok = -2; },
+  );
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("all-rejected rejects with an AggregateError carrying .errors in order", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  Promise.any([Promise.reject("r1"), Promise.reject("r2")]).then(
+    (v: any) => { ok = -1; },
+    (e: any) => {
+      const errs: any = e.errors;
+      ok = e instanceof AggregateError && errs && errs.length === 2 && errs[0] === "r1" && errs[1] === "r2" ? 1 : -3;
+    },
+  );
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("empty input rejects immediately with an AggregateError", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  Promise.any([]).then((v: any) => { ok = -1; }, (e: any) => { ok = e instanceof AggregateError ? 1 : -2; });
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("array-typed (non-literal) argument takes the runtime loop", async () => {
+    const ret = await runStandaloneHostFree(`
+let ok = 0;
+export function test(): number {
+  const arr: Promise<number>[] = [Promise.reject(new Error("z")), Promise.resolve(9)];
+  Promise.any(arr).then((v: any) => { ok = v === 9 ? 1 : -1; }, (e: any) => { ok = -2; });
+  __drain_microtasks();
+  return ok;
+}`);
+    expect(ret).toBe(1);
+  });
+});
+
+describe("#3137 — all/race controls unchanged", () => {
+  it("Promise.all still fulfills in order and rejects on first rejection", async () => {
+    const ret = await runStandaloneHostFree(`
+let a = 0, b = 0, n = 0, rej = 0;
+export function test(): number {
+  Promise.all([Promise.resolve(1), Promise.resolve(2)]).then((vs: any) => { n = vs.length; a = vs[0]; b = vs[1]; });
+  Promise.all([Promise.resolve(1), Promise.reject(new Error("x"))]).then((v: any) => { rej = -1; }, (e: any) => { rej = 1; });
+  __drain_microtasks();
+  return n === 2 && a === 1 && b === 2 && rej === 1 ? 1 : 0;
+}`);
+    expect(ret).toBe(1);
+  });
+
+  it("gc/host lane keeps the host Promise_allSettled import (no native arm)", async () => {
+    const result = await compile(
+      DRAIN +
+        `
+export function test(): number {
+  Promise.allSettled([Promise.resolve(1)]).then((r: any) => {});
+  __drain_microtasks();
+  return 1;
+}`,
+      { fileName: "test.ts", skipSemanticDiagnostics: true },
+    );
+    expect(result.success).toBe(true);
+    expect((result.imports ?? []).map((i) => i.name)).toContain("Promise_allSettled");
+  });
+});


### PR DESCRIPTION
## Summary

**#3137, the follow-on rock to #2877 (#2903 de-leak).** Post-#2980-flip, standalone promises are native `$Promise` structs — opaque to the host `Promise_allSettled`/`Promise_any` imports, so those aggregates never settled: **~99 vacuous fails** in `built-ins/Promise` (the native-into-host boundary class, standalone-specific — js-host passes these shapes). This lowers both combinators natively on the #2919 machinery.

## What's in it

1. **Native `allSettled`/`any`** (`promise-combinators.ts`): three lazily-minted wrappers — `__combinator_allsettled_fulfill`/`_reject` build `{status, value|reason}` plain-`$Object` results and only ever FULFILL the aggregate; `__combinator_any_reject` collects reasons and rejects with a **native AggregateError** (tag-branded `$Error_struct`, `.errors` on `$props` — readable, `instanceof` works) — plus `__combinator_new_aggregate_error(errorsVec)` (deliberately NOT the `__new_AggregateError` funcMap name — that is the 3-param host-import contract, #1467). `any` fulfills via the shared race wrapper. Zero-input arms per spec (allSettled([]) → `[]`; any([]) → empty-`.errors` AggregateError), both emitters (literal unroll + runtime loop). Registration is a separate `ensureSettledAnyCombinators`, so **all/race-only modules are byte-identical**; the new funcIdx fields join `COMBINATOR_FUNC_IDX_KEYS` (#2918 late-import lockstep).
2. **Upfront-import skip** extended to allSettled/any under `isStandalonePromiseActive` (the #2867-Gap-4 pattern); exotic shapes still lazily register at the host fallthrough.
3. **#2903 producer-scan re-tier**: `allSettled`/`any` move off the unconditional producer set to the subclass-receiver-only rule — the compounding de-leak (such modules now take the native then-bridge miss arm and compile **fully host-free**).
4. **Tuple-param widen for the then-callback ABI** (the latent trap this exposed, verified by WAT disassembly): TS contextually types combinator callbacks over tuple inputs as TUPLES (`rs: [PromiseSettledResult<unknown>]` → a concrete 1-field struct), but `emitThenWrapperFunction`'s ABI always delivers externref — the unguarded `ref.cast` trapped (`illegal cast in __then_fulfill_N`, 8 harness files). Fix: `ctx.widenTupleCallbackParams`, set only in the `compileStandalonePromiseThenCallback` window; `computeClosureWrapperSig` widens tuple params to externref there. Every other closure compile is byte-identical.

## Measured (allSettled+any dirs, 197 comparable files, runTest262File standalone)

| transition | n |
|---|--:|
| fail(leaky) → **pass** | **+12** |
| pass(leaky) → pass, now **host-free** | 18 |
| pass → pass | 10 |
| fail → fail (shared-protocol residue, both lanes) | 142+9 |
| CE → CE | 5 |
| pass(leaky) → fail — accepted, documented | 2 |

The 2 accepted flips (`resolve-poisoned-then.js`, `invoke-resolve-error-reject.js`) are observable-resolution-protocol exotics (poisoned `Array.prototype.then` getter / poisoned per-element resolve) that only ever passed because the leak-satisfied host ran the full protocol. They were **never host-free-credited** — `host_free_pass` is unaffected; the fix class is the same follow-on as the 69-file capability cluster (documented in the issue).

## Zero-regression proofs

- **#2903 measure sets unchanged**: 662-set → 625 host-free pass / 36 leaky / 1 pre-existing ret=2; near-miss 217-set → 215 pass + the 2 documented exotics.
- `prove-emit-identity`: **39/39 sha-identical** vs current main (gc + wasi + non-combinator standalone untouched).
- Suites green: new `tests/issue-3137.test.ts` (9), `tests/issue-2903.test.ts` (9 — one control updated by design: allSettled modules are host-free now), issue-1326 wasi contract, issue-2919 native combinators, async-await, 2918, 2980, 2895.
- Gates: lint ✓ typecheck ✓ dead-exports ✓ prettier ✓ loc-budget granted via `loc-budget-allow` in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS