### PR TITLE
chore(#3189): uncatchable-trap growth ratchet in the test262 regression gate

### DIFF
--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -216,6 +216,32 @@ real run-to-run standalone drift was 0 regressions / +3 improvements, so 15
 sits well above the noise floor. The threshold is tunable via the
 `STANDALONE_REGRESSION_TOLERANCE` env on the guard step.
 
+### Uncatchable-trap growth ratchet (#3189)
+
+On top of the net/ratio/bucket gate, `scripts/diff-test262.ts` runs a
+**per-category trap ratchet**: for each of the four uncatchable-Wasm-trap
+`error_category` values — `null_deref`, `illegal_cast`, `oob`, `unreachable` —
+it compares the candidate's population against the baseline's, and **fails the
+gate (`exit 1`) on ANY growth in ANY trap category, independent of
+`net_per_test`**. A net-positive PR that fixes 60 assertion-fails while
+introducing 12 new `illegal_cast`s clears the net/ratio gate but is blocked
+here. The rationale: a Wasm trap **escapes `try`/`catch`** and aborts the whole
+test file (#3179 — a trap inside `assert.throws` poisons every test whose body
+shares the pattern), so the "crash-free (traps → 0)" goal
+(`plan/goals/goal-graph.md`) treats a trap as strictly worse than an ordinary
+fail — the trap population may only shrink or hold. The failure names the
+newly-trapping files. This applies in **both** the normal and the oracle
+re-baseline branches (a genuinely new trap is a real regression regardless of an
+oracle bump; the trap categories are not touched by any oracle reclassification,
+so they stay comparable across a forward bump). **Decreases auto-bank** with no
+per-PR baseline-bump merge conflict: the ratchet reads the committed baseline
+jsonl that `promote-baseline` re-seeds on every push to main (#1528/#3131), so a
+trap fix lowers the floor automatically on the next promote — there is no
+separate ratchet baseline file. Byte-identical (`wasm_sha`-unchanged) pass→trap
+flips are excluded as CI runner noise, exactly like the `net_per_test` gate's
+wasm-hash filter (#1222). The pure `evaluateTrapCategoryGrowth` logic is
+unit-tested in `tests/issue-3189.test.ts`.
+
 ---
 
 ## 4. Linear history and merge mode

--- a/plan/issues/3189-trap-category-growth-ratchet-ci.md
+++ b/plan/issues/3189-trap-category-growth-ratchet-ci.md
@@ -1,7 +1,9 @@
 ---
 id: 3189
 title: "CI ratchet: hard-fail on uncatchable-trap category GROWTH (null_deref/illegal_cast/oob/unreachable) in the test262 regression gate"
-status: ready
+status: done
+completed: 2026-07-12
+assignee: ttraenkler/dev-forin-sound
 created: 2026-07-12
 priority: medium
 feasibility: medium
@@ -64,6 +66,47 @@ the four trap categories**:
 2. Trap-category decreases bank automatically without per-PR baseline-bump
    merge conflicts.
 3. Doc: one paragraph in `docs/ci-policy.md` describing the ratchet.
+
+## Resolution (2026-07-12, dev-forin-sound)
+
+Implemented as a pure, unit-tested extension of the existing `diff-test262.ts`
+gate machinery (the same script the required `check for test262 regressions` /
+`merge shard reports` guards run) — no new required-check name, no new CI job.
+
+- **`evaluateTrapCategoryGrowth(baseline, newer, tolerance=0)`** (`scripts/diff-test262.ts`):
+  per-category population diff for `null_deref` / `illegal_cast` / `oob` /
+  `unreachable` (exported `TRAP_ERROR_CATEGORIES`). **Any growth in any trap
+  category → gate fail**, independent of `net_per_test`, naming the newly-trapping
+  files. Pure (no I/O), mirroring `evaluateRegressionThresholds` (#1943).
+- **Wired into `run()`** — applied in BOTH the normal and the oracle-rebase
+  branches (a new trap is a real regression regardless of an oracle bump; the
+  trap categories aren't touched by any oracle reclassification, so they stay
+  comparable across a forward bump). Prints a `Trap categories (baseline →
+  candidate)` line every run.
+- **Decreases auto-bank, conflict-free**: the ratchet reads the committed
+  baseline jsonl that `promote-baseline` re-seeds on every push to main
+  (#1528) — no separate ratchet baseline file, so no per-PR baseline-bump merge
+  conflict (#3131 pattern, achieved structurally).
+- **Noise discipline**: a byte-identical (`wasm_sha`-unchanged) pass→trap flip is
+  excluded as CI runner noise (a static miscompile can't appear on an identical
+  binary), exactly like the `net_per_test` gate's wasm-hash filter (#1222).
+- **Operational safety valve**: `TRAP_RATCHET_TOLERANCE` env (default 0 — strict)
+  mirrors `STANDALONE_REGRESSION_TOLERANCE`, so a false-positive against baseline
+  drift can be loosened without a code change rather than wedging the queue.
+- **Coordination**: lands after / alongside #3187 (classifier split) so the
+  ratchet baseline is taken on honest categories. The four trap categories are
+  unaffected by #3187's `wasm_compile` split, so the ordering is safe either way.
+
+### Acceptance criteria disposition
+1. A PR that increases any trap-category count vs baseline gets a failing gate
+   signal (`exit 1`) naming the newly-trapping files. ✓ (unit-tested +
+   CLI-smoke-tested: growth → exit 1, flat/shrink → exit 0.)
+2. Decreases bank automatically without per-PR baseline-bump merge conflicts —
+   the baseline is the promote-refreshed jsonl, no separate file. ✓
+3. Doc paragraph in `docs/ci-policy.md` (§3, "Uncatchable-trap growth ratchet"). ✓
+
+Tests: `tests/issue-3189.test.ts` (9 cases — hold/shrink/grow, net-positive-with-
+new-traps block, wasm-identical noise exclusion, lateral move, tolerance valve).
 
 ## Audit cross-link
 

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -33,6 +33,15 @@ export const REGRESSION_RATIO_LIMIT = 0.1;
 export const REGRESSION_BUCKET_LIMIT = 50;
 export const REGRESSION_BUCKET_PATH_DEPTH = 5;
 
+// #3189 — the four UNCATCHABLE Wasm-trap error categories. A trap aborts the
+// whole test file and escapes `try`/`catch` (documented in #3179 — a trap
+// inside `assert.throws` poisons every test whose body shares the pattern), so
+// the "crash-free (traps → 0)" goal (plan/goals/goal-graph.md) treats them as
+// strictly worse than an ordinary assertion fail. These strings are assigned by
+// `classifyError` (tests/test262-runner.ts) and are stable in the jsonl.
+export const TRAP_ERROR_CATEGORIES = ["null_deref", "illegal_cast", "oob", "unreachable"] as const;
+export type TrapCategory = (typeof TRAP_ERROR_CATEGORIES)[number];
+
 // #3086 — drift tolerance for a DELIBERATE oracle re-baseline (forward-bump
 // auto-rebase or ORACLE_REBASE=1). A pure re-baseline has ~0 improvements, so
 // the strict net<0 / ratio<10% gate is structurally inapplicable: ANY residual
@@ -95,6 +104,97 @@ export function evaluateRegressionThresholds(opts: {
     }
   }
   return failures;
+}
+
+/** Minimal row shape the trap ratchet needs (a subset of `TestResult`). */
+type TrapRatchetRow = { status: string; error_category?: string; wasm_sha?: string | null };
+
+export interface TrapCategoryGrowth {
+  /** Human-readable GATE-FAIL reasons (empty ⇒ within ratchet). */
+  failures: string[];
+  /** baseline population per trap category. */
+  baseCounts: Record<TrapCategory, number>;
+  /** candidate population per trap category (noise-filtered). */
+  newCounts: Record<TrapCategory, number>;
+  /** files that newly entered each trap category (weren't trapping there in baseline). */
+  newlyTrapping: Record<TrapCategory, string[]>;
+}
+
+/**
+ * #3189 — trap-category GROWTH ratchet. For each of the four uncatchable-trap
+ * categories, compare the candidate's population against the baseline's. **Any
+ * growth in any trap category is a gate failure**, independent of `net_per_test`
+ * — so a PR that fixes 60 assertion-fails while introducing 12 new illegal-casts
+ * (net-positive, so it clears the existing net/ratio gate) is still blocked. The
+ * "crash-free (traps → 0)" goal is a strict ratchet: the trap population may
+ * only shrink or hold. Decreases auto-bank because the committed baseline jsonl
+ * is re-seeded by `promote-baseline` on every push to main (#1528) — no separate
+ * baseline file, so there is no per-PR baseline-bump merge conflict (#3131).
+ *
+ * Pure (no I/O) so the unit test drives it with fixture maps, mirroring
+ * `evaluateRegressionThresholds` (#1943).
+ *
+ * Noise discipline: a trap category is a STATIC miscompile signal — a
+ * byte-identical binary (same `wasm_sha`) cannot newly trap — so a candidate row
+ * whose wasm hash is unchanged from a baseline row of the same file is excluded
+ * as CI runner noise, exactly like the `net_per_test` gate's `wasmUnchanged`
+ * filter (#1222). This prevents a flaky pass→trap flip on an identical binary
+ * from tripping the ratchet.
+ */
+export function evaluateTrapCategoryGrowth(
+  baseline: Map<string, TrapRatchetRow>,
+  newer: Map<string, TrapRatchetRow>,
+  /**
+   * Per-category growth tolerance (default 0 — strict ratchet). An operational
+   * safety valve wired to `TRAP_RATCHET_TOLERANCE` in the CLI, mirroring
+   * `STANDALONE_REGRESSION_TOLERANCE`: if the ratchet ever proves brittle
+   * against baseline drift it can be loosened without a code change, rather than
+   * wedging the merge queue. Growth fails only when it EXCEEDS the tolerance.
+   */
+  tolerancePerCategory = 0,
+): TrapCategoryGrowth {
+  const zero = () => Object.fromEntries(TRAP_ERROR_CATEGORIES.map((c) => [c, 0])) as Record<TrapCategory, number>;
+  const baseCounts = zero();
+  const newCounts = zero();
+  const newlyTrapping = Object.fromEntries(TRAP_ERROR_CATEGORIES.map((c) => [c, [] as string[]])) as Record<
+    TrapCategory,
+    string[]
+  >;
+
+  const isTrap = (cat: string | undefined): cat is TrapCategory =>
+    !!cat && (TRAP_ERROR_CATEGORIES as readonly string[]).includes(cat);
+
+  for (const row of baseline.values()) {
+    if (isTrap(row.error_category)) baseCounts[row.error_category]++;
+  }
+
+  for (const [file, row] of newer) {
+    if (!isTrap(row.error_category)) continue;
+    const base = baseline.get(file);
+    // Wasm-identical noise: a trap can't appear on a byte-identical binary, so a
+    // same-`wasm_sha` flip is runner noise — don't let it inflate the count.
+    if (base && base.wasm_sha && row.wasm_sha && base.wasm_sha === row.wasm_sha) continue;
+    newCounts[row.error_category]++;
+    // "newly trapping HERE" = this file was not already in THIS trap category.
+    if (!base || base.error_category !== row.error_category) {
+      newlyTrapping[row.error_category].push(file);
+    }
+  }
+
+  const failures: string[] = [];
+  for (const cat of TRAP_ERROR_CATEGORIES) {
+    if (newCounts[cat] - baseCounts[cat] > tolerancePerCategory) {
+      const grew = newCounts[cat] - baseCounts[cat];
+      const sample = newlyTrapping[cat].slice().sort().slice(0, 10);
+      const more =
+        newlyTrapping[cat].length > sample.length ? ` (+${newlyTrapping[cat].length - sample.length} more)` : "";
+      failures.push(
+        `trap category "${cat}" grew ${baseCounts[cat]} → ${newCounts[cat]} (+${grew}) — uncatchable-trap ratchet (#3189). ` +
+          `Newly trapping: ${sample.join(", ")}${more}`,
+      );
+    }
+  }
+  return { failures, baseCounts, newCounts, newlyTrapping };
 }
 
 interface TestResult {
@@ -905,6 +1005,24 @@ async function run(
   // regressionsWasmChange. Gate: improvements.length - regressionsWasmChange < 0.
   const netPerTest = improvements.length - regressionsWasmChange;
   let gateFailed = false;
+
+  // #3189 — uncatchable-trap GROWTH ratchet. Applies in BOTH the normal and the
+  // oracle-rebase branches: a genuinely new trap is a real regression regardless
+  // of net_per_test or an oracle re-baseline (the four trap categories are not
+  // touched by any oracle reclassification, so they stay comparable across a
+  // forward bump). A trap escapes try/catch and poisons the whole file, so the
+  // crash-free goal forbids ANY growth. Decreases auto-bank via promote-baseline.
+  const trapTolerance = Number.parseInt(process.env.TRAP_RATCHET_TOLERANCE ?? "0", 10) || 0;
+  const trapGrowth = evaluateTrapCategoryGrowth(baseline, newer, trapTolerance);
+  console.log(
+    `=== Trap categories (baseline → candidate): ` +
+      TRAP_ERROR_CATEGORIES.map((c) => `${c} ${trapGrowth.baseCounts[c]}→${trapGrowth.newCounts[c]}`).join(", ") +
+      ` (#3189 ratchet) ===`,
+  );
+  for (const reason of trapGrowth.failures) {
+    console.log(`=== GATE FAIL: ${reason} ===`);
+    gateFailed = true;
+  }
 
   // #3086 — is this a deliberate oracle RE-BASELINE? (forward-monotonic bump
   // auto-rebase, or ORACLE_REBASE=1). Same condition the oracle guard above used

--- a/tests/issue-3189.test.ts
+++ b/tests/issue-3189.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { TRAP_ERROR_CATEGORIES, evaluateTrapCategoryGrowth } from "../scripts/diff-test262.js";
+
+// #3189 — uncatchable-trap GROWTH ratchet. The four trap categories
+// (null_deref / illegal_cast / oob / unreachable) may only shrink or hold: any
+// growth in any category fails the gate independent of net_per_test, because a
+// trap escapes try/catch and poisons the whole test file (#3179). These unit
+// tests pin the pure ratchet logic (mirrors #1943's threshold tests).
+
+type Row = { status: string; error_category?: string; wasm_sha?: string | null };
+const mk = (rows: Record<string, Row>): Map<string, Row> => new Map(Object.entries(rows));
+
+describe("#3189 — trap-category growth ratchet", () => {
+  it("exposes the four uncatchable-trap categories", () => {
+    expect([...TRAP_ERROR_CATEGORIES]).toEqual(["null_deref", "illegal_cast", "oob", "unreachable"]);
+  });
+
+  it("passes when trap population holds", () => {
+    const base = mk({
+      "a.js": { status: "fail", error_category: "illegal_cast", wasm_sha: "aa" },
+      "b.js": { status: "pass", wasm_sha: "bb" },
+    });
+    const cur = mk({
+      "a.js": { status: "fail", error_category: "illegal_cast", wasm_sha: "aa2" },
+      "b.js": { status: "pass", wasm_sha: "bb" },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toEqual([]);
+    expect(r.newCounts.illegal_cast).toBe(1);
+    expect(r.baseCounts.illegal_cast).toBe(1);
+  });
+
+  it("passes (banks) when trap population shrinks", () => {
+    const base = mk({
+      "a.js": { status: "fail", error_category: "null_deref", wasm_sha: "aa" },
+      "b.js": { status: "fail", error_category: "null_deref", wasm_sha: "bb" },
+    });
+    const cur = mk({
+      "a.js": { status: "pass", wasm_sha: "aa2" },
+      "b.js": { status: "fail", error_category: "null_deref", wasm_sha: "bb2" },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toEqual([]);
+    expect(r.baseCounts.null_deref).toBe(2);
+    expect(r.newCounts.null_deref).toBe(1);
+  });
+
+  it("FAILS when a trap category grows, naming the newly-trapping files", () => {
+    const base = mk({
+      "a.js": { status: "fail", error_category: "assertion_fail", wasm_sha: "aa" },
+      "b.js": { status: "pass", wasm_sha: "bb" },
+    });
+    const cur = mk({
+      // a.js: assertion_fail → illegal_cast (a new trap where there was none)
+      "a.js": { status: "fail", error_category: "illegal_cast", wasm_sha: "aa2" },
+      // b.js: pass → illegal_cast (a new trap), different wasm so not noise
+      "b.js": { status: "fail", error_category: "illegal_cast", wasm_sha: "bb2" },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toHaveLength(1);
+    expect(r.failures[0]).toContain("illegal_cast");
+    expect(r.failures[0]).toContain("0 → 2");
+    expect(r.failures[0]).toContain("a.js");
+    expect(r.failures[0]).toContain("b.js");
+    expect(r.newlyTrapping.illegal_cast.sort()).toEqual(["a.js", "b.js"]);
+  });
+
+  it("blocks a NET-POSITIVE PR that trades assertion-fails for new traps", () => {
+    // Baseline: 3 assertion fails, 0 traps. Candidate: fixes all 3 fails but
+    // introduces 2 new oob traps. net_per_test is +1, so the ordinary gate would
+    // pass — the trap ratchet must still block it.
+    const base = mk({
+      "f1.js": { status: "fail", error_category: "assertion_fail", wasm_sha: "1" },
+      "f2.js": { status: "fail", error_category: "assertion_fail", wasm_sha: "2" },
+      "f3.js": { status: "fail", error_category: "assertion_fail", wasm_sha: "3" },
+    });
+    const cur = mk({
+      "f1.js": { status: "pass", wasm_sha: "1b" },
+      "f2.js": { status: "pass", wasm_sha: "2b" },
+      "f3.js": { status: "pass", wasm_sha: "3b" },
+      "t1.js": { status: "fail", error_category: "oob", wasm_sha: "t1" },
+      "t2.js": { status: "fail", error_category: "oob", wasm_sha: "t2" },
+    });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures.some((f) => f.includes("oob") && f.includes("0 → 2"))).toBe(true);
+  });
+
+  it("ignores a byte-identical (same wasm_sha) pass→trap flip as CI noise", () => {
+    const base = mk({ "n.js": { status: "pass", wasm_sha: "same" } });
+    const cur = mk({ "n.js": { status: "fail", error_category: "unreachable", wasm_sha: "same" } });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toEqual([]);
+    expect(r.newCounts.unreachable).toBe(0);
+  });
+
+  it("counts a genuinely new trap on a CHANGED binary (different wasm_sha)", () => {
+    const base = mk({ "n.js": { status: "pass", wasm_sha: "old" } });
+    const cur = mk({ "n.js": { status: "fail", error_category: "unreachable", wasm_sha: "new" } });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures).toHaveLength(1);
+    expect(r.newCounts.unreachable).toBe(1);
+  });
+
+  it("honours a per-category tolerance (operational safety valve)", () => {
+    const base = mk({ "x.js": { status: "pass", wasm_sha: "x" } });
+    const cur = mk({
+      "x.js": { status: "fail", error_category: "oob", wasm_sha: "x2" },
+      "y.js": { status: "fail", error_category: "oob", wasm_sha: "y2" },
+    });
+    // Growth of 2 with tolerance 2 → within ratchet (no failure).
+    expect(evaluateTrapCategoryGrowth(base, cur, 2).failures).toEqual([]);
+    // Growth of 2 with tolerance 1 → fails.
+    expect(evaluateTrapCategoryGrowth(base, cur, 1).failures).toHaveLength(1);
+  });
+
+  it("treats a lateral trap move (illegal_cast → null_deref) as null_deref growth", () => {
+    // Per #3189: growth in ANY trap category fails, even if total trap count is
+    // flat — the crash-free goal ratchets per-category. (A lateral move banks on
+    // the next promote once the baseline picks up the new distribution.)
+    const base = mk({ "x.js": { status: "fail", error_category: "illegal_cast", wasm_sha: "x" } });
+    const cur = mk({ "x.js": { status: "fail", error_category: "null_deref", wasm_sha: "x2" } });
+    const r = evaluateTrapCategoryGrowth(base, cur);
+    expect(r.failures.some((f) => f.includes("null_deref"))).toBe(true);
+    expect(r.baseCounts.illegal_cast).toBe(1);
+    expect(r.newCounts.null_deref).toBe(1);
+  });
+});


### PR DESCRIPTION
## #3189 — uncatchable-trap growth ratchet

The PR gate keys on `net_per_test > 0` + per-bucket regression counts, so a PR that fixes 60 assertion-fails while introducing 12 new `illegal_cast`s sails through net-positive. But a Wasm trap **escapes `try`/`catch`** and aborts the whole test file (#3179 — a trap inside `assert.throws` poisons every test sharing the pattern), so the "crash-free (traps → 0)" goal needs a ratchet, not a net gate.

### What this adds
- **`evaluateTrapCategoryGrowth(baseline, newer, tolerance=0)`** in `scripts/diff-test262.ts`: per-category population diff for the four trap `error_category` values (`null_deref`, `illegal_cast`, `oob`, `unreachable`; exported as `TRAP_ERROR_CATEGORIES`). **Any growth in any trap category → gate fail (`exit 1`)**, independent of `net_per_test`, naming the newly-trapping files.
- **Wired into `run()`** — both the normal and the oracle-rebase branches (a new trap is a real regression regardless of an oracle bump; trap categories are untouched by oracle reclassification, so they stay comparable across a forward bump). Prints a `Trap categories (baseline → candidate)` line every run.
- **Decreases auto-bank, conflict-free**: reads the promote-refreshed baseline jsonl (#1528) — no separate ratchet baseline file, so no per-PR baseline-bump merge conflict (#3131 pattern, structural).
- **Noise-filtered**: a byte-identical (`wasm_sha`-unchanged) pass→trap flip is excluded as CI runner noise, like the `net_per_test` gate's wasm-hash filter (#1222).
- **Safety valve**: `TRAP_RATCHET_TOLERANCE` env (default 0, strict) mirrors `STANDALONE_REGRESSION_TOLERANCE` so a false-positive against baseline drift can be loosened without a code change rather than wedging the queue.
- **Doc**: `docs/ci-policy.md` §3 "Uncatchable-trap growth ratchet".

### Validation
- No verdict-logic change → no oracle bump (`check-verdict-oracle-bump` clean).
- `tests/issue-3189.test.ts` — 9 cases (hold/shrink/grow, net-positive-with-new-traps block, wasm-identical noise exclusion, lateral move, tolerance valve). CLI smoke-tested: trap growth → exit 1, flat/shrink → exit 0.

Coordinates with #3187 (classifier split); the four trap categories are untouched by that split, so ordering is safe either way.

Closes #3189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)