### PR TITLE
fix(#3332): direct linear-path Array.push returns new length + appends all args

### DIFF
--- a/plan/issues/3332-linear-direct-push-return-and-multiarg.md
+++ b/plan/issues/3332-linear-direct-push-return-and-multiarg.md
@@ -17,6 +17,11 @@ horizon: s
 created: 2026-07-17
 updated: 2026-07-17
 related: [2956, 1854]
+loc-budget-allow:
+  # Intended +13 LOC in the direct-path push lowering: evaluate the receiver
+  # once into a local, loop over all arguments, and read __arr_len back for the
+  # expression-position new-length result (fixes the returns-0 / drops-args bug).
+  - src/codegen-linear/index.ts
 ---
 
 ## Resolution (2026-07-17)

--- a/plan/issues/3332-linear-direct-push-return-and-multiarg.md
+++ b/plan/issues/3332-linear-direct-push-return-and-multiarg.md
@@ -1,8 +1,10 @@
 ---
 id: 3332
 title: "linear direct path: arr.push returns 0 (not new length) and drops extra args"
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/dev-standalone2
+sprint: current
 goal: backend-agnostic-ir
 feasibility: medium
 depends_on: []
@@ -16,6 +18,25 @@ created: 2026-07-17
 updated: 2026-07-17
 related: [2956, 1854]
 ---
+
+## Resolution (2026-07-17)
+
+Fixed the DIRECT linear-path `Array.prototype.push` lowering in
+`src/codegen-linear/index.ts` (`compileArrayMethodCall`, `methodName === "push"`):
+
+- The receiver is evaluated **once** into a fresh i32 local (so a
+  side-effecting receiver expression is not re-run per argument).
+- **Every** argument is appended (loop over `expr.arguments`), fixing the
+  dropped-extra-args defect.
+- The expression-position result is now the **new length** — after the pushes,
+  `__arr_len(arr)` is read back and converted to f64 — instead of the previous
+  `f64.const 0`.
+
+Guarded by `tests/issue-3332.test.ts` (6 cases, direct path forced via
+`JS2WASM_LINEAR_IR=0`). The two forward-looking `#3332` assertions in
+`tests/issue-2956.test.ts` (direct `pushExpr` returning `8`; demoted multi-arg
+`multiPush` returning length `2`) were flipped to their spec-correct values
+(`28` folded into the parity loop; `3`), as those comments instructed.
 
 # #3332 — linear direct path push defects
 

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -3552,18 +3552,31 @@ function compileArrayMethodCall(
   methodName: string,
 ): void {
   if (methodName === "push") {
-    // arr.push(val) → __arr_push(arr, slot(val)) (#1938: f64 slot)
+    // arr.push(v0, v1, …) → __arr_push(arr, slot(vi)) per arg (#1938: f64 slot).
+    // Spec: push returns the array's NEW length, and every argument is appended
+    // (#3332 — the direct linear path previously returned f64.const 0 and only
+    // pushed arguments[0]). Evaluate the receiver once into a local so a
+    // side-effecting receiver expression is not re-run per argument, then read
+    // __arr_len back at the end for the expression-position result value.
     const pushIdx = ctx.funcMap.get("__arr_push")!;
+    const lenIdx = ctx.funcMap.get("__arr_len")!;
+    const arrLocal = addLocal(fctx, `__push_arr_${fctx.locals.length}`, { kind: "i32" });
     compileExpression(ctx, fctx, propAccess.expression); // arr ptr (i32)
-    if (inferExprType(ctx, fctx, expr.arguments[0]).kind === "f64") {
-      compileExprToF64(ctx, fctx, expr.arguments[0]); // numeric/boolean → f64 slot
-    } else {
-      compileExprToI32(ctx, fctx, expr.arguments[0]); // ref → i32
-      pushI32ToSlot(fctx); // → f64 slot
+    fctx.body.push({ op: "local.set", index: arrLocal });
+    for (const arg of expr.arguments) {
+      fctx.body.push({ op: "local.get", index: arrLocal }); // arr ptr (i32)
+      if (inferExprType(ctx, fctx, arg).kind === "f64") {
+        compileExprToF64(ctx, fctx, arg); // numeric/boolean → f64 slot
+      } else {
+        compileExprToI32(ctx, fctx, arg); // ref → i32
+        pushI32ToSlot(fctx); // → f64 slot
+      }
+      fctx.body.push({ op: "call", funcIdx: pushIdx });
     }
-    fctx.body.push({ op: "call", funcIdx: pushIdx });
-    // push returns void in runtime, but expression needs a value for drop
-    fctx.body.push({ op: "f64.const", value: 0 });
+    // Expression position needs the new length (f64); __arr_push is void.
+    fctx.body.push({ op: "local.get", index: arrLocal });
+    fctx.body.push({ op: "call", funcIdx: lenIdx });
+    fctx.body.push({ op: "f64.convert_i32_s" });
   } else if (
     methodName === "filter" ||
     methodName === "map" ||

--- a/tests/issue-2956.test.ts
+++ b/tests/issue-2956.test.ts
@@ -206,8 +206,11 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
 
     const direct = await exportedFunctions(directBinary);
     const ir = await exportedFunctions(irBinary);
-    // Direct-path parity where the direct path is spec-correct.
-    for (const name of ["setInBounds", "setGrow", "pushStmt"]) {
+    // Direct-path parity where the direct path is spec-correct. push in
+    // EXPRESSION position is now folded in: #3332 fixed the direct path so it
+    // returns the new length (matching the overlay), so pushExpr joins the loud
+    // parity loop.
+    for (const name of ["setInBounds", "setGrow", "pushStmt", "pushExpr"]) {
       expect(callNumber(ir, name), `${name} IR value`).toBe(callNumber(direct, name));
     }
     // Absolute expectations (spec semantics):
@@ -216,15 +219,9 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
     // runtime's 0 sentinel -> 507.
     expect(callNumber(ir, "setGrow")).toBe(507);
     expect(callNumber(ir, "pushStmt")).toBe(8); // 5 + new length 3
-    // push in EXPRESSION position: the IR overlay is spec-correct (returns
-    // the new length -> 2*10 + 8 = 28); the DIRECT path returns 0 for the
-    // push result (pre-existing defect, tracked as #3332) -> 8. Assert both
-    // so a direct-path fix flips this into a parity check loudly.
+    // push in EXPRESSION position returns the new length: both the overlay and
+    // (post-#3332) the direct path yield n=2 -> 2*10 + a[1](8) = 28.
     expect(callNumber(ir, "pushExpr")).toBe(28);
-    expect(
-      callNumber(direct, "pushExpr"),
-      "direct pushExpr (#3332 — update to 28 + fold into parity loop when fixed)",
-    ).toBe(8);
     expect(callNumber(ir, "test")).toBe(12 + 507 + 8 + 28);
   });
 
@@ -246,10 +243,10 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
     const report = getLastLinearIrReport();
     expect(report?.compiled ?? []).not.toContain("multiPush");
     expect(report?.rejected.some((rejection) => rejection.func === "multiPush")).toBe(true);
-    // The demoted function rides the DIRECT path, which drops the extra
-    // push arg (pre-existing defect, #3332): length is 2, not the
-    // spec-correct 3. Update to 3 when #3332 lands.
-    expect(await run(binary)).toBe(2);
+    // The demoted function rides the DIRECT path. Post-#3332 the direct path
+    // appends every argument, so multi-arg push is now spec-correct there too:
+    // length is 3.
+    expect(await run(binary)).toBe(3);
   });
 });
 

--- a/tests/issue-3332.test.ts
+++ b/tests/issue-3332.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3332 — DIRECT linear path (`--target linear`, no JS2WASM_LINEAR_IR) mis-lowered
+// `Array.prototype.push`:
+//   (a) in expression position it returned f64.const 0 instead of the new length;
+//   (b) multi-arg push dropped every argument past the first.
+// Both are fixed in src/codegen-linear/index.ts compileArrayMethodCall: the
+// receiver is evaluated once into a local, every argument is appended, and the
+// new length is read back via __arr_len for the expression-position result.
+
+// Force the direct path (overlay OFF) so this guards the direct lowering
+// regardless of the selector default.
+const FLAG = "JS2WASM_LINEAR_IR";
+
+async function runLinearDirect(src: string): Promise<number> {
+  const prev = process.env[FLAG];
+  process.env[FLAG] = "0";
+  try {
+    const r = await compile(src, { target: "linear" });
+    expect(r.success, r.errors.map((e) => e.message).join("; ")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as { test: () => number }).test();
+  } finally {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  }
+}
+
+// [label, source, expected]
+const cases: [string, string, number][] = [
+  [
+    "single-arg push returns new length (expression position)",
+    `export function test(): number { const a = [1]; return a.push(8); }`,
+    2,
+  ],
+  [
+    "multi-arg push appends all arguments",
+    `export function test(): number { const a = [1]; a.push(2, 3); return a.length; }`,
+    3,
+  ],
+  ["multi-arg push returns new length", `export function test(): number { const a = [1]; return a.push(2, 3, 4); }`, 4],
+  [
+    "multi-arg push appends the actual values in order",
+    `export function test(): number { const a = [1]; a.push(2, 3); return a[0] + a[1] + a[2]; }`,
+    6,
+  ],
+  [
+    "push onto an initially-empty array",
+    `export function test(): number { const a: number[] = []; a.push(5); a.push(6, 7); return a.length; }`,
+    3,
+  ],
+  [
+    "statement-position push still appends (result dropped)",
+    `export function test(): number { const a = [1]; a.push(9); return a[1]; }`,
+    9,
+  ],
+];
+
+describe("#3332 direct linear-path Array.prototype.push (return value + multi-arg)", () => {
+  for (const [label, src, expected] of cases) {
+    it(label, async () => {
+      expect(await runLinearDirect(src)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Closes #3332. The DIRECT linear path (`--target linear`, no `JS2WASM_LINEAR_IR`) mis-lowered `Array.prototype.push`:

- **expression position** returned `f64.const 0` instead of the array's new length;
- **multi-arg** push dropped every argument past the first.

```ts
const a = [1]; a.push(8);        // returned 0   → now 2 (new length)
const a = [1]; a.push(2, 3);     // length 2     → now 3 (all args appended)
```

## Fix

`src/codegen-linear/index.ts` `compileArrayMethodCall`, `methodName === "push"`:

- evaluate the receiver **once** into a fresh i32 local (a side-effecting receiver expression is no longer re-run per argument);
- loop over **all** `expr.arguments`, calling `__arr_push` for each;
- read `__arr_len(arr)` back and convert to f64 for the expression-position result value (`__arr_push` is void).

The statement-position stack contract is unchanged (one f64 left on the stack, dropped by the caller).

## Tests

- `tests/issue-3332.test.ts` — 6-case regression guard, direct path forced via `JS2WASM_LINEAR_IR=0` (single/multi-arg return value, value ordering, empty-array, statement position).
- `tests/issue-2956.test.ts` — flipped the two forward-looking `#3332` assertions to their spec-correct values, exactly as those comments instructed: direct `pushExpr` `8 → 28` (folded into the loud parity loop), demoted `multiPush` length `2 → 3`.

## Validation

- `npm test -- tests/issue-3332.test.ts tests/issue-2956.test.ts` → 26 passed
- `npx tsc --noEmit` → no errors
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)