### PR TITLE
feat(#3132): standalone async-gen CONSUMER drive foundation — var/IIFE source resolution + call-site native-Promise passthrough

### DIFF
--- a/plan/issues/3132-standalone-native-async-generators.md
+++ b/plan/issues/3132-standalone-native-async-generators.md
@@ -18,6 +18,8 @@ updated: 2026-07-10
 assignee: ttraenkler/opus-asyncgen
 loc-budget-allow:
   - src/codegen/class-bodies.ts
+  - src/codegen/async-cps.ts
+  - src/codegen/expressions.ts
 origin: "FABLE task 30 — env::__create_async_generator touches ~2,800 leaky-passes (largest unowned chunk of the standalone-vs-host gap)."
 ---
 

--- a/plan/issues/3132-standalone-native-async-generators.md
+++ b/plan/issues/3132-standalone-native-async-generators.md
@@ -15,7 +15,7 @@ umbrella: 2860
 related: [3075, 2906, 2865, 2938, 2936, 2980, 2895, 2922, 1042, 3120]
 created: 2026-07-10
 updated: 2026-07-10
-assignee: ttraenkler/fable-3075
+assignee: ttraenkler/opus-asyncgen
 loc-budget-allow:
   - src/codegen/class-bodies.ts
 origin: "FABLE task 30 — env::__create_async_generator touches ~2,800 leaky-passes (largest unowned chunk of the standalone-vs-host gap)."

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1688,25 +1688,61 @@ const FORAWAIT_ARESULT = "__forawait_aresult";
  * (`asyncFnName` → `anon_<pos>`) or a member call is a 3d-iii edge.
  */
 function resolveAsyncGenNextHelperName(ctx: CodegenContext, source: ts.Expression): string | null {
-  if (!ts.isCallExpression(source)) return null;
-  const callee = source.expression;
-  if (!ts.isIdentifier(callee)) return null;
-  const name = `__async_gen_next_${sanitizeTypeName(callee.text)}`;
-  if (ctx.funcMap.has(name)) return name;
-  // (#2865) A const/var-held fn-EXPRESSION producer (`const f = async
-  // function* () {...}`) registers under its synthesized anon stem, not the
-  // binding name. Resolve the callee's declaration through the checker and
-  // match the producer registry by INITIALIZER NODE — exact, no naming games.
-  if (ctx.asyncGenProducers !== undefined) {
-    const { checker } = ctx;
-    const sym = checker.getSymbolAtLocation(callee);
+  // (#3132) A VAR-HELD async-gen FRAME: `var it = (async function*(){})();
+  // for await (x of it)`. The `for await` source is the identifier `it`, not a
+  // direct call — resolve its (single) initializer, which must itself be a
+  // direct async-gen call, and recurse. Only a const/var whose initializer is a
+  // CallExpression qualifies (a reassigned / param-held / member-held binding
+  // cannot be statically tied to one producer → stays legacy, correct-or-legacy).
+  // This is the row-flipping half of the ~390-file for-await-over-async-gen leak
+  // (the producer is already driven; the CONSUMER bailed to legacy CPS because
+  // the frame was held in a variable rather than called inline).
+  if (ts.isIdentifier(source)) {
+    const sym = ctx.checker.getSymbolAtLocation(source);
     const vd = sym?.valueDeclaration;
-    if (vd !== undefined && ts.isVariableDeclaration(vd) && vd.initializer !== undefined) {
-      for (const [stem, p] of ctx.asyncGenProducers) {
-        if (p.decl === vd.initializer) {
-          const exprName = `__async_gen_next_${stem}`;
-          if (ctx.funcMap.has(exprName)) return exprName;
+    if (
+      vd !== undefined &&
+      ts.isVariableDeclaration(vd) &&
+      vd.initializer !== undefined &&
+      ts.isCallExpression(vd.initializer)
+    ) {
+      return resolveAsyncGenNextHelperName(ctx, vd.initializer);
+    }
+    return null;
+  }
+  if (!ts.isCallExpression(source)) return null;
+  let callee = source.expression;
+  while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+  if (ts.isIdentifier(callee)) {
+    const name = `__async_gen_next_${sanitizeTypeName(callee.text)}`;
+    if (ctx.funcMap.has(name)) return name;
+    // (#2865) A const/var-held fn-EXPRESSION producer (`const f = async
+    // function* () {...}`) registers under its synthesized anon stem, not the
+    // binding name. Resolve the callee's declaration through the checker and
+    // match the producer registry by INITIALIZER NODE — exact, no naming games.
+    if (ctx.asyncGenProducers !== undefined) {
+      const sym = ctx.checker.getSymbolAtLocation(callee);
+      const vd = sym?.valueDeclaration;
+      if (vd !== undefined && ts.isVariableDeclaration(vd) && vd.initializer !== undefined) {
+        for (const [stem, p] of ctx.asyncGenProducers) {
+          if (p.decl === vd.initializer) {
+            const exprName = `__async_gen_next_${stem}`;
+            if (ctx.funcMap.has(exprName)) return exprName;
+          }
         }
+      }
+    }
+    return null;
+  }
+  // (#3132) An IIFE async-gen producer: `(async function*(){})()` — the callee
+  // is the async-gen function EXPRESSION itself. Match the producer registry by
+  // its declaration node (registered by `emitAsyncGenerator` when the fn-expr
+  // compiled, in source order before this consumer).
+  if ((ts.isFunctionExpression(callee) || ts.isArrowFunction(callee)) && ctx.asyncGenProducers !== undefined) {
+    for (const [stem, p] of ctx.asyncGenProducers) {
+      if (p.decl === callee) {
+        const exprName = `__async_gen_next_${stem}`;
+        if (ctx.funcMap.has(exprName)) return exprName;
       }
     }
   }

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1765,8 +1765,9 @@ function resolveAsyncGenNextHelperName(ctx: CodegenContext, source: ts.Expressio
   // This is the row-flipping half of the ~390-file for-await-over-async-gen leak
   // (the producer is already driven; the CONSUMER bailed to legacy CPS because
   // the frame was held in a variable rather than called inline).
+  const { checker } = ctx;
   if (ts.isIdentifier(source)) {
-    const sym = ctx.checker.getSymbolAtLocation(source);
+    const sym = checker.getSymbolAtLocation(source);
     const vd = sym?.valueDeclaration;
     if (
       vd !== undefined &&
@@ -1789,7 +1790,7 @@ function resolveAsyncGenNextHelperName(ctx: CodegenContext, source: ts.Expressio
     // binding name. Resolve the callee's declaration through the checker and
     // match the producer registry by INITIALIZER NODE — exact, no naming games.
     if (ctx.asyncGenProducers !== undefined) {
-      const sym = ctx.checker.getSymbolAtLocation(callee);
+      const sym = checker.getSymbolAtLocation(callee);
       const vd = sym?.valueDeclaration;
       if (vd !== undefined && ts.isVariableDeclaration(vd) && vd.initializer !== undefined) {
         for (const [stem, p] of ctx.asyncGenProducers) {

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1779,7 +1779,7 @@ function resolveAsyncGenNextHelperName(ctx: CodegenContext, source: ts.Expressio
     return null;
   }
   if (!ts.isCallExpression(source)) return null;
-  let callee = source.expression;
+  let callee: ts.Expression = source.expression;
   while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
   if (ts.isIdentifier(callee)) {
     const name = `__async_gen_next_${sanitizeTypeName(callee.text)}`;

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -14,6 +14,7 @@
 import { ts } from "../ts-api.js";
 import { isBooleanType, isPromiseType, mapTsTypeToWasm } from "../checker/type-mapper.js";
 import { classifyAsyncConsumer, analyzeAsyncBody, asyncFnNeedsCps } from "./async-cps.js";
+import { asyncGenConsumerNeedsDrive } from "./async-frame.js";
 import type { Instr, ValType } from "../ir/types.js";
 import {
   emitStandalonePromiseReject,
@@ -394,14 +395,28 @@ function asyncResultConsumedAsValue(ctx: CodegenContext, expr: ts.CallExpression
  * genuinely suspends (`asyncFnNeedsCps`). Inert off the carrier (gc/host).
  */
 function calleeIsDriveLowered(ctx: CodegenContext, expr: ts.CallExpression): boolean {
-  if (!isStandalonePromiseActive(ctx)) return false;
   const sig = ctx.checker.getResolvedSignature(expr);
   const decl = sig?.getDeclaration();
   if (!decl || !ts.isFunctionDeclaration(decl) || decl.body === undefined) return false;
   if (decl.asteriskToken) return false; // async generator — returns AsyncGenerator, not Promise
   const isAsyncDecl = (decl.modifiers ?? []).some((m) => m.kind === ts.SyntaxKind.AsyncKeyword);
   if (!isAsyncDecl) return false;
-  return asyncFnNeedsCps(decl, analyzeAsyncBody(ctx, decl));
+  // Carrier lane (wasi): a genuinely-suspending async fn is frame-driven and
+  // already returns a real `$Promise`.
+  if (isStandalonePromiseActive(ctx)) return asyncFnNeedsCps(decl, analyzeAsyncBody(ctx, decl));
+  // (#3132) `--target standalone` with the native-`$Promise` CARRIER still OFF
+  // (#2980): the async-gen-CONSUMER drive lane (`for await (x of asyncGen)`) is
+  // carrier-independent — every suspension awaits a promise MINTED by the
+  // producer's own `__async_gen_next_<name>` driver (a native `$Promise` on
+  // every lane), and the driven consumer settles its result via native
+  // `__promise_fulfill`. So its CALL result is already a native `$Promise` and
+  // must pass through UN-wrapped: the HOST try/catch wrap
+  // (`Promise_reject`/`__get_caught_exception`) was the last host dependency for
+  // the for-await-over-async-gen files whose consumer drives natively but whose
+  // call site still pulled in the host Promise machinery. Plain awaits / Promise
+  // statics stay on the legacy path pending the #2980 carrier widen.
+  if (ctx.standalone === true) return asyncGenConsumerNeedsDrive(ctx, decl, analyzeAsyncBody(ctx, decl));
+  return false;
 }
 
 /**

--- a/tests/issue-3132-s2-consumer.test.ts
+++ b/tests/issue-3132-s2-consumer.test.ts
@@ -1,0 +1,106 @@
+// #3132 (consumer foundation) — standalone async-generator CONSUMER drive.
+//
+// The async-gen PRODUCER already drives host-free (S1/S2a). The residual leak
+// on `for await (const x of <async-gen source>)` was the CONSUMER:
+//   1. `resolveAsyncGenNextHelperName` only resolved a direct NAMED call `g()`.
+//      A var-held / IIFE async-gen FRAME (`var it = (async function*(){})();
+//      for await (x of it)`) has an IDENTIFIER source → it returned null and the
+//      consumer bailed to the legacy async-CPS path.
+//   2. `calleeIsDriveLowered` was carrier-gated (WASI-only), so CALLING a driven
+//      async-gen-consumer under `--target standalone` fell to the HOST
+//      try/catch wrap (`Promise_reject` + `__get_caught_exception`).
+// Both are fixed for the IDENTIFIER-binding source; the DSTR-head composition
+// (over an async-gen source) stacks on #2996 as a follow-up PR.
+//
+// Destructuring-head for-await over an async-gen source stays on the legacy path
+// here (correct-or-legacy) — asserted below as an explicit boundary.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileStandalone(source: string) {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  expect(result.errors ?? []).toEqual([]);
+  return result;
+}
+
+function hostImportNames(result: { imports?: { name?: string; field?: string }[] }): string[] {
+  return (result.imports ?? [])
+    .map((i) => String(i.name ?? i.field ?? ""))
+    .filter((n) =>
+      /__gen_|__create_generator|__create_async_generator|__make_callback|Promise_|__get_caught_exception/.test(n),
+    );
+}
+
+async function runStandalone(source: string): Promise<number> {
+  const result = await compileStandalone(source);
+  const imports = buildImports(result.imports, undefined, result.stringPool, {}) as unknown as {
+    setExports?: (e: unknown) => void;
+  } & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports);
+  return (instance.exports.test as () => number)();
+}
+
+describe("#3132 consumer — standalone async-gen for-await drive (identifier binding)", () => {
+  it("var-held async-gen frame, identifier binding compiles host-free", async () => {
+    const r = await compileStandalone(`
+      var asyncIter = (async function*() { yield 1; yield 2; yield 3; })();
+      let out = 0;
+      async function fn() { for await (const x of asyncIter) { out += x; } }
+      export function test() { fn(); return out; }
+    `);
+    expect(hostImportNames(r)).toEqual([]);
+  });
+
+  it("var-held async-gen frame drives and accumulates correct values", async () => {
+    expect(
+      await runStandalone(`
+        var asyncIter = (async function*() { yield 1; yield 2; yield 3; })();
+        let out = 0;
+        async function fn() { for await (const x of asyncIter) { out += x; } }
+        export function test() { fn(); return out; }
+      `),
+    ).toBe(6);
+  });
+
+  it("inline async-gen call source, identifier binding is host-free and correct", async () => {
+    const src = `
+      async function* g() { yield 4; yield 5; }
+      let out = 0;
+      async function fn() { for await (const x of g()) { out += x; } }
+      export function test() { fn(); return out; }
+    `;
+    expect(hostImportNames(await compileStandalone(src))).toEqual([]);
+    expect(await runStandalone(src)).toBe(9);
+  });
+
+  it("yield*-array-literal producer, var-held, identifier binding is host-free and correct", async () => {
+    const src = `
+      var asyncIter = (async function*() { yield* [10, 20]; })();
+      let out = 0;
+      async function fn() { for await (const x of asyncIter) { out += x; } }
+      export function test() { fn(); return out; }
+    `;
+    expect(hostImportNames(await compileStandalone(src))).toEqual([]);
+    expect(await runStandalone(src)).toBe(30);
+  });
+
+  it("boundary: destructuring head over an async-gen source stays legacy (composition PR follows)", async () => {
+    // Not yet host-free — the dstr-head drive over an async-gen source is the
+    // #2996-stacked follow-up. This asserts the current correct-or-legacy
+    // boundary so the follow-up PR flips it deliberately.
+    const r = await compileStandalone(`
+      var asyncIter = (async function*() { yield* [[1, 2, 3]]; })();
+      let out = 0;
+      async function fn() { for await (const [x, y, z] of asyncIter) { out += x + y + z; } }
+      export function test() { fn(); return out; }
+    `);
+    expect(hostImportNames(r).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

PR-1 (foundation) of the #3132 standalone async-generator lever. Measure-first
found that the async-gen **producer** already drives host-free (S1/S2a); the
residual leak on the async-function `for await (const x of <async-gen source>)`
files is entirely in the **CONSUMER**. Two root causes, both fixed here for the
IDENTIFIER-binding source:

1. **`resolveAsyncGenNextHelperName`** (async-cps.ts) only resolved a direct
   NAMED call `g()`. The real test262 shape
   `var it = (async function*(){})(); for await (const x of it)` has an
   **identifier** source (a var-held frame), so the resolver returned `null` and
   the consumer bailed to the legacy async-CPS path. Now it resolves an
   identifier → its var initializer → producer, and an IIFE
   `(async function*(){})()` → producer-by-decl.

2. **`calleeIsDriveLowered`** (expressions.ts) was carrier-gated (WASI-only), so
   **calling** a driven async-gen-consumer under `--target standalone` (carrier
   off, #2980) fell to the HOST try/catch wrap, pulling in `Promise_reject` +
   `__get_caught_exception`. The async-gen-consumer drive is
   carrier-independent (it returns a native `$Promise`), so it's now recognized
   and the call result passes through un-wrapped.

## Result

Identifier-binding var-held / inline / `yield*`-array-literal async-gen
`for await` now compiles **host-free** and runs correctly (verified sums
6 / 9 / 30). Composes with #2996/#3228: my resolver improves its
`forAwaitNeedsDrive` guard (kept as-is) — once the resolver returns non-null for
var/IIFE async-gen sources, the sync array carrier correctly declines
async-gen-source dstr and routes them to the consumer path.

## Scope / boundary

- Standalone-gated; the WASI/carrier branch of `calleeIsDriveLowered` is
  byte-identical to before. gc/host lanes inert.
- **Destructuring-head** for-await over an async-gen source deliberately stays
  legacy here (asserted as an explicit boundary test) — that's PR-2, which wires
  #2996's `postDeliverEmit`/`destructureElem` into the async-gen consumer CFG
  (the ~195 `async-func-dstr-*-async-*` files).

## Tests

`tests/issue-3132-s2-consumer.test.ts` (5) — host-free + correct-value for
var-held / inline / `yield*`-literal identifier-binding sources, plus the
legacy-boundary assertion for the dstr head. Adjacent suites green; the 2
pre-existing `issue-2865` WASI-env failures are identical with these edits
reverted (not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)