### PR TITLE
feat(#3242): native standalone WeakRef (host-free new + deref)

### DIFF
--- a/plan/issues/3242-native-standalone-weakref.md
+++ b/plan/issues/3242-native-standalone-weakref.md
@@ -10,6 +10,10 @@ horizon: m
 goal: standalone-mode
 umbrella: 1781
 feasibility: hard
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/new-super.ts
+  - src/codegen/expressions/extern.ts
 ---
 
 # Native standalone WeakRef (host-free)

--- a/plan/issues/3242-native-standalone-weakref.md
+++ b/plan/issues/3242-native-standalone-weakref.md
@@ -1,0 +1,77 @@
+---
+id: 3242
+title: Native standalone WeakRef — retire WeakRef_new / WeakRef_deref host imports
+status: in-progress
+assignee: opus-weakcoll
+sprint: current
+priority: high
+horizon: m
+goal: standalone-mode
+umbrella: 1781
+feasibility: hard
+---
+
+# Native standalone WeakRef (host-free)
+
+## Problem
+
+In `--target standalone` / `--target wasi` (`nativeStrings`) mode there is no JS
+host, yet `new WeakRef(o)` routes through the generic externClass constructor
+path and emits a `WeakRef_new` host import, and `wr.deref()` emits
+`WeakRef_deref`. These are the last **sole-import** host-free leaks in the
+weak-collections family — `WeakMap` / `WeakSet` were already made native in
+#2162, but `WeakRef` was left on the host ctor table.
+
+Reproduced on current main (vitest probe against `src/`):
+
+- `new WeakMap(); wm.set/get/has/delete` → **0 env imports** (already native).
+- `new WeakSet(); ws.add/has/delete` → **0 env imports** (already native).
+- `new WeakRef(o); wr.deref()` → **`WeakRef_new`, `WeakRef_deref`** (leak).
+
+11 currently-passing standalone WeakRef tests are "leaky passes" (they pass only
+because the standalone harness stubs the `env` imports); they violate the
+host-free contract. Making WeakRef native flips them to `host_free_pass`.
+
+## What the passing tests actually need (measured)
+
+The 11 passing standalone WeakRef tests are:
+`WeakRef/{constructor,length,name,prop-desc}.js`,
+`WeakRef/prototype/prop-desc.js`,
+`WeakRef/prototype/deref/{length,name,not-a-constructor,prop-desc,return-object-target,return-symbol-target}.js`.
+
+Only two exercise an **instance**: `deref/return-object-target.js` and
+`deref/return-symbol-target.js`. Both assert exactly one thing —
+`new WeakRef(target).deref() === target` (identity preserved across repeated
+derefs), with `target` being an object OR a symbol. **No passing test observes
+GC weakness, `[[WeakRefTarget]]` emptying, `instanceof WeakRef`, or
+`Object.prototype.toString` on an instance.**
+
+So a **strong-backed** native WeakRef — a WasmGC struct holding the target as a
+single immutable `anyref` field — flips all 11 host-free with zero regression.
+There is no real weak (collectible) semantics; WasmGC has no weak refs and no
+passing spec test can observe the difference (the liveness tests that could are
+already `fail`/skip-filtered). This mirrors the #2162 WeakMap/WeakSet decision
+(strong-backed Map reuse).
+
+## Implementation
+
+- `src/codegen/weakref-runtime.ts` (new): `ensureWeakRefStruct(ctx)` lazily
+  registers a `$WeakRef` struct `{ target: anyref (immut) }` (appended to
+  `ctx.mod.types`, index in `ctx.weakRefTypeIdx`); `tryCompileNativeWeakRefNew`
+  and `tryCompileNativeWeakRefDeref` emit the `struct.new` / `struct.get 0`.
+- `src/codegen/expressions/new-super.ts`: intercept `new WeakRef(x)` when
+  `ctx.nativeStrings` and exactly one arg → coerce arg to anyref, `struct.new
+  $WeakRef`. Returns `ref $WeakRef`.
+- `src/codegen/expressions/extern.ts`: intercept `wr.deref()` when
+  `className === "WeakRef"` && `ctx.nativeStrings` → cast receiver to
+  `$WeakRef`, `struct.get 0` → anyref.
+- `src/codegen/context/types.ts`: add `weakRefTypeIdx: number` (init `-1`).
+
+Host / gc lanes are untouched (gated on `nativeStrings`), so those outputs stay
+byte-identical.
+
+## Acceptance
+
+- The 3-op WeakRef repro compiles standalone with **0 env imports**.
+- The 11 passing WeakRef standalone tests remain passing, now host-free.
+- Host / gc lane byte-identical; standalone floor NET ≥ 0.

--- a/plan/issues/3242-native-standalone-weakref.md
+++ b/plan/issues/3242-native-standalone-weakref.md
@@ -1,7 +1,8 @@
 ---
 id: 3242
 title: Native standalone WeakRef — retire WeakRef_new / WeakRef_deref host imports
-status: in-progress
+status: done
+completed: 2026-07-13
 assignee: opus-weakcoll
 sprint: current
 priority: high

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -181,6 +181,7 @@ export function createCodegenContext(
     mapBucketsTypeIdx: -1,
     mapIterTypeIdx: -1,
     mapIterResultTypeIdx: -1,
+    weakRefTypeIdx: -1,
     mapHelpers: new Map(),
     mapHelpersEmitted: false,
     refCellTypeMap: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1804,6 +1804,11 @@ export interface CodegenContext {
   mapIterResultTypeIdx: number;
   /** Map from native Map helper name → function index. */
   mapHelpers: Map<string, number>;
+  /** #3242: Wasm-native WeakRef struct `{ target: anyref (immut) }` for
+   *  standalone / WASI. `-1` until `ensureWeakRefStruct` registers it (gated on
+   *  nativeStrings). Strong-backed — no real GC weakness (WasmGC has no weak
+   *  refs; no passing spec test observes the difference). */
+  weakRefTypeIdx: number;
   /** Whether the Map runtime helper functions have been emitted. */
   mapHelpersEmitted: boolean;
   /** #1539: map from native standalone-regex helper name → function index.

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -16,6 +16,7 @@ import { tryCompileNativeDisposableStackMethodCall } from "../disposable-runtime
 import { tryCompileNativeSetMethodCall } from "../set-runtime.js";
 import { tryCompileNativeSetAlgebraCall } from "../set-algebra.js";
 import { tryCompileNativeWeakMethodCall } from "../weak-collections-runtime.js";
+import { tryCompileNativeWeakRefDeref } from "../weakref-runtime.js";
 import { addStringConstantGlobal } from "../registry/imports.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
@@ -122,6 +123,15 @@ function compileExternMethodCall(
     }
     const weakResult = tryCompileNativeWeakMethodCall(ctx, fctx, className, propAccess, callExpr);
     if (weakResult !== undefined) return weakResult;
+  }
+
+  // (#3242) Native WeakRef.prototype.deref in standalone / nativeStrings mode.
+  // Without this, `wr.deref()` emits a `WeakRef_deref` host import the standalone
+  // runtime can't satisfy. Route to the native `$WeakRef` struct (single anyref
+  // target field) — `struct.get 0`. Strong-backed; see weakref-runtime.ts.
+  if (className === "WeakRef" && ctx.nativeStrings && methodName === "deref") {
+    const derefResult = tryCompileNativeWeakRefDeref(ctx, fctx, propAccess);
+    if (derefResult !== undefined) return derefResult;
   }
 
   // (#3231) Native DisposableStack method dispatch in standalone / nativeStrings

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -41,6 +41,7 @@ import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target
 import { ensureObjectRuntime } from "../object-runtime.js"; // (#1100) standalone Proxy native runtime
 import { ensureSetHelpers } from "../set-runtime.js";
 import { ensureWeakCollectionHelpers } from "../weak-collections-runtime.js";
+import { tryCompileNativeWeakRefNew } from "../weakref-runtime.js";
 import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { compileObjectLiteralAsExternref, resolveComputedKeyExpression } from "../literals.js";
 import { stringConstantExternrefInstrs, ensureAnyToStringHelper } from "../native-strings.js";
@@ -2853,6 +2854,22 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       fctx.body.push({ op: "call", funcIdx: mapNewIdx });
       return { kind: "ref", typeIdx: ctx.mapTypeIdx };
     }
+  }
+
+  // (#3242) `new WeakRef(target)` in standalone / nativeStrings mode → the
+  // native `$WeakRef` struct (single anyref target field). Without this the
+  // generic externClass ctor table emits a `WeakRef_new` host import the
+  // standalone runtime can't satisfy. Strong-backed (no real GC weakness); see
+  // weakref-runtime.ts. Requires exactly one arg — other arities fall through.
+  if (
+    ctx.nativeStrings &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "WeakRef" &&
+    (expr.arguments?.length ?? 0) === 1
+  ) {
+    addUnionImports(ctx); // register __box_number before the target coerce (idempotent)
+    const weakRefResult = tryCompileNativeWeakRefNew(ctx, fctx, expr);
+    if (weakRefResult !== undefined) return weakRefResult;
   }
 
   // Arrow functions are NOT constructors — `new (() => {})` throws TypeError (#730)

--- a/src/codegen/weakref-runtime.ts
+++ b/src/codegen/weakref-runtime.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3242 — Wasm-native `WeakRef` runtime for standalone / WASI.
+ *
+ * In JS-host mode `new WeakRef(o)` routes through the generic `externClasses`
+ * constructor table and emits a `WeakRef_new` host import; `wr.deref()` emits a
+ * `WeakRef_deref` host method import. Under `--target standalone` / `--target
+ * wasi` there is no JS host to satisfy these, so this module provides a
+ * pure-WasmGC `WeakRef` as a one-field struct.
+ *
+ * **Semantics — strong-backed, no real weakness.** WasmGC has no weak
+ * references, so the target is held *strongly*: a standalone `WeakRef` never
+ * observes its target being collected, and `deref()` always returns it. That is
+ * a memory property, not an observable one for the passing spec suite — the two
+ * instance-exercising tests
+ * (`WeakRef/prototype/deref/return-{object,symbol}-target.js`) assert only that
+ * `new WeakRef(target).deref() === target` (identity preserved across repeated
+ * derefs, for an object or a symbol target). No passing test observes
+ * `[[WeakRefTarget]]` emptying, `instanceof WeakRef`, or
+ * `Object.prototype.toString` on an instance; the liveness tests that could tell
+ * the difference already `fail` / are skip-filtered. This mirrors the #2162
+ * WeakMap/WeakSet decision (strong Map reuse).
+ *
+ * Backing representation: `$WeakRef` = `struct { target: anyref (immut) }`.
+ *   - `new WeakRef(x)` → coerce `x` to anyref, `struct.new $WeakRef`
+ *   - `wr.deref()`     → cast receiver to `$WeakRef`, `struct.get 0` → anyref
+ *
+ * Everything is emitted lazily and only when `ctx.nativeStrings`. JS-host mode
+ * is untouched (both paths stay byte-identical to before this change).
+ */
+import { ts } from "../ts-api.js";
+import type { Instr, StructTypeDef, ValType } from "../ir/types.js";
+import { isBooleanType } from "../checker/type-mapper.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { InnerResult } from "./shared.js";
+import { coerceType, compileExpression } from "./shared.js";
+
+/**
+ * Lazily register the `$WeakRef` struct type (idempotent). Appended to
+ * `ctx.mod.types` so existing type indices are unshifted. Returns the type index
+ * (also cached on `ctx.weakRefTypeIdx`).
+ *
+ * The single `target` field is an **externref** (the standalone "any" surface
+ * rep) rather than a raw anyref: the target may be an object OR a symbol, and a
+ * symbol is a boxed `$Symbol` carrier reached through the externref box. Storing
+ * externref keeps `deref()` a simple `struct.get` while preserving symbol
+ * identity (see the box-brand note in `tryCompileNativeWeakRefNew`).
+ */
+export function ensureWeakRefStruct(ctx: CodegenContext): number {
+  if (ctx.weakRefTypeIdx >= 0) return ctx.weakRefTypeIdx;
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "WeakRef",
+    fields: [{ name: "target", type: { kind: "externref" }, mutable: false }],
+  } as StructTypeDef);
+  ctx.weakRefTypeIdx = typeIdx;
+  ctx.structMap.set("WeakRef", typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, "WeakRef");
+  return typeIdx;
+}
+
+/**
+ * (#3242) Intercept `new WeakRef(target)` in standalone / `nativeStrings` mode.
+ * Requires exactly one argument (the spec-mandatory target); other arities fall
+ * through so the existing behaviour is preserved. Returns `ref $WeakRef`.
+ */
+export function tryCompileNativeWeakRefNew(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.NewExpression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  if (!ts.isIdentifier(expr.expression) || expr.expression.text !== "WeakRef") return undefined;
+  const args = expr.arguments;
+  if (!args || args.length !== 1) return undefined;
+
+  const typeIdx = ensureWeakRefStruct(ctx);
+  const t = compileExpression(ctx, fctx, args[0]!);
+  if (t === null) return undefined;
+  // Box the target to externref preserving its JS tag (the #2785 type-aware-box
+  // rule): a `Symbol` target compiles to a symbol-BRANDED i32 handle that must
+  // box via `__box_symbol` (identity-stable `$Symbol` carrier), NOT `__box_number`
+  // — otherwise `wr.deref() === sym` compares a number-box against the interned
+  // symbol and fails. `coerceMapKeyToAnyref` mis-boxes a symbol-branded i32 as a
+  // number, so brand explicitly here off the static TS type and route through
+  // `coerceType` (which honours `.symbol` / `.boolean`). Objects / native strings
+  // are already anyref-subtypes → `extern.convert_any`.
+  const argTsType = ctx.checker.getTypeAtLocation(args[0]!);
+  const branded: ValType =
+    t.kind === "i32" && (argTsType.flags & ts.TypeFlags.ESSymbolLike) !== 0
+      ? { kind: "i32", symbol: true }
+      : t.kind === "i32" && isBooleanType(argTsType)
+        ? { kind: "i32", boolean: true }
+        : t;
+  coerceType(ctx, fctx, branded, { kind: "externref" });
+  fctx.body.push({ op: "struct.new", typeIdx } as Instr);
+  return { kind: "ref", typeIdx } as ValType;
+}
+
+/**
+ * (#3242) Intercept `wr.deref()` in standalone / `nativeStrings` mode. `deref`
+ * is 0-arity; returns the stored target as an externref (the "any" surface rep
+ * — so a downstream `===` routes through the ref.eq / `__any_strict_eq` identity
+ * path; a raw `anyref` result would be classified as a non-ref by the strict-eq
+ * operand test and fold `wr.deref() === target` to constant `false`). Returns
+ * `undefined` when the receiver is a different concrete struct so the generic
+ * path can retry.
+ */
+export function tryCompileNativeWeakRefDeref(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  if (propAccess.name.text !== "deref") return undefined;
+
+  const typeIdx = ensureWeakRefStruct(ctx);
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (recvType === null) return undefined;
+  if (recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx } as Instr);
+  } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
+    fctx.body.push({ op: "ref.cast", typeIdx } as Instr);
+  } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== typeIdx) {
+    return undefined;
+  }
+  fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 0 } as Instr);
+  return { kind: "externref" } as ValType;
+}

--- a/src/codegen/weakref-runtime.ts
+++ b/src/codegen/weakref-runtime.ts
@@ -30,7 +30,6 @@
  */
 import { ts } from "../ts-api.js";
 import type { Instr, StructTypeDef, ValType } from "../ir/types.js";
-import { isBooleanType } from "../checker/type-mapper.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression } from "./shared.js";
@@ -83,14 +82,16 @@ export function tryCompileNativeWeakRefNew(
   // box via `__box_symbol` (identity-stable `$Symbol` carrier), NOT `__box_number`
   // — otherwise `wr.deref() === sym` compares a number-box against the interned
   // symbol and fails. `coerceMapKeyToAnyref` mis-boxes a symbol-branded i32 as a
-  // number, so brand explicitly here off the static TS type and route through
-  // `coerceType` (which honours `.symbol` / `.boolean`). Objects / native strings
-  // are already anyref-subtypes → `extern.convert_any`.
-  const argTsType = ctx.checker.getTypeAtLocation(args[0]!);
+  // number, so brand explicitly here off the static type FACT (via `ctx.oracle`,
+  // the #1930 type-query boundary — the raw checker is ratchet-blocked in
+  // codegen) and route through `coerceType` (which honours `.symbol` /
+  // `.boolean`). Objects / native strings are already anyref-subtypes →
+  // `extern.convert_any`.
+  const argFactKind = ctx.oracle.typeFactOf(args[0]!).kind;
   const branded: ValType =
-    t.kind === "i32" && (argTsType.flags & ts.TypeFlags.ESSymbolLike) !== 0
+    t.kind === "i32" && argFactKind === "symbol"
       ? { kind: "i32", symbol: true }
-      : t.kind === "i32" && isBooleanType(argTsType)
+      : t.kind === "i32" && argFactKind === "boolean"
         ? { kind: "i32", boolean: true }
         : t;
   coerceType(ctx, fctx, branded, { kind: "externref" });

--- a/src/codegen/weakref-runtime.ts
+++ b/src/codegen/weakref-runtime.ts
@@ -69,7 +69,7 @@ export function tryCompileNativeWeakRefNew(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.NewExpression,
-): InnerResult | undefined {
+): ValType | undefined {
   if (!ctx.nativeStrings) return undefined;
   if (!ts.isIdentifier(expr.expression) || expr.expression.text !== "WeakRef") return undefined;
   const args = expr.arguments;

--- a/tests/issue-3242-weakref-standalone.test.ts
+++ b/tests/issue-3242-weakref-standalone.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3242 — Native standalone WeakRef.
+//
+// In `--target standalone` there is no JS host, so `new WeakRef(o)` /
+// `wr.deref()` must NOT emit `WeakRef_new` / `WeakRef_deref` host imports.
+// Before this fix WeakRef routed through the generic externClass constructor
+// table (host imports), unlike WeakMap/WeakSet which were made native in #2162.
+//
+// The native representation is a strong-backed `$WeakRef` struct holding the
+// target as a single immutable anyref field — no real GC weakness (WasmGC has
+// none), but no passing spec test observes the difference. `deref()` returns
+// the stored target with identity preserved.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string) {
+  const r = await compile(src, { target: "standalone", emitText: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  return r;
+}
+
+function envImports(wat: string): string[] {
+  return [...wat.matchAll(/\(import "env" "([^"]+)"/g)].map((m) => m[1]!);
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compileStandalone(src);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#3242 native standalone WeakRef", () => {
+  it("new WeakRef + deref emit no WeakRef_* host imports", async () => {
+    const r = await compileStandalone(`const o = { a: 1 }; const wr = new WeakRef(o); const d = wr.deref();`);
+    const wat = (r as { wat?: string; text?: string }).wat ?? (r as { text?: string }).text ?? "";
+    expect(envImports(wat).filter((i) => /Weak/.test(i))).toEqual([]);
+  });
+
+  it("deref returns the object target (identity preserved)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o = { a: 1 };
+        const wr = new WeakRef(o);
+        return wr.deref() === o ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("deref returns the same target across repeated calls (target not emptied)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o = { a: 1 };
+        const wr = new WeakRef(o);
+        return (wr.deref() === wr.deref() && wr.deref() === o) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("deref returns a symbol target", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const s = Symbol("desc");
+        const wr = new WeakRef(s);
+        return wr.deref() === s ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Retires the last **sole-import** host-free leaks in the weak-collections family: `new WeakRef(o)` and `wr.deref()` no longer emit `WeakRef_new` / `WeakRef_deref` host imports in standalone / `nativeStrings` mode. `WeakMap` / `WeakSet` were already native (#2162); `WeakRef` was left on the generic externClass host ctor table.

## What the passing tests actually need (measured)

11 currently-passing standalone WeakRef tests are "leaky passes" (they pass only because the standalone harness stubs the `env` imports). Only two exercise an **instance** — `deref/return-{object,symbol}-target.js` — and both assert exactly `new WeakRef(target).deref() === target` (identity preserved, object or symbol target). **No passing test observes GC weakness, `[[WeakRefTarget]]` emptying, `instanceof`, or `toString` on an instance.**

So this is a **strong-backed** native WeakRef: a `$WeakRef` WasmGC struct holding the target as a single immutable `externref` field. No real weak (collectible) semantics (WasmGC has none), and no passing spec test can observe the difference — the liveness tests that could already `fail` / are skip-filtered. This mirrors the #2162 WeakMap/WeakSet strong-Map-reuse decision.

## Implementation

- `src/codegen/weakref-runtime.ts` (new): `ensureWeakRefStruct` (lazy `$WeakRef` struct, appended so type indices don't shift), `tryCompileNativeWeakRefNew` (`struct.new`), `tryCompileNativeWeakRefDeref` (`struct.get 0`).
- `new-super.ts` / `extern.ts`: gated interceptions (`ctx.nativeStrings`, `className === "WeakRef"`).
- `context/types.ts` + `create-context.ts`: `weakRefTypeIdx` field (init `-1`).

Two downstream effects handled:
- **strict-eq operand classification**: `deref()` returns `externref` (not raw `anyref`) — the strict-eq operand test (`binary-ops.ts` `leftIsRef`) classifies a raw `anyref` as a non-ref and folds `wr.deref() === target` to constant `false`. `externref` routes through the `ref.eq` identity path.
- **symbol target boxing**: a `Symbol` target compiles to a symbol-BRANDED i32 handle; the target is boxed via `coerceType` (honours `.symbol` → `__box_symbol` interned carrier), not the map-key coercion which mis-boxes it as a number.

## Verification

- `new WeakRef(o); wr.deref()` compiles standalone with **0 env imports** (verified vs a WeakMap/WeakSet control which are already host-free).
- New `tests/issue-3242-weakref-standalone.test.ts` (4 tests): host-free assertion + deref identity for object, repeated-deref, and symbol targets — all pass, module validates + instantiates with an **empty** import object.
- Host / gc lane untouched (all paths gated on `nativeStrings`).
- Existing weak-collection suites (`weakmap-weakset-weakref`, `issue-2162-standalone-weak`, `issue-2861-*`) pass. (`issue-3006` / `issue-1600` FinalizationRegistry failures are **pre-existing on the base commit** — verified by reverting these changes on the same base — unrelated to this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)