### PR TITLE
plan: decompose #3182/#3184/#3185 umbrellas into 11 claimable slice issues

### DIFF
--- a/plan/issues/3056-standalone-numeric-assert-vacuity-num-specialization.md
+++ b/plan/issues/3056-standalone-numeric-assert-vacuity-num-specialization.md
@@ -1,11 +1,11 @@
 ---
 id: 3056
 title: "Standalone numeric assertions are vacuous — add `assert_sameValue_num` harness routing (measurement re-baseline)"
-status: ready
+status: blocked
 sprint: current
 model: opus
 created: 2026-07-05
-updated: 2026-07-08
+updated: 2026-07-12
 priority: high
 horizon: m
 feasibility: medium
@@ -13,7 +13,13 @@ task_type: measurement-integrity
 area: test-harness
 language_feature: test262-runner, standalone-floor
 goal: standalone-mode
+blocked_by: [3055]
 related: [3054, 3055]
+# NOT auto-pickable: human-gated. Do NOT land under the autonomous loop — this
+# re-baselines the headline standalone floor and needs HUMAN sign-off + a
+# coordinated standalone-floor re-baseline (refresh test262-current.jsonl in
+# loopdive/js2wasm-baselines). Land after/with #3055 (the real codegen fix).
+# status: blocked removes it from `budget-status --pick` (two prior mis-claims).
 ---
 
 # #3056 — Standalone numeric assertions are not enforced (vacuous host_free_pass)

--- a/plan/issues/3182-code-bloat-elimination-epic.md
+++ b/plan/issues/3182-code-bloat-elimination-epic.md
@@ -116,6 +116,11 @@ the same ES2025 semantics.
 
 ## Slices (independently claimable; each is its own PR)
 
+**Filed as claimable child issues (2026-07-12):** S1 → **#3191**,
+S2 → **#3192** (stacked on #3191), S3 → **#3193** (medium — array-methods.ts
+hot), S4 → **#3194**, S5 → **#3195**, S6 → **#3196** (medium — array-methods.ts
+hot, L). This epic stays the tracking umbrella.
+
 ### S1 — Unify the JS-error-throw templates on `buildThrowJsErrorInstrs` [M]
 
 - **Remove**: `dvTypeErrorThrow` (dataview-native.ts:653),

--- a/plan/issues/3184-default-lane-forawait-async-vacuous-cluster.md
+++ b/plan/issues/3184-default-lane-forawait-async-vacuous-cluster.md
@@ -18,6 +18,16 @@ origin: "2026-07-12 Fable codebase audit (plan/log/2026-07-12-fable-codebase-aud
 
 # #3184 — default lane: for-await-of / async-dstr vacuous cluster
 
+## Child slices (filed 2026-07-12)
+
+Decomposed into two M-sized claimable slices; this issue is the tracking
+umbrella for the async-vacuous cluster:
+
+- **#3197** — for-await-of / async-dstr drive (383 vacuous), P1.
+- **#3198** — Promise-combinator vacuous callbacks (218), medium (overlaps
+  blocked #2614 + active Promise work; likely shares the #3197 async-drive
+  root cause).
+
 ## Problem
 
 On the **default (JS-host) lane**, `language/statements/for-await-of` has

--- a/plan/issues/3185-default-lane-array-prototype-generics-observability-umbrella.md
+++ b/plan/issues/3185-default-lane-array-prototype-generics-observability-umbrella.md
@@ -71,6 +71,20 @@ Top error shapes across those method dirs (mechanism signal):
   exclusion note at `src/codegen/array-methods.ts:664-666` (different callback
   signature on the array-like path) — a known-incomplete edge.
 
+## Child slices (filed 2026-07-12)
+
+Decomposed into 3 M-sized method-family slices over the default JS-host lane
+(disjoint from the standalone #3169/#3180 receiver-ladder tests). Each slice
+folds in the trap-first mandate (§4) for its own methods:
+
+- **#3199** — fold/predicate family: reduce/reduceRight/every/some (~283), P1.
+- **#3200** — iteration/producer family: forEach/map/filter/flatMap (~204), P1.
+- **#3201** — search + structural family:
+  indexOf/lastIndexOf/slice/splice/sort/concat/pop (~312), P1 — owns the
+  30 trap-class fails (land first).
+
+This issue stays the tracking umbrella.
+
 ## Acceptance criteria (umbrella)
 
 1. Child slices filed per mechanism above (trap slice first), each with

--- a/plan/issues/3191-bloat-s1-unify-js-error-throw-templates.md
+++ b/plan/issues/3191-bloat-s1-unify-js-error-throw-templates.md
@@ -1,0 +1,73 @@
+---
+id: 3191
+title: "bloat S1: unify the 4 hand-rolled JS-error-throw templates on buildThrowJsErrorInstrs"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: medium
+task_type: refactor
+area: codegen
+es_edition: n/a
+language_feature: error-throw
+goal: maintainability
+sprint: current
+horizon: m
+umbrella: 3182
+related: [3175, 3173, 3171, 3029, 3102]
+---
+
+# #3191 — bloat S1: unify the JS-error-throw templates
+
+Slice **S1** of the #3182 code-bloat-elimination epic. See #3182 §D1.
+
+## Problem
+
+The "throw a real JS error instance" instruction template is hand-rolled in
+≥4 places that each re-implement the same shape (noJsHost →
+`emitWasiErrorConstructor`, `addStringConstantGlobal`, `ensureLateImport
+__new_<Kind>`, `flushLateImportShifts`, string instrs, optional `call`,
+`throw $exc`). The canonical implementation already exists:
+`buildThrowJsErrorInstrs` (`src/codegen/expressions/helpers.ts:231`, #3175)
+and the bare-string `emitThrowString` (`src/codegen/expressions/helpers.ts:38`).
+
+Verified copies (2026-07-12, `origin/main`):
+
+| Copy | Anchor | Divergence |
+| --- | --- | --- |
+| `dvTypeErrorThrow` | `src/codegen/dataview-native.ts:652` | no self-flush — caller pre-builds template before body (funcIdx-capture ordering) |
+| `emitDataViewRangeError` | `src/codegen/dataview-native.ts:628` | same, RangeError |
+| `emitBrandCheckTypeError` | `src/codegen/native-proto.ts:558` | sinks into a raw `Instr[]` (not fctx), unconditional `emitWasiErrorConstructor` |
+| `emitThrowString` + `throwStringInstrs` | `src/codegen/array-methods.ts:137,144` | bare-string variant; `emitThrowString` is a **verbatim** private copy of `expressions/helpers.ts:38` |
+
+## Approach (verified anchors)
+
+1. **Hoist the canonical helpers first** into a layering-safe leaf module
+   (suggest `src/codegen/js-errors.ts`); `expressions/helpers.ts` re-exports
+   for existing importers. Runtime modules (dataview-native, native-proto,
+   array-methods) must NOT import from `expressions/` (front-end layer,
+   #3029 layering).
+2. **Parameterize the two real divergences** via an options bag (not new
+   copies): (a) sink = fctx vs raw `Instr[]`; (b) self-flush
+   (`flushLateImportShifts`) vs caller-flushes — the DataView accessors build
+   throw templates BEFORE the body (ordering documented at
+   `dataview-native.ts:620-627`); preserve it EXACTLY (a wrong flush here is
+   the #1839-class index-shift hazard).
+3. **Delete** all four copies; route their call sites through the shared
+   helper. `throwStringInstrs` (array-methods.ts:144) is used at
+   :325/:1599/:1763/:7396/:7595 — re-route all.
+
+## Acceptance criteria
+
+- Zero test-diff (equivalence suite stable; test262 CI delta exactly 0
+  regressions / 0 progressions attributable to this slice).
+- All four copies deleted; call sites route through the shared helper.
+- No new import cycles; `pnpm run typecheck` clean.
+
+## Coordination
+
+- `src/codegen/array-methods.ts` is a hot file (dev-array-hof, #3185 slices
+  #3199-#3201, epic slices #3193/#3196). Re-anchor by symbol, not line;
+  re-merge `origin/main` before enqueue.
+- Predecessor for **S2 (#3192)** — #3192 consumes the hoisted `js-errors.ts`
+  module.

--- a/plan/issues/3192-bloat-s2-route-dataview-regexp-brand-checks.md
+++ b/plan/issues/3192-bloat-s2-route-dataview-regexp-brand-checks.md
@@ -1,0 +1,61 @@
+---
+id: 3192
+title: "bloat S2: route DataView + RegExp brand checks through receiver-brand.ts"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: medium
+task_type: refactor
+area: codegen
+es_edition: n/a
+language_feature: brand-check
+goal: maintainability
+sprint: current
+horizon: m
+umbrella: 3182
+depends_on: [3191]
+related: [3171, 3173, 3029, 3102]
+---
+
+# #3192 — bloat S2: DataView + RegExp brand checks → receiver-brand.ts
+
+Slice **S2** of the #3182 code-bloat-elimination epic. See #3182 §D2.
+**Stacked on #3191 (S1)** — consumes S1's hoisted `js-errors.ts` leaf module;
+claim after #3191 lands (or branch from its PR).
+
+## Problem
+
+`emitReceiverBrandCheck` / `emitReceiverBrandThrow`
+(`src/codegen/receiver-brand.ts:58,146`, #3171) is the parameterized receiver
+brand gate (struct `ref.test` + optional kind-tag refinement + catchable
+TypeError). Already adopted by collections-brand, array-object-proto,
+map-runtime, set-runtime, collections-es2025. NOT yet routed through it:
+
+- **DataView brand gate** — `DV_BRAND_MESSAGE` (`src/codegen/dataview-native.ts:640`);
+  hand-rolled test/throw around the #3173 templates (usages at
+  `dataview-native.ts:1104`, `:1294`, `:1458`).
+- **RegExp standalone brand check** — `src/codegen/regexp-standalone.ts:1022`
+  (routes through native-proto's `emitBrandCheckTypeError`, the S1/D1 copy).
+
+## Approach (verified anchors)
+
+- Route both through `emitReceiverBrandCheck` / `emitReceiverBrandThrow`
+  (`receiver-brand.ts:58/146`) with a struct-only `ReceiverBrandSpec` (no
+  `kindField`) for `$__dataview` / the RegExp struct.
+
+## Judgment gate (do not force-fit)
+
+`receiver-brand` consumes a stack receiver INSIDE an fctx; the DataView
+accessors build throw templates BEFORE the body (the pre-body ordering S1
+preserves). If that ordering contract cannot be met without weakening
+receiver-brand's API, **stop at S1's shared throw template** for DataView and
+record the decision here — do not force-fit (that would be a worse coupling
+than the dup). RegExp (native-proto route) is the cleaner half and can land
+independently.
+
+## Acceptance criteria
+
+- Zero test-diff; brand TypeError messages byte-identical
+  (`DV_BRAND_MESSAGE` string preserved verbatim).
+- No new import cycles; `pnpm run typecheck` clean.

--- a/plan/issues/3193-bloat-s3-delete-shape-path-array-call-clones.md
+++ b/plan/issues/3193-bloat-s3-delete-shape-path-array-call-clones.md
@@ -1,0 +1,67 @@
+---
+id: 3193
+title: "bloat S3: delete the 5 shape-path Array.prototype.*.call clones, route through the synthetic-call rewrite"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: medium
+feasibility: medium
+task_type: refactor
+area: codegen
+es_edition: n/a
+language_feature: array-methods
+goal: maintainability
+sprint: current
+horizon: m
+umbrella: 3182
+related: [3029, 3102, 3185]
+---
+
+# #3193 — bloat S3: delete the 5 shape-path Array.prototype.*.call clones
+
+Slice **S3** of the #3182 code-bloat-elimination epic. See #3182 §D3.
+
+## Problem
+
+`compileArrayPrototypeCall` (`src/codegen/array-methods.ts:2290`) has TWO
+lanes for the same methods:
+
+- **shape-inferred lane** → dedicated near-clones of the direct-method impls:
+  `compileArrayPrototypeIndexOf` (`:2378`), `...Includes` (`:2501`),
+  `...Every` (`:2585`), `...Some` (`:2727`), `...ForEach` (`:2849`) — ~700 LOC
+  duplicating `compileArrayIndexOf` (`:4462`), `compileArrayEvery` (`:8219`),
+  `compileArraySome` (`:8154`), `compileArrayForEach` (`:7715`) incl. a second
+  copy of the closure-invocation loop scaffolding.
+- **TS-type lane** → a **synthetic-call rewrite** (`:2356-2371`) routing to
+  `compileArrayMethodCall` (`:3246`) that reuses everything.
+
+The clones exist only because `compileArrayMethodCall`'s receiver resolution
+(`resolveArrayInfoForExpression` `:652`) never consults `ctx.shapeMap`.
+
+## Approach (verified anchors)
+
+- Make receiver resolution shapeMap-aware — extend
+  `resolveArrayInfoForExpression` (`:652`) to consult `ctx.shapeMap` for
+  identifier receivers, mirroring the lookup at `:2323`. Then the
+  shape-inferred lane takes the same synthetic-call rewrite (`:2356-2371`) and
+  the five clones die.
+- **Edge cases to diff BEFORE deleting** (clone vs direct impl):
+  callback-must-be-inline-arrow gate (`:2603`) vs the direct lane's
+  `setupArrayCallback`, receiver null-guard, `undefined`-capable results. If a
+  clone encodes a semantic the direct lane lacks, port the semantic FIRST
+  (separate commit) so the deletion commit stays zero-diff.
+
+## Acceptance criteria
+
+- Zero test-diff; `compileArrayPrototype{IndexOf,Includes,Every,Some,ForEach}`
+  deleted; ~700 LOC net negative in array-methods.ts.
+- `pnpm run typecheck` clean.
+
+## Coordination (priority lowered: hot-file collision)
+
+`src/codegen/array-methods.ts` is under active behavioral change
+(dev-array-hof, #3185 slices #3199-#3201, epic S6 #3196). Priority is
+**medium** so it does not churn against conformance work. Claim
+**serially** with #3196 (disjoint ranges: S3 is `:2378-3075`, S6 is
+`:763-1887`, but both shift line numbers — re-anchor by symbol). Re-merge
+`origin/main` immediately before enqueue.

--- a/plan/issues/3194-bloat-s4-super-dispatch-core.md
+++ b/plan/issues/3194-bloat-s4-super-dispatch-core.md
@@ -1,0 +1,50 @@
+---
+id: 3194
+title: "bloat S4: new-super.ts — extract the shared super-dispatch core (compileSuperMethodCall ≈ compileSuperElementMethodCall)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: medium
+task_type: refactor
+area: codegen
+es_edition: n/a
+language_feature: super-dispatch
+goal: maintainability
+sprint: current
+horizon: s
+umbrella: 3182
+related: [1849, 3029, 3102]
+---
+
+# #3194 — bloat S4: extract the shared super-dispatch core
+
+Slice **S4** of the #3182 code-bloat-elimination epic (from #1849). See
+#3182 §D4.
+
+## Problem
+
+`compileSuperMethodCall` (`src/codegen/expressions/new-super.ts:545`) and
+`compileSuperElementMethodCall` (`:666`) share a duplicated body. The
+no-class / no-parent fallbacks had already **diverged** in #1849's 2026-06-04
+review — re-diff first and unify on the correct (spec-side) branch,
+parameterizing method-name-vs-element lookup.
+
+## Approach (verified anchors)
+
+- Extract one shared super-dispatch core from `new-super.ts:545` and `:666`;
+  parameterize the only real difference (identifier method name vs computed
+  element expression for the property lookup).
+- Sweep the file for residual hand-rolled typed-default blocks;
+  `pushDefaultValue` (type-coercion.ts) is already imported and used at
+  `:122` / `:642` — replace any residue.
+
+## Acceptance criteria
+
+- Zero test-diff; the two functions share one core.
+- `pnpm run typecheck` clean.
+
+## Coordination
+
+`new-super.ts` is a quiet file (low collision risk). Independent of S1-S3,
+S5, S6.

--- a/plan/issues/3195-bloat-s5-unify-closure-iterable-drainers.md
+++ b/plan/issues/3195-bloat-s5-unify-closure-iterable-drainers.md
@@ -1,0 +1,60 @@
+---
+id: 3195
+title: "bloat S5: runtime.ts — one parameterized closure-iterable drainer (fold the 3 copies + truthyEnv dup)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: medium
+task_type: refactor
+area: runtime
+es_edition: n/a
+language_feature: iterable-drain
+goal: maintainability
+sprint: current
+horizon: s
+umbrella: 3182
+related: [1849, 928, 3029, 3102]
+---
+
+# #3195 — bloat S5: one parameterized closure-iterable drainer
+
+Slice **S5** of the #3182 code-bloat-elimination epic (from #1849). See
+#3182 §D4.
+
+## Problem
+
+Three near-duplicate closure-iterable drainers in `src/runtime.ts`:
+
+- `_drainClosureIterableToArray` (`runtime.ts:2938`)
+- `_drainWasmClosureIterable` (`:3031`)
+- `_drainIterable` (`:10605`)
+
+The divergences (different loop caps, #928 buffer-drain semantics, field
+resolution, wasm-exports access) are the **parameters**, not reasons to keep
+copies. Call sites: `:3008`, `:11457`, `:11460`, `:11471`, `:12724` (wasm
+variant) and the `_drainIterable` local at `:10605`.
+
+Trivial rider: `truthyEnv` is a **verbatim** dup — `src/codegen/index.ts:1438`
+vs `src/codegen/fallback-telemetry.ts:73` (both used at multiple sites in each
+file). Fold into one export.
+
+## Approach (verified anchors)
+
+- Unify the three drainers behind one function with a strategy/options param
+  (loop cap, field resolution, wasm-exports access). Diff the three first —
+  the loop caps and #928 buffer-drain semantics become options.
+- Export a single `truthyEnv` (leaf util) and import it in both index.ts and
+  fallback-telemetry.ts.
+
+## Acceptance criteria
+
+- Zero test-diff; three drainers → one; single `truthyEnv` export.
+- `pnpm run typecheck` clean.
+
+## Coordination
+
+`runtime.ts` is touched by Promise/async work (different regions — the
+`NewPromiseCapability` / combinator dispatch is `:12445`, `:13341-13465`; the
+drainers are `:2938-3031` and `:10605`). Low collision risk but re-merge
+`origin/main` before enqueue.

--- a/plan/issues/3196-bloat-s6-deinline-standalone-dynamic-hof-onto-steppers.md
+++ b/plan/issues/3196-bloat-s6-deinline-standalone-dynamic-hof-onto-steppers.md
@@ -1,0 +1,66 @@
+---
+id: 3196
+title: "bloat S6: de-inline the standalone dynamic-HOF lane in compileArrayLikePrototypeCall onto the #3098 __hof_* steppers"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: medium
+feasibility: hard
+task_type: refactor
+area: codegen
+es_edition: n/a
+language_feature: array-methods
+goal: maintainability
+sprint: current
+horizon: l
+umbrella: 3182
+related: [3098, 3029, 3102, 3185]
+---
+
+# #3196 — bloat S6: de-inline the standalone dynamic-HOF lane
+
+Slice **S6** of the #3182 code-bloat-elimination epic. See #3182 §D5.
+
+## Problem
+
+`compileArrayLikePrototypeCall` (`src/codegen/array-methods.ts:763-1887`,
+~1,124 LOC) emits a fresh `[[Get]]`-style element loop **at every call site**
+for any-typed `Array.prototype.X.call(obj, …)`. Meanwhile #3098's
+`ensureNativeArrayHof` (`src/codegen/hof-native.ts:74`; `NATIVE_HOF_METHODS`
+`:72`) already emits ONE shared `__hof_<name>` helper per method (11 methods)
+over the same `__extern_length`/`__extern_get_idx` substrate + the
+`__apply_closure` bridge — but only under `ctx.standalone`. Under standalone
+there are therefore **two dynamic-receiver HOF lowerings** of the same ES2025
+semantics.
+
+## Approach (verified anchors)
+
+- **Standalone lane only**: replace the per-call-site HOF loop inside
+  `compileArrayLikePrototypeCall` (`:763-1887`) for the 11
+  `NATIVE_HOF_METHODS` with arg-marshalling + a call to the shared
+  `__hof_<name>` helper from `ensureNativeArrayHof` (`hof-native.ts:74`).
+- **Keep the JS-host lane as-is** — it rides host imports as the sanctioned
+  fast path (dual-mode principle). `ensureNativeArrayHof`'s
+  `__extern_get_idx` array-like arms are emitted only under `ctx.standalone`;
+  extending the stepper to host mode is a **separate decision** — file a
+  follow-up if a spike shows it viable, don't smuggle it in.
+- **Boundary watch**: hof-native documents deliberate boundaries
+  (reduce-of-empty returns undefined instead of TypeError; dense carriers, no
+  hole-skip — `hof-native.ts:43-49`). If the inline loop currently implements
+  the *stricter* spec behavior for a method, routing through the stepper is a
+  behavior CHANGE — that method stays on the inline path (gap tracked under
+  #3098) and the slice notes it.
+
+## Acceptance criteria
+
+- Zero test-diff on the standalone/wasi test262 lanes AND the host lane.
+- Per-call-site loop copies gone for the migrated methods.
+- `pnpm run typecheck` clean.
+
+## Coordination (priority lowered: hot-file collision + L size)
+
+`src/codegen/array-methods.ts` is under active behavioral change
+(dev-array-hof, #3185 slices #3199-#3201, epic S3 #3193). Priority is
+**medium** and this is the epic's largest slice (L). Claim **serially** with
+#3193 (disjoint ranges: S6 is `:763-1887`, S3 is `:2378-3075`, but both shift
+line numbers — re-anchor by symbol). Re-merge `origin/main` before enqueue.

--- a/plan/issues/3197-forawait-of-async-drive-vacuous-slice.md
+++ b/plan/issues/3197-forawait-of-async-drive-vacuous-slice.md
@@ -1,0 +1,73 @@
+---
+id: 3197
+title: "default lane: drive the for-await-of / async-dstr callback chain to completion (383 vacuous fails)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: ES2018
+language_feature: for-await-of
+goal: core-semantics
+sprint: current
+horizon: m
+umbrella: 3184
+related: [3184, 2940, 3086, 2669, 3021]
+origin: "2026-07-12 Fable codebase audit §F1; slice of #3184"
+---
+
+# #3197 — for-await-of / async-dstr drive slice (383 vacuous)
+
+Sub-slice of **#3184**. This slice owns the **for-await-of** half; the
+Promise-combinator half is **#3198**.
+
+## Problem
+
+On the default (JS-host) lane, `language/statements/for-await-of` has **489
+non-pass** tests, of which **383** carry `vacuous: harness-wrapper callback
+never executed (#2940)`: the compiled test returns "success" while the async
+callback chain — and every assertion — **never runs**. Sampled files are
+dominated by destructuring-in-async shapes:
+
+```
+language/statements/for-await-of/async-func-decl-dstr-array-elem-nested-array-null.js
+language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-iter-val-err.js
+language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-init-unresolvable.js
+language/statements/for-await-of/async-gen-decl-dstr-obj-id-put-unresolvable-no-strict.js
+```
+
+The runner is NOT the gap — it implements the async protocol (`$DONE`
+`tests/test262-runner.ts:1890`, `asyncTest` `:1899`, detection `:2568-2569`).
+The failure is compiler-side: the host-lane async machinery never drives the
+`asyncTest(fn)` body to completion for for-await-of / async-destructuring
+shapes.
+
+## Reproduction path (verified anchors)
+
+For-of/for-await statement dispatch enters at `src/codegen/statements.ts:180-181`
+(`ts.isForOfStatement` → `compileForOfStatement`, imported at `:39`); the
+await-modifier lowering and its host-Promise drive live inside that path.
+First diagnostic step: compile one sampled vacuous test on the default lane
+and trace whether (a) the wrapped `asyncTest` callback is ever invoked, (b) the
+for-await loop's first `IteratorNext` promise is ever awaited, or (c) an early
+silent rejection is swallowed by the host bridge (`Promise_then` /
+`__make_callback` family in `src/runtime.ts`).
+
+## Acceptance criteria
+
+1. Root-cause note in this file: which link of the chain drops the callback
+   (asyncTest wrapper → async fn body → for-await drive → $DONE).
+2. The 383 vacuous for-await-of records: ≥ 250 flip to genuine pass OR to
+   honest assertion failures (no longer vacuous) on the default lane.
+3. `language/statements/for-await-of` non-pass drops below 250 (from 489).
+4. No standalone-lane regressions (the standalone carriers #2865/#3132 own
+   that lane; do not touch their emit paths).
+5. If the same root cause explains the async-function/async-generator vacuous
+   slice (~91), note the measured overlap; do not scope-creep into the
+   Promise-combinator slice (that is #3198).
+
+## Audit cross-link
+
+`plan/log/2026-07-12-fable-codebase-audit.md` §F1.

--- a/plan/issues/3198-promise-combinator-vacuous-callback-slice.md
+++ b/plan/issues/3198-promise-combinator-vacuous-callback-slice.md
@@ -1,0 +1,77 @@
+---
+id: 3198
+title: "default lane: Promise combinator callbacks never execute — vacuous slice (218 fails)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: medium
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: ES2018
+language_feature: promise-combinators
+goal: core-semantics
+sprint: current
+horizon: m
+umbrella: 3184
+related: [3184, 2614, 2613, 2623, 2940]
+origin: "2026-07-12 Fable codebase audit §F1; slice of #3184"
+---
+
+# #3198 — Promise-combinator vacuous slice (218)
+
+Sub-slice of **#3184**. This slice owns the **Promise-combinator** half; the
+for-await-of half is **#3197**.
+
+## Problem
+
+`built-ins/Promise/{any,race,all,allSettled,prototype}` carries **218**
+`vacuous: harness-wrapper callback never executed (#2940)` records on the
+default (JS-host) lane: the combinator's resolve/reject/element callbacks —
+and therefore every assertion — never run, yet the test reports success. This
+is the second-biggest slice of the 1,544-record vacuous family after
+for-await-of (#3197).
+
+## Distinct from #2614 / #2613 (READ THIS BEFORE CLAIMING)
+
+- **#2614** (`blocked`, assignee senior-developer) = "read the constructor's
+  own `resolve` + callable resolve/reject element functions" (~45 fails). That
+  is a spec-detail fix for combinator tests that **do run**. This slice is the
+  **vacuous-drive** class — tests where the callback chain never executes at
+  all. Mechanistically different, same method surface.
+- **#2613** (`blocked`) = await-thenable assimilation (~15). Not this.
+- The audit (§F1) explicitly recommends **un-blocking or re-slicing #2614**
+  for this 218. Coordinate: confirm whether the vacuous root cause is shared
+  with #3197's async-drive gap (likely) — if so, #3197's fix may flip a large
+  share of this bucket for free; remeasure before implementing.
+
+## Reproduction path (verified anchors)
+
+Combinator dispatch is in `src/runtime.ts`: `Promise_all` (`:13450`),
+`Promise_race` (`:13455`), `Promise_allSettled` (`:13460`), `Promise_any`
+(`:13465`); the `NewPromiseCapability(C)` / `Construct(C, «executor»)` path
+(#2614) at `:12445` and `:13341-13400`. Trace whether the combinator's
+per-element `resolve`/`reject` callbacks are ever invoked, or whether the host
+Promise bridge swallows the first tick.
+
+## Acceptance criteria
+
+1. Root-cause note: which link drops the callback (combinator entry →
+   per-element resolve/reject → settle → $DONE).
+2. ≥ 120 of the 218 vacuous Promise-combinator records flip to genuine pass OR
+   honest assertion failures (no longer vacuous) on the default lane.
+3. No standalone-lane regressions.
+4. Do NOT absorb #2614's constructor-resolve-reading fix unless it falls out
+   for free; if it does, note the overlap and coordinate the merge with the
+   #2614 owner.
+
+## Coordination (priority lowered: overlaps blocked/active Promise work)
+
+Priority is **medium**: this slice's file (`src/runtime.ts` Promise region)
+overlaps blocked #2614 (senior-developer) and active Promise-capability work
+(dev-promise-cap). Confirm no in-flight lock on the combinator dispatch region
+before claiming; prefer to land after or alongside #3197 (shared root cause).
+
+## Audit cross-link
+
+`plan/log/2026-07-12-fable-codebase-audit.md` §F1.

--- a/plan/issues/3199-default-array-fold-predicate-methods-generics.md
+++ b/plan/issues/3199-default-array-fold-predicate-methods-generics.md
@@ -1,0 +1,74 @@
+---
+id: 3199
+title: "default lane: Array.prototype fold/predicate generics (reduce/reduceRight/every/some) over real + array-like receivers (~283 fails)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: array-methods
+goal: builtin-methods
+sprint: current
+horizon: m
+umbrella: 3185
+related: [3185, 3169, 3180, 3015, 3170]
+origin: "2026-07-12 Fable codebase audit §F2; method-family slice of #3185"
+---
+
+# #3199 — default-lane Array fold/predicate generics (~283)
+
+Method-family slice **A** of **#3185** (default JS-host lane). Covers the
+callback fold/predicate family: **reduceRight (90) + reduce (88) + some (54) +
+every (51) = ~283** non-pass (baseline 2026-07-12).
+
+## Not overlapping #3169/#3180
+
+#3169 (done) and #3180 (residual) cover the SAME method family but on the
+**`--target standalone`** lane (host-free receiver ladder). This slice is the
+**default JS-host lane** — disjoint test set by construction (host-pass vs
+host-fail). Do not touch the standalone `fillExternArrayLikeStructArms` /
+`hof-native` emit paths #3169/#3180 own.
+
+## Problem mechanisms (from #3185 §F2 error shapes)
+
+1. **Observable semantics on real arrays** — callbackfn arg/return
+   (`testResult !== true`, 111 across the family), accessor/get observation
+   order (`accessed !== true`, 33), visit-count under holes/mutation
+   (`callCnt`, 8), HasProperty-before-Get, length caching.
+2. **Array-like receivers via `.call(obj, …)`** — `Array.prototype.{every,
+   reduce}.call(arrayLike)` (13 + 7 measured shapes); the host externref path
+   exists (`ARRAY_LIKE_METHOD_SET`, `src/codegen/array-methods.ts:668`; thisArg
+   `:692`, install `:996-1020`) but misses spec ordering/coverage.
+3. **Hard traps in this family** — any `illegal cast [in test()]` /
+   `array element access out of bounds [in test()]` under these methods must
+   resolve to the spec value or a thrown JS TypeError, **never a Wasm trap**
+   (umbrella trap-first mandate, #3185 §4).
+
+## Reproduction path (verified anchors)
+
+- Direct real-array impls: `compileArrayReduce` (`array-methods.ts:7357`),
+  `compileArrayReduceRight` (`:7506`), `compileArraySome` (`:8154`),
+  `compileArrayEvery` (`:8219`).
+- Array-like `.call` generic path: `compileArrayLikePrototypeCall` (`:763`),
+  gated by `ARRAY_LIKE_METHOD_SET` (`:668`). Note the reduce/reduceRight
+  exclusion documented at `:664-666` ("different callback signature (acc,
+  elem, i, arr) — handled by `__proto_method_call`") — a known-incomplete edge
+  to close for the `.call` fold sub-bucket.
+
+## Acceptance criteria
+
+1. Root-cause note per mechanism sub-bucket, with the measured test list
+   pulled from the baseline jsonl (recompute — main moves).
+2. ≥ 150 of the ~283 family records flip to genuine pass on the default lane.
+3. Zero Wasm traps under this family (spec value or thrown TypeError).
+4. No standalone-lane regressions (#3169/#3180 receiver-ladder tests).
+
+## Coordination (hot file)
+
+`src/codegen/array-methods.ts` (9,632 LOC) is shared with #3200/#3201 (sibling
+slices), epic S3 #3193 / S6 #3196, and dev-array-hof. Land as **behavioral**
+fixes; coordinate refactors with #3182/#3105. Re-anchor by symbol; re-merge
+`origin/main` before enqueue.

--- a/plan/issues/3200-default-array-iteration-producer-methods-generics.md
+++ b/plan/issues/3200-default-array-iteration-producer-methods-generics.md
@@ -1,0 +1,70 @@
+---
+id: 3200
+title: "default lane: Array.prototype iteration/producer generics (forEach/map/filter/flatMap) over real + array-like receivers (~204 fails)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: array-methods
+goal: builtin-methods
+sprint: current
+horizon: m
+umbrella: 3185
+related: [3185, 3169, 3180, 3015, 3170]
+origin: "2026-07-12 Fable codebase audit §F2; method-family slice of #3185"
+---
+
+# #3200 — default-lane Array iteration/producer generics (~204)
+
+Method-family slice **B** of **#3185** (default JS-host lane). Covers the
+callback iteration/producer family: **map (69) + filter (68) + forEach (53) +
+flatMap (14) = ~204** non-pass (baseline 2026-07-12).
+
+## Not overlapping #3169/#3180
+
+#3169 (done) / #3180 (residual) cover map/filter/forEach on the
+**`--target standalone`** lane. This slice is the **default JS-host lane** —
+disjoint by construction. flatMap is NOT in the #3169 seven-family set at all,
+so it is untracked on both lanes; keep the flatMap fix host-lane here and file
+a standalone follow-on if it diverges.
+
+## Problem mechanisms (from #3185 §F2 error shapes)
+
+1. **Observable semantics on real arrays** — callbackfn arg/return
+   (`testResult !== true`), accessor/get observation order (`accessed`), hole
+   skip-vs-visit, `callCnt` under mutation-during-iteration, length caching.
+2. **Result-object fidelity** — `newArr.length` mismatch (28),
+   `Object.getPrototypeOf(result)` mismatch (8): length / prototype / species
+   of the map/filter/flatMap result arrays.
+3. **Array-like receivers via `.call(obj, …)`** — the host externref path
+   (`ARRAY_LIKE_METHOD_SET`, `array-methods.ts:668`; thisArg `:996-1020`)
+   misses spec coverage for these methods.
+4. **Hard traps** — any `illegal cast` / OOB `[in test()]` under these methods
+   must resolve to spec value or thrown TypeError, never a Wasm trap
+   (umbrella trap-first mandate, #3185 §4).
+
+## Reproduction path (verified anchors)
+
+- Direct real-array impls: `compileArrayMap` (`array-methods.ts:7205`),
+  `compileArrayFilter` (`:7116`), `compileArrayForEach` (`:7715`),
+  `compileArrayFlatMap` (`:9561`).
+- Array-like `.call` generic path: `compileArrayLikePrototypeCall` (`:763`),
+  `ARRAY_LIKE_METHOD_SET` (`:668`).
+
+## Acceptance criteria
+
+1. Root-cause note per mechanism sub-bucket, with the measured test list from
+   the baseline jsonl (recompute — main moves).
+2. ≥ 110 of the ~204 family records flip to genuine pass on the default lane.
+3. Result-object length/prototype fidelity holds for map/filter/flatMap.
+4. Zero Wasm traps; no standalone-lane regressions.
+
+## Coordination (hot file)
+
+`src/codegen/array-methods.ts` is shared with #3199/#3201, epic S3 #3193 /
+S6 #3196, and dev-array-hof. Behavioral fixes only; re-anchor by symbol;
+re-merge `origin/main` before enqueue.

--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -1,0 +1,79 @@
+---
+id: 3201
+title: "default lane: Array.prototype search + structural generics (indexOf/lastIndexOf/slice/splice/sort/concat/pop) (~312 fails)"
+status: ready
+created: 2026-07-12
+updated: 2026-07-12
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: array-methods
+goal: builtin-methods
+sprint: current
+horizon: m
+umbrella: 3185
+related: [3185, 3169, 3180, 2036]
+origin: "2026-07-12 Fable codebase audit §F2; method-family slice of #3185"
+---
+
+# #3201 — default-lane Array search + structural generics (~312)
+
+Method-family slice **C** of **#3185** (default JS-host lane). Covers the
+non-callback search + structural family: **splice (63) + lastIndexOf (50) +
+indexOf (48) + slice (48) + sort (45) + concat (45) + pop (13) = ~312**
+non-pass (baseline 2026-07-12).
+
+## Not overlapping #3169/#3180
+
+#3169/#3180 cover the **seven callback HOF families** on the standalone lane —
+this slice's methods (indexOf/lastIndexOf/slice/splice/sort/concat/pop) are
+**not** in that set and are on the **default JS-host lane**. Disjoint on both
+axes. sort's callback comparator is in-scope here (default lane) but is not a
+#3169 HOF family.
+
+## Problem mechanisms (from #3185 §F2 error shapes)
+
+1. **Array-like receivers via `.call(obj, …)`** — `Array.prototype.
+   {indexOf,lastIndexOf}.call(arrayLike)` (13 + 12 measured shapes); the host
+   externref path (`ARRAY_LIKE_METHOD_SET`, `array-methods.ts:668`) misses
+   spec ordering/coverage.
+2. **Observable + coercion semantics** — `fromIndex`/`start`/`deleteCount`
+   ToInteger coercion, HasProperty-before-Get, `SameValueZero` vs strict
+   equality (indexOf/lastIndexOf), length caching.
+3. **Result-object fidelity** — `newArr.length` mismatch (28),
+   `Object.getPrototypeOf(result)` mismatch (8): length / prototype / species
+   of slice/splice/concat results.
+4. **Hard traps (30 family-wide, umbrella-priority)** — `illegal cast [in
+   test()]` (16) + `array element access out of bounds [in test()]` (14) are
+   soundness-adjacent (uncatchable, abort whole tests). Per #3185 §4 these are
+   the FIRST priority: every trap in this family's tests must become a spec
+   value or a thrown JS TypeError, never a Wasm trap. Coordinate with
+   #3179/#3162 mechanism notes.
+
+## Reproduction path (verified anchors)
+
+- Direct real-array impls: `compileArrayIndexOf` (`array-methods.ts:4462`),
+  `compileArrayLastIndexOf` (`:9292`), `compileArraySlice` (`:5438`),
+  `compileArraySplice` (`:6239`), `compileArraySort` (`:8285`),
+  `compileArrayConcat` (`:5550`) / `compileArrayConcatExtern` (`:5680`),
+  `compileArrayPop` (`:5100`).
+- Array-like `.call` generic path: `compileArrayLikePrototypeCall` (`:763`),
+  `ARRAY_LIKE_METHOD_SET` (`:668`).
+
+## Acceptance criteria
+
+1. The 30 trap-class fails (illegal cast / OOB) across this family → 0 traps
+   (spec result or thrown JS TypeError). **Land this sub-bucket first.**
+2. Root-cause note per mechanism sub-bucket, with the measured test list from
+   the baseline jsonl (recompute — main moves).
+3. ≥ 150 of the ~312 family records flip to genuine pass on the default lane.
+4. Result-object length/prototype fidelity holds for slice/splice/concat.
+5. No standalone-lane regressions.
+
+## Coordination (hot file)
+
+`src/codegen/array-methods.ts` is shared with #3199/#3200, epic S3 #3193 /
+S6 #3196, and dev-array-hof. Behavioral fixes only; re-anchor by symbol;
+re-merge `origin/main` before enqueue.

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -768,3 +768,32 @@ brand-check 48) fable-now; A1 rest-identity (382) stays BLOCKED on
 
 Edges: #3164 → #3178-S3 (same admission seam); #3132 ∥ #3164 ∥ #2903-R;
 #2040 slices ⊥ all of the above; #3178-S7 after S1+S2.
+
+## Umbrella decompositions filed 2026-07-12 (claimable slices)
+
+Three filed umbrellas decomposed into individually-lockable slices so multiple
+devs can work them in parallel without colliding.
+
+**#3182 bloat-elimination epic** (tracking umbrella stays open):
+- #3191 S1 — unify 4 JS-error-throw templates on `buildThrowJsErrorInstrs` [M, high]
+- #3192 S2 — DataView+RegExp brand → `receiver-brand.ts` [M, high, `depends_on: 3191`]
+- #3193 S3 — delete 5 shape-path `Array.prototype.*.call` clones [M, medium — array-methods.ts hot]
+- #3194 S4 — extract shared super-dispatch core (new-super.ts) [S, high]
+- #3195 S5 — one parameterized closure-iterable drainer (runtime.ts) [S, high]
+- #3196 S6 — de-inline standalone dynamic-HOF onto #3098 steppers [L, medium — array-methods.ts hot]
+- Edges: #3191 → #3192 (stacked); #3193 ∥ #3196 claim serially (both array-methods.ts).
+
+**#3184 async-vacuous cluster** (tracking umbrella stays open):
+- #3197 — for-await-of / async-dstr drive (383 vacuous) [M, high]
+- #3198 — Promise-combinator vacuous callbacks (218) [M, medium — overlaps blocked #2614 + active Promise work; likely shares #3197 root cause]
+
+**#3185 default-lane Array.prototype generics** (tracking umbrella stays open;
+disjoint from standalone #3169/#3180 by lane):
+- #3199 — fold/predicate: reduce/reduceRight/every/some (~283) [M, high]
+- #3200 — iteration/producer: forEach/map/filter/flatMap (~204) [M, high]
+- #3201 — search+structural: indexOf/lastIndexOf/slice/splice/sort/concat/pop (~312) [M, high — owns 30 trap-class fails, land first]
+- All three share array-methods.ts (hot: dev-array-hof, #3193/#3196) — behavioral fixes, re-anchor by symbol.
+
+Frontmatter hygiene: **#3056** set `status: blocked` + `blocked_by: [3055]`
+(human-gated standalone-floor re-baseline — was mis-claimed twice from the
+auto-pick pool while tagged `sprint: current` + high).


### PR DESCRIPTION
**Planning only — no source changes.** Decomposes three filed umbrellas into individually-lockable M/S slice issues so multiple Opus devs can work them in parallel without colliding on `array-methods.ts`. All `file:line` anchors verified against `origin/main` 2026-07-12.

## #3182 bloat-elimination epic → S1–S6 (umbrella stays tracking)
- **#3191** S1 — unify 4 JS-error-throw templates on `buildThrowJsErrorInstrs` [M, high]
- **#3192** S2 — DataView+RegExp brand → `receiver-brand.ts` [M, high, depends_on 3191]
- **#3193** S3 — delete 5 shape-path `Array.prototype.*.call` clones [M, medium — hot file]
- **#3194** S4 — extract shared super-dispatch core (new-super.ts) [S, high]
- **#3195** S5 — one parameterized closure-iterable drainer (runtime.ts) [S, high]
- **#3196** S6 — de-inline standalone dynamic-HOF onto #3098 steppers [L, medium — hot file]

## #3184 async-vacuous cluster → 2 slices
- **#3197** — for-await-of / async-dstr drive (383 vacuous) [M, high]
- **#3198** — Promise-combinator vacuous callbacks (218) [M, medium — overlaps blocked #2614 + active Promise work]

## #3185 default-lane Array.prototype generics → 3 method-family slices (disjoint from standalone #3169/#3180 by lane)
- **#3199** — fold/predicate: reduce/reduceRight/every/some (~283) [M, high]
- **#3200** — iteration/producer: forEach/map/filter/flatMap (~204) [M, high]
- **#3201** — search+structural: indexOf/lastIndexOf/slice/splice/sort/concat/pop (~312) [M, high — owns 30 trap-class fails, land first]

## Frontmatter hygiene
- **#3056** → `status: blocked` + `blocked_by: [3055]` — human-gated standalone-floor re-baseline, mis-claimed twice from the auto-pick pool while tagged `sprint: current` + high.

## Overlaps avoided
- #3169/#3180 (standalone Array HOF) — #3185 slices are default-lane, disjoint by lane.
- #2614/#2613 (blocked Promise) — #3198 is the vacuous-drive class, distinct mechanism; priority lowered + coordination note.
- Hot `array-methods.ts` slices (#3193/#3196/#3199/#3200/#3201) carry serialize/re-anchor-by-symbol notes.

Do NOT enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)