### PR TITLE
refactor(#3203): widen IR-first allowlist f64 → f64+boolean (Phase-3a enabler)

### DIFF
--- a/plan/issues/3203-ir-first-allowlist-widen-bool.md
+++ b/plan/issues/3203-ir-first-allowlist-widen-bool.md
@@ -1,0 +1,95 @@
+---
+id: 3203
+title: "IR-first allowlist widen: f64 → f64+boolean (Phase-3a enabler)"
+status: in-progress
+assignee: ttraenkler/opus-sendev
+sprint: current
+created: 2026-07-13
+updated: 2026-07-13
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: refactor
+area: ir, codegen
+language_feature: compiler-internals
+goal: ir-full-coverage
+parent: 2855
+related: [3143, 3090, 2856, 2138]
+loc-budget-allow:
+  - src/codegen/index.ts
+---
+
+# #3203 — IR-first allowlist widen: f64 → f64 + boolean
+
+First real **Phase-3a enabler** after the #3143 IR-first-default flip. The flip
+landed with a conservative **v1 allowlist** (`computeIrFirstSkipSet` +
+`irFirstBodyIsProvenLowerable`) that skips legacy body emission ONLY for
+functions whose signature is pure-`f64` and whose whole body is the
+proven-lowerable numeric subset. This widens the value domain to add **boolean**.
+
+## Why this is the right first slice (not a deletion)
+
+Scoping (see #3090 finding, reported to lead): the flip cleared **G1 for the
+numeric population only**. Measured skip rate on the ir-fallbacks corpus was
+**6/50 = 12%** — the other 88% still compile via legacy, so **G2 keeps every
+per-kind legacy handler reachable**. No frontend handler is deletable yet
+(the audit's frontend `legacy-only` count went UP 59,976→61,889 post-flip).
+The −60k payoff unlocks per-file as each file's LAST gate closes, which requires
+**widening the allowlist** so more functions are IR-owned. This is that first
+widen.
+
+## Design (safe-by-construction)
+
+`boolean` and native-int BOTH carry as Wasm `i32` (`resolvePositionType`
+`BooleanKeyword → irVal i32`), so the resolved override type cannot
+disambiguate bool from native-int checker-free. **v1 resolves the ambiguity
+structurally**: a position is `bool` domain ONLY when its resolved type is `i32`
+AND it carries an explicit `boolean` AST annotation. Unannotated-`i32` and
+native-int stay compile-twice (native-i32 is a clean follow-up slice).
+
+- **Signature** (`computeIrFirstSkipSet`, index.ts): each param resolves to a
+  domain in {`number` (f64), `bool` (i32 + `boolean` annotation)}; return in
+  {`number`, `bool`, `void`}. Anything else -> not skip-eligible.
+- **Body walk** (`irFirstBodyIsProvenLowerable`, ir-first-gate.ts): tracks a
+  per-name value-domain map (params seeded from signature, locals inferred from
+  initializer). `exprDomain(e)` returns `number`/`bool`/`null`. Enforces:
+  arithmetic/bit/shift over numbers -> number; relational compares over numbers
+  -> bool; equality over MATCHED domains -> bool; `&&`/`||`/`!` over bools ->
+  bool; `?:` branches same-domain; assignment/`++`/`--` domain-matched (bool
+  only via `=`); if/while/do/for conditions must be `bool`; `return` must match
+  the function's return domain.
+- **Calls stay number-only (v1)**: `claimedArity` is tightened to claimed
+  callees with a **pure-f64 signature** (all params f64, f64 return). A call is
+  number-domain to such a callee only. This ALSO closes a latent hole in the
+  f64-only allowlist (a call to a claimed non-f64-return callee was accepted as
+  number). Bool values never flow through inter-function calls in v1.
+- The **signature-parity fixpoint** (skip only when every caller is skipped) is
+  unchanged - conservative and load-bearing.
+
+Safe by construction: any shape the walk does not recognise keeps the function
+COMPILE-TWICE (correct, never a skipped-slot hard error). Behavior-preserving -
+the widen only changes WHICH functions skip legacy body emission; the IR path
+already lowered these (bool functions are already IR-claimed, just compile-twice).
+
+## Acceptance criteria
+
+- `irFirstBodyIsProvenLowerable` accepts bool-domain bodies (bool params/returns,
+  bool literals, logical ops, comparisons, bool equality, bool ternary) and
+  rejects mixed-domain shapes; existing f64 cases unchanged (default domains).
+- Zero `[IR-FIRST skipped-slot]` hard errors on the equivalence-inline corpus +
+  merge_group (net-non-negative required - broad impact).
+- Measurable skip-rate increase on the ir-fallbacks corpus vs the 12% baseline.
+- Cross-backend parity preserved.
+
+## Validation
+
+- `tsc`, `check:loc-budget`, `check:ir-fallbacks`
+- Full merge_group (broad-impact; standalone floor + merge-shard reports run there)
+- New unit tests in `tests/issue-3203.test.ts` (bool accept/reject + e2e
+  no-hard-error + escape-hatch parity)
+
+## Follow-ups (sequenced, NOT this PR)
+
+- Native-i32 (`type i32 = number`) domain widen (deferred - mixed-domain arith).
+- Closest-to-closing leaf-file gate readout for the first real Phase-3b deletion.

--- a/plan/log/3090-phase0-legacy-delete-list.md
+++ b/plan/log/3090-phase0-legacy-delete-list.md
@@ -83,6 +83,26 @@ on four structural facts:
   `object-runtime`). Retiring the front-end requires the IR to grow its own
   call-paths into this emission (per-kind adoption), not deletion.
 
+### Post-flip status (2026-07-13, re-verified on `origin/main` @ 3a0dabfeac)
+
+The #3143 IR-first flip is **not** "flip ⇒ delete now". It cleared **G1 for the
+numeric population only**: `computeIrFirstSkipSet`'s allowlist skips legacy body
+emission for provably-lowerable pure-`f64` (now also `boolean`, #3203)
+functions. Re-running the audit post-flip, the FRONTEND `legacy-only` count went
+**UP** 59,976 → 61,889 — nothing in the frontend became newly dead, because
+**G2 keeps every per-kind handler reachable**: the measured skip rate is ~12% of
+functions (ir-fallbacks corpus), so the other ~88% still route through
+`compileStatement`/`compileExpression` and use the legacy handler for every kind
+they contain, including `ir-owned` ones. **No frontend handler is deletable from
+the flip alone.** The −60K unlocks per-file only as each file's LAST gate closes
+(revised phase plan below); the levers are **widening the skip allowlist**
+(#3203 f64→bool landed this; native-i32 next) and **driving the selector's
+rejection buckets to zero** (#2856, `body-shape-rejected` now 14) to raise G2
+claim coverage, plus **top-level IR adoption** (G3). Gate distance is dominated
+by G2 (near-total claim coverage), not by a kind's `ir-owned`-ness, so the first
+file to close will be an all-`ir-owned`-kind file (`literals.ts` /
+`expressions/identifiers.ts`) once claim coverage approaches 100% — not before.
+
 **Consequence:** "deletable today with zero capability change" =
 the **unreferenced set (~2.1K fn-lines)** — everything else is conditional.
 The ~60K FRONTEND number is the size of the eventual win, banked per-kind as

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -29,7 +29,7 @@ import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import { planIrCompilation, irClosureSignatureFromFunctionTypeNode, type IrFallbackReason } from "../ir/select.js";
 import { makeIrHostGlobalResolver } from "../ir/host-extern.js"; // (#2856)
 import { createCodegenContext } from "./context/create-context.js";
-import { collectLocalCallEdges, irFirstBodyIsProvenLowerable } from "./ir-first-gate.js";
+import { collectLocalCallEdges, irFirstBodyIsProvenLowerable, type ValueDomain } from "./ir-first-gate.js";
 import type { FallbackCounts } from "./fallback-telemetry.js";
 import { truthyEnv } from "./fallback-telemetry.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
@@ -1544,43 +1544,68 @@ function computeIrFirstSkipSet(
   const funcs = plan.safeSelection.funcs;
   if (funcs.size === 0) return skip;
 
-  // (#3143) ALLOWLIST skip — see `irFirstBodyIsProvenLowerable`. A claimed
+  // (#3143/#3203) ALLOWLIST skip — see `irFirstBodyIsProvenLowerable`. A claimed
   // function's legacy body is skipped ONLY when its whole body is the
   // proven-lowerable numeric/boolean subset AND its signature is lowerable.
   // Everything else stays COMPILE-TWICE (safe: no skipped-slot hard error).
-  //
-  // `claimedArity`: name → parameter count for every CLAIMED function, so the
-  // body walk can enforce from-ast's exact call-arity requirement (a call to a
-  // non-claimed or wrong-arity callee is not allowlisted). Only claimed funcs
-  // are eligible callees (a claimed caller's IR `call` must target a
-  // claimed-or-compiled slot; a legacy-only callee is excluded).
+  const isF64 = (t: IrType): boolean => asVal(t)?.kind === "f64";
+  const isI32 = (t: IrType): boolean => asVal(t)?.kind === "i32";
+
+  // `claimedArity`: name → parameter count for every claimed function with a
+  // PURE-`f64` signature (all params + return `f64`). In v1 the allowlist lowers
+  // inter-function calls in NUMBER context only, so a call target must be a
+  // number-signature callee — this keeps the call-result domain sound and also
+  // closes a latent hole in the f64-only allowlist (a call to a claimed
+  // non-f64-return callee was accepted as `number`). Bool-signature functions
+  // are never allowlist call targets.
   const claimedArity = new Map<string, number>();
   for (const n of funcs) {
     const f = plan.declByName.get(n);
-    if (f) claimedArity.set(n, f.parameters.length);
-  }
-  // A resolved IR type is skip-eligible only when it is exactly `f64` (JS
-  // `number`) — the single value domain the number-only allowlist body handles.
-  // i32 (native-int OR boolean — ambiguous checker-free), strings, objects,
-  // closures, extern, dynamic, and any ref carrier are NOT; those functions
-  // stay compile-twice. (Widen to i32 once the allowlist tracks int-vs-bool.)
-  const isF64 = (t: IrType): boolean => asVal(t)?.kind === "f64";
-  const signatureLowerable = (fn: ts.FunctionDeclaration, name: string): boolean => {
-    // No default / optional / rest / destructuring params — from-ast's param
-    // binding throws on all of these ("rest/default/optional param not in
-    // Phase 1", or "unsupported param shape").
-    for (const p of fn.parameters) {
-      if (p.questionToken || p.dotDotDotToken || p.initializer) return false;
-      if (!ts.isIdentifier(p.name)) return false;
+    if (!f) continue;
+    const o = plan.overrideMap.get(n);
+    if (o && o.params.every(isF64) && o.returnType !== null && isF64(o.returnType)) {
+      claimedArity.set(n, f.parameters.length);
     }
-    // Params must all be `number` (f64); return must be `number` or void. Use
-    // the resolved overrideMap types — the selector's own resolution, so no
-    // checker call here.
+  }
+
+  // (#3203) Resolve a position's value DOMAIN for the allowlist. `number` = f64.
+  // `bool` = an `i32` carrier WITH an explicit `boolean` AST annotation — the
+  // ONLY checker-free way to disambiguate a boolean from a native-int (`type
+  // i32 = number`), which also resolves to `i32`. Unannotated `i32` (inferred)
+  // and native-int stay compile-twice (native-int is a follow-up widen). Any
+  // other carrier (string/object/closure/extern/dynamic/ref) → null.
+  const positionDomain = (annot: ts.TypeNode | undefined, resolved: IrType): ValueDomain | null => {
+    if (isF64(resolved)) return "number";
+    if (isI32(resolved) && annot?.kind === ts.SyntaxKind.BooleanKeyword) return "bool";
+    return null;
+  };
+  // Resolve the full signature domain, or null when the function is not
+  // skip-eligible. Rejects default/optional/rest/destructuring params (from-ast
+  // throws on those) up front.
+  const resolveSignatureDomains = (
+    fn: ts.FunctionDeclaration,
+    name: string,
+  ): { paramDomains: ValueDomain[]; returnDomain: ValueDomain | "void" } | null => {
+    for (const p of fn.parameters) {
+      if (p.questionToken || p.dotDotDotToken || p.initializer) return null;
+      if (!ts.isIdentifier(p.name)) return null;
+    }
     const o = plan.overrideMap.get(name);
-    if (!o) return false; // no resolved signature — stay conservative
-    if (!o.params.every(isF64)) return false;
-    if (o.returnType !== null && !isF64(o.returnType)) return false;
-    return true;
+    if (!o) return null; // no resolved signature — stay conservative
+    const paramDomains: ValueDomain[] = [];
+    for (let i = 0; i < o.params.length; i++) {
+      const d = positionDomain(fn.parameters[i]?.type, o.params[i]!);
+      if (d === null) return null;
+      paramDomains.push(d);
+    }
+    let returnDomain: ValueDomain | "void";
+    if (o.returnType === null) returnDomain = "void";
+    else {
+      const rd = positionDomain(fn.type, o.returnType);
+      if (rd === null) return null;
+      returnDomain = rd;
+    }
+    return { paramDomains, returnDomain };
   };
 
   for (const name of funcs) {
@@ -1590,8 +1615,9 @@ function computeIrFirstSkipSet(
     // JS host; a `function*` body is never in the numeric allowlist anyway, so
     // this is subsumed, but kept explicit for standalone/WASI clarity.
     if (fn.asteriskToken && !generatorsSkippable) continue;
-    if (!signatureLowerable(fn, name)) continue; // numeric/boolean signature only
-    if (!irFirstBodyIsProvenLowerable(fn, claimedArity)) continue; // ALLOWLIST body walk (#3143)
+    const sig = resolveSignatureDomains(fn, name); // numeric/boolean signature only
+    if (!sig) continue;
+    if (!irFirstBodyIsProvenLowerable(fn, claimedArity, sig.paramDomains, sig.returnDomain)) continue; // #3143/#3203
     skip.add(name);
   }
 

--- a/src/codegen/ir-first-gate.ts
+++ b/src/codegen/ir-first-gate.ts
@@ -44,49 +44,72 @@ import ts from "typescript";
 // ===========================================================================
 
 /**
- * (#3143) Return true iff `fn`'s body is entirely within the proven-lowerable
- * subset, given `claimedArity` (name → parameter count for every currently
- * claimed function — used to enforce from-ast's exact call-arity requirement;
- * a call to a non-claimed / wrong-arity callee is NOT allowlisted).
+ * (#3203) The value-domain an allowlist expression evaluates to. `number` = JS
+ * `number` (Wasm `f64`); `bool` = JS `boolean` (Wasm `i32`, disambiguated from
+ * native-int by the caller via an explicit `boolean` annotation — see
+ * `computeIrFirstSkipSet`). from-ast's Phase-1 arithmetic requires MATCHED
+ * operand types and its logical/`!` ops require BOOLEAN operands; tracking a
+ * per-expression domain (checker-free) is how the walk enforces that split.
+ */
+export type ValueDomain = "number" | "bool";
+
+/**
+ * (#3143/#3203) Return true iff `fn`'s body is entirely within the
+ * proven-lowerable subset, given:
+ *   - `claimedArity` — name → parameter count for every claimed function with a
+ *     PURE-`f64` signature (all params `f64`, `f64` return). A call to a
+ *     non-claimed / wrong-arity / non-f64-signature callee is NOT allowlisted;
+ *     in v1 calls are number-domain only (the callee's number signature is the
+ *     invariant that keeps the call result domain sound — see
+ *     `computeIrFirstSkipSet`).
+ *   - `paramDomains` — per-parameter value domain (parallel to `fn.parameters`).
+ *     Omitted ⇒ every param is `number` (preserves the pre-#3203 f64-only
+ *     behaviour and the 2-arg call sites).
+ *   - `returnDomain` — the function's return domain (`"void"` for a
+ *     value-less body). Defaults to `number`.
  *
- * **Strict number-only, with a separate boolean CONTEXT.** The caller restricts
- * params + return to `f64` (JS `number`) — so every identifier/local is a
- * number. from-ast's Phase-1 arithmetic requires MATCHED operand types and its
- * logical/`!` ops require BOOLEAN operands; a checker-free walk cannot inspect
- * types, so it enforces the split structurally:
- *   - a NUMBER context (`numOk`) allows number literals, number locals,
- *     arithmetic/bit ops between numbers, local number mutation, ternaries whose
- *     branches are numbers, and exact-arity calls to claimed functions;
- *   - a BOOLEAN context (`boolOk`) — the condition of if/while/do/for and the
- *     `?:` test, plus operands of `&&`/`||`/`!` — allows ONLY relational/equality
- *     comparisons of two NUMBERS, and `&&`/`||`/`!` over nested booleans.
- * No boolean literals, no boolean-valued locals, no string/array/object/closure/
- * class/extern/dynamic/member/element/`new`/coercion constructs — all
- * compile-twice until the IR lowers them. Local (`let`) mutation is allowed
- * (from-ast slot-promotes mutated lets); PARAMETER mutation is NOT.
+ * **Domain-tracked, safe-by-construction (#3203 widen).** Every identifier is
+ * resolved to a `number`/`bool` domain via a per-name map (params seeded from
+ * `paramDomains`, locals inferred from their initializer). `exprDomain` returns
+ * the domain of an expression or `null` when it is outside the subset:
+ *   - arithmetic / bit / shift over two NUMBERS → number;
+ *   - relational (`< > <= >=`) over two NUMBERS → bool;
+ *   - equality (`== === != !==`) over two operands of the SAME domain → bool;
+ *   - `&&` / `||` / `!` over BOOLS → bool;
+ *   - `?:` — bool condition, same-domain branches → that domain;
+ *   - `=` preserves the target local's domain; `+=`…`^=` and `++`/`--` are
+ *     number-only local mutation (PARAMETER mutation is rejected);
+ *   - a call to a claimed pure-`f64` callee with exact arity and number args →
+ *     number.
+ * if/while/do/for conditions must be `bool`; `return <e>` must match
+ * `returnDomain`. No string/array/object/closure/class/extern/dynamic/member/
+ * element/`new`/coercion constructs — all stay COMPILE-TWICE (a shape the walk
+ * does not recognise returns `null`/`false`, never a hard error).
  */
 export function irFirstBodyIsProvenLowerable(
   fn: ts.FunctionDeclaration,
   claimedArity: ReadonlyMap<string, number>,
+  paramDomains?: readonly ValueDomain[],
+  returnDomain: ValueDomain | "void" = "number",
 ): boolean {
   if (!fn.body) return false;
   const params = new Set<string>();
-  for (const p of fn.parameters) {
+  // Per-name value domain. Params seeded from the caller-provided domains
+  // (default `number`); locals populated as their declarations are walked
+  // (declare-before-use holds for the tail shapes; a not-yet-seen name resolves
+  // to `null` ⇒ reject, which is safe — it can only keep a function
+  // compile-twice, never wrongly skip it).
+  const domain = new Map<string, ValueDomain>();
+  for (let i = 0; i < fn.parameters.length; i++) {
+    const p = fn.parameters[i]!;
     if (!ts.isIdentifier(p.name)) return false; // destructuring param — reject
     params.add(p.name.text);
+    domain.set(p.name.text, paramDomains?.[i] ?? "number");
   }
-  // Every name bound anywhere in the function body. A bare identifier in number
-  // context must resolve to one of these (all numbers, per the caller's f64
-  // signature restriction); a module/host global is a from-ast throw.
-  const locals = new Set<string>(params);
-  const collectDecls = (node: ts.Node): void => {
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) locals.add(node.name.text);
-    ts.forEachChild(node, collectDecls);
-  };
-  collectDecls(fn.body);
 
-  const isAssignToken = (k: ts.SyntaxKind): boolean =>
-    k === ts.SyntaxKind.EqualsToken || (k >= ts.SyntaxKind.PlusEqualsToken && k <= ts.SyntaxKind.CaretEqualsToken);
+  // `+=`…`^=` compound arithmetic assignment (number-only). `=` handled apart.
+  const isCompoundAssignToken = (k: ts.SyntaxKind): boolean =>
+    k >= ts.SyntaxKind.PlusEqualsToken && k <= ts.SyntaxKind.CaretEqualsToken;
   // Numeric binary ops (arith / bit / shift) — NOT comparisons, NOT logical.
   const isNumericBinaryToken = (k: ts.SyntaxKind): boolean =>
     k === ts.SyntaxKind.PlusToken ||
@@ -101,12 +124,14 @@ export function irFirstBodyIsProvenLowerable(
     k === ts.SyntaxKind.LessThanLessThanToken ||
     k === ts.SyntaxKind.GreaterThanGreaterThanToken ||
     k === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken;
-  // Relational / equality — produce a boolean from two numbers.
-  const isCompareToken = (k: ts.SyntaxKind): boolean =>
+  // Relational — produce a bool from two NUMBERS.
+  const isRelationalToken = (k: ts.SyntaxKind): boolean =>
     k === ts.SyntaxKind.LessThanToken ||
     k === ts.SyntaxKind.GreaterThanToken ||
     k === ts.SyntaxKind.LessThanEqualsToken ||
-    k === ts.SyntaxKind.GreaterThanEqualsToken ||
+    k === ts.SyntaxKind.GreaterThanEqualsToken;
+  // Equality — produce a bool from two operands of the SAME domain.
+  const isEqualityToken = (k: ts.SyntaxKind): boolean =>
     k === ts.SyntaxKind.EqualsEqualsToken ||
     k === ts.SyntaxKind.EqualsEqualsEqualsToken ||
     k === ts.SyntaxKind.ExclamationEqualsToken ||
@@ -115,76 +140,98 @@ export function irFirstBodyIsProvenLowerable(
   // An assignable target: a local that is NOT a parameter (param mutation is a
   // from-ast non-slot throw; a mutated `let` slot-promotes).
   const isAssignableLocal = (e: ts.Expression): boolean =>
-    ts.isIdentifier(e) && locals.has(e.text) && !params.has(e.text);
+    ts.isIdentifier(e) && domain.has(e.text) && !params.has(e.text);
 
-  const unwrapParen = (e: ts.Expression): ts.Expression =>
-    ts.isParenthesizedExpression(e) ? unwrapParen(e.expression) : e;
-
-  // Expression in NUMBER context — must evaluate to a number.
-  const numOk = (e: ts.Expression): boolean => {
+  // The value domain of `e`, or `null` when outside the proven-lowerable subset.
+  const exprDomain = (e: ts.Expression): ValueDomain | null => {
     switch (e.kind) {
       case ts.SyntaxKind.NumericLiteral:
-        return true;
+        return "number";
+      case ts.SyntaxKind.TrueKeyword:
+      case ts.SyntaxKind.FalseKeyword:
+        return "bool";
       case ts.SyntaxKind.Identifier:
-        return locals.has((e as ts.Identifier).text);
+        return domain.get((e as ts.Identifier).text) ?? null;
       case ts.SyntaxKind.ParenthesizedExpression:
-        return numOk((e as ts.ParenthesizedExpression).expression);
+        return exprDomain((e as ts.ParenthesizedExpression).expression);
       case ts.SyntaxKind.PrefixUnaryExpression: {
         const u = e as ts.PrefixUnaryExpression;
         if (u.operator === ts.SyntaxKind.PlusPlusToken || u.operator === ts.SyntaxKind.MinusMinusToken) {
-          return isAssignableLocal(u.operand);
+          // ++x / --x — number-local mutation only.
+          return isAssignableLocal(u.operand) && domain.get((u.operand as ts.Identifier).text) === "number"
+            ? "number"
+            : null;
         }
-        // `+x` / `-x` / `~x` are numeric; `!x` is boolean (rejected here).
-        return (
-          (u.operator === ts.SyntaxKind.PlusToken ||
-            u.operator === ts.SyntaxKind.MinusToken ||
-            u.operator === ts.SyntaxKind.TildeToken) &&
-          numOk(u.operand)
-        );
+        if (u.operator === ts.SyntaxKind.ExclamationToken) {
+          return exprDomain(u.operand) === "bool" ? "bool" : null; // `!` over a bool
+        }
+        // `+x` / `-x` / `~x` are numeric.
+        if (
+          u.operator === ts.SyntaxKind.PlusToken ||
+          u.operator === ts.SyntaxKind.MinusToken ||
+          u.operator === ts.SyntaxKind.TildeToken
+        ) {
+          return exprDomain(u.operand) === "number" ? "number" : null;
+        }
+        return null;
       }
-      case ts.SyntaxKind.PostfixUnaryExpression:
-        return isAssignableLocal((e as ts.PostfixUnaryExpression).operand); // ++ / -- only
+      case ts.SyntaxKind.PostfixUnaryExpression: {
+        const u = e as ts.PostfixUnaryExpression;
+        return isAssignableLocal(u.operand) && domain.get((u.operand as ts.Identifier).text) === "number"
+          ? "number"
+          : null; // x++ / x-- — number-local mutation only
+      }
       case ts.SyntaxKind.BinaryExpression: {
         const b = e as ts.BinaryExpression;
         const op = b.operatorToken.kind;
-        if (isAssignToken(op)) return isAssignableLocal(b.left) && numOk(b.right);
-        return isNumericBinaryToken(op) && numOk(b.left) && numOk(b.right);
+        if (op === ts.SyntaxKind.EqualsToken) {
+          // `x = <rhs>` — preserves the target local's domain.
+          if (!isAssignableLocal(b.left)) return null;
+          const d = domain.get((b.left as ts.Identifier).text)!;
+          return exprDomain(b.right) === d ? d : null;
+        }
+        if (isCompoundAssignToken(op)) {
+          // `x += <rhs>` … — number-only.
+          if (!isAssignableLocal(b.left) || domain.get((b.left as ts.Identifier).text) !== "number") return null;
+          return exprDomain(b.right) === "number" ? "number" : null;
+        }
+        if (isNumericBinaryToken(op)) {
+          return exprDomain(b.left) === "number" && exprDomain(b.right) === "number" ? "number" : null;
+        }
+        if (isRelationalToken(op)) {
+          return exprDomain(b.left) === "number" && exprDomain(b.right) === "number" ? "bool" : null;
+        }
+        if (isEqualityToken(op)) {
+          const l = exprDomain(b.left);
+          const r = exprDomain(b.right);
+          return l !== null && l === r ? "bool" : null; // matched domains only
+        }
+        if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
+          return exprDomain(b.left) === "bool" && exprDomain(b.right) === "bool" ? "bool" : null;
+        }
+        return null;
       }
       case ts.SyntaxKind.ConditionalExpression: {
         const c = e as ts.ConditionalExpression;
-        return boolOk(c.condition) && numOk(c.whenTrue) && numOk(c.whenFalse);
+        if (exprDomain(c.condition) !== "bool") return null;
+        const t = exprDomain(c.whenTrue);
+        const f = exprDomain(c.whenFalse);
+        return t !== null && t === f ? t : null;
       }
       case ts.SyntaxKind.CallExpression: {
         const c = e as ts.CallExpression;
-        if (!ts.isIdentifier(c.expression)) return false; // no method calls
+        if (!ts.isIdentifier(c.expression)) return null; // no method calls
         const arity = claimedArity.get(c.expression.text);
-        if (arity === undefined || arity !== c.arguments.length) return false; // exact arity to a claimed fn
+        if (arity === undefined || arity !== c.arguments.length) return null; // exact arity to a claimed f64 fn
         for (const a of c.arguments) {
-          if (ts.isSpreadElement(a) || !numOk(a)) return false;
+          if (ts.isSpreadElement(a) || exprDomain(a) !== "number") return null;
         }
-        return true;
+        return "number"; // claimedArity holds pure-f64-signature callees only
       }
       default:
-        return false; // strings/booleans/member/element/new/array/object/arrow/this/… → reject
+        return null; // strings/member/element/new/array/object/arrow/this/… → reject
     }
   };
-
-  // Expression in BOOLEAN context — must evaluate to a boolean (comparisons of
-  // numbers, or logical combinations thereof). No boolean literals / vars: a
-  // number-vs-boolean mix is exactly the from-ast "matching operand types"
-  // throw this split exists to avoid.
-  function boolOk(e: ts.Expression): boolean {
-    const x = unwrapParen(e);
-    if (ts.isPrefixUnaryExpression(x) && x.operator === ts.SyntaxKind.ExclamationToken) return boolOk(x.operand);
-    if (ts.isBinaryExpression(x)) {
-      const op = x.operatorToken.kind;
-      if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
-        return boolOk(x.left) && boolOk(x.right);
-      }
-      if (isCompareToken(op)) return numOk(x.left) && numOk(x.right);
-    }
-    return false;
-  }
 
   const stmtOk = (s: ts.Statement): boolean => {
     switch (s.kind) {
@@ -196,33 +243,36 @@ export function irFirstBodyIsProvenLowerable(
         return true;
       case ts.SyntaxKind.ReturnStatement: {
         const r = s as ts.ReturnStatement;
-        return r.expression === undefined || numOk(r.expression);
+        if (r.expression === undefined) return true; // bare `return;`
+        return returnDomain !== "void" && exprDomain(r.expression) === returnDomain;
       }
       case ts.SyntaxKind.ExpressionStatement:
-        return numOk((s as ts.ExpressionStatement).expression);
+        return exprDomain((s as ts.ExpressionStatement).expression) !== null;
       case ts.SyntaxKind.IfStatement: {
         const i = s as ts.IfStatement;
         return (
-          boolOk(i.expression) && stmtOk(i.thenStatement) && (i.elseStatement === undefined || stmtOk(i.elseStatement))
+          exprDomain(i.expression) === "bool" &&
+          stmtOk(i.thenStatement) &&
+          (i.elseStatement === undefined || stmtOk(i.elseStatement))
         );
       }
       case ts.SyntaxKind.WhileStatement: {
         const w = s as ts.WhileStatement;
-        return boolOk(w.expression) && stmtOk(w.statement);
+        return exprDomain(w.expression) === "bool" && stmtOk(w.statement);
       }
       case ts.SyntaxKind.DoStatement: {
         const d = s as ts.DoStatement;
-        return boolOk(d.expression) && stmtOk(d.statement);
+        return exprDomain(d.expression) === "bool" && stmtOk(d.statement);
       }
       case ts.SyntaxKind.ForStatement: {
         const f = s as ts.ForStatement;
         if (f.initializer) {
           if (ts.isVariableDeclarationList(f.initializer)) {
             if (!f.initializer.declarations.every(varDeclOk)) return false;
-          } else if (!numOk(f.initializer)) return false;
+          } else if (exprDomain(f.initializer) === null) return false;
         }
-        if (f.condition && !boolOk(f.condition)) return false;
-        if (f.incrementor && !numOk(f.incrementor)) return false;
+        if (f.condition && exprDomain(f.condition) !== "bool") return false;
+        if (f.incrementor && exprDomain(f.incrementor) === null) return false;
         return stmtOk(f.statement);
       }
       case ts.SyntaxKind.VariableStatement:
@@ -235,7 +285,10 @@ export function irFirstBodyIsProvenLowerable(
   function varDeclOk(d: ts.VariableDeclaration): boolean {
     if (!ts.isIdentifier(d.name)) return false; // destructuring
     if (d.initializer === undefined) return false; // uninitialized — reject (conservative)
-    return numOk(d.initializer);
+    const dom = exprDomain(d.initializer);
+    if (dom === null) return false;
+    domain.set(d.name.text, dom); // record so later statements resolve this local
+    return true;
   }
 
   return fn.body.statements.every(stmtOk);

--- a/tests/issue-3203.test.ts
+++ b/tests/issue-3203.test.ts
@@ -1,0 +1,203 @@
+// #3203 — IR-first allowlist widen: f64 -> f64 + boolean.
+//
+// The #3143 flip's v1 allowlist skipped legacy body emission only for pure-f64
+// functions. This widens the proven-lowerable subset to add a `bool` value
+// domain (bool params/returns/locals/literals, logical ops, comparisons, bool
+// equality, bool ternary), tracked structurally so number-vs-bool operand mixes
+// stay COMPILE-TWICE (safe-by-construction: a missed shape is never a
+// skipped-slot hard error). This test locks:
+//   1. The predicate accepts bool-domain bodies when the caller passes bool
+//      param/return domains, and rejects cross-domain mixes.
+//   2. The f64-only defaults (2-arg call) are unchanged (parity with #3143).
+//   3. End-to-end: a bool-predicate program compiles with ZERO hard errors
+//      under the IR-first default, runs correctly, and matches the escape-hatch
+//      legacy order (behavior-preserving).
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { collectLocalCallEdges, irFirstBodyIsProvenLowerable, type ValueDomain } from "../src/codegen/ir-first-gate.js";
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+function fnDecl(src: string): ts.FunctionDeclaration {
+  const sf = ts.createSourceFile("t.ts", src, ts.ScriptTarget.Latest, true);
+  const fn = sf.statements.find(ts.isFunctionDeclaration);
+  if (!fn) throw new Error("no function declaration in source");
+  return fn;
+}
+
+async function instantiate(r: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return instance.exports as Record<string, Function>;
+}
+
+const NO_CALLS = new Map<string, number>();
+
+describe("#3203 — irFirstBodyIsProvenLowerable bool-domain widen", () => {
+  // [label, src, paramDomains, returnDomain]
+  it.each<[string, string, ValueDomain[], ValueDomain | "void"]>([
+    [
+      "f64 param -> bool return (predicate)",
+      `function isPos(n: number): boolean { return n > 0; }`,
+      ["number"],
+      "bool",
+    ],
+    [
+      "bool params, logical && / ||",
+      `function both(a: boolean, b: boolean): boolean { return a && b || !a; }`,
+      ["bool", "bool"],
+      "bool",
+    ],
+    ["bool literal return", `function t(): boolean { return true; }`, [], "bool"],
+    [
+      "bool local from comparison, used in condition",
+      `function f(n: number): number { const big = n > 10; if (big) return 1; return 0; }`,
+      ["number"],
+      "number",
+    ],
+    [
+      "bool ternary branches",
+      `function pick(p: boolean, a: boolean): boolean { return p ? a : false; }`,
+      ["bool", "bool"],
+      "bool",
+    ],
+    [
+      "bool equality (matched domain)",
+      `function eq(a: boolean, b: boolean): boolean { return a === b; }`,
+      ["bool", "bool"],
+      "bool",
+    ],
+    [
+      "bool local mutation via =",
+      `function f(n: number): boolean { let r = false; if (n > 0) { r = true; } return r; }`,
+      ["number"],
+      "bool",
+    ],
+  ])("accepts (skip-eligible): %s", (_label, src, pd, rd) => {
+    expect(irFirstBodyIsProvenLowerable(fnDecl(src), NO_CALLS, pd, rd)).toBe(true);
+  });
+
+  it.each<[string, string, ValueDomain[], ValueDomain | "void"]>([
+    // number-vs-bool operand mixes and domain mismatches — stay compile-twice.
+    [
+      "number + bool (arith over mixed domain)",
+      `function f(a: number, b: boolean): number { return a + (b as unknown as number); }`,
+      ["number", "bool"],
+      "number",
+    ],
+    ["bool operand in numeric arithmetic", `function f(a: boolean): number { return a * 2; }`, ["bool"], "number"],
+    [
+      "return domain mismatch (bool body, number return)",
+      `function f(a: boolean, b: boolean): number { return a && b; }`,
+      ["bool", "bool"],
+      "number",
+    ],
+    [
+      "equality across domains (number === bool)",
+      `function f(n: number, b: boolean): boolean { return n === b; }`,
+      ["number", "bool"],
+      "bool",
+    ],
+    [
+      "relational over bools",
+      `function f(a: boolean, b: boolean): boolean { return a < b; }`,
+      ["bool", "bool"],
+      "bool",
+    ],
+    [
+      "ternary branches differ in domain",
+      `function f(p: boolean, n: number): number { return p ? n : true; }`,
+      ["bool", "number"],
+      "number",
+    ],
+    ["++ on a bool local", `function f(): boolean { let r = true; r++; return r; }`, [], "bool"],
+    ["numeric literal in bool return", `function f(): boolean { return 1; }`, [], "bool"],
+  ])("rejects (compile-twice): %s", (_label, src, pd, rd) => {
+    expect(irFirstBodyIsProvenLowerable(fnDecl(src), NO_CALLS, pd, rd)).toBe(false);
+  });
+
+  it("f64-only defaults unchanged (2-arg call, parity with #3143)", () => {
+    expect(
+      irFirstBodyIsProvenLowerable(fnDecl(`function add(a: number, b: number): number { return a + b; }`), NO_CALLS),
+    ).toBe(true);
+    // a bool return with the default number returnDomain is a mismatch -> reject
+    expect(irFirstBodyIsProvenLowerable(fnDecl(`function f(): boolean { return true; }`), NO_CALLS)).toBe(false);
+  });
+});
+
+describe("#3203 — end-to-end bool predicates under IR-first default", () => {
+  // All four are within the widened subset and are leaf/exported → the IR-first
+  // default SKIPS every one (validated below). `classifyNum` keeps a pure-number
+  // body with bool *conditions* (already lowerable pre-widen); the three
+  // predicates exercise the new bool params/returns/logic paths. Deliberately
+  // avoids the `const b = boolReturningCall(); if (b && …)` shape, which trips a
+  // PRE-EXISTING from-ast overlay verify bug (unrelated to this widen — it is
+  // never skipped and reproduces with JS2WASM_IR_FIRST=0).
+  const SRC = `
+    export function isEven(n: number): boolean { return n % 2 === 0; }
+    export function inRange(n: number): boolean { return n > 0 && n < 100; }
+    export function nand(a: boolean, b: boolean): boolean { return !(a && b); }
+    export function classifyNum(n: number): number {
+      let c = 0;
+      if (n % 2 === 0) c = c + 1;
+      if (n > 100) c = c + 2;
+      return c;
+    }
+  `;
+
+  // Wasm surfaces `boolean` returns as i32 0/1.
+  const checkAll = (e: Record<string, Function>): void => {
+    expect(Boolean(e.isEven(4))).toBe(true);
+    expect(Boolean(e.isEven(3))).toBe(false);
+    expect(Boolean(e.inRange(50))).toBe(true);
+    expect(Boolean(e.inRange(200))).toBe(false);
+    expect(Boolean(e.nand(1, 1))).toBe(false);
+    expect(Boolean(e.nand(1, 0))).toBe(true);
+    expect(e.classifyNum(200)).toBe(3); // even + >100
+    expect(e.classifyNum(3)).toBe(0);
+  };
+
+  it("SKIPS the bool functions under the IR-first default, ZERO hard errors, VALID binary", async () => {
+    const r = await compile(SRC, { fileName: "bool.ts", experimentalIR: true });
+    const hard = (r.errors ?? []).filter((e) => e.severity === "error");
+    expect(hard.map((e) => e.message)).toEqual([]);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    // The widen's whole point: these legacy bodies are skipped (IR owns them).
+    expect([...(r.irFirstSkipped ?? [])].sort()).toEqual(["classifyNum", "inRange", "isEven", "nand"]);
+  });
+
+  it("runs correctly under the IR-first default", async () => {
+    const r = await compile(SRC, { fileName: "bool.ts", experimentalIR: true });
+    checkAll(await instantiate(r));
+  });
+
+  it("parity: escape-hatch legacy order (JS2WASM_IR_FIRST=0) gives the same results", async () => {
+    const prev = process.env.JS2WASM_IR_FIRST;
+    process.env.JS2WASM_IR_FIRST = "0";
+    try {
+      const r = await compile(SRC, { fileName: "bool.ts", experimentalIR: true });
+      const hard = (r.errors ?? []).filter((e) => e.severity === "error");
+      expect(hard.map((e) => e.message)).toEqual([]);
+      checkAll(await instantiate(r));
+    } finally {
+      if (prev === undefined) Reflect.deleteProperty(process.env, "JS2WASM_IR_FIRST");
+      else process.env.JS2WASM_IR_FIRST = prev;
+    }
+  });
+
+  // Guard: collectLocalCallEdges still maps the caller graph (used by the
+  // signature-parity fixpoint that the widen leaves intact).
+  it("collectLocalCallEdges maps a caller to its callee", () => {
+    const sf = ts.createSourceFile(
+      "t.ts",
+      `function a(){ return b(); } function b(){ return 1; }`,
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const edges = collectLocalCallEdges(sf);
+    expect([...(edges.get("a") ?? [])]).toContain("b");
+  });
+});


### PR DESCRIPTION
## What

First real **Phase-3a enabler** after the #3143 IR-first-default flip. The flip landed with a conservative **v1 allowlist** that skipped legacy body emission only for pure-`f64` functions. This widens the proven-lowerable value domain to add **boolean**, so bool-signature predicates and bool-bodied functions become IR-owned (skip legacy body emission) too.

## Why (scoping — reported to lead under #3090)

The flip cleared **G1 for the numeric population only**. Measured skip rate on the ir-fallbacks corpus was **6/50 = 12%**; the other 88% still compile via legacy, so **G2 keeps every per-kind legacy handler reachable** — no frontend handler is deletable yet (the reachability audit's frontend `legacy-only` count went *up* 59,976→61,889 post-flip). The −60k payoff unlocks per-file as each file's last gate closes, which requires **widening the allowlist** so more functions are IR-owned. This is that first widen (behavior-preserving scaffolding, not a −LOC deletion).

## How

- **`ir-first-gate.ts`**: replaced the number-only `numOk`/`boolOk` split with a **domain-tracking walk**. `exprDomain(e)` returns `number`/`bool`/`null`; params are seeded from caller-provided domains (default `number`, preserving the existing 2-arg call sites/tests), locals inferred from initializers. Enforces from-ast's matched-operand rule structurally: arithmetic/bit/shift over numbers → number; relational over numbers → bool; equality over **matched** domains → bool; `&&`/`||`/`!` over bools → bool; `?:` same-domain branches; number-only local mutation. Adds a `ValueDomain` export.
- **`index.ts` `computeIrFirstSkipSet`**: resolves each position's domain from the overrideMap type + AST annotation. `boolean` and native-int both carry as `i32`, so a **`boolean` annotation is the only checker-free way to disambiguate bool from native-int** — native-i32 stays compile-twice (a follow-up slice). Passes `paramDomains`/`returnDomain` to the predicate. Tightens `claimedArity` to **pure-f64-signature callees** (v1 calls are number-only), which also closes a latent hole where a call to a claimed non-f64-return callee was accepted as `number`.

**Safe-by-construction**: any shape the walk does not recognise stays COMPILE-TWICE — never a skipped-slot hard error. Behavior-preserving: bool functions were already IR-claimed (compile-twice); this only skips their now-redundant legacy body. The signature-parity fixpoint is unchanged.

## Validation

- `tsc` clean; `check:ir-fallbacks` OK (`body-shape-rejected` 14→14, no increase); `check:loc-budget` OK (index.ts +26 granted via issue `loc-budget-allow`).
- **20 new `tests/issue-3203.test.ts`**: bool accept/reject predicate cases + e2e (bool predicates SKIP under IR-first, zero hard errors, valid binary, correct results) + escape-hatch (`JS2WASM_IR_FIRST=0`) parity.
- **111 IR-equivalence + gate tests** green (`ir-numeric-bool`/`ir-if-else`/`ir-ternary`/`ir-let-const-equivalence`, `#3143`/`#2138`/`#2951`).
- Confirmed every widened shape is **verify-clean under CI-hard verify** (`VITEST`/`CI` promote from-ast `verify` failures to hard errors).

**Broad-impact — validate on `merge_group`** (standalone floor + merge-shard reports run there); net-non-negative required. A `hold` label protects the SHA from the auto-refresh bot; remove when green.

## Note (pre-existing, not this PR)

A `const b = boolReturningCall(); if (b && …)` shape trips a **pre-existing from-ast overlay verify bug** ("undefined SSA value") — reproduces with `JS2WASM_IR_FIRST=0`, is never skipped by this widen, and is net-neutral here. Flagged for the #2856 body-shape work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8