### PR TITLE
fix(#3327): update stale #1917 pin — externref→eqref narrows via ref.cast_null (#2878)

### DIFF
--- a/plan/issues/3327-issue-1917-unexpected-ref-cast-null.md
+++ b/plan/issues/3327-issue-1917-unexpected-ref-cast-null.md
@@ -1,7 +1,9 @@
 ---
 id: 3327
 title: "tests/issue-1917-coercion-plan.test.ts: 1 failure — unexpected ref.cast_null in a pinned coercion instruction shape"
-status: ready
+status: done
+assignee: ttraenkler/fable-3317
+completed: 2026-07-16
 sprint: current
 created: 2026-07-16
 priority: low
@@ -53,3 +55,39 @@ pinned-shape test — treat (b) as the default hypothesis until ruled out.
 - `tests/issue-1917-coercion-plan.test.ts` passes.
 - The resolution (updated-expectation vs. real-fix) is documented in this
   issue file with the reasoning, not just silently changed.
+
+## Resolution (2026-07-16, fable-3317): (a) stale pinned expectation
+
+Verdict: **(a) legitimate shape change — updated the pinned expectation.**
+Hypothesis (b) ruled out by tracing the cast to its introducing commit:
+
+- **Failing case**: `coercionPlan(externref, {kind:"eqref"}, H)` — expected
+  `["any.convert_extern"]`, actual `["any.convert_extern", "ref.cast_null"]`.
+  The `externref → anyref` sibling assertion passes unchanged (bare
+  conversion, anyref IS the exact result type of `any.convert_extern`).
+- **Introducing commit**: `83d0483307ae37` — `fix(#2878): narrow
+externref→eqref coercion (standalone invalid-Wasm residual)`, 2026-07-02.
+  It deliberately SPLIT the old combined `externref → anyref/eqref` row:
+  `any.convert_extern` yields ANYREF, the SUPERtype of eqref, so the bare
+  conversion the old pin froze was one representation step too wide — a
+  consuming `struct.set`/`local.set` into an eqref slot failed Wasm
+  validation ("expected eqref, found anyref"; the standalone
+  `__set_member_*` / `__call_toString`/`__call_valueOf` invalid-binary
+  bucket, #2860/#2868 residual). The narrowing `ref.cast_null` to the
+  abstract `eq` heap type (-19) is type-REQUIRED for eqref consumers:
+  null passes through (nullable cast), and every concrete GC struct/array/
+  i31 — the only values that legitimately land in an eqref slot — is an
+  eq-subtype. Not an unwanted extra cast; removing it reintroduces the
+  #2878 invalid-Wasm class.
+- **Why the failure existed**: #2878's commit added its own dedicated test
+  (`tests/issue-2878-externref-eqref-narrow.test.ts`, which pins the NEW
+  shape) but missed this older sibling pin in
+  `tests/issue-1917-coercion-plan.test.ts` — and the file is evidently not
+  exercised by a CI-run shard, so main stayed green while the pin rotted.
+- **Change**: updated the pinned expectation to
+  `["any.convert_extern", "ref.cast_null"]` with an explanatory comment
+  citing #2878; renamed the `it` to say the eqref arm adds the narrowing
+  cast. No source change (none needed).
+
+Both files green post-change: issue-1917-coercion-plan (14/14) +
+issue-2878-externref-eqref-narrow — 21 tests total.

--- a/tests/issue-1917-coercion-plan.test.ts
+++ b/tests/issue-1917-coercion-plan.test.ts
@@ -67,9 +67,18 @@ describe("#1917 coercionPlan — numeric / box-unbox table", () => {
     expect(ops(coercionPlan(anyref, ext, H)!.instrs)).toEqual(["extern.convert_any"]);
   });
 
-  it("externref → anyref/eqref is any.convert_extern", () => {
+  it("externref → anyref is any.convert_extern; → eqref adds the #2878 eq-narrowing cast", () => {
     expect(ops(coercionPlan(ext, anyref, H)!.instrs)).toEqual(["any.convert_extern"]);
-    expect(ops(coercionPlan(ext, { kind: "eqref" }, H)!.instrs)).toEqual(["any.convert_extern"]);
+    // (#2878, updated by #3327) `any.convert_extern` yields ANYREF — the
+    // SUPERtype of eqref — so the bare conversion this pin originally froze was
+    // one representation step too wide: a consuming `struct.set`/`local.set`
+    // into an eqref slot failed Wasm validation ("expected eqref, found
+    // anyref" — the standalone `__set_member_*` / `__call_toString` invalid-
+    // binary bucket). The row now narrows with a nullable `ref.cast` to the
+    // abstract `eq` heap type (null passes through; every GC struct/array/i31
+    // is an eq-subtype). See tests/issue-2878-externref-eqref-narrow.test.ts
+    // for the dedicated coverage; this sibling pin was missed by that commit.
+    expect(ops(coercionPlan(ext, { kind: "eqref" }, H)!.instrs)).toEqual(["any.convert_extern", "ref.cast_null"]);
   });
 
   it("externref/ref_extern spellings are treated as the same type (no-op)", () => {


### PR DESCRIPTION
## Summary

Closes #3327. Triage of the 1 failing case in `tests/issue-1917-coercion-plan.test.ts` (pre-existing on main, flagged during #3317/#3324 validation).

## Verdict: (a) stale pinned expectation — not a regression

- **Failing case**: `coercionPlan(externref, {kind:"eqref"}, H)` — pinned `["any.convert_extern"]`, actual `["any.convert_extern", "ref.cast_null"]`. The `externref → anyref` sibling assertion passes unchanged.
- **Introducing commit**: `83d0483307ae37` (`fix(#2878)`, 2026-07-02) deliberately split the old combined `externref → anyref/eqref` row: `any.convert_extern` yields ANYREF, the SUPERtype of eqref, so the bare conversion the old pin froze failed Wasm validation at eqref consumers ("expected eqref, found anyref" — the standalone `__set_member_*` / `__call_toString`/`__call_valueOf` invalid-binary bucket, #2860/#2868 residual). The nullable `ref.cast` to the abstract `eq` heap type is type-REQUIRED; removing it would reintroduce the #2878 invalid-Wasm class — so hypothesis (b) is ruled out.
- **Why it rotted silently**: #2878 added its own dedicated test (`tests/issue-2878-externref-eqref-narrow.test.ts`, pinning the NEW shape) but missed this older sibling pin, and the file is evidently not exercised by a CI-run shard.

## Change

Test-only + issue doc: updated the pinned expectation with a rationale comment citing #2878, renamed the `it` accordingly. No source change (none needed). Resolution reasoning recorded in `plan/issues/3327-issue-1917-unexpected-ref-cast-null.md` per its acceptance criteria.

## Validation

- `tests/issue-1917-coercion-plan.test.ts` 14/14 (was 13/14) + `tests/issue-2878-externref-eqref-narrow.test.ts` — 21/21 green
- Prettier clean; no codegen files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb