### PR TITLE
fix(#3024): packed carrier arm in array-destructuring source normalizer (slice 5)

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -6,7 +6,6 @@ sprint: current
 created: 2026-07-03
 updated: 2026-07-13
 assignee: ttraenkler/opus-3024
-status_note: slice 5 in-progress (opus-3024)
 priority: high
 horizon: m
 feasibility: medium
@@ -22,6 +21,7 @@ loc-budget-allow:
   - src/codegen/expressions/calls.ts
   - src/codegen/index.ts
   - src/codegen/property-access.ts
+  - src/codegen/destructuring-params.ts
 ---
 
 # #3024 — invalid Wasm binary emission residual (default lane)
@@ -632,3 +632,87 @@ cross-statement eval-promotion family (banked, broad-impact) and ≤4-file
 per-root-cause singletons (`struct.set (ref null #)`, `call expected externref
 found ref.func`, Atomics `__cb_#` fallthru, `i#.lt_s`, `__vec_from_extern`
 element-rep).
+
+---
+
+## Landed: packed carrier arm in array-destructuring source normalizer (opus-3024, 2026-07-13, slice 5)
+
+**PR:** `issue-3024-invalid-wasm-slice5` — clears the 8-file `array.get: Array
+type N has packed type i8. Use array.get_s or array.get_u instead.` cluster
+(resizable-ArrayBuffer / typed-array tests; function `test` /
+`ValuesFrom{Array,TypedArray}Entries`). Default-lane 144-candidate re-harvest
+(fresh baseline jsonl, run `20260713-072429`): **still-invalid 86 → 78**, exactly
+this cluster, zero new invalid signatures.
+
+### Root cause (packed carrier read in the vec-carrier-enumeration normalizer)
+
+`destructureParamArray` (`src/codegen/destructuring-params.ts` ~L1449) normalizes
+an `any`/externref array-destructuring SOURCE to a uniform externref vec so the
+pattern can index it. When the source is externref (a for-of loop var
+`[ta, length]` over a heterogeneous `[TypedArray, number]` tuple array, or an
+`any` param), it emits a RUNTIME DISPATCH: for every registered vec carrier
+(`ctx.vecTypeMap`) a `ref.test`/`if` arm copies the source's elements into a
+fresh externref array. All arms must VALIDATE even though only one executes.
+
+The per-carrier arm read the element with a plain `{ op: "array.get", typeIdx:
+srcArrTypeIdx }` (L1510) and boxed via `boxToExternref`, whose only non-string
+fallback is `extern.convert_any`. When a **packed** (i8/i16) carrier is
+registered — the byte store of a typed array / resizable ArrayBuffer, type
+`(array (mut i8))`, shared by `$__vec_i32_byte` and `$__resizable_ab` — BOTH ops
+are invalid on a packed array: `array.get` needs `_s`/`_u`, and `extern.convert_any`
+on the resulting i32 is a hierarchy error. The validator stops at the first
+(`array.get`), failing the WHOLE module even though the packed arm is DEAD for a
+heterogeneous-tuple source (which matches the externref arm at runtime).
+
+Verified by WAT dump of `TypedArray/prototype/length/resized-out-of-bounds-1.js`:
+the `for (let [ta, length] of tas_and_lengths)` normalizer emitted
+`struct.get 47 1` (data, `ref null 46` = packed i8) → `array.get 46` →
+`extern.convert_any` → `array.set 1`.
+
+Same bug **class** as the already-fixed R4 dynamic-dispatch chokepoint
+(`object-runtime.ts` `packedElemReadBox`, #2903) and the for-of packed read
+(#2934), but for THIS destructuring-source normalizer.
+
+### Fix (two coupled sites, mirrors R4)
+
+- **Read** (L1510): choose `array.get_u` when `srcElemType.kind` is `i8`/`i16`,
+  else plain `array.get` (byte-identical for non-packed). `_u`/`_s` are ONLY
+  valid on packed arrays so the guard is required both ways.
+- **Box** (`boxToExternref`): new `i8`/`i16` branch → `f64.convert_i32_s` +
+  `__box_number` (the `array.get_u` zero-extend is 0..255 / 0..65535, always
+  non-negative, so `convert_i32_s` == `_u`). Without it the packed carrier fell
+  to the `ref`-type `extern.convert_any` default → invalid on an i32.
+
+SIGNEDNESS: the shared carrier type loses the constructor's signedness (Int8Array
+and Uint8Array both map to kind `i8`), so this generic read is unsigned — the
+SAME documented limitation as the R4 read; a negative Int8/Int16 reads its
+unsigned bit-pattern. These arms were previously TOTALLY invalid (whole module
+failed), so this is strictly an improvement, never a regression.
+
+### Proofs
+
+- All 8 real test262 files flip `compile_error` (invalid Wasm) → **valid Wasm**.
+  They now `fail` on a DISTINCT unimplemented resizable-ArrayBuffer semantic
+  (`CreateResizableArrayBuffer` / RAB constructor — separate, larger feature),
+  so this is CE→fail (invalid-Wasm eliminated), NOT a pass gain. The dashboard
+  pass count is unchanged; the `wasm_compile` compile-error bucket drops by 8.
+- Full 144-candidate default-lane re-harvest (`runTest262File`, oracle path):
+  **86 → 78 still-invalid**, exactly this cluster, no new invalid signatures.
+- **Byte-identical** (sha256) output vs `origin/main` across a 14-program corpus
+  (plain/any/nested/param array-destructuring, for-of, `entries`, typed arrays,
+  spread, objects, classes, strings, closures) — the fix only adds packed-carrier
+  arms and is a no-op for every previously-valid module.
+- New `tests/issue-3024-packed-array-dstr-normalize.test.ts` (guards
+  `status !== "compile_error"` on the 8 files) passes; 87 adjacent tests pass
+  (issue-1372-ir-destructuring-params, fn-param-dstr-rest-in-rest,
+  issue-2158/2648/2934 packed-typedarray, issue-2903-r4/r4c R-series,
+  issue-1787 packed semantics, issue-3024, issue-3024-incdec-element).
+
+### Still open (roll forward)
+
+The remaining ~78 default-lane invalid-Wasm files: the banked 7-file `fN.ne`
+cross-statement eval-promotion family (broad-impact, needs a full-CI window) and
+≤4-file per-root-cause singletons (`struct.set (ref null #)`, `__cb_#` fallthru,
+`__anon_#_method` global-get numeric desync, `Parent_new` tail-call, `__new_function_#`
+funcref-cast). The 8 files here still need genuine resizable-ArrayBuffer support
+to reach `pass`.

--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -4,7 +4,9 @@ title: "codegen: invalid Wasm binary emission residual — default (JS-host) lan
 status: ready
 sprint: current
 created: 2026-07-03
-updated: 2026-07-11
+updated: 2026-07-13
+assignee: ttraenkler/opus-3024
+status_note: slice 5 in-progress (opus-3024)
 priority: high
 horizon: m
 feasibility: medium

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -356,6 +356,26 @@ function boxToExternref(ctx: CodegenContext, elemKey: string, srcElemType?: ValT
   if (srcElemType && (srcElemType.kind === "externref" || srcElemType.kind === "ref_extern")) {
     return [];
   }
+  // (#3024) Packed sub-i32 element carriers (`i8`/`i16` — Int8/Uint8/Uint8Clamped,
+  // Int16/Uint16 typed-array backing, and the resizable-ArrayBuffer byte store).
+  // Their READ side is a packed `array.get_u` (see the caller) which zero-extends
+  // to an i32 in 0..255 / 0..65535 — always non-negative, so `f64.convert_i32_s`
+  // == `_u` — then f64-box via `__box_number`. Without this branch a packed carrier
+  // fell to the `ref`-type `extern.convert_any` default below, which on an i32
+  // operand is invalid Wasm (whole module fails validation). Mirrors the R4
+  // dynamic-dispatch chokepoint (`object-runtime.ts` `packedElemReadBox`). The
+  // shared carrier type loses the constructor's signedness, so this generic read
+  // is unsigned (a negative Int8/Int16 reads its unsigned bit-pattern) — the same
+  // documented limitation as the R4 read; recovering it needs a per-signedness
+  // carrier type (deferred).
+  if (srcElemType && (srcElemType.kind === "i8" || srcElemType.kind === "i16")) {
+    addUnionImports(ctx);
+    const boxIdx = ctx.funcMap.get("__box_number");
+    if (boxIdx !== undefined) {
+      return [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxIdx } as Instr];
+    }
+    return [{ op: "drop" } as Instr, { op: "ref.null.extern" }];
+  }
   if (elemKey === "externref") {
     // Already externref, just pass through
     return [];
@@ -1507,7 +1527,19 @@ export function destructureParamArray(
                   { op: "local.get", index: cvtTmp } as Instr,
                   { op: "struct.get", typeIdx: vecIdx, fieldIdx: 1 } as Instr, // src data
                   { op: "local.get", index: idxTmp } as Instr,
-                  { op: "array.get", typeIdx: srcArrTypeIdx } as Instr,
+                  // (#3024) Packed i8/i16 backing arrays (typed-array / resizable-
+                  // ArrayBuffer byte stores) are STORAGE-only: a plain `array.get`
+                  // is invalid Wasm ("has packed type … use array.get_s/_u"). Read
+                  // packed carriers unsigned-extended (`array.get_u`); `boxToExternref`
+                  // then f64-boxes the zero-extended i32. Non-packed carriers keep the
+                  // byte-identical plain `array.get`.
+                  {
+                    op:
+                      srcElemType && (srcElemType.kind === "i8" || srcElemType.kind === "i16")
+                        ? "array.get_u"
+                        : "array.get",
+                    typeIdx: srcArrTypeIdx,
+                  } as Instr,
                   // Box primitive types before storing as externref
                   ...boxToExternref(ctx, key, srcElemType),
                   { op: "array.set", typeIdx: extArrTypeIdx } as Instr,

--- a/tests/issue-3024-packed-array-dstr-normalize.test.ts
+++ b/tests/issue-3024-packed-array-dstr-normalize.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3024 slice 5 — packed i8/i16 carrier arm in the array-destructuring source
+ * normalizer emitted INVALID Wasm.
+ *
+ * Shape: an `any`/externref-typed array-destructuring SOURCE (a for-of loop var
+ * `[ta, length]` over a heterogeneous `[TypedArray, number]` tuple array, or a
+ * function param) is normalized to a uniform externref vec by
+ * `destructureParamArray` (`src/codegen/destructuring-params.ts`). That
+ * normalizer enumerates EVERY registered vec carrier (`ctx.vecTypeMap`) and, per
+ * carrier, emits a `ref.test`/`if` runtime-dispatch arm that copies the source's
+ * elements into a fresh externref array. When a PACKED (i8/i16) carrier is
+ * registered — the byte store of a typed array / resizable ArrayBuffer, e.g.
+ * `test262/harness/resizableArrayBufferUtils.js`'s `ctors` — its arm read the
+ * element with a plain `array.get` and boxed with `extern.convert_any`. Both are
+ * invalid on a packed array ("array.get: Array type N has packed type i8. Use
+ * array.get_s or array.get_u instead."), so the WHOLE module failed validation
+ * even though that arm is dead for a heterogeneous-tuple source.
+ *
+ * Fix: the packed carrier arm reads unsigned-extended (`array.get_u`) and boxes
+ * the zero-extended i32 via `__box_number` (mirrors the R4 dynamic-dispatch
+ * chokepoint `object-runtime.ts` `packedElemReadBox`). Non-packed carriers keep
+ * the byte-identical `array.get` + boxing.
+ *
+ * These 8 real test262 files were `compile_error` (invalid Wasm) on main; the fix
+ * eliminates the validation failure. They now run — and `fail` on a DISTINCT,
+ * unimplemented resizable-ArrayBuffer semantic (`CreateResizableArrayBuffer` /
+ * the RAB constructor), which is out of scope here. The regression guard is
+ * therefore `status !== "compile_error"` (the invalid-Wasm is gone), not `pass`.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.ts";
+
+const T262 = join(process.cwd(), "test262");
+
+// The 8 default-lane (gc) files whose `array.get` on a packed carrier failed
+// validation before the fix.
+const FILES: [rel: string, category: string][] = [
+  ["test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-1.js", "built-ins/TypedArray"],
+  ["test/built-ins/TypedArray/prototype/length/resized-out-of-bounds-2.js", "built-ins/TypedArray"],
+  ["test/built-ins/TypedArray/prototype/byteOffset/resized-out-of-bounds.js", "built-ins/TypedArray"],
+  ["test/built-ins/TypedArray/prototype/byteLength/resized-out-of-bounds-1.js", "built-ins/TypedArray"],
+  ["test/built-ins/TypedArray/prototype/byteLength/resized-out-of-bounds-2.js", "built-ins/TypedArray"],
+  ["test/built-ins/TypedArray/prototype/entries/resizable-buffer.js", "built-ins/TypedArray"],
+  ["test/built-ins/Array/prototype/entries/resizable-buffer.js", "built-ins/Array"],
+  ["test/language/destructuring/binding/typedarray-backed-by-resizable-buffer.js", "language/destructuring"],
+];
+
+describe("#3024 slice 5 — packed carrier in array-destructuring normalizer", () => {
+  it.runIf(existsSync(T262))(
+    "8 resizable-ArrayBuffer test262 files no longer emit invalid Wasm (were compile_error)",
+    async () => {
+      for (const [rel, category] of FILES) {
+        const abs = join(T262, rel);
+        if (!existsSync(abs)) continue; // tolerate submodule pathing drift
+        const r = await runTest262File(abs, category, 20000);
+        // The regression is a *validation* failure surfacing as compile_error with
+        // a packed-array `array.get` message. Assert that class of error is gone.
+        const msg = String(r.error ?? r.reason ?? "");
+        expect(r.status, `${rel}: ${r.status} — ${msg}`).not.toBe("compile_error");
+        expect(msg).not.toMatch(/has packed type|array\.get_s or array\.get_u/);
+      }
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
## #3024 slice 5 — packed i8/i16 carrier arm emitted invalid Wasm

### Root cause
`destructureParamArray` (`src/codegen/destructuring-params.ts`) normalizes an `any`/externref array-destructuring **source** to a uniform externref vec via a runtime dispatch that enumerates **every** registered vec carrier (`ctx.vecTypeMap`). Each per-carrier `ref.test`/`if` arm copies the source's elements into a fresh externref array — and all arms must validate even though only one executes at runtime.

The arm read the element with a plain `array.get` and boxed via `extern.convert_any`. Both are **invalid on a PACKED (i8/i16) carrier** — the byte store of a typed array / resizable ArrayBuffer (`array.get: Array type N has packed type i8. Use array.get_s or array.get_u instead.`). The whole module failed validation even though the packed arm is dead for a heterogeneous-tuple source.

### Fix (mirrors the R4 `packedElemReadBox` chokepoint, `object-runtime.ts`)
- **Read**: `array.get_u` for `i8`/`i16` carriers, else byte-identical plain `array.get`.
- **Box** (`boxToExternref`): new `i8`/`i16` branch → `f64.convert_i32_s` + `__box_number` (the zero-extend is always non-negative, so `_s` == `_u`). Without it the packed carrier fell to the `extern.convert_any` default → invalid on an i32.

Signedness follows the same documented limitation as the R4 read (shared carrier loses Int/Uint distinction → unsigned). These arms were previously fully invalid, so this is strictly an improvement.

### Measured yield (default gc lane)
- 8 real test262 resizable-ArrayBuffer files: `compile_error` (invalid Wasm) → **valid Wasm**. They now `fail` on unimplemented RAB semantics (`CreateResizableArrayBuffer`), a separate larger feature — so this is **CE→fail** (invalid-Wasm eliminated), not a pass gain; the `wasm_compile` compile-error bucket drops by 8.
- Full 144-candidate default-lane re-harvest (`runTest262File`, fresh baseline): **86 → 78 still-invalid**, exactly this cluster, **zero new invalid signatures**.
- **Byte-identical** (sha256) output vs `origin/main` across a 14-program corpus (array/any/nested/param destructuring, for-of, entries, typed arrays, spread, objects, classes, strings, closures).

### Tests
- New `tests/issue-3024-packed-array-dstr-normalize.test.ts` (guards `status !== "compile_error"` on the 8 files).
- 87 adjacent tests pass (issue-1372-ir-destructuring-params, fn-param-dstr-rest-in-rest, issue-2158/2648/2934 packed-typedarray, issue-2903-r4/r4c R-series, issue-1787 packed semantics, issue-3024, issue-3024-incdec-element).

`loc-budget-allow` granted for `destructuring-params.ts` (+32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS