### PR TITLE
feat(#2956 L2): vec mutation (element store + push) through the linear-IR overlay

### DIFF
--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -1,13 +1,14 @@
 ---
 id: 2953
 title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait"
-status: in-review
+status: done
+completed: 2026-07-16
 assignee: ttraenkler/opus-1a
 branch: symphony/porffor/2953-after-pr-3146
 pr: 3159
 sprint: current
 created: 2026-07-02
-updated: 2026-07-16
+updated: 2026-07-17
 priority: high
 horizon: l
 feasibility: medium

--- a/plan/issues/2956-linear-backend-consumes-ir.md
+++ b/plan/issues/2956-linear-backend-consumes-ir.md
@@ -283,3 +283,35 @@ playground corpus. There is no measured corpus improvement, so
 `scripts/linear-ir-baseline.json` is intentionally unchanged. The next L2
 work is the separately owned refcell/aggregate surface; this sub-slice does
 not claim it.
+
+## Execution status — L2 vec-MUTATION sub-slice (2026-07-17, fable-epsilon)
+
+Element store (`a[i] = v`) and single-arg `a.push(v)` on selector-claimed
+`number[]` receivers now lower through the linear-IR overlay under
+`JS2WASM_LINEAR_IR=1`. No new IR instr kinds and no emitter changes — the
+sub-slice rides the existing C2 element-store helper call:
+
+- `src/ir/from-ast.ts`: the element-store and push receiver gates admit the
+  linear scalar-i32 vec receiver via the same `isVecValueExpression` probe
+  the read arms (`.length`, element access) already use. WasmGC lane
+  unaffected (its vec receivers are always refs; `check:ir-fallbacks` OK).
+- `src/ir/backend/linear-integration.ts` `resolveFunc`: intercepts the
+  `__vec_elem_set_<typeIdx>` helper name (sentinel 0 on linear) and maps it
+  to the direct runtime's `__arr_set(ptr:i32, idx:i32, val:f64)` — same
+  signature, same grow-on-OOB / zero-fill-gap / len-extension semantics as
+  the WasmGC `ensureVecElemSet` helper (negative-idx no-op + #1977
+  forwarding resolution are safe supersets). Name-based, funcIdx-shift safe.
+
+Validated: `tests/issue-2956.test.ts` 11/11 (parity vs direct for
+setInBounds/setGrow/pushStmt; OOB-growth len-extension 507; flag-off SHA
+byte-identity; multi-arg push demotes to direct); linear-array/basic +
+cross-backend-diff 43/43; tsc clean; ratchet 6→6 / build 4→4 (corpus has
+no mutation-gated rows — baseline intentionally unchanged).
+
+**Found + filed #3332**: the DIRECT linear path returns 0 from
+expression-position push (spec: new length) and drops multi-arg push
+extras — the overlay is spec-correct where claimed, so the tests document
+the divergence with #3332-referencing assertions instead of masking it.
+
+**Remaining after this sub-slice**: refcells + aggregates via `layout.ts`
+(the L2 remainder), L3 strings (after #2955), L4 default-ON flip.

--- a/plan/issues/2956-linear-backend-consumes-ir.md
+++ b/plan/issues/2956-linear-backend-consumes-ir.md
@@ -2,13 +2,11 @@
 id: 2956
 title: "Linear backend consumes the IR front-end: wire the selector + LinearEmitter into generateLinearModule"
 status: in-progress
-branch: codex/2956-l2-vec
-pr: 3110
 sprint: current
 created: 2026-07-02
-updated: 2026-07-16
-assignee: ttraenkler/codex-l2-vec
-branch: codex/2956-l2-vec
+updated: 2026-07-17
+assignee: ttraenkler/fable-epsilon
+branch: issue-2956-linear-ir-consume
 priority: medium
 horizon: xl
 feasibility: hard

--- a/plan/issues/3332-linear-direct-push-return-and-multiarg.md
+++ b/plan/issues/3332-linear-direct-push-return-and-multiarg.md
@@ -1,0 +1,54 @@
+---
+id: 3332
+title: "linear direct path: arr.push returns 0 (not new length) and drops extra args"
+status: ready
+sprint: Backlog
+goal: backend-agnostic-ir
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: ES3
+language_feature: arrays
+task_type: bug
+area: codegen-linear
+horizon: s
+created: 2026-07-17
+updated: 2026-07-17
+related: [2956, 1854]
+---
+
+# #3332 — linear direct path push defects
+
+## Problem
+
+Found while validating the #2956 L2 vec-mutation sub-slice (linear-IR
+overlay). The DIRECT linear path (`--target linear`, no `JS2WASM_LINEAR_IR`)
+mis-lowers `Array.prototype.push`:
+
+```ts
+export function pushRet(): number { const a = [1]; return a.push(8); }
+// direct linear: 0     JS/spec: 2 (the new length)
+export function multiPush(): number { const a = [1]; a.push(2, 3); return a.length; }
+// direct linear: 2     JS/spec: 3 (extra args dropped)
+```
+
+The IR overlay path (selector-claimed, `JS2WASM_LINEAR_IR=1`) is
+spec-correct for the single-arg expression-position case (returns the new
+length via the shared from-ast lowering) — so the direct path now DIVERGES
+from the overlay on the same source. `tests/issue-2956.test.ts` documents
+the divergence with explicit assertions referencing this issue.
+
+## Fix sketch
+
+`src/codegen-linear/` push lowering: (a) expression position must yield the
+new length (`__arr_push` is void — read `__arr_len` after, or return len
+from the helper); (b) multi-arg push must loop all arguments. Note the IR
+overlay's single-arg-only gate demotes multi-arg push to the direct path,
+so (b) also unblocks overlay-adjacent parity.
+
+## Acceptance
+
+- `a.push(v)` in expression position returns the new length on the direct
+  linear path.
+- Multi-arg `a.push(x, y, …)` appends all values.
+- Cross-backend corpus rows for push flip to executed parity.

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -280,6 +280,22 @@ function makeLinearIrResolver(ctx: LinearContext): IrLowerResolver & IrFromAstRe
 
   return {
     resolveFunc(ref: IrFuncRef): number {
+      // (#2956 L2) Vec MUTATION rides from-ast's element-store helper call
+      // `__vec_elem_set_<vecStructTypeIdx>` (the C2 path — element store and
+      // `.push` both emit it). On linear the sentinel typeIdx is always 0
+      // (the f64VecLayout below), and the direct runtime's
+      // `__arr_set(ptr:i32, idx:i32, val:f64) -> void` has the SAME
+      // signature and the same grow-on-OOB / zero-fill-gap / len-extension
+      // semantics as the WasmGC `ensureVecElemSet` helper (a negative-index
+      // no-op and #1977 forwarding resolution are safe supersets). Map the
+      // helper name onto it — name-based, funcIdx-shift safe.
+      if (ref.name.startsWith("__vec_elem_set_")) {
+        const arrSet = ctx.funcMap.get("__arr_set");
+        if (arrSet === undefined) {
+          throw new Error(`linear-ir: __arr_set runtime helper missing for '${ref.name}'`);
+        }
+        return arrSet;
+      }
       const idx = ctx.funcMap.get(ref.name);
       if (idx === undefined) {
         throw new Error(`linear-ir: no funcIdx for '${ref.name}' (selector claimed a call outside funcMap)`);

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2673,7 +2673,13 @@ function lowerElementStore(lhs: ts.ElementAccessExpression, rhs: ts.Expression, 
   const recv = lowerExpr(lhs.expression, cx, irVal({ kind: "f64" }));
   const recvType = cx.builder.typeOf(recv);
   const recvVal = asVal(recvType);
-  if (!recvVal || (recvVal.kind !== "ref" && recvVal.kind !== "ref_null")) {
+  // (#2956 L2) Linear vec receivers are scalar i32 arena pointers, not GC
+  // refs — admit them via the same resolver probe the read paths use
+  // (`scalarVecReceiver` at the `.length` / element-access arms). The
+  // WasmGC lane is unaffected: its vec receivers always lower as refs.
+  const scalarVecStoreReceiver =
+    recvVal?.kind === "i32" && cx.resolver?.isVecValueExpression?.(lhs.expression) === true;
+  if (!recvVal || (recvVal.kind !== "ref" && recvVal.kind !== "ref_null" && !scalarVecStoreReceiver)) {
     throw new Error(`ir/from-ast: element store on ${describeIrType(recvType)} not in IR scope (${cx.funcName})`);
   }
   const vec = cx.resolver?.resolveVec?.(recvVal);
@@ -3681,7 +3687,14 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   // externref element vecs only (mirrors `lowerElementStore`).
   {
     const vecRecvVal = asVal(recvType);
-    if (methodName === "push" && vecRecvVal && vecRecvVal.kind === "ref") {
+    // (#2956 L2) Linear vec receivers are scalar i32 arena pointers — admit
+    // them alongside the non-null GC ref (same probe as the read arms; the
+    // linear runtime's __arr_set target resolves #1977 forwarding itself).
+    const scalarVecPushReceiver =
+      vecRecvVal?.kind === "i32" &&
+      ts.isPropertyAccessExpression(expr.expression) &&
+      cx.resolver?.isVecValueExpression?.(expr.expression.expression) === true;
+    if (methodName === "push" && vecRecvVal && (vecRecvVal.kind === "ref" || scalarVecPushReceiver)) {
       const vec = cx.resolver?.resolveVec?.(vecRecvVal);
       if (vec) {
         if (expr.arguments.length !== 1 || ts.isSpreadElement(expr.arguments[0]!)) {

--- a/tests/issue-2956.test.ts
+++ b/tests/issue-2956.test.ts
@@ -185,3 +185,84 @@ describe("#2956 L2: selector-claimed vec construction", () => {
     expect(await run(binary)).toBe(0);
   });
 });
+
+const VEC_MUT_SRC = `export function setInBounds(): number {
+  const a = [1, 2, 3];
+  a[1] = 9;
+  return a[1] + a.length;
+}
+export function setGrow(): number {
+  const a = [1];
+  a[4] = 7;
+  return a.length * 100 + a[4] + a[2];
+}
+export function pushStmt(): number {
+  const a = [1, 2];
+  a.push(5);
+  return a[2] + a.length;
+}
+export function pushExpr(): number {
+  const a = [1];
+  const n = a.push(8);
+  return n * 10 + a[1];
+}
+export function test(): number {
+  return setInBounds() + setGrow() + pushStmt() + pushExpr();
+}`;
+
+describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () => {
+  it("flag ON lowers element store and push with direct-path value parity", async () => {
+    const directBinary = await compileLinear(VEC_MUT_SRC, false);
+    const irBinary = await compileLinear(VEC_MUT_SRC, true);
+    const report = getLastLinearIrReport();
+    expect(report?.rejected ?? []).toEqual([]);
+    expect([...(report?.compiled ?? [])].sort()).toEqual(["pushExpr", "pushStmt", "setGrow", "setInBounds", "test"]);
+
+    const direct = await exportedFunctions(directBinary);
+    const ir = await exportedFunctions(irBinary);
+    // Direct-path parity where the direct path is spec-correct.
+    for (const name of ["setInBounds", "setGrow", "pushStmt"]) {
+      expect(callNumber(ir, name), `${name} IR value`).toBe(callNumber(direct, name));
+    }
+    // Absolute expectations (spec semantics):
+    expect(callNumber(ir, "setInBounds")).toBe(12); // 9 + length 3
+    // a[4]=7 grows: length 5 -> 500, a[4]=7, hole a[2] reads the direct
+    // runtime's 0 sentinel -> 507.
+    expect(callNumber(ir, "setGrow")).toBe(507);
+    expect(callNumber(ir, "pushStmt")).toBe(8); // 5 + new length 3
+    // push in EXPRESSION position: the IR overlay is spec-correct (returns
+    // the new length -> 2*10 + 8 = 28); the DIRECT path returns 0 for the
+    // push result (pre-existing defect, tracked as #3332) -> 8. Assert both
+    // so a direct-path fix flips this into a parity check loudly.
+    expect(callNumber(ir, "pushExpr")).toBe(28);
+    expect(
+      callNumber(direct, "pushExpr"),
+      "direct pushExpr (#3332 — update to 28 + fold into parity loop when fixed)",
+    ).toBe(8);
+    expect(callNumber(ir, "test")).toBe(12 + 507 + 8 + 28);
+  });
+
+  it("JS2WASM_LINEAR_IR=0 keeps mutation modules byte-identical to an unset flag", async () => {
+    const unset = await compileLinear(VEC_MUT_SRC, false);
+    const zero = await compileLinear(VEC_MUT_SRC, "0");
+    const sha = (b: Uint8Array): string => createHash("sha256").update(b).digest("hex");
+    expect(sha(zero)).toBe(sha(unset));
+  });
+
+  it("multi-arg push stays on the direct fallback (single plain arg only)", async () => {
+    const source = `export function multiPush(): number {
+      const a = [1];
+      a.push(2, 3);
+      return a.length;
+    }
+    export function test(): number { return multiPush(); }`;
+    const binary = await compileLinear(source, true);
+    const report = getLastLinearIrReport();
+    expect(report?.compiled ?? []).not.toContain("multiPush");
+    expect(report?.rejected.some((rejection) => rejection.func === "multiPush")).toBe(true);
+    // The demoted function rides the DIRECT path, which drops the extra
+    // push arg (pre-existing defect, #3332): length is 2, not the
+    // spec-correct 3. Update to 3 when #3332 lands.
+    expect(await run(binary)).toBe(2);
+  });
+});


### PR DESCRIPTION
Next L2 sub-slice of plan issue #2956 (linear backend consumes the IR front-end). Follows the landed L1 overlay + the #3110 vec-construction arm.

## What (no new IR kinds, no emitter changes)

- `src/ir/from-ast.ts`: the element-store (`a[i] = v`) and single-arg `a.push(v)` receiver gates now admit the linear scalar-i32 vec receiver via the same `isVecValueExpression` resolver probe the read arms (`.length`, element access) already use. The WasmGC lane is unaffected — its vec receivers always lower as refs (`check:ir-fallbacks` OK).
- `src/ir/backend/linear-integration.ts` `resolveFunc`: intercepts the C2 element-store helper name `__vec_elem_set_<typeIdx>` (sentinel 0 on linear) and maps it to the direct runtime's `__arr_set(ptr:i32, idx:i32, val:f64) -> void` — identical signature and grow-on-OOB / zero-fill-gap / len-extension semantics as the WasmGC `ensureVecElemSet` helper (negative-idx no-op + #1977 forwarding resolution are safe supersets). Name-based resolution, funcIdx-shift safe.

## Validation

- `tests/issue-2956.test.ts` **11/11**: direct-path value parity (setInBounds/setGrow/pushStmt), OOB-growth length-extension (507 case), push in expression position (spec-correct 28), `JS2WASM_LINEAR_IR=0` SHA byte-identity, multi-arg push demotes to the direct path.
- linear-array/linear-basic/cross-backend-diff: 43/43; tsc clean; gc-lane `check:ir-fallbacks` OK.
- Ratchet `check:linear-ir`: 6→6 compiled / build:4 unchanged (the playground corpus has no mutation-gated rows; baseline intentionally unchanged — same as #3110).

## Follow-up finding

The DIRECT linear path returns **0** from expression-position `push` (spec: new length) and **drops multi-arg push extras** — pre-existing defects, filed as `plan/issues/3332-linear-direct-push-return-and-multiarg.md` (id via claim-issue --allocate). The tests assert both lanes explicitly so a direct-path fix flips the divergence loudly instead of silently.

## Also in this PR (doc-lag reconciliation, coordinator-requested)

- `plan/issues/2953-*.md` → `status: done` (PRs #2508 + #3159 merged; was stuck at in-review).
- `plan/issues/2956-*.md` claim block refreshed (PR #3110 merged; this branch owns the next sub-slice). Issue stays `in-progress` — L2 refcells/aggregates, L3 strings, L4 default-ON remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8