### PR TITLE
docs(#3197): root-cause diagnosis — host-lane async vacuity is a runner-timing issue (re-size xl, BLOCKED on scope)

### DIFF
--- a/plan/issues/3197-forawait-of-async-drive-vacuous-slice.md
+++ b/plan/issues/3197-forawait-of-async-drive-vacuous-slice.md
@@ -1,7 +1,9 @@
 ---
 id: 3197
 title: "default lane: drive the for-await-of / async-dstr callback chain to completion (383 vacuous fails)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-number-resid
+blocked: scope-decision
 created: 2026-07-12
 updated: 2026-07-12
 priority: high
@@ -12,7 +14,7 @@ es_edition: ES2018
 language_feature: for-await-of
 goal: core-semantics
 sprint: current
-horizon: m
+horizon: xl
 umbrella: 3184
 related: [3184, 2940, 3086, 2669, 3021]
 origin: "2026-07-12 Fable codebase audit §F1; slice of #3184"
@@ -38,11 +40,16 @@ language/statements/for-await-of/async-func-dstr-var-obj-ptrn-prop-id-init-unres
 language/statements/for-await-of/async-gen-decl-dstr-obj-id-put-unresolvable-no-strict.js
 ```
 
-The runner is NOT the gap — it implements the async protocol (`$DONE`
-`tests/test262-runner.ts:1890`, `asyncTest` `:1899`, detection `:2568-2569`).
-The failure is compiler-side: the host-lane async machinery never drives the
-`asyncTest(fn)` body to completion for for-await-of / async-destructuring
-shapes.
+**CORRECTION (root-cause diagnosis, dev-number-resid 2026-07-12):** the
+original claim "the runner is NOT the gap … the failure is compiler-side" is
+**wrong**. This is a **runner-timing** issue, proven by repro below. The runner
+DOES implement the harness shims (`$DONE` `:1890`, `asyncTest` `:1899`,
+detection `:2568-2569`), but it reads `test()`'s return value
+**synchronously** (`const ret = testFn()` `:4001`, vacuity check `:4035`),
+while the host/default-lane async continuation chain runs on the **host
+microtask queue**, which does not drain until AFTER `test()` has already
+returned. The callbacks are not dropped — they run too late for the runner to
+observe. See `## Root-cause diagnosis` and `## Scope Decision Needed` below.
 
 ## Reproduction path (verified anchors)
 
@@ -67,6 +74,68 @@ silent rejection is swallowed by the host bridge (`Promise_then` /
 5. If the same root cause explains the async-function/async-generator vacuous
    slice (~91), note the measured overlap; do not scope-creep into the
    Promise-combinator slice (that is #3198).
+
+## Root-cause diagnosis (dev-number-resid, 2026-07-12) — satisfies AC#1
+
+**The chain is NOT broken; it completes too late.** Reproduced with a minimal
+host-lane repro (`.tmp/repro-realshape.mjs`) mirroring the sampled test shape
+(`async fn() { for await (…) { throw ReferenceError } }` →
+`fn().then(onRes,onRej).then($DONE,$DONE)`):
+
+- `test()` returns **0 synchronously** — the exact value the runner reads at
+  `tests/test262-runner.ts:4001` (`const ret = testFn()`), which then hits the
+  `-262` vacuity sentinel path at `:4035` → scored `vacuous`.
+- After I manually drain the **host** microtask queue, the chain **completes**
+  (`getDone === 1`). So the continuation ran — just after the runner already
+  recorded the result.
+
+**Why:** on the default/JS-host lane, async functions compile to **host Promise
+imports** — `Promise_resolve` / `Promise_then2` / `Promise_reject` /
+`__make_callback` (`src/codegen/declarations.ts:1748-1765`; two-lane split
+noted at `src/codegen/async-frame.ts:96`). Host `.then` callbacks are always
+scheduled on the host microtask queue and cannot be drained synchronously from
+inside a synchronous `test()` call. The **standalone/WASI** lane does NOT have
+this bug because it drives on the in-wasm microtask scheduler (#1326/#2906),
+which `test()` drains synchronously (WASI `_start` auto-drain) before returning.
+
+**Chain-link answer (AC#1):** `asyncTest`/`.then` wrapper ✅ invoked · async fn
+body ✅ runs · for-await drive ✅ completes · `$DONE` ✅ **eventually** called —
+but on the host microtask tick that fires *after* the runner's synchronous read.
+The "dropped callback" framing is a measurement artifact of the synchronous read.
+
+**AC#5 overlap:** this same host-microtask-timing root cause explains the
+async-function / async-generator vacuous slice (~91) and every host-lane test
+that routes assertions through `Promise.prototype.then` — it is NOT specific to
+for-await-of or destructuring. (The destructuring shapes merely dominate the
+*sample*; the mechanism is lane-wide.)
+
+## Scope Decision Needed — BLOCKED (needs stakeholder sign-off)
+
+The fix is **not** an M implementation; it is a scope/policy choice. Re-sized
+`horizon: xl`, `blocked: scope-decision`. Two mutually-exclusive paths:
+
+### (a) Architectural — host-lane async on the wasm scheduler — XL / senior
+Route the JS-host async continuation chain off host Promises and onto the
+synchronously-drainable in-wasm microtask scheduler (extend the #2906 drive
+lane to `target` = default/host), so `test()` completes the chain before it
+returns. Large, deep async-codegen change; touches the host Promise bridge and
+the CPS driver. **Owner: senior-dev.** Risk: host-mode Promise semantics /
+interop with real host Promises handed across the boundary.
+
+### (b) Runner-side microtask drain — 1 line, but needs sign-off + baseline refresh
+Have the runner `await` a microtask/macrotask tick (or drain) before reading
+`ret` for `flags:[async]` tests. Mechanically trivial (drain host microtasks
+after `testFn()`), but it **flips ~250–383 currently-`vacuous`/`fail` records
+to pass/honest-fail in one commit** — a large baseline movement that, like
+#3056, requires **human sign-off + a coordinated baseline refresh** (and a
+re-check that no *currently-counted* host pass silently depended on the
+vacuity). It also revises the "runner is not the gap" premise the umbrella
+#3184 was scoped under.
+
+**Recommendation:** pursue (a) as the durable fix under a senior-dev owner;
+consider (b) only if the stakeholder accepts the baseline movement + premise
+revision. Diagnosis (AC#1) is delivered; AC#2–#4 await the scope decision.
+**Do not implement either without sign-off.**
 
 ## Audit cross-link
 


### PR DESCRIPTION
## Summary

Diagnosis-only PR for #3197 (for-await-of vacuous drive). No implementation —
the fix path is a scope/policy decision, not an M implementation.

## Root cause (reproduced)

The host/default-lane async continuation chain (`fn().then(onRes,onRej).then($DONE,$DONE)`)
runs on the **host microtask queue**, which drains only AFTER `test()` returns.
The runner reads `test()`'s return **synchronously** (`test262-runner.ts:4001`),
so at read time no assertion has run → `test()` yields the `-262` vacuity
sentinel → scored `vacuous`. The callbacks are NOT dropped — my minimal repro
shows the chain completes once the host microtask queue is drained. The
standalone/WASI lane avoids this via the in-wasm scheduler (#1326/#2906) that
`test()` drains synchronously.

Host-lane async compiles to host Promise imports
(`Promise_resolve`/`Promise_then2`/`Promise_reject`/`__make_callback`,
`declarations.ts:1748-1765`); host `.then` callbacks can't be drained
synchronously from inside `test()`.

## Changes (plan-only)

- Landed AC#1 root-cause note + AC#5 lane-wide overlap finding in the issue.
- **Corrected the issue's "runner is NOT the gap" premise** — it IS a
  runner-timing issue, proven by repro.
- Re-sized `horizon: m → xl`, `blocked: scope-decision`.
- Added `## Scope Decision Needed`: (a) host-async-on-wasm-scheduler = XL/senior
  (durable); (b) runner microtask drain = 1 line but flips ~250–383 records →
  needs human sign-off + coordinated baseline refresh (like #3056) + premise
  revision.

Issue stays `in-progress` pending the scope decision. Do not implement either
fix without sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)