### PR TITLE
ci(publish): bump publish-npm Node 20->24 (fix npm 12 EBADENGINE)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
@@ -128,7 +128,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       # OIDC trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
@@ -167,7 +167,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
 
       # `jsr publish` runs `deno publish --unstable-byonm` (bring-your-own-node-


### PR DESCRIPTION
publish-npm.yml ran on Node 20, but `npm install -g npm@latest` (npm 12) requires Node >=22 -> EBADENGINE, breaking every npm publish (v0.61.0 included). Bumps the 3 Node pins to 24 (latest LTS npm 12 supports; Node 25 is excluded by npm 12's engine range). Admin-merged to unblock releases. 🤖 Generated with Claude Code