### PR TITLE
docs(whitepaper): surface JS-host vs standalone lane distinction with both figures

### DIFF
--- a/website/docs/whitepaper.html
+++ b/website/docs/whitepaper.html
@@ -1218,9 +1218,14 @@
         <p>
           The project tracks ECMAScript compatibility through Test262, the standard conformance suite for
           JavaScript implementations <a href="https://tc39.es/ecma262/">[2]</a>
-          <a href="https://github.com/tc39/test262/">[3]</a>. The current public milestone is
-          <strong>76.5% Test262 compliance</strong> (32,990 of 43,106 official conformance tests passing
-          in the current public report).
+          <a href="https://github.com/tc39/test262/">[3]</a>. Conformance is measured along two
+          independent paths (see §5), and both are reported publicly: the <strong>JS-host path</strong>
+          (default target, host imports allowed) is at <strong>76.5% Test262 compliance</strong>
+          (32,990 of 43,106 official conformance tests passing), and the <strong>standalone / host-free
+          path</strong> (pure WasmGC, no JS host) is at <strong>53.6%</strong> (23,109 of 43,106),
+          measured host-free on the same official denominator. These are distinct metrics on different
+          targets and are never summed; the JS-host figure is the headline number, and the standalone
+          gap is where the current effort concentrates (§5.2, §12.2).
         </p>
         <div class="callout">
           <p>
@@ -1358,8 +1363,9 @@
         <h2>11. Current tradeoffs</h2>
         <p>A useful whitepaper cannot ignore the hard parts.</p>
         <p>
-          <strong>Conformance is still incomplete.</strong> At 76.5% Test262 compliance, the compiler is
-          credible but far from complete.
+          <strong>Conformance is still incomplete.</strong> At 76.5% Test262 compliance on the JS-host
+          path &mdash; and 53.6% on the standalone, host-free path &mdash; the compiler is credible but
+          far from complete, and the standalone gap in particular is a primary focus (§5.2, §12.2).
         </p>
         <p>
           <strong>Wasm GC support is required.</strong> The architecture depends on runtimes with Wasm GC

--- a/website/docs/whitepaper.md
+++ b/website/docs/whitepaper.md
@@ -13,7 +13,7 @@ That position differs from the two dominant alternatives in the space:
 1. compiling or embedding a JavaScript interpreter inside Wasm
 2. narrowing the language into a TypeScript-like subset or replacement dialect
 
-`js²` is aimed at a harder target: **full ECMAScript language compatibility over time, with TypeScript source compatibility on top**, reached through direct compilation rather than runtime emulation or language reduction. The intended endpoint is not a custom JavaScript sub- or superset; it is mainstream JavaScript semantics defined by ECMAScript and validated through public conformance work, with Test262 used as the current measurement baseline [[2]](https://tc39.es/ecma262/) [[3]](https://github.com/tc39/test262). That matters not only for language purity, but for ecosystem fit: broad compatibility with JavaScript is a cornerstone of compatibility with the wider JavaScript ecosystem, including real-world npm packages and existing application code. The project is still in active development, but it already exposes a public playground, public benchmark and compatibility reporting, and a public ECMAScript conformance milestone of **76.5% Test262 compliance**.
+`js²` is aimed at a harder target: **full ECMAScript language compatibility over time, with TypeScript source compatibility on top**, reached through direct compilation rather than runtime emulation or language reduction. The intended endpoint is not a custom JavaScript sub- or superset; it is mainstream JavaScript semantics defined by ECMAScript and validated through public conformance work, with Test262 used as the current measurement baseline [[2]](https://tc39.es/ecma262/) [[3]](https://github.com/tc39/test262). That matters not only for language purity, but for ecosystem fit: broad compatibility with JavaScript is a cornerstone of compatibility with the wider JavaScript ecosystem, including real-world npm packages and existing application code. The project is still in active development, but it already exposes a public playground, public benchmark and compatibility reporting, and a public ECMAScript conformance milestone of **76.5% Test262 compliance** on the JS-host path, with a separately tracked standalone (host-free) path at **53.6%**.
 
 This whitepaper explains the architectural thesis behind the compiler, why WebAssembly GC is the right target, what deployment profile this enables, where the approach fits, and what tradeoffs still remain.
 
@@ -211,9 +211,12 @@ The main risk in any direct JavaScript compiler is semantic coverage. JavaScript
 
 The project tracks ECMAScript compatibility through Test262, the standard conformance suite for JavaScript engines and implementations [[2]](https://tc39.es/ecma262/) [[3]](https://github.com/tc39/test262).
 
-The current public milestone is:
+Conformance is measured along **two independent paths** (see §5), and both are reported publicly:
 
-- **76.5% Test262 compliance** (32,990 / 43,106 official conformance tests passing in the current public report)
+- **JS-host path** (default target, host imports allowed): **76.5% Test262 compliance** (32,990 / 43,106 official conformance tests passing in the current public report)
+- **Standalone / host-free path** (pure WasmGC, no JS host): **53.6%** (23,109 / 43,106), measured host-free on the same official denominator
+
+These are distinct metrics on different targets and are never summed. The JS-host figure is the headline conformance number; the standalone figure is lower today because host-assisted operations are counted as failures unless a Wasm-native implementation exists, and closing that gap is where the current effort concentrates (§5.2, §12.2). Both improve as host fallbacks are replaced with compiled Wasm-native behavior.
 
 That number should be interpreted correctly. It does not mean the compiler is finished or suitable for arbitrary npm workloads today. It means there is already a public, measurable conformance baseline that can improve in a disciplined way toward the broader goal of real ecosystem compatibility.
 
@@ -317,7 +320,7 @@ The current tradeoffs are straightforward:
 
 ### 11.1 Conformance is still incomplete
 
-At 76.5% Test262 compliance, the compiler is credible but not complete. There is still significant work to do across language semantics, built-ins, and host-sensitive behaviors.
+At 76.5% Test262 compliance on the JS-host path — and 53.6% on the standalone, host-free path — the compiler is credible but not complete. There is still significant work to do across language semantics, built-ins, and host-sensitive behaviors, and the standalone gap in particular is a primary focus (§5.2, §12.2).
 
 ### 11.2 Wasm GC runtime support is required
 


### PR DESCRIPTION
Follow-on to #3073. The whitepaper discussed the two execution paths conceptually (§5) but reported a **single unlabeled conformance number**. Now §7.1 presents both lanes, each labeled — **JS-host 76.5%** (32,990/43,106) and **standalone host-free 53.6%** (23,109/43,106, same official denominator, never summed) — with the distinction carried into the abstract and §11.1, mirrored in both `.md` and `.html`. Standalone figure sourced from `benchmarks/results/test262-standalone-highwater.json`. Stopgap until #3260 auto-updates. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)