### PR TITLE
feat(#2963 Tier 2b): wire Object.is (SameValue) first-class value (standalone)

### DIFF
--- a/plan/issues/2963-builtin-first-class-reification.md
+++ b/plan/issues/2963-builtin-first-class-reification.md
@@ -389,3 +389,72 @@ i32` closure. The direct standalone `Object.is` only backs compile-time
 - Remaining Phase 2 tiers: 2c (table-driven `Math.*`), 2d
   (`Number.parseFloat/parseInt`), 2e (`Date.now`), 2f (`Array.of`), 2g
   (`Array.from` subset). `Promise.*` stays throwing (out of scope).
+
+### Resumer guide — Tiers 2c–2g (start here after 2a #3359 + 2b #3361 land)
+
+**Sequencing.** 2a (#3359) and 2b (#3361) were stacked and PAUSED. Do the
+remaining tiers **off clean `main`** once BOTH have landed — do NOT stack
+further (the stack was capped at 2a+2b for queue hygiene). Each tier is an
+independent S–M PR off `origin/main`. Do them in order, one PR each (or
+regroup per the "Sizing / routing" note above), re-merging `origin/main`
+between them since they touch the same hot files.
+
+**Shared-file conflict surface (why tiers can't run in parallel off main).**
+Every tier edits the SAME three spots, so two open tier-PRs conflict:
+
+1. `src/codegen/builtin-value-read.ts` — add a `case "<Builtin>.<method>":`
+   (type setup + `addUnionImports` / `ensure*` pre-registration) **before
+   `default:`**, and an `else if (key === "<Builtin>.<method>" &&
+!genericThrowBody)` **body block before the `genericThrowBody` arm**. The
+   `&& !genericThrowBody` guard is REQUIRED (else the degrade path double-fires).
+2. `src/codegen/builtin-fn-meta.ts` — add a `STANDALONE_STATIC_METHOD_META`
+   row (byte-equal to the `BUILTIN_STATIC_METHOD_ARITY` fallback; keep in sync
+   per the file header).
+3. `src/codegen/expressions/call-builtin-static.ts` — if the tier factors a
+   shared ops leaf (like `number-is-predicate-ops.ts` / `same-value-number-ops.ts`),
+   refactor the DIRECT call arm to consume it too (byte-inert — same Instr seq).
+
+**The invariant pattern (copy Tier 2a/2b):** params ALL-externref (or the one
+`$vec_externref` variadic param for Tier 2f — see the Math.max arm), coercion
+INSIDE the body, reuse the EXACT native the direct standalone call uses, and on
+any missing native degrade to `genericThrowBody` — NEVER `return null` (null
+re-opens the #1907 CE). Pre-register imports BEFORE `mintDefinedFunc` (#2704).
+Reused coercion primitives (`__unbox_number` etc.) ride this issue's
+`coercion-sites-allow:` frontmatter (file-level for `builtin-value-read.ts`);
+keep that key so the `quality` coercion-sites gate stays green.
+
+**Per-tier native to reuse (verify host-free standalone first):**
+
+- 2c `Math.<unary/binary>`: args → `__any_to_f64` (ToNumber; non-number→NaN,
+  §21.3) → the self-hosted `src/stdlib/math.ts` native the direct-call dispatch
+  table uses → `__box_number`. One table-driven arm keyed on the Math dispatch
+  table, not N cases.
+- 2d `Number.parseFloat/parseInt`: the global `parseFloat`/`parseInt` funcMap
+  entries (parseInt keeps the NaN radix sentinel) — but CONFIRM they're defined
+  funcs standalone, not host imports (the direct arm at call-builtin-static.ts
+  `~L411` reads `ctx.funcMap.get("parseFloat"|"parseInt")`).
+- 2e `Date.now`: 0-arg; VERIFY the standalone time source — if host-only, leave
+  the throw body and record why.
+- 2f `Array.of`: variadic `$vec_externref` convention (Math.max precedent,
+  `ctx.variadicBuiltinClosure`); elements already externref, no per-elem coerce.
+- 2g `Array.from`: ONLY the array-like/vec fast shape the direct call supports
+  standalone; other inputs keep the throw (document per-shape).
+
+**Validation harness (every tier):**
+
+- Standalone probe: `WebAssembly.instantiate(binary, {})` (no imports). Return
+  type `: number` — NOT `: i32` (a bare `i32` export hands JS a BOXED ref, not a
+  number, which looks like a bug). Avoid array methods (`filter`/`map`) in probes
+  — they pull an `env` import the empty-imports harness lacks; use scalar loops.
+- Byte-inertness (host/gc lanes MUST NOT change): from CLEAN `main` run
+  `npx tsx scripts/prove-emit-identity.mjs write --baseline /tmp/golden.json`,
+  then on the branch `npx tsx scripts/prove-emit-identity.mjs check --baseline
+/tmp/golden.json` → must print `IDENTICAL — all 56 (file,target) emits match`.
+- `.name`/`.length` reflective reads: do NOT assert `.name` in a MULTI-value
+  module (two same-signature statics co-extracted mis-dispatch — that's the
+  PRE-EXISTING #3424 bug, reproduced on main). Assert `.name` per single-value
+  module only; `.length` returns 0 for every reified static today (also #3424).
+- Test file per tier: `tests/issue-2963-<method>-value.test.ts`, mirroring
+  `issue-2963-number-is-value.test.ts` / `issue-2963-object-is-value.test.ts`
+  (a `runStandalone` helper + per-case + observational-identity-vs-direct rows).
+- Full `merge_group` (broad-impact: touches the reflective/value substrate).

--- a/plan/issues/2963-builtin-first-class-reification.md
+++ b/plan/issues/2963-builtin-first-class-reification.md
@@ -18,6 +18,16 @@ language_feature: builtins
 goal: standalone-mode
 related: [1472, 2036, 2860, 2964]
 origin: "2026-07-02 July Fable audit §3 cluster 5 (biggest standalone CE family; #1472 Phase-C refusal successor)"
+# (#2963 Tier 2a) The reified Number.is* closure body REUSES the settled
+# `__unbox_number` native — the SAME unbox the direct `Number.is*(n)` call path
+# uses via `compileNumberIsPredicate` — to recover the f64 from the boxed arg
+# after the `__typeof_number` type guard. It is NOT a fresh hand-rolled
+# ToNumber/ToString/ToPrimitive matrix (the coercion engine is deliberately
+# bypassed here because §21.1.2.x requires NO coercion — a non-Number arg is
+# `false`), so the +2 __unbox_number growth in builtin-value-read.ts is a
+# reviewed, intentional reuse of an existing coercion primitive.
+coercion-sites-allow:
+  - src/codegen/builtin-value-read.ts
 ---
 
 # #2963 — reading a builtin as a value is a compile error standalone

--- a/plan/issues/2963-builtin-first-class-reification.md
+++ b/plan/issues/2963-builtin-first-class-reification.md
@@ -2,12 +2,12 @@
 id: 2963
 title: "Reify builtins as first-class values: retire the `__get_builtin` dynamic-shape CE cluster (~400 compile errors)"
 status: in-progress
-assignee: ttraenkler/fable-identity
+assignee: ttraenkler/opus-dev-b
 sprint: current
 model: fable
 fable_role: spec
 created: 2026-07-02
-updated: 2026-07-09
+updated: 2026-07-18
 priority: high
 horizon: l
 feasibility: hard
@@ -337,3 +337,31 @@ per-method ToNumber edge cases — cite §21.3 per method in tests). Tier
 2f/2g: S–M. 2e: S after the standalone time-source check. Independent of
 #2916/#2651 (different substrate); no coordination needed beyond ordinary
 merge hygiene.
+
+### Phase 2 progress log
+
+- **Tier 2a — `Number.is{Integer,Finite,NaN,SafeInteger}` — DONE** (opus-dev-b,
+  2026-07-18). Wired real bodies in `ensureStandaloneBuiltinStaticMethodClosure`
+  (`builtin-value-read.ts`): fixed 1-arg `[externref] -> i32` closure, body =
+  `__typeof_number` guard (no ToNumber; the settled guard already excludes the
+  #2979 UNDEF_F64-sentinel `$BoxedNumber`, so `Number.isNaN(undefined)` is
+  correctly `false`) -> `__unbox_number` -> the **shared** `numberIsPredicateOps`
+  (new leaf `src/codegen/number-is-predicate-ops.ts`, also adopted by the direct
+  `call-builtin-static.ts` path -> observational identity guaranteed, byte-inert
+  over the 56-entry emit-identity corpus). Both natives are standalone-DEFINED
+  (host-free). Meta rows added to `STANDALONE_STATIC_METHOD_META`. Test:
+  `tests/issue-2963-number-is-value.test.ts` (8 cases: per-method invocation,
+  no-coercion, undefined/null/bool -> false, identity, `.name`, direct-form
+  non-regression).
+  - **Pre-existing gap surfaced (NOT introduced here, orthogonal follow-up):**
+    `.name`/`.length` reflective reads on a reified builtin value have a
+    multi-value dispatch collision — co-extracting two statics that share a
+    wrapper signature (verified on `main` with `Object.keys` + `Reflect.ownKeys`,
+    both `externref -> externref`; also `Array.isArray` + any `Number.is*`, both
+    `externref -> i32`) makes the SECOND value's `.name` mis-resolve, and
+    `.length` reads 0 for EVERY wired static (Math.max included). Invocation and
+    per-single-value `.name` are correct. Worth a dedicated issue on the reified
+    builtin-fn meta reflective-read dispatch.
+- Remaining Phase 2 tiers: 2b (`Object.is`/SameValue), 2c (table-driven
+  `Math.*`), 2d (`Number.parseFloat/parseInt`), 2e (`Date.now`), 2f (`Array.of`),
+  2g (`Array.from` subset). `Promise.*` stays throwing (out of scope).

--- a/plan/issues/2963-builtin-first-class-reification.md
+++ b/plan/issues/2963-builtin-first-class-reification.md
@@ -82,19 +82,19 @@ which already retired much of the raw cluster. Re-probing current `main`
 **live** cluster splits into distinct sub-problems that must NOT be
 conflated:
 
-| Form (current main)                                   | Status on main | Owner / phase |
-| ----------------------------------------------------- | -------------- | ------------- |
-| `const f = Array.isArray` **identity** (`f === f`)    | **wrong (`false`)** — fresh `struct.new` per read | **Phase 1 (this PR)** |
-| `const r = Promise.resolve` as value                  | CE `#1907`     | Phase 2 — but Promise itself is host-backed (`Promise_resolve` import even for the DIRECT call), so reification cannot be host-free until Promise is native (#2867/#2905/#2959). |
-| `const f = Number.isInteger` (host-free predicate)    | CE `#1907`     | Phase 2 — **blocked** (see value-call-path blocker below). |
-| `const f = Array.of` as value                         | CE `#1907`     | Phase 2 — variadic; reified fixed-arity closure needs rest handling. |
-| `const k = Symbol.matchAll`                            | CE `#1907`     | Phase 2 — non-well-known Symbol value (well-known ones already fold, #2610). |
-| `X extends Object` constructor-object identity        | leaks `__new_Object` | **separate** — #2984 / sr-objsub. |
-| array-iterator `%ArrayIteratorPrototype%` identity     | leaks `__iterator`   | **separate** — opus-12b / #2965 cluster. |
-| `Object.defineProperty(globalThis, …)`                 | leaks `__get_globalThis` | **separate** — #2988. |
+| Form (current main)                                | Status on main                                    | Owner / phase                                                                                                                                                                    |
+| -------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `const f = Array.isArray` **identity** (`f === f`) | **wrong (`false`)** — fresh `struct.new` per read | **Phase 1 (this PR)**                                                                                                                                                            |
+| `const r = Promise.resolve` as value               | CE `#1907`                                        | Phase 2 — but Promise itself is host-backed (`Promise_resolve` import even for the DIRECT call), so reification cannot be host-free until Promise is native (#2867/#2905/#2959). |
+| `const f = Number.isInteger` (host-free predicate) | CE `#1907`                                        | Phase 2 — **blocked** (see value-call-path blocker below).                                                                                                                       |
+| `const f = Array.of` as value                      | CE `#1907`                                        | Phase 2 — variadic; reified fixed-arity closure needs rest handling.                                                                                                             |
+| `const k = Symbol.matchAll`                        | CE `#1907`                                        | Phase 2 — non-well-known Symbol value (well-known ones already fold, #2610).                                                                                                     |
+| `X extends Object` constructor-object identity     | leaks `__new_Object`                              | **separate** — #2984 / sr-objsub.                                                                                                                                                |
+| array-iterator `%ArrayIteratorPrototype%` identity | leaks `__iterator`                                | **separate** — opus-12b / #2965 cluster.                                                                                                                                         |
+| `Object.defineProperty(globalThis, …)`             | leaks `__get_globalThis`                          | **separate** — #2988.                                                                                                                                                            |
 
 The three "separate" rows are the sibling gaps three other devs found the
-same day — they share the *theme* (own-object identity) but each needs its
+same day — they share the _theme_ (own-object identity) but each needs its
 own receiver-class MOP (see `project_2984_2988_2992_convergent_reification_substrate`);
 they are **not** in #2963's lane.
 
@@ -113,7 +113,7 @@ behind an `if (ref.is_null) { struct.new; global.set }` guard emitted in the
 
 **Why body-lazy-init, NOT a const-init global** (the load-bearing design
 decision): the singleton's `struct.new` operand is `ref.func <closureIdx>`,
-and `closureIdx` is a *defined-function* index that shifts whenever a late
+and `closureIdx` is a _defined-function_ index that shifts whenever a late
 import lands (`addUnionImports` / `shiftLateImportIndices` / the string-import
 shifter). All three shifters walk function bodies **and nested
 `.then`/`.body`/`.else` arrays** (verified) but **do NOT walk
@@ -122,10 +122,10 @@ stale and point at the wrong function (a silent funcidx-desync regression, the
 family of `project_standalone_hostimport_gate_index_shift`). Emitting the
 `ref.func` inside an `if.then` in `fctx.body` keeps it in a shift-covered
 array. (The `$__hole` const-init singleton in `array-holes.ts` is safe only
-because it has *no* funcref operand.)
+because it has _no_ funcref operand.)
 
 The shared mutable `bfnstate` (delete-bits) field being one instance across
-all reads is *spec-correct*: `delete fn.name` through any reference mutates the
+all reads is _spec-correct_: `delete fn.name` through any reference mutates the
 same object.
 
 **Scope**: only the standalone static-method **value-read** site
@@ -155,7 +155,7 @@ value-call dispatch integration bug** found while prototyping `Number.isInteger`
   any-callable dispatch (`expressions/calls.ts` ~13230–13640,
   `__callable_param_*`) works for them.
 - A reified value stored in a `const f = …` widens to **`externref`** (its TS
-  type is a function), so the call site must *recover* the closure by
+  type is a function), so the call site must _recover_ the closure by
   `ref.test`/`ref.cast` against a candidate struct type. Candidate selection is
   keyed by **arity**, not exact param types — so a new **`f64`-param** closure
   (e.g. `Number.isInteger`) mis-selects among same-arity candidates and the
@@ -168,7 +168,7 @@ value-call dispatch integration bug** found while prototyping `Number.isInteger`
   funcs). Once that lands, the singleton substrate here wires every host-free
   method (`Number.is*`, `Math.*` unary/binary, `Object.is` scalar, …) trivially
   via the same `ensureStandaloneBuiltinStaticMethodClosure` switch.
-- **Promise.\*** (15 of the sampled refusals) is a *further* sub-case: even the
+- **Promise.\*** (15 of the sampled refusals) is a _further_ sub-case: even the
   DIRECT `Promise.resolve(5)` call leaks a `Promise_resolve` host import today,
   so reifying it host-free is gated on native Promise (#2867/#2905/#2959), not
   on this mechanism. Until then a reified `Promise.resolve` would reuse the same
@@ -270,12 +270,12 @@ The Phase-1 note above (2026-07-02) is stale in three load-bearing ways:
    `BUILTIN_STATIC_METHOD_ARITY` as an identity-stable, spec-shaped
    (`.name`/`.length` meta subtype) closure whose body throws a **catchable
    TypeError**. So feature-detection reads, identity compares, and descriptor
-   reflection all pass today; only *invoking* an unwired extracted value
+   reflection all pass today; only _invoking_ an unwired extracted value
    throws. The remaining conformance lever is therefore "give real bodies to
    the throw-body methods", not "stop CE-ing".
 3. **The value-call dispatch fix is NOT a prerequisite anymore.** The Phase-1
    blocker ("f64-param closure mis-selects among same-arity candidates") is
-   solved by *convention*, not by a dispatcher change: every reified closure
+   solved by _convention_, not by a dispatcher change: every reified closure
    already takes **all-externref params** (or the single
    `(ref null $vec_externref)` variadic param) — exactly the shape the inline
    dynamic dispatcher's #2939 pre-registration restricts itself to, and the
@@ -293,15 +293,15 @@ Ordered by cluster size and body availability. All are `switch (key)` arms in
 each reuses the SAME native the direct-call path uses (observational identity
 with the direct call is the acceptance bar, per the `Reflect.get` precedent).
 
-| Tier | Methods | Body sketch |
-| --- | --- | --- |
-| 2a | `Number.isInteger/isFinite/isNaN/isSafeInteger` | `ref.test $BoxedNumber` on the arg (via `any.convert_extern` + the settled tag-3 peel — NOT ToNumber; a non-number arg answers `0` per §21.1.2); on hit, unbox f64 and run the existing direct-call predicate lowering |
-| 2b | `Object.is` | two externref args → the standalone SameValue helper the direct call uses (`calls.ts` Object.is arm; includes the −0/NaN discrimination). NB SameValue ≠ `===`; reuse, don't re-derive |
-| 2c | `Math.<unary/binary fixed-arity>` (`abs`, `floor`, `ceil`, `trunc`, `sign`, `sqrt`, `atan2`, `pow`, …) | arg(s) → `__any_to_f64` (spec ToNumber on the boxed value; non-number → NaN, which is §21.3 behavior) → the existing self-hosted `src/stdlib/math.ts` native → `__any_box_f64`. One table-driven arm, not N hand-written cases: key on `BUILTIN_STATIC_METHOD_ARITY.Math` + the direct-call lowering's dispatch table |
-| 2d | `Number.parseFloat/parseInt` | route to the existing native parse entries (the standalone direct-call path); parseInt keeps the NaN radix sentinel |
-| 2e | `Date.now` | 0-arg; the direct-call lowering's time source (verify which import/native serves it standalone — if it is host-only, leave the throw body and record why) |
-| 2f | `Array.of` (variadic) | the `$vec_externref` variadic convention (Math.max precedent): build a `$__vec_externref` from the args vec — elements are already externref, no per-element coercion |
-| 2g | `Array.from` (1-arg iterable subset) | ONLY the array-like/vec fast shape the direct call supports standalone; other inputs keep the catchable throw (document per-shape) |
+| Tier | Methods                                                                                                | Body sketch                                                                                                                                                                                                                                                                                                           |
+| ---- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2a   | `Number.isInteger/isFinite/isNaN/isSafeInteger`                                                        | `ref.test $BoxedNumber` on the arg (via `any.convert_extern` + the settled tag-3 peel — NOT ToNumber; a non-number arg answers `0` per §21.1.2); on hit, unbox f64 and run the existing direct-call predicate lowering                                                                                                |
+| 2b   | `Object.is`                                                                                            | two externref args → the standalone SameValue helper the direct call uses (`calls.ts` Object.is arm; includes the −0/NaN discrimination). NB SameValue ≠ `===`; reuse, don't re-derive                                                                                                                                |
+| 2c   | `Math.<unary/binary fixed-arity>` (`abs`, `floor`, `ceil`, `trunc`, `sign`, `sqrt`, `atan2`, `pow`, …) | arg(s) → `__any_to_f64` (spec ToNumber on the boxed value; non-number → NaN, which is §21.3 behavior) → the existing self-hosted `src/stdlib/math.ts` native → `__any_box_f64`. One table-driven arm, not N hand-written cases: key on `BUILTIN_STATIC_METHOD_ARITY.Math` + the direct-call lowering's dispatch table |
+| 2d   | `Number.parseFloat/parseInt`                                                                           | route to the existing native parse entries (the standalone direct-call path); parseInt keeps the NaN radix sentinel                                                                                                                                                                                                   |
+| 2e   | `Date.now`                                                                                             | 0-arg; the direct-call lowering's time source (verify which import/native serves it standalone — if it is host-only, leave the throw body and record why)                                                                                                                                                             |
+| 2f   | `Array.of` (variadic)                                                                                  | the `$vec_externref` variadic convention (Math.max precedent): build a `$__vec_externref` from the args vec — elements are already externref, no per-element coercion                                                                                                                                                 |
+| 2g   | `Array.from` (1-arg iterable subset)                                                                   | ONLY the array-like/vec fast shape the direct call supports standalone; other inputs keep the catchable throw (document per-shape)                                                                                                                                                                                    |
 
 **Explicitly OUT (keep throw bodies, with the recorded reason):**
 `Promise.*` (host-backed even for direct calls — gated on native Promise,
@@ -372,6 +372,20 @@ merge hygiene.
     `.length` reads 0 for EVERY wired static (Math.max included). Invocation and
     per-single-value `.name` are correct. Worth a dedicated issue on the reified
     builtin-fn meta reflective-read dispatch.
-- Remaining Phase 2 tiers: 2b (`Object.is`/SameValue), 2c (table-driven
-  `Math.*`), 2d (`Number.parseFloat/parseInt`), 2e (`Date.now`), 2f (`Array.of`),
-  2g (`Array.from` subset). `Promise.*` stays throwing (out of scope).
+- **Tier 2b — `Object.is` (SameValue, §20.1.2.13) — DONE** (opus-dev-b,
+  2026-07-18; stacked on the Tier 2a PR). Fixed 2-arg `[externref, externref] ->
+i32` closure. The direct standalone `Object.is` only backs compile-time
+  same-typed scalar args (the general boxed `__object_is` is a host import), so
+  the reified body composes host-free: BOTH boxes Number (`__typeof_number`) ->
+  the shared `sameValueNumberOps` (new leaf `src/codegen/same-value-number-ops.ts`,
+  also adopted by the direct `Object.is` both-Number fast path — the IEEE-754
+  bit-compare + both-NaN clause, the ONLY arm where SameValue diverges from `===`:
+  `+0`/`-0` unequal, `NaN`/`NaN` equal); else -> `__extern_strict_eq` (SameValue
+  coincides with `===` for every non-Number case — object identity via `ref.eq`,
+  strings by content, null/undefined/boolean by value). Byte-inert (56-entry
+  corpus IDENTICAL). Meta row `Object.is` added. Test:
+  `tests/issue-2963-object-is-value.test.ts` (6 cases). The pre-existing
+  reflective-read gap is filed as #3424 (rides this PR).
+- Remaining Phase 2 tiers: 2c (table-driven `Math.*`), 2d
+  (`Number.parseFloat/parseInt`), 2e (`Date.now`), 2f (`Array.of`), 2g
+  (`Array.from` subset). `Promise.*` stays throwing (out of scope).

--- a/plan/issues/3424-reified-builtin-meta-reflective-read.md
+++ b/plan/issues/3424-reified-builtin-meta-reflective-read.md
@@ -1,0 +1,99 @@
+---
+id: 3424
+title: "Reified builtin-value `.name`/`.length` reflective reads mis-dispatch when statics share a wrapper signature"
+status: backlog
+sprint: Backlog
+created: 2026-07-18
+updated: 2026-07-18
+priority: medium
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: builtins
+goal: standalone-mode
+related: [2963, 2933, 2896, 2984]
+origin: "Surfaced during #2963 Tier 2a (Number.is* first-class values) by opus-dev-b, 2026-07-18"
+---
+
+# #3424 — reified builtin-value reflective `.name`/`.length` mis-dispatch across shared wrapper signatures
+
+## Problem
+
+Reading `.name` / `.length` off a **reified builtin static value**
+(`const f: any = Number.isInteger; f.name`) mis-resolves in `--target
+standalone` when **two or more statics that share the same wrapper
+signature** are co-extracted in the same module. Only the **first**
+registered meta closure for a given signature answers its `.name`
+correctly; every subsequent one returns the wrong string (or `0`
+against a string literal compare).
+
+This is **pre-existing** (predates #2963 Phase 2) and orthogonal to the
+value-body work — it lives in the reflective-read dispatch over the
+builtin-fn meta subtypes, not in any closure body. #2963 Tier 2a merely
+made it easier to hit by adding four more `[externref] -> i32` statics
+(`Number.is*`) that share `Array.isArray`'s wrapper signature.
+
+## Reproduction (all on `main`, `--target standalone`)
+
+```ts
+// Two externref->externref statics co-extracted — the SECOND .name is wrong:
+export function a(): number {
+  const g: any = Object.keys;
+  return g.name === "keys" ? 1 : 0;
+} // => 1
+export function b(): number {
+  const f: any = Reflect.ownKeys;
+  return f.name === "ownKeys" ? 1 : 0;
+} // => 0  (BUG)
+```
+
+```ts
+// Both in one function — first ok, second wrong:
+export function t(): number {
+  const g: any = Object.keys; // g.name === "keys"    ✓
+  const f: any = Reflect.ownKeys; // f.name === "ownKeys" ✗
+  return (g.name === "keys" ? 1 : 0) * 10 + (f.name === "ownKeys" ? 1 : 0);
+} // => 10  (want 11)
+```
+
+After #2963 Tier 2a the same shows for the `[externref] -> i32` family,
+e.g. `Array.isArray` + `Number.isSafeInteger`, or any two `Number.is*`.
+
+Additionally: **`.length` reads `0` for EVERY wired reified static**
+(Math.max, Array.isArray, Reflect.get, Number.is\* — verified), even in a
+single-value module where `.name` is correct. So `.length` reflective
+reads on reified builtin values are broadly unimplemented in standalone,
+distinct from the multi-value `.name` collision above.
+
+## Root-cause hypothesis
+
+The per-`(builtin, method)` meta type is a distinct **subtype of the
+shared wrapper struct** (`ensureBuiltinFnMetaType`, `builtin-fn-meta.ts`
+— cache key `static:<Builtin>.<method>`, correct). The value is a
+module-level singleton (`pushBuiltinFnSingletonValueInstrs`). The
+**runtime `.name` reader** appears to dispatch on the wrapper BASE type
+(or `ref.test`s the registered meta subtypes in registration order and
+stops at the first that a sibling also satisfies), so it returns the
+first-registered sibling's metadata rather than the value's own exact
+subtype. `.length` returns `0` because the reflective length read isn't
+wired to the meta subtype's `length` field at all in standalone.
+
+## Acceptance criteria
+
+- `f.name` correct for EVERY reified static regardless of how many
+  same-signature statics are co-extracted (multi-value modules).
+- `f.length` returns the spec arity (`STANDALONE_STATIC_METHOD_META` /
+  `BUILTIN_STATIC_METHOD_ARITY`) for every wired reified static.
+- Test: multi-value module extracting ≥3 same-signature statics, asserting
+  each `.name`/`.length`.
+- Byte-inert on host/gc lanes (standalone-gated); emit-identity corpus
+  IDENTICAL.
+
+## Notes
+
+Investigate the property-access reflective-read path for builtin-fn meta
+values (`property-access.ts`, `builtin-fn-meta.ts` `builtinFnMetaByTypeIdx`)
+— specifically how the exact meta subtype of an `any`-typed reified value
+is recovered at runtime (a chain of `ref.test`s against every registered
+meta subtype, most-derived first, is the sound shape).

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -68,6 +68,14 @@ export const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; lengt
   // `ctx.variadicBuiltinClosure`). Spec `.length` is 2 for both (§21.3.2.24/.25).
   "Math.max": { name: "max", length: 2 },
   "Math.min": { name: "min", length: 2 },
+  // (#2963 Tier 2a) Number.is* fixed 1-arg predicates as VALUES. `.name` === the
+  // property key (§10.2.9); `.length` 1 (§21.1.2.x). These agree byte-for-byte
+  // with the generic `BUILTIN_STATIC_METHOD_ARITY` fallback, listed explicitly
+  // per the file-header sync rule for newly-wired closures.
+  "Number.isInteger": { name: "isInteger", length: 1 },
+  "Number.isFinite": { name: "isFinite", length: 1 },
+  "Number.isNaN": { name: "isNaN", length: 1 },
+  "Number.isSafeInteger": { name: "isSafeInteger", length: 1 },
 };
 
 /**

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -76,6 +76,8 @@ export const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; lengt
   "Number.isFinite": { name: "isFinite", length: 1 },
   "Number.isNaN": { name: "isNaN", length: 1 },
   "Number.isSafeInteger": { name: "isSafeInteger", length: 1 },
+  // (#2963 Tier 2b) Object.is fixed 2-arg SameValue as a VALUE (§20.1.2.13).
+  "Object.is": { name: "is", length: 2 },
 };
 
 /**

--- a/src/codegen/builtin-value-read.ts
+++ b/src/codegen/builtin-value-read.ts
@@ -15,6 +15,7 @@
 
 import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
+import { numberIsPredicateOps } from "./number-is-predicate-ops.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addUnionImports, TYPED_ARRAY_NAMES, typedArrayPackedSignedness } from "./index.js";
 import {
@@ -918,6 +919,38 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
       returnType = { kind: "externref" };
       break;
     }
+    // (#2963 Tier 2a) `Number.is{Integer,Finite,NaN,SafeInteger}` as first-class
+    // VALUES. Fixed 1-arg predicates: the reified closure takes the boxed arg as
+    // externref (the all-externref convention — coercion moves INSIDE the body)
+    // and returns i32 (0/1), exactly like the `Array.isArray` value closure. The
+    // body applies the `__typeof_number` guard (NO ToNumber — a non-Number arg is
+    // `false` per §21.1.2.x, and the settled guard already excludes the #2979
+    // UNDEF_F64-sentinel `$BoxedNumber` that carries `undefined`), then
+    // `__unbox_number` → the SHARED `numberIsPredicateOps` f64 test (the SAME ops
+    // the direct `Number.is*(n)` call emits → observational identity). Both
+    // natives are standalone-DEFINED funcs (host-free) registered by
+    // `addUnionImports`; if the substrate is unavailable, degrade to the generic
+    // catchable-TypeError body (identity/meta still hold).
+    case "Number.isInteger":
+    case "Number.isFinite":
+    case "Number.isNaN":
+    case "Number.isSafeInteger": {
+      addUnionImports(ctx);
+      const typeofNumIdx = ctx.funcMap.get("__typeof_number");
+      const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+      if (typeofNumIdx === undefined || unboxNumIdx === undefined) {
+        const genericArity = BUILTIN_STATIC_METHOD_ARITY[builtinName]?.[propName];
+        if (genericArity === undefined) return null;
+        paramTypes = [];
+        for (let i = 0; i < genericArity; i++) paramTypes.push({ kind: "externref" });
+        returnType = { kind: "externref" };
+        genericThrowBody = true;
+        break;
+      }
+      paramTypes = [{ kind: "externref" }];
+      returnType = { kind: "i32" };
+      break;
+    }
     default: {
       // (#2984 Phase 3) Any OTHER standard builtin static method — the
       // `BUILTIN_STATIC_METHOD_ARITY` membership is the complete own
@@ -1115,6 +1148,38 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
         },
         { op: "local.get", index: accLocal },
         { op: "call", funcIdx: boxNumIdx },
+      );
+    } else if (
+      (key === "Number.isInteger" ||
+        key === "Number.isFinite" ||
+        key === "Number.isNaN" ||
+        key === "Number.isSafeInteger") &&
+      !genericThrowBody
+    ) {
+      // (#2963 Tier 2a) Predicate body. Params: 0=self, 1=arg (boxed externref).
+      // `__typeof_number` answers "is this box a Number?" (excludes null /
+      // undefined / the UNDEF_F64-sentinel box / non-number tags) WITHOUT
+      // coercing — a non-Number arg yields `false` per §21.1.2.x. On a hit,
+      // `__unbox_number` recovers the f64 and the shared `numberIsPredicateOps`
+      // runs the exact test the direct call emits.
+      const typeofNumIdx = ctx.funcMap.get("__typeof_number");
+      const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+      if (typeofNumIdx === undefined || unboxNumIdx === undefined) return null;
+      const valTmp = allocLocal(closureFctx, "np_val", { kind: "f64" });
+      closureFctx.body.push(
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: typeofNumIdx },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [
+            { op: "local.get", index: 1 },
+            { op: "call", funcIdx: unboxNumIdx },
+            { op: "local.set", index: valTmp },
+            ...numberIsPredicateOps(propName, valTmp),
+          ],
+          else: [{ op: "i32.const", value: 0 }],
+        },
       );
     } else if (genericThrowBody) {
       // (#2984 Phase 3) Degrade-to-catchable body: a real TypeError instance +

--- a/src/codegen/builtin-value-read.ts
+++ b/src/codegen/builtin-value-read.ts
@@ -71,7 +71,8 @@ import { emitJsonStringifyValue } from "./json-codec-native.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
 import { getArrTypeIdxFromVec } from "./registry/types.js";
-import { ensureAnyFromExternHelper, ensureAnyHelpers } from "./any-helpers.js";
+import { ensureAnyFromExternHelper, ensureAnyHelpers, ensureExternStrictEqHelper } from "./any-helpers.js";
+import { sameValueNumberOps } from "./same-value-number-ops.js";
 
 export const BUILTIN_CTOR_NAMES = new Set([
   "Object",
@@ -951,6 +952,35 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
       returnType = { kind: "i32" };
       break;
     }
+    // (#2963 Tier 2b) `Object.is(x, y)` as a first-class VALUE — SameValue
+    // (§20.1.2.13), NOT `===`. Fixed 2-arg `[externref, externref] -> i32`. The
+    // direct standalone `Object.is` call only backs COMPILE-TIME same-typed
+    // scalar args (the general boxed `__object_is` is a host import); a reified
+    // value gets two boxed `any` args, so the body composes host-free: if BOTH
+    // boxes are Numbers (`__typeof_number`), run the shared `sameValueNumberOps`
+    // (bit-compare + both-NaN — the ONLY place SameValue diverges from `===`:
+    // `+0`/`-0` unequal, `NaN`/`NaN` equal); otherwise SameValue reduces to `===`
+    // for every non-Number case, so reuse `__extern_strict_eq` (object identity
+    // via `ref.eq`, string content, null/undefined/boolean by value). Degrade to
+    // the generic catchable-TypeError body if any native is unavailable.
+    case "Object.is": {
+      addUnionImports(ctx);
+      const typeofNumIdx = ctx.funcMap.get("__typeof_number");
+      const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+      const strictEqIdx = ensureExternStrictEqHelper(ctx);
+      if (typeofNumIdx === undefined || unboxNumIdx === undefined || strictEqIdx === undefined) {
+        const genericArity = BUILTIN_STATIC_METHOD_ARITY[builtinName]?.[propName];
+        if (genericArity === undefined) return null;
+        paramTypes = [];
+        for (let i = 0; i < genericArity; i++) paramTypes.push({ kind: "externref" });
+        returnType = { kind: "externref" };
+        genericThrowBody = true;
+        break;
+      }
+      paramTypes = [{ kind: "externref" }, { kind: "externref" }];
+      returnType = { kind: "i32" };
+      break;
+    }
     default: {
       // (#2984 Phase 3) Any OTHER standard builtin static method — the
       // `BUILTIN_STATIC_METHOD_ARITY` membership is the complete own
@@ -1179,6 +1209,42 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
             ...numberIsPredicateOps(propName, valTmp),
           ],
           else: [{ op: "i32.const", value: 0 }],
+        },
+      );
+    } else if (key === "Object.is" && !genericThrowBody) {
+      // (#2963 Tier 2b) Body. Params: 0=self, 1=x, 2=y (both boxed externref).
+      const typeofNumIdx = ctx.funcMap.get("__typeof_number");
+      const unboxNumIdx = ctx.funcMap.get("__unbox_number");
+      const strictEqIdx = ctx.funcMap.get("__extern_strict_eq");
+      if (typeofNumIdx === undefined || unboxNumIdx === undefined || strictEqIdx === undefined) return null;
+      const nx = allocLocal(closureFctx, "sv_nx", { kind: "f64" });
+      const ny = allocLocal(closureFctx, "sv_ny", { kind: "f64" });
+      closureFctx.body.push(
+        // both boxes Numbers?  __typeof_number(x) & __typeof_number(y)
+        { op: "local.get", index: 1 },
+        { op: "call", funcIdx: typeofNumIdx },
+        { op: "local.get", index: 2 },
+        { op: "call", funcIdx: typeofNumIdx },
+        { op: "i32.and" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [
+            // SameValue over two Numbers (the only §20.1.2.13 arm that ≠ ===).
+            { op: "local.get", index: 1 },
+            { op: "call", funcIdx: unboxNumIdx },
+            { op: "local.set", index: nx },
+            { op: "local.get", index: 2 },
+            { op: "call", funcIdx: unboxNumIdx },
+            { op: "local.set", index: ny },
+            ...sameValueNumberOps(nx, ny),
+          ],
+          else: [
+            // Every non-Number SameValue case coincides with `===`.
+            { op: "local.get", index: 1 },
+            { op: "local.get", index: 2 },
+            { op: "call", funcIdx: strictEqIdx },
+          ],
         },
       );
     } else if (genericThrowBody) {

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -13,6 +13,7 @@ import { isBooleanType, isNumberType, isStringType } from "../../checker/type-ma
 import type { Instr, ValType } from "../../ir/types.js";
 import { resolveArrayInfo } from "../array-methods.js";
 import { numberIsPredicateOps } from "../number-is-predicate-ops.js";
+import { sameValueNumberOps } from "../same-value-number-ops.js";
 import {
   emitArrayIteratorPrototypeSingleton,
   emitFunctionPrototypeObjectSingleton,
@@ -2831,22 +2832,9 @@ export function compileBuiltinStaticCall(
         const yt = compileExpression(ctx, fctx, yArgEarly);
         if (yt && yt.kind !== "f64") coerceType(ctx, fctx, yt, { kind: "f64" });
         fctx.body.push({ op: "local.set", index: yLocal });
-        // bits(x) == bits(y)
-        fctx.body.push({ op: "local.get", index: xLocal });
-        fctx.body.push({ op: "i64.reinterpret_f64" });
-        fctx.body.push({ op: "local.get", index: yLocal });
-        fctx.body.push({ op: "i64.reinterpret_f64" });
-        fctx.body.push({ op: "i64.eq" });
-        // (x !== x) & (y !== y)  →  both NaN
-        fctx.body.push({ op: "local.get", index: xLocal });
-        fctx.body.push({ op: "local.get", index: xLocal });
-        fctx.body.push({ op: "f64.ne" });
-        fctx.body.push({ op: "local.get", index: yLocal });
-        fctx.body.push({ op: "local.get", index: yLocal });
-        fctx.body.push({ op: "f64.ne" });
-        fctx.body.push({ op: "i32.and" });
-        // bitsEqual | bothNaN
-        fctx.body.push({ op: "i32.or" });
+        // SameValue(Number, Number): (bits(x) == bits(y)) | bothNaN — shared with
+        // the reified `Object.is` value closure so the two never drift.
+        for (const instr of sameValueNumberOps(xLocal, yLocal)) fctx.body.push(instr);
         return { kind: "i32" };
       }
 

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -12,6 +12,7 @@ import { ts } from "../../ts-api.js";
 import { isBooleanType, isNumberType, isStringType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { resolveArrayInfo } from "../array-methods.js";
+import { numberIsPredicateOps } from "../number-is-predicate-ops.js";
 import {
   emitArrayIteratorPrototypeSingleton,
   emitFunctionPrototypeObjectSingleton,
@@ -354,59 +355,19 @@ export function compileBuiltinStaticCall(
     }
     if (method === "isNaN" && expr.arguments.length >= 1) {
       // NaN !== NaN is true; for any other number it's false.
-      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
-        { op: "local.get", index: v },
-        { op: "local.get", index: v },
-        { op: "f64.ne" },
-      ]);
+      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => numberIsPredicateOps("isNaN", v));
     }
     if (method === "isInteger" && expr.arguments.length >= 1) {
       // n === trunc(n) && isFinite(n)
-      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
-        { op: "local.get", index: v },
-        { op: "local.get", index: v },
-        { op: "f64.trunc" },
-        { op: "f64.eq" },
-        // finite: n - n === 0 (Infinity - Infinity = NaN, NaN !== 0)
-        { op: "local.get", index: v },
-        { op: "local.get", index: v },
-        { op: "f64.sub" },
-        { op: "f64.const", value: 0 },
-        { op: "f64.eq" },
-        { op: "i32.and" },
-      ]);
+      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => numberIsPredicateOps("isInteger", v));
     }
     if (method === "isFinite" && expr.arguments.length >= 1) {
       // isFinite(n) → n - n === 0.0
-      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
-        { op: "local.get", index: v },
-        { op: "local.get", index: v },
-        { op: "f64.sub" },
-        { op: "f64.const", value: 0 },
-        { op: "f64.eq" },
-      ]);
+      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => numberIsPredicateOps("isFinite", v));
     }
     if (method === "isSafeInteger" && expr.arguments.length >= 1) {
       // isSafeInteger(n) = isInteger(n) && abs(n) <= MAX_SAFE_INTEGER
-      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => [
-        // isInteger: n === trunc(n) && isFinite(n)
-        { op: "local.get", index: v },
-        { op: "local.get", index: v },
-        { op: "f64.trunc" },
-        { op: "f64.eq" },
-        { op: "local.get", index: v },
-        { op: "local.get", index: v },
-        { op: "f64.sub" },
-        { op: "f64.const", value: 0 },
-        { op: "f64.eq" },
-        { op: "i32.and" },
-        // abs(n) <= MAX_SAFE_INTEGER
-        { op: "local.get", index: v },
-        { op: "f64.abs" },
-        { op: "f64.const", value: Number.MAX_SAFE_INTEGER },
-        { op: "f64.le" },
-        { op: "i32.and" },
-      ]);
+      return compileNumberIsPredicate(ctx, fctx, expr.arguments[0]!, (v) => numberIsPredicateOps("isSafeInteger", v));
     }
     if ((method === "parseFloat" || method === "parseInt") && expr.arguments.length >= 1) {
       // Delegate to the global parseInt / parseFloat host import

--- a/src/codegen/number-is-predicate-ops.ts
+++ b/src/codegen/number-is-predicate-ops.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { Instr } from "../ir/types.js";
+
+/**
+ * (#2963 Tier 2a) The f64 predicate body shared by BOTH the direct
+ * `Number.is<X>(n)` call lowering (`call-builtin-static.ts`) and the reified
+ * first-class value closure (`builtin-value-read.ts`
+ * `ensureStandaloneBuiltinStaticMethodClosure`). Factoring it here guarantees
+ * the reified `const f = Number.isInteger; f(x)` closure is byte-for-byte the
+ * SAME numeric test as the direct call — observational identity is the #2963
+ * acceptance bar — and keeps the two paths from drifting.
+ *
+ * `v` is a wasm local index holding the already-unboxed f64 candidate; the
+ * emitted sequence consumes nothing off the stack and leaves a single i32
+ * (0/1) boolean. It does NOT do ToNumber — the no-coercion §21.1.2.x rule is
+ * enforced by the CALLER (a `__typeof_number` / static-number-type guard):
+ * these ops only run once the argument is known to be a Number.
+ *
+ * The op sequences are IDENTICAL to the historical inline lambdas in
+ * `tryCompileBuiltinStaticCall` (verified byte-inert via prove-emit-identity):
+ *   - isNaN:         n !== n
+ *   - isInteger:     n === trunc(n) && (n - n === 0)   [finite]
+ *   - isFinite:      n - n === 0
+ *   - isSafeInteger: isInteger(n) && abs(n) <= MAX_SAFE_INTEGER
+ */
+export function numberIsPredicateOps(method: string, v: number): Instr[] {
+  switch (method) {
+    case "isNaN":
+      // NaN !== NaN is true; any other number → false.
+      return [{ op: "local.get", index: v }, { op: "local.get", index: v }, { op: "f64.ne" }];
+    case "isInteger":
+      // n === trunc(n) && isFinite(n)
+      return [
+        { op: "local.get", index: v },
+        { op: "local.get", index: v },
+        { op: "f64.trunc" },
+        { op: "f64.eq" },
+        // finite: n - n === 0 (Infinity - Infinity = NaN, NaN !== 0)
+        { op: "local.get", index: v },
+        { op: "local.get", index: v },
+        { op: "f64.sub" },
+        { op: "f64.const", value: 0 },
+        { op: "f64.eq" },
+        { op: "i32.and" },
+      ];
+    case "isFinite":
+      // isFinite(n) → n - n === 0.0
+      return [
+        { op: "local.get", index: v },
+        { op: "local.get", index: v },
+        { op: "f64.sub" },
+        { op: "f64.const", value: 0 },
+        { op: "f64.eq" },
+      ];
+    case "isSafeInteger":
+      // isSafeInteger(n) = isInteger(n) && abs(n) <= MAX_SAFE_INTEGER
+      return [
+        // isInteger: n === trunc(n) && isFinite(n)
+        { op: "local.get", index: v },
+        { op: "local.get", index: v },
+        { op: "f64.trunc" },
+        { op: "f64.eq" },
+        { op: "local.get", index: v },
+        { op: "local.get", index: v },
+        { op: "f64.sub" },
+        { op: "f64.const", value: 0 },
+        { op: "f64.eq" },
+        { op: "i32.and" },
+        // abs(n) <= MAX_SAFE_INTEGER
+        { op: "local.get", index: v },
+        { op: "f64.abs" },
+        { op: "f64.const", value: Number.MAX_SAFE_INTEGER },
+        { op: "f64.le" },
+        { op: "i32.and" },
+      ];
+    default:
+      throw new Error(`numberIsPredicateOps: unknown Number.is* method '${method}'`);
+  }
+}

--- a/src/codegen/same-value-number-ops.ts
+++ b/src/codegen/same-value-number-ops.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import type { Instr } from "../ir/types.js";
+
+/**
+ * (#2963 Tier 2b) SameValue(Number x, Number y) per §20.1.2.13 / §7.2.11
+ * (SameValue for two Numbers), shared by BOTH the direct `Object.is(x, y)`
+ * both-Number fast path (`call-builtin-static.ts`) and the reified `Object.is`
+ * first-class value closure (`builtin-value-read.ts`). Factoring it here keeps
+ * the reified `const f = Object.is; f(a, b)` closure byte-for-byte identical to
+ * the direct call — the #2963 acceptance bar.
+ *
+ * `xLocal` / `yLocal` are wasm f64 local indices already holding the two
+ * numbers. The emitted sequence consumes nothing off the stack and leaves a
+ * single i32 (0/1):
+ *
+ *   SameValue = (bits(x) === bits(y)) OR (x is NaN AND y is NaN)
+ *
+ * The IEEE-754 BIT comparison — not `f64.eq` — is what distinguishes SameValue
+ * from `===`: it makes `+0` and `-0` UNEQUAL (their sign bits differ), while the
+ * explicit both-NaN clause makes two NaNs EQUAL (every NaN bit pattern counts,
+ * so `NaN`/`-NaN`/payload variants all satisfy it). Ops are IDENTICAL to the
+ * historical inline sequence in `tryCompileBuiltinStaticCall` (byte-inert via
+ * prove-emit-identity).
+ */
+export function sameValueNumberOps(xLocal: number, yLocal: number): Instr[] {
+  return [
+    // bits(x) == bits(y)  (distinguishes +0 from -0; matches equal finite/±Inf)
+    { op: "local.get", index: xLocal },
+    { op: "i64.reinterpret_f64" },
+    { op: "local.get", index: yLocal },
+    { op: "i64.reinterpret_f64" },
+    { op: "i64.eq" },
+    // (x !== x) & (y !== y)  →  both NaN
+    { op: "local.get", index: xLocal },
+    { op: "local.get", index: xLocal },
+    { op: "f64.ne" },
+    { op: "local.get", index: yLocal },
+    { op: "local.get", index: yLocal },
+    { op: "f64.ne" },
+    { op: "i32.and" },
+    // bitsEqual | bothNaN
+    { op: "i32.or" },
+  ];
+}

--- a/tests/issue-2963-number-is-value.test.ts
+++ b/tests/issue-2963-number-is-value.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2963 Tier 2a — `Number.is{Integer,Finite,NaN,SafeInteger}` as first-class
+ * VALUES under `--target standalone`.
+ *
+ * Before this change, extracting one of these predicates
+ * (`const f: any = Number.isInteger`) reified a spec-shaped, identity-stable
+ * closure whose BODY threw a catchable TypeError (#2984 Phase 3) — the value
+ * existed for feature-detection / identity / reflection, but INVOKING it threw.
+ * This wires the real body: the fixed 1-arg closure takes the boxed arg as
+ * externref (the all-externref convention), applies the `__typeof_number` guard
+ * (NO ToNumber — a non-Number arg is `false` per §21.1.2.x, and the settled
+ * guard excludes the #2979 UNDEF_F64-sentinel box that carries `undefined`),
+ * then `__unbox_number` → the SHARED `numberIsPredicateOps` f64 test — the SAME
+ * ops the direct `Number.is*(n)` call emits, so the reified call is
+ * observationally identical to the direct call.
+ *
+ * Host mode is untouched: this path lives in
+ * `ensureStandaloneBuiltinStaticMethodClosure` (standalone-only) and the shared
+ * predicate-ops refactor of the direct call path is byte-identical (proven over
+ * the 56-entry emit-identity corpus). NB `.length` reflective reads on a reified
+ * builtin value return 0 in standalone for EVERY wired static today (Math.max,
+ * Array.isArray, Reflect.get included) — a pre-existing reflective-length gap
+ * orthogonal to this tier; `.name` and identity are correct.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+  if (!result.binary || result.binary.length === 0) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2963 Tier 2a — Number.is* value reads (standalone)", () => {
+  it("invokes an extracted Number.isInteger with spec results", async () => {
+    const exports = await runStandalone(`
+      export function integer(): number { const f: any = Number.isInteger; return f(4) ? 1 : 0; }
+      export function nonInteger(): number { const f: any = Number.isInteger; return f(4.5) ? 1 : 0; }
+      export function negZero(): number { const f: any = Number.isInteger; return f(-0) ? 1 : 0; }
+      export function infinite(): number { const f: any = Number.isInteger; return f(1 / 0) ? 1 : 0; }
+    `);
+    expect(exports.integer!()).toBe(1);
+    expect(exports.nonInteger!()).toBe(0);
+    expect(exports.negZero!()).toBe(1); // -0 is an integer
+    expect(exports.infinite!()).toBe(0); // Infinity is not an integer
+  });
+
+  it("invokes an extracted Number.isNaN / isFinite", async () => {
+    const exports = await runStandalone(`
+      export function nan(): number { const g: any = Number.isNaN; return g(0 / 0) ? 1 : 0; }
+      export function notNan(): number { const g: any = Number.isNaN; return g(3) ? 1 : 0; }
+      export function finite(): number { const h: any = Number.isFinite; return h(3) ? 1 : 0; }
+      export function notFinite(): number { const h: any = Number.isFinite; return h(1 / 0) ? 1 : 0; }
+    `);
+    expect(exports.nan!()).toBe(1);
+    expect(exports.notNan!()).toBe(0);
+    expect(exports.finite!()).toBe(1);
+    expect(exports.notFinite!()).toBe(0);
+  });
+
+  it("invokes an extracted Number.isSafeInteger at the 2^53-1 boundary", async () => {
+    const exports = await runStandalone(`
+      export function atMax(): number { const s: any = Number.isSafeInteger; return s(9007199254740991) ? 1 : 0; }
+      export function overMax(): number { const s: any = Number.isSafeInteger; return s(9007199254740992) ? 1 : 0; }
+    `);
+    expect(exports.atMax!()).toBe(1); // 2^53 - 1 = MAX_SAFE_INTEGER
+    expect(exports.overMax!()).toBe(0); // 2^53 is not safe
+  });
+
+  it("does NOT coerce its argument — a non-Number is false (§21.1.2.x)", async () => {
+    const exports = await runStandalone(`
+      export function str(): number { const f: any = Number.isInteger; return f("4") ? 1 : 0; }
+      export function undef(): number { const f: any = Number.isNaN; return f(undefined) ? 1 : 0; }
+      export function nul(): number { const f: any = Number.isFinite; return f(null) ? 1 : 0; }
+      export function bool(): number { const f: any = Number.isInteger; return f(true) ? 1 : 0; }
+    `);
+    expect(exports.str!()).toBe(0); // "4" is a String, not a Number → false (no ToNumber)
+    expect(exports.undef!()).toBe(0); // undefined is not NaN (the UNDEF_F64 sentinel is excluded)
+    expect(exports.nul!()).toBe(0); // null is not a Number → false
+    expect(exports.bool!()).toBe(0); // true is a Boolean, not a Number → false
+  });
+
+  it("is observationally identical to the direct call over a fixed input set", async () => {
+    // The reified closure and the direct `Number.is*(n)` lowering share the SAME
+    // `numberIsPredicateOps` body, so every (method, input) pair must agree. Fold
+    // the agreement into one i32 (avoids array methods, which pull host runtime
+    // imports the empty-import standalone harness doesn't provide).
+    const exports = await runStandalone(`
+      export function agree(): number {
+        const fi: any = Number.isInteger;
+        const fn: any = Number.isNaN;
+        const ff: any = Number.isFinite;
+        const inputs: number[] = [0, -0, 4, 4.5, -7, 1 / 0, -1 / 0, 0 / 0, 9007199254740992];
+        for (let i = 0; i < inputs.length; i++) {
+          const x = inputs[i]!;
+          if ((fi(x) ? 1 : 0) !== (Number.isInteger(x) ? 1 : 0)) return 0;
+          if ((fn(x) ? 1 : 0) !== (Number.isNaN(x) ? 1 : 0)) return 0;
+          if ((ff(x) ? 1 : 0) !== (Number.isFinite(x) ? 1 : 0)) return 0;
+        }
+        return 1;
+      }
+    `);
+    expect(exports.agree!()).toBe(1);
+  });
+
+  it("keeps value identity singleton-stable and distinct per method", async () => {
+    const exports = await runStandalone(`
+      export function ident(): number {
+        const a: any = Number.isNaN;
+        const b: any = Number.isNaN;
+        const c: any = Number.isInteger;
+        return (a === b && a !== c) ? 1 : 0;
+      }
+    `);
+    expect(exports.ident!()).toBe(1);
+  });
+
+  it("exposes the spec .name on a reified value (single-value module)", async () => {
+    // NB `.name` reflective reads on reified builtin values have a PRE-EXISTING
+    // multi-value dispatch collision on `main` — co-extracting two statics that
+    // share a wrapper signature (e.g. Object.keys + Reflect.ownKeys, both
+    // externref→externref) breaks the SECOND one's `.name`. That gap predates
+    // and is orthogonal to this tier (verified on main); assert `.name` per
+    // single-value module, where it is correct.
+    for (const [method, want] of [
+      ["isInteger", "isInteger"],
+      ["isNaN", "isNaN"],
+      ["isFinite", "isFinite"],
+      ["isSafeInteger", "isSafeInteger"],
+    ]) {
+      const exports = await runStandalone(`
+        export function test(): number { const f: any = Number.${method}; return f.name === "${want}" ? 1 : 0; }
+      `);
+      expect(exports.test!(), `Number.${method}.name`).toBe(1);
+    }
+  });
+
+  it("does not regress the direct call forms", async () => {
+    const exports = await runStandalone(`
+      export function directIsInteger(): number { const x: any = 6; return Number.isInteger(x) ? 1 : 0; }
+      export function directIsNaN(): number { const x: any = 0 / 0; return Number.isNaN(x) ? 1 : 0; }
+    `);
+    expect(exports.directIsInteger!()).toBe(1);
+    expect(exports.directIsNaN!()).toBe(1);
+  });
+});

--- a/tests/issue-2963-object-is-value.test.ts
+++ b/tests/issue-2963-object-is-value.test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2963 Tier 2b — `Object.is` as a first-class VALUE under `--target standalone`.
+ *
+ * `Object.is` is SameValue (§20.1.2.13), NOT `===`. The direct standalone call
+ * only backs COMPILE-TIME same-typed scalar args (the general boxed
+ * `__object_is` is a host import); a reified value gets two boxed `any` args, so
+ * the closure body composes host-free: if BOTH boxes are Numbers
+ * (`__typeof_number`), run the shared `sameValueNumberOps` (IEEE-754 bit-compare
+ * + both-NaN — the only place SameValue diverges from `===`: `+0`/`-0` UNEQUAL,
+ * `NaN`/`NaN` EQUAL); otherwise SameValue coincides with `===` for every
+ * non-Number case, so it reuses `__extern_strict_eq` (object identity via
+ * `ref.eq`, string content, null/undefined/boolean by value).
+ *
+ * The both-Number ops are shared with the direct `Object.is` fast path
+ * (`sameValueNumberOps`), so the reified and direct calls are byte-identical;
+ * host/gc lanes are byte-inert (56-entry emit-identity corpus IDENTICAL).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+  if (!result.binary || result.binary.length === 0) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2963 Tier 2b — Object.is value reads (standalone)", () => {
+  it("SameValue over Numbers: NaN equal, +0/-0 distinct", async () => {
+    const exports = await runStandalone(`
+      export function eq(): number { const f: any = Object.is; return f(1, 1) ? 1 : 0; }
+      export function neq(): number { const f: any = Object.is; return f(1, 2) ? 1 : 0; }
+      export function nanEqual(): number { const f: any = Object.is; return f(0 / 0, 0 / 0) ? 1 : 0; }
+      export function signedZeroDistinct(): number { const f: any = Object.is; return f(0, -0) ? 1 : 0; }
+      export function negZeroSelf(): number { const f: any = Object.is; return f(-0, -0) ? 1 : 0; }
+    `);
+    expect(exports.eq!()).toBe(1);
+    expect(exports.neq!()).toBe(0);
+    expect(exports.nanEqual!()).toBe(1); // Object.is(NaN, NaN) === true (≠ ===)
+    expect(exports.signedZeroDistinct!()).toBe(0); // Object.is(+0, -0) === false (≠ ===)
+    expect(exports.negZeroSelf!()).toBe(1);
+  });
+
+  it("SameValue over strings / booleans / mixed types", async () => {
+    const exports = await runStandalone(`
+      export function strEq(): number { const f: any = Object.is; return f("ab", "ab") ? 1 : 0; }
+      export function strNeq(): number { const f: any = Object.is; return f("ab", "ac") ? 1 : 0; }
+      export function boolEq(): number { const f: any = Object.is; return f(true, true) ? 1 : 0; }
+      export function mixedNumStr(): number { const f: any = Object.is; return f(1, "1") ? 1 : 0; }
+      export function mixedBoolNum(): number { const f: any = Object.is; return f(true, 1) ? 1 : 0; }
+    `);
+    expect(exports.strEq!()).toBe(1);
+    expect(exports.strNeq!()).toBe(0);
+    expect(exports.boolEq!()).toBe(1);
+    expect(exports.mixedNumStr!()).toBe(0); // different types → false
+    expect(exports.mixedBoolNum!()).toBe(0); // Boolean true is not the Number 1
+  });
+
+  it("SameValue over null / undefined / object identity", async () => {
+    const exports = await runStandalone(`
+      export function undefEq(): number { const f: any = Object.is; return f(undefined, undefined) ? 1 : 0; }
+      export function nullEq(): number { const f: any = Object.is; return f(null, null) ? 1 : 0; }
+      export function nullVsUndef(): number { const f: any = Object.is; return f(null, undefined) ? 1 : 0; }
+      export function sameRef(): number { const f: any = Object.is; const o = { a: 1 }; return f(o, o) ? 1 : 0; }
+      export function distinctRef(): number {
+        const f: any = Object.is; const o1 = { a: 1 }; const o2 = { a: 1 }; return f(o1, o2) ? 1 : 0;
+      }
+    `);
+    expect(exports.undefEq!()).toBe(1);
+    expect(exports.nullEq!()).toBe(1);
+    expect(exports.nullVsUndef!()).toBe(0);
+    expect(exports.sameRef!()).toBe(1); // same reference → true
+    expect(exports.distinctRef!()).toBe(0); // distinct references → false
+  });
+
+  it("is observationally identical to the direct call over a fixed input matrix", async () => {
+    const exports = await runStandalone(`
+      export function agree(): number {
+        const f: any = Object.is;
+        const xs: number[] = [0, -0, 1, -1, 4.5, 1 / 0, -1 / 0, 0 / 0];
+        for (let i = 0; i < xs.length; i++) {
+          for (let j = 0; j < xs.length; j++) {
+            const a = xs[i]!;
+            const b = xs[j]!;
+            if ((f(a, b) ? 1 : 0) !== (Object.is(a, b) ? 1 : 0)) return 0;
+          }
+        }
+        return 1;
+      }
+    `);
+    expect(exports.agree!()).toBe(1);
+  });
+
+  it("keeps value identity singleton-stable and exposes .name", async () => {
+    const exports = await runStandalone(`
+      export function ident(): number { const a: any = Object.is; const b: any = Object.is; return a === b ? 1 : 0; }
+      export function name(): number { const f: any = Object.is; return f.name === "is" ? 1 : 0; }
+    `);
+    expect(exports.ident!()).toBe(1);
+    expect(exports.name!()).toBe(1);
+  });
+
+  it("does not regress the direct Object.is scalar fast paths", async () => {
+    const exports = await runStandalone(`
+      export function nums(): number { const a: any = 0 / 0; return Object.is(a, a) ? 1 : 0; }
+      export function signedZero(): number { const a: any = 0; const b: any = -0; return Object.is(a, b) ? 1 : 0; }
+    `);
+    expect(exports.nums!()).toBe(1); // Object.is(NaN, NaN)
+    expect(exports.signedZero!()).toBe(0); // Object.is(+0, -0)
+  });
+});


### PR DESCRIPTION
## What

Phase 2 **Tier 2b** of #2963 — gives a real body to the reified `Object.is` value under `--target standalone`: `const f: any = Object.is; f(x, y)` now returns **SameValue** (§20.1.2.13) instead of throwing, observationally identical to the direct call.

> **Stacked on #3359 (Tier 2a)** — shares `builtin-value-read.ts` / `builtin-fn-meta.ts` / `call-builtin-static.ts`, so this branch is based on the Tier 2a branch and carries its two commits. Labelled `hold` so it is NOT auto-enqueued until #3359 lands; on that merge, drop `hold` + re-merge `main` (the diff reduces to just Tier 2b). Its own diff (this PR's Tier 2b commit) is reviewable standalone.

## How

`Object.is` is **SameValue, not `===`**. The direct standalone call only backs compile-time same-typed scalar args (the general boxed `__object_is` is a host import), so the reified closure — which gets two boxed `any` args — composes host-free in `Object.is`'s new arm of `ensureStandaloneBuiltinStaticMethodClosure`:

- **both boxes Number** (`__typeof_number`) → the shared `sameValueNumberOps` (new leaf `src/codegen/same-value-number-ops.ts`): IEEE-754 **bit-compare OR both-NaN**. This is the ONLY arm where SameValue diverges from `===` — `+0`/`-0` **unequal**, `NaN`/`NaN` **equal**. The direct `Object.is` both-Number fast path is refactored to consume the SAME leaf → the paths can't drift.
- **else** → `__extern_strict_eq`: SameValue coincides with `===` for every non-Number case (object identity via `ref.eq`, string content, null/undefined/boolean by value).

Degrades to the generic catchable-TypeError body if a native is unavailable.

## Safety

- **Byte-inert** on host/gc/wasi/linear — 56-entry emit-identity corpus **IDENTICAL**.
- `tsc` / `biome` / `prettier` / coercion-sites all green (the reused `__unbox_number` rides the existing #2963 file-level allowance).
- Test: `tests/issue-2963-object-is-value.test.ts` (6 cases — NaN/±0, strings/booleans/mixed, null/undefined/object-identity, observational identity vs direct over an 8×8 matrix, identity singleton + `.name`, direct-fast-path non-regression).

## Also files #3424

The **pre-existing** reflective-read mis-dispatch surfaced in Tier 2a (`.name`/`.length` on a reified builtin value mis-resolve when statics sharing a wrapper signature are co-extracted — reproduced on `main`). `sprint: Backlog`, orthogonal follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)