### PR TITLE
chore: sync README standalone conformance (24,723) — unparks the quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Conformance is tracked along the two compile paths — both figures auto-update 
 The line above is the **JS-host path** (default `gc` target): runs alongside the js2wasm JS runtime, which supplies host imports for some built-ins.
 
 <!-- AUTO:conformance-standalone-start -->
-**standalone (host-free) test262 conformance**: 24,711 / 43,106 (57.3 %)
+**standalone (host-free) test262 conformance**: 24,723 / 43,106 (57.4 %)
 <!-- AUTO:conformance-standalone-end -->
 
 The line above is the **standalone path** (`--target standalone`/`wasi`): pure WasmGC with no JS host, measured host-free on the same official denominator. Lower today and actively hardening — this is where the current gap is.


### PR DESCRIPTION
Every merge_group build is currently failing the `quality` gate on `sync:conformance --check`: README says standalone 24,711 but the 22:42Z Baseline Refresh moved the baseline to 24,723. The auto-sync commit that normally fixes this runs on push-to-main, which the earlier queue stall prevented — chicken-and-egg. This PR carries the sync, so its own merge group validates against the fixed README and every PR behind it unparks.

Shepherd: jump this to the queue front once green; then clear the 4 quality-parked holds (#3288/#3295/#3305/#3317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG