### PR TITLE
fix(#3186): host-lane for-in string-key read is SOUND — census + regression guard

### DIFF
--- a/plan/issues/3186-host-lane-forin-string-index-silent-wrong-value.md
+++ b/plan/issues/3186-host-lane-forin-string-index-silent-wrong-value.md
@@ -1,7 +1,9 @@
 ---
 id: 3186
 title: "[SOUNDNESS] host lane: for-in string-key element read returns a silently WRONG VALUE — un-filed sibling of #3179 + family census"
-status: ready
+status: done
+completed: 2026-07-12
+assignee: ttraenkler/dev-forin-sound
 created: 2026-07-12
 priority: high
 feasibility: hard
@@ -15,6 +17,78 @@ horizon: m
 related: [3179, 3162, 3176]
 origin: "2026-07-12 Fable codebase audit (plan/log/2026-07-12-fable-codebase-audit.md, §F3); documented but un-filed in #3179's own ablation notes"
 ---
+
+## RESOLUTION (2026-07-12, dev-forin-sound) — host lane is SOUND; no code fix
+
+**The premise does not reproduce.** Measured on current `origin/main`
+(65854d48d), the gc/JS-host lane for-in string-key array element read returns
+the **correct** value for reads *and* writes across every array
+representation. There is **no silent wrong value on the host lane.** The only
+host-lane defect is a **TRAP** (`illegal cast`) on the rep-divergent
+`new Array()`+numeric case — which is the #3179 loop-header mechanism
+(shared `emitArrayForIn`), *not* a silent wrong value. Since a trap
+self-announces, it is out of this issue's "silent" scope and is already owned
+by #3179 (whose fix covers both lanes because the code path is shared).
+
+**Unmasking check (decisive).** Because a trap could *mask* a downstream
+wrong-value in the element read, I cherry-picked #3179's (unmerged) loop-header
+fix locally and re-ran the census: once the loop trap is fixed, the gc host
+element read is **fully correct in every case** — the trap was masking nothing.
+Conversely, applying #3179's fix turns the standalone/WASI *traps* into *wrong
+values* (expected — #3179 flips the specific built-in/JSON rows and splits the
+residual dynamic-vec-arm face to #3183). So **all** silent wrong values live on
+the **standalone lane**, which #3179/#3183 own. This issue's host lane needs no
+change; per soundness discipline no speculative fix was shipped.
+
+Net source change: **none.** Deliverable: this census + a host-lane
+regression-guard equivalence test (`tests/issue-3186.test.ts`) that locks in the
+correct host behaviour so a future regression is caught.
+
+### Family census — for-in / `Object.keys` string-key array element access
+
+Measured 2026-07-12 on `origin/main` @65854d48d. Expected value in parens.
+`correct` = returns expected; `TRAP` = `illegal cast` (self-announcing);
+`WRONG(x)` = silent wrong value.
+
+| case (string key) | gc / JS-host | standalone / WASI | owner |
+| --- | --- | --- | --- |
+| **read** vec, string values (rep match) | `correct` | `TRAP` | #3179 (standalone trap) |
+| **read** vec, numeric values, `new Array()` (rep divergence) | `TRAP` | `TRAP` | #3179 (both lanes, shared loop header) |
+| **read** vec, numeric values, `[10,20,30]` literal | `correct` | `WRONG(30)` | **standalone silent** → #3179 family |
+| **read** via `Object.keys(a)`, numeric | `correct` | `WRONG(0)` | #3183 (dynamic vec arms) |
+| **write** `a[k]=v`, string key | `correct` | `WRONG(5)` | **standalone silent** → #3179 family |
+| **read** `Int32Array`, string key | `correct` | `WRONG(30)` | **standalone silent** → new/child of #3179 |
+| **read** `any`-typed receiver | `correct` | `WRONG(0)` | #3183 (dynamic vec arms) |
+
+Reading of the table:
+- **gc / JS-host column**: every cell is `correct` except the rep-divergence
+  `new Array()`+numeric case, which is a **TRAP** (the #3179 loop-header
+  mechanism), never a silent wrong value. **Host lane is sound for the #3186
+  concern.**
+- **standalone / WASI column**: multiple **silent** wrong values. These are the
+  real remaining soundness gaps, and they are on #3179's lane (explicitly
+  out-of-scope here per acceptance criterion 4). Cells worth flagging to the
+  #3179/#3183 owners that the existing children may not yet fully cover:
+  `[10,20,30]`-literal `WRONG(30)`, `write` `WRONG(5)`, and `Int32Array`
+  `WRONG(30)` are *concrete-path* standalone element reads, not just the
+  dynamic vec arms of #3183. Recommend confirming these are inside #3179's
+  post-fix scope or filing a measured child.
+
+### Acceptance criteria disposition
+1. Repro returns **6** on the default lane (verified) and a host-lane
+   regression-guard equivalence test is added (`tests/issue-3186.test.ts`). ✓
+2. `order-after-define-property.js` / `scope-head-var-none.js`: **root-caused as
+   distinct** — those are object-enumeration-order / head-var-scope for-in
+   semantics, not the array string-key element-read path this issue targets. The
+   array element-read path is sound on the host lane (census above); those two
+   are separate object-path concerns and are not fixed or regressed by this
+   issue. (No test262 submodule in this checkout to flip them directly; they
+   remain owned by their own object-for-in surface.)
+3. Family census table filled with measured evidence. ✓ Non-correct cells are
+   all on the standalone lane and attributed to #3179/#3183 (or flagged for a
+   measured child).
+4. No standalone regressions — this issue changes **no source**, so the
+   standalone lane is untouched (#3179 owns it). ✓
 
 # #3186 — host lane: for-in string-key element read returns silent wrong value
 

--- a/tests/issue-3186.test.ts
+++ b/tests/issue-3186.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3186 — [SOUNDNESS] host lane: for-in string-key array element read.
+//
+// The Fable audit (§F3) claimed the gc/JS-host lane returns a *silent wrong
+// value* for `for (var k in arr) arr[k]` where `k` is a runtime string index —
+// the un-filed host sibling of #3179's standalone `illegal cast` trap.
+//
+// Verification (2026-07-12, dev-forin-sound) showed the premise does NOT
+// reproduce: the host lane is CORRECT for reads and writes across every array
+// representation. The one host-lane defect is a self-announcing TRAP on the
+// rep-divergent `new Array()`+numeric case, which is the #3179 loop-header
+// mechanism (shared `emitArrayForIn`), not a silent wrong value — owned by
+// #3179. All *silent* wrong values live on the standalone/WASI lane
+// (#3179/#3183 own that lane; see the census in plan/issues/3186-*.md).
+//
+// This test is the regression GUARD: it pins the correct host-lane behaviour so
+// a future change cannot silently reintroduce a wrong value on this path. See
+// the family census in the issue file for the full {read,write} × {array rep} ×
+// {host,standalone} matrix.
+async function runHost(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as unknown as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!();
+}
+
+describe("#3186 host-lane for-in string-key array element read is sound", () => {
+  it("exact audit repro returns 6 (string values, length after concat)", async () => {
+    // The literal repro from #3179's ablation / #3186's Problem section.
+    expect(
+      await runHost(`export function test(): number {
+        var nullChars = new Array();
+        nullChars[0] = '"a"';
+        nullChars[1] = '"b"';
+        let s = '';
+        for (var index in nullChars) { s = s + nullChars[index]; }
+        return s.length;
+      }`),
+    ).toBe(6);
+  });
+
+  it("string values: concatenated content is exactly correct, not just the length", async () => {
+    // Guards against a wrong value that happens to preserve length.
+    expect(
+      await runHost(`export function test(): string {
+        var a = new Array();
+        a[0] = '"a"';
+        a[1] = '"b"';
+        let s = '';
+        for (var i in a) { s = s + a[i]; }
+        return s;
+      }`),
+    ).toBe('"a""b"');
+  });
+
+  it("read: numeric literal array sums correctly via string keys", async () => {
+    expect(
+      await runHost(`export function test(): number {
+        var a = [10, 20, 30];
+        let s = 0;
+        for (var i in a) { s = s + a[i]; }
+        return s;
+      }`),
+    ).toBe(60);
+  });
+
+  it("read: Object.keys(a)[i] numeric access is correct", async () => {
+    expect(
+      await runHost(`export function test(): number {
+        var a = [10, 20, 30];
+        let s = 0;
+        for (var i of Object.keys(a)) { s = s + a[i]; }
+        return s;
+      }`),
+    ).toBe(60);
+  });
+
+  it("write: assigning a[k]=v through a string key updates the element", async () => {
+    expect(
+      await runHost(`export function test(): number {
+        var a = [0, 0, 0];
+        for (var i in a) { a[i] = 5; }
+        return a[0] + a[1] + a[2];
+      }`),
+    ).toBe(15);
+  });
+
+  it("read: TypedArray (Int32Array) string-key element read is correct", async () => {
+    expect(
+      await runHost(`export function test(): number {
+        var a = new Int32Array(3);
+        a[0] = 10; a[1] = 20; a[2] = 30;
+        let s = 0;
+        for (var i in a) { s = s + a[i]; }
+        return s;
+      }`),
+    ).toBe(60);
+  });
+
+  it("read: any-typed receiver string-key element read is correct", async () => {
+    expect(
+      await runHost(`function get(a: any): number {
+        let s = 0;
+        for (var i in a) { s = s + a[i]; }
+        return s;
+      }
+      export function test(): number { return get([10, 20, 30]); }`),
+    ).toBe(60);
+  });
+
+  it("read+write roundtrip: mutate then re-read via string keys", async () => {
+    expect(
+      await runHost(`export function test(): number {
+        var a = ['1', '2', '3'];
+        let s = '';
+        for (var i in a) { a[i] = a[i] + '!'; }
+        for (var j in a) { s = s + a[j]; }
+        return s.length;
+      }`),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## #3186 — [SOUNDNESS] host-lane for-in string-key element read

**Resolution: the premise does not reproduce. Host lane is SOUND. No source change.**

The Fable audit (§F3) claimed the gc/JS-host lane returns a *silent wrong value* for `for (var k in arr) arr[k]` (string key), as the un-filed host sibling of #3179's standalone `illegal cast` trap. Measured on current `main`, that is not the case.

### Family census (measured, 2026-07-12)

| case (string key) | gc / JS-host | standalone / WASI | owner |
| --- | --- | --- | --- |
| read vec, string values (rep match) | `correct` | `TRAP` | #3179 |
| read vec, numeric, `new Array()` (rep divergence) | `TRAP` | `TRAP` | #3179 (shared loop header) |
| read vec, numeric, `[10,20,30]` literal | `correct` | `WRONG(30)` | standalone -> #3179 family |
| read `Object.keys(a)`, numeric | `correct` | `WRONG(0)` | #3183 |
| write `a[k]=v`, string key | `correct` | `WRONG(5)` | standalone -> #3179 family |
| read `Int32Array`, string key | `correct` | `WRONG(30)` | standalone |
| read `any`-typed receiver | `correct` | `WRONG(0)` | #3183 |

- **gc/host column**: every cell `correct` except a self-announcing **TRAP** on the rep-divergent `new Array()`+numeric case — that is the #3179 loop-header mechanism (shared `emitArrayForIn`), **not** a silent wrong value. Host lane is sound for #3186's concern.
- **Unmasking check**: cherry-picked #3179's unmerged loop fix locally -> the gc host element read is then correct in every case, so the trap was masking nothing.
- All **silent** wrong values are on the standalone/WASI lane — routed to #3179/#3183.

### Deliverables
- Family census table in `plan/issues/3186-*.md` (measured evidence so siblings get filed, not rediscovered bucket-by-bucket).
- `tests/issue-3186.test.ts`: **8 host-lane regression guards** (reads + writes across every array rep) locking in correct behaviour.

**No source change -> zero regression risk.** Standalone lane untouched (#3179 owns it).

Closes #3186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)