### PR TITLE
fix(ir): make linear plan authoritative for data segments

### DIFF
--- a/plan/issues/3298-linear-memory-plan-extraction.md
+++ b/plan/issues/3298-linear-memory-plan-extraction.md
@@ -1,7 +1,7 @@
 ---
 id: 3298
 title: "Porffor backend P3: extract the shared target-neutral LinearMemoryPlan"
-status: in-review
+status: in-progress
 sprint: porffor-backend
 created: 2026-07-16
 updated: 2026-07-17
@@ -19,9 +19,10 @@ depends_on: [3297, 2956]
 related: [3288, 2953, 2956, 3029, 747]
 origin: "#3288 P3 split: independently dispatchable shared linear-memory planning layer"
 claimed_by: porffor-codex-developer
-claimed_at: 2026-07-17T13:18:45.605Z
-branch: symphony/porffor/3298
-pr: 3245
+claimed_at: 2026-07-17T14:34:24.198Z
+branch: symphony/porffor/3298-after-pr-3245
+pr: null
+last_merged_pr: 3245
 ---
 
 # #3298 - Porffor backend P3: extract the shared target-neutral LinearMemoryPlan
@@ -116,3 +117,41 @@ Validation completed:
 - `npm run check:loc-budget`
 - `npm run check:ir-fallbacks`
 - `npm run check:linear-ir`
+
+## Continuation hardening (2026-07-17)
+
+The post-#3245 audit found that string data-segment requirements were present
+in `LinearMemoryPlan`, but the linear-Wasm adapter independently re-encoded the
+source string when assembling its data segment. This follow-up makes the plan
+authoritative for those bytes while retaining adapter-owned placement/order:
+
+- `LinearMemoryPlan` now clones and deeply freezes its serializable value graph,
+  rejects duplicate layout/allocation/data/global identities, and validates
+  allocation references to canonical layouts and data segments. Optional
+  consumers therefore cannot mutate or silently shadow middle-end decisions.
+- Linear-Wasm stores the planned relocatable bytes beside each assigned literal
+  offset and emits those stored bytes during final module assembly. Direct-AST
+  literals use the same registry, including conflict detection when both paths
+  encounter the same value.
+- The focused suite now covers immutable/canonical snapshots, invalid
+  cross-references, exact UTF-8 plan bytes, and execution of the resulting
+  Unicode literal through linear-Wasm.
+
+Continuation validation completed:
+
+- `npx vitest run tests/issue-3298.test.ts` (5 tests passed)
+- focused planner/provenance/backend regression set (9 files, 75 tests passed)
+- full linear CI slice (20 files, 204 tests passed)
+- cross-backend differential (29 tests passed)
+- `npx tsx scripts/prove-emit-identity.mjs check --baseline .tmp/emit-identity-3298.json`
+  (all 56 file/target outcomes identical to the pre-change baseline)
+- `npm run build`
+- `npm run typecheck -- --pretty false`
+- `npm run lint`
+- `npm run format:check`
+- `npm run check:pushraw`
+- `npm run check:loc-budget`
+- `npm run check:ir-fallbacks`
+- `npm run check:linear-ir`
+- `npm run check:dead-exports`
+- `npm run check:issues`

--- a/plan/issues/3298-linear-memory-plan-extraction.md
+++ b/plan/issues/3298-linear-memory-plan-extraction.md
@@ -1,7 +1,7 @@
 ---
 id: 3298
 title: "Porffor backend P3: extract the shared target-neutral LinearMemoryPlan"
-status: in-progress
+status: in-review
 sprint: porffor-backend
 created: 2026-07-16
 updated: 2026-07-17
@@ -21,7 +21,7 @@ origin: "#3288 P3 split: independently dispatchable shared linear-memory plannin
 claimed_by: porffor-codex-developer
 claimed_at: 2026-07-17T14:34:24.198Z
 branch: symphony/porffor/3298-after-pr-3245
-pr: null
+pr: 3257
 last_merged_pr: 3245
 ---
 

--- a/src/codegen-linear/context.ts
+++ b/src/codegen-linear/context.ts
@@ -3,6 +3,11 @@ import { ts } from "../ts-api.js";
 import type { Instr, LocalDef, ValType, WasmModule } from "../ir/types.js";
 import type { ClassLayout } from "./layout.js";
 
+export interface LinearStringLiteralData {
+  readonly offset: number;
+  readonly bytes: readonly number[];
+}
+
 /** Module-level context for linear-memory codegen */
 export interface LinearContext {
   mod: WasmModule;
@@ -17,8 +22,8 @@ export interface LinearContext {
   errors: { message: string; line: number; column: number }[];
   /** Class layouts for class declarations */
   classLayouts: Map<string, ClassLayout>;
-  /** String literal data segment: string value → data segment offset */
-  stringLiterals: Map<string, number>;
+  /** String literal data segment: string value → relocatable bytes + assigned artifact offset. */
+  stringLiterals: Map<string, LinearStringLiteralData>;
   /** Current data segment write offset */
   dataSegmentOffset: number;
   /** Counter for generating unique lambda function names */

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -251,9 +251,8 @@ export function generateLinearModule(ast: TypedAST, opts: LinearOptions = {}): W
   if (ctx.stringLiterals.size > 0) {
     const totalSize = ctx.dataSegmentOffset - DATA_SEGMENT_BASE;
     const bytes = new Uint8Array(totalSize);
-    for (const [str, offset] of ctx.stringLiterals) {
-      const encoded = new TextEncoder().encode(str);
-      bytes.set(encoded, offset - DATA_SEGMENT_BASE);
+    for (const literal of ctx.stringLiterals.values()) {
+      bytes.set(literal.bytes, literal.offset - DATA_SEGMENT_BASE);
     }
     mod.dataSegments.push({ offset: DATA_SEGMENT_BASE, bytes });
   }
@@ -413,9 +412,8 @@ export function generateLinearMultiModule(multiAst: MultiTypedAST, opts: LinearO
   if (ctx.stringLiterals.size > 0) {
     const totalSize = ctx.dataSegmentOffset - DATA_SEGMENT_BASE;
     const bytes = new Uint8Array(totalSize);
-    for (const [str, offset] of ctx.stringLiterals) {
-      const encoded = new TextEncoder().encode(str);
-      bytes.set(encoded, offset - DATA_SEGMENT_BASE);
+    for (const literal of ctx.stringLiterals.values()) {
+      bytes.set(literal.bytes, literal.offset - DATA_SEGMENT_BASE);
     }
     mod.dataSegments.push({ offset: DATA_SEGMENT_BASE, bytes });
   }

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -2324,27 +2324,26 @@ export function addLinearIrStringRuntime(mod: WasmModule): void {
   );
 }
 
-/**
- * Materialize a literal with the direct backend's canonical UTF-8 data
- * segment + `__str_from_data` path. Shared by direct AST codegen and the L3
- * IR resolver so literal layout and deduplication cannot drift.
- */
+/** Materialize a literal through canonical UTF-8 data and `__str_from_data`. */
 export function linearStringLiteralInstrs(
   ctx: LinearContext,
   value: string,
   strFromDataIdx = ctx.funcMap.get("__str_from_data"),
+  plannedBytes?: readonly number[],
 ): readonly Instr[] {
-  const encoded = new TextEncoder().encode(value);
-  let dataOffset = ctx.stringLiterals.get(value);
-  if (dataOffset === undefined) {
-    dataOffset = ctx.dataSegmentOffset;
-    ctx.stringLiterals.set(value, dataOffset);
-    ctx.dataSegmentOffset += encoded.length;
+  const encoded = plannedBytes === undefined ? [...new TextEncoder().encode(value)] : [...plannedBytes];
+  let literal = ctx.stringLiterals.get(value);
+  if (literal === undefined) {
+    literal = { offset: ctx.dataSegmentOffset, bytes: encoded };
+    ctx.stringLiterals.set(value, literal);
+    ctx.dataSegmentOffset += literal.bytes.length;
+  } else if (literal.bytes.length !== encoded.length || literal.bytes.some((byte, index) => byte !== encoded[index])) {
+    throw new Error(`linear string runtime: conflicting data bytes for ${JSON.stringify(value)}`);
   }
   if (strFromDataIdx === undefined) throw new Error("linear string runtime: __str_from_data helper missing");
   return [
-    { op: "i32.const", value: dataOffset },
-    { op: "i32.const", value: encoded.length },
+    { op: "i32.const", value: literal.offset },
+    { op: "i32.const", value: literal.bytes.length },
     { op: "call", funcIdx: strFromDataIdx },
   ];
 }

--- a/src/ir/analysis/linear-memory-plan.ts
+++ b/src/ir/analysis/linear-memory-plan.ts
@@ -241,16 +241,33 @@ export class LinearMemoryPlan {
   private readonly layoutsById: ReadonlyMap<string, LinearLayoutPlan>;
   private readonly allocationsById: ReadonlyMap<number, LinearAllocationSitePlan>;
   private readonly dataSegmentsById: ReadonlyMap<string, LinearDataSegmentPlan>;
+  private readonly globalsById: ReadonlyMap<string, LinearGlobalStoragePlan>;
 
   constructor(snapshot: LinearMemoryPlanSnapshot) {
-    this.policy = snapshot.policy;
-    this.layouts = Object.freeze([...snapshot.layouts]);
-    this.allocations = Object.freeze([...snapshot.allocations]);
-    this.dataSegments = Object.freeze([...snapshot.dataSegments]);
-    this.globals = Object.freeze([...snapshot.globals]);
-    this.layoutsById = new Map(this.layouts.map((layout) => [layout.id, layout]));
-    this.allocationsById = new Map(this.allocations.map((allocation) => [allocation.id as number, allocation]));
-    this.dataSegmentsById = new Map(this.dataSegments.map((segment) => [segment.id, segment]));
+    const frozen = freezePlanValue(snapshot);
+    this.policy = frozen.policy;
+    this.layouts = frozen.layouts;
+    this.allocations = frozen.allocations;
+    this.dataSegments = frozen.dataSegments;
+    this.globals = frozen.globals;
+    this.layoutsById = indexUnique(this.layouts, (layout) => layout.id, "layout");
+    this.allocationsById = indexUnique(this.allocations, (allocation) => allocation.id as number, "allocation site");
+    this.dataSegmentsById = indexUnique(this.dataSegments, (segment) => segment.id, "data segment");
+    this.globalsById = indexUnique(this.globals, (global) => global.id, "global storage");
+
+    for (const allocation of this.allocations) {
+      if (!this.layoutsById.has(allocation.layoutId)) {
+        throw new Error(
+          `linear-memory allocation site ${allocation.id as number} references missing layout '${allocation.layoutId}'`,
+        );
+      }
+      if (allocation.dataSegmentId !== undefined && !this.dataSegmentsById.has(allocation.dataSegmentId)) {
+        throw new Error(
+          `linear-memory allocation site ${allocation.id as number} references missing data segment '${allocation.dataSegmentId}'`,
+        );
+      }
+    }
+    Object.freeze(this);
   }
 
   layout(id: string): LinearLayoutPlan | undefined {
@@ -269,6 +286,16 @@ export class LinearMemoryPlan {
 
   dataSegment(id: string): LinearDataSegmentPlan | undefined {
     return this.dataSegmentsById.get(id);
+  }
+
+  requireDataSegment(id: string): LinearDataSegmentPlan {
+    const segment = this.dataSegment(id);
+    if (!segment) throw new Error(`linear-memory plan has no data segment '${id}'`);
+    return segment;
+  }
+
+  global(id: string): LinearGlobalStoragePlan | undefined {
+    return this.globalsById.get(id);
   }
 
   layoutForObjectShape(shape: IrObjectShape): LinearRecordLayoutPlan | undefined {
@@ -291,14 +318,35 @@ export class LinearMemoryPlan {
   }
 
   toJSON(): LinearMemoryPlanSnapshot {
-    return {
+    return Object.freeze({
       policy: this.policy,
       layouts: this.layouts,
       allocations: this.allocations,
       dataSegments: this.dataSegments,
       globals: this.globals,
-    };
+    });
   }
+}
+
+/** Clone + freeze the plan's deliberately plain, serializable value graph. */
+function freezePlanValue<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((item) => freezePlanValue(item))) as T;
+  }
+  const clone: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) clone[key] = freezePlanValue(item);
+  return Object.freeze(clone) as T;
+}
+
+function indexUnique<T, K>(values: readonly T[], keyOf: (value: T) => K, label: string): ReadonlyMap<K, T> {
+  const indexed = new Map<K, T>();
+  for (const value of values) {
+    const key = keyOf(value);
+    if (indexed.has(key)) throw new Error(`linear-memory plan has duplicate ${label} '${String(key)}'`);
+    indexed.set(key, value);
+  }
+  return indexed;
 }
 
 interface OwnershipMetadata {

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -541,7 +541,8 @@ function makeLinearIrResolver(
       return null;
     },
     emitStringConst(value: string, alloc?: AllocSiteId): readonly Instr[] {
-      const layout = memoryPlan?.layouts.find((candidate) => candidate.kind === "string") ?? planLinearStringLayout();
+      const plan = memoryPlan;
+      const layout = plan?.layouts.find((candidate) => candidate.kind === "string") ?? planLinearStringLayout();
       if (layout.kind !== "string") throw new Error("linear-ir: invalid string layout");
       const allocation = allocationFor(layout.id, alloc);
       const operation = plannedOperation(
@@ -550,7 +551,11 @@ function makeLinearIrResolver(
         (candidate) => candidate.family === "string" && candidate.operation === "materialize-data",
         "string materialization",
       );
-      return linearStringLiteralInstrs(ctx, value, resolveLinearRuntimeOperation(ctx, operation));
+      if (!plan || !allocation?.dataSegmentId) {
+        throw new Error("linear-ir: string literal is absent from the completed memory plan");
+      }
+      const segment = plan.requireDataSegment(allocation.dataSegmentId);
+      return linearStringLiteralInstrs(ctx, value, resolveLinearRuntimeOperation(ctx, operation), segment.bytes);
     },
     emitStringConcat(alloc?: AllocSiteId): readonly Instr[] {
       const layout = memoryPlan?.layouts.find((candidate) => candidate.kind === "string") ?? planLinearStringLayout();

--- a/tests/issue-3298.test.ts
+++ b/tests/issue-3298.test.ts
@@ -11,6 +11,7 @@ import { compile } from "../src/index.js";
 import {
   AllocSiteRegistry,
   IrFunctionBuilder,
+  LinearMemoryPlan,
   irVal,
   planLinearMemory,
   planLinearRecordLayout,
@@ -141,6 +142,32 @@ describe("#3298 — target-neutral LinearMemoryPlan", () => {
       allocationClass: "arena",
       elementStorage: "f64",
     });
+
+    const objectLayout = plan.layouts.find((layout) => layout.kind === "record");
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(Object.isFrozen(plan.allocations)).toBe(true);
+    expect(Object.isFrozen(plan.allocations[0])).toBe(true);
+    expect(Object.isFrozen(objectLayout)).toBe(true);
+    expect(objectLayout?.kind === "record" && Object.isFrozen(objectLayout.fields)).toBe(true);
+    expect(() => {
+      (plan.allocations[0] as { layoutId: string }).layoutId = "mutated";
+    }).toThrow(TypeError);
+
+    const snapshot = plan.toJSON();
+    expect(
+      () =>
+        new LinearMemoryPlan({
+          ...snapshot,
+          layouts: [...snapshot.layouts, snapshot.layouts[0]!],
+        }),
+    ).toThrow(/duplicate layout/);
+    expect(
+      () =>
+        new LinearMemoryPlan({
+          ...snapshot,
+          allocations: [{ ...snapshot.allocations[0]!, layoutId: "missing" }, ...snapshot.allocations.slice(1)],
+        }),
+    ).toThrow(/references missing layout/);
   });
 
   it("keeps the direct linear class layout on the shared record-layout primitive", () => {
@@ -185,5 +212,19 @@ describe("#3298 — target-neutral LinearMemoryPlan", () => {
       allocationClass: "arena",
       zeroed: false,
     });
+  });
+
+  it("materializes linear-Wasm string data from the canonical plan bytes", async () => {
+    const result = await compile(`export function unicode(): number { return "hé".length; }`, { target: "linear" });
+    expect(result.success, result.success ? "" : result.errors.map((error) => error.message).join("; ")).toBe(true);
+
+    const report = getLastLinearIrReport();
+    expect(report?.compiled).toContain("unicode");
+    const allocation = report?.memoryPlan.allocations.find((candidate) => candidate.dataSegmentId !== undefined);
+    expect(allocation?.dataSegmentId).toBeDefined();
+    expect(report?.memoryPlan.requireDataSegment(allocation!.dataSegmentId!).bytes).toEqual([104, 195, 169]);
+
+    const instance = await WebAssembly.instantiate(result.binary!);
+    expect((instance.instance.exports.unicode as () => number)()).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- deep-freeze and validate canonical `LinearMemoryPlan` snapshots so consumers cannot mutate, duplicate, or dangle middle-end layout/data decisions
- make linear-Wasm materialize string literals from plan-owned relocatable bytes while retaining adapter-owned placement and the default arena ABI
- keep direct and IR string literals on one conflict-checked registry and add focused immutable-snapshot plus Unicode execution coverage

This is the final #3298 hardening continuation after merged PR #3245. It does not begin Porffor heap lowering or introduce a second allocation policy.

## Validation

- focused planner/provenance/backend set: 9 files, 75 tests passed
- full linear CI slice: 20 files, 204 tests passed
- cross-backend differential: 29 tests passed
- `prove-emit-identity`: all 56 file/target outcomes identical to the pre-change baseline, including after merging current `origin/main`
- `npm run build`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run format:check`
- `npm run check:pushraw`
- `npm run check:loc-budget`
- `npm run check:ir-fallbacks`
- `npm run check:linear-ir`
- `npm run check:dead-exports`
- `npm run check:issues`

Closes #3298
