### PR TITLE
chore(harvest): file #3360 async-gen yield* abrupt-completion (oracle-7 harvest)

### DIFF
--- a/plan/issues/3360-async-gen-yield-star-abrupt-completion-protocol.md
+++ b/plan/issues/3360-async-gen-yield-star-abrupt-completion-protocol.md
@@ -1,0 +1,119 @@
+---
+id: 3360
+title: "default lane: async-generator `yield*` delegation drops iterator-protocol abrupt completions (690 honest fails, oracle-7 #3227 S5)"
+status: ready
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: es2018
+language_feature: async-generators, yield-star, iterator-protocol
+depends_on: [3227]
+related: [3227, 1259, 1346]
+created: 2026-07-17
+updated: 2026-07-17
+origin: "2026-07-17 /harvest-errors against the FRESH oracle-7 baseline (loopdive/js2wasm-baselines run 20260717-111717, host 32,138/43,106). Default (JS-host) lane. This is the concrete feature-fix that #3227's slice plan names as its 'S5+ feature-fix clusters' — the abrupt-completion delegation bugs that #3227 S4's honest CI scoring newly exposes."
+---
+
+# #3360 — async-generator `yield*` delegation drops iterator-protocol abrupt completions
+
+## Summary
+
+Under the fresh **oracle-7** baseline, **690 `yield-star-*` test262 files fail
+honestly** in the default (JS-host) lane (0 vacuous — every one is a real
+assertion failure, not a harness-callback artifact). They are the largest
+coherent honest-fail family the oracle-7 async re-scoring (#3227 S1/S4) exposed:
+these tests previously "passed" only because a premature synchronous verdict
+was read before the delegated async iteration ran. Now that the verdict is read
+post-drain, the underlying delegation bug is visible.
+
+The bug is in **`yield* <delegate>` inside an `async function*`**: our
+delegation path does not correctly **validate the delegate's iterator protocol
+and propagate abrupt completions** out of the `yield*`. #3227 S3 already fixed
+the *happy-path* "inner async-generator drained zero values" case
+(`__gen_yield_star` draining an inner that carries only `Symbol.asyncIterator`);
+what remains — and what this issue tracks — is the **abrupt / malformed-protocol
+half** of §27.6.3.8 (AsyncGeneratorYield / yield* runtime semantics).
+
+This is the S5 feature-fix follow-on to **#3227** (whose S1–S4 are the
+runner/oracle *infrastructure* that made these honest; the fix here is the
+compiler/runtime *feature* work). It `depends_on: [3227]` only so the honest CI
+scoring is in place to measure the delta.
+
+## Distribution (690 total, default lane, all `status: fail`, all honest)
+
+| Count | Sub-family (filename token)     | Mechanism                                                                                       | Sample file                                                                                     |
+| ----- | ------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 182   | `yield-star-getiter-async-*`    | GetIterator(async): delegate `[Symbol.asyncIterator]()` returns non-object / throws → must TypeError | `expressions/class/elements/async-gen-private-method/yield-star-getiter-async-returns-boolean-throw.js` |
+| 144   | `yield-star-getiter-sync-*`     | GetIterator(sync-fallback): delegate `[Symbol.iterator]()` returns non-object → must TypeError   | `expressions/async-generator/yield-star-getiter-sync-returns-number-throw.js`                    |
+| 108   | `yield-star-next-then-*`        | `iterResult = await iter.next(...)`; the result's `.then` is non-callable / non-object handling  | `expressions/class/async-gen-method-static/yield-star-next-then-non-callable-string-fulfillpromise.js` |
+| 84    | `yield-star-next-not-*`         | delegate `.next` is not callable → must TypeError, closes iter                                   | `expressions/async-generator/yield-star-next-not-callable-undefined-throw.js`                    |
+| 36    | `yield-star-next-call-*`        | `iter.next()` itself returns an abrupt completion → propagate                                    | `expressions/async-generator/yield-star-next-call-returns-abrupt.js`                             |
+| ~90   | `sync-throw` / `sync-return` / `async-throw` / `async-return` / `next-get` / `next-non` / `sync-iterator` / `async-iterator` (12 each) | throw()/return() delegation + IteratorResult `done`/`value` reads on the settled result | `statements/async-generator/yield-star-next-non-object-ignores-then.js`                          |
+| ~46   | remainder (`expr-abrupt`, `normal-notdone`, `before-newline`)                                    | | `expressions/async-generator/yield-star-expr-abrupt.js`                                          |
+
+Dominant honest-fail assertion shapes (from `error_signature`):
+
+- `throw new Test262Error('abrupt completion closes iter')` — 208
+- `assert.sameValue(done, true, 'the iterator is completed')` — 78
+- `throw new Test262Error('completion closes iter')` — 56
+- `assert.sameValue(v.constructor, TypeError, "TypeError")` — 36 (getiter returns-null-throw shape)
+
+## Root-cause pointer
+
+- `__gen_yield_star` in **`src/runtime.ts`** (around L12510 — the `name ===
+  "__gen_yield_star"` arm) is the delegation helper. #3227 S3 changed it to
+  drain an eagerly-buffered inner async-generator's remaining buffer and rethrow
+  a `pendingThrow`. That covered the *values-present, normal-completion* path.
+  It does **not** cover: (a) a delegate whose iterator-method *return value* is
+  not an Object (must `TypeError`), (b) a `.next` that is not callable / returns
+  abrupt, (c) a delegate `throw`/`return` protocol step, (d) reading `done`/
+  `value` off a malformed IteratorResult.
+- The async `yield*` lowering lives in **`src/codegen/async-cps.ts`**; confirm
+  whether GetIterator-validation should happen there (at lowering) or in the
+  runtime helper.
+
+## Slice plan (dispatchable; both touch `__gen_yield_star` — do sequentially, one owner)
+
+- **S-a — GetIterator return-value validation (326: getiter-sync 144 +
+  getiter-async 182).** When the delegate's `[Symbol.asyncIterator]()` (or the
+  sync `[Symbol.iterator]()` fallback via CreateAsyncFromSyncIterator) returns a
+  non-Object, throw a `TypeError` and let it propagate out of the `yield*`
+  (§7.4.1 GetIterator step 5). Repro from
+  `yield-star-getiter-sync-returns-number-throw.js` /
+  `yield-star-getiter-async-returns-boolean-throw.js`.
+- **S-b — IteratorNext / step protocol abrupt completions (~360: next-then 108,
+  next-not 84, next-call 36, next-get/non 24, sync/async throw/return/next
+  ~100).** `.next` not callable → TypeError; `iter.next()` returning an abrupt
+  completion → propagate; malformed IteratorResult (`.then`/`done`/`value`) →
+  the §27.6.3.8 handling. Repros: `yield-star-next-not-callable-undefined-throw.js`,
+  `yield-star-next-call-returns-abrupt.js`, `yield-star-next-then-non-callable-string-fulfillpromise.js`.
+
+## Acceptance criteria
+
+- `.tmp/` repros for one file from each of S-a and S-b confirm the abrupt
+  completion is now thrown/propagated with the correct error type (TypeError for
+  the non-callable / non-object cases).
+- The `yield-star-*` default-lane failing count drops materially from 690 — target
+  **≥ 400 of the 690 flip to pass** (S-a ~300 + a first tranche of S-b), measured
+  against the oracle-7 baseline once #3227 S4 has landed.
+- No regression to the #3227 S3 happy-path async-gen delegation
+  (`tests/issue-3227-s3.test.ts`) or to sync-generator `yield*` (#1259).
+- No new standalone-lane regression in the `yield*` cluster (the standalone lane
+  refuses async generators earlier; verify no crash-shape change).
+
+## Notes
+
+- **Relationship to #3227**: #3227 (in-progress, assignee fable-s4) owns the
+  *oracle/runner* honesty infra (S1 post-drain re-read, S4 CI-lane parity) plus
+  the S2/S3 compiler fixes. #3227's own slice notes name these abrupt-completion
+  `yield*` clusters as "the S5+ feature-fix clusters" but leave them un-carved.
+  This issue is that carve-out so the family is independently claimable and
+  trackable. Coordinate with the #3227 owner before starting — the fix lands in
+  the same `__gen_yield_star` helper S3 last touched.
+- Spec: §27.6.3.8 (AsyncGenerator yield* / AsyncGeneratorYield), §7.4 iterator
+  abstract operations, §7.4.1 GetIterator.
+</content>

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -576,3 +576,30 @@ Object.defineProperty) under existing goals — no new crash cluster. Actions:
   descriptor shapes still refused; incomplete-fix flag, follow-up optional.
 - **negative_test_fail** (55/lane, 40 = "early SyntaxError not detected"):
   covered by existing spec-gap early-error issues (#1315/#1435); no new issue.
+
+## 2026-07-17 /harvest-errors run (oracle-7 fresh baseline, both lanes)
+
+Baselines run `20260717-111717` (host 32,138 / standalone 24,711 of 43,106),
+oracle_version 7 — the honest async-scoring drop. Cross-referenced both lanes;
+**nearly every >50 cluster maps to an existing tracked issue**. The single
+genuinely-new, >50, untracked, high-value pattern:
+
+- [#3360](../3360-async-gen-yield-star-abrupt-completion-protocol.md) — **NEW.**
+  Async-generator `yield*` delegation drops iterator-protocol **abrupt
+  completions** — **690 honest `yield-star-*` fails** in the default lane (0
+  vacuous), the largest coherent honest-fail family oracle-7's #3227 S1/S4
+  re-scoring exposed. Sub-families: getiter-async (182) + getiter-sync (144) =
+  GetIterator-return-validation; next-then (108) + next-not (84) + next-call
+  (36) + … = IteratorNext/step-protocol. Root: `__gen_yield_star`
+  (`src/runtime.ts` ~L12510) — #3227 S3 fixed only the happy path. This is the
+  S5 feature-fix carve-out of #3227 (`depends_on: [3227]`). `horizon: l`.
+
+Verified-tracked (no new issue; safe-refill pointers for the lead):
+Set-like method residuals → #2761 (ready) / #1674 (blocked); resizable
+ArrayBuffer + `.transfer` → #1645 (ready) / #1595 (blocked); Reflect receiver
+→ #2046 (in-progress); standalone host-import leaks (iterator_protocol 4,021 /
+generic 1,720) → #2961 (in-progress) umbrella; new-Function/indirect-eval →
+#2928 (backlog); with-statement PutValue-through-object-env residual
+(30, `compound-assignment/S11.13.2_A5.*`) → #1387 (done) niche; import-attributes
+early-SyntaxError (35, sub-50) → #1805 (done) residual. Temporal / ShadowRealm /
+import.defer|source / Atomics.waitAsync = non-official proposals, excluded.


### PR DESCRIPTION
## Summary

`/harvest-errors` run against the FRESH **oracle-7** baseline
(loopdive/js2wasm-baselines run `20260717-111717`: host **32,138** / standalone
**24,711** of 43,106). Both lanes analyzed separately (never summed). Embedded
`#NNNN` citations extracted first, `other`/uncategorized sub-bucketed, Temporal /
ShadowRealm / import.defer|source / Atomics.waitAsync proposals excluded.

**Finding:** the corpus is mature — nearly every >50 cluster maps to an existing
tracked issue. This PR files the **single genuinely-new, >50, untracked,
high-value pattern** (plan/ only, no code):

- **#3360** — async-generator `yield*` delegation drops iterator-protocol
  **abrupt completions**: **690 honest `yield-star-*` fails** in the default
  lane (0 vacuous), the largest coherent honest-fail family oracle-7's #3227
  S1/S4 re-scoring exposed. Sub-families: getiter-async (182) + getiter-sync
  (144) = GetIterator-return-validation; next-then (108) + next-not (84) +
  next-call (36) + … = IteratorNext/step-protocol. Root: `__gen_yield_star`
  (`src/runtime.ts` ~L12510) — #3227 S3 fixed only the happy path. This is the
  S5 feature-fix carve-out of #3227 (`depends_on: [3227]`). `horizon: l`,
  `feasibility: hard`.

## Two-lane summary

**Default (JS-host) lane** — top embedded-citation counts (all tracked except #3360):

| Cited | Records | Status | Feature |
|---|---|---|---|
| #2940 | 491 | done | vacuous-pass detector (harness callback never ran) |
| #3227 | 36 | in-progress | default-lane async harness vacuous (S1–S4) |
| #1387 | 67 | done | with-statement |
| #1472 | 67 | done | standalone host object/property ops |
| **#3360** | **690** | **NEW ready** | **async-gen yield\* abrupt-completion** |

**Standalone lane** — top embedded-citation counts (all tracked):

| Cited | Records | Status | Feature |
|---|---|---|---|
| #2961 | 6,197 | in-progress | strictNoHostImports leak guarantee (umbrella) |
| #2928 | 545 | backlog | bytecode interp / new Function / indirect eval |
| #1472 | 382 | done | Proxy / host object ops (standalone) |
| #2940 | 108 | done | make-callback harness vacuous |
| #1906/#1907/#1888 | 73/64/64 | done | Object.defineProperties / static reads / open-any dispatch |

Backlog updated with the run summary + safe-refill pointers to existing
`ready`/`in-progress` issues (#2761, #1645, #2046, #2961, #2928).

🤖 Generated with [Claude Code](https://claude.com/claude-code)