### PR TITLE
fix(#3342): route any-receiver join to native externref join under standalone

### DIFF
--- a/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
+++ b/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
@@ -1,7 +1,9 @@
 ---
 id: 3342
 title: "standalone: Object.values(o).join / Object.getOwnPropertyNames(o).join misclassify receiver as Uint8ClampedArray → leak env::Uint8ClampedArray_join"
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/opus-e
 sprint: current
 created: 2026-07-17
 priority: medium
@@ -74,3 +76,29 @@ runtime shape.
    `tests/issue-3155.test.ts`).
 2. Add coverage to `tests/issue-3155.test.ts` (or a new `tests/issue-3342.test.ts`).
 3. No test262 regression; host-lane byte-identity.
+
+## Resolution (2026-07-17, opus-e)
+
+**Root cause (confirmed):** the `as any` cast on the receiver — not the choice
+of `Object.values`/`getOwnPropertyNames` vs `keys` — is the trigger. Without a
+cast, all three infer a concrete array type and dispatch through the
+array-methods native externref path (host-free since #3155). With `as any` the
+receiver is `any`-typed, so the call reaches the `any`-receiver fallback
+`tryExternClassMethodOnAny` (`src/codegen/expressions/calls-closures.ts`). That
+helper iterates `ctx.externClasses` in insertion order and first-matches any
+class declaring a `join` method with all-externref params. A TypedArray view
+(`Uint8ClampedArray`) is registered before `Array`, so the call bound
+`env::Uint8ClampedArray_join` — an unsatisfiable host import under standalone.
+(All three of keys/values/getOwnPropertyNames leaked identically once cast.)
+
+**Fix:** added a `noJsHost`-gated guard in `tryExternClassMethodOnAny` that
+routes a `join` on an `any`-typed receiver to the native externref `join`
+(`compileArrayJoinExtern`, host-free under `noJsHost` since #3155) *before* the
+first-match loop can bind the TypedArray host import. The JS-host lane is
+untouched (byte-identical). `compileArrayJoinExtern` was exported from
+`array-methods.ts` for reuse.
+
+**Files:** `src/codegen/expressions/calls-closures.ts`,
+`src/codegen/array-methods.ts` (export), `tests/issue-3342.test.ts` (new, 7
+cases: values/getOwnPropertyNames/keys as-any, multi-char + default separator,
+empty object, plain-array-as-any regression guard).

--- a/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
+++ b/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
@@ -16,6 +16,8 @@ language_feature: standalone-completeness, array-join, type-inference
 goal: standalone-parity
 related: [3155, 3170]
 origin: "carved out of #3155 (fix-standalone-object-keys-join, opus-c 2026-07-17) — Object.keys().join was fixed via the native externref-join path, but Object.values()/getOwnPropertyNames() take a DIFFERENT, distinct-root-cause path."
+loc-budget-allow:
+  - src/codegen/expressions/calls-closures.ts
 ---
 
 # #3342 — standalone `Object.values(o).join` / `Object.getOwnPropertyNames(o).join` leak `env::Uint8ClampedArray_join`

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3888,7 +3888,7 @@ function compileArrayJoinExternNative(
   return { kind: "externref" };
 }
 
-function compileArrayJoinExtern(
+export function compileArrayJoinExtern(
   ctx: CodegenContext,
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -1506,16 +1506,11 @@ export function tryExternClassMethodOnAny(
     if (dsAny !== undefined) return dsAny;
   }
 
-  // (#3342) `join` on an `any`-typed receiver is ambiguous across `Array` and
-  // every `TypedArray` view — all declare a `join` extern with all-externref
-  // params. The first-match loop below binds whichever registered first, which
-  // is a TypedArray (`env::Uint8ClampedArray_join`). That host import is
-  // unsatisfiable under standalone/wasi, so the module fails to instantiate —
-  // e.g. `(Object.values(o) as any).join(",")` /
-  // `(Object.getOwnPropertyNames(o) as any).join(",")`, whose results are boxed
-  // externref arrays. Route to the native externref `join`
-  // (`compileArrayJoinExtern`, host-free under noJsHost since #3155) instead;
-  // the JS-host lane keeps the existing import binding (byte-identical).
+  // (#3342) `join` on an `any` receiver: the first-match loop below binds the
+  // first extern class declaring it — a TypedArray (`env::Uint8ClampedArray_join`),
+  // unsatisfiable standalone (e.g. `(Object.values(o) as any).join(",")`). Route
+  // to the native externref `join` (host-free under noJsHost since #3155); host
+  // lane keeps the existing binding (byte-identical).
   if (noJsHost(ctx) && methodName === "join") {
     const nativeJoin = compileArrayJoinExtern(ctx, fctx, propAccess, expr);
     if (nativeJoin !== null) return nativeJoin;

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -11,7 +11,9 @@ import { ts } from "../../ts-api.js";
 import { isVoidType, isPromiseType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { getFuncRefWrapperRootTypeIdx, getOrCreateFuncRefWrapperTypes } from "../closures.js";
+import { compileArrayJoinExtern } from "../array-methods.js";
 import { tryCompileNativeDisposableStackAnyMethodCall } from "../disposable-runtime.js";
+import { noJsHost } from "../js-errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
 import { addFuncType, addImport, localGlobalIdx, resolveWasmType } from "../index.js";
@@ -1502,6 +1504,21 @@ export function tryExternClassMethodOnAny(
   if (ctx.nativeStrings && ctx.externClasses.get("DisposableStack")?.methods.has(methodName)) {
     const dsAny = tryCompileNativeDisposableStackAnyMethodCall(ctx, fctx, propAccess, expr, methodName);
     if (dsAny !== undefined) return dsAny;
+  }
+
+  // (#3342) `join` on an `any`-typed receiver is ambiguous across `Array` and
+  // every `TypedArray` view — all declare a `join` extern with all-externref
+  // params. The first-match loop below binds whichever registered first, which
+  // is a TypedArray (`env::Uint8ClampedArray_join`). That host import is
+  // unsatisfiable under standalone/wasi, so the module fails to instantiate —
+  // e.g. `(Object.values(o) as any).join(",")` /
+  // `(Object.getOwnPropertyNames(o) as any).join(",")`, whose results are boxed
+  // externref arrays. Route to the native externref `join`
+  // (`compileArrayJoinExtern`, host-free under noJsHost since #3155) instead;
+  // the JS-host lane keeps the existing import binding (byte-identical).
+  if (noJsHost(ctx) && methodName === "join") {
+    const nativeJoin = compileArrayJoinExtern(ctx, fctx, propAccess, expr);
+    if (nativeJoin !== null) return nativeJoin;
   }
 
   for (const [key, info] of ctx.externClasses) {

--- a/tests/issue-3342.test.ts
+++ b/tests/issue-3342.test.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3342 — standalone `(Object.values(o) as any).join(sep)` /
+// `(Object.getOwnPropertyNames(o) as any).join(sep)` must not leak a
+// `env::Uint8ClampedArray_join` host import.
+//
+// Carved out of #3155 (which made `Object.keys(o).join(...)` host-free via the
+// native externref-`join` path). This case has a DISTINCT root cause: the
+// `as any` cast makes the receiver `any`-typed, so the call reaches the
+// `any`-receiver fallback `tryExternClassMethodOnAny` (calls-closures.ts). That
+// helper first-matches whichever extern class registered a `join` method with
+// all-externref params — a TypedArray view (`Uint8ClampedArray`) is registered
+// first, so the call bound `env::Uint8ClampedArray_join`. Under `--target
+// standalone` there is no JS host to satisfy that import, so the module fails to
+// instantiate against an empty `{}` import object (real test262 symptom: the
+// join never runs).
+//
+// The fix routes a `join` on an `any`-typed receiver to the native externref
+// `join` (`compileArrayJoinExtern`, host-free under `noJsHost` since #3155)
+// before the first-match loop can bind the TypedArray host import. The JS-host
+// lane is untouched (the guard is gated on `noJsHost`), so host-lane codegen is
+// byte-identical.
+//
+// Note the `as any` on the receiver is the actual trigger — `Object.keys()`,
+// `Object.values()` and `Object.getOwnPropertyNames()` are ALL host-free without
+// the cast (they infer a concrete array type and dispatch through the array-
+// methods native path). With the cast, all three previously leaked the same
+// `Uint8ClampedArray_join` import; this guard fixes the whole `any`-join class.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Probe {
+  envImports: string[];
+  result: unknown;
+}
+
+async function standaloneProbe(src: string): Promise<Probe> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone module failed WebAssembly.validate").toBe(true);
+  const mod = new WebAssembly.Module(r.binary);
+  const envImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  // Instantiate against an EMPTY import object — a leaked env import throws here.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const result = (instance.exports as { test: () => unknown }).test();
+  return { envImports, result };
+}
+
+describe("#3342 — standalone (Object.values/getOwnPropertyNames as any).join is host-free", () => {
+  it("Object.values(o) as any: no Uint8ClampedArray_join leak and correct join", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.values(o) as any).join(",") === "1,2";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(envImports).toEqual([]);
+    expect(result).toBe(1);
+  });
+
+  it("Object.getOwnPropertyNames(o) as any: no leak and correct join", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.getOwnPropertyNames(o) as any).join(",") === "a,b";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(envImports).toEqual([]);
+    expect(result).toBe(1);
+  });
+
+  it("Object.keys(o) as any: the cast path is host-free too", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.keys(o) as any).join(",") === "a,b";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("multi-char separator is respected", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2, c: 3 };
+         return (Object.values(o) as any).join(" - ") === "1 - 2 - 3";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("default separator (no arg) folds with comma", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.values(o) as any).join() === "1,2";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("empty object joins to the empty string", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = {};
+         return (Object.values(o) as any).join(",") === "";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("plain array typed as any still joins host-free", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const a: any = [1, 2, 3];
+         return (a).join(",") === "1,2,3";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem (#3342)

`(Object.values(o) as any).join(",")` and `(Object.getOwnPropertyNames(o) as any).join(",")` compiled with `target: standalone` to a module importing `env::Uint8ClampedArray_join` — an unsatisfiable host import, so the module failed to instantiate against `{}`.

## Root cause (confirmed)

The `as any` cast on the receiver — not the choice of `Object.values`/`getOwnPropertyNames` vs `keys` — is the trigger. Without a cast, all three infer a concrete array type and dispatch through the array-methods native externref path (host-free since #3155). With `as any` the receiver is `any`-typed, so the call reaches the `any`-receiver fallback `tryExternClassMethodOnAny` (`src/codegen/expressions/calls-closures.ts`), which iterates `ctx.externClasses` in insertion order and first-matches any class declaring a `join` with all-externref params. A TypedArray view (`Uint8ClampedArray`) registers before `Array`, so the call bound the TypedArray host import. All three (keys/values/getOwnPropertyNames) leaked identically once cast.

## Fix

Added a `noJsHost`-gated guard in `tryExternClassMethodOnAny` that routes a `join` on an `any`-typed receiver to the native externref `join` (`compileArrayJoinExtern`, host-free under `noJsHost` since #3155) **before** the first-match loop can bind the TypedArray host import. The JS-host lane is untouched (guard gated on `noJsHost`) → host-lane codegen byte-identical. Exported `compileArrayJoinExtern` from `array-methods.ts`.

## Tests

New `tests/issue-3342.test.ts` — 7 cases (values/getOwnPropertyNames/keys as-any, multi-char + default separator, empty object, plain-array-as-any regression guard). All pass; #3155 still green.

Acceptance: standalone module has no `env::*` import and produces the correct joined string (verified in-wasm). No host import binding change on the JS-host lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)