### PR TITLE
feat(porffor): prove scalar control flow through Porffor C

### DIFF
--- a/plan/issues/3297-porffor-scalar-control-flow-proof.md
+++ b/plan/issues/3297-porffor-scalar-control-flow-proof.md
@@ -1,10 +1,10 @@
 ---
 id: 3297
 title: "Porffor backend P2: scalar and control-flow differential proof"
-status: ready
+status: in-review
 sprint: porffor-backend
 created: 2026-07-16
-updated: 2026-07-16
+updated: 2026-07-17
 priority: high
 horizon: l
 feasibility: hard
@@ -18,6 +18,9 @@ parent: 3288
 depends_on: [3296]
 related: [3288, 3295, 3296, 3030]
 origin: "#3288 P2 split: independently dispatchable scalar Porffor backend proof"
+claimed_by: porffor-codex-developer
+claimed_at: 2026-07-17T02:12:12.870Z
+branch: symphony/porffor/3297
 ---
 
 # #3297 - Porffor backend P2: scalar and control-flow differential proof
@@ -44,16 +47,16 @@ behavior against JavaScript and JS2's linear-Wasm backend.
 
 ## Acceptance criteria
 
-- [ ] Real JS2 IR reaches Porffor IR through the five-part backend contract;
+- [x] Real JS2 IR reaches Porffor IR through the five-part backend contract;
       there is no parallel AST-to-Porffor front end.
-- [ ] Expression construction preserves operand order and `FX` semantics for
+- [x] Expression construction preserves operand order and `FX` semantics for
       effectful scalar/control-flow fixtures.
-- [ ] Unsupported heap/reference IR fails through legality before emission.
-- [ ] Scalar fixtures produce equal results under JavaScript, linear-Wasm, and
+- [x] Unsupported heap/reference IR fails through legality before emission.
+- [x] Scalar fixtures produce equal results under JavaScript, linear-Wasm, and
       Porffor-C.
-- [ ] Function and module assembly is deterministic and independent of
+- [x] Function and module assembly is deterministic and independent of
       registration order.
-- [ ] The issue changes are committed, pushed to `origin`, and published as a
+- [x] The issue changes are committed, pushed to `origin`, and published as a
       ready, non-draft PR before completion is reported.
 
 ## Validation
@@ -73,3 +76,36 @@ behavior against JavaScript and JS2's linear-Wasm backend.
 
 After this PR merges and #2956 is complete, #3298 extracts the shared
 backend-neutral linear-memory plan.
+
+## Implementation record (2026-07-17)
+
+- Added an IR-only Porffor integration path using the existing type converter,
+  Porffor legality profile, generic function-body lowerer, structured emitter,
+  and module assembler. Production source does not statically import the
+  optional renderer or Porffor internals.
+- Added a symbolic `PorfforSink` whose statement list and value stack spill
+  pending reads/effects before later statements. Effectful operands and Wasm
+  `select` inputs are evaluated eagerly from left to right before final C
+  expression construction.
+- Added deterministic final assembly. Functions, globals, and interned types
+  retain symbolic handles during lowering, sort by stable names/keys, and only
+  receive Porffor array positions in `finalize()`.
+- Moved scalar slot and loop lowering off the Wasm-only raw-instruction escape
+  path so all four emitter families can use their own sink type. Heap,
+  reference, indirect-call, exception, and raw-Wasm families remain rejected
+  by Porffor legality or fail loudly at the emitter boundary.
+- The differential fixture lowers real typed SSA IR, renders with the pinned
+  optional Porffor checkout, compiles the generated C with `-Werror`, and
+  proves results `[1312, 26, 15, 10, -1]` against JavaScript and linear Wasm.
+  The first value distinguishes left-to-right calls from reversed evaluation.
+
+Validation completed:
+
+- `pnpm exec vitest run tests/issue-3297.test.ts tests/issue-3288.test.ts tests/issue-3295-porffor-compat.test.ts tests/backend-contract.test.ts tests/issue-2952.test.ts tests/issue-1982-ir-emission-order.test.ts --reporter=dot`
+  (6 files, 44 tests passed)
+- `pnpm run typecheck`
+- `pnpm run lint`
+- `pnpm run format:check`
+- `pnpm run build`
+- `pnpm run check:pushraw` (80 call sites, two fewer than merge-base)
+- `pnpm run check:loc-budget`

--- a/src/ir/backend/contract-conformance.ts
+++ b/src/ir/backend/contract-conformance.ts
@@ -47,6 +47,7 @@ import type {
 import type { WasmGcEmitter } from "./wasmgc-emitter.js";
 import type { LinearEmitter } from "./linear-emitter.js";
 import type { BytecodeEmitter, BytecodeSink } from "./bytecode-emitter.js";
+import type { PorfforEmitter, PorfforSink } from "./porffor/sink.js";
 
 // ---------------------------------------------------------------------------
 // 1 — the three in-tree emitters conform (type-level; no runtime cost)
@@ -59,7 +60,9 @@ type Conforms<Impl, Contract> = Impl extends Contract ? true : never;
 const wasmGcEmitterConforms: Conforms<WasmGcEmitter, BackendEmitter<Instr[]>> = true;
 const linearEmitterConforms: Conforms<LinearEmitter, BackendEmitter<Instr[]>> = true;
 const bytecodeEmitterConforms: Conforms<BytecodeEmitter, BackendEmitter<BytecodeSink>> = true;
-export const emittersConform: boolean = wasmGcEmitterConforms && linearEmitterConforms && bytecodeEmitterConforms;
+const porfforEmitterConforms: Conforms<PorfforEmitter, BackendEmitter<PorfforSink>> = true;
+export const emittersConform: boolean =
+  wasmGcEmitterConforms && linearEmitterConforms && bytecodeEmitterConforms && porfforEmitterConforms;
 
 // ---------------------------------------------------------------------------
 // 2 — the stub backend

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -186,10 +186,10 @@ function bytecodeBinopLegal(op: IrBinop): boolean {
   }
 }
 
-// #3288 P1 — deliberately narrow until the structured Porffor sink lands in
-// P2. Every admitted family reaches a typed BackendEmitter primitive in
-// lower.ts. Families that still touch pushRaw or require an Instr[] sub-buffer
-// are rejected here, before a Porffor emitter can observe them.
+// #3288 P1 / #3297 P2 — scalar/control-flow Porffor profile. Every admitted
+// family reaches a typed BackendEmitter primitive in lower.ts; heap/reference
+// families and composite ops that still need a representation decision remain
+// rejected before a Porffor emitter can observe them.
 function porfforInstrError(instr: IrInstr): string | null {
   switch (instr.kind) {
     case "const":
@@ -203,22 +203,56 @@ function porfforInstrError(instr: IrInstr): string | null {
           return `porffor backend does not support const '${instr.value.kind}'`;
       }
     case "binary":
-      return instr.op.startsWith("js.")
-        ? `porffor backend does not support binary op '${instr.op}' before typed composite-op lowering`
-        : null;
+      return porfforBinopLegal(instr.op)
+        ? null
+        : `porffor backend does not support binary op '${instr.op}' before typed composite-op lowering`;
     case "unary":
       return instr.op === "ref.is_null" ? `porffor backend does not support unary op '${instr.op}'` : null;
     case "call":
     case "global.get":
     case "global.set":
+    case "slot.read":
+    case "slot.write":
     case "select":
     case "if":
     case "early.return":
     case "br.label":
     case "if.stmt":
+    case "while.loop":
+    case "for.loop":
       return null;
     default:
       return `porffor backend does not support IR instruction '${instr.kind}' before typed Porffor lowering`;
+  }
+}
+
+function porfforBinopLegal(op: IrBinop): boolean {
+  switch (op) {
+    case "f64.add":
+    case "f64.sub":
+    case "f64.mul":
+    case "f64.div":
+    case "f64.eq":
+    case "f64.ne":
+    case "f64.lt":
+    case "f64.le":
+    case "f64.gt":
+    case "f64.ge":
+    case "i32.eq":
+    case "i32.ne":
+    case "i32.and":
+    case "i32.or":
+    case "i32.lt_s":
+    case "i32.le_s":
+    case "i32.gt_s":
+    case "i32.ge_s":
+    case "i32.lt_u":
+    case "i32.le_u":
+    case "i32.gt_u":
+    case "i32.ge_u":
+      return true;
+    default:
+      return false;
   }
 }
 

--- a/src/ir/backend/porffor/assembler.ts
+++ b/src/ir/backend/porffor/assembler.ts
@@ -1,0 +1,557 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { ModuleLayout } from "../../../emit/resolve-layout.js";
+import type { IrFunction, IrFuncRef, IrGlobalRef, IrTypeRef } from "../../nodes.js";
+import type { IrLoweredBody, IrLowerResolver } from "../../lower.js";
+import type { FuncHandle, FuncTypeDef, GlobalHandle, TypeHandle, ValType } from "../../types.js";
+import type { ModuleAssembler } from "../contract.js";
+import {
+  PORFFOR_EFFECT_ENTRIES,
+  PORFFOR_KIND_NAMES,
+  PORFFOR_TYPE_ENTRIES,
+  type PorfforFunctionRecord,
+  type PorfforGlobalRecord,
+  type PorfforNode,
+  type PorfforRendererInput,
+} from "./compat.js";
+import {
+  PORFFOR_FX,
+  type PorfforExpr,
+  type PorfforFunctionSymbol,
+  type PorfforGlobalSymbol,
+  type PorfforLocalRef,
+  type PorfforSink,
+  type PorfforStatement,
+  type PorfforSymbolResolver,
+  type PorfforTarget,
+  type PorfforTypeRef,
+} from "./sink.js";
+import { PorfforTypeConverter, type PorfforValueSlot } from "./type-converter.js";
+
+export interface PorfforFunctionDefinition {
+  readonly lowered: IrLoweredBody<PorfforSink, PorfforValueSlot>;
+}
+
+export interface PorfforGlobalDefinition {
+  readonly type: PorfforValueSlot;
+}
+
+export interface PorfforTypeDefinition {
+  readonly key: string;
+}
+
+interface FunctionEntry {
+  readonly handle: FuncHandle;
+  readonly name: string;
+  signature?: PorfforFunctionSymbol;
+  definition?: PorfforFunctionDefinition;
+}
+
+interface GlobalEntry {
+  readonly handle: GlobalHandle;
+  readonly name: string;
+  definition?: PorfforGlobalDefinition;
+}
+
+interface TypeEntry {
+  readonly handle: TypeHandle;
+  readonly key: string;
+  readonly name?: string;
+}
+
+interface LocalBinding {
+  readonly name: string;
+  readonly type: PorfforValueSlot;
+}
+
+type ControlFrame = { readonly kind: "block" | "loop" | "if"; readonly label: string };
+
+const TYPE_ORDINAL = new Map<string, number>(PORFFOR_TYPE_ENTRIES);
+const EFFECT_ORDINAL = new Map<string, number>(PORFFOR_EFFECT_ENTRIES);
+
+/**
+ * Porffor module/index authority. Handles are registration-order identities;
+ * final Porffor function/global array positions are assigned once, by stable
+ * symbolic name order, in `finalize()`.
+ */
+export class PorfforModuleAssembler
+  implements
+    ModuleAssembler<PorfforFunctionDefinition, PorfforGlobalDefinition, PorfforTypeDefinition>,
+    IrLowerResolver,
+    PorfforSymbolResolver
+{
+  readonly backend = "porffor" as const;
+  private readonly typeConverter = new PorfforTypeConverter();
+  private readonly funcsByHandle = new Map<FuncHandle, FunctionEntry>();
+  private readonly funcsByName = new Map<string, FunctionEntry>();
+  private readonly globalsByHandle = new Map<GlobalHandle, GlobalEntry>();
+  private readonly globalsByName = new Map<string, GlobalEntry>();
+  private readonly typesByHandle = new Map<TypeHandle, TypeEntry>();
+  private readonly typesByKey = new Map<string, TypeEntry>();
+  private readonly typesByName = new Map<string, TypeEntry>();
+  private readonly functionExports = new Map<string, FuncHandle>();
+  private readonly globalExports = new Map<string, GlobalHandle>();
+  private nextFuncHandle = 0;
+  private nextGlobalHandle = 0;
+  private nextTypeHandle = 0;
+  private start: FuncHandle | null = null;
+  private frozen = false;
+  private finalInput: PorfforRendererInput | null = null;
+  private preferences: Readonly<Record<string, unknown>> = { gc: false };
+
+  setPreferences(preferences: Readonly<Record<string, unknown>>): void {
+    this.assertMutable("set preferences");
+    this.preferences = { gc: false, ...preferences };
+  }
+
+  /** Declare an IR function and freeze its scalar signature before bodies lower. */
+  declareIrFunction(func: IrFunction): FuncHandle {
+    const handle = this.declareFunc(func.name);
+    const entry = this.requireFunc(handle);
+    entry.signature = {
+      name: func.name,
+      params: func.params.map((param) => this.oneSlot(param.type, `param ${param.name} of ${func.name}`)),
+      results: func.resultTypes.map((type, index) => this.oneSlot(type, `result ${index} of ${func.name}`)),
+    };
+    if (entry.signature.results.length > 1) {
+      throw new Error(`porffor backend does not support multi-value function '${func.name}'`);
+    }
+    return handle;
+  }
+
+  declarePorfforGlobal(name: string, type: PorfforValueSlot): GlobalHandle {
+    const handle = this.declareGlobal(name);
+    this.defineGlobal(handle, { type });
+    return handle;
+  }
+
+  declareFunc(name: string): FuncHandle {
+    this.assertMutable("declare function");
+    if (this.funcsByName.has(name)) throw new Error(`porffor assembler: duplicate function '${name}'`);
+    const entry: FunctionEntry = { handle: this.nextFuncHandle++, name };
+    this.funcsByHandle.set(entry.handle, entry);
+    this.funcsByName.set(name, entry);
+    return entry.handle;
+  }
+
+  defineFunc(handle: FuncHandle, definition: PorfforFunctionDefinition): void {
+    this.assertMutable("define function");
+    const entry = this.requireFunc(handle);
+    if (entry.definition) throw new Error(`porffor assembler: function '${entry.name}' is already defined`);
+    if (definition.lowered.name !== entry.name) {
+      throw new Error(
+        `porffor assembler: definition name '${definition.lowered.name}' does not match declaration '${entry.name}'`,
+      );
+    }
+    entry.definition = definition;
+  }
+
+  importFunc(_module: string, _field: string, _typeHandle: TypeHandle, name: string): FuncHandle {
+    throw new Error(`porffor backend does not support imported function '${name}' in the scalar/control-flow slice`);
+  }
+
+  lookupFunc(name: string): FuncHandle | undefined {
+    return this.funcsByName.get(name)?.handle;
+  }
+
+  declareGlobal(name: string): GlobalHandle {
+    this.assertMutable("declare global");
+    if (this.globalsByName.has(name)) throw new Error(`porffor assembler: duplicate global '${name}'`);
+    const entry: GlobalEntry = { handle: this.nextGlobalHandle++, name };
+    this.globalsByHandle.set(entry.handle, entry);
+    this.globalsByName.set(name, entry);
+    return entry.handle;
+  }
+
+  defineGlobal(handle: GlobalHandle, definition: PorfforGlobalDefinition): void {
+    this.assertMutable("define global");
+    const entry = this.requireGlobal(handle);
+    if (entry.definition) throw new Error(`porffor assembler: global '${entry.name}' is already defined`);
+    entry.definition = definition;
+  }
+
+  importGlobal(_module: string, _field: string, _type: ValType, _mutable: boolean, name: string): GlobalHandle {
+    throw new Error(`porffor backend does not support imported global '${name}' in the scalar/control-flow slice`);
+  }
+
+  lookupGlobal(name: string): GlobalHandle | undefined {
+    return this.globalsByName.get(name)?.handle;
+  }
+
+  internType(definition: PorfforTypeDefinition, name?: string): TypeHandle {
+    this.assertMutable("intern type");
+    const existing = this.typesByKey.get(definition.key);
+    if (existing) {
+      if (name) this.bindTypeName(name, existing);
+      return existing.handle;
+    }
+    const entry: TypeEntry = { handle: this.nextTypeHandle++, key: definition.key, name };
+    this.typesByHandle.set(entry.handle, entry);
+    this.typesByKey.set(entry.key, entry);
+    if (name) this.bindTypeName(name, entry);
+    return entry.handle;
+  }
+
+  lookupType(name: string): TypeHandle | undefined {
+    return this.typesByName.get(name)?.handle;
+  }
+
+  exportFunc(exportName: string, handle: FuncHandle): void {
+    this.assertMutable("export function");
+    this.requireFunc(handle);
+    if (this.functionExports.has(exportName)) throw new Error(`porffor assembler: duplicate export '${exportName}'`);
+    this.functionExports.set(exportName, handle);
+  }
+
+  exportGlobal(exportName: string, handle: GlobalHandle): void {
+    this.assertMutable("export global");
+    this.requireGlobal(handle);
+    if (this.globalExports.has(exportName)) throw new Error(`porffor assembler: duplicate export '${exportName}'`);
+    this.globalExports.set(exportName, handle);
+  }
+
+  setStart(handle: FuncHandle): void {
+    this.assertMutable("set start");
+    this.requireFunc(handle);
+    if (this.start !== null) throw new Error("porffor assembler: start function is already set");
+    this.start = handle;
+  }
+
+  finalize(): ModuleLayout {
+    this.assertMutable("finalize");
+    this.frozen = true;
+
+    const functions = [...this.funcsByHandle.values()].sort(byName);
+    const globals = [...this.globalsByHandle.values()].sort(byName);
+    const types = [...this.typesByHandle.values()].sort((left, right) => compareText(left.key, right.key));
+    for (const entry of functions) {
+      if (!entry.signature) throw new Error(`porffor assembler: function '${entry.name}' has no registered signature`);
+      if (!entry.definition)
+        throw new Error(`porffor assembler: function '${entry.name}' was declared but never defined`);
+    }
+    for (const entry of globals) {
+      if (!entry.definition)
+        throw new Error(`porffor assembler: global '${entry.name}' was declared but never defined`);
+    }
+
+    const funcPositions = new Map(functions.map((entry, index) => [entry.handle, index]));
+    const globalPositions = new Map(globals.map((entry, index) => [entry.handle, index]));
+    const typePositions = new Map(types.map((entry, index) => [entry.handle, index]));
+
+    const functionRecords = functions.map((entry, index) => this.assembleFunction(entry, index));
+    const globalRecords: PorfforGlobalRecord[] = globals.map((entry) => ({
+      name: entry.name,
+      type: typeOrdinal(entry.definition!.type),
+    }));
+    this.finalInput = {
+      funcs: functionRecords,
+      data: [],
+      globals: globalRecords,
+      entry: this.start === null ? null : this.requireFunc(this.start).name,
+      prefs: this.preferences,
+      usedTypes: new Set<number>(),
+    };
+
+    return {
+      func: (handle) => requirePosition(funcPositions, handle, "function"),
+      global: (handle) => requirePosition(globalPositions, handle, "global"),
+      type: (handle) => requirePosition(typePositions, handle, "type"),
+    };
+  }
+
+  rendererInput(): PorfforRendererInput {
+    if (!this.finalInput) throw new Error("porffor assembler: renderer input requested before finalize");
+    return this.finalInput;
+  }
+
+  resolveFunc(ref: IrFuncRef): number {
+    const handle = this.lookupFunc(ref.name);
+    if (handle === undefined) throw new Error(`porffor assembler: unresolved function '${ref.name}'`);
+    return handle;
+  }
+
+  resolveGlobal(ref: IrGlobalRef): number {
+    const handle = this.lookupGlobal(ref.name);
+    if (handle === undefined) throw new Error(`porffor assembler: unresolved global '${ref.name}'`);
+    return handle;
+  }
+
+  resolveType(ref: IrTypeRef): number {
+    const handle = this.lookupType(ref.name);
+    if (handle === undefined) throw new Error(`porffor assembler: unresolved type '${ref.name}'`);
+    return handle;
+  }
+
+  internFuncType(_type: FuncTypeDef): number {
+    throw new Error("porffor backend does not intern Wasm function types");
+  }
+
+  functionSymbol(handle: number): PorfforFunctionSymbol {
+    const entry = this.requireFunc(handle);
+    if (!entry.signature) throw new Error(`porffor assembler: function '${entry.name}' has no registered signature`);
+    return entry.signature;
+  }
+
+  globalSymbol(handle: number): PorfforGlobalSymbol {
+    const entry = this.requireGlobal(handle);
+    if (!entry.definition) throw new Error(`porffor assembler: global '${entry.name}' has no definition`);
+    return { name: entry.name, type: entry.definition.type };
+  }
+
+  private assembleFunction(entry: FunctionEntry, index: number): PorfforFunctionRecord {
+    const lowered = entry.definition!.lowered;
+    const params: LocalBinding[] = lowered.params.map((value, paramIndex) => ({
+      name: `#js2_param_${paramIndex}_${value.name}`,
+      type: oneLoweredSlot(value.slots, `param ${value.name} of ${entry.name}`),
+    }));
+    const loweredLocals: LocalBinding[] = lowered.locals.map((value, localIndex) => ({
+      name: `#js2_local_${localIndex}_${value.name}`,
+      type: oneLoweredSlot(value.slots, `local ${value.name} of ${entry.name}`),
+    }));
+    const indexedLocals = [...params, ...loweredLocals];
+    const scratchLocals: LocalBinding[] = lowered.body.scratchLocals().map((local) => ({
+      name: local.name,
+      type: this.resolveTypeRef(local.type, indexedLocals),
+    }));
+    const locals: Record<string, { type: number }> = {};
+    for (const local of [...loweredLocals, ...scratchLocals]) {
+      if (locals[local.name]) throw new Error(`porffor assembler: duplicate local '${local.name}' in ${entry.name}`);
+      locals[local.name] = { type: typeOrdinal(local.type) };
+    }
+
+    lowered.body.assertEmpty(`function ${entry.name}`);
+    const body = this.assembleStatements(lowered.body.statements, indexedLocals, entry.name, []);
+    return {
+      name: entry.name,
+      index,
+      params: params.map((param) => ({ name: param.name, type: typeOrdinal(param.type) })),
+      retType:
+        lowered.results.length === 0
+          ? typeOrdinal("none")
+          : typeOrdinal(oneLoweredSlot(lowered.results[0]!, `result of ${entry.name}`)),
+      locals,
+      body,
+    };
+  }
+
+  private assembleStatements(
+    statements: readonly PorfforStatement[],
+    locals: readonly LocalBinding[],
+    funcName: string,
+    frames: readonly ControlFrame[],
+  ): PorfforNode[] {
+    const out: PorfforNode[] = [];
+    for (const statement of statements) {
+      switch (statement.kind) {
+        case "assign": {
+          const target = this.assembleTarget(statement.target, locals);
+          const value = this.assembleExpr(statement.value, locals);
+          const globalWrite = statement.target.kind === "global" ? PORFFOR_FX.readGlobal : PORFFOR_FX.none;
+          out.push(
+            node("Assign", "none", PORFFOR_FX.writeLocal | target[2] | value[2] | globalWrite, target, value, 0),
+          );
+          break;
+        }
+        case "expr":
+          out.push(this.assembleExpr(statement.value, locals));
+          break;
+        case "if": {
+          const label = controlLabel(funcName, statement.controlId);
+          const nextFrames = [...frames, { kind: "if" as const, label }];
+          const condition = this.assembleExpr(statement.condition, locals);
+          const thenBody = this.assembleStatements(statement.then, locals, funcName, nextFrames);
+          const elseBody = this.assembleStatements(statement.else, locals, funcName, nextFrames);
+          const ifNode = node("If", "none", condition[2], condition, thenBody, elseBody.length === 0 ? null : elseBody);
+          out.push(node("Block", "none", PORFFOR_FX.none, [ifNode], label, 0));
+          break;
+        }
+        case "block": {
+          const label = controlLabel(funcName, statement.controlId);
+          const body = this.assembleStatements(statement.body, locals, funcName, [...frames, { kind: "block", label }]);
+          out.push(node("Block", "none", PORFFOR_FX.none, body, label, 0));
+          break;
+        }
+        case "loop": {
+          const label = controlLabel(funcName, statement.controlId);
+          const body = this.assembleStatements(statement.body, locals, funcName, [...frames, { kind: "loop", label }]);
+          out.push(node("Loop", "none", PORFFOR_FX.none, null, null, [body, label]));
+          break;
+        }
+        case "branch": {
+          const branch = assembleBranch(statement.depth, frames);
+          if (statement.condition) {
+            const condition = this.assembleExpr(statement.condition, locals);
+            out.push(node("If", "none", condition[2], condition, [branch], null));
+          } else {
+            out.push(branch);
+          }
+          break;
+        }
+        case "return": {
+          const value = statement.value ? this.assembleExpr(statement.value, locals) : null;
+          out.push(node("Return", "none", value?.[2] ?? PORFFOR_FX.none, value, 0, 0));
+          break;
+        }
+        case "unreachable":
+          out.push(node("Unreachable", "none", PORFFOR_FX.none, null, 0, 0));
+          break;
+      }
+    }
+    return out;
+  }
+
+  private assembleTarget(target: PorfforTarget, locals: readonly LocalBinding[]): PorfforNode {
+    if (target.kind === "local") {
+      const binding = this.resolveLocal(target.local, locals);
+      return node("Local", binding.type, PORFFOR_FX.none, binding.name, 0, 0);
+    }
+    const global = this.globalSymbol(target.handle);
+    return node("Global", global.type, PORFFOR_FX.readGlobal, global.name, 0, 0);
+  }
+
+  private assembleExpr(expression: PorfforExpr, locals: readonly LocalBinding[]): PorfforNode {
+    const type = this.resolveTypeRef(expression.type, locals);
+    switch (expression.kind) {
+      case "const":
+        return node(
+          "Const",
+          type,
+          PORFFOR_FX.none,
+          type === "i64" || type === "u64" ? String(expression.value) : Number(expression.value),
+          0,
+          0,
+        );
+      case "local": {
+        const binding = this.resolveLocal(expression.local, locals);
+        return node("Local", binding.type, PORFFOR_FX.none, binding.name, 0, 0);
+      }
+      case "global": {
+        const global = this.globalSymbol(expression.handle);
+        return node("Global", global.type, PORFFOR_FX.readGlobal, global.name, 0, 0);
+      }
+      case "binary": {
+        const left = this.assembleExpr(expression.left, locals);
+        const right = this.assembleExpr(expression.right, locals);
+        return node("Bin", expression.comparison ? "i32" : type, left[2] | right[2], expression.op, left, right);
+      }
+      case "unary": {
+        const value = this.assembleExpr(expression.value, locals);
+        return node("Un", type, value[2], expression.op, value, 0);
+      }
+      case "select": {
+        const condition = this.assembleExpr(expression.condition, locals);
+        const whenTrue = this.assembleExpr(expression.whenTrue, locals);
+        const whenFalse = this.assembleExpr(expression.whenFalse, locals);
+        return node("Select", type, condition[2] | whenTrue[2] | whenFalse[2], condition, whenTrue, whenFalse);
+      }
+      case "convert": {
+        const value = this.assembleExpr(expression.value, locals);
+        return node("Convert", type, value[2], value[1], value, expression.flags);
+      }
+      case "call": {
+        const symbol = this.functionSymbol(expression.target);
+        const args = expression.args.map((arg) => this.assembleExpr(arg, locals));
+        const effects = args.reduce<number>((combined, arg) => combined | arg[2], PORFFOR_FX.call);
+        return node("Call", type, effects, symbol.name, args, 0);
+      }
+    }
+  }
+
+  private resolveTypeRef(type: PorfforTypeRef, locals: readonly LocalBinding[]): PorfforValueSlot {
+    if (typeof type === "string") return type;
+    if (type.kind === "local") return this.resolveLocal(type.local, locals).type;
+    return this.globalSymbol(type.handle).type;
+  }
+
+  private resolveLocal(local: PorfforLocalRef, locals: readonly LocalBinding[]): LocalBinding {
+    if (local.kind === "scratch") return { name: local.name, type: this.resolveTypeRef(local.type, locals) };
+    const binding = locals[local.index];
+    if (!binding) throw new Error(`porffor assembler: unresolved lowered local index ${local.index}`);
+    return binding;
+  }
+
+  private oneSlot(type: Parameters<PorfforTypeConverter["convertType"]>[0], where: string): PorfforValueSlot {
+    return oneLoweredSlot(this.typeConverter.convertType(type), where);
+  }
+
+  private bindTypeName(name: string, entry: TypeEntry): void {
+    const existing = this.typesByName.get(name);
+    if (existing && existing !== entry) throw new Error(`porffor assembler: duplicate type name '${name}'`);
+    this.typesByName.set(name, entry);
+  }
+
+  private requireFunc(handle: FuncHandle): FunctionEntry {
+    const entry = this.funcsByHandle.get(handle);
+    if (!entry) throw new Error(`porffor assembler: unknown function handle ${handle}`);
+    return entry;
+  }
+
+  private requireGlobal(handle: GlobalHandle): GlobalEntry {
+    const entry = this.globalsByHandle.get(handle);
+    if (!entry) throw new Error(`porffor assembler: unknown global handle ${handle}`);
+    return entry;
+  }
+
+  private assertMutable(action: string): void {
+    if (this.frozen) throw new Error(`porffor assembler: cannot ${action} after finalize`);
+  }
+}
+
+function oneLoweredSlot(slots: readonly PorfforValueSlot[], where: string): PorfforValueSlot {
+  if (slots.length !== 1) throw new Error(`porffor backend requires exactly one scalar slot for ${where}`);
+  return slots[0]!;
+}
+
+function assembleBranch(depth: number, frames: readonly ControlFrame[]): PorfforNode {
+  const frame = frames[frames.length - 1 - depth];
+  if (!frame) throw new Error(`porffor assembler: branch depth ${depth} has no enclosing control frame`);
+  return frame.kind === "loop"
+    ? node("Continue", "none", PORFFOR_FX.none, frame.label, 0, 0)
+    : node("Break", "none", PORFFOR_FX.none, frame.label, 0, 0);
+}
+
+function controlLabel(funcName: string, id: number): string {
+  return `#js2_${funcName}_cf_${id}`;
+}
+
+function node(
+  kind: (typeof PORFFOR_KIND_NAMES)[number],
+  type: PorfforValueSlot | "none",
+  effects: number,
+  a: unknown,
+  b: unknown,
+  c: unknown,
+): PorfforNode {
+  const kindOrdinal = PORFFOR_KIND_NAMES.indexOf(kind);
+  if (kindOrdinal < 0) throw new Error(`porffor assembler: unknown node kind '${kind}'`);
+  return [kindOrdinal, typeOrdinal(type), effects, a, b, c];
+}
+
+function typeOrdinal(type: PorfforValueSlot | "none"): number {
+  const ordinal = TYPE_ORDINAL.get(type);
+  if (ordinal === undefined) throw new Error(`porffor assembler: unknown value type '${type}'`);
+  return ordinal;
+}
+
+function requirePosition<Handle extends number>(
+  positions: ReadonlyMap<Handle, number>,
+  handle: Handle,
+  kind: string,
+): number {
+  const position = positions.get(handle);
+  if (position === undefined) throw new Error(`porffor assembler: unknown ${kind} handle ${handle}`);
+  return position;
+}
+
+function byName(left: { readonly name: string }, right: { readonly name: string }): number {
+  return compareText(left.name, right.name);
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+// Guard the copied symbolic effect table against compatibility-fingerprint drift.
+if (EFFECT_ORDINAL.get("call") !== PORFFOR_FX.call || EFFECT_ORDINAL.get("writeLocal") !== PORFFOR_FX.writeLocal) {
+  throw new Error("porffor compatibility effect ordinals drifted from the symbolic sink");
+}

--- a/src/ir/backend/porffor/integration.ts
+++ b/src/ir/backend/porffor/integration.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrModule, IrType } from "../../nodes.js";
+import { lowerIrFunctionBody } from "../../lower.js";
+import { verifyIrBackendLegality } from "../legality.js";
+import type { PorfforRendererInput } from "./compat.js";
+import { PorfforModuleAssembler } from "./assembler.js";
+import { PorfforEmitter } from "./sink.js";
+import { PorfforTypeConverter } from "./type-converter.js";
+
+export interface PorfforGlobalInput {
+  readonly name: string;
+  readonly type: IrType;
+}
+
+export interface LowerIrModuleToPorfforOptions {
+  readonly globals?: readonly PorfforGlobalInput[];
+  /** Renderer entry name. Null/omitted emits no C main, useful for embedding/tests. */
+  readonly entry?: string | null;
+  readonly prefs?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Lower a typed JS2 SSA module through the five-part backend contract into the
+ * frozen Porffor renderer record. This is deliberately IR-only: callers must
+ * use JS2's existing AST-to-IR front end and no Porffor parser/codegen path is
+ * imported here.
+ */
+export function lowerIrModuleToPorffor(
+  module: IrModule,
+  options: LowerIrModuleToPorfforOptions = {},
+): PorfforRendererInput {
+  const assembler = new PorfforModuleAssembler();
+  const types = new PorfforTypeConverter();
+  assembler.setPreferences(options.prefs ?? {});
+
+  for (const global of options.globals ?? []) {
+    const slots = types.convertType(global.type);
+    if (slots.length !== 1) throw new Error(`porffor backend requires one scalar slot for global '${global.name}'`);
+    assembler.declarePorfforGlobal(global.name, slots[0]!);
+  }
+
+  const handles = new Map<string, number>();
+  for (const func of module.functions) {
+    const errors = verifyIrBackendLegality(func, "porffor");
+    if (errors.length > 0) {
+      throw new Error(
+        `porffor backend legality failed for ${func.name}: ${errors.map((error) => error.message).join("; ")}`,
+      );
+    }
+    handles.set(func.name, assembler.declareIrFunction(func));
+  }
+
+  for (const func of module.functions) {
+    const handle = handles.get(func.name)!;
+    const signature = assembler.functionSymbol(handle);
+    const emitter = new PorfforEmitter(assembler, signature.results);
+    const lowered = lowerIrFunctionBody(func, assembler, emitter, types);
+    assembler.defineFunc(handle, { lowered });
+    if (func.exported) assembler.exportFunc(func.name, handle);
+  }
+
+  if (options.entry) {
+    const handle = assembler.lookupFunc(options.entry);
+    if (handle === undefined) throw new Error(`porffor assembler: entry function '${options.entry}' is not defined`);
+    assembler.setStart(handle);
+  }
+
+  assembler.finalize();
+  return assembler.rendererInput();
+}

--- a/src/ir/backend/porffor/sink.ts
+++ b/src/ir/backend/porffor/sink.ts
@@ -1,0 +1,596 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrBinop, IrInstr, IrType, IrUnop } from "../../nodes.js";
+import { asVal } from "../../nodes.js";
+import type { BlockType, Instr } from "../../types.js";
+import type { BackendEmitter } from "../emitter.js";
+import type {
+  IrClassLowering,
+  IrClosureLowering,
+  IrObjectStructLowering,
+  IrRefCellLowering,
+  IrVecLowering,
+  LinearVecLowering,
+} from "../handles.js";
+import type { PorfforValueSlot } from "./type-converter.js";
+
+/** Frozen Porffor FX bits, kept on symbolic nodes until final assembly. */
+export const PORFFOR_FX = {
+  none: 0,
+  readMem: 1,
+  writeMem: 2,
+  call: 4,
+  readGlobal: 8,
+  writeLocal: 16,
+} as const;
+
+export type PorfforLocalRef =
+  | { readonly kind: "lowered"; readonly index: number }
+  | { readonly kind: "scratch"; readonly name: string; readonly type: PorfforTypeRef };
+
+export type PorfforTypeRef =
+  | PorfforValueSlot
+  | { readonly kind: "local"; readonly local: PorfforLocalRef }
+  | { readonly kind: "global"; readonly handle: number };
+
+interface PorfforExprBase {
+  readonly type: PorfforTypeRef;
+  readonly effects: number;
+}
+
+export type PorfforExpr =
+  | (PorfforExprBase & { readonly kind: "const"; readonly value: number | bigint })
+  | (PorfforExprBase & { readonly kind: "local"; readonly local: PorfforLocalRef })
+  | (PorfforExprBase & { readonly kind: "global"; readonly handle: number })
+  | (PorfforExprBase & {
+      readonly kind: "binary";
+      readonly op: string;
+      readonly left: PorfforExpr;
+      readonly right: PorfforExpr;
+      readonly comparison: boolean;
+    })
+  | (PorfforExprBase & { readonly kind: "unary"; readonly op: string; readonly value: PorfforExpr })
+  | (PorfforExprBase & {
+      readonly kind: "select";
+      readonly condition: PorfforExpr;
+      readonly whenTrue: PorfforExpr;
+      readonly whenFalse: PorfforExpr;
+    })
+  | (PorfforExprBase & {
+      readonly kind: "convert";
+      readonly value: PorfforExpr;
+      readonly flags: number;
+    })
+  | (PorfforExprBase & { readonly kind: "call"; readonly target: number; readonly args: readonly PorfforExpr[] });
+
+export type PorfforTarget =
+  | { readonly kind: "local"; readonly local: PorfforLocalRef }
+  | { readonly kind: "global"; readonly handle: number };
+
+export type PorfforStatement =
+  | { readonly kind: "assign"; readonly target: PorfforTarget; readonly value: PorfforExpr }
+  | { readonly kind: "expr"; readonly value: PorfforExpr }
+  | {
+      readonly kind: "if";
+      readonly controlId: number;
+      readonly condition: PorfforExpr;
+      readonly then: readonly PorfforStatement[];
+      readonly else: readonly PorfforStatement[];
+    }
+  | { readonly kind: "block"; readonly controlId: number; readonly body: readonly PorfforStatement[] }
+  | { readonly kind: "loop"; readonly controlId: number; readonly body: readonly PorfforStatement[] }
+  | { readonly kind: "branch"; readonly depth: number; readonly condition?: PorfforExpr }
+  | { readonly kind: "return"; readonly value: PorfforExpr | null }
+  | { readonly kind: "unreachable" };
+
+export interface PorfforFunctionSymbol {
+  readonly name: string;
+  readonly params: readonly PorfforValueSlot[];
+  readonly results: readonly PorfforValueSlot[];
+}
+
+export interface PorfforGlobalSymbol {
+  readonly name: string;
+  readonly type: PorfforValueSlot;
+}
+
+/** Symbol lookup stays handle-based until the module assembler freezes. */
+export interface PorfforSymbolResolver {
+  functionSymbol(handle: number): PorfforFunctionSymbol;
+  globalSymbol(handle: number): PorfforGlobalSymbol;
+}
+
+export interface PorfforScratchLocal {
+  readonly name: string;
+  readonly type: PorfforTypeRef;
+}
+
+class PorfforFunctionContext {
+  readonly scratchLocals: PorfforScratchLocal[] = [];
+  private nextControlId = 0;
+
+  scratch(type: PorfforTypeRef): PorfforLocalRef {
+    const name = `#js2_tmp_${this.scratchLocals.length}`;
+    const local: PorfforLocalRef = { kind: "scratch", name, type };
+    this.scratchLocals.push({ name, type });
+    return local;
+  }
+
+  controlId(): number {
+    return this.nextControlId++;
+  }
+}
+
+/**
+ * Structured Porffor builder used by the generic stack-oriented lowerer.
+ *
+ * Expressions remain symbolic trees on `values`; statements are committed in
+ * source order. Before a statement is appended, every older pending value is
+ * spilled to a function-scoped scratch. This is the key ordering invariant:
+ * a later assignment/control edge can never move ahead of an earlier local or
+ * global read merely because C evaluates the eventual expression later.
+ */
+export class PorfforSink {
+  readonly statements: PorfforStatement[] = [];
+  readonly values: PorfforExpr[] = [];
+
+  constructor(private readonly context: PorfforFunctionContext) {}
+
+  scratchLocals(): readonly PorfforScratchLocal[] {
+    return this.context.scratchLocals;
+  }
+
+  push(value: PorfforExpr): void {
+    this.values.push(value);
+  }
+
+  pop(where: string): PorfforExpr {
+    const value = this.values.pop();
+    if (!value) throw new Error(`porffor sink: value stack underflow in ${where}`);
+    return value;
+  }
+
+  popMany(count: number, where: string): PorfforExpr[] {
+    if (this.values.length < count) {
+      throw new Error(`porffor sink: value stack underflow in ${where} (need ${count}, have ${this.values.length})`);
+    }
+    return this.values.splice(this.values.length - count, count);
+  }
+
+  /** Spill every older pending operand before a statement can observe state. */
+  flushValues(): void {
+    for (let i = 0; i < this.values.length; i++) {
+      const value = this.values[i]!;
+      const local = this.spillDirect(value);
+      this.values[i] = localExpr(local);
+    }
+  }
+
+  /** Evaluate expressions eagerly and in the exact supplied order. */
+  sequence(expressions: readonly PorfforExpr[]): PorfforExpr[] {
+    this.flushValues();
+    return expressions.map((expression) => localExpr(this.spillDirect(expression)));
+  }
+
+  append(statement: PorfforStatement): void {
+    this.flushValues();
+    this.statements.push(statement);
+  }
+
+  assertEmpty(where: string): void {
+    if (this.values.length !== 0) {
+      throw new Error(`porffor sink: ${this.values.length} dangling value(s) in ${where}`);
+    }
+  }
+
+  private spillDirect(value: PorfforExpr): PorfforLocalRef {
+    const local = this.context.scratch(value.type);
+    this.statements.push({ kind: "assign", target: { kind: "local", local }, value });
+    return local;
+  }
+}
+
+function localExpr(local: PorfforLocalRef): PorfforExpr {
+  return {
+    kind: "local",
+    type: { kind: "local", local },
+    effects: PORFFOR_FX.none,
+    local,
+  };
+}
+
+function irTypeSlot(type: IrType): PorfforValueSlot {
+  const val = asVal(type);
+  if (!val) throw new Error(`porffor backend does not support IR type '${type.kind}'`);
+  switch (val.kind) {
+    case "f64":
+      return "f64";
+    case "i32":
+      return type.kind === "val" && type.signed === false ? "u32" : "i32";
+    case "i64":
+      return type.kind === "val" && type.signed === false ? "u64" : "i64";
+    default:
+      throw new Error(`porffor backend does not support ValType '${val.kind}'`);
+  }
+}
+
+type VecLayout = IrVecLowering | LinearVecLowering;
+
+/** Scalar/control-flow BackendEmitter implementation for Porffor's tree IR. */
+export class PorfforEmitter implements BackendEmitter<PorfforSink> {
+  readonly backend = "porffor" as const;
+  private readonly context = new PorfforFunctionContext();
+
+  constructor(
+    private readonly symbols: PorfforSymbolResolver,
+    private readonly resultSlots: readonly PorfforValueSlot[],
+  ) {
+    if (resultSlots.length > 1) throw new Error("porffor backend does not support multi-value function results");
+  }
+
+  scratchLocals(): readonly PorfforScratchLocal[] {
+    return this.context.scratchLocals;
+  }
+
+  newSink(): PorfforSink {
+    return new PorfforSink(this.context);
+  }
+
+  pushRaw(_out: PorfforSink, instr: Instr): void {
+    throw new Error(`porffor backend does not support raw Wasm instruction '${instr.op}'`);
+  }
+
+  emitConst(instr: Extract<IrInstr, { kind: "const" }>, _funcName: string, out: PorfforSink): void {
+    const type = instr.resultType ? irTypeSlot(instr.resultType) : constSlot(instr);
+    switch (instr.value.kind) {
+      case "bool":
+        out.push({ kind: "const", type, effects: PORFFOR_FX.none, value: instr.value.value ? 1 : 0 });
+        return;
+      case "i32":
+      case "i64":
+      case "f64":
+        out.push({ kind: "const", type, effects: PORFFOR_FX.none, value: instr.value.value });
+        return;
+      default:
+        throw new Error(`porffor backend does not support const '${instr.value.kind}'`);
+    }
+  }
+
+  emitBinary(op: IrBinop, out: PorfforSink): void {
+    let [left, right] = out.popMany(2, `binary ${op}`);
+    const effects = left!.effects | right!.effects;
+    if (effects !== PORFFOR_FX.none) [left, right] = out.sequence([left!, right!]);
+
+    const mapped = binaryOp(op);
+    const operandType = mapped.operandType ?? left!.type;
+    if (mapped.operandType && mapped.operandType !== left!.type) {
+      left = convertExpr(mapped.operandType, left!, mapped.unsigned ? 0 : 1);
+      right = convertExpr(mapped.operandType, right!, mapped.unsigned ? 0 : 1);
+    }
+    out.push({
+      kind: "binary",
+      type: mapped.comparison ? "i32" : operandType,
+      effects: left!.effects | right!.effects,
+      op: mapped.op,
+      left: left!,
+      right: right!,
+      comparison: mapped.comparison,
+    });
+  }
+
+  emitUnary(op: IrUnop, out: PorfforSink): void {
+    const value = out.pop(`unary ${op}`);
+    switch (op) {
+      case "f64.neg":
+        out.push({ kind: "unary", type: "f64", effects: value.effects, op: "neg", value });
+        return;
+      case "i32.eqz":
+        out.push({ kind: "unary", type: "i32", effects: value.effects, op: "!", value });
+        return;
+      case "i32.trunc_sat_f64_s":
+        out.push(convertExpr("i32", value, 1));
+        return;
+      case "f64.convert_i32_s":
+        out.push(convertExpr("f64", value, 1));
+        return;
+      case "f64.abs":
+      case "f64.sqrt":
+      case "f64.floor":
+      case "f64.ceil":
+      case "f64.trunc":
+        out.push({ kind: "unary", type: "f64", effects: value.effects, op: op.slice(4), value });
+        return;
+      case "ref.is_null":
+        throw new Error(`porffor backend does not support unary op '${op}'`);
+    }
+  }
+
+  emitLocalGet(index: number, out: PorfforSink): void {
+    const local: PorfforLocalRef = { kind: "lowered", index };
+    out.push(localExpr(local));
+  }
+
+  emitLocalSet(index: number, out: PorfforSink): void {
+    const value = out.pop("local.set");
+    out.append({ kind: "assign", target: { kind: "local", local: { kind: "lowered", index } }, value });
+  }
+
+  emitLocalTee(index: number, out: PorfforSink): void {
+    const local: PorfforLocalRef = { kind: "lowered", index };
+    const value = out.pop("local.tee");
+    out.append({ kind: "assign", target: { kind: "local", local }, value });
+    out.push(localExpr(local));
+  }
+
+  emitGlobalGet(handle: number, out: PorfforSink): void {
+    const global = this.symbols.globalSymbol(handle);
+    out.push({ kind: "global", type: global.type, effects: PORFFOR_FX.readGlobal, handle });
+  }
+
+  emitGlobalSet(handle: number, out: PorfforSink): void {
+    const value = out.pop("global.set");
+    out.append({ kind: "assign", target: { kind: "global", handle }, value });
+  }
+
+  emitDrop(out: PorfforSink): void {
+    const value = out.pop("drop");
+    if (value.effects !== PORFFOR_FX.none) out.append({ kind: "expr", value });
+  }
+
+  emitSelect(out: PorfforSink): void {
+    const condition = out.pop("select condition");
+    const whenFalse = out.pop("select false");
+    const whenTrue = out.pop("select true");
+    const [eagerTrue, eagerFalse, eagerCondition] = out.sequence([whenTrue, whenFalse, condition]);
+    out.push({
+      kind: "select",
+      type: eagerTrue!.type,
+      effects: eagerTrue!.effects | eagerFalse!.effects | eagerCondition!.effects,
+      condition: eagerCondition!,
+      whenTrue: eagerTrue!,
+      whenFalse: eagerFalse!,
+    });
+  }
+
+  emitReturn(out: PorfforSink): void {
+    const value = this.resultSlots.length === 0 ? null : out.pop("return");
+    out.append({ kind: "return", value });
+  }
+
+  emitUnreachable(out: PorfforSink): void {
+    out.append({ kind: "unreachable" });
+  }
+
+  emitIf(blockType: BlockType, thenSink: PorfforSink, elseSink: PorfforSink, out: PorfforSink): void {
+    const condition = out.pop("if condition");
+    if (blockType.kind === "val") {
+      const thenValue = thenSink.pop("if then result");
+      const elseValue = elseSink.pop("if else result");
+      const resultLocal = this.context.scratch(thenValue.type);
+      thenSink.append({ kind: "assign", target: { kind: "local", local: resultLocal }, value: thenValue });
+      elseSink.append({ kind: "assign", target: { kind: "local", local: resultLocal }, value: elseValue });
+      thenSink.assertEmpty("value if then arm");
+      elseSink.assertEmpty("value if else arm");
+      out.append({
+        kind: "if",
+        controlId: this.context.controlId(),
+        condition,
+        then: thenSink.statements,
+        else: elseSink.statements,
+      });
+      out.push(localExpr(resultLocal));
+      return;
+    }
+
+    thenSink.assertEmpty("if then arm");
+    elseSink.assertEmpty("if else arm");
+    out.append({
+      kind: "if",
+      controlId: this.context.controlId(),
+      condition,
+      then: thenSink.statements,
+      else: elseSink.statements,
+    });
+  }
+
+  emitBr(depth: number, out: PorfforSink): void {
+    out.append({ kind: "branch", depth });
+  }
+
+  emitBrIf(depth: number, out: PorfforSink): void {
+    const condition = out.pop("br_if condition");
+    out.append({ kind: "branch", depth, condition });
+  }
+
+  emitBlock(_blockType: BlockType, body: PorfforSink, out: PorfforSink): void {
+    body.assertEmpty("block");
+    out.append({ kind: "block", controlId: this.context.controlId(), body: body.statements });
+  }
+
+  emitLoop(_blockType: BlockType, body: PorfforSink, out: PorfforSink): void {
+    body.assertEmpty("loop");
+    out.append({ kind: "loop", controlId: this.context.controlId(), body: body.statements });
+  }
+
+  emitCall(handle: number, out: PorfforSink): void {
+    const symbol = this.symbols.functionSymbol(handle);
+    let args = out.popMany(symbol.params.length, `call ${symbol.name}`);
+    if (args.some((arg) => arg.effects !== PORFFOR_FX.none)) args = out.sequence(args);
+    const call: PorfforExpr = {
+      kind: "call",
+      type: symbol.results[0] ?? "i32",
+      effects: args.reduce<number>((effects, arg) => effects | arg.effects, PORFFOR_FX.call),
+      target: handle,
+      args,
+    };
+    if (symbol.results.length === 0) out.append({ kind: "expr", value: call });
+    else if (symbol.results.length === 1) out.push(call);
+    else throw new Error(`porffor backend does not support multi-value call '${symbol.name}'`);
+  }
+
+  emitVecLen(_layout: VecLayout, _out: PorfforSink): void {
+    this.unsupported("vec.len");
+  }
+  emitVecDataPtr(_layout: VecLayout, _out: PorfforSink): void {
+    this.unsupported("vec data pointer");
+  }
+  emitElemGet(_layout: VecLayout, _out: PorfforSink): void {
+    this.unsupported("element get");
+  }
+  emitVecNewFixed(_layout: VecLayout, _count: number, _scratch: number, _out: PorfforSink): void {
+    this.unsupported("vec.new_fixed");
+  }
+  emitNull(_type: IrType, _out: PorfforSink): void {
+    this.unsupported("null/reference values");
+  }
+  emitToExternref(_out: PorfforSink): void {
+    this.unsupported("externref conversion");
+  }
+  emitDowncast(_target: { typeIdx: number } | IrType, _out: PorfforSink): void {
+    this.unsupported("reference downcast");
+  }
+  emitFromExternref(_target: { typeIdx: number } | IrType, _out: PorfforSink): void {
+    this.unsupported("externref conversion");
+  }
+  emitFuncRef(_funcIdx: number, _out: PorfforSink): void {
+    this.unsupported("function references");
+  }
+  emitPromiseNew(_typeIdx: number, _out: PorfforSink): void {
+    this.unsupported("Promise allocation");
+  }
+  emitPromiseStateGet(_typeIdx: number, _out: PorfforSink): void {
+    this.unsupported("Promise state");
+  }
+  emitPromiseValueGet(_typeIdx: number, _out: PorfforSink): void {
+    this.unsupported("Promise value");
+  }
+  emitCallRef(_typeIdx: number, _out: PorfforSink): void {
+    this.unsupported("indirect calls");
+  }
+  emitAggregateNew(_layout: IrObjectStructLowering, _fieldCount: number, _out: PorfforSink): void {
+    this.unsupported("heap aggregate allocation");
+  }
+  emitFieldGet(_layout: IrObjectStructLowering | IrClassLowering, _name: string, _out: PorfforSink): void {
+    this.unsupported("heap field read");
+  }
+  emitFieldSet(_layout: IrObjectStructLowering | IrClassLowering, _name: string, _out: PorfforSink): void {
+    this.unsupported("heap field write");
+  }
+  emitThrow(_tagIdx: number, _out: PorfforSink): void {
+    this.unsupported("throw");
+  }
+  emitRethrow(_depth: number, _out: PorfforSink): void {
+    this.unsupported("rethrow");
+  }
+  emitTry(
+    _blockType: BlockType,
+    _body: PorfforSink,
+    _catches: { tagIdx: number; body: PorfforSink }[],
+    _catchAll: PorfforSink | undefined,
+    _out: PorfforSink,
+  ): void {
+    this.unsupported("try/catch");
+  }
+  emitClosureNew(_layout: IrClosureLowering, _captureCount: number, _out: PorfforSink): void {
+    this.unsupported("closure allocation");
+  }
+  emitClosureFuncGet(_layout: IrClosureLowering, _out: PorfforSink): void {
+    this.unsupported("closure function read");
+  }
+  emitCaptureGet(_layout: IrClosureLowering, _index: number, _out: PorfforSink): void {
+    this.unsupported("closure capture read");
+  }
+  emitRefCellNew(_layout: IrRefCellLowering, _out: PorfforSink): void {
+    this.unsupported("reference cell allocation");
+  }
+  emitRefCellGet(_layout: IrRefCellLowering, _out: PorfforSink): void {
+    this.unsupported("reference cell read");
+  }
+  emitRefCellSet(_layout: IrRefCellLowering, _out: PorfforSink): void {
+    this.unsupported("reference cell write");
+  }
+
+  private unsupported(family: string): never {
+    throw new Error(`porffor backend does not support ${family} in the scalar/control-flow slice`);
+  }
+}
+
+function constSlot(instr: Extract<IrInstr, { kind: "const" }>): PorfforValueSlot {
+  switch (instr.value.kind) {
+    case "bool":
+    case "i32":
+      return "i32";
+    case "i64":
+      return "i64";
+    case "f64":
+      return "f64";
+    default:
+      throw new Error(`porffor backend does not support const '${instr.value.kind}'`);
+  }
+}
+
+function convertExpr(type: PorfforValueSlot, value: PorfforExpr, flags: number): PorfforExpr {
+  if (type === value.type) return value;
+  return { kind: "convert", type, effects: value.effects, value, flags };
+}
+
+function binaryOp(op: IrBinop): {
+  readonly op: string;
+  readonly comparison: boolean;
+  readonly operandType?: PorfforValueSlot;
+  readonly unsigned?: boolean;
+} {
+  const comparison = op.includes(".eq") || op.includes(".ne") || /\.(?:lt|le|gt|ge)(?:_[su])?$/.test(op);
+  switch (op) {
+    case "f64.add":
+      return { op: "+", comparison: false, operandType: "f64" };
+    case "f64.sub":
+      return { op: "-", comparison: false, operandType: "f64" };
+    case "f64.mul":
+      return { op: "*", comparison: false, operandType: "f64" };
+    case "f64.div":
+      return { op: "/", comparison: false, operandType: "f64" };
+    case "i32.and":
+      return { op: "&", comparison: false, operandType: "i32" };
+    case "i32.or":
+      return { op: "|", comparison: false, operandType: "i32" };
+    case "f64.eq":
+    case "i32.eq":
+      return { op: "==", comparison, operandType: op.startsWith("f64") ? "f64" : undefined };
+    case "f64.ne":
+    case "i32.ne":
+      return { op: "!=", comparison, operandType: op.startsWith("f64") ? "f64" : undefined };
+    case "f64.lt":
+    case "f64.le":
+    case "f64.gt":
+    case "f64.ge":
+      return { op: relationSymbol(op.slice(4)), comparison, operandType: "f64" };
+    case "i32.lt_s":
+    case "i32.le_s":
+    case "i32.gt_s":
+    case "i32.ge_s":
+      return { op: relationSymbol(op.slice(4, 6)), comparison, operandType: "i32" };
+    case "i32.lt_u":
+    case "i32.le_u":
+    case "i32.gt_u":
+    case "i32.ge_u":
+      return { op: relationSymbol(op.slice(4, 6)), comparison, operandType: "u32", unsigned: true };
+    default:
+      throw new Error(`porffor backend does not support binary op '${op}'`);
+  }
+}
+
+function relationSymbol(op: string): "<" | "<=" | ">" | ">=" {
+  switch (op) {
+    case "lt":
+      return "<";
+    case "le":
+      return "<=";
+    case "gt":
+      return ">";
+    case "ge":
+      return ">=";
+    default:
+      throw new Error(`porffor backend does not support relation '${op}'`);
+  }
+}

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1949,18 +1949,12 @@ export function lowerIrFunctionBody<S, Slot>(
       }
       // Slice 6 (#1169e): slot / vec / for-of ops.
       case "slot.read": {
-        emitter.pushRaw(out, {
-          op: "local.get",
-          index: slotWasmIdx(instr.slotIndex),
-        });
+        emitter.emitLocalGet(slotWasmIdx(instr.slotIndex), out);
         return;
       }
       case "slot.write": {
         emitValue(instr.value, out);
-        emitter.pushRaw(out, {
-          op: "local.set",
-          index: slotWasmIdx(instr.slotIndex),
-        });
+        emitter.emitLocalSet(slotWasmIdx(instr.slotIndex), out);
         return;
       }
       case "vec.len": {
@@ -2767,31 +2761,27 @@ export function lowerIrFunctionBody<S, Slot>(
       // are emitted in place).
       case "while.loop":
       case "for.loop": {
-        // #1584 (a0-tail): out-of-subset (embeds an Instr[] loop body). S = Instr[].
-        const wasmOut = requireInstrSink(out);
-        const loopBody: Instr[] = [];
+        // #3297: generic structured-control-flow path. Nested buffers stay in
+        // the backend's own sink type; no raw Instr[] or Wasm-only eqz push is
+        // required for scalar loops.
+        const loopBody: S = emitter.newSink();
 
         // Helper: emit a body buffer (cond / body / update) into a
-        // target ops array using the standard SSA materialisation
-        // rules (mirrors the `forof.*` body emission). `target` is a local
-        // Instr[] sub-buffer; the arm asserted S = Instr[] so the cast to S
-        // on the recursive emit is sound (#1584 §2a).
-        const emitBodyBuffer = (bodyInstrs: readonly IrInstr[], target: Instr[]): void => {
+        // backend sink using the standard SSA materialisation rules (mirrors
+        // the `forof.*` body emission).
+        const emitBodyBuffer = (bodyInstrs: readonly IrInstr[], target: S): void => {
           for (const bodyInstr of bodyInstrs) {
             if (bodyInstr.result === null) {
-              emitInstrTree(bodyInstr, target as unknown as S);
+              emitInstrTree(bodyInstr, target);
             } else if (crossBlock.has(bodyInstr.result)) {
-              emitInstrTree(bodyInstr, target as unknown as S);
-              target.push({
-                op: "local.set",
-                index: localIdx.get(bodyInstr.result)!,
-              });
+              emitInstrTree(bodyInstr, target);
+              emitter.emitLocalSet(localIdx.get(bodyInstr.result)!, target);
               materialized.add(bodyInstr.result);
             } else if ((totalUses.get(bodyInstr.result) ?? 0) === 0 && isSideEffecting(bodyInstr)) {
               // (#2856) Zero-use side-effecting instr — eager emit + drop,
               // same contract as `emitBlockBody` (see the if-arm variant).
-              emitInstrTree(bodyInstr, target as unknown as S);
-              emitter.emitDrop(target as unknown as S);
+              emitInstrTree(bodyInstr, target);
+              emitter.emitDrop(target);
             }
             // Intra-block multi-use: handled at use site via tee pattern.
           }
@@ -2821,11 +2811,11 @@ export function lowerIrFunctionBody<S, Slot>(
         ctrlStack.push(preTestWhile && label !== undefined ? { kind: "continue", label } : { kind: "plain" });
         const emitLoopBodyStatements = (): void => {
           if (needsContinueBlock) {
-            const bodyOps: Instr[] = [];
+            const bodyOps: S = emitter.newSink();
             ctrlStack.push({ kind: "continue", label: label! });
             emitBodyBuffer(instr.body, bodyOps);
             ctrlStack.pop();
-            emitter.emitBlock({ kind: "empty" }, bodyOps as unknown as S, loopBody as unknown as S);
+            emitter.emitBlock({ kind: "empty" }, bodyOps, loopBody);
           } else {
             emitBodyBuffer(instr.body, loopBody);
           }
@@ -2838,9 +2828,9 @@ export function lowerIrFunctionBody<S, Slot>(
           // 2. Cond instructions (re-evaluated each iteration, after body).
           emitBodyBuffer(instr.cond, loopBody);
           // 3. Push the cond value, invert (i32.eqz), then br_if 1 to exit.
-          emitValue(instr.condValue, loopBody as unknown as S);
-          loopBody.push({ op: "i32.eqz" });
-          emitter.emitBrIf(1, loopBody as unknown as S);
+          emitValue(instr.condValue, loopBody);
+          emitter.emitUnary("i32.eqz", loopBody);
+          emitter.emitBrIf(1, loopBody);
         } else {
           // Pre-test (`while` / `for`): cond first, exit before running body.
           // 1. Cond instructions (re-evaluated each iteration).
@@ -2848,9 +2838,9 @@ export function lowerIrFunctionBody<S, Slot>(
 
           // 2. Push the cond value, invert (i32.eqz), then br_if 1 to exit.
           //    #1584 (a3): the control-flow ops route through the trait.
-          emitValue(instr.condValue, loopBody as unknown as S);
-          loopBody.push({ op: "i32.eqz" });
-          emitter.emitBrIf(1, loopBody as unknown as S);
+          emitValue(instr.condValue, loopBody);
+          emitter.emitUnary("i32.eqz", loopBody);
+          emitter.emitBrIf(1, loopBody);
 
           // 3. Body instructions (for `for`, continue falls to the update).
           emitLoopBodyStatements();
@@ -2862,14 +2852,14 @@ export function lowerIrFunctionBody<S, Slot>(
         }
 
         // 5. Continue back to the loop header.
-        emitter.emitBr(0, loopBody as unknown as S);
+        emitter.emitBr(0, loopBody);
         ctrlStack.pop(); // loop frame
         ctrlStack.pop(); // break frame
 
         // 6. Wrap in `block { loop { ... } }` via the trait (#1584 a3).
-        const loopWrap: Instr[] = [];
-        emitter.emitLoop({ kind: "empty" }, loopBody as unknown as S, loopWrap as unknown as S);
-        emitter.emitBlock({ kind: "empty" }, loopWrap as unknown as S, wasmOut as unknown as S);
+        const loopWrap: S = emitter.newSink();
+        emitter.emitLoop({ kind: "empty" }, loopBody, loopWrap);
+        emitter.emitBlock({ kind: "empty" }, loopWrap, out);
         return;
       }
       // (#1373b Phase C Slice 1) Async / await IR node lowering.

--- a/tests/issue-3288.test.ts
+++ b/tests/issue-3288.test.ts
@@ -188,39 +188,19 @@ describe("#3288 P1 Porffor legality", () => {
     expect(verifyIrBackendLegality(scalar, "porffor")).toEqual([]);
   });
 
-  it.each([
-    [
-      "raw.wasm",
-      {
-        kind: "raw.wasm",
-        ops: [{ op: "i32.const", value: 1 }],
-        stackDelta: 1,
-        result: asValueId(1),
-        resultType: I32,
-      } as IrInstr,
-      /porffor backend does not support IR instruction 'raw\.wasm'/,
-    ],
-    [
-      "slot.read",
-      { kind: "slot.read", slotIndex: 0, result: asValueId(1), resultType: I32 } as IrInstr,
-      /porffor backend does not support IR instruction 'slot\.read'/,
-    ],
-    [
-      "Instr-array loop",
-      {
-        kind: "while.loop",
-        cond: [],
-        condValue: asValueId(0),
-        body: [],
-        result: null,
-        resultType: null,
-      } as IrInstr,
-      /porffor backend does not support IR instruction 'while\.loop'/,
-    ],
-  ])("rejects the %s escape family before emission", (_label, instr, expected) => {
+  it("keeps rejecting the raw Wasm escape family before emission", () => {
+    const instr: IrInstr = {
+      kind: "raw.wasm",
+      ops: [{ op: "i32.const", value: 1 }],
+      stackDelta: 1,
+      result: asValueId(1),
+      resultType: I32,
+    };
     const fn = oneBlock("unsupported", [instr], []);
     const errors = verifyIrBackendLegality(fn, "porffor");
-    expect(errors.some((error) => expected.test(error.message))).toBe(true);
+    expect(
+      errors.some((error) => /porffor backend does not support IR instruction 'raw\.wasm'/.test(error.message)),
+    ).toBe(true);
     expect(() => lowerIrFunctionBody(fn, resolver(), new StubEmitter("porffor"), new PorfforTypeConverter())).toThrow(
       /porffor backend legality failed/,
     );

--- a/tests/issue-3297.test.ts
+++ b/tests/issue-3297.test.ts
@@ -1,0 +1,357 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+
+import { analyzeSource } from "../src/checker/index.js";
+import { compile } from "../src/index.js";
+import {
+  IrFunctionBuilder,
+  irVal,
+  lowerFunctionAstToIr,
+  verifyIrBackendLegality,
+  type IrFunction,
+  type IrModule,
+  type IrObjectShape,
+} from "../src/ir/index.js";
+import { PORFFOR_KIND_NAMES, porfforRendererOutputText, type PorfforNode } from "../src/ir/backend/porffor/compat.js";
+import { lowerIrModuleToPorffor } from "../src/ir/backend/porffor/integration.js";
+import { loadOptionalPorffor } from "../src/ir/backend/porffor/loader.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const porfforRoot = process.env.JS2WASM_PORFFOR_ROOT ?? join(here, "../vendor/Porffor");
+const hasOptionalPorffor = existsSync(join(porfforRoot, "compiler/ir.js"));
+const F64 = irVal({ kind: "f64" });
+const I32 = irVal({ kind: "i32" });
+
+const DIFF_SOURCE = `
+  let trace = 0;
+  function left(): number { trace = 1; return 10; }
+  function right(): number { trace = trace * 10 + 2; return 3; }
+  export function ordered(): number { trace = 0; return (left() + right()) * 100 + trace; }
+  function twice(x: number): number { return x * 2; }
+  export function directArgs(): number { return twice(6) + twice(7); }
+
+  export function loopSum(): number {
+    let n = 5;
+    let total = 0;
+    while (n > 0) {
+      total = total + n;
+      n = n - 1;
+    }
+    return total;
+  }
+
+  export function classify(x: number): number {
+    if (x > 0) return 1;
+    if (x < 0) return -1;
+    return 0;
+  }
+
+  export function forSum(): number {
+    let total = 0;
+    for (let i = 0; i < 5; i = i + 1) total = total + i;
+    return total;
+  }
+`;
+
+function effectFunctions(): IrFunction[] {
+  const global = { kind: "global" as const, name: "trace" };
+
+  const left = new IrFunctionBuilder("left", [F64]);
+  left.openBlock();
+  const one = left.emitConst({ kind: "f64", value: 1 }, F64);
+  left.emitGlobalSet(global, one);
+  const ten = left.emitConst({ kind: "f64", value: 10 }, F64);
+  left.terminate({ kind: "return", values: [ten] });
+
+  const right = new IrFunctionBuilder("right", [F64]);
+  right.openBlock();
+  const oldTrace = right.emitGlobalGet(global, F64);
+  const scale = right.emitConst({ kind: "f64", value: 10 }, F64);
+  const shifted = right.emitBinary("f64.mul", oldTrace, scale, F64);
+  const two = right.emitConst({ kind: "f64", value: 2 }, F64);
+  const nextTrace = right.emitBinary("f64.add", shifted, two, F64);
+  right.emitGlobalSet(global, nextTrace);
+  const three = right.emitConst({ kind: "f64", value: 3 }, F64);
+  right.terminate({ kind: "return", values: [three] });
+
+  const ordered = new IrFunctionBuilder("ordered", [F64], true);
+  ordered.openBlock();
+  const zero = ordered.emitConst({ kind: "f64", value: 0 }, F64);
+  ordered.emitGlobalSet(global, zero);
+  const leftResult = ordered.emitCall({ kind: "func", name: "left" }, [], F64)!;
+  const rightResult = ordered.emitCall({ kind: "func", name: "right" }, [], F64)!;
+  const sum = ordered.emitBinary("f64.add", leftResult, rightResult, F64);
+  const hundred = ordered.emitConst({ kind: "f64", value: 100 }, F64);
+  const weighted = ordered.emitBinary("f64.mul", sum, hundred, F64);
+  const finalTrace = ordered.emitGlobalGet(global, F64);
+  const result = ordered.emitBinary("f64.add", weighted, finalTrace, F64);
+  ordered.terminate({ kind: "return", values: [result] });
+
+  const twice = new IrFunctionBuilder("twice", [F64]);
+  const input = twice.addParam("x", F64);
+  twice.openBlock();
+  const multiplier = twice.emitConst({ kind: "f64", value: 2 }, F64);
+  const doubled = twice.emitBinary("f64.mul", input, multiplier, F64);
+  twice.terminate({ kind: "return", values: [doubled] });
+
+  const directArgs = new IrFunctionBuilder("directArgs", [F64], true);
+  directArgs.openBlock();
+  const six = directArgs.emitConst({ kind: "f64", value: 6 }, F64);
+  const seven = directArgs.emitConst({ kind: "f64", value: 7 }, F64);
+  const twelve = directArgs.emitCall({ kind: "func", name: "twice" }, [six], F64)!;
+  const fourteen = directArgs.emitCall({ kind: "func", name: "twice" }, [seven], F64)!;
+  const twentySix = directArgs.emitBinary("f64.add", twelve, fourteen, F64);
+  directArgs.terminate({ kind: "return", values: [twentySix] });
+
+  return [left.finish(), right.finish(), ordered.finish(), twice.finish(), directArgs.finish()];
+}
+
+function frontendFunction(source: string, name: string): IrFunction {
+  const ast = analyzeSource(source);
+  const declaration = ast.sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+  );
+  if (!declaration) throw new Error(`missing function ${name}`);
+  return lowerFunctionAstToIr(declaration, { exported: true }).main;
+}
+
+function selectAndConvertFunction(): IrFunction {
+  const builder = new IrFunctionBuilder("selectConvert", [F64], true);
+  const condition = builder.addParam("condition", I32);
+  const value = builder.addParam("value", I32);
+  builder.openBlock();
+  const converted = builder.emitUnary("f64.convert_i32_s", value, F64);
+  const fallback = builder.emitConst({ kind: "f64", value: 20 }, F64);
+  const selected = builder.emitSelect(condition, converted, fallback, F64);
+  builder.terminate({ kind: "return", values: [selected] });
+  return builder.finish();
+}
+
+function unreachableFunction(): IrFunction {
+  const builder = new IrFunctionBuilder("never", []);
+  builder.openBlock();
+  builder.terminate({ kind: "unreachable" });
+  return builder.finish();
+}
+
+function proofModule(order: "normal" | "shuffled" = "normal"): IrModule {
+  const [left, right, ordered, twice, directArgs] = effectFunctions();
+  const loop = frontendFunction(DIFF_SOURCE, "loopSum");
+  const classify = frontendFunction(DIFF_SOURCE, "classify");
+  const forLoop = frontendFunction(DIFF_SOURCE, "forSum");
+  const select = selectAndConvertFunction();
+  const never = unreachableFunction();
+  const functions =
+    order === "normal"
+      ? [left!, right!, ordered!, twice!, directArgs!, loop, forLoop, classify, select, never]
+      : [select, classify, ordered!, forLoop, never, right!, directArgs!, loop, left!, twice!];
+  return { functions };
+}
+function lowerProof(order: "normal" | "shuffled" = "normal") {
+  return lowerIrModuleToPorffor(proofModule(order), {
+    globals:
+      order === "normal"
+        ? [
+            { name: "trace", type: F64 },
+            { name: "spare", type: I32 },
+          ]
+        : [
+            { name: "spare", type: I32 },
+            { name: "trace", type: F64 },
+          ],
+    prefs: { gc: false },
+  });
+}
+
+function collectNodes(value: unknown, out: PorfforNode[] = []): PorfforNode[] {
+  if (!Array.isArray(value)) return out;
+  if (value.length === 6 && typeof value[0] === "number" && PORFFOR_KIND_NAMES[value[0]]) {
+    const node = value as unknown as PorfforNode;
+    out.push(node);
+    collectNodes(node[3], out);
+    collectNodes(node[4], out);
+    collectNodes(node[5], out);
+    return out;
+  }
+  for (const item of value) collectNodes(item, out);
+  return out;
+}
+
+function nodeName(node: PorfforNode): string {
+  return PORFFOR_KIND_NAMES[node[0]]!;
+}
+
+describe("#3297 Porffor scalar/control-flow sink", () => {
+  it("maps the scalar/control-flow family and retains Porffor FX on direct calls", () => {
+    const input = lowerProof();
+    const nodes = input.funcs.flatMap((func) => collectNodes(func?.body ?? []));
+    const kinds = new Set(nodes.map(nodeName));
+
+    for (const expected of [
+      "Const",
+      "Local",
+      "Global",
+      "Assign",
+      "Bin",
+      "Un",
+      "Select",
+      "Convert",
+      "If",
+      "Loop",
+      "Break",
+      "Continue",
+      "Block",
+      "Return",
+      "Unreachable",
+      "Call",
+    ]) {
+      expect(kinds, `missing Porffor ${expected} mapping`).toContain(expected);
+    }
+
+    const ordered = input.funcs.find((func) => func?.name === "ordered")!;
+    const calls = collectNodes(ordered.body).filter((node) => nodeName(node) === "Call");
+    expect(calls.map((call) => call[3])).toEqual(["left", "right"]);
+    expect(calls.every((call) => (call[2] & 4) !== 0)).toBe(true);
+  });
+
+  it("assigns final function positions by stable name, independent of registration order", () => {
+    expect(lowerProof("shuffled")).toStrictEqual(lowerProof("normal"));
+    expect(lowerProof().funcs.map((func) => func?.name)).toEqual([
+      "classify",
+      "directArgs",
+      "forSum",
+      "left",
+      "loopSum",
+      "never",
+      "ordered",
+      "right",
+      "selectConvert",
+      "twice",
+    ]);
+    expect(lowerProof().globals.map((global) => global.name)).toEqual(["spare", "trace"]);
+  });
+
+  it("rejects heap/reference IR through legality before sink emission", () => {
+    const shape: IrObjectShape = { fields: [{ name: "value", type: F64 }] };
+    const builder = new IrFunctionBuilder("heapRejected", [{ kind: "object", shape }]);
+    builder.openBlock();
+    const value = builder.emitConst({ kind: "f64", value: 1 }, F64);
+    const object = builder.emitObjectNew(shape, [value]);
+    builder.terminate({ kind: "return", values: [object] });
+    const func = builder.finish();
+
+    expect(
+      verifyIrBackendLegality(func, "porffor")
+        .map((error) => error.message)
+        .join("\n"),
+    ).toMatch(/porffor backend does not support (?:IR type 'object'|IR instruction 'object\.new')/);
+    expect(() => lowerIrModuleToPorffor({ functions: [func] })).toThrow(/porffor backend legality failed/);
+  });
+});
+
+describe("#3297 JavaScript / linear-Wasm / Porffor-C differential", () => {
+  const optionalIt = hasOptionalPorffor && findCCompiler() ? it : it.skip;
+
+  optionalIt(
+    "preserves scalar results and left-to-right call effects in rendered C",
+    async () => {
+      const jsSource = ts.transpileModule(DIFF_SOURCE.replace(/\bexport\s+/g, ""), {
+        compilerOptions: { module: ts.ModuleKind.None, target: ts.ScriptTarget.ES2022 },
+      }).outputText;
+      const js = new Function(`${jsSource}\nreturn { ordered, directArgs, loopSum, forSum, classify };`)() as Record<
+        string,
+        (...args: number[]) => number
+      >;
+      const expected = [js.ordered!(), js.directArgs!(), js.loopSum!(), js.forSum!(), js.classify!(-4)];
+
+      const linear = await compile(DIFF_SOURCE, { target: "linear", experimentalIR: true });
+      expect(linear.success, linear.errors.map((error) => error.message).join("\n")).toBe(true);
+      const { instance } = await WebAssembly.instantiate(linear.binary);
+      const exports = instance.exports as Record<string, (...args: number[]) => number>;
+      const linearValues = [
+        exports.ordered!(),
+        exports.directArgs!(),
+        exports.loopSum!(),
+        exports.forSum!(),
+        exports.classify!(-4),
+      ];
+
+      const input = lowerProof();
+      const porffor = await loadOptionalPorffor({ root: porfforRoot });
+      const rendered = porfforRendererOutputText(porffor.render(input));
+      const porfforValues = compileAndRunC(rendered, input.funcs, [
+        { name: "ordered", args: [] },
+        { name: "directArgs", args: [] },
+        { name: "loopSum", args: [] },
+        { name: "forSum", args: [] },
+        { name: "classify", args: [-4] },
+      ]);
+
+      expect(expected).toEqual([1312, 26, 15, 10, -1]);
+      expect(linearValues).toStrictEqual(expected);
+      expect(porfforValues).toStrictEqual(expected);
+    },
+    60_000,
+  );
+});
+
+function findCCompiler(): string | null {
+  const candidates = [process.env.CC, "cc", "clang", "gcc"].filter((candidate): candidate is string => !!candidate);
+  for (const candidate of candidates) {
+    const result = spawnSync(candidate, ["--version"], { stdio: "ignore" });
+    if (result.status === 0) return candidate;
+  }
+  return null;
+}
+
+function compileAndRunC(
+  rendered: string,
+  funcs: readonly ({ readonly name: string; readonly index: number } | null | undefined)[],
+  calls: readonly { readonly name: string; readonly args: readonly number[] }[],
+): number[] {
+  const compiler = findCCompiler();
+  if (!compiler) throw new Error("no C compiler available");
+  const symbols = new Map(
+    funcs.filter((func): func is NonNullable<typeof func> => !!func).map((func) => [func.name, func]),
+  );
+  const invocationLines = calls.map((call) => {
+    const func = symbols.get(call.name);
+    if (!func) throw new Error(`missing Porffor function ${call.name}`);
+    const args = call.args.map((arg) => (Number.isInteger(arg) ? `${arg}.0` : String(arg))).join(", ");
+    return `  printf("%.17g\\n", p${func.index}_${func.name}(${args}));`;
+  });
+  const harness = `
+int main(int argc, char** argv) {
+  porf_init(argc, argv);
+  porf_data_init();
+${invocationLines.join("\n")}
+  return 0;
+}
+`;
+
+  const directory = mkdtempSync(join(tmpdir(), "js2-porffor-3297-"));
+  const sourcePath = join(directory, "proof.c");
+  const binaryPath = join(directory, "proof");
+  try {
+    writeFileSync(sourcePath, rendered + harness);
+    const compileResult = spawnSync(
+      compiler,
+      ["-std=gnu11", "-Werror", "-Wno-unused-function", sourcePath, "-lm", "-o", binaryPath],
+      { encoding: "utf8" },
+    );
+    expect(compileResult.status, `C compiler failed:\n${compileResult.stdout}\n${compileResult.stderr}`).toBe(0);
+    const stdout = execFileSync(binaryPath, { encoding: "utf8" });
+    return stdout.trim().split("\n").map(Number);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- lower the scalar and structured control-flow SSA subset through the shared five-part backend contract
- preserve left-to-right effects in a symbolic Porffor sink and assign renderer positions only during deterministic final assembly
- reject heap/reference IR through legality and prove JavaScript, linear-Wasm, and rendered Porffor-C results agree

## Validation

- `pnpm exec vitest run tests/issue-3297.test.ts tests/issue-3288.test.ts tests/issue-3295-porffor-compat.test.ts tests/backend-contract.test.ts tests/issue-2952.test.ts tests/issue-1982-ir-emission-order.test.ts --reporter=dot` (44 tests)
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run check:pushraw`
- `pnpm run check:loc-budget`
- `pnpm run check:issue-spec-coverage`

Closes #3297