### PR TITLE
fix(#3190): standalone $__vec_base write arm for dynamic arr[i]=v (in-bounds)

### DIFF
--- a/plan/issues/3190-standalone-dynamic-vec-write-extern-set.md
+++ b/plan/issues/3190-standalone-dynamic-vec-write-extern-set.md
@@ -1,0 +1,96 @@
+---
+id: 3190
+title: "standalone: dynamic STORE to an any-typed array element is a no-op — __extern_set lacks a $__vec_base arm (write-side sibling of #3183)"
+status: in-progress
+assignee: ttraenkler/dev-vec-arms
+created: 2026-07-12
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: member-assignment
+goal: standalone
+umbrella: 2860
+sprint: current
+horizon: l
+related: [3183, 3179, 3169, 2186, 2860]
+origin: "Found while implementing #3183 (the READ-side fix). #3183 made an any-typed vec enumerate for-in and answer string-key reads; this is the remaining WRITE face."
+---
+
+# #3190 — standalone: dynamic `arr[i] = v` on an any-typed array does not land (write-path vec arm missing in `__extern_set`)
+
+## Problem (verified repros, all on main + after #3183)
+
+When the receiver's STATIC type is `any`, a computed STORE `arr[i] = v` routes
+through the dynamic `$Object` runtime via `__extern_set(obj, key, value)`. A
+real array in standalone is a `__vec_<elemKind>` struct subtyping `$__vec_base`
+(#2186), NOT a `$Object`. `__extern_set` has no `$__vec_base` arm, so the store
+is silently dropped — the element is never written.
+
+```ts
+// A: literal vec, dynamic overwrite is a no-op
+export function test(): number {
+  var a: any = [0];
+  a[0] = 42;
+  return a["0"]; // ACTUAL 0 (the literal's original element), expected 42
+}
+```
+
+```ts
+// B: new Array() + dynamic fill — nothing lands, so for-in also yields nothing
+export function test(): number {
+  var a: any = new Array();
+  a[0] = 1; a[1] = 2;
+  let n = 0;
+  for (var k in a) { n = n + 1; }
+  return n; // ACTUAL 0, expected 2 (writes never landed → vec stays empty)
+}
+```
+
+The READ side is already correct (#3183): reads of a **pre-populated** vec
+(array literals with data, aliased typed-array locals) enumerate for-in and
+answer string-key reads. Only the WRITE path is missing.
+
+## Root cause
+
+`__extern_set` (`src/codegen/object-runtime.ts`) unwraps the receiver to
+`$Object` and returns early / no-ops when the receiver is not a `$Object`. A
+`__vec_<k>` receiver is not a `$Object`, so:
+
+1. an in-bounds overwrite (`a[0] = 42` on `[0]`) never mutates `data[0]`;
+2. `new Array()` starts empty and cannot be grown through the dynamic path, so
+   B never populates anything.
+
+Two sub-problems, likely different difficulty:
+
+- **In-bounds overwrite** (`a[i] = v`, `0 <= i < len`) — a `$__vec_base` arm
+  that `array.set`s `data[i]` after coercing `v` to the carrier's element type.
+  Complication: element-type polymorphism (each `__vec_<k>` has a different
+  `data` element type and needs per-kind UNBOXING of the externref `value`),
+  mirroring `fillExternGetIdxVecArms`'s per-carrier boxing on the read side — so
+  this likely wants a finalize-fill (`fillExternSetIdxVecArms`) over every
+  registered carrier, not a single inline arm.
+- **Grow / `new Array()` append** (`a[len] = v` or `new Array()` then writes) —
+  a WasmGC `array` is fixed-length, so growth needs the resizable-vec
+  representation (spare-capacity `$Vec` / reallocation), which the dynamic
+  path does not currently drive. This is the harder half and may need its own
+  slice; the in-bounds overwrite can land first.
+
+## Acceptance criteria
+
+- Repro A returns 42 (in-bounds dynamic overwrite lands, per element kind).
+- Ideally repro B returns 2 (dynamic grow) — may be split into a follow-up if
+  the resizable representation is out of this slice's scope.
+- Zero host-lane regressions (host imports own the write path; standalone-only
+  arms, host bytes unchanged), zero standalone high-water regressions.
+
+## Notes
+
+- Read-side siblings for reference: `fillExternGetIdxVecArms` (#2190,
+  per-carrier element read), `fillDynamicForinVecArms` (#3183, for-in /
+  string-key read), `$__vec_base` length arm (#2186). The write arm is the
+  mirror of the #2190 read fill.
+- `__extern_set`'s signature and the coercion of `value` (externref) down to the
+  carrier element kind is the crux — reuse the existing unbox helpers
+  (`__unbox_number`, etc.) rather than adding parallel ones (anti-bloat).

--- a/plan/issues/3190-standalone-dynamic-vec-write-extern-set.md
+++ b/plan/issues/3190-standalone-dynamic-vec-write-extern-set.md
@@ -1,8 +1,9 @@
 ---
 id: 3190
 title: "standalone: dynamic STORE to an any-typed array element is a no-op — __extern_set lacks a $__vec_base arm (write-side sibling of #3183)"
-status: in-progress
+status: done
 assignee: ttraenkler/dev-vec-arms
+completed: 2026-07-12
 created: 2026-07-12
 priority: high
 feasibility: hard
@@ -16,6 +17,17 @@ sprint: current
 horizon: l
 related: [3183, 3179, 3169, 2186, 2860]
 origin: "Found while implementing #3183 (the READ-side fix). #3183 made an any-typed vec enumerate for-in and answer string-key reads; this is the remaining WRITE face."
+# The `$__vec_base` write fill is new native-runtime codegen that belongs in
+# object-runtime.ts (its read sibling `fillExternGetIdxVecArms` lives there); the
+# index.ts delta is just the import + one finalize call. Intended feature growth.
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
+  - src/codegen/index.ts
+# The write arm REUSES the engine's `__unbox_number` (ToNumber for both the index
+# key and per-carrier value coercion) — it does NOT hand-roll a fresh ToNumber
+# matrix; the gate counts the added call sites, so grant the allowance.
+coercion-sites-allow:
+  - src/codegen/object-runtime.ts
 ---
 
 # #3190 — standalone: dynamic `arr[i] = v` on an any-typed array does not land (write-path vec arm missing in `__extern_set`)
@@ -94,3 +106,39 @@ Two sub-problems, likely different difficulty:
 - `__extern_set`'s signature and the coercion of `value` (externref) down to the
   carrier element kind is the crux — reuse the existing unbox helpers
   (`__unbox_number`, etc.) rather than adding parallel ones (anti-bloat).
+
+## Resolution (2026-07-12) — IN-BOUNDS OVERWRITE half
+
+Implemented as `fillExternSetVecArms` (`src/codegen/object-runtime.ts`), wired
+into the finalize sequence in `src/codegen/index.ts` right after
+`fillExternGetIdxVecArms` (its read sibling). It PREPENDS a self-contained
+`ref.test $__vec_base`-guarded arm into `__extern_set` (the `fillExternGetErrorProps`
+splice discipline — append locals, never renumber; falls through untouched for
+non-vec receivers so host / non-vec output is byte-identical):
+`n = __unbox_number(key)` (ToNumber; skip on NaN) → `i = trunc_sat(n)` →
+in-bounds `0 <= i < len` via `$__vec_base` → per-carrier `ref.test <carrier>` →
+`array.set(data, i, unbox(value))`. Value coercion reuses the engine's
+`__unbox_number` via the new `unboxExternrefToVecElement` (the inverse of the
+read fill's `boxVecElementToExternref`): f64 / numeric-i32 / externref carriers;
+string/ref/bool/f32/i64 carriers have no trap-free unbox and stay a silent no-op
+(same as before), so the store is scoped to the trap-free numeric + externref
+carriers (the dominant `number[]`/`any[]` case).
+
+Verified standalone (zero host imports, `tests/issue-3190.test.ts`, 8 cases;
+writes observed via NUMERIC index reads which are vec-aware since #2190,
+independent of #3183's for-in/string-key read fill):
+- in-bounds overwrite lands (number[] → 42; overwrite-all sum → 6); index from
+  an any var → 77; non-integer value coerced (3.5 → *2 = 7); externref (any[])
+  carrier → 9.
+- OOB / negative-index store → silent no-op, no trap, existing data intact.
+- plain any-typed object element store unchanged.
+
+`quality` cheap gates green locally (loc-budget + coercion-sites allowances
+granted above; ir-fallbacks / any-box / stack-balance / codegen-fallbacks OK).
+
+### Deferred (documented, not this PR): GROWTH
+`var a: any = new Array(); a[0] = 1` and `a[len] = v` (grow) still no-op — a
+WasmGC `array` is fixed-length, so growth needs the resizable-vec representation
+which the dynamic path does not drive. Tracked here for a follow-up slice; the
+in-bounds overwrite (this PR) is the tractable, high-value half. `new Array()`
+starts empty, so its for-in/read also yields nothing until growth lands.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -71,6 +71,7 @@ import {
   fillBuiltinFnMeta,
   fillExternArrayLikeStructArms,
   fillExternGetIdxVecArms,
+  fillExternSetVecArms,
   fillExternIsArray,
   fillProxyDispatch,
 } from "./object-runtime.js";
@@ -2617,6 +2618,12 @@ export function generateModule(
     // `.length` fix, so `(arr as any)[i]` through the externref boundary reads
     // the element instead of null/0. Standalone only (no-op otherwise).
     fillExternGetIdxVecArms(ctx);
+
+    // (#3190) Write-side sibling of the fill above: splice `$__vec_base` STORE
+    // arms into `__extern_set` so `(arr as any)[i] = v` on an any-typed array
+    // lands the in-bounds element instead of silently no-op'ing. Standalone
+    // only (no-op otherwise).
+    fillExternSetVecArms(ctx);
 
     // (#3169) Splice CLOSED-STRUCT array-like arms into the standalone
     // dynamic-reader trio (`__extern_length`/`__extern_get_idx`/

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -9834,6 +9834,39 @@ export function boxVecElementToExternref(ctx: CodegenContext, elemType: ValType)
 }
 
 /**
+ * (#3190) INVERSE of `boxVecElementToExternref`: coerce the externref `value` on
+ * the stack DOWN to a carrier's `data` element type, for the standalone dynamic
+ * STORE path (`(arr as any)[i] = v` → `__extern_set` → `fillExternSetVecArms`).
+ *
+ *   - f64            → `__unbox_number(value)` (ToNumber; NaN for a non-number).
+ *   - i32 (numeric)  → `__unbox_number` then `i32.trunc_sat_f64_s`.
+ *   - externref      → identity (the canonical `externref` `$Vec`).
+ *
+ * Returns null for the kinds `boxVecElementToExternref` also skips
+ * (boolean-i32 — number box ≠ boolean box; string/ref carriers — a value cast
+ * could trap when the any-typed value is not that ref type; f32/i64/v128) so the
+ * store is a no-op for those carriers, exactly as before this fill (host-lenient
+ * silent no-op). Scoping the write to the trap-free numeric + externref carriers
+ * covers the dominant `number[]`/`any[]` case; string-carrier writes are a
+ * follow-up.
+ */
+function unboxExternrefToVecElement(ctx: CodegenContext, elemType: ValType): Instr[] | null {
+  if (elemType.kind === "f64") {
+    const unboxIdx = ctx.funcMap.get("__unbox_number");
+    return unboxIdx === undefined ? null : [{ op: "call", funcIdx: unboxIdx } as Instr];
+  }
+  if (elemType.kind === "i32") {
+    if ((elemType as { boolean?: boolean }).boolean) return null;
+    const unboxIdx = ctx.funcMap.get("__unbox_number");
+    return unboxIdx === undefined
+      ? null
+      : [{ op: "call", funcIdx: unboxIdx } as Instr, { op: "i32.trunc_sat_f64_s" } as Instr];
+  }
+  if (elemType.kind === "externref") return [];
+  return null;
+}
+
+/**
  * (#2190) Parameters needed to build the `__extern_get_idx` body, shared by the
  * eager registration (empty `vecArms`) and the FINALIZE fill (full `vecArms`).
  */
@@ -10068,6 +10101,146 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
     // is not safe, so skip rather than risk an unbalanced body.
     return;
   }
+}
+
+/**
+ * (#3190) Finalize-time `$__vec_base` write arms for the standalone dynamic
+ * STORE helper `__extern_set`. The write-side sibling of `fillExternGetIdxVecArms`
+ * (#2190, the read fill).
+ *
+ * A computed store `(arr as any)[i] = v` on an any-typed receiver lowers to
+ * `__extern_set(obj, box(i), box(v))`. A real array is a `__vec_<elemKind>`
+ * struct subtyping `$__vec_base` (#2186), NOT a `$Object`, so `__extern_set`'s
+ * `ref.test $Object` misses it and the store is silently dropped — the element
+ * is never written (#3183 fixed the READ side; this is the WRITE side).
+ *
+ * This fill PREPENDS a self-contained arm at body index 0 (the
+ * `fillExternGetErrorProps` splice discipline — append locals, never renumber;
+ * falls through untouched for non-vec receivers so host / non-vec output is
+ * byte-identical). The arm:
+ *   1. `ref.test $__vec_base` — a vec receiver enters the block and ALWAYS
+ *      returns (writes on a hit, else a host-lenient silent no-op), never
+ *      falling through to the `$Object` body.
+ *   2. index `i = trunc_sat(__unbox_number(key))` (the key is `box(i)`;
+ *      `__unbox_number` is ToNumber so a string index works too); skip on NaN.
+ *   3. in-bounds `0 <= i < len` (len via `$__vec_base` field 0) — else no-op.
+ *   4. per-carrier `ref.test <carrier>` → `array.set(data, i, unbox(value))`
+ *      with per-kind UNBOXING (`unboxExternrefToVecElement`). An unsupported
+ *      element kind (string/ref/bool/f32/i64) has no unbox arm → the store is a
+ *      no-op for that carrier (same as before the fill).
+ *
+ * SCOPE: this is the IN-BOUNDS OVERWRITE half. GROWTH (`a[len] = v`,
+ * `new Array()` then writes) needs the resizable-vec representation, which the
+ * dynamic path does not drive — deferred (see #3190 "Grow" note). Standalone
+ * only (gated on `ctx.externGetIdxReserved`, set when the trio was registered
+ * with the standalone arms); host output untouched.
+ */
+export function fillExternSetVecArms(ctx: CodegenContext): void {
+  if (!ctx.externGetIdxReserved) return; // host owns the write path
+  const fn = ctx.mod.functions.find((f) => f.name === "__extern_set");
+  if (!fn) return;
+  const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+  if (unboxNumIdx === undefined) return;
+  const vecBaseIdx = getOrRegisterVecBaseType(ctx);
+
+  // Enumerate concrete `__vec_<elemKind>` carriers (same filter as
+  // `fillExternGetIdxVecArms`) with a trap-free write unbox arm.
+  const seen = new Set<number>();
+  const carrierArms: Instr[] = [];
+  const carriers: { typeIdx: number; arrTypeIdx: number; elemType: ValType }[] = [];
+  for (const [elemKind, vecTypeIdx] of ctx.vecTypeMap.entries()) {
+    if (NON_ARRAY_BYTE_VEC_ELEM_KINDS.has(elemKind)) continue;
+    if (seen.has(vecTypeIdx)) continue;
+    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    if (arrTypeIdx < 0) continue;
+    const arrDef = ctx.mod.types[arrTypeIdx];
+    if (!arrDef || arrDef.kind !== "array") continue;
+    seen.add(vecTypeIdx);
+    carriers.push({ typeIdx: vecTypeIdx, arrTypeIdx, elemType: arrDef.element });
+  }
+  carriers.sort((a, b) => a.typeIdx - b.typeIdx);
+
+  // params: 0=obj 1=key 2=value ; append locals: setAny(anyref) setN(f64) setI(i32)
+  const setAny = 3 + fn.locals.length;
+  const setN = setAny + 1;
+  const setI = setAny + 2;
+
+  for (const { typeIdx, arrTypeIdx, elemType } of carriers) {
+    const unbox = unboxExternrefToVecElement(ctx, elemType);
+    if (unbox === null) continue; // unsupported element kind → store no-op (as before)
+    carrierArms.push(
+      { op: "local.get", index: setAny } as Instr,
+      { op: "ref.test", typeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // vec.data[i] = unbox(value)
+          { op: "local.get", index: setAny } as Instr,
+          { op: "ref.cast", typeIdx } as Instr,
+          { op: "struct.get", typeIdx, fieldIdx: 1 } as Instr,
+          { op: "local.get", index: setI } as Instr,
+          { op: "local.get", index: 2 } as Instr,
+          ...unbox,
+          { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+          { op: "return" } as Instr,
+        ],
+      } as Instr,
+    );
+  }
+  if (carrierArms.length === 0) return; // no writable carriers → leave body untouched
+
+  fn.locals.push(
+    { name: "__vec_set_any", type: { kind: "anyref" } },
+    { name: "__vec_set_n", type: { kind: "f64" } },
+    { name: "__vec_set_i", type: { kind: "i32" } },
+  );
+
+  const arm: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.tee", index: setAny },
+    { op: "ref.test", typeIdx: vecBaseIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // n = __unbox_number(key) ; skip if NaN (non-numeric key)
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: unboxNumIdx },
+        { op: "local.tee", index: setN },
+        { op: "local.get", index: setN },
+        { op: "f64.eq" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // i = trunc_sat(n) ; if 0 <= i < len → per-carrier array.set
+            { op: "local.get", index: setN },
+            { op: "i32.trunc_sat_f64_s" },
+            { op: "local.set", index: setI },
+            { op: "local.get", index: setI },
+            { op: "i32.const", value: 0 },
+            { op: "i32.ge_s" },
+            { op: "local.get", index: setI },
+            { op: "local.get", index: setAny },
+            { op: "ref.cast", typeIdx: vecBaseIdx },
+            { op: "struct.get", typeIdx: vecBaseIdx, fieldIdx: 0 },
+            { op: "i32.lt_s" },
+            { op: "i32.and" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: carrierArms,
+            } as Instr,
+          ],
+        } as Instr,
+        // vec receiver, OOB / non-numeric / grow / unsupported kind → no-op
+        { op: "return" },
+      ],
+    } as Instr,
+  ];
+  fn.body.splice(0, 0, ...arm);
 }
 
 /**

--- a/tests/issue-3190.test.ts
+++ b/tests/issue-3190.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3190 — standalone: dynamic STORE to an any-typed array element.
+ *
+ * The write-side sibling of #3183. A computed store `(arr as any)[i] = v` on an
+ * any-typed receiver lowers to `__extern_set(obj, box(i), box(v))`. A real array
+ * is a `__vec_<elemKind>` struct subtyping `$__vec_base` (#2186), NOT a
+ * `$Object`, so `__extern_set`'s `ref.test $Object` missed it and the store was
+ * silently dropped — the element was never written.
+ *
+ * `fillExternSetVecArms` (object-runtime.ts) splices a `$__vec_base` write arm
+ * into `__extern_set`: index via `__unbox_number(key)`, bounds-check through
+ * `$__vec_base`, then per-carrier `array.set(data, i, unbox(value))` with
+ * per-kind UNBOXING (`unboxExternrefToVecElement`, the inverse of the read fill's
+ * `boxVecElementToExternref`). Standalone-only; host output byte-identical.
+ *
+ * SCOPE: the IN-BOUNDS OVERWRITE half. Growth (`a[len] = v`, `new Array()` +
+ * writes) needs the resizable-vec representation and is deferred (#3190 note).
+ *
+ * Writes are OBSERVED here via NUMERIC index reads (`a[i]`), which are vec-aware
+ * since #2190 and independent of the #3183 for-in / string-key READ fill. Every
+ * case compiles standalone and must instantiate with ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandaloneNum(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary!);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3190 — standalone dynamic STORE to an any-typed array element", () => {
+  it("in-bounds overwrite lands (number[] carrier)", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [0, 0, 0];
+        a[1] = 42;
+        return a[1];
+      }`),
+    ).toBe(42);
+  });
+
+  it("overwrite every element then sum", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [0, 0, 0];
+        a[0] = 1; a[1] = 2; a[2] = 3;
+        return a[0] + a[1] + a[2];
+      }`),
+    ).toBe(6);
+  });
+
+  it("index sourced from an any-typed variable", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [0, 0];
+        var i: any = 1;
+        a[i] = 77;
+        return a[1];
+      }`),
+    ).toBe(77);
+  });
+
+  it("non-integer value coerces to the carrier element type", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [0];
+        a[0] = 3.5;
+        return (a[0] as number) * 2;
+      }`),
+    ).toBe(7);
+  });
+
+  it("externref (any[]) carrier store lands", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [1, 2, 3];
+        var b: any = a;
+        b[0] = 9;
+        return b[0];
+      }`),
+    ).toBe(9);
+  });
+
+  it("out-of-bounds store is a silent no-op (no trap, existing data intact)", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [7];
+        a[5] = 99;
+        return a[0];
+      }`),
+    ).toBe(7);
+  });
+
+  it("negative-index store is a silent no-op (no trap)", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var a: any = [7];
+        a[-1] = 99;
+        return a[0];
+      }`),
+    ).toBe(7);
+  });
+
+  it("regression guard: plain any-typed object element store is unchanged", async () => {
+    expect(
+      await runStandaloneNum(`export function test(): number {
+        var o: any = {};
+        o["x"] = 5;
+        return o["x"];
+      }`),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
## What

Fixes #3190 — the WRITE-side sibling of #3183 (which fixed the read side). A computed store `(arr as any)[i] = v` on an any-typed receiver lowers to `__extern_set(obj, box(i), box(v))`. A real array is a `__vec_<elemKind>` struct (subtype of `$__vec_base`, #2186), NOT a `$Object`, so `__extern_set`'s `ref.test $Object` missed it and the store was **silently dropped** — the element was never written.

## How

`fillExternSetVecArms` (`src/codegen/object-runtime.ts`), finalize-spliced in `src/codegen/index.ts` right after `fillExternGetIdxVecArms` (its read sibling), PREPENDS a self-contained `ref.test $__vec_base`-guarded arm into `__extern_set` (the `fillExternGetErrorProps` splice discipline — append locals, never renumber; falls through untouched for non-vec receivers so host / non-vec output is byte-identical):

`n = __unbox_number(key)` (ToNumber; skip on NaN) → `i = trunc_sat(n)` → in-bounds `0 <= i < len` (via `$__vec_base` field 0) → per-carrier `ref.test <carrier>` → `array.set(data, i, unbox(value))`.

**Anti-bloat:** value coercion reuses the engine's `__unbox_number` via the new `unboxExternrefToVecElement` — the exact inverse of the read fill's `boxVecElementToExternref` — for f64 / numeric-i32 / externref carriers. String/ref/bool/f32/i64 carriers have no trap-free unbox and stay a silent no-op (same as before), scoping the store to the trap-free numeric + externref carriers (the dominant `number[]` / `any[]` case).

## Scope

**IN-BOUNDS OVERWRITE** half. **Growth** (`new Array()` + writes, `a[len] = v`) needs the resizable-vec representation, which the dynamic path does not drive — documented as a deferred follow-up in the issue. `new Array()` starts empty, so its for-in/read also yields nothing until growth lands.

## Tests

`tests/issue-3190.test.ts` — 8 cases, all asserting **zero host imports**. Writes are observed via NUMERIC index reads (`a[i]`), vec-aware since #2190 and independent of #3183's for-in / string-key read fill:
- in-bounds overwrite (number[] → 42; overwrite-all sum → 6); index from an any var → 77; non-integer value coerced (3.5 → *2 = 7); externref (any[]) carrier → 9
- OOB / negative-index store → silent no-op, no trap, existing data intact
- plain any-typed object element store unchanged

Local: typecheck clean; loc-budget + coercion-sites allowances granted in the issue frontmatter (legitimate feature growth + reuse of `__unbox_number`); ir-fallbacks / any-box / stack-balance / codegen-fallbacks OK; object-write regression suite (issue-3033, object-methods, issue-forin) green.

Together with #3183 (read), completes dynamic read+write of pre-populated any-typed arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)