### PR TITLE
docs(#3032): correct W3 route + TDZ blocker; fix #2040 A1-unblock map

### DIFF
--- a/plan/issues/2040-standalone-generator-dstr-runtime-semantics.md
+++ b/plan/issues/2040-standalone-generator-dstr-runtime-semantics.md
@@ -704,3 +704,44 @@ iter-hof-native.ts).
 - The old acceptance criteria above are superseded: acceptance is now
   per-slice (the four assertion-family counts → ~0) + dstr standalone fail
   count ≤ 1,800 after slices 1-4.
+
+## A1-unblock map — CORRECTED (sendev-3032, 2026-07-14) — supersedes the "BLOCKED on #2580 M2 / #3032 / #3053" cell above
+
+The 2026-07-12 re-ground lists A1 (382 rows, the headline) as "BLOCKED on
+#2580 M2 / #3032 / #3053". Verified against `origin/main @ f1c9069`, that
+three-way blocker is **inaccurate**. The corrected map (each verified, not
+narrative):
+
+- **#3053 (unified carrier) — LANDED-but-VACUOUS, NOT a near-term A1 lever.**
+  U0/U1/U2 (`__dyn_member_get`/`ensureDynMemberGet`/`usesDynMemberGet`/the
+  `select.ts` scan) are all ON `origin/main` (fork branches merged; u0/u2 =0
+  commits ahead, u1 =+1 baseline-file merge). But #3053's own "U2 LANDED"
+  section proves it is corpus-VACUOUS: byte-inert (`prove-emit-identity`
+  39/39), claim-delta ~0, because property-access alone never claims the
+  `_isSameValue`/reduce comparator (it needs eq + relational + truthiness +
+  dynamic-arithmetic forms). The identity payoff (U3 #3037 CS3 / U4 #2175
+  V2-S3b) is OWNED by those issues and only materialises once #2949's
+  claim-rate forms land. So #3053 does NOT unblock A1 in the near term.
+- **#2580 M2 — value-rep rabbit hole, DEFER (not the A1 blocker).** 2388-line
+  diagnosis; M1a ejected (−13/13 regr), M2.2c WONT-FIX, most of it deferred to
+  the value-rep substrate (#35). Not a tractable near-term A1 lever; remove it
+  from the A1 blocker set.
+- **#3032 (lazy-first generators) — THE actual A1 lever.** #3032's root cause
+  (fully verified) is that the −162 classifier eject "was never a dstr/eq
+  dependency — it was eager generator bodies + comparator vacuity". Making
+  eager generators lazy turns the classifier-unmasked vacuous passes into
+  GENUINE passes, which is exactly what makes the flag-gated 3-way tag-5
+  classifier flip floor-safe. Slice 1 (zero-param generator EXPRESSIONS)
+  landed. The residual dominant standalone shape is **nested capturing NAMED
+  generators** (`function* g(){...}` inside the `export function test()`
+  wrapper) — they run their whole body AT CREATION (probe returns 202 not 1)
+  via `nested-declarations.ts`'s has-captures eager-buffer arm. See #3032 for
+  the corrected route + the TDZ-flag-capture native-threading extension that
+  the fix requires (the arch spec's function-body.ts:1052 / route-(a-i)
+  pointers are stale — verified 2026-07-14).
+
+**Net:** A1's classifier flip is gated primarily on **#3032**'s remaining
+generator-laziness work (specifically the TDZ-flag-capture native-threading
+extension), NOT on #2580 M2 or #3053. Keep the tag-5 3-way classifier flag
+gated OFF until #3032's standalone generator-laziness clears the merge_group
+floor under `JS2WASM_TAG5_CLASSIFIER=1`.

--- a/plan/issues/3032-lazy-generator-expression-thunks.md
+++ b/plan/issues/3032-lazy-generator-expression-thunks.md
@@ -1,19 +1,21 @@
 ---
 id: 3032
 title: "Lazy-first-resume generator thunks: stop running eager-buffer generator bodies at creation (unblocks #2141 S3 / #2626 classifier)"
-status: in-progress
-assignee: ttraenkler/fable-tag5
+status: ready
+assignee:
 sprint: current
 created: 2026-07-04
 priority: high
 feasibility: hard
 reasoning_effort: max
+horizon: xl
 task_type: bugfix
 area: codegen, runtime, generators, value-rep
 language_feature: generators, destructuring defaults, equality
 goal: test262-conformance
-related: [2141, 2626, 2040, 2585, 928, 2203, 991]
+related: [2141, 2626, 2040, 2585, 928, 2203, 991, 3050]
 origin: "2026-07-04 #2141 S2 root-cause (fable-tag5): the −162 dstr eject was never a dstr/eq dependency — it was eager generator bodies + comparator vacuity"
+note: "FRESH-WINDOW BIG ROCK (sendev-3032, 2026-07-14): the remaining W3 work is threading TDZ-flag capture boxes through the native generator state machine (~4-6 tightly-coupled offset sites in generators-native.ts + nested-declarations.ts; merge_group-only validation; HIGH floor-risk). Slot at a budget-window START, NOT a tail — a partial window guarantees a stranded half-done native-generator change. See '## W3 — CORRECTED ROUTE + THE REAL BLOCKER'. Slice 1 (zero-param gen expressions) already LANDED; this issue is NOT done."
 ---
 
 # #3032 — eager-buffer generators run their body AT CREATION; the tag-5 comparator vacuity is the only thing hiding it
@@ -246,3 +248,93 @@ call). Not a pure wrap — do after W3.
 - gc/host lane: no regression on the generator suites
   (`gen-func-expr-args-trailing-comma-*`, `iter-val-array-prototype` — the
   two PR-#2625 regression buckets must stay green).
+
+## W3 — CORRECTED ROUTE + THE REAL BLOCKER (sendev-3032, 2026-07-14, empirically verified against `origin/main @ f1c9069`)
+
+The 2026-07-12 Implementation Plan above is **materially wrong about the
+code** — do not follow its file anchors. Corrected, all verified by probe +
+source trace:
+
+### 1. The plan's anchors are stale
+
+- The plan asserts "**There is no `nested-declarations.ts`** — the W3 note's
+  pointer is stale; the eager path for nested named generators is the
+  function-body.ts arm." **FALSE.** `src/codegen/statements/nested-declarations.ts`
+  exists (2726 lines) and IS the target. `function-body.ts` :1041-1128 is the
+  path for **top-level** generator declarations, and in standalone/wasi its
+  non-native arm `reportError`s — it is NOT where nested capturing generators
+  land.
+- A **capturing** nested named generator (`function* g(){...}` inside
+  `export function test()`) routes through `compileNestedFunctionDeclaration`
+  → the **has-captures branch** (`nested-declarations.ts` ~:771), whose
+  generator arm is an **eager-buffer** (`__gen_create_buffer` +
+  `__create_generator`, ~:990) that runs the WHOLE body at creation. Probe
+  (`function* g(){ iterations+=1; yield 1; iterations+=1 }`, read `iterations`
+  before the first `next()`): returns **202, must be 1** — on BOTH host AND
+  standalone. That is the §27.5 violation / eager-generator vacuity.
+- The has-captures path is **direct-call-with-leading-capture-params**
+  (`ctx.nestedFuncCaptures`), NOT a closure struct. So the plan's route (a-i)
+  "route through `compileArrowAsClosure`'s generator branch" and the
+  `__create_generator(<self>, null)` thunk model **do not apply** here — there
+  is no `__self` closure to hand as a thunk.
+
+### 2. The genuinely-lazy fix + the exact blocker
+
+The right mechanism already exists: **#3050's `capturingNativeGen`** — the
+native generator state machine with captures riding as leading synthetic
+params. Native generators suspend at start (lazy by construction), so they fix
+202→1 for free, host-free, in both modes. Two gates block the dominant shape:
+
+- `nested-declarations.ts` ~:817-823 requires `bodyHasNewTryRegionAcrossYield(stmt)`.
+  Relaxing that for the standalone lane (`ctx.standalone || ctx.wasi`) is
+  **safe** and lets non-try-region native-candidate capturing generators go
+  native. Host lane stays byte-identical: `isNativeGeneratorCandidate`
+  (`generators-native.ts` :1637-1665) internally still requires a try-region
+  under a JS host, so a non-try-region capturing generator keeps the host
+  eager path there. **Verified:** with the relaxation, standalone
+  `candidate=true`, host `candidate=false` (clean split).
+- **THE REAL BLOCKER:** the same gate also requires
+  `tdzFlaggedCaptures.length === 0`. The dominant shape captures `let`/`const`
+  bindings, which are **TDZ-flagged** (`hasTdzFlag`), so the relaxation is
+  **corpus-vacuous** for the real population. #3050 gated `=== 0` because the
+  native state-struct param model + resume function **do not thread TDZ flag
+  boxes** ("flag-box plumbing not modeled in the resume fn — a separate,
+  larger change, reasoning_effort:max", `nested-declarations.ts` :810).
+
+### 3. Concrete implementation plan for the TDZ-native-threading extension (next session, a FULL fresh window)
+
+The value-capture machinery (#3050) is the template; TDZ flag boxes are
+structurally identical `ref $cell`-of-i32 params. Thread them the same way:
+
+1. `nested-declarations.ts` has-captures gate: replace `tdzFlaggedCaptures.length === 0`
+   with a standalone-lane arm that INCLUDES the tdz flags, and pass them to
+   `registerNativeGenerator` (a new `leadingTdzFlags?: {name, refCellTypeIdx}[]`
+   arg, or extend `leadingCaptures`). Note `allParamTypes` already =
+   `[valueCaps, tdzFlags, userParams]` (:798-799) — the fix must make
+   `paramNames`/`leadingCaptureCount` agree with that ordering.
+2. `registerNativeGenerator` (`generators-native.ts` :1962): insert the tdz
+   flag names into `paramNames` between `captureNames` and `userParamNames`
+   (so `param_*` state fields exist + align with `allParamTypes`), and carry a
+   `leadingTdzFlagCells` list on `NativeGeneratorInfo`.
+3. Resume function (`generators-native.ts` ~:3300-3345): after the value-capture
+   `boxedCaptures` registration (:3314), register each tdz flag box in
+   `resumeFctx.boxedTdzFlags` + `tdzFlagLocals` (map name → {refCellTypeIdx,
+   localIdx of its `param_*` local}). Update `thisOffset`/`leadingCaptureCount`
+   (:3343) to include the tdz flag count so pattern-param offsets stay correct.
+4. Confirm the TDZ-checked identifier reads inside the body
+   (`emitLocalTdzCheck`, expressions/identifiers.ts) resolve through
+   `resumeFctx.boxedTdzFlags` (they only do `local.get flagBox; struct.get`, so
+   a param-slot flag box works — same as the lifted-closure path at
+   `nested-declarations.ts` :937-950).
+
+**Validation:** probes must show V1 (lazy: `iterations` before `next()` == 0,
+return 1) and V2 (drain a capturing generator: correct values) green on host
+AND standalone; the #3050 try-region tests + a no-capture control stay
+byte-identical; **merge_group standalone-floor is the decider** (broad-impact,
+native-generator internals — do NOT trust scoped CI). Host lane must be
+byte-identical (`prove-emit-identity`) — the standalone-only gate arm
+guarantees it.
+
+**Risk:** HIGH-floor, native-generator machinery, ~4-6 tightly-coupled offset
+sites; a subtle `param_*`/offset misalignment only surfaces in merge_group.
+Budget it as a full fresh window, not a tail slice.


### PR DESCRIPTION
## What

Docs-only knowledge correction from a verify-first triage of the #2040 A1 substrate track (senior-dev). No code change.

### #3032 — corrected W3 route + the real blocker
The 2026-07-12 arch spec's file anchors are **wrong** (verified against `origin/main @ f1c9069` + probes):
- A **capturing** nested named generator (`function* g(){}` inside `export function test()`) routes through `src/codegen/statements/nested-declarations.ts` **has-captures branch** (~:990), a **direct-call-with-leading-cap-params** model (`nestedFuncCaptures`) — **NOT** `function-body.ts:1052`, **not** a closure struct, **not** `compileArrowAsClosure`. The spec's "there is no nested-declarations.ts" claim is false.
- Probe: the body runs entirely **at creation** (returns 202, must be 1) on host AND standalone — the eager-generator vacuity.
- The genuinely-lazy fix is #3050's `capturingNativeGen` (native state machine, lazy by construction), blocked by the `tdzFlaggedCaptures.length === 0` gate — `let`/`const` captures (the dominant shape) are TDZ-flagged. Documented the **TDZ-flag native-threading extension** (~4-6 tightly-coupled offset sites; merge_group-only validation; HIGH floor-risk) as an **XL fresh-window big rock**.
- Re-dispositioned: `status: ready`, `horizon: xl`, cleared the stale `assignee`, added a fresh-window note.

### #2040 — corrected A1-unblock map
The 2026-07-12 re-ground lists A1 as "BLOCKED on #2580 M2 / #3032 / #3053". Corrected:
- **#3053** — carrier substrate **already landed** on main but **corpus-vacuous**; U3/U4 owned by #3037 CS3 + #2175 V2-S3b. Not a near-term A1 lever.
- **#2580 M2** — value-rep rabbit hole, **deferred**; not the A1 blocker.
- **#3032** — eager-gen-vacuity removal is **the actual classifier-flip lever**, but its residual work is the XL TDZ-native-threading change above.
- Sequence to A1: **#3032 TDZ threading → #2949 claim-rate forms → the tag-5 classifier flip**. Classifier flag stays gated OFF.

## Why docs-only
The real W3 fix is a full-window, floor-sensitive native-generator change (merge_group-only validation). Landing a half-done version in a ~6% budget tail would strand it, so this PR banks the verified findings + implementation plan. The corpus-vacuous gate relaxation is intentionally dropped.

## Test plan
Docs-only (`plan/issues/*.md`); no source, no test, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)