### PR TITLE
fix(#3238): native `class Sub extends Object` ctor in standalone (drop __new_Object host leak)

### DIFF
--- a/plan/issues/3238-standalone-subclass-object-native-ctor.md
+++ b/plan/issues/3238-standalone-subclass-object-native-ctor.md
@@ -11,6 +11,9 @@ feasibility: hard
 goal: standalone-mode
 umbrella: 1781
 related: [56, 3053, 1536, 2902]
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
+  - src/codegen/class-bodies.ts
 ---
 
 ## Problem

--- a/plan/issues/3238-standalone-subclass-object-native-ctor.md
+++ b/plan/issues/3238-standalone-subclass-object-native-ctor.md
@@ -1,8 +1,9 @@
 ---
 id: 3238
 title: "Standalone: native constructor for `class extends Object` (drop __new_Object host leak)"
-status: in-progress
+status: done
 assignee: opus-leak2
+completed: 2026-07-13
 sprint: current
 priority: high
 horizon: m

--- a/plan/issues/3238-standalone-subclass-object-native-ctor.md
+++ b/plan/issues/3238-standalone-subclass-object-native-ctor.md
@@ -1,0 +1,86 @@
+---
+id: 3238
+title: "Standalone: native constructor for `class extends Object` (drop __new_Object host leak)"
+status: in-progress
+assignee: opus-leak2
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+goal: standalone-mode
+umbrella: 1781
+related: [56, 3053, 1536, 2902]
+---
+
+## Problem
+
+Under `--target standalone`, `class Sub extends Object { … }` lowers the parent
+construction (`super()` / implicit default derived ctor) to a host import
+`env::__new_Object`. Standalone has no JS host, so the import leaks: the module
+still *passes* (a host shim satisfies the import in the test harness), but it is
+counted as a host-import leak, not `host_free_pass`.
+
+Re-ranking the fresh standalone baseline (2026-07-13, 4,231 leaky passes) showed
+the bounded declared-but-uncalled GATE seam (the #3016 pattern) is **exhausted**
+(0 gates / 200 sampled leaky passes — every leak genuinely calls its import).
+The next lever is **substrate**: the biggest distinct, non-excluded, non-deferred
+cluster is `__new_*` subclass-builtins (49 sole-import host-free flips). This
+issue takes the **first per-builtin slice: `Object`** (4 flips), which builds
+directly on the existing native `$Object` / `__new_plain_object` substrate
+(#56 native $Object alloc + subclass proto/brand/instanceof; #3053 substrate).
+
+Affected tests (sole import `env::__new_Object`):
+- `language/statements/class/subclass-builtins/subclass-Object.js`
+- `language/expressions/class/subclass-builtins/subclass-Object.js`
+- `language/statements/class/subclass/builtin-objects/Object/replacing-prototype.js`
+- `language/expressions/delete/super-property.js` (explicit `super()` + `delete super.x`)
+
+## Root cause
+
+`src/codegen/class-bodies.ts` lowers builtin-parent construction to
+`ensureLateImport(ctx, "__new_<Parent>", …)` at two sites:
+- **implicit** default derived ctor (externref-backed, no user ctor) — ~L1769
+- **explicit** `super(...)` in a user ctor — ~L2928
+
+For the Error family, #1536c/#2902 already special-case
+`(ctx.wasi || ctx.standalone) && isWasiErrorName(parent)` → `emitWasiErrorConstructor`
+(a native `$Error_struct` builder, no host import). `Object` had no such native
+path, so it fell through to the leaking `ensureLateImport`.
+
+## Fix
+
+Per §20.1.1.1 `Object ( [ value ] )`: when NewTarget is a subclass (neither
+undefined nor `%Object%`), the `value` argument is **ignored** and the result is
+`OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")` — a fresh
+ordinary object whose [[Prototype]] is the subclass's prototype. So routing
+`super(value)` to a fresh native plain object (`__new_plain_object()`) and then
+letting the existing `emitSetSubclassProto` / `emitSetSubclassUserBrand` fix the
+prototype/brand is **spec-correct** (arg side effects are still evaluated at the
+call site, then dropped inside the native ctor).
+
+New helper `emitStandaloneObjectConstructor(ctx, argCount)` in
+`src/codegen/object-runtime.ts`:
+- idempotent on `__new_Object`
+- `ensureObjectRuntime(ctx)` (registers `__new_plain_object`)
+- registers a defined func `__new_Object : (externref × argCount) -> externref`
+  whose body ignores its params and tail-returns `call __new_plain_object`
+
+Both call sites gain a branch **before** the `ensureLateImport` fallback:
+`else if ((ctx.wasi || ctx.standalone) && parentName === "Object")` →
+`emitStandaloneObjectConstructor(ctx, arity); funcIdx = ctx.funcMap.get("__new_Object")`.
+
+## Constraints
+
+- **Host/gc lane byte-identical** — the new branch is gated on
+  `ctx.standalone || ctx.wasi`; host mode keeps the `__new_Object` import.
+- **NET ≥ 0** — Object-subclass tests currently leak (not host-free), so they
+  can only flip to host-free or stay; verify no standalone floor regression.
+- First per-builtin slice only. Follow-ups (per coordinator): RegExp/Array/
+  Function/Date/AggregateError/TypedArray as separate PRs building on the same
+  substrate.
+
+## Acceptance
+
+- The 4 `__new_Object`-sole tests compile host-free (no `env::__new_Object`) and
+  still pass.
+- Scoped standalone sweep shows no regression.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -55,6 +55,7 @@ import type { StringBuilderPresizeInfo } from "./string-builder.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { emitWasiErrorConstructor, getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
+import { emitStandaloneObjectConstructor } from "./object-runtime.js"; // (#3238) native `class Sub extends Object`
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
   cacheParamDefaultArgc,
@@ -1769,6 +1770,12 @@ function compileClassBodiesInner(
         if ((ctx.wasi || ctx.standalone) && isWasiErrorName(parentName)) {
           emitWasiErrorConstructor(ctx, parentName, implicitForwarderArity);
           funcIdx = ctx.funcMap.get(importName);
+        } else if ((ctx.wasi || ctx.standalone) && parentName === "Object") {
+          // (#3238) `class Sub extends Object` — construct a fresh native plain
+          // object instead of leaking the `env::__new_Object` host import. The
+          // subclass proto/brand fixups below re-point [[Prototype]].
+          emitStandaloneObjectConstructor(ctx, implicitForwarderArity);
+          funcIdx = ctx.funcMap.get(importName);
         } else {
           funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
           flushLateImportShifts(ctx, fctx);
@@ -2948,6 +2955,12 @@ export function compileSuperCall(
     let funcIdx: number | undefined;
     if ((ctx.wasi || ctx.standalone) && isWasiErrorName(builtinParent)) {
       emitWasiErrorConstructor(ctx, builtinParent, forwardArity);
+      funcIdx = ctx.funcMap.get(importName);
+    } else if ((ctx.wasi || ctx.standalone) && builtinParent === "Object") {
+      // (#3238) Explicit `super(...)` in a `class Sub extends Object` ctor —
+      // native fresh plain object, no `env::__new_Object` leak. Arg side
+      // effects are still evaluated below and passed as (ignored) params.
+      emitStandaloneObjectConstructor(ctx, forwardArity);
       funcIdx = ctx.funcMap.get(importName);
     } else {
       funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -189,6 +189,51 @@ export interface ObjectRuntimeTypes {
  * instead of `__obj_hash`, 146 invalid-Wasm test262 binaries). So we end any
  * pending batch first; registration then happens in a clean, final regime.
  */
+/**
+ * (#3238) Standalone/WASI-native `class Sub extends Object` construction.
+ *
+ * `super()` / the implicit default derived constructor of an `Object` subclass
+ * lowers the parent creation to a `__new_Object` host import (see the two
+ * `ensureLateImport(ctx, "__new_<Parent>", …)` sites in class-bodies.ts). In
+ * standalone mode there is no JS host to satisfy it, so the import leaks even
+ * though the module still passes — the sole remaining host import of the
+ * `subclass-Object` conformance cluster.
+ *
+ * Per §20.1.1.1 `Object ( [ value ] )`: when NewTarget is a subclass (neither
+ * undefined nor the `%Object%` intrinsic itself), the `value` argument is
+ * IGNORED and the result is `OrdinaryCreateFromConstructor(NewTarget,
+ * "%Object.prototype%")` — a fresh ordinary object whose [[Prototype]] is the
+ * subclass's prototype. The caller already re-points the prototype and brand
+ * via `emitSetSubclassProto` / `emitSetSubclassUserBrand`, so constructing a
+ * fresh native plain object here (and letting those run) is spec-correct.
+ * Argument side effects are still evaluated at the call site (then passed as
+ * this function's — ignored — params), preserving §13.3.7.1
+ * ArgumentListEvaluation ordering.
+ *
+ * Emits an in-module `__new_Object : (externref × argCount) -> externref` whose
+ * body ignores its params and tail-returns `call __new_plain_object`. Idempotent
+ * on `__new_Object`. Host/gc mode never calls this — it keeps the import.
+ */
+export function emitStandaloneObjectConstructor(ctx: CodegenContext, argCount: number): void {
+  if (ctx.funcMap.has("__new_Object")) return;
+
+  // Guarantee the native plain-object substrate is registered (registers
+  // `__new_plain_object` as a DEFINED func; idempotent).
+  ensureObjectRuntime(ctx);
+  const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object");
+  if (newPlainObjectIdx === undefined) return; // defensive: substrate unavailable
+
+  const params: ValType[] = Array.from({ length: argCount }, () => ({ kind: "externref" }) as ValType);
+  const typeIdx = addFuncType(ctx, params, [{ kind: "externref" }], "__new_Object_type");
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__new_Object", funcIdx);
+  // Ignore the (already side-effect-evaluated) constructor arguments and return
+  // a fresh native plain object. `return_call` keeps the tail position so no
+  // extra frame is retained.
+  const body: Instr[] = [{ op: "return_call", funcIdx: newPlainObjectIdx } as Instr];
+  pushDefinedFunc(ctx, funcIdx, { name: "__new_Object", typeIdx, locals: [], body, exported: false });
+}
+
 export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   if (ctx.objectRuntimeTypes) return ctx.objectRuntimeTypes;
 


### PR DESCRIPTION
## Problem

Under `--target standalone`, `class Sub extends Object { … }` lowered parent
construction (`super()` / the implicit default derived ctor) to a leaking
`env::__new_Object` host import — the **sole** remaining host import of the
subclass-`Object` conformance cluster (4 leaky passes flip host-free).

Context: re-ranking the fresh standalone baseline (2026-07-13, 4,231 leaky
passes) showed the bounded declared-but-uncalled GATE seam (#3016 pattern) is
**exhausted** (0 gates / 200 sampled). The next lever is substrate; the biggest
distinct non-excluded cluster is `__new_*` subclass-builtins (49 sole-import
flips). This is the **first per-builtin slice: `Object`**, building on the
existing native `$Object` / `__new_plain_object` substrate (#56, #3053).

## Fix

Per §20.1.1.1 `Object ( [ value ] )`: when NewTarget is a subclass (neither
undefined nor the `%Object%` intrinsic), the `value` argument is **ignored** and
the result is `OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%")` —
a fresh ordinary object with the subclass's prototype. The callers already
re-point proto/brand (`emitSetSubclassProto` / `emitSetSubclassUserBrand`), so
constructing a fresh native plain object is spec-correct; arg side effects are
still evaluated at the call site (then passed as ignored params).

- **`emitStandaloneObjectConstructor`** (`object-runtime.ts`): idempotent;
  `ensureObjectRuntime` + register an in-module `__new_Object : (externref×n) ->
  externref` whose body ignores its params and tail-returns
  `call __new_plain_object`.
- **`class-bodies.ts`** — both `__new_<Parent>` sites (implicit default derived
  ctor ~L1769, explicit `super()` ~L2928) gain a
  `(ctx.wasi || ctx.standalone) && parent === "Object"` branch **before** the
  leaking `ensureLateImport` fallback, mirroring the existing Error-family
  `emitWasiErrorConstructor` special-case (#1536c/#2902).

## Safety

- **Host/gc lane byte-identical** — the new branch is gated on
  `ctx.standalone || ctx.wasi`; host mode keeps the `__new_Object` import path
  unchanged.
- **NET ≥ 0** — the affected tests currently *leak* (not host-free), so they can
  only flip host-free or stay; no host-free Object-subclass exists today to
  regress.

## Verification

The 4 sole-`__new_Object` tests compile host-free (no `env::__new_Object`) and
pass at runtime:
- `language/{statements,expressions}/class/subclass-builtins/subclass-Object.js`
- `language/statements/class/subclass/builtin-objects/Object/replacing-prototype.js`
- `language/expressions/delete/super-property.js` (explicit `super()` +
  `delete super.x` ReferenceError preserved)

Scoped standalone sweep (100 class-subclass + Object.prototype tests): no new
compile failures — every CFAIL is a pre-existing standalone refusal for a
host-constructible builtin (Number/Set/Map/WeakMap/Boolean, `__get_builtin`),
untouched by this change.

Follow-ups (separate PRs, same substrate): RegExp/Array/Function/Date/
AggregateError/TypedArray subclass constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8