### PR TITLE
fix(#739): host-lane representation pinning for runtime-store defines (S1)

### DIFF
--- a/src/codegen/declarations/object-shape-widening.ts
+++ b/src/codegen/declarations/object-shape-widening.ts
@@ -109,6 +109,41 @@ export function collectEmptyObjectWidening(
             }
           }
 
+          // (#739 S1 — HOST-lane representation pinning, the store-unification)
+          // Any `Object.defineProperty` / `Object.defineProperties` on this
+          // receiver whose application lands in the RUNTIME STORE — the native
+          // `$Object` open hash or the `_wasmPropDescs`/`_wasmStructProps`
+          // sidecar — rather than a widened-struct `struct.set` fast path makes
+          // a widened struct UNSOUND: every later dot-read `obj.p` lowers to
+          // `struct.get` (a defined getter never fires; a runtime-store value
+          // reads the struct default) and every dot-write `obj.p = X` to
+          // `struct.set` (a defined setter is bypassed). The two stores never
+          // see each other, and `_structFieldWriteback` mirrors only data
+          // VALUES back into the field — accessors cannot be mirrored (a
+          // `struct.get` can never invoke a getter). #3230 measured both bounded
+          // point-fixes (read-reroute net −7; read-reroute + runtime fallback
+          // still fails) and proved the field-vs-sidecar choice is
+          // widening-sensitive — the only sound fix is to keep the receiver on
+          // the ONE native store. Standalone already ships this via
+          // `dynamicDescriptorWidenVars` (checked at :123) +
+          // `markStandaloneAccessorDefineTargets` (above); the host lane was
+          // exempted on the (disproved) assumption the live-mirror writeback
+          // bridges the gap. Pin here by marking the var an
+          // `objectHashConsumerVar` so the suppression branch below (a) skips
+          // widening and (b) — load-bearing — records the var's EVOLVED checker
+          // type in `objectHashConsumerTypes` (the #2944 escape discipline;
+          // without it the checker re-registers a colliding `__anon` struct at
+          // the var's escape positions and compiled-acorn null-derefs, #2937).
+          // The now-pinned `$Object` rides the extern-lane MOP ops the
+          // bracket-form (`obj["p"]`) already proves correct on main. Host-gated
+          // so standalone stays byte-identical (also avoids colliding with
+          // in-flight #2042); WASI is standalone (no host MOP).
+          if (!ctx.standalone && !ctx.objectHashConsumerVars.has(varName)) {
+            for (const s of stmts) {
+              markRuntimeStoreDefineTargets(s, varName, ctx.objectHashConsumerVars);
+            }
+          }
+
           // (#2372) Standalone: if any `Object.defineProperty(varName, …)` on
           // this receiver used a *dynamic* (non-inline-literal) descriptor, the
           // struct-widening fast path is unsound — the dynamic define is applied
@@ -634,6 +669,138 @@ function descriptorHasAccessorKey(descArg: ts.Expression): boolean {
       (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
       (prop.name.text === "get" || prop.name.text === "set")
     ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * (#739 S1, HOST-lane caller) Poison `varName` when it is the receiver of any
+ * `Object.defineProperty` / `Object.defineProperties` call whose application
+ * lands in the RUNTIME STORE (native `$Object` open hash or the
+ * `_wasmPropDescs`/`_wasmStructProps` sidecar) rather than a widened-struct
+ * `struct.set` fast path. Such receivers must stay a `$Object` so define →
+ * read → write → delete → for-in → hasOwnProperty → gOPD all target the ONE
+ * native store — see the block comment at the call site. This is the host-lane
+ * generalization of `markStandaloneAccessorDefineTargets` (which only covers
+ * accessor descriptors, standalone-gated); the host lane must additionally pin
+ * for dynamic descriptors, explicit-undefined / no-value literals, dynamic
+ * keys, and every `defineProperties` shape.
+ *
+ * Name-based, matching the widening pre-pass (aliasing is a shared documented
+ * limitation — see the issue's "Edge cases").
+ */
+function markRuntimeStoreDefineTargets(node: ts.Node, varName: string, poisonSet: Set<string>): void {
+  const visit = (n: ts.Node): void => {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      ts.isIdentifier(n.expression.expression) &&
+      n.expression.expression.text === "Object" &&
+      ts.isIdentifier(n.expression.name)
+    ) {
+      const method = n.expression.name.text;
+      const recv = n.arguments[0];
+      if (recv && ts.isIdentifier(recv) && recv.text === varName) {
+        if (method === "defineProperty" && n.arguments.length >= 3) {
+          if (definePropertyRoutesToRuntimeStore(n.arguments[1]!, n.arguments[2]!)) {
+            poisonSet.add(varName);
+          }
+        } else if (method === "defineProperties" && n.arguments.length >= 2) {
+          // Every `Object.defineProperties(varName, …)` shape lands in the
+          // runtime store: the static per-entry expansion still routes each
+          // inner define through the runtime applier, and the dynamic route
+          // (`__defineProperties`) is entirely native. A widened struct is
+          // unsound for all of them.
+          poisonSet.add(varName);
+        }
+      }
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+}
+
+/**
+ * (#739 S1) Does a single `Object.defineProperty(varName, key, desc)` route its
+ * APPLICATION to the runtime store (native `$Object` / `_wasmPropDescs`
+ * sidecar) rather than the widened-struct `struct.set` fast path? True for
+ * every shape EXCEPT a pure data-descriptor object literal (`value` key
+ * present, no `get`/`set`, no explicit-`undefined` field) on a string/numeric
+ * literal key. Mirrors the routing in `object-ops.ts`: dynamic descriptor
+ * (`:1580` → `__defineProperty_desc`), explicit-`undefined` fields (`:1608`),
+ * the accessor path (`emitExternDefinePropertyNoValue` → `__defineProperty_accessor`),
+ * and the no-`value` path (also `emitExternDefinePropertyNoValue`). The pure
+ * data-literal family is deliberately KEPT on the struct fast path + flag
+ * side-channel — it already passes (`15.2.3.6-4-*` static rows) and must not be
+ * disturbed in S1.
+ */
+function definePropertyRoutesToRuntimeStore(keyArg: ts.Expression, descArg: ts.Expression): boolean {
+  // Dynamic key (not a string/numeric literal) can never be a widened field.
+  if (!ts.isStringLiteral(keyArg) && !ts.isNumericLiteral(keyArg)) return true;
+  // Non-inline-literal descriptor → runtime `__defineProperty_desc` (:1580).
+  if (!ts.isObjectLiteralExpression(descArg)) return true;
+  // Accessor descriptor (`get`/`set` key present, any value incl. `undefined`)
+  // → runtime accessor path.
+  if (descriptorHasAccessorKey(descArg)) return true;
+  // Explicit-`undefined` descriptor field (`{ value: undefined }`,
+  // `{ writable: undefined }`, …) → runtime path so the presence bit is
+  // recorded per ToPropertyDescriptor (:1608, host-only).
+  if (descriptorHasExplicitUndefinedField(descArg)) return true;
+  // No `value` key → `emitExternDefinePropertyNoValue` → runtime sidecar.
+  if (!descriptorHasValueKey(descArg)) return true;
+  return false;
+}
+
+/** (#739 S1) Recognized descriptor field names, per §6.2.5 ToPropertyDescriptor. */
+const S1_DESCRIPTOR_FIELD_NAMES = new Set(["value", "writable", "enumerable", "configurable", "get", "set"]);
+
+/** (#739 S1) Is `expr` `undefined` / `void <x>` (an explicit-undefined field
+ * value)? Mirrors `object-ops.ts`'s `isUndefinedLikeExpression`, unwrapping
+ * transparent `as` / `!` / parenthesized wrappers. */
+function isS1UndefinedLikeExpression(expr: ts.Expression): boolean {
+  let inner: ts.Expression = expr;
+  while (
+    ts.isAsExpression(inner) ||
+    ts.isTypeAssertionExpression(inner) ||
+    ts.isNonNullExpression(inner) ||
+    ts.isParenthesizedExpression(inner) ||
+    ts.isSatisfiesExpression(inner)
+  ) {
+    inner = inner.expression;
+  }
+  return (
+    inner.kind === ts.SyntaxKind.UndefinedKeyword ||
+    (ts.isIdentifier(inner) && inner.text === "undefined") ||
+    ts.isVoidExpression(inner)
+  );
+}
+
+/** (#739 S1) Does the descriptor literal carry a recognized field explicitly
+ * set to `undefined` (`{ value: undefined }`, `{ configurable: void 0 }`, …)?
+ * Mirrors `object-ops.ts`'s `descriptorUndefinedFields(...).length > 0`. */
+function descriptorHasExplicitUndefinedField(descArg: ts.ObjectLiteralExpression): boolean {
+  for (const prop of descArg.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const name = prop.name;
+    if (!ts.isIdentifier(name) && !ts.isStringLiteral(name)) continue;
+    if (S1_DESCRIPTOR_FIELD_NAMES.has(name.text) && isS1UndefinedLikeExpression(prop.initializer)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** (#739 S1) Does the descriptor literal have a (non-undefined-guaranteed)
+ * `value` key present? A property-assignment or shorthand `value` counts; an
+ * explicit-`undefined` `value` is caught earlier by
+ * {@link descriptorHasExplicitUndefinedField}. */
+function descriptorHasValueKey(descArg: ts.ObjectLiteralExpression): boolean {
+  for (const prop of descArg.properties) {
+    if (!ts.isPropertyAssignment(prop) && !ts.isShorthandPropertyAssignment(prop)) continue;
+    const name = prop.name;
+    if ((ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === "value") {
       return true;
     }
   }

--- a/tests/issue-739.test.ts
+++ b/tests/issue-739.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+// #739 Slice S1 — host-lane representation pinning (the store-unification).
+//
+// An empty-`{}` var (inferred type, NOT `: any` — an `any` annotation already
+// disables widening) that is the receiver of an Object.defineProperty /
+// defineProperties whose application lands in the RUNTIME STORE (accessor /
+// no-value / explicit-undefined / dynamic descriptor / dynamic key / any
+// defineProperties) must stay a host `$Object` — NOT be widened to a closed
+// WasmGC struct. On `origin/main` such a var IS widened: the define routes to
+// the runtime store while every later dot-read `obj.p` lowers to `struct.get`
+// (a defined getter never fires → reads back `undefined`) and every dot-write
+// `obj.p = X` to `struct.set` (a defined setter is bypassed). These are the
+// exact #3230 read-lane (`15.2.3.6-3-207..230`) and write-lane (`-238..-260`)
+// repros — verified failing on `origin/main`, passing here. S1 pins the
+// receiver to the extern lane the bracket-form (`obj["p"]`) already proves
+// correct. `(obj as any)` casts on the reads only satisfy `tsc` (the inferred
+// `{}` type has no such member); they do not change the wasm lowering.
+describe("#739 S1 — Object.defineProperty store-unification (representation pinning)", () => {
+  it("dynamic accessor descriptor read lane fires the getter (#3230 minimal repro)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): string {
+        const obj = {};
+        const d0 = { get: function () { return "viaGetter"; } };
+        Object.defineProperty(obj, "property", d0);
+        return (obj as any).property;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("inline accessor literal read lane fires the getter", async () => {
+    await assertEquivalent(
+      `
+      export function test(): string {
+        const obj = {};
+        Object.defineProperty(obj, "property", {
+          get: function () { return "inlineGetter"; },
+        });
+        return (obj as any).property;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("setter accessor on empty-{} var fires on dot-write (write lane)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): string {
+        const obj = {};
+        let captured = "init";
+        Object.defineProperty(obj, "property", {
+          set: function (v: any) { captured = v; },
+          get: function () { return captured; },
+        });
+        (obj as any).property = "overrideData";
+        return (obj as any).property;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("get+set accessor round-trips through the one store", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const obj = {};
+        let store = 0;
+        Object.defineProperty(obj, "x", {
+          get: function () { return store + 1; },
+          set: function (v: any) { store = v * 2; },
+        });
+        (obj as any).x = 10;
+        return (obj as any).x;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("dynamic (non-literal) data descriptor read-back is consistent", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const obj = {};
+        const desc = { value: 42, writable: true, enumerable: true, configurable: true };
+        Object.defineProperty(obj, "k", desc);
+        return (obj as any).k;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("no-value {writable:true} define then assignment reads back the write", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const obj = {};
+        Object.defineProperty(obj, "b", { writable: true });
+        (obj as any).b = 11;
+        return (obj as any).b;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("explicit-undefined {value: undefined} define records the property", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const obj = {};
+        Object.defineProperty(obj, "u", { value: undefined });
+        // property PRESENT (1) with value undefined (2) → 3
+        return ("u" in obj ? 1 : 0) + ((obj as any).u === undefined ? 2 : 0);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("Object.defineProperties with an accessor descriptor fires the getter", async () => {
+    await assertEquivalent(
+      `
+      export function test(): string {
+        const obj = {};
+        Object.defineProperties(obj, {
+          p: { get: function () { return "viaDefineProperties"; }, enumerable: true },
+          q: { value: "plain", enumerable: true },
+        });
+        return (obj as any).p + "|" + (obj as any).q;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("pure inline data-value define keeps the struct fast path correct (guard C)", async () => {
+    // This shape is deliberately NOT pinned by S1 — an inline
+    // `{ value: <literal>, ...boolean-literal flags }` data descriptor stays on
+    // the struct fast path + flag side-channel. Locks the S1 boundary: the
+    // read must still be correct on the (still-widened) struct receiver.
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const obj = {};
+        Object.defineProperty(obj, "x", {
+          value: 99,
+          writable: false,
+          enumerable: true,
+          configurable: false,
+        });
+        return (obj as any).x;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## #739 Slice S1 — host-lane representation pinning (the store-unification)

Implements **Slice S1 only** of #739 per the spec in PR #3310 (which also
resolves the blocked #3230). S2 (defineProperties two-phase apply) remains
outstanding — this issue stays `ready`.

### Problem (root cause, #3230)
An empty-`{}` var that receives an `Object.defineProperty`/`defineProperties`
whose application lands in the **runtime store** (native `$Object` / `_wasmPropDescs`
sidecar) is widened to a closed WasmGC struct. The define lands in one store
while every later dot-read `obj.p` lowers to `struct.get` (a defined getter never
fires → reads back the field default) and every dot-write `obj.p = X` to
`struct.set` (a defined setter is bypassed). `_structFieldWriteback` mirrors only
data VALUES, never accessors. #3230 proved bounded read/write point-fixes are
net-negative and widening-sensitive.

### Fix
New host-lane poison predicate `markRuntimeStoreDefineTargets` in
`src/codegen/declarations/object-shape-widening.ts` pins such receivers to a
host `$Object` by marking them `objectHashConsumerVars`, so the existing
#2584/#2944 suppression branch both (a) skips widening and (b) records the var's
evolved checker type in `objectHashConsumerTypes` (the #2937 escape discipline —
without it compiled-acorn null-derefs). Every MOP op then rides the ONE native
store the bracket-form (`obj["p"]`) already proves correct.

**Runtime-routed predicate** (mirrors `object-ops.ts` routing): dynamic key,
non-literal descriptor, `get`/`set` present, explicit-`undefined` field,
no-`value` key, or any `Object.defineProperties`. Pure inline
`{value:<literal>, ...boolean-literal flags}` data-descriptor defines are kept
OUT (struct fast path unchanged, guard C). All S1 changes are
`!ctx.standalone`-guarded; standalone stays byte-identical.

### Validation (scoped; CI runs full test262)
- `tests/issue-739.test.ts` (9 cases): dynamic + inline accessor read lanes,
  setter write lane, get+set round-trip, dynamic data descriptor, no-value
  `{writable:true}`, explicit-`undefined`, `defineProperties` accessor, guard-C
  boundary. The two accessor read-lane cases are **verified failing on
  `origin/main`** (return `undefined`) and passing here — the #3230 repro.
- Regression guards green: `tests/issue-2944.test.ts` (compiled-acorn escape
  discipline, #2937), `tests/define-property-patterns.test.ts`,
  `tests/issue-2584-dual-storage.test.ts`, `3042`/`3043`/`3116`/`2726`.
- Pre-existing-on-main failures (`issue-1130` array-index growth, `issue-1336`
  symbol-key) are unrelated and out of scope.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)