### PR TITLE
refactor(#3273): make oracle-ratchet gate change-scoped (net-per-field)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,24 @@ jobs:
         # plan/log/3090-phase0-legacy-delete-list.md.
         run: pnpm run check:dead-exports
 
-      - name: Oracle ratchet (#1930)
-        # Fails when direct TS-checker usage grows under src/codegen/ —
-        # new code must query ctx.oracle (src/checker/oracle.ts). Baseline:
-        # scripts/oracle-ratchet-baseline.json (--update for intentional
-        # reseeds; --update-on-decrease banks improvements).
-        run: pnpm run check:oracle-ratchet
+      - name: Oracle ratchet (#1930/#3273)
+        # CHANGE-SCOPED (#3273, same rework as check:loc-budget /
+        # check:coercion-sites): fails only when THIS change-set grows its NET
+        # (per-field, summed over the changed files) direct-checker count under
+        # src/codegen/ — new code must query ctx.oracle (src/checker/oracle.ts).
+        # A god-file split that relocates existing sites into a new module is
+        # net-neutral and passes; scoping to the change-set's own base (HEAD^1
+        # of the synthetic merge commit — see the checkout's fetch-depth
+        # comment) keeps an unrelated main advance from re-flagging a sibling
+        # split module the PR never touched (the #3069/#3067/#3066 wedge). The
+        # committed baseline (scripts/oracle-ratchet-baseline.json) is NOT read
+        # on this path and PRs must NOT commit changes to it. Intentional net
+        # growth is granted via an `oracle-ratchet-allow:` frontmatter list in
+        # the PR's own plan/issues/*.md file. The origin/main fetch only feeds
+        # the merge-base fallback for non-synthetic checkouts; best-effort.
+        run: |
+          git fetch --no-tags --depth=200 origin main 2>/dev/null || true
+          pnpm run check:oracle-ratchet
 
       - name: LOC-regrowth ratchet (#3102/#3131)
         # CHANGE-SCOPED AND SELF-CONTAINED: fails only when THIS change-set

--- a/plan/issues/3273-oracle-ratchet-change-scoped.md
+++ b/plan/issues/3273-oracle-ratchet-change-scoped.md
@@ -1,0 +1,115 @@
+---
+id: 3273
+title: "Oracle ratchet gate: make change-scoped (net) — stop whole-tree re-flagging sibling split modules"
+status: done
+assignee: ttraenkler/senior-dev-oracle
+sprint: current
+created: 2026-07-14
+updated: 2026-07-14
+completed: 2026-07-14
+priority: high
+horizon: m
+feasibility: hard
+model: opus
+reasoning_effort: max
+task_type: refactor
+area: ci
+language_feature: compiler-internals
+goal: maintainability
+related: [1930, 3131, 3102, 2108, 3272, 3270, 3271]
+---
+
+# #3273 — Oracle ratchet: change-scoped (net), like the #3131 loc/coercion rework
+
+## Problem
+
+`scripts/check-oracle-ratchet.mjs` (the "Oracle ratchet (#1930)" step in the
+`quality` job) was WHOLE-TREE: it `walk()`ed all of `src/codegen/**` and
+compared each file's direct-TS-checker call-site count (`getTypeAtLocation(`,
+`ctx.checker`) against a committed snapshot,
+`scripts/oracle-ratchet-baseline.json`. Unlike `check:loc-budget` and
+`check:coercion-sites` — which were already reworked change-scoped in #3131 —
+this gate still judged the entire tree against a frozen baseline that has **no
+post-merge auto-refresh** (no workflow runs `check:oracle-ratchet --update`;
+grep `.github/workflows/`).
+
+That is merge-queue-UNSAFE during the god-file breakdown
+(memory `reference_ci_gate_change_scoped_not_wholetree_absolute`): a split PR
+moves checker sites out of a god-file into new sibling modules that the frozen
+baseline never banked, so the whole-tree gate flags those new modules (baseline
+0 → tree N). Worse, once one split lands, **every other open split PR that
+re-merges main inherits the new sibling module and gets flagged for a file it
+never touched**, unless it re-declares a per-issue allowance for it — a per-wave
+treadmill. Three byte-identical refactor PRs — #3069 (index.ts), #3067
+(closures.ts), #3066 (generators-native.ts) — were bot-parked on exactly this
+(`quality` failed in the `merge_group`; Test262 green, no real regression).
+
+## Root cause
+
+Same class as #3131: the gate's _memory_ (a frozen whole-tree baseline) is
+decoupled from the PR's _change-set_, so an unrelated main advance (a sibling
+split landing) re-flags files the PR did not touch. The oracle metric adds one
+twist over loc/coercion: a god-file split **relocates** existing checker sites
+source→new-module, so the change is **net-neutral** — no new oracle debt — yet a
+naive per-file "any increase fails" rule flags the new module.
+
+## Fix (the #3131 precedent, adapted to a two-field, relocation-heavy metric)
+
+Make the DEFAULT run change-scoped via the shared helper
+`scripts/lib/change-scope.mjs` (`resolveChangeBase`, `changedPaths`, `baseBlob`,
+`changeSetAllowances`), exactly as `check-coercion-sites.mjs` /
+`check-loc-budget.mjs` do:
+
+- **Base resolution**: `LOC_GATE_BASE` env → CI synthetic-merge `HEAD^1` (the
+  exact base tree, present at `fetch-depth: 2`) → `merge-base origin/main HEAD`
+  → `origin/main` tree-diff → (no git) legacy whole-tree fallback.
+- **Judge only the change-set**: for each changed `src/codegen/*.ts` file, count
+  the two checker patterns at the BASE blob vs the WORKING TREE. The committed
+  baseline is NOT consulted on this path; PRs must NOT commit changes to it.
+- **NET, not per-file** (the key adaptation): fail only when the change-set's
+  **per-field net** (Σ over changed, non-allowed files of `now − was`) grows.
+  A verbatim relocation (source −N, new module +N) nets to zero and passes
+  without any allowance; a genuinely new checker call with no offsetting removal
+  nets positive and still fails. This matches the ratchet's real job — prevent
+  GROWTH of total direct-checker usage under `src/codegen/`, not freeze the
+  physical file each site lives in. A sibling module inherited via merge is
+  identical at the base and the working tree, so it is not in the diff at all →
+  never evaluated.
+- **Intentional net growth hatch** moves off the shared file: list repo-relative
+  path(s) under an `oracle-ratchet-allow:` key in the PR's own
+  `plan/issues/*.md` frontmatter (unique file per PR ⇒ conflict-free), mirroring
+  `loc-budget-allow` / `coercion-sites-allow`.
+- **Preserved**: `--update` (whole-tree reseed, main/post-merge only),
+  `--update-on-decrease` (bank shrinks), `--verbose`. **Added**: `--all`
+  whole-tree audit vs the committed baseline (local use), and a no-git
+  fallback so the gate never crashes a hook outside a git context.
+- CI step (`ci.yml` `quality`) gains a best-effort `git fetch origin main`
+  before the gate (feeds the merge-base fallback), mirroring the loc-budget
+  step. `fetch-depth: 2` already exposes the synthetic-merge `HEAD^1`.
+
+## Validation (proved both directions)
+
+Measured with the gate's exact counting method (base blob vs head), the three
+parked PRs are **exactly net-zero** on both fields:
+
+- #3069: `index.ts` −14 gTAL / −38 ctxChk moved into `extern-declarations.ts`
+  (+14/+37) and `wasi.ts` (+0/+1) → net 0 / 0.
+- #3067: `closures.ts` −3 / −5 moved into `closures/callback-classification.ts`
+  (+3/+5) → net 0 / 0.
+- #3066: `generators-native.ts` −1 / −3 moved into
+  `generators-native-consumer.ts` (+1/+3) → net 0 / 0.
+
+- **TRUE POSITIVE preserved**: an edited `src/codegen` file that gains a new
+  `ctx.checker.getTypeAtLocation(...)` with no offsetting removal → net +1/+1 →
+  gate FAILS (exit 1), and PASSES again once the file is listed under
+  `oracle-ratchet-allow:`.
+- **FALSE POSITIVE eliminated**: a verbatim relocation (new module +N, source
+  −N) nets 0 → PASSES with no allowance; a sibling module present at the base
+  but not in the change-set's diff is never evaluated → PASSES, whereas the
+  legacy whole-tree (`--all`) path flags it.
+
+## Impact
+
+Unblocks the 3 parked Wave-A split PRs (#3069/#3067/#3066) and every future
+god-file split, with no per-PR baseline bump and no allowance needed for
+net-neutral relocations.

--- a/scripts/check-oracle-ratchet.mjs
+++ b/scripts/check-oracle-ratchet.mjs
@@ -1,31 +1,82 @@
 #!/usr/bin/env node
 // (#1930) Oracle ratchet — fails CI when direct TS-checker usage under
-// src/codegen/ GROWS. Mechanics mirror check:ir-fallbacks (#2855):
-//   - baseline: scripts/oracle-ratchet-baseline.json
-//     { files: { "<rel path>": { getTypeAtLocation: n, ctxChecker: n } },
-//       preauthorized: [ { file, field, extra, reason } ] }
-//   - growth beyond baseline+preauth fails with a per-file report;
-//   - `--update` rewrites the baseline wholesale (intentional changes);
-//   - `--update-on-decrease` banks lower counts only (post-merge job).
+// src/codegen/ GROWS. New code must query ctx.oracle (src/checker/oracle.ts)
+// instead of reaching into the raw TS checker.
 //
-// Counted patterns (occurrences, not lines):
+// Counted patterns (occurrences, not lines), per file:
 //   getTypeAtLocation:  /\bgetTypeAtLocation\s*\(/g
 //   ctxChecker:         /\bctx\.checker\b/g
-// Scope: src/codegen/**/*.ts. Symbol/binding resolution via a local
-// `checker` param is intentionally NOT counted in v1 (name resolution is
-// out of the oracle's scope — see issue #1930 D3 "explicitly OUT").
+// Scope: src/codegen/**/*.ts (excluding *.d.ts). Symbol/binding resolution via
+// a local `checker` param is intentionally NOT counted in v1 (name resolution
+// is out of the oracle's scope — see issue #1930 D3 "explicitly OUT").
+//
+// CHANGE-SCOPED (#3273, mirroring the #3131 rework of check-loc-budget.mjs and
+// check-coercion-sites.mjs). When a git diff base is resolvable
+// (scripts/lib/change-scope.mjs), the DEFAULT run judges ONLY this change-set:
+// for each changed src/codegen/*.ts file it counts the two checker patterns at
+// the BASE blob vs the WORKING TREE, then fails only when the change-set's NET
+// (per-field, summed over the changed files) direct-checker count GREW. The
+// committed baseline (scripts/oracle-ratchet-baseline.json) is NOT consulted on
+// that path.
+//
+//   NET, not per-file: a god-file split moves existing checker sites from the
+//   source file (−N) into a new sibling module (+N). That is net-neutral — no
+//   new oracle debt — so it must pass. A pure per-file "any increase fails"
+//   rule would flag the new module (0→N) and force the split PR to grant an
+//   allowance for every module it creates, which is exactly the treadmill this
+//   rework removes. Netting per field passes verbatim relocations while a
+//   genuinely NEW checker call (an edited file gains a site with no offsetting
+//   removal) nets > 0 and still fails. This matches the ratchet's actual job:
+//   prevent GROWTH of total direct-checker usage under src/codegen/, not freeze
+//   the physical file each site lives in. Measured against the three parked
+//   split PRs (#3069/#3067/#3066): each is exactly net-zero on both fields.
+//
+//   WHY the whole-tree comparison was merge-queue-UNSAFE: during the god-file
+//   breakdown, every PR that re-merges main re-flagged NEW sibling split
+//   modules (added by OTHER already-merged PRs) that the baseline never banked,
+//   unless each PR re-declared a per-issue allowance for files it never
+//   touched — a per-wave treadmill that bot-parked three byte-identical
+//   refactor PRs (#3069/#3067/#3066) with Test262 green (no real regression).
+//   See memory reference_ci_gate_change_scoped_not_wholetree_absolute. Scoping
+//   to the change-set's own base means an unrelated main advance can never
+//   re-flag a file the PR did not touch (the sibling module is identical at the
+//   base and the working tree, so it is not in the diff at all).
+//
+// Intentional growth (a reviewed migration step that adds a direct-checker
+// call) is granted per change-set — NOT via the shared baseline — by listing
+// the repo-relative path(s) under an `oracle-ratchet-allow:` key in the YAML
+// frontmatter of this PR's own plan/issues/*.md file (visible in the diff; a
+// unique file per PR ⇒ no cross-PR conflicts). This replaces the committed
+// `preauthorized` bump for the change-scoped path.
+//
+// The committed baseline + `preauthorized` list remain for the writer modes
+// and the no-git fallback; main's post-merge refresh is its sole writer.
+//
+// Usage:
+//   node scripts/check-oracle-ratchet.mjs                    # change-scoped gate (default)
+//   node scripts/check-oracle-ratchet.mjs --all              # whole-tree audit vs committed baseline
+//   node scripts/check-oracle-ratchet.mjs --update           # reseed the committed baseline (post-merge/main only)
+//   node scripts/check-oracle-ratchet.mjs --update-on-decrease  # bank lower counts (post-merge job)
+//   node scripts/check-oracle-ratchet.mjs --verbose          # print current totals
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveChangeBase, changeSetAllowances } from "./lib/change-scope.mjs";
+import { resolveChangeBase, changedPaths, baseBlob, changeSetAllowances } from "./lib/change-scope.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SCOPE = join(ROOT, "src", "codegen");
 const BASELINE_PATH = join(ROOT, "scripts", "oracle-ratchet-baseline.json");
+// Repo-relative prefix for change-scoping; baseline keys are repo-relative too
+// (relative(ROOT, file) === "src/codegen/…"), so they align with changedPaths.
+const SCOPE_PREFIX = "src/codegen/";
 
-const update = process.argv.includes("--update");
-const updateOnDecrease = process.argv.includes("--update-on-decrease");
-const verbose = process.argv.includes("--verbose");
+const FIELDS = ["getTypeAtLocation", "ctxChecker"];
+
+const args = process.argv.slice(2);
+const update = args.includes("--update");
+const updateOnDecrease = args.includes("--update-on-decrease");
+const verbose = args.includes("--verbose");
+const auditAll = args.includes("--all");
 
 function walk(dir, out = []) {
   for (const name of readdirSync(dir)) {
@@ -42,13 +93,25 @@ function countIn(src, re) {
   return m ? m.length : 0;
 }
 
+/** Per-field checker-usage counts for one file's text. Pure text → counts, so
+ *  it applies identically to the working tree and to a git base blob. */
+function countFields(src) {
+  return {
+    getTypeAtLocation: countIn(src, /\bgetTypeAtLocation\s*\(/g),
+    ctxChecker: countIn(src, /\bctx\.checker\b/g),
+  };
+}
+
+const ZERO = { getTypeAtLocation: 0, ctxChecker: 0 };
+
+// Whole-tree current counts (used by --update / --update-on-decrease / --all /
+// the no-git legacy fallback, and as the working-tree lookup for the scoped
+// gate). Only files with at least one hit are recorded.
 const current = {};
 for (const file of walk(SCOPE)) {
-  const src = readFileSync(file, "utf-8");
-  const getTypeAtLocation = countIn(src, /\bgetTypeAtLocation\s*\(/g);
-  const ctxChecker = countIn(src, /\bctx\.checker\b/g);
-  if (getTypeAtLocation > 0 || ctxChecker > 0) {
-    current[relative(ROOT, file)] = { getTypeAtLocation, ctxChecker };
+  const c = countFields(readFileSync(file, "utf-8"));
+  if (c.getTypeAtLocation > 0 || c.ctxChecker > 0) {
+    current[relative(ROOT, file)] = c;
   }
 }
 
@@ -61,6 +124,15 @@ const totals = (obj) =>
     { getTypeAtLocation: 0, ctxChecker: 0 },
   );
 
+if (verbose) {
+  const t = totals(current);
+  console.error(
+    `[oracle-ratchet] current totals: getTypeAtLocation=${t.getTypeAtLocation}, ctx.checker=${t.ctxChecker}`,
+  );
+}
+
+// ── Writer mode: --update reseeds the committed baseline wholesale (post-merge/
+//    main only). Preauthorized allowances are baked into `files`, so they reset.
 if (update) {
   writeFileSync(BASELINE_PATH, JSON.stringify({ files: current, preauthorized: [] }, null, 2) + "\n");
   const t = totals(current);
@@ -71,6 +143,93 @@ if (update) {
   process.exit(0);
 }
 
+/**
+ * Change-scoped gate (#3273): for each changed src/codegen file, count the two
+ * checker patterns at the base blob vs the working tree, then fail only when
+ * the change-set's NET (per-field, summed over the changed files) direct-checker
+ * count grew. Only THIS change-set is judged; the committed baseline is not
+ * involved. Returns false when the diff cannot be computed (caller falls back to
+ * the legacy whole-tree mode).
+ */
+function gateScoped() {
+  const { base, how } = resolveChangeBase(ROOT);
+  if (!base) return false;
+  const changedAll = changedPaths(ROOT, base, "src/codegen");
+  if (changedAll === undefined) return false;
+  const changed = [...changedAll]
+    .filter((p) => p.endsWith(".ts") && !p.endsWith(".d.ts") && p.startsWith(SCOPE_PREFIX))
+    .sort();
+  const allow = changeSetAllowances(ROOT, base, "oracle-ratchet-allow");
+
+  // Per-field net delta across the change-set, EXCLUDING allowance-granted
+  // files (their intentional growth is sanctioned, so it neither faults nor
+  // counts toward the net). A verbatim relocation nets to 0 → pass; a new
+  // checker call with no offsetting removal nets > 0 → fail.
+  const net = { getTypeAtLocation: 0, ctxChecker: 0 };
+  const increases = []; // non-allowed files that grew a field (for the report)
+  const granted = [];
+
+  for (const p of changed) {
+    const now = current[p] ?? ZERO; // deleted / dropped-to-zero → ZERO
+    const blob = baseBlob(ROOT, base, p);
+    const was = blob === undefined ? ZERO : countFields(blob);
+    const grew = FIELDS.filter((f) => now[f] > was[f]);
+    const delta = FIELDS.map((f) => `${f} ${was[f]}→${now[f]}`).join(", ");
+    if (allow.has(p)) {
+      if (grew.length > 0) granted.push(`  ${p}: ${delta} granted by ${allow.get(p).join(", ")}`);
+      continue; // sanctioned — excluded from the net
+    }
+    for (const f of FIELDS) net[f] += now[f] - was[f];
+    if (grew.length > 0) {
+      increases.push(`  ${p}: ${grew.map((f) => `${f} ${was[f]}→${now[f]}`).join(", ")}`);
+    }
+  }
+
+  if (granted.length > 0) {
+    console.log("[oracle-ratchet] intentional growth allowed by this change-set's issue file:\n" + granted.join("\n"));
+  }
+
+  const grownFields = FIELDS.filter((f) => net[f] > 0);
+  if (grownFields.length > 0) {
+    console.error(
+      `[oracle-ratchet] FAILED — this change-set ADDS direct checker usage on net ` +
+        `(${grownFields.map((f) => `${f} +${net[f]}`).join(", ")}).\n` +
+        `Files whose checker usage increased:\n` +
+        increases.join("\n") +
+        "\n\nMoving existing sites between files is net-neutral and passes; this\n" +
+        "change-set grows the total. New code must query ctx.oracle\n" +
+        "(src/checker/oracle.ts, #1930) instead of the raw TS checker\n" +
+        "(getTypeAtLocation / ctx.checker). If this growth is a genuinely\n" +
+        "intentional, reviewed migration step, grant THIS change-set an allowance:\n" +
+        "list the repo-relative path(s) under an `oracle-ratchet-allow:` key in the\n" +
+        "YAML frontmatter of this PR's own issue file (any plan/issues/*.md the PR\n" +
+        "adds or modifies), e.g.\n\n" +
+        "  oracle-ratchet-allow:\n" +
+        "    - src/codegen/expressions/calls.ts\n\n" +
+        "Do NOT commit changes to scripts/oracle-ratchet-baseline.json in a PR — it\n" +
+        "is refreshed on main only (#3273).",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[oracle-ratchet] OK — no net checker-usage growth across ${changed.length} changed src/codegen file(s) ` +
+      `(getTypeAtLocation ${net.getTypeAtLocation >= 0 ? "+" : ""}${net.getTypeAtLocation}, ` +
+      `ctx.checker ${net.ctxChecker >= 0 ? "+" : ""}${net.ctxChecker}; base: ${how}).`,
+  );
+  return true;
+}
+
+// Default path: change-scoped. --update-on-decrease and --all fall through to
+// the legacy whole-tree comparison (the former is a writer/banking mode, the
+// latter an explicit whole-tree audit).
+if (!updateOnDecrease && !auditAll && gateScoped()) {
+  process.exit(0);
+}
+
+// ── Legacy whole-tree comparison against the committed baseline. Used by --all,
+//    by --update-on-decrease (the post-merge banking writer), and as the
+//    no-git fallback so the gate never crashes a hook outside a git context.
 let baseline;
 try {
   baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf-8"));
@@ -88,8 +247,8 @@ const failures = [];
 let decreased = false;
 const merged = { ...baseline.files };
 for (const [file, counts] of Object.entries(current)) {
-  const base = baseline.files[file] ?? { getTypeAtLocation: 0, ctxChecker: 0 };
-  for (const field of ["getTypeAtLocation", "ctxChecker"]) {
+  const base = baseline.files[file] ?? ZERO;
+  for (const field of FIELDS) {
     const allowed = (base[field] ?? 0) + (preauth.get(`${file}::${field}`) ?? 0);
     if (counts[field] > allowed) {
       failures.push(`${file}: ${field} ${counts[field]} > baseline ${allowed}`);
@@ -107,41 +266,15 @@ for (const file of Object.keys(baseline.files)) {
   }
 }
 
-if (verbose) {
-  const t = totals(current);
-  console.log(`[oracle-ratchet] current totals: getTypeAtLocation=${t.getTypeAtLocation}, ctx.checker=${t.ctxChecker}`);
-}
-
 if (failures.length > 0) {
-  // Intentional-growth hatch (#3131), same change-scoped frontmatter mechanism
-  // as check:loc-budget / check:coercion-sites: a change-set waives growth for a
-  // file by listing its repo-relative path under an `oracle-ratchet-allow:` key
-  // in the YAML frontmatter of a plan/issues/*.md file THE CHANGE-SET ITSELF
-  // adds or modifies. This keeps god-file splits (which merely RELOCATE existing
-  // checker call-sites verbatim — total usage conserved) from touching the
-  // whole-tree baseline JSON, which re-conflicted every open PR on every main
-  // advance. Only issue files in the diff are consulted (an old allowance on
-  // main grants nothing), so a unique file per PR ⇒ no cross-PR conflicts.
-  const { base } = resolveChangeBase(ROOT);
-  const allow = base ? changeSetAllowances(ROOT, base, "oracle-ratchet-allow") : new Map();
-  const fileOf = (f) => f.slice(0, f.indexOf(":"));
-  const waived = failures.filter((f) => allow.has(fileOf(f)));
-  const remaining = failures.filter((f) => !allow.has(fileOf(f)));
-  for (const w of waived) {
-    console.log(`[oracle-ratchet] waived by change-set allowance (${allow.get(fileOf(w)).join(", ")}): ${w}`);
-  }
-  if (remaining.length > 0) {
-    console.error(
-      `[oracle-ratchet] FAILED — direct checker usage grew in src/codegen/ (${remaining.length} file(s)).\n` +
-        `New code must use ctx.oracle (src/checker/oracle.ts, #1930). If this growth is\n` +
-        `genuinely intentional, migrate the site to the oracle, or — for a verbatim\n` +
-        `relocation (god-file split, total usage conserved) — grant THIS change-set an\n` +
-        `allowance by listing the path(s) under an \`oracle-ratchet-allow:\` key in the\n` +
-        `YAML frontmatter of this PR's own plan/issues/*.md file. Offending files:\n  ` +
-        remaining.join("\n  "),
-    );
-    process.exit(1);
-  }
+  console.error(
+    `[oracle-ratchet] FAILED (whole-tree) — direct checker usage grew in src/codegen/ (${failures.length} file(s)).\n` +
+      `New code must use ctx.oracle (src/checker/oracle.ts, #1930). If this growth is\n` +
+      `genuinely intentional, add a preauthorized entry with a reason, or migrate the\n` +
+      `site to the oracle. Offending files:\n  ` +
+      failures.join("\n  "),
+  );
+  process.exit(1);
 }
 
 if (updateOnDecrease && decreased) {
@@ -153,4 +286,7 @@ if (updateOnDecrease && decreased) {
 }
 
 const t = totals(current);
-console.log(`[oracle-ratchet] OK — getTypeAtLocation=${t.getTypeAtLocation}, ctx.checker=${t.ctxChecker} (no growth).`);
+console.log(
+  `[oracle-ratchet] OK (whole-tree${auditAll ? " --all" : " — no git base, committed-baseline mode"}) — ` +
+    `getTypeAtLocation=${t.getTypeAtLocation}, ctx.checker=${t.ctxChecker} (no growth).`,
+);


### PR DESCRIPTION
## Problem

The **Oracle ratchet (#1930)** step in the `quality` job
(`scripts/check-oracle-ratchet.mjs`) was WHOLE-TREE: it `walk()`ed all of
`src/codegen/**` and compared each file's direct-TS-checker counts
(`getTypeAtLocation(`, `ctx.checker`) against a frozen snapshot,
`scripts/oracle-ratchet-baseline.json` — a baseline with **no post-merge
auto-refresh** (no workflow runs `check:oracle-ratchet --update`).

That is merge-queue-UNSAFE during the god-file breakdown (memory
`reference_ci_gate_change_scoped_not_wholetree_absolute`): a split PR moves
checker sites out of a god-file into new sibling modules the frozen baseline
never banked, so the whole-tree gate flags them (baseline 0 → tree N). Once one
split lands, every other open split PR that re-merges main inherits the sibling
module and gets flagged for a file it never touched. Three byte-identical
refactor PRs — **#3069** (index.ts), **#3067** (closures.ts), **#3066**
(generators-native.ts) — were bot-parked on exactly this (`quality` failed in
the `merge_group`; Test262 green, no real regression).

## Fix (the #3131 precedent, adapted to a two-field, relocation-heavy metric)

Make the DEFAULT run change-scoped via the shared helper
`scripts/lib/change-scope.mjs` (`resolveChangeBase`, `changedPaths`, `baseBlob`,
`changeSetAllowances`), exactly as `check-coercion-sites.mjs` /
`check-loc-budget.mjs` do (#3131):

- **Judge only the change-set**: for each changed `src/codegen/*.ts` file, count
  the two patterns at the BASE blob vs the WORKING TREE. The committed baseline
  is NOT consulted on this path; PRs must NOT commit changes to it.
- **NET, not per-file** (the key adaptation): fail only when the change-set's
  **per-field net** (Σ over changed, non-allowed files of `now − was`) grows. A
  god-file split relocates existing sites source→new-module, so it is
  net-neutral and passes with **no allowance**; a genuinely new checker call
  with no offsetting removal nets positive and still fails. This matches the
  ratchet's real job — prevent GROWTH of total direct-checker usage under
  `src/codegen/`, not freeze the physical file each site lives in. A sibling
  module inherited via merge is identical at the base and the working tree, so
  it is not in the diff at all → never evaluated.
- **Intentional net growth hatch** off the shared file: `oracle-ratchet-allow:`
  frontmatter list in the PR's own `plan/issues/*.md` (unique file per PR ⇒
  conflict-free), mirroring `loc-budget-allow` / `coercion-sites-allow`.
- **Preserved**: `--update`, `--update-on-decrease`, `--verbose`. **Added**:
  `--all` whole-tree audit + a no-git legacy fallback so the gate never crashes
  a hook outside a git context.
- `ci.yml` `quality` step gains a best-effort `git fetch origin main` before the
  gate (feeds the merge-base fallback), mirroring the loc-budget step;
  `fetch-depth: 2` already exposes the synthetic-merge `HEAD^1`.

Touches only the gate script, the CI step comment/fetch, and the issue file — no
compiler source, no baseline commit.

## Validation (proved BOTH directions, via the actual gate binary)

Measured with the gate's own counting (base blob vs head), the three parked PRs
are **exactly net-zero** on both fields (e.g. #3069: `index.ts` −14 gTAL / −38
ctxChk relocated into `extern-declarations.ts` +14/+37 and `wasi.ts` +0/+1).

| # | Scenario | Expect | Result |
|---|----------|--------|--------|
| A | Edited `src/codegen` file gains a new `ctx.checker.getTypeAtLocation(...)`, no offset | FAIL | **exit 1** — `net getTypeAtLocation +1, ctxChecker +1`, file listed |
| A2 | Same growth, file listed under `oracle-ratchet-allow:` in the issue frontmatter | PASS | **exit 0** — reported as granted |
| B | Verbatim split: delete a source (6 gTAL / 10 ctxChk), distribute into 2 new sibling modules | PASS | **exit 0** — net 0 / 0 |
| B2 | Same split but adds ONE extra genuine site | FAIL | **exit 1** — `net ctxChecker +1` (netting is not a blanket multi-file pass) |
| C | Sibling module present at the BASE, unchanged by the change-set | PASS (default) / FAIL (`--all`) | default **exit 0** (not in diff → not evaluated); `--all` **exit 1** (flags it) |
| D | **Real #3069** tree (all 9 changed files; `index.ts` confirmed identical on main since its base) through the gate binary | PASS (default) / FAIL (`--all`) | default **exit 0** — `net getTypeAtLocation +0, ctx.checker +0`; `--all` **exit 1** — flags the new modules |

D is the exact bot-park reproduction: the change-set that failed the whole-tree
gate in the `merge_group` passes the change-scoped gate (net 0) and would only
have failed the old `--all` path.

Local quality gates green on this PR: `lint`, `format:check`, `typecheck`,
`check:oracle-ratchet`, `check:coercion-sites`, `check:loc-budget`,
`check:issues` — all exit 0.

## Impact

Unblocks the 3 parked Wave-A split PRs (#3069/#3067/#3066) and every future
god-file split, with no per-PR baseline bump and no allowance for net-neutral
relocations. Closes #3273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)