### PR TITLE
fix(#3284): RC2 — top-level Promise.then callback fires (deferToExports in callback_maker)

### DIFF
--- a/plan/issues/3284-compiler-compatibility-with-original-test262-harness.md
+++ b/plan/issues/3284-compiler-compatibility-with-original-test262-harness.md
@@ -14,6 +14,13 @@ area: codegen, runtime
 language_feature: promises, prototype-methods
 goal: test262-conformance
 related: [3285]
+# Intentional +20 LOC in the host import-resolver: the RC2 `deferToExports`
+# guard added to the `callback_maker` case of `resolveImport` mirrors the
+# adjacent `getter_callback_maker` (#2128) host-glue bridge — extracting 20
+# host-local lines into a subsystem module would balloon a deliberately-minimal
+# bugfix. Grants THIS change-set the god-file growth (#3131).
+loc-budget-allow:
+  - src/runtime.ts
 ---
 
 > **2026-07-15 — root cause DIAGNOSED. RC2 FIXED; RC1 fix DEFERRED to a next window (senior-dev).**

--- a/plan/issues/3284-compiler-compatibility-with-original-test262-harness.md
+++ b/plan/issues/3284-compiler-compatibility-with-original-test262-harness.md
@@ -16,7 +16,7 @@ goal: test262-conformance
 related: [3285]
 ---
 
-> **2026-07-15 — root cause DIAGNOSED, fix DEFERRED to a next window (senior-dev).**
+> **2026-07-15 — root cause DIAGNOSED. RC2 FIXED; RC1 fix DEFERRED to a next window (senior-dev).**
 > The verify-first trace (below, `## Diagnosis (2026-07-15)`) refuted the original
 > hypothesis: this is NOT a call-target type-inference bug. **Both** RC1 and RC2
 > collapse to a single root cause — top-level code runs in the wasm `(start)`
@@ -24,9 +24,16 @@ related: [3285]
 > can wire `setExports(instance.exports)`; the host closure-wrap/dispatch glue
 > then has no exports to work with. Standalone mode already dispatches RC1
 > natively and is unaffected (it is the reference implementation for the fix).
-> The real fix is broad-impact host-mode codegen (option A below), validatable
-> only on `merge_group` — too large for the 4% budget tail it was found in, so it
-> is banked here as a next-window **big-rock** (horizon xl). Do NOT attempt the
+>
+> **RC2 (`Promise.then`) is FIXED** by the small, additive `deferToExports`
+> change in the `callback_maker` host bridge (`src/runtime.ts`) — a top-level
+> `.then` callback whose microtask drains before `setExports` is now parked and
+> replayed the moment the instance is wired (mirrors the #2128 setter fix). See
+> the RC2 sub-fix note in `## Diagnosis`.
+>
+> **RC1 remains a next-window big-rock.** Its real fix is broad-impact host-mode
+> codegen (option A below), validatable only on `merge_group` — too large for the
+> budget tail it was found in, so it is banked here (horizon xl). Do NOT attempt the
 > `deferTopLevelInit`/init-contract route (option B) — it breaks the very
 > external raw-`(start)` harness this issue is about.
 
@@ -249,20 +256,31 @@ runs `assert.js` etc. as real top-level code → `(start)` → the bug.
   bridge?" question is answered: yes, it reaches `src/runtime.ts`'s
   `Promise_then`). The callback is wrapped via
   `_maybeWrapCallable(cb, arity, callbackState)`.
-- Same root cause: `.then(cb)` is top-level → `(start)` → `getExports()`
-  undefined → the callback can't be wrapped into a working JS-callable, so the
-  native `Promise`'s microtask fires a dead callback (nothing prints).
-- **Same code inside a post-`setExports` `test()` fires the callback** ("in
-  then" prints) — confirming identical exports-timing root cause.
-- **Important nuance that makes RC2 narrower than RC1:** the `.then` callback is
-  **asynchronous** — it fires on the host microtask queue _after_ `(start)`
-  returns and control is back in the host, by which time `setExports` HAS run.
-  So RC2 is fixable with a **lazy/deferred wrap in the Promise bridge**
-  (`__make_callback` / `Promise_then` should resolve the closure→JS-callable at
-  **fire time**, not eagerly at `(start)` time). This is the tech-lead's
-  "lazy-wrap-at-call" idea — it does NOT work for RC1 (that call is synchronous,
-  in `(start)`), but it DOES work for RC2 (async, post-`setExports`). RC2 could
-  land as a much smaller, host-glue-local PR independent of RC1.
+- Exact lowering: `.then(cb)` compiles to `__make_callback(cbId, caps)` (a
+  `callback_maker` host bridge that returns a JS function dispatching
+  `exports.__cb_<id>`), which is passed to `Promise_then`. The
+  `callback_maker` bridge ALREADY resolves `getExports()` lazily at fire time —
+  so a naive "lazy wrap" is already in place and is NOT enough.
+- **Precise timing (the subtlety):** the `.then` microtask does NOT wait until
+  `setExports`. It drains while the async instantiate helper is still
+  `await`-ing `WebAssembly.instantiate(...)` — i.e. AFTER `(start)` returns but
+  BEFORE the caller's `setExports` line. So at fire time `getExports()` is STILL
+  `undefined`, `exports.__cb_<id>` is missing, and the callback silently
+  no-ops. Confirmed by tracing `exportsWired=false` at the `__cb` fire, printed
+  before the driver's post-`setExports` marker.
+- **FIX (landed in this issue's RC2 PR):** when the `callback_maker` callback
+  fires with exports not yet wired, **park it via `deferToExports`** and replay
+  it the instant `setExports` wires the instance — the exact #2128 mechanism
+  used for `getter_callback_maker` setters. Additive: a callback whose reaction
+  fires AFTER `setExports` (every `wrapTest`/equivalence body runs inside an
+  exported function the host calls post-wiring) never hits the new branch, so no
+  harness-executed callback changes. Verified: RC2 repro + top-level `async fn`
+  `.then` both fire; 83 async/promise equivalence tests still green. (Baseline
+  check: `new Promise(exec).then()` and chained `.then` producing data were
+  ALREADY broken at top-level on main — not regressions; the deferred replay
+  fires the callbacks, though a value-carrying top-level `.then` chain can still
+  deliver a wrong chained value pre-wiring — an acceptable strict improvement
+  over "silent", and never hit by the post-`setExports` harness path.)
 
 ### Fix options
 
@@ -287,8 +305,9 @@ runs `assert.js` etc. as real top-level code → `(start)` → the bug.
   host can invoke closures without `getExports()`. Keeps `(start)` for all
   modes, but relies on funcref→JS-callable exposure and adds a new import +
   codegen + host-glue; broad-impact, unvalidated. Only if (A) proves infeasible.
-- **RC2 sub-fix (independent, smaller):** deferred/lazy callback wrap in the
-  Promise bridge (see RC2 nuance above). Host-glue-local; can land separately.
+- **RC2 sub-fix — DONE.** `deferToExports` park-and-replay in the
+  `callback_maker` host bridge (`src/runtime.ts`); host-glue-local, additive,
+  landed independently of RC1. Test: `tests/issue-3284-rc2.test.ts`.
 
 ### Reproduce (drop into a `.tmp/` driver)
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13411,6 +13411,26 @@ assert._isSameValue = isSameValue;
       return (id: number, cap: any) =>
         (...args: any[]) => {
           const exports = callbackState?.getExports();
+          // (#3284) A callback whose reaction fires DURING WebAssembly.instantiate
+          // — e.g. a top-level `Promise.resolve(x).then(cb)` whose microtask
+          // drains while the async instantiate helper is still awaiting, BEFORE
+          // the caller wires `setExports` — sees `getExports()` undefined and
+          // would otherwise silently no-op (the `.then` callback never runs).
+          // Park it and replay the moment setExports wires the instance, mirroring
+          // the #2128 `getter_callback_maker` setter fix. Purely additive: when
+          // exports are already wired (the normal post-instantiation path, incl.
+          // every wrapTest/equivalence body that runs inside an exported function
+          // the host calls AFTER setExports), the branch is skipped and behaviour
+          // below is unchanged — so no harness-executed callback is affected.
+          if (exports === undefined && callbackState) {
+            const defer = (callbackState as { deferToExports?: (fn: () => void) => void }).deferToExports;
+            if (defer) {
+              defer(() => {
+                callbackState.getExports()?.[`__cb_${id}`]?.(cap, ...args);
+              });
+              return undefined;
+            }
+          }
           return exports?.[`__cb_${id}`]?.(cap, ...args);
         };
     case "getter_callback_maker":

--- a/tests/issue-3284-rc2.test.ts
+++ b/tests/issue-3284-rc2.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { instantiateWasm } from "../src/runtime-instantiate.js";
+
+// #3284 RC2 — a top-level `Promise.resolve(x).then(cb)` callback must fire.
+//
+// ROOT CAUSE (see plan/issues/3284-...md, `## Diagnosis`): the `.then` reaction
+// is scheduled during the wasm `(start)` section. Its microtask then drains
+// while the async instantiate helper is still `await`-ing `WebAssembly.instantiate`
+// — BEFORE the caller wires `setExports`. The `callback_maker` host bridge
+// (`__make_callback` → `exports.__cb_<id>`) resolves exports lazily at fire time,
+// but at that instant `getExports()` is still undefined, so the callback
+// silently no-ops and never runs.
+//
+// FIX: when the callback fires with exports not yet wired, park it via
+// `deferToExports` and replay it the moment `setExports` wires the instance —
+// the same #2128 mechanism used for `getter_callback_maker` setters. This is
+// additive: callbacks whose reactions fire AFTER `setExports` (every wrapTest /
+// equivalence body runs inside an exported function the host calls post-wiring)
+// never hit the new branch.
+
+/** Run a program's top-level code (which executes in the wasm `(start)` section),
+ *  wire setExports afterward (as every real host does), then drain microtasks. */
+async function runTopLevelCapturingLog(source: string): Promise<string[]> {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (...a: unknown[]) => {
+    logs.push(a.map(String).join(" "));
+  };
+  try {
+    const result = await compile(source, { fileName: "test.ts", target: "gc" });
+    if (!result.success) {
+      throw new Error(`Compile failed:\n${result.errors.map((e) => e.message).join("\n")}`);
+    }
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await instantiateWasm(
+      new Uint8Array(result.binary),
+      imports.env,
+      imports.string_constants,
+      imports.string_constants16,
+    );
+    // The `.then` microtask has already drained (unfired) by the time
+    // instantiateWasm resolves; setExports replays the parked callback.
+    if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+    // Let any remaining microtasks settle.
+    await Promise.resolve();
+    await Promise.resolve();
+  } finally {
+    console.log = orig;
+  }
+  return logs;
+}
+
+describe("Issue #3284 RC2: top-level Promise.then callback fires", () => {
+  it("runs a top-level `Promise.resolve(42).then(cb)` callback", async () => {
+    const src = `
+      console.log('before promise');
+      Promise.resolve(42).then(function (v) {
+        console.log('in then, v=', v);
+      });
+      console.log('after promise setup');
+    `;
+    const logs = await runTopLevelCapturingLog(src);
+    // The callback fired (was: never fired) — regardless of multi-arg formatting.
+    expect(logs.some((l) => l.includes("in then, v="))).toBe(true);
+    expect(logs.some((l) => l.includes("42"))).toBe(true);
+    // The synchronous top-level lines still print, in order, before the callback.
+    expect(logs.some((l) => l.includes("before promise"))).toBe(true);
+    expect(logs.some((l) => l.includes("after promise setup"))).toBe(true);
+  });
+
+  it("runs a top-level async function's `.then` continuation", async () => {
+    const src = `
+      async function f() { return 7; }
+      f().then(function (v) { console.log('async result', v); });
+    `;
+    const logs = await runTopLevelCapturingLog(src);
+    expect(logs.some((l) => l.includes("async result"))).toBe(true);
+    expect(logs.some((l) => l.includes("7"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes RC2 of #3284: a top-level `Promise.resolve(x).then(cb)` callback never fired. Small, additive, host-glue-local change to the `callback_maker` bridge in `src/runtime.ts`. RC1 remains a next-window big-rock (see #3102's diagnosis in the issue file).

## Root cause

`.then(cb)` lowers to `__make_callback(cbId, caps)` (a `callback_maker` returning a JS fn that dispatches `exports.__cb_<id>`) passed to `Promise_then`. The `.then` reaction is scheduled in the wasm `(start)` section. Its microtask then **drains while the async instantiate helper is still awaiting `WebAssembly.instantiate(...)` — after `(start)` returns but BEFORE the caller wires `setExports`**. The bridge already resolves `getExports()` lazily at fire time, but at that instant exports are still `undefined`, so `exports.__cb_<id>` is missing and the callback silently no-ops.

Traced `exportsWired=false` at the `__cb` fire, printed before the driver's post-`setExports` marker.

## Fix

When a `callback_maker` callback fires with exports not yet wired, **park it via `deferToExports` and replay it the moment `setExports` wires the instance** — the exact #2128 mechanism already used for `getter_callback_maker` setters.

**Purely additive:** any callback whose reaction fires AFTER `setExports` — which includes every `wrapTest`/equivalence body (they run inside an exported function the host calls post-wiring) — skips the new branch entirely, so no harness-executed callback changes behavior. The `merge_group` standalone-floor + full-CI is the real decider for broad impact.

## Validation

- RC2 repro prints `in then, v= 42`; top-level `async fn().then(...)` fires.
- **83 async/promise equivalence tests pass** (executor, capability, then, await, async-frame, for-await, multiawait, subclass) — no regressions.
- Baseline check: `new Promise(exec).then()` and value-carrying chained `.then` were ALREADY broken at top-level on `main` (not regressions).
- `tests/issue-3284-rc2.test.ts` added (top-level `.then` + top-level `async fn().then`).

## Scope

- `src/runtime.ts`: +20 lines in the `callback_maker` case only.
- `tests/issue-3284-rc2.test.ts`: new scoped test.
- `plan/issues/3284-...md`: mark RC2 fixed; RC1 stays open/`ready` (horizon xl).