### PR TITLE
ci(#3448): promote push:main baseline from the merge_group's own artifacts (skip 114-job rerun)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1789,6 +1789,20 @@ jobs:
           # The heal-poison step below reads exactly these two files.
           test -s shard-artifacts/test262-results-merged.jsonl
           test -s shard-artifacts/test262-standalone-results-merged.jsonl
+          # #3448 fail-SAFE guard at ingestion: reject a truncated/corrupt group
+          # artifact BEFORE it can reach the promote/commit steps. One JSONL row
+          # per test, so a full run is ~43k rows; a floor of 40000 mirrors the
+          # existing TOTAL>=40000 sanity check in the baselines-push step. A
+          # short artifact fails HERE (job red, old baseline retained) rather
+          # than promoting a partial baseline — the whole point of this change is
+          # to stay strictly no-worse than the full-matrix path.
+          HOST_ROWS=$(wc -l < shard-artifacts/test262-results-merged.jsonl)
+          SA_ROWS=$(wc -l < shard-artifacts/test262-standalone-results-merged.jsonl)
+          echo "Group artifact rows: host=${HOST_ROWS}, standalone=${SA_ROWS}."
+          if [ "$HOST_ROWS" -lt 40000 ] || [ "$SA_ROWS" -lt 40000 ]; then
+            echo "::error::#3448 group artifact ${ART_NAME} looks truncated (host=${HOST_ROWS}, standalone=${SA_ROWS}, floor=40000). Refusing to promote from it; re-run the push or dispatch a full-matrix workflow_dispatch."
+            exit 1
+          fi
           echo "Promoting from merge_group artifact ${ART_NAME} (id=${ART_ID}); skipped the 114-job rerun (#3448)."
 
       # #2099 — heal poison-classified rows BEFORE promotion. A phantom

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -337,6 +337,59 @@ jobs:
   # itself fails so no required-context stub can hide the red shard.
   # =====================================================================
 
+  # #3448 — on push:main, probe for the merge_group's own merged JSONLs
+  # (artifact `test262-group-<sha>`, published for #1956 at ~line 1158). The
+  # merge queue fast-forwards main to the group head SHA, so on push
+  # github.sha EQUALS the artifact key. A HIT lets promote-baseline reuse those
+  # JSONLs and SKIP the 114-job `test262-shard` rerun of the exact tree the
+  # merge_group just validated (the biggest remaining CI-contention win — CI
+  # acceleration review §5-A / lever L1). A MISS (direct push, expired
+  # artifact, doc-only group that uploaded no shard artifact) runs the full
+  # matrix, same fail-safe bias as the `changes` job. Runs on push AND
+  # workflow_dispatch (forcing hit=false on non-push) so `success()`
+  # propagation to `test262-shard`/`promote-baseline` — which now `needs` this
+  # job — holds; skipped on pull_request/merge_group (those don't run
+  # test262-shard's push arm), where the downstream jobs run under `always()`.
+  mg-artifact-probe:
+    name: probe merge_group baseline artifact
+    if: |
+      (github.event_name == 'push' && github.actor != 'github-actions[bot]') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    # actions:read — query the artifacts REST API of THIS repo (a cross-run
+    # read), same permission the #1956 predecessor-group step already uses.
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      hit: ${{ steps.probe.outputs.hit }}
+    steps:
+      - name: Probe for test262-group-<sha> artifact
+        id: probe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # workflow_dispatch (manual rerun) must ALWAYS run a fresh full matrix
+          # — that is the entire point of a manual rerun — so never short-circuit
+          # it via an artifact, even if a same-SHA group artifact still exists.
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "hit=false" >> "$GITHUB_OUTPUT"
+            echo "Non-push event (${{ github.event_name }}) — forcing MISS, full matrix runs."
+            exit 0
+          fi
+          ART_NAME="test262-group-${{ github.sha }}"
+          # Pick the newest non-expired artifact with this exact name.
+          ART_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ART_NAME}&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .id // empty' 2>/dev/null || echo "")
+          if [ -n "$ART_ID" ]; then
+            echo "hit=true" >> "$GITHUB_OUTPUT"
+            echo "HIT: ${ART_NAME} (id=${ART_ID}) present — promote-baseline will reuse it; skipping the 114-job test262-shard matrix."
+          else
+            echo "hit=false" >> "$GITHUB_OUTPUT"
+            echo "MISS: ${ART_NAME} not found (direct push, expired artifact, or doc-only group) — running the full matrix (fail-safe)."
+          fi
+
   test262-shard:
     # Heavy 57-shard test262 (#2519) fires ONLY for baseline/manual contexts
     # — NOT on every PR:
@@ -361,9 +414,16 @@ jobs:
     # concurrently — see scripts/gen-test262-mg-matrix.mjs). This job keeps
     # its ORIGINAL 57-shard x 2-target matrix, UNCHANGED, for push (baseline
     # update) and workflow_dispatch (manual reruns).
-    needs: [changes]
+    needs: [changes, mg-artifact-probe]
+    # #3448 — the push arm is now AND-ed with a MISS on the merge_group
+    # baseline-artifact probe: on a HIT the merge_group already produced the
+    # merged JSONLs for this exact SHA, so this 114-job matrix is SKIPPED and
+    # promote-baseline reuses that artifact. workflow_dispatch always runs the
+    # full matrix (the probe forces hit=false there). Both `changes` and
+    # `mg-artifact-probe` run+succeed on push and workflow_dispatch, so the
+    # implicit `success()` over `needs` holds for both arms.
     if: |
-      (github.event_name == 'push' && github.actor != 'github-actions[bot]') ||
+      ((github.event_name == 'push' && github.actor != 'github-actions[bot]') && needs.mg-artifact-probe.outputs.hit != 'true') ||
       github.event_name == 'workflow_dispatch'
     # Runs in PARALLEL with `gate` — both are independently required by the
     # ruleset (`cheap gate (main-ancestor + lint)` and `merge shard reports`),
@@ -700,7 +760,13 @@ jobs:
       always() &&
       (github.event_name != 'push' || github.actor != 'github-actions[bot]')
     name: merge shard reports
-    needs: [changes, test262-shard, test262-shard-mg]
+    # #3448 — mg-artifact-probe added so SHARD_SKIP_OK can green-skip the
+    # push:main HIT path (the matrix is skipped; promote-baseline sources the
+    # baseline from the merge_group artifact instead). This job already runs
+    # under `always()`, so the probe being skipped on pull_request/merge_group
+    # cannot force-skip it, and its empty output leaves SHARD_SKIP_OK unchanged
+    # in those contexts.
+    needs: [changes, test262-shard, test262-shard-mg, mg-artifact-probe]
     runs-on: ubuntu-latest
     env:
       # 'true' when EITHER the static (test262-shard) or consolidated
@@ -712,8 +778,11 @@ jobs:
       SHARDS_RAN: ${{ (needs.test262-shard.result == 'success' || needs.test262-shard-mg.result == 'success') && 'true' || 'false' }}
       # Green-skip when shards legitimately did not run: a merge_group with no
       # test262-relevant change, OR any pull_request (heavy shards are
-      # merge_group-only under the #2519 slim-down).
-      SHARD_SKIP_OK: ${{ ((github.event_name == 'merge_group' && needs.changes.outputs.run_shards == 'false') || github.event_name == 'pull_request') && 'true' || 'false' }}
+      # merge_group-only under the #2519 slim-down), OR a push:main HIT where
+      # the merge_group's own baseline artifact is reused (#3448 — the matrix is
+      # skipped and promote-baseline sources the JSONLs from that artifact, so
+      # there are no shards to merge here and this required check green-skips).
+      SHARD_SKIP_OK: ${{ ((github.event_name == 'merge_group' && needs.changes.outputs.run_shards == 'false') || github.event_name == 'pull_request' || (github.event_name == 'push' && needs.mg-artifact-probe.outputs.hit == 'true')) && 'true' || 'false' }}
 
     steps:
       - name: Fail if required test262 shards did not succeed
@@ -731,6 +800,11 @@ jobs:
             echo "   (changes.run_shards=='false'); the consolidated 59-job matrix (#3431,"
             echo "   test262-shard-mg) was intentionally skipped. Reporting 'merge shard"
             echo "   reports' green."
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            echo "-> push:main HIT (#3448): the merge_group that just landed already"
+            echo "   published its merged JSONLs as test262-group-${{ github.sha }}. The"
+            echo "   114-job test262-shard rerun was skipped; promote-baseline reuses that"
+            echo "   artifact. Reporting 'merge shard reports' green."
           else
             echo "-> pull_request: heavy test262 shards are merge_group-only under the"
             echo "   #2519 slim-down, so they do not run at PR-time. The cheap gate"
@@ -1637,7 +1711,14 @@ jobs:
     # deliverable; the baseline stays owned by unflagged runs.
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.actor != 'github-actions[bot]' && !(github.event_name == 'workflow_dispatch' && inputs.ir_first)
     name: promote merged report to main baseline
-    needs: merge-report
+    # #3448 — mg-artifact-probe decides where the merged JSONLs come from:
+    # MISS → the `test262-merged-report` artifact built by merge-report from a
+    # fresh matrix (unchanged); HIT → the merge_group's own
+    # `test262-group-<sha>` artifact, skipping the 114-job rerun. Both jobs
+    # run+succeed on push and workflow_dispatch, so the implicit `success()`
+    # over `needs` holds (merge-report green-skips on the HIT path — still
+    # success).
+    needs: [merge-report, mg-artifact-probe]
     runs-on: ubuntu-latest
     # Gate the MAIN_DEPLOY_KEY secret behind a GitHub Environment so only this
     # job — running on a `push`/`workflow_dispatch` against main — can read it.
@@ -1652,6 +1733,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # #3448 — the HIT path downloads test262-group-<sha> via the artifacts
+      # REST API (a cross-run read), same permission the #1956 predecessor
+      # step uses. The top-level `contents: write` would otherwise leave
+      # actions at `none` for this job.
+      actions: read
 
     steps:
       - name: Checkout
@@ -1666,12 +1752,44 @@ jobs:
         with:
           node-version: 25
 
-      - name: Download merged reports
+      # #3448 — MISS path: the full matrix ran and merge-report built +
+      # uploaded `test262-merged-report`. Download it exactly as before.
+      - name: Download merged reports (full-matrix path)
+        if: needs.mg-artifact-probe.outputs.hit != 'true'
         uses: actions/download-artifact@v7
         with:
           path: shard-artifacts
           pattern: test262-merged-report
           merge-multiple: true
+
+      # #3448 — HIT path: the 114-job matrix was skipped. Source the merged
+      # JSONLs from the merge_group's own `test262-group-<sha>` artifact (keyed
+      # by exactly this push's github.sha — the merge queue fast-forwarded main
+      # to the group head SHA). Downloaded via the artifacts REST API, the same
+      # pattern the #1956 predecessor-group step uses (~line 1333). The artifact
+      # holds the two merged JSONLs; the heal-poison step below rebuilds the
+      # report JSONs from them, so the rest of this job is byte-identical to the
+      # full-matrix path.
+      - name: Download merged reports (merge_group artifact, #3448)
+        if: needs.mg-artifact-probe.outputs.hit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ART_NAME="test262-group-${{ github.sha }}"
+          ART_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ART_NAME}&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last | .id // empty')
+          if [ -z "$ART_ID" ]; then
+            echo "::error::#3448 probe reported HIT but artifact ${ART_NAME} is now gone (raced expiry?). Re-run the push, or dispatch workflow_dispatch to force a full-matrix promote."
+            exit 1
+          fi
+          mkdir -p shard-artifacts
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ART_ID}/zip" > /tmp/mg-group.zip
+          unzip -o /tmp/mg-group.zip -d shard-artifacts >/dev/null
+          # The heal-poison step below reads exactly these two files.
+          test -s shard-artifacts/test262-results-merged.jsonl
+          test -s shard-artifacts/test262-standalone-results-merged.jsonl
+          echo "Promoting from merge_group artifact ${ART_NAME} (id=${ART_ID}); skipped the 114-job rerun (#3448)."
 
       # #2099 — heal poison-classified rows BEFORE promotion. A phantom
       # "Binary emit error" (etc.) row from a contaminated sharded worker would

--- a/plan/issues/3448-ci-promote-baseline-from-mergegroup-artifacts.md
+++ b/plan/issues/3448-ci-promote-baseline-from-mergegroup-artifacts.md
@@ -1,0 +1,99 @@
+---
+id: 3448
+title: "ci(test262): promote push:main baseline from the merge_group's own artifacts (skip the 114-job rerun)"
+status: done
+sprint: current
+priority: high
+horizon: m
+task_type: ci
+area: ci
+goal: maintainability
+completed: 2026-07-19
+---
+
+# ci(test262): promote push:main baseline from the merge_group's own artifacts
+
+## Problem
+
+In `.github/workflows/test262-sharded.yml`, on `push:main` (per merged src-PR)
+the `promote-baseline` job waits for a FRESH full `test262-shard` matrix run —
+**114 jobs** (57 shards × 2 targets) — over the exact tree the `merge_group`
+JUST validated. Pure duplication, and those 114 jobs contend with the NEXT
+queue entry's `merge_group` run — the main source of remaining CI contention
+(CI acceleration review, lever L1 / spec A, `plan/ci-acceleration-review.md`
+§5-A).
+
+Key fact: the `merge_group` run already uploads its merged JSONLs keyed by the
+SHA that lands on main — artifact `test262-group-${{ github.event.merge_group.head_sha }}`
+(retention 3 days, built for #1956, at ~`test262-sharded.yml:1158-1167`). The
+merge queue fast-forwards main to that same head SHA, so the subsequent
+`push:main` run's `github.sha` EQUALS the artifact key.
+
+## Fix (acceptance criteria)
+
+1. On `push:main`, a cheap first job (`mg-artifact-probe`) queries the GitHub
+   Actions artifacts API for `test262-group-${github.sha}`. HIT → the merged
+   JSONLs are downloaded and fed to `promote-baseline` directly, **SKIPPING the
+   `test262-shard` matrix entirely**.
+2. MISS (direct push, expired artifact, doc-only group with no shard artifact)
+   → run the full matrix exactly as today (fail-safe — same bias as the
+   `changes` job; also `workflow_dispatch` always runs the full matrix).
+3. The `merge shard reports` required-context semantics on push are unchanged:
+   `merge-report` still runs and reports green on both paths (green-skip on the
+   HIT path via `SHARD_SKIP_OK`, real merged report on the MISS path). No
+   required-check name changes.
+4. One-time validation: the promote output is byte-comparable to a control
+   full-run promote on the same SHA — see "Verification" below.
+5. mg artifact retention (3 d) ≥ promote window — documented assumption below.
+6. Rollback = revert this one workflow diff (self-contained).
+
+## Design
+
+- New job `mg-artifact-probe` (runs on `push` non-bot and `workflow_dispatch`
+  so `success()` propagation to `test262-shard`/`promote-baseline` holds; forces
+  `hit=false` on non-push). Outputs `hit`.
+- `test262-shard` gains `needs: [changes, mg-artifact-probe]` and its push arm
+  is AND-ed with `needs.mg-artifact-probe.outputs.hit != 'true'` — so the
+  114-job matrix is SKIPPED on a HIT and runs on a MISS / `workflow_dispatch`.
+- `merge-report` gains `mg-artifact-probe` in `needs` (it already runs under
+  `always()`, so the probe being skipped on PR/merge_group cannot force-skip
+  it) and its `SHARD_SKIP_OK` is extended with
+  `(push && hit == 'true')` → green-skip on the HIT path, real report on MISS.
+- `promote-baseline` gains `mg-artifact-probe` in `needs` + `actions: read`
+  permission. Its single download step is split: MISS → download the
+  `test262-merged-report` artifact (as today); HIT → download
+  `test262-group-${github.sha}` via the artifacts API (the exact pattern the
+  #1956 predecessor-group step at ~1333-1367 already uses) into
+  `shard-artifacts/`. Both paths land
+  `shard-artifacts/test262-results-merged.jsonl` +
+  `test262-standalone-results-merged.jsonl`; the existing heal-poison step
+  rebuilds the report JSONs from those JSONLs, so the rest of the job is
+  byte-identical between the two paths.
+
+## Verification (AC #4)
+
+The group artifact's JSONLs are the merge_group's own merged shard output over
+the exact SHA that fast-forwards onto main. The push-path full matrix
+(`test262-shard`, 57×2) and the merge_group matrix (`test262-shard-mg`,
+consolidated) partition the SAME test262 corpus at the SAME submodule pin over
+the SAME `github.sha`; their row-union is identical (same tests, same
+pass/fail). `promote-baseline` applies the identical heal-poison +
+build-test262-report pipeline to identical input JSONLs on both paths, so the
+promoted `test262-current.jsonl` / report JSONs are byte-comparable. Control
+check for the PR: on the first post-merge `push:main` HIT, diff the promoted
+`benchmarks/results/test262-current.jsonl` against a `workflow_dispatch`
+(forced-MISS) full-run promote on the same SHA — expected empty diff modulo the
+`baseline_generated_at` timestamp field.
+
+## Assumptions (AC #5)
+
+- `test262-group-<sha>` retention is 3 days (`test262-sharded.yml:1162`); the
+  `push:main` promote fires within seconds of the merge queue fast-forwarding
+  main, so the promote window is minutes, well inside the 3-day retention. An
+  expired/missing artifact simply MISSes → full-matrix fail-safe.
+
+## Notes
+
+- Pairs with #3404 (reduces its blast radius).
+- Ref: `plan/ci-acceleration-review.md` §5-A (lever L1 / spec A).
+</content>


### PR DESCRIPTION
## Problem

On `push:main` (per merged src-PR) `promote-baseline` waited for a FRESH full
`test262-shard` matrix — **114 jobs** (57×2) — over the exact tree the
`merge_group` JUST validated. Pure duplication, and those 114 jobs contend with
the NEXT queue entry's `merge_group` run — the main remaining CI-contention
source (CI acceleration review §5-A / lever L1).

The `merge_group` already uploads its merged JSONLs keyed by the SHA that lands
on main — artifact `test262-group-<head_sha>` (retention 3 d, #1956). The queue
fast-forwards main to that head SHA, so the subsequent `push:main` run's
`github.sha` EQUALS the artifact key.

## Fix (self-contained workflow diff)

- New cheap `mg-artifact-probe` job (push + workflow_dispatch): queries the
  artifacts API for `test262-group-${github.sha}`, outputs `hit`.
- `test262-shard` push arm AND-ed with `hit != 'true'` -> **HIT skips the
  114-job matrix**; MISS (direct push, expired artifact, doc-only group,
  workflow_dispatch -> forced `hit=false`) runs the full matrix, same fail-safe
  bias as `changes`.
- `promote-baseline` sources the two merged JSONLs from `test262-merged-report`
  (MISS, unchanged) or `test262-group-<sha>` via the artifacts API (HIT). The
  existing heal-poison step rebuilds the report JSONs from those JSONLs, so the
  rest of the job is byte-identical on both paths. Gains `actions: read`.
- `merge-report` green-skips the required `merge shard reports` check on the HIT
  path via `SHARD_SKIP_OK`.

## Required-context on BOTH paths (AC #3)

The required check `merge shard reports` = the `merge-report` JOB conclusion. On
every path this job RUNS (`if: always() && (push->!bot)`) and posts a real
SUCCESS conclusion — never "expected/pending":

- **push HIT**: `always()` runs it; "Fail if…" is skipped (`SHARD_SKIP_OK==true`)
  and "No-op pass" RUNS + exits 0 -> job **SUCCESS**. `promote-baseline`
  (`needs: [merge-report, mg-artifact-probe]`, implicit `success()`) fires. The
  skipped `test262-shard`/`mg-artifact-probe` post "skipping", not a pending
  required context (this PR's run shows `probe merge_group baseline artifact` =
  `skipping`, not blocking).
- **push MISS**: probe runs (`hit=false`), full matrix runs, `merge-report`
  builds the real report + uploads `test262-merged-report`, `promote-baseline`
  downloads it. **Byte-identical to today** — only added work is the ~10 s probe.
- **pull_request / merge_group**: probe is skipped; empty `outputs.hit` leaves
  `SHARD_SKIP_OK` untouched -> unchanged. This PR's own run: `merge shard
  reports` = pass, probe = `skipping`.

## Fail-SAFE, not fail-open (AC #3 safety)

Blast radius is push:main promotion, NOT the merge_group gate — a bug here
cannot block merges, only stale the baseline, so failure DIRECTION matters.
Every HIT-path failure mode degrades to old behavior or a red job, never a
silent bad promote:

- artifact missing/expired -> probe **MISS** -> full matrix.
- artifact present but empty -> `test -s` fails -> job red, **old baseline retained**.
- artifact truncated/corrupt -> new **row-count floor (>=40000 rows each**,
  mirroring the existing `TOTAL>=40000` guard) fails the download step -> job
  red, **old baseline retained**.
- The group artifact is only uploaded by a merge_group whose shards ran and
  succeeded (`if: SHARDS_RAN=='true' && merge_group`) after a `test -s` on the
  merged JSONL — so a HIT artifact is a real, complete run of the SAME
  `github.sha`, same quality as a fresh matrix.

## Byte-comparable promote (AC #4)

The group artifact JSONLs are the merge_group's own merged shard output over the
SAME `github.sha`; push-matrix and mg-matrix row-unions are identical.
`promote-baseline` applies the identical heal + build-report pipeline to
identical input -> byte-comparable promote. **Only truly exercisable on a real
push:main (the PR run cannot).** The **FIRST post-merge push:main is the
validation gate**; the fallback if the HIT path misbehaves is the artifact-miss
full-matrix path (safe direction per above). Control check for that first push:
diff the HIT-promoted `test262-current.jsonl` vs a forced-MISS
`workflow_dispatch` full-run promote on the same SHA (empty diff modulo the
`baseline_generated_at` timestamp).

## Acceptance criteria

1. push:main HIT -> promote reuses artifact, skips the 114-job matrix.
2. MISS -> full matrix (fail-safe); workflow_dispatch always full.
3. `merge shard reports` posts SUCCESS on both paths; no name change; MISS
   byte-identical to today.
4. Byte-comparable promote validated on the first post-merge push:main; fail-safe
   fallback documented.
5. mg artifact retention 3 d >> promote window (minutes after FF).
6. Rollback = revert this one diff.

Pairs with #3404. Sibling PR #3447 edits a disjoint region (~1040-1086).

Generated with Claude Code — https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG
