### PR TITLE
fix(#1568): restore Object(BigInt)/Object(Symbol) wrapper handler (regression)

### DIFF
--- a/plan/issues/1568-object-bigint-symbol-auto-box.md
+++ b/plan/issues/1568-object-bigint-symbol-auto-box.md
@@ -3,7 +3,7 @@ id: 1568
 title: "Object(BigInt) and Object(Symbol) must auto-box to wrappers (typeof === \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"object\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\")"
 status: done
 created: 2026-05-21
-updated: 2026-05-27
+updated: 2026-07-17
 completed: 2026-05-27
 feasibility: easy
 sprint: 56
@@ -13,6 +13,11 @@ type: fix
 source: plan/issues/sprints/53/post-wave-regression-investigation.md
 blocks: []
 labels: [test262, regression, ToObject, ECMAScript-spec]
+# Restoring the regressed __new_BigInt/__new_Symbol Object(v) wrapper handler
+# (a single early-return) in the runtime's extern_class "new" dispatch — an
+# intentional +13 in the runtime barrel that carries the host import handlers.
+loc-budget-allow:
+  - src/runtime.ts
 ---
 # #1568 — Object(BigInt) and Object(Symbol) auto-box
 
@@ -78,9 +83,23 @@ this is a pre-existing wrapper-`.valueOf()` unboxing limitation shared by the
 number/string/boolean wrappers (the String equivalent behaves identically), out
 of scope here. The real test262 test only checks `typeof`.
 
+## Regression + restore (2026-07-17)
+
+The original `__new_BigInt(v)` / `__new_Symbol(v)` runtime handler (an early
+`return (v) => Object(v)` at the top of the `extern_class` `"new"` dispatch)
+was **dropped during a later runtime.ts refactor** that relocated the
+`extern_class` block (it now lives near line 7635). With the handler gone,
+`Object(BigInt(42))` / `Object(BigInt(0n))` fell through to the generic
+`builtinCtors[className]` lookup, and since neither `BigInt` nor `Symbol` is a
+constructor (not in `builtinCtors`), the resolver threw
+`No dependency provided for extern class "BigInt"` at runtime — 3 of the 6
+`tests/issue-1568.test.ts` cases (the ones invoking `BigInt(...)`) failed on
+main. Restored the identical single-early-return handler in the current
+`action === "new"` block. All 6 tests pass again.
+
 ## Test Results
 
-- `tests/issue-1568.test.ts` — 6 new tests, all pass.
+- `tests/issue-1568.test.ts` — 6 tests, all pass (was 3 failing on main).
 - `tests/issue-1129.test.ts` — 9 existing tests, all pass (no regression).
 
 ## References

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7633,6 +7633,19 @@ function resolveImport(
           options == null ? self.addEventListener(type, listener) : self.addEventListener(type, listener, options);
       }
       if (intent.action === "new") {
+        // (#1568) `__new_BigInt(v)` / `__new_Symbol(v)` — Object(bigint) /
+        // Object(symbol) auto-boxing (§7.1.18 ToObject, Table 13). BigInt and
+        // Symbol are NOT constructors, so `new BigInt(v)` throws; box via the
+        // spec's literal `Object(v)`, yielding an object (typeof "object") whose
+        // valueOf() returns the underlying primitive. This handler must precede
+        // the generic `builtinCtors` lookup below — neither name is a member of
+        // that map (they aren't constructors), so without this early return the
+        // resolver throws "No dependency provided for extern class BigInt".
+        // (Regressed when the extern_class block moved during a runtime refactor;
+        // restored here — see tests/issue-1568.test.ts.)
+        if (intent.className === "BigInt" || intent.className === "Symbol") {
+          return (v: any): any => Object(v);
+        }
         // Test262Error is a simple Error subclass used by the test262 harness
         class Test262Error extends Error {
           constructor(msg?: string) {


### PR DESCRIPTION
## #1568 — `Object(BigInt(...))` broken on main (regression)

`typeof Object(BigInt(42))` / `Object(BigInt(0n))` threw
`No dependency provided for extern class "BigInt"` at runtime — 3 of the 6
`tests/issue-1568.test.ts` cases were failing on `main`.

### Root cause
The original #1568 fix (`f56287665`) added a small early-return handler in the
runtime's `extern_class` `"new"` dispatch that boxes `__new_BigInt(v)` /
`__new_Symbol(v)` via the spec's literal `Object(v)` (§7.1.18 ToObject) — BigInt
and Symbol are **not** constructors, so `new BigInt(v)` throws and they are
deliberately absent from `builtinCtors`. That handler was **dropped during a
later runtime.ts refactor** that relocated the `extern_class` block (now ~line
7635). With it gone, `Object(<bigint>)` fell through to the generic
`builtinCtors[className]` lookup → `!Ctor` → throw.

### Fix
Restored the identical single early-return at the top of the current
`action === "new"` block:
```js
if (intent.className === "BigInt" || intent.className === "Symbol") {
  return (v) => Object(v);
}
```

### Tests
`tests/issue-1568.test.ts` — **6/6 pass** (was 3 failing on main); the existing
guard file already covers `Object(0n)`, `Object(BigInt(42))`, `Object(BigInt(0n))`,
no over-boxing of bare bigint literals, and the number/boolean box regressions.
`tsc --noEmit` clean; loc-budget allowance granted in the issue file (+13 in the
runtime barrel that carries the host-import handlers).