### PR TITLE
feat(linear-ir): lower aggregate and ref-cell layouts

### DIFF
--- a/plan/issues/2956-linear-backend-consumes-ir.md
+++ b/plan/issues/2956-linear-backend-consumes-ir.md
@@ -25,7 +25,7 @@ loc-budget-allow:
   - src/codegen-linear/index.ts
 claimed_by: porffor-codex-developer
 claimed_at: 2026-07-17T05:03:10.509Z
-pr: null
+pr: 3200
 last_merged_pr: 3179
 ---
 

--- a/plan/issues/2956-linear-backend-consumes-ir.md
+++ b/plan/issues/2956-linear-backend-consumes-ir.md
@@ -6,7 +6,7 @@ sprint: current
 created: 2026-07-02
 updated: 2026-07-17
 assignee: ttraenkler/fable-epsilon
-branch: issue-2956-linear-ir-consume
+branch: symphony/porffor/2956-after-pr-3179
 priority: medium
 horizon: xl
 feasibility: hard
@@ -23,6 +23,10 @@ loc-budget-allow:
   - src/ir/from-ast.ts
   - src/codegen-linear/runtime.ts
   - src/codegen-linear/index.ts
+claimed_by: porffor-codex-developer
+claimed_at: 2026-07-17T05:03:10.509Z
+pr: null
+last_merged_pr: 3179
 ---
 
 # #2956 — the backend fork sits ABOVE the IR
@@ -315,3 +319,43 @@ the divergence with #3332-referencing assertions instead of masking it.
 
 **Remaining after this sub-slice**: refcells + aggregates via `layout.ts`
 (the L2 remainder), L3 strings (after #2955), L4 default-ON flip.
+
+## Execution status — L2 aggregate/ref-cell sub-slice implemented (2026-07-17, porffor-codex-developer)
+
+Selector-claimed numeric objects now lower through the flag-gated linear-IR
+overlay as i32 arena pointers. The resolver computes field offsets with the
+direct backend's `computeClassLayout`, and `LinearEmitter` realizes
+`object.new/get/set` plus primitive `refcell.new/get/set` as allocation calls
+and typed linear-memory loads/stores.
+
+- Aggregate constructors are deferred defined functions with signatures
+  `(field0, ...fieldN) -> i32`. They are discovered lazily but appended only
+  after every pre-assigned class/top-level function slot; the assembler checks
+  the predicted absolute index before insertion. This preserves the #2710
+  name/slot discipline and avoids a scratch-local change to the frozen emitter
+  contract.
+- Layout handles carry only target-neutral memory facts (field offset + Wasm
+  scalar type). Numeric (`f64`), boolean/pointer (`i32`), and nested-object
+  fields are admitted; other field carriers fail the linear legality gate and
+  demote before lowering.
+- The linear TypeConverter now maps object and primitive boxed/refcell IR types
+  to their i32 pointer carrier. WasmGC and bytecode conversion paths are
+  unchanged.
+- Primitive refcell allocation/get/set is wired and emitter-tested. No closure
+  promise is added: the selector does not claim closure/nested-function shapes
+  on linear today, and lifted closure slots/`call_ref` remain explicitly
+  deferred as the architect spec requires.
+- Focused coverage proves direct-path parity for numeric/boolean/nested reads,
+  mutation + strict aliasing, deferred helper index stability, and flag-off
+  SHA-256 byte identity. The overlay additionally compiles anonymous-object
+  mutation that the direct linear path currently rejects.
+
+Validation: `tests/issue-2956.test.ts` 15/15; `tests/issue-1850.test.ts`
+11/11; complete linear + cross-backend + IR proof matrix 184/184; typecheck
+clean; `check:ir-fallbacks`, `check:loc-budget`, and `check:oracle-ratchet`
+clean. Linear-IR ratchet remains `compiled=6`, `build=4` because the fixed
+playground corpus has no aggregate/refcell row, so
+`scripts/linear-ir-baseline.json` is intentionally unchanged.
+
+**Remaining after L2:** L3 strings (after #2955) and L4 default-ON + direct
+reject-list folding. The issue remains `in-progress` for those later slices.

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -211,6 +211,19 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
     compileFunction(ctx, decl);
   }
 
+  // Aggregate/ref-cell allocation helpers are deliberately appended after
+  // every pre-assigned user slot. This keeps funcMap indices stable while IR
+  // lowering discovers object shapes lazily.
+  for (const helper of linearIr?.helpers ?? []) {
+    const actualFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    if (actualFuncIdx !== helper.funcIdx) {
+      throw new Error(
+        `linear-ir: deferred helper slot mismatch for '${helper.func.name}' (expected ${helper.funcIdx}, got ${actualFuncIdx})`,
+      );
+    }
+    ctx.mod.functions.push(helper.func);
+  }
+
   // ── Emit data segments for string literals ──
   if (ctx.stringLiterals.size > 0) {
     const totalSize = ctx.dataSegmentOffset - DATA_SEGMENT_BASE;

--- a/src/codegen-linear/layout.ts
+++ b/src/codegen-linear/layout.ts
@@ -26,6 +26,11 @@ export interface ClassLayout {
   ctorFuncName: string;
 }
 
+/** Canonical header/slot constants shared by classes, object literals, and IR aggregates. */
+export const LINEAR_AGGREGATE_HEADER_SIZE = 8;
+export const LINEAR_AGGREGATE_FIELD_SIZE = 8;
+export const LINEAR_GENERIC_OBJECT_TAG = 0x10;
+
 /**
  * Compute the memory layout for a class with the given fields.
  *
@@ -34,14 +39,11 @@ export interface ClassLayout {
  * @returns The computed ClassLayout
  */
 export function computeClassLayout(name: string, fieldDefs: { name: string; type: "i32" | "f64" }[]): ClassLayout {
-  const HEADER_SIZE = 8; // tag (1) + padding (3) + payload_size (4)
-  const FIELD_SIZE = 8; // each field gets 8 bytes for uniform access
-
   const fields = new Map<string, { offset: number; type: "i32" | "f64" }>();
-  let offset = HEADER_SIZE;
+  let offset = LINEAR_AGGREGATE_HEADER_SIZE;
   for (const f of fieldDefs) {
     fields.set(f.name, { offset, type: f.type });
-    offset += FIELD_SIZE;
+    offset += LINEAR_AGGREGATE_FIELD_SIZE;
   }
 
   return {

--- a/src/ir/backend/contract.ts
+++ b/src/ir/backend/contract.ts
@@ -84,6 +84,9 @@ export type {
   IrRefCellLowering,
   IrUnionLowering,
   IrVecLowering,
+  LinearMemoryFieldLowering,
+  LinearObjectLowering,
+  LinearRefCellLowering,
   LinearVecLowering,
 } from "./handles.js";
 

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -13,9 +13,9 @@
 // for backwards compatibility, so existing `import { IrVecLowering } from
 // "./lower.js"` sites keep working.
 //
-// Phase 1 (#1713) keeps every handle WasmGC-typed (they expose `typeIdx` /
-// `fieldIdx`). A second backend (#1714 linear, #1715 bytecode) introduces
-// parallel handle shapes and parameterises the emitter over them -- see the
+// Phase 1 (#1713) began with WasmGC-typed handles (`typeIdx` / `fieldIdx`).
+// Second backends (#1714 linear, #1715 bytecode) add parallel handle metadata
+// and parameterise the emitter over it -- see the
 // `## Implementation Plan` section 7 in
 // `plan/issues/1713-ir-backend-emitter-trait-seam.md` for that design step.
 // Nothing here changes for Phase 1.
@@ -66,6 +66,31 @@ export interface IrObjectStructLowering {
 }
 
 /**
+ * Linear-memory field metadata carried by the aggregate/ref-cell handles.
+ * Offsets follow `src/codegen-linear/layout.ts`; the IR layer deliberately
+ * sees only the backend-neutral memory facts needed by `LinearEmitter`.
+ */
+export interface LinearMemoryFieldLowering {
+  readonly offset: number;
+  readonly type: ValType;
+}
+
+/**
+ * Linear-memory analogue of an object struct handle. `typeIdx`/`fieldIdx`
+ * remain present because `IrLowerResolver` predates parallel layout handles;
+ * the linear emitter consumes this additive metadata and never interprets
+ * the sentinel type index as a WasmGC type.
+ */
+export interface LinearObjectLowering extends IrObjectStructLowering {
+  readonly linearMemory: {
+    /** Deferred helper `(field0, ...fieldN) -> i32` appended after user slots. */
+    readonly newFuncIdx: number;
+    readonly fieldCount: number;
+    field(name: string): LinearMemoryFieldLowering;
+  };
+}
+
+/**
  * Slice 3 (#1169c): WasmGC type info for a closure value. Two structs
  * are involved per closure construction site:
  *   - The SUPERTYPE struct (`structTypeIdx`): contains only the funcref
@@ -95,6 +120,15 @@ export interface IrClosureLowering {
 export interface IrRefCellLowering {
   readonly typeIdx: number;
   readonly fieldIdx: number;
+}
+
+/** Linear-memory analogue of the one-field mutable ref-cell struct. */
+export interface LinearRefCellLowering extends IrRefCellLowering {
+  readonly linearMemory: {
+    /** Deferred helper `(value) -> i32` appended after user slots. */
+    readonly newFuncIdx: number;
+    readonly value: LinearMemoryFieldLowering;
+  };
 }
 
 /**

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -83,8 +83,8 @@ function checkInstr(
 // CORE-OP families (const / arithmetic / locals-as-slots / structured control
 // flow / direct call). These lower to core Wasm and `LinearEmitter` emits them
 // byte-identically to `WasmGcEmitter`. The representation-DIVERGENT families
-// (objects, closures, boxing, strings, ref-cells, exceptions, non-fixed vec
-// mutation/iteration, promises) stay rejected here — the linear analogue lands
+// (closures, dynamic boxing, strings, exceptions, non-fixed vec
+// iteration, promises) stay rejected here — the linear analogue lands
 // with the production wiring (#2956). This mirrors `bytecodeInstrError`'s
 // allow-list shape; the operand-type gate (`linearValTypeError`) independently
 // rejects any non-{i32,i64,f32,f64} value, so allowing an op kind here never
@@ -108,6 +108,14 @@ function linearInstrError(instr: IrInstr): string | null {
     case "select":
     case "if":
     case "call":
+    // #2956 L2: aggregates and primitive ref-cells use i32 arena pointers,
+    // with field access emitted as typed linear-memory loads/stores.
+    case "object.new":
+    case "object.get":
+    case "object.set":
+    case "refcell.new":
+    case "refcell.get":
+    case "refcell.set":
     case "global.get":
     case "global.set":
     case "slot.read":
@@ -225,6 +233,13 @@ function porfforInstrError(instr: IrInstr): string | null {
 function backendTypeError(backend: IrBackendKind, type: IrType): string | null {
   if (backend === "wasmgc") return null;
   if (backend === "linear") {
+    if (type.kind === "object") return linearAggregateTypeError(type);
+    if (type.kind === "boxed") {
+      const inner = asVal(type.inner);
+      return inner && (inner.kind === "i32" || inner.kind === "f64")
+        ? null
+        : `${backend} backend does not support boxed IR type '${type.inner.kind}'`;
+    }
     const v = asVal(type);
     if (!v) return `${backend} backend does not support IR type '${type.kind}'`;
     return linearValTypeError(v);
@@ -238,6 +253,28 @@ function backendTypeError(backend: IrBackendKind, type: IrType): string | null {
   const v = asVal(type);
   if (!v) return `porffor backend does not support IR type '${type.kind}'`;
   return porfforValTypeError(v);
+}
+
+function linearAggregateTypeError(type: Extract<IrType, { kind: "object" }>): string | null {
+  for (const field of type.shape.fields) {
+    if (field.type.kind === "val") {
+      if (field.type.val.kind !== "i32" && field.type.val.kind !== "f64") {
+        return `linear backend does not support aggregate field ValType '${field.type.val.kind}'`;
+      }
+      continue;
+    }
+    if (field.type.kind === "object") {
+      const nested = linearAggregateTypeError(field.type);
+      if (nested) return nested;
+      continue;
+    }
+    if (field.type.kind === "boxed") {
+      const inner = asVal(field.type.inner);
+      if (inner && (inner.kind === "i32" || inner.kind === "f64")) continue;
+    }
+    return `linear backend does not support aggregate field IR type '${field.type.kind}'`;
+  }
+  return null;
 }
 
 function checkValType(

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -16,9 +16,6 @@
 //
 // What REMAINS `notImplemented` on LinearEmitter is only the genuinely
 // representation-divergent families, each annotated with the covering issue:
-//   - aggregates (emitAggregateNew/emitFieldGet/emitFieldSet) — WasmGC
-//     `struct.*`; linear lowers objects to a memory layout (#2956)
-//   - ref-cells (emitRefCellNew/Get/Set) — 1-field mutable struct (#2953)
 //   - exceptions (emitThrow/emitRethrow/emitTry) — WasmGC EH; linear has no
 //     exception lowering yet (#2956)
 //   - typed-funcref call (emitCallRef) — `call_ref` over a reference-typed
@@ -54,7 +51,15 @@ import { emitConstInstr } from "../lower.js";
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr, ValType } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
-import type { LinearVecLowering } from "./handles.js";
+import type {
+  IrClassLowering,
+  IrObjectStructLowering,
+  IrRefCellLowering,
+  LinearMemoryFieldLowering,
+  LinearObjectLowering,
+  LinearRefCellLowering,
+  LinearVecLowering,
+} from "./handles.js";
 
 /** Byte offset of the `len:u32` field in the linear array header. */
 const LINEAR_ARRAY_LEN_OFFSET = 8;
@@ -97,6 +102,45 @@ function linearLoadOp(elem: ValType): Instr["op"] {
       // occur for the #1714 number-array proof; widen here when a backend needs it.)
       return "i32.load";
   }
+}
+
+function linearStoreOp(field: LinearMemoryFieldLowering): "i32.store" | "f64.store" {
+  switch (field.type.kind) {
+    case "i32":
+      return "i32.store";
+    case "f64":
+      return "f64.store";
+    default:
+      throw new Error(`LinearEmitter: unsupported linear-memory field type '${field.type.kind}'`);
+  }
+}
+
+function emitLinearFieldGet(field: LinearMemoryFieldLowering, out: Instr[]): void {
+  const op = field.type.kind === "i32" ? "i32.load" : field.type.kind === "f64" ? "f64.load" : undefined;
+  if (!op) throw new Error(`LinearEmitter: unsupported linear-memory field type '${field.type.kind}'`);
+  out.push({ op, align: field.type.kind === "f64" ? 3 : 2, offset: field.offset });
+}
+
+function emitLinearFieldSet(field: LinearMemoryFieldLowering, out: Instr[]): void {
+  out.push({
+    op: linearStoreOp(field),
+    align: field.type.kind === "f64" ? 3 : 2,
+    offset: field.offset,
+  });
+}
+
+function asLinearObject(layout: IrObjectStructLowering | IrClassLowering): LinearObjectLowering {
+  if (!("linearMemory" in layout)) {
+    throw new Error("LinearEmitter: aggregate layout is not a linear-memory object handle");
+  }
+  return layout as LinearObjectLowering;
+}
+
+function asLinearRefCell(layout: IrRefCellLowering): LinearRefCellLowering {
+  if (!("linearMemory" in layout)) {
+    throw new Error("LinearEmitter: ref-cell layout is not a linear-memory handle");
+  }
+  return layout as LinearRefCellLowering;
 }
 
 function notImplemented(method: string): never {
@@ -354,16 +398,21 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     notImplemented("emitCaptureGet");
   }
 
-  // struct/object family — WasmGC `struct.new`/`struct.get`/`struct.set`; the
-  // linear backend lowers objects to a bump-allocated memory layout (#2956).
-  emitAggregateNew(): void {
-    notImplemented("emitAggregateNew");
+  // struct/object family — the resolver computes offsets through the direct
+  // backend's layout.ts and supplies a deferred allocation helper. The helper
+  // consumes fields in canonical order and leaves the arena pointer (i32).
+  emitAggregateNew(layout: IrObjectStructLowering, fieldCount: number, out: Instr[]): void {
+    const linear = asLinearObject(layout).linearMemory;
+    if (fieldCount !== linear.fieldCount) {
+      throw new Error(`LinearEmitter: aggregate arity mismatch (expected ${linear.fieldCount}, got ${fieldCount})`);
+    }
+    out.push({ op: "call", funcIdx: linear.newFuncIdx });
   }
-  emitFieldGet(): void {
-    notImplemented("emitFieldGet");
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
+    emitLinearFieldGet(asLinearObject(layout).linearMemory.field(name), out);
   }
-  emitFieldSet(): void {
-    notImplemented("emitFieldSet");
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: Instr[]): void {
+    emitLinearFieldSet(asLinearObject(layout).linearMemory.field(name), out);
   }
 
   // try-throw family — WasmGC exception handling (`throw`/`try`/`rethrow`); the
@@ -378,15 +427,15 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     notImplemented("emitTry");
   }
 
-  // ref-cell family — a 1-field mutable struct (`struct.new`/`get`/`set`),
-  // structurally the same as the object family; wires with it (#2953/#2956).
-  emitRefCellNew(): void {
-    notImplemented("emitRefCellNew");
+  // ref-cell family — the same header + 8-byte field layout as a one-field
+  // aggregate, with an i32 arena pointer as its value representation.
+  emitRefCellNew(layout: IrRefCellLowering, out: Instr[]): void {
+    out.push({ op: "call", funcIdx: asLinearRefCell(layout).linearMemory.newFuncIdx });
   }
-  emitRefCellGet(): void {
-    notImplemented("emitRefCellGet");
+  emitRefCellGet(layout: IrRefCellLowering, out: Instr[]): void {
+    emitLinearFieldGet(asLinearRefCell(layout).linearMemory.value, out);
   }
-  emitRefCellSet(): void {
-    notImplemented("emitRefCellSet");
+  emitRefCellSet(layout: IrRefCellLowering, out: Instr[]): void {
+    emitLinearFieldSet(asLinearRefCell(layout).linearMemory.value, out);
   }
 }

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -32,23 +32,36 @@
 // Recorded in plan/issues/2956 §"Execution status".
 //
 // RESOLVER SCOPE: L1 supplies the four required name/table methods. L2 adds
-// only the fixed-number-vec hooks: from-ast types the value as the linear
-// backend's i32 arena pointer, while lower/emitter consume the existing vec
-// layout contract. Union/boxed/object/closure/refcell/class/string hooks stay
-// absent and therefore demote through the same legality/build channel.
+// fixed-number vecs plus numeric object/ref-cell layouts: from-ast types each
+// reference-shaped value as the linear backend's i32 arena pointer, while the
+// emitter consumes offsets computed through codegen-linear/layout.ts. Union,
+// dynamic boxing, closure/class/string hooks stay absent and therefore demote
+// through the same legality/build channel.
 
 import { ts } from "../../ts-api.js";
 import type { LinearContext } from "../../codegen-linear/context.js";
+import {
+  computeClassLayout,
+  LINEAR_AGGREGATE_HEADER_SIZE,
+  LINEAR_GENERIC_OBJECT_TAG,
+} from "../../codegen-linear/layout.js";
 import { LINEAR_IR_VEC_INIT_F64_FN } from "../../codegen-linear/runtime.js";
 import { lowerFunctionAstToIr, type IrFromAstResolver, typeNodeToIr } from "../from-ast.js";
-import { lowerIrFunctionBody, type IrLowerResolver, wasmValueTypeConverter } from "../lower.js";
-import type { IrFuncRef, IrGlobalRef, IrType, IrTypeRef } from "../nodes.js";
+import { lowerIrFunctionBody, type IrLowerResolver } from "../lower.js";
+import { asVal, type IrFuncRef, type IrGlobalRef, type IrObjectShape, type IrType, type IrTypeRef } from "../nodes.js";
 import { planIrCompilation } from "../select.js";
-import type { FuncTypeDef, ValType, WasmFunction } from "../types.js";
+import type { FuncTypeDef, Instr, ValType, WasmFunction } from "../types.js";
 import { verifyIrFunction } from "../verify.js";
+import type { TypeConverter } from "./contract.js";
 import { verifyIrBackendLegality } from "./legality.js";
 import { LinearEmitter } from "./linear-emitter.js";
-import type { IrVecLowering } from "./handles.js";
+import type {
+  IrRefCellLowering,
+  IrVecLowering,
+  LinearMemoryFieldLowering,
+  LinearObjectLowering,
+  LinearRefCellLowering,
+} from "./handles.js";
 
 /** One demoted claim: which function, and the bucketed reason. */
 export interface LinearIrRejection {
@@ -64,6 +77,13 @@ export interface LinearIrResult {
   readonly funcs: Map<string, WasmFunction>;
   readonly compiled: readonly string[];
   readonly rejected: readonly LinearIrRejection[];
+  /** Deferred helpers appended only after every pre-assigned user slot. */
+  readonly helpers: readonly LinearIrHelper[];
+}
+
+export interface LinearIrHelper {
+  readonly funcIdx: number;
+  readonly func: WasmFunction;
 }
 
 /** Slice-L1 gate: the overlay runs only under `JS2WASM_LINEAR_IR=1`. */
@@ -90,13 +110,14 @@ export function compileLinearIrFunctions(ctx: LinearContext, sourceFile: ts.Sour
   const funcs = new Map<string, WasmFunction>();
   const compiled: string[] = [];
   const rejected: LinearIrRejection[] = [];
-  const result: LinearIrResult = { funcs, compiled, rejected };
+  let helperStartFuncIdx = 0;
+  for (const funcIdx of ctx.funcMap.values()) helperStartFuncIdx = Math.max(helperStartFuncIdx, funcIdx + 1);
+  const { resolver, helpers } = makeLinearIrResolver(ctx, helperStartFuncIdx);
+  const result: LinearIrResult = { funcs, compiled, rejected, helpers };
   lastReport = result;
 
   const selection = planIrCompilation(sourceFile, { experimentalIR: true });
   if (selection.funcs.size === 0) return result;
-
-  const resolver = makeLinearIrResolver(ctx);
 
   const claimedDecls: { name: string; decl: ts.FunctionDeclaration; exported: boolean }[] = [];
   for (const stmt of sourceFile.statements) {
@@ -192,12 +213,7 @@ export function compileLinearIrFunctions(ctx: LinearContext, sourceFile: ts.Sour
           vecNewFuncIdx: ctx.funcMap.get("__arr_new"),
           vecInitF64FuncIdx: ctx.funcMap.get(LINEAR_IR_VEC_INIT_F64_FN),
         });
-        const body = lowerIrFunctionBody(
-          main,
-          resolver,
-          emitter,
-          wasmValueTypeConverter("linear", resolver, main.name),
-        );
+        const body = lowerIrFunctionBody(main, resolver, emitter, linearValueTypeConverter(resolver, main.name));
         const vecScratchLocals = new Set(emitter.getVecScratchLocalIndices());
         const wasmLocals = body.locals.flatMap((local) =>
           local.slots.map((type, slot) => ({
@@ -276,10 +292,14 @@ function bucketFromLegalityMessage(message: string): string {
 }
 
 /**
- * The linear resolver: required name/table methods plus the L2 fixed-f64-vec
- * subset. Other optional shape hooks remain absent — see the module header.
+ * The linear resolver: required name/table methods plus the L2 fixed-f64-vec,
+ * numeric-object, and primitive-refcell subsets. Other optional shape hooks
+ * remain absent — see the module header.
  */
-function makeLinearIrResolver(ctx: LinearContext): IrLowerResolver & IrFromAstResolver {
+function makeLinearIrResolver(
+  ctx: LinearContext,
+  helperStartFuncIdx: number,
+): { resolver: IrLowerResolver & IrFromAstResolver; helpers: LinearIrHelper[] } {
   // Linear vecs have no module type indices: they are i32 pointers to the
   // canonical `[header][len][cap][f64 slots...]` runtime layout. The shared
   // resolver shape still carries the WasmGC index fields for lower.ts's
@@ -293,7 +313,64 @@ function makeLinearIrResolver(ctx: LinearContext): IrLowerResolver & IrFromAstRe
     elementValType: { kind: "f64" },
   };
 
-  return {
+  const helpers: LinearIrHelper[] = [];
+  const helperByShape = new Map<string, number>();
+  const objects = new Map<string, LinearObjectLowering>();
+  const refCells = new Map<string, LinearRefCellLowering>();
+
+  const ensureAggregateHelper = (
+    key: string,
+    fields: readonly { name: string; type: ValType; offset: number }[],
+    totalSize: number,
+  ): number => {
+    const cached = helperByShape.get(key);
+    if (cached !== undefined) return cached;
+
+    const funcIdx = helperStartFuncIdx + helpers.length;
+    const name = `__linear_ir_aggregate_new_${helpers.length}`;
+    const mallocIdx = ctx.funcMap.get("__malloc");
+    if (mallocIdx === undefined) throw new Error("linear-ir: __malloc runtime helper missing");
+    const pointerLocal = fields.length;
+    const body: Instr[] = [
+      { op: "i32.const", value: totalSize },
+      { op: "call", funcIdx: mallocIdx },
+      { op: "local.tee", index: pointerLocal },
+      { op: "i32.const", value: LINEAR_GENERIC_OBJECT_TAG },
+      { op: "i32.store8", align: 0, offset: 0 },
+      { op: "local.get", index: pointerLocal },
+      { op: "i32.const", value: totalSize - LINEAR_AGGREGATE_HEADER_SIZE },
+      { op: "i32.store", align: 2, offset: 4 },
+    ];
+    fields.forEach((field, paramIndex) => {
+      body.push({ op: "local.get", index: pointerLocal }, { op: "local.get", index: paramIndex });
+      if (field.type.kind === "i32") {
+        body.push({ op: "i32.store", align: 2, offset: field.offset });
+      } else if (field.type.kind === "f64") {
+        body.push({ op: "f64.store", align: 3, offset: field.offset });
+      } else {
+        throw new Error(`linear-ir: aggregate helper cannot store '${field.type.kind}' field '${field.name}'`);
+      }
+    });
+    body.push({ op: "local.get", index: pointerLocal });
+
+    const func: WasmFunction = {
+      name,
+      typeIdx: internLinearFuncType(ctx, {
+        kind: "func",
+        params: fields.map((field) => field.type),
+        results: [{ kind: "i32" }],
+      }),
+      locals: [{ name: "$aggregate_ptr", type: { kind: "i32" } }],
+      body,
+      exported: false,
+    };
+    helpers.push({ funcIdx, func });
+    helperByShape.set(key, funcIdx);
+    ctx.funcMap.set(name, funcIdx);
+    return funcIdx;
+  };
+
+  const resolver: IrLowerResolver & IrFromAstResolver = {
     resolveFunc(ref: IrFuncRef): number {
       // (#2956 L2) Vec MUTATION rides from-ast's element-store helper call
       // `__vec_elem_set_<vecStructTypeIdx>` (the C2 path — element store and
@@ -330,24 +407,72 @@ function makeLinearIrResolver(ctx: LinearContext): IrLowerResolver & IrFromAstRe
       throw new Error(`linear-ir: symbolic type '${ref.name}' outside slice-1 scope`);
     },
     internFuncType(def: FuncTypeDef): number {
-      // Dedupe against the linear module's type section (append-only, no
-      // hoist pass on linear — the spec's "must not grow it per call").
-      const sameValType = (a: ValType, b: ValType): boolean =>
-        a.kind === b.kind && (a as { typeIdx?: number }).typeIdx === (b as { typeIdx?: number }).typeIdx;
-      for (let i = 0; i < ctx.mod.types.length; i++) {
-        const t = ctx.mod.types[i]!;
-        if (t.kind !== "func") continue;
-        if (t.params.length !== def.params.length || t.results.length !== def.results.length) continue;
-        if (
-          t.params.every((p, j) => sameValType(p, def.params[j]!)) &&
-          t.results.every((r, j) => sameValType(r, def.results[j]!))
-        ) {
-          return i;
-        }
+      return internLinearFuncType(ctx, def);
+    },
+    resolveObject(shape: IrObjectShape): LinearObjectLowering | null {
+      const key = linearObjectShapeKey(shape);
+      const cached = objects.get(key);
+      if (cached) return cached;
+
+      const fieldDefs: { name: string; type: "i32" | "f64" }[] = [];
+      for (const field of shape.fields) {
+        const type = linearAggregateFieldType(field.type);
+        if (!type) return null;
+        fieldDefs.push({ name: field.name, type: type.kind });
       }
-      const idx = ctx.mod.types.length;
-      ctx.mod.types.push(def);
-      return idx;
+      const layout = computeClassLayout(`__linear_ir_object_${objects.size}`, fieldDefs);
+      const fields = shape.fields.map((field, fieldIdx) => {
+        const memory = layout.fields.get(field.name);
+        if (!memory) throw new Error(`linear-ir: object layout has no field '${field.name}'`);
+        return {
+          name: field.name,
+          fieldIdx,
+          offset: memory.offset,
+          type: { kind: memory.type } as ValType,
+        };
+      });
+      const newFuncIdx = ensureAggregateHelper(`object:${key}`, fields, layout.totalSize);
+      const byName = new Map(fields.map((field) => [field.name, field]));
+      const lowering: LinearObjectLowering = {
+        typeIdx: 0,
+        fieldIdx(name: string): number {
+          const field = byName.get(name);
+          if (!field) throw new Error(`linear-ir: object shape has no field '${name}'`);
+          return field.fieldIdx;
+        },
+        linearMemory: {
+          newFuncIdx,
+          fieldCount: fields.length,
+          field(name: string): LinearMemoryFieldLowering {
+            const field = byName.get(name);
+            if (!field) throw new Error(`linear-ir: object shape has no field '${name}'`);
+            return field;
+          },
+        },
+      };
+      objects.set(key, lowering);
+      return lowering;
+    },
+    resolveRefCell(inner: ValType): IrRefCellLowering | null {
+      if (inner.kind !== "i32" && inner.kind !== "f64") return null;
+      const cached = refCells.get(inner.kind);
+      if (cached) return cached;
+      const layout = computeClassLayout(`__linear_ir_refcell_${inner.kind}`, [{ name: "value", type: inner.kind }]);
+      const value = layout.fields.get("value");
+      if (!value) throw new Error("linear-ir: ref-cell layout has no value field");
+      const memoryValue: LinearMemoryFieldLowering = { offset: value.offset, type: inner };
+      const newFuncIdx = ensureAggregateHelper(
+        `refcell:${inner.kind}`,
+        [{ name: "value", type: inner, offset: value.offset }],
+        layout.totalSize,
+      );
+      const lowering: LinearRefCellLowering = {
+        typeIdx: 0,
+        fieldIdx: 0,
+        linearMemory: { newFuncIdx, value: memoryValue },
+      };
+      refCells.set(inner.kind, lowering);
+      return lowering;
     },
     resolveVec(valType: ValType): IrVecLowering | null {
       return valType.kind === "i32" ? f64VecLayout : null;
@@ -372,4 +497,58 @@ function makeLinearIrResolver(ctx: LinearContext): IrLowerResolver & IrFromAstRe
       }
     },
   };
+
+  return { resolver, helpers };
+}
+
+function internLinearFuncType(ctx: LinearContext, def: FuncTypeDef): number {
+  const sameValType = (a: ValType, b: ValType): boolean =>
+    a.kind === b.kind && (a as { typeIdx?: number }).typeIdx === (b as { typeIdx?: number }).typeIdx;
+  for (let i = 0; i < ctx.mod.types.length; i++) {
+    const type = ctx.mod.types[i]!;
+    if (type.kind !== "func") continue;
+    if (type.params.length !== def.params.length || type.results.length !== def.results.length) continue;
+    if (
+      type.params.every((param, index) => sameValType(param, def.params[index]!)) &&
+      type.results.every((result, index) => sameValType(result, def.results[index]!))
+    ) {
+      return i;
+    }
+  }
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push(def);
+  return typeIdx;
+}
+
+function linearValueTypeConverter(resolver: IrLowerResolver, funcName: string): TypeConverter<ValType> {
+  return {
+    backend: "linear",
+    convertType(type: IrType): readonly ValType[] {
+      if (type.kind === "val") return [type.val];
+      if (type.kind === "object" && resolver.resolveObject?.(type.shape)) return [{ kind: "i32" }];
+      if (type.kind === "boxed") {
+        const inner = asVal(type.inner);
+        if (inner && resolver.resolveRefCell?.(inner)) return [{ kind: "i32" }];
+      }
+      throw new Error(`linear-ir: cannot carry IR type '${type.kind}' in ${funcName}`);
+    },
+  };
+}
+
+function linearAggregateFieldType(type: IrType): Extract<ValType, { kind: "i32" | "f64" }> | null {
+  if (type.kind === "val" && (type.val.kind === "i32" || type.val.kind === "f64")) return type.val;
+  if (type.kind === "object" || type.kind === "boxed") return { kind: "i32" };
+  return null;
+}
+
+function linearObjectShapeKey(shape: IrObjectShape): string {
+  const typeKey = (type: IrType): unknown => {
+    if (type.kind === "val") return ["val", type.val.kind];
+    if (type.kind === "object") {
+      return ["object", type.shape.fields.map((field) => [field.name, typeKey(field.type)])];
+    }
+    if (type.kind === "boxed") return ["boxed", typeKey(type.inner)];
+    return [type.kind];
+  };
+  return JSON.stringify(shape.fields.map((field) => [field.name, typeKey(field.type)]));
 }

--- a/tests/ir-vec-two-backend.test.ts
+++ b/tests/ir-vec-two-backend.test.ts
@@ -222,17 +222,12 @@ describe("#2954 LinearEmitter core-op families are byte-identical to WasmGc", ()
   });
 
   it("representation-divergent families still fail loudly on LinearEmitter", () => {
-    // Aggregates, boxing-adjacent funcref call, exceptions, ref-cells lower to
-    // WasmGC-specific ops; the linear analogue lands with #2956/#2953. Each stays
-    // a loud stub (WasmGc implements them; Linear throws).
+    // Boxing-adjacent funcref calls and exceptions still need distinct linear
+    // designs. Aggregates/ref-cells are covered by #2956's linear-memory tests.
     for (const call of [
       () => linear.emitCallRef(),
-      () => linear.emitAggregateNew(),
-      () => linear.emitFieldGet(),
-      () => linear.emitFieldSet(),
       () => linear.emitThrow(),
       () => linear.emitTry(),
-      () => linear.emitRefCellNew(),
       () => linear.emitVecNewFixed(),
     ]) {
       expect(call).toThrow(/LinearEmitter:/);

--- a/tests/issue-1850.test.ts
+++ b/tests/issue-1850.test.ts
@@ -249,9 +249,9 @@ describe("#1850 — per-backend IR legality and hard verifier fallback", () => {
     ).not.toThrow();
   });
 
-  it("#2954: still rejects a representation-divergent (object.new) instr on the linear boundary", () => {
-    // The core-op opening (#2954) did NOT open the divergent families — objects
-    // lower to WasmGC `struct.*`; the linear analogue lands with #2956.
+  it("#2956 L2: accepts object.new after the linear-memory aggregate lowering lands", () => {
+    // The linear resolver/emitter now carries object values as i32 arena
+    // pointers and lowers fields through layout.ts offsets.
     const objInstr: IrInstr = {
       kind: "object.new",
       shape: { fields: [] },
@@ -269,10 +269,7 @@ describe("#1850 — per-backend IR legality and hard verifier fallback", () => {
       valueCount: 3,
     };
 
-    const errors = verifyIrBackendLegality(fn, "linear");
-    expect(errors.some((e) => /linear backend does not support IR instruction 'object.new'/.test(e.message))).toBe(
-      true,
-    );
+    expect(verifyIrBackendLegality(fn, "linear")).toEqual([]);
   });
 
   it("promotes verifier fallback diagnostics to hard Codegen errors in test builds only", () => {

--- a/tests/issue-2956.test.ts
+++ b/tests/issue-2956.test.ts
@@ -10,6 +10,9 @@ import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { getLastLinearIrReport } from "../src/ir/backend/linear-integration.js";
+import { LinearEmitter } from "../src/ir/backend/linear-emitter.js";
+import type { LinearRefCellLowering } from "../src/ir/backend/handles.js";
+import type { Instr } from "../src/ir/types.js";
 
 const FLAG = "JS2WASM_LINEAR_IR";
 const savedFlag = process.env[FLAG];
@@ -264,5 +267,90 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
     // push arg (pre-existing defect, #3332): length is 2, not the
     // spec-correct 3. Update to 3 when #3332 lands.
     expect(await run(binary)).toBe(2);
+  });
+});
+
+const AGGREGATE_READ_SRC = `export function readPoint(): number {
+  const point = { x: 2, y: 3 };
+  return point.x + point.y;
+}
+export function nested(): number {
+  const inner = { value: 3 };
+  const outer = { bonus: 4, inner };
+  return outer.inner.value + outer.bonus;
+}
+export function boolField(): number {
+  const value = { ok: true, n: 4 };
+  return value.ok ? value.n : 0;
+}
+export function test(): number { return readPoint() + nested() + boolField(); }`;
+
+const AGGREGATE_MUTATION_SRC = `export function mutate(): number {
+  const point = { x: 2, y: 3 };
+  point.x = 4;
+  return point.x + point.y;
+}
+export function alias(): number {
+  const point = { x: 2 };
+  const same = point;
+  same.x = 8;
+  return point.x + same.x;
+}
+export function test(): number { return mutate() + alias(); }`;
+
+describe("#2956 L2: selector-claimed linear-memory aggregates + ref-cells", () => {
+  it("lowers object allocation and nested reads with direct-path value parity", async () => {
+    const directBinary = await compileLinear(AGGREGATE_READ_SRC, false);
+    const irBinary = await compileLinear(AGGREGATE_READ_SRC, true);
+    const report = getLastLinearIrReport();
+    expect(report?.rejected ?? []).toEqual([]);
+    expect([...(report?.compiled ?? [])].sort()).toEqual(["boolField", "nested", "readPoint", "test"]);
+    expect(report?.helpers.length).toBe(4);
+
+    const direct = await exportedFunctions(directBinary);
+    const ir = await exportedFunctions(irBinary);
+    for (const name of ["readPoint", "nested", "boolField", "test"]) {
+      expect(callNumber(ir, name), `${name} IR value`).toBe(callNumber(direct, name));
+    }
+    expect(callNumber(ir, "test")).toBe(16);
+  });
+
+  it("preserves mutation and strict aliasing through i32 arena pointers", async () => {
+    const binary = await compileLinear(AGGREGATE_MUTATION_SRC, true);
+    const report = getLastLinearIrReport();
+    expect(report?.rejected ?? []).toEqual([]);
+    expect([...(report?.compiled ?? [])].sort()).toEqual(["alias", "mutate", "test"]);
+    const exports = await exportedFunctions(binary);
+    expect(callNumber(exports, "mutate")).toBe(7);
+    expect(callNumber(exports, "alias")).toBe(16);
+    expect(callNumber(exports, "test")).toBe(23);
+  });
+
+  it("JS2WASM_LINEAR_IR=0 keeps aggregate modules byte-identical to an unset flag", async () => {
+    const unset = await compileLinear(AGGREGATE_READ_SRC, false);
+    const zero = await compileLinear(AGGREGATE_READ_SRC, "0");
+    const sha = (binary: Uint8Array): string => createHash("sha256").update(binary).digest("hex");
+    expect(sha(zero)).toBe(sha(unset));
+  });
+
+  it("emits primitive ref-cell allocation and field access through linear-memory handles", () => {
+    const layout: LinearRefCellLowering = {
+      typeIdx: 0,
+      fieldIdx: 0,
+      linearMemory: {
+        newFuncIdx: 77,
+        value: { offset: 8, type: { kind: "f64" } },
+      },
+    };
+    const emitter = new LinearEmitter();
+    const out: Instr[] = [];
+    emitter.emitRefCellNew(layout, out);
+    emitter.emitRefCellGet(layout, out);
+    emitter.emitRefCellSet(layout, out);
+    expect(out).toEqual([
+      { op: "call", funcIdx: 77 },
+      { op: "f64.load", align: 3, offset: 8 },
+      { op: "f64.store", align: 3, offset: 8 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- carry selector-claimed numeric objects as i32 linear-memory pointers
- lower object/ref-cell allocation and field access through `LinearEmitter`
- append lazily discovered aggregate constructors after all pre-assigned user slots
- keep the overlay behind `JS2WASM_LINEAR_IR=1`; strings and closures remain deferred

## Why

The L1 overlay and vec slices proved the linear backend could consume shared IR, but `object.new/get/set` and primitive ref-cells still failed the linear legality boundary. This completes the remaining L2 aggregate/ref-cell emitter and resolver surface without cloning the IR front-end or adopting a foreign object representation.

## Validation

- focused backend/fallback tests: 40/40
- complete linear + cross-backend + IR proof matrix: 210/210 after merging current `main`
- `pnpm run typecheck`
- `pnpm run check:linear-ir` (`compiled=6`, `build=4`; baseline unchanged because the fixed corpus has no aggregate row)
- `pnpm run check:ir-fallbacks`
- `pnpm run check:loc-budget`
- `pnpm run check:oracle-ratchet`
- Prettier check on every changed file

## Follow-up

#2956 remains in progress for L3 strings (after #2955) and L4 default-on/direct-reject-list folding.
