### PR TITLE
feat(#1044): ambient global Buffer typing under --emulate node

### DIFF
--- a/plan/issues/1044-node-builtin-modules-as-host.md
+++ b/plan/issues/1044-node-builtin-modules-as-host.md
@@ -2,9 +2,11 @@
 id: 1044
 title: "Node builtin modules as host imports (NODE_HOST_IMPORT_MODULES, node: prefix normalization)"
 horizon: m
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/opus-b
 created: 2026-04-11
-updated: 2026-06-19
+updated: 2026-07-17
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -14,6 +16,7 @@ parent: 1032
 depends_on: [1041]
 required_by: [1032, 1058]
 ---
+
 # #1044 — Node builtin modules as host imports
 
 ## Problem
@@ -28,13 +31,26 @@ For #1032 (axios stress test) to get past Tier 2, the compiler must recognize No
 
    ```ts
    const NODE_BUILTIN_MODULES = new Set([
-     'http', 'https', 'http2', 'url', 'querystring',
-     'stream', 'stream/web', 'events', 'buffer',
-     'zlib', 'util', 'path', 'process',
-     'net', 'tls', 'fs', 'crypto',
+     "http",
+     "https",
+     "http2",
+     "url",
+     "querystring",
+     "stream",
+     "stream/web",
+     "events",
+     "buffer",
+     "zlib",
+     "util",
+     "path",
+     "process",
+     "net",
+     "tls",
+     "fs",
+     "crypto",
    ]);
    function isNodeBuiltin(spec: string): boolean {
-     return NODE_BUILTIN_MODULES.has(spec.replace(/^node:/, ''));
+     return NODE_BUILTIN_MODULES.has(spec.replace(/^node:/, ""));
    }
    ```
 
@@ -78,3 +94,38 @@ For #1032 (axios stress test) to get past Tier 2, the compiler must recognize No
 - Depends on: **#1041** (pre-bundled single-file input — required for any multi-file npm package)
 - Coordinate with: **#1035** (WASI `node:fs` compile-time syscall path — two different mechanisms with overlapping surface; design together)
 - Architecture: `plan/design/architecture/npm-stress-compiler-gaps.md` cross-cutting gap #3
+
+## Resolution (2026-07-17)
+
+The recognition machinery landed **incrementally** across the sprint rather than
+in a single PR, and criterion 5's last gap was closed here:
+
+- **`NODE_BUILTIN_MODULES` set + `isNodeBuiltin` + `normalizeNodeBuiltin`** —
+  `src/import-resolver.ts` (set now spans http/https/url/stream/events/buffer/
+  zlib/util/fs/crypto/os/module/fs-promises/… — well beyond the original spec).
+- **`node:` prefix normalization** — `import http from "node:http"` and
+  `import http from "http"` resolve to the same host import
+  (`normalizeNodeBuiltin` strips the `node:` prefix). ✔ criterion 2.
+- **Host-import routing (no `declare const X: any` erasure)** — node-builtin
+  imports push to `nodeBuiltins` → late externref host import; typed function
+  stubs (`__nodefn__<mod>__<fn>`, #1492/#1795/#2699) and extern-class stubs
+  (#1794) for known members. ✔ criterion 3 (the axios Tier-4 surface —
+  http/https/url/stream/events/zlib/util/buffer — compiles routing through host
+  imports; full `lib/adapters/http.js` also needs async lowering #1042, a
+  declared non-goal here).
+- **WASI capability gate** — a non-`node:fs` builtin under `--target wasi`
+  errors cleanly: _"Node builtin module 'http' is not available in WASI
+  target…"_ rather than crashing. ✔ criterion 4.
+- **Global `Buffer`** — #1793 registered `Buffer` in `BUILTIN_CLASS_NAMES` so
+  `Buffer.from`/`alloc`/`concat` lower syntactically. This PR closed the last
+  gap: `buildNodeEnvDts` (`src/checker/index.ts`) now injects an ambient
+  `declare var Buffer: BufferConstructor` (parallel to the `process` global),
+  so the global form type-checks under `--emulate node` instead of emitting a
+  spurious _"Cannot find name 'Buffer'"_. Gated behind `--emulate node` (like
+  `process`/`Deno`), so the common web/test262 path stays byte-neutral; a local
+  `Buffer` import binding or a user-declared `Buffer` suppresses the inject.
+  ✔ criterion 5.
+
+Verification: `tests/issue-1044.test.ts` (9 tests: global-Buffer ambient typing,
+import-scoped dts, node:-prefix normalization, WASI gate) + the existing
+`tests/issue-1793.test.ts` (7) all green.

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -453,11 +453,45 @@ interface NodeJS_Process {
   readonly stderr: NodeJS_WritableStream;
 }`;
 
+// #1044 / #1793 — the global `Buffer` ambient surface. `Buffer` is a Node
+// GLOBAL (not just an export of `require("buffer")`); #1793 registered it in
+// BUILTIN_CLASS_NAMES so `Buffer.from` / `alloc` / `concat` and the prototype
+// methods lower syntactically in codegen regardless of typing. But WITHOUT an
+// ambient declaration the checker emits a spurious "Cannot find name 'Buffer'"
+// (TS2304/TS2580) for the common global form under `--emulate node`. This
+// injection (gated behind `--emulate node`, like `process`/`Deno` — so the
+// common web/test262 path stays byte-neutral) silences that diagnostic and
+// lets `Buffer.*` type-check as a Uint8Array subtype. Covers the #1793 Tier 0
+// surface (utf-8 + byte-array); the full encoding matrix is a follow-up.
+const BUFFER_INTERFACE_DECLS = `interface Buffer extends Uint8Array {
+  toString(encoding?: string, start?: number, end?: number): string;
+  write(str: string, encoding?: string): number;
+  equals(other: Uint8Array): boolean;
+  readUInt8(offset?: number): number;
+  readUInt16LE(offset?: number): number;
+  readUInt16BE(offset?: number): number;
+  readUInt32LE(offset?: number): number;
+  readUInt32BE(offset?: number): number;
+  writeUInt8(value: number, offset?: number): number;
+}
+interface BufferConstructor {
+  from(str: string, encoding?: string): Buffer;
+  from(data: ArrayLike<number> | ArrayBufferLike): Buffer;
+  from(data: Uint8Array): Buffer;
+  concat(list: readonly Uint8Array[], totalLength?: number): Buffer;
+  alloc(size: number, fill?: string | number, encoding?: string): Buffer;
+  allocUnsafe(size: number): Buffer;
+  isBuffer(obj: unknown): boolean;
+  byteLength(str: string, encoding?: string): number;
+}`;
+
 interface NodeEmuUsage {
   /** node:<mod> -> set of imported member names ("" sentinel = default/namespace import). */
   modules: Map<string, Set<string>>;
   /** A bare global `process` is referenced (NOT via a `node:process` import). */
   bareProcess: boolean;
+  /** A bare global `Buffer` is referenced (NOT bound by an import). */
+  bareBuffer: boolean;
 }
 
 /**
@@ -469,6 +503,10 @@ interface NodeEmuUsage {
 function scanNodeEmuUsage(source: string, scriptKind: ts.ScriptKind): NodeEmuUsage {
   const modules = new Map<string, Set<string>>();
   let importsNodeProcess = false;
+  // #1044 — a local `Buffer` binding from ANY import (`import { Buffer } from
+  // "node:buffer"`, a default/namespace named `Buffer`, etc.) means `Buffer`
+  // is the import symbol, not the ambient global — suppress the global inject.
+  let bindsBufferLocal = false;
 
   const sf = ts.createSourceFile("__scan__.ts", source, ts.ScriptTarget.Latest, /*setParentNodes*/ true, scriptKind);
 
@@ -487,6 +525,20 @@ function scanNodeEmuUsage(source: string, scriptKind: ts.ScriptKind): NodeEmuUsa
   const visit = (node: ts.Node): void => {
     if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
       const spec = node.moduleSpecifier.text;
+      // #1044 — record a local `Buffer` binding from ANY module (node: or bare).
+      const importClause = node.importClause;
+      if (importClause) {
+        if (importClause.name?.text === "Buffer") bindsBufferLocal = true;
+        if (importClause.namedBindings) {
+          if (ts.isNamespaceImport(importClause.namedBindings)) {
+            if (importClause.namedBindings.name.text === "Buffer") bindsBufferLocal = true;
+          } else {
+            for (const el of importClause.namedBindings.elements) {
+              if (el.name.text === "Buffer") bindsBufferLocal = true;
+            }
+          }
+        }
+      }
       if (spec.startsWith("node:")) {
         const members: string[] = [];
         const clause = node.importClause;
@@ -529,7 +581,13 @@ function scanNodeEmuUsage(source: string, scriptKind: ts.ScriptKind): NodeEmuUsa
   // covers any user that declares its own `process`.
   const bareProcess = !importsNodeProcess && /\bprocess\b/.test(source);
 
-  return { modules, bareProcess };
+  // #1044 — a bare global `Buffer` reference (NOT bound by an import). `Buffer`
+  // is lowered syntactically in codegen (#1793) regardless of typing; the
+  // ambient declaration only silences the "Cannot find name 'Buffer'"
+  // diagnostic. Same regex-approximation + dup-identifier fallback as `process`.
+  const bareBuffer = !bindsBufferLocal && /\bBuffer\b/.test(source);
+
+  return { modules, bareProcess, bareBuffer };
 }
 
 /**
@@ -559,6 +617,14 @@ function buildNodeEnvDts(usage: NodeEmuUsage): string | undefined {
   if (usage.bareProcess) {
     emitProcessInterfaces();
     parts.push(`declare var process: NodeJS_Process;`);
+  }
+
+  // #1044 — bare ambient global `Buffer` (Node global, lowered syntactically by
+  // #1793). Silences the "Cannot find name 'Buffer'" diagnostic and types
+  // `Buffer.*` as a Uint8Array subtype under `--emulate node`.
+  if (usage.bareBuffer) {
+    parts.push(BUFFER_INTERFACE_DECLS);
+    parts.push(`declare var Buffer: BufferConstructor;`);
   }
 
   // `node:<mod>` modules, each scoped to its imported members.
@@ -650,9 +716,10 @@ const DUP_IDENTIFIER_CODES = new Set([
 
 function diagnosticMentionsInjectedGlobal(d: ts.Diagnostic): boolean {
   const text = typeof d.messageText === "string" ? d.messageText : d.messageText.messageText;
-  // A dup-identifier on EITHER injected ambient global (`process` or `Deno`)
-  // means the user declared it themselves — rebuild without the injection.
-  return text.includes("'process'") || text.includes("'Deno'");
+  // A dup-identifier on any injected ambient global (`process`, `Deno`, or
+  // `Buffer`) means the user declared it themselves — rebuild without the
+  // injection.
+  return text.includes("'process'") || text.includes("'Deno'") || text.includes("'Buffer'");
 }
 
 // #2684 — ambient `Deno` namespace typing, injected import-scoped when the

--- a/tests/issue-1044.test.ts
+++ b/tests/issue-1044.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1044 — Node builtin modules as host imports. The recognition machinery
+// (NODE_BUILTIN_MODULES, `node:` normalization, WASI capability gate) landed
+// incrementally (#1791/#1793/#1794/#1795/#2699/#2701). This test closes the
+// last gap of acceptance criterion 5: the GLOBAL `Buffer` identifier (a Node
+// global, not just a `require("buffer")` export). #1793 lowers `Buffer.*`
+// syntactically, but the checker still emitted a spurious "Cannot find name
+// 'Buffer'" for the global form under `--emulate node`. `buildNodeEnvDts` now
+// injects an ambient `Buffer` declaration (parallel to the `process` global),
+// gated behind `--emulate node` so the common web/test262 path stays
+// byte-neutral.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildNodeEnvDtsForSource } from "../src/checker/index.js";
+
+describe("#1044 — Node builtin modules as host imports", () => {
+  describe("global Buffer ambient typing under --emulate node", () => {
+    const bufferDiags = (r: { errors?: Array<{ message: string }> }): string[] =>
+      (r.errors ?? []).map((e) => e.message).filter((m) => /Cannot find name 'Buffer'/.test(m));
+
+    it("Buffer.from as a global does not emit 'Cannot find name Buffer' under emulateNode", async () => {
+      const r = await compile(`export function test(): number { const b = Buffer.from("hi"); return b.length; }`, {
+        fileName: "test.ts",
+        emulateNode: true,
+      });
+      expect(r.success).toBe(true);
+      expect(bufferDiags(r)).toHaveLength(0);
+    });
+
+    it("Buffer.concat / alloc statics type-check cleanly under emulateNode", async () => {
+      const r = await compile(
+        `export function test(): number {
+           const c = Buffer.concat([Buffer.from("a"), Buffer.from("b")]);
+           return c.length + Buffer.alloc(4).length;
+         }`,
+        { fileName: "test.ts", emulateNode: true },
+      );
+      expect(r.success).toBe(true);
+      expect(bufferDiags(r)).toHaveLength(0);
+    });
+
+    it("a named `import { Buffer } from 'node:buffer'` still type-checks (no dup global)", async () => {
+      const r = await compile(
+        `import { Buffer } from "node:buffer";
+         export function test(): number { return Buffer.from("x").length; }`,
+        { fileName: "test.ts", emulateNode: true },
+      );
+      expect(r.success).toBe(true);
+      expect(bufferDiags(r)).toHaveLength(0);
+    });
+
+    it("a user-declared `Buffer` binding is not clobbered by the ambient inject", async () => {
+      const r = await compile(`const Buffer = 5;\nexport function test(): number { return Buffer; }`, {
+        fileName: "test.ts",
+        emulateNode: true,
+      });
+      expect(r.success).toBe(true);
+      expect(bufferDiags(r)).toHaveLength(0);
+    });
+  });
+
+  describe("buildNodeEnvDts scoping (import-scoped, byte-neutral off-path)", () => {
+    it("injects an ambient `Buffer` for a bare-global Buffer program", () => {
+      const dts = buildNodeEnvDtsForSource(`function test() { return Buffer.from("hi"); }`);
+      expect(dts).toBeDefined();
+      expect(dts).toContain("declare var Buffer: BufferConstructor");
+      expect(dts).toContain("interface BufferConstructor");
+    });
+
+    it("does NOT inject an ambient `Buffer` when Buffer is import-bound", () => {
+      const dts = buildNodeEnvDtsForSource(
+        `import { Buffer } from "node:buffer"; function t() { return Buffer.from("x"); }`,
+      );
+      // The `node:buffer` module decl may exist, but no bare `declare var Buffer`.
+      expect(dts ?? "").not.toContain("declare var Buffer: BufferConstructor");
+    });
+
+    it("does NOT inject `Buffer` for a program that never mentions Buffer", () => {
+      const dts = buildNodeEnvDtsForSource(`export function test(): number { return 42; }`);
+      // No Node surface touched at all → undefined (nothing injected).
+      expect(dts).toBeUndefined();
+    });
+  });
+
+  describe("node: prefix normalization + WASI capability gate", () => {
+    it("`node:http` and bare `http` both resolve to the same host import (JS host)", async () => {
+      const withPrefix = await compile(`import http from "node:http"; export function test(): number { return 1; }`, {
+        fileName: "a.ts",
+      });
+      const bare = await compile(`import http from "http"; export function test(): number { return 1; }`, {
+        fileName: "b.ts",
+      });
+      expect(withPrefix.success).toBe(true);
+      expect(bare.success).toBe(true);
+    });
+
+    it("a Node builtin under `--target wasi` errors cleanly (not a crash)", async () => {
+      const r = await compile(`import http from "node:http"; export function test(): number { return 1; }`, {
+        fileName: "test.ts",
+        target: "wasi",
+      });
+      expect(r.success).toBe(false);
+      expect(r.errors.some((e) => /not available in WASI target/i.test(e.message))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1044.

## Summary

Node builtin recognition (`NODE_BUILTIN_MODULES`, `node:` normalization,
host-import routing, WASI capability gate) landed **incrementally** across the
sprint (#1791/#1793/#1794/#1795/#2699/#2701). This PR closes criterion 5's last
gap: the **global** `Buffer` identifier.

#1793 registered `Buffer` in `BUILTIN_CLASS_NAMES` so `Buffer.from`/`alloc`/
`concat` lower syntactically, but the checker still emitted a spurious
"Cannot find name 'Buffer'" for the global form under `--emulate node`.
`buildNodeEnvDts` (`src/checker/index.ts`) now injects an ambient
`declare var Buffer: BufferConstructor` (parallel to the `process` global).

## Scope / safety

- **Gated behind `--emulate node`** (like `process`/`Deno`) — the common
  web/test262 path is untouched (byte-neutral off-path).
- A local `Buffer` import binding (`import { Buffer } from "node:buffer"`) or a
  user-declared `Buffer` suppresses the inject (dup-identifier rebuild guard).
- The `Buffer` interface extends `Uint8Array` with the #1793 Tier-0 surface
  (from/concat/alloc/toString/readUInt*/…); `slice`/`subarray` overrides were
  intentionally omitted to avoid the TS 5.7 `Uint8Array<ArrayBufferLike>`
  variance conflict.

## Verification

- New `tests/issue-1044.test.ts` — 9 tests: global-Buffer ambient typing,
  import-scoped dts, `node:`-prefix normalization, WASI capability gate. Green.
- Existing `tests/issue-1793.test.ts` (7) + node-emu injection tests
  (#1772/#2603/#2684) — all green.
- `tsc --noEmit` clean on `src/checker/index.ts`.

The impl PR sets the issue `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)