### PR TITLE
refactor(#3204): self-host Math trig cores (sin/cos/tan, atan/asin/acos) — net −126 LOC, bit-exact

### DIFF
--- a/plan/issues/3203-ir-first-allowlist-widen-bool.md
+++ b/plan/issues/3203-ir-first-allowlist-widen-bool.md
@@ -1,11 +1,12 @@
 ---
 id: 3203
 title: "IR-first allowlist widen: f64 → f64+boolean (Phase-3a enabler)"
-status: in-progress
+status: done
 assignee: ttraenkler/opus-sendev
 sprint: current
 created: 2026-07-13
 updated: 2026-07-13
+completed: 2026-07-13
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3204-selfhost-math-log-atan.md
+++ b/plan/issues/3204-selfhost-math-log-atan.md
@@ -1,11 +1,12 @@
 ---
 id: 3204
 title: "Self-host Math.log + Math.log2 cores (bloat −LOC, scale-up slice)"
-status: in-progress
+status: done
 assignee: ttraenkler/opus-sendev
 sprint: current
 created: 2026-07-13
 updated: 2026-07-13
+completed: 2026-07-13
 priority: high
 horizon: m
 feasibility: hard

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -23,13 +23,23 @@ import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
 import { emitSelfHostedMathFunc } from "./stdlib-selfhost.js"; // (#3141) self-hosted stdlib driver
-import { SELF_HOSTED_MATH, LOG_BUILTIN, LOG2_BUILTIN } from "../stdlib/math.js"; // (#3141/#3204) TS-source builtin bodies
+import {
+  SELF_HOSTED_MATH,
+  LOG_BUILTIN,
+  LOG2_BUILTIN,
+  REDUCE_TRIG_BUILTIN,
+  SIN_BUILTIN,
+  COS_BUILTIN,
+  ATAN_BUILTIN,
+  TAN_BUILTIN,
+  ASIN_BUILTIN,
+  ACOS_BUILTIN,
+} from "../stdlib/math.js"; // (#3141/#3204) TS-source builtin bodies
 
 // ─── Instruction shorthand helpers ──────────────────────────────────
 const f64c = (v: number): Instr => ({ op: "f64.const", value: v }) as Instr;
 const localGet = (i: number): Instr => ({ op: "local.get", index: i }) as Instr;
 const localSet = (i: number): Instr => ({ op: "local.set", index: i }) as Instr;
-const localTee = (i: number): Instr => ({ op: "local.tee", index: i }) as Instr;
 const add: Instr = { op: "f64.add" } as Instr;
 const sub: Instr = { op: "f64.sub" } as Instr;
 const mul: Instr = { op: "f64.mul" } as Instr;
@@ -85,9 +95,7 @@ function blockLoop(body: Instr[]): Instr {
 
 // ─── Constants ──────────────────────────────────────────────────────
 const PI = Math.PI;
-const TWO_PI = 2 * PI;
 const HALF_PI = PI / 2;
-const INV_TWO_PI = 1 / TWO_PI;
 const LN2 = Math.LN2;
 const LOG2E = Math.LOG2E;
 const LOG10E = Math.LOG10E;
@@ -226,156 +234,21 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
 
   // ─── Phase 1: Core functions ──────────────────────────────────────
 
-  // Range reduction helper for sin/cos
+  // Range reduction helper for sin/cos — self-hosted (#3204 follow-up).
   if (needSinCos) {
-    // Reduces x to [-pi, pi] using Cody-Waite method
-    // Local 0=x(param), 1=n
-    addMathFunc({
-      name: "__math_reduce_trig",
-      params: f64Param,
-      results: f64Result,
-      locals: [{ name: "n", type: f64Type }],
-      body: [
-        // n = round(x / (2*pi))
-        localGet(0),
-        f64c(INV_TWO_PI),
-        mul,
-        f64c(0.5),
-        add,
-        ffloor,
-        localSet(1),
-        // r = x - n * 2*pi (two-step Cody-Waite for precision)
-        localGet(0),
-        localGet(1),
-        f64c(6.283185307179586),
-        mul,
-        sub,
-        localGet(1),
-        f64c(1.2246467991473532e-16),
-        mul,
-        sub,
-      ],
-    });
+    addedFuncs.set("__math_reduce_trig", emitSelfHostedMathFunc(ctx, REDUCE_TRIG_BUILTIN));
   }
 
   // ─── Math.sin ─────────────────────────────────────────────────────
+  // Self-hosted; calls __math_reduce_trig (registered just above).
   if (needed.has("sin") || needed.has("tan")) {
-    const reduceIdx = getFuncIdx("__math_reduce_trig");
-    // Local 0=x(param), 1=r, 2=r2
-    addMathFunc({
-      name: "Math_sin",
-      params: f64Param,
-      results: f64Result,
-      locals: [
-        { name: "r", type: f64Type },
-        { name: "r2", type: f64Type },
-      ],
-      body: [
-        // NaN → NaN
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        // |x| == Infinity → NaN
-        ...ifThenRet([localGet(0), fabs, f64c(Infinity), feq], [f64c(NaN)]),
-        // x == 0 → x (preserves -0)
-        ...ifThenRet([localGet(0), f64c(0), feq], [localGet(0)]),
-
-        // Range reduce to [-pi, pi]
-        localGet(0),
-        call(reduceIdx),
-        localSet(1),
-
-        // r2 = r*r
-        localGet(1),
-        localGet(1),
-        mul,
-        localSet(2),
-
-        // sin(r) via Horner form of Taylor series:
-        // r * (1 + r2*(-1/6 + r2*(1/120 + r2*(-1/5040 + r2*(1/362880 + r2*(-1/39916800 + r2/6227020800))))))
-        localGet(2),
-        f64c(1 / 6227020800),
-        mul,
-        f64c(-1 / 39916800),
-        add,
-        localGet(2),
-        mul,
-        f64c(1 / 362880),
-        add,
-        localGet(2),
-        mul,
-        f64c(-1 / 5040),
-        add,
-        localGet(2),
-        mul,
-        f64c(1 / 120),
-        add,
-        localGet(2),
-        mul,
-        f64c(-1 / 6),
-        add,
-        localGet(2),
-        mul,
-        f64c(1),
-        add,
-        localGet(1),
-        mul,
-      ],
-    });
+    addedFuncs.set("Math_sin", emitSelfHostedMathFunc(ctx, SIN_BUILTIN));
   }
 
   // ─── Math.cos ─────────────────────────────────────────────────────
+  // Self-hosted; calls __math_reduce_trig.
   if (needed.has("cos") || needed.has("tan")) {
-    const reduceIdx = getFuncIdx("__math_reduce_trig");
-    // Local 0=x(param), 1=r, 2=r2
-    addMathFunc({
-      name: "Math_cos",
-      params: f64Param,
-      results: f64Result,
-      locals: [
-        { name: "r", type: f64Type },
-        { name: "r2", type: f64Type },
-      ],
-      body: [
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), fabs, f64c(Infinity), feq], [f64c(NaN)]),
-
-        // Range reduce
-        localGet(0),
-        call(reduceIdx),
-        localSet(1),
-        localGet(1),
-        localGet(1),
-        mul,
-        localSet(2),
-
-        // cos(r) via Horner:
-        // 1 + r2*(-1/2 + r2*(1/24 + r2*(-1/720 + r2*(1/40320 + r2*(-1/3628800 + r2/479001600)))))
-        localGet(2),
-        f64c(1 / 479001600),
-        mul,
-        f64c(-1 / 3628800),
-        add,
-        localGet(2),
-        mul,
-        f64c(1 / 40320),
-        add,
-        localGet(2),
-        mul,
-        f64c(-1 / 720),
-        add,
-        localGet(2),
-        mul,
-        f64c(1 / 24),
-        add,
-        localGet(2),
-        mul,
-        f64c(-1 / 2),
-        add,
-        localGet(2),
-        mul,
-        f64c(1),
-        add,
-      ],
-    });
+    addedFuncs.set("Math_cos", emitSelfHostedMathFunc(ctx, COS_BUILTIN));
   }
 
   // ─── Math.exp ─────────────────────────────────────────────────────
@@ -504,181 +377,27 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
   }
 
   // ─── Math.atan ────────────────────────────────────────────────────
+  // Self-hosted (#3204 follow-up). Leaf — no callees. The nested mid-body
+  // statement-if range reduction is the NATURAL form (works post-#2856/#2981).
   if (needAtan) {
-    // Locals: 0=x, 1=ax, 2=t, 3=t2, 4=offset
-    addMathFunc({
-      name: "Math_atan",
-      params: f64Param,
-      results: f64Result,
-      locals: [
-        { name: "ax", type: f64Type },
-        { name: "t", type: f64Type },
-        { name: "t2", type: f64Type },
-        { name: "offset", type: f64Type },
-      ],
-      body: [
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), f64c(Infinity), feq], [f64c(HALF_PI)]),
-        ...ifThenRet([localGet(0), f64c(-Infinity), feq], [f64c(-HALF_PI)]),
-        ...ifThenRet([localGet(0), f64c(0), feq], [localGet(0)]),
-
-        // ax = |x|
-        localGet(0),
-        fabs,
-        localSet(1),
-        f64c(0),
-        localSet(4),
-
-        // Range reduction:
-        // if ax > tan(67.5) = 2.414..., use atan(x) = pi/2 - atan(1/x)
-        // if ax > tan(22.5) = 0.414..., use atan(x) = pi/4 + atan((ax-1)/(ax+1))
-        localGet(1),
-        f64c(2.414213562373095),
-        fgt,
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [f64c(HALF_PI), localSet(4), f64c(1), localGet(1), div, neg, localSet(1)],
-          else: [
-            localGet(1),
-            f64c(0.414213562373095),
-            fgt,
-            {
-              op: "if",
-              blockType: { kind: "empty" },
-              then: [f64c(PI / 4), localSet(4), localGet(1), f64c(1), sub, localGet(1), f64c(1), add, div, localSet(1)],
-            } as Instr,
-          ],
-        } as Instr,
-
-        // t = reduced argument (stored back in local 1)
-        localGet(1),
-        localTee(2),
-        localGet(2),
-        mul,
-        localSet(3),
-
-        // atan(t) polynomial (odd, Horner form):
-        // t*(1 + t2*(-1/3 + t2*(1/5 + t2*(-1/7 + t2*(1/9 + t2*(-1/11 + t2*(1/13 - t2/15)))))))
-        localGet(3),
-        f64c(-1.0 / 15),
-        mul,
-        f64c(1.0 / 13),
-        add,
-        localGet(3),
-        mul,
-        f64c(-1.0 / 11),
-        add,
-        localGet(3),
-        mul,
-        f64c(1.0 / 9),
-        add,
-        localGet(3),
-        mul,
-        f64c(-1.0 / 7),
-        add,
-        localGet(3),
-        mul,
-        f64c(1.0 / 5),
-        add,
-        localGet(3),
-        mul,
-        f64c(-1.0 / 3),
-        add,
-        localGet(3),
-        mul,
-        f64c(1),
-        add,
-        localGet(2),
-        mul,
-
-        // result = offset + poly
-        localGet(4),
-        add,
-
-        // Apply original sign
-        localGet(0),
-        copysign,
-      ],
-    });
+    addedFuncs.set("Math_atan", emitSelfHostedMathFunc(ctx, ATAN_BUILTIN));
   }
 
   // ─── Phase 2: Derived functions ───────────────────────────────────
 
-  // Math.tan = sin/cos
+  // Math.tan = sin/cos — self-hosted; calls Math_sin / Math_cos.
   if (needed.has("tan")) {
-    const sinIdx = getFuncIdx("Math_sin");
-    const cosIdx = getFuncIdx("Math_cos");
-    addMathFunc({
-      name: "Math_tan",
-      params: f64Param,
-      results: f64Result,
-      locals: [],
-      body: [
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), fabs, f64c(Infinity), feq], [f64c(NaN)]),
-        localGet(0),
-        call(sinIdx),
-        localGet(0),
-        call(cosIdx),
-        div,
-      ],
-    });
+    addedFuncs.set("Math_tan", emitSelfHostedMathFunc(ctx, TAN_BUILTIN));
   }
 
-  // Math.asin = atan(x / sqrt(1 - x*x))
+  // Math.asin = atan(x / sqrt(1 - x*x)) — self-hosted; calls Math_atan.
   if (needed.has("asin")) {
-    const atanIdx = getFuncIdx("Math_atan");
-    addMathFunc({
-      name: "Math_asin",
-      params: f64Param,
-      results: f64Result,
-      locals: [],
-      body: [
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), fabs, f64c(1), fgt], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), f64c(1), feq], [f64c(HALF_PI)]),
-        ...ifThenRet([localGet(0), f64c(-1), feq], [f64c(-HALF_PI)]),
-        // atan(x / sqrt(1 - x*x))
-        localGet(0),
-        f64c(1),
-        localGet(0),
-        localGet(0),
-        mul,
-        sub,
-        fsqrt,
-        div,
-        call(atanIdx),
-      ],
-    });
+    addedFuncs.set("Math_asin", emitSelfHostedMathFunc(ctx, ASIN_BUILTIN));
   }
 
-  // Math.acos = pi/2 - asin(x) = pi/2 - atan(x/sqrt(1-x*x))
+  // Math.acos = pi/2 - atan(x/sqrt(1-x*x)) — self-hosted; calls Math_atan.
   if (needed.has("acos")) {
-    const atanIdx = getFuncIdx("Math_atan");
-    addMathFunc({
-      name: "Math_acos",
-      params: f64Param,
-      results: f64Result,
-      locals: [],
-      body: [
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), fabs, f64c(1), fgt], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), f64c(1), feq], [f64c(0)]),
-        ...ifThenRet([localGet(0), f64c(-1), feq], [f64c(PI)]),
-        f64c(HALF_PI),
-        localGet(0),
-        f64c(1),
-        localGet(0),
-        localGet(0),
-        mul,
-        sub,
-        fsqrt,
-        div,
-        call(atanIdx),
-        sub,
-      ],
-    });
+    addedFuncs.set("Math_acos", emitSelfHostedMathFunc(ctx, ACOS_BUILTIN));
   }
 
   // Math.atan2(y, x)

--- a/src/stdlib/math.ts
+++ b/src/stdlib/math.ts
@@ -251,22 +251,174 @@ export function Math_log2(x: number): number {
 `;
 
 /**
+ * __math_reduce_trig — Cody-Waite reduction of `x` to `[-π, π]`.
+ * `n = floor(x / 2π + 0.5)` then a two-step `x - n·(2π_hi) - n·(2π_lo)`
+ * subtraction (`2π_hi = 6.283185307179586`, `2π_lo = 1.2246467991473532e-16`)
+ * for extra precision. `INV_TWO_PI = 0.15915494309189535` (= 1/2π, exact
+ * round-trip). Mirrors the deleted hand `Instr[]` op-for-op (`x * INV`,
+ * `+ 0.5`, `Math.floor`, then the left-associated double subtract), so
+ * bit-identical. Leaf helper (no callees). (#3204 follow-up)
+ */
+const REDUCE_TRIG_SOURCE = `
+export function __math_reduce_trig(x: number): number {
+  let n: number = Math.floor(x * 0.15915494309189535 + 0.5);
+  return x - n * 6.283185307179586 - n * 1.2246467991473532e-16;
+}
+`;
+
+/**
+ * Math.sin — range-reduce to `[-π, π]` via `__math_reduce_trig`, then the
+ * odd Taylor polynomial in Horner form `r·(1 + r²(-1/6 + r²(1/120 + …)))`.
+ * Special ladder mirrors the hand version exactly: NaN → NaN, `|x| == ∞` →
+ * NaN (spelled `Math.abs(x) > MAX_VALUE`; NaN already returned), `x === 0`
+ * → x (preserves -0). The `- 1/N` subtractions are the exact IEEE
+ * equivalent of the hand `+ f64.const(-1/N)` adds. (#3204 follow-up)
+ */
+const SIN_SOURCE = `
+export function Math_sin(x: number): number {
+  if (x !== x) return x;
+  if (Math.abs(x) > 1.7976931348623157e308) return 0 / 0;
+  if (x === 0) return x;
+  let r: number = __math_reduce_trig(x);
+  let r2: number = r * r;
+  return ((((((r2 * (1 / 6227020800) - 1 / 39916800) * r2 + 1 / 362880) * r2 - 1 / 5040) * r2 + 1 / 120) * r2 - 1 / 6) * r2 + 1) * r;
+}
+`;
+
+/**
+ * Math.cos — same range reduction, even Taylor polynomial
+ * `1 + r²(-1/2 + r²(1/24 + …))`. NaN → NaN, `|x| == ∞` → NaN. No `x === 0`
+ * short-circuit needed (cos(0) falls out of the series as exactly 1, which
+ * the hand version also computed rather than special-cased). (#3204 follow-up)
+ */
+const COS_SOURCE = `
+export function Math_cos(x: number): number {
+  if (x !== x) return x;
+  if (Math.abs(x) > 1.7976931348623157e308) return 0 / 0;
+  let r: number = __math_reduce_trig(x);
+  let r2: number = r * r;
+  return ((((((r2 * (1 / 479001600) - 1 / 3628800) * r2 + 1 / 40320) * r2 - 1 / 720) * r2 + 1 / 24) * r2 - 1 / 2) * r2 + 1);
+}
+`;
+
+/**
+ * Math.atan — argument reduction to `|t| ≤ tan(22.5°)` via two SEQUENTIAL
+ * mid-body statement-ifs (the from-ast subset takes mid-body ifs without an
+ * else), then the odd minimax polynomial. Equivalent to the hand version's
+ * `if ax > 2.414… {…} else if ax > 0.414… {…}`: the first branch sets
+ * `ax = -1/ax ∈ (-0.414…, 0)`, so the second guard is then always false —
+ * exactly the else semantics. Natural statement-if form (a `let`/reassign
+ * following a non-returning mid-body if); the from-ast overlay mis-scoping
+ * that once forced a ternary rewrite was fixed in #2856 (structurizer
+ * materialized-leak) + #2981. The final `copysign(r, x)` is `x < 0 ? -r : r`
+ * (r > 0 for every remaining x since the +∞/−∞/0 cases returned early, so
+ * this equals copysign bit-for-bit). ±∞ → ±π/2, NaN → NaN, 0 → x (keeps
+ * -0). Leaf (no callees). (#3204 follow-up)
+ */
+const ATAN_SOURCE = `
+export function Math_atan(x: number): number {
+  if (x !== x) return x;
+  if (x > 1.7976931348623157e308) return 1.5707963267948966;
+  if (x < -1.7976931348623157e308) return -1.5707963267948966;
+  if (x === 0) return x;
+  let ax: number = Math.abs(x);
+  let offset: number = 0;
+  // Two SEQUENTIAL bare ifs (the from-ast subset takes mid-body ifs without
+  // an else). Equivalent to the hand version's if/else-if: when the first
+  // branch fires it sets ax = -1/ax ∈ (-0.414…, 0), so the second guard
+  // (ax > 0.414…) is then always false — exactly the else semantics.
+  if (ax > 2.414213562373095) {
+    offset = 1.5707963267948966;
+    ax = -(1 / ax);
+  }
+  if (ax > 0.414213562373095) {
+    offset = 0.7853981633974483;
+    ax = (ax - 1) / (ax + 1);
+  }
+  let t2: number = ax * ax;
+  let p: number = (((((((t2 * (-1 / 15) + 1 / 13) * t2 - 1 / 11) * t2 + 1 / 9) * t2 - 1 / 7) * t2 + 1 / 5) * t2 - 1 / 3) * t2 + 1) * ax;
+  let r: number = p + offset;
+  return x < 0 ? -r : r;
+}
+`;
+
+/**
+ * Math.tan = sin/cos. NaN → NaN, `|x| == ∞` → NaN; otherwise
+ * `Math_sin(x) / Math_cos(x)`. (#3204 follow-up)
+ */
+const TAN_SOURCE = `
+export function Math_tan(x: number): number {
+  if (x !== x) return x;
+  if (Math.abs(x) > 1.7976931348623157e308) return 0 / 0;
+  return Math_sin(x) / Math_cos(x);
+}
+`;
+
+/**
+ * Math.asin = atan(x / sqrt(1 - x²)). Domain guard `|x| > 1` → NaN; the
+ * endpoints x = ±1 return ±π/2 directly (the general expression would
+ * divide by sqrt(0) = 0). NaN → NaN. (#3204 follow-up)
+ */
+const ASIN_SOURCE = `
+export function Math_asin(x: number): number {
+  if (x !== x) return x;
+  if (Math.abs(x) > 1) return 0 / 0;
+  if (x === 1) return 1.5707963267948966;
+  if (x === -1) return -1.5707963267948966;
+  return Math_atan(x / Math.sqrt(1 - x * x));
+}
+`;
+
+/**
+ * Math.acos = π/2 - asin(x) = π/2 - atan(x / sqrt(1 - x²)). Domain guard
+ * `|x| > 1` → NaN; x = 1 → 0, x = -1 → π. NaN → NaN. (#3204 follow-up)
+ */
+const ACOS_SOURCE = `
+export function Math_acos(x: number): number {
+  if (x !== x) return x;
+  if (Math.abs(x) > 1) return 0 / 0;
+  if (x === 1) return 0;
+  if (x === -1) return 3.141592653589793;
+  return 1.5707963267948966 - Math_atan(x / Math.sqrt(1 - x * x));
+}
+`;
+
+/**
  * Early-core self-hosted builtins (#3204) — registered INLINE by
  * `emitInlineMathFunctions` at the exact emission point their hand-`Instr[]`
  * predecessors occupied (BEFORE the later hand cores that call them by
- * funcMap name: pow/log10 → Math_log). NOT part of `SELF_HOSTED_MATH` (that
- * map's leaves are emitted last). Both are standalone (no `callees`).
+ * funcMap name: pow/log10 → Math_log; asin/acos/tan → atan/sin/cos). NOT
+ * part of `SELF_HOSTED_MATH` (that map's leaves are emitted last).
+ * Ordering constraint: `__math_reduce_trig` before sin/cos; sin/cos before
+ * tan; atan before asin/acos (callees resolve by funcMap name at lower
+ * time — see the phase order in `emitInlineMathFunctions`).
  */
 export const LOG_BUILTIN: StdlibMathBuiltin = { name: "Math_log", callees: [], source: LOG_SOURCE };
 export const LOG2_BUILTIN: StdlibMathBuiltin = { name: "Math_log2", callees: [], source: LOG2_SOURCE };
+export const REDUCE_TRIG_BUILTIN: StdlibMathBuiltin = {
+  name: "__math_reduce_trig",
+  callees: [],
+  source: REDUCE_TRIG_SOURCE,
+};
+export const SIN_BUILTIN: StdlibMathBuiltin = { name: "Math_sin", callees: ["__math_reduce_trig"], source: SIN_SOURCE };
+export const COS_BUILTIN: StdlibMathBuiltin = { name: "Math_cos", callees: ["__math_reduce_trig"], source: COS_SOURCE };
+export const ATAN_BUILTIN: StdlibMathBuiltin = { name: "Math_atan", callees: [], source: ATAN_SOURCE };
+export const TAN_BUILTIN: StdlibMathBuiltin = {
+  name: "Math_tan",
+  callees: ["Math_sin", "Math_cos"],
+  source: TAN_SOURCE,
+};
+export const ASIN_BUILTIN: StdlibMathBuiltin = { name: "Math_asin", callees: ["Math_atan"], source: ASIN_SOURCE };
+export const ACOS_BUILTIN: StdlibMathBuiltin = { name: "Math_acos", callees: ["Math_atan"], source: ACOS_SOURCE };
 
 /**
  * The self-hosted subset of the Math family, keyed by `Math.<method>`
- * name. Remaining hand-emitted cores (sin/cos/exp/atan, atan2/pow, log10,
- * random) are the precision-sensitive kernels with dialect gaps
- * (exp: exponent-extraction bit ops; pow: i32 exp-by-squaring; log10:
- * `f64.nearest`; random: RNG import) — converting them needs the intrinsics
- * groundwork (#3204 follow-up). `log`/`log2` moved to EARLY cores above.
+ * name. Remaining hand-emitted cores (exp, atan2, pow, log10, random) are
+ * the ones with real dialect gaps (exp: i32 2^n squaring; pow: i32
+ * exp-by-squaring; log10: `f64.nearest`; random: RNG import; atan2: 2-arg
+ * quadrant ladder) — converting them needs the intrinsics groundwork
+ * (#3204 follow-up). `log`/`log2` and the trig cores (reduce_trig,
+ * sin/cos/tan, atan/asin/acos) moved to EARLY cores above.
  */
 export const SELF_HOSTED_MATH: ReadonlyMap<string, StdlibMathBuiltin> = new Map([
   ["cbrt", { name: "Math_cbrt", callees: [], source: CBRT_SOURCE }],


### PR DESCRIPTION
Continues the self-host bloat-reduction track (#3141 pilot → #3204 log/log2). Converts the hand-emitted \`Instr[]\` bodies for the trig cores to ordinary TS source compiled through the compiler's own IR driver (\`stdlib-selfhost.ts\`).

## What changed
- **`src/stdlib/math.ts`**: new IR-claimable-dialect sources + \`*_BUILTIN\` exports for \`__math_reduce_trig\`, \`Math_sin\`, \`Math_cos\`, \`Math_atan\`, \`Math_tan\`, \`Math_asin\`, \`Math_acos\`.
- **`src/codegen/math-helpers.ts`**: replace seven hand \`addMathFunc({...Instr[]})\` blocks with inline \`emitSelfHostedMathFunc\` registration at the SAME emission points (funcMap sibling-call ordering preserved: \`__math_reduce_trig\` before sin/cos; sin/cos before tan; atan before asin/acos). Drop now-dead \`localTee\`/\`TWO_PI\`/\`INV_TWO_PI\` shorthands.

\`atan\`'s nested range reduction uses two **sequential bare mid-body statement-ifs** (the from-ast subset takes ifs without an else) — semantically identical to the hand \`if/else-if\` (the first branch sets \`ax = -1/ax ∈ (-0.414…, 0)\`, so the second guard is then always false). Natural statement-if form (works post-#2856/#2981).

**Kept hand-emitted** (real dialect gaps): \`exp\` (i32 2^n), \`pow\` (i32 exp-by-squaring), \`log10\` (\`f64.nearest\`), \`atan2\` (2-arg quadrant ladder), \`random\` (RNG import).

## Validation
- **Bit-exact: 0 mismatches / 94,176 comparisons** (11,772 inputs × 8 funcs — sin/cos/tan/atan/asin/acos + atan2×2, the latter still hand-emitted but calling the now-self-hosted \`atan\`) vs the pre-change hand-emitted build, over a dense magnitude + fine sweep + specials (±0/±Inf/NaN/subnormals + atan boundaries 0.414/2.414 + π multiples).
- \`tsc --noEmit\` clean; \`check:loc-budget\` OK (**net −126 LOC**); prettier/biome clean.
- Math suites green (\`math-inline\`, \`math-minmax\`, \`threejs-math\`, issue-1732): 96 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8