### PR TITLE
fix(#2787): capture async console.log in diff-test harness (corpus 96→99 match)

### DIFF
--- a/benchmarks/results/diff-test-baseline.json
+++ b/benchmarks/results/diff-test-baseline.json
@@ -1,7 +1,7 @@
 {
   "total": 104,
-  "match": 92,
-  "mismatch": 10,
+  "match": 99,
+  "mismatch": 3,
   "compile_error": 0,
   "runtime_error": 2,
   "v8_error": 0,
@@ -15,8 +15,8 @@
     },
     "builtins": {
       "total": 15,
-      "match": 10,
-      "mismatch": 4,
+      "match": 14,
+      "mismatch": 0,
       "error": 1
     },
     "classes": {
@@ -27,8 +27,8 @@
     },
     "closures": {
       "total": 10,
-      "match": 7,
-      "mismatch": 2,
+      "match": 8,
+      "mismatch": 1,
       "error": 1
     },
     "control": {
@@ -45,8 +45,8 @@
     },
     "object": {
       "total": 12,
-      "match": 9,
-      "mismatch": 3,
+      "match": 11,
+      "mismatch": 1,
       "error": 0
     },
     "string": {
@@ -56,7 +56,7 @@
       "error": 0
     }
   },
-  "duration_s": 28.387,
+  "duration_s": 45.396,
   "results": [
     {
       "file": "array/01-basic.js",
@@ -65,8 +65,8 @@
       "js2wasm_stdout": "3\n1\n3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 22,
-      "ms_js2wasm": 583
+      "ms_v8": 46,
+      "ms_js2wasm": 1068
     },
     {
       "file": "array/02-push-pop.js",
@@ -75,8 +75,8 @@
       "js2wasm_stdout": "3\n3\n2\n1,2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 40,
-      "ms_js2wasm": 258
+      "ms_v8": 47,
+      "ms_js2wasm": 520
     },
     {
       "file": "array/03-shift-unshift.js",
@@ -85,8 +85,8 @@
       "js2wasm_stdout": "0,1,2,3\n0\n1,2,3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 53,
-      "ms_js2wasm": 205
+      "ms_v8": 46,
+      "ms_js2wasm": 386
     },
     {
       "file": "array/04-map.js",
@@ -95,8 +95,8 @@
       "js2wasm_stdout": "2,4,6\n0,1,2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 33,
-      "ms_js2wasm": 188
+      "ms_v8": 45,
+      "ms_js2wasm": 360
     },
     {
       "file": "array/05-filter.js",
@@ -105,8 +105,8 @@
       "js2wasm_stdout": "3,4,5\n2,4",
       "match": true,
       "outcome": "match",
-      "ms_v8": 25,
-      "ms_js2wasm": 193
+      "ms_v8": 46,
+      "ms_js2wasm": 418
     },
     {
       "file": "array/06-reduce.js",
@@ -115,8 +115,8 @@
       "js2wasm_stdout": "10\n24\nabc",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 220
+      "ms_v8": 50,
+      "ms_js2wasm": 369
     },
     {
       "file": "array/07-find-some-every.js",
@@ -125,8 +125,8 @@
       "js2wasm_stdout": "3\nfalse\ntrue\n2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 218
+      "ms_v8": 53,
+      "ms_js2wasm": 403
     },
     {
       "file": "array/08-includes-indexOf.js",
@@ -135,8 +135,8 @@
       "js2wasm_stdout": "1\n-1\ntrue\n1",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 194
+      "ms_v8": 50,
+      "ms_js2wasm": 336
     },
     {
       "file": "array/09-slice-splice.js",
@@ -145,8 +145,8 @@
       "js2wasm_stdout": "2,3,4\n1,9,4",
       "match": true,
       "outcome": "match",
-      "ms_v8": 23,
-      "ms_js2wasm": 232
+      "ms_v8": 47,
+      "ms_js2wasm": 353
     },
     {
       "file": "array/10-sort-reverse.js",
@@ -155,8 +155,8 @@
       "js2wasm_stdout": "1,2,3\n3,2,1\n3,2,1\nabc",
       "match": true,
       "outcome": "match",
-      "ms_v8": 25,
-      "ms_js2wasm": 184
+      "ms_v8": 47,
+      "ms_js2wasm": 330
     },
     {
       "file": "array/11-flat-flatMap.js",
@@ -165,8 +165,8 @@
       "js2wasm_stdout": "1,2,3,4\n1,2,3,4\n1,2,2,4,3,6",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 185
+      "ms_v8": 44,
+      "ms_js2wasm": 319
     },
     {
       "file": "array/12-from-of.js",
@@ -175,8 +175,8 @@
       "js2wasm_stdout": "1,2,3\na,b,c\n",
       "match": false,
       "outcome": "mismatch",
-      "ms_v8": 22,
-      "ms_js2wasm": 395
+      "ms_v8": 45,
+      "ms_js2wasm": 399
     },
     {
       "file": "array/13-spread-destructure.js",
@@ -185,8 +185,8 @@
       "js2wasm_stdout": "1,2,3,4,5\n1\n2,3,4,5",
       "match": true,
       "outcome": "match",
-      "ms_v8": 51,
-      "ms_js2wasm": 253
+      "ms_v8": 47,
+      "ms_js2wasm": 365
     },
     {
       "file": "array/14-fill.js",
@@ -195,8 +195,8 @@
       "js2wasm_stdout": "0,0,0,0\n1,9,9,4",
       "match": true,
       "outcome": "match",
-      "ms_v8": 34,
-      "ms_js2wasm": 305
+      "ms_v8": 45,
+      "ms_js2wasm": 381
     },
     {
       "file": "array/15-join-tostring.js",
@@ -205,8 +205,8 @@
       "js2wasm_stdout": "1,2,3\n123\n1,2,3\n",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 215
+      "ms_v8": 44,
+      "ms_js2wasm": 355
     },
     {
       "file": "builtins/01-json-stringify.js",
@@ -215,8 +215,8 @@
       "js2wasm_stdout": "{\"a\":1,\"b\":\"two\"}\n[1,2,3]\n\"hello\"\n42\nnull",
       "match": true,
       "outcome": "match",
-      "ms_v8": 43,
-      "ms_js2wasm": 313
+      "ms_v8": 50,
+      "ms_js2wasm": 362
     },
     {
       "file": "builtins/02-json-parse.js",
@@ -225,8 +225,8 @@
       "js2wasm_stdout": "1\n2,3\n42\nnull",
       "match": true,
       "outcome": "match",
-      "ms_v8": 68,
-      "ms_js2wasm": 295
+      "ms_v8": 47,
+      "ms_js2wasm": 331
     },
     {
       "file": "builtins/03-map-set.js",
@@ -235,18 +235,18 @@
       "js2wasm_stdout": "1\ntrue\n2\n3\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 35,
-      "ms_js2wasm": 310
+      "ms_v8": 46,
+      "ms_js2wasm": 364
     },
     {
       "file": "builtins/04-symbol.js",
       "category": "builtins",
       "v8_stdout": "symbol\nSymbol(desc)\ndesc\n",
-      "js2wasm_stdout": "symbol\n[object Object]\ndesc",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 29,
-      "ms_js2wasm": 266
+      "js2wasm_stdout": "symbol\nSymbol(desc)\ndesc",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 47,
+      "ms_js2wasm": 390
     },
     {
       "file": "builtins/05-date.js",
@@ -255,8 +255,8 @@
       "js2wasm_stdout": "0\n1970\n0\n0",
       "match": true,
       "outcome": "match",
-      "ms_v8": 39,
-      "ms_js2wasm": 243
+      "ms_v8": 50,
+      "ms_js2wasm": 339
     },
     {
       "file": "builtins/06-regexp.js",
@@ -265,38 +265,38 @@
       "js2wasm_stdout": "true\nhello,world\na*b*c*",
       "match": true,
       "outcome": "match",
-      "ms_v8": 36,
-      "ms_js2wasm": 296
+      "ms_v8": 52,
+      "ms_js2wasm": 352
     },
     {
       "file": "builtins/07-promise-basic.js",
       "category": "builtins",
       "v8_stdout": "42\n",
-      "js2wasm_stdout": "",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 42,
-      "ms_js2wasm": 280
+      "js2wasm_stdout": "42",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 52,
+      "ms_js2wasm": 350
     },
     {
       "file": "builtins/08-promise-chain.js",
       "category": "builtins",
       "v8_stdout": "4\n",
-      "js2wasm_stdout": "",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 48,
-      "ms_js2wasm": 212
+      "js2wasm_stdout": "4",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 50,
+      "ms_js2wasm": 364
     },
     {
       "file": "builtins/09-async-await.js",
       "category": "builtins",
       "v8_stdout": "30\n",
-      "js2wasm_stdout": "",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 99,
-      "ms_js2wasm": 373
+      "js2wasm_stdout": "30",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 49,
+      "ms_js2wasm": 386
     },
     {
       "file": "builtins/10-error-classes.js",
@@ -305,8 +305,8 @@
       "js2wasm_stdout": "true\ntype problem\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 272,
-      "ms_js2wasm": 1226
+      "ms_v8": 49,
+      "ms_js2wasm": 410
     },
     {
       "file": "builtins/11-typed-array.js",
@@ -315,8 +315,8 @@
       "js2wasm_stdout": "3\n10,20,30\n100",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 297
+      "ms_v8": 76,
+      "ms_js2wasm": 461
     },
     {
       "file": "builtins/12-arraybuffer.js",
@@ -325,8 +325,8 @@
       "js2wasm_stdout": "12345678\n18",
       "match": true,
       "outcome": "match",
-      "ms_v8": 40,
-      "ms_js2wasm": 204
+      "ms_v8": 53,
+      "ms_js2wasm": 410
     },
     {
       "file": "builtins/13-iterator.js",
@@ -335,8 +335,8 @@
       "js2wasm_stdout": "0,1,2,3,4",
       "match": true,
       "outcome": "match",
-      "ms_v8": 52,
-      "ms_js2wasm": 208
+      "ms_v8": 46,
+      "ms_js2wasm": 388
     },
     {
       "file": "builtins/14-spread-args.js",
@@ -346,8 +346,8 @@
       "match": false,
       "outcome": "runtime_error",
       "error": "runtime: illegal cast",
-      "ms_v8": 27,
-      "ms_js2wasm": 183
+      "ms_v8": 57,
+      "ms_js2wasm": 410
     },
     {
       "file": "builtins/15-tag-template.js",
@@ -356,8 +356,8 @@
       "js2wasm_stdout": "hello | world |::1,2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 34,
-      "ms_js2wasm": 167
+      "ms_v8": 48,
+      "ms_js2wasm": 393
     },
     {
       "file": "classes/01-basic.js",
@@ -366,8 +366,8 @@
       "js2wasm_stdout": "3,4",
       "match": true,
       "outcome": "match",
-      "ms_v8": 39,
-      "ms_js2wasm": 190
+      "ms_v8": 48,
+      "ms_js2wasm": 407
     },
     {
       "file": "classes/02-inheritance.js",
@@ -376,8 +376,8 @@
       "js2wasm_stdout": "dog rex",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 229
+      "ms_v8": 63,
+      "ms_js2wasm": 488
     },
     {
       "file": "classes/03-static.js",
@@ -386,8 +386,8 @@
       "js2wasm_stdout": "1\n2\n2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 38,
-      "ms_js2wasm": 210
+      "ms_v8": 50,
+      "ms_js2wasm": 394
     },
     {
       "file": "classes/04-getter-setter.js",
@@ -396,8 +396,8 @@
       "js2wasm_stdout": "10",
       "match": true,
       "outcome": "match",
-      "ms_v8": 52,
-      "ms_js2wasm": 214
+      "ms_v8": 55,
+      "ms_js2wasm": 481
     },
     {
       "file": "classes/05-method.js",
@@ -406,8 +406,8 @@
       "js2wasm_stdout": "16\n27",
       "match": true,
       "outcome": "match",
-      "ms_v8": 22,
-      "ms_js2wasm": 168
+      "ms_v8": 65,
+      "ms_js2wasm": 473
     },
     {
       "file": "classes/06-instanceof.js",
@@ -416,8 +416,8 @@
       "js2wasm_stdout": "true\ntrue\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 183
+      "ms_v8": 49,
+      "ms_js2wasm": 424
     },
     {
       "file": "classes/07-prototype-call.js",
@@ -426,8 +426,8 @@
       "js2wasm_stdout": "hi world\nhi test",
       "match": true,
       "outcome": "match",
-      "ms_v8": 25,
-      "ms_js2wasm": 221
+      "ms_v8": 53,
+      "ms_js2wasm": 379
     },
     {
       "file": "classes/08-fields.js",
@@ -436,8 +436,8 @@
       "js2wasm_stdout": "1\nx\n1,2,3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 37,
-      "ms_js2wasm": 197
+      "ms_v8": 51,
+      "ms_js2wasm": 422
     },
     {
       "file": "classes/09-super-constructor.js",
@@ -446,8 +446,8 @@
       "js2wasm_stdout": "1,2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 23,
-      "ms_js2wasm": 234
+      "ms_v8": 49,
+      "ms_js2wasm": 400
     },
     {
       "file": "classes/10-toString-impl.js",
@@ -456,8 +456,8 @@
       "js2wasm_stdout": "$42\nval=$7",
       "match": true,
       "outcome": "match",
-      "ms_v8": 22,
-      "ms_js2wasm": 196
+      "ms_v8": 49,
+      "ms_js2wasm": 316
     },
     {
       "file": "closures/01-basic.js",
@@ -466,8 +466,8 @@
       "js2wasm_stdout": "8\n15",
       "match": true,
       "outcome": "match",
-      "ms_v8": 21,
-      "ms_js2wasm": 251
+      "ms_v8": 50,
+      "ms_js2wasm": 350
     },
     {
       "file": "closures/02-counter.js",
@@ -476,8 +476,8 @@
       "js2wasm_stdout": "1\n2\n3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 30,
-      "ms_js2wasm": 182
+      "ms_v8": 52,
+      "ms_js2wasm": 407
     },
     {
       "file": "closures/03-iife.js",
@@ -486,8 +486,8 @@
       "js2wasm_stdout": "42\n12",
       "match": true,
       "outcome": "match",
-      "ms_v8": 20,
-      "ms_js2wasm": 211
+      "ms_v8": 49,
+      "ms_js2wasm": 337
     },
     {
       "file": "closures/04-shared-state.js",
@@ -496,8 +496,8 @@
       "js2wasm_stdout": "2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 38,
-      "ms_js2wasm": 376
+      "ms_v8": 52,
+      "ms_js2wasm": 391
     },
     {
       "file": "closures/05-loop-capture.js",
@@ -506,8 +506,8 @@
       "js2wasm_stdout": "0,1,2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 34,
-      "ms_js2wasm": 249
+      "ms_v8": 56,
+      "ms_js2wasm": 415
     },
     {
       "file": "closures/06-nested.js",
@@ -516,8 +516,8 @@
       "js2wasm_stdout": "3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 21,
-      "ms_js2wasm": 225
+      "ms_v8": 47,
+      "ms_js2wasm": 374
     },
     {
       "file": "closures/07-arrow-this.js",
@@ -526,8 +526,8 @@
       "js2wasm_stdout": "NaN",
       "match": false,
       "outcome": "mismatch",
-      "ms_v8": 24,
-      "ms_js2wasm": 238
+      "ms_v8": 53,
+      "ms_js2wasm": 364
     },
     {
       "file": "closures/08-method-chain.js",
@@ -537,18 +537,18 @@
       "match": false,
       "outcome": "runtime_error",
       "error": "runtime: [object WebAssembly.Exception]",
-      "ms_v8": 30,
-      "ms_js2wasm": 310
+      "ms_v8": 58,
+      "ms_js2wasm": 412
     },
     {
       "file": "closures/09-callback.js",
       "category": "closures",
       "v8_stdout": "1,4,9\n",
-      "js2wasm_stdout": ",,",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 39,
-      "ms_js2wasm": 248
+      "js2wasm_stdout": "1,4,9",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 51,
+      "ms_js2wasm": 382
     },
     {
       "file": "closures/10-mutual.js",
@@ -557,8 +557,8 @@
       "js2wasm_stdout": "true\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 26,
-      "ms_js2wasm": 272
+      "ms_v8": 57,
+      "ms_js2wasm": 411
     },
     {
       "file": "control/01-if-else.js",
@@ -567,8 +567,8 @@
       "js2wasm_stdout": "yes\nmiddle",
       "match": true,
       "outcome": "match",
-      "ms_v8": 30,
-      "ms_js2wasm": 233
+      "ms_v8": 53,
+      "ms_js2wasm": 389
     },
     {
       "file": "control/02-for.js",
@@ -577,8 +577,8 @@
       "js2wasm_stdout": "10\n5\n4\n3\n2\n1",
       "match": true,
       "outcome": "match",
-      "ms_v8": 29,
-      "ms_js2wasm": 266
+      "ms_v8": 49,
+      "ms_js2wasm": 364
     },
     {
       "file": "control/03-while.js",
@@ -587,8 +587,8 @@
       "js2wasm_stdout": "0\n1\n2\n5\n4\n3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 27,
-      "ms_js2wasm": 200
+      "ms_v8": 50,
+      "ms_js2wasm": 409
     },
     {
       "file": "control/04-break-continue.js",
@@ -597,8 +597,8 @@
       "js2wasm_stdout": "1\n3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 57,
-      "ms_js2wasm": 226
+      "ms_v8": 49,
+      "ms_js2wasm": 359
     },
     {
       "file": "control/05-labeled-break.js",
@@ -607,8 +607,8 @@
       "js2wasm_stdout": "0,0\n0,1\n0,2\n1,0",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 218
+      "ms_v8": 53,
+      "ms_js2wasm": 376
     },
     {
       "file": "control/06-switch.js",
@@ -617,8 +617,8 @@
       "js2wasm_stdout": "one\ntwo-or-three\ntwo-or-three\nother",
       "match": true,
       "outcome": "match",
-      "ms_v8": 40,
-      "ms_js2wasm": 191
+      "ms_v8": 56,
+      "ms_js2wasm": 361
     },
     {
       "file": "control/07-try-catch.js",
@@ -627,8 +627,8 @@
       "js2wasm_stdout": "caught:boom\nafter",
       "match": true,
       "outcome": "match",
-      "ms_v8": 51,
-      "ms_js2wasm": 302
+      "ms_v8": 49,
+      "ms_js2wasm": 503
     },
     {
       "file": "control/08-try-finally.js",
@@ -637,8 +637,8 @@
       "js2wasm_stdout": "finally\n1",
       "match": true,
       "outcome": "match",
-      "ms_v8": 29,
-      "ms_js2wasm": 251
+      "ms_v8": 63,
+      "ms_js2wasm": 386
     },
     {
       "file": "control/09-ternary.js",
@@ -647,8 +647,8 @@
       "js2wasm_stdout": "big\n20",
       "match": true,
       "outcome": "match",
-      "ms_v8": 30,
-      "ms_js2wasm": 208
+      "ms_v8": 49,
+      "ms_js2wasm": 376
     },
     {
       "file": "control/10-logical-ops.js",
@@ -657,8 +657,8 @@
       "js2wasm_stdout": "yes\nfallback\ndefault\n0\nfallback",
       "match": true,
       "outcome": "match",
-      "ms_v8": 45,
-      "ms_js2wasm": 201
+      "ms_v8": 52,
+      "ms_js2wasm": 371
     },
     {
       "file": "control/11-for-of-array.js",
@@ -667,8 +667,8 @@
       "js2wasm_stdout": "10\n20\n30",
       "match": true,
       "outcome": "match",
-      "ms_v8": 39,
-      "ms_js2wasm": 249
+      "ms_v8": 56,
+      "ms_js2wasm": 433
     },
     {
       "file": "control/12-for-in-object.js",
@@ -677,8 +677,8 @@
       "js2wasm_stdout": "a,b",
       "match": true,
       "outcome": "match",
-      "ms_v8": 29,
-      "ms_js2wasm": 161
+      "ms_v8": 48,
+      "ms_js2wasm": 437
     },
     {
       "file": "numeric/01-basic-arithmetic.js",
@@ -687,8 +687,8 @@
       "js2wasm_stdout": "3\n7\n20\n5\n2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 56,
-      "ms_js2wasm": 168
+      "ms_v8": 59,
+      "ms_js2wasm": 369
     },
     {
       "file": "numeric/02-float-precision.js",
@@ -697,8 +697,8 @@
       "js2wasm_stdout": "0.30000000000000004\n2.25\n0.3333333333333333",
       "match": true,
       "outcome": "match",
-      "ms_v8": 29,
-      "ms_js2wasm": 148
+      "ms_v8": 54,
+      "ms_js2wasm": 367
     },
     {
       "file": "numeric/03-negative-zero.js",
@@ -707,8 +707,8 @@
       "js2wasm_stdout": "true\nfalse\n-Infinity",
       "match": true,
       "outcome": "match",
-      "ms_v8": 25,
-      "ms_js2wasm": 187
+      "ms_v8": 49,
+      "ms_js2wasm": 389
     },
     {
       "file": "numeric/04-infinity.js",
@@ -717,8 +717,8 @@
       "js2wasm_stdout": "Infinity\n-Infinity\nInfinity\n-Infinity\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 31,
-      "ms_js2wasm": 174
+      "ms_v8": 59,
+      "ms_js2wasm": 314
     },
     {
       "file": "numeric/05-nan-propagation.js",
@@ -727,8 +727,8 @@
       "js2wasm_stdout": "NaN\nNaN\nfalse\ntrue\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 35,
-      "ms_js2wasm": 180
+      "ms_v8": 50,
+      "ms_js2wasm": 368
     },
     {
       "file": "numeric/06-integer-overflow.js",
@@ -737,8 +737,8 @@
       "js2wasm_stdout": "9007199254740991\n9007199254740992\nfalse",
       "match": true,
       "outcome": "match",
-      "ms_v8": 41,
-      "ms_js2wasm": 210
+      "ms_v8": 51,
+      "ms_js2wasm": 407
     },
     {
       "file": "numeric/07-math-sqrt.js",
@@ -747,8 +747,8 @@
       "js2wasm_stdout": "0\n1\n2\n1.4142135623730951\nNaN",
       "match": true,
       "outcome": "match",
-      "ms_v8": 33,
-      "ms_js2wasm": 235
+      "ms_v8": 53,
+      "ms_js2wasm": 387
     },
     {
       "file": "numeric/08-math-trig.js",
@@ -757,8 +757,8 @@
       "js2wasm_stdout": "0\n1\n0\ntrue\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 38,
-      "ms_js2wasm": 220
+      "ms_v8": 51,
+      "ms_js2wasm": 390
     },
     {
       "file": "numeric/09-math-min-max.js",
@@ -767,8 +767,8 @@
       "js2wasm_stdout": "1\n3\nInfinity\n-Infinity\n-10",
       "match": true,
       "outcome": "match",
-      "ms_v8": 47,
-      "ms_js2wasm": 211
+      "ms_v8": 57,
+      "ms_js2wasm": 376
     },
     {
       "file": "numeric/10-math-floor-ceil-round.js",
@@ -777,8 +777,8 @@
       "js2wasm_stdout": "3\n4\n4\n3\n-4",
       "match": true,
       "outcome": "match",
-      "ms_v8": 46,
-      "ms_js2wasm": 228
+      "ms_v8": 47,
+      "ms_js2wasm": 384
     },
     {
       "file": "numeric/11-bitwise.js",
@@ -787,8 +787,8 @@
       "js2wasm_stdout": "1\n7\n6\n-6\n16\n4\n4294967295",
       "match": true,
       "outcome": "match",
-      "ms_v8": 58,
-      "ms_js2wasm": 243
+      "ms_v8": 54,
+      "ms_js2wasm": 338
     },
     {
       "file": "numeric/12-comparison.js",
@@ -797,8 +797,8 @@
       "js2wasm_stdout": "true\ntrue\ntrue\ntrue\nfalse\nfalse",
       "match": true,
       "outcome": "match",
-      "ms_v8": 48,
-      "ms_js2wasm": 183
+      "ms_v8": 53,
+      "ms_js2wasm": 356
     },
     {
       "file": "numeric/13-typeof-number.js",
@@ -807,8 +807,8 @@
       "js2wasm_stdout": "number\nnumber\nnumber\nnumber\nnumber",
       "match": true,
       "outcome": "match",
-      "ms_v8": 102,
-      "ms_js2wasm": 196
+      "ms_v8": 55,
+      "ms_js2wasm": 385
     },
     {
       "file": "numeric/14-tostring-radix.js",
@@ -817,8 +817,8 @@
       "js2wasm_stdout": "ff\n1000\n2s\n-1\n0.5",
       "match": true,
       "outcome": "match",
-      "ms_v8": 32,
-      "ms_js2wasm": 173
+      "ms_v8": 55,
+      "ms_js2wasm": 493
     },
     {
       "file": "numeric/15-parse-int-float.js",
@@ -827,8 +827,8 @@
       "js2wasm_stdout": "42\n255\n3\n3.14\n1000\nNaN",
       "match": true,
       "outcome": "match",
-      "ms_v8": 49,
-      "ms_js2wasm": 240
+      "ms_v8": 58,
+      "ms_js2wasm": 391
     },
     {
       "file": "object/01-literal.js",
@@ -837,18 +837,18 @@
       "js2wasm_stdout": "1\n2\na,b,c",
       "match": true,
       "outcome": "match",
-      "ms_v8": 38,
-      "ms_js2wasm": 185
+      "ms_v8": 54,
+      "ms_js2wasm": 414
     },
     {
       "file": "object/02-spread.js",
       "category": "object",
       "v8_stdout": "x,y,z\n1\n3\n",
-      "js2wasm_stdout": "z,x,y\nNaN\nNaN",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 46,
-      "ms_js2wasm": 185
+      "js2wasm_stdout": "x,y,z\n1\n3",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 55,
+      "ms_js2wasm": 359
     },
     {
       "file": "object/03-destructure.js",
@@ -857,8 +857,8 @@
       "js2wasm_stdout": "1\n2\n99",
       "match": true,
       "outcome": "match",
-      "ms_v8": 32,
-      "ms_js2wasm": 296
+      "ms_v8": 69,
+      "ms_js2wasm": 358
     },
     {
       "file": "object/04-keys-values-entries.js",
@@ -867,8 +867,8 @@
       "js2wasm_stdout": "a,b\n1,2\na=1,b=2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 39,
-      "ms_js2wasm": 228
+      "ms_v8": 51,
+      "ms_js2wasm": 587
     },
     {
       "file": "object/05-in-operator.js",
@@ -877,18 +877,18 @@
       "js2wasm_stdout": "true\nfalse\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 27,
-      "ms_js2wasm": 162
+      "ms_v8": 55,
+      "ms_js2wasm": 334
     },
     {
       "file": "object/06-delete.js",
       "category": "object",
       "v8_stdout": "b\nundefined\n",
-      "js2wasm_stdout": "a,b\n1",
+      "js2wasm_stdout": "a,b\nNaN",
       "match": false,
       "outcome": "mismatch",
-      "ms_v8": 31,
-      "ms_js2wasm": 175
+      "ms_v8": 51,
+      "ms_js2wasm": 395
     },
     {
       "file": "object/07-property-shorthand.js",
@@ -897,8 +897,8 @@
       "js2wasm_stdout": "30",
       "match": true,
       "outcome": "match",
-      "ms_v8": 38,
-      "ms_js2wasm": 195
+      "ms_v8": 52,
+      "ms_js2wasm": 344
     },
     {
       "file": "object/08-computed-keys.js",
@@ -907,8 +907,8 @@
       "js2wasm_stdout": "1\n2",
       "match": true,
       "outcome": "match",
-      "ms_v8": 48,
-      "ms_js2wasm": 183
+      "ms_v8": 49,
+      "ms_js2wasm": 317
     },
     {
       "file": "object/09-nested.js",
@@ -917,8 +917,8 @@
       "js2wasm_stdout": "42\n43",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 268
+      "ms_v8": 47,
+      "ms_js2wasm": 326
     },
     {
       "file": "object/10-typeof.js",
@@ -927,8 +927,8 @@
       "js2wasm_stdout": "object\nobject\nundefined",
       "match": true,
       "outcome": "match",
-      "ms_v8": 39,
-      "ms_js2wasm": 196
+      "ms_v8": 50,
+      "ms_js2wasm": 388
     },
     {
       "file": "object/11-equality.js",
@@ -937,18 +937,18 @@
       "js2wasm_stdout": "false\ntrue\nfalse",
       "match": true,
       "outcome": "match",
-      "ms_v8": 37,
-      "ms_js2wasm": 196
+      "ms_v8": 52,
+      "ms_js2wasm": 368
     },
     {
       "file": "object/12-assign.js",
       "category": "object",
       "v8_stdout": "a,b,c\ntrue\n",
-      "js2wasm_stdout": "a\ntrue",
-      "match": false,
-      "outcome": "mismatch",
-      "ms_v8": 30,
-      "ms_js2wasm": 196
+      "js2wasm_stdout": "a,b,c\ntrue",
+      "match": true,
+      "outcome": "match",
+      "ms_v8": 52,
+      "ms_js2wasm": 424
     },
     {
       "file": "string/01-concat.js",
@@ -957,8 +957,8 @@
       "js2wasm_stdout": "hello world\na1\n1a",
       "match": true,
       "outcome": "match",
-      "ms_v8": 35,
-      "ms_js2wasm": 192
+      "ms_v8": 53,
+      "ms_js2wasm": 344
     },
     {
       "file": "string/02-length.js",
@@ -967,8 +967,8 @@
       "js2wasm_stdout": "5\n0\n5",
       "match": true,
       "outcome": "match",
-      "ms_v8": 25,
-      "ms_js2wasm": 169
+      "ms_v8": 50,
+      "ms_js2wasm": 309
     },
     {
       "file": "string/03-charAt.js",
@@ -977,8 +977,8 @@
       "js2wasm_stdout": "h\no\n\n104",
       "match": true,
       "outcome": "match",
-      "ms_v8": 36,
-      "ms_js2wasm": 218
+      "ms_v8": 48,
+      "ms_js2wasm": 345
     },
     {
       "file": "string/04-slice.js",
@@ -987,8 +987,8 @@
       "js2wasm_stdout": "hello\nworld\nworld\nello",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 187
+      "ms_v8": 47,
+      "ms_js2wasm": 303
     },
     {
       "file": "string/05-substring.js",
@@ -997,8 +997,8 @@
       "js2wasm_stdout": "hello\nworld\nel",
       "match": true,
       "outcome": "match",
-      "ms_v8": 27,
-      "ms_js2wasm": 214
+      "ms_v8": 46,
+      "ms_js2wasm": 300
     },
     {
       "file": "string/06-indexOf.js",
@@ -1007,8 +1007,8 @@
       "js2wasm_stdout": "6\n-1\n1\n3",
       "match": true,
       "outcome": "match",
-      "ms_v8": 27,
-      "ms_js2wasm": 174
+      "ms_v8": 50,
+      "ms_js2wasm": 301
     },
     {
       "file": "string/07-includes.js",
@@ -1017,8 +1017,8 @@
       "js2wasm_stdout": "true\nfalse\ntrue\ntrue\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 26,
-      "ms_js2wasm": 178
+      "ms_v8": 52,
+      "ms_js2wasm": 313
     },
     {
       "file": "string/08-toUpperLower.js",
@@ -1027,8 +1027,8 @@
       "js2wasm_stdout": "HELLO WORLD\nhello world\näbc",
       "match": true,
       "outcome": "match",
-      "ms_v8": 32,
-      "ms_js2wasm": 166
+      "ms_v8": 48,
+      "ms_js2wasm": 314
     },
     {
       "file": "string/09-split.js",
@@ -1037,8 +1037,8 @@
       "js2wasm_stdout": "a|b|c\nh-e-l-l-o\na/b/c",
       "match": true,
       "outcome": "match",
-      "ms_v8": 36,
-      "ms_js2wasm": 172
+      "ms_v8": 49,
+      "ms_js2wasm": 323
     },
     {
       "file": "string/10-replace.js",
@@ -1047,8 +1047,8 @@
       "js2wasm_stdout": "hello there\nbaa\nbbb",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 192
+      "ms_v8": 52,
+      "ms_js2wasm": 309
     },
     {
       "file": "string/11-trim.js",
@@ -1057,8 +1057,8 @@
       "js2wasm_stdout": "hello\nhello  \n  hello\nhi",
       "match": true,
       "outcome": "match",
-      "ms_v8": 26,
-      "ms_js2wasm": 143
+      "ms_v8": 49,
+      "ms_js2wasm": 314
     },
     {
       "file": "string/12-repeat-pad.js",
@@ -1067,8 +1067,8 @@
       "js2wasm_stdout": "ababab\n005\n5..\n0",
       "match": true,
       "outcome": "match",
-      "ms_v8": 24,
-      "ms_js2wasm": 205
+      "ms_v8": 50,
+      "ms_js2wasm": 319
     },
     {
       "file": "string/13-template-literal.js",
@@ -1077,8 +1077,8 @@
       "js2wasm_stdout": "hello world, n=42\nmulti\nline",
       "match": true,
       "outcome": "match",
-      "ms_v8": 37,
-      "ms_js2wasm": 178
+      "ms_v8": 48,
+      "ms_js2wasm": 355
     },
     {
       "file": "string/14-comparison.js",
@@ -1087,8 +1087,8 @@
       "js2wasm_stdout": "true\ntrue\ntrue\ntrue\ntrue",
       "match": true,
       "outcome": "match",
-      "ms_v8": 28,
-      "ms_js2wasm": 165
+      "ms_v8": 64,
+      "ms_js2wasm": 332
     },
     {
       "file": "string/15-fromCharCode.js",
@@ -1097,8 +1097,8 @@
       "js2wasm_stdout": "Hi\nA\n中",
       "match": true,
       "outcome": "match",
-      "ms_v8": 41,
-      "ms_js2wasm": 202
+      "ms_v8": 50,
+      "ms_js2wasm": 355
     }
   ]
 }

--- a/plan/issues/2787-differential-test-corpus-failures.md
+++ b/plan/issues/2787-differential-test-corpus-failures.md
@@ -1,10 +1,10 @@
 ---
 id: 2787
 title: "Differential-test corpus failures — 2 malformed_wasm + 13 mismatch + 6 runtime_error"
-status: ready
+status: in-review
 sprint: Backlog
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-19
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -113,6 +113,46 @@ The binary validates but throws during instantiation/execution:
   diff-test codegen failures, which are on the default WasmGC + JS-host path.
 
 ---
+
+## Harness fix (2026-07-19) — async side-effect capture (corpus 96→99 match)
+
+**Root cause (harness, not compiler):** the js2wasm lane in `scripts/diff-test.ts`
+restored the monkey-patched `console.log` in its `finally` block *immediately*
+after calling `__module_init()`. Corpus programs that schedule callbacks via
+`Promise.resolve().then(...)` / `async`/`await` invoke the host `console.log`
+import **after** `__module_init()` returns — i.e. after the capture window had
+already been torn down. Consequences: (1) those late writes leaked to the real
+stdout (the stray `42` / `4` / `30` lines seen in harness output), and (2) the
+program recorded **empty** output → a false `mismatch` against the V8 oracle,
+which runs the full job queue before exiting.
+
+This directly contradicts the 2026-07-06 note's claim that promise output "stayed
+empty even after a 50ms + microtask drain": draining the microtask + macrotask
+job queue **before** restoring `console.log` captures the output verbatim. The
+compiler's Promise/async lowering works for these programs; only the harness was
+dropping the async output.
+
+**Fix:** `runJs2wasm` now awaits `drainAsync()` (bounded microtask + `setTimeout(0)`
+macrotask drain) inside the capture window before restoring `console.log`. This
+flips three programs from false `mismatch` to `match` and eliminates the stdout
+pollution:
+
+- `builtins/07-promise-basic.js` — now captures `42` (#1042 cluster — not a gap)
+- `builtins/08-promise-chain.js` — now captures `4`
+- `builtins/09-async-await.js` — now captures `30`
+
+Corpus: **96 → 99 / 104 match** (3 mismatch, 2 runtime_error, 0 malformed_wasm).
+The committed `diff-test-baseline.json` is refreshed to this state so the delta
+gate now protects these three programs from regressing back to empty output.
+Scoped regression test: `tests/issue-2787.test.ts`. `runJs2wasm` is now exported
+and `main()` is guarded behind an entry-point check so the test can import it
+without triggering a full corpus run.
+
+The remaining 5 failing programs (`array/12-from-of`, `closures/07-arrow-this`,
+`object/06-delete` mismatches; `builtins/14-spread-args`,
+`closures/08-method-chain` runtime_errors) are genuine substrate-level compiler
+gaps tracked by #2796/#2797, correctly deferred — no harness or cheap localized
+fix applies.
 
 ## Re-measure (2026-07-06) — corpus improved 20→9 failing
 

--- a/scripts/diff-test.ts
+++ b/scripts/diff-test.ts
@@ -28,7 +28,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { compile } from "../src/index.ts";
 import { buildImports, instantiateWasm } from "../src/runtime.ts";
@@ -151,8 +151,27 @@ function runV8(file: string): { stdout: string; error?: string; ms: number } {
   }
 }
 
-/** Compile a JS file with js2wasm, instantiate, capture console.log output. */
-async function runJs2wasm(file: string): Promise<{
+/**
+ * #2787 — Let the microtask + macrotask job queue drain so that asynchronous
+ * `console.log` side-effects (Promise `.then`, `async`/`await`) fire while the
+ * capture is still installed. Each `setTimeout(0)` boundary flushes the entire
+ * microtask queue that precedes it; a small loop lets promise chains that
+ * re-schedule (`.then().then()`, sequential `await`s) fully settle. Bounded so a
+ * pathological unresolved chain can't hang the harness — the V8 lane has its own
+ * 5s process timeout, and the corpus promise programs settle in ≤3 ticks.
+ */
+async function drainAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>((res) => setTimeout(res, 0));
+  }
+}
+
+/**
+ * Compile a JS file with js2wasm, instantiate, capture console.log output.
+ * Exported so the scoped regression test (tests/issue-2787.test.ts) can assert
+ * that asynchronous side-effects are captured (the #2787 drain).
+ */
+export async function runJs2wasm(file: string): Promise<{
   stdout: string;
   error?: string;
   ms: number;
@@ -227,6 +246,18 @@ async function runJs2wasm(file: string): Promise<{
     // emits no `__module_init` export, so this is a no-op for those.
     const moduleInit = (instance.exports as Record<string, unknown>).__module_init;
     if (typeof moduleInit === "function") (moduleInit as () => void)();
+    // #2787 — Drain asynchronous side-effects BEFORE restoring console.log.
+    // Top-level code may schedule callbacks (`Promise.resolve().then(...)`,
+    // `async`/`await`) that invoke the host `console.log` import *after*
+    // `__module_init()` returns. Without draining the job queue inside the
+    // capture window, those late writes fire once console.log has already been
+    // restored — so they leak to the real stdout (the "42"/"4"/"30" pollution)
+    // AND the program spuriously records EMPTY output (a false `mismatch`). V8
+    // runs the full job queue before the process exits, so the js2wasm lane
+    // must too. A `setTimeout(0)` boundary flushes the entire preceding
+    // microtask queue; looping a few ticks lets promise chains that re-schedule
+    // settle.
+    await drainAsync();
   } catch (e: unknown) {
     console.log = origLog;
     console.error = origError;
@@ -366,7 +397,11 @@ async function main(): Promise<void> {
   process.exit(summary.match === summary.total ? 0 : 1);
 }
 
-main().catch((e) => {
-  console.error("Fatal:", e);
-  process.exit(2);
-});
+// Only run the full corpus when invoked as a script (not when imported by the
+// scoped regression test, which imports `runJs2wasm` directly).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((e) => {
+    console.error("Fatal:", e);
+    process.exit(2);
+  });
+}

--- a/tests/issue-2787.test.ts
+++ b/tests/issue-2787.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2787 — Differential-test harness must capture ASYNCHRONOUS console.log
+// side-effects.
+//
+// Top-level corpus code can schedule callbacks (`Promise.resolve().then(...)`,
+// `async`/`await`) that call the host `console.log` import *after*
+// `__module_init()` returns. Before the fix the harness restored console.log
+// immediately after `__module_init()`, so those late writes fired past the
+// capture window: they leaked to the real stdout AND the program recorded EMPTY
+// output — a false `mismatch` against the V8 oracle. `runJs2wasm` now drains the
+// microtask + macrotask job queue inside the capture window (see `drainAsync`),
+// so promise/async output is captured. These three programs regressing back to
+// empty output is exactly what this test guards.
+
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { runJs2wasm } from "../scripts/diff-test.ts";
+
+const CORPUS = resolve(fileURLToPath(import.meta.url), "..", "differential/corpus");
+
+describe("#2787 diff-test harness captures async console.log", () => {
+  it("Promise.resolve().then() output is captured (not empty)", async () => {
+    const r = await runJs2wasm(resolve(CORPUS, "builtins/07-promise-basic.js"));
+    expect(r.outcome).toBe("match");
+    expect(r.stdout).toBe("42");
+  });
+
+  it("promise chain .then callbacks are captured", async () => {
+    const r = await runJs2wasm(resolve(CORPUS, "builtins/08-promise-chain.js"));
+    expect(r.outcome).toBe("match");
+    expect(r.stdout).toBe("4");
+  });
+
+  it("async/await result is captured", async () => {
+    const r = await runJs2wasm(resolve(CORPUS, "builtins/09-async-await.js"));
+    expect(r.outcome).toBe("match");
+    expect(r.stdout).toBe("30");
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2787. Root cause was a **harness bug**, not the malformed-wasm fixtures (those are already 0 on main).

`scripts/diff-test.ts` restored the monkey-patched `console.log` in its `finally` block immediately after `__module_init()` returned. Corpus programs that log via `Promise.then` / `async`-`await` callbacks fired those writes *after* the capture window closed — leaking stray `42`/`4`/`30` to real stdout and recording empty output (a false `mismatch` against the V8 oracle, which drains its full job queue before exit).

Fix: `runJs2wasm` now awaits a bounded microtask + macrotask drain (`drainAsync`) inside the capture window before restoring `console.log`. **No compiler change** — Promise/async lowering already worked; the harness was discarding the output (the 2026-07-06 "stayed empty after drain" note was mistaken).

Result: corpus **96 → 99/104 match**. `builtins/07-promise-basic`, `08-promise-chain`, `09-async-await` now match. The committed `diff-test-baseline.json` is refreshed to 99 so the delta gate protects them. The remaining 5 failures are genuine #2796/#2797 substrate gaps, correctly deferred.

Files: `scripts/diff-test.ts` (drainAsync + exported `runJs2wasm` + entry-point guard), `tests/issue-2787.test.ts` (new, 3/3 pass), `benchmarks/results/diff-test-baseline.json`, `plan/issues/2787-*.md`.

Validation: `tsc` clean; prettier + biome clean on changed files; scoped vitest 3/3; diff-test delta gate exits 0 (no regressions).

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — the cla-check gate auto-skips. Legal attestation left for a human maintainer. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEr53nWNQM8tcCyQw6WuY2)_