### PR TITLE
fix(#3229): return canonical vec type from Object.keys/values fast-path

### DIFF
--- a/plan/issues/3229-object-keys-inline-length-vec-type-mismatch.md
+++ b/plan/issues/3229-object-keys-inline-length-vec-type-mismatch.md
@@ -1,15 +1,23 @@
 ---
 id: 3229
 title: "Object.keys/values/entries(closedStruct).length INLINE returns 0 — static-enumeration vec type (vec-of-externref) mismatches the `.length` dispatch type (vec-of-string); mode-agnostic"
-status: ready
-sprint: Backlog
+status: done
+assignee: ttraenkler/dev-conform
+sprint: current
 created: 2026-07-13
+updated: 2026-07-17
+completed: 2026-07-17
 priority: medium
 feasibility: medium
 task_type: bugfix
 area: codegen
 language_feature: objects, property enumeration, array length
 related: [3222, 786]
+# (#3102) The canonical-vec resolution + per-arm coercion comments grow the
+# object-ops subsystem module (the correct home for Object.keys/values/entries)
+# a few LOC; the net code is a simplification (removed manual per-field boxing).
+loc-budget-allow:
+  - src/codegen/object-ops.ts
 ---
 
 # #3229 — `Object.keys(o).length` INLINE returns 0 (vec-type mismatch)
@@ -96,3 +104,43 @@ byte-identity).
 - `Object.keys(typedLocal).length` inline === field count (host + standalone).
 - Same for `Object.values(...).length` and `Object.entries(...).length`.
 - No host/gc test262 regression (full-CI validation).
+
+## Resolution
+
+The static keys/values fast-paths (`compileObjectKeysOrValues` in
+`src/codegen/object-ops.ts`) built a vec-of-**externref** and returned its type
+index, while an inline `.length` dispatches on the CANONICAL vec type
+(`resolveWasmType(returnType)` → vec-of-string / vec-of-f64). `ref.test` against
+the canonical type failed on the vec-of-externref → the `.length` else-arm read
+`0`. (A `const k: string[] = …` binding worked only because the store coerced
+the vec to the canonical layout.)
+
+Fix — build the fast-path vec with the CANONICAL arr/element types, coercing
+each element (mirrors what the `entries` arm already did):
+
+- Hoisted the `entries` arm's `getResolvedSignature` / `getReturnTypeOfSignature`
+  resolution to the top of `compileObjectKeysOrValues` and derived the canonical
+  vec (`getVecInfo`) once; `entries` now reuses it (net-zero checker growth —
+  oracle-ratchet clean).
+- `keys`: return the canonical `string[]` vec; push each field-name string via
+  `compileStringLiteral` and `coerceType` to the vec element (host element IS
+  externref → byte-identical; standalone native-string element → fixed).
+- `values`: return the canonical values vec; `coerceType` each field value to the
+  element type — homogeneous `number[]` stores f64 unboxed (removed the manual
+  `__box_number` branches), heterogeneous `(string|number)[]` boxes to externref
+  exactly as before.
+- Falls back to the legacy vec-of-externref when the return type is unresolvable.
+
+## Test Results
+
+`tests/issue-3229.test.ts` — 20/20 pass (10 host/gc + 10 standalone): inline
+`.length` for keys/values/entries === field count; keys/values/entries content
+correctness; inline index reads; `keys.length` driving a for-loop; heterogeneous
+`(string|number)[]` boxing; intermediate-variable regression guard.
+
+No regressions in `object-keys-values-entries`, `issue-786`,
+`issue-786-object-keys-dynamic`, `issue-3222-standalone-closed-struct-enum`
+(all pass). `npx tsc --noEmit` clean; prettier clean; oracle-ratchet clean
+(checker usage +0). (The one failing case in `issue-2166-objvec-element-index`
+— an `any`-receiver out-of-bounds read yielding NaN vs +0 — fails identically on
+the clean tree; it is a pre-existing failure orthogonal to this change.)

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -4187,30 +4187,48 @@ export function compileObjectKeysOrValues(
     return true; // no explicit descriptor = enumerable by default
   });
 
+  // (#3229) Resolve the CANONICAL vec type from the call's TS return type so an
+  // INLINE `.length` (which dispatches on `resolveWasmType(returnType)` — the
+  // canonical `string[]`/`T[]` vec) matches. The keys/values fast-paths built a
+  // vec-of-EXTERNREF whose type index the `.length` `ref.test` could not match →
+  // read 0; build with the canonical arr/elem types instead. Shared across all
+  // three arms; falls back to the legacy externref vec when unresolvable.
+  const canonSig = ctx.checker.getResolvedSignature(expr);
+  const canonRetType = canonSig ? ctx.checker.getReturnTypeOfSignature(canonSig) : undefined;
+  const canonResolvedRet = canonRetType ? resolveWasmType(ctx, canonRetType) : undefined;
+  const canonicalVec =
+    canonResolvedRet &&
+    (canonResolvedRet.kind === "ref" || canonResolvedRet.kind === "ref_null") &&
+    "typeIdx" in canonResolvedRet
+      ? (() => {
+          const info = getVecInfo(ctx, (canonResolvedRet as { typeIdx: number }).typeIdx);
+          return info ? { vecTypeIdx: (canonResolvedRet as { typeIdx: number }).typeIdx, ...info } : undefined;
+        })()
+      : undefined;
+
   if (method === "keys") {
-    // Build a string[] array from the field names
-    // Each field name is already registered as a string literal thunk
-    const elemKind = "externref";
-    const vecTypeIdx = getOrRegisterVecType(ctx, elemKind);
-    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    // Build a string[] array from the field names.
+    // (#3229) Use the CANONICAL string[] vec type (so an inline `.length`
+    // matches) and coerce each field-name string to its element type; fall back
+    // to the legacy vec-of-externref when the return type is unresolvable. In
+    // host mode the canonical element IS externref, so this is byte-identical to
+    // the previous behaviour; only standalone (native-string element) changes.
+    const vecTypeIdx = canonicalVec ? canonicalVec.vecTypeIdx : getOrRegisterVecType(ctx, "externref");
+    const arrTypeIdx = canonicalVec ? canonicalVec.arrTypeIdx : getArrTypeIdxFromVec(ctx, vecTypeIdx);
     if (arrTypeIdx < 0) {
       reportError(ctx, expr, `Object.keys(): cannot resolve array type for string[]`);
       return null;
     }
+    const elemTarget: ValType = canonicalVec ? canonicalVec.elemType : { kind: "externref" };
 
-    // Push each enumerable field name string onto the stack
+    // Push each enumerable field name string onto the stack, coerced to the
+    // vec's element type. `compileStringLiteral` materialises a native string in
+    // nativeStrings mode and an externref string constant otherwise, and handles
+    // late registration when the name was not collected in the first pass (an
+    // unregistered name pushed nothing → array.new_fixed underflow, #786).
     for (const entry of enumUserFields) {
-      if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
-        compileNativeStringLiteral(ctx, fctx, entry.field.name);
-        // Object.keys returns externref strings, convert from native
-        fctx.body.push({ op: "extern.convert_any" });
-      } else {
-        // compileStringLiteral handles late registration when the field name
-        // was not collected in the first pass (e.g. dynamically-added own
-        // properties). Without it, an unregistered name pushed nothing and
-        // array.new_fixed below underflowed the stack (#786).
-        compileStringLiteral(ctx, fctx, entry.field.name, expr);
-      }
+      const pushed = compileStringLiteral(ctx, fctx, entry.field.name, expr) ?? { kind: "externref" };
+      coerceType(ctx, fctx, pushed, elemTarget);
     }
 
     // Create the backing array with array.new_fixed
@@ -4236,10 +4254,9 @@ export function compileObjectKeysOrValues(
     fctx.body.push({ op: "local.set", index: objLocal });
     emitObjectArgNullGuard(ctx, fctx, objLocal);
 
-    // Resolve the return type from the TS signature to get proper tuple/vec types
-    const sig = ctx.checker.getResolvedSignature(expr);
-    const retType = sig ? ctx.checker.getReturnTypeOfSignature(sig) : undefined;
-    const resolvedRet = retType ? resolveWasmType(ctx, retType) : undefined;
+    // (#3229) Reuse the hoisted return-type resolution (shared with keys/values)
+    // to get the proper tuple/vec types — keeps the checker query count flat.
+    const resolvedRet = canonResolvedRet;
 
     // The return type should be ref_null to a vec struct (Array<[string, T]>)
     // Extract the vec type index and from it the array type index and entry tuple type
@@ -4351,39 +4368,31 @@ export function compileObjectKeysOrValues(
   fctx.body.push({ op: "local.set", index: objLocal });
   emitObjectArgNullGuard(ctx, fctx, objLocal);
 
-  // Always use externref elements for Object.values() since the TS return type is any[]
-  const elemKind = "externref";
-  const vecTypeIdx = getOrRegisterVecType(ctx, elemKind);
-  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  // (#3229) Use the CANONICAL values[] vec type (so an inline `.length` matches)
+  // and coerce each field value to its element type, instead of always boxing to
+  // externref and returning a vec-of-externref that the inline `.length`
+  // `ref.test` could not match (→ 0). For a homogeneous `number[]` the canonical
+  // element is f64 → the field value is stored unboxed; for a heterogeneous
+  // `(string|number)[]` it is externref → `coerceType` boxes exactly as before.
+  // Falls back to the legacy vec-of-externref when the return type is
+  // unresolvable.
+  const vecTypeIdx = canonicalVec ? canonicalVec.vecTypeIdx : getOrRegisterVecType(ctx, "externref");
+  const arrTypeIdx = canonicalVec ? canonicalVec.arrTypeIdx : getArrTypeIdxFromVec(ctx, vecTypeIdx);
   if (arrTypeIdx < 0) {
     reportError(ctx, expr, `Object.values(): cannot resolve array type for values[]`);
     return null;
   }
+  const elemTarget: ValType = canonicalVec ? canonicalVec.elemType : { kind: "externref" };
 
-  // Ensure union boxing imports are registered (needed for boxing primitives)
+  // Ensure union boxing imports are registered (needed when the element target
+  // is externref and a primitive field must be boxed by coerceType).
   addUnionImports(ctx);
 
-  // Push each enumerable field value onto the stack, boxing primitives to externref
+  // Push each enumerable field value onto the stack, coerced to the vec element.
   for (const entry of enumUserFields) {
     fctx.body.push({ op: "local.get", index: objLocal });
     fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: entry.fieldIdx });
-    // Box primitive values to externref
-    if (entry.field.type.kind === "f64") {
-      const boxIdx = ctx.funcMap.get("__box_number");
-      if (boxIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: boxIdx });
-      }
-    } else if (entry.field.type.kind === "i32") {
-      fctx.body.push({ op: "f64.convert_i32_s" });
-      const boxIdx = ctx.funcMap.get("__box_number");
-      if (boxIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx: boxIdx });
-      }
-    } else if (entry.field.type.kind === "ref" || entry.field.type.kind === "ref_null") {
-      // Convert GC ref types (nested structs, etc.) to externref
-      fctx.body.push({ op: "extern.convert_any" });
-    }
-    // externref fields (strings, etc.) don't need boxing
+    coerceType(ctx, fctx, entry.field.type, elemTarget);
   }
 
   // Create the backing array with array.new_fixed

--- a/tests/issue-3229.test.ts
+++ b/tests/issue-3229.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #3229 — `Object.keys/values/entries(closedStruct).length` read INLINE on the
+// call expression returned 0 instead of the field count. The static struct
+// fast-path (`compileObjectKeysOrValues`) built and returned a vec-of-externref,
+// but an inline `.length` dispatches on the CANONICAL `string[]`/`T[]` vec type
+// (vec-of-string / vec-of-f64 from `resolveWasmType(returnType)`); the
+// `ref.test` against that type failed on the vec-of-externref, so `.length`
+// fell to the `else` arm → 0. (Assigning to a typed variable first worked
+// because the store COERCED the vec to the canonical layout.) The fix builds the
+// fast-path vec with the canonical arr/element types, coercing each element.
+// Mode-agnostic — reproduced in host/gc AND standalone.
+async function run(source: string, opts: Record<string, unknown> = {}): Promise<unknown> {
+  const result = await compile(source, opts);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as unknown as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test!();
+}
+
+const P = `type P = { a: number; b: number; c: number };`;
+
+for (const [label, opts] of [
+  ["host/gc", {}],
+  ["standalone", { target: "standalone" }],
+] as const) {
+  describe(`#3229 Object.keys/values/entries inline .length (${label})`, () => {
+    it("Object.keys(typedLocal).length inline === field count", async () => {
+      expect(
+        await run(
+          `${P}
+          export function test(): number { const o: P = { a: 1, b: 2, c: 3 }; return Object.keys(o).length; }`,
+          opts,
+        ),
+      ).toBe(3);
+    });
+
+    it("Object.values(typedLocal).length inline === field count", async () => {
+      expect(
+        await run(
+          `${P}
+          export function test(): number { const o: P = { a: 1, b: 2, c: 3 }; return Object.values(o).length; }`,
+          opts,
+        ),
+      ).toBe(3);
+    });
+
+    it("Object.entries(typedLocal).length inline === field count", async () => {
+      expect(
+        await run(
+          `${P}
+          export function test(): number { const o: P = { a: 1, b: 2, c: 3 }; return Object.entries(o).length; }`,
+          opts,
+        ),
+      ).toBe(3);
+    });
+
+    it("keys content survives the canonical-vec build", async () => {
+      expect(
+        await run(
+          `type Q = { abc: number; de: number };
+          export function test(): number { const o: Q = { abc: 1, de: 2 }; const k = Object.keys(o); return k[0].length + k[1].length; }`,
+          opts,
+        ),
+      ).toBe(5);
+    });
+
+    it("values content survives (unboxed number[] element)", async () => {
+      expect(
+        await run(
+          `${P}
+          export function test(): number { const o: P = { a: 10, b: 20, c: 3 }; const v = Object.values(o); return v[0] + v[1] + v[2]; }`,
+          opts,
+        ),
+      ).toBe(33);
+    });
+
+    it("values inline index reads the right slot", async () => {
+      expect(
+        await run(
+          `type Q = { a: number; b: number };
+          export function test(): number { const o: Q = { a: 7, b: 9 }; return Object.values(o)[1]; }`,
+          opts,
+        ),
+      ).toBe(9);
+    });
+
+    it("keys.length drives a for-loop (inline in the condition)", async () => {
+      expect(
+        await run(
+          `type Q = { x: number; yy: number; zzz: number };
+          export function test(): number { const o: Q = { x: 1, yy: 2, zzz: 3 }; const k = Object.keys(o); let s = 0; for (let i = 0; i < k.length; i++) s += k[i].length; return s; }`,
+          opts,
+        ),
+      ).toBe(6);
+    });
+
+    it("heterogeneous values (string|number) still box to an externref vec", async () => {
+      expect(
+        await run(
+          `type Q = { a: number; s: string };
+          export function test(): number { const o: Q = { a: 5, s: "hi" }; return Object.values(o).length; }`,
+          opts,
+        ),
+      ).toBe(2);
+    });
+
+    it("entries content survives", async () => {
+      expect(
+        await run(
+          `type Q = { a: number; b: number };
+          export function test(): number { const o: Q = { a: 4, b: 6 }; const e = Object.entries(o); return (e[0][1] as number) + (e[1][1] as number); }`,
+          opts,
+        ),
+      ).toBe(10);
+    });
+
+    it("keys via an intermediate variable still works (regression guard)", async () => {
+      expect(
+        await run(
+          `${P}
+          export function test(): number { const o: P = { a: 1, b: 2, c: 3 }; const k = Object.keys(o); return k.length; }`,
+          opts,
+        ),
+      ).toBe(3);
+    });
+  });
+}


### PR DESCRIPTION
## #3229 — `Object.keys/values/entries(closedStruct).length` inline returned 0

```ts
type P = { a: number; b: number; c: number };
export function f(): number {
  const o: P = { a: 1, b: 2, c: 3 };
  return Object.keys(o).length; // was 0 — now 3
}
```

Mode-agnostic (host/gc AND standalone). Assigning to a typed variable first
worked; only the **inline** read on the call expression was wrong.

### Root cause

The static struct fast-path (`compileObjectKeysOrValues`) built a
vec-of-**externref** and returned its type index, but an inline `.length`
dispatches on the CANONICAL vec type (`resolveWasmType(returnType)` →
vec-of-string / vec-of-f64). `ref.test` against the canonical type failed on the
vec-of-externref, so `.length` took the `else` arm → `0`. The variable case
worked because the `const k: string[] = …` store COERCED the vec to the
canonical layout.

### Fix

Build the fast-path vec with the canonical arr/element types, coercing each
element (mirrors what the `entries` arm already did):

- Hoisted the `entries` arm's `getResolvedSignature`/`getReturnTypeOfSignature`
  resolution to the top of `compileObjectKeysOrValues`; derive the canonical vec
  (`getVecInfo`) once and reuse it across all three arms — **net-zero `ctx.checker`
  growth (oracle-ratchet clean)**.
- `keys`: return the canonical `string[]` vec; `coerceType` each field-name to the
  element type (host element IS externref → **byte-identical**; standalone
  native-string element → fixed).
- `values`: return the canonical values vec; `coerceType` each field value to the
  element type — homogeneous `number[]` stored f64 **unboxed** (removed the manual
  `__box_number` branches), heterogeneous `(string|number)[]` boxed to externref
  exactly as before.
- Falls back to the legacy vec-of-externref when the return type is unresolvable.

Grows the `object-ops.ts` subsystem module +9 LOC (net code is a simplification);
granted via `loc-budget-allow` in the issue file (#3102).

### Tests

`tests/issue-3229.test.ts` — 20/20 (10 host/gc + 10 standalone): inline `.length`
for keys/values/entries; content correctness; inline index; `keys.length` in a
for-loop; heterogeneous `(string|number)[]` boxing; intermediate-variable guard.

No regressions in `object-keys-values-entries`, `issue-786`,
`issue-786-object-keys-dynamic`, `issue-3222-standalone-closed-struct-enum`.
`tsc --noEmit` clean; prettier clean; oracle-ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)