### PR TITLE
feat(#3234): native standalone SuppressedError multi-error aggregation

### DIFF
--- a/plan/issues/3234-standalone-suppressederror.md
+++ b/plan/issues/3234-standalone-suppressederror.md
@@ -1,0 +1,114 @@
+---
+id: 3234
+title: "Standalone: native SuppressedError multi-error aggregation in the DisposableStack dispose driver"
+status: done
+assignee: ttraenkler/opus-suppressed
+created: 2026-07-13
+updated: 2026-07-13
+completed: 2026-07-13
+priority: high
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [3231, 1781]
+umbrella: 1781
+loc-budget-allow:
+  - src/codegen/disposable-runtime.ts
+  - src/codegen/property-access.ts
+  - src/codegen/expressions/identifiers.ts
+  - src/codegen/builtin-tags.ts
+---
+
+# Standalone: native SuppressedError multi-error aggregation (#3231 Phase 1b follow-up)
+
+## Problem
+
+In `--target standalone` the native `DisposableStack` dispose driver
+(`fillDisposableStackDisposeDriver`, `src/codegen/disposable-runtime.ts`, landed
+by #3231 Phase 1a/1b) ran each stored disposer LIFO **without** try/catch, so the
+first disposer that threw unwound out of `dispose()` immediately and the
+remaining disposers never ran. Per §DisposeResources the spec requires running
+EVERY disposer and, when more than one throws, chaining the errors into nested
+`SuppressedError` instances (LIFO-with-suppression: each new error suppresses the
+accumulated one — `.error` = the newer error, `.suppressed` = the prior).
+
+Additionally, `instanceof SuppressedError` and the `.error` / `.suppressed`
+accessor reads leaked host imports standalone (`__instanceof`,
+`SuppressedError_get_error`, `SuppressedError_get_suppressed`), so a module that
+merely inspected a caught SuppressedError could not instantiate.
+
+## Scope (this issue)
+
+Native, `nativeStrings`/standalone-gated, host lane byte-identical:
+
+1. `SuppressedError` added to `BUILTIN_TYPE_TAGS` (tag −18) + `BUILTIN_PARENT`
+   (→ `Error`) so its native `$Error_struct` discriminates for `instanceof`.
+2. Native `instanceof SuppressedError` (and `instanceof Error` for a
+   SuppressedError) via the field-0 tag check — `collectErrorInstanceOfTags`
+   - the error-family `instanceof` gate in `expressions/identifiers.ts`.
+3. Native `.error` / `.suppressed` reads via the `$Error_struct.$props`
+   (fieldIdx 5) open-object backing (`emitExternrefBackedOwnFieldRead`,
+   reusing the #2101a own-field read + #3137 AggregateError `.errors` pattern),
+   intercepted in `compileExternPropertyGet`. Identity-preserving (`ref.eq`).
+4. Dispose driver aggregation: each disposer invocation wrapped in
+   `try`/`catch $exn`; every disposer runs even if a prior threw; on the first
+   throw `pending = err`, on each subsequent throw
+   `pending = SuppressedError{ error: newer, suppressed: prior }` (built inline
+   from a plain `$props` object via `__new_plain_object`/`__extern_set` + a
+   `$Error_struct` with the SuppressedError tag); the final completion is
+   rethrown via the module `$exn` tag. Single error is rethrown as-is.
+
+Native `new SuppressedError(error, suppressed, message)` **construction** is NOT
+in scope (still host in standalone) — the aggregation builds SuppressedError
+structs internally without the constructor.
+
+## Implementation
+
+- `src/codegen/builtin-tags.ts` — `SuppressedError: -18` + `BUILTIN_PARENT`.
+- `src/codegen/expressions/identifiers.ts` — `collectErrorInstanceOfTags` +
+  the `noJsHost` error-family `instanceof` gate recognise `SuppressedError`
+  (NOT added to `WASI_ERROR_NAMES` — its ctor arity differs; the tag check is
+  all `instanceof` needs).
+- `src/codegen/property-access.ts` — `compileExternPropertyGet` intercepts
+  `SuppressedError.error` / `.suppressed` in `nativeStrings` mode →
+  `emitExternrefBackedOwnFieldRead`.
+- `src/codegen/disposable-runtime.ts` — `reserveDisposableStackDisposeDriver`
+  pre-registers the object runtime + `$Error_struct` + key strings (compile
+  time, so the finalize-time fill can resolve them); the fill wraps each
+  disposer in try/catch, aggregates, and rethrows.
+
+## Test plan
+
+`tests/issue-3234-standalone-suppressederror.test.ts` — 3-error LIFO nesting
+(matches test262 `throws-suppressederror-if-multiple-errors-during-disposal`),
+single-error-as-is, run-every-disposer, 2-error aggregation, no-host-leak, host
+lane unchanged. All green; the 20 existing #3231 tests still pass (incl. the
+host-lane byte-identity gate).
+
+## Measured flip-count (honest)
+
+**0 immediate test262 standalone flips.** This is a correct host-free
+**prerequisite**, not itself a flip lever, because:
+
+- The `built-ins/DisposableStack/prototype/dispose` SuppressedError tests
+  (`throws-suppressederror…`, `throws-error-as-is…`) are blocked UPSTREAM: the
+  test262 runner hoists a nested-closure-captured `var stack` to `let stack:
+any`, and native DisposableStack method dispatch keys on
+  `className === "DisposableStack"` (`expressions/extern.ts:133`), which fails
+  on an `any`-typed receiver → `stack.defer(fn)` / `stack.dispose()` leak
+  `DisposableStack_defer` + `__make_callback` BEFORE dispose even runs. That is
+  a separate **any-receiver builtin-native dispatch** gap (see follow-up),
+  distinct from #2151 (which closed only object-literal any-receiver dispatch).
+  `throws-suppressederror…` also fails in HOST mode (a runner assert-harness
+  artifact), so it is un-passable in the runner regardless.
+- The `built-ins/SuppressedError` tests that pass standalone (7/22) are
+  descriptor-only (`name`, `prop-desc`, `prototype/*`) and pass pre-existing via
+  #2861 proto glue — they exercise none of this change's paths. The 12 failing
+  ones need native `new SuppressedError` construction (out of scope).
+
+The aggregation is verified byte-for-byte correct against the exact test262
+assertion sequence (the 3-error body returns 31 = all five asserts). Once
+any-receiver builtin dispatch lands, the dispose SuppressedError cluster flips.

--- a/src/codegen/builtin-tags.ts
+++ b/src/codegen/builtin-tags.ts
@@ -58,6 +58,11 @@ export const BUILTIN_TYPE_TAGS = {
   EvalError: -15,
   ReferenceError: -16,
   AggregateError: -17,
+  // (#3234) SuppressedError (ES2026 error aggregation) — an Error subclass; its
+  // native `$Error_struct` carries this tag so `instanceof SuppressedError` and
+  // `instanceof Error` discriminate host-free (the DisposableStack dispose driver
+  // builds SuppressedError instances natively for multi-error aggregation).
+  SuppressedError: -18,
 
   // Keyed collections
   Map: -20,
@@ -118,6 +123,7 @@ const BUILTIN_PARENT: Partial<Record<BuiltinTypeName, BuiltinTypeName>> = {
   EvalError: "Error",
   ReferenceError: "Error",
   AggregateError: "Error",
+  SuppressedError: "Error",
 };
 
 /**

--- a/src/codegen/disposable-runtime.ts
+++ b/src/codegen/disposable-runtime.ts
@@ -39,12 +39,15 @@ import { ts } from "../ts-api.js";
 import type { Instr, ValType, StructTypeDef, ArrayTypeDef } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
-import { addFuncType } from "./registry/types.js";
+import { addFuncType, getOrRegisterErrorStructType } from "./registry/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { buildThrowJsErrorInstrs } from "./js-errors.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureLateImport, flushLateImportShifts, VOID_RESULT } from "./shared.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { BUILTIN_TYPE_TAGS } from "./builtin-tags.js";
 
 const EXTERNREF: ValType = { kind: "externref" };
 const I32: ValType = { kind: "i32" };
@@ -387,6 +390,16 @@ export function reserveDisposableStackDisposeDriver(ctx: CodegenContext): number
   const existing = ctx.funcMap.get(DISPOSE_DRIVER);
   if (existing !== undefined) return existing;
   ensureDisposableStackTypes(ctx);
+  // (#3234) SuppressedError multi-error aggregation: the dispose driver wraps a
+  // second+ disposer throw into a native `$Error_struct` (SuppressedError tag)
+  // whose `error`/`suppressed` fields live on the `$props` open-object backing.
+  // Ensure the object runtime (`__new_plain_object`/`__extern_set`), the
+  // `$Error_struct` type, and the interned key/name strings NOW (compile time) so
+  // the finalize-time `fillDisposableStackDisposeDriver` can resolve them (adding
+  // them at finalize is unsafe — object-runtime registration runs during compile).
+  ensureObjectRuntime(ctx);
+  getOrRegisterErrorStructType(ctx);
+  for (const s of ["error", "suppressed", "SuppressedError", ""]) addStringConstantGlobal(ctx, s);
   const typeIdx = addFuncType(ctx, [EXTERNREF], []);
   const funcIdx = mintDefinedFunc(ctx);
   ctx.funcMap.set(DISPOSE_DRIVER, funcIdx);
@@ -429,18 +442,36 @@ export function fillDisposableStackDisposeDriver(ctx: CodegenContext): void {
   // order: 2560 < 2621), so a `use()` module has it. Resolve by name.
   const callFnMethod0 = ctx.funcMap.get("__call_fn_method_0");
 
+  // (#3234) SuppressedError aggregation dependencies (pre-registered at reserve).
+  const exnTag = ensureExnTag(ctx);
+  const errStructIdx = getOrRegisterErrorStructType(ctx);
+  const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
+  const externSetIdx = ctx.funcMap.get("__extern_set");
+  const canAggregate = newPlainObjIdx !== undefined && externSetIdx !== undefined;
+
   const STACK = 0,
     DS = 0 + 1,
     ENTRIES = 2,
     I = 3,
     ENTRY = 4,
-    KIND = 5;
+    KIND = 5,
+    // (#3234) aggregation slots: PENDING = accumulated completion error, HASPENDING
+    // its presence flag (`throw null`/`throw undefined` are still throws), CUR the
+    // just-caught error, PROPS the SuppressedError `$props` scratch.
+    PENDING = 6,
+    HASPENDING = 7,
+    CUR = 8,
+    PROPS = 9;
   driverFn.locals = [
     { name: "__ds", type: stackRefNull(ctx) },
     { name: "__entries", type: { kind: "ref_null", typeIdx: t.entriesTypeIdx } },
     { name: "__i", type: I32 },
     { name: "__entry", type: { kind: "ref_null", typeIdx: t.entryTypeIdx } },
     { name: "__kind", type: I32 },
+    { name: "__pending", type: EXTERNREF },
+    { name: "__haspending", type: I32 },
+    { name: "__cur", type: EXTERNREF },
+    { name: "__props", type: EXTERNREF },
   ];
 
   const body: Instr[] = [];
@@ -511,19 +542,76 @@ export function fillDisposableStackDisposeDriver(ctx: CodegenContext): void {
   const deferCall: Instr[] =
     callFn0 !== undefined ? [...entryCb(), { op: "call", funcIdx: callFn0 } as Instr, { op: "drop" } as Instr] : [];
   // if kind == USE → useCall; else if kind == ADOPT → adoptCall; else deferCall.
-  dispatch.push({ op: "local.get", index: KIND } as Instr);
-  dispatch.push({ op: "i32.const", value: ENTRY_KIND_USE } as Instr);
-  dispatch.push({ op: "i32.eq" } as Instr);
+  const invokeSwitch: Instr[] = [
+    { op: "local.get", index: KIND } as Instr,
+    { op: "i32.const", value: ENTRY_KIND_USE } as Instr,
+    { op: "i32.eq" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: useCall,
+      else: [
+        { op: "local.get", index: KIND } as Instr,
+        { op: "i32.const", value: ENTRY_KIND_ADOPT } as Instr,
+        { op: "i32.eq" } as Instr,
+        { op: "if", blockType: { kind: "empty" }, then: adoptCall, else: deferCall } as Instr,
+      ],
+    } as Instr,
+  ];
+  // (#3234) Run EVERY disposer even if a prior threw (§ DisposeResources). Wrap the
+  // invocation in try/catch on the module exception tag ($exn carries the thrown
+  // externref); Wasm traps are not catchable and there is no JS host to raise a
+  // foreign exception standalone, so a single-tag catch is complete (no catch_all).
+  // On the FIRST caught error: pending = err. On each SUBSEQUENT: pending =
+  // SuppressedError{ error: newer, suppressed: prior } (LIFO nesting).
+  const buildSuppressedError: Instr[] = canAggregate
+    ? [
+        // props = __new_plain_object(); props.error = cur; props.suppressed = pending
+        { op: "call", funcIdx: newPlainObjIdx! } as Instr,
+        { op: "local.set", index: PROPS } as Instr,
+        { op: "local.get", index: PROPS } as Instr,
+        ...stringConstantExternrefInstrs(ctx, "error"),
+        { op: "local.get", index: CUR } as Instr,
+        { op: "call", funcIdx: externSetIdx! } as Instr,
+        { op: "local.get", index: PROPS } as Instr,
+        ...stringConstantExternrefInstrs(ctx, "suppressed"),
+        { op: "local.get", index: PENDING } as Instr,
+        { op: "call", funcIdx: externSetIdx! } as Instr,
+        // pending = struct.new $Error_struct{ tag, message "", name, stack null, userClassId -1, props }
+        { op: "i32.const", value: BUILTIN_TYPE_TAGS.SuppressedError } as Instr,
+        ...stringConstantExternrefInstrs(ctx, ""),
+        ...stringConstantExternrefInstrs(ctx, "SuppressedError"),
+        { op: "ref.null.extern" } as Instr,
+        { op: "i32.const", value: -1 } as Instr,
+        { op: "local.get", index: PROPS } as Instr,
+        { op: "struct.new", typeIdx: errStructIdx } as Instr,
+        { op: "extern.convert_any" } as Instr,
+        { op: "local.set", index: PENDING } as Instr,
+      ]
+    : // Object runtime unavailable (should not happen — reserved at compile time):
+      // degrade to last-error-wins so the module stays valid Wasm.
+      [{ op: "local.get", index: CUR } as Instr, { op: "local.set", index: PENDING } as Instr];
+  const catchHandler: Instr[] = [
+    { op: "local.set", index: CUR } as Instr,
+    { op: "local.get", index: HASPENDING } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: buildSuppressedError,
+      else: [
+        { op: "local.get", index: CUR } as Instr,
+        { op: "local.set", index: PENDING } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: "local.set", index: HASPENDING } as Instr,
+      ],
+    } as Instr,
+  ];
   dispatch.push({
-    op: "if",
+    op: "try",
     blockType: { kind: "empty" },
-    then: useCall,
-    else: [
-      { op: "local.get", index: KIND } as Instr,
-      { op: "i32.const", value: ENTRY_KIND_ADOPT } as Instr,
-      { op: "i32.eq" } as Instr,
-      { op: "if", blockType: { kind: "empty" }, then: adoptCall, else: deferCall } as Instr,
-    ],
+    body: invokeSwitch,
+    catches: [{ tagIdx: exnTag, body: catchHandler }],
+    catchAll: undefined,
   } as Instr);
   loopBody.push({ op: "if", blockType: { kind: "empty" }, then: dispatch, else: [] } as Instr);
   // i = i - 1; continue
@@ -538,6 +626,16 @@ export function fillDisposableStackDisposeDriver(ctx: CodegenContext): void {
     op: "block",
     blockType: { kind: "empty" },
     body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  // (#3234) After all disposers ran: if any error was accumulated, rethrow the
+  // final completion (the outermost SuppressedError, or the single error as-is).
+  body.push({ op: "local.get", index: HASPENDING } as Instr);
+  body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "local.get", index: PENDING } as Instr, { op: "throw", tagIdx: exnTag } as Instr],
+    else: [],
   } as Instr);
 
   driverFn.body = body;

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -67,6 +67,10 @@ function collectErrorInstanceOfTags(ctorName: string): number[] {
     "EvalError",
     "ReferenceError",
     "AggregateError",
+    // (#3234) SuppressedError is an Error subclass (BUILTIN_PARENT). Included so
+    // `instanceof SuppressedError` matches its own tag, and `instanceof Error`
+    // also matches a native SuppressedError (built by the dispose driver).
+    "SuppressedError",
   ] as const;
   const tags: number[] = [];
   for (const n of errorNames) {
@@ -1773,7 +1777,16 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   // tags compatible with `ctorName`. No `__instanceof` host import.
   // (#1536c) `userErrorParent` extends this to externref-backed user Error
   // subclasses.
-  if (noJsHost(ctx) && (ctorName === "Error" || isWasiErrorName(ctorName) || userErrorParent !== undefined)) {
+  if (
+    noJsHost(ctx) &&
+    (ctorName === "Error" ||
+      isWasiErrorName(ctorName) ||
+      // (#3234) SuppressedError is not in WASI_ERROR_NAMES (its ctor arity/args
+      // differ), but its native `$Error_struct` carries the SuppressedError tag,
+      // so the field-0 tag check answers `instanceof SuppressedError` host-free.
+      ctorName === "SuppressedError" ||
+      userErrorParent !== undefined)
+  ) {
     const structIdx = getOrRegisterErrorStructType(ctx);
     // (#2188) When the RHS is a *user* Error subclass, sibling subclasses share
     // the same builtin parent `$tag`, so the builtin-tag check (field 0) cannot

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -6847,6 +6847,17 @@ function compileExternPropertyGet(
     if (disposedResult !== undefined) return disposedResult as ValType;
   }
 
+  // (#3234) Native SuppressedError `.error` / `.suppressed` reads in standalone /
+  // nativeStrings mode → read from the `$Error_struct.$props` (fieldIdx 5) backing
+  // object (where the dispose driver stores them via `__extern_set`) instead of the
+  // `SuppressedError_get_error` / `SuppressedError_get_suppressed` host imports.
+  // Identity-preserving: the stored externref is returned verbatim, so
+  // `se.error === originalError` holds via `ref.eq`.
+  if (className === "SuppressedError" && (propName === "error" || propName === "suppressed") && ctx.nativeStrings) {
+    const ownFieldResult = emitExternrefBackedOwnFieldRead(ctx, fctx, expr, propName);
+    if (ownFieldResult !== undefined) return ownFieldResult;
+  }
+
   // Walk inheritance chain to find the class that declares the property
   const resolvedInfo = findExternInfoForMember(ctx, className, propName, "property");
   const propOwner = resolvedInfo ?? ctx.externClasses.get(className);

--- a/tests/issue-3234-standalone-suppressederror.test.ts
+++ b/tests/issue-3234-standalone-suppressederror.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3234 — Wasm-native SuppressedError multi-error aggregation in the standalone
+// DisposableStack dispose driver (#3231 Phase 1b follow-up). When more than one
+// disposer throws, `dispose()` must run EVERY disposer and chain the errors into
+// nested native SuppressedError instances (LIFO: `.error` = the newer error,
+// `.suppressed` = the accumulated prior), then rethrow the aggregate — host-free.
+//
+// Also makes `instanceof SuppressedError` and the `.error`/`.suppressed`
+// accessors resolve natively (no `SuppressedError_get_error` / `__instanceof`
+// host imports) via the SuppressedError builtin tag + `$Error_struct.$props`.
+
+// Any leak of these host imports means the SuppressedError path is not native.
+const HOST_LEAK_RE =
+  /DisposableStack_|__make_callback|SuppressedError_get|__new_SuppressedError|__instanceof|__get_caught_exception/;
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const leaks = r.imports.map((i) => `${i.module}::${i.name}`).filter((n) => HOST_LEAK_RE.test(n));
+  expect(leaks).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+async function importsOf(src: string): Promise<string[]> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  return r.imports.map((i) => `${i.module}::${i.name}`);
+}
+
+describe("#3234 standalone SuppressedError aggregation", () => {
+  it("nests multiple disposer errors into SuppressedError (LIFO, spec §DisposeResources)", async () => {
+    // 3 defers, each throws. LIFO: d3(error3) first, d2(error2), d1(error1) last.
+    // Aggregate = SuppressedError{error: error1, suppressed: SuppressedError{error: error2, suppressed: error3}}.
+    // code bits: 1=instanceof, 2=e.error===error1, 4=e.suppressed instanceof SE,
+    //            8=inner.error===error2, 16=inner.suppressed===error3 → 31.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          class MyError extends Error {}
+          const error1 = new MyError();
+          const error2 = new MyError();
+          const error3 = new MyError();
+          const stack = new DisposableStack();
+          stack.defer(() => { throw error1; });
+          stack.defer(() => { throw error2; });
+          stack.defer(() => { throw error3; });
+          let code = 0;
+          try { stack.dispose(); code = 100; }
+          catch (e) {
+            if (e instanceof SuppressedError) code += 1;
+            const se = e as SuppressedError;
+            if (se.error === error1) code += 2;
+            if (se.suppressed instanceof SuppressedError) code += 4;
+            const inner = se.suppressed as SuppressedError;
+            if (inner.error === error2) code += 8;
+            if (inner.suppressed === error3) code += 16;
+          }
+          return code;
+        }`),
+    ).toBe(31);
+  });
+
+  it("rethrows a single disposal error as-is (not wrapped in SuppressedError)", async () => {
+    // 2=e===error1 (identity preserved); +1 would mean wrongly wrapped.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          class MyError extends Error {}
+          const error1 = new MyError();
+          const stack = new DisposableStack();
+          stack.defer(() => { throw error1; });
+          let code = 0;
+          try { stack.dispose(); code = 100; }
+          catch (e) {
+            if (e instanceof SuppressedError) code += 1;
+            if (e === error1) code += 2;
+          }
+          return code;
+        }`),
+    ).toBe(2);
+  });
+
+  it("runs every disposer even when a prior one throws", async () => {
+    // d2 throws but d1 must still run (it flips `ran`). LIFO: d2 first (throws),
+    // then d1 (sets ran=1). Aggregate rethrown; caught. Expect ran=1.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          let ran = 0;
+          const e2 = new Error();
+          const stack = new DisposableStack();
+          stack.defer(() => { ran = 1; });      // pushed first -> runs LAST
+          stack.defer(() => { throw e2; });     // pushed second -> runs FIRST, throws
+          try { stack.dispose(); } catch (e) {}
+          return ran;
+        }`),
+    ).toBe(1);
+  });
+
+  it("aggregates two errors: outermost .error is the last-run disposer's error", async () => {
+    // defer(e1) first, defer(e2) second. LIFO: e2 runs first, e1 last.
+    // Aggregate = SuppressedError{error: e1, suppressed: e2}. 1+2+4 = 7.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          class MyError extends Error {}
+          const e1 = new MyError();
+          const e2 = new MyError();
+          const stack = new DisposableStack();
+          stack.defer(() => { throw e1; });
+          stack.defer(() => { throw e2; });
+          let code = 0;
+          try { stack.dispose(); }
+          catch (e) {
+            if (e instanceof SuppressedError) code += 1;
+            const se = e as SuppressedError;
+            if (se.error === e1) code += 2;
+            if (se.suppressed === e2) code += 4;
+          }
+          return code;
+        }`),
+    ).toBe(7);
+  });
+
+  it("emits no SuppressedError / instanceof / DisposableStack host imports", async () => {
+    const imports = await importsOf(`
+      export function f(): number {
+        class MyError extends Error {}
+        const e1 = new MyError();
+        const e2 = new MyError();
+        const stack = new DisposableStack();
+        stack.defer(() => { throw e1; });
+        stack.defer(() => { throw e2; });
+        try { stack.dispose(); } catch (e) {
+          if (e instanceof SuppressedError) { const se = e as SuppressedError; return (se.error === e1 ? 1 : 0) + (se.suppressed === e2 ? 2 : 0); }
+        }
+        return 0;
+      }`);
+    expect(imports.filter((n) => HOST_LEAK_RE.test(n))).toEqual([]);
+  });
+});
+
+describe("#3234 host lane unchanged", () => {
+  it("gc/host mode still routes DisposableStack / SuppressedError through host imports", async () => {
+    const r = await compile(
+      `export function f(): number {
+        const e1 = new Error();
+        const stack = new DisposableStack();
+        stack.defer(() => { throw e1; });
+        try { stack.dispose(); } catch (e) { if (e instanceof SuppressedError) return 1; }
+        return 0;
+      }`,
+      { target: "gc" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // Host mode keeps the host-import contract (no native dispose driver).
+    const names = r.imports.map((i) => `${i.module}::${i.name}`);
+    expect(names.some((n) => /DisposableStack_/.test(n))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Native, host-free **SuppressedError multi-error aggregation** for the standalone `DisposableStack` dispose driver — the top documented #3231 Phase 1b follow-up.

The dispose driver (`fillDisposableStackDisposeDriver`) ran disposers LIFO **without** try/catch, so the first throw unwound out of `dispose()` and skipped the rest. Per §DisposeResources it now runs **every** disposer and nests multiple throws into native `SuppressedError` instances (LIFO-with-suppression: `.error` = the newer error, `.suppressed` = the accumulated prior), then rethrows the aggregate. A single error is rethrown as-is.

Also resolves, host-free (were leaking `__instanceof` / `SuppressedError_get_error` / `SuppressedError_get_suppressed`):
- `instanceof SuppressedError` (and `instanceof Error` for a SuppressedError) via a new `BUILTIN_TYPE_TAGS.SuppressedError` (−18) tag check.
- `.error` / `.suppressed` reads via the `$Error_struct.$props` backing (`emitExternrefBackedOwnFieldRead`, the #2101a / #3137 pattern) — identity-preserving (`ref.eq`).

## Changes
- `src/codegen/builtin-tags.ts` — SuppressedError tag + `BUILTIN_PARENT → Error`.
- `src/codegen/expressions/identifiers.ts` — error-family `instanceof` gate + tag set recognise SuppressedError (NOT added to `WASI_ERROR_NAMES`; its ctor arity differs, the tag check is all `instanceof` needs).
- `src/codegen/property-access.ts` — `compileExternPropertyGet` intercepts `.error`/`.suppressed` in `nativeStrings` mode.
- `src/codegen/disposable-runtime.ts` — reserve pre-registers object runtime + `$Error_struct` + key strings; fill wraps each disposer in `try`/`catch $exn`, aggregates inline, rethrows via the module `$exn` tag.

All `standalone`/`nativeStrings`-gated. **Host lane byte-identical** — the 20 existing #3231 tests pass including the host-lane byte-identity gate.

## Tests
`tests/issue-3234-standalone-suppressederror.test.ts` (6 tests, all green): 3-error LIFO nesting (matches test262 `throws-suppressederror-if-multiple-errors-during-disposal` — body returns 31 = all 5 asserts), single-error-as-is, run-every-disposer, 2-error aggregation, no-host-leak, host lane unchanged.

## Measured flip-count (honest)
**0 immediate test262 standalone flips** — this is a correct host-free **prerequisite**, not itself a flip lever:
- The `built-ins/DisposableStack/prototype/dispose` SuppressedError tests are blocked **upstream**: the test262 runner hoists a nested-closure-captured `var stack` to `let stack: any`, and native DisposableStack method dispatch keys on `className === "DisposableStack"` (`expressions/extern.ts:133`), which fails on an `any` receiver → `stack.defer(fn)` leaks `DisposableStack_defer` + `__make_callback` before dispose even runs. That is a separate **any-receiver builtin-native dispatch** gap (follow-up), distinct from #2151 (object-literal any-receiver, done). `throws-suppressederror…` also fails in HOST mode (a runner assert-harness artifact).
- The `built-ins/SuppressedError` tests passing standalone (7/22) are descriptor-only and pre-existing via #2861; the 12 failing need native `new SuppressedError` construction (out of scope).

Once any-receiver builtin dispatch lands, the dispose SuppressedError cluster flips. NET-safe (additive, gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8