### PR TITLE
fix(#3471): gate body-usage param inference on zero call sites (unsound f64 narrowing broke isSameValue → ~433 name/length tests)

### DIFF
--- a/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
+++ b/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
@@ -1,7 +1,9 @@
 ---
 id: 3471
-title: "Host lane: strict-mode assignment to a non-writable host property throws but isn't caught as instanceof TypeError inside compiled try/catch (~433-541 test262 tests)"
-status: ready
+title: "Host lane: polymorphic comparator (isSameValue) param unsoundly narrowed to f64, corrupting string compares → false isWritable revert → uncaught TypeError (~433 test262 name/length tests)"
+status: done
+assignee: ttraenkler/senior-dev
+completed: 2026-07-19
 sprint: current
 created: 2026-07-19
 priority: high
@@ -205,3 +207,80 @@ instanceof TypeError }` returns `true` in a harness-bundle-shaped
   signature-based, not a guaranteed flip count per the usual caution).
 - No regressions in the existing exception/try-catch/strict-mode test
   suites.
+
+---
+
+## RESOLUTION (senior-dev, 2026-07-19) — the reported premise was WRONG
+
+**The bug is NOT in try/catch / `instanceof TypeError` / the readonly-write
+throw.** Verified on current `origin/main` by running ONLY the strict-rerun
+variant of the real harness (fresh realm, so the sloppy phase's `delete
+obj[name]` #3470 masking does not apply — that masking is why the *same-process*
+`runTest262File` shows `should have an own property`; in the CI sharded pool the
+two phases land on different forks so #3471's signature is the dominant one, as
+the analysis above predicted). Instrumenting `isWritable` inside the real bundle
+showed:
+
+1. The strict readonly write **is** caught correctly — `e instanceof TypeError`
+   is `true`. The `catch` fires. So the issue's stated mechanism does not occur.
+2. The real defect: `writeSucceeded = isSameValue(obj[verifyProp || name],
+   newValue)` returns **`true`** after a *failed* write (`obj[name]` is still
+   `"slice"`, `newValue` is `"unlikelyValue"` — clearly unequal).
+3. That wrong `true` runs `isWritable`'s **revert** (`obj[name] = oldValue`) — a
+   SECOND strict write to the non-writable property — which throws **outside any
+   try** → the uncaught `Cannot assign to read only property` that fails the test.
+
+### Root cause: unsound f64 parameter narrowing
+
+`isSameValue(a, b)` — `if (a === 0 && b === 0) return 1/a === 1/b; if (a !== a &&
+b !== b) return true; return a === b;` — was compiled with **`(param f64 f64)`**
+(confirmed in the WAT of a genuinely-reproducing module). Both string args
+coerce to `NaN` at the call boundary, so `a !== a && b !== b` becomes `true &&
+true` → `isSameValue("slice","unlikelyValue") === true`.
+
+The f64 came from `inferParamTypeFromBody` (`src/codegen/declarations/param-
+return-inference.ts`), which narrows an untyped param to f64 on a **single**
+numeric body use (`1 / a`). It was invoked as a fallback whenever
+`inferParamTypeFromCallSites` returned `null` — but `null` conflates **"no call
+sites"** (an exported/host-only entrypoint; body is the only signal — sound)
+with **"called internally with `any`/polymorphic args"** (unsound: one numeric
+use does not prove the param is always a number). `isSameValue` has 8 internal
+call sites, all passing `any` args (`obj[name]`, `desc.value`, …) → call-site
+inference `null` → body fallback misfired → f64.
+
+### Fix (Option C — advisor-reviewed)
+
+`inferParamTypeFromCallSites` now also reports `sawCallSite`; the caller
+(`declarations.ts` `lowerParamType`) runs the body-usage fallback **only when
+`!sawCallSite`** (a genuinely-uncalled function). A polymorphic helper keeps its
+boxed `externref` params, so non-number args survive.
+
+- Rejected "bail on all non-ToNumber-invariant uses" — regresses `return n`
+  numeric entrypoints.
+- Rejected "bail on `===`/`!==`" — regresses `n === 0` base-case kernels.
+- Option C fixes `isSameValue` (has any-arg call sites) while keeping `fib`/
+  `fact` (recursive → numeric call sites → f64) and host-only numeric
+  entrypoints (zero call sites → body fallback → f64). Verified: `fact` param
+  stays f64 (result 120); `dbl` (host-only) stays f64; polymorphic comparator
+  called with strings is now `externref` and compares by value.
+
+### Verification
+
+- `isSameValue` in the real strict harness: `(param f64 f64)` → shared-type
+  boxed `externref` params after the fix.
+- All 5 sample repro files pass via the strict-only harness runner.
+- New `tests/issue-3471.test.ts` (7 cases): minimal reproducer returns 1 (BUG)
+  on `origin/main`, 0 (CORRECT) with the fix; numeric-kernel guards; the
+  isWritable-shape false-revert case.
+- No regressions in `#684`, `#2795`, `#3055` (isSameValue numeric), ir-numeric-
+  bool-equivalence, function-name-length, comparison/equality suites.
+- Full test262 delta measured on CI (broad-impact: param inference touches every
+  function). Local same-process `runTest262File` still shows the #3470 masking
+  until #3470 also lands; #3470 and #3471 are complementary.
+
+### Files
+
+- `src/codegen/declarations/param-return-inference.ts` — `inferParamTypeFromCallSites`
+  returns `{ type, sawCallSite }`.
+- `src/codegen/declarations.ts` — gate body fallback on `!sawCallSite`.
+- `tests/issue-3471.test.ts` — regression tests.

--- a/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
+++ b/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
@@ -1,0 +1,182 @@
+---
+id: 3471
+title: "Host lane: strict-mode assignment to a non-writable host property throws but isn't caught as instanceof TypeError inside compiled try/catch (~433-541 test262 tests)"
+status: in-progress
+assignee: ttraenkler/senior-dev
+sprint: current
+created: 2026-07-19
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+goal: test262-conformance
+related: [3470, 3417, 2017]
+origin: "Discovered while implementing #3470 (host verifyProperty name/length restore) — the cited sample tests still failed after #3470's fix landed, on a DIFFERENT, deeper signature. Cross-checked against the real CI baseline (loopdive/js2wasm-baselines test262-current.jsonl, fetched 2026-07-19) to confirm this is the actual dominant CI failure mode for this test family, not a local artifact."
+---
+
+# #3471 — strict-mode write to a non-writable host property: TypeError thrown but not caught as `instanceof TypeError`
+
+## Problem
+
+test262's `propertyHelper.js` (`includes: [propertyHelper.js]`) has an
+`isWritable(obj, name)` helper used by essentially every `verifyProperty`
+call that checks `writable` in the descriptor (i.e. nearly every
+`built-ins/**/name.js` and `built-ins/**/length.js` test — the standard
+"every built-in function has a non-writable `.name`/`.length`" conformance
+check):
+
+```js
+try {
+  obj[name] = newValue;
+} catch (e) {
+  if (!(e instanceof TypeError)) {
+    throw new Test262Error("Expected TypeError, got " + e);
+  }
+}
+```
+
+In **strict mode** (the auto-generated strict rerun every normal test262
+script record gets), assigning to a non-writable data property MUST throw
+a catchable `TypeError` per `PutValue` (§6.2.5.6 step 3.e /
+`OrdinarySetWithOwnDescriptor` step 2.a). `src/runtime.ts:3975-3979`
+(`_safeSet`) **correctly implements this** — it's intentional, added for
+#2017:
+
+```ts
+} else if (desc.writable === false) {
+  // OrdinarySetWithOwnDescriptor step 2.a returns false for a
+  // non-writable data descriptor; PutValue turns that false into a
+  // TypeError for a strict Reference (§6.2.5.6 step 3.e).
+  throw new TypeError(`Cannot assign to read only property '${String(key)}' of object`);
+```
+
+But when this exact pattern runs inside the **compiled** `try { obj[name]
+= newValue } catch (e) { if (!(e instanceof TypeError)) throw ... }`, the
+thrown `TypeError` is **not correctly caught/classified** — it propagates
+out of the compiled function as an uncaught runtime error instead of being
+swallowed by the `catch` block (the expected/spec-correct outcome). The
+test then fails with:
+
+```
+strict rerun: Cannot assign to read only property 'name' of object
+```
+
+## Why this matters (scale)
+
+Cross-checked the REAL CI baseline (`loopdive/js2wasm-baselines`
+`test262-current.jsonl`, fetched via `scripts/fetch-baseline-jsonl.mjs`,
+2026-07-19):
+
+- 1,444 `built-ins/**` + `annexB/built-ins/**` tests ending in `name.js` or
+  `length.js` (the `verifyProperty(fn, "name"/"length", {writable:false,
+...})` conformance-check family).
+- Of the 987 that currently FAIL: **433 fail with exactly this signature**
+  (`"Cannot assign to read only property"` in `error`) — by far the single
+  largest bucket (vs. 13 for `"should have an own property"`, which turned
+  out to be an UNRELATED bug in synthetic Promise-executor/resolve/reject
+  function naming, not this one; the remaining 541 are heterogeneous other
+  failures).
+- Confirmed via `error_signature` field:
+  `runtime_error:strict rerun: Cannot assign to read only property 'name' of object`
+  (and the `'length'` variant) appear on `Array.prototype.slice`,
+  `Date.prototype.toISOString`, `Number.prototype.toExponential`,
+  `Math.atan2`, `Promise.race`, `String.prototype.charAt`, and dozens more
+  — this is a single, well-isolated, systemic gap, not per-feature noise.
+
+This is the **actual, currently-observed dominant blocker** for the
+`name.js`/`length.js` conformance-check family — much bigger than the
+~370-test estimate #3470 was scoped against (which assumed a DIFFERENT,
+narrower root cause — see "Relationship to #3470" below).
+
+## Repro
+
+Any of hundreds of test262 files reproduce this on current `main`:
+
+```bash
+npx tsx -e "
+import { runTest262File } from './tests/test262-runner.ts';
+const r = await runTest262File('test262/test/built-ins/Array/prototype/slice/name.js', 'built-ins');
+console.log(r.status, r.error);
+"
+# fail  strict rerun: TypeError: Cannot assign to read only property 'name' of object
+```
+
+Sample files (pick any):
+
+- `built-ins/Array/prototype/slice/name.js`
+- `annexB/built-ins/Date/prototype/getYear/name.js`
+- `annexB/built-ins/RegExp/prototype/compile/name.js`
+- `annexB/built-ins/String/prototype/substr/name.js`
+- `built-ins/DataView/prototype/getFloat64/name.js`
+
+**Note for the next investigator:** a _minimal_ isolated repro (a small
+standalone TS snippet doing `try { obj.name = "x" } catch (e) { return e
+instanceof TypeError }` against `Date.prototype.getYear`, compiled with
+`inferModuleStrictArguments: true`) did **NOT** reproduce the bug — it
+correctly returned `instanceof TypeError === true`. Neither did a version
+using a computed key (`obj[name] = newValue`) inside a separately-declared
+non-exported helper function with the same shape as `propertyHelper.js`'s
+`isWritable`. So the trigger is more specific than "compiled catch can't
+classify a host-thrown TypeError" in general — something about the FULL
+harness assembly (`assembleOriginalHarness` bundling `propertyHelper.js` +
+the test body into one compilation unit, or the specific
+`"use strict"`-prologue-based strict rerun vs. `inferModuleStrictArguments`
+module-strictness) changes the behavior. **Use `runTest262File` on a real
+test262 file as the repro**, not a hand-rolled snippet — my hand-rolled
+attempts (see `.tmp/probe-readonly-catch*.mts` pattern) undersell the bug.
+
+## Relationship to #3470 (important — do not conflate root causes)
+
+#3470 targeted a DIFFERENT bug: `verifyProperty`'s `isConfigurable()` probe
+(`delete obj[name]`, no restore) leaking across the auto strict rerun via
+shared host-realm builtins, observable ONLY when the sloppy and strict
+phases share the same process/fork. That bug is real (confirmed, fixed in
+#3470) but:
+
+- In the **in-process runner** (`tests/test262-runner.ts`, 100%
+  same-process guarantee), fixing #3470 does clear the "obj should have an
+  own property" masking — but then EVERY affected test hits THIS bug
+  (readonly-assign) underneath, since virtually all `name.js`/`length.js`
+  tests specify `writable: false`.
+- In the **real CI sharded worker pool** (`scripts/test262-worker.mjs` via
+  `scripts/compiler-pool.ts`), the sloppy/strict phases of a single test
+  essentially never land on the same fork in a live pool (many concurrent
+  tests interleaved), so #3470's masking condition rarely if ever
+  triggers there — meaning THIS bug (unconditional: it fires on a
+  perfectly fresh, never-mutated realm too, since it's a pure compiled-code
+  defect) is and was already the REAL, dominant, CI-observed failure mode
+  for this whole test family, independent of #3470.
+
+**#3470 is still worth having** (in-process-runner correctness — matters
+for local dev, `pnpm run test:262:validate-baseline`, `/smoke-test-issue`)
+but its real CI-flip impact is near-zero until THIS bug is also fixed.
+Fixing #3471 first (or with #3470) should flip the ~433 tests currently
+failing on this signature (module a small number that hit yet other
+issues underneath once this layer clears — same caution as always:
+signature-addressed ≠ guaranteed flip count, verify on CI).
+
+## Task
+
+1. Trace the compiled catch site: for a `try { obj[name] = newValue; }
+catch (e) { if (!(e instanceof TypeError)) ...}` pattern reachable via
+   `assembleOriginalHarness`'s bundled compile, determine why the thrown
+   `TypeError` from `_safeSet`'s `__extern_set_strict` host import path
+   (`src/runtime.ts:3979`) is not recognized by the compiled `instanceof
+TypeError` check, or does not reach the `catch` block at all (trap vs.
+   catchable exception — family of #581/#2025's exception-catchability
+   issues, worth checking those for a shared root cause first).
+2. Fix so the exception is a genuine catchable WASM exception classified
+   correctly as `TypeError` by compiled `instanceof` checks.
+3. Regression guard: a compiled `try { nonWritableProp = x } catch (e) { e
+instanceof TypeError }` returns `true` in a harness-bundle-shaped
+   compilation (not just a trivial single-function snippet).
+
+## Acceptance criteria
+
+- The 5 sample repro files above pass end-to-end via `runTest262File`.
+- Broad sweep of the 433-signature bucket shows a large net-positive flip
+  on CI/merge_group (verify actual count — this issue's estimate is
+  signature-based, not a guaranteed flip count per the usual caution).
+- No regressions in the existing exception/try-catch/strict-mode test
+  suites.

--- a/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
+++ b/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
@@ -1,8 +1,7 @@
 ---
 id: 3471
 title: "Host lane: strict-mode assignment to a non-writable host property throws but isn't caught as instanceof TypeError inside compiled try/catch (~433-541 test262 tests)"
-status: in-progress
-assignee: ttraenkler/senior-dev
+status: ready
 sprint: current
 created: 2026-07-19
 priority: high
@@ -155,6 +154,32 @@ Fixing #3471 first (or with #3470) should flip the ~433 tests currently
 failing on this signature (module a small number that hit yet other
 issues underneath once this layer clears — same caution as always:
 signature-addressed ≠ guaranteed flip count, verify on CI).
+
+## Handoff note (2026-07-19)
+
+Routed by tech lead to a senior-dev (Opus) — `feasibility: hard` +
+`area: codegen` is out of the originating dev's (runner-only #3470) lane.
+Preliminary narrowing already done (see "Repro" above): the bug does
+**not** reproduce in small hand-rolled snippets, even ones matching
+`isWritable()`'s shape closely (tried: static key access, computed key
+access via a separately-declared helper function, both with
+`inferModuleStrictArguments: true` AND with a literal `"use strict";`
+prologue + `deferTopLevelInit: true` matching the real
+`runOriginalHarnessVariant` compile options exactly). It DOES reproduce
+via the full `assembleOriginalHarness`-bundled harness + test body
+(`propertyHelper.js`'s real `verifyProperty`/`isWritable`, not a
+simplified copy) compiled and run through `runTest262File`/the unified
+worker. Next step for whoever picks this up: bisect the REAL assembled
+source (`assembleOriginalHarness(source, meta).strictRerun.source`,
+dumped to a scratch file) by trimming sections and recompiling, to find
+the minimal diff between "reproduces" and "doesn't" — likely something
+about the specific `verifyProperty` call chain (2 levels of nesting:
+test body → `verifyProperty` → `isWritable`), or the `__isArray`/
+`nonIndexNumericPropertyName` branches in the real `isWritable`, or
+something about compiling the ~19KB bundled harness specifically (WASM
+exception tag identity across many more functions/closures than a small
+snippet has). Not yet isolated further — ran out of scope for a
+runner-only issue before finishing the bisection.
 
 ## Task
 

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -99,11 +99,7 @@ export {
 } from "./declarations/object-shape-widening.js";
 export { inferNumericReturnTypes } from "./declarations/param-return-inference.js";
 // Import-back: symbols the declaration trunk still calls internally.
-import {
-  inferParamTypeFromBody,
-  inferParamTypeFromCallSites,
-  resolveGenericCallSiteTypes,
-} from "./declarations/param-return-inference.js";
+import { inferImplicitAnyParamType, resolveGenericCallSiteTypes } from "./declarations/param-return-inference.js";
 import {
   collectInterface,
   collectObjectType,
@@ -210,18 +206,9 @@ function lowerParamType(
     (wasmType.kind === "externref" ||
       (wasmType.kind === "ref_null" && ctx.anyValueTypeIdx >= 0 && wasmType.typeIdx === ctx.anyValueTypeIdx))
   ) {
-    const callSites = inferParamTypeFromCallSites(ctx, funcName, index, sourceFile);
-    let inferred = callSites.type;
-    // (#3471) The body-usage fallback is sound ONLY for a function with no
-    // internal call sites (an exported/host-only entrypoint). When the function
-    // IS called internally but call sites are inconclusive (all-`any` args /
-    // conflict → callSites.type === null yet callSites.sawCallSite), the param
-    // is polymorphic: a single numeric body use (`1 / a`) does NOT prove it is
-    // always a number, and narrowing it to f64 would coerce non-number args to
-    // NaN at the call boundary (corrupting `a !== a`, `a === b` — the root of
-    // #3471's isSameValue miscompile). Only fall back to body usage when the
-    // function is genuinely uncalled.
-    if (!inferred && !callSites.sawCallSite) inferred = inferParamTypeFromBody(ctx, stmt, index);
+    // (#3471) Call-site inference first; body-usage fallback ONLY for a
+    // genuinely-uncalled function (see inferImplicitAnyParamType).
+    const inferred = inferImplicitAnyParamType(ctx, funcName, index, sourceFile, stmt);
     if (inferred) wasmType = inferred;
   }
   return wasmType;

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -210,8 +210,18 @@ function lowerParamType(
     (wasmType.kind === "externref" ||
       (wasmType.kind === "ref_null" && ctx.anyValueTypeIdx >= 0 && wasmType.typeIdx === ctx.anyValueTypeIdx))
   ) {
-    let inferred = inferParamTypeFromCallSites(ctx, funcName, index, sourceFile);
-    if (!inferred) inferred = inferParamTypeFromBody(ctx, stmt, index);
+    const callSites = inferParamTypeFromCallSites(ctx, funcName, index, sourceFile);
+    let inferred = callSites.type;
+    // (#3471) The body-usage fallback is sound ONLY for a function with no
+    // internal call sites (an exported/host-only entrypoint). When the function
+    // IS called internally but call sites are inconclusive (all-`any` args /
+    // conflict → callSites.type === null yet callSites.sawCallSite), the param
+    // is polymorphic: a single numeric body use (`1 / a`) does NOT prove it is
+    // always a number, and narrowing it to f64 would coerce non-number args to
+    // NaN at the call boundary (corrupting `a !== a`, `a === b` — the root of
+    // #3471's isSameValue miscompile). Only fall back to body usage when the
+    // function is genuinely uncalled.
+    if (!inferred && !callSites.sawCallSite) inferred = inferParamTypeFromBody(ctx, stmt, index);
     if (inferred) wasmType = inferred;
   }
   return wasmType;

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -245,6 +245,32 @@ export function inferParamTypeFromBody(
 }
 
 /**
+ * (#3471) Resolve a concrete wasm type for an implicit-`any` parameter, combining
+ * both inference sources with the correct precedence and soundness gate:
+ *  1. Call-site inference — if every conclusive call site agrees, use that type.
+ *  2. Body-usage fallback — ONLY when the function has **zero** internal call
+ *     sites (`!sawCallSite`), i.e. an exported/host-only entrypoint whose body is
+ *     the sole signal. A function that IS called internally with `any`/
+ *     polymorphic args (call-site inference inconclusive) is NOT body-narrowed:
+ *     a single numeric use (`1 / a`) does not prove the param is always a number,
+ *     and narrowing it to f64 would coerce non-number args to NaN at the call
+ *     boundary — the isSameValue miscompile behind #3471.
+ * Returns null to leave the param on its resolved (`externref`) type.
+ */
+export function inferImplicitAnyParamType(
+  ctx: CodegenContext,
+  funcName: string,
+  paramIndex: number,
+  sourceFile: ts.SourceFile,
+  decl: ts.FunctionLikeDeclaration,
+): ValType | null {
+  const callSites = inferParamTypeFromCallSites(ctx, funcName, paramIndex, sourceFile);
+  if (callSites.type) return callSites.type;
+  if (callSites.sawCallSite) return null;
+  return inferParamTypeFromBody(ctx, decl, paramIndex);
+}
+
+/**
  * #1121: Infer numeric (f64) return types for functions whose body is a
  * purely-numeric kernel even when TypeScript reports the return as
  * `any`/`unknown` (e.g. unannotated recursive helpers like

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -57,42 +57,67 @@ export function resolveGenericCallSiteTypes(
 }
 
 /**
+ * Result of scanning a function's call sites for a parameter's type.
+ *  - `type`: the concrete wasm type all *conclusive* call sites agree on, or
+ *    `null` when there are no conclusive call sites (none at all / all-`any`
+ *    args / a type conflict between sites).
+ *  - `sawCallSite`: whether *any* internal call to the function was found at
+ *    all, regardless of the argument types. This distinguishes "no call sites"
+ *    (an exported/host-only entrypoint — body inference is the only signal)
+ *    from "called, but with polymorphic/`any` args" (the function is invoked
+ *    internally with runtime values whose type we cannot pin — body inference
+ *    would be UNSOUND, see `inferParamTypeFromBody`). (#3471)
+ */
+export interface CallSiteParamInference {
+  type: ValType | null;
+  sawCallSite: boolean;
+}
+
+/**
  * Infer a concrete type for an untyped function parameter by scanning call sites.
  * When a parameter has no type annotation (TS gives it `any`), we look at every
  * call to that function and collect the argument types at the given index.
- * If all call sites agree on a single concrete wasm type, we return it.
- * Returns null if no call site found or types disagree.
+ * If all call sites agree on a single concrete wasm type, we return it as `type`.
+ * `type` is null if no call site found or types disagree; `sawCallSite` reports
+ * whether the function is called internally at all (see #3471 and
+ * {@link inferParamTypeFromBody}).
  */
 export function inferParamTypeFromCallSites(
   ctx: CodegenContext,
   funcName: string,
   paramIndex: number,
   sourceFile: ts.SourceFile,
-): ValType | null {
+): CallSiteParamInference {
   let agreed: ValType | null = null;
   let conflict = false;
+  let sawCallSite = false;
 
   function visit(node: ts.Node) {
-    if (conflict) return;
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === funcName) {
-      const arg = node.arguments[paramIndex];
-      if (arg) {
-        const argType = ctx.checker.getTypeAtLocation(arg);
-        // Skip if the argument itself is also `any` — no useful info
-        if (argType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
-          // Don't count this call site — it doesn't help
-        } else {
-          const wasmType = resolveWasmType(ctx, argType);
-          if (agreed === null) {
-            agreed = wasmType;
-          } else if (agreed.kind !== wasmType.kind) {
-            conflict = true;
-          } else if (
-            (agreed.kind === "ref" || agreed.kind === "ref_null") &&
-            (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
-            (agreed as { typeIdx: number }).typeIdx !== (wasmType as { typeIdx: number }).typeIdx
-          ) {
-            conflict = true;
+      // A matching call exists regardless of arg types — the function IS invoked
+      // internally, so its params are determined by runtime call args, not the
+      // body-usage fallback. Record this before any conflict short-circuit.
+      sawCallSite = true;
+      if (!conflict) {
+        const arg = node.arguments[paramIndex];
+        if (arg) {
+          const argType = ctx.checker.getTypeAtLocation(arg);
+          // Skip if the argument itself is also `any` — no useful info
+          if (argType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+            // Don't count this call site — it doesn't help
+          } else {
+            const wasmType = resolveWasmType(ctx, argType);
+            if (agreed === null) {
+              agreed = wasmType;
+            } else if (agreed.kind !== wasmType.kind) {
+              conflict = true;
+            } else if (
+              (agreed.kind === "ref" || agreed.kind === "ref_null") &&
+              (wasmType.kind === "ref" || wasmType.kind === "ref_null") &&
+              (agreed as { typeIdx: number }).typeIdx !== (wasmType as { typeIdx: number }).typeIdx
+            ) {
+              conflict = true;
+            }
           }
         }
       }
@@ -101,14 +126,21 @@ export function inferParamTypeFromCallSites(
   }
 
   forEachChild(sourceFile, visit);
-  return conflict ? null : agreed;
+  return { type: conflict ? null : agreed, sawCallSite };
 }
 
 /**
- * #1121: Fallback param-type inference from body usage. Used when
- * `inferParamTypeFromCallSites` finds no call sites (e.g. an exported
- * entrypoint that is only called from JS host) but the function body
- * itself reveals how the parameter is used.
+ * #1121: Fallback param-type inference from body usage. Used ONLY when
+ * `inferParamTypeFromCallSites` finds **zero** call sites (e.g. an exported
+ * entrypoint that is only called from JS host) — the caller gates this on
+ * `!sawCallSite` (#3471). It must NOT run when the function is called
+ * internally with `any`/polymorphic args: seeing a single numeric use of the
+ * param (`1 / a`) here is NOT proof the param is always a number at runtime.
+ * A polymorphic helper (e.g. test262's `isSameValue(a, b)`, which does
+ * `1 / a` but is also called with strings/objects) would be narrowed to f64,
+ * coercing every non-number arg to `NaN` at the call boundary — silently
+ * corrupting comparisons like `a !== a`. So this fallback is sound only for
+ * the truly-uncalled case where the body is the sole signal.
  *
  * Recognises three numeric-flow patterns:
  *  1. `param` passed as an argument to a function whose return is in

--- a/tests/issue-3471.test.ts
+++ b/tests/issue-3471.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3471 — host-lane: a polymorphic helper's `any` parameter was unsoundly
+// narrowed to f64 by the body-usage fallback, corrupting comparisons.
+//
+// Root cause (NOT the try/catch the issue first suspected — see the issue file
+// "Handoff" trail): `inferParamTypeFromBody` (param-return-inference.ts) narrows
+// an untyped parameter to f64 on a SINGLE numeric body use (`1 / a`). It was run
+// as a fallback whenever `inferParamTypeFromCallSites` returned null — but null
+// covers BOTH "no call sites" (an exported/host-only entrypoint, where the body
+// is the only signal — sound) AND "called internally with `any`/polymorphic
+// args" (UNSOUND: a single numeric use does not prove the param is always a
+// number). test262's `isSameValue(a, b)` — `if (a === 0 …) return 1/a === 1/b;
+// if (a !== a && b !== b) return true; return a === b;` — is exactly the second
+// case: it does `1/a` but is called with strings/objects. It was compiled with
+// `(param f64 f64)`, so a string arg coerced to NaN at the call boundary and
+// `a !== a && b !== b` became `true && true` → `isSameValue("x","y") === true`.
+// That is what made `propertyHelper.js`'s `isWritable` mis-classify a failed
+// non-writable write as "succeeded", run its revert (a SECOND strict write),
+// and throw an uncaught TypeError — the ~433 `built-ins/**/name.js` /
+// `length.js` conformance failures.
+//
+// Fix: gate the body-usage fallback on `!sawCallSite` — only trust body usage
+// for a genuinely-uncalled function. A polymorphic helper (has call sites, all
+// `any`) keeps its boxed `externref` params, so non-number args survive.
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { describe, expect, it } from "vitest";
+
+/** Compile in host mode, instantiate, and return the exported `test()` value. */
+async function runTest(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts" });
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if ((imports as { setExports?: (e: unknown) => void }).setExports) {
+    (imports as { setExports: (e: unknown) => void }).setExports(exports);
+  }
+  return exports.test();
+}
+
+/** The `(param …)` signature string of `func`, or `""` if it uses a shared type. */
+async function paramSig(src: string, func: string): Promise<string> {
+  const r = await compile(src, { fileName: "t.ts", emitWat: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const wat = r.wat ?? "";
+  const m = wat.match(new RegExp(`\\(func \\$${func} \\(param ([^)]*)\\)`));
+  return m ? m[1]! : "";
+}
+
+// The SameValue comparator shape from test262's propertyHelper.js, verbatim in
+// its numeric-flow structure. Its params are untyped (`any`).
+const SAME_VALUE = `
+function isSameValue(a, b) {
+  if (a === 0 && b === 0) return 1 / a === 1 / b;
+  if (a !== a && b !== b) return true;
+  return a === b;
+}`;
+
+describe("#3471 — polymorphic comparator param must not be narrowed to f64", () => {
+  it("isSameValue called with any-typed STRING args compares by value (regression: returned true)", async () => {
+    // `check`'s params are `any`, so `isSameValue(obj[key], val)` passes
+    // `any`-typed args — the exact call shape that made call-site inference
+    // return null and (pre-fix) trigger the unsound body fallback.
+    const src = `${SAME_VALUE}
+      function check(obj, key, val) { return isSameValue(obj[key], val); }
+      export function test() {
+        var o = { name: "slice" };
+        return check(o, "name", "unlikelyValue") ? 1 : 0;
+      }`;
+    // "slice" !== "unlikelyValue" → isSameValue must be false → 0.
+    // Pre-fix this returned 1 (both strings coerced to NaN, NaN!==NaN true).
+    expect(await runTest(src)).toBe(0);
+  });
+
+  it("isSameValue of two DIFFERENT any-typed strings is false; equal strings true", async () => {
+    const src = `${SAME_VALUE}
+      function check(obj, k1, k2) { return isSameValue(obj[k1], obj[k2]); }
+      export function test() {
+        var o = { a: "foo", b: "bar", c: "foo" };
+        var diff = check(o, "a", "b") ? 1 : 0;   // "foo" vs "bar" → 0
+        var same = check(o, "a", "c") ? 10 : 0;  // "foo" vs "foo" → 10
+        return diff + same;                      // expect 10
+      }`;
+    expect(await runTest(src)).toBe(10);
+  });
+
+  it("isSameValue with any-typed args keeps boxed (externref) params, not f64", async () => {
+    const src = `${SAME_VALUE}
+      function check(obj, key, val) { return isSameValue(obj[key], val); }
+      export function test() { var o = { name: "x" }; return check(o, "name", "y") ? 1 : 0; }`;
+    // The keystone of the fix: the comparator must NOT be `(param f64 f64)`.
+    expect(await paramSig(src, "isSameValue")).not.toMatch(/f64/);
+  });
+
+  it("numeric args to isSameValue still compare correctly (no over-fix)", async () => {
+    const src = `${SAME_VALUE}
+      function check(a, b) { return isSameValue(a, b); }
+      export function test() {
+        var eq = check(1, 1) ? 1 : 0;    // 1
+        var ne = check(1, 2) ? 10 : 0;   // 0
+        return eq + ne;                  // expect 1
+      }`;
+    expect(await runTest(src)).toBe(1);
+  });
+});
+
+describe("#3471 — numeric-kernel param inference is NOT regressed", () => {
+  it("a recursive numeric kernel still narrows its param to f64", async () => {
+    // fact(n) is called internally as fact(n-1) with a number-typed arg, so
+    // call-site inference (not the body fallback) supplies f64. Must stay f64.
+    const src = `export function fact(n) { return n <= 1 ? 1 : n * fact(n - 1); }
+      export function test() { return fact(5); }`;
+    expect(await paramSig(src, "fact")).toBe("f64");
+    expect(await runTest(src)).toBe(120);
+  });
+
+  it("an exported host-only numeric entrypoint (zero call sites) still narrows to f64", async () => {
+    // No internal call site → the body fallback legitimately applies.
+    const src = `export function dbl(x) { return x * 2; }
+      export function test() { return 0; }`;
+    expect(await paramSig(src, "dbl")).toBe("f64");
+  });
+});
+
+describe("#3471 — isWritable-shape false-positive revert is fixed", () => {
+  it("a failed non-writable-style compare does not spuriously report success", async () => {
+    // Mirrors propertyHelper.js's isWritable: after a write that leaves the old
+    // value in place, `isSameValue(current, newValue)` must be false so the
+    // revert branch is NOT entered. Pre-fix, isSameValue's NaN-coercion made it
+    // true, entering the revert (which in the real harness threw uncaught).
+    const src = `${SAME_VALUE}
+      function isWritableLike(obj, name, newValue) {
+        var oldValue = obj[name];
+        // (write elided — the property is non-writable so it stays oldValue)
+        var writeSucceeded = isSameValue(obj[name], newValue);
+        if (writeSucceeded) { return 999; } // revert branch — must NOT run
+        return oldValue === "slice" ? 0 : -1;
+      }
+      export function test() {
+        var o = { name: "slice" };
+        return isWritableLike(o, "name", "unlikelyValue");
+      }`;
+    expect(await runTest(src)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3471. **The reported premise (try/catch / `instanceof TypeError`) was wrong** — verified on current `origin/main`: the strict readonly write IS caught correctly (`e instanceof TypeError === true`). The real defect is a **parameter-type-inference unsoundness**.

test262's `isSameValue(a, b)` (`if (a===0 && b===0) return 1/a===1/b; if (a!==a && b!==b) return true; return a===b;`) was compiled with **`(param f64 f64)`**. `inferParamTypeFromBody` narrows an untyped param to f64 on a **single** numeric body use (`1/a`), and it was run as a fallback whenever call-site inference returned `null` — but `null` conflates *"no call sites"* (sound) with *"called with `any`/polymorphic args"* (unsound). `isSameValue` has 8 internal call sites, all passing `any` args, so the fallback misfired.

With f64 params, string args coerce to **NaN** at the call boundary → `a!==a && b!==b` = `true && true` → `isSameValue("slice","unlikelyValue") === true`. That makes `propertyHelper.js`'s `isWritable` mis-report the failed non-writable write as *succeeded*, run its **revert** (a second strict write) which throws **outside any try** → the uncaught `Cannot assign to read only property` failing the ~433 `built-ins/**/name.js` + `length.js` tests.

## Fix

`inferParamTypeFromCallSites` now also reports `sawCallSite`; the new `inferImplicitAnyParamType` runs the body-usage fallback **only when a function has zero internal call sites** (its documented purpose). Polymorphic helpers keep boxed `externref` params.

- Recursive numeric kernels (`fib`/`fact`) keep f64 via call-site inference (the recursive call passes a number-typed arg).
- Host-only numeric entrypoints (zero call sites) keep f64 via the still-valid body fallback.
- Verified: `isSameValue` string args now compare by value; `fact` param stays f64 (=120); `#3055` numeric `isSameValue` still correct.

## Why the local runner still shows a different signature

In the same-process `runTest262File`, the sloppy phase's `delete obj[name]` (#3470's realm-leak) masks this bug with `should have an own property`. In CI's **sharded pool** the two phases land on different forks, so #3470 doesn't trigger and #3471's `Cannot assign to read only property` is the dominant signature (433 in the real baseline). This PR was verified via the **strict-only** harness runner (fresh realm), where all 5 sample repro files pass. #3470 and #3471 are complementary.

## Scope / broad-impact

Parameter inference touches every function — the full test262 delta is measured on CI/merge_group. Local checks: new `tests/issue-3471.test.ts` (7 cases; minimal reproducer returns 1 on `origin/main`, 0 with the fix), plus `#684`, `#2795`, `#3055`, ir-numeric-bool-equivalence, function-name-length, comparison/equality suites — all green. tsc/biome/prettier clean.

## Test plan

- [x] `tests/issue-3471.test.ts` — 7/7 pass
- [x] numeric-kernel regression guards (fact→f64, dbl→f64)
- [x] `#3055` isSameValue numeric, `#684` usage inference, ir-numeric-bool-equivalence
- [x] tsc `--noEmit` exit 0, biome/prettier clean, LOC ratchet satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb