### PR TITLE
docs(landing): async-compile await fix + frame JS/npm compatibility as a goal

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1590,10 +1590,11 @@
         <div class="features-grid">
           <article class="feature-card">
             <div class="feature-icon"><img src="./javascript-logo-white.svg" alt="JavaScript logo" /></div>
-            <h3>JS Ecosystem Compatible</h3>
+            <h3>JS Ecosystem Compatibility</h3>
             <p>
-              Compile existing code without rewriting it into a restricted subset, and stay compatible with the full JS
-              ecosystem, the web, and NPM. Access Web APIs without writing glue code.
+              The goal is to compile existing code without rewriting it into a restricted subset, staying compatible
+              with the full JS ecosystem, the web, and npm, and accessing Web APIs without glue code &mdash; the target
+              the project is working toward, not a level of compatibility it claims today.
             </p>
           </article>
           <article class="feature-card">

--- a/website/index.html
+++ b/website/index.html
@@ -3902,7 +3902,7 @@ document.body.appendChild(el);</pre
 import { compile } from "js2wasm";
 import { buildImports } from "js2wasm/runtime";
 
-const result = compile(sourceCode, {
+const result = await compile(sourceCode, {
   fileName: "app.js"
 });
 


### PR DESCRIPTION
Follow-on to the docs review — these two `website/index.html` commits were stranded on the #3052 branch when that PR merged early (async merge race, same as #3046 earlier), so they never reached main.

1. **Missing `await`** — the 'Compile and run' example called `compile()` synchronously, but it returns `Promise<CompileResult>`, so `result.imports`/`result.binary` would be undefined. Added the await.
2. **Compatibility framed as a goal, not a claim** — the 'JS Ecosystem Compatible' feature card asserted present-tense compatibility ('stay compatible with the full JS ecosystem, the web, and NPM'). Retitled to 'JS Ecosystem Compatibility' and reworded to explicit goal language ('the target the project is working toward, not a level of compatibility it claims today').

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)