### PR TITLE
refactor(#3161): generalized typed-signature self-hosted stdlib driver (Precursor B/C)

### DIFF
--- a/plan/issues/3161-selfhost-driver-typed-signatures.md
+++ b/plan/issues/3161-selfhost-driver-typed-signatures.md
@@ -1,0 +1,118 @@
+---
+id: 3161
+title: "Self-hosted stdlib driver: generalized typed-signature emit path (Precursor B/C — unblocks array-methods + object-runtime families)"
+status: done
+assignee: ttraenkler/fable-senior2
+sprint: current
+created: 2026-07-12
+updated: 2026-07-12
+completed: 2026-07-12
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir, codegen, stdlib
+language_feature: compiler-internals
+goal: ir-full-coverage
+related: [3141, 3159, 3160]
+origin: "plan/self-hosting-scale-up.md — Precursors B/C, dispatched as their own small issue per the plan"
+---
+
+# #3161 — Self-hosted stdlib driver: generalized typed-signature emit path
+
+## Problem
+
+The #3141 pilot driver (`src/codegen/stdlib-selfhost.ts`) hardcodes the pilot's
+scope: every builtin and every callee is unary `(f64) -> f64`, and the IR is
+process-memoized. The next two families in flight need more:
+
+- **array-methods slice 1 (#3159, fable-selfhost)**: ctx-bound `ref_null`
+  typeIdx params (raw data arrays), `i32`/`f64` mixed callees up to arity 6,
+  void-returning kernels.
+- **object-runtime slice 1 (#3160, fable-senior2)**: `externref` params/returns,
+  void `__extern_set`, unannotated locals inferring externref from callee
+  returns.
+
+Both need typed per-builtin param/return signatures and typed per-callee
+signatures — exactly Precursors B/C from `plan/self-hosting-scale-up.md`.
+Landing the widening as its own PR FIRST decouples the two family slices
+(both build on main, no cross-branch stacking).
+
+## Design (agreed with fable-selfhost + tech lead, 2026-07-12)
+
+New exports in `src/codegen/stdlib-selfhost.ts`, additive — the math pilot
+path (`emitSelfHostedMathFunc` + its process memoization) keeps byte-identical
+output:
+
+```ts
+export interface SelfHostedFuncDef {
+  readonly name: string; // funcMap name == fn name in source
+  readonly source: string; // ordinary TS, IR-claimable subset
+  readonly paramTypes: readonly IrType[]; // positional, override-authoritative
+  readonly returnType: IrType | null; // null == void
+  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+}
+export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction;
+export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef): number;
+```
+
+Key decisions:
+
+- **No process memoization on the generalized path.** `paramTypes`/callee
+  types may carry ctx-bound `{ kind: "ref_null", typeIdx }` (typeIdx is only
+  meaningful in the CodegenContext that registered it). Emission is
+  funcMap-guarded once per compilation by `emitSelfHostedFunc`'s idempotent
+  early-return — the same lifecycle the hand `Instr[]` bodies had — so the
+  per-emit rebuild cost is negligible.
+- **Param/return types flow via `paramTypeOverrides`/`returnTypeOverride`**
+  (from-ast already supports both; non-primitive annotations like `unknown`
+  defer to the override, primitive annotations must agree — enforced by
+  `resolveIrType`).
+- **Scope guard retained**: `resolveGlobal`/`resolveType` throw. `ref_null`
+  ValType params do NOT hit `resolveType` (they are `val`-kind), so raw-array
+  params pass through while accidental named-type/global dialect growth stays
+  a loud compile error.
+- **Math path deduped onto the generalized builder**: `buildBuiltinIr` becomes
+  a memo-wrapping adapter constructing a `SelfHostedFuncDef` with `(f64)->f64`
+  callee sigs and f64 param/return overrides — `resolveIrType` verifies the
+  overrides agree with the `: number` annotations, output IR identical.
+
+## Acceptance criteria
+
+- [x] `emitSelfHostedFunc` + `SelfHostedFuncDef` + `buildSelfHostedIr` exported;
+      math path output byte-identical (existing `tests/issue-3141.test.ts` +
+      equivalence suite green).
+- [x] Unit test covers the widened dialect shapes end-to-end
+      (from-ast → verify → passes → lower with mock resolver): externref
+      params/returns, void callees in statement position, i32-returning
+      callees, `ref_null` typeIdx params, arity ≥ 3, unannotated locals
+      inferring externref.
+- [x] Compiler output unchanged for all programs (nothing calls the new
+      export yet) — CI net 0.
+
+## Evidence (2026-07-12)
+
+- **Byte-identity of the math-path refactor**: `.tmp/probe-3161-byteident.mts`
+  compiles a program exercising all nine self-hosted math builtins on both
+  trees — host `e67749cf…` (2,217 B) and standalone `eebac3fc…` (38,192 B)
+  SHA-256 identical between `main` and this branch.
+- **Dialect finding (caller-side rule, documented in the driver header)**:
+  a void builtin cannot END in a loop — `lowerTail` accepts return /
+  expression / if / block / throw tails only, so void kernels need an
+  explicit trailing `return;`.
+- `tests/issue-3161.test.ts` (5 tests) green; `tests/issue-3141.test.ts`
+  green; `tests/stdlib.test.ts` has 5 failures that reproduce identically
+  on `main` (pre-existing, unrelated).
+
+## Implementation notes (WHY)
+
+- The two-stage split (`buildSelfHostedIr` / `emitSelfHostedFunc`) is kept
+  from the pilot NOT for memoization (dropped here) but because the build
+  stage is pure and unit-testable without a CodegenContext — the emit stage
+  is thin proven glue (mint/push/funcMap, identical to the pilot's).
+- `irTypeArgAssignable` (from-ast) requires EXACT IrType equality for scalar
+  args — callers must declare index params as `f64` (intrinsics trunc
+  internally) rather than relying on implicit f64→i32 coercion; this is a
+  caller-side dialect rule, not a driver limitation (documented in the
+  driver header).

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -99,26 +99,43 @@ export interface SelfHostedFuncDef {
   readonly returnType: IrType | null;
   /** Typed signatures for every direct callee in `source`. */
   readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+  /**
+   * Optional process-lifetime memo key. Set ONLY for a CONTEXT-FREE def —
+   * one whose `paramTypes` / `returnType` / callee sigs carry no ctx-bound
+   * `{ typeIdx }` ref (all abstract scalars / string / externref). The
+   * memoized `IrFunction` is shared across every compilation, so a def with
+   * a ctx-relative type must NOT set this (its typeIdx would leak across
+   * contexts). The math family (all `(f64) -> f64`) sets it (keyed by
+   * builtin name); the generalized families (raw-array/typeIdx params)
+   * leave it unset and rebuild per emission — bounded to once per
+   * compilation by `emitSelfHostedFunc`'s funcMap early-return.
+   */
+  readonly memoKey?: string;
 }
 
-/** Process-lifetime cache: builtin name → immutable, context-free IR. */
+/** Process-lifetime cache: memoKey → immutable, context-free IR. */
 const irCache = new Map<string, IrFunction>();
 
 /**
  * #3161 — parse a typed self-hosted builtin's TS source and lower it to
  * a verified, optimized `IrFunction`.
  *
- * NOT memoized (unlike the math pilot's `buildBuiltinIr` wrapper below):
- * `def.paramTypes` / callee sigs may carry ctx-bound `{ typeIdx }` refs
- * that are only meaningful in the CodegenContext that registered those
- * types, so the IR must be rebuilt per emission. `emitSelfHostedFunc`'s
- * funcMap early-return bounds this to once per compilation.
+ * Memoized ONLY when `def.memoKey` is set (a context-free def — see the
+ * field doc). A def carrying ctx-bound `{ typeIdx }` refs leaves memoKey
+ * unset and is rebuilt per emission, because a memoized IR would leak a
+ * typeIdx that is only meaningful in the registering CodegenContext;
+ * `emitSelfHostedFunc`'s funcMap early-return bounds that rebuild to once
+ * per compilation.
  *
  * Exported separately from the emit glue so the widened dialect shapes
  * are unit-testable without constructing a CodegenContext (the build
  * stage is a pure function of the def).
  */
 export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction {
+  if (def.memoKey !== undefined) {
+    const cached = irCache.get(def.memoKey);
+    if (cached) return cached;
+  }
   const sourceFile = ts.createSourceFile(
     `stdlib/${def.name}.ts`,
     def.source,
@@ -169,37 +186,31 @@ export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction {
     throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
   }
 
+  if (def.memoKey !== undefined) irCache.set(def.memoKey, ir);
   return ir;
 }
 
 /**
- * Parse the builtin's TS source and lower it to a verified, optimized
- * `IrFunction`. Pure function of the builtin definition — memoized
- * (sound here, unlike the generalized path: math sigs are all context-
- * free `(f64) -> f64`, no typeIdx can appear).
+ * Build the generalized `SelfHostedFuncDef` for a math-pilot builtin.
+ * Sibling math helpers are all unary `(f64) -> f64`; the f64 param/return
+ * overrides agree with the sources' `: number` annotations (enforced by
+ * from-ast's `resolveIrType`), so lowering through the generalized builder
+ * yields IR identical to the pilot's un-overridden path. Context-free, so
+ * `memoKey` is set to the builtin name.
  */
-function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
-  const cached = irCache.get(builtin.name);
-  if (cached) return cached;
-
-  // Sibling math helpers are all unary (f64) -> f64. The f64 param/return
-  // overrides agree with the sources' `: number` annotations (enforced by
-  // from-ast's resolveIrType), so lowering through the generalized builder
-  // yields IR identical to the pilot's un-overridden path.
+function mathBuiltinDef(builtin: StdlibMathBuiltin): SelfHostedFuncDef {
   const calleeTypes = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>();
   for (const callee of builtin.callees) {
     calleeTypes.set(callee, { params: [F64], returnType: F64 });
   }
-  const ir = buildSelfHostedIr({
+  return {
     name: builtin.name,
     source: builtin.source,
     paramTypes: [F64],
     returnType: F64,
     calleeTypes,
-  });
-
-  irCache.set(builtin.name, ir);
-  return ir;
+    memoKey: builtin.name,
+  };
 }
 
 /**
@@ -272,8 +283,11 @@ function lowerAndRegister(ctx: CodegenContext, name: string, ir: IrFunction): nu
  *
  * Precondition: every name in `builtin.callees` is already registered in
  * `ctx.funcMap` (emitInlineMathFunctions emits Phase-1 cores first).
+ *
+ * Thin adapter over the generalized `emitSelfHostedFunc` — the math pilot
+ * and scale-up families share one emit path (the def carries a `memoKey`
+ * so the context-free math IR is still process-cached).
  */
 export function emitSelfHostedMathFunc(ctx: CodegenContext, builtin: StdlibMathBuiltin): number {
-  const ir = buildBuiltinIr(builtin);
-  return lowerAndRegister(ctx, builtin.name, ir);
+  return emitSelfHostedFunc(ctx, mathBuiltinDef(builtin));
 }

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -32,6 +32,31 @@
  * or vecs — the resolver below throws on all of those, which turns any
  * accidental dialect growth in `src/stdlib/math.ts` into a loud compile
  * error instead of a miscompile.
+ *
+ * #3161 — generalized typed path (`SelfHostedFuncDef` / `emitSelfHostedFunc`):
+ * the scale-up families (array-methods #3159, object-runtime #3160) need
+ * builtins whose params/returns/callees are NOT unary f64: externref
+ * params, void kernels, i32 results, and ctx-bound `ref_null { typeIdx }`
+ * raw-array params. The generalized path carries explicit positional
+ * param types + a typed callee map, flowing through from-ast's existing
+ * `paramTypeOverrides` / `returnTypeOverride`. It is deliberately NOT
+ * process-memoized: a `typeIdx` inside a def's types is only meaningful
+ * in the CodegenContext that registered it, so the IR must be rebuilt
+ * per emission. That costs little — `emitSelfHostedFunc` early-returns
+ * via `ctx.funcMap` (once per compilation, the same lifecycle the hand
+ * `Instr[]` bodies had). The global/named-type scope guard stays: raw
+ * ValType refs (`ref_null`) are `val`-kind and never hit `resolveType`,
+ * while any accidental use of module globals or symbolic named types in
+ * stdlib source remains a loud compile error.
+ *
+ * Caller-side dialect rule: from-ast validates direct-call args by EXACT
+ * IrType equality (`irTypeArgAssignable`) — declare numeric index params
+ * as `f64` in callee sigs (kernels trunc internally); there is no
+ * implicit f64→i32 argument coercion. Params whose type isn't spellable
+ * as a TS primitive should be annotated `unknown` in the source (a
+ * non-primitive annotation defers to the positional override). Void
+ * builtins must end with an explicit `return;` — a loop is not a valid
+ * tail statement in the IR subset (`lowerTail`).
  */
 
 import { ts } from "../ts-api.js";
@@ -49,49 +74,84 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 
 const F64: IrType = irVal({ kind: "f64" });
 
+/**
+ * #3161 — a self-hosted builtin with an explicit typed signature. The
+ * generalized shape behind the `StdlibMathBuiltin` pilot descriptor:
+ * positional param types + a typed callee map instead of the pilot's
+ * implicit "everything is unary f64".
+ *
+ * `paramTypes` is positional and override-authoritative: a param whose
+ * type has no TS-primitive spelling (externref, `ref_null { typeIdx }`)
+ * should be annotated `unknown` in `source` — from-ast's `resolveIrType`
+ * defers non-primitive annotations to the override, and REJECTS a
+ * primitive annotation that disagrees with it (typo guard).
+ * `returnType: null` means void (zero Wasm results; bare `return;` /
+ * fall-through tails, statement-position calls only — #1228 / #2856 C4).
+ */
+export interface SelfHostedFuncDef {
+  /** funcMap registration name — also the function's name in `source`. */
+  readonly name: string;
+  /** Ordinary TS source, IR-claimable subset. */
+  readonly source: string;
+  /** Positional param IrTypes (may carry ctx-bound typeIdx refs). */
+  readonly paramTypes: readonly IrType[];
+  /** Return IrType; null == void. */
+  readonly returnType: IrType | null;
+  /** Typed signatures for every direct callee in `source`. */
+  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+}
+
 /** Process-lifetime cache: builtin name → immutable, context-free IR. */
 const irCache = new Map<string, IrFunction>();
 
 /**
- * Parse the builtin's TS source and lower it to a verified, optimized
- * `IrFunction`. Pure function of the builtin definition — memoized.
+ * #3161 — parse a typed self-hosted builtin's TS source and lower it to
+ * a verified, optimized `IrFunction`.
+ *
+ * NOT memoized (unlike the math pilot's `buildBuiltinIr` wrapper below):
+ * `def.paramTypes` / callee sigs may carry ctx-bound `{ typeIdx }` refs
+ * that are only meaningful in the CodegenContext that registered those
+ * types, so the IR must be rebuilt per emission. `emitSelfHostedFunc`'s
+ * funcMap early-return bounds this to once per compilation.
+ *
+ * Exported separately from the emit glue so the widened dialect shapes
+ * are unit-testable without constructing a CodegenContext (the build
+ * stage is a pure function of the def).
  */
-function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
-  const cached = irCache.get(builtin.name);
-  if (cached) return cached;
-
+export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction {
   const sourceFile = ts.createSourceFile(
-    `stdlib/${builtin.name}.ts`,
-    builtin.source,
+    `stdlib/${def.name}.ts`,
+    def.source,
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
     ts.ScriptKind.TS,
   );
   const fnDecl = sourceFile.statements.find(
-    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === builtin.name,
+    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === def.name,
   );
   if (!fnDecl) {
-    throw new Error(`stdlib-selfhost: source for ${builtin.name} has no matching function declaration`);
+    throw new Error(`stdlib-selfhost: source for ${def.name} has no matching function declaration`);
   }
-
-  // Sibling math helpers are all unary (f64) -> f64.
-  const calleeTypes = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>();
-  for (const callee of builtin.callees) {
-    calleeTypes.set(callee, { params: [F64], returnType: F64 });
+  if (fnDecl.parameters.length !== def.paramTypes.length) {
+    throw new Error(
+      `stdlib-selfhost: ${def.name} declares ${fnDecl.parameters.length} params but paramTypes has ${def.paramTypes.length}`,
+    );
   }
 
   const { main, lifted } = lowerFunctionAstToIr(fnDecl, {
-    funcName: builtin.name,
+    funcName: def.name,
     exported: false,
-    calleeTypes,
+    calleeTypes: def.calleeTypes,
+    paramTypeOverrides: def.paramTypes,
+    returnTypeOverride: def.returnType,
   });
   if (lifted.length > 0) {
-    throw new Error(`stdlib-selfhost: ${builtin.name} unexpectedly produced ${lifted.length} lifted functions`);
+    throw new Error(`stdlib-selfhost: ${def.name} unexpectedly produced ${lifted.length} lifted functions`);
   }
 
   const buildErrors = verifyIrFunction(main);
   if (buildErrors.length > 0) {
-    throw new Error(`stdlib-selfhost: IR verify failed for ${builtin.name}: ${buildErrors[0]!.message}`);
+    throw new Error(`stdlib-selfhost: IR verify failed for ${def.name}: ${buildErrors[0]!.message}`);
   }
 
   // Same hygiene pipeline integration.ts runs (constantFold → deadCode →
@@ -106,11 +166,102 @@ function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
 
   const postErrors = verifyIrFunction(ir);
   if (postErrors.length > 0) {
-    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${builtin.name}: ${postErrors[0]!.message}`);
+    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
   }
+
+  return ir;
+}
+
+/**
+ * Parse the builtin's TS source and lower it to a verified, optimized
+ * `IrFunction`. Pure function of the builtin definition — memoized
+ * (sound here, unlike the generalized path: math sigs are all context-
+ * free `(f64) -> f64`, no typeIdx can appear).
+ */
+function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
+  const cached = irCache.get(builtin.name);
+  if (cached) return cached;
+
+  // Sibling math helpers are all unary (f64) -> f64. The f64 param/return
+  // overrides agree with the sources' `: number` annotations (enforced by
+  // from-ast's resolveIrType), so lowering through the generalized builder
+  // yields IR identical to the pilot's un-overridden path.
+  const calleeTypes = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>();
+  for (const callee of builtin.callees) {
+    calleeTypes.set(callee, { params: [F64], returnType: F64 });
+  }
+  const ir = buildSelfHostedIr({
+    name: builtin.name,
+    source: builtin.source,
+    paramTypes: [F64],
+    returnType: F64,
+    calleeTypes,
+  });
 
   irCache.set(builtin.name, ir);
   return ir;
+}
+
+/**
+ * #3161 — lower a typed self-hosted builtin against the live context and
+ * register it as a defined function under `def.name`. Same registration
+ * discipline as the math path (stable-regime mint + push, funcMap entry,
+ * `exported: false`) so call sites cannot tell the difference from the
+ * hand-emitted `Instr[]` body it replaces.
+ *
+ * Idempotent: early-returns the existing funcIdx when `def.name` is
+ * already registered (mirrors the `ensure*` convention of the hand
+ * emitters this replaces).
+ *
+ * Precondition: every callee in `def.calleeTypes` that the source
+ * actually calls is already registered in `ctx.funcMap` (families
+ * convert leaf-first; retained hand kernels are emitted before the
+ * self-hosted bodies that call them).
+ */
+export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef): number {
+  const existing = ctx.funcMap.get(def.name);
+  if (existing !== undefined) return existing;
+
+  const ir = buildSelfHostedIr(def);
+  const funcIdx = lowerAndRegister(ctx, def.name, ir);
+  return funcIdx;
+}
+
+/** Shared lowering + registration glue for both driver paths. */
+function lowerAndRegister(ctx: CodegenContext, name: string, ir: IrFunction): number {
+  const resolver: IrLowerResolver = {
+    resolveFunc(ref) {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) {
+        throw new Error(
+          `stdlib-selfhost: ${name} calls "${ref.name}" but it is not registered yet — ` +
+            `emit callees leaf-first (check the family's phase ordering)`,
+        );
+      }
+      return idx;
+    },
+    resolveGlobal(ref) {
+      throw new Error(`stdlib-selfhost: ${name} must not reference globals (got "${ref.name}")`);
+    },
+    resolveType(ref) {
+      throw new Error(`stdlib-selfhost: ${name} must not reference named types (got "${ref.name}")`);
+    },
+    internFuncType(type) {
+      return addFuncType(ctx, type.params, type.results, type.name);
+    },
+  };
+
+  const { func } = lowerIrFunctionToWasm(ir, resolver);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name,
+    typeIdx: func.typeIdx,
+    locals: func.locals,
+    body: func.body,
+    exported: false,
+  });
+  ctx.funcMap.set(name, funcIdx);
+  return funcIdx;
 }
 
 /**
@@ -124,38 +275,5 @@ function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
  */
 export function emitSelfHostedMathFunc(ctx: CodegenContext, builtin: StdlibMathBuiltin): number {
   const ir = buildBuiltinIr(builtin);
-
-  const resolver: IrLowerResolver = {
-    resolveFunc(ref) {
-      const idx = ctx.funcMap.get(ref.name);
-      if (idx === undefined) {
-        throw new Error(
-          `stdlib-selfhost: ${builtin.name} calls "${ref.name}" but it is not registered yet — ` +
-            `check emitInlineMathFunctions phase ordering`,
-        );
-      }
-      return idx;
-    },
-    resolveGlobal(ref) {
-      throw new Error(`stdlib-selfhost: ${builtin.name} must not reference globals (got "${ref.name}")`);
-    },
-    resolveType(ref) {
-      throw new Error(`stdlib-selfhost: ${builtin.name} must not reference named types (got "${ref.name}")`);
-    },
-    internFuncType(type) {
-      return addFuncType(ctx, type.params, type.results, type.name);
-    },
-  };
-
-  const { func } = lowerIrFunctionToWasm(ir, resolver);
-  const funcIdx = mintDefinedFunc(ctx);
-  pushDefinedFunc(ctx, funcIdx, {
-    name: builtin.name,
-    typeIdx: func.typeIdx,
-    locals: func.locals,
-    body: func.body,
-    exported: false,
-  });
-  ctx.funcMap.set(builtin.name, funcIdx);
-  return funcIdx;
+  return lowerAndRegister(ctx, builtin.name, ir);
 }

--- a/tests/issue-3161.test.ts
+++ b/tests/issue-3161.test.ts
@@ -1,0 +1,180 @@
+// #3161 — generalized typed-signature self-hosted stdlib driver.
+//
+// Unit-tests the BUILD stage (`buildSelfHostedIr`: parse → from-ast with
+// positional param/return overrides → verify → passes → verify) plus the
+// backend lowering with a mock resolver, over the exact dialect shapes the
+// scale-up families need beyond the #3141 pilot's unary-f64 scope:
+//
+//   - externref params/returns via `unknown` annotations + overrides
+//     (object-runtime #3160: __object_fromEntries / getOwnPropertyDescriptors)
+//   - void callees in statement position (#2856 C4) and void builtins (#1228)
+//   - i32-returning callees feeding i32/i32 compares (#1126 Stage 3)
+//   - ctx-bound `ref_null { typeIdx }` params (array-methods #3159 timsort
+//     raw data arrays) — and WHY the generalized path must not memoize
+//   - arity ≥ 3 callees; unannotated locals inferring externref from
+//     callee return types
+//
+// The emit stage (`emitSelfHostedFunc`) is thin glue identical to the
+// proven math path (mint + push + funcMap) and is covered end-to-end by
+// tests/issue-3141.test.ts once a family lands on it.
+import { describe, it, expect } from "vitest";
+import { buildSelfHostedIr, type SelfHostedFuncDef } from "../src/codegen/stdlib-selfhost.js";
+import { irVal, type IrType } from "../src/ir/nodes.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+
+const EXT: IrType = irVal({ kind: "externref" });
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+
+/** Lower `ir` with a mock resolver; return the func + the callees it resolved. */
+function lowerWithMockResolver(def: SelfHostedFuncDef) {
+  const ir = buildSelfHostedIr(def);
+  const resolved = new Map<string, number>();
+  let nextFunc = 500;
+  let nextType = 100;
+  const resolver: IrLowerResolver = {
+    resolveFunc(ref) {
+      let idx = resolved.get(ref.name);
+      if (idx === undefined) {
+        expect(def.calleeTypes.has(ref.name), `unexpected callee ${ref.name}`).toBe(true);
+        idx = nextFunc++;
+        resolved.set(ref.name, idx);
+      }
+      return idx;
+    },
+    resolveGlobal(ref) {
+      throw new Error(`unexpected global ${ref.name}`);
+    },
+    resolveType(ref) {
+      throw new Error(`unexpected named type ${ref.name}`);
+    },
+    internFuncType() {
+      return nextType++;
+    },
+  };
+  const { func } = lowerIrFunctionToWasm(ir, resolver);
+  return { func, resolved };
+}
+
+describe("#3161 typed self-hosted driver — widened dialect shapes", () => {
+  it("externref params/returns, void callee in statement position, inferred externref locals, arity 3", () => {
+    // The real object-runtime slice-1 shape (#3160 __object_fromEntries):
+    // externref in/out, f64 loop, void __extern_set(3 args), every local
+    // unannotated-externref except the annotated f64s.
+    const def: SelfHostedFuncDef = {
+      name: "__probe_from_entries",
+      source: `
+export function __probe_from_entries(entries: unknown): unknown {
+  const out = __new_plain_object();
+  const len: number = __extern_length(entries);
+  let i: number = 0;
+  while (i < len) {
+    const pair = __extern_get_idx(entries, i);
+    __extern_set(out, __extern_get_idx(pair, 0), __extern_get_idx(pair, 1));
+    i = i + 1;
+  }
+  return out;
+}
+`,
+      paramTypes: [EXT],
+      returnType: EXT,
+      calleeTypes: new Map([
+        ["__new_plain_object", { params: [], returnType: EXT }],
+        ["__extern_length", { params: [EXT], returnType: F64 }],
+        ["__extern_get_idx", { params: [EXT, F64], returnType: EXT }],
+        ["__extern_set", { params: [EXT, EXT, EXT], returnType: null }],
+      ]),
+    };
+    const { func, resolved } = lowerWithMockResolver(def);
+    expect(func.body.length).toBeGreaterThan(0);
+    expect([...resolved.keys()].sort()).toEqual([
+      "__extern_get_idx",
+      "__extern_length",
+      "__extern_set",
+      "__new_plain_object",
+    ]);
+  });
+
+  it("void builtin return, ref_null typeIdx params, i32 callee results in i32/i32 compare", () => {
+    // The array-methods kernel shape (#3159): raw data-array param typed
+    // with a ctx-bound ref_null typeIdx, i32-returning element reads
+    // compared i32/i32, void return.
+    const DATA: IrType = irVal({ kind: "ref_null", typeIdx: 42 });
+    const def: SelfHostedFuncDef = {
+      name: "__probe_count_less",
+      source: `
+export function __probe_count_less(data: unknown, lo: number, hi: number): void {
+  let i: number = lo;
+  while (i < hi) {
+    if (__elem_i32(data, i) < __elem_i32(data, i + 1)) {
+      __mark(data, i);
+    }
+    i = i + 1;
+  }
+  return;
+}
+`,
+      paramTypes: [DATA, F64, F64],
+      returnType: null,
+      calleeTypes: new Map([
+        ["__elem_i32", { params: [DATA, F64], returnType: I32 }],
+        ["__mark", { params: [DATA, F64], returnType: null }],
+      ]),
+    };
+    const { func, resolved } = lowerWithMockResolver(def);
+    expect(func.body.length).toBeGreaterThan(0);
+    expect([...resolved.keys()].sort()).toEqual(["__elem_i32", "__mark"]);
+  });
+
+  it("rejects a primitive annotation that disagrees with the positional override (typo guard)", () => {
+    const def: SelfHostedFuncDef = {
+      name: "__probe_bad",
+      source: `
+export function __probe_bad(x: number): number {
+  return x;
+}
+`,
+      paramTypes: [EXT], // disagrees with `: number`
+      returnType: F64,
+      calleeTypes: new Map(),
+    };
+    expect(() => buildSelfHostedIr(def)).toThrow(/disagrees with annotation/);
+  });
+
+  it("rejects a paramTypes/declared-params arity mismatch", () => {
+    const def: SelfHostedFuncDef = {
+      name: "__probe_arity",
+      source: `
+export function __probe_arity(x: number, y: number): number {
+  return x + y;
+}
+`,
+      paramTypes: [F64],
+      returnType: F64,
+      calleeTypes: new Map(),
+    };
+    expect(() => buildSelfHostedIr(def)).toThrow(/paramTypes has 1/);
+  });
+
+  it("scope guard: named-type references still throw at lowering", () => {
+    // A def whose IR is clean but whose resolver hits resolveFunc only —
+    // resolveType/resolveGlobal remain loud errors. (Positive control for
+    // the guard is structural: the resolver in this test throws, and the
+    // two happy-path tests above prove it is never invoked for val-kind
+    // ref_null / externref types.)
+    const def: SelfHostedFuncDef = {
+      name: "__probe_guard",
+      source: `
+export function __probe_guard(x: number): number {
+  return x * 2;
+}
+`,
+      paramTypes: [F64],
+      returnType: F64,
+      calleeTypes: new Map(),
+    };
+    const { func, resolved } = lowerWithMockResolver(def);
+    expect(func.body.length).toBeGreaterThan(0);
+    expect(resolved.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Widens the #3141 self-hosted stdlib driver (`src/codegen/stdlib-selfhost.ts`) with a generalized typed-signature emit path — **Precursors B/C** from `plan/self-hosting-scale-up.md`, landed as its own small PR FIRST so the two in-flight family slices (#3159 array-methods / fable-selfhost, #3160 object-runtime / fable-senior2) both build on main with no cross-branch stacking.

New exports (API shape agreed with fable-selfhost):
- `SelfHostedFuncDef` — builtin descriptor with **positional param IrTypes**, **return IrType (`null` = void)**, and a **typed callee map** (externref / i32 / f64 / ctx-bound `ref_null { typeIdx }` / void), replacing the pilot's implicit unary-f64 scope.
- `buildSelfHostedIr` — parse → from-ast (via existing `paramTypeOverrides`/`returnTypeOverride`) → verify → passes → verify. **Deliberately NOT process-memoized**: defs may carry ctx-bound `typeIdx` refs that are only meaningful in the registering CodegenContext. Exported separately so the widened dialect is unit-testable without a CodegenContext.
- `emitSelfHostedFunc` — funcMap-idempotent mint/push/register glue, identical discipline to the proven math path.

The math pilot path is deduped onto the shared builder + registration glue (memoization retained there — math sigs are context-free).

## Proof
- **Byte-identity of the math refactor**: SHA-256 probe compiling all nine self-hosted math builtins — host `e67749cf…` (2,217 B) and standalone `eebac3fc…` (38,192 B) **identical between main and this branch**.
- **Byte-inert overall**: nothing calls the new exports yet — compiler output unchanged for all programs by construction.
- `tests/issue-3161.test.ts` (5 tests): externref params/returns + void callee statement-position + inferred externref locals (the #3160 fromEntries shape); void builtin + `ref_null` typeIdx params + i32/i32 compares (the #3159 timsort kernel shape); typo-guard (primitive annotation vs override disagreement); arity-mismatch guard; scope-guard control.
- `tests/issue-3141.test.ts` green (host + standalone); `tests/stdlib.test.ts` failures reproduce identically on main (pre-existing).

## Findings (documented in driver header + issue)
- Void builtins must end with an explicit `return;` — a loop is not a valid IR tail statement.
- Direct-call args validate by EXACT IrType equality — callee sigs must declare numeric index params as f64 (kernels trunc internally).

Closes #3161 (plan issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8