### PR TITLE
fix(#3459): clamp baseline drift clock-age to non-negative (fix -43m clock-skew)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1530,10 +1530,13 @@ jobs:
           MAIN_HEAD_TS=$(git log -1 --format=%ct origin/main 2>/dev/null || git log -1 --format=%ct main 2>/dev/null || echo 0)
           BASELINE_TS="${{ steps.fetch_baseline.outputs.baseline_ts }}"
           BASELINE_SHA="${{ steps.fetch_baseline.outputs.baseline_sha }}"
-          DIFF_M=0
-          if [ "$MAIN_HEAD_TS" != "0" ] && [ "$BASELINE_TS" != "0" ]; then
-            DIFF_M=$(( (MAIN_HEAD_TS - BASELINE_TS) / 60 ))
-          fi
+          # #3459 — compute the clock age via the extracted, unit-tested helper.
+          # Both operands are epoch SECONDS but come from DIFFERENT clock sources
+          # (main HEAD committer time vs. baseline-generation wall-clock), so the
+          # raw difference can be negative when the post-merge baseline refresh is
+          # fresher than main HEAD — which used to print a nonsensical `-43m clock
+          # age`. The helper clamps to a non-negative age and flags the skew.
+          DIFF_M=$(node scripts/baseline-clock-age.mjs --main-ts "$MAIN_HEAD_TS" --baseline-ts "$BASELINE_TS")
           echo "stale_minutes=$DIFF_M" >> "$GITHUB_OUTPUT"
 
           # Parse the baseline's recorded main-sha from the baselines-repo commit

--- a/plan/issues/3459-drift-check-negative-clock-age.md
+++ b/plan/issues/3459-drift-check-negative-clock-age.md
@@ -1,7 +1,7 @@
 ---
 id: 3459
 title: "merge_group drift check reports negative baseline clock age (-43m) — clock-skew bug in instrumentation"
-status: ready
+status: in-review
 sprint: current
 created: 2026-07-19
 updated: 2026-07-19

--- a/scripts/baseline-clock-age.mjs
+++ b/scripts/baseline-clock-age.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3459 — Baseline drift/staleness "clock age" computation.
+//
+// The merge-shard-reports path of `.github/workflows/test262-sharded.yml`
+// prints a baseline "clock age" (`${DIFF_M}m clock age`) in its drift/
+// staleness footer. It was computed inline as
+//
+//     DIFF_M=$(( (MAIN_HEAD_TS - BASELINE_TS) / 60 ))
+//
+// which could go NEGATIVE (a `-43m clock age` was observed during the #3375
+// merge_group triage). Root cause: the two operands are DIFFERENT clock
+// sources with the same epoch unit but no ordering guarantee —
+//
+//   * MAIN_HEAD_TS  = git committer time (`git log -1 --format=%ct`, epoch
+//                     SECONDS) of the `origin/main` HEAD commit.
+//   * BASELINE_TS   = the wall-clock time (epoch SECONDS) at which the
+//                     baselines-repo JSONL was generated/committed.
+//
+// The baseline is refreshed by `promote-baseline` AFTER a merge lands, so the
+// baseline generation time is routinely LATER than the committer time of the
+// main commit it reflects. That legitimately makes `BASELINE_TS > MAIN_HEAD_TS`
+// → a negative raw difference. Semantically "age" is "how stale is the
+// baseline relative to main HEAD"; a baseline that is fresher than main HEAD is
+// not stale at all, so its age is 0, not a negative number.
+//
+// This module centralises the age computation on a SINGLE documented epoch
+// unit (seconds) and CLAMPS the result to be non-negative, flagging the skew
+// case so the CI log still records that the raw difference was negative.
+//
+// Usage (CLI, mirrors the inline bash it replaces):
+//   node scripts/baseline-clock-age.mjs --main-ts <sec> --baseline-ts <sec>
+//     → prints the clamped non-negative age in whole MINUTES to stdout.
+//   add --json to print { ageMinutes, rawMinutes, clamped } instead.
+//
+// A skew (raw < 0) additionally emits a `::notice::` to stderr so the
+// negative-input case is visible in the job log without corrupting the stdout
+// value the workflow captures into DIFF_M.
+
+const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Compute the baseline "clock age" in whole minutes from two epoch-SECONDS
+ * timestamps, clamped to be non-negative.
+ *
+ * @param {number} mainHeadTsSec  git committer time of origin/main HEAD (epoch seconds)
+ * @param {number} baselineTsSec  baseline-generation wall-clock time (epoch seconds)
+ * @returns {{ ageMinutes: number, rawMinutes: number, clamped: boolean }}
+ *   ageMinutes  — clamped, never negative (the value CI should display)
+ *   rawMinutes  — the un-clamped signed difference (negative under clock skew)
+ *   clamped     — true when the raw difference was negative and got clamped to 0
+ */
+export function computeClockAgeMinutes(mainHeadTsSec, baselineTsSec) {
+  const main = Number(mainHeadTsSec);
+  const baseline = Number(baselineTsSec);
+
+  // Missing / unparsable / sentinel-zero inputs → age is undetermined; report
+  // 0 (the same conservative default the inline bash used when either ts was
+  // "0"). Not a skew, so `clamped` stays false.
+  if (!Number.isFinite(main) || !Number.isFinite(baseline) || main <= 0 || baseline <= 0) {
+    return { ageMinutes: 0, rawMinutes: 0, clamped: false };
+  }
+
+  // Both operands are epoch SECONDS. Truncate toward zero to whole minutes,
+  // matching the integer `/ 60` the bash arithmetic did.
+  const rawMinutes = Math.trunc((main - baseline) / SECONDS_PER_MINUTE);
+  const ageMinutes = Math.max(0, rawMinutes);
+  return { ageMinutes, rawMinutes, clamped: rawMinutes < 0 };
+}
+
+function parseArgs(argv) {
+  const args = { mainTs: undefined, baselineTs: undefined, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--main-ts") args.mainTs = argv[++i];
+    else if (a === "--baseline-ts") args.baselineTs = argv[++i];
+    else if (a === "--json") args.json = true;
+    else if (a === "--help" || a === "-h") {
+      console.log("usage: baseline-clock-age.mjs --main-ts <epoch-sec> --baseline-ts <epoch-sec> [--json]");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function main() {
+  const { mainTs, baselineTs, json } = parseArgs(process.argv.slice(2));
+  const result = computeClockAgeMinutes(mainTs ?? 0, baselineTs ?? 0);
+  if (result.clamped) {
+    // Surface the skew in the CI log without polluting the captured stdout.
+    console.error(
+      `::notice::[baseline-clock-age] baseline is fresher than main HEAD ` +
+        `(raw age ${result.rawMinutes}m < 0 — clock skew: baseline generated ` +
+        `after the main HEAD commit time). Reporting clamped age 0m.`,
+    );
+  }
+  if (json) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(String(result.ageMinutes));
+  }
+}
+
+// Only run the CLI when invoked directly, not when imported by tests.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  main();
+}

--- a/tests/issue-3459.test.ts
+++ b/tests/issue-3459.test.ts
@@ -1,0 +1,67 @@
+// #3459 — the baseline drift/staleness "clock age" must never be negative.
+//
+// The merge-shard-reports drift footer in test262-sharded.yml printed a
+// `-43m clock age` when the baseline (refreshed post-merge) was fresher than
+// the origin/main HEAD committer time. These pin the extracted computation:
+//   1. a baseline older than main HEAD → positive age (normal staleness),
+//   2. a baseline FRESHER than main HEAD → clamped to 0 with a skew flag
+//      (the actual bug: never a negative age),
+//   3. the epoch unit is a single documented one (SECONDS in, MINUTES out),
+//   4. missing/sentinel-zero inputs → 0, undetermined (not a skew).
+import { describe, expect, it } from "vitest";
+import { computeClockAgeMinutes } from "../scripts/baseline-clock-age.mjs";
+
+describe("#3459 baseline clock-age is never negative", () => {
+  it("reports positive whole-minute age when baseline is older than main HEAD", () => {
+    // main HEAD committed 90 minutes after the baseline was generated.
+    const mainHead = 1_700_000_000;
+    const baseline = mainHead - 90 * 60;
+    const r = computeClockAgeMinutes(mainHead, baseline);
+    expect(r.ageMinutes).toBe(90);
+    expect(r.rawMinutes).toBe(90);
+    expect(r.clamped).toBe(false);
+  });
+
+  it("clamps to 0 (not negative) when the baseline is FRESHER than main HEAD — the -43m bug", () => {
+    // Reproduces the observed skew: baseline generated 43 minutes AFTER the
+    // main HEAD commit time (baseline refresh runs post-merge).
+    const mainHead = 1_700_000_000;
+    const baseline = mainHead + 43 * 60;
+    const r = computeClockAgeMinutes(mainHead, baseline);
+    expect(r.ageMinutes).toBe(0); // never -43
+    expect(r.ageMinutes).toBeGreaterThanOrEqual(0);
+    expect(r.rawMinutes).toBe(-43); // raw skew preserved for the log
+    expect(r.clamped).toBe(true);
+  });
+
+  it("treats seconds in and minutes out as the single documented epoch unit", () => {
+    // 3600 seconds difference == 60 minutes, truncated toward zero.
+    const r = computeClockAgeMinutes(2000 + 3661, 2000);
+    expect(r.ageMinutes).toBe(61); // 3661s -> 61m (trunc)
+    expect(r.clamped).toBe(false);
+  });
+
+  it("returns 0 and undetermined for sentinel-zero / missing timestamps", () => {
+    expect(computeClockAgeMinutes(0, 1_700_000_000)).toEqual({
+      ageMinutes: 0,
+      rawMinutes: 0,
+      clamped: false,
+    });
+    expect(computeClockAgeMinutes(1_700_000_000, 0)).toEqual({
+      ageMinutes: 0,
+      rawMinutes: 0,
+      clamped: false,
+    });
+    expect(computeClockAgeMinutes(NaN, NaN)).toEqual({
+      ageMinutes: 0,
+      rawMinutes: 0,
+      clamped: false,
+    });
+  });
+
+  it("accepts string timestamps (as passed from bash) and never goes negative", () => {
+    const r = computeClockAgeMinutes("1700000000", "1700002580");
+    expect(r.ageMinutes).toBe(0); // baseline 43m fresher
+    expect(r.clamped).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #3459.

The merge-shard-reports drift/staleness footer computed clock age inline as `(MAIN_HEAD_TS - BASELINE_TS)/60`. The two operands share the epoch unit (seconds) but are **different clock sources with no ordering guarantee** — `MAIN_HEAD_TS` is `origin/main` HEAD committer time, `BASELINE_TS` is baseline-generation wall-clock time. Since `promote-baseline` refreshes the baseline *after* a merge lands, `BASELINE_TS > MAIN_HEAD_TS` is normal, producing the nonsensical `-43m` age. Instrumentation-only (did not affect the regression verdict), but it makes the staleness signal untrustworthy.

Fix:
- New `scripts/baseline-clock-age.mjs` — `computeClockAgeMinutes()` + CLI mirroring the inline bash: documented single unit (seconds in / minutes out), clamps age to `>= 0` (a baseline fresher than main HEAD is not stale → age 0), and flags the skew case via `::notice::` on stderr so captured stdout stays clean.
- `.github/workflows/test262-sharded.yml` — the staleness step now calls the helper.
- `tests/issue-3459.test.ts` — pins sign/clamp/unit behavior incl. the `-43m` reproduction.

Validation: scoped vitest 5/5; prettier + biome clean; YAML parses; CLI manually exercised (normal→90, skew→0+notice, sentinel→0).

## CLA

- [ ] I have read and agree to the CLA

<!-- Internal/org-member PR — cla-check auto-skips. Legal attestation left for a human maintainer. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEr53nWNQM8tcCyQw6WuY2)_