### PR TITLE
fix(#2984): standalone gOPD(<Ctor>, Symbol.species) — @@species accessor-descriptor synthesis

### DIFF
--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -10,12 +10,83 @@ area: codegen, runtime
 goal: standalone-mode
 related: [2965, 2861, 2863, 2896, 2949, 2989]
 origin: "#2965 descriptor-cluster triage — follow-up class 1"
-assignee: ttraenkler/fable-16th
+assignee: ttraenkler/fable-sub1
 loc-budget-allow:
   - src/codegen/expressions/calls.ts
 ---
 
 # #2984 — standalone gOPD-on-builtin descriptor MOP
+
+## Slice "@@species key" LANDED (2026-07-11, fable-sub1) — builtin receiver + non-literal key
+
+> PR: `issue-2984-gopd-builtin-key-dispatch`. Takes the "builtin receiver +
+> non-literal key (the `__get_builtin` CE family)" residual of bucket 1. The
+> suite-wide `__get_builtin` non-pass cluster is 565; the gOPD-at-flagged-line
+> subset is only **38**, decomposing (measured 2026-07-11 off the standalone
+> baseline JSONL + flagged-source-line classification): **26 × `gOPD(<Ctor>,
+> Symbol.species)`** (the dominant non-literal-key shape) + 12 × RegExp annex-B
+> legacy accessors (open universe — deliberately refused). The remaining ~527
+> are NOT gOPD — they are direct unimplemented static-method calls
+> (`Atomics.*` 213, `Iterator.zip/zipKeyed/concat/from` ~99, `String.raw` 22,
+> `BigInt.asIntN/asUintN` 20, `Map.groupBy` 12, …), i.e. separate
+> builtin-surface work, not descriptor MOP.
+
+### Root cause
+
+Both compile-time synthesis gates (Phase-3 builtin-static + the #2874 struct
+key dispatch) require a LITERAL key. `Symbol.species` is a
+PropertyAccessExpression, so `gOPD(Array, Symbol.species)` fell through to the
+dynamic fallback, which routes a builtin-identifier receiver through
+`__get_builtin` → hard CE standalone (#1472 Phase B).
+
+### Fix (PR: `issue-2984-gopd-builtin-key-dispatch`)
+
+- `isSymbolSpeciesKeyExpression` (builtin-static-gopd.ts): syntactic
+  recognizer for the unshadowed `Symbol.species` key (unwraps parens/`as`/`!`).
+- `tryEmitStandaloneBuiltinSpeciesGopd` (builtin-static-gopd.ts): for the
+  @@species-owner ctors (Array/ArrayBuffer/SharedArrayBuffer/Map/Set/Promise/
+  RegExp — the complete spec set; concrete TypedArray ctors INHERIT, don't
+  own) emits `__create_accessor_descriptor(get, undefined, {e:false,c:true})`.
+  Non-owners / other symbol keys keep the loud refusal (strictly additive:
+  every intercepted shape CE'd).
+- `ensureStandaloneSpeciesGetterClosure` (property-access.ts): per-ctor
+  `get [Symbol.species]` closure — body is spec step 1 ("Return the this
+  value", param 1), meta subtype `species:<Ctor>` (name
+  `"get [Symbol.species]"`, length 0 per §10.2.9) so the reflective
+  `__builtinfn_*` natives answer propertyHelper's runtime
+  `verifyProperty(desc.get, "name"|"length")` reads; identity-stable via the
+  #2175 V2-S2 singleton; registered in
+  `nativeProtoReceiverClosureStructTypes` (meta type ONLY — the shared
+  signature-wrapper base is untouched) so a statically-resolvable
+  `g.call(thisVal)` threads the receiver.
+- Thin gate in calls.ts after the Phase-3 arm (`ctx.standalone && propLiteral
+  === undefined && isSymbolSpeciesKeyExpression`), receiver via the bucket-1
+  alias resolver. Host/gc byte-inert.
+
+### Measured (real runner, standalone lane, base = origin/main @ 026f40f771 merged)
+
+| Sweep                                             | before          | after              | Δ                        |
+| ------------------------------------------------- | --------------- | ------------------ | ------------------------ |
+| `built-ins/*/Symbol.species/*` (29)               | 0 / 5 / 24 CE   | **18 / 11 / 0 CE** | **+18 pass, 0 regressions** |
+| `built-ins/Object/getOwnPropertyDescriptor{,s}` (328) | 281 / 47 / 0 | **281 / 47 / 0**   | unchanged (0 regressions) |
+
+- `prove-emit-identity`: **IDENTICAL** — all 39 (file,target) emits match the
+  main-state baseline (host/gc/wasi inert; corpus has no species gOPD).
+- `tests/issue-2984-species.test.ts` 9/9 (accessor shape, identity stability,
+  per-ctor distinctness, getter name/length meta, reflective gOPD-on-getter,
+  alias receiver, non-owner refusal GUARD, shadowed-Symbol GUARD, host-lane
+  compile).
+- Still failing in the species dirs (NOT this slice): `return-value.js` ×6 —
+  `gOPD(...).get.call(thisVal)` invokes a descriptor-extracted closure value
+  (the #2949 first-class-closure `.call` substrate gap; the getter itself
+  returns `this` correctly when the closure resolves statically);
+  `TypedArray/Symbol.species/*` ×4 — receiver is the harness's
+  `Object.getPrototypeOf(Int8Array)` var, which the conservative alias
+  resolver declines; `Promise/symbol-species.js` — propertyHelper
+  verify-chain trips an unrelated null-access.
+- loc-budget: +20 in calls.ts (the thin gate) covered by the
+  `loc-budget-allow` frontmatter above (#3131); the synthesis lives in the
+  subsystem module.
 
 ## Slice "arg-2 name coercion" LANDED (2026-07-10, fable-16th) — struct-receiver runtime key dispatch
 

--- a/src/codegen/builtin-static-gopd.ts
+++ b/src/codegen/builtin-static-gopd.ts
@@ -66,6 +66,7 @@ import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "./nati
 import {
   BUILTIN_CTOR_ARITY,
   ensureStandaloneBuiltinStaticMethodClosure,
+  ensureStandaloneSpeciesGetterClosure,
   MATH_CONSTANT_VALUES,
   NUMBER_CONSTANT_VALUES,
   TYPED_ARRAY_BYTES_PER_ELEMENT,
@@ -314,6 +315,97 @@ export function tryEmitStandaloneBuiltinStaticGopd(
   // surface is fully covered above, so the member is genuinely absent.
   if (builtinName === "Symbol" || builtinName === "RegExp") return false;
   fctx.body.push({ op: "ref.null.extern" } as Instr);
+  return true;
+}
+
+/**
+ * (#2984 "builtin receiver + non-literal key") The constructors whose OWN
+ * property surface includes the `@@species` accessor (§ "get <Ctor>
+ * [ @@species ]"): Array §23.1.2.5, ArrayBuffer §25.1.5.3, SharedArrayBuffer
+ * §25.2.4.3, Map §24.1.2.2, Set §24.2.2.2, Promise §27.2.4.4, RegExp §22.2.6.2.
+ * (%TypedArray% also owns one, but its gOPD receiver in the corpus is a
+ * harness-bound `Object.getPrototypeOf(Int8Array)` var the conservative alias
+ * resolver declines — out of scope for this slice. The CONCRETE TypedArray
+ * ctors inherit @@species and do NOT own it, so they are correctly absent.)
+ */
+const SPECIES_OWNER_CTORS: ReadonlySet<string> = new Set([
+  "Array",
+  "ArrayBuffer",
+  "SharedArrayBuffer",
+  "Map",
+  "Set",
+  "Promise",
+  "RegExp",
+]);
+
+/**
+ * True when a gOPD KEY expression is the well-known symbol read
+ * `Symbol.species` (unwrapping parens/`as`/`!`), with `Symbol` unshadowed.
+ * This is the dominant NON-LITERAL builtin-receiver key in the corpus
+ * (`built-ins/*/ Symbol.species; /*` — 26 standalone CEs measured 2026-07-11):
+ * the key never reaches `literalKeyText`, so the shape fell through to the
+ * dynamic fallback and hit the `__get_builtin` standalone refusal (#1472
+ * Phase B) as a hard CE.
+ */
+export function isSymbolSpeciesKeyExpression(fctx: FunctionContext, expr: ts.Expression): boolean {
+  let e = expr;
+  while (
+    ts.isParenthesizedExpression(e) ||
+    ts.isAsExpression(e) ||
+    ts.isNonNullExpression(e) ||
+    ts.isTypeAssertionExpression(e)
+  ) {
+    e = e.expression;
+  }
+  return (
+    ts.isPropertyAccessExpression(e) &&
+    !ts.isPrivateIdentifier(e.name) &&
+    e.name.text === "species" &&
+    ts.isIdentifier(e.expression) &&
+    e.expression.text === "Symbol" &&
+    !(fctx.localMap.has("Symbol") || (fctx.boxedCaptures?.has("Symbol") ?? false))
+  );
+}
+
+/**
+ * Synthesize the §6.1.7.3 ACCESSOR descriptor for
+ * `Object.getOwnPropertyDescriptor(<Ctor>, Symbol.species)`:
+ * `{ get: <"get [Symbol.species]" singleton>, set: undefined,
+ *    enumerable: false, configurable: true }`.
+ * Leaves one externref (the descriptor `$Object`) on the stack and returns
+ * `true`; returns `false` — with NOTHING pushed — for non-@@species-owner
+ * receivers (caller keeps today's `__get_builtin` refusal; every intercepted
+ * owner shape was a hard CE, so the arm is strictly additive).
+ *
+ * Late-funcidx discipline: the `__create_accessor_descriptor` native is
+ * resolved (+ flushed) BEFORE the getter closure funcIdx is minted/captured,
+ * so the `ref.func` the singleton materializer bakes into `fctx.body` cannot
+ * go stale from this arm's own import addition (and `fctx.body` is
+ * shift-covered for later ones).
+ */
+export function tryEmitStandaloneBuiltinSpeciesGopd(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  builtinName: string,
+): boolean {
+  if (!SPECIES_OWNER_CTORS.has(builtinName)) return false;
+  const createAccIdx = ensureLateImport(
+    ctx,
+    "__create_accessor_descriptor",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "i32" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (createAccIdx === undefined) return false;
+  const closure = ensureStandaloneSpeciesGetterClosure(ctx, builtinName);
+  if (!closure) return false;
+  // (#2175 V2-S2) Identity-stable getter singleton — repeated gOPD calls yield
+  // the SAME `.get` function object.
+  fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
+  fctx.body.push({ op: "extern.convert_any" } as Instr); // get
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // set = undefined
+  fctx.body.push({ op: "i32.const", value: FLAG_CONFIGURABLE } as Instr); // {e:false, c:true}
+  fctx.body.push({ op: "call", funcIdx: createAccIdx } as Instr);
   return true;
 }
 

--- a/src/codegen/builtin-static-gopd.ts
+++ b/src/codegen/builtin-static-gopd.ts
@@ -59,14 +59,20 @@
 import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { BUILTIN_STATIC_METHOD_ARITY, pushBuiltinFnSingletonValueInstrs } from "./builtin-fn-meta.js";
+import {
+  BUILTIN_STATIC_METHOD_ARITY,
+  ensureBuiltinFnMetaType,
+  pushBuiltinFnSingletonValueInstrs,
+} from "./builtin-fn-meta.js";
+import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { allocLocal } from "./context/locals.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { nativeStringLiteralInstrs, stringConstantExternrefInstrs } from "./native-strings.js";
 import {
   BUILTIN_CTOR_ARITY,
   ensureStandaloneBuiltinStaticMethodClosure,
-  ensureStandaloneSpeciesGetterClosure,
+  makeBuiltinClosureFctx,
   MATH_CONSTANT_VALUES,
   NUMBER_CONSTANT_VALUES,
   TYPED_ARRAY_BYTES_PER_ELEMENT,
@@ -365,6 +371,69 @@ export function isSymbolSpeciesKeyExpression(fctx: FunctionContext, expr: ts.Exp
     e.expression.text === "Symbol" &&
     !(fctx.localMap.has("Symbol") || (fctx.boxedCaptures?.has("Symbol") ?? false))
   );
+}
+
+/**
+ * (#2984 "builtin receiver + non-literal key") The per-constructor
+ * `get [Symbol.species]` accessor closure — spec `get <Ctor> [ @@species ]`
+ * (§23.1.2.5, §25.1.5.3, §24.1.2.2, §24.2.2.2, §27.2.4.4, §22.2.6.2): the body
+ * is exactly "Return the this value" (param 1, the lifted receiver slot).
+ *
+ * The value struct is the UNIQUE per-ctor meta subtype (`species:<Ctor>`), so
+ * (a) `pushBuiltinFnSingletonValueInstrs`' per-typeIdx singleton global gives
+ * identity-stable reads (`gOPD(Array, Symbol.species).get` is the SAME object
+ * across calls) while Array's getter stays distinct from Map's (each ctor owns
+ * its OWN accessor function per spec), and (b) the reflective `__builtinfn_*`
+ * natives answer `name`/`length` at runtime — `"get [Symbol.species]"` / 0
+ * (§10.2.9 accessor spelling) — which is what the test262 propertyHelper reads
+ * (`verifyProperty(desc.get, "name"|"length", …)`).
+ *
+ * The meta type is registered in `nativeProtoReceiverClosureStructTypes`
+ * (#2193 PR-B): the getter's FIRST user param IS the receiver, so a statically
+ * resolvable `g.call(thisVal)` threads `thisVal` into param 1 (→ returns it)
+ * instead of dropping it. Only the meta subtype is registered — the shared
+ * signature-wrapper base is left alone (other closures of the same signature
+ * take a plain first ARG there, not a receiver).
+ */
+function ensureStandaloneSpeciesGetterClosure(
+  ctx: CodegenContext,
+  builtinName: string,
+): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
+  const userParams: ValType[] = [{ kind: "externref" }]; // param 1 = `this`
+  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, [{ kind: "externref" }]);
+  if (!wrapperTypes) return null;
+
+  const funcName = `__builtin_species_get_${builtinName}`;
+  let funcIdx = ctx.funcMap.get(funcName);
+  if (funcIdx === undefined) {
+    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
+    const closureFctx = makeBuiltinClosureFctx(funcName, selfType, userParams, { kind: "externref" });
+    // Step 1 (the whole algorithm): Return the this value.
+    closureFctx.body.push({ op: "local.get", index: 1 } as Instr);
+    funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
+      name: funcName,
+      typeIdx: wrapperTypes.liftedFuncTypeIdx,
+      locals: closureFctx.locals,
+      body: closureFctx.body,
+      exported: false,
+    });
+    ctx.funcMap.set(funcName, funcIdx);
+    if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();
+    ctx.nativeClosureMeta.set(funcIdx, { name: "get [Symbol.species]", length: 0 });
+  }
+
+  const metaTypeIdx = ensureBuiltinFnMetaType(
+    ctx,
+    wrapperTypes.structTypeIdx,
+    wrapperTypes.closureInfo,
+    `species:${builtinName}`,
+    "get [Symbol.species]",
+    0,
+  );
+  if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();
+  ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);
+  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
 }
 
 /**

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -156,10 +156,12 @@ import {
 } from "../native-proto.js";
 import { pushBuiltinFnSingletonValueInstrs } from "../builtin-fn-meta.js";
 import {
+  isSymbolSpeciesKeyExpression,
   resolveBuiltinReceiverName,
+  tryEmitStandaloneBuiltinSpeciesGopd,
   tryEmitStandaloneBuiltinStaticGopd,
   tryEmitStandaloneStructGopdKeyDispatch,
-} from "../builtin-static-gopd.js"; // (#2984 Phase 3 + bucket-1 alias receivers + arg-2 name coercion)
+} from "../builtin-static-gopd.js"; // (#2984 Phase 3 + bucket-1 alias receivers + arg-2 name coercion + @@species)
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import {
   emitSetExtrasArgv,
@@ -8365,6 +8367,24 @@ function compileCallExpression(
       if (ctx.standalone && propLiteral !== undefined) {
         const builtinRecv = resolveBuiltinReceiverName(fctx, arg0, BUILTIN_CLASS_NAMES);
         if (builtinRecv !== undefined && tryEmitStandaloneBuiltinStaticGopd(ctx, fctx, builtinRecv, propLiteral)) {
+          return { kind: "externref" };
+        }
+      }
+
+      // (#2984 "builtin receiver + non-literal key") `gOPD(<Ctor>,
+      // Symbol.species)` — the dominant NON-literal-key builtin-receiver shape
+      // (26 standalone CEs: built-ins/*/Symbol.species/*). The @@species own
+      // property is an ACCESSOR `{get: "get [Symbol.species]" (returns this),
+      // set: undefined, e:false, c:true}`; synthesize it from the per-ctor
+      // getter singleton (builtin-static-gopd.ts). Every intercepted shape
+      // CE'd via the `__get_builtin` refusal below, so the arm is strictly
+      // additive; non-owner receivers / other symbol keys (Symbol well-knowns,
+      // RegExp annex-B legacy statics) keep the refusal. Both operands are
+      // side-effect-free (builtin/alias identifier + `Symbol.species` fold),
+      // so neither is compiled — same discipline as the Phase-3 literal arm.
+      if (ctx.standalone && propLiteral === undefined && isSymbolSpeciesKeyExpression(fctx, arg1)) {
+        const builtinRecv = resolveBuiltinReceiverName(fctx, arg0, BUILTIN_CLASS_NAMES);
+        if (builtinRecv !== undefined && tryEmitStandaloneBuiltinSpeciesGopd(ctx, fctx, builtinRecv)) {
           return { kind: "externref" };
         }
       }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1450,6 +1450,69 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
 }
 
 /**
+ * (#2984 "builtin receiver + non-literal key") The per-constructor
+ * `get [Symbol.species]` accessor closure — spec `get <Ctor> [ @@species ]`
+ * (§23.1.2.5, §25.1.5.3, §24.1.2.2, §24.2.2.2, §27.2.4.4, §22.2.6.2): the body
+ * is exactly "Return the this value" (param 1, the lifted receiver slot).
+ *
+ * The value struct is the UNIQUE per-ctor meta subtype (`species:<Ctor>`), so
+ * (a) `pushBuiltinFnSingletonValueInstrs`' per-typeIdx singleton global gives
+ * identity-stable reads (`gOPD(Array, Symbol.species).get` is the SAME object
+ * across calls) while Array's getter stays distinct from Map's (each ctor owns
+ * its OWN accessor function per spec), and (b) the reflective `__builtinfn_*`
+ * natives answer `name`/`length` at runtime — `"get [Symbol.species]"` / 0
+ * (§10.2.9 accessor spelling) — which is what the test262 propertyHelper reads
+ * (`verifyProperty(desc.get, "name"|"length", …)`).
+ *
+ * The meta type is registered in `nativeProtoReceiverClosureStructTypes`
+ * (#2193 PR-B): the getter's FIRST user param IS the receiver, so a statically
+ * resolvable `g.call(thisVal)` threads `thisVal` into param 1 (→ returns it)
+ * instead of dropping it. Only the meta subtype is registered — the shared
+ * signature-wrapper base is left alone (other closures of the same signature
+ * take a plain first ARG there, not a receiver).
+ */
+export function ensureStandaloneSpeciesGetterClosure(
+  ctx: CodegenContext,
+  builtinName: string,
+): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
+  const userParams: ValType[] = [{ kind: "externref" }]; // param 1 = `this`
+  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, [{ kind: "externref" }]);
+  if (!wrapperTypes) return null;
+
+  const funcName = `__builtin_species_get_${builtinName}`;
+  let funcIdx = ctx.funcMap.get(funcName);
+  if (funcIdx === undefined) {
+    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
+    const closureFctx = makeBuiltinClosureFctx(funcName, selfType, userParams, { kind: "externref" });
+    // Step 1 (the whole algorithm): Return the this value.
+    closureFctx.body.push({ op: "local.get", index: 1 } as Instr);
+    funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
+      name: funcName,
+      typeIdx: wrapperTypes.liftedFuncTypeIdx,
+      locals: closureFctx.locals,
+      body: closureFctx.body,
+      exported: false,
+    });
+    ctx.funcMap.set(funcName, funcIdx);
+    if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();
+    ctx.nativeClosureMeta.set(funcIdx, { name: "get [Symbol.species]", length: 0 });
+  }
+
+  const metaTypeIdx = ensureBuiltinFnMetaType(
+    ctx,
+    wrapperTypes.structTypeIdx,
+    wrapperTypes.closureInfo,
+    `species:${builtinName}`,
+    "get [Symbol.species]",
+    0,
+  );
+  if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();
+  ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);
+  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
+}
+
+/**
  * (#1337) True when `expr` is the syntactic shape `<receiver>.bind(...)`.
  */
 function isDirectBindCall(expr: ts.Expression): boolean {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -888,7 +888,7 @@ function reportUnsupportedStandaloneBuiltinValueRead(ctx: CodegenContext, builti
   );
 }
 
-function makeBuiltinClosureFctx(
+export function makeBuiltinClosureFctx(
   name: string,
   selfType: ValType,
   paramTypes: ValType[],
@@ -1451,69 +1451,6 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
   }
 
   return { type: { kind: "ref", typeIdx: wrapperTypes.structTypeIdx }, funcIdx };
-}
-
-/**
- * (#2984 "builtin receiver + non-literal key") The per-constructor
- * `get [Symbol.species]` accessor closure — spec `get <Ctor> [ @@species ]`
- * (§23.1.2.5, §25.1.5.3, §24.1.2.2, §24.2.2.2, §27.2.4.4, §22.2.6.2): the body
- * is exactly "Return the this value" (param 1, the lifted receiver slot).
- *
- * The value struct is the UNIQUE per-ctor meta subtype (`species:<Ctor>`), so
- * (a) `pushBuiltinFnSingletonValueInstrs`' per-typeIdx singleton global gives
- * identity-stable reads (`gOPD(Array, Symbol.species).get` is the SAME object
- * across calls) while Array's getter stays distinct from Map's (each ctor owns
- * its OWN accessor function per spec), and (b) the reflective `__builtinfn_*`
- * natives answer `name`/`length` at runtime — `"get [Symbol.species]"` / 0
- * (§10.2.9 accessor spelling) — which is what the test262 propertyHelper reads
- * (`verifyProperty(desc.get, "name"|"length", …)`).
- *
- * The meta type is registered in `nativeProtoReceiverClosureStructTypes`
- * (#2193 PR-B): the getter's FIRST user param IS the receiver, so a statically
- * resolvable `g.call(thisVal)` threads `thisVal` into param 1 (→ returns it)
- * instead of dropping it. Only the meta subtype is registered — the shared
- * signature-wrapper base is left alone (other closures of the same signature
- * take a plain first ARG there, not a receiver).
- */
-export function ensureStandaloneSpeciesGetterClosure(
-  ctx: CodegenContext,
-  builtinName: string,
-): { type: { kind: "ref"; typeIdx: number }; funcIdx: number } | null {
-  const userParams: ValType[] = [{ kind: "externref" }]; // param 1 = `this`
-  const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, userParams, [{ kind: "externref" }]);
-  if (!wrapperTypes) return null;
-
-  const funcName = `__builtin_species_get_${builtinName}`;
-  let funcIdx = ctx.funcMap.get(funcName);
-  if (funcIdx === undefined) {
-    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
-    const closureFctx = makeBuiltinClosureFctx(funcName, selfType, userParams, { kind: "externref" });
-    // Step 1 (the whole algorithm): Return the this value.
-    closureFctx.body.push({ op: "local.get", index: 1 } as Instr);
-    funcIdx = mintDefinedFunc(ctx);
-    pushDefinedFunc(ctx, funcIdx, {
-      name: funcName,
-      typeIdx: wrapperTypes.liftedFuncTypeIdx,
-      locals: closureFctx.locals,
-      body: closureFctx.body,
-      exported: false,
-    });
-    ctx.funcMap.set(funcName, funcIdx);
-    if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();
-    ctx.nativeClosureMeta.set(funcIdx, { name: "get [Symbol.species]", length: 0 });
-  }
-
-  const metaTypeIdx = ensureBuiltinFnMetaType(
-    ctx,
-    wrapperTypes.structTypeIdx,
-    wrapperTypes.closureInfo,
-    `species:${builtinName}`,
-    "get [Symbol.species]",
-    0,
-  );
-  if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();
-  ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);
-  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
 }
 
 /**

--- a/tests/issue-2984-species.test.ts
+++ b/tests/issue-2984-species.test.ts
@@ -1,0 +1,150 @@
+// #2984 ("builtin receiver + non-literal key") — standalone
+// `Object.getOwnPropertyDescriptor(<Ctor>, Symbol.species)` synthesizes the
+// spec ACCESSOR descriptor instead of hard-CEing through the `__get_builtin`
+// standalone refusal (#1472 Phase B).
+//
+// Root cause: both compile-time gOPD synthesis gates (Phase-3 builtin-static +
+// the #2874 struct key dispatch) require a LITERAL key; `Symbol.species` is a
+// PropertyAccessExpression, so the shape fell through to the dynamic fallback,
+// which routes a builtin-identifier receiver through `__get_builtin` — a hard
+// CE standalone (26 tests: built-ins/*/Symbol.species/*).
+//
+// Fix: recognize the well-known `Symbol.species` key syntactically and emit
+// `__create_accessor_descriptor(<per-ctor "get [Symbol.species]" singleton>,
+// undefined, {e:false, c:true})` for the @@species-owner ctors
+// (Array/ArrayBuffer/SharedArrayBuffer/Map/Set/Promise/RegExp). The getter
+// body is spec step 1: "Return the this value". Non-owner receivers and other
+// symbol keys keep the loud refusal (strictly additive — every intercepted
+// shape CE'd before).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string) {
+  return (await compile(src, { target: "standalone" })) as {
+    success: boolean;
+    errors: { message: string }[];
+    binary: Uint8Array;
+  };
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compileStandalone(src);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#2984 standalone gOPD(<Ctor>, Symbol.species) accessor-descriptor synthesis", () => {
+  it("returns an accessor descriptor: function get, undefined set, e:false c:true", async () => {
+    const ret = await runStandalone(`
+      var desc: any = Object.getOwnPropertyDescriptor(Array, Symbol.species);
+      export function test(): number {
+        if (typeof desc.get !== "function") return 2;
+        if (desc.set !== undefined) return 3;
+        if (desc.enumerable !== false) return 4;
+        if (desc.configurable !== true) return 5;
+        if (desc.hasOwnProperty("value") !== false) return 6;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("`.get` is identity-stable across repeated gOPD calls (per-ctor singleton)", async () => {
+    const ret = await runStandalone(`
+      var a: any = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+      var b: any = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+      export function test(): number { return a.get === b.get ? 1 : 0; }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("each ctor owns a DISTINCT getter function (Array's !== Map's)", async () => {
+    const ret = await runStandalone(`
+      var a: any = Object.getOwnPropertyDescriptor(Array, Symbol.species);
+      var m: any = Object.getOwnPropertyDescriptor(Map, Symbol.species);
+      export function test(): number { return a.get !== m.get ? 1 : 0; }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("getter meta: name 'get [Symbol.species]' (§10.2.9), length 0", async () => {
+    const ret = await runStandalone(`
+      var desc: any = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);
+      export function test(): number {
+        var g: any = desc.get;
+        if (g.length !== 0) return 2;
+        if (g.name !== "get [Symbol.species]") return 3;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("reflective gOPD on the getter's own length answers spec attributes (propertyHelper shape)", async () => {
+    const ret = await runStandalone(`
+      var desc: any = Object.getOwnPropertyDescriptor(ArrayBuffer, Symbol.species);
+      var d2: any = Object.getOwnPropertyDescriptor(desc.get, "length");
+      export function test(): number {
+        if (d2 === undefined) return 2;
+        if (d2.value !== 0) return 3;
+        if (d2.writable !== false) return 4;
+        if (d2.configurable !== true) return 5;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("alias receiver resolves through the conservative reaching-def resolver", async () => {
+    const ret = await runStandalone(`
+      var s = Set;
+      var desc: any = Object.getOwnPropertyDescriptor(s, Symbol.species);
+      export function test(): number {
+        return typeof desc.get === "function" && desc.set === undefined ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("GUARD: non-@@species-owner builtin receiver keeps the loud refusal (no phantom descriptor)", async () => {
+    const r = await compileStandalone(`
+      var desc = Object.getOwnPropertyDescriptor(Math, Symbol.species);
+      export function test(): number { return 1; }
+    `);
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toMatch(/__get_builtin/);
+  });
+
+  it("GUARD: shadowed Symbol is NOT treated as the well-known key", async () => {
+    // A local `Symbol` binding means `Symbol.species` is a user value — the
+    // synthesis must decline (shape keeps today's refusal-CE path).
+    const r = await compileStandalone(`
+      export function test(): number {
+        var Symbol: any = { species: "x" };
+        var desc: any = Object.getOwnPropertyDescriptor(Array, Symbol.species);
+        return desc === undefined ? 1 : 0;
+      }
+    `);
+    // Declining the arm is the contract; whether the fallback compiles or
+    // refuses is the dynamic path's business. Assert only that when it DOES
+    // compile, no accessor descriptor was fabricated.
+    if (r.success) {
+      const { instance } = await WebAssembly.instantiate(r.binary, {});
+      const ret = (instance.exports as Record<string, () => unknown>).test?.();
+      expect(ret).toBe(1);
+    }
+  });
+
+  it("host/gc lane unchanged: the shape still compiles with host imports", async () => {
+    const r = (await compile(
+      `
+      var desc: any = Object.getOwnPropertyDescriptor(Array, Symbol.species);
+      export function test(): number { return 1; }
+    `,
+      { fileName: "test.ts" },
+    )) as { success: boolean; errors: { message: string }[] };
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Slice

#2984 residual "builtin receiver + NON-literal key (the `__get_builtin` CE family)". Measured decomposition of the gOPD subset (38 of the suite-wide 565 `__get_builtin` non-pass entries): **26 × `gOPD(<Ctor>, Symbol.species)`** + 12 × RegExp annex-B legacy accessors (open universe, deliberately still refused). This PR takes the dominant 26.

## Root cause

Both compile-time gOPD synthesis gates (Phase-3 builtin-static, #2874 struct key dispatch) require a LITERAL key. `Symbol.species` is a PropertyAccessExpression, so the shape fell through to the dynamic fallback, which routes a builtin-identifier receiver through `__get_builtin` → hard CE standalone (#1472 Phase B).

## Fix (all `ctx.standalone`-gated; host/gc byte-inert)

- `isSymbolSpeciesKeyExpression` + `tryEmitStandaloneBuiltinSpeciesGopd` (builtin-static-gopd.ts): for the @@species-owner ctors (Array/ArrayBuffer/SharedArrayBuffer/Map/Set/Promise/RegExp — the complete spec set; concrete TypedArrays inherit, don't own) emit `__create_accessor_descriptor(get, undefined, {e:false, c:true})`. Non-owners / other symbol keys keep the loud refusal — every intercepted shape CE'd before, strictly additive.
- `ensureStandaloneSpeciesGetterClosure` (builtin-static-gopd.ts): per-ctor `get [Symbol.species]` closure, body = spec step 1 ("Return the this value"), meta subtype `species:<Ctor>` (name `"get [Symbol.species]"`, length 0 per §10.2.9) so propertyHelper's runtime `verifyProperty(desc.get, "name"|"length")` answers through the reflective `__builtinfn_*` natives; identity-stable #2175 V2-S2 singleton; receiver-threading registered on the meta type only.
- Thin +20 gate in calls.ts after the Phase-3 arm (covered by the issue's `loc-budget-allow`); receiver resolves through the bucket-1 alias resolver.

## Measured (real runner, standalone lane, base = merged origin/main)

| Sweep | before | after |
|---|---|---|
| `built-ins/*/Symbol.species/*` (29) | 0 pass / 5 fail / 24 CE | **18 / 11 / 0 CE** |
| `built-ins/Object/getOwnPropertyDescriptor{,s}` (328) | 281 / 47 / 0 | **281 / 47 / 0** (unchanged) |

- `prove-emit-identity`: **IDENTICAL** — all 39 (file,target) emits vs main-state baseline.
- `tests/issue-2984-species.test.ts` 9/9; prior 2984/2874 suites 50/50.
- Remaining species-dir fails (out of slice, documented in the issue): `return-value.js` ×6 (`.get.call(thisVal)` on a descriptor-extracted closure — #2949 substrate), TypedArray ×4 (harness `Object.getPrototypeOf(Int8Array)` receiver var), Promise/symbol-species.js (unrelated propertyHelper null-access).

Issue: plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md (slice recorded; umbrella stays in-progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)