### PR TITLE
feat(#745): S2 — union locals adopt $AnyValue carrier behind opt-in unionAnyRep flag

### DIFF
--- a/plan/issues/745-tagged-union-representation-to-replace.md
+++ b/plan/issues/745-tagged-union-representation-to-replace.md
@@ -252,3 +252,46 @@ full CI/merge_group only (never scoped sweeps).
 - **#743/#744** (whole-program analysis / monomorphization, Backlog):
   complementary optimizations, NOT dependencies — TS checker union types
   suffice to identify candidates.
+
+## S2 landed (2026-07-16, fable-gamma) — opt-in mapping + measured consumer gap-list
+
+S2 shipped as an **opt-in** `unionAnyRep` flag (default OFF, mirroring the
+#2141 `honestAnyBoxing` pattern) rather than lane-default-on, because probing
+the mapping against real consumers measured exactly which ones are not yet
+carrier-agnostic. What landed:
+
+- `isHeterogeneousPrimitiveUnion` (`src/checker/type-mapper.ts`) — the narrow
+  predicate (≥2 distinct kinds among number/string/boolean after nullish
+  filtering; rejects bigint/symbol/enum/object members and homogeneous or
+  literal unions).
+- The `resolveWasmType` mapping (`src/codegen/index.ts`, union block):
+  qualifying unions → `ref_null $AnyValue` when `ctx.unionAnyRep`.
+- Flag plumbing: `CompileOptions.unionAnyRep` → `CodegenOptions` →
+  `ctx.unionAnyRep` (default false).
+- `tests/issue-745.test.ts` — byte-identity gates (flag-off ≡ legacy on
+  union-bearing input in BOTH lanes; flag-on ≡ flag-off on union-free,
+  nullable, and literal-union input) + flag-on standalone behaviour for
+  narrowed patterns + predicate unit tests.
+
+**Verified working with flag ON (standalone), via existing coercion arms
+alone**: typeof-narrowed reads/writes (`sum += x + 1` under a guard),
+narrowed `.length` string reads, `x === undefined` checks and
+undefined round-trips, cross-kind reassignment in loops. Zero host imports.
+
+**Measured NOT working with flag ON (standalone) — this is the concrete S3
+work list** (probe: `.tmp/probe-745-run.mts`):
+
+| Pattern                                  | Symptom                                               | Likely site                                                                                                                                                      |
+| ---------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x === "done"` (union vs string literal) | wrong result (0)                                      | binary-ops strict-eq path assumes externref union rep; must route `$AnyValue` operands to `__any_strict_eq`                                                      |
+| `if (x)` truthiness                      | wrong result                                          | truthiness coercion lacks a `$AnyValue` tag-switch arm                                                                                                           |
+| `x === true` (boolean\|string)           | wrong result                                          | same strict-eq path, boolean payload                                                                                                                             |
+| `"" + x` / `s + x` string concat         | `illegal cast` trap                                   | concat lowers via native-string cast on the raw ref; needs `$__any_to_string` for `$AnyValue` operands                                                           |
+| union-typed PARAM at call boundary       | Wasm validation error (`struct.get[0] expected type`) | param ValType flips to `$AnyValue` but call-site argument coercion emits the old shape — S4 territory; consider excluding params/returns until S4                |
+| `return k > 0 ? 7 : "neg"` union RETURN  | wrong result                                          | return-path coercion, same S4 territory                                                                                                                          |
+| union → `any` assignment                 | wrong result                                          | any-boundary coercion arm ($AnyValue→externref-any) mis-round-trips in standalone; check `ensureAnyToExternHelper` unwrap vs `extern.convert_any` of the carrier |
+
+S3 (revised): make the strict-eq / truthiness / concat consumers
+carrier-agnostic (first three rows). S4 (unchanged): params/returns +
+boundaries (last three rows). Flip `unionAnyRep` lane-default-on for
+standalone/nativeStrings only after BOTH, validated by full CI/merge_group.

--- a/plan/issues/745-tagged-union-representation-to-replace.md
+++ b/plan/issues/745-tagged-union-representation-to-replace.md
@@ -12,6 +12,13 @@ reasoning_effort: max
 goal: performance
 sprint: current
 related: [1624, 2104, 2105, 2106, 2107, 2141, 2949, 1852, 1471, 1917, 743, 744]
+# S2 flag plumbing (CompileOptions -> CodegenOptions -> ctx) + the resolveWasmType
+# mapping necessarily touch the option/driver files; the predicate itself lives
+# in the subsystem module (src/checker/type-mapper.ts).
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/index.ts
+  - src/compiler.ts
 files:
   src/codegen/index.ts:
     new:

--- a/src/checker/type-mapper.ts
+++ b/src/checker/type-mapper.ts
@@ -415,3 +415,38 @@ export function isHeterogeneousUnion(type: ts.Type, checker: ts.TypeChecker, fas
   const mapped = nonNullish.map((t) => mapTsTypeToWasm(t, checker, fast));
   return !mapped.every((m) => m.kind === mapped[0]!.kind);
 }
+
+/**
+ * (#745 S2) True for a *statically-known heterogeneous primitive* union —
+ * ≥2 distinct primitive kinds among {number, string, boolean} after
+ * filtering null/undefined/void. These are the unions that adopt the
+ * universal `$AnyValue` tagged carrier (see #745 `## Design Decision`)
+ * instead of externref boxing, in the lanes where `ctx.unionAnyRep` is on.
+ *
+ * Deliberately NARROW — returns false (preserving existing externref
+ * behaviour) for:
+ * - homogeneous unions (`"a" | "b"`, `0 | 2`, `true | false`) — these
+ *   already collapse to a single Wasm kind in `mapTsTypeToWasm`;
+ * - unions containing bigint (i64-branded; `$AnyValue` has no i64 payload),
+ *   symbol, enum members, object/class/array/function members, or
+ *   any/unknown — representation for those stays as-is until later slices;
+ * - `T | null/undefined` single-kind nullables (the existing unwrap path).
+ */
+export function isHeterogeneousPrimitiveUnion(type: ts.Type): boolean {
+  if (!type.isUnion()) return false;
+  const nonNullish = type.types.filter(
+    (t) => !(t.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void)),
+  );
+  if (nonNullish.length < 2) return false;
+  const kinds = new Set<string>();
+  for (const t of nonNullish) {
+    // Enum members carry NumberLiteral/StringLiteral flags too — exclude
+    // explicitly so enum-typed unions keep their existing representation.
+    if (t.flags & ts.TypeFlags.EnumLike) return false;
+    if (t.flags & (ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral)) kinds.add("number");
+    else if (t.flags & (ts.TypeFlags.String | ts.TypeFlags.StringLiteral)) kinds.add("string");
+    else if (t.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) kinds.add("boolean");
+    else return false; // non-primitive member → not this slice's shape
+  }
+  return kinds.size >= 2;
+}

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -155,6 +155,9 @@ export function createCodegenContext(
     tupleTypeMap: new Map(),
     fast: options?.fast ?? false,
     nativeStrings,
+    // (#745 S2) union→$AnyValue rep: opt-in while consumers are made
+    // carrier-agnostic (S3); flips lane-default later (see types.ts doc).
+    unionAnyRep: options?.unionAnyRep ?? false,
     // #1719 S1 — ITER_OVERRIDDEN brand; set later by the
     // sourceOverridesArrayIterator pre-scan in index.ts. Default OFF.
     arrayIteratorMaybeOverridden: false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -93,6 +93,18 @@ export interface CodegenOptions {
    * see plan/issues/2141-tag5-abi-untangle-honest-boxing.md.
    */
   honestAnyBoxing?: boolean;
+  /**
+   * (#745 S2) Known-union `$AnyValue` representation — heterogeneous primitive
+   * unions (`number | string`, …) resolve to the universal `$AnyValue` tagged
+   * carrier instead of externref. Default OFF: byte-identical to the legacy
+   * regime (the mapping in `resolveWasmType` is the only behaviour keyed on
+   * it, and it only fires on such union types). Flips to default-on for
+   * standalone/nativeStrings in a later slice, after the consumer migration
+   * (strict-eq / truthiness / string-concat / call-boundary operands — see
+   * #745 `## Slice plan` S3) makes those paths carrier-agnostic. Coordinate
+   * with #2141 (tag-5 ABI untangle).
+   */
+  unionAnyRep?: boolean;
   /** (#2141 S2/S3, #2626) Tag-5 boxed-VALUE equality classifier — see the
    *  `CompileOptions.tag5ValueEqClassifier` doc. Default false (legacy). */
   tag5ValueEqClassifier?: boolean;
@@ -1793,6 +1805,19 @@ export interface CodegenContext {
   tupleTypeMap: Map<string, number>;
   /** Fast mode: default number to i32, promote to f64 only when needed */
   fast: boolean;
+  /**
+   * (#745 S2) When true, statically-known heterogeneous primitive unions
+   * (`number | string`, `string | boolean`, … — see
+   * `isHeterogeneousPrimitiveUnion`) resolve to the universal `$AnyValue`
+   * tagged carrier instead of externref, eliminating per-op box/unbox/typeof
+   * helper round-trips. Currently OPT-IN (default false, see
+   * `CodegenOptions.unionAnyRep`): narrowed reads/writes work through the
+   * existing `$AnyValue` coercion arms, but strict-eq / truthiness /
+   * string-concat / call-boundary consumers are not yet carrier-agnostic
+   * (S3, coordinate with #2141). Modules with no such union emit
+   * byte-identical wasm regardless of this flag.
+   */
+  unionAnyRep: boolean;
   /** Use WasmGC-native strings instead of wasm:js-string imports */
   nativeStrings: boolean;
   /** #1719 S1 — `ITER_OVERRIDDEN` whole-program brand for the array

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -12,6 +12,7 @@ import {
   isBigIntType,
   isBooleanType,
   isExternalDeclaredClass,
+  isHeterogeneousPrimitiveUnion,
   isHeterogeneousUnion,
   isNullablePrimitiveType,
   isNumberType,
@@ -5467,6 +5468,16 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
       const inner = resolveWasmType(ctx, nonNullish[0]!, _depth + 1, _visited);
       if (inner.kind === "ref") return { kind: "ref_null", typeIdx: inner.typeIdx };
       return inner;
+    }
+    // (#745 S2) Known heterogeneous primitive unions (number|string, …) adopt
+    // the universal $AnyValue tagged carrier in unionAnyRep lanes
+    // (standalone/nativeStrings), replacing externref + per-op
+    // box/unbox/typeof round-trips. Homogeneous unions, nullable single-kind
+    // unions (handled above), and unions with any non-primitive member keep
+    // their existing representation — see isHeterogeneousPrimitiveUnion.
+    if (ctx.unionAnyRep && isHeterogeneousPrimitiveUnion(tsType)) {
+      ensureAnyValueType(ctx);
+      return { kind: "ref_null", typeIdx: ctx.anyValueTypeIdx };
     }
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -742,6 +742,7 @@ function buildCodegenOptions(
     standalone: options.target === "standalone",
     // (#2141 S1) honest any-boxing regime flag (default off = legacy tag-5 ABI).
     honestAnyBoxing: options.honestAnyBoxing,
+    unionAnyRep: options.unionAnyRep,
     // (#2141 S2/S3, #2626) tag-5 boxed-VALUE eq classifier flag (default off).
     tag5ValueEqClassifier: options.tag5ValueEqClassifier,
     // (#2106 S1) standalone $undefined tag-1 singleton regime flag (default off).

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,16 @@ export interface CompileOptions {
    */
   honestAnyBoxing?: boolean;
   /**
+   * (#745 S2) Known-union `$AnyValue` representation — heterogeneous primitive
+   * unions (`number | string`, …) resolve to the universal `$AnyValue` tagged
+   * carrier instead of externref, so narrowed reads become tag-checked
+   * `struct.get`s with no box/unbox helper round-trip. Default false (legacy,
+   * byte-identical — the mapping only fires on such union types). EXPERIMENTAL
+   * opt-in until the consumer migration (#745 S3: strict-eq / truthiness /
+   * string-concat / call boundaries; coordinate #2141) makes it lane-default.
+   */
+  unionAnyRep?: boolean;
+  /**
    * (#2141 S2/S3, #2626) Tag-5 boxed-VALUE equality classifier — the
    * three-way true-class dispatch inside the both-tags-5 arm of
    * `__any_eq`/`__any_strict_eq`: Number×Number → `f64.eq` (#2040),

--- a/tests/issue-745.test.ts
+++ b/tests/issue-745.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #745 S2 — known heterogeneous primitive unions on the `$AnyValue` carrier
+ * (opt-in `unionAnyRep` flag).
+ *
+ * Guards three invariants:
+ *   1. FLAG OFF (the default) is byte-identical to the legacy regime — even
+ *      for union-bearing input — in both the default (JS-host) and
+ *      standalone lanes. This is the #1917-style neutrality gate that makes
+ *      the slice landable while consumers are still carrier-unaware.
+ *   2. FLAG ON with union-free input is byte-identical to flag off: the
+ *      `resolveWasmType` mapping is the only behaviour keyed on the flag,
+ *      and it only fires on heterogeneous primitive union types.
+ *   3. FLAG ON in standalone: typeof-narrowed reads/writes over a
+ *      `number | string` local behave correctly through the existing
+ *      `$AnyValue` coercion arms (boxToAny producer, inline tag-checked
+ *      unbox consumer) — no host imports, no externref round-trip.
+ *
+ * NOT yet covered (documented S3 scope in the issue file): strict-eq /
+ * truthiness / string-concat / call-boundary / union→any operands with the
+ * flag ON — those consumers are not carrier-agnostic yet, which is exactly
+ * why the flag defaults OFF.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { isHeterogeneousPrimitiveUnion } from "../src/checker/type-mapper.js";
+import { ts } from "../src/ts-api.js";
+
+const HET_UNION_SRC = `export function test(): number {
+  let x: number | string = 5;
+  let sum = 0;
+  for (let i = 0; i < 3; i++) {
+    if (i === 2) x = "done";
+    if (typeof x === "number") sum += x + 1;
+  }
+  return sum === 12 ? 1 : 0;
+}`;
+
+const UNION_FREE_SRC = `export function test(): number {
+  let a = 1;
+  let s = "x";
+  for (let i = 0; i < 5; i++) a += i;
+  return a === 11 && s.length === 1 ? 1 : 0;
+}`;
+
+async function binaryOf(src: string, opts: object): Promise<Uint8Array> {
+  const r = await compile(src, { fileName: "t.ts", ...opts });
+  expect(r.success).toBe(true);
+  return r.binary!;
+}
+
+describe("#745 S2 — flag OFF is byte-identical (neutrality gate)", () => {
+  it("union-bearing input, default lane: explicit false === unset", async () => {
+    const off = await binaryOf(HET_UNION_SRC, {});
+    const explicit = await binaryOf(HET_UNION_SRC, { unionAnyRep: false });
+    expect(Buffer.from(explicit).equals(Buffer.from(off))).toBe(true);
+  });
+
+  it("union-bearing input, standalone lane: explicit false === unset", async () => {
+    const off = await binaryOf(HET_UNION_SRC, { target: "standalone" });
+    const explicit = await binaryOf(HET_UNION_SRC, { target: "standalone", unionAnyRep: false });
+    expect(Buffer.from(explicit).equals(Buffer.from(off))).toBe(true);
+  });
+});
+
+describe("#745 S2 — flag ON, union-free input stays byte-identical", () => {
+  it("default lane", async () => {
+    const off = await binaryOf(UNION_FREE_SRC, {});
+    const on = await binaryOf(UNION_FREE_SRC, { unionAnyRep: true });
+    expect(Buffer.from(on).equals(Buffer.from(off))).toBe(true);
+  });
+
+  it("standalone lane", async () => {
+    const off = await binaryOf(UNION_FREE_SRC, { target: "standalone" });
+    const on = await binaryOf(UNION_FREE_SRC, { target: "standalone", unionAnyRep: true });
+    expect(Buffer.from(on).equals(Buffer.from(off))).toBe(true);
+  });
+
+  it("nullable single-kind + literal-union input stays byte-identical (mapping must not fire)", async () => {
+    const src = `type Mode = "a" | "b";
+export function test(): number {
+  let x: number | null = 5;
+  let m: Mode = "a";
+  m = "b";
+  if (x !== null) return m === "b" ? x - 4 : 0;
+  return 0;
+}`;
+    const off = await binaryOf(src, { target: "standalone" });
+    const on = await binaryOf(src, { target: "standalone", unionAnyRep: true });
+    expect(Buffer.from(on).equals(Buffer.from(off))).toBe(true);
+  });
+});
+
+describe("#745 S2 — flag ON, standalone narrowed union behaviour", () => {
+  async function run(src: string): Promise<unknown> {
+    const r = await compile(src, { fileName: "t.ts", target: "standalone", unionAnyRep: true });
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary!, {});
+    return (instance.exports as { test?: () => unknown }).test?.();
+  }
+
+  it("number|string local: typeof-narrowed arithmetic after cross-kind write", async () => {
+    expect(await run(HET_UNION_SRC)).toBe(1);
+  });
+
+  it("string|number local: narrowed .length read", async () => {
+    expect(
+      await run(`export function test(): number {
+  let x: string | number = "hi";
+  if (typeof x === "string") return x.length === 2 ? 1 : 0;
+  return 0;
+}`),
+    ).toBe(1);
+  });
+
+  it("number|string|undefined local: undefined round-trip + narrowing", async () => {
+    expect(
+      await run(`export function test(): number {
+  let x: number | string | undefined = undefined;
+  let n = 0;
+  if (x === undefined) n += 1;
+  x = 3;
+  if (typeof x === "number") n += x;
+  x = "s";
+  if (x !== undefined) n += 10;
+  return n === 14 ? 1 : 0;
+}`),
+    ).toBe(1);
+  });
+
+  it("standalone module with the flag on stays host-import-free", async () => {
+    const r = await compile(HET_UNION_SRC, { fileName: "t.ts", target: "standalone", unionAnyRep: true });
+    expect(r.success).toBe(true);
+    // instantiate with an EMPTY import object — any env/__box_* leak throws.
+    await expect(WebAssembly.instantiate(r.binary!, {})).resolves.toBeDefined();
+  });
+});
+
+describe("#745 S2 — isHeterogeneousPrimitiveUnion predicate", () => {
+  function typeOfLocal(decl: string): ts.Type {
+    const full = `${decl}\nexport const __keep = 1;`;
+    const sf = ts.createSourceFile("t.ts", full, ts.ScriptTarget.Latest, true);
+    const host = ts.createCompilerHost({ strict: true });
+    const getSourceFile = host.getSourceFile.bind(host);
+    host.getSourceFile = (name, ...rest) => (name === "t.ts" ? sf : getSourceFile(name, ...rest));
+    const program = ts.createProgram(["t.ts"], { strict: true }, host);
+    const checker = program.getTypeChecker();
+    const file = program.getSourceFile("t.ts")!;
+    // The `x` declaration may be preceded by helper declarations (enum E, …).
+    const stmt = file.statements.find(
+      (s): s is ts.VariableStatement =>
+        ts.isVariableStatement(s) &&
+        s.declarationList.declarations.some((d) => ts.isIdentifier(d.name) && d.name.text === "x"),
+    )!;
+    const d = stmt.declarationList.declarations[0]!;
+    return checker.getTypeAtLocation(d.name);
+  }
+
+  it("accepts heterogeneous primitive unions", () => {
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | string;"))).toBe(true);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: string | boolean;"))).toBe(true);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | string | undefined;"))).toBe(true);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | string | null;"))).toBe(true);
+  });
+
+  it("rejects homogeneous / nullable / non-primitive shapes", () => {
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | null;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal('let x: "a" | "b";'))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: 0 | 2;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: boolean;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | bigint;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | symbol;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | { a: number };"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number | string[];"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("enum E { A, B }\nlet x: E | string;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: number;"))).toBe(false);
+    expect(isHeterogeneousPrimitiveUnion(typeOfLocal("let x: any;"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## #745 slice S2 — standalone-lane union locals → $AnyValue (feature-flagged, byte-diff-gated)

Implements S2 of the slice plan decided in #745's `## Design Decision` (landed via PR #3156). Recovered from fable-gamma's worktree after it died at the session limit mid-test-writing; rebased onto current main and re-verified.

### What changed
- `isHeterogeneousPrimitiveUnion` (`src/checker/type-mapper.ts`): narrow predicate — ≥2 distinct kinds among {number, string, boolean} after nullish filtering; rejects bigint/symbol/enum/object members, homogeneous and literal unions, nullable single-kind unions.
- `resolveWasmType` (`src/codegen/index.ts`): qualifying unions → `ref_null $AnyValue` when `ctx.unionAnyRep`.
- Flag plumbing `CompileOptions.unionAnyRep` → `CodegenOptions` → ctx, **default OFF** (mirrors #2141's `honestAnyBoxing` pattern). Opt-in until the S3 consumer migration (strict-eq / truthiness / concat) makes those paths carrier-agnostic.
- Issue file: S2 section with the **measured S3/S4 consumer gap-list** (probed per-pattern with the flag on).
- `tests/issue-745.test.ts`: neutrality gates + flag-on standalone behaviour + predicate unit tests (11 tests, all pass).

### Byte-diff evidence (#1917-style neutrality gate)
Flag-off output is **byte-identical to pristine upstream/main** (sha256, verified by temporarily reverting `src/` to upstream/main in the same worktree), even on union-bearing input:

| input | lane | branch flag-off | pristine main |
|---|---|---|---|
| union-bearing | default | `2649a26a39a17bc0` | `2649a26a39a17bc0` |
| union-bearing | standalone | `a1700f5ef122ac05` | `a1700f5ef122ac05` |
| union-free | default | `33c0a30bba03c042` | `33c0a30bba03c042` |
| union-free | standalone | `559f5cf09452badc` | `559f5cf09452badc` |

Flag-ON with union-free / nullable / literal-union input is also byte-identical (test-gated) — the mapping only fires on heterogeneous primitive union types.

### Flag-ON behaviour verified (standalone)
typeof-narrowed reads/writes across cross-kind reassignment, narrowed `.length`, `undefined` round-trip — zero host imports (instantiates with an empty import object).

### Local checks
- `tests/issue-745.test.ts`: 11/11 pass
- prettier: clean · `tsc --noEmit`: clean

Next: S3 (carrier-agnostic strict-eq / truthiness / concat consumers) per the gap-list now recorded in the issue file.