### PR TITLE
fix(#3364): key empty-object widening maps per-declaration, not by bare name

### DIFF
--- a/plan/issues/3364-widened-object-same-name-shape-collision.md
+++ b/plan/issues/3364-widened-object-same-name-shape-collision.md
@@ -24,6 +24,19 @@ depends_on: []
 # `getSymbolAtLocation` sites in codegen. Sanctioned oracle-ratchet allowance.
 oracle-ratchet-allow:
   - src/codegen/widened-var-key.ts
+# (#3364) The per-declaration widening key threads through the existing widened
+# lookup sites in these god-files; the change is a small in-place key swap
+# (bare name → name+declStart), a few lines each — not new subsystem logic that
+# belongs elsewhere. The bulk of the fix lives in the new leaf module
+# src/codegen/widened-var-key.ts.
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/registry/imports.ts
+  - src/codegen/statements/variables.ts
+  - src/codegen/typeof-delete.ts
+  - src/codegen/expressions/unary-updates.ts
+  - src/codegen/property-access.ts
+  - src/codegen/literals.ts
 ---
 
 # #3364 — widened `{}` struct shape clobbered by a same-named variable elsewhere

--- a/plan/issues/3364-widened-object-same-name-shape-collision.md
+++ b/plan/issues/3364-widened-object-same-name-shape-collision.md
@@ -1,0 +1,116 @@
+---
+id: 3364
+title: "Widened empty-object struct shape clobbered by a same-named var in an unrelated function (bare-name keying)"
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/dev-i
+sprint: current
+created: 2026-07-17
+priority: high
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: object
+goal: correctness
+parent: 2927
+related: [3343, 3308, 2937, 3024]
+depends_on: []
+---
+
+# #3364 — widened `{}` struct shape clobbered by a same-named variable elsewhere
+
+Found while root-causing #3343. **Distinct from** the #3343 fix (which addressed
+a `for (let i)` loop-counter aliasing a module global, in `loops.ts`). This bug
+**still reproduces on `main` after #3343 landed** — verified in a scratch
+worktree at `upstream/main`.
+
+## Problem
+
+`const x = {}` followed by out-of-shape property writes (`x.p = …`) is promoted
+to a **static struct** by the empty-object shape-widening pre-pass
+(`src/codegen/declarations/object-shape-widening.ts`). The synthesized struct
+shape was recorded in `ctx.widenedTypeProperties` / `ctx.widenedVarStructMap`
+keyed by the **bare variable name**.
+
+That key collides across functions. Acorn's parser (and the #3308 in-Wasm AST
+probe) reuse generic local names — `node`, `type`, `parent` — in many
+functions, each building an object with a **different field set**. With
+bare-name keying, the **last** widening for a given name overwrote every other
+same-named var, so every other same-named var's literal built the **wrong
+(foreign) struct**:
+
+- its real field values were computed and then **dropped** at `struct.new`
+  (WAT shows a degenerate 1-field `struct.new` with the extra operands
+  `drop`ped),
+- while the field getters still read the correct struct via `ref.test` →
+  **type mismatch** → `ref`/string fields (`.callee`, `.type`, `.arguments`, …)
+  read back **null**.
+
+Scale-dependent purely because more functions ⇒ more name collisions — the same
+symptom that surfaced as the #3308 / #3343 in-Wasm recursive-walk runaway, but a
+**separate cause** from the loop-counter bug fixed under #3343.
+
+## Minimal repro (standalone, no acorn)
+
+```ts
+function ident(k: number): any { const node: any = {}; node.type="Identifier"; node.start=k; node.name="v"; return node; }
+function call(callee: any, args: any): any {
+  const node: any = {};
+  node.type="CallExpression"; node.callee=callee; node.arguments=args; node.optional=false; return node;
+}
+// UNUSED, same local name 'node', DIFFERENT shape → clobbers call's struct.
+function foo(e: any): any { const node: any = {}; node.expression = e; return node; }
+export function test(): number {
+  const cl = call(ident(1), [ident(2)]);
+  return (cl.callee !== null && cl.callee !== undefined) ? 1 : 0; // pre-fix: 0
+}
+```
+
+Renaming `foo`'s local `node` → `zzz` makes it pass — proof the trigger is the
+bare-name collision.
+
+## Root cause
+
+`widenedTypeProperties` / `widenedVarStructMap` keyed by `decl.name.text`.
+`any`-typed widened vars in particular rely on this name key (they skip
+`anonTypeMap`, which is bypassed for the shared `any` singleton type), so the
+last same-named widening wins for both the constructor and the local typing.
+
+## Fix
+
+Key both maps **per declaration** (name + declaration start offset) —
+`src/codegen/widened-var-key.ts`:
+
+- `widenedVarKeyFromDecl(name)` at SET / declaration sites (the widening
+  pre-pass, `literals.ts` `compileWidenedEmptyObject`, `statements/variables.ts`).
+- `resolveWidenedVarKey(ctx, ident)` / `widenedStructNameForUse(ctx, ident)` at
+  USE sites (member reads/writes, `delete`, element-access import gating):
+  resolve the receiver identifier's symbol → `valueDeclaration` → recompute the
+  same key.
+
+Non-colliding modules are **byte-identical** (the same struct is resolved, via a
+different key string); only same-name / different-shape collisions change (to
+correct).
+
+Updated use sites: `property-access.ts`, `statements/variables.ts` (×2),
+`expressions/unary-updates.ts`, `registry/imports.ts`, `typeof-delete.ts` (×2),
+`object-ops.ts` (×3).
+
+## Acceptance criteria
+
+- [x] A same-named local in an unrelated function no longer clobbers a widened
+      object's read shape (standalone).
+- [x] Every field of a widened object survives when a same-named var exists
+      elsewhere.
+- [x] A full recursive in-Wasm walk of a heterogeneous AST-shaped tree (node
+      builders reusing generic local names) terminates with the exact node
+      count — `tests/issue-3364.test.ts`.
+
+## Notes
+
+- Likely also reduces the **#3024** "`struct.new` — not enough args" gc-lane
+  validator-error cluster (same degenerate-struct mechanism). #3024 is a broad
+  131-test multi-cause bucket with a separate owner — left open; cross-linked.
+- 98 widening-suite tests pass unchanged
+  (#2584/#2849/#2937/#2944/#2372/#3125 + object-literals + getters/setters).

--- a/plan/issues/3364-widened-object-same-name-shape-collision.md
+++ b/plan/issues/3364-widened-object-same-name-shape-collision.md
@@ -16,6 +16,14 @@ goal: correctness
 parent: 2927
 related: [3343, 3308, 2937, 3024]
 depends_on: []
+# (#3364) `resolveWidenedVarKey` resolves a USE-site receiver identifier to its
+# variable DECLARATION (for the per-declaration widening key) via
+# `checker.getSymbolAtLocation` → `symbol.valueDeclaration`. This is raw
+# symbol/declaration IDENTITY, not a type query — `ctx.oracle` (which answers
+# type questions) cannot express it, and it mirrors the 296 existing
+# `getSymbolAtLocation` sites in codegen. Sanctioned oracle-ratchet allowance.
+oracle-ratchet-allow:
+  - src/codegen/widened-var-key.ts
 ---
 
 # #3364 — widened `{}` struct shape clobbered by a same-named variable elsewhere

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2090,9 +2090,19 @@ export interface CodegenContext {
   moduleUsesDynTaView: boolean;
   /** Type index for the WasmGC `$Error_struct` used in standalone/WASI mode (#1104). -1 = not yet registered. */
   errorStructTypeIdx: number;
-  /** Extra properties for empty object variables */
+  /**
+   * Extra properties for empty object variables.
+   *
+   * (#3364) Keyed by a PER-DECLARATION key (`widenedVarKey`, name + decl start
+   * offset), NOT the bare variable name. Acorn's parser reuses generic local
+   * names (`node`, `type`, …) across many functions, each building an object
+   * with a DIFFERENT field set; bare-name keying let the last widening win, so
+   * every other same-named var built the WRONG struct — dropping its real field
+   * values, so `.callee`/`.type`/… read back null (the in-Wasm AST walk then
+   * ran away). Per-declaration keys keep each var's shape distinct.
+   */
   widenedTypeProperties: Map<string, { name: string; type: ValType }[]>;
-  /** Map from widened variable name to its registered struct name */
+  /** Map from widened variable's per-declaration key (#3364) to its registered struct name */
   widenedVarStructMap: Map<string, string>;
   /** Widened empty-object fields introduced by Object.defineProperty rather than assignment. */
   widenedDefinePropertyKeys: Set<string>;

--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -9,6 +9,7 @@ import { forEachChild, ts } from "../../ts-api.js";
 import { resolveWasmType } from "../index.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecType, registerStructType } from "../registry/types.js";
+import { widenedVarKeyFromDecl } from "../widened-var-key.js";
 import type { FieldDef, ValType } from "../../ir/types.js";
 import type { CodegenContext } from "../context/types.js";
 
@@ -178,7 +179,13 @@ export function collectEmptyObjectWidening(
           }
 
           if (extraProps.length > 0) {
-            ctx.widenedTypeProperties.set(varName, extraProps);
+            // (#3364) Key by the DECLARATION site, not the bare name — acorn
+            // reuses generic local names (`node`) across many functions with
+            // different shapes, and bare-name keying let the last widening
+            // clobber every other same-named var (foreign struct → dropped
+            // fields → null reads → runaway walk).
+            const varKey = widenedVarKeyFromDecl(decl.name);
+            ctx.widenedTypeProperties.set(varKey, extraProps);
 
             // Register the struct type now so that collectDeclarations
             // can resolve the variable type to a struct ref instead of externref
@@ -189,8 +196,8 @@ export function collectEmptyObjectWidening(
             }));
             const structName = `__anon_${ctx.anonTypeCounter++}`;
             registerStructType(ctx, structName, fields);
-            // Map variable name to struct name for later lookup
-            ctx.widenedVarStructMap.set(varName, structName);
+            // Map variable declaration key to struct name for later lookup
+            ctx.widenedVarStructMap.set(varKey, structName);
             // Also try to map TS types (may not match later due to type identity)
             // Skip `any` — it's a singleton type object shared by all any-typed vars,
             // so registering it would cause every any-typed var to resolve to this struct.

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -11,6 +11,7 @@ import { ts } from "../../ts-api.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
 import { tryEmitLinearU8ElementUpdate } from "../linear-uint8-codegen.js";
+import { resolveWidenedVarKey } from "../widened-var-key.js";
 import { reportError } from "../context/errors.js";
 import { reportSilentFallback } from "../fallback-telemetry.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
@@ -481,8 +482,10 @@ function compileMemberIncDec(
     ensureStructForType(ctx, objType);
     let typeName = resolveStructName(ctx, objType);
     // Fallback: check widened variable struct map (matches compilePropertyAssignment)
+    // (#3364) keyed per-declaration, not by bare name.
     if (!typeName && ts.isIdentifier(operand.expression)) {
-      typeName = ctx.widenedVarStructMap.get(operand.expression.text);
+      const key = resolveWidenedVarKey(ctx, operand.expression);
+      if (key !== undefined) typeName = ctx.widenedVarStructMap.get(key);
     }
     if (!typeName) {
       // (#2656) Unresolvable static struct type — typically an `any`/`externref`

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -43,6 +43,7 @@ import { resolveStructName } from "./expressions/misc.js";
 import { arrayIteratorOverrideGlobalIdx, emitArrayProtoIteratorDrive } from "./expressions/proto-override.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
+import { widenedVarKeyFromDecl } from "./widened-var-key.js";
 import { isStrictFunction, isSimpleParameterList } from "./helpers/is-strict-function.js";
 import { collectInstrs } from "./statements/shared.js";
 import {
@@ -1321,7 +1322,8 @@ export function compileObjectLiteral(
   // properties (from pre-pass), register the struct with those extra fields and
   // compile as a struct.new with default values for the widened fields.
   if (expr.properties.length === 0 && ts.isVariableDeclaration(expr.parent) && ts.isIdentifier(expr.parent.name)) {
-    const widenedProps = ctx.widenedTypeProperties.get(expr.parent.name.text);
+    // (#3364) Look up by the DECLARATION-site key, not the bare name.
+    const widenedProps = ctx.widenedTypeProperties.get(widenedVarKeyFromDecl(expr.parent.name));
     if (widenedProps && widenedProps.length > 0) {
       return compileWidenedEmptyObject(ctx, fctx, expr, widenedProps);
     }
@@ -1904,7 +1906,7 @@ export function compileWidenedEmptyObject(
     typeName = ctx.anonTypeMap.get(varType);
   }
   if (!typeName && ts.isVariableDeclaration(expr.parent) && ts.isIdentifier(expr.parent.name)) {
-    typeName = ctx.widenedVarStructMap.get(expr.parent.name.text);
+    typeName = ctx.widenedVarStructMap.get(widenedVarKeyFromDecl(expr.parent.name));
   }
   if (!typeName) {
     // Fallback: the pre-pass should have registered it but didn't match type identity.
@@ -1940,7 +1942,7 @@ export function compileWidenedEmptyObject(
         ctx.anonTypeMap.set(varType, typeName);
       }
       // Record via widenedVarStructMap so later lookups still find it for any-typed vars.
-      ctx.widenedVarStructMap.set(expr.parent.name.text, typeName);
+      ctx.widenedVarStructMap.set(widenedVarKeyFromDecl(expr.parent.name), typeName);
     }
   }
   if (!typeName) return null;

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -23,6 +23,7 @@ import { emitThrowRangeError, emitThrowTypeError } from "./expressions/helpers.j
 import { buildThrowJsErrorInstrs } from "./js-errors.js"; // (#3177 slice 4) defineProperty rejection sentinel → TypeError
 import { emitMappedArgReverseSync } from "./expressions/logical-ops.js";
 import { resolveStructName } from "./expressions/misc.js";
+import { widenedStructNameForUse } from "./widened-var-key.js";
 import { addUnionImports, cacheStringLiterals, getOrRegisterTupleType, resolveWasmType } from "./index.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
@@ -1614,8 +1615,7 @@ export function compileObjectDefineProperty(
   // Check if obj is a struct type with the given field
   const objTsType = ctx.checker.getTypeAtLocation(objArg);
   let structName =
-    resolveStructName(ctx, objTsType) ||
-    (ts.isIdentifier(objArg) ? ctx.widenedVarStructMap.get(objArg.text) : undefined);
+    resolveStructName(ctx, objTsType) || (ts.isIdentifier(objArg) ? widenedStructNameForUse(ctx, objArg) : undefined);
 
   // (#1629 S3) Whether the receiver is *statically* struct-typed — i.e. resolved
   // WITHOUT the `any`/externref rescue fallbacks 1-3 below. This is the same
@@ -2972,8 +2972,7 @@ function emitExternDefinePropertyNoValue(
   // consult for `get: identifierRef` / `set: identifierRef` descriptors.
   const objTsType = ctx.checker.getTypeAtLocation(objArg);
   const _staticStructName = resolveStructName(ctx, objTsType);
-  const _structName =
-    _staticStructName || (ts.isIdentifier(objArg) ? ctx.widenedVarStructMap.get(objArg.text) : undefined);
+  const _structName = _staticStructName || (ts.isIdentifier(objArg) ? widenedStructNameForUse(ctx, objArg) : undefined);
   const _propName = ts.isStringLiteral(propArg) ? propArg.text : undefined;
   const _structTypeIdx = _structName ? ctx.structMap.get(_structName) : undefined;
   const _fields = _structName ? ctx.structFields.get(_structName) : undefined;
@@ -3509,7 +3508,7 @@ export function compileObjectDefineProperties(
         const objTsType = ctx.checker.getTypeAtLocation(objArg);
         const structName =
           resolveStructName(ctx, objTsType) ||
-          (ts.isIdentifier(objArg) ? ctx.widenedVarStructMap.get(objArg.text) : undefined);
+          (ts.isIdentifier(objArg) ? widenedStructNameForUse(ctx, objArg) : undefined);
         const structTypeIdx = structName ? ctx.structMap.get(structName) : undefined;
         const fields = structName ? ctx.structFields.get(structName) : undefined;
         const fieldIdx = fields && propName ? fields.findIndex((f) => f.name === propName) : -1;

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -21,6 +21,7 @@ import { emitBoundsCheckedArrayGet } from "./array-methods.js";
 import { emitHoleToUndefined } from "./array-holes.js"; // (#2001 S1)
 import { classMemberFuncKey, resolveMethodOwnerClass } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys; (#2963) method-owner chain
 import { popBody, pushBody } from "./context/bodies.js";
+import { resolveWidenedVarKey } from "./widened-var-key.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.js";
@@ -730,7 +731,9 @@ export function resolveStructNameForExpr(
   const objType = ctx.checker.getTypeAtLocation(expression);
   let typeName = resolveStructName(ctx, objType);
   if (!typeName && ts.isIdentifier(expression)) {
-    typeName = ctx.widenedVarStructMap.get(expression.text);
+    // (#3364) resolve to the receiver's declaration key, not the bare name.
+    const key = resolveWidenedVarKey(ctx, expression);
+    if (key !== undefined) typeName = ctx.widenedVarStructMap.get(key);
   }
   if (!typeName && expression.kind === ts.SyntaxKind.ThisKeyword) {
     typeName = resolveThisStructName(ctx, fctx);

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -8,6 +8,7 @@
 import type { Import, Instr, TagDef, ValType } from "../../ir/types.js";
 import type { CodegenContext, ExternClassInfo } from "../context/types.js";
 import { buildStrictHostImportError, isHostImportAllowed } from "../host-import-allowlist.js";
+import { resolveWidenedVarKey } from "../widened-var-key.js";
 import { hasLoneSurrogate, hexCodeUnits, STRING_CONSTANTS16_NS } from "../../string-surrogate.js";
 import { addFuncType } from "./types.js";
 // #808 — dependencies of the import-collection/registration functions moved
@@ -2225,7 +2226,13 @@ export function collectUsedExternImports(ctx: CodegenContext, sourceFile: ts.Sou
       const sym = objType.getSymbol();
       // Skip Array and tuple types — those use Wasm GC struct/array ops, not host import
       // Skip widened empty objects — those use struct.get, not host import
-      const isWidenedVar = ts.isIdentifier(node.expression) && ctx.widenedVarStructMap.has(node.expression.text);
+      // (#3364) resolve to the receiver's declaration key, not the bare name.
+      const isWidenedVar =
+        ts.isIdentifier(node.expression) &&
+        ((): boolean => {
+          const key = resolveWidenedVarKey(ctx, node.expression);
+          return key !== undefined && ctx.widenedVarStructMap.has(key);
+        })();
       if (
         !isCallCallee &&
         !isNativeStandaloneRegExpMatchArray &&

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -11,6 +11,7 @@ import type { CodegenContext, FunctionContext, NullGuardFact, NullishExclusion }
 import { emitCoercedLocalSet, noJsHost } from "../expressions/helpers.js";
 import { emitUndefined } from "../expressions/late-imports.js";
 import { needsTdzFlag, resolveWasmType, varBindingNeedsExternrefForUndefined } from "../index.js";
+import { widenedVarKeyFromDecl } from "../widened-var-key.js";
 import {
   objectLiteralIsStandaloneAnyObjectCarrier,
   objectLiteralSpreadTakesHostPath,
@@ -165,7 +166,8 @@ export function resolveSpillLocalValType(ctx: CodegenContext, decl: ts.VariableD
   if (ctx.growableObjectLiteralVars.has(name)) return { kind: "externref" };
   // A var whose properties were widened (empty-obj + later prop writes) gets a
   // synthesized struct; mirror it if the struct is registered, else bail.
-  const widenedStructName = ctx.widenedVarStructMap.get(name);
+  // (#3364) keyed per-declaration, not by bare name.
+  const widenedStructName = ctx.widenedVarStructMap.get(widenedVarKeyFromDecl(decl.name));
   if (widenedStructName !== undefined) {
     const idx = ctx.structMap.get(widenedStructName);
     return idx === undefined ? null : { kind: "ref_null", typeIdx: idx };
@@ -971,7 +973,10 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
     // Override type for string methods returning host arrays (e.g. split() returns
     // externref but TS types as string[] which resolveWasmType maps to GC vec struct)
     // Check if this variable has widened properties (empty obj with later prop assignments)
-    const widenedStructName = ctx.widenedVarStructMap.get(name);
+    // (#3364) keyed per-declaration, not by bare name.
+    const widenedStructName = ts.isIdentifier(decl.name)
+      ? ctx.widenedVarStructMap.get(widenedVarKeyFromDecl(decl.name))
+      : undefined;
     const widenedTypeIdx = widenedStructName !== undefined ? ctx.structMap.get(widenedStructName) : undefined;
     // #1197: i32-specialized number[] arrays get __vec_i32 instead of __vec_f64.
     // The override is applied AFTER the standard type computation so it stacks

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -5,6 +5,7 @@
  */
 import { ts } from "../ts-api.js";
 import { chainRootIsGrowable } from "./property-access.js";
+import { resolveWidenedVarKey } from "./widened-var-key.js";
 import { isBooleanType, isStringType, isSymbolType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
@@ -447,7 +448,9 @@ export function compileDeleteExpression(
     const objType = ctx.checker.getTypeAtLocation(inner.expression);
     let typeName = resolveStructName(ctx, objType);
     if (!typeName && ts.isIdentifier(inner.expression)) {
-      typeName = ctx.widenedVarStructMap.get(inner.expression.text);
+      // (#3364) keyed per-declaration, not by bare name.
+      const key = resolveWidenedVarKey(ctx, inner.expression);
+      if (key !== undefined) typeName = ctx.widenedVarStructMap.get(key);
     }
     if (typeName) {
       const structTypeIdx = ctx.structMap.get(typeName);
@@ -543,7 +546,9 @@ export function compileDeleteExpression(
     const objType = ctx.checker.getTypeAtLocation(inner.expression);
     let typeName = resolveStructName(ctx, objType);
     if (!typeName && ts.isIdentifier(inner.expression)) {
-      typeName = ctx.widenedVarStructMap.get(inner.expression.text);
+      // (#3364) keyed per-declaration, not by bare name.
+      const key = resolveWidenedVarKey(ctx, inner.expression);
+      if (key !== undefined) typeName = ctx.widenedVarStructMap.get(key);
     }
     if (typeName) {
       const structTypeIdx = ctx.structMap.get(typeName);

--- a/src/codegen/widened-var-key.ts
+++ b/src/codegen/widened-var-key.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3364) Per-declaration keys for the empty-object shape-widening maps
+ * (`widenedTypeProperties` / `widenedVarStructMap`).
+ *
+ * These maps record the synthesized struct shape for a `var x = {}` that later
+ * receives out-of-shape property writes (`x.a = …`). They were originally keyed
+ * by the BARE variable name (`x`). That collides across functions: acorn's
+ * parser reuses generic local names (`node`, `type`, `parent`, …) in many
+ * functions, each building an object with a DIFFERENT field set. With bare-name
+ * keying the LAST widening for a given name overwrote all the others, so every
+ * other same-named var built the WRONG (foreign) struct — its real field values
+ * were dropped at `struct.new`, and reads of the missing ref/string fields
+ * (`.callee`, `.type`, `.arguments`, …) returned null. A full recursive in-Wasm
+ * walk over such objects then mis-descended and ran away (#3364 / #3308).
+ *
+ * The fix keys the maps by name PLUS the declaration's source start offset,
+ * which is unique per declaration site within a module. The SET side (the
+ * widening pre-pass and the literal builder) has the declaration identifier
+ * directly; USE sites (member reads/writes, delete, typeof, `in`) resolve the
+ * receiver identifier's symbol to its `valueDeclaration` and recompute the same
+ * key, so both sides agree. When a use site cannot be resolved to a widened
+ * declaration the lookup simply misses — identical to the previous
+ * bare-name-miss behavior — and the value stays on the dynamic `$Object` path.
+ */
+import { ts } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+
+/**
+ * Build the per-declaration key for a widened `{}` variable, given its
+ * declaration-site name identifier. Uses the identifier's source start offset,
+ * which is stable and unique per declaration within the source file.
+ */
+export function widenedVarKeyFromDecl(name: ts.Identifier): string {
+  // getStart() is safe for real source nodes (all widened decls are). Fall back
+  // to `pos` defensively for any synthesized node.
+  let offset: number;
+  try {
+    offset = name.getStart();
+  } catch {
+    offset = name.pos;
+  }
+  return `${name.text}@${offset}`;
+}
+
+/**
+ * Resolve a USE-site receiver identifier to the per-declaration key of the
+ * widened variable it refers to, or `undefined` when it does not resolve to a
+ * simple `var/let/const <name>` declaration (in which case the caller treats it
+ * as a non-widened receiver, exactly like the old bare-name miss).
+ */
+export function resolveWidenedVarKey(ctx: CodegenContext, ident: ts.Identifier): string | undefined {
+  const sym = ctx.checker.getSymbolAtLocation(ident);
+  const decl = sym?.valueDeclaration;
+  if (decl && ts.isVariableDeclaration(decl) && ts.isIdentifier(decl.name)) {
+    return widenedVarKeyFromDecl(decl.name);
+  }
+  return undefined;
+}
+
+/**
+ * Convenience: the registered widened struct name for a USE-site receiver
+ * identifier, or `undefined` when the receiver is not a widened `{}` variable.
+ * Combines {@link resolveWidenedVarKey} with the `widenedVarStructMap` lookup.
+ */
+export function widenedStructNameForUse(ctx: CodegenContext, ident: ts.Identifier): string | undefined {
+  const key = resolveWidenedVarKey(ctx, ident);
+  return key === undefined ? undefined : ctx.widenedVarStructMap.get(key);
+}

--- a/tests/issue-3364.test.ts
+++ b/tests/issue-3364.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3364 — widened empty-object struct shape clobbered by a same-named variable
+// in an unrelated function (a distinct, still-live cause of the #3343/#3308
+// in-Wasm recursive-read runaway; #3343 itself was fixed separately in loops.ts
+// for a for-loop-counter aliasing bug, which does NOT cover this one).
+//
+// Root cause: the empty-object shape-widening maps (`widenedTypeProperties` /
+// `widenedVarStructMap`) were keyed by the BARE variable name. Acorn's parser
+// reuses generic local names (`node`, `type`, …) across many functions, each
+// building an object with a DIFFERENT field set; bare-name keying let the last
+// widening clobber all the others, so every other same-named var built the
+// WRONG (foreign) struct — its real field values were dropped at `struct.new`,
+// and reads of the missing ref/string fields (`.callee`, `.type`, …) returned
+// null. A full recursive in-Wasm walk over such objects then mis-descended and
+// ran away past a 1e6 budget (#3308).
+//
+// Fix: key the maps per-declaration (name + declaration start offset) so each
+// same-named-but-distinct-shape var keeps its own struct.
+//
+// These are pure-Wasm standalone builds (no host), exactly the #2928/#3308
+// interpreter-ladder path. No acorn compile — the objects are hand-built.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string, arg?: number): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const fn = (instance.exports as { test: (a?: number) => unknown }).test;
+  return arg === undefined ? fn() : fn(arg);
+}
+
+describe("#3364 widened-object same-name cross-function shape collision", () => {
+  it("a same-named local in an unrelated function does not clobber the read shape", async () => {
+    // `call` and the UNUSED `foo` both name their local `node` but with
+    // different shapes. Pre-fix, foo's 1-field shape clobbered call's 6-field
+    // shape, so `cl.callee` read back null.
+    const src = `
+      function ident(k: number): any {
+        const node: any = {};
+        node.type = "Identifier"; node.start = k; node.end = k + 1; node.name = "v";
+        return node;
+      }
+      function call(callee: any, args: any): any {
+        const node: any = {};
+        node.type = "CallExpression"; node.start = 0; node.end = 1;
+        node.callee = callee; node.arguments = args; node.optional = false;
+        return node;
+      }
+      // UNUSED, same local name 'node', different shape.
+      function foo(e: any): any { const node: any = {}; node.expression = e; return node; }
+      export function test(): number {
+        const cl = call(ident(1), [ident(2), ident(3)]);
+        const c = cl.callee;
+        return (c !== null && c !== undefined && typeof c === "object") ? 1 : 0;
+      }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("every field of a widened object survives when a same-named var exists elsewhere", async () => {
+    const src = `
+      function ident(k: number): any {
+        const node: any = {};
+        node.type = "Identifier"; node.start = k; node.end = k + 1; node.name = "v";
+        return node;
+      }
+      function call(callee: any, args: any): any {
+        const node: any = {};
+        node.type = "CallExpression"; node.start = 0; node.end = 1;
+        node.callee = callee; node.arguments = args; node.optional = false;
+        return node;
+      }
+      function foo(e: any): any { const node: any = {}; node.expression = e; return node; }
+      export function test(): number {
+        const cl = call(ident(1), [ident(2), ident(3)]);
+        const okType: number = (typeof cl.type === "string") ? 1 : 0;
+        const okStart: number = (cl.start !== null && cl.start !== undefined) ? 1 : 0;
+        const okEnd: number = (cl.end !== null && cl.end !== undefined) ? 1 : 0;
+        const okCallee: number = (cl.callee !== null && cl.callee !== undefined) ? 1 : 0;
+        const okArgs: number = (cl.arguments !== null && cl.arguments !== undefined) ? 1 : 0;
+        const okOpt: number = (cl.optional !== null && cl.optional !== undefined) ? 1 : 0;
+        return okType * 100000 + okStart * 10000 + okEnd * 1000 + okCallee * 100 + okArgs * 10 + okOpt;
+      }`;
+    expect(await runStandalone(src)).toBe(111111);
+  });
+
+  it("a full recursive in-Wasm walk of a heterogeneous AST-shaped tree terminates with the exact node count", async () => {
+    // Build a Program with a body[] of ExpressionStatements, each wrapping a
+    // CallExpression tree, then walk it recursively (no visited set — a spurious
+    // back-edge would run away past the budget). All node builders reuse generic
+    // local names across functions, the exact acorn-parser pattern.
+    const src = `
+      let e0Budget: number = 0;
+      let e0Hit: number = 0;
+      function walk(node: any): number {
+        if (e0Budget <= 0) { e0Hit = 1; return 0; }
+        e0Budget = e0Budget - 1;
+        if (node === null || node === undefined) return 0;
+        if (typeof node !== "object") return 0;
+        if (Array.isArray(node)) {
+          let m = 0;
+          const len: number = (node as any).length;
+          for (let i = 0; i < len; i++) { if (e0Budget <= 0) { e0Hit = 1; return m; } m = m + walk(node[i]); }
+          return m;
+        }
+        const t = node.type;
+        if (typeof t !== "string") return 0;
+        let n = 1;
+        if (t === "Program") { n = n + walk(node.body); return n; }
+        if (t === "ExpressionStatement") { n = n + walk(node.expression); return n; }
+        if (t === "BinaryExpression") { n = n + walk(node.left); n = n + walk(node.right); return n; }
+        if (t === "CallExpression") { n = n + walk(node.callee); n = n + walk(node.arguments); return n; }
+        if (t === "Identifier") { return n; }
+        return n;
+      }
+      function ident(): any {
+        const node: any = {};
+        node.type = "Identifier"; node.start = 0; node.end = 1; node.name = "v";
+        return node;
+      }
+      function binary(l: any, r: any): any {
+        const node: any = {};
+        node.type = "BinaryExpression"; node.start = 0; node.end = 1;
+        node.left = l; node.right = r; node.operator = "+";
+        return node;
+      }
+      function call(callee: any, args: any): any {
+        const node: any = {};
+        node.type = "CallExpression"; node.start = 0; node.end = 1;
+        node.callee = callee; node.arguments = args; node.optional = false;
+        return node;
+      }
+      function exprStmt(e: any): any {
+        const node: any = {};
+        node.type = "ExpressionStatement"; node.start = 0; node.end = 1;
+        node.expression = e;
+        return node;
+      }
+      function makeExpr(depth: number): any {
+        if (depth <= 0) { return ident(); }
+        const b = binary(makeExpr(depth - 1), makeExpr(depth - 1));
+        const args: any[] = [b, ident(), ident()];
+        return call(ident(), args);
+      }
+      export function test(nstmts: number): number {
+        const body: any[] = [];
+        let i: number = 0;
+        while (i < nstmts) { body.push(exprStmt(makeExpr(3))); i = i + 1; }
+        const prog: any = {};
+        prog.type = "Program"; prog.start = 0; prog.end = 1; prog.body = body;
+        e0Budget = 1000000;
+        e0Hit = 0;
+        const n = walk(prog);
+        return e0Hit ? -99999 : n;
+      }`;
+    // Per-statement node count for depth-3 makeExpr walk:
+    //   E(d) = 5 + 2*E(d-1), E(0)=1  =>  E(3)=43; stmt = 1(exprStmt)+43 = 44.
+    // Program: 1 + nstmts*44.
+    expect(await runStandalone(src, 6)).toBe(1 + 6 * 44);
+    expect(await runStandalone(src, 10)).toBe(1 + 10 * 44);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **#3364** — a widened empty-object (`const x = {}` + later `x.p = …`)
built the **wrong static struct** when an **unrelated function** declared a
variable with the **same name** but a **different shape**.

The shape-widening pre-pass promotes such vars to a static struct and recorded
the shape in `widenedTypeProperties` / `widenedVarStructMap` keyed by the **bare
variable name**. Acorn's parser (and the #3308 in-Wasm AST probe) reuse generic
local names (`node`, `type`, …) across many functions, each with a different
field set. Bare-name keying let the **last** widening clobber all the others, so
every other same-named var's literal built the **wrong (foreign) struct** — its
real field values were **dropped** at `struct.new` while the field getters still
read the correct struct via `ref.test` → mismatch → `ref`/string fields
(`.callee`, `.type`, `.arguments`, …) read back **null**.

## Relation to #3343 / #3308

This is a **distinct, still-live** cause of the #3308/#3343 in-Wasm
recursive-walk runaway. #3343 itself was fixed separately (loops.ts, a
`for (let i)` loop-counter aliasing a module global) — that fix does **not**
cover this one (verified reproducing on `main` after #3343 landed). Renaming a
colliding local (`node`→`zzz`) is the discriminating repro.

## Fix

Key both maps **per declaration** (name + declaration start offset) —
`src/codegen/widened-var-key.ts`:
- `widenedVarKeyFromDecl` at SET/declaration sites (widening pre-pass,
  `literals.ts`, `statements/variables.ts`),
- `resolveWidenedVarKey` / `widenedStructNameForUse` at USE sites (member
  reads/writes, `delete`, element-access import gating) — resolve the receiver
  identifier's symbol → `valueDeclaration` → recompute the same key.

Non-colliding modules are **byte-identical** (same struct, different key
string); only same-name / different-shape collisions change (to correct).

## Validation

- New `tests/issue-3364.test.ts` (standalone, no acorn compile): same-name
  cross-function shape survival + a full recursive in-Wasm walk terminating with
  the exact node count.
- 98 widening-suite tests pass unchanged (#2584/#2849/#2937/#2944/#2372/#3125 +
  object-literals + getters/setters); senior-dev's #3343 test still passes.
- Broad-impact object codegen → relies on full CI / merge_group + the standalone
  floor for the byte-diff-across-modules validation.

## #3024

Likely also reduces #3024's "`struct.new` — not enough args" gc-lane
validator-error cluster (same degenerate-struct mechanism). #3024 is a broad
131-test multi-cause bucket with a separate owner — left open, cross-linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)