### PR TITLE
fix(pnpm): retain Darwin Biome binaries

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,10 @@ onlyBuiltDependencies:
   - bun
   - deno
   - esbuild
+
+supportedArchitectures:
+  os:
+    - current
+  cpu:
+    - arm64
+    - x64


### PR DESCRIPTION
## Summary
- configure pnpm supportedArchitectures with os: [current] and cpu: [arm64, x64]
- keep the change scoped to pnpm-workspace.yaml; pnpm-lock.yaml is unchanged
- avoid unrelated OS optional artifacts while retaining both CPU variants on Darwin hosts

## Validation
- node -p "process.platform + ' ' + process.arch" -> darwin arm64
- pnpm config get supportedArchitectures -> os[]=current; cpu[]=arm64; cpu[]=x64
- pnpm install --lockfile-only --offline -> Done in 229ms using pnpm v10.30.2
- git diff --check origin/main...HEAD -> pass
- git diff origin/main...HEAD --name-status -> M pnpm-workspace.yaml

Note: full dependency install/typecheck was not run in the fresh worktree because only 1.2 GiB disk was available and node_modules was intentionally not materialized.