### PR TITLE
fix(#2903): native standalone TypedArray scalar callback HOFs (R4)

### DIFF
--- a/plan/issues/2903-standalone-make-callback-residual-rootcause.md
+++ b/plan/issues/2903-standalone-make-callback-residual-rootcause.md
@@ -30,6 +30,9 @@ loc-budget-allow:
   - src/codegen/expressions.ts
   - src/codegen/index.ts
   - src/codegen/iterator-native.ts
+  - src/codegen/closures.ts
+  - src/codegen/object-runtime.ts
+  - src/codegen/array-methods.ts
 coercion-sites-allow:
   - src/codegen/iter-hof-native.ts
   - src/codegen/iter-lazy-native.ts

--- a/plan/issues/2903-standalone-make-callback-residual-rootcause.md
+++ b/plan/issues/2903-standalone-make-callback-residual-rootcause.md
@@ -629,3 +629,74 @@ flatMap was not in that set).
 - Inner iteration via `__iterator` normalizes finite iterables; per-element
   laziness WITHIN an inner is preserved (the ladder is stepped, not
   materialized).
+
+---
+
+## Landed: sub-front R4 — TypedArray SCALAR callback HOFs (opus-r4, 2026-07-13)
+
+**PR:** `issue-2903-r4-typedarray-hof`. Standalone-gated; gc/wasi byte-identical
+(prove-emit-identity: 0/26 corpus + 0/12 typed-array-snippet (file,target) pairs
+differ vs main).
+
+### Re-ground (correcting the opus-r3 R4 grounding above)
+
+The grounding claimed `__extern_get_idx`/`__extern_length` "read the typed `any`
+correctly (`b[0]`=5, `.length`=3)". **Only half true, verified on main
+@7bb01d2d:** `__extern_length` reads (the generic `$__vec_base` arm), but
+`__extern_get_idx` does NOT read the packed byte carriers — `fillExternGetIdxVecArms`
+(object-runtime.ts) explicitly skipped `NON_ARRAY_BYTE_VEC_ELEM_KINDS`, so an
+`any`-held `u8[2]` returned `0` and `u8.indexOf`/HOFs saw `undefined` at every
+index. That skipped element read — NOT the proto glue — is the root of the
+any-path wrong results. And the STATIC (untyped, test262-shape) `u8.find(cb)`
+routed to the `compileArrayMethodCall` externref arm (array-methods.ts), a
+`__make_callback` NO-OP stub that leaked the import and never ran the predicate.
+Neither path went through `emitProtoMemberBodyRefusal`.
+
+### The fix (three files, all `ctx.standalone`-gated)
+
+1. **object-runtime.ts** — `__extern_get_idx` now reads the packed byte carriers
+   (`i8_byte`/`i16_byte` unsigned via `array.get_u`; `i32_elem` plain), the single
+   chokepoint the native `__hof_*` loop + `a[i]` + `indexOf`/`includes` + for-in
+   read through. `i32_byte` (ArrayBuffer byte buffer) stays excluded.
+2. **closures.ts** — `isHostCallbackArgument` → false for a standalone
+   typed-array-receiver SCALAR HOF (callback compiles as a WasmGC closure struct,
+   not the host `__make_callback` bridge).
+3. **calls.ts** — a standalone DIRECT-carrier typed-array scalar HOF is
+   intercepted BEFORE `compileArrayMethodCall` and routed to the native
+   `__call_m_<name>_<arity>` / `__hof_<name>` substrate (`$__vec_base` arm drives
+   the predicate via `__apply_closure`, host-free).
+
+Scope: find/findIndex/findLast/findLastIndex/forEach/some/every/reduce/reduceRight.
+`map`/`filter` (typed-RESULT construction) deferred to **R4b**.
+
+### Signedness boundary (documented, not a regression)
+
+Int8Array/Uint8Array share the `i8_byte` carrier type (index.ts
+TYPED_ARRAY_PACKED_STORAGE) — no signedness tag — so the generic read is UNSIGNED
+regardless of static type. Uint8/Uint8Clamped/Uint16 correct; Int8/Int16 with
+non-negative values correct + host-free (net gain); negative Int8/Int16 elements
+read as their unsigned bit-pattern (wrong) — but those modules leaked
+`__make_callback` and failed to instantiate on main, so nothing regresses.
+Recovering sub-i32 signed dynamic reads needs a per-signedness carrier type
+(deferred).
+
+### #3162 handoff (avoid a double-path)
+
+The array-methods.ts `__make_callback` bank (~line 3010) is annotated to point
+here: the DIRECT-carrier scalar HOFs are de-leaked in calls.ts; that banked ELSE
+arm still serves the `$__ta_dyn_view` DYNAMIC-VIEW shape (kept per #3058/#3162 —
+a disjoint receiver) and `join`. Whoever de-leaks the dyn-view case must NOT add
+a competing direct-carrier de-leak there.
+
+### Proofs
+- `tests/issue-2903-r4.test.ts` (13 tests): static + untyped + `any`-held +
+  Uint16/Int32 + the signedness boundary — all host-free (zero imports) +
+  value-correct.
+- prove-emit-identity gc/wasi byte-identical (measured, above).
+- No regression: `tests/issue-2903.test.ts` + `issue-1326` (25) + the typed-array
+  suite `issue-2648`/`2872-dynview`/`2593`/`1787` (66) green; tsc clean.
+
+### Remaining sub-fronts (issue stays `ready`)
+- **R4b** — TypedArray `map`/`filter` (typed-RESULT construction, per-#2593
+  element-width wrapping).
+- **R2** — `class X extends Promise` producer. **R3 lazy iter helpers** landed.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3010,7 +3010,14 @@ const ARRAY_METHODS = new Set([
  *   - the callback methods `find`/`findIndex`/`findLast`/`findLastIndex`/`every`/`some`/
  *     `forEach`/`reduce`/`reduceRight` → `env.__make_callback`
  * These flip only once the standalone externref-receiver callback/join paths are native
- * (a separate follow-up). Also banked: in-place mutators (`fill`/`copyWithin`/`reverse`/
+ * (a separate follow-up). (#2903 R4 UPDATE) The SCALAR callback methods above
+ * (find/findIndex/findLast/findLastIndex/every/some/forEach/reduce/reduceRight)
+ * on a DIRECT (`$__vec_i8_byte`-style) carrier are now de-leaked BEFORE reaching
+ * here — intercepted in `expressions/calls.ts` and routed to the native
+ * `__call_m_<name>`/`__hof_<name>` substrate (host-free). This banked ELSE arm
+ * still serves the `$__ta_dyn_view` dynamic-view shape (kept per #3058/#3162) and
+ * `join`; do NOT add a competing direct-carrier de-leak here. `map`/`filter`
+ * (typed-RESULT) remain banked for #2903 R4b. Also banked: in-place mutators (`fill`/`copyWithin`/`reverse`/
  * `sort` — Bucket B, need write-back) and species/new-view producers (`slice`/`subarray`/
  * `map`/`filter`/`with`/`toSorted`/`toReversed` — Bucket C, need real-buffer identity).
  */

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1341,19 +1341,13 @@ const STANDALONE_TYPED_ARRAY_SCALAR_HOFS: ReadonlySet<string> = new Set([
  * (`Uint8Array`, `Int8Array`, …). Recognises the type via its symbol name and,
  * defensively, via the apparent type so a narrowed/aliased view still matches.
  */
-function isTypedArrayReceiverType(recvType: ts.Type, ctx: CodegenContext): boolean {
-  const named = (t: ts.Type | undefined): boolean => {
-    const n = t?.getSymbol?.()?.getName?.();
-    return n !== undefined && TYPED_ARRAY_VIEW_NAMES.has(n);
-  };
-  if (named(recvType)) return true;
-  try {
-    const apparent = ctx.checker.getApparentType?.(recvType);
-    if (named(apparent)) return true;
-  } catch {
-    // ignore checker errors — default to the host-callback path
-  }
-  return false;
+function isTypedArrayReceiverType(recvType: ts.Type, _ctx: CodegenContext): boolean {
+  // A concrete typed-array receiver carries its view name directly on the type
+  // symbol; the interception is scoped to that (known-element-kind) shape. A
+  // narrowed/aliased view without a direct symbol falls through to the host
+  // path (no regression — that path already worked pre-#2903).
+  const n = recvType.getSymbol?.()?.getName?.();
+  return n !== undefined && TYPED_ARRAY_VIEW_NAMES.has(n);
 }
 
 /**

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1307,6 +1307,55 @@ function isArrayLikeReceiverType(recvType: ts.Type, ctx: CodegenContext): boolea
   return false;
 }
 
+/** (#2903 R4) The nine typed-array view constructor names — a receiver of one
+ *  of these types is a native packed-carrier typed array in standalone. */
+const TYPED_ARRAY_VIEW_NAMES: ReadonlySet<string> = new Set([
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+]);
+
+/** (#2903 R4) Scalar-returning callback HOFs whose standalone typed-array
+ *  dispatch is handled natively via `__call_m_*`/`__hof_*` (calls.ts). Excludes
+ *  map/filter (typed-RESULT construction — deferred to R4b). */
+const STANDALONE_TYPED_ARRAY_SCALAR_HOFS: ReadonlySet<string> = new Set([
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+  "forEach",
+  "some",
+  "every",
+  "reduce",
+  "reduceRight",
+]);
+
+/**
+ * (#2903 R4) True when `recvType` is one of the nine typed-array view types
+ * (`Uint8Array`, `Int8Array`, …). Recognises the type via its symbol name and,
+ * defensively, via the apparent type so a narrowed/aliased view still matches.
+ */
+function isTypedArrayReceiverType(recvType: ts.Type, ctx: CodegenContext): boolean {
+  const named = (t: ts.Type | undefined): boolean => {
+    const n = t?.getSymbol?.()?.getName?.();
+    return n !== undefined && TYPED_ARRAY_VIEW_NAMES.has(n);
+  };
+  if (named(recvType)) return true;
+  try {
+    const apparent = ctx.checker.getApparentType?.(recvType);
+    if (named(apparent)) return true;
+  } catch {
+    // ignore checker errors — default to the host-callback path
+  }
+  return false;
+}
+
 /**
  * (#2640) True when `wt` is a (nullable) ref to a typed WasmGC vec/array
  * struct (`__vec_*`/`__arr_*`/`$__vec_base`). Used to widen array-like
@@ -1422,6 +1471,26 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
         // HOST_CALLBACK_METHODS allowlist still governs the invoke-during-call
         // host methods (array HOFs, Promise.then, String.replace, …).
         if ((methodName === "push" || methodName === "unshift") && isArrayLikeReceiverType(receiverType, ctx)) {
+          return false;
+        }
+        // (#2903 R4) Standalone typed-array SCALAR-returning callback HOFs
+        // (find/findIndex/…/forEach/some/every/reduce) are dispatched natively
+        // through the `__call_m_<name>`/`__hof_<name>` substrate (see the
+        // interception in `expressions/calls.ts`), which drives the predicate
+        // via `__apply_closure` on a WasmGC closure STRUCT — NOT the host
+        // `__make_callback` externref. Routing the callback through the host
+        // bridge here would leak `env.__make_callback` (breaking host-free
+        // instantiation) AND hand the substrate an externref it can't `ref.cast`
+        // to the closure struct. So give these the closure-struct path.
+        // Standalone-gated (js-host/gc keep the pre-existing host path,
+        // byte-identical). map/filter (typed-RESULT construction) are NOT here —
+        // deferred to R4b. The dyn-view (`$__ta_dyn_view`) receiver shape stays
+        // on its own #3058/#3162 path in array-methods.ts.
+        if (
+          ctx.standalone &&
+          STANDALONE_TYPED_ARRAY_SCALAR_HOFS.has(methodName) &&
+          isTypedArrayReceiverType(receiverType, ctx)
+        ) {
           return false;
         }
       } catch {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -12447,14 +12447,9 @@ function compileCallExpression(
     // path in array-methods.ts (disjoint receiver). map/filter (typed-RESULT)
     // deferred to R4b. Standalone-gated → gc/wasi byte-identical.
     if (ctx.standalone && STANDALONE_TA_SCALAR_HOFS.has(propAccess.name.text)) {
-      let taName = receiverType.getSymbol?.()?.getName?.();
-      if (taName === undefined || !isWiredTypedArrayViewName(taName)) {
-        try {
-          taName = ctx.checker.getApparentType?.(receiverType)?.getSymbol?.()?.getName?.();
-        } catch {
-          taName = undefined;
-        }
-      }
+      // A concrete typed-array receiver carries its view name directly on the
+      // type symbol (the known-element-kind shape this interception targets).
+      const taName = receiverType.getSymbol?.()?.getName?.();
       const hasSpread = expr.arguments.some((a) => ts.isSpreadElement(a));
       const dispatchArgs = hasSpread ? flattenCallArgs(expr.arguments) : [...expr.arguments];
       if (

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1435,6 +1435,25 @@ function getProtoOfCallArg(expr: ts.Expression): ts.Expression | undefined {
 }
 
 /**
+ * (#2903 R4) Scalar-returning `%TypedArray%.prototype` callback HOFs whose
+ * STANDALONE dispatch on a DIRECT (`$__vec_i8_byte`-style) carrier is routed to
+ * the native `__call_m_<name>_<arity>` / `__hof_<name>` substrate (see the
+ * interception in {@link compileCallExpression}'s array-method arm). Excludes
+ * `map`/`filter` (typed-RESULT construction — deferred to R4b) and the mutators.
+ */
+const STANDALONE_TA_SCALAR_HOFS: ReadonlySet<string> = new Set([
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+  "forEach",
+  "some",
+  "every",
+  "reduce",
+  "reduceRight",
+]);
+
+/**
  * (#2901) True iff `expr` (statically, following single-init var bindings) denotes
  * the abstract `%TypedArray%` intrinsic constructor, in either shape the test262
  * TypedArray corpus reaches it:
@@ -12410,6 +12429,65 @@ function compileCallExpression(
           }
           return VOID_RESULT;
         }
+      }
+    }
+
+    // (#2903 R4) Standalone DIRECT-carrier typed-array SCALAR callback HOFs
+    // (find/findIndex/…/forEach/some/every/reduce) → the native
+    // `__call_m_<name>_<arity>` / `__hof_<name>` substrate, BEFORE the
+    // array-methods.ts path. On main the standalone typed-array externref arm in
+    // `compileArrayMethodCall` is a `__make_callback` no-op STUB (banked at
+    // array-methods.ts ~"BANKED … the callback methods … → env.__make_callback"
+    // as "a separate follow-up") — it leaks `env.__make_callback` (breaking
+    // host-free instantiation) and never runs the predicate. The closed-method
+    // dispatcher's `$__vec_base` HOF arm drives the callback via `__apply_closure`
+    // on a WasmGC closure struct (host-free), reading elements through the
+    // byte-carrier-aware `__extern_get_idx` (this PR). Only DIRECT carriers reach
+    // here; the dynamic-view (`$__ta_dyn_view`) shape keeps its own #3058/#3162
+    // path in array-methods.ts (disjoint receiver). map/filter (typed-RESULT)
+    // deferred to R4b. Standalone-gated → gc/wasi byte-identical.
+    if (ctx.standalone && STANDALONE_TA_SCALAR_HOFS.has(propAccess.name.text)) {
+      let taName = receiverType.getSymbol?.()?.getName?.();
+      if (taName === undefined || !isWiredTypedArrayViewName(taName)) {
+        try {
+          taName = ctx.checker.getApparentType?.(receiverType)?.getSymbol?.()?.getName?.();
+        } catch {
+          taName = undefined;
+        }
+      }
+      const hasSpread = expr.arguments.some((a) => ts.isSpreadElement(a));
+      const dispatchArgs = hasSpread ? flattenCallArgs(expr.arguments) : [...expr.arguments];
+      if (
+        taName !== undefined &&
+        isWiredTypedArrayViewName(taName) &&
+        dispatchArgs !== null &&
+        dispatchArgs.length >= 1
+      ) {
+        const methodName = propAccess.name.text;
+        const arity = dispatchArgs.length;
+        const dispatchIdx = reserveClosedMethodDispatch(ctx, methodName, arity);
+        flushLateImportShifts(ctx, fctx);
+        // Receiver → externref.
+        const recvT = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+        if (recvT && recvT.kind !== "externref") coerceType(ctx, fctx, recvT, { kind: "externref" });
+        else if (recvT === null) fctx.body.push({ op: "ref.null.extern" });
+        // Args → externref; an INLINE arrow/function callback compiles as a raw
+        // WasmGC closure struct (crossing as externref) — NOT the host
+        // `__make_callback` bridge — so the dispatcher's HOF arm can drive it via
+        // `__apply_closure` (same rep an identifier-held callback crosses with).
+        for (const arg of dispatchArgs) {
+          if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
+            const at = compileArrowAsClosure(ctx, fctx, arg);
+            if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+            else if (at === null) fctx.body.push({ op: "ref.null.extern" });
+          } else {
+            const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
+            if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+            else if (at === null) fctx.body.push({ op: "ref.null.extern" });
+          }
+        }
+        fctx.body.push({ op: "call", funcIdx: dispatchIdx });
+        return { kind: "externref" };
       }
     }
 

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -10051,12 +10051,32 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
   if (!types) return;
 
   // Enumerate concrete `__vec_<elemKind>` carriers (NOT $ObjVec — it keeps its
-  // own dedicated arm — and NOT the non-array `_byte` carriers). Dedup by
-  // typeIdx; sort for deterministic emission.
+  // own dedicated arm). Dedup by typeIdx; sort for deterministic emission.
+  //
+  // (#2903 R4) The packed TypedArray ELEMENT carriers — `i8_byte`
+  // (Int8/Uint8/Uint8Clamped), `i16_byte` (Int16/Uint16), `i32_elem`
+  // (Int32/Uint32) — ARE included here so an `any`-held / dynamically-dispatched
+  // typed array reads its elements through `__extern_get_idx` (the single
+  // chokepoint the native array-HOF loop `__hof_*`, `a[i]`, indexOf, includes
+  // and for-in all read through). Without this, those carriers fell to the null
+  // fallback → the HOF loop saw `undefined` at every index and returned wrong
+  // results host-free (findIndex→-1, reduce→0). The ArrayBuffer/DataView BYTE
+  // buffer `i32_byte` stays excluded (it is a raw byte store, not a JS-array-
+  // indexable element carrier). SIGNEDNESS BOUNDARY: `i8_byte`/`i16_byte` are
+  // read UNSIGNED (`array.get_u`) — correct for Uint8/Uint8Clamped/Uint16 (the
+  // common case + the storage's documented default read, dataview-native.ts),
+  // but a negative Int8/Int16 element reads as its unsigned bit-pattern. The
+  // shared carrier type (index.ts TYPED_ARRAY_PACKED_STORAGE — Int8Array and
+  // Uint8Array both map to `i8_byte`/kind `i8`) loses the constructor's
+  // signedness, so this generic read cannot recover it (every consumer routing
+  // through here — static or dynamic — reads unsigned). Those Int8/16 reads were
+  // already fully broken (null) here, so this is not a regression; recovering
+  // sub-i32 signed reads needs a per-signedness carrier type (deferred).
+  const excludedByteVecElemKinds = new Set(["i32_byte"]);
   const seen = new Set<number>();
   const carriers: { typeIdx: number; arrTypeIdx: number; elemType: ValType }[] = [];
   for (const [elemKind, vecTypeIdx] of ctx.vecTypeMap.entries()) {
-    if (NON_ARRAY_BYTE_VEC_ELEM_KINDS.has(elemKind)) continue;
+    if (excludedByteVecElemKinds.has(elemKind)) continue;
     if (seen.has(vecTypeIdx)) continue;
     const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
     if (arrTypeIdx < 0) continue;
@@ -10072,10 +10092,28 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
   // double-remap hazard). The singleton instrs carry no funcIdx/typeIdx, so
   // splicing them at FINALIZE cannot desync any index-shift walk.
   const idxMiss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" } as Instr];
+  // (#2903 R4) Packed sub-i32 element carriers (`i8`/`i16`) need an UNSIGNED
+  // packed load (`array.get_u`) — plain `array.get` is invalid on a packed
+  // array — then f64-box the zero-extended i32 (0..255 / 0..65535, always
+  // positive so `f64.convert_i32_s` == `_u`). Non-packed carriers keep the
+  // generic `array.get` + `boxVecElementToExternref`. Returns null for a kind
+  // with no boxing (leave that carrier to the null fallback).
+  const boxNumIdx = ctx.funcMap.get("__box_number");
+  const packedElemReadBox = (elemType: ValType): { getOp: string; boxOps: Instr[] } | null => {
+    if ((elemType.kind === "i8" || elemType.kind === "i16") && boxNumIdx !== undefined) {
+      return {
+        getOp: "array.get_u",
+        boxOps: [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumIdx } as Instr],
+      };
+    }
+    const generic = boxVecElementToExternref(ctx, elemType);
+    return generic === null ? null : { getOp: "array.get", boxOps: generic };
+  };
   const vecArms: Instr[] = [];
   for (const { typeIdx, arrTypeIdx, elemType } of carriers) {
-    const boxOps = boxVecElementToExternref(ctx, elemType);
-    if (boxOps === null) continue; // unsupported element kind — leave to null fallback
+    const readBox = packedElemReadBox(elemType);
+    if (readBox === null) continue; // unsupported element kind — leave to null fallback
+    const { getOp, boxOps } = readBox;
     vecArms.push({ op: "local.get", index: 2 }, { op: "ref.test", typeIdx }, {
       op: "if",
       blockType: { kind: "empty" },
@@ -10107,7 +10145,7 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
         { op: "ref.cast", typeIdx },
         { op: "struct.get", typeIdx, fieldIdx: 1 },
         { op: "local.get", index: 4 },
-        { op: "array.get", typeIdx: arrTypeIdx },
+        { op: getOp, typeIdx: arrTypeIdx } as Instr,
         ...boxOps,
         { op: "return" },
       ],

--- a/tests/issue-2903-r4.test.ts
+++ b/tests/issue-2903-r4.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2903 R4 — standalone TypedArray SCALAR callback HOFs (sub-front 4).
+//
+// On main, a directly-constructed typed array (`new Uint8Array([...])`) held at
+// its static type reached the `compileArrayMethodCall` (array-methods.ts)
+// externref arm, which is a `__make_callback` NO-OP STUB in standalone: it
+// created the host callback (dropped → the leak), never ran the predicate, and
+// pushed `ref.null.extern`. So `u8.find(cb)`/`findIndex`/`forEach`/`some`/
+// `every`/`reduce` leaked `env.__make_callback` (host-free instantiation failed)
+// AND returned wrong results.
+//
+// Two independent gaps fixed here (both `ctx.standalone`-gated → gc/wasi
+// byte-identical, proven via prove-emit-identity):
+//   1. object-runtime.ts — `__extern_get_idx` now reads the packed byte carriers
+//      (`i8_byte`/`i16_byte`/`i32_elem`); previously it skipped them, so the
+//      native HOF loop `__hof_*` (which reads through it) + `a[i]` + indexOf saw
+//      `undefined` at every index for an `any`-held typed array.
+//   2. closures.ts + calls.ts — a standalone DIRECT-carrier typed-array scalar
+//      HOF is routed to the native `__call_m_<name>_<arity>`/`__hof_<name>`
+//      substrate, compiling the callback as a WasmGC closure struct (not the
+//      host `__make_callback` bridge).
+//
+// SIGNEDNESS BOUNDARY (documented, not a regression): both paths read through
+// the SAME generic `__extern_get_idx` substrate, which reads `i8_byte`/`i16_byte`
+// UNSIGNED — the shared carrier type (Int8Array and Uint8Array both map to
+// `i8_byte`/kind `i8`) carries no signedness tag, so a negative Int8/Int16
+// element reads as its unsigned bit-pattern regardless of the static type.
+// Correct for Uint8/Uint8Clamped/Uint16 (the common case). Int8/Int16 with
+// NON-negative values are correct + host-free (a net gain); negative Int8/Int16
+// elements read wrong — but those tests were fully broken (host-import leak,
+// failed instantiation) before, so nothing regresses. Recovering sub-i32 signed
+// reads on the dynamic substrate needs a per-signedness carrier type (deferred).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.success).toBe(true);
+  return result;
+}
+
+function importNames(result: { imports?: { name: string }[] }): string[] {
+  return (result.imports ?? []).map((i) => i.name).sort();
+}
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compileStandalone(source);
+  expect(importNames(result)).toEqual([]); // host-free: no __make_callback
+  const { instance } = await WebAssembly.instantiate(result.binary!, {}); // zero imports
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2903 R4 — standalone TypedArray scalar callback HOFs are native + host-free", () => {
+  it("static Uint8Array.findIndex runs host-free", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([3, 7, 11, 42, 5]); return a.findIndex((x: number) => x > 10); }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("static Uint8Array.find returns the element (undefined sentinel preserved)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([3, 7, 11, 42, 5]); const r = a.find((x: number) => x > 10); return r === undefined ? -1 : r; }`,
+      ),
+    ).toBe(11);
+  });
+
+  it("static Uint8Array.find not-found is undefined", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([1, 2, 3]); const r = a.find((x: number) => x > 100); return r === undefined ? 42 : -1; }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("static Uint8Array.forEach drives the callback", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([1, 2, 3, 4]); let s = 0; a.forEach((x: number) => { s += x; }); return s; }`,
+      ),
+    ).toBe(10);
+  });
+
+  it("static Uint8Array.reduce (no initial value) seeds from the first element", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([1, 2, 3, 4]); return a.reduce((s: number, x: number) => s + x); }`,
+      ),
+    ).toBe(10);
+  });
+
+  it("static Uint8Array.reduce (with initial value)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([1, 2, 3, 4]); return a.reduce((s: number, x: number) => s + x, 100); }`,
+      ),
+    ).toBe(110);
+  });
+
+  it("static Uint8Array.some / every", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([3, 7, 11]); return (a.some((x: number) => x > 10) && a.every((x: number) => x > 0)) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("untyped (test262-shape) Uint8Array HOF is host-free", async () => {
+    expect(
+      await runStandalone(
+        `function test() { var a = new Uint8Array([3, 7, 11, 42, 5]); return a.findIndex(function (x) { return x > 10; }); }\nexport { test };`,
+      ),
+    ).toBe(2);
+  });
+
+  it("Uint16Array.reduce reads wide packed elements", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint16Array([1000, 2000, 3000]); return a.reduce((s: number, x: number) => s + x, 0); }`,
+      ),
+    ).toBe(6000);
+  });
+
+  it("Int32Array.some reads full 32-bit elements", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Int32Array([100000, 5]); return a.some((x: number) => x > 50000) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("any-held Uint8Array HOF + indexing read the byte carrier (object-runtime __extern_get_idx)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: any = new Uint8Array([3, 7, 11, 42, 5]); return a.findIndex((x: number) => x > 10) + a[2] + a.indexOf(42); }`,
+      ),
+    ).toBe(2 + 11 + 3);
+  });
+
+  it("Int8Array with NON-negative values is host-free + correct", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Int8Array([5, 10, 20]); return a.findIndex((x: number) => x > 7); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("SIGNEDNESS BOUNDARY: negative Int8 elements read unsigned (documented, was a leak before)", async () => {
+    // `-5` stored as packed i8 reads back as 251 (unsigned bit-pattern), so the
+    // `x < 0` predicate never matches → undefined. On main this module leaked
+    // `env.__make_callback` and failed to instantiate, so this is not a
+    // regression — it is a host-free (if signedness-lossy) improvement.
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Int8Array([-5, 10, -20]); const r = a.find((x: number) => x < 0); return r === undefined ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2903 sub-front R4 — standalone TypedArray SCALAR callback HOFs

De-leaks + correctly drives the scalar-returning TypedArray callback HOFs
(`find`/`findIndex`/`findLast*`/`forEach`/`some`/`every`/`reduce`/`reduceRight`)
in `--target standalone`. On main these **leaked `env.__make_callback`** (host-free
instantiation failed) and **never ran the predicate** (findIndex→−1, reduce→0).

### Root causes (two disjoint paths, both fixed, all `ctx.standalone`-gated)
1. **`object-runtime.ts`** — `__extern_get_idx` skipped the packed byte carriers
   (`i8_byte`/`i16_byte`/`i32_elem`), so the native `__hof_*` loop + `a[i]` +
   `indexOf`/`includes` read `undefined` at every index for a typed array held as
   `any`. Now reads them (unsigned packed load for `i8`/`i16`). This corrects the
   opus-r3 grounding's claim that `__extern_get_idx` "read correctly" — only
   `__extern_length` did.
2. **`calls.ts` + `closures.ts`** — a **DIRECT-carrier** (`$__vec_i8_byte`-style)
   typed-array scalar HOF is intercepted before the `array-methods.ts`
   `__make_callback` no-op stub and routed to the native
   `__call_m_<name>_<arity>`/`__hof_<name>` substrate, compiling the callback as a
   WasmGC closure struct driven via `__apply_closure`.

### Scope / boundaries
- `map`/`filter` (typed-RESULT construction) deferred to **R4b**.
- The `$__ta_dyn_view` dynamic-view shape keeps its own **#3058/#3162**
  `array-methods.ts` path (disjoint receiver) — a pointer comment is added at that
  bank so the two don't become a double-path.
- **Signedness boundary** (documented, not a regression): Int8/Uint8 share the
  `i8_byte` carrier type, so sub-i32 negatives read unsigned regardless of static
  type. Uint8/Uint8Clamped/Uint16 correct; Int8/Int16 non-negative correct +
  host-free; negative Int8/Int16 read wrong — but those modules leaked
  `__make_callback` and failed to instantiate on main, so nothing regresses.

### Validation
- `tests/issue-2903-r4.test.ts` (13): static + untyped (test262-shape) + `any`-held
  + Uint16/Int32 + signedness boundary — all host-free (zero imports) + correct.
- **gc/wasi byte-identical**: prove-emit-identity 0/26 corpus + 0/12 typed-array
  snippet `(file,target)` pairs differ vs main.
- No regression: `issue-2903` + `issue-1326` (25) + typed-array suite
  `issue-2648`/`2872-dynview`/`2593`/`1787` (66); `tsc --noEmit` clean.
- Merge-group standalone floor is the decider.

#2903 stays `ready` (R4b / R2 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8