### PR TITLE
refactor(#2955): slice 5 — for-of strategy moves to resolver; nativeStrings off the from-ast interface

### DIFF
--- a/plan/issues/2955-ir-string-ops-depolymorph.md
+++ b/plan/issues/2955-ir-string-ops-depolymorph.md
@@ -328,3 +328,51 @@ iter-host.
 
 **Remaining after slice 4** (from-ast functional `nativeStrings` reads, 1):
 the for-of strategy switch (~4470, slice 5 — last). `status` stays `ready`.
+
+## Slice 5 (2026-07-17, fable-e) — for-of strategy → `stringForOfPlan`; `nativeStrings` OFF the from-ast interface
+
+The LAST functional mode read: `lowerForOfStatement`'s string arm read
+`nativeStrings?.()` to pick the native `__str_charAt` counter loop vs the
+`__iterator` host protocol. Now a resolver-owned strategy query,
+`IrFromAstResolver.stringForOfPlan(): "char-loop" | "iter-host"` (both loop
+builders stay in from-ast; only the SELECTION is resolver-owned — same
+build-time-selection shape as `stringMethodPlan`, since the two strategies
+build structurally different IR). Implementations: integration =
+`ctx.nativeStrings ? "char-loop" : "iter-host"`; the selfhost native-strings
+build resolver pins `"char-loop"` (the plan-absent default is iter-host,
+which a host-free build must never emit); linear omits it (iter-host
+fallthrough, as before). Byte-inert truth table incl. resolver-absent.
+
+**Capstone: `nativeStrings?()` is REMOVED from `IrFromAstResolver`** (and
+from both implementers). With zero functional reads left, keeping the raw
+discriminator on the front-end surface would leave a drift channel open —
+now a new representation-polymorphic IR-build branch is a compile error.
+`IrLowerResolver` (lower.ts) still carries its own `nativeStrings?()` — the
+lower side legitimately owns mode knowledge.
+
+**Verification**: sha256-identical compiled binaries vs the slice-4 parent
+in ALL THREE regimes over the 20-source corpus; mutation check (strategy
+inverted) flips native+standalone `string-forof` hashes — the read is live.
+`tsc --noEmit` clean; prettier clean; `check:ir-fallbacks` unchanged;
+`issue-1183` + `issue-1374-ir-string-iter-inline` +
+`issue-1470-string-iteration-standalone` + `issue-3161` + `issue-3256`
+52/52.
+
+## Acceptance-criteria status after slices 1–5
+
+- **from-ast.ts contains zero `nativeStrings` reads (grep-gated)** — ✅ MET;
+  stronger than the criterion: the discriminator is no longer even on the
+  from-ast resolver interface.
+- **Same source produces identical IR in both modes** — ❌ NOT met, by
+  design of the faithful byte-inert slices: the mode decisions are settled
+  at IR-BUILD time through resolver-owned queries (they must be — demote/
+  claim has no lower-time channel), so the built IR still differs per mode
+  where plans differ (`stringMethodPlan` arg reps, for-of loop shape,
+  capability demotes). Promoting the rep halves into true abstract IR ops
+  lowered per mode (the "identical IR" bar) is the documented follow-up:
+  each promotion is op-union + verifier + lower.ts case + byte proof, and
+  the demote halves stay build-time queries regardless.
+- **Per-mode lowered bytes identical to before** — ✅ every slice
+  sha256-proven over the corpus in host/native/standalone.
+- **Equivalence green both modes / string-heavy net-zero** — per-slice CI
+  (slices 1–3 landed green; 4–5 stacked PRs follow the same gate).

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -156,9 +156,6 @@ const NATIVE_STRING_METHOD_PLANS: ReadonlyMap<
 ]);
 
 const NATIVE_STRINGS_FROMAST_RESOLVER: IrFromAstResolver = {
-  nativeStrings(): boolean {
-    return true;
-  },
   // (#2955 slices 3/4) The de-polymorphed from-ast arms consult these
   // resolver-owned predicates instead of `nativeStrings()`. This build
   // resolver MUST implement them explicitly: the from-ast reads preserve
@@ -178,6 +175,12 @@ const NATIVE_STRINGS_FROMAST_RESOLVER: IrFromAstResolver = {
   },
   hasHostNumberToString(): boolean {
     return false;
+  },
+  // (#2955 slice 5) Native-strings builds iterate strings via the
+  // `__str_charAt` counter loop — the plan-absent default is iter-host
+  // (`__iterator` host import), which a host-free build must never emit.
+  stringForOfPlan(): "char-loop" | "iter-host" {
+    return "char-loop";
   },
   stringMethodPlan(method: string) {
     return NATIVE_STRING_METHOD_PLANS.get(method) ?? null;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -103,9 +103,17 @@ export interface IrExternClassMeta {
  * yet at Phase-1 build time — into the from-ast layer.
  *
  * Phase-1 callable methods only:
- *   - `nativeStrings()` — backend mode discriminator
  *   - `resolveString()` — `IrType.string` ValType (extern vs native struct ref)
  *   - `resolveVec(valType)` — vec struct shape recovery
+ *
+ * (#2955) The raw `nativeStrings()` mode discriminator is deliberately NOT
+ * on this interface anymore: every former from-ast mode read is now a
+ * narrow resolver-owned capability/rep/strategy query (`stringIsExternref`,
+ * `hasHostNumberBox`, `hasHostNumberToString`, `stringMethodPlan`,
+ * `stringForOfPlan`). Keeping the raw discriminator off the front-end
+ * surface makes a new representation-polymorphic IR-build branch a compile
+ * error instead of a drift channel. (`IrLowerResolver` still carries it —
+ * the lower side legitimately owns mode knowledge.)
  *
  * Slice 10 (#1169i) adds:
  *   - `getExternClassInfo(name)` — extern-class metadata for slice-10
@@ -119,7 +127,6 @@ export interface IrExternClassMeta {
  * until Phase 3, so from-ast doesn't see them.
  */
 export interface IrFromAstResolver {
-  nativeStrings?(): boolean;
   resolveString?(): ValType;
   /**
    * (#2955 number-box slice) Capability predicate: does this compile's lane
@@ -174,6 +181,24 @@ export interface IrFromAstResolver {
    * floor.
    */
   hasHostNumberToString?(): boolean;
+  /**
+   * (#2955 slice 5) Strategy query: how does this mode iterate a
+   * `string`-typed for-of iterable? `"char-loop"` = the native fast path
+   * (counter loop over `__str_charAt`, slice 6 part 4 — #1183);
+   * `"iter-host"` = the host-iterator protocol (`__iterator` import; the
+   * host-mode string is already externref-shaped so it feeds the import
+   * unchanged). `lowerForOfStatement` previously read `nativeStrings()`
+   * directly for this — the LAST functional mode read in from-ast; both
+   * loop builders stay here, only the selection is resolver-owned (same
+   * shape as `stringMethodPlan`: the selection must be settled at build
+   * time since the two strategies build structurally different IR).
+   * Resolver-absent default: `iter-host` (preserving the legacy falsy
+   * fallthrough). Implementations: integration =
+   * `nativeStrings ? "char-loop" : "iter-host"`; the selfhost
+   * native-strings build resolver pins `"char-loop"`; linear omits it
+   * (iter-host fallthrough, as before).
+   */
+  stringForOfPlan?(): "char-loop" | "iter-host";
   resolveVec?(valType: ValType): IrVecLowering | null;
   /**
    * #1804 — register-or-recover the vec struct for an element ValType so
@@ -4484,12 +4509,15 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
   //                                    shape; if it isn't a vec, lowering
   //                                    throws and the function falls back
   //                                    to legacy.
-  //   - `string` (native mode)      → string fast path (slice 6 part 4 — #1183).
-  //                                    Counter loop with `__str_charAt`.
-  //   - `string` (host mode)         → fall through to iter-host. The
-  //                                    string IR value is already
-  //                                    externref-backed in host mode, so
-  //                                    no coercion is needed.
+  //   - `string`                     → per the resolver's `stringForOfPlan`
+  //                                    (#2955 slice 5): `"char-loop"` =
+  //                                    string fast path (slice 6 part 4 —
+  //                                    #1183), counter loop with
+  //                                    `__str_charAt`; `"iter-host"` (or no
+  //                                    resolver) = fall through to
+  //                                    iter-host — the host-mode string IR
+  //                                    value is already externref-backed,
+  //                                    so no coercion is needed.
   //   - `(val) externref`           → iter-host (slice 6 part 3 — #1182).
   //   - `class` / `object`           → iter-host (with extern.convert_any
   //                                    coercion).
@@ -4500,16 +4528,18 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
     return;
   }
   if (iterableT.kind === "string") {
-    if (cx.resolver?.nativeStrings?.()) {
+    // (#2955 slice 5) The strategy selection is resolver-owned; from-ast
+    // reads no `nativeStrings` here. Resolver-absent → iter-host, preserving
+    // the legacy falsy fallthrough of the old `nativeStrings?.()` read.
+    if (cx.resolver?.stringForOfPlan?.() === "char-loop") {
       lowerForOfString(stmt, cx, iterableV, loopVarName);
       return;
     }
-    // Host-strings mode: fall through to iter-host. The string's
-    // underlying ValType is already externref, so no coercion is
-    // needed — the iter-host arm passes `iterableV` straight to
-    // `__iterator`. We bind the loop variable as externref (host
-    // strings only have host-side string semantics; the iter-host
-    // element is opaque externref by design).
+    // Iter-host strategy: the string's underlying ValType is already
+    // externref, so no coercion is needed — the iter-host arm passes
+    // `iterableV` straight to `__iterator`. We bind the loop variable as
+    // externref (host strings only have host-side string semantics; the
+    // iter-host element is opaque externref by design).
     lowerForOfIterFromExternrefValue(stmt, cx, iterableV, loopVarName, /* alreadyExternref */ true);
     return;
   }

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1009,9 +1009,10 @@ function externResultClassName(
 
 function makeFromAstResolver(ctx: CodegenContext, sourceFile?: ts.SourceFile): IrFromAstResolver {
   return {
-    nativeStrings(): boolean {
-      return ctx.nativeStrings;
-    },
+    // (#2955 slice 5) No raw `nativeStrings()` here anymore — from-ast's
+    // interface no longer carries the mode discriminator; every mode
+    // decision flows through the named capability/rep/strategy queries
+    // below.
     // (#2955 slice 2) The WHOLE string-prototype-method mode decision table,
     // relocated here from from-ast's `lowerStringMethodCall` so the front-end
     // reads no `nativeStrings` at that site. Byte-inert by construction: the
@@ -1160,6 +1161,14 @@ function makeFromAstResolver(ctx: CodegenContext, sourceFile?: ts.SourceFile): I
     // standalone floor (the demote arm is load-bearing there).
     hasHostNumberToString(): boolean {
       return !ctx.nativeStrings;
+    },
+    // (#2955 slice 5) String for-of strategy — the LAST from-ast mode read,
+    // relocated. Native strings iterate via the `__str_charAt` counter loop;
+    // host strings feed the `__iterator` host protocol (already
+    // externref-shaped). Byte-inert: same truth table as the old in-place
+    // `nativeStrings?.()` read (absent → iter-host).
+    stringForOfPlan(): "char-loop" | "iter-host" {
+      return ctx.nativeStrings ? "char-loop" : "iter-host";
     },
     // (#2856 C2) TypedArray-view receiver detection for element STORES —
     // the same checker walk as the legacy `elementAccessTypedArrayName`


### PR DESCRIPTION
## Summary

Final slice of #2955's read-elimination arc (follows s3 #3187, s4 #3190). `lowerForOfStatement`'s string arm — the LAST functional `nativeStrings` read in `src/ir/from-ast.ts` — now consults `IrFromAstResolver.stringForOfPlan(): "char-loop" | "iter-host"`. Both loop builders stay in from-ast; only the SELECTION is resolver-owned (build-time selection, same shape as `stringMethodPlan` — the two strategies build structurally different IR). Implementations: integration = `ctx.nativeStrings ? "char-loop" : "iter-host"`; the selfhost native-strings build resolver pins `"char-loop"` (the plan-absent default is iter-host, whose `__iterator` host import a host-free build must never emit); linear omits it (iter-host fallthrough, unchanged). Byte-inert truth table incl. resolver-absent.

**Capstone: `nativeStrings?()` is REMOVED from `IrFromAstResolver`** and both implementers. With zero functional reads left, keeping the raw mode discriminator on the front-end surface would leave the drift channel open — now a new representation-polymorphic IR-build branch is a **compile error**. `IrLowerResolver` (lower.ts) keeps its own `nativeStrings?()` — the lower side legitimately owns mode knowledge.

This completes #2955's grep-gate acceptance criterion (zero `nativeStrings` reads in from-ast — stronger: the method no longer exists there). The issue file records the full criteria status: the "identical IR across modes" criterion is a documented follow-up (abstract-op promotions), since demote/claim decisions must stay build-time queries.

## Verification

- **Byte-inert**: sha256-identical compiled binaries vs the slice-4 parent in ALL THREE regimes (host / native / standalone) over the 20-source corpus; mutation check (strategy inverted) flips native+standalone string-forof hashes — the read is live.
- Post-merge-of-main re-verified: zero functional reads, `tsc --noEmit` clean, string-iteration + selfhost suites (`issue-1183`, `issue-1374-ir-string-iter-inline`, `issue-1470-string-iteration-standalone`, `issue-3161`, `issue-3256`, `ir-frontend-widening`) 77/77.
- `check:ir-fallbacks` gate unchanged; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)