### PR TITLE
fix(#3311): add native-string vec carrier to __vec_push/__vec_pop

### DIFF
--- a/plan/issues/3311-g4-string-vec-push-pop-carrier.md
+++ b/plan/issues/3311-g4-string-vec-push-pop-carrier.md
@@ -1,8 +1,10 @@
 ---
 id: 3311
 title: "G4 — `string[]` push/pop under standalone is a no-op: native-string vec carrier missing from `__vec_push`/`__vec_pop` mutEntries"
-status: ready
+status: done
+assignee: ttraenkler/senior-dev
 created: 2026-07-16
+completed: 2026-07-17
 priority: high
 horizon: s
 feasibility: medium
@@ -60,11 +62,11 @@ fall-through also returned `undefined`); this issue is the actual fix.
 
 ## Acceptance criteria
 
-- [ ] `string[]` push/pop via the any-receiver brand arm works standalone
+- [x] `string[]` push/pop via the any-receiver brand arm works standalone
       (values, length, return values correct; host-free).
-- [ ] The `-1` sentinel path still returns `undefined` for genuinely
+- [x] The `-1` sentinel path still returns `undefined` for genuinely
       unsupported carriers (no bogus boxed `-1` length).
-- [ ] Existing #2927 push/pop suite (`tests/issue-2927-standalone-any-push-pop.test.ts`)
+- [x] Existing #2927 push/pop suite (`tests/issue-2927-standalone-any-push-pop.test.ts`)
       stays green.
 
 ## Notes
@@ -72,3 +74,56 @@ fall-through also returned `undefined`); this issue is the actual fix.
 Filed under #2784 lineage per the #2927 audit ("fix belongs in the
 `__vec_push`/`__vec_pop` carrier set, not the brand arm"). Umbrella:
 #2927 → #1584.
+
+## Implementation notes (senior-dev)
+
+**Root cause precision.** The audit note's "`ref $NativeString` elements" is
+imprecise: a `string[]` under `nativeStrings` lowers to a vec whose backing
+array element type is `(ref null $AnyString)` — the `$AnyString` *supertype*
+that covers flat native strings, cons strings, and slices — registered with
+the `vecTypeMap` key `ref_<anyStrTypeIdx>` (native-strings.ts:1218,
+native-strings-rewrite.ts:565), **not** `nativeStrTypeIdx`. The fix keys on
+`ref_<anyStrTypeIdx>` and casts to `anyStrTypeIdx`, so all three string reps
+round-trip.
+
+**Why the gap was push/pop-only.** `__vec_get` already handles this carrier:
+its non-externref, non-numeric `else` arm boxes `array.get` → externref via
+`extern.convert_any`, and the element `(ref null $AnyString)` is an anyref
+subtype, so reads worked. `__vec_len` reads field-0 (i32) generically, and
+`__vec_set_len` grows via `array.new_default` (nullable-ref-safe). Only the
+three **value-marshaling** sites needed a carrier arm:
+1. `__vec_push` `valueInstrs` — recover the GC string ref from the externref
+   value: `any.convert_extern` + `ref.cast_null $AnyString` before `array.set`
+   (no numeric unbox — the boxed side is already a GC string ref). `ref.cast_null`
+   (not `ref.cast`) matches the nullable element type and tolerates a pushed
+   `null`/`undefined`.
+2. `__vec_pop` `boxInstrs` — box the popped element straight back with
+   `extern.convert_any` (anyref subtype; no `__box_number`).
+3. `__vec_set_elem` (`vec-define-writeback.ts`) `valueInstrs` — **critical**:
+   this consumes the same `mutEntries`, and its default arm does
+   `__unbox_number` + `i32.trunc` → an i32 into a `(ref null $AnyString)` array =
+   **invalid Wasm**. Any module with BOTH a `string[]` and `Object.defineProperty`
+   would fail validation without a native-string arm here. Mirrors push's arm.
+
+`mutEntries` (also feeding `__vec_mut_supported`) admits the carrier when
+`nativeStrings && anyStrTypeIdx >= 0`. The new `nativeStrVecKey(ctx)` helper
+(exported from vec-access-exports.ts) is the single source of the key across all
+sites. The new `ref.test` arm is a sibling type under `$__vec_base`, so it can't
+cross-match the existing externref/numeric carriers — order-independent, no
+regression to those arms. The `-1` sentinel path is untouched for genuinely
+unsupported carriers (e.g. `i64`).
+
+## Test Results
+
+- New `tests/issue-3311-string-vec-push-pop.test.ts` — 8 tests, all pass
+  (host + standalone-host-free; push length, append, indexed read+equality,
+  repeated push, pop value+equality, pop shrink, push/pop round-trip, typed
+  control). Every standalone case asserts **0 function imports**.
+- `tests/issue-2927-standalone-any-push-pop.test.ts` — 7/7 still green.
+- `array-methods`, `array-prototype-methods`, `issue-1539-standalone-array-coercion`
+  — green. (`array-capacity.test.ts` has 4 pre-existing failures unrelated to
+  this change — a stale harness missing a `string_constants` import; verified
+  identical with these files reverted to base.)
+- Writeback validity: a module with both `string[]` and `Object.defineProperty`
+  compiles to valid Wasm, host-free.
+- `tsc --noEmit` clean.

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -21,6 +21,25 @@ import { flushLateImportShifts } from "./shared.js";
 import { exportFunc } from "./emit-helpers.js";
 
 /**
+ * (#3311) The `vecTypeMap` element-kind key for the standalone native-string
+ * carrier. A `string[]` under `--target standalone`/`wasi` (nativeStrings)
+ * lowers to a vec whose backing array holds `(ref null $AnyString)` elements,
+ * registered with the key `ref_<anyStrTypeIdx>` (see native-strings.ts /
+ * native-strings-rewrite.ts). Returns that key, or `null` when native strings
+ * are not in play (`anyStrTypeIdx < 0`) so callers stay byte-identical.
+ *
+ * The `__vec_push`/`__vec_pop`/`__vec_set_elem` value-marshaling arms and the
+ * `mutEntries` filter use this to admit + correctly (un)box the native-string
+ * carrier: an incoming externref value converts `any.convert_extern` +
+ * `ref.cast_null $AnyString` before `array.set` (no numeric unbox — the boxed
+ * side is already a GC string ref), and a popped element boxes back via plain
+ * `extern.convert_any` (anyref subtype).
+ */
+export function nativeStrVecKey(ctx: CodegenContext): string | null {
+  return ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 ? `ref_${ctx.anyStrTypeIdx}` : null;
+}
+
+/**
  * Emit __vec_get(externref, i32) -> externref and __vec_len(externref) -> i32
  * exports so the runtime can iterate WasmGC vec structs that were coerced to
  * externref (e.g. arrays stored in `any`-typed variables).
@@ -411,9 +430,15 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
   // through to its fail-loud TypeError instead of silently no-oping.
   const unboxNumIdx = ctx.funcMap.get("__unbox_number");
   const boxNumIdx2 = ctx.funcMap.get("__box_number");
+  // (#3311) The standalone native-string carrier (`string[]` → vec of
+  // `(ref null $AnyString)`, keyed `ref_<anyStrTypeIdx>`) is push/pop supported:
+  // no numeric box import is needed — a string value round-trips through
+  // extern↔any conversions + a `ref.cast_null $AnyString` narrow.
+  const nsKey = nativeStrVecKey(ctx);
   const mutEntries = vecEntries.filter(([elemKey]) => {
     if (elemKey === "externref") return true;
     if (elemKey === "f64" || elemKey === "i32") return unboxNumIdx !== undefined && boxNumIdx2 !== undefined;
+    if (nsKey !== null && elemKey === nsKey) return true;
     return false;
   });
 
@@ -516,12 +541,21 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       const valueInstrs: Instr[] =
         elemKey === "externref"
           ? [{ op: "local.get", index: 1 }]
-          : elemKey === "f64"
-            ? [
+          : nsKey !== null && elemKey === nsKey
+            ? // (#3311) native-string carrier: recover the GC string ref from the
+              // externref value and narrow to the array's `(ref null $AnyString)`
+              // element type (nullable cast tolerates a pushed null/undefined).
+              [
                 { op: "local.get", index: 1 },
-                { op: "call", funcIdx: unboxNumIdx! },
+                { op: "any.convert_extern" },
+                { op: "ref.cast_null", typeIdx: ctx.anyStrTypeIdx },
               ]
-            : [{ op: "local.get", index: 1 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }];
+            : elemKey === "f64"
+              ? [
+                  { op: "local.get", index: 1 },
+                  { op: "call", funcIdx: unboxNumIdx! },
+                ]
+              : [{ op: "local.get", index: 1 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 2 },
         { op: "ref.cast", typeIdx: vecTypeIdx },
@@ -658,11 +692,16 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       const boxInstrs: Instr[] =
         elemKey === "externref"
           ? []
-          : elemKey === "f64"
-            ? [{ op: "call", funcIdx: boxNumIdx2! }]
-            : isPackedByte
-              ? [{ op: "f64.convert_i32_u" }, { op: "call", funcIdx: boxNumIdx2! }]
-              : [{ op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumIdx2! }];
+          : // (#3311) native-string carrier: the popped `(ref null $AnyString)`
+            // element is an anyref subtype — box straight back to externref with
+            // `extern.convert_any` (no `__box_number`).
+            nsKey !== null && elemKey === nsKey
+            ? [{ op: "extern.convert_any" }]
+            : elemKey === "f64"
+              ? [{ op: "call", funcIdx: boxNumIdx2! }]
+              : isPackedByte
+                ? [{ op: "f64.convert_i32_u" }, { op: "call", funcIdx: boxNumIdx2! }]
+                : [{ op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumIdx2! }];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 1 },
         { op: "ref.cast", typeIdx: vecTypeIdx },

--- a/src/codegen/vec-define-writeback.ts
+++ b/src/codegen/vec-define-writeback.ts
@@ -20,6 +20,7 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
+import { nativeStrVecKey } from "./vec-access-exports.js";
 
 /**
  * Emit the two write-back exports. `mutEntries` is the caller's filtered
@@ -64,15 +65,26 @@ export function emitVecDefineWritebackExports(
         { name: `__vse_ndata_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: arrTypeIdx } },
       );
       // value unboxing per element kind (value param is local 2)
+      // (#3311) native-string carrier mirrors __vec_push: recover the GC string
+      // ref from the externref value and narrow to `(ref null $AnyString)` — a
+      // numeric unbox+trunc here would emit an i32 into a ref array (invalid Wasm)
+      // for any module that has BOTH a `string[]` and `Object.defineProperty`.
+      const nsKey = nativeStrVecKey(ctx);
       const valueInstrs: Instr[] =
         elemKey === "externref"
           ? [{ op: "local.get", index: 2 }]
-          : elemKey === "f64"
+          : nsKey !== null && elemKey === nsKey
             ? [
                 { op: "local.get", index: 2 },
-                { op: "call", funcIdx: unboxNumIdx! },
+                { op: "any.convert_extern" },
+                { op: "ref.cast_null", typeIdx: ctx.anyStrTypeIdx },
               ]
-            : [{ op: "local.get", index: 2 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }];
+            : elemKey === "f64"
+              ? [
+                  { op: "local.get", index: 2 },
+                  { op: "call", funcIdx: unboxNumIdx! },
+                ]
+              : [{ op: "local.get", index: 2 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 3 },
         { op: "ref.cast", typeIdx: vecTypeIdx },

--- a/tests/issue-3311-string-vec-push-pop.test.ts
+++ b/tests/issue-3311-string-vec-push-pop.test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3311 (G4 of the #2928 `CallBuiltin` prerequisite chain) — `string[]` push /
+// pop on a genuinely-`any` receiver under `--target standalone` / `--target
+// wasi`.
+//
+// Root cause: the carrier-generic `__vec_push` / `__vec_pop` helpers (built in
+// vec-access-exports.ts) covered only the externref / f64 / i32 element
+// carriers. The native-string vec carrier (`string[]` under nativeStrings lowers
+// to a vec of `(ref null $AnyString)` elements, keyed `ref_<anyStrTypeIdx>`) was
+// NOT in `mutEntries`, so `__vec_push` returned the `-1` unsupported-carrier
+// sentinel → the #2927 `$__vec_base` brand arm mapped that to `undefined` (a
+// silent no-op), and `__vec_pop` returned `undefined` for the same receivers.
+//
+// Fix (#3311): `mutEntries` admits the native-string carrier, and the
+// `__vec_push`/`__vec_pop`/`__vec_set_elem` value-marshaling arms recover the GC
+// string ref from the externref value (`any.convert_extern` +
+// `ref.cast_null $AnyString`) / box a popped element back (`extern.convert_any`).
+//
+// The standalone assertions instantiate with an EMPTY import object and first
+// assert the module declares ZERO function imports — the behaviour is truly
+// HOST-FREE, not silently satisfied by a JS host bridge. String VALUE checks are
+// done INSIDE the compiled function (returning a boolean) so no native string
+// crosses the JS boundary.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function runHost(source: string): Promise<unknown> {
+  const result: any = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error("compile: " + result.errors.map((e: any) => e.message).join("; "));
+  }
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as any).test();
+}
+
+/** Compile host-free (`target: standalone`), assert 0 function imports, run. */
+async function runStandaloneHostFree(source: string): Promise<unknown> {
+  const result: any = await compile(source, { fileName: "test.ts", target: "standalone" });
+  if (!result.success) {
+    throw new Error("compile: " + result.errors.map((e: any) => e.message).join("; "));
+  }
+  const mod = await WebAssembly.compile(result.binary);
+  const fnImports = WebAssembly.Module.imports(mod).filter((i) => i.kind === "function");
+  // The whole point of the fix: this path is host-free. If a JS host bridge
+  // import sneaks back in, the "standalone" result is a lie — fail loudly.
+  expect(fnImports.map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  const instance: any = await WebAssembly.instantiate(mod, {});
+  return instance.exports.test();
+}
+
+describe("#3311 — standalone any-receiver string[] .push/.pop mutates the native vec (host-free)", () => {
+  it("push returns the new length (was undefined/no-op standalone)", async () => {
+    const src = `function f(x: any, y: any): number { return x.push(y); }
+                 export function test(): number { return f(["a", "b"], "c"); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+
+  it("push actually appends (x.length was stuck at 2 standalone)", async () => {
+    const src = `function f(x: any, y: any): number { x.push(y); return x.length; }
+                 export function test(): number { return f(["a", "b"], "c"); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+
+  it("pushed element is readable at its index and equals the pushed string", async () => {
+    // Compare INSIDE the compiled function and return an explicit number (1/0) so
+    // the result is unambiguous across host mode (raw i32 export) and standalone.
+    const src = `function f(x: any, y: any): number { x.push(y); return x[2] === "c" ? 1 : 0; }
+                 export function test(): number { return f(["a", "b"], "c"); }`;
+    expect(await runHost(src)).toBe(1);
+    expect(await runStandaloneHostFree(src)).toBe(1);
+  });
+
+  it("repeated push accumulates", async () => {
+    const src = `function f(x: any): number { x.push("d"); x.push("e"); return x.length; }
+                 export function test(): number { return f(["a", "b", "c"]); }`;
+    expect(await runHost(src)).toBe(5);
+    expect(await runStandaloneHostFree(src)).toBe(5);
+  });
+
+  it("pop returns the last element (was undefined standalone)", async () => {
+    const src = `function f(x: any): number { return x.pop() === "c" ? 1 : 0; }
+                 export function test(): number { return f(["a", "b", "c"]); }`;
+    expect(await runHost(src)).toBe(1);
+    expect(await runStandaloneHostFree(src)).toBe(1);
+  });
+
+  it("pop shrinks the array", async () => {
+    const src = `function f(x: any): number { x.pop(); return x.length; }
+                 export function test(): number { return f(["a", "b", "c"]); }`;
+    expect(await runHost(src)).toBe(2);
+    expect(await runStandaloneHostFree(src)).toBe(2);
+  });
+
+  it("push then pop round-trips the same string value", async () => {
+    const src = `function f(x: any): number { x.push("z"); return x.pop() === "z" ? 1 : 0; }
+                 export function test(): number { return f(["a", "b"]); }`;
+    expect(await runHost(src)).toBe(1);
+    expect(await runStandaloneHostFree(src)).toBe(1);
+  });
+
+  it("a genuinely-string[]-typed receiver push still works (typed control)", async () => {
+    const src = `function f(x: string[]): number { x.push("c"); return x.length; }
+                 export function test(): number { return f(["a", "b"]); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+});


### PR DESCRIPTION
## #3311 — G4: `string[]` push/pop under standalone is a no-op

Slice **G4** of the #2928 `CallBuiltin` prerequisite chain (standalone interpreter track). `string[]` push/pop on a genuinely-`any` receiver was a **silent no-op** under `--target standalone`/`wasi`.

### Root cause
The carrier-generic `__vec_push`/`__vec_pop` helpers (`vec-access-exports.ts`) covered only the externref / f64 / i32 element carriers. A `string[]` under `nativeStrings` lowers to a vec whose backing array holds `(ref null $AnyString)` elements, keyed `ref_<anyStrTypeIdx>` — **not** in `mutEntries`. So `__vec_push` returned the `-1` unsupported-carrier sentinel, which the #2927 `$__vec_base` brand arm maps to `undefined` (silent no-op); `__vec_pop` returned `undefined` likewise. No regression from #2592 — it was already broken.

### Fix
Admit the native-string carrier to `mutEntries` (gated `nativeStrings && anyStrTypeIdx >= 0`) and add its value-marshaling arm to the three sites that (un)box an externref against the vec:

1. **`__vec_push`** `valueInstrs` — recover the GC string ref: `any.convert_extern` + `ref.cast_null $AnyString` before `array.set` (no numeric unbox; `ref.cast_null` matches the nullable element type and tolerates a pushed `null`/`undefined`).
2. **`__vec_pop`** `boxInstrs` — box the popped element straight back with `extern.convert_any` (anyref subtype).
3. **`__vec_set_elem`** (`vec-define-writeback.ts`) — same as push. **Required**: this consumes the same `mutEntries`, and its numeric default arm would emit an i32 into a `(ref null $AnyString)` array (**invalid Wasm**) for any module with BOTH a `string[]` and `Object.defineProperty`.

`__vec_get` / `__vec_len` / `__vec_set_len` were already carrier-generic (verified). New `nativeStrVecKey(ctx)` helper centralizes the key. The new `ref.test` arm is a sibling under `$__vec_base`, so it can't cross-match the existing carriers — order-independent, no regression to the numeric/externref arms; the `-1` sentinel path is untouched for genuinely unsupported carriers (e.g. `i64`).

### Tests
- New `tests/issue-3311-string-vec-push-pop.test.ts` — 8 tests, all pass (host + standalone-host-free). Every standalone case asserts **0 function imports**.
- Existing `tests/issue-2927-standalone-any-push-pop.test.ts` — 7/7 green.
- Broad change (adds an arm to every standalone module with a `string[]` vec) — leaning on full CI / `merge_group` for conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)