### PR TITLE
refactor(ir): route Promise aggregates through emitter

### DIFF
--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -3,8 +3,8 @@ id: 2953
 title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait"
 status: in-progress
 assignee: ttraenkler/opus-1a
-branch: symphony/porffor/2953-after-3129
-pr: 3134
+branch: symphony/porffor/2953-after-pr-3134
+pr: null
 sprint: current
 created: 2026-07-02
 updated: 2026-07-16
@@ -21,8 +21,8 @@ origin: "2026-07-02 July Fable audit §5 (77 pushRaw sites; #1852-G1 slice text 
 loc-budget-allow:
   - src/ir/lower.ts
 claimed_by: porffor-codex-developer
-claimed_at: 2026-07-16T13:41:17.751Z
-last_merged_pr: 3129
+claimed_at: 2026-07-16T14:18:50.817Z
+last_merged_pr: 3134
 ---
 
 # #2953 — 40% of IR lowering bypasses the backend trait
@@ -119,7 +119,18 @@ value/aggregate families.
       trait, reducing `emitter.pushRaw` calls in `lower.ts` from 86 to 85.
       Golden emitter coverage, closure + cross-backend suites, typecheck,
       equivalence, and the 56-record byte oracle are green.
-- [ ] Promise ops
+- [x] **Promise aggregate ops**
+      (`emitPromiseNew`/`emitPromiseStateGet`/`emitPromiseValueGet`) — added
+      required, sink-generic primitives for Promise construction and semantic
+      state/value reads. `WasmGcEmitter` preserves the canonical `$Promise`
+      `struct.new` and field 0/1 `struct.get` instructions; Linear + Bytecode
+      fail loudly until their Promise record representations land. All six
+      Promise aggregate operations in `async.return`, `async.throw`, and
+      `await` now route through the trait. The two allocation conversions reduce
+      `emitter.pushRaw` calls in `lower.ts` from 85 to 83; await's raw structured
+      `if` remains intentionally out of scope. Golden emitter coverage, the
+      86-test focused suite, typecheck, equivalence, and the 56-record byte
+      oracle are green. (porffor-codex-developer)
 - [ ] ratchet: pushRaw count check + `// pushraw-ok(#issue)` justification tag
 
 ## 2026-07-16 — unions/boxing slice results
@@ -218,3 +229,33 @@ value/aggregate families.
   `IDENTICAL — all 56 (file,target) emits match baseline`.
 - Slice acceptance: complete. The parent issue intentionally remains
   `in-progress` for Promise ops and the pushRaw justification ratchet.
+
+## 2026-07-16 — Promise aggregate slice results
+
+- Re-grounded and fast-forwarded to `origin/main` at
+  `f52edb61510b9c404ef8807e662e9d3023a14f72` before implementation; PR #3134's
+  funcref slice was already present, so this continuation advanced to Promise
+  aggregate operations without duplicating landed work.
+- Added required `emitPromiseNew`, `emitPromiseStateGet`, and
+  `emitPromiseValueGet` hooks. Lowering retains Promise type resolution,
+  operand evaluation, state comparisons, and await's structured control flow;
+  the backend now owns aggregate allocation and the semantic state/value field
+  mapping. Linear and Bytecode stop at explicit missing-representation errors.
+- Routed two `$Promise` allocations and four state/value reads through the
+  trait. No Promise `struct.new`/`struct.get` remains in `lower.ts`, while the
+  out-of-scope await `if` construction is unchanged. The `emitter.pushRaw` call
+  count is now 83 (85 before this slice).
+- Added Golden-Instr coverage for Promise construction, state reads, and value
+  reads in `tests/ir-backend-emitter.test.ts`.
+- Focused verification:
+  `pnpm vitest run tests/ir-backend-emitter.test.ts tests/ir/issue-1373b.test.ts tests/issue-1169c.test.ts tests/ir-bytecode-proof.test.ts`
+  (86 tests passed), plus `pnpm run typecheck` and
+  `pnpm run test:equivalence:gate` (1,607 passing, 36 known baseline failures,
+  zero new regressions).
+- Byte identity: rebuilt the existing `scripts/prove-emit-identity.mjs` harness
+  with esbuild, captured the pre-edit baseline, and compared the edited
+  compiler against it. Result:
+  `IDENTICAL — all 56 (file,target) emits match baseline`.
+- Slice acceptance: complete. The parent issue intentionally remains
+  `in-progress` for the pushRaw justification ratchet, which must land on the
+  next fresh continuation branch.

--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -4,7 +4,7 @@ title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coe
 status: in-progress
 assignee: ttraenkler/opus-1a
 branch: symphony/porffor/2953-after-pr-3134
-pr: null
+pr: 3146
 sprint: current
 created: 2026-07-02
 updated: 2026-07-16

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -693,6 +693,18 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
     throw new Error("BytecodeEmitter: function references not yet wired — see §2a closure family.");
   }
 
+  // ---- Promise aggregate family (#2953) — the VM needs a Promise record
+  // representation before construction or semantic field reads are valid.
+  emitPromiseNew(): void {
+    throw new Error("BytecodeEmitter: Promise construction not yet wired — see §2a struct/object family.");
+  }
+  emitPromiseStateGet(): void {
+    throw new Error("BytecodeEmitter: Promise state reads not yet wired — see §2a struct/object family.");
+  }
+  emitPromiseValueGet(): void {
+    throw new Error("BytecodeEmitter: Promise value reads not yet wired — see §2a struct/object family.");
+  }
+
   // ---- closure family (#2953) — closure records and callable handles are not
   // yet represented by the bytecode VM. Keep the trait boundary loud instead
   // of falling back to WasmGC struct instructions through pushRaw.

--- a/src/ir/backend/contract-conformance.ts
+++ b/src/ir/backend/contract-conformance.ts
@@ -164,6 +164,15 @@ class StubEmitter implements BackendEmitter<StubSink> {
   emitFuncRef(funcIdx: FuncHandle, out: StubSink): void {
     out.push(`func.ref:${funcIdx}`);
   }
+  emitPromiseNew(promiseTypeIdx: TypeHandle, out: StubSink): void {
+    out.push(`promise.new:${promiseTypeIdx}`);
+  }
+  emitPromiseStateGet(promiseTypeIdx: TypeHandle, out: StubSink): void {
+    out.push(`promise.state.get:${promiseTypeIdx}`);
+  }
+  emitPromiseValueGet(promiseTypeIdx: TypeHandle, out: StubSink): void {
+    out.push(`promise.value.get:${promiseTypeIdx}`);
+  }
   emitCall(funcIdx: FuncHandle, out: StubSink): void {
     out.push(`call:${funcIdx}`);
   }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -28,14 +28,11 @@
 //     call sites and the existing `emitValue(v, out)` helper. The emitter does
 //     NOT return `Instr[]` to be spliced.
 //
-// Phase 1 (#1713) implements only the pass-through group (locals / globals /
-// const / arithmetic / control flow) and the vec group; `WasmGcEmitter`
-// produces a byte-identical `Instr` stream. The remaining methods
-// (aggregate / union / closure / ref-coercion) are declared so #1714 / a
-// later stage can route them, and are implemented in `WasmGcEmitter` as
-// they get wired. Async (Promise) + string groups stay where they are in
-// `lower.ts` for Phase 1 (strings are already behind `emit*` resolver
-// methods; Promise/await is WasmGC-only with no linear analogue yet).
+// Phase 1 (#1713) began with the pass-through and vec groups;
+// `WasmGcEmitter` produces a byte-identical `Instr` stream. Later slices route
+// aggregate, union, closure, ref-coercion, and Promise operations as their
+// representation contracts become explicit. Strings remain behind the
+// existing `emit*` resolver methods.
 //
 // The `out: Instr[]` sink is WasmGC/linear-shaped (both backends share the
 // `Instr` union -- see codegen-axes "types.ts stays shared"). It does NOT fit
@@ -184,6 +181,18 @@ export interface BackendEmitter<S = Instr[]> {
   // table or VM-callable handle once those representations land).
   /** Materialize compiled function `funcIdx` as a first-class callable value. */
   emitFuncRef(funcIdx: number, out: S): void;
+
+  // ---- Promise aggregate family — MIGRATED behind the trait (#2953) ------
+  // The caller resolves the backend's Promise type and owns operand order:
+  // construction leaves state, value, and callbacks on the stack; await
+  // leaves the Promise reference on the stack before selecting a semantic
+  // field. The backend owns the concrete aggregate allocation and field map.
+  /** state + value + callbacks on the stack -> a new Promise value. */
+  emitPromiseNew(promiseTypeIdx: number, out: S): void;
+  /** Promise ref on the stack -> its settlement-state discriminator. */
+  emitPromiseStateGet(promiseTypeIdx: number, out: S): void;
+  /** Promise ref on the stack -> its fulfillment value or rejection reason. */
+  emitPromiseValueGet(promiseTypeIdx: number, out: S): void;
 
   // ---- closure family — MIGRATED behind the trait (#2953) -----------------
   // Closure construction and field reads are aggregate operations whose

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -24,6 +24,8 @@
 //   - typed-funcref call (emitCallRef) — `call_ref` over a reference-typed
 //     funcref; the linear backend dispatches through a table, not a GC
 //     funcref (#2956, closures)
+//   - Promise aggregates — WasmGC `$Promise` structs become linear records
+//     once #2956 defines their handle and field representation
 //   - boxing / strings / closures — routed through the resolver in lower.ts,
 //     not this emitter (strings: #679 dual backend; boxing/closures: #2956)
 //
@@ -319,6 +321,18 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   // equivalent handle, not a WasmGC funcref (#2956, closures).
   emitFuncRef(): void {
     notImplemented("emitFuncRef");
+  }
+
+  // Promise aggregate family — the linear Promise record layout and handle
+  // representation land with the remaining #2956 aggregate work.
+  emitPromiseNew(): void {
+    notImplemented("emitPromiseNew");
+  }
+  emitPromiseStateGet(): void {
+    notImplemented("emitPromiseStateGet");
+  }
+  emitPromiseValueGet(): void {
+    notImplemented("emitPromiseValueGet");
   }
 
   // typed-funcref call — `call_ref` over a GC funcref (#2956, closures). The

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -230,6 +230,21 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     out.push({ op: "ref.func", funcIdx });
   }
 
+  // ---- Promise aggregate family (#2953) — byte-identical to the prior
+  // inline struct.new/get pushes in lower.ts. The canonical WasmGC Promise
+  // layout is { state: i32, value: externref, callbacks: externref }.
+  emitPromiseNew(promiseTypeIdx: number, out: Instr[]): void {
+    out.push({ op: "struct.new", typeIdx: promiseTypeIdx });
+  }
+
+  emitPromiseStateGet(promiseTypeIdx: number, out: Instr[]): void {
+    out.push({ op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 });
+  }
+
+  emitPromiseValueGet(promiseTypeIdx: number, out: Instr[]): void {
+    out.push({ op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 });
+  }
+
   // ---- closure family (#2953) — byte-identical to the prior inline
   // struct.new/get pushes in lower.ts. The caller has already emitted the
   // lifted function reference through emitFuncRef, captures, and any required

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -2849,7 +2849,7 @@ export function lowerIrFunctionBody<S>(
         });
         emitValue(instr.value, out);
         emitter.emitNull({ kind: "val", val: { kind: "externref" } }, out);
-        emitter.pushRaw(out, { op: "struct.new", typeIdx: promiseTypeIdx });
+        emitter.emitPromiseNew(promiseTypeIdx, out);
         emitter.emitToExternref(out);
         return;
       }
@@ -2867,7 +2867,7 @@ export function lowerIrFunctionBody<S>(
         });
         emitValue(instr.reason, out);
         emitter.emitNull({ kind: "val", val: { kind: "externref" } }, out);
-        emitter.pushRaw(out, { op: "struct.new", typeIdx: promiseTypeIdx });
+        emitter.emitPromiseNew(promiseTypeIdx, out);
         emitter.emitToExternref(out);
         return;
       }
@@ -2913,11 +2913,7 @@ export function lowerIrFunctionBody<S>(
           });
         }
         wasmOut.push({ op: "local.tee", index: awaitScratchPromiseIdx });
-        wasmOut.push({
-          op: "struct.get",
-          typeIdx: promiseTypeIdx,
-          fieldIdx: 0,
-        }); // state: i32
+        emitter.emitPromiseStateGet(promiseTypeIdx, out); // state: i32
         // Build:
         //   if state == FULFILLED then
         //     local.get $await_promise
@@ -2936,11 +2932,7 @@ export function lowerIrFunctionBody<S>(
             op: "local.get",
             index: awaitScratchPromiseIdx,
           });
-          rejectedBranch.push({
-            op: "struct.get",
-            typeIdx: promiseTypeIdx,
-            fieldIdx: 1,
-          });
+          emitter.emitPromiseValueGet(promiseTypeIdx, rejectedBranch as unknown as S);
           // #1584 (a4): throw routes through the trait.
           emitter.emitThrow(exnTagIdx, rejectedBranch as unknown as S);
         }
@@ -2948,30 +2940,30 @@ export function lowerIrFunctionBody<S>(
         // PENDING / fall-through marker. Slice 2 (#1373b) replaces with
         // the CPS continuation synthesis once #1326c Phase 1C-B lands.
         const pendingBranch: Instr[] = [{ op: "unreachable" }];
+        const fulfilledBranch: Instr[] = [{ op: "local.get", index: awaitScratchPromiseIdx }];
+        emitter.emitPromiseValueGet(promiseTypeIdx, fulfilledBranch as unknown as S);
+        const unsettledBranch: Instr[] = [{ op: "local.get", index: awaitScratchPromiseIdx }];
+        emitter.emitPromiseStateGet(promiseTypeIdx, unsettledBranch as unknown as S);
+        unsettledBranch.push(
+          { op: "i32.const", value: PROMISE_STATE_REJECTED },
+          { op: "i32.eq" },
+          {
+            op: "if",
+            blockType: {
+              kind: "val",
+              type: { kind: "externref" } as ValType,
+            },
+            then: rejectedBranch,
+            else: pendingBranch,
+          },
+        );
         wasmOut.push({ op: "i32.const", value: PROMISE_STATE_FULFILLED });
         wasmOut.push({ op: "i32.eq" });
         wasmOut.push({
           op: "if",
           blockType: { kind: "val", type: { kind: "externref" } as ValType },
-          then: [
-            { op: "local.get", index: awaitScratchPromiseIdx },
-            { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 },
-          ],
-          else: [
-            { op: "local.get", index: awaitScratchPromiseIdx },
-            { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 },
-            { op: "i32.const", value: PROMISE_STATE_REJECTED },
-            { op: "i32.eq" },
-            {
-              op: "if",
-              blockType: {
-                kind: "val",
-                type: { kind: "externref" } as ValType,
-              },
-              then: rejectedBranch,
-              else: pendingBranch,
-            },
-          ],
+          then: fulfilledBranch,
+          else: unsettledBranch,
         });
         return;
       }

--- a/tests/ir-backend-emitter.test.ts
+++ b/tests/ir-backend-emitter.test.ts
@@ -179,6 +179,26 @@ describe("#2953 WasmGcEmitter — function-reference family byte-identity", () =
   });
 });
 
+describe("#2953 WasmGcEmitter — Promise aggregate family byte-identity", () => {
+  it("emitPromiseNew → struct.new $Promise", () => {
+    const out: Instr[] = [];
+    emitter.emitPromiseNew(43, out);
+    expect(out).toEqual([{ op: "struct.new", typeIdx: 43 }]);
+  });
+
+  it("emitPromiseStateGet → struct.get $Promise $state", () => {
+    const out: Instr[] = [];
+    emitter.emitPromiseStateGet(43, out);
+    expect(out).toEqual([{ op: "struct.get", typeIdx: 43, fieldIdx: 0 }]);
+  });
+
+  it("emitPromiseValueGet → struct.get $Promise $value", () => {
+    const out: Instr[] = [];
+    emitter.emitPromiseValueGet(43, out);
+    expect(out).toEqual([{ op: "struct.get", typeIdx: 43, fieldIdx: 1 }]);
+  });
+});
+
 describe("#2953 WasmGcEmitter — ref-coercion/null family byte-identity", () => {
   it("emitNull selects the canonical nullable-ref and externref ops", () => {
     const out: Instr[] = [];


### PR DESCRIPTION
## Summary

- add required Promise construction and state/value read primitives to BackendEmitter
- preserve the exact WasmGC struct.new/get sequences and fail loudly on unwired Linear/Bytecode representations
- route async.return, async.throw, and await Promise aggregate operations through the trait
- leave issue #2953 in progress for the final pushRaw ratchet slice

## Validation

- pnpm run typecheck
- pnpm vitest run tests/ir-backend-emitter.test.ts tests/ir/issue-1373b.test.ts tests/issue-1169c.test.ts tests/ir-bytecode-proof.test.ts (86 passed)
- pnpm run test:equivalence:gate (1,607 passing; 36 known baseline failures; zero regressions)
- emitted-Wasm identity oracle: all 56 file/target records identical
- pinned Prettier check on all changed files