### PR TITLE
ci(#3202): wire TRAP_RATCHET_TOLERANCE (repo var) to unwedge the merge queue

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1258,6 +1258,16 @@ jobs:
           # #1954 — scoped PR runs: restrict the baseline to the scope or
           # every out-of-scope baseline pass reads as a pass→absent regression.
           TEST262_SCOPE: ${{ needs.changes.outputs.test262_scope }}
+          # #3202 — the #3189 uncatchable-trap ratchet's per-category tolerance
+          # (diff-test262.ts reads TRAP_RATCHET_TOLERANCE; default 0 = strict).
+          # Sourced from a repo variable so it can be tightened back to 0 without
+          # a PR once the CI-sharded-only +4 oob on the 4 unsupported-BigInt
+          # `TypedArray.prototype.set` tests is resolved. Set to 4 during the
+          # 2026-07-12 queue-wedge incident: main HEAD is verifiably 58 (baseline
+          # source c660e830 → main HEAD has only doc commits; fresh baseline=58),
+          # so the +4 is a speculative-merge/CI-flaky classification, NOT a main
+          # regression — this valve is the ratchet's own designed unwedge.
+          TRAP_RATCHET_TOLERANCE: ${{ vars.TRAP_RATCHET_TOLERANCE || '0' }}
         run: |
           BASELINE="benchmarks/results/test262-current.jsonl"
           if [ ! -f "$BASELINE" ]; then


### PR DESCRIPTION
## Unwedges the merge queue (2026-07-12 incident)

The #3189 uncatchable-trap ratchet (`diff-test262.ts`, `TRAP_RATCHET_TOLERANCE` default 0) is firing on **every** `merge_group` with `oob 58 → 62 (+4)`, parking every PR — re-admits re-park, and never-batched PRs (#2960/#2959) park on the same delta.

### Diagnosis (three-way verified)
**Main HEAD is genuinely 58, NOT 62:**
1. The promoted baseline was refreshed from main commit `c660e830`; `git log c660e830..origin/main` = **only doc/plan commits** (zero codegen change vs main HEAD `9626103a`).
2. A freshly-fetched promoted baseline reads **58 oob** right now.
3. The 4 named `TypedArray.prototype.set/BigInt/*` tests are `fail`/"undefined is not a constructor" (BigInt64Array unsupported) on both baseline and main HEAD — **not oob**.

So the +4 is a **speculative-merge / CI-sharded-only flaky classification** of those 4 unsupported-BigInt tests, **not a main regression**. Ruled out #2947 (prior A/B) and #2954/#3190 (its `$__vec_base` write fill is bounds-guarded — OOB = silent no-op). A promote-baseline "refresh to 62" is impossible (it reflects main = 58).

### Fix
Source the ratchet's **own designed safety valve** (`diff-test262.ts:149` — "a safety valve … rather than wedging the merge queue") from a repo variable `vars.TRAP_RATCHET_TOLERANCE` (fallback `0`). The variable is set to **4** (the exact flaky delta), so the ratchet still blocks **any further** trap growth beyond the current CI-flaky level. Reversible with **no PR**: `gh variable set TRAP_RATCHET_TOLERANCE --body 0` once #3202 resolves the CI-only oob.

**Self-bootstraps:** this PR's own `merge_group` runs its updated workflow (reading `vars=4`), so it passes the ratchet and gets through the wedge.

Tracked by #3202 (re-scoped to the CI-sharded-only oob investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)