### PR TITLE
fix(#1616): resolve wildcard issue-link reference in #3341 blocking the quality gate

### DIFF
--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -76,6 +76,6 @@ category) are NOT in scope here — only the reasons already at zero.
 - Full test suite green; `check:ir-fallbacks` gate green.
 - Stale line-number citations in `ir-adoption.md` and `codegen-axes.md`
   corrected.
-- `plan/issues/2855-*.md` updated to reflect this slice as done against its
-  own AC (don't close #2855 itself — `body-shape-rejected` remains open via
-  #2856).
+- `plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md` updated
+  to reflect this slice as done against its own AC (don't close #2855 itself
+  — `body-shape-rejected` remains open via #2856).


### PR DESCRIPTION
## Summary
- `plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md` linked `plan/issues/2855-*.md` — a wildcard the `check-committed-issue-integrity` (#1616) gate can't resolve, even though the concrete file exists (`plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md`).
- This fails the required `quality` gate on **every** PR branched from current main (confirmed on PR #3205, run 29560554339, job 87821871178: `BROKEN issue links (1): 3341 → plan/issues/2855-*.md (no such issue file)`), blocking the whole dev fleet.
- Fix: replace the wildcard reference with the concrete filename.

## Test plan
- [x] `node scripts/check-committed-issue-integrity.mjs` → `Committed issue integrity OK for HEAD (2927 issues indexed).` (ran twice, exit 0 both times)
- [x] Plan-only change, no source touched — low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)