### PR TITLE
feat(#3032 W4): capturing method generators lower natively in standalone

### DIFF
--- a/plan/issues/3032-lazy-generator-expression-thunks.md
+++ b/plan/issues/3032-lazy-generator-expression-thunks.md
@@ -14,18 +14,18 @@ area: codegen, runtime, generators, value-rep
 language_feature: generators, destructuring defaults, equality
 goal: test262-conformance
 related: [2141, 2626, 2040, 2585, 928, 2203, 991, 3050]
-# (#3032 W3) Intended growth at the canonical sites: TDZ-flag capture boxes
-# threaded through the native generator state machine — generators-native.ts
-# (+42: NativeGeneratorCaptureParam.tdzFlagFor, leadingTdzFlags registration,
-# resume-fn boxedTdzFlags/tdzFlagLocals rehydration), nested-declarations.ts
-# (+23: lane-split gate + tdz leadingCaptures entries), context/types.ts
-# (+13: NativeGeneratorInfo.leadingTdzFlags docs). No barrel/driver growth.
+# (#3032 W3+W4) Intended growth at the canonical sites: W3 — TDZ-flag capture
+# boxes threaded through the native generator state machine
+# (generators-native.ts, nested-declarations.ts, context/types.ts). W4 —
+# the method-generator capture-bail lane split in isNativeGeneratorCandidate
+# (generators-native.ts +12: the standalone-lane arm + rationale comment).
+# No barrel/driver growth.
 loc-budget-allow:
   - src/codegen/generators-native.ts
   - src/codegen/statements/nested-declarations.ts
   - src/codegen/context/types.ts
 origin: "2026-07-04 #2141 S2 root-cause (fable-tag5): the −162 dstr eject was never a dstr/eq dependency — it was eager generator bodies + comparator vacuity"
-note: "W3 (TDZ-native-threading) LANDED (sendev-3032-w3, 2026-07-16) — see '## W3 landed'. The A1/tag-5-vacuity unblock this issue was prioritized for is delivered. Remaining banked waves: W2 (paramful gen expressions — MEASURE FIRST, predicted wont-build), W4 (method generators), W5 (retVal marshalling), W6 (retire the buffer / host-lane laziness for non-try-region shapes). Issue stays open for those; they are NOT fresh-window-critical the way W3 was."
+note: "W3 (TDZ-native-threading) + W4 (method generators, standalone lane) LANDED (sendev-3032-w3/-w4, 2026-07-16) — see '## W3 landed' / '## W4 landed'; #3302 covered capturing fn-EXPRESSIONS in between. The A1/tag-5-vacuity unblock is fully delivered on the standalone side. Remaining banked waves: W2 (paramful gen expressions — MEASURE FIRST, predicted wont-build), W5 (retVal marshalling), W6 (retire the buffer / host-lane laziness; next(v) two-way under the buffer stays broken until W6). Issue stays open for those."
 ---
 
 # #3032 — eager-buffer generators run their body AT CREATION; the tag-5 comparator vacuity is the only thing hiding it
@@ -441,3 +441,52 @@ let x = 42; it.next()` throws at CREATION (the #1177 pre-call check — an
 3. **`(yield e) as T` initializer** doesn't match the plan builder's
    resume-binding pattern — `next(v)` sent value reads 0. The untyped-cast
    shape only; `const got = yield e` in a typed generator works.
+
+## W4 landed (sendev-3032-w4, 2026-07-16, branch `issue-3032-w4-method-generators`)
+
+**One gate-term change.** The banked W4 plan ("class-bodies.ts:2309 eager arm
+wrap; not a pure wrap — param instantiation stays outside the flag branch")
+described the HOST-lane thunk route. The standalone lane turned out to need
+NO wrap and NO capture threading at all:
+
+- **The insight (verified by probe before relaxing anything):** a class /
+  object-literal method body never receives captures as params — it resolves
+  them through the #2029/#3039/#3121 promotion machinery
+  (`ctx.capturedBoxGlobals` / `ctx.capturedGlobals` MODULE GLOBALS), which is
+  fctx-INDEPENDENT. So the resume function compiles the same body statements
+  with the same global reads/writes — the #2571 native method machinery
+  (synthesizedThis + state struct) works unchanged for capturing methods.
+- **Change:** `isNativeGeneratorCandidate`'s method-bail
+  (`generatorCapturesOuterScope` term) is now HOST-lane-only. `arguments` /
+  `super` bails stay. JS-host lane byte-identical — method generators are
+  never candidates under a JS host anyway (the host-lane candidate block
+  admits only FunctionDeclarations), so its eager path is untouched.
+- Promotion ordering holds: capturing classes/literals compile DEFERRED in
+  standalone until captures initialize (#3123), so the globals exist before
+  the resume fn emits.
+
+**Validation:** probes — class/objlit method with `let` capture: standalone
+101→**1** (lazy, §27.5), 4→**0** `__gen_*` imports, `instantiate({})`
+FAIL→**OK**; objlit drain NaN→**233** (write-through); capture+this 316;
+capture+param 107; static 74; `next(7)`→107 two-way; try/finally+capture
+1111; two-methods 12. `tests/issue-3032-w4-method-generators.test.ts` 11/11.
+Method suites (2571/2581/2938/2641/generator-methods/-destructuring/3050)
+57/57 — the two #2571/#2581 tests that ASSERTED the old capture-bail now
+assert the native lowering. **gen-meth dstr family A/B (930 files, standalone,
+branch vs main): exactly ZERO flips either direction** — the family's pass
+rate is shim-neutral (the runner supplies `__gen_*` shims), so W4's win is
+the leak metric (host-free instantiate) + §27.5 laziness, with **no
+regressions**.
+
+**Known same-wrong, different-mode:** a TDZ/promotion-timing shape
+(`class C { *m() { yield z; } } const z = 42;` — class compiled before `z`
+initializes) read a stale NaN via the value-global on main (both lanes,
+silent); the native path now throws a loud TDZ ReferenceError at first
+resume in standalone. Neither matches spec (42) — the promotion-timing
+limitation predates W4 (#3123 lineage), surfaced loudly instead of silently.
+
+**Remaining after W4:** W2 (paramful gen EXPRESSIONS — measure-first,
+predicted wont-build), W5 (retVal marshalling), W6 (retire the buffer —
+host-lane laziness for the shapes the thunk model doesn't cover; `next(v)`
+two-way under the buffer stays broken until then). The tag-5/A1 unblock is
+fully delivered by W3+#3302+W4 on the standalone side.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -1781,7 +1781,19 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: GeneratorD
   if (
     ts.isMethodDeclaration(decl) &&
     decl.body &&
-    (bodyUsesArguments(decl.body) || methodBodyUsesSuper(decl.body) || generatorCapturesOuterScope(ctx, decl))
+    (bodyUsesArguments(decl.body) ||
+      methodBodyUsesSuper(decl.body) ||
+      // (#3032 W4) Outer-scope captures are ADMITTED for method generators in
+      // the standalone/wasi lane: a class / object-literal method body never
+      // receives captures as params — it resolves them through the
+      // #2029/#3039/#3121 promotion machinery (`ctx.capturedBoxGlobals` /
+      // `ctx.capturedGlobals` module globals), which is fctx-INDEPENDENT, so
+      // the resume function compiles the same body with the same global
+      // reads/writes — no threading needed. The promotion runs in the
+      // enclosing fctx before the class/literal members compile, hence before
+      // the resume fn emits. JS-host lane keeps the eager path (byte-identical;
+      // its laziness is the #3032 thunk track).
+      (!noJsHostTarget(ctx) && generatorCapturesOuterScope(ctx, decl)))
   ) {
     return false;
   }

--- a/tests/issue-2571-native-method-generators.test.ts
+++ b/tests/issue-2571-native-method-generators.test.ts
@@ -109,22 +109,22 @@ export function test(): number { return (g().next().value as number); }`;
     expect(await runNative(src)).toBe(9);
   });
 
-  it("capturing class method generator BAILS to host cleanly (valid module, no native mis-lower)", async () => {
-    // Reads `cap` captured from the enclosing function — the native state struct
-    // has no capture slot, so it must keep the host path (the module still
-    // compiles to valid Wasm; it just carries the host imports here).
+  it("capturing class method generator lowers NATIVELY in standalone (#3032 W4 — was: bail to host)", async () => {
+    // (#3032 W4) Reads `cap` captured from the enclosing function. Pre-W4 this
+    // bailed to the eager host path (this test asserted the bail); the method
+    // body resolves captures through the #2029/#3039 promotion machinery
+    // (`ctx.capturedBoxGlobals`/`capturedGlobals` module globals), which is
+    // fctx-independent — so the resume function compiles the same body with
+    // the same global reads and the standalone lane routes native: zero host
+    // imports AND the value reads back correctly (the eager path also ran the
+    // body at creation, violating §27.5.3.1-3 suspend-at-start).
     const src = `function outer(): number {
   let cap = 3;
   class C { *m() { yield cap; } }
   return (new C().m().next().value as number);
 }
 export function test(): number { return outer(); }`;
-    const { binary, genImports } = await compileNoHost(src);
-    // Host imports ARE present (intentional bail) — assert the module is still
-    // structurally valid (compile succeeded above; just confirm it has the host
-    // generator imports rather than an undefined-funcidx invalid module).
-    expect(genImports.length, "capturing method generator keeps the host path").toBeGreaterThan(0);
-    expect(WebAssembly.validate(binary), "capturing-bail module must still be valid Wasm").toBe(true);
+    expect(await runNative(src)).toBe(3);
   });
 
   it("object-literal method generator now lowers natively (#2581 lifted the #2571 deferral)", async () => {

--- a/tests/issue-2581-objlit-method-generators.test.ts
+++ b/tests/issue-2581-objlit-method-generators.test.ts
@@ -166,16 +166,18 @@ export function test(): number {
     expect(await runNative(src)).toBe(5);
   });
 
-  it("capturing object-literal method generator BAILS to host cleanly (valid module)", async () => {
+  it("capturing object-literal method generator lowers NATIVELY in standalone (#3032 W4 — was: bail to host)", async () => {
+    // (#3032 W4) Pre-W4 this asserted the eager-host bail; the method body
+    // resolves `cap` through the promotion globals (fctx-independent), so the
+    // standalone lane now routes native — zero host imports, lazy (§27.5),
+    // and the value reads back correctly.
     const src = `function outer(): number {
   let cap = 3;
   const o = { *m() { yield cap; } };
   return (o.m().next().value as number);
 }
 export function test(): number { return outer(); }`;
-    const { binary, genImports } = await compileNoHost(src);
-    expect(genImports.length, "capturing objlit method generator keeps the host path").toBeGreaterThan(0);
-    expect(WebAssembly.validate(binary), "capturing-bail module must still be valid Wasm").toBe(true);
+    expect(await runNative(src)).toBe(3);
   });
 
   it("class + free function* generators stay native (regression guard)", async () => {

--- a/tests/issue-3032-w4-method-generators.test.ts
+++ b/tests/issue-3032-w4-method-generators.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+// #3032 W4 — capturing METHOD generators (class + object-literal) lower
+// natively in the standalone lane.
+//
+// Pre-W4, `isNativeGeneratorCandidate` bailed any method generator whose body
+// captures an enclosing-function binding (`generatorCapturesOuterScope`) to
+// the eager-buffer host path — which ran the WHOLE body at generator-object
+// creation (ECMA-262 §27.5.3.1-3: EvaluateGeneratorBody/GeneratorStart
+// suspend at start-of-body; nothing runs until the first `next()`) and
+// dragged the `env::__gen_*` import family into standalone binaries.
+//
+// The key insight (verified before relaxing the gate): a method body never
+// receives captures as params — it resolves them through the #2029/#3039
+// promotion machinery (`ctx.capturedBoxGlobals`/`capturedGlobals` MODULE
+// GLOBALS), which is fctx-independent. The resume function compiles the same
+// body statements with the same global reads/writes, so no capture threading
+// was needed at all — only the standalone-lane gate term. The JS-host lane is
+// byte-identical (method generators are never candidates under a JS host —
+// the host-lane candidate block admits only FunctionDeclarations).
+
+interface RunResult {
+  value: unknown;
+  genFamilyImports: string[];
+  instantiatedHostFree: boolean;
+}
+
+async function run(source: string, opts: { standalone?: boolean } = {}): Promise<RunResult> {
+  const result = await compile(source, {
+    fileName: "test.ts",
+    ...(opts.standalone ? { target: "standalone" as const } : {}),
+  });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const mod = await WebAssembly.compile(result.binary);
+  const genFamilyImports = WebAssembly.Module.imports(mod)
+    .map((i) => `${i.module}::${i.name}`)
+    .filter((n) => /__gen|__create_generator|__get_caught_exception/.test(n));
+  let instantiatedHostFree = false;
+  if (opts.standalone) {
+    try {
+      await WebAssembly.instantiate(mod, {});
+      instantiatedHostFree = true;
+    } catch {
+      instantiatedHostFree = false;
+    }
+  }
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return { value: (instance.exports as { test: () => unknown }).test(), genFamilyImports, instantiatedHostFree };
+}
+
+describe("#3032 W4 — capturing method generators native in standalone", () => {
+  it("class method: creation runs NOTHING (§27.5), host-free, instantiates with {}", async () => {
+    const r = await run(
+      `export function test(): number {
+         let iterations = 0;
+         class C {
+           *m() { iterations += 1; yield 1; }
+         }
+         const it = new C().m();
+         return iterations * 100 + 1;
+       }`,
+      { standalone: true },
+    );
+    expect(r.genFamilyImports).toEqual([]);
+    expect(r.instantiatedHostFree).toBe(true);
+    expect(r.value).toBe(1);
+  });
+
+  it("object-literal method: lazy, host-free, instantiates with {}", async () => {
+    const r = await run(
+      `export function test(): number {
+         let iterations = 0;
+         const obj = { *m() { iterations += 1; yield 1; } };
+         const it = obj.m();
+         return iterations * 100 + 1;
+       }`,
+      { standalone: true },
+    );
+    expect(r.genFamilyImports).toEqual([]);
+    expect(r.instantiatedHostFree).toBe(true);
+    expect(r.value).toBe(1);
+  });
+
+  it("object-literal method drain: values + capture write-through (was NaN on main)", async () => {
+    const r = await run(
+      `export function test(): number {
+         let acc = 0;
+         const n = 10;
+         const obj = { *m() { acc += 1; yield n + 1; acc += 1; yield n + 2; acc += 1; } };
+         let sum = 0;
+         for (const v of obj.m()) sum += v;
+         return sum * 10 + acc; // (11+12)*10 + 3
+       }`,
+      { standalone: true },
+    );
+    expect(r.genFamilyImports).toEqual([]);
+    expect(r.value).toBe(233);
+  });
+
+  it("capture + this coexist (receiver via synthesizedThis, capture via promotion global)", async () => {
+    const r = await run(
+      `export function test(): number {
+         let bonus = 5;
+         class C {
+           x = 10;
+           *m() { yield this.x + bonus; bonus += 1; yield this.x + bonus; }
+         }
+         const c = new C();
+         let sum = 0;
+         for (const v of c.m()) sum += v; // 15 + 16
+         return sum * 10 + bonus; // 310 + 6
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(316);
+  });
+
+  it("capture + user param", async () => {
+    const r = await run(
+      `export function test(): number {
+         let base = 100;
+         class C { *m(k: number) { yield base + k; } }
+         return new C().m(7).next().value as number;
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(107);
+  });
+
+  it("static method generator with mutable capture", async () => {
+    const r = await run(
+      `export function test(): number {
+         let n = 3;
+         class C { static *m() { yield n; n += 1; yield n; } }
+         let sum = 0;
+         for (const v of C.m()) sum += v; // 3 + 4
+         return sum * 10 + n; // 70 + 4
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(74);
+  });
+
+  it("write-through visibility at each suspension", async () => {
+    const r = await run(
+      `export function test(): number {
+         let acc = 0;
+         const o = { *m() { acc += 1; yield 1; acc += 10; } };
+         const it = o.m();
+         it.next();
+         const mid = acc;        // 1 — only the pre-yield statement ran
+         it.next();              // acc += 10 → 11
+         return mid * 100 + acc; // 111
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(111);
+  });
+
+  it("next(v) two-way communication on a capturing method", async () => {
+    const r = await run(
+      `export function test(): number {
+         let base = 100;
+         class C {
+           *m(): Generator<number, void, number> {
+             const got = yield 1;
+             yield base + got;
+           }
+         }
+         const it = new C().m();
+         it.next();
+         return it.next(7).value as number;
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(107);
+  });
+
+  it("try/finally across yield with capture (the #3050 machinery on methods)", async () => {
+    const r = await run(
+      `export function test(): number {
+         let log = 0;
+         const o = { *m() { try { log += 1; yield 1; log += 10; } finally { log += 100; } } };
+         let sum = 0;
+         for (const v of o.m()) sum += v;
+         return sum * 1000 + log; // 1000 + 111
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(1111);
+  });
+
+  it("two capturing generator methods in one class", async () => {
+    const r = await run(
+      `export function test(): number {
+         let a = 1;
+         let b = 2;
+         class C { *m1() { yield a; } *m2() { yield b; } }
+         const c = new C();
+         return (c.m1().next().value as number) * 10 + (c.m2().next().value as number);
+       }`,
+      { standalone: true },
+    );
+    expect(r.value).toBe(12);
+  });
+
+  // Host-lane control: method generators are never native candidates under a
+  // JS host (the host-lane candidate block admits only FunctionDeclarations),
+  // so the eager path is byte-identical — this pins the drain behavior.
+  it("host lane: capturing method drain unchanged (control)", async () => {
+    const r = await run(
+      `export function test(): number {
+         let acc = 0;
+         const n = 10;
+         const obj = { *m() { acc += 1; yield n + 1; acc += 1; yield n + 2; acc += 1; } };
+         let sum = 0;
+         for (const v of obj.m()) sum += v;
+         return sum * 10 + acc;
+       }`,
+      {},
+    );
+    expect(r.value).toBe(233);
+  });
+});


### PR DESCRIPTION
## Summary

W4 of #3032 — capturing METHOD generators (class + object-literal). Pre-W4, `isNativeGeneratorCandidate` bailed any method generator whose body captures an enclosing-function binding to the eager-buffer host path, which ran the WHOLE body at generator-object creation (**ECMA-262 §27.5.3.1-3**: EvaluateGeneratorBody/GeneratorStart suspend at start-of-body) and leaked the `env::__gen_*` import family into standalone binaries (validate-but-can't-instantiate host-free). The object-literal gen-meth for-of drain was outright broken in standalone (NaN).

## The change (one gate term)

The banked W4 plan anticipated a body-splitting wrap of the class-bodies eager arm. Probing first showed the standalone lane needs **no wrap and no capture threading at all**: a method body never receives captures as params — it resolves them through the #2029/#3039/#3121 promotion machinery (`ctx.capturedBoxGlobals`/`capturedGlobals` **module globals**), which is fctx-independent. So the resume function compiles the same body statements with the same global reads/writes, and the existing #2571 native method machinery (synthesizedThis + state struct) works unchanged for capturing methods.

- `isNativeGeneratorCandidate`: the method-bail's `generatorCapturesOuterScope` term is now host-lane-only (`!noJsHostTarget(ctx) && ...`). The `arguments`/`super` bails stay.
- Promotion ordering holds: capturing classes/literals compile DEFERRED in standalone until captures initialize (#3123), so the globals exist before the resume fn emits.
- **JS-host lane byte-identical**: method generators are never native candidates under a JS host (the host-lane candidate block admits only FunctionDeclarations), so its eager path is untouched.

## Validation

- Probes (standalone, branch vs main): class/objlit method with `let` capture 101→**1** (lazy), 4→**0** `__gen_*` imports, `instantiate({})` FAIL→**OK**; objlit for-of drain **NaN→233** (capture write-through); capture+`this` 316; capture+param 107; static 74; `next(7)`→107 two-way; try/finally+capture 1111; two capturing methods 12.
- `tests/issue-3032-w4-method-generators.test.ts` — 11/11 (incl. zero-import + `instantiate({})` assertions and a host-lane control).
- Method-generator suites (2571/2581/2938/2641/generator-methods/generator-method-destructuring/3050): 57/57. The two #2571/#2581 tests that pinned the old capture-bail now assert the native lowering (updated with rationale).
- **gen-meth dstr family A/B — 930 files (all non-async `gen-meth-*` under class/dstr + object/dstr + expressions/class/dstr), standalone, branch vs current main: exactly ZERO flips either direction** (117 fail / 813 pass identical). The family's pass rate is shim-neutral (the test262 runner supplies `__gen_*` shims); W4's win is the host-free-instantiate leak metric + §27.5 laziness — with no regressions.
- `tsc --noEmit`, eslint, prettier, LOC-budget (covered by the issue file's existing allowance) green.
- **merge_group standalone-floor is the decider** per the issue — native-generator admission change; scoped-green is provisional.

Known same-wrong-different-mode (documented in the issue): a promotion-timing shape (class compiled before a captured `const` initializes) silently read NaN on main; the native path now throws a loud TDZ ReferenceError at first resume in standalone. Neither matches spec — pre-existing #3123-lineage limitation, not introduced here.

Issue #3032 stays open (W2 measure-first, W5, W6 banked; note updated). The A1/tag-5-vacuity unblock is now fully delivered on the standalone side by W3 + #3302 + W4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)