### PR TITLE
fix(#3331): singleton null-guard class audit + Map/WeakMap get-miss fix (4th instance)

### DIFF
--- a/plan/issues/3331-singleton-nullguard-class-audit.md
+++ b/plan/issues/3331-singleton-nullguard-class-audit.md
@@ -1,0 +1,100 @@
+---
+id: 3331
+title: "AUDIT: #2106 $undefined-singleton null-guard bug class — systematic sweep + Map get-miss fix (4th instance)"
+horizon: m
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/fable-gamma
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+feasibility: medium
+task_type: bug
+area: runtime
+goal: spec-completeness
+sprint: current
+related: [2106, 3316, 3319, 3328, 2606, 3008]
+loc-budget-allow:
+  - src/codegen/map-runtime.ts
+  - src/codegen/closed-method-dispatch.ts
+---
+
+# #3331 — the #2106 singleton null-guard bug class: audit + Map fix
+
+## The class
+
+The #2106 `$undefined`-singleton flip (default-ON for standalone/nativeStrings
+since `6f7f93c856`, Jul 4) changed the MISS/absence value of runtime lookups
+from `ref.null` to the NON-NULL tag-1 `$AnyValue` singleton. Every guard that
+still encodes "absent ⇔ ref.is_null" (consumer direction), and every producer
+that still emits `ref.null` where JS observes `undefined` (producer direction),
+silently breaks. Instances found one at a time before this audit:
+
+1. **#3316/#3307** — gOPD accessor halves (producer: null half must surface
+   as the singleton).
+2. **#3319** — gOPD miss + descriptor undefined-slots (producer).
+3. **#3328** — JSON.stringify toJSON miss-guard (consumer: `ref.is_null`
+   read the singleton miss as a callable toJSON → every object → "null").
+4. **THIS PR** — `Map`/`WeakMap` `.get(missingKey)` returned null ⇒
+   `=== undefined` false (typed, any-receiver, and WeakMap lanes); an
+   `undefined` LITERAL element stored as null read back as `null`;
+   dispatch-lane `clear()` returned null-extern.
+
+## Sweep method (reproducible)
+
+1. **Static scan** (`.tmp` scanners, this PR's methodology): all
+   `{op:"call"}` emissions of singleton-miss producers (`__extern_get`,
+   `__extern_get_idx`, `__getOwnPropertyDescriptor`, `__extern_method_call`,
+   `__call_fn_method_*`, `__apply_closure`, replacer/toJSON drivers) followed
+   by a `ref.is_null` guard within 25 lines → 20 candidate sites.
+2. **A/B battery** (`tests/issue-3331.test.ts` mirrors it): 18 miss-path
+   behavior patterns compiled+run under `JS2WASM_UNDEF_SINGLETON=0` vs `1`.
+   Regime-DIVERGENT ⇒ the class; fails-both ⇒ pre-existing (out of class).
+
+## Classification table (static candidates)
+
+| Site                                                              | Class    | Verdict                                                                    |
+| ----------------------------------------------------------------- | -------- | -------------------------------------------------------------------------- |
+| dyn-read.ts `__dyn_get`/`__dyn_has`                               | consumer | GATED (explicit S1 arms)                                                   |
+| string-raw.ts step-4/5 nullish guards                             | consumer | GATED (`__nullish_to_null` norm)                                           |
+| array-to-primitive.ts join element                                | consumer | GATED (`__extern_is_nullish`, availability-keyed)                          |
+| object-runtime.ts ToPrimitive method lookup (2687)                | consumer | GATED (`__nullish_to_null`)                                                |
+| object-runtime.ts groupBy presence (4060)                         | consumer | GATED (`__nullish_to_null`)                                                |
+| object-runtime-proxy.ts trap reads (926-942)                      | consumer | GATED (`__nullish_to_null`)                                                |
+| object-runtime-descriptors.ts gOPD halves (2198)                  | producer | FIXED by #3316/#3319                                                       |
+| json-codec-native.ts toJSON guard (783)                           | consumer | FIXED by #3328                                                             |
+| json-codec-native.ts root-replacer result (1085)                  | consumer | OK (verified: replacer-root-undefined → undefined, both regimes)           |
+| json-codec-native.ts reviver delete (3056)                        | consumer | pre-existing bug, BOTH regimes (see below)                                 |
+| map-runtime.ts `__map_get` miss (706)                             | producer | **FIXED HERE** (singleton miss, regime-gated)                              |
+| map-runtime.ts groupBy internal miss test (1302)                  | consumer | **FIXED HERE** (`ref.test $AnyValue` ⇔ miss)                               |
+| map-runtime.ts `compileCollectionElementArg` undefined literal    | producer | **FIXED HERE** (stores the singleton)                                      |
+| closed-method-dispatch.ts collection `clear` (void)               | producer | **FIXED HERE** (singleton return)                                          |
+| closed-method-dispatch.ts collection `get` boundary               | —        | no change needed (miss now honest at producer)                             |
+| destructuring-params.ts (693) / disposable-runtime.ts (921, 1197) | consumer | GATED (S1 arms present — spot-checked via battery destrDefault/spreadCopy) |
+
+## A/B battery results (post-fix)
+
+**Regime-divergent: NONE** (was 1: mapGetMiss). All Map probes pass both
+regimes: typed/any/WeakMap get-miss, stored-null (`get → null`), stored
+undefined-literal (`get → undefined`, `has → true`), Set has-miss,
+getOrInsert, clear-returns-undefined.
+
+## Out-of-class findings (pre-existing, fail BOTH regimes — for PO triage)
+
+- `o.zz()` on a missing method: no TypeError (returns 0 instead of throwing)
+- `{valueOf: () => 7} + 1`: ordinary ToPrimitive on typed object literal broken
+- `[1, undefined, 3].join(",")`: hole/undefined rendering wrong
+- JSON replacer key-drop (`{a:1,b:2}` → drop "a"): null-pointer trap
+- JSON reviver returning undefined does NOT delete the key (§25.5.1.1)
+- JSON replacer on array element → trap (should render "null")
+- `Map.groupBy` static call shape: compile refusal (`__get_builtin`)
+
+## Guard-authoring rule (retire the class)
+
+Any new **absence guard** on a value that can carry `undefined` MUST use one
+of the canonical primitives — `__extern_is_nullish` / `__nullish_to_null`
+(externref plane), `ref.test $AnyValue` exclusion (anyref plane, when the
+slot can never hold a legitimate box), or `emitIsUndefinedSingletonExternAt`
+— never a bare `ref.is_null`. Any new **producer** whose JS-visible miss is
+`undefined` materializes via `undefinedExternInstrs(ctx)` /
+`global.get ctx.undefinedGlobalIdx`, regime-gated.

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -37,7 +37,7 @@
  * arguments fall through to the existing path (the dispatcher is not used).
  */
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
-import { ensureExternSameValueZeroHelper, ensureExternStrictEqHelper } from "./any-helpers.js";
+import { ensureExternSameValueZeroHelper, ensureExternStrictEqHelper, undefinedExternInstrs } from "./any-helpers.js";
 import { buildClosureRefTestArms } from "./closure-classifier.js"; // (#3125) IsCallable arms
 import type { CodegenContext } from "./context/types.js";
 import { ensureNativeArrayHof, NATIVE_HOF_METHODS } from "./hof-native.js";
@@ -1030,13 +1030,18 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
           helperCall.push({ op: "any.convert_extern" });
         }
         helperCall.push({ op: "call", funcIdx: helperIdx });
+        const undefExternCol = undefinedExternInstrs(ctx);
         if (resultShape === "bool") {
           helperCall.push({ op: "call", funcIdx: boxBoolIdx as number }); // i32 → externref
         } else if (resultShape === "void") {
-          helperCall.push({ op: "ref.null.extern" }); // undefined
+          // (#3331) JS-visible `undefined` result — materialize the singleton
+          // under the #2106 regime; legacy keeps `ref.null.extern`.
+          helperCall.push(...(undefExternCol ?? [{ op: "ref.null.extern" } as Instr]));
         } else {
           // anyref value (get) or the chainable `ref $Map` receiver (set/add)
-          // — both anyref subtypes.
+          // — both anyref subtypes. A `get` MISS arrives as the $undefined
+          // singleton from `__map_get` itself under the #2106 regime (#3331,
+          // producer-honest miss), so no boundary materialization is needed.
           helperCall.push({ op: "extern.convert_any" });
         }
         let mapArmBody: Instr[];

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -25,6 +25,7 @@
  */
 import { ts } from "../ts-api.js";
 import type { Instr, StructTypeDef, ArrayTypeDef, ValType } from "../ir/types.js";
+import { ensureAnyValueType, undefinedSingletonActive } from "./any-helpers.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
 import { ensureObjVecBuilders, reserveApplyClosure } from "./object-runtime.js";
@@ -692,6 +693,22 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
 
   // ── __map_get(m, key) -> anyref ─────────────────────────────────────────
   {
+    // (#3331) MISS value: under the #2106 `$undefined`-singleton regime a
+    // missing key answers the singleton (miss ≡ undefined per §24.1.3.6 step
+    // 5), keeping it DISTINCT from a stored `null` — the legacy null-miss
+    // made `m.get(missing) === undefined` false (fourth instance of the
+    // singleton null-guard class). Legacy lanes keep `ref.null` (their
+    // undefined representation) byte-identically. The one internal null-keyed
+    // consumer (Map.groupBy) treats the singleton as miss explicitly below.
+    const missInstrs: Instr[] = (() => {
+      if (undefinedSingletonActive(ctx)) {
+        if (ctx.undefinedGlobalIdx === undefined) ensureAnyValueType(ctx);
+        if (ctx.undefinedGlobalIdx !== undefined) {
+          return [{ op: "global.get", index: ctx.undefinedGlobalIdx }];
+        }
+      }
+      return [{ op: "ref.null", typeIdx: NONE_HEAP }]; // legacy: undefined → null
+    })();
     // idx(2)
     const body: Instr[] = [
       { op: "local.get", index: 0 },
@@ -703,7 +720,7 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
       {
         op: "if",
         blockType: { kind: "val", type: anyref },
-        then: [{ op: "ref.null", typeIdx: NONE_HEAP }], // undefined → null
+        then: missInstrs,
         else: [
           { op: "local.get", index: 0 },
           {
@@ -1299,8 +1316,19 @@ export function ensureMapGroupBy(ctx: CodegenContext): number {
             { op: "call", funcIdx: mapGetIdx },
             { op: "local.set", index: 8 },
             // if groupAny is null → group = __objvec_new(); __map_set(out, keyAny, any(group))
+            // (#3331) under the singleton regime the __map_get MISS is the
+            // $undefined singleton (a `$AnyValue` box) — a group slot is
+            // always an objvec, so `ref.test $AnyValue` ⇔ miss. The extra
+            // test is regime-gated away in legacy lanes (byte-identical).
             { op: "local.get", index: 8 },
             { op: "ref.is_null" },
+            ...((undefinedSingletonActive(ctx) && ctx.anyValueTypeIdx >= 0
+              ? [
+                  { op: "local.get", index: 8 },
+                  { op: "ref.test", typeIdx: ctx.anyValueTypeIdx },
+                  { op: "i32.or" },
+                ]
+              : []) satisfies Instr[]),
             {
               op: "if",
               blockType: { kind: "empty" },
@@ -1449,6 +1477,17 @@ export function compileCollectionElementArg(
     // Canonical anyref-subtype null matching the runtime's ABSENT/`undefined`
     // sentinel — bypasses the `compileExpression` typed-`ref.null` + externref
     // mismatch.
+    // (#3331) Under the #2106 singleton regime an UNDEFINED literal stores
+    // the $undefined singleton (distinct from null) so `m.get(k)` reads back
+    // `undefined`, not `null`; a NULL literal keeps the canonical ref.null.
+    // Legacy lanes conflate both to ref.null byte-identically.
+    if (argExpr.kind !== ts.SyntaxKind.NullKeyword && undefinedSingletonActive(ctx)) {
+      if (ctx.undefinedGlobalIdx === undefined) ensureAnyValueType(ctx);
+      if (ctx.undefinedGlobalIdx !== undefined) {
+        fctx.body.push({ op: "global.get", index: ctx.undefinedGlobalIdx });
+        return;
+      }
+    }
     fctx.body.push({ op: "ref.null", typeIdx: NONE_HEAP });
     return;
   }

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -1323,11 +1323,7 @@ export function ensureMapGroupBy(ctx: CodegenContext): number {
             { op: "local.get", index: 8 },
             { op: "ref.is_null" },
             ...((undefinedSingletonActive(ctx) && ctx.anyValueTypeIdx >= 0
-              ? [
-                  { op: "local.get", index: 8 },
-                  { op: "ref.test", typeIdx: ctx.anyValueTypeIdx },
-                  { op: "i32.or" },
-                ]
+              ? [{ op: "local.get", index: 8 }, { op: "ref.test", typeIdx: ctx.anyValueTypeIdx }, { op: "i32.or" }]
               : []) satisfies Instr[]),
             {
               op: "if",

--- a/tests/issue-3331.test.ts
+++ b/tests/issue-3331.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3331 — the #2106 $undefined-singleton null-guard bug class (4th instance:
+ * Map/WeakMap get-miss). Guards:
+ *   1. Map/WeakMap `.get(missingKey) === undefined` — typed, any-receiver and
+ *      WeakMap lanes (the regression this PR fixes);
+ *   2. stored `null` stays distinct from a miss;
+ *   3. an `undefined` LITERAL element reads back as `undefined` with
+ *      `has === true`;
+ *   4. the miss-path A/B battery patterns that were already correct stay
+ *      correct (spot subset — the audit's full battery lives in the issue).
+ * All run under the DEFAULT regime (singleton ON for standalone).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#3331 — Map/WeakMap miss values under the $undefined singleton regime", () => {
+  it("typed Map.get(miss) === undefined", async () => {
+    expect(
+      await run(`export function test(): number {
+  const m = new Map<string, number>(); m.set("k", 1);
+  const v: any = m.get("zz"); return v === undefined ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("any-receiver Map.get(miss) === undefined", async () => {
+    expect(
+      await run(`export function test(): number {
+  const m: any = new Map(); m.set("k", 1);
+  return m.get("zz") === undefined ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("WeakMap.get(miss) === undefined", async () => {
+    expect(
+      await run(`export function test(): number {
+  const wm: any = new WeakMap(); const k: any = {};
+  return wm.get(k) === undefined ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stored null stays null (distinct from miss)", async () => {
+    expect(
+      await run(`export function test(): number {
+  const m: any = new Map(); m.set("k", null);
+  return m.get("k") === null && m.get("zz") === undefined ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("stored undefined LITERAL reads back undefined with has === true", async () => {
+    expect(
+      await run(`export function test(): number {
+  const m: any = new Map(); m.set("k", undefined); let n = 0;
+  if (m.get("k") === undefined) n += 1;
+  if (m.has("k")) n += 2;
+  return n === 3 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("clear() returns undefined (dispatch lane)", async () => {
+    expect(
+      await run(`export function test(): number {
+  const m: any = new Map(); m.set("a", 1);
+  return m.clear() === undefined && !m.has("a") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("miss-path battery spot set stays green (property/gopd/in/destructure)", async () => {
+    expect(
+      await run(`export function test(): number {
+  const o: any = { a: undefined, b: 2 }; let n = 0;
+  if (o.zz === undefined) n += 1;
+  if ("a" in o && !("zz" in o)) n += 2;
+  if (Object.getOwnPropertyDescriptor(o, "zz") === undefined) n += 4;
+  const { a = 5, zz = 6 } = o;
+  if (a === 5 && zz === 6) n += 8;
+  return n === 15 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Systematic audit of the #2106 $undefined-singleton null-guard bug class (tech-lead direct assignment)

#3328 was the THIRD silent regression rooted at the Jul-4 singleton flip (#3316 accessor halves, #3319 gOPD miss, #3328 toJSON guard — all the same shape: a null-keyed absence guard meets the non-null singleton miss value). This PR retires the class systematically instead of waiting for the fifth.

### Audit deliverables (`plan/issues/3331-*.md`)
- **Static sweep**: 20 candidate sites (every emitted call of a singleton-miss producer followed by a `ref.is_null` guard) — classification table: GATED / FIXED-by-#3316/#3319/#3328 / **fixed here** / pre-existing-out-of-class.
- **A/B regime battery**: 18 miss-path behavior patterns compiled+run under `JS2WASM_UNDEF_SINGLETON=0` vs `1`. Post-fix: **zero regime-divergent cases**.
- **Guard-authoring rule** documented (canonical nullish primitives, never bare `ref.is_null` on undefined-capable slots).
- **7 out-of-class pre-existing bugs** (fail BOTH regimes) listed for PO triage — incl. JSON replacer key-drop trap + reviver-delete, missing-method TypeError, ordinary ToPrimitive on typed literals, join hole rendering.

### The 4th instance, fixed (producer-honest, #3319 pattern, all regime-gated)
- `__map_get` miss → the $undefined singleton (distinct from stored `null`); `m.get(missing) === undefined` was false in typed, any-receiver AND WeakMap lanes.
- `undefined`-LITERAL elements store the singleton (read back `undefined`, not `null`); null literal keeps canonical `ref.null`.
- `Map.groupBy`'s internal null-keyed miss test treats the singleton as miss (`ref.test $AnyValue` — group slots are always objvecs).
- Collection-dispatch `clear()` returns the singleton (was null-extern).

### Validation
- `tests/issue-3331.test.ts`: **7/7** (all three get-miss lanes, stored-null distinctness, stored-undefined-literal + has, clear, miss-path spot battery)
- A/B battery: regime-divergent NONE; legacy lane **byte-identical** to pristine main (sha256 on map-using modules)
- loc-budget / coercion-sites / oracle-ratchet all green locally

Issue file carries `status: done` + the loc allowances. Cross-links #2106/#3316/#3319/#3328/#2606/#3008.