### PR TITLE
fix(#3139): Array generics over fnctor-instance array-likes — extern mis-bind refusal + prototype-inclusive index/length reads

### DIFF
--- a/plan/issues/3139-fnctor-receiver-method-inference.md
+++ b/plan/issues/3139-fnctor-receiver-method-inference.md
@@ -1,0 +1,119 @@
+---
+id: 3139
+title: "host lane: Array generics over fnctor-instance array-likes — first-match extern mis-bind (Uint8ClampedArray_*) + extern index/length handlers not prototype-inclusive"
+status: done
+assignee: ttraenkler/fable-harvest2
+sprint: current
+created: 2026-07-11
+updated: 2026-07-11
+completed: 2026-07-11
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, runtime
+language_feature: array-methods, prototype-chain
+es_edition: 5
+goal: correctness
+test262_category: built-ins/Array/prototype
+related: [3138, 3022, 3014, 1712, 2580, 3116]
+depends_on: [3138]
+origin: "2026-07-11 — follow-on to #3138, banked there as the 'Array-iteration fnctor subclassing' residual (~150 officially-failing files matched the shape)"
+# +22 LOC in runtime.ts: the three prototype-inclusive fall-throughs must live
+# inside the __extern_length/__extern_get_idx/__extern_has_idx handlers they
+# amend — there is no subsystem module for host-import handler bodies.
+loc-budget-allow:
+  - src/runtime.ts
+---
+
+# #3139 — Array generics over fnctor-instance array-likes
+
+## Problem
+
+The test262 applied-to-object family (`built-ins/Array/prototype/{every,filter,
+map,some,forEach,reduce,reduceRight,indexOf,lastIndexOf}/15.4.4.x-*`):
+
+```js
+foo.prototype = new Array(11, 22, 33);
+function foo() {}
+var f = new foo();
+var r = f.every(cb); // direct form
+var r2 = Array.prototype.every.call(f, cb); // .call form
+```
+
+Both forms silently iterate **zero** elements on main (post-#3138: the
+instance→ctor link exists and `f[1]` / `f.length` reads already resolve, but
+the iteration methods still see an empty receiver).
+
+## Root causes (two stacked, WAT-verified)
+
+1. **Direct form — first-match extern mis-bind.** `f` is `any`-typed, so
+   `tryExternClassMethodOnAny` (calls-closures.ts) scans `ctx.externClasses`
+   and first-match binds `f.every(cb)` to **`Uint8ClampedArray_every`** — the
+   %TypedArray% host bridge, which iterates zero elements on a receiver with
+   no [[TypedArrayName]] slot. This is EXACTLY the #3014 `forEach`/`some`
+   hazard; the refusal list simply didn't cover the other iteration/search
+   generics.
+2. **.call form — extern index/length reads are not prototype-inclusive.**
+   `Array.prototype.every.call(f, cb)` compiles to the generic array loop over
+   `__extern_length` / `__extern_get_idx` / `__extern_has_idx`. For a WasmGC
+   struct receiver those handlers stopped at own-level reads (sidecar +
+   `__sget_*`) and returned `0`/`undefined` — never walking the fnctor
+   instance→ctor prototype chain (§7.3.2 Get / §7.3.12 HasProperty are
+   prototype-inclusive), where the Array-valued prototype's LIVE length and
+   elements are served by the `_readOwnDescriptor` vec arm (#3116).
+
+## Fix
+
+- **calls-closures.ts** — extend the #3014 refusal list with `every`,
+  `filter`, `map`, `reduce`, `reduceRight`, `indexOf`, `lastIndexOf` (the
+  `indexOf` pair is String∩Array-ambiguous exactly like the #1062 `.slice`
+  refusal). Refusal falls through to the runtime-shape-dispatching generic
+  paths, which are correct for TypedArrays, arrays, strings AND fnctor
+  array-likes.
+- **runtime.ts** — `__extern_length` / `__extern_get_idx` /
+  `__extern_has_idx`: after every own-level probe misses, resolve through
+  `_fnctorProtoLookup` (before the #2580 `Object.prototype` extended-index
+  table — the receiver's own [[Prototype]] chain shadows %Object.prototype%).
+  Own reads always shadow; receivers without a registered ctor link are
+  untouched (lookup returns undefined). Depends on the #3138 call-site
+  registration having linked the instance.
+
+## Verified probes (branch, vs main which yields 0/2/0)
+
+- direct `f.every(cb)` iterates 3 elements with correct values (3066 encode);
+- `Array.prototype.every.call(f, cb)` iterates 3;
+- exact `15.4.4.16-8-10` shape passes;
+- any-receiver controls unchanged: string `indexOf`, array
+  `map`/`reduce`/`every`/`filter`/`lastIndexOf` on `any` all correct.
+
+## Acceptance criteria
+
+- Measured flips (per-file process isolation, fail-on-base/pass-on-branch)
+  in the `built-ins/Array/prototype` applied-to-object family, zero
+  regressions.
+- Controls: any-receiver String/Array method calls unchanged; genuinely
+  TypedArray-typed receivers keep the native path (never reach the `any`
+  fallback).
+
+## Measured result (fable-harvest2, 2026-07-11, branch vs post-#3138 main state)
+
+**+41 genuine flips, 0 regressions** over the 158-file officially-failing
+shape corpus, per-file process isolation both sides (contamination-safe —
+see #3138's methodology caution): every 8, filter 8, map 1, reduce 12,
+reduceRight 12; zero pass→fail / fail→other flips. The corpus now passes
+49/158 (was 8 post-#3138).
+
+Validation: emit-hash corpus **byte-identical** (typed receivers keep native
+paths); 12 adjacent suites green (issue-3014, all issue-2580 array-like
+suites incl. protoextend/any-length/map-arraylike, issue-1712 acorn
+tokenizer sentinels, array equivalence incl. externref-indexOf); any-receiver
+String/Array controls correct (string indexOf, array map/reduce/every/filter/
+lastIndexOf on `any`); tsc clean; new unit suite 5/5 (incl. the no-ctor-link
+plain-struct control: generic loops still see length 0).
+
+Residual in the corpus (~109 fails) is NOT this mechanism: mostly
+`Object.defineProperty(child, …)` attribute setups on the array-like
+(descriptor semantics on fnctor receivers), delete-on-prototype semantics,
+and strict-callback `this` checks — separate causes, none regressed here.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -1081,7 +1081,31 @@ export function tryExternClassMethodOnAny(
   // the `.slice` and `.replace`/`.replaceAll` ambiguity refusals above.
   // (A genuinely-`Uint8ClampedArray`-typed receiver never reaches here — it is
   // handled by the native array-method path before the `any` fallback.)
-  if (methodName === "forEach" || methodName === "some") return null;
+  //
+  // (#3139) Extended to the REST of the Array.prototype iteration/search
+  // generics for the same reason and with the same fallback: the mis-bind is
+  // not merely a standalone leak — `Uint8ClampedArray_every` runs the host
+  // %TypedArray% bridge on a receiver with no [[TypedArrayName]] slot, so a
+  // fnctor-instance array-like (`foo.prototype = new Array(1,2,3); new
+  // foo().every(cb)`, the 15.4.4.x applied-to-object test262 family) silently
+  // iterates ZERO elements. The generic `__extern_method_call` /
+  // `__proto_method_call` paths dispatch on the runtime shape and (post-#3138
+  // + the #3139 prototype-inclusive `__extern_length`/`__extern_get_idx`/
+  // `__extern_has_idx` handlers) resolve inherited length/elements correctly.
+  // `indexOf`/`lastIndexOf` are String∩Array-ambiguous exactly like `.slice`.
+  if (
+    methodName === "forEach" ||
+    methodName === "some" ||
+    methodName === "every" ||
+    methodName === "filter" ||
+    methodName === "map" ||
+    methodName === "reduce" ||
+    methodName === "reduceRight" ||
+    methodName === "indexOf" ||
+    methodName === "lastIndexOf"
+  ) {
+    return null;
+  }
 
   // (#3033) If the program's OWN code defines a function-valued member of this
   // name (prototype-method assignment, function-valued property, object-literal

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9424,6 +9424,16 @@ assert._isSameValue = isSameValue;
                 /* not a field */
               }
             }
+            // (#3139) Inherited `length` through the fnctor instance→ctor
+            // prototype chain (§7.3.2 Get is prototype-inclusive). The classic
+            // shape: `foo.prototype = new Array(1,2,3); var f = new foo();
+            // Array.prototype.every.call(f, cb)` — the compiled array-generic
+            // loop reads the receiver's length via THIS import, and the live
+            // length lives on the Array-valued prototype (the walk's vec arm
+            // serves it). Own reads above always shadow. Requires the #3138
+            // call-site instance→ctor registration to have linked the instance.
+            const pd = _fnctorProtoLookup(obj, "length", exports);
+            if (pd) return toLength(coerceLen(pd.get ? pd.get.call(obj) : pd.value));
             return 0;
           }
           const len = obj.length;
@@ -9474,6 +9484,14 @@ assert._isSameValue = isSameValue;
           const exports = callbackState?.getExports();
           const getter = exports?.[`__sget_${strKey}`];
           if (typeof getter === "function") return getter(obj);
+          // (#3139) Inherited index through the fnctor instance→ctor prototype
+          // chain (`foo.prototype = new Array(11,22,33); new foo()[1]` → 22).
+          // Sits BEFORE the Object.prototype extended-index table below because
+          // the receiver's own [[Prototype]] chain shadows %Object.prototype%.
+          if (_isWasmStruct(obj)) {
+            const pd = _fnctorProtoLookup(obj, strKey, exports);
+            if (pd) return pd.get ? pd.get.call(obj) : pd.value;
+          }
           // (#2580 M3 B-protoextend) Inherited indexed data/accessor on the
           // Object.prototype chain. Reached only after own fields + sidecar +
           // own accessor descriptors miss — so a real array / $Vec / receiver
@@ -9545,6 +9563,10 @@ assert._isSameValue = isSameValue;
               /* getter not defined for this struct variant — fall through */
             }
           }
+          // (#3139) Inherited index through the fnctor instance→ctor prototype
+          // chain (HasProperty §7.3.12 is prototype-inclusive). Before the
+          // Object.prototype table for the same shadowing reason as get_idx.
+          if (_isWasmStruct(obj) && _fnctorProtoLookup(obj, strKey, exports) !== undefined) return 1;
           // (#2580 M3 B-protoextend) Inherited index on the Object.prototype
           // chain. HasProperty (§7.3.12) walks `[[Prototype]]`; an array-like
           // plain-object receiver inherits `Object.prototype[i]`. Presence is

--- a/tests/issue-3139.test.ts
+++ b/tests/issue-3139.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #3139 — Array generics over fnctor-instance array-likes (host lane).
+ *
+ * Two stacked fixes:
+ *  1. `tryExternClassMethodOnAny` refuses the first-match extern bind for the
+ *     Array iteration/search generics (every/filter/map/reduce/reduceRight/
+ *     indexOf/lastIndexOf — extends #3014's forEach/some), so an `any`-typed
+ *     fnctor array-like is no longer hijacked by `Uint8ClampedArray_every`.
+ *  2. `__extern_length` / `__extern_get_idx` / `__extern_has_idx` resolve
+ *     through the #3138 fnctor instance→ctor prototype chain after own-level
+ *     misses, so the generic array loops see the Array-valued prototype's
+ *     live length/elements.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result = await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    deferTopLevelInit: true,
+  });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors.map((e) => e.message).join("; ")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(
+    new Uint8Array(result.binary),
+    imports.env,
+    imports.string_constants,
+    imports.string_constants16,
+  );
+  const ex: any = instance.exports;
+  if (imports.setExports) imports.setExports(ex);
+  const mi = ex.__module_init;
+  if (typeof mi === "function") mi();
+  return ex.test();
+}
+
+describe("#3139 — Array generics over fnctor-instance array-likes", () => {
+  it("direct f.every(cb) iterates the inherited Array prototype elements", async () => {
+    const src = `
+export function test(): number {
+  try {
+    function foo() {}
+    foo.prototype = new Array(11, 22, 33);
+    var f: any = new foo();
+    var seen = 0;
+    var vals = 0;
+    var r = f.every(function(val: any) { seen = seen + 1; vals = vals + val; return true; });
+    return seen * 1000 + vals; // 3 iterations over 11+22+33 -> 3066
+  } catch (e) { return -1; }
+}
+`;
+    await expect(run(src)).resolves.toBe(3066);
+  });
+
+  it("Array.prototype.every.call(f, cb) sees inherited length and elements", async () => {
+    const src = `
+export function test(): number {
+  try {
+    function foo() {}
+    foo.prototype = new Array(11, 22, 33);
+    var f: any = new foo();
+    var seen = 0;
+    Array.prototype.every.call(f, function(val: any) { seen = seen + 1; return true; });
+    return seen; // 3
+  } catch (e) { return -1; }
+}
+`;
+    await expect(run(src)).resolves.toBe(3);
+  });
+
+  it("own length shadows the inherited one (15.4.4.16-8-10 shape)", async () => {
+    const src = `
+export function test(): number {
+  try {
+    foo.prototype = new Array(1, 2, 3);
+    function foo() {}
+    var f: any = new foo();
+    f.length = 2;
+    var i = f.every(function(val: any) { return val <= 2; });
+    return i === true ? 1 : 2;
+  } catch (e) { return -1; }
+}
+`;
+    await expect(run(src)).resolves.toBe(1);
+  });
+
+  it("any-receiver String/Array controls keep their regular paths", async () => {
+    const src = `
+export function test(): number {
+  var s: any = "hello";
+  if (s.indexOf("ll") !== 2) return 1;
+  var a: any = [1, 2, 3];
+  var m = a.map(function(x: any) { return x * 2; });
+  if (m[2] !== 6) return 2;
+  var r = a.reduce(function(acc: any, x: any) { return acc + x; }, 0);
+  if (r !== 6) return 3;
+  if (!a.every(function(x: any) { return x > 0; })) return 4;
+  if (a.filter(function(x: any) { return x > 1; }).length !== 2) return 5;
+  if (a.lastIndexOf(2) !== 1) return 6;
+  return 100;
+}
+`;
+    await expect(run(src)).resolves.toBe(100);
+  });
+
+  it("plain struct receivers without a ctor link are untouched (no spurious inherited reads)", async () => {
+    const src = `
+export function test(): number {
+  try {
+    var o: any = {};
+    // no fnctor link, no length — the generic loop must see length 0
+    var seen = 0;
+    Array.prototype.forEach.call(o, function() { seen = seen + 1; });
+    return seen; // 0
+  } catch (e) { return -1; }
+}
+`;
+    await expect(run(src)).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem (#3139 — follow-on to #3138, the banked "Array-iteration fnctor subclassing" residual)

The test262 applied-to-object family (`built-ins/Array/prototype/{every,filter,map,reduce,reduceRight,…}/15.4.4.x-*`):

```js
foo.prototype = new Array(11, 22, 33);
function foo() {}
var f = new foo();
f.every(cb);                        // direct form — iterates ZERO elements
Array.prototype.every.call(f, cb);  // .call form — iterates ZERO elements
```

Post-#3138 the instance→ctor link exists and `f[1]`/`f.length` MOP reads resolve — but the iteration methods still saw an empty receiver, for two stacked WAT-verified causes:

1. **Direct form**: `tryExternClassMethodOnAny` (calls-closures.ts) first-match binds the `any`-typed receiver's `.every` to **`Uint8ClampedArray_every`** — the %TypedArray% bridge, which iterates zero elements on a receiver without a [[TypedArrayName]] slot. Exactly the #3014 `forEach`/`some` hazard; the refusal list didn't cover the other generics.
2. **.call form**: the compiled generic array loop reads the receiver via `__extern_length`/`__extern_get_idx`/`__extern_has_idx`, which stopped at own-level reads (sidecar + `__sget_*`) and returned 0/undefined — never walking the fnctor prototype chain (§7.3.2 Get / §7.3.12 HasProperty are prototype-inclusive), where the Array-valued prototype's live length/elements are served by the #3116 vec arm.

## Fix

- **calls-closures.ts**: extend the #3014 refusal list with `every/filter/map/reduce/reduceRight/indexOf/lastIndexOf` (the `indexOf` pair is String∩Array-ambiguous exactly like the #1062 `.slice` refusal). Fall-through dispatches on runtime shape — correct for TypedArrays, arrays, strings AND fnctor array-likes.
- **runtime.ts**: the three handlers resolve through `_fnctorProtoLookup` after every own-level probe misses, BEFORE the #2580 Object.prototype extended-index table (the receiver's own [[Prototype]] chain shadows %Object.prototype%). Receivers without a ctor link are untouched.

## Measured (per-file PROCESS-ISOLATED, branch vs post-#3138 main state)

**+41 genuine flips, 0 regressions** over the 158-file officially-failing shape corpus: every 8, filter 8, map 1, reduce 12, reduceRight 12. Corpus passes 49/158 (was 8).

Validation: emit-hash corpus **byte-identical** (typed receivers keep native paths); 12 adjacent suites green (issue-3014, all issue-2580 array-like suites, issue-1712 acorn tokenizer sentinels, array equivalence incl. externref-indexOf); any-receiver String/Array controls correct; tsc clean; new unit suite 5/5 including the no-ctor-link plain-struct control (generic loops still see length 0).

`loc-budget-allow` granted in the issue frontmatter for runtime.ts (+22 — the fall-throughs must live inside the handlers they amend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS