### PR TITLE
feat(#3233): self-host Math.atan2 (last non-dialect-gap Math core)

### DIFF
--- a/plan/issues/3233-selfhost-atan2.md
+++ b/plan/issues/3233-selfhost-atan2.md
@@ -1,0 +1,86 @@
+---
+id: 3233
+title: "self-host stdlib: convert Math.atan2 to TS source (last non-dialect-gap Math core)"
+status: done
+assignee: ttraenkler/opus-selfhost2
+sprint: Backlog
+priority: medium
+horizon: s
+feasibility: medium
+task_type: enhancement
+area: codegen, ir, stdlib
+language_feature: math-builtins
+goal: ir-full-coverage
+created: 2026-07-13
+completed: 2026-07-13
+depends_on: [3161, 3204]
+related: [3141, 3226]
+---
+
+# #3233 — self-host Math.atan2 (last non-dialect-gap Math core)
+
+## Problem
+
+The self-hosted-stdlib bloat track (#3141 → #3204) converts hand-emitted
+`Instr[]` Math builtins in `src/codegen/math-helpers.ts` into TS source in
+`src/stdlib/math.ts`, compiled through our own IR driver — deleting hand
+assembly (net −LOC) and dogfooding the compiler.
+
+Per #3226, `Math.atan2` was the **only remaining Math core with no dialect
+gap**: it is pure f64 (a quadrant ladder over `Math_atan`), just 2-arg, so it
+flows through the already-landed #3161 generalized `emitSelfHostedFunc` typed
+path (`paramTypes: [F64, F64]`) — no new intrinsics needed. The other
+still-hand-emitted cores stay: `exp`/`pow`/`log10` need the #3226 intrinsics
+groundwork (i32 bit-ops / reinterpret / sound `f64.nearest`); `random` is a
+host RNG import.
+
+## What shipped
+
+- `src/stdlib/math.ts`: `ATAN2_SOURCE` + `ATAN2_BUILTIN` — the atan2 body as
+  ordinary TS source in the IR-claimable subset. `StdlibMathBuiltin` gained an
+  `arity?: 1 | 2` field (default 1); atan2 sets `arity: 2`.
+- `src/codegen/stdlib-selfhost.ts`: `mathBuiltinDef` honors `arity` →
+  `paramTypes: [F64, F64]` for the binary builtin (callees stay unary f64).
+- `src/codegen/math-helpers.ts`: the ~110-line hand `buildAtan2Body` +
+  registration deleted, replaced by a one-line `emitSelfHostedMathFunc` call
+  at the same emission slot. Net **−51 src LOC**.
+- `tests/issue-3233.test.ts`: every special arm (quadrant signs, sign-of-zero,
+  NaN, ±Inf × ±Inf corners) pinned exactly + general-path accuracy, host and
+  standalone (no host imports).
+
+### Dialect encodings of the hand ops (bit-identical)
+
+- `copysign(mag, y)` with `mag >= 0` → `y < 0 ? -mag : mag` (finite-nonzero-y
+  branches; sign of y is its sign bit) and `1 / y < 0 ? -mag : mag` in the
+  `y === 0` branch (probing the sign of ±0 via `1/±0 = ±Infinity`);
+- `copysign(0, y)` for finite nonzero y → `y * 0` (IEEE multiply carries the
+  sign: `(-5)*0 = -0`, `5*0 = +0`);
+- `x === ±Infinity` → `x > MAX_VALUE` / `x < -MAX_VALUE`; `|y| === Infinity` →
+  `Math.abs(y) > MAX_VALUE` (NaN already returned earlier).
+
+The general path calls the SAME self-hosted `Math_atan`, so the result is
+bit-identical to the deleted hand version (they share that polynomial), not
+merely to JS `Math.atan2`.
+
+## Proof
+
+1. **Bit-exactness**: an 11,664-case sweep (108 × 108 values covering every
+   special arm — ±0, NaN, ±Inf, MAX/MIN_VALUE, subnormals, the atan
+   reduction thresholds — plus 80 random values across 60 orders of magnitude)
+   compared branch-vs-`main`-built control by raw f64 bit pattern: **ZERO
+   mismatches**.
+2. **Containment**: programs NOT using `Math.atan2` (no-math, sin/cos/tan,
+   log/pow/exp/log10/log2, atan/asin/acos, the derived family) produce
+   **byte-identical** binaries branch-vs-main (SHA-compared). Only the
+   atan2-using program's binary changes (expected).
+3. **Both pure-Wasm lanes**: `target: standalone` and `target: wasi` compile
+   with **zero** host imports.
+4. `tests/issue-3233.test.ts` (2), `tests/math-inline.test.ts` +
+   `tests/issue-3141.test.ts` (51) all green; loc-budget gate OK (net −51);
+   IR-fallback gate OK (no bucket growth).
+
+## Result
+
+`math-helpers.ts` now hand-emits only the four true dialect-gap / host cores
+(exp, pow, log10, random). All clean-slice self-host units are exhausted —
+the next −LOC on the Math family requires the #3226 intrinsics groundwork.

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -11,12 +11,15 @@
  * with arithmetic range reduction. Precision target: within 4 ULP of
  * IEEE 754 for the common range.
  *
- * #3141 — the derived family (sinh/cosh/tanh, asinh/acosh/atanh, cbrt,
- * expm1, log1p) is SELF-HOSTED: written as ordinary TS source in
- * `src/stdlib/math.ts` and compiled through the compiler's own IR
- * pipeline (`stdlib-selfhost.ts`) instead of hand-emitted `Instr[]`.
- * Only the precision-sensitive range-reduction cores (sin/cos/exp/log/
- * atan + atan2/pow/log2/log10/tan/random) remain hand-written here.
+ * #3141/#3204/#3233 — most of the family is now SELF-HOSTED: written as
+ * ordinary TS source in `src/stdlib/math.ts` and compiled through the
+ * compiler's own IR pipeline (`stdlib-selfhost.ts`) instead of
+ * hand-emitted `Instr[]` — the derived family (sinh/cosh/tanh,
+ * asinh/acosh/atanh, cbrt, expm1, log1p), the log/trig cores
+ * (log/log2, reduce_trig, sin/cos/tan, atan/asin/acos), and atan2.
+ * Only the four true dialect-gap / host cores remain hand-written here:
+ * exp/pow (i32 exp-by-squaring), log10 (`f64.nearest`), random (RNG
+ * host import) — tracked for conversion in #3226.
  */
 import type { Instr, ValType } from "../ir/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
@@ -34,7 +37,8 @@ import {
   TAN_BUILTIN,
   ASIN_BUILTIN,
   ACOS_BUILTIN,
-} from "../stdlib/math.js"; // (#3141/#3204) TS-source builtin bodies
+  ATAN2_BUILTIN,
+} from "../stdlib/math.js"; // (#3141/#3204/#3233) TS-source builtin bodies
 
 // ─── Instruction shorthand helpers ──────────────────────────────────
 const f64c = (v: number): Instr => ({ op: "f64.const", value: v }) as Instr;
@@ -400,16 +404,10 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
     addedFuncs.set("Math_acos", emitSelfHostedMathFunc(ctx, ACOS_BUILTIN));
   }
 
-  // Math.atan2(y, x)
+  // Math.atan2(y, x) — self-hosted (#3233): binary, pure f64, calls the
+  // self-hosted Math_atan (registered just above via `needAtan`).
   if (needed.has("atan2")) {
-    const atanIdx = getFuncIdx("Math_atan");
-    addMathFunc({
-      name: "Math_atan2",
-      params: [f64Type, f64Type],
-      results: f64Result,
-      locals: [{ name: "atmp", type: f64Type }], // local 2 = atan_result temp
-      body: buildAtan2Body(atanIdx),
-    });
+    addedFuncs.set("Math_atan2", emitSelfHostedMathFunc(ctx, ATAN2_BUILTIN));
   }
 
   // Math.log2(x) = e + log2(f), computed via range reduction (exact for powers of 2)
@@ -489,118 +487,6 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
 }
 
 // ─── Complex body builders ──────────────────────────────────────────
-
-function buildAtan2Body(atanIdx: number): Instr[] {
-  // atan2(y, x): params 0=y, 1=x
-  return [
-    // NaN checks
-    ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-    ...ifThenRet([localGet(1), localGet(1), fne], [f64c(NaN)]),
-
-    // y == 0 cases
-    localGet(0),
-    f64c(0),
-    feq,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        // y == 0, x > 0 → +0 (preserving sign of y)
-        localGet(1),
-        f64c(0),
-        fgt,
-        { op: "if", blockType: { kind: "empty" }, then: [localGet(0), ret] } as Instr,
-        // y == 0, x < 0 → copysign(pi, y)
-        localGet(1),
-        f64c(0),
-        flt,
-        { op: "if", blockType: { kind: "empty" }, then: [f64c(PI), localGet(0), copysign, ret] } as Instr,
-        // y == 0, x == 0 → copysign(0 or pi based on sign of x)
-        // atan2(+0,+0) = +0, atan2(+0,-0) = pi, atan2(-0,+0) = -0, atan2(-0,-0) = -pi
-        // Check sign of x via 1/x: +0 → +Inf, -0 → -Inf
-        f64c(1),
-        localGet(1),
-        div,
-        f64c(0),
-        fgt,
-        ifElse(f64Type, [f64c(0), localGet(0), copysign], [f64c(PI), localGet(0), copysign]),
-        ret,
-      ],
-    } as Instr,
-
-    // x == +Inf
-    localGet(1),
-    f64c(Infinity),
-    feq,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        localGet(0),
-        fabs,
-        f64c(Infinity),
-        feq,
-        ifElse(f64Type, [f64c(PI / 4), localGet(0), copysign], [f64c(0), localGet(0), copysign]),
-        ret,
-      ],
-    } as Instr,
-
-    // x == -Inf
-    localGet(1),
-    f64c(-Infinity),
-    feq,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        localGet(0),
-        fabs,
-        f64c(Infinity),
-        feq,
-        ifElse(f64Type, [f64c((3 * PI) / 4), localGet(0), copysign], [f64c(PI), localGet(0), copysign]),
-        ret,
-      ],
-    } as Instr,
-
-    // y == ±Inf, x finite
-    ...ifThenRet([localGet(0), fabs, f64c(Infinity), feq], [f64c(HALF_PI), localGet(0), copysign]),
-
-    // General case: atan(y/x) with quadrant adjustment
-    localGet(1),
-    f64c(0),
-    fgt,
-    ifElse(
-      f64Type,
-      [localGet(0), localGet(1), div, call(atanIdx)],
-      [
-        localGet(1),
-        f64c(0),
-        flt,
-        ifElse(
-          f64Type,
-          [
-            localGet(0),
-            localGet(1),
-            div,
-            call(atanIdx),
-            localSet(2),
-            // Add or subtract pi based on sign of y
-            localGet(0),
-            f64c(0),
-            fge,
-            ifElse(f64Type, [localGet(2), f64c(PI), add], [localGet(2), f64c(PI), sub]),
-          ],
-          [
-            // x == 0, y != 0 → copysign(pi/2, y)
-            f64c(HALF_PI),
-            localGet(0),
-            copysign,
-          ],
-        ),
-      ],
-    ),
-  ];
-}
 
 function buildPowBody(expIdx: number, logIdx: number): Instr[] {
   // pow(base, exponent): params 0=base, 1=exponent; locals 2=absBase

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -203,10 +203,13 @@ function mathBuiltinDef(builtin: StdlibMathBuiltin): SelfHostedFuncDef {
   for (const callee of builtin.callees) {
     calleeTypes.set(callee, { params: [F64], returnType: F64 });
   }
+  // Arity 1 (default) or 2 (`atan2(y, x)`) — every param is f64 either way,
+  // matching the sources' `: number` annotations. Context-free, so memoize.
+  const paramTypes: IrType[] = builtin.arity === 2 ? [F64, F64] : [F64];
   return {
     name: builtin.name,
     source: builtin.source,
-    paramTypes: [F64],
+    paramTypes,
     returnType: F64,
     calleeTypes,
     memoKey: builtin.name,

--- a/src/stdlib/math.ts
+++ b/src/stdlib/math.ts
@@ -41,6 +41,13 @@ export interface StdlibMathBuiltin {
   readonly callees: readonly string[];
   /** Ordinary TS source, IR-claimable subset (see header). */
   readonly source: string;
+  /**
+   * Number of `(f64) -> f64` positional params (default 1). `2` is used by
+   * `atan2(y, x)` — still pure f64, just binary, so it flows through the
+   * generalized #3161 typed path with `paramTypes: [F64, F64]`. Callees
+   * remain unary `(f64) -> f64`.
+   */
+  readonly arity?: 1 | 2;
 }
 
 /**
@@ -384,6 +391,56 @@ export function Math_acos(x: number): number {
 `;
 
 /**
+ * Math.atan2(y, x) — binary, pure f64 (#3226 pointer: NOT a dialect gap,
+ * just 2-arg, so it flows through the generalized #3161 typed path with
+ * `paramTypes: [F64, F64]`; the sole callee `Math_atan` stays unary f64).
+ * Mirrors the deleted hand `Instr[]` body op-for-op — and, crucially,
+ * calls the SAME self-hosted `Math_atan`, so results are bit-identical to
+ * the hand version (they share that polynomial), not merely to JS Math.atan2.
+ *
+ * Dialect encodings of the hand ops:
+ *   - NaN in either arg → return that NaN;
+ *   - `copysign(mag, y)` with `mag >= 0` is `y < 0 ? -mag : mag` in the
+ *     finite-nonzero-y branches (the sign of y is exactly its sign bit),
+ *     and `1 / y < 0 ? -mag : mag` in the `y === 0` branch (probing the
+ *     sign of ±0 via 1/±0 = ±Infinity);
+ *   - `copysign(0, y)` for finite nonzero y is `y * 0` (IEEE multiply
+ *     carries y's sign into the zero: (-5)*0 = -0, 5*0 = +0);
+ *   - `x === ±Infinity` is `x > MAX_VALUE` / `x < -MAX_VALUE` (only ±Inf
+ *     exceeds the finite max), `|y| === Infinity` is
+ *     `Math.abs(y) > MAX_VALUE` (NaN already returned).
+ * Constants are the exact f64s the hand body used: π = 3.141592653589793,
+ * 3π/4 = 2.356194490192345, π/4 = 0.7853981633974483, π/2 = 1.5707963267948966.
+ */
+const ATAN2_SOURCE = `
+export function Math_atan2(y: number, x: number): number {
+  if (y !== y) return y;
+  if (x !== x) return x;
+  if (y === 0) {
+    if (x > 0) return y;
+    if (x < 0) return 1 / y < 0 ? -3.141592653589793 : 3.141592653589793;
+    if (1 / x > 0) return y;
+    return 1 / y < 0 ? -3.141592653589793 : 3.141592653589793;
+  }
+  if (x > 1.7976931348623157e308) {
+    if (Math.abs(y) > 1.7976931348623157e308) return y < 0 ? -0.7853981633974483 : 0.7853981633974483;
+    return y * 0;
+  }
+  if (x < -1.7976931348623157e308) {
+    if (Math.abs(y) > 1.7976931348623157e308) return y < 0 ? -2.356194490192345 : 2.356194490192345;
+    return y < 0 ? -3.141592653589793 : 3.141592653589793;
+  }
+  if (Math.abs(y) > 1.7976931348623157e308) return y < 0 ? -1.5707963267948966 : 1.5707963267948966;
+  if (x > 0) return Math_atan(y / x);
+  if (x < 0) {
+    let a: number = Math_atan(y / x);
+    return y >= 0 ? a + 3.141592653589793 : a - 3.141592653589793;
+  }
+  return y < 0 ? -1.5707963267948966 : 1.5707963267948966;
+}
+`;
+
+/**
  * Early-core self-hosted builtins (#3204) — registered INLINE by
  * `emitInlineMathFunctions` at the exact emission point their hand-`Instr[]`
  * predecessors occupied (BEFORE the later hand cores that call them by
@@ -410,15 +467,21 @@ export const TAN_BUILTIN: StdlibMathBuiltin = {
 };
 export const ASIN_BUILTIN: StdlibMathBuiltin = { name: "Math_asin", callees: ["Math_atan"], source: ASIN_SOURCE };
 export const ACOS_BUILTIN: StdlibMathBuiltin = { name: "Math_acos", callees: ["Math_atan"], source: ACOS_SOURCE };
+export const ATAN2_BUILTIN: StdlibMathBuiltin = {
+  name: "Math_atan2",
+  callees: ["Math_atan"],
+  source: ATAN2_SOURCE,
+  arity: 2,
+};
 
 /**
  * The self-hosted subset of the Math family, keyed by `Math.<method>`
- * name. Remaining hand-emitted cores (exp, atan2, pow, log10, random) are
- * the ones with real dialect gaps (exp: i32 2^n squaring; pow: i32
- * exp-by-squaring; log10: `f64.nearest`; random: RNG import; atan2: 2-arg
- * quadrant ladder) — converting them needs the intrinsics groundwork
- * (#3204 follow-up). `log`/`log2` and the trig cores (reduce_trig,
- * sin/cos/tan, atan/asin/acos) moved to EARLY cores above.
+ * name. Remaining hand-emitted cores (exp, pow, log10, random) are the
+ * ones with real dialect gaps (exp: i32 2^n squaring; pow: i32
+ * exp-by-squaring; log10: `f64.nearest`; random: RNG import) — converting
+ * them needs the intrinsics groundwork (#3226). `log`/`log2`, the trig
+ * cores (reduce_trig, sin/cos/tan, atan/asin/acos) and `atan2` (binary,
+ * pure f64 — #3233) moved to EARLY cores above.
  */
 export const SELF_HOSTED_MATH: ReadonlyMap<string, StdlibMathBuiltin> = new Map([
   ["cbrt", { name: "Math_cbrt", callees: [], source: CBRT_SOURCE }],

--- a/tests/issue-3233.test.ts
+++ b/tests/issue-3233.test.ts
@@ -1,0 +1,128 @@
+// #3233 — self-host Math.atan2: the last non-dialect-gap Math core moves from
+// hand-emitted Instr[] to TS source in src/stdlib/math.ts, compiled through the
+// compiler's own IR pipeline (the #3161 generalized 2-arg path). These tests
+// pin the spec-critical special arms (quadrant signs, sign-of-zero, NaN, the
+// ±Infinity × ±Infinity corners) exactly, plus accuracy on the general path,
+// in both host and standalone (no-host-import) modes. The self-hosted body
+// calls the SAME self-hosted Math_atan, so it is bit-identical to the deleted
+// hand version — verified separately by a 11,664-case bit-exact sweep vs a
+// main-built control.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildStringConstants } from "../src/runtime.js";
+
+const SRC = `
+export function atan2(y: number, x: number): number { return Math.atan2(y, x); }
+`;
+
+type Atan2 = { atan2: (y: number, x: number) => number };
+
+async function compileHost(): Promise<Atan2> {
+  const r = await compile(SRC, { fileName: "issue-3233.ts" });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message}`);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: {},
+    "wasm:js-string": {
+      concat: (a: string, b: string) => a + b,
+      length: (s: string) => s.length,
+      equals: (a: string, b: string) => (a === b ? 1 : 0),
+      substring: (s: string, start: number, end: number) => s.substring(start, end),
+      charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+    },
+    string_constants: buildStringConstants(r.stringPool),
+  } as WebAssembly.Imports);
+  return instance.exports as unknown as Atan2;
+}
+
+async function compileStandalone(): Promise<Atan2> {
+  const r = await compile(SRC, { fileName: "issue-3233-standalone.ts", target: "standalone" });
+  if (!r.success) throw new Error(`standalone compile failed: ${r.errors[0]?.message}`);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as Atan2;
+}
+
+// Every special-case arm the spec (§21.3.2.9) pins EXACTLY — these match native
+// Math.atan2 bit-for-bit (the polynomial only enters the finite general path).
+function checkSpecials(ex: Atan2) {
+  const a = ex.atan2;
+  // NaN in either argument → NaN
+  expect(Number.isNaN(a(NaN, 1))).toBe(true);
+  expect(Number.isNaN(a(1, NaN))).toBe(true);
+  expect(Number.isNaN(a(NaN, NaN))).toBe(true);
+
+  // y === ±0 with x > 0 → ±0 (sign of y preserved)
+  expect(Object.is(a(0, 1), 0)).toBe(true);
+  expect(Object.is(a(-0, 1), -0)).toBe(true);
+  // y === ±0 with x < 0 → ±π
+  expect(a(0, -1)).toBe(Math.PI);
+  expect(a(-0, -1)).toBe(-Math.PI);
+  // y === ±0 with x === +0 → ±0
+  expect(Object.is(a(0, 0), 0)).toBe(true);
+  expect(Object.is(a(-0, 0), -0)).toBe(true);
+  // y === ±0 with x === -0 → ±π
+  expect(a(0, -0)).toBe(Math.PI);
+  expect(a(-0, -0)).toBe(-Math.PI);
+
+  // x === +Infinity, y finite → ±0
+  expect(Object.is(a(3, Infinity), 0)).toBe(true);
+  expect(Object.is(a(-3, Infinity), -0)).toBe(true);
+  // x === -Infinity, y finite → ±π
+  expect(a(3, -Infinity)).toBe(Math.PI);
+  expect(a(-3, -Infinity)).toBe(-Math.PI);
+  // x === +Infinity, y === ±Infinity → ±π/4
+  expect(a(Infinity, Infinity)).toBe(Math.PI / 4);
+  expect(a(-Infinity, Infinity)).toBe(-Math.PI / 4);
+  // x === -Infinity, y === ±Infinity → ±3π/4
+  expect(a(Infinity, -Infinity)).toBe((3 * Math.PI) / 4);
+  expect(a(-Infinity, -Infinity)).toBe(-(3 * Math.PI) / 4);
+  // y === ±Infinity, x finite → ±π/2
+  expect(a(Infinity, 5)).toBe(Math.PI / 2);
+  expect(a(-Infinity, 5)).toBe(-Math.PI / 2);
+  expect(a(Infinity, -5)).toBe(Math.PI / 2);
+  expect(a(-Infinity, -5)).toBe(-Math.PI / 2);
+
+  // x === 0, y finite nonzero → ±π/2
+  expect(a(5, 0)).toBe(Math.PI / 2);
+  expect(a(-5, 0)).toBe(-Math.PI / 2);
+  expect(a(5, -0)).toBe(Math.PI / 2);
+  expect(a(-5, -0)).toBe(-Math.PI / 2);
+}
+
+// General finite path routes through the polynomial Math_atan, so results sit a
+// few ULP from correctly-rounded libm — assert a bound loose enough for that
+// inherited error but tight enough to catch a lowering break.
+function checkAccuracy(ex: Atan2) {
+  const rel = (g: number, w: number) => Math.abs(g - w) / Math.max(Math.abs(w), Number.MIN_VALUE);
+  const cases: [number, number][] = [
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1],
+    [3, 4],
+    [-3, 4],
+    [3, -4],
+    [-3, -4],
+    [0.5, 2],
+    [100, 0.001],
+    [1e-8, 5],
+  ];
+  for (const [y, x] of cases) {
+    const got = ex.atan2(y, x);
+    const want = Math.atan2(y, x);
+    expect(rel(got, want), `atan2(${y}, ${x}) = ${got}, native ${want}`).toBeLessThan(1e-6);
+  }
+}
+
+describe("#3233 self-hosted Math.atan2 (IR-compiled TS source)", () => {
+  it("host mode: special arms exact, general path accurate", async () => {
+    const ex = await compileHost();
+    checkSpecials(ex);
+    checkAccuracy(ex);
+  });
+
+  it("standalone mode: special arms exact, general path accurate (no host imports)", async () => {
+    const ex = await compileStandalone();
+    checkSpecials(ex);
+    checkAccuracy(ex);
+  });
+});


### PR DESCRIPTION
## What

Converts the hand-emitted `Instr[]` `Math.atan2` body to ordinary TS source in `src/stdlib/math.ts`, compiled through the compiler's own IR pipeline via the #3161 generalized 2-arg path (`paramTypes: [F64, F64]`). This is the self-hosted-stdlib bloat track (#3141 → #3204 → #3233) — deleting hand assembly, dogfooding the compiler.

`atan2` was the **only remaining Math core with no dialect gap** (#3226 pointer): pure f64, just 2-arg. The four remaining hand-emitted cores all have real gaps — `exp`/`pow` (i32 exp-by-squaring), `log10` (`f64.nearest`), `random` (host RNG import) — tracked in #3226.

## Changes

- `src/stdlib/math.ts`: `ATAN2_SOURCE` + `ATAN2_BUILTIN`; `StdlibMathBuiltin` gains `arity?: 1 | 2`.
- `src/codegen/stdlib-selfhost.ts`: `mathBuiltinDef` honors `arity` → `[F64, F64]`.
- `src/codegen/math-helpers.ts`: ~110-line `buildAtan2Body` + registration deleted, replaced by a one-line `emitSelfHostedMathFunc` at the same emission slot.
- `tests/issue-3233.test.ts`: all special arms exact + general-path accuracy, host + standalone.

**Net −51 src LOC** (deletion-dominated).

### Dialect encodings (bit-identical to the hand ops)

- `copysign(mag, y)`, `mag >= 0` → `y < 0 ? -mag : mag` (finite y), `1 / y < 0 ? -mag : mag` (`y === 0`, probing ±0 via `1/±0 = ±Inf`).
- `copysign(0, y)` for finite nonzero y → `y * 0` (IEEE carries the sign).
- `x === ±Infinity` → `x > MAX_VALUE` / `x < -MAX_VALUE`; `|y| === Infinity` → `Math.abs(y) > MAX_VALUE`.

The general path calls the SAME self-hosted `Math_atan`, so it is bit-identical to the deleted hand version, not merely to JS `Math.atan2`.

## Proof

1. **Bit-exact**: 11,664-case sweep (108×108 values covering every special arm — ±0, NaN, ±Inf, MAX/MIN_VALUE, subnormals, atan thresholds — + 80 random over 60 orders of magnitude) vs a `main`-built control, compared by raw f64 bit pattern: **0 mismatches**.
2. **Containment**: non-atan2 programs (no-math, sin/cos/tan, log/pow/exp/log10/log2, atan/asin/acos, derived family) produce **byte-identical** binaries vs main (SHA). Only the atan2-using binary changes.
3. **Both pure-Wasm lanes**: `standalone` + `wasi` compile with **zero** host imports.
4. `tests/issue-3233.test.ts` (2) + `math-inline` + `issue-3141` (51) green; loc-budget + ir-fallback gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8