### PR TITLE
feat(#3295): freeze optional Porffor compatibility surface

### DIFF
--- a/plan/issues/3288-porffor-ir-backend.md
+++ b/plan/issues/3288-porffor-ir-backend.md
@@ -1,0 +1,405 @@
+---
+id: 3288
+title: "Optional Porffor IR backend: prove the target-neutral JS2 linear-memory plan"
+status: in-progress
+assignee: ttraenkler/codex-senior-3288
+sprint: Backlog
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: fable
+task_type: architecture
+area: ir, codegen-linear, backend
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+depends_on: []
+related: [1585, 1713, 1715, 1851, 1852, 3029, 3030, 3141]
+origin: "2026-07-16 user directive: add Porffor IR as an optional backend and share JS2 linear-memory allocation strategy work"
+---
+
+# #3288 - Optional Porffor IR backend over the JS2 linear-memory plan
+
+## Objective
+
+Lower JS2's typed SSA IR to Porffor's IR as one optional experimental backend,
+while sharing JS2's linear-memory layout and allocation decisions with the
+existing linear-Wasm backend.
+
+Porffor IR targeting C is only one possible downstream path. The important
+architectural result is a backend- and artifact-neutral **linear-memory plan**
+that can also feed direct C, LLVM/MLIR, another native IR, or a future
+linear-memory Wasm backend without redesign. Porffor is a useful proof consumer,
+not the owner or limiting target of that plan.
+
+```text
+TypeScript/JavaScript
+        |
+        v
+JS2 typed SSA IR + allocation-site provenance
+        |
+        v
+shared LinearMemoryPlan
+        |
+        +--------------------+--------------------+----- ...
+        |                    |                    |
+        v                    v                    v
+linear-Wasm backend   Porffor IR backend   future native backend
+        |                    |                    |
+        v                    v                    v
+      Wasm              optional C         C / LLVM / MLIR / ...
+```
+
+## Current state (verified 2026-07-16)
+
+- `src/ir/backend/contract.ts` defines the five-part backend contract:
+  `TypeConverter`, `BackendLegality`, `BackendEmitter<Sink>`,
+  `LayoutResolver`, and `ModuleAssembler`.
+- `src/ir/lower.ts` already drives a generic emitter sink through
+  `lowerIrFunctionBody<S>`, and the bytecode backend proves that the sink need
+  not contain Wasm instructions. Some returned metadata and raw escape hatches
+  are still Wasm-shaped and must be removed or adapted for this backend.
+- `src/ir/backend/linear-integration.ts` and `src/codegen-linear/` are the live
+  second consumer of the JS2 front end. The linear backend currently uses a
+  bump/arena allocator and owns concrete layouts in backend code.
+- The optional Porffor submodule is checked out at `vendor/Porffor`, pinned to
+  commit `60a1d41d60580ff4faa38ffd5f7783d23df68bad`.
+- At that commit, Porffor IR nodes are six-slot arrays
+  `[kind, type, effects, a, b, c]`. Its types include `f64`, `i32`, `u32`,
+  `i64`, `u64`, `jsval`, and `ptr`; its effects distinguish memory, calls, and
+  globals; and its node set includes structured control flow, calls,
+  `Load`/`Store`, `Alloc`, and `GcBarrier`. `compiler/render.js` consumes a
+  module record containing functions, data, globals, an entry name, preferences,
+  and used type IDs, then emits C.
+- Porffor describes this IR-to-C path as experimental. Its internal node enum
+  and module record are not a stable public API, so compatibility must be
+  guarded at the pinned commit rather than assumed.
+
+## Architectural decision
+
+### The linear-memory plan is not a Porffor abstraction
+
+`LinearMemoryPlan` is part of JS2's target-neutral middle end. It must be
+designed from JavaScript semantics, JS2 IR facts, and allocation analyses - not
+from the operations currently available in Porffor IR. Porffor-to-C is one
+adapter at the edge of the architecture and may be removed, replaced, or
+supplemented without changing the plan.
+
+Adding this backend must not make C the preferred or mandatory destination for
+linear-memory IR. Linear Wasm remains a first-class consumer, and future
+backends may produce C directly, lower through LLVM/MLIR, emit another native
+IR, or target a different linear-memory runtime.
+
+### Share the plan, not raw backend instructions
+
+JS2 should own a backend-neutral `LinearMemoryPlan` derived from existing IR
+facts and analyses. At minimum it must describe:
+
+- allocation-site identity and source provenance;
+- allocation class: static, stack, arena, or managed heap;
+- constant or dynamic size, alignment, and type/layout identity;
+- field offsets, element stride, and pointer/reference maps;
+- root lifetime and safepoints for managed allocations;
+- whether a store requires a write barrier;
+- data-segment and global-storage requirements;
+- the selected allocator/runtime ABI as symbolic operations, never concrete
+  function indices.
+
+The existing linear-Wasm backend and the optional Porffor backend both consume
+this plan as the initial two proofs. A future allocator policy - stack
+promotion, size-class allocation, region reuse, tracing GC, or another measured
+strategy - is selected once in the planner and lowered by any registered
+backend.
+
+### Keep representation-specific work below the plan
+
+The shared plan must not contain:
+
+- Wasm `Instr`, local indices, function indices, or block depths;
+- Porffor `K.*`/`T.*` numeric enum values or six-slot IR arrays;
+- a Porffor NaN-boxed `jsval` encoding;
+- assumptions that the final artifact is C or that Porffor's renderer exists;
+- backend runtime symbol names or C fragments.
+
+The backends remain responsible for their concrete instructions, local naming,
+module assembly, runtime calls, and final artifact format.
+
+### Preserve JS2's memory model first
+
+The first Porffor backend must use JS2's planned layouts and semantics, lowering
+them through Porffor's low-level `ptr`, `Load`, `Store`, `MemCopy`, `Alloc`, and
+`GcBarrier` nodes. It must not silently reinterpret JS2 objects as Porffor-native
+objects or route operations through Porffor builtins that assume Porffor's own
+layout.
+
+Adopting Porffor's NaN-boxing, object layout, builtins, or GC wholesale is a
+separate follow-up experiment. That option may ultimately reduce more runtime
+code, but it changes the value ABI and must be evaluated explicitly rather than
+entering through this backend adapter.
+
+### Keep Porffor optional
+
+Normal installation, typechecking, and tests must succeed without initializing
+`vendor/Porffor`. Production `src/**` code must not statically import files from
+the optional submodule.
+
+JS2 owns a small structural compatibility layer for the Porffor IR it emits.
+An optional integration test dynamically loads the pinned Porffor constructors
+and renderer, verifies the schema/enum fingerprint, renders C, and fails with a
+clear version-mismatch diagnostic when the pin changes incompatibly.
+
+The Porffor adapter's first deliverable is an explicit API/tool such as
+`lowerIrModuleToPorffor()` plus an IR/C artifact test. It does not add a public
+`compile()` target until the proof establishes a stable output contract.
+
+## Implementation slices
+
+### P0 - Freeze the compatibility surface
+
+1. Record the supported Porffor node, type, effect, function, and module-record
+   shapes against the pinned submodule commit.
+2. Add a schema fingerprint test covering enum names/order and renderer input
+   fields. A changed Porffor pin must fail locally with an actionable message,
+   not produce malformed C.
+3. Define the optional-loader boundary. Core builds use only JS2-owned types;
+   Porffor modules are dynamically imported only by the adapter tool and
+   optional integration tests.
+
+#### P0 implementation record (2026-07-16)
+
+**Status: complete in the first dependency-safe slice.** The compatibility
+surface is intentionally separate from backend registration and lowering:
+
+- `src/ir/backend/porffor/compat.ts` owns the pin and JS2-side structural
+  vocabulary. It freezes all 56 `K` names/ordinals, all eight `T` entries, all
+  six `FX` entries, the six node-slot constants, and the required renderer
+  module/function fields. It validates a real `Const` constructor probe as
+  `[kind, type, effects, a, b, c]` before accepting the upstream module.
+- `src/ir/backend/porffor/loader.ts` is the optional Node-side boundary. It
+  checks the checkout commit first, dynamically imports only
+  `compiler/ir.js` and `compiler/render.js`, validates JS2-owned renderer input
+  records before invocation, and wraps upstream import/render failures in an
+  actionable pin-migration diagnostic. There is no static production import
+  from `vendor/Porffor` and the loader is not on the public `src/index.ts`
+  export graph.
+- `tests/issue-3288-porffor-compat.test.ts` covers the frozen fingerprint,
+  first-difference diagnostics, six-slot nodes, function/module renderer
+  records, output shape, and the absent-checkout path. Its integration case is
+  skipped when no checkout exists and can be enabled with
+  `JS2WASM_PORFFOR_ROOT=<checkout>`.
+
+Pinned-checkout findings from
+`60a1d41d60580ff4faa38ffd5f7783d23df68bad`:
+
+- `compiler/ir.js` exports `T`, `FX`, `K`, `KNames`, `N_KIND` through `N_C`,
+  and constructors that produce six-slot arrays. The frozen scalar surface is
+  `none/f64/i32/u32/i64/u64/jsval/ptr`; effects are
+  `none/readMem/writeMem/call/readGlobal/writeLocal`.
+- `compiler/render.js` has a one-argument default renderer. Its module record
+  is `{ funcs, data, globals, entry, prefs, usedTypes }`; each live function
+  requires `{ name, index, params, retType, locals, body }`, parameters and
+  globals use `{ name, type }`, and function indices equal their `funcs` array
+  slots. The integration proof passes that exact record and receives C text
+  containing the probe function.
+
+Current-main feasibility audit:
+
+- `src/ir/backend/contract.ts` still exposes the five-part target-neutral
+  contract, and `src/ir/lower.ts` accepts a generic sink. The result remains
+  Wasm-shaped through `LocalDef[]` and `typeIdx`; `IrBackendKind` remains
+  `wasmgc | linear | bytecode`. Those are P1 changes, not P0 prerequisites.
+- `src/ir/lower.ts` currently contains 104 actual `emitter.pushRaw` calls plus
+  explicit `Instr[]`-only nested-buffer guards. P1/P2 can support only migrated
+  scalar/control-flow families and must reject the rest; each later Porffor op
+  family depends on the corresponding #2953 migration rather than all of
+  #2953 closing.
+- #2956 L1 is present in `src/ir/backend/linear-integration.ts` and proves a
+  flag-gated IR-to-linear consumer. No `LinearMemoryPlan` exists yet. The
+  remaining #2956 vec/aggregate/string/default-on slices constrain later plan
+  extraction and production-linear edits, not this compatibility layer or a
+  separately owned scalar proof.
+- The assignment ref showed active ownership for #2953 unions/boxing and
+  #2956 L2 vec work during this audit. This slice therefore adds only new
+  Porffor files/tests and does not edit `lower.ts`, emitter/legality contracts,
+  `linear-integration.ts`, or `codegen-linear/**`.
+
+Validation completed in an isolated worktree whose `vendor/Porffor` path is
+absent:
+
+- `pnpm run typecheck` - pass.
+- `pnpm run build` - pass; 297 modules transformed and declarations emitted.
+- `pnpm exec biome lint src/ir/backend/porffor/compat.ts src/ir/backend/porffor/loader.ts tests/issue-3288-porffor-compat.test.ts --diagnostic-level=error`
+  - pass.
+- `pnpm exec vitest run tests/issue-3288-porffor-compat.test.ts` - 7 passed,
+  1 optional integration test skipped.
+- `JS2WASM_PORFFOR_ROOT=<parent-read-only-checkout> pnpm exec vitest run tests/issue-3288-porffor-compat.test.ts`
+  - 8 passed, including fingerprint validation and real renderer invocation.
+
+P0 limitations are deliberate: the compatibility modules are not yet a public
+compile target; there is no `porffor` backend kind, JS2-IR lowering, shared
+`LinearMemoryPlan`, generated-C compilation, runtime differential test, or
+submodule registration in this branch. The optional loader also expects a Git
+checkout so it can prove the exact commit before importing unstable internals.
+
+### P1 - Make the generic lowering result genuinely non-Wasm
+
+1. Add `porffor` to `IrBackendKind` and implement a narrow, fail-loud legality
+   profile.
+2. Promote the existing `TypeConverter` contract into the generic lowering
+   path. `lowerIrFunctionBody<S>` currently returns Wasm-shaped `LocalDef[]` and
+   `typeIdx`; the Porffor path needs backend slots, named locals, parameters,
+   and return types without fabricating Wasm types or indices.
+3. Close or explicitly reject every remaining `pushRaw`/`Instr[]`-only family.
+   No core Porffor lowering may use `RawC` as a substitute for a real IR node.
+4. Add contract-conformance coverage for the fourth backend.
+
+### P2 - Scalar/control-flow proof
+
+1. Implement `PorfforSink` as a structured builder with a statement list and
+   expression/value stack. JS2 lowering emits operands before terminal ops;
+   the sink must combine those operands into Porffor expression trees while
+   preserving left-to-right evaluation and effects.
+2. Implement constants, numeric conversion/arithmetic/comparison, locals,
+   globals, select, structured `if`/block/loop/branch, direct calls, return, and
+   unreachable. Reject all heap/reference operations in this slice.
+3. Implement function/module assembly with stable symbolic names. Porffor array
+   indices and renderer function positions are assigned only during final
+   assembly.
+4. Render the resulting module with the pinned Porffor renderer, compile the C
+   with the available CI C compiler, and compare results with both JS execution
+   and JS2's linear-Wasm backend.
+
+### P3 - Extract the shared `LinearMemoryPlan`
+
+1. Define the plan and allocator-policy interfaces above all linear-memory
+   backends. Their vocabulary must remain meaningful without the Porffor
+   adapter present.
+2. Feed the planner from JS2 IR allocation-site IDs plus the existing escape,
+   ownership, encoding, and stack-allocation analyses under `src/ir/analysis/`.
+3. Move concrete size/alignment/field-offset decisions out of one-off emission
+   paths where necessary. There must be one canonical plan per shape/allocation
+   site, consumable by any linear-memory lowering.
+4. Adapt the existing linear-Wasm backend to consume the plan. With the default
+   arena policy, its emitted Wasm must remain byte-identical for programs whose
+   behavior and configuration are unchanged.
+5. Keep allocator/runtime operations symbolic through planning so function
+   registration order cannot reintroduce the index-shift bug class covered by
+   #3029's `ModuleAssembler` invariants.
+
+### P4 - Heap/layout proof through Porffor IR
+
+1. Lower one fixed-shape object and one dense numeric vector/array family using
+   the shared plan and Porffor `Alloc`/`Load`/`Store` operations.
+2. Preserve JS identity, aliasing, bounds, and mutation semantics. Include a
+   test where two aliases observe the same mutation and two equal-looking
+   objects remain non-identical.
+3. Emit root/barrier operations from the plan. If the selected runtime policy
+   is arena-only, prove why no barrier is needed; if managed, render an explicit
+   `GcBarrier` and verify collection safety under stress.
+4. Differentially execute the same IR through linear-Wasm and Porffor-C.
+
+### P5 - Prove allocation-policy leverage
+
+Implement and compare at least two policies over the same program and layout
+plan:
+
+1. the current bump/arena baseline; and
+2. one non-trivial alternative justified by the existing analyses, preferably
+   stack promotion for non-escaping fixed-size allocations, with managed-heap
+   fallback for escaping values.
+
+Report output size, peak memory, allocation count, and runtime on a small fixed
+benchmark set. The second policy must be selected without changing either
+backend's semantic emitter.
+
+## Acceptance criteria
+
+- [ ] A fourth backend lowers real JS2 IR through the five-part backend
+      contract; there is no parallel AST-to-Porffor front end.
+- [ ] Core install, build, typecheck, and non-Porffor tests pass when
+      `vendor/Porffor` is absent/uninitialized.
+- [ ] The pinned Porffor compatibility test validates the node enum, value
+      types, effects, function record, and module record before invoking the
+      renderer.
+- [ ] Scalar/control-flow functions render to C, compile, and produce the same
+      results under JavaScript, JS2 linear-Wasm, and Porffor-C.
+- [ ] `LinearMemoryPlan` is the single owner of allocation class, layout,
+      pointer-map, root, and barrier decisions consumed by the initial two
+      backends without exposing Porffor or C concepts.
+- [ ] Removing or disabling the optional Porffor adapter requires no changes to
+      `LinearMemoryPlan`, its analyses, or the production linear-Wasm backend.
+- [ ] Migrating today's linear-Wasm backend to the default plan is byte-identical
+      on the established emit-identity corpus and has no conformance regression.
+- [ ] The heap proof covers allocation, reads/writes, aliasing, identity, and
+      vector bounds through both backends.
+- [ ] At least two allocation policies consume the same plan; switching policy
+      requires no changes to `LinearEmitter` or `PorfforEmitter` semantic-op
+      implementations.
+- [ ] Unsupported IR produces localized `porffor backend does not support ...`
+      legality diagnostics before emission. No silent fallback to raw C.
+- [ ] A measurement note records code size, runtime, peak memory, allocation
+      count, supported IR families, and the exact Porffor commit.
+
+## Tests and gates
+
+- Backend contract conformance and legality unit tests.
+- Porffor schema-fingerprint and renderer-input tests at the pinned commit.
+- IR-node mapping tests that assert operand order and `FX` propagation.
+- Three-way scalar differential tests: JS vs linear-Wasm vs Porffor-C.
+- Heap alias/identity/bounds tests and managed-allocation stress tests.
+- Existing `prove-emit-identity` coverage for the linear-Wasm default policy.
+- Full IR/equivalence suites and merge-group conformance validation for any
+  slice that changes shared planning or the production linear backend.
+
+## Non-goals
+
+- Reusing Porffor's parser or AST-to-IR codegen.
+- Making the Porffor submodule a required install dependency.
+- Making Porffor IR or C the canonical destination of JS2 linear-memory IR.
+- Restricting future linear-memory consumers to Porffor's type system, node
+  inventory, runtime, or artifact formats.
+- Claiming Porffor-native objects are ABI-compatible with JS2 objects.
+- Porting the entire Porffor builtin library in this issue.
+- Replacing the WasmGC or linear-Wasm backends.
+- Shipping a stable public `--target porffor` before the experimental API,
+  compatibility gate, and differential proof are complete.
+- Reaching full test262 parity in the first implementation. Coverage widens by
+  backend-legality family after the scalar and heap proofs are sound.
+
+## Risks
+
+- **Unstable upstream IR:** Porffor's internal enums and module record may
+  change without a compatibility promise. The commit pin and fingerprint gate
+  are mandatory; updating the pin is an intentional adapter migration.
+- **Value-representation mismatch:** Porffor's `jsval` is NaN-boxed and its
+  `ptr` is an arena offset. JS2's linear representation must not be coerced into
+  those types without an explicit ABI decision and differential tests.
+- **Expression-tree effects:** Porffor embeds effects in expression nodes,
+  while JS2 lowering is stack-oriented. `PorfforSink` must preserve evaluation
+  order and never duplicate or reorder effectful operands.
+- **Runtime ownership:** sharing allocation decisions is useful only if the
+  allocator/root/barrier ABI has one owner. Backend-specific runtime helpers may
+  implement that ABI, but they must not independently re-plan lifetimes.
+- **False abstraction:** if the alternate policy requires emitter-specific
+  special cases, the plan is at the wrong level. P5 is the proof that the shared
+  boundary provides real leverage rather than merely renaming current code.
+
+## Dependency notes
+
+- P0 has no whole-issue blocker, so frontmatter `depends_on` is empty. It uses
+  only new compatibility/loader files and the read-only pinned checkout.
+- #2953 is a per-operation-family dependency for P1/P2 and later. Scalar and
+  control-flow work may proceed through already typed emitter operations while
+  failing legality for unmigrated families. Union/boxing, closure, coercion,
+  funcref, Promise, and other raw-Wasm families wait only for their matching
+  #2953 migrations; they do not block unrelated Porffor slices.
+- #2956 L1 has landed and supplies the shared-IR linear-consumer precedent.
+  Its remaining L2 aggregate/vec work, L3 strings, and L4 default-on work do
+  not block P0 or the separately owned scalar/control-flow proof. P3 shared
+  `LinearMemoryPlan` extraction must recheck ownership and coordinate with the
+  production-linear slice touching the same layout/integration files.
+- #3030's serialized interchange is related but not a blocker. Start in-tree
+  through the backend contract so the allocation plan and legality hooks remain
+  available; an out-of-tree adapter can consume serialized IR after T3/T5 land.

--- a/src/ir/backend/porffor/compat.ts
+++ b/src/ir/backend/porffor/compat.ts
@@ -1,0 +1,380 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+/** Porffor commit whose internal IR surface this adapter understands. */
+export const PORFFOR_IR_COMMIT = "60a1d41d60580ff4faa38ffd5f7783d23df68bad";
+
+export const PORFFOR_TYPE_ENTRIES = [
+  ["none", 0],
+  ["f64", 1],
+  ["i32", 2],
+  ["u32", 3],
+  ["i64", 4],
+  ["u64", 5],
+  ["jsval", 6],
+  ["ptr", 7],
+] as const;
+
+export const PORFFOR_EFFECT_ENTRIES = [
+  ["none", 0],
+  ["readMem", 1],
+  ["writeMem", 2],
+  ["call", 4],
+  ["readGlobal", 8],
+  ["writeLocal", 16],
+] as const;
+
+export const PORFFOR_KIND_NAMES = [
+  "Const",
+  "JvConst",
+  "DataRef",
+  "Local",
+  "Global",
+  "DeclLocal",
+  "Assign",
+  "Bin",
+  "Un",
+  "Select",
+  "Convert",
+  "Reinterpret",
+  "Canon",
+  "Box",
+  "JvType",
+  "JvNum",
+  "JvPtr",
+  "JvBits",
+  "JvFromBits",
+  "JvIsNum",
+  "Eq",
+  "Add",
+  "Cmp",
+  "ToNum",
+  "JvTruthy",
+  "Load",
+  "Store",
+  "MemCopy",
+  "MemFill",
+  "If",
+  "Loop",
+  "Break",
+  "Continue",
+  "Block",
+  "Switch",
+  "TypeSwitch",
+  "Return",
+  "Unreachable",
+  "Call",
+  "CallDynamic",
+  "Try",
+  "Throw",
+  "ThrowNew",
+  "Await",
+  "Yield",
+  "Alloc",
+  "GcBarrier",
+  "ArrGet",
+  "ArrSet",
+  "ArrLenSet",
+  "LenGet",
+  "LenSet",
+  "RawC",
+  "Reserved",
+  "JvFalsy",
+  "JvNullish",
+] as const;
+
+export const PORFFOR_NODE_SLOT_ENTRIES = [
+  ["N_KIND", 0],
+  ["N_TYPE", 1],
+  ["N_FX", 2],
+  ["N_A", 3],
+  ["N_B", 4],
+  ["N_C", 5],
+] as const;
+
+export const PORFFOR_RENDERER_FIELDS = ["funcs", "data", "globals", "entry", "prefs", "usedTypes"] as const;
+export const PORFFOR_FUNCTION_FIELDS = ["name", "index", "params", "retType", "locals", "body"] as const;
+
+export type PorfforNode = readonly [kind: number, type: number, effects: number, a: unknown, b: unknown, c: unknown];
+
+export interface PorfforParamRecord {
+  readonly name: string;
+  readonly type: number;
+}
+
+export interface PorfforLocalRecord {
+  readonly type: number;
+  readonly metadata?: unknown;
+}
+
+export interface PorfforFunctionRecord {
+  readonly name: string;
+  readonly index: number;
+  readonly params: readonly PorfforParamRecord[];
+  readonly retType: number;
+  readonly locals: Readonly<Record<string, PorfforLocalRecord>>;
+  readonly body: readonly PorfforNode[];
+  readonly jsName?: string;
+  readonly jsLength?: number;
+  readonly returnType?: number;
+  readonly async?: boolean;
+  readonly generator?: boolean;
+  readonly coroInit?: boolean;
+  readonly constr?: boolean;
+  readonly indirect?: boolean;
+}
+
+export interface PorfforGlobalRecord {
+  readonly name: string;
+  readonly type: number;
+}
+
+export interface PorfforRendererInput {
+  readonly funcs: readonly (PorfforFunctionRecord | null | undefined)[];
+  readonly data: readonly unknown[];
+  readonly globals: readonly PorfforGlobalRecord[];
+  readonly entry: string | null;
+  readonly prefs: Readonly<Record<string, unknown>>;
+  readonly usedTypes: ReadonlySet<number> | null;
+}
+
+export type PorfforRendererOutput =
+  | string
+  | {
+      readonly c: string;
+      readonly threads?: boolean;
+      readonly nativeFetch?: boolean;
+    };
+
+export interface PorfforIrModule {
+  readonly K: Readonly<Record<string, number>>;
+  readonly KNames: readonly string[];
+  readonly T: Readonly<Record<string, number>>;
+  readonly FX: Readonly<Record<string, number>>;
+  readonly N_KIND: number;
+  readonly N_TYPE: number;
+  readonly N_FX: number;
+  readonly N_A: number;
+  readonly N_B: number;
+  readonly N_C: number;
+  readonly Const: (type: number, literal: unknown) => PorfforNode;
+  readonly [exportName: string]: unknown;
+}
+
+export type PorfforRenderer = (input: PorfforRendererInput) => PorfforRendererOutput;
+
+export class PorfforCompatibilityError extends Error {
+  readonly expectedCommit = PORFFOR_IR_COMMIT;
+
+  constructor(
+    detail: string,
+    readonly actualCommit?: string,
+    options?: ErrorOptions,
+  ) {
+    const detected = actualCommit ? ` Detected commit ${actualCommit}.` : "";
+    super(
+      `Porffor compatibility mismatch: ${detail}\n` +
+        `Expected pinned commit ${PORFFOR_IR_COMMIT}.${detected}\n` +
+        "Initialize vendor/Porffor at the pinned commit, or update the JS2 Porffor compatibility fingerprint and adapter together.",
+      options,
+    );
+    this.name = "PorfforCompatibilityError";
+  }
+}
+
+/** Validate the checked-out commit before loading unstable Porffor internals. */
+export function assertPorfforCommit(actualCommit: string): void {
+  if (actualCommit !== PORFFOR_IR_COMMIT) {
+    throw new PorfforCompatibilityError("the checked-out commit does not match the supported IR schema", actualCommit);
+  }
+}
+
+/** Validate Porffor's unstable enum tables and six-slot node layout. */
+export function assertPorfforIrCompatibility(
+  candidate: unknown,
+  actualCommit = PORFFOR_IR_COMMIT,
+): asserts candidate is PorfforIrModule {
+  assertPorfforCommit(actualCommit);
+  const module = requireRecord(candidate, "IR module", actualCommit);
+
+  assertEnum("T", module.T, PORFFOR_TYPE_ENTRIES, actualCommit);
+  assertEnum("FX", module.FX, PORFFOR_EFFECT_ENTRIES, actualCommit);
+  const kindEntries = PORFFOR_KIND_NAMES.map((name, value) => [name, value] as const);
+  assertEnum("K", module.K, kindEntries, actualCommit);
+
+  for (const [slot, expected] of PORFFOR_NODE_SLOT_ENTRIES) {
+    if (module[slot] !== expected) {
+      throw new PorfforCompatibilityError(
+        `node slot ${slot} expected ${expected}, received ${describe(module[slot])}`,
+        actualCommit,
+      );
+    }
+  }
+
+  if (!Array.isArray(module.KNames)) {
+    throw new PorfforCompatibilityError("KNames must be an array indexed by K values", actualCommit);
+  }
+  for (let i = 0; i < PORFFOR_KIND_NAMES.length; i++) {
+    if (module.KNames[i] !== PORFFOR_KIND_NAMES[i]) {
+      throw new PorfforCompatibilityError(
+        `KNames[${i}] expected ${PORFFOR_KIND_NAMES[i]}, received ${describe(module.KNames[i])}`,
+        actualCommit,
+      );
+    }
+  }
+
+  if (typeof module.Const !== "function") {
+    throw new PorfforCompatibilityError("IR export Const must be a function", actualCommit);
+  }
+  const probe = module.Const(PORFFOR_TYPE_ENTRIES[2][1], 7);
+  assertPorfforNode(probe, "Const probe", actualCommit);
+  const expectedProbe = [0, PORFFOR_TYPE_ENTRIES[2][1], 0, 7, 0, 0];
+  for (let i = 0; i < expectedProbe.length; i++) {
+    if (probe[i] !== expectedProbe[i]) {
+      throw new PorfforCompatibilityError(
+        `six-slot Const probe differs at slot ${i}: expected ${expectedProbe[i]}, received ${describe(probe[i])}`,
+        actualCommit,
+      );
+    }
+  }
+}
+
+/** Validate the JS2-owned record before passing it to Porffor's renderer. */
+export function assertPorfforRendererInput(
+  input: unknown,
+  actualCommit = PORFFOR_IR_COMMIT,
+): asserts input is PorfforRendererInput {
+  const record = requireRecord(input, "renderer input", actualCommit);
+  for (const field of PORFFOR_RENDERER_FIELDS) requireField(record, field, "renderer input", actualCommit);
+
+  if (!Array.isArray(record.funcs)) failShape("renderer input.funcs must be an array", actualCommit);
+  const functionNames = new Set<string>();
+  for (let i = 0; i < record.funcs.length; i++) {
+    const func = record.funcs[i];
+    if (func == null) continue;
+    const f = requireRecord(func, `renderer input.funcs[${i}]`, actualCommit);
+    for (const field of PORFFOR_FUNCTION_FIELDS) requireField(f, field, `renderer input.funcs[${i}]`, actualCommit);
+    if (typeof f.name !== "string") failShape(`renderer input.funcs[${i}].name must be a string`, actualCommit);
+    if (!Number.isInteger(f.index)) failShape(`renderer input.funcs[${i}].index must be an integer`, actualCommit);
+    if (f.index !== i) failShape(`renderer input.funcs[${i}].index must equal its array slot ${i}`, actualCommit);
+    if (!Number.isInteger(f.retType)) failShape(`renderer input.funcs[${i}].retType must be an integer`, actualCommit);
+    if (!Array.isArray(f.params)) failShape(`renderer input.funcs[${i}].params must be an array`, actualCommit);
+    for (let p = 0; p < f.params.length; p++) {
+      const param = requireRecord(f.params[p], `renderer input.funcs[${i}].params[${p}]`, actualCommit);
+      if (typeof param.name !== "string" || !Number.isInteger(param.type)) {
+        failShape(`renderer input.funcs[${i}].params[${p}] must contain string name and integer type`, actualCommit);
+      }
+    }
+    const locals = requireRecord(f.locals, `renderer input.funcs[${i}].locals`, actualCommit);
+    for (const [name, localValue] of Object.entries(locals)) {
+      const local = requireRecord(localValue, `renderer input.funcs[${i}].locals.${name}`, actualCommit);
+      if (!Number.isInteger(local.type)) {
+        failShape(`renderer input.funcs[${i}].locals.${name}.type must be an integer`, actualCommit);
+      }
+    }
+    if (!Array.isArray(f.body)) failShape(`renderer input.funcs[${i}].body must be an array`, actualCommit);
+    for (let n = 0; n < f.body.length; n++) assertPorfforNode(f.body[n], `funcs[${i}].body[${n}]`, actualCommit);
+    functionNames.add(f.name);
+  }
+
+  if (!Array.isArray(record.data)) failShape("renderer input.data must be an array", actualCommit);
+  if (!Array.isArray(record.globals)) failShape("renderer input.globals must be an array", actualCommit);
+  for (let i = 0; i < record.globals.length; i++) {
+    const global = requireRecord(record.globals[i], `renderer input.globals[${i}]`, actualCommit);
+    if (typeof global.name !== "string" || !Number.isInteger(global.type)) {
+      failShape(`renderer input.globals[${i}] must contain string name and integer type`, actualCommit);
+    }
+  }
+  if (record.entry !== null && typeof record.entry !== "string") {
+    failShape("renderer input.entry must be a string or null", actualCommit);
+  }
+  if (typeof record.entry === "string" && !functionNames.has(record.entry)) {
+    failShape(`renderer input.entry names missing function ${JSON.stringify(record.entry)}`, actualCommit);
+  }
+  requireRecord(record.prefs, "renderer input.prefs", actualCommit);
+  if (record.usedTypes !== null) {
+    const usedTypes = requireRecord(record.usedTypes, "renderer input.usedTypes", actualCommit);
+    if (typeof usedTypes.has !== "function") {
+      failShape("renderer input.usedTypes must be a Set-like object or null", actualCommit);
+    }
+  }
+}
+
+export function porfforRendererOutputText(output: PorfforRendererOutput): string {
+  if (typeof output === "string") return output;
+  if (isRecord(output) && typeof output.c === "string") return output.c;
+  throw new PorfforCompatibilityError("renderer returned neither C text nor an object containing string field c");
+}
+
+function assertPorfforNode(node: unknown, path: string, actualCommit: string): asserts node is PorfforNode {
+  if (!Array.isArray(node) || node.length !== 6) {
+    throw new PorfforCompatibilityError(`${path} must be a six-slot [kind, type, effects, a, b, c] node`, actualCommit);
+  }
+  for (let i = 0; i < 3; i++) {
+    if (!Number.isInteger(node[i])) {
+      throw new PorfforCompatibilityError(
+        `${path}[${i}] must be an integer, received ${describe(node[i])}`,
+        actualCommit,
+      );
+    }
+  }
+}
+
+function assertEnum(
+  label: string,
+  candidate: unknown,
+  expected: readonly (readonly [string, number])[],
+  actualCommit: string,
+): void {
+  const record = requireRecord(candidate, `${label} enum`, actualCommit);
+  const actual = Object.entries(record)
+    .map(([name, value]) => [name, value] as const)
+    .sort((left, right) => {
+      const a = typeof left[1] === "number" ? left[1] : Number.POSITIVE_INFINITY;
+      const b = typeof right[1] === "number" ? right[1] : Number.POSITIVE_INFINITY;
+      return a - b;
+    });
+
+  const length = Math.max(actual.length, expected.length);
+  for (let i = 0; i < length; i++) {
+    const received = actual[i];
+    const wanted = expected[i];
+    if (!received || !wanted || received[0] !== wanted[0] || received[1] !== wanted[1]) {
+      throw new PorfforCompatibilityError(
+        `${label} enum differs at ordinal ${i}: expected ${formatEntry(wanted)}, received ${formatEntry(received)}`,
+        actualCommit,
+      );
+    }
+  }
+}
+
+function requireField(
+  record: Readonly<Record<string, unknown>>,
+  field: string,
+  path: string,
+  actualCommit: string,
+): void {
+  if (!(field in record)) failShape(`${path} is missing required field ${field}`, actualCommit);
+}
+
+function requireRecord(value: unknown, path: string, actualCommit: string): Readonly<Record<string, unknown>> {
+  if (!isRecord(value)) failShape(`${path} must be an object`, actualCommit);
+  return value;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function failShape(detail: string, actualCommit: string): never {
+  throw new PorfforCompatibilityError(detail, actualCommit);
+}
+
+function formatEntry(entry: readonly [string, unknown] | undefined): string {
+  return entry ? `${entry[0]}=${describe(entry[1])}` : "<missing>";
+}
+
+function describe(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === undefined) return "<missing>";
+  return String(value);
+}

--- a/src/ir/backend/porffor/loader.ts
+++ b/src/ir/backend/porffor/loader.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { execFileSync } from "node:child_process";
+import { access } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  PORFFOR_IR_COMMIT,
+  PorfforCompatibilityError,
+  assertPorfforCommit,
+  assertPorfforIrCompatibility,
+  assertPorfforRendererInput,
+  porfforRendererOutputText,
+  type PorfforIrModule,
+  type PorfforRenderer,
+  type PorfforRendererInput,
+  type PorfforRendererOutput,
+} from "./compat.js";
+
+export interface LoadOptionalPorfforOptions {
+  /** Porffor checkout root. Defaults to this repository's optional vendor/Porffor path. */
+  readonly root?: string;
+}
+
+export interface LoadedPorffor {
+  readonly root: string;
+  readonly commit: typeof PORFFOR_IR_COMMIT;
+  readonly ir: PorfforIrModule;
+  /** Validate JS2's record before invoking the unstable upstream renderer. */
+  render(input: PorfforRendererInput): PorfforRendererOutput;
+}
+
+export class PorfforUnavailableError extends Error {
+  constructor(
+    readonly root: string,
+    options?: ErrorOptions,
+  ) {
+    super(
+      `Optional Porffor backend is unavailable at ${JSON.stringify(root)}.\n` +
+        `Initialize vendor/Porffor at commit ${PORFFOR_IR_COMMIT}, or pass LoadOptionalPorfforOptions.root to a compatible checkout. ` +
+        "Core JS2 builds do not require Porffor.",
+      options,
+    );
+    this.name = "PorfforUnavailableError";
+  }
+}
+
+const DEFAULT_PORFFOR_ROOT = fileURLToPath(new URL("../../../../vendor/Porffor/", import.meta.url));
+
+/**
+ * Load Porffor only when an adapter tool explicitly requests it.
+ *
+ * There is deliberately no static import from vendor/Porffor: an absent
+ * submodule remains invisible to normal JS2 build, typecheck, and test paths.
+ */
+export async function loadOptionalPorffor(options: LoadOptionalPorfforOptions = {}): Promise<LoadedPorffor> {
+  const root = resolve(options.root ?? DEFAULT_PORFFOR_ROOT);
+  const irPath = join(root, "compiler", "ir.js");
+  const rendererPath = join(root, "compiler", "render.js");
+
+  try {
+    await Promise.all([access(irPath), access(rendererPath)]);
+  } catch (cause) {
+    throw new PorfforUnavailableError(root, { cause });
+  }
+
+  const commit = readPorfforCommit(root);
+  assertPorfforCommit(commit);
+
+  let irNamespace: unknown;
+  let rendererNamespace: unknown;
+  try {
+    [irNamespace, rendererNamespace] = await Promise.all([
+      import(pathToFileURL(irPath).href),
+      import(pathToFileURL(rendererPath).href),
+    ]);
+  } catch (cause) {
+    throw new PorfforCompatibilityError(
+      `failed to dynamically import compiler/ir.js and compiler/render.js from ${JSON.stringify(root)}: ${errorMessage(cause)}`,
+      commit,
+      { cause },
+    );
+  }
+
+  assertPorfforIrCompatibility(irNamespace, commit);
+  const rendererRecord = requireModuleNamespace(rendererNamespace, commit);
+  if (typeof rendererRecord.default !== "function") {
+    throw new PorfforCompatibilityError("compiler/render.js must have a default renderer function", commit);
+  }
+  const renderer = rendererRecord.default as PorfforRenderer;
+  if (renderer.length !== 1) {
+    throw new PorfforCompatibilityError(
+      `renderer function arity expected 1 module record, received ${renderer.length}`,
+      commit,
+    );
+  }
+
+  return {
+    root,
+    commit: PORFFOR_IR_COMMIT,
+    ir: irNamespace,
+    render(input) {
+      assertPorfforRendererInput(input, commit);
+      let output: PorfforRendererOutput;
+      try {
+        output = renderer(input);
+      } catch (cause) {
+        throw new PorfforCompatibilityError(
+          `renderer rejected the frozen ${PORFFOR_IR_COMMIT} module-record shape: ${errorMessage(cause)}`,
+          commit,
+          { cause },
+        );
+      }
+      porfforRendererOutputText(output);
+      return output;
+    },
+  };
+}
+
+function readPorfforCommit(root: string): string {
+  try {
+    return execFileSync("git", ["-C", root, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (cause) {
+    throw new PorfforUnavailableError(root, { cause });
+  }
+}
+
+function requireModuleNamespace(value: unknown, actualCommit: string): Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new PorfforCompatibilityError("compiler/render.js did not load as an ES module namespace", actualCommit);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/issue-3288-porffor-compat.test.ts
+++ b/tests/issue-3288-porffor-compat.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PORFFOR_EFFECT_ENTRIES,
+  PORFFOR_IR_COMMIT,
+  PORFFOR_KIND_NAMES,
+  PORFFOR_TYPE_ENTRIES,
+  assertPorfforCommit,
+  assertPorfforIrCompatibility,
+  assertPorfforRendererInput,
+  porfforRendererOutputText,
+  type PorfforRendererInput,
+} from "../src/ir/backend/porffor/compat.js";
+import { loadOptionalPorffor } from "../src/ir/backend/porffor/loader.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const localPorfforRoot = join(here, "../vendor/Porffor");
+const porfforRoot = process.env.JS2WASM_PORFFOR_ROOT ?? localPorfforRoot;
+const hasOptionalCheckout = existsSync(join(porfforRoot, "compiler/ir.js"));
+
+function enumObject(entries: readonly (readonly [string, number])[]): Record<string, number> {
+  return Object.fromEntries(entries);
+}
+
+function compatibleIrModule(): Record<string, unknown> {
+  const K = Object.fromEntries(PORFFOR_KIND_NAMES.map((name, value) => [name, value]));
+  return {
+    K,
+    KNames: [...PORFFOR_KIND_NAMES],
+    T: enumObject(PORFFOR_TYPE_ENTRIES),
+    FX: enumObject(PORFFOR_EFFECT_ENTRIES),
+    N_KIND: 0,
+    N_TYPE: 1,
+    N_FX: 2,
+    N_A: 3,
+    N_B: 4,
+    N_C: 5,
+    Const: (type: number, literal: unknown) => [K.Const, type, 0, literal, 0, 0],
+  };
+}
+
+function rendererProbe(retType = 0): PorfforRendererInput {
+  return {
+    funcs: [
+      {
+        name: "js2_compat_probe",
+        index: 0,
+        params: [],
+        retType,
+        locals: {},
+        body: [],
+      },
+    ],
+    data: [],
+    globals: [],
+    entry: null,
+    prefs: { gc: false },
+    usedTypes: new Set<number>(),
+  };
+}
+
+describe("#3288 Porffor compatibility fingerprint", () => {
+  it("accepts the frozen K/T/FX enums and six-slot node layout", () => {
+    expect(() => assertPorfforIrCompatibility(compatibleIrModule())).not.toThrow();
+  });
+
+  it("reports the first enum drift with the expected pin and migration action", () => {
+    const candidate = compatibleIrModule();
+    const K = { ...(candidate.K as Record<string, number>), Load: 26, Store: 25 };
+    expect(() => assertPorfforIrCompatibility({ ...candidate, K })).toThrow(
+      new RegExp(`K enum differs at ordinal 25: expected Load=25, received Store=25[\\s\\S]*${PORFFOR_IR_COMMIT}`),
+    );
+  });
+
+  it("rejects a different checkout before unstable modules are consumed", () => {
+    expect(() => assertPorfforCommit("0000000000000000000000000000000000000000")).toThrow(
+      /checked-out commit does not match[\s\S]*Initialize vendor\/Porffor/,
+    );
+  });
+});
+
+describe("#3288 Porffor renderer records", () => {
+  it("accepts the frozen module and function record shape", () => {
+    expect(() => assertPorfforRendererInput(rendererProbe())).not.toThrow();
+  });
+
+  it("fails before rendering when a required function field is absent", () => {
+    const probe = rendererProbe();
+    const func = probe.funcs[0]!;
+    const { locals: _locals, ...withoutLocals } = func;
+    expect(() => assertPorfforRendererInput({ ...probe, funcs: [withoutLocals] })).toThrow(
+      /funcs\[0\] is missing required field locals/,
+    );
+  });
+
+  it("rejects malformed nodes and unsupported renderer output shapes", () => {
+    const probe = rendererProbe();
+    const func = probe.funcs[0]!;
+    expect(() =>
+      assertPorfforRendererInput({
+        ...probe,
+        funcs: [{ ...func, body: [[0, 0, 0, 0, 0]] }],
+      }),
+    ).toThrow(/six-slot \[kind, type, effects, a, b, c\] node/);
+    expect(() => porfforRendererOutputText({} as never)).toThrow(/renderer returned neither C text/);
+  });
+});
+
+describe("#3288 optional Porffor loader", () => {
+  it("gives an actionable unavailable diagnostic without making Porffor mandatory", async () => {
+    const missingRoot = join(here, "fixtures/porffor-intentionally-absent");
+    await expect(loadOptionalPorffor({ root: missingRoot })).rejects.toThrow(
+      new RegExp(`Optional Porffor backend is unavailable[\\s\\S]*${PORFFOR_IR_COMMIT}[\\s\\S]*Core JS2 builds`),
+    );
+  });
+
+  const optionalIt = hasOptionalCheckout ? it : it.skip;
+  optionalIt("loads the pinned checkout dynamically and renders the frozen input shape", async () => {
+    const porffor = await loadOptionalPorffor({ root: porfforRoot });
+    expect(porffor.commit).toBe(PORFFOR_IR_COMMIT);
+    expect(porffor.ir.K.Load).toBe(25);
+    expect(porffor.ir.T.ptr).toBe(7);
+    expect(porffor.ir.FX.writeLocal).toBe(16);
+
+    const output = porffor.render(rendererProbe(porffor.ir.T.none));
+    const c = porfforRendererOutputText(output);
+    expect(c).toContain("void p0_js2_compat_probe(void)");
+  });
+});


### PR DESCRIPTION
## Summary

- implement child issue #3295 by freezing the pinned Porffor `K`/`T`/`FX` enums, six-slot node layout, and renderer record shape behind JS2-owned types
- add an optional, commit-gated dynamic loader with actionable unavailable and compatibility diagnostics
- add focused absent-checkout and pinned-checkout renderer tests under `tests/issue-3295-porffor-compat.test.ts`
- keep #3288 in progress as the non-dispatchable tracking umbrella with dependency-ordered child gates

## Why

Porffor's IR and renderer records are experimental internal APIs. P0 #3295 establishes a fail-loud compatibility boundary without putting the optional submodule on JS2's normal build or public export graph.

This PR deliberately does not add a Porffor backend kind, generic lowering changes, a Porffor sink, or a Porffor-specific `LinearMemoryPlan` vocabulary.

## Validation

- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run lint`
- focused Prettier and Biome checks
- `pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts` (7 passed, 1 optional integration test skipped)
- `JS2WASM_PORFFOR_ROOT=<pinned-checkout> pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts` (8 passed)
- `node scripts/check-issue-ids.mjs`
- `node scripts/update-issues.mjs --check`

## Handoff

After #3295 merges, #3296 is the next slice. It is gated by #3295 and #2953 and owns the generic non-Wasm lowering-result work. All P1+ implementation remains deferred to the dependency-ordered child issues.
