### PR TITLE
refactor(#3160): self-host object-runtime slice 1 — getOwnPropertyDescriptors + fromEntries

### DIFF
--- a/plan/issues/3160-selfhost-object-runtime-slice1.md
+++ b/plan/issues/3160-selfhost-object-runtime-slice1.md
@@ -1,0 +1,103 @@
+---
+id: 3160
+title: "Self-hosted stdlib: object-runtime slice 1 — getOwnPropertyDescriptors + fromEntries via our own IR pipeline"
+status: done
+assignee: ttraenkler/fable-senior2
+sprint: current
+created: 2026-07-12
+updated: 2026-07-12
+completed: 2026-07-12
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: codegen, stdlib, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+related: [3141, 3161, 3159, 2042]
+depends_on: [3161]
+origin: "plan/self-hosting-scale-up.md family #8 (object-runtime) — bounded PUREST-first slice; bloat-reduction flagship lever"
+loc-budget-allow:
+  - src/stdlib/object-runtime.ts
+---
+
+# #3160 — Self-hosted object-runtime slice 1
+
+## Problem
+
+`src/codegen/object-runtime.ts` (10,598 lines) is the biggest single hand-emitted
+builtin family and the flagship bloat-reduction target. The scale-up plan ranks it
+family #8 ("convert LAST") because the dynamic property model is rep-entangled
+(tag-5 classifier, descriptors, prototype chain). But a bounded PUREST-first slice
+is landable now: the two most self-contained helpers are thin compositions over
+already-registered funcMap helpers with zero struct/identity/MOP entanglement.
+
+## Slice scope (this PR)
+
+Convert to TS source (`src/stdlib/object-runtime.ts`), compiled through the
+generalized self-hosting driver (#3161), replacing the hand-emitted `Instr[]`
+bodies in `ensureObjectRuntime`:
+
+- `__object_getOwnPropertyDescriptors(obj)` — fresh object mapping each own key
+  (from `__getOwnPropertyNames`) to `__getOwnPropertyDescriptor(obj, key)`.
+- `__object_fromEntries(entries)` — fresh object, `out[pair[0]] = pair[1]` per pair.
+
+Both are pure compositions over six funcMap helpers registered EARLIER in the same
+pass (`__new_plain_object`, `__extern_length`, `__extern_get_idx`, `__extern_set`,
+`__getOwnPropertyNames`, `__getOwnPropertyDescriptor`) — leaf-first, no new Wasm.
+
+## Why NOT the rest of object-runtime (documented so the next slice knows)
+
+Everything else in the file is rep-entangled exactly as the plan predicted:
+
+- `__object_assign` walks the RAW hash table directly — converting compositionally
+  via `__object_keys` would CHANGE observable enumeration order.
+- `__object_is` needs `i64.reinterpret_f64` + `ref.test` on the eq-heap for
+  SameValue bit-pattern comparison.
+- integrity predicates / hasOwn / propertyIsEnumerable / isPrototypeOf all
+  `struct.get $Object`/`$PropEntry`.
+  These need **Precursor D** (typed struct intrinsics) — a later slice.
+- `__object_groupBy` is ALMOST pure but needs `group === null` on an externref
+  local, which from-ast's `tryFoldNullCompare` deliberately bails on
+  (`from-ast.ts:6263`; TODO at :6233 "emit ref.is_null directly from the IR").
+  Deferred as a dialect FINDING — the next slice unblocks once that gap closes.
+
+## Acceptance criteria
+
+- [x] Both helpers compiled from TS source through the IR pipeline; hand `Instr[]`
+      bodies deleted from `object-runtime.ts` (−145 lines in the family file).
+- [x] Behaviour preserved: `tests/issue-3160.test.ts` (8 standalone cases) +
+      existing `tests/issue-2042-fromentries-objvec.test.ts` (8) +
+      `tests/issue-2042-s3.test.ts` all green.
+- [x] No host-import leak in standalone (`__object_*` never appears in env imports).
+- [x] Host mode byte-inert (these are JS imports there — native bodies absent;
+      SHA-identical binary main vs branch).
+- [x] Standalone: identical function count (228) main vs branch — the two helpers
+      are always-retained roots (`OBJECT_RUNTIME_HELPER_NAMES`), so the change is a
+      behaviour-equivalent body-swap (+97 bytes), NOT dead-code bloat or a DCE
+      regression.
+- [x] LOC gate green; compiler-source NET −18 (object-runtime.ts −145 + new
+      127-line stdlib file). Subsequent object-runtime slices reuse this file's
+      header → strongly negative.
+
+## Findings (dialect / driver)
+
+- Object.fromEntries over an EMPTY array literal `[]` still hits a pre-existing
+  CALL-SITE refusal (the #2042 normalisation only recognises non-empty string-key
+  pair literals) — orthogonal to the helper body; not in this slice.
+- The f64-vs-i32 loop-counter representational difference from the hand body is
+  value-equivalent for the < 2^53 index range these iterate (documented in the
+  stdlib source header).
+
+## Implementation notes (WHY)
+
+- Slicing PUREST-first is the whole risk-management strategy for object-runtime:
+  these two helpers touch NONE of the rep machinery that makes the family family-#8
+  hard, so the slice is a clean composition swap provable by the existing #2042
+  equivalence suites plus the new #3160 cases — no new proof infrastructure.
+- The self-hosted funcs are registered via the same `mintDefinedFunc`/
+  `pushDefinedFunc`/`funcMap.set` path as the hand bodies (through
+  `emitSelfHostedFunc`), so every downstream pass (late-import fixups, DCE, binary
+  emit) treats them identically — which is why the standalone function count is
+  unchanged and host mode stays byte-inert.

--- a/plan/issues/3161-selfhost-driver-typed-signatures.md
+++ b/plan/issues/3161-selfhost-driver-typed-signatures.md
@@ -1,0 +1,118 @@
+---
+id: 3161
+title: "Self-hosted stdlib driver: generalized typed-signature emit path (Precursor B/C — unblocks array-methods + object-runtime families)"
+status: done
+assignee: ttraenkler/fable-senior2
+sprint: current
+created: 2026-07-12
+updated: 2026-07-12
+completed: 2026-07-12
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: ir, codegen, stdlib
+language_feature: compiler-internals
+goal: ir-full-coverage
+related: [3141, 3159, 3160]
+origin: "plan/self-hosting-scale-up.md — Precursors B/C, dispatched as their own small issue per the plan"
+---
+
+# #3161 — Self-hosted stdlib driver: generalized typed-signature emit path
+
+## Problem
+
+The #3141 pilot driver (`src/codegen/stdlib-selfhost.ts`) hardcodes the pilot's
+scope: every builtin and every callee is unary `(f64) -> f64`, and the IR is
+process-memoized. The next two families in flight need more:
+
+- **array-methods slice 1 (#3159, fable-selfhost)**: ctx-bound `ref_null`
+  typeIdx params (raw data arrays), `i32`/`f64` mixed callees up to arity 6,
+  void-returning kernels.
+- **object-runtime slice 1 (#3160, fable-senior2)**: `externref` params/returns,
+  void `__extern_set`, unannotated locals inferring externref from callee
+  returns.
+
+Both need typed per-builtin param/return signatures and typed per-callee
+signatures — exactly Precursors B/C from `plan/self-hosting-scale-up.md`.
+Landing the widening as its own PR FIRST decouples the two family slices
+(both build on main, no cross-branch stacking).
+
+## Design (agreed with fable-selfhost + tech lead, 2026-07-12)
+
+New exports in `src/codegen/stdlib-selfhost.ts`, additive — the math pilot
+path (`emitSelfHostedMathFunc` + its process memoization) keeps byte-identical
+output:
+
+```ts
+export interface SelfHostedFuncDef {
+  readonly name: string; // funcMap name == fn name in source
+  readonly source: string; // ordinary TS, IR-claimable subset
+  readonly paramTypes: readonly IrType[]; // positional, override-authoritative
+  readonly returnType: IrType | null; // null == void
+  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+}
+export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction;
+export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef): number;
+```
+
+Key decisions:
+
+- **No process memoization on the generalized path.** `paramTypes`/callee
+  types may carry ctx-bound `{ kind: "ref_null", typeIdx }` (typeIdx is only
+  meaningful in the CodegenContext that registered it). Emission is
+  funcMap-guarded once per compilation by `emitSelfHostedFunc`'s idempotent
+  early-return — the same lifecycle the hand `Instr[]` bodies had — so the
+  per-emit rebuild cost is negligible.
+- **Param/return types flow via `paramTypeOverrides`/`returnTypeOverride`**
+  (from-ast already supports both; non-primitive annotations like `unknown`
+  defer to the override, primitive annotations must agree — enforced by
+  `resolveIrType`).
+- **Scope guard retained**: `resolveGlobal`/`resolveType` throw. `ref_null`
+  ValType params do NOT hit `resolveType` (they are `val`-kind), so raw-array
+  params pass through while accidental named-type/global dialect growth stays
+  a loud compile error.
+- **Math path deduped onto the generalized builder**: `buildBuiltinIr` becomes
+  a memo-wrapping adapter constructing a `SelfHostedFuncDef` with `(f64)->f64`
+  callee sigs and f64 param/return overrides — `resolveIrType` verifies the
+  overrides agree with the `: number` annotations, output IR identical.
+
+## Acceptance criteria
+
+- [x] `emitSelfHostedFunc` + `SelfHostedFuncDef` + `buildSelfHostedIr` exported;
+      math path output byte-identical (existing `tests/issue-3141.test.ts` +
+      equivalence suite green).
+- [x] Unit test covers the widened dialect shapes end-to-end
+      (from-ast → verify → passes → lower with mock resolver): externref
+      params/returns, void callees in statement position, i32-returning
+      callees, `ref_null` typeIdx params, arity ≥ 3, unannotated locals
+      inferring externref.
+- [x] Compiler output unchanged for all programs (nothing calls the new
+      export yet) — CI net 0.
+
+## Evidence (2026-07-12)
+
+- **Byte-identity of the math-path refactor**: `.tmp/probe-3161-byteident.mts`
+  compiles a program exercising all nine self-hosted math builtins on both
+  trees — host `e67749cf…` (2,217 B) and standalone `eebac3fc…` (38,192 B)
+  SHA-256 identical between `main` and this branch.
+- **Dialect finding (caller-side rule, documented in the driver header)**:
+  a void builtin cannot END in a loop — `lowerTail` accepts return /
+  expression / if / block / throw tails only, so void kernels need an
+  explicit trailing `return;`.
+- `tests/issue-3161.test.ts` (5 tests) green; `tests/issue-3141.test.ts`
+  green; `tests/stdlib.test.ts` has 5 failures that reproduce identically
+  on `main` (pre-existing, unrelated).
+
+## Implementation notes (WHY)
+
+- The two-stage split (`buildSelfHostedIr` / `emitSelfHostedFunc`) is kept
+  from the pilot NOT for memoization (dropped here) but because the build
+  stage is pure and unit-testable without a CodegenContext — the emit stage
+  is thin proven glue (mint/push/funcMap, identical to the pilot's).
+- `irTypeArgAssignable` (from-ast) requires EXACT IrType equality for scalar
+  args — callers must declare index params as `f64` (intrinsics trunc
+  internally) rather than relying on implicit f64→i32 coercion; this is a
+  caller-side dialect rule, not a driver limitation (documented in the
+  driver header).

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -84,6 +84,8 @@ import { UNDEF_F64_BITS } from "./value-tags.js";
 import { buildIsUndefinedExternBody, undefinedExternInstrs, undefinedSingletonActive } from "./any-helpers.js";
 import { reserveClassToPrimitive } from "./class-to-primitive.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
+import { emitSelfHostedFunc } from "./stdlib-selfhost.js"; // (#3160) self-hosted object-runtime slice
+import { SELF_HOSTED_OBJECT_RUNTIME } from "../stdlib/object-runtime.js"; // (#3160) TS-source builtins
 
 /** Initial `$PropMap` capacity. Must be a power of two (mask = cap - 1). */
 const INITIAL_CAP = 8;
@@ -7178,180 +7180,33 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     registerNative("__getOwnPropertySymbols", [{ kind: "externref" }], [{ kind: "externref" }], [], body);
   }
 
-  // ── __getOwnPropertyDescriptors(externref obj) -> externref (#2042 S3) ────
+  // ── __object_getOwnPropertyDescriptors / __object_fromEntries ─────────────
   //
-  // `Object.getOwnPropertyDescriptors(obj)` — a fresh `$Object` mapping each own
-  // string key to its descriptor object. For each own key (from
-  // `__getOwnPropertyNames`) set `out[key] = __getOwnPropertyDescriptor(o, key)`.
-  // A non-`$Object` receiver yields an empty result object (the per-key loop runs
-  // zero times). Reuses the same enumeration + per-key descriptor builders, so
-  // accessor vs data shape and attribute flags are exactly consistent with the
-  // singular `getOwnPropertyDescriptor`.
+  // (#3160 — self-hosted stdlib) These two helpers are the PUREST members of
+  // the object runtime: thin COMPOSITIONS over the funcMap helpers registered
+  // above (`__new_plain_object`, `__extern_length`, `__extern_get_idx`,
+  // `__extern_set`, `__getOwnPropertyNames`, `__getOwnPropertyDescriptor`),
+  // with NO direct `$Object`/`$PropEntry` struct access or identity/proto/MOP
+  // entanglement. So they are compiled from ORDINARY TS SOURCE
+  // (`src/stdlib/object-runtime.ts`) through the compiler's own IR pipeline
+  // via the generalized self-hosting driver (#3161), exactly where the
+  // hand-emitted `Instr[]` bodies used to be pushed — the porffor model.
   //
-  // params: 0=obj(externref)
-  // locals: 1=names(externref $ObjVec) 2=cap(f64) 3=i(i32) 4=key(externref)
-  //         5=out(externref)
-  {
-    const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
-    const externLengthIdx = ctx.funcMap.get("__extern_length")!;
-    const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
-    const getOwnNamesIdx = ctx.funcMap.get("__getOwnPropertyNames")!;
-    const getOwnDescIdx = ctx.funcMap.get("__getOwnPropertyDescriptor")!;
-    const externSetLocalIdx = ctx.funcMap.get("__extern_set")!;
-    const body: Instr[] = [
-      // out = __new_plain_object()
-      { op: "call", funcIdx: newPlainObjectIdx },
-      { op: "local.set", index: 5 },
-      // names = __getOwnPropertyNames(obj)
-      { op: "local.get", index: 0 },
-      { op: "call", funcIdx: getOwnNamesIdx },
-      { op: "local.tee", index: 1 },
-      // cap = __extern_length(names)
-      { op: "call", funcIdx: externLengthIdx },
-      { op: "local.set", index: 2 },
-      // i = 0
-      { op: "i32.const", value: 0 },
-      { op: "local.set", index: 3 },
-      {
-        op: "block",
-        blockType: { kind: "empty" },
-        body: [
-          {
-            op: "loop",
-            blockType: { kind: "empty" },
-            body: [
-              // if i >= cap break  (cap is f64; compare as f64)
-              { op: "local.get", index: 3 },
-              { op: "f64.convert_i32_s" },
-              { op: "local.get", index: 2 },
-              { op: "f64.ge" },
-              { op: "br_if", depth: 1 },
-              // key = __extern_get_idx(names, i)
-              { op: "local.get", index: 1 },
-              { op: "local.get", index: 3 },
-              { op: "f64.convert_i32_s" },
-              { op: "call", funcIdx: externGetIdxIdx },
-              { op: "local.set", index: 4 },
-              // __extern_set(out, key, __getOwnPropertyDescriptor(obj, key))
-              { op: "local.get", index: 5 },
-              { op: "local.get", index: 4 },
-              { op: "local.get", index: 0 },
-              { op: "local.get", index: 4 },
-              { op: "call", funcIdx: getOwnDescIdx },
-              { op: "call", funcIdx: externSetLocalIdx },
-              // i++
-              { op: "local.get", index: 3 },
-              { op: "i32.const", value: 1 },
-              { op: "i32.add" },
-              { op: "local.set", index: 3 },
-              { op: "br", depth: 0 },
-            ],
-          },
-        ],
-      },
-      { op: "local.get", index: 5 },
-    ];
-    registerNative(
-      // Call site (calls.ts) requests this with the `__object_` prefix.
-      "__object_getOwnPropertyDescriptors",
-      [{ kind: "externref" }],
-      [{ kind: "externref" }],
-      [
-        { name: "names", type: { kind: "externref" } },
-        { name: "cap", type: { kind: "f64" } },
-        { name: "i", type: { kind: "i32" } },
-        { name: "key", type: { kind: "externref" } },
-        { name: "out", type: { kind: "externref" } },
-      ],
-      body,
-    );
-  }
-
-  // ── __object_fromEntries(externref entries) -> externref (#2042 S3 residual) ─
+  //   - getOwnPropertyDescriptors(obj): fresh object mapping each own key
+  //     (from `__getOwnPropertyNames`) to `__getOwnPropertyDescriptor(obj,key)`.
+  //   - fromEntries(entries): fresh object, `out[pair[0]] = pair[1]` per pair
+  //     (the call site normalises the arg to the indexable `$ObjVec`-of-pairs
+  //     shape before calling — see `compileObjectAssignArg`).
   //
-  // `Object.fromEntries(entries)` where `entries` is a `$ObjVec` of `[key,value]`
-  // pair `$ObjVec`s. Builds a fresh `$Object` and, for each pair, sets
-  // `out[pair[0]] = pair[1]` via `__extern_set` (which ToPropertyKeys the key —
-  // #2042 R2/S1). Iterates via `__extern_length` / `__extern_get_idx` (which
-  // index a `$ObjVec` reliably). The CALL SITE (calls.ts) normalises a literal
-  // array-of-pairs arg into this `$ObjVec`-of-`$ObjVec` shape before calling, so
-  // the helper only ever sees the indexable representation (a raw native vec /
-  // Map is not reliably indexable through `__extern_get_idx` — that's why the
-  // call site converts first, mirroring `compileObjectAssignArg`).
-  //
-  // params: 0=entries(externref) ; locals: 1=len(f64) 2=i(i32) 3=pair 4=key 5=val 6=out
-  {
-    const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
-    const externLengthIdx = ctx.funcMap.get("__extern_length")!;
-    const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
-    const externSetIdx2 = ctx.funcMap.get("__extern_set")!;
-    const pairElem = (pairLocal: number, idx: number): Instr[] => [
-      { op: "local.get", index: pairLocal },
-      { op: "f64.const", value: idx },
-      { op: "call", funcIdx: externGetIdxIdx },
-    ];
-    const body: Instr[] = [
-      { op: "call", funcIdx: newPlainObjectIdx },
-      { op: "local.set", index: 6 },
-      { op: "local.get", index: 0 },
-      { op: "call", funcIdx: externLengthIdx },
-      { op: "local.set", index: 1 },
-      { op: "i32.const", value: 0 },
-      { op: "local.set", index: 2 },
-      {
-        op: "block",
-        blockType: { kind: "empty" },
-        body: [
-          {
-            op: "loop",
-            blockType: { kind: "empty" },
-            body: [
-              { op: "local.get", index: 2 },
-              { op: "f64.convert_i32_s" },
-              { op: "local.get", index: 1 },
-              { op: "f64.ge" },
-              { op: "br_if", depth: 1 },
-              // pair = __extern_get_idx(entries, i)
-              { op: "local.get", index: 0 },
-              { op: "local.get", index: 2 },
-              { op: "f64.convert_i32_s" },
-              { op: "call", funcIdx: externGetIdxIdx },
-              { op: "local.set", index: 3 },
-              // key = pair[0]; val = pair[1]
-              ...pairElem(3, 0),
-              { op: "local.set", index: 4 },
-              ...pairElem(3, 1),
-              { op: "local.set", index: 5 },
-              // __extern_set(out, key, val)
-              { op: "local.get", index: 6 },
-              { op: "local.get", index: 4 },
-              { op: "local.get", index: 5 },
-              { op: "call", funcIdx: externSetIdx2 },
-              { op: "local.get", index: 2 },
-              { op: "i32.const", value: 1 },
-              { op: "i32.add" },
-              { op: "local.set", index: 2 },
-              { op: "br", depth: 0 },
-            ],
-          },
-        ],
-      },
-      { op: "local.get", index: 6 },
-    ];
-    registerNative(
-      "__object_fromEntries",
-      [{ kind: "externref" }],
-      [{ kind: "externref" }],
-      [
-        { name: "len", type: { kind: "f64" } },
-        { name: "i", type: { kind: "i32" } },
-        { name: "pair", type: { kind: "externref" } },
-        { name: "key", type: { kind: "externref" } },
-        { name: "val", type: { kind: "externref" } },
-        { name: "out", type: { kind: "externref" } },
-      ],
-      body,
-    );
+  // Behaviour mirrors the deleted hand bodies step-for-step (same enumeration
+  // order, same per-key `__extern_set`); the only representational difference
+  // is the f64 loop counter (the hand bodies used i32-with-convert — value-
+  // equivalent). Every callee is registered EARLIER in this pass (leaf-first).
+  // A non-`$Object` receiver still yields `{}` (the loop runs zero times).
+  // Verified by tests/issue-3160.test.ts (host + standalone) + byte-inert SHA
+  // containment for non-users.
+  for (const def of SELF_HOSTED_OBJECT_RUNTIME.values()) {
+    emitSelfHostedFunc(ctx, def);
   }
 
   // NOTE (#2042 S3): `__defineProperty_desc` (generic

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -99,26 +99,43 @@ export interface SelfHostedFuncDef {
   readonly returnType: IrType | null;
   /** Typed signatures for every direct callee in `source`. */
   readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+  /**
+   * Optional process-lifetime memo key. Set ONLY for a CONTEXT-FREE def —
+   * one whose `paramTypes` / `returnType` / callee sigs carry no ctx-bound
+   * `{ typeIdx }` ref (all abstract scalars / string / externref). The
+   * memoized `IrFunction` is shared across every compilation, so a def with
+   * a ctx-relative type must NOT set this (its typeIdx would leak across
+   * contexts). The math family (all `(f64) -> f64`) sets it (keyed by
+   * builtin name); the generalized families (raw-array/typeIdx params)
+   * leave it unset and rebuild per emission — bounded to once per
+   * compilation by `emitSelfHostedFunc`'s funcMap early-return.
+   */
+  readonly memoKey?: string;
 }
 
-/** Process-lifetime cache: builtin name → immutable, context-free IR. */
+/** Process-lifetime cache: memoKey → immutable, context-free IR. */
 const irCache = new Map<string, IrFunction>();
 
 /**
  * #3161 — parse a typed self-hosted builtin's TS source and lower it to
  * a verified, optimized `IrFunction`.
  *
- * NOT memoized (unlike the math pilot's `buildBuiltinIr` wrapper below):
- * `def.paramTypes` / callee sigs may carry ctx-bound `{ typeIdx }` refs
- * that are only meaningful in the CodegenContext that registered those
- * types, so the IR must be rebuilt per emission. `emitSelfHostedFunc`'s
- * funcMap early-return bounds this to once per compilation.
+ * Memoized ONLY when `def.memoKey` is set (a context-free def — see the
+ * field doc). A def carrying ctx-bound `{ typeIdx }` refs leaves memoKey
+ * unset and is rebuilt per emission, because a memoized IR would leak a
+ * typeIdx that is only meaningful in the registering CodegenContext;
+ * `emitSelfHostedFunc`'s funcMap early-return bounds that rebuild to once
+ * per compilation.
  *
  * Exported separately from the emit glue so the widened dialect shapes
  * are unit-testable without constructing a CodegenContext (the build
  * stage is a pure function of the def).
  */
 export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction {
+  if (def.memoKey !== undefined) {
+    const cached = irCache.get(def.memoKey);
+    if (cached) return cached;
+  }
   const sourceFile = ts.createSourceFile(
     `stdlib/${def.name}.ts`,
     def.source,
@@ -169,37 +186,31 @@ export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction {
     throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
   }
 
+  if (def.memoKey !== undefined) irCache.set(def.memoKey, ir);
   return ir;
 }
 
 /**
- * Parse the builtin's TS source and lower it to a verified, optimized
- * `IrFunction`. Pure function of the builtin definition — memoized
- * (sound here, unlike the generalized path: math sigs are all context-
- * free `(f64) -> f64`, no typeIdx can appear).
+ * Build the generalized `SelfHostedFuncDef` for a math-pilot builtin.
+ * Sibling math helpers are all unary `(f64) -> f64`; the f64 param/return
+ * overrides agree with the sources' `: number` annotations (enforced by
+ * from-ast's `resolveIrType`), so lowering through the generalized builder
+ * yields IR identical to the pilot's un-overridden path. Context-free, so
+ * `memoKey` is set to the builtin name.
  */
-function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
-  const cached = irCache.get(builtin.name);
-  if (cached) return cached;
-
-  // Sibling math helpers are all unary (f64) -> f64. The f64 param/return
-  // overrides agree with the sources' `: number` annotations (enforced by
-  // from-ast's resolveIrType), so lowering through the generalized builder
-  // yields IR identical to the pilot's un-overridden path.
+function mathBuiltinDef(builtin: StdlibMathBuiltin): SelfHostedFuncDef {
   const calleeTypes = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>();
   for (const callee of builtin.callees) {
     calleeTypes.set(callee, { params: [F64], returnType: F64 });
   }
-  const ir = buildSelfHostedIr({
+  return {
     name: builtin.name,
     source: builtin.source,
     paramTypes: [F64],
     returnType: F64,
     calleeTypes,
-  });
-
-  irCache.set(builtin.name, ir);
-  return ir;
+    memoKey: builtin.name,
+  };
 }
 
 /**
@@ -272,8 +283,11 @@ function lowerAndRegister(ctx: CodegenContext, name: string, ir: IrFunction): nu
  *
  * Precondition: every name in `builtin.callees` is already registered in
  * `ctx.funcMap` (emitInlineMathFunctions emits Phase-1 cores first).
+ *
+ * Thin adapter over the generalized `emitSelfHostedFunc` — the math pilot
+ * and scale-up families share one emit path (the def carries a `memoKey`
+ * so the context-free math IR is still process-cached).
  */
 export function emitSelfHostedMathFunc(ctx: CodegenContext, builtin: StdlibMathBuiltin): number {
-  const ir = buildBuiltinIr(builtin);
-  return lowerAndRegister(ctx, builtin.name, ir);
+  return emitSelfHostedFunc(ctx, mathBuiltinDef(builtin));
 }

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -32,6 +32,31 @@
  * or vecs — the resolver below throws on all of those, which turns any
  * accidental dialect growth in `src/stdlib/math.ts` into a loud compile
  * error instead of a miscompile.
+ *
+ * #3161 — generalized typed path (`SelfHostedFuncDef` / `emitSelfHostedFunc`):
+ * the scale-up families (array-methods #3159, object-runtime #3160) need
+ * builtins whose params/returns/callees are NOT unary f64: externref
+ * params, void kernels, i32 results, and ctx-bound `ref_null { typeIdx }`
+ * raw-array params. The generalized path carries explicit positional
+ * param types + a typed callee map, flowing through from-ast's existing
+ * `paramTypeOverrides` / `returnTypeOverride`. It is deliberately NOT
+ * process-memoized: a `typeIdx` inside a def's types is only meaningful
+ * in the CodegenContext that registered it, so the IR must be rebuilt
+ * per emission. That costs little — `emitSelfHostedFunc` early-returns
+ * via `ctx.funcMap` (once per compilation, the same lifecycle the hand
+ * `Instr[]` bodies had). The global/named-type scope guard stays: raw
+ * ValType refs (`ref_null`) are `val`-kind and never hit `resolveType`,
+ * while any accidental use of module globals or symbolic named types in
+ * stdlib source remains a loud compile error.
+ *
+ * Caller-side dialect rule: from-ast validates direct-call args by EXACT
+ * IrType equality (`irTypeArgAssignable`) — declare numeric index params
+ * as `f64` in callee sigs (kernels trunc internally); there is no
+ * implicit f64→i32 argument coercion. Params whose type isn't spellable
+ * as a TS primitive should be annotated `unknown` in the source (a
+ * non-primitive annotation defers to the positional override). Void
+ * builtins must end with an explicit `return;` — a loop is not a valid
+ * tail statement in the IR subset (`lowerTail`).
  */
 
 import { ts } from "../ts-api.js";
@@ -49,49 +74,84 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 
 const F64: IrType = irVal({ kind: "f64" });
 
+/**
+ * #3161 — a self-hosted builtin with an explicit typed signature. The
+ * generalized shape behind the `StdlibMathBuiltin` pilot descriptor:
+ * positional param types + a typed callee map instead of the pilot's
+ * implicit "everything is unary f64".
+ *
+ * `paramTypes` is positional and override-authoritative: a param whose
+ * type has no TS-primitive spelling (externref, `ref_null { typeIdx }`)
+ * should be annotated `unknown` in `source` — from-ast's `resolveIrType`
+ * defers non-primitive annotations to the override, and REJECTS a
+ * primitive annotation that disagrees with it (typo guard).
+ * `returnType: null` means void (zero Wasm results; bare `return;` /
+ * fall-through tails, statement-position calls only — #1228 / #2856 C4).
+ */
+export interface SelfHostedFuncDef {
+  /** funcMap registration name — also the function's name in `source`. */
+  readonly name: string;
+  /** Ordinary TS source, IR-claimable subset. */
+  readonly source: string;
+  /** Positional param IrTypes (may carry ctx-bound typeIdx refs). */
+  readonly paramTypes: readonly IrType[];
+  /** Return IrType; null == void. */
+  readonly returnType: IrType | null;
+  /** Typed signatures for every direct callee in `source`. */
+  readonly calleeTypes: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+}
+
 /** Process-lifetime cache: builtin name → immutable, context-free IR. */
 const irCache = new Map<string, IrFunction>();
 
 /**
- * Parse the builtin's TS source and lower it to a verified, optimized
- * `IrFunction`. Pure function of the builtin definition — memoized.
+ * #3161 — parse a typed self-hosted builtin's TS source and lower it to
+ * a verified, optimized `IrFunction`.
+ *
+ * NOT memoized (unlike the math pilot's `buildBuiltinIr` wrapper below):
+ * `def.paramTypes` / callee sigs may carry ctx-bound `{ typeIdx }` refs
+ * that are only meaningful in the CodegenContext that registered those
+ * types, so the IR must be rebuilt per emission. `emitSelfHostedFunc`'s
+ * funcMap early-return bounds this to once per compilation.
+ *
+ * Exported separately from the emit glue so the widened dialect shapes
+ * are unit-testable without constructing a CodegenContext (the build
+ * stage is a pure function of the def).
  */
-function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
-  const cached = irCache.get(builtin.name);
-  if (cached) return cached;
-
+export function buildSelfHostedIr(def: SelfHostedFuncDef): IrFunction {
   const sourceFile = ts.createSourceFile(
-    `stdlib/${builtin.name}.ts`,
-    builtin.source,
+    `stdlib/${def.name}.ts`,
+    def.source,
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
     ts.ScriptKind.TS,
   );
   const fnDecl = sourceFile.statements.find(
-    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === builtin.name,
+    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === def.name,
   );
   if (!fnDecl) {
-    throw new Error(`stdlib-selfhost: source for ${builtin.name} has no matching function declaration`);
+    throw new Error(`stdlib-selfhost: source for ${def.name} has no matching function declaration`);
   }
-
-  // Sibling math helpers are all unary (f64) -> f64.
-  const calleeTypes = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>();
-  for (const callee of builtin.callees) {
-    calleeTypes.set(callee, { params: [F64], returnType: F64 });
+  if (fnDecl.parameters.length !== def.paramTypes.length) {
+    throw new Error(
+      `stdlib-selfhost: ${def.name} declares ${fnDecl.parameters.length} params but paramTypes has ${def.paramTypes.length}`,
+    );
   }
 
   const { main, lifted } = lowerFunctionAstToIr(fnDecl, {
-    funcName: builtin.name,
+    funcName: def.name,
     exported: false,
-    calleeTypes,
+    calleeTypes: def.calleeTypes,
+    paramTypeOverrides: def.paramTypes,
+    returnTypeOverride: def.returnType,
   });
   if (lifted.length > 0) {
-    throw new Error(`stdlib-selfhost: ${builtin.name} unexpectedly produced ${lifted.length} lifted functions`);
+    throw new Error(`stdlib-selfhost: ${def.name} unexpectedly produced ${lifted.length} lifted functions`);
   }
 
   const buildErrors = verifyIrFunction(main);
   if (buildErrors.length > 0) {
-    throw new Error(`stdlib-selfhost: IR verify failed for ${builtin.name}: ${buildErrors[0]!.message}`);
+    throw new Error(`stdlib-selfhost: IR verify failed for ${def.name}: ${buildErrors[0]!.message}`);
   }
 
   // Same hygiene pipeline integration.ts runs (constantFold → deadCode →
@@ -106,11 +166,102 @@ function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
 
   const postErrors = verifyIrFunction(ir);
   if (postErrors.length > 0) {
-    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${builtin.name}: ${postErrors[0]!.message}`);
+    throw new Error(`stdlib-selfhost: post-pass IR verify failed for ${def.name}: ${postErrors[0]!.message}`);
   }
+
+  return ir;
+}
+
+/**
+ * Parse the builtin's TS source and lower it to a verified, optimized
+ * `IrFunction`. Pure function of the builtin definition — memoized
+ * (sound here, unlike the generalized path: math sigs are all context-
+ * free `(f64) -> f64`, no typeIdx can appear).
+ */
+function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
+  const cached = irCache.get(builtin.name);
+  if (cached) return cached;
+
+  // Sibling math helpers are all unary (f64) -> f64. The f64 param/return
+  // overrides agree with the sources' `: number` annotations (enforced by
+  // from-ast's resolveIrType), so lowering through the generalized builder
+  // yields IR identical to the pilot's un-overridden path.
+  const calleeTypes = new Map<string, { params: readonly IrType[]; returnType: IrType | null }>();
+  for (const callee of builtin.callees) {
+    calleeTypes.set(callee, { params: [F64], returnType: F64 });
+  }
+  const ir = buildSelfHostedIr({
+    name: builtin.name,
+    source: builtin.source,
+    paramTypes: [F64],
+    returnType: F64,
+    calleeTypes,
+  });
 
   irCache.set(builtin.name, ir);
   return ir;
+}
+
+/**
+ * #3161 — lower a typed self-hosted builtin against the live context and
+ * register it as a defined function under `def.name`. Same registration
+ * discipline as the math path (stable-regime mint + push, funcMap entry,
+ * `exported: false`) so call sites cannot tell the difference from the
+ * hand-emitted `Instr[]` body it replaces.
+ *
+ * Idempotent: early-returns the existing funcIdx when `def.name` is
+ * already registered (mirrors the `ensure*` convention of the hand
+ * emitters this replaces).
+ *
+ * Precondition: every callee in `def.calleeTypes` that the source
+ * actually calls is already registered in `ctx.funcMap` (families
+ * convert leaf-first; retained hand kernels are emitted before the
+ * self-hosted bodies that call them).
+ */
+export function emitSelfHostedFunc(ctx: CodegenContext, def: SelfHostedFuncDef): number {
+  const existing = ctx.funcMap.get(def.name);
+  if (existing !== undefined) return existing;
+
+  const ir = buildSelfHostedIr(def);
+  const funcIdx = lowerAndRegister(ctx, def.name, ir);
+  return funcIdx;
+}
+
+/** Shared lowering + registration glue for both driver paths. */
+function lowerAndRegister(ctx: CodegenContext, name: string, ir: IrFunction): number {
+  const resolver: IrLowerResolver = {
+    resolveFunc(ref) {
+      const idx = ctx.funcMap.get(ref.name);
+      if (idx === undefined) {
+        throw new Error(
+          `stdlib-selfhost: ${name} calls "${ref.name}" but it is not registered yet — ` +
+            `emit callees leaf-first (check the family's phase ordering)`,
+        );
+      }
+      return idx;
+    },
+    resolveGlobal(ref) {
+      throw new Error(`stdlib-selfhost: ${name} must not reference globals (got "${ref.name}")`);
+    },
+    resolveType(ref) {
+      throw new Error(`stdlib-selfhost: ${name} must not reference named types (got "${ref.name}")`);
+    },
+    internFuncType(type) {
+      return addFuncType(ctx, type.params, type.results, type.name);
+    },
+  };
+
+  const { func } = lowerIrFunctionToWasm(ir, resolver);
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name,
+    typeIdx: func.typeIdx,
+    locals: func.locals,
+    body: func.body,
+    exported: false,
+  });
+  ctx.funcMap.set(name, funcIdx);
+  return funcIdx;
 }
 
 /**
@@ -124,38 +275,5 @@ function buildBuiltinIr(builtin: StdlibMathBuiltin): IrFunction {
  */
 export function emitSelfHostedMathFunc(ctx: CodegenContext, builtin: StdlibMathBuiltin): number {
   const ir = buildBuiltinIr(builtin);
-
-  const resolver: IrLowerResolver = {
-    resolveFunc(ref) {
-      const idx = ctx.funcMap.get(ref.name);
-      if (idx === undefined) {
-        throw new Error(
-          `stdlib-selfhost: ${builtin.name} calls "${ref.name}" but it is not registered yet — ` +
-            `check emitInlineMathFunctions phase ordering`,
-        );
-      }
-      return idx;
-    },
-    resolveGlobal(ref) {
-      throw new Error(`stdlib-selfhost: ${builtin.name} must not reference globals (got "${ref.name}")`);
-    },
-    resolveType(ref) {
-      throw new Error(`stdlib-selfhost: ${builtin.name} must not reference named types (got "${ref.name}")`);
-    },
-    internFuncType(type) {
-      return addFuncType(ctx, type.params, type.results, type.name);
-    },
-  };
-
-  const { func } = lowerIrFunctionToWasm(ir, resolver);
-  const funcIdx = mintDefinedFunc(ctx);
-  pushDefinedFunc(ctx, funcIdx, {
-    name: builtin.name,
-    typeIdx: func.typeIdx,
-    locals: func.locals,
-    body: func.body,
-    exported: false,
-  });
-  ctx.funcMap.set(builtin.name, funcIdx);
-  return funcIdx;
+  return lowerAndRegister(ctx, builtin.name, ir);
 }

--- a/src/stdlib/object-runtime.ts
+++ b/src/stdlib/object-runtime.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Self-hosted Object-runtime builtins (#3160 — porffor model, object family
+ * slice 1). Ordinary TS source in the IR-claimable subset, compiled through
+ * the compiler's own pipeline by the generalized driver
+ * (`src/codegen/stdlib-selfhost.ts`) and registered where the hand-emitted
+ * `Instr[]` bodies used to be pushed (`ensureObjectRuntime`).
+ *
+ * SLICE SCOPE — the two PUREST helpers: thin compositions over funcMap
+ * helpers registered earlier (`__new_plain_object`, `__extern_length`,
+ * `__extern_get_idx`, `__extern_set`, `__getOwnPropertyNames`,
+ * `__getOwnPropertyDescriptor`) with NO `$Object`/`$PropEntry` struct access
+ * or identity/proto/MOP entanglement. Deeper helpers (assign's raw-table
+ * walk, Object.is SameValue, integrity predicates) stay hand-written — they
+ * need Precursor D (typed struct intrinsics), a later slice per
+ * `plan/self-hosting-scale-up.md` (family #8).
+ *
+ * DIALECT: externref params/returns have no TS-primitive spelling → annotate
+ * `unknown` (the driver's `paramTypes`/`returnType` overrides are
+ * authoritative — from-ast defers non-primitive annotations). Loop
+ * counters/lengths are `: number` (f64); `__extern_get_idx` takes the f64
+ * index directly (the hand bodies passed `f64.convert_i32_s(i)` — an f64
+ * counter is the identical value). Every callee is registered before emit
+ * (leaf-first). Behaviour mirrors the deleted hand bodies step-for-step
+ * (same enumeration order, same per-key `__extern_set`); verified by
+ * tests/issue-3160.test.ts + #2042 suites, host byte-inert.
+ */
+
+import type { SelfHostedFuncDef } from "../codegen/stdlib-selfhost.js";
+import { irVal, type IrType } from "../ir/nodes.js";
+
+const EXT: IrType = irVal({ kind: "externref" });
+const F64: IrType = irVal({ kind: "f64" });
+
+type Sig = { params: readonly IrType[]; returnType: IrType | null };
+
+/**
+ * Shared iteration/composition callees. `__extern_set` is VOID (returns
+ * `null`); the numeric index into `__extern_get_idx` is f64 (declare it f64
+ * — the driver validates call args by exact IrType equality).
+ */
+const COMMON_CALLEES: ReadonlyArray<[string, Sig]> = [
+  ["__new_plain_object", { params: [], returnType: EXT }],
+  ["__extern_length", { params: [EXT], returnType: F64 }],
+  ["__extern_get_idx", { params: [EXT, F64], returnType: EXT }],
+  ["__extern_set", { params: [EXT, EXT, EXT], returnType: null }],
+];
+
+/**
+ * `Object.getOwnPropertyDescriptors(obj)` — a fresh plain object mapping each
+ * own string key to its descriptor. Enumerates own keys via
+ * `__getOwnPropertyNames` and, per key, sets
+ * `out[key] = __getOwnPropertyDescriptor(obj, key)`. A non-object receiver
+ * yields `{}` (the loop runs zero times — `__getOwnPropertyNames` returns an
+ * empty vec). Same enumeration + per-key descriptor builder as the singular
+ * `getOwnPropertyDescriptor`, so accessor-vs-data shape and attribute flags
+ * stay consistent.
+ */
+const GET_OWN_PROPERTY_DESCRIPTORS_SOURCE = `
+export function __object_getOwnPropertyDescriptors(obj: unknown): unknown {
+  const out = __new_plain_object();
+  const names = __getOwnPropertyNames(obj);
+  const cap: number = __extern_length(names);
+  let i: number = 0;
+  while (i < cap) {
+    const key = __extern_get_idx(names, i);
+    __extern_set(out, key, __getOwnPropertyDescriptor(obj, key));
+    i = i + 1;
+  }
+  return out;
+}
+`;
+
+/**
+ * `Object.fromEntries(entries)` where `entries` is a `$ObjVec` of `[key,value]`
+ * pair `$ObjVec`s (the call site normalises a literal array-of-pairs into this
+ * indexable shape before calling). Builds a fresh plain object and, per pair,
+ * sets `out[pair[0]] = pair[1]` via `__extern_set` (which ToPropertyKeys the
+ * key). Iterates via `__extern_length` / `__extern_get_idx`.
+ */
+const FROM_ENTRIES_SOURCE = `
+export function __object_fromEntries(entries: unknown): unknown {
+  const out = __new_plain_object();
+  const len: number = __extern_length(entries);
+  let i: number = 0;
+  while (i < len) {
+    const pair = __extern_get_idx(entries, i);
+    const key = __extern_get_idx(pair, 0);
+    const val = __extern_get_idx(pair, 1);
+    __extern_set(out, key, val);
+    i = i + 1;
+  }
+  return out;
+}
+`;
+
+/**
+ * The self-hosted object-runtime slice-1 builtins, keyed by funcMap name.
+ * `ensureObjectRuntime` emits each via `emitSelfHostedFunc(ctx, def)` in place
+ * of the deleted hand body, AFTER the six shared callees are registered.
+ */
+export const SELF_HOSTED_OBJECT_RUNTIME: ReadonlyMap<string, SelfHostedFuncDef> = new Map([
+  [
+    "__object_getOwnPropertyDescriptors",
+    {
+      name: "__object_getOwnPropertyDescriptors",
+      source: GET_OWN_PROPERTY_DESCRIPTORS_SOURCE,
+      paramTypes: [EXT],
+      returnType: EXT,
+      calleeTypes: new Map<string, Sig>([
+        ...COMMON_CALLEES,
+        ["__getOwnPropertyNames", { params: [EXT], returnType: EXT }],
+        ["__getOwnPropertyDescriptor", { params: [EXT, EXT], returnType: EXT }],
+      ]),
+    },
+  ],
+  [
+    "__object_fromEntries",
+    {
+      name: "__object_fromEntries",
+      source: FROM_ENTRIES_SOURCE,
+      paramTypes: [EXT],
+      returnType: EXT,
+      calleeTypes: new Map<string, Sig>(COMMON_CALLEES),
+    },
+  ],
+]);

--- a/tests/issue-3160.test.ts
+++ b/tests/issue-3160.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3160 — self-hosted object-runtime slice 1. The two purest object-runtime
+// helpers — `Object.getOwnPropertyDescriptors` and `Object.fromEntries` — are
+// now compiled from ordinary TS source (`src/stdlib/object-runtime.ts`)
+// through the compiler's own IR pipeline via the generalized self-hosting
+// driver (#3161), replacing their hand-emitted `Instr[]` bodies in
+// `ensureObjectRuntime`. Both are STANDALONE-native (host mode backs them with
+// JS imports, so the self-hosted bodies are live only under `--target
+// standalone`/`wasi`). These tests pin observable behaviour against Node's
+// native semantics; the broader #2042 suites cover the fromEntries call-site
+// normalisation and are the primary body-swap regression guard.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  // No host import leaked for either self-hosted helper.
+  const env = (r.imports ?? []).filter((i) => i.module === "env").map((i) => i.name);
+  expect(
+    env.filter((n) => n === "__object_fromEntries" || n === "__object_getOwnPropertyDescriptors"),
+    `must not leak host import: ${env.join(", ")}`,
+  ).toEqual([]);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+const fn = (body: string) => `export function run(): number { ${body} }`;
+
+describe("#3160 self-hosted Object.fromEntries (standalone, IR-compiled TS source)", () => {
+  it("single pair value", async () => {
+    expect(await runStandalone(fn(`const o: any = Object.fromEntries([["a", 1]]); return o.a as number;`))).toBe(1);
+  });
+
+  it("multiple pairs + duplicate key (last wins)", async () => {
+    expect(
+      await runStandalone(
+        fn(`const o: any = Object.fromEntries([["a", 1], ["a", 9], ["b", 2]]); return o.a as number;`),
+      ),
+    ).toBe(9);
+  });
+
+  it("key count via Object.keys", async () => {
+    expect(
+      await runStandalone(
+        fn(`const o: any = Object.fromEntries([["a", 1], ["b", 2], ["c", 3]]); return Object.keys(o).length;`),
+      ),
+    ).toBe(3);
+  });
+
+  it("round-trips Object.entries", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const src: any = { x: 7, y: 8 }; const o: any = Object.fromEntries(Object.entries(src)); return o.y as number;`,
+        ),
+      ),
+    ).toBe(8);
+  });
+});
+
+describe("#3160 self-hosted Object.getOwnPropertyDescriptors (standalone, IR-compiled TS source)", () => {
+  it("descriptor value is readable", async () => {
+    expect(
+      await runStandalone(
+        fn(`const o: any = { a: 5 }; const d: any = Object.getOwnPropertyDescriptors(o); return d.a.value as number;`),
+      ),
+    ).toBe(5);
+  });
+
+  it("descriptor enumerable flag for a plain own property", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const o: any = { a: 1 }; const d: any = Object.getOwnPropertyDescriptors(o); return (d.a.enumerable as boolean) ? 1 : 0;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("one descriptor entry per own key", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const o: any = { a: 1, b: 2, c: 3 }; const d: any = Object.getOwnPropertyDescriptors(o); return Object.keys(d).length;`,
+        ),
+      ),
+    ).toBe(3);
+  });
+
+  it("non-object receiver yields empty descriptor map", async () => {
+    expect(
+      await runStandalone(
+        fn(`const d: any = Object.getOwnPropertyDescriptors(42 as any); return Object.keys(d).length;`),
+      ),
+    ).toBe(0);
+  });
+});

--- a/tests/issue-3161.test.ts
+++ b/tests/issue-3161.test.ts
@@ -1,0 +1,180 @@
+// #3161 — generalized typed-signature self-hosted stdlib driver.
+//
+// Unit-tests the BUILD stage (`buildSelfHostedIr`: parse → from-ast with
+// positional param/return overrides → verify → passes → verify) plus the
+// backend lowering with a mock resolver, over the exact dialect shapes the
+// scale-up families need beyond the #3141 pilot's unary-f64 scope:
+//
+//   - externref params/returns via `unknown` annotations + overrides
+//     (object-runtime #3160: __object_fromEntries / getOwnPropertyDescriptors)
+//   - void callees in statement position (#2856 C4) and void builtins (#1228)
+//   - i32-returning callees feeding i32/i32 compares (#1126 Stage 3)
+//   - ctx-bound `ref_null { typeIdx }` params (array-methods #3159 timsort
+//     raw data arrays) — and WHY the generalized path must not memoize
+//   - arity ≥ 3 callees; unannotated locals inferring externref from
+//     callee return types
+//
+// The emit stage (`emitSelfHostedFunc`) is thin glue identical to the
+// proven math path (mint + push + funcMap) and is covered end-to-end by
+// tests/issue-3141.test.ts once a family lands on it.
+import { describe, it, expect } from "vitest";
+import { buildSelfHostedIr, type SelfHostedFuncDef } from "../src/codegen/stdlib-selfhost.js";
+import { irVal, type IrType } from "../src/ir/nodes.js";
+import { lowerIrFunctionToWasm, type IrLowerResolver } from "../src/ir/lower.js";
+
+const EXT: IrType = irVal({ kind: "externref" });
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+
+/** Lower `ir` with a mock resolver; return the func + the callees it resolved. */
+function lowerWithMockResolver(def: SelfHostedFuncDef) {
+  const ir = buildSelfHostedIr(def);
+  const resolved = new Map<string, number>();
+  let nextFunc = 500;
+  let nextType = 100;
+  const resolver: IrLowerResolver = {
+    resolveFunc(ref) {
+      let idx = resolved.get(ref.name);
+      if (idx === undefined) {
+        expect(def.calleeTypes.has(ref.name), `unexpected callee ${ref.name}`).toBe(true);
+        idx = nextFunc++;
+        resolved.set(ref.name, idx);
+      }
+      return idx;
+    },
+    resolveGlobal(ref) {
+      throw new Error(`unexpected global ${ref.name}`);
+    },
+    resolveType(ref) {
+      throw new Error(`unexpected named type ${ref.name}`);
+    },
+    internFuncType() {
+      return nextType++;
+    },
+  };
+  const { func } = lowerIrFunctionToWasm(ir, resolver);
+  return { func, resolved };
+}
+
+describe("#3161 typed self-hosted driver — widened dialect shapes", () => {
+  it("externref params/returns, void callee in statement position, inferred externref locals, arity 3", () => {
+    // The real object-runtime slice-1 shape (#3160 __object_fromEntries):
+    // externref in/out, f64 loop, void __extern_set(3 args), every local
+    // unannotated-externref except the annotated f64s.
+    const def: SelfHostedFuncDef = {
+      name: "__probe_from_entries",
+      source: `
+export function __probe_from_entries(entries: unknown): unknown {
+  const out = __new_plain_object();
+  const len: number = __extern_length(entries);
+  let i: number = 0;
+  while (i < len) {
+    const pair = __extern_get_idx(entries, i);
+    __extern_set(out, __extern_get_idx(pair, 0), __extern_get_idx(pair, 1));
+    i = i + 1;
+  }
+  return out;
+}
+`,
+      paramTypes: [EXT],
+      returnType: EXT,
+      calleeTypes: new Map([
+        ["__new_plain_object", { params: [], returnType: EXT }],
+        ["__extern_length", { params: [EXT], returnType: F64 }],
+        ["__extern_get_idx", { params: [EXT, F64], returnType: EXT }],
+        ["__extern_set", { params: [EXT, EXT, EXT], returnType: null }],
+      ]),
+    };
+    const { func, resolved } = lowerWithMockResolver(def);
+    expect(func.body.length).toBeGreaterThan(0);
+    expect([...resolved.keys()].sort()).toEqual([
+      "__extern_get_idx",
+      "__extern_length",
+      "__extern_set",
+      "__new_plain_object",
+    ]);
+  });
+
+  it("void builtin return, ref_null typeIdx params, i32 callee results in i32/i32 compare", () => {
+    // The array-methods kernel shape (#3159): raw data-array param typed
+    // with a ctx-bound ref_null typeIdx, i32-returning element reads
+    // compared i32/i32, void return.
+    const DATA: IrType = irVal({ kind: "ref_null", typeIdx: 42 });
+    const def: SelfHostedFuncDef = {
+      name: "__probe_count_less",
+      source: `
+export function __probe_count_less(data: unknown, lo: number, hi: number): void {
+  let i: number = lo;
+  while (i < hi) {
+    if (__elem_i32(data, i) < __elem_i32(data, i + 1)) {
+      __mark(data, i);
+    }
+    i = i + 1;
+  }
+  return;
+}
+`,
+      paramTypes: [DATA, F64, F64],
+      returnType: null,
+      calleeTypes: new Map([
+        ["__elem_i32", { params: [DATA, F64], returnType: I32 }],
+        ["__mark", { params: [DATA, F64], returnType: null }],
+      ]),
+    };
+    const { func, resolved } = lowerWithMockResolver(def);
+    expect(func.body.length).toBeGreaterThan(0);
+    expect([...resolved.keys()].sort()).toEqual(["__elem_i32", "__mark"]);
+  });
+
+  it("rejects a primitive annotation that disagrees with the positional override (typo guard)", () => {
+    const def: SelfHostedFuncDef = {
+      name: "__probe_bad",
+      source: `
+export function __probe_bad(x: number): number {
+  return x;
+}
+`,
+      paramTypes: [EXT], // disagrees with `: number`
+      returnType: F64,
+      calleeTypes: new Map(),
+    };
+    expect(() => buildSelfHostedIr(def)).toThrow(/disagrees with annotation/);
+  });
+
+  it("rejects a paramTypes/declared-params arity mismatch", () => {
+    const def: SelfHostedFuncDef = {
+      name: "__probe_arity",
+      source: `
+export function __probe_arity(x: number, y: number): number {
+  return x + y;
+}
+`,
+      paramTypes: [F64],
+      returnType: F64,
+      calleeTypes: new Map(),
+    };
+    expect(() => buildSelfHostedIr(def)).toThrow(/paramTypes has 1/);
+  });
+
+  it("scope guard: named-type references still throw at lowering", () => {
+    // A def whose IR is clean but whose resolver hits resolveFunc only —
+    // resolveType/resolveGlobal remain loud errors. (Positive control for
+    // the guard is structural: the resolver in this test throws, and the
+    // two happy-path tests above prove it is never invoked for val-kind
+    // ref_null / externref types.)
+    const def: SelfHostedFuncDef = {
+      name: "__probe_guard",
+      source: `
+export function __probe_guard(x: number): number {
+  return x * 2;
+}
+`,
+      paramTypes: [F64],
+      returnType: F64,
+      calleeTypes: new Map(),
+    };
+    const { func, resolved } = lowerWithMockResolver(def);
+    expect(func.body.length).toBeGreaterThan(0);
+    expect(resolved.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

First **object-runtime** self-hosting slice — the flagship bloat-reduction lever. Converts the two PUREST helpers in `src/codegen/object-runtime.ts` (the biggest single hand-emitted family, 10,598 lines) from hand-emitted `Instr[]` to ordinary TS source (`src/stdlib/object-runtime.ts`) compiled through the compiler's own IR pipeline via the #3161 generalized driver:

- `__object_getOwnPropertyDescriptors(obj)` — own key → `__getOwnPropertyDescriptor(obj, key)`.
- `__object_fromEntries(entries)` — `out[pair[0]] = pair[1]` per pair.

Both are thin compositions over funcMap helpers registered earlier (leaf-first) with **zero `$Object`/`$PropEntry` struct, identity, prototype, or descriptor-MOP entanglement** — the bounded PUREST-first slice the scale-up plan prescribes for family #8 ("convert LAST").

## Stacked on #2916 (do NOT enqueue until #2916 lands)
This PR consumes the generalized typed-emit path (`emitSelfHostedFunc`/`SelfHostedFuncDef`) from #2916. Branched from that PR's branch per predecessor-stacking; re-merge after it lands.

## Bloat delta
- `object-runtime.ts`: **−145 lines**.
- Compiler-source **NET −18** (new 127-line stdlib file amortizes — future object-runtime slices reuse its header → strongly negative).

## Proof
- Behaviour preserved: `tests/issue-3160.test.ts` (8 standalone cases) + existing `tests/issue-2042-fromentries-objvec.test.ts` (8) + `tests/issue-2042-s3.test.ts` — 32/32 green.
- No host-import leak in standalone (`__object_*` absent from env imports).
- **Host mode byte-inert** (these are JS imports there; native bodies absent — SHA-identical binary main vs branch).
- **Standalone: identical function count (228)** main vs branch — `getOwnPropertyDescriptors` is an always-retained root (`OBJECT_RUNTIME_HELPER_NAMES`), so the change is a behaviour-equivalent body-swap (+97 bytes), NOT dead-code bloat or a DCE regression.

## Findings (documented in issue #3160)
- `Object.fromEntries([])` (empty literal) still hits a pre-existing CALL-SITE refusal — orthogonal to the helper body.
- `__object_groupBy` is nearly pure but blocked on from-ast's externref `=== null` fold gap (`from-ast.ts:6263`) — deferred to a later slice.
- Deeper helpers (assign raw-table walk, Object.is SameValue, integrity/struct.get predicates) need Precursor D (typed struct intrinsics) — the plan's family-#8 assessment holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8