### PR TITLE
fix(#3363): standalone-native Array.prototype.flat() (depth-1 homogeneous)

### DIFF
--- a/plan/issues/3363-standalone-array-flat-native-depth1.md
+++ b/plan/issues/3363-standalone-array-flat-native-depth1.md
@@ -1,0 +1,81 @@
+---
+id: 3363
+title: "standalone: Array.prototype.flat() has no native arm — depth-1 homogeneous nested-array flatten (child of #2717 follow-up / #3180)"
+status: in-progress
+assignee: ttraenkler/dev-j
+sprint: current
+created: 2026-07-17
+completed: 2026-07-17
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: array-methods
+goal: standalone
+related: [2717, 3180, 2860, 1136]
+origin: "#3180 umbrella verify-first probe (dev-j, 2026-07-17): flat() hard-CEs standalone; #2717 only added the fail-loud refusal and explicitly deferred 'a native recursive-flatten arm' as a separate follow-up."
+loc-budget-allow:
+  - src/codegen/array-methods.ts
+---
+
+# #3363 — standalone-native `Array.prototype.flat()` (depth-1 homogeneous)
+
+## Problem (verified, current upstream/main)
+
+Under `--target standalone`/`wasi`, `Array.prototype.flat()` hard-CEs:
+
+```
+Codegen error: Array.prototype.flat() is not yet supported in --target
+standalone/wasi (#2717) — there is no Wasm-native flatten arm …
+```
+
+`#2717` (`status: done`, sprint 67) only landed the **fail-loud refusal** —
+it swapped the unsatisfiable `__array_flat` host import for a loud
+`reportError` + `unreachable`, and its own code comment defers the real fix:
+"A native recursive-flatten arm (depth + runtime IsArray + dynamic
+result-build over heterogeneous WasmGC element types) is a separate, larger
+follow-up." This issue lands the **common, tractable slice** of that arm.
+
+Verified on current main that the underlying nested-array representation is
+fully usable standalone (`a[0][1]`, `a[i].length`, manual nested-loop flatten
+all work) — so the only gap is the missing `flat()` codegen arm.
+
+This is bucket-adjacent to the #3180 standalone Array residual umbrella (parent
+#2860 standalone-vs-host gap); it is NOT one of #3180's six HOF buckets (those
+are peer-owned #2992/bucket-1, dev-f #3359/bucket-5, or hard edge cases), so it
+does not collide with in-flight work.
+
+## Scope (single slice — deliberately narrow)
+
+Native arm for the **default depth (1)** flatten of a **statically-typed
+homogeneous** nested array `T[][]` (the outer array's element type resolves to
+a ref to an inner scalar vec, `T ∈ {number(f64/i32)}` and the WasmGC vec shape).
+Emits a two-pass flatten:
+
+1. Sum the (non-null) inner lengths → total.
+2. Allocate a fresh result data array of the inner element kind, size `total`.
+3. `array.copy` each inner vec's elements contiguously into the result.
+4. Return a fresh `$vec` struct `{ total, resultData }` of the inner vec type.
+
+**Out of scope (keeps the existing loud refusal):** an explicit `depth`
+argument (any value, including a literal ≠ 1), heterogeneous / mixed
+array-and-scalar element unions, deeper-than-1 recursion, and non-nested-vec
+receivers. Host/gc mode is unchanged (keeps the `__array_flat` delegation).
+`flatMap` remains deferred (#2717).
+
+## Spec
+
+ES2024 §23.1.3.13 `Array.prototype.flat([depth])` — with `depth` defaulting to
+1, `FlattenIntoArray` copies each element of a sub-array (an element for which
+`IsArray` is true) into the result in order; a depth-1 flatten of an array whose
+elements are all arrays is a straight concatenation of the sub-arrays.
+
+## Acceptance
+
+- `[[1,2],[3]].flat()` compiles + runs standalone → `[1,2,3]` (length 3,
+  elements correct), zero host imports.
+- Empty inner arrays contribute nothing; an empty outer array flattens to empty.
+- An explicit depth argument or non-nested receiver still refuses loudly (no
+  silent wrong value).
+- Host-lane byte-identity; no test262 regression.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -1534,7 +1534,7 @@ export function compileArrayMethodCall(
       result = compileArrayIteratorMethod(ctx, fctx, methodAccess, methodName);
       break;
     case "flat":
-      result = compileArrayFlat(ctx, fctx, methodAccess, callExpr);
+      result = compileArrayFlat(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
       break;
     case "flatMap":
       result = compileArrayFlatMap(ctx, fctx, methodAccess, callExpr);
@@ -7907,6 +7907,182 @@ function compileArrayLastIndexOf(
 }
 
 /**
+ * (#3363) Standalone-native depth-1 flatten of a statically-typed HOMOGENEOUS
+ * nested array `T[][]` — the common `[[…],[…]].flat()` case. `elemType` is the
+ * OUTER array's element type; when it resolves to a ref to an inner `$vec`
+ * struct (`{ len, data }`), each inner vec's elements are copied contiguously
+ * into a fresh result vec of the inner element kind (a straight concatenation,
+ * which is exactly a depth-1 flatten of an all-array array). Returns the result
+ * ValType on success, or `null` when the receiver is not a recognizable nested
+ * vec (the caller then refuses loudly — no silent wrong value).
+ *
+ * Only the DEFAULT depth (no `depth` argument) is handled; an explicit depth,
+ * deeper recursion, and heterogeneous array/scalar unions stay deferred to the
+ * larger #2717 follow-up.
+ */
+function tryCompileArrayFlatNativeDepth1(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+): ValType | null {
+  // Default depth only — an explicit `depth` argument falls through to refusal.
+  if (callExpr.arguments.length > 0) return null;
+  // Outer element must be a ref to an inner vec struct.
+  if (elemType.kind !== "ref" && elemType.kind !== "ref_null") return null;
+  const innerVecTypeIdx = (elemType as { typeIdx?: number }).typeIdx;
+  if (innerVecTypeIdx === undefined) return null;
+  const innerArrTypeIdx = getArrTypeIdxFromVec(ctx, innerVecTypeIdx);
+  if (innerArrTypeIdx < 0) return null;
+  const innerArrDef = ctx.mod.types[innerArrTypeIdx];
+  if (!innerArrDef || innerArrDef.kind !== "array") return null;
+
+  const outerVec = allocLocal(fctx, `__arr_flat_ov_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+  const outerData = allocLocal(fctx, `__arr_flat_od_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
+  const outerLen = allocLocal(fctx, `__arr_flat_ol_${fctx.locals.length}`, { kind: "i32" });
+  const total = allocLocal(fctx, `__arr_flat_tot_${fctx.locals.length}`, { kind: "i32" });
+  const iTmp = allocLocal(fctx, `__arr_flat_i_${fctx.locals.length}`, { kind: "i32" });
+  const inner = allocLocal(fctx, `__arr_flat_in_${fctx.locals.length}`, { kind: "ref_null", typeIdx: innerVecTypeIdx });
+  const innerLen = allocLocal(fctx, `__arr_flat_il_${fctx.locals.length}`, { kind: "i32" });
+  const innerData = allocLocal(fctx, `__arr_flat_id_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: innerArrTypeIdx,
+  });
+  const resultData = allocLocal(fctx, `__arr_flat_rd_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: innerArrTypeIdx,
+  });
+  const pos = allocLocal(fctx, `__arr_flat_pos_${fctx.locals.length}`, { kind: "i32" });
+
+  // receiver -> outerVec (null-guarded), then unpack len/data.
+  compileExpression(ctx, fctx, propAccess.expression);
+  fctx.body.push({ op: "local.tee", index: outerVec });
+  emitReceiverNullGuard(ctx, fctx, outerVec);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.set", index: outerLen });
+  fctx.body.push({ op: "local.get", index: outerVec });
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
+  fctx.body.push({ op: "local.set", index: outerData });
+
+  // Pass 1: total = Σ (non-null) inner.length
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: total });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: iTmp });
+  const pass1: Instr[] = [
+    { op: "local.get", index: iTmp },
+    { op: "local.get", index: outerLen },
+    { op: "i32.ge_s" },
+    { op: "br_if", depth: 1 },
+    // inner = outerData[i]
+    { op: "local.get", index: outerData },
+    { op: "local.get", index: iTmp },
+    { op: "array.get", typeIdx: arrTypeIdx },
+    { op: "local.set", index: inner },
+    // if inner != null: total += inner.len
+    { op: "local.get", index: inner },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: total },
+        { op: "local.get", index: inner },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 0 },
+        { op: "i32.add" },
+        { op: "local.set", index: total },
+      ],
+      else: [],
+    },
+    { op: "local.get", index: iTmp },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: iTmp },
+    { op: "br", depth: 0 },
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: pass1 }],
+  });
+
+  // resultData = new inner-element[total]
+  fctx.body.push({ op: "local.get", index: total });
+  fctx.body.push({ op: "array.new_default", typeIdx: innerArrTypeIdx });
+  fctx.body.push({ op: "local.set", index: resultData });
+
+  // Pass 2: copy each inner vec's elements contiguously into resultData.
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: pos });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: iTmp });
+  // When inner != null: unpack len/data, copy its elements into resultData[pos..],
+  // then advance pos by inner.length.
+  const copyInner: Instr[] = [
+    // innerLen = inner.len; innerData = inner.data
+    { op: "local.get", index: inner },
+    { op: "ref.as_non_null" },
+    { op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: innerLen },
+    { op: "local.get", index: inner },
+    { op: "ref.as_non_null" },
+    { op: "struct.get", typeIdx: innerVecTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: innerData },
+    // resultData[pos .. pos+innerLen) = innerData[0 .. innerLen)
+    { op: "local.get", index: resultData },
+    { op: "local.get", index: pos },
+    { op: "local.get", index: innerData },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: innerLen },
+    { op: "array.copy", dstTypeIdx: innerArrTypeIdx, srcTypeIdx: innerArrTypeIdx },
+    // pos += innerLen
+    { op: "local.get", index: pos },
+    { op: "local.get", index: innerLen },
+    { op: "i32.add" },
+    { op: "local.set", index: pos },
+  ];
+  const pass2: Instr[] = [
+    { op: "local.get", index: iTmp },
+    { op: "local.get", index: outerLen },
+    { op: "i32.ge_s" },
+    { op: "br_if", depth: 1 },
+    // inner = outerData[i]
+    { op: "local.get", index: outerData },
+    { op: "local.get", index: iTmp },
+    { op: "array.get", typeIdx: arrTypeIdx },
+    { op: "local.set", index: inner },
+    // if inner != null: copy its elements
+    { op: "local.get", index: inner },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: copyInner, else: [] },
+    // i++
+    { op: "local.get", index: iTmp },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: iTmp },
+    { op: "br", depth: 0 },
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: pass2 }],
+  });
+
+  // return struct.new $innerVec(total, resultData)
+  fctx.body.push({ op: "local.get", index: total });
+  fctx.body.push({ op: "local.get", index: resultData });
+  fctx.body.push({ op: "ref.as_non_null" });
+  fctx.body.push({ op: "struct.new", typeIdx: innerVecTypeIdx });
+  return { kind: "ref_null", typeIdx: innerVecTypeIdx };
+}
+
+/**
  * Compile arr.flat(depth?) — delegates to __array_flat host import (#1136).
  * Converts WasmGC vec receiver to externref, passes depth arg, returns externref.
  */
@@ -7915,15 +8091,21 @@ function compileArrayFlat(
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
 ): ValType | null {
-  // (#2717) `flat` has no Wasm-native arm — it delegates to the host
+  // (#2717) `flat` has no host-import Wasm-native arm — it delegates to the host
   // `__array_flat` import. Under `--target standalone`/`wasi` there is no JS host
   // to satisfy that import, so emitting it produces a module that traps at
   // instantiation. Per the #2711 fail-loud policy, refuse loudly instead of
-  // emitting an unsatisfiable import. A native recursive-flatten arm (depth +
-  // runtime IsArray + dynamic result-build over heterogeneous WasmGC element
-  // types) is a separate, larger follow-up. Host/gc mode is unchanged.
+  // emitting an unsatisfiable import.
   if (ctx.standalone || ctx.wasi) {
+    // (#3363) Native depth-1 homogeneous nested-array flatten first; falls
+    // through to the loud refusal below for depth args / non-nested / mixed
+    // receivers (the larger recursive/heterogeneous arm stays a #2717 follow-up).
+    const native = tryCompileArrayFlatNativeDepth1(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+    if (native) return native;
     reportError(
       ctx,
       callExpr,

--- a/tests/issue-3363.test.ts
+++ b/tests/issue-3363.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #3363 — standalone-native Array.prototype.flat() (depth-1 homogeneous nested array).
+//
+// #2717 only added the fail-loud refusal for standalone flat() (it swapped the
+// unsatisfiable __array_flat host import for a loud CE) and deferred the native
+// flatten arm. This slice lands the common, tractable case: a depth-1 flatten of
+// a statically-typed homogeneous nested array `T[][]` — a straight concatenation
+// of the inner vecs into a fresh result vec of the inner element kind. An
+// explicit depth argument / non-nested receiver still refuses loudly. Host mode
+// keeps the __array_flat delegation (unchanged).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#3363 — Array.prototype.flat() (standalone, depth-1 homogeneous)", () => {
+  it("flattens [[1,2],[3]] to length 3", async () => {
+    expect(await runStandalone(`export function test(): number { return [[1,2],[3]].flat().length; }`)).toBe(3);
+  });
+
+  it("preserves element values and order ([[1,2],[3]] -> [1,2,3])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const b = [[1,2],[3]].flat(); return b[0]*100 + b[1]*10 + b[2]; }`,
+      ),
+    ).toBe(123);
+  });
+
+  it("sums all flattened elements ([[1,2],[3,4]] -> 10)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const b = [[1,2],[3,4]].flat(); return b[0]+b[1]+b[2]+b[3]; }`,
+      ),
+    ).toBe(10);
+  });
+
+  it("skips empty inner arrays ([[1],[],[2,3]] -> [1,2,3])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const b = [[1],[],[2,3]].flat(); return b.length*10 + b[1]; }`,
+      ),
+    ).toBe(32);
+  });
+
+  it("empty outer array flattens to empty", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a: number[][] = []; return a.flat().length; }`),
+    ).toBe(0);
+  });
+
+  it("all-empty inner arrays flatten to empty", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const b = [[],[]].flat() as number[]; return b.length; }`),
+    ).toBe(0);
+  });
+
+  it("single inner array ([[5,6,7]] -> [5,6,7])", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const b = [[5,6,7]].flat(); return b.length*100 + b[2]; }`),
+    ).toBe(307);
+  });
+
+  it("works on a statically-typed number[][] variable receiver", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: number[][] = [[9,8],[7]]; const b = a.flat(); return b[0] + b[2]; }`,
+      ),
+    ).toBe(16);
+  });
+
+  it("flattens nested string arrays too (homogeneous inner vec of any kind)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[][] = [["ab","cd"],["ef"]]; const b = a.flat(); return b.length*10 + b[2].length; }`,
+      ),
+    ).toBe(32);
+  });
+
+  it("does not leak host imports (zero-import instantiation)", async () => {
+    const r = await compile(`export function test(): number { return [[1,2,3],[4,5]].flat().length; }`, {
+      target: "standalone",
+    });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test(): number }).test()).toBe(5);
+  });
+
+  it("an explicit depth argument still refuses loudly (out of scope)", async () => {
+    const r = await compile(`export function test(): number { return [[1,2],[3]].flat(1).length; }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(false);
+    expect(JSON.stringify(r.errors)).toContain("flat()");
+  });
+});


### PR DESCRIPTION
## #3363 — standalone-native `Array.prototype.flat()` (depth-1 homogeneous)

Lands the common, tractable slice of the native flatten arm that **#2717
deferred** — that issue only added the *fail-loud refusal* (swapping the
unsatisfiable `__array_flat` host import for a loud CE under `--target
standalone`/`wasi`) and explicitly punted "a native recursive-flatten arm … a
separate, larger follow-up." Verified against current main that `flat()` still
hard-CEs standalone; buckets 1/5 of the #3180 umbrella are peer/dev-f owned, so
this is non-colliding.

### What
- `tryCompileArrayFlatNativeDepth1` flattens a statically-typed **homogeneous**
  nested array `T[][]` at the **default depth (1)** — a straight concatenation
  of each inner vec's elements into a fresh result vec of the inner element
  kind. Two-pass: sum inner lengths → allocate → `array.copy` each inner vec
  contiguously (null inner refs skipped).
- `compileArrayFlat` now receives the outer vec's `vecTypeIdx`/`arrTypeIdx`/
  `elemType`; when `elemType` resolves to a ref to an inner `$vec` struct it
  emits the native arm, else falls through to the **existing loud refusal**.

### Scope / safety
- **Out of scope, still refuses loudly:** an explicit `depth` argument, deeper
  recursion, heterogeneous array/scalar unions (the larger #2717 follow-up).
- **Host/gc mode unchanged** — keeps the `__array_flat` delegation.
- Works for any homogeneous inner element kind (`number[][]`, `string[][]`).
- Standalone byte-native, **0 host imports**.

### Tests
`tests/issue-3363.test.ts` — 11 cases (order preservation, empty inner/outer,
single/nested-string, zero-import instantiation, depth-arg-still-refuses). All
pass locally; tsc clean; LOC gate granted in the issue frontmatter.

Child slice of #2717 follow-up / #3180 umbrella (parent #2860 standalone-vs-host
gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)