### PR TITLE
fix(#3201): trap-safe slice/concat on sparse arrays

### DIFF
--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -115,3 +115,29 @@ are NOT the method-read OOB this slice fixes:
 3. **Revoked-Proxy `illegal cast`** (concat/slice `create-revoked-proxy`,
    `is-concat-spreadable-*-revoked`) — Proxy is a deferred feature; the revoked
    handle should surface a TypeError rather than trapping on `ref.cast`.
+
+## Progress — sparse-array structural-copy trap-safety (slice/concat) landed (opus-dstr, 2026-07-13)
+
+Second trap-first slice, following the indexOf/lastIndexOf read-clamp (#2968).
+`slice` and `concat` build their result with `array.copy` over the source range
+`[start, start+len)`. On a sparse array (logical `.length` beyond the physical
+WasmGC backing) that range runs past `array.len(data)` and the `array.copy`
+TRAPS ("array element access out of bounds"). Added `emitBackingClampedCopyLen`
+— a shared helper that clamps each copy COUNT to `clamp(array.len(data) - start,
+0, requestedLen)` while the destination keeps its full logical length (the
+beyond-backing tail stays a default-initialised hole, per the spec's skip of
+absent indices). Applied to `compileArraySliceFromVecLocal` and all three
+`compileArrayConcat` copy sites (0-arg + 1-arg × 2). Pure-sparse `slice()` /
+`concat()` now return a correctly-sized result with no trap (pass-flip);
+in-backing prefixes preserved; dense arrays byte-unchanged (clamp is a no-op).
+Zero array-suite regressions (`tests/issue-3201-slice-concat.test.ts` 8/8; the
+one pre-existing `array-oob-bounds-check > destructuring shorter array` fail is
+unrelated, present on clean main).
+
+Still open in this family (documented above): huge sparse-index WRITES (trap on
+the densely-growing-backing write path), the harness-entangled `Array.prototype`
+mutation `illegal cast` cluster (reproduces only through the full test262
+preamble — not cleanly bounded), revoked-Proxy casts (deferred, #1355/#1472),
+and `includes`/`splice`/`sort`/`pop` sparse reads (includes needs a
+bounds-checked read rather than a loop-clamp because §Array.prototype.includes
+treats absent indices as `undefined` — a follow-up).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -5604,8 +5604,16 @@ export function compileArraySliceFromVecLocal(
   fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
   fctx.body.push({ op: "local.set", index: newData });
 
-  // array.copy newData[0..sliceLen] = data[start..start+sliceLen]
-  emitArrayCopy(fctx, arrTypeIdx, newData, null, dataTmp, startLocal, sliceLenTmp);
+  // (#3201) A sparse array (logical `.length` > physical backing) makes the
+  // copy source range `[start, start+sliceLen)` run past `array.len(data)`, so
+  // the `array.copy` below TRAPS ("array element access out of bounds"). The
+  // result must stay `sliceLen` long — the beyond-backing tail is a hole (spec
+  // skips absent indices), which the default-initialised `newData` already
+  // represents. So copy only the in-backing prefix.
+  const copyLenTmp = emitBackingClampedCopyLen(fctx, dataTmp, startLocal, sliceLenTmp);
+
+  // array.copy newData[0..copyLen] = data[start..start+copyLen] (bounds-safe)
+  emitArrayCopy(fctx, arrTypeIdx, newData, null, dataTmp, startLocal, copyLenTmp);
 
   // struct.new vec { sliceLen, newData }
   fctx.body.push({ op: "local.get", index: sliceLenTmp });
@@ -5613,6 +5621,43 @@ export function compileArraySliceFromVecLocal(
   fctx.body.push({ op: "ref.as_non_null" });
   fctx.body.push({ op: "struct.new", typeIdx: vecTypeIdx });
   return { kind: "ref_null", typeIdx: vecTypeIdx };
+}
+
+/**
+ * (#3201) Emit a copy-count clamped to the SOURCE array's physical backing so a
+ * sparse vec (logical `.length` > `array.len(data)`) never `array.copy`s past
+ * the backing — which traps ("array element access out of bounds"). Returns a
+ * fresh i32 local holding `clamp(array.len(data) - start, 0, requestedLen)`.
+ * The destination array keeps its full `requestedLen` slots; the beyond-backing
+ * tail stays default-initialised (a hole, per the spec's skip of absent
+ * indices). Non-sparse vecs are unaffected (backing capacity ≥ length ⇒ the
+ * clamp == requestedLen). `startLocal === null` means a start offset of 0.
+ */
+function emitBackingClampedCopyLen(
+  fctx: FunctionContext,
+  dataLocal: number,
+  startLocal: number | null,
+  requestedLenLocal: number,
+): number {
+  const out = allocLocal(fctx, `__arr_copyclamp_${fctx.locals.length}`, { kind: "i32" });
+  // avail = array.len(data) - start
+  fctx.body.push({ op: "local.get", index: dataLocal });
+  fctx.body.push({ op: "array.len" });
+  if (startLocal !== null) {
+    fctx.body.push({ op: "local.get", index: startLocal });
+    fctx.body.push({ op: "i32.sub" });
+  }
+  fctx.body.push({ op: "local.set", index: out });
+  emitClampNonNeg(fctx, out); // avail = max(0, avail)
+  // out = min(requestedLen, avail)  (select returns first if cond, else second)
+  fctx.body.push({ op: "local.get", index: requestedLenLocal });
+  fctx.body.push({ op: "local.get", index: out });
+  fctx.body.push({ op: "local.get", index: requestedLenLocal });
+  fctx.body.push({ op: "local.get", index: out });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({ op: "select" });
+  fctx.body.push({ op: "local.set", index: out });
+  return out;
 }
 
 /**
@@ -5649,8 +5694,10 @@ function compileArrayConcat(
     fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
     fctx.body.push({ op: "local.set", index: newData });
 
-    // array.copy newData[0..lenA] = dataA[0..lenA]
-    emitArrayCopy(fctx, arrTypeIdx, newData, null, dataA, null, lenA);
+    // array.copy newData[0..lenA] = dataA[0..lenA] — (#3201) copy count clamped
+    // to the backing so a sparse receiver (lenA > array.len(dataA)) doesn't trap.
+    const catCopyLenA0 = emitBackingClampedCopyLen(fctx, dataA, null, lenA);
+    emitArrayCopy(fctx, arrTypeIdx, newData, null, dataA, null, catCopyLenA0);
 
     // Create new vec struct: { lenA, newData }
     fctx.body.push({ op: "local.get", index: lenA });
@@ -5725,11 +5772,16 @@ function compileArrayConcat(
   fctx.body.push({ op: "array.new_default", typeIdx: arrTypeIdx });
   fctx.body.push({ op: "local.set", index: newData });
 
-  // array.copy newData[0..lenA] = dataA[0..lenA]
-  emitArrayCopy(fctx, arrTypeIdx, newData, null, dataA, null, lenA);
+  // array.copy newData[0..lenA] = dataA[0..lenA] — (#3201) clamp both copy
+  // counts to each source's backing so a sparse operand (logical length >
+  // array.len(data)) doesn't array.copy past the backing (which traps). The
+  // destination keeps totalLen slots; beyond-backing tails stay default holes.
+  const catCopyLenA = emitBackingClampedCopyLen(fctx, dataA, null, lenA);
+  emitArrayCopy(fctx, arrTypeIdx, newData, null, dataA, null, catCopyLenA);
 
   // array.copy newData[lenA..lenA+lenB] = dataB[0..lenB]
-  emitArrayCopy(fctx, arrTypeIdx, newData, lenA, dataB, null, lenB);
+  const catCopyLenB = emitBackingClampedCopyLen(fctx, dataB, null, lenB);
+  emitArrayCopy(fctx, arrTypeIdx, newData, lenA, dataB, null, catCopyLenB);
 
   // Create new vec struct: { totalLen, newData }
   fctx.body.push({ op: "local.get", index: totalLen });

--- a/tests/issue-3201-slice-concat.test.ts
+++ b/tests/issue-3201-slice-concat.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3201 (slice 2) — Array.prototype structural-copy trap-safety on sparse arrays.
+ *
+ * Follow-up to the indexOf/lastIndexOf sparse-read fix (PR #2968). `slice` and
+ * `concat` build their result with `array.copy` over the source range
+ * `[start, start+len)`. On a sparse array — logical `.length` set beyond the
+ * physical WasmGC backing (`a.length = N`, or a high-index write) — that range
+ * runs past `array.len(data)` and the `array.copy` TRAPS ("array element access
+ * out of bounds"), an uncatchable Wasm trap that aborts the whole program (the
+ * #3185 §4 trap-first mandate).
+ *
+ * The fix (`emitBackingClampedCopyLen`) clamps the copy COUNT to the source's
+ * physical backing while keeping the result its full logical length — the
+ * beyond-backing tail stays a default-initialised hole (spec skips absent
+ * indices in the copy). Pure-sparse `slice()`/`concat()` now return a correctly
+ * sized result with no trap; dense arrays are byte-unchanged (backing capacity ≥
+ * length ⇒ the clamp is a no-op).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function numResult(body: string, target?: "standalone"): Promise<number> {
+  const src = `export function test(): number {\n${body}\n}`;
+  const r = await compile(src, { fileName: "issue-3201-slice-concat.ts", target, skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+for (const target of ["standalone"] as const) {
+  describe(`#3201 slice/concat trap-safety on sparse arrays (${target})`, () => {
+    // --- slice ---
+    it("slice() on a length-extended empty array keeps the length (no OOB trap)", async () => {
+      expect(await numResult(`const a: any[] = []; a.length = 5; return a.slice().length;`, target)).toBe(5);
+    });
+
+    it("slice() on a partially-backed sparse array keeps the length", async () => {
+      expect(await numResult(`const a: any[] = [0]; a.length = 3; return a.slice().length;`, target)).toBe(3);
+    });
+
+    it("slice() preserves the in-backing prefix on a sparse array", async () => {
+      expect(
+        await numResult(`const a: any[] = [9]; a.length = 4; const s = a.slice(); return s[0] === 9 ? 1 : 0;`, target),
+      ).toBe(1);
+    });
+
+    it("slice(start,end) on a dense array is unchanged", async () => {
+      expect(await numResult(`return [1, 2, 3, 4].slice(1, 3).length;`, target)).toBe(2);
+      expect(await numResult(`return [1, 2, 3, 4].slice(1, 3)[0];`, target)).toBe(2);
+      expect(await numResult(`return [1, 2, 3, 4, 5].slice(-2).length;`, target)).toBe(2);
+      expect(await numResult(`return [5, 6, 7].slice().length;`, target)).toBe(3);
+    });
+
+    // --- concat (0-arg shallow copy) ---
+    it("concat() on a length-extended empty array keeps the length (no OOB trap)", async () => {
+      expect(await numResult(`const a: any[] = []; a.length = 4; return a.concat().length;`, target)).toBe(4);
+    });
+
+    it("concat() preserves the in-backing prefix on a sparse array", async () => {
+      expect(
+        await numResult(
+          `const a: any[] = [7]; a.length = 3; const c = a.concat(); return (c.length === 3 && c[0] === 7) ? 1 : 0;`,
+          target,
+        ),
+      ).toBe(1);
+    });
+
+    it("concat() (0-arg) on a dense array is unchanged", async () => {
+      expect(await numResult(`return [1, 2, 3].concat().length;`, target)).toBe(3);
+      expect(await numResult(`return [1, 2, 3].concat()[2];`, target)).toBe(3);
+    });
+
+    // --- concat (1-arg, matching vec type) ---
+    it("concat(arr) on dense arrays is unchanged", async () => {
+      expect(await numResult(`return [1, 2].concat([3, 4]).length;`, target)).toBe(4);
+      expect(await numResult(`return [1, 2].concat([3, 4])[3];`, target)).toBe(4);
+    });
+  });
+}


### PR DESCRIPTION
## What

Second trap-first slice for #3201, following the indexOf/lastIndexOf read-clamp ([#2968](https://github.com/loopdive/js2/pull/2968)).

`slice` and `concat` build their result with `array.copy` over the source range `[start, start+len)`. On a **sparse array** — logical `.length` set beyond the physical WasmGC backing (`a.length = N`, or a high-index write) — that range runs past `array.len(data)` and the `array.copy` **traps** (`array element access out of bounds`), an uncatchable Wasm trap that aborts the whole program.

Added `emitBackingClampedCopyLen`, a shared helper that clamps each copy **count** to `clamp(array.len(data) - start, 0, requestedLen)` while the destination keeps its full logical length — the beyond-backing tail stays a default-initialised hole (spec skips absent indices in the copy). Applied to `compileArraySliceFromVecLocal` and all three `compileArrayConcat` copy sites (0-arg + 1-arg × 2).

Pure-sparse `slice()`/`concat()` now return a correctly-sized result with **no trap** (pass-flip); in-backing prefixes are preserved; dense arrays are **byte-unchanged** (backing capacity ≥ length ⇒ the clamp is a no-op).

## Why

Part of the #3185 §4 **trap-first mandate** (#3201 acceptance #1): every family-wide trap must become a spec value or a thrown JS error, never a Wasm trap — so the test262 abrupt-completion harness can continue and whole tests can flip to PASS.

## Scope / follow-ups (documented in the issue)

Still open in this family: huge sparse-index **writes** (trap on the densely-growing-backing write path); the harness-entangled `Array.prototype` mutation `illegal cast` cluster (reproduces only through the full test262 preamble — not cleanly bounded); revoked-Proxy casts (deferred, #1355/#1472); and `includes`/`splice`/`sort`/`pop` sparse reads (`includes` needs a bounds-checked read rather than a loop-clamp because it treats absent indices as `undefined`).

## Testing

- `tests/issue-3201-slice-concat.test.ts` (standalone lane, 8/8): pure-sparse `slice()`/`concat()` keep length with no trap; in-backing prefixes preserved; dense slice/concat unchanged.
- Array suites (`array-methods`, `array-prototype-methods`, `array-oob-bounds-check`, `functional-array-methods`) — no new failures; the one pre-existing `array-oob > destructuring shorter array` fail is present on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8