### PR TITLE
fix(#3472): coerce externref current-value in native string += (standalone soundness)

### DIFF
--- a/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
+++ b/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
@@ -15,6 +15,8 @@ goal: standalone
 related: [2860, 3468]
 blocks: [3468]
 loc-budget-allow: [src/codegen/expressions/operator-assignment.ts]
+coercion-sites-allow:
+  - src/codegen/expressions/operator-assignment.ts
 ---
 
 ## Problem

--- a/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
+++ b/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
@@ -1,0 +1,124 @@
+---
+id: 3472
+title: "Standalone: native-string-reassigned `any`/externref param that is then `+=` string-concatenated compiles to INVALID Wasm (__str_concat gets externref for arg0)"
+status: done
+assignee: ttraenkler/senior-dev
+completed: 2026-07-19
+sprint: current
+created: 2026-07-19
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+goal: standalone
+related: [2860, 3468]
+blocks: [3468]
+---
+
+## Problem
+
+Under `--target standalone` (and WASI), a function whose unannotated
+(`any`/externref) param is **reassigned to a native-string literal in one branch
+and then string-concatenated** with `+=` compiled to an **invalid Wasm module**:
+
+```ts
+const f = function(msg){ if(msg===undefined){msg='';} else {msg+=' ';} msg+='x'; return msg; };
+```
+
+`WebAssembly.instantiate` failed with a `CompileError`:
+
+```
+call[0] expected type (ref null $AnyString), found local.get of type externref
+```
+
+i.e. `__str_concat` received an `externref` where its first operand must be
+`(ref null $AnyString)`.
+
+This is the message-building shape used by test262's
+`assert.sameValue` / `assert.throws`, so it **BLOCKS #3468's routing** (making the
+harness reach the assertion produced ~391 invalid-Wasm regressions). It is also a
+general standalone soundness bug on its own. Folded under **#2860** (standalone
+vs JS-host gap).
+
+## VERIFY-first: the stated premise was overturned
+
+The dispatch framed this as "function-EXPRESSION fails, function-DECLARATION is
+valid." On current `origin/main` **that is inverted / incomplete**: BOTH forms
+fail with the identical `CompileError`, because both route through the **same**
+codegen site. The function-expression only "looked" valid in the original probe
+because `const f = function(){…}` is never exported/called, so its body was
+tree-shaken away; once `f` is actually exercised (export + call), the expression
+form fails too. One root cause, one fix, covers both.
+
+Minimal trigger (neither half alone triggers it):
+
+| shape | result |
+| --- | --- |
+| `msg += 'x'` alone | OK (routes to `emitAnyAdd`, which coerces the externref) |
+| `if(msg===undefined){msg='';}` alone | OK |
+| `if(msg===undefined){msg='';} msg+='x';` | **INVALID Wasm** |
+| `return msg + 'x'` | OK |
+| annotated `msg: string` | OK (slot is already `ref $AnyString`) |
+
+## Root cause
+
+`compileNativeStringCompoundAssignment` in
+`src/codegen/expressions/operator-assignment.ts` handles string `+=`. The routing
+decision (`compileCompoundAssignment`) sends an `any`-typed binding here when
+`hasStringAssignment(name, …)` finds a `name = "literal"` somewhere in scope
+(the common `var x; x=""` test262 pattern). That function then loaded the
+**current value** with a bare `local.get`/`global.get` under the comment "Load
+current value as ref $AnyString" — but for an `any`/untyped binding the storage
+slot is **externref**, not a native-string ref. The RHS operand was coerced to
+`ref $AnyString` (lines ~1307-1338), the current-value load was not, so
+`__str_concat`'s **arg0** was a raw externref → invalid module.
+
+(The identifier read path was a red herring: `narrowTypeToUnbox` returns `null`
+for a string-narrowed type — "string stays externref" — and the `+=` never went
+through `compileStringBinaryOp`; it went through the compound-assignment path.)
+
+## Fix
+
+In `compileNativeStringCompoundAssignment`, after loading the current value,
+inspect the actual **slot type** for each storage class (local / captured global
+/ module global). When it is `externref` and we are in **no-JS-host mode**
+(`ctx.standalone || ctx.wasi`), coerce the loaded externref to a native
+`ref $AnyString` via **ToString** (`__extern_toString` + `any.convert_extern` +
+`ref.cast $AnyString`) — the exact coercion `compileNativeConcatOperand` uses for
+a dynamic externref `+` operand. This is spec-correct (§7.1.17): a runtime
+`number`/`undefined`/object stringifies (`5 → "5 x"`) instead of trapping an
+unconditional `ref.cast`, matching the general `+` operator lowering
+(`emitAnyAdd`).
+
+Index-shift safety: `__extern_toString` is a **native defined function** in
+standalone/WASI (`OBJECT_RUNTIME_HELPER_NAMES`, registered by
+`ensureObjectRuntime`), so `ensureLateImport` adds **no import** and shifts **no
+function index** — `concatIdx` stays valid. In JS-host `nativeStrings` mode
+`__extern_toString` is a host import (adding it mid-body would shift indices,
+#1175), so the coercion is gated off there and that path is left byte-identical
+(out of scope).
+
+Statically-`string` bindings and `let s=""` builders have a native-string ref
+slot, so the `externref` guard never fires → byte-identical, no regression.
+
+## Adjacent, out-of-scope (noted, not chased)
+
+The same site is also invalid Wasm when the slot is **f64/i32** (a param inferred
+numeric that is *also* string-assigned — a contradictory shape;
+`call[0] … found local.get of type f64`) or **`ref_null $AnyValue`** (unionAnyRep
+carrier). Both are pre-existing (reproduce on `origin/main`, unchanged by this
+fix) and are separate, narrower manifestations. A module-level `let acc: any = ''`
+accumulator returns a wrong *result* (pre-existing, native-string-ref slot so this
+fix does not touch it). Deferred.
+
+## Test Results
+
+`tests/issue-3472-standalone-fnexpr-strconcat-param.test.ts` (5 cases, all pass):
+declaration form, function-expression/closure form (`f(undefined)→"x"`,
+`f("a")→"a x"`), numeric-runtime-value ToString discriminator (`f(5)→"5 x"`),
+statically-`string` param regression, `let s=""` builder regression.
+
+Scoped regression suites green: `issue-1017-concat`, `issue-1470-*` (standalone
+string coercion/imports), `issue-1210` (string builder), `issue-2058-any-plus-string`,
+`issue-2176`/`template-literal-type-coercion`. `tsc --noEmit` clean.

--- a/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
+++ b/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
@@ -14,6 +14,7 @@ area: codegen
 goal: standalone
 related: [2860, 3468]
 blocks: [3468]
+loc-budget-allow: [src/codegen/expressions/operator-assignment.ts]
 ---
 
 ## Problem

--- a/src/codegen/expressions/operator-assignment.ts
+++ b/src/codegen/expressions/operator-assignment.ts
@@ -1282,19 +1282,51 @@ function compileNativeStringCompoundAssignment(
   const capturedIdx = ctx.capturedGlobals.get(name);
   const moduleIdx = ctx.moduleGlobals.get(name);
 
-  // Load current value as ref $AnyString
+  // Load current value. The store slot for a statically-`string` binding is a
+  // native-string ref (`ref $AnyString`), which `__str_concat` accepts as-is.
+  // But an `any`/untyped binding routed here via `hasStringAssignment` (e.g. an
+  // unannotated param `msg` that is also assigned a string literal in some
+  // branch) has an EXTERNREF slot: a bare `local.get`/`global.get` leaves an
+  // externref where `__str_concat` expects `(ref null $AnyString)` →
+  // `call[0] expected (ref null $AnyString), found externref` CompileError, i.e.
+  // an INVALID module (#3472 — the RHS below is coerced, only the current-value
+  // load was not). Under no-JS-host (standalone / WASI) coerce the loaded
+  // externref to a native `ref $AnyString` via ToString (§7.1.17) — the same
+  // `__extern_toString` path `compileNativeConcatOperand` uses for a dynamic
+  // externref `+` operand — so a runtime number / undefined / object stringifies
+  // correctly instead of trapping an unconditional `ref.cast`. `__extern_toString`
+  // is a NATIVE defined function here (OBJECT_RUNTIME_HELPER_NAMES), so
+  // registering it adds no import and shifts no function index (`concatIdx` above
+  // stays valid). In JS-host `nativeStrings` mode `__extern_toString` is a host
+  // import (adding it mid-body would shift indices, #1175), so that path is left
+  // byte-identical and out of scope.
+  const noJsHost = ctx.standalone === true || ctx.wasi === true;
+  let slotType: ValType | undefined;
   if (localIdx !== undefined) {
     fctx.body.push({ op: "local.get", index: localIdx });
+    slotType = getLocalType(fctx, localIdx);
   } else if (capturedIdx !== undefined) {
     fctx.body.push({ op: "global.get", index: capturedIdx });
+    slotType = ctx.mod.globals[localGlobalIdx(ctx, capturedIdx)]?.type;
   } else if (moduleIdx !== undefined) {
     fctx.body.push({ op: "global.get", index: moduleIdx });
+    slotType = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)]?.type;
   } else {
     // Graceful fallback: compile RHS for side effects, return null AnyString.
     const rhsFallback = compileExpression(ctx, fctx, expr.right);
     if (rhsFallback) fctx.body.push({ op: "drop" });
     fctx.body.push({ op: "ref.null", typeIdx: ctx.anyStrTypeIdx });
     return anyStrTypeNullable;
+  }
+  if (noJsHost && slotType?.kind === "externref") {
+    const externToStr = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+    flushLateImportShifts(ctx, fctx);
+    if (externToStr !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: externToStr });
+    }
+    // externref → ref $AnyString (mirrors emitNativeStringRefFromExternref).
+    fctx.body.push({ op: "any.convert_extern" });
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx });
   }
 
   // Compile RHS

--- a/tests/issue-3472-standalone-fnexpr-strconcat-param.test.ts
+++ b/tests/issue-3472-standalone-fnexpr-strconcat-param.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3472 — a native-string-reassigned `any`/untyped param that is then
+ * string-concatenated (`+=`) compiled to an INVALID standalone module.
+ *
+ * Repro shape (drives the test262 `assert.sameValue` message-building path):
+ *
+ *   const f = function(msg){
+ *     if (msg === undefined) { msg = ''; } else { msg += ' '; }
+ *     msg += 'x';
+ *     return msg;
+ *   };
+ *
+ * The unannotated param `msg` lowers to an EXTERNREF local slot. Because a
+ * branch assigns it a string literal (`msg = ''`), `+=` was routed to the
+ * native-string compound-assignment path (`compileNativeStringCompoundAssignment`),
+ * which loaded the current value with a bare `local.get` on the assumption the
+ * slot was already a native `ref $AnyString`. It was not, so `__str_concat`
+ * received an `externref` for its first operand:
+ *   `CompileError: call[0] expected type (ref null $AnyString), found ... externref`
+ * i.e. the module failed to instantiate.
+ *
+ * Fix: under no-JS-host (standalone / WASI) coerce the loaded externref
+ * current-value to a native `ref $AnyString` via ToString (§7.1.17,
+ * `__extern_toString`) — matching the general `+` operator lowering — so a
+ * runtime number/undefined/object stringifies correctly instead of an
+ * unconditional-cast trap. Both the function-DECLARATION and the
+ * function-EXPRESSION/closure forms route through the same site, so one fix
+ * covers both.
+ */
+
+async function instantiateStandalone(source: string) {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Empty import object — proves the module is JS-host-free (pure Wasm).
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#3472 standalone: native-string-reassigned externref param += concat", () => {
+  it("compiles a VALID module and runs — function DECLARATION form", async () => {
+    // In-wasm comparison → returns 1/0 (avoids marshalling native strings across
+    // the JS boundary). `f(undefined)` → "x", `f("a")` → "a x".
+    const ex = await instantiateStandalone(`
+      function f(msg){ if (msg === undefined) { msg = ''; } else { msg += ' '; } msg += 'x'; return msg; }
+      export function test(): number {
+        return (f(undefined) === 'x' && f('a') === 'a x') ? 1 : 0;
+      }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("compiles a VALID module and runs — function EXPRESSION / closure form", async () => {
+    const ex = await instantiateStandalone(`
+      export function test(): number {
+        const f = function(msg){ if (msg === undefined) { msg = ''; } else { msg += ' '; } msg += 'x'; return msg; };
+        return (f(undefined) === 'x' && f('a') === 'a x') ? 1 : 0;
+      }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("stringifies a non-string runtime value via ToString (not an unconditional-cast trap)", async () => {
+    // `msg: any` keeps the externref slot; a numeric runtime value reaches the
+    // `else` branch and must ToString → "5 x" (`ref.cast`-only would trap here).
+    const ex = await instantiateStandalone(`
+      function f(msg: any){ if (msg === undefined) { msg = ''; } else { msg += ' '; } msg += 'x'; return msg; }
+      export function test(): number { return (f(5) === '5 x') ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("does not regress a statically-string param (native-string ref slot)", async () => {
+    const ex = await instantiateStandalone(`
+      function f(msg: string){ if (msg === undefined) { msg = ''; } else { msg += ' '; } msg += 'x'; return msg; }
+      export function test(): number { return (f('a') === 'a x') ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+
+  it("does not regress a plain `let s = ''` string builder", async () => {
+    const ex = await instantiateStandalone(`
+      export function test(): number { let s = ''; s += 'a'; s += 'b'; return (s === 'ab') ? 1 : 0; }
+    `);
+    expect(ex.test!()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Under `--target standalone` (and WASI), a function whose unannotated (`any`/externref) param is **reassigned to a native-string literal in one branch and then `+=` string-concatenated** compiled to an **invalid Wasm module** — `WebAssembly.instantiate` threw `CompileError: call[0] expected type (ref null $AnyString), found ... externref`:

```ts
const f = function(msg){ if(msg===undefined){msg='';} else {msg+=' ';} msg+='x'; return msg; };
```

This is the message-building shape used by test262's `assert.sameValue`/`assert.throws`, so it **BLOCKS #3468's routing**. It is a general standalone soundness bug on its own. Folded under **#2860** (standalone vs JS-host gap).

## VERIFY-first — premise overturned

The dispatch framed this as "function-EXPRESSION fails, DECLARATION valid." On current `origin/main` that is **inverted/incomplete**: BOTH forms fail with the identical `CompileError` (they route through the same codegen site). The expression form only *looked* valid in the original probe because `const f = function(){…}` was never exported/called, so its body was tree-shaken. One root cause, one fix, covers both.

## Root cause

`compileNativeStringCompoundAssignment` (`src/codegen/expressions/operator-assignment.ts`) loaded the current value of the binding with a bare `local.get`/`global.get` under the comment "Load current value as ref $AnyString" — but an `any`/untyped binding (routed here by `hasStringAssignment` finding a `name = "literal"`) has an **externref** slot, not a native-string ref. The RHS operand was coerced; the current-value load was not, so `__str_concat` got a raw externref for arg0 → invalid module.

## Fix

Inspect the actual slot type per storage class (local/captured/module). When it is `externref` and we are in no-JS-host mode (`ctx.standalone || ctx.wasi`), coerce the loaded externref to `ref $AnyString` via **ToString** (`__extern_toString` + `any.convert_extern` + `ref.cast $AnyString`) — the exact coercion `compileNativeConcatOperand` uses for a dynamic externref `+` operand, matching the general `+` lowering (`emitAnyAdd`). A runtime number/undefined/object stringifies (`5 → "5 x"`) instead of an unconditional-cast trap.

- **Index-shift-safe**: `__extern_toString` is a native defined function in standalone/WASI (`OBJECT_RUNTIME_HELPER_NAMES`), so no import is added and no function index shifts (`concatIdx` stays valid).
- **No JS-host regression**: gated to no-JS-host; in JS-host `nativeStrings` mode `__extern_toString` is a host import (would shift indices, #1175), so that path is left byte-identical.
- **No regression** for statically-`string` params / `let s=""` builders — their slot is a native-string ref, so the externref guard never fires.

## Tests

`tests/issue-3472-standalone-fnexpr-strconcat-param.test.ts` (5 cases, all green): declaration form, function-expression/closure form (`f(undefined)→"x"`, `f("a")→"a x"`), numeric-runtime ToString discriminator (`f(5)→"5 x"`), statically-`string` regression, `let s=""` builder regression. Scoped suites green (`issue-1017-concat`, `issue-1470-*`, `issue-1210`, `issue-2058-any-plus-string`, template). `tsc --noEmit` clean.

The `loc-budget-allow` for `operator-assignment.ts` is granted in this PR's own issue frontmatter (the fix belongs in that module, already at its ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb