### PR TITLE
plan(#3371): harvest-errors 20260717 — file standalone Reflect.construct gap

### DIFF
--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -1,0 +1,107 @@
+---
+id: 3371
+title: "standalone: Reflect.construct (with NewTarget) refused — ~160 tests (proto-from-ctor-realm, subclassing) on the #1472 Phase-C refusal path"
+status: ready
+priority: medium
+horizon: l
+feasibility: hard
+task_type: feature
+area: codegen, runtime
+language_feature: reflect, constructors, prototype chain
+goal: standalone-mode
+umbrella: 1781
+related: [1781, 1905, 2046, 3240, 1472]
+origin: "2026-07-17 /harvest-errors. Baselines run 20260717-151504 (gitHash 0069df37, 32,139 pass), standalone lane test262-standalone-current.jsonl."
+---
+# #3371 — Standalone `Reflect.construct` (with NewTarget) refused
+
+## Problem
+
+`--target standalone` emits a codegen refusal for every `Reflect.construct`
+call:
+
+```text
+Codegen error: Reflect.construct not supported in standalone mode (#1472 Phase C).
+```
+
+This is **160 official standalone failures** in the
+`20260717-151504` baseline (0 in the default/JS-host lane — the host path
+handles it, so this is a pure standalone gap).
+
+The refusal was left deliberately out of scope by **#1905** (native
+`Reflect.get/set/has/deleteProperty`), which states:
+
+> `Reflect.apply` and `Reflect.construct` remain separate call/constructor
+> machinery and are **out of scope here** … `Reflect.construct` remain on the
+> standalone refusal path with the existing `#1472 Phase C` cite.
+
+Since #1472 is `done`, the refusal self-cites a closed issue and there is **no
+dedicated tracking issue** for actually implementing `Reflect.construct` in
+standalone — this issue fills that gap.
+
+## Affected tests (by category, 160 total)
+
+| Count | Category |
+| ----- | -------- |
+| 47 | built-ins/TypedArrayConstructors (`proto-from-ctor-realm`, `use-custom-proto-if-object`) |
+| 14 | built-ins/DataView |
+| 11 | built-ins/Proxy |
+| 8  | built-ins/Function |
+| 6  | built-ins/NativeErrors (`proto-from-ctor-realm`) |
+| 6  | built-ins/Reflect |
+| 6  | built-ins/ArrayBuffer |
+| 6  | built-ins/SharedArrayBuffer |
+| 4  | built-ins/Date (`subclassing`) |
+| 4  | built-ins/AsyncDisposableStack |
+| …  | (Boolean/Number/String/Promise/Map/Set proto-from-ctor tails) |
+
+Sample files:
+
+- `built-ins/TypedArrayConstructors/ctors/buffer-arg/proto-from-ctor-realm.js`
+- `built-ins/TypedArrayConstructors/ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object.js`
+- `built-ins/DataView/custom-proto-access-throws.js`
+- `built-ins/Date/subclassing.js`
+- `built-ins/NativeErrors/URIError/proto-from-ctor-realm.js`
+
+## Root cause
+
+The dominant pattern is `Reflect.construct(Target, argsList, newTarget)` used to
+exercise §10.1.13 (`GetPrototypeFromConstructor` / `OrdinaryCreateFromConstructor`)
+— the instance's `[[Prototype]]` must come from `newTarget.prototype`, not
+`Target.prototype`. Standalone codegen has no lowering for:
+
+1. The `Reflect.construct` call site itself (`src/codegen/expressions/calls.ts`,
+   the same refusal gate that #1905/#2046 added `fail-loud` for construct).
+2. Threading a distinct `newTarget` through native `__new_<Parent>` construction
+   so the prototype is selected from `newTarget.prototype`.
+
+## Relationship to existing work
+
+- **#3240** (ready) — native `__new_<Parent>` subclass constructors. That gives
+  the construction substrate but is driven by the `class X extends Parent`/`super()`
+  path, not the explicit `Reflect.construct(...)` API with an arbitrary NewTarget.
+  This issue should build on #3240's native ctors and add the NewTarget-driven
+  prototype-selection path plus the `Reflect.construct` call lowering.
+- **#2046** (in-progress) — Reflect get/set/deleteProperty spec fixes; keeps
+  construct fail-loud. This issue removes that refusal.
+- **#1472 Phase C** (done) — the umbrella whose cite the refusal string still
+  carries; update the cite to this issue when the refusal is retired.
+
+## Suggested approach
+
+1. Implement a standalone `Reflect.construct(target, argsList, newTarget)`
+   lowering that (a) spreads `argsList` into constructor args, (b) resolves the
+   effective prototype from `newTarget.prototype` (falling back to
+   `target.prototype`), routing through #3240's native `__new_<Parent>` bodies.
+2. Handle the `target !== newTarget` case (the realm/proto-from-ctor tests) by
+   overriding the created object's `[[Prototype]]`.
+3. Retire the `Reflect.construct not supported in standalone mode` refusal gate;
+   keep genuinely-unsupported argument shapes fail-loud citing **#3371**.
+
+## Acceptance Criteria
+
+- `proto-from-ctor-realm` / `use-custom-proto-if-object` TypedArray/DataView/
+  NativeErrors families compile and run under `target: "standalone"`.
+- `Reflect.construct(Base, args, Derived)` selects `Derived.prototype` for the
+  new instance.
+- Any residual refusal cites **#3371**, not the closed #1472.

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,27 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## 2026-07-17 - /harvest-errors (baselines run 20260717-151504, 32,139 pass)
+
+Harvested both lanes (default JS-host + standalone) from
+`loopdive/js2wasm-baselines`. One new >50 pattern filed; all other top
+patterns map to existing tracked issues.
+
+- [#3371](../3371-standalone-reflect-construct-newtarget.md) - standalone
+  `Reflect.construct` (with NewTarget) refused, **160 tests**, 0 in the default
+  lane. #1905 explicitly left construct out of scope; the refusal self-cites the
+  closed #1472, so there was no dedicated tracking issue. `goal: standalone-mode`,
+  umbrella #1781, builds on #3240.
+
+No other new issues warranted: the standalone host-import-leak cluster (5,715
+records citing #2961) is tracked under umbrella #3178 / #2864 / #2865 / #2867
+(in-progress); the default-lane vacuous async-callback cluster is #3227
+(in-progress) and **shrank** to 346 (from ~1,100 at the 2026-07-13 harvest) —
+active progress, not a regression. BigInt-TypedArray null-access (174 default /
+510 standalone) → #2939/#3089; ShadowRealm (61/58) → #1356; `with` (67) → #1387;
+Proxy standalone (374) → #1355; `Object.defineProperties` residual descriptor
+shapes (73) are #1906's deliberate fail-loud tail.
+
 ## 2026-07-17 - Current `origin/main` PO audit (verified high-leverage gaps)
 
 Audit scope: current `origin/main` after fetch, existing `plan/issues`, sprint


### PR DESCRIPTION
## What

Plan/docs-only PR from `/harvest-errors` on both test262 lanes (default JS-host + standalone), harvested from `loopdive/js2wasm-baselines` run **20260717-151504** (gitHash 0069df37, 32,139 / 43,106 pass).

## New issue filed

- **#3371** — standalone `Reflect.construct` (with NewTarget) refused. **160 official standalone failures, 0 in the default lane** (host path handles it). #1905 explicitly left `Reflect.construct` out of scope, so the refusal self-cites the now-closed **#1472** and had no dedicated tracking issue. `goal: standalone-mode`, umbrella **#1781**, builds on #3240's native subclass constructors. Dominated by `proto-from-ctor-realm` / `use-custom-proto-if-object` TypedArray/DataView/NativeErrors families.

## Everything else maps to existing tracked issues

- Standalone host-import-leak cluster — **5,715** records citing **#2961** (generators, async-gen, Promise, SharedArrayBuffer, dynamic-import) → umbrella **#3178** + **#2864/#2865/#2867** (in-progress).
- Default-lane vacuous async-callback cluster (**#3227**, in-progress) — **shrank to 346** from ~1,100 at the 2026-07-13 harvest → active progress, not a regression.
- BigInt-TypedArray null-access (174 default / 510 standalone) → #2939/#3089; ShadowRealm (61/58) → #1356 (backlog); `with` (67) → #1387; Proxy standalone (374) → #1355; `Object.defineProperties` residual descriptor shapes (73) are #1906's deliberate fail-loud tail.

No ADDRESSED pattern increased vs its recorded count — no regression flags added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)