### PR TITLE
feat(#3140): standalone native Function.prototype.bind — $__bound_fn carrier

### DIFF
--- a/plan/issues/3140-standalone-closure-bind-non-callable.md
+++ b/plan/issues/3140-standalone-closure-bind-non-callable.md
@@ -1,8 +1,11 @@
 ---
 id: 3140
 title: "Standalone: Function.prototype.bind on a closure returns a non-callable — blocks the entire modern test262 TypedArray harness (makeCtorArg)"
-status: ready
+status: done
+completed: 2026-07-11
+assignee: ttraenkler/fable-harvest3
 created: 2026-07-11
+updated: 2026-07-11
 priority: high
 task_type: bug
 area: codegen, runtime
@@ -12,8 +15,57 @@ sprint: current
 horizon: m
 related: [2872, 2860, 2876, 3016]
 umbrella: 2860
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
+  - src/codegen/object-runtime.ts
+  - src/codegen/index.ts
+  - src/codegen/registry/types.ts
+  - src/codegen/closure-classifier.ts
+  - src/codegen/context/types.ts
+  - src/codegen/context/create-context.ts
 origin: "2026-07-11 — discovered by fable-harvest3 during #2872 slice 1 (dynamic TA construction): every makeCtorArg-style TypedArray test fails at the HARNESS level because argFactory.bind(undefined, constructor) is not callable"
 ---
+
+## Implemented (2026-07-11, fable-harvest3)
+
+**Root cause (two layers):** (a) the typed `compileFunctionBind` route degraded
+to *identity-bind* under standalone (returned the target, DROPPED partial
+args — the #1632a documented gap); (b) an `any`-typed receiver (`argFactory`
+is an array element — no TS call signatures) never routed there at all: it fell
+to the open-object dispatcher arm and returned `undefined`.
+
+**Fix — native `$__bound_fn {target, thisArg, boundArgs}` carrier:**
+
+1. `getOrRegisterBoundFnType` (registry/types.ts), memoized on
+   `ctx.boundFnTypeIdx`; byte-inert for bind-free modules.
+2. `compileFunctionBind` standalone arm mints the carrier (spec §20.2.3.2
+   evaluation order: target → thisArg → partials, each once).
+3. Any-receiver `.bind` routes through **reserve-then-fill `__bind_dyn`**
+   (object-runtime.ts): the callable gate needs the COMPLETE closure-classifier
+   root list, only settled at finalize (#1896 hazard) — callable → mint;
+   anything else → the legacy `__extern_method_call(recv, "bind", args)` route
+   (undefined), so non-callables keep prior behavior.
+4. `fillApplyClosure` gains a `$__bound_fn` front-guard (the #3031 $Proxy
+   ladder pattern): unwraps ONE bound layer per hop — merged = boundArgs ++
+   args, [[BoundThis]] wins over the caller receiver (§10.4.1.1), recursion on
+   the target composes bound-of-bound.
+5. `tryEmitInlineDynamicCall` (bare `bound(...)` calls) gains an unwrap arm,
+   pre-scanned via `sourceHasBindCall` for compile-order independence.
+6. The closure classifier counts the carrier callable → `typeof bound ===
+   "function"`, `__is_closure`, typeof-object exclusion — one predicate, all
+   consumers.
+
+**Measured (standalone lane, local scans vs pre-fix):**
+`built-ins/Function/prototype/bind`: 16 → 27 pass (**+14 / −3**; the 3 flips
+are `Object.defineProperty`-on-the-carrier tests that previously passed by the
+identity-bind accident). `built-ins/TypedArray/prototype`: unchanged — the
+harness's NEXT gate is `Array.from({length}, fn)` / `Array.from(iterable)`
+(leaks `__make_callback` / `__array_from`), which is the follow-up lever.
+
+**Residuals (follow-ups):** bound-fn `.length`/`.name` fidelity (carrier
+reports arity 0); `Object.defineProperty` on a bound fn; `new bound(...)`
+[[Construct]]; the `Array.from` mapper/iterable standalone gap (blocks the
+makeCtorArg family — next slice of the #2872/#2860 line).
 
 # Standalone: `fn.bind(...)` on a closure is not callable
 

--- a/plan/issues/3140-standalone-closure-bind-non-callable.md
+++ b/plan/issues/3140-standalone-closure-bind-non-callable.md
@@ -64,8 +64,50 @@ harness's NEXT gate is `Array.from({length}, fn)` / `Array.from(iterable)`
 
 **Residuals (follow-ups):** bound-fn `.length`/`.name` fidelity (carrier
 reports arity 0); `Object.defineProperty` on a bound fn; `new bound(...)`
-[[Construct]]; the `Array.from` mapper/iterable standalone gap (blocks the
-makeCtorArg family — next slice of the #2872/#2860 line).
+[[Construct]]; the `Array.from` standalone gap below.
+
+## Banked intel — the NEXT rock on this line: `Array.from` standalone (per lead throttle, 2026-07-11)
+
+Deliberately NOT started this budget window (lead directive). Verified probe
+(mini repro, current main + this fix):
+
+```ts
+// leaks env::__make_callback + env::__array_from → instantiation failure
+function makeArray(TA: any, x: any) {
+  if (isPrimitive(x)) {
+    var n = Number(x);
+    if (!(n >= 0 && n < 9007199254740992)) return x;
+    return Array.from({ length: n }, function () { return "0"; }); // ← __make_callback
+  }
+  return Array.from(x); // ← __array_from
+}
+```
+
+- This is the test262 harness `makeArray`/`makeArrayLike`/`makeIterable`/
+  `makeArrayBuffer` COMMON PREFIX (`harness/testTypedArray.js`) — with #2872
+  slice 1 (dynamic TA construction, PR #2881) and this bind fix (PR #2884)
+  landed, `Array.from` is the LAST harness-level gate before the whole
+  makeCtorArg-style `built-ins/TypedArray/prototype/**` family (hundreds of
+  files) can execute their bodies. Highest-multiplier next slice.
+- Two distinct shapes to fix (both leak on the default `Array.from` call
+  path in calls.ts):
+  1. `Array.from(arrayLikeOrIterable)` — 1-arg → leaks `env::__array_from`.
+     A native `__array_from_iter_n` ALREADY exists (#2904/#3100 S4,
+     `ensureNativeArrayFromIterN`, iterator-native.ts) and `ensureLateImport`
+     routes `__array_from_iter_n` to it under noJsHost — the 1-arg
+     `Array.from` call site just doesn't route through it for all shapes.
+  2. `Array.from(x, mapFn)` — mapper → leaks `env::__make_callback` (host
+     closure bridge). Standalone should invoke the mapper via
+     `__apply_closure` (the same native bridge #3140's bound-fn guard and the
+     HOF arms use — see `NATIVE_HOF_METHODS`/`ensureNativeArrayHof` for the
+     established per-element callback pattern).
+- Array-like sources (`{length, 0: …}`) can reuse the `__extern_length` +
+  `__extern_get_idx` walk (#2872's array-like construct arm is the template).
+- Measure guide: `built-ins/TypedArray/prototype/fill` standalone was 46
+  fail / 5 pass after PR #2881+#2884; the makeCtorArg tests fail at
+  `assert #1` with the factory loop dying inside `makeArray`. Post-fix,
+  expect the passthrough/array/arraylike factory combinations to execute —
+  re-scan `built-ins/TypedArray/prototype` + `built-ins/Array/from`.
 
 # Standalone: `fn.bind(...)` on a closure is not callable
 

--- a/src/codegen/closure-classifier.ts
+++ b/src/codegen/closure-classifier.ts
@@ -60,6 +60,14 @@ export function collectClosureBaseWrapperTypeIdxs(ctx: CodegenContext): number[]
       baseTypeIdxs.push(root);
     }
   }
+  // (#3140) The native bound-function carrier (`$__bound_fn`, minted by a
+  // standalone `Function.prototype.bind` site) is callable: it must classify
+  // as `"function"` (typeof / __is_closure / the `.length` arity read) exactly
+  // like a closure wrapper. Registered lazily — absent (-1) in bind-free
+  // modules, so those stay byte-identical.
+  if (ctx.boundFnTypeIdx >= 0 && !seenBase.has(ctx.boundFnTypeIdx)) {
+    baseTypeIdxs.push(ctx.boundFnTypeIdx);
+  }
   return baseTypeIdxs;
 }
 

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -201,6 +201,7 @@ export function createCodegenContext(
     taCtorTypeIdx: -1, // (#3054 D) $__ta_ctor {kind:i32} first-class TA constructor value, lazy
     taCtorSingletonGlobals: new Map(), // (#3054 D) per-kind boxed $__ta_ctor singleton module-globals
     taDynViewTypeIdx: -1, // (#3054 D) $__ta_dyn_view {length,buf,byteOffset,kind} runtime-kinded view, lazy
+    boundFnTypeIdx: -1, // (#3140) $__bound_fn {target,thisArg,boundArgs} native bound-function carrier, lazy
     moduleUsesDynTaView: false, // (#3057) set by pre-scan when a dynamic `new ctorVar(buf)` exists
     errorStructTypeIdx: -1,
     widenedTypeProperties: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1930,6 +1930,17 @@ export interface CodegenContext {
    */
   taDynViewTypeIdx: number;
   /**
+   * (#3140) Type index for `$__bound_fn` — the standalone/WASI native
+   * bound-function carrier minted by `Function.prototype.bind`:
+   * `{target: externref, thisArg: externref, boundArgs: externref ($ObjVec)}`.
+   * `__apply_closure` carries a front-guard that unwraps it (prepending
+   * `boundArgs`) and the closure classifier treats it as callable, so
+   * `typeof bound === "function"` and bound-of-bound chains work. Registered
+   * late+once; -1 = not yet registered. Byte-inert: only emitted when a
+   * standalone `.bind(...)` site compiles.
+   */
+  boundFnTypeIdx: number;
+  /**
    * (#3057) Set by a module pre-scan when the source contains a dynamic
    * `new <ctorVar>(bufferArg)` (a `$__ta_dyn_view`-producing construct). Enables the
    * runtime-kind element byte-codec arm on the generic dynamic index path (`ta[i]` /

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -29,7 +29,13 @@ import { ensureNativeIteratorRuntime } from "../iterator-native.js"; // (#2169c)
 import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "../closed-method-dispatch.js";
 import { emitNativeDateParse } from "../date-parse-native.js"; // (#2164) pure-Wasm Date.parse / new Date(str)
 import { NATIVE_HOF_METHODS } from "../hof-native.js";
-import { ensureObjVecBuilders, ensureObjectGroupBy, ensureObjectRuntime } from "../object-runtime.js";
+import {
+  ensureObjVecBuilders,
+  ensureObjectGroupBy,
+  ensureObjectRuntime,
+  reserveApplyClosure,
+  reserveBindDynHelper,
+} from "../object-runtime.js";
 import {
   emitMicrotaskEnqueue,
   emitStandalonePromiseReject,
@@ -76,6 +82,7 @@ import {
   ensureExnTag,
   ensureI32Condition,
   getArrTypeIdxFromVec,
+  getOrRegisterBoundFnType,
   getOrRegisterRefCellType,
   getOrRegisterVecType,
   hoistLetConstWithTdz,
@@ -432,6 +439,36 @@ function receiverMayBeProxy(ctx: CodegenContext, argExpr: ts.Expression): boolea
  * (`project_proxy_no_ts_type_brand`), so the gate is syntactic by design.
  */
 const sourceCreatesProxyCache = new WeakMap<ts.SourceFile, boolean>();
+
+/**
+ * (#3140) True when the source contains any `<expr>.bind(...)` call — a
+ * `$__bound_fn` carrier may then exist at runtime, so the dynamic-call
+ * dispatch must carry the unwrap arm even when the bind SITE compiles after
+ * this call site (compile-order independence; mirrors `sourceCreatesProxy`).
+ */
+const sourceHasBindCallCache = new WeakMap<ts.SourceFile, boolean>();
+function sourceHasBindCall(sf: ts.SourceFile): boolean {
+  const cached = sourceHasBindCallCache.get(sf);
+  if (cached !== undefined) return cached;
+  let found = false;
+  if (sf.text.includes(".bind(")) {
+    const visit = (node: ts.Node): void => {
+      if (found) return;
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "bind"
+      ) {
+        found = true;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  sourceHasBindCallCache.set(sf, found);
+  return found;
+}
 function sourceCreatesProxy(sf: ts.SourceFile): boolean {
   const cached = sourceCreatesProxyCache.get(sf);
   if (cached !== undefined) return cached;
@@ -1859,6 +1896,48 @@ function countSpecLength(params: ts.NodeArray<ts.ParameterDeclaration>): number 
  * receiver returns null (e.g. unresolvable identifier); callers retain the
  * old "throws on missing receiver" behaviour in that case.
  */
+/**
+ * (#3140) Mint a native `$__bound_fn` value from PRE-EVALUATED externref
+ * locals: `{target, thisArg, boundArgs}` where `boundArgs` is a fresh `$ObjVec`
+ * of the partial-application args. Leaves the boxed externref on the stack.
+ * The carrier is unwrapped by the `__apply_closure` front-guard (boundArgs
+ * prepended, recursion on target — bound-of-bound composes) and classified
+ * callable by `closure-classifier.ts` (`typeof bound === "function"`).
+ * Standalone/WASI lane only (the $ObjVec builders are the native ones).
+ */
+function emitBoundFnValueFromLocals(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  targetLocal: number,
+  thisArgLocal: number | undefined,
+  partialArgLocals: readonly number[],
+): void {
+  const { newIdx: objVecNewIdx, pushIdx: objVecPushIdx } = ensureObjVecBuilders(ctx);
+  // Reserve the closure bridge so `fillApplyClosure` (which carries the
+  // $__bound_fn unwrap front-guard) is guaranteed to run for this module even
+  // when the bind result is never visibly called from compiled code paths that
+  // would otherwise reserve it.
+  reserveApplyClosure(ctx);
+  const bfIdx = getOrRegisterBoundFnType(ctx);
+  fctx.body.push({ op: "local.get", index: targetLocal });
+  if (thisArgLocal !== undefined) {
+    fctx.body.push({ op: "local.get", index: thisArgLocal });
+  } else {
+    fctx.body.push({ op: "ref.null.extern" });
+  }
+  const argsVecLocal = allocLocal(fctx, `__bindfn_args_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "call", funcIdx: objVecNewIdx });
+  fctx.body.push({ op: "local.set", index: argsVecLocal });
+  for (const aLocal of partialArgLocals) {
+    fctx.body.push({ op: "local.get", index: argsVecLocal });
+    fctx.body.push({ op: "local.get", index: aLocal });
+    fctx.body.push({ op: "call", funcIdx: objVecPushIdx });
+  }
+  fctx.body.push({ op: "local.get", index: argsVecLocal });
+  fctx.body.push({ op: "struct.new", typeIdx: bfIdx } as Instr);
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+}
+
 function compileFunctionBind(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1868,19 +1947,36 @@ function compileFunctionBind(
   const externRef: ValType = { kind: "externref" };
   const i32Ty: ValType = { kind: "i32" };
 
-  // Standalone (--target wasi / noJsHost): no JS host → identity-bind degraded.
-  // Drop partial args, push the receiver as externref, return it unchanged.
+  // (#3140) Standalone (--target wasi / noJsHost): no JS host — mint the native
+  // `$__bound_fn` carrier {target, thisArg, boundArgs}. Replaces the #1632a
+  // identity-bind degrade (which DROPPED the partial args, so the test262
+  // TypedArray harness `argFactory.bind(undefined, constructor)` lost the bound
+  // ctor and every makeCtorArg-style test failed at the harness level).
+  // Evaluation order per §20.2.3.2: target (receiver), then thisArg, then
+  // partials — each exactly once, into externref locals.
   if (ctx.standalone || noJsHost(ctx)) {
-    for (const arg of expr.arguments) {
-      const t = compileExpression(ctx, fctx, arg);
-      if (t !== null) fctx.body.push({ op: "drop" });
-    }
     const recvType = compileExpression(ctx, fctx, propAccess.expression, externRef);
     if (recvType === null) {
       fctx.body.push({ op: "ref.null.extern" });
     } else if (recvType.kind !== "externref") {
-      fctx.body.push({ op: "extern.convert_any" });
+      coerceType(ctx, fctx, recvType, externRef);
     }
+    const targetLocal = allocLocal(fctx, `__bindfn_tgt_${fctx.locals.length}`, externRef);
+    fctx.body.push({ op: "local.set", index: targetLocal });
+    const argLocals: number[] = [];
+    for (const arg of expr.arguments) {
+      const src = ts.isSpreadElement(arg) ? arg.expression : arg;
+      const t = compileExpression(ctx, fctx, src, externRef);
+      if (t === null) {
+        fctx.body.push({ op: "ref.null.extern" });
+      } else if (t.kind !== "externref") {
+        coerceType(ctx, fctx, t, externRef);
+      }
+      const aLocal = allocLocal(fctx, `__bindfn_arg_${fctx.locals.length}`, externRef);
+      fctx.body.push({ op: "local.set", index: aLocal });
+      argLocals.push(aLocal);
+    }
+    emitBoundFnValueFromLocals(ctx, fctx, targetLocal, argLocals[0], argLocals.slice(1));
     return externRef;
   }
 
@@ -3150,7 +3246,13 @@ function tryEmitInlineDynamicCall(
   // K1 inbound-marshalling keystone, not this dispatch.
   const wantProxyArm =
     ctx.standalone === true && (ctx.funcMap.has("__proxy_create") || sourceCreatesProxy(expr.getSourceFile()));
-  if (allCandidates.length === 0 && !wantProxyArm) return null;
+  // (#3140) A `$__bound_fn` (native Function.prototype.bind carrier) may reach a
+  // bare dynamic call (`bound(...)`) — add an unwrap arm when a bind site minted
+  // the carrier in this module.
+  const wantBoundArm =
+    (ctx.standalone === true || ctx.wasi === true) &&
+    (ctx.boundFnTypeIdx >= 0 || sourceHasBindCall(expr.getSourceFile()));
+  if (allCandidates.length === 0 && !wantProxyArm && !wantBoundArm) return null;
 
   // Dedupe by funcTypeIdx — concrete subtypes share funcTypeIdx with their
   // base wrapper; one dispatch arm per unique funcref type is enough.
@@ -3251,7 +3353,22 @@ function tryEmitInlineDynamicCall(
       proxyArm = { proxyTypeIdx, dispatchIdx, vecNewIdx: vecBuilders.newIdx, vecPushIdx: vecBuilders.pushIdx };
     }
   }
-  if (candidates.length === 0 && proxyArm === undefined) return null;
+  // (#3140) Bound-function [[Call]] arm pieces — same DEFINED-only invariant as
+  // the proxy pieces above (reserveApplyClosure mints a defined placeholder).
+  let boundArm: { bfTypeIdx: number; applyIdx: number; vecNewIdx: number; vecPushIdx: number } | undefined;
+  if (wantBoundArm) {
+    const vecBuilders = ensureObjVecBuilders(ctx);
+    const applyIdx = reserveApplyClosure(ctx);
+    boundArm = {
+      // Register on demand — the bind SITE may compile after this call site
+      // (the pre-scan `sourceHasBindCall` covers that order).
+      bfTypeIdx: getOrRegisterBoundFnType(ctx),
+      applyIdx,
+      vecNewIdx: vecBuilders.newIdx,
+      vecPushIdx: vecBuilders.pushIdx,
+    };
+  }
+  if (candidates.length === 0 && proxyArm === undefined && boundArm === undefined) return null;
 
   // Compile callee (externref) → anyref → temp local.
   const calleeType = compileExpression(ctx, fctx, expr.expression);
@@ -3415,6 +3532,39 @@ function tryEmitInlineDynamicCall(
     dispatch = [
       { op: "local.get", index: anyLocal } as Instr,
       { op: "ref.test", typeIdx: proxyArm.proxyTypeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: armBody,
+        else: dispatch,
+      } as Instr,
+    ];
+  }
+
+  // (#3140) Bound-function [[Call]] arm: `bound(...)` where `bound` is a
+  // `$__bound_fn` minted by a standalone `.bind(...)` site. Pack the args into
+  // a `$ObjVec` and route through `__apply_closure`, whose fill-time front
+  // guard unwraps the carrier (prepends [[BoundArguments]], applies
+  // [[BoundThis]], recurses on the target — bound-of-bound composes).
+  if (boundArm !== undefined) {
+    const vecLocal = allocLocal(fctx, `__dyn_bargs_${fctx.locals.length}`, { kind: "externref" });
+    const armBody: Instr[] = [
+      { op: "call", funcIdx: boundArm.vecNewIdx } as Instr,
+      { op: "local.set", index: vecLocal } as Instr,
+    ];
+    for (const argLocal of argLocals) {
+      armBody.push({ op: "local.get", index: vecLocal } as Instr);
+      armBody.push({ op: "local.get", index: argLocal } as Instr);
+      armBody.push({ op: "call", funcIdx: boundArm.vecPushIdx } as Instr);
+    }
+    armBody.push({ op: "local.get", index: anyLocal } as Instr);
+    armBody.push({ op: "extern.convert_any" } as Instr);
+    armBody.push({ op: "ref.null.extern" } as Instr); // recv — [[BoundThis]] wins in the guard
+    armBody.push({ op: "local.get", index: vecLocal } as Instr);
+    armBody.push({ op: "call", funcIdx: boundArm.applyIdx } as Instr);
+    dispatch = [
+      { op: "local.get", index: anyLocal } as Instr,
+      { op: "ref.test", typeIdx: boundArm.bfTypeIdx } as Instr,
       {
         op: "if",
         blockType: { kind: "val", type: { kind: "externref" } },
@@ -12863,6 +13013,51 @@ function compileCallExpression(
               then: thenArm,
               else: elseArm,
             } as Instr);
+            return { kind: "externref" };
+          }
+          // (#3140) `.bind` on an `any`-typed receiver that is a CLOSURE at
+          // RUNTIME — the test262 TypedArray harness shape
+          // (`argFactory.bind(undefined, constructor)` where `argFactory` is an
+          // array element). The typed `compileFunctionBind` route requires TS
+          // call signatures, so an `any` receiver fell to the open-object
+          // dispatcher arm and returned undefined (a non-callable — every
+          // makeCtorArg-style test then failed at the harness level). Emit the
+          // closure-classifier runtime arms: a callable receiver mints the
+          // native `$__bound_fn` carrier; anything else keeps the EXACT
+          // dispatcher path (closed-struct `bind` methods, open objects).
+          if (methodName === "bind" && (ctx.standalone || ctx.wasi)) {
+            // Reserve-then-fill (#1719 discipline): the callable test needs the
+            // COMPLETE closure-classifier root list, which is only settled at
+            // finalize — baking `buildClosureRefTestArms` here would miss every
+            // closure registered after this call site compiles (#1896's exact
+            // hazard). `__bind_dyn(recv, argsVec)` is filled by
+            // `fillBindDynHelper`: callable → mint `$__bound_fn`; anything else
+            // → the open-object `__extern_method_call(recv, "bind", args)`
+            // legacy route (undefined), preserving prior behavior.
+            const bindDynIdx = reserveBindDynHelper(ctx);
+            flushLateImportShifts(ctx, fctx);
+            const recvT = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+            if (recvT && recvT.kind !== "externref") {
+              coerceType(ctx, fctx, recvT, { kind: "externref" });
+            } else if (recvT === null) {
+              fctx.body.push({ op: "ref.null.extern" });
+            }
+            const recvLocal = allocLocal(fctx, `__bindany_recv_${fctx.locals.length}`, { kind: "externref" });
+            fctx.body.push({ op: "local.set", index: recvLocal });
+            const { newIdx: bvNewIdx, pushIdx: bvPushIdx } = ensureObjVecBuilders(ctx);
+            const vecLocal = allocLocal(fctx, `__bindany_vec_${fctx.locals.length}`, { kind: "externref" });
+            fctx.body.push({ op: "call", funcIdx: bvNewIdx });
+            fctx.body.push({ op: "local.set", index: vecLocal });
+            for (const arg of dispatchArgs) {
+              fctx.body.push({ op: "local.get", index: vecLocal });
+              const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
+              if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+              else if (at === null) fctx.body.push({ op: "ref.null.extern" });
+              fctx.body.push({ op: "call", funcIdx: bvPushIdx });
+            }
+            fctx.body.push({ op: "local.get", index: recvLocal });
+            fctx.body.push({ op: "local.get", index: vecLocal });
+            fctx.body.push({ op: "call", funcIdx: bindDynIdx });
             return { kind: "externref" };
           }
           // Receiver as externref.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -65,6 +65,7 @@ import { fillProtoIteratorDriver } from "./expressions/proto-override.js";
 import { fillAccessorDrivers } from "./accessor-driver.js";
 import {
   fillApplyClosure,
+  fillBindDynHelper,
   fillBuiltinFnMeta,
   fillExternGetIdxVecArms,
   fillExternIsArray,
@@ -2473,6 +2474,11 @@ export function generateModule(
     // `__call_fn_method_0..4` are registered. No-op when no standalone open-any
     // method-dispatch site reserved the bridge (`ctx.applyClosureReserved`).
     fillApplyClosure(ctx);
+
+    // (#3140) Fill the reserved `__bind_dyn` dynamic-bind helper now that every
+    // closure root is registered (the callable gate needs the COMPLETE
+    // classifier list). No-op when no standalone `.bind`-on-any site reserved it.
+    fillBindDynHelper(ctx);
 
     // (#1100) Fill the reserved standalone Proxy trap-invoke drivers
     // (`__proxy_call_{get,set,has}`) now that `__call_fn_method_2/3/4` are
@@ -15418,6 +15424,7 @@ export {
   addFuncType,
   getArrTypeIdxFromVec,
   getOrRegisterArrayType,
+  getOrRegisterBoundFnType,
   getOrRegisterRefCellType,
   getOrRegisterResizableAbType,
   getOrRegisterTemplateVecType,

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -67,7 +67,13 @@ import {
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
-import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecBaseType } from "./registry/types.js";
+import {
+  addFuncType,
+  getArrTypeIdxFromVec,
+  getOrRegisterBoundFnType,
+  getOrRegisterVecBaseType,
+} from "./registry/types.js";
+import { buildClosureRefTestArms } from "./closure-classifier.js"; // (#3140) __bind_dyn callable gate
 import { addUnionImportsViaRegistry, flushLateImportShifts } from "./shared.js";
 import { reserveAccessorGetDriver, reserveAccessorSetDriver } from "./accessor-driver.js";
 import { ensureSymbolCarrier } from "./symbol-native.js";
@@ -9038,8 +9044,252 @@ export function fillApplyClosure(ctx: CodegenContext): void {
     );
   }
 
+  const locals: { name: string; type: ValType }[] = [{ name: "n", type: { kind: "i32" } }];
+
+  // (#3140) $__bound_fn front-guard — the same ladder-step pattern as the $Proxy
+  // guard above, for the native bound-function carrier `{target, thisArg,
+  // boundArgs}` minted by a standalone `Function.prototype.bind` site. Unwrap
+  // ONE bound layer per hop: merged = boundArgs ++ args, then recurse into this
+  // bridge with (target, boundThis, merged) — [[BoundThis]] wins over the
+  // caller-provided receiver (§10.4.1.1), and bound-of-bound chains compose one
+  // guard hop at a time. Guard not emitted when no bind site minted the carrier
+  // (`ctx.boundFnTypeIdx < 0`) — byte-identical for bind-free modules.
+  const objVecNewIdx2 = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx2 = ctx.funcMap.get("__objvec_push");
+  if (ctx.boundFnTypeIdx >= 0 && objVecNewIdx2 !== undefined && objVecPushIdx2 !== undefined) {
+    const bfIdx = ctx.boundFnTypeIdx;
+    // Locals appended after `n` (params fn/recv/args = 0..2, n = 3): bf=4,
+    // merged=5, bsrc=6, bk=7, blen=8.
+    const bfLocal = 3 + locals.length; // params(3) + existing locals ([n]) → 4
+    const mergedLocal = bfLocal + 1;
+    const srcLocal = bfLocal + 2;
+    const kLocal = bfLocal + 3;
+    const lenLocal = bfLocal + 4;
+    locals.push(
+      { name: "bf", type: { kind: "ref_null", typeIdx: bfIdx } },
+      { name: "merged", type: { kind: "externref" } },
+      { name: "bsrc", type: { kind: "externref" } },
+      { name: "bk", type: { kind: "f64" } },
+      { name: "blen", type: { kind: "f64" } },
+    );
+    // for (k = 0; k < len(src); k++) objvec_push(merged, get_idx(src, k))
+    const copyLoop = (): Instr[] => {
+      const loopBody: Instr[] = [
+        { op: "local.get", index: kLocal } as Instr,
+        { op: "local.get", index: lenLocal } as Instr,
+        { op: "f64.ge" } as Instr,
+        { op: "br_if", depth: 1 } as Instr,
+        { op: "local.get", index: mergedLocal } as Instr,
+        { op: "local.get", index: srcLocal } as Instr,
+        { op: "local.get", index: kLocal } as Instr,
+        { op: "call", funcIdx: externGetIdxArr } as Instr,
+        { op: "call", funcIdx: objVecPushIdx2 } as Instr,
+        { op: "local.get", index: kLocal } as Instr,
+        { op: "f64.const", value: 1 } as Instr,
+        { op: "f64.add" } as Instr,
+        { op: "local.set", index: kLocal } as Instr,
+        { op: "br", depth: 0 } as Instr,
+      ];
+      return [
+        { op: "local.get", index: srcLocal } as Instr,
+        { op: "call", funcIdx: externLengthIdx } as Instr,
+        { op: "local.set", index: lenLocal } as Instr,
+        { op: "f64.const", value: 0 } as Instr,
+        { op: "local.set", index: kLocal } as Instr,
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+        } as Instr,
+      ];
+    };
+    body.unshift(
+      { op: "local.get", index: 0 } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.test", typeIdx: bfIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 } as Instr,
+          { op: "any.convert_extern" } as Instr,
+          { op: "ref.cast", typeIdx: bfIdx } as Instr,
+          { op: "local.set", index: bfLocal } as Instr,
+          // merged = objvec_new()
+          { op: "call", funcIdx: objVecNewIdx2 } as Instr,
+          { op: "local.set", index: mergedLocal } as Instr,
+          // copy boundArgs then call-args
+          { op: "local.get", index: bfLocal } as Instr,
+          { op: "struct.get", typeIdx: bfIdx, fieldIdx: 2 } as Instr,
+          { op: "local.set", index: srcLocal } as Instr,
+          ...copyLoop(),
+          { op: "local.get", index: 2 } as Instr,
+          { op: "local.set", index: srcLocal } as Instr,
+          ...copyLoop(),
+          // return __apply_closure(target, boundThis, merged)  [self-recursion]
+          { op: "local.get", index: bfLocal } as Instr,
+          { op: "struct.get", typeIdx: bfIdx, fieldIdx: 0 } as Instr,
+          { op: "local.get", index: bfLocal } as Instr,
+          { op: "struct.get", typeIdx: bfIdx, fieldIdx: 1 } as Instr,
+          { op: "local.get", index: mergedLocal } as Instr,
+          { op: "call", funcIdx: bridgeIdx } as Instr,
+          { op: "return" } as Instr,
+        ],
+      } as Instr,
+    );
+  }
+
   bridgeFn.body = body;
-  bridgeFn.locals = [{ name: "n", type: { kind: "i32" } }];
+  bridgeFn.locals = locals;
+}
+
+/**
+ * (#3140) Reserve `__bind_dyn(recv, argsVec) → externref` — the dynamic
+ * `Function.prototype.bind` route for an `any`-typed receiver (the test262
+ * TypedArray harness `argFactory.bind(undefined, constructor)` shape, where
+ * `argFactory` carries no TS call signatures so the typed `compileFunctionBind`
+ * route never fires). Reserve-then-fill (#1719): the body needs the COMPLETE
+ * closure-classifier root list, which is only settled at finalize —
+ * {@link fillBindDynHelper} fills it there. `argsVec` is a `$ObjVec` of
+ * `[thisArg, ...partialArgs]` built at the call site.
+ */
+export function reserveBindDynHelper(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__bind_dyn");
+  if (existing !== undefined) return existing;
+  ensureObjectRuntime(ctx); // __extern_method_call / __extern_get_idx / __extern_length + $ObjVec
+  ensureObjVecBuilders(ctx);
+  reserveApplyClosure(ctx); // the unwrap front-guard lives in fillApplyClosure
+  getOrRegisterBoundFnType(ctx);
+  addStringConstantGlobal(ctx, "bind"); // the fill's legacy-fallback method name
+  const externref: ValType = { kind: "externref" };
+  const typeIdx = addFuncType(ctx, [externref, externref], [externref]);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: "__bind_dyn",
+    typeIdx,
+    locals: [],
+    // Placeholder — filled at finalize by fillBindDynHelper. `unreachable`
+    // keeps the stub valid if the fill were ever skipped.
+    body: [{ op: "unreachable" } as Instr],
+    exported: false,
+  });
+  ctx.funcMap.set("__bind_dyn", funcIdx);
+  return funcIdx;
+}
+
+/**
+ * (#3140) Fill `__bind_dyn` at FINALIZE (closure roots settled):
+ *
+ *   any = any.convert_extern(recv)
+ *   if <recv is a callable — closure-classifier roots (incl. $__bound_fn)>:
+ *     thisArg  = __extern_get_idx(args, 0)          // absent → undefined/null
+ *     bound    = fresh $ObjVec of args[1..]
+ *     return extern($__bound_fn{recv, thisArg, bound})
+ *   return __extern_method_call(recv, "bind", args)  // legacy open-object route
+ */
+export function fillBindDynHelper(ctx: CodegenContext): void {
+  const helperIdx = ctx.funcMap.get("__bind_dyn");
+  if (helperIdx === undefined) return;
+  const helperFn = definedFuncAt(ctx, helperIdx);
+  if (!helperFn) return;
+  const bfIdx = ctx.boundFnTypeIdx;
+  const externLengthIdx = ctx.funcMap.get("__extern_length");
+  const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx");
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  const methodCallIdx = ctx.funcMap.get("__extern_method_call");
+  if (
+    bfIdx < 0 ||
+    externLengthIdx === undefined ||
+    externGetIdxIdx === undefined ||
+    objVecNewIdx === undefined ||
+    objVecPushIdx === undefined
+  ) {
+    helperFn.body = [{ op: "ref.null.extern" } as Instr];
+    helperFn.locals = [];
+    return;
+  }
+
+  // params: recv=0, args=1; locals: any=2 (anyref), thisv=3, bargs=4 (externref),
+  // k=5, len=6 (f64).
+  const ANY = 2;
+  const THISV = 3;
+  const BARGS = 4;
+  const K = 5;
+  const LEN = 6;
+  const mintArm: Instr[] = [
+    // thisArg = args[0]
+    { op: "local.get", index: 1 } as Instr,
+    { op: "f64.const", value: 0 } as Instr,
+    { op: "call", funcIdx: externGetIdxIdx } as Instr,
+    { op: "local.set", index: THISV } as Instr,
+    // bound = objvec_new(); for (k=1; k<len; k++) push(bound, args[k])
+    { op: "call", funcIdx: objVecNewIdx } as Instr,
+    { op: "local.set", index: BARGS } as Instr,
+    { op: "local.get", index: 1 } as Instr,
+    { op: "call", funcIdx: externLengthIdx } as Instr,
+    { op: "local.set", index: LEN } as Instr,
+    { op: "f64.const", value: 1 } as Instr,
+    { op: "local.set", index: K } as Instr,
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: K } as Instr,
+            { op: "local.get", index: LEN } as Instr,
+            { op: "f64.ge" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+            { op: "local.get", index: BARGS } as Instr,
+            { op: "local.get", index: 1 } as Instr,
+            { op: "local.get", index: K } as Instr,
+            { op: "call", funcIdx: externGetIdxIdx } as Instr,
+            { op: "call", funcIdx: objVecPushIdx } as Instr,
+            { op: "local.get", index: K } as Instr,
+            { op: "f64.const", value: 1 } as Instr,
+            { op: "f64.add" } as Instr,
+            { op: "local.set", index: K } as Instr,
+            { op: "br", depth: 0 } as Instr,
+          ],
+        } as Instr,
+      ],
+    } as Instr,
+    // return extern($__bound_fn{recv, thisArg, bound})
+    { op: "local.get", index: 0 } as Instr,
+    { op: "local.get", index: THISV } as Instr,
+    { op: "local.get", index: BARGS } as Instr,
+    { op: "struct.new", typeIdx: bfIdx } as Instr,
+    { op: "extern.convert_any" } as Instr,
+    { op: "return" } as Instr,
+  ];
+
+  const body: Instr[] = [
+    { op: "local.get", index: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.set", index: ANY } as Instr,
+    ...buildClosureRefTestArms(ctx, ANY, mintArm),
+  ];
+  if (methodCallIdx !== undefined) {
+    body.push(
+      { op: "local.get", index: 0 } as Instr,
+      ...stringConstantExternrefInstrs(ctx, "bind"),
+      { op: "local.get", index: 1 } as Instr,
+      { op: "call", funcIdx: methodCallIdx } as Instr,
+    );
+  } else {
+    body.push({ op: "ref.null.extern" } as Instr);
+  }
+  helperFn.body = body;
+  helperFn.locals = [
+    { name: "any", type: { kind: "anyref" } },
+    { name: "thisv", type: { kind: "externref" } },
+    { name: "bargs", type: { kind: "externref" } },
+    { name: "k", type: { kind: "f64" } },
+    { name: "len", type: { kind: "f64" } },
+  ];
 }
 
 /**

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -408,6 +408,36 @@ export function getOrRegisterTaDynViewType(ctx: CodegenContext): number {
 }
 
 /**
+ * (#3140) Get or register `$__bound_fn` — the standalone/WASI native
+ * bound-function carrier minted by `Function.prototype.bind`:
+ * `{target: externref, thisArg: externref, boundArgs: externref}` where
+ * `boundArgs` holds a boxed `$ObjVec` of the partial-application arguments.
+ * Invocation unwraps through the `__apply_closure` front-guard (prepending
+ * `boundArgs` and recursing on `target`, so bound-of-bound chains compose);
+ * the closure classifier (`closure-classifier.ts`) counts it callable so
+ * `typeof bound === "function"`. A plain struct (NOT a vec/closure subtype) so
+ * it never collides with other `ref.test`s. Registered late+once, memoized on
+ * `ctx.boundFnTypeIdx`. Byte-inert: only emitted when a standalone `.bind(...)`
+ * site compiles.
+ */
+export function getOrRegisterBoundFnType(ctx: CodegenContext): number {
+  if (ctx.boundFnTypeIdx >= 0) return ctx.boundFnTypeIdx;
+  const idx = ctx.mod.types.length;
+  const name = "__bound_fn";
+  const fields = [
+    { name: "target", type: { kind: "externref" as const }, mutable: false },
+    { name: "thisArg", type: { kind: "externref" as const }, mutable: false },
+    { name: "boundArgs", type: { kind: "externref" as const }, mutable: false },
+  ];
+  ctx.mod.types.push({ kind: "struct", name, fields });
+  ctx.boundFnTypeIdx = idx;
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, fields);
+  return idx;
+}
+
+/**
  * (#3054 C) Get or register the `$__resizable_ab` struct — a WasmGC SUBTYPE of the
  * ArrayBuffer backing vec `$__vec_i32_byte`, carrying one extra `maxByteLength`
  * field:

--- a/tests/issue-3140.test.ts
+++ b/tests/issue-3140.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3140 — standalone native Function.prototype.bind (`$__bound_fn` carrier).
+//
+// Before: (a) the typed route degraded to identity-bind (DROPPED partial args);
+// (b) an `any`-typed receiver never routed at all (dispatcher → undefined, so
+// `typeof bound !== "function"`). The test262 TypedArray harness binds every
+// arg factory (`argFactory.bind(undefined, constructor)`), so every
+// makeCtorArg-style test failed at the harness level. Now: bind mints
+// `$__bound_fn {target, thisArg, boundArgs}`; `__apply_closure` carries an
+// unwrap front-guard (bound args prepended, [[BoundThis]] wins, bound-of-bound
+// composes); the bare dynamic call dispatch has an unwrap arm; the closure
+// classifier counts the carrier callable.
+
+async function run(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors?.map((e) => e.message).join("\n")).toBe(true);
+  const imports = WebAssembly.Module.imports(new WebAssembly.Module(r.binary));
+  expect(imports.map((i) => `${i.module}::${i.name}`)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#3140 standalone Function.prototype.bind", () => {
+  it("any-receiver bind: typeof, partial-arg prepend, passthrough", async () => {
+    expect(
+      await run(`
+        function mk(TA: any, x: any) { return x; }
+        export function test(): number {
+          const f: any = mk;
+          const bound = f.bind(undefined, 42);
+          if (typeof bound !== "function") return 1;
+          const r = bound([5, 6]);
+          if (r === undefined) return 2;
+          return r.length === 2 && r[0] === 5 ? 9 : 3;
+        }`),
+    ).toBe(9);
+  });
+
+  it("typed-receiver bind keeps the partial args (was identity-bind)", async () => {
+    expect(
+      await run(`
+        function add(a: number, b: number): number { return a + b; }
+        export function test(): number {
+          const add4: any = add.bind(undefined, 4);
+          return add4(3) as number;
+        }`),
+    ).toBe(7);
+  });
+
+  it("the test262 TypedArray-harness bind flow works end-to-end", async () => {
+    expect(
+      await run(`
+        function makePassthrough(TA: any, x: any) { return x; }
+        function runWith(f: any, ctors: any) {
+          let out = 0;
+          const factories: any = [makePassthrough];
+          for (let k = 0; k < factories.length; k++) {
+            for (let i = 0; i < ctors.length; i++) {
+              const constructor = ctors[i];
+              const bound = factories[k].bind(undefined, constructor);
+              out = f(constructor, bound);
+            }
+          }
+          return out;
+        }
+        export function test(): number {
+          return runWith(function(TA: any, makeCtorArg: any) {
+            const a = new TA(makeCtorArg([0, 0, 0])).fill(8, 1);
+            return a.length * 100 + a[1] * 10 + a[2];
+          }, [Float64Array, Int8Array]);
+        }`),
+    ).toBe(388);
+  });
+
+  it("bound-of-bound composes (one unwrap hop per layer)", async () => {
+    expect(
+      await run(`
+        function sum3(a: number, b: number, c: number): number { return a * 100 + b * 10 + c; }
+        export function test(): number {
+          const f: any = sum3;
+          const g = f.bind(undefined, 1);
+          const h = g.bind(undefined, 2);
+          return h(3) as number;
+        }`),
+    ).toBe(123);
+  });
+
+  it("zero-partial bind is a plain callable wrapper", async () => {
+    expect(
+      await run(`
+        function two(): number { return 2; }
+        export function test(): number {
+          const f: any = two;
+          const b = f.bind(undefined);
+          return typeof b === "function" ? (b() as number) : -1;
+        }`),
+    ).toBe(2);
+  });
+
+  it("bind on a non-callable any keeps the legacy undefined outcome (no hijack)", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const notFn: any = { x: 1 };
+          const b = notFn.bind(undefined, 1);
+          return b === undefined ? 1 : 0;
+        }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Standalone `Function.prototype.bind` returned a **non-callable**: the typed route degraded to identity-bind (dropping the partial args — the #1632a documented gap) and an `any`-typed receiver never routed at all (dispatcher → undefined). This blocked the ENTIRE modern test262 TypedArray harness: `testWithAllTypedArrayConstructors` binds every arg factory (`argFactory.bind(undefined, constructor)`), so every makeCtorArg-style test failed at the harness level regardless of TA substrate (#2872 slice 1 landed the construction; this is the next gate).

### Changes (all standalone/wasi-gated; host lane byte-identical, carrier type never registers there)
- **`$__bound_fn {target, thisArg, boundArgs}`** carrier (registry/types.ts, lazy+memoized, byte-inert for bind-free modules).
- `compileFunctionBind` standalone arm **mints the carrier** (§20.2.3.2 evaluation order), replacing identity-bind.
- Any-receiver `.bind` routes through **reserve-then-fill `__bind_dyn`** — the callable gate needs the COMPLETE closure-classifier root list, only settled at finalize (#1896 hazard). Callable → mint; anything else → the legacy `__extern_method_call` route (undefined), preserving prior non-callable behavior.
- **`fillApplyClosure` front-guard** (the #3031 $Proxy ladder pattern): unwraps one bound layer per hop — boundArgs prepended, [[BoundThis]] wins (§10.4.1.1), recursion composes bound-of-bound.
- **Inline dynamic-call dispatch arm** for bare `bound(...)` calls, pre-scanned via `sourceHasBindCall` for compile-order independence.
- **Closure classifier** counts the carrier callable → `typeof bound === "function"` / `__is_closure` / typeof-object exclusion in lockstep.

### Measured (standalone lane, local dir scans)
| tree | before | after | flips |
| ---- | ------ | ----- | ----- |
| built-ins/Function/prototype/bind (100) | 16 pass | 27 pass | **+14 / −3** |

The 3 negative flips are `Object.defineProperty`-on-the-bound-fn tests that passed by the identity-bind accident (honest de-mask). TypedArray/prototype is unchanged by bind alone — the harness's next gate is the `Array.from({length}, fn)` / `Array.from(iterable)` standalone gap (`__make_callback`/`__array_from` leaks), the follow-up lever noted in the issue.

### Validation
- `tests/issue-3140.test.ts` — 6 cases (any/typed receivers, partial-arg prepend, harness flow end-to-end, bound-of-bound, zero-partial, non-callable no-hijack), host-free instantiation asserted per case
- bind suites green: issue-1337*, issue-1632a, issue-2710-late-bind, issue-2872, issue-2151 (its 2 custom-iterable failures reproduce identically on main — pre-existing)
- tsc, loc-budget (allowance in the issue file), dead-exports OK

Issue: plan/issues/3140-standalone-closure-bind-non-callable.md (status: done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS