### PR TITLE
fix(#3411): CACHE-SUSPECT guard for the standalone-lane host-import collapse

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -655,6 +655,20 @@ jobs:
             --baseline-generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}
 
+      # #3411 — CACHE-SUSPECT guard (runs BEFORE the floor / catastrophic
+      # guards). Stale-base merge_group runs have collapsed the standalone lane
+      # to a byte-identical ~4,508 pass / ~43,469 host-import compile_error —
+      # infrastructure poisoning, NOT a regression. Detecting the >90%
+      # host-import cluster here and failing as CACHE-SUSPECT (exit 3) gives the
+      # shepherd a re-run signal instead of the misleading −38k standalone
+      # "regression" the floor/#1668 guards would otherwise report (which
+      # auto-park then holds as a real regression, parking an innocent PR).
+      - name: Standalone cache-poison guard (#3411)
+        if: env.SHARDS_RAN == 'true'
+        run: |
+          node scripts/check-standalone-cache-poison.mjs \
+            --jsonl merged-reports/test262-standalone-results-merged.jsonl
+
       # #2097 — ABSOLUTE standalone pass-count floor (high-water-mark backstop).
       # The #1897 standalone gate is a MOVING floor (re-seeded from the new
       # baseline every push to main), so a run of small net-negative PRs each

--- a/plan/issues/3411-standalone-lane-cache-poisoning-stale-base-merge-group.md
+++ b/plan/issues/3411-standalone-lane-cache-poisoning-stale-base-merge-group.md
@@ -1,0 +1,117 @@
+---
+id: 3411
+title: "Standalone lane cache poisoning in stale-base merge_groups — 4508/43469 host-import collapse parks innocent PRs"
+status: in-progress
+assignee: ttraenkler/opus-dev-a
+sprint: current
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: ci
+language_feature: infrastructure
+horizon: m
+goal: ci-reliability
+related: [2961, 2097, 1668, 2547, 3380, 1521]
+origin: "2026-07-18 — fable-1 park diagnosis on PR #3327; byte-identical collapse also on #3322"
+---
+
+# #3411 — standalone lane cache poisoning in stale-base merge_groups
+
+## Problem
+
+`merge_group` runs built on a **stale base** collapse the STANDALONE test262
+lane to a byte-identical **4,508 pass / 43,469 compile_error**, where EVERY
+compile_error reads:
+
+```
+standalone target emitted host imports: env::console_log_externref, env::structuredClone (#2961)
+```
+
+i.e. HOST-lane wrapper import signatures recorded under the standalone lane.
+
+This is **infrastructure poisoning, not a code regression** — the classic
+identical-cluster-across-unrelated-PRs drift signature:
+
+- **PR #3327** (S1 array-descriptor overlay) merge_group run `29631783983`:
+  4,508 / 43,469.
+- **PR #3322** (async-gen for-await destructuring, entirely unrelated)
+  merge_group run `29632727762`: **byte-identical** 4,508 / 43,469, same message.
+- **PR #3325**, fresh-based, PASSED the same hour on the same main tip.
+- Local standalone probes on current main compile with **zero** host imports;
+  the full issue suites pass. Those import names are not emitted by the
+  standalone lowering for these tests.
+
+The collapse correlates with STALE-BASE merge groups (a base that fell behind
+as other PRs merged after enqueue); fresh-based groups pass.
+
+## Impact — parks innocent PRs
+
+The −38,000 standalone pass drop trips both the #2097 high-water floor and the
+#1668 catastrophic-regression guard as if it were a genuine regression, so
+`auto-park` (#2547) HOLD-labels the (innocent) PR. It then strands until a human
+diagnoses the poison by hand. Two innocent PRs (#3327, #3322) were parked this
+way on 2026-07-18.
+
+## Root-cause hypothesis (under investigation)
+
+The verdict is produced at compile+verify time by `standaloneHostImportError`
+(`tests/test262-runner.ts`) / `tests/test262-shared.ts:683`, which flags a
+would-be-pass whose `compileRecordMetadata.imports` contains `env::*` host
+imports. In the failing runs the standalone binaries genuinely carry host
+imports — a HOST-lane compile record surfaced in the standalone lane.
+
+Candidate mechanisms (not yet pinned; the guard below mitigates regardless):
+
+1. **Stale-base bundle artifact** — a `merge_group` built on a stale base
+   compiles `scripts/compiler-bundle.mjs` from a tree that predates a
+   standalone-import fix, or reuses a bundle whose `TEST262_BUNDLE_HASH`
+   (#1521) collided across a host-configured build. The disk result cache is
+   already lane-keyed (`tests/test262-shared.ts:158` includes
+   `TEST262_TARGET`) and DISABLED in the sharded runner, so it is not the
+   direct source.
+2. **Scoped-restore lane mixing** — the #1521 path-scoped skip restores prior
+   compile records for unaffected tests during report merge; if a restore ever
+   drew host-lane records into the standalone merge set the same signature
+   would appear. (The full `merge_group` runs unfiltered, so this is secondary.)
+
+Follow-up for the infra owner: bisect a stale-base `merge_group` to confirm
+which of (1)/(2) produces the host imports, then make the lane part of the
+implicated cache/restore identity (or have stale-base groups bypass the
+restore). This issue's PR ships the guard; the pinpoint fix can land
+separately.
+
+## Fix shipped in this PR — the CACHE-SUSPECT guard
+
+`scripts/check-standalone-cache-poison.mjs` scans the merged standalone results
+JSONL. When >90% of non-skip records are the #2961 host-import verdict (over a
+corpus of ≥1000), it is the poison signature — no healthy standalone run has
+~90% of its corpus as host-import failures — and it exits **3** with a loud
+`CACHE-SUSPECT` diagnosis. Wired into `test262-sharded.yml` as a step that runs
+**BEFORE** the #2097 floor and #1668 catastrophic guard, so a poisoned run
+fails as clearly-labeled INFRASTRUCTURE (re-run the merge_group) instead of the
+misleading −38k standalone "regression" that auto-park holds as real.
+
+The guard is deliberately narrow:
+
+- Only the exact #2961 host-import verdict counts (a genuine mass CE from any
+  OTHER cause passes the guard, so real regressions still reach the real gates
+  — covered by a test).
+- A corpus below `--min-records` (default 1000) passes (too small to judge).
+- A missing JSONL passes (the upstream merge step owns file presence).
+
+## Acceptance criteria
+
+- A standalone lane with >90% host-import CEs over a ≥1000 corpus fails the
+  merge_group as CACHE-SUSPECT (exit 3) with a re-run instruction, ahead of the
+  floor/#1668 guards. ✓ (`tests/issue-3411-cache-poison-guard.test.ts`)
+- A healthy run, a below-min corpus, a missing file, and an unrelated mass-CE
+  run all PASS the guard (no false CACHE-SUSPECT, real regressions not
+  swallowed). ✓
+- Root-cause of the host-import-in-standalone bundle/restore path identified
+  and fixed (follow-up; the guard prevents the parking damage meanwhile).
+
+## Source
+
+fable-1 park diagnosis on PR #3327 (2026-07-18 ~08:30); byte-identical
+collapse on PR #3322. Guard authored by opus-dev-a.

--- a/scripts/check-standalone-cache-poison.mjs
+++ b/scripts/check-standalone-cache-poison.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3411 — CACHE-SUSPECT guard for the standalone test262 lane.
+//
+// WHY THIS EXISTS (the false-regression it prevents):
+//   Stale-base merge_group runs have been observed to collapse the STANDALONE
+//   lane to a byte-identical ~4,508 pass / ~43,469 compile_error, where EVERY
+//   compile_error reads `standalone target emitted host imports:
+//   env::console_log_externref, env::structuredClone (#2961)` — HOST-lane
+//   import signatures recorded under the standalone lane. The collapse is
+//   infrastructure poisoning (a stale-base compile-record / lane artifact —
+//   see #3411), NOT a code regression: the same byte-identical cluster appears
+//   on UNRELATED PRs, fresh-based runs on the same main tip pass, and local
+//   standalone compiles emit zero host imports.
+//
+//   Without this guard the collapse trips the #2097 high-water floor and the
+//   #1668 catastrophic-regression guard as a genuine −38,000 standalone
+//   regression, which auto-park (#2547) then treats as a real merged-baseline
+//   regression and HOLD-labels the (innocent) PR. That strands the PR until a
+//   human diagnoses the poison by hand — exactly the parking of two innocent
+//   PRs on 2026-07-18.
+//
+// WHAT IT DOES:
+//   Scans the merged standalone results JSONL. If the fraction of non-skip
+//   records whose verdict is the #2961 host-import error exceeds THRESHOLD
+//   (default 0.90) over a corpus of at least MIN_RECORDS (default 1000), it is
+//   the poison signature — no healthy standalone run has ~90% of its corpus as
+//   host-import failures. Exit 3 with a loud CACHE-SUSPECT diagnosis so the
+//   merge_group fails as INFRASTRUCTURE (re-run the group), distinctly from a
+//   real regression. A healthy run (host-import fraction below THRESHOLD) exits
+//   0 and the normal floor / regression gates proceed.
+//
+// Usage:
+//   node scripts/check-standalone-cache-poison.mjs --jsonl <merged.jsonl>
+//     [--threshold 0.90] [--min-records 1000]
+//
+// Exit codes:
+//   0 — not the poison signature (clean, or too small a corpus to judge).
+//   3 — CACHE-SUSPECT: the host-import cluster exceeds THRESHOLD. Infra, re-run.
+//   2 — usage / IO error.
+
+import { readFileSync, existsSync } from "node:fs";
+
+// The stable substring of the #2961 verdict emitted by
+// `standaloneHostImportError` (tests/test262-runner.ts). Matching the message
+// (not a status literal) is robust to whether the verdict is scored
+// `compile_error` or another host-import-tagged status.
+const HOST_IMPORT_MARKER = "standalone target emitted host imports:";
+const ISSUE_TAG = "#2961";
+
+function parseArgs(argv) {
+  const args = { jsonl: undefined, threshold: 0.9, minRecords: 1000 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--jsonl") args.jsonl = argv[++i];
+    else if (a === "--threshold") args.threshold = Number(argv[++i]);
+    else if (a === "--min-records") args.minRecords = Number(argv[++i]);
+  }
+  return args;
+}
+
+function main() {
+  const { jsonl, threshold, minRecords } = parseArgs(process.argv.slice(2));
+  if (!jsonl) {
+    process.stderr.write(
+      "usage: check-standalone-cache-poison.mjs --jsonl <merged.jsonl> [--threshold 0.9] [--min-records 1000]\n",
+    );
+    process.exit(2);
+  }
+  if (!existsSync(jsonl)) {
+    // A missing JSONL is not this guard's failure to raise — the upstream merge
+    // step (which requires the file to be non-empty) owns that. Pass through.
+    process.stderr.write(
+      `check-standalone-cache-poison: no JSONL at ${jsonl}; skipping (upstream merge owns file presence).\n`,
+    );
+    process.exit(0);
+  }
+
+  let total = 0; // non-skip records
+  let hostImport = 0; // non-skip records with the #2961 host-import verdict
+  const text = readFileSync(jsonl, "utf-8");
+  for (const line of text.split("\n")) {
+    const s = line.trim();
+    if (!s) continue;
+    let rec;
+    try {
+      rec = JSON.parse(s);
+    } catch {
+      continue; // tolerate a stray non-JSON line
+    }
+    if (rec.status === "skip") continue;
+    total++;
+    const err = typeof rec.error === "string" ? rec.error : "";
+    if (err.includes(HOST_IMPORT_MARKER) && err.includes(ISSUE_TAG)) hostImport++;
+  }
+
+  const fraction = total > 0 ? hostImport / total : 0;
+  const pct = (fraction * 100).toFixed(1);
+  process.stdout.write(
+    `check-standalone-cache-poison: ${hostImport}/${total} non-skip records are #2961 host-import verdicts (${pct}%); ` +
+      `threshold ${(threshold * 100).toFixed(0)}%, min-records ${minRecords}.\n`,
+  );
+
+  if (total < minRecords) {
+    process.stdout.write(`  corpus below min-records (${total} < ${minRecords}) — too small to judge; PASS.\n`);
+    process.exit(0);
+  }
+
+  if (fraction > threshold) {
+    process.stderr.write(
+      "\n" +
+        "╔══════════════════════════════════════════════════════════════════╗\n" +
+        "║  CACHE-SUSPECT: standalone lane host-import collapse (#3411)        ║\n" +
+        "╚══════════════════════════════════════════════════════════════════╝\n" +
+        `  ${hostImport}/${total} (${pct}%) of non-skip standalone records are the\n` +
+        `  #2961 "standalone target emitted host imports" verdict — the stale-base\n` +
+        "  merge_group poisoning signature, NOT a code regression.\n\n" +
+        "  This is INFRASTRUCTURE: unrelated PRs show the byte-identical cluster,\n" +
+        "  fresh-based runs on the same main tip pass, and local standalone\n" +
+        "  compiles emit zero host imports. Do NOT treat the standalone floor /\n" +
+        "  catastrophic-regression breach below as a real regression or a park.\n\n" +
+        "  ACTION: re-run this merge_group on a fresh base (dequeue + re-enqueue\n" +
+        "  the single PR). If it recurs on a fresh base, escalate to the tech\n" +
+        "  lead — see plan/issues/3411-*.md for the root-cause investigation.\n",
+    );
+    process.exit(3);
+  }
+
+  process.stdout.write("  below threshold — not the poison signature; PASS.\n");
+  process.exit(0);
+}
+
+main();

--- a/tests/issue-3411-cache-poison-guard.test.ts
+++ b/tests/issue-3411-cache-poison-guard.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3411 — the standalone CACHE-SUSPECT guard. A stale-base merge_group
+// collapse (>90% of non-skip standalone records are the #2961 host-import
+// verdict) must fail as CACHE-SUSPECT (exit 3), distinctly from a real
+// standalone regression; a healthy run passes (exit 0).
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SCRIPT = join(import.meta.dirname ?? ".", "..", "scripts", "check-standalone-cache-poison.mjs");
+const HOST_IMPORT_ERR =
+  "standalone target emitted host imports: env::console_log_externref, env::structuredClone (#2961)";
+
+let dir: string;
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "cache-poison-"));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeJsonl(name: string, records: object[]): string {
+  const p = join(dir, name);
+  writeFileSync(p, records.map((r) => JSON.stringify(r)).join("\n"));
+  return p;
+}
+
+// Run the guard, returning its exit code (execFileSync throws on non-zero).
+function runGuard(jsonl: string): number {
+  try {
+    execFileSync("node", [SCRIPT, "--jsonl", jsonl], { stdio: "pipe" });
+    return 0;
+  } catch (e) {
+    return (e as { status?: number }).status ?? -1;
+  }
+}
+
+describe("#3411 standalone cache-poison guard", () => {
+  it("fails as CACHE-SUSPECT (exit 3) on the >90% host-import collapse", () => {
+    const records: object[] = [];
+    for (let i = 0; i < 1100; i++) records.push({ path: `t${i}`, status: "compile_error", error: HOST_IMPORT_ERR });
+    for (let i = 0; i < 100; i++) records.push({ path: `p${i}`, status: "pass" });
+    for (let i = 0; i < 50; i++) records.push({ path: `s${i}`, status: "skip", error: "unsupported" });
+    expect(runGuard(writeJsonl("poison.jsonl", records))).toBe(3);
+  });
+
+  it("passes (exit 0) on a healthy lane with a minority of host-import verdicts", () => {
+    const records: object[] = [];
+    for (let i = 0; i < 200; i++) records.push({ path: `t${i}`, status: "compile_error", error: HOST_IMPORT_ERR });
+    for (let i = 0; i < 900; i++) records.push({ path: `p${i}`, status: "pass" });
+    for (let i = 0; i < 100; i++) records.push({ path: `f${i}`, status: "fail", error: "assertion" });
+    expect(runGuard(writeJsonl("healthy.jsonl", records))).toBe(0);
+  });
+
+  it("passes (exit 0) on a corpus below min-records even at 100% host-import", () => {
+    const records: object[] = [];
+    for (let i = 0; i < 50; i++) records.push({ path: `t${i}`, status: "compile_error", error: HOST_IMPORT_ERR });
+    expect(runGuard(writeJsonl("small.jsonl", records))).toBe(0);
+  });
+
+  it("does not fire on unrelated compile_error clusters (a real regression is not CACHE-SUSPECT)", () => {
+    // A genuine mass CE from a different cause must NOT be swallowed as infra —
+    // it should pass this guard so the real regression gates evaluate it.
+    const records: object[] = [];
+    for (let i = 0; i < 1100; i++)
+      records.push({ path: `t${i}`, status: "compile_error", error: "Codegen error: something unrelated broke" });
+    for (let i = 0; i < 100; i++) records.push({ path: `p${i}`, status: "pass" });
+    expect(runGuard(writeJsonl("real-regression.jsonl", records))).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Stale-base `merge_group` runs collapse the **standalone** test262 lane to a byte-identical **~4,508 pass / ~43,469 compile_error**, every CE reading `standalone target emitted host imports: env::console_log_externref, env::structuredClone (#2961)` — HOST-lane import signatures recorded under the standalone lane.

This is **infrastructure poisoning, not a regression** (fable-1 diagnosis on #3327): unrelated PRs #3327/#3322 showed the *byte-identical* cluster, fresh-based #3325 passed the same hour on the same main tip, and local standalone compiles emit zero host imports. Without a guard the −38k drop trips the #2097 floor + #1668 catastrophic guard as a real regression, so `auto-park` (#2547) HOLD-labels the **innocent** PR — parking two of them on 2026-07-18.

## What this ships

`scripts/check-standalone-cache-poison.mjs` scans the merged standalone results JSONL; when **>90%** of non-skip records (over a ≥1000 corpus) are the #2961 host-import verdict, it exits **3** with a loud `CACHE-SUSPECT` diagnosis. Wired into `test262-sharded.yml` **before** the floor / catastrophic guards, so a poisoned run fails as clearly-labeled INFRASTRUCTURE (re-run the group) instead of the misleading standalone "regression".

Narrow by design (tested): only the exact #2961 verdict counts (an unrelated mass-CE passes → real regressions still reach the real gates); a sub-1000 corpus passes; a missing JSONL passes.

## Validation

`tests/issue-3411-cache-poison-guard.test.ts` — 4/4 pass: poison→exit 3, healthy→0, below-min-corpus→0, unrelated-mass-CE→0 (real regression NOT swallowed).

## Scope note

This guard **stops the parking damage** regardless of exact root cause. The pinpoint fix (identify whether the host-imports-in-standalone come from a stale-base bundle artifact or a scoped-restore lane mix, then put the lane in that cache/restore identity) is documented in `plan/issues/3411-*.md` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)