### PR TITLE
docs(#3244,#3245): any-container element-rep substrate + async-gen dstr host-free-fail decomposition

### DIFF
--- a/plan/issues/3244-standalone-any-boxed-reference-element-array-read.md
+++ b/plan/issues/3244-standalone-any-boxed-reference-element-array-read.md
@@ -1,0 +1,95 @@
+---
+id: 3244
+title: "Standalone: any-boxed homogeneous reference-element array reads elements as undefined (index + destructuring)"
+status: ready
+sprint: current
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen, standalone
+language_feature: arrays, any-boxing, destructuring, element-access
+goal: standalone-mode
+umbrella: 1781
+related: [2379, 3059, 2151, 2186, 3132, 1042]
+created: 2026-07-13
+origin: "opus-asyncthen bucket-2 diagnosis of async-gen dstr host-free fails — the nested-`[{x}]` destructure-null trap drilled to a broader any-container element-rep substrate bug affecting plain index access too. opus-anyrecv confirmed NOT method-dispatch (their #3237); it is value-representation (#2379/#3059 family)."
+---
+
+# #3244 — standalone any-boxed reference-element array reads elements as undefined
+
+## Problem (verified against origin/main @ 503b64ac35, 2026-07-13)
+
+Under `--target standalone`, reading an element of a **homogeneous
+reference-element array** (elements are objects, or nested arrays) returns
+`undefined`/`NaN`/empty-object when the array crosses an `any` / externref
+boundary. Affects **plain index access**, not just destructuring — so it is a
+value-representation substrate bug, not a destructuring-lowering bug.
+
+Probes (all correct on gc host lane, wrong on standalone — `.tmp/anyarr.mts`,
+`.tmp/elemtypes.mts`, `.tmp/index-vs-dstr.mts`, `.tmp/nullcheck.mts`):
+
+```ts
+function f(a: any): number { return a[0].x; }
+f([{ x: 777 }]);              // gc 777, standalone NaN
+
+const a: any = [{ x: 777 }];
+a[0].x;                        // gc 777, standalone `[Object: null prototype] {}`
+
+function g(a: any): number { return a[0][1]; }
+g([[10, 20, 30]]);            // gc 20, standalone NaN
+
+function h([e]: any) { return e; }
+h([{ x: 777 }]);              // gc {x:777}, standalone undefined
+function k([{ x }]) { return x; }
+k([{ x: 777 }]);              // TRAPS "Cannot destructure 'null' or 'undefined'"
+```
+
+### What works (bounds the trigger)
+
+- **Primitive-element arrays** (`[5]`, `["a"]`) — correct both lanes.
+- **Heterogeneous arrays** (`[1, { x: 777 }]`) — correct both lanes (every
+  element boxed to externref → `__vec_externref`).
+- **Typed receivers** (`const [e] = arr`, no `any` boxing) — correct.
+
+Only a **homogeneous reference-element** array (which compiles to a *typed
+object-vec* / nested-array-vec) boxed to `any`/externref loses its elements.
+
+## Root-cause hypothesis
+
+A homogeneous-object / homogeneous-nested-array literal compiles to a **typed
+element-vec** (element type = the object struct / inner vec), not
+`__vec_externref`. When boxed to externref (crossing an `any` boundary — param,
+`any` local, or the destructure-param `externref → __vec_externref` conversion
+at `destructuring-params.ts:1249`), the standalone element read-back path does
+not **unbox the typed-vec element** to the uniform any/externref rep. Index
+access returns a wrong-typed slot / null; the destructure path's inner
+object-pattern then sees the element as null → the "Cannot destructure null"
+throw. Fix the boxed-typed-vec element read-back once at the rep boundary and
+both index access and destructuring flip together.
+
+Family: #2379 (boxed-any elem rep), #3059 (vec-any-receiver sidecar identity),
+#2151 (any-receiver dispatch). **opus-anyrecv confirmed it is NOT method
+dispatch (#3237) — it is value-representation, and they will not adopt it.**
+
+## Why it matters (floor lever)
+
+This is the **dominant root** of the async-gen dstr host-free-FAIL cluster
+(#3132 follow-up). Most of those files compile host-free but fail at runtime
+because the async-gen param is `any`-boxed and its object/array elements read
+back undefined (nested `[{x}]`, object-property nested-defaults `{ w: {x,y,z} =
+… }`, etc.). Fixing #3244 flips the bulk of that cluster host-free-PASS
+(import-independent). See #3245 for the full cluster decomposition.
+
+## Acceptance criteria
+
+1. The probe programs return correct values host-free on standalone (identical
+   to gc): `a[0].x` → 777; nested `a[0][1]` → 20; `[e]`/`[{x}]` binds the object.
+2. No gc-lane regression (typed-receiver element access byte-identical).
+3. Full merge_group standalone floor (broad-impact — any-container rep, never
+   scoped). The async-gen dstr nested-pattern cluster flips host-free-fail → pass.
+
+## Repros
+
+`/workspace/.claude/worktrees/*/.tmp/`: `anyarr.mts`, `elemtypes.mts`,
+`index-vs-dstr.mts`, `nullcheck.mts`, `bugB.mts`, `bugB2.mts`.

--- a/plan/issues/3245-async-gen-dstr-hostfree-fail-cluster-decomposition.md
+++ b/plan/issues/3245-async-gen-dstr-hostfree-fail-cluster-decomposition.md
@@ -1,0 +1,109 @@
+---
+id: 3245
+title: "async-gen dstr host-free-FAIL cluster: root decomposition + error-path mirage + runner warm/cold artifact"
+status: ready
+sprint: current
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: analysis
+area: codegen, standalone, test-infrastructure
+language_feature: async-generators, destructuring, iterator-protocol
+goal: standalone-mode
+umbrella: 1781
+related: [3244, 3132, 2580, 1543, 1042]
+created: 2026-07-13
+origin: "opus-asyncthen — scoping the async-gen dstr host-free-FAIL cluster (#3132 follow-up). Tracks the roots that are NOT #3244, and the two measurement artifacts that made this cluster look bigger/other than it is."
+---
+
+# #3245 — async-gen dstr host-free-FAIL cluster decomposition
+
+Tracking issue for the async-generator dstr host-free-FAIL cluster (files that
+compile host-free under `--target standalone` but fail at runtime). Filed so the
+non-#3244 roots and the two measurement artifacts are not lost.
+
+## Root decomposition (verified against origin/main @ 503b64ac35, 2026-07-13)
+
+An in-process batch scan of all 558 async-generator dstr files reported ~85
+host-free fails; classified by TRUE root (each verified by instrumenting the
+actual wrapped source + cold isolated repros — the per-assert line labels are
+unreliable, see Artifact A):
+
+| Root | ~files | Owner / disposition |
+| --- | --- | --- |
+| **any-boxed reference-element read** (#3244) | bulk | **#3244** (dominant gate) |
+| **any-strict-eq object identity** (`notSameValue`) | ~30 | opus-genproto3 (ref.eq object `===`, extends #2734) |
+| error-path throws (ReferenceError / TypeError) | ~29 | **MIRAGE — see below** |
+| `__array_from_iter_n` over-pull / IteratorClose | small | this issue (genuine, isolation-resistant) |
+| object-rest `{...rest}` exclusion | ~9 | this issue (verify vs #3244) |
+
+## The error-path "root #2" is a MIRAGE (29 files)
+
+The error-raising MECHANISMS work — do NOT build an "error-machinery" slice
+from this bucket:
+
+- **Unresolvable-default → ReferenceError**: `[ x = unresolvableReference ] = []`
+  / `{ x: y = unresolvableReference }` — the PURE error-path test files
+  (`obj-ptrn-prop-id-init-unresolvable`, `dflt-ary-ptrn-elem-id-init-unresolvable`,
+  `ary-ptrn-elem-id-init-unresolvable`, expr variants) **PASS cold on both
+  lanes**. Isolated probe of unbound-name read + `typeof` unbound + renamed-bind
+  read-original all raise ReferenceError correctly (`.tmp/referr.mts`).
+- **Poisoned-iterator/getter → TypeError**: `dflt-ary-init-iter-get-err`,
+  `ary-init-iter-get-err`, `ary-ptrn-elem-id-iter-step-err`,
+  `obj-ptrn-prop-eval-err` — **PASS cold**.
+
+Files bucketed here (because their SOURCE contains an `assert.throws(...)` probe)
+actually fail on a preceding **binding-value** assert rooted in **#3244**. E.g.
+`obj-ptrn-prop-obj-init.js` (`async function* f({ w: { x, y, z } = {x:4,y:5,z:6} })`,
+called `f({ w: undefined })`) — instrumented cold, `x` reads back WRONG (not 4):
+the nested-object default binds through an any-boxed param → #3244. The
+ReferenceError probe in the same file never gets to matter. **⇒ Root #2 collapses
+into #3244; no independent error-machinery bug here.**
+
+## Genuine, non-#3244 residuals (this issue owns)
+
+1. **`__array_from_iter_n` over-pull for a param pattern over a custom
+   iterator** — `async function* f([x]) {}` called with a never-`done` custom
+   iterator (`ary-init-iter-close.js`) traps "requested new array is too large
+   in `__array_from_iter_n`" instead of pulling 1 + IteratorClose (`return()`).
+   NOTE: the simplified local `const [x,y] = iter` and a plain-param `f([x])`
+   over an *incrementing* infinite iterator both work cold — this repro is
+   **isolation-resistant** (only the async-gen frame + the specific
+   `{value:null,done:false}` iterator triggers it). Needs in-frame diagnosis.
+2. **object-rest `{a, b, ...rest}`** — `assert.sameValue(rest.a, undefined)`
+   fails (`obj-ptrn-rest-val-obj.js`, `dflt-obj-ptrn-rest-val-obj.js`). Verify
+   whether genuine rest-exclusion or #3244-adjacent (rest object built over an
+   any-boxed source).
+
+## Artifact A — unreliable per-assert line labels
+
+The runner maps a failing `test()` return value (the assert counter) back to a
+source line by text search. Async microtask reordering shifts the
+assert-count→line mapping, so labels like "assert #6 notSameValue" routinely
+mislabel the true failing assert. **Always instrument the actual wrapped source
+(bitmask per assert) — never trust the label.** (This is how the 30 `notSameValue`
+files were shown to fail on any-eq, not rest-binding.)
+
+## Artifact B — in-process runner warm/cold order-dependence
+
+The same file, same target, gives different pass/fail depending on run ORDER in
+one process: `obj-ptrn-prop-obj-init.js` **PASSES** when run after other async
+files, **FAILS** cold (first / fresh process, deterministic across 3 runs).
+Running other async tests first "warms up" state that spuriously flips a
+genuinely-failing file to pass ⇒ **batch in-process scans UNDER-count fails**.
+Cold isolated per-file runs are authoritative. Root not yet identified (compiler
+program/checker cache affecting later-file codegen? shared microtask/scheduler
+state on the host side?). Worth a runner-hygiene fix so async floor measurements
+are order-independent.
+
+## Disposition
+
+The async-gen dstr host-free-fail floor gain is **gated on #3244** (dominant) +
+genproto3 (any-eq). The residuals above are minor levers. Recommend landing
+#3244 first, then re-measuring the cluster cold before touching residuals.
+
+## Repros
+
+`/workspace/.claude/worktrees/*/.tmp/`: `referr.mts`, `cold.mts`,
+`statebleed.mts`, `bitmask3.mts`, `iterpull.mts`, `parampull.mts`,
+`classify.mts`.


### PR DESCRIPTION
Docs-only — two new issue files, no code changes. Output of the async-gen dstr host-free-FAIL cluster scoping (#3132 follow-up).

## #3244 — standalone any-boxed reference-element array element-read (the dominant gate)
Standalone reads elements of a **homogeneous reference-element array** (objects / nested arrays) as `undefined`/`NaN` when the array crosses an `any`/externref boundary. Affects plain **index access** (`a[0].x`), not just destructuring — a value-representation substrate bug (#2379/#3059 family). opus-anyrecv confirmed it is NOT method-dispatch (#3237) and declined it. Full repros in the issue. This is the dominant root of the async-gen dstr host-free-fail cluster.

## #3245 — cluster decomposition + measurement artifacts
- **Error-machinery 'root' is a MIRAGE**: the ReferenceError (unresolvable-default) and TypeError (poisoned iterator/getter) mechanisms all work cold; the bucketed files fail on the underlying #3244 substrate.
- **Artifact A**: the runner's per-assert *line labels* are unreliable (async microtask reorder shifts assert-count→line) — instrument the wrapped source.
- **Artifact B**: **in-process runner warm/cold order-dependence** — the same file passes warm, fails cold (deterministic); batch scans under-count fails. Cold isolated runs are authoritative.

Routing: #3244 → fresh substrate senior (repros are the handoff); genuine non-#3244 residuals (`__array_from_iter_n` over-pull, object-rest) tracked in #3245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8