### PR TITLE
refactor(#3279): net-per-vocabulary coercion-sites gate — stop relocation-shift split failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,16 +193,21 @@ jobs:
         # through snapshotSpeculative/rollbackSpeculative instead.
         run: pnpm run check:speculative-rollback
 
-      - name: Coercion-site drift gate (#2108/#3131)
+      - name: Coercion-site drift gate (#2108/#3131/#3279)
         # Fails when the JS-semantic coercion vocabulary (ToString/ToNumber/
         # ToPrimitive/equality/ToBoolean) is hand-rolled at a NEW site outside
         # the coercion engine (see plan/log/analysis-2026-06/03-coercion-engine
-        # -spec.md §5). CHANGE-SCOPED like check:loc-budget (#3131): judged
-        # against this change-set's own base (HEAD^1 of the synthetic merge),
-        # no committed-baseline read, no per-PR baseline bump (bump commits
-        # merge-conflicted with the post-merge refreshes on main). Intentional
-        # migration-step growth: `coercion-sites-allow:` frontmatter in the
-        # PR's own issue file. Fetch feeds the merge-base fallback only.
+        # -spec.md §5). CHANGE-SCOPED like check:loc-budget (#3131) AND
+        # NET-PER-VOCABULARY (#3279, mirroring check:oracle-ratchet #3070/#3273):
+        # judged against this change-set's own base (HEAD^1 of the synthetic
+        # merge); fails only when the change-set's NET count per vocabulary token
+        # (summed over the changed files) grew. A god-file split that relocates
+        # existing coercion sites into a new sibling module is net-neutral and
+        # passes with NO allowance (the #3076 treadmill). No committed-baseline
+        # read, no per-PR baseline bump (bump commits merge-conflicted with the
+        # post-merge refreshes on main). Intentional migration-step growth:
+        # `coercion-sites-allow:` frontmatter in the PR's own issue file. Fetch
+        # feeds the merge-base fallback only.
         run: |
           git fetch --no-tags --depth=200 origin main 2>/dev/null || true
           pnpm run check:coercion-sites

--- a/plan/issues/3279-coercion-sites-net-per-field.md
+++ b/plan/issues/3279-coercion-sites-net-per-field.md
@@ -1,0 +1,114 @@
+---
+id: 3279
+title: "Coercion-site drift gate: net-per-vocabulary — stop relocation-shift failures on god-file splits"
+status: done
+assignee: ttraenkler/senior-dev-coercion
+sprint: current
+created: 2026-07-14
+updated: 2026-07-14
+completed: 2026-07-14
+priority: high
+horizon: m
+feasibility: hard
+model: opus
+reasoning_effort: max
+task_type: refactor
+area: ci
+language_feature: compiler-internals
+goal: maintainability
+related: [2108, 3131, 3070, 3273, 3076, 3102]
+---
+
+# #3279 — Coercion-site drift gate: net-per-vocabulary (like the #3070 oracle-ratchet rework)
+
+## Problem
+
+`scripts/check-coercion-sites.mjs` (the "Coercion-site drift gate #2108/#3131"
+quality step) was change-scoped but **per-file**: for each changed non-sanctioned
+`src/codegen(-linear)` file it compared the file's coercion-vocabulary count at
+the base blob vs the working tree and failed if **any single file's** count grew.
+
+When a **byte-identical god-file split** relocates coercion-vocabulary sites out
+of the source file and into a NEW sibling module, that new file shows `0 → N`
+and the gate FAILED — unless the PR added a per-issue `coercion-sites-allow`
+entry for every new module it created. Every Wave-B split PR kept hitting this
+(e.g. **#3076** relocated `__is_truthy` into a new module and tripped the gate).
+It is a **relocation-shift false-positive treadmill** — exactly the class
+Dev-Gate already fixed for the oracle-ratchet gate in **#3070/#3273**
+(`scripts/check-oracle-ratchet.mjs`).
+
+## Fix
+
+Port the **net-per-field** comparison from `check-oracle-ratchet.mjs` (#3070)
+into `check-coercion-sites.mjs`, keeping the coercion gate's own
+vocabulary-counting logic. Instead of failing on any single changed file's
+increase, the change-scoped path now computes the **NET delta per vocabulary
+token, summed across all changed non-allowed `src/codegen` files** (Σ now − Σ
+was per token) and fails only when some token's net grew:
+
+- A verbatim relocation (new module `+N`, source file `−N`) nets to **0** for
+  every token and **PASSES with NO allowance**.
+- A genuinely-new hand-rolled coercion (a token gains a use with no offsetting
+  removal) nets **> 0** and still **FAILS**.
+
+### Design decision — net PER VOCABULARY TOKEN, not per grand total
+
+The oracle-ratchet template nets **per counted field** (`getTypeAtLocation`,
+`ctx.checker`) so that removing one kind of debt cannot mask adding a different
+kind. The faithful mirror here treats **each of the 17 sealed vocabulary tokens
+as a "field"** and nets each independently. This is both the literal reading of
+"net-per-field (a.k.a. net-per-vocabulary)" and strictly the safer choice:
+
+- **Byte-identical relocations** (the entire Wave-B split pattern, incl. #3076)
+  move every token verbatim, so each token nets 0 → they pass identically under
+  per-token or per-total netting. The lead's goal — "eliminate the recurring
+  relocation failures for all remaining Wave-B split PRs" — is fully met.
+- **Per-token is stricter on the rare token-swap case**: removing a `__is_truthy`
+  while adding a NEW `__any_to_string` in the same change-set is net-0 by grand
+  total but introduces a genuinely-new hand-rolled ToString site. Per-token
+  correctly fails it (the new-kind token nets +1); per-total would mask it. This
+  preserves the gate's stated purpose — "a new hand-rolled site fails CI". A
+  legitimate token-swap migration remains grantable via the existing
+  `coercion-sites-allow` hatch.
+
+### Preserved / added
+
+- The per-issue `coercion-sites-allow:` frontmatter hatch is still honored;
+  allowance-granted files are now **excluded from the net entirely** (they
+  neither fault nor offset), matching the oracle-ratchet semantics.
+- `--update` (post-merge/main writer) and `--update-on-decrease` (banking) are
+  unchanged.
+- The legacy whole-tree comparison against the committed baseline is preserved
+  as the **no-git fallback** and is now also reachable via an explicit **`--all`**
+  whole-tree audit (added for parity with oracle-ratchet's `--all`).
+- The committed baseline is still refreshed post-merge on `main` only; PRs must
+  not commit changes to it.
+
+## Validation
+
+Every direction was exercised end-to-end through the real gate binary against a
+controlled git base (isolated fake repo whose layout mirrors the script's
+`REPO_ROOT`; harness in `.tmp/validate-coercion-gate.sh`):
+
+| Case | Scenario | Expected | Result |
+| ---- | -------- | -------- | ------ |
+| A  | genuinely-new `__any_to_string`, no allowance | FAIL (exit 1) | FAIL ✓ |
+| A2 | same + `coercion-sites-allow` for the file | PASS (exit 0) | PASS ✓ |
+| B  | net-0 relocation (source −3, NEW module +3) — **reproduces #3076** | PASS, no allowance | PASS ✓ |
+| B2 | split that adds ONE extra `__is_truthy` site | FAIL (exit 1) | FAIL ✓ |
+| B3 | net-0 grand total but token-swap (−`__is_truthy`, +`__any_to_string`) | FAIL (exit 1) | FAIL ✓ |
+| C  | no working-tree change | PASS (exit 0) | PASS ✓ |
+
+Also verified: the real gate passes on this PR's own worktree (0 changed
+codegen files → net gate OK), the no-git/legacy fallback still compares against
+the committed baseline, and `--all` performs a whole-tree audit (which surfaces
+pre-existing committed-baseline staleness from already-merged split PRs — the
+very drift the change-scoped net path is immune to; `--all` is opt-in and never
+run in PR CI).
+
+## Impact
+
+Eliminates the recurring coercion-sites relocation failures for all remaining
+Wave-B split PRs. CI's `Coercion-site drift gate` step (`pnpm run
+check:coercion-sites`, default change-scoped mode) is the sole PR invocation and
+now nets per vocabulary token; `--all` is opt-in only.

--- a/scripts/check-coercion-sites.mjs
+++ b/scripts/check-coercion-sites.mjs
@@ -15,18 +15,40 @@
  * baseline down step by step until the count outside the engine is ~0 and the
  * grep becomes a hard seal.
  *
- * CHANGE-SCOPED (#3131, same rework as check-loc-budget.mjs): when a git diff
- * base is resolvable (scripts/lib/change-scope.mjs), the gate counts the
- * vocabulary in each changed file at the BASE blob vs the WORKING TREE and
- * fails only when THIS change-set grew a file's count. The committed baseline
- * (scripts/coercion-sites-baseline.json) is NOT consulted on that path — and
- * PRs must NOT commit changes to it (the per-PR bump merge-conflicted with
- * every post-merge refresh promote-baseline pushes to main — the same churn
- * class as the loc-budget baseline). Intentional growth (a reviewed migration
- * step) is granted per change-set via a `coercion-sites-allow:` frontmatter
- * list (repo-relative src paths) in the PR's own plan/issues/*.md file.
- * The committed baseline remains for the no-git fallback and the writer
- * modes; main's post-merge refresh is its sole writer.
+ * CHANGE-SCOPED + NET-PER-VOCABULARY (#3131 scoping, #3279 net rework mirroring
+ * check-oracle-ratchet.mjs #3070/#3273): when a git diff base is resolvable
+ * (scripts/lib/change-scope.mjs), the DEFAULT run judges ONLY this change-set.
+ * For each changed src/codegen(-linear) file it counts the coercion vocabulary
+ * at the BASE blob vs the WORKING TREE, then fails only when the change-set's
+ * NET (per vocabulary token, summed over the changed non-allowed files) count
+ * GREW. The committed baseline (scripts/coercion-sites-baseline.json) is NOT
+ * consulted on that path — and PRs must NOT commit changes to it (the per-PR
+ * bump merge-conflicted with every post-merge refresh promote-baseline pushes
+ * to main — the same churn class as the loc-budget baseline).
+ *
+ *   NET, not per-file (#3279): a byte-identical god-file split relocates
+ *   existing coercion sites out of the source file (−N) and into a NEW sibling
+ *   module (+N). That is net-neutral — no fresh hand-rolled coercion — so it
+ *   must pass. The old per-file "any file's count grew fails" rule flagged the
+ *   new module (0→N) and forced every Wave-B split PR to declare a
+ *   `coercion-sites-allow` for each module it created — a relocation-shift
+ *   false-positive treadmill that repeatedly failed split PRs (e.g. #3076).
+ *   This is exactly the class Dev-Gate already fixed for the oracle-ratchet
+ *   gate in #3070. Netting per vocabulary token passes verbatim relocations
+ *   (each token's removal from the source cancels its addition in the new
+ *   module) while a genuinely-new hand-rolled coercion (a token gains a use
+ *   with no offsetting removal) nets > 0 and still fails. Netting PER TOKEN
+ *   (rather than per grand total) keeps the gate's anti-drift purpose intact:
+ *   swapping one hand-rolled coercion for a NEW kind (remove __is_truthy, add
+ *   __any_to_string) is not masked by the offsetting removal — the new-kind
+ *   token still nets positive and fails.
+ *
+ * Intentional growth (a reviewed migration step) is granted per change-set via
+ * a `coercion-sites-allow:` frontmatter list (repo-relative src paths) in the
+ * PR's own plan/issues/*.md file; allowance-granted files are excluded from the
+ * net entirely (they neither fault nor offset). The committed baseline remains
+ * for the no-git fallback and the writer modes; main's post-merge refresh is
+ * its sole writer.
  *
  * Mechanism otherwise mirrors the IR-fallback ratchet
  * (scripts/check-ir-fallbacks.ts) and the AnyValue box-site gate
@@ -52,7 +74,8 @@
  * never counted.
  *
  * Usage:
- *   node scripts/check-coercion-sites.mjs                    # fail on growth
+ *   node scripts/check-coercion-sites.mjs                    # change-scoped net gate (default)
+ *   node scripts/check-coercion-sites.mjs --all              # whole-tree audit vs committed baseline
  *   node scripts/check-coercion-sites.mjs --update           # write current counts (post-merge/main only)
  *   node scripts/check-coercion-sites.mjs --update-on-decrease
  *   node scripts/check-coercion-sites.mjs --verbose          # print per-file breakdown
@@ -180,6 +203,7 @@ const args = process.argv.slice(2);
 const update = args.includes("--update");
 const updateOnDecrease = args.includes("--update-on-decrease");
 const verbose = args.includes("--verbose");
+const auditAll = args.includes("--all");
 
 const { totals: current, detail } = countSites();
 
@@ -213,10 +237,15 @@ if (update) {
 }
 
 /**
- * Change-scoped gate (#3131): compare each changed file's vocabulary count at
- * the base blob vs the working tree. Only this change-set's own growth can
- * fail; the committed baseline is not involved. Returns false when the diff
- * cannot be computed (caller falls back to the legacy baseline comparison).
+ * Change-scoped gate (#3131 scoping, #3279 net rework mirroring
+ * check-oracle-ratchet.mjs #3070/#3273): for each changed src/codegen file,
+ * count the coercion vocabulary at the base blob vs the working tree, then fail
+ * only when the change-set's NET (per vocabulary token, summed over the changed
+ * non-allowed files) count grew. Only THIS change-set is judged; the committed
+ * baseline is not involved. A byte-identical relocation nets to 0 per token →
+ * pass; a genuinely-new hand-rolled coercion nets > 0 → fail. Returns false
+ * when the diff cannot be computed (caller falls back to the legacy whole-tree
+ * baseline comparison).
  */
 function gateScoped() {
   const { base, how } = resolveChangeBase(REPO_ROOT);
@@ -228,37 +257,56 @@ function gateScoped() {
     .sort();
   const allow = changeSetAllowances(REPO_ROOT, base, "coercion-sites-allow");
 
-  const grown = [];
+  // Per-token net delta across the change-set, EXCLUDING allowance-granted
+  // files (their intentional growth is sanctioned, so it neither faults nor
+  // counts toward the net). A verbatim relocation nets to 0 for every token →
+  // pass; a new hand-rolled coercion with no offsetting removal nets > 0 for
+  // that token → fail.
+  const net = {}; // token -> net delta summed over non-allowed changed files
+  const increases = []; // non-allowed files that grew some token (for the report)
   const granted = [];
+
   for (const p of changed) {
     const key = p.slice("src/".length); // baseline/report keys are src-relative
-    const now = current[key] ?? 0; // deleted file → 0
+    const nowTokens = detail[`${key}::tokens`] || {}; // deleted / dropped-to-zero → {}
     const blob = baseBlob(REPO_ROOT, base, p);
-    const was = blob === undefined ? 0 : countText(blob);
-    if (now <= was) continue;
-    if (allow.has(p)) {
-      granted.push(`  ${key}: ${was} → ${now} granted by ${allow.get(p).join(", ")}`);
-      continue;
-    }
-    const nowTokens = detail[`${key}::tokens`] || {};
     const wasTokens = blob === undefined ? {} : countTokens(blob);
-    const grewTokens = Object.keys(nowTokens)
-      .filter((t) => (nowTokens[t] ?? 0) > (wasTokens[t] ?? 0))
-      .map((t) => `${t} ${wasTokens[t] ?? 0}→${nowTokens[t]}`)
-      .join(", ");
-    grown.push(`  ${key}: ${was} → ${now}${grewTokens ? ` (${grewTokens})` : ""}`);
+    const nowTotal = current[key] ?? 0;
+    const wasTotal = blob === undefined ? 0 : countText(blob);
+    const grewTokens = VOCAB.filter((t) => (nowTokens[t] ?? 0) > (wasTokens[t] ?? 0));
+
+    if (allow.has(p)) {
+      if (grewTokens.length > 0) {
+        granted.push(`  ${key}: ${wasTotal} → ${nowTotal} granted by ${allow.get(p).join(", ")}`);
+      }
+      continue; // sanctioned — excluded from the net
+    }
+
+    for (const t of VOCAB) net[t] = (net[t] ?? 0) + ((nowTokens[t] ?? 0) - (wasTokens[t] ?? 0));
+
+    if (grewTokens.length > 0) {
+      const detailStr = grewTokens.map((t) => `${t} ${wasTokens[t] ?? 0}→${nowTokens[t] ?? 0}`).join(", ");
+      increases.push(`  ${key}: ${wasTotal} → ${nowTotal} (${detailStr})`);
+    }
   }
 
   if (granted.length > 0) {
     console.log("coercion-sites: intentional growth allowed by this change-set's issue file:\n" + granted.join("\n"));
   }
 
-  if (grown.length > 0) {
-    console.error("coercion-sites gate FAILED — new hand-rolled coercion vocabulary outside the engine:");
-    console.error(grown.join("\n"));
+  const grownTokens = VOCAB.filter((t) => (net[t] ?? 0) > 0);
+  if (grownTokens.length > 0) {
     console.error(
-      "\nRoute the coercion through the single coercion engine (#1917 / #2108).\n" +
-        "Do NOT hand-roll a fresh ToString/ToNumber/ToPrimitive/equality matrix.\n" +
+      "coercion-sites gate FAILED — this change-set ADDS hand-rolled coercion vocabulary on net " +
+        `(${grownTokens.map((t) => `${t} +${net[t]}`).join(", ")}).`,
+    );
+    console.error("Files whose coercion vocabulary increased:");
+    console.error(increases.join("\n"));
+    console.error(
+      "\nMoving existing coercion sites between files is net-neutral and passes;\n" +
+        "this change-set grows the total. Route the coercion through the single\n" +
+        "coercion engine (#1917 / #2108). Do NOT hand-roll a fresh\n" +
+        "ToString/ToNumber/ToPrimitive/equality matrix.\n" +
         "See plan/log/analysis-2026-06/03-coercion-engine-spec.md §5.\n" +
         "If this growth is an intentional, reviewed migration step, grant THIS\n" +
         "change-set an allowance: list the repo-relative path(s) under a\n" +
@@ -272,19 +320,28 @@ function gateScoped() {
     process.exit(1);
   }
 
+  const netSummary = VOCAB.filter((t) => (net[t] ?? 0) !== 0)
+    .map((t) => `${t} ${net[t] > 0 ? "+" : ""}${net[t]}`)
+    .join(", ");
   console.log(
-    `coercion-sites gate: OK (no unallowed growth in ${changed.length} changed codegen file(s); base: ${how}).`,
+    `coercion-sites gate: OK (no net vocabulary growth across ${changed.length} changed codegen file(s)` +
+      `${netSummary ? `; net ${netSummary}` : ""}; base: ${how}).`,
   );
   return true;
 }
 
-if (!updateOnDecrease && gateScoped()) {
+// Default path: change-scoped net gate. --update-on-decrease and --all fall
+// through to the legacy whole-tree comparison (the former is a writer/banking
+// mode, the latter an explicit whole-tree audit).
+if (!updateOnDecrease && !auditAll && gateScoped()) {
   process.exit(0);
 }
 
-// Legacy whole-tree comparison against the committed baseline — used when no
-// git base is resolvable, and by --update-on-decrease (a writer mode: the
-// post-merge refresh / local banking; PRs must not commit the result, #3131).
+// Legacy whole-tree comparison against the committed baseline — used by --all
+// (an explicit whole-tree audit), by --update-on-decrease (a writer mode: the
+// post-merge refresh / local banking; PRs must not commit the result, #3131),
+// and as the no-git fallback so the gate never crashes a hook outside a git
+// context.
 let baseline = {};
 try {
   baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf-8"));
@@ -325,4 +382,6 @@ if (shrank.length > 0) {
   }
 }
 
-console.log("coercion-sites gate: OK (no unsanctioned growth vs. baseline).");
+console.log(
+  `coercion-sites gate: OK (whole-tree${auditAll ? " --all" : " — no git base, committed-baseline mode"}) — no unsanctioned growth vs. baseline.`,
+);


### PR DESCRIPTION
## Problem

`scripts/check-coercion-sites.mjs` (the **Coercion-site drift gate #2108/#3131** quality step) was change-scoped but **per-file**: when a byte-identical god-file split relocated coercion-vocabulary sites into a NEW sibling module, that new file showed `0 → N` and the gate FAILED unless the PR added a per-issue `coercion-sites-allow` for the new module. Every Wave-B split PR kept hitting this (e.g. **#3076** relocated `__is_truthy` into a new module and tripped it). It's a relocation-shift false-positive treadmill — exactly the class Dev-Gate already fixed for the oracle-ratchet gate in **#3070/#3273**.

## Fix

Port the **net-per-field** comparison from `check-oracle-ratchet.mjs` (#3070) into `check-coercion-sites.mjs`, keeping its own vocabulary-counting logic. The change-scoped path now computes the **NET delta per vocabulary token, summed across all changed non-allowed `src/codegen` files**, and fails only when some token's net grew:

- A verbatim relocation (new module `+N`, source `−N`) nets to **0** per token → **PASSES with NO allowance**.
- A genuinely-new hand-rolled coercion nets **> 0** → still **FAILS**.

**Design decision — net PER VOCABULARY TOKEN, not per grand total.** Each of the 17 sealed tokens is treated as a "field" (the faithful mirror of oracle-ratchet's per-field netting). Byte-identical relocations (the entire Wave-B pattern) move every token verbatim → net 0 → pass either way, so the goal is fully met. Per-token is additionally *stricter* on the rare token-swap case (remove `__is_truthy`, add a new `__any_to_string` in one change-set: net-0 by grand total but a genuinely-new ToString site) — it correctly fails, preserving the gate's "a new hand-rolled site fails CI" purpose. Legitimate token-swap migrations remain grantable via the `coercion-sites-allow` hatch.

### Preserved / added
- `coercion-sites-allow:` frontmatter hatch still honored; allowance-granted files now **excluded from the net** (neither fault nor offset), matching oracle-ratchet.
- `--update`, `--update-on-decrease`, and the no-git legacy fallback unchanged.
- Added **`--all`** whole-tree audit for parity with oracle-ratchet's `--all`.
- CI runs only the default change-scoped mode (`pnpm run check:coercion-sites`); `--all` is opt-in.

## Validation (end-to-end through the gate binary, controlled git base)

| Case | Scenario | Expected | Result |
| ---- | -------- | -------- | ------ |
| A  | genuinely-new `__any_to_string`, no allowance | FAIL | FAIL ✓ |
| A2 | same + `coercion-sites-allow` | PASS | PASS ✓ |
| B  | net-0 relocation (source −3, NEW module +3) — **reproduces #3076** | PASS, no allowance | PASS ✓ |
| B2 | split that adds ONE extra `__is_truthy` site | FAIL | FAIL ✓ |
| B3 | net-0 grand total but token-swap | FAIL | FAIL ✓ |
| C  | no change | PASS | PASS ✓ |

Also verified: the real gate passes on this PR's own worktree (0 changed codegen files → net OK), the no-git/legacy fallback still compares against the committed baseline, and `--all` performs a whole-tree audit.

Closes #3279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)