### PR TITLE
test(#3349): guard propertyHelper compile; split deepEqual residual to #3378

### DIFF
--- a/plan/issues/3349-propertyhelper-verifyenumerable-index-shift.md
+++ b/plan/issues/3349-propertyhelper-verifyenumerable-index-shift.md
@@ -1,7 +1,8 @@
 ---
 id: 3349
 title: "propertyHelper.js fails to compile at all (verifyEnumerable index-shift, #2043 class) — blocks up to 9.8% of test262 by inclusion count"
-status: ready
+status: done
+completed: 2026-07-17
 sprint: current
 created: 2026-07-17
 priority: high
@@ -13,8 +14,20 @@ task_type: bugfix
 area: codegen, emit
 language_feature: compiler-internals
 goal: test262-conformance
-related: [2043, 3284, 3285]
+related: [2043, 3284, 3285, 3378]
 ---
+
+> **Resolution (2026-07-17):** the primary target — `propertyHelper.js` /
+> `verifyEnumerable` compiling — is **fixed on current main** (verified: the
+> exact minimal repro below compiles to a `WebAssembly.validate`-clean binary,
+> and representative propertyHelper-including test262 files run end-to-end and
+> pass). A regression guard lives in `tests/issue-3349.test.ts`.
+> The `verifyEnumerable` index-shift was resolved by an earlier merge in the
+> #2043-class / late-import line (widening-map + funcIdx-repoint fixes).
+> The separately-flagged "second confirmation target" (the `deepEqual.js`
+> nested-closure **stale-local-index** instance — a different mechanism, a
+> captured-local slot vs. a funcIdx shift) is **not** part of this issue's
+> acceptance criteria and is tracked as **#3378**.
 
 # #3349 — `propertyHelper.js` (the real, unmodified test262 harness file) fails to compile entirely
 

--- a/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
+++ b/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
@@ -1,0 +1,106 @@
+---
+id: 3378
+title: "deepEqual.js fails to compile — stale LOCAL index in deeply-nested format/lazyResult closures (#2043 class, local not funcIdx)"
+status: ready
+sprint: current
+created: 2026-07-17
+priority: high
+feasibility: hard
+model: opus
+horizon: l
+reasoning_effort: high
+task_type: bugfix
+area: codegen, closures, emit
+language_feature: compiler-internals
+goal: test262-conformance
+related: [2043, 3349]
+---
+
+# #3378 — `deepEqual.js` fails to compile: stale LOCAL index in nested closures
+
+## How this was found
+
+Split out of #3349. #3349's primary target (`propertyHelper.js` /
+`verifyEnumerable`) is fixed on current main, but its "Related, likely-same-class
+finding" section flagged a **second, separate** confirmation target that is
+still live: the real, unmodified `test262/harness/deepEqual.js` fails to
+compile.
+
+`deepEqual.js` `includes:`-count is large (it backs `assert.deepEqual` across
+many built-ins/language tests), so this is a meaningful raw-harness conformance
+blocker in its own right.
+
+## Confirmed repro (current main, 2026-07-17)
+
+`deepEqual.js` alone compiles. It only fails once `assert` is a **real local
+callable** (so `deepEqual.js`'s `assert.deepEqual.format = function(){…}`
+closures are actually compiled, rather than treated as dynamic/host writes):
+
+```ts
+import { compile } from "./src/index.ts";
+import { readFileSync } from "fs";
+const rd = (f: string) => readFileSync("test262/harness/" + f, "utf8");
+// A tiny local `assert` function is enough — it is NOT assert.js's size.
+const stub = `function assert(x, m){ if(!x) throw new Error(m); }\nassert.x=1;\n`;
+const src = `export function test() {\n${stub + rd("deepEqual.js")}\nconsole.log("x");\n}`;
+const r = await compile(src, { target: "gc", fileName: "test.ts",
+  skipSemanticDiagnostics: true, emitWat: false } as any);
+// r.success === false
+```
+
+Errors observed (the second is the fatal one):
+
+```
+Cannot access 'contents' before initialization        (x4, severity: warning)
+Binary emit error: RangeError: Codegen error: local index out of range — 8
+(valid: [0, 5)) at function '__closure_15'. This is the late-import index-shift
+class (#2043): a captured index went stale ...
+```
+
+## Root-cause direction (narrowed, not yet fixed)
+
+- The fatal error is a **stale LOCAL index**, NOT a function-index shift. The
+  encoder (`src/emit/binary.ts:vIdx`/`failIndex`) rejects a `local.get`/`.set`
+  whose index (`8`) exceeds the synthesized closure's own local count (`5`).
+  The generic #2043 message ("re-resolve the funcIdx by name after the last
+  shift") is therefore **misleading for this instance** — no import shift is
+  involved; a captured-variable slot is being emitted against the WRONG
+  function's local numbering.
+- Trigger shape: `assert.deepEqual.format` contains **3 levels of nested named
+  functions** (`format` → `lazyResult` → `acceptMappers` → `toString`) plus
+  `.map(arrow)` closures and tagged-template literals, with inner closures
+  capturing outer locals (`usage`, `subs`, `strings`, `mappers`). One of the
+  synthesized `__closure_NN` bodies emits a `local.get` for a captured variable
+  using the ENCLOSING function's local index instead of its own
+  captured-struct-field / remapped-local index.
+- The `Cannot access 'contents' before initialization` warnings come from the
+  early-error TDZ checker (`src/compiler/early-errors/tdz.ts`,
+  `severity: "warning"`) mis-flagging block-scoped shadowing (`let contents` in
+  sibling `if`-blocks at lines 125/129 vs. the function-body `let contents` at
+  line 137). These are non-fatal warnings and likely a **separate, smaller**
+  bug from the fatal local-index one — but worth fixing together since both
+  surface on this file. (A minimal 2-if-block shadowing repro did NOT reproduce
+  the warning in isolation, so the TDZ path is only reached via some additional
+  structure in `format`; confirm the exact trigger before touching tdz.ts.)
+
+## Why this is `feasibility: hard` / senior-dev candidate
+
+The fatal is deep closure-lowering: a captured-local slot computed against the
+wrong function's local space in a 3-deep nested-closure chain. It resists quick
+minimization (the trigger needs most of `format`'s structure), so the fix needs
+a WAT/codegen trace of the failing `__closure_NN` body to see which captured
+variable's slot is emitted with the enclosing function's index, then a remap at
+the capture-emission site (`src/codegen/closures.ts` /
+`src/codegen/closures/*`). Follow the prior #2043-class point-fixes
+(#1809/#1839/#2029) for the "resolve the slot in the closure's own frame"
+pattern.
+
+## Acceptance criteria
+
+- The repro above (`stub-assert + deepEqual.js`) compiles to a valid binary.
+- The full real-harness combo `assert.js + sta.js + propertyHelper.js +
+  compareArray.js + deepEqual.js` (+ a trivial `Object.entries` body) compiles
+  to a valid binary.
+- The `Cannot access 'contents' before initialization` warnings on this file
+  are gone (or confirmed a legitimate spec TDZ and intentionally kept).
+- No regression in the existing JS-host test262 pass rate.

--- a/tests/issue-3349.test.ts
+++ b/tests/issue-3349.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3349 — the real, unmodified test262 harness file `propertyHelper.js`
+// (which 5,229 / 53,406 test262 files `includes:`) previously failed to
+// compile ENTIRELY. Merely defining `verifyEnumerable`
+// (`test262/harness/propertyHelper.js:423`) — without ever calling it — was
+// enough to break codegen with the #2043 late-import index-shift class error
+// ("local index out of range … at function 'verifyEnumerable'").
+//
+// That primary failure is resolved on current main. This is the regression
+// guard: (1) the exact minimal repro from the issue (assert.js + sta.js +
+// propertyHelper.js wrapped in a function, no call needed) compiles to a
+// structurally-valid binary; and (2) a representative sample of real
+// propertyHelper-including test262 files run end-to-end through the full
+// harness and PASS (not just "compiles").
+//
+// NOTE: a distinct, still-live instance of the same #2043 class remains in
+// `deepEqual.js`'s deeply-nested format/lazyResult closures (a STALE LOCAL
+// index, not a funcIdx shift) — tracked separately as #3378. It is explicitly
+// a "second, separate confirmation target" in #3349 and is NOT part of this
+// issue's acceptance criteria (which are all about propertyHelper).
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { runTest262File } from "./test262-runner.ts";
+
+const T262 = join(process.cwd(), "test262");
+const HARNESS = join(T262, "harness");
+
+describe("#3349 propertyHelper.js compiles (verifyEnumerable index-shift guard)", () => {
+  it.runIf(existsSync(HARNESS))(
+    "the minimal repro (assert + sta + propertyHelper, no call) compiles to a valid binary",
+    async () => {
+      const rd = (f: string) => readFileSync(join(HARNESS, f), "utf8");
+      const body = rd("assert.js") + rd("sta.js") + rd("propertyHelper.js") + '\nconsole.log("ok");\n';
+      const src = `export function test() {\n${body}\n}`;
+      const r = await compile(src, {
+        target: "gc",
+        fileName: "test.ts",
+        skipSemanticDiagnostics: true,
+        emitWat: false,
+        inferModuleStrictArguments: false,
+      } as Parameters<typeof compile>[1]);
+      expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+      expect(r.binary != null && r.binary.length > 0, "empty binary").toBe(true);
+      // Structural validation — the pre-fix failure was a binary-emit RangeError
+      // ("local index out of range") that surfaced only at encoding time.
+      expect(await WebAssembly.validate(r.binary!), "module failed WebAssembly.validate").toBe(true);
+    },
+    30000,
+  );
+
+  it.runIf(existsSync(T262))(
+    "representative propertyHelper-including test262 files run end-to-end and pass",
+    async () => {
+      const FILES: [rel: string, category: string][] = [
+        ["test/built-ins/Object/getOwnPropertySymbols/length.js", "built-ins/Object"],
+        ["test/built-ins/Object/getOwnPropertySymbols/name.js", "built-ins/Object"],
+        ["test/built-ins/Object/prop-desc.js", "built-ins/Object"],
+        ["test/built-ins/Boolean/prototype/S15.6.4_A2.js", "built-ins/Boolean"],
+      ];
+      for (const [rel, category] of FILES) {
+        const abs = join(T262, rel);
+        if (!existsSync(abs)) continue; // tolerate submodule pathing drift
+        const r = await runTest262File(abs, category, 20000);
+        const msg = String(r.error ?? r.reason ?? "");
+        expect(r.status, `${rel}: ${r.status} — ${msg}`).toBe("pass");
+      }
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
## Summary

**#3349's primary target is fixed on current main** — the real, unmodified test262 harness file `propertyHelper.js` (which **5,229 / 53,406** test262 files `includes:`) previously failed to compile *entirely* via the #2043 late-import index-shift on `verifyEnumerable`. Verify-first confirms it's resolved:

- The exact minimal repro from the issue (`assert.js` + `sta.js` + `propertyHelper.js`, wrapped, no call needed) now compiles to a **`WebAssembly.validate`-clean** binary.
- Representative propertyHelper-including test262 files (`Object.getOwnPropertySymbols/{length,name}`, `Object/prop-desc`, `Boolean/prototype/S15.6.4_A2`) run **end-to-end and pass** through the full harness.

The `verifyEnumerable` index-shift was closed by an earlier merge in the #2043-class / late-import line.

## What this PR does

- Adds `tests/issue-3349.test.ts` — a regression guard so the primary can't silently regress (minimal-repro compile + validate, plus 4 real propertyHelper files run-and-pass).
- Marks **#3349 done** (`status: done`, `completed: 2026-07-17`).
- **Splits the residual** into **#3378**: the separately-flagged "second confirmation target" (`deepEqual.js`'s deeply-nested `format`/`lazyResult` closures) still fails — but that is a **stale LOCAL index** (a captured-variable slot emitted against the wrong function's local numbering), a *different mechanism* from a funcIdx shift, and it is **not** part of #3349's acceptance criteria. Filed with a confirmed repro + narrowed root-cause direction for a senior-dev follow-up.

## Test

```
npx vitest run tests/issue-3349.test.ts   # 2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)