### PR TITLE
fix(#3359): thread thisArg into array-method callbacks (direct-array form)

### DIFF
--- a/plan/issues/3359-standalone-filter-thisarg-not-threaded.md
+++ b/plan/issues/3359-standalone-filter-thisarg-not-threaded.md
@@ -15,6 +15,10 @@ language_feature: array-methods, this-binding
 goal: standalone-parity
 related: [2036, 3326]
 origin: "found while fixing #3326 (stale refuse-loudly expectations in tests/issue-2036.test.ts) — the `filter threads thisArg standalone` case genuinely fails (returns 0, expected 1); confirmed the same bug on a REAL array receiver, so it is a general filter-thisArg threading gap, not an $Object-only issue."
+# (#3102) closures.ts is a god-file (split tracked by #3182); the this-param
+# strip adds a small runtimeParameters() helper + per-site call updates.
+loc-budget-allow:
+  - src/codegen/closures.ts
 ---
 
 ## Partial resolution (2026-07-17) — direct array-receiver form FIXED

--- a/plan/issues/3359-standalone-filter-thisarg-not-threaded.md
+++ b/plan/issues/3359-standalone-filter-thisarg-not-threaded.md
@@ -1,9 +1,11 @@
 ---
 id: 3359
 title: "standalone: Array.prototype.filter (and callback methods) ignore the thisArg argument — closure runs with wrong `this`"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-f
 sprint: current
 created: 2026-07-17
+updated: 2026-07-17
 priority: low
 horizon: s
 feasibility: medium
@@ -14,6 +16,43 @@ goal: standalone-parity
 related: [2036, 3326]
 origin: "found while fixing #3326 (stale refuse-loudly expectations in tests/issue-2036.test.ts) — the `filter threads thisArg standalone` case genuinely fails (returns 0, expected 1); confirmed the same bug on a REAL array receiver, so it is a general filter-thisArg threading gap, not an $Object-only issue."
 ---
+
+## Partial resolution (2026-07-17) — direct array-receiver form FIXED
+
+**Root cause (found).** A TypeScript `this` parameter
+(`function (this: T, x) {…}`) is a TYPE-LEVEL-only annotation, but codegen
+emitted it as a **real leading runtime parameter** of the lifted closure, so
+every user param shifted one slot right. Array-method call sites supply the spec
+`thisArg` via the `__current_this` global (not a positional arg), so the element
+value landed in the (spurious) `this` slot and `thisArg` was dropped — the
+predicate read `this.<prop>` as `undefined`. Verified via WAT: the callback's
+funcref carried an extra `this` param and read it instead of `__current_this`.
+
+**Fix.** New `runtimeParameters()` in `src/codegen/closures.ts` strips a leading
+TS `this` param from the closure's runtime signature, applied at every
+signature / param-local / default / destructuring site in `compileArrowAsClosure`,
+`compileArrowAsCallback`, `computeClosureWrapperSig`, `emitArrowParamDefaults`,
+and `emitClosureParamDestructuring`. A closure WITHOUT a this-param (all JS,
+incl. every test262 input) gets the original list back — **byte-identical**, so
+the conformance surface is untouched. `this` then correctly falls back to
+`__current_this`, which both dispatch paths already install.
+
+This fixes the **direct array-receiver form** — `a.filter(cb, thisArg)`,
+`.map` / `.some` / `.every` / `.find` / `.findIndex` / `.forEach` — on **both**
+the host/gc and standalone lanes. Guard: `tests/issue-3359.test.ts` (16 cases,
+host + standalone).
+
+**Residual (still open).** The BORROWED array-like form
+`Array.prototype.filter.call(arrayLike, cb, thisArg)` still binds `this` to the
+**receiver** instead of `thisArg` (predicate reads `this.<prop>` → NaN). This is
+a SEPARATE, pre-existing gap in the array-like borrow dispatch
+(`src/codegen/array-prototype-borrow.ts`): the `withThisInstalled` install of
+`__current_this` appears structurally correct in WAT (install → call_ref →
+restore, inside the per-element loop) yet the runtime value read by the callback
+is not the installed `thisArg` — likely a value-rep / dispatch-path interaction
+distinct from the this-param strip. Kept skipped in `tests/issue-2036.test.ts`
+(`filter threads thisArg standalone — array-like .call form`). This arm keeps
+#3359 open.
 
 # #3359 — standalone `filter` ignores its `thisArg`
 

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1102,14 +1102,17 @@ export function emitArrowParamDefaults(
   arrow: ts.ArrowFunction | ts.FunctionExpression,
   paramOffset: number, // offset in liftedFctx.params (usually 1 for __self)
 ): void {
+  // (#3359) Iterate the this-param-stripped list so index `i` stays aligned with
+  // `fctx.params[paramOffset + i]` (which was built without the TS `this` param).
+  const params = runtimeParameters(arrow);
   // TDZ enforcement (#413): set up TDZ flags for parameters with defaults
-  const hasDefaults = arrow.parameters.some((p) => !!p.initializer);
+  const hasDefaults = params.some((p) => !!p.initializer);
   let tdzFlags: number[] | undefined;
   if (hasDefaults) {
     if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
     tdzFlags = [];
-    for (let i = 0; i < arrow.parameters.length; i++) {
-      const param = arrow.parameters[i]!;
+    for (let i = 0; i < params.length; i++) {
+      const param = params[i]!;
       const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${i}`;
       const flagIdx = allocLocal(fctx, `__tdz_param_${paramName}`, { kind: "i32" });
       tdzFlags.push(flagIdx);
@@ -1118,15 +1121,15 @@ export function emitArrowParamDefaults(
   }
   const defaultArgcLocal =
     hasDefaults &&
-    arrow.parameters.some((param, i) => {
+    params.some((param, i) => {
       if (!param.initializer) return false;
       return paramDefaultNeedsArgc(fctx.params[paramOffset + i]?.type);
     })
       ? cacheParamDefaultArgc(ctx, fctx)
       : undefined;
 
-  for (let i = 0; i < arrow.parameters.length; i++) {
-    const param = arrow.parameters[i]!;
+  for (let i = 0; i < params.length; i++) {
+    const param = params[i]!;
     if (!param.initializer) {
       if (tdzFlags) {
         fctx.body.push({ op: "i32.const", value: 1 });
@@ -1207,8 +1210,8 @@ export function emitArrowParamDefaults(
 
   // Clean up param TDZ flags
   if (tdzFlags) {
-    for (let i = 0; i < arrow.parameters.length; i++) {
-      const param = arrow.parameters[i]!;
+    for (let i = 0; i < params.length; i++) {
+      const param = params[i]!;
       const paramName = ts.isIdentifier(param.name) ? param.name.text : `__param${i}`;
       fctx.tdzFlagLocals?.delete(paramName);
     }
@@ -1412,6 +1415,27 @@ export function closureProvablyAfterLetDecl(
 }
 
 /**
+ * (#3359) A TypeScript `this` parameter (`function (this: T, …)`) is a
+ * TYPE-LEVEL-only annotation (TS §this-parameters) and must NOT become a
+ * runtime Wasm parameter — it is always the FIRST parameter, named `this`.
+ * Codegen that iterates `node.parameters` to build the closure's runtime
+ * signature / body param-locals must skip it, otherwise a real user param
+ * shifts one slot right and the call site (which supplies the spec `thisArg`
+ * via the `__current_this` global, not a positional arg) misaligns —
+ * `Array.prototype.filter(function (this, x) {…}, thisArg)` read the element
+ * into the `this` slot and dropped `thisArg`. A closure WITHOUT a this-param
+ * (all JS, incl. every test262 input) returns the original array — byte-identical.
+ */
+export function runtimeParameters(arrow: ts.ArrowFunction | ts.FunctionExpression): readonly ts.ParameterDeclaration[] {
+  const ps = arrow.parameters;
+  const first = ps.length > 0 ? ps[0]! : undefined;
+  if (first && ts.isIdentifier(first.name) && first.name.escapedText === "this") {
+    return ps.slice(1);
+  }
+  return ps;
+}
+
+/**
  * (#2939) Compute the funcref-wrapper signature (user param ValTypes + return
  * ValType) of an arrow / function-expression closure, WITHOUT emitting anything.
  *
@@ -1436,9 +1460,9 @@ export function computeClosureWrapperSig(
 ): { params: ValType[]; returnType: ValType | null } {
   const isGenerator = ts.isFunctionExpression(arrow) && arrow.asteriskToken !== undefined;
 
-  // 1. Parameter types.
+  // 1. Parameter types. (#3359) A TS `this` param is type-level only — exclude it.
   const arrowParams: ValType[] = [];
-  for (const p of arrow.parameters) {
+  for (const p of runtimeParameters(arrow)) {
     const paramType = ctx.checker.getTypeAtLocation(p);
     let wasmType = resolveWasmType(ctx, paramType);
     if (p.initializer && wasmType.kind === "ref") {
@@ -1910,7 +1934,8 @@ export function compileArrowAsClosure(
     name: closureName,
     params: [
       { name: "__self", type: { kind: selfParamKind, typeIdx: selfTypeIdx } },
-      ...arrow.parameters.map((p, i) => ({
+      // (#3359) Skip a TS `this` param — type-level only, never a runtime arg.
+      ...runtimeParameters(arrow).map((p, i) => ({
         name: ts.isIdentifier(p.name) ? p.name.text : `__param${i}`,
         type: arrowParams[i] ?? { kind: "f64" as const },
       })),
@@ -2316,7 +2341,7 @@ export function compileArrowAsClosure(
     // Receiver/args spilling is #3032 W2.
     const genLazyEligible =
       !isAsync &&
-      arrow.parameters.length === 0 &&
+      runtimeParameters(arrow).length === 0 && // (#3359) a TS `this` param is not a runtime arg
       !(ts.isBlock(body) && closureBodyUsesArguments(body)) &&
       !genBodyReferencesThis(body);
     // (#3164) Defensive: in a no-JS-host target the eager-buffer path needs the
@@ -2615,7 +2640,9 @@ export function compileArrowAsCallback(
   const cbParams: ValType[] = [{ kind: "externref" }]; // captures param [0]
   // When needsThis=true, inject 'this' as param [1] (externref receiver)
   if (needsThis) cbParams.push({ kind: "externref" });
-  for (const p of arrow.parameters) {
+  // (#3359) A TS `this` param is type-level only — never a runtime callback arg.
+  const cbArrowParams = runtimeParameters(arrow);
+  for (const p of cbArrowParams) {
     const paramType = ctx.checker.getTypeAtLocation(p);
     const resolved = resolveWasmType(ctx, paramType);
     cbResolvedParams.push(resolved);
@@ -2662,8 +2689,8 @@ export function compileArrowAsCallback(
   if (needsThis) {
     cbFctxParams.push({ name: "__this", type: { kind: "externref" } });
   }
-  for (let i = 0; i < arrow.parameters.length; i++) {
-    const p = arrow.parameters[i]!;
+  for (let i = 0; i < cbArrowParams.length; i++) {
+    const p = cbArrowParams[i]!;
     cbFctxParams.push({
       name: ts.isIdentifier(p.name) ? p.name.text : `__param${i}`,
       type: cbParams[arrowParamOffset + i] ?? { kind: "f64" as const },
@@ -2789,9 +2816,10 @@ export function compileArrowAsCallback(
   // Emit default-value initialization for simple params with defaults
   emitArrowParamDefaults(ctx, cbFctx, arrow, arrowParamOffset /* skip __captures [and __this] */);
 
-  // Emit destructuring code for binding pattern parameters
-  for (let i = 0; i < arrow.parameters.length; i++) {
-    const param = arrow.parameters[i]!;
+  // Emit destructuring code for binding pattern parameters (#3359: over the
+  // this-param-stripped list, aligned with cbResolvedParams / cbFctxParams).
+  for (let i = 0; i < cbArrowParams.length; i++) {
+    const param = cbArrowParams[i]!;
     if (ts.isObjectBindingPattern(param.name) || ts.isArrayBindingPattern(param.name)) {
       const resolved = cbResolvedParams[i] ?? { kind: "f64" as const };
       const paramName = cbFctx.params[arrowParamOffset + i]?.name ?? `__param${i}`;

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1415,16 +1415,11 @@ export function closureProvablyAfterLetDecl(
 }
 
 /**
- * (#3359) A TypeScript `this` parameter (`function (this: T, …)`) is a
- * TYPE-LEVEL-only annotation (TS §this-parameters) and must NOT become a
- * runtime Wasm parameter — it is always the FIRST parameter, named `this`.
- * Codegen that iterates `node.parameters` to build the closure's runtime
- * signature / body param-locals must skip it, otherwise a real user param
- * shifts one slot right and the call site (which supplies the spec `thisArg`
- * via the `__current_this` global, not a positional arg) misaligns —
- * `Array.prototype.filter(function (this, x) {…}, thisArg)` read the element
- * into the `this` slot and dropped `thisArg`. A closure WITHOUT a this-param
- * (all JS, incl. every test262 input) returns the original array — byte-identical.
+ * (#3359) Drop a leading TS `this` parameter (`function (this: T, …)`) — a
+ * type-level-only annotation that must NOT become a runtime Wasm param, else a
+ * real user param shifts one slot right and the array-method call site (which
+ * supplies `thisArg` via the `__current_this` global) misaligns. No-this
+ * closures (all JS, incl. every test262 input) return the original — byte-identical.
  */
 export function runtimeParameters(arrow: ts.ArrowFunction | ts.FunctionExpression): readonly ts.ParameterDeclaration[] {
   const ps = arrow.parameters;

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -38,6 +38,7 @@ import {
   collectReferencedIdentifiers,
   collectWrittenIdentifiers,
   isOwnParamName,
+  runtimeParameters,
 } from "../closures.js";
 
 export type ArrowClosureCapture = {
@@ -490,8 +491,10 @@ export function emitClosureParamDestructuring(
   // nested patterns, rest elements, and ReferenceError-on-unresolvable defaults
   // all work uniformly across function declarations, function expressions, and
   // arrow functions (#ref-error-A).
-  for (let pi = 0; pi < arrow.parameters.length; pi++) {
-    const param = arrow.parameters[pi]!;
+  // (#3359) Over the this-param-stripped list so `pi` aligns with `arrowParams`.
+  const destructureParams = runtimeParameters(arrow);
+  for (let pi = 0; pi < destructureParams.length; pi++) {
+    const param = destructureParams[pi]!;
     if (ts.isIdentifier(param.name)) continue; // simple param, already handled
 
     const paramIdx = pi + 1; // +1 for __self

--- a/tests/issue-2036.test.ts
+++ b/tests/issue-2036.test.ts
@@ -273,13 +273,14 @@ describe("#2036 S6 — borrowed search/result-building methods run natively in s
     ).toBe(2);
   });
 
-  // (#3326/#3359) `filter`'s `thisArg` is NOT threaded into the callback's `this`
-  // under standalone — the predicate reads `this.t` as undefined and the result
-  // is empty (returns 0, not 1). Confirmed on a real array receiver too, so it is
-  // a general native filter-thisArg threading gap, not an $Object-only issue.
-  // Tracked in #3359; skipped here until that lands (leaving a genuinely-broken
-  // case as-is per the #3326 scope, rather than asserting the wrong behavior).
-  it.skip("filter threads thisArg standalone (#3359 — thisArg not threaded)", async () => {
+  // (#3326/#3359) The DIRECT array-receiver form (`a.filter(cb, thisArg)`) is
+  // FIXED for all callback methods on both lanes (root cause: a TS `this` param
+  // was emitted as a real runtime param, shifting user params — see
+  // `runtimeParameters` in closures.ts and tests/issue-3359.test.ts). The
+  // BORROWED array-like form below (`Array.prototype.filter.call(o, cb, thisArg)`)
+  // still binds `this` to the receiver instead of `thisArg` — a SEPARATE residual
+  // in the array-like borrow dispatch, kept skipped and tracked in #3359.
+  it.skip("filter threads thisArg standalone — array-like .call form (#3359 residual)", async () => {
     expect(
       await runStandalone(
         `export function test(): number {

--- a/tests/issue-3359.test.ts
+++ b/tests/issue-3359.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3359 — Array.prototype callback methods must thread their `thisArg` (2nd arg)
+// into the callback's `this`. Root cause: a TypeScript `this` parameter
+// (`function (this: T, x) {…}`) is type-level only, but codegen emitted it as a
+// REAL leading runtime param of the lifted closure, shifting every user param
+// one slot right. The array-method call site supplies the spec `thisArg` via the
+// `__current_this` global (not a positional arg), so the element landed in the
+// `this` slot and `thisArg` was dropped — the predicate read `this.<prop>` as
+// undefined. Fix: `runtimeParameters()` strips a leading TS `this` param from the
+// closure's runtime signature, so `this` correctly resolves to `__current_this`.
+//
+// Scope: this covers the DIRECT array-receiver form (`a.filter(cb, thisArg)`) on
+// both the host/gc and standalone lanes, for every thisArg-taking callback
+// method. The borrowed array-like form
+// (`Array.prototype.filter.call(arrayLike, cb, thisArg)`) has a SEPARATE residual
+// in the array-like borrow dispatch and stays tracked in #3359 (see the skipped
+// case in tests/issue-2036.test.ts).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+async function runHost(body: string): Promise<unknown> {
+  const r = await compile(body, { fileName: "test.ts" });
+  if (!r.success) throw new Error("compile failed: " + r.errors.map((e) => e.message).join("\n"));
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    env: built.env,
+    string_constants: built.string_constants,
+  });
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+async function runStandalone(body: string): Promise<unknown> {
+  const r = await compile(body, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) throw new Error("compile failed: " + r.errors.map((e) => e.message).join("\n"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+const CASES: { name: string; body: string; expected: number }[] = [
+  {
+    name: "filter threads thisArg (predicate reads this.t)",
+    body: `export function test(): number {
+      const a = [5, 15];
+      const r: any = a.filter(function (this: any, x: number) { return x > this.t; }, { t: 10 });
+      return r.length;
+    }`,
+    expected: 1,
+  },
+  {
+    name: "map threads thisArg",
+    body: `export function test(): number {
+      const a = [1, 2];
+      const r: any = a.map(function (this: any, x: number) { return x + this.t; }, { t: 10 });
+      return (r[0] as number) + (r[1] as number);
+    }`,
+    expected: 23,
+  },
+  {
+    name: "some threads thisArg",
+    body: `export function test(): number {
+      const a = [5, 15];
+      return a.some(function (this: any, x: number) { return x > this.t; }, { t: 10 }) ? 1 : 0;
+    }`,
+    expected: 1,
+  },
+  {
+    name: "every threads thisArg",
+    body: `export function test(): number {
+      const a = [11, 15];
+      return a.every(function (this: any, x: number) { return x > this.t; }, { t: 10 }) ? 1 : 0;
+    }`,
+    expected: 1,
+  },
+  {
+    name: "find threads thisArg",
+    body: `export function test(): number {
+      const a = [5, 15];
+      const r: any = a.find(function (this: any, x: number) { return x > this.t; }, { t: 10 });
+      return r as number;
+    }`,
+    expected: 15,
+  },
+  {
+    name: "findIndex threads thisArg",
+    body: `export function test(): number {
+      const a = [5, 15];
+      return a.findIndex(function (this: any, x: number) { return x > this.t; }, { t: 10 });
+    }`,
+    expected: 1,
+  },
+  {
+    name: "forEach threads thisArg",
+    body: `export function test(): number {
+      const a = [5, 15];
+      let seen = 0;
+      a.forEach(function (this: any, x: number) { if (this.t === 10) seen++; }, { t: 10 });
+      return seen;
+    }`,
+    expected: 2,
+  },
+  {
+    name: "this-param strip preserves user params (index + array still read)",
+    body: `export function test(): number {
+      const a = [10, 20];
+      let s = 0;
+      a.forEach(function (this: any, v: number, i: number) { s += v + i + this.b; }, { b: 100 });
+      return s; // (10+0+100) + (20+1+100) = 231
+    }`,
+    expected: 231,
+  },
+];
+
+describe("#3359 — array-method callbacks thread thisArg into `this` (real-array form)", () => {
+  for (const c of CASES) {
+    it(`host: ${c.name}`, async () => {
+      expect(await runHost(c.body)).toBe(c.expected);
+    });
+    it(`standalone: ${c.name}`, async () => {
+      expect(await runStandalone(c.body)).toBe(c.expected);
+    });
+  }
+});


### PR DESCRIPTION
## #3359 — array-method callbacks drop their `thisArg` (partial: direct-array form)

### Root cause
A TypeScript `this` parameter (`function (this: T, x) {…}`) is a **type-level-only** annotation, but codegen emitted it as a **real leading runtime parameter** of the lifted closure, shifting every user param one slot right. Array methods supply the spec `thisArg` via the `__current_this` global (not a positional arg), so the element value landed in the spurious `this` slot and `thisArg` was dropped — the predicate read `this.<prop>` as `undefined` (`filter` returned 0 instead of 1).

### Fix
New `runtimeParameters()` in `src/codegen/closures.ts` strips a leading TS `this` param from the closure's runtime signature, applied at every signature / param-local / default / destructuring site (`compileArrowAsClosure`, `compileArrowAsCallback`, `computeClosureWrapperSig`, `emitArrowParamDefaults`, `emitClosureParamDestructuring`). A closure **without** a this-param (all JS, incl. every test262 input) gets the original list back — **byte-identical**, so the conformance surface is untouched. `this` then correctly resolves to `__current_this`, which both dispatch paths already install.

Fixes the **direct array-receiver form** — `a.filter` / `.map` / `.some` / `.every` / `.find` / `.findIndex` / `.forEach` with a `thisArg` — on **both** the host/gc and standalone lanes.

### Validation
- `tests/issue-3359.test.ts` — 16 cases (8 shapes × host + standalone), all green.
- Regression smoke: generators, nested closures, default + destructuring params, 3-arg forEach, sort/reduce/filter-map chains — all unchanged.
- No-this closures are byte-identical (guarded strip), so test262 conformance is unaffected.

### Residual (issue stays open)
The borrowed array-like form `Array.prototype.filter.call(o, cb, thisArg)` still binds `this` to the receiver — a **separate, pre-existing** gap in the array-like borrow dispatch (unchanged by this PR; it returned 0 before too). Kept `it.skip`'d in `tests/issue-2036.test.ts` with an updated pointer. #3359 remains open for that arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)