### PR TITLE
fix(#2875): reflective String proto non-string ToString — box-struct ordering + trim flatten (standalone)

### DIFF
--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -13,6 +13,11 @@ sprint: current
 horizon: l
 related: [2860, 2870, 2862, 2885]
 umbrella: 2860
+# Slice A (#2875, 2026-07-18): +21 native-strings.ts (box-struct ensure comment
+# + addUnionImports call) and +10 array-object-proto.ts (trim flatten + guard).
+loc-budget-allow:
+  - src/codegen/native-strings.ts
+  - src/codegen/array-object-proto.ts
 ---
 
 > **Blocked on #2885** (standalone descriptor-reflection core). The reflective
@@ -176,7 +181,7 @@ family split across two PRs):
   combine (§22.1.3.4); f64 result boxed via `__box_number` ensured in the same
   first late-import batch as `__unbox_number` (funcidx-shift discipline). 10/10
   host-free tests pass; byte-diff neutrality re-verified after `git merge
-  origin/main` (12/12 unrelated programs byte-identical to main; only the two
+origin/main` (12/12 unrelated programs byte-identical to main; only the two
   target reflective programs change output).
 - **Slice 3 — in PR (dev-2875f, salvaged from dev-2875b's rotation):** the full
   search family — `indexOf`, `lastIndexOf` (number results, `__box_number`) and
@@ -229,6 +234,7 @@ family split across two PRs):
     (matches the direct path's static-only `argIsStaticRegExp` fold); no
     test262 case exercises a runtime-only RegExp arg reaching a reflective
     call today.
+
 - **Slice 4 — in PR (dev-2875f): the `not-a-constructor` bucket was a harness
   STUB TYPE BUG, not compiler work.** The runner replaces the test262
   `isConstructor` harness entirely (`needsIsConstructor` preamble,
@@ -250,7 +256,7 @@ family split across two PRs):
   — standalone wins only in sampling (18 diverse files + 5 base-compared);
   full validation in `merge_group`.
   - Adjacent gap (documented, not in-bucket): `const C: any =
-    String.prototype.indexOf; new C()` silently does NOT throw (the direct
+String.prototype.indexOf; new C()` silently does NOT throw (the direct
     member form does) — generic new-on-non-constructor-closure runtime check
     missing.
 - **Slice 5 — in PR (dev-2875f): fromCharCode ToUint16 + zero-arg.** Post-#2477
@@ -272,7 +278,7 @@ family split across two PRs):
     (a) `String.hasOwnProperty("fromCharCode")` → false (static own-property
     reflection over the builtin CONSTRUCTOR object; blocks S15.5.3.2_A1 whose
     typeof + .length asserts already pass); (b) `String.prototype[Symbol.
-    iterator].call(null/undefined)` must throw — the @@iterator symbol-member
+iterator].call(null/undefined)` must throw — the @@iterator symbol-member
     ROC guard; needs TS-symbol-name → `@@<id>` sentinel normalization in the
     reflective-call resolver before the glue arm can fire (2 tests);
     (c) matchAll flags/custom-@@matchAll (route with the RegExp-arg (c)
@@ -294,12 +300,12 @@ poisons `RegExp.prototype` mid-sweep and crashes ~780 files, so a single sweep
 undercounts):** the residual is now **~282 host-pass/standalone-fail** across
 `built-ins/String/**`, matching the #2860 re-measure. Largest coherent buckets:
 
-| bucket                                                              | fails |
-| ------------------------------------------------------------------- | ----: |
-| RegExp-arg family (match 18, replace 21, split 19, replaceAll 13, search 21, matchAll ~22) | ~114 |
-| **trim family (trim 42, trimStart 11, trimEnd 11)** — mostly `wrong_value` | **64** |
-| case family (toLowerCase 14, toUpperCase 11)                        |    25 |
-| substring 16, slice 9, normalize 9, indexOf/lastIndexOf 12, …       |   rest |
+| bucket                                                                                     |  fails |
+| ------------------------------------------------------------------------------------------ | -----: |
+| RegExp-arg family (match 18, replace 21, split 19, replaceAll 13, search 21, matchAll ~22) |   ~114 |
+| **trim family (trim 42, trimStart 11, trimEnd 11)** — mostly `wrong_value`                 | **64** |
+| case family (toLowerCase 14, toUpperCase 11)                                               |     25 |
+| substring 16, slice 9, normalize 9, indexOf/lastIndexOf 12, …                              |   rest |
 
 ### Slice A (THIS PR) — reflective non-string-primitive ToString + trim flatten
 
@@ -342,5 +348,5 @@ ToString now correct across all reflective String methods.
   `null` receivers DO throw (they are `ref.null`). Needs an `is_undefined`
   test alongside `ref.is_null` in every String proto glue's RequireObjectCoercible
   — a separate, shared slice (also fixes the pre-existing `*.call(undefined)
-  throws` assertions in `issue-2875*.test.ts`, which fail on main today).
+throws` assertions in `issue-2875*.test.ts`, which fail on main today).
 - RegExp-arg family (~114), case family (25), substring/slice/normalize.

--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -2,9 +2,9 @@
 id: 2875
 title: "Standalone: String.prototype.* cluster (159 host-pass/standalone-fail, de-masked from #2862)"
 status: in-progress
-assignee: ttraenkler/dev-2875f
+assignee: ttraenkler/fable-dev-3
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-18
 priority: high
 task_type: bug
 area: codegen
@@ -280,3 +280,67 @@ family split across two PRs):
 - **Out of scope (routed elsewhere):** the 69-test #2862 ToPrimitive substrate
   bucket; the property-attribute `compile_error` tests (S15.5.4.7_A8–A11
   et al — `delete`/for-in over builtins, a different mechanism).
+
+## Takeover + fresh re-measure (fable-dev-3, 2026-07-18)
+
+**Takeover:** assignee cleared from `dev-2875f` (stale since 07-02; all six
+`issue-2875-slice*` branches are fully merged — 0 commits ahead of main — and
+there is NO open PR). Prior slices 1–5 (charAt/at, charCodeAt/codePointAt,
+indexOf/lastIndexOf, includes/startsWith/endsWith, not-a-constructor,
+fromCharCode) all LANDED. Grounding on merged state; nothing to salvage.
+
+**Fresh re-measure (process-isolated per method subdir — the in-process runner
+poisons `RegExp.prototype` mid-sweep and crashes ~780 files, so a single sweep
+undercounts):** the residual is now **~282 host-pass/standalone-fail** across
+`built-ins/String/**`, matching the #2860 re-measure. Largest coherent buckets:
+
+| bucket                                                              | fails |
+| ------------------------------------------------------------------- | ----: |
+| RegExp-arg family (match 18, replace 21, split 19, replaceAll 13, search 21, matchAll ~22) | ~114 |
+| **trim family (trim 42, trimStart 11, trimEnd 11)** — mostly `wrong_value` | **64** |
+| case family (toLowerCase 14, toUpperCase 11)                        |    25 |
+| substring 16, slice 9, normalize 9, indexOf/lastIndexOf 12, …       |   rest |
+
+### Slice A (THIS PR) — reflective non-string-primitive ToString + trim flatten
+
+**Two root causes, both in the `ToString(this)` of a reflective
+`String.prototype.<m>.call(<non-string primitive>)`:**
+
+1. **`ensureAnyToStringHelper` box-struct ordering hazard (the big one).**
+   `__any_to_string`'s `stringifyBoxedExtern` arm recovers a boxed primitive
+   (`$__box_number_struct`/`$__box_boolean_struct`) ONLY when
+   `ctx.nativeBoxNumberTypeIdx`/`nativeBoxBooleanTypeIdx` are registered — else
+   it bakes the `"[object Object]"` fallback and CACHES it module-wide. When a
+   **0-arg** reflective glue (the trim family) is the FIRST `__any_to_string`
+   consumer, those idxs are still `-1` (unlike the char/search bodies, trim
+   never calls `unboxArgToI32`, which is what pulls in the union native funcs +
+   box structs). So `trim.call(false)` rendered `"[object Object]"` instead of
+   `"false"`, `trim.call(123)` → `"[object Object]"`, etc. This is the SAME
+   ordering hazard #3216 fixed for `number_toString`, one arm over. **Fix:**
+   `ensureAnyToStringHelper` now calls `addUnionImports(ctx)` (idempotent,
+   native-strings-gated) up front, so the box struct types exist before
+   `stringifyBoxedExtern` captures their idxs. Fixes non-string-primitive
+   ToString for EVERY reflective String method, not just trim.
+
+2. **trim glue missing the flatten.** `emitStringTrimMemberBody` fed the raw
+   `$__any_to_string` result straight into `__str_trim*`, but that helper (like
+   the DIRECT path in `string-ops.ts`, which calls `emitFlatten()` first)
+   expects a FLATTENED receiver. **Fix:** insert `__str_flatten` between
+   `$__any_to_string` and `__str_trim*` (direct-path parity).
+
+**Impact (process-isolated re-measure):** trim 42→13, trimStart 11→9,
+trimEnd 11→9 — **~33 tests flipped**, zero regressions in the char/search
+slices (charAt/charCodeAt/indexOf/includes unchanged). Boolean/number receiver
+ToString now correct across all reflective String methods.
+
+### Residual for the next slice (NOT this PR)
+
+- **`undefined`-receiver RequireObjectCoercible** — `trim.call(undefined)` (and
+  `charAt.call(undefined)`, all methods) does NOT throw: in standalone
+  `undefined` is a DISTINCT sentinel externref, NOT `ref.null.extern`, so the
+  glue's `ref.is_null` guard misses it (ToString(undefined) → "undefined").
+  `null` receivers DO throw (they are `ref.null`). Needs an `is_undefined`
+  test alongside `ref.is_null` in every String proto glue's RequireObjectCoercible
+  — a separate, shared slice (also fixes the pre-existing `*.call(undefined)
+  throws` assertions in `issue-2875*.test.ts`, which fail on main today).
+- RegExp-arg family (~114), case family (25), substring/slice/normalize.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1228,7 +1228,16 @@ function emitStringTrimMemberBody(ctx: CodegenContext, fctx: FunctionContext, me
   // (mirrors the search body's post-ensure fetch order).
   const anyToStrIdx = ensureAnyToStringHelper(ctx);
   const trimIdx = ctx.nativeStrHelpers.get(helperName);
-  if (trimIdx === undefined) return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
+  // (#2875) `__str_trim*` operates on a FLATTENED receiver (`ref $NativeString`)
+  // — the DIRECT path (`string-ops.ts`) calls `emitFlatten()` before it. The
+  // reflective glue must do the same: `$__any_to_string` on a non-string
+  // primitive (`false`, `123`, …) returns an unflattened `$AnyString`
+  // (cons/wrapper), and feeding that straight into `__str_trim*` mis-reads it
+  // (`trim.call(false)` returned "[object Boolean]"-ish instead of "false").
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  if (trimIdx === undefined || flattenIdx === undefined) {
+    return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
+  }
 
   // (1) RequireObjectCoercible(this) [param 1]: in standalone undefined≡null≡
   // ref.null.extern, so a bare ref.is_null throw covers both → catchable TypeError.
@@ -1238,10 +1247,11 @@ function emitStringTrimMemberBody(ctx: CodegenContext, fctx: FunctionContext, me
   fctx.body.push({ op: "ref.is_null" });
   fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
 
-  // (2) S = ToString(this); __str_trim*(S) → native string; → externref.
+  // (2) S = ToString(this); FLATTEN; __str_trim*(S) → native string; → externref.
   fctx.body.push({ op: "local.get", index: 1 });
   fctx.body.push({ op: "any.convert_extern" });
   fctx.body.push({ op: "call", funcIdx: anyToStrIdx });
+  fctx.body.push({ op: "call", funcIdx: flattenIdx });
   fctx.body.push({ op: "call", funcIdx: trimIdx });
   fctx.body.push({ op: "extern.convert_any" });
   return { kind: "externref" };

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -25,7 +25,7 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
-import { addImport } from "./registry/imports.js";
+import { addImport, addUnionImports } from "./registry/imports.js";
 import {
   addFuncType,
   getArrTypeIdxFromVec,
@@ -410,6 +410,27 @@ export function ensureAnyToStringHelper(ctx: CodegenContext): number {
   // and the numberArm keeps its prior fallback).
   if (ctx.nativeStrings && !ctx.funcMap.has("number_toString")) {
     emitNativeNumberFormat(ctx, new Set(["number_toString"]));
+  }
+
+  // (#2875) Ensure the boxed-primitive struct types (`$__box_number_struct` /
+  // `$__box_boolean_struct`) are REGISTERED before `stringifyBoxedExtern`
+  // (below) captures `ctx.nativeBoxNumberTypeIdx`/`nativeBoxBooleanTypeIdx`.
+  // SAME ordering hazard #3216 fixed for `number_toString`: when
+  // `ensureAnyToStringHelper` is the FIRST any-coercion consumer in a module —
+  // e.g. a 0-arg reflective `String.prototype.trim.call(<boolean|number>)`
+  // body's `ToString(this)`, which (unlike the char/search bodies) never calls
+  // `unboxArgToI32` and so never pulls in the union native funcs — both idxs
+  // were still `-1`, and `stringifyBoxedExtern` baked the "[object Object]"
+  // fallback for EVERY boxed primitive. So `trim.call(false)` rendered
+  // "[object Object]" instead of "false" (and the whole cached helper was
+  // wrong module-wide). `addUnionImports` is idempotent (`hasUnionImports`
+  // guard) and, under standalone/wasi, appends the box struct types + native
+  // box/unbox funcs; a module that already registered them earlier is a no-op
+  // (byte-identical). Native-strings-gated so host/gc lanes stay byte-identical
+  // (there `__any_to_string`'s boxed arms keep their prior fallback and the box
+  // types are host concepts).
+  if (ctx.nativeStrings) {
+    addUnionImports(ctx);
   }
 
   // (#2962) Emit the §20.5.3.4 `__error_to_string` helper BEFORE this

--- a/tests/issue-2875-slice-a-reflective-tostring.test.ts
+++ b/tests/issue-2875-slice-a-reflective-tostring.test.ts
@@ -1,0 +1,84 @@
+// #2875 Slice A — reflective `String.prototype.<m>.call(<non-string primitive>)`
+// ToString(this) fidelity on the standalone lane. Two root causes fixed:
+//
+// 1. `ensureAnyToStringHelper` box-struct ordering hazard: `__any_to_string`'s
+//    boxed-primitive recovery arm reads `ctx.nativeBox{Number,Boolean}TypeIdx`
+//    but never ensured them. When a 0-arg reflective glue (the trim family,
+//    which — unlike char/search bodies — never calls `unboxArgToI32`) was the
+//    FIRST `__any_to_string` consumer, both idxs were -1 and the arm baked (and
+//    module-cached) the "[object Object]" fallback, so `trim.call(false)` gave
+//    "[object Object]" instead of "false". Fixed by ensuring the union native
+//    funcs (which register the box structs) up front, mirroring #3216.
+// 2. `emitStringTrimMemberBody` missing the `__str_flatten` the DIRECT path
+//    (`string-ops.ts`) performs before `__str_trim*`.
+//
+// These fix boolean/number receiver ToString across ALL reflective String
+// methods, and the trim family end-to-end.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile standalone, assert host-free, instantiate, run `test()` (returns i32). */
+async function runI32(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2875 Slice A — reflective String proto non-string ToString (standalone)", () => {
+  describe("trim family: non-string primitive receivers stringify correctly", () => {
+    for (const m of ["trim", "trimStart", "trimEnd"] as const) {
+      it(`${m}.call(false) === "false" (was "[object Object]")`, async () => {
+        expect(await runI32(`return (String.prototype.${m}.call(false as any) as string) === "false" ? 1 : 0;`)).toBe(
+          1,
+        );
+      });
+      it(`${m}.call(123) === "123"`, async () => {
+        expect(await runI32(`return (String.prototype.${m}.call(123 as any) as string) === "123" ? 1 : 0;`)).toBe(1);
+      });
+    }
+
+    it("trim.call trims a non-string primitive that stringifies with padding: (' x ' via string) — string receiver still trims", async () => {
+      expect(await runI32(`return (String.prototype.trim.call("  hi  ") as string) === "hi" ? 1 : 0;`)).toBe(1);
+    });
+
+    it("trim.call(true) === 'true'", async () => {
+      expect(await runI32(`return (String.prototype.trim.call(true as any) as string) === "true" ? 1 : 0;`)).toBe(1);
+    });
+
+    it("trim.call(+Infinity) === 'Infinity' (the corpus 15.5.4.20-2-10 shape)", async () => {
+      expect(
+        await runI32(`return (String.prototype.trim.call(Infinity as any) as string) === "Infinity" ? 1 : 0;`),
+      ).toBe(1);
+    });
+  });
+
+  describe("box-struct ordering: trim glue as FIRST any-to-string consumer", () => {
+    it("trim.call(false) is correct ALONE (no prior number-method call to register the box structs)", async () => {
+      // Regression guard for the ordering hazard: the fix must make this work
+      // WITHOUT any preceding char/search glue that would pull in the union funcs.
+      expect(await runI32(`return (String.prototype.trim.call(false as any) as string).length;`)).toBe(5);
+    });
+
+    it("charAt still stringifies non-string primitives correctly (unchanged)", async () => {
+      expect(await runI32(`return (String.prototype.charAt.call(false as any, 0) as string) === "f" ? 1 : 0;`)).toBe(1);
+    });
+  });
+
+  describe("no regression: string receivers and null RequireObjectCoercible", () => {
+    it("trim.call(null) throws TypeError (null IS ref.null)", async () => {
+      expect(
+        await runI32(
+          `try { String.prototype.trim.call(null as any); return 0; } catch (e) { return e instanceof TypeError ? 2 : 1; }`,
+        ),
+      ).toBe(2);
+    });
+
+    it("direct '  x  '.trim() === 'x'", async () => {
+      expect(await runI32(`return "  x  ".trim() === "x" ? 1 : 0;`)).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## #2875 Slice A — reflective String proto non-string-primitive ToString (standalone)

Takeover of a stale issue (assignee `dev-2875f`, last touched 07-02; all 6
`issue-2875-slice*` branches fully merged, no open PR — reviewed, grounded on
merged state). Slices 1–5 already landed; a fresh process-isolated re-measure
puts the residual at ~282 host-pass/standalone-fail. This is **Slice A**.

### Two root causes in `ToString(this)` of a reflective `String.prototype.<m>.call(<non-string primitive>)`

1. **`ensureAnyToStringHelper` box-struct ordering hazard (the big one).**
   `__any_to_string`'s `stringifyBoxedExtern` arm recovers a boxed primitive
   (`$__box_number_struct` / `$__box_boolean_struct`) only when
   `ctx.nativeBoxNumberTypeIdx` / `nativeBoxBooleanTypeIdx` are registered — else
   it bakes (and module-caches) the `"[object Object]"` fallback. When a **0-arg**
   reflective glue (the trim family, which — unlike the char/search bodies —
   never calls `unboxArgToI32`, the thing that pulls in the union native funcs +
   box structs) is the FIRST `__any_to_string` consumer, both idxs are still `-1`,
   so `trim.call(false)` rendered `"[object Object]"` instead of `"false"`. This
   is the SAME ordering hazard #3216 fixed for `number_toString`, one arm over.
   **Fix:** `ensureAnyToStringHelper` now calls `addUnionImports(ctx)` up front
   (idempotent via `hasUnionImports`, native-strings-gated) so the box structs
   exist before their idxs are captured. Fixes boolean/number receiver ToString
   across **all** reflective String methods.

2. **`emitStringTrimMemberBody` missing the flatten.** It fed the raw
   `$__any_to_string` result straight into `__str_trim*`, but that helper (like
   the DIRECT path in `string-ops.ts`, which calls `emitFlatten()` first) expects
   a FLATTENED receiver. **Fix:** insert `__str_flatten` (direct-path parity).

### Validation

- Process-isolated re-measure (the in-process runner poisons `RegExp.prototype`
  mid-sweep, so per-subdir subprocess isolation): **trim 42→13, trimStart 11→9,
  trimEnd 11→9 — ~33 tests flipped.**
- Broad builtin regression A/B (Array/Object/Number `join`/`toString`/`indexOf`/
  `includes` — the primary `__any_to_string` consumers): **pass=264 fail=132 on
  BOTH pristine main and this branch — zero regressions.**
- `tests/issue-2875-slice-a-reflective-tostring.test.ts` (13 cases): boolean/
  number/Infinity/true receivers, the box-struct-ordering guard (trim as first
  consumer), charAt-unchanged, null-throws, direct-trim. PASS.
- Gates: tsc 0, prettier, oracle-ratchet +0 (no checker use), loc-budget
  allow-listed (+31).

### Residual (documented in the issue, next slice)

`undefined`-receiver RequireObjectCoercible — in standalone `undefined` is a
distinct sentinel externref, NOT `ref.null.extern`, so the glue's `ref.is_null`
guard misses it (`trim.call(undefined)` → "undefined" instead of throwing).
`null` receivers DO throw. Needs an `is_undefined` test alongside `ref.is_null`
in every String proto glue — a separate shared slice (also fixes the pre-existing
`*.call(undefined) throws` assertions in `issue-2875*.test.ts`). Plus the
RegExp-arg family (~114), case family (25), substring/slice/normalize.

Refs #2875 (Slice A — issue stays open for the remaining slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG
