### PR TITLE
fix(#3310): lift __apply_closure arity ceiling; standalone generic method-call args (G2)

### DIFF
--- a/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
+++ b/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
@@ -1,7 +1,9 @@
 ---
 id: 3310
 title: "G2 — args-passing on the standalone generic method-call path + `__apply_closure` arity>4 lift (wantArgs is host-gated)"
-status: ready
+status: done
+assignee: ttraenkler/senior-dev
+completed: 2026-07-17
 created: 2026-07-16
 priority: high
 horizon: m
@@ -80,3 +82,60 @@ Two independent caps on the standalone generic `(any, …) → any` call surface
 G1 (#3309) covers the Map/Set brand arms; G3 is done (#3098). This slice is
 the remaining "args actually flow" half of the #2927 audit's headline gap 2.
 Umbrella: #2927 → #1584.
+
+## Implementation notes (senior-dev, 2026-07-17)
+
+**Root-cause reframe — the issue's Problem #1 mis-located the reachable gap.**
+Problem #1 blamed `emitWrapperDynamicMethodCall`'s `wantArgs` host-gate
+(`calls.ts` ~2664) for standalone args being dropped. That function is real,
+but on current `main` **all three of its callers are JS-host-gated**, so its
+standalone args branch is never reached today:
+
+- `calls.ts` #2838 dynamic-`this` site — gated `!noJsHost(ctx)`;
+- `calls-closures.ts` #1712 fnctor-instance site — gated `!ctx.standalone && !ctx.wasi`;
+- `call-receiver-method.ts` #1397 wrapper-reassignment site — passes **no**
+  `callExpr`, so `wantArgs` is always `false` there (arg-less).
+
+The **genuinely-reachable** standalone open-`$Object` args lane is the #799 WI3
+generic bridge in `call-receiver-method.ts` (~3070), which *already* builds the
+arg vec with the native `$ObjVec` builders (`ensureObjVecBuilders`, gated
+`ctx.standalone`) and always packs args — so args ≤4 were **already flowing** in
+standalone. Verified empirically: on `main`, an open-object stored-closure call
+returns the correct value for 1–4 args (0 host imports) but returns the
+undefined sentinel (`0` in numeric ctx) for **5–6 args**.
+
+So the one reachable blocker was **the `__apply_closure` arity ceiling** — the
+arity switch only dispatched `n = __extern_length(args)` to
+`__call_fn_method_0..4`; 5+ args fell through to the undefined sentinel. The
+higher `__call_fn_method_5..8` exports **already exist** (`index.ts` #2687 cap =
+`min(moduleMaxClosureArity, 8)`) but the switch never reached them.
+
+**What landed:**
+
+1. **Arity lift (the fix)** — `fillApplyClosure` (`object-runtime.ts`) now
+   extends the arity switch from a hard `4` up to the highest emitted
+   `__call_fn_method_N` (`callMethod(n) !== undefined`, i.e. the #2687 cap),
+   **gated `ctx.standalone || ctx.wasi`**. Host modules keep the 0..4 ceiling →
+   byte-identical (verified: host binaries for open-object / Map.forEach /
+   Array.map are SHA-identical main-vs-branch). `buildArm(n)`/`ARG_OF(k)`
+   already source args positionally from the vec via `__extern_get_idx` and
+   thread recv→thisVal / fn→closure for arbitrary `n`, so this is purely a
+   loop-bound change wiring up dispatchers that already existed.
+2. **`emitWrapperDynamicMethodCall` args builder (latent/defensive)** — dropped
+   the `&& !ctx.standalone && !ctx.wasi` gate on `wantArgs` and select the
+   native `$ObjVec` push under `ctx.standalone`, mirroring the reachable #799
+   lane. This changes **no existing module** (the helper isn't reached in
+   standalone today) but makes it correct-by-construction if a standalone caller
+   is wired in. Kept the gating on `ctx.standalone` only (NOT `standalone||wasi`)
+   so the arg-less #1397 wrapper site's pre-existing wasi behaviour is unchanged.
+
+**Deliberately out of scope:** the `if (ctx.standalone)` (vs `standalone||wasi`)
+host-builder-in-wasi mismatch at `call-receiver-method.ts` ~3085 is a separate
+pre-existing bug on a target not in this issue's acceptance criteria; left as a
+follow-up to avoid untested wasi byte-risk.
+
+**Validation:** `tests/issue-3310.test.ts` — open-`$Object` stored closure with
+1–6 args, standalone, asserting correct positional sum + **zero host imports**;
+the 5-/6-arg cases are the regression guard (returned `0` on main). A distinct-
+digit arity-5 case (`12345`) proves positional fidelity. Host byte-stability
+diffed separately (identical).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2653,17 +2653,36 @@ export function emitWrapperDynamicMethodCall(
   callExpr?: ts.CallExpression,
 ): ValType | null {
   // (#1888 Slice 2) Standalone routes __extern_method_call native, which reads
-  // its args over a $ObjVec — build the (empty) args list with the native
-  // $ObjVec builder, not the host __js_array_new. JS-host keeps the host import.
+  // its args over a $ObjVec — build the args list with the native $ObjVec
+  // builders (__objvec_new / __objvec_push), not the host __js_array_new /
+  // __js_array_push. JS-host keeps the host imports (byte-identical).
+  //
+  // (#3310) LATENT/DEFENSIVE — the standalone empty-args restriction that used
+  // to gate `wantArgs` off (`&& !ctx.standalone && !ctx.wasi`) is lifted so this
+  // helper is correct-by-construction if a standalone caller is ever wired in.
+  // It changes NO existing module: all three current callers are JS-host-gated
+  // (the #2838 dynamic-`this` site is `!noJsHost`, the #1712 fnctor-instance
+  // site is `!ctx.standalone && !ctx.wasi`, and the #1397 wrapper-reassignment
+  // site passes NO callExpr → `wantArgs` is always false there), so the native
+  // args branch below is not reached today. The genuinely-reachable standalone
+  // open-`$Object` args lane is the #799 WI3 generic bridge in
+  // call-receiver-method.ts (which already flows args natively); the reachable
+  // gap #3310 fixes is the `__apply_closure` arity ceiling, not this helper.
+  // Gating stays on `ctx.standalone` (mirroring that reachable lane) so the
+  // pre-existing wasi behaviour of the arg-less #1397 path is unchanged.
   const arrNewIdx = ctx.standalone
     ? ensureObjVecBuilders(ctx).newIdx
     : ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
-  // (#1712) Args support: when a call expression with arguments is supplied,
-  // pack them into the args array via __js_array_push. JS-host only — the
-  // standalone $ObjVec path stays empty-args until it grows a native push.
-  const wantArgs = callExpr !== undefined && callExpr.arguments.length > 0 && !ctx.standalone && !ctx.wasi;
+  // Args support: when a call expression with arguments is supplied, pack them
+  // into the args vector. Under standalone this uses the native $ObjVec push
+  // (__objvec_push, void result — same stack shape as the host __js_array_push).
+  // `arrNewIdx` and `arrPushIdx` MUST come from the SAME domain: a native
+  // __objvec_push on a host array (or vice-versa) would type-mismatch/crash.
+  const wantArgs = callExpr !== undefined && callExpr.arguments.length > 0;
   const arrPushIdx = wantArgs
-    ? ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], [])
+    ? ctx.standalone
+      ? ensureObjVecBuilders(ctx).pushIdx
+      : ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], [])
     : undefined;
   const methodCallIdx = ensureLateImport(
     ctx,

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4306,8 +4306,17 @@ export function reserveApplyClosure(ctx: CodegenContext): number {
  *   n = i32(__extern_length(args))
  *   if n==0: __call_fn_method_0(recv, fn)
  *   if n==1: __call_fn_method_1(recv, fn, idx0)
- *   ... up to 4 ...
- *   else (n>4): return undefined (sentinel)
+ *   ... up to the highest emitted arity ...
+ *   else (n above cap): return undefined (sentinel)
+ *
+ * (#3310) Arity lift: the dispatch now extends past 4 to the highest
+ * `__call_fn_method_N` export that index.ts emits (#2687 cap =
+ * min(moduleMaxClosureArity, 8)) so a 5+-arg dynamic method call no longer falls
+ * off the bridge. Gated to standalone/wasi — host modules that emit this bridge
+ * keep the 0..4 ceiling and stay byte-identical. This is the E5 prerequisite for
+ * the #2928 interpreter's `CallBuiltin`, whose calling convention is exactly this
+ * bridge's `(fn, recv, argsVec)`: the lift removes the arity-4 cap that would
+ * otherwise clip a builtin's argument surface.
  *
  * S1 SCOPE — NO THROWS. This bridge returns the undefined sentinel
  * (`ref.null.extern`) for the not-a-function and arity-overflow cases rather
@@ -4378,9 +4387,25 @@ export function fillApplyClosure(ctx: CodegenContext): void {
     return ops;
   };
 
-  // if n==0 .. n==4 else undefined. Nest as if/else chain.
+  // (#3310) Arity lift. Arities 0..4 always dispatch (byte-identical to the
+  // pre-#3310 bridge). Under standalone/wasi ONLY, extend the arity switch to the
+  // higher `__call_fn_method_N` exports that index.ts already emits (#2687 cap =
+  // min(moduleMaxClosureArity, 8)) so a 5+-arg dynamic call no longer falls off
+  // the bridge and returns undefined (headline gap 2). An n>=5 arm is added only
+  // when its dispatcher was actually emitted (`callMethod(n) !== undefined`) — a
+  // missing one means no closure of that arity exists in the module, so the arm
+  // would be dead. Host mode is gated OUT (keeps the 0..4 ceiling), so host
+  // modules that emit this bridge stay byte-identical. Above the highest emitted
+  // arity the undefined sentinel still stands (S1 no-throw discipline, see header).
+  let maxDispatchArity = 4;
+  if (ctx.standalone || ctx.wasi) {
+    for (let n = 5; n <= 8; n++) {
+      if (callMethod(n) !== undefined) maxDispatchArity = n;
+    }
+  }
+  // if n==0 .. n==maxDispatchArity else undefined. Nest as if/else chain.
   let dispatch: Instr[] = armUnsupported;
-  for (let n = 4; n >= 0; n--) {
+  for (let n = maxDispatchArity; n >= 0; n--) {
     dispatch = [
       { op: "local.get", index: 3 },
       { op: "i32.const", value: n },

--- a/tests/issue-3310.test.ts
+++ b/tests/issue-3310.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3310 — G2: args flow on the standalone generic method-call path + the
+ * `__apply_closure` arity ceiling lift (E5 `CallBuiltin` prerequisite).
+ *
+ * A dynamic method call on an open-`$Object` receiver in standalone routes
+ * through the #799 WI3 generic bridge (`call-receiver-method.ts`), which builds
+ * the arg vector with the native `$ObjVec` builders and calls
+ * `__extern_method_call(recv, name, argsVec)` → the `$Object` arm →
+ * `__apply_closure(fn, recv, argsVec)`. `__apply_closure` dispatched the dynamic
+ * arg count (`__extern_length(args)`) only to `__call_fn_method_0..4`; a call
+ * with 5+ args fell off the bridge and returned the undefined sentinel (→ `0`
+ * in numeric context). The higher `__call_fn_method_5..8` exports already exist
+ * (index.ts #2687 cap), so the fix (fillApplyClosure, object-runtime.ts) extends
+ * the arity switch to the highest emitted dispatcher (standalone/wasi only, so
+ * host modules stay byte-identical).
+ *
+ * Regression guard: on main the 5- and 6-arg cases returned `0`; here they must
+ * return the correct sum. Every case compiles standalone and must instantiate
+ * with ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary!);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+/**
+ * Build a source that stores an N-ary arrow on an open `$Object` and invokes it
+ * with args `1..N`; the callee returns the sum, so the return value proves every
+ * argument reached the callee positionally (`1 + 2 + ... + N`).
+ */
+function openObjectClosureCall(nargs: number): string {
+  const params = Array.from({ length: nargs }, (_, i) => `a${i}: number`).join(", ");
+  const sum = Array.from({ length: nargs }, (_, i) => `a${i}`).join(" + ");
+  const callArgs = Array.from({ length: nargs }, (_, i) => String(i + 1)).join(", ");
+  return `export function test(): number {
+    const o: any = {};
+    o.m = (${params}) => ${sum};
+    return o.m(${callArgs});
+  }`;
+}
+
+const expectedSum = (n: number): number => (n * (n + 1)) / 2;
+
+describe("#3310 — standalone generic method-call args + apply_closure arity lift", () => {
+  // Arities 1..4 were already correct (the bridge dispatched __call_fn_method_0..4);
+  // they guard against a regression of the pre-existing behaviour.
+  for (const n of [1, 2, 3, 4]) {
+    it(`open-$Object stored closure receives ${n} arg(s)`, async () => {
+      expect(await runStandalone(openObjectClosureCall(n))).toBe(expectedSum(n));
+    });
+  }
+
+  // Arities 5..6 are the #3310 fix: on main these fell off the arity-4 ceiling
+  // and returned the undefined sentinel (0). They must now dispatch correctly.
+  for (const n of [5, 6]) {
+    it(`open-$Object stored closure receives ${n} arg(s) (arity > 4 — #3310 lift)`, async () => {
+      expect(await runStandalone(openObjectClosureCall(n))).toBe(expectedSum(n));
+    });
+  }
+
+  // Distinct (non-arithmetic-symmetric) args so a dropped/mis-ordered arg cannot
+  // coincidentally still sum correctly — proves positional fidelity at arity 5.
+  it("arity-5 call passes each argument to the correct position", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        o.m = (a: number, b: number, c: number, d: number, e: number) =>
+          a * 10000 + b * 1000 + c * 100 + d * 10 + e;
+        return o.m(1, 2, 3, 4, 5);
+      }`),
+    ).toBe(12345);
+  });
+});


### PR DESCRIPTION
## #3310 — G2: standalone generic method-call args + `__apply_closure` arity>4 lift

E5 `CallBuiltin` prerequisite (per the 2026-07-17 interpreter-backend audit). G1/G3 done; this is the remaining "args actually flow + arity" half of the #2927 audit's headline gap 2.

### Root cause (reframe)
The issue's Problem #1 blamed `emitWrapperDynamicMethodCall`'s host-gated `wantArgs`, but **all three of its callers are JS-host-gated**, so that branch is unreachable in standalone today. The genuinely-reachable standalone open-`$Object` args lane is the #799 WI3 generic bridge in `call-receiver-method.ts`, which **already** builds the arg vec natively and flows args ≤4. The one reachable blocker was the **`__apply_closure` arity ceiling**: its arity switch dispatched `n = __extern_length(args)` only to `__call_fn_method_0..4`, so a 5+-arg dynamic method call fell off the bridge and returned the undefined sentinel (`0` in numeric context) — even though `__call_fn_method_5..8` already exist (`index.ts` #2687 cap = `min(moduleMaxClosureArity, 8)`).

### Changes
- **`fillApplyClosure` (`object-runtime.ts`) — the fix.** Extend the arity switch from a hard `4` up to the highest emitted `__call_fn_method_N` (`callMethod(n) !== undefined`), **gated `ctx.standalone || ctx.wasi`** so host modules keep the 0..4 ceiling and stay byte-identical. `buildArm`/`ARG_OF` already source args positionally from the vec via `__extern_get_idx` and thread recv→thisVal / fn→closure for arbitrary `n` — this only wires up dispatchers that already existed.
- **`emitWrapperDynamicMethodCall` (`calls.ts`) — latent/defensive.** Drop the `&& !ctx.standalone && !ctx.wasi` gate on `wantArgs` and select the native `$ObjVec` push under `ctx.standalone` (mirroring the reachable #799 lane). Changes **no existing module** (the helper isn't reached in standalone today); makes it correct-by-construction for a future standalone caller. Gating stays `ctx.standalone` (not `standalone||wasi`) so the arg-less #1397 wrapper site's pre-existing wasi behaviour is unchanged.

**Out of scope:** the `if (ctx.standalone)` vs `standalone||wasi` host-builder-in-wasi mismatch at `call-receiver-method.ts` ~3085 is a separate pre-existing bug on a target not in this issue's acceptance criteria — left as a follow-up to avoid untested wasi byte-risk.

### Validation
- `tests/issue-3310.test.ts`: open-`$Object` stored closure with 1–6 args, standalone, asserting correct positional sum + **zero host imports**. The 5-/6-arg cases are the regression guard (returned `0` on main); a distinct-digit arity-5 case (`12345`) proves positional fidelity. 7/7 pass.
- Empirical delta: on `main` this repro returns correct values for 1–4 args but `0` for 5–6; on this branch all 1–6 pass with 0 imports.
- **Host byte-stability:** host binaries for open-object / Map.forEach / Array.map are SHA-identical main-vs-branch.
- `tsc --noEmit` clean; prettier clean.

### Acceptance criteria
- [x] Standalone: a dynamic method call through the generic open-`$Object` lane receives its arguments (values observable in the callee).
- [x] A 5+-arg call through `__apply_closure` dispatches (no undefined fall-through).
- [x] Host mode byte-stable; scoped suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)