### PR TITLE
test(#2578): regression guard for standalone dynamic multi-read (already fixed)

### DIFF
--- a/plan/issues/2578-standalone-dynamic-property-multi-read-typing.md
+++ b/plan/issues/2578-standalone-dynamic-property-multi-read-typing.md
@@ -1,8 +1,10 @@
 ---
 id: 2578
 title: "standalone dynamic property multi-read mangles inferred-typed values (writes fine, combined read → 0)"
-status: ready
-sprint: Backlog
+status: done
+assignee: dev-refactor
+completed: 2026-07-17
+sprint: current
 created: 2026-06-21
 priority: medium
 feasibility: medium
@@ -31,14 +33,14 @@ on any open-object dynamic read, so it is filed separately.
 
 ```ts
 // each property reads correctly in isolation:
-Object.create(null, { x: { value: 3 }, y: { value: 4 } }) // o.x === 3 ✓, o.y === 4 ✓
+Object.create(null, { x: { value: 3 }, y: { value: 4 } }); // o.x === 3 ✓, o.y === 4 ✓
 
 // combined read into INFERRED-typed consts → 0 (WRONG, want 7):
 export function test(): number {
   const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
-  const a = (o as any).x;   // inferred (any/number?)
+  const a = (o as any).x; // inferred (any/number?)
   const b = (o as any).y;
-  return a + b;             // → 0  (BUG)
+  return a + b; // → 0  (BUG)
 }
 
 // the SAME code with EXPLICIT `: number` annotations → 7 (CORRECT):
@@ -46,11 +48,12 @@ export function test(): number {
   const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
   const a: number = (o as any).x;
   const b: number = (o as any).y;
-  return a + b;             // → 7  ✓
+  return a + b; // → 7  ✓
 }
 ```
 
 So:
+
 - `return (o as any).x;` alone → 3 ✓
 - `return (o as any).y;` alone → 4 ✓
 - `const a=(o as any).x; const b=(o as any).y; return a+b;` (inferred) → **0** ✗
@@ -80,3 +83,17 @@ reads alias the same temp. Writes and single reads are unaffected.
 
 - #2542 (standalone dynamic property read/write by computed key — same family)
 - #2515 (surfaced here during S1; descriptor writes are correct, this is read-side)
+
+## Resolution (2026-07-17)
+
+Already fixed on current `main` — the bug does not reproduce. Every repro
+variant now returns the correct value under `--target standalone`: the inferred
+two-const combined read returns `7` (not `0`), matching the annotated form; a
+single read returns `3`; three-read, inline-combined, open-object-literal-write,
+and non-additive (multiply) combiners all return the right value.
+
+The inferred-type lowering of a dynamic `__extern_get` read was repaired by the
+dynamic property read/write family work (#2542 / #2515) after this was filed
+(2026-06-21). Closed with a regression guard rather than a code change:
+`tests/issue-2578.test.ts` (7 standalone cases) locks in the correct behavior so
+the actively-churning dynamic-read path can't silently regress. No `src/` change.

--- a/tests/issue-2578.test.ts
+++ b/tests/issue-2578.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2578 — standalone dynamic-property multi-read of inferred-typed values.
+ *
+ * Regression guard. As filed (2026-06-21), reading two dynamic (`any`-typed)
+ * properties off an open object and combining them into INFERRED-typed consts
+ * returned 0 under `--target standalone`, even though each property read
+ * correctly in isolation and the explicitly-`: number`-annotated form returned
+ * the right value. The divergence pinned it to the inferred-type lowering of a
+ * dynamic `__extern_get` read (wrong ValType / temp-local aliasing across two
+ * consecutive dynamic reads).
+ *
+ * The dynamic property read/write family work (#2542 / #2515) has since fixed
+ * this — every repro variant now returns the correct value. These tests lock
+ * that in so the actively-churning dynamic-read path can't silently regress.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  expect(WebAssembly.validate(r.binary as unknown as BufferSource)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary as unknown as BufferSource, {});
+  return (instance.exports as Record<string, () => number>).test!();
+}
+
+describe("#2578 standalone dynamic-property multi-read (inferred-typed)", () => {
+  it("two inferred consts combined → 7 (was 0)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+           const a = (o as any).x;
+           const b = (o as any).y;
+           return a + b;
+         }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("explicitly-annotated form still correct (no regression)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+           const a: number = (o as any).x;
+           const b: number = (o as any).y;
+           return a + b;
+         }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("single dynamic read in isolation → 3", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+           return (o as any).x;
+         }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("three inferred consts combined → 12", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o = Object.create(null, { x: { value: 3 }, y: { value: 4 }, z: { value: 5 } });
+           const a = (o as any).x;
+           const b = (o as any).y;
+           const c = (o as any).z;
+           return a + b + c;
+         }`,
+      ),
+    ).toBe(12);
+  });
+
+  it("inline combined dynamic reads (no intermediate consts) → 7", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+           return (o as any).x + (o as any).y;
+         }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("open object-literal writes then inferred multi-read → 7", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o: any = {};
+           (o as any).x = 3;
+           (o as any).y = 4;
+           const a = (o as any).x;
+           const b = (o as any).y;
+           return a + b;
+         }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("multiply combines two inferred reads → 12 (non-additive combiner)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+           const a = (o as any).x;
+           const b = (o as any).y;
+           return a * b;
+         }`,
+      ),
+    ).toBe(12);
+  });
+});


### PR DESCRIPTION
## Summary

#2578 (as filed 2026-06-21) reported that reading two dynamic (`any`-typed)
properties off an open object and combining them into **inferred**-typed consts
returned `0` under `--target standalone`, while each read in isolation and the
explicitly-`: number`-annotated form were correct.

**It no longer reproduces on current `main`.** The inferred-type lowering of a
dynamic `__extern_get` read was repaired by the dynamic property read/write
family work (#2542 / #2515) that landed after the issue was filed. Every repro
variant now returns the correct value.

## Change

Test-only — no `src/` change. Close the stale issue with a **regression guard**
so the actively-churning dynamic-read path can't silently regress:
`tests/issue-2578.test.ts` (7 standalone cases, empty-import instantiation):

- inferred two-const combined read → `7` (the originally-failing shape, was `0`)
- explicitly-annotated form → `7` (no regression)
- single dynamic read in isolation → `3`
- three inferred consts combined → `12`
- inline combined reads with no intermediate consts → `7`
- open object-literal writes then inferred multi-read → `7`
- non-additive (multiply) combiner → `12`

Issue frontmatter set to `done` with a resolution note crediting #2542 / #2515.

## Validation

- `tests/issue-2578.test.ts` 7/7 pass
- `prettier --check` clean