### PR TITLE
fix(#3171): Map/Set/WeakMap/WeakSet receiver brand-check protocol (standalone)

### DIFF
--- a/plan/issues/3171-standalone-collections-receiver-brand-protocol.md
+++ b/plan/issues/3171-standalone-collections-receiver-brand-protocol.md
@@ -1,7 +1,9 @@
 ---
 id: 3171
 title: "standalone: Map/Set/WeakMap/WeakSet receiver brand-check protocol — spec TypeError on incompatible receivers (~142 direct gap tests)"
-status: ready
+status: done
+completed: 2026-07-12
+assignee: ttraenkler/dev-collections-brand
 created: 2026-07-12
 updated: 2026-07-12
 priority: high
@@ -51,9 +53,15 @@ TypeError is thrown at all (the bulk). Same story for
   has the right internal-slot brand) and throw the spec `TypeError` otherwise.
 - Do it ONCE: add a shared brand-check preamble helper (pattern: the
   `$__ta_dyn_view` view-brand check from #2893, and `shape-brand.ts`) that all
-  four runtimes' dispatch arms in `closed-method-dispatch.ts` call — not four
-  hand-rolled copies. Wrong-brand-but-collection receivers
-  (`Map.prototype.get.call(new Set())`) must also throw.
+  four runtimes' dispatch arms call — not four hand-rolled copies.
+  Wrong-brand-but-collection receivers (`Map.prototype.get.call(new Set())`)
+  must also throw.
+  - **Pointer correction (impl finding):** the dispatch arms are NOT in
+    `closed-method-dispatch.ts` (that module handles closed object-literal
+    struct methods). The real brand machinery is `emitSetBrandCheck`
+    (set-runtime.ts, #2604), the three `tryCompileNative*MethodCall`
+    direct dispatchers wired via `expressions/extern.ts`, and the reflective
+    `.call` interception in `expressions/calls.ts`.
 - Accessor `size` (Set 5 / Map 7 rows) goes through the same gate on its
   getter.
 

--- a/plan/issues/3171-standalone-collections-receiver-brand-protocol.md
+++ b/plan/issues/3171-standalone-collections-receiver-brand-protocol.md
@@ -78,3 +78,36 @@ TypeError is thrown at all (the bulk). Same story for
 - Zero host-mode regressions; zero standalone high-water regressions.
 - Out of scope: `class MySet extends Set` subclassing CEs (8 rows — separate
   root cause, builtin-super construction lineage #2917), and #3172's methods.
+
+## Test Results (2026-07-12, implementation)
+
+Measured on the standalone lane (`TEST262_TARGET=standalone`,
+filter `built-ins/{Map,Set,WeakMap,WeakSet}/prototype`) vs the
+`test262-standalone-current.jsonl` main baseline:
+
+- **158 flips fail→pass, 0 regressions** (suite: 320→478 of 700).
+  150 are brand/receiver-protocol rows (`does-not-have-*`,
+  `this-not-object-*`, `context-is-*`); 8 bonus rows (size descriptor
+  meta `name`/`length`/`size.js`, `Map.set` return-map rows). Acceptance
+  bar was ≥120 ✓.
+- Host (gc) lane on the same filter: 0 flips, 0 regressions — byte-inert as
+  intended (all paths `nativeStrings`/standalone-gated).
+- `tests/issue-3171.test.ts`: 48 equivalence tests. Regression suites green:
+  #2604 (31), #2607 set-algebra (27), #2377/#2861 proto-value-read,
+  collection batch (116; 3 pre-existing failures reproduced on clean tree).
+
+### What landed (for #3172/#3174 reuse)
+
+- `src/codegen/receiver-brand.ts` — **the shared brand preamble**:
+  `emitReceiverBrandCheck(ctx, fctx, recvType, spec)` with
+  `spec: { message, structTypeIdx, kindField?: { fieldIdx, accept[] } }`.
+  Consumes the compiled receiver, leaves non-null `(ref structTypeIdx)`,
+  throws catchable TypeError on a miss. #3172: pass the Set spec from
+  `collectionBrandSpec(ctx, "Set")` (collections-brand.ts). #3174: pass
+  Date's struct typeIdx with no `kindField`.
+- `src/codegen/collections-brand.ts` — reflective `.call` dispatch, all four
+  collections; `collectionBrandSpec` exported.
+- `COLLECTION_KIND` tag field on `$Map` (map-runtime.ts, `MAP_LAYOUT.M_KIND`),
+  stamped by `__map_new(kind)`.
+- `size` accessor getter glue for Map/Set (array-object-proto.ts,
+  `makeCollectionGlue` → `emitCollectionSizeGetterBody`).

--- a/plan/issues/3171-standalone-collections-receiver-brand-protocol.md
+++ b/plan/issues/3171-standalone-collections-receiver-brand-protocol.md
@@ -18,6 +18,17 @@ sprint: current
 horizon: m
 related: [2860, 3172, 2893, 2916]
 origin: "PO groom of #2860 umbrella, 2026-07-12 lane-baseline diff"
+# (#3102) God-file growth allowance for THIS change-set: the bulk of #3171
+# lives in NEW subsystem modules (receiver-brand.ts, collections-brand.ts);
+# the residual growth below is unavoidable wiring — the size-getter glue in
+# the glue factory's home module (+77), the COLLECTION_KIND field + reflective
+# receiver params in the collection runtime itself (+48), the kind operand at
+# the 3 ctor sites (+6), and the reflective-gate swap comment (+2).
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
+  - src/codegen/map-runtime.ts
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3171 — standalone: collections receiver brand-check protocol

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -44,6 +44,8 @@ import {
   flatStringType,
   stringConstantExternrefInstrs,
 } from "./native-strings.js";
+import { COLLECTION_KIND, MAP_LAYOUT, ensureMapHelpers } from "./map-runtime.js"; // (#3171) size getter
+import { emitReceiverBrandCheck } from "./receiver-brand.js"; // (#3171) shared brand preamble
 
 /**
  * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
@@ -1343,6 +1345,77 @@ function emitTypedArrayProtoMemberBody(
   return resultType;
 }
 
+/**
+ * (#3171) Native reflective body for the `Map.prototype.size` / `Set.prototype.size`
+ * accessor GETTER — `gOPD(Map.prototype, "size").get.call(recv)`. Spec
+ * §24.1.3.10 / §24.2.4.14: "If M does not have a [[MapData]]/[[SetData]]
+ * internal slot, throw a TypeError". Routes the receiver through the shared
+ * brand preamble (receiver-brand.ts: non-trapping `ref.test $Map` + the
+ * COLLECTION_KIND tag → catchable TypeError on a miss — a Set receiver must
+ * throw for Map's getter and vice versa), then `__map_size` → boxed number.
+ *
+ * Late-funcidx discipline (mirrors `emitTypedArrayProtoMemberBody`): the
+ * `__box_number` import is resolved + flushed BEFORE the cascade; everything
+ * the brand preamble appends in standalone mode (error ctor funcs, string
+ * globals, exn tag) is append-only — no baked-index shifts.
+ */
+function emitCollectionSizeGetterBody(ctx: CodegenContext, fctx: FunctionContext, name: "Map" | "Set"): ValType | null {
+  const resultType: ValType = { kind: "externref" };
+  const refuseMsg = `TypeError: Method get ${name}.prototype.size called on incompatible receiver`;
+
+  // Register the native Map runtime (append-only defined funcs; idempotent).
+  ensureMapHelpers(ctx);
+  const sizeIdx = ctx.mapHelpers.get("__map_size");
+  if (sizeIdx === undefined || ctx.mapTypeIdx < 0) {
+    // No native collection runtime in this module → no receiver can carry the
+    // internal slot → the RequireInternalSlot throw applies unconditionally.
+    emitBrandCheckTypeError(ctx, fctx.body, refuseMsg);
+    return resultType;
+  }
+
+  const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+
+  // Closure ABI: local 0 = self wrapper, local 1 = externref `this`.
+  fctx.body.push({ op: "local.get", index: 1 } as Instr);
+  emitReceiverBrandCheck(
+    ctx,
+    fctx,
+    { kind: "externref" },
+    {
+      message: refuseMsg,
+      structTypeIdx: ctx.mapTypeIdx,
+      kindField: {
+        fieldIdx: MAP_LAYOUT.M_KIND,
+        accept: [name === "Map" ? COLLECTION_KIND.MAP : COLLECTION_KIND.SET],
+      },
+    },
+  );
+  // (ref $Map) on the stack → size (i32) → boxed number externref.
+  fctx.body.push({ op: "call", funcIdx: sizeIdx } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  fctx.body.push({ op: "call", funcIdx: boxIdx } as Instr);
+  return resultType;
+}
+
+/**
+ * (#3171) Glue factory for Map/Set — `makeGlue` plus the `size` accessor
+ * getter (real reflective body via {@link emitCollectionSizeGetterBody}).
+ */
+function makeCollectionGlue(brand: number, name: "Map" | "Set", members: readonly string[]): NativeProtoBuiltinGlue {
+  return {
+    brand,
+    name,
+    memberCsv: [...members, "size"].join(","),
+    memberKind: (member) => (member === "size" ? "getter" : "method"),
+    memberLength: (member) => (member === "size" ? 0 : (PROTO_METHOD_LENGTH[member] ?? 1)),
+    emitMemberBody: (c, fctx, member) =>
+      member === "size"
+        ? emitCollectionSizeGetterBody(c, fctx, name)
+        : emitProtoMemberBodyRefusal(c, fctx, name, member),
+  };
+}
+
 function makeGlue(
   ctx: CodegenContext,
   brand: number,
@@ -1564,7 +1637,9 @@ export function ensureMapNativeProtoGlue(ctx: CodegenContext): number | undefine
   const brand = getBuiltinBrand(ctx, "Map");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
-    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Map", MAP_PROTO_METHODS));
+    // (#3171) Collection glue = makeGlue + the `size` accessor getter with a
+    // real brand-checked reflective body.
+    registerNativeProtoBuiltin(ctx, makeCollectionGlue(brand, "Map", MAP_PROTO_METHODS));
   }
   return brand;
 }
@@ -1574,7 +1649,9 @@ export function ensureSetNativeProtoGlue(ctx: CodegenContext): number | undefine
   const brand = getBuiltinBrand(ctx, "Set");
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
-    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Set", SET_PROTO_METHODS));
+    // (#3171) Collection glue = makeGlue + the `size` accessor getter with a
+    // real brand-checked reflective body.
+    registerNativeProtoBuiltin(ctx, makeCollectionGlue(brand, "Set", SET_PROTO_METHODS));
   }
   return brand;
 }

--- a/src/codegen/collections-brand.ts
+++ b/src/codegen/collections-brand.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3171) Reflective `X.prototype.METHOD.call(recv, …)` /
+ * `inst.METHOD.call(recv, …)` dispatch for ALL FOUR keyed collections
+ * (Map / Set / WeakMap / WeakSet) with the spec receiver brand check —
+ * generalizing the #2604 Set-only reflective dispatch that used to live in
+ * set-runtime.ts.
+ *
+ * Spec §24.1.3.* / §24.2.4.* / §24.3.3.* / §24.4.3.* step 1/2: "If `this` does
+ * not have a [[MapData]] / [[SetData]] / [[WeakMapData]] / [[WeakSetData]]
+ * internal slot, throw a TypeError". Two layers:
+ *
+ *   1. **Struct brand** — the receiver must be the native `$Map` backing
+ *      struct (`ref.test`, non-trapping → catchable TypeError). Rejects
+ *      primitives, null/undefined, plain objects, arrays, `X.prototype`, …
+ *   2. **COLLECTION_KIND tag** (map-runtime.ts) — all four collections SHARE
+ *      the `$Map` hash table, so `Map.prototype.get.call(new Set())` passes
+ *      the struct test; the immutable `kind` field stamped by `__map_new`
+ *      separates the brands (`does-not-have-*-internal-slot-{map,set,weakmap,
+ *      weakset}` rows).
+ *
+ * The brand gate is the shared `emitReceiverBrandCheck` (receiver-brand.ts) —
+ * the SAME preamble the set-algebra argument validation (#2607, kind-lenient)
+ * and the Date receiver check (#3174) parameterize.
+ *
+ * On a brand HIT the call routes to the same native helpers the direct
+ * statically-typed paths use (`__map_*` / `__set_add` / `__weakset_add`, the
+ * eager keys/values/entries vec materialization, the native forEach drive), so
+ * a correct receiver behaves identically through `.call`. Direct dispatch
+ * (extern.ts / property-access.ts) is untouched — static receiver types make
+ * the brand check statically true there.
+ *
+ * `.apply` (packed args) is deferred, matching #2604.
+ */
+import { ts } from "../ts-api.js";
+import type { ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import {
+  COLLECTION_KIND,
+  MAP_LAYOUT,
+  compileCollectionElementArg,
+  emitCollectionIteratorVec,
+  ensureMapHelpers,
+  tryCompileNativeCollectionForEach,
+} from "./map-runtime.js";
+import { emitThrowTypeError } from "./expressions/helpers.js";
+import { emitReceiverBrandCheck, type ReceiverBrandSpec } from "./receiver-brand.js";
+import { ensureSetHelpers } from "./set-runtime.js";
+import type { InnerResult } from "./shared.js";
+import { VOID_RESULT, compileExpression } from "./shared.js";
+import { ensureWeakCollectionHelpers } from "./weak-collections-runtime.js";
+
+type CollectionClass = "Map" | "Set" | "WeakMap" | "WeakSet";
+
+/** Prototype methods each collection's reflective dispatch owns. ES2025
+ *  set-algebra + getOrInsert* are #3172's lane and deliberately absent. */
+const COLLECTION_METHODS: Record<CollectionClass, ReadonlySet<string>> = {
+  Map: new Set(["get", "set", "has", "delete", "clear", "forEach", "keys", "values", "entries"]),
+  Set: new Set(["add", "has", "delete", "clear", "forEach", "keys", "values", "entries"]),
+  WeakMap: new Set(["get", "set", "has", "delete"]),
+  WeakSet: new Set(["add", "has", "delete"]),
+};
+
+const KIND_OF: Record<CollectionClass, number> = {
+  Map: COLLECTION_KIND.MAP,
+  Set: COLLECTION_KIND.SET,
+  WeakMap: COLLECTION_KIND.WEAKMAP,
+  WeakSet: COLLECTION_KIND.WEAKSET,
+};
+
+/** The `[[XData]]` receiver brand for one collection class: `$Map` struct +
+ *  matching COLLECTION_KIND tag. Exported for #3172 (set-algebra receivers). */
+export function collectionBrandSpec(ctx: CodegenContext, cls: CollectionClass): ReceiverBrandSpec {
+  return {
+    message: `TypeError: Method ${cls}.prototype.* called on incompatible receiver`,
+    structTypeIdx: ctx.mapTypeIdx,
+    kindField: { fieldIdx: MAP_LAYOUT.M_KIND, accept: [KIND_OF[cls]] },
+  };
+}
+
+/**
+ * Is `closure` syntactically `X.prototype.METHOD` (X ∈ the four collection
+ * ctors) or `<expr>.METHOD` where `<expr>` is statically typed as one of the
+ * four lib collections? Returns the matched class + method. Mirrors #2604's
+ * `setMethodClosureName`, widened to all four classes.
+ */
+function collectionMethodTarget(
+  ctx: CodegenContext,
+  closure: ts.Expression,
+): { cls: CollectionClass; method: string } | undefined {
+  let e: ts.Expression = closure;
+  while (ts.isParenthesizedExpression(e) || ts.isAsExpression(e) || ts.isNonNullExpression(e)) {
+    e = (e as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
+  }
+  if (!ts.isPropertyAccessExpression(e)) return undefined;
+  const method = e.name.text;
+  const obj = e.expression;
+  // `X.prototype.METHOD`
+  if (
+    ts.isPropertyAccessExpression(obj) &&
+    obj.name.text === "prototype" &&
+    ts.isIdentifier(obj.expression) &&
+    obj.expression.text in COLLECTION_METHODS
+  ) {
+    const cls = obj.expression.text as CollectionClass;
+    if (COLLECTION_METHODS[cls].has(method)) return { cls, method };
+    return undefined;
+  }
+  // `<collectionExpr>.METHOD` where the expression is statically a lib collection.
+  try {
+    const symName = ctx.checker.getTypeAtLocation(obj).getSymbol()?.name;
+    if (symName !== undefined && symName in COLLECTION_METHODS) {
+      const cls = symName as CollectionClass;
+      if (COLLECTION_METHODS[cls].has(method)) return { cls, method };
+    }
+  } catch {
+    /* type unavailable */
+  }
+  return undefined;
+}
+
+/**
+ * Cheap syntactic predicate (NO codegen): does `expr` match a reflective
+ * collection-method `.call` shape this module dispatches? The caller
+ * (calls.ts) uses it to gate an `addUnionImports` BEFORE invoking
+ * {@link tryCompileCollectionReflectiveCall} — the arg-boxing (`__box_number`)
+ * the dispatch emits must be registered up-front, since adding it mid-body
+ * would shift indices (#2604).
+ */
+export function isCollectionReflectiveCallShape(ctx: CodegenContext, expr: ts.CallExpression): boolean {
+  if (!ctx.nativeStrings) return false;
+  if (!ts.isPropertyAccessExpression(expr.expression)) return false;
+  const dispatch = expr.expression;
+  if (dispatch.name.text !== "call") return false;
+  return collectionMethodTarget(ctx, dispatch.expression) !== undefined;
+}
+
+/**
+ * Compile a reflective collection-method `.call`. Returns the result
+ * `InnerResult` when handled, or `undefined` to fall through to the generic
+ * path (JS-host mode, non-collection closure, unsupported form).
+ */
+export function tryCompileCollectionReflectiveCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  if (!ts.isPropertyAccessExpression(expr.expression)) return undefined;
+  const dispatch = expr.expression; // `<closure>.call`
+  if (dispatch.name.text !== "call") return undefined; // .apply deferred
+  const target = collectionMethodTarget(ctx, dispatch.expression);
+  if (target === undefined) return undefined;
+  const { cls, method } = target;
+
+  // Register the class's native runtime (idempotent).
+  if (cls === "Map") ensureMapHelpers(ctx);
+  else if (cls === "Set") ensureSetHelpers(ctx);
+  else ensureWeakCollectionHelpers(ctx);
+  if (ctx.mapTypeIdx < 0) return undefined;
+
+  const brand = collectionBrandSpec(ctx, cls);
+  const callArgs = expr.arguments;
+  const recvExpr = callArgs.length > 0 ? callArgs[0]! : undefined;
+
+  // `.call()` with no receiver → `this` is undefined → unconditional brand
+  // TypeError. Uniform for every method: throw, then a null.extern sentinel
+  // keeps the (unreachable) expression result well-typed.
+  if (recvExpr === undefined) {
+    emitThrowTypeError(ctx, fctx, brand.message);
+    fctx.body.push({ op: "ref.null.extern" });
+    return { kind: "externref" } as ValType;
+  }
+
+  // forEach: shared native drive with the brand-checked receiver from arg0 and
+  // the callback from arg1. Bails (undefined) when the callback is not a
+  // compilable closure form — the generic path then keeps legacy behaviour.
+  if (method === "forEach") {
+    const inner = unwrapToPropertyAccess(dispatch.expression);
+    if (inner === undefined) return undefined;
+    return tryCompileNativeCollectionForEach(ctx, fctx, inner, expr, /* isSet */ cls === "Set", {
+      recvExpr,
+      cbArg: callArgs[1],
+      brand,
+    });
+  }
+
+  // keys/values/entries: eager vec materialization with the brand-checked
+  // receiver (same producer contract as the direct path).
+  if (method === "keys" || method === "values" || method === "entries") {
+    return emitCollectionIteratorVec(ctx, fctx, recvExpr, method, /* isSet */ cls === "Set", brand);
+  }
+
+  // Data methods → the shared `$Map` helpers.
+  const helperName = method === "add" ? (cls === "WeakSet" ? "__weakset_add" : "__set_add") : `__map_${method}`;
+  const helperIdx = ctx.mapHelpers.get(helperName);
+  if (helperIdx === undefined) return undefined;
+
+  const recvType = compileExpression(ctx, fctx, recvExpr);
+  emitReceiverBrandCheck(ctx, fctx, recvType, brand); // leaves (ref $Map)
+
+  switch (method) {
+    case "add": {
+      // (#2606 Bug A) null/undefined-literal element → canonical ref.null NONE_HEAP.
+      compileCollectionElementArg(ctx, fctx, callArgs[1]);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
+    }
+    case "get":
+    case "has":
+    case "delete": {
+      compileCollectionElementArg(ctx, fctx, callArgs[1]);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // get → anyref value; has/delete → i32 (boolean).
+      return method === "get" ? ({ kind: "anyref" } as ValType) : ({ kind: "i32" } as ValType);
+    }
+    case "set": {
+      compileCollectionElementArg(ctx, fctx, callArgs[1]);
+      compileCollectionElementArg(ctx, fctx, callArgs[2]);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // __map_set returns ref $Map (the collection) — chainable.
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
+    }
+    case "clear": {
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      return VOID_RESULT;
+    }
+  }
+  return undefined;
+}
+
+/** Unwrap parens/`as`/non-null down to the `X.prototype.METHOD` property access. */
+function unwrapToPropertyAccess(closure: ts.Expression): ts.PropertyAccessExpression | undefined {
+  let e: ts.Expression = closure;
+  while (ts.isParenthesizedExpression(e) || ts.isAsExpression(e) || ts.isNonNullExpression(e)) {
+    e = (e as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
+  }
+  return ts.isPropertyAccessExpression(e) ? e : undefined;
+}

--- a/src/codegen/collections-brand.ts
+++ b/src/codegen/collections-brand.ts
@@ -106,15 +106,13 @@ function collectionMethodTarget(
     if (COLLECTION_METHODS[cls].has(method)) return { cls, method };
     return undefined;
   }
-  // `<collectionExpr>.METHOD` where the expression is statically a lib collection.
-  try {
-    const symName = ctx.checker.getTypeAtLocation(obj).getSymbol()?.name;
-    if (symName !== undefined && symName in COLLECTION_METHODS) {
-      const cls = symName as CollectionClass;
-      if (COLLECTION_METHODS[cls].has(method)) return { cls, method };
-    }
-  } catch {
-    /* type unavailable */
+  // `<collectionExpr>.METHOD` where the expression is statically a lib
+  // collection. (#1930) Resolved through the oracle (`declaredNameOf` — the
+  // ratchet-sanctioned way to read the declared type-symbol name).
+  const symName = ctx.oracle.declaredNameOf(obj);
+  if (symName !== undefined && symName in COLLECTION_METHODS) {
+    const cls = symName as CollectionClass;
+    if (COLLECTION_METHODS[cls].has(method)) return { cls, method };
   }
   return undefined;
 }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -23,7 +23,7 @@ import { compileArrayMethodCall, compileArrayPrototypeCall, resolveArrayInfo } f
 import { emitGlobalThisGopdFold } from "../dyn-read.js"; // (#2984)
 import { mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S3b) stable-regime minting
 import { emitCollectionIteratorVec, ensureMapGroupBy } from "../map-runtime.js"; // (#42) native Set/Map → vec, shared with spread / Array.from; (#3149) native Map.groupBy
-import { isSetReflectiveCallShape, tryCompileSetReflectiveCall } from "../set-runtime.js"; // (#2604) Set.prototype.METHOD.call brand-check
+import { isCollectionReflectiveCallShape, tryCompileCollectionReflectiveCall } from "../collections-brand.js"; // (#2604/#3171) {Map,Set,WeakMap,WeakSet}.prototype.METHOD.call brand-check
 import { classMemberFuncKey, fnctorAncestorOfClass } from "../class-member-keys.js"; // (#1983 / #3123)
 import { ensureIterStepScratchGlobal, ensureNativeIteratorRuntime } from "../iterator-native.js"; // (#2169c) native Array.from drain / (#3146) Iterator-statics intrinsics
 import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "../closed-method-dispatch.js";
@@ -5484,18 +5484,20 @@ function compileCallExpression(
       const isCall = propAccess.name.text === "call";
       const innerExpr = propAccess.expression;
 
-      // (#2604) Reflective `Set.prototype.METHOD.call(recv, …)` /
-      // `inst.METHOD.call(recv, …)` — brand-check the receiver ([[SetData]]) and
-      // dispatch to the native Set runtime. Runs BEFORE the generic #2193
-      // member-closure recovery (which has no native-Set knowledge), and only
-      // matches a Set data-method closure under nativeStrings, so it ADDS a
-      // Set-specific pre-check without rewriting the generic path. addUnionImports
-      // up-front (mirrors extern.ts's direct-path setup) so the arg-boxing
-      // `__box_number` the dispatch emits is registered without a mid-body shift.
-      if (isSetReflectiveCallShape(ctx, expr)) {
+      // (#2604/#3171) Reflective `X.prototype.METHOD.call(recv, …)` /
+      // `inst.METHOD.call(recv, …)` for the four keyed collections — brand-check
+      // the receiver ([[MapData]]/[[SetData]]/[[WeakMapData]]/[[WeakSetData]],
+      // struct + COLLECTION_KIND tag) and dispatch to the native collection
+      // runtimes. Runs BEFORE the generic #2193 member-closure recovery (which
+      // has no native-collection knowledge), and only matches a collection
+      // method closure under nativeStrings, so it ADDS a collection-specific
+      // pre-check without rewriting the generic path. addUnionImports up-front
+      // (mirrors extern.ts's direct-path setup) so the arg-boxing `__box_number`
+      // the dispatch emits is registered without a mid-body shift.
+      if (isCollectionReflectiveCallShape(ctx, expr)) {
         addUnionImports(ctx);
-        const setReflResult = tryCompileSetReflectiveCall(ctx, fctx, expr);
-        if (setReflResult !== undefined) return setReflResult;
+        const collReflResult = tryCompileCollectionReflectiveCall(ctx, fctx, expr);
+        if (collReflResult !== undefined) return collReflResult;
       }
 
       // (#2193 PR-B) Reflective `m.call/apply(thisArg, …)` on a value-erased

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -35,7 +35,7 @@ import {
 } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper; (#3054 B1/B2) shared-backing TA views + windowing; (#3054 D) dynamic ctor construct
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { emitObjectCoercion } from "./calls-guards.js"; // (#3118) shared Object(...) / new Object(...) ToObject coercion
-import { ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
+import { COLLECTION_KIND, ensureMapHelpers, coerceMapKeyToAnyref } from "../map-runtime.js";
 import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
 import { ensureObjectRuntime } from "../object-runtime.js"; // (#1100) standalone Proxy native runtime
 import { ensureSetHelpers } from "../set-runtime.js";
@@ -2823,6 +2823,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       const mapNewIdx = ctx.mapHelpers.get("__map_new");
       const mapSetIdx = ctx.mapHelpers.get("__map_set");
       if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+        fctx.body.push({ op: "i32.const", value: COLLECTION_KIND.MAP }); // (#3171) brand tag
         fctx.body.push({ op: "call", funcIdx: mapNewIdx });
         if (seedablePairs && arrArg !== undefined && arrArg.elements.length > 0 && mapSetIdx !== undefined) {
           const mTmp = allocLocal(fctx, `__mapctor_m_${fctx.locals.length}`, {
@@ -2869,6 +2870,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       const mapNewIdx = ctx.mapHelpers.get("__map_new");
       const setAddIdx = ctx.mapHelpers.get("__set_add");
       if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+        fctx.body.push({ op: "i32.const", value: COLLECTION_KIND.SET }); // (#3171) brand tag
         fctx.body.push({ op: "call", funcIdx: mapNewIdx });
         if (arrArg && setAddIdx !== undefined && !arrArg.elements.some((e) => ts.isSpreadElement(e))) {
           const mTmp = allocLocal(fctx, `__setctor_m_${fctx.locals.length}`, {
@@ -2914,6 +2916,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     ensureWeakCollectionHelpers(ctx);
     const mapNewIdx = ctx.mapHelpers.get("__map_new");
     if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+      fctx.body.push({
+        op: "i32.const",
+        value: expr.expression.text === "WeakMap" ? COLLECTION_KIND.WEAKMAP : COLLECTION_KIND.WEAKSET,
+      }); // (#3171) brand tag
       fctx.body.push({ op: "call", funcIdx: mapNewIdx });
       return { kind: "ref", typeIdx: ctx.mapTypeIdx };
     }

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -32,6 +32,7 @@ import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./regis
 import type { InnerResult } from "./shared.js";
 import { compileArrowAsClosure, compileExpression, VOID_RESULT } from "./shared.js";
 import { isNullOrUndefinedLiteral } from "./destructuring-params.js";
+import { emitReceiverBrandCheck, type ReceiverBrandSpec } from "./receiver-brand.js";
 import { coercionInstrs } from "./type-coercion.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
@@ -60,11 +61,31 @@ export const MAP_LAYOUT = {
   M_ENTRIES: 1,
   M_ENTRYCOUNT: 2,
   M_LIVECOUNT: 3,
+  /** (#3171) Immutable collection-kind tag (COLLECTION_KIND), appended LAST so
+   *  every pre-existing field index stays valid. */
+  M_KIND: 4,
   F_KEY: 0,
   F_VALUE: 1,
   F_HASH: 3,
   TOMBSTONE_BIT,
 } as const;
+
+/**
+ * (#3171) Which keyed collection a `$Map` struct instance backs. All four
+ * collections share the `$Map` hash table (Set/WeakSet store key === value), so
+ * struct identity alone cannot distinguish `[[MapData]]` / `[[SetData]]` /
+ * `[[WeakMapData]]` / `[[WeakSetData]]` for the spec receiver brand checks
+ * (`Map.prototype.get.call(new Set())` must throw a TypeError). The immutable
+ * `kind` field (MAP_LAYOUT.M_KIND), stamped at construction by `__map_new`,
+ * carries the brand.
+ */
+export const COLLECTION_KIND = {
+  MAP: 0,
+  SET: 1,
+  WEAKMAP: 2,
+  WEAKSET: 3,
+} as const;
+export type CollectionKind = (typeof COLLECTION_KIND)[keyof typeof COLLECTION_KIND];
 
 /**
  * Register the WasmGC struct/array types backing the native Map. Idempotent.
@@ -123,6 +144,8 @@ export function ensureMapRuntimeTypes(ctx: CodegenContext): void {
       },
       { name: "entryCount", type: { kind: "i32" }, mutable: true },
       { name: "liveCount", type: { kind: "i32" }, mutable: true },
+      // (#3171) COLLECTION_KIND brand tag, trailing + immutable — see MAP_LAYOUT.
+      { name: "kind", type: { kind: "i32" }, mutable: false },
     ],
   } as StructTypeDef);
   ctx.structMap.set("Map", ctx.mapTypeIdx);
@@ -520,7 +543,10 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
   // pass (declareHashLocals) to guarantee indices 1..7 line up; see below.
   fixHashLocals(ctx);
 
-  // ── __map_new() -> ref $Map ─────────────────────────────────────────────
+  // ── __map_new(kind: i32) -> ref $Map ────────────────────────────────────
+  // (#3171) `kind` is the COLLECTION_KIND brand tag (0=Map 1=Set 2=WeakMap
+  // 3=WeakSet) stamped immutably at construction — every construction site
+  // (new-super.ts ctors, set-algebra results, groupBy) passes its brand.
   {
     const body: Instr[] = [
       // buckets: array.new i32 of length INIT_CAP, all -1
@@ -536,9 +562,11 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
       // entryCount=0, liveCount=0
       { op: "i32.const", value: 0 },
       { op: "i32.const", value: 0 },
+      // kind (trailing brand field)
+      { op: "local.get", index: 0 },
       { op: "struct.new", typeIdx: ctx.mapTypeIdx },
     ];
-    addMapFunc(ctx, "__map_new", [], [mref], [], body);
+    addMapFunc(ctx, "__map_new", [i32], [mref], [], body);
   }
 
   const hashIdx = ctx.mapHelpers.get("__hash_anyref")!;
@@ -1216,6 +1244,7 @@ export function ensureMapGroupBy(ctx: CodegenContext): number {
   //         6=keyExt(externref) 7=keyAny(anyref) 8=groupAny(anyref)
   //         9=groupExt(externref) 10=args(externref)
   const body: Instr[] = [
+    { op: "i32.const", value: COLLECTION_KIND.MAP }, // (#3171) groupBy returns a real Map
     { op: "call", funcIdx: mapNewIdx },
     { op: "local.set", index: 2 },
     { op: "local.get", index: 0 },
@@ -1570,13 +1599,18 @@ export function tryCompileNativeCollectionForEach(
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
   isSet: boolean,
+  // (#3171) Reflective `X.prototype.forEach.call(recv, cb)` re-entry: receiver
+  // and callback come from the `.call` argument list, and the receiver goes
+  // through the shared brand-check preamble (catchable TypeError on a
+  // wrong-brand receiver) instead of the static trapping cast.
+  reflective?: { recvExpr: ts.Expression; cbArg: ts.Expression | undefined; brand: ReceiverBrandSpec },
 ): InnerResult | undefined {
   if (!ctx.nativeStrings) return undefined;
   if (propAccess.name.text !== "forEach") return undefined;
   ensureMapHelpers(ctx);
   if (ctx.mapTypeIdx < 0) return undefined;
 
-  const cbArg = callExpr.arguments[0];
+  const cbArg = reflective !== undefined ? reflective.cbArg : callExpr.arguments[0];
   if (cbArg === undefined) return undefined;
   // Only handle Wasm-closure callbacks (arrow / function expr / named fn ref).
   const willBeClosure =
@@ -1593,16 +1627,21 @@ export function tryCompileNativeCollectionForEach(
   const F_HASH = 3;
   const anyref: ValType = { kind: "anyref" };
 
-  // Receiver → ref $Map, stored in a temp.
-  const recvType = compileExpression(ctx, fctx, propAccess.expression);
-  if (recvType === null) return undefined;
-  if (recvType.kind === "externref") {
-    fctx.body.push({ op: "any.convert_extern" } as Instr);
-    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
-  } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
-    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
-  } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
-    return undefined;
+  // Receiver → ref $Map, stored in a temp. Reflective callers brand-check
+  // (catchable TypeError); the direct path keeps the static cast/bail.
+  const recvType = compileExpression(ctx, fctx, reflective !== undefined ? reflective.recvExpr : propAccess.expression);
+  if (reflective !== undefined) {
+    emitReceiverBrandCheck(ctx, fctx, recvType, reflective.brand);
+  } else {
+    if (recvType === null) return undefined;
+    if (recvType.kind === "externref") {
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+    } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+    } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
+      return undefined;
+    }
   }
   const mTmp = allocLocal(fctx, `__mfe_m_${fctx.locals.length}`, {
     kind: "ref",
@@ -1814,6 +1853,10 @@ export function emitCollectionIteratorVec(
   receiver: ts.Expression,
   kind: "keys" | "values" | "entries",
   isSet: boolean,
+  // (#3171) Reflective `X.prototype.{keys,values,entries}.call(recv)` re-entry:
+  // the receiver goes through the shared brand-check preamble (catchable
+  // TypeError on a wrong-brand receiver) instead of the static cast/bail.
+  brand?: ReceiverBrandSpec,
 ): InnerResult | undefined {
   if (!ctx.nativeStrings) return undefined;
   ensureMapHelpers(ctx);
@@ -1842,16 +1885,21 @@ export function emitCollectionIteratorVec(
     objVecPushIdx = builders.pushIdx;
   }
 
-  // Receiver → ref $Map, stored in a temp.
+  // Receiver → ref $Map, stored in a temp. Reflective callers brand-check
+  // (catchable TypeError); the direct path keeps the static cast/bail.
   const recvType = compileExpression(ctx, fctx, receiver);
-  if (recvType === null) return undefined;
-  if (recvType.kind === "externref") {
-    fctx.body.push({ op: "any.convert_extern" } as Instr);
-    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
-  } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
-    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
-  } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
-    return undefined;
+  if (brand !== undefined) {
+    emitReceiverBrandCheck(ctx, fctx, recvType, brand);
+  } else {
+    if (recvType === null) return undefined;
+    if (recvType.kind === "externref") {
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+    } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
+      fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+    } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
+      return undefined;
+    }
   }
   const mTmp = allocLocal(fctx, `__mit_m_${fctx.locals.length}`, {
     kind: "ref",

--- a/src/codegen/receiver-brand.ts
+++ b/src/codegen/receiver-brand.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3171) Shared receiver brand-check preamble for reflectively-invoked builtin
+ * prototype methods — the spec's step-1/2 "If `this` does not have a [[X]]
+ * internal slot, throw a TypeError" gate, generalized from the #2604
+ * `emitSetBrandCheck` so every brand-carrying builtin family parameterizes ONE
+ * helper instead of hand-rolling copies:
+ *
+ *   - Map/Set/WeakMap/WeakSet (#3171): struct brand `$Map` + the
+ *     `COLLECTION_KIND` tag field ([[MapData]] vs [[SetData]] vs
+ *     [[WeakMapData]] vs [[WeakSetData]] — the four share the `$Map` backing
+ *     store, so struct identity alone cannot separate them).
+ *   - Set-algebra argument validation (#2607/#3172): struct brand `$Map`,
+ *     kind-lenient (a Map IS spec "set-like" — it has size/has/keys).
+ *   - Date (#3174): struct brand only (`$Date` has no sharing to disambiguate).
+ *
+ * Precedent: the #2893 `$__ta_dyn_view` TypedArray view-brand check — a
+ * NON-TRAPPING `ref.test` (never `ref.cast`: a cast miss traps `illegal cast`,
+ * which `assert.throws(TypeError, …)` does NOT accept) branching to a
+ * *catchable* TypeError instance on the miss arm.
+ *
+ * Contract: consumes the just-compiled receiver value on the stack (`recvType`
+ * describes it) and leaves a non-null `(ref spec.structTypeIdx)` — the
+ * validated backing struct — on the stack. On a brand miss the emitted code
+ * throws before reaching the downstream helper call; an unreachable null
+ * sentinel keeps the stack well-typed.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import { allocTempLocal, releaseTempLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { emitThrowTypeError } from "./expressions/helpers.js";
+
+/** WasmGC `none` bottom heap type (signed LEB -18); `ref.null none` is the
+ *  canonical null anyref subtype (mirrors map-runtime's NONE_HEAP). */
+const NONE_HEAP = -18;
+
+/** What a receiver must be to pass the brand gate. */
+export type ReceiverBrandSpec = {
+  /** TypeError message on a brand miss (test262 only checks the constructor,
+   *  but a stable V8-style message keeps failure signatures greppable). */
+  message: string;
+  /** The WasmGC struct type the receiver must be (`ref.test` target). */
+  structTypeIdx: number;
+  /**
+   * Optional refinement for struct types SHARED by several builtin brands
+   * (e.g. `$Map` backs all four keyed collections): an immutable i32 tag
+   * field that must hold one of `accept`. Omit for a struct-only check.
+   */
+  kindField?: { fieldIdx: number; accept: readonly number[] };
+};
+
+/**
+ * Emit the brand-check preamble. Consumes the receiver value on the stack
+ * (described by `recvType`; `null` = statically void/absent) and leaves a
+ * non-null `(ref spec.structTypeIdx)` on the stack; a runtime brand miss
+ * throws a catchable TypeError instead.
+ */
+export function emitReceiverBrandCheck(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  recvType: ValType | null,
+  spec: ReceiverBrandSpec,
+): void {
+  // Normalise the receiver to an anyref so `ref.test`/`ref.cast` apply
+  // uniformly across externref / ref-struct / primitive-typed receivers.
+  if (recvType === null) {
+    // Statically void/never receiver — a null anyref misses the test below.
+    fctx.body.push({ op: "ref.null", typeIdx: NONE_HEAP } as Instr);
+  } else if (recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+  } else if (
+    recvType.kind === "i32" ||
+    recvType.kind === "f64" ||
+    recvType.kind === "i64" ||
+    recvType.kind === "funcref"
+  ) {
+    // A primitive scalar (or bare funcref) receiver can never be the backing
+    // struct — drop it and throw unconditionally.
+    fctx.body.push({ op: "drop" } as Instr);
+    emitReceiverBrandThrow(ctx, fctx, spec);
+    return;
+  }
+  // Receiver is now an anyref (or a ref/eqref subtype) on the stack.
+  const recvTmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
+  fctx.body.push({ op: "local.tee", index: recvTmp } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: spec.structTypeIdx } as Instr);
+
+  // Optional kind-tag refinement: pass = structTest && (kind ∈ accept).
+  const kindField = spec.kindField;
+  if (kindField !== undefined && kindField.accept.length > 0) {
+    const readKind: Instr[] = [
+      { op: "local.get", index: recvTmp } as Instr,
+      { op: "ref.cast", typeIdx: spec.structTypeIdx } as Instr, // safe: struct test passed
+      { op: "struct.get", typeIdx: spec.structTypeIdx, fieldIdx: kindField.fieldIdx } as unknown as Instr,
+    ];
+    let acceptTest: Instr[];
+    if (kindField.accept.length === 1) {
+      acceptTest = [...readKind, { op: "i32.const", value: kindField.accept[0]! } as Instr, { op: "i32.eq" } as Instr];
+    } else {
+      const kindTmp = allocTempLocal(fctx, { kind: "i32" } as ValType);
+      acceptTest = [...readKind, { op: "local.set", index: kindTmp } as Instr];
+      kindField.accept.forEach((k, i) => {
+        acceptTest.push({ op: "local.get", index: kindTmp } as Instr);
+        acceptTest.push({ op: "i32.const", value: k } as Instr);
+        acceptTest.push({ op: "i32.eq" } as Instr);
+        if (i > 0) acceptTest.push({ op: "i32.or" } as Instr);
+      });
+      releaseTempLocal(fctx, kindTmp);
+    }
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: acceptTest,
+      else: [{ op: "i32.const", value: 0 } as Instr],
+    } as Instr);
+  }
+
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [],
+    else: [],
+  } as Instr);
+  // Build the throw into the else arm via a temporary body swap so the
+  // late-import shift in emitThrowTypeError patches the right buffer (#2604).
+  const ifInstr = fctx.body[fctx.body.length - 1] as unknown as { else: Instr[] };
+  const savedBody = fctx.body;
+  fctx.body = ifInstr.else;
+  emitThrowTypeError(ctx, fctx, spec.message);
+  fctx.body = savedBody;
+  // Hit: cast the saved receiver to the concrete backing struct.
+  fctx.body.push({ op: "local.get", index: recvTmp } as Instr);
+  fctx.body.push({ op: "ref.cast", typeIdx: spec.structTypeIdx } as Instr);
+  releaseTempLocal(fctx, recvTmp);
+}
+
+/**
+ * Emit an UNCONDITIONAL brand-miss throw (receiver statically absent — e.g.
+ * `X.prototype.m.call()` with no argument, `this` = undefined — or statically
+ * a scalar). Leaves an (unreachable) null `(ref_null spec.structTypeIdx)`
+ * sentinel on the stack so the downstream call still typechecks; callers that
+ * need a NON-null ref must `ref.as_non_null`… in practice the sentinel feeds a
+ * helper param typed `(ref $T)`, so we cast it non-null via `ref.as_non_null`
+ * here — the instruction is never reached.
+ */
+export function emitReceiverBrandThrow(ctx: CodegenContext, fctx: FunctionContext, spec: ReceiverBrandSpec): void {
+  emitThrowTypeError(ctx, fctx, spec.message);
+  fctx.body.push({ op: "ref.null", typeIdx: spec.structTypeIdx } as Instr);
+  fctx.body.push({ op: "ref.as_non_null" } as Instr);
+}

--- a/src/codegen/set-algebra.ts
+++ b/src/codegen/set-algebra.ts
@@ -30,7 +30,7 @@ import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
-import { ensureMapHelpers } from "./map-runtime.js";
+import { COLLECTION_KIND, ensureMapHelpers } from "./map-runtime.js";
 import { emitSetBrandCheck, ensureSetHelpers } from "./set-runtime.js";
 
 const TOMBSTONE_BIT = 0x40000000; // mirrors map-runtime.ts
@@ -148,6 +148,7 @@ export function ensureSetAlgebraHelpers(ctx: CodegenContext): void {
   // ── union(a,b): copy all of a, then all of b (set_add dedups). ───────────
   {
     const body: Instr[] = [
+      { op: "i32.const", value: COLLECTION_KIND.SET } as Instr, // (#3171) result is a Set
       { op: "call", funcIdx: mapNew } as Instr,
       { op: "local.set", index: RES } as Instr,
       { op: "i32.const", value: 0 } as Instr,
@@ -176,6 +177,7 @@ export function ensureSetAlgebraHelpers(ctx: CodegenContext): void {
       } as Instr,
     ];
     const body: Instr[] = [
+      { op: "i32.const", value: COLLECTION_KIND.SET } as Instr, // (#3171) result is a Set
       { op: "call", funcIdx: mapNew } as Instr,
       { op: "local.set", index: RES } as Instr,
       { op: "i32.const", value: 0 } as Instr,
@@ -201,6 +203,7 @@ export function ensureSetAlgebraHelpers(ctx: CodegenContext): void {
       } as Instr,
     ];
     const body: Instr[] = [
+      { op: "i32.const", value: COLLECTION_KIND.SET } as Instr, // (#3171) result is a Set
       { op: "call", funcIdx: mapNew } as Instr,
       { op: "local.set", index: RES } as Instr,
       { op: "i32.const", value: 0 } as Instr,
@@ -229,6 +232,7 @@ export function ensureSetAlgebraHelpers(ctx: CodegenContext): void {
       { op: "if", blockType: { kind: "empty" }, then: addValToResult(), else: [] } as Instr,
     ];
     const body: Instr[] = [
+      { op: "i32.const", value: COLLECTION_KIND.SET } as Instr, // (#3171) result is a Set
       { op: "call", funcIdx: mapNew } as Instr,
       { op: "local.set", index: RES } as Instr,
       { op: "i32.const", value: 0 } as Instr,

--- a/src/codegen/set-runtime.ts
+++ b/src/codegen/set-runtime.ts
@@ -31,23 +31,18 @@ import type { Instr, ValType } from "../ir/types.js";
  * (`union`/`intersection`/…) are follow-up slices.
  */
 import { ts } from "../ts-api.js";
-import { allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { emitThrowTypeError } from "./expressions/helpers.js";
 import {
   compileCollectionElementArg,
   compileNativeCollectionIterator,
   ensureMapHelpers,
   tryCompileNativeCollectionForEach,
 } from "./map-runtime.js";
+import { emitReceiverBrandCheck } from "./receiver-brand.js";
 import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { VOID_RESULT, compileExpression } from "./shared.js";
-
-/** Set.prototype methods whose `[[SetData]]` brand-check + native dispatch this
- *  module owns (the data + iteration methods; set-algebra lives in set-algebra.ts). */
-const SET_BRAND_METHODS = new Set(["add", "has", "delete", "clear", "forEach", "entries", "keys", "values"]);
 
 /**
  * Emit the `__set_add(m, v) -> ref $Map` helper (idempotent). `Set.add` stores
@@ -116,51 +111,21 @@ function castReceiverToMap(ctx: CodegenContext, fctx: FunctionContext, recvType:
  * `assert.throws(TypeError, …)` does not accept). On a hit the value is
  * `ref.cast`-ed (safe — the test passed) to `(ref $Map)`.
  *
- * NOTE: a real `Map`/`WeakSet` is ALSO `$Map`-backed and passes `ref.test $Map`;
- * distinguishing Set from Map/Weak by struct alone is not possible without a
- * kind tag (the `does-not-have-setdata-internal-slot-{map,weakset}.js` sub-rows,
- * a documented stretch — #2604). The primitive / plain-object / array / null
- * rows (the bulk) flip here.
+ * NOTE: a real `Map`/`WeakSet` is ALSO `$Map`-backed and passes `ref.test $Map` —
+ * this struct-only variant is deliberately kind-LENIENT (see body). The
+ * kind-tagged receiver checks (`does-not-have-setdata-internal-slot-{map,weakset}`)
+ * live in collections-brand.ts (#3171).
  */
 export function emitSetBrandCheck(ctx: CodegenContext, fctx: FunctionContext, recvType: ValType | null): void {
-  // Normalise the receiver to an anyref so `ref.test`/`ref.cast` apply uniformly
-  // across externref / ref-struct / primitive-typed receivers.
-  if (recvType === null) {
-    // A statically void/never receiver — emit a null anyref so the test misses.
-    fctx.body.push({ op: "ref.null", typeIdx: -1 } as unknown as Instr);
-  } else if (recvType.kind === "externref") {
-    fctx.body.push({ op: "any.convert_extern" } as Instr);
-  } else if (recvType.kind === "i32" || recvType.kind === "f64" || recvType.kind === "i64") {
-    // A primitive scalar receiver (`Set.prototype.add.call(0, …)` etc.) can never
-    // be the backing struct — drop it and throw unconditionally.
-    fctx.body.push({ op: "drop" } as Instr);
-    emitThrowTypeError(ctx, fctx, "TypeError: Method Set.prototype.* called on incompatible receiver");
-    // After the throw the stack is polymorphic; push a null $Map sentinel so the
-    // (unreached) downstream call typechecks.
-    fctx.body.push({ op: "ref.null", typeIdx: ctx.mapTypeIdx } as Instr);
-    return;
-  }
-  // Receiver is now an anyref (or already a ref/eqref subtype) on the stack.
-  const recvTmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
-  fctx.body.push({ op: "local.tee", index: recvTmp } as Instr);
-  fctx.body.push({ op: "ref.test", typeIdx: ctx.mapTypeIdx } as Instr);
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "empty" },
-    then: [],
-    else: [],
-  } as Instr);
-  // Build the throw into the else arm via a temporary body swap so the late-import
-  // shift in emitThrowTypeError patches the right buffer.
-  const ifInstr = fctx.body[fctx.body.length - 1] as unknown as { else: Instr[] };
-  const savedBody = fctx.body;
-  fctx.body = ifInstr.else;
-  emitThrowTypeError(ctx, fctx, "TypeError: Method Set.prototype.* called on incompatible receiver");
-  fctx.body = savedBody;
-  // Hit: cast the saved receiver to the concrete backing struct.
-  fctx.body.push({ op: "local.get", index: recvTmp } as Instr);
-  fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
-  releaseTempLocal(fctx, recvTmp);
+  // (#3171) Delegates to the shared receiver-brand preamble. STRUCT-ONLY on
+  // purpose (no COLLECTION_KIND refinement): the remaining caller is the
+  // set-algebra ARGUMENT validation (#2607), where a kind-lenient check is the
+  // preserved behaviour (a Map is spec "set-like" — it has size/has/keys).
+  // Receiver brand checks with the kind refinement live in collections-brand.ts.
+  emitReceiverBrandCheck(ctx, fctx, recvType, {
+    message: "TypeError: Method Set.prototype.* called on incompatible receiver",
+    structTypeIdx: ctx.mapTypeIdx,
+  });
 }
 
 /**
@@ -223,127 +188,6 @@ export function tryCompileNativeSetMethodCall(
       compileCollectionElementArg(ctx, fctx, args[0]);
       fctx.body.push({ op: "call", funcIdx: helperIdx });
       // has/delete → i32 (boolean).
-      return { kind: "i32" } as ValType;
-    }
-    case "clear": {
-      fctx.body.push({ op: "call", funcIdx: helperIdx });
-      return VOID_RESULT;
-    }
-  }
-  return undefined;
-}
-
-/**
- * (#2604) Is `expr` syntactically `X.METHOD` where METHOD is a Set data method
- * and X is `Set.prototype` or a statically Set-typed expression? Used to gate the
- * reflective `.call`/`.apply` brand-check dispatch.
- */
-function setMethodClosureName(ctx: CodegenContext, closure: ts.Expression): string | undefined {
-  let e: ts.Expression = closure;
-  while (ts.isParenthesizedExpression(e) || ts.isAsExpression(e) || ts.isNonNullExpression(e)) {
-    e = (e as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
-  }
-  if (!ts.isPropertyAccessExpression(e)) return undefined;
-  const method = e.name.text;
-  if (!SET_BRAND_METHODS.has(method)) return undefined;
-  const obj = e.expression;
-  // `Set.prototype.METHOD`
-  if (
-    ts.isPropertyAccessExpression(obj) &&
-    obj.name.text === "prototype" &&
-    ts.isIdentifier(obj.expression) &&
-    obj.expression.text === "Set"
-  ) {
-    return method;
-  }
-  // `<setExpr>.METHOD` where setExpr is statically a Set.
-  try {
-    const t = ctx.checker.getTypeAtLocation(obj);
-    if (t.getSymbol()?.name === "Set") return method;
-  } catch {
-    /* type unavailable */
-  }
-  return undefined;
-}
-
-/**
- * (#2604) Reflective `Set.prototype.METHOD.call(recv, …)` /
- * `inst.METHOD.call(recv, …)` dispatch with a `[[SetData]]` brand-check.
- *
- * The direct `s.METHOD(v)` shape is handled by {@link tryCompileNativeSetMethodCall}
- * (gated on the receiver's static `className === "Set"`); the reflective `.call`
- * shape never reaches it, so neither the native dispatch nor the spec brand-check
- * (24.2.3.* "If S does not have a [[SetData]] internal slot, throw a TypeError")
- * fires. This handler recognises the `.call` form, compiles the FIRST `.call`
- * argument as the receiver, brand-checks it ({@link emitSetBrandCheck} →
- * catchable TypeError on a non-Set), then routes the remaining args to the same
- * `__set_add`/`__map_has`/`__map_delete`/`__map_clear` helpers.
- *
- * Returns the result `InnerResult` when handled, or `undefined` to fall through.
- * Scoped to add/has/delete/clear (the bulk of the ~84-row brand-check bucket);
- * forEach/keys/values/entries reflective forms fall through (rarer). `.apply`
- * (packed-args) is deferred — only `.call` is intercepted here.
- */
-/**
- * (#2604) Cheap syntactic predicate (NO codegen): does `expr` match the
- * reflective Set data-method `.call` shape this module dispatches? The caller
- * (calls.ts) uses it to gate an `addUnionImports` BEFORE invoking
- * {@link tryCompileSetReflectiveCall} — the arg-boxing (`__box_number`) the
- * dispatch emits must be registered up-front (the direct path relies on
- * extern.ts doing the same), since adding it mid-body would shift indices.
- */
-export function isSetReflectiveCallShape(ctx: CodegenContext, expr: ts.CallExpression): boolean {
-  if (!ctx.nativeStrings) return false;
-  if (!ts.isPropertyAccessExpression(expr.expression)) return false;
-  const dispatch = expr.expression;
-  if (dispatch.name.text !== "call") return false;
-  const method = setMethodClosureName(ctx, dispatch.expression);
-  return method === "add" || method === "has" || method === "delete" || method === "clear";
-}
-
-export function tryCompileSetReflectiveCall(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  expr: ts.CallExpression,
-): InnerResult | undefined {
-  if (!ctx.nativeStrings) return undefined;
-  if (!ts.isPropertyAccessExpression(expr.expression)) return undefined;
-  const dispatch = expr.expression; // `<closure>.call`
-  if (dispatch.name.text !== "call") return undefined; // .apply deferred
-  const method = setMethodClosureName(ctx, dispatch.expression);
-  if (method === undefined) return undefined;
-  // Only the data methods are dispatched here; forEach/iterators fall through.
-  if (method !== "add" && method !== "has" && method !== "delete" && method !== "clear") return undefined;
-
-  ensureSetHelpers(ctx);
-  if (ctx.mapTypeIdx < 0) return undefined;
-  const helperName = method === "add" ? "__set_add" : `__map_${method}`;
-  const helperIdx = ctx.mapHelpers.get(helperName);
-  if (helperIdx === undefined) return undefined;
-
-  const callArgs = expr.arguments;
-  // `Set.prototype.add.call(recv, v)` — arg0 is the receiver, arg1.. are method args.
-  const recvExpr = callArgs.length > 0 ? callArgs[0]! : undefined;
-  const recvType = recvExpr ? compileExpression(ctx, fctx, recvExpr) : null;
-  if (recvExpr === undefined) {
-    // `.call()` with no receiver → `this` is undefined → TypeError.
-    emitThrowTypeError(ctx, fctx, "TypeError: Method Set.prototype.* called on incompatible receiver");
-    fctx.body.push({ op: "ref.null", typeIdx: ctx.mapTypeIdx } as Instr);
-  } else {
-    emitSetBrandCheck(ctx, fctx, recvType); // leaves (ref $Map) on the stack
-  }
-
-  switch (method) {
-    case "add": {
-      // (#2606 Bug A) null/undefined-literal element → canonical ref.null NONE_HEAP.
-      compileCollectionElementArg(ctx, fctx, callArgs[1]);
-      fctx.body.push({ op: "call", funcIdx: helperIdx });
-      return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
-    }
-    case "has":
-    case "delete": {
-      compileCollectionElementArg(ctx, fctx, callArgs[1]);
-      fctx.body.push({ op: "call", funcIdx: helperIdx });
       return { kind: "i32" } as ValType;
     }
     case "clear": {

--- a/tests/issue-3171.test.ts
+++ b/tests/issue-3171.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #3171 — standalone Map/Set/WeakMap/WeakSet receiver brand-check protocol.
+//
+// Spec §24.1.3.*/§24.2.4.*/§24.3.3.*/§24.4.3.* step 1/2: a prototype method
+// invoked with a `this` lacking the right internal slot ([[MapData]] /
+// [[SetData]] / [[WeakMapData]] / [[WeakSetData]]) throws a TypeError. Two
+// layers land here:
+//
+//   1. The #2604 Set-only reflective `.call` dispatch is generalized to ALL
+//      FOUR collections and ALL their prototype methods (data methods +
+//      keys/values/entries + forEach) — collections-brand.ts, routing through
+//      the shared `emitReceiverBrandCheck` preamble (receiver-brand.ts).
+//   2. A trailing immutable COLLECTION_KIND tag on the shared `$Map` backing
+//      struct (stamped by `__map_new` at every construction site) separates
+//      the four brands, so wrong-brand-but-collection receivers
+//      (`Map.prototype.get.call(new Set())`) also throw.
+//
+// The thrown error is a real catchable TypeError instance (ref.test →
+// branch → throw; never a trapping ref.cast).
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const io = r.importObject as WebAssembly.Imports & { __setExports?: (e: Record<string, unknown>) => void };
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports as Record<string, unknown>);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+// 1 = TypeError thrown; 0 = no throw; 2 = wrong error type.
+const throwsFor = (cls: string, method: string, recv: string, args = "") =>
+  `export function test(): number {
+     try { ${cls}.prototype.${method}.call(${recv} as any${args}); return 0; }
+     catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+   }`;
+
+describe("#3171 wrong-shape receivers throw TypeError (this-not-object / no-internal-slot rows)", () => {
+  const rows: [cls: string, method: string, recv: string, args: string][] = [
+    ["Map", "get", "{}", ", 1"],
+    ["Map", "get", "[]", ", 1"],
+    ["Map", "get", "null", ", 1"],
+    ["Map", "get", "undefined", ", 1"],
+    ["Map", "get", "''", ", 1"],
+    ["Map", "get", "0", ", 1"],
+    ["Map", "get", "false", ", 1"],
+    ["Map", "set", "{}", ", 1, 2"],
+    ["Map", "has", "undefined", ", 1"],
+    ["Map", "delete", "1", ", 1"],
+    ["Map", "keys", "{}", ""],
+    ["Map", "values", "[]", ""],
+    ["Map", "entries", "[]", ""],
+    ["Map", "forEach", "null", ", function() {}"],
+    ["Set", "entries", "Set.prototype", ""],
+    ["Set", "entries", "{}", ""],
+    ["Set", "values", "{}", ""],
+    ["Set", "forEach", "{}", ", function() {}"],
+    ["WeakMap", "get", "{}", ", {}"],
+    ["WeakMap", "set", "0", ", {}, 1"],
+    ["WeakMap", "has", "''", ", {}"],
+    ["WeakMap", "delete", "null", ", {}"],
+    ["WeakSet", "add", "{}", ", {}"],
+    ["WeakSet", "has", "[]", ", {}"],
+    ["WeakSet", "delete", "null", ", {}"],
+  ];
+  for (const [cls, method, recv, args] of rows) {
+    it(`${cls}.prototype.${method}.call(${recv}) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(cls, method, recv, args))).toBe(1);
+    });
+  }
+});
+
+describe("#3171 cross-collection receivers throw (COLLECTION_KIND tag)", () => {
+  const rows: [cls: string, method: string, recv: string, args: string][] = [
+    ["Map", "get", "new Set()", ", 1"],
+    ["Map", "get", "new WeakMap()", ", 1"],
+    ["Map", "entries", "new Set()", ""],
+    ["Set", "add", "new Map()", ", 1"],
+    ["Set", "has", "new WeakSet()", ", 1"],
+    ["Set", "entries", "new Map()", ""],
+    ["WeakMap", "set", "new Map()", ", {}, 1"],
+    ["WeakSet", "add", "new Set()", ", {}"],
+  ];
+  for (const [cls, method, recv, args] of rows) {
+    it(`${cls}.prototype.${method}.call(${recv}) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(cls, method, recv, args))).toBe(1);
+    });
+  }
+});
+
+describe("#3171 instance-form reflective calls brand-check too", () => {
+  it("m.get.call({}) → TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const m = new Map();
+           try { m.get.call({} as any, 1); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+  it("ws.add.call(new Set(), {}) → TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const ws = new WeakSet();
+           try { ws.add.call(new Set() as any, {}); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#3171 valid receivers still dispatch natively through .call", () => {
+  it("Map.prototype.get.call(realMap, k)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const m = new Map();
+           m.set(1, 42);
+           return Map.prototype.get.call(m, 1) as number;
+         }`,
+      ),
+    ).toBe(42);
+  });
+  it("Set.prototype.has.call(realSet, v)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const s = new Set([7]);
+           return Set.prototype.has.call(s, 7) ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+  it("WeakMap.prototype.get.call(realWeakMap, k)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const k = {};
+           const wm = new WeakMap();
+           wm.set(k, 9);
+           return WeakMap.prototype.get.call(wm, k) as number;
+         }`,
+      ),
+    ).toBe(9);
+  });
+  it("Set.prototype.forEach.call(realSet, cb) drives the native loop", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const s = new Set([1, 2, 3]);
+           let sum = 0;
+           Set.prototype.forEach.call(s, function (v: number) { sum += v; });
+           return sum;
+         }`,
+      ),
+    ).toBe(6);
+  });
+  it("Map.prototype.set.call chains (returns the map)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const m = new Map();
+           Map.prototype.set.call(m, "a", 5);
+           return m.get("a") as number;
+         }`,
+      ),
+    ).toBe(5);
+  });
+});
+
+describe("#3171 construction sites stamp the right COLLECTION_KIND (no collateral)", () => {
+  it("direct map/set/weak ops unregressed", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const m = new Map();
+           m.set("a", 1);
+           const s = new Set([1, 2, 2]);
+           const wm = new WeakMap();
+           const k = {};
+           wm.set(k, 5);
+           const ws = new WeakSet();
+           ws.add(k);
+           return (m.get("a") as number) + s.size + (wm.get(k) as number) + (ws.has(k) ? 1 : 0);
+         }`,
+      ),
+    ).toBe(9);
+  });
+  it("set-algebra result is Set-branded (usable as a Set receiver)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const a = new Set([1, 2]);
+           const u = a.union(new Set([3]));
+           return (Set.prototype.has.call(u, 3) ? 1 : 0) + u.size;
+         }`,
+      ),
+    ).toBe(4);
+  });
+  it("Map.groupBy result is Map-branded (rejects Set methods)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g = Map.groupBy([1, 2, 3], (x: number) => (x % 2 === 0 ? "e" : "o"));
+           try { Set.prototype.has.call(g as any, "o"); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+});

--- a/tests/issue-3171.test.ts
+++ b/tests/issue-3171.test.ts
@@ -173,6 +173,68 @@ describe("#3171 valid receivers still dispatch natively through .call", () => {
   });
 });
 
+describe("#3171 size accessor getter through gOPD brand-checks its receiver", () => {
+  it("gOPD(Map.prototype,'size').get.call(map) works; .call(new Set()) throws", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+           const map = new Map();
+           map.set(1, 2);
+           if ((descriptor as any).get.call(map) !== 1) return 3;
+           try { (descriptor as any).get.call(new Set()); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+  it("gOPD(Map.prototype,'size').get.call({}) throws", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+           try { (descriptor as any).get.call({}); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+  it("gOPD(Map.prototype,'size').get.call(false) throws (this-not-object)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const descriptor = Object.getOwnPropertyDescriptor(Map.prototype, 'size');
+           try { (descriptor as any).get.call(false); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+  it("gOPD(Set.prototype,'size').get.call(set) returns the size", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const descriptor = Object.getOwnPropertyDescriptor(Set.prototype, 'size');
+           const s = new Set([1, 2, 3]);
+           return (descriptor as any).get.call(s);
+         }`,
+      ),
+    ).toBe(3);
+  });
+  it("direct m.size / s.size unregressed", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const m = new Map();
+           m.set(1, 2);
+           const s = new Set([1, 2]);
+           return m.size + s.size;
+         }`,
+      ),
+    ).toBe(3);
+  });
+});
+
 describe("#3171 construction sites stamp the right COLLECTION_KIND (no collateral)", () => {
   it("direct map/set/weak ops unregressed", async () => {
     expect(


### PR DESCRIPTION
## Summary

Implements the spec §24.x step-1/2 receiver brand-check protocol for the four keyed collections under `--target standalone`/`wasi`: a prototype method invoked with a `this` lacking the right internal slot (`[[MapData]]`/`[[SetData]]`/`[[WeakMapData]]`/`[[WeakSetData]]`) now throws a **catchable TypeError** (non-trapping `ref.test`, never a trapping `ref.cast`).

### Tier 1 — shared brand preamble + generic reflective dispatch
- **`src/codegen/receiver-brand.ts`** (new): `emitReceiverBrandCheck(ctx, fctx, recvType, spec)` — the parameterizable brand gate (`spec: { message, structTypeIdx, kindField? }`), generalized from #2604's `emitSetBrandCheck`. **This is the shared helper #3172 (set-algebra) and #3174 (Date) reuse** — Date passes its own struct typeIdx with no kindField.
- **`src/codegen/collections-brand.ts`** (new): reflective `X.prototype.METHOD.call(recv, …)` / `inst.METHOD.call(recv, …)` dispatch for **all four** collections and **all** their prototype methods (data methods + keys/values/entries + forEach), replacing the Set-only #2604 machinery (net −170 LOC in set-runtime.ts). Valid receivers route to the same native helpers as direct dispatch.
- `emitSetBrandCheck` stays as a struct-only (kind-lenient) delegator for the set-algebra ARGUMENT validation (#2607) — behavior preserved (a Map is spec set-like).

### Tier 2 — COLLECTION_KIND tag on the shared $Map struct
All four collections share the `$Map` backing store, so struct identity alone can't separate brands. A trailing immutable i32 `kind` field (`MAP_LAYOUT.M_KIND`), stamped by `__map_new(kind)` at every construction site (ctors in new-super.ts, set-algebra results = SET, `Map.groupBy` = MAP), makes `Map.prototype.get.call(new Set())` throw per spec.

### size accessor getter (gOPD glue)
`makeCollectionGlue` (array-object-proto.ts) adds `size` to the Map/Set glue CSV as a getter with a real reflective body (brand preamble → `__map_size` → boxed number), covering `gOPD(Map.prototype,'size').get.call(x)` rows via the #2876 descriptor-accessor path.

## Measured (standalone lane, built-ins/{Map,Set,WeakMap,WeakSet}/prototype)
- **158 flips fail→pass, 0 regressions** vs the `test262-standalone-current.jsonl` baseline (suite 320→478 of 700). 150 brand/receiver-protocol rows; acceptance bar was ≥120.
- Host (gc) lane, same filter: **0 flips, 0 regressions** — byte-inert (everything `nativeStrings`/standalone-gated).

## Tests
- `tests/issue-3171.test.ts`: 48 equivalence tests (wrong-shape rows, cross-brand rows, instance form, size getter, valid receivers, construction-site branding).
- Regression suites green: #2604 (31), #2607 (27), #2377/#2861 proto-value-read, collection batch 116 (3 pre-existing failures reproduced on clean tree).

Issue: #3171 (status: done carried in this PR). Issue-file anti-bloat pointer corrected (dispatch arms live in set-runtime/extern.ts/calls.ts, not closed-method-dispatch.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)