### PR TITLE
plan(ir-audit): 2026-07-17 delta audit of src/ir vs 07-02 baseline

### DIFF
--- a/plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md
+++ b/plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md
@@ -103,3 +103,23 @@ This epic is `done` when, for every unintended bucket:
 - `plan/log/ir-adoption.md` — per-AST-kind adoption status (selector-bucket
   table at the bottom maps reasons → promotable rows).
 - `src/ir/select.ts` — `IrFallbackReason` union + the per-function claim checks.
+
+## Audit note 2026-07-17 (IR audit 01)
+
+Bucket-zeroing half is ahead of plan: `call-graph-closure`, `class-method`,
+`param-type-not-resolvable` all hit 0 since 07-02 (baseline now only
+`body-shape-rejected` 14 + deferred `async-function` 4 + moduleLevel 2).
+But the PROMOTION half has not started: `STRICT_IR_REASONS`
+(`src/codegen/index.ts:1511`) is still the empty set — none of the ~8
+zeroed reasons has been promoted, so the demote-to-warning channel still
+silently covers all of them. This is now the cheapest hardening step in
+the program. Caveat: baseline zero is corpus-zero (13 playground files),
+not strict-zero — per-reason promotion needs the corpus-vs-strict check
+the `class-method` row in `ir-adoption.md` flags. See
+`plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md` §2. Also untracked
+post-#2953 residue for a follow-up slice here or a new issue: 5 GC-op
+literals left in `lower.ts` (`class.get`/`class.set`/instanceof-tag via
+pushRaw at ~1797/1815/1908 — should use the existing
+`emitFieldGet`/`emitFieldSet` primitives like `obj.get` does) plus
+`forof.str` pushing `struct.get` on the RAW sink (`lower.ts:2614/2674`),
+invisible to the `check:pushraw` ratchet (§3).

--- a/plan/issues/2950-ir-first-default-flip-retire-compile-twice.md
+++ b/plan/issues/2950-ir-first-default-flip-retire-compile-twice.md
@@ -61,3 +61,14 @@ High blast radius (changes which front-end emits every claimed body for
 every user). Validate on the full merge_group run, never a scoped sweep
 (`project_broad_impact_validate_full_ci`). Slice 2 only after slice 1 has
 soaked through at least one budget window on main.
+
+## Audit note 2026-07-17 (IR audit 01)
+
+STALE/SUPERSEDED IN PART: the default-ON flip this issue titles was
+delivered by #3143 (done, sprint 71) — `experimentalIR` defaults true and
+IR-first runs unless `JS2WASM_IR_FIRST=0` (one-release escape hatch,
+`src/codegen/index.ts:2327-2338`). The undelivered remainder (delete the
+compile-twice machinery + phase out the demote channel) overlaps #2855
+AC4. This issue should be re-scoped to exactly that remainder or closed
+in favor of #2855/#3143 — do not dispatch it as an independent "flip"
+task. See `plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md` §6.

--- a/plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md
+++ b/plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md
@@ -1,0 +1,225 @@
+# 01 — IR system audit 2026-07-17 (delta vs the 2026-07-02 baseline)
+
+> Single-agent audit run 2026-07-17 against `origin/main @ d558684f09`.
+> Scope: `src/ir/` + its integration into `src/codegen/` and
+> `src/codegen-linear/`. This is a **delta audit** against
+> [`00-ir-async-standalone-audit.md`](00-ir-async-standalone-audit.md)
+> (2026-07-02, `@ 70732174f`): every headline claim from that report was
+> re-verified against current main; findings below say explicitly
+> better / worse / unchanged. 99 commits touched `src/ir/` in the 15 days
+> between the two audits.
+>
+> **Budget note**: this audit was cut short by a session budget stop. All
+> claims in §0–§6 are verified (command + file:line cited). §7 lists what
+> was NOT audited and needs follow-up — those are stubs, not findings.
+
+---
+
+## 0. Headline numbers (verified 2026-07-17)
+
+| Metric | 2026-07-02 | 2026-07-17 | Delta | Source |
+| --- | --- | --- | --- | --- |
+| IR-first (selector decides, legacy body skipped) | opt-in `JS2WASM_IR_FIRST=1` | **DEFAULT ON** (`JS2WASM_IR_FIRST=0` is the one-release escape hatch) | BETTER (#3143 done, sprint 71) | `src/codegen/index.ts:2327-2338`, `src/compiler.ts:762` (`experimentalIR: options.experimentalIR !== false`) |
+| `body-shape-rejected` bucket | 33 | **14** | BETTER (−19) | `scripts/ir-fallback-baseline.json` + live `pnpm run check:ir-fallbacks -- --verbose` run today (current == baseline, gate OK) |
+| `call-graph-closure` bucket | 5 | **0** | BETTER (#2858 done) | baseline JSON (bucket removed) |
+| `class-method` bucket | 6 | **0** | BETTER (#2857 + #3000 B/C/E done — accessors, ctors, inheritance/super in IR) | baseline JSON |
+| `param-type-not-resolvable` bucket | 1 | **0** | BETTER (#2859 done) | baseline JSON |
+| `async-function` bucket (deferred) | 4 | 4 | UNCHANGED | baseline JSON |
+| Module-level claim unit (#3142) | did not exist | **new gated section**: `body-shape-rejected` 2, 11 modules empty, 0 claimable | NEW | baseline `moduleLevel` + live run |
+| `STRICT_IR_REASONS` | empty set | **still empty set** | **UNCHANGED — now the gap** (see §2) | `src/codegen/index.ts:1511` |
+| `pushRaw` escape-hatch sites in `lower.ts` | 77 ("WasmGC-inline") | 82 untagged, 0 tagged — **but zero of them push GC ops** (see §3) | CHARACTER CHANGED (better), count ratcheted since 2026-07-16 | `scripts/pushraw-baseline.json`, `check:pushraw` gate |
+| WasmGC-specific op literals in `lower.ts` | (dominant pattern, 77 sites) | **5** (`struct.get` ×4, `struct.set` ×1) | MUCH BETTER (#2953 done) | `grep 'op: "struct\.\|array\.\|ref\.cast…' src/ir/lower.ts` |
+| Linear backend IR consumption in production | **zero** (fork above IR at compiler.ts:861) | **L1 landed, flag-gated** `JS2WASM_LINEAR_IR=1`, default OFF; baseline: 6 funcs compiled, 4 build-rejections | BETTER (#2956 in-progress; default flip = slice L4) | `src/ir/backend/linear-integration.ts` (header), `scripts/linear-ir-baseline.json`, `compiler.ts:891-905` |
+| Backend contract | trait + 2 proof emitters | **five-part contract FROZEN** (#3029-S1) + conformance test + **IR interchange contract v1.0** (#3030) + **Porffor as an external 4th consumer** | NEW | `src/ir/backend/contract.ts`, `contract-conformance.ts`, `src/ir/backend/porffor/` (IR-only, pinned upstream commit) |
+| IR async gate | hardcoded closed | hardcoded closed (`isAsyncIrReady` returns `false` unconditionally; `supportsAsyncIr: false` at `create-context.ts:298`) | UNCHANGED (#1373b Slice 2 pending) | `src/ir/select.ts:307-313` |
+| TODO/FIXME markers in `src/ir/**` | (not measured) | **4** total (1 is `TODO(#1373b Slice 2)`) | very clean | grep |
+| `src/ir/` size | 652 KB, 11 files | **33,400 lines** across `src/ir/` + `backend/` (12 files incl. porffor/) + `passes/` (8) + `analysis/` (5, new) | grew with adoption | `wc -l` |
+
+## 1. Finding — the #2855 ratchet WORKED: three unintended buckets zeroed in 15 days
+
+The July-2 audit's bucket table (body-shape 33 · closure 5 · class-method 6 ·
+param-type 1 · async 4) is now: **body-shape 14 · async 4 (deferred) ·
+module-level 2 (new #3142 section)**. Everything else is zero and *removed
+from the baseline* (the gate enforces no-regrowth). Verified by running
+`pnpm run check:ir-fallbacks -- --verbose` today: gate OK, current ==
+baseline, no post-claim demotions.
+
+Residual `body-shape-rejected` (14) is spread 1-per-file across 8 benchmark
+examples + `dom/calendar.ts` (4) + `js/builtins.ts`/`js/async.ts` (1 each) —
+i.e. the long tail, not one missing statement kind. The per-shape
+composition of these 14 was NOT re-triaged in this audit (see §7).
+
+Other adoption progress landed since 07-02 (all verified in git log /
+issue frontmatter):
+
+- **#3000 B/C/E done**: IR emits accessors, constructors (`class.alloc`),
+  inheritance/`super` — `classes.ts` fully IR; class-method bucket 0.
+- **#2949 (dynamic IrType — the July audit's "true critical path")** is
+  genuinely moving: slices S3/S3b (dynamic box/unbox/tag.test lowering,
+  `IrDynamicLowering` handle, gc+host strategies; explicit `any` unified
+  onto `dynamic`) and S5.0–S5.5 (truthiness, strict/loose equality,
+  relational, numeric arithmetic — all byte-inert mechanism slices) landed.
+  Still in-progress; the "claim rate on untyped corpus" number was NOT
+  re-measured (§7).
+- **#3142 slice 1 done**: module-level statements are now a synthetic
+  claim unit with its own gated bucket. Slice 2 (actual lowering +
+  `__module_init` patch) not landed.
+- **#3143 done**: IR-first default flip. #2138's compile-once inversion +
+  skipped-slot hard-error contract now run by default
+  (`irFirstBodyIsProvenLowerable` allowlist, `index.ts:1726`).
+- New IR string/operator coverage: #3167 (string relationals), #3168
+  (unary +/- ToNumber), #3154 (`substring`/`charCodeAt`), #3144
+  (instanceof + static calls + accessors), #3053 U1/U2 (`__dyn_member_get`
+  dynamic member reads), #3065, #2951 (generator `gen.setReturn`).
+
+## 2. Finding — the promotion half of #2855 has NOT started: `STRICT_IR_REASONS` is still the empty set
+
+`src/codegen/index.ts:1511`:
+`const STRICT_IR_REASONS: ReadonlySet<IrFallbackReason> = new Set<IrFallbackReason>();`
+
+Per `docs/architecture/codegen-axes.md` and CLAUDE.md, once a bucket hits
+zero its reason is supposed to be promoted into `STRICT_IR_REASONS`
+(regression ⇒ hard compile error instead of silent legacy fallback). Three
+buckets zeroed since 07-02 (`call-graph-closure`, `class-method`,
+`param-type-not-resolvable`) plus the buckets already at zero
+(`external-call`, `param-shape-rejected`, `destructuring-param-complex`,
+`return-type-not-resolvable`, `type-resolution-failure` — all absent from
+the baseline's `unintended` section) — and **none has been promoted**. The
+demote-to-warning channel (`index.ts:~1891-1912, 2390-2428` — note: NOT at
+`889-896` as `ir-adoption.md` still claims) therefore still silently
+covers every zeroed bucket. This is the single cheapest hardening step
+available today and it is #2855's own AC — #2855 is `ready|current` but
+nobody has picked up the promotion slice. **Action: noted in #2855
+(audit-note appended, this commit).** Caveat before promoting: baseline
+zero is measured against the 13-file playground corpus only; a reason can
+be zero-on-corpus but still legitimately fire on user code, so each
+promotion needs the corpus-vs-strict distinction the class-method row in
+`ir-adoption.md` already flags ("corpus bucket 0 … NOT yet strict").
+
+## 3. Finding — #2953 delivered what mattered: pushRaw is no longer a WasmGC leak; the residue is 5 GC-op sites + one raw-sink bypass
+
+The July-2 report's "77 pushRaw WasmGC-inline sites" is obsolete in
+character, not just count:
+
+- **Zero `pushRaw` sites push GC ops.** Every op literal now going through
+  `pushRaw` is backend-neutral core Wasm (`call` ×19, `local.*`,
+  `i32.*`, `f64.*`, `drop`). The union/closure/refcell/ref-coercion/
+  Promise/funcref aggregate families were routed through typed
+  `BackendEmitter` primitives (commits `d1166c82`, `34c78a4b`,
+  `d76013b3`, `6da93bd0`, `ab7a2c1a`).
+- Sites passing *variable* instr arrays (`dyn.emitBox(...)`,
+  `cl.allocInstrs`, `dyn.emitMemberGet()`, …) forward **resolver-owned**
+  sequences — per the frozen contract that is part-4 (`LayoutResolver`)
+  territory, implemented per-backend, so GC-ness there is by design.
+- **Residual GC-op literals in `lower.ts` (5 + 2 raw-sink)**, untracked now
+  that #2953 is closed:
+  - `class.get` / `class.set` / union-`instanceof` tag read emit
+    `struct.get`/`struct.set` via `pushRaw` (`lower.ts:1797, 1815, 1908`)
+    instead of the existing `emitFieldGet`/`emitFieldSet` typed primitives
+    (which the `obj.get`/`obj.set` arms at `lower.ts:1622/1639` already
+    use — an internal inconsistency, trivially alignable).
+  - `forof.str` pushes `struct.get` on the string struct **directly onto
+    the raw sink** (`wasmOut.push(...)`, `lower.ts:2614, 2674`) —
+    bypassing the emitter trait entirely, not even via `pushRaw`, so the
+    `check:pushraw` ratchet cannot see it.
+- **New ratchet landed 2026-07-16** (`check:pushraw`, commit `12771ddb`):
+  change-scoped gate rejecting untagged new `pushRaw` sites; whole-tree
+  baseline 82 untagged / 0 tagged. Note the count is *higher* than the
+  July-2 77 — sites were added while the families were being migrated and
+  before the gate existed; with the gate in place the count can only
+  ratchet down. The `// pushraw-ok(#NNNN)` tag convention exists in the
+  gate but has zero uses so far.
+- `src/ir/integration.ts` still contains **7** GC-op literals (not
+  itemized in this audit — §7).
+
+## 4. Finding — linear backend: "zero IR consumption" is no longer accurate, but production default is still direct-AST
+
+`src/ir/backend/linear-integration.ts` (#2956 slice L1, landed as
+`ffb81ed2`) wires the SAME shared front-end (`planIrCompilation` →
+`lowerFunctionAstToIr` → `verifyIrFunction` →
+`verifyIrBackendLegality("linear")` → `LinearEmitter`) into
+`generateLinearModule` — with per-function demotion to the linear direct
+path and its own bucketed ratchet (`check:linear-ir`,
+`scripts/linear-ir-baseline.json`: 6 functions compiled through IR, 4
+build-rejections). Gated `JS2WASM_LINEAR_IR=1`, byte-identical when off;
+default-ON is slice L4. The header documents an honest relationship to the
+ratified L0 adapter extraction (deliberately does not fork
+`integration.ts` logic).
+
+So the architecture story moved from "two separate compilers sharing an
+instruction encoding" (July-2 framing) to "one front-end, second backend
+in staged rollout". The July-2 `compiler.ts:861` fork-above-the-IR still
+exists (`compiler.ts:891` today, `useLinear`) — it is now the *default*
+path rather than the *only* path.
+
+Also new since 07-02: the five-part backend contract is **frozen**
+(#3029-S1; `src/ir/backend/contract.ts` invariants A1–A7,
+`contract-conformance.ts` proves all three in-tree emitters + a
+from-scratch stub satisfy it), the serializable IR interchange contract
+v1.0 landed (#3030), and a **Porffor adapter**
+(`src/ir/backend/porffor/`, pinned upstream commit, IR-only by
+construction) exists as a fourth, out-of-tree-shaped consumer. The
+"BackendEmitter is test-only theater" critique from July 2 no longer
+holds at the contract layer; it still holds for *production linear
+compiles* until L4.
+
+## 5. Finding — async IR: unchanged, still the biggest deferred bucket's root
+
+`isAsyncIrReady` (`src/ir/select.ts:307`) returns `false` unconditionally
+(scaffolding slice; the `supportsAsyncIr` option is threaded through but
+hardcoded `false` at `src/codegen/context/create-context.ts:298`).
+`IrInstrAwait`/`IrInstrAsyncReturn` remain type-only. The `async-function`
+bucket (4) is correctly classified deferred. Nothing regressed; nothing
+moved. #1373b Slice 2 (CPS continuation synthesis) is the tracked next
+step and the only `TODO(#issue)` marker in all of `src/ir/`.
+
+## 6. Finding — tracking-data staleness (fixed or flagged in this commit)
+
+1. **#2950 is a stale near-duplicate**: `status: backlog, sprint: current`
+   for "IR-first default flip: JS2WASM_IR_FIRST default-ON, then delete
+   the fallback" — but #3143 (done, sprint 71) delivered the flip. The
+   un-delivered remainder of #2950 (delete compile-twice machinery +
+   demote channel) is #2855 AC territory. Reconciliation note appended to
+   the issue in this commit; it should not sit in the `current` queue as
+   an independent flip task.
+2. **`plan/log/ir-adoption.md`** (generated, CI-checked — structure is
+   trustworthy) has two stale citations: the demote channel location
+   (`index.ts:889–896`; actually ~1891/2390 today — same drift the July-2
+   audit already flagged, still unfixed because the text lives in
+   `scripts/gen-ir-adoption.mjs`), and the `AwaitExpression` row tracking
+   #1373 (closed) instead of #1373b. Kind-status rows spot-checked OK
+   (e.g. `SwitchStatement` direct-only — confirmed: no `SwitchStatement`
+   handler and no `br_table` in `from-ast.ts`/`lower.ts`/`nodes.ts`).
+3. **`docs/architecture/codegen-axes.md`** "hidden bias" table row for
+   `lower.ts` is stale post-#2953: it still says the aggregate/closure/
+   ref-coercion groups are "not yet moved" — they moved (§3). Also still
+   cites the `889–896` demote location.
+4. **CLAUDE.md "IR Fallback Budget" table** lists buckets
+   (`external-call`, `call-graph-closure`, `param-shape-rejected`, …)
+   that are all at zero now — harmless as a reasons-catalog, misleading
+   as a status table.
+
+## 7. NOT audited (budget stop) — needs follow-up
+
+Explicitly unverified; do not treat as findings:
+
+- Composition of the residual `body-shape-rejected` 14 (which statement/
+  expression shapes; whether #2856's host-global-member diagnosis from
+  July 2 still dominates).
+- `src/ir/analysis/` (new-ish: `escape.ts`, `lattice.ts`, `ownership.ts`,
+  `stack-alloc.ts`, `encoding.ts`) — provenance, consumers, test coverage.
+- `src/ir/integration.ts`'s 7 GC-op literals; whether integration.ts's
+  planned L0 split (backend-neutral core vs `IrBackendIntegration`
+  adapter) has an owner.
+- Test-coverage map of `src/ir/` (tests/ir-*.test.ts inventory vs the 33k
+  lines) and verify.ts coverage of the new #2949 dynamic nodes.
+- Re-measurement of the IR claim rate on the untyped test262-scale corpus
+  (July-2: 8 bodies / 233 files) after #2949 S3/S5 — the single most
+  important number to re-take next audit.
+- #2955 string de-polymorph residual (slices 1–3 landed; issue still
+  `ready|current` — status/remainder not reconciled).
+- #2135 capability-table vs `isPhase1*` predicate-family duplication in
+  `select.ts` (July-2: ~2,200 lines mirroring 188 from-ast throw sites) —
+  current line counts suggest select.ts grew (3,430 lines); not re-diffed.
+- Porffor adapter depth (renderer record fidelity, drift risk vs the
+  pinned upstream commit).


### PR DESCRIPTION
Audit-only, plan/ files only. Delta audit of the IR system vs the 2026-07-02 baseline audit.

- New: plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md
- Updated: #2855 (audit note: promotion half not started, STRICT_IR_REASONS still empty; post-#2953 GC-op residue), #2950 (stale — flip delivered by #3143, re-scope or close)

Cut short by session budget; §7 of the doc lists explicitly-unverified follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)