### PR TITLE
fix(#3377): Object(bigint) boxes to a BigInt-wrapper instead of throwing

### DIFF
--- a/plan/issues/3377-object-bigint-wrapper-regression.md
+++ b/plan/issues/3377-object-bigint-wrapper-regression.md
@@ -1,0 +1,65 @@
+---
+id: 3377
+title: "Object(bigint) throws \"No dependency provided for extern class BigInt\" (regression of #1568)"
+status: done
+assignee: dev-builtins
+completed: 2026-07-17
+created: 2026-07-17
+updated: 2026-07-17
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen, runtime
+language_feature: bigint, object-coercion
+goal: test262-conformance
+related: [1568, 2728]
+# (#3377) The __new_BigInt host handler belongs in runtime.ts alongside every
+# other __new_*/__box_* import (a +6 LOC regression fix in its own module).
+loc-budget-allow:
+  - src/runtime.ts
+---
+# #3377 — `Object(bigint)` regressed: throws instead of boxing to a wrapper
+
+## Problem
+
+`Object(0n)` / `Object(BigInt(x))` throw at runtime with
+`No dependency provided for extern class "BigInt"` instead of returning a
+BigInt-wrapper object (§7.1.18 ToObject, Table 13; `typeof` → `"object"`).
+This regresses #1568, whose test file `tests/issue-1568.test.ts` had 3 failing
+rows on `main`:
+
+```
+typeof Object(0n) === 'object'
+typeof Object(BigInt(42)) === 'object'
+typeof Object(BigInt(0n)) === 'object'
+```
+
+## Root cause
+
+`tryObjectCoercionCall` lowers `Object(bigint)` to `__new_BigInt(i64) -> externref`.
+`import-manifest.ts` had **no dedicated route** for `__new_BigInt`, so it fell
+through the generic `if (name.startsWith("__new_"))` arm to
+`{ type: "extern_class", className: "BigInt", action: "new" }`. The runtime's
+`extern_class` new path then looks up `builtinCtors["BigInt"]` — which does NOT
+list `BigInt` (correctly, since `new BigInt(v)` throws: BigInt is not a
+constructor) — and falls to the "No dependency provided for extern class" throw.
+The dedicated builtin handler the #1568 calls-guards comment assumed existed was
+never wired up.
+
+## Fix
+
+Mirror the #2728 `__new_Symbol` approach:
+
+1. `src/compiler/import-manifest.ts` — route `__new_BigInt` through the dedicated
+   runtime `builtin` handler (like `__new_AggregateError`/`__new_SuppressedError`/
+   `__new_Symbol`) instead of the generic `extern_class` arm.
+2. `src/runtime.ts` — add a `__new_BigInt` builtin handler that boxes via the
+   spec's literal `Object(v)`. JS-BigInt-integration delivers the i64 arg as a JS
+   `bigint` at the boundary, so `Object(v)` produces the wrapper directly.
+
+## Acceptance
+
+- `typeof Object(0n) === "object"`, `typeof Object(BigInt(42)) === "object"`.
+- Bare `typeof 0n === "bigint"` (no over-boxing) — unchanged.
+- `Object(number)`/`Object(string)`/`Object(boolean)` still box — unchanged.
+- `tests/issue-1568.test.ts` (6 tests) all pass; `tests/issue-3377.test.ts` added.

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -220,6 +220,15 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
   // dedicated runtime builtin like AggregateError.
   if (name === "__new_SuppressedError") return { type: "builtin", name };
 
+  // (#3377, regression of #1568) `Object(bigint)` → BigInt-wrapper object.
+  // BigInt is NOT a constructor, so the generic `extern_class` path lowers
+  // `__new_BigInt` to `new BigInt(v)` — which both throws AND finds no `BigInt`
+  // entry in the runtime's `builtinCtors` map, so `Object(0n)` / `Object(BigInt(x))`
+  // failed at runtime with "No dependency provided for extern class BigInt".
+  // Route through the dedicated runtime builtin (mirrors __new_Symbol / the
+  // spec's literal `Object(v)` #1568 intent).
+  if (name === "__new_BigInt") return { type: "builtin", name };
+
   // Unknown constructor imports (__new_ClassName)
   if (name.startsWith("__new_")) {
     return { type: "extern_class", className: name.slice(6), action: "new" };

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -11526,6 +11526,12 @@ assert._isSameValue = isSameValue;
           }
           return 0;
         };
+      // (#3377, regression of #1568) `Object(bigint)` → BigInt-wrapper object
+      // (§7.1.18 ToObject, Table 13; `typeof` → "object"). BigInt is NOT a
+      // constructor, so `new BigInt(v)` throws — box via the spec's literal
+      // `Object(v)`. JS-BigInt-integration delivers the i64 arg as a JS bigint
+      // at the boundary, so `Object(v)` produces the correct wrapper directly.
+      if (name === "__new_BigInt") return (v: bigint): any => Object(v);
       // new AggregateError(errors, message, options?) — spec §20.5.7.1 (#1467).
       // Implements the spec construction sequence so that:
       //   • called without `new` constructs normally (caller dispatches both),

--- a/tests/issue-3377.test.ts
+++ b/tests/issue-3377.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3377 — `Object(bigint)` regressed to throwing "No dependency provided for
+ * extern class BigInt" instead of returning a BigInt-wrapper object
+ * (§7.1.18 ToObject, Table 13; `typeof` → "object"). Regression of #1568.
+ *
+ * Root cause: `__new_BigInt` had no dedicated route in `import-manifest.ts`, so
+ * it fell through to the generic `extern_class` `new BigInt(v)` path — which
+ * finds no `BigInt` in the runtime's `builtinCtors` (correctly: BigInt is not a
+ * constructor) and throws. Fix routes it through a dedicated runtime `builtin`
+ * handler that boxes via the spec's literal `Object(v)` (mirrors #2728's
+ * `__new_Symbol`).
+ *
+ * `tests/issue-1568.test.ts` is the primary coverage; this adds a focused guard
+ * so the regression can't silently return without a dedicated failing row.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const built = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, built as WebAssembly.Imports);
+  if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#3377 — Object(bigint) boxes to a BigInt-wrapper object", () => {
+  it("typeof Object(0n) === 'object' (does not throw)", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(0n) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("typeof Object(BigInt(42)) === 'object'", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(BigInt(42)) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("bare typeof 0n stays 'bigint' (no over-boxing)", async () => {
+    const r = await run(`export function test(): number {
+      const x = 0n;
+      return typeof x === "bigint" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("Object(bigint) wrapper is truthy (ToBoolean — even for 0n)", async () => {
+    const r = await run(`export function test(): number {
+      return Object(0n) ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+
+  it("regression: Object(number) still boxes to object", async () => {
+    const r = await run(`export function test(): number {
+      return typeof Object(42) === "object" ? 1 : 0;
+    }`);
+    expect(r).toBe(1);
+  });
+});


### PR DESCRIPTION
## #3377 — `Object(bigint)` regressed to throwing (regression of #1568)

`Object(0n)` / `Object(BigInt(x))` threw at runtime with `No dependency provided for extern class "BigInt"` instead of returning a BigInt-wrapper object (§7.1.18 ToObject, Table 13; `typeof` → `"object"`). `tests/issue-1568.test.ts` had **3 failing rows on main**.

### Root cause
`tryObjectCoercionCall` lowers `Object(bigint)` to `__new_BigInt(i64) -> externref`. `import-manifest.ts` had **no dedicated route** for `__new_BigInt`, so it fell through the generic `if (name.startsWith("__new_"))` arm to `{ type: "extern_class", className: "BigInt", action: "new" }`. The runtime `extern_class`-new path looks up `builtinCtors["BigInt"]` — absent (correctly: `new BigInt(v)` throws, BigInt is not a constructor) — and falls to the "No dependency provided" throw. The dedicated builtin handler the #1568 calls-guards comment assumed existed was never wired up.

### Fix (mirrors #2728's `__new_Symbol`)
- **`import-manifest.ts`** — route `__new_BigInt` through the dedicated runtime `builtin` handler (like `__new_AggregateError`/`__new_SuppressedError`).
- **`runtime.ts`** — add a `__new_BigInt` handler that boxes via the spec's literal `Object(v)`. JS-BigInt-integration delivers the i64 arg as a JS `bigint` at the boundary, so `Object(v)` produces the wrapper directly.

### Tests
`tests/issue-1568.test.ts` (6, previously 3 failing) all pass; `tests/issue-3377.test.ts` (5) added — typeof-object, no-over-boxing, truthiness, Object(number) regression.

`npx tsc --noEmit` clean · prettier clean · LOC-budget allowance granted (+6, handler in its own module).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)