### PR TITLE
refactor(#3358): relocate TypedArray.set bounds check out of array-methods.ts

### DIFF
--- a/plan/issues/3202-typedarray-set-bigint-oob-traps.md
+++ b/plan/issues/3202-typedarray-set-bigint-oob-traps.md
@@ -13,8 +13,8 @@ goal: crash-free
 sprint: current
 horizon: m
 related: [3189, 3173]
-loc-budget-allow:
-  - src/codegen/array-methods.ts
+# loc-budget-allow retired by #3358: the +LOC this granted was the
+# TypedArray.set bounds check, now relocated to src/codegen/typed-array-set-bounds.ts.
 origin: "The #3189 uncatchable-trap ratchet fired oob 58->62 (+4) on EVERY merge_group, wedging the queue. Re-diagnosed 2026-07-12 (dev-find-wasm): main HEAD is verifiably 58 (baseline promoted from main commit c660e830; `git log c660e830..origin/main` = ONLY doc commits; freshly-fetched promoted baseline reads 58; the 4 named tests are `fail`/'undefined is not a constructor' on both baseline and main HEAD, not oob). So the +4 is SPECULATIVE-MERGE / CI-sharded-only, NOT a main regression — a promote-baseline 'refresh to 62' is impossible (it reflects main = 58; the attempted refresh left it at 58). Unwedged via the ratchet's own designed valve TRAP_RATCHET_TOLERANCE=4 (repo var, PR #2963)."
 ---
 
@@ -31,6 +31,7 @@ so each one poisons every test that shares the pattern — exactly the robustnes
 the crash-free goal + the #3189 ratchet exist to protect.
 
 ### The 4 newly-trapping tests
+
 - `test/built-ins/TypedArray/prototype/set/BigInt/array-arg-offset-tointeger.js`
 - `test/built-ins/TypedArray/prototype/set/BigInt/array-arg-primitive-toobject.js`
 - `test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-offset-tointeger.js`
@@ -45,6 +46,7 @@ BigInt-element typed array.
 **Prior suspects #3162 / #3183 / #3190 / #2947 are RULED OUT.** The +4 does not
 exist on main (main HEAD is 58 — see `origin` above, three-way verified), so no
 merged PR introduced it:
+
 - #2947 — disproven by dev-number-resid's revert-and-diff A/B (0 per-test change).
 - #2954/#3190 — its `$__vec_base` write fill is bounds-GUARDED ("OOB/negative
   store → silent no-op, no trap"), so it introduces no oob (diff read directly).
@@ -59,6 +61,7 @@ tests whose constructor is `undefined` (BigInt typed arrays unsupported) on main
 — they score `fail`/"undefined is not a constructor", not `oob`.
 
 **Two hypotheses to investigate:**
+
 1. **CI-sharded nondeterminism** — a shard-dependent / load-dependent
    classification flips these 4 to `oob` intermittently in the sharded merged
    run (most likely given they're a stable `fail` on main + baseline).
@@ -90,7 +93,7 @@ guarded-bounds pattern used elsewhere in the standalone array path.
 3. If a real speculative trap: fix the offending queued PR's `set` offset/length
    bounds to emit a **catchable** RangeError, not an unguarded `array.set` oob.
 4. **Tighten the valve back:** `gh variable set TRAP_RATCHET_TOLERANCE --body 0
-   -R loopdive/js2wasm` (no PR needed — it's a repo variable, PR #2963) once the
+-R loopdive/js2wasm` (no PR needed — it's a repo variable, PR #2963) once the
    +4 is resolved, restoring the strict 0-tolerance ratchet.
 5. Zero net test262 regressions; no NEW trap category or growth beyond the
    current +4 flaky window while the valve is at 4.
@@ -135,6 +138,7 @@ This is **#3335 Part 1** (turn the six `TypedArray/prototype/set/BigInt/*` oob
 regressions back into catchable JS errors → the #3189 oob-ratchet should drop
 back toward its ≤45 floor). **Out of scope / follow-ups (left for #3335 Part 2 +
 this issue's criterion 4):**
+
 - #3335 Part 2 — make the baseline-refresh **refuse/flag an oob-trap-count
   INCREASE** so a main-side trap regression cannot self-legalize (a CI-guard
   task, separate from this codegen fix).

--- a/plan/issues/3358-typedarray-set-bounds-relocation.md
+++ b/plan/issues/3358-typedarray-set-bounds-relocation.md
@@ -1,8 +1,10 @@
 ---
 id: 3358
 title: "codegen: relocate TypedArray.prototype.set bounds check out of array-methods.ts (validated design, #3202 took the allowance route instead)"
-status: ready
-sprint: Backlog
+status: done
+assignee: dev-refactor
+completed: 2026-07-17
+sprint: current
 created: 2026-07-17
 priority: low
 horizon: s
@@ -24,7 +26,7 @@ related: [3202, 3102, 3131]
 and the LOC-regrowth ratchet, #3102/#3131). PR #3202 (`TypedArray.prototype.set`
 OOB throws a catchable RangeError instead of an uncatchable Wasm trap) needed to
 add ~29 net LOC of bounds-check logic to `compileTypedArraySet` in that file,
-which trips the ratchet: *any* growth of a file already over the 1,500-LOC
+which trips the ratchet: _any_ growth of a file already over the 1,500-LOC
 threshold fails `pnpm run check:loc-budget` unless the change-set grants itself
 a `loc-budget-allow:` frontmatter escape hatch (the gate's own message text:
 "Add code to the subsystem module, not the barrel/driver" — the allowance is
@@ -92,11 +94,11 @@ behavior as the allowance version, since this is a pure code-motion refactor
 2. Confirm `git log origin/main --grep="#3202"` shows the allowance-route
    fix already merged — this issue is a **pure follow-up refactor** on top of
    that landed state, not a re-implementation of the bounds check itself.
-2. Remove the `loc-budget-allow: [src/codegen/array-methods.ts]` grant from
+3. Remove the `loc-budget-allow: [src/codegen/array-methods.ts]` grant from
    #3202's issue file frontmatter once array-methods.ts net-shrinks back to
    (or below) its pre-#3202 size — the LOC-regrowth ratchet banks shrinkage
    automatically (#3102/#3131), so this closes the loop the allowance opened.
-3. Verify `pnpm run check:loc-budget`, typecheck, lint, and
+4. Verify `pnpm run check:loc-budget`, typecheck, lint, and
    `tests/issue-3202.test.ts` all stay green.
 
 ## Why this is `Backlog`/`low`/`s`, not current-sprint
@@ -105,3 +107,20 @@ Purely a code-health nit — no user-visible behavior changes, no test can
 distinguish before/after, and #3202's own functional fix is already merged
 and green via the sanctioned allowance path. Cheap to pick up opportunistically
 whenever `array-methods.ts` is next being touched anyway.
+
+## Resolution (2026-07-17)
+
+Shipped. The bounds-check emission was extracted from `compileTypedArraySet`
+(`src/codegen/array-methods.ts`) into a new single-purpose module
+`src/codegen/typed-array-set-bounds.ts` exporting
+`emitTypedArraySetBoundsCheck(ctx, fctx, offsetTmp, srcLen, dstLen)`.
+`compileTypedArraySet` now emits the check via one call site. The three operands
+(`offsetTmp`/`srcLen`/`dstLen`) are the pre-existing locals, so the emitted
+instruction sequence is unchanged.
+
+- `array-methods.ts`: 8234 → 8216 LOC (−18); `check:loc-budget` OK.
+- The `loc-budget-allow: [src/codegen/array-methods.ts]` grant in #3202's
+  frontmatter is retired (its +LOC was exactly this bounds check).
+- Proof: `scripts/prove-emit-identity.mjs check` → IDENTICAL across all 56
+  (file,target) emits; `tsc --noEmit` clean; `tests/issue-3202.test.ts` 8/8
+  pass unmodified (pure code motion, byte-identical runtime behavior).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -23,6 +23,7 @@ import {
 } from "./index.js";
 import { addStringConstantGlobal, localGlobalIdx } from "./registry/imports.js";
 import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./js-errors.js";
+import { emitTypedArraySetBoundsCheck } from "./typed-array-set-bounds.js";
 import { emitToBoolean } from "./coercion-engine.js";
 import { compileStringLiteral, elemGetOp, unpackedElemType, valTypesMatch } from "./shared.js";
 import {
@@ -7320,30 +7321,11 @@ function compileTypedArraySet(
   }
   fctx.body.push({ op: "local.set", index: offsetTmp });
 
-  // Spec §23.2.3.24 (%TypedArray%.prototype.set): the bounds check is an
-  // observable RangeError, NOT an unguarded copy that traps. Throw a *catchable*
-  // RangeError when `offset < 0` or `offset + srcLength > targetLength`; the raw
-  // `array.copy` / element-wise store below would otherwise `oob`-trap (an
-  // uncatchable Wasm abort that escapes try/catch and poisons the whole test
-  // file — #3202 / #3335 Part 1). srcLen+offset is computed in i32; test-realistic
-  // magnitudes never overflow, and a negative offset is caught by the `< 0` arm.
-  fctx.body.push(
-    // predicate: offset < 0  ||  offset + srcLen > dstLen
-    { op: "local.get", index: offsetTmp },
-    { op: "i32.const", value: 0 },
-    { op: "i32.lt_s" },
-    { op: "local.get", index: offsetTmp },
-    { op: "local.get", index: srcLen },
-    { op: "i32.add" },
-    { op: "local.get", index: dstLen },
-    { op: "i32.gt_s" },
-    { op: "i32.or" },
-    {
-      op: "if",
-      blockType: { kind: "empty" },
-      then: buildThrowJsErrorInstrs(ctx, "RangeError", "offset is out of bounds", { flush: fctx }),
-    },
-  );
+  // Spec §23.2.3.24 (%TypedArray%.prototype.set): OOB throws a catchable
+  // RangeError, not an uncatchable Wasm trap (#3202 / #3335 Part 1). Emitted by
+  // the relocated single-purpose module (#3358) — byte-identical to the former
+  // inline block.
+  emitTypedArraySetBoundsCheck(ctx, fctx, offsetTmp, srcLen, dstLen);
 
   if (srcArrTypeIdx === arrTypeIdx) {
     // Same backing array type — bulk array.copy dstData[offset..] = srcData[0..srcLen].

--- a/src/codegen/typed-array-set-bounds.ts
+++ b/src/codegen/typed-array-set-bounds.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3358 — `%TypedArray%.prototype.set` bounds check, relocated out of the
+ * `array-methods.ts` god-file (8k+ LOC, over the LOC-budget threshold — see
+ * #3102/#3131). The bounds-check emission was added to `compileTypedArraySet`
+ * by #3202 (OOB must throw a *catchable* RangeError, not an uncatchable Wasm
+ * `oob` trap that escapes try/catch), which landed via a `loc-budget-allow`
+ * escape hatch. This is the follow-up that moves those instructions into a
+ * small single-purpose module so array-methods.ts shrinks back and the
+ * allowance can be retired. Pure code motion — byte-identical emit.
+ */
+import type { Instr } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
+
+/**
+ * Emit the `%TypedArray%.prototype.set(src[, offset])` bounds check.
+ *
+ * Spec §23.2.3.24: the write must throw an observable, *catchable* `RangeError`
+ * when `offset < 0` or `offset + srcLength > targetLength`, rather than letting
+ * the subsequent `array.copy` / element-wise store `oob`-trap (an uncatchable
+ * Wasm abort that escapes try/catch and poisons the whole test file —
+ * #3202 / #3335 Part 1).
+ *
+ * The predicate is computed in i32: `offset + srcLen` for test-realistic
+ * magnitudes never overflows, and a negative offset is caught by the `< 0` arm.
+ * All three operands are pre-computed locals owned by `compileTypedArraySet`;
+ * this helper only reads them, so the emitted instruction sequence is identical
+ * to the inline version it replaced.
+ *
+ * @param offsetTmp  i32 local holding the (defaulted) destination offset
+ * @param srcLen     i32 local holding the source length
+ * @param dstLen     i32 local holding the destination (target) length
+ */
+export function emitTypedArraySetBoundsCheck(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  offsetTmp: number,
+  srcLen: number,
+  dstLen: number,
+): void {
+  fctx.body.push(
+    // predicate: offset < 0  ||  offset + srcLen > dstLen
+    { op: "local.get", index: offsetTmp },
+    { op: "i32.const", value: 0 },
+    { op: "i32.lt_s" },
+    { op: "local.get", index: offsetTmp },
+    { op: "local.get", index: srcLen },
+    { op: "i32.add" },
+    { op: "local.get", index: dstLen },
+    { op: "i32.gt_s" },
+    { op: "i32.or" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: buildThrowJsErrorInstrs(ctx, "RangeError", "offset is out of bounds", { flush: fctx }),
+    } as Instr,
+  );
+}


### PR DESCRIPTION
## Problem (#3358)

`src/codegen/array-methods.ts` is an over-threshold god-file (8k+ LOC). #3202
added the `%TypedArray%.prototype.set` OOB bounds check (throw a *catchable*
`RangeError` instead of an uncatchable Wasm `oob` trap) directly into
`compileTypedArraySet` there, which had to land via a `loc-budget-allow` escape
hatch — permanently booking that +LOC onto the god-file.

## Change

Extract the bounds-check emission into a new single-purpose module
`src/codegen/typed-array-set-bounds.ts` (`emitTypedArraySetBoundsCheck`),
called from `compileTypedArraySet` at one site. The three operands
(`offsetTmp`/`srcLen`/`dstLen`) are the pre-existing locals, so the emitted
instruction sequence is unchanged.

- `array-methods.ts`: **8234 → 8216 LOC (−18)**; `check:loc-budget` reports OK.
- Retire the now-obsolete `loc-budget-allow: [src/codegen/array-methods.ts]`
  grant in #3202's frontmatter — its +LOC was exactly this bounds check. The
  gate reads allowances per-PR from the change-set's own issue files (not a
  global registry), so this is dead historical cleanup with no gate effect.

## Safety / proof

Pure code motion — no emission-logic change:

- `scripts/prove-emit-identity.mjs check` → **IDENTICAL** across all 56
  (file,target) emits (baseline captured on clean `origin/main`)
- `npx tsc --noEmit` clean
- `prettier --check` clean on changed files
- `tests/issue-3202.test.ts` **8/8 pass unmodified** (no test can distinguish
  before/after — the difference is file-health, not behavior)

Implements the validated design captured in #3358 (re-derived against current
`origin/main` since #3202 has merged).