### PR TITLE
fix(#3332): direct linear path push appends all args + returns new length

### DIFF
--- a/plan/issues/3332-linear-direct-push-return-and-multiarg.md
+++ b/plan/issues/3332-linear-direct-push-return-and-multiarg.md
@@ -1,7 +1,8 @@
 ---
 id: 3332
 title: "linear direct path: arr.push returns 0 (not new length) and drops extra args"
-status: ready
+status: done
+completed: 2026-07-17
 sprint: Backlog
 goal: backend-agnostic-ir
 feasibility: medium
@@ -18,6 +19,16 @@ related: [2956, 1854]
 ---
 
 # #3332 — linear direct path push defects
+
+> **Resolution (2026-07-17):** fixed in `src/codegen-linear/index.ts`
+> `compileArrayMethodCall` — the `push` handler now (a) holds the receiver in a
+> local and loops over **every** argument (multi-arg no longer dropped), and (b)
+> reads `__arr_len` for the expression value so push returns the **new length**
+> instead of `f64.const 0`. Guarded by `tests/issue-3332.test.ts` (6 cases:
+> single/multi-arg return value, no-arg, value ordering, ref-element push) and
+> the `#2956` divergence assertions were folded into the direct↔IR parity loop
+> (`tests/issue-2956.test.ts`). The IR overlay's single-arg-only gate still
+> demotes multi-arg push to the direct path, which is now itself spec-correct.
 
 ## Problem
 

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -3552,18 +3552,32 @@ function compileArrayMethodCall(
   methodName: string,
 ): void {
   if (methodName === "push") {
-    // arr.push(val) → __arr_push(arr, slot(val)) (#1938: f64 slot)
+    // arr.push(v1, v2, …) → __arr_push(arr, slot(vi)) for every argument
+    // (#1938: f64 slot). Per spec §23.1.3.23, push appends ALL arguments and
+    // returns the NEW length. #3332: the old direct-path lowering handled only
+    // arguments[0] (dropping the rest) and yielded `f64.const 0` (not the new
+    // length) in expression position. Hold the receiver in a local so multiple
+    // pushes and the trailing length read all reference the same array without
+    // re-evaluating a possibly side-effecting receiver expression.
     const pushIdx = ctx.funcMap.get("__arr_push")!;
+    const lenIdx = ctx.funcMap.get("__arr_len")!;
+    const arrLocal = addLocal(fctx, `__push_arr_${fctx.locals.length}`, { kind: "i32" });
     compileExpression(ctx, fctx, propAccess.expression); // arr ptr (i32)
-    if (inferExprType(ctx, fctx, expr.arguments[0]).kind === "f64") {
-      compileExprToF64(ctx, fctx, expr.arguments[0]); // numeric/boolean → f64 slot
-    } else {
-      compileExprToI32(ctx, fctx, expr.arguments[0]); // ref → i32
-      pushI32ToSlot(fctx); // → f64 slot
+    fctx.body.push({ op: "local.set", index: arrLocal });
+    for (const arg of expr.arguments) {
+      fctx.body.push({ op: "local.get", index: arrLocal });
+      if (inferExprType(ctx, fctx, arg).kind === "f64") {
+        compileExprToF64(ctx, fctx, arg); // numeric/boolean → f64 slot
+      } else {
+        compileExprToI32(ctx, fctx, arg); // ref → i32
+        pushI32ToSlot(fctx); // → f64 slot
+      }
+      fctx.body.push({ op: "call", funcIdx: pushIdx });
     }
-    fctx.body.push({ op: "call", funcIdx: pushIdx });
-    // push returns void in runtime, but expression needs a value for drop
-    fctx.body.push({ op: "f64.const", value: 0 });
+    // Expression value: the new length (spec: Array.prototype.push returns it).
+    fctx.body.push({ op: "local.get", index: arrLocal });
+    fctx.body.push({ op: "call", funcIdx: lenIdx });
+    fctx.body.push({ op: "f64.convert_i32_s" });
   } else if (
     methodName === "filter" ||
     methodName === "map" ||

--- a/tests/issue-2956.test.ts
+++ b/tests/issue-2956.test.ts
@@ -206,8 +206,9 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
 
     const direct = await exportedFunctions(directBinary);
     const ir = await exportedFunctions(irBinary);
-    // Direct-path parity where the direct path is spec-correct.
-    for (const name of ["setInBounds", "setGrow", "pushStmt"]) {
+    // Direct-path parity where the direct path is spec-correct. #3332 fixed the
+    // direct-path push return value, so `pushExpr` now joins this parity loop.
+    for (const name of ["setInBounds", "setGrow", "pushStmt", "pushExpr"]) {
       expect(callNumber(ir, name), `${name} IR value`).toBe(callNumber(direct, name));
     }
     // Absolute expectations (spec semantics):
@@ -216,15 +217,10 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
     // runtime's 0 sentinel -> 507.
     expect(callNumber(ir, "setGrow")).toBe(507);
     expect(callNumber(ir, "pushStmt")).toBe(8); // 5 + new length 3
-    // push in EXPRESSION position: the IR overlay is spec-correct (returns
-    // the new length -> 2*10 + 8 = 28); the DIRECT path returns 0 for the
-    // push result (pre-existing defect, tracked as #3332) -> 8. Assert both
-    // so a direct-path fix flips this into a parity check loudly.
+    // push in EXPRESSION position now returns the new length on BOTH the IR
+    // overlay AND the direct path (#3332 fixed) -> 2*10 + 8 = 28.
     expect(callNumber(ir, "pushExpr")).toBe(28);
-    expect(
-      callNumber(direct, "pushExpr"),
-      "direct pushExpr (#3332 — update to 28 + fold into parity loop when fixed)",
-    ).toBe(8);
+    expect(callNumber(direct, "pushExpr")).toBe(28);
     expect(callNumber(ir, "test")).toBe(12 + 507 + 8 + 28);
   });
 
@@ -246,10 +242,10 @@ describe("#2956 L2: selector-claimed vec MUTATION (element store + push)", () =>
     const report = getLastLinearIrReport();
     expect(report?.compiled ?? []).not.toContain("multiPush");
     expect(report?.rejected.some((rejection) => rejection.func === "multiPush")).toBe(true);
-    // The demoted function rides the DIRECT path, which drops the extra
-    // push arg (pre-existing defect, #3332): length is 2, not the
-    // spec-correct 3. Update to 3 when #3332 lands.
-    expect(await run(binary)).toBe(2);
+    // The demoted function rides the DIRECT path. #3332 fixed multi-arg push on
+    // the direct path (all arguments appended), so the length is the spec-correct
+    // 3 — even though the IR overlay still demotes multi-arg push to direct.
+    expect(await run(binary)).toBe(3);
   });
 });
 

--- a/tests/issue-3332.test.ts
+++ b/tests/issue-3332.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3332 — DIRECT linear path (`--target linear`, no JS2WASM_LINEAR_IR)
+// mis-lowered Array.prototype.push two ways:
+//   (a) expression-position push yielded `f64.const 0`, not the new length;
+//   (b) multi-arg push (`a.push(x, y, …)`) dropped every argument after the
+//       first.
+// Per spec §23.1.3.23 push appends ALL arguments and returns the new length.
+// Fix: `src/codegen-linear/index.ts` compileArrayMethodCall — loop over every
+// argument and read `__arr_len` for the expression value.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+async function runLinear(src: string, fn: string): Promise<number> {
+  const r = await compile(src, { target: "linear", fileName: "t.ts" } as Parameters<typeof compile>[1]);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary!), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports as Record<string, () => number>)[fn]!();
+}
+
+describe("#3332 direct linear-path Array.prototype.push", () => {
+  it("single-arg push returns the new length in expression position", async () => {
+    expect(await runLinear(`export function pushRet(): number { const a = [1]; return a.push(8); }`, "pushRet")).toBe(
+      2,
+    );
+  });
+
+  it("multi-arg push appends every argument (length reflects all)", async () => {
+    expect(
+      await runLinear(
+        `export function multiPush(): number { const a = [1]; a.push(2, 3); return a.length; }`,
+        "multiPush",
+      ),
+    ).toBe(3);
+  });
+
+  it("multi-arg push returns the new length", async () => {
+    expect(
+      await runLinear(`export function multiRet(): number { const a = [1]; return a.push(2, 3, 4); }`, "multiRet"),
+    ).toBe(4);
+  });
+
+  it("no-arg push returns the unchanged length", async () => {
+    expect(
+      await runLinear(`export function emptyPush(): number { const a = [1, 2]; return a.push(); }`, "emptyPush"),
+    ).toBe(2);
+  });
+
+  it("all pushed values land in order", async () => {
+    expect(
+      await runLinear(
+        `export function values(): number { const a: number[] = []; a.push(5, 6, 7); return a[0] * 100 + a[1] * 10 + a[2]; }`,
+        "values",
+      ),
+    ).toBe(567);
+  });
+
+  it("multi-arg push of reference (string) elements returns the new length", async () => {
+    expect(
+      await runLinear(
+        `export function strPush(): number { const a: string[] = ["x"]; return a.push("y", "z"); }`,
+        "strPush",
+      ),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

The DIRECT linear path (`--target linear`, no `JS2WASM_LINEAR_IR`) mis-lowered `Array.prototype.push` in `src/codegen-linear/index.ts` `compileArrayMethodCall`:

- **(a)** expression-position push emitted `f64.const 0` as its value instead of the new length;
- **(b)** multi-arg push (`a.push(x, y, …)`) handled only `arguments[0]` and dropped the rest.

Per spec §23.1.3.23, `push` appends **all** arguments and returns the **new length**.

## Fix

Hold the receiver in an i32 local, loop over every argument calling `__arr_push` per arg, then read `__arr_len` for the expression value. Handles zero-arg `push()` (returns the unchanged length) and avoids re-evaluating a side-effecting receiver.

## Tests

- `tests/issue-3332.test.ts` — 6 new cases: single/multi-arg return value, no-arg, value ordering, ref-element (string) push.
- `tests/issue-2956.test.ts` — the divergence assertions that previously *documented* this defect are folded into the direct↔IR parity loop (`pushExpr` now parity; `multiPush` length 3, not 2).

```
npx vitest run tests/issue-3332.test.ts tests/issue-2956.test.ts   # 26 passed
```

The IR overlay's single-arg-only gate still demotes multi-arg push to the direct path — which is now itself spec-correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)