### PR TITLE
docs(#2872): takeover + fresh 2026-07-18 re-measurement + precise findLast root cause

### DIFF
--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -2,9 +2,9 @@
 id: 2872
 title: "Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)"
 status: in-progress
-assignee: ttraenkler/agent-a30d0acc00d3c78c5
+assignee: ttraenkler/fable-dev-4
 created: 2026-06-30
-updated: 2026-07-12
+updated: 2026-07-18
 priority: high
 task_type: bug
 feasibility: hard
@@ -22,6 +22,68 @@ loc-budget-allow:
   - src/codegen/expressions/new-super.ts
   - src/codegen/expressions/calls-closures.ts
 ---
+
+## Takeover + fresh 2026-07-18 re-measurement (fable-dev-4)
+
+**Assignee cleared 2026-07-18** — was `ttraenkler/agent-a30d0acc00d3c78c5`,
+stale since 07-11/07-12 (docs-only newest activity, 6 days dead, no open PR;
+tech-lead approved the takeover after a coordination scan). The 4 prior branches
+(`issue-2872-standalone-typedarray-hof`/`-proto`, `-real-clusters`,
+`ta-proto-methods`) carry slices 1–4 that already MERGED to main per the
+progress log below (`.fill`, `copyWithin`/`reverse`, `reduce`/`reduceRight` +
+boolean-result boxing). This takeover grounds on landed main, not those branches.
+
+**Fresh gap re-measure** (2026-07-18 promoted standalone baseline vs host, official
+scope, `file|strict` match): `built-ins/TypedArray/prototype/*` = **690 gap rows**
+(host pass ∧ standalone not-pass), up from the 294 original estimate — the metric
+de-masked runtime failures as the carriers landed (this is the #2860 re-measure's
+"assertion_fail now dominates" shift, localised to TA.prototype).
+
+### Two coherent slices (per-method + failure-signature sub-bucketing)
+
+The dominant failure across NEARLY EVERY method is **`assertion_fail` with an
+`assert.throws` signature** — the method is implemented but a spec-mandated
+throw is missing:
+
+| method | gap | dominant category |
+| ------ | --: | ----------------- |
+| slice | 58 | assertion_fail 45 (assert.throws 17), type_error 11 |
+| set | 53 | assertion_fail 46 (assert.throws 22) |
+| map | 48 | assertion_fail 38 (assert.throws 17) |
+| subarray | 46 | assertion_fail 38 (assert.throws 13) |
+| filter | 43 | assertion_fail 35 (assert.throws 15) |
+| fill | 27 | assertion_fail 25 (assert.throws 10) — *slice-1 landed the value path* |
+| copyWithin | 22 | assertion_fail 20 — *slice-2 landed value path* |
+| reduce/reduceRight | 44 | assertion_fail 34 — *slice-4 landed value path* |
+| **findLast/findLastIndex** | **43** | **host_import_leak 33** (`env::Uint8ClampedArray_findLast[Index]`) + assertion_fail 10 |
+| includes/indexOf/lastIndexOf | 60 | assertion_fail (assert.sameValue) |
+
+**SLICE 5 (this branch, the clean self-contained one) — `findLast` /
+`findLastIndex` on `Uint8ClampedArray`.** Unlike every other method, the
+dominant failure here is a genuine **host_import_leak** (`env::
+Uint8ClampedArray_findLast` ×17, `env::Uint8ClampedArray_findLastIndex` ×16) —
+the native dyn-view HOF arm covers the other TA element kinds but not the
+CLAMPED variant for these two reverse-iterating callback methods. This mirrors
+the slice-1–4 per-method dyn-view pattern (the value path already exists for
+non-clamped; extend the clamped element-kind arm). Entry points: the reverse
+callback setup at `array-methods.ts:6226`/`:6270` (`setupArrayLoopReverse`,
+`findLast`/`findLastIndex` array impls) and the TA dyn-view HOF dispatch in
+`ta-hof-map-filter.ts` + the `#3058/#3098` `__hof` substrate — find where the
+non-clamped element kinds route native and the clamped kind falls to the
+per-ctor `env::Uint8ClampedArray_*` import, and extend it.
+
+**SLICE 6+ (the BIG lever, NOT this PR — recommend a dedicated follow-on) —
+the cross-method `assert.throws` cluster (~150+ rows).** slice/set/map/subarray/
+filter/fill/copyWithin all share a missing spec-throw: calling the method with a
+detached buffer, an out-of-bounds/invalid index arg, or a wrong receiver brand
+must throw TypeError/RangeError but does not (the tests are
+`assert.throws(TypeError, () => ta.method(bad))`). A SHARED validation-prelude
+(detached-buffer guard + ToIntegerOrInfinity/range checks + brand check) emitted
+once and reused across the dyn-view method arms would flip a large coherent
+batch — but it needs its own measure-first slice (each method's exact throw
+conditions differ) and touches the shared dyn-view method emitter, so it is a
+separate PR from slice 5. Flagging it here as the highest-remaining-lever
+follow-on for tech-lead scheduling.
 
 ## Progress (2026-07-12, fable) — Slice 4: dyn-view reduce/reduceRight + boolean-result boxing (REUSE-first)
 

--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -58,19 +58,50 @@ throw is missing:
 | **findLast/findLastIndex** | **43** | **host_import_leak 33** (`env::Uint8ClampedArray_findLast[Index]`) + assertion_fail 10 |
 | includes/indexOf/lastIndexOf | 60 | assertion_fail (assert.sameValue) |
 
-**SLICE 5 (this branch, the clean self-contained one) — `findLast` /
-`findLastIndex` on `Uint8ClampedArray`.** Unlike every other method, the
-dominant failure here is a genuine **host_import_leak** (`env::
-Uint8ClampedArray_findLast` ×17, `env::Uint8ClampedArray_findLastIndex` ×16) —
-the native dyn-view HOF arm covers the other TA element kinds but not the
-CLAMPED variant for these two reverse-iterating callback methods. This mirrors
-the slice-1–4 per-method dyn-view pattern (the value path already exists for
-non-clamped; extend the clamped element-kind arm). Entry points: the reverse
-callback setup at `array-methods.ts:6226`/`:6270` (`setupArrayLoopReverse`,
-`findLast`/`findLastIndex` array impls) and the TA dyn-view HOF dispatch in
-`ta-hof-map-filter.ts` + the `#3058/#3098` `__hof` substrate — find where the
-non-clamped element kinds route native and the clamped kind falls to the
-per-ctor `env::Uint8ClampedArray_*` import, and extend it.
+**SLICE 5 — `findLast` / `findLastIndex` host-free (PRECISELY root-caused
+2026-07-18; deeper than a clean "add to set" — NOT yet landed).** The dominant
+failure is a genuine **host_import_leak** (`env::Uint8ClampedArray_findLast`
+×17, `env::Uint8ClampedArray_findLastIndex` ×16). Traced end-to-end — it is a
+**two-part** gap, not one:
+
+1. **Direct-receiver path (FIXED by a 1-line-ish change, verified):** the
+   `#3058` dyn-view two-arm set `DYN_VIEW_READ_METHODS` (array-methods.ts:829)
+   + `FIND_METHODS` (:867) EXCLUDED findLast/findLastIndex behind a **stale**
+   note ("legacy `compileArrayFind` re-entry misses `__call_1_f64` → CE"). The
+   `#3098` `__hof` substrate ALREADY has the backward steppers (`__hof_findLast`
+   /`__hof_findLastIndex`, `hof-native.ts:63-64,110` `backward` flag), exactly
+   like the already-shipped find/findIndex. Adding findLast/findLastIndex to
+   BOTH sets makes a **statically-typed** `new Uint8ClampedArray([…]).findLast(cb)`
+   compile host-free + correct (probe-verified: values right, `typeof` of
+   not-found = "undefined", reverse order correct, identical behaviour to the
+   shipped `find`). This part is a safe, isolated win.
+
+2. **`any`-receiver harness path (the ACTUAL test262 shape — STILL LEAKS after
+   part 1):** test262's `testWithTypedArrayConstructors(TA => new TA(…).method)`
+   wraps the receiver as `any`, producing the boxed `$__ta_dyn_view`. The
+   two-arm THEN arm then handles it correctly, BUT the two-arm always ALSO
+   compiles its **ELSE arm** (the "not a dyn-view at runtime" fallback), which
+   re-dispatches via `compileExpression` →
+   `compileReceiverMethodCall` → **`tryExternClassMethodOnAny`
+   (calls-closures.ts:~1519 first-match loop)**. That loop greedily binds the
+   first extern class declaring the method — a TypedArray view — to the per-ctor
+   `env::Uint8ClampedArray_findLast` HOST import (addImport at
+   calls-closures.ts:1550). Because the import is emitted at COMPILE time (both
+   arms compile), the binary leaks even though the THEN arm would run. **Fix
+   location: `tryExternClassMethodOnAny`** — it already has the exact precedent
+   at line 1514 (`join` routes native under `noJsHost` instead of binding
+   `env::Uint8ClampedArray_join`) and the `.slice`/`.replace` `continue`
+   refusals (line 1543). Under `noJsHost`, a TA-view extern-class binding for a
+   scalar-HOF method (the `STANDALONE_TA_SCALAR_HOFS` set in calls.ts:1514 —
+   find/findIndex/findLast/findLastIndex/forEach/some/every/reduce/reduceRight)
+   should be **declined** (`continue`) so the call falls through to the
+   host-free generic path, exactly like `join`. This is a SHARED fix: it would
+   also close the same latent any-receiver leak for the other scalar HOFs, so it
+   warrants its own measure-first slice + a full any-receiver regression sweep
+   (the dispatch is sensitive — the #1712 acorn `.replace` collision lived
+   here). Both parts together are slice 5; part 2 is the load-bearing one for
+   the test262 harness rows and is why this was reverted rather than shipped
+   half-done (part 1 alone flips ~0 harness rows).
 
 **SLICE 6+ (the BIG lever, NOT this PR — recommend a dedicated follow-on) —
 the cross-method `assert.throws` cluster (~150+ rows).** slice/set/map/subarray/


### PR DESCRIPTION
## #2872 takeover (doc-only)

Takes over the stale #2872 assignment (`agent-a30d…`, dead since 07-12, no open PR — tech-lead approved) and re-grounds it on fresh data.

### Fresh re-measurement (2026-07-18 baseline)
`built-ins/TypedArray/prototype/*` gap = **690 rows** (was the 294 original estimate) — the metric de-masked runtime failures as the carriers landed. Sub-bucketed by method + failure signature:
- **Cross-method `assert.throws` cluster (~150+)** — methods implemented but missing spec brand-check / detached-buffer / arg-validation throws (slice/set/map/subarray/filter/…). Flagged as the highest-remaining lever; warrants a shared-validation-prelude slice.
- **findLast/findLastIndex `host_import_leak` (~33)** — the one genuine not-implemented leak; root-caused precisely (below).

### findLast/findLastIndex — precise 2-part root cause
1. **Direct-receiver path (fix verified):** findLast/findLastIndex were excluded from the `#3058` dyn-view two-arm behind a **stale** note; the `#3098` `__hof` substrate already has the backward steppers. Adding them makes a statically-typed `new Uint8ClampedArray([…]).findLast(cb)` host-free + correct.
2. **`any`-receiver harness path (the actual test262 shape — load-bearing):** the two-arm ELSE arm re-dispatches through `tryExternClassMethodOnAny` (calls-closures.ts:1519), whose first-match loop binds the per-ctor `env::Uint8ClampedArray_findLast`. **Fix location + the exact `join` precedent (line 1514) documented** — a shared scalar-HOF any-receiver decline under `noJsHost`, warranting its own regression sweep (sensitive dispatch — the #1712 acorn `.replace` collision lived here).

The part-1-only code change was **reverted** (flips ~0 harness rows alone); this PR banks the takeover + the exact fix map so the next dev (or a follow-up with adequate budget) lands both parts together.

Doc-only: `plan/issues/2872-*.md` (assignee swap + fresh analysis + slice-5/6 plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)