### PR TITLE
chore(#3008): wire tests/*.test.ts into CI — post-merge sharded detector + per-PR changed-tests gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,35 @@ jobs:
         # equivalence shards.
         run: pnpm exec vitest run tests/issue-1580.test.ts
 
+      - name: Changed root test files must pass (#3008)
+        # Per-PR half of the #3008 wiring (the post-merge half is
+        # .github/workflows/issue-tests.yml): any tests/*.test.ts file this PR
+        # ADDS or MODIFIES must pass, so a per-issue regression test cannot be
+        # born broken (and touching a rotted one means fixing it — the
+        # fix-on-touch ratchet). Root files only; tests/equivalence/ has its
+        # own gate (#1659) and linear-*/c-abi/simd* run in `linear-tests`.
+        # Mass edits (>20 files, e.g. a repo-wide reformat) skip with a
+        # warning — the post-merge detector covers them.
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=200 origin main 2>/dev/null || true
+          BASE=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
+          if [ -z "$BASE" ]; then echo "No merge base resolvable — skipping."; exit 0; fi
+          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE" HEAD -- tests/ \
+            | grep -E '^tests/[^/]+\.test\.ts$' \
+            | grep -vE '^tests/(linear-|c-abi\.|simd)' || true)
+          if [ -z "$CHANGED" ]; then echo "No root test files changed."; exit 0; fi
+          N=$(echo "$CHANGED" | wc -l)
+          if [ "$N" -gt 20 ]; then
+            echo "::warning::$N root test files changed (>20, likely a mass edit) — skipping the per-PR gate; the post-merge issue-tests detector covers them."
+            exit 0
+          fi
+          echo "Running $N changed root test file(s):"
+          echo "$CHANGED"
+          # Invoke vitest directly (not `pnpm test --`) so the file list is
+          # scoped to vitest and not consumed by pnpm (see PR #432).
+          pnpm exec vitest run $CHANGED --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+
       - name: Conformance numbers in sync (#1522)
         run: pnpm run sync:conformance:check
 

--- a/.github/workflows/issue-tests.yml
+++ b/.github/workflows/issue-tests.yml
@@ -1,0 +1,128 @@
+# #3008 — Root-test-suite (tests/*.test.ts) post-merge regression detector.
+#
+# The ~2,100 per-issue/feature test files at the tests/ root are the project's
+# regression memory, but no CI job ran them — four silent main-regressions of
+# this class were found on 2026-07-16 alone (#1284 ambient-shadow extern-class
+# break, JSON.stringify 3/9, #3307 accessor-merge casts, #3316 tagged-template
+# CEs). The full suite is ~9 CPU-hours single-fork — far too slow to gate
+# every PR — so the wiring is two-layered (decision recorded in
+# plan/issues/3008-issue-tests-not-in-required-ci.md):
+#
+#   1. THIS workflow: post-merge (push:main, burst-deduped) + 6-hourly cron +
+#      manual dispatch. Sharded single-fork run of the whole root suite,
+#      gated against a known-failures baseline stored in
+#      loopdive/js2wasm-baselines (workflows cannot push to main — GH013).
+#      Only NEW failures fail the run (the pre-existing rot backlog, ~40% of
+#      files sampled, is baselined and tracked for triage); newly-fixed tests
+#      auto-ratchet the baseline down. A regression goes red on main within
+#      one run instead of silently rotting.
+#   2. Per-PR (ci.yml `quality`): the tests/*.test.ts files a PR adds or
+#      modifies must pass — a test cannot be born broken, and new files are
+#      automatically inside this workflow's glob (no wiring step to forget).
+#
+# Concurrency: latest-wins, no per-SHA groups — unlike promote-baseline this
+# is a cumulative detector (the newest run covers all earlier merges), so
+# collapsing a merge burst to one run is correct and caps runner usage.
+name: issue-tests
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: issue-tests-main
+  cancel-in-progress: false
+
+jobs:
+  shard:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # max-parallel keeps runners free for PR-critical jobs (test262 shards,
+      # quality); the detector's latency is not on any merge's critical path.
+      max-parallel: 6
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - name: Run root-suite shard ${{ matrix.shard }}/12
+        env:
+          SHARD: ${{ matrix.shard }}/12
+          PARTIAL_OUT: issue-tests-partial-${{ matrix.shard }}.json
+        run: node scripts/issue-tests-gate.mjs
+      - name: Upload partial result
+        uses: actions/upload-artifact@v6
+        with:
+          name: issue-tests-partial-${{ matrix.shard }}
+          path: issue-tests-partial-${{ matrix.shard }}.json
+          retention-days: 3
+
+  gate:
+    needs: shard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - name: Download shard partials
+        uses: actions/download-artifact@v7
+        with:
+          pattern: issue-tests-partial-*
+          path: issue-tests-partials
+          merge-multiple: true
+      - name: Fetch baseline from js2wasm-baselines
+        env:
+          BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "$BASELINE_DEPLOY_KEY" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git clone --depth=1 git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
+      - name: Gate against baseline (bootstrap + auto-ratchet)
+        env:
+          MERGE_PARTIALS_DIR: issue-tests-partials
+          ISSUE_TESTS_BASELINE: /tmp/js2wasm-baselines/issue-tests-baseline.json
+          ALLOW_BOOTSTRAP: "1"
+        run: node scripts/issue-tests-gate.mjs --update-on-decrease
+      - name: Push ratcheted baseline back
+        # Runs even when the gate failed (new regressions) — a newly-fixed
+        # test's ratchet-down should still bank, and a bootstrap must persist.
+        if: always()
+        env:
+          BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+        run: |
+          cd /tmp/js2wasm-baselines
+          git add issue-tests-baseline.json 2>/dev/null || exit 0
+          if git diff --cached --quiet; then
+            echo "Baseline unchanged."
+            exit 0
+          fi
+          eval "$(ssh-agent -s)"
+          echo "$BASELINE_DEPLOY_KEY" | ssh-add -
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(#3008): issue-tests baseline refresh (main@${{ github.sha }})"
+          # Latest-wins retry against concurrent baseline pushes.
+          for i in 1 2 3; do
+            git push && exit 0
+            git pull --rebase || { git rebase --abort 2>/dev/null; git fetch origin main; git reset --hard origin/main; git add issue-tests-baseline.json; git commit -m "chore(#3008): issue-tests baseline refresh (main@${{ github.sha }})"; }
+          done
+          git push

--- a/plan/issues/3008-issue-tests-not-in-required-ci.md
+++ b/plan/issues/3008-issue-tests-not-in-required-ci.md
@@ -1,10 +1,11 @@
 ---
 id: 3008
 title: "process gap: tests/issue-*.test.ts are not uniformly wired into required CI (silent regressions)"
-status: ready
+status: done
+completed: 2026-07-17
 sprint: current
 priority: low
-assignee: ttraenkler/unassigned
+assignee: ttraenkler/fable-s2
 created: 2026-07-03
 feasibility: medium
 reasoning_effort: low
@@ -64,3 +65,46 @@ re-break (as #2767 did).
   RAM/time tradeoff considered.
 - (If adopted) the wiring lands and a deliberately-broken per-issue test fails
   CI.
+
+## Decision + implementation (2026-07-17, fable-s2)
+
+**Audit.** Population: 2,092 root `tests/*.test.ts` files (1,739 `issue-*`)
+run by NO CI job (only `tests/equivalence/` (#1659), `linear-*`/`c-abi`/`simd*`
+(#2139), and ~7 individually-named files in `quality` were wired). A 30-file
+random sample on main: **12/30 files failing (40%), 57 failing assertions** —
+dominated by stale-harness rot (e.g. missing the newer `string_constants`
+import namespace — same mechanism as the `externref.test.ts` 5/5 break) plus
+genuine silent regressions (four found on 2026-07-16 alone: #1284
+ambient-shadow extern-class break, JSON.stringify 3/9, #3307, #3316).
+
+**Decision (RAM/time tradeoff).** The full suite is ~9 CPU-hours single-fork —
+infeasible as a per-PR required gate. Two-layer wiring instead:
+
+1. **Post-merge detector** — `.github/workflows/issue-tests.yml`: push:main
+   (burst-deduped via a latest-wins concurrency group) + 6-hourly cron +
+   dispatch; 12 shards (max-parallel 6, off the merge critical path), merged
+   by `scripts/issue-tests-gate.mjs` against a known-failures baseline stored
+   in `loopdive/js2wasm-baselines` (`issue-tests-baseline.json` — workflows
+   cannot push to main, GH013). First run BOOTSTRAPS the baseline (the rot
+   backlog); newly-fixed tests auto-ratchet it down
+   (`--update-on-decrease`); any NEW failure fails the run → red on main
+   within one run instead of silent rot. Collection-time errors (broken
+   imports) count as failures (`<file> :: <collect>`), closing the
+   zero-assertion blind spot.
+2. **Per-PR born-green gate** — `quality` step "Changed root test files must
+   pass (#3008)": every root test file a PR adds or modifies must pass
+   (fix-on-touch for rotted files; >20-file mass edits skip with a warning).
+   New test files are automatically inside the detector's enumeration — a
+   test cannot be born unwired.
+
+**Not adopted:** making the full suite a required per-PR/merge_group check
+(cost would throttle the queue), and auto-committing the baseline to main
+(GH013 — merge queue blocks workflow pushes; the #491 planning-artifacts
+auto-commit hit the same wall).
+
+**Follow-ups:** the bootstrapped baseline enumerates the failing-on-main set —
+triage/file the rot clusters from `js2wasm-baselines/issue-tests-baseline.json`
+after the first run (PO/tech-lead sweep; the class-suite cluster
+(`class-methods` 17F/0P etc.) is likely one stale-harness fix). The
+`array-externref-indexof.test.ts` broken import cited in the finding no longer
+exists on main (already removed/fixed).

--- a/scripts/issue-tests-gate.mjs
+++ b/scripts/issue-tests-gate.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// #3008 — Root-test-suite (tests/*.test.ts) regression gate.
+//
+// The per-issue suites under tests/*.test.ts are the project's regression
+// memory, but they were not wired into ANY CI job — a fixed issue could
+// silently re-break on main (four separate silent main-regressions were found
+// on 2026-07-16 alone: the #1284 ambient-shadow extern-class break, the
+// JSON.stringify 3/9, #3307 accessor-merge casts, #3316 tagged-template CEs).
+//
+// Design (decision recorded in plan/issues/3008-*.md):
+//   - The FULL root suite (~2,100 files, ~9 CPU-hours single-fork) is far too
+//     slow to gate every PR. It runs POST-MERGE (push to main) + cron,
+//     sharded, gating against a committed known-failures baseline — only NEW
+//     failures fail the run, so the pre-existing rot backlog (~40% of files
+//     sampled failing, mostly stale harnesses) does not block, while any
+//     merge that breaks a previously-green test goes red on main within one
+//     run and is auto-filed for triage.
+//   - Per-PR, the `quality` job runs just the tests/*.test.ts files the PR
+//     ADDS or MODIFIES (cheap — PRs touch few test files), so a test cannot
+//     be born broken or unwired: new files are automatically in the full
+//     suite's glob, and must pass at birth.
+//
+// Modeled on scripts/equivalence-gate.mjs (#1659).
+//
+// Usage:
+//   node scripts/issue-tests-gate.mjs                  # full run, gate
+//   SHARD=3/12 node scripts/issue-tests-gate.mjs       # one shard → partial
+//   MERGE_PARTIALS_DIR=dir node scripts/issue-tests-gate.mjs   # merge + gate
+//   node scripts/issue-tests-gate.mjs --update         # rewrite baseline
+//   ALLOW_BOOTSTRAP=1 ... --update-on-decrease         # post-merge auto mode:
+//       bootstrap the baseline if missing; ratchet DOWN on newly-fixed;
+//       still exit 1 on NEW failures (visible red main).
+//
+// A file that errors at COLLECTION time (broken import) is counted as a
+// failing test id `<file> :: <collect>` — a broken-import test can no longer
+// pass by contributing zero assertions.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+// The baseline lives in the loopdive/js2wasm-baselines repo (#1528 pattern) —
+// workflows cannot push to main (GH013: merge queue), so the post-merge
+// ratchet writes there via the BASELINE_DEPLOY_KEY. The workflow points this
+// env at its baselines clone; local runs default to a repo-local file.
+const BASELINE_PATH = process.env.ISSUE_TESTS_BASELINE || join(REPO_ROOT, "scripts", "issue-tests-baseline.json");
+
+const args = process.argv.slice(2);
+const UPDATE = args.includes("--update");
+const RATCHET = args.includes("--update-on-decrease");
+const ALLOW_BOOTSTRAP = process.env.ALLOW_BOOTSTRAP === "1";
+const SHARD = process.env.SHARD || ""; // e.g. "3/12"
+const MERGE_DIR = process.env.MERGE_PARTIALS_DIR || "";
+const FORK_HEAP_MB = process.env.ISSUE_TESTS_FORK_HEAP_MB || "1024";
+
+// Root tests only. tests/equivalence/ has its own gate (#1659); linear-*,
+// c-abi, simd* run in the `linear-tests` job (#2139). Everything else at the
+// tests/ root — issue-*.test.ts plus the feature suites — is THIS gate's
+// population. New test files match the selection automatically (no wiring
+// step). NOTE: vitest CLI file args are substring FILTERS, not shell globs
+// (a quoted "tests/*.test.ts" selects ZERO files) — so the population is
+// enumerated here and sharded by slicing the sorted list.
+const EXCLUDE_RE = /^(linear-|c-abi\.|simd)/;
+
+function listRootTestFiles() {
+  return readdirSync(join(REPO_ROOT, "tests"))
+    .filter((f) => f.endsWith(".test.ts") && !EXCLUDE_RE.test(f))
+    .sort()
+    .map((f) => `tests/${f}`);
+}
+
+/** Slice the sorted population for SHARD "i/n" (1-based, contiguous ranges). */
+function shardSlice(files, shard) {
+  const m = /^(\d+)\/(\d+)$/.exec(shard);
+  if (!m) {
+    console.error(`issue-tests-gate: bad SHARD "${shard}" (want i/n)`);
+    process.exit(2);
+  }
+  const i = Number(m[1]);
+  const n = Number(m[2]);
+  const per = Math.ceil(files.length / n);
+  return files.slice((i - 1) * per, i * per);
+}
+
+function testId(fileRelPath, fullName) {
+  return `${fileRelPath} :: ${fullName}`;
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE_PATH)) return null;
+  return JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+}
+
+function relName(absName) {
+  const i = absName.lastIndexOf("/tests/");
+  return i >= 0 ? absName.slice(i + 1) : absName;
+}
+
+/** Run vitest on the root suite (optionally a shard); return failing/passing id sets. */
+function runVitest() {
+  const all = listRootTestFiles();
+  const files = SHARD ? shardSlice(all, SHARD) : all;
+  if (files.length === 0) {
+    console.log(`issue-tests-gate: shard ${SHARD || "full"} selected no files (population ${all.length}).`);
+    return { failing: new Set(), passing: new Set() };
+  }
+  console.log(
+    `issue-tests-gate: running ${files.length}/${all.length} root test file(s)${SHARD ? ` (shard ${SHARD})` : ""}.`,
+  );
+  const outFile = join(mkdtempSync(join(tmpdir(), "issue-tests-")), "report.json");
+  const vitestArgs = [
+    "node_modules/vitest/dist/cli.js",
+    "run",
+    ...files,
+    "--pool=forks",
+    "--poolOptions.forks.singleFork=true",
+    "--no-file-parallelism",
+    "--reporter=json",
+    `--outputFile=${outFile}`,
+  ];
+
+  const res = spawnSync(process.execPath, vitestArgs, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      CI: "1",
+      VITEST_FORK_MAX_OLD_SPACE_SIZE: process.env.VITEST_FORK_MAX_OLD_SPACE_SIZE || FORK_HEAP_MB,
+    },
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (!existsSync(outFile)) {
+    console.error("issue-tests-gate: vitest produced no JSON report; signal=", res.signal);
+    process.exit(2);
+  }
+  const report = JSON.parse(readFileSync(outFile, "utf8"));
+  const failing = new Set();
+  const passing = new Set();
+  for (const file of report.testResults || []) {
+    const rel = relName(file.name);
+    const asserts = file.assertionResults || [];
+    // Collection-time error (broken import / syntax): the file reports status
+    // "failed" with zero assertions — record a synthetic failing id so it gates.
+    if (file.status === "failed" && asserts.length === 0) {
+      failing.add(testId(rel, "<collect>"));
+      continue;
+    }
+    for (const a of asserts) {
+      const id = testId(rel, a.fullName || a.title);
+      if (a.status === "failed") failing.add(id);
+      else if (a.status === "passed") passing.add(id);
+    }
+  }
+  return { failing, passing };
+}
+
+function mergePartials(dir) {
+  const failing = new Set();
+  const passing = new Set();
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".json")) continue;
+    const p = JSON.parse(readFileSync(join(dir, f), "utf8"));
+    for (const id of p.failing || []) failing.add(id);
+    for (const id of p.passing || []) passing.add(id);
+  }
+  return { failing, passing };
+}
+
+const { failing, passing } = MERGE_DIR ? mergePartials(MERGE_DIR) : runVitest();
+
+// Shard mode: emit a partial artifact and exit 0 — the merge job gates.
+if (SHARD && !MERGE_DIR && !UPDATE && !RATCHET) {
+  const partialPath = process.env.PARTIAL_OUT || join(REPO_ROOT, `issue-tests-partial-${SHARD.replace("/", "-")}.json`);
+  writeFileSync(partialPath, JSON.stringify({ failing: [...failing], passing: [...passing] }, null, 2));
+  console.log(`issue-tests-gate: wrote partial ${partialPath} (${failing.size} fail / ${passing.size} pass)`);
+  process.exit(0);
+}
+
+function writeBaseline(knownFailures) {
+  writeFileSync(BASELINE_PATH, JSON.stringify({ knownFailures: [...knownFailures].sort() }, null, 2) + "\n");
+}
+
+if (UPDATE) {
+  writeBaseline(failing);
+  console.log(`issue-tests-gate: baseline updated — ${failing.size} known failures recorded.`);
+  process.exit(0);
+}
+
+const baseline = loadBaseline();
+
+// Bootstrap: first post-merge run seeds the baseline from the observed
+// failure set (the rot backlog) and passes. Requires the explicit env opt-in
+// so a per-PR misconfiguration can't silently mint a fresh baseline.
+if (baseline === null) {
+  if (ALLOW_BOOTSTRAP) {
+    writeBaseline(failing);
+    console.log(
+      `issue-tests-gate: BOOTSTRAP — no baseline existed; seeded ${failing.size} known failures (${passing.size} passing protected from now on).`,
+    );
+    process.exit(0);
+  }
+  console.error(
+    "issue-tests-gate: no baseline (scripts/issue-tests-baseline.json). Run with --update or ALLOW_BOOTSTRAP=1.",
+  );
+  process.exit(2);
+}
+
+const known = new Set(baseline.knownFailures || []);
+const regressions = [...failing].filter((id) => !known.has(id)).sort();
+const newlyFixed = [...known].filter((id) => passing.has(id)).sort();
+
+console.log(`issue-tests-gate: ${failing.size} failing, ${passing.size} passing, ${known.size} known in baseline.`);
+
+if (newlyFixed.length) {
+  console.log(`\n✓ ${newlyFixed.length} baseline failure(s) now PASS.`);
+  if (RATCHET) {
+    const next = new Set(known);
+    for (const id of newlyFixed) next.delete(id);
+    writeBaseline(next);
+    console.log(`  Ratcheted baseline down to ${next.size} known failures.`);
+  } else {
+    console.log("  Ratchet with: node scripts/issue-tests-gate.mjs --update-on-decrease (or --update from a full run)");
+  }
+}
+
+if (regressions.length) {
+  console.error(`\n✗ ${regressions.length} NEW root-suite regression(s) (not in baseline):`);
+  for (const id of regressions) console.error(`    REGRESSION: ${id}`);
+  console.error(
+    "\nA previously-green per-issue test broke. Fix forward, or — if the change is intentional — update the baseline in the fixing PR.",
+  );
+  process.exit(1);
+}
+
+console.log("\n✓ No new root-suite regressions.");
+process.exit(0);


### PR DESCRIPTION
Closes plan issue #3008.

## Audit

2,092 root `tests/*.test.ts` files (1,739 `issue-*`) ran in NO CI job — only `tests/equivalence/` (#1659), `linear-*`/`c-abi`/`simd*` (#2139), and ~7 individually-named files in `quality` were wired. A 30-file random sample on main: **12/30 files failing** (57 assertions) — stale-harness rot (e.g. the pre-`string_constants` externref harness) plus genuine silent regressions (four found on 2026-07-16 alone, incl. the #1284 ambient-shadow extern-class break fixed in #3175).

## Decision (recorded in the issue; full suite is ~9 CPU-hours — infeasible per-PR)

1. **Post-merge detector** — `.github/workflows/issue-tests.yml`: push:main (burst-deduped latest-wins concurrency) + 6h cron + dispatch; 12 shards (max-parallel 6, off the merge critical path); merged and gated by `scripts/issue-tests-gate.mjs` against a known-failures baseline stored in `loopdive/js2wasm-baselines` (workflows cannot push to main — GH013). First run BOOTSTRAPS the baseline (the rot backlog, to be triaged from it); newly-fixed tests auto-ratchet down (`--update-on-decrease`); any NEW failure goes red on main within one run. Collection-time errors (broken imports) count as failures — the zero-assertion blind spot is closed.
2. **Per-PR born-green gate** — `quality` step: every root test file a PR adds/modifies must pass (fix-on-touch for rotted files; >20-file mass edits skip with a warning). New test files are automatically inside the detector's enumeration — a test cannot be born unwired.

Gate verified locally: shard partials, bootstrap, clean pass, synthetic regression → exit 1, ratchet-down 29→28. NOTE: vitest CLI file args are substring filters, not globs — the gate enumerates and self-shards (documented in-script).

Issue frontmatter rides as `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8