### PR TITLE
chore(plan): refill sprint queue — 7 promotions (round 2)

### DIFF
--- a/plan/issues/1032-compile-axios-to-wasm-node.md
+++ b/plan/issues/1032-compile-axios-to-wasm-node.md
@@ -1,6 +1,7 @@
 ---
 id: 1032
 title: "Compile axios to Wasm — Node builtins routed as host imports; harvest error patterns"
+horizon: l
 status: ready
 created: 2026-04-11
 updated: 2026-04-28
@@ -8,7 +9,7 @@ priority: high
 feasibility: hard
 reasoning_effort: high
 goal: npm-library-support
-sprint: Backlog
+sprint: current
 depends_on: [1044]
 ---
 # #1032 — Compile axios to Wasm as a real-world I/O stress test

--- a/plan/issues/2700-esquery-bundle-multi-blocker.md
+++ b/plan/issues/2700-esquery-bundle-multi-blocker.md
@@ -1,9 +1,10 @@
 ---
 id: 2700
 title: "esquery@1.7.0 bundle fails to compile — multi-blocker (PEG parser codegen index-shift + syntax + hard-type errors)"
+horizon: l
 status: ready
 assignee: ""
-sprint: Backlog
+sprint: current
 created: 2026-06-26
 priority: high
 feasibility: hard

--- a/plan/issues/3103-split-runtime-ts-host-runtime-by-concern.md
+++ b/plan/issues/3103-split-runtime-ts-host-runtime-by-concern.md
@@ -3,7 +3,7 @@ id: 3103
 title: "Split src/runtime.ts (15,032 LOC) host runtime by concern; decompose resolveImport (6,517-line function)"
 status: ready
 assignee: ttraenkler/opus-splitrt
-sprint: Backlog
+sprint: current
 created: 2026-07-09
 updated: 2026-07-13
 priority: high

--- a/plan/issues/3104-split-codegen-index-into-subsystem-modules.md
+++ b/plan/issues/3104-split-codegen-index-into-subsystem-modules.md
@@ -2,7 +2,7 @@
 id: 3104
 title: "Re-split codegen/index.ts (16,566 LOC, regrown 2.6x) into subsystem modules; driver-only index"
 status: ready
-sprint: Backlog
+sprint: current
 created: 2026-07-09
 updated: 2026-07-09
 priority: high

--- a/plan/issues/3308-e0-in-wasm-ast-consumer-probe.md
+++ b/plan/issues/3308-e0-in-wasm-ast-consumer-probe.md
@@ -11,7 +11,7 @@ task_type: test
 area: runtime, dogfood
 language_feature: eval
 goal: runtime-eval
-sprint: Backlog
+sprint: current
 parent: 2927
 related: [2928, 1584, 1710, 1712, 2841, 2851, 2852, 2847]
 ---

--- a/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
+++ b/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
@@ -11,7 +11,7 @@ task_type: feature
 area: codegen, standalone
 language_feature: dynamic-dispatch
 goal: runtime-eval
-sprint: Backlog
+sprint: current
 parent: 2927
 related: [2928, 1584, 2151, 1888, 3098]
 ---

--- a/plan/issues/3311-g4-string-vec-push-pop-carrier.md
+++ b/plan/issues/3311-g4-string-vec-push-pop-carrier.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: codegen, standalone
 language_feature: arrays
 goal: runtime-eval
-sprint: Backlog
+sprint: current
 parent: 2927
 related: [2784, 2928, 1584]
 ---


### PR DESCRIPTION
Second queue-fill for the Fable window: #1032, #2700, #3103, #3104, #3308, #3310, #3311 → sprint: current (+ horizons). Plan-files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8