### PR TITLE
fix(#1004): aggregate counted string-append loops into a single repeat

### DIFF
--- a/plan/issues/1004-optimize-repeated-string-concatenation-via.md
+++ b/plan/issues/1004-optimize-repeated-string-concatenation-via.md
@@ -1,21 +1,23 @@
 ---
 id: 1004
 title: "Optimize repeated string concatenation via compile-time folding and counted-loop aggregation"
-status: ready
+status: done
+assignee: ttraenkler/dev-perf
 created: 2026-04-09
-updated: 2026-06-19
+updated: 2026-07-17
+completed: 2026-07-17
 priority: medium
 feasibility: medium
 reasoning_effort: high
 task_type: feature
 language_feature: strings-concat
 goal: generator-model
-sprint: Backlog
+sprint: current
 es_edition: multi
 ---
 # #1004 -- Optimize repeated string concatenation via compile-time folding and counted-loop aggregation
 
-## Status: open
+## Status: done
 
 The landing-page `string.ts` benchmark is currently slower in Wasm than in JS:
 
@@ -119,3 +121,59 @@ individual concat operations.
 This issue is intentionally scoped to the non-fast path too. Fixing
 `fast: true` string support is still useful, but the default optimized path
 should not remain obviously inefficient for common repeated-concat patterns.
+
+## Resolution (2026-07-17)
+
+Directions 1 & 3 (constant-fold literal concat chains, fold adjacent constant
+operands, batched N-arg concat) were already implemented in
+`src/codegen/string-ops.ts` (`resolveStrictConstant`,
+`foldAdjacentConstantOperands`, `compileBatchedConcat`) and in the
+`nativeStrings` concat arm of `compileStringBinaryOp`.
+
+This PR completes **direction 2 — counted-append loop aggregation** — the one
+piece that hits the adversarial `string.ts` benchmark loop itself.
+
+New pass `src/codegen/statements/counted-string-append.ts`
+(`tryCompileCountedStringAppend`), hooked at the top of `compileForStatement`
+(`src/codegen/statements/loops.ts`). It recognizes
+
+```ts
+let s = <string>;
+for (let i = A; i < B; i++) s = s + FRAGMENT;   // or  s += FRAGMENT
+```
+
+and lowers the WHOLE loop to a single `s += FRAGMENT.repeat(N)`
+(`N = max(0, B − A)`), turning O(N) per-iteration concats — each crossing the
+`wasm:js-string` host boundary / calling `__str_concat` — into one
+`String.prototype.repeat` + one concat.
+
+Guard (provably-identical only; anything else falls through to the normal loop):
+
+- counter `let`/`const`-declared in the for-head (block-scoped ⇒ unobservable
+  after the loop) initialized to a compile-time integer `A`;
+- condition `i < B` / `i <= B` with compile-time integer `B` ⇒ `N` is a known
+  finite non-negative integer (no `Infinity` / non-integer-bound hazards);
+- incrementor `i++` / `++i` / `i += 1` (unit positive step);
+- body is exactly one statement `s = s + FRAGMENT` / `s += FRAGMENT`, `s` a
+  plain string-typed identifier (not the counter);
+- FRAGMENT is a side-effect-free loop-invariant string (string literal or
+  string-typed identifier ≠ `s`/`i`) — calls/member-access (getter hazards) and
+  the doubling shape `s = s + s` are declined.
+
+All type queries route through `ctx.oracle` (`staticJsTypeOf`,
+`constInitializerOf`) — the oracle-ratchet gate reports +0 net checker growth.
+
+Works in both the default JS-host (`wasm:js-string`) and `target: "standalone"`
+(native `__str_repeat`) regimes.
+
+## Test Results
+
+`tests/issue-1004.test.ts` — 17 cases green: canonical benchmark loop
+(length + byte-identical string), seed prefix, `+=` form, braced body,
+inclusive `i<=B`, invariant-identifier fragment, zero-iteration / start≥bound
+(emit-nothing), N=1 normal path, nested loops; plus decline cases proving
+correctness for counter-dependent / prepend / multi-statement / doubling /
+runtime-bound / non-unit-step shapes. Extra probes: const bound, template
+fragment, `var`-counter decline, global & closure-captured accumulator, `++i`,
+`i += 1` — all correct. Host + standalone both compile and emit the `repeat`
+call (source concat loop removed).

--- a/plan/issues/1004-optimize-repeated-string-concatenation-via.md
+++ b/plan/issues/1004-optimize-repeated-string-concatenation-via.md
@@ -14,6 +14,8 @@ language_feature: strings-concat
 goal: generator-model
 sprint: current
 es_edition: multi
+loc-budget-allow:
+  - src/codegen/statements/loops.ts
 ---
 # #1004 -- Optimize repeated string concatenation via compile-time folding and counted-loop aggregation
 

--- a/src/codegen/statements/counted-string-append.ts
+++ b/src/codegen/statements/counted-string-append.ts
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#1004) Counted-append string-loop aggregation.
+ *
+ * Recognizes the adversarial repeated-concat idiom
+ *
+ *     let s = <string>;
+ *     for (let i = A; i < B; i++) s = s + FRAGMENT;   // or  s += FRAGMENT
+ *
+ * and lowers the whole loop to a SINGLE string operation
+ *
+ *     s = s + FRAGMENT.repeat(N)          where N = max(0, B - A)
+ *
+ * turning O(N) per-iteration concat operations (each of which crosses the
+ * `wasm:js-string` host boundary or calls `__str_concat`) into one
+ * `String.prototype.repeat` call plus one concat.
+ *
+ * The transform is applied ONLY when it is provably identical to running the
+ * loop, under a deliberately tight guard:
+ *
+ *  - the loop counter `i` is `let`/`const`-declared in the for-head
+ *    (block-scoped, so it cannot be observed after the loop) and initialized to
+ *    a compile-time integer `A`;
+ *  - the condition is `i < B` or `i <= B` where `B` is a compile-time integer
+ *    (literal or `const`), so the iteration count `N` is a known finite
+ *    non-negative integer (no `Infinity` / non-integer-bound hazards);
+ *  - the incrementor is `i++`, `++i`, or `i += 1` (unit positive step);
+ *  - the body is EXACTLY one statement `s = s + FRAGMENT` or `s += FRAGMENT`
+ *    where `s` is a plain string-typed identifier (not `i`);
+ *  - FRAGMENT is a side-effect-free, loop-invariant string value — a string
+ *    literal or a string-typed identifier other than `s`/`i`. (Because the body
+ *    is only the append, no other variable is mutated in the loop, so such an
+ *    identifier is invariant; forbidding calls / member access rules out
+ *    getters and other observable effects.)
+ *
+ * Under those constraints there are no intermediate observations of `s` and
+ * FRAGMENT is evaluated with the same (side-effect-free) result each iteration,
+ * so `s + FRAGMENT.repeat(N)` yields the byte-identical final string.
+ */
+import { ts } from "../../ts-api.js";
+import type { TypeOracle } from "../../checker/oracle.js";
+import type { CodegenContext, FunctionContext } from "../context/types.js";
+import { compileStatement } from "../shared.js";
+
+/** Unwrap parentheses/`as`/non-null wrappers around an expression. */
+function unwrap(expr: ts.Expression): ts.Expression {
+  let cur: ts.Expression = expr;
+  while (
+    ts.isParenthesizedExpression(cur) ||
+    ts.isAsExpression(cur) ||
+    ts.isNonNullExpression(cur) ||
+    ts.isTypeAssertionExpression(cur)
+  ) {
+    cur = (cur as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression | ts.TypeAssertion).expression;
+  }
+  return cur;
+}
+
+/**
+ * Resolve a compile-time INTEGER constant: numeric literals, `const`
+ * identifiers initialized to one, and unary `+`/`-` of those. Returns undefined
+ * for anything non-integer or not statically known. Const resolution goes
+ * through the oracle's `constInitializerOf` (which excludes `let`/`var`), so no
+ * raw checker query is needed.
+ */
+function constIntValue(oracle: TypeOracle, expr: ts.Expression): number | undefined {
+  const e = unwrap(expr);
+  if (ts.isNumericLiteral(e)) {
+    const n = Number(e.text);
+    return Number.isInteger(n) ? n : undefined;
+  }
+  if (ts.isPrefixUnaryExpression(e)) {
+    if (e.operator === ts.SyntaxKind.MinusToken || e.operator === ts.SyntaxKind.PlusToken) {
+      const v = constIntValue(oracle, e.operand);
+      if (v === undefined) return undefined;
+      return e.operator === ts.SyntaxKind.MinusToken ? -v : v;
+    }
+    return undefined;
+  }
+  if (ts.isIdentifier(e)) {
+    const init = oracle.constInitializerOf(e);
+    if (init) return constIntValue(oracle, init);
+  }
+  return undefined;
+}
+
+/** True when `expr` is exactly the identifier named `name`. */
+function isIdentNamed(expr: ts.Expression, name: string): boolean {
+  const e = unwrap(expr);
+  return ts.isIdentifier(e) && e.text === name;
+}
+
+/**
+ * A safe, loop-invariant, side-effect-free STRING fragment: a string literal /
+ * no-substitution template, or a string-typed identifier that is neither the
+ * accumulator `s` nor the counter `i`. Calls, member access (possible getters),
+ * template substitutions, etc. are rejected.
+ */
+function isSafeStringFragment(
+  oracle: TypeOracle,
+  expr: ts.Expression,
+  accumName: string,
+  counterName: string,
+): boolean {
+  const e = unwrap(expr);
+  if (ts.isStringLiteral(e) || ts.isNoSubstitutionTemplateLiteral(e)) return true;
+  if (ts.isIdentifier(e)) {
+    if (e.text === accumName || e.text === counterName) return false;
+    return oracle.staticJsTypeOf(e) === "string";
+  }
+  return false;
+}
+
+/**
+ * Extract the accumulator identifier and the appended fragment from a single
+ * body statement of the form `s = s + FRAGMENT` or `s += FRAGMENT`.
+ * Returns the REAL (typed) `s` read node and the REAL fragment node so the
+ * synthesized replacement re-uses checker-resolvable nodes.
+ */
+function matchAppendBody(stmt: ts.Statement): { accum: ts.Identifier; fragment: ts.Expression } | undefined {
+  let exprStmt: ts.Statement = stmt;
+  if (ts.isBlock(stmt)) {
+    if (stmt.statements.length !== 1) return undefined;
+    exprStmt = stmt.statements[0]!;
+  }
+  if (!ts.isExpressionStatement(exprStmt)) return undefined;
+  const expr = exprStmt.expression;
+  if (!ts.isBinaryExpression(expr)) return undefined;
+
+  // `s += FRAGMENT`
+  if (expr.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken) {
+    const lhs = unwrap(expr.left);
+    if (!ts.isIdentifier(lhs)) return undefined;
+    return { accum: lhs, fragment: expr.right };
+  }
+
+  // `s = s + FRAGMENT`
+  if (expr.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+    const target = unwrap(expr.left);
+    if (!ts.isIdentifier(target)) return undefined;
+    const rhs = unwrap(expr.right);
+    if (!ts.isBinaryExpression(rhs) || rhs.operatorToken.kind !== ts.SyntaxKind.PlusToken) return undefined;
+    // Append shape only: `s = s + FRAGMENT` (accumulator on the LEFT of `+`).
+    if (!isIdentNamed(rhs.left, target.text)) return undefined;
+    const accumRead = unwrap(rhs.left);
+    if (!ts.isIdentifier(accumRead)) return undefined;
+    return { accum: accumRead, fragment: rhs.right };
+  }
+
+  return undefined;
+}
+
+/** Match `i++`, `++i`, or `i += 1` (unit positive step on `name`). */
+function isUnitIncrement(oracle: TypeOracle, incr: ts.Expression | undefined, name: string): boolean {
+  if (!incr) return false;
+  const e = unwrap(incr);
+  if (ts.isPostfixUnaryExpression(e) || ts.isPrefixUnaryExpression(e)) {
+    return e.operator === ts.SyntaxKind.PlusPlusToken && isIdentNamed(e.operand, name);
+  }
+  if (ts.isBinaryExpression(e) && e.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken) {
+    return isIdentNamed(e.left, name) && constIntValue(oracle, e.right) === 1;
+  }
+  return false;
+}
+
+/**
+ * If `stmt` matches the counted string-append idiom, emit the aggregated
+ * `s = s + FRAGMENT.repeat(N)` lowering and return true. Otherwise return false
+ * (the caller compiles the loop normally).
+ */
+export function tryCompileCountedStringAppend(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.ForStatement,
+): boolean {
+  const oracle = ctx.oracle;
+  const { initializer, condition, incrementor, statement } = stmt;
+  if (!initializer || !condition || !incrementor) return false;
+
+  // init: `let i = A` (single block-scoped integer counter)
+  if (!ts.isVariableDeclarationList(initializer)) return false;
+  if ((initializer.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0) return false;
+  if (initializer.declarations.length !== 1) return false;
+  const decl = initializer.declarations[0]!;
+  if (!ts.isIdentifier(decl.name) || !decl.initializer) return false;
+  const counterName = decl.name.text;
+  const start = constIntValue(oracle, decl.initializer);
+  if (start === undefined) return false;
+
+  // cond: `i < B` or `i <= B` with compile-time integer B
+  if (!ts.isBinaryExpression(condition)) return false;
+  const condOp = condition.operatorToken.kind;
+  if (condOp !== ts.SyntaxKind.LessThanToken && condOp !== ts.SyntaxKind.LessThanEqualsToken) return false;
+  if (!isIdentNamed(condition.left, counterName)) return false;
+  const bound = constIntValue(oracle, condition.right);
+  if (bound === undefined) return false;
+
+  // incrementor: unit positive step
+  if (!isUnitIncrement(oracle, incrementor, counterName)) return false;
+
+  // body: `s = s + FRAGMENT` / `s += FRAGMENT`
+  const matched = matchAppendBody(statement);
+  if (!matched) return false;
+  const { accum, fragment } = matched;
+  if (accum.text === counterName) return false;
+  if (oracle.staticJsTypeOf(accum) !== "string") return false;
+  if (!isSafeStringFragment(oracle, fragment, accum.text, counterName)) return false;
+
+  // Iteration count N = number of times the body runs.
+  const rawCount = condOp === ts.SyntaxKind.LessThanToken ? bound - start : bound - start + 1;
+  const count = rawCount > 0 ? rawCount : 0;
+
+  // N === 0 → loop never runs; the accumulator keeps its value (emit nothing).
+  if (count === 0) return true;
+
+  // N === 1 → a single append; let the normal loop path handle it (no repeat
+  // machinery needed, avoids a needless `.repeat(1)`).
+  if (count === 1) return false;
+
+  // Synthesize `accum += fragment.repeat(N)` re-using the REAL, checker-typed
+  // `accum` (string) and `fragment` nodes so type resolution and string-concat
+  // routing behave exactly as for hand-written source.
+  const countLit = ts.factory.createNumericLiteral(String(count));
+  const repeatProp = ts.factory.createPropertyAccessExpression(fragment, "repeat");
+  ts.setTextRange(repeatProp, fragment);
+  (repeatProp as unknown as { parent: ts.Node }).parent = stmt;
+  const repeatCall = ts.factory.createCallExpression(repeatProp, undefined, [countLit]);
+  ts.setTextRange(repeatCall, stmt);
+  (repeatCall as unknown as { parent: ts.Node }).parent = stmt;
+  (countLit as unknown as { parent: ts.Node }).parent = repeatCall;
+
+  const assign = ts.factory.createBinaryExpression(accum, ts.SyntaxKind.PlusEqualsToken, repeatCall);
+  ts.setTextRange(assign, stmt);
+  (assign as unknown as { parent: ts.Node }).parent = stmt;
+  const exprStmt = ts.factory.createExpressionStatement(assign);
+  ts.setTextRange(exprStmt, stmt);
+  (exprStmt as unknown as { parent: ts.Node }).parent = stmt.parent;
+
+  compileStatement(ctx, fctx, exprStmt);
+  return true;
+}

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -72,6 +72,7 @@ import {
   compileForOfIteratorAssignDestructuring,
 } from "./for-of-destructuring.js";
 import { collectPatternBindingNames } from "./tdz.js";
+import { tryCompileCountedStringAppend } from "./counted-string-append.js";
 import { emitHoleToUndefined } from "../array-holes.js"; // (#2001 S1)
 import { definedFuncAt } from "../func-space.js"; // (#1916 S2) positional-read chokepoint
 
@@ -234,6 +235,9 @@ function detectCanonicalCharReadLoop(
 }
 
 export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForStatement): void {
+  // (#1004) Counted-append string-loop aggregation: `for (let i=A;i<B;i++) s = s + FRAG`
+  // → `s += FRAG.repeat(N)`. Provably-identical fast path; returns true when handled.
+  if (tryCompileCountedStringAppend(ctx, fctx, stmt)) return;
   // Save localMap entries for let/const initializers that shadow outer variables.
   // `for (let x = ...; ...)` creates a block scope that ends after the loop.
   let savedForScope: Map<string, number> | null = null;

--- a/tests/issue-1004.test.ts
+++ b/tests/issue-1004.test.ts
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// (#1004) Counted-append string-loop aggregation: `for (let i=0;i<N;i++) s = s + FRAG`
+// lowers to `s += FRAG.repeat(N)`. These tests pin byte-identical semantics for
+// the optimizable cases and confirm the guard declines unsafe shapes.
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function runStr(src: string): Promise<string> {
+  const exports = (await compileAndInstantiate(src)) as { test(): string };
+  return exports.test();
+}
+async function runNum(src: string): Promise<number> {
+  const exports = (await compileAndInstantiate(src)) as { test(): number };
+  return exports.test();
+}
+
+describe("#1004 counted string-append aggregation", () => {
+  it("aggregates the canonical benchmark loop (length)", async () => {
+    expect(
+      await runNum(`
+        export function test(): number {
+          let str = "";
+          for (let i = 0; i < 1000; i++) str = str + "abcde";
+          return str.length;
+        }`),
+    ).toBe(5000);
+  });
+
+  it("produces the byte-identical string", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "";
+          for (let i = 0; i < 4; i++) s = s + "ab";
+          return s;
+        }`),
+    ).toBe("abababab");
+  });
+
+  it("honors a non-empty seed prefix", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "X";
+          for (let i = 0; i < 3; i++) s = s + "yz";
+          return s;
+        }`),
+    ).toBe("Xyzyzyz");
+  });
+
+  it("handles the compound-assignment form", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "";
+          for (let i = 0; i < 5; i++) s += "q";
+          return s;
+        }`),
+    ).toBe("qqqqq");
+  });
+
+  it("handles a braced single-statement body", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "";
+          for (let i = 0; i < 3; i++) { s = s + "mn"; }
+          return s;
+        }`),
+    ).toBe("mnmnmn");
+  });
+
+  it("handles a non-zero start (i<=B inclusive)", async () => {
+    // i = 2..10 inclusive → 9 iterations
+    expect(
+      await runNum(`
+        export function test(): number {
+          let s = "";
+          for (let i = 2; i <= 10; i++) s = s + "z";
+          return s.length;
+        }`),
+    ).toBe(9);
+  });
+
+  it("a loop-invariant string identifier fragment", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          const frag = "hi";
+          let s = "";
+          for (let i = 0; i < 3; i++) s = s + frag;
+          return s;
+        }`),
+    ).toBe("hihihi");
+  });
+
+  it("emits nothing for a zero-iteration loop (keeps seed)", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "seed";
+          for (let i = 0; i < 0; i++) s = s + "x";
+          return s;
+        }`),
+    ).toBe("seed");
+  });
+
+  it("emits nothing when start >= bound", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "seed";
+          for (let i = 5; i < 3; i++) s = s + "x";
+          return s;
+        }`),
+    ).toBe("seed");
+  });
+
+  it("still handles a single iteration (N=1) via the normal path", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "a";
+          for (let i = 0; i < 1; i++) s = s + "b";
+          return s;
+        }`),
+    ).toBe("ab");
+  });
+
+  // ── Guard must DECLINE unsafe / non-matching shapes (correctness) ──
+
+  it("does NOT aggregate when the body references the counter (i-dependent)", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "";
+          for (let i = 0; i < 3; i++) s = s + ("" + i);
+          return s;
+        }`),
+    ).toBe("012");
+  });
+
+  it("does NOT aggregate a prepend loop (order matters)", async () => {
+    expect(
+      await runStr(`
+        export function test(): string {
+          let s = "";
+          for (let i = 0; i < 3; i++) s = "a" + s + "b";
+          return s;
+        }`),
+    ).toBe("aaabbb");
+  });
+
+  it("does NOT aggregate a multi-statement body", async () => {
+    expect(
+      await runNum(`
+        export function test(): number {
+          let s = "";
+          let c = 0;
+          for (let i = 0; i < 4; i++) { s = s + "x"; c = c + 1; }
+          return s.length + c;
+        }`),
+    ).toBe(8);
+  });
+
+  it("does NOT aggregate a doubling accumulator (s = s + s)", async () => {
+    expect(
+      await runNum(`
+        export function test(): number {
+          let s = "ab";
+          for (let i = 0; i < 3; i++) s = s + s;
+          return s.length;
+        }`),
+    ).toBe(16);
+  });
+
+  it("does NOT aggregate a runtime (non-constant) bound", async () => {
+    expect(
+      await runNum(`
+        export function test(): number {
+          let n = 5;
+          n = n + 1;
+          let s = "";
+          for (let i = 0; i < n; i++) s = s + "z";
+          return s.length;
+        }`),
+    ).toBe(6);
+  });
+
+  it("does NOT aggregate a non-unit step", async () => {
+    expect(
+      await runNum(`
+        export function test(): number {
+          let s = "";
+          for (let i = 0; i < 10; i += 2) s = s + "z";
+          return s.length;
+        }`),
+    ).toBe(5);
+  });
+
+  it("nested aggregated loops compose correctly", async () => {
+    expect(
+      await runNum(`
+        export function test(): number {
+          let total = 0;
+          for (let j = 0; j < 3; j++) {
+            let s = "";
+            for (let i = 0; i < 4; i++) s = s + "ab";
+            total = total + s.length;
+          }
+          return total;
+        }`),
+    ).toBe(24);
+  });
+});


### PR DESCRIPTION
## #1004 — repeated string concatenation

Completes **direction 2 (counted-append loop aggregation)** of #1004 — the piece that hits the adversarial `string.ts` benchmark. Directions 1 & 3 (constant-fold literal chains, adjacent-constant folding, batched N-arg concat) were already implemented in `string-ops.ts`.

### What it does

New pass `src/codegen/statements/counted-string-append.ts` (`tryCompileCountedStringAppend`), hooked at the top of `compileForStatement`. It recognizes

```ts
let s = <string>;
for (let i = A; i < B; i++) s = s + FRAGMENT;   // or  s += FRAGMENT
```

and lowers the **whole loop** to a single `s += FRAGMENT.repeat(N)` (`N = max(0, B − A)`), turning O(N) per-iteration concats — each crossing the `wasm:js-string` host boundary / calling `__str_concat` — into one `String.prototype.repeat` + one concat.

### Guard (provably byte-identical only; anything else falls through to the normal loop)

- counter `let`/`const`-declared in the for-head (block-scoped ⇒ unobservable after the loop), initialized to a compile-time integer `A`;
- condition `i < B` / `i <= B` with a compile-time integer `B` ⇒ `N` is a known finite non-negative integer (no `Infinity` / non-integer-bound hazards);
- incrementor `i++` / `++i` / `i += 1` (unit positive step);
- body is exactly one statement `s = s + FRAGMENT` / `s += FRAGMENT`, `s` a plain string-typed identifier (not the counter);
- FRAGMENT is a side-effect-free loop-invariant string (string literal or string-typed identifier ≠ `s`/`i`) — calls / member-access (getter hazards) and the doubling shape `s = s + s` are declined.

Type queries route through `ctx.oracle` (`staticJsTypeOf`, `constInitializerOf`) — oracle-ratchet reports **+0** net checker growth. Works in both the JS-host (`wasm:js-string`) and `target: "standalone"` (native `__str_repeat`) regimes.

### Tests

`tests/issue-1004.test.ts` — 17 cases: canonical benchmark loop (length + byte-identical string), seed prefix, `+=` form, braced body, inclusive `i<=B`, invariant-identifier fragment, zero-iteration / start≥bound (emit-nothing), N=1 normal path, nested loops; **plus decline cases** proving correctness for counter-dependent / prepend / multi-statement / doubling / runtime-bound / non-unit-step shapes. Extra probes (const bound, template fragment, `var`-counter decline, global & closure-captured accumulator, `++i`, `i += 1`) all correct. Host + standalone both compile and emit the `repeat` call with the source concat loop removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)