### PR TITLE
fix(#3215): Array HOF sparse-array read trap-safety (backing clamp)

### DIFF
--- a/plan/issues/3215-array-hof-sparse-read-trapsafe.md
+++ b/plan/issues/3215-array-hof-sparse-read-trapsafe.md
@@ -1,7 +1,8 @@
 ---
 id: 3215
 title: "standalone: Array.prototype HOF sparse-array read trap-safety (forEach/map/filter/reduce/every/some/find/findIndex/findLast/findLastIndex)"
-status: ready
+status: done
+completed: 2026-07-13
 created: 2026-07-13
 priority: high
 feasibility: medium

--- a/plan/issues/3215-array-hof-sparse-read-trapsafe.md
+++ b/plan/issues/3215-array-hof-sparse-read-trapsafe.md
@@ -1,0 +1,81 @@
+---
+id: 3215
+title: "standalone: Array.prototype HOF sparse-array read trap-safety (forEach/map/filter/reduce/every/some/find/findIndex/findLast/findLastIndex)"
+status: ready
+created: 2026-07-13
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: array-methods
+goal: builtin-methods
+sprint: current
+horizon: m
+related: [3185, 3199, 3200, 3201, 2001]
+loc-budget-allow: [src/codegen/array-methods.ts]
+origin: "2026-07-13 opus-3201b — HOF analog of the #3201 sort/includes sparse-read trap fix (#2980)"
+---
+
+# #3215 — Array.prototype HOF sparse-array read trap-safety
+
+Analog of the #3201 read/copy trap-safety family (#2968 indexOf/lastIndexOf,
+#2970 slice/concat, #2973 pop/splice, #2980 sort/includes), now for the
+callback HOF family. On a SPARSE array (logical `.length` set beyond the
+physical WasmGC backing) these methods iterate to the LOGICAL length reading
+`data[i]` with a raw `array.get`, which TRAPS ("array element access out of
+bounds") once `i` passes the backing length — an uncatchable Wasm trap that
+aborts the whole test262 program (the #3185 §4 trap-first mandate).
+
+Confirmed (standalone, `[1,2,3]; a.length=6`): forEach, map, filter, every,
+reduce all TRAP; some returns early before reaching the hole.
+
+## Root cause (shared loop scaffolding)
+
+All forward HOFs build their iteration through `setupArrayLoop`
+(`array-methods.ts`), which reads `lenTmp = struct.get field0` (LOGICAL length)
+and `loopExitCheck` compares `i >= lenTmp`. `setupArrayLoopReverse` starts
+`i = lenTmp - 1`. The element read `data[i]` therefore runs past
+`array.len(data)` on a sparse receiver → trap.
+
+Consumers of `setupArrayLoop`: filter, map, reduce, forEach, find, findIndex,
+some, every (+ `setupArrayLoopReverse`: findLast, findLastIndex).
+
+## Fix
+
+Clamp the loop bound to the physical backing centrally in `setupArrayLoop`:
+`lenTmp = min(lenTmp, array.len(dataTmp))` (reuse the `min` shape from the
+merged indexOf/sort clamps). This fixes every forward + reverse consumer in one
+place. Per spec these HOFs use HasProperty (holes are SKIPPED), so iterating only
+the physical defined prefix and skipping the beyond-backing holes is
+spec-correct AND trap-free. Dense arrays keep `lenTmp` unchanged (backing ≥
+length ⇒ runtime no-op).
+
+**map result-length caveat**: `compileArrayMap` allocates its result via
+`array.new_default(loop.lenTmp)` and sizes the result vec from it — the result
+must keep the LOGICAL length (§23.1.3.19), holes preserved beyond the visited
+prefix. So `setupArrayLoop` must ALSO expose the UNCLAMPED logical length
+(`logicalLenTmp` added to `ArrayLoopLocals`); map uses `logicalLenTmp` for its
+result allocation + vec length, and the clamped `lenTmp` for the loop bound.
+Beyond-backing result slots stay default-initialised (consistent with the
+existing #2001-S2 deferred map-result-hole behavior — not made worse).
+
+filter builds its result dynamically (push kept elements), so the clamp is
+correct as-is (holes contribute nothing). reduce with no initial value still
+seeds from `data[0]` (in-backing) and skips beyond-backing holes (spec-correct).
+
+## Acceptance
+
+1. forEach/map/filter/reduce/every/some/find/findIndex/findLast/findLastIndex on
+   a sparse array → NO trap; spec-correct result (holes skipped / map keeps
+   logical length).
+2. Dense arrays behaviourally unchanged.
+3. Dedicated `tests/issue-3215-hof-sparse.test.ts`, standalone lane.
+4. No standalone-lane regressions.
+
+## Out of scope (follow-ups)
+
+- map/filter/flatMap RESULT-HOLE fidelity (source hole → result hole per
+  §23.1.3.19) — the #2001-S2 deferred widened-result-type slice.
+- flatMap sparse (if it uses a distinct loop) — verify separately.
+- Array-like `.call(obj)` HOF sparse receivers — the #3169/#3200 receiver-ladder.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -6764,7 +6764,19 @@ function setupArrayCallback(
 interface ArrayLoopLocals {
   vecTmp: number;
   dataTmp: number;
+  /**
+   * (#3215) The loop bound — CLAMPED to the physical backing
+   * (`min(field0, array.len(data))`) so a sparse receiver (logical `.length`
+   * beyond the backing) never OOB-traps on `data[i]`. Equal to the logical
+   * length for dense arrays.
+   */
   lenTmp: number;
+  /**
+   * (#3215) The UNCLAMPED logical `.length` (vec field 0). Use this — not
+   * `lenTmp` — for result-object sizing that must be the logical length
+   * (map's result, §23.1.3.19). Equal to `lenTmp` for dense arrays.
+   */
+  logicalLenTmp: number;
   iTmp: number;
   getOp: string;
 }
@@ -6815,11 +6827,26 @@ function setupArrayLoop(
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
   fctx.body.push({ op: "local.set", index: dataTmp });
 
+  // (#3215) Clamp the shared loop bound to the physical WasmGC backing so a
+  // sparse receiver (logical `.length` set beyond the backing) never TRAPS on
+  // the out-of-bounds `array.get data[i]` in the HOF loop. Per spec these HOFs
+  // use HasProperty (holes are SKIPPED), so iterating only the physical defined
+  // prefix — and skipping the beyond-backing holes — is spec-correct. The
+  // UNCLAMPED logical length is preserved in `logicalLenTmp` for consumers that
+  // must size a result by the logical length (map, §23.1.3.19). Dense arrays
+  // keep `lenTmp` unchanged (backing capacity ≥ length ⇒ min is the length ⇒
+  // runtime no-op). This is the HOF analog of the #2980 sort/includes and #2968
+  // indexOf backing-clamps.
+  const logicalLenTmp = allocLocal(fctx, `__arr_${tag}_loglen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: lenTmp });
+  fctx.body.push({ op: "local.set", index: logicalLenTmp });
+  emitBackingLenClamp(fctx, lenTmp, dataTmp);
+
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "local.set", index: iTmp });
 
   const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
-  return { vecTmp, dataTmp, lenTmp, iTmp, getOp };
+  return { vecTmp, dataTmp, lenTmp, logicalLenTmp, iTmp, getOp };
 }
 
 /**
@@ -7477,8 +7504,13 @@ function compileArrayMap(
 
   const resData = allocLocal(fctx, `__arr_map_rd_${fctx.locals.length}`, { kind: "ref_null", typeIdx: mapArrTypeIdx });
 
-  // Allocate result array with same length
-  fctx.body.push({ op: "local.get", index: loop.lenTmp });
+  // Allocate result array with the LOGICAL length (§23.1.3.19 — map's result is
+  // the same length as the source). (#3215) `loop.lenTmp` is clamped to the
+  // physical backing for trap-safety, so size the result from the UNCLAMPED
+  // `loop.logicalLenTmp`; the loop below only writes the in-backing prefix, and
+  // the beyond-backing result slots stay default-initialised (consistent with
+  // the #2001-S2 deferred map-result-hole behavior). Equal for dense arrays.
+  fctx.body.push({ op: "local.get", index: loop.logicalLenTmp });
   fctx.body.push({ op: "array.new_default", typeIdx: mapArrTypeIdx });
   fctx.body.push({ op: "local.set", index: resData });
 
@@ -7522,7 +7554,10 @@ function compileArrayMap(
 
   emitArrayLoop(fctx, loopBody);
 
-  fctx.body.push({ op: "local.get", index: loop.lenTmp });
+  // (#3215) Result vec length is the LOGICAL length (unclamped) so a sparse
+  // source's map result keeps the source length (§23.1.3.19), matching the
+  // logical-length `resData` allocation above.
+  fctx.body.push({ op: "local.get", index: loop.logicalLenTmp });
   fctx.body.push({ op: "local.get", index: resData });
   fctx.body.push({ op: "ref.as_non_null" });
   fctx.body.push({ op: "struct.new", typeIdx: mapVecTypeIdx });
@@ -7792,6 +7827,7 @@ function compileArrayReduceRight(
   const vecTmp = allocLocal(fctx, `__arr_rr_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__arr_rr_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const lenTmp = allocLocal(fctx, `__arr_rr_len_${fctx.locals.length}`, { kind: "i32" });
+  const logicalLenTmp = allocLocal(fctx, `__arr_rr_loglen_${fctx.locals.length}`, { kind: "i32" });
   const iTmp = allocLocal(fctx, `__arr_rr_i_${fctx.locals.length}`, { kind: "i32" });
 
   compileExpression(ctx, fctx, propAccess.expression);
@@ -7802,6 +7838,17 @@ function compileArrayReduceRight(
   fctx.body.push({ op: "local.get", index: vecTmp });
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
   fctx.body.push({ op: "local.set", index: dataTmp });
+
+  // (#3215) reduceRight seeds from / iterates down from `length - 1`; clamp the
+  // length to the physical backing so a sparse receiver does not TRAP on the
+  // out-of-bounds `data[length-1]` seed read (or the reverse scan). Beyond-
+  // backing indices are absent holes, skipped by reduceRight (§23.1.3.24), so
+  // seeding from and iterating the physical prefix is spec-correct. No-op for
+  // dense arrays. (reduceRight builds its own loop struct rather than going
+  // through setupArrayLoop, so it gets the clamp inline.)
+  fctx.body.push({ op: "local.get", index: lenTmp });
+  fctx.body.push({ op: "local.set", index: logicalLenTmp });
+  emitBackingLenClamp(fctx, lenTmp, dataTmp);
 
   const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
   const accTmp = allocLocal(fctx, `__arr_rr_acc_${fctx.locals.length}`, accType);
@@ -7815,6 +7862,7 @@ function compileArrayReduceRight(
     vecTmp,
     dataTmp,
     lenTmp,
+    logicalLenTmp,
     iTmp,
     getOp,
   };
@@ -8643,14 +8691,16 @@ function compileArraySort(
  * required helpers are unavailable (caller falls back to the numeric Timsort).
  */
 /**
- * (#3201) In-place clamp of a sort's length local to the physical WasmGC
- * backing: `lenLocal = min(lenLocal, array.len(dataLocal))`. A sparse array
- * (logical `.length` set beyond the backing) would otherwise trap on the
- * out-of-bounds `array.get`/`array.set` in the sort loop; per §23.1.3.30 the
- * beyond-backing indices are holes that sort to the end, so sorting only the
- * defined physical prefix is spec-correct. No-op for dense arrays.
+ * (#3201/#3215) In-place clamp of an array method's length local to the
+ * physical WasmGC backing: `lenLocal = min(lenLocal, array.len(dataLocal))`. A
+ * sparse array (logical `.length` set beyond the backing) would otherwise trap
+ * on the out-of-bounds `array.get`/`array.set` in the method's element loop.
+ * The beyond-backing indices are holes that every affected method treats as
+ * absent (sort moves them to the end §23.1.3.30; the HasProperty-driven HOFs
+ * SKIP them), so iterating only the defined physical prefix is spec-correct.
+ * No-op for dense arrays (backing ≥ length ⇒ min is the length).
  */
-function emitSortLenBackingClamp(fctx: FunctionContext, lenLocal: number, dataLocal: number): void {
+function emitBackingLenClamp(fctx: FunctionContext, lenLocal: number, dataLocal: number): void {
   fctx.body.push({ op: "local.get", index: lenLocal });
   fctx.body.push({ op: "local.get", index: dataLocal });
   fctx.body.push({ op: "array.len" });
@@ -8738,7 +8788,7 @@ function compileArrayDefaultToStringSort(
   // beyond-backing indices are holes that sort to the END, so sorting only the
   // physical defined prefix and leaving the holes in place is spec-correct.
   // Dense vecs keep `lenTmp` (backing ≥ length ⇒ runtime no-op).
-  emitSortLenBackingClamp(fctx, lenTmp, dataTmp);
+  emitBackingLenClamp(fctx, lenTmp, dataTmp);
 
   const getOp: Instr["op"] =
     elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
@@ -8928,7 +8978,7 @@ function tryCompileComparatorSort(
   // (#3201) Clamp the comparator sort length to the physical backing so a sparse
   // receiver does not trap on the out-of-bounds element access below. Holes sort
   // to the end (§23.1.3.30); no-op for dense arrays.
-  emitSortLenBackingClamp(fctx, lenTmp, dataTmp);
+  emitBackingLenClamp(fctx, lenTmp, dataTmp);
 
   const getOp: Instr["op"] =
     elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";

--- a/tests/issue-3215-hof-sparse.test.ts
+++ b/tests/issue-3215-hof-sparse.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3215 — Array.prototype HOF sparse-array read trap-safety. Analog of the
+ * #3201 read/copy family (#2968/#2970/#2973/#2980). On a sparse array (logical
+ * `.length` beyond the physical WasmGC backing) the callback HOFs iterate to
+ * the LOGICAL length via the shared `setupArrayLoop` and read `data[i]` past
+ * the backing → uncatchable "array element access out of bounds" trap. The fix
+ * clamps the shared loop bound to `min(len, array.len(data))`; per spec these
+ * HOFs skip absent (hole) indices, so iterating only the physical prefix is
+ * spec-correct. map keeps its LOGICAL result length (holes beyond the visited
+ * prefix stay default-initialised).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function numResult(body: string, target?: "standalone"): Promise<number> {
+  const src = `export function test(): number {\n${body}\n}`;
+  const r = await compile(src, { fileName: "issue-3215-hof-sparse.ts", target, skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+for (const target of ["standalone"] as const) {
+  describe(`#3215 HOF trap-safety on sparse arrays (${target})`, () => {
+    it("forEach on a sparse array visits only the defined prefix (no OOB trap)", async () => {
+      expect(
+        await numResult(
+          `const a = [1, 2, 3]; a.length = 6; let s = 0; a.forEach((x) => { s += x; }); return s;`,
+          target,
+        ),
+      ).toBe(6);
+    });
+
+    it("map on a sparse array does not trap and keeps the logical length", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.map((x) => x * 2).length;`, target)).toBe(6);
+      expect(
+        await numResult(`const a = [1, 2, 3]; a.length = 6; const b = a.map((x) => x * 2); return b[0];`, target),
+      ).toBe(2);
+    });
+
+    it("filter on a sparse array skips holes (no OOB trap)", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.filter((x) => x > 1).length;`, target)).toBe(
+        2,
+      );
+    });
+
+    it("reduce on a sparse array folds only the defined prefix (no OOB trap)", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.reduce((p, x) => p + x, 0);`, target)).toBe(
+        6,
+      );
+    });
+
+    it("every on a sparse array does not trap", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.every((x) => x > 0) ? 1 : 0;`, target)).toBe(
+        1,
+      );
+    });
+
+    it("some on a sparse array does not trap", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.some((x) => x > 2) ? 1 : 0;`, target)).toBe(
+        1,
+      );
+    });
+
+    it("find on a sparse array does not trap", async () => {
+      expect(
+        await numResult(`const a = [1, 2, 3]; a.length = 6; return a.find((x) => x === 2) as number;`, target),
+      ).toBe(2);
+    });
+
+    it("findIndex on a sparse array does not trap", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.findIndex((x) => x === 3);`, target)).toBe(2);
+    });
+
+    it("reduceRight on a sparse array folds the defined prefix (init + no-init, no OOB trap)", async () => {
+      expect(
+        await numResult(`const a = [1, 2, 3]; a.length = 6; return a.reduceRight((p, x) => p + x, 0);`, target),
+      ).toBe(6);
+      expect(await numResult(`const a = [1, 2, 3]; a.length = 6; return a.reduceRight((p, x) => p + x);`, target)).toBe(
+        6,
+      );
+    });
+
+    it("findLast on a sparse array does not trap (reverse-loop clamp)", async () => {
+      expect(
+        await numResult(`const a = [1, 2, 3]; a.length = 6; return a.findLast((x) => x === 2) as number;`, target),
+      ).toBe(2);
+    });
+
+    // --- dense controls (behaviourally unchanged) ---
+    it("dense forEach/map/filter/reduce unchanged", async () => {
+      expect(await numResult(`const a = [1, 2, 3]; let s = 0; a.forEach((x) => { s += x; }); return s;`, target)).toBe(
+        6,
+      );
+      expect(await numResult(`return [1, 2, 3].map((x) => x * 2).length;`, target)).toBe(3);
+      expect(await numResult(`return [1, 2, 3].filter((x) => x > 1).length;`, target)).toBe(2);
+      expect(await numResult(`return [1, 2, 3].reduce((p, x) => p + x, 0);`, target)).toBe(6);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Analog of the #3201 sparse-array read/copy trap-safety family (#2968 indexOf/lastIndexOf, #2970 slice/concat, #2973 pop/splice, #2980 sort/includes) — now for the callback HOF family.

On a **sparse array** (logical `.length` set beyond the physical WasmGC backing), `forEach`/`map`/`filter`/`reduce`/`reduceRight`/`every`/`some`/`find`/`findIndex`/`findLast`/`findLastIndex` iterate to the LOGICAL length reading `data[i]` → an uncatchable Wasm trap (`"array element access out of bounds"`) that aborts the whole test262 program (the #3185 §4 trap-first mandate).

## Fix

Root cause: the shared `setupArrayLoop` reads `lenTmp = field0` (logical) and `loopExitCheck` / `setupArrayLoopReverse` bound the loop by it.

- **Central clamp**: `setupArrayLoop` now clamps the loop bound to the physical backing (`lenTmp = min(len, array.len(data))` via the generalized `emitBackingLenClamp`, renamed from #2980's `emitSortLenBackingClamp`). One edit fixes every forward + reverse consumer (forEach/filter/map/reduce/find/findIndex/some/every/findLast/findLastIndex). Per spec these HOFs use HasProperty (holes SKIPPED), so iterating only the physical defined prefix is spec-correct.
- **reduceRight** builds its own loop struct → clamp applied inline (covers both the `data[length-1]` seed read and the reverse scan).
- **map result length**: `setupArrayLoop` also exposes the *unclamped* `logicalLenTmp`, and `compileArrayMap` sizes its result data + vec from it so a sparse map keeps the logical length (§23.1.3.19); beyond-backing result slots stay default-initialised (consistent with the #2001-S2 deferred map-result-hole behavior).
- **filter** uses a running kept-counter for its result length (clamped backing capacity suffices); **reduce**'s empty-array TypeError check on the clamped length is spec-correct.

Dense arrays are behaviourally unchanged (backing ≥ length ⇒ the clamp is a runtime no-op).

## Validation

- `tests/issue-3215-hof-sparse.test.ts` — standalone lane; forEach/map/filter/reduce/reduceRight/every/some/find/findIndex/findLast sparse (no trap, spec-correct) + dense controls.
- Zero new regressions: the `issue-2036` S6 "refuse-loudly" fails are pre-existing on `origin/main` (the array-like `.call` path is untouched by this change).
- `flatMap` stays a separate standalone feature gap (refuses at compile, does not trap) — out of scope.
- `loc-budget-allow` for `src/codegen/array-methods.ts` in the #3215 frontmatter (+50 genuine codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8