### PR TITLE
fix(#3470): restore host-builtin method .name/.length sub-properties between test262 runs

### DIFF
--- a/plan/issues/3470-host-verifyproperty-name-length-realm-restore.md
+++ b/plan/issues/3470-host-verifyproperty-name-length-realm-restore.md
@@ -1,0 +1,156 @@
+---
+id: 3470
+title: "Host-lane test262: verifyProperty name/length delete leaks across shared-realm strict rerun (runner-only, extends #3318)"
+status: done
+completed: 2026-07-19
+assignee: ttraenkler/senior-dev
+sprint: current
+created: 2026-07-19
+priority: high
+feasibility: low
+task_type: bug
+area: tooling
+goal: test262-conformance
+related: [3318, 3417, 3471]
+origin: "Host<->standalone parity investigation, Cluster C2 sub-family (/workspace/.tmp/parity-findings.md) — ~370 js-host-lane test262 tests fail purely from harness realm pollution, not a compiler bug"
+---
+
+# #3470 — host-lane verifyProperty name/length restore gap (runner-only)
+
+## Problem
+
+~370 host-lane test262 tests fail as `"obj should have an own property
+name"` (or `length`) purely from harness realm pollution — not a compiler
+bug:
+
+- `verifyProperty` (`test262/harness/propertyHelper.js:63-66` asserts
+  `__hasOwnProperty(obj, name)`; the destructive probe is
+  `isConfigurable()` at line 140, `delete obj[name]`) does `delete
+obj[name]` to probe `configurable:true` and does **not** restore (these
+  tests pass no `restore` option — see `propertyHelper.js:131-133`).
+- The js-host lane uses SHARED real host builtins (both the in-process
+  runner `tests/test262-runner.ts` and the sharded CI fork pool
+  `scripts/test262-worker.mjs`). The sloppy run deletes e.g.
+  `Date.prototype.getYear.name`; it is never restored before the
+  auto-generated STRICT RERUN, so the strict run sees the missing
+  sub-property and fails.
+- Real Node passes (fresh realm per test). Standalone passes (fresh
+  per-module builtins). Only the shared-host-builtin js-host lane leaks.
+- `restoreHostBuiltins` (`tests/test262-restore-builtins.ts`, added by
+  #3318) restores method **VALUES** (function identity) but NOT the
+  `.name`/`.length` **sub-properties** of those methods — deleting
+  `fn.name` never changes `fn`'s identity, so the existing `cur === orig`
+  restore check is a no-op. Its `PROTOS` list also omits Date/TypedArray/
+  DataView entirely.
+
+### Timing verification (traced, not assumed)
+
+`tests/test262-runner.ts`'s `runTest262File` (4357-4413) runs the primary
+(sloppy) variant then, if it passed, the `strictRerun` variant — both via
+`runOriginalHarnessVariant` (4179-4350), which calls
+`restoreHostBuiltins()` at entry (4187) **and** in its `finally` block
+(4348). So for the in-process runner, restore genuinely fires **between**
+the sloppy run (which does the destructive delete) and the strict rerun
+(which reads the sub-property) — same process, same realm, confirmed by
+reading the call sites in context, not inferred from the fix landing.
+
+For the CI sharded lane, `tests/test262-shared.ts` (912-969) dispatches
+the primary and `strictRerun` variants as two separate
+`pool.runTest(...)` jobs against `scripts/test262-worker.mjs`'s fork pool
+(`scripts/compiler-pool.ts`); `restoreBuiltins()` runs before **and**
+after every `doCompile` in every fork (worker.mjs:898,1762). Same-fork
+reuse across a job stream isn't individually pinned, but a small number of
+long-lived forks each handle many thousands of jobs across the run, so any
+pollution left on a fork by one job's sloppy phase persists until cleaned
+— extending the restore closes the leak class everywhere it can recur, not
+just for a single test's own two-phase pair.
+
+## Fix (runner-only, NO compiler change)
+
+Extend the host-builtin restore to cover method `.name`/`.length`
+sub-properties, and add the missing constructors, in both lanes (#3227
+both-lanes-consistent rule):
+
+- `tests/test262-restore-builtins.ts`: for every function captured as a
+  data-property value across `PROTOS`, additionally snapshot + restore
+  that function's own `.name`/`.length` property descriptors (not just the
+  method's identity/value). Add `Date`, the `TypedArray` prototypes/
+  constructors (`Int8Array`..`Float64Array`, `BigInt64Array`,
+  `BigUint64Array`, and the abstract `%TypedArray%`), and `DataView` (+
+  their prototypes) to `PROTOS`.
+- `scripts/test262-worker.mjs`: mirror the same sub-property restore. The
+  worker's existing method-VALUE snapshots (`_METHOD_SNAPSHOTS`,
+  `_STATIC_SNAPSHOTS`) are curated per-object lists that don't cover every
+  method (e.g. `annexB` methods like `Date.prototype.getYear` aren't
+  listed at all), so the fix enumerates every function-valued own property
+  on a comprehensive root-object list (existing guarded prototypes +
+  Date/DataView/TypedArray-constructor entries) directly, rather than
+  extending the curated lists — this closes the gap for annexB methods too
+  and doesn't touch the FATAL/recycle validation paths (kept best-effort,
+  since built-in function name/length descriptors are always
+  `configurable:true` per spec).
+
+## Repro (confirms the mechanism)
+
+```js
+delete Date.prototype.getYear.name;
+// before=true delRet=true after=false
+```
+
+A fresh strict compile has the correct descriptor; the shared-realm host
+lane does not, until restored.
+
+Sample failing tests (`/workspace/.tmp/clC_set1.txt`):
+
+- `annexB/built-ins/Date/prototype/getYear/name.js`
+- `annexB/built-ins/RegExp/prototype/compile/name.js`
+- `annexB/built-ins/String/prototype/substr/name.js`
+
+## Acceptance criteria
+
+- `restoreHostBuiltins()` (in-process) and `restoreBuiltins()` (sharded
+  worker) restore a deleted `.name`/`.length` own property on a
+  Date/TypedArray/DataView prototype method between test runs.
+- Focused regression test: a `verifyProperty`-style configurability delete
+  on a Date/TypedArray method's `.name` is restored before a subsequent
+  compile/strict-rerun (unit-level, direct assertion on the restore
+  functions).
+- Zero compiler change; low risk (runner-only, best-effort restore, not
+  wired into fork-recycle FATAL paths).
+
+## CORRECTION (2026-07-19, during implementation) — revised impact estimate
+
+**The original "~370 host tests flip fail→pass" estimate does not hold.**
+Verified via the real CI baseline (`loopdive/js2wasm-baselines`
+`test262-current.jsonl`) and an end-to-end run of the cited sample files
+through `runTest262File` — see **#3471** (new issue, filed as part of this
+investigation) for the full analysis. Summary:
+
+- The 3 cited sample tests (and effectively the whole `name.js`/`length.js`
+  `verifyProperty`-with-`writable:false` family, ~1,444 tests) currently
+  fail on REAL CI with a **DIFFERENT, deeper signature**: `"Cannot assign
+to read only property"` (433 of 987 current fails), not `"obj should
+have an own property"` (only 13, and those are an unrelated bug in
+  synthetic Promise-executor-function naming, not this mechanism at all).
+- That deeper signature is a genuine **compiler bug** (#3471): a
+  strict-mode assignment to a non-writable host property correctly throws
+  `TypeError` (`src/runtime.ts:3979`, intentional per #2017) but the
+  compiled `try/catch` doesn't correctly catch/classify it as `instanceof
+TypeError`, so it propagates uncaught. This happens on a **fresh,
+  never-mutated realm too** (it doesn't depend on prior state), which is
+  why it dominates on CI's worker-pool architecture (low same-fork
+  correlation between a single test's own sloppy/strict phases) while THIS
+  issue's masking (`"obj should have an own property"`) is really only
+  reliably observable in the **single-process in-process runner**
+  (`tests/test262-runner.ts`, 100% same-realm guarantee between phases).
+- **Revised scope for #3470**: still a real, confirmed, zero-risk fix —
+  restores in-process-runner correctness (matters for
+  `pnpm run test:262:validate-baseline`, `/smoke-test-issue`, local
+  dev/debugging sessions that run tests in-process) and closes a genuine
+  realm-isolation gap in `restoreHostBuiltins`/`restoreBuiltins`. Its
+  **real CI/merge_group flip count is expected to be near-zero** until
+  #3471 also lands — the two together are what's needed to actually flip
+  the ~370-1,444 test family. Landing #3470 alone is still worthwhile
+  (correctness + it's the smaller, lower-risk half; #3471 is compiler-side
+  and explicitly out of this issue's "runner-only, no compiler change"
+  scope) but should not be reported as delivering ~370 CI flips.

--- a/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
+++ b/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
@@ -1,0 +1,180 @@
+---
+id: 3471
+title: "Host lane: strict-mode assignment to a non-writable host property throws but isn't caught as instanceof TypeError inside compiled try/catch (~433-541 test262 tests)"
+status: ready
+sprint: current
+created: 2026-07-19
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+goal: test262-conformance
+related: [3470, 3417, 2017]
+origin: "Discovered while implementing #3470 (host verifyProperty name/length restore) — the cited sample tests still failed after #3470's fix landed, on a DIFFERENT, deeper signature. Cross-checked against the real CI baseline (loopdive/js2wasm-baselines test262-current.jsonl, fetched 2026-07-19) to confirm this is the actual dominant CI failure mode for this test family, not a local artifact."
+---
+
+# #3471 — strict-mode write to a non-writable host property: TypeError thrown but not caught as `instanceof TypeError`
+
+## Problem
+
+test262's `propertyHelper.js` (`includes: [propertyHelper.js]`) has an
+`isWritable(obj, name)` helper used by essentially every `verifyProperty`
+call that checks `writable` in the descriptor (i.e. nearly every
+`built-ins/**/name.js` and `built-ins/**/length.js` test — the standard
+"every built-in function has a non-writable `.name`/`.length`" conformance
+check):
+
+```js
+try {
+  obj[name] = newValue;
+} catch (e) {
+  if (!(e instanceof TypeError)) {
+    throw new Test262Error("Expected TypeError, got " + e);
+  }
+}
+```
+
+In **strict mode** (the auto-generated strict rerun every normal test262
+script record gets), assigning to a non-writable data property MUST throw
+a catchable `TypeError` per `PutValue` (§6.2.5.6 step 3.e /
+`OrdinarySetWithOwnDescriptor` step 2.a). `src/runtime.ts:3975-3979`
+(`_safeSet`) **correctly implements this** — it's intentional, added for
+#2017:
+
+```ts
+} else if (desc.writable === false) {
+  // OrdinarySetWithOwnDescriptor step 2.a returns false for a
+  // non-writable data descriptor; PutValue turns that false into a
+  // TypeError for a strict Reference (§6.2.5.6 step 3.e).
+  throw new TypeError(`Cannot assign to read only property '${String(key)}' of object`);
+```
+
+But when this exact pattern runs inside the **compiled** `try { obj[name]
+= newValue } catch (e) { if (!(e instanceof TypeError)) throw ... }`, the
+thrown `TypeError` is **not correctly caught/classified** — it propagates
+out of the compiled function as an uncaught runtime error instead of being
+swallowed by the `catch` block (the expected/spec-correct outcome). The
+test then fails with:
+
+```
+strict rerun: Cannot assign to read only property 'name' of object
+```
+
+## Why this matters (scale)
+
+Cross-checked the REAL CI baseline (`loopdive/js2wasm-baselines`
+`test262-current.jsonl`, fetched via `scripts/fetch-baseline-jsonl.mjs`,
+2026-07-19):
+
+- 1,444 `built-ins/**` + `annexB/built-ins/**` tests ending in `name.js` or
+  `length.js` (the `verifyProperty(fn, "name"/"length", {writable:false,
+...})` conformance-check family).
+- Of the 987 that currently FAIL: **433 fail with exactly this signature**
+  (`"Cannot assign to read only property"` in `error`) — by far the single
+  largest bucket (vs. 13 for `"should have an own property"`, which turned
+  out to be an UNRELATED bug in synthetic Promise-executor/resolve/reject
+  function naming, not this one; the remaining 541 are heterogeneous other
+  failures).
+- Confirmed via `error_signature` field:
+  `runtime_error:strict rerun: Cannot assign to read only property 'name' of object`
+  (and the `'length'` variant) appear on `Array.prototype.slice`,
+  `Date.prototype.toISOString`, `Number.prototype.toExponential`,
+  `Math.atan2`, `Promise.race`, `String.prototype.charAt`, and dozens more
+  — this is a single, well-isolated, systemic gap, not per-feature noise.
+
+This is the **actual, currently-observed dominant blocker** for the
+`name.js`/`length.js` conformance-check family — much bigger than the
+~370-test estimate #3470 was scoped against (which assumed a DIFFERENT,
+narrower root cause — see "Relationship to #3470" below).
+
+## Repro
+
+Any of hundreds of test262 files reproduce this on current `main`:
+
+```bash
+npx tsx -e "
+import { runTest262File } from './tests/test262-runner.ts';
+const r = await runTest262File('test262/test/built-ins/Array/prototype/slice/name.js', 'built-ins');
+console.log(r.status, r.error);
+"
+# fail  strict rerun: TypeError: Cannot assign to read only property 'name' of object
+```
+
+Sample files (pick any):
+
+- `built-ins/Array/prototype/slice/name.js`
+- `annexB/built-ins/Date/prototype/getYear/name.js`
+- `annexB/built-ins/RegExp/prototype/compile/name.js`
+- `annexB/built-ins/String/prototype/substr/name.js`
+- `built-ins/DataView/prototype/getFloat64/name.js`
+
+**Note for the next investigator:** a _minimal_ isolated repro (a small
+standalone TS snippet doing `try { obj.name = "x" } catch (e) { return e
+instanceof TypeError }` against `Date.prototype.getYear`, compiled with
+`inferModuleStrictArguments: true`) did **NOT** reproduce the bug — it
+correctly returned `instanceof TypeError === true`. Neither did a version
+using a computed key (`obj[name] = newValue`) inside a separately-declared
+non-exported helper function with the same shape as `propertyHelper.js`'s
+`isWritable`. So the trigger is more specific than "compiled catch can't
+classify a host-thrown TypeError" in general — something about the FULL
+harness assembly (`assembleOriginalHarness` bundling `propertyHelper.js` +
+the test body into one compilation unit, or the specific
+`"use strict"`-prologue-based strict rerun vs. `inferModuleStrictArguments`
+module-strictness) changes the behavior. **Use `runTest262File` on a real
+test262 file as the repro**, not a hand-rolled snippet — my hand-rolled
+attempts (see `.tmp/probe-readonly-catch*.mts` pattern) undersell the bug.
+
+## Relationship to #3470 (important — do not conflate root causes)
+
+#3470 targeted a DIFFERENT bug: `verifyProperty`'s `isConfigurable()` probe
+(`delete obj[name]`, no restore) leaking across the auto strict rerun via
+shared host-realm builtins, observable ONLY when the sloppy and strict
+phases share the same process/fork. That bug is real (confirmed, fixed in
+#3470) but:
+
+- In the **in-process runner** (`tests/test262-runner.ts`, 100%
+  same-process guarantee), fixing #3470 does clear the "obj should have an
+  own property" masking — but then EVERY affected test hits THIS bug
+  (readonly-assign) underneath, since virtually all `name.js`/`length.js`
+  tests specify `writable: false`.
+- In the **real CI sharded worker pool** (`scripts/test262-worker.mjs` via
+  `scripts/compiler-pool.ts`), the sloppy/strict phases of a single test
+  essentially never land on the same fork in a live pool (many concurrent
+  tests interleaved), so #3470's masking condition rarely if ever
+  triggers there — meaning THIS bug (unconditional: it fires on a
+  perfectly fresh, never-mutated realm too, since it's a pure compiled-code
+  defect) is and was already the REAL, dominant, CI-observed failure mode
+  for this whole test family, independent of #3470.
+
+**#3470 is still worth having** (in-process-runner correctness — matters
+for local dev, `pnpm run test:262:validate-baseline`, `/smoke-test-issue`)
+but its real CI-flip impact is near-zero until THIS bug is also fixed.
+Fixing #3471 first (or with #3470) should flip the ~433 tests currently
+failing on this signature (module a small number that hit yet other
+issues underneath once this layer clears — same caution as always:
+signature-addressed ≠ guaranteed flip count, verify on CI).
+
+## Task
+
+1. Trace the compiled catch site: for a `try { obj[name] = newValue; }
+catch (e) { if (!(e instanceof TypeError)) ...}` pattern reachable via
+   `assembleOriginalHarness`'s bundled compile, determine why the thrown
+   `TypeError` from `_safeSet`'s `__extern_set_strict` host import path
+   (`src/runtime.ts:3979`) is not recognized by the compiled `instanceof
+TypeError` check, or does not reach the `catch` block at all (trap vs.
+   catchable exception — family of #581/#2025's exception-catchability
+   issues, worth checking those for a shared root cause first).
+2. Fix so the exception is a genuine catchable WASM exception classified
+   correctly as `TypeError` by compiled `instanceof` checks.
+3. Regression guard: a compiled `try { nonWritableProp = x } catch (e) { e
+instanceof TypeError }` returns `true` in a harness-bundle-shaped
+   compilation (not just a trivial single-function snippet).
+
+## Acceptance criteria
+
+- The 5 sample repro files above pass end-to-end via `runTest262File`.
+- Broad sweep of the 433-signature bucket shows a large net-positive flip
+  on CI/merge_group (verify actual count — this issue's estimate is
+  signature-based, not a guaranteed flip count per the usual caution).
+- No regressions in the existing exception/try-catch/strict-mode test
+  suites.

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -207,6 +207,7 @@ const _origArrayProtoSymbols = new Set(Object.getOwnPropertySymbols(Array.protot
 // safer mechanism (e.g. process.disconnect() before exit, or per-test
 // fork recycle for known-polluter test paths).
 const _typedArrayProto = Object.getPrototypeOf(Int8Array.prototype); // %TypedArray%.prototype
+const _typedArrayCtor = Object.getPrototypeOf(Int8Array); // %TypedArray% (abstract constructor)
 const _iteratorProto = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
 const _PROTO_EXTRA_CLEANUP = [
   ["Number.prototype", Number.prototype],
@@ -539,6 +540,153 @@ const _accessorOrig = _ACCESSOR_SNAPSHOTS.map(([name, obj, keys]) => ({
     .filter(([, d]) => d !== undefined && typeof d.get === "function"),
 }));
 
+// --- Category 5 (#3470) — function .name/.length own-property restore.
+//
+// test262's verifyProperty() (harness/propertyHelper.js:63-66 asserts
+// __hasOwnProperty(obj, name); the destructive probe is isConfigurable() at
+// line 140, `delete obj[name]`) probes configurable:true via
+// `delete obj[name]` and does NOT restore when no `restore` option is
+// passed -- the common case for built-ins/**/name.js and length.js tests.
+// When `obj` is itself a prototype method or a constructor (e.g.
+// `Date.prototype.getYear`, `Int8Array`), the delete removes THAT
+// FUNCTION's own "name"/"length" sub-property. None of the restore logic
+// above catches this: the function's identity never changes
+// (Date.prototype.getYear is still the same function reference), so
+// _restoreMethodProp's `cur === orig` check is a no-op. The next test
+// (whether that's this same test's auto strict-rerun landing on the same
+// fork, or any later test that reads the sub-property) then sees it
+// missing and fails "obj should have an own property name"/"length". Real
+// Node passes (fresh realm per test); standalone passes (fresh per-module
+// builtins). Only this shared-host-builtin fork leaks.
+//
+// The curated _METHOD_SNAPSHOTS/_STATIC_SNAPSHOTS lists above don't cover
+// every method (e.g. annexB Date.prototype.getYear isn't listed at all),
+// so rather than extending those lists this enumerates every
+// function-valued own property on a comprehensive root-object list
+// directly -- closing the gap for annexB methods too, without touching the
+// FATAL/recycle validation paths above (kept best-effort: built-in
+// function name/length descriptors are always configurable:true per spec,
+// so defineProperty here should never fail in practice).
+const _FN_SUBPROP_ROOTS = [
+  Object.prototype,
+  Object,
+  Array.prototype,
+  Array,
+  String.prototype,
+  String,
+  Number.prototype,
+  Number,
+  Boolean.prototype,
+  Boolean,
+  Function.prototype,
+  RegExp.prototype,
+  RegExp,
+  Map.prototype,
+  Set.prototype,
+  WeakMap.prototype,
+  WeakSet.prototype,
+  Promise.prototype,
+  Promise,
+  Error.prototype,
+  Date.prototype,
+  Date,
+  Math,
+  JSON,
+  Reflect,
+  _typedArrayProto,
+  _typedArrayCtor,
+  Int8Array.prototype,
+  Int8Array,
+  Uint8Array.prototype,
+  Uint8Array,
+  Uint8ClampedArray.prototype,
+  Uint8ClampedArray,
+  Int16Array.prototype,
+  Int16Array,
+  Uint16Array.prototype,
+  Uint16Array,
+  Int32Array.prototype,
+  Int32Array,
+  Uint32Array.prototype,
+  Uint32Array,
+  Float32Array.prototype,
+  Float32Array,
+  Float64Array.prototype,
+  Float64Array,
+  BigInt64Array.prototype,
+  BigInt64Array,
+  BigUint64Array.prototype,
+  BigUint64Array,
+  DataView.prototype,
+  DataView,
+  _iteratorProto,
+];
+
+function _snapshotFnSubProps(root) {
+  const out = [];
+  let keys;
+  try {
+    keys = [...Object.getOwnPropertyNames(root), ...Object.getOwnPropertySymbols(root)];
+  } catch {
+    return out;
+  }
+  for (const key of keys) {
+    let desc;
+    try {
+      desc = Object.getOwnPropertyDescriptor(root, key);
+    } catch {
+      continue;
+    }
+    if (!desc || typeof desc.value !== "function") continue;
+    const fn = desc.value;
+    out.push({
+      fn,
+      nameDesc: Object.getOwnPropertyDescriptor(fn, "name"),
+      lengthDesc: Object.getOwnPropertyDescriptor(fn, "length"),
+    });
+  }
+  return out;
+}
+
+const _fnSubPropOrig = (() => {
+  const seen = new Set();
+  const out = [];
+  for (const root of _FN_SUBPROP_ROOTS) {
+    for (const snap of _snapshotFnSubProps(root)) {
+      if (seen.has(snap.fn)) continue;
+      seen.add(snap.fn);
+      out.push(snap);
+    }
+  }
+  return out;
+})();
+
+function _restoreFnSubProp(fn, key, orig) {
+  if (!orig) return true;
+  let cur;
+  try {
+    cur = Object.getOwnPropertyDescriptor(fn, key);
+  } catch {
+    cur = undefined;
+  }
+  if (
+    cur &&
+    cur.value === orig.value &&
+    cur.writable === orig.writable &&
+    cur.enumerable === orig.enumerable &&
+    cur.configurable === orig.configurable
+  ) {
+    return true;
+  }
+  try {
+    Object.defineProperty(fn, key, orig);
+  } catch {
+    /* residual check below */
+  }
+  const after = Object.getOwnPropertyDescriptor(fn, key);
+  return !!after && after.value === orig.value;
+}
+
 // Same sentinel-style dirty check as the JS-host test262 runner (#1310),
 // applied in the unified sharded worker so both js-host and standalone matrix
 // targets recycle a fork after a test mutates core host prototypes.
@@ -835,6 +983,16 @@ function restoreBuiltins() {
       console.error(`[unified-worker pid=${process.pid}] FATAL: ${reason} — recycling`);
       return recycleCleanup(reason);
     }
+  }
+
+  // (#3470) Restore function .name/.length sub-properties (see
+  // _FN_SUBPROP_ROOTS comment above) poisoned by verifyProperty()'s
+  // unrestored configurability probe. Best-effort, not wired into the
+  // FATAL/recycle checks above -- a missing name/length sub-prop doesn't
+  // break compilation the way the poison classes above do.
+  for (const { fn, nameDesc, lengthDesc } of _fnSubPropOrig) {
+    _restoreFnSubProp(fn, "name", nameDesc);
+    _restoreFnSubProp(fn, "length", lengthDesc);
   }
   return cleanCleanup();
 }

--- a/tests/issue-3470.test.ts
+++ b/tests/issue-3470.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#3470) extends #3318. test262's verifyProperty() (harness/
+// propertyHelper.js:63-66 asserts __hasOwnProperty(obj, name); the
+// destructive probe is isConfigurable() at line 140, `delete obj[name]`)
+// probes configurable:true via `delete obj[name]` without a `restore`
+// option for built-ins/**/name.js and length.js tests. When `obj` is a
+// prototype METHOD (e.g. Date.prototype.getYear), the delete removes THAT
+// FUNCTION's own "name"/"length" sub-property -- a mutation the pre-#3470
+// restoreHostBuiltins() never caught (it restores method VALUES/identity,
+// not a method's own sub-properties), and Date/TypedArray/DataView weren't
+// even in its PROTOS list. The auto-generated strict-mode rerun (same
+// process, same realm) then saw the missing sub-property and failed "obj
+// should have an own property name"/"length".
+//
+// IMPORTANT (found during implementation, see #3471): the cited sample
+// files do NOT reach a full "pass" after this fix, even in-process. Fixing
+// the "own property" masking unblocks verifyProperty()'s NEXT destructive
+// probe (isWritable(), which runs BEFORE isConfigurable() in
+// propertyHelper.js) -- and that hits a SEPARATE, deeper, genuine COMPILER
+// bug (#3471: a strict-mode assignment to a non-writable host property
+// throws TypeError correctly, but the compiled try/catch doesn't catch it
+// as `instanceof TypeError`). That bug is unconditional (fires on a fresh,
+// never-mutated realm too), which is why it's already the DOMINANT
+// observed failure on the real CI baseline for this whole test family --
+// independent of this issue's fix. So these end-to-end tests assert the
+// NARROWER, honest claim this fix actually delivers: the "own property"
+// signature is gone (proving the sub-prop restore mechanism works
+// end-to-end, not just at the unit level), not a full pass (blocked on
+// #3471).
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+// Sample cited files from the host<->standalone parity investigation
+// (Cluster C2 name/length sub-family).
+const CITED_NAME_TESTS = [
+  "annexB/built-ins/Date/prototype/getYear/name.js",
+  "annexB/built-ins/RegExp/prototype/compile/name.js",
+  "annexB/built-ins/String/prototype/substr/name.js",
+] as const;
+
+// Additional coverage: TypedArray/DataView, which the pre-fix PROTOS list
+// omitted entirely (not just the name/length sub-prop gap).
+const TYPED_ARRAY_DATAVIEW_TESTS = [
+  "built-ins/TypedArray/prototype/forEach/name.js",
+  "built-ins/DataView/prototype/getFloat64/name.js",
+  "built-ins/DataView/name.js",
+] as const;
+
+const OWN_PROPERTY_SIGNATURE = /should have an own property/;
+
+describe("#3470 host verifyProperty name/length realm-isolation restore", () => {
+  /**
+   * The fix's actual, verifiable claim: the strict rerun no longer fails on
+   * the "obj should have an own property name/length" masking signature.
+   * Does NOT assert `status: "pass"` -- see #3471 for the separate, deeper
+   * compiler bug (isWritable()'s non-writable-assignment TypeError isn't
+   * caught by compiled code) that these same files hit next, unblocked by
+   * this fix but not fixed by it.
+   */
+  async function expectNoOwnPropertyMasking(path: string) {
+    const result = await runTest262File(resolve("test262/test", path), path.split("/")[0]!);
+    restoreHostBuiltins();
+    expect(result.file).toBe(`test/${path}`);
+    expect(String(result.error ?? ""), `${path} must not fail on the own-property masking signature`).not.toMatch(
+      OWN_PROPERTY_SIGNATURE,
+    );
+  }
+
+  it("cited annexB name.js tests no longer fail on 'own property' masking (unblocked, see #3471 for the next layer)", async () => {
+    for (const path of CITED_NAME_TESTS) {
+      await expectNoOwnPropertyMasking(path);
+    }
+  }, 120_000);
+
+  it("TypedArray/DataView name.js tests no longer fail on 'own property' masking (previously-missing PROTOS entries)", async () => {
+    for (const path of TYPED_ARRAY_DATAVIEW_TESTS) {
+      await expectNoOwnPropertyMasking(path);
+    }
+  }, 120_000);
+
+  it("running the same name.js test twice in one process: the second run does not re-see the masking either (cross-run restore, not just intra-run)", async () => {
+    const path = CITED_NAME_TESTS[0];
+    await expectNoOwnPropertyMasking(path);
+    await expectNoOwnPropertyMasking(path);
+  }, 120_000);
+
+  it("restoreHostBuiltins() restores a deleted Date.prototype method's own .name", () => {
+    const before = Object.getOwnPropertyDescriptor(Date.prototype.getYear, "name");
+    expect(before?.value).toBe("getYear");
+    // biome-ignore lint/performance/noDelete: must remove the own property (not set undefined) to model verifyProperty's isConfigurable() probe.
+    delete (Date.prototype.getYear as unknown as Record<string, unknown>).name;
+    expect(Object.getOwnPropertyDescriptor(Date.prototype.getYear, "name")).toBeUndefined();
+    restoreHostBuiltins();
+    expect(Object.getOwnPropertyDescriptor(Date.prototype.getYear, "name")).toEqual(before);
+  });
+
+  it("restoreHostBuiltins() restores a deleted TypedArray prototype method's own .length", () => {
+    const fn = Int8Array.prototype.subarray;
+    const before = Object.getOwnPropertyDescriptor(fn, "length");
+    // biome-ignore lint/performance/noDelete: must remove the own property (not set undefined) to model verifyProperty's isConfigurable() probe.
+    delete (fn as unknown as Record<string, unknown>).length;
+    expect(Object.getOwnPropertyDescriptor(fn, "length")).toBeUndefined();
+    restoreHostBuiltins();
+    expect(Object.getOwnPropertyDescriptor(fn, "length")).toEqual(before);
+  });
+
+  it("restoreHostBuiltins() restores a deleted DataView prototype method's own .name", () => {
+    const fn = DataView.prototype.getInt8;
+    const before = Object.getOwnPropertyDescriptor(fn, "name");
+    // biome-ignore lint/performance/noDelete: must remove the own property (not set undefined) to model verifyProperty's isConfigurable() probe.
+    delete (fn as unknown as Record<string, unknown>).name;
+    expect(Object.getOwnPropertyDescriptor(fn, "name")).toBeUndefined();
+    restoreHostBuiltins();
+    expect(Object.getOwnPropertyDescriptor(fn, "name")).toEqual(before);
+  });
+
+  it("restoreHostBuiltins() restores a deleted constructor's own .name (e.g. Date.name)", () => {
+    const before = Object.getOwnPropertyDescriptor(Date, "name");
+    expect(before?.value).toBe("Date");
+    // biome-ignore lint/performance/noDelete: must remove the own property (not set undefined) to model verifyProperty's isConfigurable() probe.
+    delete (Date as unknown as Record<string, unknown>).name;
+    expect(Object.getOwnPropertyDescriptor(Date, "name")).toBeUndefined();
+    restoreHostBuiltins();
+    expect(Object.getOwnPropertyDescriptor(Date, "name")).toEqual(before);
+  });
+});

--- a/tests/test262-restore-builtins.ts
+++ b/tests/test262-restore-builtins.ts
@@ -19,6 +19,24 @@
 // re-application only as the fallback, DELETE for added keys. Non-configurable
 // poison is reported (return false) — an in-process caller cannot recycle a
 // fork, but it can surface the condition.
+//
+// (#3470) test262's `verifyProperty` (harness/propertyHelper.js:63-66 asserts
+// `__hasOwnProperty(obj, name)`; the destructive probe is `isConfigurable()`
+// at line 140, `delete obj[name]`) probes `configurable:true` via
+// `delete obj[name]` and does NOT restore when no `restore` option is passed
+// — the common case for `built-ins/**/name.js` / `length.js` tests. When
+// `obj` is a prototype METHOD (e.g. `Date.prototype.getYear`), the delete
+// removes THAT FUNCTION's own `.name`/`.length` sub-property. None of the
+// restore logic above catches this: the function's IDENTITY never changes
+// (`Date.prototype.getYear` is still the same function reference), so the
+// value-restore loop's `cur.value === orig` check is a no-op. The
+// auto-generated strict-mode rerun (same process, same realm) then sees the
+// missing sub-property and fails "obj should have an own property
+// name"/"length". Real Node passes (fresh realm per test); standalone
+// passes (fresh per-module builtins). Only this shared-host-builtin lane
+// leaks. Fix: snapshot + restore each captured method's own `.name`/
+// `.length` descriptors too (see FN_SUBPROP_SNAPSHOTS below), and add the
+// Date/TypedArray/DataView entries the original 12-proto list omitted.
 
 const PROTOS: ReadonlyArray<[string, object]> = [
   ["Object.prototype", Object.prototype],
@@ -33,6 +51,42 @@ const PROTOS: ReadonlyArray<[string, object]> = [
   ["WeakMap.prototype", WeakMap.prototype],
   ["WeakSet.prototype", WeakSet.prototype],
   ["Promise.prototype", Promise.prototype],
+  // (#3470) Date/TypedArray/DataView were entirely absent — their prototype
+  // methods (including annexB ones like Date.prototype.getYear, which don't
+  // even appear in the sharded worker's curated method lists) never got
+  // name/length sub-property restore at all.
+  ["Date.prototype", Date.prototype],
+  ["%TypedArray%.prototype", Object.getPrototypeOf(Int8Array.prototype)],
+  ["Int8Array.prototype", Int8Array.prototype],
+  ["Uint8Array.prototype", Uint8Array.prototype],
+  ["Uint8ClampedArray.prototype", Uint8ClampedArray.prototype],
+  ["Int16Array.prototype", Int16Array.prototype],
+  ["Uint16Array.prototype", Uint16Array.prototype],
+  ["Int32Array.prototype", Int32Array.prototype],
+  ["Uint32Array.prototype", Uint32Array.prototype],
+  ["Float32Array.prototype", Float32Array.prototype],
+  ["Float64Array.prototype", Float64Array.prototype],
+  ["BigInt64Array.prototype", BigInt64Array.prototype],
+  ["BigUint64Array.prototype", BigUint64Array.prototype],
+  ["DataView.prototype", DataView.prototype],
+  // Constructors too — verifyProperty also targets e.g. `Date.name`,
+  // `Int8Array.length` directly (own data properties of the constructor
+  // function itself, captured for free by the existing key-enumeration
+  // logic once the constructor object is a PROTOS entry).
+  ["Date", Date],
+  ["%TypedArray%", Object.getPrototypeOf(Int8Array)],
+  ["Int8Array", Int8Array],
+  ["Uint8Array", Uint8Array],
+  ["Uint8ClampedArray", Uint8ClampedArray],
+  ["Int16Array", Int16Array],
+  ["Uint16Array", Uint16Array],
+  ["Int32Array", Int32Array],
+  ["Uint32Array", Uint32Array],
+  ["Float32Array", Float32Array],
+  ["Float64Array", Float64Array],
+  ["BigInt64Array", BigInt64Array],
+  ["BigUint64Array", BigUint64Array],
+  ["DataView", DataView],
 ];
 
 interface ProtoSnapshot {
@@ -62,6 +116,73 @@ function snapshotProto(name: string, proto: object): ProtoSnapshot {
 
 // Snapshot at MODULE LOAD — import this module before any test executes.
 const SNAPSHOTS: ProtoSnapshot[] = PROTOS.map(([name, proto]) => snapshotProto(name, proto));
+
+// (#3470) Function `.name`/`.length` own-property snapshot, built from every
+// function captured as a data-property VALUE above (methods AND, for the
+// constructor PROTOS entries, the constructor's own name/length are already
+// covered by the `values` restore loop directly — this covers the METHOD
+// case: `Date.prototype.getYear.name` is a property of the function object
+// nested one level below `Date.prototype`, which the generic key-enumeration
+// loop above never reaches).
+interface FnSubPropSnapshot {
+  fn: (...args: unknown[]) => unknown;
+  nameDesc: PropertyDescriptor | undefined;
+  lengthDesc: PropertyDescriptor | undefined;
+}
+
+function snapshotFnSubProps(fn: (...args: unknown[]) => unknown): FnSubPropSnapshot {
+  return {
+    fn,
+    nameDesc: Object.getOwnPropertyDescriptor(fn, "name"),
+    lengthDesc: Object.getOwnPropertyDescriptor(fn, "length"),
+  };
+}
+
+const FN_SUBPROP_SNAPSHOTS: FnSubPropSnapshot[] = (() => {
+  const seen = new Set<unknown>();
+  const out: FnSubPropSnapshot[] = [];
+  for (const snap of SNAPSHOTS) {
+    for (const value of snap.values.values()) {
+      if (typeof value === "function" && !seen.has(value)) {
+        seen.add(value);
+        out.push(snapshotFnSubProps(value as (...args: unknown[]) => unknown));
+      }
+    }
+  }
+  return out;
+})();
+
+/**
+ * Restore one `.name`/`.length` own-property descriptor on a function to its
+ * module-load snapshot. Unconditional `defineProperty` (not `=`) — both
+ * sub-properties are `writable:false` on every spec-conformant builtin
+ * function, so plain assignment silently no-ops; they are always
+ * `configurable:true`, so `defineProperty` should never fail in practice.
+ */
+function restoreFnSubProp(
+  fn: (...args: unknown[]) => unknown,
+  key: "name" | "length",
+  orig: PropertyDescriptor | undefined,
+): boolean {
+  if (!orig) return true;
+  const cur = Object.getOwnPropertyDescriptor(fn, key);
+  if (
+    cur &&
+    cur.value === orig.value &&
+    cur.writable === orig.writable &&
+    cur.enumerable === orig.enumerable &&
+    cur.configurable === orig.configurable
+  ) {
+    return true;
+  }
+  try {
+    Object.defineProperty(fn, key, orig);
+  } catch {
+    /* residual check below */
+  }
+  const after = Object.getOwnPropertyDescriptor(fn, key);
+  return !!after && after.value === orig.value;
+}
 
 /**
  * Restore the host realm's builtin prototypes to their module-load state.
@@ -120,6 +241,18 @@ export function restoreHostBuiltins(): boolean {
         if (!final || ("value" in final && final.value !== orig)) clean = false;
       }
     }
+  }
+  // (#3470) Restore function .name/.length sub-properties poisoned by
+  // verifyProperty()'s unrestored configurability probe. Best-effort and
+  // intentionally NOT wired into `clean` — a missing name/length sub-prop
+  // doesn't break compilation the way the poison classes above do (that's
+  // what `clean` gates), and built-in function name/length descriptors are
+  // always configurable:true per spec, so failure here would indicate a
+  // test made a genuinely non-configurable change we can't recover from
+  // anyway.
+  for (const { fn, nameDesc, lengthDesc } of FN_SUBPROP_SNAPSHOTS) {
+    restoreFnSubProp(fn, "name", nameDesc);
+    restoreFnSubProp(fn, "length", lengthDesc);
   }
   return clean;
 }


### PR DESCRIPTION
## Summary

test262's `verifyProperty()` (`test262/harness/propertyHelper.js:63-66,140`)
probes `configurable:true` via `delete obj[name]` and does **not** restore
when no `restore` option is passed — the common case for
`built-ins/**/name.js` / `length.js` tests. When `obj` is a prototype
method (e.g. `Date.prototype.getYear`), the delete removes THAT
function's own `.name`/`.length` sub-property. The existing
`restoreHostBuiltins()` (#3318, in-process runner) and `restoreBuiltins()`
(sharded worker) restore method **values** (identity) but never caught
this — the function reference itself never changes, so the identity
check is a no-op. Their `PROTOS`/root-object lists also omitted
Date/TypedArray/DataView entirely.

- `tests/test262-restore-builtins.ts`: snapshot + restore each captured
  method's own `.name`/`.length` descriptors; add
  `Date`/`TypedArray`-constructors/`DataView` (+ their prototypes) to
  `PROTOS`.
- `scripts/test262-worker.mjs`: mirror the same fix. Enumerates every
  function-valued own property on a comprehensive root-object list
  directly (rather than extending the curated `_METHOD_SNAPSHOTS` lists),
  so it also covers `annexB` methods (e.g. `Date.prototype.getYear`) that
  aren't in those curated lists at all. Best-effort, not wired into the
  fork-recycle FATAL paths.

Runner-only. **Zero compiler change.**

## Important correction to the original scope (read before judging impact)

The originating task estimated ~370 CI flips. While validating end-to-end
(not just at the unit level), I found the cited sample tests **do not
reach a full pass** even with this fix — they hit a *separate, deeper*
compiler bug once the "own property" masking clears: a strict-mode
assignment to a non-writable host property throws `TypeError` correctly
(`src/runtime.ts:3979`, intentional per #2017), but the compiled
`try/catch` doesn't catch it as `instanceof TypeError`. Filed as **#3471**
with full analysis, repro, and real-CI-baseline scale (**433** of the
987 currently-failing `name.js`/`length.js` tests fail on exactly that
signature — the actual dominant blocker for this whole test family,
independent of this issue).

Net: this PR is still a real, confirmed, zero-risk fix (in-process-runner
correctness — matters for `pnpm run test:262:validate-baseline`,
`/smoke-test-issue`, local dev sessions that run tests in-process), but
its real CI/merge_group flip count is expected to be **near-zero** until
#3471 also lands. See `plan/issues/3470-*.md`'s "CORRECTION" section and
`plan/issues/3471-*.md` for the full writeup.

## Test plan

- [x] `tests/issue-3470.test.ts` (7 tests): unit-level restore of
      Date/TypedArray/DataView method `.name`/`.length` and constructor
      `.name`; end-to-end proof (via `runTest262File`) that the cited
      annexB + TypedArray/DataView sample files no longer fail on the
      `"obj should have an own property"` masking signature, including
      running the same file twice in one process.
- [x] `tests/issue-3318.test.ts` (4 tests, pre-existing) still green —
      no regression to the #3318 restore mechanism.
- [x] `tests/issue-3368.test.ts`, `tests/issue-3369-project-runner.test.ts`
      (pre-existing) still green.
- [x] `node --check scripts/test262-worker.mjs` — syntax valid.
- [x] Manually built `compiler-bundle.mjs`/`runtime-bundle.mjs` and ran
      the actual unified fork worker via `CompilerPool` at `poolSize: 1`
      (forcing sloppy+strict onto the same fork, the worst case for the
      realm leak) against `annexB/built-ins/Date/prototype/getYear/name.js`
      — confirms the worker-side fix also works end-to-end and the strict
      rerun now reaches the #3471 signature instead of the "own property"
      masking.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb