### PR TITLE
fix(#2872): slice 5 — standalone findLast/findLastIndex host-free (dyn-view two-arm + scalar-HOF any-receiver decline + __hof_* S1 undefined singleton)

### DIFF
--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -2,9 +2,9 @@
 id: 2872
 title: "Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)"
 status: in-progress
-assignee: ttraenkler/agent-a30d0acc00d3c78c5
+assignee: ttraenkler/fable-dev-4
 created: 2026-06-30
-updated: 2026-07-12
+updated: 2026-07-18
 priority: high
 task_type: bug
 feasibility: hard
@@ -22,6 +22,68 @@ loc-budget-allow:
   - src/codegen/expressions/new-super.ts
   - src/codegen/expressions/calls-closures.ts
 ---
+
+## Takeover + fresh 2026-07-18 re-measurement (fable-dev-4)
+
+**Assignee cleared 2026-07-18** — was `ttraenkler/agent-a30d0acc00d3c78c5`,
+stale since 07-11/07-12 (docs-only newest activity, 6 days dead, no open PR;
+tech-lead approved the takeover after a coordination scan). The 4 prior branches
+(`issue-2872-standalone-typedarray-hof`/`-proto`, `-real-clusters`,
+`ta-proto-methods`) carry slices 1–4 that already MERGED to main per the
+progress log below (`.fill`, `copyWithin`/`reverse`, `reduce`/`reduceRight` +
+boolean-result boxing). This takeover grounds on landed main, not those branches.
+
+**Fresh gap re-measure** (2026-07-18 promoted standalone baseline vs host, official
+scope, `file|strict` match): `built-ins/TypedArray/prototype/*` = **690 gap rows**
+(host pass ∧ standalone not-pass), up from the 294 original estimate — the metric
+de-masked runtime failures as the carriers landed (this is the #2860 re-measure's
+"assertion_fail now dominates" shift, localised to TA.prototype).
+
+### Two coherent slices (per-method + failure-signature sub-bucketing)
+
+The dominant failure across NEARLY EVERY method is **`assertion_fail` with an
+`assert.throws` signature** — the method is implemented but a spec-mandated
+throw is missing:
+
+| method | gap | dominant category |
+| ------ | --: | ----------------- |
+| slice | 58 | assertion_fail 45 (assert.throws 17), type_error 11 |
+| set | 53 | assertion_fail 46 (assert.throws 22) |
+| map | 48 | assertion_fail 38 (assert.throws 17) |
+| subarray | 46 | assertion_fail 38 (assert.throws 13) |
+| filter | 43 | assertion_fail 35 (assert.throws 15) |
+| fill | 27 | assertion_fail 25 (assert.throws 10) — *slice-1 landed the value path* |
+| copyWithin | 22 | assertion_fail 20 — *slice-2 landed value path* |
+| reduce/reduceRight | 44 | assertion_fail 34 — *slice-4 landed value path* |
+| **findLast/findLastIndex** | **43** | **host_import_leak 33** (`env::Uint8ClampedArray_findLast[Index]`) + assertion_fail 10 |
+| includes/indexOf/lastIndexOf | 60 | assertion_fail (assert.sameValue) |
+
+**SLICE 5 (this branch, the clean self-contained one) — `findLast` /
+`findLastIndex` on `Uint8ClampedArray`.** Unlike every other method, the
+dominant failure here is a genuine **host_import_leak** (`env::
+Uint8ClampedArray_findLast` ×17, `env::Uint8ClampedArray_findLastIndex` ×16) —
+the native dyn-view HOF arm covers the other TA element kinds but not the
+CLAMPED variant for these two reverse-iterating callback methods. This mirrors
+the slice-1–4 per-method dyn-view pattern (the value path already exists for
+non-clamped; extend the clamped element-kind arm). Entry points: the reverse
+callback setup at `array-methods.ts:6226`/`:6270` (`setupArrayLoopReverse`,
+`findLast`/`findLastIndex` array impls) and the TA dyn-view HOF dispatch in
+`ta-hof-map-filter.ts` + the `#3058/#3098` `__hof` substrate — find where the
+non-clamped element kinds route native and the clamped kind falls to the
+per-ctor `env::Uint8ClampedArray_*` import, and extend it.
+
+**SLICE 6+ (the BIG lever, NOT this PR — recommend a dedicated follow-on) —
+the cross-method `assert.throws` cluster (~150+ rows).** slice/set/map/subarray/
+filter/fill/copyWithin all share a missing spec-throw: calling the method with a
+detached buffer, an out-of-bounds/invalid index arg, or a wrong receiver brand
+must throw TypeError/RangeError but does not (the tests are
+`assert.throws(TypeError, () => ta.method(bad))`). A SHARED validation-prelude
+(detached-buffer guard + ToIntegerOrInfinity/range checks + brand check) emitted
+once and reused across the dyn-view method arms would flip a large coherent
+batch — but it needs its own measure-first slice (each method's exact throw
+conditions differ) and touches the shared dyn-view method emitter, so it is a
+separate PR from slice 5. Flagging it here as the highest-remaining-lever
+follow-on for tech-lead scheduling.
 
 ## Progress (2026-07-12, fable) — Slice 4: dyn-view reduce/reduceRight + boolean-result boxing (REUSE-first)
 

--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -2,7 +2,7 @@
 id: 2872
 title: "Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)"
 status: in-progress
-assignee: ttraenkler/fable-dev-4
+assignee: ttraenkler/fable-dev-5
 created: 2026-06-30
 updated: 2026-07-18
 priority: high
@@ -22,6 +22,56 @@ loc-budget-allow:
   - src/codegen/expressions/new-super.ts
   - src/codegen/expressions/calls-closures.ts
 ---
+
+## Slice 5 implementation plan (fable-dev-5, 2026-07-18, branch `issue-2872-scalar-hof-any-decline`, stacked on PR #3338)
+
+Executes BOTH parts of the slice-5 root-cause map below (dev-4's takeover PR
+#3338 banked the map; the stale `agent-a30d0acc00d3c78c5` claim-lock was
+force-taken per the takeover already approved there). WHY each change is
+where it is:
+
+1. **Part 2 (load-bearing) — scalar-HOF any-receiver decline in
+   `tryExternClassMethodOnAny` (calls-closures.ts).** The #3139 unconditional
+   refusal list already declines find/findIndex/forEach/some/every/filter/map/
+   reduce/reduceRight/indexOf/lastIndexOf — but NOT `findLast`/`findLastIndex`,
+   so the first-match loop still binds `env::Uint8ClampedArray_findLast[Index]`
+   (the measured host_import_leak ×33). Fix: a SHARED decline
+   `if (noJsHost(ctx) && STANDALONE_TA_SCALAR_HOFS.has(methodName)) return null;`
+   placed before the first-match loop. Uses the existing exported set from
+   calls.ts (calls-closures.ts already imports from `./calls.js` — no new
+   cycle). `noJsHost`-gated (join precedent, line ~1514) so the HOST lane keeps
+   its extern binding byte-identical — zero host-lane risk, unlike widening the
+   unconditional #3139 list. For the siblings the new line is unreachable
+   (they return earlier) — it exists as the family-level standalone guarantee
+   the map asked for. After the decline the standalone ladder bottoms out at
+   the #2151 closed-method dispatcher whose #3098 HOF arm already serves
+   findLast/findLastIndex via the native `__hof_findLast[Index]` backward
+   loops (hof-native.ts NATIVE_HOF_EACH — verified present).
+2. **Part 1 (fold-in) — findLast/findLastIndex join the #3058/#3162 dyn-view
+   two-arm (array-methods.ts).** Add both to `DYN_VIEW_READ_METHODS` AND
+   `FIND_METHODS`. The FIND_METHODS route sends the THEN arm through
+   `ensureNativeArrayHof` (`__hof_findLast[Index]`, backward flag — already
+   implemented), NOT the legacy `compileArrayFind` re-entry whose missing
+   `__call_1_f64` registration was the (now-stale) exclusion note. Gc/host
+   byte-identical by construction: the line-1135 gate `(!FIND_METHODS.has ||
+   ctx.standalone)` keeps the two-arm standalone-only for FIND_METHODS
+   members. Also prune the stale exclusion note.
+
+Checklist (kept current — resume point if interrupted):
+
+- [x] Root-cause map read (PR #3338); code paths verified on this base
+- [x] Claim lock force-taken (stale 07-12 holder; takeover per #3338)
+- [ ] Part 2 decline in calls-closures.ts
+- [ ] Part 1 set additions in array-methods.ts
+- [ ] Probe: any-receiver harness shape — no `env::*_findLast*` import, correct
+      values/order/thisArg/undefined-miss, standalone execute
+- [ ] Probe: plain-array any-receiver findLast unhijacked (guard)
+- [ ] Regression sweep: issue-2872/#3058/#3098/#3162/#1712 suites +
+      prove-emit-identity (host/gc byte-identity)
+- [ ] PR open, CI started
+
+Slice 6 (the ~150-row cross-method `assert.throws` shared-validation-prelude
+cluster) remains the NEXT slice after this — not in this PR.
 
 ## Takeover + fresh 2026-07-18 re-measurement (fable-dev-4)
 

--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -58,19 +58,50 @@ throw is missing:
 | **findLast/findLastIndex** | **43** | **host_import_leak 33** (`env::Uint8ClampedArray_findLast[Index]`) + assertion_fail 10 |
 | includes/indexOf/lastIndexOf | 60 | assertion_fail (assert.sameValue) |
 
-**SLICE 5 (this branch, the clean self-contained one) — `findLast` /
-`findLastIndex` on `Uint8ClampedArray`.** Unlike every other method, the
-dominant failure here is a genuine **host_import_leak** (`env::
-Uint8ClampedArray_findLast` ×17, `env::Uint8ClampedArray_findLastIndex` ×16) —
-the native dyn-view HOF arm covers the other TA element kinds but not the
-CLAMPED variant for these two reverse-iterating callback methods. This mirrors
-the slice-1–4 per-method dyn-view pattern (the value path already exists for
-non-clamped; extend the clamped element-kind arm). Entry points: the reverse
-callback setup at `array-methods.ts:6226`/`:6270` (`setupArrayLoopReverse`,
-`findLast`/`findLastIndex` array impls) and the TA dyn-view HOF dispatch in
-`ta-hof-map-filter.ts` + the `#3058/#3098` `__hof` substrate — find where the
-non-clamped element kinds route native and the clamped kind falls to the
-per-ctor `env::Uint8ClampedArray_*` import, and extend it.
+**SLICE 5 — `findLast` / `findLastIndex` host-free (PRECISELY root-caused
+2026-07-18; deeper than a clean "add to set" — NOT yet landed).** The dominant
+failure is a genuine **host_import_leak** (`env::Uint8ClampedArray_findLast`
+×17, `env::Uint8ClampedArray_findLastIndex` ×16). Traced end-to-end — it is a
+**two-part** gap, not one:
+
+1. **Direct-receiver path (FIXED by a 1-line-ish change, verified):** the
+   `#3058` dyn-view two-arm set `DYN_VIEW_READ_METHODS` (array-methods.ts:829)
+   + `FIND_METHODS` (:867) EXCLUDED findLast/findLastIndex behind a **stale**
+   note ("legacy `compileArrayFind` re-entry misses `__call_1_f64` → CE"). The
+   `#3098` `__hof` substrate ALREADY has the backward steppers (`__hof_findLast`
+   /`__hof_findLastIndex`, `hof-native.ts:63-64,110` `backward` flag), exactly
+   like the already-shipped find/findIndex. Adding findLast/findLastIndex to
+   BOTH sets makes a **statically-typed** `new Uint8ClampedArray([…]).findLast(cb)`
+   compile host-free + correct (probe-verified: values right, `typeof` of
+   not-found = "undefined", reverse order correct, identical behaviour to the
+   shipped `find`). This part is a safe, isolated win.
+
+2. **`any`-receiver harness path (the ACTUAL test262 shape — STILL LEAKS after
+   part 1):** test262's `testWithTypedArrayConstructors(TA => new TA(…).method)`
+   wraps the receiver as `any`, producing the boxed `$__ta_dyn_view`. The
+   two-arm THEN arm then handles it correctly, BUT the two-arm always ALSO
+   compiles its **ELSE arm** (the "not a dyn-view at runtime" fallback), which
+   re-dispatches via `compileExpression` →
+   `compileReceiverMethodCall` → **`tryExternClassMethodOnAny`
+   (calls-closures.ts:~1519 first-match loop)**. That loop greedily binds the
+   first extern class declaring the method — a TypedArray view — to the per-ctor
+   `env::Uint8ClampedArray_findLast` HOST import (addImport at
+   calls-closures.ts:1550). Because the import is emitted at COMPILE time (both
+   arms compile), the binary leaks even though the THEN arm would run. **Fix
+   location: `tryExternClassMethodOnAny`** — it already has the exact precedent
+   at line 1514 (`join` routes native under `noJsHost` instead of binding
+   `env::Uint8ClampedArray_join`) and the `.slice`/`.replace` `continue`
+   refusals (line 1543). Under `noJsHost`, a TA-view extern-class binding for a
+   scalar-HOF method (the `STANDALONE_TA_SCALAR_HOFS` set in calls.ts:1514 —
+   find/findIndex/findLast/findLastIndex/forEach/some/every/reduce/reduceRight)
+   should be **declined** (`continue`) so the call falls through to the
+   host-free generic path, exactly like `join`. This is a SHARED fix: it would
+   also close the same latent any-receiver leak for the other scalar HOFs, so it
+   warrants its own measure-first slice + a full any-receiver regression sweep
+   (the dispatch is sensitive — the #1712 acorn `.replace` collision lived
+   here). Both parts together are slice 5; part 2 is the load-bearing one for
+   the test262 harness rows and is why this was reverted rather than shipped
+   half-done (part 1 alone flips ~0 harness rows).
 
 **SLICE 6+ (the BIG lever, NOT this PR — recommend a dedicated follow-on) —
 the cross-method `assert.throws` cluster (~150+ rows).** slice/set/map/subarray/

--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -61,14 +61,45 @@ Checklist (kept current — resume point if interrupted):
 
 - [x] Root-cause map read (PR #3338); code paths verified on this base
 - [x] Claim lock force-taken (stale 07-12 holder; takeover per #3338)
-- [ ] Part 2 decline in calls-closures.ts
-- [ ] Part 1 set additions in array-methods.ts
-- [ ] Probe: any-receiver harness shape — no `env::*_findLast*` import, correct
-      values/order/thisArg/undefined-miss, standalone execute
-- [ ] Probe: plain-array any-receiver findLast unhijacked (guard)
-- [ ] Regression sweep: issue-2872/#3058/#3098/#3162/#1712 suites +
-      prove-emit-identity (host/gc byte-identity)
+- [x] Part 2 decline in calls-closures.ts
+- [x] Part 1 set additions in array-methods.ts
+- [x] Part 3 (surfaced during verification, see below): `__hof_*` S1
+      undefined-singleton producer fix in hof-native.ts
+- [x] Probe: any-receiver harness shape — no `env::*_findLast*` import, correct
+      values/order/thisArg/undefined-miss, standalone execute (suite 10/10)
+- [x] Probe: plain-array any-receiver findLast unhijacked (guard)
+- [x] Regression sweep: issue-2872×3 / #3058 / #3098 / #3162 / #1712×5 suites
+      green (only 2 PRE-EXISTING env failures, verified identical on clean
+      base: issue-2001-s2 reduce-hole, issue-1712-capture arity-0) +
+      prove-emit-identity IDENTICAL 56/56 vs base (gc/host byte-inert)
+- [x] Scoped test262 (standalone, `TypedArray/prototype/{findLast,findLastIndex}`,
+      50 files): base 4 pass / 12 fail / 34 CE → branch **24 pass / 26 fail /
+      0 CE** = **+20 pass, −34 CE, 0 regressions**
+- [x] Collateral sweep (all 9 scalar-HOF dirs, 245 files, per-file diff):
+      every flipped line is in findLast/findLastIndex; siblings
+      (find/findIndex/forEach/some/every/reduce/reduceRight) ZERO flips
 - [ ] PR open, CI started
+
+### Part 3 (found during verification): `__hof_*` S1 undefined-producer gap
+
+The slice-5 suite exposed a THIRD gap beyond the banked two: under the #2106
+`undefinedSingleton` regime (default ON since 2026-07-04, 6f7f93c85) a null
+externref is JS `null`, NOT `undefined` — but `ensureNativeArrayHof` still
+emitted legacy `ref.null.extern` for its "returns undefined" results
+(`find`/`findLast` miss, `forEach` result, reduce-of-empty). So
+`a.findLast(missPred) === undefined` was FALSE (the value classified as
+`null`: typeof "object", `=== null` true) — and this bug was LIVE on main for
+the shipped #3162 `find`/`findIndex` (its own suite's miss test fails on a
+clean checkout; invisible in CI because the `quality` gate runs only
+CHANGED test files, and #3162's PR presumably predates/raced the flip's full
+effect). Fix: `undefinedExternInstrs(ctx) ?? ref.null.extern` at the three
+result sites in hof-native.ts (regime-off builds byte-identical). The
+committed suite asserts miss `=== undefined`, falsiness, and `??` coalescing.
+
+Remaining fails in the two dirs are the KNOWN follow-on buckets (not this
+slice): the slice-6 cross-method `assert.throws` cluster (brand/detach/OOB
+spec throws, ~150+ rows), reflective `name`/`length`/`prop-desc` (#2885-glue),
+and resizable-buffer mid-iteration semantics.
 
 Slice 6 (the ~150-row cross-method `assert.throws` shared-validation-prelude
 cluster) remains the NEXT slice after this — not in this PR.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -812,8 +812,11 @@ export const ARRAY_METHODS = new Set([
  * BANKED (their externref ELSE arm pulls a host import in standalone, which would poison
  * the module):
  *   - `join` → `env.<TA>_join`
- *   - the callback methods `find`/`findIndex`/`findLast`/`findLastIndex`/`every`/`some`/
- *     `forEach`/`reduce`/`reduceRight` → `env.__make_callback`
+ *   - the callback methods `every`/`some`/`forEach` → `env.__make_callback`
+ *     (`find`/`findIndex` flipped via #3162; `findLast`/`findLastIndex` via
+ *     #2872 slice 5; `reduce`/`reduceRight` via the #2872 slice-4 re-entry —
+ *     their ELSE arms are de-leaked by the `tryExternClassMethodOnAny`
+ *     refusals in calls-closures.ts)
  * These flip only once the standalone externref-receiver callback/join paths are native
  * (a separate follow-up). (#2903 R4 UPDATE) The SCALAR callback methods above
  * (find/findIndex/findLast/findLastIndex/every/some/forEach/reduce/reduceRight)
@@ -838,10 +841,7 @@ const DYN_VIEW_READ_METHODS = new Set<string>([
   // — reusing the existing native array-HOF machinery verbatim (no per-method TA
   // handler). Scoped to `reduce`/`reduceRight` in this slice: they measured
   // clean (+2 pass, 0 CE, 0 regression). Deliberately EXCLUDED pending
-  // follow-ups: `find`/`findIndex` (the materialized `find` impl emits invalid
-  // wasm on the `predicate-call-changes-value` shape — type mismatch in the
-  // arm), `findLast`/`findLastIndex` (the array impl misses a `__call_1_f64`
-  // registration on this path → CE), `every`/`some`/`forEach` (detached-buffer
+  // follow-ups: `every`/`some`/`forEach` (detached-buffer
   // tests regress — the materialization snapshots before a mid-callback detach),
   // `map`/`filter` (return a NEW same-kind TA, not an f64-vec), `sort`/`toSorted`
   // (TA default comparator is NUMERIC, not Array's lexicographic), `with`/
@@ -853,6 +853,16 @@ const DYN_VIEW_READ_METHODS = new Set<string>([
   // two-arm predicate; gc/host keeps the pre-existing path.
   "find",
   "findIndex",
+  // (#2872 slice 5) findLast/findLastIndex — same FIND_METHODS `__hof_<name>`
+  // substrate route (the #3098 helpers carry the backward flag), which
+  // BYPASSES the legacy `compileArrayFind` re-entry whose missing
+  // `__call_1_f64` registration was the original exclusion reason here.
+  // Paired with the scalar-HOF any-receiver decline in
+  // `tryExternClassMethodOnAny` (calls-closures.ts) so the ELSE arm stays
+  // host-import-free — both are needed: the two-arm alone still leaked
+  // `env::<TA>_findLast[Index]` from the compiled-but-never-run ELSE arm.
+  "findLast",
+  "findLastIndex",
 ]);
 
 /**
@@ -864,7 +874,7 @@ const DYN_VIEW_READ_METHODS = new Set<string>([
  * failing `assert.sameValue(result, undefined)`) and dropped `thisArg`.
  * `reduce`/`reduceRight` keep their existing re-entry (no miss sentinel).
  */
-const FIND_METHODS = new Set<string>(["find", "findIndex"]);
+const FIND_METHODS = new Set<string>(["find", "findIndex", "findLast", "findLastIndex"]);
 
 /**
  * (#2872) Dyn-view read-side methods whose result is a BOOLEAN (`true`/`false`),

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -23,7 +23,12 @@ import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../sh
 import { defaultValueInstrs, emitGuardedFuncRefCast, emitGuardedRefCast, pushDefaultValue } from "../type-coercion.js";
 import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
-import { emitClosureCallArgcExtras, emitResetArgcExtras, emitWrapperDynamicMethodCall } from "./calls.js";
+import {
+  emitClosureCallArgcExtras,
+  emitResetArgcExtras,
+  emitWrapperDynamicMethodCall,
+  STANDALONE_TA_SCALAR_HOFS,
+} from "./calls.js";
 
 /**
  * (#3033) Per-source-file set of member names the USER's own code defines as
@@ -1429,6 +1434,23 @@ export function tryExternClassMethodOnAny(
   // (which now carries the native `$__ta_dyn_view` copyWithin/reverse arms)
   // resolves by runtime shape. Mirrors the `fill` refusal above.
   if (methodName === "copyWithin" || methodName === "reverse") return null;
+
+  // (#2872 slice 5) Scalar-HOF family decline under noJsHost — the SHARED
+  // standalone guarantee for every `%TypedArray%.prototype` scalar callback
+  // HOF (`STANDALONE_TA_SCALAR_HOFS`: find/findIndex/findLast/findLastIndex/
+  // forEach/some/every/reduce/reduceRight). Most members already return null
+  // unconditionally above (#3014/#3139), but `findLast`/`findLastIndex` were
+  // missing from that list, so the first-match loop below bound an
+  // `any`-typed receiver's `ta.findLast(cb)` to `env::Uint8ClampedArray_findLast`
+  // — a host import the standalone runtime cannot satisfy (measured
+  // host_import_leak ×33 across TypedArray/prototype/findLast{,Index}; the
+  // leak is emitted at COMPILE time by the #3058 two-arm's never-executed
+  // ELSE arm, so the whole module fails to instantiate). Declining lets the
+  // standalone ladder bottom out at the #2151 closed-method dispatcher, whose
+  // #3098 HOF arm drives the native backward `__hof_findLast[Index]` loops by
+  // runtime shape. noJsHost-gated (the `join` precedent below): the HOST lane
+  // keeps its extern binding byte-identical — the import is satisfiable there.
+  if (noJsHost(ctx) && STANDALONE_TA_SCALAR_HOFS.has(methodName)) return null;
 
   // (#3309) Collection methods (`get`/`set`/`has`/`add`/`delete`/`clear`) on an
   // `any` receiver under standalone/wasi. The candidate pool below still

--- a/src/codegen/hof-native.ts
+++ b/src/codegen/hof-native.ts
@@ -8,6 +8,7 @@
  * fill arm) and `expressions/calls.ts` (inline-arrow closure-compile gate).
  */
 import type { Instr, ValType } from "../ir/types.js";
+import { undefinedExternInstrs } from "./any-helpers.js";
 import type { CodegenContext } from "./context/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { ensureObjectRuntime, reserveApplyClosure } from "./object-runtime.js";
@@ -109,6 +110,19 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
   const isReduce = NATIVE_HOF_REDUCE.has(methodName);
   const backward = methodName === "findLast" || methodName === "findLastIndex" || methodName === "reduceRight";
 
+  // (#2872 slice 5) S1-producer discipline for every "returns `undefined`"
+  // result of these helpers (`find`/`findLast` miss, `forEach`'s void result,
+  // reduce-of-empty-no-init). Under the #2106 `undefinedSingleton` regime
+  // (default ON) a null externref is JS `null`, NOT `undefined` —
+  // `__extern_is_undefined` answers 0 for it — so a legacy `ref.null.extern`
+  // here made `result === undefined` / `assert.sameValue(result, undefined)`
+  // FALSE on a spec-mandated undefined (the miss-sentinel bug the findLast
+  // slice surfaced; it silently affected the shipped `find`/`findIndex`
+  // identically). Emit the `$undefined` singleton instead; regime-off builds
+  // keep the legacy null extern (byte-identical). Reserve-time global/type
+  // minting only — no funcIdx shift (#1839 discipline).
+  const undefExtern: Instr[] = undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
+
   // ── Locals ──
   // each:   params 0=recv 1=cb 2=thisArg          locals 3=len 4=i 5=val 6=res 7=args 8=out
   // reduce: params 0=recv 1=cb 2=init 3=hasInit   locals 4=len 5=i 6=val 7=args 8=acc
@@ -181,7 +195,7 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
   switch (methodName) {
     case "forEach":
       perIter = [];
-      finalResult = [{ op: "ref.null.extern" }];
+      finalResult = [...undefExtern];
       break;
     case "map":
       perIter = [
@@ -216,7 +230,7 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
           then: [{ op: "local.get", index: L.val }, { op: "return" }],
         },
       ];
-      finalResult = [{ op: "ref.null.extern" }];
+      finalResult = [...undefExtern];
       break;
     case "findIndex":
     case "findLastIndex":
@@ -305,7 +319,7 @@ export function ensureNativeArrayHof(ctx: CodegenContext, methodName: string): n
           {
             op: "if",
             blockType: { kind: "empty" },
-            then: [{ op: "ref.null.extern" }, { op: "return" }],
+            then: [...undefExtern, { op: "return" }],
           },
           // acc = first-in-iteration-order element; i = the next one
           ...((backward

--- a/tests/issue-2872-findlast-dynview.test.ts
+++ b/tests/issue-2872-findlast-dynview.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2872 slice 5 — dyn-view `findLast`/`findLastIndex` host-free (two-part fix).
+//
+// Part 1: `findLast`/`findLastIndex` join `DYN_VIEW_READ_METHODS` +
+// `FIND_METHODS` (array-methods.ts), so the #3058 two-arm's THEN arm routes the
+// materialized `$__vec_f64` through the #3098 native backward `__hof_<name>`
+// loops (correct `undefined` not-found sentinel + thisArg threading) instead of
+// the legacy `compileArrayFind` re-entry whose missing `__call_1_f64`
+// registration CE'd this path (the stale exclusion note).
+//
+// Part 2 (load-bearing): the scalar-HOF any-receiver decline in
+// `tryExternClassMethodOnAny` (calls-closures.ts). The two-arm ALWAYS compiles
+// its ELSE arm, whose re-dispatch previously first-match-bound
+// `env::Uint8ClampedArray_findLast[Index]` — a host import emitted at COMPILE
+// time, so the standalone module failed to instantiate even though the THEN
+// arm would run (measured host_import_leak ×33). `findLast`/`findLastIndex`
+// were the only `STANDALONE_TA_SCALAR_HOFS` members missing from the
+// #3014/#3139 refusals; the shared noJsHost decline closes the family.
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Must be VALID wasm AND standalone-clean (no env host imports — the leak
+  // that made the module fail to instantiate).
+  const mod = await WebAssembly.compile(r.binary);
+  const envImports = WebAssembly.Module.imports(mod).filter((i) => i.module === "env");
+  expect(envImports, `leaked host imports: ${envImports.map((i) => i.name).join(", ")}`).toHaveLength(0);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+// The test262 `testWithTypedArrayConstructors` harness shape: a dynamic
+// `$__ta_dyn_view` receiver (`new c(b)` where `c` is an `any`-typed element of
+// an `any[]`) — the runtime-kind dyn view the #3058 two-arm fires on.
+const H = (body: string): string => `
+  export function f(): number {
+    const cs: any[] = [Int8Array, Uint8Array, Int16Array, Int32Array, Float64Array];
+    const b = new ArrayBuffer(40);
+    let r = 0;
+    for (const c of cs) {
+      const a: any = new c(b);
+      a[0] = 1; a[1] = 2; a[2] = 3;
+      ${body}
+    }
+    return r;
+  }`;
+
+describe("#2872 slice 5: dyn-view findLast/findLastIndex host-free", () => {
+  it("findLast searches BACKWARD (returns the last match, not the first)", async () => {
+    // a = [1,2,3,0,0]; predicate v>0 must yield 3 (index 2), not 1 (index 0).
+    expect(
+      await runStandalone(H(`const x: any = a.findLast(function (v: any) { return v > 0; }); if (x === 3) r = r + 1;`)),
+    ).toBe(5);
+  });
+
+  it("findLastIndex returns the LAST matching index", async () => {
+    expect(
+      await runStandalone(
+        H(`const x: any = a.findLastIndex(function (v: any) { return v > 0; }); if (x === 2) r = r + 1;`),
+      ),
+    ).toBe(5);
+  });
+
+  it("findLast returns undefined (not a NaN-boxed number) when nothing matches", async () => {
+    expect(
+      await runStandalone(
+        H(`const x: any = a.findLast(function (v: any) { return v === 99; }); if (x === undefined) r = r + 1;`),
+      ),
+    ).toBe(5);
+  });
+
+  it("findLastIndex returns -1 when nothing matches", async () => {
+    expect(
+      await runStandalone(
+        H(`const x: any = a.findLastIndex(function (v: any) { return v === 99; }); if (x === -1) r = r + 1;`),
+      ),
+    ).toBe(5);
+  });
+
+  it("findLast with an arrow predicate + a MUTATING predicate stays valid + clean", async () => {
+    // Mutation mid-iteration (predicate-call-changes-value shape): backward
+    // iteration reads index 2 first, so zeroing index 0 must not affect the hit.
+    expect(
+      await runStandalone(
+        H(
+          `const x: any = a.findLast((v: any, i: any, arr: any) => { arr[0] = 0; return v === 2; }); if (x === 2) r = r + 1;`,
+        ),
+      ),
+    ).toBe(5);
+  });
+
+  it("findLast(pred, thisArg) — 2nd argument accepted, module valid/clean", async () => {
+    expect(
+      await runStandalone(
+        H(
+          `const t: any = { k: 0 }; const x: any = a.findLast(function (v: any) { return v === 2; }, t); if (x === 2) r = r + 1;`,
+        ),
+      ),
+    ).toBe(5);
+  });
+
+  it("statically-typed direct receiver stays host-free and correct", async () => {
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const a = new Uint8ClampedArray([1, 2, 3, 2]);
+          let r = 0;
+          const x: any = a.findLast((v: any) => v === 2);
+          const i: any = a.findLastIndex((v: any) => v === 2);
+          if (x === 2) r = r + 1;
+          if (i === 3) r = r + 1;
+          const miss: any = a.findLast((v: any) => v === 99);
+          if (typeof miss === "undefined") r = r + 1;
+          return r;
+        }`),
+    ).toBe(3);
+  });
+
+  it("GUARD: plain-array any receiver findLast is not hijacked", async () => {
+    // A plain number[] held in `any` — the ELSE arm / generic ladder must
+    // resolve it by runtime shape (native __hof_findLast), not a TA binding.
+    expect(
+      await runStandalone(`
+        export function f(): number {
+          const a: any = [5, 6, 7, 6];
+          let r = 0;
+          const x: any = a.findLast(function (v: any) { return v === 6; });
+          if (x === 6) r = r + 1;
+          const i: any = a.findLastIndex(function (v: any) { return v === 6; });
+          if (i === 3) r = r + 1;
+          return r;
+        }`),
+    ).toBe(2);
+  });
+
+  it("does not disturb find/findIndex (the #3162 siblings)", async () => {
+    expect(
+      await runStandalone(
+        H(
+          `const x: any = a.find(function (v: any) { return v > 0; }); const j: any = a.findIndex(function (v: any) { return v > 1; }); if (x === 1 && j === 1) r = r + 1;`,
+        ),
+      ),
+    ).toBe(5);
+  });
+});

--- a/tests/issue-2872-findlast-dynview.test.ts
+++ b/tests/issue-2872-findlast-dynview.test.ts
@@ -136,6 +136,18 @@ describe("#2872 slice 5: dyn-view findLast/findLastIndex host-free", () => {
     ).toBe(2);
   });
 
+  it("miss result is falsy and ??-coalesces (S1 singleton semantics)", async () => {
+    // The S1 `$undefined` singleton the miss now returns must behave like JS
+    // undefined beyond ===: falsy under ToBoolean and nullish for `??`.
+    expect(
+      await runStandalone(
+        H(
+          `const x: any = a.findLast(function (v: any) { return v === 99; }); if (!x) r = r + 1; const y: any = x ?? 7; if (y === 7) r = r + 1; r = r - 1;`,
+        ),
+      ),
+    ).toBe(5);
+  });
+
   it("does not disturb find/findIndex (the #3162 siblings)", async () => {
     expect(
       await runStandalone(


### PR DESCRIPTION
## Summary

Slice 5 of the #2872 TypedArray.prototype cluster, executing the two-part root-cause map banked in PR #3338 (this branch is stacked on that PR's head — its two docs commits are included and will drop out if #3338 merges first) plus a third gap the verification surfaced:

1. **Scalar-HOF any-receiver decline** (`tryExternClassMethodOnAny`, calls-closures.ts): `findLast`/`findLastIndex` were the only `STANDALONE_TA_SCALAR_HOFS` members missing from the #3014/#3139 refusals, so the first-match loop bound the harness's `any`-receiver call to `env::Uint8ClampedArray_findLast[Index]` — a compile-time host-import leak (×33 measured) that failed standalone instantiation. Shared `noJsHost`-gated decline (the `join` precedent); host lane byte-identical.
2. **Dyn-view two-arm**: `findLast`/`findLastIndex` join `DYN_VIEW_READ_METHODS` + `FIND_METHODS` (array-methods.ts) — the THEN arm routes through the #3098 native backward `__hof_findLast[Index]` loops (already implemented), bypassing the legacy `compileArrayFind` re-entry whose missing `__call_1_f64` registration was the stale exclusion reason. Standalone-gated; gc/host keeps the pre-existing path.
3. **`__hof_*` S1 undefined-producer fix** (hof-native.ts): under the default-ON #2106 `undefinedSingleton` regime, the miss/void results (`find`/`findLast` miss, `forEach` result, reduce-of-empty) emitted legacy `ref.null.extern` — which is JS `null` under S1, so `result === undefined` was FALSE. This was latent on main for the shipped #3162 `find`/`findIndex` (its own miss test fails on a clean checkout; invisible because `quality` runs only changed test files). Now emits the `` singleton; regime-off builds byte-identical.

## Measured (scoped test262, standalone lane, vs base)

| tree | base | branch | delta |
| ---- | ---- | ------ | ----- |
| `TypedArray/prototype/{findLast,findLastIndex}` (50 files) | 4 pass / 12 fail / 34 CE | **24 pass / 26 fail / 0 CE** | **+20 pass, −34 CE, 0 regressions** |
| all 9 scalar-HOF dirs (245 files, per-file diff) | — | — | flips ONLY in findLast/findLastIndex; siblings ZERO |

- `prove-emit-identity`: IDENTICAL 56/56 vs base (gc/host byte-inert).
- Suites green: new `issue-2872-findlast-dynview` (10), #3162 (9 — including the previously-failing find-miss test, now fixed by part 3), #3098 (15), #2872×3, #1712×5 (2 pre-existing env failures verified identical on clean base).
- Remaining fails in the two dirs = the known slice-6 `assert.throws` cluster + reflective name/length + resizable-buffer semantics (tracked in the issue).

Issue: plan/issues/2872-standalone-typedarray-prototype-cluster.md (slice-5 plan + measurements recorded; slice 6 is the next tracked follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG