### PR TITLE
docs(#1378): sub-issue B precise root cause — $Error_struct.name is immutable

### DIFF
--- a/plan/issues/1378-spec-gap-try-catch-finally-completion-and-error-fidelity.md
+++ b/plan/issues/1378-spec-gap-try-catch-finally-completion-and-error-fidelity.md
@@ -214,6 +214,71 @@ Empty-pattern `catch ([])` short-circuits with no materialisation per
 - `completion-values-fn-finally-normal.js` null_deref: needs separate
   investigation of the `assert_throws` host shim.
 
+## Sub-issue B — PRECISE ROOT CAUSE (fable-dev-5, 2026-07-18, re-validated on current main)
+
+Smoke-tested sub-issue B against current main and narrowed the vague
+"error-type fidelity" down to **one property**: the `name` field on an Error
+subclass. Probe matrix (standalone lane, `new MyErr("boom")` where
+`class MyErr extends Error`):
+
+| read | result | verdict |
+| --- | --- | --- |
+| `e instanceof MyErr` (throw/catch) | 1 | ✅ works (the #2188 `$userClassId` brand) |
+| `e instanceof Error` | 1 | ✅ works |
+| `e.message === "boom"` | 1 | ✅ works |
+| custom own field `e.code === 42` | 1 | ✅ works (routed via `$Error_struct.$props`) |
+| base `new Error("boom").name === "Error"` | 1 | ✅ works |
+| **`e.name` after `this.name = "MyErr"` in ctor** | **0** | ❌ **BUG** |
+| **`e.name` after class field `name = "MyErr"`** | **0** | ❌ **BUG** |
+
+**It is NOT a throw/catch bug and NOT a prototype-chain bug** (both those work).
+It is a **read/write-lane split on the `name` property specifically**:
+
+- `$Error_struct` (registry/types.ts:~627) lays out
+  `[tag(0), message(1, MUT), name(2, **immutable**), stack(3, MUT),
+  userClassId(4, MUT), props(5, MUT)]`.
+- **`name` is declared `mutable: false`** (registry/types.ts:633). A standalone
+  user Error subclass instance IS a `$Error_struct` (not a distinct struct —
+  see `emitSetSubclassUserBrand`, class-bodies.ts:501), so `this.name = "MyErr"`
+  / the `name = "MyErr"` class-field initializer has NOWHERE to write: the
+  struct's `name` field is immutable, so the write is dropped (or silently
+  routed to the `$props` overflow store), while the READ path
+  (property-access-dispatch.ts:~1083 — "Error LHS so `.message`/`.name`/`.stack`
+  read the struct field directly") reads fieldIdx 2, returning the
+  constructor-baked default (`"Error"` / the parent name). This is exactly why
+  `message` works (fieldIdx 1 is mutable) and custom fields work (they use
+  `$props`, which the read path DOES consult for non-name/message/stack keys).
+
+### Fix direction (for the implementer — NOT done here)
+
+1. Make `$Error_struct.name` **`mutable: true`** (registry/types.ts:633). Check
+   why it was pinned immutable — likely an interning/dedup assumption that a
+   built-in Error's name is constant; a user subclass violates that.
+2. Route `.name` WRITES on an `$Error_struct` receiver to `struct.set fieldIdx 2`
+   (the member-set dispatch — grep `$Error_struct` in member-set-dispatch.ts /
+   the property-write path that currently handles `.message`/`.stack` writes;
+   `.name` must join them). Cover BOTH `this.name = v` in the ctor AND the
+   class-field `name = "..."` initializer (class-bodies field-init emit).
+3. The READ path already reads fieldIdx 2 — no change needed once the write
+   lands there. Verify `$props` doesn't also shadow it.
+
+### Regression surface + measurement
+
+- The immutable-name assumption may be load-bearing for the 8 built-in
+  `__new_<Error>` constructors (they bake the canonical name). Making the field
+  mutable must not let a plain `new TypeError()` mutate its shared name — but
+  since each `struct.new` produces a fresh instance, mutability is per-instance
+  and safe. Confirm with the existing Error suites.
+- Acceptance still needs the full test262 `language/statements/try/` +
+  `built-ins/NativeErrors/` harness measurement (+60 net target) — run in CI,
+  not locally.
+- Repro to promote into `tests/issue-1378.test.ts`: the 7-row matrix above
+  (standalone lane), asserting the two ❌ rows flip to 1.
+
+This stays `feasibility: hard` / `status: ready` — the substrate change (mutable
+field + write-routing + regression sweep) is a proper slice, not a one-liner,
+but it is now precisely located.
+
 ## Frontmatter reconcile (2026-06-12)
 
 Was `in-progress` with no open PR, no active agent, and no Suspended Work section (session died sprints 42-52). Reset to `ready` during the sprint-62 issue review; re-validate against current main before claiming (#2148).


### PR DESCRIPTION
Re-validated #1378 sub-issue B (error-type fidelity) against current main and narrowed the vague "deep externref-backed Error-subclass substrate" down to **one property**.

## Finding (7-row probe matrix, standalone lane)

Everything works EXCEPT the `name` property on an Error subclass:
- `e instanceof MyErr` / `instanceof Error` — ✅ (the #2188 `$userClassId` brand)
- `e.message` — ✅ (`$Error_struct` fieldIdx 1 is mutable)
- custom own field `e.code` — ✅ (routed via `$Error_struct.$props`)
- **`this.name = "MyErr"` / class-field `name = "MyErr"`** — ❌

The existing RESCOPE note (which claimed `instanceof` fails and it's a prototype-chain bug) is **stale on current main** — both now work; this doc corrects it.

## Root cause

`$Error_struct` (registry/types.ts:~627) is `[tag(0), message(1,MUT), **name(2, immutable)**, stack(3,MUT), userClassId(4,MUT), props(5,MUT)]`. A standalone user Error subclass instance IS a `$Error_struct` (not a distinct struct — `emitSetSubclassUserBrand`, class-bodies.ts:501). Because **`name` is `mutable: false`** (registry/types.ts:633), a subclass `this.name =` / `name =` write has nowhere to land — it's dropped (or routed to `$props`), while the read path (property-access-dispatch.ts:~1083) reads fieldIdx 2 directly, returning the ctor-baked default. `message` works because fieldIdx 1 is mutable; custom fields work via `$props`.

## Fix direction (banked for the implementer — NOT done here)

1. `$Error_struct.name` → `mutable: true`.
2. Route `.name` WRITES on a `$Error_struct` receiver to `struct.set fieldIdx 2` (join the existing `.message`/`.stack` write path), covering both `this.name =` and the class-field initializer.
3. Read path already reads fieldIdx 2 — no change once the write lands there.

Stays `feasibility: hard` / `status: ready` — the mutable-field + write-routing + regression sweep is a proper slice (acceptance needs the full test262 `try/` + `NativeErrors` harness), but it is now precisely located. Doc-only PR; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG