### PR TITLE
fix(#2650): regression guard for standalone String.at() nullable member-read

### DIFF
--- a/plan/issues/2650-standalone-string-at-nullable-result-member-read.md
+++ b/plan/issues/2650-standalone-string-at-nullable-result-member-read.md
@@ -1,8 +1,10 @@
 ---
 id: 2650
 title: "Standalone: member-read on String.prototype.at result returns empty (.length/.charCodeAt)"
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/dev-standalone2
+sprint: current
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -11,6 +13,34 @@ area: string
 language_feature: string-methods
 goal: standalone-mode
 related: [2600, 2644]
+---
+
+## Resolution (2026-07-17)
+
+**Already fixed on main** by the native-string nullable work that landed after
+the issue was filed (#2644 / #2648 / #2161 undefined-sentinel families and the
+subsequent nullable-native-string coercion cleanup). Re-verified against main
+`93e86d717`: in `--target standalone`, member reads on a `String.prototype.at()`
+result now return correct values (they previously read as if the string were
+empty).
+
+| expr (standalone) | before | now |
+|---|---|---|
+| `const c = "abcd".at(2)!; c.length` | `0` | `1` |
+| `"abcd".at(2)!.charCodeAt(0)` | `0` | `99` |
+| `"abcd".at(-1)!.charCodeAt(0)` | — | `100` |
+| `"abcd".at(2)!.toUpperCase() === "C"` | — | `true` |
+| `"abcd".at(2)!.at(0) === "c"` | — | `true` |
+| `"abcd".at(99)?.length ?? -1` | — | `-1` |
+
+Closed with a standalone regression guard:
+`tests/issue-2650-standalone-string-at-member-read.test.ts` (6 cases, all green).
+
+**Separate finding (not this issue):** in **gc / JS-host** mode,
+`"abcd".at(99)?.length` traps because the `length` host import is invoked on
+`undefined` — the optional-chain short-circuit is not honored before the native
+`length` call on a nullable native-string receiver. That is a distinct
+host-path bug outside #2650's standalone scope; left for a follow-up.
 ---
 
 # #2650 — Standalone member-read on a String.prototype.at result returns empty

--- a/tests/issue-2650-standalone-string-at-member-read.test.ts
+++ b/tests/issue-2650-standalone-string-at-member-read.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2650 — Regression guard (standalone / no-JS-host).
+//
+// `String.prototype.at(i)` returns a NULLABLE native AnyString ref (an
+// out-of-range index yields `undefined`). An earlier bug flattened a member
+// read (`.length`, `.charCodeAt`, chained methods) on that nullable receiver to
+// an empty-string path, so `"abcd".at(2).length` read `0` and
+// `"abcd".at(2).charCodeAt(0)` read `0` even though `at` itself returned the
+// right character. This was fixed alongside the #2644/#2648/#2161 native-string
+// nullable work; the guard locks the member-read-through-`at` behavior in for
+// standalone codegen.
+//
+// Raw Wasm exports return i32, so boolean results come back as 1/0 — assertions
+// below use numeric expectations accordingly.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+// [label, source, expected]
+const cases: [string, string, number][] = [
+  [".length on at() result", `export function test(): number { const c = "abcd".at(2)!; return c.length; }`, 1],
+  [
+    ".charCodeAt on at() result",
+    `export function test(): number { return "abcd".at(2)!.charCodeAt(0); }`,
+    99, // "c"
+  ],
+  [
+    "negative-index at() then .charCodeAt",
+    `export function test(): number { return "abcd".at(-1)!.charCodeAt(0); }`,
+    100, // "d"
+  ],
+  [
+    "chained .toUpperCase on at() result equals uppercase",
+    `export function test(): number { return "abcd".at(2)!.toUpperCase() === "C" ? 1 : 0; }`,
+    1,
+  ],
+  ["chained .at on at() result", `export function test(): number { return "abcd".at(2)!.at(0) === "c" ? 1 : 0; }`, 1],
+  [
+    "OOB at() optional-chained .length coalesces",
+    `export function test(): number { return "abcd".at(99)?.length ?? -1; }`,
+    -1,
+  ],
+];
+
+describe("#2650 member read on String.prototype.at() result (standalone, nullable native string)", () => {
+  for (const [label, src, expected] of cases) {
+    it(label, async () => {
+      expect(await runStandalone(src)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #2650. The bug — a member read (`.length`, `.charCodeAt`, chained methods) on a `String.prototype.at(i)` result reading as if the string were empty in `--target standalone` — is **already fixed on `main`** by the native-string nullable work that landed after the issue was filed (#2644 / #2648 / #2161).

Re-verified against `main` (`93e86d717`); all cases now return correct values in standalone:

| expr (standalone) | before | now |
|---|---|---|
| `const c = "abcd".at(2)!; c.length` | `0` | `1` |
| `"abcd".at(2)!.charCodeAt(0)` | `0` | `99` |
| `"abcd".at(-1)!.charCodeAt(0)` | — | `100` |
| `"abcd".at(2)!.toUpperCase() === "C"` | — | `true` |
| `"abcd".at(2)!.at(0) === "c"` | — | `true` |
| `"abcd".at(99)?.length ?? -1` | — | `-1` |

## Changes

- `tests/issue-2650-standalone-string-at-member-read.test.ts` — 6-case standalone regression guard (all green).
- `plan/issues/2650-*.md` — `status: done`, resolution note.

## Separate finding (not this PR)

In **gc / JS-host** mode, `"abcd".at(99)?.length` traps because the host `length` import is invoked on `undefined` — the optional-chain short-circuit is not honored before the native `length` call on a nullable native-string receiver. Distinct host-path bug, outside #2650's standalone scope; left for a follow-up.

## Validation

- `npm test -- tests/issue-2650-standalone-string-at-member-read.test.ts` → 6 passed
- `npx tsc --noEmit` → no errors
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)