### PR TITLE
chore(hooks): file-based override for spawn load gate (.claude/max-load)

### DIFF
--- a/.claude/hooks/pre-agent-spawn.sh
+++ b/.claude/hooks/pre-agent-spawn.sh
@@ -20,7 +20,11 @@ INPUT=$(cat)
 CORES=$(nproc 2>/dev/null || echo 4)
 # Default ceiling = cores-2 (leave headroom), floor of 1.
 DEFAULT_MAX_LOAD=$(( CORES > 2 ? CORES - 2 : 1 ))
-MAX_LOAD=${JS2WASM_MAX_LOAD:-$DEFAULT_MAX_LOAD}
+# Override precedence: env var > .claude/max-load file > cores-2 default.
+# The file knob exists because the hook runs in its own process — an agent
+# session cannot inject JS2WASM_MAX_LOAD into it mid-session. Per-box, gitignored.
+FILE_MAX_LOAD=$(cat "${CLAUDE_PROJECT_DIR:-/workspace}/.claude/max-load" 2>/dev/null | tr -cd '0-9.')
+MAX_LOAD=${JS2WASM_MAX_LOAD:-${FILE_MAX_LOAD:-$DEFAULT_MAX_LOAD}}
 MIN_RAM_MB=${JS2WASM_MIN_RAM_MB:-1500}
 
 AVAIL_MB=$(free -m | awk '/Mem/{print $7}')

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ benchmarks/results/test262-current.jsonl
 benchmarks/results/test262-results.jsonl
 .pnpm-store/
 .claude/settings.local.json
+.claude/max-load
 .claude/worktrees/
 .claude/agents/
 .claude/agent-status/


### PR DESCRIPTION
The pre-agent-spawn load gate could only be raised via `JS2WASM_MAX_LOAD`, but the hook runs in its own process — a live session cannot inject env into it mid-session. This adds a per-box, gitignored `.claude/max-load` file as a second override.

Precedence: `JS2WASM_MAX_LOAD` env > `.claude/max-load` file > `cores-2` default.

The knob value itself is deliberately NOT committed (gitignored) — it's a per-box throughput/responsiveness trade, set locally (currently `8` on the 8-core dev box per user direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8