### PR TITLE
fix(#2970): import.meta is a distinct per-module object with stable identity

### DIFF
--- a/plan/issues/2970-import-meta-per-module-identity.md
+++ b/plan/issues/2970-import-meta-per-module-identity.md
@@ -1,9 +1,11 @@
 ---
 id: 2970
 title: "codegen: import.meta is not a distinct per-module object (identity shared/absent across modules)"
-status: ready
+status: done
+assignee: ttraenkler/dev-perf
+completed: 2026-07-17
 priority: medium
-sprint: Backlog
+sprint: current
 created: 2026-07-02
 feasibility: medium
 task_type: bug
@@ -11,6 +13,9 @@ area: codegen
 language_feature: module-code
 goal: spec-completeness
 related: [2932]
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/expressions.ts
 ---
 
 # #2970 — `import.meta` per-module object identity
@@ -47,3 +52,42 @@ compiled module unit), not a shared or absent value.
 
 - `distinct-for-each-module.js` passes via the test262 runner.
 - Identity is stable within a module and distinct across modules.
+
+## Resolution (2026-07-17)
+
+Previously a bare `import.meta` value read compiled to a shared
+`"[object Object]"` string constant (`src/codegen/expressions.ts`), so every
+`import.meta` in every module was the *same* value — `import.meta !== other`
+was always `false` and the distinctness assertions failed.
+
+New module `src/codegen/import-meta.ts` (`ensureImportMetaObject`):
+
+- registers ONE shared zero-field `$ImportMeta` struct type (`ImportMeta`),
+- creates a DISTINCT immutable global instance per source file
+  (`struct.new $ImportMeta`), keyed by `SourceFile.fileName`.
+
+The bare `import.meta` value handler now emits `global.get` of the current
+file's singleton (`expr.getSourceFile().fileName`), typed `(ref $ImportMeta)`.
+Because multi-file compiles land in a single Wasm module, "per module record"
+== "per source file"; each `struct.new` is a fresh instance, so `ref.eq`
+identity gives:
+
+- stable within a module (`fixture_meta === getMeta()` — the function's
+  `import.meta` node lives in the fixture file → fixture's global),
+- distinct across modules (`import.meta !== fixture_meta`).
+
+`import.meta.<prop>` reads (`.url`, unknown props) are intercepted **upstream**
+in `trySuperAndImportMetaRead` (property-access-dispatch), so the object needs
+no concrete fields — only reference identity. `import.meta + ""` still yields
+`"[object Object]"` (generic struct ToString), and `typeof import.meta` is
+still `"object"` (handled by AST in typeof-delete). No raw checker queries
+(uses `expr.getSourceFile()`) — oracle-ratchet +0.
+
+## Test Results
+
+`tests/issue-2970.test.ts` — 7 cases green: the `distinct-for-each-module`
+shape via `compileMulti` (returns 7 = all three identity assertions), same-
+module `===` stability, `typeof === "object"`, `!== null`/`!== undefined`,
+`+ ""` → `"[object Object]"`, unknown-prop `=== undefined`, and a two-importer
+re-export chain (both importers see the SAME fixture object; entry's own
+differs).

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -108,6 +108,8 @@ export function createCodegenContext(
     suppressVecUsageFlag: false, // (#2083) true only during the two prereg calls below
     holeTypeIdx: -1, // (#2001 S1) $Hole struct type; lazily registered
     holeGlobalIdx: undefined, // (#2001 S1) $__hole singleton global
+    importMetaTypeIdx: undefined, // (#2970) shared $ImportMeta struct type
+    importMetaGlobals: new Map(), // (#2970) per-source-file import.meta object globals
     inModuleInitFlagReads: undefined, // (#2800) recorded __in_module_init flag reads
     inModuleInitGlobalIdx: undefined, // (#2800) __in_module_init flag global (set at finalize)
     usesDynRead: false, // (#2580 M0) set by a __dyn_has/__dyn_get call site (M1+); M0 adds none

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1182,6 +1182,16 @@ export interface CodegenContext {
   holeTypeIdx: number;
   holeGlobalIdx: number | undefined;
   /**
+   * (#2970) `import.meta` per-module object identity. One shared zero-field
+   * `$ImportMeta` struct type, plus a DISTINCT immutable global instance per
+   * source file (keyed by `SourceFile.fileName`). Each `import.meta` value read
+   * returns the global of the file it syntactically occurs in, so identity is
+   * stable within a module and distinct across modules (§sec-meta-properties).
+   * Created lazily by `ensureImportMetaObject`.
+   */
+  importMetaTypeIdx: number | undefined;
+  importMetaGlobals: Map<string, number>;
+  /**
    * (#2800) The mutable i32 `__in_module_init` flag — 1 for the duration of
    * `__module_init` (the Wasm `start` section in gc/host mode, which runs INSIDE
    * `WebAssembly.instantiate`, BEFORE the host wires struct getters via

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -46,6 +46,7 @@ import {
   VOID_RESULT,
 } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
+import { ensureImportMetaObject } from "./import-meta.js";
 import { coerceType as coerceTypeImpl, pushDefaultValue } from "./type-coercion.js";
 
 // ── Sub-module imports ─────────────────────────────────────────────────
@@ -1512,7 +1513,13 @@ function compileExpressionInner(
   }
 
   if (ts.isMetaProperty(expr) && expr.keywordToken === ts.SyntaxKind.ImportKeyword && expr.name.text === "meta") {
-    return compileStringLiteral(ctx, fctx, "[object Object]");
+    // (#2970) A bare `import.meta` VALUE read yields a distinct per-module
+    // object with stable reference identity — one immutable `$ImportMeta`
+    // global per source file. (`import.meta.<prop>` reads are intercepted
+    // upstream in trySuperAndImportMetaRead, so this object needs no fields.)
+    const globalIdx = ensureImportMetaObject(ctx, expr.getSourceFile().fileName);
+    fctx.body.push({ op: "global.get", index: globalIdx });
+    return { kind: "ref", typeIdx: ctx.importMetaTypeIdx! };
   }
 
   if (ts.isMetaProperty(expr) && expr.keywordToken === ts.SyntaxKind.ImportKeyword) {

--- a/src/codegen/import-meta.ts
+++ b/src/codegen/import-meta.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2970) `import.meta` per-module object identity.
+ *
+ * `sec-meta-properties-runtime-semantics-evaluation`: `module.[[ImportMeta]]`
+ * is created once per module record and cached; distinct module records have
+ * distinct objects. Multi-file compiles land in a single Wasm module, so the
+ * per-module object is modelled as ONE shared zero-field `$ImportMeta` struct
+ * type with a DISTINCT immutable global instance per source file.
+ *
+ * A bare `import.meta` value read returns the global for the source file the
+ * expression syntactically occurs in — so a function declared in module `A`
+ * that returns `import.meta` yields `A`'s object regardless of caller, giving:
+ *   - stable identity within a module (`fixture_meta === getMeta()`),
+ *   - distinct identity across modules (`import.meta !== fixture_meta`).
+ *
+ * `import.meta.<prop>` reads (e.g. `.url`) are intercepted upstream in
+ * `trySuperAndImportMetaRead` (property-access-dispatch), so this object never
+ * needs concrete fields — only reference identity.
+ */
+import type { StructTypeDef } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+
+/** Register the shared zero-field `$ImportMeta` struct type once. */
+function ensureImportMetaType(ctx: CodegenContext): number {
+  if (ctx.importMetaTypeIdx !== undefined) return ctx.importMetaTypeIdx;
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: "ImportMeta", fields: [] } as StructTypeDef);
+  ctx.importMetaTypeIdx = typeIdx;
+  ctx.structMap.set("ImportMeta", typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, "ImportMeta");
+  ctx.structFields.set("ImportMeta", []);
+  return typeIdx;
+}
+
+/**
+ * Get-or-create the immutable `$ImportMeta` singleton global for `fileName`.
+ * Each source file gets its own `struct.new $ImportMeta` instance, so distinct
+ * files compare unequal by reference identity while a single file is stable.
+ * Returns the global index (`global.get`-able as `(ref $ImportMeta)`).
+ */
+export function ensureImportMetaObject(ctx: CodegenContext, fileName: string): number {
+  const existing = ctx.importMetaGlobals.get(fileName);
+  if (existing !== undefined) return existing;
+
+  const typeIdx = ensureImportMetaType(ctx);
+  const globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  ctx.mod.globals.push({
+    name: `__import_meta_${ctx.importMetaGlobals.size}`,
+    type: { kind: "ref", typeIdx },
+    mutable: false,
+    init: [{ op: "struct.new", typeIdx }],
+  });
+  ctx.importMetaGlobals.set(fileName, globalIdx);
+  return globalIdx;
+}

--- a/tests/issue-2970.test.ts
+++ b/tests/issue-2970.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// (#2970) `import.meta` is a distinct per-module object with stable reference
+// identity: stable within a module, distinct across modules
+// (sec-meta-properties). Mirrors test262
+// language/expressions/import.meta/distinct-for-each-module.js.
+import { describe, expect, it } from "vitest";
+import { compileMulti } from "../src/index.js";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+async function runMulti(files: Record<string, string>, entry: string): Promise<number> {
+  const r: any = await compileMulti(files, entry);
+  if (!r.success) throw new Error("compile failed: " + JSON.stringify(r.errors)?.slice(0, 300));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): number }).test();
+}
+
+async function runBool(src: string): Promise<boolean> {
+  // Wasm returns i32 (1/0) for a boolean export — coerce to a JS boolean.
+  const ex = (await compileAndInstantiate(src)) as { test(): number };
+  return Boolean(ex.test());
+}
+async function runStr(src: string): Promise<string> {
+  const ex = (await compileAndInstantiate(src)) as { test(): string };
+  return ex.test();
+}
+
+describe("#2970 import.meta per-module identity", () => {
+  it("distinct across modules, stable within (distinct-for-each-module)", async () => {
+    const files = {
+      "fixture.ts": `
+        export const meta = import.meta;
+        export function getMeta(): object { return import.meta; }
+      `,
+      "entry.ts": `
+        import { meta as fixtureMeta, getMeta } from './fixture.ts';
+        export function test(): number {
+          // 1: each module gets its own object
+          const a = import.meta !== fixtureMeta ? 1 : 0;
+          // 2: a function returns the import.meta of the module it is declared in
+          const b = import.meta !== getMeta() ? 2 : 0;
+          // 4: stable identity within one module
+          const c = fixtureMeta === getMeta() ? 4 : 0;
+          return a + b + c;
+        }
+      `,
+    };
+    expect(await runMulti(files, "entry.ts")).toBe(7);
+  });
+
+  it("import.meta === import.meta within one module (stable identity)", async () => {
+    expect(await runBool(`export function test(): boolean { const a = import.meta; return a === import.meta; }`)).toBe(
+      true,
+    );
+  });
+
+  it("typeof import.meta is 'object'", async () => {
+    expect(await runBool(`export function test(): boolean { return typeof import.meta === "object"; }`)).toBe(true);
+  });
+
+  it("import.meta is not null / undefined", async () => {
+    expect(await runBool(`export function test(): boolean { return import.meta !== (null as any); }`)).toBe(true);
+    expect(await runBool(`export function test(): boolean { return import.meta !== (undefined as any); }`)).toBe(true);
+  });
+
+  it("string coercion yields [object Object]", async () => {
+    expect(await runStr(`export function test(): string { return import.meta + ""; }`)).toBe("[object Object]");
+  });
+
+  it("unknown import.meta property is undefined", async () => {
+    expect(await runBool(`export function test(): boolean { return (import.meta as any).foo === undefined; }`)).toBe(
+      true,
+    );
+  });
+
+  it("two importers of the same fixture see the SAME fixture meta", async () => {
+    const files = {
+      "fixture.ts": `export const meta = import.meta;`,
+      "mid.ts": `import { meta } from './fixture.ts'; export const midMeta = meta;`,
+      "entry.ts": `
+        import { meta as m1 } from './fixture.ts';
+        import { midMeta as m2 } from './mid.ts';
+        export function test(): number {
+          // both re-exports resolve to the fixture module's single object
+          const same = m1 === m2 ? 1 : 0;
+          // and the entry module's own meta differs from the fixture's
+          const diff = import.meta !== m1 ? 2 : 0;
+          return same + diff;
+        }
+      `,
+    };
+    expect(await runMulti(files, "entry.ts")).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2970 — `import.meta` per-module object identity

Fixes `test/language/expressions/import.meta/distinct-for-each-module.js`.

### Root cause

A bare `import.meta` **value** read compiled to a shared `"[object Object]"` string constant (`src/codegen/expressions.ts`), so every module's `import.meta` was the *same* value — `import.meta !== fixtureMeta` was always `false` and the spec's distinctness assertions failed.

### Fix

New module `src/codegen/import-meta.ts` (`ensureImportMetaObject`):

- registers **one** shared zero-field `$ImportMeta` struct type;
- creates a **distinct immutable global instance per source file** (`struct.new $ImportMeta`, keyed by `SourceFile.fileName`).

The bare `import.meta` handler now emits `global.get` of the current file's singleton, typed `(ref $ImportMeta)`. Because multi-file compiles land in a single Wasm module, "per module record" == "per source file"; each `struct.new` is a fresh instance, so `ref.eq` identity gives:

- **stable within a module** — `fixture_meta === getMeta()` (the function's `import.meta` node lives in the fixture file → fixture's global);
- **distinct across modules** — `import.meta !== fixture_meta`.

`import.meta.<prop>` reads (`.url`, unknown props) are intercepted **upstream** in `trySuperAndImportMetaRead` (property-access-dispatch), so the object needs no concrete fields — only reference identity. `import.meta + ""` still yields `"[object Object]"` (generic struct ToString) and `typeof import.meta` is still `"object"`.

No raw checker queries (uses `expr.getSourceFile()`) — **oracle-ratchet +0**. Compiles in host / standalone / wasi.

### Tests

`tests/issue-2970.test.ts` — 7 cases (via `compileMulti` for the multi-module shapes): the `distinct-for-each-module` shape returns 7 (all three identity assertions), same-module `===` stability, `typeof === "object"`, `!== null`/`!== undefined`, `+ "" → "[object Object]"`, unknown-prop `=== undefined`, and a two-importer re-export chain (both importers see the SAME fixture object; entry's own differs). Existing `tests/equivalence/import-meta.test.ts` (url / typeof / truthy / url-in-var) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)