### PR TITLE
fix(#3311): native-string vec carrier for __vec_push/__vec_pop/__vec_set_elem

### DIFF
--- a/plan/issues/3311-g4-string-vec-push-pop-carrier.md
+++ b/plan/issues/3311-g4-string-vec-push-pop-carrier.md
@@ -1,7 +1,8 @@
 ---
 id: 3311
 title: "G4 — `string[]` push/pop under standalone is a no-op: native-string vec carrier missing from `__vec_push`/`__vec_pop` mutEntries"
-status: ready
+status: done
+completed: 2026-07-17
 created: 2026-07-16
 priority: high
 horizon: s
@@ -72,3 +73,36 @@ fall-through also returned `undefined`); this issue is the actual fix.
 Filed under #2784 lineage per the #2927 audit ("fix belongs in the
 `__vec_push`/`__vec_pop` carrier set, not the brand arm"). Umbrella:
 #2927 → #1584.
+
+## Resolution (2026-07-17, opus-c)
+
+Confirmed the repro standalone: `const a: any = ["a","b"]; a.push("c")` left
+`a.length === 2` (push a no-op), `a[2]` absent, `a.pop()` → `undefined`; the f64
+carrier worked (control).
+
+Fix (as planned): added `nativeStrVecElemTypeIdx` (vec-access-exports.ts) — the
+`string[]` vec is keyed `ref_${anyStrTypeIdx}` with backing element
+`(ref null $AnyString)` (`$NativeString <: $AnyString`). Admitted that carrier to
+the `mutEntries` filter, and gave three helpers its arm:
+
+- **`__vec_push`** value-unbox: the boxed externref value is a `$NativeString`;
+  recover the ref element via `any.convert_extern` + `ref.cast $AnyString` (no
+  numeric unbox) before `array.set`.
+- **`__vec_pop`** element-box: the popped `ref null $AnyString` boxes back to
+  externref via `extern.convert_any` (plain anyref box, no `__box_number`).
+- **`__vec_set_elem`** (vec-define-writeback.ts, the array-exotic
+  `Object.defineProperty` write-back) took the SAME missing arm — without it the
+  string carrier now in `mutEntries` fell through to the i32 conversion and
+  emitted invalid Wasm (`array.set expected (ref null …), found i32`). Fixed
+  identically.
+
+`__vec_get` / `__vec_len` already covered the carrier (get boxes a non-externref
+ref element via `extern.convert_any`; len is element-kind-agnostic).
+
+Verified standalone (host-free, `{}`-instantiable): push→length 3, push return 3,
+`a[2]==="c"`, multi-push order, grow-from-empty, pop→"c", pop→length 2, push/pop
+round-trip. gc-host `string[]` push/pop unaffected (uses the `wasm:js-string`
+path, not this vec carrier). No regression in vec-push / defineProperty-writeback
+/ wasi-defineProperty suites.
+
+Delivered: `tests/issue-3311.test.ts` (10 tests, the #2093 probe-coverage guard).

--- a/src/codegen/vec-access-exports.ts
+++ b/src/codegen/vec-access-exports.ts
@@ -21,6 +21,28 @@ import { flushLateImportShifts } from "./shared.js";
 import { exportFunc } from "./emit-helpers.js";
 
 /**
+ * (#3311) The native-string vec carrier. `string[]` under nativeStrings /
+ * standalone lowers to a vec whose backing array element is `(ref null
+ * $AnyString)` (keyed `ref_${anyStrTypeIdx}`; `$NativeString <: $AnyString`).
+ * Returns that element ref typeIdx (`anyStrTypeIdx`, or `nativeStrTypeIdx` for a
+ * concretely-native element) so `__vec_push` / `__vec_pop` can admit + cast this
+ * carrier — otherwise they returned the `-1`/`null.extern` unsupported sentinel
+ * and `(a as any).push("x")` on a `string[]` was a silent no-op standalone.
+ * Returns `-1` for a non-string carrier.
+ */
+export function nativeStrVecElemTypeIdx(ctx: CodegenContext, vecTypeIdx: number): number {
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return -1;
+  const arrDef = ctx.mod.types[arrTypeIdx];
+  if (!arrDef || arrDef.kind !== "array") return -1;
+  const el = arrDef.element as ValType;
+  if (el.kind !== "ref" && el.kind !== "ref_null") return -1;
+  if (ctx.anyStrTypeIdx >= 0 && el.typeIdx === ctx.anyStrTypeIdx) return ctx.anyStrTypeIdx;
+  if (ctx.nativeStrTypeIdx >= 0 && el.typeIdx === ctx.nativeStrTypeIdx) return ctx.nativeStrTypeIdx;
+  return -1;
+}
+
+/**
  * Emit __vec_get(externref, i32) -> externref and __vec_len(externref) -> i32
  * exports so the runtime can iterate WasmGC vec structs that were coerced to
  * externref (e.g. arrays stored in `any`-typed variables).
@@ -411,9 +433,12 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
   // through to its fail-loud TypeError instead of silently no-oping.
   const unboxNumIdx = ctx.funcMap.get("__unbox_number");
   const boxNumIdx2 = ctx.funcMap.get("__box_number");
-  const mutEntries = vecEntries.filter(([elemKey]) => {
+  const mutEntries = vecEntries.filter(([elemKey, vecTypeIdx]) => {
     if (elemKey === "externref") return true;
     if (elemKey === "f64" || elemKey === "i32") return unboxNumIdx !== undefined && boxNumIdx2 !== undefined;
+    // (#3311) native-string carrier (`string[]` standalone) — no numeric unbox,
+    // the value round-trips through `any.convert_extern` / `ref.cast $AnyString`.
+    if (nativeStrVecElemTypeIdx(ctx, vecTypeIdx) >= 0) return true;
     return false;
   });
 
@@ -513,6 +538,7 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         { name: `__vp_ndata_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: arrTypeIdx } },
       );
       // value unboxing per element kind (value param is local 1)
+      const strElemIdx = nativeStrVecElemTypeIdx(ctx, vecTypeIdx);
       const valueInstrs: Instr[] =
         elemKey === "externref"
           ? [{ op: "local.get", index: 1 }]
@@ -521,7 +547,12 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
                 { op: "local.get", index: 1 },
                 { op: "call", funcIdx: unboxNumIdx! },
               ]
-            : [{ op: "local.get", index: 1 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }];
+            : elemKey === "i32"
+              ? [{ op: "local.get", index: 1 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }]
+              : // (#3311) native-string carrier: the boxed externref value is a
+                // `$NativeString` (<: `$AnyString`); recover the ref element for
+                // `array.set` — no numeric unbox.
+                [{ op: "local.get", index: 1 }, { op: "any.convert_extern" }, { op: "ref.cast", typeIdx: strElemIdx }];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 2 },
         { op: "ref.cast", typeIdx: vecTypeIdx },
@@ -655,14 +686,19 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       // — same unsigned read/box. `i32_elem` (Int32/Uint32 element storage) stays
       // full-width signed (plain `array.get`), preserving its pre-split behaviour.
       const isPackedByte = elemKey === "i8_byte" || elemKey === "i16_byte" || elemKey === "i32_byte";
+      const isNativeStr = nativeStrVecElemTypeIdx(ctx, vecTypeIdx) >= 0;
       const boxInstrs: Instr[] =
         elemKey === "externref"
           ? []
-          : elemKey === "f64"
-            ? [{ op: "call", funcIdx: boxNumIdx2! }]
-            : isPackedByte
-              ? [{ op: "f64.convert_i32_u" }, { op: "call", funcIdx: boxNumIdx2! }]
-              : [{ op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumIdx2! }];
+          : // (#3311) native-string element (`ref null $AnyString`) → externref via
+            // the plain anyref→externref box (no `__box_number`).
+            isNativeStr
+            ? [{ op: "extern.convert_any" }]
+            : elemKey === "f64"
+              ? [{ op: "call", funcIdx: boxNumIdx2! }]
+              : isPackedByte
+                ? [{ op: "f64.convert_i32_u" }, { op: "call", funcIdx: boxNumIdx2! }]
+                : [{ op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumIdx2! }];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 1 },
         { op: "ref.cast", typeIdx: vecTypeIdx },

--- a/src/codegen/vec-define-writeback.ts
+++ b/src/codegen/vec-define-writeback.ts
@@ -20,6 +20,7 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
+import { nativeStrVecElemTypeIdx } from "./vec-access-exports.js";
 
 /**
  * Emit the two write-back exports. `mutEntries` is the caller's filtered
@@ -64,6 +65,7 @@ export function emitVecDefineWritebackExports(
         { name: `__vse_ndata_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: arrTypeIdx } },
       );
       // value unboxing per element kind (value param is local 2)
+      const strElemIdx = nativeStrVecElemTypeIdx(ctx, vecTypeIdx);
       const valueInstrs: Instr[] =
         elemKey === "externref"
           ? [{ op: "local.get", index: 2 }]
@@ -72,7 +74,10 @@ export function emitVecDefineWritebackExports(
                 { op: "local.get", index: 2 },
                 { op: "call", funcIdx: unboxNumIdx! },
               ]
-            : [{ op: "local.get", index: 2 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }];
+            : elemKey === "i32"
+              ? [{ op: "local.get", index: 2 }, { op: "call", funcIdx: unboxNumIdx! }, { op: "i32.trunc_sat_f64_s" }]
+              : // (#3311) native-string carrier: recover the `$AnyString` ref element.
+                [{ op: "local.get", index: 2 }, { op: "any.convert_extern" }, { op: "ref.cast", typeIdx: strElemIdx }];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 3 },
         { op: "ref.cast", typeIdx: vecTypeIdx },

--- a/tests/issue-3311.test.ts
+++ b/tests/issue-3311.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3311 (G4) — `string[]` push/pop must work under `--target standalone`.
+//
+// The carrier-generic `__vec_push` / `__vec_pop` / `__vec_set_elem` helpers
+// (src/codegen/vec-access-exports.ts, vec-define-writeback.ts) covered only the
+// externref / f64 / i32 element carriers. The native-string vec carrier — the
+// standalone rep of `string[]`, a WasmGC `(array (mut (ref null $AnyString)))`
+// keyed `ref_${anyStrTypeIdx}` — was absent from the `mutEntries` set, so
+// `__vec_push` returned the `-1` unsupported sentinel (mapped to `undefined` by
+// the `$__vec_base` brand arm) and `(a as any).push("x")` on a `string[]` was a
+// SILENT NO-OP standalone; `__vec_pop` returned `undefined`.
+//
+// Fix: admit the native-string carrier (`nativeStrVecElemTypeIdx`) — push casts
+// the boxed externref value back to `ref $AnyString` (`any.convert_extern` +
+// `ref.cast`, no numeric unbox) before `array.set`; pop boxes the popped
+// `ref $AnyString` via `extern.convert_any`. The gc-host lane is unaffected
+// (`string[]` there uses the `wasm:js-string` push path, not this vec carrier).
+//
+// A standalone module instantiates against an EMPTY import object, and a string
+// export is an opaque `ref $AnyString` from JS, so every assertion is checked
+// IN-WASM and returned as a number/boolean.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await compile(src, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#3311 — standalone string[] push", () => {
+  it("push grows the length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a: any = ["a", "b"];
+        a.push("c");
+        return a.length;
+      }`),
+    ).toBe(3);
+  });
+
+  it("push returns the new length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a: any = ["a", "b"];
+        return a.push("c");
+      }`),
+    ).toBe(3);
+  });
+
+  it("the pushed element is readable at its index", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const a: any = ["a", "b"];
+        a.push("c");
+        return a[2] === "c";
+      }`),
+    ).toBe(1);
+  });
+
+  it("multiple pushes append in order", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const a: any = ["a"];
+        a.push("b");
+        a.push("c");
+        return a.length === 3 && a[1] === "b" && a[2] === "c";
+      }`),
+    ).toBe(1);
+  });
+
+  it("push onto an empty string array works (grow from 0)", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const a: string[] = [];
+        (a as any).push("x");
+        return a.length === 1 && a[0] === "x";
+      }`),
+    ).toBe(1);
+  });
+});
+
+describe("#3311 — standalone string[] pop", () => {
+  it("pop returns the last element", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const a: any = ["a", "b", "c"];
+        return a.pop() === "c";
+      }`),
+    ).toBe(1);
+  });
+
+  it("pop shrinks the length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a: any = ["a", "b", "c"];
+        a.pop();
+        return a.length;
+      }`),
+    ).toBe(2);
+  });
+
+  it("push then pop round-trips", async () => {
+    expect(
+      await runStandalone(`export function test(): boolean {
+        const a: any = ["a", "b"];
+        a.push("z");
+        const popped = a.pop();
+        return popped === "z" && a.length === 2 && a[1] === "b";
+      }`),
+    ).toBe(1);
+  });
+});
+
+describe("#3311 — standalone string[] push/pop is host-import-free", () => {
+  it("no env imports for a push/pop program", async () => {
+    const r = await compile(
+      `export function test(): number {
+         const a: any = ["a", "b"];
+         a.push("c");
+         a.pop();
+         return a.length;
+       }`,
+      { target: "standalone" },
+    );
+    expect(r.success).toBe(true);
+    const env = WebAssembly.Module.imports(new WebAssembly.Module(r.binary))
+      .filter((i) => i.module === "env")
+      .map((i) => i.name);
+    expect(env, `unexpected env imports: ${env.join(", ")}`).toEqual([]);
+  });
+});
+
+describe("#3311 — gc-host string[] push/pop unaffected", () => {
+  it("gc-host push/pop still works (different, js-string path)", async () => {
+    expect(
+      await runGc(`export function test(): number {
+        const a: string[] = ["a", "b"];
+        a.push("c");
+        a.pop();
+        a.push("d");
+        return a.length;
+      }`),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## #3311 (G4) — standalone `string[]` push/pop was a silent no-op

`string[]` under `--target standalone` / nativeStrings lowers to a vec whose
backing array element is `(ref null $AnyString)` (keyed `ref_${anyStrTypeIdx}`).
That carrier was missing from the `mutEntries` filter in
`vec-access-exports.ts`, so `__vec_push` returned the `-1` unsupported sentinel
(mapped to `undefined` by the `$__vec_base` brand arm) — `(a as any).push("x")`
on a `string[]` was a **silent no-op** standalone, and `__vec_pop` returned
`undefined`. (No regression from #2592 — it was already broken; this is the fix.)

## Fix
Add `nativeStrVecElemTypeIdx` and admit the carrier in three helpers:
- **`__vec_push`** — value-unbox the boxed externref via `any.convert_extern` +
  `ref.cast $AnyString` (no numeric unbox) before `array.set`.
- **`__vec_pop`** — box the popped `ref $AnyString` via `extern.convert_any`.
- **`__vec_set_elem`** (`vec-define-writeback.ts`, `Object.defineProperty`
  array write-back) — the SAME arm; the carrier now in `mutEntries` otherwise
  fell to the i32 conversion and emitted invalid Wasm (`array.set expected
  (ref null …), found i32`).

`__vec_get` / `__vec_len` already covered the carrier (get boxes a non-externref
ref via `extern.convert_any`; len is element-kind-agnostic).

## Verified (all standalone, `{}`-instantiable, checked in-wasm)
push→length 3, push return 3, `a[2]==="c"`, multi-push order, grow-from-empty,
pop→"c", pop→length 2, push/pop round-trip. **gc-host `string[]` push/pop
unaffected** (uses the `wasm:js-string` path, not this carrier). No regression
in vec-push / defineProperty-writeback / wasi-defineProperty / #2927 push-pop
suites. `tsc --noEmit` clean.

`tests/issue-3311.test.ts` — 10 tests (the #2093 probe-coverage guard).

Slice **G4** of the #2928 / #2927 `CallBuiltin` prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)