### PR TITLE
refactor(tests): consolidate compileAndRun helpers into tests/helpers/compile.ts (#3109)

### DIFF
--- a/plan/issues/3109-test-helper-consolidation-compileandrun.md
+++ b/plan/issues/3109-test-helper-consolidation-compileandrun.md
@@ -4,7 +4,7 @@ title: "Test-helper consolidation: 132 test files re-declare compileAndRun (10+ 
 status: ready
 sprint: current
 created: 2026-07-09
-updated: 2026-07-12
+updated: 2026-07-13
 priority: high
 # 2026-07-12 (#3182 groom): elevated Backlog/medium → current/high.
 # Re-measured: 133 test files declare their own compileAndRun today.
@@ -82,3 +82,43 @@ one correct harness for host-closure wiring.
 1. `tests/helpers/compile.ts` exists; ≥ 100 of the 132 local definitions removed.
 2. Full vitest suite green with unchanged assertions.
 3. No src/ changes in the PR(s).
+
+## Progress
+
+### Slice 1 (ttraenkler/opus-tests) — 19 files, `tests/helpers/compile.ts` seeded
+
+Behavior-preserving refactor. `tests/helpers/compile.ts` created with the three
+highest-duplication **identical-body** clusters extracted ONCE. Migrated files
+delete their local `compileAndRun` and import the shared function under an alias
+(`import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js"`),
+so every call site is unchanged.
+
+Why three distinct helpers, not one merged shape: the clusters differ in how
+they wire host imports, and merging them would change which imports a module
+links (semantic drift). Each exported function is byte-for-byte behaviorally
+identical to the local copy it replaces:
+
+- `compileAndRunStubs` — 9 files: assert `result.success` (msg + WAT), bare
+  `env.console_log_*` no-op stub imports. codegen, void-expr, compiler, bitwise,
+  generics, numeric-separators, logical-assignment, issue-243, spread-rest.
+- `compileAndRunImportObject` — 5 files: assert `result.success` (no WAT),
+  instantiate against `result.importObject!`. issue-2055/2062/2067/2053/2065.
+- `compileAndRunBuildImports` — 5 files: guard non-empty `result.binary` then
+  full `buildImports(...)` host object; compiles with `{ fileName: "test.ts" }`.
+  math-minmax, issue-146, math-inline, new-array, string-coercion.
+
+Net −247 LOC across the 19 test files; +78 for the shared module. Orphaned
+`compile` / `buildImports` imports dropped where the local helper was their only
+user.
+
+**Parity proof:** the 19 files were run with `vitest --reporter=json` before and
+after migration — identical per-test result set (224 tests, 125 pass / 99 fail;
+the 99 pre-existing main-state failures are unchanged). Full `tsc --noEmit`,
+`biome lint`, and `prettier --check` all green. Zero `src/` changes.
+
+**Remaining (future slices):** ~113 local `compileAndRun` definitions across the
+other signature variants (result-object shapes, `Promise<number>`,
+`expectCompiles`-based, custom import-stub variants, `compileAndRunMulti`, …).
+Migrate additional identical-body clusters the same way; keep non-equivalent
+local helpers local (or thread the extra via an `opts` param). This issue stays
+`ready` until ≥100 of 132 removed (acceptance criterion 1).

--- a/tests/bitwise.test.ts
+++ b/tests/bitwise.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("bitwise operators", () => {
   it("AND (&)", async () => {

--- a/tests/codegen.test.ts
+++ b/tests/codegen.test.ts
@@ -1,22 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("comparison operators", () => {
   it("less than", async () => {

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -1,22 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("arithmetic", () => {
   it("add", async () => {

--- a/tests/generics.test.ts
+++ b/tests/generics.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("generics", () => {
   it("identity with number", async () => {

--- a/tests/helpers/compile.ts
+++ b/tests/helpers/compile.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3109 — shared compile-and-run test harness.
+ *
+ * `tests/` re-declares a local `async function compileAndRun(source: string)`
+ * in 130+ files across 10+ divergent signatures. This module extracts the
+ * highest-duplication *identical-body* clusters ONCE so the copies can be
+ * deleted.
+ *
+ * These are deliberately THREE distinct helpers, not one merged shape: the
+ * clusters differ in how they wire host imports, and merging them would change
+ * runtime behavior for the migrated tests (e.g. bare console-stub imports vs.
+ * the full {@link buildImports} host object link different sets of imports).
+ * Each function below is byte-for-byte behaviorally identical to the local copy
+ * it replaces, so migration is a pure dedup with zero semantic drift. A test
+ * whose local helper does something *extra* (custom import stubs, wasi knobs,
+ * result-object shapes) is NOT a member of these clusters and keeps its local
+ * helper.
+ *
+ * Import into a test file with an alias so the call sites stay unchanged, e.g.
+ *   import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
+ */
+import { expect } from "vitest";
+import { compile } from "../../src/index.js";
+import { buildImports } from "../../src/runtime.js";
+
+/**
+ * Cluster A (9 files): assert `result.success` (message includes the WAT), then
+ * instantiate against bare no-op `env.console_log_*` stub imports and return the
+ * exports. Used by tests whose compiled module only imports the console logging
+ * builtins.
+ */
+export async function compileAndRunStubs(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source);
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+  ).toBe(true);
+  const imports = {
+    env: {
+      console_log_number: () => {},
+      console_log_string: () => {},
+      console_log_bool: () => {},
+    },
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return instance.exports as Record<string, Function>;
+}
+
+/**
+ * Cluster B (5 files): assert `result.success` (message without WAT), then
+ * instantiate against the compiler-provided `result.importObject` and return the
+ * exports.
+ */
+export async function compileAndRunImportObject(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
+  return instance.exports as Record<string, Function>;
+}
+
+/**
+ * Cluster C (5 files): guard on a non-empty `result.binary` (throwing on failure
+ * rather than asserting `result.success`), then instantiate against the full
+ * {@link buildImports} host object and return the exports. Compiles with
+ * `{ fileName: "test.ts" }`.
+ */
+export async function compileAndRunBuildImports(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.binary || result.binary.length === 0) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return instance.exports as Record<string, Function>;
+}

--- a/tests/issue-146.test.ts
+++ b/tests/issue-146.test.ts
@@ -1,16 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-import { buildImports } from "../src/runtime.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source, { fileName: "test.ts" });
-  if (!result.binary || result.binary.length === 0) {
-    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
-  }
-  const imports = buildImports(result.imports, undefined, result.stringPool);
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunBuildImports as compileAndRun } from "./helpers/compile.js";
 
 async function compileOnly(source: string) {
   const result = await compile(source, { fileName: "test.ts" });

--- a/tests/issue-2053.test.ts
+++ b/tests/issue-2053.test.ts
@@ -1,19 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
+import { compileAndRunImportObject as compileAndRun } from "./helpers/compile.js";
 
 // #2053 — a spread followed by trailing positional args used to greedily
 // consume every remaining parameter, reading past the spread array (OOB → NaN)
 // and leaving the trailing args as surplus stack values. The fix reserves the
 // trailing positional param slots so the spread only fills the params it covers.
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
-    true,
-  );
-  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
-  return instance.exports as Record<string, Function>;
-}
 
 const SUM3 = `function sum3(a: number, b: number, c: number): number { return a * 100 + b * 10 + c; }`;
 const SUM4 = `function sum4(a: number, b: number, c: number, d: number): number { return a * 1000 + b * 100 + c * 10 + d; }`;

--- a/tests/issue-2055.test.ts
+++ b/tests/issue-2055.test.ts
@@ -1,20 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
+import { compileAndRunImportObject as compileAndRun } from "./helpers/compile.js";
 
 // #2055 — a relational comparison where one operand is an i32-promoted loop var
 // used to force the i32 numeric hint onto the *other* operand, truncating a
 // fractional f64 (e.g. `i < 2.5` became `i < 2`) via i32.trunc_sat_f64_s. The
 // fix only takes the i32 fast path when BOTH operands are provably i32-pure;
 // otherwise the i32 local is promoted to f64 and an f64 compare is emitted.
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
-    true,
-  );
-  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
-  return instance.exports as Record<string, Function>;
-}
 
 describe("#2055 relational i32 hint must not truncate a fractional f64 operand", () => {
   it("if (i < 2.5) with i32 loop var", async () => {

--- a/tests/issue-2062.test.ts
+++ b/tests/issue-2062.test.ts
@@ -1,20 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
+import { compileAndRunImportObject as compileAndRun } from "./helpers/compile.js";
 
 // #2062 — `catch (e) { e = ...; throw e; }` used to emit Wasm `rethrow`, which
 // re-raises the ORIGINALLY-caught exception, ignoring the reassignment. The
 // rethrow fast path is now disabled whenever the catch parameter is written
 // anywhere in the block (assignment, compound, ++/--, or via a capturing
 // closure); plain `catch (e) { throw e; }` keeps the fast path.
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
-    true,
-  );
-  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
-  return instance.exports as Record<string, Function>;
-}
 
 describe("#2062 throw e after catch-param reassignment", () => {
   it("reassign then throw propagates the new value", async () => {

--- a/tests/issue-2065.test.ts
+++ b/tests/issue-2065.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
+import { compileAndRunImportObject as compileAndRun } from "./helpers/compile.js";
 
 // #2065 — the for-of array fast path hoisted the vec's `length` and `data` into
 // locals once before the loop, so elements pushed during iteration were never
@@ -7,15 +7,6 @@ import { compile } from "../src/index.js";
 // array left `data` stale). When the iterable is a plain identifier whose array
 // the body may mutate, the loop now re-reads length/data from the vec each
 // iteration. Non-mutating loops keep the hoisted fast path.
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
-    true,
-  );
-  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
-  return instance.exports as Record<string, Function>;
-}
 
 describe("#2065 for-of observes mid-iteration array mutation", () => {
   it("push during iteration is visited", async () => {

--- a/tests/issue-2067.test.ts
+++ b/tests/issue-2067.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
+import { compileAndRunImportObject as compileAndRun } from "./helpers/compile.js";
 
 // #2067 — the generic for-of iterator lowering carried a hard `br_if` guard that
 // silently `break`ed after 1,000,000 iterations, and its counter local was never
@@ -7,15 +7,6 @@ import { compile } from "../src/index.js";
 // accumulated toward the cap. The guard is removed: the loop runs to the
 // iterator's own `done`. (The eager-generator buffer's separate `RangeError`
 // cap is out of scope here.)
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
-    true,
-  );
-  const { instance } = await WebAssembly.instantiate(result.binary, result.importObject!);
-  return instance.exports as Record<string, Function>;
-}
 
 const GEN = `function* gen(n: number): Generator<number> { for (let i = 0; i < n; i++) yield 1; }`;
 

--- a/tests/issue-243.test.ts
+++ b/tests/issue-243.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("Issue #243: Unsupported assignment target patterns", () => {
   it("array destructuring assignment: [a, b] = [1, 2]", async () => {

--- a/tests/logical-assignment.test.ts
+++ b/tests/logical-assignment.test.ts
@@ -1,22 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("logical assignment operators", () => {
   describe("??= (nullish coalescing assignment)", () => {

--- a/tests/math-inline.test.ts
+++ b/tests/math-inline.test.ts
@@ -1,16 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-import { buildImports } from "../src/runtime.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source, { fileName: "test.ts" });
-  if (!result.binary || result.binary.length === 0) {
-    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
-  }
-  const imports = buildImports(result.imports, undefined, result.stringPool);
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunBuildImports as compileAndRun } from "./helpers/compile.js";
 
 // Tolerance for polynomial approximations (inline Wasm, not native IEEE 754)
 const EPSILON = 1e-3;

--- a/tests/math-minmax.test.ts
+++ b/tests/math-minmax.test.ts
@@ -1,16 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-import { buildImports } from "../src/runtime.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source, { fileName: "test.ts" });
-  if (!result.binary || result.binary.length === 0) {
-    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
-  }
-  const imports = buildImports(result.imports, undefined, result.stringPool);
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunBuildImports as compileAndRun } from "./helpers/compile.js";
 
 describe("Math.min / Math.max", () => {
   it("Math.min with 2 args", async () => {

--- a/tests/new-array.test.ts
+++ b/tests/new-array.test.ts
@@ -1,16 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-import { buildImports } from "../src/runtime.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source, { fileName: "test.ts" });
-  if (!result.binary || result.binary.length === 0) {
-    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
-  }
-  const imports = buildImports(result.imports, undefined, result.stringPool);
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunBuildImports as compileAndRun } from "./helpers/compile.js";
 
 describe("new Array()", () => {
   it("new Array() creates empty array", async () => {

--- a/tests/numeric-separators.test.ts
+++ b/tests/numeric-separators.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("numeric separators", () => {
   it("integer with underscores (1_000_000)", async () => {

--- a/tests/spread-rest.test.ts
+++ b/tests/spread-rest.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 // ── Rest parameters ────────────────────────────────────────────────────
 

--- a/tests/string-coercion.test.ts
+++ b/tests/string-coercion.test.ts
@@ -1,16 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-import { buildImports } from "../src/runtime.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source, { fileName: "test.ts" });
-  if (!result.binary || result.binary.length === 0) {
-    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
-  }
-  const imports = buildImports(result.imports, undefined, result.stringPool);
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunBuildImports as compileAndRun } from "./helpers/compile.js";
 
 describe("string to number coercion", () => {
   it("unary + on string calls parseFloat", async () => {

--- a/tests/void-expr.test.ts
+++ b/tests/void-expr.test.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compile } from "../src/index.js";
-
-async function compileAndRun(source: string) {
-  const result = await compile(source);
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
-  ).toBe(true);
-  const imports = {
-    env: {
-      console_log_number: () => {},
-      console_log_string: () => {},
-      console_log_bool: () => {},
-    },
-  };
-  const { instance } = await WebAssembly.instantiate(result.binary, imports);
-  return instance.exports as Record<string, Function>;
-}
+import { compileAndRunStubs as compileAndRun } from "./helpers/compile.js";
 
 describe("void expression", () => {
   it("void 0 produces undefined (null externref)", async () => {


### PR DESCRIPTION
## Summary

Slice 1 of #3109 (test-helper consolidation epic). Behavior-preserving refactor: extract the three highest-duplication **identical-body** `compileAndRun` clusters into one shared module `tests/helpers/compile.ts` and migrate 19 test files to import it under an alias, so every call site stays unchanged. **Zero `src/` changes** — emitted Wasm untouched by construction.

### New shared module — `tests/helpers/compile.ts`

Three distinct helpers (deliberately not merged — the clusters link different host-import sets, and merging would drift runtime behavior):

- `compileAndRunStubs` — 9 files: assert `result.success` (msg + WAT), bare `env.console_log_*` no-op stub imports.
- `compileAndRunImportObject` — 5 files: assert `result.success` (no WAT), instantiate against `result.importObject!`.
- `compileAndRunBuildImports` — 5 files: guard non-empty `result.binary`, full `buildImports(...)` host object, `{ fileName: "test.ts" }`.

Each exported function is byte-for-byte behaviorally identical to the local copy it replaces. Orphaned `compile` / `buildImports` imports were dropped where the local helper was their only user.

### Files migrated (19)

- **Stubs:** codegen, void-expr, compiler, bitwise, generics, numeric-separators, logical-assignment, issue-243, spread-rest
- **ImportObject:** issue-2055, issue-2062, issue-2067, issue-2053, issue-2065
- **BuildImports:** math-minmax, issue-146, math-inline, new-array, string-coercion

### Parity proof

The 19 files were run with `vitest --reporter=json` **before and after** migration. The per-test result set is **identical** — 224 tests, 125 pass / 99 fail (the 99 are pre-existing main-state failures, unchanged by this refactor). Verified at both the original base and after merging `origin/main`. `tsc --noEmit`, `biome lint`, `prettier --check` all green.

### LOC delta

Net **−247** across the 19 test files; **+78** for the shared module. 19 of 132 local `compileAndRun` definitions removed.

### Scope

This is a bounded first slice. The epic (#3109 acceptance: ≥100 of 132 removed) stays `ready` for follow-up slices covering the remaining ~113 divergent-signature copies. See the `## Progress` section in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS