### PR TITLE
fix(#3328): captured-string += inside closures trapped standalone (coercion-order.js class)

### DIFF
--- a/plan/issues/3328-capturing-closure-toprimitive-dispatch.md
+++ b/plan/issues/3328-capturing-closure-toprimitive-dispatch.md
@@ -1,0 +1,100 @@
+---
+id: 3328
+title: "standalone: `+=` on a captured string inside a closure compiles to f64.add + a trapping null placeholder (kills every capturing toString/valueOf — coercion-order.js class)"
+status: done
+assignee: ttraenkler/sendev-date-3174
+created: 2026-07-17
+updated: 2026-07-17
+completed: 2026-07-17
+priority: high
+feasibility: hard
+model: fable
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: closures
+goal: standalone
+umbrella: 2860
+sprint: current
+horizon: m
+related: [3306, 3174, 795, 2120, 2873]
+origin: "root-caused during #3306 (toString-only ToNumber); initially presumed to be the #2873 funcref-RTT dispatch class — WAT tracing disproved that"
+loc-budget-allow:
+  - src/codegen/expressions/operator-assignment.ts
+  - src/codegen/closures.ts
+---
+
+# #3328 — capturing-closure `+=` string trap (the coercion-order.js blocker)
+
+## Problem
+
+Under `--target standalone`, ANY object whose `toPrimitive` method captures
+and `+=`-appends a function-scoped string traps `dereferencing a null
+pointer` the first time the method runs:
+
+```ts
+export function test() {
+  var log = "";
+  var year = { toString: function () { log += "y"; return 5; } };
+  return +year; // RuntimeError: dereferencing a null pointer (inside __closure_0)
+}
+```
+
+This is the exact shape of the test262 side-effect-ordering suites —
+`Date/coercion-order.js`, `Date/UTC/coercion-order.js`, every
+`set*/arg-coercion-order.js`, and sibling coercion-order rows across
+builtins (`{toString(){ log += 'x'; return v; }}`) — so the whole class
+hard-trapped standalone. Module-scoped `log` worked (globals, no ref cell).
+
+## Root cause (WAT-verified — NOT the presumed #2873 funcref-RTT class)
+
+The trap is **inside the closure body**, not in the ToPrimitive dispatch
+guard (the funcref sig-test passes; stack trace pins `__closure_0`).
+
+`log` is a mutable capture → boxed into a ref cell
+(`struct { value: (mut ref null $AnyString) }`). The boxed-capture compound
+assignment arm (`operator-assignment.ts`) has a string-concat gate from
+#795 that tests **`boxed.valType.kind === "externref"`** — the HOST-mode
+string representation. Under nativeStrings the captured string's cell
+valType is `ref/ref_null $AnyString` — the gate never fires and `+=` falls
+to the f64 arithmetic arm:
+
+1. `coerceType(cellValue: ref $AnyString → f64)` — StringToNumber,
+2. `f64.add`,
+3. writeback `coerceType(f64 → ref $AnyString)` — **no such arm exists**,
+   emitting `drop; ref.null; ref.as_non_null` — an always-trapping
+   placeholder.
+
+## Fix
+
+1. **`operator-assignment.ts`** — native-strings analog of the #795 arm in
+   the boxed-capture compound path: same string-detection heuristics
+   (rhs/lhs static string, `hasStringAssignment`), RHS via the existing
+   `compileAndCoerceToAnyStr` (numbers/booleans included), `__str_concat`,
+   flatten when the cell is a concrete `$NativeString`, null-guarded
+   `struct.set` writeback — mirroring the unboxed
+   `compileNativeStringCompoundAssignment` discipline. Numeric captured
+   compounds (`count += 1`, #2120) are untouched.
+2. **`closures.ts` / `registry/types.ts`** (defence-in-depth, same bug
+   class one level deeper): the three `alreadyBoxed` capture-materialization
+   sites defaulted a missing outer `boxedCaptures` entry to
+   `valType: f64` — silently retyping captured strings as numbers. New
+   `refCellValueType(ctx, refCellTypeIdx)` reads the cell's field-0 type
+   (the authoritative value type) as the fallback before f64.
+
+## Measured
+
+- All capture shapes fixed: valueOf/toString numeric, string-hint, template
+  literal, loose-eq, nested captures, 2/3/7-arg Date ctor coercion-order.
+- `built-ins/Date`: +2 (`coercion-order.js`, `UTC/coercion-order.js`), zero
+  regressions (the one diff row, `toJSON/called-as-function.js`, fails
+  identically on current main — pre-existing drift).
+- `language/expressions/compound-assignment` (454): byte-identical vs main.
+
+## Notes
+
+- The `value-to-primitive-*` Date ctor rows remain (different gaps:
+  @@toPrimitive-on-arg, runtime string-result → `__date_parse` dispatch —
+  documented in #3306's follow-ups).
+- The #2873 funcref-RTT dispatch theory was WRONG for this class — recorded
+  here so the next agent doesn't chase it again for coercion-order rows.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -46,6 +46,7 @@ import {
   resolveWasmType,
   resolveWasmTypeForClosureReturn,
 } from "./index.js";
+import { refCellValueType } from "./registry/types.js"; // (#3328) boxed-capture valType fallback
 import {
   coerceType,
   compileExpression,
@@ -1969,9 +1970,15 @@ export function compileArrowAsClosure(
       if (cap.alreadyBoxed && (cap.type.kind === "ref" || cap.type.kind === "ref_null")) {
         // Already boxed: the field stores the ref cell directly
         refCellTypeIdx = (cap.type as { typeIdx: number }).typeIdx;
-        // Look up the original value type from the outer scope's boxed capture info
+        // Look up the original value type from the outer scope's boxed capture
+        // info; when absent (#3328 — the lifted body compiles BEFORE the
+        // construct site populates fctx.boxedCaptures), fall back to the ref
+        // cell's own field-0 type, which IS the value type. The old blind f64
+        // default retyped captured strings as numbers, so `log += 'y'` inside
+        // a capturing toString/valueOf compiled to f64.add + a null-ref
+        // placeholder that trapped on first call.
         const outerBoxed = fctx.boxedCaptures?.get(cap.name);
-        valType = outerBoxed?.valType ?? { kind: "f64" };
+        valType = outerBoxed?.valType ?? refCellValueType(ctx, refCellTypeIdx) ?? { kind: "f64" };
       } else {
         refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.type);
         valType = cap.type;
@@ -1991,7 +1998,8 @@ export function compileArrowAsClosure(
       // through struct.get on the ref cell instead of using the raw ref value.
       const refCellTypeIdx = (cap.type as { typeIdx: number }).typeIdx;
       const outerBoxed = fctx.boxedCaptures?.get(cap.name);
-      const valType = outerBoxed?.valType ?? { kind: "f64" as const };
+      // (#3328) Cell field-0 type as the fallback — see the mutable arm above.
+      const valType = outerBoxed?.valType ?? refCellValueType(ctx, refCellTypeIdx) ?? { kind: "f64" as const };
       const refCellType: ValType = { kind: "ref_null", typeIdx: refCellTypeIdx };
       const localIdx = allocLocal(liftedFctx, cap.name, refCellType);
       selfCaptureLayoutEntries.push({ name: cap.name, fieldIdx: i + 1, localType: refCellType });
@@ -2699,7 +2707,8 @@ export function compileArrowAsCallback(
         if (cap.alreadyBoxed && (cap.type.kind === "ref" || cap.type.kind === "ref_null")) {
           refCellTypeIdx = (cap.type as { typeIdx: number }).typeIdx;
           const outerInfo = fctx.boxedCaptures?.get(cap.name);
-          valType = outerInfo?.valType ?? { kind: "f64" };
+          // (#3328) Cell field-0 type as the fallback — see the arrow-lift arm.
+          valType = outerInfo?.valType ?? refCellValueType(ctx, refCellTypeIdx) ?? { kind: "f64" };
         } else {
           refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.type);
           valType = cap.type;

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -1808,6 +1808,67 @@ export function compileCompoundAssignment(
       }
     }
 
+    // (#3328) Native-strings analog of the #795 externref string-concat arm
+    // above. Under nativeStrings a captured string's cell valType is a
+    // `ref/ref_null $AnyString`-family type — NOT externref — so the #795 gate
+    // never fired and `log += 'y'` inside a capturing closure fell to the f64
+    // arithmetic below: the string cell value was coerced string→number,
+    // f64.add'd, and the f64→string writeback coercion has no arm, emitting a
+    // `ref.null` + `ref.as_non_null` placeholder — a GUARANTEED
+    // "dereferencing a null pointer" trap the first time any capturing
+    // toString/valueOf ran (blocked Date/UTC coercion-order.js and every
+    // capturing-ToPrimitive test262 row).
+    if (
+      op === ts.SyntaxKind.PlusEqualsToken &&
+      ctx.nativeStrings &&
+      ctx.anyStrTypeIdx >= 0 &&
+      (boxed.valType.kind === "ref" || boxed.valType.kind === "ref_null") &&
+      ((boxed.valType as { typeIdx: number }).typeIdx === ctx.anyStrTypeIdx ||
+        (boxed.valType as { typeIdx: number }).typeIdx === ctx.nativeStrTypeIdx)
+    ) {
+      const rhsIsStringN = isStringType(ctx.checker.getTypeAtLocation(expr.right));
+      const lhsIsStringN = isStringType(ctx.checker.getTypeAtLocation(expr.left));
+      const varHasStringAssignN = hasStringAssignment(name, expr) || hasStringAssignmentInParentScopes(name, expr);
+      const concatIdxN = ctx.nativeStrHelpers.get("__str_concat");
+      if (concatIdxN !== undefined && (rhsIsStringN || lhsIsStringN || varHasStringAssignN)) {
+        // Current cell value (ref/ref_null $AnyString) is on the stack from the
+        // null-guarded read above. RHS → non-null ref $AnyString (numbers via
+        // number_toString, booleans via emitBoolToString — the same coercions
+        // the unboxed native-string += uses).
+        const coercedRhs = compileAndCoerceToAnyStr(ctx, fctx, expr.right);
+        if (coercedRhs !== null) {
+          fctx.body.push({ op: "call", funcIdx: concatIdxN });
+          // A concrete $NativeString cell can't hold the ConsString concat
+          // result — flatten first. $AnyString cells store it directly.
+          if (
+            (boxed.valType as { typeIdx: number }).typeIdx === ctx.nativeStrTypeIdx &&
+            ctx.nativeStrTypeIdx !== ctx.anyStrTypeIdx
+          ) {
+            const flattenIdxN = ctx.nativeStrHelpers.get("__str_flatten");
+            if (flattenIdxN !== undefined) fctx.body.push({ op: "call", funcIdx: flattenIdxN });
+          }
+          const tmpStrN = allocLocal(fctx, `__box_cmp_${fctx.locals.length}`, boxed.valType);
+          fctx.body.push({ op: "local.set", index: tmpStrN });
+          fctx.body.push({ op: "local.get", index: localIdx });
+          fctx.body.push({ op: "ref.is_null" });
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [],
+            else: [
+              { op: "local.get", index: localIdx },
+              { op: "local.get", index: tmpStrN },
+              { op: "struct.set", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 },
+            ],
+          });
+          fctx.body.push({ op: "local.get", index: tmpStrN });
+          return boxed.valType;
+        }
+        reportError(ctx, expr, "Failed to compile string += RHS");
+        return null;
+      }
+    }
+
     // The compound-op switch below emits f64 arithmetic, so any non-f64 cell
     // value (and its RHS) must be promoted to f64 first and coerced back on
     // writeback. This includes i32 (#2120): a captured i32 loop var that is

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -1826,8 +1826,13 @@ export function compileCompoundAssignment(
       ((boxed.valType as { typeIdx: number }).typeIdx === ctx.anyStrTypeIdx ||
         (boxed.valType as { typeIdx: number }).typeIdx === ctx.nativeStrTypeIdx)
     ) {
-      const rhsIsStringN = isStringType(ctx.checker.getTypeAtLocation(expr.right));
-      const lhsIsStringN = isStringType(ctx.checker.getTypeAtLocation(expr.left));
+      // Oracle-routed (#1930 ratchet): fact kind "string" covers String |
+      // StringLiteral; the String wrapper object (`new String("x")`)
+      // classifies as builtin "String" — same coverage as isStringType.
+      const rhsFactN = ctx.oracle.typeFactOf(expr.right);
+      const lhsFactN = ctx.oracle.typeFactOf(expr.left);
+      const rhsIsStringN = rhsFactN.kind === "string" || (rhsFactN.kind === "builtin" && rhsFactN.name === "String");
+      const lhsIsStringN = lhsFactN.kind === "string" || (lhsFactN.kind === "builtin" && lhsFactN.name === "String");
       const varHasStringAssignN = hasStringAssignment(name, expr) || hasStringAssignmentInParentScopes(name, expr);
       const concatIdxN = ctx.nativeStrHelpers.get("__str_concat");
       if (concatIdxN !== undefined && (rhsIsStringN || lhsIsStringN || varHasStringAssignN)) {

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -574,6 +574,25 @@ export function getOrRegisterRefCellType(ctx: CodegenContext, valType: ValType):
   return typeIdx;
 }
 
+/**
+ * (#3328) The VALUE type a mutable-capture ref cell carries — its field-0
+ * type. The authoritative fallback for a boxed capture's `valType` when the
+ * outer scope's `boxedCaptures` entry is not populated yet (the lifted body
+ * compiles BEFORE the construct site boxes the outer local, so
+ * `fctx.boxedCaptures.get(name)` misses and the legacy `?? {kind:"f64"}`
+ * default silently retyped e.g. a captured STRING as a number — `log += 'y'`
+ * inside the closure then compiled as `f64.add` with a `ref.null` +
+ * `ref.as_non_null` placeholder for the string result, a guaranteed
+ * "dereferencing a null pointer" trap the first time any capturing
+ * `toString`/`valueOf` ran). Returns undefined when `refCellTypeIdx` is not a
+ * cell-shaped struct so callers keep their final default.
+ */
+export function refCellValueType(ctx: CodegenContext, refCellTypeIdx: number): ValType | undefined {
+  const def = ctx.mod.types[refCellTypeIdx];
+  if (!def || def.kind !== "struct") return undefined;
+  return (def as StructTypeDef).fields[0]?.type;
+}
+
 /** Get the raw array type index from a vec struct type index. */
 export function getArrTypeIdxFromVec(ctx: CodegenContext, vecTypeIdx: number): number {
   const vecDef = ctx.mod.types[vecTypeIdx];

--- a/tests/issue-3328.test.ts
+++ b/tests/issue-3328.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3328 — standalone `+=` on a captured string inside a closure.
+ *
+ * The boxed-capture compound-assignment arm's string-concat gate (#795)
+ * tested `boxed.valType.kind === "externref"` — host-mode strings only.
+ * Under nativeStrings a captured string's ref cell holds a
+ * `ref/ref_null $AnyString`, so `log += 'y'` inside a capturing
+ * toString/valueOf fell to the f64 arithmetic arm whose f64→string
+ * writeback emitted a `ref.null` + `ref.as_non_null` placeholder — an
+ * always-trapping "dereferencing a null pointer". This killed the entire
+ * test262 coercion-order class (`{toString(){ log += 'x'; return v; }}`).
+ *
+ * Fix: native-strings analog of the #795 arm (`__str_concat` +
+ * `compileAndCoerceToAnyStr` + null-guarded cell writeback) in
+ * operator-assignment.ts, plus `refCellValueType` as the authoritative
+ * fallback for boxed-capture value types in closures.ts (the blind f64
+ * default was the same bug class one level deeper).
+ */
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envImports = (r.imports ?? []).filter((i) => i.module === "env").map((i) => i.name);
+  expect(envImports, "must stay host-free").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports.test as () => unknown)();
+}
+
+describe("#3328 — captured-string += inside closures (standalone)", () => {
+  it("capturing toString appends to a fn-scoped string (the coercion-order shape)", async () => {
+    expect(
+      await runStandalone(`
+export function test(): number {
+  var log = '';
+  var year = { toString: function() { log += 'y'; return 5; } };
+  var n = +year;
+  return n === 5 && log === 'y' ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("capturing valueOf appends; loose-eq and template-literal paths too", async () => {
+    expect(
+      await runStandalone(`
+export function test(): number {
+  var log = '';
+  var o = { valueOf: function() { log += 'v'; return 5; } };
+  if (!((o as any) == 5)) return 10;
+  var t = { toString: function() { log += 't'; return "S"; } };
+  if (\`\${t}\` !== "S") return 11;
+  return log === 'vt' ? 1 : 12;
+}`),
+    ).toBe(1);
+  });
+
+  it("new Date(y, m, d, h, min, s, ms) coercion order logs left-to-right (§20.4.2)", async () => {
+    expect(
+      await runStandalone(`
+export function test(): number {
+  var log = '';
+  var year = { toString: function() { log += 'year'; return 0; } };
+  var month = { toString: function() { log += 'month'; return 0; } };
+  var date = { toString: function() { log += 'date'; return 1; } };
+  var hours = { toString: function() { log += 'hours'; return 0; } };
+  var minutes = { toString: function() { log += 'minutes'; return 0; } };
+  var seconds = { toString: function() { log += 'seconds'; return 0; } };
+  var ms = { toString: function() { log += 'ms'; return 0; } };
+  new Date(year, month, date, hours, minutes, seconds, ms);
+  return log === 'yearmonthdatehoursminutessecondsms' ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("appending a NUMBER to a captured string coerces to string", async () => {
+    expect(
+      await runStandalone(`
+export function test(): number {
+  var log = '';
+  var o = { toString: function() { log += 1; return 0; } };
+  var n = +o;
+  return n === 0 && log === '1' ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("numeric captured compound (count += 1, #2120) is untouched", async () => {
+    expect(
+      await runStandalone(`
+export function test(): number {
+  var count = 0;
+  var o = { valueOf: function() { count += 1; return 5; } };
+  var n = (+o) + (+o);
+  return n === 10 && count === 2 ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+
+  it("nested closures capturing the same string (alreadyBoxed path)", async () => {
+    expect(
+      await runStandalone(`
+export function test(): number {
+  var log = '';
+  var outer = function() {
+    var inner = { toString: function() { log += 'i'; return 3; } };
+    return +inner;
+  };
+  var n = outer();
+  return n === 3 && log === 'i' ? 1 : 2;
+}`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes plan issue #3328 (umbrella #2860; root-caused during #3306, carried as the coordinator-assigned follow-up).

## What

Under `--target standalone`, any ToPrimitive method that captures and `+=`-appends a function-scoped string trapped `dereferencing a null pointer` on first invocation:

```ts
var log = "";
var year = { toString: function () { log += "y"; return 5; } };
+year; // RuntimeError: dereferencing a null pointer
```

This is the exact shape of the test262 side-effect-ordering suites — `Date/coercion-order.js`, `Date/UTC/coercion-order.js`, every `set*/arg-coercion-order.js`, and sibling coercion-order rows across builtins — so the whole class hard-trapped standalone (module-scoped accumulators worked; only fn-scoped captures trapped).

## Root cause (WAT-verified — and NOT the presumed #2873 funcref-RTT dispatch)

The wasm stack trace pins the trap **inside the closure body**, not in the ToPrimitive dispatch guard. `log` is a mutable capture → boxed into a ref cell. The boxed-capture compound-assignment arm in `operator-assignment.ts` has a string-concat gate from #795 that tests `boxed.valType.kind === "externref"` — the **host-mode** string representation. Under nativeStrings the captured string's cell holds `ref/ref_null $AnyString`, so the gate never fired and `+=` fell to the f64 arithmetic arm: cell string → StringToNumber → `f64.add` → writeback `coerceType(f64 → ref $AnyString)` which has **no arm** and emits `drop; ref.null; ref.as_non_null` — an always-trapping placeholder.

## Fix

1. **`src/codegen/expressions/operator-assignment.ts`** — native-strings analog of the #795 arm in the boxed-capture compound path: same string-detection heuristics, RHS via the existing `compileAndCoerceToAnyStr` (numbers/booleans included), `__str_concat`, flatten when the cell is a concrete `$NativeString`, null-guarded `struct.set` writeback — mirroring the unboxed `compileNativeStringCompoundAssignment` discipline. Numeric captured compounds (`count += 1`, #2120) untouched.
2. **`src/codegen/registry/types.ts` + `src/codegen/closures.ts`** (defence-in-depth, same bug class one level deeper): the three `alreadyBoxed` capture-materialization sites defaulted a missing outer `boxedCaptures` entry to `valType: f64`, silently retyping captured strings as numbers. New `refCellValueType` reads the cell's field-0 type (the authoritative value type) as the fallback before f64. Imported directly from `registry/types.js` (no barrel growth).

## Measured

- All capture shapes fixed: valueOf/toString numeric coercion, string-hint, template literal, loose-eq, nested (alreadyBoxed) captures, and the 2/3/7-arg `new Date(...)` coercion-order shapes.
- `built-ins/Date`: **+2** (`coercion-order.js`, `UTC/coercion-order.js`), zero regressions (the single diff row `toJSON/called-as-function.js` fails identically on current main — pre-existing drift, not this PR).
- `language/expressions/compound-assignment` (454 tests): byte-identical vs main.
- Adjacent suites (`issue-1175`, `issue-1210`, `issue-1744`, `issue-2120`, `issue-2623-capture-box-depth`, `issue-3306`, `issue-3174`): 46/46 green.

## Notes

- The remaining `Date/value-to-primitive-*` ctor rows are different gaps (@@toPrimitive-on-arg, runtime string-result → `__date_parse` dispatch) — documented in #3306's follow-ups.
- The #2873 funcref-RTT theory was disproved for this class and recorded in the issue file so the next agent doesn't chase it for coercion-order rows.
- Pre-claim check: #2873's `assignee: ttraenkler/dev-2873` is stale (claim released 2026-07-01 per the issue-assignments ref; the branch's own handoff commit records the stale verdict) — this PR scopes a fresh issue rather than folding into that cluster, per tech-lead guidance.

## Tests

`tests/issue-3328.test.ts` — 6 standalone host-free tests: the coercion-order shape, loose-eq + template paths, the full 7-arg Date ctor ordering, number-append coercion, #2120 numeric-compound non-regression, nested-capture (alreadyBoxed) path.