### PR TITLE
docs(#3143): post-merge cleanup — status:done + G1 marker (allowlist)

### DIFF
--- a/plan/issues/3143-ir-first-default-flip.md
+++ b/plan/issues/3143-ir-first-default-flip.md
@@ -1,11 +1,12 @@
 ---
 id: 3143
 title: "Flip IR-first (JS2WASM_IR_FIRST) to default — clears gate G1 of the legacy-frontend retirement"
-status: in-progress
+status: done
 sprint: current
 assignee: ttraenkler/sendev-3143flip
 created: 2026-07-11
-updated: 2026-07-12
+updated: 2026-07-13
+completed: 2026-07-13
 priority: high
 horizon: m
 feasibility: medium
@@ -343,3 +344,30 @@ skipped-slot HARD errors land in `CompileResult.errors` — the meter is a FALSE
 GREEN for flip-readiness. The authoritative gate is a `result.errors` scan for
 `[IR-FIRST skipped-slot` over the EQUIVALENCE inline corpus (not a dir walk).
 Fold both into the #3153 meter as a follow-up.
+
+## CI GREEN (2026-07-12, sendev-3143flip) — PR #2891 @ 3b7d4a25f3
+
+All PR-level required checks PASS: **equivalence-gate** (138 regressions → 1 →
+0; the gradual-typing regression fixed by the signature-parity fixpoint),
+**quality** (dead-export green after deleting the 7 unwired predicates),
+**cross-backend-parity**, **equivalence-shards 1–8**, cheap-gate / smoke /
+linear-tests / check-for-test262-regressions / changes. test262 host+standalone
+shards + merge-shard-reports + standalone-floor `skipping` on the PR — they run
+on **merge_group** only (post-enqueue).
+
+Behavior-preserving proof: the 8-file ON-vs-OFF A/B was IDENTICAL (22==22
+failures, all pre-existing — fail with `experimentalIR:false` too). The
+allowlist skips only functions whose IR body ships identically to the overlay,
+so the flip changes compile-time work, not output → the test262 merged-report
+delta should be net-zero by construction.
+
+**Follow-ups (post-merge):**
+
+1. Widen the allowlist beyond f64-numeric (proven strings/vecs/JS-host
+   generators → restore #2951/#2972 compile-once) via the #2855/#2856
+   capability track; each widening unlocks more Phase-3a legacy deletion.
+2. The −60k deletion is INCREMENTAL, not one flip: a legacy handler is
+   deletable only once NO compile-twice function uses it (requires the allowlist
+   to own that node kind). Scope deletion slices as the allowlist widens.
+3. Fold the `result.errors` skipped-slot scan over the equivalence inline corpus
+   into the #3153 meter (retire the false-green `irPostClaimErrors` channel).

--- a/plan/log/3090-phase0-legacy-delete-list.md
+++ b/plan/log/3090-phase0-legacy-delete-list.md
@@ -48,15 +48,21 @@ when `experimentalIR: true`". The pipeline disproves this; deletion is gated
 on four structural facts:
 
 - **G1 — legacy compiles EVERYTHING first.** ~~By default the IR is an
-  _overlay_~~ **CLEARED 2026-07-11 by #3143**: IR-first is now the default
-  (`JS2WASM_IR_FIRST=0` is a one-release escape hatch) — legacy emission is
-  skipped for claimed functions that pass `computeIrFirstSkipSet`'s gates
-  (2 generators-standalone, 4 host-nodes, 5 string-element, 6
-  dynamic-signature, 7 `??` residual). NOTE this clears G1 only for the
-  *skipped* population: functions excluded by gates 2/4/5/6/7, selector-
-  rejected functions (G2), top-level statements (G3), and class members
-  still compile via legacy — per-kind handler deletion still requires
-  G2/G3/G4 plus emptying the relevant skip-gate.
+  _overlay_~~ **CLEARED 2026-07-13 by #3143** (PR #2891, merge 1fc3b9d3a3):
+  IR-first is now the default (`JS2WASM_IR_FIRST=0` is a one-release escape
+  hatch). `computeIrFirstSkipSet` is an **ALLOWLIST** (not the earlier
+  denylist gates): legacy emission is skipped ONLY for a function whose
+  signature is f64-params + (f64|void)-return AND whose body is the
+  proven-lowerable numeric/boolean subset (`irFirstBodyIsProvenLowerable`) AND
+  whose internal callers are all also skipped (signature-parity fixpoint,
+  `collectLocalCallEdges`). Safe-by-construction: everything else compiles
+  twice. **The −60k deletion is INCREMENTAL, not unlocked by this flip alone:**
+  a per-kind handler is deletable only once NO compile-twice function uses it,
+  which requires the allowlist to OWN that node kind. The initial subset is
+  pure-numeric, so the immediately-deletable set is small; it grows as the
+  allowlist WIDENS (proven strings/vecs/JS-host generators → …) via the
+  #2855/#2856 capability track. Per-kind deletion still also requires
+  G2/G3/G4.
 - **G2 — whole-function claim unit keeps every handler live.** The selector
   claims `FunctionDeclaration`s; any rejection (every non-zero bucket in
   `plan/log/ir-adoption.md`, every `mixed`/`direct-only`/`deferred` kind in


### PR DESCRIPTION
Post-merge doc cleanup for #3143 (the IR-first default flip, PR #2891, merged 1fc3b9d3a3).

- Set issue #3143 `status: done` + `completed: 2026-07-13` (it merged at `in-progress` via manual enqueue, not self-merge).
- Update the G1 marker in `plan/log/3090-phase0-legacy-delete-list.md` to describe the ALLOWLIST mechanism (`irFirstBodyIsProvenLowerable` + the signature-parity fixpoint) that actually landed — not the earlier denylist gates — and the INCREMENTAL nature of the −60k deletion (unlocks as the allowlist widens via #2855/#2856).
- Banks the CI-green summary + follow-up list in the issue file.

Doc-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8