### PR TITLE
feat(#3177): standalone TA descriptor MOP arms + expando side-table (slice 4)

### DIFF
--- a/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
+++ b/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
@@ -38,11 +38,23 @@ origin: "PO groom of #2860 umbrella, 2026-07-12 lane-baseline diff; the 'TypedAr
 # proxy/bound-fn arms extend — extracting the chain builder to a module is
 # the #3182 consolidation epic's call, not this slice's); the proto/
 # isExtensible arms themselves live in ta-dyn-mop.ts.
+# (slice 4): the descriptor arms + expando live in ta-dyn-mop.ts (non-god);
+# the god-file growth is glue that MUST sit at the owning sites:
+# object-ops.ts +44 — the shared emitDefinePropertyRejectionThrow helper +
+# its 4 call-site wirings (§20.1.2.4 step 3: Object.defineProperty converts
+# the dyn-view [[DefineOwnProperty]]-false sentinel to TypeError — the
+# Object-vs-Reflect distinction only exists at the call sites);
+# object-runtime-descriptors.ts +14 — __obj_define_from_desc threads the
+# sentinel out (one scratch local + null-check, inside the native's body);
+# dataview-native.ts +3 — the three dyn-view struct.new sites push the new
+# expando field's null initializer.
 loc-budget-allow:
   - src/codegen/dataview-native.ts
   - src/codegen/property-access-dispatch.ts
   - src/codegen/index.ts
   - src/codegen/expressions/calls.ts
+  - src/codegen/object-ops.ts
+  - src/codegen/object-runtime-descriptors.ts
 # coercion-sites-allow: the NEW module's 4 uses (number_toString ×2,
 # __str_to_number, __unbox_number) are the exact §7.1.21
 # CanonicalNumericIndexString round-trip + the finalize-safe ToNumber the
@@ -302,20 +314,94 @@ Known residuals (documented, low corpus value):
   B1 `$__ta_view` rep) don't reach the dyn-view arm — harness shapes are
   all any-typed.
 
+### Slice 4 — descriptor MOP arms + expando side-table (PR: issue-3177-slice4-descriptor-expando, 2026-07-16, fable-3177)
+
+Directory sweep (411 non-bigint files, standalone): 154 → **196 pass (+42),
+0 regressions** (every diff line fail→pass vs the slice-3 result; cumulative
+#3177: 124 → 196). Ordinary-object blast radius verified against a clean
+origin/main baseline worktree: `built-ins/Reflect/defineProperty` identical
+(9/12), `built-ins/Object/defineProperty` +1 bonus flip (coerced-P-shrink),
+0 regressions.
+
+What landed:
+
+- **Expando side-table**: `$__ta_dyn_view` gains an APPEND-ONLY 5th field
+  `expando (mut externref)` (registry/types.ts; externref so the type has no
+  `$Object` registration dependency — `$__bound_fn` precedent). The three
+  creation sites push a null initializer; a lazily-created `$Object` carries
+  every non-index own prop + the preventExtensions state.
+- **Ordinary-key delegation in the slice-1 arms** (ta-dyn-mop.ts
+  `buildStringKeyArm` miss paths): non-canonical string keys AND symbol keys
+  now delegate to the expando by RECURSING the same native (the expando is a
+  `$Object`, so the dyn-view arm declines and the ordinary body runs —
+  no new machinery). get/has/delete keep legacy miss results when no expando
+  exists; set/reflect_set lazily create it. Flipped the whole
+  `key-is-not-numeric-index` / `key-is-not-canonical-index` /
+  `detached-buffer-key-is-*` / `key-is-symbol` families across
+  Get/Set/Delete/HasProperty (§10.4.5 "Otherwise, return Ordinary*").
+- **§10.4.5.1 [[GetOwnProperty]]** — `__getOwnPropertyDescriptor` dyn-view
+  arm: valid canonical index → fresh data descriptor `{value, w:T, e:T,
+  c:T}` (via `__new_plain_object`/`__extern_set`/`__box_boolean`); invalid →
+  undefined; ordinary keys → expando read-back.
+- **§10.4.5.3 [[DefineOwnProperty]]** — dyn-view arms in
+  `__defineProperty_value` (validate: invalid index / accessor bit /
+  attribute specified-and-false via the host flags' specified-bits → REJECT;
+  else element write) and `__defineProperty_accessor` (canonical index →
+  always REJECT). **Rejection channel**: the natives return the input obj on
+  every ordinary path and never null, so a `ref.null.extern` SENTINEL
+  signals the spec `false`: `__obj_define_from_desc` threads it out
+  (+scratch local), Reflect.defineProperty's existing `__is_truthy` reads it
+  as `false`, and the compile-time Object.defineProperty sites (literal
+  paths in emitExternDefinePropertyValue/NoValue + the two dynamic-desc
+  sites) convert it to the §20.1.2.4 TypeError via the new shared
+  `emitDefinePropertyRejectionThrow` (standalone/wasi-gated; ordinary
+  receivers never return null so host/ordinary behavior is untouched).
+  This serves BOTH test shapes: `…-throws.js` (Object.defineProperty →
+  TypeError) and the Reflect `→ false` twins.
+- **preventExtensions/isExtensible over the expando**:
+  `__object_preventExtensions` dyn-view arm lazily creates the expando and
+  flags it; the slice-3 isExtensible arm now recurses on the expando; a NEW
+  key on a non-extensible expando pre-checks (`__hasOwnProperty` +
+  `__object_isExtensible`) and rejects with the sentinel (this-is-not-
+  extensible: Reflect → false ✓).
+
+Verified: tests/issue-3177.test.ts 61/61 (16 new); suites 2186/2190/2872/
+3054\*/3057/3058 + 1629-S6/1629b (descriptor lineage) all green;
+DefineOwnProperty bucket 1 → 24/28, GetOwnProperty 1 → 5/12 (rest are
+#2940-vacuous rows + the symbol-key descriptor READ-BACK residual below).
+
+Known residuals:
+
+- Ordinary `$Object` gOPD has no symbol-key read-back (string-keyed
+  `$PropEntry` lookup) — `gOPD(view, sym)` after a symbol-keyed define
+  returns undefined (internals/GetOwnProperty/key-is-symbol.js). The
+  WRITE/READ MOP paths handle symbols (#2866 interning); only the
+  descriptor reflection misses.
+- `desc-value-throws.js`: element-write ToNumber uses `__unbox_number`,
+  which does not invoke user `valueOf` (slice-2 finding) — the Test262Error
+  from a throwing valueOf can't propagate.
+- Reflect.defineProperty on a SEALED ORDINARY object still throws instead
+  of returning false (pre-existing: the ordinary S4 preflight throws and
+  Reflect has no catch channel; fixing it needs the ordinary path moved to
+  the same sentinel discipline — a follow-on, NOT this issue).
+- `__object_keys` does not append expando keys yet (OwnPropertyKeys
+  enumeration of non-index own props).
+
 ### Remaining (next slices — release+reclaim per phase)
 
 - ~~**Ctor-arg protocol throws**~~ — DONE in slice 2 (above), EXCEPT the
   `Object.getPrototypeOf(ta) === TA.prototype` identity part (moved to the
   "found while probing" list — it is a proto-graph mechanism, not a throw)
   and the static-lane parity noted there.
-- **Descriptor MOP arms** (~70 rows, `internals/DefineOwnProperty` +
-  `GetOwnProperty`): dyn-view arms in `__defineProperty_*` + the GOPD
-  call-site guard — COORDINATE with in-flight #2984 (builtin-descriptor
-  MOP owner).
-- **Expando side-table**: non-index own props on views
-  (`Object.defineProperty(sample, "bar", …)` + delete-configurability) —
-  needs an `expando (mut ref null $Object)` field appended to
-  `$__ta_dyn_view` (append-only keeps `$__vec_base` prefix valid).
+- ~~**Descriptor MOP arms**~~ — DONE in slice 4 (above). #2984 coordination
+  note: no in-flight #2984 PR existed at implementation time (its GOPD
+  builtin-key slice had landed); the arms EXTEND the #2984/#2965 natives
+  (`__getOwnPropertyDescriptor`/`__defineProperty_*`) per the anti-bloat
+  directive — no parallel descriptor path was created.
+- ~~**Expando side-table**~~ — DONE in slice 4 (above; field is
+  `mut externref`, not `ref null $Object`, avoiding an `$Object` type
+  dependency at dyn-view registration). Residual: `__object_keys` expando
+  enumeration (see slice-4 residuals).
 - **BigInt kinds** (~150 rows, everything `*-bigint`/`BigInt`): BigInt64/
   BigUint64 need i64 elements + ToBigInt — gated on the #1349/#1644
   i64-brand ValType decision; NOT schedulable until that ADR lands.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -3696,11 +3696,12 @@ export function emitDynamicTaViewConstruct(
       lenOutLocal,
       lenGiven ? { kind: "static-yes", lenLocal: lenElemsLocal, lenF64Local } : { kind: "static-no" },
     );
-    // view = {length (elements | -1 tracking), buf, byteOffset, kind}.
+    // view = {length (elements | -1 tracking), buf, byteOffset, kind, expando}.
     fctx.body.push({ op: "local.get", index: lenOutLocal });
     fctx.body.push({ op: "local.get", index: bufLocal });
     fctx.body.push({ op: "local.get", index: offsetLocal });
     fctx.body.push({ op: "local.get", index: kindLocal });
+    fctx.body.push({ op: "ref.null.extern" }); // expando (#3177 slice 4) — lazily created
     fctx.body.push({ op: "struct.new", typeIdx: dynIdx });
     fctx.body.push({ op: "extern.convert_any" });
     fctx.body.push({ op: "local.set", index: resultLocal });
@@ -3873,7 +3874,7 @@ export function emitTaDynCtorConstructFromLocals(
     fctx.body.push({ op: "local.get", index: dstBlLocal });
     fctx.body.push({ op: "array.new_default", typeIdx: byteArrIdx });
     fctx.body.push({ op: "local.set", index: dstArrLocal });
-    // view = {length: n, buf: {bl, arr}, byteOffset: 0, kind}
+    // view = {length: n, buf: {bl, arr}, byteOffset: 0, kind, expando}
     fctx.body.push({ op: "local.get", index: dstNLocal });
     fctx.body.push({ op: "local.get", index: dstBlLocal });
     fctx.body.push({ op: "local.get", index: dstArrLocal });
@@ -3881,6 +3882,7 @@ export function emitTaDynCtorConstructFromLocals(
     fctx.body.push({ op: "struct.new", typeIdx: byteVecIdx });
     fctx.body.push({ op: "i32.const", value: 0 });
     fctx.body.push({ op: "local.get", index: kindLocal });
+    fctx.body.push({ op: "ref.null.extern" }); // expando (#3177 slice 4) — lazily created
     fctx.body.push({ op: "struct.new", typeIdx: dynIdx });
     fctx.body.push({ op: "extern.convert_any" });
     fctx.body.push({ op: "local.set", index: resultLocal });
@@ -4168,11 +4170,12 @@ export function emitTaDynCtorConstructFromLocals(
             /* skipAutoModulo — bare-byte-vec pun, see helper doc */ true,
           );
         }
-        // view = {n, sharedBuf, off, kind}
+        // view = {n, sharedBuf, off, kind, expando}
         fctx.body.push({ op: "local.get", index: dstNLocal });
         fctx.body.push({ op: "local.get", index: bufLocal });
         fctx.body.push({ op: "local.get", index: offLocal });
         fctx.body.push({ op: "local.get", index: kindLocal });
+        fctx.body.push({ op: "ref.null.extern" }); // expando (#3177 slice 4) — lazily created
         fctx.body.push({ op: "struct.new", typeIdx: dynIdx });
         fctx.body.push({ op: "extern.convert_any" });
         fctx.body.push({ op: "local.set", index: resultLocal });

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -19,6 +19,7 @@ import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitThrowRangeError, emitThrowTypeError } from "./expressions/helpers.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js"; // (#3177 slice 4) defineProperty rejection sentinel → TypeError
 import { emitMappedArgReverseSync } from "./expressions/logical-ops.js";
 import { resolveStructName } from "./expressions/misc.js";
 import { addUnionImports, cacheStringLiterals, getOrRegisterTupleType, resolveWasmType } from "./index.js";
@@ -1264,7 +1265,7 @@ export function compileObjectDefineProperty(
       const init = !ts.isObjectLiteralExpression(descArg)
         ? descriptorInitializerForIdentifier(ctx, descArg)
         : undefined;
-      return emitDefinePropertyDescRuntime(
+      const r = emitDefinePropertyDescRuntime(
         ctx,
         fctx,
         objArg,
@@ -1272,6 +1273,10 @@ export function compileObjectDefineProperty(
         descArg,
         init ? descriptorUndefinedFields(init) : [],
       );
+      // (#3177 slice 4) Object.defineProperty converts a null (rejection
+      // sentinel / falsy-undefined trap result) into the §20.1.2.4 TypeError.
+      if (r !== null) emitDefinePropertyRejectionThrow(ctx, fctx);
+      return r;
     }
   }
 
@@ -1572,7 +1577,7 @@ export function compileObjectDefineProperty(
   // sibling Object.create path at calls.ts:3996+ (#1631).
   if (!ts.isObjectLiteralExpression(descArg)) {
     const init = descriptorInitializerForIdentifier(ctx, descArg);
-    return emitDefinePropertyDescRuntime(
+    const r = emitDefinePropertyDescRuntime(
       ctx,
       fctx,
       objArg,
@@ -1580,6 +1585,12 @@ export function compileObjectDefineProperty(
       descArg,
       init ? descriptorUndefinedFields(init) : [],
     );
+    // (#3177 slice 4) §20.1.2.4 step 3: the applier threads the dyn-view
+    // [[DefineOwnProperty]]-false sentinel (null) out — Object.defineProperty
+    // converts it to TypeError. (Reflect.defineProperty consumes the same
+    // applier via `__is_truthy` → `false` instead; see call-namespace-static.)
+    if (r !== null) emitDefinePropertyRejectionThrow(ctx, fctx);
+    return r;
   }
 
   // (#1629) Explicit-`undefined` descriptor fields (e.g. `{ value: undefined }`,
@@ -2726,10 +2737,41 @@ function emitExternDefinePropertyValue(
   flushLateImportShifts(ctx, fctx);
   if (funcIdx !== undefined) {
     fctx.body.push({ op: "call", funcIdx });
+    emitDefinePropertyRejectionThrow(ctx, fctx);
   }
 
   // __defineProperty_value returns obj, so we're done
   return { kind: "externref" };
+}
+
+/**
+ * (#3177 slice 4) §20.1.2.4 step 3: `Object.defineProperty` throws TypeError
+ * when [[DefineOwnProperty]] returns false. The standalone dyn-view arms in
+ * `__defineProperty_value`/`_accessor` signal that false with a
+ * `ref.null.extern` SENTINEL (every ordinary path returns the input obj, and
+ * a null/undefined obj already threw in `emitObjectArgNullGuard` — so a null
+ * result can ONLY be the rejection sentinel). Reflect.defineProperty keeps
+ * its own consumption (`__is_truthy` → spec `false`) and is NOT routed here.
+ * Standalone-only: the host-lane import returns the JS object, never null.
+ * Leaves the (non-null) result on the stack.
+ */
+function emitDefinePropertyRejectionThrow(ctx: CodegenContext, fctx: FunctionContext): void {
+  if (!(ctx.standalone || ctx.wasi)) return;
+  const resLocal = allocLocal(fctx, `__defprop_res_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.tee", index: resLocal });
+  fctx.body.push({ op: "ref.is_null" });
+  const throwInstrs = buildThrowJsErrorInstrs(
+    ctx,
+    "TypeError",
+    "Cannot define property, object is not extensible or index is invalid",
+    {
+      flush: fctx,
+    },
+  );
+  // Stack: `local.tee` kept the copy in the local, `ref.is_null` consumed the
+  // stack copy — re-read the local for the caller.
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwInstrs, else: [] });
+  fctx.body.push({ op: "local.get", index: resLocal });
 }
 
 /**
@@ -3087,6 +3129,7 @@ function emitExternDefinePropertyNoValue(
       flushLateImportShifts(ctx, fctx);
       if (accFuncIdx !== undefined) {
         fctx.body.push({ op: "call", funcIdx: accFuncIdx });
+        emitDefinePropertyRejectionThrow(ctx, fctx);
       }
 
       // (#3125) STANDALONE closed-struct receiver: the runtime
@@ -3161,6 +3204,7 @@ function emitExternDefinePropertyNoValue(
     flushLateImportShifts(ctx, fctx);
     if (funcIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx });
+      emitDefinePropertyRejectionThrow(ctx, fctx);
     }
     return { kind: "externref" };
   }

--- a/src/codegen/object-runtime-descriptors.ts
+++ b/src/codegen/object-runtime-descriptors.ts
@@ -1546,6 +1546,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
     const L_VALUE = 8;
     const L_GETTER = 9;
     const L_SETTER = 10;
+    const L_DEFINE_RESULT = 11; // (#3177 slice 4) dyn-view rejection-sentinel thread-out
 
     const keyRef = (key: string): Instr[] => [...nativeStringLiteralInstrs(ctx, key), { op: "extern.convert_any" }];
     const hasField = (key: string): Instr[] => [
@@ -1781,7 +1782,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
           { op: "local.get", index: L_FLAGS },
           { op: "f64.convert_i32_s" },
           { op: "call", funcIdx: defineAccessorIdx },
-          { op: "drop" },
+          { op: "local.set", index: L_DEFINE_RESULT },
         ],
         else: [
           { op: "local.get", index: 0 },
@@ -1790,8 +1791,20 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
           { op: "local.get", index: L_FLAGS },
           { op: "f64.convert_i32_s" },
           { op: "call", funcIdx: defineValueIdx },
-          { op: "drop" },
+          { op: "local.set", index: L_DEFINE_RESULT },
         ],
+      },
+      // (#3177 slice 4) Thread the [[DefineOwnProperty]] REJECTION sentinel
+      // out: the dyn-view arms in __defineProperty_value/_accessor return
+      // ref.null.extern on a §10.4.5.3 false (every ordinary path returns the
+      // input obj, never null), so a null result propagates to the caller —
+      // Reflect.defineProperty's `__is_truthy` reads it as the spec `false`.
+      { op: "local.get", index: L_DEFINE_RESULT },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "ref.null.extern" }, { op: "return" }],
       },
       { op: "local.get", index: 0 },
     ];
@@ -1809,6 +1822,7 @@ export function buildObjectDescriptorHelpers(ctx: CodegenContext, s: ObjectDescr
         { name: "value", type: { kind: "externref" } },
         { name: "getter", type: { kind: "externref" } },
         { name: "setter", type: { kind: "externref" } },
+        { name: "defineResult", type: { kind: "externref" } },
       ],
       body,
     );

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -404,6 +404,13 @@ export function getOrRegisterTaDynViewType(ctx: CodegenContext): number {
     { name: "buf", type: { kind: "ref_null" as const, typeIdx: bufVecTypeIdx }, mutable: false },
     { name: "byteOffset", type: { kind: "i32" as const }, mutable: false },
     { name: "kind", type: { kind: "i32" as const }, mutable: false },
+    // (#3177 slice 4) Expando side-table: non-index own props defined on the
+    // view (`Object.defineProperty(sample, "foo", …)`, symbol keys, and the
+    // preventExtensions state) live on a lazily-created `$Object` boxed as
+    // externref (no `$Object` type dependency at registration — the MOP arms
+    // cast on use). APPEND-ONLY: existing field indices and the `$__vec_base`
+    // supertype prefix stay valid.
+    { name: "expando", type: { kind: "externref" as const }, mutable: true },
   ];
   ctx.mod.types.push({ kind: "struct", name, superTypeIdx: vecBaseIdx, fields });
   ctx.taDynViewTypeIdx = idx;

--- a/src/codegen/ta-dyn-mop.ts
+++ b/src/codegen/ta-dyn-mop.ts
@@ -500,6 +500,7 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     const aLen = base + 4;
     const aKey = base + 5; // normalized key externref
     const aN = base + 6; // parsed numeric key f64
+    const aExp = base + 7; // (#3177 slice 4) expando $Object externref
     fn.locals.push(
       { name: "__tam_any", type: { kind: "anyref" } },
       { name: "__tam_dv", type: { kind: "ref_null", typeIdx: dynIdx } },
@@ -508,6 +509,7 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
       { name: "__tam_len", type: { kind: "i32" } },
       { name: "__tam_key", type: { kind: "externref" } },
       { name: "__tam_n", type: { kind: "f64" } },
+      { name: "__tam_exp", type: { kind: "externref" } },
     );
 
     // Build the inner (receiver IS dyn-view) body with a mini fctx so the
@@ -538,20 +540,82 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     inner.push({ op: "local.get", index: 1 });
     inner.push({ op: "call", funcIdx: tpkIdx });
     inner.push({ op: "local.set", index: aKey });
-    // Non-string key (Symbol / opaque) → ordinary miss for this arm.
+    // (#3177 slice 4) Ordinary (non-index, non-intrinsic) keys — including
+    // Symbol keys — delegate to the EXPANDO side-table (`$__ta_dyn_view`
+    // field 4, a lazily-created `$Object` boxed as externref): the §10.4.5
+    // "Otherwise, return Ordinary*" steps. Reads (get/has/delete) on a view
+    // with no expando keep the pre-slice-4 miss results; writes
+    // (set/reflect_set) lazily CREATE the expando. The delegate is a
+    // recursive self-call on the SAME native — the expando is a `$Object`,
+    // so the dyn-view arm's `ref.test` declines and the ordinary body runs.
+    const selfIdx = ctx.funcMap.get(
+      mode === "get"
+        ? "__extern_get"
+        : mode === "has"
+          ? "__extern_has"
+          : mode === "set"
+            ? "__extern_set"
+            : mode === "reflect_set"
+              ? "__reflect_set"
+              : "__delete_property",
+    );
+    const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
+    const loadExpando = (): Instr[] => [
+      { op: "local.get", index: aDv },
+      { op: "ref.as_non_null" },
+      { op: "struct.get", typeIdx: dynIdx, fieldIdx: 4 },
+      { op: "local.set", index: aExp },
+    ];
     const missInstrs = (): Instr[] => {
-      switch (mode) {
-        case "get":
-          return [...undef(), { op: "return" }];
-        case "has":
-          return [{ op: "i32.const", value: 0 }, { op: "return" }];
-        case "set":
-          return [{ op: "return" }]; // void — expando writes are a follow-on
-        case "reflect_set":
-          return [{ op: "i32.const", value: 1 }, { op: "return" }]; // OrdinarySet on extensible → true
-        case "delete":
-          return [{ op: "i32.const", value: 1 }, { op: "return" }]; // no own prop → true
+      const legacyMiss: Instr[] = (() => {
+        switch (mode) {
+          case "get":
+            return [...undef(), { op: "return" }];
+          case "has":
+            return [{ op: "i32.const", value: 0 }, { op: "return" }];
+          case "set":
+            return [{ op: "return" }]; // void
+          case "reflect_set":
+            return [{ op: "i32.const", value: 1 }, { op: "return" }]; // OrdinarySet on extensible → true
+          case "delete":
+            return [{ op: "i32.const", value: 1 }, { op: "return" }]; // no own prop → true
+        }
+      })();
+      if (selfIdx === undefined) return legacyMiss;
+      const out: Instr[] = [...loadExpando()];
+      if (mode === "set" || mode === "reflect_set") {
+        if (newPlainObjIdx === undefined) return legacyMiss;
+        // Lazily create the expando on first ordinary write.
+        out.push({ op: "local.get", index: aExp });
+        out.push({ op: "ref.is_null" });
+        out.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "call", funcIdx: newPlainObjIdx },
+            { op: "local.set", index: aExp },
+            { op: "local.get", index: aDv },
+            { op: "ref.as_non_null" },
+            { op: "local.get", index: aExp },
+            { op: "struct.set", typeIdx: dynIdx, fieldIdx: 4 },
+          ],
+        });
+        out.push({ op: "local.get", index: aExp });
+        out.push({ op: "local.get", index: aKey });
+        out.push({ op: "local.get", index: 2 });
+        out.push({ op: "call", funcIdx: selfIdx });
+        out.push({ op: "return" });
+        return out;
       }
+      // get / has / delete: no expando → legacy miss; else delegate.
+      out.push({ op: "local.get", index: aExp });
+      out.push({ op: "ref.is_null" });
+      out.push({ op: "if", blockType: { kind: "empty" }, then: legacyMiss });
+      out.push({ op: "local.get", index: aExp });
+      out.push({ op: "local.get", index: aKey });
+      out.push({ op: "call", funcIdx: selfIdx });
+      out.push({ op: "return" });
+      return out;
     };
     inner.push({ op: "local.get", index: aKey });
     inner.push({ op: "any.convert_extern" });
@@ -796,11 +860,16 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
     );
   }
 
-  // __object_isExtensible(externref) -> i32: a live view IS extensible
-  // (§10.4.5 views are ordinary wrt [[IsExtensible]]; no preventExtensions
-  // state exists on `$__ta_dyn_view` yet — the expando slice owns that).
+  // __object_isExtensible(externref) -> i32: a live view IS extensible unless
+  // preventExtensions was applied — that state lives on the EXPANDO $Object
+  // (#3177 slice 4): no expando → true; else recurse on the expando (whose
+  // ordinary flags arm reads OBJ_FLAG_NONEXTENSIBLE).
   const isExtFn = findFn("__object_isExtensible");
-  if (isExtFn) {
+  const isExtIdx = ctx.funcMap.get("__object_isExtensible");
+  if (isExtFn && isExtIdx !== undefined) {
+    const base = 1 + isExtFn.locals.length;
+    const xExp = base;
+    isExtFn.locals.push({ name: "__tax_exp", type: { kind: "externref" } });
     isExtFn.body.unshift(
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
@@ -808,7 +877,22 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "any.convert_extern" },
+          { op: "ref.cast", typeIdx: dynIdx },
+          { op: "struct.get", typeIdx: dynIdx, fieldIdx: 4 },
+          { op: "local.tee", index: xExp },
+          { op: "ref.is_null" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+          },
+          { op: "local.get", index: xExp },
+          { op: "call", funcIdx: isExtIdx },
+          { op: "return" },
+        ],
       },
     );
   }
@@ -884,5 +968,324 @@ export function fillTaDynViewMopArms(ctx: CodegenContext): void {
       { op: "ref.test", typeIdx: ctorIdx },
       { op: "if", blockType: { kind: "empty" }, then: inner },
     );
+  }
+
+  // ── (#3177 slice 4) Descriptor MOP arms — §10.4.5.3 [[DefineOwnProperty]] /
+  // §10.4.5.1 [[GetOwnProperty]] over dyn-view receivers, composing the
+  // #2984/#2965 builtin-descriptor natives (arms extension, NOT a parallel
+  // descriptor path). REJECTION CHANNEL: `__defineProperty_value`/`_accessor`
+  // return the input obj on every existing path and never null, so the arms
+  // signal a §10.4.5.3 false with a `ref.null.extern` SENTINEL: the
+  // `__obj_define_from_desc` applier threads it out (Reflect.defineProperty's
+  // `__is_truthy` then yields the spec `false`), and the compile-time
+  // Object.defineProperty call sites convert it to the §20.1.2.4 TypeError.
+  // Ordinary (non-index) keys delegate to the lazily-created EXPANDO (whose
+  // ordinary define enforces its own attribute semantics); a NEW key on a
+  // non-extensible expando pre-checks via __hasOwnProperty +
+  // __object_isExtensible and rejects with the sentinel (Reflect → false).
+  {
+    const newPlainObjIdx = ctx.funcMap.get("__new_plain_object");
+    const boxBoolIdx = ctx.funcMap.get("__box_boolean");
+    const externSetIdx = ctx.funcMap.get("__extern_set");
+    const gopdIdx = ctx.funcMap.get("__getOwnPropertyDescriptor");
+    const dpvIdx = ctx.funcMap.get("__defineProperty_value");
+    const dpaIdx = ctx.funcMap.get("__defineProperty_accessor");
+    const preventExtIdx = ctx.funcMap.get("__object_preventExtensions");
+    const hasOwnIdx = ctx.funcMap.get("__hasOwnProperty");
+
+    const keyExtern = (lit: string): Instr[] => [...nativeStringLiteralInstrs(ctx, lit), { op: "extern.convert_any" }];
+    const nullRet: Instr[] = [{ op: "ref.null.extern" }, { op: "return" }];
+
+    // Shared arm-builder pieces: derive dv/key locals on a native with params
+    // 0=obj 1=key …; returns the locals base. Appends 4 locals.
+    type FilledFn = { locals: { name: string; type: ValType }[]; body: Instr[] };
+    const pushDvKeyPreamble = (
+      fn: FilledFn,
+      numParams: number,
+      inner: Instr[],
+    ): { dDv: number; dKey: number; dN: number; dExp: number } => {
+      const base = numParams + fn.locals.length;
+      const dDv = base;
+      const dKey = base + 1;
+      const dN = base + 2;
+      const dExp = base + 3;
+      fn.locals.push(
+        { name: "__tad_dv", type: { kind: "ref_null", typeIdx: dynIdx } },
+        { name: "__tad_key", type: { kind: "externref" } },
+        { name: "__tad_n", type: { kind: "f64" } },
+        { name: "__tad_exp", type: { kind: "externref" } },
+      );
+      inner.push({ op: "local.get", index: 0 });
+      inner.push({ op: "any.convert_extern" });
+      inner.push({ op: "ref.cast", typeIdx: dynIdx });
+      inner.push({ op: "local.set", index: dDv });
+      inner.push({ op: "local.get", index: 1 });
+      inner.push({ op: "call", funcIdx: tpkIdx });
+      inner.push({ op: "local.set", index: dKey });
+      return { dDv, dKey, dN, dExp };
+    };
+    // `key is $AnyString && CanonicalNumericIndexString(key)` → i32 (writes dN).
+    const keyIsStringCanonical = (dKey: number, dN: number): Instr[] => [
+      { op: "local.get", index: dKey },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: anyStrTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: keyIsCanonical(dKey, dN),
+        else: [{ op: "i32.const", value: 0 }],
+      },
+    ];
+    // Load expando into dExp; lazily create when `create` (define semantics).
+    const loadOrCreateExpando = (dDv: number, dExp: number, create: boolean): Instr[] => {
+      const out: Instr[] = [
+        { op: "local.get", index: dDv },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: dynIdx, fieldIdx: 4 },
+        { op: "local.set", index: dExp },
+      ];
+      if (create && newPlainObjIdx !== undefined) {
+        out.push({ op: "local.get", index: dExp });
+        out.push({ op: "ref.is_null" });
+        out.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "call", funcIdx: newPlainObjIdx },
+            { op: "local.set", index: dExp },
+            { op: "local.get", index: dDv },
+            { op: "ref.as_non_null" },
+            { op: "local.get", index: dExp },
+            { op: "struct.set", typeIdx: dynIdx, fieldIdx: 4 },
+          ],
+        });
+      }
+      return out;
+    };
+    // §10.1.6.3 pre-check for the expando delegate: a NEW key on a
+    // NON-extensible expando → reject (sentinel). Emits `if (…) nullRet`.
+    const expandoExtensibilityCheck = (dExp: number, dKey: number): Instr[] => {
+      if (hasOwnIdx === undefined || isExtIdx === undefined) return [];
+      return [
+        { op: "local.get", index: dExp },
+        { op: "local.get", index: dKey },
+        { op: "call", funcIdx: hasOwnIdx },
+        { op: "i32.eqz" },
+        { op: "local.get", index: dExp },
+        { op: "call", funcIdx: isExtIdx },
+        { op: "i32.eqz" },
+        { op: "i32.and" },
+        { op: "if", blockType: { kind: "empty" }, then: [...nullRet] },
+      ];
+    };
+
+    // __getOwnPropertyDescriptor(obj, key) -> externref (§10.4.5.1):
+    // canonical index → valid: fresh data descriptor {value, w:T, e:T, c:T};
+    // invalid: undefined. Ordinary key → expando read-back (or undefined).
+    const gopdFn = findFn("__getOwnPropertyDescriptor");
+    if (
+      gopdFn &&
+      gopdIdx !== undefined &&
+      newPlainObjIdx !== undefined &&
+      boxBoolIdx !== undefined &&
+      externSetIdx !== undefined
+    ) {
+      const inner: Instr[] = [];
+      const { dDv, dKey, dN, dExp } = pushDvKeyPreamble(gopdFn, 2, inner);
+      const gDesc = 2 + gopdFn.locals.length;
+      gopdFn.locals.push({ name: "__tad_desc", type: { kind: "externref" } });
+      const boolProp = (name: string): Instr[] => [
+        { op: "local.get", index: gDesc },
+        ...keyExtern(name),
+        { op: "i32.const", value: 1 },
+        { op: "call", funcIdx: boxBoolIdx },
+        { op: "call", funcIdx: externSetIdx },
+      ];
+      inner.push(...keyIsStringCanonical(dKey, dN));
+      inner.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: dN },
+          { op: "call", funcIdx: helpers.hasIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "call", funcIdx: newPlainObjIdx },
+              { op: "local.set", index: gDesc },
+              { op: "local.get", index: gDesc },
+              ...keyExtern("value"),
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: dN },
+              { op: "call", funcIdx: helpers.getElem },
+              { op: "call", funcIdx: externSetIdx },
+              ...boolProp("writable"),
+              ...boolProp("enumerable"),
+              ...boolProp("configurable"),
+              { op: "local.get", index: gDesc },
+              { op: "return" },
+            ],
+          },
+          ...undef(),
+          { op: "return" },
+        ],
+      });
+      inner.push(...loadOrCreateExpando(dDv, dExp, false));
+      inner.push({ op: "local.get", index: dExp });
+      inner.push({ op: "ref.is_null" });
+      inner.push({ op: "if", blockType: { kind: "empty" }, then: [...undef(), { op: "return" }] });
+      inner.push({ op: "local.get", index: dExp });
+      inner.push({ op: "local.get", index: dKey });
+      inner.push({ op: "call", funcIdx: gopdIdx });
+      inner.push({ op: "return" });
+      gopdFn.body.unshift(
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "ref.test", typeIdx: dynIdx },
+        { op: "if", blockType: { kind: "empty" }, then: inner },
+      );
+    }
+
+    // __defineProperty_value(obj, key, value, flagsF64) -> externref
+    // (§10.4.5.3, data descriptor): canonical index → validate (invalid index /
+    // accessor bit / any attribute EXPLICITLY false → sentinel-reject), then
+    // write the element when [[Value]] is present. Ordinary key → expando.
+    // Host flag bits (computeRuntimeFlags): 0=w 1=e 2=c 3=wSpec 4=eSpec
+    // 5=cSpec 6=accessor 7=hasValue.
+    const dpvFn = findFn("__defineProperty_value");
+    if (dpvFn && dpvIdx !== undefined && newPlainObjIdx !== undefined) {
+      const inner: Instr[] = [];
+      const { dDv, dKey, dN, dExp } = pushDvKeyPreamble(dpvFn, 4, inner);
+      const dFlags = 4 + dpvFn.locals.length;
+      dpvFn.locals.push({ name: "__tad_flags", type: { kind: "i32" } });
+      const flagBit = (bit: number): Instr[] => [
+        { op: "local.get", index: dFlags },
+        { op: "i32.const", value: bit },
+        { op: "i32.and" },
+        { op: "i32.const", value: 0 },
+        { op: "i32.ne" },
+      ];
+      const rejectIfSpecifiedFalse = (specBit: number, valueBit: number): Instr[] => [
+        ...flagBit(specBit),
+        ...flagBit(valueBit),
+        { op: "i32.eqz" },
+        { op: "i32.and" },
+        { op: "if", blockType: { kind: "empty" }, then: [...nullRet] },
+      ];
+      inner.push(...keyIsStringCanonical(dKey, dN));
+      inner.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 3 },
+          { op: "i32.trunc_sat_f64_s" },
+          { op: "local.set", index: dFlags },
+          // i. IsValidIntegerIndex (detach/OOB/-0/non-integral) → reject.
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: dN },
+          { op: "call", funcIdx: helpers.hasIdx },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: [...nullRet] },
+          // ii. accessor descriptor → reject.
+          ...flagBit(1 << 6),
+          { op: "if", blockType: { kind: "empty" }, then: [...nullRet] },
+          // iii–v. configurable/enumerable/writable specified-and-false → reject.
+          ...rejectIfSpecifiedFalse(1 << 5, 1 << 2),
+          ...rejectIfSpecifiedFalse(1 << 4, 1 << 1),
+          ...rejectIfSpecifiedFalse(1 << 3, 1 << 0),
+          // vi. [[Value]] present → IntegerIndexedElementSet.
+          ...flagBit(1 << 7),
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: dN },
+              { op: "local.get", index: 2 },
+              { op: "call", funcIdx: helpers.setElem },
+              { op: "drop" },
+            ],
+          },
+          { op: "local.get", index: 0 },
+          { op: "return" },
+        ],
+      });
+      inner.push(...loadOrCreateExpando(dDv, dExp, true));
+      inner.push(...expandoExtensibilityCheck(dExp, dKey));
+      inner.push({ op: "local.get", index: dExp });
+      inner.push({ op: "local.get", index: dKey });
+      inner.push({ op: "local.get", index: 2 });
+      inner.push({ op: "local.get", index: 3 });
+      inner.push({ op: "call", funcIdx: dpvIdx });
+      inner.push({ op: "drop" });
+      inner.push({ op: "local.get", index: 0 });
+      inner.push({ op: "return" });
+      dpvFn.body.unshift(
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "ref.test", typeIdx: dynIdx },
+        { op: "if", blockType: { kind: "empty" }, then: inner },
+      );
+    }
+
+    // __defineProperty_accessor(obj, key, get, set, flagsF64) -> externref:
+    // an accessor descriptor on a canonical index is ALWAYS rejected
+    // (§10.4.5.3 step ii); ordinary keys delegate to the expando.
+    const dpaFn = findFn("__defineProperty_accessor");
+    if (dpaFn && dpaIdx !== undefined && newPlainObjIdx !== undefined) {
+      const inner: Instr[] = [];
+      const { dDv, dKey, dN, dExp } = pushDvKeyPreamble(dpaFn, 5, inner);
+      inner.push(...keyIsStringCanonical(dKey, dN));
+      inner.push({ op: "if", blockType: { kind: "empty" }, then: [...nullRet] });
+      inner.push(...loadOrCreateExpando(dDv, dExp, true));
+      inner.push(...expandoExtensibilityCheck(dExp, dKey));
+      inner.push({ op: "local.get", index: dExp });
+      inner.push({ op: "local.get", index: dKey });
+      inner.push({ op: "local.get", index: 2 });
+      inner.push({ op: "local.get", index: 3 });
+      inner.push({ op: "local.get", index: 4 });
+      inner.push({ op: "call", funcIdx: dpaIdx });
+      inner.push({ op: "drop" });
+      inner.push({ op: "local.get", index: 0 });
+      inner.push({ op: "return" });
+      dpaFn.body.unshift(
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "ref.test", typeIdx: dynIdx },
+        { op: "if", blockType: { kind: "empty" }, then: inner },
+      );
+    }
+
+    // __object_preventExtensions(obj) -> externref: the state lives on the
+    // (lazily-created) expando; identity-preserving return of the view.
+    const pxFn = findFn("__object_preventExtensions");
+    if (pxFn && preventExtIdx !== undefined && newPlainObjIdx !== undefined) {
+      const inner: Instr[] = [];
+      const base = 1 + pxFn.locals.length;
+      const pDv = base;
+      const pExp = base + 1;
+      pxFn.locals.push(
+        { name: "__tad_dv", type: { kind: "ref_null", typeIdx: dynIdx } },
+        { name: "__tad_exp", type: { kind: "externref" } },
+      );
+      inner.push({ op: "local.get", index: 0 });
+      inner.push({ op: "any.convert_extern" });
+      inner.push({ op: "ref.cast", typeIdx: dynIdx });
+      inner.push({ op: "local.set", index: pDv });
+      inner.push(...loadOrCreateExpando(pDv, pExp, true));
+      inner.push({ op: "local.get", index: pExp });
+      inner.push({ op: "call", funcIdx: preventExtIdx });
+      inner.push({ op: "drop" });
+      inner.push({ op: "local.get", index: 0 });
+      inner.push({ op: "return" });
+      pxFn.body.unshift(
+        { op: "local.get", index: 0 },
+        { op: "any.convert_extern" },
+        { op: "ref.test", typeIdx: dynIdx },
+        { op: "if", blockType: { kind: "empty" }, then: inner },
+      );
+    }
   }
 }

--- a/tests/issue-3177.test.ts
+++ b/tests/issue-3177.test.ts
@@ -326,6 +326,130 @@ describe("#3177 slice 3 — proto identity, without-new TypeError, isExtensible"
   });
 });
 
+describe("#3177 slice 4 — descriptor MOP arms (§10.4.5.1/.3) + expando side-table", () => {
+  it("Reflect.defineProperty on a valid index writes the element and returns true", async () => {
+    expect(
+      await run(
+        `const r: any = Reflect.defineProperty(s, "0", { value: 9, writable: true, enumerable: true, configurable: true }); const v: any = s[0]; return (r === true && v === 9) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty index with writable:false → false (§10.4.5.3 v)", async () => {
+    expect(
+      await run(
+        `const r: any = Reflect.defineProperty(s, "0", { value: 9, writable: false }); return r === false ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Object.defineProperty index with writable:false → TypeError (§20.1.2.4 step 3)", async () => {
+    expect(
+      await run(
+        `try { Object.defineProperty(s, "0", { value: 9, writable: false }); return 0; } catch (e) { return (e as any) instanceof TypeError ? 1 : 2; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty OOB index → false (IsValidIntegerIndex)", async () => {
+    expect(await run(`const r: any = Reflect.defineProperty(s, "5", { value: 9 }); return r === false ? 1 : 0;`)).toBe(
+      1,
+    );
+  });
+
+  it("defineProperty a NON-index key lands on the expando and reads back via [[Get]]", async () => {
+    expect(
+      await run(
+        `Object.defineProperty(s, "foo", { value: 42 }); const v: any = (s as any).foo; return v === 42 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("symbol-keyed [[Set]]/[[Get]] round-trips through the expando", async () => {
+    expect(
+      await run(
+        `const sym: any = Symbol("k"); s[sym] = "test262"; const v: any = s[sym]; return v === "test262" ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("[[Delete]] of an expando prop → true and the prop is gone", async () => {
+    expect(
+      await run(
+        `s.bar = 7; const d: any = delete s.bar; const v: any = s.bar; return (d === true && v === undefined) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("[[HasProperty]] sees expando props", async () => {
+    expect(await run(`s.baz = 1; return Reflect.has(s, "baz") ? 1 : 0;`)).toBe(1);
+  });
+
+  it("gOPD on a valid index → {value, writable:true, enumerable:true, configurable:true}", async () => {
+    expect(
+      await run(
+        `const d: any = Object.getOwnPropertyDescriptor(s, "0"); return (d.value === 42 && d.writable === true && d.enumerable === true && d.configurable === true) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("gOPD on an OOB / '-0' key → undefined", async () => {
+    expect(
+      await run(
+        `const a: any = Object.getOwnPropertyDescriptor(s, "5"); const b: any = Object.getOwnPropertyDescriptor(s, "-0"); return (a === undefined && b === undefined) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("gOPD reads back an expando prop's descriptor", async () => {
+    expect(
+      await run(
+        `Object.defineProperty(s, "foo", { value: 42 }); const d: any = Object.getOwnPropertyDescriptor(s, "foo"); return d.value === 42 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("accessor descriptor on a canonical index → TypeError via Object.defineProperty (§10.4.5.3 ii)", async () => {
+    expect(
+      await run(
+        `try { Object.defineProperty(s, "0", { get: function(): number { return 1; } }); return 0; } catch (e) { return (e as any) instanceof TypeError ? 1 : 2; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("preventExtensions(view) → isExtensible false; new expando define rejected", async () => {
+    expect(
+      await run(
+        `Object.preventExtensions(s); const x = Object.isExtensible(s); const r: any = Reflect.defineProperty(s, "nope", { value: 1 }); return (!x && r === false) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("detached buffer: index define → TypeError (IsValidIntegerIndex step 2)", async () => {
+    expect(
+      await run(
+        `const b: any = s.buffer; (b as any).__detached__ = true; try { Object.defineProperty(s, "0", { value: 8 }); return 0; } catch (e) { return (e as any) instanceof TypeError ? 1 : 2; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("guard: plain-object defineProperty/gOPD unchanged", async () => {
+    expect(
+      await run(
+        `const o: any = {}; Object.defineProperty(o, "x", { value: 5, writable: true, enumerable: true, configurable: true }); const d: any = Object.getOwnPropertyDescriptor(o, "x"); return (o.x === 5 && d.value === 5) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("guard: Reflect.defineProperty on a plain object still returns true", async () => {
+    expect(
+      await run(
+        `const o: any = {}; const r: any = Reflect.defineProperty(o, "x", { value: 1 }); return r === true ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+});
+
 describe("#3177 — non-view receivers keep their behavior (arms fall through)", () => {
   it("plain any-typed array element/length are unchanged", async () => {
     // NOTE: `Object.keys(<any-typed plain array>)` returns [] on main (the


### PR DESCRIPTION
## Summary

Slice 4 of #3177 (follows merged slices 1/#3118, 2/#3127, 3/#3142): the **§10.4.5.1/.3 descriptor MOP arms** over dyn-view receivers plus the **expando side-table** for non-index own props — the `internals/DefineOwnProperty` + `GetOwnProperty` buckets and the ordinary-key families across Get/Set/Delete/HasProperty.

**TypedArrayConstructors directory sweep (411 non-bigint files, standalone): 154 → 196 pass (+42), 0 regressions** — every before/after diff line is fail→pass. Cumulative #3177 across four slices: **124 → 196** in this tree.

### What changed

1. **Expando side-table** (`registry/types.ts`, `dataview-native.ts`): `$__ta_dyn_view` gains an APPEND-ONLY 5th field `expando (mut externref)` — a lazily-created `$Object` carrying every non-index own prop + the preventExtensions state. `externref` (not `ref null $Object`) so the dyn-view type registration has no `$Object` dependency (`$__bound_fn` precedent). The three creation sites push a null initializer; existing field indices and the `$__vec_base` supertype prefix stay valid.
2. **Ordinary-key delegation** (`ta-dyn-mop.ts` slice-1 arm miss paths): non-canonical string keys AND symbol keys now delegate to the expando by **recursing the same native** — the expando is a `$Object`, so the dyn-view arm declines and the ordinary body runs (no new machinery). get/has/delete keep legacy miss results without an expando; set/reflect_set lazily create it. This alone flipped the `key-is-not-numeric-index` / `key-is-not-canonical-index` / `detached-buffer-key-is-*` / `key-is-symbol` families across four internals buckets (§10.4.5 "Otherwise, return Ordinary*").
3. **§10.4.5.1 [[GetOwnProperty]]**: `__getOwnPropertyDescriptor` dyn-view arm — valid canonical index → fresh `{value, writable:true, enumerable:true, configurable:true}` data descriptor; invalid/OOB/-0/detached → undefined; ordinary keys → expando read-back.
4. **§10.4.5.3 [[DefineOwnProperty]]**: dyn-view arms in `__defineProperty_value` (invalid index / accessor bit / attribute **specified-and-false** — read from the host flags' specified-bits — → reject; else element write via the shared codec) and `__defineProperty_accessor` (canonical index → always reject). **Rejection channel:** the natives never return null on ordinary paths, so a `ref.null.extern` **sentinel** signals the spec `false`: `__obj_define_from_desc` threads it out, `Reflect.defineProperty`'s existing `__is_truthy` reads it as `false`, and the compile-time `Object.defineProperty` sites convert it to the §20.1.2.4 TypeError (new shared `emitDefinePropertyRejectionThrow`, standalone/wasi-gated). This serves BOTH corpus shapes: `…-throws.js` (Object → TypeError) and the Reflect `→ false` twins — the pre-existing throw-only channel couldn't distinguish them.
5. **preventExtensions/isExtensible** ride the expando's ordinary flags; a NEW key on a non-extensible expando pre-checks and rejects with the sentinel (`this-is-not-extensible`: Reflect → false).

### #2984 coordination

Per the issue's anti-bloat directive the arms EXTEND the #2984/#2965 builtin-descriptor natives — no parallel descriptor path. No in-flight #2984 PR existed at implementation time (its GOPD builtin-key slice landed earlier; verified via `gh pr list`).

### Validation

- Sweep diff vs slice-3 state: +42 all fail→pass, 0 regressions; `internals/DefineOwnProperty` 1 → 24/28, `GetOwnProperty` 1 → 5/12 (rest: #2940-vacuous rows + one symbol-descriptor read-back residual)
- **Ordinary-object blast radius** vs a clean origin/main baseline worktree: `built-ins/Reflect/defineProperty` identical (9/12), `built-ins/Object/defineProperty` **+1 bonus flip** (coerced-P-shrink.js), 0 regressions
- `tests/issue-3177.test.ts`: 61/61 (16 new slice-4 tests incl. plain-object guards)
- Related suites green: 2186/2190/2872/3054*/3057/3058 + 1629-S6/1629b (descriptor lineage), 117 tests
- `check:loc-budget` (granted via the issue allow-list: ta-dyn-mop owns the arms; god-file growth is the 3 struct.new null-pushes, the sentinel thread-out, and the shared rejection-throw helper at its owning call sites), `check:coercion-sites`, prettier, tsc: green

### Known residuals (documented in the issue file)

Symbol-key descriptor READ-BACK (ordinary $Object gOPD is string-keyed); `desc-value-throws` (`__unbox_number` doesn't invoke valueOf — slice-2 finding); Reflect-on-sealed-ORDINARY-object still throws (pre-existing S4 behavior, needs the ordinary path moved to the sentinel discipline — follow-on); `__object_keys` expando enumeration.

Issue: plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md (stays `in-progress` — remaining: from/of statics, -sab representation, BigInt (#1349-gated), Reflect.construct (#1472 Phase C))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb