### PR TITLE
fix(#3342): standalone .join on any-typed externref array is host-free

### DIFF
--- a/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
+++ b/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
@@ -1,7 +1,9 @@
 ---
 id: 3342
 title: "standalone: Object.values(o).join / Object.getOwnPropertyNames(o).join misclassify receiver as Uint8ClampedArray → leak env::Uint8ClampedArray_join"
-status: ready
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/dev-1044
 sprint: current
 created: 2026-07-17
 priority: medium
@@ -13,6 +15,9 @@ area: codegen
 language_feature: standalone-completeness, array-join, type-inference
 goal: standalone-parity
 related: [3155, 3170]
+loc-budget-allow:
+  - src/codegen/array-methods.ts
+  - src/codegen/expressions/calls-closures.ts
 origin: "carved out of #3155 (fix-standalone-object-keys-join, opus-c 2026-07-17) — Object.keys().join was fixed via the native externref-join path, but Object.values()/getOwnPropertyNames() take a DIFFERENT, distinct-root-cause path."
 ---
 
@@ -68,9 +73,41 @@ runtime shape.
 
 ## Acceptance
 
-1. `Object.values(o).join(sep)` and `Object.getOwnPropertyNames(o).join(sep)`
+1. [x] `Object.values(o).join(sep)` and `Object.getOwnPropertyNames(o).join(sep)`
    compile with `target: "standalone"` to a module with **no** `env::*` import
    and produce the correct joined string (verified in-wasm, mirroring
    `tests/issue-3155.test.ts`).
-2. Add coverage to `tests/issue-3155.test.ts` (or a new `tests/issue-3342.test.ts`).
-3. No test262 regression; host-lane byte-identity.
+2. [x] Add coverage — new `tests/issue-3342.test.ts` (8 cases).
+3. [x] No test262 regression; host-lane byte-identity.
+
+## Resolution (2026-07-17, dev-1044)
+
+**Root cause was NOT return-type inference** — it was the `as any` cast (and
+any `any`-typed array receiver). With the receiver statically `string[]`
+(no cast), `.join` rides the native array-`join` dispatch (`receiverIsExternref`
+arm, #3155) and is already host-free. With the receiver statically `any`, the
+call reaches `tryExternClassMethodOnAny` (`calls-closures.ts`), whose
+first-match loop bound `.join` to the FIRST registered extern class declaring a
+`join` method — a TypedArray, `Uint8ClampedArray` — emitting the unsatisfiable
+`env::Uint8ClampedArray_join`.
+
+**Fix**: in `tryExternClassMethodOnAny`, under `ctx.standalone || ctx.wasi`,
+route `methodName === "join"` to the #3155 native externref-array walk via the
+new `compileArrayJoinExternForAny` (`array-methods.ts`, gated on `noJsHost`,
+returns null before emitting when unavailable). This mirrors the existing
+`get`/`set`/`has`/… standalone refusal block above it. A genuine TypedArray
+receiver typed `any` rides the same native walk correctly, so it is a general
+externref-array-`join` fix, not an Object.values special-case.
+
+**Host lane**: the guard is skipped when neither `standalone` nor `wasi`, so
+JS-host still binds `Uint8ClampedArray_join` (satisfiable there) — byte-identical.
+
+**Note on wasi**: `Object.values`/`Object.keys` themselves currently return an
+empty result under `--target wasi` (a pre-existing object-model limitation that
+also affects the #3155 non-cast path — orthogonal to this issue). The fix
+converts the cast-path wasi *crash* (unsatisfiable import) into that same
+contained empty-result behaviour; standalone is fully correct.
+
+Files: `src/codegen/array-methods.ts` (new `compileArrayJoinExternForAny`),
+`src/codegen/expressions/calls-closures.ts` (dispatch + import),
+`tests/issue-3342.test.ts`.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3888,6 +3888,35 @@ function compileArrayJoinExternNative(
   return { kind: "externref" };
 }
 
+/**
+ * (#3342) Standalone/WASI entry point for `.join(sep?)` on an `any`-typed
+ * receiver that reaches the extern-class-method-on-`any` dispatcher
+ * ({@link tryExternClassMethodOnAny}). Without this, the first-match loop there
+ * binds `.join` to the first registered extern class declaring a `join` method
+ * — a TypedArray (`Uint8ClampedArray_join`) — whose `env::*` host import is
+ * unsatisfiable in standalone mode, so the module fails to instantiate. The
+ * concrete leak: `(Object.values(o) as any).join(",")` /
+ * `(Object.getOwnPropertyNames(o) as any).join(",")`, whose receiver is a boxed
+ * externref host array.
+ *
+ * This walks the externref array host-free via the #3155 native path
+ * (`__extern_length` / `__extern_get_idx` / `__extern_toString`), identical to
+ * the receiver's own host-free `.length` read. Returns `null` (⇒ caller keeps
+ * its existing behaviour) only OUTSIDE `noJsHost` or when the native string
+ * helpers are unavailable — and it returns null BEFORE emitting any
+ * instructions, so a null result never leaves a partially-compiled receiver on
+ * the stack.
+ */
+export function compileArrayJoinExternForAny(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): ValType | null {
+  if (!noJsHost(ctx)) return null;
+  return compileArrayJoinExternNative(ctx, fctx, propAccess, callExpr);
+}
+
 function compileArrayJoinExtern(
   ctx: CodegenContext,
   fctx: FunctionContext,

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -11,6 +11,7 @@ import { ts } from "../../ts-api.js";
 import { isVoidType, isPromiseType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { getFuncRefWrapperRootTypeIdx, getOrCreateFuncRefWrapperTypes } from "../closures.js";
+import { compileArrayJoinExternForAny } from "../array-methods.js";
 import { tryCompileNativeDisposableStackAnyMethodCall } from "../disposable-runtime.js";
 import { allocLocal } from "../context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
@@ -1454,6 +1455,22 @@ export function tryExternClassMethodOnAny(
       methodName === "clear")
   ) {
     return null;
+  }
+
+  // (#3342) `.join(sep?)` on an `any`-typed receiver in standalone/WASI. The
+  // first-match loop below would bind it to the first registered extern class
+  // declaring a `join` method — a TypedArray, `Uint8ClampedArray_join` — whose
+  // `env::*` host import is unsatisfiable standalone, so the module fails to
+  // instantiate. The concrete leak: `(Object.values(o) as any).join(",")` /
+  // `(Object.getOwnPropertyNames(o) as any).join(",")`, whose receiver is a
+  // boxed externref host array. Route to the #3155 native externref-array join
+  // (host-free, via `__extern_length`/`__extern_get_idx`/`__extern_toString`),
+  // matching the receiver's own host-free `.length`. Returns null (fall through
+  // unchanged) outside `noJsHost` or when the native helpers are unavailable —
+  // and never after emitting, so no partial receiver is stranded on the stack.
+  if ((ctx.standalone || ctx.wasi) && methodName === "join") {
+    const native = compileArrayJoinExternForAny(ctx, fctx, propAccess, expr);
+    if (native !== null) return native;
   }
 
   // (#3033) If the program's OWN code defines a function-valued member of this

--- a/tests/issue-3155.test.ts
+++ b/tests/issue-3155.test.ts
@@ -25,9 +25,12 @@
 // as a boolean; the no-`env::*`-leak property is verified by instantiating
 // against an empty `{}` import object (a leaked import would throw a LinkError).
 //
-// Carve-out: `Object.values(o).join(...)` currently routes through a distinct
-// TypedArray-join misclassification (leaks `env::Uint8ClampedArray_join`) that
-// is unrelated to this externref-join fix — tracked separately, out of scope.
+// Carve-out (RESOLVED by #3342): the `as any`-cast form
+// `(Object.values(o) as any).join(...)` routed through a distinct
+// TypedArray-join misclassification in `tryExternClassMethodOnAny` (leaked
+// `env::Uint8ClampedArray_join`). Fixed in #3342 by routing `.join` on an
+// `any` receiver to this same native externref walk under standalone/WASI —
+// see `tests/issue-3342.test.ts`.
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 

--- a/tests/issue-3342.test.ts
+++ b/tests/issue-3342.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3342 — standalone `.join(sep?)` on an `any`-typed externref array
+// (`(Object.values(o) as any).join(",")` /
+// `(Object.getOwnPropertyNames(o) as any).join(",")`) must not leak
+// `env::Uint8ClampedArray_join`.
+//
+// #3155 fixed `Object.keys(o).join(...)` where the receiver is statically
+// `string[]` (the native array-`join` dispatch's `receiverIsExternref` arm).
+// But when the receiver is statically `any` — the `as any` cast, or any
+// `any`-typed array variable — the call reaches the extern-class-method-on-
+// `any` dispatcher (`tryExternClassMethodOnAny`, calls-closures.ts). Its
+// first-match loop bound `.join` to the first registered extern class that
+// declares a `join` method — a TypedArray, `Uint8ClampedArray` — emitting an
+// `env::Uint8ClampedArray_join` host import. That import is satisfiable JS-host
+// (byte-identical there) but UNSATISFIABLE under `--target standalone`: the
+// module fails to instantiate against an empty import object.
+//
+// The fix routes `.join` on an `any` receiver, under standalone/WASI, to the
+// same #3155 native externref-array walk (`compileArrayJoinExternForAny` →
+// `compileArrayJoinExternNative`): length via `__extern_length`, each element
+// via `__extern_get_idx` then §7.1.17 ToString via `__extern_toString`, folded
+// with the shared native-string join. All three helpers already have native
+// standalone arms (the receiver's own host-free `.length` proves it). The
+// JS-host lane is untouched (the guard is gated on `ctx.standalone ||
+// ctx.wasi`), so it still binds `Uint8ClampedArray_join` — byte-identical.
+//
+// A genuine TypedArray receiver typed `any` (`(new Uint8Array([...]) as any)
+// .join`) rides the SAME native walk correctly, so this is a general
+// externref-array-join fix, not just an Object.values special-case.
+//
+// The join *result* is an opaque `ref $AnyString` from JS, so it is verified
+// in-wasm via `===` and returned as a boolean; the no-`env::*`-leak property is
+// verified by instantiating against an empty `{}` import object (a leaked
+// import would throw a LinkError).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Probe {
+  envImports: string[];
+  result: unknown;
+}
+
+async function standaloneProbe(src: string): Promise<Probe> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone module failed WebAssembly.validate").toBe(true);
+  const mod = new WebAssembly.Module(r.binary);
+  const envImports = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  // Instantiate against an EMPTY import object — a leaked env import throws here.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const result = (instance.exports as { test: () => unknown }).test();
+  return { envImports, result };
+}
+
+describe("#3342 — standalone .join on an any-typed externref array is host-free", () => {
+  it("(Object.values(o) as any).join(',') has no Uint8ClampedArray_join leak and is correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.values(o) as any).join(",") === "1,2";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("(Object.getOwnPropertyNames(o) as any).join(',') has no leak and is correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.getOwnPropertyNames(o) as any).join(",") === "a,b";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("(Object.keys(o) as any).join('|') — the any-cast keys form — is host-free and correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2, c: 3 };
+         return (Object.keys(o) as any).join("|") === "a|b|c";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("default separator: (Object.values(o) as any).join() folds with ','", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 10, b: 20, c: 30 };
+         return (Object.values(o) as any).join() === "10,20,30";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("multi-char separator on an any-typed values array is correct", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { x: 1, y: 2 };
+         return (Object.values(o) as any).join(" - ") === "1 - 2";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("empty object → empty-string join (not 'null'), still host-free", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = {};
+         return (Object.values(o) as any).join(",") === "";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("a genuine TypedArray typed `any` rides the same native join host-free", async () => {
+    const { envImports, result } = await standaloneProbe(
+      `export function test(): boolean {
+         const t: any = new Uint8Array([5, 9]);
+         return t.join(",") === "5,9";
+       }`,
+    );
+    expect(envImports).not.toContain("Uint8ClampedArray_join");
+    expect(result).toBe(1);
+  });
+
+  it("the standalone module has zero env imports for the any-values-join program", async () => {
+    const { envImports } = await standaloneProbe(
+      `export function test(): boolean {
+         const o: any = { a: 1, b: 2 };
+         return (Object.values(o) as any).join(",") === "1,2";
+       }`,
+    );
+    expect(envImports, `standalone module must have no env imports, got: ${envImports.join(", ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`(Object.values(o) as any).join(",")` / `(Object.getOwnPropertyNames(o) as any).join(",")` compiled with `--target standalone` leaked an unsatisfiable `env::Uint8ClampedArray_join` host import — the module failed to instantiate against `{}`.

## Root cause

With the receiver statically `any` (the `as any` cast, or any `any`-typed array), `.join` reaches `tryExternClassMethodOnAny` (`calls-closures.ts`). Its first-match loop bound `.join` to the **first** registered extern class declaring a `join` method — a TypedArray, `Uint8ClampedArray`. #3155 only fixed the non-cast (`string[]`) form, which rides the native array-join dispatch.

## Fix

In `tryExternClassMethodOnAny`, under `standalone || wasi`, route `methodName === "join"` to the #3155 native externref-array walk via new `compileArrayJoinExternForAny` (`array-methods.ts`, gated on `noJsHost`, returns null **before** emitting when unavailable). Mirrors the existing `get`/`set`/`has`/… standalone refusal block. A genuine TypedArray typed `any` rides the same native walk correctly, so this is a general externref-array-`join` fix, not an Object.values special-case.

**Host lane**: guard skipped when neither standalone nor wasi → still binds `Uint8ClampedArray_join` (satisfiable JS-host) → byte-identical.

## Tests

- New `tests/issue-3342.test.ts` (8 cases): values/getOwnPropertyNames/keys as-any, default/multi-char separators, empty object, genuine TypedArray-as-any, and a zero-env-imports assertion.
- Updated the now-resolved carve-out note in `tests/issue-3155.test.ts`.
- `tsc` clean; loc-budget / coercion-sites / pushraw / any-box-sites / dead-exports gates pass; 68 adjacent extern-class/join/object regression tests green.

Closes #3342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)