### PR TITLE
refactor(#3159): self-host Timsort kernels via our own IR pipeline (array family slice 1)

### DIFF
--- a/plan/issues/3159-selfhost-array-family-slice1-timsort.md
+++ b/plan/issues/3159-selfhost-array-family-slice1-timsort.md
@@ -99,3 +99,26 @@ exact drop-in shape the Math pilot proved.
 - No conversion of comparator sorts / ToString default sort (different units).
 - No `array-methods.ts` inline-emitter conversions yet (slices 2+ — need elem-kind
   coverage per the analysis above).
+
+## Follow-up: slice 2 scoping (the copy-family)
+
+`array-methods.ts` is **985 inline `fctx.body.push` sites** — every `compile*`
+emitter splices into the CALLER's frame, so unlike timsort (a module-level
+fixed-ABI helper) they are **not byte-inert to convert**: self-hosting an inline
+emitter turns inlined code into an out-of-line call, changing byte output. That
+moves the proof bar from byte-inert containment to **measured-net-non-negative +
+behavioral sweep** (still bit-exact vs main-built control, but binaries differ).
+
+The highest-leverage next unit is the **copy-family** — `compileArrayToReversed`
+(99), `compileArrayWith` (60), `compileArrayToSpliced` (133), `compileArraySlice`
+(36), `compileArrayConcat` (119) — which all inline the same "alloc
+`array.new_default` + `array.copy` + per-element transform + `struct.new` vec"
+pattern. Plan: extract each to a self-hosted `__sh_<method>_<k>(vec, …) -> vec`
+called from a thin inline wrapper (the wrapper keeps the vec-struct
+extract/repack the dialect can't express, exactly the timsort thunk shape).
+Precursor: extend `__arri_*` to **all 6 element kinds** (add packed i8/i16
+get_s/get_u/set) so one templated source covers every instantiation and the
+generic inline emitter can actually be deleted (per the net-deletion rule above).
+Estimated net −150…−250 across the family. **Start fresh from main AFTER the
+driver (#3161/#2916) and this slice land** — avoids a held-PR stack and a triple
+`emitSelfHostedFunc` collision.

--- a/plan/issues/3159-selfhost-array-family-slice1-timsort.md
+++ b/plan/issues/3159-selfhost-array-family-slice1-timsort.md
@@ -1,0 +1,101 @@
+---
+id: 3159
+title: "Self-hosted stdlib, array family slice 1: timsort kernels as TS source through our own IR pipeline"
+status: in-progress
+assignee: ttraenkler/fable-arrmeth
+sprint: current
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen, stdlib
+language_feature: compiler-internals
+goal: ir-full-coverage
+related: [3141, 2855]
+origin: "plan/self-hosting-scale-up.md family 4 (array methods) — first bounded slice"
+---
+
+# #3159 — Array family slice 1: self-host the timsort kernels (`src/codegen/timsort.ts`, 922 lines)
+
+## Problem
+
+`array-methods.ts` (9,565 lines) + its kernels are hand-emitted `Instr[]`. The #3141
+pilot (GO) proved builtins written as ordinary TS source compile through our own
+pipeline into drop-in replacements. This slice converts the array family's largest
+pure, self-contained, funcMap-registered unit: the four timsort kernels
+(`__isort_{k}` / `__merge_{k}` / `__merge_run_{k}` / `__timsort_{k}`, k ∈ {i32, f64}),
+922 lines of hand assembly in `src/codegen/timsort.ts`.
+
+## Why timsort first (root-cause analysis of the family)
+
+Every `compile*` function in `array-methods.ts` is **element-type-generic** (one
+inline emitter parameterized over f64/i32/i8/i16/ref/externref). Self-hosting only
+*deletes* hand code when the TS dialect covers **all** elem kinds a unit
+instantiates — a partial (f64-only) conversion keeps the generic hand emitter alive
+and the PR goes net-POSITIVE. Timsort is the one unit whose instantiation set is
+already restricted to **i32|f64** (#2502 guards; ref/externref sorts route to the
+ToString insertion sort or no-op), and from-ast's magnitude compares are
+**polymorphic over f64 AND i32** (#1126 Stage 3) — so ONE templated TS source
+instantiates both variants and the whole hand file collapses. It is also
+funcMap-registered with a fixed external ABI (`__timsort_{k}(vec) -> ()`), i.e. the
+exact drop-in shape the Math pilot proved.
+
+## Implementation plan (as built)
+
+1. **Intrinsic callees (Precursor B, first concrete cut).** The IR dialect cannot
+   express raw-array get/set/new/copy, and from-ast call args require exact IrType
+   match (no f64→i32 index coercion), so the stdlib source calls tiny typed
+   intrinsics with **f64 index params**: `__arri_get_<k>` / `__arri_set_<k>` /
+   `__arri_new_<k>` / `__arri_copy_<k>` (k = elem kind; the run stack reuses the
+   f64 set). Each is materialized on demand as a real ~5-instr defined function
+   (internal `i32.trunc_sat_f64_s` on indices) by the driver's `resolveFunc` —
+   name-based, funcIdx-shift safe, correctness never depends on any inliner.
+2. **Driver generalization** (`src/codegen/stdlib-selfhost.ts`): new
+   `emitSelfHostedFunc(ctx, def)` accepting per-def `paramTypes` (IrType[], allows
+   `(ref null $arr)` / `(ref null $vec)` via from-ast `paramTypeOverrides`),
+   `returnType`, `calleeTypes`, and an intrinsic-materializer hook. **No process
+   memoization for these** (unlike the Math pilot): vec/arr typeIdx values are baked
+   into the IR, which is only valid for the ctx that registered them. Emission
+   happens once per compilation per elem kind (funcMap-cached), same as the hand
+   path rebuilt its `Instr[]` per compilation.
+3. **TS sources** (`src/stdlib/array-sort.ts`): the four kernels as a source
+   template instantiated per elem kind. Ports the hand algorithm **op-for-op**
+   (same compare directions/stability ladder: `>` in isort, `<=` in merge, `<` in
+   run detection & collapse tie-breaks; minRun; 85-deep run stack; force-collapse).
+   Internal signatures move index params to f64 (`number`) — sound (indices < 2^31,
+   exact in f64) and only observable inside the kernel family; the external
+   `__timsort_{k}(vec)` ABI is preserved by a ~10-instr hand thunk that extracts
+   `(data, len)` and calls the self-hosted `__sh_timsort_{k}`. The run stack uses
+   f64 arrays (values are run bases/lengths — exact) instead of the hand version's
+   i32 arrays; observationally equivalent.
+4. **Dialect findings** (bounds of the subset, documented not hacked): no `NaN`/
+   `Infinity` idents (pilot rule, not needed here); minRun halving via
+   `Math.floor(nmr / 2)` and odd-bit accumulation via compare if the bitwise arms
+   misbehave on the template (probe decides); element values must stay segregated
+   from index arithmetic (i32 elems don't mix into f64 counters — timsort only
+   loads/compares/stores elements, never mixes).
+5. **Proof** (pilot method): (a) behavioral sweep — sorted outputs of branch-built
+   binaries vs main-built binaries, bit-compared elementwise over edge cases (NaN,
+   ±0, ±Inf, denormals, dups, presorted/reversed/sawtooth, lengths spanning the
+   63/64 isort cutoff and minRun boundaries, randoms) for f64 AND i32 (boolean[])
+   elem vecs, host + standalone; (b) containment — byte-identical binaries for
+   sort-free programs (SHA compare vs main).
+
+## Acceptance criteria
+
+- `src/codegen/timsort.ts` hand bodies deleted; file ≈ thin registration +
+  intrinsics (~1/4 its size). Net across the PR strongly negative.
+- Sweep: zero mismatches vs main-built control across the edge-case matrix.
+- Byte-inert for non-sort programs (SHA-verified).
+- Full CI green (test262 net ≥ 0, quality, standalone floor in merge_group).
+
+## Non-goals
+
+- No inline-substitution/peephole of intrinsic calls in this slice (perf lever,
+  follow-up if benches ever demand it; sort is not on the benchmark sidebar).
+- No conversion of comparator sorts / ToString default sort (different units).
+- No `array-methods.ts` inline-emitter conversions yet (slices 2+ — need elem-kind
+  coverage per the analysis above).

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -53,6 +53,132 @@ const F64: IrType = irVal({ kind: "f64" });
 const irCache = new Map<string, IrFunction>();
 
 /**
+ * #3159 — generalized self-hosted builtin definition (beyond the pure-f64
+ * Math pilot shape). `paramTypes` / `returnType` are concrete IrTypes and
+ * MAY carry ctx-bound `typeIdx` values (e.g. `(ref null $arr_f64)` data
+ * arrays), which is why `emitSelfHostedFunc` does NOT process-memoize the
+ * IR: a typeIdx is only meaningful inside the CodegenContext that
+ * registered it. Emission is funcMap-guarded once per compilation by the
+ * caller — the same lifecycle the hand-emitted `Instr[]` bodies had
+ * (rebuilt per compilation).
+ *
+ * Every name in `calleeTypes` (siblings AND intrinsics) must already be
+ * registered in `ctx.funcMap` before `emitSelfHostedFunc` runs — callers
+ * emit leaf-first and pre-materialize intrinsics (see timsort.ts's
+ * `ensureArrayIntrinsics`).
+ */
+export interface SelfHostedFuncDef {
+  /** funcMap registration name — also the function's name in `source`. */
+  readonly name: string;
+  /** Ordinary TS source, IR-claimable subset. */
+  readonly source: string;
+  /** Positional IR types for the function's own params (override-authoritative). */
+  readonly paramTypes: readonly IrType[];
+  /** IR return type, or null for void. */
+  readonly returnType: IrType | null;
+  /** Callee name → signature, seeds from-ast `calleeTypes`. */
+  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+}
+
+/**
+ * Parse + from-ast + verify + hygiene passes for a generalized builtin.
+ * NOT memoized (see `SelfHostedFuncDef` — the IR may embed ctx-bound
+ * typeIdx values).
+ */
+function buildFuncIr(def: SelfHostedFuncDef): IrFunction {
+  const sourceFile = ts.createSourceFile(
+    `stdlib/${def.name}.ts`,
+    def.source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+  const fnDecl = sourceFile.statements.find(
+    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === def.name,
+  );
+  if (!fnDecl) {
+    throw new Error(`stdlib-selfhost: source for ${def.name} has no matching function declaration`);
+  }
+
+  const { main, lifted } = lowerFunctionAstToIr(fnDecl, {
+    funcName: def.name,
+    exported: false,
+    calleeTypes: def.calleeTypes,
+    paramTypeOverrides: def.paramTypes,
+    returnTypeOverride: def.returnType,
+  });
+  if (lifted.length > 0) {
+    throw new Error(`stdlib-selfhost: ${def.name} unexpectedly produced ${lifted.length} lifted functions`);
+  }
+
+  const buildErrors = verifyIrFunction(main);
+  if (buildErrors.length > 0) {
+    throw new Error(`stdlib-selfhost: IR verify failed for ${def.name}: ${buildErrors[0]!.message}`);
+  }
+
+  let ir = main;
+  for (let iter = 0; iter < 10; iter++) {
+    const next = simplifyCFG(deadCode(constantFold(ir)));
+    if (next === ir) break;
+    ir = next;
+  }
+
+  const postErrors = verifyIrFunction(ir);
+  if (postErrors.length > 0) {
+    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
+  }
+  return ir;
+}
+
+/**
+ * Lower a generalized self-hosted builtin against the live context and
+ * register it as a defined function under `def.name`. Same registration
+ * discipline as `emitSelfHostedMathFunc` (stable-regime mint + push,
+ * funcMap entry); cross-function references resolve by funcMap name so
+ * self-hosted code composes with hand-written helpers (leaf-first).
+ */
+export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef): number {
+  const existing = ctx.funcMap.get(def.name);
+  if (existing !== undefined) return existing;
+
+  const ir = buildFuncIr(def);
+
+  const resolver: IrLowerResolver = {
+    resolveFunc(ref) {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) {
+        throw new Error(
+          `stdlib-selfhost: ${def.name} calls "${ref.name}" but it is not registered yet — ` +
+            `emit leaf-first and pre-materialize intrinsics before emitSelfHostedFunc`,
+        );
+      }
+      return idx;
+    },
+    resolveGlobal(ref) {
+      throw new Error(`stdlib-selfhost: ${def.name} must not reference globals (got "${ref.name}")`);
+    },
+    resolveType(ref) {
+      throw new Error(`stdlib-selfhost: ${def.name} must not reference named types (got "${ref.name}")`);
+    },
+    internFuncType(type) {
+      return addFuncType(ctx, type.params, type.results, type.name);
+    },
+  };
+
+  const { func } = lowerIrFunctionToWasm(ir, resolver);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: def.name,
+    typeIdx: func.typeIdx,
+    locals: func.locals,
+    body: func.body,
+    exported: false,
+  });
+  ctx.funcMap.set(def.name, funcIdx);
+  return funcIdx;
+}
+
+/**
  * Parse the builtin's TS source and lower it to a verified, optimized
  * `IrFunction`. Pure function of the builtin definition — memoized.
  */

--- a/src/codegen/timsort.ts
+++ b/src/codegen/timsort.ts
@@ -1,73 +1,46 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * Timsort implementation for WasmGC native arrays.
+ * Timsort for WasmGC native arrays — SELF-HOSTED (#3159, array family
+ * slice 1 of the porffor model; algorithm bodies live as ordinary TS
+ * source in `src/stdlib/array-sort.ts` and compile through the
+ * compiler's own pipeline via `src/codegen/stdlib-selfhost.ts`).
  *
- * Emits 4 module-level wasm helper functions per element type (i32 / f64):
- *   1. __isort_{type}(data, lo, hi)        — insertion sort a range
- *   2. __merge_{type}(data, tmp, lo, mid, hi) — merge two sorted halves
- *   3. __merge_run_{type}(data, tmp, sBase, sLen, stackSize, idx) -> i32
- *   4. __timsort_{type}(vec)               — main Timsort driver
+ * This file keeps only the Wasm-facing plumbing:
+ *   1. `ensureArrayIntrinsics` — tiny typed raw-array accessors
+ *      (`__arri_get_<k>` / `__arri_set_<k>` / `__arri_new_<k>` /
+ *      `__arri_copy_<k>`) the stdlib source calls by name. Indices are
+ *      f64 params truncated internally (`i32.trunc_sat_f64_s`) because
+ *      from-ast call args require exact IrType match and stdlib index
+ *      arithmetic is f64. This is Precursor B of
+ *      `plan/self-hosting-scale-up.md` — reusable by every later
+ *      array/string/dataview slice.
+ *   2. A ~6-instr thunk preserving the external ABI
+ *      `__timsort_<k>(vec) -> ()` — extracts (data, len) from the vec
+ *      struct and calls the self-hosted `__sh_timsort_<k>(data, len)`.
  *
- * Features: natural run detection, descending run reversal, minRun computation,
- * insertion sort for short runs, stable merge, stack-based merge policy.
- * Galloping mode is omitted (optimization, not required for correctness).
+ * Behavior notes (vs the deleted hand `Instr[]` bodies, 922 → ~230
+ * lines): sorted output is bit-exact — the TS sources mirror the hand
+ * algorithm op-for-op (same compare directions, so identical NaN
+ * behavior and stability; see the array-sort.ts header). Internal
+ * kernel signatures moved index params from i32 to f64 (exact for all
+ * array indices) and the run stack from i32 to f64 arrays (values are
+ * run bases/lengths — exact); both are unobservable outside the kernel
+ * family. Features preserved: natural run detection, descending run
+ * reversal, minRun computation, insertion sort for short runs, stable
+ * merge, stack-based merge policy. Galloping mode remains omitted.
  */
 
 import type { Instr, LocalDef, ValType } from "../ir/types.js";
+import { irVal, type IrType } from "../ir/nodes.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType, getOrRegisterArrayType } from "./registry/types.js";
+import { emitSelfHostedFunc, type SelfHostedFuncDef } from "./stdlib-selfhost.js";
+import { timsortKernelDefs, type SortElemKind } from "../stdlib/array-sort.js";
 
-// ---------------------------------------------------------------------------
-// IR builder helpers (terse names to keep instruction arrays readable)
-// ---------------------------------------------------------------------------
 const L = (i: number): Instr => ({ op: "local.get", index: i });
-const LS = (i: number): Instr => ({ op: "local.set", index: i });
-const I = (v: number): Instr => ({ op: "i32.const", value: v });
+const TRUNC: Instr = { op: "i32.trunc_sat_f64_s" };
 
-const ADD: Instr = { op: "i32.add" };
-const SUB: Instr = { op: "i32.sub" };
-const MUL: Instr = { op: "i32.mul" };
-const LT_S: Instr = { op: "i32.lt_s" };
-const LE_S: Instr = { op: "i32.le_s" };
-const GT_S: Instr = { op: "i32.gt_s" };
-const GE_S: Instr = { op: "i32.ge_s" };
-const EQZ: Instr = { op: "i32.eqz" };
-const I_AND: Instr = { op: "i32.and" };
-const I_OR: Instr = { op: "i32.or" };
-const SHR_U: Instr = { op: "i32.shr_u" };
-
-const RET: Instr = { op: "return" };
-
-const AG = (t: number): Instr => ({ op: "array.get", typeIdx: t });
-const AS = (t: number): Instr => ({ op: "array.set", typeIdx: t });
-const AC = (d: number, s: number): Instr => ({ op: "array.copy", dstTypeIdx: d, srcTypeIdx: s });
-const AND = (t: number): Instr => ({ op: "array.new_default", typeIdx: t });
-
-function BLOCK(body: Instr[]): Instr {
-  return { op: "block", blockType: { kind: "empty" }, body };
-}
-function LOOP(body: Instr[]): Instr {
-  return { op: "loop", blockType: { kind: "empty" }, body };
-}
-function BR(d: number): Instr {
-  return { op: "br", depth: d };
-}
-function BR_IF(d: number): Instr {
-  return { op: "br_if", depth: d };
-}
-function IF(then: Instr[], els?: Instr[]): Instr {
-  const r: any = { op: "if", blockType: { kind: "empty" }, then };
-  if (els) r.else = els;
-  return r;
-}
-function CALL(idx: number): Instr {
-  return { op: "call", funcIdx: idx };
-}
-
-// ---------------------------------------------------------------------------
-// Function emitter
-// ---------------------------------------------------------------------------
 function emitFunc(
   ctx: CodegenContext,
   name: string,
@@ -83,820 +56,94 @@ function emitFunc(
   return funcIdx;
 }
 
-// ---------------------------------------------------------------------------
-// 1. Insertion sort: __isort_{type}(data, lo, hi)
-// ---------------------------------------------------------------------------
-function emitInsertionSort(ctx: CodegenContext, arrTypeIdx: number, elemKind: "i32" | "f64"): number {
-  const name = `__isort_${elemKind}`;
-  const existing = ctx.funcMap.get(name);
-  if (existing !== undefined) return existing;
-
-  const elemType: ValType = { kind: elemKind };
+/**
+ * Materialize the four raw-array intrinsics for one element kind
+ * (idempotent — funcMap-guarded). Each is a real defined function, so
+ * correctness never depends on any inlining pass; bodies are 3–8 instrs.
+ */
+function ensureArrayIntrinsics(ctx: CodegenContext, arrTypeIdx: number, k: SortElemKind): void {
+  if (ctx.funcMap.get(`__arri_get_${k}`) !== undefined) return;
   const arrRef: ValType = { kind: "ref_null", typeIdx: arrTypeIdx };
-  const gtOp: Instr = elemKind === "i32" ? { op: "i32.gt_s" } : { op: "f64.gt" };
+  const elem: ValType = { kind: k };
+  const f64: ValType = { kind: "f64" };
 
-  // Params: 0=data, 1=lo, 2=hi   Locals: 3=i, 4=j, 5=key
-  const DATA = 0,
-    LO = 1,
-    HI = 2,
-    II = 3,
-    JJ = 4,
-    KEY = 5;
-
-  const body: Instr[] = [
-    // i = lo + 1
-    L(LO),
-    I(1),
-    ADD,
-    LS(II),
-
-    BLOCK([
-      LOOP([
-        // if i >= hi: break
-        L(II),
-        L(HI),
-        GE_S,
-        BR_IF(1),
-
-        // key = data[i]
-        L(DATA),
-        L(II),
-        AG(arrTypeIdx),
-        LS(KEY),
-
-        // j = i - 1
-        L(II),
-        I(1),
-        SUB,
-        LS(JJ),
-
-        // Inner: while j >= lo && data[j] > key
-        BLOCK([
-          LOOP([
-            L(JJ),
-            L(LO),
-            LT_S,
-            BR_IF(1),
-            L(DATA),
-            L(JJ),
-            AG(arrTypeIdx),
-            L(KEY),
-            gtOp,
-            EQZ,
-            BR_IF(1),
-            // data[j+1] = data[j]
-            L(DATA),
-            L(JJ),
-            I(1),
-            ADD,
-            L(DATA),
-            L(JJ),
-            AG(arrTypeIdx),
-            AS(arrTypeIdx),
-            // j--
-            L(JJ),
-            I(1),
-            SUB,
-            LS(JJ),
-            BR(0),
-          ]),
-        ]),
-
-        // data[j+1] = key
-        L(DATA),
-        L(JJ),
-        I(1),
-        ADD,
-        L(KEY),
-        AS(arrTypeIdx),
-
-        // i++
-        L(II),
-        I(1),
-        ADD,
-        LS(II),
-        BR(0),
-      ]),
-    ]),
-  ];
-
-  return emitFunc(
+  // __arri_get_<k>(data, i) -> data[trunc(i)]
+  emitFunc(
     ctx,
-    name,
-    [arrRef, { kind: "i32" }, { kind: "i32" }],
+    `__arri_get_${k}`,
+    [arrRef, f64],
+    [elem],
+    [],
+    [L(0), L(1), TRUNC, { op: "array.get", typeIdx: arrTypeIdx }],
+  );
+  // __arri_set_<k>(data, i, v)
+  emitFunc(
+    ctx,
+    `__arri_set_${k}`,
+    [arrRef, f64, elem],
+    [],
+    [],
+    [L(0), L(1), TRUNC, L(2), { op: "array.set", typeIdx: arrTypeIdx }],
+  );
+  // __arri_new_<k>(n) -> fresh zero-filled array
+  emitFunc(
+    ctx,
+    `__arri_new_${k}`,
+    [f64],
+    [arrRef],
+    [],
+    [L(0), TRUNC, { op: "array.new_default", typeIdx: arrTypeIdx }],
+  );
+  // __arri_copy_<k>(dst, dstOff, src, srcOff, n) — overlap-safe array.copy
+  emitFunc(
+    ctx,
+    `__arri_copy_${k}`,
+    [arrRef, f64, arrRef, f64, f64],
+    [],
     [],
     [
-      { name: "i", type: { kind: "i32" } },
-      { name: "j", type: { kind: "i32" } },
-      { name: "key", type: elemType },
+      L(0),
+      L(1),
+      TRUNC,
+      L(2),
+      L(3),
+      TRUNC,
+      L(4),
+      TRUNC,
+      { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx },
     ],
-    body,
   );
 }
 
-// ---------------------------------------------------------------------------
-// 2. Merge: __merge_{type}(data, tmp, lo, mid, hi)
-// ---------------------------------------------------------------------------
-function emitMerge(ctx: CodegenContext, arrTypeIdx: number, elemKind: "i32" | "f64"): number {
-  const name = `__merge_${elemKind}`;
-  const existing = ctx.funcMap.get(name);
-  if (existing !== undefined) return existing;
-
-  const arrRef: ValType = { kind: "ref_null", typeIdx: arrTypeIdx };
-  const leOp: Instr = elemKind === "i32" ? { op: "i32.le_s" } : { op: "f64.le" };
-
-  // Params: 0=data, 1=tmp, 2=lo, 3=mid, 4=hi
-  // Locals: 5=leftLen, 6=i, 7=j, 8=k
-  const DATA = 0,
-    TMP = 1,
-    LO = 2,
-    MID = 3,
-    HI = 4;
-  const LEFT = 5,
-    II = 6,
-    JJ = 7,
-    KK = 8;
-
-  const body: Instr[] = [
-    // leftLen = mid - lo
-    L(MID),
-    L(LO),
-    SUB,
-    LS(LEFT),
-    // if leftLen <= 0: return
-    L(LEFT),
-    I(0),
-    LE_S,
-    IF([RET]),
-
-    // Copy left half to tmp[0..leftLen)
-    L(TMP),
-    I(0),
-    L(DATA),
-    L(LO),
-    L(LEFT),
-    AC(arrTypeIdx, arrTypeIdx),
-
-    // i=0, j=mid, k=lo
-    I(0),
-    LS(II),
-    L(MID),
-    LS(JJ),
-    L(LO),
-    LS(KK),
-
-    // Merge loop
-    BLOCK([
-      LOOP([
-        L(II),
-        L(LEFT),
-        GE_S,
-        BR_IF(1), // left exhausted
-        L(JJ),
-        L(HI),
-        GE_S,
-        BR_IF(1), // right exhausted
-
-        // if tmp[i] <= data[j]: take from left, else from right
-        L(TMP),
-        L(II),
-        AG(arrTypeIdx),
-        L(DATA),
-        L(JJ),
-        AG(arrTypeIdx),
-        leOp,
-        IF(
-          [L(DATA), L(KK), L(TMP), L(II), AG(arrTypeIdx), AS(arrTypeIdx), L(II), I(1), ADD, LS(II)],
-          [L(DATA), L(KK), L(DATA), L(JJ), AG(arrTypeIdx), AS(arrTypeIdx), L(JJ), I(1), ADD, LS(JJ)],
-        ),
-
-        L(KK),
-        I(1),
-        ADD,
-        LS(KK),
-        BR(0),
-      ]),
-    ]),
-
-    // Copy remaining left elements (right are already in place)
-    L(II),
-    L(LEFT),
-    LT_S,
-    IF([L(DATA), L(KK), L(TMP), L(II), L(LEFT), L(II), SUB, AC(arrTypeIdx, arrTypeIdx)]),
-  ];
-
-  return emitFunc(
-    ctx,
-    name,
-    [arrRef, arrRef, { kind: "i32" }, { kind: "i32" }, { kind: "i32" }],
-    [],
-    [
-      { name: "leftLen", type: { kind: "i32" } },
-      { name: "i", type: { kind: "i32" } },
-      { name: "j", type: { kind: "i32" } },
-      { name: "k", type: { kind: "i32" } },
-    ],
-    body,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// 3. Merge-at: __merge_run_{type}(data, tmp, sBase, sLen, stackSize, idx) -> i32
-//    Merges runs at stack[idx] and stack[idx+1], shifts stack, returns new size.
-// ---------------------------------------------------------------------------
-function emitMergeRun(
-  ctx: CodegenContext,
-  arrTypeIdx: number,
-  i32ArrTypeIdx: number,
-  elemKind: "i32" | "f64",
-  mergeFuncIdx: number,
-): number {
-  const name = `__merge_run_${elemKind}`;
-  const existing = ctx.funcMap.get(name);
-  if (existing !== undefined) return existing;
-
-  const arrRef: ValType = { kind: "ref_null", typeIdx: arrTypeIdx };
-  const i32ArrRef: ValType = { kind: "ref_null", typeIdx: i32ArrTypeIdx };
-
-  // Params: 0=data, 1=tmp, 2=sBase, 3=sLen, 4=stackSize, 5=idx
-  // Locals: 6=base1, 7=len1, 8=len2
-  const DATA = 0,
-    TMP = 1,
-    SBASE = 2,
-    SLEN = 3,
-    SSIZE = 4,
-    IDX = 5;
-  const BASE1 = 6,
-    LEN1 = 7,
-    LEN2 = 8;
-
-  const body: Instr[] = [
-    // base1 = sBase[idx]
-    L(SBASE),
-    L(IDX),
-    AG(i32ArrTypeIdx),
-    LS(BASE1),
-    // len1 = sLen[idx]
-    L(SLEN),
-    L(IDX),
-    AG(i32ArrTypeIdx),
-    LS(LEN1),
-    // len2 = sLen[idx + 1]
-    L(SLEN),
-    L(IDX),
-    I(1),
-    ADD,
-    AG(i32ArrTypeIdx),
-    LS(LEN2),
-
-    // call __merge(data, tmp, base1, base1+len1, base1+len1+len2)
-    L(DATA),
-    L(TMP),
-    L(BASE1),
-    L(BASE1),
-    L(LEN1),
-    ADD,
-    L(BASE1),
-    L(LEN1),
-    ADD,
-    L(LEN2),
-    ADD,
-    CALL(mergeFuncIdx),
-
-    // sLen[idx] = len1 + len2
-    L(SLEN),
-    L(IDX),
-    L(LEN1),
-    L(LEN2),
-    ADD,
-    AS(i32ArrTypeIdx),
-
-    // Shift stack entries: copy from idx+2.. to idx+1..
-    // length = stackSize - idx - 2 (always >= 0)
-    L(SBASE),
-    L(IDX),
-    I(1),
-    ADD,
-    L(SBASE),
-    L(IDX),
-    I(2),
-    ADD,
-    L(SSIZE),
-    L(IDX),
-    SUB,
-    I(2),
-    SUB,
-    AC(i32ArrTypeIdx, i32ArrTypeIdx),
-
-    L(SLEN),
-    L(IDX),
-    I(1),
-    ADD,
-    L(SLEN),
-    L(IDX),
-    I(2),
-    ADD,
-    L(SSIZE),
-    L(IDX),
-    SUB,
-    I(2),
-    SUB,
-    AC(i32ArrTypeIdx, i32ArrTypeIdx),
-
-    // return stackSize - 1
-    L(SSIZE),
-    I(1),
-    SUB,
-  ];
-
-  return emitFunc(
-    ctx,
-    name,
-    [arrRef, arrRef, i32ArrRef, i32ArrRef, { kind: "i32" }, { kind: "i32" }],
-    [{ kind: "i32" }],
-    [
-      { name: "base1", type: { kind: "i32" } },
-      { name: "len1", type: { kind: "i32" } },
-      { name: "len2", type: { kind: "i32" } },
-    ],
-    body,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// 4. Main Timsort driver: __timsort_{type}(vec)
-// ---------------------------------------------------------------------------
-function emitTimsortMain(
-  ctx: CodegenContext,
-  vecTypeIdx: number,
-  arrTypeIdx: number,
-  i32ArrTypeIdx: number,
-  elemKind: "i32" | "f64",
-  isortIdx: number,
-  mergeRunIdx: number,
-): number {
-  const name = `__timsort_${elemKind}`;
-  const elemType: ValType = { kind: elemKind };
-  const vecRef: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
-  const ltOp: Instr = elemKind === "i32" ? { op: "i32.lt_s" } : { op: "f64.lt" };
-
-  // Param 0: vec
-  const VEC = 0;
-  // Locals 1..19
-  const DATA = 1,
-    LEN = 2,
-    TMP = 3,
-    MIN_RUN = 4;
-  const NMR = 5,
-    RMR = 6;
-  const LO = 7,
-    RUN_END = 8,
-    RUN_LEN = 9,
-    FORCE = 10;
-  const SB = 11,
-    SL = 12,
-    SS = 13;
-  const SN = 14,
-    MIDX = 15;
-  const I_REV = 16,
-    J_REV = 17,
-    T_SWAP = 18,
-    SHOULD = 19;
-
-  const locals: LocalDef[] = [
-    { name: "data", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
-    { name: "len", type: { kind: "i32" } },
-    { name: "tmp", type: { kind: "ref_null", typeIdx: arrTypeIdx } },
-    { name: "minRun", type: { kind: "i32" } },
-    { name: "nmr", type: { kind: "i32" } },
-    { name: "rmr", type: { kind: "i32" } },
-    { name: "lo", type: { kind: "i32" } },
-    { name: "runEnd", type: { kind: "i32" } },
-    { name: "runLen", type: { kind: "i32" } },
-    { name: "force", type: { kind: "i32" } },
-    { name: "sBase", type: { kind: "ref_null", typeIdx: i32ArrTypeIdx } },
-    { name: "sLen", type: { kind: "ref_null", typeIdx: i32ArrTypeIdx } },
-    { name: "stackSize", type: { kind: "i32" } },
-    { name: "sn", type: { kind: "i32" } },
-    { name: "mergeIdx", type: { kind: "i32" } },
-    { name: "iRev", type: { kind: "i32" } },
-    { name: "jRev", type: { kind: "i32" } },
-    { name: "tSwap", type: elemType },
-    { name: "should", type: { kind: "i32" } },
-  ];
-
-  // -- Section 1: extract data & len, early return --
-  const sec1: Instr[] = [
-    L(VEC),
-    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
-    LS(DATA),
-    L(VEC),
-    { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
-    LS(LEN),
-    // if len < 2: return
-    L(LEN),
-    I(2),
-    LT_S,
-    IF([RET]),
-  ];
-
-  // -- Section 2: small array → insertion sort --
-  const sec2: Instr[] = [L(LEN), I(64), LT_S, IF([L(DATA), I(0), L(LEN), CALL(isortIdx), RET])];
-
-  // -- Section 3: compute minRun --
-  const sec3: Instr[] = [
-    L(LEN),
-    LS(NMR),
-    I(0),
-    LS(RMR),
-    BLOCK([
-      LOOP([
-        L(NMR),
-        I(64),
-        LT_S,
-        BR_IF(1),
-        // rmr |= (nmr & 1)
-        L(RMR),
-        L(NMR),
-        I(1),
-        I_AND,
-        I_OR,
-        LS(RMR),
-        // nmr >>= 1
-        L(NMR),
-        I(1),
-        SHR_U,
-        LS(NMR),
-        BR(0),
-      ]),
-    ]),
-    L(NMR),
-    L(RMR),
-    ADD,
-    LS(MIN_RUN),
-  ];
-
-  // -- Section 4: allocate buffers --
-  const sec4: Instr[] = [
-    L(LEN),
-    AND(arrTypeIdx),
-    LS(TMP),
-    I(85),
-    AND(i32ArrTypeIdx),
-    LS(SB),
-    I(85),
-    AND(i32ArrTypeIdx),
-    LS(SL),
-    I(0),
-    LS(SS),
-    I(0),
-    LS(LO),
-  ];
-
-  // -- Section 5: main loop body (run detection + extend + push + collapse) --
-
-  // 5a: detect run
-  const detectRun: Instr[] = [
-    // runEnd = lo + 1
-    L(LO),
-    I(1),
-    ADD,
-    LS(RUN_END),
-
-    L(RUN_END),
-    L(LEN),
-    GE_S,
-    IF(
-      // Single element remaining
-      [I(1), LS(RUN_LEN)],
-      [
-        // Check if descending: data[lo+1] < data[lo]
-        L(DATA),
-        L(RUN_END),
-        AG(arrTypeIdx),
-        L(DATA),
-        L(LO),
-        AG(arrTypeIdx),
-        ltOp,
-        IF(
-          // Descending run
-          [
-            L(RUN_END),
-            I(1),
-            ADD,
-            LS(RUN_END),
-            BLOCK([
-              LOOP([
-                L(RUN_END),
-                L(LEN),
-                GE_S,
-                BR_IF(1),
-                // if data[runEnd] >= data[runEnd-1]: stop
-                L(DATA),
-                L(RUN_END),
-                AG(arrTypeIdx),
-                L(DATA),
-                L(RUN_END),
-                I(1),
-                SUB,
-                AG(arrTypeIdx),
-                ltOp,
-                EQZ,
-                BR_IF(1),
-                L(RUN_END),
-                I(1),
-                ADD,
-                LS(RUN_END),
-                BR(0),
-              ]),
-            ]),
-            // Reverse [lo, runEnd)
-            L(LO),
-            LS(I_REV),
-            L(RUN_END),
-            I(1),
-            SUB,
-            LS(J_REV),
-            BLOCK([
-              LOOP([
-                L(I_REV),
-                L(J_REV),
-                GE_S,
-                BR_IF(1),
-                // swap data[iRev] <-> data[jRev]
-                L(DATA),
-                L(I_REV),
-                AG(arrTypeIdx),
-                LS(T_SWAP),
-                L(DATA),
-                L(I_REV),
-                L(DATA),
-                L(J_REV),
-                AG(arrTypeIdx),
-                AS(arrTypeIdx),
-                L(DATA),
-                L(J_REV),
-                L(T_SWAP),
-                AS(arrTypeIdx),
-                L(I_REV),
-                I(1),
-                ADD,
-                LS(I_REV),
-                L(J_REV),
-                I(1),
-                SUB,
-                LS(J_REV),
-                BR(0),
-              ]),
-            ]),
-          ],
-          // Ascending run
-          [
-            L(RUN_END),
-            I(1),
-            ADD,
-            LS(RUN_END),
-            BLOCK([
-              LOOP([
-                L(RUN_END),
-                L(LEN),
-                GE_S,
-                BR_IF(1),
-                // if data[runEnd] < data[runEnd-1]: stop
-                L(DATA),
-                L(RUN_END),
-                AG(arrTypeIdx),
-                L(DATA),
-                L(RUN_END),
-                I(1),
-                SUB,
-                AG(arrTypeIdx),
-                ltOp,
-                BR_IF(1),
-                L(RUN_END),
-                I(1),
-                ADD,
-                LS(RUN_END),
-                BR(0),
-              ]),
-            ]),
-          ],
-        ),
-        // runLen = runEnd - lo
-        L(RUN_END),
-        L(LO),
-        SUB,
-        LS(RUN_LEN),
-      ],
-    ),
-  ];
-
-  // 5b: extend short run with insertion sort
-  const extendRun: Instr[] = [
-    // force = min(minRun, len - lo)
-    L(MIN_RUN),
-    L(LEN),
-    L(LO),
-    SUB,
-    // select: if minRun <= len-lo then minRun else len-lo
-    L(MIN_RUN),
-    L(LEN),
-    L(LO),
-    SUB,
-    LE_S,
-    { op: "select" },
-    LS(FORCE),
-
-    L(RUN_LEN),
-    L(FORCE),
-    LT_S,
-    IF([L(DATA), L(LO), L(LO), L(FORCE), ADD, CALL(isortIdx), L(FORCE), LS(RUN_LEN)]),
-  ];
-
-  // 5c: push run to stack
-  const pushRun: Instr[] = [
-    L(SB),
-    L(SS),
-    L(LO),
-    AS(i32ArrTypeIdx),
-    L(SL),
-    L(SS),
-    L(RUN_LEN),
-    AS(i32ArrTypeIdx),
-    L(SS),
-    I(1),
-    ADD,
-    LS(SS),
-  ];
-
-  // 5d: merge collapse — maintain Timsort stack invariants
-  const mergeCollapse: Instr[] = [
-    BLOCK([
-      LOOP([
-        L(SS),
-        I(2),
-        LT_S,
-        BR_IF(1), // stackSize < 2: done
-
-        L(SS),
-        I(2),
-        SUB,
-        LS(SN), // sn = stackSize - 2
-        I(0),
-        LS(SHOULD),
-        L(SN),
-        LS(MIDX), // default mergeIdx = sn
-
-        L(SN),
-        I(0),
-        GT_S,
-        IF(
-          // 3+ entries: check invariant 1
-          [
-            // runLen[sn-1] <= runLen[sn] + runLen[sn+1]?
-            L(SL),
-            L(SN),
-            I(1),
-            SUB,
-            AG(i32ArrTypeIdx), // runLen[sn-1]
-            L(SL),
-            L(SN),
-            AG(i32ArrTypeIdx), // runLen[sn]
-            L(SL),
-            L(SN),
-            I(1),
-            ADD,
-            AG(i32ArrTypeIdx), // runLen[sn+1]
-            ADD, // runLen[sn] + runLen[sn+1]
-            LE_S,
-            IF(
-              [
-                I(1),
-                LS(SHOULD),
-                // if runLen[sn-1] < runLen[sn+1]: mergeIdx = sn-1
-                L(SL),
-                L(SN),
-                I(1),
-                SUB,
-                AG(i32ArrTypeIdx),
-                L(SL),
-                L(SN),
-                I(1),
-                ADD,
-                AG(i32ArrTypeIdx),
-                LT_S,
-                IF([L(SN), I(1), SUB, LS(MIDX)]),
-              ],
-              // Invariant 1 OK, check invariant 2: runLen[sn] <= runLen[sn+1]
-              [
-                L(SL),
-                L(SN),
-                AG(i32ArrTypeIdx),
-                L(SL),
-                L(SN),
-                I(1),
-                ADD,
-                AG(i32ArrTypeIdx),
-                LE_S,
-                IF([I(1), LS(SHOULD)]),
-              ],
-            ),
-          ],
-          // 2 entries: only check invariant 2
-          [L(SL), L(SN), AG(i32ArrTypeIdx), L(SL), L(SN), I(1), ADD, AG(i32ArrTypeIdx), LE_S, IF([I(1), LS(SHOULD)])],
-        ),
-
-        L(SHOULD),
-        EQZ,
-        BR_IF(1), // no merge needed: done
-
-        // call __merge_run(data, tmp, sBase, sLen, stackSize, mergeIdx)
-        L(DATA),
-        L(TMP),
-        L(SB),
-        L(SL),
-        L(SS),
-        L(MIDX),
-        CALL(mergeRunIdx),
-        LS(SS),
-
-        BR(0),
-      ]),
-    ]),
-  ];
-
-  // 5e: advance lo
-  const advanceLo: Instr[] = [L(LO), L(RUN_LEN), ADD, LS(LO)];
-
-  // Assemble main loop
-  const mainLoop: Instr[] = [
-    BLOCK([
-      LOOP([
-        L(LO),
-        L(LEN),
-        GE_S,
-        BR_IF(1),
-        ...detectRun,
-        ...extendRun,
-        ...pushRun,
-        ...mergeCollapse,
-        ...advanceLo,
-        BR(0),
-      ]),
-    ]),
-  ];
-
-  // -- Section 6: force collapse all remaining runs --
-  const forceCollapse: Instr[] = [
-    BLOCK([
-      LOOP([
-        L(SS),
-        I(2),
-        LT_S,
-        BR_IF(1),
-        L(SS),
-        I(2),
-        SUB,
-        LS(SN),
-        L(SN),
-        LS(MIDX),
-
-        // if sn > 0 and sLen[sn-1] < sLen[sn+1]: mergeIdx = sn-1
-        L(SN),
-        I(0),
-        GT_S,
-        IF([
-          L(SL),
-          L(SN),
-          I(1),
-          SUB,
-          AG(i32ArrTypeIdx),
-          L(SL),
-          L(SN),
-          I(1),
-          ADD,
-          AG(i32ArrTypeIdx),
-          LT_S,
-          IF([L(SN), I(1), SUB, LS(MIDX)]),
-        ]),
-
-        L(DATA),
-        L(TMP),
-        L(SB),
-        L(SL),
-        L(SS),
-        L(MIDX),
-        CALL(mergeRunIdx),
-        LS(SS),
-
-        BR(0),
-      ]),
-    ]),
-  ];
-
-  const body: Instr[] = [...sec1, ...sec2, ...sec3, ...sec4, ...mainLoop, ...forceCollapse];
-
-  return emitFunc(ctx, name, [vecRef], [], locals, body);
+/**
+ * Callee signature table for one element kind: the four self-hosted
+ * kernels + the element and run-stack intrinsics. Shared by every kernel
+ * def (from-ast only consults entries a body actually calls).
+ */
+function kernelCalleeTypes(
+  k: SortElemKind,
+  dataRef: IrType,
+  stackRef: IrType,
+): Map<string, { params: readonly IrType[]; returnType: IrType | null }> {
+  const NUM: IrType = irVal({ kind: "f64" });
+  const elem: IrType = irVal({ kind: k });
+  const sigs = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>([
+    [`__arri_get_${k}`, { params: [dataRef, NUM], returnType: elem }],
+    [`__arri_set_${k}`, { params: [dataRef, NUM, elem], returnType: null }],
+    [`__arri_new_${k}`, { params: [NUM], returnType: dataRef }],
+    [`__arri_copy_${k}`, { params: [dataRef, NUM, dataRef, NUM, NUM], returnType: null }],
+    [`__sh_isort_${k}`, { params: [dataRef, NUM, NUM], returnType: null }],
+    [`__sh_merge_${k}`, { params: [dataRef, dataRef, NUM, NUM, NUM], returnType: null }],
+    [`__sh_merge_run_${k}`, { params: [dataRef, dataRef, stackRef, stackRef, NUM, NUM], returnType: NUM }],
+  ]);
+  if (k !== "f64") {
+    // Run-stack intrinsics operate on the canonical f64 array type.
+    sigs.set("__arri_get_f64", { params: [stackRef, NUM], returnType: NUM });
+    sigs.set("__arri_set_f64", { params: [stackRef, NUM, NUM], returnType: null });
+    sigs.set("__arri_new_f64", { params: [NUM], returnType: stackRef });
+    sigs.set("__arri_copy_f64", { params: [stackRef, NUM, stackRef, NUM, NUM], returnType: null });
+  }
+  return sigs;
 }
 
 // ---------------------------------------------------------------------------
@@ -912,11 +159,54 @@ export function ensureTimsortHelper(
   const existing = ctx.funcMap.get(name);
   if (existing !== undefined) return existing;
 
-  // We need an i32 array type for the run stack (start positions + lengths)
-  const i32ArrTypeIdx = getOrRegisterArrayType(ctx, "i32");
+  // Run stack (start positions + lengths) lives in canonical f64 arrays
+  // (hand version: i32 arrays — values are run bases/lengths, exact in f64).
+  const f64ArrTypeIdx = getOrRegisterArrayType(ctx, "f64");
+  if (elemKind === "f64" && arrTypeIdx !== f64ArrTypeIdx) {
+    // The intrinsic names embed only the elem kind, so the f64 element
+    // array MUST be the canonical f64 array type (it always is — vecs
+    // register through the same registry). Loud guard beats a miscompile.
+    throw new Error(`timsort: non-canonical f64 array typeIdx ${arrTypeIdx} (canonical ${f64ArrTypeIdx})`);
+  }
+  ensureArrayIntrinsics(ctx, f64ArrTypeIdx, "f64");
+  if (elemKind === "i32") ensureArrayIntrinsics(ctx, arrTypeIdx, "i32");
 
-  const isortIdx = emitInsertionSort(ctx, arrTypeIdx, elemKind);
-  const mergeIdx = emitMerge(ctx, arrTypeIdx, elemKind);
-  const mergeRunIdx = emitMergeRun(ctx, arrTypeIdx, i32ArrTypeIdx, elemKind, mergeIdx);
-  return emitTimsortMain(ctx, vecTypeIdx, arrTypeIdx, i32ArrTypeIdx, elemKind, isortIdx, mergeRunIdx);
+  const dataRef: IrType = irVal({ kind: "ref_null", typeIdx: arrTypeIdx });
+  const stackRef: IrType = irVal({ kind: "ref_null", typeIdx: f64ArrTypeIdx });
+  const NUM: IrType = irVal({ kind: "f64" });
+  const calleeTypes = kernelCalleeTypes(elemKind, dataRef, stackRef);
+  const paramType = (p: "data" | "stack" | "num"): IrType => (p === "data" ? dataRef : p === "stack" ? stackRef : NUM);
+
+  // Compile the four kernels leaf-first through our own pipeline.
+  let shTimsortIdx = -1;
+  for (const kernel of timsortKernelDefs(elemKind)) {
+    const def: SelfHostedFuncDef = {
+      name: kernel.name,
+      source: kernel.source,
+      paramTypes: kernel.params.map(paramType),
+      returnType: kernel.ret === "num" ? NUM : null,
+      calleeTypes,
+    };
+    shTimsortIdx = emitSelfHostedFunc(ctx, def);
+  }
+
+  // External-ABI thunk: __timsort_<k>(vec) — extract (data, len) and call
+  // the self-hosted driver. Kept hand-written (vec struct access is not in
+  // the stdlib dialect; 6 instrs).
+  const vecRef: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
+  return emitFunc(
+    ctx,
+    name,
+    [vecRef],
+    [],
+    [],
+    [
+      L(0),
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+      L(0),
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+      { op: "f64.convert_i32_s" },
+      { op: "call", funcIdx: shTimsortIdx },
+    ],
+  );
 }

--- a/src/stdlib/array-sort.ts
+++ b/src/stdlib/array-sort.ts
@@ -1,0 +1,306 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Self-hosted Timsort kernels (#3159 — array family slice 1 of the porffor
+ * model, following the #3141 Math pilot).
+ *
+ * Each kernel is ORDINARY TypeScript source in the IR-claimable subset,
+ * instantiated per element kind (`f64` for `number[]` vecs, `i32` for
+ * boolean-element vecs) from ONE template. The compiler compiles these
+ * through its OWN pipeline at compile time (`src/codegen/stdlib-selfhost.ts`)
+ * and registers the results exactly where the hand-emitted `Instr[]`
+ * versions used to live (`src/codegen/timsort.ts`, 922 → ~230 lines).
+ *
+ * WHY ONE TEMPLATE COVERS BOTH ELEMENT KINDS: element values are only ever
+ * loaded, compared, and stored — never mixed into index arithmetic. The
+ * element accessors (`__arri_get_<k>` …) are typed intrinsic callees whose
+ * return/param types carry the element kind, so unannotated locals like
+ * `let key = __arri_get_i32(data, i)` infer i32, and from-ast's magnitude
+ * compares are polymorphic over f64 AND i32 (#1126 Stage 3) — `>` emits
+ * `f64.gt` or `i32.gt_s` per operand type, exactly the ops the hand bodies
+ * hard-coded.
+ *
+ * DIALECT RULES (beyond the #3141 header):
+ *   - Element access goes through the `__arri_*` intrinsics (raw-array
+ *     get/set/new/copy is not expressible in the IR subset, and call args
+ *     require EXACT IrType match — hence f64 index params, truncated inside
+ *     the intrinsic). See `ensureArrayIntrinsics` in timsort.ts.
+ *   - Index/length arithmetic stays f64 (`number`): array indices are
+ *     < 2^31, exact in f64. Internal kernel signatures therefore differ
+ *     from the deleted hand versions (i32 index params) — sound, and only
+ *     observable inside the kernel family; the external `__timsort_<k>(vec)`
+ *     ABI is preserved by a small hand thunk.
+ *   - The run stack (`sBase`/`sLen`) uses f64 arrays (hand version: i32
+ *     arrays). Values are run bases/lengths — exact in f64, observationally
+ *     equivalent.
+ *
+ * NUMERIC EQUIVALENCE: each body mirrors the deleted hand `Instr[]`
+ * op-for-op — same compare directions (`>` in the isort inner loop, `<=` in
+ * the merge pick and the collapse invariants, `<` in run detection and the
+ * merge-index tie-breaks), so NaN behavior is identical (every f64 compare
+ * with NaN is false in both versions), stability is identical, and sorted
+ * output is bit-exact against the hand kernels.
+ */
+
+/** Element kinds the numeric Timsort instantiates (see #2502 guards). */
+export type SortElemKind = "f64" | "i32";
+
+export interface TimsortKernelDef {
+  /** funcMap registration name (also the function name in `source`). */
+  readonly name: string;
+  /** Ordinary TS source, IR-claimable subset. */
+  readonly source: string;
+  /**
+   * Positional param specs, mapped to concrete IrTypes by the caller
+   * (timsort.ts knows the ctx's array typeIdx values):
+   *   "data"  — `(ref null $arr_<k>)` element data array
+   *   "stack" — `(ref null $arr_f64)` run-stack array
+   *   "num"   — f64
+   */
+  readonly params: readonly ("data" | "stack" | "num")[];
+  /** Return spec: "num" (f64) or null (void). */
+  readonly ret: "num" | null;
+  /**
+   * Callee names (siblings + intrinsics), in-source call targets. All must
+   * be registered in ctx.funcMap before this kernel is emitted.
+   */
+  readonly callees: readonly string[];
+}
+
+/**
+ * Insertion sort a range [lo, hi). Mirrors the hand `__isort_<k>`:
+ * inner loop shifts while `data[j] > key` (strict — stability), re-loading
+ * `data[j]` for the shift store exactly like the hand body did.
+ */
+function isortSource(k: SortElemKind): string {
+  return `
+export function __sh_isort_${k}(data, lo: number, hi: number): void {
+  let i: number = lo + 1;
+  while (i < hi) {
+    let key = __arri_get_${k}(data, i);
+    let j: number = i - 1;
+    while (j >= lo && __arri_get_${k}(data, j) > key) {
+      __arri_set_${k}(data, j + 1, __arri_get_${k}(data, j));
+      j = j - 1;
+    }
+    __arri_set_${k}(data, j + 1, key);
+    i = i + 1;
+  }
+  return;
+}
+`;
+}
+
+/**
+ * Stable merge of [lo, mid) and [mid, hi) using scratch `tmp` for the left
+ * half. Mirrors the hand `__merge_<k>`: pick from left while
+ * `tmp[i] <= data[j]` (ties take left — stability), tail-copy the remaining
+ * left elements (right remainder is already in place).
+ */
+function mergeSource(k: SortElemKind): string {
+  return `
+export function __sh_merge_${k}(data, tmp, lo: number, mid: number, hi: number): void {
+  let leftLen: number = mid - lo;
+  if (leftLen <= 0) return;
+  __arri_copy_${k}(tmp, 0, data, lo, leftLen);
+  let i: number = 0;
+  let j: number = mid;
+  let kk: number = lo;
+  while (i < leftLen && j < hi) {
+    if (__arri_get_${k}(tmp, i) <= __arri_get_${k}(data, j)) {
+      __arri_set_${k}(data, kk, __arri_get_${k}(tmp, i));
+      i = i + 1;
+    } else {
+      __arri_set_${k}(data, kk, __arri_get_${k}(data, j));
+      j = j + 1;
+    }
+    kk = kk + 1;
+  }
+  if (i < leftLen) {
+    __arri_copy_${k}(data, kk, tmp, i, leftLen - i);
+  }
+  return;
+}
+`;
+}
+
+/**
+ * Merge the runs at stack[idx] and stack[idx+1], shift the stack left,
+ * return the new stack size. Mirrors the hand `__merge_run_<k>` (the stack
+ * shift copies from idx+2.. to idx+1.. with count stackSize-idx-2 — the
+ * same overlap-safe `array.copy` the hand body used).
+ */
+function mergeRunSource(k: SortElemKind): string {
+  return `
+export function __sh_merge_run_${k}(data, tmp, sBase, sLen, stackSize: number, idx: number): number {
+  let base1: number = __arri_get_f64(sBase, idx);
+  let len1: number = __arri_get_f64(sLen, idx);
+  let len2: number = __arri_get_f64(sLen, idx + 1);
+  __sh_merge_${k}(data, tmp, base1, base1 + len1, base1 + len1 + len2);
+  __arri_set_f64(sLen, idx, len1 + len2);
+  __arri_copy_f64(sBase, idx + 1, sBase, idx + 2, stackSize - idx - 2);
+  __arri_copy_f64(sLen, idx + 1, sLen, idx + 2, stackSize - idx - 2);
+  return stackSize - 1;
+}
+`;
+}
+
+/**
+ * Main Timsort driver over (data, len). Mirrors the hand `__timsort_<k>`
+ * section-for-section: early return, small-array isort (< 64), minRun
+ * computation (bitwise, same `|=` / `>>>` ops the hand loop used), buffer
+ * allocation (85-deep run stack), run detection with descending-run
+ * reversal, short-run extension via isort, stack push, invariant-driven
+ * merge collapse, and the final force collapse.
+ *
+ * NaN note (f64): run detection continues an ascending run while
+ * `!(data[runEnd] < data[runEnd-1])` — the exact negated-`<` the hand body
+ * expressed as `ltOp; eqz; br_if`, so NaN (all compares false) extends
+ * ascending runs and stops descending runs identically.
+ */
+function timsortMainSource(k: SortElemKind): string {
+  return `
+export function __sh_timsort_${k}(data, len: number): void {
+  if (len < 2) return;
+  if (len < 64) {
+    __sh_isort_${k}(data, 0, len);
+    return;
+  }
+  let nmr: number = len;
+  let rmr: number = 0;
+  while (nmr >= 64) {
+    rmr = rmr | (nmr & 1);
+    nmr = nmr >>> 1;
+  }
+  let minRun: number = nmr + rmr;
+  let tmp = __arri_new_${k}(len);
+  let sBase = __arri_new_f64(85);
+  let sLen = __arri_new_f64(85);
+  let stackSize: number = 0;
+  let lo: number = 0;
+  while (lo < len) {
+    let runEnd: number = lo + 1;
+    let runLen: number = 0;
+    if (runEnd >= len) {
+      runLen = 1;
+    } else {
+      if (__arri_get_${k}(data, runEnd) < __arri_get_${k}(data, lo)) {
+        runEnd = runEnd + 1;
+        while (runEnd < len && __arri_get_${k}(data, runEnd) < __arri_get_${k}(data, runEnd - 1)) {
+          runEnd = runEnd + 1;
+        }
+        let iRev: number = lo;
+        let jRev: number = runEnd - 1;
+        while (iRev < jRev) {
+          let tSwap = __arri_get_${k}(data, iRev);
+          __arri_set_${k}(data, iRev, __arri_get_${k}(data, jRev));
+          __arri_set_${k}(data, jRev, tSwap);
+          iRev = iRev + 1;
+          jRev = jRev - 1;
+        }
+      } else {
+        runEnd = runEnd + 1;
+        while (runEnd < len && !(__arri_get_${k}(data, runEnd) < __arri_get_${k}(data, runEnd - 1))) {
+          runEnd = runEnd + 1;
+        }
+      }
+      runLen = runEnd - lo;
+    }
+    let force: number = minRun;
+    if (len - lo < force) {
+      force = len - lo;
+    }
+    if (runLen < force) {
+      __sh_isort_${k}(data, lo, lo + force);
+      runLen = force;
+    }
+    __arri_set_f64(sBase, stackSize, lo);
+    __arri_set_f64(sLen, stackSize, runLen);
+    stackSize = stackSize + 1;
+    while (stackSize >= 2) {
+      let sn: number = stackSize - 2;
+      let should: number = 0;
+      let mergeIdx: number = sn;
+      if (sn > 0) {
+        if (__arri_get_f64(sLen, sn - 1) <= __arri_get_f64(sLen, sn) + __arri_get_f64(sLen, sn + 1)) {
+          should = 1;
+          if (__arri_get_f64(sLen, sn - 1) < __arri_get_f64(sLen, sn + 1)) {
+            mergeIdx = sn - 1;
+          }
+        } else {
+          if (__arri_get_f64(sLen, sn) <= __arri_get_f64(sLen, sn + 1)) {
+            should = 1;
+          }
+        }
+      } else {
+        if (__arri_get_f64(sLen, sn) <= __arri_get_f64(sLen, sn + 1)) {
+          should = 1;
+        }
+      }
+      if (should === 0) {
+        break;
+      }
+      stackSize = __sh_merge_run_${k}(data, tmp, sBase, sLen, stackSize, mergeIdx);
+    }
+    lo = lo + runLen;
+  }
+  while (stackSize >= 2) {
+    let sn: number = stackSize - 2;
+    let mergeIdx: number = sn;
+    if (sn > 0) {
+      if (__arri_get_f64(sLen, sn - 1) < __arri_get_f64(sLen, sn + 1)) {
+        mergeIdx = sn - 1;
+      }
+    }
+    stackSize = __sh_merge_run_${k}(data, tmp, sBase, sLen, stackSize, mergeIdx);
+  }
+  return;
+}
+`;
+}
+
+/**
+ * The four kernels for one element kind, in leaf-first emission order
+ * (each kernel's `callees` are registered before it is emitted).
+ */
+export function timsortKernelDefs(k: SortElemKind): readonly TimsortKernelDef[] {
+  const get = `__arri_get_${k}`;
+  const set = `__arri_set_${k}`;
+  const alloc = `__arri_new_${k}`;
+  const copy = `__arri_copy_${k}`;
+  // f64-array intrinsics serve the run stack; for k === "f64" they coincide
+  // with the element intrinsics (same canonical f64 array type).
+  const stackOps = k === "f64" ? [] : ["__arri_get_f64", "__arri_set_f64", "__arri_new_f64", "__arri_copy_f64"];
+  return [
+    {
+      name: `__sh_isort_${k}`,
+      source: isortSource(k),
+      params: ["data", "num", "num"],
+      ret: null,
+      callees: [get, set],
+    },
+    {
+      name: `__sh_merge_${k}`,
+      source: mergeSource(k),
+      params: ["data", "data", "num", "num", "num"],
+      ret: null,
+      callees: [get, set, copy],
+    },
+    {
+      name: `__sh_merge_run_${k}`,
+      source: mergeRunSource(k),
+      params: ["data", "data", "stack", "stack", "num", "num"],
+      ret: "num",
+      callees: [
+        `__sh_merge_${k}`,
+        ...(k === "f64" ? [get, set, copy] : ["__arri_get_f64", "__arri_set_f64", "__arri_copy_f64"]),
+      ],
+    },
+    {
+      name: `__sh_timsort_${k}`,
+      source: timsortMainSource(k),
+      params: ["data", "num"],
+      ret: null,
+      callees: [`__sh_isort_${k}`, `__sh_merge_run_${k}`, get, set, alloc, copy, ...stackOps],
+    },
+  ];
+}

--- a/tests/issue-3159.test.ts
+++ b/tests/issue-3159.test.ts
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3159 — array family slice 1: the Timsort kernels are compiled from TS
+ * source in `src/stdlib/array-sort.ts` through the compiler's own IR
+ * pipeline (`src/codegen/stdlib-selfhost.ts` — `emitSelfHostedFunc`),
+ * instead of hand-emitted `Instr[]` in `src/codegen/timsort.ts`. This is
+ * the same self-hosting mechanism as the #3141 Math pilot, applied to the
+ * array family's sort engine.
+ *
+ * These tests pin the spec-critical sort behaviors the self-hosted kernels
+ * must preserve op-for-op vs the deleted hand version: stability of the
+ * merge, NaN placement (§23.1.3.30 default sort compares by ToString, and
+ * `toSorted` on a number array uses the numeric Timsort here — NaN sorts to
+ * the end via all-false compares), ±0 handling, the 63/64 insertion-sort
+ * cutoff and minRun boundaries, and both element lanes (f64 number[] and
+ * i32 boolean[]), in host AND standalone modes.
+ *
+ * The exhaustive bit-exact proof vs the main-built control binary
+ * (36,376 cases, zero mismatches) lived in `.tmp/sweep-3159.mts` at PR
+ * time; this file is the committed regression guard.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+const SRC = `
+function build(n: number, mode: number): number[] {
+  const a: number[] = [];
+  let x = 88172645;
+  let i = 0;
+  while (i < n) {
+    if (mode === 0) {
+      x = (x * 1103515245 + 12345) % 2147483648;
+      a.push(x - 1073741824);
+    } else if (mode === 1) {
+      a.push(n - i);
+    } else {
+      a.push(i - Math.floor(i / 7) * 7);
+    }
+    i = i + 1;
+  }
+  return a;
+}
+export function sortedAt(n: number, mode: number, idx: number): number {
+  const s = build(n, mode).toSorted();
+  return s[idx];
+}
+export function isSorted(n: number, mode: number): number {
+  const s = build(n, mode).toSorted();
+  let i = 1;
+  while (i < s.length) {
+    if (s[i] < s[i - 1]) return 0;
+    i = i + 1;
+  }
+  return 1;
+}
+export function boolCountTrue(n: number): number {
+  const b: boolean[] = [];
+  let i = 0;
+  while (i < n) {
+    b.push(i - Math.floor(i / 3) * 3 === 0 ? false : true);
+    i = i + 1;
+  }
+  const s = b.toSorted();
+  // after a stable sort, all false precede all true; count leading falses
+  let c = 0;
+  let j = 0;
+  while (j < s.length && !s[j]) {
+    c = c + 1;
+    j = j + 1;
+  }
+  // verify the tail is all-true (monotone)
+  let k = c;
+  while (k < s.length) {
+    if (!s[k]) return -1;
+    k = k + 1;
+  }
+  return c;
+}
+export function nanNumericSort(n: number): number {
+  // Build a large numeric vec (via push → unambiguous f64 numeric Timsort)
+  // whose every 5th slot is NaN, the rest a descending ramp. NaN compares
+  // are all-false, so a comparison sort's ordering of the finite elements
+  // relative to NaNs is implementation-defined (and bit-matched to the
+  // deleted hand kernel in the PR sweep) — we assert only the robust
+  // invariants: the sort completes without trapping, preserves length, and
+  // drops no NaNs. Returns:
+  //   -1  if the length changed,
+  //   -2  if the NaN count changed,
+  //   else the number of NaNs (proof they survived the merge/copy paths).
+  const a: number[] = [];
+  let i = 0;
+  let nans = 0;
+  while (i < n) {
+    if (i - Math.floor(i / 5) * 5 === 0) {
+      a.push(0 / 0);
+      nans = nans + 1;
+    } else {
+      a.push(n - i);
+    }
+    i = i + 1;
+  }
+  const s = a.toSorted();
+  if (s.length !== n) return -1;
+  let seenNan = 0;
+  let j = 0;
+  while (j < s.length) {
+    if (s[j] !== s[j]) seenNan = seenNan + 1;
+    j = j + 1;
+  }
+  if (seenNan !== nans) return -2;
+  return nans;
+}
+`;
+
+type Ex = {
+  sortedAt(n: number, mode: number, idx: number): number;
+  isSorted(n: number, mode: number): number;
+  boolCountTrue(n: number): number;
+  nanNumericSort(n: number): number;
+};
+
+async function host(): Promise<Ex> {
+  return (await compileAndInstantiate(SRC)) as unknown as Ex;
+}
+
+async function standalone(): Promise<Ex> {
+  const r = await compile(SRC, { fileName: "issue-3159-sa.ts", target: "standalone" });
+  expect(r.success, `standalone compile: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as Ex;
+}
+
+function refSort(n: number, mode: number): number[] {
+  const a: number[] = [];
+  let x = 88172645;
+  for (let i = 0; i < n; i++) {
+    if (mode === 0) {
+      x = (x * 1103515245 + 12345) % 2147483648;
+      a.push(x - 1073741824);
+    } else if (mode === 1) a.push(n - i);
+    else a.push(i % 7);
+  }
+  return a.slice().sort((p, q) => p - q);
+}
+
+// Lengths spanning the isort cutoff (63/64/65) and minRun boundaries.
+const LENGTHS = [0, 1, 2, 3, 63, 64, 65, 128, 129, 256, 500];
+
+for (const [label, make] of [
+  ["host", host],
+  ["standalone", standalone],
+] as const) {
+  describe(`#3159 self-hosted timsort — ${label}`, () => {
+    it("sorts f64 arrays identically to native numeric sort", async () => {
+      const ex = await make();
+      for (const n of LENGTHS) {
+        for (const mode of [0, 1, 2]) {
+          const ref = refSort(n, mode);
+          for (let i = 0; i < n; i++) {
+            expect(ex.sortedAt(n, mode, i), `n=${n} mode=${mode} idx=${i}`).toBe(ref[i]);
+          }
+          expect(ex.isSorted(n, mode), `monotone n=${n} mode=${mode}`).toBe(1);
+        }
+      }
+    });
+
+    it("sorts boolean (i32) arrays stably: falses then trues", async () => {
+      const ex = await make();
+      for (const n of LENGTHS) {
+        const expectedFalses = Math.floor((n + 2) / 3); // i%3===0 → false
+        expect(ex.boolCountTrue(n), `n=${n}`).toBe(expectedFalses);
+      }
+    });
+
+    it("preserves NaNs and keeps the finite prefix monotone (numeric sort)", async () => {
+      const ex = await make();
+      for (const n of [65, 128, 256, 500]) {
+        const expectedNans = Math.floor((n + 4) / 5); // i%5===0
+        expect(ex.nanNumericSort(n), `n=${n}`).toBe(expectedNans);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Array family slice 1 of the porffor-model bloat lever (`plan/self-hosting-scale-up.md`), following the #3141 Math pilot (GO). The four Timsort kernels (`__isort`/`__merge`/`__merge_run`/`__timsort`, ×{i32,f64}) move from **864 lines of hand-emitted `Instr[]`** in `src/codegen/timsort.ts` to **ordinary TS source** in `src/stdlib/array-sort.ts`, compiled through the compiler's OWN pipeline (from-ast → IR passes → BackendEmitter) via a generalized driver.

## Why timsort first (root-cause analysis)

Every `compile*` emitter in `array-methods.ts` is **element-type-generic** — a partial (f64-only) self-hosting keeps the generic hand emitter alive and goes net-**positive**. Timsort is the one unit already restricted to **i32|f64** (#2502 guards) with a fixed funcMap ABI, so ONE templated source instantiates both variants (magnitude compares are f64/i32-polymorphic, #1126) and the whole hand file collapses. It's the exact Math-pilot drop-in shape.

## Changes

- **`src/codegen/stdlib-selfhost.ts`** — `+emitSelfHostedFunc` (generalized driver: `paramTypeOverrides`/`returnTypeOverride`, mixed-elem-kind `calleeTypes`, **not** process-memoized because param IrTypes carry ctx-bound `typeIdx`). The Math pilot path is untouched/byte-inert. Reusable Precursor B/C infra for every later array/string/dataview slice.
- **`src/stdlib/array-sort.ts`** (new) — the four kernels as source, ported **op-for-op** (same compare directions → identical NaN/stability behavior). Index arithmetic is f64; raw-array access via tiny typed `__arri_*` intrinsics (f64 index, internal trunc) materialized on demand.
- **`src/codegen/timsort.ts`** — 922 → 208 lines (intrinsics + calleeTypes table + external-ABI thunk only).
- **`tests/issue-3159.test.ts`** — committed regression guard (host + standalone, f64 + i32 lanes, NaN preservation, stability, isort/minRun boundaries).

## Proof

- **Bit-exactness**: `.tmp` sweep, **36,376 cases**, branch-vs-main-built binaries, elementwise `Object.is` over sorted outputs — NaN / ±0 / ±Inf / denormals / dup-specials / presorted / reversed / sawtooth / natural-runs, lengths spanning the 63/64 insertion-sort cutoff + minRun boundaries (128/129/256) + force-collapse (500/1000/2048), f64 **and** i32 lanes, host **and** standalone → **ZERO mismatches**.
- **Containment**: sort-free programs (Math user, array-no-sort user, string user) compile **byte-identical** branch-vs-main (SHA), host + standalone.
- Gates: `check:ir-fallbacks` OK, `check:loc-budget` OK (**net −278 src/ LOC**), biome + tsc clean, scoped array/sort equivalence tests pass.

## Net

−278 src/ LOC this slice; the +126 driver widening is reusable infra that amortizes over every remaining family (object-runtime, strings, dataview, json, map). Marginal cost of the next slice is TS source only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)