### PR TITLE
feat(symphony): scope Porffor backend workflow (#3288) ✓

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,8 @@
 	path = test262
 	url = https://github.com/tc39/test262.git
 	ignore = untracked
+[submodule "porffor"]
+	path = vendor/Porffor
+	url = https://github.com/CanadaHonk/porffor.git
+	update = none
+	ignore = all

--- a/WORKFLOW.porffor.md
+++ b/WORKFLOW.porffor.md
@@ -1,0 +1,101 @@
+---
+tracker:
+  kind: markdown
+  issues_dir: plan/issues
+  sprint: porffor-backend
+  active_states: [ready, in-progress, in-review]
+  claimable_states: [ready]
+  claim_state: in-progress
+  terminal_states: [done, wont-fix]
+polling:
+  interval_ms: 30000
+pull_requests:
+  enabled: true
+  repository: loopdive/js2
+  command: gh
+  poll_interval_ms: 30000
+  timeout_ms: 30000
+  review_states: [in-review, in-progress]
+  sprint_only: true
+  include_dependencies: true
+workspace:
+  kind: git_worktree
+  root: .codex/worktrees/symphony-porffor
+  base_ref: origin/main
+  branch_prefix: symphony/porffor
+  fetch_before_create: true
+hooks:
+  timeout_ms: 120000
+  after_create: |
+    git submodule update --init --checkout vendor/Porffor
+    common_dir="$(git rev-parse --git-common-dir)"
+    repo_root="$(cd "$common_dir/.." && pwd)"
+    if [ -d "$repo_root/node_modules" ] && [ ! -e node_modules ]; then
+      ln -s "$repo_root/node_modules" node_modules
+    fi
+agent:
+  max_concurrent_agents: 1
+  max_turns: 1
+  max_retry_backoff_ms: 300000
+  lanes:
+    - name: porffor-codex-developer
+      kind: codex
+      role: teammate
+      command: $SYMPHONY_CODEX_COMMAND
+      prompt_mode: argument
+      max_concurrent: 1
+codex:
+  command: codex exec -m gpt-5.6-sol -c approval_policy="never" --sandbox danger-full-access --skip-git-repo-check --json
+  turn_timeout_ms: 3600000
+  read_timeout_ms: 5000
+  stall_timeout_ms: 300000
+logging:
+  root: .codex/symphony/porffor
+---
+
+You are implementing one dependency-ordered slice of JS2's optional Porffor
+IR backend.
+
+Issue: {{ issue.identifier }} - {{ issue.title }}
+Issue file: {{ issue.file }}
+Sprint: {{ issue.sprint }}
+Workspace: {{ workspace.path }}
+Branch: {{ workspace.branch }}
+Pull request: {{ issue.pr }}
+Attempt: {{ attempt }}
+Agent lane: {{ agent.name }} ({{ agent.kind }} / {{ agent.role }})
+
+Issue specification:
+
+{{ issue.description }}
+
+Rules:
+
+- Work only inside the assigned workspace and only on this issue.
+- Read `AGENTS.md`, `CLAUDE.md`, `.claude/memory/MEMORY.md`, and the assigned
+  issue before substantial work.
+- Treat `vendor/Porffor` as an optional pinned compatibility dependency. Core
+  install, build, typecheck, and non-Porffor tests must work without it.
+- Keep the JS2 linear-memory plan target-neutral. Porffor IR and its
+  experimental C renderer are optional consumers, not the canonical or only
+  destinations.
+- Do not import Porffor internals statically from production `src/**` code and
+  do not adopt Porffor's object layout, NaN boxing, builtins, or GC implicitly.
+- Preserve the dependency boundaries and non-goals in the issue. Do not start
+  a later P1-P5 slice from the same branch.
+- Write focused tests in `tests/issue-{{ issue.identifier }}.test.ts` unless the
+  issue specifies a more appropriate existing suite. Do not run full local
+  test262.
+- Update the issue file with findings and acceptance status. Leave it
+  `in-review` after publishing the completed slice; Symphony marks it `done`
+  only after GitHub reports the PR merged.
+- Commit all changes with a Claude Code-style message and a
+  `Co-authored-by: Codex <codex@openai.com>` trailer.
+- Merge or rebase current `origin/main` before publishing, then push the
+  assigned branch to `origin` and open a ready, non-draft PR against `main`.
+- On a retry for an existing PR, inspect the failed checks, repair the same
+  head branch, preserve `last_ci_retry_head`, and never open a duplicate PR.
+- Enqueue the PR through the normal merge queue when GitHub accepts it. Never
+  bypass required checks or force-merge.
+- Report changed files, validation, commit SHA, PR URL, and queue state. A
+  failed push, PR creation, or queue operation leaves the issue incomplete.

--- a/plan/issues/3288-porffor-ir-backend.md
+++ b/plan/issues/3288-porffor-ir-backend.md
@@ -11,7 +11,7 @@ task_type: architecture
 area: ir, codegen-linear, backend
 language_feature: compiler-internals
 goal: backend-agnostic-ir
-sprint: current
+sprint: porffor-backend
 depends_on: []
 horizon: xl
 model: gpt-5.6-sol
@@ -160,7 +160,7 @@ through one PR per dependency-ordered child issue:
 
 | Slice | Issue                                                     | Dispatch gate     |
 | ----- | --------------------------------------------------------- | ----------------- |
-| P0    | #3295 - freeze the optional Porffor compatibility surface | ready immediately |
+| P0    | #3295 - freeze the optional Porffor compatibility surface | merged (#3107/#3109) |
 | P1    | #3296 - make generic lowering results non-Wasm            | #3295 and #2953   |
 | P2    | #3297 - scalar/control-flow Porffor proof                 | #3296             |
 | P3    | #3298 - extract shared `LinearMemoryPlan`                 | #3297 and #2956   |

--- a/plan/issues/3295-porffor-compatibility-surface.md
+++ b/plan/issues/3295-porffor-compatibility-surface.md
@@ -1,9 +1,11 @@
 ---
 id: 3295
 title: "Porffor backend P0: freeze the optional IR compatibility surface"
-status: in-progress
+status: done
 assignee: ttraenkler/codex-senior-3295
-sprint: current
+sprint: porffor-backend
+pr: 3109
+completed: 2026-07-16
 created: 2026-07-16
 updated: 2026-07-16
 priority: high
@@ -57,8 +59,9 @@ depends on Porffor's experimental internal enums or module-record shape.
 
 ## Implementation record (2026-07-16)
 
-P0 is implemented in ready PR #3107. The issue remains `in-progress` until the
-PR merges; #3288 remains the tracking umbrella.
+P0 landed in PR #3107, with the independently dispatchable issue boundary and
+renamed focused test finalized in PR #3109. Both PRs are merged; #3288 remains
+the tracking umbrella and #3296 owns the next implementation slice.
 
 ### Files
 

--- a/plan/issues/3296-porffor-generic-lowering-result.md
+++ b/plan/issues/3296-porffor-generic-lowering-result.md
@@ -1,0 +1,70 @@
+---
+id: 3296
+title: "Porffor backend P1: make generic lowering results genuinely non-Wasm"
+status: ready
+sprint: porffor-backend
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: refactor
+area: ir, backend
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3288
+depends_on: [3295, 2953]
+related: [3288, 2953, 2956, 1852]
+origin: "#3288 P1 split: independently dispatchable generic lowering contract work"
+---
+
+# #3296 - Porffor backend P1: make generic lowering results genuinely non-Wasm
+
+## Objective
+
+Remove the remaining Wasm-shaped assumptions from the generic typed-SSA
+lowering result so a fourth backend can participate through the existing
+five-part backend contract without fabricating Wasm locals, indices, or types.
+
+## Scope
+
+1. Add `porffor` to `IrBackendKind` and define a narrow fail-loud legality
+   profile for the families enabled in this slice.
+2. Promote `TypeConverter` into the generic lowering path. Replace or adapt the
+   Wasm-shaped `LocalDef[]` and `typeIdx` result with backend slots, named
+   locals, parameters, and return types.
+3. Close or explicitly reject every `pushRaw`/`Instr[]`-only family reachable
+   by the Porffor legality profile.
+4. Add contract-conformance coverage for the fourth backend.
+
+## Acceptance criteria
+
+- [ ] Generic lowering returns no mandatory Wasm `ValType`, local index,
+      function index, block depth, or `Instr[]` value.
+- [ ] The existing WasmGC, bytecode, and linear integrations continue to use
+      the same generic contract without behavior regressions.
+- [ ] Porffor legality rejects unsupported families before emission with a
+      localized `porffor backend does not support ...` diagnostic.
+- [ ] No Porffor path uses `RawC` or a raw Wasm instruction escape hatch.
+- [ ] Backend contract tests cover all four registered backend kinds.
+- [ ] The issue changes are committed, pushed to `origin`, and published as a
+      ready, non-draft PR before completion is reported.
+
+## Validation
+
+- Run backend contract and legality tests.
+- Run focused generic lowering tests for locals, parameters, and returns.
+- Run the existing IR and emit-identity suites affected by result-shape changes.
+
+## Non-goals
+
+- Rendering C or executing Porffor output.
+- Heap/object lowering.
+- Extracting `LinearMemoryPlan`.
+
+## Handoff
+
+After this PR merges, #3297 owns the first executable scalar/control-flow
+Porffor sink and module proof.

--- a/plan/issues/3297-porffor-scalar-control-flow-proof.md
+++ b/plan/issues/3297-porffor-scalar-control-flow-proof.md
@@ -1,0 +1,75 @@
+---
+id: 3297
+title: "Porffor backend P2: scalar and control-flow differential proof"
+status: ready
+sprint: porffor-backend
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: feature
+area: ir, backend
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3288
+depends_on: [3296]
+related: [3288, 3295, 3296, 3030]
+origin: "#3288 P2 split: independently dispatchable scalar Porffor backend proof"
+---
+
+# #3297 - Porffor backend P2: scalar and control-flow differential proof
+
+## Objective
+
+Lower a real scalar/control-flow subset of JS2 typed SSA IR into Porffor IR,
+render it through the pinned optional renderer, compile the C, and prove
+behavior against JavaScript and JS2's linear-Wasm backend.
+
+## Scope
+
+1. Implement `PorfforSink` as a structured builder with a statement list and
+   expression/value stack while preserving left-to-right evaluation and
+   effects.
+2. Implement constants, numeric conversion/arithmetic/comparison, locals,
+   globals, select, structured conditionals/blocks/loops/branches, direct
+   calls, return, and unreachable.
+3. Reject every heap/reference operation in this slice.
+4. Assemble functions and modules with stable symbolic names; assign Porffor
+   array positions only during final assembly.
+5. Render with the pinned Porffor renderer, compile with the available CI C
+   compiler, and execute differential fixtures.
+
+## Acceptance criteria
+
+- [ ] Real JS2 IR reaches Porffor IR through the five-part backend contract;
+      there is no parallel AST-to-Porffor front end.
+- [ ] Expression construction preserves operand order and `FX` semantics for
+      effectful scalar/control-flow fixtures.
+- [ ] Unsupported heap/reference IR fails through legality before emission.
+- [ ] Scalar fixtures produce equal results under JavaScript, linear-Wasm, and
+      Porffor-C.
+- [ ] Function and module assembly is deterministic and independent of
+      registration order.
+- [ ] The issue changes are committed, pushed to `origin`, and published as a
+      ready, non-draft PR before completion is reported.
+
+## Validation
+
+- Run focused IR-node mapping and operand-order tests.
+- Run three-way scalar differential tests.
+- Compile rendered C with warnings treated as errors where supported.
+- Run existing backend contract tests.
+
+## Non-goals
+
+- Heap allocation, objects, arrays, roots, or barriers.
+- A public Porffor compile target.
+- Adopting Porffor's `jsval` or object ABI.
+
+## Handoff
+
+After this PR merges and #2956 is complete, #3298 extracts the shared
+backend-neutral linear-memory plan.

--- a/plan/issues/3298-linear-memory-plan-extraction.md
+++ b/plan/issues/3298-linear-memory-plan-extraction.md
@@ -1,0 +1,74 @@
+---
+id: 3298
+title: "Porffor backend P3: extract the shared target-neutral LinearMemoryPlan"
+status: ready
+sprint: porffor-backend
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: architecture
+area: ir, codegen-linear, backend
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3288
+depends_on: [3297, 2956]
+related: [3288, 2953, 2956, 3029, 747]
+origin: "#3288 P3 split: independently dispatchable shared linear-memory planning layer"
+---
+
+# #3298 - Porffor backend P3: extract the shared target-neutral LinearMemoryPlan
+
+## Objective
+
+Make JS2's middle end the single owner of allocation class, layout, root, and
+barrier decisions through a backend- and artifact-neutral `LinearMemoryPlan`
+consumed by both linear-Wasm and the optional Porffor backend.
+
+## Scope
+
+1. Define plan and allocator-policy interfaces whose vocabulary remains useful
+   without Porffor or C.
+2. Feed the planner from allocation-site IDs and existing escape, ownership,
+   encoding, and stack-allocation analyses under `src/ir/analysis/`.
+3. Centralize size, alignment, field-offset, element-stride, pointer-map,
+   lifetime, safepoint, barrier, data-segment, and global-storage decisions.
+4. Keep allocator/runtime operations symbolic through planning.
+5. Adapt linear-Wasm to consume the plan while preserving byte identity under
+   the default arena policy for unchanged programs.
+
+## Acceptance criteria
+
+- [ ] `LinearMemoryPlan` contains no Wasm instructions/indices, Porffor enums or
+      arrays, C fragments, renderer assumptions, or concrete runtime symbols.
+- [ ] There is one canonical plan per allocation site/shape shared by initial
+      linear-memory consumers.
+- [ ] Linear-Wasm consumes the plan without changing default-policy behavior or
+      established emitted bytes.
+- [ ] Function registration order cannot change symbolic allocator/runtime
+      references before module assembly.
+- [ ] Removing the optional Porffor adapter requires no planner changes.
+- [ ] The issue changes are committed, pushed to `origin`, and published as a
+      ready, non-draft PR before completion is reported.
+
+## Validation
+
+- Run focused planner and layout tests.
+- Run `prove-emit-identity` coverage for the default linear-Wasm policy.
+- Run scoped linear-backend equivalence and regression tests.
+- Run merge-group conformance validation because this slice changes shared
+  production planning.
+
+## Non-goals
+
+- Choosing Porffor's value ABI, object layout, builtins, or GC.
+- Implementing a second allocation policy; #3300 owns that proof.
+- Making C the preferred or mandatory output.
+
+## Handoff
+
+After this PR merges, #3299 lowers representative heap layouts through
+Porffor IR using this plan without re-planning them in the adapter.

--- a/plan/issues/3299-porffor-heap-layout-proof.md
+++ b/plan/issues/3299-porffor-heap-layout-proof.md
@@ -1,0 +1,71 @@
+---
+id: 3299
+title: "Porffor backend P4: heap and layout proof through shared planning"
+status: ready
+sprint: porffor-backend
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: feature
+area: ir, codegen-linear, backend
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3288
+depends_on: [3298]
+related: [3288, 3297, 3298]
+origin: "#3288 P4 split: independently dispatchable Porffor heap/layout proof"
+---
+
+# #3299 - Porffor backend P4: heap and layout proof through shared planning
+
+## Objective
+
+Prove that Porffor IR can execute JS2-planned heap layouts without adopting or
+silently depending on Porffor's own object representation.
+
+## Scope
+
+1. Lower one fixed-shape object and one dense numeric vector/array family using
+   `LinearMemoryPlan` and Porffor `Alloc`, `Load`, and `Store` operations.
+2. Preserve JS identity, aliasing, mutation, bounds, and layout semantics.
+3. Lower planned root and barrier operations. For arena-only policy, document
+   and test why no barrier is required; for managed policy, emit `GcBarrier`
+   and stress collection safety.
+4. Differentially execute the same typed SSA IR through linear-Wasm and
+   Porffor-C.
+
+## Acceptance criteria
+
+- [ ] Two aliases observe the same mutation while two equal-looking allocated
+      objects remain non-identical.
+- [ ] Fixed-shape field offsets and vector strides come exclusively from the
+      shared plan.
+- [ ] Vector bounds and mutation behavior match JavaScript and linear-Wasm.
+- [ ] Root/barrier behavior follows the selected planned runtime policy and is
+      covered by stress validation where collection is possible.
+- [ ] The Porffor adapter does not reinterpret values as Porffor-native objects
+      or call builtins that assume Porffor layouts.
+- [ ] The issue changes are committed, pushed to `origin`, and published as a
+      ready, non-draft PR before completion is reported.
+
+## Validation
+
+- Run heap alias, identity, mutation, and bounds tests.
+- Run three-way differential fixtures for the supported heap families.
+- Run managed-allocation stress tests when the selected policy can collect.
+- Run linear-Wasm emit-identity coverage for unaffected programs.
+
+## Non-goals
+
+- General JS object coverage.
+- Adopting Porffor NaN boxing, builtins, object layouts, or GC wholesale.
+- A second allocation strategy.
+
+## Handoff
+
+After this PR merges, #3300 must demonstrate that allocation policy can change
+without changing either backend's semantic emitter.

--- a/plan/issues/3300-linear-memory-allocation-policy-proof.md
+++ b/plan/issues/3300-linear-memory-allocation-policy-proof.md
@@ -1,0 +1,77 @@
+---
+id: 3300
+title: "Porffor backend P5: prove shared allocation-policy leverage"
+status: ready
+sprint: porffor-backend
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+model: gpt-5.6-sol
+task_type: performance
+area: ir, codegen-linear, backend
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+parent: 3288
+depends_on: [3299]
+related: [3288, 3298, 3299, 747]
+origin: "#3288 P5 split: independently dispatchable allocation-policy comparison"
+---
+
+# #3300 - Porffor backend P5: prove shared allocation-policy leverage
+
+## Objective
+
+Demonstrate that `LinearMemoryPlan` is a meaningful shared optimization layer
+by selecting and comparing at least two allocation policies without changing
+the linear-Wasm or Porffor semantic emitters.
+
+## Scope
+
+Implement and compare:
+
+1. the current bump/arena baseline; and
+2. one non-trivial policy justified by existing analyses, preferably stack
+   promotion for non-escaping fixed-size allocations with managed-heap fallback
+   for escaping values.
+
+Use a fixed benchmark set and report output size, peak memory, allocation
+count, and runtime for both linear-Wasm and Porffor-C where supported.
+
+## Acceptance criteria
+
+- [ ] Both policies consume the same allocation sites, layouts, pointer maps,
+      roots, barriers, and symbolic runtime ABI from `LinearMemoryPlan`.
+- [ ] Switching policy requires no changes to `LinearEmitter` or
+      `PorfforEmitter` semantic-operation implementations.
+- [ ] The alternative policy preserves behavior under alias, identity, bounds,
+      and collection-stress fixtures.
+- [ ] A checked-in measurement note records code size, runtime, peak memory,
+      allocation count, supported IR families, exact Porffor commit, compiler,
+      and benchmark commands.
+- [ ] Results distinguish planner decisions from backend-specific artifact
+      effects and document any unsupported comparison explicitly.
+- [ ] The issue changes are committed, pushed to `origin`, and published as a
+      ready, non-draft PR before completion is reported.
+
+## Validation
+
+- Run the P4 heap differential and stress corpus under both policies.
+- Run the fixed benchmark suite with warmup/repetition sufficient to report
+  stable medians and peak-memory methodology.
+- Run linear-Wasm emit-identity coverage for the baseline policy.
+- Run scoped IR/equivalence and merge-group conformance validation.
+
+## Non-goals
+
+- Declaring one policy universally optimal from the pilot benchmark set.
+- Coupling the shared planner to C, Porffor, or a particular allocator symbol.
+- Expanding backend legality beyond families required by the proof.
+
+## Completion of parent
+
+After this PR merges, revalidate every acceptance criterion in #3288 and update
+the parent with child PR links, measured results, supported families, and the
+final completion status.

--- a/plan/method/symphony-service.md
+++ b/plan/method/symphony-service.md
@@ -126,6 +126,26 @@ Use `--dry-run` first. It exercises workflow loading, issue scanning, lane
 selection, and dispatch planning without creating worktrees or launching
 agents.
 
+## Scoped Porffor Workflow
+
+`WORKFLOW.porffor.md` isolates the optional Porffor backend chain in the
+`porffor-backend` sprint. It uses one `gpt-5.6-sol` lane, a dedicated worktree
+and log root, and initializes only the optional `vendor/Porffor` submodule in
+worker worktrees. Start and inspect it with:
+
+```bash
+pnpm run symphony -- --workflow WORKFLOW.porffor.md --dry-run --json
+pnpm run symphony -- --workflow WORKFLOW.porffor.md
+pnpm run symphony -- --workflow WORKFLOW.porffor.md --status --json
+```
+
+The workflow sets `pull_requests.sprint_only: true` and
+`pull_requests.include_dependencies: true`. Fresh candidate dispatch therefore
+ignores every issue outside `porffor-backend`, while PR reconciliation includes
+only that sprint and its transitive prerequisites. Symphony can repair or
+complete #2953/#2956 so P1/P3 unblock, but it cannot consume unrelated
+`in-progress` or `in-review` work from the broad `current` sprint.
+
 ## Safety Posture
 
 - The service refuses to launch an agent in `/workspace`.

--- a/scripts/symphony-pr-state.mjs
+++ b/scripts/symphony-pr-state.mjs
@@ -64,6 +64,27 @@ export function planPullRequestAction(
   return { action: "requeue", failureKey };
 }
 
+export function scopePullRequestIssues(issues, { sprintOnly = false, includeDependencies = false } = {}) {
+  if (!sprintOnly) return issues;
+  const byId = new Map(issues.map((issue) => [String(issue.id), issue]));
+  const selected = issues.filter((issue) => String(issue.sprint) === String(issue.selected_sprint));
+  if (!includeDependencies) return selected;
+
+  const included = new Set(selected.map((issue) => String(issue.id)));
+  const queue = [...selected];
+  for (let index = 0; index < queue.length; index++) {
+    const issue = queue[index];
+    for (const dependency of issue.blocked_by ?? []) {
+      const dependencyId = String(dependency?.id ?? dependency?.identifier ?? dependency);
+      const dependencyIssue = byId.get(dependencyId);
+      if (!dependencyIssue || included.has(dependencyId)) continue;
+      included.add(dependencyId);
+      queue.push(dependencyIssue);
+    }
+  }
+  return issues.filter((issue) => included.has(String(issue.id)));
+}
+
 export function readPullRequest({ command = "gh", cwd, number, repository = "", timeoutMs = 30_000 }) {
   const args = [
     "pr",

--- a/scripts/symphony.mjs
+++ b/scripts/symphony.mjs
@@ -12,7 +12,12 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { planPullRequestAction, readPullRequest, readPullRequestForBranch } from "./symphony-pr-state.mjs";
+import {
+  planPullRequestAction,
+  readPullRequest,
+  readPullRequestForBranch,
+  scopePullRequestIssues,
+} from "./symphony-pr-state.mjs";
 
 const ROOT = path.resolve(path.join(path.dirname(new URL(import.meta.url).pathname), ".."));
 const DEFAULT_WORKFLOW = path.join(ROOT, "WORKFLOW.md");
@@ -1416,7 +1421,11 @@ class Orchestrator {
     const repository = String(get(this.config, "pull_requests.repository", ""));
     const command = String(get(this.config, "pull_requests.command", "gh"));
     const timeoutMs = Number(get(this.config, "pull_requests.timeout_ms", 30000)) || 30000;
-    const issues = this.tracker.fetchIssuesByStates(reviewStates);
+    const wantedReviewStates = new Set(reviewStates.map(normalizeState));
+    const issues = scopePullRequestIssues(this.tracker.allIssues(), {
+      sprintOnly: Boolean(get(this.config, "pull_requests.sprint_only", false)),
+      includeDependencies: Boolean(get(this.config, "pull_requests.include_dependencies", false)),
+    }).filter((issue) => wantedReviewStates.has(issue.state));
 
     for (const issue of issues) {
       if (!issue.pull_request && !issue.branch_name) continue;

--- a/tests/symphony-pr-reconciliation.test.ts
+++ b/tests/symphony-pr-reconciliation.test.ts
@@ -8,6 +8,7 @@ import {
   planPullRequestAction,
   readPullRequest,
   readPullRequestForBranch,
+  scopePullRequestIssues,
 } from "../scripts/symphony-pr-state.mjs";
 
 describe("Symphony pull-request reconciliation", () => {
@@ -59,6 +60,26 @@ describe("Symphony pull-request reconciliation", () => {
         ],
       }).status,
     ).toBe("passed");
+  });
+
+  it("can scope pull-request reconciliation to the selected sprint", () => {
+    const issues = [
+      {
+        id: 1,
+        sprint: "porffor-backend",
+        selected_sprint: "porffor-backend",
+        blocked_by: [{ id: 3 }],
+      },
+      { id: 2, sprint: "current", selected_sprint: "porffor-backend" },
+      { id: 3, sprint: "current", selected_sprint: "porffor-backend", blocked_by: [{ id: 4 }] },
+      { id: 4, sprint: "foundation", selected_sprint: "porffor-backend" },
+    ];
+
+    expect(scopePullRequestIssues(issues, { sprintOnly: true }).map((issue) => issue.id)).toEqual([1]);
+    expect(
+      scopePullRequestIssues(issues, { sprintOnly: true, includeDependencies: true }).map((issue) => issue.id),
+    ).toEqual([1, 3, 4]);
+    expect(scopePullRequestIssues(issues).map((issue) => issue.id)).toEqual([1, 2, 3, 4]);
   });
 
   it("requeues one failed head once and closes merged work", () => {


### PR DESCRIPTION
## Summary
- add a dedicated one-lane gpt-5.6-sol Symphony workflow for the porffor-backend sprint
- scope fresh dispatch to Porffor issues and PR reconciliation to that sprint plus transitive prerequisites
- publish dependency-ordered P1-P5 issues, mark merged P0 complete, and pin the optional Porffor submodule
- preserve JS2's target-neutral linear-memory plan; Porffor IR/C remains an optional consumer

## Current dispatch state
The dry run selects only porffor-backend and plans zero workers because P1 #3296 is correctly blocked on #2953. Once that prerequisite merges, Symphony can dispatch P1 without consuming unrelated current-sprint work.

## Validation
- pnpm exec vitest run tests/symphony-pr-reconciliation.test.ts (7 passed)
- JS2WASM_PORFFOR_ROOT=vendor/Porffor pnpm exec vitest run tests/issue-3295-porffor-compat.test.ts (8 passed)
- pnpm exec tsc --noEmit --pretty false
- pnpm run lint
- pnpm run format:check
- pnpm run check:issues
- pnpm run check:issue-ids
- node scripts/symphony.mjs --workflow WORKFLOW.porffor.md --once --dry-run --json
- git submodule update --init --checkout vendor/Porffor