### PR TITLE
fix(#3024): box a static method named constructor as a value (no raw funcref)

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -18,6 +18,7 @@ test262_ce: 131
 related: []
 loc-budget-allow:
   - src/codegen/expressions/calls.ts
+  - src/codegen/property-access.ts
 ---
 
 # #3024 — invalid Wasm binary emission residual (default lane)
@@ -496,4 +497,58 @@ ALWAYS invalid Wasm, so no valid module changes shape.
 - The remaining 72 invalid-Wasm files: 7-file `fN.ne` cross-statement
   eval-promotion family (banked, broad-impact), then ≤4-file singletons
   (`__obj_meth_tramp_*_valueOf`, `struct.set (ref null #)`, `call expected
-  externref found ref.func`, Atomics `__cb_#` fallthru, `i#.lt_s` …).
+externref found ref.func`, Atomics `__cb_#` fallthru, `i#.lt_s` …).
+
+---
+
+## Landed: static-method-named-`constructor` as a value (fable-wasm, 2026-07-11, slice 4)
+
+**PR:** `issue-3024-static-ctor-genmeth` — clears the 4-file
+`grammar-static-ctor-{gen,async-gen}-meth-valid` cluster
+(`language/{expressions,statements}/class/elements/syntax/valid/`;
+`call[N] expected externref, found ref.func of type (ref M)` in `test`).
+
+### Root cause (funcref through `extern.convert_any`)
+
+A class may declare a STATIC method literally named `constructor`
+(`static * constructor() {}` — legal ES, distinct from the instance
+constructor). Reading it as a value (`C.constructor`, e.g. the harness'
+`assert.notSameValue(C.prototype.constructor, C.constructor)`) must box it like
+any other static method: a closure struct → `extern.convert_any` (the
+`emitFuncRefAsClosure` arm at property-access.ts ~5005). But the
+`ClassName.constructor` arm (property-access.ts ~4980) fired FIRST and took a
+raw path — `ref.func <C_constructor>` + `extern.convert_any`. A funcref is NOT
+in the anyref hierarchy, so `extern.convert_any` on a funcref is invalid, and
+the invalid value surfaced at the CONSUMER as `call[N] expected externref,
+found ref.func of (ref M)`.
+
+### Fix (property-access.ts)
+
+Guard the raw ctor-ref arm with `&& !ctx.staticMethodSet.has(fullName)` so a
+class that owns a static `constructor` method falls through to the
+static-method closure arm (correct funcref → closure-struct → externref
+boxing). Plain classes (no static `constructor`) are unaffected — byte-inert.
+
+### Proofs
+
+- Repro (`sink(C.constructor)` with `static * constructor`) VALIDATES; plain-class
+  `C.constructor` and ordinary static-method-value controls unchanged.
+- All 4 target test262 files flip CE → valid Wasm (they now fail only on a
+  distinct `C.prototype.hasOwnProperty('constructor')` semantic, not a compile
+  error).
+- Full 214-candidate re-harvest: the 4 `ref.func` files cleared, zero new
+  invalid signatures (72 → 68 on the slice-1+2 base).
+- 12-program corpus **byte-identical** (sha256) to main.
+- New `tests/issue-3024-static-ctor-method-value.test.ts` (4 tests); adjacent
+  class-static-method suites (issue-1394, 2933-reflect-static-method-value,
+  3133-instance-constructor-identity, 846-class-static-prototype, 2587,
+  test262-runner-static-gen-yield — 51 tests) pass. The class-elements-619
+  failures are PRE-EXISTING on main (verified by control run).
+- `loc-budget-allow` granted for `property-access.ts` (#3131; +11 net).
+
+### Still open (roll forward)
+
+The remaining invalid-Wasm files: the banked 7-file `fN.ne` cross-statement
+eval-promotion family (broad-impact) and ≤4-file per-root-cause singletons
+(`struct.set (ref null #)`, Atomics `__cb_#` fallthru, `i#.lt_s`,
+`__vec_from_extern` element-rep, async-gen `__closure_#`).

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -4976,8 +4976,19 @@ export function compilePropertyAccess(
         fctx.body.push({ op: "ref.null.extern" });
         return { kind: "externref" };
       }
-      // ClassName.constructor — return the constructor function reference
-      if (propName === "constructor") {
+      // ClassName.constructor — return the constructor function reference.
+      // (#3024) A class may declare a STATIC method literally named
+      // `constructor` (`static * constructor() {}` — legal, distinct from the
+      // instance constructor; the `grammar-static-ctor-*-meth-valid` test262
+      // family). `C.constructor` then reads that static method as a value and
+      // must be boxed like any other static method (a closure struct →
+      // `extern.convert_any`, the arm below). The legacy raw path here emitted
+      // `ref.func <C_constructor>` + `extern.convert_any` — but a funcref is
+      // NOT in the anyref hierarchy, so `extern.convert_any` on it is invalid
+      // Wasm (`call[N] expected externref, found ref.func of (ref M)`). Skip
+      // the raw path when a static method owns the name, letting the
+      // static-method closure arm below handle it correctly.
+      if (propName === "constructor" && !ctx.staticMethodSet.has(fullName)) {
         const ctorName = `${resolvedClass}_constructor`;
         const funcIdx = ctx.funcMap.get(ctorName);
         if (funcIdx !== undefined) {

--- a/tests/issue-3024-static-ctor-method-value.test.ts
+++ b/tests/issue-3024-static-ctor-method-value.test.ts
@@ -1,0 +1,53 @@
+// (#3024) A class may declare a STATIC method literally named `constructor`
+// (`static * constructor() {}` — legal ES, distinct from the instance
+// constructor; the test262 `grammar-static-ctor-{gen,async-gen}-meth-valid`
+// family). Reading it as a value — `C.constructor` — must box it like any
+// other static method (closure struct → `extern.convert_any`).
+//
+// The `ClassName.constructor` property-access arm (property-access.ts) instead
+// took a raw path: `ref.func <C_constructor>` + `extern.convert_any`. A funcref
+// is NOT in the anyref hierarchy, so `extern.convert_any` on it is invalid Wasm,
+// surfacing at the CONSUMER as `call[N] expected externref, found ref.func of
+// type (ref M)` (the static generator constructor forwarded to an `any`-typed
+// param such as `assert.notSameValue(C.prototype.constructor, C.constructor)`).
+//
+// Fix: skip the raw ctor-ref path when a static method owns the `constructor`
+// name (`ctx.staticMethodSet`), letting the static-method closure arm box it.
+//
+// `WebAssembly.compile` is load-bearing: the regression was a *validation*
+// failure.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileValid(source: string) {
+  const r = await compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+}
+
+describe("#3024 static method named `constructor` as a value", () => {
+  it("static generator constructor forwarded to an any-typed param validates", async () => {
+    await compileValid(`function sink(x: any): void {}
+      class C { static * constructor() {} constructor() {} }
+      export function test(): number { sink(C.constructor); return 1; }`);
+  });
+
+  it("static async-generator constructor as a value validates", async () => {
+    await compileValid(`function sink(x: any): void {}
+      class C { static async * constructor() {} constructor() {} }
+      export function test(): number { sink(C.constructor); return 1; }`);
+  });
+
+  it("control: a plain class `C.constructor` value still validates", async () => {
+    await compileValid(`function sink(x: any): void {}
+      class C { constructor() {} }
+      export function test(): number { sink(C.constructor); return 1; }`);
+  });
+
+  it("control: an ordinary static method value still validates", async () => {
+    await compileValid(`function sink(x: any): void {}
+      class C { static m() { return 1; } }
+      export function test(): number { sink(C.m); return 1; }`);
+  });
+});


### PR DESCRIPTION
## Summary

Fourth bounded slice of **#3024** (default-lane invalid-Wasm emitter residual). Clears the 4-file `grammar-static-ctor-{gen,async-gen}-meth-valid` cluster (`language/{expressions,statements}/class/elements/syntax/valid/`; `call[N] expected externref, found ref.func of type (ref M)` in `test`). The 4 files flip CE → valid Wasm.

## Root cause

A class may declare a **static method literally named `constructor`** (`static * constructor() {}` — legal ES, distinct from the instance constructor; this test262 family). Reading it as a value (`C.constructor`, e.g. the harness' `assert.notSameValue(C.prototype.constructor, C.constructor)`) must box it like any other static method: a closure struct → `extern.convert_any` (the `emitFuncRefAsClosure` arm, property-access.ts ~5005). But the `ClassName.constructor` arm (~4980) fired **first** and took a raw path — `ref.func <C_constructor>` + `extern.convert_any`. A funcref is **not** in the anyref hierarchy, so `extern.convert_any` on it is invalid; the bad value surfaced at the consumer as `call[N] expected externref, found ref.func of (ref M)`.

## Fix

Guard the raw ctor-ref arm with `&& !ctx.staticMethodSet.has(fullName)` so a class that owns a static `constructor` method falls through to the static-method closure arm (correct funcref → closure-struct → externref boxing). Plain classes (no static `constructor`) are unaffected — byte-inert.

## Proofs

- Repro (`sink(C.constructor)` with `static * constructor`) validates; plain-class `C.constructor` + ordinary static-method-value controls unchanged.
- All 4 target test262 files flip CE → valid Wasm (now fail only on a distinct `C.prototype.hasOwnProperty('constructor')` semantic).
- Full 214-candidate re-harvest: the 4 `ref.func` files cleared, zero new invalid signatures.
- 12-program corpus **byte-identical** (sha256) to main.
- New `tests/issue-3024-static-ctor-method-value.test.ts` (4 tests); 51 adjacent class-static-method tests pass (issue-1394/2933/3133/846/2587/test262-runner-static-gen-yield). The class-elements-619 failures are **pre-existing on main** (verified by control run).
- `loc-budget-allow` granted for `property-access.ts` (#3131).

Fourth of four #3024 slices this session (PR #2890, #2896, #2901 preceding). Issue stays `ready` — remaining invalid-Wasm files are the banked 7-file `fN.ne` family + ≤4-file singletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)