### PR TITLE
plan(#3178): decompose the standalone async-machinery umbrella into spec'd children #3386-#3391

### DIFF
--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -1,8 +1,9 @@
 ---
 id: 3178
 title: "UMBRELLA: retire the generator/async/Promise HOST machinery in standalone — the 4,467-leaky-pass (10.3 pt) family, measured slice map + shared-substrate design"
-status: in-progress
-assignee: fable-3178
+status: ready
+# decomposition delivered 2026-07-17 (fable-3178, children #3386-#3391);
+# umbrella stays open as tracking — #3391 owns the acceptance closeout.
 sprint: current
 created: 2026-07-12
 updated: 2026-07-17
@@ -15,11 +16,48 @@ task_type: architecture
 area: codegen, standalone
 language_feature: generators, async-generators, promises, async-functions
 goal: standalone-mode
-related: [1781, 2860, 3164, 3132, 3032, 2903, 2906, 2865, 2895, 1326, 2959, 2040]
+related: [1781, 2860, 3164, 3132, 3032, 2903, 2906, 2865, 2895, 1326, 2959, 2040, 3386, 3387, 3388, 3389, 3390, 3391]
+children: [3386, 3387, 3388, 3389, 3390, 3391]
 origin: "2026-07-12 architect (arch-standalone-family-plans): plan/log/standalone-gap-map.md finding — 4,456 leaky passes ride host-import shims, ~90% the generator/async-gen/Promise host machinery. This umbrella is the substrate spec + measured slice ranking the family builds on."
 ---
 
 # #3178 — UMBRELLA: standalone host async-machinery retirement
+
+## Decomposition 2026-07-17 (fable-3178) — child issues #3386–#3391
+
+State change since this umbrella was written (2026-07-12): **S1 (#3164), S2
+(#3132), S3 (#3302), S4 (#3228), S5/S6 (#2903) have all landed/closed** — but
+#3132 closed after its own S1+S2 only, banking its S3 (general `yield*`) and
+S4 (`return` completion) unspun. Also the ACCOUNTING changed: since #2961 a
+standalone compile that emits host imports is a hard `compile_error`
+(`error_category: host_import_leak`) — there are no "leaky passes" anymore.
+Every pass is host-free (24,949 on the 2026-07-17 promoted baseline — the
+host_free_pass ≥ 24,500 acceptance bar is MET); the residual family scope is
+now the **4,410 official-scope `host_import_leak` CE rows**, i.e. potential
+NEW passes, re-measured 2026-07-17 and decomposed into six children:
+
+| Child     | Scope (one line)                                                                                                                    |   Rows |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------- | -----: |
+| **#3386** | sync-gen destructuring-pattern params: fn-expr gate, element defaults, untyped array patterns via native iterator protocol, methods | ~1,860 |
+| **#3387** | NESTED async-gens with for-await bodies — close the nested-vs-module-scope drivability seam (owns the seam root-cause)              |   ~577 |
+| **#3388** | async-gen general `yield*` runtime delegation (nested + method lanes, §27.6.3.7 GetIterator error semantics) — #3132 S3 re-grounded |   ~600 |
+| **#3389** | async-gen `return`/`throw` completion — settleReturn terminator + driven `.return()`/`.throw()` — #3132 S4 re-grounded              |   ~300 |
+| **#3390** | Promise combinators with non-Promise receivers (`.call(nonCtor)` TypeError, custom-ctor admission)                                  |   ~119 |
+| **#3391** | S7 mechanical closeout: registration assert, dead-arm audit, umbrella acceptance measurement (depends on the rest)                  |      0 |
+
+**The load-bearing new finding (probe matrix 2026-07-17)**: for-await bodies,
+general `yield*` (ident AND custom async-iterable), and `return` completion in
+async gens all compile HOST-FREE at module scope on current main, but LEAK
+when the generator is nested inside a function — and the test262 runner wraps
+every file in `export function test(){}`, so the whole async-gen residual
+rides that one seam (`nested-declarations.ts:678/:1104` →
+`isAsyncGenDriveCandidate` → `analyzeAsyncGen`'s bounded shape). #3387 owns
+root-causing which module-scope arm admits these (and validating its runtime
+correctness — it is corpus-under-tested precisely because everything is
+wrapped); #3388/#3389 build on the documented finding. `__make_callback` is
+fully retired (0 rows). Dynamic-import chains (288 rows) stay deferred
+(#1089/#1512). Remaining non-family leak cohorts (SharedArrayBuffer 344,
+BigInt64Array, `__array_from_async` 76, …) are OUTSIDE this umbrella.
 
 ## The one-paragraph thesis
 
@@ -42,16 +80,16 @@ family can be staffed without re-deriving any of this.
 Aggregated from `.test262-cache/test262-standalone-current.jsonl`
 (official-scope subset; rows with `status=pass && imports.length>0`):
 
-| Cohort (by import combo) | leaky passes | Rides on |
-| --- | ---: | --- |
-| carries ANY `__gen_*`/`__create_*` generator machinery | **4,034** | #3164 (sync fn-exprs), #3132 (async gens), residual below |
-| — sync-only bundles (`__create_generator` = 1,739 total) | ~1,741 | **#3164** (fn expressions ≈ ALL of it — the dstr harness IIFE `var iter = function*(){…}();`) |
-| — async-gen bundles (`__create_async_generator` = 2,408) | ~2,408 | **#3132** S2–S4 (methods 1,725 files, yield\*, return) |
-| Promise/callback-only, NO gen machinery | **182** | this umbrella S4–S6 |
-| — for-await-of dstr via legacy async lowering (`Promise_resolve/reject/then2` + `__make_callback` + `__get_caught_exception`) | 90 | S4 |
-| — dynamic-import chains (`__dynamic_import` + then-arms) | 47 | deferred (#1089/#1512) |
-| — `__make_callback`-only (lazy Iterator helpers, TypedArray callbacks, DisposableStack, Function.prototype) | ~30 | S6 (#2903 sub-fronts 2b/4) |
-| — `Promise_new` non-inline executor / misc | ~15 | S5 |
+| Cohort (by import combo)                                                                                                      | leaky passes | Rides on                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------------------- | -----------: | --------------------------------------------------------------------------------------------- |
+| carries ANY `__gen_*`/`__create_*` generator machinery                                                                        |    **4,034** | #3164 (sync fn-exprs), #3132 (async gens), residual below                                     |
+| — sync-only bundles (`__create_generator` = 1,739 total)                                                                      |       ~1,741 | **#3164** (fn expressions ≈ ALL of it — the dstr harness IIFE `var iter = function*(){…}();`) |
+| — async-gen bundles (`__create_async_generator` = 2,408)                                                                      |       ~2,408 | **#3132** S2–S4 (methods 1,725 files, yield\*, return)                                        |
+| Promise/callback-only, NO gen machinery                                                                                       |      **182** | this umbrella S4–S6                                                                           |
+| — for-await-of dstr via legacy async lowering (`Promise_resolve/reject/then2` + `__make_callback` + `__get_caught_exception`) |           90 | S4                                                                                            |
+| — dynamic-import chains (`__dynamic_import` + then-arms)                                                                      |           47 | deferred (#1089/#1512)                                                                        |
+| — `__make_callback`-only (lazy Iterator helpers, TypedArray callbacks, DisposableStack, Function.prototype)                   |          ~30 | S6 (#2903 sub-fronts 2b/4)                                                                    |
+| — `Promise_new` non-inline executor / misc                                                                                    |          ~15 | S5                                                                                            |
 
 **Key correction to the gap map's Promise row**: the `Promise_then2/resolve/
 reject` ~1,500 column is NOT an independent Promise gap — probe-verified on
@@ -77,7 +115,7 @@ parallel machinery.
 1. **Microtask/job queue** — `src/codegen/async-scheduler.ts` (#1326 1C-A):
    funcref+externref ring (`__microtask_enqueue` / `__drain_microtasks` /
    `__microtask_grow`), uniform job signature `$__mt_func_type
-   (externref, externref) -> externref`, WASI `_start` auto-drain, plus the
+(externref, externref) -> externref`, WASI `_start` auto-drain, plus the
    #2632 timer-heap/run-loop reactor. This IS the spec HostEnqueuePromiseJob.
 2. **`$Promise` carrier** — `getOrRegisterPromiseType` (async-scheduler.ts):
    `{state i32 mut, value externref mut, callbacks (ref null $PromiseCallback) mut}`;
@@ -121,15 +159,15 @@ machines 2/3.
 
 ## Slice map (ranked by leaky-passes-retired; every slice = its own issue/PR)
 
-| # | Slice | Retires (leaky) | Owner issue | Class |
-| - | --- | ---: | --- | --- |
-| S1 | sync generator FUNCTION EXPRESSIONS native | ~1,741 | **#3164 — done** | fable-executable-now |
-| S2 | async-gen methods / yield\* / return native | ~2,408 (subsumes most of the Promise column) | **#3132** S2–S4 (in-progress, live dev — coordinate, don't fork) | in-flight (XL) |
-| S3 | capturing nested generators → capture slots in the state struct | small leaky (≤ ~60) but large FAIL/CE value + unblocks #3032 semantics | **#3302 — done** (2026-07-16; declarations landed via #3032 W3's TDZ-native-threading, fn-expressions + the latent #3164 sgDeps-only fill hole via #3302's own PR) | landed |
-| S4 | for-await-of dstr legacy async lowering → native drive | 90 | **#3228 — done** (banked the 24 array-source files); residual 96 `asyncIter`-var-source files fold into **#3132**'s lane per #3228's own scope note — not a separate child | mostly done, residual rides #3132 |
-| S5 | `new Promise(NON-inline executor)` + `class X extends Promise` producer | ~15 leaky + fail-bucket | #2903 (re-grounded plan there) | fable-executable-now |
-| S6 | lazy Iterator helpers (map/filter/take/drop/flatMap) + TypedArray callback methods | ~30 | #2903 sub-fronts 2b/4 (plan there) | fable-executable-now |
-| S7 | `__get_caught_exception` zero-registration assert + eager-buffer code deletion | 0 direct (accounting rides S1/S2) | fold into the LAST of S1/S2 to land | mechanical |
+| #   | Slice                                                                              |                                                        Retires (leaky) | Owner issue                                                                                                                                                                | Class                             |
+| --- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| S1  | sync generator FUNCTION EXPRESSIONS native                                         |                                                                 ~1,741 | **#3164 — done**                                                                                                                                                           | fable-executable-now              |
+| S2  | async-gen methods / yield\* / return native                                        |                           ~2,408 (subsumes most of the Promise column) | **#3132** S2–S4 (in-progress, live dev — coordinate, don't fork)                                                                                                           | in-flight (XL)                    |
+| S3  | capturing nested generators → capture slots in the state struct                    | small leaky (≤ ~60) but large FAIL/CE value + unblocks #3032 semantics | **#3302 — done** (2026-07-16; declarations landed via #3032 W3's TDZ-native-threading, fn-expressions + the latent #3164 sgDeps-only fill hole via #3302's own PR)         | landed                            |
+| S4  | for-await-of dstr legacy async lowering → native drive                             |                                                                     90 | **#3228 — done** (banked the 24 array-source files); residual 96 `asyncIter`-var-source files fold into **#3132**'s lane per #3228's own scope note — not a separate child | mostly done, residual rides #3132 |
+| S5  | `new Promise(NON-inline executor)` + `class X extends Promise` producer            |                                                ~15 leaky + fail-bucket | #2903 (re-grounded plan there)                                                                                                                                             | fable-executable-now              |
+| S6  | lazy Iterator helpers (map/filter/take/drop/flatMap) + TypedArray callback methods |                                                                    ~30 | #2903 sub-fronts 2b/4 (plan there)                                                                                                                                         | fable-executable-now              |
+| S7  | `__get_caught_exception` zero-registration assert + eager-buffer code deletion     |                                      0 direct (accounting rides S1/S2) | fold into the LAST of S1/S2 to land                                                                                                                                        | mechanical                        |
 
 Sequencing: S1 ∥ S2 ∥ S5/S6 are independent. S3 after S1 (same
 `isNativeGeneratorCandidate` seam; S1's fn-expr registration is the pattern S3

--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -1,10 +1,11 @@
 ---
 id: 3178
 title: "UMBRELLA: retire the generator/async/Promise HOST machinery in standalone — the 4,467-leaky-pass (10.3 pt) family, measured slice map + shared-substrate design"
-status: ready
+status: in-progress
+assignee: fable-3178
 sprint: current
 created: 2026-07-12
-updated: 2026-07-12
+updated: 2026-07-17
 priority: high
 horizon: xl
 feasibility: hard

--- a/plan/issues/3386-standalone-syncgen-pattern-param-widening.md
+++ b/plan/issues/3386-standalone-syncgen-pattern-param-widening.md
@@ -1,0 +1,177 @@
+---
+id: 3386
+title: "standalone: native sync-generator DESTRUCTURING-pattern params — methods, fn-expressions, element defaults, untyped array patterns (~1,860 host_import_leak rows)"
+status: ready
+sprint: current
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+horizon: l
+feasibility: hard
+model: opus
+reasoning_effort: high
+task_type: feature
+area: codegen, standalone
+language_feature: generators, destructuring
+goal: standalone-mode
+umbrella: 3178
+related: [2920, 3164, 3302, 3032, 2938, 3312, 2581]
+origin: "2026-07-17 fable-3178 umbrella decomposition — largest sync-gen residual cohort in the standalone host_import_leak baseline (post-#2961 accounting)."
+---
+
+# #3386 — sync-generator pattern params: widen the native admission
+
+## Problem
+
+Since #2961, a standalone compile that emits the `env::__gen_*` family is a
+hard `compile_error` (`error_category: host_import_leak`). The single largest
+SYNC-generator residual cohort is **generators with destructuring-pattern
+params**, measured 2026-07-17 from the promoted
+`test262-standalone-current.jsonl` (official scope):
+
+| dir                                                                        |  rows | shape                                             |
+| -------------------------------------------------------------------------- | ----: | ------------------------------------------------- |
+| `{expressions,statements}/class/dstr` (`gen-meth-*`, `private-gen-meth-*`) | 1,184 | class generator METHODS with pattern params       |
+| `expressions/generators/dstr`                                              |   174 | generator fn EXPRESSIONS with pattern params      |
+| `expressions/object/dstr` (`gen-meth-*`)                                   |   170 | object-literal generator methods                  |
+| `statements/generators/dstr`                                               |   166 | generator fn DECLARATIONS (dflt:87 ary:53 obj:25) |
+| smaller (`class/elements` 78, `for-of/dstr` 27, `assignment/dstr` 24)      |  ~130 | mixed                                             |
+
+Dominant import combo:
+`__create_generator,__gen_create_buffer,__gen_next[,__gen_return,__gen_result_*],__get_caught_exception`.
+
+## Live probes (2026-07-17, current main, `--target standalone`)
+
+| probe                                                               | result    |
+| ------------------------------------------------------------------- | --------- |
+| `function* f([x, y]) {}` at module scope                            | HOST-FREE |
+| `function* f([x = 1]) {}` at module scope                           | HOST-FREE |
+| same decl WRAPPED in the test262 `export function test(){}` wrapper | **LEAKS** |
+| `class C { *method([x, y]) {} }` (even module scope, plain pattern) | **LEAKS** |
+| `var f = function*([x = 1]) {}`                                     | **LEAKS** |
+| `{ *method([x]) {} }` object literal                                | **LEAKS** |
+| wrapped `function* g() { yield 1; }` (no pattern)                   | HOST-FREE |
+
+So sync-gen NESTING itself is solved (#3302/#3032 W3/W4); the bails are all in
+the pattern-param admission.
+
+## Root cause (exact gates, verified on current main)
+
+All in `src/codegen/generators-native.ts`:
+
+1. **Fn-expression gate is identifier-only** — `isNativeGeneratorExpressionShape`
+   (line 1454; the identifier check at line 1457: `if (!ts.isIdentifier(param.name)) return false;`).
+   #3164 shipped fn-exprs but never extended them to the #2920 pattern-param
+   lowering. This alone bails all 174 `expressions/generators/dstr` rows and the
+   fn-expr-shaped harness templates.
+2. **Element defaults bail** — plan builder at lines ~1274–1281: any
+   `el.initializer` (`[x = 23]`, `{a: b = expr}`) returns `null` ("throwing /
+   function-valued default produced invalid modules"). This bails every
+   `dflt-*` file (87×2 decl rows + the method `gen-meth-dflt-*` families).
+3. **Untyped ARRAY patterns bail** — lines ~1282–1305: array patterns require a
+   syntactic `param.type` resolving to a concrete vec/tuple ref. Test262 is
+   plain JS — **no param is ever TS-annotated**, so every array-pattern param in
+   the corpus bails. (Object patterns are admitted untyped; that is why
+   `obj-ptrn-id-init-skipped.js` passes host-free.) This is what bails the
+   plain-pattern class-method probe above.
+4. **Whole-param defaults, nested sub-patterns, rest elements bail** — lines
+   ~1250–1273 (`param.initializer`, non-identifier elements, `dotDotDotToken`).
+5. Object-literal methods with param defaults/optionals bail separately
+   (lines ~1736–1744, the `__argc_default` trampoline gap, #2581) — keep that
+   bail; it is NOT this issue's scope to fix the trampoline.
+
+## Implementation Plan
+
+Waves, each independently landable and measure-first (sample by CONSTRUCT):
+
+### W1 — fn-expression pattern params (cheap, unlocks ~174+ rows)
+
+**File: `src/codegen/generators-native.ts`**, `isNativeGeneratorExpressionShape`
+(line 1454). Replace the `!ts.isIdentifier(param.name)` bail with the SAME
+param acceptance the plan builder applies (identifier | ArrayBindingPattern |
+ObjectBindingPattern, no rest) — i.e. delegate the pattern legality entirely to
+`buildNativeGeneratorPlan` (which `isNativeGeneratorCandidate` already calls
+last). Check the #3164 emit site in `closures.ts` (the lifted-closure factory
+registration) threads the raw pattern arg into the state struct the same way
+the free-function path does (`emitPatternParamDestructure` +
+`collectPatternBindingIdentifiers`, both already exported in
+generators-native.ts). The single-candidate-gate discipline (#3164 comment at
+line ~1685) means NO separate mirror edit is needed in
+`sourceNeedsGeneratorHostImports` — but verify with a leak probe on
+`var f = function*([x]) {}` in both lanes.
+
+### W2 — array-pattern params via the native ITERATOR protocol (the big lever)
+
+The `param.type`-required vec-indexing destructure is both too narrow AND
+spec-divergent: §14.3.3 array destructuring goes through the iterator protocol
+(the corpus tests exactly that — `ary-ptrn-elem-id-iter-done`,
+`iter-step-err`, `iter-val-*`). Replace the state-0 resume-prelude destructure
+for array patterns with the SAME native `__iterator` /
+IteratorBindingInitialization lowering that ordinary (non-generator) function
+params and for-of heads already use host-free (see `iterator-native.ts` and
+`destructuring-params.ts` — find the non-generator array-pattern param path and
+reuse its emitters; do NOT build a parallel destructure). Then drop the
+`param.type` requirement (lines ~1282–1305) — the raw arg is stored externref
+in the state struct and iterated in the prelude, so the concrete-vec typing
+question disappears.
+
+- Edge cases: iterator `done` before pattern exhausted → remaining bindings
+  `undefined`; abrupt `next()` → the error must propagate out of the FIRST
+  `.next()` call on the generator (the prelude runs at state 0, i.e. first
+  resume — matches §27.5.3.1 lazy semantics); elision holes advance the
+  iterator without binding; IteratorClose on early abrupt completion.
+- The eager host path snapshots by-value at CREATION — the native prelude runs
+  at first `.next()`. That is a semantic FIX (lazy per spec), but re-run the
+  construct sample in the JS-HOST lane too: host lane must stay byte-identical
+  (the gate change is inside plan admission consumed identically by both — the
+  host lane's own candidate arm at line 1651 restricts to fn decls with
+  try-across-yield, so host-lane emission does not change; verify with
+  SHA-equal probe).
+
+### W3 — element defaults in the resume-prelude destructure
+
+Lines ~1274–1281. After W2, a defaulted element lowers as: bind from iterator
+step; `if (value === undefined) value = <initializer>`. Initializers evaluate
+in the RESUME function scope — they may reference earlier pattern bindings
+(already spilled), module globals, and captured boxes (#3302 slots). First
+root-cause the recorded "#2920 invalid modules on throwing/function-valued
+defaults" (likely: the initializer expression compiled against the OUTER fctx
+local table instead of the resume fctx — compile initializers with the resume
+fctx, same as body statements). Whole-param defaults (`[x] = []`, line ~1257)
+join here: evaluate the whole-param initializer when the raw arg field reads
+undefined, BEFORE the iterator acquire.
+
+### W4 — nested sub-patterns + rest elements
+
+Nested patterns recurse the W2 lowering (each sub-pattern gets its own
+iterator/property extraction). Array rest (`[a, ...rest]`) drains the iterator
+into a native vec (host-free — the `__iterator` loop); object rest still needs
+`__extern_rest_object` — keep object-rest bailed (correct-or-legacy) and note
+the residual count.
+
+### Excluded / guarded
+
+- The 16 `*-ary-ptrn-elem-ary-elision-iter` private-gen files guarded on #3312
+  (shadowed-binding capture promotion) stay excluded until #3312 lands.
+- Object-literal method param DEFAULTS keep the #2581 `__argc_default` bail.
+
+## Test plan
+
+- Leak probes per wave (compile → import set empty + `WebAssembly.instantiate(binary, {})` succeeds).
+- Construct-sampled corpus flip on `class/dstr` + `generators/dstr` +
+  `object/dstr` (never directory-sampled — #2938 lesson).
+- Equivalence tests: add `tests/issue-3386.test.ts` with wrapped-shape probes
+  (the wrapper is load-bearing — module-scope-only probes gave false greens
+  during decomposition).
+- JS-host lane byte-identity (SHA-equal) on modules without the construct AND
+  on host-lane generator modules (the host candidate arm must not widen).
+
+## Regression risks
+
+- Gate/registration lockstep: `isNativeGeneratorCandidate` ==
+  `sourceNeedsGeneratorHostImports` == the emit sites (class-bodies.ts:~2354
+  region, literals.ts, closures.ts) must agree per-decl or the module bakes an
+  undefined `__gen_*` funcIdx (invalid wasm). Every wave: run the async/gen
+  corpus compile-validity scan (0 invalid wasm).
+- The wrapped-vs-module-scope delta above means ALL probes must use the test262
+  wrapper shape.

--- a/plan/issues/3387-standalone-nested-asyncgen-forawait-drive.md
+++ b/plan/issues/3387-standalone-nested-asyncgen-forawait-drive.md
@@ -1,0 +1,146 @@
+---
+id: 3387
+title: "standalone: NESTED async generators with for-await bodies leak the host buffer — close the nested-vs-module-scope drivability gap (~577 for-await-of rows)"
+status: ready
+sprint: current
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+horizon: l
+feasibility: hard
+model: opus
+reasoning_effort: high
+task_type: feature
+area: codegen, standalone
+language_feature: async-generators, for-await-of, destructuring
+goal: standalone-mode
+umbrella: 3178
+related: [3132, 3228, 2906, 2865, 2895, 3388, 3389]
+origin: "2026-07-17 fable-3178 umbrella decomposition — the for-await-of cohort of the standalone host_import_leak baseline; probe matrix isolated NESTING as the gate."
+---
+
+# #3387 — nested async-gen for-await bodies: close the drivability seam
+
+## Problem
+
+577 official-scope `host_import_leak` rows in
+`test/language/statements/for-await-of/` (measured 2026-07-17, promoted
+standalone baseline). Prefixes: `async-gen-dstr-{const,var,let}[-async]`
+(86×3 + 59×3), `async-gen-decl-dstr-array*` (67), `async-gen-decl-dstr` (64).
+Template shape:
+
+```js
+var callCount = 0;
+async function* fn() {
+  for await (const [x = 23] of [[undefined]]) { /* asserts */ callCount += 1; }
+}
+fn().next().then(...).then($DONE, $DONE);
+```
+
+Dominant combos:
+`Promise_reject,Promise_resolve,Promise_then2,__create_async_generator,__gen_create_buffer,__gen_next,__get_caught_exception` (384)
+and the same without `Promise_*` (121).
+
+## The decisive probe matrix (2026-07-17, current main)
+
+| shape                                                         | module scope | wrapped in `export function test(){}` |
+| ------------------------------------------------------------- | ------------ | ------------------------------------- |
+| `async function* fn() { for await (const [x] of [[1]]) {…} }` | HOST-FREE    | **LEAKS**                             |
+| same, non-capturing (no outer binding touched)                | HOST-FREE    | **LEAKS**                             |
+| `async function* g() { yield 1; }` (plain yield, capturing)   | HOST-FREE    | HOST-FREE                             |
+
+**Nesting — not capture — is the gate.** Every test262 file compiles inside the
+runner's `export function test(){}` wrapper, so the whole cohort rides this one
+seam. The same seam also gates `yield*` (#3388) and `return` (#3389); this
+issue owns the SEAM ROOT-CAUSE + the for-await shape, and its findings must be
+written back to umbrella #3178 for the sibling issues.
+
+## Root cause (verified gates)
+
+The NESTED-declaration lane routes through:
+
+- `src/codegen/statements/nested-declarations.ts:678` and `:1104` —
+  `isGenerator && isAsync && isAsyncGenDriveCandidate(ctx, stmt)` →
+  `emitAsyncGenerator`, else the legacy `__create_async_generator` buffer.
+- `isAsyncGenDriveCandidate` (`src/codegen/async-frame.ts:2073`):
+  under the carrier → `asyncGenDrivableUnderCarrier` (async-frame.ts:2062)
+  → `isBoundedAsyncGenBody` → `analyzeAsyncGen` (`src/codegen/async-cps.ts:2240`);
+  carrier off → `isAwaitFreeAsyncGenBody` (same analyzer).
+- `analyzeAsyncGen` REJECTS a for-await statement: it is a lead statement and
+  `containsAwaitOrYield(st)` (async-cps.ts:~2310) returns null → non-drivable
+  → legacy buffer. A non-drivable gen also sets
+  `moduleHasNonDrivableAsyncGen` (import-collector.ts:1047-1074), turning the
+  module's native `$Promise` carrier OFF → the `Promise_*` co-leak in the
+  384-row combo.
+
+Yet at MODULE scope the identical body compiles host-free. **Step 1 of this
+issue is locating and validating that module-scope arm**: candidates are the
+#2906 CFG machinery (`planAsyncCfg` with `allowLoops`, async-cps.ts:1156-1178,
+whose `planForAwaitAsyncCfg`/`planForAwaitCfg` arms already build for-await
+loop CFGs) reached via a lane the nested path never enters. CAUTION: the
+module-scope arm is corpus-UNDER-TESTED (the runner wraps everything), so
+before reusing it, verify its RUNTIME semantics on driven shapes
+(values, completion order, `callCount` visibility) — not just the import set.
+
+## Implementation Plan
+
+1. **Root-cause the seam** (investigation commit, written into this issue +
+   umbrella #3178): instrument/trace which planner admits
+   `async function* fn() { for await … }` at module scope
+   (`declarations.ts` emit path vs `planAsyncCfg(allowLoops)` vs an
+   inline-drive of `fn().next()`), and confirm runtime correctness of that arm
+   with executed probes (`.tmp/`, values asserted). If the module-scope arm is
+   silently WRONG (e.g. sync-driving a genuinely-async source), file that
+   finding immediately — the fix then targets the arm itself first.
+2. **Wire the nested lane to the same machinery.** Preferred shape: extend
+   `analyzeAsyncGen` with a FOR-AWAIT segment kind instead of rejecting it as
+   a lead — embedding the proven `analyzeForAwait` shape
+   (async-cps.ts:1460) as an inner-loop construct of the async-gen CFG:
+   - states: iterator-acquire → step (`await inner.next()`) → binding
+     destructure (sync IteratorBindingInitialization on the settled step value
+     — the #3228 mechanism) → body leads → back-edge; `done` → continue with
+     trailing segments.
+   - frame: reuse `computeForAwaitSpills` (async-frame.ts) for the loop's
+     spill layout inside the async-gen `$AsyncFrame` (#2865 carrier).
+     Because `analyzeAsyncGen` is the SINGLE gate propagated to
+     `isBoundedAsyncGenBody` / `isAwaitFreeAsyncGenBody` /
+     `isAsyncGenDriveCandidate` / `asyncGenDrivableUnderCarrier` /
+     `sourceNeedsGeneratorHostImports` / the import-collector carrier verdict,
+     widening it flips admission, import retirement, AND carrier-on in lockstep
+     — no mirror edits (verify the lockstep with leak probes in a module mixing
+     drivable + newly-admitted gens).
+3. **Sources to admit in slice 1** (correct-or-legacy): array-literal source
+   (the corpus shape `of [[undefined]]`), identifier-held driven async-gen
+   source, sync-iterable identifier (through the existing
+   AsyncFromSync-equivalent arm in `planForAwaitAsyncCfg`). Keep bailed:
+   `yield` inside the dstr initializer (`*-elem-init-yield-expr` files —
+   needs expression-level suspend numbering, note residual), `await` in the
+   source expression.
+4. **Binding forms**: `const`/`let`/`var` × array/object patterns with
+   defaults ride the SYNC destructure once the step value is settled — reuse
+   the #3228 IteratorBindingInitialization path verbatim; do not re-implement.
+
+## Edge cases
+
+- Abrupt inner `next()` rejection → the driven `next()` promise rejects; the
+  for-await must run IteratorClose per §14.7.5.
+- Loop body throw → same close path; `finally` interaction stays bailed if the
+  body contains try/finally across the await (note residual).
+- `moduleHasNonDrivableAsyncGen` flip: a module where SOME gen stays
+  non-drivable must keep carrier-off behavior for ALL (the #3132 mix-safety
+  invariant) — pre-pass ⊆ emit must hold after the widen.
+
+## Test plan
+
+- Executed (not just leak) probes for: values yielded, `callCount` visibility,
+  completion ordering vs V8, all under the test262 WRAPPER shape.
+- Construct-sampled corpus flip on the 577-file cohort; zero pass→fail on the
+  adjacent for-await non-dstr + async-function scans.
+- `prove-emit-identity` on gc/host lane; standalone floor via merge_group.
+
+## Regression risks
+
+- The carrier verdict is module-wide: a bug in the widened analyzer can flip a
+  previously-host-pipeline module onto the carrier with a legacy-buffer gen
+  still inside (invalid mix). The #3132 S2 lockstep tests are the template.
+- Do not touch `wrapAsyncCallInTryCatch` host-lane arms; standalone arm only.

--- a/plan/issues/3388-standalone-asyncgen-yieldstar-delegation.md
+++ b/plan/issues/3388-standalone-asyncgen-yieldstar-delegation.md
@@ -1,0 +1,131 @@
+---
+id: 3388
+title: "standalone: async-gen `yield*` over non-literal sources in NESTED/method producers — runtime delegation with §27.6.3.7 GetIterator error semantics (~600 rows)"
+status: ready
+sprint: current
+created: 2026-07-17
+updated: 2026-07-17
+priority: high
+horizon: l
+feasibility: hard
+model: opus
+reasoning_effort: high
+task_type: feature
+area: codegen, standalone
+language_feature: async-generators, yield-star, iterator-protocol
+goal: standalone-mode
+umbrella: 3178
+related: [3132, 3387, 3389, 2906, 2865, 3075]
+origin: "2026-07-17 fable-3178 umbrella decomposition — the yield-star cohort of the standalone host_import_leak baseline (#3132 S3, re-grounded with the nesting-seam finding)."
+---
+
+# #3388 — async-gen `yield*` delegation for nested + method producers
+
+## Problem
+
+~600 official-scope `host_import_leak` rows carry `__gen_yield_star`
+(917 total across combos; the pure combo
+`__create_async_generator,__gen_create_buffer,__gen_next,__gen_yield_star,__get_caught_exception`
+alone is 544). Concentrated in:
+
+- `{expressions,statements}/class/elements` — `yield-star-getiter-*`,
+  `yield-star-next-*` private/RS async-gen METHOD files (200-row combo),
+- `{expressions,statements}/class/async-gen-method[-static]` (~262 across
+  combos — `yield-star-getiter-sync-not-callable-*-throw`, abrupt-path tests),
+- `expressions/object/method-definition` (~65).
+
+These are the #3132 S3 banked slice, re-grounded: #3132 closed after S1
+(array-literal unroll) + S2 (methods receiver-threading); general `yield*`
+never landed for the shapes below.
+
+## Probe matrix (2026-07-17, current main, `--target standalone`)
+
+| shape                                                    | module scope | wrapped / method    |
+| -------------------------------------------------------- | ------------ | ------------------- |
+| `async function* g() { yield* arr; }` (array ident)      | HOST-FREE    | **LEAKS** (wrapped) |
+| `async function* g() { yield* customAsyncIterableObj; }` | HOST-FREE    | **LEAKS** (wrapped) |
+| class `async *m() { yield* … }` (the corpus files)       | —            | **LEAKS**           |
+
+Same seam as #3387: `analyzeAsyncGen` (`src/codegen/async-cps.ts:2240`)
+returns null for any `yield*` whose operand is not an ARRAY LITERAL
+(the S1 gate at ~2266: `if (!ts.isArrayLiteralExpression(src)) return null`),
+and the nested-declaration / class-method / object-literal lanes
+(`nested-declarations.ts:678/:1104`, `class-bodies.ts:2354` region,
+`literals.ts:2974-2982`) all consult that analyzer via
+`isAsyncGenDriveCandidate` (async-frame.ts:2073). At module scope some OTHER
+arm admits these host-free — #3387 step 1 locates and validates that arm;
+coordinate with whoever lands #3387 first and reuse the documented finding
+from umbrella #3178.
+
+## Implementation Plan
+
+### Slice 1 — runtime delegation loop (the #3132 S3 design, now actionable)
+
+Extend `analyzeAsyncGen` with a DELEGATION segment kind for `yield* <expr>`
+over an arbitrary operand (identifier, call, member, string), lowered as a
+runtime CFG loop — the producer-side DUAL of the `planForAwaitAsyncCfg`
+consumer (async-cps.ts:1907):
+
+- **head state**: evaluate operand once; GetIterator per §27.6.3.7 —
+  try `Symbol.asyncIterator`, fall back to `Symbol.iterator` wrapped in the
+  AsyncFromSync equivalent (reuse the existing consumer machinery in
+  `iterator-native.ts` — the ITER_KIND dispatch — rather than a parallel
+  GetIterator).
+- **loop**: `inner.next()` → await (carrier `$Promise` assimilation, #2865) →
+  read `{done, value}` from the `$IteratorResult` struct → if `done` exit with
+  the result VALUE as the yield\*'s completion value → else `settleYield value`
+  (the outer's pending `next()` promise fulfills `{value, done:false}`) →
+  back-edge on outer resume.
+- Slice 1 forwards `next()` only. Outer `.return()`/`.throw()` forwarding into
+  the delegate (§27.6.3.7 steps 7.b/7.c) is #3389's completion machinery —
+  keep those legacy where they cannot be expressed (correct-or-legacy), but
+  note that many corpus files here only need the GetIterator ERROR paths (see
+  edge cases), which slice 1 fully covers.
+
+### Slice 2 — the method lanes
+
+The class-method (`class-bodies.ts`, after the #3132 S2 receiver-threading
+gate) and object-literal (`literals.ts:2974`) lanes admit the widened bodies
+automatically once `analyzeAsyncGen` accepts them — the gate is shared. Verify
+the S2 exclusions (super/arguments/static-this, `methodBodyRefsShadowedOuterLocal`
+#3312 guard, stem dedup) still bail correctly, and run the private-name RS
+file family (`same-line-async-gen-rs-*`) — several are already host-free on
+main, so measure-first to avoid re-fixing landed rows (the promoted baseline
+lags; see #3380).
+
+## Edge cases (these ARE the corpus tests)
+
+- `GetMethod(obj, @@asyncIterator)` returns null/undefined → fall to sync;
+  both absent → TypeError at delegation start (getiter-\*-not-callable files:
+  boolean/number/string/symbol/object variants).
+- `@@asyncIterator` getter throws → propagate (getiter-\*-get-abrupt).
+- iterator object not an object / `next` not callable → TypeError
+  (yield-star-next-not-callable-\*).
+- `next()` result not an object / `done`/`value` getter throws → propagate
+  (next-call-{done,value}-get-abrupt, next-call-returns-abrupt).
+- All of these must surface through the OUTER driven `next()` promise
+  REJECTION (the native `__exn` tag path, `ensureExnTag` in
+  `src/codegen/registry/imports.ts`) — never a trap.
+- The implicit-await distinction (#3120): delegation does NOT re-await inner
+  values on the modeled lane — keep the S1 mode routing
+  (`yieldOperandIsPromiseTyped`) consistent.
+
+## Test plan
+
+- Executed probes (wrapped shape) for: value forwarding order, done-value as
+  completion value, each abrupt GetIterator path asserting TypeError delivery
+  via rejection.
+- Construct-sample the `yield-star-*` file family across
+  class/elements + async-gen-method dirs; zero pass→fail on the #3132 S1/S2
+  suites (`tests/issue-3132*.test.ts`) and the driven-consumer scans.
+- Mix-safety: module with one delegating gen + one legacy-only gen keeps
+  carrier off coherently (pre-pass ⊆ emit).
+
+## Regression risks
+
+- The delegation loop shares frame/state numbering with #3387's for-await
+  states — if both land concurrently, coordinate the CFG segment-kind
+  enum/state-allocation in `analyzeAsyncGen` (same function, guaranteed
+  conflict; sequence the PRs, second re-merges first).
+- `__gen_yield_star` import retirement must not orphan the HOST-lane eager
+  buffer which still uses it (host lane byte-identical — SHA probe).

--- a/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
+++ b/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
@@ -1,0 +1,125 @@
+---
+id: 3389
+title: "standalone: `return` completion in driven async-gen bodies (settleReturn terminator) + AsyncGeneratorPrototype.return/.throw residual (~300 rows)"
+status: ready
+sprint: current
+created: 2026-07-17
+updated: 2026-07-17
+priority: medium
+horizon: m
+feasibility: hard
+model: opus
+reasoning_effort: high
+task_type: feature
+area: codegen, standalone
+language_feature: async-generators
+goal: standalone-mode
+umbrella: 3178
+related: [3132, 3387, 3388, 2865, 2906]
+origin: "2026-07-17 fable-3178 umbrella decomposition — #3132 S4 banked slice, re-grounded: __gen_set_return 268 / __gen_return (async combos) / __gen_throw 80 rows."
+---
+
+# #3389 — async-gen `return`/`throw` completion for the driven lane
+
+## Problem
+
+Async-gen bodies containing an own-scope `return` are non-drivable, so they
+fall to the legacy host buffer (and force the module's carrier OFF — the
+`Promise_*` co-leak). Measured 2026-07-17: `__gen_set_return` appears in 268
+official-scope leak rows, `__gen_throw` in 80; the class/elements 126-row combo
+(`…__gen_result_*,__gen_set_return,__get_caught_exception` + `Promise_*`) and
+the corpus `has-return` decomposition (#3132: 172 method + 5 fn files) are the
+targets, plus `built-ins/AsyncGeneratorPrototype/{return,throw}` (14+11 rows).
+
+Probe matrix (2026-07-17): `async function* g() { yield 1; return 42; }` is
+HOST-FREE at module scope but **LEAKS**
+(`__gen_set_return,__gen_push_f64,__create_async_generator,…`) when wrapped in
+the test262 `export function test(){}` wrapper — the same nesting seam as
+#3387/#3388 (all corpus files are wrapped).
+
+## Root cause
+
+- `analyzeAsyncGen` (`src/codegen/async-cps.ts:2240`) rejects any lead
+  statement containing an own-scope `return`: `containsOwnScopeReturn`
+  (async-cps.ts:2118, applied at ~2311). The doc comment on it names the gap:
+  a lead `return v` would settle the pending `next()` promise with the RAW
+  value via the `asyncDriveReturn` hook instead of the §27.6-required
+  IteratorResult `{value, done: true}` — "bodies with returns stay on the
+  legacy path until a settleReturn terminator exists (3d-iii)".
+- The async-gen CFG has only `settleUndefined` (fall-through ⇒
+  `{value: undefined, done: true}`) and `settleYield` terminators.
+
+## Implementation Plan
+
+### Slice 1 — `settleReturn` terminator (top-level `return E`)
+
+**Files: `src/codegen/async-cps.ts` (analyzer + CFG plan),
+`src/codegen/async-frame.ts` (emitters).**
+
+1. Admit a top-level `return E` / bare `return` in `analyzeAsyncGen`: a
+   trailing tail segment, or a mid-body return that terminates the CFG (a
+   `return` after which no further segments execute). Relax
+   `containsOwnScopeReturn` only for DIRECT top-level return statements —
+   returns nested in control flow stay bailed (correct-or-legacy) until the
+   general CFG generalization.
+2. Add a `settleReturn(E)` CFG terminator + emitter: evaluate `E` in the
+   resume scope, settle the frame's pending result promise with the
+   IteratorResult struct `{value: E, done: true}` (§27.6.3.8
+   AsyncGeneratorCompleteStep with a return completion — NOT the same as
+   fall-through, which must keep `value: undefined`). Mint the
+   `$IteratorResult` via the same struct the `settleYield` emitter uses.
+   Subsequent `next()` calls on a completed frame return
+   `{value: undefined, done: true}` — verify the frame's done-state guard
+   already does this (the state machine's terminal state).
+3. `return E` where `E` is Promise-typed: §27.6.3.8 awaits the return value
+   under a return completion. On the carrier lane assimilate the native
+   `$Promise` before settling (reuse the awaited-yield assimilation arm);
+   carrier-off lane: keep Promise-typed `E` bailed (same policy as
+   `yield await` — correct-or-legacy).
+4. Lockstep is automatic through the single analyzer
+   (`isBoundedAsyncGenBody`/`isAsyncGenDriveCandidate`/import-collector) —
+   verify with wrapped leak probes and a mixed-module carrier probe.
+
+### Slice 2 — consumer `.return()` / `.throw()` on DRIVEN frames
+
+`AsyncGeneratorPrototype/{return,throw}` rows (25) + `__gen_throw` combos:
+the driven frame's `.return(v)`/`.throw(e)` methods must:
+
+- `.return(v)`: if suspended-at-yield → settle `{value: v, done: true}` and
+  mark the frame done (no finally support in slice 2 — bodies with
+  try/finally across a yield stay legacy); if completed → same result promise.
+- `.throw(e)`: if suspended-at-yield → reject the pending promise with `e`
+  and complete the frame; if completed → rejected promise per §27.6.3.9.
+- Wire through the SAME dispatch registry the `.next()` driver uses
+  (`__async_gen_next_<stem>`, `ctx.asyncGenProducers`) — add
+  `__async_gen_return_<stem>`/`__async_gen_throw_<stem>` siblings, or a
+  completion-kind param on the existing driver (prefer the param — one
+  function, no registry key churn; check `resolveAsyncGenNextHelperName`
+  (#3001) consumers for where the dispatch happens).
+
+## Edge cases
+
+- `return` inside try/finally must run the finally on the return path — OUT
+  of scope for both slices (stay bailed; note residual count).
+- Distinguish body fall-through (`value: undefined`) from `return;`
+  (also `value: undefined` but via return completion — observable only with
+  finally, so slice 1 treats them identically; document this).
+- yield\* interaction (delegate return forwarding, §27.6.3.7 step 7.b) belongs
+  to #3388/#3389 jointly — only needed once BOTH land; keep bailed with a
+  cross-reference note.
+
+## Test plan
+
+- Executed wrapped probes: `{value: 42, done: true}` on the settling `next()`,
+  subsequent `next()` gives undefined/done, `.return`/`.throw` on suspended
+  and completed frames, rejection identity.
+- Construct-sample the `has-return` method corpus + AsyncGeneratorPrototype
+  return/throw dirs; zero pass→fail on issue-3132\* suites.
+- Host lane SHA-identical.
+
+## Regression risks
+
+- Same `analyzeAsyncGen` conflict surface as #3387/#3388 — sequence PRs.
+- The driver-signature change (completion-kind param) touches every driven
+  consumer call site — grep `__async_gen_next_` emitters before choosing the
+  param vs sibling-function shape.

--- a/plan/issues/3390-standalone-promise-combinator-receivers.md
+++ b/plan/issues/3390-standalone-promise-combinator-receivers.md
@@ -1,0 +1,119 @@
+---
+id: 3390
+title: "standalone: Promise combinators with non-Promise receivers — `Promise.all.call(nonCtor)` TypeError + custom-constructor admission (~119 rows)"
+status: ready
+sprint: current
+created: 2026-07-17
+updated: 2026-07-17
+priority: medium
+horizon: m
+feasibility: medium
+model: opus
+reasoning_effort: high
+task_type: feature
+area: codegen, standalone
+language_feature: promises
+goal: standalone-mode
+umbrella: 3178
+related: [2903, 2867, 2919, 2922, 3137]
+origin: "2026-07-17 fable-3178 umbrella decomposition — the Promise built-ins residual of the standalone host_import_leak baseline (S5/S6 leftover after #2903 closed)."
+---
+
+# #3390 — Promise combinator receiver admission
+
+## Problem
+
+119 official-scope `host_import_leak` rows under `built-ins/Promise/`
+(measured 2026-07-17): allSettled 35, all/any 29 each, race 19, prototype 7.
+Combos: `Promise_allSettled,__js_array_new,__js_array_push` (22),
+`Promise_all,__js_array_new,__js_array_push` (15), bare `Promise_all` (5), etc.
+File families: `ctx-non-ctor`, `ctx-ctor[-throws]`, `species-get-error`,
+`invoke-resolve-on-{values,promises}-*`, `resolve-from-same-thenable`,
+`call-resolve-*`, `resolve-element-function-*` variants.
+
+Probe (2026-07-17, current main): `Promise.all.call(F, [])` with a
+non-constructor `F` leaks `env::Promise_all`. Direct
+`Promise.all([...])` / `.race` / `.allSettled` / `.any` are native and
+host-free (#2867/#2919/#2922/#3137) — the gap is exactly the RECEIVER-generic
+`.call` path.
+
+## Root cause
+
+`emitStandalonePromiseCombinator` (`src/codegen/promise-combinators.ts:799`)
+serves the direct `Promise.<method>(iter)` form. The `.call(receiver, iter)`
+form routes through the host-import fallback in
+`src/codegen/expressions/calls.ts` — a partial scanner already exists there
+(~lines 2402–2550: "does a non-Promise constructor flow to
+`Promise.{all,allSettled,race,any}.call(Constructor, …)`" + the comment at
+~2550 noting `Promise.all.call(MyPromise, iter)` then throws on the host
+shim). The native path never admits `.call` receivers, so every `ctx-*` /
+species test leaks.
+
+## Implementation Plan
+
+Measure-first: many `resolve-element-function-*` rows are already host-free on
+current main (probe confirmed one; the promoted baseline lags — #3380).
+Re-probe the 119 files and split actual-residual vs stale before slicing.
+
+### Slice 1 — provably-non-constructor receiver → native TypeError (cheap)
+
+Per §27.2.4.1 step 2 (NewPromiseCapability → IsConstructor check), a
+non-constructor receiver must throw TypeError BEFORE touching the iterable.
+In `calls.ts`, at the `Promise.<combinator>.call(recv, …)` site: when the
+static verdict on `recv` is "not a constructor" (arrow fn, plain object,
+primitive, undefined — reuse the existing scanner's classification at
+~2439–2462), emit the native TypeError throw (the same `__exn`-tag TypeError
+pattern `emitStandalonePromiseCombinatorRuntime` uses for non-iterable args —
+see calls.ts:7821 comment) instead of the `Promise_<method>` host import.
+This covers the `ctx-non-ctor` / `ctx-ctor-throws`-adjacent families.
+Note: evaluation ORDER — the receiver check precedes iterable evaluation;
+arguments still need their side effects evaluated per spec order (receiver is
+already evaluated by then; the iterable must NOT be iterated).
+
+### Slice 2 — `Promise`-receiver `.call` → route to the native combinator
+
+`Promise.all.call(Promise, iter)` is semantically the direct form: when the
+receiver is provably the global `Promise` identifier, route into
+`emitStandalonePromiseCombinator` (same arg lowering via
+`resolveExternrefVecArg`, promise-combinators.ts:896). Covers the
+`call-resolve-*` files that use the plain receiver.
+
+### Slice 3 — custom-constructor receivers (species machinery) — MEASURE FIRST
+
+The `invoke-resolve-on-*` / `species-get-error` / subclass families need the
+real NewPromiseCapability protocol: call `recv` as a constructor with an
+executor, look up `recv.resolve` per iteration, count invocations. This is a
+substantially bigger lift (dynamic constructor invocation + per-iteration
+`resolve` lookup on an arbitrary object). Only build it if the re-probe shows
+the row count justifies it; otherwise leave those rows as honest
+`host_import_leak` CEs and record the residual in umbrella #3178. A middle
+path: admit receivers that are STATICALLY `class X extends Promise` with no
+own `resolve`/`Symbol.species` override — the capability then degenerates to
+the native `$Promise` path with the subclass prototype (check what the
+object-runtime prototype machinery supports before promising this).
+
+## Edge cases
+
+- `Promise.all.call()` (no receiver) → undefined receiver → TypeError.
+- Receiver constructor that THROWS when invoked (`ctx-ctor-throws`) → only
+  covered by slice 3; keep leak/legacy meanwhile.
+- Do not regress the direct-form native combinators: the `.call` dispatch must
+  not intercept the plain `Promise.all(iter)` route.
+- `Promise.resolve.call` / `Promise.reject.call` are NOT combinators — out of
+  scope (different family; note if the re-probe shows rows there).
+
+## Test plan
+
+- Executed probes: TypeError identity + message-class for slice 1 shapes;
+  value/order parity for slice 2 vs direct form.
+- Construct-sample the 4 combinator dirs; equivalence suite
+  `tests/issue-3390.test.ts`.
+- Host lane byte-identical (the `.call` scanner change must gate on
+  standalone/wasi).
+
+## Regression risks
+
+- The existing calls.ts scanner (~2402–2550) feeds OTHER decisions (host-shim
+  admission); read its consumers before repurposing its classification.
+- TypeError-before-iteration ordering is observable (poisoned iterables) —
+  the corpus tests it; get the order right in slice 1.

--- a/plan/issues/3391-standalone-gen-host-import-retirement-assert.md
+++ b/plan/issues/3391-standalone-gen-host-import-retirement-assert.md
@@ -1,0 +1,91 @@
+---
+id: 3391
+title: "standalone: S7 mechanical — assert-zero `__gen_*`/`__get_caught_exception` registration + eager-buffer dead-path accounting (umbrella #3178 closeout)"
+status: ready
+sprint: current
+created: 2026-07-17
+updated: 2026-07-17
+priority: low
+horizon: s
+feasibility: medium
+model: opus
+reasoning_effort: medium
+task_type: refactor
+area: codegen, standalone, ci
+language_feature: generators, async-generators
+goal: standalone-mode
+umbrella: 3178
+related: [3386, 3387, 3388, 3389, 2961, 2097]
+depends_on: [3386, 3387, 3388, 3389]
+origin: "2026-07-17 fable-3178 umbrella decomposition — the S7 'fold into the last slice' step, made explicit now that S1/S2 closed without it."
+---
+
+# #3391 — S7: retirement assert + accounting (LAST child, after #3386–#3389)
+
+## Problem
+
+Umbrella #3178's S7 was "fold the `__get_caught_exception`
+zero-registration assert + eager-buffer code deletion into the LAST of S1/S2
+to land" — but #3164 and #3132 both closed without it. This issue makes S7 an
+explicit, dispatchable closeout child. It has ~0 direct row yield; its value
+is (a) ratcheting the win so the generator host bundle can never silently
+return to the standalone lane, and (b) the umbrella's acceptance measurement.
+
+## Preconditions
+
+#3386–#3389 landed (or explicitly re-scoped). Before starting, re-measure the
+family residual from a FRESH promoted standalone baseline
+(`node scripts/fetch-baseline-jsonl.mjs --standalone`, aggregate
+`error_category === "host_import_leak"` rows by import — the umbrella's
+acceptance is each of `__create_generator` / `__create_async_generator` /
+`__make_callback` / `__get_caught_exception` under 100 official-scope rows;
+`__make_callback` is already at 0 as of 2026-07-17). Mind #3380: the promoted
+baseline can lag main by hours-to-a-day — verify the baseline commit
+timestamp postdates the last child's merge.
+
+## Implementation Plan
+
+1. **Registration-site ratchet.** The gen host bundle registers in
+   `src/codegen/registry/imports.ts` (~1988–2020, the function guarded by
+   `ctx.funcMap.has("__gen_create_buffer")`; standalone/wasi early-return at
+   ~1990 unless `options?.allowNoJsHost`). Add a standalone-lane assertion
+   counter: when `(ctx.standalone || ctx.wasi)` and the bundle registers via
+   the `allowNoJsHost` escape, record the reason
+   (`ctx.fallbackTelemetry`-style, see `src/codegen/fallback-telemetry.ts`).
+   Then add a scripts-level check (pattern: `scripts/check-standalone-highwater.mjs`)
+   that compiles a small FIXED probe corpus (the wrapped shapes from
+   #3386–#3389's test files) and fails CI if any probe registers the bundle.
+   Do NOT gate on the full test262 corpus in PR CI (cost); the merge_group
+   standalone floor (#2097) remains the corpus-level ratchet.
+2. **Dead-arm audit, not blind deletion.** The eager-buffer emit sites
+   (`class-bodies.ts` legacy arm at ~3035–3038, `literals.ts`,
+   `nested-declarations.ts` legacy arms, the `__gen_*` emitters in
+   `generators-native.ts`/`runtime.ts`) remain LIVE for the JS-host lane and
+   for still-bailed standalone shapes (object-rest patterns, try/finally
+   returns, dynamic-import chains). Audit which arms are provably unreachable
+   under `standalone && !allowNoJsHost` and delete ONLY those; each deletion
+   must keep the host lane byte-identical (SHA probe) — this is the #2662/#3032
+   W6 boundary: host-lane eager-buffer retirement is NOT this issue.
+3. **`__get_caught_exception` per-site check.** Its two sources: the gen
+   bundle (dies with it) and the host-lane async wrap
+   (`wrapAsyncCallInTryCatch`, `src/codegen/expressions.ts` — the standalone
+   arm at ~516 already avoids it). Grep for any remaining standalone-reachable
+   emission; add the import name to the standalone-refusal set if fully dead.
+4. **Umbrella acceptance write-back.** Update #3178 with the final measured
+   table (per-import residual, host_free_pass count) and flip it to done if
+   the acceptance bars hold (<100 rows per family import; host_free_pass ≥
+   24,500 — already 24,949 on 2026-07-17, so this bar re-verifies trivially).
+
+## Test plan
+
+- The fixed probe corpus compiles standalone with zero family imports and
+  instantiates with `{}` imports.
+- Full-repo: `prove-emit-identity` host lane; standalone floor in merge_group.
+- The new CI check fails when a probe is deliberately broken (self-test).
+
+## Regression risks
+
+- Over-deletion: a standalone shape still legitimately on the legacy path
+  (correct-or-legacy residuals listed in #3386–#3390) must keep a VALID module
+  — deleting its import registration while its emit arm survives bakes
+  undefined funcIdx. The audit order is: telemetry first, delete second.


### PR DESCRIPTION
Plan-only PR — no compiler code changes.

## What

Decomposes umbrella **#3178** (retire the generator/async/Promise host machinery for standalone) into six independently-landable, Opus-actionable child issues, each with a complete `## Implementation Plan` (exact file:line gates, codegen patterns, edge cases, test plan, regression risks):

| Child | Scope | Rows |
| --- | --- | ---: |
| #3386 | sync-gen destructuring-pattern params (fn-expr gate, element defaults, untyped array patterns via native iterator protocol, methods) | ~1,860 |
| #3387 | NESTED async-gens with for-await bodies — nested-vs-module-scope drivability seam (owns the seam root-cause) | ~577 |
| #3388 | async-gen general `yield*` runtime delegation (#3132 S3 re-grounded) | ~600 |
| #3389 | async-gen `return`/`throw` completion — settleReturn terminator (#3132 S4 re-grounded) | ~300 |
| #3390 | Promise combinators with non-Promise receivers | ~119 |
| #3391 | S7 mechanical closeout: registration assert + acceptance measurement | 0 |

## Grounding

- Fresh measurement from the 2026-07-17 promoted `test262-standalone-current.jsonl`: post-#2961 there are no leaky passes — the family scope is now **4,410 official-scope `host_import_leak` CE rows**. `__make_callback` is fully retired (0 rows); host_free_pass = 24,949 (the umbrella's ≥24,500 bar is met).
- Live compile probes on current main isolated the load-bearing finding: for-await bodies, general `yield*`, and `return` completion in async gens are all HOST-FREE at module scope but LEAK when nested — and the test262 runner wraps every file in `export function test(){}`, so the whole async-gen residual rides the nested-declaration lane seam (`isAsyncGenDriveCandidate` → `analyzeAsyncGen` bounded shape).
- Does not duplicate in-flight #2865/#2895/#2570/#2662 — children are admission-gate widenings on the machinery those issues built.

Child ids allocated via `claim-issue.mjs --allocate` (3386–3391).

🤖 Generated with [Claude Code](https://claude.com/claude-code)