### PR TITLE
refactor(#2955): slice 4 — number-toString capability read moves to resolver predicate

### DIFF
--- a/plan/issues/2955-ir-string-ops-depolymorph.md
+++ b/plan/issues/2955-ir-string-ops-depolymorph.md
@@ -283,3 +283,31 @@ unrelated).
 **Remaining after slice 3** (from-ast functional `nativeStrings` reads, 2):
 the number-`toString` capability site (~3600, slice 4 next) and the for-of
 strategy switch (~4470, slice 5). `status` stays `ready`.
+
+## Slice 4 (2026-07-17, fable-e) — number-`toString` capability → `hasHostNumberToString`
+
+The `<number>.toString()` arm in `lowerMethodCall` read
+`nativeStrings?.() === false` as a PROXY for "does this lane own the
+`number_toString` `(f64) -> externref` host import?" (host-lane-only, and its
+return IS host-mode's string carrier — the mode read was doing capability
+duty). It now consults `IrFromAstResolver.hasHostNumberToString()`,
+implemented in `integration.ts` as exactly `!ctx.nativeStrings` — the
+boolean-capability shape of `hasHostNumberBox`, byte-inert truth table
+including the resolver-absent case (old `undefined === false` and new
+`undefined === true` are both false → demote).
+
+Same recorded constraints as the number-box slice: the answer stays a
+build-time answer (the native arm is a demote; no lower-time demote channel),
+and widening — a native number formatter returning the `(ref $AnyString)`
+carrier — is a semantic follow-up that must be validated against the
+standalone floor.
+
+**Verification**: sha256-identical compiled binaries vs the slice-3 parent
+commit in ALL THREE regimes (host / native / standalone) over the same
+20-source corpus; mutation check (predicate inverted) changes the
+number-toString snippet + dom/style example hashes in host mode — the site is
+genuinely exercised. `tsc --noEmit` clean; prettier clean;
+`check:ir-fallbacks` unchanged.
+
+**Remaining after slice 4** (from-ast functional `nativeStrings` reads, 1):
+the for-of strategy switch (~4470, slice 5 — last). `status` stays `ready`.

--- a/plan/issues/2955-ir-string-ops-depolymorph.md
+++ b/plan/issues/2955-ir-string-ops-depolymorph.md
@@ -309,5 +309,22 @@ number-toString snippet + dom/style example hashes in host mode — the site is
 genuinely exercised. `tsc --noEmit` clean; prettier clean;
 `check:ir-fallbacks` unchanged.
 
+**Also in this slice — selfhost build-resolver hardening (latent slice-3
+gap).** `IrFromAstResolver` has three implementers: `makeFromAstResolver`
+(integration, gets every predicate), `makeLinearIrResolver` (linear — omits
+`nativeStrings` entirely, so the per-site preserved resolver-absent defaults
+keep it byte-inert across all slices), and stdlib-selfhost's
+`NATIVE_STRINGS_FROMAST_RESOLVER` (`nativeStrings() → true`). The last one
+diverged after slice 3: site 3366's resolver-absent default is
+**pass-through** (host-shaped), the opposite of the demote-throw a
+native-strings build wants — a latent (corpus-unreachable, byte-diff- and
+CI-verified-inert today) hazard where a `(ref $AnyString)` could flow into an
+externref-expected position without the loud error. Fixed here by
+implementing `stringIsExternref() → false` (plus `hasHostNumberBox`/
+`hasHostNumberToString` → false explicitly — those absent-defaults already
+demoted, made total rather than lucky). Slice 5 must likewise give this
+resolver its for-of answer (`char-loop`), since the plan-absent default is
+iter-host.
+
 **Remaining after slice 4** (from-ast functional `nativeStrings` reads, 1):
 the for-of strategy switch (~4470, slice 5 — last). `status` stays `ready`.

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -159,6 +159,26 @@ const NATIVE_STRINGS_FROMAST_RESOLVER: IrFromAstResolver = {
   nativeStrings(): boolean {
     return true;
   },
+  // (#2955 slices 3/4) The de-polymorphed from-ast arms consult these
+  // resolver-owned predicates instead of `nativeStrings()`. This build
+  // resolver MUST implement them explicitly: the from-ast reads preserve
+  // their legacy resolver-ABSENT defaults, and for `stringIsExternref` that
+  // default (host-shaped → pass-through) is the OPPOSITE of what a
+  // native-strings build wants — omitting it would let a `(ref $AnyString)`
+  // silently flow into an externref-expected position instead of surfacing
+  // the loud demote-throw this resolver's scope-guard discipline relies on.
+  stringIsExternref(): boolean {
+    return false;
+  },
+  // Native-strings builds own no JS-host imports: no f64⇄externref box pair,
+  // no `number_toString`. (The absent-defaults already demote for these —
+  // implemented explicitly so the capability surface is total, not luck.)
+  hasHostNumberBox(): boolean {
+    return false;
+  },
+  hasHostNumberToString(): boolean {
+    return false;
+  },
   stringMethodPlan(method: string) {
     return NATIVE_STRING_METHOD_PLANS.get(method) ?? null;
   },

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -157,6 +157,23 @@ export interface IrFromAstResolver {
    * true abstract op (tracked in #2955's remaining-slices map).
    */
   stringIsExternref?(): boolean;
+  /**
+   * (#2955 slice 4) Capability predicate: does this compile's lane own the
+   * `number_toString` `(f64) -> externref` host import (pre-registered by
+   * the legacy source scan whenever a checker-number `.toString()` appears
+   * in source)? The from-ast `<number>.toString()` arm previously read
+   * `nativeStrings?.() === false` as a PROXY for this — the import is
+   * host-lane-only AND its return is host-mode's string carrier
+   * (externref), so the mode read was doing capability duty. Same shape as
+   * `hasHostNumberBox`: the answer MUST stay a build-time answer (the
+   * native arm is a demote — no lower-time demote channel), the
+   * implementation is intentionally `!ctx.nativeStrings` today (byte-inert
+   * relocation), and widening (a native number formatter whose return is
+   * the `(ref $AnyString)` carrier) is a semantic follow-up tracked in
+   * #2955's remaining-slices map, to be validated against the standalone
+   * floor.
+   */
+  hasHostNumberToString?(): boolean;
   resolveVec?(valType: ValType): IrVecLowering | null;
   /**
    * #1804 — register-or-recover the vec struct for an element ValType so
@@ -3600,18 +3617,22 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   // (#2856) `<number>.toString()` (no radix) on an f64 receiver → the
   // `number_toString` `(f64) -> externref` host import, pre-registered by the
   // legacy source scan whenever a checker-number `.toString()` appears in
-  // source (src/codegen/index.ts ~9100). Host-strings mode only: the import
-  // returns a HOST string (externref), which is exactly `IrType.string`'s
+  // source (src/codegen/index.ts ~9100). The import is host-lane-only and
+  // its return is a HOST string (externref), which is exactly `IrType.string`'s
   // carrier there — so the result composes with the string `+` proof arms
-  // (`"n=" + i.toString()`). Native-strings mode has a `(ref $AnyString)`
-  // carrier and demotes here (native number formatting is a follow-up arm);
+  // (`"n=" + i.toString()`). (#2955 slice 4: that availability question is
+  // resolver-owned — `hasHostNumberToString` — so from-ast reads no
+  // `nativeStrings` here. The `=== true` polarity preserves the legacy
+  // resolver-absent default of this site's old `nativeStrings?.() === false`
+  // read: no resolver → demote.) Lanes without the import (native strings:
+  // `(ref $AnyString)` carrier, no native number formatter yet) demote here;
   // radix args likewise demote.
   if (
     methodName === "toString" &&
     expr.arguments.length === 0 &&
     recvType.kind === "val" &&
     recvType.val.kind === "f64" &&
-    cx.resolver?.nativeStrings?.() === false
+    cx.resolver?.hasHostNumberToString?.() === true
   ) {
     const r = cx.builder.emitCall({ kind: "func", name: "number_toString" }, [recv], { kind: "string" });
     if (r === null) {

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1147,6 +1147,20 @@ function makeFromAstResolver(ctx: CodegenContext, sourceFile?: ts.SourceFile): I
     stringIsExternref(): boolean {
       return !ctx.nativeStrings;
     },
+    // (#2955 slice 4) Capability: this lane owns the `number_toString`
+    // `(f64) -> externref` host import (legacy pre-registers it on any
+    // checker-number `.toString()` in source; its return IS host-mode's
+    // string carrier). The from-ast `<number>.toString()` arm consults THIS
+    // predicate instead of reading `nativeStrings` directly — same
+    // build-time capability shape as `hasHostNumberBox`, deliberately the
+    // exact truth value the old in-place `nativeStrings?.() === false` read
+    // produced (byte-inert relocation). Widening — a native number
+    // formatter returning the `(ref $AnyString)` carrier — is a semantic
+    // follow-up tracked in #2955 and must be validated against the
+    // standalone floor (the demote arm is load-bearing there).
+    hasHostNumberToString(): boolean {
+      return !ctx.nativeStrings;
+    },
     // (#2856 C2) TypedArray-view receiver detection for element STORES —
     // the same checker walk as the legacy `elementAccessTypedArrayName`
     // (assignment.ts): symbol name of the receiver's TS type against the


### PR DESCRIPTION
## Summary

Slice 4 of #2955 (follows slice 3, PR #3187). The `<number>.toString()` arm in `lowerMethodCall` read `nativeStrings?.() === false` as a proxy for "this lane owns the `number_toString` `(f64) -> externref` host import" (host-lane-only, and its return IS host-mode's string carrier — the mode read was doing capability duty). It now consults `IrFromAstResolver.hasHostNumberToString()`, implemented in `integration.ts` as exactly `!ctx.nativeStrings` — the boolean-capability shape of `hasHostNumberBox`, byte-inert truth table including the resolver-absent case (old `undefined === false` and new `undefined === true` both demote).

**Also: selfhost build-resolver hardening (closes a latent slice-3 gap).** `IrFromAstResolver` has three implementers; stdlib-selfhost's `NATIVE_STRINGS_FROMAST_RESOLVER` (`nativeStrings→true`) diverged latently after slice 3: `coerceToExpectedExtern`'s resolver-absent default is pass-through — the opposite of the demote-throw a native-strings build wants. This PR implements `stringIsExternref() → false` there explicitly (plus `hasHostNumberBox`/`hasHostNumberToString` → false — those absent-defaults already demoted; made total rather than lucky). The linear resolver omits `nativeStrings` entirely, so the per-site preserved absent-defaults keep it byte-inert across all slices (verified). Corpus-unreachable today (byte-diff + green CI on #3187 confirm inert), fixed before it can matter.

## Verification

- **Byte-inert**: sha256-identical compiled binaries vs the slice-3 parent commit in ALL THREE regimes (host / native / standalone) over the 20-source corpus (13 playground examples + 7 targeted snippets).
- **Mutation check**: inverting the predicate changes the number-toString snippet + dom/style example hashes in host mode — the site is genuinely exercised.
- `tsc --noEmit` clean; prettier clean; `check:ir-fallbacks` unchanged (0 post-claim demotions); `issue-3161` + `issue-3256` selfhost suites 17/17.

Slice 5 (for-of strategy + removing `nativeStrings` from the from-ast interface) is stacked on this branch and opens after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)