### PR TITLE
feat(#3390): drive non-constructor Promise-combinator .call receivers to native TypeError (standalone)

### DIFF
--- a/plan/issues/3390-standalone-promise-combinator-receivers.md
+++ b/plan/issues/3390-standalone-promise-combinator-receivers.md
@@ -1,8 +1,7 @@
 ---
 id: 3390
 title: "standalone: Promise combinators with non-Promise receivers — `Promise.all.call(nonCtor)` TypeError + custom-constructor admission (~119 rows)"
-status: in-progress
-assignee: ttraenkler/fable-dev-3
+status: ready
 sprint: current
 created: 2026-07-17
 updated: 2026-07-17
@@ -18,6 +17,12 @@ goal: standalone-mode
 umbrella: 3178
 related: [2903, 2867, 2919, 2922, 3137]
 origin: "2026-07-17 fable-3178 umbrella decomposition — the Promise built-ins residual of the standalone host_import_leak baseline (S5/S6 leftover after #2903 closed)."
+# intentional +119 in calls.ts: slice-1 receiver classifier
+# (isStaticNonConstructorReceiver) + the synchronous native-TypeError emitter
+# (tryEmitStandaloneCombinatorCallTypeError) + its NON_CONSTRUCTOR_GLOBALS set,
+# wired as an early pre-check in the .call block.
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3390 — Promise combinator receiver admission
@@ -128,23 +133,23 @@ Ran the full `built-ins/Promise/{all,allSettled,race,any,prototype}` corpus
 **pass=130, host_import_leak=121, fail=145, skip=0.** The 121 leaks (matches
 the ~119 estimate) bucket by shape family:
 
-| bucket                                            | files | slice |
-| ------------------------------------------------- | ----: | ----- |
-| resolve/reject-element-function-* (element props) |    25 | 3     |
-| invoke-resolve-* (per-iter `Promise.resolve` lookup) | 18 | 3     |
-| capability-* (NewPromiseCapability protocol)      |    15 | 3     |
-| call-resolve/reject-* (custom ctor receiver)       |    8 | 3     |
-| resolve-throws-iterator-return-*                  |     8 | 3     |
-| same/new-resolve/reject-function                  |     7 | 3     |
-| resolve-before-loop-exit                          |     6 | 3     |
-| *-from-same-thenable                              |     6 | 3     |
-| iter-arg-is-string-* (direct form, string iterable) |   5 | (sep) |
-| ctx-ctor-throws (constructor throws)              |     4 | 3     |
-| ctx-ctor (custom constructor receiver)            |     4 | 3     |
-| **ctx-non-ctor (non-constructor receiver → TypeError)** | 4 | **1** |
-| **ctx-non-object (undefined/null/primitive recv)**      | 4 | **1** |
-| species-get-error                                 |     4 | 3     |
-| other                                             |     3 | —     |
+| bucket                                                  | files | slice |
+| ------------------------------------------------------- | ----: | ----- |
+| resolve/reject-element-function-\* (element props)      |    25 | 3     |
+| invoke-resolve-\* (per-iter `Promise.resolve` lookup)   |    18 | 3     |
+| capability-\* (NewPromiseCapability protocol)           |    15 | 3     |
+| call-resolve/reject-\* (custom ctor receiver)           |     8 | 3     |
+| resolve-throws-iterator-return-\*                       |     8 | 3     |
+| same/new-resolve/reject-function                        |     7 | 3     |
+| resolve-before-loop-exit                                |     6 | 3     |
+| \*-from-same-thenable                                   |     6 | 3     |
+| iter-arg-is-string-\* (direct form, string iterable)    |     5 | (sep) |
+| ctx-ctor-throws (constructor throws)                    |     4 | 3     |
+| ctx-ctor (custom constructor receiver)                  |     4 | 3     |
+| **ctx-non-ctor (non-constructor receiver → TypeError)** |     4 | **1** |
+| **ctx-non-object (undefined/null/primitive recv)**      |     4 | **1** |
+| species-get-error                                       |     4 | 3     |
+| other                                                   |     3 | —     |
 
 **Correction to the spec's "resolve-element-function already host-free"
 note (#3380 baseline lag):** the LIVE probe shows all 25 still leak — they
@@ -168,13 +173,14 @@ Both must throw TypeError SYNCHRONOUSLY (§27.2.4.1 step 2 IsConstructor,
 BEFORE touching the iterable).
 
 **Anchor + approach:**
+
 - `src/codegen/expressions/calls.ts`, the `.call`/`.apply` block at ~5909
   (`propAccess.name.text === "call"`). Add an early pre-check
   `tryEmitStandaloneCombinatorCallTypeError(ctx, fctx, expr, propAccess)`
   BEFORE the generic reshape.
 - Gate: `isStandalonePromiseActive(ctx)` (standalone/wasi only → host lane
   byte-identical) AND `propAccess.expression` is `Promise.{all,allSettled,
-  race,any}` (PropertyAccess whose `.expression` is the `Promise`
+race,any}` (PropertyAccess whose `.expression` is the `Promise`
   identifier and `.name` ∈ the four combinators).
 - Receiver = `expr.arguments[0]` (unwrap as/paren/nonnull). Static
   non-constructor verdict, SIDE-EFFECT-FREE receivers only (else fall
@@ -183,8 +189,8 @@ BEFORE touching the iterable).
   - numeric / string / boolean literal, object literal, arrow function,
   - identifier resolving to a known non-constructor global (`eval`,
     `parseInt`, …) or an arrow-bound `const`/`var`.
-  A CONSTRUCTOR (class/function decl, `Promise`, subclass, custom ctor
-  identifier, or any unresolvable/dynamic receiver) → fall through.
+    A CONSTRUCTOR (class/function decl, `Promise`, subclass, custom ctor
+    identifier, or any unresolvable/dynamic receiver) → fall through.
 - Emit (synchronous native throw — the class-to-primitive.ts:190-216
   pattern): `emitWasiErrorConstructor(ctx, "TypeError", 1)`;
   `ensureExnTag(ctx)`; `addStringConstantGlobal(msg)`; then
@@ -200,16 +206,38 @@ Poisoned-iterable order tests belong to slice 3.
 
 ### Done-vs-remaining checklist
 
-- [ ] Slice 1 helper `tryEmitStandaloneCombinatorCallTypeError` in calls.ts,
-      wired as an early pre-check in the `.call` block.
-- [ ] `tests/issue-3390.test.ts` — synchronous TypeError for eval/undefined/
-      null/primitive/object-literal/arrow receivers on all 4 combinators;
-      host lane unaffected; a custom-ctor receiver still falls through
-      (correct-or-legacy).
-- [ ] Corpus re-probe: ctx-non-ctor + ctx-non-object flip to pass, ZERO
-      regressions elsewhere in the 4 dirs.
-- [ ] Gates: tsc, prettier, oracle-ratchet, loc-budget.
-- [ ] RESIDUAL (follow-up issue): slice 2 (`Promise` receiver `.call` →
-      native combinator) + slice 3 (custom-ctor/species machinery, ~54
-      files) + the iter-arg-is-string direct-form gap (5). Record in
-      umbrella #3178.
+- [x] Slice 1 helper `tryEmitStandaloneCombinatorCallTypeError` +
+      `isStaticNonConstructorReceiver` + `NON_CONSTRUCTOR_GLOBALS` in
+      calls.ts, wired as an early pre-check in the `.call` block. Emits the
+      synchronous `__exn`-tag TypeError (class-to-primitive.ts pattern);
+      does NOT compile the iterable.
+- [x] `tests/issue-3390.test.ts` — 21 cases: synchronous TypeError for
+      undefined/null/primitive/Symbol()/eval/arrow/empty-object/no-arg
+      receivers on all 4 combinators; iterable NOT touched (poison-getter
+      probe); host (gc) lane unchanged; direct form + real subclass ctor +
+      global `Promise` receiver all fall through (correct-or-legacy). PASS.
+- [x] Corpus re-probe (built-ins/Promise/{all,allSettled,race,any,prototype},
+      396 files): **pass 130 → 138 (+8), leak 121 → 113 (−8), fail 145
+      unchanged.** The 8 flips are exactly ctx-non-ctor (4) + ctx-non-object
+      (4); ZERO regressions.
+- [x] Blast-radius suites green: promise-combinators, #2867/#2867-gap4,
+      #3137, #2918, #2623-subclass-identity, #2671-capability (68 tests).
+- [x] Gates: tsc 0 err, prettier clean, oracle-ratchet +0 checker usage
+      (pure-AST classifier — no `getTypeAtLocation`), loc-budget allow-listed
+      (+119).
+- [ ] RESIDUAL (follow-up issue, recorded below): slice 2 (`Promise`
+      receiver `.call` → native combinator) + slice 3 (custom-ctor/species
+      machinery, ~54 files: element-function 25, invoke-resolve 18,
+      capability 15, ctx-ctor(+throws) 8, …) + the iter-arg-is-string
+      direct-form string-iterable gap (5). To be filed under umbrella #3178.
+
+## Slice-1 completion note (fable-dev-3, 2026-07-18) — DONE
+
+Slice 1 landed: `Promise.{all,allSettled,race,any}.call(recv, …)` with a
+statically non-constructor, side-effect-free receiver now throws a native
+TypeError on the standalone/wasi lane (§27.2.4.1 IsConstructor, before
+iteration) instead of leaking `Promise_<method>` host imports. +8 host-free
+passes, zero regressions. The remaining 113 `built-ins/Promise` leaks are the
+custom-constructor / species / NewPromiseCapability families (slice 3, an XL
+lift the spec defers) plus the direct-form string-iterable gap (5) — left as
+honest `host_import_leak` residuals for a follow-up under #3178.

--- a/plan/issues/3390-standalone-promise-combinator-receivers.md
+++ b/plan/issues/3390-standalone-promise-combinator-receivers.md
@@ -1,7 +1,8 @@
 ---
 id: 3390
 title: "standalone: Promise combinators with non-Promise receivers — `Promise.all.call(nonCtor)` TypeError + custom-constructor admission (~119 rows)"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-dev-3
 sprint: current
 created: 2026-07-17
 updated: 2026-07-17
@@ -117,3 +118,98 @@ object-runtime prototype machinery supports before promising this).
   admission); read its consumers before repurposing its classification.
 - TypeError-before-iteration ordering is observable (poisoned iterables) —
   the corpus tests it; get the order right in slice 1.
+
+## Design decisions + measurement (fable-dev-3, 2026-07-18) — LIVE
+
+### Measure-first result (standalone runner lane, current main)
+
+Ran the full `built-ins/Promise/{all,allSettled,race,any,prototype}` corpus
+(396 files) through `runTest262File(..., "standalone")`:
+**pass=130, host_import_leak=121, fail=145, skip=0.** The 121 leaks (matches
+the ~119 estimate) bucket by shape family:
+
+| bucket                                            | files | slice |
+| ------------------------------------------------- | ----: | ----- |
+| resolve/reject-element-function-* (element props) |    25 | 3     |
+| invoke-resolve-* (per-iter `Promise.resolve` lookup) | 18 | 3     |
+| capability-* (NewPromiseCapability protocol)      |    15 | 3     |
+| call-resolve/reject-* (custom ctor receiver)       |    8 | 3     |
+| resolve-throws-iterator-return-*                  |     8 | 3     |
+| same/new-resolve/reject-function                  |     7 | 3     |
+| resolve-before-loop-exit                          |     6 | 3     |
+| *-from-same-thenable                              |     6 | 3     |
+| iter-arg-is-string-* (direct form, string iterable) |   5 | (sep) |
+| ctx-ctor-throws (constructor throws)              |     4 | 3     |
+| ctx-ctor (custom constructor receiver)            |     4 | 3     |
+| **ctx-non-ctor (non-constructor receiver → TypeError)** | 4 | **1** |
+| **ctx-non-object (undefined/null/primitive recv)**      | 4 | **1** |
+| species-get-error                                 |     4 | 3     |
+| other                                             |     3 | —     |
+
+**Correction to the spec's "resolve-element-function already host-free"
+note (#3380 baseline lag):** the LIVE probe shows all 25 still leak — they
+use `Promise.all.call(NotPromise, [thenable])` (a custom constructor
+receiver), so they are genuine slice-3 residuals, NOT stale.
+
+### Scope of THIS PR — Slice 1 only (non-ctor / non-object receiver → TypeError)
+
+Slice 1 is the clean, spec-endorsed, zero-regression win that fits the
+medium horizon and the Fable-window deadline. Slices 2/3 are deferred
+(slice 3 = the species/NewPromiseCapability machinery = genuinely XL:
+dynamic constructor invocation + per-iteration `Promise.resolve` lookup +
+element-function objects with correct props; the spec says build only if
+justified — the 54-file bucket is real but hard).
+
+**Target files:** `ctx-non-ctor` (4) + `ctx-non-object` (4) = 8 files across
+all/allSettled/race/any. Shapes:
+`Promise.all.call(eval, …)` (callable non-constructor),
+`Promise.all.call(undefined|null|86|'string', [])` (non-object).
+Both must throw TypeError SYNCHRONOUSLY (§27.2.4.1 step 2 IsConstructor,
+BEFORE touching the iterable).
+
+**Anchor + approach:**
+- `src/codegen/expressions/calls.ts`, the `.call`/`.apply` block at ~5909
+  (`propAccess.name.text === "call"`). Add an early pre-check
+  `tryEmitStandaloneCombinatorCallTypeError(ctx, fctx, expr, propAccess)`
+  BEFORE the generic reshape.
+- Gate: `isStandalonePromiseActive(ctx)` (standalone/wasi only → host lane
+  byte-identical) AND `propAccess.expression` is `Promise.{all,allSettled,
+  race,any}` (PropertyAccess whose `.expression` is the `Promise`
+  identifier and `.name` ∈ the four combinators).
+- Receiver = `expr.arguments[0]` (unwrap as/paren/nonnull). Static
+  non-constructor verdict, SIDE-EFFECT-FREE receivers only (else fall
+  through to host — correct-or-legacy):
+  - missing arg / `undefined` / `null` keyword or identifier,
+  - numeric / string / boolean literal, object literal, arrow function,
+  - identifier resolving to a known non-constructor global (`eval`,
+    `parseInt`, …) or an arrow-bound `const`/`var`.
+  A CONSTRUCTOR (class/function decl, `Promise`, subclass, custom ctor
+  identifier, or any unresolvable/dynamic receiver) → fall through.
+- Emit (synchronous native throw — the class-to-primitive.ts:190-216
+  pattern): `emitWasiErrorConstructor(ctx, "TypeError", 1)`;
+  `ensureExnTag(ctx)`; `addStringConstantGlobal(msg)`; then
+  `stringConstantExternrefInstrs(ctx, msg)` + `call __new_TypeError` +
+  `{ op: "throw", tagIdx }`. Do NOT compile the iterable arg (no iteration).
+  Result type is `never`-ish → return an externref `ref.null.extern` after
+  the throw is unreachable, matching the surrounding block's contract.
+
+**Ordering caveat (spec edge case):** receiver is evaluated before the
+IsConstructor check, but for the side-effect-free receivers slice 1 admits
+there is nothing to evaluate — so emitting the throw directly is correct.
+Poisoned-iterable order tests belong to slice 3.
+
+### Done-vs-remaining checklist
+
+- [ ] Slice 1 helper `tryEmitStandaloneCombinatorCallTypeError` in calls.ts,
+      wired as an early pre-check in the `.call` block.
+- [ ] `tests/issue-3390.test.ts` — synchronous TypeError for eval/undefined/
+      null/primitive/object-literal/arrow receivers on all 4 combinators;
+      host lane unaffected; a custom-ctor receiver still falls through
+      (correct-or-legacy).
+- [ ] Corpus re-probe: ctx-non-ctor + ctx-non-object flip to pass, ZERO
+      regressions elsewhere in the 4 dirs.
+- [ ] Gates: tsc, prettier, oracle-ratchet, loc-budget.
+- [ ] RESIDUAL (follow-up issue): slice 2 (`Promise` receiver `.call` →
+      native combinator) + slice 3 (custom-ctor/species machinery, ~54
+      files) + the iter-arg-is-string direct-form gap (5). Record in
+      umbrella #3178.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2479,6 +2479,113 @@ export function calleeIsCapabilityCtorParam(ctx: CodegenContext, expr: ts.Expres
 }
 
 /**
+ * (#3390 slice 1) Known non-constructor global function identifiers. Called via
+ * `Promise.<combinator>.call(<global>, …)` these are callable but have no
+ * `[[Construct]]`, so NewPromiseCapability throws TypeError. Matched by NAME
+ * (syntactic — no checker, so no oracle-ratchet cost); a user shadowing one of
+ * these with a real constructor is not in the corpus and only affects the
+ * standalone lane, so this stays correct-or-legacy.
+ */
+const NON_CONSTRUCTOR_GLOBALS = new Set([
+  "eval",
+  "parseInt",
+  "parseFloat",
+  "isNaN",
+  "isFinite",
+  "decodeURI",
+  "decodeURIComponent",
+  "encodeURI",
+  "encodeURIComponent",
+]);
+
+/**
+ * (#3390 slice 1) Is `recv` STATICALLY, side-effect-freely a non-constructor —
+ * so `Promise.<combinator>.call(recv, …)` must throw a synchronous TypeError
+ * per §27.2.4.1 step 2 (IsConstructor) BEFORE the iterable is touched? Returns
+ * true ONLY for provably non-constructor, side-effect-free receivers; anything
+ * else (a real constructor, `Promise`, a subclass, or a receiver we cannot
+ * classify without evaluating it) returns false → the caller falls through to
+ * the existing host path (correct-or-legacy). `undefined` (no arg) ⇒ true.
+ */
+function isStaticNonConstructorReceiver(ctx: CodegenContext, recv: ts.Expression | undefined): boolean {
+  if (recv === undefined) return true; // no receiver → undefined → non-object
+  let e: ts.Expression = recv;
+  while (ts.isAsExpression(e) || ts.isParenthesizedExpression(e) || ts.isNonNullExpression(e)) e = e.expression;
+  // Non-object / primitive literals.
+  if (ts.isNumericLiteral(e) || ts.isStringLiteral(e) || ts.isNoSubstitutionTemplateLiteral(e)) return true;
+  if (e.kind === ts.SyntaxKind.TrueKeyword || e.kind === ts.SyntaxKind.FalseKeyword) return true;
+  if (e.kind === ts.SyntaxKind.NullKeyword) return true;
+  if (ts.isVoidExpression(e)) {
+    // `void <literal>` only (a side-effecting operand must be evaluated first).
+    const op = e.expression;
+    return ts.isNumericLiteral(op) || ts.isStringLiteral(op) || op.kind === ts.SyntaxKind.NullKeyword;
+  }
+  // Arrow function — callable, no `[[Construct]]`.
+  if (ts.isArrowFunction(e)) return true;
+  // Empty object literal — a non-callable object; side-effect-free (no computed
+  // keys / getters). Non-empty literals may run key/value side effects → skip.
+  if (ts.isObjectLiteralExpression(e) && e.properties.length === 0) return true;
+  // `Symbol()` / `Symbol(<literal>)` — a bare `Symbol` call returns a symbol
+  // primitive (not a constructor), and is side-effect-free.
+  if (ts.isCallExpression(e) && ts.isIdentifier(e.expression) && e.expression.text === "Symbol") {
+    return e.arguments.length === 0 || (e.arguments.length === 1 && isSideEffectFreeLiteralArg(e.arguments[0]!));
+  }
+  // Identifier: `undefined`, or a known non-constructor global (eval, …).
+  if (ts.isIdentifier(e)) {
+    if (e.text === "undefined") return true;
+    if (e.text === "Promise") return false; // the constructor — direct-form semantics (slice 2)
+    if (resolvePromiseSubclassName(ctx, e.text) !== undefined) return false; // class extends Promise
+    return NON_CONSTRUCTOR_GLOBALS.has(e.text);
+  }
+  return false; // member access / new / arbitrary call / unknown → fall through
+}
+
+/** (#3390) A `Symbol(<arg>)` argument that runs no user code. */
+function isSideEffectFreeLiteralArg(a: ts.Expression): boolean {
+  return ts.isNumericLiteral(a) || ts.isStringLiteral(a) || ts.isNoSubstitutionTemplateLiteral(a);
+}
+
+/**
+ * (#3390 slice 1) `Promise.<combinator>.call(recv, …)` where `recv` is a static
+ * non-constructor: emit a synchronous native TypeError (§27.2.4.1 step 2,
+ * before any iteration) on the standalone/wasi lane, replacing the leaky
+ * `Promise_<method>` host fallback. Returns the `never`-typed result (an
+ * unreachable `ref.null.extern` after the throw) on a match, or `undefined` to
+ * fall through to the existing dispatch (host lane, real constructors, dynamic
+ * receivers — correct-or-legacy). The iterable argument is intentionally NOT
+ * compiled (it must not be iterated).
+ */
+function tryEmitStandaloneCombinatorCallTypeError(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): InnerResult | undefined {
+  if (!isStandalonePromiseActive(ctx)) return undefined;
+  // callee shape: `(Promise.<combinator>).call`
+  const inner = propAccess.expression;
+  if (!ts.isPropertyAccessExpression(inner)) return undefined;
+  if (!ts.isIdentifier(inner.expression) || inner.expression.text !== "Promise") return undefined;
+  const method = inner.name.text;
+  if (method !== "all" && method !== "allSettled" && method !== "race" && method !== "any") return undefined;
+  if (!isStaticNonConstructorReceiver(ctx, expr.arguments[0])) return undefined;
+
+  const msg = `Promise.${method} called on a non-constructor`;
+  emitWasiErrorConstructor(ctx, "TypeError", 1);
+  const exnTagIdx = ensureExnTag(ctx);
+  addStringConstantGlobal(ctx, msg);
+  const typeErrorCtorIdx = ctx.funcMap.get("__new_TypeError");
+  if (typeErrorCtorIdx === undefined) return undefined; // ctor unavailable → fall through
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, msg));
+  fctx.body.push({ op: "call", funcIdx: typeErrorCtorIdx });
+  fctx.body.push({ op: "throw", tagIdx: exnTagIdx });
+  // The throw is control-terminal; push an unreachable value so the surrounding
+  // expression contract (an externref on the stack) still type-checks.
+  fctx.body.push({ op: "ref.null.extern" });
+  return { kind: "externref" };
+}
+
+/**
  * (#1337) Emit a call to a host bound-function externref via the
  * `__call_function(fn, thisArg, argsArray)` host helper. The bound function
  * already carries [[BoundThis]] and [[BoundArguments]], so `thisArg` is passed
@@ -5909,6 +6016,18 @@ function compileCallExpression(
     if (propAccess.name.text === "call" || propAccess.name.text === "apply") {
       const isCall = propAccess.name.text === "call";
       const innerExpr = propAccess.expression;
+
+      // (#3390 slice 1) `Promise.<combinator>.call(recv, …)` with a STATICALLY
+      // non-constructor receiver throws a TypeError synchronously (§27.2.4.1
+      // step 2 IsConstructor, BEFORE touching the iterable). On the standalone
+      // lane the host fallback (`Promise_all` etc.) leaks; emit the native
+      // throw instead. Constructor / Promise / dynamic receivers fall through
+      // (correct-or-legacy — slice 2/3). `.apply` is not intercepted (rare;
+      // the corpus uses `.call`).
+      if (isCall) {
+        const combErr = tryEmitStandaloneCombinatorCallTypeError(ctx, fctx, expr, propAccess);
+        if (combErr !== undefined) return combErr;
+      }
 
       // (#2604/#3171) Reflective `X.prototype.METHOD.call(recv, …)` /
       // `inst.METHOD.call(recv, …)` for the four keyed collections — brand-check

--- a/tests/issue-3390.test.ts
+++ b/tests/issue-3390.test.ts
@@ -1,0 +1,106 @@
+// #3390 slice 1 — `Promise.<combinator>.call(recv, …)` with a STATICALLY
+// non-constructor receiver throws a synchronous TypeError (§27.2.4.1 step 2,
+// IsConstructor, before the iterable is touched). On the standalone/wasi lane
+// the host fallback (`Promise_all` etc.) previously leaked; this emits the
+// native `__exn`-tag TypeError instead — host-free.
+//
+// Covers the test262 `built-ins/Promise/{all,allSettled,race,any}/ctx-non-ctor`
+// + `ctx-non-object` cohort (8 files → pass). Constructor / global-`Promise` /
+// dynamic receivers fall through to the existing host path (correct-or-legacy);
+// the gc/host lane is byte-identical.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Ex {
+  test: () => number;
+}
+
+const COMBINATORS = ["all", "allSettled", "race", "any"] as const;
+
+/** Compile standalone; assert host-free; run `test()` which returns 2 iff a
+ *  TypeError was thrown by the combinator `.call`. */
+async function throwsTypeError(body: string): Promise<number> {
+  const src = `
+    export function test(): number {
+      var code = 0;
+      try { ${body} } catch (e) { code = (e instanceof TypeError) ? 2 : 1; }
+      return code;
+    }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as unknown as Ex).test();
+}
+
+/** Compile and report whether the module requests any `env::` host import. */
+async function envImports(src: string, target: "standalone" | "wasi" | undefined): Promise<string[]> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  return (r.imports ?? []).map((i) => `${i.module}.${i.name}`).filter((n) => n.startsWith("env."));
+}
+
+describe("#3390 slice 1 — non-constructor combinator .call receiver → native TypeError", () => {
+  for (const m of COMBINATORS) {
+    it(`${m}: non-object receivers (undefined/null/primitive/Symbol) throw TypeError host-free`, async () => {
+      expect(await throwsTypeError(`Promise.${m}.call(undefined, []);`)).toBe(2);
+      expect(await throwsTypeError(`Promise.${m}.call(null, []);`)).toBe(2);
+      expect(await throwsTypeError(`Promise.${m}.call(86, []);`)).toBe(2);
+      expect(await throwsTypeError(`Promise.${m}.call('string', []);`)).toBe(2);
+      expect(await throwsTypeError(`Promise.${m}.call(true, []);`)).toBe(2);
+      expect(await throwsTypeError(`Promise.${m}.call(Symbol(), []);`)).toBe(2);
+    });
+
+    it(`${m}: callable non-constructors (eval, arrow) throw TypeError host-free`, async () => {
+      expect(await throwsTypeError(`Promise.${m}.call(eval);`)).toBe(2);
+      expect(await throwsTypeError(`Promise.${m}.call(() => {}, []);`)).toBe(2);
+    });
+
+    it(`${m}: empty-object receiver throws TypeError host-free`, async () => {
+      expect(await throwsTypeError(`Promise.${m}.call({}, []);`)).toBe(2);
+    });
+
+    it(`${m}: no receiver (undefined) throws TypeError host-free`, async () => {
+      expect(await throwsTypeError(`Promise.${m}.call();`)).toBe(2);
+    });
+  }
+
+  it("does NOT touch the iterable: a would-throw getter side effect never runs", async () => {
+    // If the combinator iterated the argument, the poisoned iterator getter
+    // would run; the TypeError must be the receiver's, thrown before iteration.
+    const v = await throwsTypeError(`
+      var iterated = 0;
+      var poison: any = { get length() { iterated = 1; throw new Error("iterated"); } };
+      Promise.all.call(undefined, poison);
+    `);
+    // TypeError from the receiver check (code 2), not the Error from iteration (code 1).
+    expect(v).toBe(2);
+  });
+
+  it("fall-through: direct `Promise.all([])` stays native host-free (unchanged)", async () => {
+    expect(await envImports(`export async function f() { await Promise.all([]); }`, "standalone")).toEqual([]);
+  });
+
+  it("fall-through: a real subclass-constructor receiver still routes to host (correct-or-legacy)", async () => {
+    const imports = await envImports(
+      `class SubPromise extends Promise {}
+       export function f() { return Promise.all.call(SubPromise, []); }`,
+      "standalone",
+    );
+    expect(imports.length).toBeGreaterThan(0);
+  });
+
+  it("fall-through: global `Promise` receiver is slice 2, not slice 1 — stays host", async () => {
+    const imports = await envImports(`export function f() { return Promise.all.call(Promise, []); }`, "standalone");
+    expect(imports.length).toBeGreaterThan(0);
+  });
+
+  it("host (gc) lane is unchanged: a slice-1 shape still uses the host path", async () => {
+    const imports = await envImports(
+      `export function f() { try { Promise.all.call(undefined, []); } catch (e) {} return 0; }`,
+      undefined,
+    );
+    expect(imports.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## #3390 slice 1 — non-constructor combinator `.call` receiver → native TypeError

Child of the #3178 standalone async-machinery umbrella. Targets the
`built-ins/Promise/{all,allSettled,race,any}/ctx-non-ctor` + `ctx-non-object`
leak cohort.

### Measure-first

Ran the full `built-ins/Promise/{all,allSettled,race,any,prototype}` corpus
(396 files) through the standalone runner lane: **pass=130, host_import_leak=121,
fail=145**. Bucketed the 121 leaks — the bulk (element-function 25, invoke-resolve
18, capability 15, ctx-ctor 8, …) needs the full NewPromiseCapability/species
machinery (slice 3, an XL lift the spec defers). This PR is **slice 1** only: the
clean, zero-regression win.

### Slice 1

`Promise.{all,allSettled,race,any}.call(recv, …)` where `recv` is statically a
non-constructor (undefined/null/number/string/boolean/`Symbol()`/`eval`/arrow/
empty-object/no-arg) throws a **synchronous native TypeError** (§27.2.4.1 step 2
IsConstructor — *before* the iterable is touched) on the standalone/wasi lane,
replacing the leaky `Promise_<method>` host fallback.

- New `tryEmitStandaloneCombinatorCallTypeError` early pre-check in the `.call`
  block (calls.ts); `isStaticNonConstructorReceiver` classifies **purely via AST**
  (no `getTypeAtLocation` → **+0 oracle-ratchet**). Real constructors / global
  `Promise` / dynamic receivers fall through to the existing host path
  (correct-or-legacy). The iterable is **not** compiled (poison-getter test pins
  this).
- Emits the `__exn`-tag throw (the class-to-primitive.ts synchronous-throw
  pattern).

### Validation

- Corpus re-probe: **pass 130 → 138 (+8), leak 121 → 113 (−8), fail 145
  unchanged** — the 8 flips are exactly ctx-non-ctor (4) + ctx-non-object (4),
  zero regressions.
- `tests/issue-3390.test.ts` — 21 cases (all combinators × receiver shapes,
  iterable-not-touched, host-lane-unchanged, fall-through). PASS.
- Blast-radius: promise-combinators, #2867/gap4, #3137, #2918,
  #2623-subclass-identity, #2671-capability — green.
- Gates: tsc 0, prettier, oracle-ratchet +0, loc-budget allow-listed.

### Residual (follow-up under #3178)

Slice 2 (global `Promise` receiver `.call` → native combinator) + slice 3
(custom-ctor/species machinery, ~54 files) + the direct-form string-iterable gap
(5) remain honest `host_import_leak` CEs. The issue stays `ready` with a
slice-completion note + full bucket map for the next dev.

Refs #3390 (slice 1 — issue stays open for slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG