### PR TITLE
feat(ir): #3142 slice 1 — module-level claim assessment + module-level ir-fallbacks bucket (gate G3)

### DIFF
--- a/plan/issues/3142-ir-module-level-statement-adoption.md
+++ b/plan/issues/3142-ir-module-level-statement-adoption.md
@@ -17,6 +17,12 @@ language_feature: compiler-internals
 goal: ir-full-coverage
 related: [3090, 2855, 2856]
 origin: "plan/bloat-reduction-battle-plan.md slice 6; gate G3 in plan/log/3090-phase0-legacy-delete-list.md"
+# Slice 1 adds the module-init claim assessment to the selector; it must live
+# in select.ts because it reads the module-level isPhase1* walk state
+# (earlyReturnLoopDepth / barrier / forInitLeakedNames) that is deliberately
+# not exported (see the threading rationale on currentHostGlobalResolver).
+loc-budget-allow:
+  - src/ir/select.ts
 ---
 
 # #3142 — IR adoption for module-level statements (gate G3)

--- a/plan/issues/3142-ir-module-level-statement-adoption.md
+++ b/plan/issues/3142-ir-module-level-statement-adoption.md
@@ -1,10 +1,12 @@
 ---
 id: 3142
 title: "IR module-level (top-level statement) adoption — clears gate G3 of the legacy-frontend retirement"
-status: ready
-sprint: Backlog
+status: in-progress
+assignee: ttraenkler/fable-alpha
+sprint: current
 created: 2026-07-11
-updated: 2026-07-11
+updated: 2026-07-16
+note: "Slice 1 (selector + telemetry) landing via PR; Slice 2 (lowering + __module_init patch) remains — issue stays in-progress until Slice 2."
 priority: high
 horizon: l
 feasibility: hard
@@ -47,3 +49,39 @@ statement handler can be deleted until the IR can own module-level lowering.
   module-init through the IR (verifiable via `trackFallbacks`).
 - ir-fallback gate has a `module-level` bucket with a corpus baseline.
 - Equivalence suite + merge_group net ≥ 0.
+
+## Slice plan (fable-alpha, 2026-07-16)
+
+Precedent: #1370 Phase A landed the class-member claim unit **selector-only**
+first, then wired integration in Phase B. Same sequencing here:
+
+- **Slice 1 (this PR) — selector assessment + `module-level` telemetry bucket.**
+  - `src/ir/select.ts`: new `IrModuleInitAssessment` on `IrSelection`
+    (`moduleInit?`), populated under `trackFallbacks` only (production
+    compiles byte-identical — `STRICT_IR_REASONS` is empty, so
+    `trackFallbacks` is off outside the gate/tests). The assessment takes the
+    top-level statement population (everything except function/class/type/
+    import/export declarations), wraps it in a synthetic void
+    `<module-init>` FunctionDeclaration, and runs the EXISTING per-kind
+    rules: `isPhase1BodyStatement` per statement (constructor-body
+    precedent: no tail requirement, early-return barrier armed), then the
+    same external-call / call-graph-closure gate as Step 2 via
+    `buildLocalCallGraph` over `declByName ∪ {<module-init>}` — every local
+    callee must be in the FINAL claimed set. Rejection reasons reuse
+    `IrFallbackReason` per the architect plan.
+  - `scripts/check-ir-fallbacks.ts`: new `moduleLevel` baseline section
+    (rejection-reason histogram over corpus modules) gated
+    must-not-increase, plus informational claimable/empty counts;
+    back-compat with baselines lacking the field (info-only until
+    refreshed).
+  - `scripts/ir-fallback-baseline.json`: corpus baseline for the new bucket.
+  - `tests/issue-3142.test.ts`: unit tests over `planIrCompilation`
+    (empty population, claimable init, body-shape reject, external-call,
+    call-graph-closure).
+- **Slice 2 (follow-up) — lowering + integration.** Build the synthetic
+  module-init through from-ast/lower with a module-scope outermost LowerCtx
+  (bindings → symbolic `global.get/set`, reusing the existing global/export
+  machinery in `declarations.ts`), patch the `__module_init` slot in
+  `compileIrPathFunctions`, and demote whole-module to legacy on any
+  build/verify failure (the existing warning channel). Flip the selector
+  assessment from telemetry-only to claim-feeding.

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -117,6 +117,16 @@ These are the reasons a `FunctionDeclaration` ends up in `mixed` rather
 than `ir-owned`. Driving each unintended bucket to zero promotes the
 relevant kind row above.
 
+**Module-level unit (#3142, gate G3).** Since Slice 1 the selector also
+assesses the top-level statement list as a synthetic `<module-init>` claim
+unit (`IrSelection.moduleInit`, `trackFallbacks` only). Its rejections
+REUSE the reasons below but are baselined separately — the `moduleLevel`
+section of `scripts/ir-fallback-baseline.json` counts one entry per corpus
+MODULE whose module-init unit is not claimable (gated must-not-increase by
+`check:ir-fallbacks`). Slice 2 wires the actual lowering + the
+`__module_init` slot patch; only then do legacy statement handlers become
+per-file deletable (gate G3 in `plan/log/3090-phase0-legacy-delete-list.md`).
+
 | Bucket reason                 | Category   | What promotes a row                                                                                                                                   |
 | ----------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `body-shape-rejected`         | unintended | from-ast.ts handles every statement in the body                                                                                                       |

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -136,6 +136,12 @@ interface Baseline {
   // Optional for backward compatibility with pre-#1923 baselines (treated as
   // all-empty, which is the desired target).
   readonly postClaim?: PostClaimBuckets;
+  // #3142 Slice 1 — module-level (top-level statement) claim rejections,
+  // keyed by rejection reason: one count per corpus MODULE whose module-init
+  // unit is not IR-claimable (`selection.moduleInit.reason != null`).
+  // Optional for backward compatibility: when absent from the committed
+  // baseline the section is reported informationally but not gated.
+  readonly moduleLevel?: Partial<Record<IrFallbackReason, number>>;
 }
 
 function listTsFiles(root: string): string[] {
@@ -161,6 +167,11 @@ async function aggregate(): Promise<{
   unintended: Partial<Record<IrFallbackReason, number>>;
   deferred: Partial<Record<IrFallbackReason, number>>;
   postClaim: PostClaimBuckets;
+  // #3142 Slice 1 — module-level rejection histogram + informational
+  // claimable/empty module counts (not baselined; printed for context).
+  moduleLevel: Partial<Record<IrFallbackReason, number>>;
+  moduleLevelInfo: { claimable: number; empty: number };
+  modulePerFile: Array<{ file: string; status: string }>;
   perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }>;
   // (#2856 Step-1) Per-rejection reject-arm detail for `body-shape-rejected`,
   // populated only when JS2WASM_IR_SHAPE_DIAG=1 (select.ts records it).
@@ -176,6 +187,9 @@ async function aggregate(): Promise<{
   // corpus file (the selector-level `planIrCompilation` below cannot see them
   // — they happen during build/verify/lower AFTER the selector claims).
   const postClaim = emptyPostClaim();
+  const moduleLevel: Partial<Record<IrFallbackReason, number>> = {};
+  const moduleLevelInfo = { claimable: 0, empty: 0 };
+  const modulePerFile: Array<{ file: string; status: string }> = [];
   const perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }> = [];
   const shapeDetails: Array<{ file: string; name: string; detail: string }> = [];
 
@@ -254,6 +268,21 @@ async function aggregate(): Promise<{
     }
     perFile.push({ file: relative(REPO_ROOT, filePath), reasons: fileReasons });
 
+    // #3142 Slice 1 — module-level claim assessment (one verdict per module).
+    if (selection.moduleInit) {
+      const mi = selection.moduleInit;
+      if (mi.reason !== null) {
+        moduleLevel[mi.reason] = (moduleLevel[mi.reason] ?? 0) + 1;
+        modulePerFile.push({ file: relative(REPO_ROOT, filePath), status: `${mi.reason} (${mi.stmtCount} stmts)` });
+      } else if (mi.stmtCount === 0) {
+        moduleLevelInfo.empty += 1;
+        modulePerFile.push({ file: relative(REPO_ROOT, filePath), status: "empty (no module-init statements)" });
+      } else {
+        moduleLevelInfo.claimable += 1;
+        modulePerFile.push({ file: relative(REPO_ROOT, filePath), status: `claimable (${mi.stmtCount} stmts)` });
+      }
+    }
+
     // #1923 — post-claim demotions: compile the file for real and aggregate
     // `irPostClaimErrors` by kind + normalized message class. A compile that
     // throws contributes nothing (same tolerance as the selector pass above).
@@ -268,7 +297,7 @@ async function aggregate(): Promise<{
       // ignore — example-file compile failures are not the gate's concern
     }
   }
-  return { unintended, deferred, postClaim, perFile, shapeDetails };
+  return { unintended, deferred, postClaim, moduleLevel, moduleLevelInfo, modulePerFile, perFile, shapeDetails };
 }
 
 function loadBaseline(): Baseline | undefined {
@@ -361,7 +390,8 @@ async function main(): Promise<void> {
   const verbose = args.has("--verbose");
   const shapeDiag = args.has("--shape-diag");
 
-  const { unintended, deferred, postClaim, perFile, shapeDetails } = await aggregate();
+  const { unintended, deferred, postClaim, moduleLevel, moduleLevelInfo, modulePerFile, perFile, shapeDetails } =
+    await aggregate();
 
   // (#2856 Step-1) `--shape-diag`: print the `body-shape-rejected` reject-arm
   // histogram. Requires `JS2WASM_IR_SHAPE_DIAG=1` in the env (select.ts reads it
@@ -393,18 +423,25 @@ async function main(): Promise<void> {
   }
 
   if (mode === "json") {
-    process.stdout.write(JSON.stringify({ unintended, deferred, postClaim, perFile }, null, 2) + "\n");
+    process.stdout.write(
+      JSON.stringify({ unintended, deferred, postClaim, moduleLevel, moduleLevelInfo, perFile }, null, 2) + "\n",
+    );
     return;
   }
 
   const generated = new Date().toISOString().slice(0, 10);
-  const next: Baseline = { generated, unintended, deferred, postClaim };
+  const next: Baseline = { generated, unintended, deferred, postClaim, moduleLevel };
+
+  // #3142 — one-line context for the module-level section (informational).
+  const moduleLevelSummary = `\nModule-level units: ${moduleLevelInfo.claimable} claimable, ${moduleLevelInfo.empty} empty (declarations-only)\n`;
 
   if (mode === "update") {
     writeFileSync(BASELINE_PATH, JSON.stringify(next, null, 2) + "\n", "utf-8");
     process.stdout.write(`Updated ${relative(REPO_ROOT, BASELINE_PATH)}\n`);
     process.stdout.write(formatTable("Unintended (target = 0)", diffTable({}, unintended).rows));
     process.stdout.write(formatTable("Deferred (informational)", diffTable({}, deferred).rows));
+    process.stdout.write(formatTable("Module-level rejections (#3142; target = 0)", diffTable({}, moduleLevel).rows));
+    process.stdout.write(moduleLevelSummary);
     process.stdout.write(
       formatTable("Post-claim demotions (target = 0)", diffPostClaim(undefined, postClaim).rows) + "\n",
     );
@@ -421,8 +458,21 @@ async function main(): Promise<void> {
   const unDiff = diffTable(baseline.unintended, unintended);
   const defDiff = diffTable(baseline.deferred, deferred);
   const pcDiff = diffPostClaim(baseline.postClaim, postClaim);
+  // #3142 — module-level bucket: gated only once the committed baseline
+  // carries the section (back-compat: older baselines report info-only).
+  const mlGated = baseline.moduleLevel !== undefined;
+  const mlDiff = diffTable(baseline.moduleLevel ?? {}, moduleLevel);
   process.stdout.write(formatTable("Unintended (gated; must not increase)", unDiff.rows));
   process.stdout.write(formatTable("Deferred (informational)", defDiff.rows));
+  process.stdout.write(
+    formatTable(
+      mlGated
+        ? "Module-level rejections (#3142; gated; must not increase)"
+        : "Module-level rejections (#3142; informational — baseline has no section yet)",
+      mlDiff.rows,
+    ),
+  );
+  process.stdout.write(moduleLevelSummary);
   process.stdout.write(formatTable("Post-claim demotions (gated; must not increase)", pcDiff.rows) + "\n");
 
   if (unDiff.anyIncrease) {
@@ -454,6 +504,18 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // #3142 — module-level bucket growth fails once the baseline carries it.
+  if (mlGated && mlDiff.anyIncrease) {
+    process.stderr.write(
+      `\nIR fallback gate: the module-level rejection bucket grew vs. baseline (#3142).\n` +
+        `A corpus module whose top-level statement list was IR-claimable no longer is.\n` +
+        `If the change was intentional, run \`pnpm run check:ir-fallbacks -- --update\` and\n` +
+        `commit the refreshed baseline.\n`,
+    );
+    for (const row of modulePerFile) process.stderr.write(`  ${row.file}: ${row.status}\n`);
+    process.exit(1);
+  }
+
   // #1530 — ratchet policy. When a PR decreases an unintended bucket, the
   // gate writes the lower number back to the committed baseline so the next
   // PR can't silently regress the gain. Decreases are STAGED on disk only;
@@ -471,7 +533,14 @@ async function main(): Promise<void> {
   const totalCur = Object.values(unintended).reduce((a: number, b) => a + (b ?? 0), 0);
   // #1923 — bank post-claim decreases too, so a PR that fixes an IR-path
   // demotion ratchets the bucket down and the next PR can't reintroduce it.
-  const anyDecrease = unDiff.rows.some((r) => r.delta < 0) || pcDiff.rows.some((r) => r.delta < 0);
+  // #3142 — likewise for the module-level bucket (and a baseline that lacks
+  // the section counts as a bankable change so the first ratchet run after
+  // this gate lands writes it).
+  const anyDecrease =
+    unDiff.rows.some((r) => r.delta < 0) ||
+    pcDiff.rows.some((r) => r.delta < 0) ||
+    (mlGated && mlDiff.rows.some((r) => r.delta < 0)) ||
+    !mlGated;
 
   if (mode === "update-on-decrease" && anyDecrease) {
     writeFileSync(BASELINE_PATH, JSON.stringify(next, null, 2) + "\n", "utf-8");
@@ -485,8 +554,12 @@ async function main(): Promise<void> {
 
   // All decreases or equal — silently refresh on local runs is unsafe (would
   // cause main to drift). Just succeed; CI doesn't auto-update either.
-  process.stdout.write("\nIR fallback gate: OK (no unintended/post-claim increases vs. baseline).\n");
-  if (verbose) process.stdout.write(formatPerFile(perFile));
+  process.stdout.write("\nIR fallback gate: OK (no unintended/post-claim/module-level increases vs. baseline).\n");
+  if (verbose) {
+    process.stdout.write(formatPerFile(perFile));
+    process.stdout.write("\nModule-level per-file (#3142):\n");
+    for (const row of modulePerFile) process.stdout.write(`  ${row.file}: ${row.status}\n`);
+  }
 }
 
 main().catch((err) => {

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -261,7 +261,17 @@ const BUCKETS_INTRO = `## Selector buckets (one row = one reason from \`src/ir/s
 
 These are the reasons a \`FunctionDeclaration\` ends up in \`mixed\` rather
 than \`ir-owned\`. Driving each unintended bucket to zero promotes the
-relevant kind row above.`;
+relevant kind row above.
+
+**Module-level unit (#3142, gate G3).** Since Slice 1 the selector also
+assesses the top-level statement list as a synthetic \`<module-init>\` claim
+unit (\`IrSelection.moduleInit\`, \`trackFallbacks\` only). Its rejections
+REUSE the reasons below but are baselined separately — the \`moduleLevel\`
+section of \`scripts/ir-fallback-baseline.json\` counts one entry per corpus
+MODULE whose module-init unit is not claimable (gated must-not-increase by
+\`check:ir-fallbacks\`). Slice 2 wires the actual lowering + the
+\`__module_init\` slot patch; only then do legacy statement handlers become
+per-file deletable (gate G3 in \`plan/log/3090-phase0-legacy-delete-list.md\`).`;
 
 const FOOTER = `## How to update this table
 

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-11",
+  "generated": "2026-07-16",
   "unintended": {
     "body-shape-rejected": 14
   },
@@ -11,5 +11,8 @@
     "verify": {},
     "lower": {},
     "backend-legality": {}
+  },
+  "moduleLevel": {
+    "body-shape-rejected": 2
   }
 }

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -204,6 +204,37 @@ export interface IrSelection {
    *  individually claimed); callers must treat a missing map as "no edge
    *  information" and behave conservatively. */
   readonly localCallees?: ReadonlyMap<string, ReadonlySet<string>>;
+  /** (#3142 Slice 1) Module-level (top-level statement) claim assessment —
+   *  gate G3 of the legacy-frontend retirement. Selector-only for now
+   *  (mirrors #1370 Phase A): the assessment is REPORTED so the
+   *  `check:ir-fallbacks` gate can ratchet a `module-level` bucket, but
+   *  `compileIrPathFunctions` does not yet lower the module-init unit —
+   *  Slice 2 wires the integration. Populated only when
+   *  `IrSelectionOptions.trackFallbacks` is true (production compiles skip
+   *  the extra walk entirely). */
+  readonly moduleInit?: IrModuleInitAssessment;
+}
+
+/**
+ * (#3142 Slice 1) Result of assessing the module-level statement list as a
+ * synthetic IR claim unit (`<module-init>`). The population is every
+ * top-level statement that is not a function / class / type / import /
+ * export declaration — i.e. the statements the legacy path routes into
+ * `__module_init` (approximated syntactically; the legacy collection in
+ * `declarations.ts` additionally drops some side-effect-free forms, which
+ * only makes this assessment conservative, never unsound).
+ */
+export interface IrModuleInitAssessment {
+  /** Number of statements in the module-init population. `0` means the
+   *  module is all declarations — vacuously claimable, nothing to adopt. */
+  readonly stmtCount: number;
+  /** `null` = claimable under the same per-kind rules as function bodies;
+   *  otherwise the rejection reason (reuses `IrFallbackReason`, per the
+   *  architect plan). */
+  readonly reason: IrFallbackReason | null;
+  /** (#2856 Step-1 parity) Reject-arm detail for `body-shape-rejected`,
+   *  populated only when `JS2WASM_IR_SHAPE_DIAG=1`. */
+  readonly detail?: string;
 }
 
 export interface IrSelectionOptions {
@@ -551,10 +582,13 @@ export function planIrCompilation(
     const fallbacks: IrFallback[] = [];
     for (const [name, reason] of fallbackReasons) fallbacks.push({ name, reason, detail: fallbackDetails.get(name) });
     for (let i = 0; i < unnamedCount; i++) fallbacks.push({ name: `<unnamed:${i}>`, reason: "unnamed" });
+    // (#3142 Slice 1) Module-init assessment — no top-level function is
+    // claimed on this path, so any local callee rejects the unit.
+    const moduleInit = assessModuleInit(sourceFile, new Set<string>(), declByName, localClasses);
     if (individuallyClaimedClassMembers.size === 0) {
-      return { funcs: new Set<string>(), fallbacks };
+      return { funcs: new Set<string>(), fallbacks, moduleInit };
     }
-    return { funcs: new Set<string>(), classMembers: individuallyClaimedClassMembers, fallbacks };
+    return { funcs: new Set<string>(), classMembers: individuallyClaimedClassMembers, fallbacks, moduleInit };
   }
 
   // -------------------------------------------------------------------------
@@ -677,9 +711,13 @@ export function planIrCompilation(
   const fallbacks: IrFallback[] = [];
   for (const [name, reason] of fallbackReasons) fallbacks.push({ name, reason, detail: fallbackDetails.get(name) });
   for (let i = 0; i < unnamedCount; i++) fallbacks.push({ name: `<unnamed:${i}>`, reason: "unnamed" });
+  // (#3142 Slice 1) Module-init assessment against the FINAL claimed set —
+  // runs after the Step-2 closure so `call-graph-closure` verdicts match
+  // what Slice 2's lowering will actually be able to link against.
+  const moduleInit = assessModuleInit(sourceFile, claimed, declByName, localClasses);
   return classMembers
-    ? { funcs: claimed, classMembers, fallbacks, localCallees: callees }
-    : { funcs: claimed, fallbacks, localCallees: callees };
+    ? { funcs: claimed, classMembers, fallbacks, localCallees: callees, moduleInit }
+    : { funcs: claimed, fallbacks, localCallees: callees, moduleInit };
 }
 
 // ---------------------------------------------------------------------------
@@ -3086,6 +3124,102 @@ function isPhase1BinaryOp(op: ts.SyntaxKind): boolean {
 // ---------------------------------------------------------------------------
 // Call graph (local edges only)
 // ---------------------------------------------------------------------------
+
+/**
+ * (#3142 Slice 1) Assess the module-level statement list as a synthetic IR
+ * claim unit. See `IrModuleInitAssessment` for the population definition.
+ *
+ * Two gates, mirroring the per-function claim exactly:
+ *   1. **Shape** — every population statement must pass
+ *      `isPhase1BodyStatement` (the constructor-body precedent: the unit is
+ *      void, has no tail requirement, and the early-return barrier is armed
+ *      because a top-level `return` is never claimable). Scope starts empty;
+ *      top-level `var`/`let`/`const` names enter it in document order via
+ *      `isPhase1VarDecl`, so in-order reads of module bindings pass and
+ *      use-before-declaration conservatively rejects.
+ *   2. **Call graph** — run the SAME `buildLocalCallGraph` scan over
+ *      `declByName ∪ {<module-init>}`: an external callee rejects with
+ *      `external-call`; a local callee outside the FINAL claimed set rejects
+ *      with `call-graph-closure` (the unit is lowerable only when every
+ *      callee's signature lives on the IR side of the fence — identical to
+ *      the Step-2 closure for ordinary functions).
+ *
+ * Called only under `trackFallbacks` (telemetry), AFTER every per-function
+ * body walk — so resetting the module-level walk state here mirrors
+ * `whyNotIrClaimable`'s per-subject reset without clobbering anything.
+ */
+function assessModuleInit(
+  sourceFile: ts.SourceFile,
+  claimedFuncs: ReadonlySet<string>,
+  declByName: ReadonlyMap<string, ts.FunctionDeclaration>,
+  localClasses: ReadonlySet<string>,
+): IrModuleInitAssessment {
+  const population: ts.Statement[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (
+      ts.isFunctionDeclaration(stmt) ||
+      ts.isClassDeclaration(stmt) ||
+      ts.isInterfaceDeclaration(stmt) ||
+      ts.isTypeAliasDeclaration(stmt) ||
+      ts.isImportDeclaration(stmt) ||
+      ts.isImportEqualsDeclaration(stmt) ||
+      ts.isExportDeclaration(stmt) ||
+      ts.isExportAssignment(stmt) ||
+      ts.isEmptyStatement(stmt)
+    ) {
+      // Declaration statements are owned by the existing declaration
+      // machinery (`compileDeclarations` / class collection / export glue) —
+      // not module-init work. NOTE: `enum` and `namespace` declarations
+      // deliberately STAY in the population (they generate runtime code) and
+      // reject via the body-shape gate's unhandled-statement arm.
+      continue;
+    }
+    population.push(stmt);
+  }
+  if (population.length === 0) return { stmtCount: 0, reason: null };
+
+  // Gate 1 — shape.
+  if (SHAPE_DIAG_ON) shapeRejectDetail = null;
+  earlyReturnLoopDepth = 0;
+  earlyReturnBarrierDepth = 1;
+  forInitLeakedNames = new Set();
+  currentFnIsGenerator = false;
+  currentFnIsVoidReturn = true;
+  const scope = new Set<string>();
+  for (const stmt of population) {
+    if (!isPhase1BodyStatement(stmt, scope, localClasses)) {
+      const detail = SHAPE_DIAG_ON ? (takeShapeRejectDetail() ?? "unattributed-arm:helper-internal") : undefined;
+      return { stmtCount: population.length, reason: "body-shape-rejected", detail };
+    }
+  }
+
+  // Gate 2 — call graph. The synthetic wrapper reuses `buildLocalCallGraph`
+  // verbatim (zero parity drift with the Step-2 scan); factory nodes are
+  // only ever walked downward via `forEachChild`, so the missing
+  // parent/position info on the wrapper is inert.
+  const syntheticName = "<module-init>";
+  const synthetic = ts.factory.createFunctionDeclaration(
+    /* modifiers */ undefined,
+    /* asteriskToken */ undefined,
+    syntheticName,
+    /* typeParameters */ undefined,
+    /* parameters */ [],
+    /* type */ undefined,
+    ts.factory.createBlock(population, /* multiLine */ true),
+  );
+  const decls = new Map(declByName);
+  decls.set(syntheticName, synthetic);
+  const graph = buildLocalCallGraph(decls, localClasses);
+  if (graph.hasExternalCall.has(syntheticName)) {
+    return { stmtCount: population.length, reason: "external-call" };
+  }
+  for (const callee of graph.callees.get(syntheticName) ?? []) {
+    if (!claimedFuncs.has(callee)) {
+      return { stmtCount: population.length, reason: "call-graph-closure" };
+    }
+  }
+  return { stmtCount: population.length, reason: null };
+}
 
 function buildLocalCallGraph(
   decls: ReadonlyMap<string, ts.FunctionDeclaration>,

--- a/tests/issue-3142.test.ts
+++ b/tests/issue-3142.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3142 Slice 1 — module-level (top-level statement) claim assessment.
+//
+// The selector now reports an `IrModuleInitAssessment` on `IrSelection`
+// (`moduleInit`) when `trackFallbacks` is on: the top-level statement
+// population is shape-checked with the SAME per-kind rules as a claimed
+// function body (constructor-body precedent — void unit, no tail
+// requirement, early-return barrier armed), then gated through the same
+// external-call / call-graph-closure logic as Step 2.
+//
+// Slice 1 is selector-only (mirrors #1370 Phase A): nothing consumes the
+// assessment in codegen yet — these tests pin the selector verdicts and the
+// telemetry contract so Slice 2 (lowering + `__module_init` patch) can flip
+// it to claim-feeding without re-litigating the population definition.
+
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+import { planIrCompilation } from "../src/ir/select.js";
+
+function plan(source: string, trackFallbacks = true) {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.ES2022, /* setParentNodes */ true);
+  return planIrCompilation(sf, { experimentalIR: true, trackFallbacks });
+}
+
+describe("#3142 Slice 1 — module-init claim assessment", () => {
+  it("declarations-only module: vacuously claimable with stmtCount 0", () => {
+    const sel = plan(`
+      function add(a: number, b: number): number { return a + b; }
+      function mul(a: number, b: number): number { return a * b; }
+    `);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.stmtCount).toBe(0);
+    expect(sel.moduleInit!.reason).toBeNull();
+  });
+
+  it("claimable init: var decl + assignment + call to a claimed function", () => {
+    const sel = plan(`
+      function add(a: number, b: number): number { return a + b; }
+      let total: number = 0;
+      total = add(1, 2);
+    `);
+    expect(sel.funcs.has("add")).toBe(true);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.stmtCount).toBe(2);
+    expect(sel.moduleInit!.reason).toBeNull();
+  });
+
+  it("body-shape rejection: a top-level statement kind the IR does not own", () => {
+    // `switch` has no isPhase1BodyStatement arm — the unit must reject with
+    // the same reason bucket a function body would.
+    const sel = plan(`
+      function add(a: number, b: number): number { return a + b; }
+      switch (1) { default: break; }
+    `);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.reason).toBe("body-shape-rejected");
+  });
+
+  it("top-level return rejects (early-return barrier armed)", () => {
+    // A bare top-level `return` is not claimable; the barrier must reject it
+    // rather than treating the void unit like a loop-body early exit.
+    const sel = plan(`
+      function f(a: number): number { return a; }
+      return;
+    `);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.reason).toBe("body-shape-rejected");
+  });
+
+  it("external-call rejection: top-level call to a non-local identifier", () => {
+    const sel = plan(`
+      function f(a: number): number { return a; }
+      parseInt("42");
+    `);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.reason).toBe("external-call");
+  });
+
+  it("call-graph-closure rejection: top-level call to an unclaimed local function", () => {
+    // `g` has unannotated params and no TypeMap is provided, so it is not
+    // individually claimable — the module-init unit calling it must reject
+    // with call-graph-closure, exactly like a claimed function would.
+    const sel = plan(`
+      function g(a): number { return 1; }
+      g(1);
+    `);
+    expect(sel.funcs.has("g")).toBe(false);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.reason).toBe("call-graph-closure");
+  });
+
+  it("not populated without trackFallbacks (production compiles untouched)", () => {
+    const sel = plan(
+      `
+      function add(a: number, b: number): number { return a + b; }
+      let total: number = 0;
+      total = add(1, 2);
+    `,
+      /* trackFallbacks */ false,
+    );
+    expect(sel.moduleInit).toBeUndefined();
+  });
+
+  it("import/export/type declarations are not module-init work", () => {
+    const sel = plan(`
+      export function add(a: number, b: number): number { return a + b; }
+      interface P { x: number }
+      type Q = number;
+      export default add;
+    `);
+    expect(sel.moduleInit).toBeDefined();
+    expect(sel.moduleInit!.stmtCount).toBe(0);
+    expect(sel.moduleInit!.reason).toBeNull();
+  });
+});


### PR DESCRIPTION
Slice 1 of #3142 (IR module-level statement adoption — gate G3 of the legacy-frontend retirement). Selector-only, mirroring the #1370 Phase A precedent.

## What

- **`src/ir/select.ts`**: `planIrCompilation` now assesses the top-level statement population (everything except function/class/type/import/export declarations) as a synthetic `<module-init>` claim unit, under the SAME per-kind rules as function bodies:
  - shape gate: `isPhase1BodyStatement` per statement (constructor-body precedent — void unit, no tail requirement, early-return barrier armed);
  - call gate: the Step-2 `buildLocalCallGraph` scan run over `declByName ∪ {<module-init>}` — external callee → `external-call`, local callee outside the FINAL claimed set → `call-graph-closure`.
  - Reported as `IrSelection.moduleInit` (**`trackFallbacks` only** — `STRICT_IR_REASONS` is empty, so production compiles are untouched; zero codegen change in this PR).
- **`scripts/check-ir-fallbacks.ts`**: new `moduleLevel` baseline section — one count per corpus module whose module-init unit is rejected, keyed by `IrFallbackReason`, gated must-not-increase; informational claimable/empty counts; ratchet (`--update-on-decrease`) banks decreases; back-compat with baselines lacking the section.
- **`scripts/ir-fallback-baseline.json`**: corpus baseline — `body-shape-rejected: 2` (13 corpus modules: 11 declarations-only, 2 rejected, 0 claimable-nonempty yet).
- **`plan/log/ir-adoption.md`** (via `gen-ir-adoption.mjs`): module-level unit documented next to the selector buckets.
- **`tests/issue-3142.test.ts`**: 8 selector tests (empty population, claimable init, body-shape / top-level-return / external-call / call-graph-closure rejections, trackFallbacks gating, declaration filtering).

## Why slice

The issue is L and two-phase by the architect plan; #1370 Phase A landed the class-member claim unit selector-first for the same reason: the measurement + population definition is independently reviewable and gives the ratchet a baseline before any lowering lands. Slice 2 (follow-up) builds the unit through from-ast/lower with a module-scope LowerCtx (bindings → symbolic globals, reusing the `declarations.ts` export machinery) and patches the `__module_init` slot. Issue stays `in-progress` until Slice 2.

## Validation

- `tsc --noEmit` clean; biome lint + prettier clean.
- `check:ir-fallbacks` gate + `gen-ir-adoption --check` pass; all existing buckets delta 0.
- Neighboring selector suites green: issue-1182 / issue-1169g / issue-1169n (73 tests).
- Production compile paths byte-identical (assessment only runs under `trackFallbacks`).

Refs #3142, #3090 (gate G3), #2855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8