### PR TITLE
docs(#2903): R2 extends-Promise statics measured — defer (species load-bearing)

### DIFF
--- a/plan/issues/2903-standalone-make-callback-residual-rootcause.md
+++ b/plan/issues/2903-standalone-make-callback-residual-rootcause.md
@@ -453,6 +453,42 @@ Measure FIRST how many of the ~15 leaky + fail-bucket rows need real
 species is load-bearing, keep host and document as deferred (graveyard rule:
 measure-first honest yield).
 
+**MEASURED 2026-07-13 (opus-rescue) — DEFERRED, species is load-bearing on
+every row. Native routing yields ZERO host-free-pass flips and would regress to
+wrong results.** Grounded on current main + the 2026-07-11 standalone baseline.
+
+Repro confirmed the mechanism: `class P extends Promise {}` + `P.resolve(42)`
+leaks `__make_callback, __new_Promise, FileSystemDirectoryHandle_resolve,
+Promise_then`; `P.all([...])` leaks `__make_callback, __new_Promise,
+Promise_then`; `P.reject(7).catch` leaks `..., Promise_catch` — while plain
+`Promise.resolve(42).then(...)` is host-free (control). The divergence is in
+`expressions/calls.ts`: `isResolveReject` (~L10091) matches only
+`propAccess.expression.text === "Promise"`, and `nativeCombinatorEligible`
+(~L10112) explicitly excludes `isPromiseSubclassReceiver` — so subclass statics
+fall to the `Promise_{method}` / symbol-derived host import.
+
+**The 24 `built-ins/Promise/**` `extends Promise` tests, standalone baseline:**
+3 pass (all `prototype/finally/subclass-*` — already host-free via the finally
+sub-front, untouched by this arm), 19 fail, 2 compile_error. EVERY failing row
+asserts constructor-chain/species that a plain native `$Promise` cannot satisfy:
+- `{resolve,reject,race,any,all,allSettled,withResolvers,try}/ctx-ctor.js` →
+  `instance instanceof SubPromise === true`, `instance.constructor === SubPromise`,
+  subclass `callCount === 1`, `typeof executor === 'function'` (NewPromiseCapability
+  must invoke the SUBCLASS ctor with an executor).
+- `{all,any,allSettled,race}/invoke-resolve-on-*-every-iteration-of-custom.js` →
+  `Custom.resolve` invoked once per iterated value and `Promise.resolve` NEVER
+  invoked (the combinator must dispatch through the receiver ctor's `resolve`).
+
+A native `$Promise` from `emitStandalonePromiseResolve` is a fixed WasmGC struct
+with no per-subclass RTT/brand: it is not `instanceof SubPromise`, never calls the
+subclass ctor (`callCount` stays 0), and cannot route combinators through
+`C.resolve`. So native routing flips 0 of the 19 fails to host-free-pass and
+would produce semantically WRONG results (worse than the current clean
+leaky-fail). True native subclass statics require carrying a subclass brand on the
+promise carrier so `instanceof P` holds and the ctor runs — that is the
+builtin-subclass object-model substrate (shared with #2622 "subclass a builtin"),
+NOT an S/M lever. **R2 kept HOST, deferred to the #2622 builtin-subclass track.**
+
 ### R3 — lazy Iterator helpers `map/filter/take/drop/flatMap` (fable-executable-now, M)
 
 Sub-front 2 covered the EAGER helpers. The lazy five need a wrapper-iterator:


### PR DESCRIPTION
## Summary

Records the **measure-first result** for the #2903 **R2** sub-front (`class X extends Promise` producer statics), per the spec's graveyard rule: *"Measure FIRST … if species is load-bearing, keep host and document as deferred."*

**Documentation-only** — no code change. R2 is kept host-backed and deferred to the #2622 builtin-subclass-brand track.

## Measurement (current main + 2026-07-11 standalone baseline)

Repro confirms the leak mechanism: `class P extends Promise {}` + `P.resolve/reject/all/race` leak `__new_Promise` + `FileSystemDirectoryHandle_resolve` (symbol-derived name — `P.resolve` isn't recognised as `Promise.resolve`) + `Promise_then`, while plain `Promise.resolve().then()` is host-free. Divergence is in `expressions/calls.ts`: `isResolveReject` matches only the literal `Promise` receiver and `nativeCombinatorEligible` excludes subclass receivers.

Of the 24 `built-ins/Promise/**` `extends Promise` rows: **3 already host-free-pass** (finally sub-front), **19 fail**, **2 CE**. **Every failing row asserts constructor-chain/species** a plain native `$Promise` cannot satisfy:
- `{resolve,reject,race,any,all,allSettled,withResolvers,try}/ctx-ctor.js` → `instance instanceof SubPromise`, subclass `callCount === 1`, `typeof executor === 'function'`.
- `{all,any,allSettled,race}/invoke-resolve-on-*-every-iteration-of-custom.js` → `Custom.resolve` invoked per element, `Promise.resolve` **never** invoked.

A native `$Promise` is a fixed WasmGC struct with no per-subclass RTT/brand → not `instanceof SubPromise`, never runs the subclass ctor, can't route combinators through `C.resolve`. **Native routing = 0 host-free-pass flips + semantically wrong results.** True native subclass statics need the builtin-subclass brand substrate (#2622), not an S/M lever.

## Reconcile note
R3/R3b (lazy Iterator `map/filter/take/drop/flatMap`) are already host-free on current main (#2969) — verified, not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)