### PR TITLE
docs: file 6 standalone builtin-CALL-surface issues (#3145-#3150) from #2984 triage

### DIFF
--- a/plan/issues/3145-standalone-atomics-nonshared-throws.md
+++ b/plan/issues/3145-standalone-atomics-nonshared-throws.md
@@ -1,0 +1,54 @@
+---
+id: 3145
+title: "standalone: Atomics.* on non-shared views (the non-SAB subset — ~29 __get_builtin CEs)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2984]
+origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+---
+
+# #3145 — standalone Atomics.* on non-shared views (non-SAB subset)
+
+## Problem
+
+`Atomics.add/sub/and/or/xor/store/exchange/compareExchange/notify/wait/waitAsync`
+used as a standalone value/call hard-CEs through the `__get_builtin`
+dynamic-shape refusal (#1472 Phase B) — measured **312** non-pass standalone
+entries mentioning `__get_builtin` under `built-ins/Atomics/`.
+
+## Scope caution (measured 2026-07-11)
+
+**Only ~29 of the 312 are in scope.** 283 require `SharedArrayBuffer`, which is
+on the standalone/test262 skip list (see CLAUDE.md skip filters:
+SharedArrayBuffer) — those are out of scope until SAB itself is supported. The
+**in-scope 29** are the *non-shared* error-path tests, which only need
+`Atomics.*` to be a resolvable builtin that throws the spec `TypeError` when
+handed a non-shared integer view (i.e. no real shared-memory semantics needed —
+just the recognizer + the throw-on-non-shared branch).
+
+## Sample paths (in-scope, non-SAB)
+
+- `test/built-ins/Atomics/sub/non-shared-int-views-throws.js`
+- `test/built-ins/Atomics/add/non-shared-int-views-throws.js`
+- `test/built-ins/Atomics/store/non-shared-int-views-throws.js`
+- `test/built-ins/Atomics/notify/retrieve-length-before-index-coercion-non-shared.js`
+- `test/built-ins/Atomics/waitAsync/null-bufferdata-throws.js`
+- `test/built-ins/Atomics/waitAsync/bigint/null-bufferdata-throws.js`
+
+## Shared-infra deps
+
+- The `Atomics` namespace must resolve as a builtin under standalone (today it
+  falls to `__get_builtin`). A minimal recognizer + spec `TypeError` on
+  non-shared / null-buffer receivers likely flips all ~29 without real atomic
+  ops. Confirm the exact count against current main before sizing.
+
+## Acceptance
+
+- The ~29 non-SAB `built-ins/Atomics/*` error-path tests compile + pass on the
+  standalone lane; 0 regressions on a passing-test sweep. SAB-dependent tests
+  stay skipped (out of scope).

--- a/plan/issues/3146-standalone-iterator-helpers.md
+++ b/plan/issues/3146-standalone-iterator-helpers.md
@@ -1,0 +1,47 @@
+---
+id: 3146
+title: "standalone: Iterator.zip / zipKeyed / concat / from (~99 __get_builtin CEs)"
+status: ready
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+area: codegen, runtime
+goal: standalone-mode
+related: [2984]
+origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+---
+
+# #3146 — standalone Iterator static helpers (zip / zipKeyed / concat / from)
+
+## Problem
+
+The ES2025 Iterator static helpers `Iterator.zip`, `Iterator.zipKeyed`,
+`Iterator.concat`, `Iterator.from` used standalone hard-CE through the
+`__get_builtin` dynamic-shape refusal (#1472 Phase B). Measured **99** non-pass
+standalone entries under `built-ins/Iterator/{zip,zipKeyed,concat,from}/`. This
+is the largest single in-scope builtin-CALL-surface bucket in the #2984
+`__get_builtin` triage.
+
+## Sample paths
+
+- `test/built-ins/Iterator/zip/iterator-zip-iteration-shortest-iterator-close-abrupt-completion.js`
+- `test/built-ins/Iterator/zipKeyed/iterator-zip-iteration-strict-iterator-close-i-is-zero-abrupt-completion.js`
+- `test/built-ins/Iterator/concat/return-is-forwarded.js`
+- `test/built-ins/Iterator/concat/return-is-not-forwarded-after-exhaustion.js`
+
+## Shared-infra deps
+
+- Needs the standalone iterator-protocol substrate (open-object iterator
+  result reads, `.next()`/`.return()` forwarding, abrupt-completion
+  iterator-close). Much of the corpus exercises iterator-close ordering on
+  abrupt completions — the hard part is the protocol plumbing, not the
+  namespace recognizer. Likely wants an architect spec first (feasibility:
+  hard). Consider splitting `from` (simplest — wraps an iterable) from
+  `zip/zipKeyed/concat` (multi-source close semantics).
+
+## Acceptance
+
+- `built-ins/Iterator/{zip,zipKeyed,concat,from}/*` standalone tests compile +
+  pass with 0 regressions on a passing-test sweep. May land as sub-slices per
+  helper.

--- a/plan/issues/3147-standalone-string-raw.md
+++ b/plan/issues/3147-standalone-string-raw.md
@@ -1,0 +1,45 @@
+---
+id: 3147
+title: "standalone: String.raw (22 __get_builtin CEs)"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2984, 2160]
+origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+---
+
+# #3147 — standalone String.raw
+
+## Problem
+
+`String.raw(template, ...substitutions)` used standalone hard-CEs through the
+`__get_builtin` dynamic-shape refusal (#1472 Phase B). Measured **22** non-pass
+standalone entries under `built-ins/String/raw/`. Note: this is the FUNCTION
+`String.raw(obj)` reflective/error-path form (a `cooked`/`raw` ToObject +
+length-coercion + string-concat loop); the tagged-template lowering
+`String.raw\`...\`` is a separate path (#2510) and already handled — these
+tests call `String.raw` as an ordinary function with hand-built objects.
+
+## Sample paths
+
+- `test/built-ins/String/raw/template-length-throws.js`
+- `test/built-ins/String/raw/template-raw-not-object-throws.js`
+- `test/built-ins/String/raw/return-empty-string-if-length-is-zero-NaN.js`
+- `test/built-ins/String/raw/returns-abrupt-from-next-key.js`
+
+## Shared-infra deps
+
+- Needs `String.raw` as a resolvable standalone builtin function with the spec
+  §22.1.2.16 algorithm: `ToObject(template.raw)`, `ToLength(len)`, per-index
+  `Get` + `ToString` on both raw segments and substitutions, string
+  concatenation. Reuses the open-object dynamic `__extern_get` + native string
+  concat already present; the error-path tests mostly assert TypeError on a
+  non-object `.raw` / abrupt getters.
+
+## Acceptance
+
+- `built-ins/String/raw/*` standalone tests compile + pass with 0 regressions.

--- a/plan/issues/3148-standalone-bigint-asintn.md
+++ b/plan/issues/3148-standalone-bigint-asintn.md
@@ -1,0 +1,46 @@
+---
+id: 3148
+title: "standalone: BigInt.asIntN / asUintN (20 __get_builtin CEs)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2984, 1349, 1644]
+origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+---
+
+# #3148 — standalone BigInt.asIntN / asUintN
+
+## Problem
+
+`BigInt.asIntN(bits, bigint)` / `BigInt.asUintN(bits, bigint)` used standalone
+hard-CE through the `__get_builtin` dynamic-shape refusal (#1472 Phase B).
+Measured **20** non-pass standalone entries under
+`built-ins/BigInt/{asIntN,asUintN}/`.
+
+## Sample paths
+
+- `test/built-ins/BigInt/asIntN/bigint-tobigint.js`
+- `test/built-ins/BigInt/asIntN/bigint-tobigint-errors.js`
+- `test/built-ins/BigInt/asUintN/bigint-tobigint-toprimitive.js`
+- `test/built-ins/BigInt/asUintN/bits-toindex.js`
+
+## Shared-infra deps
+
+- **Blocked on / entangled with the BigInt i64-brand ValType decision**
+  (#1349 / #1644 — see memory `project_bigint_i64_brand_gate`). `asIntN`/
+  `asUintN` need a real BigInt value representation (i64-brand) to do the
+  modular wrap; without it only the `ToIndex(bits)` / `ToBigInt` coercion
+  ERROR-path tests (`*-errors.js`, `bits-toindex.js`, `*-toprimitive.js`) are
+  reachable — those may flip with just the namespace recognizer + coercion
+  throws, but the value-computation tests wait on the brand. Re-measure the
+  error-path-only subset before sizing; may want to gate behind #1349.
+
+## Acceptance
+
+- The coercion/error-path subset compiles + passes standalone with 0
+  regressions; value-computation tests tracked against the #1349 i64-brand
+  landing.

--- a/plan/issues/3149-standalone-map-groupby.md
+++ b/plan/issues/3149-standalone-map-groupby.md
@@ -1,0 +1,44 @@
+---
+id: 3149
+title: "standalone: Map.groupBy (12 __get_builtin CEs)"
+status: ready
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2984, 2162, 2863]
+origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+---
+
+# #3149 — standalone Map.groupBy
+
+## Problem
+
+`Map.groupBy(items, callback)` used standalone hard-CEs through the
+`__get_builtin` dynamic-shape refusal (#1472 Phase B). Measured **12** non-pass
+standalone entries under `built-ins/Map/groupBy/`. (Object.groupBy is a
+sibling; check whether it clusters here too and fold it in if so.)
+
+## Sample paths
+
+- `test/built-ins/Map/groupBy/negativeZero.js`
+- `test/built-ins/Map/groupBy/callback-throws.js`
+- `test/built-ins/Map/groupBy/invalid-callback.js`
+- `test/built-ins/Map/groupBy/map-instance.js`
+
+## Shared-infra deps
+
+- Needs `Map.groupBy` as a resolvable standalone builtin: iterate the iterable,
+  call the callback per element, `CanonicalizeKeyedCollectionKey` (the -0→+0
+  normalization the `negativeZero.js` test asserts), and append into a Map
+  keyed by the callback result. Reuses the standalone Map runtime (#2162) +
+  the iterator-protocol substrate. Small (12 tests, S) — good tail-filler.
+  The `groupBy` grouping helper (`#2863` groupBy landed for arrays?) may share
+  code — check before implementing.
+
+## Acceptance
+
+- `built-ins/Map/groupBy/*` standalone tests compile + pass with 0
+  regressions.

--- a/plan/issues/3150-standalone-uint8array-base64-hex.md
+++ b/plan/issues/3150-standalone-uint8array-base64-hex.md
@@ -1,0 +1,45 @@
+---
+id: 3150
+title: "standalone: Uint8Array.fromBase64 / fromHex (+ toBase64/toHex/setFrom*) (12 __get_builtin CEs)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2984]
+origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+---
+
+# #3150 — standalone Uint8Array base64/hex codec statics
+
+## Problem
+
+The ES2025 `Uint8Array.fromBase64` / `Uint8Array.fromHex` statics (and the
+sibling instance methods `toBase64`/`toHex`/`setFromBase64`/`setFromHex`) used
+standalone hard-CE through the `__get_builtin` dynamic-shape refusal (#1472
+Phase B). Measured **12** non-pass standalone entries under
+`built-ins/Uint8Array/{fromBase64,fromHex}/` (the static-factory subset; sweep
+the instance methods too when sizing).
+
+## Sample paths
+
+- `test/built-ins/Uint8Array/fromHex/illegal-characters.js`
+- `test/built-ins/Uint8Array/fromHex/odd-length-input.js`
+- `test/built-ins/Uint8Array/fromHex/string-coercion.js`
+- `test/built-ins/Uint8Array/fromBase64/illegal-characters.js`
+
+## Shared-infra deps
+
+- Needs `Uint8Array.fromBase64`/`fromHex` as resolvable standalone statics with
+  a native base64/hex decoder writing into a fresh Uint8Array (linear or
+  WasmGC typed array backing). The error-path tests (illegal chars, odd
+  length) mostly assert `SyntaxError`/`TypeError` on malformed input +
+  string-coercion of the arg — the decoder itself is a self-contained byte
+  loop, no cross-cutting substrate. Reuses the existing TypedArray backing.
+
+## Acceptance
+
+- `built-ins/Uint8Array/{fromBase64,fromHex}/*` standalone tests compile + pass
+  with 0 regressions; extend to `toBase64`/`toHex`/`setFrom*` if they cluster.


### PR DESCRIPTION
Banks the #2984 `__get_builtin` cluster triage (fable-sub1, 2026-07-11): the standalone non-pass cluster is **565** entries, but only **38** are gOPD/descriptor work — the other ~527 are unimplemented builtin **CALL** surfaces. Filed one `sprint:current` `status:ready` issue per surface family so the TaskList sync picks them up as dispatchable conformance levers:

| Issue | Surface | Tests | Note |
|---|---|---|---|
| #3145 | Atomics.* non-shared throws | ~29 | **283 of 312 need SharedArrayBuffer (skip-listed) — out of scope**; only the non-SAB error-path subset is in scope |
| #3146 | Iterator.zip/zipKeyed/concat/from | 99 | largest bucket; needs iterator-protocol substrate; likely architect spec + sub-slices |
| #3147 | String.raw (function form) | 22 | §22.1.2.16 reflective form (not the tagged-template path #2510) |
| #3148 | BigInt.asIntN/asUintN | 20 | value-compute blocked on #1349 i64-brand; error-path subset reachable now |
| #3149 | Map.groupBy | 12 | S tail-filler; reuses Map runtime #2162 + iterator substrate |
| #3150 | Uint8Array.fromBase64/fromHex | 12 | self-contained byte codec |

Each file records the measured test count, sample paths, and shared-infra deps. Docs-only (no code) — new `plan/issues/*.md` allocated via `claim-issue.mjs --allocate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)