### PR TITLE
feat(#3167): IR lowers string relational operators (< > <= >=)

### DIFF
--- a/plan/issues/3167-ir-string-relational-operators.md
+++ b/plan/issues/3167-ir-string-relational-operators.md
@@ -1,7 +1,9 @@
 ---
 id: 3167
 title: "IR: lower string relational operators (< > <= >=) — #3143 flip-track post-claim divergence class 2"
-status: ready
+status: done
+completed: 2026-07-12
+assignee: ttraenkler/fable-eqfix
 sprint: current
 created: 2026-07-12
 updated: 2026-07-12
@@ -15,7 +17,50 @@ language_feature: strings, operators
 goal: ir-full-coverage
 related: [3143, 3153, 3156, 2949, 2138]
 origin: "2026-07-12 architect IR audit: #3153 census class 2; blocks the #3143 IR-first flip (post-claim throw = hard error under IR-first)."
+loc-budget-allow:
+  - src/ir/from-ast.ts
+  - src/ir/integration.ts
 ---
+
+## Resolution (2026-07-12, fable-eqfix)
+
+Landed the both-string relational lowering following the #3156 minimal
+`emit-a-named-call` pattern — **no new IR node kind** (contrary to the initial
+plan's node-based sketch). from-ast's both-string switch (`from-ast.ts` ~:5821)
+gains `<`/`>`/`<=`/`>=` cases that emit a call to the sentinel
+`IR_STRING_COMPARE_FN` (a -1/0/1 lexicographic sign) then fold the sign to the
+operator's boolean via a signed i32 compare against 0 (`i32.lt_s`/`gt_s`/
+`le_s`/`ge_s`) — using only existing `call`/`const`/`binary` IR nodes.
+
+`integration.ts` `resolveFunc` maps the sentinel mode-appropriately: native/
+WASI → the `__str_compare` defined helper (idempotently ensured via
+`ensureNativeStringHelpers`, append-only → no funcIdx shift; re-resolved by
+name against the post-shift function table); host → the `string_compare` env
+import (already registered by the legacy declaration-collection pass whenever
+source has a string relational — `declarations.ts` ~:587-599 — so no new host
+surface, stable import index). `preregisterStringSupport` flags the compare
+call so a pure-compare body (`f(a,b:string){return a<b}`, no other string op)
+still pre-registers host string support before Phase-3.
+
+**Both operands statically string** is the delivered scope (census class 2 —
+the common `if (a < b)` shape). Verified: 24 regression tests
+(`tests/issue-3167.test.ts`) × both lanes; `irPostClaimErrors: []` +
+`fallbackCounts: {}` for a string-relational body under `JS2WASM_IR_FIRST=1`
+(IR claims and emits it — no demotion, no post-claim throw); ir-fallbacks,
+oracle-ratchet, coercion-sites all clean; #3156 / ir-cluster / ir-widening
+suites green.
+
+**Selector-mirror note for #3143 (important):** the architect plan asked for a
+select.ts mirror rejecting the MIXED string/non-string relational pre-claim.
+`select.ts` is **checker-free / purely syntactic** (`isPhase1Expr` has no type
+access — it explicitly defers "type compatibility ... to from-ast"), so a
+type-aware mixed-operand reject is NOT expressible there. The mixed case keeps
+its existing from-ast throw (unchanged from today; it already demoted under the
+overlay). It is **not** a #3167 regression. For the #3143 flip, the mixed
+relational is handled empirically by the #3153 post-claim meter: if it appears
+on the corpus it must be lowered too (ToNumber-both + f64 compare, mirroring
+legacy `emitAnyRelational`'s numeric arm) — a small follow-up, tracked under
+#3143's gate-check step, not blocking this slice.
 
 # #3167 — IR string relational operators
 

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3787,6 +3787,36 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
  * Returns `null` for unsupported methods so the caller can fall back to
  * legacy via a clean throw.
  */
+/**
+ * (#3167) Sentinel func-ref name for the string relational compare helper.
+ * `resolveFunc` (integration.ts) maps it mode-appropriately to the native
+ * `__str_compare` defined helper or the host `string_compare` env import —
+ * both `(str, str) -> i32` returning a -1/0/1 lexicographic sign. Keeping the
+ * mode decision in `resolveFunc` (not from-ast) mirrors the #3156 charCodeAt
+ * sentinel pattern, so from-ast reads no `nativeStrings`.
+ */
+export const IR_STRING_COMPARE_FN = "__ir_str_compare";
+
+/**
+ * (#3167) Emit a both-string relational `<`/`>`/`<=`/`>=`. Calls the mode-
+ * resolved compare helper for a -1/0/1 sign, then folds to the operator's
+ * boolean via a signed i32 compare of the sign against 0 (`foldOp`). Total
+ * for two strings — the sign is never the dynamic-path `2` sentinel.
+ */
+function emitStringRelational(
+  lhs: IrValueId,
+  rhs: IrValueId,
+  foldOp: "i32.lt_s" | "i32.gt_s" | "i32.le_s" | "i32.ge_s",
+  cx: LowerCtx,
+): IrValueId {
+  const sign = cx.builder.emitCall({ kind: "func", name: IR_STRING_COMPARE_FN }, [lhs, rhs], irVal({ kind: "i32" }));
+  if (sign === null) {
+    throw new Error(`ir/from-ast: string compare produced void result (${cx.funcName})`);
+  }
+  const zero = cx.builder.emitConst({ kind: "i32", value: 0 }, irVal({ kind: "i32" }));
+  return cx.builder.emitBinary(foldOp, sign, zero, irVal({ kind: "i32" }));
+}
+
 interface StringMethodSig {
   /** User-arg ValTypes in JS-host mode (excluding receiver). Used to
    *  hint `lowerExpr` and to choose i32-truncation for native mode. */
@@ -5817,6 +5847,27 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
       case ts.SyntaxKind.ExclamationEqualsEqualsToken:
       case ts.SyntaxKind.ExclamationEqualsToken:
         return cx.builder.emitStringEq(lhs, rhs, true);
+      // (#3167) String relational operators `<` `>` `<=` `>=` — §7.2.13
+      // IsLessThan for two String operands is lexicographic code-unit
+      // comparison (NOT locale, NOT numeric). Both operands are statically
+      // `IrType.string` here (the mixed-string case already threw above), so
+      // the compare is always well-defined: emit a call to the mode-resolved
+      // compare helper (`IR_STRING_COMPARE_FN` → native `__str_compare` /
+      // host `string_compare`, resolved by `resolveFunc`), which yields a
+      // -1/0/1 sign i32, then FOLD the sign to the operator's boolean via a
+      // signed i32 compare against 0. This mirrors legacy `emitAnyRelational`'s
+      // both-string arm (binary-ops.ts) but stays representation-agnostic in
+      // from-ast (the #3156 emit-a-named-call pattern — no new IR node kind).
+      // The -1/0/1 sign is total for two strings (never the dynamic path's
+      // `2` incomparable sentinel), so `sign {<,>,<=,>=} 0` is exact.
+      case ts.SyntaxKind.LessThanToken:
+        return emitStringRelational(lhs, rhs, "i32.lt_s", cx);
+      case ts.SyntaxKind.GreaterThanToken:
+        return emitStringRelational(lhs, rhs, "i32.gt_s", cx);
+      case ts.SyntaxKind.LessThanEqualsToken:
+        return emitStringRelational(lhs, rhs, "i32.le_s", cx);
+      case ts.SyntaxKind.GreaterThanEqualsToken:
+        return emitStringRelational(lhs, rhs, "i32.ge_s", cx);
       default:
         throw new Error(`ir/from-ast: string operator '${ts.tokenToString(op)}' not in slice 1 (${cx.funcName})`);
     }

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -68,7 +68,7 @@ import {
   JSSTR_CHARCODEAT_FN,
   NATIVE_CHARCODEAT_FN,
 } from "../codegen/char-code-at-helpers.js";
-import { lowerFunctionAstToIr, STRING_METHOD_TABLE, type IrFromAstResolver } from "./from-ast.js";
+import { IR_STRING_COMPARE_FN, lowerFunctionAstToIr, STRING_METHOD_TABLE, type IrFromAstResolver } from "./from-ast.js";
 import {
   lowerIrFunctionToWasm,
   lowerIrTypeToValType,
@@ -1333,6 +1333,34 @@ function makeResolver(
         }
         return helperIdx;
       }
+      // (#3167) String relational compare helper. Resolve mode-appropriately:
+      //   native/WASI → the `__str_compare` defined helper (idempotently
+      //     ensured via `ensureNativeStringHelpers`; append-only, so no funcIdx
+      //     shift — same discipline as `ensureFmod`/the charCodeAt helpers).
+      //   host → the `string_compare` env import (registered by the legacy
+      //     declaration-collection pass whenever source has a string relational,
+      //     so it is already in `ctx.funcMap`; its import index is stable).
+      // Both are `(str, str) -> i32` returning a -1/0/1 lexicographic sign.
+      if (ref.name === IR_STRING_COMPARE_FN) {
+        if (ctx.nativeStrings) {
+          ensureNativeStringHelpers(ctx);
+          const helperIdx = ctx.nativeStrHelpers.get("__str_compare");
+          if (helperIdx === undefined) {
+            throw new Error(`ir/integration: cannot materialize ${ref.name} (native __str_compare unavailable)`);
+          }
+          // Re-resolve by name against the post-shift function table (the
+          // helper map's captured index can predate later import inserts).
+          for (let i = 0; i < ctx.mod.functions.length; i++) {
+            if (ctx.mod.functions[i]!.name === "__str_compare") return ctx.numImportFuncs + i;
+          }
+          return helperIdx;
+        }
+        const hostIdx = ctx.funcMap.get("string_compare");
+        if (hostIdx === undefined) {
+          throw new Error(`ir/integration: cannot resolve ${ref.name} (host string_compare import not registered)`);
+        }
+        return hostIdx;
+      }
       const idx = ctx.funcMap.get(ref.name);
       if (idx !== undefined) return idx;
       // Slice 6 part 4 (#1183): native-string helpers (`__str_charAt`,
@@ -1609,6 +1637,15 @@ function preregisterStringSupport(ctx: CodegenContext, fns: readonly BuiltFnRef[
     // string op (e.g. `f(s: string) { return s.charCodeAt(0); }` — receiver
     // is a param, no literals), so detect the call target explicitly.
     if (instr.kind === "call" && instr.target.name === JSSTR_CHARCODEAT_FN) {
+      usesStringOp = true;
+    }
+    // (#3167) A body may carry a string relational (`a < b` on string params)
+    // with NO other string op — no literal, concat, or eq. Detect the compare
+    // call so host-mode pre-registration (`addStringImports` + any literal
+    // globals) and native-mode helper availability are guaranteed before
+    // Phase-3 emission. (`resolveFunc` also ensures the native `__str_compare`
+    // on demand, but flagging here keeps the host string-import path uniform.)
+    if (instr.kind === "call" && instr.target.name === IR_STRING_COMPARE_FN) {
       usesStringOp = true;
     }
     if (instr.kind === "extern.regex") {

--- a/tests/issue-3167.test.ts
+++ b/tests/issue-3167.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3167 — IR lowering of string relational operators (`<` `>` `<=` `>=`).
+//
+// `src/ir/from-ast.ts` previously threw `string operator '<' not in slice 1`
+// for a string-typed relational, demoting the whole function to legacy (a
+// warning under the overlay, a HARD compile error under the #3143 IR-first
+// flip — codegen/index.ts:2147-2172). #3153's post-claim census ranked this
+// the #2 remaining divergence class on the equivalence corpus (class 1,
+// substring/charCodeAt, landed as #3156).
+//
+// Fix: both-string relational lowers to a call to the mode-resolved compare
+// helper (native `__str_compare` / host `string_compare`, both a -1/0/1
+// lexicographic sign — §7.2.13 IsLessThan, code-unit order), then folds the
+// sign to the operator's boolean via a signed i32 compare against 0. No new
+// IR node kind (the #3156 emit-a-named-call pattern). The mixed string/
+// non-string case still demotes (unchanged), as does everything else.
+//
+// Governing spec: ECMA-262 §7.2.13 IsLessThan — two String operands compare
+// by UTF-16 code unit (NOT locale, NOT numeric), total for two strings.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "issue-3167.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const leaked = WebAssembly.Module.imports(mod).filter((i) => i.module === "env");
+  expect(
+    leaked.map((i) => i.name),
+    "no host imports leaked in standalone",
+  ).toEqual([]);
+  const inst = await WebAssembly.instantiate(mod, {});
+  return (inst.exports as { test(): number }).test();
+}
+
+async function runHost(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "issue-3167.ts" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = buildImports((r as unknown as { imports: unknown[] }).imports ?? [], undefined, r.stringPool);
+  const inst = await WebAssembly.instantiate(mod, imports as unknown as WebAssembly.Imports);
+  (imports as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    inst.exports as Record<string, Function>,
+  );
+  return (inst.exports as { test(): number }).test();
+}
+
+function bothLanes(name: string, src: string, expected: number) {
+  it(`${name} (standalone)`, async () => expect(await runStandalone(src)).toBe(expected));
+  it(`${name} (host)`, async () => expect(await runHost(src)).toBe(expected));
+}
+
+describe("#3167 — IR string relational operators", () => {
+  bothLanes(
+    "a < b lexicographic true",
+    `export function test(): number { const a="apple"; const b="banana"; return a < b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "a < b false when a > b",
+    `export function test(): number { const a="banana"; const b="apple"; return a < b ? 1 : 0; }`,
+    0,
+  );
+  bothLanes(
+    "a > b true",
+    `export function test(): number { const a="banana"; const b="apple"; return a > b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "a <= b true on equal",
+    `export function test(): number { const a="apple"; const b="apple"; return a <= b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "a >= b true on equal",
+    `export function test(): number { const a="apple"; const b="apple"; return a >= b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "a < b false on equal (strict)",
+    `export function test(): number { const a="apple"; const b="apple"; return a < b ? 1 : 0; }`,
+    0,
+  );
+  bothLanes(
+    "empty string is least",
+    `export function test(): number { const a=""; const b="a"; return a < b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "prefix is less than extension",
+    `export function test(): number { const a="app"; const b="apple"; return a < b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "compares across a function boundary (string params)",
+    `function cmp(a: string, b: string): number { return a < b ? 1 : 0; }
+     export function test(): number { return cmp("a", "b"); }`,
+    1,
+  );
+  bothLanes(
+    "operand from concat (rope) compares by flattened content",
+    `export function test(): number { let a="ap"; a = a + "ple"; return a < "banana" ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    'code-unit order, not numeric ("10" < "9")',
+    `export function test(): number { const a="10"; const b="9"; return a < b ? 1 : 0; }`,
+    1,
+  );
+  bothLanes(
+    "sort-style loop over string comparisons",
+    `export function test(): number {
+       const xs: string[] = ["pear", "apple", "orange"];
+       let swaps = 0;
+       for (let i = 0; i < xs.length; i++) {
+         for (let j = 0; j < xs.length - 1; j++) {
+           if (xs[j] > xs[j + 1]) { const t = xs[j]; xs[j] = xs[j + 1]; xs[j + 1] = t; swaps++; }
+         }
+       }
+       return (xs[0] === "apple" && xs[1] === "orange" && xs[2] === "pear") ? swaps : -1;
+     }`,
+    2,
+  );
+});


### PR DESCRIPTION
## Summary

Clears **#3153 post-claim census class 2** — the #2 remaining IR-first divergence class after #3156's substring/charCodeAt family. On the #3143 IR-first flip track.

`src/ir/from-ast.ts` threw `string operator '<' not in slice 1` for a string-typed relational — a legacy demote under today's overlay, but a **hard compile error** under the #3143 IR-first flip (codegen/index.ts:2147-2172).

Governing spec: **ECMA-262 §7.2.13 IsLessThan** — two String operands compare by UTF-16 **code unit** (not locale, not numeric), total for two strings.

## Fix (both operands statically string)

Follows the #3156 **emit-a-named-call** pattern — **no new IR node kind** (only existing `call`/`const`/`binary` nodes). The both-string switch emits a call to the mode-resolved compare helper (a -1/0/1 lexicographic sign), then folds the sign to the operator's boolean via a signed i32 compare against 0 (`i32.lt_s`/`gt_s`/`le_s`/`ge_s`).

- `IR_STRING_COMPARE_FN` sentinel keeps from-ast **mode-agnostic**; `integration.ts` `resolveFunc` maps it:
  - **native/WASI** → `__str_compare` defined helper (idempotently ensured via `ensureNativeStringHelpers`, append-only + re-resolved by name against the post-shift function table → **no funcIdx shift**),
  - **host** → `string_compare` env import (already registered by the legacy declaration-collection pass whenever source has a string relational — `declarations.ts` ~:587-599 — so **no new host surface**, stable import index).
- `preregisterStringSupport` flags the compare call so a pure-compare body (`f(a,b:string){return a<b}`, no other string op) still pre-registers host string support before Phase-3.

## Validation
- `tests/issue-3167.test.ts` — 12 shapes × **both lanes** (standalone + host), 24 green: lexicographic order, equal/prefix/empty edges, code-unit-not-numeric (`"10" < "9"`), rope operand (concat), cross-function params, a bubble-sort-style comparison loop.
- Under `JS2WASM_IR_FIRST=1`, a string-relational body reports `irPostClaimErrors: []` + `fallbackCounts: {}` — the **IR claims and emits it** (no pre-claim demotion, no post-claim throw).
- `ir-fallbacks` / `oracle-ratchet` / `coercion-sites` clean; loc-budget allowance granted in the issue file (genuine IR feature code, from-ast +51 / integration +37). #3156 + ir-algorithms-cluster + ir-frontend-widening suites green.
- **Broad-impact (IR frontend)** — validated on full CI equivalence shards; not byte-inert for claimed string-relational functions.

## Scope note (for #3143)
The architect plan asked for a `select.ts` mirror rejecting the **mixed** string/non-string relational pre-claim. `select.ts` is **checker-free / purely syntactic** (`isPhase1Expr` defers type compatibility to from-ast), so a type-aware mixed-operand reject isn't expressible there. The mixed case keeps its existing from-ast throw — **unchanged from today** (it already demoted under the overlay), **not a #3167 regression**. For the #3143 flip it's handled empirically by the #3153 post-claim meter (lower it as ToNumber-both + f64 compare only if it appears on the corpus — a small #3143 gate-check follow-up). See the issue's resolution note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8