### PR TITLE
chore(#3187): split error_category classifier — missing_builtin / missing_dependency out of wasm_compile

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -33,6 +33,17 @@ several `standalone-invalid-wasm-*` issues already tracked (#2039, #2878,
 #2934 — all standalone-target-specific), this bucket is on the **default
 `gc` target**, so it's a distinct residual not covered by those.
 
+> **Re-anchor (#3187, 2026-07-12):** this **131** figure is the *genuine*
+> validator-error subset (harvested by the `invalid Wasm binary` /
+> `Compiling function … failed` text). It is **not** the raw
+> `error_category: "wasm_compile"` bucket, which carried **~448** records
+> before #3187 because the classifier mis-binned `… is not a function`
+> (missing builtin) and `No dependency provided …` (missing dependency) as
+> `wasm_compile`. Post-#3187 the `wasm_compile` category is narrowed to the
+> genuine class (~87–131 depending on baseline), so this issue's scope was
+> already the honest count; use the `wasm_compile` bucket directly now that
+> it is un-inflated.
+
 ## Breakdown by validator error
 
 | reason                                              |               count |

--- a/plan/issues/3187-test262-error-category-wasm-compile-mislabel.md
+++ b/plan/issues/3187-test262-error-category-wasm-compile-mislabel.md
@@ -1,7 +1,9 @@
 ---
 id: 3187
 title: "test262 runner: error_category classifier mis-bins ~80% of 'wasm_compile' — missing-builtin / missing-dependency need own buckets"
-status: ready
+status: done
+completed: 2026-07-12
+assignee: ttraenkler/dev-forin-sound
 created: 2026-07-12
 priority: medium
 feasibility: easy
@@ -82,6 +84,40 @@ label-only). Check `tests/issue-1908.test.ts:52` / `tests/issue-1781.test.ts:48`
    `missing_dependency` buckets absorb the rest; zero pass/fail flips.
 2. `oracle_version` bumped; affected fixture tests updated.
 3. #3024's problem statement re-anchored to the honest count (one-line edit).
+
+## Resolution (2026-07-12, dev-forin-sound)
+
+`classifyError` (`tests/test262-runner.ts`) now classifies in this order:
+
+1. `/invalid Wasm binary|Compiling function/` → `wasm_compile` (genuine, first).
+2. `/No dependency provided/` → `missing_dependency` (new — captures BOTH
+   `extern class "X"` and `imported function env::__X` forms; broader than the
+   issue's `extern class`-only suggestion so the DI diagnostic is binned
+   consistently).
+3. `/\bis not a function\b/` → `missing_builtin` (new — kept AFTER rule 1 so an
+   instantiate error that quotes source isn't stolen).
+4. `/no test export/` → `harness_shape` (new — was `wasm_compile`; the module
+   compiled fine, it just exposes no `test` export).
+
+- `ORACLE_VERSION` bumped 2 → 3 (`tests/test262-oracle-version.ts`) with a
+  history entry; the `check-verdict-oracle-bump` gate passes. **Label-only:
+  zero pass/fail flips** — no verdict changes, only category names. The
+  regression-gate bucket diff on the next promote is label-noise (ORACLE_REBASE).
+- Fixtures: `tests/issue-1781.test.ts` updated (the `No dependency provided …`
+  record moves `wasm_compile` → `missing_dependency`, signature + assertion).
+  `tests/issue-1908.test.ts` unchanged — its error quotes `Compiling function`
+  so it stays `wasm_compile` (rule 1). New unit test `tests/issue-3187.test.ts`
+  pins all four buckets + the ordering guarantee + the oracle bump.
+- #3024 problem statement re-anchored (one-line block) — its 131 is the genuine
+  validator-error subset, not the ~448 raw `wasm_compile` error_category count.
+
+### Acceptance criteria disposition
+1. Post-change: genuine `wasm_compile` narrowed to `invalid Wasm binary`/
+   `Compiling function` (~87–131); `missing_builtin` / `missing_dependency` /
+   `harness_shape` absorb the rest; zero pass/fail flips. ✓ (verified via
+   `classifyError` unit test; baseline bucket counts shift on next promote.)
+2. `oracle_version` bumped; affected fixtures updated. ✓
+3. #3024 re-anchored to the honest count. ✓
 
 ## Audit cross-link
 

--- a/tests/issue-1781.test.ts
+++ b/tests/issue-1781.test.ts
@@ -45,8 +45,8 @@ describe("#1781 standalone test262 artifact root-cause map", () => {
         category: "built-ins/Object",
         status: "compile_error",
         error: "No dependency provided for imported function env::__extern_get",
-        error_category: "wasm_compile",
-        error_signature: "wasm_compile:No dependency provided for imported function env::__extern_get",
+        error_category: "missing_dependency",
+        error_signature: "missing_dependency:No dependency provided for imported function env::__extern_get",
         imports: ["env::__extern_get"],
         host_import_leak_class: "dynamic_object_property",
         reached_test: false,
@@ -104,7 +104,7 @@ describe("#1781 standalone test262 artifact root-cause map", () => {
     expect(byId.get("standalone-dynamic-object-property").issues).toContain("#1472");
     expect(byId.get("standalone-regexp-native-engine").issues).toContain("#1914");
     expect(byId.get("standalone-dynamic-object-property").sample_signatures).toContain(
-      "wasm_compile:No dependency provided for imported function env::__extern_get",
+      "missing_dependency:No dependency provided for imported function env::__extern_get",
     );
     expect(byId.get("standalone-dynamic-object-property").sample_signatures).toContain(
       "other:L#:## Codegen error: Proxy not supported in standalone mode (## Phase C).",

--- a/tests/issue-3187.test.ts
+++ b/tests/issue-3187.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { classifyError } from "./test262-runner.js";
+import { ORACLE_VERSION } from "./test262-oracle-version.js";
+
+// #3187 — error_category classifier split.
+//
+// classifyError previously binned "… is not a function" (a missing builtin /
+// unimplemented runtime feature) and "No dependency provided for …" (the
+// compiler's own dependency-injection diagnostic) as `wasm_compile`, inflating
+// the genuine invalid-Wasm bucket ~3.4× (~448 → ~87 default-lane records). This
+// pins the split into three honest buckets and the narrowed wasm_compile.
+//
+// This is a verdict-classification change, so ORACLE_VERSION was bumped (>= 3).
+describe("#3187 error_category classifier split", () => {
+  it("keeps GENUINE invalid-Wasm as wasm_compile", () => {
+    expect(
+      classifyError(
+        'invalid Wasm binary (WebAssembly.instantiate(): Compiling function #47:"isSameValue" failed: call[0] expected type i32, found local.get of type externref @+123)',
+      ),
+    ).toBe("wasm_compile");
+    expect(classifyError("WebAssembly.instantiate(): Compiling function #3 failed")).toBe("wasm_compile");
+  });
+
+  it("bins '… is not a function' as missing_builtin, not wasm_compile", () => {
+    for (const msg of [
+      "safeBroadcast is not a function",
+      "safeBroadcastAsync is not a function",
+      "transferToImmutable is not a function",
+      "sumPrecise is not a function",
+      "then is not a function",
+      "object is not a function",
+      "undefined is not a function",
+    ]) {
+      expect(classifyError(msg), msg).toBe("missing_builtin");
+    }
+  });
+
+  it("bins 'No dependency provided …' as missing_dependency, not wasm_compile", () => {
+    for (const msg of [
+      'No dependency provided for extern class "BigInt"',
+      'No dependency provided for extern class "FinalizationRegistry"',
+      "No dependency provided for imported function env::__extern_get",
+    ]) {
+      expect(classifyError(msg), msg).toBe("missing_dependency");
+    }
+  });
+
+  it("bins 'no test export' as harness_shape, not wasm_compile", () => {
+    expect(classifyError("no test export")).toBe("harness_shape");
+  });
+
+  it("does not steal a genuine wasm_compile that also quotes source text", () => {
+    // An instantiate error that quotes a helper name must stay wasm_compile even
+    // though the ordering places missing_builtin/missing_dependency later.
+    expect(classifyError('Compiling function #12:"isConstructor" failed: type mismatch')).toBe("wasm_compile");
+  });
+
+  it("bumped ORACLE_VERSION (classification logic changed)", () => {
+    expect(ORACLE_VERSION).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/tests/test262-oracle-version.ts
+++ b/tests/test262-oracle-version.ts
@@ -31,7 +31,7 @@
  * version or a date. Two runs with the same ORACLE_VERSION are guaranteed to
  * apply identical verdict logic, so their rows are directly comparable.
  */
-export const ORACLE_VERSION = 2;
+export const ORACLE_VERSION = 3;
 
 /**
  * Append-only log of what each oracle version means. Newest last.
@@ -57,5 +57,19 @@ export const ORACLE_VERSION_HISTORY: ReadonlyArray<{ version: number; note: stri
       "regression). Landed with ORACLE_REBASE (forward-monotonic bump auto-" +
       "rebases in diff-test262.ts) so the guards treat the cross-policy diff as " +
       "a re-baseline; promote-baseline re-seeds host+standalone baselines at v2.",
+  },
+  {
+    version: 3,
+    note:
+      "#3187 error_category classifier split. classifyError previously binned " +
+      "'… is not a function' (missing builtin/runtime feature) and 'No dependency " +
+      "provided for …' (the compiler's DI diagnostic) as wasm_compile, inflating " +
+      "the genuine invalid-Wasm bucket ~3.4× (~448 → ~87 default-lane). Splits out " +
+      "three honest buckets: missing_builtin ('\\bis not a function\\b'), " +
+      "missing_dependency ('No dependency provided'), and harness_shape ('no test " +
+      "export'), while wasm_compile is narrowed to 'invalid Wasm binary|Compiling " +
+      "function'. LABEL-ONLY: zero pass/fail flips (net_per_test 0). The " +
+      "regression-gate bucket diff is label-noise; landed with ORACLE_REBASE so " +
+      "the guards treat the cross-policy relabel as a re-baseline.",
   },
 ];

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -4204,10 +4204,24 @@ function round2(n: number): number {
  *   promise_error   — Promise rejection or async failure
  *   assertion_fail  — Test returned non-1 value (assert counter)
  *   exception_in_test — Test returned -1 (exception caught by wrapper)
- *   wasm_compile    — Wasm validation/instantiation error
+ *   wasm_compile    — GENUINE Wasm validation/instantiation error
+ *                     ("invalid Wasm binary" / "Compiling function #N…failed")
+ *   missing_dependency — (#3187) compiler DI diagnostic: a required extern
+ *                     class or host import function was never wired
+ *                     ("No dependency provided for …") — NOT invalid-Wasm
+ *   missing_builtin — (#3187) an unimplemented builtin / runtime feature
+ *                     ("… is not a function") — NOT invalid-Wasm
+ *   harness_shape   — (#3187) module compiled but exposes no `test` export
+ *                     ("no test export") — NOT invalid-Wasm
  *   negative_test_fail — Negative test that should have failed but passed
  *   runtime_error   — Other Cannot/Invalid runtime errors
  *   other           — Unclassified
+ *
+ * (#3187) The wasm_compile / missing_dependency / missing_builtin / harness_shape
+ * split un-inflates the genuine invalid-Wasm bucket (~448 → ~87): "… is not a
+ * function" and "No dependency provided …" were previously mis-binned as
+ * wasm_compile. This is a verdict-classification change, so ORACLE_VERSION was
+ * bumped (see tests/test262-oracle-version.ts). Label-only: no pass/fail flips.
  */
 export function classifyError(errorMsg: string | undefined): string | undefined {
   if (!errorMsg) return undefined;
@@ -4237,11 +4251,26 @@ export function classifyError(errorMsg: string | undefined): string | undefined 
   // WITHOUT the constructor-name prefix.
   if (/^Test262Error\b/.test(errorMsg)) return "assertion_fail";
 
-  // Wasm compile/validation errors (from instantiation)
-  if (/Compiling function|No dependency provided|not a function/i.test(errorMsg)) return "wasm_compile";
+  // Wasm compile/validation errors (from instantiation). (#3187) Order matters:
+  // classify GENUINE invalid-Wasm FIRST so an instantiation error that quotes
+  // source text ("Compiling function #N…failed: …") isn't stolen by the
+  // missing-builtin/missing-dependency rules below.
+  if (/invalid Wasm binary|Compiling function/i.test(errorMsg)) return "wasm_compile";
+  // (#3187) The compiler's own dependency-injection diagnostic — "No dependency
+  // provided for extern class X" / "…for imported function env::__X" — is NOT
+  // invalid-Wasm; it means a required host import/extern was never wired. Its own
+  // bucket so it stops inflating wasm_compile (~56 records were mis-binned).
+  if (/No dependency provided/i.test(errorMsg)) return "missing_dependency";
+  // (#3187) "… is not a function" is a missing builtin / unimplemented runtime
+  // feature (safeBroadcast, transferToImmutable, sumPrecise, then, …), not an
+  // invalid-Wasm binary. Kept AFTER the genuine-wasm_compile rule above so
+  // instantiate errors that quote source aren't stolen (~170 records mis-binned).
+  if (/\bis not a function\b/i.test(errorMsg)) return "missing_builtin";
   if (/expected .+ but compiled/i.test(errorMsg)) return "negative_test_fail";
   if (/expected runtime .+ but succeeded/i.test(errorMsg)) return "negative_test_fail";
-  if (/no test export/i.test(errorMsg)) return "wasm_compile";
+  // (#3187) "no test export" is a harness-shape problem (module compiled fine but
+  // exposes no `test` export), not invalid-Wasm — its own bucket.
+  if (/no test export/i.test(errorMsg)) return "harness_shape";
 
   // Catch-all for other errors
   if (/Cannot |Invalid /i.test(errorMsg)) return "runtime_error";


### PR DESCRIPTION
## #3187 — error_category classifier split

`classifyError` (`tests/test262-runner.ts`) previously binned `… is not a function` (a missing builtin/runtime feature) and `No dependency provided for …` (the compiler's own DI diagnostic) as `wasm_compile`, inflating the genuine invalid-Wasm bucket ~3.4× (~448 → ~87 default-lane records).

### New classification order
1. `/invalid Wasm binary|Compiling function/` → `wasm_compile` (genuine, first — so an instantiate error that quotes source isn't stolen).
2. `/No dependency provided/` → `missing_dependency` (**new**; captures both `extern class "X"` and `imported function env::__X`).
3. `/\bis not a function\b/` → `missing_builtin` (**new**).
4. `/no test export/` → `harness_shape` (**new**; was `wasm_compile`).

### Label-only, oracle bumped
- **Zero pass/fail flips** — only category names change (net_per_test 0). The regression-gate bucket diff on the next promote is label-noise.
- `ORACLE_VERSION` bumped **2 → 3** (`tests/test262-oracle-version.ts`) with a history entry, per the #3003 verdict-logic rule. `check-verdict-oracle-bump` gate passes locally.

### Fixtures / tests
- `tests/issue-1781.test.ts`: the `No dependency provided …` record moves `wasm_compile` → `missing_dependency` (field + signature + assertion).
- `tests/issue-1908.test.ts`: **unchanged** — its error quotes `Compiling function` so it stays `wasm_compile` (rule 1).
- `tests/issue-3187.test.ts`: **new** unit test pinning all four buckets, the ordering guarantee, and the oracle bump.
- #3024 problem statement re-anchored (one-line block): its 131 is the genuine validator-error subset, not the ~448 raw `wasm_compile` count.

Closes #3187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)