### PR TITLE
fix(#3427): dedupe duplicate top-level harness function declarations (isPrimitive)

### DIFF
--- a/plan/issues/3427-harness-assembly-duplicate-identifier-isprimitive.md
+++ b/plan/issues/3427-harness-assembly-duplicate-identifier-isprimitive.md
@@ -1,0 +1,88 @@
+---
+id: 3427
+title: "Harness-assembly compile error: Duplicate identifier 'isPrimitive' at L1:10 (host 2,054 + standalone 2,051 TypedArray/Array tests)"
+status: done
+completed: 2026-07-18
+assignee: ttraenkler/opus-dev-b
+sprint: current
+created: 2026-07-18
+updated: 2026-07-18
+priority: high
+horizon: s
+feasibility: medium
+task_type: bug
+area: test262-runner, harness-assembly
+language_feature: n/a
+es_edition: n/a
+goal: test262-conformance
+related: [3370, 3426]
+origin: "2026-07-18 oracle-v8 harvest (fable harvest agent): host + standalone `other` sub-bucket, both lanes @ oracle 8."
+---
+
+# #3427 — Duplicate identifier 'isPrimitive' harness-assembly compile error
+
+## Problem
+
+A single compile-error signature accounts for ~2k tests in **both** lanes:
+
+| Lane       | Records |
+| ---------- | ------: |
+| Host (JS)  |   2,054 |
+| Standalone |   2,051 |
+
+```
+L1:10 Duplicate identifier 'isPrimitive'
+```
+
+The error is at **line 1** (the assembled-prelude region), and every affected
+test is a **TypedArray / Array** test that pulls the `testTypedArray.js`
+(or `testBigIntTypedArray.js`) harness include:
+
+Host samples (all `compile_error`, strict + non-strict):
+
+```
+test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js
+test/built-ins/TypedArray/prototype/fill/fill-values-relative-end.js
+test/built-ins/TypedArray/prototype/filter/BigInt/speciesctor-get-species-custom-ctor-throws.js
+test/built-ins/TypedArray/prototype/at/index-non-numeric-argument-tointeger.js
+test/built-ins/TypedArray/prototype/Symbol.iterator/not-a-constructor.js
+```
+
+Standalone samples:
+
+```
+test/built-ins/TypedArray/prototype/reverse/get-length-uses-internal-arraylength.js
+test/built-ins/TypedArray/prototype/includes/return-abrupt-tointeger-fromindex-symbol.js
+test/built-ins/TypedArray/prototype/findLastIndex/this-is-not-object.js
+test/built-ins/TypedArray/prototype/forEach/callbackfn-resize.js
+```
+
+## Root cause (hypothesis)
+
+This is a **harness-assembly regression from #3370** (make the literal upstream
+harness authoritative), not a codegen or conformance bug. The authoritative
+assembly concatenates: runtime shim + harness includes + `assert.js` + `sta.js` +
+test body. `isPrimitive` is defined by a TypedArray harness include
+(`testTypedArray.js` defines `isPrimitive`/related helpers), and the assembled
+prelude / another include defines `isPrimitive` a second time → duplicate
+identifier at the top of the module. Because TypeScript is the front-end,
+duplicate `function isPrimitive`/`const isPrimitive` declarations are a hard
+compile error rather than a JS last-wins redefinition.
+
+This is a **high-ROI runner-side fix**, not deep codegen: de-duplicate harness
+includes during assembly (or rename/guard the prelude's `isPrimitive`), and ~4k
+TypedArray/Array tests across both lanes recompile.
+
+## Acceptance criteria
+
+- The sample TypedArray/Array tests compile without `Duplicate identifier
+'isPrimitive'`.
+- Harness-include assembly de-duplicates repeated include definitions (or the
+  prelude no longer collides with `testTypedArray.js`'s `isPrimitive`).
+- Both lanes: the `Duplicate identifier 'isPrimitive'` compile-error class drops
+  to ~0.
+
+## Cross-reference
+
+Consequence of #3370 (authoritative harness). Reduces standalone
+`compile_error` count alongside #3426.

--- a/tests/issue-3427-isprimitive-dedup.test.ts
+++ b/tests/issue-3427-isprimitive-dedup.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3427 — the authoritative upstream harness (#3370) declares `isPrimitive` in
+ * BOTH `testTypedArray.js` and `assert.js`. A JS engine tolerates the duplicate
+ * top-level function declaration (last-wins), but our TypeScript front-end
+ * rejects it as `Duplicate identifier 'isPrimitive'` at L1, which failed ~2k
+ * TypedArray/Array tests in EACH lane. `assembleOriginalHarness` now
+ * de-duplicates top-level function declarations in the assembled prefix
+ * (renaming all-but-last to a dead `NAME$dupK`), matching JS last-wins.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { assembleOriginalHarness } from "./test262-original-harness.js";
+import { parseMeta } from "./test262-runner.js";
+
+const TEST262_ROOT = join(import.meta.dirname, "..", "test262", "test");
+
+// The exact worker options for the literal-harness lane (scripts/test262-worker.mjs
+// `doCompile`): skipSemanticDiagnostics drops purely-semantic collisions (e.g.
+// the runtime shim's `var print` vs the ambient DOM `print`), leaving the
+// binder-level duplicate-identifier grammar error this fix targets.
+const HARNESS_COMPILE_OPTS = { allowJs: true, fileName: "test.js", skipSemanticDiagnostics: true } as const;
+
+function assembleFromFile(relPath: string) {
+  const source = readFileSync(join(TEST262_ROOT, relPath), "utf8");
+  const meta = parseMeta(source);
+  return assembleOriginalHarness(source, meta);
+}
+
+describe("#3427 harness-assembly de-duplicates isPrimitive", () => {
+  const typedArraySamples = [
+    "built-ins/TypedArray/prototype/at/index-non-numeric-argument-tointeger.js",
+    "built-ins/TypedArray/prototype/fill/fill-values-relative-end.js",
+    "built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js",
+  ];
+
+  it("assembles a single live `isPrimitive` (earlier declaration renamed)", () => {
+    const asm = assembleFromFile(typedArraySamples[0]!);
+    const src = asm.primary.source;
+    // assert.js's isPrimitive (the LAST declaration) survives verbatim…
+    expect((src.match(/function isPrimitive\s*\(/g) ?? []).length).toBe(1);
+    // …and testTypedArray.js's earlier one is renamed to a dead identifier.
+    expect((src.match(/function isPrimitive\$dup0\s*\(/g) ?? []).length).toBe(1);
+  });
+
+  it("preserves bodyLineOffset (rename adds no lines)", () => {
+    const asm = assembleFromFile(typedArraySamples[0]!);
+    // The renamed token is same-line, so the offset is still the exact prefix
+    // line count (last body line = prefix lines + body-internal line).
+    const prefixLen =
+      asm.primary.source.length - readFileSync(join(TEST262_ROOT, typedArraySamples[0]!), "utf8").length;
+    expect(prefixLen).toBeGreaterThan(0);
+    expect(asm.primary.bodyLineOffset).toBeGreaterThan(0);
+  });
+
+  it("compiles the TypedArray/Array samples without a duplicate-identifier error", async () => {
+    for (const relPath of typedArraySamples) {
+      const asm = assembleFromFile(relPath);
+      const r = await compile(asm.primary.source, HARNESS_COMPILE_OPTS);
+      const dupErrors = (r.errors ?? []).filter((e) => /Duplicate identifier/.test(e.message));
+      expect(dupErrors, `${relPath}: ${dupErrors.map((e) => e.message).join(", ")}`).toHaveLength(0);
+      expect(r.success, `${relPath} should compile`).toBe(true);
+    }
+  });
+
+  it("keeps the strict rerun variant duplicate-free too", async () => {
+    const asm = assembleFromFile(typedArraySamples[0]!);
+    expect(asm.strictRerun).toBeDefined();
+    const r = await compile(asm.strictRerun!.source, HARNESS_COMPILE_OPTS);
+    const dupErrors = (r.errors ?? []).filter((e) => /Duplicate identifier/.test(e.message));
+    expect(dupErrors).toHaveLength(0);
+  });
+});

--- a/tests/test262-original-harness.ts
+++ b/tests/test262-original-harness.ts
@@ -43,6 +43,48 @@ function lineCount(source: string): number {
   return source.split("\n").length - 1;
 }
 
+/**
+ * (#3427) De-duplicate TOP-LEVEL `function NAME(...)` declarations across the
+ * assembled harness prefix. The authoritative upstream harness (#3370) defines
+ * the same helper in more than one include — notably `isPrimitive`, declared by
+ * BOTH `testTypedArray.js` and `assert.js` with identical bodies. A real JS
+ * engine (which is what test262.fyi runs) tolerates duplicate top-level function
+ * declarations under last-wins semantics, so the reference runner is unaffected;
+ * but our TypeScript front-end treats two `function isPrimitive` declarations as
+ * a hard `Duplicate identifier 'isPrimitive'` compile error at L1 — which failed
+ * ~2k TypedArray/Array tests in EACH lane before this fix.
+ *
+ * Rename every duplicate declaration EXCEPT the last to a dead `NAME$dupK`
+ * identifier. This matches JS last-wins exactly (the final declaration is the
+ * one all call sites bind to — function declarations hoist, so calls that appear
+ * before it still resolve to it), leaves the renamed earlier definitions as
+ * harmless unused functions, and — because only the declaration's name token is
+ * rewritten (no lines added/removed) — keeps `bodyLineOffset` (`lineCount`)
+ * exact so test-body error line mapping is unchanged. Only column-0
+ * declarations match (`^`, multiline), so nested/inner functions and named
+ * function EXPRESSIONS (`x = function foo(){}`) are never touched, and the
+ * untouched test body is deliberately excluded (dedup runs on the prefix only).
+ */
+function dedupeTopLevelFunctionDeclarations(prefix: string): string {
+  const declRe = /^((?:async[ \t]+)?function[ \t]+)([A-Za-z_$][\w$]*)([ \t]*\()/gm;
+  const total = new Map<string, number>();
+  prefix.replace(declRe, (full, _kw: string, name: string) => {
+    total.set(name, (total.get(name) ?? 0) + 1);
+    return full;
+  });
+  const dup = new Set([...total].filter(([, count]) => count > 1).map(([name]) => name));
+  if (dup.size === 0) return prefix;
+  const seen = new Map<string, number>();
+  return prefix.replace(declRe, (full, kw: string, name: string, paren: string) => {
+    if (!dup.has(name)) return full;
+    const idx = seen.get(name) ?? 0;
+    seen.set(name, idx + 1);
+    // Keep the LAST declaration (JS last-wins); rename the earlier ones.
+    if (idx === total.get(name)! - 1) return full;
+    return `${kw}${name}$dup${idx}${paren}`;
+  });
+}
+
 function assembleVariant(
   source: string,
   meta: HarnessMeta,
@@ -61,6 +103,11 @@ function assembleVariant(
   prefix += cachedSource(RUNTIME_PATH);
   prefix += harnessSource("assert.js");
   prefix += harnessSource("sta.js");
+  // (#3427) Our TS front-end rejects the upstream harness's duplicate top-level
+  // helper declarations (e.g. `isPrimitive` in both testTypedArray.js + assert.js)
+  // that a JS engine tolerates last-wins. Rename all-but-last in place (line-count
+  // preserving) so bodyLineOffset below stays exact.
+  prefix = dedupeTopLevelFunctionDeclarations(prefix);
   return {
     source: prefix + source,
     bodyLineOffset: lineCount(prefix),


### PR DESCRIPTION
## What

The authoritative upstream harness (#3370) declares `isPrimitive` in **both** `testTypedArray.js` and `assert.js` (identical bodies). A JS engine — which is what test262.fyi runs — tolerates duplicate top-level function declarations under last-wins, so the reference runner is unaffected; but our **TypeScript front-end** rejects two `function isPrimitive` as a hard `Duplicate identifier 'isPrimitive'` compile error at L1. That failed **~4k TypedArray/Array tests** (host 2,054 + standalone 2,051) in the oracle-v8 harvest.

## How

`assembleOriginalHarness` post-processes the assembled prefix through a new `dedupeTopLevelFunctionDeclarations`: every duplicate top-level `function NAME(` **except the last** is renamed to a dead `NAME$dupK`.

- **Matches JS last-wins exactly** — function declarations hoist, so every call site binds to the surviving final declaration (assert.js's `isPrimitive`, same as the reference runner's last-wins result). The renamed earlier definitions are harmless unused functions.
- **`bodyLineOffset` preserved** — only the name token is rewritten (no lines added/removed), so test-body error line mapping is unchanged.
- **Byte-inert for non-colliding assemblies** — when no name collides the prefix is returned verbatim, so only the TypedArray/Array collision set changes; every other test's assembly is identical.
- **Scoped** — column-0 anchoring means nested functions and named function *expressions* are never touched, and the untouched test body is excluded (prefix-only).

## Validation

- The 3 sample tests (`TypedArray/prototype/at/…`, `TypedArray/prototype/fill/…`, `Array/prototype/every/…`) fail `Duplicate identifier 'isPrimitive'` on `main` and compile clean here, under the worker's **real** options (`skipSemanticDiagnostics: true` — which is why the semantic-only `print`-vs-ambient-DOM collision a naive probe surfaces never reaches the runner).
- Test: `tests/issue-3427-isprimitive-dedup.test.ts` (4 cases). `tsc` / `biome` / `prettier` clean.
- **Runner-side only — no codegen change.** Expect a strongly net-positive test262 delta (compile_error → {pass|fail}).

Consequence of #3370. Issue file rides this PR (also present on the harvest PR #3364 — trivial plan-file reconcile if #3364 lands first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)