### PR TITLE
fix(#3410): close legacy-origin bypass in the private-labs pre-push guard

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,72 +15,38 @@
 remote="$1"
 remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "")
 
+# Capture the ref-update lines once (git streams them on stdin). Both the labs
+# guard and the version-tag refresh below consume them, so read them into a
+# variable rather than draining stdin twice.
+push_refs=$(cat)
+
 # ---------- (1) labs/ safety check ---------------------------------------
 #
-# Classify the remote by URL rather than by name. Anyone can rename their
-# remotes locally; the URL is the authoritative signal.
+# Classify the destination by URL (not remote name — anyone can rename a
+# remote locally) via the shared, unit-tested helper. Only the allowlisted
+# private mirror (loopdive/js2wasm-labs) may receive labs/ paths; the canonical
+# upstream, the legacy loopdive/js2wasm alias, public forks, and any
+# unrecognized destination are all scanned and blocked. Classification and the
+# scan live in scripts/hooks/push-remote-classify.sh so they can be unit-tested
+# (tests/hooks/pre-push-labs-remote.test.ts) — see #3410.
 
-case "$remote_url" in
-  *loopdive/js2.git|*loopdive/js2)
-    is_public=1
-    ;;
-  *)
-    is_public=0
-    ;;
-esac
-
-if [ "$is_public" = "1" ]; then
-  while read local_ref local_oid remote_ref remote_oid; do
-    # Skip deletes (no labs/ paths in a delete diff).
-    if [ "$local_oid" = "0000000000000000000000000000000000000000" ]; then
-      continue
-    fi
-
-    # Determine the diff range and list the changed paths.
-    if [ "$remote_oid" = "0000000000000000000000000000000000000000" ]; then
-      # New branch on the remote — compare against the remote's main if we
-      # can find a merge-base; otherwise scan all commits the new branch
-      # introduces.
-      base=$(git merge-base "$local_oid" "${remote}/main" 2>/dev/null || echo "")
-      if [ -z "$base" ]; then
-        diff_paths=$(git log --name-only --pretty=format: "$local_oid" 2>/dev/null | sort -u)
-      else
-        diff_paths=$(git diff --name-only "$base..$local_oid" 2>/dev/null)
-      fi
-    else
-      diff_paths=$(git diff --name-only "$remote_oid..$local_oid" 2>/dev/null)
-    fi
-
-    forbidden=$(printf '%s\n' "$diff_paths" | grep -E '^labs/' || true)
-    if [ -n "$forbidden" ]; then
-      echo ""
-      echo "==========================================================================="
-      echo "ERROR: Refusing to push labs/ paths to a public remote."
-      echo "       remote: $remote ($remote_url)"
-      echo "---------------------------------------------------------------------------"
-      echo "The following paths are private and may not appear in the public repo:"
-      echo ""
-      printf '%s\n' "$forbidden" | sed 's/^/  /' | head -30
-      remaining=$(printf '%s\n' "$forbidden" | wc -l)
-      if [ "$remaining" -gt 30 ]; then
-        echo "  ... and $((remaining - 30)) more."
-      fi
-      echo ""
-      echo "Push to the private 'labs' remote instead:"
-      echo "  git push labs $local_ref"
-      echo ""
-      echo "If this push is intentionally public AND your diff includes labs/ paths,"
-      echo "split the change so the labs/ paths land separately on the labs remote."
-      echo "==========================================================================="
-      exit 1
-    fi
-  done
+hook_lib="$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/push-remote-classify.sh"
+if [ -r "$hook_lib" ]; then
+  . "$hook_lib"
+  if ! printf '%s\n' "$push_refs" | run_labs_guard "$remote" "$remote_url"; then
+    exit 1
+  fi
+else
+  echo "Pre-push: ERROR — cannot read $hook_lib; refusing to push without the labs/ guard." >&2
+  echo "          Restore the file, or use 'git push --no-verify' only if you are certain" >&2
+  echo "          the diff contains no labs/ content." >&2
+  exit 1
 fi
 
 # ---------- (2) version-tag benchmark refresh ----------------------------
 
 if [ "$remote" = "origin" ]; then
-  while read local_ref local_oid remote_ref remote_oid; do
+  printf '%s\n' "$push_refs" | while read local_ref local_oid remote_ref remote_oid; do
     case "$remote_ref" in
       refs/tags/v[0-9]*)
         echo "Pre-push: version tag detected ($remote_ref) — refreshing benchmarks..."

--- a/plan/issues/3410-public-remote-labs-guard-legacy-url.md
+++ b/plan/issues/3410-public-remote-labs-guard-legacy-url.md
@@ -1,9 +1,9 @@
 ---
 id: 3410
 title: "Private labs pre-push guard misses the legacy public js2wasm origin URL"
-status: ready
+status: in-review
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 priority: critical
 horizon: s
 feasibility: easy

--- a/scripts/hooks/push-remote-classify.sh
+++ b/scripts/hooks/push-remote-classify.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+# POSIX-sh helpers for the private-labs pre-push guard (#3410).
+#
+# This file is SOURCED by `.husky/pre-push` and exercised directly by
+# `tests/hooks/pre-push-labs-remote.test.ts`. It defines pure functions and has
+# no side effects at source time, so both callers can rely on it. Keep it free
+# of bashisms and of any dependency on node — the labs safety control must work
+# even when the JS toolchain is unavailable.
+#
+# Contract
+# --------
+#   normalize_owner_repo <url>   -> prints "owner/repo" (lowercased, `.git`
+#                                   stripped) or "" when no owner/repo can be
+#                                   recovered offline.
+#   classify_push_remote <url>   -> prints one of:
+#                                     labs-remote  the allowlisted private repo
+#                                                  (loopdive/js2wasm-labs)
+#                                     public       a known public destination
+#                                                  (canonical loopdive/js2,
+#                                                  legacy loopdive/js2wasm, or a
+#                                                  public fork <owner>/js2)
+#                                     unknown      cannot be confirmed private
+#   run_labs_guard <remote> <url> reads pre-push ref lines on stdin; returns 0
+#                                 (allow) or 1 (block) and prints a diagnostic
+#                                 for every blocked ref.
+#
+# Fail-safe policy: only `labs-remote` skips the labs/ scan. `public` AND
+# `unknown` both scan and block labs/ paths — an unrecognized destination can
+# never silently masquerade as the private mirror.
+
+# The single allowlisted PRIVATE destination for labs/ content.
+LABS_PRIVATE_REPO="js2wasm-labs"
+# The canonical public repo name, and its pre-rename legacy alias. A remote
+# whose repo segment normalizes to the canonical name is public regardless of
+# owner, so upstream and public forks are both covered.
+PUBLIC_REPO_CANONICAL="js2"
+PUBLIC_REPO_LEGACY="js2wasm"
+NULL_OID="0000000000000000000000000000000000000000"
+
+# normalize_owner_repo <url> -> "owner/repo" | ""
+#
+# Recovers the trailing owner/repo from every remote-URL syntax we care about:
+#   https://github.com/loopdive/js2.git
+#   https://x-access-token:TOKEN@github.com/loopdive/js2
+#   ssh://git@github.com/loopdive/js2.git
+#   git@github.com:loopdive/js2.git          (SCP short syntax)
+#   http://local_proxy@127.0.0.1:41729/git/loopdive/js2   (proxied)
+# by stripping the scheme, turning ':' into '/' (SCP colon and any host:port
+# become path separators — harmless because only the last two segments are
+# kept), dropping a trailing '.git', and taking the final two '/'-segments.
+normalize_owner_repo() {
+  _url=$(printf '%s' "${1:-}" | tr -d '[:space:]')
+  [ -n "$_url" ] || { printf ''; return 0; }
+  # Strip a leading scheme (https://, http://, ssh://, git://, …).
+  _s=${_url#*://}
+  # Collapse ':' to '/' so SCP syntax and host:port split uniformly.
+  _s=$(printf '%s' "$_s" | tr ':' '/')
+  # Drop trailing slashes.
+  while [ "${_s%/}" != "$_s" ]; do _s=${_s%/}; done
+  # Drop a single trailing .git.
+  case "$_s" in *.git) _s=${_s%.git} ;; esac
+  # Need at least an owner/repo pair (two '/'-separated segments).
+  case "$_s" in */*/*|*/*) : ;; *) printf ''; return 0 ;; esac
+  _repo=${_s##*/}
+  _rest=${_s%/*}
+  _owner=${_rest##*/}
+  if [ -z "$_repo" ] || [ -z "$_owner" ]; then
+    printf ''
+    return 0
+  fi
+  printf '%s/%s' "$(printf '%s' "$_owner" | tr '[:upper:]' '[:lower:]')" \
+                 "$(printf '%s' "$_repo" | tr '[:upper:]' '[:lower:]')"
+}
+
+# classify_push_remote <url> -> labs-remote | public | unknown
+classify_push_remote() {
+  _or=$(normalize_owner_repo "${1:-}")
+  if [ -z "$_or" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  _repo=${_or#*/}
+  case "$_repo" in
+    "$LABS_PRIVATE_REPO")
+      printf 'labs-remote'
+      ;;
+    "$PUBLIC_REPO_CANONICAL"|"$PUBLIC_REPO_LEGACY")
+      # Canonical upstream, legacy upstream, and any public fork keep the
+      # repo name — all public.
+      printf 'public'
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+# labs_forbidden_paths <newline-separated-paths> -> the subset under labs/
+labs_forbidden_paths() {
+  printf '%s\n' "${1:-}" | grep -E '^labs/' || true
+}
+
+# run_labs_guard <remote> <remote_url> ; reads ref lines on stdin.
+# Returns 0 (allow) or 1 (block). Prints a diagnostic for each blocked ref.
+run_labs_guard() {
+  _remote=$1
+  _remote_url=$2
+  _class=$(classify_push_remote "$_remote_url")
+  _norm=$(normalize_owner_repo "$_remote_url")
+  [ -n "$_norm" ] || _norm="(unrecognized)"
+
+  # Only the explicitly allowlisted private mirror skips the scan.
+  if [ "$_class" = "labs-remote" ]; then
+    return 0
+  fi
+
+  _block=0
+  while read local_ref local_oid remote_ref remote_oid; do
+    # Skip deletes (no labs/ paths in a delete diff).
+    [ -n "$local_oid" ] || continue
+    if [ "$local_oid" = "$NULL_OID" ]; then
+      continue
+    fi
+
+    if [ "$remote_oid" = "$NULL_OID" ]; then
+      # New branch on the remote — compare against the remote's main if a
+      # merge-base exists; otherwise scan every commit the branch introduces.
+      _base=$(git merge-base "$local_oid" "${_remote}/main" 2>/dev/null || echo "")
+      if [ -z "$_base" ]; then
+        _diff_paths=$(git log --name-only --pretty=format: "$local_oid" 2>/dev/null | sort -u)
+      else
+        _diff_paths=$(git diff --name-only "$_base..$local_oid" 2>/dev/null)
+      fi
+    else
+      _diff_paths=$(git diff --name-only "$remote_oid..$local_oid" 2>/dev/null)
+    fi
+
+    _forbidden=$(labs_forbidden_paths "$_diff_paths")
+    if [ -n "$_forbidden" ]; then
+      echo ""
+      echo "==========================================================================="
+      echo "ERROR: Refusing to push labs/ paths to a non-private remote."
+      echo "       remote:        $_remote ($_remote_url)"
+      echo "       normalized as: $_norm"
+      echo "       classified as: $_class (only '$LABS_PRIVATE_REPO' is treated as private)"
+      echo "---------------------------------------------------------------------------"
+      echo "The following paths are private and may not appear in a public repo:"
+      echo ""
+      printf '%s\n' "$_forbidden" | sed 's/^/  /' | head -30
+      _remaining=$(printf '%s\n' "$_forbidden" | wc -l)
+      if [ "$_remaining" -gt 30 ]; then
+        echo "  ... and $((_remaining - 30)) more."
+      fi
+      echo ""
+      echo "Push to the private 'labs' remote instead:"
+      echo "  git push labs $local_ref"
+      echo ""
+      echo "If this push is intentionally public AND your diff includes labs/ paths,"
+      echo "split the change so the labs/ paths land separately on the labs remote."
+      echo "==========================================================================="
+      _block=1
+    fi
+  done
+
+  return "$_block"
+}

--- a/tests/hooks/pre-push-labs-remote.test.ts
+++ b/tests/hooks/pre-push-labs-remote.test.ts
@@ -1,0 +1,191 @@
+// #3410 — the private-labs pre-push guard must recognize the destination
+// across every remote-URL syntax and fail safe on anything it cannot confirm
+// is the private mirror. These tests exercise the shared POSIX-sh helper
+// (scripts/hooks/push-remote-classify.sh) directly — the same code `.husky/
+// pre-push` sources — so classification and the labs/ scan are covered without
+// touching a network remote or any real private file.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const LIB = join(REPO_ROOT, "scripts", "hooks", "push-remote-classify.sh");
+const NULL_OID = "0000000000000000000000000000000000000000";
+
+// Run a single helper function from the sourced library and return its stdout.
+function runFn(fn: string, arg: string): string {
+  return execFileSync("sh", ["-c", `. "$0"; ${fn} "$1"`, LIB, arg], {
+    encoding: "utf8",
+  }).trim();
+}
+
+// Drive run_labs_guard against a git repo (cwd), feeding pre-push ref lines on
+// stdin. Returns the exit status (0 = allow, 1 = block) and combined output.
+function runGuard(cwd: string, remote: string, url: string, refLines: string[]): { status: number; output: string } {
+  try {
+    const out = execFileSync("sh", ["-c", '. "$0"; run_labs_guard "$1" "$2"', LIB, remote, url], {
+      cwd,
+      input: refLines.join("\n") + "\n",
+      encoding: "utf8",
+    });
+    return { status: 0, output: out };
+  } catch (e: any) {
+    return { status: e.status ?? -1, output: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+describe("#3410 pre-push labs guard — remote classification", () => {
+  // owner/repo normalization across HTTPS, SSH, SCP, proxied, tokened URLs.
+  const normCases: Array<[string, string]> = [
+    ["https://github.com/loopdive/js2.git", "loopdive/js2"],
+    ["https://github.com/loopdive/js2", "loopdive/js2"],
+    ["https://github.com/loopdive/js2wasm.git", "loopdive/js2wasm"],
+    ["ssh://git@github.com/loopdive/js2.git", "loopdive/js2"],
+    ["git@github.com:loopdive/js2wasm.git", "loopdive/js2wasm"],
+    ["git@github.com:loopdive/js2wasm-labs.git", "loopdive/js2wasm-labs"],
+    ["http://local_proxy@127.0.0.1:41729/git/loopdive/js2", "loopdive/js2"],
+    ["https://x-access-token:TOKEN@github.com/loopdive/js2wasm.git", "loopdive/js2wasm"],
+    ["https://GitHub.com/LoopDive/JS2.git", "loopdive/js2"], // case-insensitive
+    ["garbage", ""], // no owner/repo recoverable
+    ["", ""],
+  ];
+  it.each(normCases)("normalize_owner_repo(%s) -> %s", (url, expected) => {
+    expect(runFn("normalize_owner_repo", url)).toBe(expected);
+  });
+
+  // Classification: only the labs mirror is private; canonical + legacy
+  // upstream and forks are public; anything else is unknown (fail-safe).
+  const classCases: Array<[string, string]> = [
+    ["https://github.com/loopdive/js2.git", "public"],
+    ["https://github.com/loopdive/js2", "public"],
+    ["https://github.com/loopdive/js2wasm.git", "public"], // legacy alias
+    ["https://github.com/loopdive/js2wasm", "public"],
+    ["git@github.com:loopdive/js2wasm.git", "public"],
+    ["ssh://git@github.com/loopdive/js2.git", "public"],
+    ["https://github.com/ttraenkler/js2.git", "public"], // public fork
+    ["git@github.com:ttraenkler/js2wasm.git", "public"], // legacy-named fork
+    ["http://local_proxy@127.0.0.1:41729/git/loopdive/js2", "public"], // current origin
+    ["https://github.com/loopdive/js2wasm-labs.git", "labs-remote"],
+    ["git@github.com:loopdive/js2wasm-labs.git", "labs-remote"],
+    ["/local/path/somerepo", "unknown"],
+    ["garbage", "unknown"],
+    ["", "unknown"],
+  ];
+  it.each(classCases)("classify_push_remote(%s) -> %s", (url, expected) => {
+    expect(runFn("classify_push_remote", url)).toBe(expected);
+  });
+
+  it("the exact current origin URL classifies as public", () => {
+    let originUrl = "";
+    try {
+      originUrl = execFileSync("git", ["remote", "get-url", "origin"], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      originUrl = "";
+    }
+    if (!originUrl) return; // no origin in this checkout — nothing to assert
+    expect(runFn("classify_push_remote", originUrl)).toBe("public");
+  });
+});
+
+describe("#3410 pre-push labs guard — end-to-end scan", () => {
+  let repo: string;
+  let baseOid = "";
+  let labsCommitOid = "";
+  let cleanCommitOid = "";
+
+  const git = (cwd: string, ...args: string[]) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), "prepush-labs-"));
+    git(repo, "init", "-q", "-b", "main");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test");
+
+    // base commit: an ordinary public path only.
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "a.txt"), "a\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "base");
+    baseOid = git(repo, "rev-parse", "HEAD");
+
+    // Simulate the remote-tracking ref the guard consults for new branches.
+    git(repo, "update-ref", "refs/remotes/origin/main", baseOid);
+
+    // commit introducing a private labs/ path (the fixture — synthetic, no real
+    // private content).
+    mkdirSync(join(repo, "labs"), { recursive: true });
+    writeFileSync(join(repo, "labs", "example.txt"), "synthetic private fixture\n");
+    writeFileSync(join(repo, "docs.md"), "public\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "add labs fixture");
+    labsCommitOid = git(repo, "rev-parse", "HEAD");
+
+    // a further commit with no labs/ path.
+    writeFileSync(join(repo, "src", "b.txt"), "b\n");
+    git(repo, "add", "-A");
+    git(repo, "commit", "-q", "-m", "public-only change");
+    cleanCommitOid = git(repo, "rev-parse", "HEAD");
+  });
+
+  afterAll(() => {
+    if (repo) rmSync(repo, { recursive: true, force: true });
+  });
+
+  const PUBLIC = "https://github.com/loopdive/js2.git";
+  const LEGACY = "https://github.com/loopdive/js2wasm.git";
+  const FORK = "https://github.com/ttraenkler/js2.git";
+  const LABS = "https://github.com/loopdive/js2wasm-labs.git";
+  const UNKNOWN = "https://example.com/private/mirror.git";
+
+  it("blocks labs/ on an update push to the canonical public remote", () => {
+    const line = `refs/heads/topic ${labsCommitOid} refs/heads/topic ${baseOid}`;
+    const r = runGuard(repo, "origin", PUBLIC, [line]);
+    expect(r.status).toBe(1);
+    expect(r.output).toMatch(/labs\/example\.txt/);
+  });
+
+  it("blocks labs/ identically on the legacy loopdive/js2wasm origin", () => {
+    const line = `refs/heads/topic ${labsCommitOid} refs/heads/topic ${baseOid}`;
+    const r = runGuard(repo, "origin", LEGACY, [line]);
+    expect(r.status).toBe(1);
+    expect(r.output).toMatch(/legacy|labs\/example\.txt/);
+  });
+
+  it("blocks labs/ on a public fork URL", () => {
+    const line = `refs/heads/topic ${labsCommitOid} refs/heads/topic ${baseOid}`;
+    expect(runGuard(repo, "fork", FORK, [line]).status).toBe(1);
+  });
+
+  it("blocks labs/ on a new-branch push (merge-base vs origin/main)", () => {
+    const line = `refs/heads/topic ${labsCommitOid} refs/heads/topic ${NULL_OID}`;
+    const r = runGuard(repo, "origin", PUBLIC, [line]);
+    expect(r.status).toBe(1);
+    expect(r.output).toMatch(/labs\/example\.txt/);
+  });
+
+  it("fails safe: blocks labs/ on an unknown/unconfirmed remote", () => {
+    const line = `refs/heads/topic ${labsCommitOid} refs/heads/topic ${baseOid}`;
+    expect(runGuard(repo, "mirror", UNKNOWN, [line]).status).toBe(1);
+  });
+
+  it("allows the intentional labs remote to receive labs/ content", () => {
+    const line = `refs/heads/topic ${labsCommitOid} refs/heads/topic ${baseOid}`;
+    const r = runGuard(repo, "labs", LABS, [line]);
+    expect(r.status).toBe(0);
+  });
+
+  it("allows a public push whose diff has no labs/ paths", () => {
+    const line = `refs/heads/topic ${cleanCommitOid} refs/heads/topic ${labsCommitOid}`;
+    expect(runGuard(repo, "origin", PUBLIC, [line]).status).toBe(0);
+  });
+
+  it("allows a delete ref (no diff to scan) to a public remote", () => {
+    const line = `(delete) ${NULL_OID} refs/heads/topic ${labsCommitOid}`;
+    expect(runGuard(repo, "origin", PUBLIC, [line]).status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #3410 — a verified safety-control bypass in `.husky/pre-push`.

The labs/ safety check classified a remote as public only when its URL matched `loopdive/js2` exactly. The normal `origin` still uses the pre-rename `loopdive/js2wasm` URL (GitHub redirects it; the shell matcher did not), so `is_public` was `0` and the entire private-path scan was **skipped for the standard destination**. Public fork URLs were likewise unrecognized.

Remote classification + the labs/ scan are extracted into a shared, unit-tested POSIX-sh helper, `scripts/hooks/push-remote-classify.sh`:

- Normalize HTTPS / SSH / SCP / proxied / tokened URLs to `owner/repo`, strip optional `.git`, and fold the legacy `js2wasm` repo alias to `js2`.
- Classify: only the private mirror is the allowlisted private destination; canonical upstream, legacy upstream, and public forks (`<owner>/js2`) are `public`; anything else is `unknown`.
- **Fail safe**: `public` AND `unknown` both scan and block labs/ paths — an unrecognized destination can never masquerade as the private mirror. If the helper is unreadable the hook refuses the push rather than skipping the guard.
- Emit the normalized destination + classification in the block diagnostic.

The hook now reads the ref lines once and feeds both the labs guard and the version-tag refresh (the guard previously drained stdin, silently disabling the refresh on origin).

New test `tests/hooks/pre-push-labs-remote.test.ts` (34 cases): table-driven classification across every URL form incl. the exact current origin, plus an end-to-end scan over a synthetic repo with a `labs/` fixture for new-branch, update, and delete refs — no network remote or real private file.

Validation: 34/34 tests pass; `sh -n` on both files; prettier + biome clean; `tsc --noEmit` clean; issue-integrity + issue-ids gates pass. The modified hook self-validated on push (correctly classified the proxied origin as public and ran the scan).

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate auto-skips. Legal attestation left for a human maintainer. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEr53nWNQM8tcCyQw6WuY2)_