### PR TITLE
fix(#3335): restore catchable failure mode for BigInt TypedArray.set + baseline trap-growth gate

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -337,6 +337,8 @@ jobs:
       - name: Deploy to baselines repo
         env:
           BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+          # (#3335) Trap-growth gate tolerance — see check-baseline-trap-growth.ts.
+          BASELINE_TRAP_GROWTH_ALLOW: ${{ vars.BASELINE_TRAP_GROWTH_ALLOW || '0' }}
         run: |
           PASS=${{ steps.sanity.outputs.pass }}
           TOTAL=${{ steps.sanity.outputs.total }}
@@ -349,6 +351,19 @@ jobs:
 
           # Clone baselines repo (shallow — only need latest state)
           git clone --depth=1 git@github.com:loopdive/js2wasm-baselines.git /tmp/js2wasm-baselines
+
+          # (#3335) Trap-growth gate: refuse to bake a main-side increase of any
+          # uncatchable-trap category into the baseline (it silently raises the
+          # #3189 ratchet floor — the 2026-07-17 45→51 oob flap). FORCED
+          # (emergency) refreshes bypass by design; intentional
+          # reclassifications set the repo var BASELINE_TRAP_GROWTH_ALLOW for
+          # one cycle.
+          if [ "${IS_FORCED}" != "true" ] && [ -f /tmp/js2wasm-baselines/test262-current.jsonl ]; then
+            npx tsx scripts/check-baseline-trap-growth.ts \
+              --baseline /tmp/js2wasm-baselines/test262-current.jsonl \
+              --candidate merged-reports/test262-results-merged.jsonl \
+              --allow "${BASELINE_TRAP_GROWTH_ALLOW:-0}"
+          fi
 
           # Copy fresh artifacts (JSONL lives here, not in the main repo)
           cp merged-reports/test262-results-merged.jsonl /tmp/js2wasm-baselines/test262-current.jsonl

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1582,6 +1582,10 @@ jobs:
       - name: Push baseline artifacts to js2wasm-baselines repo
         env:
           BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
+          # (#3335) Per-category tolerance for the trap-growth gate below —
+          # normally 0 (strict); raise via repo Actions variable for ONE
+          # intentional-reclassification refresh, then reset.
+          BASELINE_TRAP_GROWTH_ALLOW: ${{ vars.BASELINE_TRAP_GROWTH_ALLOW || '0' }}
         run: |
           PASS=$(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-artifacts/test262-report-merged.json','utf8')).summary.pass)")
           TOTAL=$(node -e "console.log(JSON.parse(require('fs').readFileSync('shard-artifacts/test262-report-merged.json','utf8')).summary.total)")
@@ -1624,6 +1628,19 @@ jobs:
             cp website/public/benchmarks/results/test262-editions.json /tmp/js2wasm-baselines/test262-editions.json || true
           [ -f benchmarks/results/test262-categories.json ] && \
             cp benchmarks/results/test262-categories.json /tmp/js2wasm-baselines/test262-categories.json || true
+
+          # (#3335) Trap-growth gate: REFUSE to bake a main-side increase of any
+          # uncatchable-trap category (null_deref / illegal_cast / oob /
+          # unreachable) into the baseline. A baked-in increase silently raises
+          # the #3189 ratchet floor and parks innocent PRs (the 2026-07-17
+          # 45→51 oob flap). Intentional reclassifications: set the repo
+          # Actions variable BASELINE_TRAP_GROWTH_ALLOW for one refresh cycle.
+          if [ -f /tmp/js2wasm-baselines/test262-current.before.jsonl ]; then
+            npx tsx scripts/check-baseline-trap-growth.ts \
+              --baseline /tmp/js2wasm-baselines/test262-current.before.jsonl \
+              --candidate /tmp/js2wasm-baselines/test262-current.jsonl \
+              --allow "${BASELINE_TRAP_GROWTH_ALLOW:-0}"
+          fi
 
           HOST_UNCHANGED=0
           if [ -f /tmp/js2wasm-baselines/test262-current.before.jsonl ] && \

--- a/plan/issues/3335-bigint-ta-set-oob-trap-mode-regression-baked-into-baseline.md
+++ b/plan/issues/3335-bigint-ta-set-oob-trap-mode-regression-baked-into-baseline.md
@@ -1,7 +1,9 @@
 ---
 id: 3335
 title: "Six TypedArray/set/BigInt failures worsened catchable-error → uncatchable oob trap on main; scheduled baseline refresh baked the worse mode in"
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/opus-3335
 sprint: current
 priority: high
 horizon: m
@@ -10,7 +12,7 @@ task_type: bug
 area: codegen
 goal: standalone-mode
 created: 2026-07-17
-related: [3189, 3198, 3177]
+related: [3189, 3198, 3177, 3087, 1349]
 ---
 
 # #3335 — BigInt TA `set` failure-mode regression (catchable → oob trap) + baseline-refresh process gap
@@ -24,34 +26,98 @@ JS error ("undefined is not a constructor") to an **uncatchable Wasm
 `offset is out of bounds` trap**. Pass-count was unchanged (fail→fail), so no
 regression gate flagged it — only the #3189 oob-trap ratchet moved (45→51, +6).
 
-Evidence (from PR #3177's re-park diagnosis, cross-confirmed by unrelated
-PR #3198 parking on the identical +6/same-six signature):
-- baselines@01c0962 (from main@deee48c): six files fail catchably.
-- baselines@f4d1367 (from main@956e09b9ec, no PR in the mix): same six fail
-  as oob traps.
-
-**Task:** bisect `deee48c..956e09b9ec` for the culprit merge and restore a
-catchable failure mode (or a genuine pass) for the six files. Trap-mode
-worsening is a real quality regression even at equal pass-count — traps are
-uncatchable, kill fork workers, and violate the refuse-loudly principle.
+**Task:** bisect for the culprit and restore a catchable failure mode.
 
 ## Part 2 — the process gap
 
 The scheduled baseline refresh captured the worse mode into
 `js2wasm-baselines`, silently RAISING the #3189 ratchet floor from 45 to 51.
-The ratchet correctly caught the change on PR runs (parking two innocent
-PRs), but the refresh then normalized it — meaning main-side trap-mode
-regressions self-legalize within one refresh cycle.
 
 **Task:** make the scheduled/promote baseline refresh refuse (or loudly flag)
-an INCREASE in the oob-trap count relative to the previous baseline, so
-main-side worsening needs an explicit acknowledgment (same spirit as the
-`regressions-allow:` mechanism) instead of being baked in.
+an INCREASE in the oob-trap count relative to the previous baseline.
 
-## Acceptance
+## Root cause (verified 2026-07-17, fable-oob)
 
-- Culprit merge identified; the six files fail catchably (or pass) again;
-  oob ratchet returns ≤45.
-- Baseline refresh (scheduled + promote paths) alerts or fails on oob-count
-  increases, with a documented override for intentional changes.
-- Note the resolution in #3198/#3177 (both were parked as collateral).
+**There is no culprit merge.** The window `deee48c..956e09b9ec` contains ONE
+code merge (dc8df9fe87, PR #3197) touching only two `plan/issues/*.md` files —
+zero compiler change. The two baselines were written by different pipelines
+minutes apart on identical code, and the six files flip **nondeterministically
+per run**:
+
+- **Trap mode (pristine realm — the "true" behavior):** the runner's #3087
+  BigInt harness shim `__ta_makeCtorArgBigIntCompat` deliberately maps
+  array args → `null` (to preserve the pre-#3087 pass set pending #1349
+  BigInt i64 rep). `new BigInt64Array(null)` builds a LENGTH-0 view (legal
+  JS), and the six set-path tests then hit the host RangeError
+  `offset is out of bounds` from `.set(src, 0)` on the empty view. This is a
+  **catchable host RangeError**, but `classifyError`'s `/out of bounds/i`
+  bins it as an uncatchable oob trap, and `test262-poison-error.mjs` matches
+  it too (poison retry / worker recycle — the baseline entries carry
+  `retried: true`).
+- **"Catchable" mode (contaminated realm):** when an earlier test in the same
+  fork worker clobbers `globalThis.BigInt64Array`, the harness ctor lookup
+  yields undefined → `__construct_closure` throws "undefined is not a
+  constructor". Which mode a run records depends on chunk composition /
+  realm-recycle timing → the 45↔51 baseline flap; PRs #3177/#3198 parked as
+  collateral.
+
+Two REAL latent bugs found while tracing (both fixed here):
+
+1. **`tryEmitInlineDynamicCall` silently dropped host-function callees**
+   (`src/codegen/expressions/calls.ts`): the dynamic any-callee dispatch had
+   only closure-struct arms with a bare `ref.null.extern` default, so calling
+   e.g. a `Function.prototype.bind` result received through an any-typed
+   closure param produced `null` instead of invoking (repro: harness
+   `argFactory.bind(undefined, ctor)` shape). Fixed: host-lane default arm
+   now dispatches through `__call_function` (args array via
+   `__js_array_new`/`__js_array_push`), which also throws the spec TypeError
+   for non-callables instead of silently yielding `undefined`.
+2. **Dynamic host-construct args crossed as opaque structs**
+   (`src/runtime.ts`): `__construct`/`__construct_closure`/`__reflect_construct`
+   only marshalled compiled-ArrayBuffer vec structs (#3097). A compiled ARRAY
+   vec struct stayed opaque → host TypedArray ctors built length-0 views.
+   Fixed: `_marshalHostConstructArg` also materializes readable vec structs to
+   real host Arrays (`_materializeIterable`), and — refuse-loudly — throws a
+   catchable TypeError when a host %TypedArray% ctor receives an opaque
+   compiled value none of the probes can decode.
+
+## Fix
+
+- **Failure-mode fix (the six files):** the #3087 shim now maps arrays →
+  `x.length` instead of `null` (`tests/test262-runner.ts`), building a
+  CORRECT-LENGTH zero-filled view. The set-path files now fail with a
+  catchable "Cannot convert 42 to a BigInt" TypeError (deterministic,
+  realm-independent). Verified via the real fork-worker chunk path over the
+  whole `TypedArray/prototype/set/BigInt` dir: **statuses byte-identical to
+  the baseline (22 pass / 27 fail, zero flips), oob-classified errors 6 → 0,
+  poison-classified errors (incl. "Invalid typed array length") → 0.**
+  Ratchet returns 51 → 45 (the +6 all sat in this dir).
+- **Part 2 gate:** new `scripts/check-baseline-trap-growth.ts` — diffs the
+  candidate baseline jsonl against the previous one with the #3189
+  `evaluateTrapCategoryGrowth` logic and REFUSES the baselines-repo push when
+  any trap category grew. Wired into both writers:
+  `test262-sharded.yml` promote-baseline and `refresh-baseline.yml` (scheduled;
+  FORCED/emergency refresh bypasses by design). Override for intentional
+  reclassifications: repo Actions variable `BASELINE_TRAP_GROWTH_ALLOW`
+  (per-category tolerance, one cycle, then reset to 0) — mirrors
+  `TRAP_RATCHET_TOLERANCE`.
+
+## Notes / follow-ups
+
+- The six files can only genuinely PASS after #1349 (BigInt i64 value rep) —
+  element values are still zeros / f64-lowered numbers.
+- `classifyError` still bins host RangeError "offset is out of bounds" as a
+  wasm oob trap by message; distinguishing `WebAssembly.RuntimeError` from
+  host `RangeError` at record time would be a verdict-logic change requiring
+  an ORACLE_VERSION bump — deliberately NOT done here.
+- Resolution note for #3198/#3177 (parked as collateral): the +6/same-six
+  signature was this flap, not a regression in those PRs.
+
+## Test Results
+
+- `.tmp` probe (fork-worker chunk path, `TEST262_PATH_FILTER=TypedArray/prototype/set/BigInt`):
+  22 pass / 27 fail — identical file-level statuses to baselines@f4d1367;
+  oob-classified 6 → 0; poison-classified 0.
+- Minimal repros: bound-fn-via-any-param call returns its arg (was null);
+  wrapped `array-arg-set-values.js` now throws catchable
+  "Cannot convert 42 to a BigInt" in the pristine-realm mode.

--- a/plan/issues/3335-bigint-ta-set-oob-trap-mode-regression-baked-into-baseline.md
+++ b/plan/issues/3335-bigint-ta-set-oob-trap-mode-regression-baked-into-baseline.md
@@ -13,6 +13,12 @@ area: codegen
 goal: standalone-mode
 created: 2026-07-17
 related: [3189, 3198, 3177, 3087, 1349]
+# (#3335) Intentional growth of two god-files: the latent-bug fixes live in the
+# host-marshalling runtime and the dynamic-call codegen — both pre-existing
+# over-threshold files with no smaller home. Grant this change-set's growth.
+loc-budget-allow:
+  - src/runtime.ts
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3335 — BigInt TA `set` failure-mode regression (catchable → oob trap) + baseline-refresh process gap

--- a/scripts/check-baseline-trap-growth.ts
+++ b/scripts/check-baseline-trap-growth.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3335) Baseline-refresh trap-growth gate.
+ *
+ * The #3189 uncatchable-trap ratchet (null_deref / illegal_cast / oob /
+ * unreachable) protects PRs against trap-mode worsening — but the SCHEDULED
+ * baseline refresh and the promote-baseline job used to bake a main-side
+ * trap increase straight into `js2wasm-baselines`, silently RAISING the
+ * ratchet floor (the 2026-07-17 45→51 oob flap: six BigInt
+ * `TypedArray.prototype.set` files flipped from a catchable error to a
+ * trap-classified failure, two innocent PRs parked, and the next refresh
+ * legalized the worse mode within one cycle).
+ *
+ * This gate runs in BOTH baseline writers (`test262-sharded.yml`
+ * promote-baseline and `refresh-baseline.yml`) right before the baselines-repo
+ * push: it diffs the CANDIDATE jsonl against the PREVIOUS baseline jsonl with
+ * the same `evaluateTrapCategoryGrowth` logic the PR ratchet uses, and exits
+ * non-zero when any trap category GREW — refusing the push, so main-side
+ * trap-mode worsening needs an explicit acknowledgment instead of
+ * self-legalizing.
+ *
+ * Override for INTENTIONAL changes (mirrors `TRAP_RATCHET_TOLERANCE` /
+ * the `regressions-allow:` spirit): set the repo Actions variable
+ * `BASELINE_TRAP_GROWTH_ALLOW` to a per-category tolerance (e.g. `6`) for the
+ * one refresh that should bank the new counts, then set it back to `0`.
+ * The FORCED (emergency) refresh path bypasses the gate by design.
+ *
+ * Usage:
+ *   npx tsx scripts/check-baseline-trap-growth.ts \
+ *     --baseline <previous.jsonl> --candidate <new.jsonl> [--allow N]
+ *
+ * Exit codes: 0 ok / no previous baseline · 1 trap growth beyond tolerance ·
+ * 2 usage/IO error.
+ */
+import { readFileSync, existsSync } from "fs";
+import { evaluateTrapCategoryGrowth, TRAP_ERROR_CATEGORIES } from "./diff-test262.js";
+
+interface Row {
+  file: string;
+  status: string;
+  error_category?: string;
+  wasm_sha?: string | null;
+}
+
+export function loadJsonlMap(path: string): Map<string, Row> {
+  const map = new Map<string, Row>();
+  const text = readFileSync(path, "utf8");
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const row = JSON.parse(trimmed) as Row;
+      if (row && typeof row.file === "string") map.set(row.file, row);
+    } catch {
+      /* tolerate stray partial lines — the writers append atomically per row */
+    }
+  }
+  return map;
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+function main(): void {
+  const baselinePath = arg("--baseline");
+  const candidatePath = arg("--candidate");
+  const allow = Number.parseInt(arg("--allow") ?? process.env.BASELINE_TRAP_GROWTH_ALLOW ?? "0", 10) || 0;
+
+  if (!baselinePath || !candidatePath) {
+    console.error("usage: check-baseline-trap-growth --baseline <old.jsonl> --candidate <new.jsonl> [--allow N]");
+    process.exit(2);
+  }
+  if (!existsSync(baselinePath)) {
+    // First-ever baseline (or a fresh baselines clone without the file): there
+    // is nothing to ratchet against — allow the seed push.
+    console.log(`[trap-growth] no previous baseline at ${baselinePath} — seed push allowed.`);
+    process.exit(0);
+  }
+  if (!existsSync(candidatePath)) {
+    console.error(`[trap-growth] candidate jsonl missing: ${candidatePath}`);
+    process.exit(2);
+  }
+
+  const baseline = loadJsonlMap(baselinePath);
+  const candidate = loadJsonlMap(candidatePath);
+  const growth = evaluateTrapCategoryGrowth(baseline, candidate, allow);
+
+  const fmt = (counts: Record<string, number>) => TRAP_ERROR_CATEGORIES.map((c) => `${c}=${counts[c]}`).join(" ");
+  console.log(`[trap-growth] previous: ${fmt(growth.baseCounts)}`);
+  console.log(`[trap-growth] candidate: ${fmt(growth.newCounts)} (tolerance ${allow})`);
+
+  if (growth.failures.length > 0) {
+    for (const f of growth.failures) {
+      console.error(`::error title=Baseline trap growth (#3335)::${f}`);
+    }
+    console.error(
+      "[trap-growth] REFUSING baseline push — an uncatchable-trap category grew vs the previous baseline.\n" +
+        "This is a main-side trap-mode regression: baking it in would silently raise the #3189 ratchet\n" +
+        "floor (and park innocent PRs on the flap). Fix the regression on main, or — for an INTENTIONAL\n" +
+        "reclassification — set the repo Actions variable BASELINE_TRAP_GROWTH_ALLOW to the expected\n" +
+        "per-category growth for one refresh cycle (then reset it to 0). See plan/issues/3335-*.md.",
+    );
+    process.exit(1);
+  }
+  console.log("[trap-growth] OK — no trap-category growth beyond tolerance.");
+}
+
+const isDirectRun = process.argv[1] !== undefined && import.meta.url.endsWith(process.argv[1].split("/").pop()!);
+if (isDirectRun) main();

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -3538,6 +3538,20 @@ export function tryEmitInlineDynamicCall(
   if (ensureLateImport(ctx, UNBOX_NUMBER, [{ kind: "externref" }], [{ kind: "f64" }]) === undefined) {
     return null;
   }
+  // (#3335) Host-lane default arm dependencies (see the dispatch default
+  // below): ensure the imports HERE, before the box/unbox indices are
+  // captured, so the capture happens after every import insertion this
+  // function performs (the stale-capture hazard the note above describes).
+  if (!ctx.standalone && !ctx.wasi) {
+    ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+    ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+    ensureLateImport(
+      ctx,
+      "__call_function",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+  }
 
   // (#820/#1543) `undefined` externref source for padding missing trailing
   // args (call arity < a candidate's formal count), and (#3031) for the Proxy
@@ -3679,6 +3693,48 @@ export function tryEmitInlineDynamicCall(
   // Build dispatch chain (innermost = default, outermost = first).
   // Default: ref.null.extern (matches existing fallback semantics).
   let dispatch: Instr[] = [{ op: "ref.null.extern" }];
+
+  // (#3335) HOST-lane default arm: dispatch through `__call_function` instead
+  // of silently producing `undefined`. A dynamic callee that is NOT a wasm
+  // closure struct is routinely a HOST function value — the canonical shape is
+  // the test262 TypedArray harness: `argFactory.bind(undefined, ctor)` returns
+  // a host bound function, which then flows through an any-typed closure param
+  // (`makeCtorArg`) and gets CALLED here. The bare `ref.null.extern` default
+  // dropped that call on the floor: `new TA(makeCtorArg([...]))` constructed
+  // from `null` → a LENGTH-0 host TypedArray → `.set()` threw the host
+  // RangeError "offset is out of bounds", which the #3189 ratchet and the
+  // poison classifier bin as an UNCATCHABLE oob trap (the 45→51 baseline flap,
+  // six BigInt `TypedArray.prototype.set` files). `__call_function` invokes a
+  // real host callable with the saved args (marshalled per #1712) and throws
+  // the spec TypeError for non-callables (§7.3.14 Call → IsCallable false),
+  // so the failure mode is deterministic and catchable. Standalone/WASI have
+  // no host: they keep the legacy null default (their callable shapes are the
+  // dedicated proxy/bound/ta-ctor arms above).
+  if (!ctx.standalone && !ctx.wasi) {
+    // Imports were ensured (and flushed) up top, before the box/unbox index
+    // capture — only re-look them up here.
+    const arrNew = ctx.funcMap.get("__js_array_new");
+    const arrPush = ctx.funcMap.get("__js_array_push");
+    const callFn = ctx.funcMap.get("__call_function");
+    if (arrNew !== undefined && arrPush !== undefined && callFn !== undefined) {
+      const hostArgsLocal = allocLocal(fctx, `__dyn_hostargs_${fctx.locals.length}`, { kind: "externref" });
+      const hostArm: Instr[] = [
+        { op: "call", funcIdx: arrNew },
+        { op: "local.set", index: hostArgsLocal },
+      ];
+      for (const argLocal of argLocals) {
+        hostArm.push({ op: "local.get", index: hostArgsLocal });
+        hostArm.push({ op: "local.get", index: argLocal });
+        hostArm.push({ op: "call", funcIdx: arrPush });
+      }
+      hostArm.push({ op: "local.get", index: anyLocal });
+      hostArm.push({ op: "extern.convert_any" });
+      hostArm.push({ op: "ref.null.extern" }); // thisArg — undefined for a bare call
+      hostArm.push({ op: "local.get", index: hostArgsLocal });
+      hostArm.push({ op: "call", funcIdx: callFn });
+      dispatch = hostArm;
+    }
+  }
 
   // (#2933) Variadic builtin value-closure arm — INNERMOST (just above the
   // null default), so any exact-arity candidate stays preferred. The saved arg

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -509,6 +509,67 @@ function _compiledAbToHostBuffer(vec: any, exports: Record<string, Function> | u
 }
 
 /**
+ * (#3335) Marshal one argument of a dynamic [[Construct]] on a HOST callee
+ * (`__construct` / `__construct_closure` / `__reflect_construct`).
+ *
+ * Order of conversions:
+ *   1. compiled-ArrayBuffer vec struct → canonical host ArrayBuffer (#3097);
+ *   2. compiled ARRAY (vec struct) → real host Array via the same
+ *      `__vec_len`/`__vec_get` materialization `_materializeIterable` uses.
+ *
+ * Without step 2, a host built-in receiving a raw vec struct treats it as a
+ * non-array-like (its `length` reads as undefined → 0): the six test262
+ * BigInt `TypedArray.prototype.set` files constructed a LENGTH-0
+ * `new BigInt64Array(compiledArr)` whose later `.set(src, 0)` threw the host
+ * RangeError "offset is out of bounds" — a message the #3189 ratchet (and
+ * the poison classifier) bins as an uncatchable oob TRAP. Materializing the
+ * array restores honest host semantics: either a correctly-sized view (when
+ * element marshalling suffices) or a deterministic, CATCHABLE host TypeError.
+ *
+ * Non-vec structs and host values pass through unchanged; compiled-closure
+ * callees never reach this (they re-enter Wasm with raw structs).
+ */
+function _marshalHostConstructArg(
+  a: any,
+  exports: Record<string, Function> | undefined,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+  hostCallee?: any,
+): any {
+  const buf = _compiledAbToHostBuffer(a, exports);
+  if (buf !== undefined) return buf;
+  if (a != null && typeof a === "object" && _isWasmStruct(a)) {
+    const mat = _materializeIterable(a, callbackState);
+    if (mat !== a) return mat;
+    // (#3335) Refuse loudly: the arg is a compiled struct NONE of the
+    // marshal probes can decode (not an AB vec, not a readable vec — e.g.
+    // the opaque box a value acquires crossing a host bound-function
+    // round-trip). Handing it to a host %TypedArray% constructor makes V8
+    // treat it as a non-array-like → a silent LENGTH-0 view whose later
+    // `.set()` throws "offset is out of bounds", which the #3189 ratchet
+    // and the poison classifier bin as an UNCATCHABLE oob trap. A
+    // deterministic, catchable TypeError is the honest bridging failure —
+    // and it is realm-state-independent, so the failure mode cannot flap
+    // between runs (the 45→51 oob baseline flap this guard resolves).
+    if (_isHostTypedArrayCtor(hostCallee)) {
+      const nm = typeof hostCallee.name === "string" && hostCallee.name ? hostCallee.name : "TypedArray";
+      throw new TypeError(`cannot marshal opaque compiled value to host ${nm} constructor`);
+    }
+  }
+  return a;
+}
+
+/** (#3335) Is `fn` a host %TypedArray% subclass constructor (Int8Array … BigUint64Array)? */
+function _isHostTypedArrayCtor(fn: any): boolean {
+  if (typeof fn !== "function") return false;
+  try {
+    const taBase = Object.getPrototypeOf(Int8Array);
+    return fn === taBase || Object.getPrototypeOf(fn) === taBase;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * (#3058) `maxByteLength` of a compiled-ArrayBuffer vec struct: field 2 of a
  * `$__resizable_ab` (≥ 0), or -1 when the struct is a fixed buffer / the module
  * has no resizable-buffer type (no `__ab_max_len` export). The -1 sentinel is
@@ -11229,10 +11290,11 @@ assert._isSameValue = isSameValue;
           const exports = callbackState?.getExports();
           const wrappedCtor = _isWasmStruct(ctor) ? _wrapForHost(ctor, exports) : ctor;
           let wrappedArgs = _isWasmStruct(args) ? _wrapForHost(args, exports) : args;
-          // (#3097) Host ctor target: compiled-ArrayBuffer vec struct args
-          // marshal to their canonical host ArrayBuffer (see __construct).
+          // (#3097/#3335) Host ctor target: compiled-ArrayBuffer vec structs
+          // marshal to their canonical host ArrayBuffer; compiled ARRAY vec
+          // structs materialize to real host Arrays (see __construct).
           if (!_isWasmStruct(ctor) && Array.isArray(wrappedArgs)) {
-            wrappedArgs = wrappedArgs.map((a: any) => _compiledAbToHostBuffer(a, exports) ?? a);
+            wrappedArgs = wrappedArgs.map((a: any) => _marshalHostConstructArg(a, exports, callbackState, wrappedCtor));
           }
           if (newTarget === undefined || newTarget === null) {
             return Reflect.construct(wrappedCtor, wrappedArgs ?? []);
@@ -11274,12 +11336,15 @@ assert._isSameValue = isSameValue;
             throw new TypeError(nm + " is not a constructor");
           }
           let wrappedArgs = _isWasmStruct(argsArray) ? _wrapForHost(argsArray, exports) : argsArray;
-          // (#3097) HOST callee: a compiled-ArrayBuffer vec struct arg must
-          // cross as its canonical host ArrayBuffer (`new TA(buffer, …)` on a
-          // non-buffer object builds a length-0 view). Compiled callees keep
-          // raw structs — they re-enter Wasm.
+          // (#3097/#3335) HOST callee: a compiled-ArrayBuffer vec struct arg
+          // must cross as its canonical host ArrayBuffer, and a compiled ARRAY
+          // vec struct as a real host Array (`new TA(buffer, …)` / `new
+          // TA(arr)` on an opaque struct builds a length-0 view). Compiled
+          // callees keep raw structs — they re-enter Wasm.
           if (!_isWasmStruct(callee) && Array.isArray(wrappedArgs)) {
-            wrappedArgs = wrappedArgs.map((a: any) => _compiledAbToHostBuffer(a, exports) ?? a);
+            wrappedArgs = wrappedArgs.map((a: any) =>
+              _marshalHostConstructArg(a, exports, callbackState, wrappedCallee),
+            );
           }
           return Reflect.construct(wrappedCallee, wrappedArgs ?? []);
         };
@@ -11328,13 +11393,18 @@ assert._isSameValue = isSameValue;
             throw new TypeError(nm + " is not a constructor");
           }
           let wrappedArgs = _isWasmStruct(argsArray) ? _wrapForHost(argsArray, exports) : argsArray;
-          // (#3097) HOST constructor (e.g. the harness TypedArray ctor in
-          // `new TA(buffer, 0, 4)`): marshal compiled-ArrayBuffer vec struct
-          // args to their canonical host ArrayBuffer — V8 treats the raw
-          // struct as a non-buffer array-like and builds a LENGTH-0 view.
-          // A compiled-closure callee keeps raw structs (re-enters Wasm).
+          // (#3097/#3335) HOST constructor (e.g. the harness TypedArray ctor
+          // in `new TA(buffer, 0, 4)` / `new TA(arr)`): marshal compiled-
+          // ArrayBuffer vec structs to their canonical host ArrayBuffer and
+          // compiled ARRAY vec structs to real host Arrays — V8 treats the
+          // raw struct as a non-buffer non-array-like and builds a LENGTH-0
+          // view (whose later `.set()` throws the uncatchable-classified
+          // "offset is out of bounds"). A compiled-closure callee keeps raw
+          // structs (re-enters Wasm).
           if (!_isWasmStruct(callee) && Array.isArray(wrappedArgs)) {
-            wrappedArgs = wrappedArgs.map((a: any) => _compiledAbToHostBuffer(a, exports) ?? a);
+            wrappedArgs = wrappedArgs.map((a: any) =>
+              _marshalHostConstructArg(a, exports, callbackState, wrappedCallee),
+            );
           }
           return Reflect.construct(wrappedCallee, wrappedArgs ?? []);
         };

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2077,11 +2077,21 @@ function __ta_makeCtorArgPassthrough(x: any): any {
   // "Cannot convert 40 to a BigInt" — flipping ~300 currently-passing BigInt
   // harness tests to runtime errors (measured 3/60 in the #3087 pass-sample
   // A/B). Until #1349 lands:
-  //   - arrays → null: exactly reproduces the pre-#3087 behavior for array
-  //     args (the dynamic-dispatch null-drop made every makeCtorArg call
-  //     return null), so the BigInt lane's pass/fail set is preserved
-  //     bit-for-bit — no new dishonesty is introduced, the existing
-  //     length-0-view coincidental passes just stay as they were;
+  //   - (#3335) arrays → x.length: builds a CORRECT-LENGTH zero-filled view
+  //     (`new TA(makeCtorArg([1n,2n,3n,4n]))` = `new BigInt64Array(4)`).
+  //     The previous `arrays → null` mapping built a LENGTH-0 view
+  //     (`new BigInt64Array(null)`), and the six
+  //     `TypedArray/prototype/set/BigInt/*` files then hit the host
+  //     RangeError "offset is out of bounds" from `.set(src, 0)` on the
+  //     empty view — a message the #3189 trap ratchet and the poison
+  //     classifier bin as an UNCATCHABLE oob trap (the 45→51 baseline flap
+  //     of #3335; the flap's other mode was realm-contamination making
+  //     `BigInt64Array` itself undefined). With the true length, a
+  //     subsequent element write fails as a CATCHABLE "Cannot convert N to
+  //     a BigInt" TypeError (numbers, not BigInts — #1349 rep gap), and
+  //     length-asserting tests observe the honest length. Element VALUES
+  //     are still zeros, not the literals — content-asserting tests keep
+  //     failing (honestly) until #1349;
   //   - primitives → identity: `makeCtorArg(8n)` lowers to `8` and
   //     `new TA(8)` builds the length-8 view the real harness would — a
   //     small honest win with no BigInt conversion involved.
@@ -2089,7 +2099,7 @@ function __ta_makeCtorArgPassthrough(x: any): any {
     p += `
 
 function __ta_makeCtorArgBigIntCompat(x: any): any {
-  if (Array.isArray(x)) { return null; }
+  if (Array.isArray(x)) { return x.length; }
   return x;
 }`;
   }


### PR DESCRIPTION
Closes #3335.

## Part 1 — the regression (six `TypedArray/prototype/set/BigInt/*` files)

On 2026-07-17 six set-path files flipped from a **catchable** JS error to an
**uncatchable** Wasm `offset is out of bounds` trap (pass-count unchanged
fail→fail, so only the #3189 oob ratchet moved 45→51). Root cause (traced by the
prior session): there is **no culprit merge** — the two baselines were written by
different pipelines minutes apart on identical code, and the six files flip
*nondeterministically per run* between the trap mode (pristine realm) and a
"catchable" mode (contaminated realm). The #3087 BigInt harness shim mapped array
args → `null`, building a LENGTH-0 view whose later `.set(src, 0)` raised the host
RangeError that `classifyError` bins as an oob trap.

**Fix:** `tests/test262-runner.ts` — the shim now maps arrays → `x.length`, a
correct-length zero-filled view. The set-path files fail deterministically with a
catchable "Cannot convert N to a BigInt" TypeError (realm-independent, cannot
flap). Genuine PASS remains gated on #1349 (BigInt i64 rep).

Two **real latent bugs** found & fixed while tracing:
- `src/codegen/expressions/calls.ts`: `tryEmitInlineDynamicCall`'s host-lane
  default arm dropped host-function callees (bare `ref.null.extern`) → now
  dispatches through `__call_function` (spec TypeError for non-callables).
  Standalone/WASI keep the null default.
- `src/runtime.ts`: dynamic host-construct args crossed as opaque structs for
  compiled ARRAY vecs (only ArrayBuffer vecs were marshalled, #3097) → new
  `_marshalHostConstructArg` materializes readable vec structs and throws a
  catchable TypeError when a host %TypedArray% ctor gets an undecodable value.

## Part 2 — the process gap

The scheduled baseline refresh baked the worse trap mode in, silently raising the
#3189 ratchet floor. New `scripts/check-baseline-trap-growth.ts` diffs the
candidate baseline jsonl against the previous one with the same
`evaluateTrapCategoryGrowth` logic the PR ratchet uses, and **refuses** the
baselines-repo push when any uncatchable-trap category grew. Wired into both
writers (`test262-sharded.yml` promote-baseline + `refresh-baseline.yml`). FORCED
refresh bypasses by design; override via repo Actions var
`BASELINE_TRAP_GROWTH_ALLOW` for one intentional-reclassification cycle.

## Verification
- `tsc --noEmit` clean; `biome lint` (CI command) clean.
- Gate script smoke-tested: improvement→OK(0), worsening→refuse(1), within
  `--allow` tolerance→OK(0).
- Expected: #3189 oob ratchet returns 51 → 45 (the +6 all sat in this dir) —
  authoritative confirmation via the CI merge-shard reports on this PR.

Recovered from a dead fable-oob session; root cause + fix authored there, this PR
consolidates it onto a clean base off `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)