### PR TITLE
fix(#3314): allow-list parser drops comment-preceded frontmatter items

### DIFF
--- a/plan/issues/3314-frontmatter-allow-list-parser-drops-items-after-comments.md
+++ b/plan/issues/3314-frontmatter-allow-list-parser-drops-items-after-comments.md
@@ -1,0 +1,94 @@
+---
+id: 3314
+title: "scripts/lib/change-scope.mjs frontmatter parser silently drops allow-list items after a leading comment line"
+status: done
+sprint: current
+created: 2026-07-16
+completed: 2026-07-16
+priority: high
+feasibility: trivial
+model: fable
+horizon: s
+task_type: bug
+area: ci-infra
+goal: test-infrastructure
+related: [3131, 3279, 3303, 3306]
+---
+
+# #3314 — allow-list parser drops items when preceded by an explanatory comment
+
+## Problem
+
+PR #3138 (#3306) declared, correctly per the documented format:
+
+```yaml
+coercion-sites-allow:
+  # __str_to_number +2 — NOT a fresh hand-rolled matrix: routes the toString
+  # closure result through the EXISTING StringToNumber scanner (the same
+  # helper the direct string→f64 arm uses), replacing a spec-violating
+  # drop+NaN.
+  - src/codegen/type-coercion.ts
+```
+
+CI's Coercion-site drift gate (#2108/#3131/#3279) still failed as if **no**
+allowance had been declared at all. Root-caused (not a dev mistake, not a
+hand-rolled-matrix problem as first suspected by the PR-queue shepherd):
+`parseFrontmatterList` in `scripts/lib/change-scope.mjs` scans the block
+list line-by-line and `break`s on the **first line that doesn't match
+`^\s+-\s+(.+)$`** — which includes `#`-comment lines. Since the dev's
+comments came _before_ the actual `- src/codegen/type-coercion.ts` item,
+the parser broke immediately and returned an empty list, silently granting
+nothing.
+
+`parseFrontmatterCountReason` (the #3303 numeric-allowance counterpart used
+by `regressions-allow`) has the identical bug in its nested `count:`/
+`reason:` scalar-block scan.
+
+Confirmed via direct repro before touching the parser:
+
+```js
+parseFrontmatterList(
+  `---
+coercion-sites-allow:
+  # comment
+  - src/codegen/type-coercion.ts
+---
+`,
+  "coercion-sites-allow",
+);
+// => []  (should be ["src/codegen/type-coercion.ts"])
+```
+
+This is a real landmine for every future PR: the gate's own failure message
+explicitly encourages writing an explanation ("If this growth is an
+intentional, reviewed migration step, grant THIS change-set an
+allowance..."), and the natural writing order is explain-then-list — exactly
+the order that silently defeats the parser.
+
+## Fix
+
+Skip blank and `#`-comment lines while scanning both block forms, in both
+`parseFrontmatterList` and `parseFrontmatterCountReason`
+(`scripts/lib/change-scope.mjs`). Still `break`s correctly on a true dedent
+(an unindented top-level YAML key can never match the indented
+`^\s+...` patterns, so no risk of over-reading past the intended block).
+
+Verified with three cases: the exact failing #3138 shape (now parses to
+`["src/codegen/type-coercion.ts"]`), a `regressions-allow` block with an
+inline comment (`count`/`reason` still parse), and a no-overrun check
+(a real trailing top-level key still terminates the scan correctly).
+
+## Immediate unblock for #3138 (not part of this fix)
+
+Reordering the frontmatter so the list item precedes the comment also
+works around this without a parser change — noted for the #3306 dev in
+case this fix hasn't landed yet by the time they see this.
+
+## Acceptance criteria
+
+- `parseFrontmatterList` and `parseFrontmatterCountReason` tolerate
+  interior blank/comment lines in their block-list scan.
+- No change to the documented allow-list frontmatter format — this is a
+  parser fix, not a spec change.
+- PR #3138's existing `coercion-sites-allow` declaration (unmodified)
+  passes the gate once this lands and #3138 rebases/re-merges main.

--- a/plan/issues/3314-frontmatter-allow-list-parser-drops-items-after-comments.md
+++ b/plan/issues/3314-frontmatter-allow-list-parser-drops-items-after-comments.md
@@ -77,6 +77,9 @@ Verified with three cases: the exact failing #3138 shape (now parses to
 `["src/codegen/type-coercion.ts"]`), a `regressions-allow` block with an
 inline comment (`count`/`reason` still parse), and a no-overrun check
 (a real trailing top-level key still terminates the scan correctly).
+Permanent repro: `tests/issue-3314.test.ts` (5 cases, covers both parser
+functions with and without interior comments, plus the no-over-read
+regression guard).
 
 ## Immediate unblock for #3138 (not part of this fix)
 

--- a/scripts/lib/change-scope.mjs
+++ b/scripts/lib/change-scope.mjs
@@ -215,8 +215,9 @@ export function parseFrontmatterCountReason(text, key) {
     let count;
     let reason;
     for (let j = i + 1; j < lines.length; j++) {
+      if (/^\s*$/.test(lines[j]) || /^\s*#/.test(lines[j])) continue; // blank / comment line inside the block
       const lm = lines[j].match(/^\s+([A-Za-z_-]+):\s*(.*)$/);
-      if (!lm) break; // dedent / list item / blank ⇒ end of the nested block
+      if (!lm) break; // dedent / list item ⇒ end of the nested block
       const v = unquote(lm[2].trim());
       if (lm[1] === "count") count = /^[0-9]+$/.test(v) ? Number.parseInt(v, 10) : NaN;
       else if (lm[1] === "reason") reason = v;
@@ -250,6 +251,7 @@ export function parseFrontmatterList(text, key) {
       out.push(unquote(rest));
     } else {
       for (let j = i + 1; j < lines.length; j++) {
+        if (/^\s*$/.test(lines[j]) || /^\s*#/.test(lines[j])) continue; // blank / comment line inside the block
         const lm = lines[j].match(/^\s+-\s+(.+)$/);
         if (!lm) break;
         const v = unquote(lm[1].trim());

--- a/tests/issue-3314.test.ts
+++ b/tests/issue-3314.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3314 — parseFrontmatterList / parseFrontmatterCountReason must tolerate
+ * blank and `#`-comment lines inside an allow-list frontmatter block.
+ *
+ * Both scanners used to `break` on the first line that didn't match their
+ * expected pattern, which included comment lines — so an allow-list with an
+ * explanatory comment *before* the actual list item (exactly the style the
+ * gate's own failure message encourages) silently granted nothing. This is
+ * what PR #3138 (#3306) hit: its `coercion-sites-allow` declaration was
+ * correct per the documented format, but the gate failed as if no
+ * allowance existed at all.
+ */
+import { describe, expect, it } from "vitest";
+import { parseFrontmatterCountReason, parseFrontmatterList } from "../scripts/lib/change-scope.mjs";
+
+describe("#3314 frontmatter allow-list parser tolerates comments", () => {
+  it("parseFrontmatterList reads a list item preceded by comment lines (the #3138 shape)", () => {
+    const text = `---
+coercion-sites-allow:
+  # __str_to_number +2 — routes through the existing scanner, not a fresh
+  # hand-rolled matrix.
+  - src/codegen/type-coercion.ts
+---
+`;
+    expect(parseFrontmatterList(text, "coercion-sites-allow")).toEqual(["src/codegen/type-coercion.ts"]);
+  });
+
+  it("parseFrontmatterList still stops at a real dedent / trailing top-level key (no over-read)", () => {
+    const text = `---
+coercion-sites-allow:
+  - src/codegen/type-coercion.ts
+other-key: value
+---
+`;
+    expect(parseFrontmatterList(text, "coercion-sites-allow")).toEqual(["src/codegen/type-coercion.ts"]);
+  });
+
+  it("parseFrontmatterList with no comments still works (regression guard)", () => {
+    const text = `---
+loc-budget-allow:
+  - src/codegen/type-coercion.ts
+---
+`;
+    expect(parseFrontmatterList(text, "loc-budget-allow")).toEqual(["src/codegen/type-coercion.ts"]);
+  });
+
+  it("parseFrontmatterCountReason reads count/reason preceded by a comment line", () => {
+    const text = `---
+regressions-allow:
+  # explanatory comment above the scalars
+  count: 2700
+  reason: "#3285 assert_throws error-type tightening, see #3286"
+---
+`;
+    expect(parseFrontmatterCountReason(text, "regressions-allow")).toEqual({
+      count: 2700,
+      reason: "#3285 assert_throws error-type tightening, see #3286",
+    });
+  });
+
+  it("parseFrontmatterCountReason with no comments still works (regression guard)", () => {
+    const text = `---
+regressions-allow:
+  count: 2700
+  reason: "plain declaration, no comments"
+---
+`;
+    expect(parseFrontmatterCountReason(text, "regressions-allow")).toEqual({
+      count: 2700,
+      reason: "plain declaration, no comments",
+    });
+  });
+});


### PR DESCRIPTION
## What

`parseFrontmatterList`/`parseFrontmatterCountReason` in `scripts/lib/change-scope.mjs` (the shared reader behind `loc-budget-allow`, `coercion-sites-allow`, and `regressions-allow`) breaks out of its block-list scan on the first line that doesn't match the expected pattern — including `#`-comment lines. An allow-list frontmatter block with an explanatory comment *before* the list item therefore silently grants nothing.

This is exactly what PR #3138 (#3306) hit: it declared `coercion-sites-allow: [comment lines] - src/codegen/type-coercion.ts` — correct per the documented format — and the Coercion-site drift gate still failed as if no allowance existed. Confirmed via direct repro before touching the parser:

```js
parseFrontmatterList(`---
coercion-sites-allow:
  # comment
  - src/codegen/type-coercion.ts
---
`, "coercion-sites-allow")
// => []  (should be ["src/codegen/type-coercion.ts"])
```

## Fix

Skip blank and `#`-comment lines while scanning both block forms (the path-list form and the #3303 `count`/`reason` numeric form). Still terminates correctly on a true dedent — an unindented top-level YAML key never matches the indented patterns these scanners look for, so there's no risk of reading past the intended block.

## Validation

Manually verified three cases: the exact failing #3138 shape now parses correctly, a `regressions-allow` block with an interior comment still parses `count`/`reason`, and a block followed by a real top-level key still terminates the scan at the right place (no over-read).

No behavior change to the documented allow-list format — this is a parser bug fix only.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>