### PR TITLE
fix(#3338): CLI refuses to publish Wasm that fails validation

### DIFF
--- a/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
+++ b/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
@@ -1,7 +1,8 @@
 ---
 id: 3338
 title: "cli: refuse to write invalid Wasm artifacts after optimizer fallback"
-status: ready
+status: in-progress
+assignee: dev-refactor
 created: 2026-07-17
 updated: 2026-07-17
 priority: high
@@ -11,7 +12,7 @@ task_type: bugfix
 area: cli, compiler, optimizer
 language_feature: compiler-output-validation
 goal: trustworthiness
-sprint: Backlog
+sprint: current
 horizon: s
 es_edition: n/a
 complexity: S

--- a/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
+++ b/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
@@ -1,8 +1,9 @@
 ---
 id: 3338
 title: "cli: refuse to write invalid Wasm artifacts after optimizer fallback"
-status: in-progress
+status: done
 assignee: dev-refactor
+completed: 2026-07-17
 created: 2026-07-17
 updated: 2026-07-17
 priority: high

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -430,6 +430,31 @@ if (suppressedAllowlist > 0) {
   );
 }
 
+// #3338 — refuse to publish an invalid primary artifact. `result.success`
+// means codegen completed, NOT that the binary validates: on wasm-opt failure
+// the optimizer emits a warning and preserves the original (possibly invalid)
+// bytes (src/optimize.ts), and `--no-optimize` ships raw codegen with no
+// validator at all. Without this guard the CLI exits 0 and writes an
+// uninstantiable `.wasm` (plus `.wat`/`.d.ts`/imports helper). Validate the
+// final binary once here — before the `--wat` stdout path and before any
+// output file is written — so a malformed artifact never escapes with a
+// success exit code. Optimizer-availability warnings stay nonfatal because the
+// preserved binary they fall back to still reaches this check and validates.
+if (!WebAssembly.validate(result.binary)) {
+  let detail = "";
+  try {
+    // Constructing a Module surfaces the first engine validation detail that
+    // `WebAssembly.validate` (a bare boolean) does not expose.
+    new WebAssembly.Module(result.binary);
+  } catch (err) {
+    detail = err instanceof Error ? err.message : String(err);
+  }
+  console.error(
+    `${absInput}: error: emitted WebAssembly failed validation and was not written` + (detail ? ` — ${detail}` : ""),
+  );
+  process.exit(1);
+}
+
 if (watOnly) {
   process.stdout.write(result.wat);
   process.exit(0);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -440,12 +440,17 @@ if (suppressedAllowlist > 0) {
 // output file is written — so a malformed artifact never escapes with a
 // success exit code. Optimizer-availability warnings stay nonfatal because the
 // preserved binary they fall back to still reaches this check and validates.
-if (!WebAssembly.validate(result.binary)) {
+// Cast to BufferSource: under TS 5.7+ the typed-array generic types this as
+// `Uint8Array<ArrayBufferLike>`, which the lib `validate`/`Module` overloads
+// (param: BufferSource) don't structurally accept without the widening — the
+// same cast `optimizedBinaryValidates` uses in src/optimize.ts.
+const binaryForValidation = result.binary as unknown as BufferSource;
+if (!WebAssembly.validate(binaryForValidation)) {
   let detail = "";
   try {
     // Constructing a Module surfaces the first engine validation detail that
     // `WebAssembly.validate` (a bare boolean) does not expose.
-    new WebAssembly.Module(result.binary);
+    new WebAssembly.Module(binaryForValidation);
   } catch (err) {
     detail = err instanceof Error ? err.message : String(err);
   }

--- a/tests/issue-3338-cli-refuse-invalid-wasm.test.ts
+++ b/tests/issue-3338-cli-refuse-invalid-wasm.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Issue #3338 — the CLI must not publish an invalid primary artifact with a
+// success exit code. `CompileResult.success` means codegen completed, not that
+// the binary validates: on wasm-opt failure the optimizer emits a warning and
+// preserves the original (possibly invalid) bytes, and `--no-optimize` ships
+// raw codegen with no validator at all. The CLI now validates the final binary
+// before writing any output; on failure it exits nonzero and writes nothing.
+
+const CLI = path.resolve("src/cli.ts");
+
+// Reduced from test/language/expressions/in/private-field-rhs-non-object.js.
+// On current main this compiles (`success: true`) but emits a binary whose
+// `C_init` has a `local.tee` storing f64 into a reference local — invalid Wasm
+// that `WebAssembly.validate` rejects. It is a stand-in for any malformed-Wasm
+// producer; the CLI publication boundary must refuse it regardless of source.
+const INVALID_SOURCE = `let caught: any = null;
+class C {
+  #field: any;
+  constructor() {
+    try {
+      // @ts-ignore
+      #field in {} << 0;
+    } catch (error) {
+      caught = error;
+    }
+  }
+}
+new C();
+`;
+
+const VALID_SOURCE = `export function add(a: number, b: number): number {
+  return a + b;
+}
+`;
+
+interface RunResult {
+  status: number;
+  stderr: string;
+  dir: string;
+  name: string;
+}
+
+function runCli(source: string, extraArgs: string[]): RunResult {
+  const dir = mkdtempSync(path.join(tmpdir(), "issue-3338-"));
+  const name = "input";
+  const inFile = path.join(dir, `${name}.ts`);
+  writeFileSync(inFile, source);
+  try {
+    execFileSync("npx", ["-y", "tsx", CLI, inFile, "--quiet", "-o", dir, ...extraArgs], {
+      cwd: process.cwd(),
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+    return { status: 0, stderr: "", dir, name };
+  } catch (err) {
+    const e = err as { status?: number; stderr?: Buffer | string };
+    const stderr = e.stderr == null ? "" : typeof e.stderr === "string" ? e.stderr : e.stderr.toString("utf-8");
+    return { status: e.status ?? 1, stderr, dir, name };
+  }
+}
+
+// The set of artifacts the CLI would normally write next to the input.
+function emittedArtifacts(dir: string, name: string): string[] {
+  return [`${name}.wasm`, `${name}.wat`, `${name}.d.ts`, `${name}.imports.js`, `${name}.wit`].filter((f) =>
+    existsSync(path.join(dir, f)),
+  );
+}
+
+describe("issue #3338 — CLI refuses to publish invalid Wasm artifacts", () => {
+  it("default (optimized) mode: exits nonzero and writes no artifacts for an invalid binary", () => {
+    const r = runCli(INVALID_SOURCE, []);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/failed validation/i);
+    // The engine detail (e.g. "local.tee ... expected type anyref, found f64")
+    // must accompany the diagnostic per the acceptance criteria.
+    expect(r.stderr.length).toBeGreaterThan("failed validation".length);
+    expect(emittedArtifacts(r.dir, r.name)).toEqual([]);
+  }, 60_000);
+
+  it("--no-optimize mode: exits nonzero and writes no artifacts for an invalid binary", () => {
+    const r = runCli(INVALID_SOURCE, ["--no-optimize"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/failed validation/i);
+    expect(emittedArtifacts(r.dir, r.name)).toEqual([]);
+  }, 60_000);
+
+  it("valid source (default mode): exits zero and writes its artifacts", () => {
+    const r = runCli(VALID_SOURCE, ["--target", "standalone"]);
+    expect(r.status).toBe(0);
+    const artifacts = emittedArtifacts(r.dir, r.name);
+    expect(artifacts).toContain("input.wasm");
+    // The published .wasm must actually validate.
+    const bytes = readFileSync(path.join(r.dir, "input.wasm"));
+    expect(WebAssembly.validate(bytes)).toBe(true);
+  }, 60_000);
+
+  it("valid source (--no-optimize): exits zero and writes a valid .wasm", () => {
+    const r = runCli(VALID_SOURCE, ["--target", "standalone", "--no-optimize"]);
+    expect(r.status).toBe(0);
+    expect(emittedArtifacts(r.dir, r.name)).toContain("input.wasm");
+    const bytes = readFileSync(path.join(r.dir, "input.wasm"));
+    expect(WebAssembly.validate(bytes)).toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
## Problem (#3338)

The CLI treated `CompileResult.success` as sufficient to write output, but
`success` only means codegen completed. On `wasm-opt` failure the optimizer
emits a warning and preserves the original (possibly invalid) bytes; with
`--no-optimize` the CLI ships raw codegen with no validator at all. The CLI
then exited `0` and wrote an uninstantiable `.wasm` (plus `.wat`/`.d.ts`/imports
helper), breaking shell automation, build caches, and user trust.

## Fix

Add a publication guard in `src/cli.ts` after compile/optimize and **before**
the `--wat` stdout path or any output-file write:

- Validate the final binary with `WebAssembly.validate`.
- On failure, emit a fatal diagnostic including the first engine validation
  detail (obtained via `new WebAssembly.Module`) and `process.exit(1)`, writing
  no `.wasm`/`.wat`/`.d.ts`/imports-helper/`.wit`.
- Optimizer-availability warnings stay nonfatal: the preserved binary they fall
  back to still reaches this check and, when valid, passes through.

This is a systemic publication boundary — it closes the gap for any
malformed-Wasm producer, not just the private-field-`in` family that surfaced
it (that producer bug is #3024's, not fixed here).

## Tests

`tests/issue-3338-cli-refuse-invalid-wasm.test.ts` drives the real CLI as a
subprocess:
- invalid binary, default (-O3) mode → nonzero exit, `failed validation` on
  stderr with engine detail, no artifacts written
- invalid binary, `--no-optimize` → nonzero exit, no artifacts written
- valid source (default + `--no-optimize`) → exit 0, `.wasm` written and
  `WebAssembly.validate` true

## Validation

- `npx tsc --noEmit` clean
- `prettier --check` clean on changed files
- 4/4 focused tests pass (before and after merging latest `origin/main`)

Acceptance criteria in the issue are all covered.