### PR TITLE
fix(#3348): arbitrate — compiled-acorn parse does NOT throw in-Wasm (harness artifact); un-block #3308

### DIFF
--- a/plan/issues/3308-e0-in-wasm-ast-consumer-probe.md
+++ b/plan/issues/3308-e0-in-wasm-ast-consumer-probe.md
@@ -15,18 +15,23 @@ language_feature: eval
 goal: runtime-eval
 sprint: current
 parent: 2927
-depends_on: [3348]
-related: [2928, 1584, 1710, 1712, 2841, 2851, 2852, 2847, 3348]
+depends_on: []
+related: [2928, 1584, 1710, 1712, 2841, 2851, 2852, 2847, 3343, 3348]
 ---
 
-> **BLOCKED / re-scoped 2026-07-17 (opus-4).** Attempted E0. The in-Wasm
-> AST-consumer measurement cannot proceed because **compiled-acorn's own
-> `parse()` currently throws in-Wasm** ("parse is not a function" dynamic
-> method-dispatch failure) on current main — even the acorn-alone control via
-> `wrapExports` fails, a regression since the 2026-06-30 corpus baseline. Filed
-> as **#3348** (feasibility:hard, priority:high). This issue was mis-sized `S`;
-> re-tagged `feasibility:hard`, `horizon:m`, and `depends_on: [3348]` — it needs
-> a walkable compiled-acorn AST first. See #3348 for the full repro.
+> **NOT BLOCKED — E0 is COMPLETE (2026-07-17, senior-dev).** A prior
+> `BLOCKED / depends_on: [3348]` re-scope (PR #3230) was based on **#3348's
+> claim that compiled-acorn's `parse()` throws in-Wasm**. That claim was
+> **arbitrated empirically and refuted**: it was a _harness artifact_ — the repro
+> omitted `io.__setExports(instance.exports)` after `WebAssembly.instantiate`,
+> which makes host dispatch mis-resolve and raises the runtime's
+> `method is not a function` guard. With that one line, acorn-alone
+> `wrapExports(...).parse("const a=1; let b=2; function f(){}", …)` returns a
+> correct `Program` (`body.length === 3`), and the committed corpus harness
+> reports **`compiled-threw=0`** across all 23 inputs on current main (_better_
+> than the 2026-06-30 baseline's 1 — nothing regressed). **#3348 is
+> `wont-fix`; no bisect is warranted.** `depends_on` cleared and the E0
+> measurement below stands. Full evidence in #3348's resolution banner.
 
 # #3308 — E0: in-Wasm AST consumer probe
 

--- a/plan/issues/3348-compiled-acorn-parse-throws-in-wasm.md
+++ b/plan/issues/3348-compiled-acorn-parse-throws-in-wasm.md
@@ -1,8 +1,9 @@
 ---
 id: 3348
 title: "compiled-acorn parse() throws in-Wasm on current main — 'parse is not a function' dynamic method-dispatch failure (regressed since 2026-06-30 corpus baseline)"
-status: ready
+status: wont-fix
 created: 2026-07-17
+resolved: 2026-07-17
 priority: high
 horizon: m
 feasibility: hard
@@ -11,13 +12,94 @@ task_type: bug
 area: codegen, runtime, dogfood
 language_feature: dynamic-dispatch
 goal: runtime-eval
-related: [3308, 2927, 1584, 1710, 1712]
+related: [3308, 2927, 1584, 1710, 1712, 3343]
 origin: "#3308 E0 probe attempt (2026-07-17, opus-4) — the in-Wasm AST-consumer measurement is blocked because compiled-acorn's own parse() throws in-Wasm."
 ---
 
+> # ⛔ RESOLVED 2026-07-17 — HARNESS ARTIFACT, NOT A REGRESSION. Do NOT bisect.
+>
+> **Verdict (senior-dev, empirical, on current `origin/main`): compiled-acorn's
+> `parse()` does NOT throw in-Wasm. Both reported errors are caused by the
+> repro harness omitting `io.__setExports(instance.exports)` after
+> `WebAssembly.instantiate`.** Without that call `callbackState.getExports()`
+> returns `undefined`, host method dispatch mis-resolves, and the runtime raises
+> its `method is not a function` guard (`runtime.ts:10656`) — producing exactly
+> the reported `"parse is not a function"`. This is a known harness trap
+> (memory `project_wrapforhost_setexports_harness`; cost ~30 min on #1694).
+>
+> **The committed corpus harness does call it** —
+> `tests/dogfood/acorn-corpus.mjs:183` (`io.__setExports?.(instance.exports)`)
+> immediately before `wrapExports` at :184 — so the claim that the repro ran
+> "exactly as the corpus harness does" does not hold; that one line was missing.
+>
+> ## Controlled experiment — ONE compile, ONE instance, single variable
+>
+> Same binary, same instance; the ONLY difference is whether `__setExports` was
+> called. Acorn **alone**, `fileName: "acorn.mjs"`,
+> `skipSemanticDiagnostics: true`, #3348's exact input and options. Self-contained
+> repro:
+>
+> ```js
+> const r = await compile(acornSrc, { fileName: "acorn.mjs", skipSemanticDiagnostics: true });
+> const io = r.importObject ?? {};
+> const { instance } = await WebAssembly.instantiate(r.binary, io);
+> const SRC = "const a=1; let b=2; function f(){}";
+> const OPTS = { ecmaVersion: 2025, sourceType: "script" };
+> const parseIt = () => wrapExports(instance.exports, { signatures: r.exportSignatures }).parse(SRC, OPTS);
+>
+> parseIt(); // THROWS "parse is not a function"   <-- #3348's conditions
+> io.__setExports?.(instance.exports); // <-- THE MISSING LINE (acorn-corpus.mjs:183)
+> parseIt(); // OK: Program, body.length === 3
+> ```
+>
+> | probe                                            | WITHOUT `__setExports` (#3348's conditions)                          | WITH `__setExports` (corpus-harness conditions)                                                                                        |
+> | ------------------------------------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+> | `wrapExports(...).parse(SRC, OPTS)` (control #1) | **THREW `"parse is not a function"`** — the reported error, verbatim | **OK** → `{type:"Program", bodyLen:3, kinds:["VariableDeclaration","VariableDeclaration","FunctionDeclaration"]}` — exactly node-acorn |
+> | `probeBodyLen(src)` (control #2, in-Wasm)        | **THREW `"parse is not a function"`**                                | **OK → 3** (correct)                                                                                                                   |
+>
+> ## The "regression" claim is directly refuted on today's main
+>
+> `pnpm run dogfood:acorn-corpus` (the committed, authoritative `wrapExports`
+> control) on current `origin/main`:
+>
+> ```
+> inputs=23  equal=0  equal±quirks=23  REAL=0  compiled-threw=0  oracle-error=0
+> ```
+>
+> **`compiled-threw=0`** — `parse` works for **all 23** corpus inputs today. That
+> is _better_ than the 2026-06-30 baseline (`compiled-threw=1`, `regex.js`), so
+> nothing regressed across the ~343 commits; the window **improved**. This issue's
+> own acceptance criterion ("`compiled-threw` back to its 2026-06-30 level (≤1)")
+> was **already met on main** at filing time. **No bisect is warranted.**
+>
+> ## The third symptom, explained
+>
+> `"type incompatibility when transforming from/to JS"` reproduces only when
+> reading the AST through **`wrapExports` on the _combined_ module** (acorn +
+> an appended probe export), even _with_ `__setExports` — appending an export
+> perturbs `exportSignatures`, so it is a **`wrapExports`/signatures marshalling
+> artifact of the combined module**, not acorn's internal dispatch. It does not
+> affect the in-Wasm path: the same combined module's internal `probeBodyLen`
+> returns **3** correctly. E0's probe sidesteps it entirely by returning only
+> scalars and never calling `wrapExports`.
+>
+> ## Consequences
+>
+> - **#3308 (E0) is NOT blocked** — un-blocked; E0 is complete (all three gap
+>   verdicts measured INTACT in-Wasm, single-construct node-count parity 15/15).
+>   See `tests/dogfood/acorn-probe.mjs` / `pnpm run dogfood:acorn-probe`.
+> - **#3343 stands** — its "Not a parse bug" claim is confirmed. The real
+>   in-Wasm limit is a _recursive-read_ runaway at scale (~60+ nodes), not parse.
+> - **Lesson worth keeping:** any hand-rolled `compile → instantiate` probe MUST
+>   call `io.__setExports(instance.exports)`, or host dispatch silently
+>   mis-resolves and every dynamic method reads as "not a function". Prefer
+>   copying `tests/dogfood/acorn-corpus.mjs`'s setup verbatim.
+>
+> Kept (not deleted) as the record of the arbitration. Original report below.
+
 # #3348 — compiled-acorn `parse()` throws in-Wasm on current main
 
-## Problem
+## Problem (ORIGINAL REPORT — superseded, see the resolution banner above)
 
 While attempting the #3308 (E0) in-Wasm AST-consumer probe, the **control**
 measurement — compiled-acorn **alone**, calling the exported `parse` through
@@ -32,7 +114,7 @@ parse is not a function
 ```
 
 This is a **dynamic method-dispatch failure** raised by the host runtime's
-`method-not-a-function` guard, reached from *within* acorn's compiled `parse`
+`method-not-a-function` guard, reached from _within_ acorn's compiled `parse`
 (so `exp.parse` IS callable at the JS level; acorn's internal dispatch — e.g.
 `Parser.parse(...)` / a prototype-method call — resolves to a non-function
 in-Wasm and throws).
@@ -52,13 +134,13 @@ Combined-module and control experiments (host/gc mode, `skipSemanticDiagnostics:
 true`, the corpus's exact compile options):
 
 1. **Control — acorn ALONE**: `compile(acornSrc, { fileName: "acorn.mjs",
-   skipSemanticDiagnostics: true })` compiles successfully; then
+skipSemanticDiagnostics: true })` compiles successfully; then
    `wrapExports(instance.exports, { signatures }).parse("const a=1; let b=2;
-   function f(){}", { ecmaVersion: 2025, sourceType: "script" })` **throws
+function f(){}", { ecmaVersion: 2025, sourceType: "script" })` **throws
    "parse is not a function"**.
 2. **Combined acorn + in-Wasm walker** (append `export function
-   probeBodyLen(src){ const ast = parse(src, { ecmaVersion: 2025, sourceType:
-   "script" }); return ast.body.length; }` to the acorn source before compile):
+probeBodyLen(src){ const ast = parse(src, { ecmaVersion: 2025, sourceType:
+"script" }); return ast.body.length; }` to the acorn source before compile):
    compiles (**703 KB** binary), but
    - the exported `parse` still throws "parse is not a function" (with options)
      / "type incompatibility when transforming from/to JS",

--- a/tests/dogfood/acorn-corpus.mjs
+++ b/tests/dogfood/acorn-corpus.mjs
@@ -180,6 +180,16 @@ export async function runCorpus({ quiet = false, includeAcornSelf = true } = {})
   await WebAssembly.compile(r.binary); // validate (throws on invalid)
   const io = r.importObject ?? {};
   const { instance } = await WebAssembly.instantiate(r.binary, io);
+  // LOAD-BEARING — do NOT drop this line when copying this setup into a new probe.
+  // The host runtime resolves dynamic method dispatch through
+  // `callbackState.getExports()`. Until `__setExports` hands it the instance's
+  // exports, that returns `undefined`, dispatch silently mis-resolves, and the
+  // runtime's method-not-a-function guard fires — so EVERY dynamic method reads
+  // as missing. The failure is maximally misleading: `parse` looks broken
+  // ("parse is not a function") when the compiler is perfectly fine.
+  // This has cost real hours twice: #1694 (~30 min) and #3348 (filed as a
+  // "compiled-acorn parse() regression", nearly triggered a 343-commit bisect —
+  // resolved wont-fix; the only defect was a probe missing this line).
   io.__setExports?.(instance.exports);
   const exp = wrapExports(instance.exports, { signatures: r.exportSignatures });
   if (typeof exp.parse !== "function") {


### PR DESCRIPTION
## Verdict: #3348 is a **harness artifact — not a regression**. No bisect warranted.

#3348 (merged to main via #3230, currently `status: ready`, `priority: high`, `feasibility: hard`) claims compiled-acorn's `parse()` throws in-Wasm on current main, calls it a regression across **~343 commits**, requests a **bisect**, and re-scoped #3308 to `blocked`. Arbitrated empirically on current `origin/main`: **the claim does not hold.**

### Root cause
The repro omitted **`io.__setExports(instance.exports)`** after `WebAssembly.instantiate`. Without it, `callbackState.getExports()` returns `undefined`, host dynamic-method dispatch mis-resolves, and `runtime.ts:10656` raises its `method is not a function` guard — producing the reported `"parse is not a function"` exactly. The committed corpus harness **does** call it (`acorn-corpus.mjs:183`, immediately before `wrapExports` at `:184`), so the repro did not run "exactly as the corpus harness does" as stated — that one line was missing.

### Controlled experiment — ONE compile, ONE instance, single variable
acorn **alone**, #3348's verbatim input `"const a=1; let b=2; function f(){}"` and options `{ecmaVersion:2025, sourceType:"script"}`:

| probe | WITHOUT `__setExports` (#3348's conditions) | WITH `__setExports` |
|---|---|---|
| `wrapExports(...).parse(SRC, OPTS)` | **THREW `"parse is not a function"`** — the reported error, verbatim | **OK** → `{type:"Program", bodyLen:3, kinds:[VariableDeclaration,VariableDeclaration,FunctionDeclaration]}` — exactly node-acorn |
| `probeBodyLen(src)` (in-Wasm) | **THREW `"parse is not a function"`** | **OK → 3** |

### The regression claim is refuted independently of my probe
`pnpm run dogfood:acorn-corpus` (the committed, authoritative `wrapExports` control) on current main:
```
inputs=23  equal±quirks=23  REAL=0  compiled-threw=0  oracle-error=0
```
**`compiled-threw=0`** — `parse` works for all 23 inputs today, which is *better* than the 2026-06-30 baseline's `compiled-threw=1`. Nothing regressed across the ~343 commits; the window **improved**. **#3348's own acceptance criterion ("`compiled-threw` back to its 2026-06-30 level (≤1)") was already met on main at filing time.**

### Third symptom, tied off
`"type incompatibility when transforming from/to JS"` reproduces only through `wrapExports` on the **combined** module (acorn + an appended export), even *with* `__setExports` — appending an export perturbs `exportSignatures`, so it's a marshalling artifact, not acorn's dispatch. The same module's in-Wasm `probeBodyLen` returns **3**. E0's probe sidesteps it (scalars only, never `wrapExports`).

## Changes
- **#3348 → `wont-fix`** with the full evidence + a self-contained repro.
- **#3308 un-blocked** — `depends_on: [3348]` cleared, BLOCKED banner replaced. (Main currently holds a contradiction: #3230's BLOCKED banner auto-merged alongside #3220's `status: done` with no conflict raised. This resolves it.)
- **`acorn-corpus.mjs`** — a comment at the copy site explaining *why* `__setExports` is load-bearing. This gotcha has now cost real hours twice (#1694 ~30 min; #3348's entire filing + a nearly-routed bisect); documenting it at the line people copy is the cheap fix.

**#3343 stands** — its "Not a parse bug" claim is confirmed. The real in-Wasm limit is a *recursive-read* runaway at scale (~60+ nodes), not parse.

Docs + one comment only — no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)