### PR TITLE
release: v0.62.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.61.0",
+  "version": "0.62.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
0.62.0 — captures the #3369 standalone recovery (standalone 10%→56.1%, js-host 58.3%→64.5%), the oracle-v8 harness reset, the harness-compile speedup (#3374), and the shard rebalance. Cut from current main; publishes via the Node-24-fixed publish-npm workflow. 🤖 Generated with Claude Code