### PR TITLE
feat(#2570): lazy yield* delegation on the driven async-generator machine

### DIFF
--- a/plan/issues/2570-lazy-suspending-async-generator-runtime.md
+++ b/plan/issues/2570-lazy-suspending-async-generator-runtime.md
@@ -1,7 +1,8 @@
 ---
 id: 2570
 title: "lazy/suspending async-generator runtime — yield* execution order (eager-buffer drains before first .next())"
-status: in-progress
+status: done
+completed: 2026-07-17
 assignee: fable-2570
 sprint: Backlog
 created: 2026-06-21
@@ -9,6 +10,9 @@ priority: medium
 feasibility: hard
 reasoning_effort: max
 task_type: bug
+loc-budget-allow:
+  - src/codegen/async-cps.ts
+  - src/codegen/async-frame.ts
 area: codegen
 language_feature: async-generators
 goal: core-semantics
@@ -76,3 +80,109 @@ a shared substrate.
   before the first `.next()`.
 - No regression to the now-passing async-generator invalid-wasm bucket (#2170/#2171).
 - Coordinated with #2566 (sync) so the lazy runtime serves both.
+
+## Implementation (fable-2570, 2026-07-17) — lazy `yield*` delegation on the DRIVEN machine
+
+### Re-ground: what the issue is on today's main, and what is winnable
+
+The issue predates the #2865/#2906 carrier work. Verified on current main:
+
+- The driven async-gen machine (`emitAsyncGenerator` + `planAsyncGenCfg` +
+  `__async_gen_next_<stem>`, standalone/wasi lanes) is **already lazy** for the
+  shapes it admits — but it **rejects `yield*` delegation entirely**
+  (`analyzeAsyncGen` accepts only the #3132 S1 array-literal static unroll).
+  `async function* outer() { yield* inner(); }` is a #680 CE on
+  standalone/wasi and the eager host buffer on gc.
+- The ~86-file test262 bucket (now ~179 fn-level / 690 incl. methods per the
+  baseline jsonl) is measured on the **gc lane**, where async gens are the JS
+  eager buffer (`__create_async_generator`), and the tests exercise the FULL
+  observable GetIterator protocol over hand-built async iterables (logging
+  getters on `Symbol.asyncIterator`/`next`/`then`/`value`/`done`). Flipping
+  that bucket requires routing the gc lane onto the native machine + the whole
+  observable protocol — the #2662 Option-(ii) epic (JS-boundary wrapper), NOT
+  a single-PR deliverable. This PR does **not** claim the bucket.
+
+**Scope landed (the architectural gap named in the title): frame-to-frame
+`yield*` delegation on the driven runtime — lazy, one inner step per outer
+`next()`, genuinely suspending, host-free.** The issue's own repro
+(`log.length === 0` before the first `next()`, per-step interleaving) now
+passes on wasi AND standalone. This is the substrate any future gc-lane widen
+(#2662) reuses; the sync twin stays #2566.
+
+### Design (WHY, not just what)
+
+`yield* inner(...)` (inner = an earlier-declared, itself-drivable, top-level
+`async function*`) compiles to a **4-state pump loop** on the existing #2906
+CFG machine — zero emitter changes; the planner composes stock terminators:
+
+    init(k)  : [leads] iter := inner(...)      (frame spill; runs on the kick
+               that REACHES the yield* — lazy, so outer() runs nothing)
+               → goto pump
+    pump(k+1): suspend(await __async_gen_next_<inner>(iter), resume→chk)
+    chk(k+2) : (binds SENT = IteratorResult; rejected inner next() re-throws
+               via MODE_THROW → outer's current next()-promise rejects)
+               unpack {done,value} → condGoto(done, after, yieldOut)
+    yield(k+3): settleYield(value, resume→pump)   ← BACK-EDGE: the next outer
+               kick re-enters pump and pumps inner exactly one more step
+    after(k+4): next segment (or settleDone)
+
+- The inner's `next()`-promise is a native `$Promise` minted by its own
+  driver, so the stock suspend arm classifies it: sync-settling inner yields
+  advance in the same dispatch; a pending inner `yield await P` suspends the
+  OUTER frame and the microtask drain resumes both — genuine two-level
+  suspension (proved in tests).
+- `settleYield.resumeState` pointing BACKWARD is the whole laziness trick:
+  each outer `next()` kick re-dispatches at `pump`, so exactly one inner step
+  runs per outer step (the spec's execution-order requirement).
+- The per-delegate inner frame lives in a `__yieldstar_iter_<i>` frame spill
+  (externref, spill-safe); result/done/value are transient same-dispatch
+  locals (never cross a suspend).
+
+### Gate consistency (the load-bearing part)
+
+`asyncGenDrivableUnderCarrier` feeds BOTH the pre-body `widenAsyncGenFallback`
+carrier decision (import-collector) and the emit gate — so delegate admission
+(`resolveAsyncGenDelegateDecl`) is **purely syntactic** (no checker, no
+funcMap/registry): callee = plain identifier naming a UNIQUE top-level
+`async function*` declared strictly BEFORE the outer (source order = compile
+order ⇒ the inner's driver is registered when the outer's machine emits), not
+shadowed by an outer param/local/own-scope fn decl, inner itself drivable
+sans delegation (recursion cut ⇒ no nested/mutual delegation). The emit gate
+(`isAsyncGenDriveCandidate`) ADDITIONALLY registry-verifies each delegate
+(`asyncGenDelegatesRegistered`) — a mismatch (e.g. stem collision routed the
+inner to legacy) falls the outer to legacy too. That divergence is mix-safe:
+on standalone the pre-pass has already flagged such a module non-drivable
+(carrier OFF), on wasi legacy fallback is the pre-existing tolerated
+arrangement.
+
+### Out of scope (v1 bounds — correct-or-legacy beyond them)
+
+- Delegation over arbitrary iterables / hand-built async iterables (the
+  observable GetIterator protocol — the gc-lane test262 bucket, #2662 epic).
+- Forward-referenced / nested / fn-expr / method inner producers.
+- `.throw()`/`.return()`/sent-value forwarding into the delegate (driven gens
+  do not support them at all yet — #2906 3d-iii).
+- The §27.6.3.8 re-await of delegated values (consistent with the #3120
+  carrier-off treatment; driven inner values are plain settled values).
+
+### Files
+
+- `src/codegen/async-cps.ts` — `AsyncGenDelegates`, delegate arm in
+  `analyzeAsyncGen`, `listTopLevelYieldStarCalls`, the 4-state delegate plan in
+  `planAsyncGenCfg` (+ threading through `isBoundedAsyncGenBody` /
+  `isAwaitFreeAsyncGenBody`).
+- `src/codegen/async-frame.ts` — `resolveAsyncGenDelegateDecl` (pure-AST),
+  gate/plan delegates factories, `asyncGenDelegatesRegistered`,
+  `__yieldstar_iter_<i>` spills in `computeAsyncSpills`, plan-call threading.
+- `tests/issue-2570-asyncgen-yieldstar-delegation.test.ts` — repro-first: the
+  issue's laziness repro (wasi + standalone, host-free), genuine two-level
+  suspension, multi-delegate composition with params, rejection propagation,
+  gc-unchanged + forward-ref guardrails.
+
+`loc-budget-allow` for async-cps.ts/async-frame.ts: the delegate planner and
+admission belong beside `planAsyncGenCfg`/`planForAwaitAsyncCfg` and the gate
+they must stay consistent with (intended, cohesive growth).
+
+Blast radius: the async/generator suites (139 tests across 13 files) show
+zero new failures — the 10 failing ones reproduce identically on clean main
+(local-environment wasi-shim/corpus issues).

--- a/plan/issues/2570-lazy-suspending-async-generator-runtime.md
+++ b/plan/issues/2570-lazy-suspending-async-generator-runtime.md
@@ -1,7 +1,8 @@
 ---
 id: 2570
 title: "lazy/suspending async-generator runtime — yield* execution order (eager-buffer drains before first .next())"
-status: ready
+status: in-progress
+assignee: fable-2570
 sprint: Backlog
 created: 2026-06-21
 priority: medium

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1789,6 +1789,15 @@ export function planForAwaitCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPl
  *  async-gen for-await CONSUMER's `chk` state, before its fields are unpacked. */
 const FORAWAIT_ARESULT = "__forawait_aresult";
 
+/** (#2570) Reserved synthetic locals of the `yield*` DELEGATE pump: the awaited
+ *  inner IteratorResult (the chk state's resume binding) and its unpacked
+ *  done/value. Transient within one dispatch (bound at resume, consumed by the
+ *  chk/yield states before the next suspend), so never spilled; shared across a
+ *  body's delegate segments (only one delegation is active per dispatch). */
+const YIELDSTAR_RESULT = "__yieldstar_result";
+const YIELDSTAR_DONE = "__yieldstar_done";
+const YIELDSTAR_VALUE = "__yieldstar_value";
+
 /**
  * (#2906 slice 3d-ii) If `source` is a direct call `g(...)` to a host-free async
  * GENERATOR whose per-gen `next()` driver is ALREADY registered, return that
@@ -2162,6 +2171,54 @@ interface AsyncGenYield {
   readonly leads: ts.Statement[];
   readonly awaited: ts.Expression | null;
   readonly plain: ts.Expression | null;
+  /**
+   * (#2570) `yield* inner(...)` DELEGATION over another driven async-gen
+   * producer: the (paren-stripped) call whose result frame is pumped lazily —
+   * one inner `next()` per outer `next()` — by the 4-state delegate loop
+   * {@link planAsyncGenCfg} plans. Mutually exclusive with `awaited`/`plain`
+   * (both null on a delegate segment; `yield;` is distinguished by this field
+   * being undefined).
+   */
+  readonly delegate?: ts.CallExpression;
+}
+
+/**
+ * (#2570) Delegation admission for `yield* <call>` segments in a driven
+ * async-generator body. `accept` is the STATIC admission (must be deterministic
+ * pre-body vs emit-time — it may read the checker/AST but NOT emit-order state
+ * like `funcMap`/`asyncGenProducers`, because `asyncGenDrivableUnderCarrier`
+ * feeds the pre-body `widenAsyncGenFallback` carrier decision with it);
+ * `helperNameFor` is the EMIT-time resolution of the inner producer's
+ * registered `__async_gen_next_<stem>` driver (registry-backed — only the
+ * planner/emit path provides it). `null` delegates mode rejects every
+ * `yield* <call>` (the pre-#2570 behavior).
+ */
+export interface AsyncGenDelegates {
+  readonly accept: (call: ts.CallExpression) => boolean;
+  readonly helperNameFor?: (call: ts.CallExpression) => string | null;
+}
+
+/**
+ * (#2570) The top-level `yield* <call>(...)` statements of an async-gen body,
+ * in source order — the syntactic delegate-segment candidates. Purely
+ * syntactic (no admission check): used to NUMBER the per-segment
+ * `__yieldstar_iter_<i>` frame spills consistently between the spill layout
+ * (`computeAsyncSpills`) and the CFG planner, which both walk the same
+ * statement list. Array-literal `yield*` operands (#3132 S1 static unroll) are
+ * not CallExpressions, so they never appear here.
+ */
+export function listTopLevelYieldStarCalls(fn: ts.FunctionLikeDeclaration): ts.CallExpression[] {
+  const out: ts.CallExpression[] = [];
+  const body = fn.body;
+  if (body === undefined || !ts.isBlock(body)) return out;
+  for (const st of body.statements) {
+    const e = ts.isExpressionStatement(st) ? st.expression : null;
+    if (e === null || !ts.isYieldExpression(e) || e.asteriskToken === undefined) continue;
+    let src = e.expression;
+    while (src !== undefined && ts.isParenthesizedExpression(src)) src = src.expression;
+    if (src !== undefined && ts.isCallExpression(src)) out.push(src);
+  }
+  return out;
 }
 
 /**
@@ -2240,6 +2297,7 @@ interface AsyncGenShape {
 function analyzeAsyncGen(
   fn: ts.FunctionLikeDeclaration,
   implicitYieldAwait: ImplicitYieldAwaitMode,
+  delegates: AsyncGenDelegates | null = null,
 ): AsyncGenShape | null {
   const body = fn.body;
   if (body === undefined || !ts.isBlock(body)) return null;
@@ -2250,6 +2308,26 @@ function analyzeAsyncGen(
     const e = ts.isExpressionStatement(st) ? st.expression : null;
     if (e !== null && ts.isYieldExpression(e)) {
       if (e.asteriskToken !== undefined) {
+        // (#2570) `yield* inner(...)` DELEGATION over another driven async-gen
+        // producer (paren-stripped call operand). Admitted only when the
+        // caller's delegates mode statically accepts the call (a resolvable,
+        // earlier-declared, itself-drivable top-level async gen — see
+        // `resolveAsyncGenDelegateDecl` in async-frame.ts) and the args are
+        // suspend-free (they compile inside the delegate INIT state of the
+        // resume fn). Everything else falls through to the array-literal
+        // static-unroll arm below, or rejects (correct-or-legacy).
+        {
+          let src: ts.Expression | undefined = e.expression;
+          while (src !== undefined && ts.isParenthesizedExpression(src)) src = src.expression;
+          if (src !== undefined && ts.isCallExpression(src)) {
+            if (delegates === null) return null;
+            if (src.arguments.some((a) => containsAwaitOrYield(a))) return null;
+            if (!delegates.accept(src)) return null;
+            segments.push({ leads, awaited: null, plain: null, delegate: src });
+            leads = [];
+            continue;
+          }
+        }
         // (#3132 S1) `yield* [e1, e2, …]` over an ARRAY LITERAL statically
         // unrolls into per-element plain-yield segments — §27.5.3 delegation
         // over an array forwards exactly the `done:false` element values, and
@@ -2315,8 +2393,11 @@ function analyzeAsyncGen(
 
 /** True when `fn` is a bounded 3d-i async-generator body drivable host-free.
  *  Acceptance is (#3120-)mode-neutral, so no checker is needed here. */
-export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
-  return analyzeAsyncGen(fn, null) !== null;
+export function isBoundedAsyncGenBody(
+  fn: ts.FunctionLikeDeclaration,
+  delegates: AsyncGenDelegates | null = null,
+): boolean {
+  return analyzeAsyncGen(fn, null, delegates) !== null;
 }
 
 /**
@@ -2335,9 +2416,17 @@ export function isBoundedAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
  * byte-identical) rather than demoting the body to the legacy #680 CE — see
  * {@link ImplicitYieldAwaitMode}.
  */
-export function isAwaitFreeAsyncGenBody(fn: ts.FunctionLikeDeclaration): boolean {
-  const shape = analyzeAsyncGen(fn, null);
+export function isAwaitFreeAsyncGenBody(
+  fn: ts.FunctionLikeDeclaration,
+  delegates: AsyncGenDelegates | null = null,
+): boolean {
+  const shape = analyzeAsyncGen(fn, null, delegates);
   if (shape === null) return false;
+  // (#2570) Delegate segments count as await-free: their suspends await
+  // promises minted by the INNER producer's own `__async_gen_next_<stem>`
+  // driver — always a native `$Promise` regardless of the carrier gate (the
+  // same carrier-independence argument as `asyncGenConsumerNeedsDrive`). The
+  // inner body's own await-freeness is checked by the delegates mode.
   return shape.segments.every((y) => y.awaited === null);
 }
 
@@ -2396,13 +2485,146 @@ export function asyncGenOwnLocalDecls(fn: ts.FunctionLikeDeclaration): Map<strin
 export function planAsyncGenCfg(
   fn: ts.FunctionLikeDeclaration,
   implicitYieldAwait: ImplicitYieldAwaitMode,
+  delegates: AsyncGenDelegates | null = null,
 ): AsyncCfgPlan | null {
-  const shape = analyzeAsyncGen(fn, implicitYieldAwait);
+  const shape = analyzeAsyncGen(fn, implicitYieldAwait, delegates);
   if (shape === null) return null;
   const asLead = (stmts: readonly ts.Statement[]): AsyncCfgStmt[] => stmts.map((stmt) => ({ stmt, handler: 0 }));
   const states: AsyncCfgState[] = [];
   let id = 0;
+  let delegateIdx = 0;
   for (const y of shape.segments) {
+    if (y.delegate !== undefined) {
+      // (#2570) `yield* inner(...)` DELEGATION — the lazy 4-state pump loop.
+      // One OUTER `next()` kick pumps the inner driven gen exactly ONE step:
+      //
+      //   init(k)  : [leads] iter := inner(...)   (frame spill — lazy: runs on
+      //              the kick that REACHES the yield*, not at outer())
+      //              → goto pump
+      //   pump(k+1): suspend(await __async_gen_next_<inner>(iter), resume→chk)
+      //   chk(k+2) : (binds SENT = IteratorResult; a rejected inner next()
+      //              re-throws via the MODE_THROW prelude → outer's current
+      //              next()-promise rejects, §27.6.4.2.5.g)
+      //              unpack {done,value} → condGoto(done, after, yieldOut)
+      //   yield(k+3): settleYield(value, resume→pump)   ← the BACK-EDGE: the
+      //              NEXT outer kick re-enters pump and pumps inner again
+      //   after(k+4): the next segment's first state (or settleDone)
+      //
+      // The inner next()-promise is a native `$Promise` minted by the inner's
+      // own driver (carrier-independent), so the stock suspend arm classifies
+      // it: a sync-settling inner yield advances in the same dispatch; a
+      // genuinely-pending one (inner `yield await P`) suspends the OUTER frame
+      // and the microtask drain resumes it — genuine two-level suspension.
+      // `.throw()`/`.return()`/sent-value forwarding into the delegate are out
+      // of scope (driven gens do not support them yet — #2906 3d-iii).
+      const call = y.delegate;
+      const helperName = delegates?.helperNameFor?.(call) ?? null;
+      if (helperName === null) return null; // registry miss — gate/plan drift (unreachable post-gate)
+      const iterSpillName = `__yieldstar_iter_${delegateIdx}`;
+      delegateIdx += 1;
+      const initId = id;
+      const pumpId = id + 1;
+      const chkId = id + 2;
+      const yieldId = id + 3;
+      const afterId = id + 4;
+
+      // init: iter := inner(...) into the persisted per-delegate frame spill.
+      const initEmit: AsyncCfgStepEmit = (ctx, fctx) => {
+        const iterSlot = fctx.localMap.get(iterSpillName) ?? allocLocal(fctx, iterSpillName, { kind: "externref" });
+        const srcType = compileExpression(ctx, fctx, call);
+        if (srcType !== null && srcType !== undefined) {
+          coerceType(ctx, fctx, srcType as ValType, { kind: "externref" });
+        } else {
+          fctx.body.push({ op: "ref.null.extern" });
+        }
+        fctx.body.push({ op: "local.set", index: iterSlot });
+      };
+
+      // pump operand: push __async_gen_next_<inner>(iter) — the next()-promise.
+      // funcIdx resolved fresh by NAME at emit (late imports shift defined idxs).
+      const pumpOperand: AsyncCfgValueEmit = (ctx, fctx) => {
+        const iterSlot = fctx.localMap.get(iterSpillName) ?? allocLocal(fctx, iterSpillName, { kind: "externref" });
+        const nextIdx = ctx.funcMap.get(helperName);
+        if (nextIdx === undefined) {
+          // Unreachable: the drive gate required the helper to be registered.
+          fctx.body.push({ op: "ref.null.extern" });
+          return { kind: "externref" };
+        }
+        fctx.body.push({ op: "local.get", index: iterSlot });
+        fctx.body.push({ op: "call", funcIdx: nextIdx });
+        return { kind: "externref" };
+      };
+
+      // chk: unpack the delivered IteratorResult (the resume binding local)
+      // into transient done/value locals (same-dispatch use only — no spill).
+      const unpackResult: AsyncCfgStepEmit = (ctx, fctx) => {
+        const resultTypeIdx = ensureNativeGeneratorResultType(ctx, { kind: "externref" });
+        const resSlot = fctx.localMap.get(YIELDSTAR_RESULT);
+        const doneSlot = fctx.localMap.get(YIELDSTAR_DONE) ?? allocLocal(fctx, YIELDSTAR_DONE, { kind: "i32" });
+        const valueSlot =
+          fctx.localMap.get(YIELDSTAR_VALUE) ?? allocLocal(fctx, YIELDSTAR_VALUE, { kind: "externref" });
+        if (resSlot === undefined) {
+          // Unreachable: chk is the pump-suspend's resumeState, so the binding
+          // local exists. Deliver done=1 so the loop exits rather than traps.
+          fctx.body.push({ op: "i32.const", value: 1 });
+          fctx.body.push({ op: "local.set", index: doneSlot });
+          fctx.body.push({ op: "ref.null.extern" });
+          fctx.body.push({ op: "local.set", index: valueSlot });
+          return;
+        }
+        fctx.body.push({ op: "local.get", index: resSlot });
+        fctx.body.push({ op: "any.convert_extern" });
+        fctx.body.push({ op: "ref.cast", typeIdx: resultTypeIdx });
+        fctx.body.push({ op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_DONE_FIELD });
+        fctx.body.push({ op: "local.set", index: doneSlot });
+        fctx.body.push({ op: "local.get", index: resSlot });
+        fctx.body.push({ op: "any.convert_extern" });
+        fctx.body.push({ op: "ref.cast", typeIdx: resultTypeIdx });
+        fctx.body.push({ op: "struct.get", typeIdx: resultTypeIdx, fieldIdx: RESULT_VALUE_FIELD });
+        fctx.body.push({ op: "local.set", index: valueSlot });
+      };
+
+      const doneCond: AsyncCfgValueEmit = (_ctx, fctx) => {
+        fctx.body.push({ op: "local.get", index: fctx.localMap.get(YIELDSTAR_DONE)! });
+        return { kind: "i32" };
+      };
+
+      const yieldValue: AsyncCfgValueEmit = (_ctx, fctx) => {
+        fctx.body.push({ op: "local.get", index: fctx.localMap.get(YIELDSTAR_VALUE)! });
+        return { kind: "externref" };
+      };
+
+      states.push(
+        {
+          id: initId,
+          resumeFrom: null,
+          lead: asLead(y.leads),
+          emit: initEmit,
+          terminator: { kind: "goto", target: pumpId },
+        },
+        {
+          id: pumpId,
+          resumeFrom: null,
+          lead: [],
+          terminator: { kind: "suspend", awaited: { emit: pumpOperand }, resumeState: chkId, handler: 0 },
+        },
+        {
+          id: chkId,
+          resumeFrom: { binding: { name: YIELDSTAR_RESULT, type: undefined }, handler: 0 },
+          lead: [],
+          emit: unpackResult,
+          terminator: { kind: "condGoto", cond: { emit: doneCond }, whenTrue: afterId, whenFalse: yieldId, handler: 0 },
+        },
+        {
+          id: yieldId,
+          resumeFrom: null,
+          lead: [],
+          terminator: { kind: "settleYield", value: { emit: yieldValue }, fromSent: false, resumeState: pumpId },
+        },
+      );
+      id += 4;
+      continue;
+    }
     if (y.awaited !== null) {
       // await-suspend state → yield-from-sent state.
       states.push({

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -40,6 +40,7 @@ import type { AsyncCfgPlan, AsyncCfgState, AsyncCpsPlan, AsyncResumePoint } from
 import {
   ASYNC_CPS_ENABLED,
   FORAWAIT_ITER_SPILL,
+  type AsyncGenDelegates,
   analyzeAsyncBody,
   asyncFnNeedsCps,
   awaitedExprIsPromiseCombinator,
@@ -50,6 +51,7 @@ import {
   isAwaitFreeAsyncGenBody,
   isBoundedAsyncGenBody,
   isEmitOperand,
+  listTopLevelYieldStarCalls,
   loopAsyncSpillInfo,
   planAsyncCfg,
   planAsyncGenCfg,
@@ -722,6 +724,16 @@ function computeAsyncSpills(
       spillNames.push(name);
       spillTypes.push(resolveSpillLocalValType(ctx, node) ?? { kind: "externref" });
     }
+    // (#2570) One persisted externref slot per `yield* <call>` delegate — the
+    // inner frame carrier, created lazily in the delegate INIT state and live
+    // across every pump suspend. Numbered in source order, matching the CFG
+    // planner's `__yieldstar_iter_<i>` naming exactly (both walk the same
+    // top-level statement list).
+    const delegateCalls = listTopLevelYieldStarCalls(decl);
+    for (let i = 0; i < delegateCalls.length; i++) {
+      spillNames.push(`__yieldstar_iter_${i}`);
+      spillTypes.push({ kind: "externref" });
+    }
     return { spillNames, spillTypes };
   }
   const linear = planLinearAwaits(decl, plan);
@@ -1002,7 +1014,14 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // planner always see the same segment split. Type queries go through
   // `ctx.oracle` (the #1930 boundary), not the raw checker.
   const cfg = info.asyncGen
-    ? planAsyncGenCfg(info.decl, isStandalonePromiseActive(ctx) ? { oracle: ctx.oracle } : null)
+    ? planAsyncGenCfg(
+        info.decl,
+        isStandalonePromiseActive(ctx) ? { oracle: ctx.oracle } : null,
+        // (#2570) Emit-time delegates mode (registry-backed helper resolution)
+        // on the same lane split as the admission gate, so gate and planner
+        // always see the same segment shape.
+        asyncGenDelegatesForPlan(ctx, info.decl, isStandalonePromiseActive(ctx) ? "carrier" : "awaitFree"),
+      )
     : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
@@ -2059,7 +2078,11 @@ export function emitAsyncFrameStateMachine(
  * doubt (rest param, unbounded body, unsafe spill) returns false ⇒ the module
  * keeps the pre-#2980 host Promise pipeline, exactly as before.
  */
-export function asyncGenDrivableUnderCarrier(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
+export function asyncGenDrivableUnderCarrier(
+  ctx: CodegenContext,
+  decl: ts.FunctionLikeDeclaration,
+  allowDelegates = true,
+): boolean {
   if (!ASYNC_CPS_ENABLED) return false;
   for (const p of decl.parameters) {
     if (p.dotDotDotToken !== undefined) return false;
@@ -2067,7 +2090,169 @@ export function asyncGenDrivableUnderCarrier(ctx: CodegenContext, decl: ts.Funct
   for (const node of asyncGenOwnLocalDecls(decl).values()) {
     if (!isSpillSafeType(resolveSpillLocalValType(ctx, node) ?? { kind: "externref" })) return false;
   }
-  return isBoundedAsyncGenBody(decl);
+  // (#2570) `yield* inner()` delegate segments are admitted when the inner
+  // producer is a resolvable, earlier-declared, itself-drivable top-level
+  // async gen. `allowDelegates=false` is the recursion cut when this predicate
+  // judges an INNER producer from a delegate accept() — v1 has no nested
+  // delegation, so an inner with its own `yield* call` rejects.
+  const delegates = allowDelegates ? asyncGenDelegatesForGate(ctx, decl, "carrier") : null;
+  return isBoundedAsyncGenBody(decl, delegates);
+}
+
+/**
+ * (#2570) Resolve a `yield* <callee>(...)` delegate callee to its inner
+ * async-generator FunctionDeclaration — PURELY syntactic (no checker, no
+ * emit-order state), so the pre-body `widenAsyncGenFallback` carrier pre-pass
+ * and the emit-time gate reach the SAME verdict. v1 bounds (correct-or-legacy
+ * beyond them):
+ *   - OUTER is a top-level `async function*` declaration (its scope chain is
+ *     then exactly own params/locals → module, so the shadowing guard below is
+ *     complete without checker resolution);
+ *   - callee is a plain identifier naming a UNIQUE top-level `async function*`
+ *     declaration with a body — not shadowed by an outer param/local/own-scope
+ *     nested function declaration;
+ *   - the inner is declared strictly BEFORE the outer (function bodies compile
+ *     in source order, so the inner's `__async_gen_next_<stem>` driver is
+ *     registered by the time the outer's resume machine emits — the same
+ *     order-robustness argument as `resolveAsyncGenNextHelperName`), and is
+ *     not the outer itself (no self/mutual recursion).
+ */
+export function resolveAsyncGenDelegateDecl(
+  call: ts.CallExpression,
+  outer: ts.FunctionLikeDeclaration,
+): ts.FunctionDeclaration | null {
+  let callee: ts.Expression = call.expression;
+  while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+  if (!ts.isIdentifier(callee)) return null;
+  const name = callee.text;
+  if (!ts.isFunctionDeclaration(outer) || !ts.isSourceFile(outer.parent)) return null;
+  // Shadowing guards: an outer param, own local, or own-scope nested function
+  // declaration named like the callee would bind the call away from the
+  // top-level producer.
+  for (const p of outer.parameters) {
+    if (bindingNameBinds(p.name, name)) return null;
+  }
+  if (asyncGenOwnLocalDecls(outer).has(name)) return null;
+  if (outer.body !== undefined && ownScopeHasFunctionDeclNamed(outer.body, name)) return null;
+  const sf = outer.parent;
+  let found: ts.FunctionDeclaration | null = null;
+  for (const st of sf.statements) {
+    if (ts.isFunctionDeclaration(st) && st.name !== undefined && st.name.text === name) {
+      if (found !== null) return null; // ambiguous duplicate top-level name
+      found = st;
+    }
+  }
+  if (found === null || found === outer) return null;
+  if (found.asteriskToken === undefined || found.body === undefined) return null;
+  const mods = ts.getModifiers(found);
+  if (!mods?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)) return null;
+  if (found.pos >= outer.pos) return null; // must be declared (⇒ emitted) before the outer
+  return found;
+}
+
+/** (#2570) Does a param binding name (identifier or pattern) bind `name`? */
+function bindingNameBinds(binding: ts.BindingName, name: string): boolean {
+  if (ts.isIdentifier(binding)) return binding.text === name;
+  for (const el of binding.elements) {
+    if (!ts.isBindingElement(el)) continue; // OmittedExpression (array holes)
+    if (bindingNameBinds(el.name, name)) return true;
+  }
+  return false;
+}
+
+/** (#2570) Own-scope (not crossing nested fn scopes) `function <name>` decl? */
+function ownScopeHasFunctionDeclNamed(body: ts.Node, name: string): boolean {
+  let found = false;
+  const walk = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isFunctionDeclaration(node)) {
+      if (node.name !== undefined && node.name.text === name) found = true;
+      return; // do not descend — its inner decls are its own scope
+    }
+    if (ts.isFunctionExpression(node) || ts.isArrowFunction(node) || ts.isMethodDeclaration(node)) return;
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(body, walk);
+  return found;
+}
+
+/**
+ * (#2570) The STATIC delegate-admission mode for one outer async gen. Reads no
+ * emit-order state (safe for the pre-body carrier pre-pass — see
+ * {@link AsyncGenDelegates}). The carrier lane admits any drivable inner (full
+ * bounded shape, awaited yields included); the await-free (carrier-off) lane
+ * requires the inner itself await-free + spill-safe + rest-free, mirroring the
+ * `isAsyncGenDriveCandidate` await-free arm it feeds.
+ */
+function asyncGenDelegatesForGate(
+  ctx: CodegenContext,
+  outer: ts.FunctionLikeDeclaration,
+  lane: "carrier" | "awaitFree",
+): AsyncGenDelegates {
+  return {
+    accept: (call: ts.CallExpression): boolean => {
+      const inner = resolveAsyncGenDelegateDecl(call, outer);
+      if (inner === null) return false;
+      if (lane === "carrier") return asyncGenDrivableUnderCarrier(ctx, inner, /*allowDelegates*/ false);
+      if (!isAwaitFreeAsyncGenBody(inner, null)) return false;
+      for (const p of inner.parameters) {
+        if (p.dotDotDotToken !== undefined) return false;
+      }
+      for (const node of asyncGenOwnLocalDecls(inner).values()) {
+        if (!isSpillSafeType(resolveSpillLocalValType(ctx, node) ?? { kind: "externref" })) return false;
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * (#2570) EMIT-time delegates mode: static admission plus registry-backed
+ * helper-name resolution for the planner's pump state. Only valid once the
+ * inner producers have emitted (guaranteed by the declared-before-outer bound
+ * plus source-order body compilation).
+ */
+function asyncGenDelegatesForPlan(
+  ctx: CodegenContext,
+  outer: ts.FunctionLikeDeclaration,
+  lane: "carrier" | "awaitFree",
+): AsyncGenDelegates {
+  const base = asyncGenDelegatesForGate(ctx, outer, lane);
+  return {
+    accept: base.accept,
+    helperNameFor: (call: ts.CallExpression): string | null => {
+      const inner = resolveAsyncGenDelegateDecl(call, outer);
+      if (inner === null) return null;
+      const stem = asyncGenStem(inner);
+      const reg = ctx.asyncGenProducers?.get(stem);
+      if (reg === undefined || reg.decl !== inner) return null;
+      const name = `__async_gen_next_${stem}`;
+      return ctx.funcMap.has(name) ? name : null;
+    },
+  };
+}
+
+/**
+ * (#2570) Emit-time verification that every syntactic `yield* <call>` delegate
+ * of `decl` resolves to an inner producer that ACTUALLY emitted driven (its
+ * `__async_gen_next_<stem>` driver registered against the SAME declaration).
+ * Vacuously true for a body with no delegate calls, so non-delegating gens are
+ * untouched. A mismatch (e.g. a stem collision made the inner fall to legacy)
+ * routes the outer to legacy too — correct-or-legacy, and mix-safe: on
+ * standalone the pre-pass has already flagged such a module non-drivable
+ * (carrier off), and on wasi a legacy fallback is the pre-existing tolerated
+ * arrangement.
+ */
+function asyncGenDelegatesRegistered(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
+  for (const call of listTopLevelYieldStarCalls(decl)) {
+    const inner = resolveAsyncGenDelegateDecl(call, decl);
+    if (inner === null) return false;
+    const stem = asyncGenStem(inner);
+    const reg = ctx.asyncGenProducers?.get(stem);
+    if (reg === undefined || reg.decl !== inner) return false;
+    if (!ctx.funcMap.has(`__async_gen_next_${stem}`)) return false;
+  }
+  return true;
 }
 
 export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionLikeDeclaration): boolean {
@@ -2111,7 +2296,12 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // emit gate and the `widenAsyncGenFallback` pre-pass provably consistent, so a
   // module the pre-pass judged all-driven never falls a gen to the legacy buffer
   // here (which would re-introduce the native-`$Promise`-into-host-buffer mix).
-  if (isStandalonePromiseActive(ctx)) return asyncGenDrivableUnderCarrier(ctx, decl);
+  // (#2570) Both arms additionally require every `yield* <call>` delegate's
+  // inner producer to have ACTUALLY emitted driven (registry-verified) —
+  // vacuous for non-delegating bodies.
+  if (isStandalonePromiseActive(ctx)) {
+    return asyncGenDrivableUnderCarrier(ctx, decl) && asyncGenDelegatesRegistered(ctx, decl);
+  }
   // (#2865) `--target standalone` with the carrier gate still OFF (#2980):
   // drive the producer host-free ONLY for await-free bodies. With the carrier
   // off an awaited operand does not lower to a native `$Promise`, so
@@ -2122,7 +2312,13 @@ export function isAsyncGenDriveCandidate(ctx: CodegenContext, decl: ts.FunctionL
   // (#3120: a Promise-typed plain `yield P` deliberately stays PLAIN — and
   // driven, byte-identically — on this lane; its implicit-await value gap is
   // the carrier widen's to close. See ImplicitYieldAwaitMode in async-cps.ts.)
-  if (isAsyncDriveActive(ctx)) return isAwaitFreeAsyncGenBody(decl) && spillsSafe();
+  if (isAsyncDriveActive(ctx)) {
+    return (
+      isAwaitFreeAsyncGenBody(decl, asyncGenDelegatesForGate(ctx, decl, "awaitFree")) &&
+      spillsSafe() &&
+      asyncGenDelegatesRegistered(ctx, decl)
+    );
+  }
   return false;
 }
 

--- a/tests/issue-2570-asyncgen-yieldstar-delegation.test.ts
+++ b/tests/issue-2570-asyncgen-yieldstar-delegation.test.ts
@@ -1,0 +1,185 @@
+// #2570 — lazy/suspending async-generator runtime: `yield*` DELEGATION.
+//
+// The issue's repro: an eager generator runtime drains `yield* inner()` to
+// completion BEFORE the consumer's first `.next()`, so side effects of the
+// delegated iterator run at construction time — violating the spec's lazy,
+// one-step-per-`next()` semantics (`log.length === 0` must hold right after
+// `outer()`).
+//
+// This suite pins the DRIVEN lane fix: `yield* inner(...)` over an
+// earlier-declared, itself-drivable top-level async generator now compiles to
+// a lazy 4-state pump loop on the #2906 CFG resume machine (init → pump →
+// chk → yield-out with a BACK-EDGE to pump), so ONE outer `next()` pumps the
+// inner exactly ONE step. The inner's `next()`-promise is a native `$Promise`
+// minted by its own `__async_gen_next_<stem>` driver, so a sync-settling inner
+// yield advances in the same dispatch while a genuinely-pending one (inner
+// `yield await P`) suspends the OUTER frame and resumes via the microtask
+// drain — genuine two-level suspension, host-free.
+//
+// Out of scope (v1, correct-or-legacy): delegation over arbitrary iterables /
+// hand-built async iterables (the observable GetIterator protocol), nested or
+// forward-referenced inner producers, `.throw()`/`.return()`/sent-value
+// forwarding into the delegate (driven gens do not support them yet — #2906
+// 3d-iii). gc/host keeps the legacy path byte-identically.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface GenExports {
+  outer: (...args: number[]) => unknown;
+  __async_gen_next_outer: (frame: unknown) => unknown;
+  __async_gen_p_state: (p: unknown) => number;
+  __async_gen_result_done: (p: unknown) => number;
+  __async_gen_result_value: (p: unknown) => number;
+  __drain_microtasks: () => void;
+  logLen?: () => number;
+}
+
+async function instantiate(src: string, target: "wasi" | "standalone" = "wasi"): Promise<GenExports> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // Host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as unknown as GenExports;
+}
+
+/** Drive one outer `next()`, drain, read the settled IteratorResult. */
+function step(ex: GenExports, frame: unknown): { pendingBeforeDrain: boolean; done: number; value: number } {
+  const p = ex.__async_gen_next_outer(frame);
+  const pendingBeforeDrain = ex.__async_gen_p_state(p) === 0;
+  ex.__drain_microtasks();
+  expect(ex.__async_gen_p_state(p)).toBe(1); // FULFILLED
+  return { pendingBeforeDrain, done: ex.__async_gen_result_done(p), value: ex.__async_gen_result_value(p) };
+}
+
+const LAZY_REPRO = `
+let log: number[] = [];
+export async function* inner(): AsyncGenerator<number> {
+  log.push(1);
+  yield 10;
+  log.push(2);
+  yield 20;
+  log.push(3);
+}
+export async function* outer(): AsyncGenerator<number> {
+  yield* inner();
+}
+export function logLen(): number { return log.length; }
+`;
+
+describe("#2570 — async-generator yield* delegation (lazy, suspending)", () => {
+  it("THE issue repro: nothing runs before the first next(); side effects interleave one step per next()", async () => {
+    const ex = await instantiate(LAZY_REPRO);
+    const frame = ex.outer();
+    // The eager-buffer bug: log.length was already 3 here. Lazy: still 0 —
+    // inner() has not even been CALLED yet (the init state runs on the first
+    // kick that reaches the yield*).
+    expect(ex.logLen!()).toBe(0);
+    const s1 = step(ex, frame);
+    expect([s1.done, s1.value]).toEqual([0, 10]);
+    expect(ex.logLen!()).toBe(1); // exactly ONE inner step ran
+    const s2 = step(ex, frame);
+    expect([s2.done, s2.value]).toEqual([0, 20]);
+    expect(ex.logLen!()).toBe(2);
+    const s3 = step(ex, frame);
+    expect(s3.done).toBe(1); // final pump runs the inner tail, then outer completes
+    expect(ex.logLen!()).toBe(3);
+  });
+
+  it("same repro drives host-free under --target standalone (carrier ON — all gens drivable)", async () => {
+    const ex = await instantiate(LAZY_REPRO, "standalone");
+    const frame = ex.outer();
+    expect(ex.logLen!()).toBe(0);
+    const s1 = step(ex, frame);
+    expect([s1.done, s1.value]).toEqual([0, 10]);
+    expect(ex.logLen!()).toBe(1);
+    expect(step(ex, frame).value).toBe(20);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("GENUINE two-level suspension: a pending inner awaited yield suspends the OUTER frame; the drain resumes both", async () => {
+    const ex = await instantiate(`
+      export async function* inner(): AsyncGenerator<number> {
+        yield await Promise.resolve(1).then((v: number) => v + 10);
+        yield await Promise.resolve(2).then((v: number) => v + 10);
+      }
+      export async function* outer(): AsyncGenerator<number> {
+        yield* inner();
+      }
+    `);
+    const frame = ex.outer();
+    const s1 = step(ex, frame);
+    expect(s1.pendingBeforeDrain).toBe(true); // outer next()-promise pending until the microtask drain
+    expect([s1.done, s1.value]).toEqual([0, 11]);
+    const s2 = step(ex, frame);
+    expect(s2.pendingBeforeDrain).toBe(true);
+    expect([s2.done, s2.value]).toEqual([0, 12]);
+    expect(step(ex, frame).done).toBe(1);
+  });
+
+  it("composes: plain yields around TWO delegate segments, inner params/args", async () => {
+    const ex = await instantiate(`
+      export async function* inner(base: number): AsyncGenerator<number> {
+        yield base;
+        yield base + 1;
+      }
+      export async function* outer(): AsyncGenerator<number> {
+        yield 1;
+        yield* inner(100);
+        yield 2;
+        yield* inner(200);
+        yield 3;
+      }
+    `);
+    const frame = ex.outer();
+    const got: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      const s = step(ex, frame);
+      if (s.done) break;
+      got.push(s.value);
+    }
+    expect(got).toEqual([1, 100, 101, 2, 200, 201, 3]);
+  });
+
+  it("rejection propagates: a rejected inner next() REJECTS the outer's current next()-promise", async () => {
+    const src = `
+      export async function* inner(): AsyncGenerator<number> {
+        yield await Promise.reject(99);
+      }
+      export async function* outer(): AsyncGenerator<number> {
+        yield* inner();
+      }
+    `;
+    const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as unknown as GenExports;
+    const frame = ex.outer();
+    const p = ex.__async_gen_next_outer(frame);
+    ex.__drain_microtasks();
+    expect(ex.__async_gen_p_state(p)).toBe(2); // REJECTED — §27.6.4.2.5.g, not vacuously fulfilled
+  });
+
+  it("guardrails: gc/host lane unchanged (legacy imports); forward-referenced inner stays legacy (#680 CE) — v1 bound", async () => {
+    const src = `
+      export async function* inner(): AsyncGenerator<number> { yield 1; }
+      export async function* outer(): AsyncGenerator<number> { yield* inner(); }
+    `;
+    // gc: legacy __create_async_generator path with host imports — UNCHANGED.
+    const gc = await compile(src, { fileName: "test.ts" });
+    expect(gc.success).toBe(true);
+    expect((gc.imports ?? []).length).toBeGreaterThan(0);
+    // A forward-referenced inner (declared AFTER the outer) is not admitted —
+    // its driver would not be registered when the outer's machine emits. The
+    // outer keeps today's behavior (the #680 CE on host-free targets).
+    const fwd = await compile(
+      `
+      export async function* outer(): AsyncGenerator<number> { yield* inner(); }
+      export async function* inner(): AsyncGenerator<number> { yield 1; }
+      `,
+      { fileName: "test.ts", target: "wasi" },
+    );
+    expect(fwd.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Issue

#2570 — lazy/suspending async-generator runtime: `yield*` execution order (eager buffer drains before the first `.next()`).

## What this PR does

`yield* inner(...)` over an earlier-declared, itself-drivable **top-level async generator** now compiles to a lazy 4-state pump loop on the existing #2906 CFG resume machine — **zero emitter changes**, planner-only composition of stock terminators:

```
init(k)  : [leads] iter := inner(...)   (frame spill; runs on the kick that
           REACHES the yield* — lazy, so outer() runs nothing)
pump(k+1): suspend(await __async_gen_next_<inner>(iter), resume→chk)
chk(k+2) : (SENT = IteratorResult; rejected inner next() re-throws →
           outer's current next()-promise rejects) unpack {done,value}
yield(k+3): settleYield(value, resume→pump)   ← BACK-EDGE: next outer kick
           pumps inner exactly one more step
```

- **Lazy per spec**: the issue's repro passes — `log.length === 0` right after `outer()`, side effects interleave one inner step per outer `next()` (wasi AND standalone, host-free, `imports: []`).
- **Genuinely suspending**: a pending inner `yield await P` suspends the OUTER frame; `__drain_microtasks` resumes both levels (two-level microtask chain).
- **Rejection propagates**: inner rejection rejects the outer's current `next()`-promise (§27.6.4.2.5.g).
- **Gate consistency** (load-bearing): delegate admission (`resolveAsyncGenDelegateDecl`) is purely syntactic — no checker, no emit-order state — so the pre-body `widenAsyncGenFallback` carrier pre-pass and the emit gate reach the SAME verdict. The emit gate additionally registry-verifies each delegate; divergence falls the outer to legacy (mix-safe: standalone would already have carrier OFF, wasi tolerates legacy).

## Scope honesty

The ~86-file test262 bucket is measured on the **gc lane** (eager JS buffer) and exercises the full observable GetIterator protocol over hand-built iterables — that is the #2662 Option-(ii) epic, not one PR. This PR closes the architectural gap named in the title on the driven lane and is the substrate a future gc widen reuses. Out of scope (correct-or-legacy): arbitrary-iterable delegation, forward-referenced/nested/method inners, `.throw`/`.return`/sent-value forwarding (#2906 3d-iii).

## Validation

- `tests/issue-2570-asyncgen-yieldstar-delegation.test.ts` — 6 repro-first tests (laziness repro on both lanes, two-level suspension, multi-delegate composition with params, rejection, gc-unchanged + forward-ref guardrails). All pass.
- `npx tsc --noEmit` clean; prettier clean; oracle-ratchet net 0 (resolver is pure AST); loc-budget granted via `loc-budget-allow` in the issue file (intended, cohesive growth beside `planAsyncGenCfg`).
- Blast radius: 139 async/generator tests across 13 suites — zero new failures (10 pre-existing local-env failures reproduce identically on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)