### PR TITLE
fix(#3148): standalone-native BigInt.asIntN / asUintN

### DIFF
--- a/plan/issues/3148-standalone-bigint-asintn.md
+++ b/plan/issues/3148-standalone-bigint-asintn.md
@@ -1,7 +1,9 @@
 ---
 id: 3148
 title: "standalone: BigInt.asIntN / asUintN (20 __get_builtin CEs)"
-status: ready
+status: done
+completed: 2026-07-14
+assignee: ttraenkler/senior-dev-3148
 sprint: current
 priority: medium
 horizon: m
@@ -44,3 +46,72 @@ Measured **20** non-pass standalone entries under
 - The coercion/error-path subset compiles + passes standalone with 0
   regressions; value-computation tests tracked against the #1349 i64-brand
   landing.
+
+## Resolution (2026-07-14)
+
+Added a standalone/WASI-native `BigInt.asIntN` / `BigInt.asUintN` handler in the
+property-access-call section of `src/codegen/expressions/calls.ts`, right after
+the `Math.*` handler. The `#1349`/`#1644` i64-brand BigInt rep
+(`{kind:"i64", bigint:true}`) has **already landed**, so — contrary to the
+issue's original "may want to gate behind #1349" caveat — the full modular wrap
+is now expressible as pure i64 ops with **no JS host import**. The arm is gated
+on `ctx.standalone === true || ctx.wasi === true`; host (gc) mode keeps the
+existing `__get_builtin` path (real JS BigInt) and is byte-unchanged.
+
+### Why this design (not a symptom patch)
+
+- **Root cause**: `BigInt.*` member calls fell through to the generic
+  member-call path → `env::__get_builtin`, which refuses-loud under standalone
+  (#1472 Phase B). The fix intercepts *before* that fallthrough with a native
+  lowering, mirroring the sibling `Number.is*` / `String.fromCharCode` /
+  `RegExp.escape` standalone-native handlers in the same block.
+- **Spec order (order-of-steps.js)**: `ToIndex(bits)` is evaluated *before*
+  `ToBigInt(value)`. The handler compiles `bits` (and its coercion side
+  effects) first, stores it in a local, then compiles `value` — preserving the
+  observable valueOf ordering.
+- **ToIndex(bits)** = ToNumber → `f64.trunc` (truncate toward zero, per
+  ToIntegerOrInfinity) → RangeError when `< 0` or `> 2^53-1` (a real
+  `RangeError` *instance* via `buildThrowJsErrorInstrs`, so wrapped
+  `assert.throws(RangeError, …)` sees `e instanceof RangeError`). `NaN` fails
+  both range comparisons (no throw) and is mapped to `0` by the signed
+  `trunc_sat` (spec: `ToIntegerOrInfinity(NaN) = 0`).
+- **ToBigInt(value)** rides the existing expected-type coercion
+  (`{kind:"i64", bigint:true}` → `__to_bigint`), which already throws TypeError
+  on undefined/null/symbol. A missing value arg is a direct TypeError throw.
+- **Modular wrap** in i64, keyed on the bits value at runtime (works for a
+  literal *or* a computed `bits`):
+  - `bits == 0` ⇒ `0n`.
+  - `1 ≤ bits ≤ 63`: asIntN sign-extends via `(v << (64-bits)) >>_s (64-bits)`;
+    asUintN masks via `v & ((1<<bits)-1)`.
+  - `bits ≥ 64` ⇒ value unchanged. This is exact for asIntN and for asUintN of
+    a non-negative value. Special-casing `0` and `≥64` is **required** because
+    Wasm shift counts are taken mod 64, so a raw `64-bits` shift at the boundary
+    would alias to a 0-shift and mis-handle it.
+
+### Representability boundary (the honest limit)
+
+The i64-brand rep holds only the **low 64 bits** of a BigInt, which is exactly
+what `asIntN`/`asUintN` of `bits ≤ 64` observes — so those are computed
+correctly *even for source literals wider than 64 bits* (verified:
+`asIntN(8, 0xabcdef0123456789abcdef0123n) === 0x23n`). Two subsets remain
+out of scope (inherently unrepresentable in i64, still tracked against the
+#1349 lane, not regressed by this change — they were CE before and are non-pass
+now):
+
+1. `asIntN`/`asUintN` with `bits > 64` where the true result needs bits the i64
+   rep does not carry (e.g. `asIntN(65, huge)`, `asIntN(200/201, huge)` in
+   `arithmetic.js`).
+2. `bigint-tobigint.js` **string/array→BigInt** value coercion — `__to_bigint`
+   /`__bigint_ctor` do not yet parse a string to a BigInt in standalone (a
+   pre-existing infra gap: `BigInt("10")` itself throws a `WebAssembly.Exception`
+   in standalone today, independent of this handler). The number/boolean value
+   cases and all `bits-toindex.js` numeric coercions **do** pass.
+
+## Test Results
+
+- `tests/issue-3148.test.ts` — 33 cases, all green: asIntN/asUintN across bit
+  widths (0, 1, 2, 4, 8, 64, >64), negative inputs, wide (>64-bit) literals,
+  ToIndex numeric coercions (trunc-toward-zero, NaN⇒0), a no-`__get_builtin`-CE
+  guard + `env`-import-leak guard, and a host-mode-still-compiles guard.
+- `tsc --noEmit` clean; existing `tests/bigint*.test.ts` + `tests/issue-1644*`
+  all pass (no regression).

--- a/plan/issues/3148-standalone-bigint-asintn.md
+++ b/plan/issues/3148-standalone-bigint-asintn.md
@@ -12,6 +12,14 @@ area: codegen, runtime
 goal: standalone-mode
 related: [2984, 1349, 1644]
 origin: "#2984 __get_builtin cluster triage (fable-sub1, 2026-07-11)"
+# (#3102) The native BigInt.asIntN/asUintN handler is added inline in the
+# property-access-call dispatch of calls.ts, consistent with its sibling
+# standalone-native builtin handlers already inline in the SAME block
+# (Number.is*, RegExp.escape, String.fromCharCode). calls.ts sits exactly at
+# its LOC cap, so this genuinely-intended feature growth needs an allowance;
+# the baseline re-absorbs it post-merge (#3131).
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3148 — standalone BigInt.asIntN / asUintN

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6753,6 +6753,145 @@ function compileCallExpression(
       // (e.g. Array.prototype.every.call(Math, ...) rewritten as Math.every(...))
     }
 
+    // (#3148) Standalone/WASI-native BigInt.asIntN(bits, bigint) /
+    // BigInt.asUintN(bits, bigint) — §21.2.2.1 / §21.2.2.2. The generic
+    // member-call path routes `BigInt.*` through the dynamic-shape
+    // `env::__get_builtin` host import, which refuses-loud under standalone
+    // (#1472 Phase B) → 20 hard CEs under built-ins/BigInt/{asIntN,asUintN}/.
+    // Here the modular wrap is lowered to pure i64 ops over the #1644 i64-brand
+    // BigInt rep (`{kind:"i64", bigint:true}`), with NO JS host import. Host
+    // (gc) mode keeps the `__get_builtin` path (which produces a real JS
+    // BigInt), so this arm is gated on no-JS-host.
+    //
+    // Representability note: the i64-brand rep holds only the low 64 bits of a
+    // BigInt, which is exactly what asIntN/asUintN of `bits <= 64` observes, so
+    // those are computed correctly even for source literals wider than 64 bits.
+    // For `bits > 64` we return the value unchanged: asIntN is exact, and
+    // asUintN is exact for non-negative values (a negative value with bits>=64
+    // is inherently not representable in i64 — documented out of scope).
+    if (
+      (ctx.standalone === true || ctx.wasi === true) &&
+      ts.isIdentifier(propAccess.expression) &&
+      propAccess.expression.text === "BigInt" &&
+      (propAccess.name.text === "asIntN" || propAccess.name.text === "asUintN")
+    ) {
+      const isIntN = propAccess.name.text === "asIntN";
+      const bitsArg = expr.arguments[0];
+      const valArg = expr.arguments[1];
+
+      // Step 1 — bits = ? ToIndex(bits). ToNumber → truncate toward zero →
+      // RangeError when < 0 or > 2^53-1. A missing bits argument is
+      // `undefined` ⇒ ToNumber(undefined) = NaN ⇒ ToIntegerOrInfinity = 0.
+      // ToIndex(bits) runs BEFORE ToBigInt(value) (order-of-steps.js): the
+      // bits argument (and its valueOf) is fully evaluated here first.
+      const bitsF64Idx = allocLocal(fctx, `__asN_bits_${fctx.locals.length}`, { kind: "f64" });
+      if (bitsArg !== undefined) {
+        compileExpression(ctx, fctx, bitsArg, { kind: "f64" });
+      } else {
+        fctx.body.push({ op: "f64.const", value: NaN });
+      }
+      // ToIntegerOrInfinity: truncate toward zero (NaN stays NaN; mapped to 0
+      // by the RangeError-free trunc_sat below).
+      fctx.body.push({ op: "f64.trunc" } as Instr);
+      fctx.body.push({ op: "local.tee", index: bitsF64Idx });
+      // RangeError guard: bits < 0 OR bits > 2^53-1. NaN fails both comparisons
+      // (no throw) and is later mapped to 0. ±Infinity is caught (−∞ < 0,
+      // +∞ > 2^53-1).
+      fctx.body.push({ op: "f64.const", value: 0 });
+      fctx.body.push({ op: "f64.lt" } as Instr);
+      fctx.body.push({ op: "local.get", index: bitsF64Idx });
+      fctx.body.push({ op: "f64.const", value: 9007199254740991 }); // 2^53 - 1
+      fctx.body.push({ op: "f64.gt" } as Instr);
+      fctx.body.push({ op: "i32.or" });
+      {
+        const throwInstrs = buildThrowJsErrorInstrs(
+          ctx,
+          "RangeError",
+          `RangeError: bits must be in the range 0 to 2^53-1 in BigInt.as${isIntN ? "IntN" : "UintN"}`,
+          { flush: fctx },
+        );
+        fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwInstrs, else: [] } as Instr);
+      }
+      // bits as an i64 count in [0, 2^53-1]. Signed trunc_sat is exact for this
+      // range and maps NaN→0 (spec: ToIntegerOrInfinity(NaN) = 0).
+      const bitsI64Idx = allocLocal(fctx, `__asN_bitsI_${fctx.locals.length}`, { kind: "i64" });
+      fctx.body.push({ op: "local.get", index: bitsF64Idx });
+      fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
+      fctx.body.push({ op: "local.set", index: bitsI64Idx });
+
+      // Step 2 — value = ? ToBigInt(value). A missing value argument is
+      // `undefined`, and ToBigInt(undefined) is a TypeError (§7.1.13).
+      if (valArg === undefined) {
+        emitThrowTypeError(ctx, fctx, "TypeError: Cannot convert undefined to a BigInt");
+        // The throw is stack-polymorphic; return the nominal bigint result type.
+        return { kind: "i64", bigint: true };
+      }
+      const valI64Idx = allocLocal(fctx, `__asN_val_${fctx.locals.length}`, { kind: "i64", bigint: true });
+      // Expected-type `{kind:"i64", bigint:true}` drives the ToBigInt coercion:
+      // identity on a bigint, `__to_bigint` on an any/string/boolean/object
+      // carrier (which throws TypeError on undefined/null/symbol/number).
+      compileExpression(ctx, fctx, valArg, { kind: "i64", bigint: true });
+      fctx.body.push({ op: "local.set", index: valI64Idx });
+
+      // Step 3 — modular wrap in i64. The shift/mask forms below are valid only
+      // for 1 <= bits <= 63; bits==0 ⇒ 0n and bits>=64 ⇒ value are special-cased
+      // (Wasm shift counts are taken mod 64, so a raw 64-bits shift would alias
+      // to 0 and mis-handle the boundary).
+      const resultIdx = allocLocal(fctx, `__asN_res_${fctx.locals.length}`, { kind: "i64", bigint: true });
+      const innerElse: Instr[] = isIntN
+        ? [
+            // asIntN: sign-extend bit (bits-1) via (v << (64-bits)) >>_s (64-bits).
+            { op: "local.get", index: valI64Idx },
+            { op: "i64.const", value: 64n },
+            { op: "local.get", index: bitsI64Idx },
+            { op: "i64.sub" } as Instr,
+            { op: "i64.shl" } as Instr,
+            { op: "i64.const", value: 64n },
+            { op: "local.get", index: bitsI64Idx },
+            { op: "i64.sub" } as Instr,
+            { op: "i64.shr_s" } as Instr,
+            { op: "local.set", index: resultIdx },
+          ]
+        : [
+            // asUintN: mask the low `bits` bits via v & ((1 << bits) - 1).
+            { op: "local.get", index: valI64Idx },
+            { op: "i64.const", value: 1n },
+            { op: "local.get", index: bitsI64Idx },
+            { op: "i64.shl" } as Instr,
+            { op: "i64.const", value: 1n },
+            { op: "i64.sub" } as Instr,
+            { op: "i64.and" } as Instr,
+            { op: "local.set", index: resultIdx },
+          ];
+      const geq64Branch: Instr[] = [
+        { op: "local.get", index: bitsI64Idx },
+        { op: "i64.const", value: 64n },
+        { op: "i64.ge_u" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: valI64Idx },
+            { op: "local.set", index: resultIdx },
+          ],
+          else: innerElse,
+        } as Instr,
+      ];
+      fctx.body.push({ op: "local.get", index: bitsI64Idx });
+      fctx.body.push({ op: "i64.eqz" } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "i64.const", value: 0n },
+          { op: "local.set", index: resultIdx },
+        ],
+        else: geq64Branch,
+      } as Instr);
+      fctx.body.push({ op: "local.get", index: resultIdx });
+      return { kind: "i64", bigint: true };
+    }
+
     // #2590 — RegExp.escape(s) (ES2025, §22.2.5). A pure string transform that
     // escapes regex-syntax-significant code points. Standalone-only: routing it
     // through the native `__regex_escape` helper avoids leaking the dynamic

--- a/tests/issue-3148.test.ts
+++ b/tests/issue-3148.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3148 — standalone/WASI-native `BigInt.asIntN(bits, bigint)` /
+// `BigInt.asUintN(bits, bigint)` (§21.2.2.1 / §21.2.2.2).
+//
+// Before: `BigInt.asIntN`/`asUintN` under `--target standalone` routed through
+// the generic member-call path → the dynamic-shape `env::__get_builtin` host
+// import, which refuses-loud in standalone (#1472 Phase B) → 20 hard CEs under
+// built-ins/BigInt/{asIntN,asUintN}/.
+//
+// After: the modular wrap is lowered to pure i64 ops over the #1644 i64-brand
+// BigInt rep — NO JS host import. The i64 rep holds the low 64 bits of a
+// BigInt, which is exactly what asIntN/asUintN of `bits <= 64` observes, so
+// those are computed correctly even for source literals wider than 64 bits.
+//
+// This test guards: (1) the standalone path COMPILES (no `__get_builtin` CE)
+// and leaks no `env` host import; (2) the modular-wrap VALUES are correct
+// across bit widths, including the `bits == 0` and `bits > 64` boundaries and
+// negative inputs; (3) ToIndex(bits) number coercions (truncate-toward-zero,
+// NaN⇒0); (4) host (gc) mode still compiles the same source (untouched).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * Compile `export function test(): number { return (<expr>) ? 1 : 0; }` under
+ * `--target standalone`, instantiate with NO imports (pure Wasm), and run.
+ * Returns the i32 result (1 = the bigint predicate held).
+ */
+async function runStandalone(expr: string): Promise<number> {
+  const src = `export function test(): number { return (${expr}) ? 1 : 0; }`;
+  const r = await compile(src, { fileName: "t.ts", target: "standalone" });
+  expect(r.success, `standalone compile failed for \`${expr}\`: ${r.errors[0]?.message ?? "(no error)"}`).toBe(true);
+  // No JS-host import leaked into the standalone binary.
+  const env = (r.imports ?? []).filter((i: { module?: string }) => i.module === "env");
+  expect(env.length, `\`${expr}\` leaked env imports: ${env.map((i: { name?: string }) => i.name).join(",")}`).toBe(0);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#3148 standalone BigInt.asIntN / asUintN", () => {
+  it("does not CE through the __get_builtin refusal", async () => {
+    const r = await compile(`export function test(): bigint { return BigInt.asIntN(4, 25n); }`, {
+      fileName: "t.ts",
+      target: "standalone",
+    });
+    expect(r.success).toBe(true);
+    expect(r.errors.some((e) => e.message.includes("__get_builtin"))).toBe(false);
+  });
+
+  // §21.2.2.1 — asIntN sign-extends bit (bits-1).
+  describe("asIntN arithmetic", () => {
+    const intCases: Array<[string, boolean]> = [
+      // bits == 0 ⇒ 0n for any value.
+      ["BigInt.asIntN(0, -2n) === 0n", true],
+      ["BigInt.asIntN(0, 0n) === 0n", true],
+      ["BigInt.asIntN(0, 2n) === 0n", true],
+      // bits == 1
+      ["BigInt.asIntN(1, -3n) === -1n", true],
+      ["BigInt.asIntN(1, -2n) === 0n", true],
+      ["BigInt.asIntN(1, 1n) === -1n", true],
+      // bits == 2
+      ["BigInt.asIntN(2, -3n) === 1n", true],
+      ["BigInt.asIntN(2, -2n) === -2n", true],
+      ["BigInt.asIntN(2, 2n) === -2n", true],
+      ["BigInt.asIntN(2, 3n) === -1n", true],
+      // bits == 4 (25 = 0b11001 → low-4 = 1001 → sign bit set → -7)
+      ["BigInt.asIntN(4, 25n) === -7n", true],
+      // bits == 8
+      ["BigInt.asIntN(8, 0xabn) === -0x55n", true],
+      ["BigInt.asIntN(8, 0xabcdn) === -0x33n", true],
+      // bits == 64 (identity on an i64-representable value)
+      ["BigInt.asIntN(64, 0x0123456789abcdefn) === 0x0123456789abcdefn", true],
+      // wide (>64-bit) source literal: only the low `bits` bits are observed.
+      ["BigInt.asIntN(8, 0xabcdef0123456789abcdef0123n) === 0x23n", true],
+      // bits > 64 ⇒ value unchanged (asIntN is exact here).
+      ["BigInt.asIntN(200, 5n) === 5n", true],
+      ["BigInt.asIntN(200, -5n) === -5n", true],
+    ];
+    for (const [expr, want] of intCases) {
+      it(expr, async () => {
+        expect(await runStandalone(expr)).toBe(want ? 1 : 0);
+      });
+    }
+  });
+
+  // §21.2.2.2 — asUintN masks the low `bits` bits (unsigned).
+  describe("asUintN arithmetic", () => {
+    const uintCases: string[] = [
+      "BigInt.asUintN(0, -2n) === 0n",
+      "BigInt.asUintN(0, 5n) === 0n",
+      "BigInt.asUintN(4, 25n) === 9n",
+      "BigInt.asUintN(3, -3n) === 5n",
+      "BigInt.asUintN(2, -1n) === 3n",
+      "BigInt.asUintN(8, 0xabn) === 0xabn",
+      "BigInt.asUintN(8, 0xabcdn) === 0xcdn",
+      // wide source literal — low 8 bits.
+      "BigInt.asUintN(8, 0xabcdef0123456789abcdef0123n) === 0x23n",
+      // bits > 64 with a NON-negative value ⇒ value unchanged (exact).
+      "BigInt.asUintN(100, 42n) === 42n",
+    ];
+    for (const expr of uintCases) {
+      it(expr, async () => {
+        expect(await runStandalone(expr)).toBe(1);
+      });
+    }
+  });
+
+  // ToIndex(bits): ToNumber → truncate toward zero; NaN ⇒ 0. (bits-toindex.js)
+  describe("ToIndex(bits) numeric coercion", () => {
+    const bitsCases: string[] = [
+      "BigInt.asIntN(-0.9, 1n) === 0n", // truncate toward 0
+      "BigInt.asIntN(0.9, 1n) === 0n", // truncate toward 0
+      "BigInt.asIntN(NaN, 1n) === 0n", // NaN ⇒ 0
+      "BigInt.asIntN(3.9, 10n) === 2n", // truncate toward 0
+      "BigInt.asIntN(3, 10n) === 2n",
+    ];
+    for (const expr of bitsCases) {
+      it(expr, async () => {
+        expect(await runStandalone(expr)).toBe(1);
+      });
+    }
+  });
+
+  // Host (gc) mode is untouched — the same source still compiles via the
+  // existing `__get_builtin` path (produces a real JS BigInt). We only assert
+  // it COMPILES; instantiation there needs the JS host imports.
+  it("host (gc) mode still compiles BigInt.asIntN", async () => {
+    const r = await compile(`export function test(): bigint { return BigInt.asIntN(4, 25n); }`, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Lowers `BigInt.asIntN(bits, bigint)` / `BigInt.asUintN(bits, bigint)` to pure
i64 ops over the #1644 i64-brand BigInt rep under `--target standalone`/`wasi`,
instead of falling through to the dynamic-shape `env::__get_builtin` host import
(which refuses-loud in standalone, #1472 Phase B → **20 hard CEs** under
`built-ins/BigInt/{asIntN,asUintN}/`). No new host import; host (gc) mode keeps
the `__get_builtin` path and is byte-unchanged.

Fixes #3148.

## Approach (§21.2.2.1 / §21.2.2.2)

New standalone-native arm in the property-access-call section of
`src/codegen/expressions/calls.ts`, right after the `Math.*` handler:

- **ToIndex(bits)** = ToNumber → `f64.trunc` (truncate toward zero) → real
  `RangeError` instance when `< 0` or `> 2^53-1`. `NaN` ⇒ `0`. Evaluated
  **before** ToBigInt(value) (order-of-steps).
- **ToBigInt(value)** rides the existing `{kind:"i64", bigint:true}`
  expected-type coercion (`__to_bigint`); a missing value arg ⇒ TypeError.
- **Modular wrap** in i64, keyed on the runtime bits value: `bits==0 ⇒ 0n`;
  `1..63` sign-extend (asIntN) / low-bits mask (asUintN); `bits>=64 ⇒ value`
  (special-cased — Wasm shift counts are mod 64, so the 0/≥64 boundaries must be
  handled explicitly).

The i64 rep holds the **low 64 bits** of a BigInt, which is exactly what
`asIntN`/`asUintN` of `bits ≤ 64` observes — correct even for source literals
wider than 64 bits (e.g. `asIntN(8, 0xabcdef0123456789abcdef0123n) === 0x23n`).

## Out of scope (still tracked against the #1349 lane — were CE, now non-pass, not regressed)

- `bits > 64` where the true result needs bits the i64 rep doesn't carry
  (`arithmetic.js` `asIntN(65/200/201, huge)`).
- `bigint-tobigint.js` **string/array → BigInt** value coercion — `__to_bigint`
  doesn't yet parse a string to a BigInt in standalone (`BigInt("10")` itself
  throws a `WebAssembly.Exception` in standalone today, independent of this
  change). Number/boolean value cases and all `bits-toindex.js` numeric
  coercions **do** pass.

## Testing

- `tests/issue-3148.test.ts` — 33 cases, all green: asIntN/asUintN across bit
  widths (0, 1, 2, 4, 8, 64, >64), negatives, wide (>64-bit) literals, ToIndex
  numeric coercions, a no-`__get_builtin`-CE + `env`-import-leak guard, and a
  host-mode-still-compiles guard.
- `tsc --noEmit` clean; existing `tests/bigint*.test.ts` + `tests/issue-1644*`
  pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)