### PR TITLE
refactor(#3192): route RegExp brand check through shared receiver-brand.ts

### DIFF
--- a/plan/issues/3192-bloat-s2-route-dataview-regexp-brand-checks.md
+++ b/plan/issues/3192-bloat-s2-route-dataview-regexp-brand-checks.md
@@ -1,9 +1,10 @@
 ---
 id: 3192
 title: "bloat S2: route DataView + RegExp brand checks through receiver-brand.ts"
-status: ready
+status: done
+completed: 2026-07-14
 created: 2026-07-12
-updated: 2026-07-12
+updated: 2026-07-14
 priority: high
 feasibility: medium
 task_type: refactor
@@ -59,3 +60,42 @@ independently.
 - Zero test-diff; brand TypeError messages byte-identical
   (`DV_BRAND_MESSAGE` string preserved verbatim).
 - No new import cycles; `pnpm run typecheck` clean.
+
+## Resolution (2026-07-14)
+
+**RegExp — routed (the clean half).** `recoverRegExpStructFromExternref`
+(`regexp-standalone.ts`) previously hand-rolled the §22.2.6 brand gate
+(`any.convert_extern` → `ref.test $NativeRegExp` → `i32.eqz` → `if` throw via
+native-proto's `emitBrandCheckTypeError` → `ref.cast`). It now delegates the
+entire gate to the shared `emitReceiverBrandCheck` (`receiver-brand.ts`, #3171)
+with a **struct-only** `ReceiverBrandSpec` (RegExp has no shared backing store,
+so no `kindField`). The externref `this` is pushed on the stack, the preamble
+throws a catchable TypeError on a miss (message preserved verbatim:
+`"Method called on incompatible receiver (RegExp brand check failed)"`) and
+leaves the recovered `(ref $NativeRegExp)` on the stack, which the function then
+stashes in a typed local — identical observable behaviour. The now-unused
+`emitBrandCheckTypeError` import was dropped. Validated: `tests/issue-3192.test.ts`
+plus the existing `issue-2175-native-proto-brands` (5), `issue-2876` (8) and
+`issue-2161-regex-symbol-protocol` (14) suites all green; typecheck clean; no
+new runtime import cycle (`receiver-brand.ts` is a leaf — its only regexp edge
+is a pre-existing type-only import in `context/types.ts`, erased at runtime).
+
+**DataView — deliberately NOT routed (judgment gate hit).** The DataView
+accessors (`dataview-native.ts`) build the brand throw as a **template `Instr[]`
+(`dvTypeErrorThrow(ctx, DV_BRAND_MESSAGE)`) BEFORE the accessor body** — the
+funcIdx-capture ordering S1 preserves (`__new_TypeError` / `emitWasiErrorConstructor`
+push must precede any later funcIdx capture) — and then weave that template into
+a hand-built `if (not $__dv_window) <brandThrow>` that shares its single
+`$__dv_window` `ref.test` result with the detached-buffer and bounds checks (and
+reads the view length / buffer off the same narrowed struct). `emitReceiverBrandCheck`
+consumes a **stack receiver inside the fctx**, runs its **own** `ref.test`, and
+emits the throw **inline** (not as a pre-built, reusable template) — so adopting
+it here would either (a) force a second redundant `ref.test`, (b) break the
+pre-body template-ordering contract, or (c) require weakening receiver-brand's
+API to hand back a template. All three are worse couplings than the current
+tiny dup. Per the issue's explicit judgment gate we **stop at S1's shared throw
+template for DataView**: its throw already routes through S1's
+`buildThrowJsErrorInstrs` (#3191) via `dvTypeErrorThrow`, so the DataView brand
+throw is already de-duplicated at the throw-builder layer; only the gate
+structure stays local. `DV_BRAND_MESSAGE` unchanged; DataView brand behaviour
+locked by `tests/issue-3192.test.ts`.

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -60,12 +60,12 @@ import {
 } from "./regex/bytecode.js";
 import { compilePattern, RepeatTooLargeError } from "./regex/compile.js";
 import {
-  emitBrandCheckTypeError,
   emitNativeProtoIdentityReturnUndefined,
   getBuiltinBrand,
   registerNativeProtoBuiltin,
   type NativeProtoBuiltinGlue,
 } from "./native-proto.js";
+import { emitReceiverBrandCheck } from "./receiver-brand.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
@@ -1007,26 +1007,28 @@ export function recoverRegExpStructFromExternref(
   thisExternLocal: number,
 ): { regexpLocal: number; structTypeIdx: number } | null {
   const structTypeIdx = ensureStandaloneRegExpStruct(ctx);
-  const anyLocal = allocLocal(fctx, `__re_this_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
-  // any.convert_extern(this) → anyref, kept in a local for the ref.test guard.
+
+  // (#3192 S2) Brand check via the shared `emitReceiverBrandCheck` preamble
+  // (receiver-brand.ts, #3171): it consumes the externref `this` on the stack,
+  // `ref.test $NativeRegExp` (struct-only spec — RegExp has no shared backing
+  // store to disambiguate), throws a *catchable* TypeError on a miss (the
+  // wrong-`this` brand-check the 31 reflective brand-check tests gate on — never
+  // a `ref.cast` trap), and leaves the recovered non-null `(ref $NativeRegExp)`
+  // on the stack. Message preserved verbatim (§22.2.6.4.1 step 2).
   fctx.body.push({ op: "local.get", index: thisExternLocal });
-  fctx.body.push({ op: "any.convert_extern" } as Instr);
-  fctx.body.push({ op: "local.set", index: anyLocal });
+  emitReceiverBrandCheck(
+    ctx,
+    fctx,
+    { kind: "externref" },
+    {
+      message: "Method called on incompatible receiver (RegExp brand check failed)",
+      structTypeIdx,
+    },
+  );
 
-  // Brand check: ref.test $NativeRegExp. On failure throw a catchable TypeError
-  // (the wrong-`this` brand-check the 31 reflective brand-check tests gate on).
-  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
-  fctx.body.push({ op: "ref.test", typeIdx: structTypeIdx } as Instr);
-  fctx.body.push({ op: "i32.eqz" } as Instr);
-  const throwBody: Instr[] = [];
-  emitBrandCheckTypeError(ctx, throwBody, "Method called on incompatible receiver (RegExp brand check failed)");
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwBody, else: [] } as Instr);
-
-  // ref.cast to the concrete struct and stash in a typed local.
+  // Stash the recovered struct in a typed local (callers read fields via it).
   const reStructType: ValType = { kind: "ref", typeIdx: structTypeIdx };
   const regexpLocal = allocLocal(fctx, `__re_recovered_${fctx.locals.length}`, reStructType);
-  fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
-  fctx.body.push({ op: "ref.cast", typeIdx: structTypeIdx } as Instr);
   fctx.body.push({ op: "local.set", index: regexpLocal });
   return { regexpLocal, structTypeIdx };
 }

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -1007,26 +1007,13 @@ export function recoverRegExpStructFromExternref(
   thisExternLocal: number,
 ): { regexpLocal: number; structTypeIdx: number } | null {
   const structTypeIdx = ensureStandaloneRegExpStruct(ctx);
-
-  // (#3192 S2) Brand check via the shared `emitReceiverBrandCheck` preamble
-  // (receiver-brand.ts, #3171): it consumes the externref `this` on the stack,
-  // `ref.test $NativeRegExp` (struct-only spec — RegExp has no shared backing
-  // store to disambiguate), throws a *catchable* TypeError on a miss (the
-  // wrong-`this` brand-check the 31 reflective brand-check tests gate on — never
-  // a `ref.cast` trap), and leaves the recovered non-null `(ref $NativeRegExp)`
-  // on the stack. Message preserved verbatim (§22.2.6.4.1 step 2).
+  // (#3192 S2) Brand check via the shared `emitReceiverBrandCheck` (receiver-brand.ts,
+  // #3171): consumes the externref `this`, `ref.test $NativeRegExp` (struct-only
+  // spec), throws a *catchable* TypeError on a miss (§22.2.6.4.1 step 2, message
+  // verbatim — never a `ref.cast` trap) and leaves the recovered struct on the stack.
+  const brandMsg = "Method called on incompatible receiver (RegExp brand check failed)";
   fctx.body.push({ op: "local.get", index: thisExternLocal });
-  emitReceiverBrandCheck(
-    ctx,
-    fctx,
-    { kind: "externref" },
-    {
-      message: "Method called on incompatible receiver (RegExp brand check failed)",
-      structTypeIdx,
-    },
-  );
-
-  // Stash the recovered struct in a typed local (callers read fields via it).
+  emitReceiverBrandCheck(ctx, fctx, { kind: "externref" }, { message: brandMsg, structTypeIdx });
   const reStructType: ValType = { kind: "ref", typeIdx: structTypeIdx };
   const regexpLocal = allocLocal(fctx, `__re_recovered_${fctx.locals.length}`, reStructType);
   fctx.body.push({ op: "local.set", index: regexpLocal });

--- a/tests/issue-3192.test.ts
+++ b/tests/issue-3192.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #3192 — bloat S2: route the RegExp standalone brand check through the shared
+// `emitReceiverBrandCheck` preamble (receiver-brand.ts, #3171).
+//
+// This is a REFACTOR (zero behaviour change). `recoverRegExpStructFromExternref`
+// (regexp-standalone.ts) previously hand-rolled the §22.2.6 brand gate
+// (`any.convert_extern` + `ref.test $NativeRegExp` + `i32.eqz` + `if` throw via
+// native-proto's `emitBrandCheckTypeError` + `ref.cast`); it now delegates the
+// whole gate to the parameterized `emitReceiverBrandCheck` (struct-only spec).
+// These tests lock the observable contract that must stay byte-identical:
+//   - a reflective RegExp method/getter on a NON-RegExp `this` throws a catchable
+//     TypeError (never a `ref.cast` trap);
+//   - the §22.2.6 proto-identity carve-out (`this === RegExp.prototype`) still
+//     short-circuits BEFORE the brand throw (flags → "", source → "(?:)");
+//   - a genuine RegExp receiver still dispatches natively through `.call`.
+//
+// DataView's brand gate was evaluated as the other half of S2 but is
+// deliberately left on S1's shared throw template (`buildThrowJsErrorInstrs`,
+// via `dvTypeErrorThrow`) per the issue's judgment gate: the DataView accessors
+// build the throw template BEFORE the body (funcIdx-capture ordering) and weave
+// the brand test with the detached-buffer + bounds checks, reusing the single
+// `$__dv_window` test result — a shape `emitReceiverBrandCheck` (stack receiver,
+// inline throw, own `ref.test`) cannot express without weakening its API. The
+// DataView cases below assert that its brand behaviour is unchanged.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const io = r.importObject as WebAssembly.Imports & { __setExports?: (e: Record<string, unknown>) => void };
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports as Record<string, unknown>);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#3192 RegExp reflective brand check → shared receiver-brand preamble", () => {
+  it("flags getter on a plain object throws a catchable TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const d = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags') as any;
+           try { d.get.call({}); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("global getter on a primitive (number) throws a catchable TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const d = Object.getOwnPropertyDescriptor(RegExp.prototype, 'global') as any;
+           try { d.get.call(5); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("proto-identity carve-out short-circuits before the brand throw (flags → '', source → '(?:)')", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const fd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags') as any;
+           const sd = Object.getOwnPropertyDescriptor(RegExp.prototype, 'source') as any;
+           const flags = fd.get.call(RegExp.prototype);
+           const source = sd.get.call(RegExp.prototype);
+           return flags === '' && source === '(?:)' ? 1 : 9;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("genuine RegExp receiver still dispatches natively through .call (test / exec)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const re = /ab+c/;
+           const ok = RegExp.prototype.test.call(re, 'xabbc') ? 1 : 0;
+           const re2 = /(\\d+)/;
+           const m = RegExp.prototype.exec.call(re2, 'n42') as any;
+           const cap = m && m[1] === '42' ? 1 : 0;
+           return ok + cap;
+         }`,
+      ),
+    ).toBe(2);
+  });
+});
+
+describe("#3192 DataView brand behaviour unchanged (stays on S1's shared throw template)", () => {
+  it("reflective accessor on a non-DataView throws a catchable TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g = DataView.prototype.getInt8;
+           try { (g as any).call({}, 0); return 0; }
+           catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("genuine DataView still reads/writes natively", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const b = new ArrayBuffer(8);
+           const dv = new DataView(b);
+           dv.setInt8(0, 42);
+           return dv.getInt8(0);
+         }`,
+      ),
+    ).toBe(42);
+  });
+});


### PR DESCRIPTION
## #3192 — bloat S2: DataView + RegExp brand checks → receiver-brand.ts

Slice **S2** of the #3182 code-bloat-elimination epic (stacked on #3191/S1, which landed the shared `buildThrowJsErrorInstrs` throw builder).

### RegExp — routed (the clean half)
`recoverRegExpStructFromExternref` (`regexp-standalone.ts`) previously hand-rolled the §22.2.6 brand gate (`any.convert_extern` → `ref.test $NativeRegExp` → `i32.eqz` → `if`-throw via native-proto's `emitBrandCheckTypeError` → `ref.cast`). It now delegates the whole gate to the shared **`emitReceiverBrandCheck`** (`receiver-brand.ts`, #3171) with a struct-only `ReceiverBrandSpec` (RegExp has no shared backing store → no `kindField`). The brand-miss message is preserved verbatim (`"Method called on incompatible receiver (RegExp brand check failed)"`); the now-unused `emitBrandCheckTypeError` import is dropped.

### DataView — deliberately NOT routed (issue judgment gate)
The DataView accessors build the brand throw as a **template `Instr[]` BEFORE the body** (funcIdx-capture ordering) and weave it into a hand-built `if (not $__dv_window)` that shares its single `$__dv_window` `ref.test` with the detached-buffer + bounds checks. `emitReceiverBrandCheck` consumes a stack receiver inside the fctx, runs its own `ref.test`, and emits the throw inline — it cannot express that pre-built-template / shared-test shape without weakening its API. Per the issue's explicit judgment gate, DataView **stays on S1's shared throw template** (`dvTypeErrorThrow` → `buildThrowJsErrorInstrs`, #3191) — already de-duplicated at the throw-builder layer. `DV_BRAND_MESSAGE` unchanged. Decision recorded in the issue file.

### Validation
- **Zero behaviour change** — verified origin/main and this branch both throw the same catchable TypeError on a non-RegExp `this` and preserve the §22.2.6 proto-identity carve-out (`flags` → `""`, `source` → `"(?:)"`).
- New `tests/issue-3192.test.ts` (6 cases: RegExp brand throw / proto-identity / genuine dispatch + DataView brand throw / genuine read).
- Existing `issue-2175-native-proto-brands` (5), `issue-2876` (8), `issue-2161-regex-symbol-protocol` (14) suites green.
- `pnpm run typecheck` clean; no new runtime import cycle (receiver-brand.ts is a leaf).

Closes #3192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)