### PR TITLE
feat(#3177): standalone TA proto identity + without-new TypeError + isExtensible (slice 3)

### DIFF
--- a/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
+++ b/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
@@ -32,10 +32,17 @@ origin: "PO groom of #2860 umbrella, 2026-07-12 lane-baseline diff; the 'TypedAr
 # index.ts: +6 — one import + the fillTaDynViewMopArms(ctx) call, which MUST
 # sit in the barrel's finalize sequence (ordering vs the other fills is
 # load-bearing); the implementation itself is in the new module.
+# (slice 3, calls.ts +29): the §23.2.5.1-step-1 without-`new` TypeError arm
+# must live INSIDE tryEmitInlineDynamicCall's dynamic-callee dispatch chain
+# (it is one `ref.test $__ta_ctor` arm prepended to the same chain the
+# proxy/bound-fn arms extend — extracting the chain builder to a module is
+# the #3182 consolidation epic's call, not this slice's); the proto/
+# isExtensible arms themselves live in ta-dyn-mop.ts.
 loc-budget-allow:
   - src/codegen/dataview-native.ts
   - src/codegen/property-access-dispatch.ts
   - src/codegen/index.ts
+  - src/codegen/expressions/calls.ts
 # coercion-sites-allow: the NEW module's 4 uses (number_toString ×2,
 # __str_to_number, __unbox_number) are the exact §7.1.21
 # CanonicalNumericIndexString round-trip + the finalize-safe ToNumber the
@@ -243,6 +250,57 @@ the upgraded static-windowed RangeError path.
   `emitTaViewConstructWindowed` has alignment/bounds but no detached check;
   static count `new Int8Array(-1)` ToIndex asymmetry) — low corpus value,
   the harness always constructs through dynamic ctor values.
+
+### Slice 3 — proto identity + without-new + isExtensible (PR: issue-3177-slice3-proto-identity, 2026-07-16, fable-3177)
+
+Directory sweep (411 non-bigint files, standalone): 134 → **154 pass (+20),
+0 regressions** (every diff line fail→pass vs the slice-2 result).
+
+What landed:
+
+- **`Object.getPrototypeOf(view) === TA.prototype` identity**
+  (ta-dyn-mop.ts): the per-kind proto object IS the per-view-brand
+  `$NativeProto` glue SINGLETON that a static `<View>.prototype` value read
+  already yields (`emitLazyNativeProtoGet` global, #2651/#2901 lineage) — no
+  new object shape. The fill registers the glue for all 9 kinds
+  (`ensureTypedArrayViewNativeProtoGlue`, idempotent; shared memberCsv) and
+  prepends: (a) a `__getPrototypeOf` dyn-view arm (runtime kind → glue
+  global, lazy-init inline), (b) an `__extern_get` `$__ta_ctor` receiver arm
+  serving `prototype` (same switch — identity closes) and
+  `BYTES_PER_ELEMENT`; other keys fall through to the original body.
+- **`TA(1)` without `new` → TypeError** (§23.2.5.1 step 1,
+  calls.ts `tryEmitInlineDynamicCall`): an outermost `ref.test $__ta_ctor`
+  arm in the dynamic-callee dispatch throws a real TypeError instance;
+  gated on `ctx.taCtorTypeIdx >= 0` (byte-inert without TA ctor values) and
+  added to the empty-candidates early-outs so it fires even in closure-free
+  modules. Flipped all 7 undefined-newtarget/invoked-with-undefined-newtarget
+  rows (incl. one `-sab` — the call throws before any SAB cast).
+- **`Object.isExtensible(view)` → true** (`__object_isExtensible` dyn-view
+  arm) — flipped all 5 new-instance-extensibility rows.
+
+Flipped (20): defined-length(+-and-offset)/defined-offset,
+returns-new-instance, returns-object ×2, as-array-returns,
+same-ctor-returns-new-cloned-typedarray, new-instance-extensibility ×5,
+undefined-newtarget-throws ×4, invoked-with-undefined-newtarget ×2 (+sab),
+object-arg/length-throws (collateral of the ctor-receiver [[Get]] arm).
+
+Verified: tests/issue-3177.test.ts 45/45 (11 new — incl. plain-object
+getPrototypeOf/isExtensible/closure-dispatch fall-through guards); scoped
+suites 2186/2190/2872/3006/3054\*/3057/3058/3133 all green (197 tests).
+
+Known residuals (documented, low corpus value):
+
+- The `__extern_get` ctor arm lives inside the dyn-view-gated fill, so a
+  module that mentions a TA ctor but never CONSTRUCTS a view gets no
+  `TA.prototype`/`BYTES_PER_ELEMENT` runtime read (corpus always
+  constructs).
+- `getProto(ta).constructor` chained-dyn reads land on the glue struct
+  (whose `$ctor` field is null, #2651 S1) → undefined; the corpus asserts
+  `ta.constructor` (slice 1) and `<TA>.prototype.constructor` (static arm)
+  instead.
+- Statically-typed receivers (`getPrototypeOf(new Uint8Array(4))` with a
+  B1 `$__ta_view` rep) don't reach the dyn-view arm — harness shapes are
+  all any-typed.
 
 ### Remaining (next slices — release+reclaim per phase)
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3549,7 +3549,14 @@ export function tryEmitInlineDynamicCall(
   const wantBoundArm =
     (ctx.standalone === true || ctx.wasi === true) &&
     (ctx.boundFnTypeIdx >= 0 || sourceHasBindCall(expr.getSourceFile()));
-  if (allCandidates.length === 0 && !wantProxyArm && !wantBoundArm) return null;
+  // (#3177 slice 3) §23.2.5.1 step 1: CALLING a TypedArray-constructor VALUE
+  // without `new` (undefined NewTarget) must throw TypeError — `TA(1)` inside
+  // `assert.throws(TypeError, …)` is the undefined-newtarget-throws corpus
+  // shape. Armed only when a `$__ta_ctor` value can exist in the module
+  // (byte-inert otherwise). Standalone/WASI lane; the host lane's callee is a
+  // real host constructor whose [[Call]] already throws.
+  const wantTaCtorArm = (ctx.standalone === true || ctx.wasi === true) && ctx.taCtorTypeIdx >= 0;
+  if (allCandidates.length === 0 && !wantProxyArm && !wantBoundArm && !wantTaCtorArm) return null;
 
   // Dedupe by funcTypeIdx — concrete subtypes share funcTypeIdx with their
   // base wrapper; one dispatch arm per unique funcref type is enough.
@@ -3665,7 +3672,7 @@ export function tryEmitInlineDynamicCall(
       vecPushIdx: vecBuilders.pushIdx,
     };
   }
-  if (candidates.length === 0 && proxyArm === undefined && boundArm === undefined) return null;
+  if (candidates.length === 0 && proxyArm === undefined && boundArm === undefined && !wantTaCtorArm) return null;
 
   // Compile callee (externref) → anyref → temp local.
   const calleeType = compileExpression(ctx, fctx, expr.expression);
@@ -3866,6 +3873,28 @@ export function tryEmitInlineDynamicCall(
         op: "if",
         blockType: { kind: "val", type: { kind: "externref" } },
         then: armBody,
+        else: dispatch,
+      },
+    ];
+  }
+
+  // (#3177 slice 3) `$__ta_ctor` [[Call]] arm — outermost: a TypedArray
+  // constructor value invoked WITHOUT `new` throws TypeError (§23.2.5.1
+  // step 1, undefined NewTarget). Built here (immediately before the dispatch
+  // is attached) so the baked `__new_TypeError` funcIdx cannot go stale: on
+  // this lane the constructor is an in-module DEFINED function (append-only,
+  // no import shift) and `buildThrowJsErrorInstrs` self-flushes against fctx.
+  if (wantTaCtorArm) {
+    const throwInstrs = buildThrowJsErrorInstrs(ctx, "TypeError", "Constructor cannot be invoked without 'new'", {
+      flush: fctx,
+    });
+    dispatch = [
+      { op: "local.get", index: anyLocal },
+      { op: "ref.test", typeIdx: ctx.taCtorTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: throwInstrs, // terminal throw — stack-polymorphic, validates as externref
         else: dispatch,
       },
     ];

--- a/src/codegen/ta-dyn-mop.ts
+++ b/src/codegen/ta-dyn-mop.ts
@@ -47,10 +47,14 @@ import {
   pushElemSizeForKind,
   pushTaDynViewInBoundsLen,
 } from "./dataview-native.js";
-import { addFuncType } from "./registry/types.js";
+import { addFuncType, TA_CTOR_KINDS } from "./registry/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
 import { nativeStringLiteralInstrs } from "./native-strings.js";
+// (#3177 slice 3) per-kind `<View>.prototype` identity — the SAME $NativeProto
+// glue singleton a static `<View>.prototype` value read yields.
+import { ensureTypedArrayViewNativeProtoGlue } from "./array-object-proto.js";
+import { emitLazyNativeProtoGet } from "./native-proto.js";
 
 /** Fresh synthetic FunctionContext for a native helper (the #2872 pattern). */
 function makeFctx(name: string, params: { name: string; type: ValType }[], returnType: ValType): FunctionContext {
@@ -721,6 +725,163 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
       { op: "any.convert_extern" },
       { op: "local.tee", index: kAny },
       { op: "ref.test", typeIdx: dynIdx },
+      { op: "if", blockType: { kind: "empty" }, then: inner },
+    );
+  }
+
+  // ── (#3177 slice 3) Proto-identity + isExtensible arms ────────────────────
+  //
+  // `Object.getPrototypeOf(view) === TA.prototype` (ctors/*/defined-length,
+  // returns-new-instance, returns-object, …) needs BOTH sides to resolve to
+  // the per-kind `$NativeProto` glue SINGLETON — the same object a static
+  // `<View>.prototype` value read yields (one lazily-initialized global per
+  // view brand, `emitLazyNativeProtoGet`). Register the glue for every kind
+  // up front (idempotent; the memberCsv string is shared across kinds), then
+  // switch on the runtime `kind`.
+  const protoKinds: { kind: number; brand: number }[] = [];
+  for (let k = 0; k < TA_CTOR_KINDS.length; k++) {
+    const brand = ensureTypedArrayViewNativeProtoGlue(ctx, TA_CTOR_KINDS[k]!);
+    if (brand !== undefined) protoKinds.push({ kind: k, brand });
+  }
+  // kind (i32 local) → push the glue externref → return. Emitted via a body
+  // swap on `fctxLike` because emitLazyNativeProtoGet pushes onto fctx.body.
+  const pushKindToProtoSwitch = (fctxLike: FunctionContext, kindLocal: number): void => {
+    for (const { kind: k, brand } of protoKinds) {
+      const armThen: Instr[] = [];
+      const saved = fctxLike.body;
+      fctxLike.body = armThen;
+      const ok = emitLazyNativeProtoGet(ctx, fctxLike, brand);
+      fctxLike.body = saved;
+      if (!ok) continue;
+      armThen.push({ op: "return" });
+      fctxLike.body.push({ op: "local.get", index: kindLocal });
+      fctxLike.body.push({ op: "i32.const", value: k });
+      fctxLike.body.push({ op: "i32.eq" });
+      fctxLike.body.push({ op: "if", blockType: { kind: "empty" }, then: armThen });
+    }
+  };
+
+  // __getPrototypeOf(externref) -> externref: dyn-view receiver → per-kind
+  // `<View>.prototype` glue (§10.4.5 views are ordinary here — their
+  // [[Prototype]] IS the intrinsic per-kind prototype).
+  const getProtoFn = findFn("__getPrototypeOf");
+  if (getProtoFn && protoKinds.length > 0) {
+    const base = 1 + getProtoFn.locals.length;
+    const pAny = base;
+    const pKind = base + 1;
+    getProtoFn.locals.push(
+      { name: "__tap_any", type: { kind: "anyref" } },
+      { name: "__tap_kind", type: { kind: "i32" } },
+    );
+    const inner: Instr[] = [];
+    const fctxLike = {
+      body: inner,
+      locals: getProtoFn.locals,
+      params: [{ name: "p", type: { kind: "externref" } }],
+      localMap: new Map(),
+    } as unknown as FunctionContext;
+    inner.push({ op: "local.get", index: pAny });
+    inner.push({ op: "ref.cast", typeIdx: dynIdx });
+    inner.push({ op: "struct.get", typeIdx: dynIdx, fieldIdx: 3 });
+    inner.push({ op: "local.set", index: pKind });
+    pushKindToProtoSwitch(fctxLike, pKind);
+    inner.push({ op: "ref.null.extern" });
+    inner.push({ op: "return" });
+    getProtoFn.body.unshift(
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: pAny },
+      { op: "ref.test", typeIdx: dynIdx },
+      { op: "if", blockType: { kind: "empty" }, then: inner },
+    );
+  }
+
+  // __object_isExtensible(externref) -> i32: a live view IS extensible
+  // (§10.4.5 views are ordinary wrt [[IsExtensible]]; no preventExtensions
+  // state exists on `$__ta_dyn_view` yet — the expando slice owns that).
+  const isExtFn = findFn("__object_isExtensible");
+  if (isExtFn) {
+    isExtFn.body.unshift(
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: dynIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+      },
+    );
+  }
+
+  // __extern_get $__ta_ctor receiver arm: `TA.prototype` (→ the SAME per-kind
+  // glue as getPrototypeOf above, closing the identity) and
+  // `TA.BYTES_PER_ELEMENT`. Other keys fall through to the original body
+  // (current behavior: undefined). Only when a `$__ta_ctor` value can exist.
+  if (getFn && ctx.taCtorTypeIdx >= 0 && protoKinds.length > 0) {
+    const ctorIdx = ctx.taCtorTypeIdx;
+    const base = 2 + getFn.locals.length;
+    const cAny = base;
+    const cKind = base + 1;
+    const cKey = base + 2;
+    getFn.locals.push(
+      { name: "__tac_any", type: { kind: "anyref" } },
+      { name: "__tac_kind", type: { kind: "i32" } },
+      { name: "__tac_key", type: { kind: "externref" } },
+    );
+    const inner: Instr[] = [];
+    const fctxLike = {
+      body: inner,
+      locals: getFn.locals,
+      params: [
+        { name: "p0", type: { kind: "externref" } },
+        { name: "p1", type: { kind: "externref" } },
+      ],
+      localMap: new Map(),
+    } as unknown as FunctionContext;
+    inner.push({ op: "local.get", index: cAny });
+    inner.push({ op: "ref.cast", typeIdx: ctorIdx });
+    inner.push({ op: "struct.get", typeIdx: ctorIdx, fieldIdx: 0 });
+    inner.push({ op: "local.set", index: cKind });
+    inner.push({ op: "local.get", index: 1 });
+    inner.push({ op: "call", funcIdx: tpkIdx });
+    inner.push({ op: "local.set", index: cKey });
+    const strKeyed: Instr[] = [];
+    const savedInner = fctxLike.body;
+    fctxLike.body = strKeyed;
+    strKeyed.push(...keyIs(cKey, "prototype"));
+    {
+      const protoThen: Instr[] = [];
+      const saved2 = fctxLike.body;
+      fctxLike.body = protoThen;
+      pushKindToProtoSwitch(fctxLike, cKind);
+      fctxLike.body = saved2;
+      protoThen.push(...undef());
+      protoThen.push({ op: "return" });
+      strKeyed.push({ op: "if", blockType: { kind: "empty" }, then: protoThen });
+    }
+    strKeyed.push(...keyIs(cKey, "BYTES_PER_ELEMENT"));
+    {
+      const bpeThen: Instr[] = [];
+      const saved2 = fctxLike.body;
+      fctxLike.body = bpeThen;
+      pushElemSizeForKind(fctxLike, cKind);
+      fctxLike.body = saved2;
+      bpeThen.push({ op: "f64.convert_i32_s" });
+      bpeThen.push({ op: "call", funcIdx: boxNumIdx });
+      bpeThen.push({ op: "return" });
+      strKeyed.push({ op: "if", blockType: { kind: "empty" }, then: bpeThen });
+    }
+    fctxLike.body = savedInner;
+    // Only string keys take the fast checks; anything else falls through.
+    inner.push({ op: "local.get", index: cKey });
+    inner.push({ op: "any.convert_extern" });
+    inner.push({ op: "ref.test", typeIdx: anyStrTypeIdx });
+    inner.push({ op: "if", blockType: { kind: "empty" }, then: strKeyed });
+    getFn.body.unshift(
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: cAny },
+      { op: "ref.test", typeIdx: ctorIdx },
       { op: "if", blockType: { kind: "empty" }, then: inner },
     );
   }

--- a/tests/issue-3177.test.ts
+++ b/tests/issue-3177.test.ts
@@ -250,6 +250,82 @@ describe("#3177 slice 2 — §23.2.5.1 ctor-arg protocol throws (buffer/length a
   });
 });
 
+describe("#3177 slice 3 — proto identity, without-new TypeError, isExtensible", () => {
+  it("Object.getPrototypeOf(dynview) === TA.prototype (static read) — THE identity", async () => {
+    expect(
+      await run(
+        `const p: any = Object.getPrototypeOf(s); const sp: any = Uint8Array.prototype; return p === sp ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Object.getPrototypeOf(dynview) === Reflect.get(TA, 'prototype') (runtime read)", async () => {
+    expect(
+      await run(
+        `const p: any = Object.getPrototypeOf(s); const q: any = Reflect.get(TA, "prototype"); return p === q ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("cross-kind protos stay distinct: getProto(new Uint16Array) !== Uint8Array.prototype", async () => {
+    expect(
+      await run(
+        `const T16: any = Uint16Array; const t: any = new T16(4); const sp: any = Uint8Array.prototype; return Object.getPrototypeOf(t) === sp ? 0 : 1;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("TA(1) without new → TypeError instance (§23.2.5.1 step 1)", async () => {
+    expect(await run(`try { TA(1); return 0; } catch (e) { return (e as any) instanceof TypeError ? 1 : 2; }`)).toBe(1);
+  });
+
+  it("without-new throw fires inside a closure (the assert.throws harness shape)", async () => {
+    expect(
+      await run(
+        `const f = function(): number { try { TA(1); return 0; } catch (e) { return (e as any) instanceof TypeError ? 1 : 2; } }; return f();`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Object.isExtensible(dynview) → true", async () => {
+    expect(await run(`return Object.isExtensible(s) ? 1 : 0;`)).toBe(1);
+  });
+
+  it("TA.BYTES_PER_ELEMENT via runtime [[Get]] (construct present in module)", async () => {
+    expect(
+      await run(
+        `const T16: any = Uint16Array; const b: any = Reflect.get(T16, "BYTES_PER_ELEMENT"); return b === 2 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("guard: getPrototypeOf on a plain object keeps the $proto walk", async () => {
+    expect(
+      await run(
+        `const base: any = { x: 1 }; const o: any = Object.create(base); return Object.getPrototypeOf(o) === base ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("guard: isExtensible on a plain object stays true / false after preventExtensions", async () => {
+    expect(
+      await run(
+        `const o: any = {}; const a = Object.isExtensible(o); Object.preventExtensions(o); const b = Object.isExtensible(o); return (a && !b) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("guard: unknown key on a TA-ctor receiver falls through to undefined", async () => {
+    expect(await run(`const v: any = Reflect.get(TA, "someUnknownKey"); return v === undefined ? 1 : 0;`)).toBe(1);
+  });
+
+  it("guard: a non-ctor dynamic callee still dispatches (closures unaffected)", async () => {
+    expect(await run(`const f: any = (x: number): number => x + 1; const r: any = f(2); return r === 3 ? 1 : 0;`)).toBe(
+      1,
+    );
+  });
+});
+
 describe("#3177 — non-view receivers keep their behavior (arms fall through)", () => {
   it("plain any-typed array element/length are unchanged", async () => {
     // NOTE: `Object.keys(<any-typed plain array>)` returns [] on main (the


### PR DESCRIPTION
## Summary

Slice 3 of #3177 (follows merged slices 1/#3118 and 2/#3127), per the mapped handoff in the issue file: the three remaining small mechanisms in the `ctors/*` bucket.

**TypedArrayConstructors directory sweep (411 non-bigint files, standalone): 134 → 154 pass (+20), 0 regressions** — every before/after diff line is fail→pass. Cumulative across the three slices: 124 → 154 in this tree, with cross-directory gains expected in full CI (the arms are generic).

### What changed

1. **`Object.getPrototypeOf(view) === TA.prototype` identity** (`src/codegen/ta-dyn-mop.ts`): the per-kind prototype object IS the per-view-brand `$NativeProto` glue **singleton** that a static `<View>.prototype` value read already yields (#2651/#2901 lineage, `emitLazyNativeProtoGet` globals) — no new object shape, identity closes by construction. The fill registers the glue for all 9 kinds (idempotent, shared memberCsv) and prepends:
   - a `__getPrototypeOf` dyn-view arm — runtime `kind` → glue-global switch with inline lazy init;
   - an `__extern_get` `$__ta_ctor` receiver arm serving `prototype` (same switch) and `BYTES_PER_ELEMENT`; other keys fall through to the original body unchanged.
2. **`TA(1)` without `new` → real TypeError** (§23.2.5.1 step 1; `src/codegen/expressions/calls.ts` `tryEmitInlineDynamicCall`): an outermost `ref.test $__ta_ctor` arm in the dynamic-callee dispatch chain (same chain the proxy/bound-fn arms extend). Gated on `ctx.taCtorTypeIdx >= 0` (byte-inert without TA ctor values) and added to the empty-candidates early-outs so it fires even in closure-free modules. Flips all 7 `undefined-newtarget`/`invoked-with-undefined-newtarget` rows (incl. one `-sab` — the throw fires before any SAB cast).
3. **`Object.isExtensible(view)` → true** (`__object_isExtensible` dyn-view arm) — flips all 5 `new-instance-extensibility` rows.

### Flipped (20)

defined-length / defined-length-and-offset / defined-offset, returns-new-instance, returns-object ×2, as-array-returns, same-ctor-returns-new-cloned-typedarray, new-instance-extensibility ×5, undefined-newtarget-throws ×4, invoked-with-undefined-newtarget ×2 (+sab), object-arg/length-throws.

### Validation

- `tests/issue-3177.test.ts`: 45/45 (11 new — including plain-object `getPrototypeOf`/`isExtensible`/closure-dispatch fall-through guards)
- Scoped suites 2186/2190/2872/3006/3054*/3057/3058/3133: all green (197 tests)
- `check:loc-budget` (calls.ts +29 granted via the issue's allow-list — the arm must live inside the dispatch chain; extracting the chain builder is #3182's call), `check:coercion-sites`, prettier, tsc: green

### Notes

Known residuals documented in the issue file (no-construct module shape for the ctor-receiver [[Get]] arm; `getProto(ta).constructor` chained-dyn on the glue struct whose `$ctor` field is null per #2651 S1; statically-typed B1 receivers). Next-slice map in the issue file remains: descriptor MOP arms (coordinate #2984), expando side-table, -sab representation, from/of statics, BigInt kinds (#1349-gated), Reflect.construct (#1472 Phase C).

Issue: plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md (stays `in-progress` — multi-slice, release+reclaim per phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb