### PR TITLE
fix(#3306): StringToNumber the toString-only object ToNumber result in standalone (was drop+NaN)

### DIFF
--- a/plan/issues/3306-standalone-tostring-only-tonumber.md
+++ b/plan/issues/3306-standalone-tostring-only-tonumber.md
@@ -1,0 +1,90 @@
+---
+id: 3306
+title: "standalone: ToNumber of a toString-only object drops the native-string result to NaN (§7.1.1.1 OrdinaryToPrimitive → §7.1.4.1 StringToNumber)"
+status: in-progress
+assignee: ttraenkler/sendev-date-3174
+created: 2026-07-16
+updated: 2026-07-16
+priority: high
+feasibility: medium
+model: fable
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: coercion
+goal: standalone
+umbrella: 2860
+sprint: current
+horizon: s
+related: [3174, 3304, 2891, 866, 1806]
+origin: "root-caused during #3174 residual analysis (Date ctor coercion-order rows); carried through #3304 as the next-next candidate"
+loc-budget-allow:
+  - src/codegen/type-coercion.ts
+coercion-sites-allow:
+  # __str_to_number +2 — NOT a fresh hand-rolled matrix: routes the toString
+  # closure result through the EXISTING StringToNumber scanner (the same
+  # helper the direct string→f64 arm uses), replacing a spec-violating
+  # drop+NaN.
+  - src/codegen/type-coercion.ts
+---
+
+# #3306 — standalone: toString-only object ToNumber → NaN
+
+## Problem
+
+Under `--target standalone` (nativeStrings), ToNumber of an object whose only
+ToPrimitive method is `toString` runs the method but throws away its string
+result:
+
+```ts
+var arg = { toString: function() { return "7"; } };
++arg;                      // NaN (should be 7)
+Number(arg);               // NaN (should be 7)
+new Date(0).setTime(arg);  // NaN (should be 7-ish ms)
+```
+
+`{ valueOf }` and `{ valueOf-returns-object + toString }` (#2891's
+fallthrough) both work — only the **no-valueOf** shape fails.
+
+## Root cause (WAT-verified 2026-07-16)
+
+`tryToStringFallback` (type-coercion.ts, #866) DOES find and `call_ref` the
+`toString` closure — but every one of its three result-conversion sites treats
+a `ref`/`ref_null`-kind return as "object → drop + NaN":
+
+- the eqref-field inline converter (the arm object literals actually hit —
+  emitted `call_ref 44; drop; f64.const NaN`),
+- `emitToStringResultToF64` (closure-ref field arm),
+- `emitToStringResultToF64ByKind` (`${name}_toString` funcMap arm).
+
+Under nativeStrings a `toString(){ return "7" }` closure returns a **native
+string struct** (`ref $NativeString` / `ref $AnyString` subtype) — a ref kind.
+Per §7.1.1.1 OrdinaryToPrimitive + §7.1.4 ToNumber, a String primitive result
+must convert via StringToNumber (§7.1.4.1) — the `__str_to_number` scanner the
+direct string→f64 arm (type-coercion.ts ~2277) already uses.
+
+The externref arm (host-string returns) already unboxes correctly; only the
+ref-kind (native-string) returns were dropped.
+
+## Fix
+
+One shared `refResultStringToF64Instrs` helper: runtime `ref.test $AnyString`
+on the ref-kind result → hit: `extern.convert_any` + `__str_to_number`; miss
+(genuine object return): keep the existing NaN. Wired into all three
+converter sites. Runtime-tested (not static-typeIdx-matched) so loosely-typed
+closure returns (eqref/anyref) convert too.
+
+## Out of scope (follow-ups)
+
+- `any`-typed receiver (`var arg: any = { toString... }; +arg`) traps
+  `illegal cast` — a different path (`__to_primitive`'s $Object toString
+  dispatch / funcref RTT class, cf. #2873). Not touched here.
+- Spec-exact TypeError when BOTH valueOf/toString return non-primitives
+  (currently NaN on the toString-only path) — pre-existing, unchanged.
+
+## Acceptance criteria
+
+- `+{toString(){return "7"}}` === 7; `Number(...)` and Date setter args
+  likewise, host-free standalone.
+- `{valueOf}` / fallthrough shapes byte-equivalent (no regression).
+- Zero host-mode changes; zero standalone high-water regressions.

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -2838,6 +2838,25 @@ function tryToStringFallback(
                       instrs.push({ op: "drop" });
                       instrs.push({ op: "f64.const", value: NaN });
                     }
+                  } else if (
+                    info.returnType &&
+                    (info.returnType.kind === "ref" ||
+                      info.returnType.kind === "ref_null" ||
+                      info.returnType.kind === "anyref" ||
+                      info.returnType.kind === "eqref")
+                  ) {
+                    // (#3306) ref-kind result — under nativeStrings this is the
+                    // native string `toString` returned; StringToNumber it
+                    // (§7.1.4.1). This is the arm object-literal `{toString}`
+                    // shapes actually hit (eqref-typed field): the old
+                    // drop+NaN ran the method and threw away "7".
+                    const strInstrs = refResultStringToF64Instrs(ctx, fctx);
+                    if (strInstrs !== null) {
+                      instrs.push(...strInstrs);
+                    } else {
+                      instrs.push({ op: "drop" });
+                      instrs.push({ op: "f64.const", value: NaN });
+                    }
                   } else if (!info.returnType || info.returnType.kind !== "f64") {
                     if (info.returnType) instrs.push({ op: "drop" });
                     instrs.push({ op: "f64.const", value: NaN });
@@ -3173,10 +3192,63 @@ function emitToStringResultToF64(
       fctx.body.push({ op: "f64.const", value: NaN });
     }
   } else {
-    // ref or other — drop and push NaN
-    fctx.body.push({ op: "drop" });
-    fctx.body.push({ op: "f64.const", value: NaN });
+    // (#3306) ref-kind result: under nativeStrings a `toString(){return "7"}`
+    // closure returns the NATIVE string struct — StringToNumber it. Genuine
+    // object returns keep the legacy NaN.
+    const strInstrs = refResultStringToF64Instrs(ctx, fctx);
+    if (strInstrs !== null) {
+      fctx.body.push(...strInstrs);
+    } else {
+      // ref or other — drop and push NaN
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "f64.const", value: NaN });
+    }
   }
+}
+
+/**
+ * (#3306 — the #3174 "toString-only object → NaN" residual) Instruction
+ * sequence converting a REF-kind ToPrimitive-method result that may be a
+ * native string into f64 per §7.1.4 ToNumber step "If argument is a String,
+ * return StringToNumber(argument)".
+ *
+ * Every `tryToStringFallback` result-converter treated a `ref`/`ref_null`
+ * return as "object → drop + NaN" — but under nativeStrings that is exactly
+ * what `toString(){ return "…" }` returns (a `ref $NativeString`/`$AnyString`
+ * subtype), so `+{toString(){return "7"}}` executed toString and then dropped
+ * the "7" (NaN). The test is a RUNTIME `ref.test $AnyString` (not a static
+ * typeIdx match) so loosely-typed closure returns (eqref/anyref carriers)
+ * convert too; a genuine object return misses the test and keeps the legacy
+ * NaN (the spec's both-non-primitive TypeError remains a follow-up, unchanged
+ * by this fix).
+ *
+ * Expects the ref-kind result on the stack; the sequence leaves an f64.
+ * Returns `null` when native strings / `__str_to_number` are unavailable
+ * (host lane — externref strings never reach the ref arm) so callers keep
+ * their legacy drop+NaN byte-identically.
+ */
+function refResultStringToF64Instrs(ctx: CodegenContext, fctx: FunctionContext): Instr[] | null {
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return null;
+  let strToNumberIdx = ctx.funcMap.get("__str_to_number");
+  if (strToNumberIdx === undefined) {
+    addUnionImports(ctx);
+    strToNumberIdx = ctx.funcMap.get("__str_to_number");
+  }
+  if (strToNumberIdx === undefined) return null;
+  const tmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
+  const instrs: Instr[] = [
+    { op: "local.set", index: tmp },
+    { op: "local.get", index: tmp },
+    { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } },
+      then: [{ op: "local.get", index: tmp }, { op: "extern.convert_any" }, { op: "call", funcIdx: strToNumberIdx }],
+      else: [{ op: "f64.const", value: NaN }],
+    },
+  ];
+  releaseTempLocal(fctx, tmp);
+  return instrs;
 }
 
 /**
@@ -3192,6 +3264,15 @@ function emitToStringResultToF64ByKind(ctx: CodegenContext, fctx: FunctionContex
     const unboxIdx = ctx.funcMap.get("__unbox_number");
     if (unboxIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: unboxIdx });
+    } else {
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "f64.const", value: NaN });
+    }
+  } else if (retKind === "ref" || retKind === "ref_null" || retKind === "anyref" || retKind === "eqref") {
+    // (#3306) ref-kind result — may be a native string; StringToNumber it.
+    const strInstrs = refResultStringToF64Instrs(ctx, fctx);
+    if (strInstrs !== null) {
+      fctx.body.push(...strInstrs);
     } else {
       fctx.body.push({ op: "drop" });
       fctx.body.push({ op: "f64.const", value: NaN });

--- a/tests/issue-3306.test.ts
+++ b/tests/issue-3306.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3306 — standalone ToNumber of a toString-only object (§7.1.1.1
+ * OrdinaryToPrimitive → §7.1.4.1 StringToNumber).
+ *
+ * `tryToStringFallback` (type-coercion.ts) found and invoked the `toString`
+ * closure but every result converter treated a `ref`-kind return as
+ * "object → drop + NaN" — under nativeStrings that is exactly the NATIVE
+ * string struct `toString(){ return "7" }` returns, so `+obj` executed the
+ * method and threw away the "7". Fixed by the shared
+ * `refResultStringToF64Instrs` (runtime `ref.test $AnyString` →
+ * `__str_to_number`; genuine object returns keep NaN), wired into all three
+ * converter sites. Host lane byte-identical (strings are externref there and
+ * already unboxed).
+ */
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envImports = (r.imports ?? []).filter((i) => i.module === "env").map((i) => i.name);
+  expect(envImports, "must stay host-free").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports.test as () => unknown)();
+}
+
+describe("#3306 — toString-only object ToNumber (standalone)", () => {
+  it("+{toString(){return '7'}} === 7 (unary plus)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var arg = { toString: function() { return "7"; } }; return +arg; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("Number(toString-only object) converts via StringToNumber", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var arg = { toString: function() { return "  12.5 "; } }; return Number(arg); }`,
+      ),
+    ).toBe(12.5);
+  });
+
+  it("toString returning a non-numeric string yields NaN", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var arg = { toString: function() { return "abc"; } }; var n = +arg; return n !== n ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("toString returning a NUMBER passes through", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var arg = { toString: function() { return 5; } }; return +arg; }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("Date.prototype.setTime coerces a toString-only argument", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var d = new Date(0); var arg = { toString: function() { return "5"; } }; return d.setTime(arg); }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("valueOf still wins over toString for hint number (§7.1.1.1 order)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var arg = { valueOf: function() { return 3; }, toString: function() { return "9"; } }; return +arg; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("valueOf-returns-object → toString fallthrough (#2891) unchanged", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { var arg = { valueOf: function() { return {}; }, toString: function() { return "7"; } }; return +arg; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("new Date(y, m) with toString-only args runs coercion in order", async () => {
+    expect(
+      await runStandalone(`
+var log = "";
+export function test(): number {
+  var year = { toString: function() { log += "year"; return 1970; } };
+  var month = { toString: function() { log += "month"; return 0; } };
+  var d = new Date(year, month);
+  return log === "yearmonth" && d.getFullYear() === 1970 ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes plan issue #3306 (umbrella #2860; the toString-only-object ToNumber gap root-caused during #3174's residual analysis and carried through #3304).

## What

Under `--target standalone`, ToNumber of an object whose only ToPrimitive method is `toString` ran the method and threw its result away:

```ts
+{ toString(){ return "7" } }          // NaN (should be 7)
Number({ toString(){ return "12.5" }}) // NaN
new Date(0).setTime({ toString(){ return "5" }}) // NaN
```

`{valueOf}` and the #2891 valueOf-returns-object→toString fallthrough both worked — only the **no-valueOf** shape failed.

## Root cause (WAT-verified)

`tryToStringFallback` (type-coercion.ts, #866) correctly finds and `call_ref`s the `toString` closure — but all three of its result converters treated a `ref`-kind return as "object → drop + NaN" (emitted `call_ref; drop; f64.const NaN`). Under nativeStrings, a `toString(){ return "7" }` closure returns the **native string struct** (`ref $NativeString`/`$AnyString` subtype) — a ref kind. §7.1.1.1 OrdinaryToPrimitive + §7.1.4 ToNumber require the String result to convert via StringToNumber (§7.1.4.1).

## Fix

One shared `refResultStringToF64Instrs` helper: runtime `ref.test $AnyString` on the ref-kind result → hit: `extern.convert_any` + the **existing** `__str_to_number` scanner (the same helper the direct string→f64 arm uses — no fresh coercion matrix); miss (genuine object return): legacy NaN unchanged. Wired into `emitToStringResultToF64`, `emitToStringResultToF64ByKind`, and the eqref-field inline arm (the shape object literals actually hit). The runtime test (not a static typeIdx match) also converts loosely-typed (eqref/anyref) closure returns. Host lane byte-identical — strings there are externref and were already unboxed.

Gate allowances in the issue frontmatter: `coercion-sites-allow` (`__str_to_number` +2 — routing through the existing scanner, replacing a spec-violating drop) and `loc-budget-allow` for type-coercion.ts.

## Measured

- `built-ins/Number` sweep (338): +1 (`S9.3_A5_T1.js`), zero regressions.
- `built-ins/Date` sweep (594): zero regressions (the ctor `coercion-errors` rows already banked from #3174's NaN fix).
- Adjacent coercion suites (`issue-1806*`, `issue-1917`, `issue-2163`, `issue-2358*`, `issue-2598-2599`): 67/67 green.
- The measured test262 delta is small, but the semantic class (`+obj` / `Number(obj)` / setter args / ctor args with toString-only objects) is pervasive in user code.

## Follow-up (documented in the issue, out of scope)

- Fn-scoped **capturing** `toString` closures (`var log=''; { toString(){ log+='x'; return 0 } }` inside a function body) trap `dereferencing a null pointer` in the closure-dispatch guard — the funcref sig-test misses (the #2873 wrapper-chain RTT class) and the guard's `ref.null` + `ref.as_non_null` traps instead of degrading. This blocks `Date/coercion-order.js` / `UTC/coercion-order.js` and needs the closure-ABI treatment (cast to wrapper root + funcref sig-dispatch), not a local patch.
- `any`-typed receivers (`+ (arg: any)`) trap on a different path (`__to_primitive` $Object dispatch) — also noted.

## Tests

`tests/issue-3306.test.ts` — 8 standalone host-free tests: unary plus / `Number()` / Date-setter arg / non-numeric string → NaN / number-returning toString passthrough / §7.1.1.1 valueOf-first order / #2891 fallthrough non-regression / `new Date(y, m)` coercion order.