### PR TITLE
fix(#3235): standalone — stop declaring spurious env::__make_callback import

### DIFF
--- a/plan/issues/3235-standalone-spurious-make-callback-import-leak.md
+++ b/plan/issues/3235-standalone-spurious-make-callback-import-leak.md
@@ -13,6 +13,9 @@ language_feature: closures, callbacks, iterator-helpers, standalone
 goal: host-independence
 assignee: ttraenkler/opus-leak
 related: [2940, 3098, 3016, 2903]
+loc-budget-allow:
+  - src/codegen/closures.ts
+  - src/codegen/declarations.ts
 origin: "2026-07-13 standalone sole-import leak ranking (opus-leak). test262-standalone-current.jsonl @ 13.7.2026 11:39; 25 sole-`__make_callback` leaky-pass entries + ~2.3k multi-import de-leaks."
 ---
 

--- a/plan/issues/3235-standalone-spurious-make-callback-import-leak.md
+++ b/plan/issues/3235-standalone-spurious-make-callback-import-leak.md
@@ -1,0 +1,83 @@
+---
+id: 3235
+title: "standalone: spurious `env::__make_callback` import leak — coarse callbackFound scan declares an unsatisfiable host import that is never called"
+status: done
+completed: 2026-07-13
+sprint: current
+priority: high
+feasibility: medium
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: closures, callbacks, iterator-helpers, standalone
+goal: host-independence
+assignee: ttraenkler/opus-leak
+related: [2940, 3098, 3016, 2903]
+origin: "2026-07-13 standalone sole-import leak ranking (opus-leak). test262-standalone-current.jsonl @ 13.7.2026 11:39; 25 sole-`__make_callback` leaky-pass entries + ~2.3k multi-import de-leaks."
+---
+
+# #3235 — standalone spurious `env::__make_callback` import leak
+
+## Problem
+
+In standalone (no-JS-host) / WASI mode the compiled module **declares**
+`env::__make_callback` as a host import but **never calls it**, which fails the
+host-free-pass metric even though the code runs host-free. Ranked #1 bounded
+sole-import leak in the 2026-07-13 standalone baseline:
+
+- **25** leaky-*pass* entries have `__make_callback` as their **sole** import
+  (Iterator-helper `next-method-returns-throwing-value-done` tails for
+  find/every/reduce/map/filter/forEach, `Function.prototype.toString` proxy
+  cases, `String.prototype.at` ToInteger, etc.). Every one flips to host-free.
+- `__make_callback` also appears in **~2,356** total leaky-pass entries; this
+  removes it from the ~2,331 multi-import ones too, de-leaking them (each moves
+  one import closer to a future host-free flip).
+
+### Root cause
+
+`src/codegen/declarations.ts` `collectCallbackImports` sets
+`state.callbackFound = true` for **any** `ArrowFunction` / `FunctionExpression`
+anywhere in the module — an extremely coarse trigger. The finalize step then
+registers `env::__make_callback` **unconditionally** (no standalone gate),
+unlike the JSON imports right above it (`jsonHostUnavailable`) and the
+async-CPS detector right below it (`!ctx.standalone && !ctx.wasi`).
+
+The **call site** (`compileArrowAsCallback`, gated by `isHostCallbackArgument`)
+already correctly routes standalone callbacks to the native closure path — the
+`#3098` dispatch substrate (`__apply_closure` / `__hof_*` / `__iter_hof_*`)
+services every *exercised* callback host-free. So the eager registration only
+ever declares a **never-called** import.
+
+Verified by compiling `iterator.find(() => {})` standalone: the `.wat` contains
+the `(import "env" "__make_callback" …)` declaration at exactly one line and
+**zero** `call $__make_callback` sites.
+
+Why this is safe for pass-count: a genuinely-*called* `__make_callback` in
+standalone is an unsatisfiable import → the module can't instantiate → it can't
+be `pass`. So every standalone leaky-*pass* with `__make_callback` has it
+declared-but-uncalled. (#2940 previously warned that naively dropping the import
+yields "dishonest vacuous passes"; #3098 has since landed the real native
+callback-dispatch substrate, so exercised callbacks now dispatch natively and
+the residual is purely the spurious declaration.)
+
+## Fix
+
+Two-file, standalone/WASI-gated, JS-host lane byte-identical:
+
+1. **`src/codegen/declarations.ts`** — gate the `__make_callback` registration
+   on `!(ctx.standalone || ctx.wasi)` (mirrors the async-CPS detector). The
+   JS-host lane is unchanged.
+2. **`src/codegen/closures.ts`** (`compileArrowAsCallback`) — belt-and-
+   suspenders: when `__make_callback` is unavailable AND standalone/WASI, degrade
+   to `compileArrowAsClosure` (native first-class closure struct) instead of
+   `reportError`. Guarantees no dangling `call __make_callback` if any residual
+   host-bridge site is reached; the callback becomes a valid host-free function
+   object dispatched via `__call_fn_N` / `__apply_closure` where exercised.
+
+## Acceptance
+
+- `iterator.find(() => {})` compiles standalone with **no** `__make_callback`
+  import (host-free).
+- The 25 sole-`__make_callback` standalone leaky-pass entries flip host-free.
+- No standalone regression: genuinely-exercised callbacks still dispatch via the
+  native substrate; JS-host lane byte-identical.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -3717,18 +3717,11 @@ export function compileArrowAsCallback(
   const makeCallbackName = needsThis ? "__make_getter_callback" : "__make_callback";
   const makeCallbackIdx = ctx.funcMap.get(makeCallbackName);
   if (makeCallbackIdx === undefined) {
-    // (#3235) In standalone / WASI mode the `__make_callback` host bridge is
-    // intentionally not registered (declarations.ts collectCallbackImports
-    // finalize) — there is no JS host to wrap the callback for. Rather than
-    // hard-error, degrade a callback that reaches this host-bridge path to the
-    // native first-class closure-struct value. The #3098 dispatch substrate
-    // (`__apply_closure` / `__call_fn_N`) invokes that struct host-free wherever
-    // the callback is actually exercised, so the common case (never-invoked /
-    // natively-dispatched callbacks) stays correct and host-free. Note: we've
-    // already appended the exported `__cb_<id>` adapter function above; leaving
-    // it unreferenced is harmless (an unused export), and the closure path emits
-    // its own self-contained function object. The JS-host lane is unaffected
-    // (makeCallbackIdx is always defined there).
+    // (#3235) Standalone/WASI intentionally doesn't register the `__make_callback`
+    // host bridge (declarations.ts). Rather than hard-error, degrade a callback
+    // that reaches this host-bridge path to the native first-class closure struct;
+    // the #3098 substrate (`__apply_closure`/`__call_fn_N`) invokes it host-free
+    // wherever it's exercised. JS-host lane unaffected (idx always defined there).
     if (ctx.standalone || ctx.wasi) {
       return compileArrowAsClosure(ctx, fctx, arrow);
     }

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -3717,6 +3717,21 @@ export function compileArrowAsCallback(
   const makeCallbackName = needsThis ? "__make_getter_callback" : "__make_callback";
   const makeCallbackIdx = ctx.funcMap.get(makeCallbackName);
   if (makeCallbackIdx === undefined) {
+    // (#3235) In standalone / WASI mode the `__make_callback` host bridge is
+    // intentionally not registered (declarations.ts collectCallbackImports
+    // finalize) — there is no JS host to wrap the callback for. Rather than
+    // hard-error, degrade a callback that reaches this host-bridge path to the
+    // native first-class closure-struct value. The #3098 dispatch substrate
+    // (`__apply_closure` / `__call_fn_N`) invokes that struct host-free wherever
+    // the callback is actually exercised, so the common case (never-invoked /
+    // natively-dispatched callbacks) stays correct and host-free. Note: we've
+    // already appended the exported `__cb_<id>` adapter function above; leaving
+    // it unreferenced is harmless (an unused export), and the closure path emits
+    // its own self-contained function object. The JS-host lane is unaffected
+    // (makeCallbackIdx is always defined there).
+    if (ctx.standalone || ctx.wasi) {
+      return compileArrowAsClosure(ctx, fctx, arrow);
+    }
     reportError(ctx, arrow, `Missing ${makeCallbackName} import`);
     return null;
   }

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1734,7 +1734,30 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // ── collectCallbackImports finalize ──
   if (state.callbackFound || state.getterCallbackFound || state.asyncCpsFound) {
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }, { kind: "externref" }], [{ kind: "externref" }]);
-    if ((state.callbackFound || state.asyncCpsFound) && !ctx.funcMap.has("__make_callback")) {
+    // (#3235) The plain-`callbackFound` scan (collectCallbackImports above) fires
+    // for ANY arrow / function-expression anywhere in the module — a very coarse
+    // trigger. In JS-host mode that pre-registers `__make_callback` with a stable
+    // funcIdx so genuine host-callback call sites (`compileArrowAsCallback`) can
+    // bake in its index without the late-import shift hazard (#1384). But in
+    // STANDALONE / WASI mode there is NO JS host: a `call __make_callback` can never
+    // succeed, so no currently-passing standalone module actually *calls* it — the
+    // native callback-dispatch substrate (#3098: `__apply_closure` / `__hof_*` /
+    // `__iter_hof_*`) services every exercised callback host-free. The eager
+    // registration therefore only ever *declares* an unsatisfiable import that is
+    // never called (verified: `iterator.find(() => {})` emits the import decl with
+    // ZERO call sites), which needlessly fails the host-free-pass metric on ~25
+    // sole-leak entries (Iterator-helper tails etc.) and de-leaks ~2.3k multi-import
+    // ones. Gate it off in standalone/WASI, mirroring the async-CPS detector below
+    // which is already `!ctx.standalone`-gated. Any genuine host-callback site that
+    // still reaches `compileArrowAsCallback` degrades to the native closure-struct
+    // path (see the standalone fallback there) — never a dangling call. The JS-host
+    // lane is byte-identical (this branch is unchanged when not standalone/WASI).
+    const makeCallbackHostUnavailable = ctx.standalone || ctx.wasi;
+    if (
+      !makeCallbackHostUnavailable &&
+      (state.callbackFound || state.asyncCpsFound) &&
+      !ctx.funcMap.has("__make_callback")
+    ) {
       addImport(ctx, "env", "__make_callback", { kind: "func", typeIdx });
     }
     if (state.getterCallbackFound) {

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1734,27 +1734,18 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   // ── collectCallbackImports finalize ──
   if (state.callbackFound || state.getterCallbackFound || state.asyncCpsFound) {
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }, { kind: "externref" }], [{ kind: "externref" }]);
-    // (#3235) The plain-`callbackFound` scan (collectCallbackImports above) fires
-    // for ANY arrow / function-expression anywhere in the module — a very coarse
-    // trigger. In JS-host mode that pre-registers `__make_callback` with a stable
-    // funcIdx so genuine host-callback call sites (`compileArrowAsCallback`) can
-    // bake in its index without the late-import shift hazard (#1384). But in
-    // STANDALONE / WASI mode there is NO JS host: a `call __make_callback` can never
-    // succeed, so no currently-passing standalone module actually *calls* it — the
-    // native callback-dispatch substrate (#3098: `__apply_closure` / `__hof_*` /
-    // `__iter_hof_*`) services every exercised callback host-free. The eager
-    // registration therefore only ever *declares* an unsatisfiable import that is
-    // never called (verified: `iterator.find(() => {})` emits the import decl with
-    // ZERO call sites), which needlessly fails the host-free-pass metric on ~25
-    // sole-leak entries (Iterator-helper tails etc.) and de-leaks ~2.3k multi-import
-    // ones. Gate it off in standalone/WASI, mirroring the async-CPS detector below
-    // which is already `!ctx.standalone`-gated. Any genuine host-callback site that
-    // still reaches `compileArrowAsCallback` degrades to the native closure-struct
-    // path (see the standalone fallback there) — never a dangling call. The JS-host
-    // lane is byte-identical (this branch is unchanged when not standalone/WASI).
-    const makeCallbackHostUnavailable = ctx.standalone || ctx.wasi;
+    // (#3235) `callbackFound` fires for ANY arrow/function-expr — coarse. In
+    // JS-host mode the upfront registration gives `__make_callback` a stable
+    // funcIdx (#1384). But standalone/WASI has NO host: a `call __make_callback`
+    // can never succeed, so no passing standalone module actually calls it (#3098's
+    // native `__apply_closure`/`__hof_*`/`__iter_hof_*` serve exercised callbacks
+    // host-free) — the eager registration only ever *declares* an unsatisfiable
+    // never-called import that fails the host-free metric. Gate it off (mirrors the
+    // async-CPS `!ctx.standalone` gate below); any residual host-callback site
+    // degrades to the native closure struct (see compileArrowAsCallback). JS-host
+    // lane byte-identical.
     if (
-      !makeCallbackHostUnavailable &&
+      !(ctx.standalone || ctx.wasi) &&
       (state.callbackFound || state.asyncCpsFound) &&
       !ctx.funcMap.has("__make_callback")
     ) {

--- a/tests/issue-3235.test.ts
+++ b/tests/issue-3235.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3235 — standalone spurious `env::__make_callback` import leak.
+//
+// Root cause: `collectCallbackImports` (declarations.ts) sets
+// `state.callbackFound = true` for ANY arrow / function-expression anywhere in
+// the module, then the finalize step registered `env::__make_callback`
+// UNCONDITIONALLY — with no standalone gate (unlike the JSON imports above it or
+// the async-CPS detector below it). In standalone / WASI mode there is no JS
+// host, so the import can never be satisfied; but the native callback-dispatch
+// substrate (#3098 `__apply_closure` / `__hof_*` / `__iter_hof_*`) already
+// services every EXERCISED callback host-free, so the eager registration only
+// ever DECLARED a never-called import that failed the host-free-pass metric.
+//
+// Fix (standalone/WASI-gated, JS-host lane byte-identical):
+//  1. declarations.ts — gate the `__make_callback` registration on
+//     `!(ctx.standalone || ctx.wasi)`.
+//  2. closures.ts `compileArrowAsCallback` — if the bridge is unavailable in
+//     standalone/WASI, degrade to the native first-class closure struct
+//     (`compileArrowAsClosure`) instead of hard-erroring, so no dangling call.
+//
+// Each assertion instantiates with an EMPTY import object and first asserts the
+// module declares ZERO imports — the behaviour is truly HOST-FREE.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile host-free (`target: standalone`), assert 0 imports, run test(). */
+async function runStandaloneHostFree(source: string): Promise<unknown> {
+  const result: any = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  if (!result.success) {
+    throw new Error("compile: " + result.errors.map((e: any) => e.message).join("; "));
+  }
+  const mod = await WebAssembly.compile(result.binary);
+  const imports = WebAssembly.Module.imports(mod);
+  // The point of the fix: no `__make_callback` (or any host import) may sneak in.
+  expect(imports.map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  const instance: any = await WebAssembly.instantiate(mod, {});
+  return instance.exports.test();
+}
+
+/** Compile host-free and return the declared import names (no run). */
+async function standaloneImports(source: string): Promise<string[]> {
+  const result: any = await compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+  if (!result.success) {
+    throw new Error("compile: " + result.errors.map((e: any) => e.message).join("; "));
+  }
+  const mod = await WebAssembly.compile(result.binary);
+  return WebAssembly.Module.imports(mod).map((i) => `${i.module}.${i.name}`);
+}
+
+const t = (body: string) => `export function test(): number { ${body} }`;
+
+describe("#3235 — standalone spurious __make_callback import leak", () => {
+  it("a never-invoked callback argument does NOT declare __make_callback", async () => {
+    // The predicate is never called (the value is unused), yet the coarse
+    // callbackFound scan used to register the host import defensively.
+    const imports = await standaloneImports(t(`const a: any = [1, 2, 3]; const c = (x: any) => x; return a.length;`));
+    expect(imports).not.toContain("env.__make_callback");
+    expect(imports).toEqual([]);
+  });
+
+  it("a plain arrow bound to a variable leaks no host import", async () => {
+    expect(await runStandaloneHostFree(t(`const f = (x: number) => x + 1; return f(41);`))).toBe(42);
+  });
+
+  it("a function-expression bound to a variable leaks no host import", async () => {
+    expect(await runStandaloneHostFree(t(`const f = function (x: number) { return x * 2; }; return f(21);`))).toBe(42);
+  });
+
+  it("exercised iterator-helper callbacks stay correct AND host-free (not vacuous)", async () => {
+    // find/reduce predicates are genuinely invoked — they must dispatch natively
+    // (via #3098 substrate), proving the flip is honest, not a vacuous pass.
+    expect(
+      await runStandaloneHostFree(
+        t(`
+          function* gen() { yield 1; yield 2; yield 3; }
+          const r = gen().find((x: number) => x === 2);
+          const s = gen().reduce((a: number, b: number) => a + b, 0);
+          return (r === 2 && s === 6) ? 1 : 0;
+        `),
+      ),
+    ).toBe(1);
+  });
+
+  it("array map with a real callback stays correct AND host-free", async () => {
+    expect(
+      await runStandaloneHostFree(
+        t(`const a = [10, 20, 30]; const m = a.map((x) => x * 2); return m[0] + m[1] + m[2];`),
+      ),
+    ).toBe(120);
+  });
+});


### PR DESCRIPTION
## Problem

In standalone (no-JS-host) / WASI mode the compiled module **declares**
`env::__make_callback` as a host import but **never calls it**, failing the
host-free-pass metric even though the code runs host-free. Ranked #1 bounded
sole-import leak in the 2026-07-13 standalone baseline:

- **25** leaky-*pass* entries have `__make_callback` as their **sole** import
  (Iterator-helper `next-method-returns-throwing-value-done` tails for
  find/every/reduce/map/filter/forEach, `Function.prototype.toString` proxy,
  `String.prototype.at` ToInteger, etc.) — every one flips host-free.
- `__make_callback` also appears in **~2,356** total leaky-pass entries; this
  de-leaks the ~2,331 multi-import ones too (each one import closer to a future
  host-free flip).

### Root cause

`collectCallbackImports` (declarations.ts) sets `state.callbackFound = true` for
**any** `ArrowFunction` / `FunctionExpression` anywhere in the module, then the
finalize step registered `env::__make_callback` **unconditionally** — with no
standalone gate (unlike the JSON imports right above it, or the async-CPS
detector right below it which is already `!ctx.standalone`-gated). The **call
site** (`compileArrowAsCallback`, gated by `isHostCallbackArgument`) already
routes standalone callbacks to the native closure path; the #3098 dispatch
substrate (`__apply_closure` / `__hof_*` / `__iter_hof_*`) services every
*exercised* callback host-free. So the eager registration only ever declared a
**never-called** import.

Verified by compiling `iterator.find(() => {})` standalone: the `.wat` contains
exactly one `(import "env" "__make_callback" …)` line and **zero**
`call $__make_callback` sites. A genuinely-*called* `__make_callback` in
standalone is an unsatisfiable import → the module can't instantiate → can't be
`pass`, so every standalone leaky-*pass* with `__make_callback` has it
declared-but-uncalled. (#2940 warned that naively dropping it yields "vacuous
passes"; #3098 has since landed the real native dispatch substrate, so exercised
callbacks now dispatch natively and the residual is purely the spurious decl.)

## Fix (2 files, standalone/WASI-gated, JS-host lane byte-identical)

1. **`src/codegen/declarations.ts`** — gate the `__make_callback` registration
   on `!(ctx.standalone || ctx.wasi)` (mirrors the async-CPS detector).
2. **`src/codegen/closures.ts`** (`compileArrowAsCallback`) — belt-and-
   suspenders: when the bridge is unavailable AND standalone/WASI, degrade to
   `compileArrowAsClosure` (native first-class closure struct) instead of
   `reportError`. Guarantees no dangling `call __make_callback`; the callback
   becomes a valid host-free function object dispatched via `__call_fn_N` /
   `__apply_closure` where exercised.

## Verification

- `iterator.find(() => {})` compiles standalone with **0** `__make_callback`
  imports (was 1) and runs host-free under wasmtime.
- Honesty check (not vacuous): generator `find`/`reduce` predicates and array
  `map` callbacks that are genuinely invoked stay correct + host-free (zero
  `env` imports) — dispatched via the #3098 native substrate.
- JS-host (`gc`) lane byte-identical: the same test compiled without
  `--standalone` still emits `__make_callback` (count 1).
- `tests/issue-3235.test.ts` (5 tests) + `issue-3098` + `issue-3016` +
  `issue-2903-iter-helpers` all pass (37 tests).
- The 2 pre-existing `issue-1712`/`issue-1528` failures reproduce on a clean
  `origin/main` build (gc-mode, where this change is a provable no-op) — not
  caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8