### PR TITLE
refactor(#2955): slice 3 — string-rep externref-shaped reads move to resolver predicate

### DIFF
--- a/plan/issues/2955-ir-string-ops-depolymorph.md
+++ b/plan/issues/2955-ir-string-ops-depolymorph.md
@@ -4,8 +4,8 @@ title: "De-polymorph the IR front-end on string mode: abstract IR string ops res
 status: ready
 sprint: current
 created: 2026-07-02
-updated: 2026-07-10
-assignee: ttraenkler/fable-2856
+updated: 2026-07-17
+assignee: ttraenkler/fable-e
 priority: medium
 horizon: m
 feasibility: medium
@@ -236,3 +236,50 @@ number-`toString` capability site (string-rep-coupled: the host import's
 return IS host-mode's string carrier), `lowerStringMethodCall` (Slice 2, PR
 #2857, landed 2026-07-10), and the for-of strategy switch. `status` stays
 `ready`.
+
+## Slice 3 (2026-07-17, fable-e) — the string-rep externref-shaped class → `stringIsExternref`
+
+Re-measured against `upstream/main` @ `19e287460b`: the map had drifted again —
+the standalone "string→externref arm" sites (old 3402/4124) are **gone from
+main**, leaving 4 functional reads: 3366 (`coerceToExpectedExtern` string
+arm), 3586 (number-`toString` capability), 4454 (for-of strategy), 6332
+(`tryLowerUndefinedCompare` externref-shaped test). This slice takes the
+string-rep class the Slice-2 wrap-up grouped together: **3366 + 6332**.
+
+Both sites ask the identical rep question — "is `IrType.string`'s carrier
+externref (host strings), so a string SSA value can flow unchanged into an
+externref-expected position?" Following the Slice-2/number-box pattern, that
+question is now a resolver-owned predicate,
+`IrFromAstResolver.stringIsExternref()`, implemented in `integration.ts`
+(`makeFromAstResolver`) as exactly `!ctx.nativeStrings` (byte-inert
+relocation). The from-ast reads preserve each site's **legacy resolver-absent
+default**, which differed between the two sites:
+
+- 3366 read `!== false` (old `!cx.resolver?.nativeStrings?.()`: absent →
+  host-shaped → pass-through); its native arm falls to the demote throw —
+  a build-time claim/demote decision (no lower-time demote channel, same
+  constraint as `stringMethodPlan`/`hasHostNumberBox`). Unlike the
+  number-box capability there is **no widening follow-up** on this arm: a
+  native `(ref $AnyString)` can never satisfy an externref host-arg position.
+- 6332 read `=== true` (old `nativeStrings?.() === false`: absent → NOT
+  externref-shaped → fold path / demote). The native fold arm could later
+  move to a true abstract "is-undefined-on-string" op (the map's Slice-4
+  promotion); this slice relocates the mode knowledge only.
+
+**Verification**: sha256-identical compiled binaries vs pristine base in ALL
+THREE regimes (host / native / standalone) over a 20-source corpus (13
+playground examples + 7 targeted snippets covering: string→extern-class-arg,
+strict `===`/`!==  undefined` on `string` and `string | undefined`, string
+methods, string for-of, generator-yield-string, number-toString). Mutation
+check: inverting the predicate CHANGES host-mode hashes (t2-undef-cmp +
+dom/calendar/algorithms examples) — the corpus genuinely exercises both
+sites. `tsc --noEmit` clean; prettier clean; `check:ir-fallbacks` gate
+unchanged (0 post-claim demotions); `ir-frontend-widening` +
+`issue-2856-extern-in-ir` + `ir-algorithms-cluster` + `issue-2949-s5-2-eq`
+62/62; `logical-conditional-identity` 20/23 with the same 3 pre-existing
+`void x` TS-diagnostic failures on pristine base (verified base-vs-branch,
+unrelated).
+
+**Remaining after slice 3** (from-ast functional `nativeStrings` reads, 2):
+the number-`toString` capability site (~3600, slice 4 next) and the for-of
+strategy switch (~4470, slice 5). `status` stays `ready`.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -135,6 +135,28 @@ export interface IrFromAstResolver {
    * standalone `$AnyValue` boxing) is a semantic follow-up tracked in #2955.
    */
   hasHostNumberBox?(): boolean;
+  /**
+   * (#2955 slice 3) Rep predicate: is `IrType.string`'s carrier ValType
+   * externref (the host-strings backend), so a string SSA value can flow
+   * unchanged into an externref-expected position (host-call args,
+   * `__extern_is_undefined` operands)? The two from-ast string-rep arms
+   * (`coerceToExpectedExtern` string→externref pass-through,
+   * `tryLowerUndefinedCompare` externref-shaped test) previously read
+   * `nativeStrings` directly for this — a mode read the #2955 grep gate
+   * wants out of the front-end. The mode knowledge now lives on the
+   * resolver/lower side (`integration.ts`); from-ast only asks the rep
+   * question and demotes (or takes the native fold path) when the answer
+   * is no. The answer MUST stay a build-time answer: the native arm of
+   * `coerceToExpectedExtern` is a demote throw (claim/demote decisions
+   * have no lower-time channel — same constraint as `stringMethodPlan` /
+   * `hasHostNumberBox`). Implementation is intentionally
+   * `!ctx.nativeStrings` today (byte-inert relocation); a native string
+   * (`(ref $AnyString)`) can NEVER satisfy an externref host-arg position,
+   * so unlike the number-box capability there is no widening follow-up on
+   * the coercion arm — only the undefined-test's fold could ever move to a
+   * true abstract op (tracked in #2955's remaining-slices map).
+   */
+  stringIsExternref?(): boolean;
   resolveVec?(valType: ValType): IrVecLowering | null;
   /**
    * #1804 — register-or-recover the vec struct for an element ValType so
@@ -3358,12 +3380,18 @@ function coerceToExpectedExtern(value: IrValueId, expected: ValType, cx: LowerCt
   if (got && got.kind === expected.kind) {
     return value;
   }
-  // String → externref: in host-strings mode, IrType.string is already
-  // externref; the verifier sees the SSA type as `string` but the Wasm
-  // valtype is externref so the host call accepts it transparently.
-  // We keep the SSA type as-is and rely on the lowerer's ValType
-  // resolution.
-  if (expected.kind === "externref" && t.kind === "string" && !cx.resolver?.nativeStrings?.()) {
+  // String → externref: when the string carrier IS externref (host-strings
+  // mode), the verifier sees the SSA type as `string` but the Wasm valtype
+  // is externref so the host call accepts it transparently. We keep the
+  // SSA type as-is and rely on the lowerer's ValType resolution. When the
+  // carrier is the native `(ref $AnyString)` struct, a string can never
+  // satisfy an externref host-arg position → fall through to the demote
+  // throw. (#2955 slice 3: the rep question is resolver-owned —
+  // `stringIsExternref` — so from-ast reads no `nativeStrings` here. The
+  // `!== false` polarity deliberately preserves the legacy resolver-absent
+  // default of this site's old `!cx.resolver?.nativeStrings?.()` read:
+  // no resolver → host-shaped → pass-through.)
+  if (expected.kind === "externref" && t.kind === "string" && cx.resolver?.stringIsExternref?.() !== false) {
     return value;
   }
   // extern → externref: extern values are externref-shaped.
@@ -6326,10 +6354,15 @@ function tryLowerUndefinedCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, 
     return isStrictNeq ? cx.builder.emitUnary("i32.eqz", flag, irVal({ kind: "i32" })) : flag;
   }
   const tv = asVal(t);
+  // (#2955 slice 3) The string arm asks the resolver-owned rep predicate
+  // (`stringIsExternref`) instead of reading `nativeStrings` directly. The
+  // `=== true` polarity deliberately preserves the legacy resolver-absent
+  // default of this site's old `nativeStrings?.() === false` read: no
+  // resolver → NOT externref-shaped → fall to the fold path / demote.
   const externrefShaped =
     (tv !== null && tv.kind === "externref") ||
     t.kind === "extern" ||
-    (t.kind === "string" && cx.resolver?.nativeStrings?.() === false);
+    (t.kind === "string" && cx.resolver?.stringIsExternref?.() === true);
   if (externrefShaped) {
     const flag = cx.builder.emitCall({ kind: "func", name: "__extern_is_undefined" }, [v], irVal({ kind: "i32" }));
     if (flag === null) {

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1131,6 +1131,22 @@ function makeFromAstResolver(ctx: CodegenContext, sourceFile?: ts.SourceFile): I
     hasHostNumberBox(): boolean {
       return !ctx.nativeStrings;
     },
+    // (#2955 slice 3) Rep predicate: the string carrier is externref (host
+    // strings), so string SSA values flow unchanged into externref-expected
+    // positions (`coerceToExpectedExtern` host-call args) and take the
+    // externref-shaped `__extern_is_undefined` arm of the strict
+    // undefined-compare. The from-ast string-rep arms consult THIS
+    // predicate instead of reading `nativeStrings` directly — the mode
+    // knowledge lives here, on the lower/integration side, per #2955's
+    // de-polymorph direction. Implementation is deliberately the exact
+    // truth value the old in-place reads produced (byte-inert relocation).
+    // The demote arm this gates in `coerceToExpectedExtern` is a build-time
+    // claim/demote decision (no lower-time demote channel) and — unlike the
+    // number-box capability — has no widening follow-up: a native
+    // `(ref $AnyString)` can never satisfy an externref host-arg position.
+    stringIsExternref(): boolean {
+      return !ctx.nativeStrings;
+    },
     // (#2856 C2) TypedArray-view receiver detection for element STORES —
     // the same checker walk as the legacy `elementAccessTypedArrayName`
     // (assignment.ts): symbol name of the receiver's TS type against the


### PR DESCRIPTION
## Summary

Slice 3 of #2955 (de-polymorph the IR front-end on string mode). The two remaining **string-rep** `nativeStrings` reads in `src/ir/from-ast.ts` — `coerceToExpectedExtern`'s string→externref pass-through and `tryLowerUndefinedCompare`'s externref-shaped test — now consult a resolver-owned rep predicate, `IrFromAstResolver.stringIsExternref()`, implemented in `integration.ts` (`makeFromAstResolver`) as exactly `!ctx.nativeStrings`. Byte-inert truth-table relocation following the slice-2 `stringMethodPlan` / number-box `hasHostNumberBox` pattern: the mode knowledge moves to the lower/integration side; from-ast only asks the rep question.

Each read deliberately preserves its site's legacy resolver-absent default (they differed): the coerce site reads `!== false` (absent → host-shaped → pass-through), the undefined-test reads `=== true` (absent → fold path / demote). The coerce site's native arm stays a build-time demote throw (claim/demote decisions have no lower-time channel); unlike the number-box capability there is no widening follow-up there — a native `(ref $AnyString)` can never satisfy an externref host-arg position.

After this slice, 2 functional `nativeStrings` reads remain in from-ast (number-toString capability, for-of strategy — slices 4/5, map updated in the issue file).

## Verification

- **Byte-inert**: sha256-identical compiled binaries vs pristine base in ALL THREE regimes (host / native / standalone) over a 20-source corpus (13 playground examples + 7 targeted snippets: string→extern-class-arg, strict undefined-compare on `string` and `string | undefined`, string methods, string for-of, generator-yield-string, number-toString).
- **Mutation check**: inverting the predicate changes host-mode hashes (undefined-compare snippet + dom/calendar/algorithms examples) — the corpus genuinely exercises both sites.
- `tsc --noEmit` clean; prettier clean; `check:ir-fallbacks` unchanged (0 post-claim demotions).
- Scoped suites: `ir-frontend-widening` + `issue-2856-extern-in-ir` + `ir-algorithms-cluster` + `issue-2949-s5-2-eq` 62/62; `logical-conditional-identity` 20/23 with the same 3 pre-existing `void x` TS-diagnostic failures on pristine base (verified base-vs-branch, unrelated).

Issue file updated with the re-measured slice map (`status` stays `ready` — slices 4/5 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)