### PR TITLE
fix(#2649): standalone TypedArray.subarray().length returns the windowed length, not 0

### DIFF
--- a/plan/issues/2649-standalone-typedarray-subarray-empty.md
+++ b/plan/issues/2649-standalone-typedarray-subarray-empty.md
@@ -1,8 +1,9 @@
 ---
 id: 2649
 title: "Standalone: TypedArray.prototype.subarray returns an empty view (.length === 0)"
-status: in-progress
+status: done
 assignee: dev-refactor
+completed: 2026-07-17
 sprint: current
 priority: medium
 feasibility: medium
@@ -26,12 +27,12 @@ the result returns the right values), so the bug is specifically in the
 
 ### Verified repros (host pass / standalone wrong-value, main `06e1e04d68`)
 
-| call (`a = new Int8Array([10,11,12,13])`) | host | standalone |
-|---|---|---|
-| `a.subarray(1).length` | `3` | **`0`** |
-| `a.subarray(0,2).length` | `2` | **`0`** |
-| `a.subarray().length` | `4` | **`0`** |
-| `a.subarray(1)[0]` | `11` | `11` (data OK) |
+| call (`a = new Int8Array([10,11,12,13])`) | host | standalone     |
+| ----------------------------------------- | ---- | -------------- |
+| `a.subarray(1).length`                    | `3`  | **`0`**        |
+| `a.subarray(0,2).length`                  | `2`  | **`0`**        |
+| `a.subarray().length`                     | `4`  | **`0`**        |
+| `a.subarray(1)[0]`                        | `11` | `11` (data OK) |
 
 So `subarray()` builds the result view but its length field is left at 0.
 
@@ -52,6 +53,28 @@ standalone correctness for direct `ta.subarray(...)` call sites. Surfaced while
 surveying for the #2648 fix.
 
 ## Suggested validation
+
 - New `tests/issue-2649-*`: `subarray(b)`, `subarray(b,e)`, `subarray()`,
   negative begin/end, across packed (Int8/Uint16) and 32-bit (Int32/Float64)
   views × standalone + gc; assert `.length` and element values; gc-mode guard.
+
+## Resolution (2026-07-17)
+
+Root cause was NOT in `compileTypedArraySubarray` (it builds the `$__subview`
+struct with the correct windowed `length` at field 0). The bug was in the
+**`.length` read dispatch** (`src/codegen/property-access-dispatch.ts`): for a
+receiver whose compiled ref type differs from its static TS-derived vec type, it
+`ref.test`ed the value against the static plain-`$__vec` type and fell back to
+`0` on a miss. `a.subarray(1)` is TS-typed `Int8Array` (→ plain `$__vec`) but
+compiles to a `$__subview` struct, so the test always missed → `.length` == 0.
+
+Fix: when the compiled receiver is a known `$__subview` ref type
+(`isSubviewTypeIdx`), read its field-0 length directly — no `ref.test` against
+the mismatched static type. `$__ta_view` is intentionally excluded (its field-0
+can be a resizable-length sentinel, handled by the auto-length arm).
+
+Standalone-only (gc/host `subarray` returns a plain-vec copy whose length
+already read correctly). Coverage: `tests/issue-2649.test.ts` (10 cases —
+begin/begin+end/no-arg, negative begin/end, stored-in-local, nested subarray,
+16-bit element view, element-access regression guard, and a length-driven sum
+loop). tsc + prettier clean; `tests/issue-1664.test.ts` (subarray/set) still 7/7.

--- a/plan/issues/2649-standalone-typedarray-subarray-empty.md
+++ b/plan/issues/2649-standalone-typedarray-subarray-empty.md
@@ -1,8 +1,9 @@
 ---
 id: 2649
 title: "Standalone: TypedArray.prototype.subarray returns an empty view (.length === 0)"
-status: ready
-sprint: Backlog
+status: in-progress
+assignee: dev-refactor
+sprint: current
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -98,6 +98,7 @@ import {
   getArrTypeIdxFromVec,
   getOrRegisterResizableAbType,
   getOrRegisterVecType,
+  isSubviewTypeIdx,
   isTaViewTypeIdx,
   taCtorKindOf,
 } from "./registry/types.js";
@@ -2378,6 +2379,21 @@ export function tryLengthAndNameReads(
           (exprResult.kind === "ref" || exprResult.kind === "ref_null") &&
           (exprResult as any).typeIdx !== vecTypeIdx
         ) {
+          // (#2649) The compiled receiver has a KNOWN concrete ref type that
+          // differs from the static TS-derived vec type. The canonical case:
+          // `a.subarray(1)` is TS-typed `Int8Array` (→ plain `$__vec`) but
+          // compiles to a `$__subview` struct. A `$__subview` carries its
+          // windowed element count at field 0 (`{length, data, byteOffset}`),
+          // so read field 0 off the ACTUAL type directly — a `ref.test` against
+          // the mismatched static vec type below would miss and wrongly yield 0.
+          // (`$__ta_view` is excluded: its field 0 can be a resizable-length
+          // sentinel and is handled by the auto-length local arm above.)
+          const actualIdx = (exprResult as { typeIdx: number }).typeIdx;
+          if (isSubviewTypeIdx(ctx, actualIdx)) {
+            fctx.body.push({ op: "struct.get", typeIdx: actualIdx, fieldIdx: 0 });
+            if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          }
           const lenTmp = allocLocal(fctx, `__len_tmp_${fctx.locals.length}`, { kind: "anyref" });
           fctx.body.push({ op: "local.set", index: lenTmp });
           fctx.body.push({ op: "local.get", index: lenTmp });

--- a/tests/issue-2649.test.ts
+++ b/tests/issue-2649.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2649 — Standalone `TypedArray.prototype.subarray(...).length` returned 0.
+ *
+ * In `--target standalone`/`wasi`, `subarray` builds a `$__subview` struct that
+ * shares the parent's backing array (byteOffset + windowed length). Element
+ * reads worked (they discriminate the `$__subview` type), but the `.length`
+ * read did NOT: the length dispatch used the receiver's STATIC TS type
+ * (`Int8Array` → plain `$__vec`) and `ref.test`ed the value against that plain
+ * vec type. A `$__subview` value fails that test, so the read fell to the `0`
+ * fallback. Fix: when the compiled receiver is a known `$__subview` ref type,
+ * read its field-0 length directly (property-access-dispatch.ts). This is a
+ * standalone-only path — gc/host mode returns a copy (plain vec) whose length
+ * already read correctly.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  expect(WebAssembly.validate(r.binary as unknown as BufferSource)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary as unknown as BufferSource, {});
+  return (instance.exports as Record<string, () => number>).test!();
+}
+
+describe("#2649 standalone TypedArray.prototype.subarray length", () => {
+  it("subarray(begin).length is the windowed length, not 0", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int8Array([10,11,12,13]); return a.subarray(1).length; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("subarray(begin,end).length reflects the window", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int8Array([10,11,12,13]); return a.subarray(0,2).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("subarray().length is the full length", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int8Array([10,11,12,13]); return a.subarray().length; }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("element access through the subview still works (regression guard)", async () => {
+    expect(
+      await runStandalone(`export function test(){ const a=new Int8Array([10,11,12,13]); return a.subarray(1)[0]; }`),
+    ).toBe(11);
+  });
+
+  it("negative begin clamps against length", async () => {
+    expect(
+      await runStandalone(`export function test(){ const a=new Int8Array([1,2,3,4]); return a.subarray(-2).length; }`),
+    ).toBe(2);
+  });
+
+  it("negative end clamps against length", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int8Array([1,2,3,4]); return a.subarray(1,-1).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("length reads correctly off a subview stored in a local", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int32Array([5,6,7,8,9]); const s=a.subarray(2); return s.length; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("nested subarray accumulates offsets and windows the length", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int8Array([0,1,2,3,4,5]); return a.subarray(1).subarray(1).length; }`,
+      ),
+    ).toBe(4);
+  });
+
+  it("works for a 16-bit element view", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Uint16Array([10,20,30,40]); return a.subarray(1,3).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("length drives an element-summing loop over the subview", async () => {
+    expect(
+      await runStandalone(
+        `export function test(){ const a=new Int8Array([10,11,12,13]); const s=a.subarray(1); let t=0; for(let i=0;i<s.length;i++) t+=s[i]; return t; }`,
+      ),
+    ).toBe(36);
+  });
+});


### PR DESCRIPTION
## Problem (#2649)

Under `--target standalone`/`wasi`, `TypedArray.prototype.subarray(...).length`
read as **0** for every form (`subarray(1)`, `subarray(0,2)`, `subarray()`),
even though indexed element access on the same view returned the right values.

## Root cause

Not in `compileTypedArraySubarray` — it correctly builds the `$__subview` struct
(`{length, data, byteOffset}`) with the windowed length at field 0. The bug is in
the **`.length` read dispatch** (`src/codegen/property-access-dispatch.ts`): for a
receiver whose compiled ref type differs from its static TS-derived vec type, it
`ref.test`ed the value against the static **plain `$__vec`** type and fell back to
`0` on a miss. `a.subarray(1)` is TS-typed `Int8Array` (→ plain `$__vec`) but
compiles to a `$__subview`, so the `ref.test` always missed → `.length == 0`.

## Fix

When the compiled receiver is a known `$__subview` ref type (`isSubviewTypeIdx`),
read its field-0 length **directly** — no `ref.test` against the mismatched
static type. `$__ta_view` is intentionally excluded (its field-0 can be a
resizable-length sentinel, handled by the auto-length arm above). Narrowly gated,
so non-subview `.length` paths are untouched.

Standalone-only: gc/host `subarray` returns a plain-vec copy whose length already
read correctly.

## Tests

`tests/issue-2649.test.ts` (10 cases, standalone, empty-import instantiation):
`subarray(b)` / `subarray(b,e)` / `subarray()`, negative begin/end clamping,
subview stored in a local, nested `subarray().subarray()`, a 16-bit element view,
an element-access regression guard, and a `for (i < s.length)` sum loop.

## Validation

- `tests/issue-2649.test.ts` 10/10 pass (before and after merging latest `main`)
- `npx tsc --noEmit` clean; `prettier --check` clean
- `tests/issue-1664.test.ts` (TypedArray set/subarray, no host imports) still 7/7