### PR TITLE
feat(#1792): node:url URL / URLSearchParams as host constructors

### DIFF
--- a/plan/issues/1792-node-url-builtin-impl.md
+++ b/plan/issues/1792-node-url-builtin-impl.md
@@ -1,10 +1,12 @@
 ---
 id: 1792
 title: "node:url — URL / URLSearchParams as host constructors"
-status: ready
-sprint: Backlog
+status: done
+sprint: current
+assignee: ttraenkler/opus-b
 created: 2026-06-03
-updated: 2026-06-03
+updated: 2026-07-17
+completed: 2026-07-17
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -56,3 +58,35 @@ Tier 0 (JS-host target — standalone deferred):
 
 `tests/issue-1792.test.ts` — compile each Tier 0 snippet under JS-host config
 and assert the result against the host's native `URL`.
+
+## Resolution (opus-b, 2026-07-17)
+
+Wired `URL` / `URLSearchParams` as extern-class host constructors, mirroring the
+`Set`/`Map`/`EventEmitter` (#1794) machinery:
+
+1. **Global form** (`new URL(...)` / `new URLSearchParams(...)`):
+   `registerBuiltinExternClasses` (`src/codegen/extern-declarations.ts`)
+   registers both with their method/property tables, so construction lowers to
+   the `URL_new` / `URLSearchParams_new` host imports. `builtinCtors`
+   (`src/runtime.ts`, `typeof URL`/`URLSearchParams` guarded) binds them to the
+   real WHATWG globals. Skipped under `nativeStrings` (standalone) — a pure-Wasm
+   URL parser is deferred (approach step 4).
+2. **Import form** (`import { URL } from "node:url"`):
+   `NODE_BUILTIN_CLASS_TYPED_STUBS.url` (`src/import-resolver.ts`) supplies the
+   #1794 typed `declare namespace url { class URL {…} } + declare const URL`
+   stub → `namespacePath: ["url"]` → runtime `_resolveNamespacedClass` binds to
+   `require("url").URL` (functionally `=== globalThis.URL`).
+3. Instance property reads (`.pathname`, `.searchParams`, …) flow through the
+   generic `__extern_get` host import; method calls (`.get`, `.getAll`, …)
+   through `__extern_method_call`.
+4. `fileURLToPath` / `pathToFileURL` (AC4) were already routed via the existing
+   `NODE_BUILTIN_FN_TYPED_STUBS.url` named-function imports — verified still
+   working.
+
+**Acceptance:** AC1 (relative pathname → `/a/b`; the issue's `=== "/b"` is a typo
+— Node resolves `./b` against `file:///a/` to `/a/b`), AC2 (searchParams.get),
+AC3 (getAll), AC4 (fileURLToPath), AC6 (global + import forms) all pass. AC5 is
+the `Uint8Array`↔`Buffer` bridge — that's #1793's scope, not URL.
+
+**Note:** Tier 0 covers JS-host mode only. Standalone (WASI) URL is deferred
+(#1471/#1472 family) — a follow-up would port a pure-TS URL parser.

--- a/plan/issues/1792-node-url-builtin-impl.md
+++ b/plan/issues/1792-node-url-builtin-impl.md
@@ -18,6 +18,7 @@ parent: 1575
 related: [1044, 1494, 1400, 1032]
 loc-budget-allow:
   - src/codegen/extern-declarations.ts
+  - src/runtime.ts
 ---
 # node:url — URL / URLSearchParams as host constructors
 

--- a/plan/issues/1792-node-url-builtin-impl.md
+++ b/plan/issues/1792-node-url-builtin-impl.md
@@ -16,6 +16,8 @@ language_feature: node-builtins
 goal: npm-library-support
 parent: 1575
 related: [1044, 1494, 1400, 1032]
+loc-budget-allow:
+  - src/codegen/extern-declarations.ts
 ---
 # node:url — URL / URLSearchParams as host constructors
 

--- a/src/codegen/extern-declarations.ts
+++ b/src/codegen/extern-declarations.ts
@@ -291,6 +291,72 @@ export function registerBuiltinExternClasses(ctx: CodegenContext): void {
     });
   }
 
+  // (#1792) node:url — `URL` / `URLSearchParams` as host constructors. Both are
+  // WHATWG globals present in Node 18+ and every browser, so the JS-host path
+  // binds them via `builtinCtors` (runtime.ts) exactly like Set/Map. `new
+  // URL(...)` / `new URLSearchParams(...)` lower to `URL_new` /
+  // `URLSearchParams_new`; instance property reads (`.pathname`,
+  // `.searchParams`, …) flow through the generic `__extern_get` host import and
+  // method calls (`.get`, `.getAll`, …) through `__extern_method_call`. The
+  // method tables below give the typed-dispatch path exact arities. Standalone
+  // (WASI) needs a pure-Wasm URL parser — deferred (#1792 approach step 4), so
+  // skip registration under nativeStrings to avoid leaking an unsatisfiable
+  // `URL_new` host import into the standalone module.
+  if (!ctx.externClasses.has("URL") && !ctx.nativeStrings) {
+    const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
+    methods.set("toString", externMethod(0)); // toString() → string
+    methods.set("toJSON", externMethod(0)); // toJSON() → string
+    ctx.externClasses.set("URL", {
+      importPrefix: "URL",
+      namespacePath: [],
+      className: "URL",
+      constructorParams: [{ kind: "externref" }, { kind: "externref" }], // new URL(url, base?)
+      methods,
+      // All URL instance properties are host getters read via __extern_get;
+      // listing the common ones as readonly gives the typed path their shape.
+      properties: new Map(
+        [
+          "href",
+          "origin",
+          "protocol",
+          "username",
+          "password",
+          "host",
+          "hostname",
+          "port",
+          "pathname",
+          "search",
+          "searchParams",
+          "hash",
+        ].map((p) => [p, { type: { kind: "externref" } as ValType, readonly: p === "origin" }]),
+      ),
+    });
+  }
+
+  if (!ctx.externClasses.has("URLSearchParams") && !ctx.nativeStrings) {
+    const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
+    methods.set("append", externMethod(2)); // append(name, value) → void
+    methods.set("delete", externMethod(2, false)); // delete(name, value?) → void
+    methods.set("get", externMethod(1)); // get(name) → string | null
+    methods.set("getAll", externMethod(1)); // getAll(name) → string[]
+    methods.set("has", externMethod(2)); // has(name, value?) → boolean
+    methods.set("set", externMethod(2, false)); // set(name, value) → void
+    methods.set("sort", externMethod(0, false)); // sort() → void
+    methods.set("toString", externMethod(0)); // toString() → string
+    methods.set("forEach", externMethod(1, false)); // forEach(cb) → void
+    methods.set("entries", externMethod(0)); // entries() → Iterator
+    methods.set("keys", externMethod(0)); // keys() → Iterator
+    methods.set("values", externMethod(0)); // values() → Iterator
+    ctx.externClasses.set("URLSearchParams", {
+      importPrefix: "URLSearchParams",
+      namespacePath: [],
+      className: "URLSearchParams",
+      constructorParams: [{ kind: "externref" }], // new URLSearchParams(init?)
+      methods,
+      properties: new Map([["size", { type: { kind: "externref" }, readonly: true }]]),
+    });
+  }
+
   // #1238 — synthetic ExternClassInfo for String and Array.
   //
   // String and Array are JS built-ins, not declared classes (`declare class

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -110,6 +110,48 @@ const NODE_BUILTIN_CLASS_TYPED_STUBS: Record<string, Record<string, string>> = {
       "setMaxListeners(n: number): any;",
     ].join("\n    "),
   },
+  // (#1792) node:url — the WHATWG `URL` / `URLSearchParams` classes as named
+  // imports (`import { URL } from "node:url"`). The global form `new URL(...)`
+  // is served by the registerBuiltinExternClasses global registration; this
+  // stub gives the IMPORT form the same #1794 extern-class shape with
+  // namespacePath ["url"] so runtime `_resolveNamespacedClass` binds it to
+  // `deps.url ?? require("url")` — functionally the same host constructor as
+  // the global (`require("url").URL === globalThis.URL` in Node).
+  url: {
+    URL: [
+      "constructor(url: any, base?: any);",
+      "readonly href: string;",
+      "readonly origin: string;",
+      "readonly protocol: string;",
+      "readonly username: string;",
+      "readonly password: string;",
+      "readonly host: string;",
+      "readonly hostname: string;",
+      "readonly port: string;",
+      "readonly pathname: string;",
+      "readonly search: string;",
+      "readonly searchParams: any;",
+      "readonly hash: string;",
+      "toString(): string;",
+      "toJSON(): string;",
+    ].join("\n    "),
+    URLSearchParams: [
+      "constructor(init?: any);",
+      "readonly size: number;",
+      "append(name: string, value: string): any;",
+      "delete(name: string, value?: string): any;",
+      "get(name: string): any;",
+      "getAll(name: string): any;",
+      "has(name: string, value?: string): boolean;",
+      "set(name: string, value: string): any;",
+      "sort(): any;",
+      "toString(): string;",
+      "forEach(cb: any): any;",
+      "entries(): any;",
+      "keys(): any;",
+      "values(): any;",
+    ].join("\n    "),
+  },
 };
 
 /** (#1794) Lookup: is `name` a known node-builtin class export of `moduleName`? */

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7588,6 +7588,13 @@ function resolveImport(
           ...(typeof Intl !== "undefined" && typeof Intl.NumberFormat !== "undefined"
             ? { NumberFormat: Intl.NumberFormat }
             : {}),
+          // (#1792) node:url — WHATWG URL / URLSearchParams globals (Node 18+ /
+          // every browser). Registered as extern-class host constructors so
+          // `new URL(...)` / `new URLSearchParams(...)` bind to the real host
+          // constructor; property/method reads flow through __extern_get /
+          // __extern_method_call.
+          ...(typeof URL !== "undefined" ? { URL } : {}),
+          ...(typeof URLSearchParams !== "undefined" ? { URLSearchParams } : {}),
         };
         let Ctor = deps?.[intent.className] ?? builtinCtors[intent.className];
         // #1044 — Resolve via namespace path (e.g. require('http').Server)

--- a/tests/issue-1792.test.ts
+++ b/tests/issue-1792.test.ts
@@ -1,0 +1,87 @@
+// #1792 — node:url: URL / URLSearchParams as host constructors.
+//
+// `new URL(...)` / `new URLSearchParams(...)` (and the `node:url` named-import
+// form) previously did not lower to the host WHATWG constructors — the opaque
+// `__node_url` externref path only reached the `require("url").fn(...)` method
+// forms, so `new URL(...)` produced an empty/null object (`.pathname`
+// undefined; `new URLSearchParams(...)` returned null).
+//
+// Fix wires both as extern-class host constructors (registerBuiltinExternClasses
+// + builtinCtors for the global form; NODE_BUILTIN_CLASS_TYPED_STUBS for the
+// `node:url` named-import form). Property/method reads flow through the generic
+// __extern_get / __extern_method_call host imports in JS-host mode.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts", skipSemanticDiagnostics: true });
+  expect(r.success, `Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(true);
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports.test as () => unknown)();
+}
+
+describe("#1792 — node:url URL / URLSearchParams host constructors", () => {
+  it("new URL(relative, base).pathname resolves against the base", async () => {
+    // Node: new URL("./b", "file:///a/").pathname === "/a/b"
+    expect(await run(`export function test(): string { return new URL("./b", "file:///a/").pathname; }`)).toBe("/a/b");
+  });
+
+  it("URL.searchParams.get reads a query param", async () => {
+    expect(
+      await run(
+        `export function test(): string { return new URL("https://x.com/p?q=1").searchParams.get("q") as string; }`,
+      ),
+    ).toBe("1");
+  });
+
+  it("URL string getters (href / hostname / search)", async () => {
+    expect(await run(`export function test(): string { return new URL("https://x.com/p?q=1").href; }`)).toBe(
+      "https://x.com/p?q=1",
+    );
+    expect(await run(`export function test(): string { return new URL("https://x.com/p").hostname; }`)).toBe("x.com");
+    expect(await run(`export function test(): string { return new URL("https://x.com/p?q=1&r=2").search; }`)).toBe(
+      "?q=1&r=2",
+    );
+  });
+
+  it("new URLSearchParams(str).getAll returns repeated values", async () => {
+    expect(
+      await run(`export function test(): string { return new URLSearchParams("a=1&a=2").getAll("a").join(","); }`),
+    ).toBe("1,2");
+  });
+
+  it("URLSearchParams append + toString + has", async () => {
+    expect(
+      await run(
+        `export function test(): string { const p = new URLSearchParams(); p.append("a","1"); p.append("b","2"); return p.toString(); }`,
+      ),
+    ).toBe("a=1&b=2");
+    expect(
+      await run(`export function test(): string { return new URLSearchParams("a=1").has("a") ? "yes" : "no"; }`),
+    ).toBe("yes");
+  });
+
+  it("the node:url import form resolves to the same host constructor (AC6)", async () => {
+    expect(
+      await run(
+        `import { URL } from "node:url";\nexport function test(): string { return new URL("https://i.com/").hostname; }`,
+      ),
+    ).toBe("i.com");
+    expect(
+      await run(
+        `import { URLSearchParams } from "node:url";\nexport function test(): string { return new URLSearchParams("k=v").get("k") as string; }`,
+      ),
+    ).toBe("v");
+  });
+
+  it("node:url fileURLToPath named-function import still works (AC4)", async () => {
+    expect(
+      await run(
+        `import { fileURLToPath } from "node:url";\nexport function test(): string { return fileURLToPath("file:///a/b.js"); }`,
+      ),
+    ).toBe("/a/b.js");
+  });
+});


### PR DESCRIPTION
## #1792 — node:url: URL / URLSearchParams as host constructors

`new URL(...)` / `new URLSearchParams(...)` (and the `node:url` named-import
form) did not lower to the host WHATWG constructors. The opaque `__node_url`
externref path only reached the `require("url").fn(...)` method forms, so
`new URL(...)` produced an empty object (`.pathname` undefined) and
`new URLSearchParams(...)` returned null.

### Fix (mirrors the Set/Map/EventEmitter extern-class machinery)
- **Global form** (`new URL(...)` / `new URLSearchParams(...)`):
  `registerBuiltinExternClasses` (`src/codegen/extern-declarations.ts`) registers
  both with their method/property tables → `URL_new` / `URLSearchParams_new` host
  imports; `builtinCtors` (`src/runtime.ts`, `typeof`-guarded) binds them to the
  real WHATWG globals. Skipped under `nativeStrings` (standalone deferred).
- **Import form** (`import { URL } from "node:url"`):
  `NODE_BUILTIN_CLASS_TYPED_STUBS.url` (`src/import-resolver.ts`) supplies the
  #1794 typed `declare namespace url { class URL {…} } + declare const URL` stub
  → `namespacePath: ["url"]` → runtime `_resolveNamespacedClass` binds
  `require("url").URL` (functionally `=== globalThis.URL`).
- Instance property reads (`.pathname`, `.searchParams`, …) flow through the
  generic `__extern_get` host import; method calls (`.get`, `.getAll`, …) through
  `__extern_method_call`.

### Acceptance
AC1 (relative pathname → `/a/b`; the issue's `=== "/b"` is a typo — Node resolves
`./b` against `file:///a/` to `/a/b`), AC2 (searchParams.get), AC3 (getAll), AC4
(fileURLToPath — already routed via `NODE_BUILTIN_FN_TYPED_STUBS.url`, verified),
AC6 (global + import forms) all pass. AC5 (Uint8Array↔Buffer bridge) is #1793's
scope. Standalone (WASI) URL is deferred (#1471/#1472 family).

Test: `tests/issue-1792.test.ts` (7). No new failures in adjacent
extern-class / node-import suites (issue-1575 + import-resolver failures are
pre-existing on the merge base, verified with the change reverted).

`loc-budget-allow` granted for `extern-declarations.ts` (god-file, +66 for two
extern-class tables).

Closes #1792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)