### PR TITLE
feat(porffor): prove shared heap layouts (#3299)

### DIFF
--- a/plan/issues/3299-porffor-heap-layout-proof.md
+++ b/plan/issues/3299-porffor-heap-layout-proof.md
@@ -22,6 +22,11 @@ claimed_by: porffor-codex-developer
 claimed_at: 2026-07-17T16:08:01.435Z
 branch: symphony/porffor/3299
 pr: 3263
+loc-budget-allow:
+  - src/ir/builder.ts
+  - src/ir/lower.ts
+  - src/ir/nodes.ts
+last_ci_retry_head: bf951fe7ddbd208830096214c84584130ae8acce
 ---
 
 # #3299 - Porffor backend P4: heap and layout proof through shared planning

--- a/plan/issues/3299-porffor-heap-layout-proof.md
+++ b/plan/issues/3299-porffor-heap-layout-proof.md
@@ -21,6 +21,7 @@ origin: "#3288 P4 split: independently dispatchable Porffor heap/layout proof"
 claimed_by: porffor-codex-developer
 claimed_at: 2026-07-17T16:08:01.435Z
 branch: symphony/porffor/3299
+pr: 3263
 ---
 
 # #3299 - Porffor backend P4: heap and layout proof through shared planning
@@ -52,7 +53,7 @@ silently depending on Porffor's own object representation.
       covered by stress validation where collection is possible.
 - [x] The Porffor adapter does not reinterpret values as Porffor-native objects
       or call builtins that assume Porffor layouts.
-- [ ] The issue changes are committed, pushed to `origin`, and published as a
+- [x] The issue changes are committed, pushed to `origin`, and published as a
       ready, non-draft PR before completion is reported.
 
 ## Validation

--- a/plan/issues/3299-porffor-heap-layout-proof.md
+++ b/plan/issues/3299-porffor-heap-layout-proof.md
@@ -1,10 +1,10 @@
 ---
 id: 3299
 title: "Porffor backend P4: heap and layout proof through shared planning"
-status: ready
+status: in-review
 sprint: porffor-backend
 created: 2026-07-16
-updated: 2026-07-16
+updated: 2026-07-17
 priority: high
 horizon: l
 feasibility: hard
@@ -18,6 +18,9 @@ parent: 3288
 depends_on: [3298]
 related: [3288, 3297, 3298]
 origin: "#3288 P4 split: independently dispatchable Porffor heap/layout proof"
+claimed_by: porffor-codex-developer
+claimed_at: 2026-07-17T16:08:01.435Z
+branch: symphony/porffor/3299
 ---
 
 # #3299 - Porffor backend P4: heap and layout proof through shared planning
@@ -40,14 +43,14 @@ silently depending on Porffor's own object representation.
 
 ## Acceptance criteria
 
-- [ ] Two aliases observe the same mutation while two equal-looking allocated
+- [x] Two aliases observe the same mutation while two equal-looking allocated
       objects remain non-identical.
-- [ ] Fixed-shape field offsets and vector strides come exclusively from the
+- [x] Fixed-shape field offsets and vector strides come exclusively from the
       shared plan.
-- [ ] Vector bounds and mutation behavior match JavaScript and linear-Wasm.
-- [ ] Root/barrier behavior follows the selected planned runtime policy and is
+- [x] Vector bounds and mutation behavior match JavaScript and linear-Wasm.
+- [x] Root/barrier behavior follows the selected planned runtime policy and is
       covered by stress validation where collection is possible.
-- [ ] The Porffor adapter does not reinterpret values as Porffor-native objects
+- [x] The Porffor adapter does not reinterpret values as Porffor-native objects
       or call builtins that assume Porffor layouts.
 - [ ] The issue changes are committed, pushed to `origin`, and published as a
       ready, non-draft PR before completion is reported.
@@ -69,3 +72,46 @@ silently depending on Porffor's own object representation.
 
 After this PR merges, #3300 must demonstrate that allocation policy can change
 without changing either backend's semantic emitter.
+
+## Implementation record (2026-07-17)
+
+- Extended shared backend handles with each allocation site's canonical
+  `LinearAllocationSitePlan`. The Porffor resolver now requires a completed
+  `LinearMemoryPlan`, verifies each site/layout pairing, and exposes record
+  fields and vector layout operations without re-planning them.
+- Added symbolic Porffor heap expressions/statements and final assembly for the
+  pinned `Alloc`, `Load`, and `Store` nodes. Fixed-shape fields use only planned
+  field offsets; vectors use only planned length/capacity/elements offsets,
+  minimum capacity, allocation size, and element stride. Allocations use type
+  id zero and never invoke Porffor object/array builtins, `jsval`, NaN boxing,
+  native layouts, or parser/codegen paths.
+- Added the typed `vec.set` terminal operation across the backend contract,
+  verifier/effects/ownership passes, WasmGC emitter, linear emitter, and
+  Porffor emitter. Bounds remain explicit in surrounding typed SSA; the
+  terminal performs one planned in-bounds store.
+- Selected the existing `arena-v1` plan policy. Every supported site is
+  non-moving arena allocation with `root:none`, `safepoints:none`, and
+  `barrier:none`; the adapter rejects managed sites, non-arena policies, or a
+  renderer with `prefs.gc` enabled. Therefore no `GcBarrier` is emitted and a
+  managed-collection stress run is inapplicable for this slice.
+- The focused fixture executes one identical typed SSA module through
+  linear-Wasm and rendered Porffor-C, with a JavaScript oracle. Results
+  `[911, 309, 300, 300]` prove alias-visible mutation, identity/non-identity,
+  vector mutation, and negative/high out-of-bounds reads.
+
+Validation completed:
+
+- `IR_VERIFY_ALLOC=1 pnpm exec vitest run tests/issue-3299.test.ts tests/issue-3298.test.ts tests/issue-3297.test.ts tests/issue-3288.test.ts tests/backend-contract.test.ts tests/ir-vec-two-backend.test.ts tests/ir/alloc-registry.test.ts tests/ir/alloc-provenance.test.ts --reporter=dot`
+  (8 files, 56 tests passed)
+- `pnpm exec vitest run tests/issue-3297.test.ts tests/issue-3298.test.ts tests/issue-3299.test.ts`
+  (3 files, 11 tests passed, including Porffor-C rendering compiled with
+  warnings as errors)
+- `npx --yes tsx scripts/prove-emit-identity.mjs check --baseline .tmp/emit-identity-3299.json`
+  (all 56 file/target outcomes identical to the clean pre-change
+  `origin/main` baseline)
+- `pnpm run build`
+- `pnpm run typecheck`
+- focused `biome lint` over changed IR/backend/tests
+- `pnpm run check:pushraw` (79 call sites, one fewer than merge-base)
+- `pnpm run check:linear-ir`
+- `pnpm run check:ir-fallbacks`

--- a/src/ir/analysis/ownership.ts
+++ b/src/ir/analysis/ownership.ts
@@ -260,6 +260,10 @@ function applyInstrEffect(instr: IrInstr, state: State, allocOf: Map<IrValueId, 
       touch(state, instr.cell, allocOf, null, "write");
       markEscaped(state, instr.value, allocOf);
       break;
+    case "vec.set":
+      touch(state, instr.vec, allocOf, null, "write");
+      markEscaped(state, instr.newValue, allocOf);
+      break;
 
     // --- read-modify-write -> `mutate` ---------------------------------------
     // (no dedicated RMW instr in Phase-1 IR; reserved for when one lands.)

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -679,6 +679,9 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
   emitElemGet(): void {
     throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }
+  emitElemSet(): void {
+    throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
+  }
   emitVecNewFixed(): void {
     throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }

--- a/src/ir/backend/contract-conformance.ts
+++ b/src/ir/backend/contract-conformance.ts
@@ -98,6 +98,9 @@ export class StubEmitter implements BackendEmitter<StubSink> {
   emitElemGet(_layout: StubVecLayout, out: StubSink): void {
     out.push("elem.get");
   }
+  emitElemSet(_layout: StubVecLayout, _scratch: number, out: StubSink): void {
+    out.push("elem.set");
+  }
   emitVecNewFixed(_layout: StubVecLayout, count: number, _scratch: number, out: StubSink): void {
     out.push(`vec.new_fixed:${count}`);
   }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -102,6 +102,12 @@ export interface BackendEmitter<S = Instr[]> {
   /** data-region handle + i32 index on stack -> element value. */
   emitElemGet(layout: VecLayout, out: S): void;
   /**
+   * data-region handle + i32 index + element value on stack -> in-place store.
+   * `valueScratchLocal` is an element-typed local available to backends whose
+   * address calculation must temporarily move the topmost value.
+   */
+  emitElemSet(layout: VecLayout, valueScratchLocal: number, out: S): void;
+  /**
    * #1804 — N element values on the stack (e0 deepest … eN top) -> a fully
    * built vec ref. WasmGC: `array.new_fixed $arr N`, stash the data ref in
    * `dataScratchLocal`, push `i32.const N` (length, field 0), re-load the data

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -23,6 +23,7 @@
 import type { Instr, ValType } from "../types.js";
 import type { JsTag } from "../../codegen/js-tag.js";
 import type {
+  LinearAllocationSitePlan,
   LinearRecordLayoutPlan,
   LinearRuntimeOperation,
   LinearVectorLayoutPlan,
@@ -86,16 +87,26 @@ export interface LinearMemoryFieldLowering {
  * the linear emitter consumes this additive metadata and never interprets
  * the sentinel type index as a WasmGC type.
  */
-export interface LinearObjectLowering extends IrObjectStructLowering {
-  readonly linearMemory: {
-    /** Canonical target-neutral layout consumed by this backend handle. */
-    readonly layout: LinearRecordLayoutPlan;
-    /** Still symbolic until the linear module adapter assembles the helper. */
-    readonly allocate: LinearRuntimeOperation;
+export interface PlannedObjectMemoryLowering {
+  /** Canonical per-site allocation decision; absent on read/write-only handles. */
+  readonly allocation?: LinearAllocationSitePlan;
+  /** Canonical target-neutral layout consumed by every linear-memory backend. */
+  readonly layout: LinearRecordLayoutPlan;
+  /** Still symbolic until the selected backend binds its allocator. */
+  readonly allocate: LinearRuntimeOperation;
+  readonly fieldCount: number;
+  field(name: string): LinearMemoryFieldLowering;
+}
+
+/** Shared-plan record handle consumed by linear-Wasm and Porffor IR. */
+export interface PlannedObjectLowering extends IrObjectStructLowering {
+  readonly linearMemory: PlannedObjectMemoryLowering;
+}
+
+export interface LinearObjectLowering extends PlannedObjectLowering {
+  readonly linearMemory: PlannedObjectMemoryLowering & {
     /** Deferred helper `(field0, ...fieldN) -> i32` appended after user slots. */
     readonly newFuncIdx: number;
-    readonly fieldCount: number;
-    field(name: string): LinearMemoryFieldLowering;
   };
 }
 
@@ -429,6 +440,8 @@ export interface LinearVecLowering {
   /** Element ValType — drives stride (4 vs 8) and the load op. */
   readonly elementValType: ValType;
   readonly linearMemory: {
+    /** Canonical per-site decision; absent on read/write-only handles. */
+    readonly allocation?: LinearAllocationSitePlan;
     readonly layout: LinearVectorLayoutPlan;
     readonly allocate: LinearRuntimeOperation;
     readonly initializeElement: LinearRuntimeOperation;

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -131,6 +131,7 @@ function linearInstrError(instr: IrInstr): string | null {
     case "vec.new_fixed":
     case "vec.len":
     case "vec.get":
+    case "vec.set":
     case "while.loop":
     case "for.loop":
     // #2952 slice 2 — br.label lowers to a core-Wasm `br` (depth derived by
@@ -225,8 +226,15 @@ function porfforInstrError(instr: IrInstr): string | null {
     case "call":
     case "global.get":
     case "global.set":
+    case "object.new":
+    case "object.get":
+    case "object.set":
     case "slot.read":
     case "slot.write":
+    case "vec.new_fixed":
+    case "vec.len":
+    case "vec.get":
+    case "vec.set":
     case "select":
     case "if":
     case "early.return":
@@ -291,9 +299,20 @@ function backendTypeError(backend: IrBackendKind, type: IrType): string | null {
     if (!v) return `bytecode backend does not support IR type '${type.kind}'`;
     return bytecodeValTypeError(v);
   }
+  if (type.kind === "object") return porfforAggregateTypeError(type);
   const v = asVal(type);
   if (!v) return `porffor backend does not support IR type '${type.kind}'`;
   return porfforValTypeError(v);
+}
+
+function porfforAggregateTypeError(type: Extract<IrType, { kind: "object" }>): string | null {
+  for (const field of type.shape.fields) {
+    const value = asVal(field.type);
+    if (!value || (value.kind !== "i32" && value.kind !== "f64")) {
+      return `porffor backend does not support aggregate field IR type '${field.type.kind}'`;
+    }
+  }
+  return null;
 }
 
 function linearAggregateTypeError(type: Extract<IrType, { kind: "object" }>): string | null {

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -193,6 +193,24 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     } as Instr); // computed-op
   }
 
+  emitElemSet(layout: LinearVecLowering, valueScratchLocal: number, out: Instr[]): void {
+    const linear = asLinearVec(layout);
+    const stride = linear.linearMemory.layout.elementStride;
+    if (layout.elementValType.kind !== "f64" && layout.elementValType.kind !== "i32") {
+      throw new Error(`LinearEmitter: unsupported vec.set element type '${layout.elementValType.kind}'`);
+    }
+    out.push({ op: "local.set", index: valueScratchLocal });
+    out.push({ op: "i32.const", value: stride });
+    out.push({ op: "i32.mul" });
+    out.push({ op: "i32.add" });
+    out.push({ op: "local.get", index: valueScratchLocal });
+    out.push({
+      op: layout.elementValType.kind === "f64" ? "f64.store" : "i32.store",
+      align: stride === 8 ? 3 : 2,
+      offset: 0,
+    });
+  }
+
   // #1804 / #2956 L2 — fixed number-array construction. `lower.ts` has already
   // pushed e0...eN. Allocate the canonical linear array, then consume values
   // from the top of the stack and store each at its original index through the

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -459,7 +459,7 @@ function makeLinearIrResolver(
       dataFieldIdx: 0,
       arrayTypeIdx: 0,
       elementValType: { kind: "f64" },
-      linearMemory: { layout, allocate, initializeElement },
+      linearMemory: { allocation, layout, allocate, initializeElement },
     };
   };
 
@@ -612,6 +612,7 @@ function makeLinearIrResolver(
           return field.fieldIdx;
         },
         linearMemory: {
+          allocation,
           layout,
           allocate,
           newFuncIdx,

--- a/src/ir/backend/porffor/assembler.ts
+++ b/src/ir/backend/porffor/assembler.ts
@@ -1,10 +1,20 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
 import type { ModuleLayout } from "../../../emit/resolve-layout.js";
-import type { IrFunction, IrFuncRef, IrGlobalRef, IrTypeRef } from "../../nodes.js";
+import type { LinearMemoryPlan, LinearRuntimeOperation, LinearStorageKind } from "../../analysis/linear-memory-plan.js";
+import {
+  irVal,
+  type AllocSiteId,
+  type IrFunction,
+  type IrFuncRef,
+  type IrGlobalRef,
+  type IrObjectShape,
+  type IrTypeRef,
+} from "../../nodes.js";
 import type { IrLoweredBody, IrLowerResolver } from "../../lower.js";
 import type { FuncHandle, FuncTypeDef, GlobalHandle, TypeHandle, ValType } from "../../types.js";
 import type { ModuleAssembler } from "../contract.js";
+import type { IrVecLowering, LinearMemoryFieldLowering, LinearVecLowering, PlannedObjectLowering } from "../handles.js";
 import {
   PORFFOR_EFFECT_ENTRIES,
   PORFFOR_KIND_NAMES,
@@ -98,6 +108,14 @@ export class PorfforModuleAssembler
   private frozen = false;
   private finalInput: PorfforRendererInput | null = null;
   private preferences: Readonly<Record<string, unknown>> = { gc: false };
+  private memoryPlan: LinearMemoryPlan | undefined;
+  private readonly objects = new Map<string, PlannedObjectLowering>();
+
+  bindMemoryPlan(plan: LinearMemoryPlan): void {
+    this.assertMutable("bind memory plan");
+    if (this.memoryPlan) throw new Error("porffor assembler: memory plan already bound");
+    this.memoryPlan = plan;
+  }
 
   setPreferences(preferences: Readonly<Record<string, unknown>>): void {
     this.assertMutable("set preferences");
@@ -286,6 +304,61 @@ export class PorfforModuleAssembler
     throw new Error("porffor backend does not intern Wasm function types");
   }
 
+  resolveObject(shape: IrObjectShape, alloc?: AllocSiteId): PlannedObjectLowering | null {
+    const plan = this.requireMemoryPlan();
+    const layout = plan.layoutForObjectShape(shape);
+    if (!layout) throw new Error("porffor assembler: object layout is absent from the shared memory plan");
+    const allocation = this.allocationFor(layout.id, alloc);
+    const allocate = plannedOperation(
+      allocation.operations,
+      (operation) => operation.family === "memory" && operation.operation === "allocate",
+      `record allocation for '${layout.id}'`,
+    );
+    const cacheKey = `${layout.id}:${allocation.id as number}`;
+    const cached = this.objects.get(cacheKey);
+    if (cached) return cached;
+
+    const fields = shape.fields.map((field, fieldIdx) => {
+      const planned = layout.fields.find((candidate) => candidate.name === field.name);
+      if (!planned) throw new Error(`porffor assembler: object layout has no field '${field.name}'`);
+      const type = memoryValType(planned.storage);
+      if (!type) {
+        throw new Error(`porffor assembler: object field '${field.name}' has unsupported '${planned.storage}' storage`);
+      }
+      return { name: field.name, fieldIdx, offset: planned.offset, type };
+    });
+    const fieldsByName = new Map(fields.map((field) => [field.name, field]));
+    const lowering: PlannedObjectLowering = {
+      typeIdx: 0,
+      fieldIdx(name: string): number {
+        const field = fieldsByName.get(name);
+        if (!field) throw new Error(`porffor assembler: object shape has no field '${name}'`);
+        return field.fieldIdx;
+      },
+      linearMemory: {
+        allocation,
+        layout,
+        allocate,
+        fieldCount: fields.length,
+        field(name: string): LinearMemoryFieldLowering {
+          const field = fieldsByName.get(name);
+          if (!field) throw new Error(`porffor assembler: object shape has no field '${name}'`);
+          return field;
+        },
+      },
+    };
+    this.objects.set(cacheKey, lowering);
+    return lowering;
+  }
+
+  resolveVec(valType: ValType): IrVecLowering | null {
+    return valType.kind === "i32" ? this.f64VecHandle() : null;
+  }
+
+  resolveVecForElement(elementValType: ValType, alloc?: AllocSiteId): IrVecLowering | null {
+    return elementValType.kind === "f64" ? this.f64VecHandle(alloc) : null;
+  }
+
   functionSymbol(handle: number): PorfforFunctionSymbol {
     const entry = this.requireFunc(handle);
     if (!entry.signature) throw new Error(`porffor assembler: function '${entry.name}' has no registered signature`);
@@ -387,6 +460,24 @@ export class PorfforModuleAssembler
           }
           break;
         }
+        case "store": {
+          const pointer = this.assembleExpr(statement.pointer, locals);
+          const value = this.assembleExpr(statement.value, locals);
+          out.push(
+            node("Store", "none", pointer[2] | value[2] | PORFFOR_FX.writeMem, statement.ctype, pointer, [
+              statement.offset,
+              false,
+              value,
+            ]),
+          );
+          break;
+        }
+        case "gc-barrier": {
+          const pointer = this.assembleExpr(statement.pointer, locals);
+          const typeId = this.assembleExpr(statement.typeId, locals);
+          out.push(node("GcBarrier", "none", pointer[2] | typeId[2] | PORFFOR_FX.writeMem, pointer, typeId, 0));
+          break;
+        }
         case "return": {
           const value = statement.value ? this.assembleExpr(statement.value, locals) : null;
           out.push(node("Return", "none", value?.[2] ?? PORFFOR_FX.none, value, 0, 0));
@@ -448,6 +539,17 @@ export class PorfforModuleAssembler
         const value = this.assembleExpr(expression.value, locals);
         return node("Convert", type, value[2], value[1], value, expression.flags);
       }
+      case "alloc": {
+        const bytes = this.assembleExpr(expression.bytes, locals);
+        return node("Alloc", "ptr", bytes[2] | PORFFOR_FX.call, bytes, expression.typeId, [expression.siteId, false]);
+      }
+      case "load": {
+        const pointer = this.assembleExpr(expression.pointer, locals);
+        return node("Load", type, pointer[2] | PORFFOR_FX.readMem, expression.ctype, pointer, [
+          expression.offset,
+          false,
+        ]);
+      }
       case "call": {
         const symbol = this.functionSymbol(expression.target);
         const args = expression.args.map((arg) => this.assembleExpr(arg, locals));
@@ -472,6 +574,53 @@ export class PorfforModuleAssembler
 
   private oneSlot(type: Parameters<PorfforTypeConverter["convertType"]>[0], where: string): PorfforValueSlot {
     return oneLoweredSlot(this.typeConverter.convertType(type), where);
+  }
+
+  private requireMemoryPlan(): LinearMemoryPlan {
+    if (!this.memoryPlan) throw new Error("porffor assembler: heap lowering requires a shared LinearMemoryPlan");
+    return this.memoryPlan;
+  }
+
+  private allocationFor(layoutId: string, alloc?: AllocSiteId) {
+    const plan = this.requireMemoryPlan();
+    if (alloc === undefined) {
+      const allocation = plan.allocationsForLayout(layoutId)[0];
+      if (!allocation) throw new Error(`porffor assembler: plan has no allocation for '${layoutId}'`);
+      return allocation;
+    }
+    const allocation = plan.allocation(alloc);
+    if (!allocation) throw new Error(`porffor assembler: allocation site ${alloc as number} is absent from the plan`);
+    if (allocation.layoutId !== layoutId) {
+      throw new Error(
+        `porffor assembler: allocation site ${alloc as number} planned '${allocation.layoutId}', expected '${layoutId}'`,
+      );
+    }
+    return allocation;
+  }
+
+  private f64VecHandle(alloc?: AllocSiteId): IrVecLowering & LinearVecLowering {
+    const plan = this.requireMemoryPlan();
+    const layout = plan.layoutForVector(irVal({ kind: "f64" }));
+    if (!layout) throw new Error("porffor assembler: f64 vector layout is absent from the shared memory plan");
+    const allocation = this.allocationFor(layout.id, alloc);
+    const allocate = plannedOperation(
+      allocation.operations,
+      (operation) => operation.family === "vector" && operation.operation === "allocate",
+      `vector allocation for '${layout.id}'`,
+    );
+    const initializeElement = plannedOperation(
+      allocation.operations,
+      (operation) => operation.family === "vector" && operation.operation === "initialize-element",
+      `vector element initialization for '${layout.id}'`,
+    );
+    return {
+      vecStructTypeIdx: 0,
+      lengthFieldIdx: 0,
+      dataFieldIdx: 0,
+      arrayTypeIdx: 0,
+      elementValType: { kind: "f64" },
+      linearMemory: { allocation, layout, allocate, initializeElement },
+    };
   }
 
   private bindTypeName(name: string, entry: TypeEntry): void {
@@ -500,6 +649,22 @@ export class PorfforModuleAssembler
 function oneLoweredSlot(slots: readonly PorfforValueSlot[], where: string): PorfforValueSlot {
   if (slots.length !== 1) throw new Error(`porffor backend requires exactly one scalar slot for ${where}`);
   return slots[0]!;
+}
+
+function memoryValType(storage: LinearStorageKind): ValType | null {
+  if (storage === "f64") return { kind: "f64" };
+  if (storage === "i32" || storage === "pointer") return { kind: "i32" };
+  return null;
+}
+
+function plannedOperation(
+  operations: readonly LinearRuntimeOperation[],
+  predicate: (operation: LinearRuntimeOperation) => boolean,
+  label: string,
+): LinearRuntimeOperation {
+  const operation = operations.find(predicate);
+  if (!operation) throw new Error(`porffor assembler: shared plan has no ${label}`);
+  return operation;
 }
 
 function assembleBranch(depth: number, frames: readonly ControlFrame[]): PorfforNode {

--- a/src/ir/backend/porffor/integration.ts
+++ b/src/ir/backend/porffor/integration.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 
-import type { IrModule, IrType } from "../../nodes.js";
+import type { LinearMemoryPlan } from "../../analysis/linear-memory-plan.js";
+import { forEachInstrDeep, type IrModule, type IrType } from "../../nodes.js";
 import { lowerIrFunctionBody } from "../../lower.js";
 import { verifyIrBackendLegality } from "../legality.js";
 import type { PorfforRendererInput } from "./compat.js";
@@ -18,6 +19,8 @@ export interface LowerIrModuleToPorfforOptions {
   /** Renderer entry name. Null/omitted emits no C main, useful for embedding/tests. */
   readonly entry?: string | null;
   readonly prefs?: Readonly<Record<string, unknown>>;
+  /** Target-neutral layout/allocation authority required by heap instructions. */
+  readonly memoryPlan?: LinearMemoryPlan;
 }
 
 /**
@@ -33,6 +36,40 @@ export function lowerIrModuleToPorffor(
   const assembler = new PorfforModuleAssembler();
   const types = new PorfforTypeConverter();
   assembler.setPreferences(options.prefs ?? {});
+
+  const hasPlannedHeap = module.functions.some((func) =>
+    func.blocks.some((block) =>
+      block.instrs.some((instr) => {
+        let found = false;
+        forEachInstrDeep(instr, (nested) => {
+          if (
+            nested.kind === "object.new" ||
+            nested.kind === "object.get" ||
+            nested.kind === "object.set" ||
+            nested.kind === "vec.new_fixed" ||
+            nested.kind === "vec.len" ||
+            nested.kind === "vec.get" ||
+            nested.kind === "vec.set"
+          ) {
+            found = true;
+          }
+        });
+        return found;
+      }),
+    ),
+  );
+  if (hasPlannedHeap && !options.memoryPlan) {
+    throw new Error("porffor backend heap lowering requires a shared LinearMemoryPlan");
+  }
+  if (options.memoryPlan) {
+    if (options.memoryPlan.policy !== "arena-v1") {
+      throw new Error(`porffor backend P4 supports the arena-v1 memory policy, got '${options.memoryPlan.policy}'`);
+    }
+    if (options.prefs?.gc !== undefined && options.prefs.gc !== false) {
+      throw new Error("porffor backend arena-v1 requires prefs.gc=false because planned pointers are not GC roots");
+    }
+    assembler.bindMemoryPlan(options.memoryPlan);
+  }
 
   for (const global of options.globals ?? []) {
     const slots = types.convertType(global.type);

--- a/src/ir/backend/porffor/sink.ts
+++ b/src/ir/backend/porffor/sink.ts
@@ -2,6 +2,7 @@
 
 import type { IrBinop, IrInstr, IrType, IrUnop } from "../../nodes.js";
 import { asVal } from "../../nodes.js";
+import type { LinearAllocationSitePlan } from "../../analysis/linear-memory-plan.js";
 import type { BlockType, Instr } from "../../types.js";
 import type { BackendEmitter } from "../emitter.js";
 import type {
@@ -11,6 +12,7 @@ import type {
   IrRefCellLowering,
   IrVecLowering,
   LinearVecLowering,
+  PlannedObjectLowering,
 } from "../handles.js";
 import type { PorfforValueSlot } from "./type-converter.js";
 
@@ -32,6 +34,8 @@ export type PorfforTypeRef =
   | PorfforValueSlot
   | { readonly kind: "local"; readonly local: PorfforLocalRef }
   | { readonly kind: "global"; readonly handle: number };
+
+export type PorfforMemoryCType = "i32" | "u32" | "f64";
 
 interface PorfforExprBase {
   readonly type: PorfforTypeRef;
@@ -61,6 +65,18 @@ export type PorfforExpr =
       readonly value: PorfforExpr;
       readonly flags: number;
     })
+  | (PorfforExprBase & {
+      readonly kind: "alloc";
+      readonly bytes: PorfforExpr;
+      readonly typeId: number;
+      readonly siteId: number;
+    })
+  | (PorfforExprBase & {
+      readonly kind: "load";
+      readonly ctype: PorfforMemoryCType;
+      readonly pointer: PorfforExpr;
+      readonly offset: number;
+    })
   | (PorfforExprBase & { readonly kind: "call"; readonly target: number; readonly args: readonly PorfforExpr[] });
 
 export type PorfforTarget =
@@ -80,6 +96,14 @@ export type PorfforStatement =
   | { readonly kind: "block"; readonly controlId: number; readonly body: readonly PorfforStatement[] }
   | { readonly kind: "loop"; readonly controlId: number; readonly body: readonly PorfforStatement[] }
   | { readonly kind: "branch"; readonly depth: number; readonly condition?: PorfforExpr }
+  | {
+      readonly kind: "store";
+      readonly ctype: PorfforMemoryCType;
+      readonly pointer: PorfforExpr;
+      readonly offset: number;
+      readonly value: PorfforExpr;
+    }
+  | { readonly kind: "gc-barrier"; readonly pointer: PorfforExpr; readonly typeId: PorfforExpr }
   | { readonly kind: "return"; readonly value: PorfforExpr | null }
   | { readonly kind: "unreachable" };
 
@@ -215,6 +239,74 @@ function irTypeSlot(type: IrType): PorfforValueSlot {
 }
 
 type VecLayout = IrVecLowering | LinearVecLowering;
+
+function asPlannedObject(layout: IrObjectStructLowering | IrClassLowering): PlannedObjectLowering {
+  if (!("linearMemory" in layout)) {
+    throw new Error("porffor backend requires a shared linear-memory object handle");
+  }
+  return layout as PlannedObjectLowering;
+}
+
+function asPlannedVec(layout: VecLayout): LinearVecLowering {
+  if (!("linearMemory" in layout)) {
+    throw new Error("porffor backend requires a shared linear-memory vector handle");
+  }
+  return layout;
+}
+
+function memoryCType(type: { readonly kind: string }): PorfforMemoryCType {
+  if (type.kind === "f64") return "f64";
+  if (type.kind === "i32") return "i32";
+  throw new Error(`porffor backend does not support planned memory value type '${type.kind}'`);
+}
+
+function allocateExpr(bytes: number, siteId: number): PorfforExpr {
+  const size: PorfforExpr = { kind: "const", type: "u32", effects: PORFFOR_FX.none, value: bytes };
+  return {
+    kind: "alloc",
+    type: "ptr",
+    effects: PORFFOR_FX.call,
+    bytes: size,
+    // Type id zero is deliberately representation-neutral in the selected
+    // non-collecting arena. No Porffor object/array type is claimed here.
+    typeId: 0,
+    siteId,
+  };
+}
+
+function requireArenaAllocation(
+  allocation: LinearAllocationSitePlan | undefined,
+  family: string,
+): LinearAllocationSitePlan & { readonly size: { readonly kind: "constant"; readonly bytes: number } } {
+  if (!allocation) throw new Error(`porffor backend requires a planned allocation site for ${family}`);
+  if (allocation.allocationClass !== "arena") {
+    throw new Error(`porffor backend P4 supports arena allocation only; site ${allocation.id as number} is managed`);
+  }
+  if (allocation.size.kind !== "constant") {
+    throw new Error(`porffor backend requires a constant planned allocation size for ${family}`);
+  }
+  if (allocation.root.kind !== "none" || allocation.safepoints.kind !== "none" || allocation.barrier.kind !== "none") {
+    throw new Error(
+      `porffor arena allocation site ${allocation.id as number} unexpectedly requires roots, safepoints, or barriers`,
+    );
+  }
+  return allocation as LinearAllocationSitePlan & {
+    readonly size: { readonly kind: "constant"; readonly bytes: number };
+  };
+}
+
+function addPointerOffset(pointer: PorfforExpr, offset: number): PorfforExpr {
+  if (offset === 0) return pointer;
+  return {
+    kind: "binary",
+    type: "ptr",
+    effects: pointer.effects,
+    op: "+",
+    left: pointer,
+    right: { kind: "const", type: "u32", effects: PORFFOR_FX.none, value: offset },
+    comparison: false,
+  };
+}
 
 /** Scalar/control-flow BackendEmitter implementation for Porffor's tree IR. */
 export class PorfforEmitter implements BackendEmitter<PorfforSink> {
@@ -428,17 +520,110 @@ export class PorfforEmitter implements BackendEmitter<PorfforSink> {
     else throw new Error(`porffor backend does not support multi-value call '${symbol.name}'`);
   }
 
-  emitVecLen(_layout: VecLayout, _out: PorfforSink): void {
-    this.unsupported("vec.len");
+  emitVecLen(layout: VecLayout, out: PorfforSink): void {
+    const planned = asPlannedVec(layout).linearMemory.layout;
+    const pointer = out.pop("vec.len");
+    out.push({
+      kind: "load",
+      type: "i32",
+      effects: pointer.effects | PORFFOR_FX.readMem,
+      ctype: "u32",
+      pointer,
+      offset: planned.lengthOffset,
+    });
   }
-  emitVecDataPtr(_layout: VecLayout, _out: PorfforSink): void {
-    this.unsupported("vec data pointer");
+  emitVecDataPtr(layout: VecLayout, out: PorfforSink): void {
+    const planned = asPlannedVec(layout).linearMemory.layout;
+    out.push(addPointerOffset(out.pop("vec data pointer"), planned.elementsOffset));
   }
-  emitElemGet(_layout: VecLayout, _out: PorfforSink): void {
-    this.unsupported("element get");
+  emitElemGet(layout: VecLayout, out: PorfforSink): void {
+    const planned = asPlannedVec(layout).linearMemory.layout;
+    const [data, index] = out.popMany(2, "element get");
+    const scaled: PorfforExpr = {
+      kind: "binary",
+      type: "u32",
+      effects: index!.effects,
+      op: "*",
+      left: index!,
+      right: { kind: "const", type: "u32", effects: PORFFOR_FX.none, value: planned.elementStride },
+      comparison: false,
+    };
+    const pointer: PorfforExpr = {
+      kind: "binary",
+      type: "ptr",
+      effects: data!.effects | scaled.effects,
+      op: "+",
+      left: data!,
+      right: scaled,
+      comparison: false,
+    };
+    out.push({
+      kind: "load",
+      type: irTypeSlot({ kind: "val", val: layout.elementValType }),
+      effects: pointer.effects | PORFFOR_FX.readMem,
+      ctype: memoryCType(layout.elementValType),
+      pointer,
+      offset: 0,
+    });
   }
-  emitVecNewFixed(_layout: VecLayout, _count: number, _scratch: number, _out: PorfforSink): void {
-    this.unsupported("vec.new_fixed");
+  emitElemSet(layout: VecLayout, _valueScratch: number, out: PorfforSink): void {
+    const planned = asPlannedVec(layout).linearMemory.layout;
+    const [data, index, value] = out.sequence(out.popMany(3, "element set"));
+    const scaled: PorfforExpr = {
+      kind: "binary",
+      type: "u32",
+      effects: index!.effects,
+      op: "*",
+      left: index!,
+      right: { kind: "const", type: "u32", effects: PORFFOR_FX.none, value: planned.elementStride },
+      comparison: false,
+    };
+    out.append({
+      kind: "store",
+      ctype: memoryCType(layout.elementValType),
+      pointer: {
+        kind: "binary",
+        type: "ptr",
+        effects: data!.effects | scaled.effects,
+        op: "+",
+        left: data!,
+        right: scaled,
+        comparison: false,
+      },
+      offset: 0,
+      value: value!,
+    });
+  }
+  emitVecNewFixed(layout: VecLayout, count: number, _scratch: number, out: PorfforSink): void {
+    const linear = asPlannedVec(layout).linearMemory;
+    const allocation = requireArenaAllocation(linear.allocation, "vec.new_fixed");
+    const elements = out.sequence(out.popMany(count, "vec.new_fixed elements"));
+    const [pointer] = out.sequence([allocateExpr(allocation.size.bytes, allocation.id as number)]);
+    const capacity = Math.max(count, linear.layout.minimumCapacity);
+    out.append({
+      kind: "store",
+      ctype: "u32",
+      pointer: pointer!,
+      offset: linear.layout.lengthOffset,
+      value: { kind: "const", type: "u32", effects: PORFFOR_FX.none, value: count },
+    });
+    out.append({
+      kind: "store",
+      ctype: "u32",
+      pointer: pointer!,
+      offset: linear.layout.capacityOffset,
+      value: { kind: "const", type: "u32", effects: PORFFOR_FX.none, value: capacity },
+    });
+    elements.forEach((value, index) => {
+      out.append({
+        kind: "store",
+        ctype: memoryCType(layout.elementValType),
+        pointer: pointer!,
+        offset: linear.layout.elementsOffset + index * linear.layout.elementStride,
+        value,
+      });
+    });
+    out.push(pointer!);
   }
   emitNull(_type: IrType, _out: PorfforSink): void {
     this.unsupported("null/reference values");
@@ -467,14 +652,48 @@ export class PorfforEmitter implements BackendEmitter<PorfforSink> {
   emitCallRef(_typeIdx: number, _out: PorfforSink): void {
     this.unsupported("indirect calls");
   }
-  emitAggregateNew(_layout: IrObjectStructLowering, _fieldCount: number, _out: PorfforSink): void {
-    this.unsupported("heap aggregate allocation");
+  emitAggregateNew(layout: IrObjectStructLowering, fieldCount: number, out: PorfforSink): void {
+    const linear = asPlannedObject(layout).linearMemory;
+    if (fieldCount !== linear.fieldCount) {
+      throw new Error(`porffor backend aggregate arity mismatch (expected ${linear.fieldCount}, got ${fieldCount})`);
+    }
+    const allocation = requireArenaAllocation(linear.allocation, "object.new");
+    const values = out.sequence(out.popMany(fieldCount, "object.new fields"));
+    const [pointer] = out.sequence([allocateExpr(allocation.size.bytes, allocation.id as number)]);
+    linear.layout.fields.forEach((field, index) => {
+      const memory = linear.field(field.name);
+      out.append({
+        kind: "store",
+        ctype: memoryCType(memory.type),
+        pointer: pointer!,
+        offset: field.offset,
+        value: values[index]!,
+      });
+    });
+    out.push(pointer!);
   }
-  emitFieldGet(_layout: IrObjectStructLowering | IrClassLowering, _name: string, _out: PorfforSink): void {
-    this.unsupported("heap field read");
+  emitFieldGet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: PorfforSink): void {
+    const field = asPlannedObject(layout).linearMemory.field(name);
+    const pointer = out.pop(`field read ${name}`);
+    out.push({
+      kind: "load",
+      type: irTypeSlot({ kind: "val", val: field.type }),
+      effects: pointer.effects | PORFFOR_FX.readMem,
+      ctype: memoryCType(field.type),
+      pointer,
+      offset: field.offset,
+    });
   }
-  emitFieldSet(_layout: IrObjectStructLowering | IrClassLowering, _name: string, _out: PorfforSink): void {
-    this.unsupported("heap field write");
+  emitFieldSet(layout: IrObjectStructLowering | IrClassLowering, name: string, out: PorfforSink): void {
+    const field = asPlannedObject(layout).linearMemory.field(name);
+    const [pointer, value] = out.sequence(out.popMany(2, `field write ${name}`));
+    out.append({
+      kind: "store",
+      ctype: memoryCType(field.type),
+      pointer: pointer!,
+      offset: field.offset,
+      value: value!,
+    });
   }
   emitThrow(_tagIdx: number, _out: PorfforSink): void {
     this.unsupported("throw");

--- a/src/ir/backend/porffor/type-converter.ts
+++ b/src/ir/backend/porffor/type-converter.ts
@@ -9,13 +9,14 @@ import type { TypeConverter } from "../contract.js";
  * P2's module adapter maps these names to the compatibility-checked ordinals
  * only at final Porffor assembly time.
  */
-export type PorfforValueSlot = "f64" | "i32" | "u32" | "i64" | "u64";
+export type PorfforValueSlot = "f64" | "i32" | "u32" | "i64" | "u64" | "ptr";
 
 /** Narrow scalar converter matching the P1 Porffor legality profile. */
 export class PorfforTypeConverter implements TypeConverter<PorfforValueSlot> {
   readonly backend = "porffor" as const;
 
   convertType(type: IrType): readonly PorfforValueSlot[] {
+    if (type.kind === "object") return ["ptr"];
     const value = asVal(type);
     if (!value) {
       throw new Error(`porffor backend does not support IR type '${type.kind}'`);
@@ -28,6 +29,11 @@ export class PorfforTypeConverter implements TypeConverter<PorfforValueSlot> {
         return [type.kind === "val" && type.signed === false ? "u32" : "i32"];
       case "i64":
         return [type.kind === "val" && type.signed === false ? "u64" : "i64"];
+      case "ref":
+      case "ref_null":
+        // Only backend-created vec scratch locals reach this arm in P4. JS2
+        // heap values themselves remain explicit linear-memory pointers.
+        return ["ptr"];
       default:
         throw new Error(`porffor backend does not support ValType '${value.kind}'`);
     }

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -61,6 +61,10 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
     out.push({ op: "array.get", typeIdx: layout.arrayTypeIdx });
   }
 
+  emitElemSet(layout: IrVecLowering, _valueScratchLocal: number, out: Instr[]): void {
+    out.push({ op: "array.set", typeIdx: layout.arrayTypeIdx });
+  }
+
   // #1804 — build a fixed-length vec from N element values already on the
   // stack (e0 deepest … eN top). Mirrors the legacy `compileArrayLiteral` fast
   // path (src/codegen/literals.ts): the vec struct is { length:i32,

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -1295,6 +1295,18 @@ export class IrFunctionBuilder {
     return result;
   }
 
+  /** Store one value into a planned dense-vector element. */
+  emitVecSet(vec: IrValueId, indexI32: IrValueId, newValue: IrValueId): void {
+    this.pushInstr({
+      kind: "vec.set",
+      vec,
+      index: indexI32,
+      newValue,
+      result: null,
+      resultType: null,
+    });
+  }
+
   /** Construct a fixed vec whose result uses the resolver's `vecRefType`, so
    * downstream `vec.get`/`.length`/`for-of` reads retain the same identity. */
   emitVecNewFixed(elements: readonly IrValueId[], elementType: IrType, vecRefType: IrType): IrValueId {

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -149,6 +149,7 @@ export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new M
     case "object.set":
     case "class.set":
     case "refcell.set":
+    case "vec.set":
       fx.writesHeap = true;
       break;
     // Call-like: may read AND write arbitrary heap state. `extern.prop` can

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -855,6 +855,16 @@ export function lowerIrFunctionBody<S, Slot>(
     vecNewFixedDataScratch.set(arrayTypeIdx, idx);
     return idx;
   };
+  const vecElementScratch = new Map<string, number>();
+  const ensureVecElementScratch = (type: ValType): number => {
+    const key = `${type.kind}:${"typeIdx" in type ? type.typeIdx : ""}`;
+    const existing = vecElementScratch.get(key);
+    if (existing !== undefined) return existing;
+    const idx = func.params.length + locals.length;
+    locals.push({ name: `$vec_element_${key}`, type, logicalType: { kind: "val", val: type } });
+    vecElementScratch.set(key, idx);
+    return idx;
+  };
   const ensureJsBitwiseScratch = (rhsIsI32: boolean): { rhs: number; tmp: number } => {
     if (jsBitwiseTmpIdx === null) {
       jsBitwiseTmpIdx = func.params.length + locals.length;
@@ -1965,9 +1975,9 @@ export function lowerIrFunctionBody<S, Slot>(
         emitValue(instr.vec, out);
         emitter.emitVecLen(vec, out);
         // IR-level result is f64 (matches JS Number semantics) — promote.
-        // The f64.convert is an IR-result-type coercion, not a backend op,
-        // so it stays in the caller (#1713 spec section 3).
-        emitter.pushRaw(out, { op: "f64.convert_i32_s" });
+        // Route the coercion through the emitter so non-Wasm sinks do not
+        // need to accept a raw Wasm escape hatch.
+        emitter.emitUnary("f64.convert_i32_s", out);
         return;
       }
       case "vec.get": {
@@ -1980,6 +1990,18 @@ export function lowerIrFunctionBody<S, Slot>(
         emitter.emitVecDataPtr(vec, out);
         emitValue(instr.index, out);
         emitter.emitElemGet(vec, out);
+        return;
+      }
+      case "vec.set": {
+        const vecT = asVal(typeOf(instr.vec));
+        if (!vecT) throw new Error(`ir/lower: vec.set vec must be a val IrType (${func.name})`);
+        const vec = resolver.resolveVec?.(vecT);
+        if (!vec) throw new Error(`ir/lower: resolver cannot lower vec for vec.set (${func.name})`);
+        emitValue(instr.vec, out);
+        emitter.emitVecDataPtr(vec, out);
+        emitValue(instr.index, out);
+        emitValue(instr.newValue, out);
+        emitter.emitElemSet(vec, ensureVecElementScratch(vec.elementValType), out);
         return;
       }
       case "vec.new_fixed": {
@@ -3273,6 +3295,8 @@ function collectIrUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.vec];
     case "vec.get":
       return [instr.vec, instr.index];
+    case "vec.set":
+      return [instr.vec, instr.index, instr.newValue];
     case "vec.new_fixed":
       return instr.elements; // #1804
     case "forof.vec":

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -1467,6 +1467,19 @@ export interface IrInstrVecGet extends IrInstrBase {
 }
 
 /**
+ * Mutate one already-allocated dense-vector element. The index is i32 and the
+ * value must match the vector element type. Bounds/growth policy stays
+ * explicit in surrounding IR; this terminal instruction performs one planned
+ * in-bounds store.
+ */
+export interface IrInstrVecSet extends IrInstrBase {
+  readonly kind: "vec.set";
+  readonly vec: IrValueId;
+  readonly index: IrValueId;
+  readonly newValue: IrValueId;
+}
+
+/**
  * #1804 — Construct a vec from a fixed, statically-known set of element SSA
  * values. All `elements` share the IrType `elementType` (the from-ast lowerer
  * coerces each element to this type before emitting). `resultType` is the vec
@@ -2335,6 +2348,7 @@ export type IrInstr =
   | IrInstrSlotWrite
   | IrInstrVecLen
   | IrInstrVecGet
+  | IrInstrVecSet
   | IrInstrVecNewFixed
   | IrInstrForOfVec
   | IrInstrCoerceToExternref
@@ -2636,6 +2650,7 @@ export function forEachNestedBuffer(instr: IrInstr, fn: (buffer: readonly IrInst
     case "slot.write":
     case "vec.len":
     case "vec.get":
+    case "vec.set":
     case "vec.new_fixed":
     case "coerce.to_externref":
     case "iter.new":
@@ -2786,6 +2801,7 @@ export function mapNestedBuffers(
     case "slot.write":
     case "vec.len":
     case "vec.get":
+    case "vec.set":
     case "vec.new_fixed":
     case "coerce.to_externref":
     case "iter.new":
@@ -2907,6 +2923,8 @@ export function directUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.vec];
     case "vec.get":
       return [instr.vec, instr.index];
+    case "vec.set":
+      return [instr.vec, instr.index, instr.newValue];
     case "vec.new_fixed":
       return instr.elements;
     case "forof.vec":

--- a/src/ir/passes/inline-small.ts
+++ b/src/ir/passes/inline-small.ts
@@ -623,6 +623,13 @@ function renameInstrOperands(inst: IrInstr, rename: ReadonlyMap<IrValueId, IrVal
       if (v === inst.vec && idx === inst.index) return inst;
       return { ...inst, vec: v, index: idx };
     }
+    case "vec.set": {
+      const v = mapId(rename, inst.vec);
+      const idx = mapId(rename, inst.index);
+      const newValue = mapId(rename, inst.newValue);
+      if (v === inst.vec && idx === inst.index && newValue === inst.newValue) return inst;
+      return { ...inst, vec: v, index: idx, newValue };
+    }
     case "vec.new_fixed": {
       // #1804 — rewrite each element operand (mirrors object.new).
       let changed = false;

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -713,6 +713,8 @@ function collectUses(instr: IrInstr): readonly IrValueId[] {
       return [instr.vec];
     case "vec.get":
       return [instr.vec, instr.index];
+    case "vec.set":
+      return [instr.vec, instr.index, instr.newValue];
     case "vec.new_fixed":
       return [...instr.elements]; // #1804
     case "forof.vec": {

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -819,6 +819,8 @@ function collectUses(instr: IrBlock["instrs"][number]): readonly IrValueId[] {
       return [instr.vec];
     case "vec.get":
       return [instr.vec, instr.index];
+    case "vec.set":
+      return [instr.vec, instr.index, instr.newValue];
     case "vec.new_fixed":
       // #1804 — every element is an SSA use (like object.new's values).
       return instr.elements;
@@ -1275,6 +1277,18 @@ function verifyInstrTypeRules(func: IrFunction, typeOf: ReadonlyMap<IrValueId, I
               block: blockId,
             });
           }
+        }
+        break;
+      }
+      case "vec.get":
+      case "vec.set": {
+        const indexKind = valKindOf(typeOf, instr.index);
+        if (indexKind !== null && indexKind !== "i32") {
+          errors.push({
+            message: `${instr.kind} index must be i32, got ${indexKind}`,
+            func: func.name,
+            block: blockId,
+          });
         }
         break;
       }

--- a/tests/ir-vec-two-backend.test.ts
+++ b/tests/ir-vec-two-backend.test.ts
@@ -27,7 +27,7 @@ import type { IrVecLowering, LinearVecLowering } from "../src/ir/backend/handles
 import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
 import { lowerIrFunctionToWasm } from "../src/ir/lower.js";
 import { emitBinary } from "../src/emit/binary.js";
-import { irVal, type IrLowerResolver } from "../src/ir/index.js";
+import { defaultOperationsForLayout, irVal, planLinearVectorLayout, type IrLowerResolver } from "../src/ir/index.js";
 import type { BlockType, Instr, ValType, WasmFunction, WasmModule } from "../src/ir/types.js";
 
 const wasmgc = new WasmGcEmitter();
@@ -40,7 +40,22 @@ const gcVec: IrVecLowering = {
   arrayTypeIdx: 4,
   elementValType: { kind: "f64" },
 };
-const linVec: LinearVecLowering = { elementValType: { kind: "f64" } };
+function linearVec(elementValType: ValType): LinearVecLowering {
+  const layout = planLinearVectorLayout(irVal(elementValType));
+  const operations = defaultOperationsForLayout(layout);
+  return {
+    elementValType,
+    linearMemory: {
+      layout,
+      allocate: operations.find((operation) => operation.family === "vector" && operation.operation === "allocate")!,
+      initializeElement: operations.find(
+        (operation) => operation.family === "vector" && operation.operation === "initialize-element",
+      )!,
+    },
+  };
+}
+
+const linVec = linearVec({ kind: "f64" });
 
 describe("#1714 vec primitives diverge per backend (same intent, two emitters)", () => {
   it("emitVecLen: WasmGC struct.get vs linear i32.load@8", () => {
@@ -81,7 +96,7 @@ describe("#1714 vec primitives diverge per backend (same intent, two emitters)",
 
   it("emitElemGet stride follows elementValType (i32 → stride 4, i32.load)", () => {
     const lin: Instr[] = [];
-    linear.emitElemGet({ elementValType: { kind: "i32" } }, lin);
+    linear.emitElemGet(linearVec({ kind: "i32" }), lin);
     expect(lin).toEqual([
       { op: "i32.const", value: 4 },
       { op: "i32.mul" },

--- a/tests/issue-3297.test.ts
+++ b/tests/issue-3297.test.ts
@@ -240,7 +240,7 @@ describe("#3297 Porffor scalar/control-flow sink", () => {
     expect(lowerProof().globals.map((global) => global.name)).toEqual(["spare", "trace"]);
   });
 
-  it("rejects heap/reference IR through legality before sink emission", () => {
+  it("requires the shared memory plan before heap emission", () => {
     const shape: IrObjectShape = { fields: [{ name: "value", type: F64 }] };
     const builder = new IrFunctionBuilder("heapRejected", [{ kind: "object", shape }]);
     builder.openBlock();
@@ -249,12 +249,8 @@ describe("#3297 Porffor scalar/control-flow sink", () => {
     builder.terminate({ kind: "return", values: [object] });
     const func = builder.finish();
 
-    expect(
-      verifyIrBackendLegality(func, "porffor")
-        .map((error) => error.message)
-        .join("\n"),
-    ).toMatch(/porffor backend does not support (?:IR type 'object'|IR instruction 'object\.new')/);
-    expect(() => lowerIrModuleToPorffor({ functions: [func] })).toThrow(/porffor backend legality failed/);
+    expect(verifyIrBackendLegality(func, "porffor")).toEqual([]);
+    expect(() => lowerIrModuleToPorffor({ functions: [func] })).toThrow(/shared LinearMemoryPlan/);
   });
 });
 

--- a/tests/issue-3299.test.ts
+++ b/tests/issue-3299.test.ts
@@ -1,0 +1,523 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { addArrayRuntime, addLinearIrVecRuntime, addRuntime } from "../src/codegen-linear/runtime.js";
+import { emitBinary } from "../src/emit/binary.js";
+import {
+  AllocSiteRegistry,
+  IrFunctionBuilder,
+  irVal,
+  planLinearMemory,
+  verifyIrBackendLegality,
+  verifyIrFunction,
+  type AllocSiteId,
+  type IrFunction,
+  type IrLowerResolver,
+  type IrModule,
+  type IrObjectShape,
+  type IrType,
+} from "../src/ir/index.js";
+import { LinearEmitter } from "../src/ir/backend/linear-emitter.js";
+import type {
+  IrVecLowering,
+  LinearMemoryFieldLowering,
+  LinearObjectLowering,
+  LinearVecLowering,
+} from "../src/ir/backend/handles.js";
+import { PORFFOR_KIND_NAMES, porfforRendererOutputText, type PorfforNode } from "../src/ir/backend/porffor/compat.js";
+import { lowerIrModuleToPorffor } from "../src/ir/backend/porffor/integration.js";
+import { loadOptionalPorffor } from "../src/ir/backend/porffor/loader.js";
+import { lowerIrFunctionBody } from "../src/ir/lower.js";
+import type { FuncTypeDef, ValType, WasmFunction, WasmModule } from "../src/ir/types.js";
+import type {
+  LinearAllocationSitePlan,
+  LinearMemoryPlan,
+  LinearRuntimeOperation,
+} from "../src/ir/analysis/linear-memory-plan.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const porfforRoot = process.env.JS2WASM_PORFFOR_ROOT ?? join(here, "../vendor/Porffor");
+const hasOptionalPorffor = existsSync(join(porfforRoot, "compiler/ir.js"));
+const F64: IrType = irVal({ kind: "f64" });
+const I32: IrType = irVal({ kind: "i32" });
+const VECTOR_POINTER: IrType = irVal({ kind: "i32" });
+const SHAPE: IrObjectShape = {
+  fields: [
+    { name: "x", type: F64 },
+    { name: "y", type: F64 },
+  ],
+};
+
+function proofFixture(): { module: IrModule; plan: LinearMemoryPlan } {
+  const allocations = new AllocSiteRegistry();
+
+  const object = new IrFunctionBuilder("objectProof", [F64], true, allocations);
+  object.openBlock();
+  const four = object.emitConst({ kind: "f64", value: 4 }, F64);
+  const five = object.emitConst({ kind: "f64", value: 5 }, F64);
+  const first = object.emitObjectNew(SHAPE, [four, five]);
+  const second = object.emitObjectNew(SHAPE, [four, five]);
+  const truth = object.emitConst({ kind: "bool", value: true }, I32);
+  const alias = object.emitSelect(truth, first, second, { kind: "object", shape: SHAPE });
+  const nine = object.emitConst({ kind: "f64", value: 9 }, F64);
+  object.emitObjectSet(alias, "x", nine);
+  const observed = object.emitObjectGet(first, "x", F64);
+  const sameIdentity = object.emitBinary("i32.eq", first, alias, I32);
+  const distinctIdentity = object.emitBinary("i32.ne", first, second, I32);
+  const sameNumber = object.emitUnary("f64.convert_i32_s", sameIdentity, F64);
+  const distinctNumber = object.emitUnary("f64.convert_i32_s", distinctIdentity, F64);
+  const hundred = object.emitConst({ kind: "f64", value: 100 }, F64);
+  const ten = object.emitConst({ kind: "f64", value: 10 }, F64);
+  const mutationScore = object.emitBinary("f64.mul", observed, hundred, F64);
+  const aliasScore = object.emitBinary("f64.mul", sameNumber, ten, F64);
+  const identityScore = object.emitBinary("f64.add", aliasScore, distinctNumber, F64);
+  const objectResult = object.emitBinary("f64.add", mutationScore, identityScore, F64);
+  object.terminate({ kind: "return", values: [objectResult] });
+
+  const vector = new IrFunctionBuilder("vectorProof", [F64], true, allocations);
+  const index = vector.addParam("index", I32);
+  vector.openBlock();
+  const values = [4, 5, 6].map((value) => vector.emitConst({ kind: "f64", value }, F64));
+  const vec = vector.emitVecNewFixed(values, F64, VECTOR_POINTER);
+  const one = vector.emitConst({ kind: "i32", value: 1 }, I32);
+  const replacement = vector.emitConst({ kind: "f64", value: 9 }, F64);
+  vector.emitVecSet(vec, one, replacement);
+  const length = vector.emitVecLen(vec);
+  const lengthI32 = vector.emitUnary("i32.trunc_sat_f64_s", length, I32);
+  const inBounds = vector.emitBinary("i32.lt_u", index, lengthI32, I32);
+  let found!: ReturnType<IrFunctionBuilder["emitVecGet"]>;
+  const foundBody = vector.collectBodyInstrs(() => {
+    found = vector.emitVecGet(vec, index, F64);
+  });
+  let missing!: ReturnType<IrFunctionBuilder["emitConst"]>;
+  const missingBody = vector.collectBodyInstrs(() => {
+    missing = vector.emitConst({ kind: "f64", value: 0 }, F64);
+  });
+  const selected = vector.emitIfElse({
+    cond: inBounds,
+    then: foundBody,
+    thenValue: found,
+    else: missingBody,
+    elseValue: missing,
+    resultType: F64,
+  });
+  const vectorHundred = vector.emitConst({ kind: "f64", value: 100 }, F64);
+  const lengthScore = vector.emitBinary("f64.mul", length, vectorHundred, F64);
+  const vectorResult = vector.emitBinary("f64.add", selected, lengthScore, F64);
+  vector.terminate({ kind: "return", values: [vectorResult] });
+
+  const module = { functions: [object.finish(), vector.finish()] };
+  for (const func of module.functions) {
+    expect(verifyIrFunction(func)).toEqual([]);
+    expect(verifyIrBackendLegality(func, "linear")).toEqual([]);
+    expect(verifyIrBackendLegality(func, "porffor")).toEqual([]);
+  }
+  return { module, plan: planLinearMemory(module, allocations) };
+}
+
+function collectNodes(value: unknown, out: PorfforNode[] = []): PorfforNode[] {
+  if (!Array.isArray(value)) return out;
+  if (value.length === 6 && typeof value[0] === "number" && PORFFOR_KIND_NAMES[value[0]]) {
+    const node = value as unknown as PorfforNode;
+    out.push(node);
+    collectNodes(node[3], out);
+    collectNodes(node[4], out);
+    collectNodes(node[5], out);
+    return out;
+  }
+  for (const item of value) collectNodes(item, out);
+  return out;
+}
+
+function nodeName(node: PorfforNode): string {
+  return PORFFOR_KIND_NAMES[node[0]]!;
+}
+
+describe("#3299 shared heap/layout plan", () => {
+  it("binds Porffor Alloc/Load/Store exclusively to planned arena layouts", () => {
+    const { module, plan } = proofFixture();
+    const input = lowerIrModuleToPorffor(module, { memoryPlan: plan });
+    const nodes = input.funcs.flatMap((func) => collectNodes(func?.body ?? []));
+    const names = nodes.map(nodeName);
+
+    expect(names).toContain("Alloc");
+    expect(names).toContain("Load");
+    expect(names).toContain("Store");
+    for (const forbidden of ["GcBarrier", "ArrGet", "ArrSet", "ArrLenSet", "LenGet", "LenSet", "RawC"] as const) {
+      expect(names, `Porffor-native heap operation ${forbidden} escaped the adapter`).not.toContain(forbidden);
+    }
+
+    const objectLayout = plan.layoutForObjectShape(SHAPE)!;
+    const vectorLayout = plan.layoutForVector(F64)!;
+    expect(objectLayout.fields.map(({ name, offset }) => ({ name, offset }))).toEqual([
+      { name: "x", offset: 8 },
+      { name: "y", offset: 16 },
+    ]);
+    expect(vectorLayout).toMatchObject({
+      lengthOffset: 8,
+      capacityOffset: 12,
+      elementsOffset: 16,
+      elementStride: 8,
+    });
+
+    const stores = nodes.filter((node) => nodeName(node) === "Store");
+    const loads = nodes.filter((node) => nodeName(node) === "Load");
+    const storeOffsets = stores.map((node) => (node[5] as readonly unknown[])[0]);
+    const loadOffsets = loads.map((node) => (node[5] as readonly unknown[])[0]);
+    for (const field of objectLayout.fields) {
+      expect(storeOffsets).toContain(field.offset);
+    }
+    expect(loadOffsets).toContain(objectLayout.fields.find((field) => field.name === "x")!.offset);
+    expect(storeOffsets).toEqual(
+      expect.arrayContaining([
+        vectorLayout.lengthOffset,
+        vectorLayout.capacityOffset,
+        vectorLayout.elementsOffset,
+        vectorLayout.elementsOffset + vectorLayout.elementStride,
+        vectorLayout.elementsOffset + vectorLayout.elementStride * 2,
+      ]),
+    );
+    expect(loadOffsets).toContain(vectorLayout.lengthOffset);
+    const scaledIndex = nodes.find(
+      (node) =>
+        nodeName(node) === "Bin" &&
+        node[3] === "*" &&
+        Array.isArray(node[5]) &&
+        nodeName(node[5] as unknown as PorfforNode) === "Const" &&
+        (node[5] as unknown as PorfforNode)[3] === vectorLayout.elementStride,
+    );
+    expect(scaledIndex, "vector addressing must multiply by the planned stride").toBeDefined();
+
+    const allocs = nodes.filter((node) => nodeName(node) === "Alloc");
+    expect(allocs).toHaveLength(plan.allocations.length);
+    for (const alloc of allocs) {
+      const [siteId, raw] = alloc[5] as readonly [number, boolean];
+      const planned = plan.allocation(siteId as AllocSiteId)!;
+      const bytesNode = alloc[3] as PorfforNode;
+      expect(nodeName(bytesNode)).toBe("Const");
+      expect(bytesNode[3]).toBe(planned.size.kind === "constant" ? planned.size.bytes : undefined);
+      expect(alloc[4]).toBe(0);
+      expect(raw).toBe(false);
+    }
+    expect(plan.policy).toBe("arena-v1");
+    expect(
+      plan.allocations.every(
+        (allocation: LinearAllocationSitePlan) =>
+          allocation.allocationClass === "arena" &&
+          allocation.root.kind === "none" &&
+          allocation.safepoints.kind === "none" &&
+          allocation.barrier.kind === "none",
+      ),
+    ).toBe(true);
+    expect(input.prefs.gc).toBe(false);
+    expect(input.usedTypes).toEqual(new Set());
+    expect(() => lowerIrModuleToPorffor(module, { memoryPlan: plan, prefs: { gc: true } })).toThrow(
+      /arena-v1 requires prefs\.gc=false/,
+    );
+  });
+
+  const optionalIt = hasOptionalPorffor && findCCompiler() ? it : it.skip;
+  optionalIt(
+    "executes the same typed SSA through linear-Wasm and Porffor-C with JS semantics",
+    async () => {
+      const { module, plan } = proofFixture();
+      const expected = [objectOracle(), vectorOracle(1), vectorOracle(-1), vectorOracle(8)];
+
+      const linear = await instantiateLinearProof(module, plan);
+      const linearValues = [linear.objectProof(), linear.vectorProof(1), linear.vectorProof(-1), linear.vectorProof(8)];
+
+      const input = lowerIrModuleToPorffor(module, { memoryPlan: plan });
+      const porffor = await loadOptionalPorffor({ root: porfforRoot });
+      const rendered = porfforRendererOutputText(porffor.render(input));
+      const porfforValues = compileAndRunC(rendered, input.funcs, [
+        { name: "objectProof", args: [] },
+        { name: "vectorProof", args: [1] },
+        { name: "vectorProof", args: [-1] },
+        { name: "vectorProof", args: [8] },
+      ]);
+
+      expect(expected).toEqual([911, 309, 300, 300]);
+      expect(linearValues).toStrictEqual(expected);
+      expect(porfforValues).toStrictEqual(expected);
+    },
+    60_000,
+  );
+});
+
+function objectOracle(): number {
+  const first = { x: 4, y: 5 };
+  const alias = first;
+  const second = { x: 4, y: 5 };
+  alias.x = 9;
+  return first.x * 100 + (first === alias ? 10 : 0) + (first !== second ? 1 : 0);
+}
+
+function vectorOracle(index: number): number {
+  const values = [4, 5, 6];
+  values[1] = 9;
+  return (index >= 0 && index < values.length ? values[index]! : 0) + values.length * 100;
+}
+
+function emptyLinearModule(): WasmModule {
+  return {
+    types: [],
+    imports: [],
+    functions: [],
+    exports: [],
+    tables: [],
+    elements: [],
+    globals: [],
+    tags: [],
+    stringPool: [],
+    externClasses: [],
+    nodeBuiltinModules: new Set(),
+    stringLiteralValues: new Map(),
+    asyncFunctions: new Set(),
+    declaredFuncRefs: [],
+    funcOrdinalToPosition: [],
+    memories: [],
+    dataSegments: [],
+  };
+}
+
+async function instantiateLinearProof(
+  module: IrModule,
+  plan: LinearMemoryPlan,
+): Promise<{ objectProof: () => number; vectorProof: (index: number) => number }> {
+  const wasm = emptyLinearModule();
+  addRuntime(wasm);
+  addArrayRuntime(wasm);
+  addLinearIrVecRuntime(wasm);
+
+  const objectLayout = plan.layoutForObjectShape(SHAPE)!;
+  const mallocIdx = functionIndex(wasm, "__malloc");
+  const objectHelperType = internFuncType(wasm, {
+    kind: "func",
+    params: SHAPE.fields.map(() => ({ kind: "f64" as const })),
+    results: [{ kind: "i32" }],
+  });
+  const objectHelperIdx = wasm.functions.length;
+  wasm.functions.push({
+    name: "__proof_object_new",
+    typeIdx: objectHelperType,
+    locals: [{ name: "#ptr", type: { kind: "i32" } }],
+    body: [
+      { op: "i32.const", value: objectLayout.size.kind === "constant" ? objectLayout.size.bytes : 0 },
+      { op: "call", funcIdx: mallocIdx },
+      { op: "local.set", index: 2 },
+      ...objectLayout.fields.flatMap((field, index) => [
+        { op: "local.get" as const, index: 2 },
+        { op: "local.get" as const, index },
+        { op: "f64.store" as const, align: 3 as const, offset: field.offset },
+      ]),
+      { op: "local.get", index: 2 },
+    ],
+    exported: false,
+  });
+
+  const resolver = linearResolver(wasm, plan, objectHelperIdx);
+  for (const ir of module.functions) {
+    const emitter = new LinearEmitter({ resolveRuntimeOperation: (operation) => runtimeOperation(wasm, operation) });
+    const body = lowerIrFunctionBody(ir, resolver, emitter, {
+      backend: "linear",
+      convertType(type: IrType): readonly ValType[] {
+        if (type.kind === "val") return [type.val];
+        if (type.kind === "object") return [{ kind: "i32" }];
+        throw new Error(`proof linear converter cannot carry '${type.kind}'`);
+      },
+    });
+    const params = body.params.flatMap((param) => [...param.slots]);
+    const results = body.results.flatMap((result) => [...result]);
+    const vecScratch = new Set(emitter.getVecScratchLocalIndices());
+    const lowered: WasmFunction = {
+      name: body.name,
+      typeIdx: internFuncType(wasm, { kind: "func", params, results }),
+      locals: body.locals.flatMap((local) =>
+        local.slots.map((type, slot) => {
+          const index =
+            params.length +
+            body.locals.slice(0, body.locals.indexOf(local)).reduce((n, item) => n + item.slots.length, 0) +
+            slot;
+          return {
+            name: slot === 0 ? local.name : `${local.name}$${slot}`,
+            type: vecScratch.has(index) ? ({ kind: "i32" } as const) : type,
+          };
+        }),
+      ),
+      body: body.body,
+      exported: body.exported,
+    };
+    const index = wasm.functions.length;
+    wasm.functions.push(lowered);
+    wasm.exports.push({ name: ir.name, desc: { kind: "func", index } });
+  }
+
+  const binary = emitBinary(wasm);
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return instance.exports as unknown as { objectProof: () => number; vectorProof: (index: number) => number };
+}
+
+function linearResolver(wasm: WasmModule, plan: LinearMemoryPlan, objectHelperIdx: number): IrLowerResolver {
+  const allocationFor = (layoutId: string, alloc?: AllocSiteId): LinearAllocationSitePlan => {
+    const allocation = alloc === undefined ? plan.allocationsForLayout(layoutId)[0] : plan.allocation(alloc);
+    if (!allocation || allocation.layoutId !== layoutId) throw new Error(`missing allocation for ${layoutId}`);
+    return allocation;
+  };
+  const operation = (
+    allocation: LinearAllocationSitePlan,
+    predicate: (candidate: LinearRuntimeOperation) => boolean,
+  ): LinearRuntimeOperation => {
+    const found = allocation.operations.find(predicate);
+    if (!found) throw new Error(`missing planned operation for site ${allocation.id as number}`);
+    return found;
+  };
+  const vec = (alloc?: AllocSiteId): IrVecLowering & LinearVecLowering => {
+    const layout = plan.layoutForVector(F64)!;
+    const allocation = allocationFor(layout.id, alloc);
+    return {
+      vecStructTypeIdx: 0,
+      lengthFieldIdx: 0,
+      dataFieldIdx: 0,
+      arrayTypeIdx: 0,
+      elementValType: { kind: "f64" },
+      linearMemory: {
+        allocation,
+        layout,
+        allocate: operation(
+          allocation,
+          (candidate) => candidate.family === "vector" && candidate.operation === "allocate",
+        ),
+        initializeElement: operation(
+          allocation,
+          (candidate) => candidate.family === "vector" && candidate.operation === "initialize-element",
+        ),
+      },
+    };
+  };
+
+  return {
+    resolveFunc(): number {
+      throw new Error("proof module has no calls");
+    },
+    resolveGlobal(): number {
+      throw new Error("proof module has no globals");
+    },
+    resolveType(): number {
+      throw new Error("proof module has no symbolic types");
+    },
+    internFuncType(type: FuncTypeDef): number {
+      return internFuncType(wasm, type);
+    },
+    resolveObject(shape: IrObjectShape, alloc?: AllocSiteId): LinearObjectLowering | null {
+      const layout = plan.layoutForObjectShape(shape);
+      if (!layout) return null;
+      const allocation = allocationFor(layout.id, alloc);
+      const fields = shape.fields.map((field, fieldIdx) => {
+        const planned = layout.fields.find((candidate) => candidate.name === field.name)!;
+        return { name: field.name, fieldIdx, offset: planned.offset, type: { kind: "f64" as const } };
+      });
+      const byName = new Map(fields.map((field) => [field.name, field]));
+      return {
+        typeIdx: 0,
+        fieldIdx(name: string): number {
+          return byName.get(name)!.fieldIdx;
+        },
+        linearMemory: {
+          allocation,
+          layout,
+          allocate: operation(
+            allocation,
+            (candidate) => candidate.family === "memory" && candidate.operation === "allocate",
+          ),
+          newFuncIdx: objectHelperIdx,
+          fieldCount: fields.length,
+          field(name: string): LinearMemoryFieldLowering {
+            return byName.get(name)!;
+          },
+        },
+      };
+    },
+    resolveVec(valType: ValType): IrVecLowering | null {
+      return valType.kind === "i32" ? vec() : null;
+    },
+    resolveVecForElement(elementValType: ValType, alloc?: AllocSiteId): IrVecLowering | null {
+      return elementValType.kind === "f64" ? vec(alloc) : null;
+    },
+  };
+}
+
+function internFuncType(wasm: WasmModule, type: FuncTypeDef): number {
+  const index = wasm.types.length;
+  wasm.types.push({ ...type, name: `$proof_type_${index}` });
+  return index;
+}
+
+function functionIndex(wasm: WasmModule, name: string): number {
+  const index = wasm.functions.findIndex((func) => func.name === name);
+  if (index < 0) throw new Error(`missing linear runtime function ${name}`);
+  return wasm.imports.filter((entry) => entry.desc.kind === "func").length + index;
+}
+
+function runtimeOperation(wasm: WasmModule, operation: LinearRuntimeOperation): number {
+  if (operation.family === "memory" && operation.operation === "allocate") return functionIndex(wasm, "__malloc");
+  if (operation.family === "vector" && operation.operation === "allocate") return functionIndex(wasm, "__arr_new");
+  if (operation.family === "vector" && operation.operation === "initialize-element") {
+    return functionIndex(wasm, "__linear_ir_vec_init_f64");
+  }
+  throw new Error(`unsupported proof runtime operation ${JSON.stringify(operation)}`);
+}
+
+function findCCompiler(): string | null {
+  const candidates = [process.env.CC, "cc", "clang", "gcc"].filter((candidate): candidate is string => !!candidate);
+  for (const candidate of candidates) {
+    if (spawnSync(candidate, ["--version"], { stdio: "ignore" }).status === 0) return candidate;
+  }
+  return null;
+}
+
+function compileAndRunC(
+  rendered: string,
+  funcs: readonly ({ readonly name: string; readonly index: number } | null | undefined)[],
+  calls: readonly { readonly name: string; readonly args: readonly number[] }[],
+): number[] {
+  const compiler = findCCompiler();
+  if (!compiler) throw new Error("no C compiler available");
+  const symbols = new Map(
+    funcs.filter((func): func is NonNullable<typeof func> => !!func).map((func) => [func.name, func]),
+  );
+  const invocationLines = calls.map((call) => {
+    const func = symbols.get(call.name);
+    if (!func) throw new Error(`missing Porffor function ${call.name}`);
+    return `  printf("%.17g\\n", p${func.index}_${func.name}(${call.args.join(", ")}));`;
+  });
+  const harness = `
+int main(int argc, char** argv) {
+  porf_init(argc, argv);
+  porf_data_init();
+${invocationLines.join("\n")}
+  return 0;
+}
+`;
+  const directory = mkdtempSync(join(tmpdir(), "js2-porffor-3299-"));
+  const sourcePath = join(directory, "proof.c");
+  const binaryPath = join(directory, "proof");
+  try {
+    writeFileSync(sourcePath, rendered + harness);
+    const result = spawnSync(
+      compiler,
+      ["-std=gnu11", "-Werror", "-Wno-unused-function", sourcePath, "-lm", "-o", binaryPath],
+      { encoding: "utf8" },
+    );
+    expect(result.status, `C compiler failed:\n${result.stdout}\n${result.stderr}`).toBe(0);
+    return execFileSync(binaryPath, { encoding: "utf8" }).trim().split("\n").map(Number);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- bind Porffor fixed-shape object and dense-vector lowering to the shared LinearMemoryPlan
- emit pinned Alloc, Load, and Store nodes without Porffor-native object layouts or builtins
- add typed vec.set lowering and prove aliasing, identity, mutation, bounds, and arena root/barrier policy

## Validation

- IR_VERIFY_ALLOC=1 focused backend/allocation suite: 8 files, 56 tests
- JavaScript / linear-Wasm / Porffor-C differential: [911, 309, 300, 300]
- build, typecheck, focused lint, pushRaw/linear-IR/fallback ratchets
- prove-emit-identity: all 56 file/target outcomes identical to origin/main

Closes #3299