### PR TITLE
fix(#3310): lift __apply_closure arity ceiling from 4 to 8 (standalone dynamic method calls)

### DIFF
--- a/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
+++ b/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
@@ -1,7 +1,9 @@
 ---
 id: 3310
 title: "G2 — args-passing on the standalone generic method-call path + `__apply_closure` arity>4 lift (wantArgs is host-gated)"
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/opus-4
 created: 2026-07-16
 priority: high
 horizon: m
@@ -80,3 +82,40 @@ Two independent caps on the standalone generic `(any, …) → any` call surface
 G1 (#3309) covers the Map/Set brand arms; G3 is done (#3098). This slice is
 the remaining "args actually flow" half of the #2927 audit's headline gap 2.
 Umbrella: #2927 → #1584.
+
+## Resolution (2026-07-17, ttraenkler/opus-4)
+
+**Part 1 (args-passing) was already resolved** by the sibling landings, verified
+against current main (`o.f(3,4)` under `--target standalone` returns `7`, and a
+2-arg dynamic call returns correctly): the standalone open-`$Object` any-receiver
+generic lane (`call-receiver-method.ts` #799 WI3, #1888 Slice 2) and the
+fnctor-subclass lane (`emitFnctorSubclassDynamicMethodCall`, calls.ts, #3123/#3201)
+both already build the args vec with the native `__objvec_new` / `__objvec_push`
+builders. The only remaining `wantArgs` host-gate is in
+`emitWrapperDynamicMethodCall` (calls.ts ~2668), whose two standalone-reachable
+callers pass no `callExpr` — so it drops nothing observable under standalone.
+
+**Part 2 (arity ceiling) was the live gap and is the fix here.** Repro on current
+main: a 5-arg dynamic call through the open-`$Object` lane
+(`const o:any={}; o.add5=(a,b,c,d,e)=>…; (o as any).add5(1,2,3,4,5)`) returned
+`0` (the undefined sentinel coerced to a number), while a 2-arg call returned
+correctly. Root cause: `__call_fn_method_N` dispatchers are emitted (index.ts,
+`emitClosureMethodCallExportN`) for every arity up to `min(maxClosureArity, 8)`,
+but `fillApplyClosure` (`object-runtime.ts`) built its arity dispatch chain with a
+hard `for (let n = 4; n >= 0; n--)`, so arities 5–8 fell through to the undefined
+sentinel even though their dispatchers existed.
+
+Fix: lift the `fillApplyClosure` dispatch loop bound to 8 (a named
+`APPLY_CLOSURE_MAX_ARITY`) to match the emission cap. `buildArm(n)` already
+returns the undefined sentinel for any arity whose `__call_fn_method_N` was not
+registered, so the widening is byte-identical for modules without ≥5-arg
+closures and only adds live dispatch where the matching dispatcher exists.
+
+Arities beyond 8 remain the undefined sentinel — the unbounded spill-arm
+(`__call_fn_method_vec(recv, fn, argsVec)`) the plan's option (b) describes is the
+#2928 `CallBuiltin` follow-up and is out of scope here.
+
+Tests: `tests/issue-3310.test.ts` — standalone dynamic method calls at arities 2
+(control), 5, 6, 7, 8 return correct values, plus a 0-function-imports assertion.
+The two pre-existing `issue-2151.test.ts` "custom iterable via any-method .next()"
+failures are main-state (fail identically on the b4fca62242 base) and unrelated.

--- a/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
+++ b/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
@@ -16,6 +16,12 @@ goal: runtime-eval
 sprint: current
 parent: 2927
 related: [2928, 1584, 2151, 1888, 3098]
+# (#3102/#3131) The arity lift adds a small named-constant + comment to the
+# fillApplyClosure dispatcher in the god-file object-runtime.ts (the helper
+# already lives there; no clean subsystem module to relocate to). Intended
+# minimal growth for a real standalone correctness fix.
+loc-budget-allow:
+  - src/codegen/object-runtime.ts
 ---
 
 # #3310 — G2: pass args on the standalone generic dispatch path; lift the arity-4 ceiling

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4360,16 +4360,10 @@ export function fillApplyClosure(ctx: CodegenContext): void {
   const callMethod = (n: number): number | undefined => ctx.funcMap.get(`__call_fn_method_${n}`);
   const armUnsupported = undefinedSentinel();
 
-  // (#3310 G2) Highest arity the bridge dispatches. The `__call_fn_method_N`
-  // dispatchers are emitted (index.ts, `emitClosureMethodCallExportN`) for every
-  // arity up to `min(maxClosureArity, 8)`, so the bridge must reach the same 8 —
-  // the previous hard cap at 4 silently dropped a 5+-arg dynamic method call
-  // (`o.m(a,b,c,d,e)` through the open-`$Object` lane) to the undefined sentinel.
-  // `buildArm(n)` returns that same sentinel for any arity whose dispatcher was
-  // not registered, so widening the range is byte-identical for modules without
-  // ≥5-arg closures and only adds live dispatch where the matching dispatcher
-  // exists. Arities beyond 8 remain the undefined sentinel (the spill-arm
-  // `__call_fn_method_vec` calling convention is the #2928 CallBuiltin follow-up).
+  // (#3310 G2) Match the `__call_fn_method_N` emission cap (index.ts:
+  // min(maxClosureArity, 8)); the prior hard cap at 4 dropped 5+-arg dynamic
+  // calls to the undefined sentinel. buildArm returns that sentinel for any
+  // unregistered arity, so widening is byte-identical without ≥5-arg closures.
   const APPLY_CLOSURE_MAX_ARITY = 8;
 
   const buildArm = (n: number): Instr[] => {

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4306,8 +4306,8 @@ export function reserveApplyClosure(ctx: CodegenContext): number {
  *   n = i32(__extern_length(args))
  *   if n==0: __call_fn_method_0(recv, fn)
  *   if n==1: __call_fn_method_1(recv, fn, idx0)
- *   ... up to 4 ...
- *   else (n>4): return undefined (sentinel)
+ *   ... up to 8 (#3310 G2 — matches the `emitClosureMethodCallExportN` cap) ...
+ *   else (n>8): return undefined (sentinel)
  *
  * S1 SCOPE — NO THROWS. This bridge returns the undefined sentinel
  * (`ref.null.extern`) for the not-a-function and arity-overflow cases rather
@@ -4355,10 +4355,22 @@ export function fillApplyClosure(ctx: CodegenContext): void {
     { op: "call", funcIdx: externGetIdxArr },
   ];
 
-  // Build the arity dispatch from the bottom up (n>4 → undefined), each arm
+  // Build the arity dispatch from the bottom up (n>MAX → undefined), each arm
   // guarded on the matching __call_fn_method_N being registered.
   const callMethod = (n: number): number | undefined => ctx.funcMap.get(`__call_fn_method_${n}`);
   const armUnsupported = undefinedSentinel();
+
+  // (#3310 G2) Highest arity the bridge dispatches. The `__call_fn_method_N`
+  // dispatchers are emitted (index.ts, `emitClosureMethodCallExportN`) for every
+  // arity up to `min(maxClosureArity, 8)`, so the bridge must reach the same 8 —
+  // the previous hard cap at 4 silently dropped a 5+-arg dynamic method call
+  // (`o.m(a,b,c,d,e)` through the open-`$Object` lane) to the undefined sentinel.
+  // `buildArm(n)` returns that same sentinel for any arity whose dispatcher was
+  // not registered, so widening the range is byte-identical for modules without
+  // ≥5-arg closures and only adds live dispatch where the matching dispatcher
+  // exists. Arities beyond 8 remain the undefined sentinel (the spill-arm
+  // `__call_fn_method_vec` calling convention is the #2928 CallBuiltin follow-up).
+  const APPLY_CLOSURE_MAX_ARITY = 8;
 
   const buildArm = (n: number): Instr[] => {
     const idx = callMethod(n);
@@ -4378,9 +4390,9 @@ export function fillApplyClosure(ctx: CodegenContext): void {
     return ops;
   };
 
-  // if n==0 .. n==4 else undefined. Nest as if/else chain.
+  // if n==0 .. n==APPLY_CLOSURE_MAX_ARITY else undefined. Nest as if/else chain.
   let dispatch: Instr[] = armUnsupported;
-  for (let n = 4; n >= 0; n--) {
+  for (let n = APPLY_CLOSURE_MAX_ARITY; n >= 0; n--) {
     dispatch = [
       { op: "local.get", index: 3 },
       { op: "i32.const", value: n },

--- a/tests/issue-3310.test.ts
+++ b/tests/issue-3310.test.ts
@@ -1,0 +1,69 @@
+// #3310 — G2: the standalone open-`$Object` dynamic method-call bridge
+// (`__apply_closure`) previously hard-capped its arity dispatch at 4, silently
+// dropping a 5+-arg call (`o.m(a,b,c,d,e)`) to the undefined sentinel (→ 0 in a
+// numeric context). The `__call_fn_method_N` dispatchers are emitted up to
+// arity 8, so the bridge dispatch is lifted to match. This asserts a dynamic
+// method call through the generic open-object lane receives its arguments for
+// arities 2 (control, already worked), 5, 6, 7, and 8 under `--target standalone`,
+// host-free (0 function imports).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string, entry: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) {
+    throw new Error("compile failed: " + (r.errors ?? []).map((e) => e.message).join("; "));
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const fn = (instance.exports as Record<string, unknown>)[entry];
+  if (typeof fn !== "function") throw new Error(`export ${entry} is not a function`);
+  return (fn as () => unknown)();
+}
+
+const SRC = `
+const o: any = {};
+o.add2 = (a: number, b: number) => a + b;
+o.add5 = (a: number, b: number, c: number, d: number, e: number) => a + b + c + d + e;
+o.add6 = (a: number, b: number, c: number, d: number, e: number, f: number) => a + b + c + d + e + f;
+o.add7 = (a: number, b: number, c: number, d: number, e: number, f: number, g: number) =>
+  a + b + c + d + e + f + g;
+o.add8 = (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) =>
+  a + b + c + d + e + f + g + h;
+export function two(): number { const g: any = o; return g.add2(10, 20) as number; }
+export function five(): number { const g: any = o; return g.add5(1, 2, 3, 4, 5) as number; }
+export function six(): number { const g: any = o; return g.add6(1, 2, 3, 4, 5, 6) as number; }
+export function seven(): number { const g: any = o; return g.add7(1, 2, 3, 4, 5, 6, 7) as number; }
+export function eight(): number { const g: any = o; return g.add8(1, 2, 3, 4, 5, 6, 7, 8) as number; }
+`;
+
+describe("#3310 — standalone dynamic method-call arity lift (>4 args through __apply_closure)", () => {
+  it("arity 2 (control) still dispatches", async () => {
+    expect(await runStandalone(SRC, "two")).toBe(30);
+  });
+
+  it("arity 5 dispatches (was the undefined-sentinel bug)", async () => {
+    expect(await runStandalone(SRC, "five")).toBe(15);
+  });
+
+  it("arity 6 dispatches", async () => {
+    expect(await runStandalone(SRC, "six")).toBe(21);
+  });
+
+  it("arity 7 dispatches", async () => {
+    expect(await runStandalone(SRC, "seven")).toBe(28);
+  });
+
+  it("arity 8 dispatches (the emission cap)", async () => {
+    expect(await runStandalone(SRC, "eight")).toBe(36);
+  });
+
+  it("standalone binary has zero function imports", async () => {
+    const r = await compile(SRC, { fileName: "test.ts", target: "standalone" });
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const mod = await WebAssembly.compile(r.binary);
+    const funcImports = WebAssembly.Module.imports(mod).filter((i) => i.kind === "function");
+    expect(funcImports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3310 Part 2 (the live gap). The standalone open-`$Object` dynamic method-call bridge (`__apply_closure`, `fillApplyClosure` in `src/codegen/object-runtime.ts`) built its arity dispatch chain with a hard `for (let n = 4; n >= 0; n--)`, so a 5+-arg dynamic method call (`o.m(a,b,c,d,e)` through the open-object lane) fell through to the undefined sentinel and returned `0` in a numeric context — even though the `__call_fn_method_N` dispatchers are emitted (index.ts, `emitClosureMethodCallExportN`) for every arity up to `min(maxClosureArity, 8)`.

**Fix:** lift the `fillApplyClosure` dispatch loop bound to a named `APPLY_CLOSURE_MAX_ARITY = 8` to match the emission cap. `buildArm(n)` already returns the undefined sentinel for any arity whose `__call_fn_method_N` was not registered, so the widening is **byte-identical for modules without ≥5-arg closures** and only adds live dispatch where the matching dispatcher exists.

## Part 1 was already resolved
The args-passing half was already handled by #1888 Slice 2 / #3123 / #3201 (verified against current main: `o.f(3,4)` standalone returns `7`). The only remaining `wantArgs` host-gate (`emitWrapperDynamicMethodCall`) has no standalone caller that passes a `callExpr`, so it drops nothing observable under standalone. See the issue's Resolution section for the full trace.

## Repro (current main)
`const o:any={}; o.add5=(a,b,c,d,e)=>a+b+c+d+e; (o as any).add5(1,2,3,4,5)` → `0` before, `15` after (standalone).

## Tests
`tests/issue-3310.test.ts` — standalone dynamic method calls at arities 2 (control), 5, 6, 7, 8 return correct values, plus a 0-function-imports assertion. All 6 pass.

The two pre-existing `issue-2151.test.ts` "custom iterable via any-method .next()" failures are main-state (fail identically on the `b4fca62242` base) and unrelated to this change.

Arities beyond 8 remain the undefined sentinel — the unbounded spill-arm (`__call_fn_method_vec`) is the #2928 `CallBuiltin` follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)