### PR TITLE
docs: schedule #3343 into current sprint + fork-push rule to kill duplicate PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,8 @@ GitHub branch protection is the hard block.
    - Planning artifact conflicts (`dashboard/`, `plan/`, `public/`) → `git checkout --theirs` + regen
    - Compiler source conflicts (`src/**/*.ts`) → create a priority `[CONFLICT]` TaskList item; assign to `senior-developer` (Opus); do NOT resolve inline
 2. **Dev runs scoped local checks** — issue-targeted compile/run checks for confidence
-3. **Dev pushes the branch to origin and opens a PR against `main`** — PRs MUST target the **upstream** repo (`loopdive/js2`), never the fork (`ttraenkler/js2`). **Always pass `-R loopdive/js2 --head ttraenkler:<branch>` to `gh pr create`** — the container's gh 2.23 ignores the pinned default (`remote.upstream.gh-resolved=base`) for `pr create` and silently opens the PR on the fork (verified 2026-06-11: fork PRs #6/#7 both had to be closed as misrouted). After creating, verify the PR URL starts with `github.com/loopdive/`. Note the pre-push integrity gate chokes on the fork/upstream divergence — `git push --no-verify` is sanctioned (CI runs the real gate).
+3. **Dev pushes the branch to the `fork` remote and opens a PR against `main`** — PRs MUST target the **upstream** repo (`loopdive/js2`), never the fork (`ttraenkler/js2`). **Push the branch with `git push fork <branch>` FIRST**, then **always pass `-R loopdive/js2 --head ttraenkler:<branch>` to `gh pr create`** — the container's gh 2.23 ignores the pinned default (`remote.upstream.gh-resolved=base`) for `pr create` and silently opens the PR on the fork (verified 2026-06-11: fork PRs #6/#7 both had to be closed as misrouted). After creating, verify the PR URL starts with `github.com/loopdive/`. Note the pre-push integrity gate chokes on the fork/upstream divergence — `git push --no-verify` is sanctioned (CI runs the real gate).
+   - **Push to `fork`, not `origin` — this is load-bearing, not cosmetic (#3343-era, 2026-07-17).** `origin` is **upstream** (`loopdive/js2wasm`) and `push.default=current`, so a plain `git push` puts the branch on **upstream**. `gh pr create --head ttraenkler:<branch>` then fails with "No commits between" (the branch isn't on the fork), and the tempting workaround — dropping the `ttraenkler:` prefix — opens an upstream-head PR. That is how a **duplicate PR** survives: **two lanes run concurrently** (this checkout + a fork-origin lane), and when the same branch NAME exists in two different head repos, GitHub **cannot** apply its normal same-head+base rejection. Both PRs coexist and the work is done twice. Pushing to `fork` restores that free rejection. Do NOT rely on `claim-issue.mjs` to prevent this — it returns **exit 0 to both lanes** (they share the `ttraenkler/senior-dev` slug); the lock is advisory. Before starting an issue, also run `git log origin/main --grep="#<id>"` to check it isn't already merged. A PR that goes **DIRTY on files it itself touched** is a duplicate-merge smell, not an ordinary conflict.
 4. **Dev blocks on CI** — polls `gh pr checks <N>` every 30s for ~2 min wall time, in-context (Sonnet idle is nearly free). Use `gh run watch <run-id>` or a `while ! done; do sleep 30; done` loop with a max timeout (~10 min before noting unusual wait, ~20 min before escalating).
 5. **On CI completion**:
    - **All required checks green** → run `/dev-self-merge`; if MERGE, mark the task completed and **stand down** (proceed to step 8). The dev does NOT enqueue — the server-side `auto-enqueue.yml` workflow enqueues on CI-completion (grace 0, #2786). NEVER enqueue or re-enqueue from a dev
@@ -408,7 +409,9 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
+
 **test262 conformance**: 32,138 / 43,106 (74.6 %)
+
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,9 +409,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-
 **test262 conformance**: 32,138 / 43,106 (74.6 %)
-
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/plan/issues/3343-inwasm-object-recursive-read-runaway-at-scale.md
+++ b/plan/issues/3343-inwasm-object-recursive-read-runaway-at-scale.md
@@ -2,6 +2,7 @@
 id: 3343
 title: "In-Wasm dynamic-$Object recursive read runs away at scale (spurious back-edge on ~60+-node ASTs)"
 status: ready
+sprint: current
 created: 2026-07-17
 priority: high
 horizon: m


### PR DESCRIPTION
Two small lead-hygiene fixes from today's duplicate-PR incident.

## 1. `#3343` → `sprint: current`

`#3343` (in-Wasm dynamic-`$Object` recursive read runs away at scale) landed on main via #3220 **with no `sprint:` field**, so the real bug was never in the sprint queue.

This matters more than a routine tag: #3348 claimed compiled-acorn `parse()` throws in-Wasm and called for bisecting ~343 commits. That was **arbitrated as a harness artifact** — its repro omitted `io.__setExports(instance.exports)`, and without that line host dispatch mis-resolves and raises runtime.ts's "method is not a function" guard. With it: `{type:"Program", bodyLen:3}`, matching node-acorn. Independently, the committed corpus harness reports `compiled-threw=0` — better than the 2026-06-30 baseline's 1, so nothing regressed in that window and #3348's own acceptance criterion was already met at filing time.

So #3343 — not #3348 — is the live gate for the #2928 bytecode emitter (E2). It belongs in the queue.

## 2. Merge protocol step 3: push to `fork`, not `origin`

`origin` is upstream (`loopdive/js2wasm`) and `push.default=current`, so a plain `git push` puts the branch on **upstream**. `gh pr create --head ttraenkler:<branch>` then fails with "No commits between", and the tempting workaround — dropping the `ttraenkler:` prefix — opens an upstream-head PR.

That is how duplicate PRs survive. **Two lanes run concurrently** (this checkout + a fork-origin lane). When the same branch NAME exists in two different head repos, GitHub **cannot** apply its normal same-head+base rejection, so both PRs coexist and the work gets done twice.

This is not hypothetical: **#3310, #3311, #3341 and #3308 were all independently re-implemented on 2026-07-17.** The duplicates were closed only after each author proved redundancy by running its own test suite unmodified against main's implementation.

`claim-issue.mjs` does not prevent this — it returned **exit 0 to both lanes** (they share the `ttraenkler/senior-dev` slug). The lock is advisory; it only binds agents that consult it. Pushing to `fork` restores GitHub's free duplicate rejection.

This PR follows the rule it documents: branch pushed via `git push fork`, PR opened with `--head ttraenkler:` — which is what makes this exact command work.

Docs + one frontmatter line only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)