### PR TITLE
devcontainer: auto-start sshd on container restart (overrideCommand=false)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
     }
   },
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW", "--memory=16g", "--memory-swap=32g"],
+  "overrideCommand": false,
   "appPort": ["2222:2222", "7681:7681"],
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## What
Sets `"overrideCommand": false` in `.devcontainer/devcontainer.json` so sshd reliably comes up on every container boot/restart.

## Why
The Dockerfile already ships `ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]`, and `entrypoint.sh` was written specifically to start sshd on every boot/restart (its comment notes sshd "used to silently stay down after a restart"). But for Dockerfile-based dev containers VS Code defaults `overrideCommand` to `true`, replacing that entrypoint with its own keep-alive loop — so `entrypoint.sh` never ran and sshd only started when the devcontainer `postStartCommand` happened to fire (i.e. not on a bare `docker restart`).

Setting `overrideCommand=false` lets `entrypoint.sh` run as PID 1, restoring the intended behavior.

## Notes
- One-line config change; no Dockerfile/image change needed (the image's baked host keys are valid).
- Takes effect after the container is rebuilt/recreated ("Dev Containers: Rebuild Container" or `devcontainer up`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)