### PR TITLE
docs(#3163): file new-fnctor-via-any-cast-callee-returns-null bug

### DIFF
--- a/plan/issues/3163-new-fnctor-via-any-cast-callee-returns-null.md
+++ b/plan/issues/3163-new-fnctor-via-any-cast-callee-returns-null.md
@@ -1,0 +1,69 @@
+---
+id: 3163
+title: "`new (Fn as any)()` on a function-style constructor returns null (dynamic-callee construct drops the instance)"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: medium
+created: 2026-07-12
+task_type: bugfix
+area: codegen
+language_feature: function-constructors, new-expression, any-callee
+goal: self-hosting-dogfood
+related: [1725, 1632, 3033, 3005]
+origin: "blocked minimal repros while investigating #3033 Bug 2a (dev-3051c)"
+---
+
+# #3163 — `new (Fn as any)()` on a fnctor returns null
+
+## Problem
+
+Constructing a function-style constructor (fnctor) through an `any`-typed /
+cast callee expression returns **null** instead of the instance. The direct
+`new Fn()` (bare identifier callee) works; routing the callee through
+`(Fn as any)` (or any expression whose type erases the concrete ctor) takes the
+dynamic-construct path, which drops the instance and yields null.
+
+## Minimal repro (compiled returns null, node/V8 returns the instance)
+
+```ts
+function P(this: any): void { this.v = 7; }
+export function test(): string {
+  const p: any = new (P as any)();   // p === null  (should be { v: 7 })
+  return p === null ? "NULL" : ("ok v=" + (p.v as number));
+}
+```
+
+Both `new (P as any)()` and a `new (P as any as { new(): any })()` cast return
+NULL. The bare `new P()` identifier-callee path is unaffected (works).
+
+## Why it matters
+
+This blocks **minimal-scale reproduction** of every fnctor-instance codegen bug:
+any probe that constructs a fnctor via a cast/`any` callee (the natural way to
+write a compact repro without a full type-annotated ctor) gets a null instance
+and masks the behavior under test. It surfaced while validating #3033 Bug 2a
+(`var ty = this.type` off a fnctor `this`) — the fix could only be verified at
+acorn scale because the 2-3-line repros all hit this null. Likely also affects
+real code that stores a constructor in an `any`/loosely-typed slot and `new`s it
+(the acorn `new this(...)` / `new C(...)` dynamic-ctor idioms, cf. #1632b's
+`__construct_closure` follow-up).
+
+## Suggested approach
+
+The dynamic-callee `new` path (grep `new-super.ts` for the `any`/externref
+callee arm and the `_wrapCallableForHost.construct` host bridge, runtime.ts)
+must return the constructed instance, not null. Compare against the working
+bare-identifier fnctor `new` path (`__fnctor_<Name>_new`, new-super.ts ~1426)
+and the host construct trap (`_wrapCallableForHost`, runtime.ts ~6800) — the
+instance is built but not threaded back through the `any`-callee coercion.
+Check the return-value coercion of the dynamic construct expression (the result
+is likely coerced externref→struct and null-dropped, mirroring #1725's
+ref.cast-null family).
+
+## Acceptance
+
+- `new (P as any)()` returns `{ v: 7 }` (not null); `new P()` regression-free.
+- A minimal fnctor-via-cast construct + field read round-trips.
+- No test262 regression.


### PR DESCRIPTION
Files #3163 — `new (Fn as any)()` on a function-style constructor returns null (the dynamic-callee construct path drops the instance); bare `new Fn()` works.

Surfaced while validating #3033 Bug 2a: it blocks minimal-scale reproduction of every fnctor-instance codegen bug (2-3-line repros that construct a fnctor via a cast/`any` callee all get a null instance and mask the behavior under test). Repro + suggested approach (dynamic-callee `new` return-value coercion, cf. #1725's ref.cast-null family) in the file.

Docs-only (new issue file); no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)