### PR TITLE
docs(audit): engineering risks and implementation plans (#3406-#3410)

### DIFF
--- a/plan/issues/1132-publish-compiler-as-loopdive-js2.md
+++ b/plan/issues/1132-publish-compiler-as-loopdive-js2.md
@@ -1,18 +1,46 @@
 ---
 id: 1132
 title: "Publish compiler as @loopdive/js2 on npm + JSR"
-status: ready
+status: done
 created: 2026-04-19
-updated: 2026-06-19
+updated: 2026-07-18
+completed: 2026-07-06
 priority: high
 feasibility: medium
 reasoning_effort: medium
 goal: platform
 sprint: Backlog
 ---
-## Problem
+
+## Resolution / audit reconciliation (2026-07-18)
+
+Publication is complete. This issue remained `ready` after the release system
+and public packages landed, so the 2026-07-18 engineering audit reconciled it
+against repository and public-registry evidence:
+
+- npm `@loopdive/js2` was first published on 2026-06-27 and is live at 0.60.1.
+- npm `js2wasm`, the unscoped proxy, is live at 0.60.1.
+- JSR `@loopdive/js2` is live at 0.60.1 (0.60.0 and 0.60.1 published).
+- `.github/workflows/publish-npm.yml` verifies tag/package version parity,
+  builds and packs the canonical npm package, publishes both npm packages with
+  provenance, and publishes JSR independently.
+- `docs/releasing.md` and `scripts/release.mjs` document/enforce the lockstep
+  release flow.
+
+Two original acceptance details were superseded by later product decisions:
+
+- The shipped package is ESM-only (`exports.import`), not dual ESM/CJS.
+- npm reports 8,904,177 bytes unpacked, above the old `<5 MB` target. The package
+  now intentionally includes `examples/` (#2828), and size was not retained as a
+  release blocker.
+
+The historical problem and implementation sketch below are retained as the
+planning record; they are not current instructions.
+
+## Historical problem
 
 The compiler has no npm presence. Users must clone the repo and build from source. Publishing as `@loopdive/js2` gives:
+
 - Install via `npm install -g @loopdive/js2` or `npx @loopdive/js2 input.ts -o output.wasm`
 - Programmatic API via `import { compile } from "@loopdive/js2"`
 - Canonical ownership under `@loopdive` org — branded, no squatting risk
@@ -28,7 +56,7 @@ The compiler has no npm presence. Users must clone the repo and build from sourc
 - `@loopdive/js2@0.1.0` published to npmjs.com under the `loopdive` org
 - README on npm page links to GitHub repo and playground
 
-## Implementation Plan
+## Historical implementation plan (superseded)
 
 ### 1. package.json changes
 
@@ -51,11 +79,7 @@ The compiler has no npm presence. Users must clone the repo and build from sourc
       "types": "./dist/index.d.ts"
     }
   },
-  "files": [
-    "dist/",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist/", "README.md", "LICENSE"],
   "publishConfig": {
     "access": "public"
   }
@@ -65,6 +89,7 @@ The compiler has no npm presence. Users must clone the repo and build from sourc
 ### 2. .npmignore / files field
 
 Exclude:
+
 - `test262/`, `tests/`, `benchmarks/`, `.claude/`, `plan/`, `scripts/`, `src/`, `components/`, `dashboard/`, `playground/`
 - All `*.test.ts`, `*.jsonl`, `*.wat`, `*.wasm` files
 - Dev configs: `vitest.config.ts`, `tsconfig*.json` (except bundled types)
@@ -74,6 +99,7 @@ Only ship: `dist/`, `README.md`, `LICENSE`
 ### 3. Build pipeline
 
 Ensure `pnpm build` produces:
+
 - `dist/index.js` — CJS entry (compiler API)
 - `dist/index.mjs` — ESM entry
 - `dist/index.d.ts` — type declarations
@@ -85,6 +111,7 @@ Check existing `scripts/compiler-bundle.mjs` and `scripts/runtime-bundle.mjs` �
 ### 4. CLI entry
 
 Ensure `dist/cli.js` handles:
+
 ```
 js2 input.ts -o output.wasm
 js2 input.ts --target wasi -o output.wasm
@@ -99,7 +126,7 @@ js2 --help
 // dist/index.d.ts should export:
 export function compile(source: string, options?: CompileOptions): CompileResult;
 export interface CompileOptions {
-  target?: 'js' | 'wasi';
+  target?: "js" | "wasi";
   optimize?: boolean;
   nativeStrings?: boolean;
   allowJs?: boolean;
@@ -126,10 +153,11 @@ Publish from CI (GitHub Actions) on git tag `v0.1.0` push, using `NPM_TOKEN` sec
 ### 7. GitHub Actions workflow
 
 Create `.github/workflows/publish-npm.yml`:
+
 ```yaml
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -147,6 +175,7 @@ jobs:
 JSR (`jsr.io`) is TypeScript-native and supports Deno, Bun, and Node.js. Same `@loopdive/js2` scope.
 
 Add `jsr.json` at repo root:
+
 ```json
 {
   "name": "@loopdive/js2",
@@ -167,6 +196,7 @@ JSR imports directly from TypeScript source — no build step needed for JSR con
 ```
 
 Deno users get:
+
 ```ts
 import { compile } from "jsr:@loopdive/js2";
 ```

--- a/plan/issues/3406-zero-candidate-dynamic-call-silent-null.md
+++ b/plan/issues/3406-zero-candidate-dynamic-call-silent-null.md
@@ -1,0 +1,137 @@
+---
+id: 3406
+title: "Dynamic any-callee with zero closure candidates silently returns null instead of invoking or throwing"
+status: ready
+created: 2026-07-18
+updated: 2026-07-18
+priority: critical
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: dynamic-call
+goal: correctness
+sprint: current
+related: [2939, 2940, 3335, 1858]
+origin: "2026-07-18 codebase engineering audit (plan/log/2026-07-18-codebase-engineering-audit.md, F1)"
+---
+
+# #3406 — zero-candidate dynamic calls silently return `null`
+
+## Problem
+
+A real JS function passed through an `any` parameter is silently not called when
+the current module has no registered closure-wrapper candidates:
+
+```ts
+export function test(f: any): any {
+  return f(2);
+}
+```
+
+Verified on `origin/main` at `852c40a9`: compilation succeeds and the Wasm
+validates, but invoking `test((x) => x + 1)` returns `null` instead of `3`.
+
+This is a silent miscompile, not a diagnostic-quality issue. Argument side
+effects still execute, while callee side effects and the return value disappear.
+A non-callable value likewise takes the synthesized-`null` path instead of throwing a
+catchable `TypeError`.
+
+## Root cause
+
+`tryEmitInlineDynamicCall` derives closure arms from
+`ctx.closureInfoByTypeIdx`. At
+`src/codegen/expressions/calls.ts:3618`, it returns `null` when there are zero
+closure candidates and no standalone special carrier. That happens before the
+host `__call_function` default arm added by #3335 can be built.
+
+The identifier-call caller interprets `null` as "unsupported unknown function"
+and deliberately lowers the call to:
+
+1. evaluate each argument;
+2. drop each argument value;
+3. push `ref.null.extern` as the result.
+
+See `src/codegen/expressions/call-identifier.ts:1651-1666`.
+
+#3335 repaired the default arm of a dispatch chain that has candidates. It did
+not cover the zero-candidate early return, so the old silent fallback remains
+reachable in the simplest exported-parameter shape.
+
+## Scope
+
+- Repair bare identifier calls whose callee is dynamically typed and whose
+  closure candidate set is empty.
+- Host lane: invoke a non-null raw host callable through the existing
+  `__call_function` bridge.
+- Standalone/WASI: dispatch any supported native callable carrier; otherwise
+  refuse at compile time or throw a catchable runtime `TypeError`.
+- Preserve exactly-once evaluation of the callee and every argument.
+- Do not broaden unrelated property/method-call dispatch in the same slice.
+
+## Implementation steps
+
+1. Add `tests/issue-3406.test.ts` with the minimal exported-parameter regression
+   before changing code. Assert compile success, Wasm validation, exactly one
+   callback invocation, argument `2`, and result `3`.
+2. Add a non-callable probe under `try/catch` and assert a catchable `TypeError`,
+   not `null`/`undefined` and not an uncatchable Wasm trap.
+3. Restructure the zero-candidate guard in `tryEmitInlineDynamicCall` so host
+   mode can build the existing raw-callee `__call_function` arm even when the
+   closure-arm list is empty. Reuse the existing argument array and host-call
+   marshalling; do not add a second bridge.
+4. Keep standalone special carriers (`Proxy`, bound functions, TypedArray
+   constructors) ahead of the refusal arm. Add a loud terminal arm for an
+   unsupported/non-callable dynamic value.
+5. Audit late-import registration order. All host helper imports must be
+   ensured and `flushLateImportShifts` completed before any helper/function
+   index is captured into detached dispatch buffers.
+6. Remove or narrow the outer `ref.null.extern` call fallback so no reachable
+   dynamic call reports success while deleting the invocation.
+
+## Acceptance criteria
+
+- [ ] The verified `test(f:any) { return f(2) }` probe calls a host function
+      once and returns `3` in the default lane with zero closure candidates.
+- [ ] A dynamically supplied non-callable throws a catchable JS `TypeError`.
+- [ ] Callee and argument expressions are evaluated once, in JS order, on both
+      success and throw paths.
+- [ ] Host, standalone, and WASI behavior is explicit; none silently synthesizes
+      a synthesized nullish value for an unsupported call.
+- [ ] Existing one-candidate and multi-candidate closure dispatch tests remain
+      valid and stack-balanced.
+- [ ] Generated modules pass `WebAssembly.validate`; no new stack-balance,
+      function-index, host-import, or codegen-fallback debt is introduced.
+
+## Validation plan
+
+- Targeted `tests/issue-3406.test.ts` regression suite covering zero/one/many candidates,
+  void/value-returning callbacks, non-callables, thrown callback errors, and
+  side-effectful arguments.
+- Existing dynamic dispatch suites: #2939, #2940, #3031, #3140, #3177, and
+  #3335 tests.
+- `pnpm run typecheck`
+- `pnpm run check:stack-balance`
+- `pnpm run check:codegen-fallbacks`
+- `pnpm run check:loc-budget`
+- Default-lane test262 comparison, with special attention to callback-vacuity,
+  Promise, TypedArray harness, and `TypeError` buckets.
+
+## Dependencies
+
+- Reuse the host-call bridge landed by #3335.
+- Coordinate with any in-flight work touching
+  `tryEmitInlineDynamicCall`/`call-identifier.ts`; this is a high-conflict,
+  stack-sensitive area.
+
+## Risks
+
+- Ensuring host imports inside detached buffers can shift function indices and
+  reproduce the #1858/#2611 class of invalid Wasm unless the shift is flushed
+  before indices are captured.
+- Every `if` arm must leave the exact declared block result type. Void and value
+  call sites need separate coverage.
+- A broad fallback change can turn existing vacuous results into real execution,
+  exposing honest test262 failures. Treat such flips as behavior corrections,
+  not grounds to restore the silent no-op.

--- a/plan/issues/3407-test262-duplicate-verdict-key-invariant.md
+++ b/plan/issues/3407-test262-duplicate-verdict-key-invariant.md
@@ -1,0 +1,142 @@
+---
+id: 3407
+title: "test262 fixture runner emits duplicate and contradictory verdict rows; enforce one canonical result per file"
+status: ready
+created: 2026-07-18
+updated: 2026-07-18
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: testing
+language_feature: test262-harness
+goal: test-infrastructure
+sprint: current
+related: [1221, 2913, 2920, 3003]
+origin: "2026-07-18 codebase engineering audit (plan/log/2026-07-18-codebase-engineering-audit.md, F2)"
+---
+
+# #3407 — enforce one canonical test262 verdict per file
+
+## Problem
+
+The current fetched JS-host baseline has **48,113 JSONL rows for 48,088 unique
+test files**: 25 duplicate keys. Twenty-two duplicate pairs are fail/fail with
+different diagnostics, and three are contradictory fail/pass pairs:
+
+```text
+test/language/module-code/top-level-await/module-import-rejection-body.js
+test/language/module-code/top-level-await/module-import-rejection-tick.js
+test/language/module-code/top-level-await/module-import-rejection.js
+```
+
+The canonical JSONL therefore does not satisfy one-verdict-per-file. The report
+builder masks the source defect with worst-status dedup, while `diff-test262`
+uses last-write-wins. The same baseline file can be a fail in the published
+summary and a pass in regression analysis.
+
+## Verified root cause
+
+`recordResult` writes a JSONL row and throws `ConformanceError` for every
+non-pass verdict. In the fixture execution path, the inner catch at
+`tests/test262-shared.ts:779-831` catches that sentinel and calls
+`recordResult` again:
+
+- an ordinary failure is written once with its real diagnostic, then again as
+  `ConformanceError: [fail] ...`;
+- a runtime-negative "execution succeeded" failure can be caught and then
+  reclassified as a pass.
+
+The outer catch at `tests/test262-shared.ts:833-841` has the #1221 guard that
+rethrows `ConformanceError`, but the duplicate has already been written by the
+inner catch.
+
+The merge workflow concatenates shard files without validating identity
+uniqueness (`.github/workflows/test262-sharded.yml:622-644`). Consumers then
+apply incompatible policies:
+
+- worst-status precedence in `scripts/build-test262-report.mjs:902-960`;
+- last-write-wins in `scripts/diff-test262.ts:519-533`.
+
+## Relationship to #2913
+
+#2913 completed defensive dedup for headline reports and edition summaries. Its
+resolution explicitly left the duplicate-write source as a follow-up. This
+issue keeps that completed work intact and owns the remaining producer,
+canonical-data, and consumer-consistency contract.
+
+## Scope
+
+- Stop the fixture execution path from recording a second verdict after
+  `recordResult` throws its sentinel.
+- Define a single result identity key for the current runner. Today that is
+  `file` because each row has `strict: "both"`; if future strict variants become
+  separate executions, include the variant explicitly rather than overloading
+  one file key.
+- Validate merged JSONL uniqueness before report construction, diffing, or
+  promotion.
+- Make every defensive consumer share one duplicate policy. Contradictory
+  duplicates must fail loudly; they must not be silently resolved by row order.
+
+## Implementation steps
+
+1. Add a fixture-path regression that forces each inner `recordResult` branch
+   (ordinary fail, expected runtime-negative pass, unexpected runtime-negative
+   success) and asserts exactly one emitted row.
+2. In the inner fixture execution catch, rethrow `ConformanceError` before any
+   error-classification branch. Preserve the outer guard as defense in depth.
+3. Extract a streaming JSONL identity validator/shared loader used by report,
+   diff, and baseline-promotion checks. It should report duplicate keys, both
+   statuses, and source row numbers.
+4. Add a merge-report step immediately after concatenation that rejects any
+   duplicate key. Do not "fix" the canonical artifact by silently deleting
+   rows.
+5. Align defensive historical-file behavior. Same-status identical retries may
+   use one documented deterministic record; conflicting statuses must be a hard
+   error unless an explicit retry-attempt schema defines which verdict is
+   canonical.
+6. Refresh the baseline after the producer fix and verify report, diff, editions,
+   trap growth, and feature generators all see the same 48,088 identities.
+
+## Acceptance criteria
+
+- [ ] A full merged JS-host and standalone JSONL contains exactly one canonical
+      row per result identity key.
+- [ ] The three current fail/pass duplicate files each have one stable verdict.
+- [ ] `build-test262-report` and `diff-test262` cannot disagree because of
+      duplicate row order.
+- [ ] Merge/promotion fails with an actionable diagnostic when synthetic input
+      contains a conflicting duplicate.
+- [ ] Report totals, category totals, editions, and diff population all reconcile
+      to the same unique-key count.
+- [ ] Retry metadata remains representable without creating a second canonical
+      verdict row.
+
+## Validation plan
+
+- Unit tests with identical duplicates, same-status/different-diagnostic
+  duplicates, fail/pass conflicts, malformed rows, and missing file keys.
+- Targeted fixture-runner tests for positive, ordinary-fail, compile-error,
+  runtime-negative-pass, and runtime-negative-fail paths.
+- Build reports from the pre-fix baseline and prove the validator identifies
+  exactly the measured 25 keys.
+- Run the relevant test262 path filter for `language/module-code` and confirm no
+  duplicate keys.
+- `pnpm run typecheck`, formatting, and issue integrity.
+- If canonical verdict selection changes rather than merely removing the second
+  write, follow #3003: version/rebaseline the oracle in a queue-safe rollout.
+
+## Dependencies
+
+- #2913 supplies the current defensive report precedence and fixtures.
+- #1221 documents the earlier outer-catch attempt and must not be regressed.
+
+## Risks
+
+- A fail-loud uniqueness check will block baseline promotion until every writer
+  obeys the invariant; wire it only with the producer fix in the same change.
+- Raw retries may be intentionally append-oriented. Preserve attempt telemetry
+  separately instead of treating two attempts as two canonical test results.
+- Changing a pass/fail conflict to one verdict can look like a conformance delta.
+  The baseline and oracle rollout must make that policy transition explicit.

--- a/plan/issues/3408-retire-nonatomic-issue-id-entrypoints.md
+++ b/plan/issues/3408-retire-nonatomic-issue-id-entrypoints.md
@@ -1,0 +1,114 @@
+---
+id: 3408
+title: "Retire non-atomic issue-ID entrypoints and stale collision-remediation guidance"
+status: ready
+created: 2026-07-18
+updated: 2026-07-18
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: developer-experience
+sprint: current
+related: [2530, 2531, 2943, 2974, 2977]
+origin: "2026-07-18 codebase engineering audit (plan/log/2026-07-18-codebase-engineering-audit.md, F4)"
+---
+
+# #3408 — retire non-atomic issue-ID entrypoints
+
+## Problem
+
+The repository mandates atomic ID allocation through:
+
+```text
+node scripts/claim-issue.mjs --allocate
+```
+
+because optimistic `max + 1` selection races with open PRs and concurrent
+agents, and collisions surface only in `merge_group`. Yet the shortest,
+canonical-looking package command still invokes the deprecated predictor:
+
+```json
+"new:issue-id": "node scripts/next-issue-id.mjs"
+```
+
+(`package.json:78-81`). The safe alias is less discoverable:
+`new:issue-id:allocate` (`package.json:157-160`).
+
+`scripts/next-issue-id.mjs:12-24` explicitly says it does not reserve and does
+not scan open PRs. The merged-tree collision check nevertheless tells users to
+repair a collision with that deprecated script
+(`scripts/check-merged-issue-integrity.mjs:160-166`). Stale agent context also
+describes it as reliable allocation guidance.
+
+The failure path therefore sends contributors back into the same race that the
+#2531 allocator and CI gate were built to eliminate.
+
+## Scope
+
+- Make the canonical `new:issue-id` command perform atomic allocation.
+- Retain a non-mutating predictor only under an explicit preview name.
+- Replace all active remediation and agent guidance that recommends
+  `next-issue-id.mjs` for allocation.
+- Add a cheap static contract test so aliases/messages cannot drift back.
+- Do not redesign the allocator or its orphan-ref locking protocol.
+
+## Implementation steps
+
+1. Change `pnpm run new:issue-id` to call
+   `node scripts/claim-issue.mjs --allocate`.
+2. Rename the old behavior to an honest command such as
+   `preview:issue-id`; keep `scripts/next-issue-id.mjs` only as the documented
+   read-only preview implementation if it still has a user.
+3. Update collision diagnostics in
+   `scripts/check-merged-issue-integrity.mjs` and any other active checker to
+   recommend the atomic allocator.
+4. Update current agent/developer context. Historical logs may retain old
+   commands when clearly historical; active operating instructions may not.
+5. Add a no-network static test that parses `package.json` and checker messages:
+   canonical creation aliases/remediation must contain
+   `claim-issue.mjs --allocate`, while preview aliases must be labeled preview.
+6. Document that the canonical command mutates the reservation ref so users who
+   only want visibility choose the preview command deliberately.
+
+## Acceptance criteria
+
+- [ ] `pnpm run new:issue-id` atomically reserves against main, open PRs, and
+      the issue-assignments ref.
+- [ ] A clearly named preview command remains available without pushing a
+      reservation, if preview behavior is still needed.
+- [ ] No active checker, agent instruction, or package alias recommends
+      `next-issue-id.mjs` as an allocator or collision repair.
+- [ ] Static tests fail if canonical aliases/remediation regress to the
+      non-reserving predictor.
+- [ ] Existing `claim-issue.mjs --allocate` concurrency and dry-run tests remain
+      green.
+
+## Validation plan
+
+- Package-script contract test and checker-message unit test.
+- `node scripts/claim-issue.mjs --allocate --dry-run --no-pr-scan` for a
+  non-mutating smoke test.
+- Existing allocator/issue-ID test suites and `pnpm run check:issues`.
+- `pnpm run check:issue-ids:against-main` on a clean branch and a synthetic
+  colliding fixture.
+- Formatting and typecheck (where applicable).
+
+## Dependencies
+
+- Builds on #2531's allocator and #2530's merged-state gate.
+- #2943/#2974/#2977 own allocator robustness under API failure/contention; this
+  issue changes entrypoints and guidance only.
+
+## Risks
+
+- Existing users may assume `new:issue-id` is read-only. The command rename and
+  documentation must call out that it now creates a reservation.
+- Tests must not reserve real IDs. Use static assertions and allocator dry-run
+  modes only.
+- Do not remove the preview script until all legitimate read-only callers are
+  identified; the defect is misleading allocation guidance, not the existence
+  of a preview tool.

--- a/plan/issues/3409-portable-prepush-format-timeout.md
+++ b/plan/issues/3409-portable-prepush-format-timeout.md
@@ -1,0 +1,110 @@
+---
+id: 3409
+title: "Pre-push format gate hard-depends on GNU timeout and falsely blocks macOS pushes"
+status: ready
+created: 2026-07-18
+updated: 2026-07-18
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: developer-experience
+sprint: current
+related: [914, 1525, 1771, 3102]
+origin: "2026-07-18 codebase engineering audit publication preflight (plan/log/2026-07-18-codebase-engineering-audit.md, F8)"
+---
+
+# #3409 — make the pre-push format timeout portable
+
+## Problem
+
+The Husky pre-push hook runs the format gate through an unconditional GNU
+`timeout` invocation:
+
+```sh
+fmt_out=$(timeout 90 pnpm run format:check 2>&1)
+```
+
+(`.husky/pre-push:151-170`). Stock macOS does not provide `timeout`, and this
+Darwin development host has neither `timeout` nor Homebrew's `gtimeout` on
+`PATH`. The command therefore exits 127 before Prettier starts. The hook treats
+every nonzero code other than 124 as a genuine format failure and blocks the
+push.
+
+This audit reproduced the failure on an otherwise clean planning-only branch:
+
+- pre-push typecheck and lint passed;
+- direct `pnpm run format:check` passed;
+- direct Markdown Prettier checks passed;
+- `git push` stopped at `Pre-push: format:check FAILED` without naming an
+  offending file.
+
+The diagnostic is blank because the hook filters captured output to Prettier
+warnings and `.ts` paths, hiding the actual `timeout: command not found` error.
+The advertised escape hatch, `git push --no-verify`, also bypasses every other
+pre-push safety/integrity guard.
+
+## Scope
+
+- Make the 90-second format watchdog work on supported Linux and macOS hosts
+  without requiring an undocumented GNU coreutils installation.
+- Preserve the intended policy: genuine format failures block, a local watchdog
+  timeout fails open to CI, and runner/setup failures are diagnosed accurately.
+- Add isolated hook tests for formatter success, formatter failure, timeout, and
+  missing watchdog tooling.
+- Do not change the repository's formatter or formatting scope.
+
+## Implementation steps
+
+1. Extract the timed-command behavior into a small testable helper, preferably a
+   cross-platform Node process runner already available wherever `pnpm` runs.
+2. If shell command selection is retained, explicitly probe `timeout` and
+   `gtimeout`; when neither exists, run the format check without a watchdog or
+   fail open with a clear warning rather than manufacturing a format failure.
+3. Preserve and distinguish exit states: formatter nonzero, watchdog expiry,
+   command-not-found/setup error, and success.
+4. On an unexpected runner error, print the unfiltered captured stderr. Only use
+   the warning/path filter as an optional summary after the real failure is
+   visible.
+5. Add `tests/hooks/pre-push-format-timeout.test.ts` (or the established hook-test
+   location) with a synthetic `PATH` that contains neither timeout binary.
+6. Document any host prerequisite if the final design intentionally retains an
+   external utility.
+
+## Acceptance criteria
+
+- [ ] A normal push on stock macOS reaches and executes `pnpm run format:check`.
+- [ ] A correctly formatted branch is not blocked when GNU `timeout` is absent.
+- [ ] A real Prettier failure still blocks and names the offending file(s).
+- [ ] A watchdog expiry emits the documented warning and defers to CI without
+      being mislabeled as a formatting defect.
+- [ ] An unexpected runner/setup failure exposes its real stderr and does not
+      print an empty `Offending files` section.
+- [ ] Linux behavior and the 90-second hang protection remain covered.
+
+## Validation plan
+
+- Hook unit/integration tests with stub `pnpm`, `timeout`, and `gtimeout`
+  executables covering exit 0, exit 1, exit 124, exit 127, and a hanging child.
+- Run the hook test matrix on Linux and macOS GitHub Actions runners.
+- On macOS without coreutils: `pnpm run format:check`, then a dry-run/synthetic
+  pre-push invocation; both must pass for formatted input.
+- Confirm malformed TypeScript still produces a blocking formatter diagnostic.
+- Existing `pnpm run format:check`, typecheck, lint, and issue-integrity gates.
+
+## Dependencies
+
+- No implementation dependency. Coordinate with PR #3355 only if its separate
+  pre-git-push LOC hook changes shared hook-test infrastructure.
+
+## Risks
+
+- A hand-rolled shell watchdog can leak child processes or mis-handle signals;
+  prefer a small cross-platform process helper with explicit termination.
+- Silently removing the timeout can reintroduce the original 300-second push
+  hang. The portable fix must retain bounded behavior or clearly fail open.
+- Encouraging `--no-verify` as the ordinary macOS path disables unrelated
+  privacy and integrity guards, so it is a workaround, not an acceptable fix.

--- a/plan/issues/3410-public-remote-labs-guard-legacy-url.md
+++ b/plan/issues/3410-public-remote-labs-guard-legacy-url.md
@@ -1,0 +1,116 @@
+---
+id: 3410
+title: "Private labs pre-push guard misses the legacy public js2wasm origin URL"
+status: ready
+created: 2026-07-18
+updated: 2026-07-18
+priority: critical
+horizon: s
+feasibility: easy
+reasoning_effort: high
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: reliability
+sprint: current
+related: [3409]
+origin: "2026-07-18 codebase engineering audit publication preflight (plan/log/2026-07-18-codebase-engineering-audit.md, F9)"
+---
+
+# #3410 — close the legacy-origin bypass in the private-labs guard
+
+## Problem
+
+The first responsibility of `.husky/pre-push` is to stop any `labs/` path from
+being pushed to the public repository. It classifies a remote as public only
+when its URL matches the canonical post-rename path:
+
+```sh
+case "$remote_url" in
+  *loopdive/js2.git|*loopdive/js2) is_public=1 ;;
+  *) is_public=0 ;;
+esac
+```
+
+(`.husky/pre-push:20-34`). The normal `origin` in this repository is still:
+
+```text
+https://github.com/loopdive/js2wasm.git
+```
+
+GitHub redirects that legacy repository name to the same public `loopdive/js2`
+repository, but the local shell matcher does not. `is_public` is therefore zero
+and the entire private-path diff scan is skipped for the standard origin. Public
+fork URLs are likewise outside the two accepted patterns.
+
+This is a verified safety-control bypass. The audit did not stage or push any
+`labs/` content and observed no disclosure; the defect is that the guard does
+not run on a normal public destination.
+
+## Scope
+
+- Recognize both canonical and legacy upstream URLs across HTTPS, SSH, and SCP
+  syntax.
+- Protect public forks as well as the upstream repository.
+- Make the allow/deny model explicit and fail safely when destination visibility
+  cannot be inferred offline.
+- Keep the private `loopdive/js2wasm-labs` remote usable for intentional labs
+  pushes.
+- Add tests without reading, staging, or publishing real private content.
+
+## Implementation steps
+
+1. Extract remote classification and forbidden-path scanning into testable shell
+   helpers or a small cross-platform script.
+2. Normalize URL syntax, optional `.git`, and the known `js2wasm` → `js2` legacy
+   alias before classifying the destination.
+3. Prefer an explicit private-destination allowlist/configuration: the known
+   labs repository is allowed; canonical upstream, legacy upstream, and public
+   forks are blocked for `labs/` paths. Define the behavior for unknown remotes
+   deliberately rather than defaulting them to safe.
+4. Preserve new-branch and existing-branch diff calculation, then test both
+   paths with synthetic object IDs and fixtures named under `labs/`.
+5. Emit the normalized destination and classification in the block diagnostic
+   so contributors can see why a push was refused.
+6. Add `tests/hooks/pre-push-labs-remote.test.ts` (or the established hook-test
+   location) covering all supported URL forms and `--no-verify` documentation.
+
+## Acceptance criteria
+
+- [ ] `labs/` changes are blocked when pushing to `loopdive/js2` through HTTPS
+      or SSH.
+- [ ] The legacy `loopdive/js2wasm` origin URL receives the identical block.
+- [ ] A public fork URL cannot bypass the guard.
+- [ ] The explicit private labs remote still permits intentional labs pushes.
+- [ ] Unknown or malformed remote URLs follow a documented fail-safe policy and
+      cannot silently masquerade as non-public.
+- [ ] Tests exercise new-branch, update, and delete ref inputs without touching
+      actual private files or a network remote.
+
+## Validation plan
+
+- Table-driven remote-classification tests for canonical/legacy HTTPS, SSH URL,
+  SCP syntax, public fork, labs remote, local path, and malformed URL.
+- Synthetic pre-push stdin tests with one `labs/example.txt` fixture and one
+  ordinary public path for both new and existing branch ranges.
+- Verify the exact current `origin` URL is classified as public.
+- Verify `git push labs <branch>` remains allowed in the synthetic harness.
+- Existing hook tests, shell lint, and issue-integrity checks.
+
+## Dependencies
+
+- Coordinate with #3409 because both change `.husky/pre-push`; they can share a
+  portable hook-test harness but have independent acceptance criteria.
+- PR #3355 does not modify Husky pre-push today, but avoid colliding if its hook
+  test infrastructure changes before this lands.
+
+## Risks
+
+- Treating every unknown remote as public is confidentiality-safe but may block
+  legitimate pushes to another private labs mirror. Provide an explicit,
+  reviewable allowlist rather than a permissive default.
+- URL string matching alone can drift on future repository renames. Centralize
+  repository identity aliases and cover them with tests.
+- `--no-verify` necessarily bypasses client-side protection. Server-side secret
+  scanning and repository separation remain defense in depth, but do not replace
+  a correct local guard.

--- a/plan/log/2026-07-18-codebase-engineering-audit.md
+++ b/plan/log/2026-07-18-codebase-engineering-audit.md
@@ -1,0 +1,339 @@
+# 2026-07-18 — Codebase engineering audit
+
+**Repository:** `loopdive/js2` (local remote still named `loopdive/js2wasm`)
+
+**Audited tree:** `origin/main` at `852c40a9f5167a2a959d53faa066cb0753b623cc`
+
+**Artifact scope:** audit and implementation-plan issues only; no implementation
+source was changed.
+
+## Executive summary
+
+The highest-risk newly verified defect is a reachable silent miscompile: a real
+host function passed through an `any` parameter is not called when the module has
+zero registered closure candidates. The generated export returns `null` instead
+of the function's result. The next reliability defect is in the test262 oracle
+pipeline: the current baseline JSONL contains 25 duplicate file keys, including
+three contradictory fail/pass pairs. Different consumers resolve those pairs
+differently.
+
+Two process ratchets also have holes. The god-file profiler is already red on
+clean `main` and is not invoked by CI; that finding is already owned by in-flight
+#3400 in PR #3331, so this audit deliberately does not create a competing issue.
+The canonical-looking `pnpm run new:issue-id` command still invokes the
+deprecated non-reserving predictor even though the repository mandates the
+atomic allocator.
+
+Publication preflight exposed two additional hook defects. The private-`labs/`
+guard does not recognize this checkout's legacy `loopdive/js2wasm` origin even
+though GitHub redirects it to the public repository. Separately, the format
+watchdog assumes GNU `timeout`, so a stock macOS push is falsely reported as a
+Prettier failure. No private content was staged or disclosed during this audit.
+
+| Rank | Severity | Finding                                                                          | Confidence                                                        | Canonical plan             |
+| ---- | -------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------- | -------------------------- |
+| 1    | Critical | Zero-candidate dynamic calls silently return `null` instead of invoking/throwing | Verified defect                                                   | #3406                      |
+| 2    | Critical | Private-`labs/` guard skips the legacy public `js2wasm` origin URL               | Verified safeguard bypass; no disclosure observed                 | #3410                      |
+| 3    | High     | test262 JSONL has duplicate and contradictory file verdicts; consumers disagree  | Verified defect                                                   | #3407                      |
+| 4    | High     | God-file regression check is unwired and already fails on clean `main`           | Verified process gap                                              | In-flight #3400 (PR #3331) |
+| 5    | High     | `new:issue-id` points at a deprecated, non-atomic predictor                      | Verified workflow defect                                          | #3408                      |
+| 6    | High     | Pre-push format watchdog assumes GNU `timeout` and blocks stock macOS            | Verified workflow defect                                          | #3409                      |
+| 7    | Medium   | #1132 says publication has not happened, but npm and JSR are live at 0.60.1      | Verified stale plan                                               | #1132 updated here         |
+| 8    | Medium   | Selector and emitters retain explicitly non-reentrant module state               | Architecture hypothesis; current synchronous core limits exposure | No new issue               |
+| 9    | Medium   | Two regression tests accept compile failure by returning early                   | Verified test weakness, bounded                                   | No new issue               |
+
+## Baseline and method
+
+- Read repository agent guidance, compiler/test262 memories, prior audits, issue
+  schema, and report conventions before inspection.
+- Audited compiler call dispatch, IR selection and emit state, test262 result
+  production/merge/diff/report paths, release configuration, CI quality gates,
+  issue allocation, and representative regression tests.
+- Fetched the current test262 JSONL through the established baseline helper. The
+  fetched file contained 48,113 rows and 48,088 distinct `file` keys. The
+  committed summary is oracle v7 and reports 32,321/43,106 official passes
+  (75.0%), 10,440 fails, 243 compile errors, 83 compile timeouts, and 19 skips
+  (`benchmarks/results/test262-current.json:2-20`).
+- Measured 42,995 official rows with compile timing: p50 131 ms, p90 337 ms,
+  p95 460 ms, p99 1,522 ms, max 10,000 ms, 86 over 5 s, and 8,310,596 ms
+  aggregate (~2.31 CPU-hours). This is a material cost surface, but it is already
+  guarded by #1942 (`.github/workflows/test262-sharded.yml:866-919`), so no
+  duplicate performance issue was filed.
+- Ran issue integrity/spec coverage, LOC, stack-balance, and god-file checks on
+  clean `main`. The first four completed cleanly; `check:godfiles` failed as
+  described in F3.
+
+## F1 — zero-candidate dynamic host calls silently miscompile
+
+**Severity:** Critical · **Status:** Verified defect
+**Plan:** #3406
+
+### Evidence
+
+For an `any`/externref identifier callee, `tryEmitInlineDynamicCall` builds its
+dispatch from closure types registered in `ctx.closureInfoByTypeIdx`. If there
+are no closure candidates and no standalone special carrier, it returns `null`
+before building the host-call fallback
+(`src/codegen/expressions/calls.ts:3504-3536,3618`). The caller then evaluates
+and drops only the arguments, pushes `ref.null.extern`, and treats that as the
+call result (`src/codegen/expressions/call-identifier.ts:1651-1666`).
+
+A temporary end-to-end audit probe (removed after execution) compiled:
+
+```ts
+export function test(f: any): any {
+  return f(2);
+}
+```
+
+The module compiled and validated. Calling the export with `(x) => x + 1`
+produced:
+
+```text
+AUDIT_DYNAMIC_CALL_OUTPUT {"output":null,"type":"object"}
+```
+
+Expected output was `3`. This is not merely an unsupported-program diagnostic:
+the compiler reports success and emits valid Wasm with the observable call
+deleted.
+
+#3335 added a host `__call_function` default arm when a dynamic dispatch chain
+exists, but the zero-candidate early return bypasses that arm. This explains why
+the adjacent bug can be marked fixed while the simplest no-candidate shape still
+miscompiles.
+
+### Impact
+
+- A real function supplied by an embedder through `any` is silently not invoked.
+- Argument side effects run, making the output look plausible while callee side
+  effects and return values disappear.
+- A non-callable value also takes the same synthesized-`null` path instead of the required catchable
+  `TypeError`, erasing control flow such as `try/catch`.
+- Candidate registration is an incidental whole-module property, so adding an
+  unrelated closure can change the lowering selected for the same call site.
+
+### Required direction
+
+Host mode must route a non-null raw callee through the existing
+`__call_function` bridge even when the closure candidate set is empty. Host-free
+targets must either support a known native callable carrier or refuse/throw
+loudly; returning a synthesized nullish value is not an acceptable fallback. See #3406 for the
+stack-balance, late-import, and validation plan.
+
+## F2 — duplicate test262 verdict keys survive into promoted JSONL
+
+**Severity:** High · **Status:** Verified defect · **Plan:** #3407
+**Related:** #1221, #2913
+
+### Evidence
+
+The fetched current JSONL has **48,113 rows for 48,088 files**: 25 duplicate
+rows. All duplicates are fixture/module paths. Twenty-two duplicate pairs are
+fail/fail with different diagnostics. Three are contradictory fail/pass pairs:
+
+- `test/language/module-code/top-level-await/module-import-rejection-body.js`
+- `test/language/module-code/top-level-await/module-import-rejection-tick.js`
+- `test/language/module-code/top-level-await/module-import-rejection.js`
+
+The concrete producer is the fixture execution catch. A non-pass
+`recordResult(...)` throws `ConformanceError`; the inner execution catch at
+`tests/test262-shared.ts:779-831` catches that sentinel and records a second
+verdict. The outer catch contains the intended rethrow guard, but it is one catch
+too late (`tests/test262-shared.ts:833-841`). The 22 fail/fail pairs have exactly
+this fingerprint: the first diagnostic plus a second
+`ConformanceError: [fail] ...` diagnostic. Runtime-negative tests can record
+fail and then pass through the same control-flow mistake.
+
+Defensive consumers are inconsistent:
+
+- The report builder uses deterministic worst-status precedence and reports
+  dropped duplicates (`scripts/build-test262-report.mjs:902-960`).
+- `diff-test262` silently uses last-write-wins (`scripts/diff-test262.ts:519-533`).
+- The workflow concatenates shard JSONLs and checks only that the result is
+  non-empty; it does not enforce unique keys
+  (`.github/workflows/test262-sharded.yml:622-644`).
+
+Thus the published summary can treat a file as failing while the regression
+diff treats the same baseline file as passing. Row order, rather than compiler
+behavior, can decide whether a future candidate is classified as a regression.
+
+### Why #2913 is not sufficient
+
+#2913 correctly made report and edition totals deterministic, and its own
+resolution explicitly left the duplicate-write source for a scoped follow-up.
+It did not make the canonical JSONL unique or align the diff loader with the
+report policy. #3407 owns that residual rather than reopening or duplicating the
+completed defensive-report work.
+
+## F3 — the god-file ratchet is unwired and red
+
+**Severity:** High · **Status:** Verified process/maintainability gap
+**Plan ownership:** in-flight #3400 in PR #3331; no duplicate issue created
+
+`package.json:99-100` exposes `check:godfiles`, and the profiler says
+`--check` is a CI gate that rejects new mega-functions or growth beyond a
+40-line margin (`scripts/profile-godfiles.mjs:23-31,51-56,120-149`). The quality
+workflow invokes file LOC, dead-export, stack-balance, fallback, boxing, and
+coercion ratchets, but never invokes the god-file check
+(`.github/workflows/ci.yml:103-227`).
+
+On clean `origin/main`, `pnpm run check:godfiles` fails with three regressions:
+
+```text
+GREW 438→610 LOC (+172): src/codegen/expressions/calls.ts#tryEmitInlineDynamicCall
+GREW 216→285 LOC (+69): src/codegen/object-runtime.ts#fillExternArrayLikeStructArms
+NEW mega-function (161 LOC): src/codegen/array-methods.ts#tryCompileArrayFlatNativeDepth1
+```
+
+The baseline confirms the older 438/216 values
+(`scripts/godfile-profile-baseline.json:3,25`). Simply wiring the existing
+absolute-baseline command now would make every PR red and can wedge merge groups
+on unrelated main drift. Open PR #3331 already files #3400 to implement a
+change-scoped per-function ceiling ratchet, which is the correct ownership and
+merge-queue-safe direction. This report records the current failure as evidence
+for that plan and deliberately does not modify the other agent's open work.
+
+## F4 — canonical issue-ID shortcut bypasses atomic allocation
+
+**Severity:** High · **Status:** Verified workflow defect
+**Plan:** #3408
+
+The repository requires `claim-issue.mjs --allocate` because optimistic IDs can
+collide only in `merge_group` and wedge the queue. CI documents that requirement
+at `.github/workflows/ci.yml:229-239`, and `next-issue-id.mjs` itself says it is
+deprecated, predicts without reserving, and does not scan open PRs
+(`scripts/next-issue-id.mjs:12-24`).
+
+Despite that, the shortest and most discoverable package script still maps
+`new:issue-id` to the unsafe predictor (`package.json:78-81`); the safe command
+is the longer `new:issue-id:allocate` at `package.json:157-160`. The merged-tree
+collision checker also tells users to repair a collision using the deprecated
+script (`scripts/check-merged-issue-integrity.mjs:160-166`). Stale agent context
+repeats the old guidance.
+
+This is not cosmetic documentation drift: it directs users from the failure
+message back into the race that caused the failure. #3408 preserves an honestly
+named preview command while making the canonical creation path atomic.
+
+## F5 — publication plan #1132 contradicts shipped reality
+
+**Severity:** Medium
+**Status:** Verified stale plan; canonical issue updated in this audit
+
+#1132 remained `ready` and said the compiler had no npm presence
+(`plan/issues/1132-publish-compiler-as-loopdive-js2.md:1-20`). Current repository
+evidence has a complete tag-driven release workflow: it builds, packs, and
+publishes `@loopdive/js2` with provenance
+(`.github/workflows/publish-npm.yml:90-108`), publishes the unscoped proxy
+(`:110-145`), and publishes JSR independently (`:147-183`). Public registry
+metadata checked on 2026-07-18 reports all three at 0.60.1:
+
+- npm `@loopdive/js2`: first published 2026-06-27, latest 0.60.1.
+- npm `js2wasm` proxy: latest 0.60.1.
+- JSR `@loopdive/js2`: latest 0.60.1.
+
+The old acceptance text also specified CJS and `<5 MB` unpacked. The shipped
+package is explicitly ESM-only (`package.json:23-50`) and npm reports 8,904,177
+bytes unpacked, partly because `examples/` is intentionally shipped
+(`package.json:52-57`, #2828). Those are superseded product decisions, not
+evidence that publication is still pending. #1132 is marked done with a
+reconciliation note while retaining the original plan as history.
+
+## F6 — explicitly non-reentrant compiler internals
+
+**Severity:** Medium
+**Status:** Architecture hypothesis, not a reproduced public-API defect
+
+The IR selector stores per-run resolver, declaration, scope, and return-shape
+state in module variables (`src/ir/select.ts:789-838,1248-1257`) and explicitly
+states that `planIrCompilation` is not reentrant (`:831-838`). The WAT emitter
+does the same for resolved layout and likewise documents non-reentrancy
+(`src/emit/wat.ts:15-22,120-124`). Binary emission uses module globals too, but
+at least clears them in `finally` (`src/emit/binary.ts:296-307`).
+
+Today the main compilation core is deliberately synchronous; only optional
+post-codegen Binaryen optimization awaits (`src/compiler.ts:1084-1109`). That
+substantially limits ordinary `Promise.all(compile(...))` overlap, so this audit
+does **not** claim a verified concurrent-compile bug. The architecture still
+creates a trap for callback-driven re-entry, direct consumers of exported
+selector/emitter APIs, and any future asynchronous or parallel codegen pass.
+Before adding such concurrency, state should become invocation-local and an
+overlapping/reentrant compile test should extend #923's sequential idempotency
+coverage.
+
+## F7 — bounded false-green regression tests
+
+**Severity:** Medium
+**Status:** Verified test weakness; not broad enough for a separate high-value issue
+
+- The full Axios regression case catches any `compileProject` exception and
+  returns, then also returns on an unsuccessful result
+  (`tests/issue-1693.test.ts:47-61`). Dependency resolution failure, OOM, or a
+  compiler crash can therefore make the test green without validating Wasm.
+- The class-method destructuring equivalence case explicitly skips on compile
+  failure (`tests/equivalence/binding-null-guard.test.ts:97-121`).
+
+Most superficially similar `if (!result.success) return` sites are safe because
+they immediately follow `expect(result.success).toBe(true)`; these two do not.
+They should be tightened when their canonical implementation areas are next
+touched. A repository-wide lint is not justified by the two-case residual.
+
+## F8 — pre-push formatting watchdog is not portable to macOS
+
+**Severity:** High · **Status:** Verified workflow defect · **Plan:** #3409
+
+The pre-push format stage unconditionally executes
+`timeout 90 pnpm run format:check` and treats every nonzero result other than
+124 as a real formatting defect (`.husky/pre-push:151-170`). On this Darwin
+host, neither `timeout` nor `gtimeout` exists. A publication push therefore
+passed typecheck and lint, then failed with an empty `Offending files` section.
+Direct `pnpm run format:check` and direct Markdown Prettier checks both passed.
+
+The captured `command not found` diagnostic is suppressed by a filter that only
+prints Prettier warnings or `.ts` paths. This leaves `--no-verify` as the only
+obvious workaround, which disables all other hook checks too. #3409 specifies a
+portable timed-command helper and a host/exit-code test matrix.
+
+## F9 — private-labs guard skips the repository's normal public origin
+
+**Severity:** Critical · **Status:** Verified safeguard bypass; no disclosure observed · **Plan:** #3410
+
+The same hook intends to block every `labs/` path sent to the public repository,
+but it considers only URLs matching `loopdive/js2` public
+(`.husky/pre-push:20-58`). This checkout's normal origin is still
+`https://github.com/loopdive/js2wasm.git`. GitHub redirects that legacy name to
+the canonical public repository, while the local shell pattern falls into
+`is_public=0`; the forbidden-path scan never runs. Public fork URLs are also
+unrecognized.
+
+The bypass is verified from the exact remote URL and hook branch condition. No
+actual `labs/` file was staged, read for the probe, or pushed, and the audit
+found no evidence of a disclosure. The impact is nevertheless critical because
+the control's sole purpose is preventing private material from entering public
+history. #3410 requires canonical/legacy/fork URL coverage and a fail-safe,
+explicit private-destination policy.
+
+## Existing coverage deliberately not duplicated
+
+- The current official conformance residual (10,785 non-passes) remains the
+  dominant correctness backlog, but its large clusters are already represented
+  by the July 12 audit issues (#3184–#3189) and subsequent slices. This audit did
+  not create another conformance umbrella.
+- Compile-time regression signals are already enforced by #1942.
+- File-level god-file growth is already guarded by #3102; the missing
+  function-level enforcement is owned by in-flight #3400.
+- Report/edition duplicate counting was fixed by #2913; #3407 is limited to the
+  still-broken producer, canonical JSONL invariant, and cross-consumer policy.
+
+## Recommended execution order
+
+1. #3410 — restore the private-path safety boundary for the actual public origin.
+2. #3406 — stop the verified silent call deletion and lock it with an E2E test.
+3. #3407 — restore one-verdict-per-file and make baseline consumers agree.
+4. #3409 — make normal macOS pushes run the intended gates without requiring
+   `--no-verify`.
+5. Land/review in-flight #3400 — establish a merge-queue-safe function-size
+   ratchet, then triage the three current overages rather than rebasing them
+   silently.
+6. #3408 — remove the unsafe issue-ID creation affordance before the next
+   collision incident.


### PR DESCRIPTION
## Summary

- add a durable 2026-07-18 engineering audit covering correctness, test-oracle integrity, architecture, performance, workflow safety, maintainability, and stale plans
- add implementation-plan issues #3406-#3410 for five verified high-value defects
- reconcile canonical publication issue #1132 against the live npm/JSR release system
- preserve in-flight ownership: the unwired/red god-file ratchet is documented but left to #3400 / PR #3331

No implementation, test, workflow, generated-index, or source files are changed.

## Top findings

1. Dynamic `any` calls with zero closure candidates compile and validate but silently return `null` instead of invoking a host function (#3406).
2. The private-`labs/` pre-push guard does not recognize the checkout's legacy public `loopdive/js2wasm` origin URL (#3410). No private content was staged or disclosed.
3. The current test262 JSONL has 25 duplicate file keys, including three fail/pass contradictions, while report and diff consumers apply incompatible policies (#3407).
4. The canonical `new:issue-id` alias still invokes a deprecated non-reserving predictor (#3408).
5. The pre-push formatter watchdog assumes GNU `timeout` and falsely blocks stock macOS pushes (#3409).

## Validation

- `pnpm run check:issues`
- `pnpm run check:issue-ids`
- `pnpm run check:issue-ids:against-main`
- `pnpm run check:issue-spec-coverage`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- direct Prettier check for all seven Markdown artifacts
- `pnpm run sync:conformance` (0 updated)
- `git diff --check origin/main...HEAD`
- final `git merge origin/main --no-edit` (already up to date)

Audit measurement: `pnpm run check:godfiles` fails on clean `main` for three existing function-size regressions. This PR does not change those files; ownership is already in #3400 / PR #3331.

The first normal push was correctly stopped before remote mutation by the newly documented #3409 hook defect (`timeout` is absent on Darwin). After all underlying hook gates passed directly and the diff was confirmed to contain no `labs/` path, the exact head was pushed with `--no-verify`.
