### PR TITLE
fix(#2649): standalone TypedArray.subarray() view .length reads correctly

### DIFF
--- a/plan/issues/2649-standalone-typedarray-subarray-empty.md
+++ b/plan/issues/2649-standalone-typedarray-subarray-empty.md
@@ -1,8 +1,10 @@
 ---
 id: 2649
 title: "Standalone: TypedArray.prototype.subarray returns an empty view (.length === 0)"
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-17
+assignee: ttraenkler/dev-standalone2
+sprint: current
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -11,7 +13,32 @@ area: typedarray
 language_feature: typedarray-methods
 goal: standalone-mode
 related: [2648, 1907]
+loc-budget-allow:
+  # Intended +19 LOC: read `.length` field 0 directly off a subview receiver's
+  # own type instead of ref.test-ing the mismatched vec type (which returned 0).
+  - src/codegen/property-access-dispatch.ts
 ---
+
+## Resolution (2026-07-17)
+
+Fixed in `src/codegen/property-access-dispatch.ts` (the `.length` dispatch).
+
+Root cause: `ta.subarray(...)` returns a `$__subview_<elem>` struct (a window
+sharing the parent's backing array). Its element data is reachable, but the
+`.length` read is TS-typed as the TypedArray, so the length dispatch
+`ref.test`-ed the receiver against the concrete `$__vec_<elem>` type. A subview
+is a **sibling** subtype of `$__vec_base` (not the vec), so the `ref.test` FAILS
+and the arm fell back to `f64.const 0`.
+
+Fix: when the compiled receiver's OWN static wasm type is a length-prefixed
+`{length, data}` struct (the subview), read field 0 **directly** from that type
+instead of `ref.test`-ing the mismatched vec type. Correct and cheaper.
+
+Guarded by `tests/issue-2649.test.ts` (13 cases): begin/end/no-arg/negative/empty
+windows, packed (Int8/Uint16) and 32-bit/float (Int32/Float64) views, nested
+subarray, combined length+element read, a plain typed-array `.length` regression
+guard, and a gc-host parity case. No host-lane behavior change (host `subarray`
+uses copy/slice semantics — `.length` was never broken there).
 
 # #2649 — Standalone TypedArray.prototype.subarray returns an empty view
 

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -2374,6 +2374,25 @@ export function tryLengthAndNameReads(
           (exprResult.kind === "ref" || exprResult.kind === "ref_null") &&
           (exprResult as any).typeIdx !== vecTypeIdx
         ) {
+          // (#2649) The compiled receiver's OWN static type may itself be a
+          // length-prefixed {length,data} struct that differs from the
+          // TS-resolved vec type — the canonical case is a `$__subview_<elem>`
+          // returned by `ta.subarray(...)`: TS types it as the TypedArray (vec
+          // `vecTypeIdx`), but the runtime value is the subview, whose field 0 IS
+          // the element count. Read it DIRECTLY from the receiver's own type;
+          // the `ref.test vecTypeIdx` fallback below always FAILS on the subview
+          // (sibling subtype of `$__vec_base`, not the vec) and returns 0.
+          const exprTypeIdx = (exprResult as { typeIdx: number }).typeIdx;
+          const exprTypeDef = ctx.mod.types[exprTypeIdx];
+          if (
+            exprTypeDef?.kind === "struct" &&
+            exprTypeDef.fields[0]?.name === "length" &&
+            exprTypeDef.fields[1]?.name === "data"
+          ) {
+            fctx.body.push({ op: "struct.get", typeIdx: exprTypeIdx, fieldIdx: 0 });
+            if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          }
           const lenTmp = allocLocal(fctx, `__len_tmp_${fctx.locals.length}`, { kind: "anyref" });
           fctx.body.push({ op: "local.set", index: lenTmp });
           fctx.body.push({ op: "local.get", index: lenTmp });

--- a/tests/issue-2649.test.ts
+++ b/tests/issue-2649.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.ts";
+
+// #2649 — In `--target standalone`, `TypedArray.prototype.subarray(begin?, end?)`
+// returned a view whose `.length` read as 0 regardless of begin/end (the element
+// data was reachable, so only the length was wrong).
+//
+// Root cause: `subarray` returns a `$__subview_<elem>` struct (a window sharing
+// the parent's backing array). The `.length` read is TS-typed as the TypedArray,
+// so the length dispatch `ref.test`-ed the receiver against the concrete
+// `$__vec_<elem>` type — which the subview (a sibling subtype of `$__vec_base`,
+// not the vec) FAILS — and fell back to `f64.const 0`. Fixed in
+// property-access-dispatch.ts: when the compiled receiver's own static type is a
+// length-prefixed {length,data} struct (the subview), read field 0 directly from
+// that type instead of ref.test-ing the mismatched vec type.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("; ")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function runHost(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("; ")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+// [label, source, expected]
+const cases: [string, string, number][] = [
+  [
+    "subarray(begin).length",
+    `export function test(): number { const a = new Int8Array([10,11,12,13]); return a.subarray(1).length; }`,
+    3,
+  ],
+  [
+    "subarray(begin,end).length",
+    `export function test(): number { const a = new Int8Array([10,11,12,13]); return a.subarray(0,2).length; }`,
+    2,
+  ],
+  [
+    "subarray() full-range length",
+    `export function test(): number { const a = new Int8Array([10,11,12,13]); return a.subarray().length; }`,
+    4,
+  ],
+  [
+    "negative begin clamps to length",
+    `export function test(): number { const a = new Int8Array([10,11,12,13]); return a.subarray(-2).length; }`,
+    2,
+  ],
+  [
+    "negative end clamps to length",
+    `export function test(): number { const a = new Int8Array([10,11,12,13]); return a.subarray(1,-1).length; }`,
+    2,
+  ],
+  [
+    "empty window subarray(2,2).length",
+    `export function test(): number { const a = new Int8Array([1,2,3,4]); return a.subarray(2,2).length; }`,
+    0,
+  ],
+  [
+    "Uint16Array subarray length",
+    `export function test(): number { const a = new Uint16Array([1,2,3,4,5]); return a.subarray(1).length; }`,
+    4,
+  ],
+  [
+    "Int32Array subarray length",
+    `export function test(): number { const a = new Int32Array([1,2,3,4]); return a.subarray(0,3).length; }`,
+    3,
+  ],
+  [
+    "Float64Array subarray length",
+    `export function test(): number { const a = new Float64Array([1,2,3,4]); return a.subarray(2).length; }`,
+    2,
+  ],
+  [
+    "nested subarray length",
+    `export function test(): number { const a = new Int8Array([1,2,3,4,5,6]); return a.subarray(1).subarray(1).length; }`,
+    4,
+  ],
+  [
+    "length AND element value both correct (len*100 + s[0])",
+    `export function test(): number { const a = new Int8Array([10,11,12,13]); const s = a.subarray(1); return s.length * 100 + s[0]; }`,
+    311,
+  ],
+  [
+    "plain typed-array .length regression guard",
+    `export function test(): number { const a = new Int8Array([1,2,3]); return a.length; }`,
+    3,
+  ],
+];
+
+describe("#2649 TypedArray.prototype.subarray view length (standalone)", () => {
+  describe("standalone (no JS host)", () => {
+    for (const [label, src, expected] of cases) {
+      it(label, async () => {
+        expect(await runStandalone(src)).toBe(expected);
+      });
+    }
+  });
+
+  // Host mode uses copy (slice) semantics for subarray, so length was never
+  // broken there — parity guard on the headline case.
+  describe("gc (JS host) parity", () => {
+    it("subarray(begin).length", async () => {
+      expect(
+        await runHost(
+          `export function test(): number { const a = new Int8Array([10,11,12,13]); return a.subarray(1).length; }`,
+        ),
+      ).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2649. In `--target standalone`, `ta.subarray(begin?, end?)` returned a view whose `.length` read as **0** regardless of `begin`/`end` (element data was reachable — only the length was wrong).

```ts
const a = new Int8Array([10,11,12,13]);
a.subarray(1).length    // was 0 → now 3
a.subarray(0,2).length  // was 0 → now 2
a.subarray().length     // was 0 → now 4
a.subarray(1)[0]        // 11 (data was always OK)
```

## Root cause

`subarray` returns a `$__subview_<elem>` struct (a window sharing the parent's backing array). The `.length` read is TS-typed as the TypedArray, so the length dispatch `ref.test`-ed the receiver against the concrete `$__vec_<elem>` type. A subview is a **sibling** subtype of `$__vec_base` (not the vec), so the `ref.test` FAILS and the arm fell back to `f64.const 0`.

## Fix

`src/codegen/property-access-dispatch.ts` (`.length` dispatch): when the compiled receiver's OWN static wasm type is a length-prefixed `{length, data}` struct (the subview), read field 0 **directly** from that type instead of `ref.test`-ing the mismatched vec type. Correct and cheaper.

## Tests

- `tests/issue-2649.test.ts` — 13 cases: begin / end / no-arg / negative / empty windows, Int8/Uint16/Int32/Float64 views, nested subarray, combined length+element read, a plain typed-array `.length` regression guard, and a gc-host parity case.
- `loc-budget-allow` for the +19 LOC in property-access-dispatch.ts (granted in the issue file).

No host-lane behavior change (host `subarray` uses copy/slice semantics — `.length` was never broken there).

## Validation

- `npm test -- tests/issue-2649.test.ts` → 13 passed
- `npx tsc --noEmit` → no errors
- `prettier --check` → clean
- `pnpm run check:loc-budget` → OK (+19 granted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)