### PR TITLE
feat(#3226): self-host Math.exp/pow/log10 in pure-f64 dialect (no new intrinsics)

### DIFF
--- a/plan/issues/3226-selfhost-math-dialect-intrinsics-groundwork.md
+++ b/plan/issues/3226-selfhost-math-dialect-intrinsics-groundwork.md
@@ -1,0 +1,105 @@
+---
+id: 3226
+title: "self-host stdlib: convert exp/pow/log10 to TS source (dialect-intrinsics groundwork NOT needed after all)"
+status: done
+assignee: ttraenkler/opus-selfhost2
+sprint: Backlog
+priority: medium
+horizon: l
+feasibility: medium
+task_type: enhancement
+area: codegen, ir, stdlib
+language_feature: math-builtins
+goal: ir-full-coverage
+created: 2026-07-13
+completed: 2026-07-13
+depends_on: [3161, 3204]
+related: [3141, 3159, 3160, 3233]
+---
+
+# #3226 — self-host exp / pow / log10 (dialect-intrinsics groundwork NOT needed)
+
+## Outcome (2026-07-13): reframed — no new intrinsics required
+
+The self-hosted-stdlib bloat track (#3141 → #3204) converts hand-emitted
+`Instr[]` Math builtins into TS source in `src/stdlib/math.ts`, compiled through
+our own IR driver. `exp`, `pow`, `log10` were the last cores presumed to need
+**new dialect intrinsics** (i32 bit-ops + shift, f64↔i64 `reinterpret`, a sound
+`f64.nearest`). **Verify-first tracing of the hand `Instr[]` bodies proved that
+premise wrong** — all three are expressible in the EXISTING pure-f64 dialect,
+converted exactly like `atan2` (#3233), with zero `select.ts` / `from-ast`
+changes:
+
+- **exp** — computes `2^n` by repeated SQUARING of the non-negative integer loop
+  counter `ni` (the hand `ni & 1` / `ni >>> 1`). This is NOT IEEE
+  exponent-field extraction / `reinterpret`; it is parity + halve of a small
+  non-negative integer, exactly `ni - Math.floor(ni/2)*2` and `Math.floor(ni/2)`
+  in f64 (bit-identical for a non-negative integer counter).
+- **pow** — the same f64 exp-by-squaring for the integer-exponent fast path; the
+  `i32.and` boolean combines become `&&`; the general path is
+  `Math_exp(e·Math_log(|b|))`, calling the SAME self-hosted cores.
+- **log10** — used `f64.nearest` only for a round-to-nearest-integer correction
+  GATED by `|result - round| < 1e-12`. Within that guard `Math.floor(result+0.5)`
+  (Math.floor is whitelisted) is bit-identical to `f64.nearest` — the
+  round-half-to-even tie at `x.5` sits ~0.5 from any integer, orders of
+  magnitude outside the guard, so it never enters it. One sign-of-zero fix-up
+  (`f64.nearest(-4.3e-13) = -0` vs `floor(...)= +0`) restores the zero sign from
+  `result` when the rounded value is 0.
+
+I probed the self-host dialect (`from-ast`): it ALREADY lowers `%`, `&&`, `||`,
+nested-if, `while` + mid-body-if, early-return-in-loop, `Math.trunc`, and the
+`-0` literal survives to runtime. So the conversions are pure-f64, net −LOC,
+zero compiler-internals risk. `random` stays hand-emitted — a host RNG import,
+NOT a dialect gap.
+
+## Why the original "intrinsics groundwork" is not needed (history)
+
+The issue was filed presuming exp/pow needed `i32-local + shl/shr_u/and/or +
+f64↔i64 reinterpret` and log10 needed a sound `f64.nearest` self-host intrinsic.
+That was inferred from the *op families* the hand bodies emit (`i32.and`,
+`i32.shr_u`, `f64.nearest`) without tracing what those ops actually COMPUTE. In
+every case the computation is over small non-negative integers or a
+guard-bounded near-integer, so the pure-f64 encodings above are exact. Building
+the intrinsics dialect would have been correct but far larger and riskier
+(touching `select.ts`'s whitelist + `from-ast` lowering); it is unnecessary for
+this family. Kept as a note in case a FUTURE builtin genuinely needs bitwise
+f64-representation surgery (none in the Math family does).
+
+## What shipped
+
+- `src/stdlib/math.ts`: `EXP_SOURCE`/`EXP_BUILTIN`, `LOG10_SOURCE`/`LOG10_BUILTIN`,
+  `POW_SOURCE`/`POW_BUILTIN` (arity 2). `StdlibMathBuiltin` gained `arity?: 1|2`.
+- `src/codegen/stdlib-selfhost.ts`: `mathBuiltinDef` honors `arity` → `[F64,F64]`.
+- `src/codegen/math-helpers.ts`: hand `Math_exp` block, hand `Math_log10` block,
+  and `buildPowBody` (~260 lines) deleted, replaced by one-line
+  `emitSelfHostedMathFunc` calls at the same emission slots; dead `Instr[]`
+  shorthands removed (`blockLoop`, `i32eqz`, `truncSatI32`, `i32sub`, `neg`,
+  `fsqrt`, `ftrunc`, `fle`, `LN2`, `LOG2E`, `LOG10E`, `i32Type`).
+- `tests/issue-3226.test.ts`: exp/pow/log10 specials + accuracy, host + standalone.
+
+## Proof (the gate)
+
+Each of the three bit-exact-validated against a `main`-built control (raw f64
+bit-pattern comparison):
+
+1. **Bit-exact**: ~10,900 cases = 1,626 boundary + 9,300 random. exp: 0/58
+   boundary (+1,500 random); log10: 0/48 (+1,800); pow: 0/1,520 (+6,000). Dense
+   at the risk boundaries: exp-by-squaring parity/halve at loop-count boundaries,
+   large/negative/2^31 exponents, overflow (709.7) / underflow (-745) / subnormal
+   edges, log10 values just in/out of the 1e-12 guard + exact powers of ten +
+   sign-of-zero below 1, and ±0/NaN/±Inf/denormals throughout. **0 mismatches.**
+2. **Containment**: programs not using exp/pow/log10 are byte-identical vs main
+   (no-math, sin/cos/tan, log/log2, atan/asin/acos, random, and the exp-free
+   derived subset cbrt/asinh/acosh/atanh/log1p all SHA-identical). Only direct
+   users + `sinh/cosh/tanh/expm1` (transitive exp users) change — expected.
+3. **Both pure-Wasm lanes**: `standalone` + `wasi` compile with ZERO host imports.
+4. `tests/issue-3226.test.ts` (2) + `math-inline` + `issue-3141` (51) green;
+   loc-budget + ir-fallback gates OK.
+
+## Acceptance (met)
+
+- exp/pow/log10 self-hosted (hand `Instr[]` deleted), bit-exact vs main (0
+  mismatches), Math suites green, net −LOC.
+- `random` remains hand-emitted (host RNG import, documented as not a dialect gap).
+- Dialect-intrinsics groundwork determined UNNECESSARY for the Math family
+  (rationale recorded above).

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -11,12 +11,15 @@
  * with arithmetic range reduction. Precision target: within 4 ULP of
  * IEEE 754 for the common range.
  *
- * #3141 — the derived family (sinh/cosh/tanh, asinh/acosh/atanh, cbrt,
- * expm1, log1p) is SELF-HOSTED: written as ordinary TS source in
- * `src/stdlib/math.ts` and compiled through the compiler's own IR
- * pipeline (`stdlib-selfhost.ts`) instead of hand-emitted `Instr[]`.
- * Only the precision-sensitive range-reduction cores (sin/cos/exp/log/
- * atan + atan2/pow/log2/log10/tan/random) remain hand-written here.
+ * #3141/#3204/#3226 — nearly the whole family is now SELF-HOSTED: written as
+ * ordinary TS source in `src/stdlib/math.ts`, compiled through the compiler's
+ * own IR pipeline (`stdlib-selfhost.ts`) instead of hand-emitted `Instr[]` —
+ * the derived family (sinh/cosh/tanh, asinh/acosh/atanh, cbrt, expm1, log1p),
+ * the log/trig cores (log/log2, reduce_trig, sin/cos/tan, atan/asin/acos), and
+ * exp/pow/log10 (#3226 established none needs new dialect intrinsics — the
+ * presumed i32-bit-op / reinterpret / f64.nearest gaps are all avoidable in
+ * pure f64). The ONLY Math core still hand-written here is `random` — a host
+ * RNG import, not a dialect gap. (`atan2` self-hosts via #3233.)
  */
 import type { Instr, ValType } from "../ir/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
@@ -34,7 +37,10 @@ import {
   TAN_BUILTIN,
   ASIN_BUILTIN,
   ACOS_BUILTIN,
-} from "../stdlib/math.js"; // (#3141/#3204) TS-source builtin bodies
+  EXP_BUILTIN,
+  LOG10_BUILTIN,
+  POW_BUILTIN,
+} from "../stdlib/math.js"; // (#3141/#3204/#3226) TS-source builtin bodies
 
 // ─── Instruction shorthand helpers ──────────────────────────────────
 const f64c = (v: number): Instr => ({ op: "f64.const", value: v }) as Instr;
@@ -44,23 +50,16 @@ const add: Instr = { op: "f64.add" } as Instr;
 const sub: Instr = { op: "f64.sub" } as Instr;
 const mul: Instr = { op: "f64.mul" } as Instr;
 const div: Instr = { op: "f64.div" } as Instr;
-const neg: Instr = { op: "f64.neg" } as Instr;
 const fabs: Instr = { op: "f64.abs" } as Instr;
-const fsqrt: Instr = { op: "f64.sqrt" } as Instr;
 const ffloor: Instr = { op: "f64.floor" } as Instr;
-const ftrunc: Instr = { op: "f64.trunc" } as Instr;
 const feq: Instr = { op: "f64.eq" } as Instr;
 const fne: Instr = { op: "f64.ne" } as Instr;
 const flt: Instr = { op: "f64.lt" } as Instr;
 const fgt: Instr = { op: "f64.gt" } as Instr;
-const fle: Instr = { op: "f64.le" } as Instr;
 const fge: Instr = { op: "f64.ge" } as Instr;
 const ret: Instr = { op: "return" } as Instr;
 const copysign: Instr = { op: "f64.copysign" } as Instr;
 const i32const = (v: number): Instr => ({ op: "i32.const", value: v }) as Instr;
-const i32eqz: Instr = { op: "i32.eqz" } as Instr;
-const truncSatI32: Instr = { op: "i32.trunc_sat_f64_s" } as Instr;
-const i32sub: Instr = { op: "i32.sub" } as Instr;
 
 function ifThenRet(cond: Instr[], result: Instr[]): Instr[] {
   return [...cond, { op: "if", blockType: { kind: "empty" }, then: [...result, ret] } as Instr];
@@ -79,30 +78,12 @@ function call(funcIdx: number): Instr {
   return { op: "call", funcIdx } as Instr;
 }
 
-function blockLoop(body: Instr[]): Instr {
-  return {
-    op: "block",
-    blockType: { kind: "empty" },
-    body: [
-      {
-        op: "loop",
-        blockType: { kind: "empty" },
-        body,
-      } as Instr,
-    ],
-  } as Instr;
-}
-
 // ─── Constants ──────────────────────────────────────────────────────
 const PI = Math.PI;
 const HALF_PI = PI / 2;
-const LN2 = Math.LN2;
-const LOG2E = Math.LOG2E;
-const LOG10E = Math.LOG10E;
 
 // ─── Type aliases ───────────────────────────────────────────────────
 const f64Type: ValType = { kind: "f64" };
-const i32Type: ValType = { kind: "i32" };
 const f64Param: ValType[] = [f64Type];
 const f64Result: ValType[] = [f64Type];
 
@@ -252,122 +233,11 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
   }
 
   // ─── Math.exp ─────────────────────────────────────────────────────
-  // exp(x) = 2^n * exp(r), where x = n*ln2 + r, |r| <= ln2/2
+  // Self-hosted (#3226): 2^n by pure-f64 repeated squaring (no i32 bit-ops /
+  // reinterpret needed). Early core — emitted before its callers (sinh/cosh/
+  // tanh/expm1/pow) so their `Math_exp` calls resolve by funcMap name.
   if (needExp) {
-    // Locals: 0=x, 1=n, 2=r, 3=expR, 4=ni(i32), 5=pow2, 6=base
-    addMathFunc({
-      name: "Math_exp",
-      params: f64Param,
-      results: f64Result,
-      locals: [
-        { name: "n", type: f64Type },
-        { name: "r", type: f64Type },
-        { name: "expR", type: f64Type },
-        { name: "ni", type: i32Type },
-        { name: "pow2", type: f64Type },
-        { name: "base", type: f64Type },
-      ],
-      body: [
-        ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-        ...ifThenRet([localGet(0), f64c(Infinity), feq], [f64c(Infinity)]),
-        ...ifThenRet([localGet(0), f64c(-Infinity), feq], [f64c(0)]),
-        ...ifThenRet([localGet(0), f64c(709.7), fgt], [f64c(Infinity)]),
-        ...ifThenRet([localGet(0), f64c(-745), flt], [f64c(0)]),
-
-        // n = round(x / ln2)
-        localGet(0),
-        f64c(LOG2E),
-        mul,
-        f64c(0.5),
-        add,
-        ffloor,
-        localSet(1),
-
-        // r = x - n * ln2
-        localGet(0),
-        localGet(1),
-        f64c(LN2),
-        mul,
-        sub,
-        localSet(2),
-
-        // exp(r) via Horner (Taylor order 7):
-        // 1 + r*(1 + r*(1/2 + r*(1/6 + r*(1/24 + r*(1/120 + r*(1/720 + r/5040))))))
-        localGet(2),
-        f64c(1.0 / 5040),
-        mul,
-        f64c(1.0 / 720),
-        add,
-        localGet(2),
-        mul,
-        f64c(1.0 / 120),
-        add,
-        localGet(2),
-        mul,
-        f64c(1.0 / 24),
-        add,
-        localGet(2),
-        mul,
-        f64c(1.0 / 6),
-        add,
-        localGet(2),
-        mul,
-        f64c(1.0 / 2),
-        add,
-        localGet(2),
-        mul,
-        f64c(1),
-        add,
-        localGet(2),
-        mul,
-        f64c(1),
-        add,
-        localSet(3),
-
-        // Compute 2^n via repeated squaring
-        f64c(1),
-        localSet(5),
-        localGet(1),
-        fabs,
-        truncSatI32,
-        localSet(4),
-        f64c(2),
-        localSet(6),
-
-        blockLoop([
-          localGet(4),
-          i32eqz,
-          { op: "br_if", depth: 1 } as Instr,
-          // if ni & 1, pow2 *= base
-          localGet(4),
-          i32const(1),
-          { op: "i32.and" } as Instr,
-          { op: "if", blockType: { kind: "empty" }, then: [localGet(5), localGet(6), mul, localSet(5)] } as Instr,
-          // base *= base
-          localGet(6),
-          localGet(6),
-          mul,
-          localSet(6),
-          // ni >>= 1
-          localGet(4),
-          i32const(1),
-          { op: "i32.shr_u" } as Instr,
-          localSet(4),
-          { op: "br", depth: 0 } as Instr,
-        ]),
-
-        // If n < 0, pow2 = 1/pow2
-        localGet(1),
-        f64c(0),
-        flt,
-        { op: "if", blockType: { kind: "empty" }, then: [f64c(1), localGet(5), div, localSet(5)] } as Instr,
-
-        // result = expR * pow2
-        localGet(3),
-        localGet(5),
-        mul,
-      ],
-    });
+    addedFuncs.set("Math_exp", emitSelfHostedMathFunc(ctx, EXP_BUILTIN));
   }
 
   // ─── Math.log ─────────────────────────────────────────────────────
@@ -418,58 +288,17 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
     addedFuncs.set("Math_log2", emitSelfHostedMathFunc(ctx, LOG2_BUILTIN));
   }
 
-  // Math.log10(x) = log(x) * LOG10E, with integer rounding for exact powers of 10
-  // Locals: 0=x, 1=result, 2=rounded
+  // Math.log10 — self-hosted (#3226): `Math.floor(result + 0.5)` replaces the
+  // hand `f64.nearest` (bit-identical within the <1e-12 correction guard).
+  // Calls the early-core self-hosted Math_log (registered above).
   if (needed.has("log10")) {
-    const logIdx = getFuncIdx("Math_log");
-    addMathFunc({
-      name: "Math_log10",
-      params: f64Param,
-      results: f64Result,
-      locals: [
-        { name: "result", type: f64Type },
-        { name: "rounded", type: f64Type },
-      ],
-      body: [
-        // Compute log(x) * LOG10E
-        localGet(0),
-        call(logIdx),
-        f64c(LOG10E),
-        mul,
-        localSet(1),
-
-        // Round-to-nearest integer when very close (within 1e-12)
-        // This corrects precision loss for exact powers of 10
-        localGet(1),
-        { op: "f64.nearest" } as Instr,
-        localSet(2),
-        localGet(1),
-        localGet(2),
-        sub,
-        fabs,
-        f64c(1e-12),
-        flt,
-        ifElse(f64Type, [localGet(2)], [localGet(1)]),
-      ],
-    });
+    addedFuncs.set("Math_log10", emitSelfHostedMathFunc(ctx, LOG10_BUILTIN));
   }
 
-  // Math.pow(base, exponent)
+  // Math.pow — self-hosted (#3226): pure-f64 exp-by-squaring + exp(e·log b)
+  // general path, calling the self-hosted Math_exp / Math_log. Binary (arity 2).
   if (needed.has("pow")) {
-    const expIdx = getFuncIdx("Math_exp");
-    const logIdx = getFuncIdx("Math_log");
-    addMathFunc({
-      name: "Math_pow",
-      params: [f64Type, f64Type],
-      results: f64Result,
-      locals: [
-        { name: "absBase", type: f64Type }, // 2
-        { name: "powRes", type: f64Type }, // 3 — squaring accumulator
-        { name: "powBase", type: f64Type }, // 4 — repeatedly squared base
-        { name: "powN", type: i32Type }, // 5 — |exponent| as i32 loop counter
-      ],
-      body: buildPowBody(expIdx, logIdx),
-    });
+    addedFuncs.set("Math_pow", emitSelfHostedMathFunc(ctx, POW_BUILTIN));
   }
 
   // ─── Self-hosted subset (#3141) ───────────────────────────────────
@@ -599,266 +428,5 @@ function buildAtan2Body(atanIdx: number): Instr[] {
         ),
       ],
     ),
-  ];
-}
-
-function buildPowBody(expIdx: number, logIdx: number): Instr[] {
-  // pow(base, exponent): params 0=base, 1=exponent; locals 2=absBase
-  return [
-    // exp == 0 → 1 (for any base, including NaN)
-    ...ifThenRet([localGet(1), f64c(0), feq], [f64c(1)]),
-    // NaN checks (must come before base==1, per spec: pow(1, NaN) → NaN)
-    ...ifThenRet([localGet(0), localGet(0), fne], [f64c(NaN)]),
-    ...ifThenRet([localGet(1), localGet(1), fne], [f64c(NaN)]),
-    // §21.3.2.26: if abs(base) == 1 and abs(exponent) == +Infinity → NaN
-    // (must come before base == 1 short-circuit; covers pow(±1, ±Infinity))
-    ...ifThenRet(
-      [localGet(0), fabs, f64c(1), feq, localGet(1), fabs, f64c(Infinity), feq, { op: "i32.and" } as Instr],
-      [f64c(NaN)],
-    ),
-    // base == 1 → 1
-    ...ifThenRet([localGet(0), f64c(1), feq], [f64c(1)]),
-    // exp == 1 → base
-    ...ifThenRet([localGet(1), f64c(1), feq], [localGet(0)]),
-    // exp == -1 → 1/base
-    ...ifThenRet([localGet(1), f64c(-1), feq], [f64c(1), localGet(0), div]),
-    // exp == 0.5 → sqrt(base)
-    ...ifThenRet([localGet(1), f64c(0.5), feq], [localGet(0), fsqrt]),
-    // exp == 2 → base*base
-    ...ifThenRet([localGet(1), f64c(2), feq], [localGet(0), localGet(0), mul]),
-
-    // base == 0: check sign of base and parity of exponent
-    localGet(0),
-    f64c(0),
-    feq,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        // isNegZero AND isOddInt? → result has negative sign
-        // isNegZero: 1/base == -Infinity
-        // isOddInt: trunc(exp) == exp AND floor(exp/2)*2 != trunc(exp)
-        f64c(1),
-        localGet(0),
-        div,
-        f64c(-Infinity),
-        feq, // isNegZero?
-        localGet(1),
-        localGet(1),
-        ftrunc,
-        feq, // isInteger?
-        { op: "i32.and" } as Instr,
-        localGet(1),
-        ftrunc,
-        f64c(2),
-        div,
-        ffloor, // isOdd?
-        f64c(2),
-        mul,
-        localGet(1),
-        ftrunc,
-        fne,
-        { op: "i32.and" } as Instr,
-        // Stack: i32 (isNegZeroAndOddInt)
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [
-            // Negative zero base + odd integer exp
-            localGet(1),
-            f64c(0),
-            fgt,
-            ifElse(f64Type, [f64c(-0.0)], [f64c(-Infinity)]),
-            ret,
-          ],
-        } as Instr,
-        // Positive zero base (or even/non-integer exp)
-        localGet(1),
-        f64c(0),
-        fgt,
-        ifElse(f64Type, [f64c(0)], [f64c(Infinity)]),
-        ret,
-      ],
-    } as Instr,
-
-    // base == +Inf
-    ...ifThenRet(
-      [localGet(0), f64c(Infinity), feq],
-      [localGet(1), f64c(0), fgt, ifElse(f64Type, [f64c(Infinity)], [f64c(0)])],
-    ),
-
-    // base == -Inf: sign depends on whether exponent is odd integer
-    localGet(0),
-    f64c(-Infinity),
-    feq,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        // isOddInt: trunc(exp) == exp AND floor(exp/2)*2 != trunc(exp)
-        localGet(1),
-        localGet(1),
-        ftrunc,
-        feq, // isInteger?
-        localGet(1),
-        ftrunc,
-        f64c(2),
-        div,
-        ffloor, // isOdd?
-        f64c(2),
-        mul,
-        localGet(1),
-        ftrunc,
-        fne,
-        { op: "i32.and" } as Instr,
-        // Now i32 isOddInt is on stack
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [
-            // Odd integer exponent: -Inf or -0
-            localGet(1),
-            f64c(0),
-            fgt,
-            ifElse(f64Type, [f64c(-Infinity)], [f64c(-0.0)]),
-            ret,
-          ],
-        } as Instr,
-        // Even/non-integer exponent: +Inf or +0
-        localGet(1),
-        f64c(0),
-        fgt,
-        ifElse(f64Type, [f64c(Infinity)], [f64c(0)]),
-        ret,
-      ],
-    } as Instr,
-
-    // ── Integer-exponent fast path (exact) ─────────────────────────────
-    // For an integer exponent that fits in an i32 counter, compute base^|exp|
-    // by exponentiation-by-squaring (mirrors V8's `power_double_int`). This is
-    // EXACT for integer base/exponent within f64 range, so e.g. 3**3 === 27 and
-    // (-3)**3 === -27, instead of the ~1-ULP-low `exp(exp*log|base|)` result
-    // (3**3 → 26.999…) the generic path below produces. Repeated multiplication
-    // also carries the sign of a negative base correctly (no separate odd/even
-    // negation needed) and overflows to ±Inf / underflows to ±0 the same way the
-    // generic path would for huge exponents. Reached only after the
-    // exp ∈ {0,1,-1,0.5,2} and base ∈ {0,±1,±Inf} special cases returned, so the
-    // base here is finite, non-zero, ≠ ±1 and the exponent is a finite integer
-    // not already handled. (#2887)
-    localGet(1),
-    localGet(1),
-    ftrunc,
-    feq, // exponent is an integer?
-    localGet(1),
-    fabs,
-    f64c(2147483648), // |exp| < 2^31 so it fits the i32 loop counter
-    flt,
-    { op: "i32.and" } as Instr,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        f64c(1),
-        localSet(3), // powRes = 1
-        localGet(0),
-        localSet(4), // powBase = base
-        localGet(1),
-        fabs,
-        truncSatI32,
-        localSet(5), // powN = |exp|
-        blockLoop([
-          localGet(5),
-          i32eqz,
-          { op: "br_if", depth: 1 } as Instr,
-          // if (powN & 1) powRes *= powBase
-          localGet(5),
-          i32const(1),
-          { op: "i32.and" } as Instr,
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [localGet(3), localGet(4), mul, localSet(3)],
-          } as Instr,
-          // powBase *= powBase
-          localGet(4),
-          localGet(4),
-          mul,
-          localSet(4),
-          // powN >>= 1 (unsigned)
-          localGet(5),
-          i32const(1),
-          { op: "i32.shr_u" } as Instr,
-          localSet(5),
-          { op: "br", depth: 0 } as Instr,
-        ]),
-        // Negative exponent → reciprocal
-        localGet(1),
-        f64c(0),
-        flt,
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [f64c(1), localGet(3), div, localSet(3)],
-        } as Instr,
-        localGet(3),
-        ret,
-      ],
-    } as Instr,
-
-    // base < 0: non-integer exp → NaN; otherwise (a non-finite |exp|, i.e.
-    // ±Infinity, or an integer exponent too large for the i32 fast path above)
-    // → exp(exp * log(|base|)) with the sign reapplied for odd integer exponents.
-    // The common small-integer base<0 case already returned from the fast path;
-    // this branch only covers |exp| ≥ 2^31 and ±Infinity (where the result is
-    // ±Inf / 0 anyway, so the exp/log approximation is exact enough).
-    localGet(0),
-    f64c(0),
-    flt,
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: [
-        // Non-integer (finite) exponent → NaN
-        localGet(1),
-        localGet(1),
-        ftrunc,
-        fne,
-        { op: "if", blockType: { kind: "empty" }, then: [f64c(NaN), ret] } as Instr,
-        // |exp| == Infinity or huge integer: result = exp(exp * log(|base|))
-        localGet(0),
-        fabs,
-        localSet(2),
-        localGet(1),
-        localGet(2),
-        call(logIdx),
-        mul,
-        call(expIdx),
-        localSet(2), // reuse absBase local to store result
-        // If exponent is odd, negate the result (odd: floor(exp/2)*2 != exp)
-        localGet(1),
-        ftrunc,
-        f64c(2),
-        div,
-        ffloor,
-        f64c(2),
-        mul,
-        localGet(1),
-        ftrunc,
-        fne,
-        ifElse(
-          f64Type,
-          [localGet(2), neg], // odd → negate
-          [localGet(2)], // even → keep
-        ),
-        ret,
-      ],
-    } as Instr,
-
-    // General case (base > 0, non-integer exponent): exp(exponent * log(base))
-    localGet(1),
-    localGet(0),
-    call(logIdx),
-    mul,
-    call(expIdx),
   ];
 }

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -44,48 +44,15 @@ import {
 } from "../stdlib/math.js"; // (#3141/#3204/#3233/#3226) TS-source builtin bodies
 
 // ─── Instruction shorthand helpers ──────────────────────────────────
+// Only `Math.random` remains hand-emitted (WASI `random_get` host import —
+// not a dialect gap); every other Math core is self-hosted TS source in
+// `src/stdlib/math.ts`. These are the few shorthands its body still needs.
 const f64c = (v: number): Instr => ({ op: "f64.const", value: v }) as Instr;
-const localGet = (i: number): Instr => ({ op: "local.get", index: i }) as Instr;
-const localSet = (i: number): Instr => ({ op: "local.set", index: i }) as Instr;
-const add: Instr = { op: "f64.add" } as Instr;
-const sub: Instr = { op: "f64.sub" } as Instr;
 const mul: Instr = { op: "f64.mul" } as Instr;
-const div: Instr = { op: "f64.div" } as Instr;
-const fabs: Instr = { op: "f64.abs" } as Instr;
-const ffloor: Instr = { op: "f64.floor" } as Instr;
-const feq: Instr = { op: "f64.eq" } as Instr;
-const fne: Instr = { op: "f64.ne" } as Instr;
-const flt: Instr = { op: "f64.lt" } as Instr;
-const fgt: Instr = { op: "f64.gt" } as Instr;
-const fge: Instr = { op: "f64.ge" } as Instr;
-const ret: Instr = { op: "return" } as Instr;
-const copysign: Instr = { op: "f64.copysign" } as Instr;
 const i32const = (v: number): Instr => ({ op: "i32.const", value: v }) as Instr;
-
-function ifThenRet(cond: Instr[], result: Instr[]): Instr[] {
-  return [...cond, { op: "if", blockType: { kind: "empty" }, then: [...result, ret] } as Instr];
-}
-
-function ifElse(type: ValType, thenBody: Instr[], elseBody: Instr[]): Instr {
-  return {
-    op: "if",
-    blockType: { kind: "val", type },
-    then: thenBody,
-    else: elseBody,
-  } as Instr;
-}
-
-function call(funcIdx: number): Instr {
-  return { op: "call", funcIdx } as Instr;
-}
-
-// ─── Constants ──────────────────────────────────────────────────────
-const PI = Math.PI;
-const HALF_PI = PI / 2;
 
 // ─── Type aliases ───────────────────────────────────────────────────
 const f64Type: ValType = { kind: "f64" };
-const f64Param: ValType[] = [f64Type];
 const f64Result: ValType[] = [f64Type];
 
 type MathFuncDef = {
@@ -117,14 +84,6 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
     ctx.funcMap.set(def.name, funcIdx);
     addedFuncs.set(def.name, funcIdx);
     return funcIdx;
-  }
-
-  function getFuncIdx(name: string): number {
-    const idx = addedFuncs.get(name);
-    if (idx === undefined) {
-      throw new Error(`Math helper ${name} not yet added but referenced`);
-    }
-    return idx;
   }
 
   // ─── Math.random ──────────────────────────────────────────────────

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -203,10 +203,13 @@ function mathBuiltinDef(builtin: StdlibMathBuiltin): SelfHostedFuncDef {
   for (const callee of builtin.callees) {
     calleeTypes.set(callee, { params: [F64], returnType: F64 });
   }
+  // Arity 1 (default) or 2 (`pow(base, exp)`) — every param is f64 either way,
+  // matching the sources' `: number` annotations. Context-free, so memoize.
+  const paramTypes: IrType[] = builtin.arity === 2 ? [F64, F64] : [F64];
   return {
     name: builtin.name,
     source: builtin.source,
-    paramTypes: [F64],
+    paramTypes,
     returnType: F64,
     calleeTypes,
     memoKey: builtin.name,

--- a/src/stdlib/math.ts
+++ b/src/stdlib/math.ts
@@ -41,6 +41,13 @@ export interface StdlibMathBuiltin {
   readonly callees: readonly string[];
   /** Ordinary TS source, IR-claimable subset (see header). */
   readonly source: string;
+  /**
+   * Number of `(f64) -> f64` positional params (default 1). `2` is used by
+   * `pow(base, exp)` — still pure f64, just binary, so it flows through the
+   * generalized #3161 typed path with `paramTypes: [F64, F64]`. Callees
+   * remain unary `(f64) -> f64`.
+   */
+  readonly arity?: 1 | 2;
 }
 
 /**
@@ -412,13 +419,153 @@ export const ASIN_BUILTIN: StdlibMathBuiltin = { name: "Math_asin", callees: ["M
 export const ACOS_BUILTIN: StdlibMathBuiltin = { name: "Math_acos", callees: ["Math_atan"], source: ACOS_SOURCE };
 
 /**
+ * Math.exp — Cody-style reduction `x = n·ln2 + r`, `|r| ≤ ln2/2`, then
+ * `exp(r)` by an order-7 Taylor Horner and `2^n` by repeated SQUARING of the
+ * non-negative integer `ni = |n|`. #3226 established this needs NO IEEE
+ * exponent-field extraction / `reinterpret` — the hand body's `ni & 1` /
+ * `ni >>> 1` are just parity + halve of a small non-negative integer, exactly
+ * `ni - Math.floor(ni/2)*2` and `Math.floor(ni/2)` in pure f64 (bit-identical
+ * for a non-negative integer). ±Infinity / overflow / underflow specials
+ * mirror the hand ladder: `x == +Inf` → `x`; `x == -Inf` / `x < -745` → 0;
+ * `x > 709.7` → `1 / 0` (= +Inf; the dialect forbids the `Infinity` identifier).
+ * LOG2E = 1.4426950408889634, LN2 = 0.6931471805599453.
+ */
+const EXP_SOURCE = `
+export function Math_exp(x: number): number {
+  if (x !== x) return x;
+  if (x > 1.7976931348623157e308) return x;
+  if (x < -1.7976931348623157e308) return 0;
+  if (x > 709.7) return 1 / 0;
+  if (x < -745) return 0;
+  let n: number = Math.floor(x * 1.4426950408889634 + 0.5);
+  let r: number = x - n * 0.6931471805599453;
+  let expR: number = ((((((r * (1 / 5040) + 1 / 720) * r + 1 / 120) * r + 1 / 24) * r + 1 / 6) * r + 1 / 2) * r + 1) * r + 1;
+  let ni: number = Math.abs(n);
+  let pow2: number = 1;
+  let base: number = 2;
+  while (ni > 0) {
+    let half: number = Math.floor(ni / 2);
+    if (ni - half * 2 === 1) { pow2 = pow2 * base; }
+    base = base * base;
+    ni = half;
+  }
+  if (n < 0) { pow2 = 1 / pow2; }
+  return expR * pow2;
+}
+`;
+
+/**
+ * Math.log10 = `log(x) · LOG10E` with a round-to-nearest-integer correction
+ * for exact powers of 10. #3226: the hand body's `f64.nearest` is AVOIDABLE —
+ * the correction is gated by `|result - round| < 1e-12`, and within that guard
+ * `Math.floor(result + 0.5)` (Math.floor is whitelisted) is bit-identical to
+ * `f64.nearest` (the round-half-to-even tie at `x.5` is ~0.5 from any integer,
+ * so it never enters the guard; both paths return the raw `result` there).
+ * One sign-of-zero fix-up: `f64.nearest` preserves the sign of a near-zero
+ * input (nearest(-4.3e-13) = -0) whereas `Math.floor(result + 0.5)` yields +0,
+ * so when the rounded value is 0 the sign is restored from `result`
+ * (`result < 0 ? -0 : 0`) — needed for `log10` of values just below 1.
+ * LOG10E = 0.4342944819032518. Domain/specials fall out of `Math_log`'s own
+ * ladder (log(≤0)/NaN/±Inf) then flow through the guard unchanged.
+ */
+const LOG10_SOURCE = `
+export function Math_log10(x: number): number {
+  let result: number = Math_log(x) * 0.4342944819032518;
+  let rounded: number = Math.floor(result + 0.5);
+  if (Math.abs(result - rounded) < 1e-12) {
+    if (rounded === 0) return result < 0 ? -0 : 0;
+    return rounded;
+  }
+  return result;
+}
+`;
+
+/**
+ * Math.pow(b, e) — binary, pure f64 (#3226: NOT a dialect gap). Mirrors the
+ * hand `Instr[]` body's special-case ladder op-for-op, then two shared cores:
+ *   - integer-exponent fast path (`trunc(e)===e && |e| < 2^31`): exact
+ *     exponentiation-by-SQUARING, the f64 encoding of the hand i32 loop
+ *     (`powN & 1` → `powN - Math.floor(powN/2)*2 === 1`, `powN >>> 1` →
+ *     `Math.floor(powN/2)`) — bit-identical for the non-negative integer counter;
+ *   - general path `Math_exp(e * Math_log(|b|/b))` — calls the SAME self-hosted
+ *     exp/log, so bit-identical to the hand version (which shares those cores).
+ * `i32.and` boolean combines become `&&`; `-0` results use a `-0` literal
+ * (survives the IR path) or `b` itself (which is -0 in the neg-zero-base arm);
+ * `±Infinity` via `1 / 0` / `-1 / 0`; NaN-out via `0 / 0`. §21.3.2.26 corner
+ * `pow(±1, ±Infinity) → NaN` is preserved (checked before the base==1 arm).
+ */
+const POW_SOURCE = `
+export function Math_pow(b: number, e: number): number {
+  if (e === 0) return 1;
+  if (b !== b) return b;
+  if (e !== e) return e;
+  if (Math.abs(b) === 1 && Math.abs(e) > 1.7976931348623157e308) return 0 / 0;
+  if (b === 1) return 1;
+  if (e === 1) return b;
+  if (e === -1) return 1 / b;
+  if (e === 0.5) return Math.sqrt(b);
+  if (e === 2) return b * b;
+  if (b === 0) {
+    if (1 / b < 0 && e === Math.trunc(e) && Math.floor(Math.trunc(e) / 2) * 2 !== Math.trunc(e)) {
+      if (e > 0) return b;
+      return 1 / b;
+    }
+    if (e > 0) return 0;
+    return 1 / 0;
+  }
+  if (b > 1.7976931348623157e308) {
+    if (e > 0) return 1 / 0;
+    return 0;
+  }
+  if (b < -1.7976931348623157e308) {
+    if (e === Math.trunc(e) && Math.floor(Math.trunc(e) / 2) * 2 !== Math.trunc(e)) {
+      if (e > 0) return -1 / 0;
+      return -0;
+    }
+    if (e > 0) return 1 / 0;
+    return 0;
+  }
+  if (e === Math.trunc(e) && Math.abs(e) < 2147483648) {
+    let powRes: number = 1;
+    let powBase: number = b;
+    let powN: number = Math.abs(e);
+    while (powN > 0) {
+      let half: number = Math.floor(powN / 2);
+      if (powN - half * 2 === 1) { powRes = powRes * powBase; }
+      powBase = powBase * powBase;
+      powN = half;
+    }
+    if (e < 0) { powRes = 1 / powRes; }
+    return powRes;
+  }
+  if (b < 0) {
+    if (e !== Math.trunc(e)) return 0 / 0;
+    let res: number = Math_exp(e * Math_log(Math.abs(b)));
+    if (Math.floor(Math.trunc(e) / 2) * 2 !== Math.trunc(e)) return -res;
+    return res;
+  }
+  return Math_exp(e * Math_log(b));
+}
+`;
+
+export const EXP_BUILTIN: StdlibMathBuiltin = { name: "Math_exp", callees: [], source: EXP_SOURCE };
+export const LOG10_BUILTIN: StdlibMathBuiltin = { name: "Math_log10", callees: ["Math_log"], source: LOG10_SOURCE };
+export const POW_BUILTIN: StdlibMathBuiltin = {
+  name: "Math_pow",
+  callees: ["Math_exp", "Math_log"],
+  source: POW_SOURCE,
+  arity: 2,
+};
+
+/**
  * The self-hosted subset of the Math family, keyed by `Math.<method>`
- * name. Remaining hand-emitted cores (exp, atan2, pow, log10, random) are
- * the ones with real dialect gaps (exp: i32 2^n squaring; pow: i32
- * exp-by-squaring; log10: `f64.nearest`; random: RNG import; atan2: 2-arg
- * quadrant ladder) — converting them needs the intrinsics groundwork
- * (#3204 follow-up). `log`/`log2` and the trig cores (reduce_trig,
- * sin/cos/tan, atan/asin/acos) moved to EARLY cores above.
+ * name. `exp`/`log10`/`pow` (#3226) and `atan2` (#3233) are self-hosted as
+ * EARLY cores above — #3226 established none of them needs new dialect
+ * intrinsics (the presumed i32-bit-op / reinterpret / `f64.nearest` gaps are
+ * all avoidable in pure f64; see the per-source docs). The ONLY remaining
+ * hand-emitted Math core is `random` — a host RNG import, not a dialect gap.
+ * `log`/`log2` and the trig cores (reduce_trig, sin/cos/tan, atan/asin/acos)
+ * are EARLY cores too.
  */
 export const SELF_HOSTED_MATH: ReadonlyMap<string, StdlibMathBuiltin> = new Map([
   ["cbrt", { name: "Math_cbrt", callees: [], source: CBRT_SOURCE }],

--- a/tests/issue-3226.test.ts
+++ b/tests/issue-3226.test.ts
@@ -1,0 +1,148 @@
+// #3226 — self-host Math.exp / Math.pow / Math.log10: the last dialect-gap Math
+// cores move from hand-emitted Instr[] to TS source in src/stdlib/math.ts,
+// compiled through the compiler's own IR pipeline. #3226 established these need
+// NO new dialect intrinsics (no i32 bit-ops / f64↔i64 reinterpret / f64.nearest):
+//   - exp/pow: 2^n / exp-by-squaring reduce to pure-f64 parity+halve
+//     (`ni - Math.floor(ni/2)*2`, `Math.floor(ni/2)`);
+//   - log10: `f64.nearest` → `Math.floor(x+0.5)` (guard-equivalent within the
+//     <1e-12 correction window, with a sign-of-zero fix-up).
+// These tests pin the spec-critical specials + accuracy in host and standalone
+// (no-host-import) modes. Bit-exactness vs a main-built control is proven
+// separately by a ~10,900-case sweep (0 mismatches).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildStringConstants } from "../src/runtime.js";
+
+const SRC = `
+export function exp(x: number): number { return Math.exp(x); }
+export function log10(x: number): number { return Math.log10(x); }
+export function pow(b: number, e: number): number { return Math.pow(b, e); }
+`;
+
+interface MathExports {
+  exp: (x: number) => number;
+  log10: (x: number) => number;
+  pow: (b: number, e: number) => number;
+}
+
+async function compileHost(): Promise<MathExports> {
+  const r = await compile(SRC, { fileName: "issue-3226.ts" });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message}`);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: {},
+    "wasm:js-string": {
+      concat: (a: string, b: string) => a + b,
+      length: (s: string) => s.length,
+      equals: (a: string, b: string) => (a === b ? 1 : 0),
+      substring: (s: string, start: number, end: number) => s.substring(start, end),
+      charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+    },
+    string_constants: buildStringConstants(r.stringPool),
+  } as WebAssembly.Imports);
+  return instance.exports as unknown as MathExports;
+}
+
+async function compileStandalone(): Promise<MathExports> {
+  const r = await compile(SRC, { fileName: "issue-3226-standalone.ts", target: "standalone" });
+  if (!r.success) throw new Error(`standalone compile failed: ${r.errors[0]?.message}`);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as MathExports;
+}
+
+function checkSpecials(ex: MathExports) {
+  // exp specials
+  expect(Number.isNaN(ex.exp(NaN))).toBe(true);
+  expect(ex.exp(Infinity)).toBe(Infinity);
+  expect(ex.exp(-Infinity)).toBe(0);
+  expect(ex.exp(0)).toBe(1);
+  expect(ex.exp(710)).toBe(Infinity); // overflow (> 709.7)
+  expect(ex.exp(-746)).toBe(0); // underflow (< -745)
+
+  // log10 specials
+  expect(Number.isNaN(ex.log10(NaN))).toBe(true);
+  expect(Number.isNaN(ex.log10(-1))).toBe(true);
+  expect(ex.log10(0)).toBe(-Infinity);
+  expect(ex.log10(Infinity)).toBe(Infinity);
+  expect(ex.log10(1)).toBe(0);
+  // Positive powers of ten — the poly stays within the 1e-12 correction guard,
+  // so the round-to-nearest-integer correction fires and returns EXACTLY the
+  // integer. (Whether a given power lands inside the guard depends on the poly
+  // error, so some large-|negative| powers return the raw uncorrected value —
+  // bit-identical to the hand version, which is why the ~10,900-case sweep
+  // passes; that behaviour is covered by the accuracy check below, not here.)
+  for (let p = 1; p <= 15; p++) {
+    expect(ex.log10(Math.pow(10, p)), `log10(1e${p})`).toBe(p);
+  }
+  // sign-of-zero just below 1 (the f64.nearest → floor(x+0.5) fix-up)
+  expect(Object.is(ex.log10(0.999999999999), -0)).toBe(true);
+
+  // pow specials (§21.3.2.26 ladder)
+  expect(ex.pow(3, 0)).toBe(1);
+  expect(ex.pow(NaN, 0)).toBe(1); // exp 0 wins even over NaN base
+  expect(Number.isNaN(ex.pow(NaN, 2))).toBe(true);
+  expect(Number.isNaN(ex.pow(2, NaN))).toBe(true);
+  expect(Number.isNaN(ex.pow(1, Infinity))).toBe(true); // pow(±1, ±Inf) → NaN
+  expect(Number.isNaN(ex.pow(-1, Infinity))).toBe(true);
+  expect(ex.pow(1, 12345)).toBe(1);
+  expect(ex.pow(5, 1)).toBe(5);
+  expect(ex.pow(4, -1)).toBe(0.25);
+  expect(ex.pow(9, 0.5)).toBe(3);
+  expect(ex.pow(3, 2)).toBe(9);
+  // exact integer exponentiation (the exp-by-squaring fast path)
+  expect(ex.pow(3, 3)).toBe(27);
+  expect(ex.pow(-3, 3)).toBe(-27);
+  expect(ex.pow(-2, 10)).toBe(1024);
+  expect(ex.pow(2, -3)).toBe(0.125);
+  // signed-zero base
+  expect(Object.is(ex.pow(-0, 3), -0)).toBe(true); // odd positive → -0
+  expect(Object.is(ex.pow(-0, 2), 0)).toBe(true); // even → +0
+  expect(ex.pow(-0, -3)).toBe(-Infinity);
+  expect(ex.pow(0, -1)).toBe(Infinity);
+  // infinite base
+  expect(ex.pow(Infinity, 2)).toBe(Infinity);
+  expect(ex.pow(Infinity, -1)).toBe(0);
+  expect(ex.pow(-Infinity, 3)).toBe(-Infinity); // odd int
+  expect(Object.is(ex.pow(-Infinity, -3), -0)).toBe(true);
+  expect(ex.pow(-Infinity, 2)).toBe(Infinity); // even
+  // negative base, non-integer exp → NaN
+  expect(Number.isNaN(ex.pow(-2, 0.5))).toBe(true);
+}
+
+function checkAccuracy(ex: MathExports) {
+  const rel = (g: number, w: number) => Math.abs(g - w) / Math.max(Math.abs(w), Number.MIN_VALUE);
+  const expCases = [1, -1, 2.5, -2.5, 5, -5, 0.001, 100, -100];
+  for (const v of expCases) {
+    expect(rel(ex.exp(v), Math.exp(v)), `exp(${v})`).toBeLessThan(1e-8);
+  }
+  // log10 = log(x)·LOG10E inherits the shared Math_log polynomial's ~1e-7
+  // relative error (identical to the hand version — bit-exactness is proven by
+  // the sweep; this is a lowering-sanity floor, not a precision assertion).
+  const log10Cases = [2, 3, 123.456, 0.5, 1e15, 1e-15];
+  for (const v of log10Cases) {
+    expect(rel(ex.log10(v), Math.log10(v)), `log10(${v})`).toBeLessThan(1e-7);
+  }
+  const powCases: [number, number][] = [
+    [2, 10],
+    [2.5, 3.3],
+    [10, -2.5],
+    [0.5, 8],
+    [7, 0.333],
+  ];
+  for (const [b, e] of powCases) {
+    expect(rel(ex.pow(b, e), Math.pow(b, e)), `pow(${b},${e})`).toBeLessThan(1e-6);
+  }
+}
+
+describe("#3226 self-hosted Math.exp / log10 / pow (IR-compiled TS source)", () => {
+  it("host mode: specials exact, general path accurate", async () => {
+    const ex = await compileHost();
+    checkSpecials(ex);
+    checkAccuracy(ex);
+  });
+
+  it("standalone mode: specials exact, general path accurate (no host imports)", async () => {
+    const ex = await compileStandalone();
+    checkSpecials(ex);
+    checkAccuracy(ex);
+  });
+});


### PR DESCRIPTION
## What

Converts the last three hand-emitted `Instr[]` Math cores — `Math.exp`, `Math.pow`, `Math.log10` — to TS source in `src/stdlib/math.ts`, compiled through the compiler's own IR pipeline. Self-host bloat track (#3141 → #3204 → #3233 → this).

**#3226's premise was wrong** (verify-first): these do NOT need new dialect intrinsics (no i32 bit-ops, no f64↔i64 `reinterpret`, no `f64.nearest`). Tracing the hand bodies shows every "bit" op is really pure-f64 integer arithmetic:

- **exp/pow**: `2^n` / exp-by-squaring operate on a **non-negative integer loop counter** — `ni & 1` → `ni - Math.floor(ni/2)*2` (parity), `ni >>> 1` → `Math.floor(ni/2)` (halve); `i32.and` boolean combines → `&&`. No IEEE exponent-field surgery.
- **log10**: `f64.nearest` only rounds within a `|result - round| < 1e-12` guard, where `Math.floor(result + 0.5)` is bit-identical (the round-half-to-even tie at `x.5` sits ~0.5 from any integer, never in the guard) — plus a sign-of-zero fix-up for values just below 1.

The self-host dialect (`from-ast`) already lowers `%`, `&&`, `||`, nested-if, while+mid-body-if, early-return-in-loop, `Math.trunc`, and `-0` survives to runtime. Zero `select.ts`/`from-ast` changes. `random` stays hand-emitted (host RNG import, not a dialect gap).

## Changes

- `src/stdlib/math.ts`: `EXP_SOURCE`/`LOG10_SOURCE`/`POW_SOURCE` + builtins; `StdlibMathBuiltin` gains `arity?:1|2` (pow is binary).
- `src/codegen/stdlib-selfhost.ts`: `mathBuiltinDef` honors `arity`.
- `src/codegen/math-helpers.ts`: hand exp/log10 blocks + `buildPowBody` (~260 lines) deleted; dead `Instr[]` shorthands removed.
- `tests/issue-3226.test.ts`.

**Net −296 src LOC.**

## Proof (the gate)

Each of the three bit-exact-validated against a `main`-built control (raw f64 bit pattern):

1. **Bit-exact**: ~10,900 cases = 1,626 boundary + 9,300 random. exp **0**, log10 **0**, pow **0** mismatches. Dense at the risk boundaries: exp-by-squaring parity/halve at loop-count boundaries, large/negative/2^31 exponents, overflow 709.7 / underflow -745 / subnormal edges; log10 values just in/out of the 1e-12 guard + exact powers of ten + sign-of-zero below 1; ±0/NaN/±Inf/denormals throughout.
2. **Containment**: non-users byte-identical (no-math, sin/cos/tan, log/log2, atan/asin/acos, random, exp-free derived subset all SHA-identical). Only exp/pow/log10 users + `sinh/cosh/tanh/expm1` (transitive exp users) change — expected.
3. **Both pure-Wasm lanes**: `standalone` + `wasi` zero host imports.
4. `tests/issue-3226.test.ts` + `issue-3233` + `math-inline` + `issue-3141` green (55); loc-budget + ir-fallback gates OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8