### PR TITLE
fix(#2649): standalone TypedArray.subarray(...).length direct-chain reads 0

### DIFF
--- a/plan/issues/2649-standalone-typedarray-subarray-empty.md
+++ b/plan/issues/2649-standalone-typedarray-subarray-empty.md
@@ -1,8 +1,10 @@
 ---
 id: 2649
 title: "Standalone: TypedArray.prototype.subarray returns an empty view (.length === 0)"
-status: ready
-sprint: Backlog
+status: done
+assignee: ttraenkler/dev-spec
+completed: 2026-07-17
+sprint: current
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -11,6 +13,11 @@ area: typedarray
 language_feature: typedarray-methods
 goal: standalone-mode
 related: [2648, 1907]
+# Bug fix: a length-bearing-struct direct-read arm in the length member dispatch
+# (subview .length was mis-routed to the vec ref.test fallback → 0). The fix lives
+# in the dispatch file that already owns the .length member lowering.
+loc-budget-allow:
+  - src/codegen/property-access-dispatch.ts
 ---
 
 # #2649 — Standalone TypedArray.prototype.subarray returns an empty view
@@ -54,3 +61,28 @@ surveying for the #2648 fix.
 - New `tests/issue-2649-*`: `subarray(b)`, `subarray(b,e)`, `subarray()`,
   negative begin/end, across packed (Int8/Uint16) and 32-bit (Int32/Float64)
   views × standalone + gc; assert `.length` and element values; gc-mode guard.
+
+## Resolution (2026-07-17)
+
+Root cause was NOT in `compileTypedArraySubarray` — the `$__subview` struct's
+length field is built correctly (`max(clamp(end) − clamp(begin), 0)`). The bug
+was in the **`.length` member read on the DIRECT chain** `a.subarray(1).length`
+(`src/codegen/property-access-dispatch.ts`, the `propName === "length"` block):
+
+- `a.subarray(1)` compiles to a `$__subview_<elem>` struct (field 0 = `length`).
+- `resolveWasmType(Int8Array)` gives the plain `$__vec_<elem>` type.
+- Since compiled-type ≠ TS-derived vec type, the length dispatch `ref.test`ed
+  the subview value against the **vec** type, missed, and fell to the
+  `f64.const 0` else-arm → `.length === 0`.
+- The via-variable form (`const s = a.subarray(1); s.length`) masked it because
+  the local carried the subview type, so `.length` read field 0 directly.
+
+**Fix**: when the compiled receiver is itself a length-bearing struct (field 0
+named `length`, i.e. any `$__vec` / `$__subview` / `$__ta_view`), read `.length`
+field 0 **directly** off the compiled type — exact, no `ref.test` needed.
+
+### Test Results
+`tests/issue-2649-standalone-subarray-length.test.ts` — 10/10 pass: direct-chain
+`subarray(b)` / `subarray(b,e)` / `subarray()`, negative begin, element data
+through the view, Int32 / Float64 views, nested subarray, via-variable regression
+guard, gc-mode guard.

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -2370,6 +2370,28 @@ export function tryLengthAndNameReads(
           fctx.body.push({ op: "local.get", index: lenTmp2 });
           return lenType;
         }
+        // (#2649) The compiled receiver may itself be a length-bearing struct
+        // that is NOT the TS-derived vec type — e.g. `a.subarray(1)` yields a
+        // `$__subview_<elem>` ({length, data, byteOffset}) whose `.length` lives
+        // at field 0, but `resolveWasmType(Int8Array)` gives the plain
+        // `$__vec_<elem>` type. Reading `.length` DIRECTLY off the compiled
+        // subview type is both correct and exact (the static type IS the
+        // subview) — the generic `typeIdx !== vecTypeIdx` guard below would
+        // otherwise `ref.test` the subview against the vec type, fail, and fall
+        // to the `f64.const 0` else-arm (the `a.subarray(1).length === 0` bug).
+        if (
+          exprResult &&
+          (exprResult.kind === "ref" || exprResult.kind === "ref_null") &&
+          (exprResult as any).typeIdx !== vecTypeIdx
+        ) {
+          const compiledTypeIdx = (exprResult as { typeIdx: number }).typeIdx;
+          const compiledDef = ctx.mod.types[compiledTypeIdx];
+          if (compiledDef?.kind === "struct" && compiledDef.fields[0]?.name === "length") {
+            fctx.body.push({ op: "struct.get", typeIdx: compiledTypeIdx, fieldIdx: 0 });
+            if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          }
+        }
         // Guard: the TS type might not match the runtime struct type.
         // If the compiled expression returned a different ref type, use ref.test
         // to verify before struct.get, falling back to 0.

--- a/tests/issue-2649-standalone-subarray-length.test.ts
+++ b/tests/issue-2649-standalone-subarray-length.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #2649 — Standalone `TypedArray.prototype.subarray(...).length` read 0.
+ *
+ * `a.subarray(b, e)` builds a `$__subview_<elem>` struct ({length, data,
+ * byteOffset}) whose length field IS computed correctly. The bug was in the
+ * `.length` MEMBER READ on the DIRECT chain `a.subarray(1).length`: the compiled
+ * receiver type is the subview struct, but `resolveWasmType(Int8Array)` yields
+ * the plain `$__vec_<elem>` type — the length dispatch `ref.test`ed the subview
+ * against the vec type, missed, and returned the `f64.const 0` else-arm. Storing
+ * the result in a typed variable first (`const s = a.subarray(1); s.length`)
+ * masked it (the local carried the subview type). The fix reads `.length` field 0
+ * directly off the compiled length-bearing struct type (property-access-dispatch).
+ */
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {} as WebAssembly.Imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function runGc(source: string): Promise<number> {
+  const r = await compile(source, { fileName: "test.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2649 standalone TypedArray.prototype.subarray().length", () => {
+  it("direct chain a.subarray(begin).length (was 0)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int8Array([10, 11, 12, 13]);
+        return a.subarray(1).length;
+      }`),
+    ).toBe(3);
+  });
+
+  it("direct chain a.subarray(begin, end).length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int8Array([10, 11, 12, 13]);
+        return a.subarray(0, 2).length;
+      }`),
+    ).toBe(2);
+  });
+
+  it("direct chain a.subarray().length (full range)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int8Array([10, 11, 12, 13]);
+        return a.subarray().length;
+      }`),
+    ).toBe(4);
+  });
+
+  it("negative begin clamps against length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int32Array([1, 2, 3, 4, 5]);
+        return a.subarray(-2).length;
+      }`),
+    ).toBe(2);
+  });
+
+  it("element data through the subarray view still reads correctly", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int8Array([10, 11, 12, 13]);
+        return a.subarray(1)[0]!;
+      }`),
+    ).toBe(11);
+  });
+
+  it("32-bit view (Int32Array) direct-chain length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int32Array([100, 200, 300, 400]);
+        return a.subarray(1, 3).length;
+      }`),
+    ).toBe(2);
+  });
+
+  it("Float64Array direct-chain length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Float64Array([1, 2, 3, 4]);
+        return a.subarray(2).length;
+      }`),
+    ).toBe(2);
+  });
+
+  it("nested subarray direct-chain length", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int8Array([1, 2, 3, 4, 5, 6]);
+        return a.subarray(1).subarray(1).length;
+      }`),
+    ).toBe(4);
+  });
+
+  it("via-variable form remains correct (regression guard)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const a = new Int8Array([10, 11, 12, 13]);
+        const s = a.subarray(1);
+        return s.length;
+      }`),
+    ).toBe(3);
+  });
+
+  it("gc-mode subarray length is unaffected", async () => {
+    expect(
+      await runGc(`export function test(): number {
+        const a = new Int8Array([10, 11, 12, 13]);
+        return a.subarray(1).length;
+      }`),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2649 — standalone `a.subarray(...).length` reads 0

In `--target standalone`, `TypedArray.prototype.subarray(begin?, end?).length`
read **0** for the direct chain (`a.subarray(1).length`), even though the element
data through the view was correct.

### Root cause
Not in `compileTypedArraySubarray` — the `$__subview_<elem>` struct's length
field (`max(clamp(end) − clamp(begin), 0)`) is built correctly. The bug was in
the **`.length` member read** (`property-access-dispatch.ts`, `propName === "length"`):

- `a.subarray(1)` compiles to a `$__subview_<elem>` struct (field 0 = `length`).
- `resolveWasmType(Int8Array)` gives the plain `$__vec_<elem>` type.
- compiled-type ≠ TS-derived vec type → the dispatch `ref.test`ed the subview
  value against the **vec** type, missed, and fell to the `f64.const 0` else-arm.
- The via-variable form (`const s = a.subarray(1); s.length`) masked it (the
  local carried the subview type, so `.length` read field 0 directly).

### Fix
When the compiled receiver is itself a length-bearing struct (field 0 named
`length` — any `$__vec` / `$__subview` / `$__ta_view`), read `.length` field 0
**directly** off the compiled type — exact, no `ref.test`.

### Tests
`tests/issue-2649-standalone-subarray-length.test.ts` — **10/10**: direct-chain
`subarray(b)` / `(b,e)` / `()`, negative begin, element data through the view,
Int32 / Float64 views, nested subarray, via-variable regression guard, gc-mode
guard. `tsc` clean; loc-budget allowance granted in the issue file.