### PR TITLE
fix(#3389 slice 2): async-gen .return()/.throw() consumer methods [DRAFT — held pending #3344]

### DIFF
--- a/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
+++ b/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
@@ -18,6 +18,11 @@ goal: standalone-mode
 umbrella: 3178
 related: [3132, 3387, 3388, 2865, 2906]
 origin: "2026-07-17 fable-3178 umbrella decomposition — #3132 S4 banked slice, re-grounded: __gen_set_return 268 / __gen_return (async combos) / __gen_throw 80 rows."
+# Slice 1: settleReturn terminator — analyzer admission + CFG plan (async-cps.ts)
+# and the emitter arm + validateAsyncCfg (async-frame.ts).
+loc-budget-allow:
+  - src/codegen/async-cps.ts
+  - src/codegen/async-frame.ts
 ---
 
 # #3389 — async-gen `return`/`throw` completion for the driven lane
@@ -143,11 +148,11 @@ origin/main; the stack collapses).
    records `returnExpr` and terminates the body (trailing statements are
    unreachable). Suspend-free operand only (`!containsAwaitOrYield(E)`).
    Promise-typed `E` BAILS on the carrier lane (`implicitYieldAwait !== null &&
-   yieldOperandIsPromiseTyped`) — the §27.6.3.8 return-value Await is deferred
+yieldOperandIsPromiseTyped`) — the §27.6.3.8 return-value Await is deferred
    (correct-or-legacy, same policy as `yield await` / #3120); carrier-off admits
    all suspend-free E (documented promise-return value gap, mirrors #3120).
 3. `AsyncCfgTerminator` gains `{ kind: "settleReturn"; value: AsyncCfgOperand |
-   null; resumeState }`. `planAsyncGenCfg`: when `shape.returnExpr !== undefined`
+null; resumeState }`. `planAsyncGenCfg`: when `shape.returnExpr !== undefined`
    the tail state gets `settleReturn(value, resume→doneState)` and a TRAILING
    `settleDone` state is appended — so the first settling `next()` gives
    `{value: E, done: true}` and every SUBSEQUENT `next()` gives
@@ -163,4 +168,4 @@ with wrapped leak probes + a mixed-module carrier probe.
 
 Slice 2 (consumer `.return()`/`.throw()` on driven frames) is a follow-up.
 Out of scope both slices: `return` inside try/finally (finally-across-suspend),
-yield* delegate return forwarding (§27.6.3.7 7.b — needs #3388+#3389 both).
+yield\* delegate return forwarding (§27.6.3.7 7.b — needs #3388+#3389 both).

--- a/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
+++ b/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
@@ -1,7 +1,8 @@
 ---
 id: 3389
 title: "standalone: `return` completion in driven async-gen bodies (settleReturn terminator) + AsyncGeneratorPrototype.return/.throw residual (~300 rows)"
-status: ready
+status: in-progress
+assignee: ttraenkler/fable-dev-3
 sprint: current
 created: 2026-07-17
 updated: 2026-07-17
@@ -123,3 +124,43 @@ the driven frame's `.return(v)`/`.throw(e)` methods must:
 - The driver-signature change (completion-kind param) touches every driven
   consumer call site — grep `__async_gen_next_` emitters before choosing the
   param vs sibling-function shape.
+
+## Implementation notes (fable-dev-3, 2026-07-18) — Slice 1 in progress
+
+STACKED on #3388's real branch (`fork/issue-3388-asyncgen-yieldstar`, PR #3332)
+per the known-dependency exception — #3389's `settleReturn` sits in the same
+`analyzeAsyncGen`/`planAsyncGenCfg`/`emitAsyncFrameStateMachine` surface #3388
+extended (rtDelegate). PR opens only AFTER #3332 merges (then re-merge
+origin/main; the stack collapses).
+
+### Slice 1 design (top-level `return E` → settleReturn)
+
+1. `AsyncGenShape` gains `returnExpr?: ts.Expression | null` (undefined = no
+   return / fall-through `settleUndefined`+`settleDone`; null = bare `return;`;
+   Expression = `return E`).
+2. `analyzeAsyncGen`: a top-level `ReturnStatement` (statement position, not
+   nested in control flow — `containsOwnScopeReturn` on a LEAD still bails)
+   records `returnExpr` and terminates the body (trailing statements are
+   unreachable). Suspend-free operand only (`!containsAwaitOrYield(E)`).
+   Promise-typed `E` BAILS on the carrier lane (`implicitYieldAwait !== null &&
+   yieldOperandIsPromiseTyped`) — the §27.6.3.8 return-value Await is deferred
+   (correct-or-legacy, same policy as `yield await` / #3120); carrier-off admits
+   all suspend-free E (documented promise-return value gap, mirrors #3120).
+3. `AsyncCfgTerminator` gains `{ kind: "settleReturn"; value: AsyncCfgOperand |
+   null; resumeState }`. `planAsyncGenCfg`: when `shape.returnExpr !== undefined`
+   the tail state gets `settleReturn(value, resume→doneState)` and a TRAILING
+   `settleDone` state is appended — so the first settling `next()` gives
+   `{value: E, done: true}` and every SUBSEQUENT `next()` gives
+   `{value: undefined, done: true}` (§27.6.3.8 completed-frame semantics).
+4. `emitAsyncFrameStateMachine` (async-frame.ts): the `settleReturn` arm mirrors
+   `settleYield` (compute E → externref) but builds `{value: E, done: 1}` (like
+   `settleDone`'s struct but with the real value), settles the result promise,
+   sets STATE=resumeState (the trailing settleDone), spills, returns.
+
+Lockstep is automatic (single `analyzeAsyncGen` gate →
+`isBoundedAsyncGenBody`/`isAsyncGenDriveCandidate`/import-collector), verified
+with wrapped leak probes + a mixed-module carrier probe.
+
+Slice 2 (consumer `.return()`/`.throw()` on driven frames) is a follow-up.
+Out of scope both slices: `return` inside try/finally (finally-across-suspend),
+yield* delegate return forwarding (§27.6.3.7 7.b — needs #3388+#3389 both).

--- a/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
+++ b/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
@@ -189,3 +189,81 @@ top-level `return E` shape. Two follow-ups remain for the full ~268-row bucket:
   rows — the return-completion handler must run the `finally` on the return
   path (out of scope for slices 1–2; needs the async-frame handler-region
   generalization, cross-ref #2906 gap-3 try/finally).
+
+## Slice 2 — implementation-ready spec (fable-dev-3, 2026-07-18)
+
+Full source investigation done; this is a de-risked, ground-truth spec so slice 2
+can be implemented cleanly (fresh, not rushed at a deep session's tail — it
+touches the shared async-gen frame state machine that 5 in-flight PRs ride).
+Two independent sub-slices, ONE PR each.
+
+### Sub-slice 2a — `.return(v)` / `.throw(e)` consumer methods (LOW RISK)
+
+**Key simplification:** bodies with try/finally or catch ACROSS a yield stay
+legacy (that's sub-slice 2b / out of scope). So for every gen the driven lane
+ADMITS, a suspended-at-yield `.return(v)`/`.throw(e)` runs NO further body — it
+just completes the frame. Therefore we do NOT need to kick the resume machine
+or add a MODE_RETURN/MODE_THROW resume path. Just settle + mark-done.
+
+**Mark-done WITHOUT touching the shared dispatch:** set `frame.STATE` to the
+gen's existing `settleDone` state id. A subsequent `.next()` re-dispatches
+there → `{value: undefined, done: true}` (settleDone is entry-independent). No
+done-guard, no change to `emitAsyncFrameStateMachine`'s if-chain (zero
+regression surface on the shared machine).
+
+Steps (all in async-frame.ts + the two dispatch files):
+
+1. `AsyncFrameInfo.settleDoneStateId?: number`. In `ensureAsyncResumeFunction`
+   after `cfg` is built (async-frame.ts:1044), set it to the id of the state
+   whose `terminator.kind === "settleDone"` (exactly one per gen cfg — the last
+   state; for a `return E` body it's the trailing settleDone slice 1 appended).
+2. `emitAsyncGenReturnThrowHelpers(ctx, info, promiseTypeIdx)` next to
+   `emitAsyncGenNextHelper` (async-frame.ts:2530). Two exported funcs
+   `(frame externref, arg externref) -> externref`:
+   - `__async_gen_return_<stem>`: f=cast; p=fresh pending $Promise;
+     f.result_promise=p; build IteratorResult `{value: arg, done: 1}`
+     (`ensureNativeGeneratorResultType(ctx,{externref})`); `rt.fulfillFuncIdx(p,
+result)`; `f.STATE = info.settleDoneStateId`; return p.
+   - `__async_gen_throw_<stem>`: f=cast; p=fresh; f.result_promise=p;
+     `rt.rejectFuncIdx(p, arg)`; `f.STATE = settleDoneStateId`; return p.
+     (`rt = ensureAsyncDriveRuntime(ctx)`; `.fulfillFuncIdx`/`.rejectFuncIdx` —
+     the same handles `emitAsyncFrameStateMachine` uses at async-frame.ts:1247.)
+     §27.6.3.9: a completed-frame `.throw` still rejects — same code path (STATE
+     already at settleDone; reject again is correct). `.return` on a completed
+     frame → `{value: v, done: true}` — same path.
+3. In `emitAsyncGenerator` (async-frame.ts:2457) call the new helper after
+   `emitAsyncGenNextHelper`. Extend `ctx.asyncGenProducers` entry with
+   `returnHelperName`/`throwHelperName` (additive — #2570/#3388 delegate
+   resolution reads `nextHelperName`/`stateTypeIdx`/`decl` only, so new optional
+   fields are inert there).
+4. `tryEmitAsyncGenReturnThrowDispatch(ctx, fctx, receiverExpr, method, argExpr)`
+   in calls.ts, modeled on `tryEmitAsyncGenNextDispatch` (calls.ts:4400) — same
+   `ref.test` producer chain, but call `p.returnHelperName`/`throwHelperName`
+   with (recv, arg). Miss arm: host `__gen_return`/`__gen_throw` only when
+   `asyncGenLegacyBufferEmitted`, else null (host-free floor), mirroring next.
+5. Recognize `.return(v)`/`.throw(e)` (arg count 0 or 1) on the
+   `AsyncGenerator`/`AsyncIterableIterator`/`AsyncIterator` receiver at
+   call-receiver-method.ts:337-349 (the block that today only handles `.next()`
+   and comments "`.throw()`/`.return()` are 3d-iii").
+
+- Corpus: `built-ins/AsyncGeneratorPrototype/{return,throw}` (25 rows) + the
+  `__gen_throw` (80) / `__gen_set_return` combos on simple-body gens.
+- Tests: `.return(v)` on a suspended-at-yield gen → `{v,true}` + subsequent
+  next→`{undefined,true}`; `.throw(e)` → rejected(e) + gen done; `.return`/
+  `.throw` on a completed gen; correct-or-legacy: a gen with try/finally across
+  a yield keeps the legacy path (its `.return` runs finally — 2b).
+
+### Sub-slice 2b — try-across-yield return admission (HIGHER RISK, the corpus multiplier)
+
+WHY slice-1's corpus flip was modest: most `has-return` async-gen corpus files
+wrap the `return` in `try { … yield … } finally { … }` (or catch), which
+`analyzeAsyncGen` bails today (`containsAwaitOrYield` on the try lead + no
+handler-region support in the GEN cfg). Admitting them needs the #2906 Gap-3
+handler-region machinery (finalizer inline copy + abrupt-path catch replay,
+async-frame.ts:1833-1871) EXTENDED to the async-gen settleYield/settleReturn
+terminators: a `.return()`/`.throw()` or a body `return` that crosses a try must
+run the `finally` on the completion path before settling. This is the genuinely
+hard part (handler regions interacting with the yield suspend/resume + the
+return completion) and should be its own carefully-validated PR after 2a, using
+the #3132 S2 lockstep tests as the mix-safety template. Out of scope until 2a
+lands and the handler-region-in-gen design gets an architect pass.

--- a/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
+++ b/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
@@ -20,9 +20,15 @@ related: [3132, 3387, 3388, 2865, 2906]
 origin: "2026-07-17 fable-3178 umbrella decomposition — #3132 S4 banked slice, re-grounded: __gen_set_return 268 / __gen_return (async combos) / __gen_throw 80 rows."
 # Slice 1: settleReturn terminator — analyzer admission + CFG plan (async-cps.ts)
 # and the emitter arm + validateAsyncCfg (async-frame.ts).
+# Slice 2a: .return()/.throw() drivers (async-frame.ts) + consumer dispatch
+# (calls.ts) + recognition (call-receiver-method.ts) + producer registry
+# (context/types.ts).
 loc-budget-allow:
   - src/codegen/async-cps.ts
   - src/codegen/async-frame.ts
+  - src/codegen/expressions/calls.ts
+  - src/codegen/expressions/call-receiver-method.ts
+  - src/codegen/context/types.ts
 ---
 
 # #3389 — async-gen `return`/`throw` completion for the driven lane

--- a/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
+++ b/plan/issues/3389-standalone-asyncgen-return-throw-completion.md
@@ -169,3 +169,23 @@ with wrapped leak probes + a mixed-module carrier probe.
 Slice 2 (consumer `.return()`/`.throw()` on driven frames) is a follow-up.
 Out of scope both slices: `return` inside try/finally (finally-across-suspend),
 yield\* delegate return forwarding (§27.6.3.7 7.b — needs #3388+#3389 both).
+
+## Slice 1 landed — Documented next slices (fable-dev-3, 2026-07-18)
+
+Slice 1 (settleReturn terminator, PR opened post-#3388-merge) admits the clean
+top-level `return E` shape. Two follow-ups remain for the full ~268-row bucket:
+
+- **Slice 2 — consumer `.return()` / `.throw()` on DRIVEN frames**
+  (`AsyncGeneratorPrototype/{return,throw}` rows + `__gen_throw` combos): add
+  `__async_gen_return_<stem>` / `__async_gen_throw_<stem>` siblings (or a
+  completion-kind param on the existing `__async_gen_next_<stem>` driver) that
+  settle/reject a suspended-at-yield or completed frame. See the Slice 2 block
+  in the Implementation Plan above.
+- **try-across-yield follow-up (the corpus multiplier)**: the has-return
+  async-gen CORPUS files overwhelmingly wrap the `return` in `try`/`catch`/
+  `finally` across a `yield` (e.g. `try { yield* x } catch(e) { } return thrown`),
+  or combine it with `yield*` return-forwarding (§27.6.3.7 7.b). Those stay
+  legacy after slice 1 (correct-or-legacy) and are what gates most of the 268
+  rows — the return-completion handler must run the `finally` on the return
+  path (out of scope for slices 1–2; needs the async-frame handler-region
+  generalization, cross-ref #2906 gap-3 try/finally).

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1020,6 +1020,20 @@ export type AsyncCfgTerminator =
       /** State entered on the next `next()` kick after this yield. */
       readonly resumeState: number;
     }
+  | {
+      // (#3389) Async-generator `return E` completion: fulfil the CURRENT
+      // `next()`-promise with an IteratorResult `{value: E, done: true}`
+      // (§27.6.3.8 with a return completion — distinct from `settleDone`'s
+      // `{value: undefined, done: true}`), set STATE=resumeState (a trailing
+      // `settleDone` state), and `return`. Every SUBSEQUENT `next()` kick then
+      // re-dispatches at that `settleDone`, giving `{value: undefined, done:
+      // true}` on a completed frame.
+      readonly kind: "settleReturn";
+      /** The returned value. `null` ⇒ bare `return;` (value undefined). */
+      readonly value: AsyncCfgOperand | null;
+      /** State entered on the next `next()` kick (the trailing settleDone). */
+      readonly resumeState: number;
+    }
   | { readonly kind: "settleDone" }; // async-gen body end — fulfil `{value: undefined, done: true}`
 
 /** One basic block of the async CFG. */
@@ -2317,6 +2331,17 @@ function yieldOperandIsPromiseTyped(oracle: TypeOracle, operand: ts.Expression):
 interface AsyncGenShape {
   readonly segments: AsyncGenYield[];
   readonly tailLeads: ts.Statement[];
+  /**
+   * (#3389) A top-level `return` completion terminating the body:
+   *   - `undefined` — no top-level return (fall-through ⇒ `settleDone`,
+   *     `{value: undefined, done: true}`);
+   *   - `null` — bare `return;` (also `{value: undefined, done: true}`, but via
+   *     a return completion — observable only with `finally`, which stays
+   *     bailed, so slice 1 emits it identically to fall-through);
+   *   - `ts.Expression` — `return E` ⇒ `settleReturn(E)`, `{value: E, done: true}`.
+   * `tailLeads` are the statements before the return (they run before it settles).
+   */
+  readonly returnExpr?: ts.Expression | null;
 }
 
 /** Recognise the bounded async-gen body; return its segment list, or `null`
@@ -2444,6 +2469,25 @@ function analyzeAsyncGen(
       }
       leads = [];
       continue;
+    }
+    // (#3389) A TOP-LEVEL `return E` / bare `return;` — a return completion that
+    // terminates the body. Admitted as a `settleReturn` terminator (below). Only
+    // a DIRECT top-level statement (a return nested in control flow is still
+    // caught by `containsOwnScopeReturn` on a LEAD and bails — correct-or-legacy).
+    // The operand must be suspend-free; a Promise-typed operand on the CARRIER
+    // lane bails (the §27.6.3.8 return-value Await is deferred, same policy as
+    // `yield await` / #3120 — carrier-off admits it with the documented
+    // promise-return value gap). Statements after a top-level return are
+    // unreachable, so we stop here (`leads` become the return state's tail).
+    if (ts.isReturnStatement(st)) {
+      const operand = st.expression;
+      if (operand !== undefined) {
+        if (containsAwaitOrYield(operand)) return null; // `return await P` / nested — follow-up
+        if (implicitYieldAwait !== null && yieldOperandIsPromiseTyped(implicitYieldAwait.oracle, operand)) {
+          return null; // Promise-typed return on the carrier lane — deferred
+        }
+      }
+      return { segments, tailLeads: leads, returnExpr: operand ?? null };
     }
     // A LEAD statement: must be suspend-free (a yield/await nested in control
     // flow needs expression-level suspend numbering) and return-free.
@@ -2827,6 +2871,23 @@ export function planAsyncGenCfg(
       });
       id += 1;
     }
+  }
+  // (#3389) A top-level `return E` terminates with `settleReturn(E)` — the tail
+  // state runs the pre-return leads then fulfils `{value: E, done: true}` and
+  // suspends into a TRAILING `settleDone` state, so the first settling `next()`
+  // delivers E-with-done and every subsequent `next()` on the completed frame
+  // delivers `{value: undefined, done: true}`. A bare `return;` (returnExpr ===
+  // null) carries a `null` value ⇒ `{value: undefined, done: true}` directly.
+  if (shape.returnExpr !== undefined) {
+    const value: AsyncCfgOperand | null = shape.returnExpr === null ? null : shape.returnExpr;
+    states.push({
+      id,
+      resumeFrom: null,
+      lead: asLead(shape.tailLeads),
+      terminator: { kind: "settleReturn", value, resumeState: id + 1 },
+    });
+    states.push({ id: id + 1, resumeFrom: null, lead: [], terminator: { kind: "settleDone" } });
+    return { states, handlers: [] };
   }
   states.push({ id, resumeFrom: null, lead: asLead(shape.tailLeads), terminator: { kind: "settleDone" } });
   return { states, handlers: [] };

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -950,6 +950,8 @@ function validateAsyncCfg(cfg: AsyncCfgPlan): string | null {
     if (t.kind === "suspend" && !inRange(t.resumeState)) return `suspend.resumeState ${t.resumeState} out of range`;
     if (t.kind === "settleYield" && !inRange(t.resumeState))
       return `settleYield.resumeState ${t.resumeState} out of range`;
+    if (t.kind === "settleReturn" && !inRange(t.resumeState))
+      return `settleReturn.resumeState ${t.resumeState} out of range`;
     if (t.kind === "goto" && !inRange(t.target)) return `goto.target ${t.target} out of range`;
     if (t.kind === "condGoto" && (!inRange(t.whenTrue) || !inRange(t.whenFalse))) {
       return `condGoto targets ${t.whenTrue}/${t.whenFalse} out of range`;
@@ -1710,6 +1712,41 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
           out.push({ op: "call", funcIdx: settleFulfillIdx });
           out.push({ op: "drop" });
           // Suspend: STATE=resumeState, persist spills, return (await the next kick).
+          out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.resumeState));
+          out.push(...storeSpills(info, resumeFctx, frameLocal));
+          out.push({ op: "return" });
+          break;
+        }
+        case "settleReturn": {
+          // (#3389) `return E` completion — fulfil the current `next()`-promise
+          // with `{value: E, done: true}` (§27.6.3.8 with a return completion),
+          // set STATE=resumeState (the trailing settleDone), persist spills, and
+          // `return`. The next `next()` kick re-dispatches at settleDone →
+          // `{value: undefined, done: true}` on the completed frame. Mirrors
+          // `settleYield` but with done=1 and no back-edge.
+          const resultTypeIdx = info.asyncGenResultTypeIdx!;
+          if (term.value === null) {
+            out.push({ op: "ref.null.extern" }); // bare `return;` → undefined
+          } else {
+            const vt = isEmitOperand(term.value)
+              ? term.value.emit(ctx, resumeFctx)
+              : compileExpression(ctx, resumeFctx, term.value);
+            if (vt !== null && vt !== undefined) {
+              coerceType(ctx, resumeFctx, vt as ValType, { kind: "externref" });
+            } else {
+              out.push({ op: "ref.null.extern" });
+            }
+          }
+          out.push({ op: "local.set", index: yieldValLocal });
+          // result_promise.fulfil( IteratorResult{value: retVal, done: 1} )
+          out.push({ op: "local.get", index: resultPromiseLocal });
+          out.push({ op: "local.get", index: yieldValLocal });
+          out.push({ op: "i32.const", value: 1 }); // done = true
+          out.push({ op: "struct.new", typeIdx: resultTypeIdx });
+          out.push({ op: "extern.convert_any" });
+          out.push({ op: "call", funcIdx: settleFulfillIdx });
+          out.push({ op: "drop" });
+          // Complete the frame: STATE=resumeState (settleDone), persist spills, return.
           out.push(...setStateI32FromConst(info, frameLocal, STATE_FIELD, term.resumeState));
           out.push(...storeSpills(info, resumeFctx, frameLocal));
           out.push({ op: "return" });

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -319,6 +319,14 @@ export interface AsyncFrameInfo {
   /** (#2906 slice 3d-i) `{value: externref, done: i32}` IteratorResult struct typeIdx (async-gen only). */
   asyncGenResultTypeIdx?: number;
   /**
+   * (#3389 slice 2a) The `settleDone` state id of this gen's CFG. The
+   * `.return()`/`.throw()` driver helpers set `frame.STATE` to it after
+   * settling/rejecting, so a subsequent `.next()` re-dispatches into settleDone
+   * → `{value: undefined, done: true}` — completing the frame WITHOUT touching
+   * the shared resume dispatch. Set in `ensureAsyncResumeFunction`; async-gen only.
+   */
+  settleDoneStateId?: number;
+  /**
    * (#2865) Capture-cell metadata of a NESTED producer (lifted with captures
    * as leading params — nested-declarations.ts). The frame captures the cells
    * as param fields; the resume body must deref reads/writes through them, so
@@ -1048,6 +1056,15 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     reportError(ctx, info.decl, `internal: async CFG plan violates the emitter contract — ${cfgError} (#2906)`);
     info.resumeFuncIdx = -1;
     return -1;
+  }
+
+  // (#3389 slice 2a) Record this gen's `settleDone` state id so the
+  // `.return()`/`.throw()` drivers can complete the frame by re-pointing STATE
+  // there (subsequent `.next()` → `{value: undefined, done: true}`). Exactly one
+  // settleDone per gen cfg (the terminal state).
+  if (info.asyncGen) {
+    const doneState = cfg.states.find((s) => s.terminator.kind === "settleDone");
+    if (doneState !== undefined) info.settleDoneStateId = doneState.id;
   }
 
   // Host backend never touches the native scheduler (no `$Promise` struct, no
@@ -2455,6 +2472,8 @@ export function emitAsyncGenerator(ctx: CodegenContext, fctx: FunctionContext, d
 
   // Per-gen re-entrant next() driver + the generic reader probes (once/module).
   emitAsyncGenNextHelper(ctx, info, promiseTypeIdx);
+  // (#3389 slice 2a) Per-gen `.return(v)` / `.throw(e)` drivers.
+  emitAsyncGenReturnThrowHelpers(ctx, info, promiseTypeIdx);
   ensureAsyncGenReaderProbes(ctx, promiseTypeIdx, resultTypeIdx);
 
   // (#2865) Register the producer so (a) the `.next()` runtime dispatch chain
@@ -2468,6 +2487,8 @@ export function emitAsyncGenerator(ctx: CodegenContext, fctx: FunctionContext, d
     ctx.asyncGenProducers.set(stem, {
       stateTypeIdx: info.stateTypeIdx,
       nextHelperName: `__async_gen_next_${stem}`,
+      returnHelperName: `__async_gen_return_${stem}`,
+      throwHelperName: `__async_gen_throw_${stem}`,
       decl,
     });
   }
@@ -2574,6 +2595,103 @@ function emitAsyncGenNextHelper(ctx: CodegenContext, info: AsyncFrameInfo, promi
     exported: false,
   });
   ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+}
+
+/**
+ * (#3389 slice 2a) Build + export the per-gen `.return(v)` / `.throw(e)` drivers
+ * `__async_gen_return_<stem>(frame, arg) -> Promise` /
+ * `__async_gen_throw_<stem>(frame, arg) -> Promise`.
+ *
+ * For every body the DRIVEN lane admits, try/finally + catch ACROSS a yield stay
+ * legacy (2b), so a suspended-at-yield `.return`/`.throw` runs NO further body —
+ * it just COMPLETES the frame. So the drivers do not kick the resume machine:
+ *   `.return(v)`: mint a fresh pending result promise, store it, fulfil it with
+ *     `{value: v, done: true}` (§27.6.3.8 return completion), and complete the
+ *     frame by re-pointing `frame.STATE` at its `settleDone` state (a subsequent
+ *     `.next()` then re-dispatches there → `{value: undefined, done: true}`).
+ *   `.throw(e)`: mint + store the promise, REJECT it with `e` (§27.6.3.9), and
+ *     complete the frame the same way.
+ * A completed frame's `.return`/`.throw` takes the identical path (STATE is
+ * already at settleDone; settling/rejecting a fresh promise is correct). No
+ * change to the shared resume dispatch — zero regression surface on it.
+ */
+function emitAsyncGenReturnThrowHelpers(ctx: CodegenContext, info: AsyncFrameInfo, promiseTypeIdx: number): void {
+  const stem = sanitizeTypeName(info.functionName);
+  const rt = ensureAsyncDriveRuntime(ctx);
+  const resultTypeIdx = ensureNativeGeneratorResultType(ctx, { kind: "externref" });
+  const frameRef: ValType = { kind: "ref", typeIdx: info.stateTypeIdx };
+  const promiseRef: ValType = { kind: "ref", typeIdx: promiseTypeIdx };
+  const doneStateId = info.settleDoneStateId ?? 0;
+
+  // Shared prologue: cast the carrier, mint a fresh pending result promise, store
+  // it into `frame.result_promise`. Leaves the frame ref in $f (local 2) and the
+  // promise ref in $p (local 3). Params: 0 = frame externref, 1 = arg externref.
+  const prologue = (fLocal: number, pLocal: number): Instr[] => [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: info.stateTypeIdx },
+    { op: "local.set", index: fLocal },
+    { op: "i32.const", value: PROMISE_STATE_PENDING },
+    { op: "ref.null.extern" },
+    { op: "ref.null.extern" },
+    { op: "struct.new", typeIdx: promiseTypeIdx },
+    { op: "local.set", index: pLocal },
+    { op: "local.get", index: fLocal },
+    { op: "local.get", index: pLocal },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.resultPromiseFieldIdx },
+  ];
+  // Shared epilogue: complete the frame (STATE = settleDone) and return $p.
+  const epilogue = (fLocal: number, pLocal: number): Instr[] => [
+    { op: "local.get", index: fLocal },
+    { op: "i32.const", value: doneStateId },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+    { op: "local.get", index: pLocal },
+    { op: "extern.convert_any" },
+  ];
+
+  const register = (name: string, settleIdx: number, buildValue: (fLocal: number, pLocal: number) => Instr[]): void => {
+    if (ctx.funcMap.has(name)) return;
+    const typeIdx = addFuncType(
+      ctx,
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+      `${name}_type`,
+    );
+    const funcIdx = mintDefinedFunc(ctx);
+    ctx.funcMap.set(name, funcIdx);
+    const fLocal = 2;
+    const pLocal = 3;
+    const body: Instr[] = [
+      ...prologue(fLocal, pLocal),
+      // settle: settleIdx(p, <value>) → drop
+      { op: "local.get", index: pLocal },
+      ...buildValue(fLocal, pLocal),
+      { op: "call", funcIdx: settleIdx },
+      { op: "drop" },
+      ...epilogue(fLocal, pLocal),
+    ];
+    pushDefinedFunc(ctx, funcIdx, {
+      name,
+      typeIdx,
+      locals: [
+        { name: "$f", type: frameRef },
+        { name: "$p", type: promiseRef },
+      ],
+      body,
+      exported: false,
+    });
+    ctx.mod.exports.push({ name, desc: { kind: "func", index: funcIdx } });
+  };
+
+  // `.return(v)` → fulfil with IteratorResult {value: arg, done: true}.
+  register(`__async_gen_return_${stem}`, rt.fulfillFuncIdx, () => [
+    { op: "local.get", index: 1 }, // arg (value)
+    { op: "i32.const", value: 1 }, // done = true
+    { op: "struct.new", typeIdx: resultTypeIdx },
+    { op: "extern.convert_any" },
+  ]);
+  // `.throw(e)` → reject with the raw reason `arg`.
+  register(`__async_gen_throw_${stem}`, rt.rejectFuncIdx, () => [{ op: "local.get", index: 1 }]);
 }
 
 /**

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1698,7 +1698,18 @@ export interface CodegenContext {
    * `__async_gen_next_<stem>` helper typed for the FIRST gen's frame — a
    * guaranteed `ref.cast` trap for the second).
    */
-  asyncGenProducers?: Map<string, { stateTypeIdx: number; nextHelperName: string; decl: ts.Node }>;
+  asyncGenProducers?: Map<
+    string,
+    {
+      stateTypeIdx: number;
+      nextHelperName: string;
+      decl: ts.Node;
+      /** (#3389 slice 2a) `__async_gen_return_<stem>` — the `.return(v)` driver. */
+      returnHelperName?: string;
+      /** (#3389 slice 2a) `__async_gen_throw_<stem>` — the `.throw(e)` driver. */
+      throwHelperName?: string;
+    }
+  >;
   /**
    * (#2865) True once ANY async generator was emitted on the LEGACY buffer path
    * (`__create_async_generator`). The `.next()` runtime dispatch chain uses this

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -130,6 +130,7 @@ import {
   sourceHasMethodReassignment,
   standaloneThenMissArmCanBeNative,
   tryEmitAsyncGenNextDispatch,
+  tryEmitAsyncGenReturnThrowDispatch,
 } from "./calls.js";
 
 /**
@@ -335,15 +336,30 @@ export function compileReceiverMethodCall(
   }
 
   // (#2865) `.next()` on a DRIVEN async-generator object (typed receiver).
-  // `next(v)` sent-value delivery + `.throw()`/`.return()` are 3d-iii.
+  // `next(v)` sent-value delivery is still 3d-iii; `.return()`/`.throw()` are
+  // now handled (#3389 slice 2a).
   {
     const recvSymName = receiverType.getSymbol()?.name;
-    if (
-      propAccess.name.text === "next" &&
-      expr.arguments.length === 0 &&
-      (recvSymName === "AsyncGenerator" || recvSymName === "AsyncIterableIterator" || recvSymName === "AsyncIterator")
-    ) {
+    const isAsyncGenRecv =
+      recvSymName === "AsyncGenerator" || recvSymName === "AsyncIterableIterator" || recvSymName === "AsyncIterator";
+    if (isAsyncGenRecv && propAccess.name.text === "next" && expr.arguments.length === 0) {
       const dispatched = tryEmitAsyncGenNextDispatch(ctx, fctx, propAccess.expression);
+      if (dispatched !== null) return dispatched;
+    }
+    // (#3389 slice 2a) `.return(v)` / `.throw(e)` on a driven async-gen — the
+    // consumer-completion protocol (§27.6.3.8/.9). One optional arg.
+    if (
+      isAsyncGenRecv &&
+      (propAccess.name.text === "return" || propAccess.name.text === "throw") &&
+      expr.arguments.length <= 1
+    ) {
+      const dispatched = tryEmitAsyncGenReturnThrowDispatch(
+        ctx,
+        fctx,
+        propAccess.expression,
+        propAccess.name.text,
+        expr.arguments[0],
+      );
       if (dispatched !== null) return dispatched;
     }
   }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4446,6 +4446,85 @@ export function tryEmitAsyncGenNextDispatch(
 }
 
 /**
+ * (#3389 slice 2a) `.return(v)` / `.throw(e)` on a DRIVEN async-generator
+ * receiver — the sibling of {@link tryEmitAsyncGenNextDispatch}. Routes to the
+ * per-gen `__async_gen_return_<stem>` / `__async_gen_throw_<stem>` driver (which
+ * settles/rejects a fresh result promise and completes the frame). `method` is
+ * `"return"` or `"throw"`; `argExpr` is the single optional arg (undefined → the
+ * `ref.null.extern` sentinel). Runtime-dispatched by `ref.test`ing each
+ * registered producer's frame struct, exactly like `.next()`.
+ *
+ * Miss arm: the legacy host `__gen_return`/`__gen_throw` is kept ONLY when a
+ * legacy buffer async gen was emitted (`asyncGenLegacyBufferEmitted`); else a
+ * plain null result, so an all-driven module stays host-free. Returns null
+ * (fall through) off the standalone/wasi lane or when no driven producers exist.
+ */
+export function tryEmitAsyncGenReturnThrowDispatch(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiverExpr: ts.Expression,
+  method: "return" | "throw",
+  argExpr: ts.Expression | undefined,
+): ValType | null {
+  const producers = ctx.asyncGenProducers;
+  if (ctx.standalone !== true && ctx.wasi !== true) return null;
+  if (producers === undefined || producers.size === 0) return null;
+  // Evaluate the receiver ONCE into an externref local.
+  const recvLocal = allocLocal(fctx, `__agen_rt_recv_${fctx.locals.length}`, { kind: "externref" });
+  const rt = compileExpression(ctx, fctx, receiverExpr, { kind: "externref" });
+  if (rt !== null && rt !== undefined && (rt as ValType).kind !== "externref") {
+    coerceType(ctx, fctx, rt as ValType, { kind: "externref" });
+  }
+  fctx.body.push({ op: "local.set", index: recvLocal });
+  // Evaluate the arg ONCE into an externref local (undefined → null sentinel).
+  const argLocal = allocLocal(fctx, `__agen_rt_arg_${fctx.locals.length}`, { kind: "externref" });
+  if (argExpr !== undefined) {
+    const at = compileExpression(ctx, fctx, argExpr, { kind: "externref" });
+    if (at !== null && at !== undefined && (at as ValType).kind !== "externref") {
+      coerceType(ctx, fctx, at as ValType, { kind: "externref" });
+    }
+  } else {
+    fctx.body.push({ op: "ref.null.extern" });
+  }
+  fctx.body.push({ op: "local.set", index: argLocal });
+  // funcMap lookups AFTER the receiver/arg compiles (which may shift indices).
+  const hostName = method === "return" ? "__gen_return" : "__gen_throw";
+  const wantHostFallback = ctx.asyncGenLegacyBufferEmitted === true;
+  const hostIdx = wantHostFallback ? ctx.funcMap.get(hostName) : undefined;
+  let chain: Instr[] =
+    hostIdx !== undefined
+      ? [
+          { op: "local.get", index: recvLocal },
+          { op: "local.get", index: argLocal },
+          { op: "call", funcIdx: hostIdx },
+        ]
+      : [{ op: "ref.null.extern" }];
+  for (const p of [...producers.values()].reverse()) {
+    const helperName = method === "return" ? p.returnHelperName : p.throwHelperName;
+    if (helperName === undefined) continue;
+    const helperIdx = ctx.funcMap.get(helperName);
+    if (helperIdx === undefined) continue;
+    chain = [
+      { op: "local.get", index: recvLocal },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: p.stateTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "externref" } },
+        then: [
+          { op: "local.get", index: recvLocal },
+          { op: "local.get", index: argLocal },
+          { op: "call", funcIdx: helperIdx },
+        ],
+        else: chain,
+      },
+    ];
+  }
+  fctx.body.push(...chain);
+  return { kind: "externref" };
+}
+
+/**
  * (#2903) Host-import names that PRODUCE promises the standalone module did
  * not mint natively. Checked (alongside the pre-body syntactic scan flag
  * `ctx.moduleHasHostPromiseSource`) before replacing the `.then`/`.catch`

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4469,6 +4469,25 @@ export function tryEmitAsyncGenReturnThrowDispatch(
   const producers = ctx.asyncGenProducers;
   if (ctx.standalone !== true && ctx.wasi !== true) return null;
   if (producers === undefined || producers.size === 0) return null;
+  // (#3389 slice 2a — correct-or-legacy) `.return(v)` AWAITS its value under a
+  // return completion (§27.6.3.8): a thenable/Promise return value must be
+  // adopted before the IteratorResult settles. The driver fulfils with the raw
+  // value, so bail a STATICALLY Promise/PromiseLike-typed `.return` arg to the
+  // legacy path rather than deliver the un-awaited thenable (wrong value).
+  // `.throw(e)` does NOT await its reason (§27.6.3.9 throws it directly), so no
+  // restriction there.
+  if (method === "return" && argExpr !== undefined) {
+    const builtin = ctx.oracle.builtinReceiverOf(argExpr);
+    const declared = ctx.oracle.declaredNameOf(argExpr);
+    const parts = ctx.oracle.unionPartsOf(argExpr);
+    if (
+      builtin === "Promise" ||
+      declared === "PromiseLike" ||
+      (parts !== undefined && parts.some((p) => p.kind === "builtin" && p.name === "Promise"))
+    ) {
+      return null;
+    }
+  }
   // Evaluate the receiver ONCE into an externref local.
   const recvLocal = allocLocal(fctx, `__agen_rt_recv_${fctx.locals.length}`, { kind: "externref" });
   const rt = compileExpression(ctx, fctx, receiverExpr, { kind: "externref" });

--- a/tests/issue-3389-asyncgen-return.test.ts
+++ b/tests/issue-3389-asyncgen-return.test.ts
@@ -1,0 +1,154 @@
+// #3389 Slice 1 — `settleReturn` terminator for a top-level `return E` in a
+// driven async generator (standalone). Before this, any own-scope `return`
+// bailed `analyzeAsyncGen` (`containsOwnScopeReturn`), so the gen fell to the
+// legacy host buffer (`__gen_set_return` + the carrier-off `Promise_*` co-leak).
+//
+// Slice 1 admits a DIRECT top-level `return E` / bare `return;` and settles the
+// current `next()`-promise with the §27.6.3.8 return completion
+// `{value: E, done: true}` (distinct from fall-through's `{value: undefined}`),
+// then completes the frame so subsequent `next()` give `{value: undefined,
+// done: true}`. Correct-or-legacy: a return nested in control flow, or
+// `return await P`, stays on the legacy path.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Ex {
+  test: () => number;
+  probe: () => number;
+  __drain_microtasks?: () => void;
+}
+
+/** Compile standalone, assert host-free, instantiate, kick test(), drain, read probe(). */
+async function drive(code: string): Promise<number> {
+  const r = await compile(code, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as unknown as Ex;
+  ex.test();
+  ex.__drain_microtasks?.();
+  return ex.probe();
+}
+
+/** Compile standalone; assert the module KEEPS the legacy host imports. */
+async function expectLegacy(code: string): Promise<void> {
+  const r = await compile(code, { fileName: "test.ts", target: "standalone" });
+  expect(r.success).toBe(true);
+  expect(
+    (r.imports ?? []).map((i) => `${i.module}.${i.name}`).filter((n) => n.startsWith("env.")).length,
+  ).toBeGreaterThan(0);
+}
+
+describe("#3389 Slice 1 — settleReturn for top-level return in driven async-gen (standalone)", () => {
+  it("yield 1; return 42 — first next {1,false}, second {42,true}, third done", async () => {
+    // NOTE: the value/done reads happen INSIDE the compiled `.then` (wasm), so
+    // the return VALUE (42) and the `done` flags are the load-bearing checks.
+    // (`value === undefined` is asserted separately below — at the raw JS
+    // boundary externref-null reads as `null`, so it is not checked here.)
+    const v = await drive(`
+      var v1 = -9, d1 = -9, v2 = -9, d2 = -9, d3 = -9;
+      export function test(): number {
+        async function* g() { yield 1; return 42; }
+        const it = g();
+        it.next().then((r: any) => {
+          v1 = r.value as number; d1 = r.done ? 1 : 0;
+          it.next().then((r2: any) => {
+            v2 = r2.value as number; d2 = r2.done ? 1 : 0;
+            it.next().then((r3: any) => { d3 = r3.done ? 1 : 0; });
+          });
+        });
+        return 0;
+      }
+      // v1=1 d1=0 | v2=42 d2=1 | d3=1
+      export function probe(): number { return v1 * 100000 + d1 * 10000 + v2 * 100 + d2 * 10 + d3; }
+    `);
+    // 1*1e5 + 0 + 42*100 + 1*10 + 1 = 104211
+    expect(v).toBe(104211);
+  });
+
+  it("return 5 only (no yield) — first next {5,true}", async () => {
+    const v = await drive(`
+      var val = -9, d = -9;
+      export function test(): number {
+        async function* g() { return 5; }
+        g().next().then((r: any) => { val = r.value as number; d = r.done ? 1 : 0; });
+        return 0;
+      }
+      export function probe(): number { return val * 10 + d; }
+    `);
+    // {5,true} → 51
+    expect(v).toBe(51);
+  });
+
+  it("bare return; completes the frame (done=true on the settling and subsequent next)", async () => {
+    const v = await drive(`
+      var d2 = -9, d3 = -9;
+      export function test(): number {
+        async function* g() { yield 7; return; }
+        const it = g();
+        it.next().then((_: any) => {
+          it.next().then((r2: any) => {
+            d2 = r2.done ? 1 : 0;
+            it.next().then((r3: any) => { d3 = r3.done ? 1 : 0; });
+          });
+        });
+        return 0;
+      }
+      export function probe(): number { return d2 * 10 + d3; }
+    `);
+    // second next (settleReturn bare) done=true, third next (settleDone) done=true → 11
+    expect(v).toBe(11);
+  });
+
+  it("leads before return run before it settles", async () => {
+    const v = await drive(`
+      var side = 0, val = -9;
+      export function test(): number {
+        async function* g() { yield 1; side = 99; return side + 1; }
+        const it = g();
+        it.next().then((_: any) => { it.next().then((r: any) => { val = r.value as number; }); });
+        return 0;
+      }
+      export function probe(): number { return val; }
+    `);
+    expect(v).toBe(100); // side set to 99 by the lead, return 99+1
+  });
+
+  describe("correct-or-legacy: unsupported return shapes stay on the legacy path", () => {
+    it("return nested in an if stays legacy", async () => {
+      await expectLegacy(`
+        export function test(): number {
+          async function* g() { yield 1; if (Math.random() > 0.5) return 3; yield 2; }
+          g().next();
+          return 0;
+        }
+      `);
+    });
+
+    it("return await P stays legacy", async () => {
+      await expectLegacy(`
+        export function test(): number {
+          async function* g() { yield 1; return await Promise.resolve(9); }
+          g().next();
+          return 0;
+        }
+      `);
+    });
+  });
+
+  it("no-regression: a plain yield gen without return still drives host-free", async () => {
+    const v = await drive(`
+      var val = -9, d = -9;
+      export function test(): number {
+        async function* g() { yield 8; }
+        const it = g();
+        it.next().then((r: any) => { val = r.value as number; });
+        it.next();
+        return 0;
+      }
+      export function probe(): number { return val; }
+    `);
+    expect(v).toBe(8);
+  });
+});

--- a/tests/issue-3389-slice2a-return-throw.test.ts
+++ b/tests/issue-3389-slice2a-return-throw.test.ts
@@ -1,0 +1,117 @@
+// #3389 Slice 2a — `.return(v)` / `.throw(e)` consumer methods on DRIVEN
+// async-generator carriers (§27.6.3.8/.9), standalone lane.
+//
+// For every body the driven lane admits, try/finally + catch ACROSS a yield
+// stay legacy (2b), so a suspended-at-yield `.return`/`.throw` runs NO further
+// body — it just COMPLETES the frame. The per-gen `__async_gen_return_<stem>` /
+// `__async_gen_throw_<stem>` drivers settle/reject a fresh result promise and
+// re-point `frame.STATE` at the gen's settleDone state (subsequent `.next()` →
+// `{value: undefined, done: true}`), without touching the shared resume
+// dispatch. Host-free: no `__gen_return`/`__gen_throw` host imports.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+interface Ex {
+  test: () => number;
+  probe: () => number;
+  __drain_microtasks?: () => void;
+}
+
+async function drive(code: string): Promise<number> {
+  const r = await compile(code, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`).filter((n) => n.startsWith("env."))).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as unknown as Ex;
+  ex.test();
+  ex.__drain_microtasks?.();
+  return ex.probe();
+}
+
+describe("#3389 Slice 2a — driven async-gen .return()/.throw() (standalone, host-free)", () => {
+  it(".return(42) on a suspended-at-yield gen → {42,true}, then next → done", async () => {
+    const v = await drive(`
+      var rv = -9, rd = -9, nd = -9;
+      export function test(): number {
+        async function* g(): AsyncGenerator<number, number, unknown> { yield 1; yield 2; return 0; }
+        const it = g();
+        it.next().then((_: any) => {
+          it.return(42).then((r: any) => {
+            rv = r.value as number; rd = r.done ? 1 : 0;
+            it.next().then((n: any) => { nd = n.done ? 1 : 0; });
+          });
+        });
+        return 0;
+      }
+      export function probe(): number { return rv * 100 + rd * 10 + nd; }
+    `);
+    // rv=42 rd=1 nd=1 → 4211
+    expect(v).toBe(4211);
+  });
+
+  it(".throw(e) on a suspended gen rejects the returned promise", async () => {
+    const v = await drive(`
+      var caught = -9;
+      export function test(): number {
+        async function* g(): AsyncGenerator<number, number, unknown> { yield 1; yield 2; return 0; }
+        const it = g();
+        it.next().then((_: any) => {
+          it.throw(new Error("boom")).then((_r: any) => { caught = 1; }, (_e: any) => { caught = 2; });
+        });
+        return 0;
+      }
+      export function probe(): number { return caught; }
+    `);
+    expect(v).toBe(2); // rejected
+  });
+
+  it(".return() bare on a fresh (never-nexted) gen → done, frame completed", async () => {
+    const v = await drive(`
+      var rd = -9, nd = -9;
+      export function test(): number {
+        async function* g(): AsyncGenerator<number, void, unknown> { yield 1; }
+        const it = g();
+        it.return().then((r: any) => {
+          rd = r.done ? 1 : 0;
+          it.next().then((n: any) => { nd = n.done ? 1 : 0; });
+        });
+        return 0;
+      }
+      export function probe(): number { return rd * 10 + nd; }
+    `);
+    // .return() done=true; frame completed → subsequent next done=true → 11
+    expect(v).toBe(11);
+  });
+
+  it(".return(v) completes the frame: a later .return gives {v2,true} too", async () => {
+    const v = await drive(`
+      var r1d = -9, r2v = -9, r2d = -9;
+      export function test(): number {
+        async function* g(): AsyncGenerator<number, number, unknown> { yield 1; yield 2; return 0; }
+        const it = g();
+        it.return(5).then((r1: any) => {
+          r1d = r1.done ? 1 : 0;
+          it.return(9).then((r2: any) => { r2v = r2.value as number; r2d = r2.done ? 1 : 0; });
+        });
+        return 0;
+      }
+      export function probe(): number { return r1d * 1000 + r2v * 10 + r2d; }
+    `);
+    // r1: {5,true} → r1d=1 ; r2 on completed frame: {9,true} → r2v=9 r2d=1 → 1000 + 90 + 1 = 1091
+    expect(v).toBe(1091);
+  });
+
+  it("no-regression: a plain driven gen without .return/.throw still drives host-free", async () => {
+    const v = await drive(`
+      var val = -9;
+      export function test(): number {
+        async function* g(): AsyncGenerator<number, void, unknown> { yield 8; }
+        g().next().then((r: any) => { val = r.value as number; });
+        return 0;
+      }
+      export function probe(): number { return val; }
+    `);
+    expect(v).toBe(8);
+  });
+});


### PR DESCRIPTION
Captures fable-dev-3's suspended slice-2 work (team dismantled 2026-07-18). Slice-2a implemented + committed (8 commits, HEAD 95a5249); **held pending #3344** (settleReturn terminator / slice-1) merging first — slice-2a re-merges that state machine. Slice-2b spec'd, not yet implemented. Draft so it is captured on a PR without enqueuing ahead of its #3344 dependency. Resume note in task #22 / the #3389 issue plan. Do NOT mark ready until #3344 lands.