### PR TITLE
fix(#3244): standalone any-boxed reference-element array element reads

### DIFF
--- a/plan/issues/3244-standalone-any-boxed-reference-element-array-read.md
+++ b/plan/issues/3244-standalone-any-boxed-reference-element-array-read.md
@@ -1,7 +1,9 @@
 ---
 id: 3244
 title: "Standalone: any-boxed homogeneous reference-element array reads elements as undefined (index + destructuring)"
-status: ready
+status: done
+assignee: opus-anycontainer
+completed: 2026-07-13
 sprint: current
 priority: high
 feasibility: hard
@@ -12,6 +14,9 @@ language_feature: arrays, any-boxing, destructuring, element-access
 goal: standalone-mode
 umbrella: 1781
 related: [2379, 3059, 2151, 2186, 3132, 1042]
+loc-budget-allow:
+  - src/codegen/literals.ts
+  - src/codegen/object-runtime.ts
 created: 2026-07-13
 origin: "opus-asyncthen bucket-2 diagnosis of async-gen dstr host-free fails — the nested-`[{x}]` destructure-null trap drilled to a broader any-container element-rep substrate bug affecting plain index access too. opus-anyrecv confirmed NOT method-dispatch (their #3237); it is value-representation (#2379/#3059 family)."
 ---
@@ -93,3 +98,63 @@ back undefined (nested `[{x}]`, object-property nested-defaults `{ w: {x,y,z} =
 
 `/workspace/.claude/worktrees/*/.tmp/`: `anyarr.mts`, `elemtypes.mts`,
 `index-vs-dstr.mts`, `nullcheck.mts`, `bugB.mts`, `bugB2.mts`.
+
+## Resolution (opus-anycontainer, 2026-07-13)
+
+Root cause was **two separate defects on the standalone lane**, not one. WAT
+inspection of `const a: any = [{ x: 777 }]; a[0].x` vs the working
+`const o = { x: 777 }; const a: any = [o]; a[0].x` was decisive — the inline
+literal built a **null** element, the named-var built a real struct.
+
+**Defect 1 — element read-back (READ time).** `boxVecElementToExternref`
+(`src/codegen/object-runtime.ts`) — which `fillExternGetIdxVecArms` uses to box
+a typed `__vec_<k>` element as it is read through the externref boundary
+(`__extern_get_idx`) — only had arms for `f64` / `i32` / `externref` /
+**string-ref** elements. A homogeneous object array is a `__vec_<objStruct>` and
+a nested array is a `__vec_<innerVec>`; both have a **general GC struct/array
+ref** element, which hit the `return null` fallback → the carrier was skipped →
+`__extern_get_idx` answered the null miss → element read back undefined/NaN.
+Fix: generalize the string-only ref arm to box **any GC struct/array referent**
+via `extern.convert_any` (the universal GC-ref → externref boxing the string arm
+already used), guarded to skip **func-typed** referents (`funcref` is not an
+`anyref` subtype — converting it is invalid Wasm). This alone flipped nested
+arrays, string sub-arrays, and named-object arrays.
+
+**Defect 2 — inline-object-literal carrier mismatch (BUILD time).** An inline
+object literal in an `any` / `Array<any>` context is compiled as a **dynamic
+`$Object`** (externref), because its contextual type is `any`. But the array's
+element carrier is inferred from the literal's *structural* type
+(`{ x: number }` → a **closed `__anon_0` struct** → `__vec_<__anon_0>`). The
+element store then coerced `$Object → (ref null __anon_0)` via
+`any.convert_extern; ref.test; (if … ref.cast (else ref.null))` — the `ref.test`
+**fails** ($Object is not the closed struct) → the element was stored as
+**NULL**. So `a[0]` was genuinely null and Defect 1's fix could not help.
+Fix: extend the existing `#3154`/`#2106 S0` `any`-context element-widening in
+`compileArrayLiteral` (`src/codegen/literals.ts`) — which already re-keys numeric
+`any[]` elements to an externref carrier — to also fire for **plain object-struct
+elements**, so each object is stored by its own dynamic rep (identical to a
+heterogeneous `[1, { x: 777 }]` array, which already boxes every element).
+Standalone/nativeStrings-gated (the host lane uses `__js_array_new` + real JS
+values, already correct); nested-array vec-struct carriers are **excluded**
+(they read back fine via Defect 1's typed vec arm).
+
+**Both fixes are standalone-only** — host-lane binaries are byte-identical to
+`origin/main` (verified via SHA over the host-lane binary for object-array,
+typed-array, class, and object-literal shapes). GC-vs-standalone parity verified
+across 13 shapes (index, nested, deep-nested, multi-field, multi-element,
+string-field, nested-object-field, typed-then-any, and primitive/string/boolean
+controls) — all match host-free. Regression test:
+`tests/issue-3244-standalone-any-container-elem-rep.test.ts` (10 cases).
+
+**Flip-ceiling / breadth.** test262 is not checked out locally, so the full
+corpus flip-count runs in CI's merge_group standalone floor. Per opus-asyncthen's
+#3245 decomposition, #3244 is the **dominant root** of the ~85-file async-gen
+dstr host-free-FAIL cluster (nested `[{x}]`, `{ w: {x,y,z} = … }` nested-default
+patterns, etc.); the ~30 `notSameValue` files are any-strict-eq (genproto3,
+separate), and the ~29 "error-path" files were a mirage that collapse into #3244
+(their binding-value assert fails first). Coordinated with **opus-leak3**
+(cluster #2, ~925 "Cannot access property on null/undefined") — that cluster is a
+DISTINCT root (missing this-brand-check TypeError on TypedArray/ArrayBuffer
+prototype accessors), NOT #3244; only a small nested-`results[i][j]` slice
+overlaps. Coordinated with **opus-crashes** (`__iterator` plain/user-iterable
+dispatch-guard cluster) — also distinct, no src overlap.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3743,7 +3743,43 @@ export function compileArrayLiteral(
   // element is boxed by its own static type at construction, not by Wasm kind
   // after the fact. Scoped strictly to `any` contextual elements: number[] /
   // string[] / struct[] literals are untouched (byte-identical).
-  if (!hasSpread && (elemWasm.kind === "i32" || elemWasm.kind === "f64")) {
+  //
+  // (#3244) EXTENDED to object-struct elements. `[{ x: 777 }]` in an `any` /
+  // `Array<any>` context (`const a: any = [{ x: 777 }]`, `f([{ x: 777 }])` with
+  // `f(a: any)`) infers a homogeneous element type `{ x: number }`, so the
+  // first-element heuristic picks a CLOSED anon-struct carrier
+  // (`__vec_<__anon_0>`). But the object literal itself, compiled in an `any`
+  // context, is a DYNAMIC `$Object` (externref) — and the element store then
+  // coerces `$Object → (ref null __anon_0)` via `ref.test`/`ref.cast`, which
+  // FAILS (a `$Object` is not the closed struct) → the element is stored as
+  // NULL. `a[0]` reads back null → `a[0].x` throws / reads NaN. Widening the
+  // carrier to `externref` (exactly as the numeric case does) stores each object
+  // element by its own dynamic rep, so the read-back + member dispatch work
+  // identically to a heterogeneous `[1, { x: 777 }]` array (which already boxes
+  // every element). Scoped, like the numeric widening, to an `any`/`Array<any>`
+  // contextual type — a genuinely-typed `Iface[]` / `{x:number}[]` literal keeps
+  // its closed-struct carrier byte-identical (and reads back correctly through
+  // the #3244 `boxVecElementToExternref` arm when it later crosses the boundary).
+  // NESTED-ARRAY (vec-struct) elements are EXCLUDED — they already read back via
+  // the typed `__extern_get_idx` vec arm — so this only re-keys plain objects.
+  const elemIsPlainObjectStructRef =
+    // Standalone/nativeStrings only — the closed-struct-carrier + lossy
+    // `$Object`→struct downcast is the STANDALONE array-build path (the host lane
+    // uses `__js_array_new` + real JS values, already correct at 777). Gating
+    // here keeps the host lane byte-identical (the numeric widenings above stay
+    // ungated because they fix genuine any[]-boxing needed in both lanes).
+    (ctx.standalone || ctx.nativeStrings) &&
+    (elemWasm.kind === "ref" || elemWasm.kind === "ref_null") &&
+    (() => {
+      const ti = (elemWasm as { typeIdx: number }).typeIdx;
+      if (ti < 0) return false;
+      if (ti === ctx.anyStrTypeIdx || ti === ctx.nativeStrTypeIdx) return false; // strings keep their carrier
+      const rt = ctx.mod.types[ti];
+      if (rt?.kind !== "struct") return false;
+      for (const v of ctx.vecTypeMap.values()) if (v === ti) return false; // exclude nested-array vec carriers
+      return true;
+    })();
+  if (!hasSpread && (elemWasm.kind === "i32" || elemWasm.kind === "f64" || elemIsPlainObjectStructRef)) {
     const ctxArrType = ctx.checker.getContextualType(expr);
     if (ctxArrType) {
       const ctxArrSym = (ctxArrType as ts.TypeReference).symbol ?? ctxArrType.symbol;

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -10140,8 +10140,33 @@ export function boxVecElementToExternref(ctx: CodegenContext, elemType: ValType)
   // behaviour to those paths.
   if (elemType.kind === "ref" || elemType.kind === "ref_null") {
     const ti = (elemType as { typeIdx: number }).typeIdx;
-    if (ti >= 0 && (ti === ctx.anyStrTypeIdx || ti === ctx.nativeStrTypeIdx)) {
-      return [{ op: "extern.convert_any" } as Instr];
+    // (#3244) GENERALISED from the string-only arm this replaces. A homogeneous
+    // reference-element array — `[{ x: 777 }]` (element = object STRUCT ref) or a
+    // nested `[[10, 20, 30]]` (element = inner `__vec_<k>` STRUCT ref) — compiles
+    // to a typed `__vec_<structKind>` carrier, NOT `__vec_externref`. Boxing it
+    // to `any`/externref and reading an element back (`(a as any)[0].x`,
+    // `(a as any)[0][1]`, and the destructure-param inner object/array pattern)
+    // routes through `__extern_get_idx`; without an arm here the carrier was
+    // skipped → the element read fell to the null fallback → read back
+    // undefined/NaN (and the nested-pattern destructure then saw null → the
+    // "Cannot destructure null" trap). `extern.convert_any` is the universal
+    // GC-ref → externref boxing (identity round-trip: the consuming site
+    // re-tests/casts the returned externref back to the object/vec type, exactly
+    // as for a heterogeneous `__vec_externref` element or the string sub-array
+    // that the prior narrow arm handled — `$AnyString`/`$NativeString` are
+    // struct types, so they still match here).
+    //
+    // GUARD — only GC STRUCT/ARRAY referents are subtypes of `anyref`, the input
+    // `extern.convert_any` requires. A FUNC-typed ref (`funcref` hierarchy) is
+    // NOT an `anyref` subtype, so converting it is invalid Wasm; those carriers
+    // stay on the null fallback (the rare closure/funcref-element vec — never
+    // read positionally through the boundary in practice). An unknown/negative
+    // typeIdx also skips, conservatively.
+    if (ti >= 0) {
+      const referent = ctx.mod.types[ti];
+      if (referent && (referent.kind === "struct" || referent.kind === "array")) {
+        return [{ op: "extern.convert_any" } as Instr];
+      }
     }
   }
   // other ref / ref_null / f32 / i64 / v128 → no arm (see scope note).

--- a/tests/issue-3244-standalone-any-container-elem-rep.test.ts
+++ b/tests/issue-3244-standalone-any-container-elem-rep.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3244 — Standalone: any-boxed homogeneous reference-element array reads
+ * elements as undefined/NaN (index access + destructuring).
+ *
+ * A homogeneous reference-element array — `[{ x: 777 }]` (element = object
+ * struct ref) or a nested `[[10, 20, 30]]` (element = inner vec struct ref) —
+ * compiles to a typed `__vec_<structKind>` carrier, NOT `__vec_externref`.
+ * Under `--target standalone`, boxing that carrier to `any`/externref and reading
+ * an element back (`(a as any)[0].x`, `(a as any)[0][1]`, or the destructure-param
+ * inner object/array pattern) lost the element (read back undefined/NaN, or the
+ * nested-pattern destructure saw null → "Cannot destructure null" throw).
+ *
+ * Two root fixes, both standalone-only:
+ *  1. `boxVecElementToExternref` (object-runtime.ts) now boxes ANY GC struct/array
+ *     element via `extern.convert_any` (was string-ref only), so the typed-vec
+ *     element read-back through `__extern_get_idx` produces a dispatchable
+ *     externref.
+ *  2. Array-literal carrier widening (literals.ts) — an object-literal element in
+ *     an `any`/`Array<any>` context is a dynamic `$Object`, but the carrier was a
+ *     closed struct → the store lossily downcast `$Object → struct` to NULL.
+ *     Widen the carrier to externref (as the numeric `any[]` case already does).
+ *
+ * Correct on the WasmGC host lane before this fix; these assert the standalone
+ * lane now matches, host-free.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<{ val: unknown; hostImports: string[] }> {
+  const r = await compile(src, { fileName: "issue-3244.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const hostImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module !== "wasi_snapshot_preview1")
+    .map((i) => `${i.module}::${i.name}`);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return { val: (instance.exports as { main(): unknown }).main(), hostImports };
+}
+
+describe("#3244 — standalone any-boxed reference-element array element reads", () => {
+  it("reads an object element property through an any param (index access)", async () => {
+    const { val, hostImports } = await runStandalone(
+      `function f(a: any): number { return a[0].x; }
+       export function main(): number { return f([{ x: 777 }]); }`,
+    );
+    expect(val).toBe(777);
+    expect(hostImports, "must be host-free").toEqual([]);
+  });
+
+  it("reads a nested array element through an any param (double index)", async () => {
+    const { val } = await runStandalone(
+      `function g(a: any): number { return a[0][1]; }
+       export function main(): number { return g([[10, 20, 30]]); }`,
+    );
+    expect(val).toBe(20);
+  });
+
+  it("reads a deeply-nested array element", async () => {
+    const { val } = await runStandalone(
+      `function f(a: any): number { return a[0][0][0]; }
+       export function main(): number { return f([[[42]]]); }`,
+    );
+    expect(val).toBe(42);
+  });
+
+  it("binds an object element through a destructuring param `[e]`", async () => {
+    const { val } = await runStandalone(
+      `function h([e]: any): number { return e.x; }
+       export function main(): number { return h([{ x: 777 }]); }`,
+    );
+    expect(val).toBe(777);
+  });
+
+  it("binds a nested object-pattern destructuring param `[{ x }]` (was: 'Cannot destructure null')", async () => {
+    const { val } = await runStandalone(
+      `function k([{ x }]: any): number { return x; }
+       export function main(): number { return k([{ x: 55 }]); }`,
+    );
+    expect(val).toBe(55);
+  });
+
+  it("reads multiple fields and multiple object elements", async () => {
+    const { val } = await runStandalone(
+      `function f(a: any): number { return a[0].x + a[0].y + a[1].x; }
+       export function main(): number { return f([{ x: 3, y: 4 }, { x: 5 }]); }`,
+    );
+    expect(val).toBe(12);
+  });
+
+  it("reads a string field off an object element (string sub-value)", async () => {
+    const { val } = await runStandalone(
+      `function f(a: any): number { return a[0].s.length; }
+       export function main(): number { return f([{ s: "hello" }]); }`,
+    );
+    expect(val).toBe(5);
+  });
+
+  it("reads a nested-object field off an object element", async () => {
+    const { val } = await runStandalone(
+      `function f(a: any): number { return a[0].p.q; }
+       export function main(): number { return f([{ p: { q: 9 } }]); }`,
+    );
+    expect(val).toBe(9);
+  });
+
+  it("reads back through a genuinely-typed array that later crosses the any boundary", async () => {
+    const { val } = await runStandalone(
+      `export function main(): number { const arr: { x: number }[] = [{ x: 5 }]; const a: any = arr; return a[0].x; }`,
+    );
+    expect(val).toBe(5);
+  });
+
+  it("does not regress primitive / string / heterogeneous element reads", async () => {
+    expect((await runStandalone(`export function main(): number { const a: any = [5, 6, 7]; return a[1]; }`)).val).toBe(
+      6,
+    );
+    expect(
+      (await runStandalone(`export function main(): number { const a: any = ["ab", "cd"]; return a[0].length; }`)).val,
+    ).toBe(2);
+    expect(
+      (
+        await runStandalone(`function f(a: any): number { return a[1].x; }
+        export function main(): number { return f([1, { x: 777 }]); }`)
+      ).val,
+    ).toBe(777);
+  });
+});


### PR DESCRIPTION
## Problem

Under `--target standalone`, reading an element of a **homogeneous
reference-element array** (elements are objects, or nested arrays) through an
`any`/externref boundary returned `undefined`/`NaN` for index access, or threw
"Cannot destructure 'null' or 'undefined'" for a nested destructure pattern.
Correct on the WasmGC host lane; wrong only on standalone.

```ts
function f(a: any): number { return a[0].x; }   f([{ x: 777 }]);   // gc 777, standalone was NaN
function g(a: any): number { return a[0][1]; }  g([[10,20,30]]);   // gc 20,  standalone was NaN
function k([{ x }]: any) { return x; } k([{ x: 777 }]);            // standalone threw "Cannot destructure null"
```

Primitive-element (`[5]`), string-element (`["a"]`), and heterogeneous
(`[1, {x:777}]`) arrays already worked on both lanes.

## Root cause — two separate standalone-lane defects

WAT of `const a: any = [{ x: 777 }]; a[0].x` (broken) vs
`const o = { x: 777 }; const a: any = [o]; a[0].x` (works) was decisive: the
inline literal stored a **null** element; the named-var stored a real struct.

**Defect 1 — element read-back (READ time).** `boxVecElementToExternref`
(`src/codegen/object-runtime.ts`), used by `fillExternGetIdxVecArms` to box a
typed `__vec_<k>` element as it's read through `__extern_get_idx`, only had arms
for `f64`/`i32`/`externref`/**string-ref** elements. A homogeneous object array
is a `__vec_<objStruct>` and a nested array is a `__vec_<innerVec>` — both have a
general **GC struct/array ref** element, which hit the `return null` fallback →
carrier skipped → element read back as the null miss. Fix: generalize the
string-only ref arm to box **any GC struct/array referent** via
`extern.convert_any`, guarded to skip **func-typed** referents (`funcref` is not
an `anyref` subtype → converting it is invalid Wasm).

**Defect 2 — inline-object-literal carrier mismatch (BUILD time).** An inline
object literal in an `any`/`Array<any>` context compiles to a dynamic `$Object`
(externref), but the array's element carrier is inferred from the literal's
structural type → a **closed `__anon_0` struct** (`__vec_<__anon_0>`). The
element store coerced `$Object → (ref null __anon_0)` via `ref.test`/`ref.cast`,
which **fails** → stored as **NULL**. Fix: extend the existing `#3154`/`#2106 S0`
numeric `any`-context element-widening in `compileArrayLiteral`
(`src/codegen/literals.ts`) to also fire for plain object-struct elements, so
each object is stored by its own dynamic rep (identical to a heterogeneous
array). Standalone/nativeStrings-gated; nested-array vec carriers excluded (they
read back via Defect 1's typed vec arm).

## Safety

- **Both fixes standalone-only** — host-lane binaries **byte-identical** to
  `origin/main` (verified via SHA over host-lane output for object-array,
  typed-array, class, and object-literal shapes).
- **GC-vs-standalone parity** verified across 13 shapes (index, nested,
  deep-nested, multi-field, multi-element, string-field, nested-object-field,
  typed-then-any, plus primitive/string/boolean controls) — all match, host-free.
- Regression test `tests/issue-3244-standalone-any-container-elem-rep.test.ts`
  (10 cases). Relevant array/destructuring/standalone suites pass; the two
  pre-existing failures in `illegal-cast-vec-tuple-648` and `fast-arrays > array
  find` also fail on `origin/main` (stale-API / TS-strictness, unrelated).

## Breadth

Dominant root of the async-gen dstr host-free-FAIL cluster per opus-asyncthen's
#3245 decomposition. Confirmed **distinct** from opus-leak3's cluster #2
(this-brand-check TypeError on TA/AB accessors) and opus-crashes's `__iterator`
dispatch-guard cluster — no shared root, no src overlap. Full corpus flip-count
runs in CI's merge_group standalone floor.

Closes #3244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8