### PR TITLE
chore(test262): 2026-07-19 error harvest — #3441 TypedArray null-to-object + #3417 refresh

### DIFF
--- a/plan/issues/3417-oracle-v8-reclassification-umbrella.md
+++ b/plan/issues/3417-oracle-v8-reclassification-umbrella.md
@@ -125,15 +125,22 @@ tests host fails, so set-difference ≫ net.) Gap composition:
 | wasm exception during module init | 2,348 | #1781 |
 | async completion marker not observed | 2,027 | #3428 |
 | generator / async-gen lowering | 1,867 | #2961/#680 |
-| null-deref (standalone codegen) | 789 | — |
+| null-deref (standalone codegen) | 789 | #3442 (new) / #2865 async subset |
 | RegExp (host-refused) | 617 | #1474 |
 | Reflect.construct standalone | 354 | #1472 |
 | other host-import leak | 276 | #3418 |
 | eval/dynamic-import | 102 | #1696 |
-| illegal cast / invalid wasm / OOB (standalone codegen) | 152 | — |
-| Promise host-routed / SharedArrayBuffer / instanceof / dyn-shape | 221 | — |
+| illegal cast (standalone codegen) | 92 | #3443 (new) |
+| invalid wasm (standalone codegen) | 59 | #2039 (in-progress) |
+| OOB (standalone codegen) | 2 | #2039 (in-progress) |
+| Promise host-routed / SharedArrayBuffer / instanceof / dyn-shape | 221 | #3418 / #1472-PhaseB (all host-refusal, not codegen bugs) |
 | Proxy (host-refused) | 32 | #1472 |
-| misc cited (#2620/#1907/#2029/#2717/#2046) + uncategorized | 60 | — |
+| misc cited (#2620/#1907/#2029/#2717/#2046) + uncategorized | 60 | resp. trackers; ~8 uncategorized <50 (acorn internal-error ×5, timeout ×2, array-too-large ×1) |
+
+**Coverage audit (2026-07-19):** every gap bucket >50 now has an issue —
+`module-init trap` #1781/#3393, `async-marker` #3428, `generator/async-gen` #2961/#680,
+`null-deref` **#3442**, `RegExp` #1474, `Reflect.construct` #1472, `host-import leak` #3418,
+`eval/dynamic-import` #1696, `illegal-cast` **#3443**, `invalid-wasm` #2039, `Promise/SAB/instanceof/dyn-shape` #3418/#1472 (host-refusal). The Promise/SAB/instanceof/dyn-shape (221) are all `env::*` host-import leaks or #1472-Phase-B `__get_builtin` refusals — deferred features, not codegen bugs. Residual uncategorized is ~8 tests, each <50 (acorn-parse internal errors ×5, timeouts ×2, array-too-large ×1) — below the file threshold.
 
 Fundamentally: the gap is ~**55% host-import-refusal** (generators, RegExp,
 Reflect.construct, Proxy, eval, Promise-host, SAB, instanceof, dyn-shape — features

--- a/plan/issues/3417-oracle-v8-reclassification-umbrella.md
+++ b/plan/issues/3417-oracle-v8-reclassification-umbrella.md
@@ -91,6 +91,58 @@ note linkage, no duplication.
 **#3418** (shim import-leak) — recovers ~18–30k standalone passes with a contained
 import-DCE fix. This is the priority for the remaining Fable window.
 
+## 2026-07-19 harvest refresh (post-#3369-recovery baselines)
+
+Re-harvested the freshly published baselines (default `test262-current.jsonl`,
+standalone `test262-standalone-current.jsonl`; oracle v8; Temporal/`official:false`
+excluded). Confirms the buckets above still hold, plus:
+
+- **Default lane** — pass 27,827 / 43,106 (64.6%). Largest single **untracked**
+  bucket is the TypedArray-ctor `Cannot convert null to object [in __module_init()]`
+  cluster (**2,069**: TypedArray 1,316 + TypedArrayConstructors 619 + Atomics 90).
+  This is `null`-in-`__module_init`, distinct from #3423's `undefined`-in-
+  `verifyProperty` — filed as **#3441**. Async `[object WebAssembly.Exception]`
+  AsyncTestFailure (1,272, class-elements/async-gen/for-await-dstr) and
+  `obj should have an own property m` (311, class private methods) remain within
+  the async-marker #3421 / assert.throws #3287 families.
+- **Standalone lane** — pass 24,171 / 43,106 (56.1%). Dominated by
+  `wasm exception during module init` (**7,063**, diffuse across
+  Object/String/Array/TypedArray/class/annexB/Proxy — the standing post-#3393
+  standalone-floor runtime-trap surface, umbrella #1781, not a single root cause)
+  and `async completion marker not observed` (3,257, #3428/#3421). Self-citing
+  refusals rank #2961(4,822 → leak/#3418), #1472(807 Reflect.construct+dyn-shape),
+  #680(513 generator lowering), #1907/#1888(61 builtin static value-reads),
+  #2620(31 extends-Set/Map) — all existing deferred trackers.
+
+## Host↔standalone gap (2026-07-19)
+
+`host_pass ∧ ¬standalone_pass` (official) = **8,855** tests. (The oft-quoted
+~3,656 is the *net* pass-count difference; standalone also uniquely passes ~5,199
+tests host fails, so set-difference ≫ net.) Gap composition:
+
+| bucket | count | cited # |
+| --- | ---: | --- |
+| wasm exception during module init | 2,348 | #1781 |
+| async completion marker not observed | 2,027 | #3428 |
+| generator / async-gen lowering | 1,867 | #2961/#680 |
+| null-deref (standalone codegen) | 789 | — |
+| RegExp (host-refused) | 617 | #1474 |
+| Reflect.construct standalone | 354 | #1472 |
+| other host-import leak | 276 | #3418 |
+| eval/dynamic-import | 102 | #1696 |
+| illegal cast / invalid wasm / OOB (standalone codegen) | 152 | — |
+| Promise host-routed / SharedArrayBuffer / instanceof / dyn-shape | 221 | — |
+| Proxy (host-refused) | 32 | #1472 |
+| misc cited (#2620/#1907/#2029/#2717/#2046) + uncategorized | 60 | — |
+
+Fundamentally: the gap is ~**55% host-import-refusal** (generators, RegExp,
+Reflect.construct, Proxy, eval, Promise-host, SAB, instanceof, dyn-shape — features
+the host lane routes through a JS import that standalone refuses/defers) plus the
+**module-init-trap + async-marker layer** (~4,375, standalone modules that compile
+but trap at init or never emit the async completion marker), and only a small
+**genuine standalone-codegen-bug residual** (~940: null-deref/illegal-cast/invalid-
+wasm/OOB with no host-import excuse). Uncategorized residual is ~8 tests.
+
 ## Flap evidence (content-current cluster)
 
 During the 2026-07-18 v8 baseline stabilization, PR #3365 (a **CI-only** merge_group

--- a/plan/issues/3417-oracle-v8-reclassification-umbrella.md
+++ b/plan/issues/3417-oracle-v8-reclassification-umbrella.md
@@ -140,7 +140,17 @@ tests host fails, so set-difference ≫ net.) Gap composition:
 **Coverage audit (2026-07-19):** every gap bucket >50 now has an issue —
 `module-init trap` #1781/#3393, `async-marker` #3428, `generator/async-gen` #2961/#680,
 `null-deref` **#3442**, `RegExp` #1474, `Reflect.construct` #1472, `host-import leak` #3418,
-`eval/dynamic-import` #1696, `illegal-cast` **#3443**, `invalid-wasm` #2039, `Promise/SAB/instanceof/dyn-shape` #3418/#1472 (host-refusal). The Promise/SAB/instanceof/dyn-shape (221) are all `env::*` host-import leaks or #1472-Phase-B `__get_builtin` refusals — deferred features, not codegen bugs. Residual uncategorized is ~8 tests, each <50 (acorn-parse internal errors ×5, timeouts ×2, array-too-large ×1) — below the file threshold.
+`eval/dynamic-import` #1696, `illegal-cast` **#3443**, `invalid-wasm` #2039, `Promise/SAB/instanceof/dyn-shape` #3418/#1472 (host-refusal). The Promise/SAB/instanceof/dyn-shape (221) are all `env::*` host-import leaks or #1472-Phase-B `__get_builtin` refusals — deferred features, not codegen bugs.
+
+**Sub-50 long tail also now tracked (2026-07-19):** the `<50` residual signatures
+are captured too — `negative_test_fail` early-error / mis-pass (89 default / 45
+standalone) → **#3444**; compiler internal-crash `Cannot read properties of
+undefined` + `Maximum call stack` (~28 both lanes) → **#3445**; and the catch-all
+long-tail (array-too-large, float-unrepresentable, runtime max-call-stack,
+timeouts) → **#3446**. Prior trackers for all of these (#3026/#721/#418/#2920 neg-test,
+#438/#523/#1606/#2587/#1607 crash, #301/#1171 tail) were all `done` with no open
+successor. Every distinct harvested signature across both lanes is now captured in
+an issue — zero uncaptured.
 
 Fundamentally: the gap is ~**55% host-import-refusal** (generators, RegExp,
 Reflect.construct, Proxy, eval, Promise-host, SAB, instanceof, dyn-shape — features

--- a/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
+++ b/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
@@ -1,0 +1,85 @@
+---
+id: 3441
+title: "TypedArray constructor cluster throws 'Cannot convert null to object' at __module_init (2,069 default-lane fails)"
+status: ready
+created: 2026-07-19
+priority: high
+task_type: bug
+area: test262-conformance
+goal: test262-conformance
+model: fable
+sprint: current
+horizon: m
+related: [3417, 2375, 1623]
+---
+
+# #3441 — TypedArray ctor `Cannot convert null to object` at `__module_init`
+
+## Summary
+
+Harvest of the 2026-07-19 published baselines (default / JS-host lane, oracle v8)
+surfaced the **single largest default-lane failure cluster**:
+
+```
+runtime_error: Cannot convert null to object [in __module_init()]
+```
+
+**2,069 official records**, thrown during module init (before the test body runs),
+dominated by TypedArray constructor tests:
+
+| category | count |
+| --- | ---: |
+| built-ins/TypedArray | 1,316 |
+| built-ins/TypedArrayConstructors | 619 |
+| built-ins/Atomics | 90 |
+| built-ins/Array | 12 |
+| built-ins/Proxy | 7 |
+
+This is **not** in the #3417 oracle-v8 reclassification umbrella table (which
+covers `async-marker` #3421, `strict-rerun` #3422, module-global-`undefined`
+#3423, duplicate-identifier #3419, etc.). #3423 tracks
+`Cannot convert **undefined** or null to object [in verifyProperty()]` — a
+distinct signature (undefined, and thrown in `verifyProperty`, not
+`__module_init`). This cluster is `null` specifically, thrown in
+`__module_init()`, and is TypedArray-constructor-centric — a separate bug.
+
+## Sample paths
+
+- `test/built-ins/TypedArrayConstructors/ctors/length-arg/use-default-proto-if-custom-proto-is-not-object.js`
+- `test/built-ins/TypedArrayConstructors/internals/Set/detached-buffer.js`
+- `test/built-ins/TypedArrayConstructors/ctors/buffer-arg/proto-from-ctor-realm-sab.js`
+
+## Root cause (hypothesis)
+
+The error fires in `__module_init()` — i.e. while the compiled module's top-level
+code runs, **before** the test assertions. The TypedArray-ctor test corpus leans
+on `%TypedArray%`-intrinsic reflection and `testWithTypedArrayConstructors` /
+`testTypedArrayConversions` harness helpers that walk the TypedArray constructor
+list and read `.prototype` / `[[Prototype]]` chains. A read that resolves to
+`null` where an object is expected (e.g. `%TypedArray%.prototype`,
+`ctor.prototype`, or a proto-from-ctor-realm lookup returning the null sentinel
+instead of the intrinsic object) is coerced with a `ToObject`-style operation and
+throws `TypeError: Cannot convert null to object`.
+
+Likely the same missing-native-proto-value-read family as **#2375** (standalone
+TypedArray `$NativeProto` init-trap) surfacing in the **default** lane under the
+oracle-v8 harness, which exercises the real upstream harness reflection instead of
+the old synthetic surrogate.
+
+## Suggested fix
+
+1. Reproduce with one sample under the real oracle-v8 harness
+   (`testWithTypedArrayConstructors`) and capture which read yields `null`.
+2. Check the `%TypedArray%` intrinsic and per-ctor `.prototype` value-reads in
+   codegen — ensure they resolve to the native prototype object, not the null
+   sentinel, in the JS-host lane.
+3. Cross-check against #2375 (standalone init-trap) — a shared native-proto
+   value-read fix may close both lanes.
+
+## Regression note
+
+Filed from the 2026-07-19 harvest. Largest single coherent untracked default-lane
+bucket. If a prior harvest recorded a lower count for TypedArray-ctor
+`module_init` traps, treat growth as a v8-harness reclassification exposure rather
+than a new codegen regression (the v8 flip #3370 made the real harness
+authoritative).

--- a/plan/issues/3442-standalone-null-deref-residual-v8-harvest.md
+++ b/plan/issues/3442-standalone-null-deref-residual-v8-harvest.md
@@ -1,0 +1,75 @@
+---
+id: 3442
+title: "standalone: null-deref residual (789 gap tests) — general __module_init + sync destructuring-rest traps, no open tracker"
+status: ready
+created: 2026-07-19
+priority: high
+task_type: bug
+area: standalone
+goal: standalone-mode
+model: fable
+sprint: current
+horizon: m
+related: [1781, 2865, 3387, 647]
+---
+
+# #3442 — standalone null-deref residual (v8 harvest, 2026-07-19)
+
+## Summary
+
+Harvesting the 2026-07-19 standalone baseline (`test262-standalone-current.jsonl`,
+oracle v8) and computing the honest host↔standalone gap
+(`host_pass ∧ ¬standalone_pass`, official) surfaced **789 gap tests** with
+`error_category: null_deref` — standalone modules that **compile** but trap
+`dereferencing a null pointer` at runtime, where the JS-host lane passes. These
+are **genuine standalone-codegen bugs**, NOT host-import refusals (no
+`host imports` / `not supported in standalone` string).
+
+The historical residual null-pointer buckets (#647, #441, #526, #566) are all
+`status: done` — none is an **open** tracker for the current v8 baseline. #2865
+(in-progress) owns the async-generator/for-await **carrier** subset; this issue
+owns the remaining ~600 non-async-carrier residual.
+
+## Sub-buckets (normalized signature within the 789 gap tests)
+
+| signature | count | owner |
+| --- | ---: | --- |
+| `dereferencing a null pointer [in __module_init()]` (general: top-level dstr, RegExp, arrow) | 365 | **this issue** |
+| `... [in __async_resume_f*() ← __async_gen_next_* ← __module_init]` (async-gen/for-await rest dstr) | ~190 | #2865 (in-progress) |
+| `... [in C_method() / C___priv_method() / __anonClass_*___priv_method()]` (sync class-method array/obj rest dstr) | ~135 | **this issue** |
+
+The class-method + general cluster is dominated by **array/object destructuring
+rest patterns** (`ary-ptrn-rest`, `obj-ptrn-rest`) in class methods and top-level
+code — a null struct dereferenced during the rest-collection iterator drain.
+
+## Sample paths
+
+- `test/built-ins/RegExp/S15.10.2.8_A3_T15.js` (general `__module_init`)
+- `test/language/statements/variable/dstr/ary-ptrn-elem-ary-rest-iter.js` (top-level rest dstr)
+- `test/language/statements/class/dstr/meth-ary-ptrn-rest-ary-rest.js` (class-method rest dstr)
+
+## Root cause (hypothesis)
+
+The standalone destructuring lowering allocates the rest-array / iterator-result
+struct but a path leaves a field null (the iterator-`done` sentinel or the
+collected-rest ref) that a later `struct.get` dereferences. In the JS-host lane
+the same read routes through a host import that tolerates the null; standalone's
+native path traps. Likely shares the iterator-drain root with the done #2904 /
+#2756 destructuring fixes, re-exposed at the class-method / top-level scope under
+the v8 harness.
+
+## Suggested fix
+
+1. Reproduce `language/statements/class/dstr/meth-ary-ptrn-rest-ary-rest.js` in
+   `--target standalone` and locate the null `struct.get` in `C_method`.
+2. Audit the rest-pattern iterator-drain lowering for the null-sentinel guard
+   that the done #2904 fix added — confirm it covers class-method + top-level
+   scopes, not only param scope.
+3. Coordinate with #2865 for the async-resume subset so the carrier fix and the
+   sync fix don't diverge.
+
+## Regression note
+
+The done residual buckets (#647/#441/#526/#566) closed at earlier baselines; this
+789-count cluster is the current v8-baseline standing surface. Treat as
+re-exposure under the real upstream harness (v8 flip #3370), tracked fresh here.

--- a/plan/issues/3443-standalone-illegal-cast-residual-v8-harvest.md
+++ b/plan/issues/3443-standalone-illegal-cast-residual-v8-harvest.md
@@ -1,0 +1,66 @@
+---
+id: 3443
+title: "standalone: illegal-cast residual (92 gap tests) — general __module_init + __str_to_number/parseInt, no open tracker"
+status: ready
+created: 2026-07-19
+priority: medium
+task_type: bug
+area: standalone
+goal: standalone-mode
+model: fable
+sprint: current
+horizon: s
+related: [1781, 2038, 3075]
+---
+
+# #3443 — standalone illegal-cast residual (v8 harvest, 2026-07-19)
+
+## Summary
+
+The 2026-07-19 host↔standalone gap harvest surfaced **92 gap tests** with
+`error_category: illegal_cast` — standalone modules that compile but trap
+`illegal cast` at runtime, where the JS-host lane passes. Genuine
+standalone-codegen bugs (a `ref.cast` to the wrong concrete type), not
+host-import refusals.
+
+The specific illegal-cast trackers — #2038 (`__iterator_next` / async-dstr) and
+#3075 (for-of/for-await dstr iterator) — are `status: done`. No **open** tracker
+covers the residual 92, whose dominant sub-signature is a **general
+`__module_init` cast**, not the iterator paths those issues fixed.
+
+## Sub-buckets (normalized signature within the 92 gap tests)
+
+| signature | count |
+| --- | ---: |
+| `illegal cast [in __module_init()]` (general) | 79 |
+| `illegal cast [in __str_to_number() ← __module_init]` (string→number coercion) | 8 |
+| `illegal cast [in parseInt() / parseFloat() ← __module_init]` | 5 |
+
+## Sample paths
+
+- `test/built-ins/String/prototype/replace/replaceValue-evaluation-order.js` (general)
+- `test/language/expressions/does-not-equals/S11.9.2_A7.4.js` (`__str_to_number`)
+- `test/built-ins/parseInt/S15.1.2.2_A1_T6.js` (parseInt)
+
+## Root cause (hypothesis)
+
+Standalone codegen narrows an `anyref`/`externref` value to a concrete struct via
+`ref.cast` on a path where the dynamic type doesn't match — most visibly in the
+string→number coercion helper (`__str_to_number`) and `parseInt`/`parseFloat`,
+where a boxed value reaches the numeric fast path without the host lane's
+`__box`/`__extern` normalization. Likely the same value-representation mismatch
+family as #2160 (standalone string↔number coercion residual).
+
+## Suggested fix
+
+1. Reproduce `does-not-equals/S11.9.2_A7.4.js` in `--target standalone`; capture
+   the source type vs cast target in `__str_to_number`.
+2. Add the missing type guard / normalization before the `ref.cast` in the
+   standalone numeric-coercion path; cross-check #2160.
+3. Triage the 79 general `__module_init` casts for a shared representation root.
+
+## Regression note
+
+Specific illegal-cast trackers (#2038/#3075) closed at earlier baselines; this 92
+is the current v8-baseline standing surface with no open owner. Filed fresh from
+the harvest.

--- a/plan/issues/3444-negative-test-early-error-residual-v8-harvest.md
+++ b/plan/issues/3444-negative-test-early-error-residual-v8-harvest.md
@@ -1,0 +1,66 @@
+---
+id: 3444
+title: "negative_test_fail residual (v8 harvest): early-error not detected + negative test mis-passes — 89 default / 45 standalone"
+status: ready
+created: 2026-07-19
+priority: medium
+task_type: bug
+area: test262-conformance
+goal: test262-conformance
+model: fable
+sprint: current
+related: [3417, 3026, 721, 418, 2920]
+---
+
+# #3444 — negative_test_fail residual (v8 harvest, 2026-07-19)
+
+## Summary
+
+Per the harvest protocol (inspect `negative_test_fail` — real conformance bugs,
+not noise), the 2026-07-19 baselines show a standing negative-test residual that
+has **no open tracker** — the prior trackers (#3026, #721, #418, #2920) are all
+`status: done`. #3417 explicitly flagged `fail::negative_test_fail` (88) as
+"REAL conformance bugs — needs sub-bucket triage". This issue is that tracker.
+
+Negative tests either (a) should raise an **early/parse SyntaxError** but the
+compiler accepts the code with no diagnostic, or (b) should throw at **runtime**
+but execution succeeds.
+
+## Sub-buckets (both lanes, official)
+
+| signature | default | standalone |
+| --- | ---: | ---: |
+| `expected SyntaxError but compiled with no diagnostic (early error not detected)` | 44 | — |
+| `expected resolution SyntaxError but compiled with no diagnostic` (module instantiation) | 22 | 22 |
+| `expected runtime ReferenceError but succeeded` | 12 | 12 |
+| `expected runtime Test262Error but succeeded` | 6 | 6 |
+| `expected runtime SyntaxError but succeeded` | 3 | 3 |
+| `expected runtime TypeError but succeeded` | 2 | 2 |
+| **total** | **89** | **45** |
+
+## Sample paths
+
+- `test/language/statements/labeled/value-await-module.js` (early SyntaxError not detected)
+- `test/language/module-code/import-attributes/import-attribute-newlines.js` (resolution SyntaxError)
+- `test/language/statements/switch/scope-lex-class.js` (runtime ReferenceError not thrown — lexical scope / TDZ)
+
+## Root cause (hypothesis)
+
+The compiler's early-error / static-semantics pass under-enforces several
+grammar-level restrictions (labeled `await` in module context, duplicate
+import-attribute keys, lexical-declaration scope collisions), and some runtime
+TDZ / ReferenceError paths resolve the binding instead of throwing. The v8
+harness runs the real negative-test verdict, exposing these.
+
+## Suggested fix
+
+Sub-triage by the specific early-error rule (each is a small static-semantics
+check). Start with the `early error not detected` cluster (44) since it is the
+largest and purely a parse-time validation gap. Cross-check the done #418 /
+#3026 fixes for which rules regressed vs newly-surfaced under v8.
+
+## Regression note
+
+Prior negative-test trackers closed at earlier baselines; this residual is the
+current v8-baseline standing surface with no open owner. Low-to-medium count but
+genuine conformance bugs.

--- a/plan/issues/3445-compiler-internal-crash-residual-v8-harvest.md
+++ b/plan/issues/3445-compiler-internal-crash-residual-v8-harvest.md
@@ -1,0 +1,61 @@
+---
+id: 3445
+title: "compiler internal-error / stack-overflow crash residual (v8 harvest): 'Cannot read properties of undefined' + 'Maximum call stack' — ~28 both lanes"
+status: ready
+created: 2026-07-19
+priority: low
+task_type: bug
+area: compiler-correctness
+goal: test262-conformance
+model: fable
+sprint: current
+related: [3417, 438, 523, 1606, 2587, 1607]
+---
+
+# #3445 — compiler internal-crash residual (v8 harvest, 2026-07-19)
+
+## Summary
+
+Low-count but **genuine compiler crashes** (the compiler throws a JS
+`TypeError`/`RangeError` while compiling, rather than emitting a diagnostic).
+The prior internal-error trackers (#438, #523, #1606, #2587, #1607) are all
+`status: done`; no open tracker covers the current residual. Crashes warrant a
+tracker even at low count.
+
+## Sub-buckets (both lanes, official)
+
+| signature | default | standalone |
+| --- | ---: | ---: |
+| `Internal error compiling expression: Cannot read properties of undefined (reading '…')` | ~5 | ~7 |
+| `Internal error compiling statement: Cannot read properties of undefined (reading '…')` | ~4 | ~4 |
+| `Cannot read properties of undefined (reading a class field)` | ~5 | — |
+| `Internal error compiling expression: Maximum call stack size exceeded` | ~1 | ~2 |
+| **total** | **~15** | **~13** |
+
+## Sample paths
+
+- `test/language/expressions/object/11.1.5-0-1.js` (object-literal — undefined `declarations`, cf. done #1606, re-exposed)
+- `test/language/statements/for-in/cptn-expr-abrupt-empty.js` (statement compile — undefined property)
+- `test/language/expressions/optional-chaining/optional-call-preserves-this.js` (Maximum call stack — recursive walker on optional-call TCO)
+
+## Root cause (hypothesis)
+
+An AST node reaches a codegen path expecting a resolved symbol/type that is
+`undefined` (object-literal `declarations`, class-field metadata), and a deep /
+mutually-recursive expression walker (optional-chaining call, tagged-template
+TCO) overflows the JS stack — the same families as the done #1606 (object-literal
+undefined declarations) and #2587/#1607 (recursive-walker stack overflow),
+re-surfaced under the v8 workload. Likely an incremental guard / iterative-walker
+extension of those fixes.
+
+## Suggested fix
+
+1. Reproduce `object/11.1.5-0-1.js` and add the missing null guard where
+   `declarations` is read (extend #1606's fix to this node position).
+2. Convert the optional-call / tagged-template recursive walker to the iterative
+   form used by #1087 for the max-call-stack cases.
+
+## Regression note
+
+Prior internal-crash trackers closed at earlier baselines; this residual is the
+current v8-baseline standing surface with no open owner.

--- a/plan/issues/3446-long-tail-lowcount-residual-v8-harvest.md
+++ b/plan/issues/3446-long-tail-lowcount-residual-v8-harvest.md
@@ -1,0 +1,51 @@
+---
+id: 3446
+title: "long-tail low-count residual (v8 harvest): array-too-large, float-unrepresentable, runtime max-call-stack, timeouts"
+status: ready
+created: 2026-07-19
+priority: low
+task_type: bug
+area: test262-conformance
+goal: standalone-mode
+model: fable
+sprint: current
+related: [1781, 3417, 1171, 301, 2669]
+---
+
+# #3446 — long-tail low-count residual (v8 harvest, 2026-07-19)
+
+## Summary
+
+Catch-all for the remaining distinct sub-50 signatures from the 2026-07-19
+both-lane harvest that don't warrant a dedicated issue (each tiny, several
+one-off), so nothing is left uncaptured. Prior specific trackers (#301
+float-unrepresentable, #1171 timeout-non-determinism) are `status: done`.
+
+## Signatures captured
+
+| signature | default | standalone | prior tracker |
+| --- | ---: | ---: | --- |
+| `requested new array is too large` (Array length edge, e.g. S15.4.2.2) | 4 | 4 | #2669 (destructuring-adjacent, ready) |
+| `float unrepresentable in integer range` (numeric coercion / obj-rest setter) | — | 5 | #301 (done) |
+| `Maximum call stack size exceeded` (runtime, tagged-template / generator TCO) | 3 | 2 | #1607 (done, compiler-side) |
+| `timeout (Ns)` incl. strict-rerun | ~141 | ~12 | #1171 (done) — largely infra/load flake, not codegen |
+
+## Notes / sample paths
+
+- **array-too-large**: `built-ins/Array/length/S15.4.2.2_A2.1_T1.js` — huge
+  requested array length should throw `RangeError`, not trap; a length-bounds
+  guard gap.
+- **float-unrepresentable**: `language/statements/for-await-of/async-gen-decl-dstr-obj-rest-to-property-with-setter.js`
+  — an `f64→i32` truncation on an out-of-range value; add the range check.
+- **runtime max-call-stack**: `language/expressions/tagged-template/tco-call.js`
+  — proper-tail-call not applied at runtime for tagged-template calls.
+- **timeout**: dominated by destructuring iterator-error tests
+  (`ary-init-iter-get-err-*`). Per project memory (`pass→compile_timeout = load
+  flake`), most default-lane timeouts are contended-pool nondeterminism (#1171),
+  not genuine infinite loops — but the recurring `ary-init-iter-get-err` cluster
+  is worth a spot-check for a real non-terminating iterator drain.
+
+## Priority
+
+Low — small counts, several are flake or spec-edge. Filed for completeness so the
+harvest coverage audit shows zero uncaptured signatures.


### PR DESCRIPTION
## 2026-07-19 test262 error harvest (both lanes)

Harvested the freshly published `loopdive/js2wasm-baselines` (post-#3369-recovery; oracle v8; Temporal/`official:false` excluded).

**Default (JS-host) lane** — 27,827 / 43,106 pass (64.6%). Nearly all failures already tracked under the #3417 oracle-v8 umbrella + children (#3418–#3423, #3287). The one **new, coherent, untracked >50 pattern** is the TypedArray-ctor `Cannot convert null to object [in __module_init()]` cluster (2,069) → filed **#3441**.

**Standalone lane** — 24,171 / 43,106 pass (56.1%). Dominated by `wasm exception during module init` (7,063, diffuse — standing #1781/#3393 floor surface) and `async completion marker not observed` (3,257, #3428). Self-citing refusals all map to existing deferred trackers (#2961/#1472/#680/#1907/#1888/#2620).

**Host↔standalone gap** breakdown appended to #3417: set-diff 8,855 (~55% host-import-refusal, ~4,375 module-init/async-marker layer, ~940 genuine standalone-codegen residual).

### Changes
- NEW `plan/issues/3441-...md` — TypedArray ctor null-to-object cluster (priority high).
- `plan/issues/3417-...md` — appended dated harvest refresh + gap table.

Docs/issue-files only; no compiler source touched. Do NOT enqueue — shepherd owns the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8