### PR TITLE
fix(#3241): native object-rest for for-of/for-await loop-var rest (standalone)

### DIFF
--- a/plan/issues/3241-standalone-forof-obj-rest-native.md
+++ b/plan/issues/3241-standalone-forof-obj-rest-native.md
@@ -10,6 +10,9 @@ goal: standalone-mode
 umbrella: 1781
 assignee: opus-restobj
 completed: 2026-07-13
+loc-budget-allow:
+  - src/codegen/destructuring-params.ts
+  - src/codegen/statements/loops.ts
 ---
 
 ## Problem

--- a/plan/issues/3241-standalone-forof-obj-rest-native.md
+++ b/plan/issues/3241-standalone-forof-obj-rest-native.md
@@ -1,0 +1,79 @@
+---
+id: 3241
+title: "Native object-rest CopyDataProperties for for-of/for-await loop-var rest (standalone)"
+status: done
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+goal: standalone-mode
+umbrella: 1781
+assignee: opus-restobj
+completed: 2026-07-13
+---
+
+## Problem
+
+Under `--target standalone`/`wasi`, the object-rest loop-var binding in a
+`for (const { a, ...rest } of arr)` / `for await (...)` still emitted the
+`env.__extern_rest_object` **host import** (`src/codegen/statements/loops.ts`).
+That leaks an `env::` import — breaking zero-import instantiation — and, once
+the DEFINED native `__extern_rest_object` (from #3223) was registered by another
+rest site in the same module, was **silently miscompiled**: the loop site passed
+a comma-joined excluded **string** as the 2nd arg, but the native helper takes an
+exclusion **object** (its `__extern_has(excl, key)` membership probe), so a
+string arg reports every key "absent" ⇒ NO key excluded ⇒ the rest object
+wrongly keeps the destructured keys.
+
+opus-leak2's standalone leak re-rank flagged `__extern_rest_object` as ~9
+sole-import host-free flips. Investigation on current main found the **9
+`for-await-of` tests were already host-free** via #3223's externref decl path
+(the standalone baseline was captured pre-#3223, so it was stale). The remaining
+real leak was the **for-of/for-await struct-typed loop-var rest** path — the 9
+`for-of/dstr/{const,let,var}-obj-ptrn-rest-{val-obj,getter,skip-non-enumerable}`
+tests — which this issue de-leaks.
+
+## Fix
+
+Extracted the #3223 native-rest emission into a shared
+`emitStandaloneObjectRest(ctx, fctx, emitSource, excludedKeys, restIdx)` helper
+(`src/codegen/destructuring-params.ts`): it builds the exclusion `$Object` (own
+keys = excluded names), invokes `emitSource` (which must leave an **open
+`$Object`** externref on the stack), and calls the native `__extern_rest_object`.
+
+- **loops.ts** (for-of/for-await struct-rest): added a `ctx.standalone||wasi`
+  branch that reifies the CLOSED-shape loop-element struct into an open
+  `$Object` via `materializeStructAsObject` (#3222 C1 — a bare
+  `extern.convert_any` is invisible to `__object_keys` and yields an EMPTY rest)
+  and routes to the shared helper. Host/gc lane below is byte-identical.
+- **destructuring-params.ts** (function-param rest): refactored its inline #3223
+  native branch to call the shared helper (behavior-identical; the param source
+  is already an open `$Object` externref, so no reification).
+- **assignment.ts** (`({a,...rest} = obj)`): **deferred** to a follow-up slice —
+  this path has two entangled sub-paths (an externref-RHS reader that never
+  collects the rest, and a struct-RHS path where `resultType` can be externref
+  while `structTypeIdx` names a struct), so a correct native route needs that
+  untangling first. Its test262 cases are all `fail` for INDEPENDENT reasons
+  (getter side-effects, computed keys, descriptor checks), so de-leaking flips
+  nothing today; deferring avoids regressing shim-provided runs. It keeps the
+  host import (leak), matching prior behaviour.
+
+## Acceptance
+
+- for-of/for-await object-rest instantiates host-free (empty imports `{}`) in
+  standalone AND wasi.
+- Correct own-enumerable copy semantics: excluded keys dropped, own getters
+  invoked ([[Get]]), non-enumerable props skipped.
+- Host/gc lane byte-identical (changes gated on `ctx.standalone || ctx.wasi`).
+- Regression test: `tests/issue-3241-standalone-forof-obj-rest.test.ts` (6
+  tests, all green). Existing `tests/issue-3222-standalone-closed-struct-enum`
+  + destructuring/rest suites still green.
+
+Flips the 9 `for-of/dstr` object-rest tests to host-free passes (the 9
+`for-await` siblings were already host-free via #3223).
+
+## Follow-up
+
+- Assignment-target object-rest (`({a,...rest} = obj)`) standalone de-leak —
+  needs the externref-RHS vs struct-RHS sub-path untangling. All-`fail` tests,
+  no flip today; low priority.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -52,6 +52,62 @@ import {
 } from "./statements/destructuring.js";
 
 /**
+ * (#3241) Emit the host-free object-rest CopyDataProperties (ES §14.7.4) for
+ * `--target standalone`/`wasi`, storing the fresh rest `$Object` into `restIdx`.
+ *
+ * Shared by every object-rest binding site (function-param rest, for-of/-await
+ * loop-var rest, assignment-target rest) so they all route to the DEFINED native
+ * `__extern_rest_object` (#3223) instead of the `env.__extern_rest_object` host
+ * import — which both LEAKS an env:: import (breaking zero-import instantiation)
+ * and, worse, is SILENTLY MISCOMPILED when the native func is already registered
+ * by another rest site: the host-import call sites pass a comma-joined excluded
+ * STRING, but the native helper takes an EXCLUSION OBJECT, so its
+ * `__extern_has(excl, key)` membership probe reports "absent" for the string and
+ * NO key is excluded (the rest object wrongly keeps the destructured keys).
+ *
+ * This helper builds the exclusion object (own keys = excluded property names;
+ * value is the key itself — only presence matters), then invokes `emitSource`,
+ * which MUST leave an **open-`$Object` externref** for the source on the stack
+ * (`__object_keys` walks only the open-`$Object` hash — a CLOSED-shape struct
+ * reinterpreted via `extern.convert_any` is invisible to it and yields an EMPTY
+ * rest, #3222 C1; struct sources must be reified via `materializeStructAsObject`
+ * inside `emitSource`). Returns `false` (caller keeps its host/gc path) if a
+ * dependency is unexpectedly missing. The host/gc lanes are untouched — this is
+ * gated on `ctx.standalone || ctx.wasi` at each call site.
+ */
+export function emitStandaloneObjectRest(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  emitSource: () => void,
+  excludedKeys: string[],
+  restIdx: number,
+): boolean {
+  const restObjIdx = ensureExternRestObject(ctx);
+  const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
+  const externSetIdx = ctx.funcMap.get("__extern_set");
+  if (restObjIdx === undefined || newPlainObjIdx === undefined || externSetIdx === undefined) return false;
+  const exclLocal = allocLocal(fctx, `__rest_excl_${fctx.locals.length}`, { kind: "externref" });
+  // excl = OrdinaryObjectCreate(null)
+  fctx.body.push({ op: "call", funcIdx: newPlainObjIdx });
+  fctx.body.push({ op: "local.set", index: exclLocal });
+  // for each excluded key: __extern_set(excl, key, key) — the value only needs
+  // to be non-null so the helper's membership probe (__extern_has) reports
+  // "present"; reuse the key's own externref as a cheap sentinel.
+  for (const key of excludedKeys) {
+    fctx.body.push({ op: "local.get", index: exclLocal });
+    for (const instr of stringConstantExternrefInstrs(ctx, key)) fctx.body.push(instr);
+    for (const instr of stringConstantExternrefInstrs(ctx, key)) fctx.body.push(instr);
+    fctx.body.push({ op: "call", funcIdx: externSetIdx });
+  }
+  // rest = __extern_rest_object(source, excl)
+  emitSource();
+  fctx.body.push({ op: "local.get", index: exclLocal });
+  fctx.body.push({ op: "call", funcIdx: restObjIdx });
+  fctx.body.push({ op: "local.set", index: restIdx });
+  return true;
+}
+
+/**
  * #2032 — resolve the static property key for an object binding element.
  *
  * For a plain identifier or string/numeric literal property name the key is
@@ -545,29 +601,17 @@ export function destructureParamObjectExternref(
       // and no delimiter false-match. The host/gc branch below is byte-identical
       // to the prior behaviour.
       if (ctx.standalone || ctx.wasi) {
-        const restObjIdx = ensureExternRestObject(ctx);
+        // The param is an externref (already an open `$Object` at runtime), so
+        // no `materializeStructAsObject` reification is needed here.
+        const ok = emitStandaloneObjectRest(
+          ctx,
+          fctx,
+          () => fctx.body.push({ op: "local.get", index: paramIdx }),
+          excludedKeys,
+          restIdx,
+        );
         getIdx = ctx.funcMap.get("__extern_get");
-        const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
-        const externSetIdx = ctx.funcMap.get("__extern_set");
-        if (restObjIdx === undefined || newPlainObjIdx === undefined || externSetIdx === undefined) continue;
-        const exclLocal = allocLocal(fctx, `__rest_excl_${fctx.locals.length}`, { kind: "externref" });
-        // excl = OrdinaryObjectCreate(null)
-        fctx.body.push({ op: "call", funcIdx: newPlainObjIdx });
-        fctx.body.push({ op: "local.set", index: exclLocal });
-        // for each excluded key: __extern_set(excl, key, key) — the value only
-        // needs to be non-null so the helper's membership probe (__extern_get)
-        // reports "present"; reuse the key's own externref as a cheap sentinel.
-        for (const key of excludedKeys) {
-          fctx.body.push({ op: "local.get", index: exclLocal });
-          for (const instr of stringConstantExternrefInstrs(ctx, key)) fctx.body.push(instr);
-          for (const instr of stringConstantExternrefInstrs(ctx, key)) fctx.body.push(instr);
-          fctx.body.push({ op: "call", funcIdx: externSetIdx });
-        }
-        // rest = __extern_rest_object(obj, excl)
-        fctx.body.push({ op: "local.get", index: paramIdx });
-        fctx.body.push({ op: "local.get", index: exclLocal });
-        fctx.body.push({ op: "call", funcIdx: restObjIdx });
-        fctx.body.push({ op: "local.set", index: restIdx });
+        if (!ok) continue;
         if (isDecl) emitLocalTdzInit(fctx, restName);
         continue;
       }

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -30,11 +30,7 @@ import {
 } from "../index.js";
 import { getSubviewArrTypeIdx, isSubviewTypeIdx, isTaViewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write; (#3054 B1) TA view write
 import { emitTaDynViewElementSet, emitTaViewElementSet } from "../dataview-native.js"; // (#3054 B1) shared-backing TA view write; (#3057) dynamic view element write
-import {
-  buildDestructureNullThrow,
-  emitStandaloneObjectRest,
-  patternIteratorStepCount,
-} from "../destructuring-params.js";
+import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { resolveReceiverStruct } from "../fnctor-escape-gate.js"; // (#2681/#2686 A3) pinned-struct write dispatch
 import { reserveMemberSetDispatch } from "../member-set-dispatch.js"; // (#2681/#2686 A3) pre-check set dispatcher
@@ -1482,17 +1478,6 @@ function compileDestructuringAssignment(
             else if (ts.isNumericLiteral(pn)) excludedKeys.push(pn.text);
           }
         }
-        // (#3241) NOTE: the standalone/WASI object-rest de-leak for the
-        // ASSIGNMENT target path (`({a, ...rest} = obj)`) is deferred to a
-        // follow-up slice. Unlike the decl / for-of / function-param rest sites,
-        // this path has two entangled sub-paths (an externref-RHS reader that
-        // never collects the rest at all, and this struct-RHS path where
-        // `resultType` can be externref while `structTypeIdx` names a struct), so
-        // a correct native route needs that untangling first. Its test262 cases
-        // are all `fail` for INDEPENDENT reasons (getter side-effects, computed
-        // keys, descriptor checks), so de-leaking flips nothing today — deferring
-        // avoids regressing shim-provided runs. It keeps the host import (leak)
-        // below, matching prior behaviour.
         // Use __extern_rest_object(externObj, excludedKeysStr)
         let restObjIdx = ctx.funcMap.get("__extern_rest_object");
         if (restObjIdx === undefined) {

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -30,7 +30,11 @@ import {
 } from "../index.js";
 import { getSubviewArrTypeIdx, isSubviewTypeIdx, isTaViewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write; (#3054 B1) TA view write
 import { emitTaDynViewElementSet, emitTaViewElementSet } from "../dataview-native.js"; // (#3054 B1) shared-backing TA view write; (#3057) dynamic view element write
-import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
+import {
+  buildDestructureNullThrow,
+  emitStandaloneObjectRest,
+  patternIteratorStepCount,
+} from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { resolveReceiverStruct } from "../fnctor-escape-gate.js"; // (#2681/#2686 A3) pinned-struct write dispatch
 import { reserveMemberSetDispatch } from "../member-set-dispatch.js"; // (#2681/#2686 A3) pre-check set dispatcher
@@ -1478,6 +1482,17 @@ function compileDestructuringAssignment(
             else if (ts.isNumericLiteral(pn)) excludedKeys.push(pn.text);
           }
         }
+        // (#3241) NOTE: the standalone/WASI object-rest de-leak for the
+        // ASSIGNMENT target path (`({a, ...rest} = obj)`) is deferred to a
+        // follow-up slice. Unlike the decl / for-of / function-param rest sites,
+        // this path has two entangled sub-paths (an externref-RHS reader that
+        // never collects the rest at all, and this struct-RHS path where
+        // `resultType` can be externref while `structTypeIdx` names a struct), so
+        // a correct native route needs that untangling first. Its test262 cases
+        // are all `fail` for INDEPENDENT reasons (getter side-effects, computed
+        // keys, descriptor checks), so de-leaking flips nothing today — deferring
+        // avoids regressing shim-provided runs. It keeps the host import (leak)
+        // below, matching prior behaviour.
         // Use __extern_rest_object(externObj, excludedKeysStr)
         let restObjIdx = ctx.funcMap.get("__extern_rest_object");
         if (restObjIdx === undefined) {

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -17,7 +17,11 @@ import { reportError, reportErrorNoNode } from "../context/errors.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext, HoistedCharRead } from "../context/types.js";
-import { emitExternrefDestructureGuard, emitObjectPatternRestFromVec } from "../destructuring-params.js";
+import {
+  emitExternrefDestructureGuard,
+  emitObjectPatternRestFromVec,
+  emitStandaloneObjectRest,
+} from "../destructuring-params.js";
 import {
   emitAssignToTarget,
   findUnresolvableInArrayPattern,
@@ -57,6 +61,7 @@ import {
   compileExpression,
   compileStatement,
   emitBoundsCheckedArrayGet,
+  materializeStructAsObject,
   valTypesMatch,
 } from "../shared.js";
 import {
@@ -1459,6 +1464,32 @@ export function compileForOfDestructuring(
               if (ts.isIdentifier(pn)) excludedKeys.push(pn.text);
               else if (ts.isStringLiteral(pn)) excludedKeys.push(pn.text);
               else if (ts.isNumericLiteral(pn)) excludedKeys.push(pn.text);
+            }
+            // (#3241) Standalone/WASI: route to the DEFINED native
+            // __extern_rest_object (exclusion-OBJECT signature) instead of the
+            // `env.__extern_rest_object` host import — which leaks an env::
+            // import AND is silently miscompiled if the native func is already
+            // registered (the CSV-string 2nd arg is not an exclusion object, so
+            // no key gets excluded). Host/gc lane below is byte-identical.
+            if (ctx.standalone || ctx.wasi) {
+              // The loop element is a CLOSED-shape struct; reify it into an open
+              // `$Object` (#3222 C1) so `__object_keys` enumeration sees the
+              // fields — a bare `extern.convert_any` would yield an EMPTY rest.
+              emitStandaloneObjectRest(
+                ctx,
+                fctx,
+                () => {
+                  fctx.body.push({ op: "local.get", index: elemLocal });
+                  if (elemType.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
+                  if (!materializeStructAsObject(ctx, fctx, structTypeIdx, { skipInternalFields: true })) {
+                    // Declined — struct ref still on stack; reinterpret as-is.
+                    fctx.body.push({ op: "extern.convert_any" } as Instr);
+                  }
+                },
+                excludedKeys,
+                restIdx,
+              );
+              continue;
             }
             let restObjIdx = ctx.funcMap.get("__extern_rest_object");
             if (restObjIdx === undefined) {

--- a/tests/issue-3241-standalone-forof-obj-rest.test.ts
+++ b/tests/issue-3241-standalone-forof-obj-rest.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3241 — native object-rest CopyDataProperties (ES §14.7.4) for the
+ * FOR-OF / FOR-AWAIT loop-var rest binding in standalone / WASI.
+ *
+ * #3223 made the DECL (`const {a,...rest} = o`) and function-PARAM rest paths
+ * host-free (routing to the DEFINED native `__extern_rest_object` with an
+ * exclusion-OBJECT arg). The for-of/for-await loop-var rest site
+ * (`for (const {a,...rest} of arr)`) still emitted the `env.__extern_rest_object`
+ * host import — which both LEAKS an env:: import (breaking zero-import
+ * instantiation) AND, once the native func was registered by another rest site
+ * in the same module, was silently miscompiled (the host site passed a
+ * comma-joined excluded STRING, not the exclusion OBJECT the native helper
+ * expects, so `__extern_has` reported "absent" and NO key was excluded).
+ *
+ * These tests instantiate with an EMPTY import object (`{}`) to prove genuine
+ * host-free enumeration, and assert exclusion + own-enumerable-copy semantics
+ * (including getter [[Get]] invocation and non-enumerable skipping).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string, target: "standalone" | "wasi" = "standalone"): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  // No `env::__extern_rest_object` (nor any env:: import) should be emitted.
+  expect(/import "env" "__extern_rest_object"/.test(r.wat ?? ""), "leaked env::__extern_rest_object").toBe(false);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f(): number }).f();
+}
+
+describe("#3241 — standalone for-of object-rest", () => {
+  it("rest keeps the remaining own keys and excludes the named binding", async () => {
+    // {a,...rest} of {a:1,x:2,y:3} → rest keys = [x,y] → length 2
+    expect(
+      await runStandalone(`export function f(): number {
+        let n = 0;
+        for (const { a, ...rest } of [{ a: 1, x: 2, y: 3 }]) { n = Object.keys(rest).length; }
+        return n; }`),
+    ).toBe(2);
+  });
+
+  it("rest carries the correct VALUES and drops the excluded key", async () => {
+    // rest.x + rest.y = 2 + 3 = 5, and rest.a is undefined (excluded)
+    expect(
+      await runStandalone(`export function f(): number {
+        let s = 0;
+        for (const { a, ...rest } of [{ a: 1, x: 2, y: 3 }]) {
+          s = (rest.x || 0) + (rest.y || 0) + (rest.a ? 100 : 0);
+        }
+        return s; }`),
+    ).toBe(5);
+  });
+
+  it("multi-binding rest excludes every named binding", async () => {
+    // {a,b,...rest} of {x:1,y:2,a:5,b:3} → rest keys = [x,y] → length 2
+    expect(
+      await runStandalone(`export function f(): number {
+        let n = 0;
+        for (const { a, b, ...rest } of [{ x: 1, y: 2, a: 5, b: 3 }]) { n = Object.keys(rest).length; }
+        return n; }`),
+    ).toBe(2);
+  });
+
+  it("rest invokes own getters ([[Get]]) when copying values", async () => {
+    // rest.y reads the getter's returned 42; rest.x = 1 → 43
+    expect(
+      await runStandalone(`export function f(): number {
+        let n = 0;
+        const src = { x: 1, get y() { return 42; }, a: 9 };
+        for (const { a, ...rest } of [src]) { n = (rest.x || 0) + (rest.y || 0); }
+        return n; }`),
+    ).toBe(43);
+  });
+
+  it("rest skips non-enumerable own properties", async () => {
+    // "hidden" is defined non-enumerable → not copied; rest.x = 2 → 2
+    expect(
+      await runStandalone(`export function f(): number {
+        const o: any = { a: 1, x: 2 };
+        Object.defineProperty(o, "hidden", { value: 99, enumerable: false });
+        let n = 0;
+        for (const { a, ...rest } of [o]) { n = (rest.x || 0) + (rest.hidden ? 100 : 0); }
+        return n; }`),
+    ).toBe(2);
+  });
+
+  it("wasi target enumerates the for-of rest the same way", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+          let n = 0;
+          for (const { a, ...rest } of [{ a: 1, x: 2, y: 3 }]) { n = Object.keys(rest).length; }
+          return n; }`,
+        "wasi",
+      ),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

Under `--target standalone`/`wasi`, the object-rest loop-var binding in a
`for (const { a, ...rest } of arr)` / `for await (...)` still emitted the
`env.__extern_rest_object` **host import** (`src/codegen/statements/loops.ts`).
That leaks an `env::` import — breaking zero-import instantiation — and, once the
DEFINED native `__extern_rest_object` (#3223) was registered by another rest site
in the same module, was **silently miscompiled**: the loop site passed a
comma-joined excluded **string** as the 2nd arg, but the native helper takes an
exclusion **object** (`__extern_has(excl, key)` membership), so a string arg
reports every key "absent" ⇒ NO key excluded ⇒ the rest object wrongly keeps the
destructured keys.

opus-leak2's standalone leak re-rank flagged `__extern_rest_object` as ~9
sole-import host-free flips. On current main the 9 `for-await-of` tests were
**already host-free** via #3223's decl path (the standalone baseline was stale,
captured pre-#3223). The real remaining leak is the **for-of/for-await
struct-typed loop-var rest** — the 9 `for-of/dstr/{const,let,var}-obj-ptrn-rest-{val-obj,getter,skip-non-enumerable}`
tests — which this PR de-leaks.

## Fix

- Extract #3223's native-rest emission into a shared
  `emitStandaloneObjectRest(ctx, fctx, emitSource, excludedKeys, restIdx)`
  (`destructuring-params.ts`): builds the exclusion `$Object`, invokes
  `emitSource` (must leave an open `$Object` externref), calls native
  `__extern_rest_object`.
- **loops.ts**: added a `ctx.standalone||wasi` branch that reifies the
  closed-shape loop element into an open `$Object` via `materializeStructAsObject`
  (#3222 C1 — a bare `extern.convert_any` is invisible to `__object_keys` and
  yields an EMPTY rest) and routes to the helper.
- **destructuring-params.ts**: refactored its inline #3223 native branch onto the
  shared helper (behavior-identical; param source is already an open `$Object`).
- **assignment.ts** (`({a,...rest} = obj)`): **deferred** to a follow-up — its
  entangled externref-RHS/struct-RHS sub-paths need untangling first, and its
  test262 cases are all `fail` for independent reasons (getters/computed/desc),
  so de-leaking flips nothing today. Keeps the host import (leak), unchanged.

Host/gc lane byte-identical (all changes gated on `ctx.standalone || ctx.wasi`;
verified the default target still emits the host import).

## Tests

- New `tests/issue-3241-standalone-forof-obj-rest.test.ts` (6 tests): host-free
  instantiation (`{}` imports) + exclusion, correct values, multi-binding,
  getter [[Get]] invocation, non-enumerable skip, wasi target — all green.
- Existing `tests/issue-3222-standalone-closed-struct-enum` + destructuring/rest
  suites still green.

Flips the 9 `for-of/dstr` object-rest tests to host-free passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8