### PR TITLE
docs(plan): file stronger-model audit gaps

### DIFF
--- a/plan/issues/3337-wasi-process-argv-args-get.md
+++ b/plan/issues/3337-wasi-process-argv-args-get.md
@@ -18,6 +18,7 @@ complexity: M
 related: [1035, 1482, 1490, 1532, 1801, 3340]
 origin: "2026-07-17 current-origin/main PO audit, corrected by second-pass probe: process.argv validates but returns an empty import-free vector"
 ---
+
 # #3337 - WASI `process.argv` must materialize through `args_get`
 
 ## Problem

--- a/plan/issues/3337-wasi-process-argv-args-get.md
+++ b/plan/issues/3337-wasi-process-argv-args-get.md
@@ -1,6 +1,6 @@
 ---
 id: 3337
-title: "wasi: lower process.argv through args_get instead of invalid native-string path"
+title: "wasi: materialize process.argv through args_get instead of a silent empty vector"
 status: ready
 created: 2026-07-17
 updated: 2026-07-17
@@ -14,30 +14,45 @@ goal: standalone-mode
 sprint: Backlog
 horizon: m
 es_edition: n/a
-related: [1035, 1482, 1490, 1532, 1801]
-origin: "2026-07-17 current-origin/main PO audit: tests/real-world-wasi.test.ts marks process.argv under --target wasi as invalid-binary it.fails"
+complexity: M
+related: [1035, 1482, 1490, 1532, 1801, 3340]
+origin: "2026-07-17 current-origin/main PO audit, corrected by second-pass probe: process.argv validates but returns an empty import-free vector"
 ---
-
-# #3337 - WASI `process.argv` must lower through `args_get`
+# #3337 - WASI `process.argv` must materialize through `args_get`
 
 ## Problem
 
-`process.argv` under `--target wasi` reports compile success but emits an
-invalid WebAssembly module. The current tests document this as an `it.fails`
-sentinel, and the previous WASI invalid-binary issue explicitly deferred it as a
-separate native-string argv defect.
+`process.argv` under `--target wasi` reports compile success and emits valid
+WebAssembly, but the module has no argv imports and silently exposes an empty
+vector. A direct runtime probe returns `argc() === 0` even when the host has
+arguments. The current `it.fails` test and its invalid-binary comment are stale:
+the assertion now passes, so Vitest fails only because an expected failure
+unexpectedly passed.
 
 The fix should implement a real WASI argv path, not reuse the Node host-import
 path and not narrow the behavior to a JS polyfill-only shortcut.
 
 ## Evidence on current `origin/main`
 
-- `tests/real-world-wasi.test.ts:39-58` marks `"reads process.argv as a valid
-WASI module"` as `it.fails`; the comment says `process.argv.length` compiles
-  successfully but emits an invalid binary in `__str_flatten`.
-- #1801 recorded this as out of scope and said "the native-string argv defect
-  should get its own issue" at
-  `plan/issues/1801-wasi-process-exit-invalid-binary.md:121-129`.
+- `tests/real-world-wasi.test.ts:39-58` still marks `"reads process.argv as a
+valid WASI module"` as `it.fails` and describes an `__str_flatten`
+  invalid-binary failure. On current main, focused execution reports
+  `Expect test to fail`: both `result.success` and `WebAssembly.validate` are
+  now `true`.
+
+  ```ts
+  declare const process: { argv: string[] };
+  export function argc(): number {
+    return process.argv.length;
+  }
+  ```
+
+- A current-main runtime probe of that exact source reports no module imports,
+  instantiates with `buildWasiPolyfill()`, and returns `argc() === 0`. It does
+  not import `wasi_snapshot_preview1.args_sizes_get` or `args_get`.
+- #1801 recorded the then-observed native-string failure as out of scope at
+  `plan/issues/1801-wasi-process-exit-invalid-binary.md:121-129`. The failure
+  mode has changed, but the deferred argv semantics remain unimplemented.
 - The implemented `process.argv` runtime path is explicitly non-WASI:
   `src/codegen/property-access-dispatch.ts:1524-1549` gates the Node
   `__get_process_argv` import on `!ctx.wasi`.
@@ -54,7 +69,7 @@ WASI module"` as `it.fails`; the comment says `process.argv.length` compiles
   syscall suite at `plan/issues/1532-wasi-syscall-unit-test-suite.md:26-33`,
   but its acceptance is "PR is tests-only" at
   `plan/issues/1532-wasi-syscall-unit-test-suite.md:69-77`. It cannot fix this
-  compiler/runtime invalid-binary path.
+  compiler/runtime behavior.
 - `src/runtime/wasi-polyfill.ts:24-35` exposes fd, env, clock, and memory
   helpers but no `args_sizes_get` / `args_get` shims or `{ args }` option.
 - `src/codegen/wasi.ts:498-525` shows the current `process.env` precedent:
@@ -63,18 +78,18 @@ WASI module"` as `it.fails`; the comment says `process.argv.length` compiles
 
 ## Impact
 
-WASI CLI programs cannot inspect their arguments. Worse, the compiler returns
-`success: true` and emits a module that does not validate, so users get a late
-binary failure instead of either working argv support or a clear compile-time
-unsupported diagnostic. This blocks normal standalone command-line programs and
-keeps a known invalid-binary sentinel in the real-world WASI suite.
+WASI CLI programs cannot inspect their arguments, and the failure is silent:
+valid-looking programs compile, instantiate, and observe the wrong argc rather
+than receiving an unsupported-feature diagnostic. That can misconfigure real
+command-line programs without any compilation or runtime signal. The stale
+expected-failure sentinel also pollutes the root issue-test baseline (#3340).
 
 ## Root cause / unknowns
 
-The likely root cause is that WASI `process.argv` falls through to a generic
-array/native-string path instead of registering `args_sizes_get` and `args_get`
-and materializing a guest `string[]`. The implementation must confirm the exact
-current lowering route before patching it.
+The exact current lowering route is unknown. It no longer reaches the old
+invalid native-string path; instead, it produces an import-free value whose
+length is zero. The implementation must trace where `process.argv` is replaced
+or defaulted before adding `args_sizes_get` / `args_get` materialization.
 
 Open semantic choices for the implementer:
 
@@ -83,7 +98,7 @@ Open semantic choices for the implementer:
   chosen contract and keep tests consistent with it.
 - Whether the first slice supports only `.length` and indexed reads, or full
   array iteration. If only a subset is shipped, unsupported operations must
-  fail loudly instead of emitting invalid Wasm.
+  fail loudly instead of silently returning incomplete data.
 
 ## Proposed approach
 
@@ -99,14 +114,14 @@ Open semantic choices for the implementer:
 4. Keep the Node host import path in `property-access-dispatch.ts` gated to
    non-WASI mode. WASI modules should import only `wasi_snapshot_preview1`
    functions for argv unless a documented test-only polyfill import is needed.
-5. Replace the `it.fails` sentinel with executable validity/runtime coverage.
+5. Replace the stale `it.fails` sentinel with executable import, validity, and
+   runtime coverage.
 
 ## Non-goals
 
 - Reworking Node host-mode `process.argv` (#1490).
 - Implementing all Node `process` APIs in WASI mode.
-- Solving unrelated native-string invalid-binary buckets such as the broader
-  standalone `__str_flatten` residuals.
+- Solving unrelated native-string invalid-binary buckets.
 - Implementing WASI component-model `wasi:cli/environment`; this issue targets
   preview1 `args_sizes_get` / `args_get`.
 
@@ -115,30 +130,30 @@ Open semantic choices for the implementer:
 - Related: #1482 (`process.env`/`environ_get`) is the closest implementation
   precedent.
 - Related: #1801 fixed `process.exit` invalid-binary behavior and documented
-  this argv defect as separate.
+  argv as separate work.
 - Related: #1490 covers Node host mode and must not be regressed.
 - Related: #1532 should use this issue's implementation as the prerequisite for
   its argv syscall-suite case; it is not an implementation owner.
-- No open issue currently owns WASI argv support.
+- Related: #3340 owns expected-failure/baseline hygiene, not argv semantics.
+- No open issue other than this one owns WASI argv support.
 
 ## Why this is not already covered
 
-#1801 explicitly deferred this bug. #1490 is Node-host-only, #1482 is env-only,
-#1532 is tests-only, and #1035's old follow-up pointer is stale. Searches for
-`args_get`, `args_sizes_get`, and `process.argv` on current `origin/main` find
-no open implementation issue or code path that turns the existing `it.fails`
-into a valid WASI module.
+#1801 explicitly deferred argv work. #1490 is Node-host-only, #1482 is env-only,
+#1532 is tests-only, #3340 is gate hygiene only, and #1035's old follow-up
+pointer is stale. Searches for `args_get`, `args_sizes_get`, and `process.argv`
+on current `origin/main` find no implementation owner that supplies host argv
+to the guest.
 
 ## Acceptance criteria
 
-- [ ] The `tests/real-world-wasi.test.ts` `it.fails("reads process.argv as a
-valid WASI module", ...)` sentinel is converted to a passing test.
+- [ ] The stale `tests/real-world-wasi.test.ts` `it.fails` sentinel and
+      invalid-binary comment are replaced with a passing runtime contract test.
 - [ ] `process.argv.length` under `{ target: "wasi" }` returns the documented
       argc value with a deterministic test argv source.
 - [ ] At least one indexed read test, for example `process.argv[1].length` or a
       string equality check, validates that argv strings are materialized
-      correctly and do not pass through `__str_flatten` with invalid operand
-      types.
+      correctly.
 - [ ] The emitted WASI module validates with `WebAssembly.validate(binary) ===
 true` and instantiates with `buildWasiPolyfill({ args: [...] })`.
 - [ ] The module's argv imports come from `wasi_snapshot_preview1`

--- a/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
+++ b/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
@@ -18,6 +18,7 @@ complexity: S
 related: [953, 1858, 1927, 1950, 2143, 3024]
 origin: "2026-07-17 stronger-model current-origin/main audit: CLI exits 0 and writes a validator-rejected private-field-in artifact in default and --no-optimize modes"
 ---
+
 # #3338 - CLI must refuse invalid Wasm artifacts
 
 ## Problem

--- a/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
+++ b/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
@@ -1,0 +1,151 @@
+---
+id: 3338
+title: "cli: refuse to write invalid Wasm artifacts after optimizer fallback"
+status: ready
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: cli, compiler, optimizer
+language_feature: compiler-output-validation
+goal: trustworthiness
+sprint: Backlog
+horizon: s
+es_edition: n/a
+complexity: S
+related: [953, 1858, 1927, 1950, 2143, 3024]
+origin: "2026-07-17 stronger-model current-origin/main audit: CLI exits 0 and writes a validator-rejected private-field-in artifact in default and --no-optimize modes"
+---
+# #3338 - CLI must refuse invalid Wasm artifacts
+
+## Problem
+
+The CLI treats `CompileResult.success` as sufficient to publish output. When
+codegen returns `success: true` with an invalid binary, the default optimizer
+reports a validator warning and returns the original bytes; the CLI then exits
+zero and writes those bytes. `--no-optimize` writes the same invalid module
+without even the optimizer warning.
+
+Users therefore receive a `.wasm`, `.wat`, and imports helper accompanied by a
+success exit code even though the primary artifact cannot be instantiated.
+
+## Evidence on current `origin/main`
+
+This reduced source is distilled from
+`test/language/expressions/in/private-field-rhs-non-object.js`:
+
+```js
+let caught = null;
+class C {
+  #field;
+  constructor() {
+    try {
+      #field in {} << 0;
+    } catch (error) {
+      caught = error;
+    }
+  }
+}
+new C();
+```
+
+- Running `src/cli.ts` normally exits `0`, prints the generated artifact paths,
+  and writes an 808-byte Wasm file. The warning says `wasm-opt -O3 failed` and
+  identifies `C_init` with `local.tee` producing `f64` for a reference local.
+  `WebAssembly.validate` on the written file is `false`.
+- Running the same CLI command with `--no-optimize` also exits `0`, writes the
+  same 808-byte invalid Wasm, and has no optimizer validator diagnostic.
+- `src/cli.ts:383-395` gates failure only on `result.success`, then
+  `src/cli.ts:438-448` writes `result.binary` and `result.wat` without a binary
+  validation boundary.
+- `src/compiler.ts:671-685` turns optimizer failure into a warning without
+  changing `success`.
+- `src/optimize.ts:208-223` presumes the input is valid and returns the original
+  binary after a native `wasm-opt` error; the fallback at
+  `src/optimize.ts:236-245` likewise describes shipping unoptimized output.
+- The current committed test262 summary records 138 `wasm_compile` failures,
+  and #3024 already includes the private-field `in` family. The producer bug is
+  real and separately owned; this issue is the missing user-facing publication
+  boundary.
+
+## Impact
+
+A compiler CLI that exits successfully after writing an invalid primary
+artifact breaks shell automation, build caches, package publishing, and user
+trust. Fixing individual emitter bugs cannot close this systemic boundary: any
+new malformed-Wasm producer can recur until the CLI validates before publishing.
+
+## Root cause / unknowns
+
+`CompileResult.success` currently means code generation completed, not that the
+binary validates. The optimizer deliberately preserves the original binary on
+failure, and the CLI has no final validation step. The implementation must
+decide whether to validate in memory before any output is written or stage all
+artifacts and publish atomically after validation; the small in-memory check is
+the expected first slice.
+
+## Proposed approach
+
+1. Add a CLI publication guard after compilation/optimization and before the
+   `--wat` stdout path or any output-file write.
+2. Validate `result.binary` with `WebAssembly.validate`; on failure, emit a
+   concise fatal diagnostic, optionally obtaining the first engine validation
+   detail from `new WebAssembly.Module(result.binary)`.
+3. Exit nonzero and write no `.wasm`, `.wat`, `.d.ts`, or imports-helper files
+   when the primary binary is invalid.
+4. Add subprocess tests for both default `-O3` and `--no-optimize`, following
+   the CLI patterns in `tests/issue-1950-default-optimization.test.ts`.
+5. Keep ordinary optimizer-availability warnings nonfatal when the preserved
+   binary itself validates.
+
+## Non-goals
+
+- Fixing the private-field `in` emitter defect or the wider #3024 bucket.
+- Changing the programmatic `compile()` API's definition of `success`; that
+  broader contract needs separate compatibility analysis.
+- Making every warning fatal.
+- Replacing Binaryen or changing optimization policy for valid input.
+
+## Dependencies / related issues
+
+- No hard dependency: the CLI can protect users before #3024 is fully fixed.
+- #3024 owns default-lane malformed-Wasm producers, including this source
+  family; it does not own CLI artifact publication.
+- #2143 validates binaries in the differential harness, not the CLI boundary.
+- #1927/#1950 own optimizer plumbing and default optimization behavior.
+- #953 is done and claimed CLI validation in acceptance, but current source and
+  the executable probe show that invariant is not present today.
+
+## Why this is not already covered
+
+Existing malformed-Wasm issues repair producer families. #2143 classifies
+malformed output in a test harness. #953 is closed, and its intended CLI guard
+is absent from current main. Searches across open issues, CLI tests, and
+optimizer tests find no active owner for refusing the final invalid artifact in
+both optimized and unoptimized CLI modes.
+
+## Acceptance criteria
+
+- [ ] The reduced private-field source exits nonzero through the default CLI
+      pipeline and creates none of its normal output artifacts.
+- [ ] The same source with `--no-optimize` exits nonzero and creates no output
+      artifacts.
+- [ ] The fatal diagnostic states that the emitted Wasm failed validation and
+      includes the first available engine/validator detail.
+- [ ] A representative valid source still exits zero and emits all requested
+      artifacts in default and `--no-optimize` modes.
+- [ ] An unavailable/failing optimizer remains a warning, not a fatal error,
+      when the original binary validates.
+- [ ] Focused tests exercise the real CLI as a subprocess and assert exit code,
+      stderr, and filesystem side effects.
+
+## Validation plan
+
+- Run the new `tests/issue-3338-*.test.ts` subprocess suite.
+- Run `pnpm test tests/issue-1950-default-optimization.test.ts` plus existing
+  CLI output/flag tests.
+- Run the reduced source manually in both modes and call
+  `WebAssembly.validate` on any artifact; no invalid artifact may remain.
+- Run `pnpm run typecheck`, `pnpm run lint`, and `pnpm run format:check`.

--- a/plan/issues/3339-compileproject-axios-core-oom.md
+++ b/plan/issues/3339-compileproject-axios-core-oom.md
@@ -19,6 +19,7 @@ related: [1032, 1571, 1693, 1927]
 needs_architect_spec: true
 origin: "2026-07-17 stronger-model current-origin/main audit: compileProject on axios/lib/core/Axios.js exhausts a 512 MB heap after about 85 seconds"
 ---
+
 # #3339 - Bound `compileProject` expansion on Axios core
 
 ## Problem

--- a/plan/issues/3339-compileproject-axios-core-oom.md
+++ b/plan/issues/3339-compileproject-axios-core-oom.md
@@ -1,0 +1,162 @@
+---
+id: 3339
+title: "compiler: bound compileProject graph expansion on axios core instead of OOM"
+status: backlog
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: compiler, resolver, codegen
+language_feature: multi-module-compilation
+goal: npm-library-support
+sprint: Backlog
+horizon: l
+es_edition: multi
+complexity: L
+related: [1032, 1571, 1693, 1927]
+needs_architect_spec: true
+origin: "2026-07-17 stronger-model current-origin/main audit: compileProject on axios/lib/core/Axios.js exhausts a 512 MB heap after about 85 seconds"
+---
+# #3339 - Bound `compileProject` expansion on Axios core
+
+## Problem
+
+`compileProject("node_modules/axios/lib/core/Axios.js", { allowJs: true })`
+does not return. On current main it consumes a CPU core, grows to the V8 heap
+limit, and terminates with an out-of-memory fatal error instead of producing a
+compile result or bounded diagnostic.
+
+This is the dominant unresolved Axios Tier 1 blocker: every surveyed entry that
+reaches the core Axios graph exhibits the same nontermination class.
+
+## Evidence on current `origin/main`
+
+- A fresh isolated probe against installed `axios@1.16.1` reached
+  `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of
+memory` after about 84.5 seconds with a roughly 510 MB V8 heap. A Vitest
+  timeout could not interrupt it because compilation is synchronous.
+
+  ```ts
+  import { compileProject } from "./src/index.ts";
+  compileProject("node_modules/axios/lib/core/Axios.js", { allowJs: true });
+  ```
+
+- `package.json:170` pins Axios as `^1.16.1`; the installed audited package is
+  1.16.1.
+- `tests/stress/axios-tier1.test.ts:23-30` still labels this blocker `#TBD-1`,
+  and `tests/stress/axios-tier1.test.ts:164-183` keeps Tier 1e skipped because
+  `compileProject` never returns.
+- `plan/issues/1571-axios-tier1-survey.md:78-144` documents four affected entry
+  points and explicitly proposes a follow-on issue, but the survey is not an
+  implementation owner.
+- `node_modules/axios/lib/core/Axios.js:3-11` imports `utils`, `buildURL`,
+  `InterceptorManager`, `dispatchRequest`, `mergeConfig`, `buildFullPath`,
+  `validator`, `AxiosHeaders`, and transitional defaults before defining
+  `Axios` at line 22. This is the shared graph root identified by the survey.
+
+  ```js
+  import utils from "../utils.js";
+  import InterceptorManager from "./InterceptorManager.js";
+  import dispatchRequest from "./dispatchRequest.js";
+  import mergeConfig from "./mergeConfig.js";
+  import AxiosHeaders from "./AxiosHeaders.js";
+  ```
+
+- #1693 treats Axios full-graph nontermination as out of scope and points back
+  to #1571's proposed new issue. No dedicated canonical issue was filed.
+
+## Impact
+
+An unbounded compiler process is worse than an unsupported-library diagnostic:
+it can kill editor services, CI workers, build daemons, and user processes. It
+also prevents progress on four Axios survey entries and makes the Tier 1 test
+unsafe to enable in-process. A bounded architecture fix may improve other large
+or cyclic package graphs even if Axios exposes the first known trigger.
+
+## Root cause / unknowns
+
+The root cause is not yet established. #1571 records three hypotheses:
+module-resolution cycles, repeated IR/type/lowering work, or unbounded object
+method trampoline emission. The OOM confirms growth rather than a passive
+deadlock, but does not identify the responsible phase. An architect must first
+specify phase instrumentation, graph invariants, and the correct ownership of
+deduplication or cycle detection before implementation is dispatched.
+
+## Proposed approach
+
+1. Produce an architect-approved diagnostic spec that timestamps phases and
+   counts resolved modules, lowered declarations/functions, generated
+   trampolines/helpers, and revisits by stable source/symbol identity.
+2. Run the real probe in a child process with explicit heap and wall-clock
+   limits so diagnosis and CI can fail without taking down the test worker.
+3. Bisect `Axios.js` imports or generate a reduced cyclic/dynamic-dispatch graph
+   that preserves the unbounded counter.
+4. Add the missing visited-set, memoization, or fixed-point convergence
+   invariant at the phase identified by evidence. Do not add a
+   package-name-specific bailout.
+5. Turn Tier 1e into a bounded compile-and-validate regression test and replace
+   `#TBD-1` references with this issue ID.
+
+## Non-goals
+
+- Making `axios.get()` perform real HTTP I/O; Tier 1f also depends on async and
+  Node host APIs.
+- Fixing the separate `AxiosHeaders_set` and `isBuffer` validator failures from
+  #1571.
+- Raising V8 heap limits or extending timeouts as the fix.
+- Special-casing Axios paths, source text, or package identity.
+- Dispatching implementation before the architecture/phase-attribution spec.
+
+## Dependencies / related issues
+
+- No code prerequisite is known, but implementation is blocked on the
+  architect spec required by this issue.
+- #1032 is the Axios support parent.
+- #1571 is the verified survey and historical hypothesis source; its own scope
+  assigns follow-on issue creation to PO triage.
+- #1693 explicitly leaves this full-graph blocker out of scope.
+- #1927 unified compile entry-point options but does not bound project graph
+  expansion.
+
+## Why this is not already covered
+
+#1571 names the defect as `NEW issue 1` and #TBD-1, but remains a survey issue;
+it provides no independently dispatchable acceptance contract. #1032 is a
+product goal, while #1693 and the other Axios blockers explicitly exclude this
+nontermination path. Searches for the four affected entry points, `#TBD-1`, and
+the reported hang found no canonical implementation issue.
+
+## Acceptance criteria
+
+- [ ] An architect-approved implementation spec identifies the growing phase,
+      stable identity key, convergence invariant, and safe ownership boundary.
+- [ ] A reduced reproducer or phase-counter trace proves the root cause; the
+      issue implementation notes reject or confirm each #1571 hypothesis.
+- [ ] The real Axios core probe runs in an isolated child process and cannot OOM
+      the main test runner even on regression.
+- [ ] With a 1 GB child-process heap limit, compiling
+      `node_modules/axios/lib/core/Axios.js` returns within 120 seconds without
+      a heap OOM.
+- [ ] The child process returns a serialized `CompileResult` instead of being
+      killed for timeout or heap exhaustion. Success and binary validity are
+      recorded, but independently scoped Axios validator defects do not expand
+      this nontermination issue.
+- [ ] Axios Tier 1e's bounded-completion rung is enabled, `#TBD-1` is replaced
+      with `#3339`, and any remaining compile/validation assertion is split
+      behind its exact independently filed blocker.
+- [ ] A reduced cycle/memoization regression guards the responsible compiler
+      phase.
+- [ ] Existing React, ESLint, and lodash project-compilation stress tests do not
+      regress materially in time, memory, or output validity.
+
+## Validation plan
+
+- Run the reduced phase-invariant test under the normal Vitest worker.
+- Run the Axios probe through a child process with `--max-old-space-size=1024`
+  and a hard 120-second parent watchdog.
+- Run `pnpm test tests/stress/axios-tier1.test.ts` and the existing React,
+  ESLint, and lodash Tier 1 compile tests.
+- Capture before/after phase counters and peak RSS in implementation notes.
+- Run standard typecheck, lint, format, and issue-specific gates.

--- a/plan/issues/3340-issue-tests-unexpected-pass-baseline.md
+++ b/plan/issues/3340-issue-tests-unexpected-pass-baseline.md
@@ -18,6 +18,7 @@ complexity: M
 related: [2143, 2787, 3008, 3337]
 origin: "2026-07-17 stronger-model current-origin/main audit: root baseline records two now-valid malformed-Wasm guards and a WASI it.fails unexpected pass as ordinary failures"
 ---
+
 # #3340 - Keep expected-failure inversions out of the root baseline
 
 ## Problem

--- a/plan/issues/3340-issue-tests-unexpected-pass-baseline.md
+++ b/plan/issues/3340-issue-tests-unexpected-pass-baseline.md
@@ -1,0 +1,163 @@
+---
+id: 3340
+title: "issue-tests: keep inverted expected-failure sentinels out of the root baseline"
+status: ready
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: test
+area: ci, test-infra
+language_feature: regression-gating
+goal: quality-infra
+sprint: Backlog
+horizon: s
+es_edition: n/a
+complexity: M
+related: [2143, 2787, 3008, 3337]
+origin: "2026-07-17 stronger-model current-origin/main audit: root baseline records two now-valid malformed-Wasm guards and a WASI it.fails unexpected pass as ordinary failures"
+---
+# #3340 - Keep expected-failure inversions out of the root baseline
+
+## Problem
+
+The root issue-test gate classifies every failed Vitest assertion as an ordinary
+known failure. It cannot distinguish a real regression from an `it.fails` test
+whose body now passes, or from a stale negative sentinel that still expects
+valid output to be malformed. Bootstrap consequently absorbed three
+improvements as baseline rot, so main can stay green while tests demand obsolete
+bad behavior.
+
+## Evidence on current `origin/main`
+
+- `tests/issue-2143-validate-unoptimized.test.ts:27-45` labels
+  `array/02-push-pop.js` and `control/12-for-in-object.js` as
+  `KNOWN_MALFORMED` and asserts `WebAssembly.validate(...) === false`.
+  Current-main focused execution fails both assertions because both binaries
+  now validate. The representative positive guard passes.
+
+  ```ts
+  const KNOWN_MALFORMED = ["array/02-push-pop.js", "control/12-for-in-object.js"];
+  expect(r.success).toBe(true);
+  expect(WebAssembly.validate(r.binary)).toBe(false);
+  ```
+
+- `tests/real-world-wasi.test.ts:39-58` is `it.fails`, but its only assertions
+  (`success` and binary validity) both pass. Vitest reports `Expect test to
+fail`; #3337 separately owns the still-missing argv runtime semantics.
+- The current `loopdive/js2wasm-baselines/issue-tests-baseline.json` includes
+  all three exact failure IDs, so they are treated as accepted main failures
+  rather than ratchet work:
+
+  ```text
+  tests/issue-2143-validate-unoptimized.test.ts :: #2143 ... array/02-push-pop.js ...
+  tests/issue-2143-validate-unoptimized.test.ts :: #2143 ... control/12-for-in-object.js ...
+  tests/real-world-wasi.test.ts :: real-world: WASI command-line programs reads process.argv as a valid WASI module
+  ```
+
+- `scripts/issue-tests-gate.mjs:141-159` puts every failed assertion into one
+  `failing` set based only on `a.status`.
+- `scripts/issue-tests-gate.mjs:162-180` serializes/merges only `failing` and
+  `passing`; no unexpected-pass class survives sharding.
+- `scripts/issue-tests-gate.mjs:188-215` writes or bootstraps every failure into
+  `knownFailures`, then computes improvements only when an ID appears in the
+  passing set. An inverted sentinel can therefore never self-ratchet.
+- #3008's completed implementation explicitly left post-bootstrap rot-cluster
+  triage as follow-up work at
+  `plan/issues/3008-issue-tests-not-in-required-ci.md:105-110`.
+
+## Impact
+
+The gate currently turns compiler improvements into permanent accepted
+failures. That hides stale test intent, inflates the baseline, and can later
+encourage developers to preserve or reintroduce invalid output just to satisfy
+an obsolete negative assertion. Because the root suite is a post-merge safety
+net, classification integrity is a prerequisite for trusting its regression
+signal.
+
+## Root cause / unknowns
+
+Vitest's JSON report represents an unexpected pass of `it.fails` as a failed
+assertion, and the gate discards failure-message semantics. Negative
+characterization tests also have no metadata that says when their expected bad
+behavior has become stale. The implementation should parse the stable Vitest
+unexpected-pass signal and add a narrow source-policy guard; it should not infer
+all assertion intent heuristically.
+
+## Proposed approach
+
+1. Extract failed assertion messages in `issue-tests-gate.mjs` and classify the
+   Vitest `Expect test to fail` condition into an `unexpectedPasses` set.
+2. Preserve that set in shard artifacts and merge results. Never seed or update
+   those IDs into `knownFailures`; report them as `UNEXPECTED PASS` requiring
+   test promotion.
+3. Add focused gate fixtures for bootstrap, update, ratchet, sharding, and a
+   genuine regression so classification cannot weaken the existing gate.
+4. Convert #2143's two now-valid programs to positive compile-and-validate
+   guards.
+5. Replace the weak WASI `it.fails` validity check with either a tracked todo
+   for #3337 or a characterization that tests the actual missing runtime/import
+   contract without asserting already-correct validity should fail.
+6. Add a narrow policy check preventing positive compiler fixtures from
+   asserting that otherwise-valid source must fail `WebAssembly.validate`,
+   while explicitly exempting encoder-negative tests built from intentional
+   malformed byte sequences.
+
+## Non-goals
+
+- Implementing WASI argv semantics (#3337).
+- Fixing malformed-Wasm producer families (#3024 and related issues).
+- Making the entire root issue suite a required per-PR gate.
+- Removing all `it.fails` tests or rewriting the Vitest runner.
+- Treating every changed error message as an unexpected pass.
+
+## Dependencies / related issues
+
+- No hard dependency; gate classification and the two stale #2143 tests can be
+  fixed immediately.
+- #3008 created the root-suite baseline workflow and explicitly deferred rot
+  triage. This issue is one verified classification cluster from that follow-up.
+- #2143's differential-harness validation remains correct; only its stale
+  negative fixtures need promotion.
+- #3337 owns real `process.argv` behavior. This issue owns how its stale
+  expected-failure test is represented in the baseline.
+- #2787 is related test-classification/gate infrastructure, not this root-suite
+  unexpected-pass path.
+
+## Why this is not already covered
+
+#3008 is complete and intentionally bootstrapped the existing failure set, with
+rot triage left as follow-up. #2143 is complete and owns differential result
+classification, not root-baseline semantics. #3337 owns WASI implementation.
+Searches for `Expect test to fail`, `unexpectedPasses`, the three baseline IDs,
+and `KNOWN_MALFORMED` found no issue or gate logic that distinguishes these
+improvements from regressions.
+
+## Acceptance criteria
+
+- [ ] The two #2143 corpus programs are positive guards and pass only when
+      compilation succeeds and their binaries validate.
+- [ ] A gate fixture proves an `it.fails` unexpected pass is reported as
+      `UNEXPECTED PASS`, fails the maintenance run, and is never written to
+      `knownFailures` by bootstrap or `--update`.
+- [ ] Sharded partial artifacts and merge mode preserve the unexpected-pass
+      classification.
+- [ ] A genuine failed assertion remains a regression or known failure under
+      the existing rules; collection failures still gate.
+- [ ] The WASI test no longer fails merely because binary validation succeeds,
+      and its unresolved runtime semantics point to #3337.
+- [ ] The current baseline ratchets out the two #2143 IDs and the stale WASI
+      expected-pass ID after the corrected main workflow completes.
+- [ ] Intentional malformed-byte encoder tests remain supported by the policy
+      check and are documented as the explicit exemption.
+
+## Validation plan
+
+- Run focused unit/integration tests for `scripts/issue-tests-gate.mjs` in
+  bootstrap, update, ratchet, shard, and merge modes.
+- Run `pnpm test tests/issue-2143-validate-unoptimized.test.ts tests/real-world-wasi.test.ts`.
+- Run a local root issue-test shard containing both an `it.fails` unexpected
+  pass and a genuine failure; inspect the partial JSON and merged report.
+- Validate the baseline diff against the current external baseline and confirm
+  exactly the three stale IDs are removed by this slice.

--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -76,6 +76,6 @@ category) are NOT in scope here — only the reasons already at zero.
 - Full test suite green; `check:ir-fallbacks` gate green.
 - Stale line-number citations in `ir-adoption.md` and `codegen-axes.md`
   corrected.
-- `plan/issues/2855-*.md` updated to reflect this slice as done against its
-  own AC (don't close #2855 itself — `body-shape-rejected` remains open via
-  #2856).
+- `plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md` updated
+  to reflect this slice as done against its own AC (don't close #2855 itself —
+  `body-shape-rejected` remains open via #2856).

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -15,16 +15,34 @@ dispatchable gaps:
   issue titles/sprints still route target-neutral planner work through the
   Porffor backend wave.
 - [#3337](../3337-wasi-process-argv-args-get.md) - WASI `process.argv` must
-  lower through `args_get` instead of the invalid native-string path. Highest
-  correctness value because the real-world WASI suite currently carries an
-  `it.fails` invalid-binary sentinel and the previous owner explicitly deferred
-  this as a separate issue; #1532 is tests-only and cannot fix the runtime path.
+  materialize through `args_get` instead of silently returning an empty,
+  import-free vector. A second-pass runtime probe corrected the original
+  invalid-binary premise: validity is fixed, argv semantics are not.
+- [#3338](../3338-cli-refuse-invalid-wasm-artifacts.md) - CLI must validate the
+  final binary before writing any artifacts. Verified in both default `-O3` and
+  `--no-optimize`: the CLI exits zero and writes the same invalid private-field
+  module; #3024 owns the producer, not this systemic publication boundary.
+- [#3339](../3339-compileproject-axios-core-oom.md) - bound `compileProject`
+  graph expansion on Axios core. The current probe exhausts a 512 MB heap after
+  about 85 seconds, blocking four Tier 1 entries; architect phase attribution
+  is required before implementation.
+- [#3340](../3340-issue-tests-unexpected-pass-baseline.md) - keep inverted
+  expected-failure sentinels out of the root issue-test baseline. Two #2143
+  programs now validate and the WASI validity check now passes, but all three
+  improvements are stored as accepted failures because the gate has no
+  unexpected-pass class.
 
 Investigated, no new issue filed: cross-backend parity as a required advisory
 gate is already owned by #2711; the linear-IR overlay ratchet and flag-on
 coverage are active in #2956 (PR #3200 has landed for the L2 aggregate/ref-cell
 slice, with later slices still tracked there), so a separate gate-hardening
 issue would duplicate current work.
+
+The stronger-model second pass also rechecked CLI emission, Axios Tier 1,
+root-suite baseline semantics, current test262 categories, and active PRs. It
+did not file separate issues for producer-specific invalid Wasm, Axios
+validator sub-buckets, or full root-suite required gating because #3024,
+#1571's other proposed blockers, and #3008 already own those scopes.
 
 ## 2026-07-03 — `/harvest-errors` sweep (both lanes, fresh baselines)
 

--- a/plan/log/dependency-graph.md
+++ b/plan/log/dependency-graph.md
@@ -56,10 +56,13 @@ displace the #2860 standalone-vs-js-host sprint focus above, but they are high
 leverage backlog candidates because each removes a planning or correctness risk
 that can otherwise misdirect larger implementation work.
 
-| Issue | Area                          | Priority | Horizon | Status | Dependency note                                                                                                                              |
-| ----- | ----------------------------- | -------- | ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| #3336 | planning / IR / linear memory | high     | s       | ready  | No code deps. Must be done before dispatching target-neutral `LinearMemoryPlan` work as Porffor-only work. Related: #3288/#3298/#3300/#2956. |
-| #3337 | WASI argv correctness         | high     | m       | ready  | No hard deps. #1482 is the env precedent; #1801 explicitly deferred this argv invalid-binary defect; #1532 is tests-only.                    |
+| Issue | Area                          | Priority | Horizon | Status  | Dependency note                                                                                                                              |
+| ----- | ----------------------------- | -------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| #3336 | planning / IR / linear memory | high     | s       | ready   | No code deps. Must be done before dispatching target-neutral `LinearMemoryPlan` work as Porffor-only work. Related: #3288/#3298/#3300/#2956. |
+| #3337 | WASI argv correctness         | high     | m       | ready   | No hard deps. Validity now passes, but argv is an empty import-free vector; #1482 is the env precedent and #1532 is tests-only.              |
+| #3338 | CLI artifact validation       | high     | s       | ready   | No code deps. Protects users from every malformed-Wasm producer while #3024 and related emitter issues fix individual families.              |
+| #3339 | Axios project nontermination  | high     | l       | backlog | Architect spec required: identify the unbounded resolver/lowering/emitter phase before dispatch; parent #1032, survey #1571.                 |
+| #3340 | Root baseline classification  | high     | s       | ready   | No hard deps. Ratchets stale #2143 and WASI expected-pass IDs; coordinates with #3337 but does not implement argv.                           |
 
 ## IR front-end migration — fallback-bucket ratchet (added 2026-06-30, DEMOTED to `priority: low` 2026-06-30)
 


### PR DESCRIPTION
## Summary

- correct #3337 against current main: WASI process.argv validates but silently returns an empty import-free vector
- file #3338 for the CLI's success exit and invalid artifact publication boundary
- file #3339 for compileProject heap exhaustion on the Axios core graph
- file #3340 for root issue-test baseline misclassification of unexpected passes
- repair the literal wildcard link in newly landed #3341 so issue integrity passes

## Why these rank highest

These are verified trust, availability, and regression-gate failures with broad blast radius: corrupt CLI outputs are published successfully, a real npm graph can kill the compiler process, and the root safety net stores compiler improvements as accepted failures. #3337 remains a silent WASI correctness defect after correcting its stale invalid-binary premise.

## Validation

- pnpm run check:issues
- pnpm run check:issue-ids
- GATE_BASE=origin/main pnpm run check:issue-ids:against-main
- pnpm run check:issue-ids:staged
- node scripts/check-committed-issue-integrity.mjs HEAD
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pinned Prettier check for all changed plan files
- pnpm run sync:conformance:check
- direct CLI probes in default -O3 and --no-optimize modes
- focused WASI argv runtime/import probe
- focused #2143 and root-baseline inspection
- isolated Axios compileProject probe (confirmed 512 MB heap OOM)

The normal pre-push hook was bypassed only after its macOS-only timeout wrapper failed with exit 127 because the timeout executable is absent; all underlying checks were run directly and passed.