### PR TITLE
docs(readme): fix CLI example — -o is an output directory, not a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,13 @@ pnpm install
 Compile a file:
 
 ```bash
-npx js2wasm input.ts -o output.wasm
+npx js2wasm input.ts          # writes input.wasm (+ .wat, .d.ts) next to your CWD
+npx js2wasm input.ts -o dist  # -o is an existing output DIRECTORY, not a file
 ```
+
+The compiler derives the output name from the input basename; `-o <dir>` chooses
+the directory to write into (it must already exist). The default (JS-host) build
+also emits an `input.imports.js` helper — see [Compile modes and imports](#compile-modes-and-imports).
 
 Programmatic API:
 


### PR DESCRIPTION
While verifying 'can npx js2wasm compile a .js file' I hit a real doc bug.

**`npx js2wasm input.ts -o output.wasm` (as documented) fails** with `ENOENT: … open 'output.wasm/input.wasm'`. Root cause: the CLI's `-o`/`--out` flag is an output **directory**, not a file (`cli.ts:177` → `outDir`; the `.wasm` name is derived from the input basename, `cli.ts:353`), so `-o output.wasm` writes `output.wasm/input.wasm` into a directory that doesn't exist.

**Verified end-to-end:** `npx js2wasm add.js` (no `-o`) correctly compiles the `.js` and writes `add.wasm` (+ `.wat`, `.d.ts`, `.imports.js`) to the CWD, via the published `js2wasm` proxy package (v0.60.1).

Fix: document the no-flag form and clarify `-o` takes an existing directory. Docs-only.

Possible follow-up (not in this PR): make the CLI friendlier — accept `-o file.wasm` as a file when it ends in `.wasm`, or `mkdir -p` the outDir, or error clearly instead of ENOENT. Happy to file an issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)