### PR TITLE
fix(symphony): isolate continuation slices

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -81,6 +81,8 @@ Rules:
 - Record the PR number in the issue frontmatter as `pr: <number>` and leave the issue
   `status: in-review`; Symphony also discovers the PR from the assigned branch if this metadata
   write is missed, then flips the issue to `done` after GitHub reports the PR merged.
+- For a continuation slice, use the exact assigned branch. Symphony creates a fresh branch after
+  every merged non-final slice; do not push another slice to an already-merged branch.
 - On a retry attempt for an existing PR, inspect its failed checks first, repair the existing head
   branch, push the fix, and keep the same PR. Preserve Symphony's `last_ci_retry_head` frontmatter
   field and never open a duplicate PR for a CI repair.

--- a/WORKFLOW.porffor.md
+++ b/WORKFLOW.porffor.md
@@ -92,6 +92,9 @@ Rules:
   issue `in-progress` with its PR so Symphony requeues it after merge. Use
   `in-review` only for the final slice; Symphony marks that issue `done` after
   GitHub reports the PR merged.
+- For a continuation slice, publish from the exact assigned branch. Symphony
+  creates a fresh branch after every merged non-final slice; do not reuse an
+  already-merged branch for the next Porffor slice.
 - Commit all changes with a Claude Code-style message and a
   `Co-authored-by: Codex <codex@openai.com>` trailer.
 - Merge current `origin/main` before implementation and merge it again before

--- a/plan/method/symphony-service.md
+++ b/plan/method/symphony-service.md
@@ -54,10 +54,11 @@ the PR head and check rollup:
   makes completed dependencies visible to the normal candidate scan.
 - A merged PR for an `in-progress` multi-slice issue clears the old PR, records
   it in `last_merged_pr`, and returns the issue to `ready` for its next slice.
-  The durable merge key prevents restart from requeueing the same merged PR.
-  Branches outside the workflow's configured prefix are cleared during this
-  handoff so the next slice starts from current main on a Symphony-owned
-  branch; an existing Symphony branch remains reusable by later slices.
+  The next slice always receives a fresh Symphony branch named from the issue
+  and merged PR, such as `symphony/porffor/2953-after-pr-3128`. The durable
+  merge key prevents restart from requeueing the same merged PR, and branch PR
+  discovery ignores that already-handled PR so it cannot bind the next slice to
+  a stale merged review.
 - A failed check rollup changes the issue back to `in-progress` and dispatches
   a repair attempt in the same deterministic workspace. If that workspace does
   not exist, Symphony checks out the PR's actual head branch from `origin`.
@@ -70,6 +71,11 @@ the PR head and check rollup:
   dispatch loop.
 - Pending or passing open PRs remain `in-review`. Symphony leaves merge-queue
   enrollment to the worker contract.
+- If a worker exits successfully while the issue remains `in-progress` without
+  a PR, Symphony first checks the assigned branch for a fresh PR. If none
+  exists, it moves the issue back to `ready` instead of treating the run as
+  complete. That keeps a missed PR creation from stranding the slice outside
+  the claimable queue.
 
 PR polling errors are logged without changing issue state. The standalone
 `issues:pr-status` poller remains useful for non-Symphony issues, but Symphony
@@ -159,7 +165,9 @@ prerequisites. Symphony can continue multi-slice #2953/#2956 work until P1/P3
 unblock, but it cannot consume unrelated work from the broad `current` sprint.
 Workers leave a multi-slice prerequisite `in-progress` while unchecked slices
 remain so each merged PR requeues the next slice; only the final PR uses
-`in-review` and closes the issue on merge.
+`in-review` and closes the issue on merge. Every continuation slice gets a new
+branch after the previous PR merges; workers must publish from the branch named
+in their prompt rather than pushing another slice to an already-merged branch.
 
 ## Safety Posture
 

--- a/scripts/symphony-pr-state.mjs
+++ b/scripts/symphony-pr-state.mjs
@@ -15,6 +15,22 @@ function checkStatus(check) {
   return String(check?.status ?? "").toUpperCase();
 }
 
+function normalizePullRequestNumber(value) {
+  if (value == null || value === "") return null;
+  const text = String(value).trim();
+  const match = text.match(/\/pull\/(\d+)/i) || text.match(/^#?(\d+)$/);
+  return match ? match[1] : text;
+}
+
+function selectPullRequestForBranch(snapshots, { excludeNumbers = [] } = {}) {
+  const excluded = new Set(excludeNumbers.map(normalizePullRequestNumber).filter(Boolean));
+  const candidates = snapshots.filter((snapshot) => {
+    const number = normalizePullRequestNumber(snapshot?.number);
+    return !number || !excluded.has(number);
+  });
+  return candidates.find((snapshot) => String(snapshot?.state ?? "").toUpperCase() === "OPEN") ?? candidates[0] ?? null;
+}
+
 export function classifyPullRequest(snapshot) {
   if (!snapshot || typeof snapshot !== "object") throw new Error("invalid_pull_request_snapshot");
 
@@ -136,7 +152,14 @@ export function readPullRequest({ command = "gh", cwd, number, repository = "", 
   return classifyPullRequest(snapshot);
 }
 
-export function readPullRequestForBranch({ branch, command = "gh", cwd, repository = "", timeoutMs = 30_000 }) {
+export function readPullRequestForBranch({
+  branch,
+  command = "gh",
+  cwd,
+  repository = "",
+  timeoutMs = 30_000,
+  excludeNumbers = [],
+}) {
   const args = [
     "pr",
     "list",
@@ -145,7 +168,7 @@ export function readPullRequestForBranch({ branch, command = "gh", cwd, reposito
     "--state",
     "all",
     "--limit",
-    "1",
+    "20",
     "--json",
     "number,state,mergedAt,url,headRefName,headRefOid,statusCheckRollup",
   ];
@@ -169,5 +192,6 @@ export function readPullRequestForBranch({ branch, command = "gh", cwd, reposito
     throw new Error(`pull_request_query_invalid_json: ${error.message}`);
   }
   if (!Array.isArray(snapshots)) throw new Error("pull_request_query_invalid_json: expected an array");
-  return snapshots.length > 0 ? classifyPullRequest(snapshots[0]) : null;
+  const selected = selectPullRequestForBranch(snapshots, { excludeNumbers });
+  return selected ? classifyPullRequest(selected) : null;
 }

--- a/scripts/symphony.mjs
+++ b/scripts/symphony.mjs
@@ -327,6 +327,13 @@ function sanitizeKey(s) {
     .slice(0, 120);
 }
 
+function continuationBranchName(issue, branchPrefix, mergeKey) {
+  const prefix = String(branchPrefix || "symphony").replace(/\/+$/, "") || "symphony";
+  const issueKey = sanitizeKey(issue.identifier || issue.id || "issue") || "issue";
+  const mergeSegment = sanitizeKey(mergeKey || "merged") || "merged";
+  return `${prefix}/${issueKey}-after-pr-${mergeSegment}`;
+}
+
 function parseFrontmatter(text) {
   const match = text.match(/^---\n([\s\S]*?)\n---\n?/);
   if (!match) return { data: {}, body: text };
@@ -652,7 +659,7 @@ class WorkspaceManager {
     } else if (this.kind === "git_worktree") {
       const actualBranch = this.git(["branch", "--show-current"], workspaceAbs);
       if (actualBranch !== branch) {
-        throw new Error(`workspace_branch_mismatch: expected ${branch}, found ${actualBranch || "detached"}`);
+        this.switchGitWorktreeBranch(workspaceAbs, branch, actualBranch, issue);
       }
     }
     return { path: workspaceAbs, workspace_key: key, created_now: createdNow, branch };
@@ -665,6 +672,31 @@ class WorkspaceManager {
     if (branchExists) this.git(["worktree", "add", workspacePath, branch], ROOT);
     else if (remoteBranchExists) this.git(["worktree", "add", workspacePath, "-b", branch, `origin/${branch}`], ROOT);
     else this.git(["worktree", "add", workspacePath, "-b", branch, this.baseRef], ROOT);
+  }
+
+  switchGitWorktreeBranch(workspacePath, branch, previousBranch, issue) {
+    const status = this.git(["status", "--porcelain"], workspacePath);
+    if (status.trim()) {
+      throw new Error(
+        `workspace_branch_mismatch_dirty: expected ${branch}, found ${previousBranch || "detached"} with local changes`,
+      );
+    }
+    if (this.fetchBeforeCreate) this.git(["fetch", "origin"], ROOT);
+    const branchExists = this.gitOptional(["show-ref", "--verify", `refs/heads/${branch}`], ROOT);
+    const remoteBranchExists = this.gitOptional(["show-ref", "--verify", `refs/remotes/origin/${branch}`], ROOT);
+    if (branchExists) this.git(["switch", branch], workspacePath);
+    else if (remoteBranchExists) this.git(["switch", "-c", branch, `origin/${branch}`], workspacePath);
+    else this.git(["switch", "-c", branch, this.baseRef], workspacePath);
+    const actualBranch = this.git(["branch", "--show-current"], workspacePath);
+    if (actualBranch !== branch) {
+      throw new Error(`workspace_branch_mismatch: expected ${branch}, found ${actualBranch || "detached"}`);
+    }
+    this.logger.event("workspace_branch_switched", {
+      issue_id: issue.id,
+      issue_identifier: issue.identifier,
+      from: previousBranch || null,
+      branch,
+    });
   }
 
   remove(issue) {
@@ -1049,6 +1081,33 @@ class Orchestrator {
     return Number(get(this.config, "pull_requests.poll_interval_ms", this.pollInterval())) || this.pollInterval();
   }
 
+  discoverPullRequestForIssueBranch(issue) {
+    if (!issue?.branch_name) return null;
+    const repository = String(get(this.config, "pull_requests.repository", ""));
+    const command = String(get(this.config, "pull_requests.command", "gh"));
+    const timeoutMs = Number(get(this.config, "pull_requests.timeout_ms", 30000)) || 30000;
+    try {
+      return readPullRequestForBranch({
+        branch: issue.branch_name,
+        command,
+        cwd: ROOT,
+        repository,
+        timeoutMs,
+        excludeNumbers: [issue.last_merged_pr],
+      });
+    } catch (error) {
+      this.logger.event("pull_request_poll_failed", {
+        issue_id: issue.id,
+        issue_identifier: issue.identifier,
+        pr: issue.pull_request,
+        branch: issue.branch_name,
+        error: error.message,
+        quiet: true,
+      });
+      return null;
+    }
+  }
+
   validate() {
     const kind = get(this.config, "tracker.kind", "");
     if (kind !== "markdown") throw new Error(`unsupported_tracker_kind: ${kind || "(missing)"}`);
@@ -1315,12 +1374,40 @@ class Orchestrator {
       });
     } else if (result.status === "succeeded") {
       const current = this.tracker.fetchIssueStatesByIds([id])[0];
-      if (current?.pull_request && current.state === "in-review") {
+      if (current?.pull_request && ["in-progress", "in-review"].includes(current.state)) {
         this.logger.event("agent_awaiting_pull_request", {
           issue_id: issue.id,
           issue_identifier: issue.identifier,
           pr: current.pull_request,
         });
+      } else if (current?.state === "in-progress" && !current.pull_request) {
+        const discovered = this.discoverPullRequestForIssueBranch(current);
+        if (discovered?.number) {
+          current.pull_request = discovered.number;
+          current.pr = discovered.number;
+          if (discovered.headBranch) current.branch_name = discovered.headBranch;
+          this.tracker.updateIssueStatusFile(current, current.file, current.state, {
+            pr: discovered.number,
+            ...(current.branch_name ? { branch: current.branch_name } : {}),
+          });
+          this.logger.event("pull_request_discovered", {
+            issue_id: issue.id,
+            issue_identifier: issue.identifier,
+            pr: discovered.number,
+            branch: current.branch_name || null,
+          });
+        } else {
+          this.tracker.updateIssueStatusFile(current, current.file, "ready", {
+            ...(current.branch_name ? { branch: current.branch_name } : {}),
+            pr: null,
+          });
+          this.completed.delete(id);
+          this.logger.event("agent_missing_pull_request_requeued", {
+            issue_id: issue.id,
+            issue_identifier: issue.identifier,
+            branch: current.branch_name || null,
+          });
+        }
       } else {
         this.completed.add(id);
       }
@@ -1449,13 +1536,7 @@ class Orchestrator {
               repository,
               timeoutMs,
             })
-          : readPullRequestForBranch({
-              branch: issue.branch_name,
-              command,
-              cwd: ROOT,
-              repository,
-              timeoutMs,
-            });
+          : this.discoverPullRequestForIssueBranch(issue);
       } catch (error) {
         this.logger.event("pull_request_poll_failed", {
           issue_id: issue.id,
@@ -1517,10 +1598,7 @@ class Orchestrator {
       if (planned.action === "continue") {
         const mergedBranch = issue.branch_name;
         const branchPrefix = String(get(this.config, "workspace.branch_prefix", "symphony")).replace(/\/+$/, "");
-        const continuationBranch =
-          mergedBranch && (mergedBranch === branchPrefix || mergedBranch.startsWith(`${branchPrefix}/`))
-            ? mergedBranch
-            : null;
+        const continuationBranch = continuationBranchName(issue, branchPrefix, planned.mergeKey);
         const running = this.running.get(id);
         const retry = this.retryAttempts.get(id);
         if (retry?.timer_handle) clearTimeout(retry.timer_handle);

--- a/tests/symphony-pr-reconciliation.test.ts
+++ b/tests/symphony-pr-reconciliation.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -170,6 +170,370 @@ esac
     ).toMatchObject({ number: 100, status: "pending", headBranch: "agent/100" });
   });
 
+  it("does not rediscover an already handled merged PR for a branch", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-pr-branch-handled-"));
+    const fakeGh = join(tempDir, "gh");
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr list --head symphony/porffor/2953"*"--repo loopdive/js2"*)
+    printf '%s\\n' '[{"number":3128,"state":"MERGED","mergedAt":"2026-07-16T08:00:00Z","headRefName":"symphony/porffor/2953","headRefOid":"old-sha","statusCheckRollup":[]}]'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    chmodSync(fakeGh, 0o755);
+
+    expect(
+      readPullRequestForBranch({
+        branch: "symphony/porffor/2953",
+        command: fakeGh,
+        cwd: tempDir,
+        repository: "loopdive/js2",
+        excludeNumbers: [3128],
+      }),
+    ).toBeNull();
+  });
+
+  it("prefers a fresh open branch PR over an older merged PR", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-pr-branch-open-"));
+    const fakeGh = join(tempDir, "gh");
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr list --head symphony/porffor/2953-after-pr-3128"*"--repo loopdive/js2"*)
+    printf '%s\\n' '[{"number":3128,"state":"MERGED","mergedAt":"2026-07-16T08:00:00Z","headRefName":"symphony/porffor/2953-after-pr-3128","headRefOid":"old-sha","statusCheckRollup":[]},{"number":3130,"state":"OPEN","headRefName":"symphony/porffor/2953-after-pr-3128","headRefOid":"new-sha","statusCheckRollup":[]}]'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    chmodSync(fakeGh, 0o755);
+
+    expect(
+      readPullRequestForBranch({
+        branch: "symphony/porffor/2953-after-pr-3128",
+        command: fakeGh,
+        cwd: tempDir,
+        repository: "loopdive/js2",
+        excludeNumbers: [3128],
+      }),
+    ).toMatchObject({ number: 3130, status: "pending", headBranch: "symphony/porffor/2953-after-pr-3128" });
+  });
+
+  it("continues a merged Porffor slice on a fresh branch and requeues if no new PR appears", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-porffor-continuation-"));
+    const issuesDir = join(tempDir, "issues");
+    const workspaceRoot = join(tempDir, "workspaces");
+    const loggingRoot = join(tempDir, "logs");
+    const issueFile = join(issuesDir, "2953-porffor-runtime-lowering.md");
+    const workflow = join(tempDir, "WORKFLOW.md");
+    const fakeGh = join(tempDir, "gh");
+    const fakeAgent = join(tempDir, "agent");
+    const response = join(tempDir, "pr.json");
+    const marker = join(tempDir, "agent-runs.txt");
+
+    mkdirSync(issuesDir, { recursive: true });
+    writeFileSync(
+      issueFile,
+      `---
+id: 2953
+title: "Porffor runtime lowering"
+status: in-progress
+sprint: porffor-backend
+branch: symphony/porffor/2953
+pr: 3128
+---
+# Porffor runtime lowering
+`,
+    );
+    writeFileSync(
+      workflow,
+      `---
+tracker:
+  kind: markdown
+  issues_dir: ${issuesDir}
+  sprint: porffor-backend
+  active_states: [ready, in-progress, in-review]
+  claimable_states: [ready]
+  claim_state: in-progress
+  terminal_states: [done, wont-fix]
+polling:
+  interval_ms: 10
+pull_requests:
+  enabled: true
+  repository: loopdive/js2
+  command: ${fakeGh}
+  poll_interval_ms: 10
+  review_states: [in-progress, in-review]
+workspace:
+  kind: directory
+  root: ${workspaceRoot}
+  branch_prefix: symphony/porffor
+agent:
+  max_concurrent_agents: 1
+  max_turns: 1
+  lanes:
+    - name: fake-agent
+      kind: generic
+      command: ${fakeAgent}
+      prompt_mode: stdin
+      max_concurrent: 1
+logging:
+  root: ${loggingRoot}
+---
+Issue {{ issue.identifier }} branch {{ workspace.branch }}
+`,
+    );
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr view 3128"*"--repo loopdive/js2"*) cat "$PR_RESPONSE" ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    writeFileSync(
+      fakeAgent,
+      `#!/bin/sh\nprintf '%s %s\\n' "$SYMPHONY_ISSUE_ID" "$SYMPHONY_BRANCH" >> "$AGENT_MARKER"\ncat >/dev/null\n`,
+    );
+    chmodSync(fakeGh, 0o755);
+    chmodSync(fakeAgent, 0o755);
+    writeFileSync(
+      response,
+      JSON.stringify({
+        number: 3128,
+        state: "MERGED",
+        mergedAt: "2026-07-16T08:00:00Z",
+        headRefName: "symphony/porffor/2953",
+        headRefOid: "slice-one-sha",
+        statusCheckRollup: [],
+      }),
+    );
+
+    execFileSync(process.execPath, ["scripts/symphony.mjs", "--workflow", workflow, "--once"], {
+      cwd: process.cwd(),
+      env: { ...process.env, PR_RESPONSE: response, AGENT_MARKER: marker },
+      stdio: "pipe",
+    });
+
+    const issue = readFileSync(issueFile, "utf8");
+    expect(issue).toContain("status: ready");
+    expect(issue).toContain("pr: null");
+    expect(issue).toContain("last_merged_pr: 3128");
+    expect(issue).toContain("branch: symphony/porffor/2953-after-pr-3128");
+    expect(readFileSync(marker, "utf8")).toBe("2953 symphony/porffor/2953-after-pr-3128\n");
+    const events = readFileSync(join(loggingRoot, "events.jsonl"), "utf8");
+    expect(events).toContain('"event":"pull_request_merged_issue_requeued"');
+    expect(events).toContain('"event":"agent_missing_pull_request_requeued"');
+  });
+
+  it("records a fresh continuation PR when the worker missed PR metadata", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-porffor-discover-fresh-pr-"));
+    const issuesDir = join(tempDir, "issues");
+    const workspaceRoot = join(tempDir, "workspaces");
+    const loggingRoot = join(tempDir, "logs");
+    const issueFile = join(issuesDir, "2953-porffor-runtime-lowering.md");
+    const workflow = join(tempDir, "WORKFLOW.md");
+    const fakeGh = join(tempDir, "gh");
+    const fakeAgent = join(tempDir, "agent");
+    const response = join(tempDir, "pr.json");
+    const marker = join(tempDir, "agent-runs.txt");
+
+    mkdirSync(issuesDir, { recursive: true });
+    writeFileSync(
+      issueFile,
+      `---
+id: 2953
+title: "Porffor runtime lowering"
+status: in-progress
+sprint: porffor-backend
+branch: symphony/porffor/2953
+pr: 3128
+---
+# Porffor runtime lowering
+`,
+    );
+    writeFileSync(
+      workflow,
+      `---
+tracker:
+  kind: markdown
+  issues_dir: ${issuesDir}
+  sprint: porffor-backend
+  active_states: [ready, in-progress, in-review]
+  claimable_states: [ready]
+  claim_state: in-progress
+  terminal_states: [done, wont-fix]
+polling:
+  interval_ms: 10
+pull_requests:
+  enabled: true
+  repository: loopdive/js2
+  command: ${fakeGh}
+  poll_interval_ms: 10
+  review_states: [in-progress, in-review]
+workspace:
+  kind: directory
+  root: ${workspaceRoot}
+  branch_prefix: symphony/porffor
+agent:
+  max_concurrent_agents: 1
+  max_turns: 1
+  lanes:
+    - name: fake-agent
+      kind: generic
+      command: ${fakeAgent}
+      prompt_mode: stdin
+      max_concurrent: 1
+logging:
+  root: ${loggingRoot}
+---
+Issue {{ issue.identifier }} branch {{ workspace.branch }}
+`,
+    );
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr view 3128"*"--repo loopdive/js2"*) cat "$PR_RESPONSE" ;;
+  *"pr list --head symphony/porffor/2953-after-pr-3128"*"--repo loopdive/js2"*)
+    printf '%s\\n' '[{"number":3130,"state":"OPEN","headRefName":"symphony/porffor/2953-after-pr-3128","headRefOid":"slice-two-sha","statusCheckRollup":[]}]'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    writeFileSync(
+      fakeAgent,
+      `#!/bin/sh\nprintf '%s %s\\n' "$SYMPHONY_ISSUE_ID" "$SYMPHONY_BRANCH" >> "$AGENT_MARKER"\ncat >/dev/null\n`,
+    );
+    chmodSync(fakeGh, 0o755);
+    chmodSync(fakeAgent, 0o755);
+    writeFileSync(
+      response,
+      JSON.stringify({
+        number: 3128,
+        state: "MERGED",
+        mergedAt: "2026-07-16T08:00:00Z",
+        headRefName: "symphony/porffor/2953",
+        headRefOid: "slice-one-sha",
+        statusCheckRollup: [],
+      }),
+    );
+
+    execFileSync(process.execPath, ["scripts/symphony.mjs", "--workflow", workflow, "--once"], {
+      cwd: process.cwd(),
+      env: { ...process.env, PR_RESPONSE: response, AGENT_MARKER: marker },
+      stdio: "pipe",
+    });
+
+    const issue = readFileSync(issueFile, "utf8");
+    expect(issue).toContain("status: in-progress");
+    expect(issue).toContain("pr: 3130");
+    expect(issue).toContain("last_merged_pr: 3128");
+    expect(issue).toContain("branch: symphony/porffor/2953-after-pr-3128");
+    expect(readFileSync(marker, "utf8")).toBe("2953 symphony/porffor/2953-after-pr-3128\n");
+    const events = readFileSync(join(loggingRoot, "events.jsonl"), "utf8");
+    expect(events).toContain('"event":"pull_request_discovered"');
+    expect(events).not.toContain('"event":"agent_missing_pull_request_requeued"');
+  });
+
+  it("does not bind a restarted in-progress slice to its already handled merged PR", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "symphony-porffor-handled-discovery-"));
+    const issuesDir = join(tempDir, "issues");
+    const workspaceRoot = join(tempDir, "workspaces");
+    const loggingRoot = join(tempDir, "logs");
+    const issueFile = join(issuesDir, "2953-porffor-runtime-lowering.md");
+    const workflow = join(tempDir, "WORKFLOW.md");
+    const fakeGh = join(tempDir, "gh");
+    const fakeAgent = join(tempDir, "agent");
+    const marker = join(tempDir, "agent-runs.txt");
+
+    mkdirSync(issuesDir, { recursive: true });
+    writeFileSync(
+      issueFile,
+      `---
+id: 2953
+title: "Porffor runtime lowering"
+status: in-progress
+sprint: porffor-backend
+branch: symphony/porffor/2953
+last_merged_pr: 3128
+---
+# Porffor runtime lowering
+`,
+    );
+    writeFileSync(
+      workflow,
+      `---
+tracker:
+  kind: markdown
+  issues_dir: ${issuesDir}
+  sprint: porffor-backend
+  active_states: [ready, in-progress, in-review]
+  claimable_states: [ready]
+  claim_state: in-progress
+  terminal_states: [done, wont-fix]
+polling:
+  interval_ms: 10
+pull_requests:
+  enabled: true
+  repository: loopdive/js2
+  command: ${fakeGh}
+  poll_interval_ms: 10
+  review_states: [in-progress, in-review]
+workspace:
+  kind: directory
+  root: ${workspaceRoot}
+  branch_prefix: symphony/porffor
+agent:
+  max_concurrent_agents: 1
+  max_turns: 1
+  lanes:
+    - name: fake-agent
+      kind: generic
+      command: ${fakeAgent}
+      prompt_mode: stdin
+      max_concurrent: 1
+logging:
+  root: ${loggingRoot}
+---
+Issue {{ issue.identifier }}
+`,
+    );
+    writeFileSync(
+      fakeGh,
+      `#!/bin/sh
+case "$*" in
+  *"pr list --head symphony/porffor/2953"*"--repo loopdive/js2"*)
+    printf '%s\\n' '[{"number":3128,"state":"MERGED","mergedAt":"2026-07-16T08:00:00Z","headRefName":"symphony/porffor/2953","headRefOid":"slice-one-sha","statusCheckRollup":[]}]'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+    );
+    writeFileSync(fakeAgent, `#!/bin/sh\nprintf '%s\\n' "$SYMPHONY_ISSUE_ID" >> "$AGENT_MARKER"\ncat >/dev/null\n`);
+    chmodSync(fakeGh, 0o755);
+    chmodSync(fakeAgent, 0o755);
+
+    execFileSync(process.execPath, ["scripts/symphony.mjs", "--workflow", workflow, "--once"], {
+      cwd: process.cwd(),
+      env: { ...process.env, AGENT_MARKER: marker },
+      stdio: "pipe",
+    });
+
+    const issue = readFileSync(issueFile, "utf8");
+    expect(issue).toContain("status: in-progress");
+    expect(issue).toContain("last_merged_pr: 3128");
+    expect(issue).not.toMatch(/^pr: 3128$/m);
+    expect(existsSync(marker)).toBe(false);
+  });
+
   it("continues an external dependency after merge and unblocks only its sprint root", () => {
     tempDir = mkdtempSync(join(tmpdir(), "symphony-reconcile-"));
     const issuesDir = join(tempDir, "issues");
@@ -314,17 +678,17 @@ fi
     );
     runSymphony();
     const continuedIssue = readFileSync(issueFile, "utf8");
-    expect(continuedIssue).toContain("status: in-progress");
+    expect(continuedIssue).toContain("status: ready");
     expect(continuedIssue).toContain("pr: null");
     expect(continuedIssue).toContain("last_ci_retry_head: null");
     expect(continuedIssue).toContain("last_merged_pr: 99");
-    expect(continuedIssue).toContain("branch: symphony/9001");
+    expect(continuedIssue).toContain("branch: symphony/9001-after-pr-99");
     expect(readFileSync(marker, "utf8")).toBe("9001\n9001\n");
     expect(readFileSync(join(loggingRoot, "events.jsonl"), "utf8")).not.toContain('"event":"retry_suppressed"');
 
     writeFileSync(
       issueFile,
-      continuedIssue.replace("status: in-progress", "status: in-review").replace("pr: null", "pr: 100"),
+      continuedIssue.replace("status: ready", "status: in-review").replace("pr: null", "pr: 100"),
     );
     writeFileSync(
       response,


### PR DESCRIPTION
## Summary
- create a fresh Symphony continuation branch after every merged non-final slice
- ignore already-handled merged PRs during branch discovery
- requeue successful in-progress runs that still have no fresh PR, while preserving discovery when a PR exists but metadata was missed

## Validation
- node /Users/thomas/Documents/Arbeit/Startup/Projekte/Mosaic/code/@loopdive/ts2wasm/node_modules/vitest/dist/cli.js run tests/symphony-pr-reconciliation.test.ts
- git diff --check

Note: local git commit/push hooks could not run in this isolated worktree because local dependencies are unavailable or incomplete there (tsc missing from worktree node_modules; Biome optional binary missing from root node_modules).