### PR TITLE
ci(#3447): make the #1942 compile-timeout guard contention-tolerant

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1027,28 +1027,51 @@ jobs:
       # pass) converts passes to timeouts and trips no gate. Two cheap signals
       # — both already EMITTED by diff-test262.ts (#1942) into the catastrophic
       # guard's /tmp/cat-diff.txt — gate that surface:
-      #   1. count: pass→compile_timeout above COMPILE_TIMEOUT_THRESHOLD
-      #      (N=25, calibrated above the observed contention-flake floor; the
-      #      #1589 serial retry already absorbs most CT flake, and the
-      #      test262-canary separates non-determinism).
-      #   2. aggregate: sum(compile_ms) over the shared both-compiled set, fail
-      #      when it rises > AGG_COMPILE_TIME_PCT_THRESHOLD (20%). Immune to
-      #      single-test flake and set churn — it measures the same population
-      #      on both sides, so a 20% jump is a real systemic slowdown.
+      #   1. count: pass→compile_timeout tests (the CT count).
+      #   2. aggregate: sum(compile_ms) over the shared both-compiled set (a
+      #      signed Δ%). Immune to single-test flake and set churn — it measures
+      #      the same population on both sides, so a jump is a real systemic
+      #      slowdown.
       # Reuses /tmp/cat-diff.txt from the catastrophic guard (same job, same
       # merged report) so this adds no extra diff run.
-      - name: Compile-time regression guard (#1942)
+      #
+      # Contention-tolerant trigger (#3447 / CI-acceleration review §5-B, lever
+      # L2). The old flat `CT > 50 ⇒ fail` priced runner CPU contention as if it
+      # were a compile-perf regression: it FALSE-EJECTED PR #3365 from the merge
+      # queue TWICE, both times with CT>50 while the aggregate compile-time Δ was
+      # only +3.2% — and a genuine regression that pushes >50 tests past the 30s
+      # per-test timeout cannot leave the aggregate that flat. Real slowdowns
+      # move BOTH signals; contention moves only the count. So:
+      #   • FAIL on (CT > CT_SOFT AND aggregate Δ > +10%)  — both signals agree.
+      #   • FAIL unconditionally on CT > CT_HARD           — survivor-bias hole:
+      #       a pathological slowdown times out its victims, removing them from
+      #       the both-compiled shared set, so the aggregate can stay flat while
+      #       the count spikes into the hundreds. CT_HARD (~boundary-population
+      #       scale) still catches that even when the aggregate arm is fooled.
+      #   • CT_SOFT < CT ≤ CT_HARD with a flat aggregate ⇒ ::warning + run
+      #       summary, NO fail (this is the #3365 contention regime).
+      # The aggregate +20% arm (AGG_COMPILE_TIME_PCT_THRESHOLD) is UNCHANGED and
+      # remains the standalone systemic-slowdown backstop.
+      - name: Compile-time regression guard (#1942, #3447)
         if: env.SHARDS_RAN == 'true'
         env:
-          # Scales with per-shard test density (#3431). The 114→59 merge_group
-          # shard consolidation ~doubles tests-per-shard, so boundary compiles
-          # that flirt with the 30s per-test timeout cross it proportionally more
-          # often under runner CPU contention (25 × 114/59 ≈ 48, rounded to 50
-          # for headroom). This count threshold is the flake-noise filter only;
-          # the aggregate +20% compile-time guard below is UNCHANGED and remains
-          # the systemic-slowdown backstop, so raising this does not weaken real
-          # compile-perf regression detection.
-          COMPILE_TIMEOUT_THRESHOLD: "50"
+          # CT_SOFT: contention-flake floor. A CT above this is only actionable
+          #   when the aggregate arm agrees (see the combined trigger). Scaled
+          #   with per-shard test density (#3431): the 114→59 merge_group shard
+          #   consolidation ~doubles tests-per-shard, so boundary compiles that
+          #   flirt with the 30s per-test timeout cross it proportionally more
+          #   often under CPU contention (25 × 114/59 ≈ 48, rounded to 50).
+          CT_SOFT: "50"
+          # CT_HARD: unconditional-fail ceiling (~boundary-population scale). A CT
+          #   this high is a real pathological slowdown regardless of the
+          #   aggregate — it closes the survivor-bias hole (timed-out victims
+          #   leave the shared set, flattening the aggregate).
+          CT_HARD: "200"
+          # AGG_SOFT_PCT: the aggregate-agreement threshold for the combined
+          #   trigger (both signals must move). +3.2% (the #3365 case) stays well
+          #   under this; a real slowdown that times out 50+ tests does not.
+          AGG_SOFT_PCT: "10"
+          # AGG_COMPILE_TIME_PCT_THRESHOLD: UNCHANGED standalone systemic backstop.
           AGG_COMPILE_TIME_PCT_THRESHOLD: "20"
         run: |
           if [ ! -f /tmp/cat-diff.txt ]; then
@@ -1063,18 +1086,41 @@ jobs:
           AGG_LINE=$(grep -F 'Aggregate compile time (shared' /tmp/cat-diff.txt | head -1)
           AGG_PCT=$(echo "$AGG_LINE" | grep -oE 'Δ [+-]?[0-9]+\.[0-9]+%' | grep -oE '[-]?[0-9]+\.[0-9]+' | head -1)
           AGG_PCT="${AGG_PCT:-0.0}"
-          echo "Compile-time guard: pass→compile_timeout=${CT} (threshold ${COMPILE_TIMEOUT_THRESHOLD}); aggregate compile-time Δ=${AGG_PCT}% (threshold +${AGG_COMPILE_TIME_PCT_THRESHOLD}%)."
-          echo "  ${AGG_LINE}"
-          fail=0
-          if [ "$CT" -gt "$COMPILE_TIMEOUT_THRESHOLD" ]; then
-            echo "::error::COMPILE-TIME regression: ${CT} tests went pass→compile_timeout, exceeding the ${COMPILE_TIMEOUT_THRESHOLD} flake threshold. A spike this large is a real compile-perf regression (compilation got slow enough to cross the 30s per-test timeout), not runner-load noise. See #1942."
-            fail=1
-          fi
-          # Integer-compare the percentage (floor): strip the fractional part
-          # for the shell -gt comparison, so +20.x stays under a 20% threshold
-          # and only +21%+ trips.
+          # Integer floor of the signed percent (for the ×1 -gt comparisons):
+          # strip the fractional part so +20.x stays under a 20 threshold.
           AGG_INT=$(echo "$AGG_PCT" | grep -oE '^-?[0-9]+')
           AGG_INT="${AGG_INT:-0}"
+          echo "Compile-time guard: pass→compile_timeout=${CT} (soft ${CT_SOFT}, hard ${CT_HARD}); aggregate compile-time Δ=${AGG_PCT}% (combined-arm +${AGG_SOFT_PCT}%, standalone +${AGG_COMPILE_TIME_PCT_THRESHOLD}%)."
+          echo "  ${AGG_LINE}"
+          fail=0
+          # 1. Unconditional CT ceiling — closes the survivor-bias hole where a
+          #    pathological slowdown flattens the aggregate by evicting victims.
+          if [ "$CT" -gt "$CT_HARD" ]; then
+            echo "::error::COMPILE-TIME regression: ${CT} tests went pass→compile_timeout, exceeding the hard ceiling ${CT_HARD}. A spike this large is a pathological compile-perf regression regardless of the aggregate Δ (timed-out tests drop out of the shared set, so the aggregate can look flat). See #1942/#3447."
+            fail=1
+          # 2. Combined trigger — both signals must agree for a soft-range CT to
+          #    fail. Contention moves only the count; a real slowdown moves both.
+          elif [ "$CT" -gt "$CT_SOFT" ] && [ "$AGG_INT" -gt "$AGG_SOFT_PCT" ]; then
+            echo "::error::COMPILE-TIME regression: ${CT} tests went pass→compile_timeout (> soft ${CT_SOFT}) AND aggregate compile time rose ${AGG_PCT}% (> +${AGG_SOFT_PCT}%) over the shared both-compiled set. Both signals agree — this is a real compile-perf regression, not runner-load noise. See #1942/#3447."
+            fail=1
+          elif [ "$CT" -gt "$CT_SOFT" ]; then
+            # 3. Soft-range CT with a flat aggregate: the #3365 contention regime.
+            #    Warn + record, do NOT fail (CT>50 at Δ=+3.2% false-ejected #3365
+            #    from the merge queue twice — do not repeat that).
+            echo "::warning::Elevated pass→compile_timeout count ${CT} (> soft ${CT_SOFT}, ≤ hard ${CT_HARD}) but aggregate compile-time Δ is only ${AGG_PCT}% (≤ +${AGG_SOFT_PCT}%). Treating as runner CPU contention, not a compile-perf regression (see #3365). Not failing."
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              {
+                echo "### Compile-time guard: elevated timeout count (contention, not failed)"
+                echo ""
+                echo "- pass→compile_timeout count: **${CT}** (soft ${CT_SOFT}, hard ${CT_HARD})"
+                echo "- aggregate compile-time Δ: **${AGG_PCT}%** (combined-arm threshold +${AGG_SOFT_PCT}%)"
+                echo ""
+                echo "Both signals must agree to fail; only the count moved, so this is priced as runner CPU contention (#3447)."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          # 4. Standalone aggregate backstop (UNCHANGED): a systemic slowdown that
+          #    lifts the whole shared set > +20% fails on its own, independent of CT.
           if [ "$AGG_INT" -gt "$AGG_COMPILE_TIME_PCT_THRESHOLD" ]; then
             echo "::error::COMPILE-TIME regression: aggregate compile time rose ${AGG_PCT}% over the shared both-compiled test set, exceeding the +${AGG_COMPILE_TIME_PCT_THRESHOLD}% threshold. This is a systemic compilation slowdown (the same tests take materially longer to compile). See #1942."
             fail=1

--- a/plan/issues/3447-ci-compile-timeout-guard-contention-tolerant.md
+++ b/plan/issues/3447-ci-compile-timeout-guard-contention-tolerant.md
@@ -1,0 +1,58 @@
+---
+id: 3447
+title: "ci(test262): make the #1942 compile-timeout count guard contention-tolerant"
+status: done
+completed: 2026-07-19
+sprint: current
+priority: high
+horizon: s
+task_type: ci
+area: ci
+goal: maintainability
+---
+
+# ci(test262): make the #1942 compile-timeout count guard contention-tolerant
+
+## Problem
+
+`.github/workflows/test262-sharded.yml` has the "Compile-time regression guard
+(#1942)" step. It failed when the `pass → compile_timeout` COUNT `CT` exceeded a
+flat threshold (`CT > 50 ⇒ fail`). That count is priced by runner CPU
+contention, not by real compile-perf regressions: it **false-ejected PR #3365
+from the merge queue TWICE**, both times with `CT > 50` while the aggregate
+compile-time Δ was only **+3.2%**. A genuine regression that pushes >50 tests
+past the 30s per-test timeout cannot leave the aggregate that flat — real
+slowdowns move BOTH the count and the aggregate; contention moves only the
+count.
+
+Reference: `plan/ci-acceleration-review.md` §5-B (lever L2 / spec B).
+
+## Fix (acceptance criteria)
+
+Replace the flat count trigger in the guard step with:
+
+1. **Fail** only on `(CT > CT_SOFT AND aggregate Δ > +10%)` — both signals must
+   agree. `CT_SOFT = 50`.
+2. **Fail** unconditionally on `CT > CT_HARD` (`= 200`, ~boundary-population
+   scale). Closes the survivor-bias hole: a pathological slowdown times out its
+   victims, removing them from the both-compiled shared set, so the aggregate
+   can stay flat while the count spikes into the hundreds.
+3. `CT_SOFT < CT ≤ CT_HARD` with a flat aggregate ⇒ emit `::warning` + write the
+   count into `$GITHUB_STEP_SUMMARY`, do **not** fail (the #3365 contention
+   regime).
+4. Leave the existing aggregate **+20%** arm UNCHANGED (standalone systemic
+   backstop).
+5. Document the `CT_SOFT` derivation (25 × 114/59 ≈ 48 → 50) so future matrix
+   changes have the rationale.
+6. In-workflow comment documents the thresholds + the #3365 double-ejection
+   evidence (CT>50 at Δ=+3.2% twice) so the rationale is durable.
+
+## Verification (arithmetic dry-run)
+
+- #3365 contention case (CT≈55, Δ=+3.2%): `CT>200` no; `CT>50 && 3>10` no →
+  warning path; `3>20` no → **does NOT fail**. ✓
+- Real pathological regression (CT=300): `CT>200` → **fails** via CT_HARD. ✓
+- Real regression, both signals (CT=80, Δ=+15%): `CT>50 && 15>10` → **fails**. ✓
+- Systemic slowdown, low CT (CT=10, Δ=+25%): standalone `25>20` → **fails**. ✓
+
+CI-workflow-only change; no `src/` touched.


### PR DESCRIPTION
Fixes #3447. CI-workflow-only change (no src), from the CI-acceleration review §5-B (lever L2).

## Problem
The `Compile-time regression guard (#1942)` step failed on a flat `CT > 50 ⇒ fail` (pass→compile_timeout count). That count is priced by runner CPU contention, not real compile-perf regressions — it **false-ejected PR #3365 from the merge queue TWICE**, both with CT>50 while aggregate compile-time Δ was only **+3.2%**. A genuine regression that pushes 50+ tests past the 30s timeout cannot leave the aggregate that flat.

## Fix
- **FAIL** only on `(CT > CT_SOFT[50] AND aggregate Δ > +10%)` — real slowdowns move BOTH signals; contention moves only the count.
- **FAIL** unconditionally on `CT > CT_HARD[200]` — closes the survivor-bias hole: a pathological slowdown times out its victims, evicting them from the both-compiled shared set, so the aggregate can stay flat while the count spikes into the hundreds.
- `CT_SOFT < CT ≤ CT_HARD` with flat aggregate ⇒ `::warning` + $GITHUB_STEP_SUMMARY, no fail (the #3365 contention regime).
- Existing aggregate **+20%** arm UNCHANGED (standalone systemic backstop).
- In-workflow comment documents thresholds + the #3365 double-ejection evidence.

## Verification (bash logic dry-run, all pass)
| case | CT | Δ | result |
|---|---|---|---|
| #3365 contention | 55 | +3.2% | no fail (warn) ✓ |
| below soft | 45 | +3.2% | no fail ✓ |
| pathological | 300 | +1.0% | fail (CT_HARD) ✓ |
| both signals | 80 | +15% | fail (combined) ✓ |
| systemic low-CT | 10 | +25% | fail (standalone) ✓ |
| soft CT, agg <10 | 60 | +9% | no fail (warn) ✓ |
| soft CT, agg >10 | 60 | +11% | fail (combined) ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG