### PR TITLE
docs: wire god-file profiler into the bloat issues as their acceptance meter

### DIFF
--- a/plan/issues/3256-selfhost-string-family-tier1.md
+++ b/plan/issues/3256-selfhost-string-family-tier1.md
@@ -52,6 +52,24 @@ style callee sigs.
   containment SHA (non-users byte-identical). Both pure-Wasm lanes zero host imports.
 - Update `plan/self-hosting-scale-up.md` with the measured per-helper compression.
 
+## Measurement (the profiler is this issue's progress meter)
+
+Use the god-file profiler from #3259 as the acceptance instrument, not eyeballed
+LOC:
+
+- **Before/after:** `pnpm run profile:godfiles` — `native-strings.ts` is the
+  target; its `ensureNativeStringHelpers` (baseline 4,844 LOC, emission-density
+  d≈0.46, classified `hand-emitted-runtime`) is the block this tier shrinks.
+  Record the LOC delta per converted helper here and in
+  `plan/self-hosting-scale-up.md`.
+- **Landing proof:** after each conversion, refresh the tracked baseline —
+  `node scripts/profile-godfiles.mjs --update` and commit
+  `scripts/godfile-profile-baseline.json` — so the `pnpm run check:godfiles`
+  gate ratchets down (it fails on regrowth). A shrink that isn't reflected in the
+  baseline isn't banked.
+- Shape context: report `plan/log/3259-bloat-quickwins-report.md` (32,272 LOC of
+  `hand-emitted-runtime` across the god-files → this self-host track).
+
 ## Non-goals
 
 - No object/array family (Tier-2/3, separate issues #3257/#3258).

--- a/plan/issues/3257-selfhost-array-family-tier2.md
+++ b/plan/issues/3257-selfhost-array-family-tier2.md
@@ -43,6 +43,20 @@ any-elem helpers for the object tier.
   backend needs the a1..a6 trait migration first (it doesn't consume array-methods
   today either, so nothing regresses).
 
+## Measurement (the profiler is this issue's progress meter)
+
+Use the god-file profiler from #3259 as the acceptance instrument:
+
+- **Before/after:** `pnpm run profile:godfiles` — `array-methods.ts` is the
+  target; the tracked `hand-emitted-runtime` blocks this tier shrinks include
+  `compileArrayLikePrototypeCall` (1,100 LOC, d≈0.21) and the per-method helpers
+  (`compileArrayIncludes` d≈0.31, `compileArrayLastIndexOf` d≈0.32, …). Record
+  the per-helper LOC delta here and in `plan/self-hosting-scale-up.md`.
+- **Landing proof:** after each conversion, `node scripts/profile-godfiles.mjs
+  --update` and commit `scripts/godfile-profile-baseline.json` so
+  `pnpm run check:godfiles` ratchets down (fails on regrowth).
+- Shape context: `plan/log/3259-bloat-quickwins-report.md`.
+
 ## Non-goals
 
 - Object-family / any-elem helpers (Tier-3, #3258).

--- a/plan/issues/3258-selfhost-object-family-tier3.md
+++ b/plan/issues/3258-selfhost-object-family-tier3.md
@@ -42,6 +42,22 @@ self-host nets negative ONLY if the TS dialect covers ALL elem-kinds).
 - Written verdict on which object-runtime helpers are NOT self-hostable yet
   (dialect-gap) + what dialect work would unblock them.
 
+## Measurement (the profiler is this issue's progress meter)
+
+Use the god-file profiler from #3259 as the acceptance instrument:
+
+- **Before/after:** `pnpm run profile:godfiles` — `object-runtime.ts` is the
+  largest single lever; `ensureObjectRuntime` (baseline 7,355 LOC, d≈0.39,
+  `hand-emitted-runtime`) is 42% of the file, plus `ensureProxyRuntime`
+  (1,338 LOC, d≈0.32) and the `fill*`/`buildOrdered*` groups. Record the
+  per-group LOC delta here and in `plan/self-hosting-scale-up.md`.
+- **Landing proof:** after each helper-group conversion,
+  `node scripts/profile-godfiles.mjs --update` and commit
+  `scripts/godfile-profile-baseline.json` so `pnpm run check:godfiles` ratchets
+  down (fails on regrowth). Helpers left hand-emitted for a dialect-gap stay in
+  the baseline — the written verdict names them.
+- Shape context: `plan/log/3259-bloat-quickwins-report.md`.
+
 ## Non-goals
 
 - Big-bang: convert leaf-first, one helper group per PR, measure each.

--- a/plan/issues/3259-bloat-quickwins-knip-jscpd.md
+++ b/plan/issues/3259-bloat-quickwins-knip-jscpd.md
@@ -48,7 +48,12 @@ passes bank easy −LOC and inform the self-host order.
 
 ## Outcome (2026-07-14) — no cheap −LOC left; both halves empty
 
-Full run recorded in `plan/log/3259-bloat-quickwins-report.md`.
+Full run recorded in `plan/log/3259-bloat-quickwins-report.md`. Shipped the
+god-file profiler as the durable follow-on tool (#3047):
+`pnpm run profile:godfiles` (rank god-file functions by LOC + emission-density,
+classify bloat shape → lever) and `pnpm run check:godfiles` (regression gate vs
+`scripts/godfile-profile-baseline.json`, 62 tracked functions). #3256/#3257/#3258
+use it as their landing-proof meter.
 
 **Half 1 — dead-export sweep.** knip was never actually wired (the premise was
 off — #3090 Phase 2b used a purpose-built reachability audit,


### PR DESCRIPTION
Makes the god-file profiler (#3047: `profile:godfiles` / `check:godfiles`) the explicit progress meter for the self-host bloat issues, which previously quoted raw LOC counts without pointing at the tool that measures them.

- **#3256 / #3257 / #3258** — add a **Measurement** section: run `pnpm run profile:godfiles` before/after, named per issue with its tracked functions + emission-densities (`ensureNativeStringHelpers` d≈0.46, `ensureObjectRuntime` d≈0.39, the array-method helpers), and refresh `scripts/godfile-profile-baseline.json` (`--update`) as landing proof so `check:godfiles` ratchets down and fails on regrowth.
- **#3259** — name the profiler commands in the outcome (was a report link only).

Docs-only. (The one-pager auto-update issue is dropped from this PR — the one-pager lives in another repo; tracking separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)