### PR TITLE
fix(#86): reject {standalone:true} compile option; convert vacuous callers to target:standalone

### DIFF
--- a/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
+++ b/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
@@ -1,0 +1,60 @@
+---
+id: 3155
+title: "standalone: object spread / Object.assign / Object.keys-values order + object→primitive gaps (unmasked by the #86 vacuous-standalone audit)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [86, 2131, 2746, 2804]
+origin: "#86 {standalone:true}-option-ignored audit (fable-wasm, 2026-07-11) — 3 tests were asserting standalone behavior while vacuously running gc-host; the real standalone lane fails."
+loc-budget-allow:
+  - src/compiler.ts
+---
+
+# #3155 — standalone object spread / assign / key-enumeration gaps
+
+## Source
+
+Surfaced by **#86** (the `{ standalone: true }`-compile-option-ignored audit).
+Three test files carried a "standalone" mode that, because the option was
+silently dropped, ran the **gc-host** lane and passed vacuously. When #86
+converted them to the real `target: "standalone"` lane, they FAIL — revealing
+genuine standalone gaps. The standalone modes are now `describe.skip` /
+`it.skip` with a pointer here (honest: explicitly pending, not falsely passing);
+the host modes keep real coverage.
+
+## Failing on the real standalone lane
+
+- **`tests/issue-2804.test.ts`** — object spread `{ ...a, z }` + `Object.assign`
+  copy keys/values, `Object.values`/`Object.getOwnPropertyNames`/`for-in`
+  consistency. Fails with `TypeError: Cannot convert object to primitive value`
+  and empty/mis-read key sets on standalone.
+- **`tests/issue-2746.test.ts`** — `Object.keys` own-key listing paths.
+- **`tests/issue-2131.test.ts`** — integer-key enumeration order
+  (`Object.keys(o).join(",")` → `"1,2,b,a"`); the standalone `.join` / key
+  read path fails ("Cannot convert object to primitive value").
+
+## Root-cause hypothesis (to verify)
+
+Two clusters, both standalone-only:
+
+1. **object → primitive** — `Object.keys(o).join(",")` / template-literal on a
+   standalone object array trips `Cannot convert object to primitive value`
+   (the native ToPrimitive / string-coercion path for the key array or its
+   elements is not wired standalone). Likely shares a root with the #2160 /
+   #2358 standalone ToPrimitive substrate.
+2. **key enumeration fidelity** — `Object.keys` / `Object.values` /
+   `Object.assign` on a dynamic `$Object` return empty / mis-ordered sets
+   standalone (integer-key canonical order, insertion order). Likely the
+   dynamic `$Object` own-key walk (#2162 substrate family).
+
+## Acceptance
+
+- The `describe.skip` / `it.skip` standalone modes in issue-2804 / 2746 / 2131
+  are re-enabled (`describe`/`it`) and pass on `target: "standalone"` with 0
+  regressions.
+- `built-ins/Object/{keys,values,assign,getOwnPropertyNames}` + object-spread
+  standalone test262 improve (measure).

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -709,6 +709,24 @@ function buildCodegenOptions(
     jsxRuntime?: import("./import-resolver.js").JsxRuntimeImport;
   },
 ): CodegenOptions {
+  // (#86) Measurement-integrity guard. The standalone / wasi codegen regime is
+  // derived ONLY from `options.target` (below). There is NO `standalone` /
+  // `wasi` boolean OPTION — a caller that passes `{ standalone: true }` (or
+  // `{ wasi: true }`) to `compile()` intends a standalone/wasi run but silently
+  // gets the default gc-host lane, i.e. VACUOUS standalone coverage (the entire
+  // point of #86). TypeScript's excess-property check catches the direct-literal
+  // form (the fields are typed `never` on CompileOptions), but callers that
+  // widen options to `Record<string, unknown>` erase that — so fail LOUDLY here
+  // too. Use `target: "standalone"` / `target: "wasi"`.
+  const strayRegime = (options as Record<string, unknown>).standalone ?? (options as Record<string, unknown>).wasi;
+  if (strayRegime !== undefined) {
+    const key = (options as Record<string, unknown>).standalone !== undefined ? "standalone" : "wasi";
+    throw new Error(
+      `Unknown compile option '${key}' — the ${key} codegen regime is selected via ` +
+        `target: "${key}", not a '${key}' boolean. Passing { ${key}: true } silently ran the ` +
+        `default gc-host lane (vacuous ${key} coverage). Use { target: "${key}" }. (#86)`,
+    );
+  }
   return {
     sourceMap: emitSourceMap,
     fast: options.fast,

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,6 +270,20 @@ export interface CompileOptions {
    *  `nativeStrings: true` and refuses to emit any `wasm:js-string` or
    *  `env` JS-host string imports. */
   target?: "gc" | "linear" | "wasi" | "standalone";
+  /**
+   * (#86) NOT a real option — declared `never` so `compile(src, { standalone:
+   * true })` is a TypeScript excess-property error. The standalone codegen
+   * regime is selected via `target: "standalone"`; a `standalone` boolean was
+   * silently ignored (it never reached codegen), producing vacuous standalone
+   * coverage. `buildCodegenOptions` also throws at runtime for widened
+   * (`Record`-typed) callers. Use `target: "standalone"`.
+   */
+  standalone?: never;
+  /**
+   * (#86) NOT a real option — see `standalone`. The WASI regime is
+   * `target: "wasi"`; a `wasi` boolean was silently ignored.
+   */
+  wasi?: never;
   /** Enable fast mode — i32 default numbers, performance optimizations */
   fast?: boolean;
   /**

--- a/tests/ir-algorithms-cluster.test.ts
+++ b/tests/ir-algorithms-cluster.test.ts
@@ -505,7 +505,7 @@ describe("#2856 — whole algorithms.ts component end-to-end", () => {
   });
 
   it("standalone / wasi compiles stay clean (host-gated Map arm defers)", async () => {
-    for (const extra of [{ standalone: true }, { target: "wasi" as const }]) {
+    for (const extra of [{ target: "standalone" as const }, { target: "wasi" as const }]) {
       const r = await compile(ALGORITHMS, { experimentalIR: true, trackFallbacks: true, ...(extra as object) });
       expect(r.success, `compile ok under ${JSON.stringify(extra)}`).toBe(true);
       expect(r.irPostClaimErrors ?? []).toStrictEqual([]);

--- a/tests/issue-2131.test.ts
+++ b/tests/issue-2131.test.ts
@@ -88,7 +88,12 @@ describe("#2131 — JS-host integer-key enumeration order", () => {
     expect(out).toBe("b,01,a");
   });
 
-  it("standalone mode (already fixed by #1837) keeps the same order", async () => {
+  // (#86/#3155) This "standalone" test ran gc-host vacuously (the `{ standalone:
+  // true }` option was silently ignored) — the #1837 "fix" was never exercised
+  // on the real lane. On the true `target: "standalone"` lane the
+  // `Object.keys(o).join(",")` path fails. Skipped-pending-#3155 (HONEST — was
+  // vacuously "passing"). The host-mode order test above keeps real coverage.
+  it.skip("standalone mode (already fixed by #1837) keeps the same order", async () => {
     const out = await run(
       `
       export function test(): string {
@@ -96,7 +101,7 @@ describe("#2131 — JS-host integer-key enumeration order", () => {
         return Object.keys(o).join(",");
       }
     `,
-      { standalone: true },
+      { target: "standalone" },
     );
     expect(out).toBe("1,2,b,a");
   });

--- a/tests/issue-2162-weak-mapHelpers-shift.test.ts
+++ b/tests/issue-2162-weak-mapHelpers-shift.test.ts
@@ -17,7 +17,7 @@
 // more robust than a runtime value, and it is exactly the failure mode (a
 // `call` to the wrong-signature helper) the fix addresses.
 //
-// Reproducing condition: `standalone: true, nativeStrings: true` — this routes
+// Reproducing condition: `target: "standalone" as const, nativeStrings: true` — this routes
 // the WasmGC-native Map/Set/Weak runtime AND defers `__box_number` to a late
 // import, so the numeric key/value coercion opens the stale-`mapHelpers` window
 // mid-method-call. (Under `--target wasi` the box helpers import eagerly, so the
@@ -32,7 +32,7 @@ import { compile } from "../src/index.js";
 
 /** Compile `source` standalone + nativeStrings; assert the binary is VALID Wasm. */
 async function expectValidStandalone(source: string): Promise<void> {
-  const r = await compile(source, { fileName: "test.ts", standalone: true, nativeStrings: true });
+  const r = await compile(source, { fileName: "test.ts", target: "standalone" as const, nativeStrings: true });
   expect(r.success).toBe(true);
   // A stale mapHelpers index emits a `call` to the wrong-signature helper, which
   // fails validation. This assertion is `false` without the three-site fix.

--- a/tests/issue-2746.test.ts
+++ b/tests/issue-2746.test.ts
@@ -16,7 +16,10 @@ import { buildImports } from "../src/runtime.js";
 //   M-C Object.keys(null|undefined) throws a TypeError (ToObject, §7.1.18).
 
 async function run(source: string, opts: { standalone?: boolean } = {}): Promise<unknown> {
-  const result: any = await compile(source, { fileName: "test.ts", ...(opts.standalone ? { standalone: true } : {}) });
+  const result: any = await compile(source, {
+    fileName: "test.ts",
+    ...(opts.standalone ? { target: "standalone" as const } : {}),
+  });
   if (!result.success) {
     throw new Error(`Compile failed:\n${result.errors.map((e: any) => `  L${e.line}: ${e.message}`).join("\n")}`);
   }
@@ -33,7 +36,12 @@ const MODES: Array<{ name: string; standalone?: boolean }> = [
 
 describe("#2746 Object.keys own-key listing", () => {
   for (const mode of MODES) {
-    describe(mode.name, () => {
+    // (#86/#3155) The standalone mode ran gc-host vacuously until #86 honored the
+    // real target; on the true standalone lane the object-key listing paths fail.
+    // Skipped-pending-#3155 (HONEST — was vacuously "passing"); host keeps real
+    // coverage.
+    const describeMode = mode.standalone ? describe.skip : describe;
+    describeMode(mode.name, () => {
       it("M1: arr.hasOwnProperty(index) holds for in-bounds, false otherwise", async () => {
         const src = `
           export function test(): number {

--- a/tests/issue-2804.test.ts
+++ b/tests/issue-2804.test.ts
@@ -27,7 +27,7 @@ import { buildImports, instantiateWasm } from "../src/runtime.js";
 async function run(source: string, opts: { standalone?: boolean } = {}): Promise<unknown> {
   const result: any = await compile(source, {
     fileName: "test.ts",
-    ...(opts.standalone ? { standalone: true } : {}),
+    ...(opts.standalone ? { target: "standalone" as const } : {}),
   });
   if (!result.success) {
     throw new Error(`Compile failed:\n${result.errors.map((e: any) => `  L${e.line}: ${e.message}`).join("\n")}`);
@@ -46,7 +46,13 @@ const MODES: Array<{ name: string; standalone?: boolean }> = [
 
 describe("#2804 — object spread & Object.assign copy keys + values", () => {
   for (const mode of MODES) {
-    describe(mode.name, () => {
+    // (#86/#3155) The standalone mode ran gc-host vacuously until #86 honored the
+    // real target; on the true standalone lane object spread / Object.assign /
+    // Object.keys-order fail ("Cannot convert object to primitive value" +
+    // empty/mis-ordered key reads). Skipped-pending-#3155 (HONEST — was
+    // vacuously "passing"); the host mode keeps real coverage.
+    const describeMode = mode.standalone ? describe.skip : describe;
+    describeMode(mode.name, () => {
       // ── A: object spread { ...a, z } ──────────────────────────────────────
       it("A: spread copies keys in INSERTION order (x,y,z, not z,x,y)", async () => {
         expect(

--- a/tests/issue-2856-vec-push.test.ts
+++ b/tests/issue-2856-vec-push.test.ts
@@ -201,7 +201,7 @@ describe("#2856 — sibling for-loops re-declaring the counter (C)", () => {
 
 describe("#2856 — mode cleanliness", () => {
   it("standalone / wasi compiles stay clean (pure-WasmGC helper, no host import)", async () => {
-    for (const extra of [{ standalone: true }, { target: "wasi" as const }]) {
+    for (const extra of [{ target: "standalone" as const }, { target: "wasi" as const }]) {
       const r = await compile(BENCH_ARRAY, { experimentalIR: true, trackFallbacks: true, ...(extra as object) });
       expect(r.success, `compile ok under ${JSON.stringify(extra)}`).toBe(true);
       expect(r.irPostClaimErrors ?? []).toStrictEqual([]);

--- a/tests/issue-3121-objlit-method-closure-capture-aliasing.test.ts
+++ b/tests/issue-3121-objlit-method-closure-capture-aliasing.test.ts
@@ -18,7 +18,10 @@ import { describe, expect, it } from "vitest";
 import { compile } from "../src/index";
 
 async function run(src: string, standalone: boolean): Promise<unknown> {
-  const r = await compile(src, standalone ? { fileName: "test.ts", standalone: true } : { fileName: "test.ts" });
+  const r = await compile(
+    src,
+    standalone ? { fileName: "test.ts", target: "standalone" as const } : { fileName: "test.ts" },
+  );
   expect(r.success, r.success ? undefined : r.errors?.map((e) => e.message).join("; ")).toBe(true);
   if (!r.success) return undefined;
   const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);


### PR DESCRIPTION
## Summary

Measurement-integrity audit (**#86**): the standalone/wasi codegen regime derives **only** from `options.target` (`compiler.ts buildCodegenOptions`). There is **no** `standalone`/`wasi` boolean OPTION — so `compile(src, { standalone: true })` silently ran the default **gc-host** lane, i.e. **vacuous standalone coverage**.

## Fix — two-layer hard error

- `CompileOptions.standalone` / `.wasi` are now typed `never` → a direct-literal `{ standalone: true }` is a TypeScript excess-property error.
- `buildCodegenOptions` throws a clear, actionable error for `Record`-widened callers that erase the type (e.g. `run(src, opts: Record<string, unknown>)`).

Selecting the regime via `target: "standalone"` / `"wasi"` is unchanged; `createCodegenContext({ standalone: true })` sites (a real context flag) are unaffected.

## Vacuous callers converted + the finding

Converted the **8** `compile()` callers passing `standalone: true` to `target: "standalone"`. Result:

- **5 files pass on the REAL standalone lane** — coverage is now genuine (issue-2162-weak, issue-2856-vec-push, ir-algorithms-cluster, issue-3121, issue-3053 was already a context site).
- **3 files FAIL on the real lane** (issue-2131 / issue-2746 / issue-2804) — object spread, `Object.assign`, `Object.keys`/`values` order, and object→primitive are broken standalone, **hidden until now by the vacuous gc-host runs**. Their standalone modes are `describe.skip`/`it.skip` pending **#3155** (HONEST — was falsely "passing"); host modes keep real coverage. **#3155 filed** with the gap detail.

## Proofs

- The guard throws on `{ standalone: true }` and `target: "standalone"` compiles cleanly (verified).
- All 8 converted test files are green (75 pass, 18 honestly-skipped-pending-#3155).
- No other `compile()` option-caller in src/scripts; the `wasi: true` sites in tests are all context/config objects (unaffected).
- `loc-budget-allow` for `src/compiler.ts` on #3155 (#3131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)