### PR TITLE
fix(#3136): restore boxed-capture cell-read identity assertions (standalone)

### DIFF
--- a/plan/issues/3136-standalone-cell-read-identity-loss.md
+++ b/plan/issues/3136-standalone-cell-read-identity-loss.md
@@ -1,10 +1,12 @@
 ---
 id: 3136
 title: "Standalone: object read back through a boxed-capture cell loses `===` identity with the outer variable"
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/dev-standalone2
+sprint: current
 created: 2026-07-10
-updated: 2026-07-10
+updated: 2026-07-17
 priority: medium
 horizon: s
 feasibility: medium
@@ -15,6 +17,25 @@ goal: standalone-mode
 related: [3128, 2583, 3130]
 origin: "#3128 rescue (fable-18th) — surfaced when the issue-3128 test suite was moved from the vacuous `{standalone:true}` compile option (silently gc-host) to the real `target: 'standalone'` lane"
 ---
+
+## Resolution (2026-07-17)
+
+**Already fixed on main** by the intervening any-typed strict-equality / boxed
+native-value work (the tag-5 host-only arm — `reference_2583_*` family — was
+generalised to a carrier-agnostic path; see #745 S3 `$AnyValue` strict-eq).
+Re-verified against current main: the minimal repro and both identity controls
+now return `1` under `target: "standalone"`.
+
+Closed by:
+- restoring the identity assertions in `tests/issue-3128.test.ts` — the two
+  `standaloneSrc` value-only relaxations (the "escaped self-capturing closure"
+  and "sibling closure outside the RHS" cases) are removed, so `closureRead()
+  === p2` OBJECT-identity now runs on BOTH lanes;
+- adding `tests/issue-3136.test.ts` — the exact minimal repro + arrow variant +
+  controls (value-flow, no-write, aliasing, mutate-through-cell), on both the
+  standalone and js-host lanes.
+
+No host-lane behavior change (guard-only + already-green fix).
 
 # #3136 — standalone cell-read object identity loss
 

--- a/tests/issue-3128.test.ts
+++ b/tests/issue-3128.test.ts
@@ -45,15 +45,13 @@ async function run(src: string, standalone: boolean): Promise<unknown> {
   return (instance.exports as { test: () => unknown }).test();
 }
 
-// `standaloneSrc`: variant for the real standalone lane. The two cases that
-// assert `closureRead() === p2` OBJECT IDENTITY hit a PRE-EXISTING standalone
-// bug that is independent of #3128 (measured on main: `var p2: any; var f =
-// function(){ return p2; }; p2 = { a: 1 }; f() !== p2` — no IIFE, no
-// self-capture RHS — already fails; the boxed-cell read path loses identity,
-// same family as the tag-5 host-only strict-eq arm,
-// reference_2583_any_strict_eq_tag5_host_only / #3136). The standalone
-// variants assert the VALUE flows through the cell instead; identity stays
-// pinned on the host lane.
+// #3136 (FIXED): the two cases that assert `closureRead() === p2` OBJECT
+// IDENTITY previously hit a standalone-only boxed-cell-read identity-loss bug
+// (independent of #3128 — the tag-5 host-only strict-eq arm,
+// reference_2583_any_strict_eq_tag5_host_only). They used `standaloneSrc`
+// variants that only checked the VALUE through the cell. That bug is now fixed,
+// so the `standaloneSrc` relaxations were removed and the identity assertions
+// run on BOTH lanes.
 const CASES: Array<{ name: string; src: string; expected: number; standaloneSrc?: string }> = [
   {
     // The issue's table row: plain-object RHS, no Promise involved.
@@ -91,17 +89,6 @@ export function test(): number {
   if (captured() !== p2) return 8;
   return 1;
 }`,
-    standaloneSrc: `
-export function test(): number {
-  var p2: any;
-  var captured: any;
-  p2 = (function(){ captured = (function(){ return p2; }); return { a: 1 }; })();
-  if (p2 === null || p2 === undefined) return 9;
-  var got: any = captured();
-  if (got === null || got === undefined) return 8;
-  if (got.a !== 1) return 8;
-  return 1;
-}`,
     expected: 1,
   },
   {
@@ -114,17 +101,6 @@ export function test(): number {
   p2 = (function(){ return { a: 1 }; })();
   if (p2 === null || p2 === undefined) return 9;
   if (f() !== p2) return 8;
-  return 1;
-}`,
-    standaloneSrc: `
-export function test(): number {
-  var p2: any;
-  var f = function(){ return p2; };
-  p2 = (function(){ return { a: 1 }; })();
-  if (p2 === null || p2 === undefined) return 9;
-  var got: any = f();
-  if (got === null || got === undefined) return 8;
-  if (got.a !== 1) return 8;
   return 1;
 }`,
     expected: 1,

--- a/tests/issue-3136.test.ts
+++ b/tests/issue-3136.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.ts";
+
+// #3136 — object read back through a boxed-capture cell must keep `===` identity
+// with the outer variable in `--target standalone`.
+//
+// When an `any`-typed `var` is promoted to a ref-cell capture and a closure
+// reads it back, `closureRead() === outerRead` previously answered FALSE for the
+// SAME object on the standalone lane (the cell-read result and the outer local
+// went through different boxing/conversions, landing in the tag-5 host-only
+// strict-eq arm — same family as reference_2583_any_strict_eq_tag5_host_only).
+// This guards the fixed behavior on BOTH lanes.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("; ")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function runHost(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("; ")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+// [label, source]  — every case returns 1 on success.
+const cases: [string, string][] = [
+  [
+    "minimal repro: write-after-capture cell read keeps identity",
+    `export function test(): number {
+      var p2: any;
+      var f = function () { return p2; };
+      p2 = { a: 1 };
+      if (f() !== p2) return 8;
+      return 1;
+    }`,
+  ],
+  [
+    "arrow closure variant",
+    `export function test(): number {
+      var p2: any;
+      var f = () => p2;
+      p2 = { a: 2 };
+      if (f() !== p2) return 8;
+      return 1;
+    }`,
+  ],
+  [
+    "control: value still flows through the cell",
+    `export function test(): number {
+      var p2: any;
+      var f = function () { return p2; };
+      p2 = { a: 1 };
+      return f().a === 1 ? 1 : 8;
+    }`,
+  ],
+  [
+    "control: no write after capture keeps identity",
+    `export function test(): number {
+      var p2: any = { a: 1 };
+      var f = () => p2;
+      return f() === p2 ? 1 : 8;
+    }`,
+  ],
+  [
+    "control: direct aliasing keeps identity",
+    `export function test(): number {
+      var p2: any;
+      p2 = { a: 1 };
+      var q: any = p2;
+      return q === p2 ? 1 : 8;
+    }`,
+  ],
+  [
+    "mutate through cell then identity + value both hold",
+    `export function test(): number {
+      var p2: any;
+      var f = () => p2;
+      p2 = { a: 1 };
+      p2.a = 5;
+      if (f() !== p2) return 8;
+      return f().a === 5 ? 1 : 8;
+    }`,
+  ],
+];
+
+describe("#3136 boxed-capture cell-read object identity", () => {
+  describe("standalone (no JS host)", () => {
+    for (const [label, src] of cases) {
+      it(label, async () => {
+        expect(await runStandalone(src)).toBe(1);
+      });
+    }
+  });
+
+  describe("js-host parity", () => {
+    for (const [label, src] of cases) {
+      it(label, async () => {
+        expect(await runHost(src)).toBe(1);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3136. The standalone-only bug — a closure reading an `any`-typed `var` back through a boxed-capture ref-cell answered `closureRead() === outerVar` as **FALSE for the same object** — is **already fixed on `main`** by the carrier-agnostic any-typed strict-equality work (#745 S3 `$AnyValue`; the tag-5 host-only strict-eq arm was generalised).

Re-verified against current `main`, all return `1` under `target: "standalone"`:

```ts
var p2: any; var f = function () { return p2; };
p2 = { a: 1 };
f() !== p2   // was true (bug) → now false (identity holds)
```

## Changes

- `tests/issue-3128.test.ts` — remove the two `standaloneSrc` value-only relaxations (the "escaped self-capturing closure" and "sibling closure outside the RHS" cases), so `closureRead() === p2` OBJECT-identity now runs on **both** lanes (the #3136 acceptance criterion).
- `tests/issue-3136.test.ts` — dedicated guard: exact minimal repro + arrow variant + controls (value-flow, no-write, direct aliasing, mutate-through-cell), on the standalone **and** js-host lanes.
- `plan/issues/3136-*.md` — `status: done`, resolution note.

Guard-only + already-green fix; no host-lane behavior change.

## Validation

- `npm test -- tests/issue-3136.test.ts tests/issue-3128.test.ts` → 26 passed
- `npx tsc --noEmit` → no errors
- `prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)