### PR TITLE
fix(#3207): async-gen implicit yield-await (§27.6.3.8) for PromiseLike operands

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -1009,3 +1009,27 @@ the gen body / `yield*` / nested-yield (shared with 3d-i′); forward-referenced
 const/arrow-held async gens (the gate is bounded to direct named-function calls);
 `break`/`continue`/`try` in the consumer loop body (abrupt close via `it.return()`).
 Issue stays `in-progress` for 3d-iii + the slice-1d carrier widen.
+
+## Slice 3d-iii(a) — implicit yield-await §27.6.3.8 for PromiseLike operands (LANDED → #3207)
+
+**What shipped (host-free wasi lane).** §27.6.3.8 `AsyncGeneratorYield` awaits ANY
+thenable, not only the `Promise` builtin. #3120 landed the static classifier for
+`Promise`-typed / union-with-Promise plain `yield E`; #3207 extends
+`yieldOperandIsPromiseTyped` (async-cps.ts) to also recognise a `PromiseLike<T>`-typed
+operand (a structural thenable), routing it through the same
+suspend+`settleYield(fromSent)` lane. Verified: `const t: PromiseLike<number> =
+Promise.resolve(5); yield t` delivers `5` (was NaN — the un-awaited thenable object).
+Correct-or-inert (a non-native thenable fails the suspend's `ref.test $Promise` and
+falls through to the pre-fix raw-yield delivery). Byte-inertness A/B: exactly ONE hash
+changed (`promiseLikeYield wasi`); all gc/standalone + every other wasi program
+identical. Tests in `tests/issue-3207-asyncgen-yield-promiselike.test.ts`.
+
+**Banked (higher-value, blocked BELOW this lane).** The dominant residual §27.6.3.8
+gap is a **native-`$Promise` value-representation bug**, not a classifier issue: a
+`$Promise` that flows through a user-function return (`yield mk()`) or a Promise-typed
+local (`const pv = mk(); yield pv`) loses its native struct identity (the suspend's
+`ref.test $Promise` fails → delivered raw → NaN), while `yield await mk()` → 5 works.
+This is the native-`$Promise` identity-preservation family (cf. #3134), below the
+async-frame lane — the yield-await classifier cannot reach it. `any`-typed runtime
+thenables need a runtime thenable probe in the settle arm (the #3120 follow-up).
+Issue stays `in-progress` for the remaining 3d-iii edges + the slice-1d carrier widen.

--- a/plan/issues/3207-asyncgen-yield-promiselike-await.md
+++ b/plan/issues/3207-asyncgen-yield-promiselike-await.md
@@ -1,0 +1,107 @@
+---
+id: 3207
+title: "Standalone async-gen: implicit yield-await (§27.6.3.8) for PromiseLike-typed operands"
+status: done
+assignee: ttraenkler/opus-asyncgen
+created: 2026-07-13
+completed: 2026-07-13
+priority: medium
+feasibility: medium
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: s
+related: [3120, 2906, 2865]
+umbrella: 2906
+loc-budget-allow:
+  - src/codegen/async-cps.ts
+---
+
+# Async-generator implicit yield-await (§27.6.3.8) for PromiseLike operands
+
+## Problem
+
+§27.6.3.8 `AsyncGeneratorYield(value)` runs `value = ? Await(value)` — a plain
+`yield <E>` in an async generator implicitly **awaits any thenable** before
+yielding it, not only the `Promise` builtin. #3120 landed the static classifier
+(`yieldOperandIsPromiseTyped`) that routes a `Promise`-typed (or
+union-with-Promise) plain `yield E` through the SAME suspend+`settleYield(fromSent)`
+lane as `yield await E`. But it recognised **only** the `Promise` builtin (via the
+receiver heuristic) + unions containing it.
+
+A **`PromiseLike<T>`-typed operand** — a structural thenable — was classified
+PLAIN, so the un-awaited thenable was yielded verbatim and the consumer saw the
+promise OBJECT rather than the resolved value.
+
+Measured on the host-free wasi drive lane (`.tmp/probe-reconcile.mts`), before this
+fix:
+
+```
+yield t   // t: PromiseLike<number> = Promise.resolve(5)   → value NaN (promise object yielded)
+yield await t                                              → value 5   (explicit await works)
+```
+
+## Fix
+
+Extend `yieldOperandIsPromiseTyped` (async-cps.ts) to also classify a
+`PromiseLike<T>`-typed operand as implicit-yield-await (one line +
+`oracle.declaredNameOf(operand) === "PromiseLike"`). After the fix, `yield t`
+delivers `5`, matching `yield await t`.
+
+**Correct-or-inert (the #2367 graveyard rule).** When the PromiseLike operand is
+backed by a native `$Promise` at runtime, the suspend arm's `ref.test $Promise`
+succeeds and adopts it (delivering the resolved value). A NON-native thenable
+fails that `ref.test` and falls through to the plain delivery — the **exact pre-fix
+raw-yield behaviour** — so no shape regresses.
+
+## Scope / carrier gating
+
+The implicit-yield-await classifier is invoked **only** on the native-`$Promise`
+carrier lane (`isStandalonePromiseActive`, wasi-only for async-gen modules — the
+`widenAsyncGenFallback` keeps standalone async-gen on the host lane). So gc + host
++ standalone stay byte-identical; only the wasi native drive lane changes, and only
+for a PromiseLike-typed yield operand.
+
+## Byte-inertness proof (the −16/−29 discipline)
+
+sha256 of 6 programs × {gc, standalone, wasi}, WITH vs WITHOUT the one-line fix
+(`.tmp/hash-lanes.mts`, self-restoring A/B). **Exactly one** hash changed:
+
+| program            | gc        | standalone | wasi                       |
+| ------------------ | --------- | ---------- | -------------------------- |
+| plainGen           | identical | identical  | identical                  |
+| awaitYield         | identical | identical  | identical                  |
+| promiseYield       | identical | identical  | identical                  |
+| **promiseLikeYield** | identical | identical  | **CHANGED** (intended unlock) |
+| plainAsync         | identical | identical  | identical                  |
+| plainSync          | identical | identical  | identical                  |
+
+Every gc + standalone lane is byte-identical; every wasi lane EXCEPT a
+PromiseLike-typed async-gen yield is byte-identical.
+
+## Verification
+
+`tests/issue-3207-asyncgen-yield-promiselike.test.ts` (4 host-free wasi tests: the
+settled-PromiseLike proof → 5; the genuinely-pending PromiseLike drain proof
+(suspends at kick, resumes to 42); a mixed PromiseLike-then-plain sequence; and a
+plain-yield parity guard). The async-gen blast radius (2906-3a/3b/3d-i/3d-ii/
+multiawait, 3120, async-await, async-census, generators, 1042, 2895) shows the
+SAME pre-existing failure set as `origin/main` (verified on the base checkout: the
+3× gap3-tryfinally throw-path, 2× issue-2865 AG0-wasi harness, and 6× issue-1672
+AsyncFromSyncIterator failures are all pre-existing, byte-identical to base since
+those programs are not PromiseLike-yields). `tsc --noEmit` clean.
+
+## Banked follow-up intel (higher-value, blocked BELOW the async-frame lane)
+
+The dominant residual §27.6.3.8 gap is NOT a classifier issue: a native `$Promise`
+that flows through a **user-function return** (`yield mk()` where
+`mk(): Promise<number>`) or a **Promise-typed local** (`const pv = mk(); yield pv`)
+loses its native `$Promise` struct identity — the suspend's `ref.test $Promise`
+fails → the value is delivered raw → NaN. Measured: `yield await mk()` → 5 but
+`yield mk()` (classified Promise) → NaN, and `const pv = mk(); yield pv` → NaN.
+This is a **value-representation bug below the async-frame lane** (the same native
+`$Promise` identity-preservation family, cf. `#3134` promise-value-slot-rep), not
+an async-gen-machine problem — extending the yield-await classifier cannot reach
+it. Also banked: `any`-typed runtime thenables need a runtime thenable probe in
+the settle arm (the #3120 follow-up), not a static classification.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -2014,6 +2014,15 @@ type ImplicitYieldAwaitMode = { readonly oracle: TypeOracle } | null;
  */
 function yieldOperandIsPromiseTyped(oracle: TypeOracle, operand: ts.Expression): boolean {
   if (oracle.builtinReceiverOf(operand) === "Promise") return true;
+  // (#3207) §27.6.3.8 `AsyncGeneratorYield` awaits ANY thenable, not only the
+  // `Promise` builtin. A `PromiseLike<T>`-typed operand is a structural
+  // thenable, so it must route through the SAME suspend+settleYield(fromSent)
+  // lane as a `Promise`-typed operand. This is correct-or-inert: when the
+  // operand is backed by a native `$Promise` at runtime the suspend arm adopts
+  // it (delivering the resolved value); a NON-native thenable fails the
+  // suspend's `ref.test $Promise` and falls through to the plain delivery — the
+  // exact pre-#3207 raw-yield behaviour — so no shape regresses.
+  if (oracle.declaredNameOf(operand) === "PromiseLike") return true;
   const parts = oracle.unionPartsOf(operand);
   return parts !== undefined && parts.some((p) => p.kind === "builtin" && p.name === "Promise");
 }

--- a/tests/issue-3207-asyncgen-yield-promiselike.test.ts
+++ b/tests/issue-3207-asyncgen-yield-promiselike.test.ts
@@ -1,0 +1,108 @@
+// #3207 — async-generator implicit yield-await (§27.6.3.8) for PromiseLike operands.
+//
+// §27.6.3.8 `AsyncGeneratorYield(value)` runs `value = ? Await(value)` — it awaits
+// ANY thenable before yielding it, not only the `Promise` builtin. #3120 landed the
+// static classifier for `Promise`-typed (and union-with-Promise) operands, so a plain
+// `yield <Promise>` routes through the same suspend+settleYield(fromSent) lane as
+// `yield await <Promise>`. This slice extends that classifier to `PromiseLike<T>`-typed
+// operands (structural thenables), which §27.6.3.8 must also await.
+//
+// Root cause before this fix: `yieldOperandIsPromiseTyped` only recognised the
+// `Promise` builtin (via the receiver heuristic) + unions containing it. A
+// `PromiseLike<T>`-typed operand classified as PLAIN → the un-awaited thenable was
+// yielded verbatim → the consumer saw the promise OBJECT (NaN when read as a number).
+//
+// The fix is correct-or-inert: when the PromiseLike operand is backed by a native
+// `$Promise` at runtime the suspend arm adopts it (delivers the resolved value); a
+// non-native thenable fails the suspend's `ref.test $Promise` and falls through to the
+// plain delivery — the exact pre-fix raw-yield behaviour — so no shape regresses.
+//
+// Native (wasi) drive lane only; gc/host + standalone stay byte-identical (the classifier
+// is gated on the native-`$Promise` carrier, which is wasi-only for async-gen modules).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface GenExports {
+  g: () => unknown;
+  __async_gen_next_g: (frame: unknown) => unknown;
+  __async_gen_p_state: (p: unknown) => number;
+  __async_gen_result_done: (p: unknown) => number;
+  __async_gen_result_value: (p: unknown) => number;
+  __drain_microtasks: () => void;
+}
+
+async function instantiateAsyncGen(src: string): Promise<GenExports> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // Host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as GenExports;
+}
+
+/** Drive one `next()`, drain microtasks, read the settled IteratorResult. */
+function step(ex: GenExports, frame: unknown): { pendingBeforeDrain: boolean; done: number; value: number } {
+  const p = ex.__async_gen_next_g(frame);
+  const pendingBeforeDrain = ex.__async_gen_p_state(p) === 0;
+  ex.__drain_microtasks();
+  expect(ex.__async_gen_p_state(p)).toBe(1); // FULFILLED
+  return { pendingBeforeDrain, done: ex.__async_gen_result_done(p), value: ex.__async_gen_result_value(p) };
+}
+
+describe("#3207 — async-gen implicit yield-await for PromiseLike operands (§27.6.3.8)", () => {
+  it("THE proof: a PromiseLike-typed plain yield is AWAITED (delivers the resolved value, not the thenable)", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        const t: PromiseLike<number> = Promise.resolve(5);
+        yield t;
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    // Was NaN before the fix (the un-awaited thenable object was yielded).
+    expect([s1.done, s1.value]).toEqual([0, 5]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("GENUINE suspension: a genuinely-pending PromiseLike yield suspends at kick=0 and resumes on drain", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        const t: PromiseLike<number> = Promise.resolve(2).then((v: number) => v + 40);
+        yield t;
+      }
+    `);
+    const frame = ex.g();
+    const s1 = step(ex, frame);
+    expect(s1.pendingBeforeDrain).toBe(true); // the value is not present until the drain
+    expect([s1.done, s1.value]).toEqual([0, 42]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("mixed: a PromiseLike yield followed by a plain yield delivers both in order", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        const t: PromiseLike<number> = Promise.resolve(7);
+        yield t;
+        yield 8;
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(7);
+    expect(step(ex, frame).value).toBe(8);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("parity: a plain (non-thenable) yield stays plain — the classifier does not touch it", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield 3;
+        yield 4;
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(3);
+    expect(step(ex, frame).value).toBe(4);
+    expect(step(ex, frame).done).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

§27.6.3.8 `AsyncGeneratorYield(value)` runs `value = ? Await(value)` — a plain `yield <E>` in an async generator awaits **any thenable** before yielding it, not only the `Promise` builtin. #3120 landed the static classifier for `Promise`-typed / union-with-Promise plain `yield E`. This one-line extension teaches `yieldOperandIsPromiseTyped` (async-cps.ts) to also recognise a **`PromiseLike<T>`-typed operand** (a structural thenable), routing it through the same `suspend`+`settleYield(fromSent)` lane as `yield await E`.

Verified host-free (wasi direct-drive): `const t: PromiseLike<number> = Promise.resolve(5); yield t` now delivers **5** (was **NaN** — the un-awaited thenable object was yielded).

## Why it's safe (correct-or-inert)

When the PromiseLike operand is backed by a native `$Promise` at runtime, the suspend arm's `ref.test $Promise` succeeds and adopts it. A **non-native** thenable fails that `ref.test` and falls through to the plain delivery — the **exact pre-fix raw-yield behaviour** — so no shape regresses. Carrier-gated on `isStandalonePromiseActive` (wasi-only for async-gen modules), so **gc + host + standalone stay byte-identical**.

## Byte-inertness proof

sha256 A/B (with vs without the one line), 6 programs × {gc, standalone, wasi}: **exactly one hash changed** — `promiseLikeYield wasi` (the intended unlock). Every gc + standalone lane and every other wasi program byte-identical.

## Tests

`tests/issue-3207-asyncgen-yield-promiselike.test.ts` (4 host-free wasi): settled-PromiseLike → 5; genuinely-pending drain (suspend at kick, resume to 42); mixed PromiseLike-then-plain; plain-yield parity guard. Async-gen blast radius unchanged vs `origin/main` (gap3-tryfinally / issue-2865 / issue-1672 failures are pre-existing, byte-identical on base). `tsc --noEmit` clean.

## Banked follow-up (higher-value, below this lane)

The dominant residual §27.6.3.8 gap is a **native-`$Promise` value-representation bug**: a `$Promise` flowing through a user-function return (`yield mk()`) or a Promise-typed local (`const pv = mk(); yield pv`) loses its native struct identity (`ref.test $Promise` fails → delivered raw → NaN), while `yield await mk()` → 5 works. This is the native-`$Promise` identity-preservation family (cf. #3134), below the async-frame lane. Documented in `plan/issues/3207-*.md` + the #2906 3d-iii note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS