### PR TITLE
fix(#3225): standalone Array write-path sparse-array trap-safety (fill/reverse/copyWithin backing-grow)

### DIFF
--- a/plan/issues/3225-array-writepath-sparse-trapsafe.md
+++ b/plan/issues/3225-array-writepath-sparse-trapsafe.md
@@ -1,0 +1,88 @@
+---
+id: 3225
+title: "standalone Array write-path sparse-array trap-safety (fill/reverse/copyWithin backing-grow)"
+status: done
+created: 2026-07-13
+updated: 2026-07-13
+completed: 2026-07-13
+assignee: opus-writepath
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: array-methods
+goal: builtin-methods
+sprint: current
+horizon: m
+umbrella: 3185
+parent: 3201
+related: [3201, 3185, 3169]
+loc-budget-allow:
+  - src/codegen/array-methods.ts
+origin: "2026-07-13 write-path tail of the #3201 sparse-array trap family (read family #2968→#2990 done)"
+---
+
+# #3225 — standalone Array write-path sparse-array trap-safety
+
+The distinct, bigger tail of the #3201 sparse-array trap family. The **read**
+family (indexOf/lastIndexOf/slice/concat/pop/splice/sort/includes) landed in
+#2968→#2990 by CLAMPING copies/reads down to the physical WasmGC backing. The
+**in-place WRITE/move** methods — `fill`, `reverse`, `copyWithin` — cannot
+clamp: they must land a write at every index up to the LOGICAL `.length`, so
+on a sparse array (logical `.length` set beyond the backing via the
+`a.length = N` setter) they index `data[i]` past `array.len(data)` and TRAP
+("array element access out of bounds"), an uncatchable Wasm abort (#3185 §4
+trap-first mandate).
+
+## Mechanism (distinct from the read family — GROW, not clamp)
+
+A vec is `struct { 0: length i32, 1: data (ref $arr) }`. Index-writes and
+`push` already grow the backing to the needed capacity
+(`array.new_default` + `array.copy` + `struct.set` field 1); sparse arrays
+arise only via the `a.length = N` setter, which bumps field 0 without growing
+the backing.
+
+New shared helper **`emitEnsureBackingCapacity(vecLocal, dataLocal, …,
+neededLenLocal)`** (in `array-methods.ts`) reuses that canonical grow shape: when
+`array.len(data) < needed` it reallocates the backing to `needed`, copies the
+in-backing prefix, writes it back into the vec, and re-points the caller's
+`dataLocal`. Grow-only (never shrinks); a dense receiver is a runtime no-op.
+
+Applied at three sites, **`ctx.standalone`/`ctx.wasi`-gated** so the host/gc
+lane emits byte-identical code (the grow branch isn't emitted there at all):
+
+- **fill** — grow to the clamped `end` (§23.3.3.7 fill writes its range
+  unconditionally, no HasProperty guard ⇒ grow-then-write is spec-exact).
+- **reverse** — grow to the logical length (`j + 1`) so the two-pointer swap
+  reaches both ends.
+- **copyWithin** — grow to the logical length (target/start/end are all clamped
+  to `len`, so `target+count ≤ len` and `start+count ≤ len`).
+
+The freshly-allocated tail is default-initialised (0/null): `fill` overwrites
+its range; `reverse`/`copyWithin` move those defaults. The residual
+undefined-vs-null hole fidelity for externref sparse arrays matches the read
+family's precedent and the #2106 conflation — out of scope here; the trap-first
+mandate is to eliminate the abort.
+
+**Out of scope** (documented follow-ups): huge sparse-index WRITES
+(`arr[2**32-2] = v` — the index-write path, whose i32 length field can't even
+hold the index; the dominant remaining trap cause per #3201), and flat/flatMap
+(feature gap #2717, refuse-not-trap).
+
+## Acceptance criteria
+
+1. `fill` / `reverse` / `copyWithin` on a sparse array → no Wasm trap
+   (standalone). ✓
+2. Dense arrays byte-identical on host/gc (gate); dense standalone unaffected
+   (never-taken branch). ✓
+3. Dedicated tests + zero standalone-floor regression. ✓
+   (`tests/issue-3201-writepath.test.ts` 11/11; the array-capacity /
+   fast-arrays / array-oob pre-existing fails are present identically on clean
+   `origin/main`.)
+
+## Result
+
+Native WasmGC backing-grow makes the standalone write-path family trap-safe.
+`emitEnsureBackingCapacity` is the write-side mirror of the read family's
+`emitBackingClampedCopyLen`.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -588,6 +588,78 @@ export function emitClampNonNeg(fctx: FunctionContext, local: number): void {
   } as Instr);
 }
 
+/**
+ * (#3201 write-path) Grow a vec's physical WasmGC backing array so it can hold
+ * at least `neededLen` elements, then keep `dataLocal` pointing at the (possibly
+ * reallocated) backing. The mirror-image of the READ family's
+ * {@link emitBackingClampedCopyLen}: those methods COPY out and clamp the count
+ * down to the backing so they never trap; the in-place WRITE/move family
+ * (`fill`/`reverse`/`copyWithin`) must instead materialise the missing slots so
+ * the write itself lands in-bounds.
+ *
+ * A sparse array — logical `.length` (field 0) pushed beyond the backing via the
+ * `a.length = N` setter — has `array.len(data) < length`. `fill`/`reverse`/
+ * `copyWithin` then index `data[i]` up to the LOGICAL length and TRAP ("array
+ * element access out of bounds"), an uncatchable abort. This helper reallocates
+ * the backing to `neededLen` (`array.new_default` + `array.copy` of the existing
+ * prefix + `struct.set` field 1), exactly the grow shape used by
+ * `compileArrayPush` / `maybeEmitVecLengthGrowth`, so the vec regains
+ * `capacity ≥ neededLen` and the write is bounds-safe. The freshly-allocated
+ * tail is default-initialised (0 / null) — the beyond-backing indices that were
+ * absent holes; `fill` overwrites its range unconditionally (spec-exact,
+ * §23.3.3.7 writes without a HasProperty guard), while `reverse`/`copyWithin`
+ * move those defaults (the minor undefined-vs-null fidelity gap for externref
+ * sparse arrays matches the read family's precedent; the trap-first mandate,
+ * #3185 §4, prioritises eliminating the abort).
+ *
+ * Grow only — never shrinks. A non-sparse vec (backing capacity ≥ neededLen) is
+ * a runtime no-op (the `if` is not taken). Callers gate the EMISSION on
+ * `ctx.standalone`/`ctx.wasi` so the host/gc lane stays byte-identical.
+ */
+function emitEnsureBackingCapacity(
+  fctx: FunctionContext,
+  vecLocal: number,
+  dataLocal: number,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  neededLenLocal: number,
+): void {
+  const oldCap = allocLocal(fctx, `__ensure_ocap_${fctx.locals.length}`, { kind: "i32" });
+  const newData = allocLocal(fctx, `__ensure_ndata_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
+
+  // if (array.len(data) < needed) grow backing to `needed`
+  fctx.body.push({ op: "local.get", index: dataLocal });
+  fctx.body.push({ op: "array.len" });
+  fctx.body.push({ op: "local.tee", index: oldCap });
+  fctx.body.push({ op: "local.get", index: neededLenLocal });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      // newData = array.new_default(needed)
+      { op: "local.get", index: neededLenLocal } as Instr,
+      { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+      { op: "local.set", index: newData } as Instr,
+      // array.copy newData[0..oldCap] = data[0..oldCap]
+      { op: "local.get", index: newData } as Instr,
+      { op: "i32.const", value: 0 } as Instr,
+      { op: "local.get", index: dataLocal } as Instr,
+      { op: "i32.const", value: 0 } as Instr,
+      { op: "local.get", index: oldCap } as Instr,
+      { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+      // vec.data = newData
+      { op: "local.get", index: vecLocal } as Instr,
+      { op: "local.get", index: newData } as Instr,
+      { op: "ref.as_non_null" } as Instr,
+      { op: "struct.set", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
+      // keep the caller's data pointer pointing at the grown backing
+      { op: "local.get", index: newData } as Instr,
+      { op: "local.set", index: dataLocal } as Instr,
+    ],
+  } as Instr);
+}
+
 // ── Array method calls (pure Wasm, no host imports) ─────────────────
 
 /** Resolve array type info from a TS type. Returns null if not a Wasm GC vec struct. */
@@ -5009,6 +5081,21 @@ function compileArrayReverse(
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
   fctx.body.push({ op: "local.set", index: dataTmp });
 
+  // (#3201 write-path) A SPARSE array (logical `.length` beyond the WasmGC
+  // backing via `a.length = N`) makes the two-pointer swap read/write `data[i]`
+  // / `data[j]` up to the LOGICAL length (`j = length - 1`) and TRAP ("array
+  // element access out of bounds"). Grow the backing to the logical length
+  // (`j + 1`) so the whole reversal lands in-bounds. Standalone/WASI-gated
+  // (host/gc byte-identical); dense receiver ⇒ runtime no-op.
+  if (ctx.standalone || ctx.wasi) {
+    const needTmp = allocLocal(fctx, `__arr_rev_need_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push({ op: "local.get", index: jTmp });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "i32.add" });
+    fctx.body.push({ op: "local.set", index: needTmp });
+    emitEnsureBackingCapacity(fctx, vecTmp, dataTmp, vecTypeIdx, arrTypeIdx, needTmp);
+  }
+
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "local.set", index: iTmp });
 
@@ -9204,6 +9291,18 @@ function compileArrayFill(
   fctx.body.push({ op: "local.set", index: endTmp });
   emitClampIndex(fctx, endTmp, lenTmp);
 
+  // (#3201 write-path) On a SPARSE array (logical `.length` set beyond the
+  // WasmGC backing via `a.length = N`) the write range `[start, end)` runs past
+  // `array.len(data)` and the `array.set` below TRAPS ("array element access out
+  // of bounds"). `fill` writes its range unconditionally (§23.3.3.7 has no
+  // HasProperty guard), so grow the backing to the clamped `end` first — then
+  // the whole loop lands in-bounds and materialises the (formerly absent) slots
+  // as required. Standalone/WASI-gated so the host/gc lane stays byte-identical;
+  // a dense receiver (capacity ≥ end) makes the grow a runtime no-op.
+  if (ctx.standalone || ctx.wasi) {
+    emitEnsureBackingCapacity(fctx, vecTmp, dataTmp, vecTypeIdx, arrTypeIdx, endTmp);
+  }
+
   // i = start
   fctx.body.push({ op: "local.get", index: startTmp });
   fctx.body.push({ op: "local.set", index: iTmp });
@@ -9612,6 +9711,19 @@ function compileArrayCopyWithin(
   fctx.body.push({ op: "select" });
   fctx.body.push({ op: "local.set", index: countTmp });
   emitClampNonNeg(fctx, countTmp);
+
+  // (#3201 write-path) On a SPARSE array (logical `.length` beyond the WasmGC
+  // backing via `a.length = N`) both the source `[start, start+count)` and the
+  // destination `[target, target+count)` ranges — clamped to the LOGICAL length
+  // — can run past `array.len(data)`, so the in-place `array.copy` below TRAPS
+  // ("array element access out of bounds"). Grow the backing to the logical
+  // length first (target/start/end are all clamped to `len`, so
+  // `target+count ≤ len` and `start+count ≤ len`); the move then lands
+  // in-bounds. Standalone/WASI-gated (host/gc byte-identical); dense receiver ⇒
+  // runtime no-op.
+  if (ctx.standalone || ctx.wasi) {
+    emitEnsureBackingCapacity(fctx, vecTmp, dataTmp, vecTypeIdx, arrTypeIdx, lenTmp);
+  }
 
   // array.copy data[target..target+count] = data[start..start+count]
   emitArrayCopy(fctx, arrTypeIdx, dataTmp, targetTmp, dataTmp, startTmp, countTmp);

--- a/tests/issue-3201-writepath.test.ts
+++ b/tests/issue-3201-writepath.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3201 (write-path) — Array.prototype in-place WRITE/move trap-safety on sparse
+ * arrays. Follow-up tail of the merged sparse-READ family (#2968 indexOf →
+ * #2990 pop/splice). `fill` / `reverse` / `copyWithin` write or move elements
+ * up to the LOGICAL `.length`. On a sparse array — logical `.length` set beyond
+ * the physical WasmGC backing via the `a.length = N` setter — those indices run
+ * past `array.len(data)` and the `array.set` / `array.copy` TRAPS ("array
+ * element access out of bounds"), an uncatchable Wasm abort (#3185 §4
+ * trap-first mandate).
+ *
+ * Unlike the read family (which CLAMPED copies down to the backing), the write
+ * family must GROW the backing so the write itself lands in-bounds. The shared
+ * `emitEnsureBackingCapacity` helper reallocates the backing to the needed
+ * length (`array.new_default` + `array.copy` of the prefix + `struct.set`), the
+ * same grow shape as `compileArrayPush`. Standalone/WASI-gated so the host/gc
+ * lane stays byte-identical; a dense receiver (capacity ≥ needed) makes the
+ * grow a runtime no-op.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function num(body: string, target: "standalone" = "standalone"): Promise<number> {
+  const src = `export function test(): number {\n${body}\n}`;
+  const r = await compile(src, { fileName: "issue-3201-writepath.ts", target, skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#3201 write-path sparse-array trap-safety (standalone)", () => {
+  // --- fill ---
+  it("fill() on a length-extended empty array materialises the range (no OOB trap)", async () => {
+    expect(await num(`const a: any[] = []; a.length = 5; a.fill(7); return a[3] === 7 ? 1 : 0;`)).toBe(1);
+  });
+  it("fill() keeps the logical length on a partially-backed sparse array", async () => {
+    expect(await num(`const a: any[] = [1]; a.length = 4; a.fill(9); return a.length;`)).toBe(4);
+  });
+  it("fill(value, start) with start past the backing does not trap", async () => {
+    expect(
+      await num(`const a: any[] = [1]; a.length = 5; a.fill(3, 2); return (a[3] === 3 && a.length === 5) ? 1 : 0;`),
+    ).toBe(1);
+  });
+  it("fill(value, start, end) fills only the requested sub-range (lower edge respected)", async () => {
+    // a[0] is below `start` so it keeps its original 0; a[1]/a[3] are in [start,end).
+    // (a[4] is a beyond-grown-backing index read — the separate pre-existing sparse
+    // index-READ trap, out of this write-path slice's scope.)
+    expect(
+      await num(
+        `const a: number[] = [0]; a.length = 6; a.fill(2, 1, 4); return (a[0]===0 && a[1]===2 && a[3]===2) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  // --- reverse ---
+  it("reverse() on a sparse array does not trap and keeps the length", async () => {
+    expect(await num(`const a: any[] = [1]; a.length = 4; a.reverse(); return a.length;`)).toBe(4);
+  });
+  it("reverse() moves the in-backing value to the tail", async () => {
+    expect(await num(`const a: any[] = [1]; a.length = 3; a.reverse(); return a[2] === 1 ? 1 : 0;`)).toBe(1);
+  });
+
+  // --- copyWithin ---
+  it("copyWithin() on a sparse array does not trap and keeps the length", async () => {
+    expect(await num(`const a: any[] = [1, 2]; a.length = 6; a.copyWithin(3, 0); return a.length;`)).toBe(6);
+  });
+  it("copyWithin(target, start, end) moves the in-backing prefix into a grown region", async () => {
+    expect(
+      await num(
+        `const a: number[] = [5, 6]; a.length = 6; a.copyWithin(3, 0, 2); return (a[3]===5 && a[4]===6) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  // --- dense receivers: the standalone grow branch is present but never taken ---
+  it("dense fill() is unchanged", async () => {
+    expect(
+      await num(`const a = [1, 2, 3, 4]; a.fill(0, 1, 3); return (a[1]===0 && a[2]===0 && a[3]===4) ? 1 : 0;`),
+    ).toBe(1);
+  });
+  it("dense reverse() is unchanged", async () => {
+    expect(await num(`return [1, 2, 3].reverse()[0];`)).toBe(3);
+  });
+  it("dense copyWithin() is unchanged", async () => {
+    expect(await num(`const a = [1, 2, 3, 4, 5]; a.copyWithin(0, 3); return (a[0]===4 && a[1]===5) ? 1 : 0;`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

The distinct write-path tail of the **#3201** sparse-array trap family (sub-issue **#3225**). The **read** family (indexOf/lastIndexOf/slice/concat/pop/splice/sort/includes) landed in #2968→#2990 by **clamping** copies/reads down to the physical WasmGC backing. The in-place **write/move** methods — `fill`, `reverse`, `copyWithin` — cannot clamp: they must land a write at every index up to the LOGICAL `.length`. On a **sparse** array (logical `.length` set beyond the backing via the `a.length = N` setter) they index `data[i]` past `array.len(data)` and **trap** (`array element access out of bounds`), an uncatchable Wasm abort (#3185 §4 trap-first mandate).

## How — GROW, not clamp (distinct mechanism)

New shared helper `emitEnsureBackingCapacity` reuses the canonical push/index-write grow shape (`array.new_default` + `array.copy` of the in-backing prefix + `struct.set` field 1, re-pointing the caller's `data` local) to reallocate the backing to the needed length **before** the write. Grow-only; a dense receiver is a runtime no-op. It's the write-side mirror of the read family's `emitBackingClampedCopyLen`.

Applied at three sites, **`ctx.standalone`/`ctx.wasi`-gated** so the host/gc lane emits **byte-identical** code (the grow branch isn't emitted there at all):

| method | grows backing to | note |
|---|---|---|
| `fill` | clamped `end` | §23.3.3.7 writes unconditionally ⇒ grow-then-write is spec-exact |
| `reverse` | logical length (`j+1`) | two-pointer swap reaches both ends |
| `copyWithin` | logical length | target/start/end clamped to `len` ⇒ `target+count ≤ len`, `start+count ≤ len` |

## Out of scope (documented follow-ups)

- **Huge sparse-index WRITES** (`arr[2**32-2]=v`) — the index-**write** path, whose i32 length field can't even hold the index; the dominant remaining trap cause per #3201.
- **flat/flatMap** — feature gap #2717 (refuse, not trap).

## Validation

- `tests/issue-3201-writepath.test.ts` — **11/11** (sparse fill/reverse/copyWithin no-trap + spec results, plus dense no-op-branch cases).
- Merged read-family suites (#3201 / slice-concat / pop-splice) — **25/25**, unchanged.
- **Zero regressions**: the array-capacity / fast-arrays / array-oob-bounds fails are a pre-existing harness issue, present **identically on clean `origin/main`** (verified in a detached baseline worktree).
- Broad-impact → validates on the `merge_group` standalone floor; expected floor delta **net ≥ 0** (pass-flips for the 15.4.4.* sparse write cases that currently trap-abort; dense/host-gc byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)