### PR TITLE
fix(#3201): trap-safe indexOf/lastIndexOf on sparse arrays

### DIFF
--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -15,6 +15,7 @@ sprint: current
 horizon: m
 umbrella: 3185
 related: [3185, 3169, 3180, 2036]
+loc-budget-allow: [src/codegen/array-methods.ts]
 origin: "2026-07-12 Fable codebase audit §F2; method-family slice of #3185"
 ---
 

--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -77,3 +77,40 @@ axes. sort's callback comparator is in-scope here (default lane) but is not a
 `src/codegen/array-methods.ts` is shared with #3199/#3200, epic S3 #3193 /
 S6 #3196, and dev-array-hof. Behavioral fixes only; re-anchor by symbol;
 re-merge `origin/main` before enqueue.
+## Progress — sparse-array read trap-safety (indexOf/lastIndexOf) landed (opus-dstr, 2026-07-13)
+
+Partial fix for the trap-first sub-bucket (acceptance #1). `compileArrayIndexOf`
+and `compileArrayLastIndexOf` looped `0 .. vec.length` (logical length, field 0)
+reading `data[i]` with a raw `array.get`, which TRAPS ("array element access out
+of bounds") once `i` passes the physical backing length — the case where a
+sparse array's logical `.length` was set beyond its WasmGC backing (`a.length =
+N`, or a high-index write). Per §23.1.3.14 / §23.1.3.20 (HasProperty-driven)
+those absent indices are SKIPPED, so the fix clamps the iteration bound (indexOf:
+effective length = `min(logicalLen, array.len(data))`; lastIndexOf: clamp the
+reverse-scan start index down to `array.len(data)-1`). Pure-sparse searches now
+return the correct `-1` with no trap; dense arrays are byte-unchanged (backing
+capacity ≥ length ⇒ clamp is a no-op). Zero array-suite regressions
+(`tests/issue-3201.test.ts`, standalone lane; the two pre-existing
+`fast-arrays`/`array-oob-bounds-check` fails are unrelated and present on clean
+main).
+
+### Remaining trap-class root causes (NOT addressed here — separate follow-ups)
+
+Measured against the 2026-07-13 baseline, most of the family's trap-class fails
+are NOT the method-read OOB this slice fixes:
+
+1. **Huge sparse-index WRITE** (`arr[Math.pow(2,32)-2] = v`) — traps on the
+   element-WRITE path trying to densely grow the backing to ~4 billion slots
+   (`15.4.4.14-5-16/-5-12/-9-9`, `15.4.4.15-5-12/-8-9`, splice/concat variants).
+   Needs a sparse representation or a graceful cap/RangeError in the array
+   index-write lowering — out of `array-methods.ts` scope. **Dominant remaining
+   trap cause.**
+2. **`Array.prototype` mutation** (`Array.prototype.length = 0`,
+   `Array.prototype[1] = 1`) — `illegal cast` writing the prototype's `length`,
+   and prototype-inherited index reads the flat WasmGC vec cannot model
+   (`15.4.4.14-2-4`, `15.4.4.15-2-4`, pop/concat `S15.4.4.*_A*`). The read side
+   would need prototype-chain index fallback (shared with the #2001-deferred
+   hole/prototype-inheritance boundary).
+3. **Revoked-Proxy `illegal cast`** (concat/slice `create-revoked-proxy`,
+   `is-concat-spreadable-*-revoked`) — Proxy is a deferred feature; the revoked
+   handle should surface a TypeError rather than trapping on `ref.cast`.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -4546,6 +4546,27 @@ function compileArrayIndexOf(
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
   fctx.body.push({ op: "local.set", index: dataTmp });
 
+  // (#3201) A sparse array (logical `.length` set beyond the physical backing,
+  // or a high-index write) has `lenTmp` (field 0) > `array.len(dataTmp)`. The
+  // search loop below reads `data[i]` with a raw `array.get`, which TRAPS
+  // ("array element access out of bounds") once `i` passes the backing length.
+  // Per §23.1.3.14 (HasProperty-driven) those absent indices are SKIPPED, so
+  // clamp the iteration bound to the backing length — the beyond-backing holes
+  // can never strict-equal the search value anyway. Normal (non-sparse) vecs
+  // keep `lenTmp` unchanged (backing capacity ≥ length ⇒ min is the length).
+  const effLenTmp = allocLocal(fctx, `__arr_iof_efflen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: lenTmp });
+  fctx.body.push({ op: "local.get", index: dataTmp });
+  fctx.body.push({ op: "array.len" });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "local.get", index: lenTmp } as Instr],
+    else: [{ op: "local.get", index: dataTmp } as Instr, { op: "array.len" } as Instr],
+  } as Instr);
+  fctx.body.push({ op: "local.set", index: effLenTmp });
+
   compileExpression(ctx, fctx, callExpr.arguments[0]!, elemType);
   fctx.body.push({ op: "local.set", index: valTmp });
 
@@ -4654,7 +4675,7 @@ function compileArrayIndexOf(
 
   const loopBody: Instr[] = [
     { op: "local.get", index: iTmp },
-    { op: "local.get", index: lenTmp },
+    { op: "local.get", index: effLenTmp },
     { op: "i32.ge_s" },
     { op: "br_if", depth: 1 },
 
@@ -9459,6 +9480,30 @@ function compileArrayLastIndexOf(
   fctx.body.push({ op: "local.get", index: vecTmp });
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
   fctx.body.push({ op: "local.set", index: dataTmp });
+
+  // (#3201) A sparse array (logical `.length` > physical backing) starts the
+  // reverse scan at `len-1`, beyond the backing array — the first `data[i]`
+  // read TRAPS ("array element access out of bounds"). Per §23.1.3.20
+  // (HasProperty-driven) the absent top indices are SKIPPED, so clamp the
+  // start index down to `array.len(data)-1`. Non-sparse vecs are unaffected
+  // (backing capacity ≥ length ⇒ the clamp is a no-op).
+  fctx.body.push({ op: "local.get", index: iTmp });
+  fctx.body.push({ op: "local.get", index: dataTmp });
+  fctx.body.push({ op: "array.len" });
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "i32.sub" });
+  fctx.body.push({ op: "i32.gt_s" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: dataTmp } as Instr,
+      { op: "array.len" } as Instr,
+      { op: "i32.const", value: 1 } as Instr,
+      { op: "i32.sub" } as Instr,
+      { op: "local.set", index: iTmp } as Instr,
+    ],
+  } as Instr);
 
   // Compile search value
   compileExpression(ctx, fctx, callExpr.arguments[0]!, valType);

--- a/tests/issue-3201.test.ts
+++ b/tests/issue-3201.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3201 — Array.prototype search-family trap-safety on sparse arrays.
+ *
+ * A sparse array (its logical `.length` set beyond the physical WasmGC backing
+ * array, e.g. `a.length = 100` on a short/empty vec) has `vec.length` (field 0)
+ * greater than `array.len(vec.data)` (field 1). Before this fix,
+ * `indexOf`/`lastIndexOf` iterated `0 .. logicalLength` reading `data[i]` with a
+ * raw `array.get`, which TRAPS ("array element access out of bounds") once `i`
+ * passes the backing length — an uncatchable Wasm trap that aborts the whole
+ * program (the #3185 §4 trap-first mandate: every such trap must become a spec
+ * value or a thrown JS error).
+ *
+ * §23.1.3.14 (indexOf) / §23.1.3.20 (lastIndexOf) are HasProperty-driven, so the
+ * absent beyond-backing indices are SKIPPED — they can never strict-equal the
+ * search value. The fix clamps the iteration bound to the backing length, which
+ * yields the correct `-1` for a purely-sparse search AND never traps. Normal
+ * (non-sparse) arrays are byte-for-byte unaffected: the backing capacity is ≥
+ * the logical length, so the clamp is a no-op.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function numResult(body: string, target?: "standalone"): Promise<number> {
+  const src = `export function test(): number {\n${body}\n}`;
+  const r = await compile(src, { fileName: "issue-3201.ts", target, skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+// The clamp is lane-agnostic (not gated on `ctx.standalone`); the standalone
+// lane instantiates with a bare import object, so it is the reliable unit-test
+// vehicle. The default (gc-host) lane is exercised by the CI test262 sweep over
+// `built-ins/Array/prototype/{indexOf,lastIndexOf}` sparse-array tests.
+for (const target of ["standalone"] as const) {
+  const label = target;
+  describe(`#3201 — Array.prototype search trap-safety on sparse arrays (${label})`, () => {
+    it("indexOf on a length-extended empty array returns -1 (no OOB trap)", async () => {
+      expect(await numResult(`const a: any[] = []; a.length = 100; return a.indexOf(true);`, target)).toBe(-1);
+    });
+
+    it("indexOf on a partially-backed sparse array returns -1 (no OOB trap)", async () => {
+      expect(await numResult(`const a: any[] = [0]; a.length = 8; return a.indexOf(true);`, target)).toBe(-1);
+    });
+
+    it("lastIndexOf on a length-extended empty array returns -1 (no OOB trap)", async () => {
+      expect(await numResult(`const a: any[] = []; a.length = 100; return a.lastIndexOf(true);`, target)).toBe(-1);
+    });
+
+    it("lastIndexOf on a partially-backed sparse array returns -1 (no OOB trap)", async () => {
+      expect(await numResult(`const a: any[] = [0]; a.length = 8; return a.lastIndexOf(true);`, target)).toBe(-1);
+    });
+
+    it("indexOf still finds a present in-bounds element on a sparse array", async () => {
+      // Index 0 is backed with 7; the search must find it before the clamp.
+      expect(await numResult(`const a: any[] = [7]; a.length = 50; return a.indexOf(7);`, target)).toBe(0);
+    });
+
+    it("lastIndexOf still finds a present in-bounds element on a sparse array", async () => {
+      expect(await numResult(`const a: any[] = [7]; a.length = 50; return a.lastIndexOf(7);`, target)).toBe(0);
+    });
+
+    // Regression guards: dense (non-sparse) arrays are unchanged.
+    it("indexOf on a dense array is unchanged", async () => {
+      expect(await numResult(`const a = [10, 20, 30]; return a.indexOf(20);`, target)).toBe(1);
+      expect(await numResult(`const a = [10, 20, 30]; return a.indexOf(99);`, target)).toBe(-1);
+      expect(await numResult(`const a = [5, 5, 5]; return a.indexOf(5, 1);`, target)).toBe(1);
+      expect(await numResult(`const a = [1, 2, 3]; return a.indexOf(3, -1);`, target)).toBe(2);
+    });
+
+    it("lastIndexOf on a dense array is unchanged", async () => {
+      expect(await numResult(`const a = [1, 2, 3, 2]; return a.lastIndexOf(2);`, target)).toBe(3);
+      expect(await numResult(`const a = [1, 2]; return a.lastIndexOf(9);`, target)).toBe(-1);
+      expect(await numResult(`const a = [2, 2, 2]; return a.lastIndexOf(2, 1);`, target)).toBe(1);
+    });
+  });
+}


### PR DESCRIPTION
## What

`compileArrayIndexOf` / `compileArrayLastIndexOf` looped `0 .. vec.length` (the **logical** length, struct field 0) reading `data[i]` with a raw `array.get`. On a **sparse array** — where the logical `.length` was set beyond the physical WasmGC backing array (`a.length = N`, or a high-index write) — `i` passes `array.len(data)` and the raw `array.get` **traps** (`array element access out of bounds`), an uncatchable Wasm trap that aborts the whole program.

Per §23.1.3.14 (indexOf) / §23.1.3.20 (lastIndexOf), which are HasProperty-driven, the absent beyond-backing indices are **skipped** — they can never strict-equal the search value. So the fix clamps the iteration to the backing length:
- **indexOf**: effective bound = `min(logicalLen, array.len(data))`.
- **lastIndexOf**: clamp the reverse-scan start index down to `array.len(data) - 1`.

Pure-sparse searches now return the correct `-1` with **no trap**; dense (non-sparse) arrays are **byte-for-byte unchanged** — the backing capacity is ≥ the logical length, so the clamp is a no-op.

## Why

Part of the #3185 §4 **trap-first mandate** (#3201 acceptance #1): every family-wide trap must become a spec value or a thrown JS error, never a Wasm trap.

## Scope

This lands the indexOf/lastIndexOf sparse-read sub-bucket only. The **dominant remaining** trap causes are separate root causes, documented as follow-ups in the issue: huge sparse-index **writes** (`arr[2**32-2]=v`, traps on the write path densely growing the backing), `Array.prototype` mutation (`illegal cast`), and revoked-Proxy casts (deferred feature).

## Testing

- `tests/issue-3201.test.ts` (standalone lane, 8/8): pure-sparse indexOf/lastIndexOf return `-1` with no trap; in-bounds elements still found; dense arrays unchanged.
- Array suites (`array-methods`, `array-prototype-methods`, `array-oob-bounds-check`, `functional-array-methods`) — no new failures. The two pre-existing fails (`fast-arrays > array find`, `array-oob > destructuring shorter array`) are present on clean main (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8