### PR TITLE
fix(#3134): Promise<T> value slots lower to externref on the host lane (unblocks #2967 2c class-2)

### DIFF
--- a/plan/issues/3134-promise-typed-value-slots-unwrap-to-f64-host-lane.md
+++ b/plan/issues/3134-promise-typed-value-slots-unwrap-to-f64-host-lane.md
@@ -95,3 +95,45 @@ as the honest end-state.
 - The three probe shapes above resolve to 42 on the host lane.
 - Full-corpus A/B net ≥ 0 (this touches declaration typing — broad impact,
   full CI validation, never scoped-sweep only).
+
+## Implementation (2026-07-11, fable-senior) — Direction 2 (rep convergence)
+
+Chose direction 2 (the issue's recommended end-state) over the narrow
+direction 1 because `resolveWasmType` is a PURE function of the TS type — it
+cannot see the initializer, so direction 1 would need per-call-site changes at
+every typing site (locals, params-with-defaults, fields, non-async returns,
+AND vec element types), and direction 1 cannot reach a `Promise<T>` VEC ELEMENT
+at all (no per-element initializer to inspect). Direction 2 is the single site
+that fixes all of them — and it is exactly the rep the #2967 2c class-2 blocker
+needs (a `Promise<T>[]` vec element now resolves to `vec<externref>`, matching
+the stored promise, so the async-frame spill guess stops diverging).
+
+**The change** (`src/codegen/index.ts`, the `sym?.name === "Promise"` branch of
+`resolveWasmType`): `Promise<T>` → `externref` on EVERY lane (dropped the
+`isStandalonePromiseActive` gate that made host/GC unwrap to `T`). One
+externref serves BOTH reps:
+
+- a REAL promise (Promise builtin, activated async fn result) passes through
+  as externref — fixing the `__unbox_number` → NaN;
+- a SYNC-FAKERY value (a legacy async call compiled synchronously returns the
+  unwrapped `T` = f64) boxes at the declaration coerce (`__box_number`), then
+  either `__unbox_number`s back for a later numeric use, or assimilates through
+  `Promise_resolve` at `await` — both correct.
+
+Why it's safe where it matters: an async fn's OWN wasm return signature is
+pre-unwrapped via `unwrapPromiseType` (declarations/closures/class-bodies)
+BEFORE this branch runs, so activated result types are unaffected. externref is
+a leaf valtype — no new type registration, no DCE remap / funcIdx churn.
+
+**Local validation:** the 5 acceptance cases (3 probe shapes + sync-fakery
+parity + the class-2 vec-element rep) all resolve to 42. Async battery
+(async-await / equivalence async-function / 1042-host-drive / 2957 /
+2967-engine-convergence / 2906-multiawait) green; the only 2 failures are
+`promise-combinators` `Promise.all/race with resolved values` — pre-existing
+("undefined is not iterable", the exact documented #2967-slice-1 failure mode,
+engine-independent). tsc clean.
+
+**Risk:** broad — every `Promise<T>` value slot's rep flips f64→externref. The
+merge_group full-corpus A/B is the hard gate (never scoped-sweep only).
+
+status: in-review pending the full-CI A/B.

--- a/plan/issues/3134-promise-typed-value-slots-unwrap-to-f64-host-lane.md
+++ b/plan/issues/3134-promise-typed-value-slots-unwrap-to-f64-host-lane.md
@@ -1,9 +1,10 @@
 ---
 id: 3134
 title: "Promise<T>-typed value slots unwrap to T (f64) on the JS-host lane — a real promise externref gets __unbox_number'd to NaN at the declaration"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-senior
 created: 2026-07-10
-updated: 2026-07-10
+updated: 2026-07-11
 priority: medium
 horizon: m
 feasibility: hard

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -12095,15 +12095,24 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
         // storing the externref into an f64/struct slot would otherwise coerce
         // `externref → f64` via __unbox_number = NaN (or an illegal struct cast).
         //
-        // GC/host stays byte-identical: the unwrap-to-T contract only held
-        // because async fns are compiled synchronously, which is exactly when the
-        // carrier is OFF. An async fn's OWN wasm return signature pre-unwraps via
-        // unwrapPromiseType (function-body.ts / declarations.ts), so this branch
-        // is only hit for *value* slots (bindings / params / fields / non-async
-        // returns), never an async fn's own result type. externref is a leaf
-        // valtype — registers no new type, so no DCE remap / funcIdx churn.
-        if (isStandalonePromiseActive(ctx)) return { kind: "externref" };
-        return resolveWasmType(ctx, inner, _depth + 1, _visited);
+        // (#3134) A `Promise<T>`-typed VALUE slot lowers to externref on EVERY
+        // lane — it holds a real promise object (a Promise builtin chain, or an
+        // activated async fn's result), never the unwrapped `T`. Unwrapping to
+        // `T` (f64) then `__unbox_number`'d the real promise externref at the
+        // declaration → NaN (#3134); it only "worked" for the legacy sync-fakery
+        // population, where an async call returns the unwrapped value — and there
+        // the boxed value round-trips harmlessly (`f() : Promise<number>` stores
+        // the f64 via `__box_number`, and a later numeric use `__unbox_number`s
+        // it back, while `await p` assimilates it through `Promise_resolve`). So
+        // externref serves BOTH reps: a real promise passes through, a
+        // sync-fakery value boxes/unboxes. This ALSO unifies the rep of a
+        // `Promise<T>`-typed vec ELEMENT (`const xs = [p]`) — the frame spill
+        // guess now matches the stored promise (unblocks #2967 2c class-2).
+        // An async fn's OWN wasm return signature pre-unwraps via
+        // `unwrapPromiseType` (declarations/closures/class-bodies) BEFORE this
+        // branch, so it is unaffected. externref is a leaf valtype — no new type,
+        // no DCE remap / funcIdx churn. Broad rep change → full-CI A/B (#3134).
+        return { kind: "externref" };
       }
       return { kind: "externref" }; // bare Promise without type arg
     }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -106,7 +106,6 @@ import {
   exportDrainMicrotasksIfRegistered,
   getDrainFuncIdxForWasiStart,
   getRunLoopFuncIdxForWasiStart,
-  isStandalonePromiseActive,
   shiftAsyncSideChannelFuncIdxs,
 } from "./async-scheduler.js";
 import { inLiveShiftRange } from "../emit/resolve-layout.js"; // (#1916 S3) stable handles never shift

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -12087,31 +12087,17 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
       if (typeArgs.length > 0) {
         const inner = typeArgs[0]!;
         if (isVoidType(inner)) return { kind: "externref" }; // Promise<void> → externref (no value)
-        // (#2905) Under the native `$Promise` carrier (isStandalonePromiseActive
-        // — today WASI, widened to standalone by #2895 slice 1d) a STORED/TYPED
-        // `Promise<T>` is a real `$Promise` externref (produced by wrapAsyncReturn
-        // at the call site / the drive-layer result), NOT the unwrapped `T`.
-        // Lower the value slot to externref so it matches the value end-to-end;
-        // storing the externref into an f64/struct slot would otherwise coerce
-        // `externref → f64` via __unbox_number = NaN (or an illegal struct cast).
-        //
-        // (#3134) A `Promise<T>`-typed VALUE slot lowers to externref on EVERY
-        // lane — it holds a real promise object (a Promise builtin chain, or an
-        // activated async fn's result), never the unwrapped `T`. Unwrapping to
-        // `T` (f64) then `__unbox_number`'d the real promise externref at the
-        // declaration → NaN (#3134); it only "worked" for the legacy sync-fakery
-        // population, where an async call returns the unwrapped value — and there
-        // the boxed value round-trips harmlessly (`f() : Promise<number>` stores
-        // the f64 via `__box_number`, and a later numeric use `__unbox_number`s
-        // it back, while `await p` assimilates it through `Promise_resolve`). So
-        // externref serves BOTH reps: a real promise passes through, a
-        // sync-fakery value boxes/unboxes. This ALSO unifies the rep of a
-        // `Promise<T>`-typed vec ELEMENT (`const xs = [p]`) — the frame spill
-        // guess now matches the stored promise (unblocks #2967 2c class-2).
-        // An async fn's OWN wasm return signature pre-unwraps via
-        // `unwrapPromiseType` (declarations/closures/class-bodies) BEFORE this
-        // branch, so it is unaffected. externref is a leaf valtype — no new type,
-        // no DCE remap / funcIdx churn. Broad rep change → full-CI A/B (#3134).
+        // (#2905/#3134) A `Promise<T>` VALUE slot (local/param/field/non-async
+        // return/vec element) lowers to externref on EVERY lane — it holds a
+        // real promise, not the unwrapped `T`. Unwrapping to `T` (f64) then
+        // `__unbox_number`'d a real promise externref → NaN; externref serves
+        // the legacy sync-fakery rep too (an async call compiled synchronously
+        // returns the unwrapped f64, which boxes at the coerce and unboxes /
+        // `Promise_resolve`-assimilates on use). Unifying the rep also fixes a
+        // `Promise<T>[]` element (frame spill guess now matches the stored
+        // promise → unblocks #2967 2c class-2). An async fn's OWN return
+        // pre-unwraps via `unwrapPromiseType` before this branch. externref is
+        // a leaf valtype (no DCE/funcIdx churn). Broad rep change → full-CI A/B.
         return { kind: "externref" };
       }
       return { kind: "externref" }; // bare Promise without type arg

--- a/tests/issue-3134-promise-value-slot-rep.test.ts
+++ b/tests/issue-3134-promise-value-slot-rep.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3134 — a `Promise<T>`-typed VALUE slot (local / param / field / non-async
+ * return / vec element) must lower to externref on the JS-host lane, because it
+ * holds a REAL promise object (a Promise builtin chain, or an activated async
+ * fn's result), not the unwrapped `T`. Before the fix, `resolveWasmType`
+ * unwrapped `Promise<T>` → `T` (f64) on the host/GC lane, so the declaration
+ * coerced the real promise externref through `__unbox_number` → NaN (the
+ * awaited value settled as NaN).
+ *
+ * The unwrap "worked" only for the legacy sync-fakery population (an async call
+ * compiled synchronously returns the unwrapped value); externref serves that
+ * case too — the value boxes via `__box_number` at the store and either
+ * `__unbox_number`s back for a numeric use or assimilates through
+ * `Promise_resolve` at `await`. So one rep (externref) is correct for both.
+ */
+import { describe, expect, it } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+async function settled<T>(p: T | Promise<T>, ms = 2000): Promise<T> {
+  return Promise.race([
+    Promise.resolve(p),
+    new Promise<never>((_, rej) => setTimeout(() => rej(new Error("result promise never settled")), ms)),
+  ]);
+}
+
+describe("#3134 — Promise<T> value slots are externref (host lane)", () => {
+  it("a local holding a Promise builtin chain awaits to its value (was NaN)", async () => {
+    const e = await compileToWasm(`
+      export async function main(): Promise<number> {
+        const p = Promise.resolve(21).then((x: number) => x * 2);
+        return await p;
+      }`);
+    await expect(settled(e.main())).resolves.toBe(42);
+  });
+
+  it("a local holding an activated async fn's result awaits to its value (was NaN)", async () => {
+    const e = await compileToWasm(`
+      async function f(): Promise<number> { return await Promise.resolve(21).then((x: number) => x * 2); }
+      export async function main(): Promise<number> { const p = f(); return await p; }`);
+    await expect(settled(e.main())).resolves.toBe(42);
+  });
+
+  it("a `() => Promise<number>` typed callback param preserves the real promise (was NaN)", async () => {
+    const e = await compileToWasm(`
+      function runTest(cb: () => Promise<number>): Promise<number> { return cb(); }
+      export function main(): any {
+        return runTest(async function (): Promise<number> {
+          return await Promise.resolve(21).then((x: number) => x * 2);
+        });
+      }`);
+    await expect(settled(e.main())).resolves.toBe(42);
+  });
+
+  it("SYNC-FAKERY parity: a Promise<number> local bound to a resolved-value async call still works", async () => {
+    const e = await compileToWasm(`
+      async function g(): Promise<number> { return 40; }
+      export async function main(): Promise<number> { const a = await g(); return a + 2; }`);
+    await expect(settled(e.main())).resolves.toBe(42);
+  });
+
+  it("a Promise<T> VEC ELEMENT slot is externref — the real promise survives the array (the #2967 2c class-2 rep)", async () => {
+    const e = await compileToWasm(`
+      export function main(): any {
+        const g = async function (): Promise<number> {
+          const p = Promise.resolve(40).then((x: number) => x + 0);
+          const expected = [p];
+          const first = await expected[0];
+          const a = await Promise.resolve(2).then((x: number) => x + 0);
+          return first + a;
+        };
+        return g();
+      }`);
+    await expect(settled(e.main())).resolves.toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

A `Promise<T>`-typed VALUE slot (local / param / field / non-async return / **vec element**) holds a REAL promise object — a Promise builtin chain, or an activated async fn's result — not the unwrapped `T`. `resolveWasmType`'s Promise branch unwrapped `Promise<T>` → `T` (f64) on the JS-host/GC lane, so the declaration coerced the real promise externref through `__unbox_number` → **NaN**; awaiting NaN settled with NaN.

**Fix — Direction 2 (rep convergence, the issue's recommended end-state):** `Promise<T>` → `externref` on EVERY lane (dropped the `isStandalonePromiseActive` gate that made host/GC unwrap). One externref serves both reps:
- a REAL promise passes through as externref (fixes the NaN);
- a legacy SYNC-FAKERY value (an async call compiled synchronously returns the unwrapped `T`=f64) boxes at the declaration coerce (`__box_number`), then `__unbox_number`s back for a numeric use or `Promise_resolve`-assimilates at `await` — both correct.

`resolveWasmType` is a PURE function of the TS type (can't see the initializer), so the narrow direction 1 would need per-site changes at every typing site and still can't reach a `Promise<T>` **vec element** (no per-element initializer). Direction 2 is the single site that fixes all of them — and the vec-element case is exactly the rep the **#2967 slice 2c class-2 blocker** needs (`Promise<T>[]` → `vec<externref>` now matches the stored promise, so the async-frame spill guess stops diverging). This is the highest-leverage step toward the CPS-engine deletion.

An async fn's OWN wasm return signature is pre-unwrapped via `unwrapPromiseType` (declarations/closures/class-bodies) BEFORE this branch, so activated result types are unaffected. externref is a leaf valtype — no new type, no DCE remap / funcIdx churn.

## Validation

- `tests/issue-3134-promise-value-slot-rep.test.ts` — 5/5 (3 probe shapes + sync-fakery parity + the class-2 vec-element rep) resolve to 42
- Async battery (async-await / equivalence async-function / 1042-host-drive / 2957 / 2967-engine-convergence / 2906-multiawait) green; the only failures are `promise-combinators` `Promise.all/race with resolved values` — pre-existing ("undefined is not iterable", the documented #2967-slice-1 mode, engine-independent)
- tsc + prettier clean

**Risk: broad** — every `Promise<T>` value slot's rep flips f64→externref. The merge_group full-corpus A/B is the hard gate (never scoped-sweep only); watch the async + Promise buckets.

Part of #2967 (unblocks 2c). Fixes #3134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)