### PR TITLE
docs(arch): implementation plans for deferred hard tasks (#3181 #3162 #3032 #3172 #2802)

### DIFF
--- a/plan/issues/2802-nested-any-vec-multipush-join-first-element-drop.md
+++ b/plan/issues/2802-nested-any-vec-multipush-join-first-element-drop.md
@@ -67,3 +67,86 @@ return the same backing vec each time).
 
 - Banked probe under the #2794 branch `.tmp/` (`vec-read.ts` + `vec-read-run.mjs`,
   the multi-push + join case). Compile is small/fast (no full acorn needed).
+
+## Implementation Plan
+
+(arch, 2026-07-12. Verify-first, per the issue. Anchors verified on main.)
+
+### Where the round-trip actually lives (read this before instrumenting)
+
+Host (gc) mode; `s: any` is a WasmGC `$Scope` struct handled as externref.
+
+- `s.lexical` read → host import `__extern_get(s, "lexical")`
+  (src/runtime.ts sidecar machinery) → returns the vec struct, possibly
+  wrapped by `_wrapForHost` (identity-stable per struct via
+  `_hostProxyCache`, runtime.ts:5281).
+- `.push("a")` → `__extern_method_call` → the **#1712 vec-mutator arm**
+  (runtime.ts:11517-11565): `_unwrapForHost(obj)` → `rawVec`, then
+  `__vec_mut_supported(rawVec)` gate → `exports.__vec_push(rawVec, x)`
+  (Wasm-side per-vec-type dispatch, reserved up front by #2784 S3 —
+  src/codegen/index.ts:5923-5940; `__vec_mut_supported` emit at :6352-6381).
+  If the gate says NO, control falls to the **#2794 read-materialize arm**
+  (runtime.ts:11570-11600): `_VEC_PRIMITIVE_READ_METHODS` copies the vec
+  into a fresh JS array and applies the native method — for a READ that is
+  fine; if a PUSH ever falls past the mut arm, the mutation lands on a
+  transient copy and is lost.
+- `.join("|")` → the same #2794 read-materialize arm (join is read-only).
+
+### Step 1 — reproduce + pin the arm (half a day)
+
+1. Re-run the banked probe on current main (the #2784/#2794 fixes may have
+   moved the behavior; the issue predates them in detail).
+2. Instrument runtime.ts: log per call — method name, whether
+   `__vec_mut_supported(rawVec)` returned 1, `__vec_len` before/after, and a
+   stable id for `rawVec` (e.g. a WeakMap counter). Three pushes then join:
+   the log will show exactly which push (if any) took the fallthrough arm
+   and whether all four calls saw the SAME rawVec identity.
+3. Prime suspect A — **empty-literal vec typing**: `this.lexical = []` in
+   the constructor may allocate a DIFFERENT vec type (generic/externref vec)
+   than the field's declared `string[]` vec; `__vec_push`'s per-vec-type
+   dispatch (index.ts:5923) then rejects the first push (returns <0 / gate
+   fails) → first element lands via some fallback → dropped or stored on a
+   replaced backing. Check the WAT: which vec type the constructor stores vs
+   which type `__vec_push`'s dispatch arms cover.
+4. Prime suspect B — **first-push backing replacement**: `__vec_push` grows
+   by replacing the `data` array field inside the vec struct. If the FIELD
+   READ (`s.lexical`) returned a copy/snapshot rather than the struct (or
+   the host cached a materialized JS array across the push), the first
+   push's grow is invisible to later reads. The `indexOf`-correct /
+   `join`-wrong asymmetry fits a stale materialization cached between the
+   read-materialize arm calls.
+
+### Step 2 — fix per finding
+
+- **If A (typing)**: make the empty-array-literal initializer in a class
+  field/constructor assignment adopt the DECLARED field vec type (codegen
+  side — the array-literal typing at the assignment site), or add the
+  missing vec-type arm to the `__vec_push` dispatch builder
+  (index.ts:5923-5960 region). Prefer the former: one representation, no
+  dispatch growth.
+- **If B (stale materialization/identity)**: ensure the #2794
+  read-materialize arm NEVER caches the built JS array across calls (it
+  currently builds fresh each call — verify), and that `_unwrapForHost`
+  reverses every wrapper shape the field read can produce (the
+  closure-bridge reverse at runtime.ts:11534-11539 is one such repair;
+  the miss may be an analogous unreversed wrapper for string-vecs).
+
+### Reuse
+
+- The #1712 vec-mutator arm + #2794 read arm (runtime.ts:11517-11600) —
+  extend the existing arms; do not add a new method-call path.
+- `__vec_push`/`__vec_mut_supported` Wasm exports
+  (src/codegen/index.ts:5923/:6352, the #2784 S3 reserve-up-front pattern) —
+  any new vec-type arm goes into the same builders.
+- `_wrapForHost`/`_hostProxyCache`/`_unwrapForHost` (runtime.ts:5281) for
+  identity-stability questions.
+
+### Acceptance / tests
+
+- The issue's repro yields `"a|b|c"`; `length`/`indexOf`/`join` consistent
+  across interleaved push/read sequences on a nested `any`-vec field.
+- Add `tests/issue-2802.test.ts`: the repro + an interleaved
+  push/read/push/join variant + a `this.field = []`-then-push-in-same-method
+  variant (distinguishes A from B).
+- acorn dogfood lane unchanged (this edge is off acorn's real path — #2794
+  diffed EQUAL — so any fix must be regression-neutral there).

--- a/plan/issues/3032-lazy-generator-expression-thunks.md
+++ b/plan/issues/3032-lazy-generator-expression-thunks.md
@@ -146,3 +146,103 @@ default (#2141 S3/S4, #2626 acceptance) only after enough waves land that
 the **merge_group standalone floor** clears: every vacuous pass the
 classifier unmasks must first be made a GENUINE pass by laziness. Measure
 with `JS2WASM_TAG5_CLASSIFIER=1 pnpm run test:262` A/B per wave.
+
+## Implementation Plan (W3 then W2 — the next executable waves)
+
+(arch, 2026-07-12. Anchors re-verified on main: the landed Slice-1 lazy wrap
+lives in `src/codegen/closures.ts` — `genLazyEligible` gate at :2886, eager
+sequence capture at :2893, flag-branch emission at :2953,
+`ensureGenEagerFlag` at :1721. The gc-host eager-buffer arm for NAMED
+generator declarations is `src/codegen/function-body.ts` :1052-1080 (the
+`__gen_create_buffer` block; the standalone #680 gate is right above at
+:1045). The method-generator eager arm is `src/codegen/class-bodies.ts`
+:2309. There is no `nested-declarations.ts` — the W3 note's pointer is
+stale; the eager path for nested named generators is the function-body.ts
+arm.)
+
+**Recommended order: W3 (route a — cheap wrap) first, then W2 (measure
+before building), then W4.** W3 covers the dominant test262 shape (named
+generators inside the `export function test()` wrapper); W2's zero-param
+observation in the banked note ("the fixture corpus is ~all zero-param")
+means W2 may be a measurement no-op.
+
+### W3 route (a) — nested capturing NAMED generators via the same if-flag wrap
+
+**Where**: `src/codegen/function-body.ts` :1052-1080 — the eager-buffer arm
+for a gc-host generator FUNCTION DECLARATION (`function* g() {...}` nested
+inside the test wrapper falls here after failing native candidacy).
+
+**Change**:
+1. Extract the Slice-1 wrap into a shared helper
+   `wrapGeneratorEagerSeqLazy(ctx, fctx, bodyEmitter, selfClosureEmitter)`
+   in closures.ts (parameterize what :2886-2960 does inline today): capture
+   the eager sequence into a fresh `Instr[]`, then emit
+   `if (global.get $__gen_eager_mode) { <eager seq, clears flag at top> }
+   else { <return __create_generator(<self as externref>, null)> }`.
+2. Apply it in the function-body.ts arm. The one W3-specific problem is the
+   THUNK SELF value: a declaration-form generator is a plain defined func,
+   not a closure struct, so there is no `__self` param to pass to
+   `__create_generator`. Two options — (a-i) mint the nested named generator
+   AS a closure value at its declaration site (route it through
+   `compileArrowAsClosure`'s generator branch — it then inherits the landed
+   lazy wrap verbatim, captures included); (a-ii) synthesize a zero-capture
+   closure struct wrapping the defined funcIdx purely as the thunk handle.
+   Prefer (a-i): it reuses the PROVEN Slice-1 branch end-to-end and gives
+   capture cells for free; the call sites (`g()`) already compile
+   identifier-call-of-closure.
+3. Eligibility gates: same as Slice 1 (`!isAsync`, no `arguments`, no
+   `this`/`super` — reuse `closureBodyUsesArguments` +
+   `genBodyReferencesThis`, both already exported for the :2886 gate), PLUS
+   `parameters.length === 0` until W2 lands.
+
+**Hazards** (from the Slice-1 PR #2625 lessons, all still live):
+- `ctx.genEagerFlagGlobalIdx` staleness across string-constant imports —
+  `fixupModuleGlobalIndices` (src/codegen/registry/imports.ts) already
+  covers the cached idx; any NEW cached global here must be added there.
+- The eager arm must clear the flag at its top (nested creations stay lazy).
+- Host contract: `__create_generator` thunk detection + `__call_fn_0`
+  re-invocation (src/runtime.ts) is shape-agnostic — no host change needed
+  if (a-i) is taken (the thunk IS a closure).
+
+**Probe/tests**: probe v14 (the banked shape — named capturing generator in
+the wrapper, `iterations` must stay 0 before first `next()`); the
+class/dstr `dflt` canaries with `JS2WASM_TAG5_CLASSIFIER=1`;
+return/throw-before-start (v16/v17 twins for the named shape).
+
+### W2 — paramful generator expressions (measure first)
+
+**Step 0 (measurement gate)**: grep the test262 corpus for paramful
+`function*(...)` EXPRESSIONS that are also lazy-eligible; the banked note
+predicts ~none. If the measured population is <10 files, mark W2 wont-build
+and move to W4.
+
+**If built**: at creation time, spill call args into ref cells appended to
+the closure struct — but do NOT add a second struct instance. Simpler
+concrete shape than the banked sketch: extend `computeClosureWrapperSig`'s
+generator arm so a lazy-eligible paramful generator expression's lifted func
+reads its params from CAPTURE FIELDS instead of wasm params (compile-time
+rewrite: params become synthetic captures initialized at creation), making
+the thunk re-invocation `__call_fn_0`-compatible (zero wasm params) with no
+host/ABI change. Gate `genLazyEligible` on "all params spillable"
+(spill-safe types only, the #2906 rule).
+
+**Reuse**: the ref-cell capture machinery in closures.ts (the mutable
+closure-capture struct fields — `struct (field $value (mut T))`), the
+Slice-1 wrap, `__call_fn_0`.
+
+### W4 pointer (banked, unchanged)
+
+class-bodies.ts:2309 is the method-generator eager arm; param
+instantiation must stay OUTSIDE the flag branch (spec: param defaults run at
+call). Not a pure wrap — do after W3.
+
+### Acceptance per wave
+
+- Probe battery v10-v17 green; creation runs NOTHING (side-effect counter
+  0 before first `next()`).
+- `JS2WASM_TAG5_CLASSIFIER=1` A/B on the dstr/class cluster: unmasked
+  vacuous passes become genuine (net ≥ 0 per wave vs the classifier-off
+  baseline).
+- gc/host lane: no regression on the generator suites
+  (`gen-func-expr-args-trailing-comma-*`, `iter-val-array-prototype` — the
+  two PR-#2625 regression buckets must stay green).

--- a/plan/issues/3162-dynview-find-two-arm-invalid-wasm.md
+++ b/plan/issues/3162-dynview-find-two-arm-invalid-wasm.md
@@ -102,3 +102,133 @@ arm-result coercion / the `find` impl's returned ValType, NOT per-method.
 - `every`/`some`/`forEach`: detached-buffer regressions (materialization
   snapshots before a mid-callback detach) — a semantics gap, not soundness.
 - `map`/`filter`/`sort`/`with`: need a TA-result builder.
+
+## Implementation Plan
+
+(arch, 2026-07-12. Anchors verified on main: `DYN_VIEW_READ_METHODS`
+array-methods.ts:3023, `coerceArmToExternref` :3088, `emitDynViewMethodTwoArm`
+:3157, the two-arm gate in `compileArrayMethodCall` :3267-3285,
+`compileArrayFind` :7747, `setupArrayCallback` :6501,
+`compileArrowAsClosure` closures.ts:1853, `computeClosureWrapperSig`
+closures.ts:1616, `__hof_find` / `NATIVE_HOF_METHODS` hof-native.ts:57-72.)
+
+### The double-compile mechanism (what "compiled twice" concretely means)
+
+The two-arm compiles the SAME callback `ts.FunctionExpression` node twice:
+
+1. **THEN arm** (`emitDynViewMethodTwoArm` :3201): re-enters
+   `compileArrayMethodCall(..., skipDynViewWrap=true)` over the materialized
+   `$__vec_f64` → `compileArrayFind` (:7747) → `setupArrayCallback` (:6501)
+   → `compileArrowAsClosure(ctx, fctx, cbArg)` (closures.ts:1853) — mints
+   `__closure_N` with a wrapper sig from `computeClosureWrapperSig`.
+2. **ELSE arm** (:3212): re-dispatches the WHOLE call via
+   `compileExpression` — the ordinary externref/standalone path compiles the
+   same node AGAIN (a second `__closure_M` mint, via `compileArrowAsClosure`
+   or the #3098 closed-method-dispatch HOF arm).
+
+Note `reduce`/`reduceRight` are ALREADY in the set (:3044) and double-compile
+their callbacks WITHOUT emitting invalid wasm — so double-mint per se is
+tolerated (bloat, not soundness). The find-specific breakage is state that
+leaks between the two compiles (or between an arm compile and a late
+registration) for the mutating-predicate shape.
+
+### Step 1 — reproduce and pin the broken mint (half a day, do this first)
+
+1. Add `"find"` to `DYN_VIEW_READ_METHODS` (:3023) in a scratch branch.
+2. Compile the issue's repro standalone; dump WAT (`.tmp/` probe). Locate
+   `__closure_5`: read its DECLARED func type (the `(ref null 4)` result)
+   vs its BODY's fallthru (i32), and identify what type index 4 actually is
+   (likely `$__vec_f64` or a closure struct).
+3. Diff the two mints for the same predicate node (`__closure_4` vs
+   `__closure_5` or similar): param types, result type, capture struct.
+4. Decide between the two candidate root causes:
+   - **H1 — per-node state contamination**: the second
+     `computeClosureWrapperSig`/capture analysis run sees memoized per-node
+     state from the first (e.g. `addFunctionOwnLocals` memo #2103, contextual
+     widen flags like `ctx.forceExternrefCallbackParams`, or the #2939
+     dynamic-dispatch pre-scan wrapper-type registration) and mints a body
+     whose emitted result no longer matches its registered type.
+   - **H2 — late-registration index mismatch**: a helper/type registration
+     fired between mint and push INSIDE an arm buffer, so the closure body
+     was attached against a stale funcIdx/typeIdx (the #1839-class hazard;
+     the two-arm's `savedBodies` patches funcIdx immediates in bodies, but
+     a closure minted inside an arm adds a whole defined function). Compare
+     against the working `reduce` arm to see what `find` registers extra
+     (`compileArrayFind`'s hole-map `holeToUndefinedInstrs` :7818 and the
+     `emitCallbackTypeCheck` :7757 are find-specific registrations).
+
+### Step 2 — the fix (two acceptable shapes, prefer A)
+
+**Fix A (class-wide, preferred) — hoist the callback compile out of the
+two-arm.** In `emitDynViewMethodTwoArm` (:3157), when `callExpr.arguments[0]`
+is an arrow/function expression: compile it ONCE in the OUTER body (before
+the `ref.test` split) via `compileArrowAsClosure`, store the closure value in
+an outer local, and record it in a per-compile
+`WeakMap<ts.Expression, {localIdx, valType}>` (module-scoped beside
+`dynViewTwoArmActive` :3064). Teach `setupArrayCallback` (:6501) and the
+else-arm's ordinary path to consult that map FIRST and `local.get` the
+precompiled closure instead of recompiling the node. This removes the
+double-mint for every method in the set (also shrinks reduce/reduceRight
+bloat) and makes the arm result types deterministic.
+
+**Fix B (narrower) — route the THEN arm for find/findIndex through the #3098
+substrate.** `__hof_find`/`__hof_findIndex` (hof-native.ts, emitted at
+reserve time, standalone-only) already run the spec loop over
+`__extern_length`/`__extern_get_idx`, which explicitly accept "real
+`$__vec_*` arrays" (hof-native.ts:27). THEN arm becomes: validate +
+materialize (unchanged, :3195-3198) → `extern.convert_any` the mat vec →
+`call __hof_find(matExt, cbExt, undefined)` — result is already externref,
+so `coerceArmToExternref` is a no-op and the fragile re-entry into
+`compileArrayFind` disappears. The callback is compiled once per arm as an
+externref closure via the proven `__apply_closure` bridge. Caveats: (a)
+standalone/wasi-only (`ensureNativeArrayHof` returns undefined otherwise —
+gate the set membership or keep the re-entry for gc/host); (b) verify
+`__hof_find`'s result boxing matches the TA `find` element semantics
+(f64 elements → `__box_number`); (c) the mutating predicate mutates the
+materialized copy — same semantics the measured +13 already had.
+
+If Step 1 lands on H2 (late-registration), Fix A still applies (the hoist
+moves the mint out of the arm-buffer window); additionally pre-ensure the
+find-specific registrations (`ensureGetUndefined`/hole map, callback
+type-check error machinery) BEFORE the arm split, mirroring the existing
+pre-flush pattern in `setupArrayLoop` (:6586-6589).
+
+### Reuse
+
+- `emitDynViewMethodTwoArm` / `coerceArmToExternref` (array-methods.ts:3157/
+  :3088) — extend in place; do not fork a per-method two-arm.
+- `__hof_find`/`__hof_findIndex` + `reserveApplyClosure`
+  (src/codegen/hof-native.ts:57-110, the #3098 callback substrate) — the
+  Fix-B loop; already reserve-time/append-only (no funcIdx shift).
+- `compileArrowAsClosure` (closures.ts:1853) — the single mint entry; the
+  hoist calls it once, nothing new.
+- The `savedBodies` late-import-shift discipline already documented in the
+  two-arm's doc block (:3152-3156) — any new outer-local emission must stay
+  inside that registration.
+
+### Edge cases
+
+- Predicate is an identifier (already-compiled closure value) — the hoist
+  map only intercepts inline arrow/function-expression args; identifiers
+  keep the existing path.
+- 0-arg `find()` — stays excluded by the existing `arguments.length >= 1`
+  gate (:3278).
+- `findIndex` twin + `BigInt/` variants (the issue's 4 test262 files).
+- thisArg 2nd argument (`find(pred, thisArg)`) — `setupArrayCallback`'s
+  `compileThisArg` (:6543) must still run per-arm even when the closure is
+  hoisted (spec arg-order evaluation happens once — hoist BOTH callback and
+  thisArg evaluation to the outer body to keep single-evaluation semantics).
+- Do not disturb `reduce`/`reduceRight` byte-behavior beyond removing the
+  double-mint (A/B-test the existing dyn-view suites).
+
+### Acceptance / tests
+
+Per the issue's Acceptance section, plus:
+- New equivalence test `tests/issue-3162.test.ts`: the repro shape for
+  find + findIndex, mutating and non-mutating predicates, thisArg form,
+  identifier-callback form.
+- `prove-emit-identity` IDENTICAL for the gc/host lanes (set membership +
+  two-arm changes are standalone-reachable only if Fix B; Fix A touches the
+  shared two-arm — verify the hoist emits byte-identical modules for
+  programs without dyn views, which it does by construction since the
+  two-arm gate requires `ctx.moduleUsesDynTaView`).

--- a/plan/issues/3172-standalone-set-algebra-getorinsert-spec-semantics.md
+++ b/plan/issues/3172-standalone-set-algebra-getorinsert-spec-semantics.md
@@ -116,3 +116,106 @@ Standalone lane (`TEST262_TARGET=standalone`, filter
 - The 14 `has/keys-is-callable` regressions from the first measurement were
   fixed in-branch (`__setrec_check_callable` reserve-then-fill IsCallable
   gate); final run is 0-regression.
+
+## Implementation Plan — residual buckets as independently claimable plan-lets
+
+(arch, 2026-07-12. The protocol layer landed — PR merged as
+`src/codegen/collections-es2025.ts` (1,248 lines): `ensureSetRecFieldGetters`
+reserve at :558-600, `fillSetRecFieldGetters` finalize fill at :613,
+`__setrec_check_callable` fill at :683, `ensureSetAlgebraAnyDispatch` at
+:780, `ensureGetOrInsertKernels` at :160, `compileCollectionGetOrInsert` at
+:342. Each bucket below is a separate S/M slice, one PR each; all
+standalone-gated, zero host-lane bytes.)
+
+### Plan-let R1 — class-based set-likes (~14 tests, M) — `allows-set-like-class`, `set-like-class-order`
+
+**Gap**: `__setrec_field_<size|has|keys>` (fill at collections-es2025.ts:613)
+reads only DATA properties off the argument. A set-like written as
+`class MySetLike { get size() {...} has(k) {...} keys() {...} }` needs (a)
+accessor `get size()` invocation and (b) METHODS on a closed class struct
+materialized as callable values.
+
+**Change**: in `fillSetRecFieldGetters`'s `ref.test` arm for closed class
+structs, route the read through the same accessor-aware path
+`__extern_get` uses (getter descriptor → call; see the accessor arm
+object-runtime.ts ~:1127), and for method members mint the method as a
+closure value via `closed-method-dispatch.ts`'s method-as-value machinery
+(the #3098-adjacent closed-struct dispatch — grep
+`closed-method-dispatch.ts:171` comment block for the HOF callback arm
+pattern). The invocation side (`__setrec_call_has`/keys-iteration) already
+dispatches through `__apply_closure` — only the field READ is the gap.
+
+**Reuse**: `__extern_get`'s accessor arm (object-runtime.ts);
+`closed-method-dispatch.ts` method minting; `__apply_closure`
+(reserveApplyClosure, object-runtime.ts). Do NOT add a per-class glue.
+
+**Tests**: `Set/prototype/*/allows-set-like-class.js`,
+`set-like-class-order.js` (also asserts read/call ORDER: size → has → keys,
+then keys() iteration last — the fill must preserve GetSetRecord step order).
+
+### Plan-let R2 — `set-like-array` (~7 tests, S)
+
+**Gap**: expando `size`/`has`/`keys` properties written onto a vec-backed
+array (`const a = [1,2]; a.size = 2; a.has = ...`). The `__setrec_field_*`
+readers miss expando fields on vec carriers.
+
+**Change**: extend the fill's receiver dispatch with the vec-expando arm —
+the sidecar/expando lookup that `__extern_get` already performs for
+vec-backed arrays (grep object-runtime.ts for the vec expando arm used by
+`__extern_get`; reuse that helper by funcidx, per the #2108
+coercion-sites discipline).
+
+**Reuse**: the existing vec-expando read arm in object-runtime.ts —
+one `call`, no new reader.
+
+### Plan-let R3 — getOrInsert boxed-any value rows (~10 tests, S–M, may be a no-op here)
+
+**Gap**: `assert.sameValue(map.getOrInsert(k, obj), obj)` — two boxed anys
+compared by the harness comparator; the values round-trip tag-5 and compare
+vacuously/wrongly. This is the **#3056 boxed-compare lane** (and the #3053
+U3 carrier), NOT collection dispatch.
+
+**Action**: verify per-row that the failure is the comparator (compile one
+row with `JS2WASM_TAG5_CLASSIFIER=1`); if so, tag the rows to #3056/#3053 in
+the lane baseline and do NOT patch collections code. Only genuinely-wrong
+STORED values (identity lost through the map kernel itself,
+`ensureGetOrInsertKernels` :160) belong here.
+
+### Plan-let R4 — `builtins.js` function-object meta (7 tests, M)
+
+**Gap**: `Object.isExtensible(Set.prototype.union)`,
+`Object.getPrototypeOf(...)`, `.toString()` on the method VALUE — the
+algebra methods need function-object meta surface when read as values.
+
+**Change**: this is the same machinery as #3181 cluster A/B (builtin proto
+method values with meta surface) — implement AFTER the #3181 pattern lands
+and reuse its glue (`array-object-proto.ts` `registerNativeProtoBuiltin` +
+`tryCompileStandaloneBuiltinProtoMemberMeta`, property-access.ts:1104) for
+the Set brand. Do not build a Set-specific meta path first.
+
+### Plan-let R5 — re-entrant mutation ordering + IteratorClose (~7 tests, M–L, lowest priority)
+
+**Gap**: `set-like-class-mutation` (the argument's `has`/`keys` mutates the
+receiver mid-algorithm — spec fixes `size` and snapshots per-method reads)
+and `set-like-iter-return` (abrupt completion must call the keys iterator's
+`return()` — IteratorClose).
+
+**Change**: in `ensureSetAlgebraAnyDispatch` (:780) kernels: (a) read + 
+ToNumber `size` ONCE into a local before iteration (verify current fill
+order — likely already correct from `size-is-a-number`); (b) snapshot the
+receiver's backing entries where §24.2.4.x prescribes (intersection/
+difference iterate `O.[[SetData]]` live — follow the per-method spec text,
+not a blanket copy); (c) wrap the keys-iteration loop with an IteratorClose
+arm on early exit — reuse the iterator-protocol close helper from
+`iterator-native.ts` (the ITER close discipline the #3098 iterator steppers
+use) rather than a new close path.
+
+**Out of scope stays out**: `class MySubset extends Set` rows (~12) are
+#2917 builtin-super lineage — do not touch here.
+
+### Sequencing / ownership
+
+R2 (S) → R1 (M) → R5 (M–L) independent of each other; R3 is triage-first;
+R4 blocks on #3181 cluster A/B landing. Each PR: scoped standalone sweep of
+`built-ins/{Map,Set,WeakMap}/prototype` vs the 559/700 post-#3172 baseline,
+0 host-lane regressions, `tests/issue-3172.test.ts` stays green.

--- a/plan/issues/3181-standalone-number-proto-brand-surface.md
+++ b/plan/issues/3181-standalone-number-proto-brand-surface.md
@@ -103,3 +103,152 @@ Measurement method: real `wrapTest` + `compile({target:"standalone"})` over ever
   work — it landed in PR #2933. Start from post-#2933 main.
 - `buildThrowJsErrorInstrs` (helpers.ts, added in #3175) is the reusable
   conditional-throw helper for any new TypeError/RangeError instance gate here.
+
+## Implementation Plan
+
+(arch, 2026-07-12. Anchors verified on `origin/main` pre-#2933; PR #2933 is
+in-flight and only touches `plan/issues/3175-*` + its own code — re-grep
+anchors after it lands, and pick up `buildThrowJsErrorInstrs` from it.)
+
+Ship order: **C → B → D → A** (effort-ascending; each cluster is an
+independently mergeable PR-let).
+
+### Cluster C — method `.length` (3 files, S)
+
+**Root cause**: for `Number.prototype.toString.length` the generic `.length`
+property handler in `src/codegen/property-access.ts` runs BEFORE the
+builtin-proto-member meta fold. The fold itself works — `.name` already
+returns `"toString"` via `tryCompileStandaloneBuiltinProtoMemberMeta`
+(property-access.ts:1104, called at :4186).
+
+**Change** (`src/codegen/property-access.ts`):
+- Locate the generic `.length` arm that intercepts the shape (grep for the
+  `.length` dispatch ABOVE line 4186 in `compilePropertyAccess`'s ladder).
+  Add a narrow deferral: when the receiver is itself a property access on a
+  builtin prototype surface (`Number.prototype.<m>` /
+  `<numLiteral|Number-typed expr>.<m>` resolving into the `$NativeProto` glue
+  member set), skip the generic arm so control reaches the meta fold at
+  :4186. Prefer a helper predicate `isBuiltinProtoMemberShape(expr)` shared
+  with the fold rather than duplicating the shape test.
+- In the glue (`src/codegen/array-object-proto.ts`, `NUMBER_PROTO_METHODS`
+  at :208, registered via `makeGlue(...)` at :1550): verify
+  `memberLength` (consumed at property-access.ts:1153) returns **0** for
+  `valueOf` and `toLocaleString`, **1** for `toString`. The issue notes a
+  `?? 1` default — add explicit per-member lengths instead of the fallback.
+
+**Reuse**: `tryCompileStandaloneBuiltinProtoMemberMeta`
+(property-access.ts:1104) and the `NUMBER_PROTO_METHODS` glue table
+(array-object-proto.ts:208) — extend, do not add a new fold.
+
+**Edge cases**: don't reorder `.length` for arrays/strings/arguments
+(regression-sensitive); gate the deferral on the builtin-proto-member shape
+only, standalone-gated like the fold itself.
+
+**Tests**: `built-ins/Number/prototype/toString/length.js`,
+`valueOf/length` (0), `toLocaleString/length` (0); scoped standalone sweep
+of `built-ins/Number/prototype/**` + a host-lane byte-identity spot-check.
+
+### Cluster B — property surface (~12 files, M)
+
+**Root cause**: `Number.prototype` does not answer reflective own-property
+queries (`hasOwnProperty("toString")`, `hasOwnProperty("constructor")`,
+enumeration) — only direct method dispatch works.
+
+**Change** (`src/codegen/array-object-proto.ts`):
+- The `$NativeProto` machinery already models `Array.prototype`/
+  `String.prototype` as objects (see `registerNativeProtoBuiltin` at :1550).
+  Extend the same reflective arms for the Number brand:
+  `hasOwnProperty(name)` over the glue's member table + `"constructor"`,
+  and `Number.prototype.constructor === Number` identity.
+- Grep how `Array.prototype`-surface tests pass today (the glue's
+  `hasOwnProperty` arm) and mirror it — the member list is
+  `NUMBER_PROTO_METHODS` ∪ {`constructor`, `toLocaleString`, ...} exactly as
+  registered.
+
+**Reuse**: `registerNativeProtoBuiltin` / `makeGlue`
+(array-object-proto.ts:1550) — one table drives dispatch AND reflection; do
+not build a parallel descriptor store.
+
+**Tests**: `S15.7.4_A3.1..A3.7`, `S15.7.3.1_A2_T1/T2`, `S15.7.3.1_A3`,
+`15.7.3.1-2`, `S15.7.4_A1`.
+
+### Cluster D — toExponential/toPrecision no-arg + arg coercion (~8 files, M)
+
+**Root cause** (two parts): (1) the no-arg render in
+`src/codegen/number-format-native.ts` is a 6-digit approximation, not the
+spec shortest/`ToString(x)` form; (2) the previous attempt to delegate
+`toPrecision(undefined)` → `number_toString` hit the
+`number_toString` ← `number_toString_radix` emit-order dependency
+(number-format-native.ts:374-395: `ensureNumberFormatHelpers(which)` — the
+"must run before" registration block) and was reverted with a CE.
+
+**Change** (`src/codegen/number-format-native.ts`):
+- In the helper-registration block (:374-395), make
+  `number_toPrecision`/`number_toExponential` declare a dependency on
+  `number_toString` the same way `number_toFixed` already does (":392 —
+  number_toFixed needs number_toString for its |x| >= 1e21 branch"): add the
+  name to `which` before minting, so registration order is topological, not
+  incidental. This dissolves the emit-graph collision that killed the #3175
+  attempt.
+- `toPrecision(undefined)` → emit `call number_toString` (§21.1.3.5 step 2).
+- `toExponential()` no-arg: implement trailing-zero-trim on the 6-digit
+  render (sufficient for the cited test262 rows; full shortest-round-trip
+  stays documented out of scope).
+- Symbol/BigInt fractionDigits/precision args → real TypeError instance via
+  `buildThrowJsErrorInstrs` (from PR #2933) before ToIntegerOrInfinity.
+
+**Reuse**: `ensureNumberFormatHelpers` registration block
+(number-format-native.ts:374-395); `buildThrowJsErrorInstrs` (#3175/PR
+#2933); the existing ToIntegerOrInfinity truncation from #3175.
+
+**Tests**: `toExponential/{undefined-fractiondigits,return-values,
+tointeger-fractiondigits,return-abrupt-tointeger-fractiondigits-symbol}`,
+`toPrecision/{undefined-precision-arg,exponential,tointeger-precision,
+precision-cannot-be-coerced-to-a-number-in-range}`,
+`toFixed/toFixed-tonumber-throws-typeerror-{bigint,toprimitive}`.
+
+### Cluster A — brand check on transferred method values (~12 files, L)
+
+**Root cause**: `s.toString = Number.prototype.toString; s.toString()` — the
+method must exist as a first-class function VALUE that brand-checks its
+receiver at CALL time (§21.1.3 "not generic" TypeError). Today the method
+only exists as compile-time dispatch; a transferred reference either CEs or
+runs without the brand gate.
+
+**Change**:
+1. Materialize `Number.prototype.<m>` reads (value position, not call
+   position) as closures via the glue's member minting — the same path that
+   already gives `.name`/`.length` their function-object identity
+   (`tryCompileStandaloneBuiltinProtoMemberMeta` sits beside the read arm;
+   grep array-object-proto.ts for where Array.prototype method VALUES are
+   minted for transfer — follow that pattern for Number).
+2. Inside each minted wrapper body, FIRST emit the receiver brand gate:
+   `emitReceiverBrandCheck` (src/codegen/receiver-brand.ts:58) /
+   `emitReceiverBrandThrow` (:146) against the boxed-Number brand
+   (`$BoxedNumber` ref.test + raw-f64 receiver accept), throwing a real
+   TypeError via `buildThrowJsErrorInstrs` on mismatch.
+3. Dynamic dispatch of the transferred value goes through the existing
+   closure/`__apply_closure` bridge — no new calling convention.
+
+**Reuse**: `emitReceiverBrandCheck`/`emitReceiverBrandThrow`
+(receiver-brand.ts:58/:146 — the #3171/#3174 shared gate, landed);
+`NUMBER_PROTO_METHODS` glue; the closure-mint machinery of
+`array-object-proto.ts` (`registerNativeProtoBuiltin`). Do NOT hand-roll a
+per-method brand test.
+
+**Edge cases**: receiver is a raw f64 (accept); receiver is a `$BoxedNumber`
+(accept, unwrap `[[NumberData]]`); `String` object / plain object / null →
+TypeError; `call`/`apply` transfer shapes.
+
+**Tests**: `toString/S15.7.4.2_A4_T01..T05`, `valueOf/S15.7.4.4_A2_T01..T05`,
+`toExponential/this-type-not-number-or-number-object`,
+`toPrecision/this-type-not-number-or-number-object`.
+
+### Global acceptance gates (all clusters)
+
+- Zero host-mode regressions (host lane byte-identity for modules without
+  the construct — every new arm `ctx.standalone`-gated).
+- Standalone `built-ins/Number/prototype/**` sweep strictly increases from
+  the post-#2933 130/168 baseline toward ≥139.
+- Coordinate with PR #2933 (in-flight): branch AFTER it lands; its issue
+  file (#3175) stays untouched by this work.


### PR DESCRIPTION
Wind-down planning pass (plan-only, no code changes): appends verified-anchor `## Implementation Plan` sections so future devs can pick these hard tasks up cold.

- **#3181** standalone Number.prototype residuals — 4 cluster plan-lets (C .length dispatch-order → B property surface via `registerNativeProtoBuiltin` glue → D toExp/toPrec no-arg + emit-graph fix in `ensureNumberFormatHelpers` → A brand-checked method values via `emitReceiverBrandCheck`).
- **#3162** [SOUNDNESS] dyn-view find/findIndex invalid wasm — pins the double-compile mechanism (`setupArrayCallback` → `compileArrowAsClosure` per arm), gives a repro-first procedure and two fix shapes (hoist-the-callback-out-of-the-two-arm preferred; `__hof_find` #3098-substrate re-route alternative).
- **#3032** lazy generator thunks — concrete W3 (nested named generators via the landed Slice-1 wrap, function-body.ts eager arm; stale `nested-declarations.ts` pointer corrected) + measure-first W2.
- **#3172** Set-algebra/getOrInsert residuals — 5 independently claimable plan-lets (R1 class set-likes, R2 vec-expando, R3 triage-to-#3056, R4 after-#3181 meta surface, R5 mutation-order/IteratorClose) over the landed `collections-es2025.ts` kernels.
- **#2802** nested any-vec first-element drop — verify-first plan over the #1712/#2794 runtime arms + `__vec_push`/`__vec_mut_supported` (#2784 S3) with two pinned suspects (empty-literal vec typing vs stale materialization).

Skipped (see issues): #3179/#3180 files live only on open PRs #2935/#2932 (add/add conflict hazard — plans delivered to tech lead + as PR comments); #3175/#3176 owned by active devs; #2906/#3053/#3030/#3029 already carry authored architect specs/decompositions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)