### PR TITLE
fix(#3163): new (Fn as any)() constructs the fnctor/class instance — unwrap cast callees in the identifier arms

### DIFF
--- a/plan/issues/3163-new-fnctor-via-any-cast-callee-returns-null.md
+++ b/plan/issues/3163-new-fnctor-via-any-cast-callee-returns-null.md
@@ -1,18 +1,23 @@
 ---
 id: 3163
 title: "`new (Fn as any)()` on a function-style constructor returns null (dynamic-callee construct drops the instance)"
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/fable-b
 sprint: current
 priority: medium
 horizon: m
 feasibility: medium
 created: 2026-07-12
+updated: 2026-07-17
 task_type: bugfix
 area: codegen
 language_feature: function-constructors, new-expression, any-callee
 goal: self-hosting-dogfood
 related: [1725, 1632, 3033, 3005]
 origin: "blocked minimal repros while investigating #3033 Bug 2a (dev-3051c)"
+loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
 ---
 
 # #3163 — `new (Fn as any)()` on a fnctor returns null
@@ -67,3 +72,26 @@ ref.cast-null family).
 - `new (P as any)()` returns `{ v: 7 }` (not null); `new P()` regression-free.
 - A minimal fnctor-via-cast construct + field read round-trips.
 - No test262 regression.
+
+## Fix (fable-b, 2026-07-17)
+
+Root cause was simpler than the suggested dynamic-path theory: the CLASS and
+FNCTOR identifier arms in `compileNewExpression` (new-super.ts) gated on the
+RAW callee node — `ts.isIdentifier(expr.expression)` — so any cast/paren
+wrapper missed both arms entirely and fell to the dynamic path's null base.
+No host bridge was even reached (traced: zero imports fire; the null is
+static). The #1528b unwrap (`unwrappedNonId`) already existed for the
+non-constructor GUARDS; the fix routes the identifier ARMS through the same
+unwrapped node (`calleeIdent`), including the `getSymbolAtLocation`
+resolution (a cast node has no symbol of its own).
+
+Fixed shapes (tests/issue-3163.test.ts, 5/5): `new (P as any)()`,
+`new (P as any as { new(): any })()`, `new (C as any)()` for a compiled
+class (same raw-node gate), bare `new P()` unregressed, and the
+`new ((() => {}) as any)()` / `new (Math as any)()` TypeError guards still
+fire (they run before the arms).
+
+Observed pre-existing residual (NOT this issue, present on bare `new Pt(2,5)`
+too): a 2-arg fnctor whose ctor sums params yields the second arg only
+(`this.s = x + y` reads 5, not 7) — the cast path now matches the bare
+path's behavior exactly, which is this issue's acceptance bar.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3069,8 +3069,18 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       className = mapped;
     }
   }
-  if ((!className || !ctx.classSet.has(className)) && ts.isIdentifier(expr.expression)) {
-    const idName = expr.expression.text;
+  // (#3163) Resolve the callee identifier THROUGH cast/paren wrappers —
+  // `new (P as any)()` must construct exactly like `new P()`. The raw-node
+  // `ts.isIdentifier(expr.expression)` gates below made every cast-wrapped
+  // identifier callee (the natural minimal-repro shape, and the "ctor stored
+  // behind an `any` cast" idiom) miss the class/fnctor arms and fall through
+  // to the dynamic path, which yielded null. `unwrappedNonId` is the #1528b
+  // unwrap (parens / `as` / `!` / type assertions) computed above; a cast
+  // never changes the runtime VALUE, so symbol resolution on the unwrapped
+  // identifier reflects the actual binding.
+  const calleeIdent = ts.isIdentifier(unwrappedNonId) ? unwrappedNonId : undefined;
+  if ((!className || !ctx.classSet.has(className)) && calleeIdent) {
+    const idName = calleeIdent.text;
     if (ctx.classSet.has(idName)) {
       className = idName;
     } else {
@@ -3185,8 +3195,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
   // Check if the identifier resolves to a function declaration used as constructor
   // (e.g. `function Foo() { this.x = 1; }; new Foo()`)
-  if ((!className || !ctx.classSet.has(className)) && ts.isIdentifier(expr.expression)) {
-    const fnName = expr.expression.text;
+  // (#3163) `calleeIdent` — the cast/paren-unwrapped identifier — so
+  // `new (Foo as any)()` takes the same fnctor build path as `new Foo()`.
+  if ((!className || !ctx.classSet.has(className)) && calleeIdent) {
+    const fnName = calleeIdent.text;
     // Check cache first — if we already built a constructor for this function
     const cachedFnCtor = ctx.funcConstructorMap.get(fnName);
     if (cachedFnCtor) {
@@ -3213,7 +3225,9 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
     // Resolve via type checker to find the function declaration
     if (!cachedFnCtor) {
-      const exprSymbol = ctx.checker.getSymbolAtLocation(expr.expression);
+      // (#3163) Resolve on the unwrapped identifier — a cast/paren node has no
+      // symbol of its own.
+      const exprSymbol = ctx.checker.getSymbolAtLocation(calleeIdent);
       const decls = exprSymbol?.getDeclarations();
       if (decls) {
         for (const decl of decls) {

--- a/tests/issue-3163.test.ts
+++ b/tests/issue-3163.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3163 — `new (Fn as any)()` on a function-style constructor returned null.
+//
+// The class/fnctor arms in compileNewExpression gated on the RAW callee node
+// being an identifier (`ts.isIdentifier(expr.expression)`), so a cast/paren
+// wrapper — `new (P as any)()`, the natural minimal-repro shape and the
+// "constructor stored behind an any cast" idiom — missed both arms and fell
+// to the dynamic path, which yielded null. The #1528b unwrap
+// (`unwrappedNonId`: parens / `as` / `!` / type assertions) already existed
+// for the non-constructor GUARDS; the fix routes the identifier ARMS through
+// the same unwrapped node (`calleeIdent`), so a cast callee constructs
+// exactly like the bare identifier. Guards are unaffected (they fire before
+// the arms): `new ((() => {}) as any)()` and `new (Math as any)()` still
+// throw TypeError.
+
+import { describe, expect, it } from "vitest";
+
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+describe("#3163 — new (Fn as any)() constructs the fnctor instance", () => {
+  it("single as-any cast returns the instance", async () => {
+    const src = `
+      function P(this: any): void { this.v = 7; }
+      export function test(): string {
+        const p: any = new (P as any)();
+        return p === null ? "NULL" : ("ok v=" + (p.v as number));
+      }
+    `;
+    const exports = await compileAndInstantiate(src);
+    expect(String((exports.test as () => unknown)())).toBe("ok v=7");
+  });
+
+  it("double cast (as any as { new(): any }) returns the instance", async () => {
+    const src = `
+      function P(this: any): void { this.v = 7; }
+      export function test(): string {
+        const p: any = new (P as any as { new (): any })();
+        return p === null ? "NULL" : ("ok v=" + (p.v as number));
+      }
+    `;
+    const exports = await compileAndInstantiate(src);
+    expect(String((exports.test as () => unknown)())).toBe("ok v=7");
+  });
+
+  it("cast CLASS constructor also constructs (same raw-node gate)", async () => {
+    const src = `
+      class C { x: number; constructor() { this.x = 3; } }
+      export function test(): string {
+        const c: any = new (C as any)();
+        return c === null ? "NULL" : ("ok x=" + (c.x as number));
+      }
+    `;
+    const exports = await compileAndInstantiate(src);
+    expect(String((exports.test as () => unknown)())).toBe("ok x=3");
+  });
+
+  it("bare identifier path unregressed", async () => {
+    const src = `
+      function P(this: any): void { this.v = 7; }
+      export function test(): string {
+        const p: any = new P();
+        return p === null ? "NULL" : ("ok v=" + (p.v as number));
+      }
+    `;
+    const exports = await compileAndInstantiate(src);
+    expect(String((exports.test as () => unknown)())).toBe("ok v=7");
+  });
+
+  it("non-constructor guards still fire through casts (arrow / Math)", async () => {
+    const src = `
+      export function test(): string {
+        let out = "";
+        try { new ((() => {}) as any)(); out += "no-throw"; } catch (e) { out += (e instanceof TypeError ? "TypeError" : "other"); }
+        out += "|";
+        try { new (Math as any)(); out += "no-throw"; } catch (e) { out += (e instanceof TypeError ? "TypeError" : "other"); }
+        return out;
+      }
+    `;
+    const exports = await compileAndInstantiate(src);
+    expect(String((exports.test as () => unknown)())).toBe("TypeError|TypeError");
+  });
+});


### PR DESCRIPTION
## Summary

`new (P as any)()` on a function-style constructor returned **null** instead of the instance (#3163). This blocked minimal-scale repros of every fnctor-instance bug (the natural compact-repro shape) and the "constructor stored in an any-typed slot" idiom.

## Root cause

Simpler than the issue's dynamic-path theory: the CLASS and FNCTOR identifier arms in `compileNewExpression` (new-super.ts) gate on the RAW callee node — `ts.isIdentifier(expr.expression)` — so a cast/paren wrapper missed both arms entirely and fell to the dynamic path's **static null base** (traced: zero host imports fire at runtime; the null is compile-time). The #1528b unwrap (`unwrappedNonId`, parens / `as` / `!` / type assertions) already existed for the non-constructor guards.

## Fix

Route the identifier ARMS through the same unwrapped node (`calleeIdent`), including the `getSymbolAtLocation` resolution (a cast node has no symbol of its own). A cast never changes the runtime value, so unwrapped-symbol resolution reflects the actual binding.

- `new (P as any)()` / `new (P as any as { new(): any })()` → the instance (was null)
- `new (C as any)()` for a compiled class → the instance (same raw-node gate, bonus fix)
- bare `new P()` unregressed; guards (`new ((() => {}) as any)()`, `new (Math as any)()`) still throw TypeError — they run before the arms

## Validation

- `tests/issue-3163.test.ts` 5/5 (both cast forms, class cast, bare unregressed, guard parity)
- `dynamic-new` / `issue-3087` fnctor suites green; oracle ratchet +0/+0; LOC allowance granted in the issue file
- Noted in the issue: a pre-existing 2-arg fnctor residual (`this.s = x + y` yields the 2nd arg) reproduces on the BARE path too — out of scope; cast path now matches bare exactly (the acceptance bar)

Closes #3163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8