### PR TITLE
docs(#3341): correct stale demote-hatch citations + document per-reason STRICT_IR_REASONS rule

### DIFF
--- a/docs/architecture/codegen-axes.md
+++ b/docs/architecture/codegen-axes.md
@@ -165,7 +165,9 @@ Stay in `src/codegen/` (direct) until the listed issues land:
 
 `scripts/ir-fallback-baseline.json` is the ratchet. When a kind is
 adopted, its bucket goes to zero and the demote-to-warning escape hatch
-in `src/codegen/index.ts:889–896` is removed for that kind — see #2855.
+in `src/codegen/index.ts:~1889/~2390` is removed for that kind — see #2855.
+(Bucket-zero is necessary but **not sufficient** to make a reason a hard
+error via `STRICT_IR_REASONS`; see #3341 and the escape-hatch section below.)
 
 ## Current hidden bias in `src/ir/` (and what to do about it)
 
@@ -189,18 +191,35 @@ the `BackendEmitter` trait becomes linear-capable by implementation
 rather than by a separate front-end. The remaining inline WasmGC emission
 in `lower.ts` is staged under #1713.
 
-## The fallback-to-warning escape hatch (`src/codegen/index.ts:889–896`)
+## The fallback-to-warning escape hatch (`src/codegen/index.ts:~1889/~2390`)
 
 Today, if the IR path throws while compiling a function the selector
 claimed, the failure is logged at severity `"warning"` and the legacy
 direct-codegen body is kept. This makes the IR safe to enable by default
-without breaking test262, but it also masks real IR bugs.
+without breaking test262, but it also masks real IR bugs. (Two sites:
+`~1889` when a selector-claimed function's types can't be resolved, and
+`~2390` for an IR-build throw — both gated by `STRICT_IR_REASONS` /
+`STRICT_IR_BUILD_ERRORS` respectively, which are empty today.)
 
 **This is a transitional safety net, not the final design.** #2855 phases
 the warning channel out. The endgame: when a node kind is IR-owned, the
 selector either claims it (and IR succeeds) or it stays direct (and the
 selector reports a structured "deferred" reason). There is no third
 "IR claimed it and silently fell back" state.
+
+**Promoting a reason to strict is per-reason, not a corpus-zero flip
+(#3341).** A reason absent from `scripts/ir-fallback-baseline.json` only
+means the 13-file playground corpus doesn't happen to trigger it — it does
+**not** mean the reason is unreachable on real code. Reasons like
+`external-call`, `call-graph-closure`, `param/return-type-not-resolvable`,
+`type-resolution-failure`, and `class-method` describe **legitimate**
+IR-non-claimability (an external dependency, an unclaimable callee, an
+unresolvable type, a computed/generator/abstract method name) that the
+legacy path must still catch. Adding such a reason to `STRICT_IR_REASONS`
+would turn those legitimate fallbacks into hard compile errors and regress
+real programs. STRICT promotion is therefore gated on first making a
+_specific_ reason genuinely unreachable in the IR (real #2855-family
+adoption work), reason by reason — not a documentation flip.
 
 If you're reading this and the warning channel still exists, treat any
 new warning here as an error — it means a regression slipped past the IR

--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -1,12 +1,12 @@
 ---
 id: 3341
-title: "Promote zeroed IR fallback reasons into STRICT_IR_REASONS (#2855's own AC — cheapest unstarted hardening step)"
+title: "STRICT_IR_REASONS hardening — per-reason (NOT a corpus-zero flip); doc-correction shipped, real per-reason work remains"
 status: ready
 sprint: current
 created: 2026-07-17
-priority: high
-feasibility: medium
-horizon: s
+priority: medium
+feasibility: hard
+horizon: m
 task_type: feature
 area: codegen
 language_feature: compiler-internals
@@ -15,7 +15,47 @@ related: [2855, 2856, 2857, 2858, 2859, 2950]
 origin: "carved out of #2855's umbrella scope per the 2026-07-17 IR audit (plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md §2) — the promotion half of #2855's AC has not started even though the underlying buckets are already zero"
 ---
 
-# #3341 — promote zeroed IR fallback reasons into `STRICT_IR_REASONS`
+# #3341 — STRICT_IR_REASONS hardening (per-reason)
+
+> **RE-SCOPED 2026-07-17 (opus-c, confirmed by tech lead).** The original
+> premise — "the buckets are already zero, so promoting the reasons into
+> `STRICT_IR_REASONS` is the cheapest unstarted hardening step" — is **UNSAFE**
+> and has been corrected. Bucket-zero in `scripts/ir-fallback-baseline.json` is
+> measured against the **13-file playground corpus only**; corpus-zero does
+> **not** mean the reason is unreachable on real code. `external-call`,
+> `call-graph-closure`, `param/return-type-not-resolvable`,
+> `type-resolution-failure`, `class-method`, and the destructuring-param buckets
+> all describe **legitimate IR-non-claimability** (an external dependency, an
+> unclaimable callee, an unresolvable type, a computed/generator/abstract method
+> name) that the legacy path must still catch. Adding any of them to
+> `STRICT_IR_REASONS` would turn those legitimate fallbacks into **hard compile
+> errors** and regress real programs — an unvalidatable-locally, broad-blast
+> change. `ir-adoption.md`'s `class-method` row already documented exactly this
+> ("corpus bucket 0 … NOT yet strict"); the same logic applies to every other
+> corpus-zero reason.
+>
+> **What shipped (the doc-correction portion, DONE):**
+>
+> - Fixed the stale `src/codegen/index.ts:889–896` citations (actual demote
+>   sites are `~1889` for a selector-claimed unresolvable-types fallback and
+>   `~2390` for an IR-build throw) in `scripts/gen-ir-adoption.mjs` (→ regenerated
+>   `plan/log/ir-adoption.md`) and `docs/architecture/codegen-axes.md`.
+> - Added a code-comment at `STRICT_IR_REASONS` (`src/codegen/index.ts`)
+>   explaining the necessary-but-not-sufficient condition, so no future dev
+>   naively flips a corpus-zero reason and reddens the build.
+> - Documented the per-reason (not corpus-flip) promotion rule in
+>   `codegen-axes.md`'s escape-hatch section.
+>
+> **What remains OPEN (this issue stays `ready`):** the _actual_ per-reason
+> hardening — pick ONE reason, do the real #2855-family IR-adoption work to make
+> that construct genuinely unreachable in the IR (IR always claims+lowers it, so
+> a rejection IS a bug), THEN add it to `STRICT_IR_REASONS` and validate on full
+> CI. That is `feasibility: hard`, not a doc flip. The stale `lower.ts`
+> "not yet moved" claim in `codegen-axes.md` (aggregate/closure/ref-coercion
+> groups) was NOT touched here — it needs a `lower.ts` audit to confirm before
+> editing; folded into the remaining work.
+
+## Original problem (premise now corrected — see re-scope note above)
 
 ## Problem
 

--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -13,6 +13,10 @@ language_feature: compiler-internals
 goal: compiler-architecture
 related: [2855, 2856, 2857, 2858, 2859, 2950]
 origin: "carved out of #2855's umbrella scope per the 2026-07-17 IR audit (plan/log/analysis-2026-07/01-ir-audit-2026-07-17.md §2) — the promotion half of #2855's AC has not started even though the underlying buckets are already zero"
+loc-budget-allow:
+  # (#3341) +15-line rationale comment at STRICT_IR_REASONS documenting the
+  # necessary-but-not-sufficient corpus-zero condition (build-safety guardrail).
+  - src/codegen/index.ts
 ---
 
 # #3341 — STRICT_IR_REASONS hardening (per-reason)

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -30,8 +30,10 @@ bucket work #2856–#2859.
 - **mixed** — `from-ast.ts` handles a _subset_ of the kind. Whole-function
   rejection by the selector or per-node throws inside `from-ast.ts` causes
   the function to fall back to direct codegen via the demote-to-warning
-  path (`src/codegen/index.ts:889–896`). Ratchet target: drive the
-  rejection bucket to zero, then promote to `ir-owned`.
+  path (`src/codegen/index.ts:~1889` for a selector-claimed function whose
+  types can't be resolved, and `~2390` for an IR-build throw; both emit a
+  severity-`warning`). Ratchet target: drive the rejection bucket to zero,
+  then promote to `ir-owned`.
 - **direct-only** — IR has no handler; direct codegen is the only path. A
   function touching one of these kinds is rejected by the selector and
   compiles entirely via legacy.

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -249,8 +249,10 @@ bucket work #2856–#2859.
 - **mixed** — \`from-ast.ts\` handles a *subset* of the kind. Whole-function
   rejection by the selector or per-node throws inside \`from-ast.ts\` causes
   the function to fall back to direct codegen via the demote-to-warning
-  path (\`src/codegen/index.ts:889–896\`). Ratchet target: drive the
-  rejection bucket to zero, then promote to \`ir-owned\`.
+  path (\`src/codegen/index.ts:~1889\` for a selector-claimed function whose
+  types can't be resolved, and \`~2390\` for an IR-build throw; both emit a
+  severity-\`warning\`). Ratchet target: drive the rejection bucket to zero,
+  then promote to \`ir-owned\`.
 - **direct-only** — IR has no handler; direct codegen is the only path. A
   function touching one of these kinds is rejected by the selector and
   compiles entirely via legacy.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1509,9 +1509,24 @@ function irFieldTypeMatchesLegacyValType(
 // dates that drive this list.
 // ---------------------------------------------------------------------------
 const STRICT_IR_REASONS: ReadonlySet<IrFallbackReason> = new Set<IrFallbackReason>();
-// Empty as of #1530 — flip entries to "strict" in follow-up PRs once
-// their `scripts/ir-fallback-baseline.json` bucket reaches zero. The
-// intended order (cheapest first, see plan/log/ir-adoption.md):
+// Empty as of #1530 — and #3341 established that a bucket reaching zero in
+// `scripts/ir-fallback-baseline.json` is NECESSARY but NOT SUFFICIENT to add
+// its reason here. That baseline is measured against the 13-file playground
+// corpus only; corpus-zero does NOT mean the reason is unreachable on real
+// code. Most rejection reasons describe LEGITIMATE IR-non-claimability that the
+// legacy path must still catch — e.g. `external-call` (a call to a
+// non-whitelisted external fn), `call-graph-closure` (an unclaimable callee),
+// `param-type-not-resolvable` / `return-type-not-resolvable` /
+// `type-resolution-failure` (TypeMap can't resolve the type), `class-method`
+// (still covers computed/generator/abstract names, static super,
+// subclass-of-builtin — see plan/log/ir-adoption.md), and the destructuring
+// param buckets. Adding any of these here would promote a legitimate fallback
+// to a HARD COMPILE ERROR and regress real programs. So a reason may be
+// promoted to strict ONLY once it is genuinely UNREACHABLE in the IR (i.e. the
+// IR is now expected to always claim+lower that construct, so a rejection is a
+// bug) — real #2855-family adoption work, reason by reason, not a doc flip.
+// The intended promotion order once each becomes genuinely unreachable
+// (cheapest first, see plan/log/ir-adoption.md):
 //   "param-type-not-resolvable",
 //   "call-graph-closure",
 //   "body-shape-rejected",


### PR DESCRIPTION
## #3341 — re-scoped: the "promote corpus-zero reasons" premise is unsafe

#3341 was filed as "the buckets are already zero, so promoting them into
`STRICT_IR_REASONS` is the cheapest hardening step." **Analysis (confirmed by
the tech lead) shows that premise is unsafe.** Bucket-zero in
`scripts/ir-fallback-baseline.json` is measured against the **13-file playground
corpus only** — corpus-zero does NOT mean a reason is unreachable on real code.
`external-call`, `call-graph-closure`, `param/return-type-not-resolvable`,
`type-resolution-failure`, `class-method`, and the destructuring-param buckets
all describe **legitimate IR-non-claimability** (external dep, unclaimable
callee, unresolvable type, computed/generator/abstract method name) that the
legacy path must still catch. Promoting any of them would turn those legitimate
fallbacks into **hard compile errors** and regress real programs (broad blast,
unvalidatable locally). `ir-adoption.md`'s `class-method` row already documented
exactly this ("corpus bucket 0 … NOT yet strict").

## What this PR ships (the safe correction — NO promotion)
- **Fixes the stale `src/codegen/index.ts:889–896` demote-hatch citation** → the
  actual sites (`~1889` selector-claimed unresolvable types; `~2390` IR-build
  throw) in `scripts/gen-ir-adoption.mjs` (→ regenerated `plan/log/ir-adoption.md`)
  and `docs/architecture/codegen-axes.md`.
- **Adds a code-comment at `STRICT_IR_REASONS`** documenting the
  necessary-but-not-sufficient condition, so no future dev naively flips a
  corpus-zero reason and reddens the build.
- **Documents the per-reason (not corpus-flip) promotion rule** in
  `codegen-axes.md`'s escape-hatch section.
- **Re-scopes #3341** (stays `ready`, `feasibility: hard`): the real per-reason
  hardening — make a specific reason genuinely unreachable in the IR first, then
  promote + full-CI validate — remains OPEN as future #2855-family work.

`STRICT_IR_REASONS` stays empty ⇒ **no codegen behavior change**.
`check:ir-fallbacks` + `gen:ir-adoption --check` green; loc-budget allowance for
the +15-line comment granted in #3341's frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)