### PR TITLE
refactor(ir): route funcref materialization through emitter

### DIFF
--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -4,7 +4,7 @@ title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coe
 status: in-progress
 assignee: ttraenkler/opus-1a
 branch: symphony/porffor/2953-after-3129
-pr: null
+pr: 3134
 sprint: current
 created: 2026-07-02
 updated: 2026-07-16

--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -3,8 +3,8 @@ id: 2953
 title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait"
 status: in-progress
 assignee: ttraenkler/opus-1a
-branch: symphony/porffor/2953
-pr: 3129
+branch: symphony/porffor/2953-after-3129
+pr: null
 sprint: current
 created: 2026-07-02
 updated: 2026-07-16
@@ -21,8 +21,8 @@ origin: "2026-07-02 July Fable audit §5 (77 pushRaw sites; #1852-G1 slice text 
 loc-budget-allow:
   - src/ir/lower.ts
 claimed_by: porffor-codex-developer
-claimed_at: 2026-07-16T12:43:20.310Z
-last_merged_pr: 3128
+claimed_at: 2026-07-16T13:41:17.751Z
+last_merged_pr: 3129
 ---
 
 # #2953 — 40% of IR lowering bypasses the backend trait
@@ -111,7 +111,14 @@ value/aggregate families.
       allocation/field ops remain for their dedicated slice. Golden emitter tests,
       closure + cross-backend suites, equivalence, and the 56-record byte oracle
       are green. (porffor-codex-developer)
-- [ ] funcref (`emitFuncRef`)
+- [x] **funcref** (`emitFuncRef`) — promoted the optional, `Instr[]`-specific
+      hook to a required sink-generic primitive. `WasmGcEmitter` materializes
+      the resolved function index with the canonical `ref.func`; Linear and
+      Bytecode fail loudly until their table/VM-callable handle representations
+      land. The sole raw `ref.func` in `closure.new` now routes through the
+      trait, reducing `emitter.pushRaw` calls in `lower.ts` from 86 to 85.
+      Golden emitter coverage, closure + cross-backend suites, typecheck,
+      equivalence, and the 56-record byte oracle are green.
 - [ ] Promise ops
 - [ ] ratchet: pushRaw count check + `// pushraw-ok(#issue)` justification tag
 
@@ -185,3 +192,29 @@ value/aggregate families.
   `IDENTICAL — all 56 (file,target) emits match baseline`.
 - Slice acceptance: complete. The parent issue intentionally remains
   `in-progress` for funcref, Promise ops, and the pushRaw justification ratchet.
+
+## 2026-07-16 — funcref slice results
+
+- Re-grounded and fast-forwarded to `origin/main` at
+  `2a77b7131c6239e980029f5a870ab43b70f354ae` before implementation.
+- Made `emitFuncRef` required and generic over the backend sink. Lowering still
+  resolves the lifted function name and owns closure operand order; the backend
+  now owns materializing that resolved handle as a first-class callable value.
+  WasmGC emits the exact former `{ op: "ref.func", funcIdx }` instruction, while
+  Linear and Bytecode stop at explicit missing-representation errors instead of
+  accepting a raw WasmGC instruction.
+- Routed the `closure.new` materialization site through the trait and added a
+  Golden-Instr assertion for `WasmGcEmitter.emitFuncRef` in
+  `tests/ir-backend-emitter.test.ts`. The `emitter.pushRaw` call count in
+  `lower.ts` is now 85 (86 before this slice).
+- Focused verification:
+  `pnpm vitest run tests/ir-backend-emitter.test.ts tests/issue-1169c.test.ts tests/ir-bytecode-proof.test.ts`
+  (75 tests passed), plus `pnpm run typecheck` and
+  `pnpm run test:equivalence:gate` (1,607 passing, 36 known baseline failures,
+  zero new regressions).
+- Byte identity: rebuilt the existing `scripts/prove-emit-identity.mjs` harness
+  with esbuild, captured the pre-edit baseline, and compared the edited compiler
+  against it. Result:
+  `IDENTICAL — all 56 (file,target) emits match baseline`.
+- Slice acceptance: complete. The parent issue intentionally remains
+  `in-progress` for Promise ops and the pushRaw justification ratchet.

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -687,6 +687,12 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     throw new Error("BytecodeEmitter: externref conversion not yet wired — see §2a ref-coercion family.");
   }
 
+  // ---- function-reference family (#2953) — callable values need a VM handle
+  // representation; do not admit a raw WasmGC ref.func through pushRaw.
+  emitFuncRef(): void {
+    throw new Error("BytecodeEmitter: function references not yet wired — see §2a closure family.");
+  }
+
   // ---- closure family (#2953) — closure records and callable handles are not
   // yet represented by the bytecode VM. Keep the trait boundary loud instead
   // of falling back to WasmGC struct instructions through pushRaw.

--- a/src/ir/backend/contract-conformance.ts
+++ b/src/ir/backend/contract-conformance.ts
@@ -161,6 +161,9 @@ class StubEmitter implements BackendEmitter<StubSink> {
   emitFromExternref(_target: { typeIdx: number } | IrType, out: StubSink): void {
     out.push("from.externref");
   }
+  emitFuncRef(funcIdx: FuncHandle, out: StubSink): void {
+    out.push(`func.ref:${funcIdx}`);
+  }
   emitCall(funcIdx: FuncHandle, out: StubSink): void {
     out.push(`call:${funcIdx}`);
   }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -177,8 +177,13 @@ export interface BackendEmitter<S = Instr[]> {
   /** externref on the stack -> a ref narrowed to `target`. */
   emitFromExternref(target: { typeIdx: number } | IrType, out: S): void;
 
-  // ---- NOT YET MOVED (declared for #1714+ staging; see issue Scope) ----
-  emitFuncRef?(funcIdx: number, out: Instr[]): void;
+  // ---- function-reference family — MIGRATED behind the trait (#2953) ------
+  // The caller resolves the lifted function handle and owns its position in
+  // the closure-construction operand order. The backend owns how that handle
+  // becomes a first-class callable value (WasmGC: ref.func; linear/bytecode:
+  // table or VM-callable handle once those representations land).
+  /** Materialize compiled function `funcIdx` as a first-class callable value. */
+  emitFuncRef(funcIdx: number, out: S): void;
 
   // ---- closure family — MIGRATED behind the trait (#2953) -----------------
   // Closure construction and field reads are aggregate operations whose
@@ -186,8 +191,8 @@ export interface BackendEmitter<S = Instr[]> {
   // closure.new leaves the lifted function reference followed by each capture
   // on the stack; closure.cap performs its subtype downcast before the field
   // read; closure.call performs its typed-funcref cast after the function-field
-  // read. Those ref.func/ref.cast operations migrate in their dedicated #2953
-  // slices, while these hooks close the closure struct.new/get bypasses.
+  // read. Function materialization and narrowing route through their own
+  // representation hooks; these hooks own closure allocation and field reads.
   /** lifted function ref + captureCount captures on the stack -> closure value. */
   emitClosureNew(layout: IrClosureLowering, captureCount: number, out: S): void;
   /** closure ref on the stack -> its abstract funcref field. */

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -315,6 +315,12 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     notImplemented("emitFromExternref");
   }
 
+  // function materialization — a linear closure carries a table index or
+  // equivalent handle, not a WasmGC funcref (#2956, closures).
+  emitFuncRef(): void {
+    notImplemented("emitFuncRef");
+  }
+
   // typed-funcref call — `call_ref` over a GC funcref (#2956, closures). The
   // linear backend dispatches indirect calls through a table (`call_indirect`),
   // not a reference-typed funcref, so this needs distinct lowering.

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -223,9 +223,17 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     this.emitDowncast(target, out);
   }
 
+  // ---- function-reference family (#2953) — byte-identical to the prior
+  // inline ref.func push in lower.ts. Name/handle resolution and operand order
+  // remain with the caller.
+  emitFuncRef(funcIdx: number, out: Instr[]): void {
+    out.push({ op: "ref.func", funcIdx });
+  }
+
   // ---- closure family (#2953) — byte-identical to the prior inline
   // struct.new/get pushes in lower.ts. The caller has already emitted the
-  // lifted function reference, captures, and any required ref.cast.
+  // lifted function reference through emitFuncRef, captures, and any required
+  // ref.cast.
   emitClosureNew(layout: IrClosureLowering, _captureCount: number, out: Instr[]): void {
     out.push({ op: "struct.new", typeIdx: layout.structTypeIdx });
   }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1589,7 +1589,7 @@ export function lowerIrFunctionBody<S>(
         }
         const liftedIdx = resolver.resolveFunc(instr.liftedFunc);
         // ref.func $lifted, push captures, struct.new <subtype>.
-        emitter.pushRaw(out, { op: "ref.func", funcIdx: liftedIdx });
+        emitter.emitFuncRef(liftedIdx, out);
         for (const cap of instr.captures) emitValue(cap, out);
         emitter.emitClosureNew(sub, instr.captures.length, out);
         return;

--- a/tests/ir-backend-emitter.test.ts
+++ b/tests/ir-backend-emitter.test.ts
@@ -171,6 +171,14 @@ describe("#2953 WasmGcEmitter — closure family byte-identity", () => {
   });
 });
 
+describe("#2953 WasmGcEmitter — function-reference family byte-identity", () => {
+  it("emitFuncRef → ref.func $lifted", () => {
+    const out: Instr[] = [];
+    emitter.emitFuncRef(23, out);
+    expect(out).toEqual([{ op: "ref.func", funcIdx: 23 }]);
+  });
+});
+
 describe("#2953 WasmGcEmitter — ref-coercion/null family byte-identity", () => {
   it("emitNull selects the canonical nullable-ref and externref ops", () => {
     const out: Instr[] = [];


### PR DESCRIPTION
## Summary

- promote `emitFuncRef` to a required, sink-generic `BackendEmitter` primitive
- preserve WasmGC `ref.func` emission byte-for-byte and add explicit Linear/Bytecode representation boundaries
- route closure construction through the trait and add golden emitter coverage
- record the completed funcref slice while leaving #2953 in progress for Promise ops and the pushRaw ratchet

## Validation

- `pnpm vitest run tests/ir-backend-emitter.test.ts tests/issue-1169c.test.ts tests/ir-bytecode-proof.test.ts` — 75 passed
- `pnpm run typecheck`
- `pnpm run test:equivalence:gate` — 1,607 passing, 36 known baseline failures, zero new regressions
- `scripts/prove-emit-identity.mjs` — identical for all 56 `(file,target)` records
- Prettier check and Biome lint on changed TypeScript files

Co-authored-by: Codex <codex@openai.com>