### PR TITLE
ci(publish): auto-publish the GitHub release on tag push

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -181,3 +181,43 @@ jobs:
       # slow-type check would otherwise reject the publish.
       - name: Publish to JSR
         run: npx jsr publish --allow-slow-types
+
+  # Publish (or create) the GitHub Release for the tag so it goes live
+  # automatically alongside the npm/JSR pushes. Previously the GH release object
+  # was created by hand and left in DRAFT state — v0.62.0 published to npm+JSR
+  # but sat as a draft on GitHub until a manual undraft (2026-07-19). This job
+  # closes that gap: on a real tag push, once version verification passes, it
+  # marks the release published + latest (or creates it with auto-generated
+  # notes if it doesn't exist yet). Gated on verify-version success only — a
+  # transient registry hiccup in an individual publish job must not block the
+  # release from going live (each publish target is independent + re-runnable).
+  publish-github-release:
+    name: publish GitHub release
+    runs-on: ubuntu-latest
+    needs: [verify-version, publish-npm, publish-npm-proxy, publish-jsr]
+    # Job-level permissions REPLACE the workflow-level set, so this grants the
+    # contents:write needed for `gh release` (the workflow default is
+    # contents:read); id-token is not needed here.
+    permissions:
+      contents: write
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      needs.verify-version.result == 'success'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Publish or create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $tag exists — undrafting and marking latest."
+            gh release edit "$tag" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          else
+            echo "Creating published release $tag with auto-generated notes."
+            gh release create "$tag" --repo "$GITHUB_REPOSITORY" \
+              --title "$tag" --generate-notes --latest
+          fi
+          echo "GitHub release $tag is published and marked latest."


### PR DESCRIPTION
## Problem

The GitHub **Release object** was created by hand and left in **DRAFT** state. v0.62.0 published to npm (`@loopdive/js2` + `js2wasm` proxy) and JSR, but the GitHub release sat as an unpublished draft (with the `untagged-…` preview URL) until a manual `gh release edit --draft=false --latest` on 2026-07-19. **No workflow ever marked it live** — `publish-npm.yml` touches npm/JSR only.

## Fix

Add a `publish-github-release` job to `publish-npm.yml`. On a real tag push, once `verify-version` passes, it:

- **undrafts + marks-latest** the release for the tag (`gh release edit --draft=false --latest`), or
- **creates** it published with auto-generated notes if it doesn't exist yet (`gh release create --generate-notes --latest`).

Design notes:
- Gated on `verify-version` **success only** (via `always() && needs.verify-version.result == 'success'`) so a transient registry hiccup in an individual publish job can't block the release going live — each publish target is independent and re-runnable.
- Job-level `permissions: contents: write` (workflow default is `contents: read`) grants the `gh release` permission; `id-token` isn't needed here.
- Idempotent: safe to re-run — the exists-check picks edit-vs-create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8