### PR TITLE
fix(#3237): any-receiver dispatch for native DisposableStack dispose/disposed (Slice 1)

### DIFF
--- a/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
+++ b/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
@@ -1,0 +1,93 @@
+---
+id: 3237
+title: "Standalone: any-receiver dispatch for builtin-native methods (DisposableStack/Map/Set/…) leaks host imports"
+status: ready
+created: 2026-07-13
+updated: 2026-07-13
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: methods, dynamic-dispatch, disposablestack
+goal: standalone
+related: [2151, 3231, 3234]
+umbrella: 1781
+---
+
+# Standalone: any-receiver dispatch for builtin-native methods leaks host imports
+
+## Problem
+
+Native builtin-runtime method dispatch is keyed on the receiver's **static
+class name**, so a call on an `any`/externref receiver never takes the native
+path and leaks the host import — which is unsatisfiable standalone, so the whole
+module fails to instantiate.
+
+Concretely for `DisposableStack` (`src/codegen/expressions/extern.ts:133`):
+
+```ts
+if (className === "DisposableStack" && ctx.nativeStrings) {
+  const dsResult = tryCompileNativeDisposableStackMethodCall(...);
+}
+```
+
+`className` comes from the receiver's TS type. When the receiver is `any`
+(e.g. `let s: any = new DisposableStack(); s.defer(fn); s.dispose();`), the
+native arm is skipped and `s.defer(fn)` / `s.dispose()` lower to
+`DisposableStack_defer` + `__make_callback` / `DisposableStack_dispose` host
+imports.
+
+This is why the `built-ins/DisposableStack/prototype/dispose` **SuppressedError**
+tests (and any dispose/defer test whose `stack` the test262 runner hoists to
+`let stack: any` because it is captured in a nested closure like
+`assert.throws(() => stack.dispose())`) still fail standalone even though the
+native dispose driver + #3234 SuppressedError aggregation are correct — the leak
+happens **before** dispose runs. This is the real ~7-flip lever the #3234 work
+was a prerequisite for.
+
+## Distinct from #2151
+
+#2151 (DONE) closed any-receiver dispatch for **user object-literal closed
+structs** (`const o: any = { next() {…} }; o.next()`). This issue is the
+**builtin-native runtime** analog: the receiver is an externref-carried native
+struct (`$DisposableStack`, and likely `$Map`/`$Set`/…) whose methods are
+intercepted by a `className ===` gate, not the generic object-literal method
+path. The two do not overlap.
+
+## Scope (likely broader than DisposableStack)
+
+Any native-method dispatch that keys on `className ===` for a builtin (grep
+`expressions/extern.ts` + `property-access.ts` for the `className === "<Builtin>"
+&& ctx.nativeStrings` arms — Map `.size`, Set `.size`, DisposableStack
+`disposed`/`defer`/`adopt`/`use`/`move`/`dispose`, …). An `any`-typed receiver
+should still reach the native path.
+
+## Design sketch (to be refined by the implementer)
+
+Runtime `ref.test`-based dispatch when the static receiver is `any`/externref
+and the method name is a known native-builtin method:
+
+- For zero-arg / value methods (`dispose`, `disposed`, `size`, `move`): emit
+  `ref.test $<NativeStruct>` on the receiver; if it matches → the native op;
+  else a clean TypeError (**not** the host import — the import must never be
+  emitted standalone, or the module can't instantiate).
+- For callback methods (`defer`/`adopt`/`use`): the callback must compile as a
+  native closure (the `closures.ts` standalone gate) rather than
+  `__make_callback`; that gate is currently reached only when the call is
+  recognised as a native DisposableStack method. Route the any-receiver call
+  through the same native path so the closure gate fires.
+
+Gate strictly on `ctx.nativeStrings`; host lane byte-identical. Validate on the
+`merge_group` standalone floor (broad-impact — never scope-check only). Slice if
+it balloons past one PR (start with `dispose`/`disposed`, then the callback
+methods).
+
+## Acceptance
+
+- `built-ins/DisposableStack/prototype/dispose/throws-error-as-is…` and the
+  broader dispose/defer cluster pass standalone in the test262 runner (the ones
+  gated purely by the any-receiver leak).
+- No `DisposableStack_*` / `__make_callback` host import for a standalone
+  DisposableStack method call regardless of receiver static type.
+- Host lane byte-identical; NET ≥ 0 on the standalone floor.

--- a/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
+++ b/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
@@ -1,7 +1,8 @@
 ---
 id: 3237
 title: "Standalone: any-receiver dispatch for builtin-native methods (DisposableStack/Map/Set/…) leaks host imports"
-status: ready
+status: in-progress
+assignee: opus-anyrecv
 created: 2026-07-13
 updated: 2026-07-13
 priority: high
@@ -91,3 +92,47 @@ methods).
 - No `DisposableStack_*` / `__make_callback` host import for a standalone
   DisposableStack method call regardless of receiver static type.
 - Host lane byte-identical; NET ≥ 0 on the standalone floor.
+
+## Slice 1 — DONE (PR #3023)
+
+**Scope shipped:** `dispose()` (call) + `disposed` (accessor) on an `any`/union
+receiver carrying a native `$DisposableStack`.
+
+**Root cause confirmed (measure-first, on current main):**
+- `dispose()` on an `any` receiver did NOT go through the `className ===` gate at
+  `extern.ts:133` at all — an `any` receiver has no nominal symbol, so
+  `isExternalDeclaredClass` is false and `compileExternMethodCall` is skipped.
+  The leak actually came from the **any-receiver first-match extern loop**
+  `tryExternClassMethodOnAny` (`calls-closures.ts:1463`): it iterates
+  `ctx.externClasses`, first-matches `DisposableStack.dispose`, and lazily adds
+  the `DisposableStack_dispose` **host import** → module fails to instantiate.
+- `disposed` on an `any` receiver did NOT leak — it fell to the generic
+  `__extern_get` dynamic reader (`property-access.ts`), a MISS on the non-`$Object`
+  native struct → always `false` (silently wrong after dispose;
+  `sets-state-to-disposed.js`).
+
+**Why the interception is regression-safe (the key subtlety):** a user
+object-literal `{ dispose(){} }` on an `any` receiver ALREADY works host-free —
+the #3033 user-function-member refusal (`calls-closures.ts:1438`) fires first and
+routes it to the #2151 closed-struct dispatcher. So the fix intercepts `dispose`
+**after** that refusal, right before the host-import loop — exactly (and only)
+where the loop would otherwise bind the host import. Both interceptions are
+additionally gated on `DisposableStack` being a registered extern class, so they
+are inert for programs that don't use it.
+
+**Implementation:**
+- `tryCompileNativeDisposableStackAnyMethodCall` (disposable-runtime.ts) — `dispose`
+  only: `ref.test $DisposableStack` → native driver on a hit, clean TypeError on a
+  miss (never the host import). Value vs statement position handled (undefined
+  singleton in value position).
+- `tryCompileNativeDisposableStackAnyDisposedGet` (disposable-runtime.ts) —
+  `ref.test $DisposableStack` → struct disposed flag (boxed boolean) on a hit,
+  generic `__extern_get` read on a miss (user object's own `.disposed` preserved).
+- Wired into `tryExternClassMethodOnAny` (calls-closures.ts) and
+  `compilePropertyAccess` (property-access.ts).
+
+**Remaining (Slice 2 / future):** the callback methods `defer`/`adopt`/`use` on an
+`any` receiver still leak — they additionally need the standalone closure gate
+(`closures.ts`) to fire on the any-receiver path (currently only reached when the
+call is recognised as a typed native DisposableStack method). Also the broader
+`Map`/`Set`/`WeakMap`/… any-receiver `className ===` arms (out of Slice-1 scope).

--- a/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
+++ b/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
@@ -14,6 +14,13 @@ language_feature: methods, dynamic-dispatch, disposablestack
 goal: standalone
 related: [2151, 3231, 3234]
 umbrella: 1781
+# Slice 1 wiring: the bulk of the logic lives in the disposable-runtime.ts
+# subsystem module; these two driver files grow only by the minimal dispatch
+# hookup (dispose interception in tryExternClassMethodOnAny; disposed getter in
+# compilePropertyAccess). Genuine, minimal growth — allowance granted per #3102.
+loc-budget-allow:
+  - src/codegen/property-access.ts
+  - src/codegen/expressions/calls-closures.ts
 ---
 
 # Standalone: any-receiver dispatch for builtin-native methods leaks host imports

--- a/src/codegen/disposable-runtime.ts
+++ b/src/codegen/disposable-runtime.ts
@@ -42,6 +42,8 @@ import { allocLocal } from "./context/locals.js";
 import { addFuncType } from "./registry/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { buildThrowJsErrorInstrs } from "./js-errors.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureLateImport, flushLateImportShifts, VOID_RESULT } from "./shared.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
@@ -549,6 +551,158 @@ export function fillDisposableStackDisposeDriver(ctx: CodegenContext): void {
 function compileArgAsExternref(ctx: CodegenContext, fctx: FunctionContext, arg: ts.Expression): void {
   const t = compileExpression(ctx, fctx, arg);
   if (t !== null && !(t.kind === "externref")) coerceType(ctx, fctx, t, EXTERNREF);
+}
+
+/**
+ * (#3237 Slice 1) Intercept a native `DisposableStack` method call whose STATIC
+ * receiver is `any`/externref (the test262 runner hoists a nested-closure-captured
+ * `var stack = new DisposableStack()` to `let stack: any`, so `stack.dispose()`
+ * loses the nominal `DisposableStack` symbol). Without this, the any-receiver
+ * first-match extern loop (`tryExternClassMethodOnAny`, calls-closures.ts) binds
+ * `dispose` to the `DisposableStack_dispose` HOST import — unsatisfiable
+ * standalone, so the whole module fails to instantiate BEFORE dispose ever runs.
+ *
+ * Dispatch on the RUNTIME shape instead: `ref.test $DisposableStack` on the
+ * receiver. Match → the native dispose driver (same reserve/fill func the typed
+ * path uses). Miss (incl. null/undefined) → a clean TypeError (RequireInternalSlot
+ * fail, §12.3.3.2 step 2) — NEVER the host import.
+ *
+ * Caller (`tryExternClassMethodOnAny`) gates this to fire only where the
+ * first-match loop WOULD have bound the host import: `ctx.nativeStrings`, no
+ * user-defined member of the same name shadows it (the #3033 refusal already ran),
+ * and `DisposableStack` is a registered extern class declaring the method. A
+ * user object-literal `{ dispose() {} }` on an `any` receiver keeps taking the
+ * closed-struct dispatch path (#2151) — it never reaches here.
+ *
+ * Slice 1 handles `dispose` only. The callback methods (`defer`/`adopt`/`use`)
+ * additionally need the standalone closure gate to fire on the any-receiver path
+ * (Slice 2); they fall through (`undefined`) here.
+ */
+export function tryCompileNativeDisposableStackAnyMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  methodName: string,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  // Slice 1: `dispose` (zero-arg) only. Callback methods are Slice 2.
+  if (methodName !== "dispose") return undefined;
+  if (callExpr.arguments.length !== 0) return undefined;
+
+  const t = ensureDisposableStackTypes(ctx);
+  const driver = reserveDisposableStackDisposeDriver(ctx);
+
+  // Evaluate the receiver ONCE into an externref local — it is consumed twice
+  // (the `ref.test` brand check and, on a hit, the driver call).
+  const recvLocal = allocLocal(fctx, `__ds_anyrecv_${fctx.locals.length}`, EXTERNREF);
+  const rt = compileExpression(ctx, fctx, propAccess.expression);
+  if (rt !== null && rt.kind !== "externref") coerceType(ctx, fctx, rt, EXTERNREF);
+  fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
+
+  // if ref.test $DisposableStack(recv): native dispose ; else TypeError.
+  // `ref.test (ref $DisposableStack)` is 0 for null and for a non-matching ref,
+  // so a null/undefined or wrong-type receiver lands in the TypeError arm —
+  // matching RequireInternalSlot without ever emitting the host import.
+  fctx.body.push({ op: "local.get", index: recvLocal } as Instr);
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: t.stackTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "local.get", index: recvLocal } as Instr, { op: "call", funcIdx: driver } as Instr],
+    else: buildThrowJsErrorInstrs(
+      ctx,
+      "TypeError",
+      "DisposableStack.prototype.dispose requires a DisposableStack receiver",
+      { flush: fctx },
+    ),
+  } as Instr);
+
+  // `dispose()` returns undefined. In a VALUE position (`assert.sameValue(
+  // s.dispose(), undefined)` — returns-undefined.js) hand back the undefined
+  // singleton (null externref ≡ undefined in standalone; cf. the DataView-setter
+  // precedent in calls.ts) so the caller's argument stack stays balanced.
+  // Statement position keeps the zero-cost VOID_RESULT.
+  if (!ts.isExpressionStatement(callExpr.parent)) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    return { kind: "externref" };
+  }
+  return VOID_RESULT;
+}
+
+/**
+ * (#3237 Slice 1) Read `.disposed` on a DYNAMIC (`any`/`unknown`/union) receiver
+ * that may carry a native `$DisposableStack`. The compile-time className arm
+ * (`tryCompileNativeDisposableStackDisposedGet`, gated on the nominal symbol)
+ * cannot fire when the runner hoists `var stack = new DisposableStack()` to
+ * `let stack: any`, so `stack.disposed` fell to the generic dynamic reader — a
+ * `__extern_get` MISS on the non-`$Object` native struct → always
+ * `undefined`/false, i.e. silently wrong AFTER `dispose()` (breaks
+ * `sets-state-to-disposed.js`).
+ *
+ * Runtime `ref.test $DisposableStack` dispatch instead: a match reads the struct
+ * `disposed` flag (boxed as a boolean externref, matching the `any`-context value
+ * contract); a miss falls to the same generic `__extern_get` read the receiver
+ * would otherwise have taken — so a user object's own `.disposed` property (an
+ * `$Object` field) is preserved. Gated `nativeStrings`; caller additionally
+ * requires a dynamic receiver + a registered `DisposableStack` extern class.
+ */
+export function tryCompileNativeDisposableStackAnyDisposedGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiver: ts.Expression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  const t = ensureDisposableStackTypes(ctx);
+  // `__extern_get` + the boxing helpers live in the native object runtime.
+  ensureObjectRuntime(ctx);
+
+  // Evaluate the receiver ONCE into an externref local (consumed by the brand
+  // test AND, on a miss, the generic fallback read).
+  const recvLocal = allocLocal(fctx, `__ds_dget_${fctx.locals.length}`, EXTERNREF);
+  const rt = compileExpression(ctx, fctx, receiver);
+  if (rt !== null && rt.kind !== "externref") coerceType(ctx, fctx, rt, EXTERNREF);
+  fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
+
+  // Register the boxing + dynamic-read helpers AFTER the receiver's own imports
+  // settle, then flush late-import index shifts against this body before baking
+  // the funcIdxs (mirrors the `use()` path).
+  const boxBoolIdx = ensureLateImport(ctx, "__box_boolean", [I32], [EXTERNREF]);
+  ensureLateImport(ctx, "__extern_get", [EXTERNREF, EXTERNREF], [EXTERNREF]);
+  flushLateImportShifts(ctx, fctx);
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  if (boxBoolIdx === undefined || externGetIdx === undefined) {
+    // Substrate unavailable — hand back `undefined` (null externref) rather than
+    // an unbalanced body. (Should not happen once ensureObjectRuntime ran.)
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    return { kind: "externref" };
+  }
+  addStringConstantGlobal(ctx, "disposed");
+
+  fctx.body.push({ op: "local.get", index: recvLocal } as Instr);
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: t.stackTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: EXTERNREF },
+    then: [
+      // Native DisposableStack → box the i32 disposed flag as a boolean externref.
+      { op: "local.get", index: recvLocal } as Instr,
+      ...externToStack(ctx),
+      { op: "ref.as_non_null" } as Instr,
+      { op: "struct.get", typeIdx: t.stackTypeIdx, fieldIdx: 0 } as Instr,
+      { op: "call", funcIdx: boxBoolIdx } as Instr,
+    ],
+    else: [
+      // Not a DisposableStack → the generic dynamic property read (`$Object`
+      // sidecar), so a user object's own `.disposed` property still resolves.
+      { op: "local.get", index: recvLocal } as Instr,
+      ...stringConstantExternrefInstrs(ctx, "disposed"),
+      { op: "call", funcIdx: externGetIdx } as Instr,
+    ],
+  } as Instr);
+  return { kind: "externref" };
 }
 
 /**

--- a/src/codegen/disposable-runtime.ts
+++ b/src/codegen/disposable-runtime.ts
@@ -42,8 +42,6 @@ import { allocLocal } from "./context/locals.js";
 import { addFuncType, getOrRegisterErrorStructType } from "./registry/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { buildThrowJsErrorInstrs } from "./js-errors.js";
-import { addStringConstantGlobal } from "./registry/imports.js";
-import { stringConstantExternrefInstrs } from "./native-strings.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureLateImport, flushLateImportShifts, VOID_RESULT } from "./shared.js";
 import { ensureObjectRuntime } from "./object-runtime.js";

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -11,6 +11,7 @@ import { ts } from "../../ts-api.js";
 import { isVoidType, isPromiseType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { getFuncRefWrapperRootTypeIdx, getOrCreateFuncRefWrapperTypes } from "../closures.js";
+import { tryCompileNativeDisposableStackAnyMethodCall } from "../disposable-runtime.js";
 import { allocLocal } from "../context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
 import { addFuncType, addImport, localGlobalIdx, resolveWasmType } from "../index.js";
@@ -1459,6 +1460,20 @@ export function tryExternClassMethodOnAny(
     for (const p of sig.params) if (p.kind !== "externref") return false;
     return true;
   };
+
+  // (#3237 Slice 1) Native `DisposableStack` dispatch on an `any` receiver.
+  // Reaching here means every ambiguity/user-member refusal above already
+  // passed, so if `DisposableStack` is a registered extern class declaring this
+  // method the first-match loop below WOULD bind it to the `DisposableStack_*`
+  // HOST import (unsatisfiable standalone → module fails to instantiate before
+  // dispose runs). In `nativeStrings` mode, run a `ref.test $DisposableStack`
+  // runtime dispatch to the native driver instead (miss → clean TypeError, never
+  // the import). Gated inside the helper to Slice-1 `dispose`; other methods fall
+  // through to the loop unchanged. Host lane (`!nativeStrings`) is untouched.
+  if (ctx.nativeStrings && ctx.externClasses.get("DisposableStack")?.methods.has(methodName)) {
+    const dsAny = tryCompileNativeDisposableStackAnyMethodCall(ctx, fctx, propAccess, expr, methodName);
+    if (dsAny !== undefined) return dsAny;
+  }
 
   for (const [key, info] of ctx.externClasses) {
     if (key !== info.className) continue;

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -62,7 +62,10 @@ import {
 import { emitJsonStringifyValue } from "./json-codec-native.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
-import { tryCompileNativeDisposableStackDisposedGet } from "./disposable-runtime.js";
+import {
+  tryCompileNativeDisposableStackAnyDisposedGet,
+  tryCompileNativeDisposableStackDisposedGet,
+} from "./disposable-runtime.js";
 import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
 import { tryEmitLinearU8ElementGet, tryEmitLinearU8Length } from "./linear-uint8-codegen.js";
 import { tryEmitFnctorPrototypeRead } from "./expressions/fnctor-prototype.js";
@@ -3565,6 +3568,23 @@ export function compilePropertyAccess(
     if (isDynamicReceiver) {
       const r = emitTaViewDynamicByteLength(ctx, fctx, () => compileExpression(ctx, fctx, expr.expression));
       if (r) return r;
+    }
+  }
+
+  // (#3237 Slice 1) `.disposed` on a DYNAMIC (`any`/`unknown`/union) receiver
+  // carrying a native `$DisposableStack` (the runner hoists a captured
+  // `var stack = new DisposableStack()` to `let stack: any`). The className arm
+  // below can't fire (no nominal symbol), so it fell to the generic dynamic
+  // reader — a `__extern_get` miss on the non-`$Object` native struct → always
+  // false, silently wrong after `dispose()`. Runtime `ref.test $DisposableStack`
+  // dispatch: match → the struct's disposed flag; miss → the generic read (a user
+  // object's own `.disposed` still resolves). Byte-inert unless a
+  // `DisposableStack` extern class is registered; `nativeStrings`-gated.
+  if (propName === "disposed" && ctx.nativeStrings && ctx.externClasses.has("DisposableStack")) {
+    const isDynamicReceiver = (objType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0 || objType.isUnion();
+    if (isDynamicReceiver) {
+      const r = tryCompileNativeDisposableStackAnyDisposedGet(ctx, fctx, expr.expression);
+      if (r !== undefined) return r as ValType;
     }
   }
 

--- a/tests/issue-3237-standalone-any-receiver-disposablestack.test.ts
+++ b/tests/issue-3237-standalone-any-receiver-disposablestack.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3237 Slice 1 — any-receiver dispatch for the native DisposableStack `dispose`
+// method + `disposed` accessor. The test262 runner hoists a nested-closure-
+// captured `var stack = new DisposableStack()` to `let stack: any`, so
+// `stack.dispose()` / `stack.disposed` lose the nominal `DisposableStack` symbol.
+// Before this slice `dispose` on an `any` receiver first-match-bound the
+// `DisposableStack_dispose` HOST import (unsatisfiable standalone → the module
+// failed to instantiate), and `disposed` fell to the generic `__extern_get` reader
+// (a miss on the native struct → always false, silently wrong after dispose).
+//
+// Slice 1 dispatches on the RUNTIME shape (`ref.test $DisposableStack`): match →
+// the native op; miss → a clean TypeError (dispose) / the generic read (disposed).
+// The callback methods (`defer`/`adopt`/`use`) are Slice 2.
+
+const HOST_LEAK_RE = /DisposableStack_|__make_callback/;
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const leaks = r.imports.map((i) => `${i.module}::${i.name}`).filter((n) => HOST_LEAK_RE.test(n));
+  expect(leaks).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#3237 slice 1 — any-receiver DisposableStack dispose/disposed", () => {
+  it("dispose() on an any-typed receiver is host-free and flips disposed", async () => {
+    // The receiver is `any`, so the nominal className arm never fires.
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); s.dispose(); return s.disposed ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("disposed accessor on an any receiver reads the real flag before/after dispose", async () => {
+    // sets-state-to-disposed.js shape: read `.disposed` before and after dispose.
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let s: any = new DisposableStack();
+           let wasDisposed = s.disposed;
+           s.dispose();
+           let isDisposed = s.disposed;
+           return (!wasDisposed && isDisposed) ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("dispose() on an any receiver returns undefined (value position)", async () => {
+    // returns-undefined.js: `assert.sameValue(stack.dispose(), undefined)`.
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); let u = s.dispose(); return (u === undefined) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("dispose() on an any receiver is idempotent; disposed stays true", async () => {
+    // does-not-throw-if-already-disposed.js: dispose twice, no throw.
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); s.dispose(); s.dispose(); return s.disposed ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a fresh stack read through an any receiver is not disposed", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); return s.disposed ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  // ── Regression guards: the fix must NOT hijack non-DisposableStack receivers ──
+
+  it("a user object's dispose() on an any receiver still routes to the closed-struct method", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { let o: any = { dispose() { return 5; } }; return o.dispose(); }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("a user object's dispose() on an any receiver still works when DisposableStack is also present", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let d = new DisposableStack(); d.dispose();
+           let o: any = { dispose() { return 7; } };
+           return o.dispose();
+         }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("a user object's own disposed property on an any receiver still resolves (truthy)", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let d = new DisposableStack();
+           let o: any = { disposed: true };
+           return o.disposed ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a user object's own disposed property (false) on an any receiver still resolves (falsy)", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let d = new DisposableStack();
+           let o: any = { disposed: false };
+           return o.disposed ? 1 : 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("the typed (nominal) dispose/disposed path is unchanged", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { const s = new DisposableStack(); s.dispose(); return s.disposed ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #3237 Slice 1 — any-receiver dispatch for builtin-native DisposableStack

### Problem
The test262 runner hoists a nested-closure-captured `var stack = new DisposableStack()` to `let stack: any`, so `stack.dispose()` / `stack.disposed` lose the nominal `DisposableStack` symbol. Two distinct standalone failures followed:

- **`dispose()` LEAKED a host import.** The any-receiver first-match extern loop (`tryExternClassMethodOnAny`) bound `dispose` to the `DisposableStack_dispose` **host import** — unsatisfiable standalone, so the whole module **failed to instantiate before dispose ever ran**. This is the real lever the #3231 native runtime + #3234 SuppressedError aggregation were prerequisites for.
- **`disposed` read the WRONG VALUE.** On an `any` receiver it fell to the generic `__extern_get` reader — a miss on the non-`$Object` native struct → always `false`, silently wrong after dispose (breaks `sets-state-to-disposed.js`).

Distinct from #2151 (any-receiver dispatch for user object-literal closed structs) — this is the builtin-native `className ===` gate.

### Fix — dispatch on the runtime shape (`ref.test $DisposableStack`)
- **`dispose()`** (`tryCompileNativeDisposableStackAnyMethodCall`, wired into `tryExternClassMethodOnAny` right before the host-import loop): match → the native dispose driver (same reserve/fill func the typed path uses); miss (incl. null/undefined) → a clean **TypeError** (RequireInternalSlot, §12.3.3.2) — **never the host import**. Value position hands back the undefined singleton (`returns-undefined.js`); statement position keeps `VOID_RESULT`.
- **`disposed`** (`tryCompileNativeDisposableStackAnyDisposedGet`, wired into `compilePropertyAccess`): match → the struct's disposed flag (boxed boolean); miss → the generic `__extern_get` read, so a user object's own `.disposed` property still resolves.

### Regression safety
Both interceptions are gated on `ctx.nativeStrings` **and** `DisposableStack` being a registered extern class, so they are **inert** for any program that doesn't use DisposableStack. The interception point for `dispose` is placed *after* the #3033 user-member refusal, so a user object-literal `{ dispose(){} }` on an `any` receiver keeps taking the #2151 closed-struct path (verified). Host lane (`!nativeStrings`) byte-identical.

### Scope
Slice 1 = `dispose` + `disposed` only. The callback methods (`defer`/`adopt`/`use`) additionally need the standalone closure gate to fire on the any-receiver path — that's Slice 2 (a separate PR).

### Tests
`tests/issue-3237-standalone-any-receiver-disposablestack.test.ts` (10 cases): dispose+disposed flip host-free on an any receiver (mirrors `sets-state-to-disposed` / `returns-undefined` / `does-not-throw-if-already-disposed`), plus regression guards that user-object `dispose()`/`disposed` on an any receiver (with and without DisposableStack present) and the typed path are unchanged. All 36 existing DisposableStack tests (#3231/#2029/#2861) + #3234 SuppressedError still pass.

Two failures seen in a broad standalone sweep (`issue-2151` `.next()` any-iterable, `issue-681` for-of refusal) were **verified pre-existing on origin/main** — reverting these three files to origin/main reproduces them identically; both are DisposableStack-free, so this change is provably inert for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8