### PR TITLE
ci(#3457): net-aware / flap-tolerant test262 regression-ratio gate

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1695,6 +1695,28 @@ jobs:
 
       - name: Compare against current main baseline
         id: regression_diff
+        # NET-AWARE / FLAP-TOLERANT fine gate (#3457). `diff-test262.ts`'s
+        # regression-RATIO arm (the #1943 10 % gate) no longer hard-fails when
+        # the stable-path NET (improvements − wasm-change regressions) is ≥ 0.
+        # A raw ratio counts the regression side without netting it against an
+        # equal-or-larger improvement side, so SYMMETRIC content-current flap
+        # (improvements ≈ regressions; #3351/#3318/#3359, net ≈ 0) and genuine
+        # net-conformance GAINS with a few offsetting edge-case regressions
+        # (#3406 net +29 / ratio 17 %; #3409 net +30 / ratio 11.8 %) were
+        # false-parked, each costing a `hold` + a full re-validation run.
+        # New classification (see scripts/diff-test262.ts
+        # evaluateRegressionThresholds):
+        #   • net ≥ 0                         → ratio breach is an advisory
+        #                                       `GATE WARN`, NOT a fail.
+        #   • net < 0 AND regressions ≥ 10    → ratio breach HARD-FAILS (a real
+        #                                       one-directional net regression).
+        #   • net < 0 AND regressions < 10    → advisory WARN (small-sample floor:
+        #                                       the ratio is noise; the net gate
+        #                                       (net < 0) already hard-fails it).
+        # UNCHANGED hard gates (orthogonal, still park regardless of net): the
+        # net gate (net < 0), the per-bucket >50 concentration check, and the
+        # #3189 uncatchable-trap growth ratchet. `compile_timeout` / ct_flake is
+        # already excluded from the wasm-change regression numerator.
         if: env.SHARDS_RAN == 'true'
         env:
           # #1954 — scoped PR runs: restrict the baseline to the scope or

--- a/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
+++ b/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
@@ -1,7 +1,8 @@
 ---
 id: 3457
 title: "ci(test262): make the merge_group regression-ratio gate flap-tolerant (stop false-parking symmetric content-current churn)"
-status: ready
+status: in-progress
+assignee: ttraenkler/senior-dev-3457
 sprint: current
 created: 2026-07-19
 updated: 2026-07-19
@@ -67,3 +68,95 @@ regressions, and each false-park costs a `hold` + a full re-validation run.
 - #3376 (logged the flap evidence during the firefight).
 - Review: `plan/ci-acceleration-review.md` §2.4 (guard fragility / contention
   pricing).
+
+## Implementation Plan (senior-dev, 2026-07-19)
+
+### Root cause (precise)
+
+The fine gate lives in `scripts/diff-test262.ts`, invoked from the "Compare
+against current main baseline" step (`id: regression_diff`) of
+`.github/workflows/test262-sharded.yml` and hard-failed by the downstream
+"Fail on regressions" step. In the NON-rebase branch of `run()` the gate has
+TWO independent hard-fail conditions:
+
+1. **Net gate** — `netPerTest = stableImprovements − regressionsWasmChange < 0`.
+2. **Ratio gate** (`evaluateRegressionThresholds`, #1943) — fires whenever
+   `regressionsWasmChange > 0` AND `regressions/improvements ≥ 10 %`,
+   **independently of net**. This is the over-park bug: a net-POSITIVE PR
+   (#3409 net +30, ratio 11.8 %; #3406 net +29, ratio 17 %) trips condition (2)
+   even though condition (1) passes.
+
+`regressionsWasmChange` already excludes `compile_timeout`, wasm-identical
+noise, host-canary-quarantined paths, leaky→host-free, and vacuity flips — so
+AC2 (compile_timeout excluded from the numerator) is ALREADY satisfied by the
+existing `noiseFiltered` filter (`r.to !== "compile_timeout"`). Verified, no
+change needed there.
+
+### Change (net-aware / flap-tolerant ratio gate — #3457)
+
+`evaluateRegressionThresholds` now computes `net = improvements − regressions`
+and classifies the ratio breach:
+
+- **`net ≥ 0`** → the ratio breach is a **WARNING, not a failure**. Net
+  conformance held or rose; the regressions are outnumbered by improvements in
+  the same run (symmetric flap / net-positive). This is the AC1 fix.
+- **`net < 0` AND `regressions ≥ SMALL_SAMPLE_FLOOR (10)`** → ratio breach is a
+  **hard FAILURE** (a genuine, statistically-meaningful one-directional
+  regression). AC3.
+- **`net < 0` AND `regressions < 10`** → ratio breach is a **WARNING**: below
+  the floor a single flaky flip dominates the ratio, so it is statistically
+  meaningless. The independent net gate (net<0) already hard-fails this diff, so
+  we don't ALSO report a noisy ratio as a separate hard failure. AC-small-sample.
+
+**Floor = 10.** Reasoning: below ~10 transitions a single flake shifts the ratio
+by ≥10 points (1 flake on a 9-improvement PR = 11 %), so the ratio is noise; 10
+is well under the 50-per-bucket concentration limit so a genuinely concentrated
+break still trips the (unchanged) bucket gate; and the net gate independently
+catches any true net-negative change regardless of the floor. The floor gates
+only the RATIO signal — it never lets a net-negative change pass.
+
+**Return shape**: `evaluateRegressionThresholds` now returns
+`{ failures: string[]; warnings: string[] }` (was `string[]`). The CLI prints
+`GATE WARN (#3457): …` for warnings and `GATE FAIL: …` for failures. The
+per-bucket (>50) concentration check stays a hard failure, unconditional on net.
+
+### Gates PRESERVED unchanged (verified)
+
+- **Net gate** (`netPerTest < 0`) — untouched; still the primary hard fail.
+- **#3189 uncatchable-trap growth ratchet** (`evaluateTrapCategoryGrowth`) —
+  untouched; still a SEPARATE hard fail independent of net (a net-positive PR
+  that adds a null_deref/illegal_cast/oob/unreachable still parks). AC-trap.
+- **Per-bucket >50 concentration** — untouched hard fail.
+- **Rebase-mode gate** (`evaluateRebaseGate`, #3086/#3303 regressions-allow) —
+  untouched; the net-aware ratio logic is in the NON-rebase branch only, so the
+  `regressions-allow:` escape hatch composes cleanly (it only lives in rebase
+  mode).
+- **`scripts/check-baseline-trap-growth.ts`** (promote-side trap ratchet) —
+  NOT touched.
+
+### oracle_version — NO bump (verified)
+
+This is a PR-level GATE-DECISION change, not a per-test verdict change. The
+per-SHA verdict caches (status / error_category in the JSONL) are unaffected, so
+cached rows stay valid. `scripts/check-verdict-oracle-bump.mjs` only triggers on
+edits to `PURE_VERDICT_FILES` / `MIXED_VERDICT_FILES`
+(negative-verdict.mjs, test262-worker.mjs, test262-shared.ts,
+test262-vitest.test.ts, test262-runner.ts) — `scripts/diff-test262.ts` is NOT in
+that surface, so the oracle-bump gate does not fire.
+
+### `--baseline-content-current`
+
+The `baseline_content_current` signal exists as a **workflow step output**
+(staleness step) used only for the drift FOOTER message; it is NOT a
+`diff-test262.ts` CLI flag today (the comment at yml:1223 is aspirational). The
+net-≥0 waiver added here addresses the same content-current flake class more
+directly and generally, so no new flag is wired. The existing footer path is
+left untouched.
+
+### Tests
+
+`tests/issue-1943.test.ts` updated for the new return shape + net-aware
+semantics; new cases in `tests/issue-3457.test.ts`: net-positive-high-ratio →
+PASS (warning); net-negative + regressions≥floor → FAIL; net-negative +
+regressions<floor → PASS (small-sample floor); bucket>50 → FAIL regardless of
+net; net-zero symmetric churn → PASS.

--- a/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
+++ b/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
@@ -40,7 +40,7 @@ regressions, and each false-park costs a `hold` + a full re-validation run.
 ## Fix (spec)
 
 1. **Require ASYMMETRIC churn before parking** — park only when regressions
-   *materially exceed* improvements, not on a raw ratio. Net-neutral symmetric
+   _materially exceed_ improvements, not on a raw ratio. Net-neutral symmetric
    flap must pass.
 2. **Exclude `compile_timeout` / `ct_flake` ≤ 5000 ms noise from the regression
    numerator** — runner-load contention timeouts are not content regressions
@@ -62,7 +62,7 @@ regressions, and each false-park costs a `hold` + a full re-validation run.
 ## Related
 
 - #1943 (established the 10 % ratio / 50-per-bucket gate this refines).
-- #3404 (sibling: promote tolerates single-shard *upload* flake — a different
+- #3404 (sibling: promote tolerates single-shard _upload_ flake — a different
   flake, not this content-churn gate).
 - #3447 (same spirit: contention-tolerant compile-timeout count guard).
 - #3376 (logged the flap evidence during the firefight).

--- a/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
+++ b/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
@@ -1,11 +1,12 @@
 ---
 id: 3457
 title: "ci(test262): make the merge_group regression-ratio gate flap-tolerant (stop false-parking symmetric content-current churn)"
-status: in-progress
+status: done
 assignee: ttraenkler/senior-dev-3457
 sprint: current
 created: 2026-07-19
 updated: 2026-07-19
+completed: 2026-07-19
 priority: medium
 horizon: m
 feasibility: medium

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -33,6 +33,17 @@ export const REGRESSION_RATIO_LIMIT = 0.1;
 export const REGRESSION_BUCKET_LIMIT = 50;
 export const REGRESSION_BUCKET_PATH_DEPTH = 5;
 
+// #3457 — small-sample floor for the regression-RATIO gate. Below this absolute
+// count of wasm-change regressions the ratio is statistically meaningless: a
+// single flaky pass↔fail flip shifts the ratio by ≥10 points (1 flake on a
+// 9-improvement diff already reads 11 %), so a raw 10 % ratio breach on a tiny
+// sample is noise, not signal. The floor is well under the 50-per-bucket
+// concentration limit, so a genuinely concentrated break still trips the
+// (unchanged) bucket gate; and the independent net gate (net < 0) still
+// hard-fails any true net-negative change regardless of the floor. See the
+// #3351/#3318/#3359 and #3406/#3409 false-parks in plan/issues/3457-*.md.
+export const REGRESSION_RATIO_SMALL_SAMPLE_FLOOR = 10;
+
 export interface HostNoiseCanaryProvenance {
   canary_run_id: number;
   compiler_sha: string;
@@ -428,28 +439,82 @@ export function bucketRegressions(files: string[]): { bucket: string; count: num
   return [...counts.entries()].map(([bucket, count]) => ({ bucket, count })).sort((a, b) => b.count - a.count);
 }
 
+export interface RegressionThresholdResult {
+  /** Human-readable HARD-FAIL reasons (empty ⇒ the ratio/bucket gate passes). */
+  failures: string[];
+  /**
+   * Human-readable ADVISORY signals that did NOT hard-fail (#3457): a ratio
+   * breach that was waived because the change is net-positive/net-neutral, or
+   * because the absolute regression count is below the small-sample floor. The
+   * CLI prints these as `GATE WARN` so the signal stays visible without parking.
+   */
+  warnings: string[];
+}
+
 /**
  * Evaluate the documented merge thresholds against the wasm-hash-filtered
- * counts. Returns the list of human-readable failure reasons (empty ⇒ pass).
- * Pure (no I/O) so the unit test can drive it directly with fixture data
- * (#1943 acceptance criteria). The ratio gate only fires when there is at
- * least one regression — a clean PR (R == 0) always passes regardless of how
- * few improvements it carries.
+ * counts. Pure (no I/O) so the unit test can drive it directly with fixture
+ * data (#1943 acceptance criteria).
+ *
+ * #3457 — NET-AWARE / FLAP-TOLERANT ratio gate. The raw 10 % regression-ratio
+ * gate (#1943) false-parked net-positive and net-neutral PRs: symmetric
+ * content-current flap (improvements ≈ regressions, so NET ≥ 0) and genuine
+ * net-conformance GAINS with a handful of offsetting edge-case regressions
+ * (#3406 net +29 ratio 17 %; #3409 net +30 ratio 11.8 %; #3351/#3318/#3359
+ * net-neutral) all tripped the ratio even though conformance held or rose. The
+ * ratio is now classified against the NET (improvements − regressions):
+ *
+ *   • net ≥ 0                              → ratio breach is a WARNING, not a
+ *                                            fail. Conformance did not drop, so
+ *                                            the regressions are outnumbered —
+ *                                            not merge-blocking.
+ *   • net < 0 AND regressions ≥ floor(10)  → ratio breach HARD-FAILS: a
+ *                                            statistically-meaningful,
+ *                                            one-directional net regression.
+ *   • net < 0 AND regressions <  floor(10) → ratio breach is a WARNING: below
+ *                                            the small-sample floor the ratio is
+ *                                            noise (a single flake dominates it),
+ *                                            and the independent net gate already
+ *                                            hard-fails this net-negative diff.
+ *
+ * The per-bucket (>50) concentration check is UNCHANGED and stays a hard fail
+ * independent of net — a net-positive PR that nukes one test family (≥50 in one
+ * bucket) is still suspicious and still parks. The #3189 uncatchable-trap growth
+ * ratchet and the net gate (net < 0) live outside this function and are likewise
+ * unchanged. The ratio gate only fires when there is at least one wasm-change
+ * regression — a clean diff (R == 0) always passes.
  */
 export function evaluateRegressionThresholds(opts: {
   improvements: number;
   regressionsWasmChange: number;
   regressedFiles: string[];
-}): string[] {
+}): RegressionThresholdResult {
   const failures: string[] = [];
+  const warnings: string[] = [];
   const { improvements, regressionsWasmChange, regressedFiles } = opts;
+  const net = improvements - regressionsWasmChange;
   if (regressionsWasmChange > 0) {
     const ratio = improvements > 0 ? regressionsWasmChange / improvements : Infinity;
     if (ratio >= REGRESSION_RATIO_LIMIT) {
       const pct = improvements > 0 ? (ratio * 100).toFixed(1) + "%" : "∞ (0 improvements)";
-      failures.push(
-        `regression ratio ${pct} (${regressionsWasmChange}/${improvements}) meets/exceeds the ${(REGRESSION_RATIO_LIMIT * 100).toFixed(0)}% limit`,
-      );
+      const base = `regression ratio ${pct} (${regressionsWasmChange}/${improvements}) meets/exceeds the ${(REGRESSION_RATIO_LIMIT * 100).toFixed(0)}% limit`;
+      if (net >= 0) {
+        // Net conformance held or rose — the ratio is advisory, not blocking.
+        warnings.push(
+          `${base} — WAIVED (#3457): net conformance change is +${net} (improvements ${improvements} ≥ regressions ${regressionsWasmChange}); ratio is advisory on a net-positive/neutral diff`,
+        );
+      } else if (regressionsWasmChange < REGRESSION_RATIO_SMALL_SAMPLE_FLOOR) {
+        // Net-negative but below the small-sample floor — ratio too noisy to
+        // gate on; the net gate (net < 0) already fails this diff.
+        warnings.push(
+          `${base} — WAIVED (#3457): only ${regressionsWasmChange} wasm-change regression(s) < small-sample floor ${REGRESSION_RATIO_SMALL_SAMPLE_FLOOR}; ratio is statistically noisy on a small sample (the net gate already hard-fails this net-negative diff)`,
+        );
+      } else {
+        // Net-negative AND ≥ floor regressions — a real one-directional break.
+        failures.push(
+          `${base} (net ${net} < 0, ${regressionsWasmChange} ≥ small-sample floor ${REGRESSION_RATIO_SMALL_SAMPLE_FLOOR})`,
+        );
+      }
     }
   }
   for (const { bucket, count } of bucketRegressions(regressedFiles)) {
@@ -457,7 +522,7 @@ export function evaluateRegressionThresholds(opts: {
       failures.push(`bucket "${bucket}" has ${count} regressions, exceeds the ${REGRESSION_BUCKET_LIMIT}-test limit`);
     }
   }
-  return failures;
+  return { failures, warnings };
 }
 
 /** Minimal row shape the trap ratchet needs (a subset of `TestResult`). */
@@ -1772,14 +1837,21 @@ async function run(
     // that previously lived only in the dev-self-merge skill text. Same
     // wasm-hash-filtered count the net gate uses (`noiseFiltered`), so
     // compile_timeout flaps and byte-identical flips never trip these either.
-    const thresholdFailures = evaluateRegressionThresholds({
+    // #3457 — the ratio arm is now NET-AWARE: a ratio breach on a net-positive
+    // / net-neutral diff (or below the small-sample floor) is reported as a
+    // WARNING, not a hard fail. The per-bucket concentration check stays a hard
+    // fail. See evaluateRegressionThresholds.
+    const thresholdResult = evaluateRegressionThresholds({
       improvements: stableImprovements.length,
       regressionsWasmChange,
       regressedFiles: noiseFiltered.map((r) => r.file),
     });
-    for (const reason of thresholdFailures) {
+    for (const reason of thresholdResult.failures) {
       console.log(`=== GATE FAIL: ${reason} ===`);
       gateFailed = true;
+    }
+    for (const warning of thresholdResult.warnings) {
+      console.log(`=== GATE WARN (#3457): ${warning} ===`);
     }
   }
 

--- a/tests/issue-1943.test.ts
+++ b/tests/issue-1943.test.ts
@@ -3,6 +3,7 @@ import {
   REGRESSION_RATIO_LIMIT,
   REGRESSION_BUCKET_LIMIT,
   REGRESSION_BUCKET_PATH_DEPTH,
+  REGRESSION_RATIO_SMALL_SAMPLE_FLOOR,
   bucketRegressions,
   evaluateRegressionThresholds,
 } from "../scripts/diff-test262.js";
@@ -11,11 +12,18 @@ import {
 // must be ENFORCED by the regression gate, not just documented in the
 // dev-self-merge skill text. These unit tests pin the pure gate logic so the
 // constants and the bucket grouping stay byte-identical to the skill.
+//
+// #3457 — the ratio arm is now NET-AWARE (see issue-3457.test.ts for the full
+// matrix): a ratio breach on a net-positive/neutral diff or below the
+// small-sample floor is a WARNING, not a hard fail. `evaluateRegressionThresholds`
+// now returns `{ failures, warnings }` instead of a bare `string[]`. The
+// per-bucket concentration check remains a hard fail independent of net.
 describe("#1943 — regression threshold enforcement", () => {
   it("exposes the documented constants", () => {
     expect(REGRESSION_RATIO_LIMIT).toBe(0.1);
     expect(REGRESSION_BUCKET_LIMIT).toBe(50);
     expect(REGRESSION_BUCKET_PATH_DEPTH).toBe(5);
+    expect(REGRESSION_RATIO_SMALL_SAMPLE_FLOOR).toBe(10);
   });
 
   it("buckets regressions by the first 5 path segments (skill-identical)", () => {
@@ -28,18 +36,18 @@ describe("#1943 — regression threshold enforcement", () => {
     expect(buckets.find((b) => b.bucket === "test/built-ins/Array/prototype/some")?.count).toBe(1);
   });
 
-  it("FAILS a 10-improvement / 5-regression diff (ratio 50%)", () => {
-    const failures = evaluateRegressionThresholds({
-      improvements: 10,
-      regressionsWasmChange: 5,
-      regressedFiles: Array.from({ length: 5 }, (_, i) => `test/built-ins/Reg${i}/x/y/t.js`),
+  it("HARD-FAILS a net-negative 12-improvement / 20-regression diff (ratio 167%, net −8 ≥ floor)", () => {
+    const { failures } = evaluateRegressionThresholds({
+      improvements: 12,
+      regressionsWasmChange: 20,
+      regressedFiles: Array.from({ length: 20 }, (_, i) => `test/built-ins/Reg${i}/x/y/t.js`),
     });
     expect(failures.length).toBeGreaterThan(0);
-    expect(failures.some((f) => f.includes("ratio") && f.includes("50.0%"))).toBe(true);
+    expect(failures.some((f) => f.includes("ratio") && f.includes("166.7%"))).toBe(true);
   });
 
   it("FAILS a 60-in-one-bucket diff even when the ratio is under 10%", () => {
-    const failures = evaluateRegressionThresholds({
+    const { failures } = evaluateRegressionThresholds({
       improvements: 700, // 60/700 = 8.6% < 10% → ratio OK
       regressionsWasmChange: 60,
       regressedFiles: Array.from({ length: 60 }, (_, i) => `test/built-ins/Array/prototype/every/case${i}.js`),
@@ -49,25 +57,31 @@ describe("#1943 — regression threshold enforcement", () => {
   });
 
   it("PASSES a clean diff (no regressions, few improvements)", () => {
-    expect(evaluateRegressionThresholds({ improvements: 2, regressionsWasmChange: 0, regressedFiles: [] })).toEqual([]);
+    expect(evaluateRegressionThresholds({ improvements: 2, regressionsWasmChange: 0, regressedFiles: [] })).toEqual({
+      failures: [],
+      warnings: [],
+    });
   });
 
-  it("PASSES a borderline 9% ratio (under the 10% limit)", () => {
+  it("PASSES a borderline 9% ratio (under the 10% limit) with no warning", () => {
     expect(
       evaluateRegressionThresholds({
         improvements: 100,
         regressionsWasmChange: 9,
         regressedFiles: Array.from({ length: 9 }, (_, i) => `test/reg${i}/x/y/z/t.js`),
       }),
-    ).toEqual([]);
+    ).toEqual({ failures: [], warnings: [] });
   });
 
-  it("FAILS when regressions exist but there are zero improvements (∞ ratio)", () => {
-    const failures = evaluateRegressionThresholds({
+  it("WARNS (does not fail) with zero improvements below the floor (∞ ratio, net<0, small sample)", () => {
+    const { failures, warnings } = evaluateRegressionThresholds({
       improvements: 0,
       regressionsWasmChange: 3,
       regressedFiles: ["test/a/b/c/d/e.js", "test/a/b/c/d/f.js", "test/g/h/i/j/k.js"],
     });
-    expect(failures.some((f) => f.includes("ratio") && f.includes("∞"))).toBe(true);
+    // 3 regressions < floor(10): the ratio is too noisy to hard-fail; the net
+    // gate (net < 0) is what fails such a diff, not the ratio.
+    expect(failures).toEqual([]);
+    expect(warnings.some((w) => w.includes("ratio") && w.includes("∞") && w.includes("small-sample floor"))).toBe(true);
   });
 });

--- a/tests/issue-3457.test.ts
+++ b/tests/issue-3457.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  REGRESSION_RATIO_SMALL_SAMPLE_FLOOR,
+  evaluateRegressionThresholds,
+  evaluateTrapCategoryGrowth,
+} from "../scripts/diff-test262.js";
+
+// #3457 — NET-AWARE / FLAP-TOLERANT regression-ratio gate.
+//
+// The raw 10 % regression-ratio gate (#1943) false-parked clean, net-positive
+// and net-neutral PRs on small-sample flap:
+//   • #3406 — issue-ID *scripts* only (0 codegen files): net +29, ratio 17 %
+//             (6/35). The 6 "regressions" are physically impossible with no
+//             codegen change → pure runner flake. Parked anyway.
+//   • #3409 — real codegen lane-flip: stable-path net +30 (34 improvements − 4
+//             regressions), ratio 11.8 %. A genuine net conformance GAIN parked.
+//   • #3351/#3318/#3359 — symmetric content-current async/$DONE flap, net ≈ 0.
+//
+// The fix classifies the ratio breach against the NET (improvements −
+// regressions): net ≥ 0 → advisory WARNING; net < 0 with regressions ≥ the
+// small-sample floor → hard FAIL; net < 0 below the floor → advisory WARNING
+// (the independent net gate fails it). The per-bucket (>50) concentration check
+// and the #3189 uncatchable-trap growth ratchet stay independent hard gates.
+describe("#3457 — net-aware / flap-tolerant regression-ratio gate", () => {
+  const regFiles = (n: number, prefix = "Reg") =>
+    Array.from({ length: n }, (_, i) => `test/built-ins/${prefix}${i}/a/b/c.js`);
+
+  it("WAIVES the ratio on a net-positive high-ratio diff — #3409 signature (34 imp / 4 reg, net +30, 11.8%)", () => {
+    const { failures, warnings } = evaluateRegressionThresholds({
+      improvements: 34,
+      regressionsWasmChange: 4,
+      regressedFiles: regFiles(4),
+    });
+    expect(failures).toEqual([]); // NOT parked
+    expect(warnings.some((w) => w.includes("11.8%") && w.includes("WAIVED") && w.includes("+30"))).toBe(true);
+  });
+
+  it("WAIVES the ratio on a net-positive high-ratio diff — #3406 signature (35 imp / 6 reg, net +29, 17.1%)", () => {
+    const { failures, warnings } = evaluateRegressionThresholds({
+      improvements: 35,
+      regressionsWasmChange: 6,
+      regressedFiles: regFiles(6),
+    });
+    expect(failures).toEqual([]);
+    expect(warnings.some((w) => w.includes("WAIVED") && w.includes("net conformance change is +29"))).toBe(true);
+  });
+
+  it("WAIVES the ratio on net-NEUTRAL symmetric churn — #3351/#3318/#3359 signature (20 imp / 20 reg, net 0)", () => {
+    const { failures, warnings } = evaluateRegressionThresholds({
+      improvements: 20,
+      regressionsWasmChange: 20,
+      regressedFiles: regFiles(20),
+    });
+    expect(failures).toEqual([]); // net 0 ≥ 0 → not parked
+    expect(warnings.some((w) => w.includes("WAIVED") && w.includes("+0"))).toBe(true);
+  });
+
+  it("HARD-FAILS a genuine net-negative one-directional regression (10 imp / 25 reg, net −15 ≥ floor)", () => {
+    const { failures } = evaluateRegressionThresholds({
+      improvements: 10,
+      regressionsWasmChange: 25,
+      regressedFiles: regFiles(25),
+    });
+    expect(failures.some((f) => f.includes("ratio") && f.includes("net -15"))).toBe(true);
+  });
+
+  it("HARD-FAILS a net-negative diff with zero improvements once at/above the floor (0 imp / 10 reg, ∞ ratio)", () => {
+    const { failures } = evaluateRegressionThresholds({
+      improvements: 0,
+      regressionsWasmChange: REGRESSION_RATIO_SMALL_SAMPLE_FLOOR, // exactly the floor
+      regressedFiles: regFiles(REGRESSION_RATIO_SMALL_SAMPLE_FLOOR),
+    });
+    expect(failures.some((f) => f.includes("ratio") && f.includes("∞"))).toBe(true);
+  });
+
+  it("small-sample floor: WARNS (does not fail) a net-negative diff just below the floor (2 imp / 9 reg, net −7)", () => {
+    const { failures, warnings } = evaluateRegressionThresholds({
+      improvements: 2,
+      regressionsWasmChange: 9, // < floor(10)
+      regressedFiles: regFiles(9),
+    });
+    expect(failures).toEqual([]); // ratio does not hard-fail; net gate (elsewhere) does
+    expect(warnings.some((w) => w.includes("small-sample floor") && w.includes("WAIVED"))).toBe(true);
+  });
+
+  it("per-bucket >50 concentration STILL hard-fails even when the diff is net-positive (#3457 keeps the bucket gate)", () => {
+    const files = Array.from({ length: 60 }, (_, i) => `test/built-ins/Array/prototype/every/case${i}.js`);
+    const { failures } = evaluateRegressionThresholds({
+      improvements: 1000, // net +940, ratio 6% — ratio arm would waive
+      regressionsWasmChange: 60,
+      regressedFiles: files,
+    });
+    expect(failures.some((f) => f.includes("bucket") && f.includes("every") && f.includes("60"))).toBe(true);
+    expect(failures.some((f) => f.includes("ratio"))).toBe(false); // ratio under 10% and net-positive anyway
+  });
+
+  it("a net-positive diff with NO ratio breach produces neither failure nor warning (5% ratio)", () => {
+    expect(
+      evaluateRegressionThresholds({ improvements: 100, regressionsWasmChange: 5, regressedFiles: regFiles(5) }),
+    ).toEqual({ failures: [], warnings: [] });
+  });
+
+  // The #3189 uncatchable-trap growth ratchet is a SEPARATE hard gate that must
+  // still fire regardless of net — a net-positive PR that introduces a new
+  // null_deref / illegal_cast / oob / unreachable trap still parks.
+  it("trap-growth ratchet HARD-FAILS a new illegal_cast trap even when the surrounding diff is net-positive", () => {
+    const baseline = new Map<string, { status: string; error_category?: string; wasm_sha?: string | null }>([
+      ["test/a.js", { status: "pass", wasm_sha: "aaaa" }],
+    ]);
+    const newer = new Map<string, { status: string; error_category?: string; wasm_sha?: string | null }>([
+      ["test/a.js", { status: "pass", wasm_sha: "aaaa" }],
+      // A brand-new illegal_cast trap on a file that changed binary.
+      ["test/b.js", { status: "fail", error_category: "illegal_cast", wasm_sha: "bbbb" }],
+    ]);
+    const growth = evaluateTrapCategoryGrowth(baseline, newer);
+    expect(growth.failures.some((f) => f.includes("illegal_cast") && f.includes("ratchet"))).toBe(true);
+    // The net-aware ratio arm on its own would WAIVE this diff (net-positive),
+    // proving the two gates are orthogonal: the trap ratchet parks it anyway.
+    const ratio = evaluateRegressionThresholds({
+      improvements: 50,
+      regressionsWasmChange: 1,
+      regressedFiles: ["test/b.js"],
+    });
+    expect(ratio.failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

The #1943 regression-**ratio** gate hard-failed a PR whenever
`regressions/improvements >= 10%`, **independently of the net conformance
change**. This false-parked clean, net-positive and net-neutral PRs on
small-sample flap:

- **#3406** — issue-ID *scripts* only (0 codegen files): net **+29**, ratio 17% (6/35). The 6 "regressions" are physically impossible with no codegen change → pure runner flake. Parked anyway.
- **#3409** — `unionAnyRep` lane-flip (real codegen): stable-path net **+30** (34 improvements − 4 regressions), ratio 11.8%. A genuine net conformance **GAIN**, parked.
- **#3351 / #3318 / #3359** — symmetric content-current async/`$DONE` flap, net ≈ 0.

## Change

`evaluateRegressionThresholds` (in `scripts/diff-test262.ts`) now classifies the
ratio breach against the **NET** (improvements − wasm-change regressions):

| Case | Result |
|------|--------|
| `net ≥ 0` | advisory `GATE WARN` — **not** a fail |
| `net < 0` AND `regressions ≥ 10` (small-sample floor) | hard `GATE FAIL` (real one-directional net regression) |
| `net < 0` AND `regressions < 10` | advisory `GATE WARN` (ratio is noise; the net gate already hard-fails the diff) |

Return type is now `{ failures, warnings }`; the CLI prints `GATE WARN (#3457)`
for waived breaches.

**Small-sample floor = 10**: below ~10 transitions a single flake shifts the
ratio by ≥10 points, so the ratio is statistically meaningless; 10 is well under
the 50-per-bucket concentration limit, and the net gate independently catches any
true net-negative change.

## Gates preserved UNCHANGED (orthogonal hard fails)

- **Net gate** (`net < 0`) — still the primary hard fail.
- **Per-bucket >50 concentration** check — still hard-fails regardless of net.
- **#3189 uncatchable-trap growth ratchet** — a net-positive PR that adds a new `null_deref`/`illegal_cast`/`oob`/`unreachable` still **parks**. `scripts/check-baseline-trap-growth.ts` untouched.
- **`compile_timeout` / ct_flake** stays excluded from the numerator (existing `noiseFiltered`).
- **Rebase-mode gate** (`evaluateRebaseGate`, #3086/#3303 `regressions-allow`) untouched — the net-aware logic is in the non-rebase branch only.

## oracle_version — NO bump

PR-level GATE-DECISION change, not a per-test verdict change. Per-SHA verdict
caches (oracle v8) stay valid; `check-verdict-oracle-bump.mjs` does not fire
(`diff-test262.ts` is not a verdict-logic file). Verified locally: gate exits 0
("no verdict-logic files changed").

## Tests

- `tests/issue-3457.test.ts` — full net matrix (net-positive-high-ratio → PASS/warn; net-negative≥floor → FAIL; net-negative<floor → warn; net-neutral → PASS; bucket>50 → FAIL regardless of net) + trap-ratchet orthogonality.
- `tests/issue-1943.test.ts` — updated for the new `{ failures, warnings }` return shape.
- CLI end-to-end verified: #3409 signature exits 0 with `GATE WARN`; net-negative≥floor exits 1 with both net + ratio `GATE FAIL`.

Closes #3457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)