### PR TITLE
release: v0.63.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Lockstep version bump 0.62.0 → 0.63.0 (package.json + packages/js2wasm proxy). Cut from current main.

Captures today's test262 gains: host 65.6% (28,294/43,106), standalone 63.5% (27,378/43,106, +2,495); plus baseline-drift structural fix (#3467), net-aware regression gate (#3457), landing-page baseline refresh (#3468).

Release commit ba4d98382 carries local tag v0.63.0. **After merge**, push the tag to trigger publish-npm: `git push origin v0.63.0` (do NOT push the tag before merge — publish-npm.yml fires on any v<x.y.z> push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)