### PR TITLE
fix(#3318): in-process runner realm-pollution crash — restore host builtins at runTest262File entry

### DIFF
--- a/plan/issues/3318-declaredtype-property-on-number-crash.md
+++ b/plan/issues/3318-declaredtype-property-on-number-crash.md
@@ -1,7 +1,9 @@
 ---
 id: 3318
 title: 'Compiler crash: "Cannot create property ''declaredType'' on number ''1''" (prototype-delete pattern)'
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/fable-s2
 sprint: current
 created: 2026-07-16
 priority: high
@@ -49,3 +51,36 @@ practice of not bundling drive-by fixes into an unrelated method-family PR.
   failure, not an internal exception).
 - No regressions in the existing array-prototype / shape-widening test
   suites.
+
+## Root cause + fix (2026-07-17, fable-s2)
+
+**Not a per-test compiler bug — an in-process realm-pollution crash.** The
+in-process runner (`runTest262File`) compiles AND executes tests in the
+caller's own realm. `lastIndexOf/15.4.4.15-8-a-14.js` leaves
+`Array.prototype[1] = 1` behind (verified: the file PASSES alone, and the
+SAME file re-run in the same process then fails `compile_error`). The next
+compile crashes inside the TypeScript checker's
+`getDeclaredTypeOfClassOrInterface` during `initializeTypeChecker`: its
+`symbolLinks` lookup is a plain array read, so `symbolLinks[1]` INHERITS the
+polluted `Array.prototype[1]` → `links = 1` →
+"Cannot create property 'declaredType' on number '1'".
+
+The sharded CI worker has had `restoreBuiltins()` for this class since
+#1153/#1154/#1160/#1220/#1221 (the official lane passes both files) — the
+in-process runner (baseline validator, smoke-tests, residual-harvest
+measurements like #3170's, where this crash was OBSERVED) had no counterpart,
+so harvests manufactured phantom `compile_error` records that depended on
+in-process test ORDER.
+
+**Fix:** `tests/test262-restore-builtins.ts` (module-load snapshot of 12 core
+prototypes; delete added keys/symbols incl. numeric Array indices, re-assign
+changed data values with descriptor-fallback) + an ENTRY call in
+`runTest262File`. The worker's version stays untouched (coupled to fork
+recycle); unification is #3182 territory.
+
+## Test Results
+
+- `tests/issue-3318.test.ts` (4): cited files back-to-back → pass/pass; same
+  file twice → pass/pass (was pass → compile_error); synthetic numeric
+  pollution cleared; replaced method value restored.
+- Runner-consumer sweep: issue-1049/1318-locator/1385/1450/1567 — 24/24.

--- a/tests/issue-3318.test.ts
+++ b/tests/issue-3318.test.ts
@@ -1,0 +1,61 @@
+// (#3318) "Cannot create property 'declaredType' on number '1'" — an
+// in-process realm-pollution crash, not a per-test compiler bug. The
+// in-process runner (runTest262File) executes compiled test code in the
+// caller's own realm; lastIndexOf/15.4.4.15-8-a-14.js leaves
+// `Array.prototype[1] = 1` behind, and the NEXT compile crashes inside the
+// TypeScript checker (its symbolLinks array read inherits the polluted
+// index). Fix: restoreHostBuiltins() at runTest262File entry (the in-process
+// counterpart of the sharded worker's restoreBuiltins, #1153..#1221).
+import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { runTest262File } from "./test262-runner.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { compile } from "../src/index.js";
+
+const ROOT = "/workspace/test262/test/";
+const CITED = [
+  "built-ins/Array/prototype/indexOf/15.4.4.14-9-a-14.js",
+  "built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-14.js",
+];
+
+describe("#3318 prototype-pollution compile crash", () => {
+  it("both cited files run back-to-back in-process without an internal crash", async () => {
+    for (const rel of CITED) {
+      if (!existsSync(ROOT + rel)) return; // test262 checkout not present
+      const res = await runTest262File(ROOT + rel, rel.split("/")[0]!);
+      expect(String(res.error ?? ""), `${rel} must not crash the compiler internally`).not.toMatch(
+        /declaredType|Cannot create property/,
+      );
+      expect(res.status).toBe("pass");
+    }
+  });
+
+  it("the same file twice in one process stays green (entry restore)", async () => {
+    const rel = CITED[1]!;
+    if (!existsSync(ROOT + rel)) return;
+    const first = await runTest262File(ROOT + rel, rel.split("/")[0]!);
+    const second = await runTest262File(ROOT + rel, rel.split("/")[0]!);
+    expect(first.status).toBe("pass");
+    expect(second.status).toBe("pass"); // was compile_error pre-fix
+  });
+
+  it("restoreHostBuiltins clears synthetic numeric Array.prototype pollution", async () => {
+    (Array.prototype as unknown as Record<number, unknown>)[1] = 1;
+    expect(Object.getOwnPropertyDescriptor(Array.prototype, "1")).toBeDefined();
+    restoreHostBuiltins();
+    expect(Object.getOwnPropertyDescriptor(Array.prototype, "1")).toBeUndefined();
+    // And a compile after the restore works (a fresh checker initializes).
+    const r = await compile("export function test(): number { return 1; }", { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+  });
+
+  it("restores a replaced builtin method value", () => {
+    const orig = Array.prototype.includes;
+    // eslint-disable-next-line no-extend-native
+    (Array.prototype as unknown as Record<string, unknown>).includes = () => {
+      throw new Error("poisoned");
+    };
+    restoreHostBuiltins();
+    expect(Array.prototype.includes).toBe(orig);
+  });
+});

--- a/tests/test262-restore-builtins.ts
+++ b/tests/test262-restore-builtins.ts
@@ -1,0 +1,125 @@
+// (#3318) In-process host-realm builtin restore for tests/test262-runner.ts.
+//
+// The IN-PROCESS runner (`runTest262File`) compiles AND executes tests in the
+// caller's own realm: a test's compiled code mutates the REAL builtin
+// prototypes (e.g. `Array.prototype[1] = 1` in
+// built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-14.js), and the poison
+// survives into the NEXT call — where the TypeScript checker crashes with
+// "Cannot create property 'declaredType' on number '1'" (its `symbolLinks`
+// lookup is a plain array read, `symbolLinks[1]` inherits the polluted
+// Array.prototype[1]). The SHARDED CI worker (scripts/test262-worker.mjs) has
+// long had a comprehensive `restoreBuiltins()` (#1153/#1154/#1160/#1220/#1221)
+// — but it is coupled to the fork-pool recycle protocol and executes pool
+// logic at module load, so it cannot be imported here. This module is the
+// runner-side counterpart covering the compile-killing pollution classes;
+// unifying the two is part of the #3182 consolidation epic.
+//
+// Strategy mirrors the worker: value RE-ASSIGNMENT for changed props (never
+// defineProperty first — it disturbs V8 shape/IC caches, #1153), descriptor
+// re-application only as the fallback, DELETE for added keys. Non-configurable
+// poison is reported (return false) — an in-process caller cannot recycle a
+// fork, but it can surface the condition.
+
+const PROTOS: ReadonlyArray<[string, object]> = [
+  ["Object.prototype", Object.prototype],
+  ["Array.prototype", Array.prototype],
+  ["String.prototype", String.prototype],
+  ["Number.prototype", Number.prototype],
+  ["Boolean.prototype", Boolean.prototype],
+  ["Function.prototype", Function.prototype],
+  ["RegExp.prototype", RegExp.prototype],
+  ["Map.prototype", Map.prototype],
+  ["Set.prototype", Set.prototype],
+  ["WeakMap.prototype", WeakMap.prototype],
+  ["WeakSet.prototype", WeakSet.prototype],
+  ["Promise.prototype", Promise.prototype],
+];
+
+interface ProtoSnapshot {
+  name: string;
+  proto: object;
+  ownKeys: Set<string>;
+  ownSymbols: Set<symbol>;
+  /** Original VALUES of data properties (functions and primitives alike). */
+  values: Map<string | symbol, unknown>;
+  /** Original descriptors, for the defineProperty fallback. */
+  descs: Map<string | symbol, PropertyDescriptor>;
+}
+
+function snapshotProto(name: string, proto: object): ProtoSnapshot {
+  const ownKeys = new Set(Object.getOwnPropertyNames(proto));
+  const ownSymbols = new Set(Object.getOwnPropertySymbols(proto));
+  const values = new Map<string | symbol, unknown>();
+  const descs = new Map<string | symbol, PropertyDescriptor>();
+  for (const key of [...ownKeys, ...ownSymbols]) {
+    const d = Object.getOwnPropertyDescriptor(proto, key);
+    if (!d) continue;
+    descs.set(key, d);
+    if ("value" in d) values.set(key, d.value);
+  }
+  return { name, proto, ownKeys, ownSymbols, values, descs };
+}
+
+// Snapshot at MODULE LOAD — import this module before any test executes.
+const SNAPSHOTS: ProtoSnapshot[] = PROTOS.map(([name, proto]) => snapshotProto(name, proto));
+
+/**
+ * Restore the host realm's builtin prototypes to their module-load state.
+ * Returns `false` when some poison could not be removed (non-configurable,
+ * non-writable descriptor added by a test) — the caller should treat further
+ * in-process compiles as unreliable.
+ */
+export function restoreHostBuiltins(): boolean {
+  let clean = true;
+  for (const snap of SNAPSHOTS) {
+    const { proto, ownKeys, ownSymbols, values, descs } = snap;
+    // Delete ADDED keys (numeric-index pollution on Array.prototype is the
+    // compile-killing case — the TS checker's array-indexed symbolLinks).
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (!ownKeys.has(key)) {
+        try {
+          delete (proto as Record<string, unknown>)[key];
+        } catch {
+          /* fall through to the residual check */
+        }
+        if (Object.getOwnPropertyDescriptor(proto, key)) clean = false;
+      }
+    }
+    for (const sym of Object.getOwnPropertySymbols(proto)) {
+      if (!ownSymbols.has(sym)) {
+        try {
+          delete (proto as Record<symbol, unknown>)[sym];
+        } catch {
+          /* fall through */
+        }
+        if (Object.getOwnPropertyDescriptor(proto, sym)) clean = false;
+      }
+    }
+    // Restore CHANGED data values (deleted or replaced methods): plain `=`
+    // first (writable descriptors — the common case), descriptor
+    // re-application as the fallback (#1160 defineProperty-poisoned shapes).
+    for (const [key, orig] of values) {
+      const cur = Object.getOwnPropertyDescriptor(proto, key);
+      if (cur && "value" in cur && cur.value === orig) continue;
+      try {
+        (proto as Record<string | symbol, unknown>)[key] = orig;
+      } catch {
+        /* fall through */
+      }
+      const after = Object.getOwnPropertyDescriptor(proto, key);
+      if (!after || !("value" in after) || after.value !== orig) {
+        const d = descs.get(key);
+        if (d) {
+          try {
+            Object.defineProperty(proto, key, d);
+          } catch {
+            /* residual check below */
+          }
+        }
+        const final = Object.getOwnPropertyDescriptor(proto, key);
+        if (!final || ("value" in final && final.value !== orig)) clean = false;
+      }
+    }
+  }
+  return clean;
+}

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -15,6 +15,7 @@ import { createContext, runInContext } from "node:vm";
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
 import { ts } from "../src/ts-api.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
 
 // #1310: per-shard global isolation for test262.
 //
@@ -4003,6 +4004,17 @@ export async function runTest262File(
   // path rejects any non-empty import manifest, matching the sharded worker.
   target?: "standalone",
 ): Promise<TestResult> {
+  // (#3318) ENTRY restore: the previous in-process run may have executed test
+  // code that poisoned the REAL builtin prototypes (this runner compiles and
+  // runs in the caller's realm). E.g. `Array.prototype[1] = 1` left behind by
+  // lastIndexOf/15.4.4.15-8-a-14.js crashes the NEXT compile inside the TS
+  // checker ("Cannot create property 'declaredType' on number '1'" — its
+  // symbolLinks array read inherits the polluted index). The sharded CI
+  // worker has its own restoreBuiltins; this is the in-process counterpart.
+  // NOTE: the FINAL call still leaves that test's pollution in the process —
+  // callers doing further compiles outside the runner should invoke
+  // restoreHostBuiltins() themselves.
+  restoreHostBuiltins();
   const totalStart = performance.now();
   const relPath = relative(TEST262_ROOT, filePath);
   const source = readFileSync(filePath, "utf-8");


### PR DESCRIPTION
Closes plan issue #3318.

## Root cause — not a per-test compiler bug

`Cannot create property 'declaredType' on number '1'` is an **in-process realm-pollution crash**. `runTest262File` compiles AND executes tests in the caller's own realm: `built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-14.js` leaves `Array.prototype[1] = 1` behind (verified: the file passes ALONE; the SAME file re-run in the same process then fails `compile_error`). The next compile crashes inside the TypeScript checker's `getDeclaredTypeOfClassOrInterface` during `initializeTypeChecker`: the checker's `symbolLinks` lookup is a plain array read, so `symbolLinks[1]` inherits the polluted `Array.prototype[1]` → `links = 1` → the crash.

The sharded CI worker has had `restoreBuiltins()` for this class since #1153/#1154/#1160/#1220/#1221 (the official lane passes both cited files) — the **in-process** runner (baseline validator, smoke-tests, residual-harvest measurements like #3170's, where this was observed) had no counterpart, so harvests manufactured **order-dependent phantom compile_error records**.

## Fix

- `tests/test262-restore-builtins.ts` — module-load snapshot of 12 core prototypes; deletes added keys/symbols (incl. numeric Array indices), re-assigns changed data values with a descriptor-reapplication fallback (#1160 pattern), reports non-configurable residue. The worker's version stays untouched (coupled to fork-recycle); unification is #3182 territory.
- Entry call in `runTest262File` (each in-process run starts from restored builtins).

## Tests

`tests/issue-3318.test.ts` (4/4): both cited files back-to-back pass; same-file-twice pass/pass (was pass → compile_error); synthetic numeric pollution cleared; replaced method restored. Runner-consumer sweep (issue-1049/1318-locator/1385/1450/1567): 24/24.

Issue frontmatter rides as `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8