### PR TITLE
fix(#3201): inherited-length array-like .call — replace unsound __sget_length probe with _readOwnDescriptor

### DIFF
--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -225,3 +225,36 @@ Still open in this family (documented above, left `ready`): huge sparse-index
 WRITES (trap on the densely-growing-backing write path), the harness-entangled
 `Array.prototype`-mutation `illegal cast` cluster, revoked-Proxy casts
 (deferred, #1355/#1472), and `splice`/`pop` sparse reads.
+
+## Progress — inherited-length array-like `.call` cluster: `__extern_length` unsound probe (fable-e, 2026-07-17)
+
+Mechanism-1 slice (array-like receivers via `.call(obj, …)`). Root cause found
+by live instrumentation: `__extern_length`'s struct arm resolved own `length`
+with a raw `__sget_length` try/catch probe. On a fnctor instance struct
+(`var Con = function(){}; Con.prototype = {length: 2}; new Con()`) the probe
+CAST-SUCCEEDS via structural canonicalization on some registered
+`__sget_length` getter and reads a **zero-initialized unrelated slot** —
+returning own length 0 (a non-null, non-throwing wrong answer, so no
+null-check gate can catch it) and SHADOWING the inherited `length` that
+`_fnctorProtoLookup` (#3139) resolves correctly one line below. This is the
+`#1629` unsound-`__sget_*`-probe anti-pattern.
+
+Fix: resolve own `length` through the #1629-safe `_readOwnDescriptor` (vec
+live length via `__vec_len`, sidecar, shape-gated struct field via
+`_getStructFieldNames`), then the fnctor prototype chain. Flips the
+`15.4.4.14-2-{6,8,9}` + `15.4.4.15-2-{6,8,9}` inherited-length clusters
+(6 verified per-process flips on the 97-test indexOf/lastIndexOf
+baseline-fail sample); also feeds every array-like borrow loop (forEach/map/
+filter etc. — #3200's families).
+
+**Coordination (agreed with fable-2, 2026-07-17):** the SAME unsound-probe
+class exists in `__extern_get_idx` (wrong-shape null served as a real
+element, masking inherited indices) and `__extern_has_idx` (`return 1` on
+any non-throwing probe visits holes as own) — those two arms are **fable-2's**
+(branch issue-3200-array-iteration-generics); `__extern_length` is this
+branch. The remaining ~19 `.call`-cluster fails in this family hinge on
+those two arms plus the element-kind mechanisms.
+
+Suites: `issue-3201-inherited-length` 5/5 (new), `issue-1360` +
+`issue-3138` + `issue-3116` + `issue-1629-S1` + `issue-3139` + `issue-1629`
++ `issue-1629a` 76/76, tsc clean.

--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -15,7 +15,7 @@ sprint: current
 horizon: m
 umbrella: 3185
 related: [3185, 3169, 3180, 2036]
-loc-budget-allow: [src/codegen/array-methods.ts]
+loc-budget-allow: [src/codegen/array-methods.ts, src/runtime.ts]
 origin: "2026-07-12 Fable codebase audit §F2; method-family slice of #3185"
 ---
 

--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -258,3 +258,22 @@ those two arms plus the element-kind mechanisms.
 Suites: `issue-3201-inherited-length` 5/5 (new), `issue-1360` +
 `issue-3138` + `issue-3116` + `issue-1629-S1` + `issue-3139` + `issue-1629`
 + `issue-1629a` 76/76, tsc clean.
+
+## Progress — len==0 before ToInteger(fromIndex) (fable-e, 2026-07-17, same PR)
+
+Mechanism-2 slice, same PR (#3194). §23.1.3.14/.20 step 3: on an empty array,
+`return -1` precedes step 4's `ToIntegerOrInfinity(fromIndex)`, so a throwing
+`valueOf` on the fromIndex object must not be observed
+(`{indexOf,lastIndexOf}/length-zero-returns-minus-one.js` — both flip to
+pass). `compileArrayIndexOf`/`compileArrayLastIndexOf` compiled the fromIndex
+coercion (whose f64 path embeds ToPrimitive → `valueOf`) unconditionally;
+now the coercion+clamp instrs are compiled into the main body then spliced
+into a `len != 0` guard arm (safe: nested `then`/`else` arms ARE walked by
+`flushLateImportShifts`' recursive `shiftBody`, so no detached-array funcIdx
+staleness — only never-embedded arrays are hazardous, per the #2001
+pre-ensure note). len==0 arms: indexOf iTmp=0 (loop bound 0 → -1);
+lastIndexOf iTmp=-1 (same as the empty default `len-1`).
+
+Suites: `issue-3201-inherited-length` 8/8 (3 new ordering tests incl. the
+positive valueOf-IS-observed control), the five issue-3201* suites +
+`issue-1360` + `array-prototype-methods` 91/91, tsc clean.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -2386,6 +2386,16 @@ function compileArrayIndexOf(
 
   // fromIndex (optional 2nd arg, default 0)
   if (callExpr.arguments.length >= 2) {
+    // (#3201) §23.1.3.14 step 3: if len is 0, return -1 BEFORE step 4's
+    // ToIntegerOrInfinity(fromIndex) — a throwing `valueOf` on the fromIndex
+    // object must NOT be observed on an empty array
+    // (indexOf/length-zero-returns-minus-one.js). Compile the coercion into
+    // the main body, then splice it into a `len != 0` guard arm — spliced
+    // instrs are immediately re-embedded in fctx.body (nested arms ARE
+    // walked by flushLateImportShifts' recursive shiftBody), so no detached-
+    // array funcIdx staleness. The len==0 arm leaves iTmp at 0; the loop
+    // bound (effLenTmp == 0) then falls through to the -1 result.
+    const guardStart = fctx.body.length;
     if (ctx.fast) {
       compileExpression(ctx, fctx, callExpr.arguments[1]!, { kind: "i32" });
     } else {
@@ -2418,10 +2428,22 @@ function compileArrayIndexOf(
       ],
     });
     fctx.body.push({ op: "local.get", index: fromTmp });
+    fctx.body.push({ op: "local.set", index: iTmp });
+    const guarded = fctx.body.splice(guardStart);
+    fctx.body.push({ op: "local.get", index: lenTmp });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: guarded,
+      else: [
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: iTmp },
+      ],
+    });
   } else {
     fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "local.set", index: iTmp });
   }
-  fctx.body.push({ op: "local.set", index: iTmp });
 
   // (#2648) Drive the packed i8/i16 load off the VIEW NAME signedness so a
   // signed Int8/Int16 value (`Int8Array([-1]).indexOf(-1)`) and an unsigned
@@ -7546,6 +7568,16 @@ function compileArrayLastIndexOf(
 
   if (callExpr.arguments.length >= 2) {
     // fromIndex provided -- clamp negative and clamp to length - 1
+    // (#3201) §23.1.3.20 step 3: if len is 0, return -1 BEFORE step 4's
+    // ToIntegerOrInfinity(fromIndex) — a throwing `valueOf` on the fromIndex
+    // object must NOT be observed on an empty array
+    // (lastIndexOf/length-zero-returns-minus-one.js). Same splice-into-guard
+    // pattern as compileArrayIndexOf: the spliced instrs are immediately
+    // re-embedded in fctx.body (nested arms ARE walked by
+    // flushLateImportShifts), so no detached-array funcIdx staleness. The
+    // len==0 arm sets iTmp to -1 (the same value the no-fromIndex default
+    // `len - 1` yields on an empty array), so the reverse loop never runs.
+    const guardStart = fctx.body.length;
     if (ctx.fast) {
       compileExpression(ctx, fctx, callExpr.arguments[1]!, { kind: "i32" });
     } else {
@@ -7580,6 +7612,17 @@ function compileArrayLastIndexOf(
         { op: "local.get", index: lenTmp },
         { op: "i32.const", value: 1 },
         { op: "i32.sub" },
+        { op: "local.set", index: iTmp },
+      ],
+    });
+    const guarded = fctx.body.splice(guardStart);
+    fctx.body.push({ op: "local.get", index: lenTmp });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: guarded,
+      else: [
+        { op: "i32.const", value: -1 },
         { op: "local.set", index: iTmp },
       ],
     });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8409,19 +8409,26 @@ assert._isSameValue = isSameValue;
             }
             return Number(v);
           };
-          // Reading .length on an opaque wasmGC struct throws — check sidecar first (#983)
+          // Reading .length on an opaque wasmGC struct throws — resolve through
+          // the #1629-safe own-descriptor reader (#983 sidecar + vec live length
+          // + shape-gated struct field), then the inherited chain.
           if (_isWasmStruct(obj)) {
-            const sc = _sidecarGet(obj, "length");
-            if (sc !== undefined) return toLength(coerceLen(sc));
             const exports = callbackState?.getExports();
-            const getter = exports?.[`__sget_length`];
-            if (typeof getter === "function") {
-              try {
-                return toLength(coerceLen(getter(obj)));
-              } catch {
-                /* not a field */
-              }
-            }
+            // (#3201) Own `length` via _readOwnDescriptor — NOT a raw
+            // `__sget_length` try/catch probe. The raw probe was the #1629
+            // anti-pattern and produced a REAL miss here: on a fnctor instance
+            // struct whose shape happens to cast-succeed for some registered
+            // `__sget_length` getter, the probe "succeeds" reading a
+            // zero-initialized unrelated slot and returns own length 0, which
+            // SHADOWS the inherited `length` on the ctor prototype
+            // (`Con.prototype = { length: 2 }; new Con()` — the
+            // indexOf/15.4.4.14-2-* array-like `.call` cluster). The
+            // descriptor reader serves the vec live length (step 0), sidecar
+            // values (step 1), and genuine struct `length` fields shape-gated
+            // via _getStructFieldNames (step 3), so every previously-correct
+            // own read stays served.
+            const own = _readOwnDescriptor(obj, "length", exports);
+            if (own) return toLength(coerceLen(own.get ? own.get.call(obj) : own.value));
             // (#3139) Inherited `length` through the fnctor instance→ctor
             // prototype chain (§7.3.2 Get is prototype-inclusive). The classic
             // shape: `foo.prototype = new Array(1,2,3); var f = new foo();

--- a/tests/issue-3201-inherited-length.test.ts
+++ b/tests/issue-3201-inherited-length.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #3201 — array-like `.call` receivers with an INHERITED `length`.
+ *
+ * `__extern_length`'s struct arm used a raw `__sget_length` try/catch probe.
+ * On a fnctor instance struct whose shape happens to cast-succeed for some
+ * registered `__sget_length` getter, the probe "succeeds" reading a
+ * zero-initialized unrelated slot and returns own length 0 — SHADOWING the
+ * inherited `length` on the ctor prototype that `_fnctorProtoLookup`
+ * resolves correctly (§7.3.2 Get is prototype-inclusive). Covers the
+ * test262 `built-ins/Array/prototype/{indexOf,lastIndexOf}/15.4.4.1[45]-2-*`
+ * inherited-length clusters.
+ *
+ * Fix: resolve own `length` through the #1629-safe `_readOwnDescriptor`
+ * (vec live length / sidecar / shape-gated struct field) — never a raw
+ * `__sget_*` probe — then fall to the fnctor prototype chain.
+ */
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime-instantiate";
+
+describe("#3201 array-like .call with inherited length", () => {
+  it("indexOf.call finds an own element under an inherited length (15.4.4.14-2-6)", async () => {
+    const exports = await compileAndInstantiate(`
+      var proto = { length: 2 };
+      var Con = function() {};
+      Con.prototype = proto;
+
+      var childOne = new Con();
+      childOne[1] = true;
+      var childTwo = new Con();
+      childTwo[2] = true;
+
+      export function foundInRange(): number {
+        return Array.prototype.indexOf.call(childOne, true);
+      }
+      export function beyondLength(): number {
+        return Array.prototype.indexOf.call(childTwo, true);
+      }
+    `);
+    // childOne[1] is within the inherited length 2 → found at 1.
+    expect((exports.foundInRange as () => number)()).toBe(1);
+    // childTwo[2] is beyond the inherited length 2 → not visited → -1.
+    expect((exports.beyondLength as () => number)()).toBe(-1);
+  });
+
+  it("lastIndexOf.call honours the inherited length (15.4.4.15-2-6 shape)", async () => {
+    const exports = await compileAndInstantiate(`
+      var proto = { length: 2 };
+      var Con = function() {};
+      Con.prototype = proto;
+
+      var child = new Con();
+      child[1] = "x";
+
+      export function test(): number {
+        return Array.prototype.lastIndexOf.call(child, "x");
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("own length still shadows the inherited one", async () => {
+    const exports = await compileAndInstantiate(`
+      var proto = { length: 0 };
+      var Con = function() {};
+      Con.prototype = proto;
+
+      var child = new Con();
+      child.length = 2;
+      child[1] = true;
+
+      export function test(): number {
+        return Array.prototype.indexOf.call(child, true);
+      }
+    `);
+    // Own length 2 (sidecar) shadows inherited 0 → element visible.
+    expect((exports.test as () => number)()).toBe(1);
+  });
+
+  it("real-array receivers keep their live length (no _readOwnDescriptor regression)", async () => {
+    const exports = await compileAndInstantiate(`
+      var arr = [10, 20, 30];
+      export function test(): number {
+        return Array.prototype.indexOf.call(arr, 30);
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(2);
+  });
+
+  it("plain object-literal receivers with own length keep working", async () => {
+    const exports = await compileAndInstantiate(`
+      var obj = { 0: 5, 1: 7, length: 2 };
+      export function test(): number {
+        return Array.prototype.indexOf.call(obj, 7);
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(1);
+  });
+});

--- a/tests/issue-3201-inherited-length.test.ts
+++ b/tests/issue-3201-inherited-length.test.ts
@@ -96,3 +96,58 @@ describe("#3201 array-like .call with inherited length", () => {
     expect((exports.test as () => number)()).toBe(1);
   });
 });
+
+describe("#3201 len==0 checked before ToInteger(fromIndex) (§23.1.3.14/.20 step 3)", () => {
+  it("indexOf on an empty array does not observe fromIndex.valueOf", async () => {
+    const exports = await compileAndInstantiate(`
+      var observed = false;
+      var fromIndex: any = {
+        valueOf: function(): number { observed = true; return 0; }
+      };
+      export function test(): number {
+        var e: number[] = [];
+        var r = e.indexOf(2, fromIndex);
+        if (r !== -1) return 100;
+        if (observed) return 200;
+        return 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(0);
+  });
+
+  it("lastIndexOf on an empty array does not observe fromIndex.valueOf", async () => {
+    const exports = await compileAndInstantiate(`
+      var observed = false;
+      var fromIndex: any = {
+        valueOf: function(): number { observed = true; return 0; }
+      };
+      export function test(): number {
+        var e: number[] = [];
+        var r = e.lastIndexOf(2, fromIndex);
+        if (r !== -1) return 100;
+        if (observed) return 200;
+        return 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(0);
+  });
+
+  it("fromIndex.valueOf IS observed on a non-empty array", async () => {
+    const exports = await compileAndInstantiate(`
+      var observed = false;
+      var fromIndex: any = {
+        valueOf: function(): number { observed = true; return 1; }
+      };
+      export function test(): number {
+        var a = [7, 8, 8];
+        var r = a.indexOf(8, fromIndex);
+        if (r !== 1) return 100 + r;
+        if (!observed) return 200;
+        var r2 = a.lastIndexOf(8, fromIndex);
+        if (r2 !== 1) return 300 + r2;
+        return 0;
+      }
+    `);
+    expect((exports.test as () => number)()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Mechanism-1 slice of #3201 (array-like receivers via `Array.prototype.<m>.call(obj, …)`). Root cause found by live instrumentation: `__extern_length`'s struct arm resolved own `length` with a raw `__sget_length` try/catch probe. On a fnctor instance struct (`var Con = function(){}; Con.prototype = {length: 2}; new Con()`) the probe **cast-succeeds via structural canonicalization** and reads a zero-initialized unrelated slot — returning own length 0 (a non-null, non-throwing wrong answer, so no null-check gate can catch it) and shadowing the inherited `length` that `_fnctorProtoLookup` (#3139) resolves correctly one line below. This is the #1629 unsound-`__sget_*`-probe anti-pattern.

**Fix**: resolve own `length` through the #1629-safe `_readOwnDescriptor` (vec live length via `__vec_len`, sidecar, shape-gated struct field via `_getStructFieldNames`), then the fnctor prototype chain — so every previously-correct own read stays served.

Flips the `built-ins/Array/prototype/{indexOf,lastIndexOf}/15.4.4.1[45]-2-{6,8,9}` inherited-length clusters (6 verified per-process flips on the 97-test baseline-fail family sample). `__extern_length` feeds **every** array-like borrow loop, so the forEach/map/filter `.call` families (#3200) benefit too.

**Coordination (agreed with fable-2)**: the same unsound-probe class in `__extern_get_idx` / `__extern_has_idx` is fable-2's, on `issue-3200-array-iteration-generics` — disjoint arms, conflict-free runtime.ts merge by design.

## Verification

- New suite `tests/issue-3201-inherited-length.test.ts` 5/5 (inherited length found/beyond-length, lastIndexOf, own-shadows-inherited, real-array + object-literal no-regression controls).
- Neighborhood suites 76/76: `issue-1360` (array-like search), `issue-3138`/`issue-3139` (fnctor registration/length), `issue-3116` (vec descriptors), `issue-1629`/`issue-1629a`/`issue-1629-S1` (descriptor reader).
- `tsc --noEmit` clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)