### PR TITLE
fix(#3407): guard test262 fixture runner inner catch against duplicate/contradictory verdict rows

### DIFF
--- a/plan/issues/3407-test262-duplicate-verdict-key-invariant.md
+++ b/plan/issues/3407-test262-duplicate-verdict-key-invariant.md
@@ -1,9 +1,9 @@
 ---
 id: 3407
 title: "test262 fixture runner emits duplicate and contradictory verdict rows; enforce one canonical result per file"
-status: ready
+status: in-review
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 priority: high
 horizon: m
 feasibility: medium

--- a/scripts/verdict-once.mjs
+++ b/scripts/verdict-once.mjs
@@ -1,0 +1,36 @@
+// #3407 — one canonical test262 verdict per file.
+//
+// The fixture runner's `recordResult` writes the canonical JSONL row for a
+// verdict and THEN throws a `ConformanceError` for every non-pass status (so a
+// failing test still surfaces to vitest). That sentinel is the signal that a
+// row has ALREADY been written for this file.
+//
+// The fixture execution path nests two catches: an inner catch that classifies
+// an execution error into a verdict, and an outer catch that treats an
+// unexpected throw as a compile error. If EITHER catch receives a
+// recorded-verdict sentinel and proceeds to call `recordResult` again, it emits
+// a SECOND, often contradictory, row for the same file (e.g. a `pass` path that
+// `recordResult` internally reclassified to `compile_error` via a standalone
+// host-import leak throws its sentinel into the inner catch, which then records
+// a `fail` "ConformanceError: [compile_error] …" row). That is the
+// duplicate/contradictory verdict-key defect this module guards against.
+//
+// Both catches must therefore RETHROW a recorded-verdict sentinel before any
+// error-classification branch, so the already-written row stays the single
+// canonical verdict.
+//
+// The check is name-based rather than `instanceof` so it holds across module
+// realms and for any future subclass that keeps the `ConformanceError` name.
+
+/**
+ * @param {unknown} err
+ * @returns {boolean} true when `err` is the sentinel `recordResult` throws after
+ *   it has already written a canonical (non-pass) verdict row.
+ */
+export function isRecordedVerdictSentinel(err) {
+  return (
+    !!err &&
+    (typeof err === "object" || typeof err === "function") &&
+    /** @type {{ name?: unknown }} */ (err).name === "ConformanceError"
+  );
+}

--- a/tests/issue-3407-verdict-key-invariant.test.ts
+++ b/tests/issue-3407-verdict-key-invariant.test.ts
@@ -1,0 +1,145 @@
+// #3407 — the test262 fixture runner must emit exactly ONE canonical verdict
+// row per file. `recordResult` writes the JSONL row and then throws a
+// ConformanceError sentinel for any non-pass verdict; the fixture execution
+// path nests an inner classification catch inside an outer compile-error catch.
+// Before the guard, a `pass` record that `recordResult` internally reclassified
+// to `compile_error` (standalone host-import leak) threw its sentinel into the
+// inner catch, which reclassified it into a SECOND, contradictory `fail` row —
+// the duplicate/contradictory verdict-key defect.
+//
+// This test pins the shared `isRecordedVerdictSentinel` guard AND a faithful
+// model of the fixture runner's two-catch control flow, proving the guard makes
+// every branch emit exactly one row and that WITHOUT the guard the double-write
+// reproduces.
+import { describe, it, expect } from "vitest";
+import { isRecordedVerdictSentinel } from "../scripts/verdict-once.mjs";
+
+// Mirror of tests/test262-shared.ts ConformanceError: recordResult throws this
+// AFTER it has already written the canonical JSONL row for a non-pass verdict.
+class ConformanceError extends Error {
+  constructor(status: string, detail?: string) {
+    super(`[${status}] ${detail || "unknown"}`);
+    this.name = "ConformanceError";
+  }
+}
+
+describe("#3407 isRecordedVerdictSentinel", () => {
+  it("recognizes a ConformanceError instance as an already-recorded verdict", () => {
+    expect(isRecordedVerdictSentinel(new ConformanceError("fail", "boom"))).toBe(true);
+    expect(isRecordedVerdictSentinel(new ConformanceError("compile_error"))).toBe(true);
+  });
+
+  it("recognizes any object carrying the ConformanceError name (cross-realm safe)", () => {
+    expect(isRecordedVerdictSentinel({ name: "ConformanceError", message: "x" })).toBe(true);
+  });
+
+  it("does NOT treat ordinary execution errors or non-errors as recorded verdicts", () => {
+    expect(isRecordedVerdictSentinel(new Error("plain execution throw"))).toBe(false);
+    expect(isRecordedVerdictSentinel(new TypeError("bad"))).toBe(false);
+    expect(isRecordedVerdictSentinel(Symbol("originalHarnessNoThrow"))).toBe(false);
+    expect(isRecordedVerdictSentinel(undefined)).toBe(false);
+    expect(isRecordedVerdictSentinel(null)).toBe(false);
+    expect(isRecordedVerdictSentinel("ConformanceError")).toBe(false);
+  });
+});
+
+// ── Faithful model of the fixture runner's nested-catch verdict flow ────────
+//
+// Reproduces tests/test262-shared.ts:713-862 structure: an inner try records a
+// `pass` (which recordResult may reclassify to compile_error + throw), an inner
+// catch classifies execution errors, and an outer catch treats an unexpected
+// throw as compile_error. `guard` is injected so we can prove the shipped guard
+// is load-bearing (guard on ⇒ one row; guard off ⇒ the historical double write).
+type Row = { status: string; error?: string };
+
+const RUNTIME_NEG_SUCCESS = Symbol("originalHarnessNoThrow");
+
+function simulateFixture(
+  scenario: {
+    // an execution error thrown from the try body BEFORE the `pass` record
+    execThrow?: unknown;
+    // recordResult internally flips a `pass` to compile_error (host-import leak)
+    hostImportLeak?: boolean;
+    isRuntimeNegative?: boolean;
+  },
+  // The inner catch (test262-shared.ts:779) is the one #3407 adds a guard to.
+  // The outer catch (test262-shared.ts:843) has always carried the #1221 guard,
+  // so it is fixed ON here — the historical defect was the INNER catch alone.
+  innerGuard: (err: unknown) => boolean,
+): Row[] {
+  const rows: Row[] = [];
+  // Mirror of recordResult: write the row, then throw the sentinel for non-pass.
+  const recordResult = (status: string, error?: string): void => {
+    let s = status;
+    let e = error;
+    if (s === "pass" && scenario.hostImportLeak) {
+      s = "compile_error";
+      e = "standalone host-import leak";
+    }
+    rows.push({ status: s, error: e });
+    if (s !== "pass") throw new ConformanceError(s, e);
+  };
+
+  try {
+    try {
+      // try body (test262-shared.ts:713-778)
+      if (scenario.isRuntimeNegative) throw RUNTIME_NEG_SUCCESS;
+      if (scenario.execThrow !== undefined) throw scenario.execThrow;
+      recordResult("pass");
+    } catch (execErr: unknown) {
+      // inner classification catch (test262-shared.ts:779) — guard under test
+      if (innerGuard(execErr)) throw execErr;
+      if (execErr === RUNTIME_NEG_SUCCESS) {
+        recordResult("fail", "expected runtime error but execution succeeded");
+      } else {
+        recordResult("fail", String(execErr));
+      }
+    }
+  } catch (e: unknown) {
+    // outer compile-error catch (test262-shared.ts:843) — #1221 guard always on
+    if (isRecordedVerdictSentinel(e)) return rows;
+    recordResult("compile_error", String(e));
+  }
+  return rows;
+}
+
+describe("#3407 fixture verdict-key invariant — exactly one row per file", () => {
+  const guard = isRecordedVerdictSentinel;
+
+  it("positive pass records exactly one pass row", () => {
+    const rows = simulateFixture({}, guard);
+    expect(rows).toEqual([{ status: "pass", error: undefined }]);
+  });
+
+  it("ordinary execution failure records exactly one fail row", () => {
+    const rows = simulateFixture({ execThrow: new Error("boom") }, guard);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("fail");
+  });
+
+  it("runtime-negative that succeeds records exactly one fail row", () => {
+    const rows = simulateFixture({ isRuntimeNegative: true }, guard);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("fail");
+  });
+
+  it("REGRESSION: pass reclassified to compile_error records exactly one row", () => {
+    // The core #3407 case: recordResult flips pass→compile_error and throws its
+    // sentinel INTO the inner catch. The guard must rethrow, not re-record.
+    const rows = simulateFixture({ hostImportLeak: true }, guard);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("compile_error");
+  });
+
+  it("proves the inner guard is load-bearing: WITHOUT it the pass→compile_error case double-writes", () => {
+    const noInnerGuard = () => false;
+    const rows = simulateFixture({ hostImportLeak: true }, noInnerGuard);
+    // Historical defect: the inner catch re-records a contradictory `fail` row
+    // (whose message embeds the ConformanceError sentinel) after the real
+    // compile_error row; the outer #1221 guard then stops a third write.
+    expect(rows).toHaveLength(2);
+    expect(rows[0].status).toBe("compile_error");
+    expect(rows[1].status).toBe("fail");
+    expect(rows[1].error).toContain("ConformanceError");
+  });
+});

--- a/tests/test262-shared.ts
+++ b/tests/test262-shared.ts
@@ -17,6 +17,7 @@ import { availableParallelism } from "os";
 import { CompilerPool, type TestResult } from "../scripts/compiler-pool.js";
 import { isPoisonCompileError } from "../scripts/test262-poison-error.mjs";
 import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "../scripts/negative-verdict.mjs";
+import { isRecordedVerdictSentinel } from "../scripts/verdict-once.mjs";
 import { findNthAssert } from "./test262-assert-locator.js";
 import { ORACLE_VERSION } from "./test262-oracle-version.js";
 import {
@@ -777,6 +778,15 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   );
                   return;
                 } catch (execErr: any) {
+                  // #3407: recordResult() writes the canonical JSONL row and then
+                  // throws a ConformanceError sentinel for any non-pass verdict.
+                  // The "pass" record above can be reclassified to compile_error
+                  // inside recordResult (standalone host-import leak) and throw
+                  // that sentinel INTO this catch. Reclassifying it here would
+                  // write a SECOND, contradictory row for the same file. Rethrow
+                  // the already-recorded verdict before any classification branch;
+                  // the outer guard is defense in depth.
+                  if (isRecordedVerdictSentinel(execErr)) throw execErr;
                   const execRecordMetadata = metadataFromImports(result.imports, reachedFixtureTest);
                   if (execErr === originalHarnessNoThrow) {
                     recordResult(
@@ -831,14 +841,15 @@ export function runTest262Chunk(chunkIndex: number, totalChunks: number) {
                   }
                 }
               } catch (e: any) {
-                // #1221: recordResult() throws a ConformanceError after
+                // #1221/#3407: recordResult() throws a ConformanceError after
                 // writing the JSONL row whenever status !== "pass". If we
                 // catch THAT and call recordResult again, we double-write
                 // the row (e.g. a "fail" row followed by a "compile_error"
                 // row prefixed "[fail] …"). Re-throw so the inner record
                 // is the only JSONL entry, matching the non-FIXTURE path
-                // which has no outer catch.
-                if (e instanceof ConformanceError) throw e;
+                // which has no outer catch. Shared guard with the inner catch
+                // so both catches apply one identical duplicate policy.
+                if (isRecordedVerdictSentinel(e)) throw e;
                 recordResult(
                   relPath,
                   category,


### PR DESCRIPTION
## Description

Fixes #3407 (producer-side guard + regression test; steps 1–2 of the issue).

Root cause: the fixture runner's **inner** classification catch (`tests/test262-shared.ts:779`) lacked the #1221 double-write guard the **outer** catch already has. `recordResult` writes the canonical JSONL row and then throws a `ConformanceError` sentinel for any non-pass verdict. When the `pass` path was internally reclassified to `compile_error` (standalone host-import leak), that sentinel landed in the inner catch, which re-recorded a second, contradictory `fail` row for the same file — the duplicate/contradictory verdict keys the issue documents.

Fix:
- New `scripts/verdict-once.mjs` — shared `isRecordedVerdictSentinel` helper (name-based, so it holds across module realms).
- Rethrow the sentinel at the top of the inner catch before any classification branch; route the outer catch through the same helper so both apply one identical duplicate policy.
- `tests/issue-3407-verdict-key-invariant.test.ts` — guard unit tests + a faithful model of the two-catch flow proving each branch emits exactly one row and the inner guard is load-bearing.

Out of scope (flagged for a follow-up): steps 3–6 — streaming JSONL uniqueness validator, merge-report rejection check, consumer alignment, rebaseline.

Validation: scoped vitest 8/8; `tsc --noEmit` clean; prettier + biome clean.

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — cla-check auto-skips. Legal attestation left for a human maintainer. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEr53nWNQM8tcCyQw6WuY2)_