### PR TITLE
fix(#2106 S1): complete the array-absence producer arm behind the $undefined flag (byte-inert)

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -15,6 +15,14 @@ area: codegen
 language_feature: type-coercion
 goal: core-semantics
 related: [2004, 2051, 2030, 2001]
+# (#3102) PR-1 array-absence producer completion adds gated singleton arms +
+# explanatory comments to three god-files (destructuring-params +13, type-coercion
+# +13, array-methods +11). The growth is intended (byte-inert flag-OFF producer
+# fixes at their canonical sites, not a barrel/driver); allow it for this change-set.
+loc-budget-allow:
+  - src/codegen/destructuring-params.ts
+  - src/codegen/type-coercion.ts
+  - src/codegen/array-methods.ts
 origin: "2026-06-11 analysis program (report 02 phase P3); stub 08-E21"
 reconcile_note: "2026-06-24 (PO reconcile vs upstream/main): SUSPENDED, not dev-claimable as a fresh sprint task. P3 headline landed (PR #1701, commit 347f3c79a). The remaining S1 standalone $undefined tag-1 singleton is an ATOMIC ~40-site change (producer flip breaks all ref.is_null nullish consumers) — see memory project_2106_undefined_singleton_s1_atomic; branch issue-2106-s1-undefined-singleton. Resume-only for a senior-dev (max effort), NOT a routine sprint-65 dev pull. → backlog."
 ---

--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -686,3 +686,89 @@ needs the box-protocol fix), S4 (union-collapse reversal) remain per plan.
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 
 NOT done — the referencing merged PR was a REVERT (PR #2025 auto-parked: standalone floor breach, NET -1245 test262 rows), so it is floor-neutral undo, NOT progress. S1 (standalone tag-1 $undefined singleton) still requires the FULL ~40-site producer+consumer sweep (architect re-spec) — no narrow floor-saving subset exists. S2 (sNaN carve-out), S3 (number|undefined→externref), S4 (union-collapse reversal), typeof-null→object all remain. Stays in-progress; resume-only for a senior-dev at max effort.
+
+---
+
+# S1 default-flip RE-MEASURE + array-absence producer COMPLETION (opus-2580, 2026-07-13, max-reasoning)
+
+> Scope-first re-measure of the default-flip NO-GO (PR #2655) against CURRENT
+> main, then a bounded, byte-inert completion of the residual producer gap. The
+> flagged sweep (PR #2633) IS on main; this is PR-1 of a two-step decoupling
+> (PR-1 = byte-inert completion; PR-2 = the default flip, gated on a FULL fork
+> A/B). All probes per-process; the fork run's floor step decoded, not trusted.
+
+## Why the last default-flip (PR #2655) was declined — VERIFIED, not stale-inferred
+
+PR #2655 (flip `undefinedSingleton` default ON) was closed citing the fork A/B
+"conclusion=failure". Decoded fork run **28716643775**: all 30 shards were GREEN;
+the failing job is `merge shard reports` → step **"Standalone pass-count
+high-water floor (#2097)"**: `current pass=19062, mark=20952, delta=-1890`. So
+the decline was correct — flag-ON was a genuine **−1890** standalone floor breach
+(worse than June's partial −1245), NOT infra. BUT that A/B is against main @
+`265a26fc3` (8 days / hundreds of commits stale; #3053 U0-U2 carrier, #3033,
+#3183, #3169 landed since).
+
+## The −1890 is a BOUNDED lockstep gap, not a representation cost (current-main A/B)
+
+Re-measured flag-ON vs flag-OFF per-process on current main. Flag-ON is ALREADY
+correct for: null/undefined distinctness, `typeof null === "object"`, the June
+−1245 ROOT (dstr default no longer fires on a present `null`), `""+undefined`,
+**object** missing-key default (`{a=7}={}`→7), explicit `[undefined]` element,
+`fn(undefined)`. The ONLY live regression class was the **array-element-absence
+producers** — they still emitted raw `ref.null.extern` for "absent", while their
+dstr-default CONSUMER (`emitExternrefDefaultCheck` → `__extern_is_undefined`,
+which is **singleton-only** under the flag, dropping the `ref.is_null` arm) was
+flipped → the default spuriously failed to fire:
+
+| shape | flag-OFF | flag-ON (before) | producer |
+| --- | --- | --- | --- |
+| `[x=9]=[]` (hole) | 9 | **0** | array-OOB decl/param read |
+| `[,y=9]=[1]` (elision) | 9 | **0** | array-OOB decl/param read |
+| `[a,b=9]=[1]` (past-end) | 9 | **0** | array-OOB decl/param read |
+| `fn(x=9)` absent param | 9 | **0** | absent optional/default param padding |
+| `for(const [a=9] of [[]])` | 9 | **0** | for-of loop-head array-destructure |
+
+Object-key-absence and explicit-undefined were already flipped; only the
+array-absence + absent-param producers were missed — the dstr/dflt/ptrn cluster
+that was ~70% of June's −1245, hence it plausibly dominates the −1890.
+
+## PR-1 (this change) — the array-absence producer completion (byte-inert)
+
+Three producers now route the "absent → undefined" value through the `$undefined`
+singleton under the flag (byte-identical flag-OFF, so PR-1 cannot breach the floor
+— it only matters once PR-2 flips the default). Each is the `emitUndefined`/
+`undefinedExternInstrs` singleton vehicle, gated so flag-OFF emits the exact prior
+`ref.null.extern`:
+
+1. **`emitBoundsCheckedArrayGetUndef`** (`destructuring-params.ts`) — the OOB
+   else-arm of the decl/param array-element read. Standalone flag-ON → singleton;
+   host unchanged (`__get_undefined`); standalone flag-OFF → legacy fallback.
+2. **`emitUndefinedValue`** (`type-coercion.ts`, the param-padding chokepoint used
+   by `pushDefaultValue`/`pushParamSentinel`) — absent optional/default param.
+   Standalone flag-ON → singleton; else `ref.null.extern` (byte-identical).
+3. **`emitBoundsCheckedArrayGet`** (`array-methods.ts`) — the `useUndefinedSentinel`
+   OOB else-arm (the for-of loop-head destructuring path). Gated on
+   `useUndefinedSentinel` so non-destructuring array reads are byte-identical.
+
+**Validated** (per-process A/B, both flag states + `tests/issue-2106-s1-array-absence-producers.test.ts`,
+5 cases): all 5 shapes above flip to correct under flag-ON; present-value / explicit-
+undefined / present-`null` unaffected; flag-OFF byte-inert (control green). Existing
+`issue-2106-s1-undefined-singleton` (9) + `issue-2574` (7) + default-param/dstr batch
+(32/33; the 1 fail is a pre-existing `wasm:js-string` host-import env artifact in
+`issue-1016b`, flag-OFF, unrelated). tsc + prettier clean.
+
+## PR-2 (NEXT, separate) — the default flip, gated on a FULL fork A/B
+
+Do NOT flip the default from this PR. After PR-1 lands, re-run the FULL fork
+sharded A/B (`JS2WASM_UNDEF_SINGLETON=1`, the merge_group standalone-floor #2097 —
+NEVER a local/scoped measurement) and flip the default OFF→ON only if
+`host_free_pass` is net-non-negative vs the flag-OFF floor. If a residual remains,
+document the next producer bucket and keep the flag OFF — PR-1's completion still
+banks as progress toward a future flip. The −1245/−1890 history is unambiguous:
+the flip decision is a full-gate measurement, not a local judgment.
+
+**Audit note (heeded):** this is NOT a single-site fix — the broad per-process
+audit (nested `[[a=9]]`/`[{p=9}]`, rest, multi-param, object defaults, arrow,
+expression-default side-effects, for-of) is all green flag-ON after the three
+producer flips. Any producer still missed is byte-inert (flag-OFF default) and
+will surface as a residual bucket in PR-2's fork A/B, not a floor breach now.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -47,7 +47,7 @@ import {
   VOID_RESULT,
 } from "./shared.js";
 import { emitUndefined, ensureGetUndefined } from "./expressions/late-imports.js";
-import { ensureExternSameValueZeroHelper, ensureExternStrictEqHelper } from "./any-helpers.js";
+import { ensureExternSameValueZeroHelper, ensureExternStrictEqHelper, undefinedExternInstrs } from "./any-helpers.js";
 import {
   ensureNativeStringHelpers,
   nativeStringLiteralInstrs,
@@ -498,10 +498,21 @@ export function emitBoundsCheckedArrayGet(
 
   // Build the "else" branch: out-of-bounds -> default value (or JS undefined
   // when the destructuring caller opted in via `useUndefinedSentinel`).
+  // (#2106 S1) In standalone/nativeStrings with the $undefined singleton flag ON,
+  // an OOB externref destructuring read must yield the tag-1 singleton (not raw
+  // `ref.null.extern`), so the externref default-check (`__extern_is_undefined`,
+  // singleton-only under the flag) fires the default — the for-of loop-head
+  // array-destructuring producer arm (`for (const [a=9] of [[]]) …`). Gated on
+  // `useUndefinedSentinel` so non-destructuring array reads are byte-identical;
+  // flag OFF → `defaultValueInstrs` (`ref.null.extern`, byte-identical).
+  const singletonOob =
+    useUndefinedSentinel && ctx && (elementType.kind === "externref" || elementType.kind === "ref_extern")
+      ? undefinedExternInstrs(ctx)
+      : undefined;
   const elseInstrs: Instr[] =
     undefinedFuncIdx !== undefined
       ? [{ op: "call", funcIdx: undefinedFuncIdx } as Instr]
-      : defaultValueInstrs(valueType);
+      : (singletonOob ?? defaultValueInstrs(valueType));
 
   // When the element type is a non-null ref, the else branch produces ref.null
   // which is ref_null. Use ref_null as the block type so both branches validate,

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -25,7 +25,7 @@ import { ensureExternRestObject } from "./object-runtime.js";
 import { emitLocalTdzInit } from "./statements/tdz.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import { holeToUndefinedInstrs } from "./array-holes.js"; // (#2001 S1)
-import { emitIsUndefinedSingletonExternAt, undefinedSingletonActive } from "./any-helpers.js"; // (#2106 S1)
+import { emitIsUndefinedSingletonExternAt, undefinedExternInstrs, undefinedSingletonActive } from "./any-helpers.js"; // (#2106 S1)
 import {
   coerceType,
   compileExpression,
@@ -226,8 +226,21 @@ function emitBoundsCheckedArrayGetUndef(
   const getUndefIdx = ctx.nativeStrings
     ? undefined
     : ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
-  if (getUndefIdx === undefined) {
-    // standalone mode — can't get JS undefined, fall back to regular path
+  // (#2106 S1) Determine the OOB "undefined" else-arm producer:
+  //   - host mode → the `__get_undefined` import call;
+  //   - standalone/nativeStrings with the $undefined singleton flag ON → the
+  //     tag-1 singleton (so the externref default-check, which is singleton-only
+  //     under the flag, fires the destructuring default for a past-length index);
+  //   - standalone flag OFF → the legacy fallback below (byte-identical).
+  // Without the singleton arm, standalone OOB yielded raw `ref.null.extern`,
+  // which the flag-on `__extern_is_undefined` (singleton-only) does NOT treat as
+  // undefined → array-pattern defaults spuriously failed to fire (the #2106
+  // array-absence producer gap: `[x=9]=[]`, `[,y=9]=[1]`, `[a,b=9]=[1]`).
+  const singletonOobInstrs = getUndefIdx === undefined ? undefinedExternInstrs(ctx) : undefined;
+  const oobElse: Instr[] | undefined =
+    getUndefIdx !== undefined ? [{ op: "call", funcIdx: getUndefIdx } as Instr] : singletonOobInstrs;
+  if (oobElse === undefined) {
+    // standalone flag OFF — can't get JS undefined, fall back to regular path
     emitBoundsCheckedArrayGet(fctx, arrTypeIdx, elementType);
     return;
   }
@@ -264,7 +277,7 @@ function emitBoundsCheckedArrayGetUndef(
     op: "if",
     blockType: { kind: "val", type: { kind: "externref" } },
     then: inBoundsThen,
-    else: [{ op: "call", funcIdx: getUndefIdx } as Instr],
+    else: oobElse,
   });
 }
 

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -13,6 +13,7 @@ import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.j
 import type { ClosureInfo, CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { addUnionImports, ensureAnyHelpers, ensureAnyToExternHelper, isAnyValue } from "./index.js";
+import { undefinedExternInstrs } from "./any-helpers.js"; // (#2106 S1)
 import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
 import { ensureWrapperStringValueHelper } from "./object-runtime.js";
@@ -3199,6 +3200,18 @@ function emitUndefinedValue(ctx: CodegenContext, fctx: FunctionContext): void {
   if (funcIdx !== undefined) {
     flushLateImportShifts(ctx, fctx);
     fctx.body.push({ op: "call", funcIdx });
+    return;
+  }
+  // (#2106 S1) In standalone/nativeStrings with the $undefined singleton flag ON,
+  // an absent optional/default parameter must be the tag-1 singleton so the
+  // callee's externref default-check (`__extern_is_undefined`, singleton-only
+  // under the flag) fires the default. Flag OFF → the legacy `ref.null.extern`
+  // (byte-identical). Without this, a missing `any`-typed default param
+  // (`function f(x = 9){} ; f()`) padded with raw null was invisible to the
+  // flag-on check → the default spuriously failed to fire.
+  const singletonInstrs = undefinedExternInstrs(ctx);
+  if (singletonInstrs !== undefined) {
+    fctx.body.push(...singletonInstrs);
   } else {
     fctx.body.push({ op: "ref.null.extern" });
   }

--- a/tests/issue-2106-s1-array-absence-producers.test.ts
+++ b/tests/issue-2106-s1-array-absence-producers.test.ts
@@ -1,0 +1,97 @@
+// #2106 S1 — array-absence producer completion (flag ON, standalone/wasi).
+//
+// The complete `$undefined` tag-1 singleton sweep flipped the OBJECT missing-key
+// producer (`__extern_get` miss) and explicit-`undefined` producers, and the
+// undefined-specific CONSUMERS (`__extern_is_undefined` is singleton-only under
+// the flag). But three ARRAY-absence producers still emitted raw
+// `ref.null.extern` for an absent element, which the flag-on singleton-only
+// consumer does NOT treat as undefined → the destructuring/param default
+// spuriously failed to fire:
+//
+//   1. array-pattern OOB element read in decl/param destructuring
+//      (`const [x=9]=[]`, `[,y=9]=[1]`, `[a,b=9]=[1]`)  — emitBoundsCheckedArrayGetUndef
+//   2. absent optional/default parameter padding (`function f(x=9){}; f()`)
+//      — emitUndefinedValue (via pushDefaultValue)
+//   3. for-of loop-head array destructuring (`for (const [a=9] of [[]]) …`)
+//      — emitBoundsCheckedArrayGet's useUndefinedSentinel arm
+//
+// This test pins all three flip to the singleton under the flag (default fires),
+// while the present-value and present-`null` cases are unaffected (default does
+// NOT fire on a present `null` — §13.15.5.3). Each case is a distinct producer,
+// so a future default-flip A/B measures the whole array-absence cluster at once.
+//
+// Flag OFF is the legacy conflated regime and stays byte-identical (a partial
+// producer flip is what breached the standalone floor at −1245/−1890 before;
+// this completion is byte-inert until a deliberate, fork-A/B-measured flip).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+async function run(source: string, undefinedSingleton: boolean): Promise<number> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi", undefinedSingleton });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const module = await WebAssembly.compile(result.binary);
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  return (exports.test as () => number)();
+}
+
+const P1 = `export function test(): number {
+  const [x = 9] = [] as any[];             // OOB index 0 on []
+  const [, y = 9] = [1] as any[];          // OOB index 1 (elision)
+  const [a, b = 9] = [1] as any[];         // OOB index 1 (past-end)
+  return (x === 9 && y === 9 && b === 9) ? 1 : 0;
+}`;
+
+const P2 = `function f(x: any = 9) { return x; }
+function g(a: any, b: any = 9) { return b; }
+export function test(): number {
+  return (f() === 9 && g(1) === 9) ? 1 : 0;      // absent default param → default fires
+}`;
+
+const P3 = `export function test(): number {
+  let s = 0;
+  for (const [a = 9] of [[]] as any[][]) { s = a === 9 ? 1 : 0; }   // for-of OOB element
+  return s;
+}`;
+
+const PRESENT = `export function test(): number {
+  const [x = 9] = [5] as any[];            // present value → NO default
+  const [u = 9] = [undefined] as any[];    // explicit undefined → default
+  const n: any = ([null] as any[])[0];     // present null (via [x=9]=[null])
+  const [m = 9] = [null] as any[];
+  return (x === 5 && u === 9 && m === null) ? 1 : 0;
+}`;
+
+describe("#2106 S1 array-absence producers (flag ON)", () => {
+  it("array-pattern OOB decl destructuring defaults fire (was raw null → default skipped)", async () => {
+    expect(await run(P1, true)).toBe(1);
+  });
+
+  it("absent optional/default parameter padding fires the default", async () => {
+    expect(await run(P2, true)).toBe(1);
+  });
+
+  it("for-of loop-head array-destructuring default fires on an OOB element", async () => {
+    expect(await run(P3, true)).toBe(1);
+  });
+
+  it("present value / explicit undefined / present null are unaffected (§13.15.5.3)", async () => {
+    expect(await run(PRESENT, true)).toBe(1);
+  });
+
+  it("flag OFF control: legacy path still applies OOB defaults (byte-inert regime)", async () => {
+    // Under the legacy conflated regime the OOB default also fires (ref.is_null
+    // catches the raw null) — this proves the fix is additive, not a behavior
+    // change for flag-off.
+    expect(await run(P1, false)).toBe(1);
+    expect(await run(P2, false)).toBe(1);
+    expect(await run(P3, false)).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Completes the array-element-absence producer arm of the `#2106` S1 `$undefined` tag-1 singleton sweep, **behind the existing default-OFF `undefinedSingleton` flag** (byte-inert — safe to merge, zero main risk). This is **PR-1** of a two-step decoupling; the default **flip** (PR-2) is separate and gated on a full fork A/B.

## Why

The complete lockstep sweep (PR #2633, on main) flipped the OBJECT missing-key + explicit-`undefined` producers and the undefined-specific CONSUMERS (`__extern_is_undefined` is singleton-only under the flag, dropping the `ref.is_null` arm). But three **array-absence** producers still emitted raw `ref.null.extern` for an absent element — invisible to the flag-on singleton-only consumer → array/param destructuring defaults **spuriously failed to fire**:

| shape | flag-OFF | flag-ON before | flag-ON after |
| --- | --- | --- | --- |
| `[x=9]=[]` / `[,y=9]=[1]` / `[a,b=9]=[1]` (OOB) | 9 | **0** | 9 |
| `function f(x=9){}; f()` (absent param) | 9 | **0** | 9 |
| `for (const [a=9] of [[]]) …` | 9 | **0** | 9 |

This is the dstr/dflt/ptrn cluster that dominated the flag-ON standalone floor breach that caused PR #2655's default-flip to be declined (fork run 28716643775 → `merge shard reports` floor step **−1890** `host_free_pass`; decoded, not inferred — all 30 shards were green).

## The fix (3 producers, all byte-inert flag-OFF)

Route the "absent → undefined" value through the `$undefined` singleton under the flag; each falls back to the exact prior `ref.null.extern` when `undefinedExternInstrs(ctx)` is `undefined` (flag OFF / host mode):

1. `emitBoundsCheckedArrayGetUndef` (`destructuring-params.ts`) — OOB else-arm of the decl/param array-element read.
2. `emitUndefinedValue` (`type-coercion.ts`) — absent optional/default param padding (the `pushDefaultValue`/`pushParamSentinel` chokepoint).
3. `emitBoundsCheckedArrayGet` (`array-methods.ts`) — the `useUndefinedSentinel` OOB else-arm (for-of loop-head array destructuring).

## Scope / safety

- **Byte-inert by construction** flag-OFF (the default) → cannot breach the floor; the completeness only matters once PR-2 flips the default.
- Broad per-process audit (nested `[[a=9]]`/`[{p=9}]`, rest, multi-param, object defaults, arrow, expression-default side-effects, for-of) all green flag-ON after the three flips; present-value / explicit-undefined / present-`null` unaffected.

## Validation

- `tests/issue-2106-s1-array-absence-producers.test.ts` (5, flag on + off control).
- `issue-2106-s1-undefined-singleton` (9) + `issue-2574` (7) + default-param/dstr batch (32/33; the 1 fail is a pre-existing `wasm:js-string` host-import env artifact in `issue-1016b`, flag-OFF, unrelated). tsc + prettier clean.

## NOT in this PR

The default **flip** (PR-2) — separate, gated on a FULL fork A/B (merge_group standalone floor #2097), never a local measurement, per the −1245/−1890 history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8