### PR TITLE
chore(hooks): make pre-agent-spawn.sh OS-aware (darwin support)

### DIFF
--- a/.claude/hooks/pre-agent-spawn.sh
+++ b/.claude/hooks/pre-agent-spawn.sh
@@ -17,7 +17,7 @@
 
 INPUT=$(cat)
 
-CORES=$(nproc 2>/dev/null || echo 4)
+CORES=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 # Default ceiling = cores-2 (leave headroom), floor of 1.
 DEFAULT_MAX_LOAD=$(( CORES > 2 ? CORES - 2 : 1 ))
 # Override precedence: env var > .claude/max-load file > cores-2 default.
@@ -27,15 +27,26 @@ FILE_MAX_LOAD=$(cat "${CLAUDE_PROJECT_DIR:-/workspace}/.claude/max-load" 2>/dev/
 MAX_LOAD=${JS2WASM_MAX_LOAD:-${FILE_MAX_LOAD:-$DEFAULT_MAX_LOAD}}
 MIN_RAM_MB=${JS2WASM_MIN_RAM_MB:-1500}
 
-AVAIL_MB=$(free -m | awk '/Mem/{print $7}')
-LOAD1=$(awk '{print $1}' /proc/loadavg 2>/dev/null)
+# OS-aware RAM/load probes: Linux has free(1)+/proc; darwin needs vm_stat/sysctl.
+if command -v free >/dev/null 2>&1; then
+  AVAIL_MB=$(free -m | awk '/Mem/{print $7}')
+else
+  PAGESIZE=$(sysctl -n hw.pagesize 2>/dev/null || echo 4096)
+  AVAIL_MB=$(vm_stat 2>/dev/null | awk -v ps="$PAGESIZE" '/Pages free|Pages inactive|Pages speculative/{gsub("\\.","",$NF); s+=$NF} END{printf "%d", s*ps/1048576}')
+fi
+if [ -r /proc/loadavg ]; then
+  LOAD1=$(awk '{print $1}' /proc/loadavg 2>/dev/null)
+else
+  LOAD1=$(sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}')
+fi
 # Coarse footprint for observability only (NOT used for the hard gate — see header).
 CLAUDE_PROCS=$(pgrep -fc 'claude\.exe' 2>/dev/null || echo 0)
 
 AGENT_NAME=$(echo "$INPUT" | jq -r '.tool_input.name // "unknown"' 2>/dev/null)
 AGENT_TYPE=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // "general"' 2>/dev/null)
 
-source /workspace/.claude/hooks/event-log.sh
+EVENT_LOG="${CLAUDE_PROJECT_DIR:-/workspace}/.claude/hooks/event-log.sh"
+if [ -f "$EVENT_LOG" ]; then source "$EVENT_LOG"; else log_event() { :; }; fi
 log_event "agent_spawn" "agent=$AGENT_NAME" "type=$AGENT_TYPE" "ram_mb=$AVAIL_MB" "load1=$LOAD1" "cores=$CORES" "claude_procs=$CLAUDE_PROCS"
 
 # Prefer teammates over bare subagents for sprint work — warn but don't block.


### PR DESCRIPTION
The agent-spawn concurrency gate hard-depended on Linux-only probes: `free(1)` for available RAM, `/proc/loadavg` for the 1-min load, `nproc` for the core count, and a hardcoded `/workspace` path for `event-log.sh`. On a macOS checkout every probe failed, which blocked all agent spawns.

Changes (all fallback-guarded — Linux picks the original probes first):
- RAM: fall back to `vm_stat` pages (free+inactive+speculative) × `hw.pagesize`
- load: fall back to `sysctl vm.loadavg`
- cores: fall back to `sysctl hw.ncpu`
- `event-log.sh`: resolve via `CLAUDE_PROJECT_DIR` and no-op `log_event` when absent

Verified on darwin: dry-run spawn input exits 0 with sane RAM/load values; on Linux the `command -v free` / `-r /proc/loadavg` checks keep behavior byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG