### PR TITLE
fix(#2903): standalone R1 — native new Promise(value executor)

### DIFF
--- a/plan/issues/2903-standalone-make-callback-residual-rootcause.md
+++ b/plan/issues/2903-standalone-make-callback-residual-rootcause.md
@@ -377,7 +377,41 @@ sequencing lives in umbrella **#3178**.
 
 What remains HERE, ranked, each a bounded PR:
 
-### R1 — `new Promise(NON-inline executor)` (fable-executable-now, S)
+### R1 — `new Promise(NON-inline executor)` — LANDED (opus-r3, 2026-07-13)
+
+**PR:** `issue-2903-r1-promise-executor`. Retires the `Promise_new` +
+`__make_callback` + `Promise_then` leak for a value/param-held executor.
+
+**The lowering** (`emitStandalonePromiseFromExecutorValue`, promise-executor.ts;
+wired in new-super.ts between the inline path and the host fallthrough): when the
+executor arg is NOT a syntactic inline arrow/function-expression (so the inline
+`ClosureInfo`-based `call_ref` path declines), invoke the runtime closure value
+through the open-`any` bridge `__apply_closure(exec, undefined, [resolve,
+reject])` (arity-clamps per #2939). Allocates the pending `$Promise`, builds the
+two capturing settle closures via the shared `ensurePromiseExecutorClosures`,
+runs the executor synchronously inside a try/catch (throw-before-settle →
+`reject`), returns the `$Promise`. Does NOT set `moduleHasHostPromiseSource`, so
+the then-bridge de-leak applies. Standalone/WASI only; gc/host lane keeps
+`Promise_new` byte-unchanged (verified).
+
+**Proofs** (`tests/issue-2903-r1.test.ts`, 7): const-held + PARAM-held executor
+resolve (11, 13), reject routing (4), executor-throw→reject (8), single-param
+executor (7) — all host-free (`env` imports `[]`, bare `{}` instantiate); inline
+path unchanged (42); gc lane keeps `Promise_new`. issue-1326 + issue-2903
+(25 tests) green.
+
+**Boundary (documented, separate follow-up — NOT an R1 regression)**: the
+cross-function shape `function make(ex){ return new Promise(ex); }` consumed via
+a `.then` in a DIFFERENT function delivers the wrong value (NaN / fulfilled-not-
+rejected) — the promise is created in one function and the `make(...)` call is
+async-call-WRAPPED (`isAsyncCallExpression`/`wrapAsyncCallInTryCatch`), whose
+adoption of the returned native `$Promise` is the gap. This is the
+async-call-wrap machinery, not the executor lowering; on main this shape LEAKED
+(un-instantiable host-free) so there is no standalone `host_free_pass`
+regression — it moves from leaky-fail to host-free-fail. The in-scope executor
+cases (the R1 core) are fully correct.
+
+--- (original R1 plan below) ---
 
 Probe: `function make(ex){ return new Promise(ex); } make((res)=>res(42))`
 leaks `Promise_new + __make_callback + Promise_then`.
@@ -429,11 +463,53 @@ passes + the `Iterator/prototype/{map,filter,take,drop,flatMap}` fail
 directories (~250 files; tree currently 92/373 post-sub-front-2). Follow the
 iter-hof-native.ts reserve-then-fill discipline (#1719) exactly.
 
-### R4 — TypedArray callback methods (sub-front 4, fable-executable-now, S)
+### R4 — TypedArray callback methods (sub-front 4)
 
 `Uint8ClampedArray_find + __make_callback` style leaks (~5 rows) + fail rows.
 Native %TypedArray% HOF bodies invoking via `call_ref` — same pattern as the
 vec HOF arm; ground in `closed-method-dispatch.ts` + the #2651 family.
+
+#### R4 grounding (opus-r3, 2026-07-13) — bigger than "S", dispatch-selection
+
+Measured on current main (`--target standalone`). The premise "add native
+%TypedArray% HOF bodies" is directionally right but R4 is **not a bounded
+carrier-admission add** — it is a **dispatch-SELECTION** issue in the
+`%TypedArray%.prototype` proto glue:
+
+- `(u8 as any).forEach(cb)` / `.find(cb)` — the callback **never drives**:
+  `find` returns `0` (should find the element), `forEach` leaves a captured var
+  at `0`, `filter` returns the **receiver unchanged** (length passthrough, not
+  the filtered result). NOT a capture-writeback issue — `find` has no capture
+  and still fails.
+- **Plain `any` arrays work** (`[1,2,3] as any`.forEach/find → correct via the
+  #3098 native `__hof_*` arm). **`Array.from(u8)` then `.find` works.** So the
+  native HOF machinery is fine; the typed-array value doesn't reach it.
+- Carriers are `$__vec_i8_byte` / `$__subview_i8_byte` — **both
+  `$__vec_base`-subtyped** (so `ref.test $__vec_base` in the #3098 arm SHOULD
+  match) — and `__extern_get_idx` / `__extern_length` on the typed `any`
+  **read correctly** (`b[0]` = 5, `.length` = 3). So neither the carrier test
+  nor the element reads are the gap.
+- The break is that a typed-array-typed receiver's `.forEach`/`.find` (even
+  cast to `any`) routes to the `%TypedArray%.prototype` **proto glue**
+  (`array-object-proto.ts`, the `emitProtoMemberBodyRefusal` family — filter/
+  find/forEach/map are in its member sets at lines ~335-346) which degrades to a
+  refusal/identity stub instead of the generic `__call_m_*` / `__hof_*` path —
+  exactly the same shape as the Iterator/Promise proto-refusal root cause in the
+  TL;DR. `filter` returning the receiver is the identity-stub signature.
+- **Separately**, the STATICALLY-typed `a.forEach(cb)` (no `as any`) leaks
+  `env.__make_callback` — a second, distinct routing bug on the typed path.
+
+**Fix shape for whoever picks R4 up**: implement the native
+`%TypedArray%.prototype` HOF bodies (find/findIndex/findLast*/forEach/some/
+every/reduce/reduceRight — scalar/undefined returns) in the proto glue, driving
+via the already-working `__extern_get_idx`/`__extern_length` + `__apply_closure`
+(mirror `__hof_*` / the eager `__iter_hof_*` bodies), and route the typed
+callback path there instead of the refusal stub / `__make_callback`. `map`/
+`filter` need typed-RESULT construction (a new typed vec with element-width
+wrapping per #2593) — split as **R4b**. Note: WAT symbolic-name grep is
+unreliable for confirming the runtime call target (numeric `call N` encoding,
+per the TL;DR trap) — use runtime instrumentation or read the proto-glue member
+routing directly.
 
 ### NOT this issue (re-affirmed)
 

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -85,7 +85,7 @@ import {
 import { localGlobalIdx } from "../registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { emitFnctorProtoGet } from "./fnctor-prototype.js"; // (#2660 S3a) reconstruct `new F()` as $Object
-import { emitStandalonePromiseFromExecutor } from "../promise-executor.js"; // (#2959) native new Promise(executor)
+import { emitStandalonePromiseFromExecutor, emitStandalonePromiseFromExecutorValue } from "../promise-executor.js"; // (#2959 / #2903 R1) native new Promise(executor)
 import { deriveFnctorFields, resolveFnctorSymbol, resolveEnclosingFnctorOwner } from "../fnctor-escape-gate.js"; // (#2660 S3a) canonical fnctor-name key; (#2773 S1) shared field derivation; (#2681/#2686 A1) `new this()` owner
 import { funcSignatureOf, mintDefinedFunc, pushDefinedFunc } from "../func-space.js"; // (#1916 S2 read chokepoint / S3b stable-regime minting)
 
@@ -3027,6 +3027,26 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       !ctx.classSet.has("Promise") &&
       resolvesToAmbientGlobal(ctx, expr.expression) &&
       emitStandalonePromiseFromExecutor(ctx, fctx, promiseArgs[0]!)
+    ) {
+      return { kind: "externref" };
+    }
+    // (#2903 R1) Native path for a NON-inline executor VALUE (identifier / param
+    // / any runtime closure) — invoked through `__apply_closure` since its
+    // concrete closure type isn't recoverable at compile time. Tried only when
+    // the inline path above declined AND the executor arg is not a syntactic
+    // arrow/function-expression (those are the inline path's domain). Retires the
+    // `Promise_new` + `__make_callback` leak for `make(ex)=>new Promise(ex)`.
+    if (
+      promiseArgs.length >= 1 &&
+      !ctx.classSet.has("Promise") &&
+      resolvesToAmbientGlobal(ctx, expr.expression) &&
+      !ts.isArrowFunction(promiseArgs[0]!) &&
+      !ts.isFunctionExpression(promiseArgs[0]!) &&
+      emitStandalonePromiseFromExecutorValue(ctx, fctx, () => {
+        const t = compileExpression(ctx, fctx, promiseArgs[0]!, { kind: "externref" });
+        if (t && t.kind !== "externref") coerceType(ctx, fctx, t, { kind: "externref" });
+        else if (t === null) fctx.body.push({ op: "ref.null.extern" });
+      })
     ) {
       return { kind: "externref" };
     }

--- a/src/codegen/promise-executor.ts
+++ b/src/codegen/promise-executor.ts
@@ -38,6 +38,8 @@ import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/typ
 import { ensureExnTag } from "./registry/imports.js";
 import { coerceType, emitGuardedFuncRefCast, pushDefaultValue } from "./type-coercion.js";
 import { emitNullCheckThrow } from "./property-access.js";
+import { ensureObjectRuntime, reserveApplyClosure } from "./object-runtime.js";
+import { addUnionImportsViaRegistry } from "./shared.js";
 import {
   PROMISE_STATE_PENDING,
   // (#3125) `ensurePromiseExecutorClosures` + its interface moved to
@@ -200,6 +202,120 @@ export function emitStandalonePromiseFromExecutor(
   } as Instr);
 
   // 6. Result: the pending/settled $Promise as externref.
+  fctx.body.push({ op: "local.get", index: pLocal });
+  fctx.body.push({ op: "extern.convert_any" });
+  return true;
+}
+
+/**
+ * #2903 R1 — native standalone `new Promise(executorVALUE)` where the executor
+ * is NOT a syntactic inline arrow/function-expression (an identifier / param /
+ * any runtime closure value), so {@link emitStandalonePromiseFromExecutor}'s
+ * `ClosureInfo`-based `call_ref` cannot apply. Instead of recovering the
+ * executor's concrete closure struct type at compile time, we invoke the
+ * runtime value through the open-`any` closure bridge `__apply_closure(exec,
+ * undefined, [resolve, reject])` (arity-clamping per #2939), which dispatches
+ * ANY closure struct shape natively — retiring the `Promise_new` +
+ * `__make_callback` host leak for `function make(ex){ return new Promise(ex); }`
+ * and `const ex = (r)=>r(x); new Promise(ex)` shapes.
+ *
+ * `compileExecutorValue` is a caller-provided thunk that leaves the executor as
+ * an externref on `fctx.body` (kept as a callback to avoid an eval-time import
+ * cycle with expressions.ts). Returns `true` having emitted the native path
+ * (leaving an externref `$Promise` on the stack); `false` — emitting NOTHING —
+ * when inapplicable (host/gc mode, deps unavailable), so the caller falls
+ * through to the `Promise_new` host path byte-unchanged.
+ *
+ * BOUNDARY: a non-callable executor value is dispatched through
+ * `__apply_closure` (which no-ops / returns undefined on a non-closure) rather
+ * than throwing the spec §27.2.3.1-step-2 TypeError — the same no-throw
+ * discipline as the other #2903 native bodies; the promise simply stays pending.
+ */
+export function emitStandalonePromiseFromExecutorValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  compileExecutorValue: () => void,
+): boolean {
+  if (!isStandalonePromiseActive(ctx)) return false;
+
+  const exnTag = ensureExnTag(ctx);
+  const closures = ensurePromiseExecutorClosures(ctx);
+  if (!closures) return false;
+  const { resolveClFuncIdx, rejectClFuncIdx, capTypeIdx, promiseTypeIdx, rejectFuncIdx } = closures;
+
+  // Open-`any` closure bridge + the boxed-any args vec builders.
+  ensureObjectRuntime(ctx);
+  addUnionImportsViaRegistry(ctx);
+  const applyClosureIdx = reserveApplyClosure(ctx);
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new");
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  if (applyClosureIdx === undefined || objVecNewIdx === undefined || objVecPushIdx === undefined) return false;
+
+  // 1. Compile the executor VALUE to externref, into a local (runs any side
+  //    effects of the executor expression exactly once, before the invoke).
+  const execLocal = allocLocal(fctx, `__pexecv_fn_${fctx.locals.length}`, { kind: "externref" });
+  compileExecutorValue();
+  fctx.body.push({ op: "local.set", index: execLocal });
+
+  // 2. Allocate the pending $Promise.
+  const pLocal = allocLocal(fctx, `__pexecv_p_${fctx.locals.length}`, { kind: "ref", typeIdx: promiseTypeIdx });
+  fctx.body.push({ op: "i32.const", value: PROMISE_STATE_PENDING });
+  fctx.body.push({ op: "ref.null.extern" });
+  fctx.body.push({ op: "ref.null.extern" });
+  fctx.body.push({ op: "struct.new", typeIdx: promiseTypeIdx });
+  fctx.body.push({ op: "local.set", index: pLocal });
+
+  // 3. resolve / reject as capturing closure VALUES (externref), capturing p.
+  const emitSettleValue = (clFuncIdx: number, dst: number): void => {
+    fctx.body.push({ op: "ref.func", funcIdx: clFuncIdx });
+    fctx.body.push({ op: "local.get", index: pLocal });
+    fctx.body.push({ op: "struct.new", typeIdx: capTypeIdx });
+    fctx.body.push({ op: "extern.convert_any" });
+    fctx.body.push({ op: "local.set", index: dst });
+  };
+  const rvLocal = allocLocal(fctx, `__pexecv_rv_${fctx.locals.length}`, { kind: "externref" });
+  emitSettleValue(resolveClFuncIdx, rvLocal);
+  const rjLocal = allocLocal(fctx, `__pexecv_rj_${fctx.locals.length}`, { kind: "externref" });
+  emitSettleValue(rejectClFuncIdx, rjLocal);
+
+  // 4. Invoke the executor synchronously via __apply_closure(exec, undefined,
+  //    [resolve, reject]) inside try/catch; a throw-before-settle rejects p.
+  const reasonLocal = allocLocal(fctx, `__pexecv_reason_${fctx.locals.length}`, { kind: "externref" });
+  const argsLocal = allocLocal(fctx, `__pexecv_args_${fctx.locals.length}`, { kind: "externref" });
+  const tryBody: Instr[] = [
+    { op: "call", funcIdx: objVecNewIdx } as Instr,
+    { op: "local.set", index: argsLocal } as Instr,
+    { op: "local.get", index: argsLocal } as Instr,
+    { op: "local.get", index: rvLocal } as Instr,
+    { op: "call", funcIdx: objVecPushIdx } as Instr,
+    { op: "local.get", index: argsLocal } as Instr,
+    { op: "local.get", index: rjLocal } as Instr,
+    { op: "call", funcIdx: objVecPushIdx } as Instr,
+    { op: "local.get", index: execLocal } as Instr,
+    { op: "ref.null.extern" } as Instr, // undefined `this`
+    { op: "local.get", index: argsLocal } as Instr,
+    { op: "call", funcIdx: applyClosureIdx } as Instr,
+    { op: "drop" } as Instr, // executor return value is ignored (§27.2.3.1)
+  ];
+  fctx.body.push({
+    op: "try",
+    blockType: { kind: "empty" },
+    body: tryBody,
+    catches: [
+      {
+        tagIdx: exnTag,
+        body: [
+          { op: "local.set", index: reasonLocal } as Instr,
+          { op: "local.get", index: pLocal } as Instr,
+          { op: "local.get", index: reasonLocal } as Instr,
+          { op: "call", funcIdx: rejectFuncIdx } as Instr,
+          { op: "drop" } as Instr,
+        ],
+      },
+    ],
+  } as Instr);
+
+  // 5. Result: the pending/settled $Promise as externref.
   fctx.body.push({ op: "local.get", index: pLocal });
   fctx.body.push({ op: "extern.convert_any" });
   return true;

--- a/tests/issue-2903-r1.test.ts
+++ b/tests/issue-2903-r1.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2903 R1 — native standalone `new Promise(executorVALUE)` where the executor
+// is NOT a syntactic inline arrow/function-expression (an identifier / param /
+// any runtime closure value).
+//
+// The inline path (#2959, `emitStandalonePromiseFromExecutor`) needs the
+// executor arrow's `ClosureInfo` to `call_ref` it. A value/param-held executor
+// has no recoverable ClosureInfo, so on main it fell to the `Promise_new` host
+// import (+ `__make_callback` + `Promise_then`) — un-instantiable host-free.
+//
+// R1 invokes the runtime executor value through the open-`any` closure bridge
+// `__apply_closure(exec, undefined, [resolve, reject])` instead, retiring the
+// host leak. The `resolve`/`reject` settle closures + throw-before-settle
+// rejection are shared with the inline path.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const DRAIN = "declare function __drain_microtasks(): void;\n";
+
+async function runHostFree(source: string): Promise<number> {
+  const result = await compile(DRAIN + source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success).toBe(true);
+  const mod = await WebAssembly.compile(result.binary!);
+  const envImports = WebAssembly.Module.imports(mod).filter((i) => i.module === "env");
+  expect(envImports).toEqual([]); // host-free: no Promise_new / __make_callback / Promise_then
+  const { instance } = await WebAssembly.instantiate(result.binary!, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2903 R1 — new Promise(value executor) is host-free and correct", () => {
+  it("resolves via a const-held executor", async () => {
+    expect(
+      await runHostFree(
+        `export function test(): number {
+           const ex = (res: any) => res(11);
+           const p = new Promise(ex);
+           let v = 0; p.then((x: any) => { v = x; });
+           __drain_microtasks(); return v;
+         }`,
+      ),
+    ).toBe(11);
+  });
+
+  it("resolves via a PARAM-held executor (the core R1 shape)", async () => {
+    expect(
+      await runHostFree(
+        `function run(ex: any): number {
+           const p = new Promise(ex);
+           let v = 0; p.then((x: any) => { v = x; });
+           __drain_microtasks(); return v;
+         }
+         export function test(): number { return run((res: any) => res(13)); }`,
+      ),
+    ).toBe(13);
+  });
+
+  it("routes a rejected value-executor through onRejected", async () => {
+    expect(
+      await runHostFree(
+        `export function test(): number {
+           const ex = (res: any, rej: any) => rej(4);
+           const p = new Promise(ex);
+           let v = 0; p.then((x: any) => { v = 1; }, (e: any) => { v = e; });
+           __drain_microtasks(); return v;
+         }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("an executor that throws before settling rejects the promise", async () => {
+    expect(
+      await runHostFree(
+        `export function test(): number {
+           const ex = (res: any, rej: any) => { throw 8; };
+           const p = new Promise(ex);
+           let v = 0; p.then((x: any) => { v = 1; }, (e: any) => { v = e; });
+           __drain_microtasks(); return v;
+         }`,
+      ),
+    ).toBe(8);
+  });
+
+  it("a single-param executor (reject ignored) still resolves", async () => {
+    expect(
+      await runHostFree(
+        `export function test(): number {
+           const ex = (res: any) => res(7);
+           const p = new Promise(ex);
+           let v = 0; p.then((x: any) => { v = x; });
+           __drain_microtasks(); return v;
+         }`,
+      ),
+    ).toBe(7);
+  });
+});
+
+describe("#2903 R1 — other lanes unaffected", () => {
+  it("inline executor path is unchanged (still native, host-free)", async () => {
+    expect(
+      await runHostFree(
+        `export function test(): number {
+           const p = new Promise((res: any) => res(42));
+           let v = 0; p.then((x: any) => { v = x; });
+           __drain_microtasks(); return v;
+         }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("gc/host lane keeps the Promise_new host import for a value executor", async () => {
+    const result = await compile(
+      `function make(ex: any) { return new Promise(ex); }
+       export function test(): number { const p = make((res: any) => res(1)); return 1; }`,
+      { fileName: "test.ts", skipSemanticDiagnostics: true },
+    );
+    expect(result.success).toBe(true);
+    const mod = await WebAssembly.compile(result.binary!);
+    const names = WebAssembly.Module.imports(mod)
+      .filter((i) => i.module === "env")
+      .map((i) => i.name);
+    expect(names).toContain("Promise_new"); // gc lane byte-unchanged (host executor path)
+  });
+});


### PR DESCRIPTION
## Sub-front R1 of #2903 — `new Promise(NON-inline executor)` (standalone host-free)

Retires the `Promise_new` + `__make_callback` + `Promise_then` leak for a
value/param-held Promise executor (identifier / param / any runtime closure),
where the inline path (#2959, `ClosureInfo` `call_ref`) can't apply.

### The lowering
New `emitStandalonePromiseFromExecutorValue` (`promise-executor.ts`), wired in
`new-super.ts` between the inline path and the `Promise_new` host fallthrough:
when the executor arg isn't a syntactic inline arrow/fn-expr, invoke the runtime
closure value through the open-`any` bridge
`__apply_closure(exec, undefined, [resolve, reject])` (arity-clamps per #2939).
Allocates the pending `$Promise`, builds the capturing `resolve`/`reject` settle
closures via the shared `ensurePromiseExecutorClosures`, runs the executor
synchronously in try/catch (throw-before-settle → `reject`), returns the
`$Promise`. Does NOT set `moduleHasHostPromiseSource`, so the then-bridge de-leak
applies. Standalone/WASI only; gc/host keeps `Promise_new` byte-unchanged.

### Validation
- `tests/issue-2903-r1.test.ts` (7): const + **PARAM-held** executor resolve
  (11, 13), reject routing (4), executor-throw→reject (8), single-param (7) —
  all **host-free** (`env` imports `[]`, bare `{}` instantiate); inline path
  unchanged (42); gc lane keeps `Promise_new`.
- `issue-1326` + `issue-2903` (25 tests) green.
- Broad-impact standalone → merge_group standalone floor is the decider.

Also persists the **R4 grounding** (typed-array HOF dispatch-selection bug —
bigger than the assumed "S") into the #2903 issue for the next picker-up.

### Boundary (documented, separate follow-up — NOT an R1 regression)
Cross-function `function make(ex){ return new Promise(ex); }` consumed via a
`.then` in another function delivers the wrong value — the `make(...)` call is
async-call-**wrapped** and its adoption of the returned native `$Promise` is the
gap (async-call-wrap machinery, not the executor lowering). On main this shape
LEAKED (un-instantiable host-free), so there's no standalone `host_free_pass`
regression; the in-scope executor cases (the R1 core) are fully correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)