### PR TITLE
fix(#2935): verify String-wrapper .split/.replace(RegExp) null-deref fixed + regression lock

### DIFF
--- a/plan/issues/2935-strflatten-regexparg-null-deref.md
+++ b/plan/issues/2935-strflatten-regexparg-null-deref.md
@@ -1,9 +1,11 @@
 ---
 id: 2935
 title: "Standalone: __str_flatten null-deref on new String(...).split/replace(RegExp) — String-wrapper receiver not unwrapped before flatten"
-status: ready
+status: done
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-17
+completed: 2026-07-17
+assignee: ttraenkler/opus-3
 priority: medium
 horizon: m
 feasibility: medium
@@ -15,6 +17,30 @@ related: [2878, 2860]
 umbrella: 2860
 origin: "2026-07-02 spun out of #2878 Class B triage (dev-callback). origin/main current."
 ---
+
+## Verification — already fixed on main (2026-07-17, opus-3)
+
+Re-verified against current `origin/main` (079c585fa6): the `__str_flatten`
+null-deref on a String-**wrapper** receiver (`new String(...)` or a var typed
+`String`) calling `.split(RegExp)` / `.replace(RegExp, …)` under
+`--target standalone` **no longer reproduces** — the wrapper receiver runs
+host-free and its results match the primitive receiver. The intervening
+borrowed-receiver `RequireObjectCoercible` + `ToString` unwrap work
+(**PR #3254**, `d44d0d6c34`; cf. the #2934 receiver-ToString normalise) now
+recovers the primitive `$AnyString` from the wrapper's `[[StringData]]` before
+the native flatten helper, so the receiver-shape-specific null-deref is gone.
+
+Probed on main (all correct, no trap):
+- `new String("abc").split(/[a-z]/).length` → **4** (matches `"abc".split(...)`)
+- `new String("aXbXc").split(/X/).length` → **3**
+- `new String("abc").replace(/[a-z]/, "X")` → `"Xbc"` (`.length` 3, `charCodeAt(0)` 88)
+- `new String("abcabc").replace(/b/g, "X").length` → **6** (global flag honored)
+- `const s: String = new String("a1b2c3"); s.split(/[0-9]/).length` → **4**
+
+Locked with a regression test (`tests/issue-2935.test.ts`, 5 cases,
+standalone host-free). This PR is test + doc only — **byte-inert** to the
+compiler (no `src/` change).
+
 
 # #2935 — `__str_flatten` null-deref on String-wrapper `.split`/`.replace(RegExp)`
 

--- a/tests/issue-2935.test.ts
+++ b/tests/issue-2935.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2935 — `__str_flatten` null-deref on String-wrapper `.split(RegExp)` /
+// `.replace(RegExp, …)` (regression lock).
+//
+// Under `--target standalone`, calling `.split(regexp)` / `.replace(regexp, …)`
+// on a String WRAPPER receiver (`new String(...)`, or a var typed `String`)
+// used to trap at runtime — `dereferencing a null pointer in __str_flatten()` —
+// because the RegExp split/replace lowering handed the wrapper `$Object`
+// receiver to the native `__str_flatten` helper WITHOUT first performing the
+// `thisStringValue` unwrap to recover the primitive `$AnyString`. The intervening
+// borrowed-receiver ToString/RequireObjectCoercible work (PR #3254 / #2934)
+// now unwraps the wrapper before flatten, so the wrapper receiver runs host-free
+// and matches the primitive receiver. This test locks that: the wrapper repro
+// must compile to valid standalone Wasm, instantiate with NO import object, and
+// produce the same result as the primitive receiver.
+//
+// Results are asserted on numeric derivations (`.length` / `.charCodeAt`) rather
+// than the string value itself: a raw standalone `$AnyString` return marshals to
+// `undefined` across the JS boundary (a harness artifact, not a codegen bug), so
+// the string is consumed inside Wasm and only a number crosses out.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  // Standalone modules must instantiate with NO import object (host-free).
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2935 — String-wrapper receiver .split/.replace(RegExp) (standalone)", () => {
+  it("new String(...).split(/re/) runs host-free (no __str_flatten null-deref)", async () => {
+    // "abc".split(/[a-z]/) -> ["", "", "", ""] -> length 4
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new String("abc"); return s.split(/[a-z]/).length; }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("wrapper split content matches primitive receiver", async () => {
+    // "aXbXc".split(/X/) -> ["a", "b", "c"] -> length 3
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new String("aXbXc"); return s.split(/X/).length; }`,
+      ),
+    ).toBe(3);
+    expect(await runStandalone(`export function test(): number { return "aXbXc".split(/X/).length; }`)).toBe(3);
+  });
+
+  it("new String(...).replace(/re/, repl) replaces the first match, host-free", async () => {
+    // "abc".replace(/[a-z]/, "X") -> "Xbc" -> length 3, first char 'X' (88)
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new String("abc"); return s.replace(/[a-z]/, "X").length; }`,
+      ),
+    ).toBe(3);
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new String("abc"); return s.replace(/[a-z]/, "X").charCodeAt(0); }`,
+      ),
+    ).toBe(88); // 'X'
+  });
+
+  it("wrapper .replace(/re/g, …) honors the global flag", async () => {
+    // "abcabc".replace(/b/g, "X") -> "aXcaXc" -> length 6
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new String("abcabc"); return s.replace(/b/g, "X").length; }`,
+      ),
+    ).toBe(6);
+  });
+
+  it("a var typed `String` (wrapper type) unwraps before flatten", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const s: String = new String("a1b2c3"); return s.split(/[0-9]/).length; }`,
+      ),
+    ).toBe(4); // ["a","b","c",""]
+  });
+});


### PR DESCRIPTION
## #2935 — `__str_flatten` null-deref on String-wrapper `.split`/`.replace(RegExp)`

Re-verified against current `origin/main`: the standalone `__str_flatten`
null-deref on a String **wrapper** receiver (`new String(...)` / var typed
`String`) calling `.split(RegExp)` / `.replace(RegExp, …)` **no longer
reproduces**. The intervening borrowed-receiver `RequireObjectCoercible` +
`ToString` unwrap work (**PR #3254**; cf. #2934) recovers the primitive
`$AnyString` from the wrapper's `[[StringData]]` before the native flatten
helper, eliminating the receiver-shape-specific null deref.

### What this PR does
- Adds `tests/issue-2935.test.ts` — 5 standalone, host-free regression cases:
  wrapper `.split(/re/)`, wrapper vs primitive split parity, wrapper
  `.replace(/re/, repl)` (first match), global-flag `.replace(/re/g, …)`, and a
  `const s: String = new String(...)` typed-wrapper form. All assert on numeric
  derivations (`.length` / `.charCodeAt`) since a raw standalone `$AnyString`
  return marshals to `undefined` (harness artifact, not a codegen bug).
- Marks issue #2935 `status: done` with a verification note.

### Byte-inert
Test + issue-doc only — **no `src/` change**. Compiler output is unchanged for
gc/host and for primitive-receiver split/replace.

### Verification
`npx vitest run tests/issue-2935.test.ts` → 5/5 pass. Wrapper results match the
primitive receiver (`split(/[a-z]/)` length 4, `replace(/[a-z]/,"X")` → `"Xbc"`,
global `/b/g` → `"aXcaXc"`).