### PR TITLE
docs(#3261): standalone env::* leaks — __host_loose_eq / __extern_toString / __date_format

### DIFF
--- a/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
+++ b/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
@@ -5,8 +5,8 @@ status: ready
 sprint: current
 created: 2026-07-14
 priority: medium
-feasibility: hard
-model: fable
+feasibility: medium
+model: opus
 horizon: m
 task_type: fix
 area: codegen
@@ -74,5 +74,14 @@ Do NOT add a new host import without a standalone fallback. Behaviour-preserving
 - Sibling issue **#2903** (`ready`, `model: fable`) covers a *different* host-backed leak family
   (`env.__make_callback` for Promise.then/.catch and Iterator helpers) — keep them separate.
 - Feeds the standalone-parity umbrella **#2860**.
-- Tagged `model: fable` / `feasibility: hard` — same hard-standalone class as #2903; the
-  value-rep-aware native equality/coercion is the tricky part.
+- **Tier: `model: opus` / `feasibility: medium`.** Unlike its #2903 sibling, the native
+  primitives this needs already exist — `__any_eq` (native loose-equality, #1134) and
+  `__any_to_string` (native ToString, #1470). So `__host_loose_eq` and `__extern_toString`
+  are mostly a *routing* job: point the remaining standalone arms (e.g. the boolean==string
+  arm at `binary-ops.ts:1030`, already flagged `(#2073)` at :1046) at the existing native
+  helper, `noJsHost`-gated, byte-identity-guarded on the host lane. That's Opus-appropriate
+  refactor work, not novel reasoning.
+- **Scope carve-out:** `__date_format` (native Date-to-string) is the one genuinely harder
+  sub-part and overlaps the standalone Date cluster — do it under / alongside **#3174**
+  (Date-native) rather than block this issue on it. #3261's core deliverable is the two
+  routing fixes (loose-eq + extern-toString).

--- a/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
+++ b/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
@@ -1,0 +1,78 @@
+---
+id: 3261
+title: "standalone: __host_loose_eq / __extern_toString / __date_format leak env::* imports (missing native-helper set membership)"
+status: ready
+sprint: current
+created: 2026-07-14
+priority: medium
+feasibility: hard
+model: fable
+horizon: m
+task_type: fix
+area: codegen
+language_feature: standalone-completeness
+goal: standalone-parity
+related: [2903, 2860, 3107, 1471, 1470]
+---
+
+# #3261 — standalone env::* leaks: `__host_loose_eq` / `__extern_toString` / `__date_format`
+
+**Source:** surfaced by the #3107 `as Instr` cast-elimination non-null-assertion audit
+(2026-07-14). Tangential to #3107 (NOT a cast bug) — the audit traced the `?? ensureLateImport(...)`
+fallbacks that back several `funcIdx` non-null assertions and noticed three helpers register a
+**host** import with no standalone (`--target standalone` / `noJsHost`) native arm.
+
+## Problem
+
+Three runtime helpers are **not members of the standalone native-helper set**
+(`UNION_NATIVE_HELPER_NAMES` and siblings). When a standalone build reaches the code paths that
+call them, the compiler emits an `env::*` host import (or, for `__extern_toString`, queues a loud
+refusal) — violating the dual-mode contract that standalone mode is pure Wasm with **no JS host
+imports** (CLAUDE.md "Dual-mode: JS host optional"; the historical host-independence work
+#1470/#1471/#1180 closed the same class for other helpers).
+
+| Helper               | Reached from (host lane)                                   | Standalone symptom                          |
+| -------------------- | ---------------------------------------------------------- | ------------------------------------------- |
+| `__host_loose_eq`    | `binary-ops.ts` loose-equality (`==` / `!=`) coercion arm  | leaks `env::__host_loose_eq`                |
+| `__extern_toString`  | `binary-ops.ts` any→string coercion (string concat, etc.)  | loud refusal / `env::__extern_toString`     |
+| `__date_format`      | `builtins.ts` Date formatting (`toString`/`toLocale*`)     | leaks `env::__date_format`                  |
+
+Contrast: the strict-equality sibling `__host_eq` DOES have a native arm (see
+`any-helpers.ts:~545` and `array-methods.ts:~779`, which internalise both externrefs and compare
+natively). The pattern to follow already exists — these three just never got the same treatment.
+
+`==` coercion, string coercion, and Date stringification are common operations, so real
+test262 rows in standalone mode are likely affected (impact not yet measured — see acceptance).
+
+## Fix direction
+
+For each helper, add a Wasm-native arm gated on `noJsHost` (mirror the existing `__host_eq`
+native replacement in `any-helpers.ts`), OR route the call through an existing native primitive:
+- `__host_loose_eq` → the abstract-equality algorithm over the value-rep tags (much of this
+  already exists for `__any_eq`; #1134 landed strict/loose cross-tag coercion — reuse it).
+- `__extern_toString` → the native ToString path (native-strings + `__box`/tag dispatch).
+- `__date_format` → native Date-to-string (overlaps the standalone Date cluster; coordinate
+  with #3174 and the Date-native work).
+
+Do NOT add a new host import without a standalone fallback. Behaviour-preserving on the host lane
+(guard the native arm behind `noJsHost`).
+
+## Acceptance criteria
+
+1. Measure first: compile representative standalone cases (`x == y` mixed-type, `"" + obj`,
+   `String(new Date())` / `new Date().toString()`) with `--target standalone` and confirm each
+   currently emits an `env::*` import for the named helper (the repro).
+2. After the fix, none of the three helpers appears as an `env::*` import in a standalone build of
+   those cases; the standalone output runs and matches the host-lane result.
+3. Add a permanent test (`tests/issue-3261.test.ts`) covering the three standalone paths (the
+   #2093 probe-coverage gate requires it).
+4. No test262 regression; host-lane byte-identity for the affected functions (the native arm is
+   `noJsHost`-gated, so the host lane must be untouched).
+
+## Notes
+
+- Sibling issue **#2903** (`ready`, `model: fable`) covers a *different* host-backed leak family
+  (`env.__make_callback` for Promise.then/.catch and Iterator helpers) — keep them separate.
+- Feeds the standalone-parity umbrella **#2860**.
+- Tagged `model: fable` / `feasibility: hard` — same hard-standalone class as #2903; the
+  value-rep-aware native equality/coercion is the tricky part.


### PR DESCRIPTION
Files issue #3261 (id allocated via claim-issue.mjs --allocate).

Surfaced tangentially by the #3107 `as Instr` non-null-assertion audit: three runtime helpers (`__host_loose_eq`, `__extern_toString`, `__date_format`) lack standalone native-helper-set membership, so a `--target standalone` build leaks `env::*` imports on `==`/string-coercion/Date-format paths — violating pure-Wasm standalone mode.

- Sibling to #2903 (different helper family: `__make_callback` Promise/Iterator) — kept separate.
- Feeds the standalone-parity umbrella #2860.
- Tagged `feasibility: hard` / `model: fable` (same hard-standalone class as #2903).

Doc-only (new issue file). 🤖 Generated with [Claude Code](https://claude.com/claude-code)