### PR TITLE
fix(#3320): update stale #1888 refuse-loud guardrails to the #2984 runtime-refusal-closure contract

### DIFF
--- a/plan/issues/3320-1888-guardrails-refusal-closures.md
+++ b/plan/issues/3320-1888-guardrails-refusal-closures.md
@@ -1,0 +1,73 @@
+---
+id: 3320
+title: "stale #1888 S6/S6-b guardrails: builtin value-read compile-refusal contract was retired by #2984 (runtime refusal closures) — update to the current contract"
+status: done
+assignee: ttraenkler/fable-3316
+completed: 2026-07-16
+sprint: current
+created: 2026-07-16
+priority: medium
+horizon: s
+feasibility: easy
+model: fable
+task_type: fix
+area: tests
+goal: standalone-mode
+related: [1888, 1907, 2984, 2933, 3319]
+origin: "found during #3319 validation as 2 pre-existing failures (verified failing on base); lead-approved follow-up (fable-3316, 2026-07-16)"
+---
+
+# #3320 — update the two stale #1888 refuse-loud guardrails
+
+## Problem
+
+Two guardrail tests asserted the OLD contract — unsupported builtin static
+value-reads (`const f: any = Math.max` / `Array.from`) **refuse at compile
+time** with a `#1888 S6` / `#1907` cite:
+
+- `tests/issue-1888-s6c.test.ts > guardrail: unsupported Builtin.method
+value-read still refuses-loud (S6-b lever)`
+- `tests/issue-1888.test.ts > unsupported built-in static value reads refuse
+loud with a #1888 cite`
+
+Both had been failing silently for ~10 days (`expected true to be false` on
+`r.success`) — another instance of the not-in-scoped-CI silent-suite gap
+(#3316's "Not caught by CI" pattern).
+
+## Root cause (bisected 2026-07-16, fable-3316)
+
+**First bad commit: `823479ff` — merge of PR #2851 (#2984
+gopd-ctor-receivers, 2026-07-06).** Deliberate contract change, not a bug:
+`#2984 Phase 2/3` reifies un-wired builtin members as **identity-stable
+closures that throw a catchable error at CALL time** (so gOPD descriptors are
+spec-shaped and `desc.value === <Builtin>.<m>` identity holds) — replacing
+the compile-time refusal the guardrails asserted. Probes on current main:
+`Math.max` value-read is now genuinely native (**graduated** via #2933,
+returns 2 host-free); `Array.from`/`JSON.parse`/`Object.getOwnPropertyNames`
+value-reads compile to valid host-free Wasm and throw catchably at call time;
+`Reflect.ownKeys` works outright.
+
+## Fix (test-only)
+
+Update both guardrails to the CURRENT contract, preserving their original
+spirit (the S6 hazard was `__get_builtin` leakage / invalid Wasm — that must
+still never happen):
+
+- `issue-1888-s6c`: split into (a) `Math.max` graduated-pair positive test
+  (native, host-free, returns 2) and (b) a still-un-wired pair (`JSON.parse`)
+  compiling to valid host-free Wasm that throws catchably at call time.
+- `issue-1888`: `Array.from` value-read compiles host-free + valid, call
+  throws catchably in-module (try/catch returns the sentinel).
+
+No src changes.
+
+## Measured
+
+- `tests/issue-1888*.test.ts`: 23/23 (was 21/23; the 2 failures verified
+  pre-existing on base at bb239d65 → pass, 026f40f771 → fail bracketing).
+
+## Residual (noted, not fixed here)
+
+The runtime refusal-closure throw message does not cite an issue number
+(probed: no `#1888`/`#1907`/"unsupport" substring). If loud attribution
+matters, a follow-up could thread a cite into the refusal body message.

--- a/tests/issue-1888-s6c.test.ts
+++ b/tests/issue-1888-s6c.test.ts
@@ -80,13 +80,39 @@ describe("#1888 S6-c — Math/Number constants reach native f64.const under stan
     expect((instance.exports as NumExports).run()).toBe(1);
   });
 
-  it("guardrail: unsupported Builtin.method value-read still refuses-loud (S6-b lever)", async () => {
+  // (#3320) The S6-b compile-refusal contract for unsupported Builtin.method
+  // value-reads was deliberately retired by #2984 (PR #2851, 2026-07-06):
+  // un-wired members now reify as IDENTITY-STABLE closures that throw a
+  // catchable error at CALL time (so gOPD descriptors are spec-shaped and
+  // `desc.value === <Builtin>.<m>` holds). Math.max itself then graduated to
+  // a genuine native variadic value closure (#2933). The two guardrails below
+  // assert the CURRENT contract: (a) a graduated pair computes natively,
+  // (b) a still-un-wired pair compiles to VALID host-free Wasm and throws
+  // catchably at call time — never routes through __get_builtin or emits
+  // invalid Wasm (the original S6-b hazard).
+  it("graduated Builtin.method value-read (Math.max, #2933) computes natively", async () => {
     const r = await compile(`export function run(): number { const f: any = Math.max; return f(1, 2); }`, {
       target: "standalone",
     });
-    // #1907 only enables selected static method values; unsupported pairs still
-    // refuse cleanly instead of routing through __get_builtin or invalid Wasm.
-    expect(r.success).toBe(false);
-    expect(r.errors.map((e) => e.message).join("\n")).toMatch(/#1907|#1888 S6-b/);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(2);
+  });
+
+  it("guardrail: un-wired Builtin.method value-read is a valid host-free module that throws catchably at call time (#2984 contract)", async () => {
+    const r = await compile(
+      `export function run(): number {
+  const f: any = JSON.parse;
+  try { f("1"); return 0; } catch (e) { return 1; }
+}`,
+      { target: "standalone" },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    assertNoHostObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as NumExports).run()).toBe(1);
   });
 });

--- a/tests/issue-1888.test.ts
+++ b/tests/issue-1888.test.ts
@@ -87,18 +87,28 @@ describe("#1888 S6 — standalone built-in static globals", () => {
     expect(value).toBe(1);
   });
 
-  it("unsupported built-in static value reads refuse loud with a #1888 cite", async () => {
+  // (#3320) The compile-refusal contract for un-wired built-in static
+  // value-reads was deliberately retired by #2984 (PR #2851, 2026-07-06):
+  // un-wired members reify as IDENTITY-STABLE closures that throw a catchable
+  // error at CALL time (spec-shaped gOPD descriptors, `desc.value === m`
+  // identity). The guardrail now asserts the CURRENT contract: the module
+  // compiles to VALID host-free Wasm (the original #1888 S6 hazard —
+  // `__get_builtin` leakage / invalid Wasm — must still never happen) and the
+  // call throws catchably instead of computing a wrong result silently.
+  it("un-wired built-in static value read compiles host-free and throws catchably at call time (#2984 contract)", async () => {
     const r = await compile(
       `
         export function run(): number {
           const f: any = Array.from;
-          return f([1]).length;
+          try { f([1]); return 0; } catch (e) { return 1; }
         }
       `,
       { target: "standalone" },
     );
-    expect(r.success).toBe(false);
-    expect(r.errors.map((e) => e.message).join("\n")).toMatch(/#1888 S6/);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
     assertNoStandaloneObjectImports(r.imports);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Test-only. The two #1888 refuse-loud guardrails (`issue-1888.test.ts`, `issue-1888-s6c.test.ts`) asserted that unsupported builtin static value-reads (`const f: any = Math.max` / `Array.from`) fail compilation with a `#1888 S6`/`#1907` cite. They had been failing silently for ~10 days — same not-in-scoped-CI gap class as #3316.

**Bisected** (bracket `bb239d65` pass → `026f40f771` fail): first bad commit `823479ff` — merge of PR #2851 (#2984 gopd-ctor-receivers). A **deliberate contract change**, not a bug: #2984 reifies un-wired builtin members as identity-stable closures that throw a catchable error at CALL time (spec-shaped gOPD descriptors, `desc.value === <Builtin>.<m>` identity). `Math.max` subsequently graduated to a genuine native variadic value closure (#2933, merged today) — probe: returns 2 host-free.

## Change

Updated both guardrails to the current contract while preserving the original S6 hazard checks (no `__get_builtin` leakage, valid host-free Wasm):
- `issue-1888-s6c`: split into a `Math.max` graduated-pair positive test (native, returns 2) and a still-un-wired pair (`JSON.parse`) that compiles to valid host-free Wasm and throws catchably at call time.
- `issue-1888`: `Array.from` value-read compiles host-free + valid; in-module try/catch confirms the catchable call-time throw.

## Measured

- `tests/issue-1888*.test.ts`: **23/23** (was 21/23; both failures verified pre-existing on base).
- No src changes; `check-loc-budget` net +0; `check:issue-ids:against-main` OK.

Residual (noted in the issue file): the runtime refusal-closure throw message carries no issue cite — follow-up candidate if loud attribution matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb