### PR TITLE
docs(#3295): scope Porffor P0 under child issue

### DIFF
--- a/plan/issues/3288-porffor-ir-backend.md
+++ b/plan/issues/3288-porffor-ir-backend.md
@@ -2,21 +2,20 @@
 id: 3288
 title: "Optional Porffor IR backend: prove the target-neutral JS2 linear-memory plan"
 status: in-progress
-assignee: ttraenkler/codex-senior-3288
-sprint: Backlog
 created: 2026-07-16
 updated: 2026-07-16
 priority: high
-horizon: xl
 feasibility: hard
 reasoning_effort: max
-model: fable
 task_type: architecture
 area: ir, codegen-linear, backend
 language_feature: compiler-internals
 goal: backend-agnostic-ir
+sprint: current
 depends_on: []
-related: [1585, 1713, 1715, 1851, 1852, 3029, 3030, 3141]
+horizon: xl
+model: gpt-5.6-sol
+related: [1585, 1713, 1715, 1851, 1852, 3029, 3030, 3141, 3295, 3296, 3297, 3298, 3299, 3300]
 origin: "2026-07-16 user directive: add Porffor IR as an optional backend and share JS2 linear-memory allocation strategy work"
 ---
 
@@ -154,6 +153,23 @@ The Porffor adapter's first deliverable is an explicit API/tool such as
 `lowerIrModuleToPorffor()` plus an IR/C artifact test. It does not add a public
 `compile()` target until the proof establishes a stable output contract.
 
+## Dispatch structure
+
+This issue is the non-dispatchable tracking umbrella. Implementation proceeds
+through one PR per dependency-ordered child issue:
+
+| Slice | Issue                                                     | Dispatch gate     |
+| ----- | --------------------------------------------------------- | ----------------- |
+| P0    | #3295 - freeze the optional Porffor compatibility surface | ready immediately |
+| P1    | #3296 - make generic lowering results non-Wasm            | #3295 and #2953   |
+| P2    | #3297 - scalar/control-flow Porffor proof                 | #3296             |
+| P3    | #3298 - extract shared `LinearMemoryPlan`                 | #3297 and #2956   |
+| P4    | #3299 - heap/layout proof through Porffor IR              | #3298             |
+| P5    | #3300 - prove allocation-policy leverage                  | #3299             |
+
+Do not mark #3288 complete until all six child issues are merged and the
+umbrella acceptance criteria below are revalidated.
+
 ## Implementation slices
 
 ### P0 - Freeze the compatibility surface
@@ -166,82 +182,6 @@ The Porffor adapter's first deliverable is an explicit API/tool such as
 3. Define the optional-loader boundary. Core builds use only JS2-owned types;
    Porffor modules are dynamically imported only by the adapter tool and
    optional integration tests.
-
-#### P0 implementation record (2026-07-16)
-
-**Status: complete in the first dependency-safe slice.** The compatibility
-surface is intentionally separate from backend registration and lowering:
-
-- `src/ir/backend/porffor/compat.ts` owns the pin and JS2-side structural
-  vocabulary. It freezes all 56 `K` names/ordinals, all eight `T` entries, all
-  six `FX` entries, the six node-slot constants, and the required renderer
-  module/function fields. It validates a real `Const` constructor probe as
-  `[kind, type, effects, a, b, c]` before accepting the upstream module.
-- `src/ir/backend/porffor/loader.ts` is the optional Node-side boundary. It
-  checks the checkout commit first, dynamically imports only
-  `compiler/ir.js` and `compiler/render.js`, validates JS2-owned renderer input
-  records before invocation, and wraps upstream import/render failures in an
-  actionable pin-migration diagnostic. There is no static production import
-  from `vendor/Porffor` and the loader is not on the public `src/index.ts`
-  export graph.
-- `tests/issue-3288-porffor-compat.test.ts` covers the frozen fingerprint,
-  first-difference diagnostics, six-slot nodes, function/module renderer
-  records, output shape, and the absent-checkout path. Its integration case is
-  skipped when no checkout exists and can be enabled with
-  `JS2WASM_PORFFOR_ROOT=<checkout>`.
-
-Pinned-checkout findings from
-`60a1d41d60580ff4faa38ffd5f7783d23df68bad`:
-
-- `compiler/ir.js` exports `T`, `FX`, `K`, `KNames`, `N_KIND` through `N_C`,
-  and constructors that produce six-slot arrays. The frozen scalar surface is
-  `none/f64/i32/u32/i64/u64/jsval/ptr`; effects are
-  `none/readMem/writeMem/call/readGlobal/writeLocal`.
-- `compiler/render.js` has a one-argument default renderer. Its module record
-  is `{ funcs, data, globals, entry, prefs, usedTypes }`; each live function
-  requires `{ name, index, params, retType, locals, body }`, parameters and
-  globals use `{ name, type }`, and function indices equal their `funcs` array
-  slots. The integration proof passes that exact record and receives C text
-  containing the probe function.
-
-Current-main feasibility audit:
-
-- `src/ir/backend/contract.ts` still exposes the five-part target-neutral
-  contract, and `src/ir/lower.ts` accepts a generic sink. The result remains
-  Wasm-shaped through `LocalDef[]` and `typeIdx`; `IrBackendKind` remains
-  `wasmgc | linear | bytecode`. Those are P1 changes, not P0 prerequisites.
-- `src/ir/lower.ts` currently contains 104 actual `emitter.pushRaw` calls plus
-  explicit `Instr[]`-only nested-buffer guards. P1/P2 can support only migrated
-  scalar/control-flow families and must reject the rest; each later Porffor op
-  family depends on the corresponding #2953 migration rather than all of
-  #2953 closing.
-- #2956 L1 is present in `src/ir/backend/linear-integration.ts` and proves a
-  flag-gated IR-to-linear consumer. No `LinearMemoryPlan` exists yet. The
-  remaining #2956 vec/aggregate/string/default-on slices constrain later plan
-  extraction and production-linear edits, not this compatibility layer or a
-  separately owned scalar proof.
-- The assignment ref showed active ownership for #2953 unions/boxing and
-  #2956 L2 vec work during this audit. This slice therefore adds only new
-  Porffor files/tests and does not edit `lower.ts`, emitter/legality contracts,
-  `linear-integration.ts`, or `codegen-linear/**`.
-
-Validation completed in an isolated worktree whose `vendor/Porffor` path is
-absent:
-
-- `pnpm run typecheck` - pass.
-- `pnpm run build` - pass; 297 modules transformed and declarations emitted.
-- `pnpm exec biome lint src/ir/backend/porffor/compat.ts src/ir/backend/porffor/loader.ts tests/issue-3288-porffor-compat.test.ts --diagnostic-level=error`
-  - pass.
-- `pnpm exec vitest run tests/issue-3288-porffor-compat.test.ts` - 7 passed,
-  1 optional integration test skipped.
-- `JS2WASM_PORFFOR_ROOT=<parent-read-only-checkout> pnpm exec vitest run tests/issue-3288-porffor-compat.test.ts`
-  - 8 passed, including fingerprint validation and real renderer invocation.
-
-P0 limitations are deliberate: the compatibility modules are not yet a public
-compile target; there is no `porffor` backend kind, JS2-IR lowering, shared
-`LinearMemoryPlan`, generated-C compilation, runtime differential test, or
-submodule registration in this branch. The optional loader also expects a Git
-checkout so it can prove the exact commit before importing unstable internals.
 
 ### P1 - Make the generic lowering result genuinely non-Wasm
 
@@ -388,18 +328,12 @@ backend's semantic emitter.
 
 ## Dependency notes
 
-- P0 has no whole-issue blocker, so frontmatter `depends_on` is empty. It uses
-  only new compatibility/loader files and the read-only pinned checkout.
-- #2953 is a per-operation-family dependency for P1/P2 and later. Scalar and
-  control-flow work may proceed through already typed emitter operations while
-  failing legality for unmigrated families. Union/boxing, closure, coercion,
-  funcref, Promise, and other raw-Wasm families wait only for their matching
-  #2953 migrations; they do not block unrelated Porffor slices.
-- #2956 L1 has landed and supplies the shared-IR linear-consumer precedent.
-  Its remaining L2 aggregate/vec work, L3 strings, and L4 default-on work do
-  not block P0 or the separately owned scalar/control-flow proof. P3 shared
-  `LinearMemoryPlan` extraction must recheck ownership and coordinate with the
-  production-linear slice touching the same layout/integration files.
+- The umbrella has no whole-issue blocker; dependency gates belong to its
+  dispatchable children.
+- P0 #3295 has no blocker. P1 #3296 waits for #3295 and #2953. This makes
+  #2953 a generic-lowering/op-family dependency rather than a P0 dependency.
+- #2956 L1 already supplies the production linear-IR precedent. Its remaining
+  work gates shared-plan extraction through #3298, not #3295 through #3297.
 - #3030's serialized interchange is related but not a blocker. Start in-tree
   through the backend contract so the allocation plan and legality hooks remain
   available; an out-of-tree adapter can consume serialized IR after T3/T5 land.

--- a/plan/issues/3295-porffor-compatibility-surface.md
+++ b/plan/issues/3295-porffor-compatibility-surface.md
@@ -1,0 +1,119 @@
+---
+id: 3295
+title: "Porffor backend P0: freeze the optional IR compatibility surface"
+status: in-progress
+assignee: ttraenkler/codex-senior-3295
+sprint: current
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+model: gpt-5.6-sol
+task_type: infrastructure
+area: ir, backend, tooling
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3288
+depends_on: []
+related: [3288, 2953, 2956, 3030]
+origin: "#3288 P0 split: independently dispatchable Porffor compatibility boundary"
+---
+
+# #3295 - Porffor backend P0: freeze the optional IR compatibility surface
+
+## Objective
+
+Define and test the smallest JS2-owned compatibility surface required to emit
+Porffor IR at the optional submodule commit pinned in `vendor/Porffor`.
+
+This slice establishes an explicit version boundary before production lowering
+depends on Porffor's experimental internal enums or module-record shape.
+
+## Scope
+
+1. Record the supported Porffor node, type, effect, function-record, and
+   module-record shapes against the pinned commit.
+2. Add a schema fingerprint test covering enum names/order and renderer input
+   fields. A changed pin must fail with an actionable compatibility diagnostic.
+3. Define the optional loader boundary. Core code uses JS2-owned structural
+   types; Porffor modules are loaded dynamically only by the adapter tool and
+   optional integration tests.
+4. Keep normal install, typecheck, build, and tests functional when
+   `vendor/Porffor` is absent or uninitialized.
+
+## Acceptance criteria
+
+- [x] JS2-owned types describe only the Porffor structures required by the
+      pilot and contain no static production import from `vendor/Porffor`.
+- [x] A compatibility test validates the pinned node/type/effect enums and the
+      renderer's function/module input records before rendering.
+- [x] A mismatched pin fails before emission with the expected and observed
+      schema fingerprints.
+- [x] Core typecheck and non-Porffor tests pass with the submodule unavailable.
+- [x] The issue changes are committed, pushed to `origin`, and published as a
+      ready, non-draft PR before completion is reported.
+
+## Implementation record (2026-07-16)
+
+P0 is implemented in ready PR #3107. The issue remains `in-progress` until the
+PR merges; #3288 remains the tracking umbrella.
+
+### Files
+
+- `src/ir/backend/porffor/compat.ts` freezes the exact commit, all 56 `K`
+  names/ordinals, eight `T` entries, six `FX` entries, six node slots, and the
+  JS2-owned function/module renderer records. A real `Const` probe verifies the
+  six-slot `[kind, type, effects, a, b, c]` constructor shape.
+- `src/ir/backend/porffor/loader.ts` checks the Git pin before dynamically
+  importing `compiler/ir.js` and `compiler/render.js`. It validates renderer
+  input before invocation and wraps import, schema, and render drift in an
+  actionable compatibility diagnostic. It is not on the public export graph.
+- `tests/issue-3295-porffor-compat.test.ts` covers compatible and mismatched
+  enums, mismatched commits, malformed nodes/records, unavailable checkout,
+  and optional real-renderer invocation.
+
+### Pinned findings
+
+At `60a1d41d60580ff4faa38ffd5f7783d23df68bad`, Porffor's required renderer
+record is `{ funcs, data, globals, entry, prefs, usedTypes }`. Each live
+function requires `{ name, index, params, retType, locals, body }`; parameters
+and globals use `{ name, type }`; function indices equal their `funcs` slots.
+The optional integration test passes that exact shape and receives C containing
+the probe function.
+
+### Validation
+
+- `pnpm run typecheck` - pass with `vendor/Porffor` absent.
+- `pnpm run build` - pass with `vendor/Porffor` absent; 297 modules transformed.
+- `pnpm run lint` and focused Prettier/Biome checks - pass.
+- `pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts` - 7 passed,
+  1 optional integration test skipped.
+- `JS2WASM_PORFFOR_ROOT=<pinned-read-only-checkout> pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts`
+  - 8 passed, including real renderer invocation.
+
+### Boundaries and handoff
+
+This slice adds no backend kind, generic lowering change, Porffor sink,
+`LinearMemoryPlan`, C compilation, or runtime differential test. Those remain
+owned by dependency-ordered children. After #3295 merges, #3296 is next and is
+gated by both #3295 and #2953.
+
+## Validation
+
+- Run the focused compatibility and optional-loader tests.
+- Run core typecheck with the Porffor integration disabled.
+- Exercise the mismatch diagnostic with a controlled fixture rather than
+  modifying the checked-out submodule.
+
+## Non-goals
+
+- Emitting a JS2 function as Porffor IR.
+- Importing Porffor's parser, AST lowering, builtins, object layouts, or GC.
+- Adding a public `compile()` target.
+
+## Handoff
+
+After this PR merges, #3296 may rely on the JS2-owned structural contract and
+optional loader without importing Porffor internals into generic lowering.

--- a/tests/issue-3295-porffor-compat.test.ts
+++ b/tests/issue-3295-porffor-compat.test.ts
@@ -65,7 +65,7 @@ function rendererProbe(retType = 0): PorfforRendererInput {
   };
 }
 
-describe("#3288 Porffor compatibility fingerprint", () => {
+describe("#3295 Porffor compatibility fingerprint", () => {
   it("accepts the frozen K/T/FX enums and six-slot node layout", () => {
     expect(() => assertPorfforIrCompatibility(compatibleIrModule())).not.toThrow();
   });
@@ -85,7 +85,7 @@ describe("#3288 Porffor compatibility fingerprint", () => {
   });
 });
 
-describe("#3288 Porffor renderer records", () => {
+describe("#3295 Porffor renderer records", () => {
   it("accepts the frozen module and function record shape", () => {
     expect(() => assertPorfforRendererInput(rendererProbe())).not.toThrow();
   });
@@ -112,7 +112,7 @@ describe("#3288 Porffor renderer records", () => {
   });
 });
 
-describe("#3288 optional Porffor loader", () => {
+describe("#3295 optional Porffor loader", () => {
   it("gives an actionable unavailable diagnostic without making Porffor mandatory", async () => {
     const missingRoot = join(here, "fixtures/porffor-intentionally-absent");
     await expect(loadOptionalPorffor({ root: missingRoot })).rejects.toThrow(


### PR DESCRIPTION
## Summary

- add child issue #3295 with the completed P0 compatibility findings, acceptance checks, validation, and handoff
- convert #3288 to the non-dispatchable tracking umbrella for children #3295 through #3300 without marking it complete
- rename the focused compatibility test from issue #3288 to #3295 and update suite labels

## Context

PR #3107 merged the P0 implementation before the split-aware documentation commit reached the branch. This follow-up contains only the remaining issue-scope correction; the compatibility and loader source is already on `main`.

The umbrella has no whole-issue dependency. #3296 is the next implementation slice after #3295 and is gated by both #3295 and #2953. All P1+ changes remain deferred.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts` (7 passed, 1 optional integration test skipped)
- `JS2WASM_PORFFOR_ROOT=<pinned-checkout> pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts` (8 passed)
- focused Biome and Prettier checks
- `node scripts/check-issue-ids.mjs`
- `node scripts/update-issues.mjs --check`
