### PR TITLE
feat(#3462): two-baseline + fast-oracle-lane plumbing (#3450 hybrid)

### DIFF
--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -583,6 +583,23 @@ interface TestResult {
    */
   oracle_version?: number;
   /**
+   * #3462: oracle LANE discriminator (the #3450 hybrid two-oracle pipeline).
+   * "honest" = the in-wasm v8 lane (host + standalone; the published number);
+   * "fast-nativeharness" = the host-only fast merge-gate oracle (harness runs
+   * natively, body-only wasm compile). Absent ⇒ "honest" (backward-compatible
+   * with pre-#3462 baselines). An INDEPENDENT axis from `oracle_version`: a fast
+   * row and an honest row are both v8 but produced by different oracles and are
+   * NOT comparable. Stamped by `recordResult` (tests/test262-shared.ts).
+   */
+  oracle_lane?: "honest" | "fast-nativeharness";
+  /**
+   * #3462: revision of the FAST native-harness oracle, present ONLY on
+   * `oracle_lane: "fast-nativeharness"` rows. Bumped independently of
+   * `oracle_version` whenever the native-harness verdict boundary changes
+   * (binding-shim/realm policy). Defined in tests/test262-oracle-version.ts.
+   */
+  oracle_fast_rev?: number;
+  /**
    * #2879 §1 — leak class of the host imports this row's module declared, or
    * null/absent when the module ran host-free (no `env::` import). Computed by
    * `classifyHostImportLeak` (scripts/test262-worker.mjs) and recorded by
@@ -699,6 +716,8 @@ export function isVacuousReclassification(base: TestResult | undefined, cur: Tes
 
 type StatusMap = Map<string, TestResult>;
 
+type OracleLane = "honest" | "fast-nativeharness";
+
 interface LoadedJsonl {
   map: StatusMap;
   /**
@@ -707,11 +726,27 @@ interface LoadedJsonl {
    * from shards run under different oracles, which must never be compared.
    */
   oracleVersion: number | "mixed" | undefined;
+  /**
+   * #3462: the oracle LANE observed in the file, normalized so an absent
+   * `oracle_lane` (pre-#3462 rows) counts as "honest". `undefined` only for an
+   * empty file (no rows at all). `"mixed"` if rows disagreed — a file assembled
+   * from BOTH lanes (e.g. host-fast + standalone-honest rows in one JSONL),
+   * which must never be diffed against a single-lane baseline.
+   */
+  oracleLane: OracleLane | "mixed" | undefined;
+  /**
+   * #3462: the fast-oracle revision observed among `fast-nativeharness` rows.
+   * `undefined` when the file carries no fast rows. `"mixed"` if fast rows
+   * disagreed on the rev. Only consulted when both sides are the fast lane.
+   */
+  oracleFastRev: number | "mixed" | undefined;
 }
 
 async function loadJsonl(path: string): Promise<LoadedJsonl> {
   const map: StatusMap = new Map();
   let oracleVersion: number | "mixed" | undefined;
+  let oracleLane: OracleLane | "mixed" | undefined;
+  let oracleFastRev: number | "mixed" | undefined;
   const rl = createInterface({ input: createReadStream(path) });
   for await (const line of rl) {
     if (!line.trim()) continue;
@@ -721,6 +756,18 @@ async function loadJsonl(path: string): Promise<LoadedJsonl> {
         if (oracleVersion === undefined) oracleVersion = entry.oracle_version;
         else if (oracleVersion !== entry.oracle_version) oracleVersion = "mixed";
       }
+      // #3462: normalize absent oracle_lane ⇒ "honest" (backward-compatible),
+      // then track a single file-level lane. A file mixing lanes is "mixed" and
+      // is refused, exactly like a mixed oracle_version.
+      const lane: OracleLane = entry.oracle_lane === "fast-nativeharness" ? "fast-nativeharness" : "honest";
+      if (oracleLane !== "mixed") {
+        if (oracleLane === undefined) oracleLane = lane;
+        else if (oracleLane !== lane) oracleLane = "mixed";
+      }
+      if (lane === "fast-nativeharness" && typeof entry.oracle_fast_rev === "number" && oracleFastRev !== "mixed") {
+        if (oracleFastRev === undefined) oracleFastRev = entry.oracle_fast_rev;
+        else if (oracleFastRev !== entry.oracle_fast_rev) oracleFastRev = "mixed";
+      }
       if (entry.file) {
         map.set(entry.file, entry);
       }
@@ -728,7 +775,7 @@ async function loadJsonl(path: string): Promise<LoadedJsonl> {
       // skip malformed lines
     }
   }
-  return { map, oracleVersion };
+  return { map, oracleVersion, oracleLane, oracleFastRev };
 }
 
 // Reads baseline metadata (baseline_generated_at, baseline_sha) from a report.json.
@@ -938,6 +985,92 @@ async function run(
       `Oracle-version note (#2096): ${fmtOracle(baseOracle)} (baseline) vs ${fmtOracle(newOracle)} (new) — ` +
         `at least one side is unstamped, comparing as legacy same-oracle.`,
     );
+  }
+
+  // #3462 — oracle-LANE guard (the #3450 hybrid two-oracle pipeline). The FAST
+  // native-harness lane (host only) and the HONEST in-wasm v8 lane share the
+  // same `oracle_version` (v8) but produce DIFFERENT verdicts at the
+  // native-harness boundary (~9,244 corpus-projected flips). They must never be
+  // diffed against each other, or the gate reads those baked-in boundary flips
+  // as regressions. `oracle_version` alone cannot catch this — both lanes are
+  // v8 — so the lane is a SEPARATE guard here.
+  //
+  // Unlike the version axis, the lane axis is NOT monotonic: there is no
+  // "forward bump" that auto-rebases (#3086), because neither lane supersedes
+  // the other — they measure different things. So a lane mismatch is excused
+  // ONLY by an explicit `ORACLE_REBASE=1`, which is how the fast baseline is
+  // seeded (#3465). Absent `oracle_lane` is normalized to "honest" in the loader
+  // (backward-compatible with every pre-#3462 baseline), so an old honest
+  // baseline vs a new honest candidate compares cleanly.
+  const baseLane = baselineLoaded.oracleLane;
+  const newLane = newerLoaded.oracleLane;
+  const fmtLane = (v: OracleLane | "mixed" | undefined) =>
+    v === undefined ? "honest (no rows)" : v === "mixed" ? "mixed (both lanes)" : v;
+
+  // A file assembled from BOTH lanes (e.g. host-fast + standalone-honest rows in
+  // one JSONL) is never comparable to a single-lane baseline — hard error,
+  // regardless of ORACLE_REBASE (mirrors the mixed-oracle_version refusal).
+  if (baseLane === "mixed" || newLane === "mixed") {
+    console.error(
+      `\n✖ Oracle-lane guard (#3462): one side carries MIXED oracle lanes ` +
+        `(baseline=${fmtLane(baseLane)}, new=${fmtLane(newLane)}).\n` +
+        `  A result file that mixes the honest and fast-native-harness lanes cannot be diffed.\n` +
+        `  Split the run by lane (host-fast vs standalone/honest) and diff each against its own baseline.\n`,
+    );
+    process.exit(2);
+  }
+
+  if (baseLane !== undefined && newLane !== undefined && baseLane !== newLane) {
+    // Cross-LANE diff (honest-vs-fast or fast-vs-honest). Excused only by the
+    // explicit env flag — there is no forward-bump auto-rebase for the lane.
+    if (!oracleRebase) {
+      console.error(
+        `\n✖ Oracle-lane guard (#3462): cross-lane diff refused.\n` +
+          `  baseline lane = ${fmtLane(baseLane)}, new lane = ${fmtLane(newLane)}.\n` +
+          `  The fast native-harness lane and the honest in-wasm v8 lane are both oracle ${fmtOracle(newOracle)}\n` +
+          `  but produce different verdicts at the native-harness boundary (~9,244 baked-in flips),\n` +
+          `  so diffing one against the other reads that boundary as regressions. This is the mechanism\n` +
+          `  that keeps a fast candidate from ever being gated against the honest baseline (and vice-versa).\n` +
+          `  If this is a deliberate fast-lane re-seed (#3465), re-run with ORACLE_REBASE=1.\n`,
+      );
+      process.exit(2);
+    }
+    console.log(
+      `ORACLE_REBASE=1 — comparing across oracle LANES ` +
+        `(baseline ${fmtLane(baseLane)} → new ${fmtLane(newLane)}). Deliberate fast-lane re-seed (#3462/#3465): ` +
+        `the ~9,244 native-harness boundary flips are being baked into the fast baseline.`,
+    );
+  } else if (baseLane === "fast-nativeharness" && newLane === "fast-nativeharness") {
+    // Same lane (both FAST) — the fast-rev must ALSO match. A rev bump means the
+    // native-harness verdict boundary itself moved (binding-shim/realm policy),
+    // so its baseline must be re-seeded, exactly like an honest oracle bump.
+    const baseRev = baselineLoaded.oracleFastRev;
+    const newRev = newerLoaded.oracleFastRev;
+    const fmtRev = (v: number | "mixed" | undefined) =>
+      v === undefined ? "unstamped" : v === "mixed" ? "mixed (multiple revs)" : `rev${v}`;
+    if (baseRev === "mixed" || newRev === "mixed") {
+      console.error(
+        `\n✖ Oracle-lane guard (#3462): one fast side carries MIXED fast revs ` +
+          `(baseline=${fmtRev(baseRev)}, new=${fmtRev(newRev)}).\n` +
+          `  A fast result file assembled from shards run under different fast revisions cannot be diffed.\n`,
+      );
+      process.exit(2);
+    }
+    if (typeof baseRev === "number" && typeof newRev === "number" && baseRev !== newRev) {
+      if (!oracleRebase) {
+        console.error(
+          `\n✖ Oracle-lane guard (#3462): fast-lane rev mismatch — diff refused.\n` +
+            `  baseline ${fmtRev(baseRev)}, new ${fmtRev(newRev)}.\n` +
+            `  The native-harness verdict boundary changed between these revisions, so their rows are not\n` +
+            `  comparable. Re-seed the fast baseline at the new rev with ORACLE_REBASE=1 (#3465).\n`,
+        );
+        process.exit(2);
+      }
+      console.log(
+        `ORACLE_REBASE=1 — comparing across fast oracle revisions ` +
+          `(baseline ${fmtRev(baseRev)} → new ${fmtRev(newRev)}). Deliberate fast-lane re-seed (#3462/#3465).`,
+      );
+    }
   }
 
   if (pathFilter.length > 0) {

--- a/scripts/fetch-baseline-jsonl.mjs
+++ b/scripts/fetch-baseline-jsonl.mjs
@@ -56,9 +56,20 @@ export const BASELINE_REMOTE_URL =
 export const STANDALONE_BASELINE_REMOTE_URL =
   "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.jsonl";
 
+// (#3462) The FAST native-harness lane (host only) gates the merge queue against
+// its OWN self-consistent baseline so the ~9,244 native-harness boundary flips
+// are baked in once and never false-fail a PR (the #3450 hybrid two-oracle
+// pipeline). It lives in the same baselines repo, seeded/refreshed on push:main
+// from the merge_group's fast host JSONL (#3448 rework, wired in #3463) and
+// initially seeded by #3465. Stamped `oracle_lane: fast-nativeharness`. This is
+// NEVER read by any landing-page/badge path — the published number is honest v8.
+export const FAST_BASELINE_REMOTE_URL =
+  "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-fast-current.jsonl";
+
 export const BASELINE_CACHE_DIR = resolve(REPO_ROOT, ".test262-cache");
 export const BASELINE_CACHE_PATH = resolve(BASELINE_CACHE_DIR, "test262-current.jsonl");
 export const STANDALONE_BASELINE_CACHE_PATH = resolve(BASELINE_CACHE_DIR, "test262-standalone-current.jsonl");
+export const FAST_BASELINE_CACHE_PATH = resolve(BASELINE_CACHE_DIR, "test262-fast-current.jsonl");
 
 // Sanity-check thresholds — a healthy baseline has ~43k entries and is ~15 MB.
 // Smaller than this almost certainly means a partial download or a corrupted
@@ -131,6 +142,26 @@ export async function ensureStandaloneBaselineJsonl(opts = {}) {
 }
 
 /**
+ * (#3462) FAST-lane analog of {@link ensureBaselineJsonl}. Fetches
+ * `test262-fast-current.jsonl` (host-only native-harness baseline) from the
+ * baselines repo to `FAST_BASELINE_CACHE_PATH`. Same idempotent +
+ * graceful-fallback semantics as the host/standalone fetch: an existing cache is
+ * a no-op; a download failure falls back to a present cache and only throws when
+ * upstream is unreachable AND no cache exists. The regression gate selects this
+ * baseline for the host diff when the run is fast-mode (`TEST262_ORACLE_MODE=fast`,
+ * wired in #3463). Until the fast baseline is seeded (#3465) upstream 404s, so
+ * callers must not invoke this before the seed exists (documented ordering).
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.force]
+ * @param {boolean} [opts.noCache]
+ * @returns {Promise<string>} absolute path to the fast-lane JSONL ready to read
+ */
+export async function ensureFastBaselineJsonl(opts = {}) {
+  return ensureLaneBaselineJsonl(FAST_BASELINE_REMOTE_URL, FAST_BASELINE_CACHE_PATH, "test262-fast-current", opts);
+}
+
+/**
  * Shared fetch+cache core for a single lane's baseline JSONL.
  *
  * @param {string} remoteUrl   raw.githubusercontent URL of the lane's JSONL
@@ -185,10 +216,11 @@ if (process.argv[1] && resolve(process.argv[1]) === __filename) {
   const noCache = args.includes("--no-cache");
   const printPath = args.includes("--print-path");
   const standalone = args.includes("--standalone"); // (#2095) fetch the standalone lane JSONL
+  const fast = args.includes("--fast"); // (#3462) fetch the fast native-harness (host) lane JSONL
 
-  const cachePath = standalone ? STANDALONE_BASELINE_CACHE_PATH : BASELINE_CACHE_PATH;
-  const ensure = standalone ? ensureStandaloneBaselineJsonl : ensureBaselineJsonl;
-  const remoteUrl = standalone ? STANDALONE_BASELINE_REMOTE_URL : BASELINE_REMOTE_URL;
+  const cachePath = fast ? FAST_BASELINE_CACHE_PATH : standalone ? STANDALONE_BASELINE_CACHE_PATH : BASELINE_CACHE_PATH;
+  const ensure = fast ? ensureFastBaselineJsonl : standalone ? ensureStandaloneBaselineJsonl : ensureBaselineJsonl;
+  const remoteUrl = fast ? FAST_BASELINE_REMOTE_URL : standalone ? STANDALONE_BASELINE_REMOTE_URL : BASELINE_REMOTE_URL;
 
   if (printPath) {
     process.stdout.write(`${cachePath}\n`);

--- a/tests/issue-3462.test.ts
+++ b/tests/issue-3462.test.ts
@@ -1,0 +1,169 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ORACLE_FAST_REV, ORACLE_FAST_HISTORY, ORACLE_VERSION } from "./test262-oracle-version.js";
+import {
+  FAST_BASELINE_CACHE_PATH,
+  FAST_BASELINE_REMOTE_URL,
+  ensureFastBaselineJsonl,
+} from "../scripts/fetch-baseline-jsonl.mjs";
+
+function writeJsonl(path: string, records: Record<string, unknown>[]) {
+  writeFileSync(path, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+}
+
+/**
+ * Run scripts/diff-test262.ts on two JSONL files and capture exit code + output,
+ * mirroring tests/issue-2096.test.ts so the oracle-LANE guard (#3462) can be
+ * asserted without throwing on a non-zero exit.
+ */
+function runDiff(baseline: string, candidate: string, env: Record<string, string> = {}): { code: number; out: string } {
+  try {
+    const out = execFileSync("npx", ["tsx", "scripts/diff-test262.ts", baseline, candidate, "--quiet"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, REGRESSIONS_ALLOW_FILE: "/dev/null", ...env },
+    });
+    return { code: 0, out };
+  } catch (err: any) {
+    return { code: err.status ?? 1, out: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+  }
+}
+
+// Honest rows use the current honest oracle_version and lane; fast rows share
+// the SAME oracle_version (both are v8) but carry the fast lane + rev — the
+// whole point of #3462 is that the version axis cannot distinguish them, so the
+// lane is a separate guard.
+const V = ORACLE_VERSION;
+const honest = (file: string, status: string, extra: Record<string, unknown> = {}) => ({
+  oracle_version: V,
+  oracle_lane: "honest",
+  file,
+  status,
+  ...extra,
+});
+const fast = (file: string, status: string, rev = ORACLE_FAST_REV, extra: Record<string, unknown> = {}) => ({
+  oracle_version: V,
+  oracle_lane: "fast-nativeharness",
+  oracle_fast_rev: rev,
+  file,
+  status,
+  ...extra,
+});
+
+describe("#3462 oracle_lane stamping + fast/honest diff guard", () => {
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  function paths() {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-3462-"));
+    return { base: join(tmpDir, "base.jsonl"), cand: join(tmpDir, "cand.jsonl") };
+  }
+
+  it("ORACLE_FAST_REV is a positive integer with a matching history entry", () => {
+    expect(Number.isInteger(ORACLE_FAST_REV)).toBe(true);
+    expect(ORACLE_FAST_REV).toBeGreaterThan(0);
+    const latest = ORACLE_FAST_HISTORY[ORACLE_FAST_HISTORY.length - 1];
+    expect(latest?.rev).toBe(ORACLE_FAST_REV);
+  });
+
+  it("diffs honest-vs-honest normally (exit 0)", () => {
+    const p = paths();
+    writeJsonl(p.base, [honest("a.js", "pass"), honest("b.js", "pass")]);
+    writeJsonl(p.cand, [honest("a.js", "pass"), honest("b.js", "pass")]);
+    expect(runDiff(p.base, p.cand).code).toBe(0);
+  });
+
+  // Backward compatibility: a pre-#3462 honest baseline carries NO oracle_lane;
+  // absent ⇒ honest, so it still compares cleanly against a stamped honest run.
+  it("treats an absent oracle_lane as honest (exit 0 against a stamped honest candidate)", () => {
+    const p = paths();
+    writeJsonl(p.base, [{ oracle_version: V, file: "a.js", status: "pass" }]);
+    writeJsonl(p.cand, [honest("a.js", "pass")]);
+    expect(runDiff(p.base, p.cand).code).toBe(0);
+  });
+
+  it("diffs fast-vs-fast (same rev) normally (exit 0)", () => {
+    const p = paths();
+    writeJsonl(p.base, [fast("a.js", "pass"), fast("b.js", "pass")]);
+    writeJsonl(p.cand, [fast("a.js", "pass"), fast("b.js", "pass")]);
+    expect(runDiff(p.base, p.cand).code).toBe(0);
+  });
+
+  it("REFUSES a fast candidate against an honest baseline (exit 2) without ORACLE_REBASE", () => {
+    const p = paths();
+    writeJsonl(p.base, [honest("a.js", "pass")]);
+    writeJsonl(p.cand, [fast("a.js", "pass")]);
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(2);
+    expect(out).toMatch(/cross-lane diff refused/i);
+  });
+
+  it("REFUSES an honest candidate against a fast baseline (exit 2) without ORACLE_REBASE", () => {
+    const p = paths();
+    writeJsonl(p.base, [fast("a.js", "pass")]);
+    writeJsonl(p.cand, [honest("a.js", "pass")]);
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(2);
+    expect(out).toMatch(/cross-lane diff refused/i);
+  });
+
+  it("allows a cross-lane diff with ORACLE_REBASE=1 (fast-lane re-seed)", () => {
+    const p = paths();
+    writeJsonl(p.base, [honest("a.js", "pass")]);
+    writeJsonl(p.cand, [fast("a.js", "pass")]);
+    const { code, out } = runDiff(p.base, p.cand, { ORACLE_REBASE: "1" });
+    expect(code).toBe(0);
+    expect(out).toMatch(/comparing across oracle LANES/i);
+  });
+
+  it("REFUSES a fast-lane rev mismatch (exit 2) without ORACLE_REBASE", () => {
+    const p = paths();
+    writeJsonl(p.base, [fast("a.js", "pass", 1)]);
+    writeJsonl(p.cand, [fast("a.js", "pass", 2)]);
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(2);
+    expect(out).toMatch(/fast-lane rev mismatch/i);
+  });
+
+  it("allows a fast-lane rev mismatch with ORACLE_REBASE=1", () => {
+    const p = paths();
+    writeJsonl(p.base, [fast("a.js", "pass", 1)]);
+    writeJsonl(p.cand, [fast("a.js", "pass", 2)]);
+    const { code, out } = runDiff(p.base, p.cand, { ORACLE_REBASE: "1" });
+    expect(code).toBe(0);
+    expect(out).toMatch(/across fast oracle revisions/i);
+  });
+
+  it("hard-refuses a MIXED-lane file (exit 2) even with ORACLE_REBASE=1", () => {
+    const p = paths();
+    writeJsonl(p.base, [honest("a.js", "pass")]);
+    writeJsonl(p.cand, [honest("a.js", "pass"), fast("b.js", "pass")]);
+    const { code, out } = runDiff(p.base, p.cand, { ORACLE_REBASE: "1" });
+    expect(code).toBe(2);
+    expect(out).toMatch(/MIXED oracle lanes/i);
+  });
+
+  it("hard-refuses a MIXED fast-rev file (exit 2) even with ORACLE_REBASE=1", () => {
+    const p = paths();
+    writeJsonl(p.base, [fast("a.js", "pass", 1)]);
+    writeJsonl(p.cand, [fast("a.js", "pass", 1), fast("b.js", "pass", 2)]);
+    const { code, out } = runDiff(p.base, p.cand, { ORACLE_REBASE: "1" });
+    expect(code).toBe(2);
+    expect(out).toMatch(/MIXED fast revs/i);
+  });
+});
+
+describe("#3462 fast-baseline fetch helper", () => {
+  it("exposes the fast-baseline URL, cache path, and ensure helper", () => {
+    expect(FAST_BASELINE_REMOTE_URL).toMatch(/js2wasm-baselines\/main\/test262-fast-current\.jsonl$/);
+    expect(FAST_BASELINE_CACHE_PATH).toMatch(/[\\/]\.test262-cache[\\/]test262-fast-current\.jsonl$/);
+    expect(typeof ensureFastBaselineJsonl).toBe("function");
+  });
+});

--- a/tests/test262-oracle-version.ts
+++ b/tests/test262-oracle-version.ts
@@ -192,3 +192,64 @@ export const ORACLE_VERSION_HISTORY: ReadonlyArray<{ version: number; note: stri
       "version requires an ORACLE_REBASE baseline refresh when landed.",
   },
 ];
+
+/**
+ * #3462 — FAST-oracle revision (the native-harness lane), an INDEPENDENT axis
+ * from `ORACLE_VERSION` above. Do NOT fold the fast lane into the honest integer.
+ *
+ * The #3450 hybrid runs two oracles:
+ *   - the HONEST in-wasm v8 oracle (`ORACLE_VERSION`, above) — the sole source
+ *     of the published conformance number and the honest regression signal; and
+ *   - the FAST native-harness oracle (host lane only) — used ONLY to gate merges
+ *     against its own self-consistent baseline. The native harness runs
+ *     assert.js/sta.js as native JS in the per-test sandbox and compiles the
+ *     test BODY only, so its pass/fail verdict diverges from the honest lane at
+ *     the native-harness boundary (error-identity, MOP/marshaling, and the
+ *     builtins the harness reads from V8 rather than js2wasm — ~9,244 corpus-
+ *     projected flips per the spike, plan/design/3450-native-harness-ab-findings.md).
+ *
+ * These two boundaries move for UNRELATED reasons, so they need independent
+ * identities. If the fast lane reused `ORACLE_VERSION = 9`, a future HONEST v9
+ * bump would collide: `diff-test262` would then treat a fast rev-1 baseline and
+ * an honest v9 candidate as comparable and read the ~9,244 baked-in boundary
+ * flips as regressions. Instead the fast lane carries `oracle_lane:
+ * "fast-nativeharness"` PLUS this `ORACLE_FAST_REV`, and `diff-test262` refuses
+ * to compare rows whose (oracle_version, oracle_lane, oracle_fast_rev) tuple
+ * differs unless `ORACLE_REBASE=1`.
+ *
+ * ── HOW TO BUMP ──────────────────────────────────────────────────────────
+ * Increment `ORACLE_FAST_REV` (and add an `ORACLE_FAST_HISTORY` entry) whenever
+ * the native-harness VERDICT BOUNDARY changes — e.g. the binding-shim policy,
+ * realm/error-construction handling, or which harness symbols resolve natively.
+ * Then re-seed the fast baseline (`test262-fast-current.jsonl`) with
+ * `ORACLE_REBASE=1` (the fast-lane analog of the honest ORACLE_VERSION bump;
+ * see #3465). The honest integer is untouched by a fast-rev bump and vice-versa.
+ *
+ * Like `ORACLE_VERSION`, this is an opaque monotonic integer scoped to the fast
+ * lane — NOT a compiler version or a date.
+ */
+export const ORACLE_FAST_REV = 1;
+
+/**
+ * Append-only log of what each fast-oracle revision means. Newest last.
+ */
+export const ORACLE_FAST_HISTORY: ReadonlyArray<{ rev: number; note: string }> = [
+  {
+    rev: 1,
+    note:
+      "#3461/#3450 native-harness fast oracle (host lane only). The harness " +
+      "prelude (runtime shim + metadata includes + assert.js + sta.js) runs as " +
+      "NATIVE JS in the per-test sandbox via runInContext; only the test BODY " +
+      "(prefixed by a binding shim that binds the referenced harness symbols " +
+      "into body scope) is compiled to wasm and instantiated with the sandbox " +
+      "as globalSandbox. This moves the verdict boundary relative to the honest " +
+      "in-wasm v8 lane: harness-side error identity (assert.js's Test262Error / " +
+      "assert.throws matching) is decided by native V8, and MOP/marshaling reads " +
+      "that the honest lane performs in-wasm (e.g. Array.prototype.*.length, " +
+      "property-descriptor checks in verifyProperty) are delegated to the host. " +
+      "Net effect per the spike A/B (plan/design/3450-native-harness-ab-findings.md): " +
+      "~18 flips on the 252-test stratified sample, ~9,244 corpus-projected, both " +
+      "directions. These are baked into the fast baseline ONCE (seed #3465) and " +
+      "never published — the honest v8 lane remains the sole source of the badge.",
+  },
+];

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -18,7 +18,7 @@ import { CompilerPool, type TestResult } from "../scripts/compiler-pool.js";
 import { isPoisonCompileError } from "../scripts/test262-poison-error.mjs";
 import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "../scripts/negative-verdict.mjs";
 import { findNthAssert } from "./test262-assert-locator.js";
-import { ORACLE_VERSION } from "./test262-oracle-version.js";
+import { ORACLE_VERSION, ORACLE_FAST_REV } from "./test262-oracle-version.js";
 import {
   classifyError,
   classifyTestScope,
@@ -151,6 +151,25 @@ function parseTest262Target(): Test262CompileTarget | undefined {
 }
 
 const TEST262_TARGET = parseTest262Target();
+
+// #3462 — oracle LANE selection (the #3450 hybrid two-oracle pipeline). Two
+// oracles run under the same `ORACLE_VERSION`:
+//   - HONEST in-wasm v8 (the default) — host + standalone, the published number;
+//   - FAST native-harness (host lane ONLY) — the merge-gate oracle sr-3461 wires
+//     behind `TEST262_ORACLE_MODE=fast` in the worker (harness runs natively,
+//     body-only wasm compile). We read the SAME pinned env var + the target here
+//     to stamp each result row's lane, so `diff-test262` can refuse to compare a
+//     fast candidate against the honest baseline (and vice-versa).
+//
+// The "host" lane is the JS-host default (no TEST262_TARGET → gc/js-string). The
+// native harness needs a JS host to run assert.js/sta.js natively, so it applies
+// ONLY there: standalone (and linear/wasi) can never host-exec the harness, so
+// they stay HONEST v8 even inside a fast-mode merge_group run. This mirrors the
+// worker's own rule (sr-3461): standalone target NEVER sets `nativeHarness`.
+const TEST262_ORACLE_MODE = process.env.TEST262_ORACLE_MODE;
+const IS_HOST_LANE = TEST262_TARGET === undefined;
+const ORACLE_LANE: "honest" | "fast-nativeharness" =
+  TEST262_ORACLE_MODE === "fast" && IS_HOST_LANE ? "fast-nativeharness" : "honest";
 
 function getCachePaths(wrappedSource: string): { wasmPath: string; metaPath: string } {
   const hash = createHash("md5")
@@ -345,6 +364,15 @@ function recordResult(
     // comparisons (which would read oracle skew as regressions). Bump in
     // tests/test262-oracle-version.ts when the oracle tightens (e.g. #1945).
     oracle_version: ORACLE_VERSION,
+    // #3462: oracle LANE discriminator (the #3450 hybrid). "honest" is the
+    // in-wasm v8 lane (host + standalone, the published number); a fast-mode
+    // HOST run stamps "fast-nativeharness" and its own `oracle_fast_rev`. This
+    // is an INDEPENDENT axis from oracle_version — a fast row and an honest row
+    // are both v8 but produced by different oracles, so diff-test262 keys on the
+    // (version, lane, fast_rev) tuple. Absent on pre-#3462 rows ⇒ treated as
+    // "honest" (backward-compatible; existing honest baselines are unaffected).
+    oracle_lane: ORACLE_LANE,
+    oracle_fast_rev: ORACLE_LANE === "fast-nativeharness" ? ORACLE_FAST_REV : undefined,
     file,
     category,
     status,


### PR DESCRIPTION
Child (b) of the #3450 HYBRID two-oracle test262 pipeline (spec: `plan/design/3450-hybrid-two-oracle-plan.md` §2). Makes the fast merge-gate lane diff **fast-vs-fast** so the ~9,244 native-harness boundary flips are baked into a fast baseline once and never false-fail a PR against the honest v8 baseline.

## What
- **`tests/test262-oracle-version.ts`**: keep `ORACLE_VERSION = 8` (honest, untouched). Add `ORACLE_FAST_REV = 1` + `ORACLE_FAST_HISTORY` on an **independent axis** — deliberately NOT reusing the honest integer 9 (a future honest v9 bump would otherwise collide with the fast lane).
- **`tests/test262-shared.ts` `recordResult`**: stamp `oracle_lane: "honest" | "fast-nativeharness"` and, when fast, `oracle_fast_rev`. Lane = `fast-nativeharness` iff `TEST262_ORACLE_MODE=fast` **AND** the host lane; everything else (incl. all standalone, linear, wasi) stays honest v8. Absent `oracle_lane` ⇒ honest (backward-compatible).
- **`scripts/diff-test262.ts`**: refuse a diff unless `oracle_version` AND `oracle_lane` (+ `oracle_fast_rev` when fast) match — unless `ORACLE_REBASE=1`. The lane axis is **non-monotonic** (no forward-bump auto-rebase, unlike the version axis); mixed-lane / mixed-rev files hard-refuse like mixed-version.
- **`scripts/fetch-baseline-jsonl.mjs`**: `FAST_BASELINE_REMOTE_URL` + `FAST_BASELINE_CACHE_PATH` + `ensureFastBaselineJsonl()` + `--fast` CLI, mirroring the existing graceful-fallback semantics.
- **`tests/issue-3462.test.ts`**: 12 cases — lane guard (fast-vs-honest refused; fast-vs-fast + honest-vs-honest accepted; absent⇒honest; ORACLE_REBASE override), fast-rev guard, mixed-lane/mixed-rev hard-refusal, and the fast-baseline helper exports.

## Acceptance criteria
1. ✅ Fast-mode host rows carry `oracle_lane: fast-nativeharness` + `oracle_fast_rev`; honest/standalone rows carry `oracle_lane: honest` + `oracle_version: 8`.
2. ✅ `diff-test262` refuses fast-vs-honest without `ORACLE_REBASE=1`; accepts fast-vs-fast and honest-vs-honest.
3. ✅ `fetch-baseline-jsonl.mjs` exposes the fast-baseline fetch with the existing graceful-fallback semantics.
4. ✅ Existing honest baselines + consumers byte-unaffected (`oracle_lane` is additive; absent ⇒ honest — existing `#2096` guard tests still green).

## Coordination
Shares the `oracle_lane` / `TEST262_ORACLE_MODE` interface with **#3461** (sr-3461, parallel): sr-3461 OWNS introducing `TEST262_ORACLE_MODE=fast` in the worker + the native-harness compile path; this PR READS that pinned env var + target in `recordResult` to stamp `oracle_lane`. Different regions of `test262-shared.ts` (this: `recordResult`; sr-3461: the compile path).

Depends on the #3462 stub landing via #3397 (still open) — the issue file will be flipped to `status: done` once #3397 merges and origin/main is re-merged.

## Test
`npx vitest run tests/issue-3462.test.ts tests/issue-2096.test.ts` → 22 pass. `format:check`, `typecheck`, and the `check:verdict-oracle` gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XP2h4ZbUmrPqmUDsELn9bG