### PR TITLE
fix(#2872): standalone dyn-view reduce/reduceRight + boolean-result boxing (reuse-first)

### DIFF
--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -23,6 +23,49 @@ loc-budget-allow:
   - src/codegen/expressions/calls-closures.ts
 ---
 
+## Progress (2026-07-12, fable) — Slice 4: dyn-view reduce/reduceRight + boolean-result boxing (REUSE-first)
+
+The #3140 `Function.prototype.bind`-on-closure blocker the earlier slices
+flagged as THE cluster unblock is now **DONE** (PR #2884), so the
+`testWithTypedArrayConstructors` harness reaches the method bodies.
+
+Per the standing no-bloat directive, this slice adds **zero new per-method TA
+handlers** — it extends the existing #3058 dyn-view two-arm
+(`emitDynViewMethodTwoArm`, which materializes a `$__ta_dyn_view` → `$__vec_f64`
+and re-enters the ORDINARY native array-HOF impl):
+
+1. `reduce` / `reduceRight` added to `DYN_VIEW_READ_METHODS` (array-methods.ts) —
+   they return a scalar accumulator with Array-identical semantics, so the
+   materialize-and-reuse path is correct verbatim.
+2. **Boolean-result boxing fix** (shared): the two-arm's `coerceArmToExternref`
+   boxed a boolean method's raw i32 as a NUMBER, so `includes(x) === true`/
+   `=== false` failed (truthiness worked, which masked it) — a LATENT #3058 bug
+   for `includes` (already in the read set). New `BOOLEAN_RESULT_METHODS` set +
+   a `boolResult` param route boolean methods through `__box_boolean`. One fix
+   lights up `includes` (+6) and pre-wires a future `every`/`some`.
+
+**Measured (real runner, standalone, `built-ins/TypedArray{,Constructors}/prototype`
+reduce+reduceRight+includes+callback family, 441 files, vs main):
++8 fail→pass, ZERO regressions, ZERO CEs.** (reduce +1, reduceRight +1,
+includes +6.)
+
+- `prove-emit-identity`: IDENTICAL 39/39 (gc/wasi/standalone corpus byte-inert).
+- 402-file broad standalone stride: zero flips (no collateral — the shared
+  two-arm coercion change is inert outside dyn-view receivers).
+- `tests/issue-2872-ta-dynview-reduce-includes.test.ts` 9/9; all prior
+  #2872/TypedArray/array-method suites green (114 tests).
+
+**Deferred (measured but NOT shipped — would regress/CE):**
+`find`/`findIndex` (+13 pass but the materialized `find` impl emits invalid wasm
+on `predicate-call-changes-value` — arm type mismatch), `findLast`/
+`findLastIndex` (array impl misses a `__call_1_f64` registration on this path →
+CE), `every`/`some`/`forEach` (detached-buffer tests regress — materialization
+snapshots before a mid-callback detach). Each needs targeted work: the `find`
+arm-result type fix, the `findLast` `__call_1_f64` wiring, and detached-aware
+materialization. `map`/`filter` (new same-kind TA result), `sort`/`toSorted`
+(numeric default comparator), `with`/`toReversed` (new TAs) still need a
+TA-result builder.
+
 > **UNBLOCKED 2026-07-11 (fable-harvest3):** the #2893 brand dependency landed
 > on main 2026-07-01 (PR #2395 merged — the "CONFIRMED BLOCKED" note below is
 > stale). Slice 1 (general dynamic construction + dyn-view `.fill`) is

--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -1,11 +1,13 @@
 ---
 id: 2872
 title: "Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)"
-status: ready
+status: in-progress
+assignee: ttraenkler/agent-a30d0acc00d3c78c5
 created: 2026-06-30
-updated: 2026-07-11
+updated: 2026-07-12
 priority: high
 task_type: bug
+feasibility: hard
 area: codegen
 goal: standalone
 sprint: current

--- a/plan/issues/3162-dynview-find-two-arm-invalid-wasm.md
+++ b/plan/issues/3162-dynview-find-two-arm-invalid-wasm.md
@@ -1,0 +1,104 @@
+---
+id: 3162
+title: "[SOUNDNESS] dyn-view find/findIndex through the #3058 two-arm emits INVALID wasm (fallthru type i32 vs ref) on a mutating predicate"
+status: ready
+sprint: current
+created: 2026-07-12
+priority: high
+task_type: bug
+feasibility: medium
+area: codegen
+goal: standalone
+language_feature: typed-arrays, array-methods
+test262_category: built-ins/TypedArray/prototype/find
+related: [2872, 3058]
+parent: 2872
+---
+
+# #3162 — dyn-view `find`/`findIndex` two-arm emits INVALID wasm
+
+## Severity: codegen soundness (higher than a CE or a feature gap)
+
+This is **not** a missing-feature gap and **not** a leaked-host-import CE — it is
+the compiler emitting a **structurally invalid wasm module** (fails
+`WebAssembly.compile`/`instantiate` validation), i.e. a codegen-soundness bug.
+Whoever picks it up should treat it as an emitter type-unification fix, not a
+feature addition.
+
+## Currently LATENT (why it isn't biting main today)
+
+The bug only manifests when `find`/`findIndex` are members of
+`DYN_VIEW_READ_METHODS` (`src/codegen/array-methods.ts`) — i.e. routed through
+the #3058 dyn-view two-arm (`emitDynViewMethodTwoArm`). #2872 slice 4
+deliberately **excluded** `find`/`findIndex` from that set for exactly this
+reason, so main is unaffected. This issue tracks the soundness fix that must
+land **before** `find`/`findIndex` (a measured **+13 fail→pass**) can be
+lit up.
+
+## Repro
+
+Add `"find"` (and/or `"findIndex"`) to `DYN_VIEW_READ_METHODS`, then compile the
+harness shape standalone:
+
+```ts
+export function test(): number {
+  function run(TA: any): number {
+    const a: any = new TA([1, 2, 3]);
+    // a mutating predicate is the trigger (test262 predicate-call-changes-value)
+    return a.find(function (v: any, i: any, arr: any) { arr[0] = 9; return v === 2; }) === 2 ? 1 : 0;
+  }
+  return run(Int8Array);
+}
+```
+
+test262 file: `built-ins/TypedArray/prototype/find/predicate-call-changes-value.js`
+(+ the `findIndex` twin, + the `BigInt/` variants).
+
+**Observed** (real runner, `--target standalone`):
+
+```
+compile_error: WebAssembly.instantiate(): Compiling function #218:"__closure_5"
+failed: type error in fallthru[0] (expected (ref null 4), got i32) @+67789
+```
+
+Measured impact when the set includes find+findIndex: **+13 fail→pass but +4
+fail→compile_error** — the CEs are these invalid-wasm modules.
+
+## Root-cause hypothesis
+
+The two-arm (`emitDynViewMethodTwoArm`, array-methods.ts) unifies its THEN arm
+(the dyn-view-materialized-to-`$__vec_f64` `find` result) and ELSE arm to a
+single `externref` branch result via `coerceArmToExternref`. On the
+`predicate-call-changes-value` shape the materialized `find` impl over the
+f64-vec leaves an **i32** on the stack where the branch fallthrough expects a
+`(ref null …)` — the arm result ValType is not being coerced before the
+`if`-block's fallthrough. The "expected (ref null 4)" (not `externref`) in the
+error suggests the mismatch is between the materialized-vec element ref type and
+the branch type, i.e. `find`'s returned ValType for this shape is not the
+`externref` `coerceArmToExternref` assumes. Likely the mutating-predicate path
+takes a different `find` codegen branch (a closure-capture / re-entrancy arm)
+whose result ValType the two-arm doesn't coerce.
+
+Investigate: what ValType does `compileArrayMethodCall(... "find" ..., skipDynViewWrap=true)`
+return over an `$__vec_f64` for the mutating-predicate shape, and why
+`coerceArmToExternref` leaves it as i32. The fix is almost certainly in the
+arm-result coercion / the `find` impl's returned ValType, NOT per-method.
+
+## Acceptance
+
+- With `find`/`findIndex` in `DYN_VIEW_READ_METHODS`, the repro + the four
+  `find`/`findIndex` `predicate-call-changes-value{,BigInt}` test262 files
+  compile to VALID wasm (no fallthru type error).
+- Net for `find`+`findIndex` dyn-view lane: the +13 fail→pass lands with **zero
+  fail→CE**.
+- `prove-emit-identity` IDENTICAL (gc/wasi/standalone corpus byte-inert — the
+  change is dyn-view-two-arm-only).
+- No regressions in the broader standalone stride.
+
+## Not in scope (separate #2872 cluster-tracker notes, lower severity)
+
+- `findLast`/`findLastIndex`: missing `__call_1_f64` registration on this path
+  (a CE, not invalid wasm) — likely a shared dispatch-arm addition.
+- `every`/`some`/`forEach`: detached-buffer regressions (materialization
+  snapshots before a mid-callback detach) — a semantics gap, not soundness.
+- `map`/`filter`/`sort`/`with`: need a TA-result builder.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3020,7 +3020,38 @@ const ARRAY_METHODS = new Set([
  * `sort` — Bucket B, need write-back) and species/new-view producers (`slice`/`subarray`/
  * `map`/`filter`/`with`/`toSorted`/`toReversed` — Bucket C, need real-buffer identity).
  */
-const DYN_VIEW_READ_METHODS = new Set<string>(["at", "indexOf", "lastIndexOf", "includes", "toLocaleString"]);
+const DYN_VIEW_READ_METHODS = new Set<string>([
+  "at",
+  "indexOf",
+  "lastIndexOf",
+  "includes",
+  "toLocaleString",
+  // (#2872) Read-side CALLBACK methods that return a scalar (NO new TypedArray
+  // allocation) with Array-identical semantics. The two-arm materializes the
+  // dyn-view to an `$__vec_f64` and re-enters the ORDINARY array-method HOF impl
+  // — reusing the existing native array-HOF machinery verbatim (no per-method TA
+  // handler). Scoped to `reduce`/`reduceRight` in this slice: they measured
+  // clean (+2 pass, 0 CE, 0 regression). Deliberately EXCLUDED pending
+  // follow-ups: `find`/`findIndex` (the materialized `find` impl emits invalid
+  // wasm on the `predicate-call-changes-value` shape — type mismatch in the
+  // arm), `findLast`/`findLastIndex` (the array impl misses a `__call_1_f64`
+  // registration on this path → CE), `every`/`some`/`forEach` (detached-buffer
+  // tests regress — the materialization snapshots before a mid-callback detach),
+  // `map`/`filter` (return a NEW same-kind TA, not an f64-vec), `sort`/`toSorted`
+  // (TA default comparator is NUMERIC, not Array's lexicographic), `with`/
+  // `toReversed` (new TAs). `includes` (above) is boolean-returning and lights
+  // up via the {@link BOOLEAN_RESULT_METHODS} boxing fix below.
+  "reduce",
+  "reduceRight",
+]);
+
+/**
+ * (#2872) Dyn-view read-side methods whose result is a BOOLEAN (`true`/`false`),
+ * so the two-arm boxes the impl's raw i32 via `__box_boolean` (not the generic
+ * number box) — see {@link coerceArmToExternref}. `includes` was already in the
+ * read set and shared the same latent mis-box.
+ */
+const BOOLEAN_RESULT_METHODS = new Set<string>(["every", "some", "includes"]);
 
 /**
  * (#3058) Call expressions whose dyn-view two-arm ELSE arm is CURRENTLY re-dispatching
@@ -3059,6 +3090,14 @@ function coerceArmToExternref(
   fctx: FunctionContext,
   r: ValType | null | undefined | typeof VOID_RESULT,
   treatNullAsVoid = false,
+  // (#2872) When the arm result is a BOOLEAN-returning method (`every`/`some`/
+  // `includes`), its impl leaves a raw i32 (0/1). The generic `coerceType`
+  // i32→externref path boxes it as a NUMBER (`__box_number`), so the boxed
+  // result is `0`/`1`, not `false`/`true` — `result === false` then fails
+  // (truthiness still works, which masked this). Box via `__box_boolean` so the
+  // spec `assert.sameValue(…, false)` identity holds. Falls back to the generic
+  // number box when the native helper is unavailable (byte-identical to before).
+  boolResult = false,
 ): boolean {
   if (r === undefined || r === null) {
     // THEN arm (treatNullAsVoid=false): a null/undefined from the recursive f64-vec
@@ -3075,6 +3114,13 @@ function coerceArmToExternref(
     return true;
   }
   const vt = r as ValType;
+  if (boolResult && vt.kind === "i32") {
+    const boxBoolIdx = ctx.funcMap.get("__box_boolean");
+    if (boxBoolIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: boxBoolIdx } as Instr);
+      return true;
+    }
+  }
   if (vt.kind !== "externref") coerceType(ctx, fctx, vt, { kind: "externref" });
   return true;
 }
@@ -3155,7 +3201,7 @@ function emitDynViewMethodTwoArm(
   const rThen = compileArrayMethodCall(ctx, fctx, propAccess, callExpr, receiverType, methodName, expectedType, true);
   if (savedBind !== undefined) fctx.localMap.set(name, savedBind);
   else fctx.localMap.delete(name);
-  const thenOk = coerceArmToExternref(ctx, fctx, rThen);
+  const thenOk = coerceArmToExternref(ctx, fctx, rThen, false, BOOLEAN_RESULT_METHODS.has(methodName));
 
   // --- ELSE arm (exact existing non-dyn-view impl) — re-dispatch the WHOLE call
   // through compileExpression so the caller's host/externref fallback (which lives

--- a/tests/issue-2872-ta-dynview-reduce-includes.test.ts
+++ b/tests/issue-2872-ta-dynview-reduce-includes.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2872 (slice: dyn-view reduce/reduceRight + boolean-result boxing) — standalone
+ * `%TypedArray%.prototype.{reduce,reduceRight,includes}` on a dynamically-
+ * constructed view reached through an `any` receiver (the
+ * `testWithTypedArrayConstructors(TA => new TA(…).reduce(…))` harness shape).
+ *
+ * REUSE, not new machinery: `reduce`/`reduceRight` join the #3058
+ * `DYN_VIEW_READ_METHODS` set, so the existing dyn-view two-arm materializes the
+ * view to an `$__vec_f64` and re-enters the ORDINARY native array-HOF impl — no
+ * per-method TA handler. `includes` was already in that set but returned a
+ * NUMBER-boxed 0/1 (so `result === true`/`=== false` failed while truthiness
+ * worked); the two-arm now boxes boolean-result methods via `__box_boolean`
+ * (the shared {@link BOOLEAN_RESULT_METHODS} fix — also latent for a future
+ * `every`/`some`).
+ *
+ * Every case asserts host-free instantiation (`WebAssembly.instantiate(binary,
+ * {})`) and zero env imports — the prior `Uint8ClampedArray_*` / `__make_callback`
+ * leak is gone on this path.
+ */
+
+async function runStandalone(src: string): Promise<{ value: unknown; envImports: string[] }> {
+  const r = await compile(src, { target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  if (!r.success) throw new Error("unreachable");
+  const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const value = (instance.exports as { test: () => unknown }).test();
+  return { value, envImports };
+}
+
+// Wrap the body in a per-constructor helper so the receiver is a dynamically
+// constructed view held in an `any` param (the harness shape that produces a
+// boxed `$__ta_dyn_view`), across a representative kind set.
+const withTA = (ctor: string, body: string) =>
+  `export function test(): number { function run(TA: any): number { ${body} } return run(${ctor}); }`;
+
+describe("#2872 — dyn-view reduce/reduceRight (standalone, host-free)", { timeout: 30000 }, () => {
+  it("reduce with an initial value", async () => {
+    const { value, envImports } = await runStandalone(
+      withTA(
+        "Int16Array",
+        `const a: any = new TA([1, 2, 3, 4]); return a.reduce(function (x: any, y: any) { return x + y; }, 0) === 10 ? 1 : 0;`,
+      ),
+    );
+    expect(value).toBe(1);
+    expect(envImports).toEqual([]);
+  });
+
+  it("reduce with no initial value seeds from the first element", async () => {
+    const { value } = await runStandalone(
+      withTA(
+        "Float64Array",
+        `const a: any = new TA([2, 3, 4]); return a.reduce(function (x: any, y: any) { return x + y; }) === 9 ? 1 : 0;`,
+      ),
+    );
+    expect(value).toBe(1);
+  });
+
+  it("reduce callback sees (accumulator, value, index)", async () => {
+    const { value } = await runStandalone(
+      withTA(
+        "Uint32Array",
+        `const a: any = new TA([10, 20, 30]); let lastIdx = -1; a.reduce(function (acc: any, v: any, i: any) { lastIdx = i; return acc + v; }, 0); return lastIdx === 2 ? 1 : 0;`,
+      ),
+    );
+    expect(value).toBe(1);
+  });
+
+  it("reduceRight folds right-to-left", async () => {
+    // Order captured numerically (acc*10+v): 0→3→32→321 proves 3,2,1 visitation.
+    const { value, envImports } = await runStandalone(
+      withTA(
+        "Int8Array",
+        `const a: any = new TA([1, 2, 3]); return a.reduceRight(function (acc: any, v: any) { return acc * 10 + v; }, 0) === 321 ? 1 : 0;`,
+      ),
+    );
+    expect(value).toBe(1);
+    expect(envImports).toEqual([]);
+  });
+});
+
+describe("#2872 — dyn-view includes boolean identity (standalone, host-free)", { timeout: 30000 }, () => {
+  it("includes(present) === true (was number-boxed 1, failed strict-eq)", async () => {
+    const { value, envImports } = await runStandalone(
+      withTA("Float32Array", `const a: any = new TA([1, 2, 3]); return a.includes(2) === true ? 1 : 0;`),
+    );
+    expect(value).toBe(1);
+    expect(envImports).toEqual([]);
+  });
+
+  it("includes(absent) === false", async () => {
+    const { value } = await runStandalone(
+      withTA("Int16Array", `const a: any = new TA([1, 2, 3]); return a.includes(9) === false ? 1 : 0;`),
+    );
+    expect(value).toBe(1);
+  });
+
+  it("includes truthiness still holds", async () => {
+    const { value } = await runStandalone(
+      withTA("Uint8Array", `const a: any = new TA([5, 6, 7]); return a.includes(6) ? 1 : 0;`),
+    );
+    expect(value).toBe(1);
+  });
+});
+
+describe("#2872 — GUARDS: plain-array any receiver unaffected", { timeout: 30000 }, () => {
+  it("plain array reduce still native + host-free", async () => {
+    const { value, envImports } = await runStandalone(
+      `export function test(): number { const a: any = [1, 2, 3]; return a.reduce(function (x: any, y: any) { return x + y; }, 0) === 6 ? 1 : 0; }`,
+    );
+    expect(value).toBe(1);
+    expect(envImports).toEqual([]);
+  });
+
+  it("plain array includes === true unaffected by the boolean-box change", async () => {
+    const { value } = await runStandalone(
+      `export function test(): number { const a: any = [1, 2, 3]; return a.includes(2) === true ? 1 : 0; }`,
+    );
+    expect(value).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 4 of the #2872 TypedArray.prototype standalone cluster. The #3140 `Function.prototype.bind`-on-closure blocker earlier slices flagged as THE cluster unblock is now DONE (PR #2884), so the `testWithTypedArrayConstructors` harness reaches the method bodies.

Per the standing **no-bloat directive**, this adds **zero new per-method TA handlers** — it extends the existing #3058 dyn-view two-arm (`emitDynViewMethodTwoArm`: materialize `$__ta_dyn_view` → `$__vec_f64`, re-enter the ORDINARY native array-HOF impl):

1. **`reduce`/`reduceRight`** join `DYN_VIEW_READ_METHODS` — scalar-returning, Array-identical semantics, so materialize-and-reuse is correct verbatim.
2. **Boolean-result boxing fix** (shared, latent #3058 bug): the two-arm boxed a boolean method's raw i32 as a NUMBER, so `includes(x) === true`/`=== false` failed while truthiness worked. New `BOOLEAN_RESULT_METHODS` set + `boolResult` param route boolean methods through `__box_boolean`. Lights up `includes` (+6) and pre-wires a future `every`/`some`.

## Validation (measured, branch vs main)

- `TypedArray{,Constructors}/prototype` reduce+reduceRight+includes+callback family (441 files, standalone): **+8 fail→pass, ZERO regressions, ZERO CEs** (reduce +1, reduceRight +1, includes +6).
- `prove-emit-identity`: **IDENTICAL 39/39** (gc/wasi/standalone corpus byte-inert).
- 402-file broad standalone stride: **zero flips**.
- `tests/issue-2872-ta-dynview-reduce-includes.test.ts` 9/9; all prior #2872 / TypedArray / array-method suites green (114 tests).

## Deferred (measured, would regress/CE — documented in the issue)

`find`/`findIndex` (+13 pass but materialized `find` emits invalid wasm on `predicate-call-changes-value`), `findLast`/`findLastIndex` (missing `__call_1_f64` → CE), `every`/`some`/`forEach` (detached-buffer regressions), `map`/`filter`/`sort`/`with` (need a TA-result builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)