### PR TITLE
docs(#3245): post-#3244 cold re-measure — cluster collapsed; file #3333 (standalone pattern-param default literal)

### DIFF
--- a/plan/issues/3245-async-gen-dstr-hostfree-fail-cluster-decomposition.md
+++ b/plan/issues/3245-async-gen-dstr-hostfree-fail-cluster-decomposition.md
@@ -1,7 +1,9 @@
 ---
 id: 3245
 title: "async-gen dstr host-free-FAIL cluster: root decomposition + error-path mirage + runner warm/cold artifact"
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/fable-s2
 sprint: current
 priority: medium
 feasibility: hard
@@ -29,13 +31,13 @@ host-free fails; classified by TRUE root (each verified by instrumenting the
 actual wrapped source + cold isolated repros — the per-assert line labels are
 unreliable, see Artifact A):
 
-| Root | ~files | Owner / disposition |
-| --- | --- | --- |
-| **any-boxed reference-element read** (#3244) | bulk | **#3244** (dominant gate) |
-| **any-strict-eq object identity** (`notSameValue`) | ~30 | opus-genproto3 (ref.eq object `===`, extends #2734) |
-| error-path throws (ReferenceError / TypeError) | ~29 | **MIRAGE — see below** |
-| `__array_from_iter_n` over-pull / IteratorClose | small | this issue (genuine, isolation-resistant) |
-| object-rest `{...rest}` exclusion | ~9 | this issue (verify vs #3244) |
+| Root                                               | ~files | Owner / disposition                                 |
+| -------------------------------------------------- | ------ | --------------------------------------------------- |
+| **any-boxed reference-element read** (#3244)       | bulk   | **#3244** (dominant gate)                           |
+| **any-strict-eq object identity** (`notSameValue`) | ~30    | opus-genproto3 (ref.eq object `===`, extends #2734) |
+| error-path throws (ReferenceError / TypeError)     | ~29    | **MIRAGE — see below**                              |
+| `__array_from_iter_n` over-pull / IteratorClose    | small  | this issue (genuine, isolation-resistant)           |
+| object-rest `{...rest}` exclusion                  | ~9     | this issue (verify vs #3244)                        |
 
 ## The error-path "root #2" is a MIRAGE (29 files)
 
@@ -67,7 +69,7 @@ into #3244; no independent error-machinery bug here.**
    iterator (`ary-init-iter-close.js`) traps "requested new array is too large
    in `__array_from_iter_n`" instead of pulling 1 + IteratorClose (`return()`).
    NOTE: the simplified local `const [x,y] = iter` and a plain-param `f([x])`
-   over an *incrementing* infinite iterator both work cold — this repro is
+   over an _incrementing_ infinite iterator both work cold — this repro is
    **isolation-resistant** (only the async-gen frame + the specific
    `{value:null,done:false}` iterator triggers it). Needs in-frame diagnosis.
 2. **object-rest `{a, b, ...rest}`** — `assert.sameValue(rest.a, undefined)`
@@ -107,3 +109,33 @@ genproto3 (any-eq). The residuals above are minor levers. Recommend landing
 `/workspace/.claude/worktrees/*/.tmp/`: `referr.mts`, `cold.mts`,
 `statebleed.mts`, `bitmask3.mts`, `iterpull.mts`, `parampull.mts`,
 `classify.mts`.
+
+## Post-#3244 cold re-measure (2026-07-17, fable-s2) — CLOSING
+
+#3244 is `done` on main. Cold isolated per-file re-runs (one process per
+file, `--target standalone`) of every residual this issue owned:
+
+| File                                                                   | Pre (#3245 filing) | Now                                  |
+| ---------------------------------------------------------------------- | ------------------ | ------------------------------------ |
+| `ary-init-iter-close.js` (residual 1: `__array_from_iter_n` over-pull) | trap               | **pass**                             |
+| `obj-ptrn-rest-val-obj.js` (residual 2: rest exclusion)                | fail               | **pass**                             |
+| `obj-ptrn-prop-obj-init.js` (#3244-rooted control)                     | fail cold          | **pass**                             |
+| `dflt-obj-ptrn-rest-val-obj.js`                                        | fail               | **still fails** (`rest.a` assert #1) |
+
+Both owned residuals collapsed with #3244's landing except the `dflt-`
+variant — and reduction shows that one is NOT a rest bug at all: the
+whole-pattern param **default OBJECT LITERAL never binds on standalone**
+(`function f({a,b}: any = {a:5,b:3}); f()` — even `a === 5` is false; the
+module-var default, host lane, and passed-arg variants all work). Filed as
+**#3333** with the full differential and a 6-line repro; that issue now owns
+the `dflt-*` dstr template family on the standalone lane.
+
+Artifact B (warm/cold order-dependence of the in-process runner) is at least
+partially addressed by #3318 (PR #3181): `restoreHostBuiltins()` at
+`runTest262File` entry removes cross-test REALM pollution, one confirmed
+order-dependence mechanism (it manufactured phantom compile_errors). If a
+non-pollution warm/cold flip is still observed after #3318 lands, measure it
+fresh — do not reopen this tracker.
+
+Disposition: analysis complete; all roots either landed (#3244), collapsed
+(error-path mirage), or precisely re-filed (#3333). Closing.

--- a/plan/issues/3333-standalone-pattern-param-default-literal.md
+++ b/plan/issues/3333-standalone-pattern-param-default-literal.md
@@ -1,0 +1,69 @@
+---
+id: 3333
+title: "standalone: whole-pattern param default OBJECT LITERAL never binds — `function f({a,b}: any = {a:5,b:3}); f()` reads garbage/NaN"
+horizon: s
+status: ready
+sprint: current
+priority: high
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring-params, default-values
+goal: standalone-mode
+related: [3245, 3244, 2568, 852]
+origin: "2026-07-17 fable-s2 — reduced from #3245's obj-rest residual (dflt-obj-ptrn-rest-val-obj.js) after the #3244 re-measure"
+---
+
+# #3333 — standalone pattern-param default literal never binds
+
+## Reduced repro (verified 2026-07-17 on current main, `--target standalone`)
+
+```ts
+export function test(): number {
+  let got = -1;
+  const f = function ({ a, b }: any = { a: 5, b: 3 }) {
+    got = a === 5 && b === 3 ? 1 : 0;
+  };
+  f();
+  return got; // → 0 (bindings read garbage/NaN); expected 1
+}
+```
+
+Precise differential (each single-variable):
+
+| variant                                              | result      |
+| ---------------------------------------------------- | ----------- |
+| standalone + pattern param + default LITERAL         | **0 (bug)** |
+| same, host (default) lane                            | 1           |
+| standalone, default is a module-level `const D: any` | 1           |
+| standalone, identifier param `o: any = {a:5,b:3}`    | 1           |
+| standalone, arg passed explicitly (default unused)   | 1           |
+| function DECLARATION form                            | **0 (bug)** |
+| with `...rest` in the pattern                        | **0 (bug)** |
+
+`rest.x` reads back NaN; even `a === 5` is false — the whole pattern binds
+from the wrong value when the default fires. The default CHECK fires
+correctly (the module-var default works), so the mismatch is between the
+shape the default LITERAL materializes in (`structHintForBindingPattern`,
+#2568 — WAT shows `f64.const 5; f64.const 3; struct.new <anon>`) and the
+shape `destructureParamObject`'s read path expects on the standalone lane
+(its `ref.test` fast path / dynamic fallback misses that struct, reads 0/NaN).
+Suspect: the two "mirrored" struct-type derivations diverge for `any`-typed
+patterns on standalone, or the destructure's else-branch (`__extern_get`
+dynamic read) cannot read the anonymous f64-field struct (the classic
+value-rep substrate gap, cf. project_standalone_any_string_value_read
+memory).
+
+## test262 anchor
+
+`language/expressions/async-generator/dstr/dflt-obj-ptrn-rest-val-obj.js`
+(fails `assert #1: rest.a === undefined`) — and every `dflt-*` dstr template
+sibling that routes a whole-pattern default literal on the standalone lane.
+The non-dflt twin (`obj-ptrn-rest-val-obj.js`) passes.
+
+## Acceptance
+
+- The reduced repro returns 1 on `--target standalone` (expression AND
+  declaration forms, with and without `...rest`).
+- `dflt-obj-ptrn-rest-val-obj.js` passes cold standalone.
+- Host lane byte-neutral or verified no-regression on the dstr family.


### PR DESCRIPTION
Closes plan issue #3245 (analysis tracker — docs-only + one new issue file, id via claim-issue --allocate).

Post-#3244 cold isolated re-measure of every residual this tracker owned:
- `ary-init-iter-close.js` (the `__array_from_iter_n` over-pull) → **pass**
- `obj-ptrn-rest-val-obj.js` (rest exclusion) → **pass**
- `obj-ptrn-prop-obj-init.js` (#3244-rooted control) → **pass**
- `dflt-obj-ptrn-rest-val-obj.js` → still fails — and reduction shows it is NOT a rest bug: **the whole-pattern param default OBJECT LITERAL never binds on standalone** (`function f({a,b}: any = {a:5,b:3}); f()` — even `a === 5` is false; module-var default / host lane / passed-arg all work). Filed as **#3333** with the 6-line repro + full single-variable differential.

Also notes Artifact B (runner warm/cold order-dependence) is at least partially the #3318 realm-pollution mechanism (PR #3181 adds `restoreHostBuiltins()` at `runTest262File` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8