### PR TITLE
fix(#3024): source promoted capture cell from the box global at capturing-fn call sites

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -17,8 +17,7 @@ test262_category: language/expressions/object/dstr, built-ins/AsyncFromSyncItera
 test262_ce: 131
 related: []
 loc-budget-allow:
-  - src/codegen/expressions/unary-updates.ts
-  - src/codegen/type-coercion.ts
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3024 — invalid Wasm binary emission residual (default lane)
@@ -434,3 +433,67 @@ The remaining 78 are the scattered per-root-cause singletons listed above
 broad-impact, needs a full-CI window; then the 6-file `object/dstr`
 `meth-ary-ptrn-(rest-)elision` `call[#] expected (ref null #), found f#`
 cluster).
+
+---
+
+## Landed: capturing-fn call after method capture promotion (fable-wasm, 2026-07-11, slice 2)
+
+**PR:** `issue-3024-promoted-capture-call` — clears the 6-file `object/dstr`
+`{meth,gen-meth,async-gen-meth}-ary-ptrn-(rest-ary-)elision` cluster
+(`call[#] expected (ref null #), found local.get of type f#` in `test`).
+Post-slice-1 harvest: 78 → **72**, zero new signatures.
+
+### Root cause (stale `boxedCaptures` branch after #3121 promotion)
+
+The trigger is NOT destructuring: it is a local that is (a) closure-MUTATED by
+a nested function (boxed to a ref cell, `fctx.boxedCaptures`) and (b) also
+referenced by an object-literal METHOD. Compiling the object literal runs the
+accessor/method capture promotion (#2029/#3039/#3121, `closures.ts`): the
+shared cell is aliased into a module global (`ctx.capturedBoxGlobals`) and the
+`localMap` binding is DELETED (closures.ts ~L609) so post-promotion enclosing-
+function code routes through the global. But the direct-call capture-prepend
+(`compileCallExpression`, calls.ts ~L15260) checked `boxedCaptures` FIRST and
+resolved `fctx.localMap.get(name) ?? cap.outerLocalIdx` — the stale pre-boxing
+RAW f64 slot — baking `local.get <f64>` where the callee signature expects the
+ref cell. The correct `capturedBoxGlobals` arm existed (#2029 family A) but was
+unreachable behind the `boxedCaptures` branch.
+
+Verified by instrument: at the `g2()` call, `localMap=undefined boxed=true
+boxGlobal=true` → fallback to `cap.outerLocalIdx` (the raw f64).
+
+### Fix (calls.ts, narrow)
+
+Before the `boxedCaptures` branch: when `localMap.get(cap.name)` is undefined
+AND `ctx.capturedBoxGlobals` has the name, source the SAME shared cell from
+the promotion global (`global.get` + `ref.as_non_null`). Live write-through is
+preserved — the callee mutation, the method body, and the enclosing function
+all share one cell (proven at runtime: g2 `+=1` → method reads 1 → method
+`+=10` → enclosing reads 11). The old fallback in this configuration was
+ALWAYS invalid Wasm, so no valid module changes shape.
+
+### Proofs
+
+- 13 discriminator probes VALID (generator/non-generator mutator, normal and
+  destructuring method params, elision/binding patterns); all previously-valid
+  controls unchanged.
+- test262: 3 of the 6 files now **pass** end-to-end
+  (`*-rest-ary-elision.js`); the 3 `*-ptrn-elision.js` flip CE→plain fail on a
+  DISTINCT bug (the param-elision destructure advances the iterator twice —
+  `assert.sameValue(second, 0)` fails; see roll-forward below).
+- Full 214-candidate re-harvest: 78 → **72**, exactly this cluster, no new
+  signatures.
+- 12-program corpus **byte-identical** (sha256) to main.
+- New `tests/issue-3024-promoted-capture-call.test.ts` (5 tests, runtime
+  write-through assertions) passes; adjacent promotion suites (issue-3121,
+  issue-3039, issue-2029-tagged-template-capture-local-index,
+  issue-3024-incdec-element — 30 tests) pass.
+
+### Still open (roll forward)
+
+- **NEW (distinct root cause):** array-binding-pattern ELISION in a method
+  param over-steps the iterator (one extra IteratorStep) — turns the 3
+  `*-ptrn-elision.js` files into semantic fails now that they validate.
+- The remaining 72 invalid-Wasm files: 7-file `fN.ne` cross-statement
+  eval-promotion family (banked, broad-impact), then ≤4-file singletons
+  (`__obj_meth_tramp_*_valueOf`, `struct.set (ref null #)`, `call expected
+  externref found ref.func`, Atomics `__cb_#` fallthru, `i#.lt_s` …).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -15264,7 +15264,24 @@ function compileCallExpression(
             const hasBoxedName = localSlot?.name?.startsWith(`__boxed_`) ?? false;
             candidateIsBoxed = isRefCellTyped && hasBoxedName;
           }
-          if (fctx.boxedCaptures?.has(cap.name) || candidateIsBoxed) {
+          // (#3024) Method/accessor capture promotion (#2029/#3039/#3121,
+          // closures.ts) moves a boxed capture's cell into a module global and
+          // DELETES the localMap binding so post-promotion code in the
+          // enclosing function routes through the global. `boxedCaptures`
+          // still has the name, so without this arm the branch below resolved
+          // `localMap.get(name) ?? cap.outerLocalIdx` → the STALE pre-boxing
+          // raw slot (an f64/i32 local) and baked `local.get <raw>` where the
+          // callee expects the ref cell → invalid Wasm (`call[0] expected
+          // (ref null N), found local.get of type f64`; the test262
+          // object/dstr meth-ary-ptrn-elision family). Source the SAME shared
+          // cell from the promotion global instead (live write-through — the
+          // method body and the enclosing function read/write this cell too).
+          const promotedBoxGlobal =
+            fctx.localMap.get(cap.name) === undefined ? ctx.capturedBoxGlobals?.get(cap.name) : undefined;
+          if (promotedBoxGlobal !== undefined && fctx.boxedCaptures?.has(cap.name)) {
+            fctx.body.push({ op: "global.get", index: promotedBoxGlobal.globalIdx });
+            fctx.body.push({ op: "ref.as_non_null" });
+          } else if (fctx.boxedCaptures?.has(cap.name) || candidateIsBoxed) {
             // Already a ref cell — pass the ref cell reference directly
             const currentLocalIdx = fctx.localMap.get(cap.name) ?? cap.outerLocalIdx;
             fctx.body.push({ op: "local.get", index: currentLocalIdx });

--- a/tests/issue-3024-promoted-capture-call.test.ts
+++ b/tests/issue-3024-promoted-capture-call.test.ts
@@ -1,0 +1,110 @@
+// (#3024) Calling a capturing nested function AFTER a method/accessor capture
+// promotion produced invalid Wasm.
+//
+// Shape: a local is closure-MUTATED by a nested function (boxed into a ref
+// cell, `fctx.boxedCaptures`), and an object-literal method also references
+// it. Compiling the object literal runs the accessor/method capture promotion
+// (#2029/#3039/#3121, closures.ts): the shared cell is aliased into a module
+// global and the `localMap` binding is DELETED so post-promotion code routes
+// through the global. But the direct-call capture-prepend in calls.ts checked
+// `boxedCaptures` FIRST and resolved `localMap.get(name) ?? cap.outerLocalIdx`
+// — the stale pre-boxing RAW slot — baking `local.get <f64>` where the callee
+// expects the ref cell: `call[0] expected (ref null N), found local.get of
+// type f64` (test262 language/expressions/object/dstr
+// {meth,gen-meth,async-gen-meth}-ary-ptrn-(rest-ary-)elision, 6 files).
+//
+// The fix sources the SAME shared cell from the promotion global
+// (`ctx.capturedBoxGlobals`) when the localMap binding is gone, so the callee
+// mutation, the method body, and the enclosing function all share one cell.
+//
+// `WebAssembly.compile` is load-bearing: the regression was a *validation*
+// failure. Runtime assertions prove the write-through semantics.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+  const imports = buildImports(r.imports, undefined, r.stringPool) as WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: unknown) => void }).setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#3024 capturing-fn call after method capture promotion", () => {
+  it("nested fn mutating a var read by an object method — validates and writes through", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var first = 0;
+          function g2() { first += 1; }
+          var obj = { method([,]) { if (first !== 1) return 0; } };
+          g2();
+          obj.method([1]);
+          return first;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("generator arg + destructuring-param method (test262 elision shape) validates", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var first = 0;
+          function* g() { first += 1; yield; }
+          var obj = { method([,]) { if (first !== 1) return 0; return 1; } };
+          obj.method(g());
+          return first;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("method with a NORMAL param — same promotion, same call path", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var first = 0;
+          function g2() { first += 2; }
+          var obj = { method(x: number) { if (first !== 2) return 0; } };
+          g2();
+          obj.method(1);
+          return first;
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it("method mutation is visible to the enclosing function after the callee ran (shared cell)", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var first = 0;
+          function g2() { first += 1; }
+          var obj = { method([,]) { first = first + 10; } };
+          g2();
+          obj.method([1]);
+          return first;
+        }
+      `),
+    ).toBe(11);
+  });
+
+  it("control: capturing call with NO object-literal method stays correct", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var first = 0;
+          function g2() { first += 1; }
+          g2();
+          g2();
+          return first;
+        }
+      `),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Second bounded slice of **#3024** (default-lane invalid-Wasm emitter residual). Clears the 6-file `language/expressions/object/dstr` `{meth,gen-meth,async-gen-meth}-ary-ptrn-(rest-ary-)elision` cluster (`call[0] expected (ref null N), found local.get of type f64` in `test`). Post-slice-1 measurement: **78** still-invalid; after this PR: **72**, zero new signatures.

## Root cause

Not a destructuring bug. Trigger: a local that is (a) closure-mutated by a nested function (boxed to a ref cell, `fctx.boxedCaptures`) and (b) also referenced by an object-literal method. Compiling the object literal runs the method/accessor capture promotion (#2029/#3039/#3121, `closures.ts`): the shared cell is aliased into a module global (`ctx.capturedBoxGlobals`) and the `localMap` binding is **deleted** so post-promotion code routes through the global. But the direct-call capture-prepend (`calls.ts`) checks `boxedCaptures` first and resolved `localMap.get(name) ?? cap.outerLocalIdx` — the stale pre-boxing RAW f64 slot — baking `local.get <f64>` where the callee signature expects the ref cell. The correct `capturedBoxGlobals` arm (#2029 family A) existed but was unreachable behind the `boxedCaptures` branch. Verified by instrumentation (`localMap=undefined boxed=true boxGlobal=true` at the call).

## Fix

Narrow arm ahead of the `boxedCaptures` branch: when the `localMap` binding is gone AND `ctx.capturedBoxGlobals` has the name, source the SAME shared cell from the promotion global (`global.get` + `ref.as_non_null`). Live write-through preserved (callee mutation → method read → enclosing-function read all hit one cell; proven at runtime 1 → 11). The old fallback in this configuration was always invalid Wasm, so no valid module changes shape.

## Proofs

- 13 discriminator probes valid (generator/non-generator mutator, normal + destructuring method params, elision/binding); all previously-valid controls unchanged.
- test262: 3/6 cluster files now **pass** end-to-end; the 3 `*-ptrn-elision.js` flip CE→plain semantic fail on a DISTINCT bug (method-param elision advances the iterator twice — documented as roll-forward in the issue).
- Full 214-candidate re-harvest: 78 → **72**, exactly this cluster, no new signatures.
- 12-program corpus **byte-identical** (sha256) to main.
- New `tests/issue-3024-promoted-capture-call.test.ts` (5 tests, runtime write-through assertions); adjacent promotion suites (issue-3121, issue-3039, issue-2029-tagged-template-capture-local-index, issue-3024-incdec-element — 30 tests) pass.
- `loc-budget-allow` granted for `calls.ts` in the issue frontmatter (#3131).

Issue #3024 stays `ready` — 72 scattered singletons remain (largest: the banked 7-file `fN.ne` cross-statement eval-promotion family, broad-impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)