### PR TITLE
feat(#1795): node:http/https GET round-trip (axios unblocker) + fix(#3329) shared-capture cell unification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,35 @@ jobs:
         # equivalence shards.
         run: pnpm exec vitest run tests/issue-1580.test.ts
 
+      - name: Changed root test files must pass (#3008)
+        # Per-PR half of the #3008 wiring (the post-merge half is
+        # .github/workflows/issue-tests.yml): any tests/*.test.ts file this PR
+        # ADDS or MODIFIES must pass, so a per-issue regression test cannot be
+        # born broken (and touching a rotted one means fixing it — the
+        # fix-on-touch ratchet). Root files only; tests/equivalence/ has its
+        # own gate (#1659) and linear-*/c-abi/simd* run in `linear-tests`.
+        # Mass edits (>20 files, e.g. a repo-wide reformat) skip with a
+        # warning — the post-merge detector covers them.
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=200 origin main 2>/dev/null || true
+          BASE=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
+          if [ -z "$BASE" ]; then echo "No merge base resolvable — skipping."; exit 0; fi
+          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE" HEAD -- tests/ \
+            | grep -E '^tests/[^/]+\.test\.ts$' \
+            | grep -vE '^tests/(linear-|c-abi\.|simd)' || true)
+          if [ -z "$CHANGED" ]; then echo "No root test files changed."; exit 0; fi
+          N=$(echo "$CHANGED" | wc -l)
+          if [ "$N" -gt 20 ]; then
+            echo "::warning::$N root test files changed (>20, likely a mass edit) — skipping the per-PR gate; the post-merge issue-tests detector covers them."
+            exit 0
+          fi
+          echo "Running $N changed root test file(s):"
+          echo "$CHANGED"
+          # Invoke vitest directly (not `pnpm test --`) so the file list is
+          # scoped to vitest and not consumed by pnpm (see PR #432).
+          pnpm exec vitest run $CHANGED --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+
       - name: Conformance numbers in sync (#1522)
         run: pnpm run sync:conformance:check
 

--- a/.github/workflows/issue-tests.yml
+++ b/.github/workflows/issue-tests.yml
@@ -1,0 +1,128 @@
+# #3008 — Root-test-suite (tests/*.test.ts) post-merge regression detector.
+#
+# The ~2,100 per-issue/feature test files at the tests/ root are the project's
+# regression memory, but no CI job ran them — four silent main-regressions of
+# this class were found on 2026-07-16 alone (#1284 ambient-shadow extern-class
+# break, JSON.stringify 3/9, #3307 accessor-merge casts, #3316 tagged-template
+# CEs). The full suite is ~9 CPU-hours single-fork — far too slow to gate
+# every PR — so the wiring is two-layered (decision recorded in
+# plan/issues/3008-issue-tests-not-in-required-ci.md):
+#
+#   1. THIS workflow: post-merge (push:main, burst-deduped) + 6-hourly cron +
+#      manual dispatch. Sharded single-fork run of the whole root suite,
+#      gated against a known-failures baseline stored in
+#      loopdive/js2wasm-baselines (workflows cannot push to main — GH013).
+#      Only NEW failures fail the run (the pre-existing rot backlog, ~40% of
+#      files sampled, is baselined and tracked for triage); newly-fixed tests
+#      auto-ratchet the baseline down. A regression goes red on main within
+#      one run instead of silently rotting.
+#   2. Per-PR (ci.yml `quality`): the tests/*.test.ts files a PR adds or
+#      modifies must pass — a test cannot be born broken, and new files are
+#      automatically inside this workflow's glob (no wiring step to forget).
+#
+# Concurrency: latest-wins, no per-SHA groups — unlike promote-baseline this
+# is a cumulative detector (the newest run covers all earlier merges), so
+# collapsing a merge burst to one run is correct and caps runner usage.
+name: issue-tests
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: issue-tests-main
+  cancel-in-progress: false
+
+jobs:
+  shard:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # max-parallel keeps runners free for PR-critical jobs (test262 shards,
+      # quality); the detector's latency is not on any merge's critical path.
+      max-parallel: 6
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - name: Run root-suite shard ${{ matrix.shard }}/12
+        env:
+          SHARD: ${{ matrix.shard }}/12
+          PARTIAL_OUT: issue-tests-partial-${{ matrix.shard }}.json
+        run: node scripts/issue-tests-gate.mjs
+      - name: Upload partial result
+        uses: actions/upload-artifact@v6
+        with:
+          name: issue-tests-partial-${{ matrix.shard }}
+          path: issue-tests-partial-${{ matrix.shard }}.json
+          retention-days: 3
+
+  gate:
+    needs: shard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.30.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - name: Download shard partials
+        uses: actions/download-artifact@v7
+        with:
+          pattern: issue-tests-partial-*
+          path: issue-tests-partials
+          merge-multiple: true
+      - name: Fetch baseline from js2wasm-baselines
+        env:
+          BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "$BASELINE_DEPLOY_KEY" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git clone --depth=1 git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
+      - name: Gate against baseline (bootstrap + auto-ratchet)
+        env:
+          MERGE_PARTIALS_DIR: issue-tests-partials
+          ISSUE_TESTS_BASELINE: /tmp/js2wasm-baselines/issue-tests-baseline.json
+          ALLOW_BOOTSTRAP: "1"
+        run: node scripts/issue-tests-gate.mjs --update-on-decrease
+      - name: Push ratcheted baseline back
+        # Runs even when the gate failed (new regressions) — a newly-fixed
+        # test's ratchet-down should still bank, and a bootstrap must persist.
+        if: always()
+        env:
+          BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+        run: |
+          cd /tmp/js2wasm-baselines
+          git add issue-tests-baseline.json 2>/dev/null || exit 0
+          if git diff --cached --quiet; then
+            echo "Baseline unchanged."
+            exit 0
+          fi
+          eval "$(ssh-agent -s)"
+          echo "$BASELINE_DEPLOY_KEY" | ssh-add -
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(#3008): issue-tests baseline refresh (main@${{ github.sha }})"
+          # Latest-wins retry against concurrent baseline pushes.
+          for i in 1 2 3; do
+            git push && exit 0
+            git pull --rebase || { git rebase --abort 2>/dev/null; git fetch origin main; git reset --hard origin/main; git add issue-tests-baseline.json; git commit -m "chore(#3008): issue-tests baseline refresh (main@${{ github.sha }})"; }
+          done
+          git push

--- a/plan/issues/1795-node-http-builtin-impl.md
+++ b/plan/issues/1795-node-http-builtin-impl.md
@@ -2,7 +2,13 @@
 id: 1795
 title: "node:http (+ https) — GET round-trip host import (axios unblocker)"
 horizon: m
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/fable-s2
+loc-budget-allow:
+  - src/runtime.ts
+  - src/import-resolver.ts
+  - src/codegen/closures.ts
 sprint: current
 created: 2026-06-03
 updated: 2026-06-03
@@ -17,6 +23,7 @@ parent: 1575
 related: [1044, 1032, 640, 1500]
 depends_on: [1793, 1794]
 ---
+
 # node:http (+ https) — GET round-trip host import (axios unblocker)
 
 ## Problem
@@ -38,7 +45,9 @@ import { get } from "node:http";
 function fetchText(url: string, cb: (s: string) => void): void {
   get(url, (res) => {
     let body = "";
-    res.on("data", (chunk: any) => { body += chunk.toString(); });
+    res.on("data", (chunk: any) => {
+      body += chunk.toString();
+    });
     res.on("end", () => cb(body));
   });
 }
@@ -67,3 +76,32 @@ function fetchText(url: string, cb: (s: string) => void): void {
 
 `tests/issue-1795.test.ts` — spin up a localhost server, compile the Tier 0
 `fetchText`, assert the returned body. Gate behind #1793 + #1794 landing.
+
+## Implementation (2026-07-17, fable-s2)
+
+- `NODE_BUILTIN_FN_TYPED_STUBS` (import-resolver.ts) gains `http`/`https`
+  `get` + `request` — `__nodefn__http__get` → `require("http").get` via the
+  existing `node_builtin_fn` intent.
+- `makeNodeBuiltinFnAdapter` (runtime.ts) wraps wasm-closure args as JS
+  callables via the identity-cached `_maybeWrapCallableUnknownArity` bridge
+  (Node either threw on or ignored the raw struct).
+- The response `res: any` externref's `.on(...)` listeners classify as
+  DEFERRED via the new any-receiver listener-name fallback
+  (callback-classification.ts) — no type symbol to key the per-class
+  allowlist on.
+- **#3329 fixed en route** (blocking: the acceptance shape shares `body`
+  between the `data` and `end` listeners): deferred callbacks now get the
+  needsThis-style `localMap` rebind, so sibling stored callbacks alias ONE
+  ref cell.
+
+## Test Results
+
+- `tests/issue-1795.test.ts`: 3/3 — acceptance shape end-to-end against a
+  localhost server ("hello-1795" through the cb param), multi-chunk
+  accumulation (part1-part2-part3), https binding-liveness.
+- `tests/issue-1794.test.ts` multi-listener test upgraded to the SHARED
+  accumulator (33) per #3329 acceptance; 5/5.
+- Sweep: issue-1695, issue-2861, issue-2128, issue-3051, issue-2029,
+  issue-859, issue-929 — all pass.
+- Buffer round-trip note: `chunk.toString()` rides #1793 (landed); the
+  EventEmitter contract rides #1794 (same PR stack).

--- a/plan/issues/3008-issue-tests-not-in-required-ci.md
+++ b/plan/issues/3008-issue-tests-not-in-required-ci.md
@@ -1,10 +1,11 @@
 ---
 id: 3008
 title: "process gap: tests/issue-*.test.ts are not uniformly wired into required CI (silent regressions)"
-status: ready
+status: done
+completed: 2026-07-17
 sprint: current
 priority: low
-assignee: ttraenkler/unassigned
+assignee: ttraenkler/fable-s2
 created: 2026-07-03
 feasibility: medium
 reasoning_effort: low
@@ -64,3 +65,46 @@ re-break (as #2767 did).
   RAM/time tradeoff considered.
 - (If adopted) the wiring lands and a deliberately-broken per-issue test fails
   CI.
+
+## Decision + implementation (2026-07-17, fable-s2)
+
+**Audit.** Population: 2,092 root `tests/*.test.ts` files (1,739 `issue-*`)
+run by NO CI job (only `tests/equivalence/` (#1659), `linear-*`/`c-abi`/`simd*`
+(#2139), and ~7 individually-named files in `quality` were wired). A 30-file
+random sample on main: **12/30 files failing (40%), 57 failing assertions** —
+dominated by stale-harness rot (e.g. missing the newer `string_constants`
+import namespace — same mechanism as the `externref.test.ts` 5/5 break) plus
+genuine silent regressions (four found on 2026-07-16 alone: #1284
+ambient-shadow extern-class break, JSON.stringify 3/9, #3307, #3316).
+
+**Decision (RAM/time tradeoff).** The full suite is ~9 CPU-hours single-fork —
+infeasible as a per-PR required gate. Two-layer wiring instead:
+
+1. **Post-merge detector** — `.github/workflows/issue-tests.yml`: push:main
+   (burst-deduped via a latest-wins concurrency group) + 6-hourly cron +
+   dispatch; 12 shards (max-parallel 6, off the merge critical path), merged
+   by `scripts/issue-tests-gate.mjs` against a known-failures baseline stored
+   in `loopdive/js2wasm-baselines` (`issue-tests-baseline.json` — workflows
+   cannot push to main, GH013). First run BOOTSTRAPS the baseline (the rot
+   backlog); newly-fixed tests auto-ratchet it down
+   (`--update-on-decrease`); any NEW failure fails the run → red on main
+   within one run instead of silent rot. Collection-time errors (broken
+   imports) count as failures (`<file> :: <collect>`), closing the
+   zero-assertion blind spot.
+2. **Per-PR born-green gate** — `quality` step "Changed root test files must
+   pass (#3008)": every root test file a PR adds or modifies must pass
+   (fix-on-touch for rotted files; >20-file mass edits skip with a warning).
+   New test files are automatically inside the detector's enumeration — a
+   test cannot be born unwired.
+
+**Not adopted:** making the full suite a required per-PR/merge_group check
+(cost would throttle the queue), and auto-committing the baseline to main
+(GH013 — merge queue blocks workflow pushes; the #491 planning-artifacts
+auto-commit hit the same wall).
+
+**Follow-ups:** the bootstrapped baseline enumerates the failing-on-main set —
+triage/file the rot clusters from `js2wasm-baselines/issue-tests-baseline.json`
+after the first run (PO/tech-lead sweep; the class-suite cluster
+(`class-methods` 17F/0P etc.) is likely one stale-harness fix). The
+`array-externref-indexof.test.ts` broken import cited in the finding no longer
+exists on main (already removed/fixed).

--- a/plan/issues/3329-host-callback-shared-mutable-capture-divergence.md
+++ b/plan/issues/3329-host-callback-shared-mutable-capture-divergence.md
@@ -2,8 +2,10 @@
 id: 3329
 title: "host-callback closures: two closures sharing one mutable captured local get SEPARATE ref cells — writes diverge (last writeback wins)"
 horizon: m
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/fable-s2
+sprint: current
 created: 2026-07-16
 priority: medium
 feasibility: medium

--- a/scripts/issue-tests-gate.mjs
+++ b/scripts/issue-tests-gate.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// #3008 — Root-test-suite (tests/*.test.ts) regression gate.
+//
+// The per-issue suites under tests/*.test.ts are the project's regression
+// memory, but they were not wired into ANY CI job — a fixed issue could
+// silently re-break on main (four separate silent main-regressions were found
+// on 2026-07-16 alone: the #1284 ambient-shadow extern-class break, the
+// JSON.stringify 3/9, #3307 accessor-merge casts, #3316 tagged-template CEs).
+//
+// Design (decision recorded in plan/issues/3008-*.md):
+//   - The FULL root suite (~2,100 files, ~9 CPU-hours single-fork) is far too
+//     slow to gate every PR. It runs POST-MERGE (push to main) + cron,
+//     sharded, gating against a committed known-failures baseline — only NEW
+//     failures fail the run, so the pre-existing rot backlog (~40% of files
+//     sampled failing, mostly stale harnesses) does not block, while any
+//     merge that breaks a previously-green test goes red on main within one
+//     run and is auto-filed for triage.
+//   - Per-PR, the `quality` job runs just the tests/*.test.ts files the PR
+//     ADDS or MODIFIES (cheap — PRs touch few test files), so a test cannot
+//     be born broken or unwired: new files are automatically in the full
+//     suite's glob, and must pass at birth.
+//
+// Modeled on scripts/equivalence-gate.mjs (#1659).
+//
+// Usage:
+//   node scripts/issue-tests-gate.mjs                  # full run, gate
+//   SHARD=3/12 node scripts/issue-tests-gate.mjs       # one shard → partial
+//   MERGE_PARTIALS_DIR=dir node scripts/issue-tests-gate.mjs   # merge + gate
+//   node scripts/issue-tests-gate.mjs --update         # rewrite baseline
+//   ALLOW_BOOTSTRAP=1 ... --update-on-decrease         # post-merge auto mode:
+//       bootstrap the baseline if missing; ratchet DOWN on newly-fixed;
+//       still exit 1 on NEW failures (visible red main).
+//
+// A file that errors at COLLECTION time (broken import) is counted as a
+// failing test id `<file> :: <collect>` — a broken-import test can no longer
+// pass by contributing zero assertions.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+// The baseline lives in the loopdive/js2wasm-baselines repo (#1528 pattern) —
+// workflows cannot push to main (GH013: merge queue), so the post-merge
+// ratchet writes there via the BASELINE_DEPLOY_KEY. The workflow points this
+// env at its baselines clone; local runs default to a repo-local file.
+const BASELINE_PATH = process.env.ISSUE_TESTS_BASELINE || join(REPO_ROOT, "scripts", "issue-tests-baseline.json");
+
+const args = process.argv.slice(2);
+const UPDATE = args.includes("--update");
+const RATCHET = args.includes("--update-on-decrease");
+const ALLOW_BOOTSTRAP = process.env.ALLOW_BOOTSTRAP === "1";
+const SHARD = process.env.SHARD || ""; // e.g. "3/12"
+const MERGE_DIR = process.env.MERGE_PARTIALS_DIR || "";
+const FORK_HEAP_MB = process.env.ISSUE_TESTS_FORK_HEAP_MB || "1024";
+
+// Root tests only. tests/equivalence/ has its own gate (#1659); linear-*,
+// c-abi, simd* run in the `linear-tests` job (#2139). Everything else at the
+// tests/ root — issue-*.test.ts plus the feature suites — is THIS gate's
+// population. New test files match the selection automatically (no wiring
+// step). NOTE: vitest CLI file args are substring FILTERS, not shell globs
+// (a quoted "tests/*.test.ts" selects ZERO files) — so the population is
+// enumerated here and sharded by slicing the sorted list.
+const EXCLUDE_RE = /^(linear-|c-abi\.|simd)/;
+
+function listRootTestFiles() {
+  return readdirSync(join(REPO_ROOT, "tests"))
+    .filter((f) => f.endsWith(".test.ts") && !EXCLUDE_RE.test(f))
+    .sort()
+    .map((f) => `tests/${f}`);
+}
+
+/** Slice the sorted population for SHARD "i/n" (1-based, contiguous ranges). */
+function shardSlice(files, shard) {
+  const m = /^(\d+)\/(\d+)$/.exec(shard);
+  if (!m) {
+    console.error(`issue-tests-gate: bad SHARD "${shard}" (want i/n)`);
+    process.exit(2);
+  }
+  const i = Number(m[1]);
+  const n = Number(m[2]);
+  const per = Math.ceil(files.length / n);
+  return files.slice((i - 1) * per, i * per);
+}
+
+function testId(fileRelPath, fullName) {
+  return `${fileRelPath} :: ${fullName}`;
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE_PATH)) return null;
+  return JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+}
+
+function relName(absName) {
+  const i = absName.lastIndexOf("/tests/");
+  return i >= 0 ? absName.slice(i + 1) : absName;
+}
+
+/** Run vitest on the root suite (optionally a shard); return failing/passing id sets. */
+function runVitest() {
+  const all = listRootTestFiles();
+  const files = SHARD ? shardSlice(all, SHARD) : all;
+  if (files.length === 0) {
+    console.log(`issue-tests-gate: shard ${SHARD || "full"} selected no files (population ${all.length}).`);
+    return { failing: new Set(), passing: new Set() };
+  }
+  console.log(
+    `issue-tests-gate: running ${files.length}/${all.length} root test file(s)${SHARD ? ` (shard ${SHARD})` : ""}.`,
+  );
+  const outFile = join(mkdtempSync(join(tmpdir(), "issue-tests-")), "report.json");
+  const vitestArgs = [
+    "node_modules/vitest/dist/cli.js",
+    "run",
+    ...files,
+    "--pool=forks",
+    "--poolOptions.forks.singleFork=true",
+    "--no-file-parallelism",
+    "--reporter=json",
+    `--outputFile=${outFile}`,
+  ];
+
+  const res = spawnSync(process.execPath, vitestArgs, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["ignore", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      CI: "1",
+      VITEST_FORK_MAX_OLD_SPACE_SIZE: process.env.VITEST_FORK_MAX_OLD_SPACE_SIZE || FORK_HEAP_MB,
+    },
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (!existsSync(outFile)) {
+    console.error("issue-tests-gate: vitest produced no JSON report; signal=", res.signal);
+    process.exit(2);
+  }
+  const report = JSON.parse(readFileSync(outFile, "utf8"));
+  const failing = new Set();
+  const passing = new Set();
+  for (const file of report.testResults || []) {
+    const rel = relName(file.name);
+    const asserts = file.assertionResults || [];
+    // Collection-time error (broken import / syntax): the file reports status
+    // "failed" with zero assertions — record a synthetic failing id so it gates.
+    if (file.status === "failed" && asserts.length === 0) {
+      failing.add(testId(rel, "<collect>"));
+      continue;
+    }
+    for (const a of asserts) {
+      const id = testId(rel, a.fullName || a.title);
+      if (a.status === "failed") failing.add(id);
+      else if (a.status === "passed") passing.add(id);
+    }
+  }
+  return { failing, passing };
+}
+
+function mergePartials(dir) {
+  const failing = new Set();
+  const passing = new Set();
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".json")) continue;
+    const p = JSON.parse(readFileSync(join(dir, f), "utf8"));
+    for (const id of p.failing || []) failing.add(id);
+    for (const id of p.passing || []) passing.add(id);
+  }
+  return { failing, passing };
+}
+
+const { failing, passing } = MERGE_DIR ? mergePartials(MERGE_DIR) : runVitest();
+
+// Shard mode: emit a partial artifact and exit 0 — the merge job gates.
+if (SHARD && !MERGE_DIR && !UPDATE && !RATCHET) {
+  const partialPath = process.env.PARTIAL_OUT || join(REPO_ROOT, `issue-tests-partial-${SHARD.replace("/", "-")}.json`);
+  writeFileSync(partialPath, JSON.stringify({ failing: [...failing], passing: [...passing] }, null, 2));
+  console.log(`issue-tests-gate: wrote partial ${partialPath} (${failing.size} fail / ${passing.size} pass)`);
+  process.exit(0);
+}
+
+function writeBaseline(knownFailures) {
+  writeFileSync(BASELINE_PATH, JSON.stringify({ knownFailures: [...knownFailures].sort() }, null, 2) + "\n");
+}
+
+if (UPDATE) {
+  writeBaseline(failing);
+  console.log(`issue-tests-gate: baseline updated — ${failing.size} known failures recorded.`);
+  process.exit(0);
+}
+
+const baseline = loadBaseline();
+
+// Bootstrap: first post-merge run seeds the baseline from the observed
+// failure set (the rot backlog) and passes. Requires the explicit env opt-in
+// so a per-PR misconfiguration can't silently mint a fresh baseline.
+if (baseline === null) {
+  if (ALLOW_BOOTSTRAP) {
+    writeBaseline(failing);
+    console.log(
+      `issue-tests-gate: BOOTSTRAP — no baseline existed; seeded ${failing.size} known failures (${passing.size} passing protected from now on).`,
+    );
+    process.exit(0);
+  }
+  console.error(
+    "issue-tests-gate: no baseline (scripts/issue-tests-baseline.json). Run with --update or ALLOW_BOOTSTRAP=1.",
+  );
+  process.exit(2);
+}
+
+const known = new Set(baseline.knownFailures || []);
+const regressions = [...failing].filter((id) => !known.has(id)).sort();
+const newlyFixed = [...known].filter((id) => passing.has(id)).sort();
+
+console.log(`issue-tests-gate: ${failing.size} failing, ${passing.size} passing, ${known.size} known in baseline.`);
+
+if (newlyFixed.length) {
+  console.log(`\n✓ ${newlyFixed.length} baseline failure(s) now PASS.`);
+  if (RATCHET) {
+    const next = new Set(known);
+    for (const id of newlyFixed) next.delete(id);
+    writeBaseline(next);
+    console.log(`  Ratcheted baseline down to ${next.size} known failures.`);
+  } else {
+    console.log("  Ratchet with: node scripts/issue-tests-gate.mjs --update-on-decrease (or --update from a full run)");
+  }
+}
+
+if (regressions.length) {
+  console.error(`\n✗ ${regressions.length} NEW root-suite regression(s) (not in baseline):`);
+  for (const id of regressions) console.error(`    REGRESSION: ${id}`);
+  console.error(
+    "\nA previously-green per-issue test broke. Fix forward, or — if the change is intentional — update the baseline in the fixing PR.",
+  );
+  process.exit(1);
+}
+
+console.log("\n✓ No new root-suite regressions.");
+process.exit(0);

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -2886,7 +2886,15 @@ export function compileArrowAsCallback(
         // getter, which kept reading the creation-time snapshot. The orphaned
         // original local slot keeps receiving writebacks — harmless (no reads
         // resolve to it once localMap points at the box).
-        if (needsThis) {
+        // (#3329) DEFERRED (stored) callbacks get the same rebind: the callback
+        // fires from a LATER host call, and a SIBLING stored callback capturing
+        // the same local must alias ONE cell — without the rebind each creation
+        // minted its own cell and the last writeback won (`body += chunk` in a
+        // "data" listener was invisible to the "end" listener: the #1795 http
+        // Tier 0 shape, and the #1794 multi-listener shape). After the rebind
+        // the sibling's capture analysis sees the local as already-boxed and
+        // pushes the SAME cell.
+        if (needsThis || options?.deferredInvocation === true) {
           fctx.localMap.set(cap.name, refCellLocal);
           (fctx.boxedCaptures ??= new Map()).set(cap.name, { refCellTypeIdx, valType: cap.type });
         }

--- a/src/codegen/closures/callback-classification.ts
+++ b/src/codegen/closures/callback-classification.ts
@@ -315,6 +315,21 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
  * to persistent writebacks when the receiver type matches — e.g. a user-defined
  * `class Foo { defer(cb) {} }` calling `foo.defer(...)` must NOT be promoted.
  */
+/**
+ * (#1795) Listener-method names treated as deferred when the RECEIVER is
+ * `any`/`unknown` (no type symbol to key the per-class allowlist on) — the
+ * EventEmitter surface every Node stream/response exposes.
+ */
+const ANY_RECEIVER_DEFERRED_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "on",
+  "once",
+  "off",
+  "addListener",
+  "removeListener",
+  "prependListener",
+  "prependOnceListener",
+]);
+
 const DEFERRED_CALLBACK_METHODS_BY_CLASS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ["DisposableStack", new Set(["defer", "use", "adopt"])],
   ["AsyncDisposableStack", new Set(["defer", "use", "adopt"])],
@@ -347,6 +362,15 @@ export function isDeferredCallbackArgument(node: ts.Node, ctx: CodegenContext): 
     if (symName) {
       const methods = DEFERRED_CALLBACK_METHODS_BY_CLASS.get(symName);
       if (methods?.has(methodName)) return true;
+    }
+    // (#1795) UNTYPED receiver (`res: any` — e.g. the http.get response, or
+    // any duck-typed EventEmitter): no symbol to key the allowlist on, so
+    // fall back to the universal listener-method NAMES. Promoting a
+    // synchronous same-named user method is semantics-preserving (persistent
+    // writebacks are just extra resyncs; the #3329 cell rebind aliases reads
+    // and writes through one cell either way).
+    if (!symName && (recType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) {
+      if (ANY_RECEIVER_DEFERRED_METHOD_NAMES.has(methodName)) return true;
     }
     const baseTypes = recType.getBaseTypes?.();
     if (baseTypes) {

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -126,6 +126,20 @@ const NODE_BUILTIN_FN_TYPED_STUBS: Record<
   string,
   Record<string, { params: string; returns: string; passthrough: string }>
 > = {
+  // #1795 — node:http/https Tier 0 (client GET round-trip, the axios
+  // unblocker). `get`/`request` take a wasm-closure callback; the
+  // `node_builtin_fn` runtime adapter wraps closure-shaped args as JS
+  // callables (identity-cached), and the response object flows back into the
+  // callback as an externref whose `.on(...)` listeners ride the same
+  // closure-callback contract as #1794 EventEmitter.
+  http: {
+    get: { params: "url: any, cb: any", returns: "any", passthrough: "url, cb" },
+    request: { params: "url: any, cb: any", returns: "any", passthrough: "url, cb" },
+  },
+  https: {
+    get: { params: "url: any, cb: any", returns: "any", passthrough: "url, cb" },
+    request: { params: "url: any, cb: any", returns: "any", passthrough: "url, cb" },
+  },
   crypto: {
     randomBytes: { params: "size: number", returns: "Uint8Array", passthrough: "size" },
     randomUUID: { params: "", returns: "string", passthrough: "" },

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6646,7 +6646,12 @@ function _warnTimerCallbackUnresolvable(mode: "timeout" | "interval"): void {
  *   shim does not have to special-case Buffer.
  * - All other functions are passed through unchanged.
  */
-function makeNodeBuiltinFnAdapter(moduleName: string, fnName: string, raw: (...args: any[]) => any): Function {
+function makeNodeBuiltinFnAdapter(
+  moduleName: string,
+  fnName: string,
+  raw: (...args: any[]) => any,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): Function {
   if (moduleName === "crypto" && fnName === "randomBytes") {
     return (n: number) => {
       const out = raw(n);
@@ -6660,7 +6665,15 @@ function makeNodeBuiltinFnAdapter(moduleName: string, fnName: string, raw: (...a
       return new Uint8Array(0);
     };
   }
-  return raw;
+  if (!callbackState) return raw;
+  // (#1795) Callback-taking node-builtin functions (http/https get/request,
+  // and any future callback-shaped surface): a compiled callback arrives as a
+  // WasmGC closure STRUCT (no [[Call]]); Node either throws on it or silently
+  // never invokes it. Wrap closure-shaped args as JS callables via the
+  // identity-cached dynamic bridge; non-closure args pass through untouched
+  // (`_maybeWrapCallableUnknownArity` uses the `__is_closure` export as the
+  // authoritative discriminator, so plain structs/values are unaffected).
+  return (...args: any[]) => raw(...args.map((a) => _maybeWrapCallableUnknownArity(a, callbackState)));
 }
 
 let _warnedNodeBuiltinFnFallback = false;
@@ -14048,7 +14061,7 @@ assert._isSameValue = isSameValue;
       const fnName = intent.name;
       const depMod = deps?.[moduleName] as Record<string, unknown> | undefined;
       if (depMod && typeof depMod[fnName] === "function") {
-        return makeNodeBuiltinFnAdapter(moduleName, fnName, (depMod[fnName] as Function).bind(depMod));
+        return makeNodeBuiltinFnAdapter(moduleName, fnName, (depMod[fnName] as Function).bind(depMod), callbackState);
       }
       const req = _getNodeRequire();
       if (req) {
@@ -14056,7 +14069,7 @@ assert._isSameValue = isSameValue;
           const mod = req(moduleName);
           const raw = mod?.[fnName];
           if (typeof raw === "function") {
-            return makeNodeBuiltinFnAdapter(moduleName, fnName, raw.bind(mod));
+            return makeNodeBuiltinFnAdapter(moduleName, fnName, raw.bind(mod), callbackState);
           }
         } catch {
           // fall through to browser / standalone fallback

--- a/tests/issue-1794.test.ts
+++ b/tests/issue-1794.test.ts
@@ -77,25 +77,23 @@ export function test(): number {
     ).toBe(7);
   });
 
-  it("addListener alias works; multiple listeners on one event both fire", async () => {
-    // NOTE: each listener captures its OWN local. Two host-callbacks sharing
-    // one mutable captured local diverge (per-closure ref cells — pre-existing
-    // #859/#929 writeback design, also affects DisposableStack; follow-up
-    // filed as the shared-capture cell-unification issue).
+  it("addListener alias works; multiple listeners SHARING one accumulator both land (#3329)", async () => {
+    // Two stored listeners capturing the SAME mutable local alias one ref
+    // cell (the #3329 deferred-callback localMap rebind) — pre-fix each
+    // creation minted its own cell and the last writeback won (returned 30).
     expect(
       await run(`
 import { EventEmitter } from "node:events";
 export function test(): number {
   const e = new EventEmitter();
-  let a = 0;
-  let b = 0;
-  e.addListener("n", (v: number) => { a = v; });
-  e.on("n", (v: number) => { b = v * 10; });
+  let sum = 0;
+  e.addListener("n", (v: number) => { sum = sum + v; });
+  e.on("n", (v: number) => { sum = sum + v * 10; });
   e.emit("n", 3);
-  return a * 100 + b;
+  return sum;
 }
 `),
-    ).toBe(330);
+    ).toBe(33);
   });
 
   it("#1284 guard intact: a REAL user class still shadows extern classes", async () => {

--- a/tests/issue-1795.test.ts
+++ b/tests/issue-1795.test.ts
@@ -1,0 +1,120 @@
+// (#1795) node:http (+ https) — GET round-trip (axios unblocker, Tier 0).
+// `import { get } from "node:http"` routes through NODE_BUILTIN_FN_TYPED_STUBS
+// (`__nodefn__http__get` → require("http").get); the node_builtin_fn runtime
+// adapter wraps wasm-closure args as JS callables (identity-cached bridge), and
+// the response externref's `.on(...)` listeners ride the #1794 EventEmitter
+// closure-callback contract (any-receiver deferred-listener classification).
+// Includes the #3329 fix: sibling STORED callbacks capturing the same mutable
+// local now alias ONE ref cell (localMap rebind for deferred callbacks) — the
+// "data" accumulator is finally visible to the "end" listener.
+import { describe, expect, it } from "vitest";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string) {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors?.[0]?.message).toBe(true);
+  const imports = buildImports(r.imports ?? [], undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary!, imports as unknown as WebAssembly.Imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  (instance.exports as { __module_init?: () => void }).__module_init?.();
+  return instance.exports as Record<string, Function>;
+}
+
+function listen(body: string): Promise<{ server: Server; url: string }> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(body);
+  });
+  return new Promise((resolve) =>
+    server.listen(0, () => {
+      const port = (server.address() as { port: number }).port;
+      resolve({ server, url: `http://127.0.0.1:${port}/` });
+    }),
+  );
+}
+
+const drain = (ms = 500) => new Promise((res) => setTimeout(res, ms));
+
+describe("#1795 node:http GET round-trip (Tier 0)", () => {
+  it("acceptance shape: get(url, res => res.on(data/end)) delivers the body through cb", async () => {
+    const { server, url } = await listen("hello-1795");
+    try {
+      const ex = await instantiate(`
+import { get } from "node:http";
+let out: string = "";
+export function getOut(): string { return out; }
+function fetchText(url: string, cb: (s: string) => void): void {
+  get(url, (res: any) => {
+    let body = "";
+    res.on("data", (chunk: any) => { body += chunk.toString(); });
+    res.on("end", () => cb(body));
+  });
+}
+export function test(url: string): void {
+  fetchText(url, (s: string) => { out = s; });
+}
+`);
+      ex.test!(url);
+      await drain();
+      expect(ex.getOut!()).toBe("hello-1795");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("multi-chunk accumulation across data events (#3329 shared cell)", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200);
+      res.write("part1-");
+      setTimeout(() => {
+        res.write("part2-");
+        setTimeout(() => res.end("part3"), 20);
+      }, 20);
+    });
+    const url: string = await new Promise((resolve) =>
+      server.listen(0, () => resolve(`http://127.0.0.1:${(server.address() as { port: number }).port}/`)),
+    );
+    try {
+      const ex = await instantiate(`
+import { get } from "node:http";
+let out: string = "";
+export function getOut(): string { return out; }
+export function test(url: string): void {
+  get(url, (res: any) => {
+    let body = "";
+    res.on("data", (chunk: any) => { body += chunk.toString(); });
+    res.on("end", () => { out = body; });
+  });
+}
+`);
+      ex.test!(url);
+      await drain(700);
+      expect(ex.getOut!()).toBe("part1-part2-part3");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("node:https `get` binds the same way (resolution only — TLS is the host's)", async () => {
+    // No localhost TLS server in the unit lane; assert the import compiles and
+    // the call reaches the host binding (an invalid-URL error, not a silent
+    // no-op or a struct-arg type error).
+    const ex = await instantiate(`
+import { get } from "node:https";
+let err: string = "";
+export function getErr(): string { return err; }
+export function test(): void {
+  try {
+    get("not-a-valid-url", (res: any) => {});
+  } catch (e: any) {
+    err = "threw";
+  }
+}
+`);
+    ex.test!();
+    expect(ex.getErr!()).toBe("threw"); // require("https").get rejected the URL — binding is live
+  });
+});


### PR DESCRIPTION
Closes plan issues #1795 and #3329. (Stacked on #3192's CI-wiring commits — collapses when that lands; the code changes here are independent.)

## #1795 — Tier 0 GET round-trip (verified end-to-end against a localhost server)

- `NODE_BUILTIN_FN_TYPED_STUBS` (import-resolver.ts) gains `http`/`https` `get` + `request` → the existing `node_builtin_fn` intent (`require(mod).get`).
- `makeNodeBuiltinFnAdapter` (runtime.ts) wraps wasm-closure args as JS callables via the identity-cached `_maybeWrapCallableUnknownArity` bridge — Node threw ERR_INVALID_ARG_TYPE on (or ignored) the raw closure struct.
- The response `res: any` externref's `.on(...)` listeners classify as DEFERRED via a new any-receiver listener-name fallback (callback-classification.ts) — an `any` receiver has no type symbol for the #1794 per-class allowlist.

## #3329 — sibling stored callbacks sharing one mutable captured local

The Tier 0 acceptance shape (`body += chunk` in `data`, `cb(body)` in `end`) was BLOCKED on #3329: each closure creation minted its own ref cell, so the last writeback won. Fix: deferred (stored) callbacks now get the needsThis-style `localMap` rebind (closures.ts), so siblings alias ONE cell. The #1794 multi-listener test upgrades back to a SHARED accumulator (33), per #3329's own acceptance.

## Tests

- `tests/issue-1795.test.ts` (3): acceptance shape end-to-end ("hello-1795" through the cb param), multi-chunk accumulation across data events, https binding-liveness.
- `tests/issue-1794.test.ts` updated multi-listener shared-accumulator (33); 5/5.
- Sweep: issue-1695 / 2861 / 2128 / 3051 / 2029 / 859 / 929 — all pass. Re-verified post-merge on current main (8/8).

Issue frontmatter rides as `status: done` for both (+ loc-budget-allow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8