### PR TITLE
fix(#3237): Slice 2 — any-receiver DisposableStack defer/adopt/use native dispatch

### DIFF
--- a/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
+++ b/plan/issues/3237-standalone-any-receiver-builtin-native-dispatch.md
@@ -1,10 +1,11 @@
 ---
 id: 3237
 title: "Standalone: any-receiver dispatch for builtin-native methods (DisposableStack/Map/Set/…) leaks host imports"
-status: in-progress
-assignee: opus-anyrecv
+status: done
+assignee: opus-anyrecv2
 created: 2026-07-13
 updated: 2026-07-13
+completed: 2026-07-13
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -138,8 +139,64 @@ are inert for programs that don't use it.
 - Wired into `tryExternClassMethodOnAny` (calls-closures.ts) and
   `compilePropertyAccess` (property-access.ts).
 
-**Remaining (Slice 2 / future):** the callback methods `defer`/`adopt`/`use` on an
-`any` receiver still leak — they additionally need the standalone closure gate
-(`closures.ts`) to fire on the any-receiver path (currently only reached when the
-call is recognised as a typed native DisposableStack method). Also the broader
-`Map`/`Set`/`WeakMap`/… any-receiver `className ===` arms (out of Slice-1 scope).
+**Remaining (future):** the broader `Map`/`Set`/`WeakMap`/… any-receiver
+`className ===` arms (out of scope here — DisposableStack-specific).
+
+## Slice 2 — DONE (PR pending)
+
+**Scope shipped:** the callback methods `defer(cb)` / `adopt(value, cb)` /
+`use(value)` on an `any`/externref receiver, plus a value-position `undefined`
+correctness fix that also covered a latent Slice-1 `dispose` bug.
+
+**Root cause confirmed (measure-first, on current main):** a `let s: any = new
+DisposableStack(); s.defer(fn)` / `s.adopt(v, fn)` / `s.use(v)` reached
+`tryExternClassMethodOnAny`'s first-match extern loop and lazily bound
+`env::DisposableStack_defer` / `_adopt` / `_use` HOST imports — module fails to
+instantiate standalone, exactly the Slice-1 `dispose` leak for the callback
+methods. (Reproduced: each leaked its sole `DisposableStack_*` import.) The
+`__make_callback` bridge did NOT additionally leak — the #3235 standalone gate
+already degrades the `defer`/`adopt` arrow callbacks to native first-class
+closures.
+
+**Implementation** (`disposable-runtime.ts`, gated `ctx.nativeStrings`; host lane
+byte-identical because the whole path is unreachable in host mode):
+- `tryCompileNativeDisposableStackAnyMethodCall` now routes `defer`/`adopt`/`use`
+  to `compileNativeDisposableStackAnyCallbackMethod`.
+- `compileNativeDisposableStackAnyCallbackMethod` — evaluates receiver + args ONCE
+  into externref locals (call-site order), then `ref.test $DisposableStack`: hit →
+  the native `__disposablestack_append` (defer/adopt) substrate; miss → a clean
+  TypeError (RequireInternalSlot, §12.3.3.{2,4}) — never the host import, never a
+  `ref.cast_null` trap on a non-stack ref (the append/use helpers cast externref→
+  struct and would trap without the brand gate). `use` delegates to
+  `compileNativeDisposableStackAnyUse`, wrapping the typed use logic
+  (disposed-throw + `GetDisposeMethod(value, @@dispose)` read + conditional
+  append) in the same guard; a non-stack `this` → TypeError, null/undefined
+  `value` → return value with no resource added.
+- **funcIdx-ordering (the crux):** every late import is registered FIRST (the
+  append/check helpers → `__new_ReferenceError`; object substrate →
+  `__extern_get`/`__box_symbol`/`__extern_is_undefined`); the guard TypeError's
+  `buildThrowJsErrorInstrs` performs the final `flushLateImportShifts` against
+  `fctx.body`; only THEN are the native helper funcIdxs re-fetched from
+  `ctx.funcMap` (post-shift, final) and baked into the nested `if` arms. No late
+  import registers after the re-fetch. (The value-position `emitUndefined` runs
+  AFTER the `if` is in `fctx.body`, so any shift it triggers correctly updates the
+  baked `appendIdx` via the recursive nested-body shifter.)
+
+**Value-position `undefined` fix (Slice-1 defect, also affected Slice 2 `defer`):**
+`dispose()`/`defer()` in value position returned a raw `ref.null.extern`, but
+under the #2106 undefined-singleton regime `x === undefined` compares against the
+SINGLETON, not null — so `let u = s.dispose(); u === undefined` was FALSE
+(`returns-undefined.js`). Fixed to emit the canonical undefined via
+`emitUndefined` (the singleton in standalone, `__get_undefined` in host). This
+un-breaks the pre-existing Slice-1 `returns undefined (value position)` unit test
+(deterministically red on main, but not in the `quality` CI gate's named-file
+allowlist, so it never blocked main).
+
+**Verified host-free + correct** (`tests/issue-3237-…`): defer LIFO, adopt returns
+value + disposes it, use runs `value[Symbol.dispose]()`, use(null) returns value,
+reverse-order dispose across all three registrars, `=== undefined` for
+dispose/defer value position, user-object `defer` still routes to the #2151
+closed-struct path (via the #3033 refusal), typed nominal path unchanged. No
+`DisposableStack_*` / `__make_callback` import on any. This slice + the landed
+#3234 SuppressedError aggregation flip the dispose-SuppressedError cluster
+host-free.

--- a/src/codegen/disposable-runtime.ts
+++ b/src/codegen/disposable-runtime.ts
@@ -47,6 +47,7 @@ import { coerceType, compileExpression, ensureLateImport, flushLateImportShifts,
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitUndefined } from "./expressions/late-imports.js";
 import { BUILTIN_TYPE_TAGS } from "./builtin-tags.js";
 
 const EXTERNREF: ValType = { kind: "externref" };
@@ -682,7 +683,12 @@ export function tryCompileNativeDisposableStackAnyMethodCall(
   methodName: string,
 ): InnerResult | undefined {
   if (!ctx.nativeStrings) return undefined;
-  // Slice 1: `dispose` (zero-arg) only. Callback methods are Slice 2.
+  // Slice 2: the callback methods `defer`/`adopt`/`use` route through the native
+  // append/use substrate guarded by the same `ref.test $DisposableStack` shape
+  // dispatch. Slice 1 handles `dispose` below.
+  if (methodName === "defer" || methodName === "adopt" || methodName === "use") {
+    return compileNativeDisposableStackAnyCallbackMethod(ctx, fctx, propAccess, callExpr, methodName);
+  }
   if (methodName !== "dispose") return undefined;
   if (callExpr.arguments.length !== 0) return undefined;
 
@@ -716,15 +722,253 @@ export function tryCompileNativeDisposableStackAnyMethodCall(
   } as Instr);
 
   // `dispose()` returns undefined. In a VALUE position (`assert.sameValue(
-  // s.dispose(), undefined)` — returns-undefined.js) hand back the undefined
-  // singleton (null externref ≡ undefined in standalone; cf. the DataView-setter
-  // precedent in calls.ts) so the caller's argument stack stays balanced.
+  // s.dispose(), undefined)` — returns-undefined.js) hand back the canonical
+  // undefined value via `emitUndefined` so the caller's stack stays balanced AND
+  // a subsequent `=== undefined` compares equal. A raw `ref.null.extern` is NOT
+  // the undefined singleton under the #2106 regime (`x === undefined` checks the
+  // singleton, not null), so `let u = s.dispose(); u === undefined` was false —
+  // `emitUndefined` emits the singleton (standalone) / `__get_undefined` (host).
   // Statement position keeps the zero-cost VOID_RESULT.
   if (!ts.isExpressionStatement(callExpr.parent)) {
-    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    emitUndefined(ctx, fctx);
     return { kind: "externref" };
   }
   return VOID_RESULT;
+}
+
+/**
+ * (#3237 Slice 2) The callback DisposableStack methods — `defer(cb)` /
+ * `adopt(value, cb)` / `use(value)` — on an `any`/externref receiver. Same leak
+ * as Slice 1's `dispose`: reaching `tryExternClassMethodOnAny`'s first-match
+ * extern loop, an `any`-typed `stack.defer(fn)` / `stack.adopt(v, fn)` /
+ * `stack.use(v)` would otherwise bind the `DisposableStack_defer` / `_adopt` /
+ * `_use` HOST import — unsatisfiable standalone, so the module fails to
+ * instantiate BEFORE dispose ever runs (this is the residual leak of the
+ * dispose/defer test262 cluster the #3234 SuppressedError aggregation was a
+ * prerequisite for).
+ *
+ * Dispatch on the RUNTIME shape instead: `ref.test $DisposableStack` on the
+ * receiver. Match → the SAME native append (`defer`/`adopt`) / use substrate the
+ * typed path uses. Miss (incl. null/undefined) → a clean TypeError
+ * (RequireInternalSlot, §12.3.3.{2,4} step 1) — NEVER the host import, and never a
+ * `ref.cast_null` trap (the append/use helpers cast externref→struct and would
+ * trap on a non-stack non-null ref, so the brand test must gate them).
+ *
+ * The receiver and args are evaluated ONCE into externref locals BEFORE the guard
+ * — preserving JS call-site evaluation order (arguments are evaluated before the
+ * method body runs, so a non-stack receiver still evaluates its args). The
+ * `defer`/`adopt` callbacks compile as native first-class WasmGC closures via the
+ * standalone closure gate (#3235), so no `__make_callback` host bridge leaks.
+ *
+ * funcIdx-ordering (the crux, cf. the late-import shifter in index.ts): every
+ * late import is registered FIRST (append/use helpers → `__new_ReferenceError`;
+ * the object substrate → `__box_symbol`/`__extern_is_undefined`/`__extern_get`;
+ * the guard TypeError → `__new_ReferenceError`/`__new_TypeError`), the guard
+ * TypeError's `buildThrowJsErrorInstrs` performs the final `flushLateImportShifts`
+ * against `fctx.body` (fixing the already-emitted receiver/arg eval), and only
+ * THEN are the native helper funcIdxs re-fetched from `ctx.funcMap` (post-shift,
+ * final) and baked into the nested `if` arms. No late import is registered after
+ * that re-fetch, so the baked indices stay valid.
+ */
+function compileNativeDisposableStackAnyCallbackMethod(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  methodName: string,
+): InnerResult {
+  const t = ensureDisposableStackTypes(ctx);
+  const args = callExpr.arguments;
+
+  // Evaluate the receiver ONCE into an externref local (consumed by the brand
+  // test AND, on a hit, the native op).
+  const recvLocal = allocLocal(fctx, `__ds_anyrecv_${fctx.locals.length}`, EXTERNREF);
+  const rt = compileExpression(ctx, fctx, propAccess.expression);
+  if (rt !== null && rt.kind !== "externref") coerceType(ctx, fctx, rt, EXTERNREF);
+  fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
+
+  // `ref.test (ref $DisposableStack)` is 0 for null and for a non-matching ref, so
+  // a null/undefined/wrong-type receiver lands in the TypeError arm — matching
+  // RequireInternalSlot without ever emitting the host import.
+  const brandTest = (): Instr[] => [
+    { op: "local.get", index: recvLocal } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx: t.stackTypeIdx } as Instr,
+  ];
+  const guardMsg = `DisposableStack.prototype.${methodName} requires a DisposableStack receiver`;
+
+  if (methodName === "defer") {
+    ensureDisposableStackAppend(ctx); // register the helper + its late imports
+    // Eval callback → cbLocal (after receiver — call-site order).
+    const cbLocal = allocLocal(fctx, `__ds_cb_${fctx.locals.length}`, EXTERNREF);
+    if (args[0]) compileArgAsExternref(ctx, fctx, args[0]);
+    else fctx.body.push({ op: "ref.null.extern" } as Instr);
+    fctx.body.push({ op: "local.set", index: cbLocal } as Instr);
+    // Guard TypeError registers the last late import + flushes fctx; fetch the
+    // append funcIdx AFTER so the bake is post-shift.
+    const elseThrow = buildThrowJsErrorInstrs(ctx, "TypeError", guardMsg, { flush: fctx });
+    const appendIdx = ctx.funcMap.get("__disposablestack_append")!;
+    fctx.body.push(...brandTest());
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: recvLocal } as Instr,
+        { op: "local.get", index: cbLocal } as Instr,
+        { op: "ref.null.extern" } as Instr, // value = null
+        { op: "i32.const", value: ENTRY_KIND_DEFER } as Instr,
+        { op: "call", funcIdx: appendIdx } as Instr,
+      ],
+      else: elseThrow,
+    } as Instr);
+    // `defer()` returns undefined (VOID in statement position; the canonical
+    // undefined value via `emitUndefined` in value position — so `=== undefined`
+    // compares equal, matching Slice 1 `dispose`). The guarded `if` is already in
+    // `fctx.body`, so any late-import shift `emitUndefined` triggers correctly
+    // updates the `appendIdx` baked in its `then` arm.
+    if (!ts.isExpressionStatement(callExpr.parent)) {
+      emitUndefined(ctx, fctx);
+      return { kind: "externref" };
+    }
+    return VOID_RESULT;
+  }
+
+  if (methodName === "adopt") {
+    ensureDisposableStackAppend(ctx);
+    // adopt(value, onDispose) — eval value then onDispose; return value.
+    const valueLocal = allocLocal(fctx, `__ds_val_${fctx.locals.length}`, EXTERNREF);
+    if (args[0]) compileArgAsExternref(ctx, fctx, args[0]);
+    else fctx.body.push({ op: "ref.null.extern" } as Instr);
+    fctx.body.push({ op: "local.set", index: valueLocal } as Instr);
+    const cbLocal = allocLocal(fctx, `__ds_cb_${fctx.locals.length}`, EXTERNREF);
+    if (args[1]) compileArgAsExternref(ctx, fctx, args[1]);
+    else fctx.body.push({ op: "ref.null.extern" } as Instr);
+    fctx.body.push({ op: "local.set", index: cbLocal } as Instr);
+    const elseThrow = buildThrowJsErrorInstrs(ctx, "TypeError", guardMsg, { flush: fctx });
+    const appendIdx = ctx.funcMap.get("__disposablestack_append")!;
+    fctx.body.push(...brandTest());
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: recvLocal } as Instr,
+        { op: "local.get", index: cbLocal } as Instr,
+        { op: "local.get", index: valueLocal } as Instr,
+        { op: "i32.const", value: ENTRY_KIND_ADOPT } as Instr,
+        { op: "call", funcIdx: appendIdx } as Instr,
+      ],
+      else: elseThrow,
+    } as Instr);
+    // adopt returns the value (§12.3.3.4 step 5). The throw arm is unreachable, so
+    // the post-`if` `value` is the sole result on both statement/value positions.
+    fctx.body.push({ op: "local.get", index: valueLocal } as Instr);
+    return { kind: "externref" };
+  }
+
+  // methodName === "use": value[Symbol.dispose] member-lookup disposer (§12.3.3.3).
+  return compileNativeDisposableStackAnyUse(ctx, fctx, propAccess, callExpr, recvLocal, brandTest, guardMsg);
+}
+
+/**
+ * (#3237 Slice 2) `DisposableStack.prototype.use(value)` on an `any` receiver —
+ * the typed-path use logic (`compileNativeDisposableStackUse`) wrapped in the
+ * `ref.test $DisposableStack` brand guard. Steps (§12.3.3.3): RequireInternalSlot
+ * (the brand test — a non-stack `this` throws TypeError, matching step 1's
+ * distinction from the disposed ReferenceError), then disposed-throw + the
+ * GetDisposeMethod(value, @@dispose) read + conditional append, all inside the
+ * hit arm. The value arg is evaluated up front (call-site order) into a local so
+ * the miss/TypeError arm still evaluates it. Returns the value.
+ */
+function compileNativeDisposableStackAnyUse(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  recvLocal: number,
+  brandTest: () => Instr[],
+  guardMsg: string,
+): InnerResult {
+  void propAccess;
+  const args = callExpr.arguments;
+  const valueLocal = allocLocal(fctx, `__ds_val_${fctx.locals.length}`, EXTERNREF);
+  const methodLocal = allocLocal(fctx, `__ds_method_${fctx.locals.length}`, EXTERNREF);
+
+  // Eval value → valueLocal (after receiver — call-site order).
+  if (args[0]) compileArgAsExternref(ctx, fctx, args[0]);
+  else fctx.body.push({ op: "ref.null.extern" } as Instr);
+  fctx.body.push({ op: "local.set", index: valueLocal } as Instr);
+
+  // Register every late import BEFORE the final flush: the append/check helpers
+  // (→ `__new_ReferenceError`), the object substrate (`__extern_get`), and
+  // `__box_symbol`/`__extern_is_undefined`.
+  ensureDisposableStackAppend(ctx);
+  ensureDisposableStackCheckActive(ctx);
+  ensureObjectRuntime(ctx);
+  ensureLateImport(ctx, "__box_symbol", [I32], [EXTERNREF]);
+  ensureLateImport(ctx, "__extern_is_undefined", [EXTERNREF], [I32]);
+  // The guard TypeError registers the final late import (`__new_TypeError`) and
+  // performs the flush against fctx.body; fetch every helper funcIdx AFTER.
+  const elseThrow = buildThrowJsErrorInstrs(ctx, "TypeError", guardMsg, { flush: fctx });
+  const appendIdx = ctx.funcMap.get("__disposablestack_append")!;
+  const checkIdx = ctx.funcMap.get("__disposablestack_check_active")!;
+  const externGetIdx = ctx.funcMap.get("__extern_get");
+  const boxSymIdx = ctx.funcMap.get("__box_symbol");
+  const isUndefinedIdx = ctx.funcMap.get("__extern_is_undefined");
+  if (externGetIdx === undefined || boxSymIdx === undefined || isUndefinedIdx === undefined) {
+    // Substrate unavailable (should not happen once ensureObjectRuntime ran) —
+    // keep the body balanced: value was evaluated for side effects; return it.
+    fctx.body.push({ op: "local.get", index: valueLocal } as Instr);
+    return { kind: "externref" };
+  }
+
+  // Regime-independent "is null OR undefined" for a value held in `localIdx`
+  // (mirrors the typed use path — cover both the boxed-undefined and the
+  // undefined-singleton regimes).
+  const nullishOf = (localIdx: number): Instr[] => [
+    { op: "local.get", index: localIdx } as Instr,
+    { op: "ref.is_null" } as Instr,
+    { op: "local.get", index: localIdx } as Instr,
+    { op: "call", funcIdx: isUndefinedIdx } as Instr,
+    { op: "i32.or" } as Instr,
+  ];
+
+  // Hit arm: disposed-throw check, then GetDisposeMethod + conditional append.
+  const hit: Instr[] = [];
+  hit.push({ op: "local.get", index: recvLocal } as Instr);
+  hit.push({ op: "call", funcIdx: checkIdx } as Instr);
+
+  // if !nullish(value): method = __extern_get(value, __box_symbol(13)); validate; append.
+  const nonNullishBody: Instr[] = [];
+  nonNullishBody.push({ op: "local.get", index: valueLocal } as Instr);
+  nonNullishBody.push({ op: "i32.const", value: SYMBOL_DISPOSE_ID } as Instr);
+  nonNullishBody.push({ op: "call", funcIdx: boxSymIdx } as Instr);
+  nonNullishBody.push({ op: "call", funcIdx: externGetIdx } as Instr);
+  nonNullishBody.push({ op: "local.set", index: methodLocal } as Instr);
+  nonNullishBody.push(...nullishOf(methodLocal));
+  nonNullishBody.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: buildThrowJsErrorInstrs(ctx, "TypeError", "DisposableStack.prototype.use: value is not disposable", {
+      flush: fctx,
+    }),
+    else: [],
+  } as Instr);
+  nonNullishBody.push({ op: "local.get", index: recvLocal } as Instr);
+  nonNullishBody.push({ op: "local.get", index: methodLocal } as Instr);
+  nonNullishBody.push({ op: "local.get", index: valueLocal } as Instr);
+  nonNullishBody.push({ op: "i32.const", value: ENTRY_KIND_USE } as Instr);
+  nonNullishBody.push({ op: "call", funcIdx: appendIdx } as Instr);
+
+  hit.push(...nullishOf(valueLocal));
+  hit.push({ op: "i32.eqz" } as Instr);
+  hit.push({ op: "if", blockType: { kind: "empty" }, then: nonNullishBody, else: [] } as Instr);
+
+  fctx.body.push(...brandTest());
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: hit, else: elseThrow } as Instr);
+
+  // Return value.
+  fctx.body.push({ op: "local.get", index: valueLocal } as Instr);
+  return { kind: "externref" };
 }
 
 /**

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -1461,15 +1461,16 @@ export function tryExternClassMethodOnAny(
     return true;
   };
 
-  // (#3237 Slice 1) Native `DisposableStack` dispatch on an `any` receiver.
+  // (#3237 Slice 1/2) Native `DisposableStack` dispatch on an `any` receiver.
   // Reaching here means every ambiguity/user-member refusal above already
   // passed, so if `DisposableStack` is a registered extern class declaring this
   // method the first-match loop below WOULD bind it to the `DisposableStack_*`
   // HOST import (unsatisfiable standalone → module fails to instantiate before
   // dispose runs). In `nativeStrings` mode, run a `ref.test $DisposableStack`
   // runtime dispatch to the native driver instead (miss → clean TypeError, never
-  // the import). Gated inside the helper to Slice-1 `dispose`; other methods fall
-  // through to the loop unchanged. Host lane (`!nativeStrings`) is untouched.
+  // the import). The helper handles `dispose` (Slice 1) + `defer`/`adopt`/`use`
+  // (Slice 2); other methods fall through to the loop unchanged. Host lane
+  // (`!nativeStrings`) is untouched.
   if (ctx.nativeStrings && ctx.externClasses.get("DisposableStack")?.methods.has(methodName)) {
     const dsAny = tryCompileNativeDisposableStackAnyMethodCall(ctx, fctx, propAccess, expr, methodName);
     if (dsAny !== undefined) return dsAny;

--- a/tests/issue-3237-standalone-any-receiver-disposablestack.test.ts
+++ b/tests/issue-3237-standalone-any-receiver-disposablestack.test.ts
@@ -130,4 +130,128 @@ describe("#3237 slice 1 — any-receiver DisposableStack dispose/disposed", () =
       ),
     ).toBe(1);
   });
+
+  it("dispose() in value position === undefined (undefined singleton, not raw null)", async () => {
+    // returns-undefined.js: the value handed back must compare `=== undefined`.
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); let u = s.dispose(); return (u === undefined) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+// #3237 Slice 2 — the callback methods `defer(cb)` / `adopt(value, cb)` /
+// `use(value)` on an `any` receiver. Before this slice these first-match-bound the
+// `DisposableStack_defer` / `_adopt` / `_use` HOST imports (unsatisfiable
+// standalone → module fails to instantiate before dispose runs) — the residual
+// leak of the dispose/defer cluster the #3234 SuppressedError aggregation was a
+// prerequisite for. Slice 2 routes them through the native append/use substrate
+// guarded by `ref.test $DisposableStack` (miss → clean TypeError, never the
+// import; the `defer`/`adopt` callbacks compile as native closures via #3235).
+
+describe("#3237 slice 2 — any-receiver DisposableStack defer/adopt/use", () => {
+  it("defer(cb) on an any receiver runs its callback at dispose (LIFO), host-free", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let log = 0;
+           let s: any = new DisposableStack();
+           s.defer(() => { log = log * 10 + 1; });
+           s.defer(() => { log = log * 10 + 2; });
+           s.dispose();
+           return log; }`,
+      ),
+    ).toBe(21); // LIFO: the second-deferred callback runs first
+  });
+
+  it("defer() in value position returns undefined (=== undefined)", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); let u = s.defer(() => {}); s.dispose(); return (u === undefined) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("adopt(value, cb) on an any receiver returns the value and disposes it, host-free", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let seen = 0;
+           let s: any = new DisposableStack();
+           let ret = s.adopt(7, (v: number) => { seen = v; });
+           s.dispose();
+           return ret * 100 + seen; }`,
+      ),
+    ).toBe(707); // ret === 7 (value returned); callback saw value 7 at dispose
+  });
+
+  it("use(value) on an any receiver runs value[Symbol.dispose]() at dispose, host-free", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let d = 0;
+           let s: any = new DisposableStack();
+           let res: any = { [Symbol.dispose]() { d = 1; } };
+           s.use(res);
+           s.dispose();
+           return d; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("use(null) on an any receiver returns the value and adds no resource (no throw)", async () => {
+    // allows-null-value.js / returns-value.js: null/undefined value → return value.
+    expect(
+      await runStandalone(
+        `export function f(): number { let s: any = new DisposableStack(); let u = s.use(null); s.dispose(); return (u === null) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("defer disposers run in reverse order after use + adopt (dispose cluster shape)", async () => {
+    // disposes-resources-in-reverse-order.js shape across all three registrars.
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let log = 0;
+           let s: any = new DisposableStack();
+           s.defer(() => { log = log * 10 + 1; });
+           s.adopt(0, () => { log = log * 10 + 2; });
+           let res: any = { [Symbol.dispose]() { log = log * 10 + 3; } };
+           s.use(res);
+           s.dispose();
+           return log; }`,
+      ),
+    ).toBe(321); // LIFO: use(3) first, then adopt(2), then defer(1)
+  });
+
+  // ── Regression guards: the fix must NOT hijack non-DisposableStack receivers ──
+
+  it("a user object's own defer() on an any receiver still routes to the closed-struct method", async () => {
+    // The #3033 user-function-member refusal fires before the any-receiver native
+    // dispatch, so a user object with its own `defer` keeps the #2151 path.
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let d = new DisposableStack(); d.dispose();
+           let o: any = { defer() { return 9; } };
+           return o.defer(); }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("the typed (nominal) defer/adopt/use path is unchanged", async () => {
+    expect(
+      await runStandalone(
+        `export function f(): number {
+           let log = 0;
+           const s = new DisposableStack();
+           s.defer(() => { log = log * 10 + 1; });
+           s.adopt(0, () => { log = log * 10 + 2; });
+           s.dispose();
+           return log; }`,
+      ),
+    ).toBe(21);
+  });
 });


### PR DESCRIPTION
## Summary

Slice 2 of #3237. The callback DisposableStack methods `defer(cb)` / `adopt(value, cb)` / `use(value)` on an `any`/externref receiver reached `tryExternClassMethodOnAny`'s first-match extern loop and lazily bound the `DisposableStack_defer` / `_adopt` / `_use` **host imports** — unsatisfiable standalone, so the module fails to instantiate before dispose ever runs. This was the residual leak of the dispose/defer test262 cluster that the landed #3234 SuppressedError aggregation was a prerequisite for.

Extends the Slice-1 (#3023) `ref.test $DisposableStack` any-receiver dispatch to the callback methods:
- **hit** → the native `__disposablestack_append` (defer/adopt) / use substrate the typed path uses;
- **miss** → a clean `TypeError` (RequireInternalSlot, §12.3.3.{2,4} step 1) — never the host import, and never a `ref.cast_null` trap on a non-stack ref (the append/use helpers cast externref→struct and would trap without the brand gate).

The `defer`/`adopt` arrow callbacks compile as native first-class WasmGC closures via the #3235 standalone gate, so no `__make_callback` bridge leaks either.

### Value-position `undefined` fix (Slice-1 defect, shared by the new `defer`)

`dispose()`/`defer()` in value position returned a raw `ref.null.extern`, but under the #2106 undefined-singleton regime `x === undefined` compares against the singleton, not null — so `let u = s.dispose(); u === undefined` was **false** (`returns-undefined.js`). Now emits the canonical undefined via `emitUndefined` (the singleton in standalone). This un-breaks the pre-existing Slice-1 `returns undefined (value position)` unit test (deterministically red on main, but outside the `quality` gate's named-file allowlist, so it never blocked main).

## Discipline

- Gated `ctx.nativeStrings`; **host lane byte-identical** — the whole path is unreachable in host mode.
- funcIdx-ordering handled explicitly: all late imports registered first, the guard TypeError performs the final `flushLateImportShifts`, native helper funcIdxs re-fetched post-shift before baking into the nested `if` arms.
- LOC: bulk in the `disposable-runtime.ts` subsystem module; `calls-closures.ts` +1 (comment) covered by the issue file's `loc-budget-allow`.

## Tests

`tests/issue-3237-standalone-any-receiver-disposablestack.test.ts` (Slice 2 block): defer LIFO, adopt returns value + disposes it, use runs `value[Symbol.dispose]()`, use(null) returns value, reverse-order dispose across defer+adopt+use, `=== undefined` for dispose/defer value position, user-object `defer` still routes to the #2151 closed-struct path, typed nominal path unchanged. All host-free (no `DisposableStack_*` / `__make_callback` import). 61/61 disposable+suppressederror unit tests pass.

The merge_group standalone floor is the conformance gate; this + #3234 flip the dispose-SuppressedError cluster host-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8