### PR TITLE
docs(ci): file #3459 — merge_group drift check reports negative clock age

### DIFF
--- a/plan/issues/3459-drift-check-negative-clock-age.md
+++ b/plan/issues/3459-drift-check-negative-clock-age.md
@@ -1,0 +1,58 @@
+---
+id: 3459
+title: "merge_group drift check reports negative baseline clock age (-43m) — clock-skew bug in instrumentation"
+status: ready
+sprint: current
+created: 2026-07-19
+updated: 2026-07-19
+priority: low
+horizon: s
+feasibility: easy
+task_type: bug
+area: ci, merge-queue, instrumentation
+goal: release-pipeline
+related: [3456, 3378]
+origin: "2026-07-19 pr-shepherd observation during #3375 regression triage: the baseline-drift check printed a NEGATIVE clock age."
+---
+
+# #3459 — baseline drift check prints negative clock age (-43m)
+
+## Problem
+
+During the `merge_group` re-validation that caught the #3375/#3370
+`null_deref` regression, the baseline **drift/staleness check** printed a
+**negative** baseline clock age (`-43m clock age`). A negative age is
+nonsensical — it means the instrumentation computed `now - baseline_ts`
+with skewed or wrongly-sourced timestamps (e.g. baseline timestamp read in
+a different timezone/epoch unit than `now`, or the runner clock vs. the
+commit-authored time).
+
+This is **instrumentation-only** — it did **not** affect the regression
+verdict (the gate correctly failed on the trap-growth + ratio signals). But
+a negative "age" makes the staleness signal untrustworthy: a genuinely
+stale baseline could be misreported, and it obscures the real
+`baseline_staleness_commits` reading operators rely on when interpreting
+`net_per_test` / regression counts.
+
+## Where to look
+
+The drift/staleness computation in the merge-shard-reports path of
+`.github/workflows/test262-sharded.yml` (the "Build merged … report" /
+baseline-age step) and/or the script it calls (the baseline fetch/compare
+helper). Audit how the baseline timestamp is sourced and differenced
+against `now` — unify the epoch unit (seconds vs ms) and the clock source,
+and clamp/flag rather than print a negative age.
+
+## Acceptance criteria
+
+- [ ] The baseline clock-age value is never negative.
+- [ ] The age is computed from a single, documented clock source and epoch
+      unit.
+- [ ] A quick unit/sanity check covers the sign.
+
+## Notes
+
+Low priority — cosmetic/observability, not a correctness gate. Surfaced by
+the pr-shepherd while triaging the #3375 real-regression (see #3370 hold and
+CI-FIX for the actual codegen bug). Related to the merge-queue instrumentation
+touched in [[3456]] / #3378.


### PR DESCRIPTION
Files tracking issue **#3459** (low-priority, instrumentation-only).

During the `merge_group` re-validation that caught the #3375/#3370 `null_deref` regression, the baseline drift/staleness check printed a **negative** clock age (`-43m`). Nonsensical value → a clock-skew bug in how the baseline timestamp is differenced against `now` (likely epoch-unit or clock-source mismatch). Did **not** affect the regression verdict, but makes the staleness signal untrustworthy.

Surfaced by the pr-shepherd while triaging the real #3375 regression (the actual codegen bug is tracked on #3370's hold + CI-FIX task #16). Docs-only, one issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8