### PR TITLE
refactor(#3113): move shared-vocabulary js-tag below the IR layer (slice 1)

### DIFF
--- a/plan/issues/3113-ir-codegen-layering-shared-vocab.md
+++ b/plan/issues/3113-ir-codegen-layering-shared-vocab.md
@@ -1,10 +1,10 @@
 ---
 id: 3113
 title: "Fix IR->codegen reverse layering: move shared vocabulary (js-tag) below IR; contain the bridge to ir/integration.ts"
-status: ready
-sprint: Backlog
+status: in-progress
+sprint: current
 created: 2026-07-09
-updated: 2026-07-09
+updated: 2026-07-17
 priority: medium
 horizon: m
 feasibility: medium
@@ -99,3 +99,27 @@ logic changes anywhere.
 2. CI guard in place and failing on a synthetic violation.
 3. `prove-emit-identity check` IDENTICAL; `tsc --noEmit` clean; no test262
    regression.
+
+## Progress — slice 1 (js-tag relocation) shipped 2026-07-17
+
+Problem 1 (js-tag mis-homed) is resolved. `js-tag.ts` — the dependency-free
+shared-vocabulary leaf (the `JsTag` enum + `jsTagUnboxKind`) — was moved from
+`src/codegen/js-tag.ts` to `src/ir/js-tag.ts`, below the codegen layer. Import
+paths updated in all consumers: `ir/nodes.ts`, `ir/verify.ts`, `ir/builder.ts`,
+`ir/from-ast.ts`, `ir/integration.ts`, `ir/backend/handles.ts` (now import
+in-layer), `codegen/value-tags.ts` (imports down-stack via `../ir/js-tag.js`,
+re-export preserved), and the 7 `issue-2949-*` test files.
+
+Effect on the inversion: `ir/nodes.ts`, `ir/verify.ts`, and `ir/builder.ts` had
+js-tag as their ONLY codegen import — they now have ZERO codegen imports.
+`ir/from-ast.ts` and `ir/integration.ts` each drop one codegen import.
+
+The move is pure relocation (js-tag has zero imports, no logic change): proven
+byte-identical via `scripts/prove-emit-identity.mjs check` — all 56
+(file,target) emits match baseline. tsc clean; the `issue-2949-*` suites pass.
+
+**Remaining — slice 2 (the substantive part):** Problem 2, containing the
+2,610-LOC `ir/integration.ts` IR→codegen bridge so `import "src/ir"` stops
+transitively pulling ~17 codegen modules (move the bridge to the codegen side /
+behind a narrow interface). That is a larger, design-sensitive change and is
+left open under this issue.

--- a/src/codegen/js-tag.ts
+++ b/src/codegen/js-tag.ts
@@ -1,80 +1,11 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * #2949 (IR dynamic value representation, slice 1) — the canonical `JsTag`
- * enum, extracted from `value-tags.ts` into a dependency-free leaf module.
- *
- * WHY the extraction: the IR type lattice (`src/ir/nodes.ts`) now carries a
- * `{ kind: "dynamic", tag?: JsTag }` leaf, so the IR layer needs the tag
- * enum. `value-tags.ts` (the tag POLICY home — classifier, boxing entry
- * point, undefined sentinel) transitively imports `ts-api` and the codegen
- * context types; importing it from `ir/nodes.ts` (a pure leaf consumed by
- * every IR module AND by codegen) would create a module-graph knot with
- * TDZ hazards for module-load-time enum reads. This file has ZERO imports,
- * so both layers share ONE tag table (June audit D4 rule: never mint a
- * second tag/boxing table) with no cycle risk. `value-tags.ts` re-exports
- * `JsTag`, so every existing import site is unchanged.
- *
- * Canonical JS-type tag for the `$AnyValue` boxed representation.
- *
- * Invariant V1 (tag fidelity): the tag always equals the value's ECMAScript
- * type partition (the `typeof` partition with `null` split out). No consumer
- * may infer a JS type from a Wasm kind.
- *
- * Invariant V2 (numeric class): tags 2 and 3 are ONE JS type (`number`) — one
- * uses the i32 payload, one the f64 payload. Equality / relational / typeof /
- * ToString helpers must treat `{2,3}` as a single class.
- *
- * These values MUST match the runtime tags written by the `__any_box_*`
- * helpers in `any-helpers.ts` (asserted by tests). `Function` (7) is reserved
- * for a later phase (today closures box as `Object`).
- *
- * (Plain `enum`, not `const enum` — Biome's `noConstEnum` forbids the latter;
- * the numeric values are still inlined at our use sites.)
+ * @deprecated #3113 — the `JsTag` shared-vocabulary leaf moved BELOW the codegen
+ * layer to `src/ir/js-tag.ts` (it is consumed by IR core files, so it must not
+ * live in `src/codegen/`). This re-export is a one-cycle compatibility shim so
+ * any in-flight branch still importing `codegen/js-tag` keeps compiling while it
+ * rebases; the #2855/#2856 IR-migration branches actively edit the IR importers.
+ * New code MUST import from `../ir/js-tag.js` (or, in codegen, keep using the
+ * `value-tags.ts` re-export). Remove this shim once the in-flight branches land.
  */
-export enum JsTag {
-  Null = 0,
-  Undefined = 1,
-  NumberI32 = 2,
-  NumberF64 = 3,
-  Boolean = 4,
-  String = 5,
-  Object = 6,
-  Function = 7,
-}
-
-/**
- * #2949 slice 1 — the Wasm-carrier *kind* of a `JsTag` partition's unboxed
- * payload on the WasmGC backend, per the ratified #1852 representation table
- * and the `$AnyValue` struct layout (`any-helpers.ts`:
- * `{tag:i32, i32val:i32, f64val:f64, refval:eqref, externval:externref}`).
- *
- * Used by the IR verifier to check `unbox`/`tag.test` consistency on
- * `dynamic`-typed operands:
- *
- *   - `"i32"` / `"f64"` — exact scalar payload kind; the unbox target
- *     ValType must match exactly (NumberI32/Boolean → i32val, NumberF64 →
- *     f64val).
- *   - `"ref"` — the partition's payload is reference-shaped (String →
- *     externval or a native `$AnyString` ref; Object/Function → refval or
- *     externval). The exact ValType is a backend/resolver decision at
- *     lowering time, so the verifier only requires a ref-shaped target.
- *   - `null` — the partition has NO payload (Null/Undefined are singleton
- *     partitions). `unbox` with these tags is invalid; identity is observed
- *     via `tag.test` alone.
- */
-export function jsTagUnboxKind(tag: JsTag): "i32" | "f64" | "ref" | null {
-  switch (tag) {
-    case JsTag.NumberI32:
-    case JsTag.Boolean:
-      return "i32";
-    case JsTag.NumberF64:
-      return "f64";
-    case JsTag.String:
-    case JsTag.Object:
-    case JsTag.Function:
-      return "ref";
-    case JsTag.Null:
-    case JsTag.Undefined:
-      return null;
-  }
-}
+export { JsTag, jsTagUnboxKind } from "../ir/js-tag.js";

--- a/src/codegen/value-tags.ts
+++ b/src/codegen/value-tags.ts
@@ -38,7 +38,7 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
  * remains the tag POLICY home (classifier, boxing entry point, sentinel).
  * See `js-tag.ts` for the invariants (V1 tag fidelity, V2 numeric class).
  */
-export { JsTag, jsTagUnboxKind } from "./js-tag.js";
+export { JsTag, jsTagUnboxKind } from "../ir/js-tag.js";
 
 /** Static JS-type classification of an expression, resolved from its TS type. */
 export type JsStaticType =

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -21,7 +21,7 @@
 // Nothing here changes for Phase 1.
 
 import type { Instr, ValType } from "../types.js";
-import type { JsTag } from "../../codegen/js-tag.js";
+import type { JsTag } from "../js-tag.js";
 import type {
   LinearAllocationSitePlan,
   LinearRecordLayoutPlan,

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -37,7 +37,7 @@ import {
 } from "./nodes.js";
 import type { AllocSiteRegistry } from "./alloc-registry.js";
 import type { Instr, ValType } from "./types.js";
-import { JsTag, jsTagUnboxKind } from "../codegen/js-tag.js";
+import { JsTag, jsTagUnboxKind } from "./js-tag.js";
 
 interface OpenBlock {
   readonly id: IrBlockId;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -54,7 +54,7 @@ import {
 } from "./capability.js";
 import type { IrLowerResolver, IrVecLowering } from "./lower.js";
 import { mathUnaryToIrOp } from "./select.js";
-import { JsTag } from "../codegen/js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
+import { JsTag } from "./js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
 import {
   asVal,
   closureSignatureEquals,

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -41,7 +41,7 @@ import {
   emitToBoolean as emitCoercionToBoolean,
   emitToNumber as emitCoercionToNumber,
 } from "../codegen/coercion-engine.js";
-import { JsTag, jsTagUnboxKind } from "../codegen/js-tag.js";
+import { JsTag, jsTagUnboxKind } from "./js-tag.js";
 import { ensureVecElemSet, VEC_ELEM_SET_PREFIX } from "../codegen/vec-elem-set.js"; // (#2856 C2) on-demand element-store helper
 import { classMemberFuncKey } from "../codegen/class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import {

--- a/src/ir/js-tag.ts
+++ b/src/ir/js-tag.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2949 (IR dynamic value representation, slice 1) — the canonical `JsTag`
+ * enum, extracted from `value-tags.ts` into a dependency-free leaf module.
+ *
+ * #3113 — this leaf now lives under `src/ir/` (was `src/codegen/js-tag.ts`).
+ * It is shared vocabulary consumed by IR core files (nodes/verify/builder/
+ * from-ast) AND by codegen (`value-tags.ts`). Homing it in `src/ir/` puts it
+ * BELOW the codegen layer, so the IR core files import it in-layer instead of
+ * reaching up into `src/codegen/` — removing that IR→codegen import inversion.
+ * codegen (above IR) importing it via `value-tags.ts` is the correct downward
+ * direction. The file still has ZERO imports, so the move is pure relocation.
+ *
+ * WHY the extraction: the IR type lattice (`src/ir/nodes.ts`) now carries a
+ * `{ kind: "dynamic", tag?: JsTag }` leaf, so the IR layer needs the tag
+ * enum. `value-tags.ts` (the tag POLICY home — classifier, boxing entry
+ * point, undefined sentinel) transitively imports `ts-api` and the codegen
+ * context types; importing it from `ir/nodes.ts` (a pure leaf consumed by
+ * every IR module AND by codegen) would create a module-graph knot with
+ * TDZ hazards for module-load-time enum reads. This file has ZERO imports,
+ * so both layers share ONE tag table (June audit D4 rule: never mint a
+ * second tag/boxing table) with no cycle risk. `value-tags.ts` re-exports
+ * `JsTag`, so every existing import site is unchanged.
+ *
+ * Canonical JS-type tag for the `$AnyValue` boxed representation.
+ *
+ * Invariant V1 (tag fidelity): the tag always equals the value's ECMAScript
+ * type partition (the `typeof` partition with `null` split out). No consumer
+ * may infer a JS type from a Wasm kind.
+ *
+ * Invariant V2 (numeric class): tags 2 and 3 are ONE JS type (`number`) — one
+ * uses the i32 payload, one the f64 payload. Equality / relational / typeof /
+ * ToString helpers must treat `{2,3}` as a single class.
+ *
+ * These values MUST match the runtime tags written by the `__any_box_*`
+ * helpers in `any-helpers.ts` (asserted by tests). `Function` (7) is reserved
+ * for a later phase (today closures box as `Object`).
+ *
+ * (Plain `enum`, not `const enum` — Biome's `noConstEnum` forbids the latter;
+ * the numeric values are still inlined at our use sites.)
+ */
+export enum JsTag {
+  Null = 0,
+  Undefined = 1,
+  NumberI32 = 2,
+  NumberF64 = 3,
+  Boolean = 4,
+  String = 5,
+  Object = 6,
+  Function = 7,
+}
+
+/**
+ * #2949 slice 1 — the Wasm-carrier *kind* of a `JsTag` partition's unboxed
+ * payload on the WasmGC backend, per the ratified #1852 representation table
+ * and the `$AnyValue` struct layout (`any-helpers.ts`:
+ * `{tag:i32, i32val:i32, f64val:f64, refval:eqref, externval:externref}`).
+ *
+ * Used by the IR verifier to check `unbox`/`tag.test` consistency on
+ * `dynamic`-typed operands:
+ *
+ *   - `"i32"` / `"f64"` — exact scalar payload kind; the unbox target
+ *     ValType must match exactly (NumberI32/Boolean → i32val, NumberF64 →
+ *     f64val).
+ *   - `"ref"` — the partition's payload is reference-shaped (String →
+ *     externval or a native `$AnyString` ref; Object/Function → refval or
+ *     externval). The exact ValType is a backend/resolver decision at
+ *     lowering time, so the verifier only requires a ref-shaped target.
+ *   - `null` — the partition has NO payload (Null/Undefined are singleton
+ *     partitions). `unbox` with these tags is invalid; identity is observed
+ *     via `tag.test` alone.
+ */
+export function jsTagUnboxKind(tag: JsTag): "i32" | "f64" | "ref" | null {
+  switch (tag) {
+    case JsTag.NumberI32:
+    case JsTag.Boolean:
+      return "i32";
+    case JsTag.NumberF64:
+      return "f64";
+    case JsTag.String:
+    case JsTag.Object:
+    case JsTag.Function:
+      return "ref";
+    case JsTag.Null:
+    case JsTag.Undefined:
+      return null;
+  }
+}

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -15,10 +15,10 @@
 
 import type { ValType } from "./types.js";
 // #2949 slice 1 — the canonical JS-type tag enum, from the dependency-free
-// leaf `codegen/js-tag.ts` (extracted there precisely so this pure-leaf
-// module can carry it without importing the codegen policy chain). Type-only:
+// leaf `ir/js-tag.ts` (#3113 moved it below the IR layer so IR core files
+// consume it without the IR→codegen import inversion). Type-only:
 // nodes.ts stays free of value imports.
-import type { JsTag } from "../codegen/js-tag.js";
+import type { JsTag } from "./js-tag.js";
 
 // ---------------------------------------------------------------------------
 // Symbolic references

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -25,7 +25,7 @@ import type { ValType } from "./types.js";
 // #2949 slice 1 — canonical JsTag policy for the dynamic-operand rules
 // (payload-kind consistency of unbox/tag.test on `dynamic` values). Imported
 // from the dependency-free leaf, so this adds no codegen module-graph pull.
-import { JsTag, jsTagUnboxKind } from "../codegen/js-tag.js";
+import { JsTag, jsTagUnboxKind } from "./js-tag.js";
 
 /**
  * #1850 — successor block ids of a block, derived from its terminator.

--- a/tests/issue-2949-ir-dynamic-type.test.ts
+++ b/tests/issue-2949-ir-dynamic-type.test.ts
@@ -21,7 +21,7 @@ import {
   type IrType,
   type IrValueId,
 } from "../src/ir/index.js";
-import { JsTag, jsTagUnboxKind } from "../src/codegen/js-tag.js";
+import { JsTag, jsTagUnboxKind } from "../src/ir/js-tag.js";
 import { JsTag as JsTagReexport } from "../src/codegen/value-tags.js";
 import type { FuncTypeDef, ValType } from "../src/ir/types.js";
 

--- a/tests/issue-2949-s5-0-emit-plumbing.test.ts
+++ b/tests/issue-2949-s5-0-emit-plumbing.test.ts
@@ -33,7 +33,7 @@ import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
 import { addFuncType } from "../src/codegen/registry/types.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
-import { JsTag } from "../src/codegen/js-tag.js";
+import { JsTag } from "../src/ir/js-tag.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
 import { peepholeOptimize } from "../src/codegen/peephole.js";

--- a/tests/issue-2949-s5-1-truthiness.test.ts
+++ b/tests/issue-2949-s5-1-truthiness.test.ts
@@ -33,7 +33,7 @@ import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
 import { addFuncType } from "../src/codegen/registry/types.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
-import { JsTag } from "../src/codegen/js-tag.js";
+import { JsTag } from "../src/ir/js-tag.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
 import { peepholeOptimize } from "../src/codegen/peephole.js";

--- a/tests/issue-2949-s5-2-eq.test.ts
+++ b/tests/issue-2949-s5-2-eq.test.ts
@@ -37,7 +37,7 @@ import { ensureLateImport } from "../src/codegen/shared.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
 import { addFuncType } from "../src/codegen/registry/types.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
-import { JsTag } from "../src/codegen/js-tag.js";
+import { JsTag } from "../src/ir/js-tag.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
 import { peepholeOptimize } from "../src/codegen/peephole.js";

--- a/tests/issue-2949-s5-3-relational.test.ts
+++ b/tests/issue-2949-s5-3-relational.test.ts
@@ -43,7 +43,7 @@ import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
 import { addFuncType } from "../src/codegen/registry/types.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
-import { JsTag } from "../src/codegen/js-tag.js";
+import { JsTag } from "../src/ir/js-tag.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
 import { peepholeOptimize } from "../src/codegen/peephole.js";

--- a/tests/issue-2949-s5-5-dyn-arith.test.ts
+++ b/tests/issue-2949-s5-5-dyn-arith.test.ts
@@ -44,7 +44,7 @@ import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
 import { addFuncType } from "../src/codegen/registry/types.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
 import { FMOD_FN, ensureFmod } from "../src/codegen/fmod.js";
-import { JsTag } from "../src/codegen/js-tag.js";
+import { JsTag } from "../src/ir/js-tag.js";
 import { analyzeSource } from "../src/checker/index.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { repairStructTypeMismatches } from "../src/codegen/fixups.js";

--- a/tests/issue-2949-slice3-dynamic-lowering.test.ts
+++ b/tests/issue-2949-slice3-dynamic-lowering.test.ts
@@ -40,7 +40,7 @@ import { addUnionImports, createCodegenContext } from "../src/codegen/index.js";
 import { mintDefinedFunc, pushDefinedFunc } from "../src/codegen/func-space.js";
 import { addFuncType } from "../src/codegen/registry/types.js";
 import type { CodegenContext } from "../src/codegen/context/types.js";
-import { JsTag } from "../src/codegen/js-tag.js";
+import { JsTag } from "../src/ir/js-tag.js";
 import { emitBinary } from "../src/emit/binary.js";
 import { repairStructTypeMismatches } from "../src/codegen/fixups.js";
 import { peepholeOptimize } from "../src/codegen/peephole.js";


### PR DESCRIPTION
## Problem (#3113, slice 1)

The intended codegen layering is `emit ← ir ← codegen` (codegen consumes IR; IR
consumes nothing above it). But `js-tag.ts` — the dependency-free leaf holding
the `JsTag` enum + `jsTagUnboxKind` (shared *vocabulary*, extracted in #2949) —
lived in `src/codegen/`, while it is consumed by IR core files
(`nodes`/`verify`/`builder`/`from-ast`). Those IR files reaching into
`src/codegen/` for it are exactly the IR→codegen import inversion #3113 tracks.

## Change

Move `src/codegen/js-tag.ts` → `src/ir/js-tag.ts` (pure relocation — the file
has zero imports, no logic change), and update all consumers:

- the 6 IR importers (`nodes`, `verify`, `builder`, `from-ast`, `integration`,
  `backend/handles`) now import it **in-layer**
- `codegen/value-tags.ts` imports it **down-stack** (`../ir/js-tag.js`); its
  `JsTag`/`jsTagUnboxKind` re-export is preserved so existing call sites are
  unchanged
- the 7 `issue-2949-*` test files updated
- a thin `@deprecated` re-export stub stays at `src/codegen/js-tag.ts` for one
  cycle so the concurrently-edited #2855/#2856 IR-migration branches keep
  compiling while they rebase (per the issue's step-1 guidance)

**Effect on the inversion:** `ir/nodes.ts`, `ir/verify.ts`, `ir/builder.ts` had
js-tag as their ONLY codegen import → now **zero** codegen imports;
`ir/from-ast.ts` and `ir/integration.ts` each drop one.

## Safety / proof

Pure file motion + import-path rewrites, no emission-logic change:

- `scripts/prove-emit-identity.mjs check` → **IDENTICAL** across all 56
  (file,target) emits (baseline captured before the move)
- `npx tsc --noEmit` clean
- `prettier --check` clean on changed files
- `issue-2949-*` suites pass (41 tests)

## Scope

This is **slice 1** (Problem 1) of #3113. **Slice 2** — containing the
2,610-LOC `ir/integration.ts` IR→codegen bridge so `import "src/ir"` stops
transitively pulling ~17 codegen modules — is the larger, design-sensitive part
and stays open under #3113 (documented in a Progress note in the issue). The
CI boundary guard (step 4) is deferred with it.