### PR TITLE
docs(#1645): record dev-g slicing analysis for ArrayBuffer transfer/detach

### DIFF
--- a/plan/issues/1645-spec-gap-arraybuffer-resizable-and-typedarray-detached.md
+++ b/plan/issues/1645-spec-gap-arraybuffer-resizable-and-typedarray-detached.md
@@ -98,3 +98,53 @@ TypedArray/DataView detached-buffer guards are all unimplemented; the
 `built-ins/ArrayBuffer` pass-rate target (44% → ≥75%) is unmet. Status correctly
 stays `ready` / `sprint: Backlog` — the full Implementation Plan above is the work
 to be done.
+
+## Slicing (dev-g investigation, 2026-07-17)
+
+Measured against fresh `upstream/main`: substantial resize/detach machinery
+already exists (#3054-C / #3058 `.resize`, #3097 host-AB marshal bridge), but
+**`ArrayBuffer.prototype.transfer` has no dispatch arm** — `ab.transfer()`
+throws `TypeError: transfer is not a function` from the `__extern_method_call`
+fall-through (`src/runtime.ts` ~L10668, right after the `resize` arm at L10569).
+
+I prototyped a runtime `transfer` / `transferToFixedLength` arm that allocates a
+host `ArrayBuffer` with the copied bytes and marks the source detached
+(`_detachedBuffers.add`). It compiles and `dest.byteLength` reads correctly, but
+it **fails the target test262 asserts** (`prototype/transfer/from-fixed-to-same.js`
+et al.) for two structural reasons, both requiring **codegen** work, not
+runtime-only:
+
+1. **Source detach is invisible to compiled native reads.** The test asserts
+   `source.byteLength === 0` after transfer. A statically-typed `ArrayBuffer`
+   receiver lowers `.byteLength` to a direct `array.len` on the backing vec
+   struct, which **bypasses** the host `_detachedBuffers` WeakSet mark — so it
+   returns the *old* length (measured: 8, not 0). Detaching a compiled AB struct
+   needs a **native detach primitive** (zero the vec length field + a
+   struct-readable detached flag), so `array.len` / the detached guards observe
+   it. The same gap breaks `source.slice()`-throws-after-detach.
+2. **`new Uint8Array(dest)` over a host-AB externref returns NaN.** transfer must
+   return a value the *compiled* code can view; the compiled `TypedArray`
+   constructor over a host `ArrayBuffer` externref does not read its bytes
+   (measured: `destArray[0]` → NaN). Either the ctor must accept a host AB, or
+   transfer must return a **compiled vec struct** (which needs a host-callable
+   struct allocator — none is exported today; only in-place `__rab_resize`).
+
+### Proposed 3-way split
+
+- **(a) native AB detach primitive + `transfer`/`transferToFixedLength`** —
+  senior-dev, **L**. Add a codegen detach op on the vec struct (length→0 +
+  detached flag readable by `array.len` sites and the detached guards) and a
+  host-callable byte-vec allocator so `transfer` can return a live compiled
+  buffer; wire the two dispatch arms. Unblocks the `transfer` cluster
+  (~48 tests) and acceptance criterion #2.
+- **(b) detached-buffer method guards** on TypedArray/DataView prototype
+  methods — **M**. `$262.detachArrayBuffer` uses the host WeakSet path (already
+  observable), so these guards (`copyWithin`/`getInt32`/… throw TypeError when
+  detached) are runtime-tractable independent of (a). Acceptance criteria #3/#4.
+- **(c) resizable prototype-introspection / descriptor tests** — **hard**.
+  `resize.length === 1`, `transfer.name`, `dest.resizable`/`maxByteLength`
+  descriptor shape, etc. require real function-object / accessor introspection
+  on builtin prototypes, which the compilation model does not currently model.
+
+Leave #1645 `ready` as the umbrella; (a)/(b)/(c) can be filed as sub-issues when
+scheduled.


### PR DESCRIPTION
Plan-only. Records the dev-g investigation of #1645: `ArrayBuffer.prototype.transfer` has no dispatch arm, and a runtime-only host-ArrayBuffer prototype fails the target test262 asserts for two structural reasons that both need **codegen**, not runtime-only:

1. Compiled `.byteLength` on a statically-typed AB lowers to `array.len` on the vec struct, bypassing the host `_detachedBuffers` WeakSet mark → source reads old length (8, not 0) after transfer. Detaching a compiled AB needs a native detach primitive.
2. `new Uint8Array(dest)` over a host-AB externref returns NaN — transfer must return a compiled vec struct (needs a host-callable allocator) or the ctor must accept host AB.

Proposes a 3-way split: (a) native AB detach primitive + transfer [senior-dev, L]; (b) detached-buffer method guards [M]; (c) resizable descriptor tests [hard]. #1645 stays `ready` as the umbrella.

No source changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)