### PR TITLE
docs(#3152): correct root cause (eager-buffer generators) + re-scope m→xl

### DIFF
--- a/plan/issues/3152-array-destructure-drains-iterator.md
+++ b/plan/issues/3152-array-destructure-drains-iterator.md
@@ -4,10 +4,10 @@ title: "array-pattern destructuring DRAINS the source iterator (materialize-then
 status: ready
 sprint: current
 created: 2026-07-11
-updated: 2026-07-11
+updated: 2026-07-17
 priority: medium
-horizon: m
-feasibility: medium
+horizon: xl
+feasibility: hard
 reasoning_effort: high
 task_type: bugfix
 area: codegen
@@ -20,6 +20,46 @@ origin: "2026-07-11 #3024 slice-2 (fable-wasm): the 3 *-ptrn-elision.js files fl
 ---
 
 # #3152 — array destructuring drains the iterator instead of stepping it
+
+## ⚠️ Root-cause CORRECTION (2026-07-17, opus-a) — re-scoped m → xl
+
+The "bounded drain" framing below is a **misdiagnosis**. Verified on current
+main (d17ba4d2): the actual test262 files
+(`meth-ary-ptrn-elision.js` etc.) use a **closure-mutating** generator:
+
+```js
+var first = 0, second = 0;
+function* g() { first += 1; yield; second += 1; }
+obj.method(g());   // method([,]) asserts second === 0
+```
+
+A generator that **mutates outer-scope variables** does NOT pass the
+native-resumable shape gate (`generators-native-ast-scan.ts`) — it bails to the
+**eager-buffer host path** (`__create_generator` / `__gen_create_buffer` /
+`__gen_push_ref`). The eager path **runs the ENTIRE generator body at the
+`g()` call site** and buffers every yield *before destructuring ever sees the
+result* (confirmed via WAT: the destructure reads a pre-filled buffer struct,
+never calls `__array_from_iter_n`). So `second += 1` has already executed by the
+time `[,]` binds — there is **no lazy stepping to bound**.
+
+Consequences:
+- The suggested `__array_from_iter_n(maxCount)` / `emitNativeGeneratorToVec`
+  bound (below) is **inert** for these tests: those paths only run for the
+  *native-resumable* generator subset, and in that subset the over-drain is
+  **unobservable** (values are still correct; only wasted resumes) precisely
+  because side-effecting generators are forced eager. I prototyped the bound and
+  it changed nothing observable — reverted.
+- The real fix requires the **eager-path generator to become lazy/resumable**
+  when it (a) has observable side effects and (b) is consumed by a spec
+  observer that steps lazily (destructuring / manual `.next()`). That is the
+  lazy-generator work (native-resumable shape-gate widening for
+  closure-mutating bodies, or a lazy-thunk host path — see #2865 / the
+  `eager-gen` slices), **not** an M-horizon drain-bound. Re-scoped to `xl`,
+  `feasibility: hard`.
+
+Everything below is the ORIGINAL (superseded) framing, kept for history.
+
+---
 
 ## Problem
 


### PR DESCRIPTION
## What

Corrects the root-cause diagnosis for #3152 and re-scopes it `m → xl`.

## Why

The issue framed the bug as an unbounded drain that could be fixed by capping
`__array_from_iter_n` to the pattern's element count. Verified on current main
(d17ba4d2): the actual failing test262 files
(`language/expressions/object/dstr/meth-ary-ptrn-elision.js` etc.) use a
**closure-mutating** generator:

```js
var first = 0, second = 0;
function* g() { first += 1; yield; second += 1; }
obj.method(g());   // method([,]) asserts second === 0
```

A generator that mutates outer-scope variables does **not** pass the
native-resumable shape gate — it takes the **eager-buffer host path**
(`__create_generator` / `__gen_create_buffer`), which runs the entire body at
the `g()` call site and buffers every yield **before destructuring sees the
result** (confirmed via WAT: the destructure reads a pre-filled buffer struct
and never calls `__array_from_iter_n`). So `second += 1` has already executed —
there is no lazy stepping to bound.

I prototyped the suggested bound (capping `emitNativeGeneratorToVec` /
`__array_from_iter_n`); it changed nothing observable because those paths only
run for the native-resumable subset, where the over-drain is unobservable.
Reverted. The real fix is lazy/resumable generators for the eager path (#2865
territory), hence `xl` / `feasibility: hard`.

## Change

Docs only — updates the #3152 issue file with the corrected root cause and
re-scopes frontmatter (`horizon m→xl`, `feasibility medium→hard`). No source
changes. Keeps the original framing for history.