### PR TITLE
fix(#2992): standalone delete on {}-widened receivers observes real deletion (slice 4)

### DIFF
--- a/plan/issues/2992-standalone-defineproperties-mop-residual.md
+++ b/plan/issues/2992-standalone-defineproperties-mop-residual.md
@@ -68,7 +68,7 @@ Wants slicing into separate PRs:
 1. delete-tombstone-read survival (bounded — start here). **SHIPPED — see slice-1 findings below.**
 2. array/arguments index + `length` own-prop MOP. **BLOCKED on the vec-receiver own-prop substrate (see slice-3 findings) — no bounded slice (#2986 agrees).**
 3. accessor-attribute (get/set) define→gOPD fidelity. **SHIPPED (with the broader §10.1.6.3 partial-descriptor MERGE) — see slice-3 findings below.**
-4. (NEW, found during slice 1) nominal-struct field delete fidelity — see below.
+4. (NEW, found during slice 1) nominal-struct field delete fidelity — see below. **SHIPPED (standalone `{}`-widening shape) — see slice-4 findings below.**
 5. (NEW, found during slice 3) accessor/own-prop MOP on CLOSED-STRUCT receivers (`__extern_get` accessor arm misses; hasOwnProperty/delete invisible) — the biggest residual cluster (4-75/4-82-* family), substrate-adjacent to slice 2 and slice 4.
 
 ## Slice 1 findings (measured 2026-07-10 on main 569e29b761, fable-18th)
@@ -150,6 +150,41 @@ preventExtensions, create, gOPD, Reflect, Array.prototype, Boolean) still
 pass; equivalence `object-define-property*`, `define-property-typeerror`,
 `hasownproperty-call`: 46/46; `tests/issue-2992.test.ts` 12/12;
 new `tests/issue-2992-accessor-merge.test.ts` 18/18 (gc + standalone).
+
+## Slice 4 findings (measured 2026-07-11 on main 2ff0db4f0a, fable-sub2)
+
+The headline nominal-struct delete repro is fixed for the **empty-`{}`-widening
+shape** (the issue's documented case): `delete varName.prop` /
+`delete varName[k]` is now an `$Object`-hash consumer for the widening
+decision in `src/codegen/declarations.ts` (`markStandaloneDeleteTargets`,
+standalone-gated). A widened closed-struct field can only take a type-shaped
+SENTINEL on delete (f64 → NaN, ref → null; `typeof-delete.ts`), and the
+statically-typed read const-folds `o.k === undefined` to false — so the var
+now stays a `$Object`, where the slice-1 `__delete_property` tombstones give
+correct delete → read / `in` / hasOwnProperty / typeof semantics.
+
+Measured: probe matrix 10/10 (top-level + in-function, f64 + string fields,
+delete→redefine cycle, parenthesized target, elem-access delete, no-delete
+widening control, cross-var control); `tests/issue-2992-delete-widening.test.ts`
+12 pass + 2 documented gc-lane skips; +3 flips in the 80-file defineProperty
+gap sample and +2/9 in the `language/expressions/delete` standalone gap;
+142/142 baseline-pass sweep and the 50-test equivalence regression set clean.
+
+**Documented residuals (fail identically on unmodified main — NOT regressions):**
+
+- **gc-lane twin**: the top-level widened-struct delete has the same
+  sentinel/const-fold bug in the gc/host lane; this slice is standalone-gated
+  (host poison needs the #2937/#2944 `objectHashConsumerTypes` escape
+  discipline — separate risk profile).
+- **Non-empty literal receivers** (`const o = { name: "hello" }; delete
+  o.name`) — closed-struct-literal shape (fails in gc too; the pre-existing
+  `delete-sentinel` equivalence failure). Extending #2837's
+  `collectGrowableObjectLiterals` triggers with delete-targets is the likely
+  lever, but its consumer-safety guard needs its own validation pass.
+- **Two-`{}`-var type-interning hazard**: when ANOTHER var's widening interns
+  the shared `{}` literal ts.Type in `anonTypeMap`, the poisoned var's `{}`
+  initializer can still compile to the OTHER var's struct (pre-existing
+  type-identity hazard, fails identically on main).
 
 ## Test Results (slice 1)
 

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2549,6 +2549,24 @@ export function collectEmptyObjectWidening(
             markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
           }
 
+          // (#2992 S4, standalone) `delete varName.prop` / `delete varName[k]`
+          // is an `$Object`-hash consumer too: a widened closed-struct FIELD
+          // cannot represent a deleted property — the struct-delete arm
+          // (typeof-delete.ts) writes a type-shaped SENTINEL (f64 → NaN,
+          // ref → null) into the fixed slot, and a statically-f64 read makes
+          // `o.k === undefined` CONST-FOLD to false, so the read can never
+          // observe the deletion (the issue's headline nominal-struct repro;
+          // also the pre-existing `delete-sentinel` string-field equivalence
+          // failure). Poison the widening so the var stays a `$Object`, where
+          // `__delete_property` tombstones give correct delete → read / `in` /
+          // hasOwnProperty semantics. Standalone-gated: the host lane's
+          // sidecar + live-mirror handles struct deletes (byte-inert).
+          if (ctx.standalone && !ctx.objectHashConsumerVars.has(varName)) {
+            for (const s of stmts) {
+              markStandaloneDeleteTargets(s, varName, ctx.objectHashConsumerVars);
+            }
+          }
+
           // (#2372) Standalone: if any `Object.defineProperty(varName, …)` on
           // this receiver used a *dynamic* (non-inline-literal) descriptor, the
           // struct-widening fast path is unsound — the dynamic define is applied
@@ -2931,6 +2949,34 @@ function isAccessorDescriptor(descArg: ts.Expression): boolean {
  * matching the existing widening pre-pass (aliasing is a shared, documented
  * limitation — see the issue's `## Deferred`).
  */
+/**
+ * (#2992 S4, standalone-only caller) Poison `varName` when it is the receiver
+ * of any `delete varName.prop` / `delete varName[<expr>]` in the scanned
+ * statements. A widened closed struct cannot drop a field, so the delete arm's
+ * sentinel write (NaN / null) lies to every later read (`o.k === undefined`
+ * const-folds false on an f64 field). Keeping the var a `$Object` routes the
+ * delete through the `__delete_property` tombstone machinery, which slice 1
+ * (#2872) already proved correct in every lane. Parenthesized targets
+ * (`delete (o.k)`) are unwrapped like the module-init collector does.
+ */
+function markStandaloneDeleteTargets(node: ts.Node, varName: string, poisonSet: Set<string>): void {
+  const visit = (n: ts.Node): void => {
+    if (ts.isDeleteExpression(n)) {
+      let target: ts.Expression = n.expression;
+      while (ts.isParenthesizedExpression(target)) target = target.expression;
+      if (
+        (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
+        ts.isIdentifier(target.expression) &&
+        target.expression.text === varName
+      ) {
+        poisonSet.add(varName);
+      }
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+}
+
 function markObjectHashConsumers(node: ts.Node, varName: string, poisonSet: Set<string>): void {
   const isVarRef = (n: ts.Node): boolean => ts.isIdentifier(n) && n.text === varName;
 

--- a/tests/issue-2992-delete-widening.test.ts
+++ b/tests/issue-2992-delete-widening.test.ts
@@ -1,0 +1,154 @@
+// #2992 (slice 4) — standalone: `delete` on an empty-`{}`-widened receiver
+// must observe real deletion semantics.
+//
+// Root cause (documented in the issue's slice-1 findings): the empty-object
+// widening pre-pass (declarations.ts) promoted an all-prop-access `{}` var to
+// a closed nominal struct. The struct-delete arm (typeof-delete.ts) can only
+// write a type-shaped SENTINEL into the fixed field (f64 → NaN, ref → null),
+// and a statically-f64 read makes `o.k === undefined` CONST-FOLD to
+// `i32.const 0` — the read can never observe the deletion (nor can `in` /
+// hasOwnProperty).
+//
+// Fix: `delete varName.prop` / `delete varName[k]` is now an `$Object`-hash
+// consumer for the widening decision (standalone-gated — the host lane keeps
+// its sidecar + live-mirror struct-delete handling byte-identical). The var
+// stays a `$Object`, where `__delete_property` tombstones (slice 1, #2872)
+// give correct delete → read / `in` / hasOwnProperty / typeof semantics.
+//
+// Documented residuals (fail identically on unmodified main — NOT regressions):
+//   - NON-EMPTY literal receivers (`const o = { name: "hello" }; delete
+//     o.name`) — closed-struct-literal shape, fails in the gc lane too
+//     (tests/equivalence/delete-sentinel.test.ts "delete string property").
+//   - TWO `{}` vars where another var's widening interns the shared `{}`
+//     literal type in `anonTypeMap` — the poisoned var's literal can still
+//     compile to the OTHER var's struct (pre-existing type-identity hazard).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string, target: "gc" | "standalone"): Promise<any> {
+  const result: any = await compile(src, {
+    fileName: "test.ts",
+    target,
+    skipSemanticDiagnostics: true,
+  } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as any).test?.();
+}
+
+// The top-level and parenthesized variants ALSO fail in the gc lane on
+// unmodified main (the gc widened-struct delete writes the same sentinel and
+// hits the same const-fold) — that gc residual is pre-existing and out of this
+// standalone-gated slice; those two cases run standalone-only.
+for (const target of ["gc", "standalone"] as const) {
+  describe(`#2992 S4 — delete on widened {} receiver (${target})`, () => {
+    (target === "standalone" ? it : it.skip)(
+      "top-level all-prop-access {}: delete then read observes undefined (headline repro)",
+      async () => {
+        const ret = await run(
+          `
+const o: any = {};
+o.k = 1;
+delete o.k;
+export function test(): number { return o.k === undefined ? 1 : 0; }
+`,
+          target,
+        );
+        expect(ret).toBe(1);
+      },
+    );
+
+    it("in-function: delete then read / 'in' / hasOwnProperty / typeof all observe the deletion", async () => {
+      const ret = await run(
+        `
+export function test(): number {
+  const o: any = {};
+  o.k = 1;
+  delete o.k;
+  return (o.k === undefined && !("k" in o) && !o.hasOwnProperty("k") && typeof o.k === "undefined") ? 1 : 0;
+}
+`,
+        target,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("string-typed field: delete makes it undefined", async () => {
+      const ret = await run(
+        `
+export function test(): number {
+  const o: any = {};
+  o.s = "hello";
+  delete o.s;
+  return o.s === undefined ? 1 : 0;
+}
+`,
+        target,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("delete → redefine cycle (verifyProperty shape) round-trips", async () => {
+      const ret = await run(
+        `
+export function test(): number {
+  const o: any = {};
+  o.k = 1;
+  delete o.k;
+  o.k = 2;
+  return (o.k === 2 && o.hasOwnProperty("k")) ? 1 : 0;
+}
+`,
+        target,
+      );
+      expect(ret).toBe(1);
+    });
+
+    (target === "standalone" ? it : it.skip)("parenthesized delete target still poisons the widening", async () => {
+      const ret = await run(
+        `
+export function test(): number {
+  const o: any = {};
+  o.k = 1;
+  delete (o.k);
+  return o.k === undefined ? 1 : 0;
+}
+`,
+        target,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("no-delete control: the widening fast path is unaffected", async () => {
+      const ret = await run(
+        `
+export function test(): number {
+  const o: any = {};
+  o.k = 1;
+  o.j = 2;
+  return (o.k === 1 && o.j === 2) ? 1 : 0;
+}
+`,
+        target,
+      );
+      expect(ret).toBe(1);
+    });
+
+    it("element-access delete on the widened var works too", async () => {
+      const ret = await run(
+        `
+export function test(): number {
+  const o: any = {};
+  o.k = 1;
+  delete o["k"];
+  return o.k === undefined ? 1 : 0;
+}
+`,
+        target,
+      );
+      expect(ret).toBe(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Slice 4 of #2992. The empty-object widening pre-pass promoted an all-prop-access `{}` var to a closed nominal struct; the struct-delete arm (`typeof-delete.ts`) can only write a type-shaped SENTINEL into the fixed field (f64 → NaN, ref → null), and the statically-typed read CONST-FOLDS `o.k === undefined` to false — so a deleted property could never be observed (nor via `in` / `hasOwnProperty` / `typeof`). This was the issue's headline nominal-struct repro and the mechanism behind destructive verifyProperty delete-cycles on widened receivers.

### Change
`delete varName.prop` / `delete varName[k]` (parenthesized targets unwrapped) is now an `$Object`-hash consumer for the widening decision in `src/codegen/declarations.ts` (`markStandaloneDeleteTargets`, joins the #2584/#2849 poison at the same decision point). The var stays a `$Object`, where the slice-1 (#2872) `__delete_property` tombstones give correct delete semantics. **Standalone-gated** — the gc/host lane's widening decision and bytes are untouched.

### Measured (standalone, real runner pipeline)
- +3 flips in the 80-file defineProperty standalone gap sample; +2/9 in the `language/expressions/delete` standalone gap.
- Probe matrix 10/10 (top-level + in-function, f64 + string fields, delete→redefine cycle, elem-access delete, widening-control, cross-var control).
- **Zero regressions**: 142/142 baseline-passing sweep (defineProperty/ies, freeze, seal, create, gOPD, Reflect, Array, Boolean); equivalence set 50/50 (incl. `empty-object-widening`).
- New `tests/issue-2992-delete-widening.test.ts`: 12 pass + 2 documented gc-lane skips.

### Documented residuals (fail identically on unmodified main)
gc-lane sentinel twin (needs the #2937/#2944 host escape discipline), non-empty-literal receivers (the pre-existing `delete-sentinel` gc equivalence failure — #2837 trigger extension is the likely lever), and the two-`{}`-var `anonTypeMap` type-interning hazard — all recorded in the issue file.

Issue stays `in-progress` (slices 2/5 are substrate-walled — see the issue's slicing table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)