### PR TITLE
feat(symphony): reconcile agent pull requests

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -2,13 +2,20 @@
 tracker:
   kind: markdown
   issues_dir: plan/issues
-  sprint: latest
-  active_states: [ready, in-progress]
+  sprint: current
+  active_states: [ready, in-progress, in-review]
   claimable_states: [ready]
   claim_state: in-progress
   terminal_states: [done, wont-fix]
 polling:
   interval_ms: 30000
+pull_requests:
+  enabled: true
+  repository: loopdive/js2
+  command: gh
+  poll_interval_ms: 30000
+  timeout_ms: 30000
+  review_states: [in-review, in-progress]
 workspace:
   kind: git_worktree
   root: .codex/worktrees/symphony
@@ -32,7 +39,7 @@ agent:
       prompt_mode: argument
       max_concurrent: 8
 codex:
-  command: codex exec -c approval_policy="never" --sandbox danger-full-access --skip-git-repo-check --json
+  command: codex exec -m gpt-5.6-sol -c approval_policy="never" --sandbox danger-full-access --skip-git-repo-check --json
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000
@@ -47,8 +54,13 @@ Issue file: {{ issue.file }}
 Sprint: {{ issue.sprint }}
 Workspace: {{ workspace.path }}
 Branch: {{ workspace.branch }}
+Pull request: {{ issue.pr }}
 Attempt: {{ attempt }}
 Agent lane: {{ agent.name }} ({{ agent.kind }} / {{ agent.role }})
+
+Issue specification:
+
+{{ issue.description }}
 
 Rules:
 
@@ -67,7 +79,10 @@ Rules:
 - Open a ready, non-draft pull request against `main`; do not mark the issue `done` until the PR
   exists.
 - Record the PR number in the issue frontmatter as `pr: <number>` and leave the issue
-  `status: in-review`; the PR-status poller flips it to `done` after GitHub reports the PR merged.
+  `status: in-review`; Symphony flips it to `done` after GitHub reports the PR merged.
+- On a retry attempt for an existing PR, inspect its failed checks first, repair the existing head
+  branch, push the fix, and keep the same PR. Preserve Symphony's `last_ci_retry_head` frontmatter
+  field and never open a duplicate PR for a CI repair.
 - Enqueue the PR in the merge queue when GitHub accepts it. If required checks are still pending,
   enable auto-merge/merge-queue entry so GitHub queues it as soon as checks pass.
 - Report changed files, validation, commit SHA, PR URL, and merge-queue or auto-merge state before

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -79,7 +79,8 @@ Rules:
 - Open a ready, non-draft pull request against `main`; do not mark the issue `done` until the PR
   exists.
 - Record the PR number in the issue frontmatter as `pr: <number>` and leave the issue
-  `status: in-review`; Symphony flips it to `done` after GitHub reports the PR merged.
+  `status: in-review`; Symphony also discovers the PR from the assigned branch if this metadata
+  write is missed, then flips the issue to `done` after GitHub reports the PR merged.
 - On a retry attempt for an existing PR, inspect its failed checks first, repair the existing head
   branch, push the fix, and keep the same PR. Preserve Symphony's `last_ci_retry_head` frontmatter
   field and never open a duplicate PR for a CI repair.

--- a/plan/method/symphony-service.md
+++ b/plan/method/symphony-service.md
@@ -37,9 +37,11 @@ again as fresh work.
 
 ## Pull Request Reconciliation
 
-Workers record `pr: <number>` and leave the issue `in-review`. On every
-configured PR polling interval Symphony asks GitHub for the PR head and check
-rollup:
+Symphony records the assigned `branch` at dispatch. Workers record
+`pr: <number>` and leave the issue `in-review`; if that metadata write is
+missed, Symphony discovers the PR by its assigned head branch and writes the PR
+number itself. On every configured PR polling interval Symphony asks GitHub for
+the PR head and check rollup:
 
 - A merged PR changes the issue to `done`, records the merge date in
   `completed`, releases any broker claim/retry, and immediately makes completed

--- a/plan/method/symphony-service.md
+++ b/plan/method/symphony-service.md
@@ -24,15 +24,42 @@ added later without changing the orchestrator or runner contracts.
 
 - `ready`: claimable by Symphony.
 - `in-progress`: claimed, running, or resumable by an existing retry.
-- `in-review`: worker published a PR or handed off for lead review.
+- `in-review`: worker published a PR; Symphony monitors it until merge or a
+  failed-CI repair dispatch.
 - `done` / `wont-fix`: terminal.
 
 On dispatch, Symphony immediately flips the issue frontmatter from `ready` to
 `in-progress` in the main checkout and mirrors that status into the assigned
 worktree issue file. `WORKFLOW.md` uses `tracker.claimable_states: [ready]` for
-fresh dispatch and `tracker.active_states: [ready, in-progress]` for
-reconciliation/retries, so a claimed issue is not picked again as fresh work and
-is not cancelled just because the claim state changed.
+fresh dispatch and keeps `ready`, `in-progress`, and `in-review` active for
+reconciliation. A published issue is therefore monitored without being picked
+again as fresh work.
+
+## Pull Request Reconciliation
+
+Workers record `pr: <number>` and leave the issue `in-review`. On every
+configured PR polling interval Symphony asks GitHub for the PR head and check
+rollup:
+
+- A merged PR changes the issue to `done`, records the merge date in
+  `completed`, releases any broker claim/retry, and immediately makes completed
+  dependencies visible to the normal candidate scan.
+- A failed check rollup changes the issue back to `in-progress` and dispatches
+  a repair attempt in the same deterministic workspace. If that workspace does
+  not exist, Symphony checks out the PR's actual head branch from `origin`.
+- Each failed head SHA is dispatched at most once. Symphony persists the
+  handled SHA as `last_ci_retry_head` in the issue and mirrors it into the
+  worker branch, together with the discovered PR `branch`. Restart or a
+  transient workspace failure therefore cannot reset the guard or switch the
+  repair onto a new branch. A subsequent push gets a new SHA and can trigger
+  another repair if its checks fail; an unchanged stale failure cannot create a
+  dispatch loop.
+- Pending or passing open PRs remain `in-review`. Symphony leaves merge-queue
+  enrollment to the worker contract.
+
+PR polling errors are logged without changing issue state. The standalone
+`issues:pr-status` poller remains useful for non-Symphony issues, but Symphony
+does not depend on it for its own workers.
 
 ## Agent Lanes
 
@@ -53,7 +80,8 @@ that can receive the rendered prompt and run in the assigned workspace.
 
 By default:
 
-- Codex uses `codex.command` unless `SYMPHONY_CODEX_COMMAND` overrides it.
+- Codex uses `gpt-5.6-sol` through `codex.command` unless
+  `SYMPHONY_CODEX_COMMAND` overrides the full command.
 - Claude uses a `claude-channel` lane. Symphony sends dispatch events to an interactive Claude Code team lead instead of launching `claude -p` workers.
 
 Start Claude Code with the project channel enabled:
@@ -121,6 +149,7 @@ Implemented:
 - structured JSONL logs
 - runtime state snapshot
 - retry/backoff and stall reconciliation
+- merged-PR completion and failed-CI repair reconciliation
 
 Not implemented yet:
 

--- a/scripts/symphony-pr-state.mjs
+++ b/scripts/symphony-pr-state.mjs
@@ -1,0 +1,95 @@
+import { spawnSync } from "node:child_process";
+
+const FAILED_CONCLUSIONS = new Set(["ACTION_REQUIRED", "CANCELLED", "FAILURE", "STARTUP_FAILURE", "TIMED_OUT"]);
+const PENDING_STATUSES = new Set(["IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"]);
+
+function checkName(check) {
+  return String(check?.name ?? check?.context ?? "unknown check");
+}
+
+function checkConclusion(check) {
+  return String(check?.conclusion ?? check?.state ?? "").toUpperCase();
+}
+
+function checkStatus(check) {
+  return String(check?.status ?? "").toUpperCase();
+}
+
+export function classifyPullRequest(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") throw new Error("invalid_pull_request_snapshot");
+
+  const state = String(snapshot.state ?? "").toUpperCase();
+  const headSha = snapshot.headRefOid ? String(snapshot.headRefOid) : null;
+  const base = {
+    number: Number(snapshot.number) || null,
+    url: snapshot.url ? String(snapshot.url) : null,
+    headBranch: snapshot.headRefName ? String(snapshot.headRefName) : null,
+    headSha,
+  };
+
+  if (state === "MERGED" || snapshot.mergedAt) {
+    return {
+      ...base,
+      status: "merged",
+      mergedAt: snapshot.mergedAt ? String(snapshot.mergedAt) : null,
+      failedChecks: [],
+    };
+  }
+
+  const checks = Array.isArray(snapshot.statusCheckRollup) ? snapshot.statusCheckRollup : [];
+  const failedChecks = checks.filter((check) => FAILED_CONCLUSIONS.has(checkConclusion(check))).map(checkName);
+  if (failedChecks.length > 0) return { ...base, status: "failed", mergedAt: null, failedChecks };
+
+  if (state === "CLOSED") return { ...base, status: "closed", mergedAt: null, failedChecks: [] };
+
+  const pending =
+    checks.length === 0 ||
+    checks.some((check) => {
+      const conclusion = checkConclusion(check);
+      return !conclusion || PENDING_STATUSES.has(checkStatus(check));
+    });
+  return { ...base, status: pending ? "pending" : "passed", mergedAt: null, failedChecks: [] };
+}
+
+export function planPullRequestAction(
+  state,
+  { handledFailureKey = null, busy = false, paused = false, hasCapacity = true } = {},
+) {
+  if (state.status === "merged") return { action: "mark_done", failureKey: null };
+  if (state.status !== "failed") return { action: "wait", failureKey: null };
+
+  const failureKey = state.headSha || `pr-${state.number || "unknown"}-unknown-head`;
+  if (handledFailureKey === failureKey) return { action: "wait", failureKey };
+  if (busy || paused || !hasCapacity) return { action: "defer", failureKey };
+  return { action: "requeue", failureKey };
+}
+
+export function readPullRequest({ command = "gh", cwd, number, repository = "", timeoutMs = 30_000 }) {
+  const args = [
+    "pr",
+    "view",
+    String(number),
+    "--json",
+    "number,state,mergedAt,url,headRefName,headRefOid,statusCheckRollup",
+  ];
+  if (repository) args.push("--repo", repository);
+
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw new Error(`pull_request_query_failed: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new Error(`pull_request_query_failed: ${String(result.stderr || result.stdout || result.status).trim()}`);
+  }
+
+  let snapshot;
+  try {
+    snapshot = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`pull_request_query_invalid_json: ${error.message}`);
+  }
+  return classifyPullRequest(snapshot);
+}

--- a/scripts/symphony-pr-state.mjs
+++ b/scripts/symphony-pr-state.mjs
@@ -93,3 +93,39 @@ export function readPullRequest({ command = "gh", cwd, number, repository = "", 
   }
   return classifyPullRequest(snapshot);
 }
+
+export function readPullRequestForBranch({ branch, command = "gh", cwd, repository = "", timeoutMs = 30_000 }) {
+  const args = [
+    "pr",
+    "list",
+    "--head",
+    String(branch),
+    "--state",
+    "all",
+    "--limit",
+    "1",
+    "--json",
+    "number,state,mergedAt,url,headRefName,headRefOid,statusCheckRollup",
+  ];
+  if (repository) args.push("--repo", repository);
+
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw new Error(`pull_request_query_failed: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new Error(`pull_request_query_failed: ${String(result.stderr || result.stdout || result.status).trim()}`);
+  }
+
+  let snapshots;
+  try {
+    snapshots = JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`pull_request_query_invalid_json: ${error.message}`);
+  }
+  if (!Array.isArray(snapshots)) throw new Error("pull_request_query_invalid_json: expected an array");
+  return snapshots.length > 0 ? classifyPullRequest(snapshots[0]) : null;
+}

--- a/scripts/symphony.mjs
+++ b/scripts/symphony.mjs
@@ -12,7 +12,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { planPullRequestAction, readPullRequest } from "./symphony-pr-state.mjs";
+import { planPullRequestAction, readPullRequest, readPullRequestForBranch } from "./symphony-pr-state.mjs";
 
 const ROOT = path.resolve(path.join(path.dirname(new URL(import.meta.url).pathname), ".."));
 const DEFAULT_WORKFLOW = path.join(ROOT, "WORKFLOW.md");
@@ -1147,6 +1147,8 @@ class Orchestrator {
         return;
       }
       workspace = this.workspaceManager.ensure(issue);
+      issue.branch_name = workspace.branch;
+      this.tracker.updateIssueStatusFile(issue, issue.file, issue.state, { branch: workspace.branch });
       const workspaceClaim = this.tracker.claimIssueInWorkspace(issue, workspace, lane);
       if (workspaceClaim?.changed) {
         this.logger.event("workspace_issue_claimed", {
@@ -1417,17 +1419,25 @@ class Orchestrator {
     const issues = this.tracker.fetchIssuesByStates(reviewStates);
 
     for (const issue of issues) {
-      if (!issue.pull_request) continue;
+      if (!issue.pull_request && !issue.branch_name) continue;
       const id = String(issue.id);
       let state;
       try {
-        state = readPullRequest({
-          command,
-          cwd: ROOT,
-          number: issue.pull_request,
-          repository,
-          timeoutMs,
-        });
+        state = issue.pull_request
+          ? readPullRequest({
+              command,
+              cwd: ROOT,
+              number: issue.pull_request,
+              repository,
+              timeoutMs,
+            })
+          : readPullRequestForBranch({
+              branch: issue.branch_name,
+              command,
+              cwd: ROOT,
+              repository,
+              timeoutMs,
+            });
       } catch (error) {
         this.logger.event("pull_request_poll_failed", {
           issue_id: issue.id,
@@ -1438,9 +1448,24 @@ class Orchestrator {
         });
         continue;
       }
+      if (!state) continue;
 
       this.pullRequestStates.set(id, state);
       if (state.headBranch) issue.branch_name = state.headBranch;
+      if (!issue.pull_request && state.number) {
+        issue.pull_request = state.number;
+        issue.pr = state.number;
+        this.tracker.updateIssueStatusFile(issue, issue.file, issue.state, {
+          pr: state.number,
+          ...(issue.branch_name ? { branch: issue.branch_name } : {}),
+        });
+        this.logger.event("pull_request_discovered", {
+          issue_id: issue.id,
+          issue_identifier: issue.identifier,
+          pr: state.number,
+          branch: issue.branch_name,
+        });
+      }
       const planned = planPullRequestAction(state, {
         handledFailureKey: this.handledFailedPrHeads.get(id) || issue.last_ci_retry_head,
         busy: this.running.has(id) || this.claimed.has(id) || this.retryAttempts.has(id),

--- a/scripts/symphony.mjs
+++ b/scripts/symphony.mjs
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { planPullRequestAction, readPullRequest } from "./symphony-pr-state.mjs";
 
 const ROOT = path.resolve(path.join(path.dirname(new URL(import.meta.url).pathname), ".."));
 const DEFAULT_WORKFLOW = path.join(ROOT, "WORKFLOW.md");
@@ -365,6 +366,12 @@ function readArrayField(fm, key) {
     .filter(Boolean);
 }
 
+function readPullRequestNumber(fm) {
+  const raw = readScalarField(fm, "pr", "");
+  const match = raw.match(/\/pull\/(\d+)/i) || raw.match(/#(\d+)/) || raw.match(/^\s*(\d+)\s*$/);
+  return match ? Number(match[1]) : null;
+}
+
 function walkIssueFiles(dir) {
   if (!existsSync(dir)) return [];
   const out = [];
@@ -417,6 +424,7 @@ function loadMarkdownIssues(config) {
     const id = readScalarField(fm, "id", basenameIssueId(file));
     const state = normalizeState(readScalarField(fm, "status", "ready"));
     const sprint = readScalarField(fm, "sprint", "");
+    const pullRequest = readPullRequestNumber(fm);
     const issue = {
       id,
       identifier: id,
@@ -425,7 +433,10 @@ function loadMarkdownIssues(config) {
       priority: priorityRank(fm.priority),
       priority_raw: fm.priority ?? null,
       state,
-      branch_name: null,
+      branch_name: readScalarField(fm, "branch", null),
+      pull_request: pullRequest,
+      pr: pullRequest,
+      last_ci_retry_head: readScalarField(fm, "last_ci_retry_head", null),
       url: null,
       labels: [fm.area, fm.task_type, fm.language_feature, fm.goal].filter(Boolean).map((v) => String(v).toLowerCase()),
       blocked_by: readArrayField(fm, "depends_on").map((dep) => ({ id: dep, identifier: dep, state: null })),
@@ -502,6 +513,8 @@ class MarkdownTracker {
     return this.updateIssueStatusFile(issue, workspaceIssueFile, claimState, {
       claimed_by: lane.name,
       claimed_at: new Date().toISOString(),
+      ...(issue.branch_name ? { branch: issue.branch_name } : {}),
+      ...(issue.last_ci_retry_head ? { last_ci_retry_head: issue.last_ci_retry_head } : {}),
     });
   }
 
@@ -615,13 +628,18 @@ class WorkspaceManager {
     if (!workspaceAbs.startsWith(`${rootAbs}${path.sep}`) && workspaceAbs !== rootAbs) {
       throw new Error(`workspace_outside_root: ${workspaceAbs}`);
     }
-    const branch = `${this.branchPrefix}/${key}`;
+    const branch = issue.branch_name || `${this.branchPrefix}/${key}`;
     const createdNow = !existsSync(workspaceAbs);
     if (createdNow) {
       mkdirSync(rootAbs, { recursive: true });
       if (this.kind === "git_worktree") this.createGitWorktree(workspaceAbs, branch);
       else mkdirSync(workspaceAbs, { recursive: true });
       this.runHook("after_create", workspaceAbs, issue);
+    } else if (this.kind === "git_worktree") {
+      const actualBranch = this.git(["branch", "--show-current"], workspaceAbs);
+      if (actualBranch !== branch) {
+        throw new Error(`workspace_branch_mismatch: expected ${branch}, found ${actualBranch || "detached"}`);
+      }
     }
     return { path: workspaceAbs, workspace_key: key, created_now: createdNow, branch };
   }
@@ -629,7 +647,9 @@ class WorkspaceManager {
   createGitWorktree(workspacePath, branch) {
     if (this.fetchBeforeCreate) this.git(["fetch", "origin"], ROOT);
     const branchExists = this.gitOptional(["show-ref", "--verify", `refs/heads/${branch}`], ROOT);
+    const remoteBranchExists = this.gitOptional(["show-ref", "--verify", `refs/remotes/origin/${branch}`], ROOT);
     if (branchExists) this.git(["worktree", "add", workspacePath, branch], ROOT);
+    else if (remoteBranchExists) this.git(["worktree", "add", workspacePath, "-b", branch, `origin/${branch}`], ROOT);
     else this.git(["worktree", "add", workspacePath, "-b", branch, this.baseRef], ROOT);
   }
 
@@ -889,6 +909,10 @@ class Orchestrator {
     this.claimed = new Set();
     this.retryAttempts = new Map();
     this.completed = new Set();
+    this.pullRequestStates = new Map();
+    this.handledFailedPrHeads = new Map();
+    this.pullRequestRetryCounts = new Map();
+    this.lastPullRequestPollAt = 0;
     this.codexTotals = { input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0 };
     this.rateLimits = null;
     this.laneCursor = 0;
@@ -1007,6 +1031,10 @@ class Orchestrator {
     return Number(get(this.config, "polling.interval_ms", 30000)) || 30000;
   }
 
+  pullRequestPollInterval() {
+    return Number(get(this.config, "pull_requests.poll_interval_ms", this.pollInterval())) || this.pollInterval();
+  }
+
   validate() {
     const kind = get(this.config, "tracker.kind", "");
     if (kind !== "markdown") throw new Error(`unsupported_tracker_kind: ${kind || "(missing)"}`);
@@ -1020,8 +1048,9 @@ class Orchestrator {
 
   async tick() {
     this.processControls();
-    this.reconcileRunning();
     this.validate();
+    this.reconcilePullRequests();
+    this.reconcileRunning();
     if (this.stopping && this.running.size === 0) {
       this.shouldExit = true;
       this.writeState();
@@ -1269,7 +1298,16 @@ class Orchestrator {
         reason: this.stopping ? "stopping" : this.draining ? "draining" : "operator control",
       });
     } else if (result.status === "succeeded") {
-      this.completed.add(id);
+      const current = this.tracker.fetchIssueStatesByIds([id])[0];
+      if (current?.pull_request && current.state === "in-review") {
+        this.logger.event("agent_awaiting_pull_request", {
+          issue_id: issue.id,
+          issue_identifier: issue.identifier,
+          pr: current.pull_request,
+        });
+      } else {
+        this.completed.add(id);
+      }
       const maxTurns = Number(get(this.config, "agent.max_turns", 1)) || 1;
       if ((attempt ?? 0) + 1 < maxTurns) this.scheduleRetry(issue, lane, "continuation", 1000, (attempt ?? 0) + 1);
     } else {
@@ -1365,6 +1403,106 @@ class Orchestrator {
       }
     }
   }
+
+  reconcilePullRequests() {
+    if (this.options.dryRun || get(this.config, "pull_requests.enabled", true) === false) return;
+    const now = Date.now();
+    if (now - this.lastPullRequestPollAt < this.pullRequestPollInterval()) return;
+    this.lastPullRequestPollAt = now;
+
+    const reviewStates = asArray(get(this.config, "pull_requests.review_states"), ["in-review", "in-progress"]);
+    const repository = String(get(this.config, "pull_requests.repository", ""));
+    const command = String(get(this.config, "pull_requests.command", "gh"));
+    const timeoutMs = Number(get(this.config, "pull_requests.timeout_ms", 30000)) || 30000;
+    const issues = this.tracker.fetchIssuesByStates(reviewStates);
+
+    for (const issue of issues) {
+      if (!issue.pull_request) continue;
+      const id = String(issue.id);
+      let state;
+      try {
+        state = readPullRequest({
+          command,
+          cwd: ROOT,
+          number: issue.pull_request,
+          repository,
+          timeoutMs,
+        });
+      } catch (error) {
+        this.logger.event("pull_request_poll_failed", {
+          issue_id: issue.id,
+          issue_identifier: issue.identifier,
+          pr: issue.pull_request,
+          error: error.message,
+          quiet: true,
+        });
+        continue;
+      }
+
+      this.pullRequestStates.set(id, state);
+      if (state.headBranch) issue.branch_name = state.headBranch;
+      const planned = planPullRequestAction(state, {
+        handledFailureKey: this.handledFailedPrHeads.get(id) || issue.last_ci_retry_head,
+        busy: this.running.has(id) || this.claimed.has(id) || this.retryAttempts.has(id),
+        paused: this.paused || this.draining || this.stopping,
+        hasCapacity: this.running.size < this.maxConcurrent(),
+      });
+
+      if (planned.action === "mark_done") {
+        const completed = state.mergedAt ? state.mergedAt.slice(0, 10) : todayIsoDate();
+        const update = this.tracker.updateIssueStatusFile(issue, issue.file, "done", { completed });
+        const retry = this.retryAttempts.get(id);
+        if (retry?.timer_handle) clearTimeout(retry.timer_handle);
+        this.retryAttempts.delete(id);
+        this.claimed.delete(id);
+        this.completed.add(id);
+        this.handledFailedPrHeads.delete(id);
+        if (activeDispatchClaim(id)) releaseDispatchClaim(id, `PR #${issue.pull_request} merged`);
+        if (update?.changed) {
+          this.logger.event("pull_request_merged_issue_done", {
+            issue_id: issue.id,
+            issue_identifier: issue.identifier,
+            pr: issue.pull_request,
+            completed,
+          });
+        }
+        continue;
+      }
+
+      if (planned.action === "defer") {
+        this.logger.event("pull_request_failure_deferred", {
+          issue_id: issue.id,
+          issue_identifier: issue.identifier,
+          pr: issue.pull_request,
+          head_sha: state.headSha,
+          quiet: true,
+        });
+        continue;
+      }
+      if (planned.action !== "requeue") continue;
+
+      const lane = this.nextAvailableLane();
+      if (!lane) continue;
+      issue.last_ci_retry_head = planned.failureKey;
+      this.tracker.updateIssueStatusFile(issue, issue.file, "in-progress", {
+        ...(issue.branch_name ? { branch: issue.branch_name } : {}),
+        last_ci_retry_head: planned.failureKey,
+      });
+      this.handledFailedPrHeads.set(id, planned.failureKey);
+      const attempt = (this.pullRequestRetryCounts.get(id) ?? 0) + 1;
+      this.pullRequestRetryCounts.set(id, attempt);
+      this.logger.event("pull_request_ci_failed_requeued", {
+        issue_id: issue.id,
+        issue_identifier: issue.identifier,
+        pr: issue.pull_request,
+        head_sha: state.headSha,
+        failed_checks: state.failedChecks.join(", "),
+        lane: lane.name,
+      });
+      this.dispatch(issue, lane, attempt);
+    }
+  }
+
   reconcileRunning() {
     this.reconcileChannelDispatches();
     const stallMs = Number(get(this.config, "codex.stall_timeout_ms", 300000)) || 0;
@@ -1391,6 +1529,7 @@ class Orchestrator {
       const issue = current.get(id);
       if (!issue) continue;
       if (this.tracker.terminalStates.has(issue.state)) {
+        this.suppressedRetries.add(id);
         if (entry.lane.kind === "claude-channel") {
           this.running.delete(id);
           this.claimed.delete(id);
@@ -1454,6 +1593,7 @@ class Orchestrator {
       })),
       claimed: [...this.claimed],
       completed: [...this.completed],
+      pull_requests: Object.fromEntries(this.pullRequestStates),
       codex_totals: {
         ...this.codexTotals,
         seconds_running:

--- a/tests/symphony-pr-reconciliation.test.ts
+++ b/tests/symphony-pr-reconciliation.test.ts
@@ -1,0 +1,216 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { classifyPullRequest, planPullRequestAction, readPullRequest } from "../scripts/symphony-pr-state.mjs";
+
+describe("Symphony pull-request reconciliation", () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  it("classifies merged and failed pull requests", () => {
+    expect(
+      classifyPullRequest({
+        number: 42,
+        state: "MERGED",
+        mergedAt: "2026-07-16T08:00:00Z",
+        headRefName: "symphony/42",
+        headRefOid: "abc123",
+        statusCheckRollup: [],
+      }),
+    ).toMatchObject({ status: "merged", headBranch: "symphony/42", headSha: "abc123" });
+
+    expect(
+      classifyPullRequest({
+        number: 43,
+        state: "OPEN",
+        headRefOid: "def456",
+        statusCheckRollup: [
+          { name: "quality", status: "COMPLETED", conclusion: "FAILURE" },
+          { context: "cla-check", state: "SUCCESS" },
+        ],
+      }),
+    ).toMatchObject({ status: "failed", headSha: "def456", failedChecks: ["quality"] });
+  });
+
+  it("distinguishes pending checks from a passing rollup", () => {
+    expect(
+      classifyPullRequest({
+        state: "OPEN",
+        statusCheckRollup: [{ name: "quality", status: "IN_PROGRESS", conclusion: null }],
+      }).status,
+    ).toBe("pending");
+    expect(
+      classifyPullRequest({
+        state: "OPEN",
+        statusCheckRollup: [
+          { name: "quality", status: "COMPLETED", conclusion: "SUCCESS" },
+          { name: "optional", status: "COMPLETED", conclusion: "SKIPPED" },
+        ],
+      }).status,
+    ).toBe("passed");
+  });
+
+  it("requeues one failed head once and closes merged work", () => {
+    const failed = classifyPullRequest({
+      number: 44,
+      state: "OPEN",
+      headRefOid: "failed-sha",
+      statusCheckRollup: [{ name: "quality", conclusion: "FAILURE" }],
+    });
+    expect(planPullRequestAction(failed)).toEqual({ action: "requeue", failureKey: "failed-sha" });
+    expect(planPullRequestAction(failed, { handledFailureKey: "failed-sha" })).toEqual({
+      action: "wait",
+      failureKey: "failed-sha",
+    });
+    expect(planPullRequestAction(failed, { busy: true })).toEqual({
+      action: "defer",
+      failureKey: "failed-sha",
+    });
+    expect(planPullRequestAction(classifyPullRequest({ state: "MERGED" }))).toEqual({
+      action: "mark_done",
+      failureKey: null,
+    });
+  });
+
+  it("queries gh with the configured repository and classifies its response", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-pr-"));
+    const fakeGh = join(tempDir, "gh");
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr view 99"*"--repo loopdive/js2"*)
+    printf '%s\\n' '{"number":99,"state":"OPEN","url":"https://example.test/99","headRefName":"agent/99","headRefOid":"sha99","statusCheckRollup":[{"name":"quality","status":"COMPLETED","conclusion":"TIMED_OUT"}]}'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    chmodSync(fakeGh, 0o755);
+
+    expect(readPullRequest({ command: fakeGh, cwd: tempDir, number: 99, repository: "loopdive/js2" })).toMatchObject({
+      number: 99,
+      status: "failed",
+      headBranch: "agent/99",
+      headSha: "sha99",
+      failedChecks: ["quality"],
+    });
+  });
+
+  it("persists one repair per failed SHA and marks a later merge done", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-reconcile-"));
+    const issuesDir = join(tempDir, "issues");
+    const workspaceRoot = join(tempDir, "workspaces");
+    const loggingRoot = join(tempDir, "logs");
+    const issueFile = join(issuesDir, "9001-pr-retry.md");
+    const workflow = join(tempDir, "WORKFLOW.md");
+    const fakeGh = join(tempDir, "gh");
+    const fakeAgent = join(tempDir, "agent");
+    const response = join(tempDir, "pr.json");
+    const marker = join(tempDir, "agent-runs.txt");
+
+    mkdirSync(issuesDir, { recursive: true });
+    writeFileSync(
+      issueFile,
+      `---
+id: 9001
+title: "PR retry probe"
+status: in-review
+sprint: probe
+pr: https://github.com/loopdive/js2/pull/99
+---
+# PR retry probe
+`,
+    );
+    writeFileSync(
+      workflow,
+      `---
+tracker:
+  kind: markdown
+  issues_dir: ${issuesDir}
+  sprint: probe
+  active_states: [ready, in-progress, in-review]
+  claimable_states: [ready]
+  claim_state: in-progress
+  terminal_states: [done, wont-fix]
+polling:
+  interval_ms: 10
+pull_requests:
+  enabled: true
+  repository: loopdive/js2
+  command: ${fakeGh}
+  poll_interval_ms: 10
+  review_states: [in-review, in-progress]
+workspace:
+  kind: directory
+  root: ${workspaceRoot}
+agent:
+  max_concurrent_agents: 1
+  max_turns: 1
+  lanes:
+    - name: fake-agent
+      kind: generic
+      command: ${fakeAgent}
+      prompt_mode: stdin
+      max_concurrent: 1
+logging:
+  root: ${loggingRoot}
+---
+Issue {{ issue.identifier }} attempt {{ attempt }}
+`,
+    );
+    writeFileSync(fakeGh, `#!/bin/sh\ncat "$PR_RESPONSE"\n`);
+    writeFileSync(fakeAgent, `#!/bin/sh\nprintf 'run\\n' >> "$AGENT_MARKER"\ncat >/dev/null\n`);
+    chmodSync(fakeGh, 0o755);
+    chmodSync(fakeAgent, 0o755);
+
+    const runSymphony = () =>
+      execFileSync(process.execPath, ["scripts/symphony.mjs", "--workflow", workflow, "--once"], {
+        cwd: process.cwd(),
+        env: { ...process.env, PR_RESPONSE: response, AGENT_MARKER: marker },
+        stdio: "pipe",
+      });
+
+    writeFileSync(
+      response,
+      JSON.stringify({
+        number: 99,
+        state: "OPEN",
+        headRefName: "agent/9001",
+        headRefOid: "failed-sha",
+        statusCheckRollup: [{ name: "quality", status: "COMPLETED", conclusion: "FAILURE" }],
+      }),
+    );
+    runSymphony();
+    const failedIssue = readFileSync(issueFile, "utf8");
+    expect(failedIssue).toContain("last_ci_retry_head: failed-sha");
+    expect(failedIssue).toContain("branch: agent/9001");
+    expect(readFileSync(marker, "utf8")).toBe("run\n");
+
+    runSymphony();
+    expect(readFileSync(marker, "utf8")).toBe("run\n");
+
+    writeFileSync(
+      response,
+      JSON.stringify({
+        number: 99,
+        state: "MERGED",
+        mergedAt: "2026-07-16T09:00:00Z",
+        headRefName: "agent/9001",
+        headRefOid: "fixed-sha",
+        statusCheckRollup: [],
+      }),
+    );
+    runSymphony();
+    const mergedIssue = readFileSync(issueFile, "utf8");
+    expect(mergedIssue).toContain("status: done");
+    expect(mergedIssue).toContain("completed: 2026-07-16");
+    expect(readFileSync(marker, "utf8")).toBe("run\n");
+  });
+});

--- a/tests/symphony-pr-reconciliation.test.ts
+++ b/tests/symphony-pr-reconciliation.test.ts
@@ -3,7 +3,12 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { classifyPullRequest, planPullRequestAction, readPullRequest } from "../scripts/symphony-pr-state.mjs";
+import {
+  classifyPullRequest,
+  planPullRequestAction,
+  readPullRequest,
+  readPullRequestForBranch,
+} from "../scripts/symphony-pr-state.mjs";
 
 describe("Symphony pull-request reconciliation", () => {
   let tempDir: string | undefined;
@@ -103,6 +108,32 @@ esac
     });
   });
 
+  it("discovers an agent PR from its assigned branch", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-pr-branch-"));
+    const fakeGh = join(tempDir, "gh");
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr list --head agent/100"*"--repo loopdive/js2"*)
+    printf '%s\\n' '[{"number":100,"state":"OPEN","headRefName":"agent/100","headRefOid":"sha100","statusCheckRollup":[]}]'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    chmodSync(fakeGh, 0o755);
+
+    expect(
+      readPullRequestForBranch({
+        branch: "agent/100",
+        command: fakeGh,
+        cwd: tempDir,
+        repository: "loopdive/js2",
+      }),
+    ).toMatchObject({ number: 100, status: "pending", headBranch: "agent/100" });
+  });
+
   it("persists one repair per failed SHA and marks a later merge done", () => {
     tempDir = mkdtempSync(join(tmpdir(), "symphony-reconcile-"));
     const issuesDir = join(tempDir, "issues");
@@ -123,7 +154,7 @@ id: 9001
 title: "PR retry probe"
 status: in-review
 sprint: probe
-pr: https://github.com/loopdive/js2/pull/99
+branch: agent/9001
 ---
 # PR retry probe
 `,
@@ -165,7 +196,18 @@ logging:
 Issue {{ issue.identifier }} attempt {{ attempt }}
 `,
     );
-    writeFileSync(fakeGh, `#!/bin/sh\ncat "$PR_RESPONSE"\n`);
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+if [ "$2" = "list" ]; then
+  printf '['
+  cat "$PR_RESPONSE"
+  printf ']\\n'
+else
+  cat "$PR_RESPONSE"
+fi
+`,
+    );
     writeFileSync(fakeAgent, `#!/bin/sh\nprintf 'run\\n' >> "$AGENT_MARKER"\ncat >/dev/null\n`);
     chmodSync(fakeGh, 0o755);
     chmodSync(fakeAgent, 0o755);
@@ -189,6 +231,7 @@ Issue {{ issue.identifier }} attempt {{ attempt }}
     );
     runSymphony();
     const failedIssue = readFileSync(issueFile, "utf8");
+    expect(failedIssue).toContain("pr: 99");
     expect(failedIssue).toContain("last_ci_retry_head: failed-sha");
     expect(failedIssue).toContain("branch: agent/9001");
     expect(readFileSync(marker, "utf8")).toBe("run\n");


### PR DESCRIPTION
## Summary

- keep published issues active and poll their GitHub PR state inside Symphony
- persist assigned branches and discover PR numbers when an agent misses the frontmatter update
- mark merged PR issues done and immediately unblock dependency scanning
- requeue failed CI on the existing PR head branch once per head SHA, with a durable restart guard
- default Symphony Codex workers to gpt-5.6-sol and document the lifecycle

## Safety

- pending and passing open PRs remain in review
- unchanged failed SHAs cannot create dispatch loops, including across daemon restarts
- existing workspaces must match the PR head branch; mismatches fail loudly
- PR polling errors leave issue state unchanged

## Validation

- 6 focused unit/integration tests passed
- TypeScript no-emit check passed
- Prettier check passed
- Biome lint reported no errors
- Node syntax checks passed
- Symphony dry-run workflow parse passed