### PR TITLE
fix(#3220): PromiseResolve idempotence in wrapAsyncReturn — native $Promise identity through a Promise-returning call

### DIFF
--- a/plan/issues/3220-promise-return-double-wrap.md
+++ b/plan/issues/3220-promise-return-double-wrap.md
@@ -1,0 +1,127 @@
+---
+id: 3220
+title: "Standalone: native $Promise loses struct identity through a Promise-returning call consumed as a thenable (double-wrap)"
+status: done
+assignee: ttraenkler/opus-promiserep
+created: 2026-07-13
+completed: 2026-07-13
+priority: medium
+feasibility: hard
+task_type: fix
+area: codegen
+goal: standalone
+sprint: current
+horizon: s
+related: [3207, 2906, 3134, 1151, 2867]
+umbrella: 2906
+loc-budget-allow:
+  - src/codegen/expressions.ts
+---
+
+# Native `$Promise` loses struct identity through a `$Promise`-returning call (double-wrap)
+
+## Problem
+
+Banked by #3207: in async-generator / async code, a native `$Promise` that
+flows through a **user-function return** (`yield mk()` where
+`mk(): Promise<number>`) or a **Promise-typed local** initialised by such a call
+(`const pv = mk(); yield pv`) loses its native `$Promise` struct identity, so the
+suspend's `ref.test $Promise` misses and the value is delivered raw → **NaN**,
+while `yield await mk()` → 5 works.
+
+Measured on the host-free wasi drive lane (`.tmp/probe-promise-identity.mts`),
+before this fix:
+
+```
+yield await mk()                       → 5    (control, works)
+yield mk()                             → NaN  (call-return operand)
+const pv = mk(); yield pv              → NaN  (Promise-typed local)
+yield Promise.resolve(5)               → 5    (control, direct expression)
+const pv = Promise.resolve(5); yield pv → 5    (control, direct local)
+```
+
+The differentiator is the **user-function return**: the direct-expression /
+direct-local controls preserve identity, so it is neither the local-store nor
+the yield machinery — it is `mk()`'s call-site coercion.
+
+## Root cause (why the identity drops)
+
+`mk` (a plain, non-`async` function returning `Promise<number>`) already returns
+a real native `$Promise` externref on the carrier lane — its body
+`return Promise.resolve(5)` lowers to a `ref.test`-guarded PromiseResolve that
+yields the `$Promise`. But at the **call site**:
+
+1. `isAsyncCallExpression` (expressions.ts) classifies `mk()` as an "async call"
+   via the `isPromiseType(callSig.getReturnType())` fallback (#1151) — it matches
+   any signature returning `Promise<T>`, not only `async` declarations.
+2. `yield mk()`'s consumer is a `thenable` (the `YieldExpression` parent), so
+   `asyncResultConsumedAsValue` returns `false` → the wrap is NOT skipped.
+   (`yield await mk()` has an `AwaitExpression` parent → `value` consumer → wrap
+   IS skipped, which is why the control works.)
+3. `calleeIsDriveLowered` returns `false` — it only recognises drive-lowered
+   `async` *declarations*, and `mk` is a plain function.
+4. `wrapAsyncReturn`'s standalone/carrier arm then **unconditionally** builds a
+   SECOND `$Promise{FULFILLED, <mk()'s $Promise>, null}` — a Promise-of-Promise.
+
+Downstream, the async-gen yield suspend arm's `ref.test $Promise` succeeds on the
+OUTER wrapper (state FULFILLED), reads field 1 = the inner `$Promise`, and
+delivers it as `SENT`. Reading `.value` off a `$Promise` object → NaN.
+
+This violates PromiseResolve idempotence (§25.6.4.5.1 / §27.2.4.7:
+`Promise.resolve(p)` returns `p` when `p` is already a Promise). The
+drive-lowered-callee skip (`calleeIsDriveLowered`, #2867) already acknowledged
+the double-wrap for one narrow callee class; the fix generalises the correctness
+to a **runtime** guard covering every `$Promise`-returning callee.
+
+## Fix
+
+`wrapAsyncReturn`'s `isStandalonePromiseActive` arm (expressions.ts) is made
+idempotent: a runtime `ref.test $Promise` guard passes an **already-`$Promise`**
+value through UNCHANGED; a raw value takes the **unchanged** fulfilled-mint
+(byte-identical to pre-#3220 in that arm). One function, ~13 added instructions,
+mirroring `emitStandaloneAwaitUnwrap`'s proven guard shape.
+
+This resolves BOTH banked shapes at once, because both route the identity drop
+through `mk()`'s single `wrapAsyncReturn` call site:
+
+```
+yield mk()                → 5   (was NaN)
+const pv = mk(); yield pv → 5   (was NaN)
+```
+
+## Scope / carrier gating
+
+The arm is reached only when `isStandalonePromiseActive(ctx)` (wasi, or
+non-wasi standalone when the promise carrier is on — i.e. `!widenAsyncGenFallback`).
+So:
+
+- **gc/host** — `isStandalonePromiseActive` is false → the arm is never reached →
+  byte-identical for every program.
+- **standalone async-gen modules** — `widenAsyncGenFallback` keeps the carrier
+  off → byte-identical (host-consistent pipeline preserved, #2980).
+- **unrelated (non-async) modules** — never call `wrapAsyncReturn` →
+  byte-identical in every lane.
+- Only a **`$Promise`-returning call consumed as a thenable** on the active
+  carrier lane changes bytes, and only from the buggy double-wrap to the correct
+  passthrough (or the identical fulfilled-mint for a genuinely-raw value).
+
+## Byte-inertness proof (the −16/−29 discipline)
+
+sha256 of representative programs × {gc, standalone, wasi}, origin/main base vs
+branch (`.tmp/hash-3220.mts`, base restored via
+`git checkout origin/main -- src/codegen/expressions.ts`). Every gc lane is
+byte-identical; every non-async program is byte-identical in all three lanes;
+only a `$Promise`-returning-call-as-thenable program changes on the
+standalone + wasi carrier lanes (the intended unlock — see the `## Byte-inertness`
+table below for the measured hashes).
+
+## Verification
+
+`tests/issue-3220-promise-return-double-wrap.test.ts` (6 host-free wasi tests:
+the `yield mk()` fix → 5; the `const pv = mk(); yield pv` fix → 5; the
+`yield await mk()` control parity; a genuinely-pending call whose promise settles
+on a later microtask (suspends at kick, resumes to 42 on drain); a
+mixed call-then-plain-yield sequence; and the direct-expression control).
+`tsc --noEmit` clean. Process-isolated test262 async/async-gen/Promise
+measurement vs pristine-main control shows genuine fail→pass only, zero
+regressions (see `## Test Results`).

--- a/plan/issues/3220-promise-return-double-wrap.md
+++ b/plan/issues/3220-promise-return-double-wrap.md
@@ -107,21 +107,58 @@ So:
 
 ## Byte-inertness proof (the −16/−29 discipline)
 
-sha256 of representative programs × {gc, standalone, wasi}, origin/main base vs
-branch (`.tmp/hash-3220.mts`, base restored via
-`git checkout origin/main -- src/codegen/expressions.ts`). Every gc lane is
-byte-identical; every non-async program is byte-identical in all three lanes;
-only a `$Promise`-returning-call-as-thenable program changes on the
-standalone + wasi carrier lanes (the intended unlock — see the `## Byte-inertness`
-table below for the measured hashes).
+sha256 (first 16 hex) of representative programs × {gc, standalone, wasi},
+origin/main base vs branch (`.tmp/hash-3220.mts`, base restored via
+`git checkout origin/main -- src/codegen/expressions.ts`). 16/18 identical; the
+ONLY two changes are the async-gen fix on wasi:
+
+| program            | gc        | standalone                 | wasi                          |
+| ------------------ | --------- | -------------------------- | ----------------------------- |
+| nonAsync           | identical | identical                  | identical                     |
+| **promiseCallYield** | identical | identical (widenAsyncGenFb) | **CHANGED** (intended unlock) |
+| **promiseCallLocal** | identical | identical (widenAsyncGenFb) | **CHANGED** (intended unlock) |
+| awaitCallYield     | identical | identical                  | identical                     |
+| directPromiseYield | identical | identical                  | identical                     |
+| plainGen           | identical | identical                  | identical                     |
+
+For an async-generator module, the standalone lane keeps `widenAsyncGenFallback`
+on (carrier off) so it is byte-identical (host-consistency preserved). A separate
+**non-generator** module (`mk().then(v=>v+1)`, `.tmp/probe-standalone-nongen.mts`)
+confirms the standalone carrier lane IS reached and changed by the fix, while gc
+stays identical:
+
+| lane       | base       | branch     |
+| ---------- | ---------- | ---------- |
+| gc         | `57aab3fa…` | `57aab3fa…` (identical) |
+| standalone | `45b4b9f6…` | `b8101202…` (CHANGED)  |
+| wasi       | `ad9f20df…` | `d1b5dc32…` (CHANGED)  |
 
 ## Verification
 
-`tests/issue-3220-promise-return-double-wrap.test.ts` (6 host-free wasi tests:
-the `yield mk()` fix → 5; the `const pv = mk(); yield pv` fix → 5; the
+`tests/issue-3220-promise-return-double-wrap.test.ts` (6 host-free wasi tests,
+all pass: the `yield mk()` fix → 5; the `const pv = mk(); yield pv` fix → 5; the
 `yield await mk()` control parity; a genuinely-pending call whose promise settles
 on a later microtask (suspends at kick, resumes to 42 on drain); a
 mixed call-then-plain-yield sequence; and the direct-expression control).
-`tsc --noEmit` clean. Process-isolated test262 async/async-gen/Promise
-measurement vs pristine-main control shows genuine fail→pass only, zero
-regressions (see `## Test Results`).
+`tsc --noEmit` clean.
+
+## Test Results
+
+- **Repro (host-free wasi, `.tmp/probe-promise-identity.mts`)** — before → after:
+  `yield mk()` NaN → 5; `const pv = mk(); yield pv` NaN → 5; the three controls
+  (`yield await mk()`, `yield Promise.resolve(5)`, direct local) stay 5.
+- **test262 standalone A/B** (process-isolated `runTest262File`, 590 files:
+  async-function / async-arrow / await / Promise resolve·reject·then·all·race·finally),
+  branch vs base: `{pass:348, fail:226, compile_error:16}` on BOTH — **zero flips,
+  zero regressions**. (These files don't isolate the double-wrap shape, so no
+  fail→pass here; the genuine unlock is the wasi async-gen drive lane the harness
+  can't target, proven non-vacuously by the vitest tests above.)
+- **test262 gc A/B** (249 files: async-function / async-arrow / await), branch vs
+  base: **zero flips** — confirms the hash-proven gc inertness behaviourally.
+- **vitest async/async-gen/Promise blast radius** (17 files, 129 tests:
+  async-await, async-census, 1042[-host-drive], 2895[-drain-hook],
+  2906-3a/3b/3di/3dii/multiawait/gap3, 2865, 3134, 2623, 3207, 3220): 124 pass;
+  the 5 failures (3× gap3-tryfinally throw-path, 2× issue-2865 AG0-wasi harness)
+  are **pre-existing on origin/main** — verified an identical 5-fail set on the
+  base checkout (`git checkout origin/main -- src/codegen/expressions.ts`). Zero
+  regressions.

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -443,11 +443,37 @@ function wrapAsyncReturn(ctx: CodegenContext, fctx: FunctionContext, resultType:
     const valueLocal = allocTempLocal(fctx, { kind: "externref" });
     const promiseTypeIdx = getOrRegisterPromiseType(ctx);
     fctx.body.push({ op: "local.set", index: valueLocal });
-    fctx.body.push({ op: "i32.const", value: PROMISE_STATE_FULFILLED });
+    // (#3220) PromiseResolve idempotence (§25.6.4.5.1 / §27.2.4.7): a value that
+    // is ALREADY a native `$Promise` must pass through UNCHANGED, not be
+    // re-wrapped in a SECOND `$Promise`. The unconditional fulfilled-mint below
+    // double-wrapped a callee that already returns a native `$Promise` on the
+    // carrier lane — e.g. a plain `function mk(): Promise<number>` whose result
+    // is consumed as a thenable (`yield mk()`, `const pv = mk(); yield pv`,
+    // `mk().then(...)`). `isAsyncCallExpression` classifies such a call as an
+    // "async call" via its `Promise<T>` return type (#1151), so it reaches this
+    // wrap even though the raw `$Promise` is already on the stack; the second
+    // `$Promise{FULFILLED, <innerPromise>, null}` made a later `ref.test
+    // $Promise` (the await/yield suspend arm) adopt the OUTER wrapper and
+    // deliver the inner promise OBJECT raw → NaN (`calleeIsDriveLowered` only
+    // skips the wrap for drive-lowered async *declarations*, not a plain
+    // `$Promise`-returning fn). A runtime `ref.test $Promise` guard makes the
+    // wrap idempotent: an existing `$Promise` passes through; a raw value takes
+    // the unchanged fulfilled-mint (byte-identical to pre-#3220 in that arm).
     fctx.body.push({ op: "local.get", index: valueLocal });
-    fctx.body.push({ op: "ref.null.extern" });
-    fctx.body.push({ op: "struct.new", typeIdx: promiseTypeIdx });
-    fctx.body.push({ op: "extern.convert_any" });
+    fctx.body.push({ op: "any.convert_extern" });
+    fctx.body.push({ op: "ref.test", typeIdx: promiseTypeIdx });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [{ op: "local.get", index: valueLocal }],
+      else: [
+        { op: "i32.const", value: PROMISE_STATE_FULFILLED },
+        { op: "local.get", index: valueLocal },
+        { op: "ref.null.extern" },
+        { op: "struct.new", typeIdx: promiseTypeIdx },
+        { op: "extern.convert_any" },
+      ],
+    });
     releaseTempLocal(fctx, valueLocal);
     return { kind: "externref" };
   }

--- a/tests/issue-3220-promise-return-double-wrap.test.ts
+++ b/tests/issue-3220-promise-return-double-wrap.test.ts
@@ -1,0 +1,133 @@
+// #3220 — native `$Promise` struct-identity preservation through a
+// `$Promise`-returning call consumed as a thenable.
+//
+// Root cause: `wrapAsyncReturn` (expressions.ts) wrapped an "async call" result
+// in `Promise.resolve(...)`. `isAsyncCallExpression` classifies ANY call whose
+// signature returns `Promise<T>` as async (#1151), including a PLAIN
+// `function mk(): Promise<number>` that already returns a native `$Promise` on
+// the standalone/wasi carrier lane. The standalone arm's UNCONDITIONAL
+// fulfilled-mint then built a SECOND `$Promise{FULFILLED, <innerPromise>, null}`
+// — a Promise-of-Promise. A later `ref.test $Promise` (the async-gen yield /
+// await suspend arm) adopted the OUTER wrapper and delivered the inner promise
+// OBJECT raw, which reads as NaN. `calleeIsDriveLowered` only un-wrapped
+// drive-lowered async *declarations*, not a plain `$Promise`-returning fn.
+//
+// Fix: make the wrap idempotent (§25.6.4.5.1 / §27.2.4.7 PromiseResolve) — a
+// value already a native `$Promise` passes through unchanged; a raw value takes
+// the unchanged fulfilled-mint. So `yield mk()` and `const pv = mk(); yield pv`
+// deliver the resolved value, matching the `yield await mk()` control.
+//
+// Native (wasi) drive lane; gc/host stays inert (`isStandalonePromiseActive`
+// is false there), and unrelated non-async modules are byte-identical.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface GenExports {
+  g: () => unknown;
+  __async_gen_next_g: (frame: unknown) => unknown;
+  __async_gen_p_state: (p: unknown) => number;
+  __async_gen_result_done: (p: unknown) => number;
+  __async_gen_result_value: (p: unknown) => number;
+  __drain_microtasks: () => void;
+}
+
+async function instantiateAsyncGen(src: string): Promise<GenExports> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // Host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as GenExports;
+}
+
+/** Drive one `next()`, drain microtasks, read the settled IteratorResult. */
+function step(ex: GenExports, frame: unknown): { pendingBeforeDrain: boolean; done: number; value: number } {
+  const p = ex.__async_gen_next_g(frame);
+  const pendingBeforeDrain = ex.__async_gen_p_state(p) === 0;
+  ex.__drain_microtasks();
+  expect(ex.__async_gen_p_state(p)).toBe(1); // FULFILLED
+  return { pendingBeforeDrain, done: ex.__async_gen_result_done(p), value: ex.__async_gen_result_value(p) };
+}
+
+describe("#3220 — native $Promise identity through a Promise-returning call consumed as a thenable", () => {
+  it("THE fix: `yield mk()` (call-return operand) awaits the returned $Promise → resolved value, not NaN", async () => {
+    const ex = await instantiateAsyncGen(`
+      function mk(): Promise<number> { return Promise.resolve(5); }
+      export async function* g(): AsyncGenerator<number> {
+        yield mk();
+      }
+    `);
+    const frame = ex.g();
+    const s = step(ex, frame);
+    // Was NaN before the fix (the double-wrapped $Promise delivered the inner
+    // promise object raw).
+    expect([s.done, s.value]).toEqual([0, 5]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("THE fix: `const pv = mk(); yield pv` (Promise-typed local) → resolved value, not NaN", async () => {
+    const ex = await instantiateAsyncGen(`
+      function mk(): Promise<number> { return Promise.resolve(5); }
+      export async function* g(): AsyncGenerator<number> {
+        const pv: Promise<number> = mk();
+        yield pv;
+      }
+    `);
+    const frame = ex.g();
+    const s = step(ex, frame);
+    expect([s.done, s.value]).toEqual([0, 5]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("control parity: `yield await mk()` still delivers the resolved value", async () => {
+    const ex = await instantiateAsyncGen(`
+      function mk(): Promise<number> { return Promise.resolve(5); }
+      export async function* g(): AsyncGenerator<number> {
+        yield await mk();
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(5);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("genuine suspension: a Promise-returning call whose promise settles on a later microtask", async () => {
+    const ex = await instantiateAsyncGen(`
+      function mk(): Promise<number> { return Promise.resolve(2).then((v: number) => v + 40); }
+      export async function* g(): AsyncGenerator<number> {
+        yield mk();
+      }
+    `);
+    const frame = ex.g();
+    const s = step(ex, frame);
+    expect(s.pendingBeforeDrain).toBe(true); // not resolved until the drain
+    expect([s.done, s.value]).toEqual([0, 42]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("mixed: a Promise-returning-call yield followed by a plain yield delivers both in order", async () => {
+    const ex = await instantiateAsyncGen(`
+      function mk(): Promise<number> { return Promise.resolve(7); }
+      export async function* g(): AsyncGenerator<number> {
+        yield mk();
+        yield 8;
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(7);
+    expect(step(ex, frame).value).toBe(8);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("control: direct `yield Promise.resolve(5)` unchanged (no call-return coercion)", async () => {
+    const ex = await instantiateAsyncGen(`
+      export async function* g(): AsyncGenerator<number> {
+        yield Promise.resolve(5);
+      }
+    `);
+    const frame = ex.g();
+    expect(step(ex, frame).value).toBe(5);
+    expect(step(ex, frame).done).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Banked by #3207: in async-generator / async code, a native `$Promise` that flows
through a **user-function return** (`yield mk()` where `mk(): Promise<number>`) or
a **Promise-typed local** (`const pv = mk(); yield pv`) lost its native `$Promise`
struct identity — the suspend's `ref.test $Promise` missed and the value was
delivered raw → **NaN**, while `yield await mk()` → 5 worked. The differentiator
is the user-function return: direct-expression / direct-local controls preserve
identity.

## Root cause

`mk` (a plain, non-`async` `Promise<number>`-returning fn) already returns a real
native `$Promise` on the carrier lane. But `isAsyncCallExpression` classifies
`mk()` as an "async call" via the `Promise<T>`-return fallback (#1151),
`yield mk()`'s thenable consumer doesn't skip the wrap, and `calleeIsDriveLowered`
only skips drive-lowered async *declarations*. So `wrapAsyncReturn`'s
standalone/carrier arm **unconditionally** built a SECOND
`$Promise{FULFILLED, <mk()'s $Promise>, null}` — a Promise-of-Promise. The
async-gen yield suspend arm's `ref.test $Promise` adopted the OUTER wrapper,
delivered the inner promise OBJECT as `SENT`, and reading `.value` off it → NaN.
This violates PromiseResolve idempotence (§25.6.4.5.1 / §27.2.4.7).

## Fix

One function — `wrapAsyncReturn`'s `isStandalonePromiseActive` arm
(`src/codegen/expressions.ts`, +30/−4). A runtime `ref.test $Promise` guard makes
the wrap idempotent: an already-`$Promise` value passes through UNCHANGED; a raw
value takes the **unchanged** fulfilled-mint. Mirrors `emitStandaloneAwaitUnwrap`.
Resolves BOTH banked shapes at their single call site (`yield mk()` → 5,
`const pv = mk(); yield pv` → 5).

## Byte-inertness (the −16/−29 discipline)

- **gc/host**: byte-identical always (`isStandalonePromiseActive` false).
- **standalone async-gen modules**: byte-identical (`widenAsyncGenFallback`
  host-consistency preserved, #2980).
- **unrelated (non-async) modules**: byte-identical everywhere.
- Only a `$Promise`-returning call consumed as a thenable on the active carrier
  lane changes (async-gen wasi + non-gen standalone). sha256 A/B: 16/18 identical;
  the two changes are `promiseCall{Yield,Local}/wasi`.

## Measurement (branch vs pristine-main)

- **Repro** (host-free wasi): `yield mk()` NaN→5, `const pv=mk(); yield pv` NaN→5;
  controls stay 5.
- **test262 standalone A/B** (`runTest262File`, 590 async-function/async-arrow/
  await/Promise files): `{pass:348, fail:226, ce:16}` on both — **zero flips**.
- **test262 gc A/B** (249 files): **zero flips**.
- **vitest async/async-gen/Promise blast radius** (17 files / 129 tests): 124
  pass; the 5 failures (3× gap3-tryfinally throw-path, 2× issue-2865 AG0-wasi
  harness) are **pre-existing on origin/main** (identical 5-fail set on base).
  Zero regressions.
- **New**: `tests/issue-3220-promise-return-double-wrap.test.ts` (6 host-free wasi
  tests) + 4 #3207 siblings pass. `tsc --noEmit` clean.

Closes #3220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS