### PR TITLE
fix(#2903): standalone R3 — native lazy Iterator helpers map/filter/take/drop

### DIFF
--- a/plan/issues/2903-standalone-make-callback-residual-rootcause.md
+++ b/plan/issues/2903-standalone-make-callback-residual-rootcause.md
@@ -29,8 +29,10 @@ loc-budget-allow:
   - src/codegen/async-scheduler.ts
   - src/codegen/expressions.ts
   - src/codegen/index.ts
+  - src/codegen/iterator-native.ts
 coercion-sites-allow:
   - src/codegen/iter-hof-native.ts
+  - src/codegen/iter-lazy-native.ts
 ---
 
 # #2903 — residual `env::__make_callback` leak: root cause + decomposition
@@ -445,3 +447,71 @@ vec HOF arm; ground in `closed-method-dispatch.ts` + the #2651 family.
 Leak probe (zero family env imports + bare `{}` instantiate OK), construct-
 sampled corpus flip, `prove-emit-identity` gc/wasi byte-identical, merge_group
 standalone floor as the decider.
+
+---
+
+## Landed: sub-front R3 — lazy Iterator helpers map/filter/take/drop (opus-r3, 2026-07-13)
+
+**PR:** `issue-2903-r3-lazy-iter-helpers`. **New module
+`src/codegen/iter-lazy-native.ts`.**
+
+### The lowering
+
+A single closed struct `$LazyIterHelper { kind i32, src externref, fn externref,
+state (mut f64), inner (mut externref) }` (the `inner` field is reserved for a
+future flatMap slice — unused here). `.map/filter/take/drop(arg)` on a **non-vec,
+non-`$Object` iterator receiver** (generator frame, Map/Set/array iterator, or a
+chained lazy wrapper) constructs one via `__iter_lazy_<name>(recv, arg)`, whose
+`src` is the OPENED source handle (`__iter_hof_open(recv)` — GetIteratorDirect at
+call time). A shared `__lazy_iter_step(wrapper) -> (i32 done, externref value)`
+drives `src` through `__iter_hof_next` and applies the kind-dispatched transform:
+map applies `fn(value, counter)`; filter loops until truthy; take counts down
+`state` (0 ⇒ IteratorClose(src) + done); drop drains `state` skips then passes
+through. `fn` invoked via `__apply_closure` — **no `env.__make_callback`, no host
+import**.
+
+The wrapper is itself an iterator, wired into BOTH drive paths:
+- `closed-method-dispatch.ts` — a lazy arm mirrors the #2903 eager arm's
+  non-vec/non-`$Object` split; for map/filter it sits UNDER the #3098 vec HOF arm
+  so a vec receiver still eager-maps (arrays keep `[...].map` returning an array).
+- `iter-hof-native.ts` `fillIterHofSteppers` — `$LazyIterHelper` arms in
+  `__iter_hof_open/_next/_close` (pass-through / `__lazy_iter_step` /
+  `__lazy_iter_close`) so `.toArray()`, the eager helpers, and lazy→lazy chaining
+  drive it.
+- `iter-lazy-native.ts` `fillLazyIterLadderArms` — prepends a `$LazyIterHelper`
+  recognition arm to the GetIterator ladder (`__iterator` returns the wrapper,
+  `__iterator_next` → `__lazy_iter_step`, `__iterator_return` → `__lazy_iter_close`,
+  `__iterator_rest` → `__array_from_iter_n(rec,-1)`) so `Array.from(...)`,
+  `[...spread]`, and `for…of` drain it natively.
+- `iterator-native.ts` `fillNativeIteratorLateArms` — admits `$LazyIterHelper` to
+  the `__array_from_iter_n` drain allowlist (the element-wise drainer the
+  `__iterator_rest` arm delegates to).
+
+### Proofs
+
+- `tests/issue-2903-r3.test.ts` (14 tests): map/filter/take/drop via `.toArray()`,
+  `Array.from`, `[...spread]`, `for-of`, mapper-counter, lazy→lazy + filter→take
+  chaining, empty/`take(0)`/`drop`-beyond edge cases — all **host-free** (`env`
+  imports = `[]`, bare `{}` instantiate) + value-correct. Plus eager-array-HOF /
+  gc-lane guards.
+- `tests/issue-2903.test.ts` + `tests/issue-1326.test.ts`: 25/25 still green
+  (then/catch/finally/allSettled de-leak + gc + wasi lanes untouched).
+- **gc/wasi byte-identity by construction**: every new path is gated on
+  `ctx.standalone`; `$LazyIterHelper` is only registered under standalone, so
+  `fillLazyIterLadderArms` and the `__array_from_iter_n` drain-admission no-op in
+  gc/host/wasi (structMap miss).
+
+### Boundaries (documented, not gate regressions)
+
+- Helper on a non-iterator receiver → the source handle is null ⇒ the wrapper
+  yields nothing, NOT the spec TypeError (same no-throw discipline as the eager
+  helpers, #3098).
+- `take(n)`/`drop(n)` floor + clamp-negative-to-0, NOT the spec RangeError on
+  negative/NaN.
+- `result-is-iterator` / `x instanceof Iterator` brand identity is NOT modeled
+  (the wrapper is a bespoke struct, not `%IteratorHelperPrototype%`).
+- **flatMap is NOT in this slice** — it needs the `inner`-iterator drain-then-
+  advance state machine (the struct field is reserved for it). Follow-up R3b.
+- Array-iterator reification is still a separate gap: `[1,2,3].values()` returns
+  NULL standalone, so `.values().map(...)` shapes stay failing (not a helper
+  problem).

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -42,6 +42,7 @@ import { buildClosureRefTestArms } from "./closure-classifier.js"; // (#3125) Is
 import type { CodegenContext } from "./context/types.js";
 import { ensureNativeArrayHof, NATIVE_HOF_METHODS } from "./hof-native.js";
 import { ensureNativeIterHof, isIterHofForm, NATIVE_ITER_HOF_METHODS } from "./iter-hof-native.js"; // (#2903)
+import { ensureNativeLazyIter, isLazyIterForm, LAZY_ITER_METHODS } from "./iter-lazy-native.js"; // (#2903 R3)
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { ensureObjVecBuilders, reserveApplyClosure } from "./object-runtime.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
@@ -194,6 +195,16 @@ export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: str
   // answered `undefined`. Standalone only.
   if (ctx.standalone && NATIVE_ITER_HOF_METHODS.has(methodName) && isIterHofForm(methodName, arity)) {
     ensureNativeIterHof(ctx, methodName);
+  }
+
+  // (#2903 R3) For the LAZY Iterator-helper methods (map/filter/take/drop on an
+  // iterator receiver, arity ≥1), emit the native wrapper constructor
+  // `__iter_lazy_<name>` + shared steppers NOW (append-only; the fill only READS
+  // funcMap — #1719). The fill adds a lazy arm under the same non-vec/non-$Object
+  // iterator split as the eager arm; for map/filter it sits UNDER the #3098 vec
+  // HOF arm so a vec receiver still eager-maps. Standalone only.
+  if (ctx.standalone && LAZY_ITER_METHODS.has(methodName) && isLazyIterForm(methodName, arity)) {
+    ensureNativeLazyIter(ctx, methodName);
   }
 
   // Signature: (recv, arg0..arg{arity-1}) all externref → externref.
@@ -536,6 +547,67 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
             blockType: { kind: "val", type: { kind: "externref" } },
             then: current,
             else: iterCall,
+          } as Instr,
+        ];
+      }
+    }
+
+    // (#2903 R3) LAZY Iterator-helper arm (map/filter/take/drop, arity ≥1).
+    // Same non-vec/non-$Object iterator split as the eager arm above: a
+    // generator / driven frame / Map-Set-array iterator / lazy-wrapper receiver
+    // routes to the native wrapper constructor `__iter_lazy_<name>(recv, arg0)`
+    // (returns a `$LazyIterHelper` iterator, iter-lazy-native.ts). For map/filter
+    // this sits UNDER the #3098 vec HOF arm (wrapped outside), so a vec receiver
+    // still eager-maps; take/drop have no vec arm (arrays lack them → the legacy
+    // undefined on a vec receiver, unchanged). Previously these receivers fell to
+    // `__extern_method_call`'s non-`$Object` arm and silently answered undefined.
+    {
+      const lazyCtorIdx = ctx.funcMap.get(`__iter_lazy_${methodName}`);
+      const objTypeIdxForLazy = ctx.objectRuntimeTypes?.objectTypeIdx;
+      const objVecTypeIdxForLazy = ctx.objectRuntimeTypes?.objVecTypeIdx;
+      if (
+        ctx.standalone &&
+        lazyCtorIdx !== undefined &&
+        LAZY_ITER_METHODS.has(methodName) &&
+        isLazyIterForm(methodName, arity) &&
+        objTypeIdxForLazy !== undefined
+      ) {
+        const lazyCall: Instr[] = [
+          { op: "local.get", index: 0 } as Instr, // recv
+          { op: "local.get", index: 1 } as Instr, // arg0 (mapper/predicate | count)
+          { op: "call", funcIdx: lazyCtorIdx } as Instr,
+        ];
+        // isNotIterTarget = null ∨ $Object ∨ $__vec_base ∨ $ObjVec — a NULL/
+        // $Object/vec receiver keeps the legacy route; everything else (iterator
+        // carriers) constructs the lazy wrapper.
+        const notIterTest: Instr[] = [
+          { op: "local.get", index: anyLocalIdx } as Instr,
+          { op: "ref.is_null" } as Instr,
+          { op: "local.get", index: anyLocalIdx } as Instr,
+          { op: "ref.test", typeIdx: objTypeIdxForLazy } as Instr,
+          { op: "i32.or" } as Instr,
+        ];
+        if (ctx.vecBaseTypeIdx >= 0) {
+          notIterTest.push(
+            { op: "local.get", index: anyLocalIdx } as Instr,
+            { op: "ref.test", typeIdx: ctx.vecBaseTypeIdx } as Instr,
+            { op: "i32.or" } as Instr,
+          );
+        }
+        if (objVecTypeIdxForLazy !== undefined) {
+          notIterTest.push(
+            { op: "local.get", index: anyLocalIdx } as Instr,
+            { op: "ref.test", typeIdx: objVecTypeIdxForLazy } as Instr,
+            { op: "i32.or" } as Instr,
+          );
+        }
+        current = [
+          ...notIterTest,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: current,
+            else: lazyCall,
           } as Instr,
         ];
       }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -57,6 +57,7 @@ import { fillCombinatorToVec } from "./promise-combinators.js"; // (#2922) dynam
 import { fillClosedMethodDispatch, fillPromiseThenableHelpers } from "./closed-method-dispatch.js";
 import { fillSetRecFieldGetters } from "./collections-es2025.js"; // (#3172)
 import { fillIterHofSteppers } from "./iter-hof-native.js"; // (#2903)
+import { fillLazyIterLadderArms } from "./iter-lazy-native.js"; // (#2903 R3)
 import { fillMemberSetDispatch, reserveVecFieldMaterializers } from "./member-set-dispatch.js";
 import { fillMemberGetDispatch } from "./member-get-dispatch.js";
 import { emitUndefined, ensureGetUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
@@ -2475,6 +2476,13 @@ export function generateModule(
     // per-producer driven-generator arms + the positive-admission classifier.
     // Read-only per #1719; no-op unless a helper call site reserved them.
     fillIterHofSteppers(ctx);
+
+    // (#2903 R3) Prepend the `$LazyIterHelper` recognition arm to the
+    // GetIterator ladder (`__iterator`/`_next`/`_return`) so `Array.from(...)`,
+    // spread, and `for…of` drive a lazy map/filter/take/drop wrapper natively.
+    // MUST run AFTER `fillNativeIteratorLateArms` (which rebuilds those bodies).
+    // No-op unless a lazy wrapper was constructed.
+    fillLazyIterLadderArms(ctx);
 
     // (#2922) Rebuild `__combinator_to_vec`'s user-iterable arm with the same
     // closed-struct dispatchers (identical five-dispatcher condition, so the

--- a/src/codegen/iter-hof-native.ts
+++ b/src/codegen/iter-hof-native.ts
@@ -401,7 +401,7 @@ export function ensureNativeIterHof(ctx: CodegenContext, methodName: string): nu
  * it at factory-compile time) — so the fill only READS `ctx.nativeGenerators`
  * + funcMap (#1719 discipline; append-only reserve, read-only fill).
  */
-function reserveIterHofSteppers(
+export function reserveIterHofSteppers(
   ctx: CodegenContext,
 ): { openIdx: number; nextIdx: number; closeIdx: number } | undefined {
   const existing = ctx.funcMap.get("__iter_hof_open");
@@ -536,6 +536,22 @@ export function fillIterHofSteppers(ctx: CodegenContext): void {
   const iteratorReturnIdx = ctx.funcMap.get("__iterator_return");
   if (iteratorIdx === undefined || iteratorNextIdx === undefined || iteratorReturnIdx === undefined) return;
 
+  // (#2903 R3) Lazy Iterator-helper wrapper (`$LazyIterHelper`, iter-lazy-native.ts)
+  // arms. When the module built any `g().map/filter/take/drop(...)` wrapper, its
+  // struct type + the shared `__lazy_iter_step`/`__lazy_iter_close` steppers are
+  // registered (append-only). A wrapper handle reaching `__iter_hof_open` (a
+  // downstream eager helper / `.toArray()` / chained lazy helper) is its OWN
+  // iterator: open passes it through, next delegates to `__lazy_iter_step`, close
+  // to `__lazy_iter_close`. Read by funcMap/structMap (no import of the lazy
+  // module — one-directional dep).
+  const lazyHelperTypeIdx = ctx.structMap.get("$LazyIterHelper");
+  const lazyStepIdx = ctx.funcMap.get("__lazy_iter_step");
+  const lazyCloseIdx = ctx.funcMap.get("__lazy_iter_close");
+  const lazyArm =
+    lazyHelperTypeIdx !== undefined && lazyStepIdx !== undefined && lazyCloseIdx !== undefined
+      ? { typeIdx: lazyHelperTypeIdx, stepIdx: lazyStepIdx, closeIdx: lazyCloseIdx }
+      : undefined;
+
   // The `__iterator` GetIterator ladder is only SAFE for receivers one of its
   // arms admits — everything else hits the legacy vec hard-cast. Admissible
   // here: the canonical externref `$Vec` (the always-present vec arm) and,
@@ -587,6 +603,18 @@ export function fillIterHofSteppers(ctx: CodegenContext): void {
   const openFn = definedFuncAt(ctx, openIdx);
   if (openFn) {
     const arms: Instr[] = [];
+    // Lazy Iterator-helper wrapper → the wrapper IS the handle (pass-through).
+    if (lazyArm) {
+      arms.push(
+        { op: "local.get", index: ANY } as Instr,
+        { op: "ref.test", typeIdx: lazyArm.typeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "local.get", index: 0 } as Instr, { op: "return" } as Instr],
+        } as Instr,
+      );
+    }
     // Driven generator frame → the frame IS the handle (pass-through).
     for (const p of producers) {
       arms.push(
@@ -628,6 +656,23 @@ export function fillIterHofSteppers(ctx: CodegenContext): void {
   const nextFn = definedFuncAt(ctx, nextIdx);
   if (nextFn) {
     const arms: Instr[] = [];
+    // Lazy Iterator-helper wrapper → delegate the step to `__lazy_iter_step`
+    // (which itself drives the wrapper's source via `__iter_hof_next`).
+    if (lazyArm) {
+      arms.push(
+        { op: "local.get", index: ANY } as Instr,
+        { op: "ref.test", typeIdx: lazyArm.typeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: 0 } as Instr,
+            { op: "call", funcIdx: lazyArm.stepIdx } as Instr,
+            { op: "return" } as Instr,
+          ],
+        } as Instr,
+      );
+    }
     for (const p of producers) {
       arms.push(
         { op: "local.get", index: ANY } as Instr,
@@ -662,6 +707,22 @@ export function fillIterHofSteppers(ctx: CodegenContext): void {
   const closeFn = definedFuncAt(ctx, closeIdx);
   if (closeFn) {
     const arms: Instr[] = [];
+    // Lazy Iterator-helper wrapper → close its source via `__lazy_iter_close`.
+    if (lazyArm) {
+      arms.push(
+        { op: "local.get", index: ANY } as Instr,
+        { op: "ref.test", typeIdx: lazyArm.typeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: 0 } as Instr,
+            { op: "call", funcIdx: lazyArm.closeIdx } as Instr,
+            { op: "return" } as Instr,
+          ],
+        } as Instr,
+      );
+    }
     for (const p of producers) {
       arms.push(
         { op: "local.get", index: ANY } as Instr,

--- a/src/codegen/iter-lazy-native.ts
+++ b/src/codegen/iter-lazy-native.ts
@@ -1,0 +1,549 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2903 R3 — native standalone LAZY Iterator-helper wrappers for dynamic
+ * (`any`/externref) iterator receivers: `%Iterator.prototype%.map / filter /
+ * take / drop` (ES2025 §27.1.4.2/.3/.4/.5). Sub-front 2 (iter-hof-native.ts)
+ * covered the EAGER helpers (find/every/some/forEach/reduce/toArray) that drive
+ * the source to completion and return a value; the lazy helpers instead return
+ * a NEW iterator that produces transformed elements on demand.
+ *
+ * Design (per the #2903 re-ground R3 plan): ONE closed struct
+ * `$LazyIterHelper { kind i32, src externref, fn externref, state (mut f64),
+ * inner (mut externref) }`. `.map(fn)` etc. on an iterator receiver allocates a
+ * wrapper whose `src` is the OPENED source handle (`__iter_hof_open(recv)` —
+ * GetIteratorDirect at call time, §27.1.4 step 3) and whose `fn`/`state` carry
+ * the transform. A single `__lazy_iter_step(wrapper) -> (i32 done, externref
+ * value)` drives `src` via `__iter_hof_next` and applies the kind-dispatched
+ * transform:
+ *   - map:    apply `fn(value, counter)`, counter in `state`.
+ *   - filter: loop pulling until `fn(value, counter)` is truthy.
+ *   - take:   `state` = remaining; 0 ⇒ IteratorClose(src) + done.
+ *   - drop:   `state` = remaining-to-skip; drain that many, then pass through.
+ * (`inner` is reserved for a future flatMap slice — unused here.)
+ *
+ * The wrapper is itself an iterator: it is admitted by `__iter_hof_open`
+ * (pass-through) so it CHAINS into downstream eager helpers / `.toArray()` /
+ * further lazy helpers (arms in {@link fillIterHofSteppers}), and by the
+ * `__iterator` / `__iterator_next` / `__iterator_return` GetIterator ladder
+ * (prepended arms, {@link fillLazyIterLadderArms}) so `Array.from(...)`, spread,
+ * and `for…of` drive it natively. No `env.__make_callback` host bridge, no host
+ * import — the whole point of R3.
+ *
+ * BOUNDARIES (documented, same no-throw discipline as the eager helpers, #3098):
+ *  - `.map`/`.filter`/`.take`/`.drop` on a NON-iterator receiver → the source
+ *    handle is null ⇒ the wrapper yields nothing (empty), rather than the spec
+ *    TypeError. (The dispatch arm already routes only non-`$Object`/non-vec
+ *    receivers here; a plain object with no `[Symbol.iterator]` produces null.)
+ *  - `take(n)`/`drop(n)` do ToInteger-ish flooring + clamp-negative-to-0, NOT
+ *    the spec RangeError on negative/NaN (§27.1.4.4/.5 step 3.c).
+ *  - IteratorClose on early exit is best-effort (`take` closes on limit; a
+ *    caller's early break closes via `__iterator_return`); a driven-generator
+ *    source frame's `.return()`/finally is not triggered (§27.5.3.3 boundary,
+ *    inherited from the eager steppers).
+ *  - `result-is-iterator` / `instanceof Iterator` brand identity is NOT modeled
+ *    (the wrapper is a bespoke struct, not `%IteratorHelperPrototype%`).
+ *
+ * Emitted at RESERVE time (append-only defined funcs — no funcIdx shift), so the
+ * fills only READ funcMap/structMap (#1719). Standalone only. Idempotent.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { reserveIterHofSteppers } from "./iter-hof-native.js";
+import { ensureNativeArrayFromIterN, ensureNativeIteratorRuntime } from "./iterator-native.js";
+import { ensureObjectRuntime, reserveApplyClosure } from "./object-runtime.js";
+import { addFuncType } from "./registry/types.js";
+import { addUnionImportsViaRegistry } from "./shared.js";
+
+/** Method names served by {@link ensureNativeLazyIter}. */
+export const LAZY_ITER_METHODS: ReadonlySet<string> = new Set(["map", "filter", "take", "drop"]);
+
+/** `state` semantics differ by kind (see module header). */
+const KIND: Record<string, number> = { map: 0, filter: 1, take: 2, drop: 3 };
+
+/** Field indices of `$LazyIterHelper` — load-bearing order. */
+const F_KIND = 0;
+const F_SRC = 1;
+const F_FN = 2;
+const F_STATE = 3;
+// const F_INNER = 4; // reserved for flatMap
+
+/** True when `methodName`/`arity` is a form the lazy arm services. */
+export function isLazyIterForm(methodName: string, arity: number): boolean {
+  return LAZY_ITER_METHODS.has(methodName) && arity >= 1;
+}
+
+/**
+ * Lazily register (or fetch) the `$LazyIterHelper` GC struct type. One per
+ * module, cached via `ctx.structMap`. Mirrors `getOrRegisterIterRecType`.
+ */
+function getOrRegisterLazyHelperType(ctx: CodegenContext): number {
+  const existing = ctx.structMap.get("$LazyIterHelper");
+  if (existing !== undefined) return existing;
+  const fields = [
+    { name: "kind", type: { kind: "i32" as const }, mutable: false },
+    { name: "src", type: { kind: "externref" as const }, mutable: false },
+    { name: "fn", type: { kind: "externref" as const }, mutable: false },
+    { name: "state", type: { kind: "f64" as const }, mutable: true },
+    { name: "inner", type: { kind: "externref" as const }, mutable: true },
+  ];
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: "$LazyIterHelper", fields });
+  ctx.structMap.set("$LazyIterHelper", typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, "$LazyIterHelper");
+  ctx.structFields.set("$LazyIterHelper", fields);
+  return typeIdx;
+}
+
+interface LazyDeps {
+  helperTypeIdx: number;
+  openIdx: number;
+  nextIdx: number;
+  closeIdx: number;
+  applyClosureIdx: number;
+  boxNumIdx: number;
+  unboxNumIdx: number;
+  isTruthyIdx: number;
+  objVecNewIdx: number;
+  objVecPushIdx: number;
+}
+
+/** Gather (registering as needed) every dependency the lazy runtime needs.
+ *  Returns undefined when a dep is unavailable (⇒ no native arm; legacy path). */
+function gatherLazyDeps(ctx: CodegenContext): LazyDeps | undefined {
+  if (!ctx.standalone) return undefined;
+  ensureObjectRuntime(ctx);
+  addUnionImportsViaRegistry(ctx);
+  ensureNativeIteratorRuntime(ctx);
+  // (#2903 R3) Register the bulk-drain helper so `Array.from(lazyWrapper)` /
+  // spread (which route through `__iterator_rest`) have it available; the
+  // `__iterator_rest` lazy arm delegates to it, and the finalize rebuild admits
+  // `$LazyIterHelper` to its drain guard.
+  ensureNativeArrayFromIterN(ctx);
+  reserveApplyClosure(ctx);
+  const steppers = reserveIterHofSteppers(ctx);
+  if (steppers === undefined) return undefined;
+  const helperTypeIdx = getOrRegisterLazyHelperType(ctx);
+  const applyClosureIdx = ctx.funcMap.get("__apply_closure");
+  const boxNumIdx = ctx.funcMap.get("__box_number");
+  const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+  const isTruthyIdx = ctx.funcMap.get("__is_truthy");
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  if (
+    applyClosureIdx === undefined ||
+    boxNumIdx === undefined ||
+    unboxNumIdx === undefined ||
+    isTruthyIdx === undefined ||
+    objVecNewIdx === undefined ||
+    objVecPushIdx === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    helperTypeIdx,
+    openIdx: steppers.openIdx,
+    nextIdx: steppers.nextIdx,
+    closeIdx: steppers.closeIdx,
+    applyClosureIdx,
+    boxNumIdx,
+    unboxNumIdx,
+    isTruthyIdx,
+    objVecNewIdx,
+    objVecPushIdx,
+  };
+}
+
+/**
+ * Emit (or fetch) the native lazy-helper constructor `__iter_lazy_<methodName>`
+ * plus the shared `__lazy_iter_step` / `__lazy_iter_close` steppers. Returns the
+ * constructor funcIdx, or undefined when unavailable. Append-only — safe at
+ * reserve time.
+ */
+export function ensureNativeLazyIter(ctx: CodegenContext, methodName: string): number | undefined {
+  if (!LAZY_ITER_METHODS.has(methodName)) return undefined;
+  const ctorName = `__iter_lazy_${methodName}`;
+  const existing = ctx.funcMap.get(ctorName);
+  if (existing !== undefined) return existing;
+
+  const deps = gatherLazyDeps(ctx);
+  if (deps === undefined) return undefined;
+
+  ensureLazyStepper(ctx, deps);
+  return emitLazyConstructor(ctx, methodName, deps);
+}
+
+/** Reserve the shared `__lazy_iter_step` / `__lazy_iter_close`. Idempotent. */
+function ensureLazyStepper(ctx: CodegenContext, deps: LazyDeps): void {
+  if (ctx.funcMap.get("__lazy_iter_step") !== undefined) return;
+  const { helperTypeIdx, nextIdx, closeIdx, applyClosureIdx, boxNumIdx, isTruthyIdx, objVecNewIdx, objVecPushIdx } =
+    deps;
+
+  // Locals: 0 param (externref), 1 helperAny (anyref), 2 src, 3 kind (i32),
+  // 4 st (f64), 5 done (i32), 6 val, 7 args, 8 res.
+  const P = 0;
+  const HANY = 1;
+  const SRC = 2;
+  const KIND_L = 3;
+  const ST = 4;
+  const DONE = 5;
+  const VAL = 6;
+  const ARGS = 7;
+  const RES = 8;
+
+  const cast = (): Instr[] => [
+    { op: "local.get", index: HANY } as Instr,
+    { op: "ref.cast", typeIdx: helperTypeIdx } as Instr,
+  ];
+  const doneReturn: Instr[] = [
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "ref.null.extern" } as Instr,
+    { op: "return" } as Instr,
+  ];
+  // (done, val) = __iter_hof_next(src); if done → return (done, null).
+  const pullStep: Instr[] = [
+    { op: "local.get", index: SRC } as Instr,
+    { op: "call", funcIdx: nextIdx } as Instr,
+    { op: "local.set", index: VAL } as Instr,
+    { op: "local.set", index: DONE } as Instr,
+    { op: "local.get", index: DONE } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: doneReturn } as Instr,
+  ];
+  // args = [val, box(st)].
+  const buildArgs: Instr[] = [
+    { op: "call", funcIdx: objVecNewIdx } as Instr,
+    { op: "local.set", index: ARGS } as Instr,
+    { op: "local.get", index: ARGS } as Instr,
+    { op: "local.get", index: VAL } as Instr,
+    { op: "call", funcIdx: objVecPushIdx } as Instr,
+    { op: "local.get", index: ARGS } as Instr,
+    { op: "local.get", index: ST } as Instr,
+    { op: "call", funcIdx: boxNumIdx } as Instr,
+    { op: "call", funcIdx: objVecPushIdx } as Instr,
+  ];
+  // res = __apply_closure(helper.fn, undefined, args).
+  const invoke: Instr[] = [
+    ...cast(),
+    { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_FN } as Instr,
+    { op: "ref.null.extern" } as Instr,
+    { op: "local.get", index: ARGS } as Instr,
+    { op: "call", funcIdx: applyClosureIdx } as Instr,
+    { op: "local.set", index: RES } as Instr,
+  ];
+  // st += 1; persist to struct.
+  const bumpCounter: Instr[] = [
+    { op: "local.get", index: ST } as Instr,
+    { op: "f64.const", value: 1 } as Instr,
+    { op: "f64.add" } as Instr,
+    { op: "local.set", index: ST } as Instr,
+    ...cast(),
+    { op: "local.get", index: ST } as Instr,
+    { op: "struct.set", typeIdx: helperTypeIdx, fieldIdx: F_STATE } as Instr,
+  ];
+
+  const mapArm: Instr[] = [
+    ...pullStep,
+    ...buildArgs,
+    ...invoke,
+    ...bumpCounter,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.get", index: RES } as Instr,
+    { op: "return" } as Instr,
+  ];
+
+  const filterArm: Instr[] = [
+    {
+      op: "loop",
+      blockType: { kind: "empty" },
+      body: [
+        ...pullStep,
+        ...buildArgs,
+        ...invoke,
+        ...bumpCounter,
+        { op: "local.get", index: RES } as Instr,
+        { op: "call", funcIdx: isTruthyIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "i32.const", value: 0 } as Instr,
+            { op: "local.get", index: VAL } as Instr,
+            { op: "return" } as Instr,
+          ],
+        } as Instr,
+        { op: "br", depth: 0 } as Instr,
+      ],
+    } as Instr,
+  ];
+
+  const takeArm: Instr[] = [
+    // st <= 0 ⇒ IteratorClose(src) + done.
+    { op: "local.get", index: ST } as Instr,
+    { op: "f64.const", value: 0 } as Instr,
+    { op: "f64.le" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: SRC } as Instr, { op: "call", funcIdx: closeIdx } as Instr, ...doneReturn],
+    } as Instr,
+    ...pullStep,
+    // st -= 1; persist.
+    ...cast(),
+    { op: "local.get", index: ST } as Instr,
+    { op: "f64.const", value: 1 } as Instr,
+    { op: "f64.sub" } as Instr,
+    { op: "struct.set", typeIdx: helperTypeIdx, fieldIdx: F_STATE } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.get", index: VAL } as Instr,
+    { op: "return" } as Instr,
+  ];
+
+  const dropArm: Instr[] = [
+    // Skip `st` elements (once — state persists, so re-entry after yielding
+    // sees st==0 and skips the block).
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: ST } as Instr,
+            { op: "f64.const", value: 0 } as Instr,
+            { op: "f64.le" } as Instr,
+            { op: "br_if", depth: 1 } as Instr, // done skipping → exit block
+            ...pullStep,
+            // st -= 1; persist.
+            { op: "local.get", index: ST } as Instr,
+            { op: "f64.const", value: 1 } as Instr,
+            { op: "f64.sub" } as Instr,
+            { op: "local.set", index: ST } as Instr,
+            ...cast(),
+            { op: "local.get", index: ST } as Instr,
+            { op: "struct.set", typeIdx: helperTypeIdx, fieldIdx: F_STATE } as Instr,
+            { op: "br", depth: 0 } as Instr,
+          ],
+        } as Instr,
+      ],
+    } as Instr,
+    ...pullStep,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.get", index: VAL } as Instr,
+    { op: "return" } as Instr,
+  ];
+
+  const stepBody: Instr[] = [
+    { op: "local.get", index: P } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.set", index: HANY } as Instr,
+    // src = helper.src
+    ...cast(),
+    { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_SRC } as Instr,
+    { op: "local.set", index: SRC } as Instr,
+    // null source ⇒ empty iterator.
+    { op: "local.get", index: SRC } as Instr,
+    { op: "ref.is_null" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: doneReturn } as Instr,
+    // kind / st
+    ...cast(),
+    { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_KIND } as Instr,
+    { op: "local.set", index: KIND_L } as Instr,
+    ...cast(),
+    { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_STATE } as Instr,
+    { op: "local.set", index: ST } as Instr,
+    // if kind==map
+    { op: "local.get", index: KIND_L } as Instr,
+    { op: "i32.eqz" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: mapArm } as Instr,
+    // if kind==filter
+    { op: "local.get", index: KIND_L } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.eq" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: filterArm } as Instr,
+    // if kind==take
+    { op: "local.get", index: KIND_L } as Instr,
+    { op: "i32.const", value: 2 } as Instr,
+    { op: "i32.eq" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: takeArm } as Instr,
+    // if kind==drop
+    { op: "local.get", index: KIND_L } as Instr,
+    { op: "i32.const", value: 3 } as Instr,
+    { op: "i32.eq" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: dropArm } as Instr,
+    // fallthrough: unknown kind ⇒ done.
+    ...doneReturn,
+  ];
+
+  const stepTypeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }, { kind: "externref" }]);
+  const stepIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__lazy_iter_step", stepIdx);
+  pushDefinedFunc(ctx, stepIdx, {
+    name: "__lazy_iter_step",
+    typeIdx: stepTypeIdx,
+    locals: [
+      { name: "helperAny", type: { kind: "anyref" } },
+      { name: "src", type: { kind: "externref" } },
+      { name: "kind", type: { kind: "i32" } },
+      { name: "st", type: { kind: "f64" } },
+      { name: "done", type: { kind: "i32" } },
+      { name: "val", type: { kind: "externref" } },
+      { name: "args", type: { kind: "externref" } },
+      { name: "res", type: { kind: "externref" } },
+    ],
+    body: stepBody,
+    exported: false,
+  });
+
+  // __lazy_iter_close(helperExt) → IteratorClose(src) when non-null.
+  const closeBody: Instr[] = [
+    { op: "local.get", index: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: helperTypeIdx } as Instr,
+    { op: "struct.get", typeIdx: helperTypeIdx, fieldIdx: F_SRC } as Instr,
+    { op: "local.set", index: 1 } as Instr,
+    { op: "local.get", index: 1 } as Instr,
+    { op: "ref.is_null" } as Instr,
+    { op: "i32.eqz" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: 1 } as Instr, { op: "call", funcIdx: closeIdx } as Instr],
+    } as Instr,
+  ];
+  const closeTypeIdx = addFuncType(ctx, [{ kind: "externref" }], []);
+  const lazyCloseIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__lazy_iter_close", lazyCloseIdx);
+  pushDefinedFunc(ctx, lazyCloseIdx, {
+    name: "__lazy_iter_close",
+    typeIdx: closeTypeIdx,
+    locals: [{ name: "src", type: { kind: "externref" } }],
+    body: closeBody,
+    exported: false,
+  });
+}
+
+/** Emit `__iter_lazy_<methodName>(recv, arg) -> externref`. */
+function emitLazyConstructor(ctx: CodegenContext, methodName: string, deps: LazyDeps): number {
+  const { helperTypeIdx, openIdx, unboxNumIdx } = deps;
+  const kind = KIND[methodName];
+  const isCount = methodName === "take" || methodName === "drop";
+  const ctorName = `__iter_lazy_${methodName}`;
+
+  // Locals: 0 recv, 1 arg, 2 src (externref), 3 cnt (f64).
+  const body: Instr[] = [
+    // src = __iter_hof_open(recv)
+    { op: "local.get", index: 0 } as Instr,
+    { op: "call", funcIdx: openIdx } as Instr,
+    { op: "local.set", index: 2 } as Instr,
+  ];
+  if (isCount) {
+    // cnt = floor(ToNumber(arg)); clamp NaN/negative → 0.
+    body.push(
+      { op: "local.get", index: 1 } as Instr,
+      { op: "call", funcIdx: unboxNumIdx } as Instr,
+      { op: "f64.floor" } as Instr,
+      { op: "local.set", index: 3 } as Instr,
+      { op: "local.get", index: 3 } as Instr,
+      { op: "f64.const", value: 0 } as Instr,
+      { op: "f64.lt" } as Instr,
+      { op: "local.get", index: 3 } as Instr,
+      { op: "local.get", index: 3 } as Instr,
+      { op: "f64.ne" } as Instr, // NaN
+      { op: "i32.or" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "f64.const", value: 0 } as Instr, { op: "local.set", index: 3 } as Instr],
+      } as Instr,
+    );
+  }
+  // struct.new $LazyIterHelper { kind, src, fn, state, inner:null }
+  body.push(
+    { op: "i32.const", value: kind } as Instr, // kind
+    { op: "local.get", index: 2 } as Instr, // src
+    isCount ? ({ op: "ref.null.extern" } as Instr) : ({ op: "local.get", index: 1 } as Instr), // fn
+    isCount ? ({ op: "local.get", index: 3 } as Instr) : ({ op: "f64.const", value: 0 } as Instr), // state
+    { op: "ref.null.extern" } as Instr, // inner
+    { op: "struct.new", typeIdx: helperTypeIdx } as Instr,
+    { op: "extern.convert_any" } as Instr,
+  );
+
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set(ctorName, funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: ctorName,
+    typeIdx,
+    locals: [
+      { name: "src", type: { kind: "externref" } },
+      { name: "cnt", type: { kind: "f64" } },
+    ],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/**
+ * FINALIZE fill: prepend a `$LazyIterHelper` recognition arm to the GetIterator
+ * ladder bodies (`__iterator` / `__iterator_next` / `__iterator_return`) so
+ * `Array.from(...)`, spread, and `for…of` drive a lazy wrapper natively. A
+ * wrapper is its OWN iterator: `__iterator` returns it unchanged, `_next`
+ * delegates to `__lazy_iter_step`, `_return` to `__lazy_iter_close`. No-op when
+ * the module built no lazy wrapper. Must run AFTER `fillNativeIteratorLateArms`
+ * (which rebuilds those bodies) in the index.ts finalize sequence.
+ */
+export function fillLazyIterLadderArms(ctx: CodegenContext): void {
+  const helperTypeIdx = ctx.structMap.get("$LazyIterHelper");
+  const stepIdx = ctx.funcMap.get("__lazy_iter_step");
+  const closeIdx = ctx.funcMap.get("__lazy_iter_close");
+  if (helperTypeIdx === undefined || stepIdx === undefined || closeIdx === undefined) return;
+
+  // FRESH instr objects per prepend (#2169b / shared-instr double-remap hazard):
+  // one `Instr` object aliased into multiple function bodies is remapped at most
+  // once by the DCE type-remap's WeakSet guard, desyncing the others — the
+  // `ref.test $LazyIterHelper` embedded in `__iterator`/`_next`/`_return` MUST be
+  // three distinct objects. Each `prepend` builds its own.
+  const prepend = (funcName: string, thenBody: Instr[]): void => {
+    const idx = ctx.funcMap.get(funcName);
+    if (idx === undefined) return;
+    const fn = definedFuncAt(ctx, idx);
+    if (!fn) return;
+    fn.body = [
+      { op: "local.get", index: 0 } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.test", typeIdx: helperTypeIdx } as Instr,
+      { op: "if", blockType: { kind: "empty" }, then: thenBody } as Instr,
+      ...fn.body,
+    ];
+  };
+
+  // __iterator(obj) → obj (the wrapper is its own iterator).
+  prepend("__iterator", [{ op: "local.get", index: 0 } as Instr, { op: "return" } as Instr]);
+  // __iterator_next(rec) → __lazy_iter_step(rec) (multivalue i32,externref).
+  prepend("__iterator_next", [
+    { op: "local.get", index: 0 } as Instr,
+    { op: "call", funcIdx: stepIdx } as Instr,
+    { op: "return" } as Instr,
+  ]);
+  // __iterator_return(rec) → __lazy_iter_close(rec).
+  prepend("__iterator_return", [
+    { op: "local.get", index: 0 } as Instr,
+    { op: "call", funcIdx: closeIdx } as Instr,
+    { op: "return" } as Instr,
+  ]);
+  // __iterator_rest(rec) → __array_from_iter_n(rec, -1) — the bulk drain used by
+  // `Array.from(...)` / `[...wrapper]`. `__iterator_rest`'s vec body would hard-
+  // cast the wrapper to `$IterRec`; delegate to the element-wise drainer (which
+  // admits `$LazyIterHelper` and drives it via the ladder prepends above).
+  const afinIdx = ctx.funcMap.get("__array_from_iter_n");
+  if (afinIdx !== undefined) {
+    prepend("__iterator_rest", [
+      { op: "local.get", index: 0 } as Instr,
+      { op: "f64.const", value: -1 } as Instr,
+      { op: "call", funcIdx: afinIdx } as Instr,
+      { op: "return" } as Instr,
+    ]);
+  }
+}

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -1333,7 +1333,14 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
   // (#3119) With `objDeps`, a source carrying a truthy `@@iterator` PROPERTY
   // (post-hoc `o[Symbol.iterator] = fn`) is likewise admitted to the drain;
   // `@@iterator`-less array-like `$Object`s keep the indexed pass-through.
-  if (deps || objDeps || sgDeps) {
+  // (#2903 R3) Admit the lazy Iterator-helper wrapper `$LazyIterHelper` to the
+  // `__array_from_iter_n` drain: `Array.from(g().map(f))` / spread must DRIVE it
+  // (via the `__iterator`/`__iterator_next` prepends `fillLazyIterLadderArms`
+  // adds later in finalize) rather than pass the wrapper through to the indexed
+  // reader. The prepends run AFTER this fill, but the drain loop calls them at
+  // runtime, so ordering is irrelevant.
+  const lazyHelperTypeIdx = ctx.structMap.get("$LazyIterHelper");
+  if (deps || objDeps || sgDeps || lazyHelperTypeIdx !== undefined) {
     const afinIdx = ctx.funcMap.get("__array_from_iter_n");
     const afinFn = afinIdx !== undefined ? definedFuncAt(ctx, afinIdx) : undefined;
     if (afinFn && afinFn.body.length > 0) {
@@ -1347,7 +1354,8 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
       // through to the indexed reader (which answers length 0 → every binding
       // silently `undefined`).
       const genStateTypeIdxs = sgDeps ? sgDeps.producers.map((p) => p.stateTypeIdx) : [];
-      if (userTypeIdxs.length > 0 || objDeps || genStateTypeIdxs.length > 0) {
+      const lazyTypeIdxs = lazyHelperTypeIdx !== undefined ? [lazyHelperTypeIdx] : [];
+      if (userTypeIdxs.length > 0 || objDeps || genStateTypeIdxs.length > 0 || lazyTypeIdxs.length > 0) {
         afinFn.body = buildArrayFromIterNBody(
           { vecTypeIdx: types.vecTypeIdx, arrTypeIdx: types.arrTypeIdx },
           {
@@ -1355,7 +1363,7 @@ export function fillNativeIteratorLateArms(ctx: CodegenContext): void {
             iteratorNextIdx,
             iteratorReturnIdx: ctx.funcMap.get("__iterator_return"),
           },
-          [...userTypeIdxs, ...genStateTypeIdxs],
+          [...userTypeIdxs, ...genStateTypeIdxs, ...lazyTypeIdxs],
           objDeps,
         );
       }

--- a/tests/issue-2903-r3.test.ts
+++ b/tests/issue-2903-r3.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2903 R3 — standalone LAZY Iterator-helper wrappers (`map`/`filter`/`take`/
+// `drop`) on a dynamic (`any`/generator) iterator receiver.
+//
+// Sub-front 2 covered the EAGER helpers (find/every/some/forEach/reduce/toArray)
+// that drive the source to completion. The lazy five instead return a NEW
+// iterator (`$LazyIterHelper`, iter-lazy-native.ts) that produces transformed
+// elements on demand. The wrapper is admitted by `__iter_hof_open`
+// (`.toArray()` / eager-helper chaining) AND by the `__iterator` /
+// `__iterator_next` / `__iterator_rest` GetIterator ladder (`Array.from(...)`,
+// `[...spread]`, `for…of`) — all pure Wasm, zero host imports.
+//
+// Before this slice a `.map(cb)` on a generator fell to `__extern_method_call`'s
+// non-`$Object` arm and silently answered `undefined` (or trapped in the
+// Array.from drain). These flip host-free.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success).toBe(true);
+  return result;
+}
+
+/** Compile standalone, assert zero host imports, instantiate host-free, run. */
+async function runHostFree(source: string): Promise<number> {
+  const result = await compileStandalone(source);
+  const mod = await WebAssembly.compile(result.binary!);
+  const envImports = WebAssembly.Module.imports(mod).filter((i) => i.module === "env");
+  expect(envImports).toEqual([]); // host-free: no __make_callback, no env import
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2903 R3 — lazy Iterator helpers are host-free and correct", () => {
+  it("map(...).toArray() applies the mapper natively", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; }
+         const r = (g() as any).map((x: number) => x * 2).toArray();
+         export function test(): number { return r[0] + r[1] + r[2]; }`,
+      ),
+    ).toBe(12);
+  });
+
+  it("map passes (value, counter) to the mapper", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 10; yield 20; yield 30; }
+         const r = (g() as any).map((v: number, c: number) => c).toArray();
+         export function test(): number { return r[0] * 100 + r[1] * 10 + r[2]; }`,
+      ),
+    ).toBe(12); // counters 0,1,2
+  });
+
+  it("Array.from(map(...)) drives the wrapper through the GetIterator ladder", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; }
+         const r = Array.from((g() as any).map((x: number) => x * 2));
+         export function test(): number { return r.length * 100 + r[0] + r[1] + r[2]; }`,
+      ),
+    ).toBe(312);
+  });
+
+  it("[...spread] of a lazy map drains it natively", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; }
+         const r = [...(g() as any).map((x: number) => x * 2)];
+         export function test(): number { return r.length * 100 + r[0] + r[1] + r[2]; }`,
+      ),
+    ).toBe(312);
+  });
+
+  it("for-of over a lazy map yields the transformed values", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; }
+         let s = 0; for (const x of (g() as any).map((v: number) => v * 2)) s += x;
+         export function test(): number { return s; }`,
+      ),
+    ).toBe(12);
+  });
+
+  it("filter keeps only predicate-truthy values", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; yield 4; }
+         const r = (g() as any).filter((x: number) => x % 2 === 0).toArray();
+         export function test(): number { return r.length * 100 + r[0] + r[1]; }`,
+      ),
+    ).toBe(206); // [2, 4]
+  });
+
+  it("take(n) yields the first n and stops", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; yield 4; }
+         const r = (g() as any).take(2).toArray();
+         export function test(): number { return r.length * 100 + r[0] + r[1]; }`,
+      ),
+    ).toBe(203); // [1, 2]
+  });
+
+  it("drop(n) skips the first n", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; yield 4; }
+         const r = (g() as any).drop(2).toArray();
+         export function test(): number { return r.length * 100 + r[0] + r[1]; }`,
+      ),
+    ).toBe(207); // [3, 4]
+  });
+
+  it("chains map(...).map(...) natively (each is its own iterator)", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; }
+         const r = Array.from((g() as any).map((x: number) => x + 1).map((x: number) => x * 10));
+         export function test(): number { return r[0] + r[1] + r[2]; }`,
+      ),
+    ).toBe(90); // [20, 30, 40]
+  });
+
+  it("chains filter(...).take(...) natively", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; yield 3; yield 4; yield 5; yield 6; }
+         const r = (g() as any).filter((x: number) => x % 2 === 0).take(2).toArray();
+         export function test(): number { return r.length * 100 + r[0] + r[1]; }`,
+      ),
+    ).toBe(206); // [2, 4]
+  });
+
+  it("empty source → empty result (no trap)", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){}
+         const r = (g() as any).map((x: number) => x).toArray();
+         export function test(): number { return r.length; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("take(0) yields nothing; drop beyond length yields nothing", async () => {
+    expect(
+      await runHostFree(
+        `function* g(){ yield 1; yield 2; }
+         const a = (g() as any).take(0).toArray();
+         function* h(){ yield 1; yield 2; }
+         const b = (h() as any).drop(5).toArray();
+         export function test(): number { return a.length * 10 + b.length; }`,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("#2903 R3 — eager array HOFs and gc/host lane unaffected", () => {
+  it("standalone `any` array .map stays on the eager vec HOF arm", async () => {
+    expect(
+      await runHostFree(
+        `const a: any = [1, 2, 3];
+         const r = a.map((x: number) => x * 2);
+         export function test(): number { return r[0] + r[1] + r[2]; }`,
+      ),
+    ).toBe(12);
+  });
+
+  it("gc/host lane compiles `.map` on an array with no $LazyIterHelper type", async () => {
+    const result = await compile(
+      `const a = [1, 2, 3];
+       export function test(): number { const r = a.map((x) => x * 2); return r[0] + r[1] + r[2]; }`,
+      { fileName: "test.ts", skipSemanticDiagnostics: true },
+    );
+    expect(result.success).toBe(true);
+    // The lazy wrapper is standalone-only — it must never appear in gc/host output.
+    const mod = await WebAssembly.compile(result.binary!);
+    void mod; // compiles cleanly; struct absence is guaranteed by the standalone gate
+  });
+});


### PR DESCRIPTION
## Sub-front R3 of #2903 — lazy Iterator helpers (standalone host-free)

Retires the `env.__make_callback` / silently-wrong residual for the **lazy**
Iterator-helper family `map` / `filter` / `take` / `drop` on a dynamic
(`any`/generator) iterator receiver. Sub-front 2 covered the EAGER helpers
(find/every/some/forEach/reduce/toArray); the lazy five return a NEW iterator
that produces transformed elements on demand.

### Before
`(g() as any).map(cb)` on a generator fell to `__extern_method_call`'s
non-`$Object` arm and silently answered `undefined`; `Array.from(g().map(cb))`
trapped `illegal cast`.

### The lowering
New module `src/codegen/iter-lazy-native.ts` — one closed struct
`$LazyIterHelper { kind, src, fn, state (mut f64), inner }` whose shared
`__lazy_iter_step` drives the opened source via `__iter_hof_next` and applies
the kind transform (map applies `fn(value, counter)`; filter loops until truthy;
take counts down `state`; drop drains then passes through), invoking the
callback via `__apply_closure` — **no `env.__make_callback`, no host import**.

The wrapper is its own iterator, wired into both drive paths:
- **closed-method dispatch** lazy arm — under the #3098 vec HOF arm, so `any`
  arrays still eager-map.
- **`__iter_hof_*` steppers** — `.toArray()`, eager-helper + lazy→lazy chaining.
- **`__iterator`/`_next`/`_return`/`_rest` GetIterator ladder** — `Array.from`,
  `[...spread]`, `for-of`.
- **`__array_from_iter_n` drain allowlist** — admits the wrapper.

### Validation
- `tests/issue-2903-r3.test.ts` (14): all four helpers via `.toArray()`,
  `Array.from`, spread, for-of, mapper-counter, lazy→lazy + filter→take chains,
  empty/`take(0)`/`drop`-beyond edges — **host-free** (`env` imports `[]`, bare
  `{}` instantiate) + value-correct. Plus eager-array-HOF / gc-lane guards.
- `tests/issue-2903.test.ts` + `tests/issue-1326.test.ts`: 25/25 green.
- `2169c`/`2169b`/`1665` iterator-drain regression tests green.
- **gc/wasi byte-identical by construction** — every new path is
  `ctx.standalone`-gated; `$LazyIterHelper` is only registered under standalone.
- Broad-impact standalone → merge_group standalone floor is the decider.

### Deferred (documented)
- **flatMap** → R3b (needs the inner-iterator drain-then-advance machine; the
  struct `inner` field is reserved).
- Array-iterator reification (`[1,2,3].values()` → NULL standalone) is a
  separate gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)