### PR TITLE
feat(#3236 S2 / #3243): native object === identity + generator instance prototype (standalone)

### DIFF
--- a/plan/issues/3236-standalone-sync-generator-prototype-intrinsic-chain.md
+++ b/plan/issues/3236-standalone-sync-generator-prototype-intrinsic-chain.md
@@ -217,3 +217,28 @@ unregressed) that the other reflective callers depend on.
 `!(ctx.standalone || ctx.wasi)`, so the host path emits nothing new; the shared
 `emitReflectiveNativeProtoClosureCall` param defaults off → existing callers
 byte-identical.
+
+## Implementation Notes (Slice 2 — opus-genproto3)
+
+### What shipped
+
+`Object.getPrototypeOf(<sync generator instance>)` → the identity-stable
+`%GeneratorPrototype%` singleton (default-proto.js §27.5.1). A new
+`argTsType.getSymbol()?.name === "Generator"` branch in
+`Object.getPrototypeOf` (calls.ts, sibling to the #3013 ArrayIterator branch)
+drops the instance arg for side effects and returns
+`emitGeneratorPrototypeSingleton` — the SAME cached global the `genFn.prototype`
+/ `getPrototypeOf(genFn).prototype` paths return, so
+`getPrototypeOf(g()) === getPrototypeOf(g).prototype` holds by identity. Sync
+only (async generators are typed `AsyncGenerator` → keep the host path).
+
+### Root-cause escalation — the real blocker is object `===`, tracked as #3243
+
+The instance wiring alone banks NO flip: default-proto.js's assertion
+`sameValue(getPrototypeOf(g()), GeneratorPrototype)` is an object `===`, which in
+standalone folded to the tag-5 string-content compare and was **layout-fragile**
+— the same fragility that made Slice 1's flips (prototype-relation, descriptor
+tests) pass only coincidentally. The enabling fix (extend #2734's `ref.eq`
+identity fast path to inline `emitStrictEq`, object/`any`-scoped) is **#3243**,
+landed in the same PR. With #3243, default-proto.js passes AND the Slice-1
+cluster is hardened against layout drift. See #3243 for the substrate detail.

--- a/plan/issues/3243-standalone-object-strict-eq-refeq-identity.md
+++ b/plan/issues/3243-standalone-object-strict-eq-refeq-identity.md
@@ -1,7 +1,8 @@
 ---
 id: 3243
 title: "standalone: native object === identity — extend #2734 ref.eq fast path to inline strict-eq (retire tag-5 string-content fold for objects)"
-status: in-progress
+status: done
+completed: 2026-07-13
 sprint: current
 priority: high
 feasibility: hard

--- a/plan/issues/3243-standalone-object-strict-eq-refeq-identity.md
+++ b/plan/issues/3243-standalone-object-strict-eq-refeq-identity.md
@@ -1,0 +1,101 @@
+---
+id: 3243
+title: "standalone: native object === identity — extend #2734 ref.eq fast path to inline strict-eq (retire tag-5 string-content fold for objects)"
+status: in-progress
+sprint: current
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: substrate
+area: codegen
+language_feature: strict-equality, object-identity, tag-5-classifier, standalone
+goal: host-independence
+umbrella: 1781
+assignee: ttraenkler/opus-genproto3
+related: [2734, 2583, 2040, 2580, 3236]
+origin: "2026-07-13 #3236 Slice 2 root-cause: native object `===` folds to tag-5 string-content compare, layout-fragile; discovered while wiring generator instance prototype identity."
+---
+
+# #3243 — native object `===` identity in standalone (ref.eq fast path for inline strict-eq)
+
+## Problem
+
+In standalone/WASI, `===`/`!==` between two native `$Object` externrefs is
+UNRELIABLE. `emitAnyEqOperands` (coercion-engine.ts) marshals each externref
+operand through `__any_from_extern`, whose non-honest default folds an object
+externref into the **tag-5 (string) fallback**. `__any_strict_eq` then compares
+the two objects by string CONTENT — a layout-dependent result.
+
+Demonstrated (standalone, compile+instantiate+run):
+
+```
+function* g() {}
+function f() {}
+// same comparison, two module layouts:
+rel():          getPrototypeOf(getPrototypeOf(g)) === getPrototypeOf(f)   // → 1
+relWithNoise(): const x = getPrototypeOf(g());                            //
+                getPrototypeOf(getPrototypeOf(g)) === getPrototypeOf(f)   // → 0  (!!)
+```
+
+The SAME comparison flips 1→0 merely because an unrelated `getPrototypeOf(g())`
+precedes it. Consequence: #3236 Slice 1's `host_free_pass` flips
+(prototype-relation-to-function.js, the GeneratorPrototype descriptor/this-val
+tests) pass only **coincidentally** by code shape and are latently fragile;
+#3236 Slice 2 (default-proto.js) cannot pass at all.
+
+## Root cause
+
+`__extern_strict_eq` (#2734, used by Array indexOf/includes) already prepends a
+`ref.eq` reference-identity fast path (internalize both externrefs; identical
+`eq` ref → 1) before the `__any_from_extern` + `__any_strict_eq` fallback. But
+the **inline** `emitStrictEq` path (`===`/`!==` in source) routes through
+`emitAnyEqOperands` → `__any_strict_eq` DIRECTLY and never gets that fast path,
+so object identity is lost to the tag-5 fold.
+
+This is the tag-5 field-4 object-identity family: #2734 (native ref.eq
+identity), #2583 (any-strict-eq tag-5 host-only), #2040/#2580 (tag-5 3-way
+classifier).
+
+## Fix
+
+Extend #2734's `ref.eq` identity fast path to inline `emitStrictEq`, **scoped to
+object/`any` operands only** via `isReferenceLikeEqOperand`:
+
+- When `helperName === "__any_strict_eq"`, `ctx.standalone || ctx.wasi`, and BOTH
+  operand static types are reference-like (`Any`/`Unknown`/`Object`, or a union
+  whose every constituent is) — compile both operands to `externref` and call
+  `__extern_strict_eq` (the ref.eq-guarded helper).
+- number/boolean/bigint/symbol/**string** operands are excluded → they keep
+  their exact existing tag-3/tag-4/tag-5 path (byte-identical, verified).
+- Host lane emits nothing new (gated) → #1917 both-lane neutrality preserved.
+
+`__extern_strict_eq` never false-positives a primitive: distinct number/string
+boxes are distinct refs (ref.eq fails → value comparison); only a genuinely
+identical reference short-circuits.
+
+## Acceptance
+
+- Object `===` returns identity-correct results REGARDLESS of module layout
+  (default-proto.js + prototype-relation-to-function.js stable).
+- Primitive `===` (number/float/NaN/string/bool/null/undefined/mixed/±0) emit
+  **byte-identical** wasm vs. baseline (verified: SHA `602540fb…`, both lanes).
+- JS-host lane byte-identical.
+- NET ≥ 0 on the merge_group standalone floor.
+
+## Implementation Notes (opus-genproto3)
+
+Landed together with #3236 Slice 2 (the generator-instance `getPrototypeOf`
+branch): Slice 2's instance wiring is necessary but banks no flip without this;
+this substrate fix is the enabler and additionally hardens the whole #3236
+Slice-1 cluster against layout drift.
+
+Files:
+- `src/codegen/coercion-engine.ts` — `isReferenceLikeEqOperand` gate +
+  `__extern_strict_eq` reroute in `emitAnyEquality` (strict-eq only).
+- `src/codegen/expressions/calls.ts` — `Object.getPrototypeOf(<Generator
+  instance>)` → `%GeneratorPrototype%` singleton (#3236 Slice 2).
+
+Local validation: 16/16 `===` semantic cases preserved; primitive-eq program
+byte-identical to baseline; rel/relWithNoise/defProto all reliably `1`.
+Authoritative gate is the merge_group standalone floor (this touches every
+object/any `===` in standalone).

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -34,7 +34,7 @@
 import { isBooleanType, isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
-import { ensureAnyFromExternHelper } from "./any-helpers.js";
+import { ensureAnyFromExternHelper, ensureExternStrictEqHelper } from "./any-helpers.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { noJsHost } from "./expressions/helpers.js";
 import { addUnionImports, nativeStringType } from "./index.js";
@@ -522,6 +522,31 @@ export function emitLooseEq(
   return emitAnyEquality(ctx, fctx, expr, "__any_eq", negate);
 }
 
+/**
+ * (#3236 S2) True when an operand's static type is a REFERENCE-like value that
+ * `===` must compare by object identity (or a dynamic `any` that could be one) —
+ * so the standalone `ref.eq` object-identity fast path (`__extern_strict_eq`) is
+ * safe to apply. Excludes number/boolean/bigint/symbol value types, which must
+ * keep their existing tag-3/tag-4 numeric/boolean comparison path. Strings are
+ * excluded too (content equality already works via the tag-5 arm and needs no
+ * identity fast path). Unions qualify only when EVERY constituent qualifies, so
+ * a `number | object` operand conservatively stays on the legacy path.
+ */
+function isReferenceLikeEqOperand(t: ts.Type): boolean {
+  const primitiveValue =
+    ts.TypeFlags.NumberLike |
+    ts.TypeFlags.BooleanLike |
+    ts.TypeFlags.BigIntLike |
+    ts.TypeFlags.ESSymbolLike |
+    ts.TypeFlags.StringLike |
+    ts.TypeFlags.EnumLike;
+  if (t.flags & primitiveValue) return false;
+  if (t.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) return true;
+  if (t.flags & ts.TypeFlags.Object) return true;
+  if (t.isUnion()) return t.types.every(isReferenceLikeEqOperand);
+  return false;
+}
+
 function emitAnyEquality(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -532,6 +557,38 @@ function emitAnyEquality(
   ensureAnyHelpers(ctx);
   const funcIdx = ctx.funcMap.get(helperName);
   if (funcIdx === undefined) return null;
+
+  // (#3236 S2) Native object-identity for standalone `===`/`!==`. Two native
+  // `$Object` externrefs (e.g. `getPrototypeOf(g()) === genFn.prototype`,
+  // default-proto.js §27.5.1) otherwise fold to the tag-5 (string) fallback in
+  // `__any_from_extern` and get string-CONTENT compared — a layout-dependent
+  // result that made object `===` unreliable (and left Slice-1's
+  // prototype-relation flip passing only coincidentally). `__extern_strict_eq`
+  // (#2734) prepends the `ref.eq` reference-identity fast path (both operands
+  // internalized; identical `eq` ref → 1) then falls through to the SAME
+  // `__any_from_extern` + `__any_strict_eq` primitive comparison, so it never
+  // false-positives a primitive. Scoped to OBJECT/`any` operands only (via
+  // `isReferenceLikeEqOperand`): number/boolean/bigint/symbol comparisons keep
+  // their exact existing tag-3/tag-4 path untouched. Standalone/WASI only — the
+  // host lane emits nothing new (byte-identical).
+  if (helperName === "__any_strict_eq" && (ctx.standalone || ctx.wasi)) {
+    const leftTs = ctx.checker.getTypeAtLocation(expr.left);
+    const rightTs = ctx.checker.getTypeAtLocation(expr.right);
+    if (isReferenceLikeEqOperand(leftTs) && isReferenceLikeEqOperand(rightTs)) {
+      const externEqIdx = ensureExternStrictEqHelper(ctx);
+      if (externEqIdx !== undefined) {
+        const lt = compileExpression(ctx, fctx, expr.left, { kind: "externref" });
+        if (!lt) return null;
+        if (lt.kind !== "externref") coerceType(ctx, fctx, lt, { kind: "externref" });
+        const rt = compileExpression(ctx, fctx, expr.right, { kind: "externref" });
+        if (!rt) return null;
+        if (rt.kind !== "externref") coerceType(ctx, fctx, rt, { kind: "externref" });
+        fctx.body.push({ op: "call", funcIdx: externEqIdx });
+        if (negate) fctx.body.push({ op: "i32.eqz" });
+        return { kind: "i32" };
+      }
+    }
+  }
 
   if (!emitAnyEqOperands(ctx, fctx, expr)) return null;
 

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -576,7 +576,7 @@ function emitAnyEquality(
   // internalized; identical `eq` ref → 1) then falls through to the SAME
   // `__any_from_extern` + `__any_strict_eq` primitive comparison, so it never
   // false-positives a primitive. Scoped to OBJECT/`any` operands only (via
-  // `isReferenceLikeEqOperand`): number/boolean/bigint/symbol comparisons keep
+  // `isReferenceLikeEqFact`): number/boolean/bigint/symbol comparisons keep
   // their exact existing tag-3/tag-4 path untouched. Standalone/WASI only — the
   // host lane emits nothing new (byte-identical).
   if (helperName === "__any_strict_eq" && (ctx.standalone || ctx.wasi)) {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -164,6 +164,7 @@ import {
   emitTypedArrayIntrinsicCtorObject,
   emitArrayIteratorPrototypeSingleton,
   emitGeneratorFunctionPrototypeSingleton,
+  emitGeneratorPrototypeSingleton,
   emitFunctionPrototypeObjectSingleton,
   isWiredTypedArrayViewName,
 } from "../array-object-proto.js";
@@ -8164,6 +8165,32 @@ function compileCallExpression(
         const argType = compileExpression(ctx, fctx, arg0);
         if (argType) fctx.body.push({ op: "drop" });
         const protoType = emitArrayIteratorPrototypeSingleton(ctx, fctx);
+        if (protoType) return protoType;
+        // Runtime unavailable: preserve the historical null return.
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
+
+      // (#3236 S2) `Object.getPrototypeOf(<sync generator instance>)` → the same
+      // native `%GeneratorPrototype%` singleton that `genFn.prototype` /
+      // `getPrototypeOf(genFn).prototype` resolve to (§27.5.1). A generator
+      // INSTANCE (`g()`) is OrdinaryCreateFromConstructor(g, "%GeneratorPrototype%")
+      // — its `[[Prototype]]` is the intrinsic %GeneratorPrototype% captured at
+      // instantiation, INDEPENDENT of any later mutation of `g.prototype`
+      // (default-proto.js sets `g.prototype = null` yet still expects GP). The
+      // native generator model doesn't carry a per-instance proto slot, so we
+      // route to the identity-stable GP singleton directly — the SAME cached
+      // global `emitGeneratorPrototypeSingleton` returns everywhere, so the
+      // `getPrototypeOf(g()) === getPrototypeOf(g).prototype` identity holds.
+      // The TS checker names a sync generator's result type `Generator`
+      // (distinct from `AsyncGenerator`, which keeps the host path), so this
+      // routes genuinely. Compile+drop the arg for its evaluation side effects
+      // (`g()` evaluates arguments; the generator body itself stays suspended).
+      // Host/gc mode keeps the `__getPrototypeOf` import (byte-inert).
+      if ((ctx.standalone || ctx.wasi) && argTsType.getSymbol()?.name === "Generator") {
+        const argType = compileExpression(ctx, fctx, arg0);
+        if (argType) fctx.body.push({ op: "drop" });
+        const protoType = emitGeneratorPrototypeSingleton(ctx, fctx);
         if (protoType) return protoType;
         // Runtime unavailable: preserve the historical null return.
         fctx.body.push({ op: "ref.null.extern" });


### PR DESCRIPTION
## Summary

**#3236 Slice 2** — `Object.getPrototypeOf(<sync generator instance>)` now resolves to the identity-stable `%GeneratorPrototype%` singleton (default-proto.js §27.5.1), via a `Generator`-typed branch in `Object.getPrototypeOf` mirroring the #3013 ArrayIterator pattern. Sync generators only; async generators keep the host path.

**#3243 (root-cause enabler)** — the instance wiring alone banks no flip because native object `===` was **unreliable** in standalone: two `$Object` externrefs folded to the tag-5 (string) fallback in `__any_from_extern` and got **string-content compared** — a layout-dependent result. This also left #3236 Slice 1's `host_free_pass` flips passing only *coincidentally*: the same `getPrototypeOf(getPrototypeOf(g)) === getPrototypeOf(f)` comparison flips `1→0` merely when an unrelated `getPrototypeOf(g())` precedes it.

**Fix**: extend #2734's `ref.eq` reference-identity fast path (already in `__extern_strict_eq`, used by Array indexOf/includes) to the inline `emitStrictEq` path, **scoped to OBJECT/`any` operands** via `isReferenceLikeEqOperand`. number/boolean/bigint/symbol/string comparisons keep their exact existing tag-3/tag-4/tag-5 path.

## Discipline / neutrality

- **Standalone/WASI-gated** — host lane emits nothing new (#1917 both-lane neutrality holds).
- **Primitives byte-identical** — verified: a primitive-only `===` program compiles to the SAME wasm on baseline and this branch (SHA `602540fb…`, 36402 bytes).
- **16/16 `===` semantic cases preserved** (number/float/NaN/string/bool/null/undefined/mixed/object-distinct/object-self/±0).
- default-proto + prototype-relation now reliably pass **regardless of module layout** — hardens the whole #3236 Slice-1 cluster against layout drift, not just the one target.

## Authoritative gate

This touches **every object/`any` `===` in standalone**, so the **merge_group standalone floor** is the authoritative gate — NET ≥ 0 on the full floor is required. Will report the measured flip-count once CI's standalone report lands.

Resolves #3243; completes #3236 Slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8