### PR TITLE
docs(memory): sprint-71 session learnings (standalone frontier + measurement/CI gotchas)

### DIFF
--- a/.claude/memory/feedback_fable_writes_impl_plans_for_hard_issues.md
+++ b/.claude/memory/feedback_fable_writes_impl_plans_for_hard_issues.md
@@ -1,0 +1,38 @@
+---
+name: feedback_fable_writes_impl_plans_for_hard_issues
+description: "Standing directive (2026-07-12): spend the abundant fable budget having a fable ARCHITECT write concrete `## Implementation Plan` specs into the issue files for the DIFFICULT issues — deep-compiler / architectural / broad-impact ones that opus (or any dev) may not crack alone without a written design first. De-risk the hard stuff with specs, don't just attempt it."
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**User directive (2026-07-12, during the fable burn):** "Make sure a fable
+agent writes down an implementation plan for difficult issues that opus may not
+be able to do alone."
+
+**Why:** the fable weekly budget is plentiful and being burned hard; its
+highest-leverage use for the HARDEST issues is not fable attempting them
+directly (fable may not crack a broad-impact/architectural one), but a fable
+**architect** producing architect-grade `## Implementation Plan` sections —
+concrete functions, file:line anchors, Wasm/IR patterns, edge cases, spec
+citations, bounded slicing, and CI/validation strategy — so those issues become
+tractable for whoever implements them later (opus in the sprint loop, or a
+fresh fable dev). Specs de-risk; a naive attempt on broad-impact codegen just
+parks in merge_group.
+
+**How to apply:** keep (at least intermittently) a fable **architect** subagent
+(`subagent_type: architect`, `model: fable`, one-shot: read source → write
+plans → PR the plan additions → exit) working the difficult backlog. Target set
+= `[ARCH]`-tagged, `feasibility: hard`, broad-impact (value-rep / dispatch /
+scorer-adjacent), or repeatedly-parked issues that LACK an existing
+`## Implementation Plan`. EXCLUDE the aspirational goal-epics (compile
+React/axios/tsc-itself, TS7 rewrite, big demos) — those are long-horizon goals,
+not sprint-actionable. First concrete target this session: **#2997** (try→
+try_table Wasm EH opcode migration — explicitly "needs architect spec first").
+The architect edits ONLY `plan/issues/*.md`, never src/. This is additive to
+the [[project_bloat_reduction_week_of_2026_07_11]] burn — it runs alongside the
+4 devs + shepherd, as a transient subagent (auto-cleanup), not a 5th standing
+teammate. Related: the `/architect-spec` skill, [[feedback_verify_first_beats_architect_spec]]
+(verify-on-current-main beats a stale spec — architect must ground specs against
+CURRENT main, not narrative).

--- a/.claude/memory/feedback_idle_waiting_agent_not_terminated_dont_reassign_pr.md
+++ b/.claude/memory/feedback_idle_waiting_agent_not_terminated_dont_reassign_pr.md
@@ -1,0 +1,35 @@
+---
+name: feedback_idle_waiting_agent_not_terminated_dont_reassign_pr
+description: A background teammate's "completed" task-notification (or a transient SendMessage "not reachable") means it STOPPED THAT TURN — often idle-waiting on its own background CI watcher — NOT that it terminated; don't spawn a replacement or reassign its in-flight PR without verifying, or two agents collide on one branch.
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+A background dev teammate that has opened a PR and backgrounded a CI watcher goes
+quiet and emits a `<task-notification>` with `status=completed` — but it is
+**still alive**, resumable, and will wake when its watcher fires. A one-off
+SendMessage "No agent named X is reachable" can also be transient (the agent is
+mid-watcher-cycle), not proof of termination.
+
+**Hazard:** treating that as "the agent exited" and (a) spawning a replacement
+and/or (b) reassigning its in-flight PR/branch to another dev → two agents on one
+branch → clobber risk (one force-pushes over the other's fix).
+
+**What happened (2026-07-10):** fable-2856 opened PR #2857, backgrounded a
+watcher, notified `completed`; an earlier shutdown SendMessage returned "not
+reachable". I concluded it exited and told fable-9th to rescue #2857. fable-2856
+was actually alive and had already rescued #2857 itself (pushed 864d10ea71).
+Caught it only by checking the PR head before fable-9th pushed; redirected
+fable-9th to a different task. No clobber, but it was luck of timing.
+
+**Rule:** before spawning a replacement for or reassigning the PR of an
+apparently-done teammate, VERIFY termination — check the PR head/state
+(`gh pr view <N> --json headRefOid,mergeStateStatus`), and prefer a targeted
+SendMessage to the agent ("are you still on X?") over assuming. Idle-waiting on a
+watcher is the healthy state (see [[feedback_dev_silence_protocol]]); silence ≠
+exit. If two agents must touch one branch, one drops it — never both push.
+Related: [[feedback_no_shared_worktree_assignment]],
+[[feedback_shared_worktree_clobber_check_claim_first]],
+[[feedback_background_teammate_shutdown_limitation]].

--- a/.claude/memory/project_bloat_reduction_week_of_2026_07_11.md
+++ b/.claude/memory/project_bloat_reduction_week_of_2026_07_11.md
@@ -1,0 +1,109 @@
+---
+name: project_bloat_reduction_week_of_2026_07_11
+description: "Week of 2026-07-11: stakeholder's #1 priority is a bloat-reduction battle plan + execution — src/ is ~320k lines (src/codegen 238k) at 76.0% test262 vs porffor's ~30k lines at comparable pass rate. Burn the weekly Fable budget fast (max parallelism) toward this. Plan doc: plan/bloat-reduction-battle-plan.md."
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: ba8f46fe-f3a2-4212-b22a-2f3e64ded7ab
+---
+
+**Directive (2026-07-11, new week):** burn the weekly Fable budget as fast as
+possible (max parallelism) **until Sunday**; keep the TaskList full the whole
+time; the SINGLE most important deliverable is a **battle plan to reduce codebase
+bloat** and then execute it. Battle plan DELIVERED: `plan/bloat-reduction-battle-plan.md`
+(PR #2885) + issue stubs #3141 (self-hosting pilot — IN FLIGHT, fable-selfhost),
+#3142 (module-level IR adoption / clears G3), #3143 (IR-first default flip / clears
+G1 → unlocks −60k legacy frontend).
+
+**FLEET SIZE CAP (2026-07-12, user directive): EXACTLY 4 dev agents + 1 shepherd —
+do NOT oversubscribe the 8-core box.** More than ~4 heavy dev agents thrashes it
+(load spiked 46 from a census sweep + fleet; ~5 agents already push load 11-15).
+The merge_group queue is FAST (~4 min/PR) — so the throughput bottleneck is NOT the
+queue, it's agent-side: on a thrashed box each dev is slow to produce a green PR.
+Fewer agents each getting real CPU = green PRs faster = more merges. So: hold at 4
+devs + 1 shepherd; NEVER spawn a 5th dev; when a dev finishes, REDIRECT it (don't
+stand down) — net fleet stays 4. BAN heavy in-agent full-corpus runs (census /
+run-test262 sweeps) unless load-checked first — they froze the box. Load cap stays
+cores-2=6 (spawn gate); never raise JS2WASM_MAX_LOAD.
+
+**STANDING DIRECTIVE (2026-07-11 Sun, updated):** burn to end of Sunday; DEVS DO
+NOT STAND DOWN — on PR-land / wall-hit / "next or stand down?", ALWAYS redirect to
+the next TaskList task (never send shutdown, never accept a voluntary stand-down)
+unless a dev hits a hard context/budget wall. Keep the TaskList FULL (sync +
+287-issue backlog + filed issues; re-run scripts/sync-current-tasklist.mjs if low).
+REPORT MERGED BLOAT WINS to the user as they land (CPS-engine deletion #2967 2c,
+selector-precision slices, #3090 dead-code, self-hosting scale-up, any −LOC PR).
+
+**DEADLINE: the burn window closes SUNDAY (calendar), which as of 2026-07-11 is
+TOMORROW — ~1 day left, NOT the 6.1d the budget-status "weekly window" shows (that
+is a rolling rate-limit clock, not the calendar deadline the user set).** With
+~93% budget unspent and ~1 day: STOP pacing, spend hard, and prioritize
+LANDABLE-by-Sunday value + decision-data (esp. the #3141 self-hosting go/no-go
+verdict — must land in-window to be actionable) over long-horizon XL work that
+can't finish. Do NOT hold big-bang PRs for after the window.
+
+**Operational state (2026-07-11 ~18:45):** budget 96% / (rolling-window 6.2d but
+calendar deadline Sunday) — the 5h *sub*-window cycles ~5× before Sunday and its reset KILLS agents
+with "session-limit"/"login-expired" API errors (they push progress first; resume
+by respawning FRESH on their pushed branches, force-taking stale locks). Queue
+depth is handled by `scripts/sync-current-tasklist.mjs` (hook-wired; 63 tasks
+queued, 287 ready/in-progress issues available) — re-run it if depth drops.
+**Per-tick loop responsibilities for the week:** (1) keep fleet at ~6-8 active
+(respawn after window-reset deaths onto the dead agents' pushed branches); (2)
+keep TaskList full (re-run sync if low); (3) shepherd the merge queue (keep it fed
+3-deep → ~12/hr); (4) surface the #3141 pilot go/no-go + real escalations to the
+user. Load cap = cores-2 = 6; do NOT raise JS2WASM_MAX_LOAD without user go
+(trades away SSH responsiveness); 6 heavy Fable agents already spike load to 9-15
+in compile bursts — that's the ceiling, spawns gate above it. Framing: porffor
+is ~30,000 lines at a comparable-or-better test262 pass rate; ours is ~320,000
+(`src/codegen/` alone 238k) at 76.0% conformance.
+
+**Measured bloat shape (2026-07-11):** src/ 320k total. src/codegen 238k (74%),
+src/ir 33k, codegen-linear 10k. Biggest files: calls.ts 18k, runtime.ts 16k,
+codegen/index.ts 15k, object-runtime 10k, array-methods 9.5k, property-access
+8.5k, native-strings 7.4k, from-ast (IR) 6.8k.
+
+**Three reducible levers, in leverage order:**
+**★ SELF-HOSTING PILOT #3141 VERDICT = GO (2026-07-11, decisive, hard proof).**
+fable-selfhost converted 9 Math helpers (sinh/cosh/tanh/asinh/acosh/atanh/cbrt/
+expm1/log1p) from hand-emitted Wasm to ordinary TS source (src/stdlib/math.ts)
+compiled through our OWN IR pipeline via a reusable driver (src/codegen/
+stdlib-selfhost.ts: from-ast → IR passes → BackendEmitter, symbolic-ref lowering
+against live ctx). Proof: 36,477-case bit-exact sweep vs exact JS port = ZERO
+mismatches; byte-identical containment for non-using programs; standalone+wasi zero
+host imports; NO dialect gaps (from-ast accepted everything first try; only quirk =
+no NaN/Infinity identifiers in the subset, avoid via x!==x / 0/0 / >MAX_VALUE).
+Economics: ~3.3× compression on function bodies (−316 hand → ~95 TS-source);
+one-time driver +161 AMORTIZES → marginal cost per additional family = just its TS
+source. => the ~45-55k stdlib reduction is VALIDATED as real. Scale-up (convert
+array-methods 9.5k / object-runtime 10k / native-strings 7.4k / dataview-native
+3.9k / …) is the flagship for the NEXT window; each family byte-inert-proven via the
+pilot's bit-exact + containment method. Scale-up plan being written by fable-selfhost.
+
+1. **Self-host the stdlib (the porffor model) — highest leverage, PILOT PROVED GO.**
+   ~50-60k lines are hand-written per-builtin Wasm emission (runtime.ts +
+   *-methods.ts + object-runtime). Porffor writes builtins as a JS/TS subset it
+   compiles through its own pipeline (source-data, not compiler-code). Open
+   feasibility question: is our self-compile path stable enough to eat the
+   stdlib? Architect (fable-architect) scoping a go/no-go.
+2. **Delete the legacy AST→Wasm frontend as IR claims node kinds — ~60k
+   deletable, low-risk, incremental, IN MOTION.** #2855 (IR fallback retirement)
+   + #3090 (codegen-shrink; Phase 0/2a/2b/2c landed; audit
+   `scripts/audit-legacy-reachability.mjs`, list
+   `plan/log/3090-phase0-legacy-delete-list.md`). Handler deletion is
+   IR-overlay-gated (legacy compiles everything first; a handler stays live until
+   IR fully owns that node kind — respect G1-G4). #2967 async-engine convergence
+   deletes the CPS engine (emitAsyncStateMachine/splitBodyAtAwait) = concrete
+   headline win.
+3. **Collapse god-files** (calls.ts 18k, index.ts 15k, property-access 8.5k) via
+   the unified emitter/IR contract — lower line-yield.
+
+**NOT reducible:** the WasmGC-vs-linear BACKEND split (both stay, target-dependent
+per CLAUDE.md / #1527). Deletion lives in the legacy-vs-IR FRONTEND split only.
+
+**Safety rule for every deletion slice:** byte-inert (prove-emit-identity /
+sha-identical both string modes) OR measured-net-non-negative via the equivalence
+gate + merge_group — pass rate must not regress. See [[project_broad_impact_validate_full_ci]].
+Related: [[feedback_devs_default_opus]] (devs run fable), the load cap ~cores-2,
+and the queue-throughput note: keep the merge queue fed 3-deep (shepherd) — it
+merges ~12/hr back-to-back when fed, ~2/hr when it idles between rebases.

--- a/.claude/memory/reference_async_standalone_measure_warm_cold_order_dependence.md
+++ b/.claude/memory/reference_async_standalone_measure_warm_cold_order_dependence.md
@@ -1,0 +1,49 @@
+---
+name: reference_async_standalone_measure_warm_cold_order_dependence
+description: "Async-generator/Promise standalone test262 results are ORDER-DEPENDENT in the in-process (warm) runner: the SAME file passes when run after other async files but FAILS when run cold (fresh process, isolated). Warm-up spuriously flips genuinely-failing files to pass, so BATCH scans UNDER-COUNT async host-free-fails; COLD isolated runs are authoritative. Also: the runner's per-assert LINE labels are unreliable for async tests (microtask reorder shifts the assert-count→source-line mapping) — instrument the wrapped source, never trust the label. When measuring async standalone floor / bucketing async fails, run cold-isolated and instrument source."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Surfaced 2026-07-13 (opus-asyncthen, scoping async-gen dstr host-free-fails).**
+Two measurement artifacts that corrupt async standalone bucketing if you trust
+the batch runner:
+
+**Artifact A — unreliable per-assert line labels.** For async tests, microtask
+reordering shifts the assert-count→source-line mapping, so a scan label like
+"assert #6 notSameValue" frequently mislabels the TRUE failing assert. Verify
+every root by instrumenting the actual wrapped source + isolated repros, not the
+scan's line label.
+
+**Artifact B — in-process warm/cold order-dependence (the dangerous one).** The
+SAME async file **passes when run after other async files (warm) but FAILS run
+cold** (fresh process, isolated) — deterministically. Warm-up spuriously flips
+genuinely-failing files to *pass*, so a batch scan **UNDER-COUNTS** async
+host-free-fails; the true failing set is larger. **Cold isolated runs are
+authoritative** for async floor measurement. Suspected root (TBD): compiler
+program/checker cache affecting later-file codegen, or shared host scheduler
+state leaking across in-process compiles. Worth a runner-hygiene fix (filed under
+#3245) — until then, measure async standalone fails cold-isolated.
+
+**Breadth CONFIRMED far beyond async (lead, 2026-07-13, diffing two consecutive
+promoted standalone baselines 34 min apart):** the order-dependence churns
+**~277 tests per run** — and they're DETERMINISTIC pure functions (Math.cos/sin/
+tan/log/pow, parseInt, parseFloat, Date setters, Number numeric-separator
+literals, DataView.getFloat), which cannot really regress. Between two baselines:
+277 flipped host-free-pass→fail AND 269 flipped fail→host-free-pass (near-
+symmetric = flake, not code). Net host_free_pass moved only −8 (22,973→22,965,
+53.29→53.28%) while total pass rose +209. **⇒ single-run standalone host_free_pass
+has a ~±0.6% (~277-test) noise band; a 0.1% single-run move is UNINTERPRETABLE.**
+Judge standalone by the #2097 HIGH-WATER FLOOR (ignores churn) or a multi-run
+median, never a single-run %. Real gains only show once they exceed the ~277
+band. Fix: runner-hygiene (#3245).
+
+**Consequence for dispatch:** don't size an async-gen host-free-fail lever from a
+warm batch scan — it will read too small. And a "cluster of N error-path fails"
+may be a MIRAGE: opus-asyncthen found the 29 "error-machinery" async-gen dstr
+fails actually pass their error probe and fail on a *preceding* binding assert
+rooted in the any-container element-rep substrate [[reference_postflip_standalone_hostfreefail_is_the_frontier]]
+(#3244) — the whole async-gen dstr host-free-fail cluster collapses into #3244 +
+the object-`===` eq fix, not independent error-machinery work.

--- a/.claude/memory/reference_backgrounded_merge_watcher_dies_strands_agent_on_base_merge.md
+++ b/.claude/memory/reference_backgrounded_merge_watcher_dies_strands_agent_on_base_merge.md
@@ -1,0 +1,59 @@
+---
+name: reference_backgrounded_merge_watcher_dies_strands_agent_on_base_merge
+description: "When an agent sequences a same-file next-slice by PARKING on a backgrounded bash watcher for its BASE PR to merge, the watcher dies with the reaped process, so when the base actually merges the agent is NEVER re-invoked → it sits idle for hours, having silently produced nothing. Symptom: agent's task .output mtime goes stale (2–6h) with NO new PR after its base merged, load unexpectedly low. Recovery: SendMessage the agent directly (resumes it from transcript, bypassing the dead watcher). Prevention: don't let agents re-park on a backgrounded watcher for the base-merge; the LEAD proactively re-engages the waiting agent the moment its base PR merges (or dispatches the next slice fresh)."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Diagnosed 2026-07-13 (lead) — caught THREE agents stranded simultaneously
+(opus-delete/atan, opus-r4/R4b, opus-3201b/join-for-of).** All three had
+finished a slice on a hotspot file (`math-helpers.ts`, `array-methods.ts`,
+`calls.ts`), and — to avoid a same-file self-conflict — each parked waiting for
+its just-opened PR to MERGE before branching the NEXT slice from fresh main,
+using a **backgrounded bash merge-watcher** (`while ! merged; do sleep; done`)
+plus "go quiet." The base PRs all merged. But the watchers had **died with the
+reaped agent process**, so the merge event never re-invoked any of them → all
+three sat idle 2.5–5.5h producing nothing, while the lead believed they were
+building.
+
+**How it was caught:** the lead health-checked agent liveness via task
+`.output` mtime (`stat -c %Y` on `<taskdir>/<agentId>.output`, without reading
+the transcript). Stale mtimes (329/173/151 min) + no open PRs from the fleet +
+unexpectedly low load (~2.4) = stranded, not building. Confirmed by checking the
+worktree HEAD (a plain "Merge origin/main" commit, no next-slice work) and that
+the base PR had already merged hours earlier.
+
+**⚠ CAVEAT — stale mtime ALONE is NOT a stall (false-positive seen same day):**
+a long FOREGROUND command (full compile/test suite, a bit-exact 2851-comparison
+sweep) freezes the agent's `.output` mtime for 20–75 min while the agent is
+perfectly healthy. Before concluding "stalled," CONFIRM with worktree activity:
+`git -C <wt> log -1 --format=%cr` (recent commit?), `git status --porcelain`
+(dirty files = actively editing?), and `pgrep -fc vitest/tsc/esbuild` (live
+compiles?). Stranded = stale mtime **AND** worktree HEAD is a plain merge commit
+with no dirty files **AND** no live compiles **AND** the base PR already merged.
+If the worktree has recent commits / dirty files, or vitest/tsc are running, the
+agent is on a long command — LEAVE IT, do not re-engage (re-engaging mid-command
+is disruptive). Load is a tell: genuinely-stranded fleet → load unexpectedly LOW;
+healthy-but-quiet fleet → load elevated from the compiles.
+
+**Recovery (works):** `SendMessage` the stalled agent directly — the harness
+reports "had no active task; resumed from transcript" and re-invokes it,
+bypassing the dead watcher. It picks up its recorded next-slice plan and
+proceeds. (Resume runs on the LEAD model, fine when the agent is already opus —
+see [[reference_resume_runs_lead_model_not_agent_fable]].) If it can't progress
+(truly wedged / deep-budget), dispatch the next slice FRESH.
+
+**Prevention / orchestration change:** for same-file serialized slices, do NOT
+trust an agent's backgrounded merge-watcher to sequence the next slice. Either
+(a) the LEAD proactively SendMessages the waiting agent the instant its base PR
+merges (the lead sees merges on its loop reground), or (b) the agent opens its
+PR and STANDS DOWN, and the next slice is dispatched fresh from merged main.
+Add "check fleet .output mtimes; re-engage any stale agent whose base PR merged"
+to the loop-tick routine. Same root family as
+[[feedback_background_teammate_shutdown_limitation]] (backgrounded watchers /
+BG-teammate lifecycle die outside the agent's own turn) and the #2225/#2247
+"CI-watcher dies on stand-down → green PR strands" class that moved enqueue
+server-side (#2786). Here it's the SEQUENCING watcher, not the enqueue watcher,
+but the failure is identical.

--- a/.claude/memory/reference_baseline_chore_treadmill_manual_enqueue_broadimpact_pr.md
+++ b/.claude/memory/reference_baseline_chore_treadmill_manual_enqueue_broadimpact_pr.md
@@ -1,0 +1,40 @@
+---
+name: reference_baseline_chore_treadmill_manual_enqueue_broadimpact_pr
+description: "A broad-impact PR with slow CI (full standalone shards) can get stuck perpetually BEHIND — NOT from coordinator merges but from the automated `[skip ci]` baseline-refresh chore that advances main every ~10 min. auto-enqueue.yml guards on CLEAN so it skips a PR that a chore BEHIND-ed mid-CI. Fix: lead one-shot manually enqueues via enqueuePullRequest (user PAT) the moment it's all-green, before the next chore."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Diagnosed 2026-07-12 (fable-eqfix, on #2922 / #90):** a broad-impact PR
+whose CI takes a while (full standalone shards + equivalence) can cycle BEHIND
+indefinitely and never enqueue, even when the merge queue is empty and no dev
+is merging. Root cause is NOT coordinator/dev merges — it's the **automated
+`[skip ci]` baseline-refresh chore that commits to `main` every ~10 min**
+(touching only baseline JSON). Every chore bumps `main`, so a PR that was CLEAN
+at CI-start is BEHIND by CI-completion. `auto-enqueue.yml` guards on `CLEAN`
+(mergeStateStatus), so it **skips** the just-green-but-now-BEHIND PR — and the
+dev re-merges, re-runs slow CI, and the next chore catches it again. The
+"treadmill."
+
+**Why dormancy makes it worse:** a dev that goes quiet after pushing only wakes
+on its OWN CI-completion, not on `main` advancing under it — so it doesn't
+re-merge promptly and the PR sits BEHIND for long stretches (see
+[[feedback_idle_waiting_agent_not_terminated_dont_reassign_pr]]). Keep the dev
+ACTIVELY polling `gh pr view <N> --json mergeStateStatus` every ~60s.
+
+**The fix (lead/shepherd action):** the moment the PR is **all-green**, the
+lead **one-shot manually enqueues** it via the `enqueuePullRequest` GraphQL
+mutation with the **user PAT** (NOT a re-enqueue loop — a single enqueue).
+Manual enqueue takes a BEHIND PR that `auto-enqueue.yml` skips; once it's IN the
+queue, `merge_group` rebases it onto current `main` and baseline chores can no
+longer displace it. Sequence: dev polls → pings lead "GREEN #<N> head=<sha>" →
+lead enqueues that sha immediately (beat the next ~10-min chore).
+
+**Applies to:** any broad-impact / slow-CI PR — the upcoming standalone-family
+PRs (#3164/#3132/#2903 R-slices), #90-class value-rep changes, etc. NEVER
+re-enqueue in a loop (cancels the in-flight merge_group run —
+[[project_merge_queue_requeue_cancels_run]]). Related CI-gotcha: baseline
+refresh commits BEHIND every PR (the general note); this is the acute
+slow-CI-treadmill case + its manual-enqueue remedy.

--- a/.claude/memory/reference_combined_git_add_commit_hook_block_stale_amend.md
+++ b/.claude/memory/reference_combined_git_add_commit_hook_block_stale_amend.md
@@ -1,0 +1,26 @@
+---
+name: reference_combined_git_add_commit_hook_block_stale_amend
+description: "Running `git add … && git commit …` as ONE compound Bash command is dangerous in this repo: the pre-commit checklist PreToolUse hook blocks the WHOLE command, so the `git add` never runs. A subsequent `git commit --amend` then silently commits the OLD (unstaged) tree — the refactor you thought you committed isn't in the commit, and CI fails on the un-applied change (e.g. oracle-ratchet firing on code you 'removed'). Fix: ALWAYS stage and commit as SEPARATE Bash calls (`git add …` first, verify, then `git commit …`)."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Observed 2026-07-13 (opus-genproto3, PR #3031).** An agent ran
+`git add <files> && git commit -m …` as a single compound Bash command. The
+pre-commit checklist PreToolUse hook intercepts and blocks the **entire**
+command (not just the commit), so the `git add` half never executed. The agent
+then did `git commit --amend`, which **silently committed the OLD tree** — its
+actual refactor was never staged, so the pushed commit didn't contain the change.
+CI failed the **oracle-ratchet** gate TWICE (firing on a `ctx.checker` call the
+agent believed it had migrated to `ctx.oracle`) before the agent realized the
+refactor wasn't in the commit at all.
+
+**Fix / rule:** stage and commit as **separate** Bash tool calls —
+`git add <files>` (let the hook run / verify it staged), THEN `git commit -m …`
+as its own call. Never combine `git add && git commit` in one compound command
+in this repo. Symptom to recognize: CI fails a gate on code you're sure you
+changed, and `git show HEAD --stat` doesn't list your edited file. Related git/gh
+gotchas: reference_gh_remove_label_rest_not_pr_edit, the pre-git-commit.sh
+reminder behavior in CLAUDE.md.

--- a/.claude/memory/reference_intentional_standalone_rebaseline_fast_path.md
+++ b/.claude/memory/reference_intentional_standalone_rebaseline_fast_path.md
@@ -1,0 +1,26 @@
+---
+name: reference_intentional_standalone_rebaseline_fast_path
+description: "Fast path for an INTENTIONAL standalone floor drop (honest re-baseline, e.g. #3055 de-vacuification): land via the coordinated manifest (one clean PR), NOT admin-bypass; if bypassed, the recovery lever is refresh-baseline.yml EMERGENCY mode (NOT the sharded force-promote, which cascade-skips)."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+When a change INTENTIONALLY drops the standalone host_free_pass floor (a de-vacuification / honest re-baseline like #3055/#2757 — the fix makes previously-vacuous passes honestly fail), landing it fights TWO merge_group gates in `test262-sharded.yml`'s required "merge shard reports" job:
+- **#2097 high-water floor** (`scripts/check-standalone-highwater.mjs` vs committed `benchmarks/results/test262-standalone-highwater.json`). SOLVABLE in-PR: lower the committed mark to the honest number (data-only PR self-lands; a next promote --update re-raises).
+- **#1897 standalone regression guard** (`diff-test262.ts`, tol −15). The baseline is the EXTERNAL `loopdive/js2wasm-baselines` repo, re-seeded ONLY by the post-merge `promote-baseline` job → chicken/egg: the promote that would fix #1897 has `needs: merge-report`, which fails on #1897, so the promote cascade-SKIPS. No in-PR self-land via the sharded workflow.
+
+Do NOT bump oracle_version for this — a de-vacuification is CODEGEN, not verdict-logic (touches none of `check-verdict-oracle-bump.mjs` ALL_VERDICT_FILES); bumping self-wedges (merged=v2 vs baselines=v1 → diff-test262.ts exit 2 → guards hard-fail in base-YAML).
+
+**FAST PATH (do this, avoids a multi-hour reactive incident):**
+1. **Land via the COORDINATED manifest, not admin-bypass.** Build/extend a committed, self-removing re-baseline-excusal in `diff-test262.ts` (generalize the #3004 `isVacuousReclassification` excusal) that excuses the one-time expected drop of N in named buckets → #1897 passes IN-PR → one clean self-landing PR, no wedge. This is banked in #3056/#3055. Admin-merging past the gate is what created the #2097+#1897 wedge that took hours to unwind (2026-07-06).
+2. Set N from the SCOPED estimate immediately (opus-3055 measured −25 on a 5-suite sample → extrapolated ~1,978 corpus-wide in minutes) + margin — don't block on a full ~68-min sharded run.
+
+**RECOVERY LEVER (if it was already admin-bypassed and the queue is wedged on #1897):**
+- The external baseline re-seed is `refresh-baseline.yml` → **"Baseline Refresh (scheduled + emergency)"**, EMERGENCY mode: `gh workflow run "Baseline Refresh (scheduled + emergency)" -R loopdive/js2 --ref main -f force_baseline_refresh=true -f confirm_force=YES`. This does an UNCONDITIONAL promote (ignores regressions) → re-seeds committed baseline + the js2wasm-baselines repo → clears #1897.
+- Do NOT use `test262-sharded.yml`'s `force_baseline_refresh` for this — its promote is `needs: merge-report`, which fails on #1897 first, so the promote SKIPS (wasted a ~68-min run 2026-07-06).
+- Also lower the committed #2097 highwater (data-only PR) — that gate is separate and not fixed by the emergency refresh's promote until it completes.
+- Landing page (js2.loopdive.com) needs a deploy-pages run AFTER the baseline refresh to serve the new number (see [[feedback_trigger_deploy_pages]]).
+
+Timing reality (corrected 2026-07-06): a full test262 run on GitHub Actions is SHARDED (~114 parallel shards) → **~2–5 min per run**, NOT 68 min (68 min is the LOCAL single-container `JS2WASM_LOCAL_CI` figure — do not conflate). The multi-hour wall-clock of this incident was NOT test duration — it was (a) serial reactive gate-by-gate fix-cycles after the admin-bypass, (b) one wrong lever (gated sharded force-promote), and (c) POLLING CADENCE — the loop rescheduled at 20–30 min while CI finished in ~5 min. **When actively driving a CI-gated fix, poll at ~5-min cadence, not 20–30 min.** The coordinated one-PR manifest path avoids stacking serial cycles entirely.

--- a/.claude/memory/reference_irfirst_flip_meter_false_green_skipped_slot_errors.md
+++ b/.claude/memory/reference_irfirst_flip_meter_false_green_skipped_slot_errors.md
@@ -1,0 +1,91 @@
+---
+name: reference_irfirst_flip_meter_false_green_skipped_slot_errors
+description: "The #3153 IR post-claim divergence meter (ir-postclaim-meter.mts / check:ir-fallbacks) reads irPostClaimErrors, but the REAL IR-first-flip (#3143) hard errors land in result.errors as '[IR-FIRST skipped-slot]' — the meter is BLIND to them. So a 'meter = ZERO' reading is a FALSE GREEN for flip readiness; scan result.errors instead. This is why every prior #3143 flip attempt regressed in CI despite meter-zero."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Diagnosed 2026-07-12 (opus-irflip, completing the #3143 IR-first default
+flip).** The prior handoff (fable-eqfix/fable-irflip) claimed "the #3153 meter
+STRIDE=300 reads ZERO, classes 1/2/3 gone, only class 4 remains" — a FALSE
+GREEN.
+
+**Root cause:** the #3153 divergence meter (`scripts/ir-postclaim-meter.mts`,
+`pnpm run check:ir-fallbacks`) reads the `irPostClaimErrors` field. But an
+IR-first flip's actual regressions come from **skipped-slot HARD errors** —
+functions IR-first tries to own but hard-errors on — which land in
+`result.errors` (severity `error`, message `"[IR-FIRST skipped-slot]…"`), NOT
+in `irPostClaimErrors`. Proven empirically: the class-4 TA-view-store file
+pre-fix returned `errors=2, irPostClaimErrors=0`. So meter-zero ≠ flip-safe.
+This is almost certainly **why every prior #3143 flip attempt regressed in CI
+despite "meter-zero."**
+
+**The reliable flip-readiness gate:** scan `result.errors` for
+`"[IR-FIRST skipped-slot"` across the corpus. Enumerate the COMPLETE
+firing-class set and fix the batch; do NOT flip until that scan reads zero.
+
+**CRITICAL corpus-scoping (opus-irflip, 2026-07-12 — the trap that caught two
+rounds of "done"):** a file-walking scanner over `examples/`/`playground/`/
+`test262/` dirs MISSES the authoritative corpus. The #3153 dense divergence
+source is the **inline template-literal programs embedded INSIDE
+`tests/equivalence/*.test.ts`** — they are not standalone `.ts` files, so a
+dir-walk never sees them. You MUST run the actual equivalence SUITE to hit them
+(the CI `equivalence-gate` compares shard partials vs baseline and is what
+surfaces these — first-round file-scan "zero" is a FALSE GREEN twice over: once
+for reading irPostClaimErrors, once for scanning the wrong corpus). Also run
+the cross-backend-parity harness (adversarial WasmGC-vs-linear differential with
+its own inline programs — separate again). Real gate classes found beyond the
+first three: gate 9 `irFirstBodyMutatesParam` (`n--`/`n+=` on a from-ast
+non-slot param), gate 10 `irFirstBodyCallsUnloweredArrayMethod` (selector claims
+`recv.m()` without checking m is lowerable — only `.push` on a vec lowers),
+`arr.length = 0` "property assignment on ref not in slice 4". All gates are
+SAFE-by-construction (compile-twice skip, never a hard error). The from-ast
+throw surface is finite (~60 sites, most selector-rejected) and shrinking, but
+enumerate against the RIGHT corpora (equivalence-suite inline + cross-backend +
+full test262 merge_group) or you get a false green.
+
+**Real blocker classes found (larger than "class 4 only"):**
+- class-4 TypedArray-view element store (putAscii/putUint) → fixed via gate 8
+  `irFirstBodyStoresTypedArrayView` in `src/codegen/ir-first-gate.ts`
+  (compile-twice skip-set, same as gates 4/5/7 — no new lowering).
+- `new <TypedArrayCtor>(n)` → "unknown class" (masked by gate 4 in host lane,
+  fires standalone).
+- `__box_number` "unknown function ref" (e.g. fibMemo): from-ast emits a
+  `__box_number` funcref assuming **legacy's `addUnionImports` side-effect**
+  registered the import; IR-first skips legacy → import missing. GENERAL fix =
+  pre-register the union-import family when the built IR references it
+  (idempotent, pre-emission) — NOT per-function gating; likely generalizes to
+  other addUnionImports-side-effect-dependent funcrefs.
+
+**STRATEGIC (opus-irflip, 2026-07-12, after scanning the equivalence-inline
+corpus): the "flip IR-first → delete −60k in one shot" premise is FALSE — use an
+ALLOWLIST, not a denylist.** The full equivalence-inline scan found **~22 real
+distinct from-ast throw classes / 125+ skipped-slot hard errors** under
+IR-first-default, and they are CORE operations, not edge cases: type-mismatched
+arithmetic/compare ("Phase 1 requires matching operand types" — biggest bucket),
+most String methods (.split/.replace/.replaceAll/.padStart/.padEnd/.repeat/
+.trim*/.lastIndexOf), number .toString/.valueOf on i32/f64, class member
+resolution, call/constructor ARITY (default/optional params), property
+assignment on ref (obj.prop=/arr.length=), .call/.apply, `new Date`, template/
+unary/bool coercion, array-literal widening. **Denylist-gating 22+ core classes
+is impractical AND self-defeating** — a gated node kind can't have its legacy
+handler deleted (killing the −60k payoff), and any missed shape = a hard-error
+regression. **The correct mechanism is an ALLOWLIST:** `computeIrFirstSkipSet`
+skips legacy ONLY for functions whose ENTIRE body is a small proven-lowerable
+subset (matched-type numeric arith, control flow, local calls with correct
+arity, returns — NO method calls / class / closures / coercion / mismatched
+types). Safe-by-construction: a missed allowlist entry keeps compile-twice
+(safe); a missed denylist entry is a regression. This clears G1 (IR-first is the
+default MODE) with a conservative compile-once subset NOW, and the −60k deletion
+unlocks **INCREMENTALLY** as the allowlist widens via real lowering
+(#2855/#2856) — matching CLAUDE.md's gated G1-G4 deletion model. So #3143's
+payoff is a multi-step incremental program, NOT a single flip; the bloat plan's
+"flip → −60k now" framing was over-optimistic.
+
+The flip is broad-impact: validate on full-CI/merge_group, net-non-negative,
+never force-merge on regression. Related: [[project_broad_impact_validate_full_ci]],
+[[feedback_verify_first_beats_architect_spec]] (the deep-tracing dev caught what
+the prior devs' meter-trust missed). Issue: #3143; the flip unlocks the ~60k
+legacy-frontend deletion (#3090/#2855/#2950).

--- a/.claude/memory/reference_irfirst_widen_skip_ceiling_28pct_pivot_to_selfhost.md
+++ b/.claude/memory/reference_irfirst_widen_skip_ceiling_28pct_pivot_to_selfhost.md
@@ -1,0 +1,47 @@
+---
+name: reference_irfirst_widen_skip_ceiling_28pct_pivot_to_selfhost
+description: "The IR-first allowlist SIGNATURE-WIDEN program (f64→bool→native-int, #3203+) caps at a ~28% skip-coverage CEILING — measured empirically 441/1,568 top-level funcs on the tests/equivalence corpus. The other ~72% need G4 runtime-path IR (strings/objects/arrays/methods), NOT reachable by any signature widening. So the first Phase-3b legacy-handler DELETION is 10+ PRs out, gated on the runtime-IR migration (#2856+), not on widening. Do NOT re-attempt 'widen → delete soon'. Pivot spare senior cycles to immediate-−LOC self-host units."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Measured 2026-07-13 (opus-delete), empirical on the 1,568 top-level
+functions of the tests/equivalence corpus — the decision-gate estimate for the
+−60k Phase-3b deletion.**
+
+The #3143 IR-first flip cleared G1 for a NUMERIC-only skip population; the −60k
+legacy-frontend deletion was expected to unlock incrementally as the skip
+allowlist widens (f64→bool→native-int). This measurement bounds that program:
+
+- **Widen-reachable skip CEILING = 441/1,568 = 28.1%.** These are functions
+  whose signature is number/bool/native-int AND whose body is primitive (no
+  member access / method calls / `new` / strings / arrays / objects). That is
+  the ABSOLUTE MAX skip coverage signature-widening can ever reach, with every
+  primitive widen done. Breakdown: num-only=437, +bool=4, **+native-int=0**.
+- **needs-runtime = 1,127/1,568 = 71.9%** — need G4 runtime-path IR
+  (strings/objects/arrays/methods). NOT reachable by signature widening at all;
+  that is the whole IR-full-coverage epic (#2856+ claim-coverage + runtime
+  lowering), not a widen.
+- **native-i32 adds 0.0% on this corpus** — there are ZERO native-int
+  (`i32`/`u32`) annotations in the equivalence corpus. Implementing it is pure
+  correctness groundwork (removes the i32/bool domain-ambiguity caveat), NOT a
+  coverage lever. Don't spend cycles on it for coverage.
+- **identifiers.ts G2 distance:** `Identifier` appears in ~every function, so
+  `expressions/identifiers.ts` (and every all-ir-owned file) closes its G2 gate
+  only at ~100% skip coverage. The widen caps at 28%. Closing the remaining 72%
+  IS the runtime-path migration → **10+ PRs, realistically many more**, not 2-3.
+
+**Decision taken: PIVOT.** Bank the widen (#3203 f64→bool, landed) as correctness
+groundwork; move senior cycles to immediate-−LOC self-host units
+([[reference_selfhost_netnegative_needs_full_elemkind_dialect]] — timsort −404,
+object-runtime −145, Math next). The widen + #2856 body-shape-rejected
+bucket-drain (claim-coverage) continue INCREMENTALLY/opportunistically as a slow
+background epic, not a near-term −LOC lever. **Do NOT let a future agent
+re-frame 'widen the allowlist → delete legacy soon' — the ceiling is 28% and the
+first deletion is gated on runtime-IR (#2856+), not widening.** Related:
+[[reference_irfirst_flip_meter_false_green_skipped_slot_errors]] (the flip
+itself + why allowlist-not-denylist), the #3090 delete-list G2 trap (a kind
+being ir-owned does NOT make its legacy handler dead — needs whole-function
+claim+skip coverage).

--- a/.claude/memory/reference_loc_budget_post_3131_no_commit_baseline_use_allow_frontmatter.md
+++ b/.claude/memory/reference_loc_budget_post_3131_no_commit_baseline_use_allow_frontmatter.md
@@ -1,0 +1,34 @@
+---
+name: reference_loc_budget_post_3131_no_commit_baseline_use_allow_frontmatter
+description: "Post-#3131, the LOC-regrowth ratchet FORBIDS committing scripts/loc-budget-baseline.json in a PR — `check:loc-budget --update` is the obsolete pre-#3131 path and now fails the `quality` gate. For intended growth, drop the baseline change (take main's) + add `loc-budget-allow: [<file>]` to the PR's issue-file frontmatter."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+The LOC-regrowth ratchet (#3102 / #3131) changed how loc-budget conflicts are
+resolved. The OLD advice — resolve a `scripts/loc-budget-baseline.json` conflict
+with `pnpm run check:loc-budget --update` and commit the regenerated baseline —
+is now WRONG and makes the `quality` gate fail in the merge_group (auto-parks the
+PR). #3131 forbids a PR from committing `loc-budget-baseline.json`: the baseline
+refreshes **post-merge on main only**, and the gate's own error text says so.
+
+**Correct resolution for a loc-budget / god-file-growth failure (post-#3131):**
+1. In any `loc-budget-baseline.json` merge conflict, take **main's** version
+   (`git checkout --theirs scripts/loc-budget-baseline.json` / drop your change) —
+   never commit a modified baseline.
+2. If the growth is INTENTIONAL (a real feature slice legitimately grows a
+   tracked file, e.g. `src/ir/from-ast.ts`), add an allowance to the PR's **own
+   issue-file frontmatter**: `loc-budget-allow: [src/ir/from-ast.ts]`. That
+   frontmatter allowance is what the gate honors for intended growth.
+3. Verify locally with `pnpm run check:loc-budget` (NOT `--update`) + `tsc` +
+   scoped tests, then push.
+
+**Diagnostic signature:** merge_group `quality` fails ONLY (test262 sharded +
+equivalence shards all PASS) with `<file>: NNNN > MMMM (+K)` — that's the ratchet,
+not a conformance regression. Confirmed on #2868 (from-ast.ts 6785 > 6684 +101),
+#2865, #2871 (senior2 used the frontmatter-allowance path), all 2026-07-10.
+
+Do NOT put `check:loc-budget --update` in dev spawn prompts anymore. Related:
+[[reference_ci_quality_format_uses_prettier_not_biome]].

--- a/.claude/memory/reference_lower_structurizer_materialized_leak_across_tail_dup_arms.md
+++ b/.claude/memory/reference_lower_structurizer_materialized_leak_across_tail_dup_arms.md
@@ -1,0 +1,44 @@
+---
+name: reference_lower_structurizer_materialized_leak_across_tail_dup_arms
+description: "src/ir/lower.ts structurizer soundness bug (#2856/#2977): a non-terminating mid-body `if(cond){effect} rest` makes `rest` a merge block that emitBlockBody TAIL-DUPLICATES into both wasm if-arms; the FUNCTION-GLOBAL `materialized` set leaked the then-arm's lazy `local.tee` of an intra-block multi-use value into the else-arm copy, so the else path read a local it never set → SILENT miscompile (Math.log(2.414) returned log(2)) or '[IR-FIRST] undefined SSA value' throw. Fix: snapshot/restore `materialized` around the br_if arms so each runtime path re-materializes its own intra-block locals."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Root-caused 2026-07-13 (opus-2856), fixed in PR #2977 (~15 LOC in
+src/ir/lower.ts).** Presented as two separate "from-ast overlay" bugs
+(#3203 classify + #3204 `let`-after-mid-body-`if`), but the IR was correct —
+it's a **structurizer/lowering** bug, not from-ast/select.
+
+**Mechanism:** a non-terminating mid-body `if (cond) { effect } rest` rewrite
+makes `rest` a merge block that `emitBlockBody` **tail-duplicates into both wasm
+`if` arms**. The **function-global `materialized` set** (tracking which lazy
+values have been emitted as a `local.tee`) leaked the THEN-arm's tee of an
+intra-block multi-use value into the ELSE-arm copy — so the else path emitted a
+`local.get` of a local it never `local.set`, reading unset → **silent 0**
+(`Math.log(2.414)` returned `log(2)`!) or the `[IR-FIRST] undefined SSA value`
+hard throw. It's a CLAIMED-but-MISCOMPILED correctness bug, NOT a selector
+rejection.
+
+**Fix:** snapshot/restore `materialized` around the `br_if` arms so each
+separate runtime path re-materializes its own intra-block locals. Any future
+structurizer/lowering refactor that tail-duplicates blocks MUST scope
+per-arm-materialization state (materialized/emitted-tee sets) to the arm, never
+share it function-globally across duplicated paths.
+
+**Two corrections it banked:**
+1. Fixing this does NOT reduce the `body-shape-rejected` bucket (stays 14) — the
+   14 are cross-module benchmark mains (gated on **#2858** cross-module calls +
+   first-class function values) + DOM calendar arms, none the overlay shape. So
+   "#2856 = drive body-shape-rejected to zero" is a multi-capability program
+   gated on #2858/DOM, NOT this fix. The real value here = correctness +
+   **IR-first-skip SAFETY** (prereq for the IR-first-ONLY −60k epic: can't make
+   IR-first the sole path while it silently miscompiles this shape).
+2. The #3203 shape ALSO trips a SEPARATE pre-existing `inline-small`
+   post-inline-verify bug (different pass) — left as a focused follow-up.
+
+Related: [[reference_irfirst_flip_meter_false_green_skipped_slot_errors]],
+[[reference_irfirst_widen_skip_ceiling_28pct_pivot_to_selfhost]] (the −60k
+IR-first program this safety fix serves).

--- a/.claude/memory/reference_merge_commit_doesnt_trigger_workflows_pr_stuck_unknown.md
+++ b/.claude/memory/reference_merge_commit_doesnt_trigger_workflows_pr_stuck_unknown.md
@@ -1,0 +1,30 @@
+---
+name: reference_merge_commit_doesnt_trigger_workflows_pr_stuck_unknown
+description: "After merging origin/main INTO a PR branch to clear a BEHIND, the heavy required workflows (Test262 Sharded, CI/quality) sometimes DON'T trigger on the resulting merge commit — only CLA runs, and the PR sits at mergeStateStatus=UNKNOWN indefinitely (the required check contexts are never CREATED, so the rollup has nothing pending and the PR silently strands). Recovery: push a single EMPTY commit (git commit --allow-empty) to re-trigger — all workflows then fire immediately."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Observed 2026-07-13 (opus-gapmap, on PR #2996/#3228).** After merging
+`origin/main` into the branch to clear a BEHIND, the merge commit `77cf8c7c`
+triggered ONLY `cla-check` — Test262 Sharded + CI never fired, no
+Test262/quality check contexts were created, and `mergeStateStatus` stuck at
+**UNKNOWN** for several minutes (rollup had no pending contexts because they were
+never created). The PRIOR SHA had been fully green, so it wasn't a real failure —
+the workflows just didn't trigger on that merge commit.
+
+**Recovery (works):** push a single empty commit
+(`git commit --allow-empty -m "ci: nudge workflows" && git push`) — all 6
+workflows fire immediately on the new SHA and go green.
+
+**Why it matters:** this SILENTLY strands a PR at UNKNOWN — it looks like it's
+"still computing," but nothing will ever complete because no check contexts
+exist. Distinct from a real CI failure or a BEHIND. Symptom to recognize:
+mergeStateStatus=UNKNOWN for many minutes, rollup shows only cla-check (no
+Test262/quality contexts even pending), on a merge commit. Don't wait it out;
+nudge with an empty commit. Likely a GitHub Actions `push`/`pull_request`
+trigger race on merge commits. Related strand patterns:
+[[reference_setup_node_corepack_flake_parks_pr_as_merge_group_failure]],
+[[reference_backgrounded_merge_watcher_dies_strands_agent_on_base_merge]].

--- a/.claude/memory/reference_postflip_standalone_hostfreefail_is_the_frontier.md
+++ b/.claude/memory/reference_postflip_standalone_hostfreefail_is_the_frontier.md
@@ -1,0 +1,51 @@
+---
+name: reference_postflip_standalone_hostfreefail_is_the_frontier
+description: "After the #3020 undefined-singleton flip landed (2026-07-13), a fresh post-flip standalone re-rank shows the SOLE-IMPORT LEAK track is essentially EXHAUSTED — of 4,020 remaining leaky-passes, 94% co-occur __get_caught_exception (the #3132 generator-runtime epic, ALL-OR-NOTHING: nothing flips until the whole gen runtime self-hosts together), the rest is dynamic_import (host gate) + deferred features. The real lever pool is 4× bigger: HOST-FREE-FAIL (15,450) — tests that compile host-free but return the WRONG runtime result, so a SEMANTICS fix (not an import fix) flips host_free_pass. Pivot fleet dispatch from individual-import-leak-fixes to host-free-fail semantics clusters."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Post-#3020-flip standalone landscape re-rank (opus-leak3, 2026-07-13, fresh
+baseline promoted 17:48 UTC — AFTER the 16:50 flip merge).** Corpus 48,121 rows;
+host_free_pass = status==pass AND zero `env::` imports (#2879 §2).
+
+**(A) LEAKY-PASS (pass but ≥1 import) — 4,020, essentially MINED OUT.** Almost
+entirely sync/async generator RUNTIME substrate and **all-or-nothing**:
+`__get_caught_exception` co-occurs in 3,758/4,020 (94%), so no generator test
+flips host-free until the WHOLE gen runtime (create_generator, gen_next,
+gen_yield_star, gen_result_*, Promise_*, __get_caught_exception) self-hosts
+*together* — that IS the #3132 epic (opus-asyncgen2's banked S2/S3/S4). Outside
+that: `dynamic_import` (99+141) is a genuine host module-loader gate (out of
+scope). **No actionable individual-import-leak lever remains** — the season of
+`#3016`-style bounded gate fixes + one-import-at-a-time substrate (weak-collections,
+subclass-ctors, `__make_callback`, gen-proto) is over post-flip.
+
+**(B) HOST-FREE FAIL — 15,450 (4× bigger, the real pool).** Compiles host-free
+but wrong runtime result → a **semantics** fix flips host_free_pass (no import
+involved). assertion_fail 9,731 · type_error 2,256 · illegal_cast 265 · null_deref
+251. Deferred ~7k (Temporal 5,000+, dynamic/annexB eval ~977, ShadowRealm 58).
+Top ACTIONABLE concentrated clusters:
+1. **Object.defineProperty/defineProperties validation — ~914.** Exotic-object
+   redefinition (arguments/array-index non-configurable not throwing TypeError,
+   137) + defineProperties shape gaps ("Property description must be an object"
+   191, "unsupported descriptor shape" bail 78). Standalone-only (host uses
+   `__defineProperty_desc` import → host byte-identical). Plain data+accessor
+   paths ALREADY validate (#2042-S4/#2992-S3/#2965) — residual is exotic +
+   shape. (opus-leak3's pick.)
+2. **type_error "Cannot access property on null/undefined" — 925 → re-scoped
+   (opus-tabrand):** NOT a single 925 root. It's **~100 shared-root getter-GOPD
+   brand-check — FIXED by #3250/PR#3041** (GOPD returned undefined for un-wired
+   buffer-family accessor getters ArrayBuffer/SharedArrayBuffer/DataView/
+   %TypedArray%.buffer → the test's `.get` deref trapped; 1-line fix extending the
+   `native-proto.ts` refusal-body fallback from methods to getters; +37 measured,
+   0 regressions, byte-inert on wired getters) — **plus ~800 DIFFUSE remainder**
+   (detached-buffer, bigint, species, null-deref elsewhere), no single next root.
+3. **illegal_cast 141 / null_deref 164** — runtime crashes across Array/String/
+   DataView prototype methods, diffuse.
+
+**Dispatch strategy going forward:** pivot the fleet from import-leak fixes to
+host-free-fail semantics clusters (1→2→3 by size/tractability). Related:
+[[reference_standalone_leak_gate_vs_substrate_numeric_callN]] (the now-exhausted
+leak track), the descriptor-cluster family #2042/#2992/#2965.

--- a/.claude/memory/reference_promote_on_push_ratchet_queue_deadlock_force_refresh.md
+++ b/.claude/memory/reference_promote_on_push_ratchet_queue_deadlock_force_refresh.md
@@ -1,0 +1,65 @@
+---
+name: reference_promote_on_push_ratchet_queue_deadlock_force_refresh
+description: "A merge_group ratchet whose baseline lives in the EXTERNAL js2wasm-baselines repo (re-seeded by promote-baseline ONLY on push-to-main) can DEADLOCK the whole queue: when a merged PR advances main past the baseline, every subsequent PR parks in merge_group, and no push-to-main can promote a new baseline while the queue is wedged. A PR can't fix it (no in-repo baseline file). The sanctioned recovery is the workflow's own force-refresh run on main."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**⚠️ CORRECTION (2026-07-12, same day): the #3189 instance below was NOT a real
+main-count deadlock — it was a CI-SHARDED-RUNNER-ONLY artifact.** Main was
+genuinely at oob=58; the "+4 → 62" only appeared in the sharded `merge_group`
+environment (a runner/env difference), NOT on main. So the force-refresh
+correctly promoted 58 (main's real state) and did NOT unwedge. The ACTUAL fix
+was a **`TRAP_RATCHET_TOLERANCE` repo var (set =4), wired into the merge_group
+ratchet** (`vars.TRAP_RATCHET_TOLERANCE || '0'`), absorbing the CI-only +4 while
+keeping the baseline honest at 58 (team commit 8d337dbef2 / #2963). LESSON: the
+tell-tale "same +N delta across unrelated PRs, net +0" can be a **sharded-env
+artifact**, not a real main regression — VERIFY the count on MAIN itself (not
+just merge_group runs) before force-refreshing; if main's count equals the
+baseline, a force-refresh won't help and the fix is a tolerance var for the
+CI-only noise. The general promote-on-push deadlock mechanism below is still
+valid for a GENUINE main-count deadlock, but confirm real-on-main first.
+
+**Diagnosed 2026-07-12 (pr-shepherd), on the #3189 uncatchable-trap ratchet.**
+
+**The deadlock:** the #3189 trap ratchet (and any gate that compares against the
+external `loopdive/js2wasm-baselines` jsonl, which `promote-baseline` re-seeds
+ONLY on push-to-main, #1528) has **no in-repo baseline file**. When a merged PR
+moves main's counts past the last-promoted baseline (here: `oob` traps 58→62,
+from #3162/#3183 vec-bounds changes merging after #2949 added the ratchet
+without bumping it), EVERY subsequent PR fails the gate in merge_group at
+"62 > 58" and auto-parks (`hold` + `auto-park-bot:merge-group-failure`). The
+whole queue wedges — and it's a true deadlock: a PR editing a baseline can't fix
+it (nothing in-repo to edit), and the normal promotion (push-to-main) can't
+happen while the queue is wedged.
+
+**Tell-tale signature (pr-shepherd's diagnosis pattern):** the SAME gate failure
+with the SAME test delta across MULTIPLE UNRELATED PRs (none of which touch the
+implicated feature), net conformance +0 (zero pass→fail regressions). That means
+queue-wide baseline poisoning, NOT per-PR regressions — a lead/dev-level fix, not
+a shepherd re-enqueue.
+
+**The sanctioned recovery (verified honest):**
+1. FIRST verify net +0 across ≥3 independent merge_group runs (main + unrelated
+   PRs) — the failing count is real on main, and there are ZERO pass→fail
+   regressions. NEVER force-refresh if a real conformance regression is hiding.
+2. Trigger the workflow's own force-refresh ON MAIN:
+   `gh workflow run test262-sharded.yml --ref main -f force_baseline_refresh=true -f confirm_force=YES`
+   It re-measures main HEAD's ACTUAL state and force-promotes it to the baselines
+   repo. Inherently honest: it runs on main, can only promote main's real state,
+   can NOT mask a PR regression (unlike hand-bumping a baseline in a PR). ~15-20
+   min (full sharded).
+3. Once it promotes, every parked PR's next merge_group compares against the new
+   baseline and PASSES → shepherd re-enqueues + de-holds the parked PRs (they
+   were bot-parked on the poisoned gate, not real regressions).
+4. File a P2 FOLLOW-UP to fix the underlying regression properly (here #3202:
+   make the 4 TypedArray.prototype.set BigInt/tointeger oob traps throw a
+   catchable RangeError) so the ratchet floor drops back to its lower value.
+
+Related: [[feedback_merge_queue_wedge_recovery]], the baselines-repo /
+promote-baseline notes in CLAUDE.md (#1528), [[reference_verdict_logic_change_must_bump_oracle_version]]
+(the sibling "gate wedges the queue" class). Root prevention: a PR that grows a
+promote-on-push ratchet's count must land its baseline bump atomically (or the
+ratchet must tolerate the merging PR's own delta).

--- a/.claude/memory/reference_resume_runs_lead_model_not_agent_fable.md
+++ b/.claude/memory/reference_resume_runs_lead_model_not_agent_fable.md
@@ -1,0 +1,46 @@
+---
+name: reference_resume_runs_lead_model_not_agent_fable
+description: "SendMessage-RESUMING a dormant background agent runs that turn on the LEAD/parent session model (Opus 4.8 here), ignoring BOTH the agent's model:fable spawn param AND the agent-def model: frontmatter. Fresh Agent spawns DO honor the def/param (→ fable). So to keep work on fable: spawn fresh + keep agents ACTIVE/self-serving; NEVER rely on resuming dormant agents (every resume is an Opus turn). Can't be fixed mid-session (lead model is pinned)."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Diagnosed 2026-07-12 (fable-eqfix flagged it, confirmed by transcript census
++ a controlled resume test).** Model resolution for a subagent is
+`explicit spawn param > agent-def frontmatter model: > parent/lead model`.
+
+- **Fresh `Agent({model:"fable"})` spawn → runs on `claude-fable-5`.** ✓ The
+  override works at spawn. (Even without the param now — see the def fix below.)
+- **`SendMessage`-RESUME of a dormant/completed agent → runs that turn on the
+  LEAD's model (`claude-opus-4-8`).** Resume has NO model parameter, and it
+  **ignores the agent-def model too** — it inherits the parent lead session
+  model. Verified: after changing the defs to `model: fable`, a resume of
+  fable-architect STILL logged one `claude-opus-4-8` turn (its 115 original
+  spawn turns were all fable-5).
+- **This can't be fixed mid-session** — the lead's own model is pinned
+  (Opus 4.8 here) and can't be changed; SendMessage can't pass a model.
+
+**Root cause of the stale config:** `.claude/agents/{senior-developer,
+developer,architect}.md` pinned `model: opus` despite the 2026-07-02 "devs
+default fable" directive (see [[feedback_devs_default_opus]]) — the frontmatter
+was never updated. FIXED 2026-07-12: defs → `model: fable`, so param-less
+spawns now default fable. (This fixes SPAWNS only, NOT resumes.)
+
+**Operational rules to keep work on fable:**
+1. **Spawn fresh; never rely on resuming a dormant agent** — every resume is an
+   Opus turn. fable-gen stayed pure `claude-fable-5` across 478 turns by keeping
+   itself active + self-serving the next slice; fable-eqfix went mostly-Opus
+   (577 Opus / 209 fable) because I resumed it ~10× fighting the treadmill.
+2. **Instruct spawned agents to STAY ACTIVE / self-serve** (background CI
+   watcher, self-claim the next slice, don't idle waiting to be resumed) — the
+   [[feedback_idle_waiting_agent_not_terminated_dont_reassign_pr]] dormancy that
+   forces resumes is what leaks Opus.
+3. **Verify actual model via the transcript `model` field, NOT the agent's
+   self-report** — an agent reads the model from its *latest turn's* context, so
+   a resumed agent self-reports "Opus" even if its original work was fable
+   (fable-eqfix did exactly this, causing a false "the whole fleet is Opus"
+   alarm). Grep `'"model"[: ]*"claude-[^"]*"'` in the task `.output` transcript.
+
+Related: [[feedback_devs_default_opus]], [[feedback_sonnet_for_sprint_loop]].

--- a/.claude/memory/reference_selfhost_netnegative_needs_full_elemkind_dialect.md
+++ b/.claude/memory/reference_selfhost_netnegative_needs_full_elemkind_dialect.md
@@ -1,0 +1,47 @@
+---
+name: reference_selfhost_netnegative_needs_full_elemkind_dialect
+description: "Self-hosting a stdlib family (the bloat lever) nets NEGATIVE LOC only if the TS dialect covers ALL elem/value kinds the unit instantiates — codegen hand-emitters are element-type-GENERIC (one emitter param over f64/i32/i8/i16/ref/externref), so a partial (e.g. f64-only) conversion keeps the generic hand emitter alive and goes net-POSITIVE. Convert already-type-restricted + pure + fixed-ABI units first."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Finding (2026-07-12, fable-selfhost while scoping array-methods self-host
+slice 1, issue #3159):** the self-hosting bloat lever (convert hand-emitted
+Wasm builtins → TS source compiled through our own IR driver
+`src/codegen/stdlib-selfhost.ts`) only DELETES hand code — i.e. nets negative
+LOC — if the compilable TS dialect covers **all** the elem/value kinds the
+target unit instantiates.
+
+**Why:** the `compile*` emitters in `array-methods.ts` (and by extension the
+other big stdlib files) are **element-type-GENERIC** — one inline emitter
+parameterized over f64/i32/i8/i16/ref/externref. If you self-host only the
+common case (e.g. the f64 path), the generic hand emitter STAYS ALIVE to serve
+the other elem kinds, so you've ADDED the TS-source version on top of code you
+couldn't delete → **net-POSITIVE**, which defeats the whole point.
+
+**Dialect coverage today (verify — it grows):** f64 fully; i32 compares
+(polymorphic, #1126); element STORES only f64/externref (i8/i16 not yet).
+
+**Strategy that nets negative:**
+1. Convert units that are **already type/shape-restricted + pure computation +
+   funcMap-registered with a fixed external ABI** first — the Math-pilot
+   (#3141) drop-in shape. Concrete win: `src/codegen/timsort.ts` (922 lines,
+   the array sort engine, already restricted to i32|f64 by #2502 guards, pure,
+   called only from array-methods sort/toSorted) → slice 1, est. net −550..−650.
+2. Build **"Precursor B"** = tiny typed intrinsic callees (typed element
+   access materialized on demand) — reusable by every later array/string/
+   dataview slice.
+3. Only AFTER expanding elem-kind dialect coverage (element stores beyond
+   f64/externref; i8/i16) do the generic inline emitters become net-negative
+   to convert.
+
+**Rule for dispatch:** before writing any self-host conversion, estimate
+deleted-hand-LOC vs added-TS-LOC and confirm net-negative. object-runtime is a
+poor early target (heavy on identity/proto/brand — NOT pure); prefer
+Math/timsort/native-strings/dataview pure units. Proof method per family: the
+pilot's bit-exact behavioral sweep vs main-built control binaries
+(NaN/±0/±Inf/denormals/dups/boundary lengths, all elem kinds, host+standalone)
++ SHA byte-inertness for programs that don't use the unit. Plan:
+`plan/self-hosting-scale-up.md`. Related: [[project_bloat_reduction_week_of_2026_07_11]].

--- a/.claude/memory/reference_setup_node_corepack_flake_parks_pr_as_merge_group_failure.md
+++ b/.claude/memory/reference_setup_node_corepack_flake_parks_pr_as_merge_group_failure.md
@@ -1,0 +1,38 @@
+---
+name: reference_setup_node_corepack_flake_parks_pr_as_merge_group_failure
+description: "A merge_group test262 shard that fails at the 'Setup Node' / 'Setup pnpm via Corepack' step is an INFRA FLAKE (no tests ran) — auto-parks the PR as a merge-group-failure, but is a safe single re-admit, not a real regression"
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+The `auto-park-bot:merge-group-failure` fires whenever ANY required check fails
+in the `merge_group` — including when a `test262 js-host shard N` job dies at an
+**infrastructure setup step** (`Setup Node`, or `Setup pnpm via Corepack` →
+`registry.npmjs.org` network error) BEFORE any test runs. When setup fails,
+steps 5-7 (Install deps / Build compiler / Run shard) are all **skipped**, so the
+shard executes **zero tests** → there is no pass→fail delta → it is NOT a real
+regression.
+
+**Confirmed twice (2026-07-05/06):**
+- #2738 (B3 write-through): `js-host shard 6` died at "Setup pnpm via Corepack".
+- #2748 (delete +1): `js-host shard 3` died at "Setup Node".
+Both were front-end/byte-inert-off-path changes; both re-admitted once and merged.
+
+**How to diagnose (do this BEFORE removing a bot-park hold):**
+```
+RUN=$(gh run list -R loopdive/js2 --workflow test262-sharded.yml --limit 25 \
+  --json databaseId,event,conclusion \
+  --jq '[.[]|select(.event=="merge_group" and .conclusion=="failure")][0].databaseId')
+gh run view $RUN -R loopdive/js2 --json jobs \
+  --jq '.jobs[]|select(.name|test("js-host shard N"))|{conclusion,steps:[.steps[]|select(.conclusion=="failure")|.name]}'
+```
+If the failed step is `Setup Node` / `Setup pnpm via Corepack` / any setup step
+(not "Run … shard") → **infra flake, safe single re-admit** (remove hold, one-shot
+enqueue, comment the diagnosis). If the failed step is the actual test run →
+real regression, fix on branch, do NOT re-admit.
+
+Contrast with [[reference_gh_json_jobs_truncates_30_masks_merge_group_failure]]:
+there the aggregator genuinely failed the standalone floor (real). Here the shard
+never ran. Always read the failed STEP name, not just the job conclusion.

--- a/.claude/memory/reference_standalone_leak_gate_vs_substrate_numeric_callN.md
+++ b/.claude/memory/reference_standalone_leak_gate_vs_substrate_numeric_callN.md
@@ -1,0 +1,41 @@
+---
+name: reference_standalone_leak_gate_vs_substrate_numeric_callN
+description: "Classifying standalone sole-import leaks as bounded GATE (declared-but-uncalled, #3016-style, a few-file fix) vs SUBSTRATE (genuinely called, needs native impl) MUST count NUMERIC `call N` sites in the emitted wat, not grep the symbolic `$name`: wat renders import calls as `call <0-based-func-index>`, so a name-only grep FALSELY labels every substrate import as a dead gate (fake bounded win). Corrected probe: map each `(import … (func $sym))` to its func index, then count call|ref.func|return_call by BOTH index and symbol. Also: as of 2026-07-13 the #3016 bounded-gate seam is EXHAUSTED (0 gates / 200 sampled leaky-passes = all substrate); remaining sole-import leaks are all substrate."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Observed 2026-07-13 (opus-leak2, standalone leak re-rank after #3016 merged).**
+
+**The trap:** to decide whether a standalone `env::__foo` sole-import leaky-pass is a
+bounded GATE (import DECLARED but never CALLED — a #3016/#3235-style spurious
+unconditional registration, fixable by a standalone gate on the registration,
+flips host-free with a few-file change) vs SUBSTRATE (the import is genuinely
+CALLED — needs a real native implementation), you must inspect the emitted wat's
+CALL sites. The wat renders an import call as **numeric `call N`** where N is the
+import's 0-based func index — NOT the symbolic `$name`. A **name-only grep**
+(`grep '\$__foo'`) for call sites finds the import DECLARATION but misses the
+numeric call, so it FALSELY reports "0 call sites → dead gate → bounded win."
+opus-leak2's first pass hit this and mislabeled substrate imports
+(`__extern_rest_object` etc.) as dead gates.
+
+**Corrected probe:** parse each `(import … (func $sym))` to its 0-based func
+index (order of appearance), then count `call|ref.func|return_call` occurrences
+by BOTH the numeric index AND the symbol. Only truly-zero → bounded gate.
+
+**Strategic state (2026-07-13): the bounded-gate seam is MINED OUT.** Rigorous
+sample of 200 random standalone leaky-passes → **0 gates / 200 substrate**. The
+only true declared-but-uncalled gate left in the whole corpus is
+`__instanceof_check` on ONE test (instanceof in a ReferenceError-short-circuited
+position) — not PR-worthy. So the next standalone-conformance levers are all
+SUBSTRATE, ranked by distinct host-free flips (excluding in-flight/deferred):
+`__new_*` subclass-builtins **49** (`class Sub extends Object/Array/Function/
+Date/RegExp/TypedArray` super()→native builtin construction; biggest, builds on
+#56/#3053 native $Object substrate) > `__extern_rest_object` obj-rest
+CopyDataProperties **9** > weak-collections **8**. Callback-dispatch
+`__call_*`/`__make_callback` (164) was #3016 (done); `__dynamic_import`/
+SharedArrayBuffer/Temporal/Array.fromAsync are deferred features. Related:
+[[reference_selfhost_netnegative_needs_full_elemkind_dialect]],
+the #3016/#3235 gate-fix pattern.

--- a/.claude/memory/reference_standdown_at_merge_not_green_prlevel_mergegroup_gates_orphan.md
+++ b/.claude/memory/reference_standdown_at_merge_not_green_prlevel_mergegroup_gates_orphan.md
@@ -1,0 +1,39 @@
+---
+name: reference_standdown_at_merge_not_green_prlevel_mergegroup_gates_orphan
+description: "When you stand an agent down as soon as its PR is GREEN AT THE PR LEVEL, the merge_group re-validation can still surface additional required-gate fails (coercion-site-drift #2108/#3131, issue-integrity #1616, standalone-floor, oracle-ratchet) that the PR-level checks did not run — and with the author gone the PR ORPHANS on a fixable gate. Prevention: either keep the author alive until the PR actually MERGES, or (cheaper) accept green-PR-level stand-down but STAFF a CI-FIX sweep to adopt+fix post-standdown merge_group gate fails. Don't assume a green-PR-level PR merges unattended."
+metadata:
+  node_type: memory
+  type: reference
+  originSessionId: 00d53514-a026-4121-9d65-d0a8c54ba5a5
+---
+
+**Observed 2026-07-13 (lead).** Stood down three deep-budget agents on their
+milestones the moment they reported green PRs (opus-r4/#2989 R4b, opus-3201b/
+#2990 join-for-of, opus-substrate/#2986). Two then FAILED a merge_group required
+gate that the PR-level checks hadn't run:
+- **#2989** → "Coercion-site drift gate (#2108/#3131)" (R4b's new
+  ta-hof-map-filter.ts added coercion sites; fix = `coercion-sites-allow`
+  frontmatter, baseline unmodified per #3131).
+- **#2990** → "Issue integrity + link gate (#1616)" (issue-file frontmatter/link
+  integrity).
+- (plus a separately-stranded **#2975** on "Issue→probe coverage gate #2093".)
+
+With the authors gone, all three orphaned BEHIND on a *fixable* gate — no
+regression, just an allowance/frontmatter/probe entry nobody was left to add.
+
+**Two valid models — pick one, don't drift into neither:**
+1. **Stand down at actual MERGE, not green-PR-level** — keep the author alive
+   (or its next-slice self-serve loop) until the queue lands the PR, so it fixes
+   any merge_group gate fail itself. Costs the ~15-min merge wait per agent.
+2. **Stand down at green-PR-level (cheaper) + STAFF a CI-FIX sweep** — accept the
+   author leaves, and dispatch a dedicated CI-FIX developer (or pr-shepherd3 +
+   a [CI-FIX] task) to ADOPT orphaned PRs and add the allowance/frontmatter/probe
+   per gate. This is the model used here (agent opus-cifix rescued all three).
+
+The CI-FIX adopter flow: `git fetch`, checkout the PR branch, `git merge
+origin/main` (un-BEHIND), smallest-correct fix per gate (allowlist frontmatter,
+NOT a baseline edit), `git push --no-verify`, verify the check flips green, let
+auto-enqueue land it. Same pattern as the earlier "[CI-FIX] land orphaned #29xx,
+dead author" tasks. Related: [[reference_backgrounded_merge_watcher_dies_strands_agent_on_base_merge]]
+(the other way agents strand near merge), the coercion-sites-allow / loc-budget
+#3131 frontmatter-allowlist mechanism.


### PR DESCRIPTION
Bundles the 20 agent-memory reference/feedback files accumulated during the sprint-71 window into the repo. Docs-only (.claude/memory/), no code.

Key learnings: post-flip host-free-FAIL frontier map (import-leak track mined out; the semantics-fix pool is 4x bigger), async standalone warm/cold measurement flake (~0.6% run-to-run band), leak gate-vs-substrate numeric-call-N classification, backgrounded-watcher strand + stand-down orphan patterns, the compound stage-and-commit hook trap, and related dispatch/CI gotchas.

Generated with Claude Code.