### PR TITLE
fix(#3408): retire non-atomic issue-ID entrypoints in favor of the atomic allocator

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "scripts": {
     "release": "node scripts/release.mjs",
-    "new:issue-id": "node scripts/next-issue-id.mjs",
+    "new:issue-id": "node scripts/claim-issue.mjs --allocate",
+    "preview:issue-id": "node scripts/next-issue-id.mjs",
     "worktree:provision": "bash scripts/provision-worktree-deps.sh",
     "build": "vite build --config vite.config.lib.ts",
     "build:playground": "vite build --config website/playground/vite.config.ts",

--- a/plan/agent-context/dev-1125-bench.md
+++ b/plan/agent-context/dev-1125-bench.md
@@ -268,7 +268,7 @@ User asked for a Claude Code statusline sprint progress bar (e.g. " sprint 45 " 
 
 ## Operational notes for next session
 
-1. **Use `node scripts/next-issue-id.mjs` BEFORE creating any issue file**. The tool landed during this session as commit `e002a706f`. Even then, the ID can collide if main moves between check and merge — the safer pattern is to defer ID assignment to push time, but the tool reduces the collision rate dramatically.
+1. **Allocate an issue ID atomically with `node scripts/claim-issue.mjs --allocate` (`pnpm run new:issue-id`) BEFORE creating any issue file** — it RESERVES the id (first-push-wins on the `issue-assignments` ref) against main + open PRs, so concurrent branches can't collide. `scripts/next-issue-id.mjs` (`pnpm run preview:issue-id`) only PREDICTS `max+1` without reserving and races; use it for read-only visibility only, never to allocate. (Historical note: this session predated the atomic reserver and used the predictor `next-issue-id.mjs`, which landed as commit `e002a706f`.)
 
 2. **Two agents working the same issue independently is a real failure mode.** PR #74 and PR #75 both fixed #1186 with functionally-equivalent patches. The `file-locks.md` mechanism gave both agents (me with `compileForOfString`, the other agent with whatever they claimed) false confidence. Consider:
    - File-locks should claim by ISSUE number, not just by function-in-file.

--- a/plan/agent-context/tech-lead.md
+++ b/plan/agent-context/tech-lead.md
@@ -59,7 +59,7 @@ No context summaries were written by agents. State captured here instead:
 
 ### Tooling shipped this session
 - `scripts/statusline-sprint.mjs` — sprint progress script (used by statusline-command.sh)
-- `scripts/next-issue-id.mjs` — reliably returns next free issue number
+- `scripts/next-issue-id.mjs` — read-only PREVIEW of the next free issue number (`pnpm run preview:issue-id`); does NOT reserve. To ALLOCATE an id, use the atomic reserver `node scripts/claim-issue.mjs --allocate` (`pnpm run new:issue-id`).
 - `.claude/statusline-command.sh` — updated with sprint bar + days-left bar
 - `.claude/settings.json` — statusLine wired to statusline-command.sh with 30s refresh
 

--- a/plan/issues/3408-retire-nonatomic-issue-id-entrypoints.md
+++ b/plan/issues/3408-retire-nonatomic-issue-id-entrypoints.md
@@ -1,9 +1,9 @@
 ---
 id: 3408
 title: "Retire non-atomic issue-ID entrypoints and stale collision-remediation guidance"
-status: ready
+status: in-review
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 priority: high
 horizon: s
 feasibility: easy

--- a/scripts/check-issue-ids.mjs
+++ b/scripts/check-issue-ids.mjs
@@ -226,6 +226,8 @@ if (dupes.length === 0) {
     for (const f of files) console.error(`    plan/issues/${f}`);
   }
   console.error("");
-  console.error("Fix: rename the newer file to use a fresh ID (next after the current max).");
+  console.error("Fix: reserve a FRESH id atomically and rename the newer file —");
+  console.error("  NEW=$(node scripts/claim-issue.mjs --allocate)   # prints the reserved id");
+  console.error("  git mv plan/issues/<old>-<slug>.md plan/issues/$NEW-<slug>.md   # then set frontmatter id: $NEW");
   process.exit(1);
 }

--- a/scripts/check-merged-issue-integrity.mjs
+++ b/scripts/check-merged-issue-integrity.mjs
@@ -161,8 +161,9 @@ if (result.status !== 0) {
   console.error(
     `\n[merged-issue-integrity] FAILED against the merge with ${baseRef}. ` +
       `This is the collision that would otherwise wedge the merge queue. ` +
-      `Rename the colliding issue file to a fresh id (see ` +
-      `\`node scripts/next-issue-id.mjs\`) and re-push.`,
+      `Rename the colliding issue file to a freshly RESERVED id ` +
+      `(\`node scripts/claim-issue.mjs --allocate\` — atomic: reserves against ` +
+      `main + open PRs + the issue-assignments ref) and re-push.`,
   );
 }
 process.exit(result.status ?? 1);

--- a/scripts/next-issue-id.mjs
+++ b/scripts/next-issue-id.mjs
@@ -21,7 +21,12 @@
 // --allocate --dry-run --no-pr-scan`); it does not consult open PRs.
 //
 // Usage:  node scripts/next-issue-id.mjs        -> prints e.g. 1745 (preview only)
-//         pnpm run new:issue-id
+//         pnpm run preview:issue-id             -> same, read-only preview
+//
+// NOTE: `pnpm run new:issue-id` is NO LONGER this predictor — it now runs the
+// ATOMIC reserver (`claim-issue.mjs --allocate`), which MUTATES the reservation
+// ref on the orphan `issue-assignments` branch. Use `pnpm run preview:issue-id`
+// when you want visibility WITHOUT reserving an id.
 
 import { execSync } from "node:child_process";
 import { readdirSync } from "node:fs";

--- a/tests/issue-3408.test.ts
+++ b/tests/issue-3408.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3408 — retire non-atomic issue-ID entrypoints and stale collision-repair
+// guidance. Static, no-network contract tests (they never reserve an id): the
+// canonical creation alias and every active collision-remediation message must
+// point at the ATOMIC allocator (`claim-issue.mjs --allocate`), never at the
+// non-reserving predictor (`next-issue-id.mjs`), which only prints `max+1` and
+// races — the dup surfaces in `merge_group`, wedging the queue. The read-only
+// predictor may survive, but only under an explicitly "preview" alias name.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8");
+const pkg = JSON.parse(read("../package.json")) as { scripts: Record<string, string> };
+
+const ALLOCATOR = "claim-issue.mjs --allocate";
+const PREDICTOR = "next-issue-id.mjs";
+
+describe("#3408 issue-ID entrypoint contract", () => {
+  it("canonical `new:issue-id` runs the atomic allocator, not the predictor", () => {
+    const cmd = pkg.scripts["new:issue-id"];
+    expect(cmd, "new:issue-id script must exist").toBeTruthy();
+    expect(cmd).toContain(ALLOCATOR);
+    expect(cmd).not.toContain(PREDICTOR);
+  });
+
+  it("`new:issue-id:allocate` remains an atomic-allocator alias", () => {
+    const cmd = pkg.scripts["new:issue-id:allocate"];
+    expect(cmd).toContain(ALLOCATOR);
+    expect(cmd).not.toContain(PREDICTOR);
+  });
+
+  it("the read-only predictor survives only under an explicit `preview` alias", () => {
+    const predictorAliases = Object.entries(pkg.scripts)
+      .filter(([, cmd]) => cmd.includes(PREDICTOR))
+      .map(([name]) => name);
+    // A named preview alias must exist so read-only visibility is preserved.
+    expect(predictorAliases).toContain("preview:issue-id");
+    // AND no non-preview alias may invoke the predictor.
+    for (const name of predictorAliases) {
+      expect(name, `predictor alias '${name}' must be labeled preview`).toMatch(/preview/i);
+    }
+  });
+
+  it("merged-issue-integrity collision remediation points at the atomic allocator", () => {
+    const src = read("../scripts/check-merged-issue-integrity.mjs");
+    expect(src).toContain(ALLOCATOR);
+    // Must NOT send users to repair a collision with the racing predictor.
+    expect(src).not.toContain(PREDICTOR);
+  });
+
+  it("check-issue-ids duplicate-ID remediation points at the atomic allocator", () => {
+    const src = read("../scripts/check-issue-ids.mjs");
+    expect(src).toContain(ALLOCATOR);
+    // The user must not be sent back to a racy `max+1` predictor.
+    expect(src).not.toContain(PREDICTOR);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #3408.

Retires the non-atomic issue-ID entrypoints so a hand-picked / `max+1` id can't race two branches into the same number:

- `package.json` — `new:issue-id` now runs `node scripts/claim-issue.mjs --allocate` (the atomic reserver); the racy predictor survives only under a new read-only `preview:issue-id` alias. Existing `new:issue-id:allocate` retained.
- `scripts/next-issue-id.mjs` — usage docs point at `preview:issue-id` and warn that `new:issue-id` now mutates the reservation ref.
- `scripts/check-merged-issue-integrity.mjs` / `scripts/check-issue-ids.mjs` — collision-remediation messages now recommend the atomic `claim-issue.mjs --allocate` flow instead of `next-issue-id.mjs` / "max+1".
- `plan/agent-context/tech-lead.md`, `plan/agent-context/dev-1125-bench.md` — active guidance updated to the atomic allocator (historical framing retained).
- `tests/issue-3408.test.ts` — new static, no-network contract test locking in the atomic-allocator invariant so aliases/messages can't drift back.

No `CLAUDE.md` changes needed.

Validation: scoped vitest (issue-3408 5/5, issue-2943 4/4); `node scripts/check-issue-ids.mjs` clean; `claim-issue.mjs --allocate --dry-run --no-pr-scan` smoke ok; `tsc --noEmit` clean; prettier + biome clean on changed code files.

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — cla-check auto-skips. Legal attestation left for a human maintainer. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEr53nWNQM8tcCyQw6WuY2)_