### PR TITLE
refactor(ir): route closure aggregates through BackendEmitter

### DIFF
--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -3,8 +3,8 @@ id: 2953
 title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait"
 status: in-progress
 assignee: ttraenkler/opus-1a
-branch: agent/2953-unions-boxing
-pr: 3108
+branch: symphony/porffor/2953
+pr: null
 sprint: current
 created: 2026-07-02
 updated: 2026-07-16
@@ -20,6 +20,9 @@ related: [1852, 1713, 2954, 2956, 2949]
 origin: "2026-07-02 July Fable audit §5 (77 pushRaw sites; #1852-G1 slice text had no issue)"
 loc-budget-allow:
   - src/ir/lower.ts
+claimed_by: porffor-codex-developer
+claimed_at: 2026-07-16T11:55:48.323Z
+last_merged_pr: 3108
 ---
 
 # #2953 — 40% of IR lowering bypasses the backend trait
@@ -86,7 +89,16 @@ value/aggregate families.
   104 → 98. Golden union lowering stayed instruction-identical, and the emitted
   Wasm oracle matched clean main for all 56 `(file,target)` records across gc,
   standalone, wasi, and linear. (ttraenkler/codex-2953-unions-boxing)
-- [ ] closures (`emitClosureNew`/`emitClosureFuncGet`/`emitCaptureGet`)
+- [x] **closures** (`emitClosureNew`/`emitClosureFuncGet`/`emitCaptureGet`) —
+  promoted from declared-optional to required on `BackendEmitter`, implemented
+  byte-identically on `WasmGcEmitter` (`struct.new` for construction and the
+  canonical `struct.get` fields for function/capture reads), and stubbed loudly
+  on Linear + Bytecode until their closure representations land. The 3 closure
+  aggregate `pushRaw` sites now use the trait, reducing `emitter.pushRaw` calls
+  in `lower.ts` from 98 to 95. The existing `ref.func` and `ref.cast` sites stay
+  in their dependency-ordered funcref/coercion slices. Golden emitter tests,
+  the 31-case IR closure suite, cross-backend proof, equivalence gate, and the
+  56-record byte oracle are green. (porffor-codex-developer)
 - [ ] coercions/null (`emitNull`/`emitToExternref`/`emitFromExternref`)
 - [ ] funcref (`emitFuncRef`)
 - [ ] Promise ops
@@ -109,3 +121,26 @@ value/aggregate families.
 - Byte identity: `scripts/prove-emit-identity.mjs` was run against a detached
   clean-main baseline via Vite's TypeScript loader because `tsx` is not installed
   in this checkout. Result: `IDENTICAL — all 56 (file,target) emits match baseline`.
+
+## 2026-07-16 — closure slice results
+
+- Re-grounded and fast-forwarded to `origin/main` at
+  `b2b30a02336c1cf6deaa8941a383598ead35d586` before implementation.
+- Made the three closure aggregate hooks required and sink-generic. Lowering
+  continues to own evaluation order: it emits the lifted `ref.func`, captures,
+  and subtype/typed-funcref casts in the same positions, while the backend owns
+  only the terminal closure allocation or field read. Linear and Bytecode
+  implementations throw instead of falling through to WasmGC-shaped raw ops.
+- Added Golden-Instr coverage for closure construction, function-field reads,
+  and capture-index mapping in `tests/ir-backend-emitter.test.ts`.
+- Focused verification:
+  `pnpm vitest run tests/ir-backend-emitter.test.ts tests/issue-1169c.test.ts tests/ir-bytecode-proof.test.ts`
+  (69 tests passed), plus `pnpm run typecheck`, focused Biome + Prettier checks,
+  and `pnpm run test:equivalence:gate`.
+- Byte identity: bundled the existing `scripts/prove-emit-identity.mjs` harness
+  with esbuild because `tsx` is absent, captured the pre-edit baseline, and
+  checked the edited compiler against it. Result:
+  `IDENTICAL — all 56 (file,target) emits match baseline`.
+- Slice acceptance: complete. The parent issue intentionally remains
+  `in-progress` for coercions/null, funcref, Promise ops, and the pushRaw
+  justification ratchet.

--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -4,7 +4,7 @@ title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coe
 status: in-progress
 assignee: ttraenkler/opus-1a
 branch: symphony/porffor/2953
-pr: null
+pr: 3128
 sprint: current
 created: 2026-07-02
 updated: 2026-07-16

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -671,6 +671,19 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }
 
+  // ---- closure family (#2953) — closure records and callable handles are not
+  // yet represented by the bytecode VM. Keep the trait boundary loud instead
+  // of falling back to WasmGC struct instructions through pushRaw.
+  emitClosureNew(): void {
+    throw new Error("BytecodeEmitter: closure construction not yet wired — see §2a closure family.");
+  }
+  emitClosureFuncGet(): void {
+    throw new Error("BytecodeEmitter: closure function reads not yet wired — see §2a closure family.");
+  }
+  emitCaptureGet(): void {
+    throw new Error("BytecodeEmitter: closure capture reads not yet wired — see §2a closure family.");
+  }
+
   // ---- (a5) ref-cell family (#2953) — a 1-field mutable struct. Not yet wired
   // into the VM heap model; a future wiring mirrors the (a2) struct family
   // (STRUCT_NEW fieldCount=1 / STRUCT_GET|SET fieldIdx=0).

--- a/src/ir/backend/contract-conformance.ts
+++ b/src/ir/backend/contract-conformance.ts
@@ -38,6 +38,7 @@ import {
 import type { IrBinop, IrUnop } from "../nodes.js";
 import type {
   IrClassLowering,
+  IrClosureLowering,
   IrObjectStructLowering,
   IrRefCellLowering,
   IrVecLowering,
@@ -180,6 +181,15 @@ class StubEmitter implements BackendEmitter<StubSink> {
     for (const c of catches) out.push(`catch:${c.tagIdx}`, ...c.body);
     if (catchAll) out.push("catch_all", ...catchAll);
     out.push("end");
+  }
+  emitClosureNew(_layout: IrClosureLowering, captureCount: number, out: StubSink): void {
+    out.push(`closure.new:${captureCount}`);
+  }
+  emitClosureFuncGet(_layout: IrClosureLowering, out: StubSink): void {
+    out.push("closure.func.get");
+  }
+  emitCaptureGet(_layout: IrClosureLowering, index: number, out: StubSink): void {
+    out.push(`closure.capture.get:${index}`);
   }
   emitRefCellNew(_layout: IrRefCellLowering, out: StubSink): void {
     out.push("refcell.new");

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -173,9 +173,21 @@ export interface BackendEmitter<S = Instr[]> {
   emitToExternref?(out: Instr[]): void;
   emitFromExternref?(layout: { typeIdx: number } | IrType, out: Instr[]): void;
   emitFuncRef?(funcIdx: number, out: Instr[]): void;
-  emitClosureNew?(layout: IrClosureLowering, captureCount: number, out: Instr[]): void;
-  emitClosureFuncGet?(layout: IrClosureLowering, out: Instr[]): void;
-  emitCaptureGet?(layout: IrClosureLowering, index: number, out: Instr[]): void;
+
+  // ---- closure family — MIGRATED behind the trait (#2953) -----------------
+  // Closure construction and field reads are aggregate operations whose
+  // representation differs by backend. The caller still owns operand order:
+  // closure.new leaves the lifted function reference followed by each capture
+  // on the stack; closure.cap performs its subtype downcast before the field
+  // read; closure.call performs its typed-funcref cast after the function-field
+  // read. Those ref.func/ref.cast operations migrate in their dedicated #2953
+  // slices, while these hooks close the closure struct.new/get bypasses.
+  /** lifted function ref + captureCount captures on the stack -> closure value. */
+  emitClosureNew(layout: IrClosureLowering, captureCount: number, out: S): void;
+  /** closure ref on the stack -> its abstract funcref field. */
+  emitClosureFuncGet(layout: IrClosureLowering, out: S): void;
+  /** downcast closure-subtype ref on the stack -> capture at `index`. */
+  emitCaptureGet(layout: IrClosureLowering, index: number, out: S): void;
 
   // ---- (a1) call family — MIGRATED behind the trait (#1584 §2a) -----------
   // The first op-family to move from inline `lower.ts` pushes to typed trait

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -307,6 +307,18 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     notImplemented("emitCallRef");
   }
 
+  // closure family — WasmGC wrapper structs become arena records + table
+  // indices in the linear backend (#2956), so no raw struct fallback is valid.
+  emitClosureNew(): void {
+    notImplemented("emitClosureNew");
+  }
+  emitClosureFuncGet(): void {
+    notImplemented("emitClosureFuncGet");
+  }
+  emitCaptureGet(): void {
+    notImplemented("emitCaptureGet");
+  }
+
   // struct/object family — WasmGC `struct.new`/`struct.get`/`struct.set`; the
   // linear backend lowers objects to a bump-allocated memory layout (#2956).
   emitAggregateNew(): void {

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -19,6 +19,7 @@ import type { BlockType, Instr, ValType } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
 import type {
   IrClassLowering,
+  IrClosureLowering,
   IrObjectStructLowering,
   IrRefCellLowering,
   IrUnionLowering,
@@ -175,6 +176,21 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
 
   emitTagLoad(layout: IrUnionLowering, out: Instr[]): void {
     out.push({ op: "struct.get", typeIdx: layout.typeIdx, fieldIdx: layout.tagFieldIdx });
+  }
+
+  // ---- closure family (#2953) — byte-identical to the prior inline
+  // struct.new/get pushes in lower.ts. The caller has already emitted the
+  // lifted function reference, captures, and any required ref.cast.
+  emitClosureNew(layout: IrClosureLowering, _captureCount: number, out: Instr[]): void {
+    out.push({ op: "struct.new", typeIdx: layout.structTypeIdx });
+  }
+
+  emitClosureFuncGet(layout: IrClosureLowering, out: Instr[]): void {
+    out.push({ op: "struct.get", typeIdx: layout.structTypeIdx, fieldIdx: layout.funcFieldIdx });
+  }
+
+  emitCaptureGet(layout: IrClosureLowering, index: number, out: Instr[]): void {
+    out.push({ op: "struct.get", typeIdx: layout.structTypeIdx, fieldIdx: layout.capFieldIdx(index) });
   }
 
   // ---- (a1) call family (#1584 §2a) — byte-identical to the prior inline

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1591,7 +1591,7 @@ export function lowerIrFunctionBody<S>(
         // ref.func $lifted, push captures, struct.new <subtype>.
         emitter.pushRaw(out, { op: "ref.func", funcIdx: liftedIdx });
         for (const cap of instr.captures) emitValue(cap, out);
-        emitter.pushRaw(out, { op: "struct.new", typeIdx: sub.structTypeIdx });
+        emitter.emitClosureNew(sub, instr.captures.length, out);
         return;
       }
       case "closure.cap": {
@@ -1608,11 +1608,7 @@ export function lowerIrFunctionBody<S>(
         }
         emitValue(instr.self, out);
         emitter.pushRaw(out, { op: "ref.cast", typeIdx: sub.structTypeIdx });
-        emitter.pushRaw(out, {
-          op: "struct.get",
-          typeIdx: sub.structTypeIdx,
-          fieldIdx: sub.capFieldIdx(instr.index),
-        });
+        emitter.emitCaptureGet(sub, instr.index, out);
         return;
       }
       case "closure.call": {
@@ -1632,20 +1628,16 @@ export function lowerIrFunctionBody<S>(
         emitValue(instr.callee, out);
         for (const a of instr.args) emitValue(a, out);
         emitValue(instr.callee, out);
-        emitter.pushRaw(out, {
-          op: "struct.get",
-          typeIdx: cl.structTypeIdx,
-          fieldIdx: cl.funcFieldIdx,
-        });
+        emitter.emitClosureFuncGet(cl, out);
         // The struct's `func` field is typed as the abstract `funcref`
         // (matches the legacy `getOrCreateFuncRefWrapperTypes` pattern,
         // which avoids a circular type reference between the struct and
         // its lifted func type). `call_ref` requires a typed funcref, so
         // we emit `ref.cast` to convert.
-        // The struct.get (a2 struct family) + ref.cast (a5 ref-coercion) before
-        // this stay on pushRaw until their families migrate; only the terminal
-        // call_ref is the (a1) call family → typed emitCallRef (byte-identical
-        // {op:"call_ref"} on WasmGC, OP.CALL_REF on bytecode).
+        // The function-field read now routes through the closure-family hook.
+        // The ref.cast stays on pushRaw until the coercion family migrates; the
+        // terminal call_ref is the (a1) call family → typed emitCallRef
+        // (byte-identical {op:"call_ref"} on WasmGC, OP.CALL_REF on bytecode).
         emitter.pushRaw(out, { op: "ref.cast", typeIdx: cl.funcTypeIdx });
         emitter.emitCallRef(cl.funcTypeIdx, out);
         return;

--- a/tests/ir-backend-emitter.test.ts
+++ b/tests/ir-backend-emitter.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from "vitest";
 
 import { WasmGcEmitter } from "../src/ir/backend/wasmgc-emitter.js";
-import type { IrRefCellLowering, IrVecLowering } from "../src/ir/backend/handles.js";
+import type { IrClosureLowering, IrRefCellLowering, IrVecLowering } from "../src/ir/backend/handles.js";
 import type { Instr } from "../src/ir/types.js";
 
 const emitter = new WasmGcEmitter();
@@ -141,5 +141,32 @@ describe("#2953 WasmGcEmitter — ref-cell family byte-identity", () => {
     const out: Instr[] = [];
     emitter.emitRefCellSet(cell, out);
     expect(out).toEqual([{ op: "struct.set", typeIdx: 11, fieldIdx: 0 }]);
+  });
+});
+
+describe("#2953 WasmGcEmitter — closure family byte-identity", () => {
+  const closure: IrClosureLowering = {
+    structTypeIdx: 17,
+    funcFieldIdx: 0,
+    capFieldIdx: (index) => index + 1,
+    funcTypeIdx: 29,
+  };
+
+  it("emitClosureNew → struct.new $closure (function and captures already on the stack)", () => {
+    const out: Instr[] = [];
+    emitter.emitClosureNew(closure, 2, out);
+    expect(out).toEqual([{ op: "struct.new", typeIdx: 17 }]);
+  });
+
+  it("emitClosureFuncGet → struct.get $closure $func", () => {
+    const out: Instr[] = [];
+    emitter.emitClosureFuncGet(closure, out);
+    expect(out).toEqual([{ op: "struct.get", typeIdx: 17, fieldIdx: 0 }]);
+  });
+
+  it("emitCaptureGet maps the capture position through the layout", () => {
+    const out: Instr[] = [];
+    emitter.emitCaptureGet(closure, 2, out);
+    expect(out).toEqual([{ op: "struct.get", typeIdx: 17, fieldIdx: 3 }]);
   });
 });


### PR DESCRIPTION
## Summary

- promote `emitClosureNew`, `emitClosureFuncGet`, and `emitCaptureGet` to required sink-generic backend hooks
- implement byte-identical WasmGC closure aggregate emission and loud Linear/Bytecode stubs
- route the three closure `struct.new`/`struct.get` escape hatches through the trait (`pushRaw` 98 → 95)
- keep `ref.func` and `ref.cast` unchanged for the later funcref/coercion slices

Plan issue #2953 remains `in-progress` because later slices are still unchecked.

## Validation

- `pnpm run typecheck`
- `pnpm vitest run tests/ir-backend-emitter.test.ts tests/issue-1169c.test.ts tests/ir-bytecode-proof.test.ts` (69 passed)
- `pnpm run test:equivalence:gate`
- focused Biome and Prettier checks
- emitted-Wasm identity: all 56 `(file,target)` records identical across gc, standalone, wasi, and linear
