### PR TITLE
test(#3261): lock standalone eq/ToString host-free property with regression guard

### DIFF
--- a/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
+++ b/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
@@ -1,7 +1,8 @@
 ---
 id: 3261
 title: "standalone: __host_loose_eq / __extern_toString / __date_format leak env::* imports (missing native-helper set membership)"
-status: ready
+status: done
+completed: 2026-07-17
 sprint: current
 created: 2026-07-14
 priority: medium
@@ -85,3 +86,42 @@ Do NOT add a new host import without a standalone fallback. Behaviour-preserving
   sub-part and overlaps the standalone Date cluster — do it under / alongside **#3174**
   (Date-native) rather than block this issue on it. #3261's core deliverable is the two
   routing fixes (loose-eq + extern-toString).
+
+## Resolution (2026-07-17, opus-c) — verified already host-free; locked with a regression guard
+
+**Acceptance criterion #1 (measure first) does NOT reproduce on current main
+for the two core helpers.** A `WebAssembly.Module.imports` probe over ~30 varied
+`target: "standalone"` programs — covering every arm the issue names
+(any==any, str/num/bool loose-eq, concrete string⇄primitive, wrapper objects,
+`"" + obj`, `String(any)`, template literals, `a.join(",")`) — shows **zero**
+`env::__host_loose_eq` and **zero** `env::__extern_toString` imports. Each module
+instantiates against an **empty** import object `{}` and returns the correct,
+JS-parity result. The identical programs on the gc-host lane still (correctly)
+import `env::__host_loose_eq` / `env::__extern_to_string_default`, confirming the
+probe is valid and the standalone lane is genuinely host-free here.
+
+The behavioral gaps were closed by the intervening native standalone work,
+*before* this issue was picked up:
+
+- `__host_loose_eq` → the native IsLooselyEqual tail: the two-`any`-externref arm
+  routes through `emitAnyEqFromExternTemps` → `__any_eq` (#2081 / #1917), and the
+  concrete string⇄number / string⇄boolean arm lowers to the native
+  `__str_to_number` scanner + `f64.eq` under `noJsHost` (`binary-ops.ts` #2073).
+- `__extern_toString` → its native `registerNative` registration in
+  `ensureObjectRuntime` (`object-runtime.ts`), reached by the native ToString
+  cascade in `coercion-engine.ts` (`emitToString`) for the dynamic-externref arm.
+
+**No codegen change was needed** — adding a `noJsHost` guard to the residual
+un-reached arms (concretely-typed wrapper-object equality, the
+`eitherIsString`-loose typed-dispatch arm) would be dead code that the any-
+dispatch / native blocks already shadow, and risks a host-lane byte change for
+no benefit. Per the issue's own "byte-identity host lane" guidance the honest
+outcome is: verify + lock, not speculative routing.
+
+**Delivered:** `tests/issue-3261.test.ts` (the permanent guard required by the
+#2093 probe-coverage gate) — asserts the representative equality + ToString
+standalone programs emit no `env::*` host imports, instantiate against `{}`, and
+produce the correct result (ToString correctness checked in-wasm via a native
+`===` compare since a standalone string export is an opaque `ref $AnyString`).
+
+`__date_format` remains carved out to **#3174** (Date-native), unchanged.

--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -76,6 +76,6 @@ category) are NOT in scope here — only the reasons already at zero.
 - Full test suite green; `check:ir-fallbacks` gate green.
 - Stale line-number citations in `ir-adoption.md` and `codegen-axes.md`
   corrected.
-- `plan/issues/2855-*.md` updated to reflect this slice as done against its
-  own AC (don't close #2855 itself — `body-shape-rejected` remains open via
-  #2856).
+- `plan/issues/2855-ir-frontend-migration-ratchet-buckets-to-zero.md` updated to
+  reflect this slice as done against its own AC (don't close #2855 itself —
+  `body-shape-rejected` remains open via #2856).

--- a/tests/issue-3261.test.ts
+++ b/tests/issue-3261.test.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3261 — standalone must not leak `env::__host_loose_eq` / `env::__extern_toString`.
+//
+// Three runtime helpers historically registered a JS-**host** import with no
+// standalone (`--target standalone`, `noJsHost`) native arm, violating the
+// dual-mode contract that standalone mode is pure Wasm with no `env::*` host
+// imports (CLAUDE.md "Dual-mode: JS host optional"; #1470/#1471/#1180 closed the
+// same class for other helpers):
+//
+//   | Helper              | Reached from (host lane)                         |
+//   | ------------------- | ------------------------------------------------ |
+//   | `__host_loose_eq`   | binary-ops loose-equality (`==` / `!=`) coercion |
+//   | `__extern_toString` | any→string coercion (concat, template, String()) |
+//   | `__date_format`     | Date formatting — CARVED OUT to #3174            |
+//
+// The two core helpers were driven host-free on the standalone lane by the
+// intervening native work — `__host_loose_eq` via the native IsLooselyEqual
+// tail (#2081 `__any_eq` / #1917 `emitAnyEqFromExternTemps` and the native
+// `__str_to_number` string⇄number arm in binary-ops.ts), and `__extern_toString`
+// via its native `registerNative` registration in `ensureObjectRuntime`
+// (object-runtime.ts) plus the native ToString path (#1470). Contrast the
+// gc-host lane, which still (correctly) imports `env::__host_loose_eq` /
+// `env::__extern_to_string_default` for the identical programs.
+//
+// This is the permanent regression guard required by the #2093 probe-coverage
+// gate: it locks in the no-`env::*`-leak property so a future refactor of an
+// equality / ToString arm that reintroduces a bare host import (an arm that
+// forgets the `noJsHost` native route) fails here instead of silently emitting
+// an unsatisfiable standalone module.
+//
+// `__date_format` (native Date-to-string) is the one genuinely harder sub-part
+// and overlaps the standalone Date cluster — it is deferred to #3174, so it is
+// out of scope here.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Host-import names that MUST NOT appear on the standalone lane (#3261). */
+const FORBIDDEN_STANDALONE_HOST_IMPORTS = ["__host_loose_eq", "__extern_toString", "__extern_to_string_default"];
+
+interface StandaloneProbe {
+  envImports: string[];
+  result: unknown;
+}
+
+/**
+ * Compile `src` with `target: "standalone"`, assert the module has no `env::*`
+ * host imports at all (a standalone module must instantiate against an EMPTY
+ * import object), instantiate, and return the `test()` export result plus the
+ * observed `env` import names.
+ */
+async function standaloneProbe(src: string): Promise<StandaloneProbe> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone module failed WebAssembly.validate").toBe(true);
+  const mod = new WebAssembly.Module(r.binary);
+  const envImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  // Instantiate against an EMPTY import object — any leaked `env::*` import
+  // would throw a LinkError here, so this is the strongest possible guard.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const result = (instance.exports as { test: () => unknown }).test();
+  return { envImports, result };
+}
+
+describe("#3261 — standalone equality has no env::__host_loose_eq leak", () => {
+  it("mixed-type loose equality via any operands ('1' == 1) is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `function g(): any { return "1"; }
+       function h(): any { return 1; }
+       export function test(): boolean { return g() == h(); }`,
+    );
+    expect(envImports).not.toContain("__host_loose_eq");
+    expect(result).toBe(1); // JS: "1" == 1 → true
+  });
+
+  it("boolean == string ('' == false) is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         let b: boolean = false; let s: string = "";
+         return (b as any) == (s as any);
+       }`,
+    );
+    expect(envImports).not.toContain("__host_loose_eq");
+    expect(result).toBe(1); // JS: false == "" → true (both ToNumber 0)
+  });
+
+  it("concrete string == number ('1' == 1) is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         let s: string = "1"; let n: number = 1;
+         return s == n;
+       }`,
+    );
+    expect(envImports).not.toContain("__host_loose_eq");
+    expect(result).toBe(1);
+  });
+
+  it("string != number ('x' != 1) is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         let s: string = "x"; let n: number = 1;
+         return s != n;
+       }`,
+    );
+    expect(envImports).not.toContain("__host_loose_eq");
+    expect(result).toBe(1); // JS: "x" != 1 → true (ToNumber("x") is NaN)
+  });
+});
+
+describe("#3261 — standalone ToString has no env::__extern_toString leak", () => {
+  // NOTE: a standalone string-returning export yields a native WasmGC
+  // `ref $AnyString` (an opaque `{}` from JS), so the ToString *result* is
+  // verified IN-WASM via a native string `===` compare (which is host-free on
+  // the standalone lane) and returned as a boolean; the export type stays
+  // numeric so the JS boundary round-trips cleanly.
+  it("object concat ('' + {}) is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `function g(): any { return { x: 1 }; }
+       export function test(): boolean { return ("" + g()) === "[object Object]"; }`,
+    );
+    expect(envImports).not.toContain("__extern_toString");
+    expect(envImports).not.toContain("__extern_to_string_default");
+    expect(result).toBe(1); // "" + {x:1} === "[object Object]"
+  });
+
+  it("String(any-boxed number) is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean { const a: any = 5; return String(a) === "5"; }`,
+    );
+    expect(envImports).not.toContain("__extern_toString");
+    expect(result).toBe(1);
+  });
+
+  it("template literal on an any operand is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `function g(): any { return 7; }
+       export function test(): boolean { return \`v=\${g()}\` === "v=7"; }`,
+    );
+    expect(envImports).not.toContain("__extern_toString");
+    expect(result).toBe(1);
+  });
+});
+
+describe("#3261 — standalone lane is fully host-import-free for these programs", () => {
+  // A standalone module must instantiate against `{}` — assert ZERO env imports
+  // for the representative equality + ToString programs (the umbrella guard).
+  const programs: Array<[string, string]> = [
+    [
+      "loose-eq any==any",
+      `function g():any{return "1";} function h():any{return 1;} export function test():boolean{return g()==h();}`,
+    ],
+    ["concat object", `function g():any{return {x:1};} export function test():string{return ""+g();}`],
+    ["String(any number)", `export function test():string{const a:any=5;return String(a);}`],
+  ];
+  for (const [label, src] of programs) {
+    it(`${label}: no env::* imports`, async () => {
+      const { envImports } = await standaloneProbe(src);
+      const leaked = envImports.filter((n) => FORBIDDEN_STANDALONE_HOST_IMPORTS.includes(n));
+      expect(leaked, `leaked host imports: ${leaked.join(", ")}`).toEqual([]);
+      expect(envImports, `standalone module must have no env imports, got: ${envImports.join(", ")}`).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## #3261 — standalone `__host_loose_eq` / `__extern_toString` env leaks

**Verified already host-free on current main; locked with a regression guard.**

Acceptance criterion #1 (measure first) does **not** reproduce for the two core
helpers. A `WebAssembly.Module.imports` probe over ~30 varied `target:
"standalone"` programs — covering every arm the issue names (any==any,
str/num/bool loose-eq, concrete string⇄primitive, wrapper objects, `"" + obj`,
`String(any)`, template literals, `.join`) — shows **zero**
`env::__host_loose_eq` and **zero** `env::__extern_toString` imports. Each module
instantiates against an empty `{}` import object and returns the JS-parity
result. The identical programs on the gc-host lane still (correctly) import
`env::__host_loose_eq` / `env::__extern_to_string_default`, confirming the probe
is valid and the standalone lane is genuinely host-free here.

The behavioral gaps were closed by the intervening native standalone work
*before* this issue was picked up:
- `__host_loose_eq` → native IsLooselyEqual: two-`any`-externref arm via
  `emitAnyEqFromExternTemps` → `__any_eq` (#2081 / #1917); concrete
  string⇄number/boolean arm via native `__str_to_number` + `f64.eq` under
  `noJsHost` (#2073).
- `__extern_toString` → native `registerNative` in `ensureObjectRuntime`,
  reached by the native ToString cascade in `coercion-engine.ts` (`emitToString`).

**No codegen change** — guarding the residual un-reached arms (concretely-typed
wrapper equality, the `eitherIsString`-loose typed-dispatch arm) would be dead
code shadowed by the any-dispatch / native blocks and would risk a host-lane
byte change for no benefit. Per the issue's own byte-identity guidance the honest
outcome is verify + lock.

## What this PR delivers
- `tests/issue-3261.test.ts` — the permanent guard required by the #2093
  probe-coverage gate. Asserts the representative equality + ToString standalone
  programs emit no `env::*` host imports, instantiate against `{}`, and produce
  the correct result (ToString correctness checked in-wasm via a native `===`
  compare, since a standalone string export is an opaque `ref $AnyString`).
- Marks the issue `status: done`; `__date_format` stays carved out to #3174.

## Test
`npx vitest run tests/issue-3261.test.ts` → 10/10 pass. No src change ⇒ no
test262 impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)