### PR TITLE
fix(#3395 shape 2): Weak-collection typed-null → valid Wasm (child of #2039)

### DIFF
--- a/plan/issues/3395-standalone-obj-ref-externref-boxing.md
+++ b/plan/issues/3395-standalone-obj-ref-externref-boxing.md
@@ -1,0 +1,229 @@
+---
+id: 3395
+title: "standalone: object/closure GC ref not boxed (or double-boxed) at externref boundaries — any.convert_extern / extern.convert_any invalid Wasm (~34 tests)"
+status: ready
+assignee: ttraenkler/fable-dev-1
+sprint: current
+created: 2026-07-18
+updated: 2026-07-18
+priority: high
+feasibility: hard
+reasoning_effort: high
+model: fable
+task_type: bugfix
+area: codegen, type-coercion
+language_feature: classes, private-methods, weakcollections, abstract-equality
+goal: standalone-mode
+umbrella: 2039
+related: [2039, 1888]
+test262_bucket: standalone-invalid-wasm
+test262_count: 34
+es_edition: multi
+loc-budget-allow:
+  - src/codegen/map-runtime.ts
+  - src/codegen/weak-collections-runtime.ts
+---
+
+> **SLICE 1 (fable-dev-1, 2026-07-18) — SHAPE 2 fixed (Weak-collection typed
+> null, ~6 rows).** Shapes 1 (missing box in class/private-method init) and 3
+> (== double-convert with a wrapper Object) remain — see the "Progress" section
+> at the bottom for grounded findings + resume anchors. Issue stays `ready`.
+
+# #3395 — object/closure ref ↔ externref boxing at boundaries (child of #2039)
+
+## Bucket
+
+- **Records:** 34
+- **Validator signatures (three related shapes, same "extern boxing direction"
+  root):**
+  1. `call[N] expected type externref, found struct.new of type (ref M)` — a
+     freshly-constructed GC object passed to an externref parameter WITHOUT
+     `any.convert_extern` (12 rows).
+  2. `any.convert_extern[0] expected type externref, found ref.null of type
+(ref null M)` — a **typed** `ref.null $Struct` fed to `any.convert_extern`
+     (which wants externref) (6 rows, all Weak collections).
+  3. `extern.convert_any[0] expected type anyref, found call of type externref`
+     — **double convert**: a helper call already returns externref, then
+     `extern.convert_any` (wants an internal anyref) is applied again (11 rows,
+     `==` abstract-equality).
+  4. Plus `call expected externref, found local.get/local.tee of type (ref M)`
+     stragglers (5 rows).
+- **Area distribution:** expressions (== / class):14, statements:5,
+  WeakSet:3, Set:3, WeakMap:2, Array:2, Promise:2, built-ins:3.
+- **3 sample tests (one per shape):**
+  - `test/language/expressions/class/elements/private-methods/prod-private-generator.js`
+    (`call[1] expected externref, found struct.new of type (ref 7)` in `C_init`)
+  - `test/built-ins/WeakSet/prototype/has/returns-false-when-value-cannot-be-held-weakly.js`
+    (`any.convert_extern … found ref.null of type (ref null 120)`)
+  - `test/language/expressions/equals/S11.9.1_A7.3.js`
+    (`extern.convert_any … found call of type externref` — double convert)
+
+## Reproduced on current main
+
+```
+INVALID [prod-private-generator.js]:
+  Compiling function #78:"C_init" failed:
+  call[1] expected type externref, found struct.new of type (ref 7) @+33097
+INVALID [WeakSet…returns-false…]:
+  Compiling function #54:"test" failed:
+  any.convert_extern[0] expected type externref, found ref.null of type (ref null 120) @+29376
+INVALID [equals/S11.9.1_A7.3.js]:
+  Compiling function #56:"test" failed:
+  extern.convert_any[0] expected type anyref, found call of type externref @+30610
+```
+
+## Root cause
+
+Three sites emit the wrong boundary conversion for a GC-object value:
+
+1. **Missing box (shapes 1 & 4).** A concrete GC struct (from `struct.new` /
+   `local.get`) is pushed as an argument to an externref-typed callee slot
+   without the ref→externref boxing (`extern.convert_any`, or
+   `any.convert_extern` when the value is already anyref). The argument-coercion
+   path is not calling `coerceType(refType, externref)` (the arm at
+   `src/codegen/type-coercion.ts:2035`) for these callee slots — likely the
+   private-method init (`C_init`) and Weak-collection key argument lowering
+   push the raw struct.
+
+2. **Typed `ref.null` (shape 2).** The null literal for a "not held weakly"
+   value is emitted as a **typed** `ref.null $Struct` and then handed to
+   `any.convert_extern`, whose operand must be `externref`, not a concrete ref.
+   The null-in-externref-context helper should emit `ref.null extern` (or box
+   through the extern path) — see the CLAUDE.md pattern "null/undefined in f64
+   context: emit directly (avoids externref roundtrip)"; the analogous
+   externref-context null should be `ref.null extern`, never a typed struct null
+   fed to `any.convert_extern`.
+
+3. **Double convert (shape 3, the `==` path).** The abstract-equality helper
+   (`S11.9.1` = `==`) already produces an externref operand, and the surrounding
+   coercion re-applies `extern.convert_any` (which expects an internal anyref,
+   not externref). The `==` operand-preparation code path double-boxes: it
+   should detect the operand is already externref and skip the convert, or use
+   `any.convert_extern` to go externref→anyref if an anyref is genuinely needed.
+
+## Implementation Plan
+
+### Investigation anchors
+
+- **Shape 1/4 (missing box):** grep the class-init / private-method emit
+  (`C_init`, `registerNative` for private methods) in `src/codegen/index.ts`
+  and the generic call-argument coercion in `src/codegen/expressions.ts`
+  (`compileCallExpression` argument loop). Confirm the callee slot ValType is
+  `externref` and that arg coercion routes through `coerceType(..., externref)`.
+- **Shape 2 (typed null):** grep `ref.null` emission for Weak-collection
+  key/value args in `src/codegen/object-ops.ts` / the collection builtins. The
+  null path must emit `ref.null extern` when the target is externref.
+- **Shape 3 (double convert):** grep the `==` / abstract-equality lowering
+  (`compileBinaryExpression` `==`/`!=` case in `src/codegen/expressions.ts`) and
+  the operand-boxing helper. Add an "already externref → no extern.convert_any"
+  guard.
+
+### Fix pattern
+
+- Route ALL these through `coerceType(from, to)` rather than hand-emitting
+  convert opcodes, so the from-kind dispatch (`ref/ref_null`→externref at
+  :2035, `externref`→anyref via `any.convert_extern`, and the identity
+  short-circuit) is applied uniformly. Where a site hand-emits
+  `extern.convert_any`/`any.convert_extern`, replace with a `coerceType` call
+  keyed on the real operand ValType.
+
+### Wasm IR pattern (targets)
+
+```wasm
+;; shape 1: GC struct → externref arg
+struct.new $Obj
+extern.convert_any            ;; box (was: raw struct passed)
+;; shape 2: null in externref position
+ref.null extern               ;; was: ref.null $Struct then any.convert_extern
+;; shape 3: operand already externref → no re-convert
+call $eq_operand              ;; result already externref; do NOT extern.convert_any
+```
+
+### Edge cases
+
+- Identity preservation: a GC object boxed to externref and later unboxed must
+  round-trip to the SAME reference (WeakSet/WeakMap identity semantics). Prefer
+  `extern.convert_any`/`any.convert_extern` (identity) over `__box_*`.
+- `==` with mixed operand types (one externref, one f64): only skip the convert
+  on the operand that is already externref; the numeric operand still needs its
+  own coercion.
+- Do not regress host mode — host `==`/collection paths may already be correct;
+  gate changes on the standalone/native-ref regime where the invalid opcode is
+  emitted.
+
+### Test files to verify
+
+- `test/language/expressions/class/elements/private-methods/prod-private-generator.js`
+- `test/built-ins/WeakSet/prototype/has/returns-false-when-value-cannot-be-held-weakly.js`
+- `test/language/expressions/equals/S11.9.1_A7.3.js`
+- Regression test `tests/issue-3395-extern-boxing.test.ts` (standalone + wasi +
+  host-guard) covering all three shapes.
+
+## Acceptance criteria
+
+- All 34 rows compile to valid Wasm (or refuse loudly).
+- WeakSet/WeakMap identity semantics preserved (round-trip test).
+- No host-mode regression; equivalence tests green.
+
+---
+
+## Progress (fable-dev-1, 2026-07-18)
+
+Branch `issue-3395-extern-boxing`, worktree
+`/workspace/.claude/worktrees/agent-aeb10fb7d183a166f`.
+
+### SHAPE 2 — DONE (Weak-collection typed null → invalid Wasm; ~6 rows)
+
+Root: `WeakSet`/`WeakMap` `get`/`has`/`delete`/`set`/`add` compiled the key/value
+arg RAW (`compileExpression` + `coerceMapKeyToAnyref`) in
+`src/codegen/weak-collections-runtime.ts`, so a null/undefined key literal
+(incl. `null as any` — the §CanBeHeldWeakly "value cannot be held weakly" rows)
+emitted a TYPED `ref.null $Struct` that `coerceArgToAnyref`'s externref arm fed
+to `any.convert_extern` ("expected externref, found ref.null of type (ref null
+N)"). Unlike the Map/Set native path, the weak path did NOT use the
+`compileCollectionElementArg` null-literal guard.
+
+Fix: route weak-collection args through `compileCollectionElementArg` (canonical
+`ref.null NONE_HEAP` null-guard + the #3394 i64 arm), and add an
+`as`/paren/`!`/`satisfies` unwrap (`unwrapExprWrappers`) to that guard so a
+WRAPPED null literal is still recognized. Verified: WeakSet.has(null)→false,
+object identity round-trips (add/has, set/get), WeakMap unregressed.
+`tests/issue-3395-extern-boxing.test.ts` (5 tests, green).
+
+### SHAPE 1 — NOT reproduced standalone-of-raw-body (missing box; ~17 rows)
+
+`prod-private-generator.js` (`call[1] expected externref, found struct.new of
+type (ref 7)` in `C_init`). RESUME ANCHOR: the raw test body compiles VALID on
+BOTH main and this branch (`--target standalone`) — the failing `C_init`
+boxing is only reached with the test262 harness (`assert`/`verifyProperty`)
+injected, which the standalone probe lacks. To reproduce: run the file through
+the actual test262 runner (`pnpm run test:262` filtered) or replicate the
+harness's private-method registration path. The fix is per the plan's Shape-1
+investigation anchors (class-init / private-method emit in `index.ts`; the
+call-arg coercion must route through `coerceType(refType, externref)` for the
+externref private-method slot).
+
+### SHAPE 3 — reproduced, deep root (== double-convert; ~11 rows)
+
+Minimal repro: `true == new String("x")` (also `1 == new String`,
+`new String == 1`) → `extern.convert_any[0] expected anyref, found call of type
+externref`. `new Boolean`/`new Number` inline are VALID — only the STRING
+wrapper. `const s = new String("x"); true == s` (via local) is VALID — only the
+INLINE `new String` operand double-converts. WAT shows `call $__new_String`
+(returns externref) immediately followed by a second `extern.convert_any`. The
+`new String` producer itself correctly returns `{kind:"externref"}`
+(`new-builtin-globals.ts:159-174`); the second convert is emitted in the `==`
+wrapper-equality dispatch (`binary-ops-typed-dispatch.ts`, the
+`isEqOp`/`wrapperEquality` operand-coercion cascade). RESUME ANCHOR: trace which
+branch fires for `boolean == <String-wrapper externref>` (the
+`isStringType(rightTsType)` gate is FALSE for a `String` OBJECT, so it falls to
+the `else if (isNumericOp || isEqOp || isNeqOp)` valueOf-coercion arm ~:370);
+add an "operand already externref → skip the convert / use any.convert_extern"
+guard there per the plan's Shape-3 fix.
+
+### Regression status
+
+Weak/Map/Set suites green (issue-2162-standalone-weak, issue-3242-weakref,
+issue-2378, issue-2861, issue-3309, issue-2162-map-foreach — 50 tests). The
+shape-2 change is scoped to the standalone/native weak-collection arg path;
+host mode unchanged.

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -1464,12 +1464,41 @@ function coerceArgToAnyref(ctx: CodegenContext, fctx: FunctionContext, t: ValTyp
  * to a queried `none`-null, so SameValueZero null/undefined equality works once
  * the representation is uniform.
  */
+/**
+ * (#3395) Peel `as`/`satisfies`/parenthesized/`!` wrappers that never change a
+ * value's runtime identity, so a null/undefined literal behind such a wrapper
+ * (`null as any`, `(undefined)`) is still recognized as a null literal by the
+ * collection element null-guard.
+ */
+function unwrapExprWrappers(expr: ts.Expression): ts.Expression {
+  let e: ts.Expression = expr;
+  while (
+    ts.isAsExpression(e) ||
+    ts.isParenthesizedExpression(e) ||
+    ts.isNonNullExpression(e) ||
+    ts.isSatisfiesExpression(e) ||
+    ts.isTypeAssertionExpression(e)
+  ) {
+    e = e.expression;
+  }
+  return e;
+}
+
 export function compileCollectionElementArg(
   ctx: CodegenContext,
   fctx: FunctionContext,
   argExpr: ts.Expression | undefined,
 ): void {
-  if (argExpr !== undefined && isNullOrUndefinedLiteral(argExpr)) {
+  // (#3395) Unwrap `as`/parenthesized/`!` wrappers before the null-literal
+  // check: a Weak-collection key written `s.has(null as any)` (or the raw
+  // `s.has(null)` whose `null` reaches here through a cast) is an AsExpression,
+  // not a bare NullKeyword, so the guard below missed it — `compileExpression`
+  // then emitted a TYPED `ref.null $Struct` and `coerceArgToAnyref`'s externref
+  // arm fed it to `any.convert_extern` ("expected externref, found ref.null of
+  // type (ref null N)"), invalid Wasm. Unwrapping routes it to the canonical
+  // `ref.null NONE_HEAP` path (identical runtime ABSENT/undefined semantics).
+  const unwrapped = argExpr !== undefined ? unwrapExprWrappers(argExpr) : undefined;
+  if (unwrapped !== undefined && isNullOrUndefinedLiteral(unwrapped)) {
     // Canonical anyref-subtype null matching the runtime's ABSENT/`undefined`
     // sentinel — bypasses the `compileExpression` typed-`ref.null` + externref
     // mismatch.
@@ -1477,7 +1506,7 @@ export function compileCollectionElementArg(
     // the $undefined singleton (distinct from null) so `m.get(k)` reads back
     // `undefined`, not `null`; a NULL literal keeps the canonical ref.null.
     // Legacy lanes conflate both to ref.null byte-identically.
-    if (argExpr.kind !== ts.SyntaxKind.NullKeyword && undefinedSingletonActive(ctx)) {
+    if (unwrapped.kind !== ts.SyntaxKind.NullKeyword && undefinedSingletonActive(ctx)) {
       if (ctx.undefinedGlobalIdx === undefined) ensureAnyValueType(ctx);
       if (ctx.undefinedGlobalIdx !== undefined) {
         fctx.body.push({ op: "global.get", index: ctx.undefinedGlobalIdx });

--- a/src/codegen/weak-collections-runtime.ts
+++ b/src/codegen/weak-collections-runtime.ts
@@ -38,7 +38,7 @@ import { addFuncType } from "./registry/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { compileExpression, VOID_RESULT } from "./shared.js";
-import { coerceMapKeyToAnyref, ensureMapHelpers } from "./map-runtime.js";
+import { compileCollectionElementArg, ensureMapHelpers } from "./map-runtime.js";
 
 /**
  * Emit the `__weakset_add(m, v) -> ref $Map` helper (idempotent). WeakSet.add
@@ -117,28 +117,31 @@ export function tryCompileNativeWeakMethodCall(
   if (!castReceiverToMap(ctx, fctx, recvType)) return undefined;
 
   const args = callExpr.arguments;
+  // (#3395) Route key/value args through `compileCollectionElementArg`, not a
+  // raw `compileExpression` + `coerceMapKeyToAnyref`: the former recognizes a
+  // null/undefined key literal (incl. `null as any` — the §CanBeHeldWeakly
+  // "value cannot be held weakly" test rows) and emits a canonical
+  // `ref.null NONE_HEAP` instead of letting a TYPED `ref.null $Struct` flow into
+  // `any.convert_extern` ("expected externref, found ref.null of type (ref null
+  // N)", invalid Wasm). It also carries the #3394 i64/bigint boxing arm.
   switch (methodName) {
     case "get":
     case "has":
     case "delete": {
-      const kt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
-      coerceMapKeyToAnyref(ctx, fctx, kt);
+      compileCollectionElementArg(ctx, fctx, args.length > 0 ? args[0]! : undefined);
       fctx.body.push({ op: "call", funcIdx: helperIdx });
       // get → anyref value; has/delete → i32 (boolean).
       return methodName === "get" ? ({ kind: "anyref" } as ValType) : ({ kind: "i32" } as ValType);
     }
     case "set": {
-      const kt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
-      coerceMapKeyToAnyref(ctx, fctx, kt);
-      const vt = args.length > 1 ? compileExpression(ctx, fctx, args[1]!) : null;
-      coerceMapKeyToAnyref(ctx, fctx, vt);
+      compileCollectionElementArg(ctx, fctx, args.length > 0 ? args[0]! : undefined);
+      compileCollectionElementArg(ctx, fctx, args.length > 1 ? args[1]! : undefined);
       fctx.body.push({ op: "call", funcIdx: helperIdx });
       // __map_set returns ref $Map (the collection) — chainable.
       return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
     }
     case "add": {
-      const vt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
-      coerceMapKeyToAnyref(ctx, fctx, vt);
+      compileCollectionElementArg(ctx, fctx, args.length > 0 ? args[0]! : undefined);
       fctx.body.push({ op: "call", funcIdx: helperIdx });
       // __weakset_add returns ref $Map — chainable.
       return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;

--- a/tests/issue-3395-extern-boxing.test.ts
+++ b/tests/issue-3395-extern-boxing.test.ts
@@ -1,0 +1,94 @@
+// #3395 — object/closure GC ref ↔ externref boxing at boundaries (child of
+// #2039's standalone invalid-Wasm bucket).
+//
+// SHAPE 2 (this slice): a WeakSet/WeakMap key/value that is a null/undefined
+// literal (incl. `null as any` — the §CanBeHeldWeakly "value cannot be held
+// weakly" rows) was compiled raw and its TYPED `ref.null $Struct` flowed into
+// `any.convert_extern`, which wants an externref → invalid Wasm
+// ("any.convert_extern expected externref, found ref.null of type (ref null
+// N)"). Fix: route the weak-collection args through the canonical
+// null-literal guard (`compileCollectionElementArg` → `ref.null NONE_HEAP`),
+// with an as/paren/!/satisfies unwrap so wrapped null literals are recognized.
+//
+// Shapes 1 (missing box in class/private-method init) and 3 (== double-convert
+// with a wrapper Object) are tracked as follow-ups in the issue file.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function validStandalone(source: string): Promise<boolean> {
+  const result = await compile(source, { fileName: "t.ts", target: "standalone" as const });
+  if (!result.success) throw new Error(`compile failed: ${result.errors[0]?.message}`);
+  return WebAssembly.validate(result.binary);
+}
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { fileName: "t.ts", target: "standalone" as const });
+  if (!result.success) throw new Error(`compile failed: ${result.errors[0]?.message}`);
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#3395 shape 2 — Weak-collection null key → valid Wasm", () => {
+  it("WeakSet.has / .add / .delete with a null/undefined key compile to valid Wasm", async () => {
+    expect(
+      await validStandalone(`export function test(): boolean { const s = new WeakSet(); return s.has(null as any); }`),
+    ).toBe(true);
+    expect(
+      await validStandalone(
+        `export function test(): boolean { const s = new WeakSet(); return s.has(undefined as any); }`,
+      ),
+    ).toBe(true);
+    expect(await validStandalone(`export function test(): void { const s = new WeakSet(); s.add(null as any); }`)).toBe(
+      true,
+    );
+  });
+
+  it("WeakMap.has / .get / .set with a null key compile to valid Wasm", async () => {
+    expect(
+      await validStandalone(`export function test(): boolean { const m = new WeakMap(); return m.has(null as any); }`),
+    ).toBe(true);
+    expect(
+      await validStandalone(
+        `export function test(): boolean { const m = new WeakMap<any,any>(); m.set(null as any, 1); return m.has(null as any); }`,
+      ),
+    ).toBe(true);
+  });
+
+  it("WeakSet.has(null) returns false (CanBeHeldWeakly is false)", async () => {
+    // `has` lowers to an i32 boolean; encode as a number so the falsy result is
+    // representation-stable across the wasm boundary (0 === false).
+    const got = await runStandalone(
+      `export function test(): number { const s = new WeakSet(); return s.has(null as any) ? 1 : 0; }`,
+    );
+    expect(got).toBe(0);
+  });
+
+  it("object identity is preserved across add/has (no regression)", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        const s = new WeakSet();
+        const a = {};
+        const b = {};
+        s.add(a);
+        return (s.has(a) ? 1 : 0) * 10 + (s.has(b) ? 1 : 0);   // 10: a in, b out
+      }
+    `);
+    expect(got).toBe(10);
+  });
+
+  it("WeakMap identity round-trip preserved (no regression)", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        const m = new WeakMap<any, any>();
+        const k = {};
+        m.set(k, 42);
+        const v: any = m.get(k);
+        return typeof v === "number" ? v : -1;
+      }
+    `);
+    expect(got).toBe(42);
+  });
+});


### PR DESCRIPTION
## #3395 shape 2 — Weak-collection typed `ref.null` → `any.convert_extern` invalid Wasm

Child of #2039's standalone invalid-Wasm bucket. This PR lands **shape 2** of the
three (the Weak-collection typed-null rows, ~6); shapes 1 & 3 are documented as
follow-ups with grounded resume anchors in the issue file.

### Root cause (shape 2)

`WeakSet`/`WeakMap` `get`/`has`/`delete`/`set`/`add` compiled the key/value arg
**raw** (`compileExpression` + `coerceMapKeyToAnyref`) in
`src/codegen/weak-collections-runtime.ts` — unlike the Map/Set native path, they
did NOT use the `compileCollectionElementArg` null-literal guard. So a
null/undefined key (incl. `null as any`, the §CanBeHeldWeakly "value cannot be
held weakly" rows) emitted a **typed** `ref.null $Struct` that
`coerceArgToAnyref`'s externref arm fed to `any.convert_extern` — invalid
(`expected externref, found ref.null of type (ref null N)`).

### Fix

- Route weak-collection args through `compileCollectionElementArg` (canonical
  `ref.null NONE_HEAP` null-guard + the #3394 i64/bigint arm).
- Add an `as`/paren/`!`/`satisfies` unwrap (`unwrapExprWrappers`) to the
  null-literal guard so a **wrapped** null literal (`null as any`) is recognized.

### Verification

- New `tests/issue-3395-extern-boxing.test.ts` (5 tests): valid Wasm for
  WeakSet/WeakMap null keys, `WeakSet.has(null) === false` (CanBeHeldWeakly), and
  **object-identity round-trips** (`add`/`has`, `set`/`get`) — identity is
  preserved (the fix uses `ref.null`, not a `__box_*` reallocation).
- Regression: Weak/Map/Set suites green (issue-2162-standalone-weak,
  issue-3242-weakref, issue-2378, issue-2861, issue-3309, issue-2162-map-foreach
  — 50 tests). Scoped to the standalone/native weak-collection arg path; host
  mode unchanged. oracle-ratchet clean; `loc-budget-allow` granted.

### Follow-ups (documented in the issue file with resume anchors)

- **Shape 1** (missing box in class/private-method `C_init`, ~17 rows): the raw
  test body compiles valid standalone — reproducing needs the test262 harness.
- **Shape 3** (`==` double-convert, ~11 rows): minimal repro `true == new
  String("x")` — the second `extern.convert_any` is in the `==` wrapper-equality
  operand cascade (`binary-ops-typed-dispatch.ts` ~:370); needs an "already
  externref → skip convert" guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG