### PR TITLE
feat(#3236 Slice 1b): Function.prototype.call/apply on dynamically-read %GeneratorPrototype% member closure (standalone)

### DIFF
--- a/plan/issues/3236-standalone-sync-generator-prototype-intrinsic-chain.md
+++ b/plan/issues/3236-standalone-sync-generator-prototype-intrinsic-chain.md
@@ -11,7 +11,7 @@ area: codegen
 language_feature: generators, intrinsics, prototype-chain, standalone
 goal: host-independence
 umbrella: 1781
-assignee: ttraenkler/opus-genproto
+assignee: ttraenkler/opus-genproto2
 # (#3102/#3236 S1) Genuine native-substrate growth: the intrinsic-chain
 # singleton emitters + brand-checked method-closure install live with the
 # native-proto singletons (array-object-proto.ts); the two rewire call sites are
@@ -158,3 +158,62 @@ this-val group until the `.call`-on-native-method-closure invocation path lands.
 Slice 1b: route `<value>.call(thisArg)` where `<value>` is a
 `nativeProtoReceiverClosureStructTypes` closure to the closure invocation (thread
 `thisArg` → param 1), mirroring the direct-call dispatch that already works.
+
+## Implementation Notes (Slice 1b — opus-genproto2)
+
+### What shipped (host-free, 6 this-val flips)
+
+`Function.prototype.call`/`.apply` on a dynamically-read %GeneratorPrototype%
+member closure now INVOKES the closure so its Slice-1 catchable-TypeError
+refusal body fires. Flips `GeneratorPrototype/{next,return,throw}/this-val-not-{object,generator}.js`
+(the 6 remaining this-val entries). All changes in
+`src/codegen/expressions/calls.ts` only (+111/−1); host lane byte-identical.
+
+### Root cause (WHY the symbol path missed)
+
+The test binds `var GeneratorPrototype = Object.getPrototypeOf(g).prototype`,
+which is **fully `any`-typed** (both `getPrototypeOf` and the `.prototype` read
+on `any` produce `any`). So `GeneratorPrototype.next` has NO method-signature
+symbol — `tryEmitNativeProtoReflectiveCall` (the #2193 symbol/var-init recovery)
+can't resolve `(brand, member)` and `.call` degraded to a plain `next.call`
+property read → `undefined` → no invocation → no throw. (Direct `GP.next()`
+already threw: it routes through the `__call_m_next_N` closed-method dispatcher →
+open-`$Object` fall-through → dynamic closure invoke.)
+
+### Design (WHY this shape, not a runtime dispatch)
+
+Two new helpers + one hook in the `.call`/`.apply` handler (Case-2 sibling),
+all gated on `ctx.standalone || ctx.wasi`:
+
+- **`isGeneratorPrototypeReceiver`** — resolves that the `.call` receiver object
+  is `%GeneratorPrototype%` from its **syntactic provenance** (spec chain
+  §27.3.3.3 / §27.5.1), tracing ≤1 var-initializer indirection:
+  `<genFn>.prototype` or `Object.getPrototypeOf(<genFn>).prototype`, where
+  `<genFn> ∈ ctx.generatorFunctions` (sync only — async generators keep the host
+  path). Conservative: any unprovable shape → `false` → unchanged legacy `.call`.
+- **`tryEmitGeneratorProtoReflectiveCall`** — for member ∈ {next,return,throw}
+  with a GeneratorPrototype receiver, resolves the brand via
+  `ensureGeneratorPrototypeNativeProtoGlue` and reuses the shared reflective
+  emitter (`emitReflectiveNativeProtoClosureCall`), which compiles the receiver
+  `GP.next` to the stored closure externref, `ref.cast`s it to the wrapper
+  struct, and `call_ref`s it threading `thisArg → this` param 1. Static
+  resolution (not a runtime ref.test chain) because the (brand, member) is
+  syntactically knowable and it exactly matches the existing native-proto
+  reflective-call architecture.
+
+**Key correction (the blocker):** `emitReflectiveNativeProtoClosureCall` called
+`ensureStandaloneNativeMethodClosure` WITHOUT `refusalBodyFallback`, so for a
+member whose only body is the refusal (GeneratorPrototype has no wired native
+body) it returned `null` and the reflective call bailed. Added a **strictly
+opt-in** `useRefusalBodyFallback` param (default `false`) so only the
+GeneratorPrototype caller mints/casts to the identity-stable fallback singleton —
+the same struct type the Slice-1 value-read stored on the `$Object`. Default-off
+preserves the documented `hasOwnProperty.call` fall-through contract (verified
+unregressed) that the other reflective callers depend on.
+
+### Host-lane neutrality
+
+`tryEmitGeneratorProtoReflectiveCall` returns `undefined` on its first line when
+`!(ctx.standalone || ctx.wasi)`, so the host path emits nothing new; the shared
+`emitReflectiveNativeProtoClosureCall` param defaults off → existing callers
+byte-identical.

--- a/scripts/oracle-ratchet-baseline.json
+++ b/scripts/oracle-ratchet-baseline.json
@@ -273,6 +273,12 @@
       "field": "ctxChecker",
       "extra": 1,
       "reason": "#3173: tryEmitNativeProtoReflectiveCall resolves a LIB-MISSING DataView member (getFloat16/setFloat16 — absent from the bundled lib, so no method-signature symbol exists) by tracing the receiver variable back to its `<Builtin>.prototype.<member>` initializer via checker.getSymbolAtLocation(ident).valueDeclaration. ctx.oracle exposes node-based TypeFacts, not declaration/initializer NODES, which this static data-flow trace requires. Same shape as the #3172 collections-brand entry above."
+    },
+    {
+      "file": "src/codegen/expressions/calls.ts",
+      "field": "ctxChecker",
+      "extra": 1,
+      "reason": "#3236 Slice 1b: isGeneratorPrototypeReceiver traces the `.call`/`.apply` receiver variable back to its `Object.getPrototypeOf(<genFn>).prototype` / `<genFn>.prototype` initializer NODE via checker.getSymbolAtLocation(ident).valueDeclaration to prove it is the native %GeneratorPrototype% singleton (the receiver is `any`-typed, so no type-fact resolves it). ctx.oracle exposes node-based TypeFacts, not declaration/initializer NODES, which this static data-flow trace requires — identical shape to the #3173 DataView entry above."
     }
   ]
 }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -160,6 +160,7 @@ import {
   ensureDateNativeProtoGlue,
   ensureObjectNativeProtoGlue,
   ensureStringNativeProtoGlue,
+  ensureGeneratorPrototypeNativeProtoGlue,
   emitTypedArrayIntrinsicCtorObject,
   emitArrayIteratorPrototypeSingleton,
   emitGeneratorFunctionPrototypeSingleton,
@@ -1250,8 +1251,24 @@ function emitReflectiveNativeProtoClosureCall(
   member: string,
   kind: "method" | "getter",
   isCall: boolean,
+  /**
+   * (#3236 Slice 1b) When set, resolve the closure through the factory's
+   * `refusalBodyFallback` — the identity-stable throwing stand-in a member with
+   * no wired native body reifies to. Needed for the %GeneratorPrototype% members
+   * (`next`/`return`/`throw`), whose only body IS the catchable-TypeError refusal
+   * and whose stored `$Object` data-property value is exactly that fallback
+   * singleton. Off by default so the existing native-bodied callers (Array/Object
+   * proto slice/etc.) are byte-identical.
+   */
+  useRefusalBodyFallback = false,
 ): ValType | undefined {
-  const closure = ensureStandaloneNativeMethodClosure(ctx, brand, member, kind);
+  const closure = ensureStandaloneNativeMethodClosure(
+    ctx,
+    brand,
+    member,
+    kind,
+    useRefusalBodyFallback ? { refusalBodyFallback: true } : undefined,
+  );
   if (!closure) return undefined; // member body refuses / not native yet → fall through
   const closureInfo = ctx.closureInfoByTypeIdx.get(closure.type.typeIdx);
   if (!closureInfo) return undefined;
@@ -1338,6 +1355,90 @@ function emitReflectiveNativeProtoClosureCall(
   emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: closureInfo.funcTypeIdx });
   fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx } as Instr);
   return closureInfo.returnType ?? { kind: "externref" };
+}
+
+/**
+ * (#3236 Slice 1b) True when `objExpr` syntactically resolves to the native
+ * `%GeneratorPrototype%` singleton — the object whose own `next`/`return`/`throw`
+ * are the brand-checked closure values Slice 1 installed. Recognises the two
+ * shapes the test262 GeneratorPrototype `this-val-*` tests use, tracing at most
+ * ONE variable-initializer indirection (`var GP = <expr>; GP.next.call(x)`):
+ *
+ *   - `<genFn>.prototype`                    (§27.5.1 — genFn.prototype IS %GP%)
+ *   - `Object.getPrototypeOf(<genFn>).prototype`
+ *          (getPrototypeOf(genFn) = %Generator%, whose own `.prototype` = %GP%)
+ *
+ * `<genFn>` must be a `function*` declaration known to `ctx.generatorFunctions`
+ * (sync only — async generators keep the host-import path). Conservative: any
+ * shape it can't prove returns false, so the caller falls through to the
+ * unchanged legacy `.call` lowering (no regression).
+ */
+function isGeneratorPrototypeReceiver(ctx: CodegenContext, objExpr: ts.Expression): boolean {
+  let cur = unwrapTransparent(objExpr);
+  // One level of `var GP = <init>` indirection.
+  if (ts.isIdentifier(cur)) {
+    const sym = ctx.checker.getSymbolAtLocation(cur);
+    const decl = sym?.valueDeclaration;
+    if (decl && ts.isVariableDeclaration(decl) && decl.initializer) {
+      cur = unwrapTransparent(decl.initializer);
+    }
+  }
+  if (!ts.isPropertyAccessExpression(cur) || cur.name.text !== "prototype") return false;
+  const base = unwrapTransparent(cur.expression);
+  // Shape A: `<genFn>.prototype`.
+  if (ts.isIdentifier(base) && ctx.generatorFunctions.has(base.text)) return true;
+  // Shape B: `Object.getPrototypeOf(<genFn>).prototype`.
+  if (ts.isCallExpression(base)) {
+    const callee = unwrapTransparent(base.expression);
+    if (
+      ts.isPropertyAccessExpression(callee) &&
+      callee.name.text === "getPrototypeOf" &&
+      ts.isIdentifier(callee.expression) &&
+      callee.expression.text === "Object" &&
+      base.arguments.length >= 1
+    ) {
+      const arg = unwrapTransparent(base.arguments[0]!);
+      if (ts.isIdentifier(arg) && ctx.generatorFunctions.has(arg.text)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * (#3236 Slice 1b) Reflective `<GP>.next.call/apply(thisArg, …)` where the
+ * `.call`/`.apply` receiver `<GP>.next` is a DYNAMICALLY-READ %GeneratorPrototype%
+ * member closure. Unlike `tryEmitNativeProtoReflectiveCall` (which recovers the
+ * closure from the receiver's TS symbol), here the receiver object `<GP>` is
+ * `any`-typed (`Object.getPrototypeOf(g).prototype`), so `<GP>.next` has no
+ * method-signature symbol — the closure value is an own `$Object` data property.
+ * We instead resolve the `(brand, member)` from the receiver's syntactic
+ * GeneratorPrototype provenance, then reuse the shared reflective closure-call
+ * emitter, which compiles `<GP>.next` to the stored closure externref, casts it
+ * to the wrapper struct, and `call_ref`s it with `thisArg → this` param. The
+ * closure's Slice-1 catchable-TypeError refusal body then fires on the bad
+ * `this` (GeneratorValidate §27.5.1.2). Standalone-gated; returns the result
+ * ValType when handled, or `undefined` to fall through unchanged.
+ */
+function tryEmitGeneratorProtoReflectiveCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  innerExpr: ts.Expression,
+  isCall: boolean,
+): ValType | undefined {
+  if (!(ctx.standalone || ctx.wasi)) return undefined;
+  const recv = unwrapTransparent(innerExpr);
+  if (!ts.isPropertyAccessExpression(recv)) return undefined;
+  const member = recv.name.text;
+  if (member !== "next" && member !== "return" && member !== "throw") return undefined;
+  if (!isGeneratorPrototypeReceiver(ctx, recv.expression)) return undefined;
+  const brand = ensureGeneratorPrototypeNativeProtoGlue(ctx);
+  if (brand === undefined) return undefined;
+  // `useRefusalBodyFallback: true` — the GeneratorPrototype members carry only
+  // the catchable-TypeError refusal body (no wired native body), and their
+  // stored `$Object` data-property value IS that identity-stable fallback
+  // singleton, so the reflective cast must target the same struct type.
+  return emitReflectiveNativeProtoClosureCall(ctx, fctx, expr, recv, brand, member, "method", isCall, true);
 }
 
 /** Unwrap parenthesized / `as` / non-null wrappers to the underlying expression. */
@@ -5686,6 +5787,15 @@ function compileCallExpression(
         // recovered by data-flow trace rather than a TS symbol.
         const descAccResult = tryEmitNativeProtoDescriptorAccessorCall(ctx, fctx, expr, recv, isCall);
         if (descAccResult !== undefined) return descAccResult;
+
+        // (#3236 Slice 1b) Reflective `.call`/`.apply` on a dynamically-read
+        // %GeneratorPrototype% member closure (`GeneratorPrototype.next.call(x)`).
+        // The receiver object is `any`-typed so the symbol-based paths above miss;
+        // resolve the (brand, member) from the receiver's GeneratorPrototype
+        // provenance and invoke the stored closure with `thisArg → this`, so its
+        // Slice-1 brand-check fires on the bad `this`. Standalone-gated.
+        const genProtoResult = tryEmitGeneratorProtoReflectiveCall(ctx, fctx, expr, recv, isCall);
+        if (genProtoResult !== undefined) return genProtoResult;
       }
 
       // Sub-fix 3 (#1596): Function.prototype.{apply,call}.call(fn, ...) reshape.

--- a/tests/issue-3236-slice1b-genproto-call.test.ts
+++ b/tests/issue-3236-slice1b-genproto-call.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3236 Slice 1b — `Function.prototype.call`/`.apply` on a dynamically-read
+ * %GeneratorPrototype% member closure.
+ *
+ * Slice 1 installed `%GeneratorPrototype%`'s own `next`/`return`/`throw` as
+ * brand-checked native-method closure VALUES (real `$Object` data properties)
+ * and wired the DIRECT-call path: `GeneratorPrototype.next()` throws a catchable
+ * TypeError (GeneratorValidate §27.5.1.2, whose Slice-1 stand-in is an
+ * unconditional catchable-TypeError refusal body).
+ *
+ * The remaining test262 `this-val-not-{object,generator}` cases invoke the
+ * member via `GeneratorPrototype.next.call(undefined)`. There the receiver
+ * `GeneratorPrototype.next` is a DYNAMIC `$Object` data-property read (the
+ * closure value) on an `any`-typed object, so the symbol-based reflective
+ * `.call` recovery misses and `.call` degraded to reading `next.call` →
+ * `undefined` (no invocation → no throw). Slice 1b resolves the (brand, member)
+ * from the receiver's syntactic GeneratorPrototype provenance and routes the
+ * value-call through the shared reflective closure-call emitter (threading
+ * `thisArg → this`), so the brand-check fires and the spec TypeError is thrown.
+ *
+ * Standalone-gated; every case compiles host-free (zero imports).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compHostFree(src: string) {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone", nativeStrings: true } as any);
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.map((e) => e.message).join("; ")}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+const PRELUDE = `
+function* g() {}
+var GeneratorPrototype = Object.getPrototypeOf(g).prototype;
+var symbol = Symbol();
+`;
+
+describe("#3236 Slice 1b — GeneratorPrototype.<m>.call/apply throws TypeError host-free", () => {
+  it("this-val-not-object: every non-object this throws a catchable TypeError", async () => {
+    // Mirrors built-ins/GeneratorPrototype/next/this-val-not-object.js.
+    const ex = await compHostFree(`${PRELUDE}
+function throws1(): boolean {
+  try { GeneratorPrototype.next.call(undefined); return false; } catch (e) { return e instanceof TypeError; }
+}
+function throws2(): boolean {
+  try { GeneratorPrototype.next.call(undefined, 1); return false; } catch (e) { return e instanceof TypeError; }
+}
+export function allThrow(): number {
+  var vals: any[] = [undefined, null, true, 's', 1, symbol];
+  for (var i = 0; i < vals.length; i++) {
+    try { GeneratorPrototype.next.call(vals[i]); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+    try { GeneratorPrototype.next.call(vals[i], 1); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  }
+  return throws1() && throws2() ? 1 : 0;
+}
+`);
+    expect(ex.allThrow()).toBe(1);
+  });
+
+  it("this-val-not-generator: ordinary/function/generator-fn this throws TypeError", async () => {
+    // Mirrors built-ins/GeneratorPrototype/next/this-val-not-generator.js.
+    const ex = await compHostFree(`${PRELUDE}
+export function allThrow(): number {
+  try { GeneratorPrototype.next.call({}); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.next.call({}, 1); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.next.call(function() {}); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.next.call(g); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.next.call(g.prototype); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  return 1;
+}
+`);
+    expect(ex.allThrow()).toBe(1);
+  });
+
+  it("return / throw members flip the same way, incl. .apply", async () => {
+    const ex = await compHostFree(`${PRELUDE}
+export function allThrow(): number {
+  try { GeneratorPrototype.return.call(undefined); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.throw.call({}); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.next.apply(undefined); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  try { GeneratorPrototype.next.apply(undefined, [1]); return 0; } catch (e) { if (!(e instanceof TypeError)) return 0; }
+  return 1;
+}
+`);
+    expect(ex.allThrow()).toBe(1);
+  });
+
+  it("Slice-1 direct-call + value-read semantics are unregressed", async () => {
+    const ex = await compHostFree(`${PRELUDE}
+export function directThrows(): number {
+  try { GeneratorPrototype.next(); return 0; } catch (e) { return e instanceof TypeError ? 1 : 0; }
+}
+export function isFn(): number { return typeof GeneratorPrototype.next === 'function' ? 1 : 0; }
+export function descOK(): number {
+  var d = Object.getOwnPropertyDescriptor(GeneratorPrototype, 'next');
+  return (d && d.writable === true && d.enumerable === false && d.configurable === true) ? 1 : 0;
+}
+`);
+    expect(ex.directThrows()).toBe(1);
+    expect(ex.isFn()).toBe(1);
+    expect(ex.descOK()).toBe(1);
+  });
+
+  it("unrelated borrowed-method idiom (hasOwnProperty.call) is unaffected", async () => {
+    // The reflective refusal-body fall-through path emitReflectiveNativeProtoClosureCall
+    // relies on for Object.prototype.hasOwnProperty.call must stay intact — Slice 1b's
+    // refusalBodyFallback is strictly opt-in and must not leak to this caller.
+    const ex = await compHostFree(`
+export function hop(): number {
+  var o: any = { a: 1 };
+  return Object.prototype.hasOwnProperty.call(o, 'a') ? 1 : 0;
+}
+`);
+    expect(ex.hop()).toBe(1);
+  });
+});


### PR DESCRIPTION
## #3236 Slice 1b — `.call`/`.apply` on a dynamically-read %GeneratorPrototype% member closure

Follows Slice 1 (#3022, +4 host_free_pass). Slice 1 installed `%GeneratorPrototype%`'s own `next`/`return`/`throw` as brand-checked native-method **closure values** (real `$Object` data properties) and wired the DIRECT-call path (`GeneratorPrototype.next()` throws a catchable TypeError). This slice wires the `Function.prototype.call`/`.apply` path.

### The gap (6 flips)

The remaining `built-ins/GeneratorPrototype/{next,return,throw}/this-val-not-{object,generator}.js` tests invoke via `GeneratorPrototype.next.call(undefined)`. The receiver binds `var GeneratorPrototype = Object.getPrototypeOf(g).prototype`, which is **fully `any`-typed**, so `GeneratorPrototype.next` has no method-signature symbol — the #2193 symbol-based reflective `.call` recovery missed and `.call` degraded to a plain `next.call` property read (→ `undefined`, no invocation, no throw). Verified: direct `GP.next()` threw (threw=1), `.call` did not (threw=0).

### Fix (all in `src/codegen/expressions/calls.ts`)

- **`isGeneratorPrototypeReceiver`** — resolves `%GeneratorPrototype%` from the receiver's **syntactic provenance** (`<genFn>.prototype` / `Object.getPrototypeOf(<genFn>).prototype`, sync generators only), tracing ≤1 var-initializer indirection. Conservative — any unprovable shape falls through to the unchanged legacy `.call`.
- **`tryEmitGeneratorProtoReflectiveCall`** — resolves the brand via `ensureGeneratorPrototypeNativeProtoGlue` and reuses the shared reflective closure-call emitter, threading `thisArg → this` param 1 so the Slice-1 brand-check refusal body fires.
- **`emitReflectiveNativeProtoClosureCall`** gains a strictly opt-in `useRefusalBodyFallback` param (default `false`). The GeneratorPrototype members carry only the refusal body, and their stored `$Object` data-property value IS that identity-stable fallback singleton, so the reflective cast must target the same struct type. Default-off preserves the documented `hasOwnProperty.call` fall-through contract the other reflective callers depend on (verified unregressed).

### Discipline

- **Standalone-gated** (`ctx.standalone || ctx.wasi`); **host lane byte-identical** — the new helper returns `undefined` on the host path before emitting anything, and the shared-emitter param defaults off.
- **+110 LOC** in `calls.ts`, granted by the issue's `loc-budget-allow`. `check:loc-budget`, `check:issues`, `check:stack-balance`, `check:dead-exports`, `lint` all green locally.
- New regression test `tests/issue-3236-slice1b-genproto-call.test.ts`: both this-val groups, next/return/throw, `.apply`, TypeError constructor check, Slice-1 direct-call/value-read non-regression, and the `hasOwnProperty.call` guard — all host-free (zero imports).
- De-conflicted with #3237/PR #3023 (opus-anyrecv): no shared src file (they touch `calls-closures.ts`/`disposable-runtime.ts`/`property-access.ts`; this touches only `calls.ts`), different call class. Confirmed by both.

merge_group standalone floor is the gate: 6 this-val flips, no regression to Slice 1's +4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8