### PR TITLE
docs(#3341): Slice A spec correction (unreachable invariant — DO NOT CLAIM) + block #2958 on #2867

### DIFF
--- a/plan/issues/2958-standalone-unhandled-rejection-tracking.md
+++ b/plan/issues/2958-standalone-unhandled-rejection-tracking.md
@@ -1,7 +1,8 @@
 ---
 id: 2958
 title: "Standalone: unhandled-rejection tracking — report rejected promises with no handler at drain/event-loop exit"
-status: ready
+status: blocked
+depends_on: [2867]
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
@@ -80,6 +81,7 @@ still actively churning. **Do not implement until #2867 lands.** What follows is
 the execution-ready spec so the next window moves fast once the file settles.
 
 ### Gating reality (important — corrects the title's "standalone")
+
 The native `$Promise` carrier is **`ctx.wasi`-gated**, not `ctx.standalone`:
 `isStandalonePromiseActive()` returns `ctx.wasi === true`
 (async-scheduler.ts ~L3298), and `emitStandalonePromiseThen` /
@@ -90,6 +92,7 @@ exist). **Host mode is byte-inert by construction** — host never registers
 so no host-lane sha256 risk.
 
 ### Data model
+
 - **`$Promise` struct** (`getOrRegisterPromiseType`, async-scheduler.ts ~L258):
   append two fields — `handled: i32 (mut)` and `unhandledNext: externref (mut)`.
   Appending keeps existing `fieldIdx` 0/1/2 (`state`/`value`/`callbacks`) stable,
@@ -100,11 +103,12 @@ so no host-lane sha256 risk.
   next to the microtask globals (~L400). Intrusive singly-linked list head.
 
 ### Emit sites (all in async-scheduler.ts unless noted)
+
 1. **Reject settle** — `buildPromiseSettleBody`, **REJECTED variant only**
    (`settledState === PROMISE_STATE_REJECTED`). After callbacks are read into
    `$callbacks` (L868–872), guard `ref.is_null($callbacks)`: if null (no
    handler at settle) → `promise.unhandledNext = __unhandled_head;
-   __unhandled_head = promise` (O(1) push). The callback-drain loop below is a
+__unhandled_head = promise` (O(1) push). The callback-drain loop below is a
    no-op when callbacks is null, so ordering is safe.
 2. **Late attach ("handle")** — `emitStandalonePromiseThen`, the **already-
    rejected receiver** branch (the inner `then:` enqueuing `rejectWrapperFuncIdx`,
@@ -127,6 +131,7 @@ so no host-lane sha256 risk.
    report or exit.
 
 ### HAZARD — late-import funcIdx shift (#2642 / the memory `*_funcidx_desync` cluster)
+
 `__report_unhandled_rejections` references `__wasi_write_string_stderr` **and**
 `proc_exit`, which are only registered when `console.error` / `process.exit`
 are otherwise used. When this feature is active you MUST (a) **ensure both are
@@ -137,7 +142,9 @@ late import. Emit the report body after all imports are fixed, or repoint by
 name (`ctx.funcMap.get(...)`) at finalize.
 
 ### Test (`tests/issue-2958.test.ts`)
+
 WASI-compile + run under wasmtime (or the standalone harness):
+
 - `Promise.reject(new Error("x"))` with no handler → **nonzero exit** + a stderr
   line. (AC1)
 - same but with `.catch(() => {})` → exit 0, no line. (AC2)

--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -59,6 +59,40 @@ loc-budget-allow:
 > groups) was NOT touched here — it needs a `lower.ts` audit to confirm before
 > editing; folded into the remaining work.
 
+## Slice A — spec correction: DO NOT CLAIM as written (dev-h, 2026-07-17)
+
+**The arch Implementation Plan's Slice A (in #3244) is UNREACHABLE against the
+current code — claiming it would add a dead reason + a vacuous strict entry.**
+
+Slice A proposes peeling a `param-type-internal-desync` reason off
+`param-type-not-resolvable` for the case "the param has an explicit primitive /
+known-class annotation yet `resolveParamType` returned `null`." **That state
+cannot occur.** `resolveParamType` (`src/ir/select.ts:1159–1207`):
+
+- returns a concrete kind for **every** primitive keyword —
+  `number → "f64"` (:1161), `boolean → "bool"` (:1162), `string → "string"`
+  (:1163), `any → "dynamic"` (:1173) — never `null`;
+- returns `"object"` for **every** class/interface `TypeReferenceNode`,
+  `TypeLiteralNode`, and `ArrayTypeNode` (:1192) — never `null`.
+
+The only `null` returns with an annotation present are **legitimate
+rejections**, not desyncs: an inexpressible function-type/closure signature
+(:1178–1179) and genuinely non-lowerable type nodes (unions, tuple, literal,
+conditional, keyof, …, the fall-through :1193). Promoting any of those to a
+hard error would regress real programs. So there is **no safe, non-vacuous
+per-reason peel at these `select.ts` sites** — the reason is entirely
+legitimate here.
+
+**Where a real invariant DOES live (needs re-spec, > M):** the genuine
+"selector-claimed-but-can't-lower" desync is at the **`resolvePositionType`
+layer** (`src/codegen/index.ts`) — `resolveParamType` says `"object"`
+(claimable) but `objectIrTypeFromTsType` / `resolvePositionType` then fails to
+materialize the `IrType`. Peeling _that_ into a strict reason requires tracing
+the select→codegen handoff (the override-map placeholder path), which is a
+larger analysis than the current M sizing. **Slice A needs re-spec before any
+dev claims it.** (Slice B — the `STRICT_IR_BUILD_ERRORS` name-repoint-invariant
+promotion — shipped independently in PR #3249 and is unaffected by this.)
+
 ## Original problem (premise now corrected — see re-scope note above)
 
 ## Problem


### PR DESCRIPTION
Plan-only PR (no code). Two corrections requested by the tech lead:

## 1. #3341 Slice A — mark DO NOT CLAIM (arch spec is unreachable)
The Slice A per-reason split in the arch Implementation Plan (#3244) cannot be implemented as written. Its invariant — "the param has an explicit primitive / known-class annotation yet `resolveParamType` returned `null`" — is **unreachable**:
- `resolveParamType` (`src/ir/select.ts:1159–1207`) returns a concrete kind for **every** primitive keyword (`number→"f64"` :1161, `boolean→"bool"` :1162, `string→"string"` :1163, `any→"dynamic"` :1173) and `"object"` for **every** class `TypeReferenceNode`/`TypeLiteralNode`/`ArrayTypeNode` (:1192) — it never returns `null` for a concrete annotation.
- The only annotation-present `null` returns are **legitimate** rejections (inexpressible closure signature :1178–1179; non-lowerable type nodes at the :1193 fall-through), not desyncs.

So Slice A as written adds a dead reason + a vacuous strict entry. The genuine "selector-claimed-but-can't-lower" invariant lives at the **`resolvePositionType` layer** (select says `"object"`/claimable, codegen then can't materialize the `IrType`); peeling that is a larger-than-M analysis. Marked **DO NOT CLAIM — needs re-spec**. (Slice B — the `STRICT_IR_BUILD_ERRORS` name-repoint-invariant promotion — shipped independently in #3249 and is unaffected.)

## 2. #2958 — status `ready` → `blocked`, add `depends_on: [2867]`
Three devs have independently misclaimed #2958 because its status said `ready` while the "do not implement until #2867 lands" sequencing gate was buried in the body. Flipping to `blocked` stops it surfacing as claimable until #2867 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)