### PR TITLE
fix(#3155): native standalone join for externref arrays (Object.keys().join)

### DIFF
--- a/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
+++ b/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
@@ -18,6 +18,11 @@ loc-budget-allow:
   # (#3155) the native standalone externref-join `compileArrayJoinExternNative`
   # must live beside `compileArrayJoinExtern` in array-methods.ts (+~100 LOC).
   - src/codegen/array-methods.ts
+coercion-sites-allow:
+  # (#3155) the native externref-join mirrors compileArrayJoinNative's existing
+  # `__extern_toString` element-ToString (§7.1.17) — same coercion vocabulary,
+  # relocated into the new externref-receiver arm, not novel hand-rolling.
+  - src/codegen/array-methods.ts
 ---
 
 # #3155 — standalone object spread / assign / key-enumeration gaps

--- a/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
+++ b/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
@@ -1,16 +1,17 @@
 ---
 id: 3155
 title: "standalone: object spread / Object.assign / Object.keys-values order + object→primitive gaps (unmasked by the #86 vacuous-standalone audit)"
-status: ready
+status: done
+completed: 2026-07-17
 sprint: current
 created: 2026-07-11
-updated: 2026-07-16
+updated: 2026-07-17
 priority: medium
 horizon: m
 feasibility: medium
 area: codegen, runtime
 goal: standalone-mode
-related: [86, 2131, 2746, 2804]
+related: [86, 2131, 2746, 2804, 3342]
 origin: "#86 {standalone:true}-option-ignored audit (fable-wasm, 2026-07-11) — 3 tests were asserting standalone behavior while vacuously running gc-host; the real standalone lane fails."
 loc-budget-allow:
   - src/compiler.ts
@@ -82,3 +83,45 @@ root); listing them here so the acceptance measurement includes them.
   regressions.
 - `built-ins/Object/{keys,values,assign,getOwnPropertyNames}` + object-spread
   standalone test262 improve (measure).
+
+## Resolution (2026-07-17, opus-c)
+
+**Measured first.** Compiling the issue's cases with `target: "standalone"` and a
+`WebAssembly.Module.imports` probe pinned the concrete failure: the
+`Cannot convert object to primitive value` symptom is the **externref-array
+`join`** path. `Object.keys(o).join(sep)` leaked `env::__array_join_any` (an
+unsatisfiable host import → instantiate-against-`{}` fails). The other listed
+sub-parts were already host-free on current main: object **spread** (`{...a,z}`),
+**Object.assign**, **Object.keys(o).length**, and **Object.entries(o).length**
+all compile to zero `env::*` imports and run correctly standalone.
+
+**Fix.** Added `compileArrayJoinExternNative` (`src/codegen/array-methods.ts`):
+under `noJsHost`, `compileArrayJoinExtern` now walks the externref array
+natively — length via `__extern_length`, each element via `__extern_get_idx`
+then §7.1.17 ToString via `__extern_toString` (all native-registered standalone,
+the same helpers the receiver's own `.length` already uses host-free) — and folds
+with the shared `emitStringJoinFold` over the native-string representation,
+mirroring the WasmGC-vec `compileArrayJoinNative`. Host lane is byte-identical
+(guarded on `noJsHost`; the 23 host-lane assertions in issue-2131/2746/2804 stay
+green).
+
+**Verified fixed standalone:** `Object.keys(o).join()` / `.join(",")` /
+multi-char sep / integer-key canonical order (`"1,2,b,a"`) / empty-object (`""`)
+/ single-key — all host-free and correct.
+
+**Delivered:**
+
+- `tests/issue-3155.test.ts` — permanent regression guard (#2093), in-wasm
+  correctness + zero-`env::*`-import assertions.
+- `tests/issue-2131.test.ts` — the vacuous `it.skip("standalone …")` is
+  **un-skipped** and converted to a real in-wasm check (integer-key order), now
+  passing on the true standalone lane.
+
+**Carved out to #3342:** `Object.values(o).join(...)` and
+`Object.getOwnPropertyNames(o).join(...)` take a **different** dispatch arm — the
+join receiver-type probe misclassifies their result as a `Uint8ClampedArray`, so
+they route to the TypedArray-`join` host lowering and leak
+`env::Uint8ClampedArray_join`. Distinct root cause (type inference / probe
+misread), unrelated to the externref-join fix here — tracked in #3342. The
+describe.skip standalone blocks in issue-2746/2804 remain skipped because they
+exercise those still-gapped `Object.values` / `getOwnPropertyNames` paths.

--- a/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
+++ b/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
@@ -15,6 +15,9 @@ related: [86, 2131, 2746, 2804, 3342]
 origin: "#86 {standalone:true}-option-ignored audit (fable-wasm, 2026-07-11) — 3 tests were asserting standalone behavior while vacuously running gc-host; the real standalone lane fails."
 loc-budget-allow:
   - src/compiler.ts
+  # (#3155) the native standalone externref-join `compileArrayJoinExternNative`
+  # must live beside `compileArrayJoinExtern` in array-methods.ts (+~100 LOC).
+  - src/codegen/array-methods.ts
 ---
 
 # #3155 — standalone object spread / assign / key-enumeration gaps

--- a/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
+++ b/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
@@ -1,0 +1,76 @@
+---
+id: 3342
+title: "standalone: Object.values(o).join / Object.getOwnPropertyNames(o).join misclassify receiver as Uint8ClampedArray → leak env::Uint8ClampedArray_join"
+status: ready
+sprint: current
+created: 2026-07-17
+priority: medium
+horizon: s
+feasibility: medium
+model: opus
+task_type: fix
+area: codegen
+language_feature: standalone-completeness, array-join, type-inference
+goal: standalone-parity
+related: [3155, 3170]
+origin: "carved out of #3155 (fix-standalone-object-keys-join, opus-c 2026-07-17) — Object.keys().join was fixed via the native externref-join path, but Object.values()/getOwnPropertyNames() take a DIFFERENT, distinct-root-cause path."
+---
+
+# #3342 — standalone `Object.values(o).join` / `Object.getOwnPropertyNames(o).join` leak `env::Uint8ClampedArray_join`
+
+## Source
+
+Surfaced while fixing **#3155** (standalone `Object.keys(o).join(sep)`). That fix
+added a native externref-`join` path (`compileArrayJoinExternNative`,
+array-methods.ts) reached when the join-dispatch classifies the receiver as an
+externref. `Object.keys(o).join(...)` now works host-free standalone.
+
+But `Object.values(o).join(...)` and `Object.getOwnPropertyNames(o).join(...)`
+take a **different** dispatch path and are NOT fixed by #3155.
+
+## Problem (measured, current main + #3155 branch)
+
+```ts
+export function test(): boolean {
+  const o: any = { a: 1, b: 2 };
+  return (Object.values(o) as any).join(",") === "1,2"; // standalone
+}
+```
+
+compiles (with `target: "standalone"`) to a module importing
+`env::Uint8ClampedArray_join` — an unsatisfiable host import (module fails to
+instantiate against `{}`). Identical symptom for
+`Object.getOwnPropertyNames(o).join(...)`. `Object.keys(o).join(...)` (fixed by
+#3155) and `Object.entries(o).length` are host-free.
+
+## Root cause (to confirm)
+
+The `join` receiver-type probe (`array-methods.ts`, the `receiverIsExternref` /
+`actualType` classification around the method dispatch) classifies the
+`Object.values` / `Object.getOwnPropertyNames` result as a **Uint8ClampedArray**
+rather than a boxed externref array, so the dispatch routes to the TypedArray
+`join` lowering (`env::<TA>_join`) instead of the externref path that #3155 made
+native. Why those two builtins' results infer to a clamped typed array (while
+`Object.keys` infers to a plain array/externref) is the thing to pin down — most
+likely a return-type / lib.d.ts inference quirk or a probe misread of the
+runtime shape.
+
+## Fix direction
+
+- Confirm via a WAT/import probe which dispatch arm is chosen for the
+  `Object.values` / `getOwnPropertyNames` receiver (TypedArray-`join` vs
+  externref-`join`).
+- Correct the classification so these externref-array results take the native
+  externref-`join` path (`compileArrayJoinExternNative`, already host-free), OR
+  give the TypedArray-`join` host arm a `noJsHost` native fallback if the
+  receiver genuinely is a native typed-array here.
+- Do NOT add a host import without a standalone fallback (dual-mode contract).
+
+## Acceptance
+
+1. `Object.values(o).join(sep)` and `Object.getOwnPropertyNames(o).join(sep)`
+   compile with `target: "standalone"` to a module with **no** `env::*` import
+   and produce the correct joined string (verified in-wasm, mirroring
+   `tests/issue-3155.test.ts`).
+2. Add coverage to `tests/issue-3155.test.ts` (or a new `tests/issue-3342.test.ts`).
+3. No test262 regression; host-lane byte-identity.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3795,12 +3795,113 @@ function compileArrayConcatExtern(
  * cast". Instead, delegate to the host's `Array.prototype.join` via the
  * `__array_join_any` import, which handles JS arrays and WasmGC vecs.
  */
+/**
+ * #3155 — standalone (`noJsHost`) `arr.join(sep?)` for an EXTERNREF receiver
+ * (e.g. `Object.keys(any).join(",")`, whose receiver is a boxed array walked
+ * via the native `__extern_length` / `__extern_get_idx` boundary).
+ *
+ * The host lane's {@link compileArrayJoinExtern} delegates to the JS
+ * `__array_join_any` import, which is an unsatisfiable `env::*` import in
+ * standalone mode (CLAUDE.md "Dual-mode: JS host optional"). This lane instead
+ * walks the externref array natively — length via `__extern_length`, each
+ * element via `__extern_get_idx` then ToString via `__extern_toString` (both
+ * native-registered under standalone, the same helpers the receiver's `.length`
+ * already uses host-free) — and folds with the shared {@link emitStringJoinFold}
+ * over the native-string representation, mirroring {@link compileArrayJoinNative}.
+ *
+ * Returns `null` (⇒ caller falls back to the host import) when the native
+ * string helpers are unavailable.
+ */
+function compileArrayJoinExternNative(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): ValType | null {
+  const repr = nativeStringRepr(ctx);
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  if (repr === undefined || anyStrTypeIdx < 0) return null;
+
+  // Native extern-array boundary helpers. `__extern_length`/`__extern_get_idx`
+  // carry f64 length/index (§ import-manifest); `__extern_toString` is the same
+  // §7.1.17 ToString the boxed-any element path uses. All three have native
+  // arms under standalone (the receiver's own `.length` read proves it), so
+  // these `ensureLateImport`s resolve to the native funcs, not host imports.
+  const externLenIdx = ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
+  const externGetIdx = ensureLateImport(
+    ctx,
+    "__extern_get_idx",
+    [{ kind: "externref" }, { kind: "f64" }],
+    [{ kind: "externref" }],
+  );
+  const externToStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (externLenIdx === undefined || externGetIdx === undefined || externToStrIdx === undefined) return null;
+
+  const recvTmp = allocLocal(fctx, `__ejoin_recv_${fctx.locals.length}`, { kind: "externref" });
+  const foldLocals = allocJoinFoldLocals(fctx, repr, "ejoin");
+  const { lenTmp, iTmp, resultTmp, sepTmp } = foldLocals;
+
+  // Receiver → externref, retained in recvTmp. len = trunc(__extern_length(recv)).
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (recvType && recvType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+  fctx.body.push({ op: "local.tee", index: recvTmp });
+  fctx.body.push({ op: "call", funcIdx: externLenIdx });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+  fctx.body.push({ op: "local.set", index: lenTmp });
+
+  // Separator: explicit arg (coerced to a native string) or the spec default ",".
+  if (callExpr.arguments.length >= 1) {
+    const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!, { kind: "externref" });
+    if (argType === null) {
+      fctx.body.push(...nativeStringLiteralInstrs(ctx, ","));
+    } else {
+      fctx.body.push({ op: "any.convert_extern" });
+      fctx.body.push({ op: "ref.cast", typeIdx: anyStrTypeIdx });
+    }
+  } else {
+    fctx.body.push(...nativeStringLiteralInstrs(ctx, ","));
+  }
+  fctx.body.push({ op: "local.set", index: sepTmp });
+
+  // result = "" (empty-array join is "", #1968) and i = 0.
+  fctx.body.push(...nativeStringLiteralInstrs(ctx, ""));
+  fctx.body.push({ op: "local.set", index: resultTmp });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: iTmp });
+
+  // element → ref $AnyString: __extern_toString(__extern_get_idx(recv, i)).
+  const elemToStr: Instr[] = [
+    { op: "local.get", index: recvTmp },
+    { op: "local.get", index: iTmp },
+    { op: "f64.convert_i32_s" },
+    { op: "call", funcIdx: externGetIdx },
+    { op: "call", funcIdx: externToStrIdx },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: anyStrTypeIdx },
+  ];
+  emitStringJoinFold(ctx, fctx, repr, foldLocals, elemToStr);
+
+  // Return the joined native string as externref for the caller.
+  fctx.body.push({ op: "local.get", index: resultTmp });
+  fctx.body.push({ op: "extern.convert_any" });
+  return { kind: "externref" };
+}
+
 function compileArrayJoinExtern(
   ctx: CodegenContext,
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
 ): ValType | null {
+  // #3155 — standalone/WASI has no JS host, so the `__array_join_any` delegation
+  // below leaks an unsatisfiable `env::__array_join_any` import (the module
+  // fails to instantiate). Walk the externref array natively instead.
+  if (noJsHost(ctx)) {
+    const native = compileArrayJoinExternNative(ctx, fctx, propAccess, callExpr);
+    if (native !== null) return native;
+    // else fall through — native string helpers unavailable, best-effort host.
+  }
   const joinAnyIdx = ensureLateImport(
     ctx,
     "__array_join_any",

--- a/tests/issue-2131.test.ts
+++ b/tests/issue-2131.test.ts
@@ -90,19 +90,20 @@ describe("#2131 — JS-host integer-key enumeration order", () => {
 
   // (#86/#3155) This "standalone" test ran gc-host vacuously (the `{ standalone:
   // true }` option was silently ignored) — the #1837 "fix" was never exercised
-  // on the real lane. On the true `target: "standalone"` lane the
-  // `Object.keys(o).join(",")` path fails. Skipped-pending-#3155 (HONEST — was
-  // vacuously "passing"). The host-mode order test above keeps real coverage.
-  it.skip("standalone mode (already fixed by #1837) keeps the same order", async () => {
+  // on the real lane. #3155 wired the native externref-`join` path so
+  // `Object.keys(o).join(",")` is host-free on the real `target: "standalone"`
+  // lane. A standalone string export is an opaque `ref $AnyString` from JS, so
+  // the order is verified in-wasm via a native `===` compare returning a boolean.
+  it("standalone mode keeps the same integer-key-first order (#3155)", async () => {
     const out = await run(
       `
-      export function test(): string {
+      export function test(): boolean {
         const o: any = { b: 1, "2": 2, a: 3, "1": 4 };
-        return Object.keys(o).join(",");
+        return Object.keys(o).join(",") === "1,2,b,a";
       }
     `,
       { target: "standalone" },
     );
-    expect(out).toBe("1,2,b,a");
+    expect(out).toBe(1);
   });
 });

--- a/tests/issue-3155.test.ts
+++ b/tests/issue-3155.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3155 — standalone `Object.keys(o).join(sep)` must not leak `env::__array_join_any`.
+//
+// `Object.keys(any)` yields a boxed (externref) array. The array-`join` dispatch
+// routes an externref receiver through `compileArrayJoinExtern`, which on the
+// JS-host lane delegates to the `__array_join_any` host import. Under
+// `--target standalone` there is no JS host, so that import is unsatisfiable —
+// the module fails to instantiate against an empty import object, and the real
+// test262 symptom is a `TypeError: Cannot convert object to primitive value` on
+// paths like `Object.keys(o).join(",")` (surfaced by the #86 vacuous-standalone
+// audit; contrast the receiver's own `.length`, which was already host-free via
+// the native `__extern_length` arm).
+//
+// The fix (`compileArrayJoinExternNative`, array-methods.ts) walks the externref
+// array natively under `noJsHost`: length via `__extern_length`, each element
+// via `__extern_get_idx` then §7.1.17 ToString via `__extern_toString` (all
+// native-registered standalone), folded with the shared `emitStringJoinFold`
+// over the native-string representation — the same machinery the WasmGC-vec
+// `join` lane uses. The host lane is byte-identical (guarded on `noJsHost`).
+//
+// This is the permanent regression guard required by the #2093 probe-coverage
+// gate. Since a standalone string export is an opaque `ref $AnyString` from JS,
+// the join *result* is verified in-wasm via a native `===` compare and returned
+// as a boolean; the no-`env::*`-leak property is verified by instantiating
+// against an empty `{}` import object (a leaked import would throw a LinkError).
+//
+// Carve-out: `Object.values(o).join(...)` currently routes through a distinct
+// TypedArray-join misclassification (leaks `env::Uint8ClampedArray_join`) that
+// is unrelated to this externref-join fix — tracked separately, out of scope.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Probe {
+  envImports: string[];
+  result: unknown;
+}
+
+async function standaloneProbe(src: string): Promise<Probe> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone module failed WebAssembly.validate").toBe(true);
+  const mod = new WebAssembly.Module(r.binary);
+  const envImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  // Instantiate against an EMPTY import object — a leaked env import throws here.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const result = (instance.exports as { test: () => unknown }).test();
+  return { envImports, result };
+}
+
+describe("#3155 — standalone Object.keys().join is host-free", () => {
+  it("default separator: Object.keys(o).join() has no env leak and is correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2, c: 3 };
+         return Object.keys(o).join() === "a,b,c";
+       }`,
+    );
+    expect(envImports).not.toContain("__array_join_any");
+    expect(result).toBe(1);
+  });
+
+  it("explicit comma separator has no env leak and is correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return Object.keys(o).join(",") === "a,b";
+       }`,
+    );
+    expect(envImports).not.toContain("__array_join_any");
+    expect(result).toBe(1);
+  });
+
+  it("multi-char separator has no env leak and is correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2, c: 3 };
+         return Object.keys(o).join(" - ") === "a - b - c";
+       }`,
+    );
+    expect(envImports).not.toContain("__array_join_any");
+    expect(result).toBe(1);
+  });
+
+  it("integer-key canonical order is preserved (ascending index keys first)", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { b: 1, "2": 2, a: 3, "1": 4 };
+         return Object.keys(o).join(",") === "1,2,b,a";
+       }`,
+    );
+    expect(envImports).not.toContain("__array_join_any");
+    expect(result).toBe(1);
+  });
+
+  it("empty object joins to the empty string (not the string 'null')", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = {};
+         return Object.keys(o).join(",") === "";
+       }`,
+    );
+    expect(envImports).not.toContain("__array_join_any");
+    expect(result).toBe(1);
+  });
+
+  it("single-key object needs no separator emission", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { only: 42 };
+         return Object.keys(o).join(",") === "only";
+       }`,
+    );
+    expect(envImports).not.toContain("__array_join_any");
+    expect(result).toBe(1);
+  });
+
+  it("the standalone module has zero env imports for the join program", async () => {
+    const { envImports } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return Object.keys(o).join(",") === "a,b";
+       }`,
+    );
+    expect(envImports, `standalone module must have no env imports, got: ${envImports.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## #3155 — standalone `Object.keys(o).join(sep)` leaked `env::__array_join_any`

`Object.keys(any)` yields a boxed (externref) array. The array-`join` dispatch
routes an externref receiver through `compileArrayJoinExtern`, which delegated
to the JS `__array_join_any` host import. Under `--target standalone` that
import is unsatisfiable — the module fails to instantiate against `{}` and the
real test262 symptom is `TypeError: Cannot convert object to primitive value` on
`Object.keys(o).join(",")` (surfaced by the #86 vacuous-standalone audit;
contrast the receiver's own `.length`, already host-free via the native
`__extern_length` arm).

## Fix
`compileArrayJoinExternNative` (`src/codegen/array-methods.ts`): under
`noJsHost`, walk the externref array natively — length via `__extern_length`,
each element via `__extern_get_idx` then §7.1.17 ToString via
`__extern_toString` (all native-registered standalone) — folding with the
shared `emitStringJoinFold` over the native-string repr, mirroring the
WasmGC-vec `compileArrayJoinNative`. **Host lane byte-identical** (guarded on
`noJsHost`; the 23 host-lane assertions in issue-2131/2746/2804 stay green).

## Measured
Spread `{...a,z}`, `Object.assign`, `Object.keys().length`,
`Object.entries().length` were already host-free; only the externref-`join`
leaked. Now host-free + correct standalone: `Object.keys().join()` / `.join(sep)`
/ multi-char sep / integer-key order (`"1,2,b,a"`) / empty (`""`) / single-key.

## Tests
- `tests/issue-3155.test.ts` — permanent guard (#2093): in-wasm correctness +
  zero-`env::*`-import assertions (7 tests).
- `tests/issue-2131.test.ts` — un-skip the vacuous standalone `it.skip`,
  converted to a real in-wasm check; now passes on the true standalone lane.

## Carve-out
`Object.values()/getOwnPropertyNames().join` take a **different** dispatch arm
(receiver misclassified as `Uint8ClampedArray` → leaks
`env::Uint8ClampedArray_join`); distinct root cause, tracked in **#3342**.

Local: `npx vitest run tests/issue-3155.test.ts tests/issue-2131.test.ts` green;
`tsc --noEmit` clean; host-lane issue-2746/2804 unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)