### PR TITLE
chore: route hardest architect issues to model: fable

### DIFF
--- a/plan/issues/2370-dce-remap-non-idempotent-aliased-body.md
+++ b/plan/issues/2370-dce-remap-non-idempotent-aliased-body.md
@@ -7,6 +7,7 @@ created: 2026-06-18
 assignee: ""
 priority: medium
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: bugfix
 area: codegen

--- a/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
+++ b/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
@@ -8,6 +8,7 @@ updated: 2026-07-02
 priority: medium
 horizon: l
 feasibility: hard
+model: fable
 reasoning_effort: high
 task_type: investigation
 area: runtime

--- a/plan/issues/2793-structural-narrowing-struct-copy-breaks-mutation.md
+++ b/plan/issues/2793-structural-narrowing-struct-copy-breaks-mutation.md
@@ -9,6 +9,7 @@ updated: 2026-06-28
 priority: medium
 horizon: l
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: bug
 area: codegen

--- a/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
+++ b/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
@@ -6,6 +6,7 @@ created: 2026-06-30
 updated: 2026-07-12
 priority: high
 feasibility: hard
+model: fable
 task_type: epic
 area: codegen
 goal: standalone

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -8,6 +8,7 @@ created: 2026-07-01
 priority: medium
 horizon: l
 feasibility: hard
+model: fable
 reasoning_effort: high
 task_type: feature
 area: codegen

--- a/plan/issues/2917-standalone-native-class-extends-builtin-super-construction.md
+++ b/plan/issues/2917-standalone-native-class-extends-builtin-super-construction.md
@@ -7,6 +7,7 @@ created: 2026-07-01
 priority: medium
 horizon: l
 feasibility: hard
+model: fable
 reasoning_effort: high
 task_type: feature
 area: codegen

--- a/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
+++ b/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
@@ -7,6 +7,7 @@ updated: 2026-07-04
 priority: medium
 horizon: xl
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: feature
 area: runtime

--- a/plan/issues/2929-interpreter-direct-eval-with-proxy-mop.md
+++ b/plan/issues/2929-interpreter-direct-eval-with-proxy-mop.md
@@ -7,6 +7,7 @@ updated: 2026-07-02
 priority: medium
 horizon: xl
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: feature
 area: runtime

--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -6,6 +6,7 @@ sprint: current
 priority: high
 horizon: xl
 feasibility: hard
+model: fable
 area: codegen, runtime
 goal: standalone-mode
 related: [2965, 2861, 2863, 2896, 2949, 2989]

--- a/plan/issues/3031-dynamic-mop-extensions-spec.md
+++ b/plan/issues/3031-dynamic-mop-extensions-spec.md
@@ -9,6 +9,7 @@ assignee: ttraenkler/fable-3031 (apply slice only — released on merge; umbrell
 priority: high
 horizon: xl
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: analysis
 area: codegen, runtime

--- a/plan/issues/3032-lazy-generator-expression-thunks.md
+++ b/plan/issues/3032-lazy-generator-expression-thunks.md
@@ -7,6 +7,7 @@ sprint: current
 created: 2026-07-04
 priority: high
 feasibility: hard
+model: fable
 reasoning_effort: max
 horizon: xl
 task_type: bugfix

--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -8,6 +8,7 @@ updated: 2026-07-12
 priority: high
 horizon: xl
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: architecture
 area: codegen, standalone

--- a/plan/issues/3251-array-descriptor-overlay-substrate.md
+++ b/plan/issues/3251-array-descriptor-overlay-substrate.md
@@ -6,6 +6,7 @@ sprint: Backlog
 created: 2026-07-13
 priority: high
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: epic
 area: codegen, runtime, standalone

--- a/plan/issues/3284-compiler-compatibility-with-original-test262-harness.md
+++ b/plan/issues/3284-compiler-compatibility-with-original-test262-harness.md
@@ -6,7 +6,7 @@ sprint: current
 created: 2026-07-15
 priority: high
 feasibility: hard
-model: opus
+model: fable
 horizon: xl
 reasoning_effort: high
 task_type: bugfix

--- a/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
+++ b/plan/issues/3341-strict-ir-reasons-promote-zeroed-buckets.md
@@ -6,6 +6,7 @@ sprint: current
 created: 2026-07-17
 priority: medium
 feasibility: hard
+model: fable
 horizon: m
 task_type: feature
 area: codegen

--- a/plan/issues/3360-async-gen-yield-star-abrupt-completion-protocol.md
+++ b/plan/issues/3360-async-gen-yield-star-abrupt-completion-protocol.md
@@ -6,6 +6,7 @@ sprint: current
 priority: high
 horizon: l
 feasibility: hard
+model: fable
 reasoning_effort: high
 task_type: bug
 area: codegen

--- a/plan/issues/743-whole-program-type-flow-analysis.md
+++ b/plan/issues/743-whole-program-type-flow-analysis.md
@@ -6,6 +6,7 @@ created: 2026-03-22
 updated: 2026-04-28
 priority: critical
 feasibility: hard
+model: fable
 reasoning_effort: max
 goal: performance
 sprint: Backlog

--- a/plan/issues/744-function-monomorphization-for-polymorphic-call.md
+++ b/plan/issues/744-function-monomorphization-for-polymorphic-call.md
@@ -6,6 +6,7 @@ created: 2026-03-21
 updated: 2026-06-19
 priority: high
 feasibility: hard
+model: fable
 reasoning_effort: high
 task_type: performance
 area: codegen

--- a/plan/issues/773-monomorphize-functions-compile-with-call.md
+++ b/plan/issues/773-monomorphize-functions-compile-with-call.md
@@ -7,6 +7,7 @@ created: 2026-03-22
 updated: 2026-06-19
 priority: critical
 feasibility: hard
+model: fable
 reasoning_effort: max
 task_type: performance
 area: codegen

--- a/plan/issues/779-assert-failures-tests-compile-and.md
+++ b/plan/issues/779-assert-failures-tests-compile-and.md
@@ -7,6 +7,7 @@ created: 2026-03-23
 updated: 2026-05-28
 priority: critical
 feasibility: hard
+model: fable
 reasoning_effort: max
 goal: spec-completeness
 sprint: current


### PR DESCRIPTION
## Summary
- Tags 20 of the hardest architect-scoped backlog issues with `model: fable` so they route to the frontier model during its short (~2 day) availability window.
- Adds `model: fable` to 19 issues with no prior `model:` line.
- Flips #3284 from `model: opus` to `model: fable`.
- Frontmatter-only change: `model:` field alone, no status/sprint/priority/body edits.

Issues tagged: #743, #744, #773, #779, #2370, #2763, #2793, #2860, #2916, #2917, #2928, #2929, #2984, #3031, #3032, #3178, #3251, #3341, #3360, #3284

Skipped (already `status: done`, not touched): #2681, #2686, #2769

## Test plan
- Plan-only markdown change; no code touched.
- Verified via `git diff --stat` that exactly one `model:` line was added/changed per file (20 files, +20/-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)