### PR TITLE
docs(issues): sprint-71 bloat-reduction issues #3256-3259 (self-host tiers + quick-wins)

### DIFF
--- a/plan/issues/3256-selfhost-string-family-tier1.md
+++ b/plan/issues/3256-selfhost-string-family-tier1.md
@@ -1,0 +1,57 @@
+---
+id: 3256
+title: "Self-host stdlib: convert native-strings.ts hand-emitted Instr[] to TS (Tier-1 resolver-widening)"
+status: ready
+sprint: current
+priority: high
+horizon: xl
+feasibility: hard
+task_type: refactor
+area: codegen, stdlib, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+created: 2026-07-14
+related: [3141, 3226, 3204]
+origin: "sprint-71 bloat audit — native-strings.ts = 7.5k LOC / 2,953 hand-emitted Instr[] sites"
+---
+
+# #3256 — Self-host the `native-strings.ts` family (Tier-1)
+
+## Problem
+
+`src/codegen/native-strings.ts` (7.5k LOC, ~2,953 hand-emitted `Instr[]`
+sites) is the largest bloat lever after Math. The #3141 pilot proved the
+self-host model (Math family: −390 LOC, bit-exact) and #3226 confirmed no
+dialect gaps for pure-f64. Strings are the next family per the scale-up plan.
+
+## Blocker / groundwork (Tier-1, do first)
+
+The self-host driver's resolver (`stdlib-selfhost.ts:243`) throws on
+globals/named-types/objects. opus-selfhost2 scoped a **tiered purpose-built
+widening** (see `plan/self-hosting-scale-up.md`): Tier-1 = strings —
+(a) widen `resolveFunc` to add makeResolver's name-fallback + on-demand
+string-helper materialization; (b) `resolveString` via exporting
+`computeStringBackend(ctx)`; (c) `resolveType` for the string struct. NO
+object/closure/vec registries needed. Precursor A: declare `__str_charCodeAt`-
+style callee sigs.
+
+## Scope
+
+1. Land the Tier-1 resolver widening + Precursor A.
+2. Convert the SMALLEST fixed-ABI leaf `__str_*` helper first (opus-selfhost2's
+   pick: `__str_repeat` or `__str_startsWith`) to `src/stdlib/` TS, proving the
+   path end-to-end — MEASURE net LOC + containment before going wide.
+3. Then convert the rest of the discrete `__str_*` runtime helpers
+   (indexOf/padStart/slice/includes/…).
+
+## Acceptance
+
+- Tier-1 resolver widening lands; ≥1 `__str_*` helper self-hosted (hand `Instr[]`
+  deleted), net −LOC.
+- Validation: A/B equivalence (non-numeric → equivalence, not bit-exact-sweep) +
+  containment SHA (non-users byte-identical). Both pure-Wasm lanes zero host imports.
+- Update `plan/self-hosting-scale-up.md` with the measured per-helper compression.
+
+## Non-goals
+
+- No object/array family (Tier-2/3, separate issues #3257/#3258).

--- a/plan/issues/3257-selfhost-array-family-tier2.md
+++ b/plan/issues/3257-selfhost-array-family-tier2.md
@@ -1,0 +1,48 @@
+---
+id: 3257
+title: "Self-host stdlib: convert array-methods.ts hand-emitted Instr[] to TS (Tier-2)"
+status: ready
+sprint: current
+priority: high
+horizon: xl
+feasibility: hard
+task_type: refactor
+area: codegen, stdlib, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+created: 2026-07-14
+depends_on: [3256]
+related: [3141, 3256]
+origin: "sprint-71 bloat audit — array-methods.ts = 10.2k LOC / 2,128 hand-emitted Instr[] sites"
+---
+
+# #3257 — Self-host the `array-methods.ts` family (Tier-2)
+
+## Problem
+
+`src/codegen/array-methods.ts` (10.2k LOC, ~2,128 hand-emitted `Instr[]`
+sites) is the second-largest self-host bloat lever. Depends on the Tier-1
+string groundwork (#3256) landing first.
+
+## Scope (Tier-2, per plan/self-hosting-scale-up.md)
+
+Extend the driver resolver with **VEC_ELEM_SET on-demand + vec `resolveType`**
+(Tier-2), then convert the discrete fixed-ABI array runtime helpers (the
+type-restricted, pure, fixed-ABI ones first per the self-host net-negative rule —
+see `reference_selfhost_netnegative_needs_full_elemkind_dialect`). Convert only
+the units whose element-kind dialect is fully covered; leave heterogeneous /
+any-elem helpers for the object tier.
+
+## Acceptance
+
+- Tier-2 vec resolver support lands; the type-restricted array helpers self-hosted
+  (hand `Instr[]` deleted), net −LOC.
+- A/B equivalence + containment SHA; both pure-Wasm lanes zero host imports.
+- Caveat check: the IR loop/try op families are WasmGC-`Instr[]`-only today
+  (#1584 §2a) — loop-bearing self-hosted bodies serve the WasmGC backend; linear
+  backend needs the a1..a6 trait migration first (it doesn't consume array-methods
+  today either, so nothing regresses).
+
+## Non-goals
+
+- Object-family / any-elem helpers (Tier-3, #3258).

--- a/plan/issues/3258-selfhost-object-family-tier3.md
+++ b/plan/issues/3258-selfhost-object-family-tier3.md
@@ -1,0 +1,47 @@
+---
+id: 3258
+title: "Self-host stdlib: convert object-runtime.ts hand-emitted Instr[] to TS (Tier-3)"
+status: ready
+sprint: current
+priority: medium
+horizon: xl
+feasibility: hard
+task_type: refactor
+area: codegen, stdlib, ir
+language_feature: compiler-internals
+goal: ir-full-coverage
+created: 2026-07-14
+depends_on: [3257]
+related: [3141, 3256, 3257]
+origin: "sprint-71 bloat audit — object-runtime.ts = 11.6k LOC / 3,738 hand-emitted Instr[] sites (largest single lever)"
+---
+
+# #3258 — Self-host the `object-runtime.ts` family (Tier-3)
+
+## Problem
+
+`src/codegen/object-runtime.ts` (11.6k LOC, **3,738** hand-emitted `Instr[]`
+sites) is the single largest self-host bloat lever — but also the hardest
+(object/any element-kinds, dynamic shapes). Depends on Tier-1 (#3256) + Tier-2
+(#3257) landing first.
+
+## Scope (Tier-3, per plan/self-hosting-scale-up.md)
+
+Only THEN wire the full deferred-registry machinery (Object/Closure/RefCell/
+Class resolvers via integration.ts's `makeResolver`) into the driver resolver.
+Convert the object-runtime helpers whose ABI is fixed; the dynamic-shape /
+any-receiver ones may stay hand-emitted if the dialect can't cover their
+elem-kinds (per `reference_selfhost_netnegative_needs_full_elemkind_dialect` —
+self-host nets negative ONLY if the TS dialect covers ALL elem-kinds).
+
+## Acceptance
+
+- Tier-3 object/class resolver support lands; the fixed-ABI object-runtime helpers
+  self-hosted (hand `Instr[]` deleted), net −LOC.
+- A/B equivalence + containment SHA; both pure-Wasm lanes zero host imports.
+- Written verdict on which object-runtime helpers are NOT self-hostable yet
+  (dialect-gap) + what dialect work would unblock them.
+
+## Non-goals
+
+- Big-bang: convert leaf-first, one helper group per PR, measure each.

--- a/plan/issues/3259-bloat-quickwins-knip-jscpd.md
+++ b/plan/issues/3259-bloat-quickwins-knip-jscpd.md
@@ -1,0 +1,46 @@
+---
+id: 3259
+title: "Bloat quick-wins: knip dead-export sweep + jscpd duplication scan of src/codegen"
+status: ready
+sprint: current
+priority: high
+horizon: s
+feasibility: easy
+task_type: chore
+area: codegen, ci
+goal: ir-full-coverage
+created: 2026-07-14
+related: [3090, 3256]
+origin: "sprint-71 bloat audit — automated dead-code + duplication before the self-host epic"
+---
+
+# #3259 — Bloat quick-wins: knip + jscpd
+
+## Problem
+
+Before the multi-window self-host epic (#3256–#3258), two cheap automated
+passes bank easy −LOC and inform the self-host order.
+
+## Scope
+
+1. **knip dead-export sweep.** `knip` is already wired into quality CI (#3090
+   Phase 2b, banked −1,800 LOC). Re-run it (`pnpm run knip` or the wired check),
+   delete confirmed dead exports/files, gated by the existing knip config. Land as
+   a single deletion PR (merge_group A/B validates zero behavior change).
+2. **jscpd copy-paste scan of `src/codegen/`.** Run jscpd over `src/codegen/`
+   (the hand-emission families likely share large duplicated `Instr[]`
+   sequences). Report the top duplicated blocks. Where a duplicated Instr-sequence
+   is a clear helper-extraction, extract it (net −LOC, byte-inert). Where it's an
+   artifact of hand-emission that self-hosting will delete anyway, just note it in
+   `plan/self-hosting-scale-up.md` to sequence #3256–#3258.
+
+## Acceptance
+
+- knip dead-exports deleted (net −LOC), quality CI green.
+- jscpd top-duplication report committed to `plan/log/`; any clean helper
+  extractions landed byte-inert.
+
+## Non-goals
+
+- No risky god-file restructuring (calls.ts/index.ts shrink is a byproduct of the
+  IR migration #2855 + backend convergence #2953/#2956, not direct editing).


### PR DESCRIPTION
Adds 4 sprint:current issues from the sprint-71 compiler bloat audit:
- #3256 self-host native-strings.ts (Tier-1 resolver-widening; 2,953 emit-sites)
- #3257 self-host array-methods.ts (Tier-2; depends 3256)
- #3258 self-host object-runtime.ts (Tier-3, largest lever; 3,738 sites; depends 3257)
- #3259 knip dead-export + jscpd duplication quick-wins

Docs-only. Builds on the proven #3141/#3226 self-host track. Generated with Claude Code.