### PR TITLE
fix(symphony): continue merged multi-slice issues ✓

### DIFF
--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -3,6 +3,8 @@ id: 2953
 title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait"
 status: in-progress
 assignee: ttraenkler/opus-1a
+branch: agent/2953-unions-boxing
+pr: 3108
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02

--- a/plan/issues/2956-linear-backend-consumes-ir.md
+++ b/plan/issues/2956-linear-backend-consumes-ir.md
@@ -2,6 +2,8 @@
 id: 2956
 title: "Linear backend consumes the IR front-end: wire the selector + LinearEmitter into generateLinearModule"
 status: in-progress
+branch: codex/2956-l2-vec
+pr: 3110
 sprint: current
 created: 2026-07-02
 updated: 2026-07-10

--- a/plan/method/symphony-service.md
+++ b/plan/method/symphony-service.md
@@ -43,9 +43,12 @@ missed, Symphony discovers the PR by its assigned head branch and writes the PR
 number itself. On every configured PR polling interval Symphony asks GitHub for
 the PR head and check rollup:
 
-- A merged PR changes the issue to `done`, records the merge date in
-  `completed`, releases any broker claim/retry, and immediately makes completed
-  dependencies visible to the normal candidate scan.
+- A merged PR for an `in-review` issue changes the issue to `done`, records the
+  merge date in `completed`, releases any broker claim/retry, and immediately
+  makes completed dependencies visible to the normal candidate scan.
+- A merged PR for an `in-progress` multi-slice issue clears the old PR, records
+  it in `last_merged_pr`, and returns the issue to `ready` for its next slice.
+  The durable merge key prevents restart from requeueing the same merged PR.
 - A failed check rollup changes the issue back to `in-progress` and dispatches
   a repair attempt in the same deterministic workspace. If that workspace does
   not exist, Symphony checks out the PR's actual head branch from `origin`.

--- a/scripts/symphony-pr-state.mjs
+++ b/scripts/symphony-pr-state.mjs
@@ -53,9 +53,26 @@ export function classifyPullRequest(snapshot) {
 
 export function planPullRequestAction(
   state,
-  { handledFailureKey = null, busy = false, paused = false, hasCapacity = true } = {},
+  {
+    handledFailureKey = null,
+    issueState = "in-review",
+    lastMergedPr = null,
+    busy = false,
+    paused = false,
+    hasCapacity = true,
+  } = {},
 ) {
-  if (state.status === "merged") return { action: "mark_done", failureKey: null };
+  if (state.status === "merged") {
+    if (issueState === "in-progress") {
+      const mergeKey = state.number ? String(state.number) : state.headSha || "unknown-merge";
+      return {
+        action: String(lastMergedPr || "") === mergeKey ? "wait" : "continue",
+        failureKey: null,
+        mergeKey,
+      };
+    }
+    return { action: "mark_done", failureKey: null, mergeKey: null };
+  }
   if (state.status !== "failed") return { action: "wait", failureKey: null };
 
   const failureKey = state.headSha || `pr-${state.number || "unknown"}-unknown-head`;

--- a/scripts/symphony.mjs
+++ b/scripts/symphony.mjs
@@ -437,6 +437,7 @@ function loadMarkdownIssues(config) {
       pull_request: pullRequest,
       pr: pullRequest,
       last_ci_retry_head: readScalarField(fm, "last_ci_retry_head", null),
+      last_merged_pr: readScalarField(fm, "last_merged_pr", null),
       url: null,
       labels: [fm.area, fm.task_type, fm.language_feature, fm.goal].filter(Boolean).map((v) => String(v).toLowerCase()),
       blocked_by: readArrayField(fm, "depends_on").map((dep) => ({ id: dep, identifier: dep, state: null })),
@@ -1468,6 +1469,8 @@ class Orchestrator {
       }
       const planned = planPullRequestAction(state, {
         handledFailureKey: this.handledFailedPrHeads.get(id) || issue.last_ci_retry_head,
+        issueState: issue.state,
+        lastMergedPr: issue.last_merged_pr,
         busy: this.running.has(id) || this.claimed.has(id) || this.retryAttempts.has(id),
         paused: this.paused || this.draining || this.stopping,
         hasCapacity: this.running.size < this.maxConcurrent(),
@@ -1491,6 +1494,39 @@ class Orchestrator {
             completed,
           });
         }
+        continue;
+      }
+
+      if (planned.action === "continue") {
+        const running = this.running.get(id);
+        const retry = this.retryAttempts.get(id);
+        if (retry?.timer_handle) clearTimeout(retry.timer_handle);
+        this.retryAttempts.delete(id);
+        this.pullRequestRetryCounts.delete(id);
+        this.handledFailedPrHeads.delete(id);
+        if (running?.lane.kind !== "claude-channel") {
+          this.suppressedRetries.add(id);
+          running?.child.kill("SIGTERM");
+        } else if (activeDispatchClaim(id)) {
+          releaseDispatchClaim(id, `PR #${state.number} merged; continuing issue`);
+        }
+        issue.last_merged_pr = planned.mergeKey;
+        issue.last_ci_retry_head = null;
+        issue.pull_request = null;
+        issue.pr = null;
+        this.tracker.updateIssueStatusFile(issue, issue.file, "ready", {
+          pr: null,
+          last_ci_retry_head: null,
+          last_merged_pr: planned.mergeKey,
+        });
+        if (!running) this.claimed.delete(id);
+        this.completed.delete(id);
+        this.logger.event("pull_request_merged_issue_requeued", {
+          issue_id: issue.id,
+          issue_identifier: issue.identifier,
+          pr: state.number,
+          branch: issue.branch_name,
+        });
         continue;
       }
 

--- a/tests/symphony-pr-reconciliation.test.ts
+++ b/tests/symphony-pr-reconciliation.test.ts
@@ -80,7 +80,19 @@ describe("Symphony pull-request reconciliation", () => {
     expect(planPullRequestAction(classifyPullRequest({ state: "MERGED" }))).toEqual({
       action: "mark_done",
       failureKey: null,
+      mergeKey: null,
     });
+    expect(
+      planPullRequestAction(classifyPullRequest({ number: 45, state: "MERGED" }), {
+        issueState: "in-progress",
+      }),
+    ).toEqual({ action: "continue", failureKey: null, mergeKey: "45" });
+    expect(
+      planPullRequestAction(classifyPullRequest({ number: 45, state: "MERGED" }), {
+        issueState: "in-progress",
+        lastMergedPr: 45,
+      }),
+    ).toEqual({ action: "wait", failureKey: null, mergeKey: "45" });
   });
 
   it("queries gh with the configured repository and classifies its response", () => {
@@ -134,7 +146,7 @@ esac
     ).toMatchObject({ number: 100, status: "pending", headBranch: "agent/100" });
   });
 
-  it("persists one repair per failed SHA and marks a later merge done", () => {
+  it("persists one repair per failed SHA, continues a merged slice, and marks the final merge done", () => {
     tempDir = mkdtempSync(join(tmpdir(), "symphony-reconcile-"));
     const issuesDir = join(tempDir, "issues");
     const workspaceRoot = join(tempDir, "workspaces");
@@ -251,9 +263,32 @@ fi
       }),
     );
     runSymphony();
+    const continuedIssue = readFileSync(issueFile, "utf8");
+    expect(continuedIssue).toContain("status: in-progress");
+    expect(continuedIssue).toContain("pr: null");
+    expect(continuedIssue).toContain("last_ci_retry_head: null");
+    expect(continuedIssue).toContain("last_merged_pr: 99");
+    expect(readFileSync(marker, "utf8")).toBe("run\nrun\n");
+
+    writeFileSync(
+      issueFile,
+      continuedIssue.replace("status: in-progress", "status: in-review").replace("pr: null", "pr: 100"),
+    );
+    writeFileSync(
+      response,
+      JSON.stringify({
+        number: 100,
+        state: "MERGED",
+        mergedAt: "2026-07-16T10:00:00Z",
+        headRefName: "agent/9001",
+        headRefOid: "final-sha",
+        statusCheckRollup: [],
+      }),
+    );
+    runSymphony();
     const mergedIssue = readFileSync(issueFile, "utf8");
     expect(mergedIssue).toContain("status: done");
     expect(mergedIssue).toContain("completed: 2026-07-16");
-    expect(readFileSync(marker, "utf8")).toBe("run\n");
+    expect(readFileSync(marker, "utf8")).toBe("run\nrun\n");
   });
 });


### PR DESCRIPTION
## Summary
- requeue an in-progress issue after a slice PR merges while completing final in-review PRs
- cancel stale CI repair timers/state and guard merged slices across Symphony restarts
- register the active #2953/#2956 PR branches so their failed CI is discoverable

## Validation
- pnpm exec vitest run tests/symphony-pr-reconciliation.test.ts (6 tests)
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm run check:issues
- pnpm run check:issue-ids
- pnpm run symphony:dry-run -- --json
- node --check scripts/symphony.mjs
- node --check scripts/symphony-pr-state.mjs