### PR TITLE
refactor(#3090): delete dead UndefinedKeyword-as-expression handler + disjuncts (byte-identical)

### DIFF
--- a/plan/issues/3090-shrink-codegen-delete-dormant-legacy-handlers.md
+++ b/plan/issues/3090-shrink-codegen-delete-dormant-legacy-handlers.md
@@ -8,7 +8,7 @@ status: ready
 # GATED (see the audit doc's G1–G4) — do not start Phase 1 before the gates.
 sprint: current
 created: 2026-07-08
-updated: 2026-07-11
+updated: 2026-07-13
 priority: high
 horizon: xl
 feasibility: medium
@@ -176,6 +176,41 @@ copies live in `expressions/helpers.ts`), `index.ts#registerExternClassImports`,
 Dead-export baseline ratcheted 36 → 16 entries (19 stale entries from
 already-landed deletions also cleared). Byte-inertness proven: 13 playground
 examples × 2 string modes SHA-identical vs base commit.
+
+## Phase 2e — dead `UndefinedKeyword`-as-expression handler + disjuncts (2026-07-13, opus-dead)
+
+A **structurally-dead** (not merely unreferenced) deletion the static
+reachability audit cannot see, found via the byte-identity oracle.
+
+**Root cause / WHY it is dead:** in TypeScript's parsed AST the value
+`undefined` is always an `Identifier` (text `"undefined"`); the
+`UndefinedKeyword` SyntaxKind is emitted **only in type position**
+(`x: undefined`), never as an `ts.Expression`. Verified with an AST probe
+over every value/type occurrence (0 expression-position `UndefinedKeyword`,
+type-position only) and a repo-wide scan confirming nothing synthesizes an
+`UndefinedKeyword` **expression** node and feeds it to the dispatcher. So the
+`compileExpressionInner` dispatch arm `if (expr.kind === UndefinedKeyword)`
+was a dead handler branch, and the three `inner.kind === UndefinedKeyword ||`
+disjuncts in the numeric / ref / any-value null-fast-paths were always-false
+`||` operands (the companion `ts.isIdentifier(inner) && inner.text ===
+"undefined"` clause is the live one and is retained).
+
+Note this is why the audit's static reachability marked these regions "live":
+the enclosing functions ARE reached; only the specific `UndefinedKeyword`
+sub-conditions are unreachable — a case only the emit-byte oracle catches.
+
+**Deleted** (all in `src/codegen/expressions.ts`, my lane): the dead dispatch
+arm in `compileExpressionInner` + the 3 dead disjuncts in
+`compileExpressionBody`. **Net −14 LOC** (3 ins / 17 del); `emitUndefined`
+retains 8 live callers (no orphaned symbol).
+
+**Byte-identity PROOF of dead-ness:** `prove-emit-identity check` over the full
+`website/playground/examples/` corpus × {gc, standalone, wasi} = **39/39
+(file,target) emits IDENTICAL** to the pre-edit golden baseline. Behaviour
+cross-check: the null/undefined equivalence batch (11 files, 83 cases)
+produces the **same 8 pre-existing failures** (`null-dereference-guards`
+#396) with and without the change — **zero delta**. typecheck / prettier /
+`check:dead-exports` / `check:ir-fallbacks` / `check:loc-budget` all green.
 
 ## Guardrails / hazards
 

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -667,10 +667,7 @@ function compileExpressionBody(
             : (inner as ts.TypeAssertion).expression;
     }
     const isNull = inner.kind === ts.SyntaxKind.NullKeyword;
-    const isUndefined =
-      inner.kind === ts.SyntaxKind.UndefinedKeyword ||
-      (ts.isIdentifier(inner) && inner.text === "undefined") ||
-      ts.isOmittedExpression(inner);
+    const isUndefined = (ts.isIdentifier(inner) && inner.text === "undefined") || ts.isOmittedExpression(inner);
     if (isNull || isUndefined) {
       if (expectedType.kind === "f64") {
         if (isNull) {
@@ -733,10 +730,7 @@ function compileExpressionBody(
             : (inner as ts.TypeAssertion).expression;
     }
     const isNull = inner.kind === ts.SyntaxKind.NullKeyword;
-    const isUndefined =
-      inner.kind === ts.SyntaxKind.UndefinedKeyword ||
-      (ts.isIdentifier(inner) && inner.text === "undefined") ||
-      ts.isOmittedExpression(inner);
+    const isUndefined = (ts.isIdentifier(inner) && inner.text === "undefined") || ts.isOmittedExpression(inner);
     if (isNull || isUndefined) {
       const typeIdx = (expectedType as { typeIdx: number }).typeIdx;
       fctx.body.push({ op: "ref.null", typeIdx });
@@ -762,10 +756,7 @@ function compileExpressionBody(
             : (inner as ts.TypeAssertion).expression;
     }
     const isNull = inner.kind === ts.SyntaxKind.NullKeyword;
-    const isUndefined =
-      inner.kind === ts.SyntaxKind.UndefinedKeyword ||
-      (ts.isIdentifier(inner) && inner.text === "undefined") ||
-      ts.isOmittedExpression(inner);
+    const isUndefined = (ts.isIdentifier(inner) && inner.text === "undefined") || ts.isOmittedExpression(inner);
     if (isNull || isUndefined) {
       ensureAnyHelpers(ctx);
       const helperName = isNull ? "__any_box_null" : "__any_box_undefined";
@@ -987,11 +978,6 @@ function compileExpressionInner(
 
   if (expr.kind === ts.SyntaxKind.NullKeyword) {
     fctx.body.push({ op: "ref.null.extern" });
-    return { kind: "externref" };
-  }
-
-  if (expr.kind === ts.SyntaxKind.UndefinedKeyword) {
-    emitUndefined(ctx, fctx);
     return { kind: "externref" };
   }
 


### PR DESCRIPTION
## What

Deletes structurally-dead code in `src/codegen/expressions.ts` (net **-14 LOC**):
- the `compileExpressionInner` dispatch arm `if (expr.kind === UndefinedKeyword)` — a dead handler branch, and
- the three `inner.kind === UndefinedKeyword ||` disjuncts in the numeric / ref / any-value null-fast-paths — always-false `||` operands.

## Why it is dead (root cause)

In TypeScript's parsed AST, the value `undefined` is **always** an `Identifier` (text `"undefined"`); the `UndefinedKeyword` SyntaxKind is emitted **only in type position** (`x: undefined`), never as an `ts.Expression`. Verified with an AST probe (0 expression-position occurrences) and a repo-wide scan confirming nothing synthesizes an `UndefinedKeyword` *expression* node. The live `isIdentifier(inner) && text === "undefined"` companion clause is retained; `emitUndefined` keeps 8 live callers.

This is code the **static reachability audit cannot flag** (the enclosing functions are live; only the `UndefinedKeyword` sub-conditions are unreachable) — found via the emitted-byte oracle.

## Proof (zero behaviour change)

- **Byte-identity:** `prove-emit-identity check` over the full `website/playground/examples/` corpus × {gc, standalone, wasi} = **39/39 (file,target) emits IDENTICAL** to the pre-edit baseline (re-verified after merging `origin/main`).
- **Behaviour cross-check:** the null/undefined equivalence batch (11 files, 83 cases) shows the **same 8 pre-existing failures** (`null-dereference-guards` #396) with and without the change — **zero delta**.
- Green: typecheck · prettier `format:check` · `check:dead-exports` · `check:ir-fallbacks` · `check:loc-budget` (net -14).

Part of the #3090 code-consolidation epic (Phase 2e). Umbrella stays open — the large gated FRONTEND deletions (G1-G4) remain per the Phase 0 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS