### PR TITLE
fix(#3344): bound promote push with a step timeout + scope workflow_dispatch retriggers

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1580,6 +1580,14 @@ jobs:
         run: node --experimental-strip-types scripts/generate-editions.ts --results benchmarks/results/test262-current.jsonl
 
       - name: Push baseline artifacts to js2wasm-baselines repo
+        # (#3344) Bound the git-over-SSH clone/push to the baselines repo. Without
+        # a step timeout a hung SSH push (no progress) can run for the whole
+        # job budget — the 2026-07-17 promote stranded for ~2.5h this way,
+        # blocking the honest oracle-v7 baseline from publishing. The re-anchor
+        # loop below already retries transient races; this cap makes a genuine
+        # hang fail FAST and retriable (via a `push`/workflow_dispatch re-run)
+        # instead of wedging the promote pipeline indefinitely.
+        timeout-minutes: 10
         env:
           BASELINE_DEPLOY_KEY: ${{ secrets.BASELINE_DEPLOY_KEY }}
           # (#3335) Per-category tolerance for the trap-growth gate below —
@@ -1836,6 +1844,10 @@ jobs:
       # bypass relies on — do NOT swap this back to GITHUB_TOKEN/HTTPS or GH013
       # returns (#1861).
       - name: Commit refreshed summary JSON to main repo
+        # (#3344) Same hang-class bound as the baselines push above: cap the
+        # git-over-SSH deploy-key push to main so a stalled push fails fast and
+        # retriable instead of consuming the whole job budget.
+        timeout-minutes: 10
         env:
           MAIN_DEPLOY_KEY: ${{ secrets.MAIN_DEPLOY_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plan/issues/3344-catastrophic-guard-honor-regressions-allow.md
+++ b/plan/issues/3344-catastrophic-guard-honor-regressions-allow.md
@@ -1,0 +1,82 @@
+---
+id: 3344
+title: "CI: baseline promote pipeline can hang indefinitely + emergency workflow_dispatch retrigger loses change-set scoping"
+status: done
+completed: 2026-07-17
+sprint: current
+priority: critical
+horizon: m
+feasibility: medium
+task_type: ci-fix
+area: ci
+created: 2026-07-17
+related: [3227, 3303, 3111, 3161, 1668]
+origin: "the #3227/#3201 oracle v6→v7 honest-drop baseline could not publish — the promote job's git-over-SSH push to js2wasm-baselines hung ~2.5h with no timeout, and an emergency workflow_dispatch retrigger could not reproduce the organic change-set scoping"
+---
+
+# #3344 — Harden the baseline promote pipeline (push timeout + workflow_dispatch scoping)
+
+## Problem
+
+**Corrected scope (2026-07-17).** The original framing — "the catastrophic
+regression guard ignores the `regressions-allow` ceiling" — was **wrong**. A
+deeper trace disproved it: `scripts/diff-test262.ts` already calls
+`readRegressionsAllowance()` unconditionally in oracle-rebase mode (arm-1
+auto-discovery from the change-set's own issue files), and the #1668/#1897
+guards already treat the script's exit code as authoritative on PASS (#3303).
+The organic push run on the #3201 merge **passed** the gate. The guard is NOT
+neutered and needs no `REGRESSIONS_ALLOW_FILE` wiring.
+
+The REAL reason the honest oracle-v7 baseline could not publish was two
+CI-robustness gaps in the promote pipeline:
+
+1. **PRIMARY — no timeout on the promote push.** The
+   `promote merged report to main baseline` job (`test262-sharded.yml`) runs a
+   git-over-SSH clone/push to `loopdive/js2wasm-baselines` with **no
+   step-level `timeout-minutes`**. On 2026-07-17 that push hung ~2.5h with no
+   progress, consuming the job budget and stranding the promote — so the fresh
+   v7 baseline (JS-host 32,138/43,106, standalone 24,711/43,106; the expected
+   −650 async-drain correction) never reached the baselines repo, and the
+   merge queue kept diffing the stale oracle-6 floor.
+
+2. **SECONDARY — `workflow_dispatch` lost change-set scoping.**
+   `resolveChangeBase` (`scripts/lib/change-scope.mjs`) whitelisted only
+   `pull_request` / `merge_group` / `push` for the synthetic-merge-parent fast
+   path. An **emergency manual retrigger** (`workflow_dispatch`) against a real
+   merge-commit SHA therefore could NOT reproduce the organic scoping (the
+   PR's own change-set, incl. its `regressions-allow:` declaration) — it fell
+   through to the coarser merge-base arm.
+
+## Fix
+
+1. Add `timeout-minutes: 10` to the baselines-repo push step (and to the
+   sibling main-repo summary push, same hang class), so a hung SSH push fails
+   FAST and is retriable (via a `push`/`workflow_dispatch` re-run) instead of
+   wedging the promote pipeline for the whole job budget. The existing
+   re-anchor loop still handles transient push races within that window.
+
+2. Add `workflow_dispatch` to the `resolveChangeBase` synthetic-merge-parent
+   whitelist, INSIDE the existing `HEAD^2` guard. Backward-compatible: an
+   ordinary branch-tip dispatch has a single-parent HEAD, so the guard no-ops
+   and it falls through to the merge-base arm exactly as before; only a
+   dispatch against a real 2-parent merge commit now reproduces the organic
+   `ci-merge-parent` scoping.
+
+## Acceptance
+
+- The promote push cannot hang indefinitely — a step timeout bounds it and a
+  re-run publishes the pending baseline. (`tests/issue-3344.test.ts` asserts
+  both push steps carry `timeout-minutes`.)
+- An emergency `workflow_dispatch` retrigger against a real merge-commit SHA
+  resolves the change base to `HEAD^1` (`ci-merge-parent(workflow_dispatch)`),
+  while a single-parent branch-tip dispatch still resolves to the merge-base
+  arm. (`tests/issue-3344.test.ts` pins both.)
+- The catastrophic guard is unchanged and NOT neutered — it still fails on a
+  genuine regression lacking a declared ceiling (the #3303 exit-code contract,
+  already covered by `tests/issue-3303.test.ts`, is untouched).
+
+## Non-goals
+- Do NOT hand-push a baseline to js2wasm-baselines (bypasses CI validation).
+- Do NOT lower/disable the catastrophic guard globally.
+- Do NOT wire `REGRESSIONS_ALLOW_FILE` into the guard — it is already wired via
+  arm-1 auto-discovery.

--- a/scripts/lib/change-scope.mjs
+++ b/scripts/lib/change-scope.mjs
@@ -18,7 +18,8 @@
 // BASE RESOLUTION (exactness matters — there is no committed ceiling to mask
 // an over-included diff anymore):
 //   1. `LOC_GATE_BASE` env — explicit override (tests, emergencies).
-//   2. CI merge parent: on `pull_request` / `merge_group` / `push` events the
+//   2. CI merge parent: on `pull_request` / `merge_group` / `push` /
+//      `workflow_dispatch` (#3344) events the
 //      checked-out HEAD is a synthetic merge commit created by GitHub
 //      (refs/pull/N/merge, the merge-queue group head, or the landed queue
 //      merge) whose FIRST parent is always the base side. `HEAD^1` is
@@ -65,9 +66,18 @@ export function resolveChangeBase(repoRoot) {
   if (process.env.LOC_GATE_BASE) return { base: process.env.LOC_GATE_BASE, how: "env:LOC_GATE_BASE" };
   if (gitTry(repoRoot, ["rev-parse", "--is-inside-work-tree"]) !== "true") return { base: undefined, how: "no-git" };
   const ev = process.env.GITHUB_EVENT_NAME;
-  if (process.env.GITHUB_ACTIONS === "true" && (ev === "pull_request" || ev === "merge_group" || ev === "push")) {
+  if (
+    process.env.GITHUB_ACTIONS === "true" &&
+    (ev === "pull_request" || ev === "merge_group" || ev === "push" || ev === "workflow_dispatch")
+  ) {
     // Synthetic-merge fast path (see header). Only when HEAD really is a
     // merge commit; a single-commit direct push falls through to merge-base.
+    // `workflow_dispatch` (#3344) is included so an EMERGENCY manual retrigger
+    // against a real merge-commit SHA reproduces the organic push scoping (the
+    // PR's own change-set, incl. its regressions-allow declaration). The
+    // HEAD^2 guard makes this backward-compatible: an ordinary branch-tip
+    // dispatch has a single-parent HEAD, so it no-ops here and falls through
+    // to the merge-base arm exactly as before.
     if (gitTry(repoRoot, ["rev-parse", "--verify", "--quiet", "HEAD^2"])) {
       const p1 = gitTry(repoRoot, ["rev-parse", "--verify", "--quiet", "HEAD^1"]);
       if (p1) return { base: p1, how: `ci-merge-parent(${ev})` };

--- a/tests/issue-3344.test.ts
+++ b/tests/issue-3344.test.ts
@@ -48,7 +48,7 @@ describe("#3344 — resolveChangeBase honors workflow_dispatch on a real merge c
   beforeEach(() => {
     for (const k of ["GITHUB_ACTIONS", "GITHUB_EVENT_NAME", "LOC_GATE_BASE"]) saved[k] = process.env[k];
     // A stale LOC_GATE_BASE would short-circuit arm 1 — clear it for these tests.
-    delete process.env.LOC_GATE_BASE;
+    Reflect.deleteProperty(process.env, "LOC_GATE_BASE");
     repo = mkdtempSync(join(tmpdir(), "issue-3344-repo-"));
     // Base commit on `base` branch; `origin/main` ref points at it so the
     // merge-base fallback arm is reachable in the single-parent case.
@@ -63,7 +63,7 @@ describe("#3344 — resolveChangeBase honors workflow_dispatch on a real merge c
 
   afterEach(() => {
     for (const k of ["GITHUB_ACTIONS", "GITHUB_EVENT_NAME", "LOC_GATE_BASE"]) {
-      if (saved[k] === undefined) delete process.env[k];
+      if (saved[k] === undefined) Reflect.deleteProperty(process.env, k);
       else process.env[k] = saved[k];
     }
     rmSync(repo, { recursive: true, force: true });

--- a/tests/issue-3344.test.ts
+++ b/tests/issue-3344.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3344 — CI-robustness for the baseline promote pipeline.
+//
+// Two surgical fixes, one PR:
+//
+//   (1) The promote job's git-over-SSH pushes (baselines repo + main summary)
+//       carry a step-level `timeout-minutes` so a hung push fails FAST and is
+//       retriable, instead of consuming the whole job budget (the 2026-07-17
+//       promote stranded ~2.5h this way, blocking the honest oracle-v7
+//       baseline from publishing).
+//
+//   (2) `resolveChangeBase` (scripts/lib/change-scope.mjs) now includes
+//       `workflow_dispatch` in the synthetic-merge-parent whitelist, so an
+//       EMERGENCY manual retrigger against a real merge-commit SHA reproduces
+//       the organic push scoping (the PR's own change-set, incl. its
+//       `regressions-allow:` declaration). The HEAD^2 guard keeps it
+//       backward-compatible: an ordinary branch-tip dispatch (single-parent
+//       HEAD) still falls through to the merge-base arm.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveChangeBase } from "../scripts/lib/change-scope.mjs";
+
+const ROOT = resolve(import.meta.dirname ?? ".", "..");
+
+// ---------------------------------------------------------------------------
+// (2) resolveChangeBase — workflow_dispatch synthetic-merge scoping
+// ---------------------------------------------------------------------------
+
+describe("#3344 — resolveChangeBase honors workflow_dispatch on a real merge commit", () => {
+  let repo: string;
+  const saved: Record<string, string | undefined> = {};
+
+  function git(...args: string[]): string {
+    const r = spawnSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", ...args], {
+      cwd: repo,
+      encoding: "utf-8",
+    });
+    if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+    return (r.stdout ?? "").trim();
+  }
+
+  beforeEach(() => {
+    for (const k of ["GITHUB_ACTIONS", "GITHUB_EVENT_NAME", "LOC_GATE_BASE"]) saved[k] = process.env[k];
+    // A stale LOC_GATE_BASE would short-circuit arm 1 — clear it for these tests.
+    delete process.env.LOC_GATE_BASE;
+    repo = mkdtempSync(join(tmpdir(), "issue-3344-repo-"));
+    // Base commit on `base` branch; `origin/main` ref points at it so the
+    // merge-base fallback arm is reachable in the single-parent case.
+    git("init", "-q", "-b", "base");
+    git("commit", "--allow-empty", "-m", "base", "-q");
+    const baseSha = git("rev-parse", "HEAD");
+    git("update-ref", "refs/remotes/origin/main", baseSha);
+    // Feature branch with one commit off base.
+    git("checkout", "-q", "-b", "feature");
+    git("commit", "--allow-empty", "-m", "feature work", "-q");
+  });
+
+  afterEach(() => {
+    for (const k of ["GITHUB_ACTIONS", "GITHUB_EVENT_NAME", "LOC_GATE_BASE"]) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("resolves the first parent of a 2-parent HEAD under workflow_dispatch", () => {
+    // Synthetic merge commit: FIRST parent = base side (GitHub's convention).
+    git("checkout", "-q", "base");
+    const baseSha = git("rev-parse", "HEAD");
+    git("merge", "--no-ff", "-m", "merge feature", "feature", "-q");
+    expect(git("rev-parse", "--verify", "HEAD^2")).toBeTruthy(); // really 2-parent
+
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.GITHUB_EVENT_NAME = "workflow_dispatch";
+    const { base, how } = resolveChangeBase(repo);
+    expect(how).toBe("ci-merge-parent(workflow_dispatch)");
+    expect(base).toBe(baseSha); // HEAD^1
+  });
+
+  it("falls through to the merge-base arm for a single-parent tip under workflow_dispatch", () => {
+    // HEAD = feature tip: single parent, so the HEAD^2 guard no-ops and the
+    // resolver drops to the merge-base arm (unchanged from before the fix).
+    process.env.GITHUB_ACTIONS = "true";
+    process.env.GITHUB_EVENT_NAME = "workflow_dispatch";
+    const { base, how } = resolveChangeBase(repo);
+    expect(how).toBe("merge-base");
+    expect(base).toBe(git("merge-base", "refs/remotes/origin/main", "HEAD"));
+  });
+
+  it("still resolves the merge parent under the pre-existing push/merge_group/pull_request events", () => {
+    git("checkout", "-q", "base");
+    const baseSha = git("rev-parse", "HEAD");
+    git("merge", "--no-ff", "-m", "merge feature", "feature", "-q");
+    process.env.GITHUB_ACTIONS = "true";
+    for (const ev of ["push", "merge_group", "pull_request"]) {
+      process.env.GITHUB_EVENT_NAME = ev;
+      const { base, how } = resolveChangeBase(repo);
+      expect(how).toBe(`ci-merge-parent(${ev})`);
+      expect(base).toBe(baseSha);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (1) promote-job push steps carry a step timeout
+// ---------------------------------------------------------------------------
+
+describe("#3344 — promote push steps are bounded by a step timeout", () => {
+  const workflow = readFileSync(resolve(ROOT, ".github/workflows/test262-sharded.yml"), "utf-8");
+
+  /** The block of YAML for the named step, up to the next `- name:` sibling. */
+  function stepBlock(stepName: string): string {
+    const lines = workflow.split("\n");
+    const start = lines.findIndex((l) => l.trimStart().startsWith(`- name: ${stepName}`));
+    expect(start, `step "${stepName}" not found`).toBeGreaterThanOrEqual(0);
+    const indent = lines[start].length - lines[start].trimStart().length;
+    let end = start + 1;
+    for (; end < lines.length; end++) {
+      const l = lines[end];
+      if (l.trim() === "") continue;
+      const ind = l.length - l.trimStart().length;
+      if (ind <= indent && l.trimStart().startsWith("- name:")) break;
+    }
+    return lines.slice(start, end).join("\n");
+  }
+
+  it("bounds the baselines-repo push (the 2.5h hang class)", () => {
+    expect(stepBlock("Push baseline artifacts to js2wasm-baselines repo")).toMatch(/timeout-minutes:\s*\d+/);
+  });
+
+  it("bounds the main-repo summary push (same hang class)", () => {
+    expect(stepBlock("Commit refreshed summary JSON to main repo")).toMatch(/timeout-minutes:\s*\d+/);
+  });
+});


### PR DESCRIPTION
## Problem (corrected scope)

The 2026-07-17 honest oracle-v7 baseline (JS-host 32,138/43,106) could not publish. The original #3344 framing — "the catastrophic guard ignores the regressions-allow ceiling" — was **wrong**: `diff-test262.ts` already honors the #3303 ceiling via arm-1 change-set auto-discovery, and the organic #3201 push passed the gate. The REAL cause was two CI-robustness gaps:

1. **PRIMARY:** the `promote merged report to main baseline` job's git-over-SSH push to `js2wasm-baselines` had **no step timeout** — it hung ~2.5h with no progress, consuming the job budget and stranding the promote.
2. **SECONDARY:** `resolveChangeBase` (`scripts/lib/change-scope.mjs`) whitelisted only `pull_request`/`merge_group`/`push` for the synthetic-merge-parent fast path, so an emergency `workflow_dispatch` retrigger against a real merge-commit SHA lost the organic change-set scoping.

## Fix

1. `timeout-minutes: 10` on the baselines-repo push step **and** the sibling main-repo summary push (same hang class) — a hung SSH push now fails fast and is retriable instead of wedging the pipeline. The existing re-anchor loop still covers transient races.
2. Add `workflow_dispatch` to the `resolveChangeBase` whitelist, **inside** the existing `HEAD^2` guard. Backward-compatible: a single-parent branch-tip dispatch still falls through to the merge-base arm; only a dispatch against a real 2-parent merge commit now reproduces `ci-merge-parent` scoping.

## Tests

`tests/issue-3344.test.ts` (5 tests, passing):
- `workflow_dispatch` on a 2-parent HEAD resolves `HEAD^1` (`ci-merge-parent(workflow_dispatch)`); a 1-parent tip resolves to `merge-base`.
- pre-existing `push`/`merge_group`/`pull_request` scoping unchanged.
- both promote push steps carry `timeout-minutes`.

`tests/issue-3303.test.ts` (32 tests) unchanged — the catastrophic guard is NOT neutered.

Closes #3344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)