### PR TITLE
refactor(#3191): bloat S1 — unify the 4 JS-error-throw templates onto js-errors.ts

### DIFF
--- a/plan/issues/3191-bloat-s1-unify-js-error-throw-templates.md
+++ b/plan/issues/3191-bloat-s1-unify-js-error-throw-templates.md
@@ -1,7 +1,9 @@
 ---
 id: 3191
 title: "bloat S1: unify the 4 hand-rolled JS-error-throw templates on buildThrowJsErrorInstrs"
-status: ready
+status: done
+completed: 2026-07-12
+assignee: ttraenkler/dev-number-resid
 created: 2026-07-12
 updated: 2026-07-12
 priority: high

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -21,7 +21,8 @@ import {
   resolveWasmType,
   typedArrayPackedSignedness,
 } from "./index.js";
-import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
+import { addStringConstantGlobal, localGlobalIdx } from "./registry/imports.js";
+import { buildThrowStringInstrs, emitThrowString, noJsHost } from "./js-errors.js";
 import { emitToBoolean } from "./coercion-engine.js";
 import { compileStringLiteral, elemGetOp, unpackedElemType, valTypesMatch } from "./shared.js";
 import {
@@ -34,7 +35,6 @@ import {
   isTaViewTypeIdx,
 } from "./registry/types.js";
 import { emitTaDynViewToVec, emitTaDynViewValidate, emitTaViewToVec, emitTaViewWriteBack } from "./dataview-native.js"; // (#3054 B1 Option A) de-view; (B3) write-through; (#3058) dyn-view materialize+validate
-import { noJsHost } from "./expressions/helpers.js";
 import { ensureNativeIteratorRuntime, getOrRegisterIterRecType } from "./iterator-native.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
 import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
@@ -134,19 +134,11 @@ function nativeStringElementEqInstrs(
   ];
 }
 
-/** Emit throw with a string message (local version to avoid circular dep on expressions.ts) */
-function emitThrowString(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
-  addStringConstantGlobal(ctx, message);
-  fctx.body.push(...stringConstantExternrefInstrs(ctx, message));
-  const tagIdx = ensureExnTag(ctx);
-  fctx.body.push({ op: "throw", tagIdx });
-}
-
-function throwStringInstrs(ctx: CodegenContext, message: string): Instr[] {
-  addStringConstantGlobal(ctx, message);
-  const tagIdx = ensureExnTag(ctx);
-  return [...stringConstantExternrefInstrs(ctx, message), { op: "throw", tagIdx } as Instr];
-}
+// (#3191) The former private `emitThrowString` / `throwStringInstrs` copies (a
+// verbatim duplicate of the canonical bare-string throw, kept local to avoid a
+// circular dep on `expressions/`) now route through the layering-safe leaf
+// module `./js-errors.ts` — `emitThrowString` (push) + `buildThrowStringInstrs`
+// (returns the terminal `Instr[]` for an `if.then`/`else` arm).
 
 // unpackedElemType / elemGetOp are canonical in shared.ts (#2934 — needed by
 // loops.ts and type-coercion.ts too, and array-methods.ts is not importable
@@ -323,7 +315,7 @@ function emitReceiverNullGuard(
   fctx.body.push({
     op: "if",
     blockType: { kind: "empty" },
-    then: throwStringInstrs(ctx, "TypeError: Array method called on null or undefined"),
+    then: buildThrowStringInstrs(ctx, "TypeError: Array method called on null or undefined"),
     else: [],
   });
 }
@@ -1597,7 +1589,7 @@ export function compileArrayLikePrototypeCall(
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: throwStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
+          then: buildThrowStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
         });
       }
 
@@ -1761,7 +1753,7 @@ export function compileArrayLikePrototypeCall(
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: throwStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
+          then: buildThrowStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
         });
       }
 
@@ -7451,7 +7443,7 @@ function compileArrayReduce(
     fctx.body.push({
       op: "if",
       blockType: { kind: "empty" },
-      then: throwStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
+      then: buildThrowStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
     } as Instr);
     fctx.body.push({ op: "local.get", index: loop.dataTmp });
     fctx.body.push({ op: "i32.const", value: 0 });
@@ -7650,7 +7642,7 @@ function compileArrayReduceRight(
     fctx.body.push({
       op: "if",
       blockType: { kind: "empty" },
-      then: throwStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
+      then: buildThrowStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
     } as Instr);
     fctx.body.push({ op: "local.get", index: dataTmp });
     fctx.body.push({ op: "local.get", index: lenTmp });

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -39,10 +39,9 @@
 import type { Instr, ValType } from "../ir/types.js";
 import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { emitThrowTypeError, noJsHost } from "./expressions/helpers.js";
+import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./js-errors.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
-import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import {
   addFuncType,
@@ -626,14 +625,10 @@ const DV_RANGE_MESSAGE = "RangeError: Offset is outside the bounds of the DataVi
  * accessor body and flushes shifts.
  */
 function emitDataViewRangeError(ctx: CodegenContext): Instr[] {
-  if (noJsHost(ctx)) emitWasiErrorConstructor(ctx, "RangeError", 1);
-  addStringConstantGlobal(ctx, DV_RANGE_MESSAGE);
-  const ctorIdx = ensureLateImport(ctx, "__new_RangeError", [{ kind: "externref" }], [{ kind: "externref" }]);
-  const tagIdx = ensureExnTag(ctx);
-  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, DV_RANGE_MESSAGE)];
-  if (ctorIdx !== undefined) instrs.push({ op: "call", funcIdx: ctorIdx } as Instr);
-  instrs.push({ op: "throw", tagIdx } as Instr);
-  return instrs;
+  // (#3191) Unified onto the shared builder. No `flush` opt: the caller
+  // pre-builds this template BEFORE emitting the body and flushes shifts itself
+  // (funcIdx-capture ordering, see the doc above) — exactly the former behavior.
+  return buildThrowJsErrorInstrs(ctx, "RangeError", DV_RANGE_MESSAGE);
 }
 
 /** §24.3.1.1/§24.3.1.2 step 2 — receiver has no [[DataView]] internal slot. */
@@ -650,14 +645,8 @@ const DV_TOBIGINT_UNDEFINED_MESSAGE = "TypeError: Cannot convert undefined to a 
  * MUST be built (and shifts flushed) BEFORE any later funcIdx is captured.
  */
 function dvTypeErrorThrow(ctx: CodegenContext, message: string): Instr[] {
-  if (noJsHost(ctx)) emitWasiErrorConstructor(ctx, "TypeError", 1);
-  addStringConstantGlobal(ctx, message);
-  const ctorIdx = ensureLateImport(ctx, "__new_TypeError", [{ kind: "externref" }], [{ kind: "externref" }]);
-  const tagIdx = ensureExnTag(ctx);
-  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, message)];
-  if (ctorIdx !== undefined) instrs.push({ op: "call", funcIdx: ctorIdx } as Instr);
-  instrs.push({ op: "throw", tagIdx } as Instr);
-  return instrs;
+  // (#3191) Unified onto the shared builder — caller-flush ordering (see above).
+  return buildThrowJsErrorInstrs(ctx, "TypeError", message);
 }
 
 /**

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -12428,7 +12428,7 @@ function compileCallExpression(
           // (#3175) Throw a real RangeError INSTANCE so the raw-`try`/`catch` +
           // `assert(e instanceof RangeError)` corpus passes (not a bare string).
           const rangeErrMsg = "RangeError: toString() radix must be between 2 and 36";
-          const throwInstrs = buildThrowJsErrorInstrs(ctx, fctx, "RangeError", rangeErrMsg);
+          const throwInstrs = buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx });
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
@@ -12644,7 +12644,7 @@ function compileCallExpression(
         {
           // (#3175) Real RangeError INSTANCE (see the toString radix gate).
           const rangeErrMsg = "RangeError: toFixed() digits argument must be between 0 and 100";
-          const throwInstrs = buildThrowJsErrorInstrs(ctx, fctx, "RangeError", rangeErrMsg);
+          const throwInstrs = buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx });
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },

--- a/src/codegen/expressions/helpers.ts
+++ b/src/codegen/expressions/helpers.ts
@@ -15,32 +15,35 @@ import type { Instr, ValType } from "../../ir/types.js";
 import { getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { funcSignatureOf } from "../func-space.js";
-import { stringConstantExternrefInstrs } from "../native-strings.js";
-import { addStringConstantGlobal, ensureExnTag } from "../registry/imports.js";
-import { emitWasiErrorConstructor } from "../registry/error-types.js";
-import { coerceType, ensureLateImport, flushLateImportShifts, valTypesMatch } from "../shared.js";
+import { coerceType, valTypesMatch } from "../shared.js";
 
-/**
- * #1473 — No-JS-host predicate. Both `--target wasi` and `--target standalone`
- * run without a JS runtime, so neither can rely on host imports such as
- * `__throw_type_error` / `__new_TypeError` resolving to JS constructors. In
- * these modes the compiler emits Wasm-native Error constructors instead.
- */
-export function noJsHost(ctx: CodegenContext): boolean {
-  return ctx.wasi || ctx.standalone;
-}
-
-/**
- * Emit a Wasm throw instruction with a string error message.
- * This replaces `unreachable` traps so that JS try/catch (and assert.throws)
- * can catch the error instead of getting an uncatchable RuntimeError.
- */
-export function emitThrowString(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
-  addStringConstantGlobal(ctx, message);
-  fctx.body.push(...stringConstantExternrefInstrs(ctx, message));
-  const tagIdx = ensureExnTag(ctx);
-  fctx.body.push({ op: "throw", tagIdx });
-}
+// (#3191 — bloat S1) The JS-error-throw lowering was hoisted into the
+// layering-safe leaf module `../js-errors.ts` so runtime modules (dataview-
+// native / native-proto / array-methods / …) can share it without importing
+// from `expressions/` (#3029). Imported here (some are used internally) AND
+// re-exported so existing front-end importers keep resolving through
+// `expressions/helpers.js` unchanged.
+import {
+  buildThrowJsErrorInstrs,
+  buildThrowStringInstrs,
+  emitThrowJsError,
+  emitThrowRangeError,
+  emitThrowReferenceError,
+  emitThrowString,
+  emitThrowTypeError,
+  noJsHost,
+} from "../js-errors.js";
+export {
+  buildThrowJsErrorInstrs,
+  buildThrowStringInstrs,
+  emitThrowJsError,
+  emitThrowRangeError,
+  emitThrowReferenceError,
+  emitThrowString,
+  emitThrowTypeError,
+  noJsHost,
+};
+export type { JsErrorKind } from "../js-errors.js";
 
 /**
  * #1365 — Resolve the class struct that declared a `#name` PrivateIdentifier.
@@ -179,117 +182,6 @@ export function emitPrivateBrandPredicate(
     then: tagChecks,
     else: [{ op: "i32.const", value: 0 } as Instr],
   } as Instr);
-}
-
-/**
- * (#2102) Error constructors {@link emitThrowJsError} can build. Each maps to a
- * `__new_<Kind>(message)` host import in JS-host mode and to the in-module WASI
- * Error constructor under `--target standalone`/`wasi`. The set is the spec's
- * runtime-check error family (the §10/§22/§23 bounds/integrity/callable checks).
- */
-export type JsErrorKind = "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError" | "Error";
-
-/**
- * (#2102) THE shared "throw a real JS Error instance" lowering. Runtime checks
- * (bounds / integrity / callable / [[Set]] failures) that the spec requires to
- * raise a catchable `TypeError`/`RangeError`/… must route through here instead
- * of emitting an uncatchable Wasm `unreachable`/`ref.cast` trap or a bare string
- * throw. The thrown ref is a real `<Kind>`-tagged externref (`e instanceof
- * <Kind>` holds), produced by the same `__new_<Kind>(message)` path `new
- * <Kind>(msg)` uses, and dispatched through the shared `$exc` tag so the user's
- * try/catch (and test262 `assert.throws`) catches it.
- *
- * Dual-mode: in no-JS-host mode (`--target standalone`/`wasi`) the constructor
- * is the in-module `emitWasiErrorConstructor` function, so no unsatisfiable
- * `env::__new_<Kind>` host import is requested. The constructor is registered
- * BEFORE the funcIdx is resolved so `ensureLateImport` finds the in-module
- * function in funcMap and does NOT add an `env::__new_<Kind>` host import.
- * (Consolidates the previously-duplicated #1365 TypeError / #1473
- * ReferenceError / #2164 RangeError lowerings.)
- *
- * Leaves nothing on the value stack (the `throw` is terminal / stack-polymorphic).
- */
-export function emitThrowJsError(ctx: CodegenContext, fctx: FunctionContext, kind: JsErrorKind, message: string): void {
-  fctx.body.push(...buildThrowJsErrorInstrs(ctx, fctx, kind, message));
-}
-
-/**
- * (#3175) Same real-instance `<Kind>`-throw lowering as {@link emitThrowJsError},
- * but RETURNS the terminal instruction sequence instead of pushing it, so it can
- * be spliced into a nested `if.then` array (a CONDITIONAL throw — e.g. the
- * `Number.prototype.toString(radix)` out-of-2..36 / `toFixed(digits)` out-of-
- * 0..100 RangeError gates). Those gates previously threw a BARE STRING via the
- * shared `$exc` tag, so `e instanceof RangeError` was false and the raw-`try`/
- * `catch` + `assert(e instanceof RangeError)` corpus (S15.7.4.5 A1.3/A1.4) failed.
- *
- * As a side effect it registers the constructor / string constant and flushes
- * any late-import index shift against the CURRENT `fctx.body` (so the returned
- * `call` funcIdx is stable). Callers must therefore have already pushed the
- * condition instructions before calling this — the shift correctly relocates any
- * funcIdx baked into them.
- */
-export function buildThrowJsErrorInstrs(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  kind: JsErrorKind,
-  message: string,
-): Instr[] {
-  if (noJsHost(ctx)) {
-    emitWasiErrorConstructor(ctx, kind, 1);
-  }
-  addStringConstantGlobal(ctx, message);
-  const ctorIdx = ensureLateImport(ctx, `__new_${kind}`, [{ kind: "externref" }], [{ kind: "externref" }]);
-  flushLateImportShifts(ctx, fctx);
-  const tagIdx = ensureExnTag(ctx);
-  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, message)];
-  // If the constructor isn't available, the message externref is still on the
-  // stack — degrade to throwing a string. Both paths produce the same tag.
-  if (ctorIdx !== undefined) {
-    instrs.push({ op: "call", funcIdx: ctorIdx });
-  }
-  instrs.push({ op: "throw", tagIdx });
-  return instrs;
-}
-
-/**
- * #1365 — Emit a Wasm throw of a real TypeError INSTANCE (not a bare string).
- * Thin wrapper over {@link emitThrowJsError}; retained as the canonical call
- * site name (many uses). Required for spec-compliant `assert.throws(TypeError,
- * fn)` test262 cases — those check `e instanceof TypeError` on the caught value.
- */
-export function emitThrowTypeError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
-  emitThrowJsError(ctx, fctx, "TypeError", message);
-}
-
-/**
- * #1473 — Emit a throw of a ReferenceError INSTANCE for TDZ / unresolved
- * identifier references. Mirrors `emitThrowTypeError`.
- *
- * In no-JS-host mode (`--target wasi` / `--target standalone`), the
- * ReferenceError is built via the in-module `__new_ReferenceError` function
- * (emitted by `emitWasiErrorConstructor`), so no `env::__new_ReferenceError`
- * host import is required. In JS-host mode the same import name resolves to
- * the JS `ReferenceError` constructor.
- *
- * Either way the throw is observable in the user's catch block via the
- * shared `$exc` tag, and `e instanceof ReferenceError` works through the
- * `$Error_struct` `$tag` field discrimination.
- */
-export function emitThrowReferenceError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
-  // (#2102) Delegates to the shared lowering — see emitThrowJsError.
-  emitThrowJsError(ctx, fctx, "ReferenceError", message);
-}
-
-/**
- * #2164 — Emit a throw of a RangeError INSTANCE. Mirrors `emitThrowTypeError`.
- * Used by `Date.prototype.toISOString` on an Invalid Date receiver
- * (ECMA-262 §21.4.4.36 — RangeError "Invalid time value"). In no-JS-host mode
- * the RangeError is built via the in-module `__new_RangeError` constructor; in
- * JS-host mode the import resolves to the JS `RangeError`.
- */
-export function emitThrowRangeError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
-  // (#2102) Delegates to the shared lowering — see emitThrowJsError.
-  emitThrowJsError(ctx, fctx, "RangeError", message);
 }
 
 /**

--- a/src/codegen/js-errors.ts
+++ b/src/codegen/js-errors.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3191 — bloat S1) Canonical JS-error-throw lowering, hoisted into a
+ * **layering-safe leaf module**. Runtime modules (`dataview-native.ts`,
+ * `native-proto.ts`, `array-methods.ts`, `collections-es2025.ts`, …) must NOT
+ * import from `expressions/` (the front-end layer, #3029), yet they all need to
+ * emit a catchable JS-error throw. Before this slice the same instruction
+ * template was hand-rolled in ≥4 places; they now all route through the shared
+ * builders here.
+ *
+ * `expressions/helpers.ts` re-exports the whole surface so existing front-end
+ * importers are unaffected. This module imports ONLY from leaf layers
+ * (`native-strings`, `registry/*`, `shared`) — never from `expressions/` — so it
+ * introduces no import cycle.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+
+/**
+ * #1473 — No-JS-host predicate. Both `--target wasi` and `--target standalone`
+ * run without a JS runtime, so neither can rely on host imports such as
+ * `__throw_type_error` / `__new_TypeError` resolving to JS constructors. In
+ * these modes the compiler emits Wasm-native Error constructors instead.
+ */
+export function noJsHost(ctx: CodegenContext): boolean {
+  return ctx.wasi || ctx.standalone;
+}
+
+/** The real-instance JS error kinds that have an `__new_<Kind>` constructor. */
+export type JsErrorKind = "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError" | "Error";
+
+/**
+ * Build the terminal instruction sequence that throws a BARE STRING message via
+ * the shared `$exc` tag. Returns the instrs (does not push) so it can be spliced
+ * into an `if.then`/`else` arm or a raw `Instr[]`. Registers the string constant
+ * + exception tag as a side effect. (No late-import / funcIdx capture, so there
+ * is nothing to flush.)
+ */
+export function buildThrowStringInstrs(ctx: CodegenContext, message: string): Instr[] {
+  addStringConstantGlobal(ctx, message);
+  const tagIdx = ensureExnTag(ctx);
+  return [...stringConstantExternrefInstrs(ctx, message), { op: "throw", tagIdx } as Instr];
+}
+
+/**
+ * Emit a Wasm throw instruction with a string error message.
+ * This replaces `unreachable` traps so that JS try/catch (and assert.throws)
+ * can catch the error instead of getting an uncatchable RuntimeError.
+ */
+export function emitThrowString(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
+  fctx.body.push(...buildThrowStringInstrs(ctx, message));
+}
+
+/**
+ * (#3175) Build the real-instance `<Kind>`-throw lowering as a terminal
+ * instruction sequence (does not push), so it can be spliced into a nested
+ * `if.then` array (a CONDITIONAL throw — e.g. the `Number.prototype.toString`
+ * out-of-2..36 / `toFixed` out-of-0..100 RangeError gates). Those gates
+ * previously threw a BARE STRING via the shared `$exc` tag, so
+ * `e instanceof RangeError` was false and the raw-`try`/`catch` corpus failed.
+ *
+ * Dual-mode: in no-JS-host mode (`--target standalone`/`wasi`) the constructor
+ * is the in-module `emitWasiErrorConstructor` function, so no unsatisfiable
+ * `env::__new_<Kind>` host import is requested; the constructor is registered
+ * BEFORE the funcIdx is resolved so `ensureLateImport` finds the in-module
+ * function in funcMap. Leaves nothing on the value stack (the `throw` is
+ * terminal / stack-polymorphic).
+ *
+ * (#3191) The two real divergences of the former hand-rolled copies are
+ * parameterized via `opts` instead of separate copies:
+ *  - `opts.flush` — a `FunctionContext` to flush late-import index shifts
+ *    against. The front-end pushers pass their `fctx` (code has already been
+ *    emitted into `fctx.body`, so those funcIdxs must be relocated after
+ *    `ensureLateImport` may have shifted them). The DataView accessors build the
+ *    throw template BEFORE emitting the body (funcIdx-capture ordering,
+ *    `dataview-native.ts:620-627`) and flush themselves later, so they omit it.
+ *    Omitting `flush` is NOT the #1839 index-shift hazard for those callers
+ *    precisely because nothing has been emitted into the body yet.
+ *  - `opts.forceInModuleCtor` — always emit the in-module `__new_<Kind>` (via
+ *    `emitWasiErrorConstructor` + `funcMap`), regardless of `noJsHost`. The
+ *    native-proto brand-check throw uses this so its host-mode codegen is
+ *    unchanged by the unification (it always used the in-module constructor).
+ */
+export function buildThrowJsErrorInstrs(
+  ctx: CodegenContext,
+  kind: JsErrorKind,
+  message: string,
+  opts?: { flush?: FunctionContext; forceInModuleCtor?: boolean },
+): Instr[] {
+  const inModule = opts?.forceInModuleCtor === true || noJsHost(ctx);
+  if (inModule) emitWasiErrorConstructor(ctx, kind, 1);
+  addStringConstantGlobal(ctx, message);
+  const ctorIdx = opts?.forceInModuleCtor
+    ? ctx.funcMap.get(`__new_${kind}`)
+    : ensureLateImport(ctx, `__new_${kind}`, [{ kind: "externref" }], [{ kind: "externref" }]);
+  if (opts?.flush) flushLateImportShifts(ctx, opts.flush);
+  const tagIdx = ensureExnTag(ctx);
+  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, message)];
+  // If the constructor isn't available, the message externref is still on the
+  // stack — degrade to throwing a string. Both paths produce the same tag.
+  if (ctorIdx !== undefined) {
+    instrs.push({ op: "call", funcIdx: ctorIdx } as Instr);
+  }
+  instrs.push({ op: "throw", tagIdx } as Instr);
+  return instrs;
+}
+
+/**
+ * #1365 — Emit a Wasm throw of a real JS Error INSTANCE (not a bare string).
+ * Pushes the terminal sequence onto `fctx.body`, self-flushing late-import
+ * shifts against it. Required for spec-compliant `assert.throws(<Kind>, fn)`
+ * test262 cases — those check `e instanceof <Kind>` on the caught value.
+ *
+ * Leaves nothing on the value stack (the `throw` is terminal / stack-polymorphic).
+ */
+export function emitThrowJsError(ctx: CodegenContext, fctx: FunctionContext, kind: JsErrorKind, message: string): void {
+  fctx.body.push(...buildThrowJsErrorInstrs(ctx, kind, message, { flush: fctx }));
+}
+
+/**
+ * #1365 — Emit a throw of a real TypeError INSTANCE. Canonical call-site name
+ * (many uses). Required for `assert.throws(TypeError, fn)`.
+ */
+export function emitThrowTypeError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
+  emitThrowJsError(ctx, fctx, "TypeError", message);
+}
+
+/**
+ * #1473 — Emit a throw of a ReferenceError INSTANCE for TDZ / unresolved
+ * identifier references. Mirrors `emitThrowTypeError`.
+ */
+export function emitThrowReferenceError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
+  emitThrowJsError(ctx, fctx, "ReferenceError", message);
+}
+
+/**
+ * #2164 — Emit a throw of a RangeError INSTANCE. Mirrors `emitThrowTypeError`.
+ */
+export function emitThrowRangeError(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
+  emitThrowJsError(ctx, fctx, "RangeError", message);
+}

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -35,10 +35,9 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { ensureBuiltinFnMetaType } from "./builtin-fn-meta.js";
-import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
-import { emitWasiErrorConstructor } from "./registry/error-types.js";
-import { emitThrowTypeError } from "./expressions/helpers.js"; // (#2984) refusal-body fallback
+import { buildThrowJsErrorInstrs, emitThrowTypeError } from "./js-errors.js"; // (#2984) refusal-body fallback
 import { allocLocal } from "./context/locals.js";
 
 // ── Brand space (shared with #2101 — MUST stay coherent) ──────────────────────
@@ -556,14 +555,13 @@ export function ensureStandaloneNativeMethodClosure(
  * never a `ref.cast` trap (#2100 M2 / §22.2.6.4.1 step 2).
  */
 export function emitBrandCheckTypeError(ctx: CodegenContext, body: Instr[], message: string): void {
-  emitWasiErrorConstructor(ctx, "TypeError", 1);
-  addStringConstantGlobal(ctx, message);
-  for (const instr of stringConstantExternrefInstrs(ctx, message)) body.push(instr);
-  const newTypeErrorIdx = ctx.funcMap.get("__new_TypeError");
-  if (newTypeErrorIdx !== undefined) {
-    body.push({ op: "call", funcIdx: newTypeErrorIdx } as Instr);
+  // (#3191) Unified onto the shared builder. `forceInModuleCtor` reproduces the
+  // former behavior EXACTLY — always emit the in-module `__new_TypeError` (via
+  // `emitWasiErrorConstructor` + `funcMap`) regardless of `noJsHost`, so host-
+  // mode codegen for these brand checks is unchanged. Sinks into the raw `body`.
+  for (const instr of buildThrowJsErrorInstrs(ctx, "TypeError", message, { forceInModuleCtor: true })) {
+    body.push(instr);
   }
-  body.push({ op: "throw", tagIdx: ensureExnTag(ctx) } as Instr);
 }
 
 /** The `eq` abstract heap type, signed-LEB128 -19 (= 0x6d). `ref.test`/`ref.cast`

--- a/tests/issue-3191.test.ts
+++ b/tests/issue-3191.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3191 (bloat S1) — the four hand-rolled JS-error-throw templates were unified
+// onto the shared builders in the layering-safe leaf module `src/codegen/
+// js-errors.ts`:
+//   - `emitDataViewRangeError` / `dvTypeErrorThrow` (dataview-native.ts) →
+//     `buildThrowJsErrorInstrs` (no-flush, caller-flush ordering preserved)
+//   - `emitBrandCheckTypeError` (native-proto.ts) →
+//     `buildThrowJsErrorInstrs({ forceInModuleCtor: true })` (host-mode codegen
+//     unchanged — always the in-module `__new_TypeError`)
+//   - `emitThrowString` / `throwStringInstrs` (array-methods.ts) →
+//     `emitThrowString` / `buildThrowStringInstrs`
+//
+// This is a zero-behavior-change refactor; the assertions below are a
+// regression guard proving each unified path still throws a CATCHABLE real
+// error instance (not an uncatchable trap or a bare string). Standalone mode so
+// no host imports are needed.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile a numeric-returning body in standalone mode and run it. */
+async function numResult(body: string): Promise<number> {
+  const src = `export function test(): number {\n${body}\n}`;
+  const r = await compile(src, { fileName: "issue-3191.ts", target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3191 — unified JS-error-throw templates stay catchable", () => {
+  // array-methods.ts `buildThrowStringInstrs` — reduce of an empty array with no
+  // initial value throws the shared `$exc` tag (a BARE STRING, the same variant
+  // as before the unification), so it is CATCHABLE (not an uncatchable trap).
+  it("Array.prototype.reduce on an empty array throws a catchable error", async () => {
+    expect(
+      await numResult(`
+        const arr: number[] = [];
+        try { arr.reduce((a: number, b: number) => a + b); return 0; }
+        catch (e) { return 1; }
+      `),
+    ).toBe(1);
+  });
+
+  // dataview-native.ts `emitDataViewRangeError` (→ buildThrowJsErrorInstrs) —
+  // out-of-bounds getInt32 throws a catchable RangeError INSTANCE.
+  it("DataView getInt32 out of bounds throws a catchable RangeError instance", async () => {
+    expect(
+      await numResult(`
+        const dv = new DataView(new ArrayBuffer(4));
+        try { dv.getInt32(4); return 0; }
+        catch (e) { return (e instanceof RangeError) ? 1 : 2; }
+      `),
+    ).toBe(1);
+  });
+
+  // A plain compiles-and-runs sanity check that the unification did not break a
+  // normal (non-throwing) reduce.
+  it("Array.prototype.reduce on a non-empty array still works", async () => {
+    expect(await numResult(`return [1, 2, 3, 4].reduce((a: number, b: number) => a + b);`)).toBe(10);
+  });
+
+  // native-proto.ts `emitBrandCheckTypeError` (→ buildThrowJsErrorInstrs with
+  // forceInModuleCtor) and array-methods.ts `emitThrowString` are additionally
+  // covered by the host-lane suites #1344 (generator brand check), #2590
+  // (RegExp.escape), #1514 (set-like brand) and functional-array-methods
+  // (callback-not-a-function) — all still green after the unification.
+});


### PR DESCRIPTION
## Summary

Slice **S1** of the #3182 code-bloat-elimination epic. Unifies the four
hand-rolled "throw a real JS error instance / bare string" templates onto shared
builders in a new **layering-safe leaf module** `src/codegen/js-errors.ts`.

## Changes

- **New leaf module** `src/codegen/js-errors.ts` hosts the canonical throw
  lowering (`buildThrowStringInstrs`, `emitThrowString`,
  `buildThrowJsErrorInstrs`, `emitThrowJsError`,
  `emitThrow{Type,Reference,Range}Error`, `noJsHost`, `JsErrorKind`). It imports
  only from leaf layers (`native-strings` / `registry/*` / `shared`) — no
  `expressions/` import, no cycle. `expressions/helpers.ts` imports + re-exports
  the surface so front-end importers are unchanged.
- **Options bag parameterizes the two real divergences** (not new copies):
  - `opts.flush?: FunctionContext` — self-flush late-import shifts (front-end
    pushers) vs caller-flush (DataView accessors pre-build the template before
    the body — funcIdx-capture ordering preserved exactly).
  - `opts.forceInModuleCtor?` — always the in-module `__new_<Kind>` regardless of
    `noJsHost` (native-proto brand check — host-mode codegen byte-unchanged).
- **All four copies deleted**, call sites routed through the shared helpers:
  `emitDataViewRangeError` / `dvTypeErrorThrow` (dataview-native),
  `emitBrandCheckTypeError` (native-proto), `emitThrowString` /
  `throwStringInstrs` (array-methods), + the 2 number-RangeError sites in
  calls.ts.
- **Layering (#3029)**: dataview-native / native-proto / array-methods no longer
  import any throw helper from `expressions/`.

## Validation (zero behavior change)

`tsc` + ESLint clean; LOC budget gate green (god-files shrank). Touched
error-throw paths all green: #2199/#2199b/#2164 (DataView RangeError/TypeError),
#1344 (generator brand check), #2590 (RegExp.escape), #1514 (set-like brand),
functional-array-methods (reduce), #1473 (ReferenceError), #3175 (number
RangeError gates). New regression guard `tests/issue-3191.test.ts`.

Predecessor for **S2 (#3192)**, which consumes `js-errors.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)