### PR TITLE
chore(#2855): flip status backlog→ready (surface the IR-migration bloat lever)

### DIFF
--- a/plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md
+++ b/plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md
@@ -1,7 +1,7 @@
 ---
 id: 2855
 title: "IR front-end migration: ratchet unintended fallback buckets to zero + promote to STRICT_IR_REASONS"
-status: backlog
+status: ready
 sprint: current
 created: 2026-06-30
 updated: 2026-06-30


### PR DESCRIPTION
One-line frontmatter fix. #2855 was `sprint: current` but `status: backlog` — a contradiction that kept the highest-leverage bloat lever (the IR-migration ratchet that ultimately makes the 13k-line `compileCallExpression` deletable) from ever surfacing as a claimable TaskList item. Flip to `ready`.

No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)