### PR TITLE
chore(sprint): freeze sprint 72 (fable-final→current, 139 done)

### DIFF
--- a/plan/issues/1004-optimize-repeated-string-concatenation-via.md
+++ b/plan/issues/1004-optimize-repeated-string-concatenation-via.md
@@ -4,7 +4,7 @@ title: "Optimize repeated string concatenation via compile-time folding and coun
 status: done
 assignee: ttraenkler/dev-perf
 created: 2026-04-09
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: medium
 feasibility: medium
@@ -12,7 +12,7 @@ reasoning_effort: high
 task_type: feature
 language_feature: strings-concat
 goal: generator-model
-sprint: current
+sprint: 72
 es_edition: multi
 loc-budget-allow:
   - src/codegen/statements/loops.ts

--- a/plan/issues/1044-node-builtin-modules-as-host.md
+++ b/plan/issues/1044-node-builtin-modules-as-host.md
@@ -6,12 +6,12 @@ status: done
 completed: 2026-07-17
 assignee: ttraenkler/opus-b
 created: 2026-04-11
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 feasibility: medium
 reasoning_effort: high
 goal: async-model
-sprint: current
+sprint: 72
 parent: 1032
 depends_on: [1041]
 required_by: [1032, 1058]

--- a/plan/issues/1102-wasm-native-eval-ahead-of.md
+++ b/plan/issues/1102-wasm-native-eval-ahead-of.md
@@ -6,7 +6,7 @@ completed: 2026-07-16
 pr: 3113
 assignee: ttraenkler/sendev-1102
 created: 2026-04-12
-updated: 2026-07-16
+updated: 2026-07-19
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -14,7 +14,7 @@ task_type: feature
 language_feature: eval
 goal: spec-completeness
 model: fable
-sprint: current
+sprint: 72
 required_by: [1584]
 es_edition: ES5
 # oracle-ratchet-allow: resolveConstStringBinding needs BINDING resolution

--- a/plan/issues/1315-import-defer-source-early-error-gap.md
+++ b/plan/issues/1315-import-defer-source-early-error-gap.md
@@ -5,7 +5,7 @@ horizon: m
 status: done
 completed: 2026-07-17
 created: 2026-05-07
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -13,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: modules, import-defer, import-source
 goal: spec-completeness
-sprint: current
+sprint: 72
 ---
 # #1315 — `import.defer` / `import.source` early error detection gap (157 negative tests)
 

--- a/plan/issues/1373-ir-async-function.md
+++ b/plan/issues/1373-ir-async-function.md
@@ -5,7 +5,7 @@ status: done
 model: fable
 fable_role: implement
 created: 2026-05-08
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-05-21
 priority: medium
 feasibility: hard
@@ -14,7 +14,7 @@ task_type: feature
 area: ir, codegen
 language_feature: async
 goal: ir-full-coverage
-sprint: fable-final
+sprint: 72
 closed: 2026-05-20
 ---
 # #1373 — IR: async function support

--- a/plan/issues/1792-node-url-builtin-impl.md
+++ b/plan/issues/1792-node-url-builtin-impl.md
@@ -3,10 +3,10 @@ id: 1792
 title: "node:url — URL / URLSearchParams as host constructors"
 horizon: m
 status: done
-sprint: current
+sprint: 72
 assignee: ttraenkler/opus-b
 created: 2026-06-03
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: high
 feasibility: medium

--- a/plan/issues/1793-node-buffer-builtin-impl.md
+++ b/plan/issues/1793-node-buffer-builtin-impl.md
@@ -7,9 +7,9 @@ completed: 2026-07-16
 assignee: ttraenkler/fable-epsilon
 loc-budget-allow:
   - src/codegen/expressions/calls.ts
-sprint: current
+sprint: 72
 created: 2026-06-03
-updated: 2026-07-16
+updated: 2026-07-19
 priority: high
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/1794-node-events-builtin-impl.md
+++ b/plan/issues/1794-node-events-builtin-impl.md
@@ -4,9 +4,9 @@ title: "node:events / EventEmitter — host class + closure-callback contract"
 status: done
 completed: 2026-07-16
 assignee: ttraenkler/fable-s2
-sprint: current
+sprint: 72
 created: 2026-06-03
-updated: 2026-07-16
+updated: 2026-07-19
 loc-budget-allow:
   - src/runtime.ts
   - src/import-resolver.ts

--- a/plan/issues/1795-node-http-builtin-impl.md
+++ b/plan/issues/1795-node-http-builtin-impl.md
@@ -9,9 +9,9 @@ loc-budget-allow:
   - src/runtime.ts
   - src/import-resolver.ts
   - src/codegen/closures.ts
-sprint: current
+sprint: 72
 created: 2026-06-03
-updated: 2026-06-03
+updated: 2026-07-19
 priority: high
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/2040-standalone-generator-dstr-runtime-semantics.md
+++ b/plan/issues/2040-standalone-generator-dstr-runtime-semantics.md
@@ -4,12 +4,12 @@ title: "standalone: generator/destructuring runtime-semantics residual — rest-
 status: done
 completed: 2026-07-16
 assignee: ttraenkler/fable-beta
-sprint: current
+sprint: 72
 loc-budget-allow:
   - src/codegen/any-helpers.ts
   - src/codegen/context/types.ts
 created: 2026-06-10
-updated: 2026-07-16
+updated: 2026-07-19
 priority: critical
 horizon: l
 feasibility: hard

--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -7,7 +7,7 @@ status: in-progress
 model: fable
 fable_role: spec
 assignee: ttraenkler/opus-regexp
-sprint: fable-final
+sprint: current
 created: 2026-06-11
 updated: 2026-07-17
 s1_note: "S1 (standalone tag-1 $undefined singleton) NOT COMPLETE — PR #2025 was AUTO-PARKED in merge_group (2026-06-24): standalone high-water floor breached (pass 23729 vs mark 24956), NET −1245 test262 rows (1654 regressed / 409 gained). Root cause (diagnosed by sdev-s1fix 2026-06-25, see '## S1 merge_group regression — diagnosis'): S1.1 flipped the CONSUMER __extern_is_undefined to singleton-only but did NOT flip the matching PRODUCERS (notably __extern_get's missing-key return at object-runtime.ts:856, still ref.null.extern), so destructuring/param defaults stop firing. This is the architect-spec's full ~40-site producer+consumer sweep done as a partial subset — there is NO narrow floor-saving fix. RESOLUTION 2026-06-25: S1.1+S1.2 behavioral flips REVERTED on the branch (kept inert S1.0); PR #2025 re-targets to a floor-neutral revert. S1 to be re-landed as a fully-scoped complete sweep (architect re-spec). REMAINING slices unchanged: S2 (sNaN carve-out), S3 (number|undefined→externref), S4 (union-collapse reversal), typeof-null→object."

--- a/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
+++ b/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
@@ -3,7 +3,7 @@ id: 2141
 title: "Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing"
 status: in-progress
 assignee: ttraenkler/fable-tag5
-sprint: fable-final
+sprint: current
 created: 2026-06-12
 updated: 2026-07-17
 unblocked_note: "2026-07-02: blocked_by #2167 (Fable disabled) is done — Fable restored; flipped on claim per owner directive (task #32)."

--- a/plan/issues/2175-standalone-builtin-prototype-readers.md
+++ b/plan/issues/2175-standalone-builtin-prototype-readers.md
@@ -5,7 +5,7 @@ status: in-progress
 model: fable
 fable_role: spec
 assignee: ttraenkler/opus-2175s3
-sprint: fable-final
+sprint: current
 created: 2026-06-16
 updated: 2026-07-17
 priority: high

--- a/plan/issues/2509-referenced-names-property-access-imprecision.md
+++ b/plan/issues/2509-referenced-names-property-access-imprecision.md
@@ -4,9 +4,9 @@ title: "referencedNames over-collects property-access names → spurious env.<na
 status: done
 assignee: dev-builtins
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-06-19
-updated: 2026-07-17
+updated: 2026-07-19
 priority: low
 feasibility: medium
 reasoning_effort: low

--- a/plan/issues/2578-standalone-dynamic-property-multi-read-typing.md
+++ b/plan/issues/2578-standalone-dynamic-property-multi-read-typing.md
@@ -4,7 +4,7 @@ title: "standalone dynamic property multi-read mangles inferred-typed values (wr
 status: done
 assignee: dev-refactor
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-06-21
 priority: medium
 feasibility: medium

--- a/plan/issues/2622-native-extends-collection-subclass.md
+++ b/plan/issues/2622-native-extends-collection-subclass.md
@@ -5,7 +5,7 @@ status: backlog
 updated: 2026-07-17
 model: fable
 fable_role: spec
-sprint: fable-final
+sprint: current
 created: 2026-06-22
 priority: medium
 feasibility: hard

--- a/plan/issues/2649-standalone-typedarray-subarray-empty.md
+++ b/plan/issues/2649-standalone-typedarray-subarray-empty.md
@@ -4,7 +4,7 @@ title: "Standalone: TypedArray.prototype.subarray returns an empty view (.length
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/dev-standalone2
-sprint: current
+sprint: 72
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2650-standalone-string-at-nullable-result-member-read.md
+++ b/plan/issues/2650-standalone-string-at-nullable-result-member-read.md
@@ -4,7 +4,7 @@ title: "Standalone: member-read on String.prototype.at result returns empty (.le
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/dev-standalone2
-sprint: current
+sprint: 72
 priority: low
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2651-builtin-constructor-prototype-as-value-substrate.md
+++ b/plan/issues/2651-builtin-constructor-prototype-as-value-substrate.md
@@ -9,7 +9,7 @@ blocked_on: 2580
 assignee: ttraenkler/sd-2651
 slices_done: "D2/M1 (PR #2043, commit 7374c34c6)"
 slices_remaining: "M3 (%TypedArray% intrinsic value-dispatch) — predecessor-stack on #2580 M3"
-sprint: fable-final
+sprint: current
 created: 2026-06-24
 priority: high
 feasibility: hard

--- a/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
+++ b/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
@@ -6,7 +6,7 @@ updated: 2026-07-17
 model: fable
 fable_role: implement
 assignee: ttraenkler/fable-dev-1
-sprint: fable-final
+sprint: current
 created: 2026-06-25
 priority: high
 feasibility: hard

--- a/plan/issues/2690-eslint-rule-tester-polymorphic-return-widening.md
+++ b/plan/issues/2690-eslint-rule-tester-polymorphic-return-widening.md
@@ -5,7 +5,7 @@ status: ready
 updated: 2026-07-17
 model: fable
 fable_role: spec
-sprint: fable-final
+sprint: current
 created: 2026-06-26
 priority: low
 area: codegen

--- a/plan/issues/2728-object-symbol-wrapper-boxing.md
+++ b/plan/issues/2728-object-symbol-wrapper-boxing.md
@@ -5,13 +5,13 @@ status: done
 assignee: dev-builtins
 completed: 2026-07-17
 created: 2026-06-26
-updated: 2026-07-17
+updated: 2026-07-19
 priority: low
 feasibility: medium
 task_type: bugfix
 area: codegen
 goal: test262-conformance
-sprint: current
+sprint: 72
 depends_on: []
 related: [1568, 3280, 3383]
 # (#2728) The new `__new_Symbol` host handler belongs in runtime.ts alongside

--- a/plan/issues/2739-forin-prototype-chain-defineproperty-enumeration.md
+++ b/plan/issues/2739-forin-prototype-chain-defineproperty-enumeration.md
@@ -3,7 +3,7 @@ id: 2739
 title: "for-in does not enumerate setPrototypeOf / constructor-prototype-chain properties; Object.defineProperty ordering"
 horizon: l
 status: done
-sprint: current
+sprint: 72
 goal: test262-conformance
 feasibility: hard
 depends_on: []
@@ -12,7 +12,7 @@ es_edition: ES5
 language_feature: for-in
 task_type: bug
 created: 2026-06-27
-updated: 2026-07-16
+updated: 2026-07-19
 completed: 2026-07-16
 assignee: ttraenkler/fable-delta
 loc-budget-allow:

--- a/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
+++ b/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
@@ -2,7 +2,7 @@
 id: 2763
 title: "[SUBSTRATE][ARCH] instanceof value-rep residual: cross-realm Object/Function identity + .prototype access on dynamic Function values"
 status: ready
-sprint: fable-final
+sprint: current
 created: 2026-06-28
 updated: 2026-07-17
 priority: medium

--- a/plan/issues/2773-value-rep-substrate-epic.md
+++ b/plan/issues/2773-value-rep-substrate-epic.md
@@ -3,7 +3,7 @@ id: 2773
 title: "[EPIC][ARCH] Value-rep substrate: consistent native dispatch for reconstructed-struct field access + DCE/finalize-stable typeIdx"
 status: in-progress
 assignee: ttraenkler/fable-2773t
-sprint: fable-final
+sprint: current
 model: fable
 fable_role: implement
 created: 2026-06-28

--- a/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
+++ b/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
@@ -11,7 +11,7 @@ fable_role: spec
 task_type: epic
 area: codegen
 goal: standalone
-sprint: fable-final
+sprint: current
 horizon: xl
 related: [2861, 2862, 2863, 2864, 2865, 2866, 2867, 2868, 2872, 2873, 2874, 2875, 2876, 2877, 2878, 2879, 3027, 3169, 3170, 3171, 3172, 3173, 3174, 3175, 3176, 3177]
 ---

--- a/plan/issues/2865-standalone-async-generator-carrier.md
+++ b/plan/issues/2865-standalone-async-generator-carrier.md
@@ -12,7 +12,7 @@ feasibility: hard
 task_type: feature
 area: codegen
 goal: standalone
-sprint: fable-final
+sprint: current
 horizon: xl
 related: [2860, 2864, 2867]
 umbrella: 2860

--- a/plan/issues/2895-standalone-await-frame-suspension.md
+++ b/plan/issues/2895-standalone-await-frame-suspension.md
@@ -11,7 +11,7 @@ feasibility: hard
 task_type: feature
 area: codegen
 goal: standalone
-sprint: fable-final
+sprint: current
 horizon: xl
 related: [2864, 2865, 2867, 2367]
 umbrella: 2860

--- a/plan/issues/2903-standalone-make-callback-residual-rootcause.md
+++ b/plan/issues/2903-standalone-make-callback-residual-rootcause.md
@@ -3,9 +3,9 @@ id: 2903
 title: "standalone: residual env.__make_callback leak is host-backed builtin methods (Promise.then/.catch, Iterator helpers), NOT a callback-representation gap"
 status: done
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-06-30
-updated: 2026-07-16
+updated: 2026-07-19
 priority: high
 feasibility: hard
 reasoning_effort: max

--- a/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
+++ b/plan/issues/2916-standalone-native-instanceof-and-isprototypeof.md
@@ -4,7 +4,7 @@ title: "[SUBSTRATE][ARCH] Standalone native instanceof operator + isPrototypeOf 
 status: in-progress
 updated: 2026-07-17
 assignee: ttraenkler/sendev-instanceof
-sprint: fable-final
+sprint: current
 created: 2026-07-01
 priority: medium
 horizon: l

--- a/plan/issues/2917-standalone-native-class-extends-builtin-super-construction.md
+++ b/plan/issues/2917-standalone-native-class-extends-builtin-super-construction.md
@@ -3,7 +3,7 @@ id: 2917
 title: "[SUBSTRATE][ARCH] Standalone native `class X extends <Builtin>` super-construction (~10 generic conversions)"
 status: ready
 assignee: fable-2917
-sprint: fable-final
+sprint: current
 updated: 2026-07-17
 created: 2026-07-01
 priority: medium

--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -6,9 +6,9 @@ completed: 2026-07-16
 assignee: ttraenkler/opus-1a
 branch: symphony/porffor/2953-after-pr-3146
 pr: 3159
-sprint: current
+sprint: 72
 created: 2026-07-02
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 horizon: l
 feasibility: medium

--- a/plan/issues/2958-standalone-unhandled-rejection-tracking.md
+++ b/plan/issues/2958-standalone-unhandled-rejection-tracking.md
@@ -4,9 +4,9 @@ title: "Standalone: unhandled-rejection tracking — report rejected promises wi
 status: done
 assignee: dev-2958
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-07-02
-updated: 2026-07-17
+updated: 2026-07-19
 priority: low
 horizon: m
 feasibility: medium

--- a/plan/issues/2961-standalone-strict-leak-scan.md
+++ b/plan/issues/2961-standalone-strict-leak-scan.md
@@ -5,10 +5,10 @@ status: done
 completed: 2026-07-17
 assignee: dev-2961
 depends_on: [3009]
-sprint: current
+sprint: 72
 model: opus
 created: 2026-07-02
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/2970-import-meta-per-module-identity.md
+++ b/plan/issues/2970-import-meta-per-module-identity.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/dev-perf
 completed: 2026-07-17
 priority: medium
-sprint: current
+sprint: 72
 created: 2026-07-02
 feasibility: medium
 task_type: bug

--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -3,7 +3,7 @@ id: 2984
 title: "Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)"
 status: in-progress
 updated: 2026-07-17
-sprint: fable-final
+sprint: current
 priority: high
 horizon: xl
 feasibility: hard

--- a/plan/issues/3008-issue-tests-not-in-required-ci.md
+++ b/plan/issues/3008-issue-tests-not-in-required-ci.md
@@ -3,7 +3,7 @@ id: 3008
 title: "process gap: tests/issue-*.test.ts are not uniformly wired into required CI (silent regressions)"
 status: done
 completed: 2026-07-17
-sprint: current
+sprint: 72
 priority: low
 assignee: ttraenkler/fable-s2
 created: 2026-07-03

--- a/plan/issues/3022-defineproperty-descriptor-fidelity-tail-residual.md
+++ b/plan/issues/3022-defineproperty-descriptor-fidelity-tail-residual.md
@@ -2,9 +2,9 @@
 id: 3022
 title: "UMBRELLA: Object.defineProperty(ies) descriptor fidelity + non-object-receiver tail (~728 default-lane fails)"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-03
-updated: 2026-07-05
+updated: 2026-07-19
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3037-object-identity-canonicalization-substrate.md
+++ b/plan/issues/3037-object-identity-canonicalization-substrate.md
@@ -3,7 +3,7 @@ id: 3037
 title: "Object-identity canonicalization substrate for standalone dynamic reads (foundation under #3027 / V2-S3b reader-arm)"
 status: in-progress
 assignee: ttraenkler/fable-identity
-sprint: fable-final
+sprint: current
 model: fable
 fable_role: spec
 created: 2026-07-05

--- a/plan/issues/3041-any-receiver-nested-class-getter-dispatch-nan.md
+++ b/plan/issues/3041-any-receiver-nested-class-getter-dispatch-nan.md
@@ -3,9 +3,9 @@ id: 3041
 title: "get-accessor via an any-typed receiver on a class declared inside a function returns NaN/undefined (dynamic accessor dispatch gap)"
 status: done
 assignee: ttraenkler/dev-conform
-sprint: current
+sprint: 72
 created: 2026-07-05
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: medium
 horizon: m

--- a/plan/issues/3053-unified-dynamic-reader-carrier-substrate.md
+++ b/plan/issues/3053-unified-dynamic-reader-carrier-substrate.md
@@ -5,7 +5,7 @@ status: in-progress
 model: fable
 fable_role: spec
 assignee: ttraenkler/opus-u2-flip
-sprint: fable-final
+sprint: current
 created: 2026-07-05
 updated: 2026-07-17
 priority: high

--- a/plan/issues/3055-standalone-any-eq-boxed-number-class-present.md
+++ b/plan/issues/3055-standalone-any-eq-boxed-number-class-present.md
@@ -5,7 +5,7 @@ status: in-progress
 updated: 2026-07-17
 model: fable
 fable_role: spec
-sprint: fable-final
+sprint: current
 assignee: opus-3055
 created: 2026-07-05
 priority: high

--- a/plan/issues/3101-bytecode-isa-frame-abi-prespec.md
+++ b/plan/issues/3101-bytecode-isa-frame-abi-prespec.md
@@ -4,7 +4,7 @@ title: "Bytecode interpreter ISA + `$Frame`/`$EnvRec` ABI pre-spec (E1 executabl
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/senior-dev
-sprint: current
+sprint: 72
 priority_note: "promoted 2026-07-17 by the interpreter-backend audit (plan/log/analysis-2026-07/02-interpreter-backend-audit-2026-07-17.md): P1/P2 (#2853) done sprint 71, compiled-acorn corpus 23/23 parity — E1 has zero unmet dependencies and is the start of Tier 2"
 model: fable
 created: 2026-07-09

--- a/plan/issues/3107-as-instr-cast-elimination-codemod.md
+++ b/plan/issues/3107-as-instr-cast-elimination-codemod.md
@@ -2,9 +2,9 @@
 id: 3107
 title: "Cast-debt codemod: eliminate 10,678 'as Instr' + 129 'as unknown as Instr' + shrink 579 'as any'"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-09
-updated: 2026-07-14
+updated: 2026-07-19
 completed: 2026-07-14
 priority: high
 # 2026-07-12 (#3182 groom): elevated Backlog/medium → current/high.

--- a/plan/issues/3132-standalone-native-async-generators.md
+++ b/plan/issues/3132-standalone-native-async-generators.md
@@ -3,7 +3,7 @@ id: 3132
 title: "Standalone native ASYNC GENERATORS — retire env::__create_async_generator leaky-passes (~2,800 files)"
 status: done
 completed: 2026-07-16
-sprint: current
+sprint: 72
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -15,7 +15,7 @@ horizon: xl
 umbrella: 2860
 related: [3075, 2906, 2865, 2938, 2936, 2980, 2895, 2922, 1042, 3120, 3312, 3313]
 created: 2026-07-10
-updated: 2026-07-16
+updated: 2026-07-19
 assignee: ttraenkler/fable-3132-s2
 loc-budget-allow:
   - src/codegen/class-bodies.ts

--- a/plan/issues/3136-standalone-cell-read-identity-loss.md
+++ b/plan/issues/3136-standalone-cell-read-identity-loss.md
@@ -4,9 +4,9 @@ title: "Standalone: object read back through a boxed-capture cell loses `===` id
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/dev-standalone2
-sprint: current
+sprint: 72
 created: 2026-07-10
-updated: 2026-07-17
+updated: 2026-07-19
 priority: medium
 horizon: s
 feasibility: medium

--- a/plan/issues/3142-ir-module-level-statement-adoption.md
+++ b/plan/issues/3142-ir-module-level-statement-adoption.md
@@ -4,9 +4,9 @@ title: "IR module-level (top-level statement) adoption — clears gate G3 of the
 status: done
 completed: 2026-07-16
 assignee: ttraenkler/fable-b
-sprint: current
+sprint: 72
 created: 2026-07-11
-updated: 2026-07-16
+updated: 2026-07-19
 note: "Slice 1 (selector + telemetry) landed via PR #3160; Slice 2 (claim-feeding lowering + __module_init patch, f64/i32 module bindings) lands in this PR."
 priority: high
 horizon: l

--- a/plan/issues/3145-standalone-atomics-nonshared-throws.md
+++ b/plan/issues/3145-standalone-atomics-nonshared-throws.md
@@ -4,7 +4,7 @@ title: "standalone: Atomics.* on non-shared views (the non-SAB subset — ~29 __
 status: done
 completed: 2026-07-14
 assignee: ttraenkler/senior-dev-a7a4
-sprint: current
+sprint: 72
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/3148-standalone-bigint-asintn.md
+++ b/plan/issues/3148-standalone-bigint-asintn.md
@@ -4,7 +4,7 @@ title: "standalone: BigInt.asIntN / asUintN (20 __get_builtin CEs)"
 status: done
 completed: 2026-07-14
 assignee: ttraenkler/senior-dev-3148
-sprint: current
+sprint: 72
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/3150-standalone-uint8array-base64-hex.md
+++ b/plan/issues/3150-standalone-uint8array-base64-hex.md
@@ -3,7 +3,7 @@ id: 3150
 title: "standalone: Uint8Array.fromBase64 / fromHex (+ toBase64/toHex/setFrom*) (12 __get_builtin CEs)"
 status: done
 completed: 2026-07-17
-sprint: current
+sprint: 72
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
+++ b/plan/issues/3155-standalone-object-spread-assign-keys-order-gaps.md
@@ -3,9 +3,9 @@ id: 3155
 title: "standalone: object spread / Object.assign / Object.keys-values order + object→primitive gaps (unmasked by the #86 vacuous-standalone audit)"
 status: done
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-07-11
-updated: 2026-07-17
+updated: 2026-07-19
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/3163-new-fnctor-via-any-cast-callee-returns-null.md
+++ b/plan/issues/3163-new-fnctor-via-any-cast-callee-returns-null.md
@@ -4,12 +4,12 @@ title: "`new (Fn as any)()` on a function-style constructor returns null (dynami
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-b
-sprint: current
+sprint: 72
 priority: medium
 horizon: m
 feasibility: medium
 created: 2026-07-12
-updated: 2026-07-17
+updated: 2026-07-19
 task_type: bugfix
 area: codegen
 language_feature: function-constructors, new-expression, any-callee

--- a/plan/issues/3170-standalone-array-search-methods-value-arraylike.md
+++ b/plan/issues/3170-standalone-array-search-methods-value-arraylike.md
@@ -4,7 +4,7 @@ title: "standalone: Array.prototype.indexOf/lastIndexOf/includes — method-as-v
 status: done
 assignee: ttraenkler/opus-3170
 created: 2026-07-12
-updated: 2026-07-13
+updated: 2026-07-19
 completed: 2026-07-16
 priority: high
 feasibility: hard
@@ -14,7 +14,7 @@ es_edition: multi
 language_feature: array-methods
 goal: standalone
 umbrella: 2860
-sprint: current
+sprint: 72
 horizon: m
 related: [2860, 2670, 3169, 2861, 2175, 3317, 3318]
 origin: "PO groom of #2860 umbrella, 2026-07-12 lane-baseline diff"

--- a/plan/issues/3174-standalone-date-brand-coercion-order.md
+++ b/plan/issues/3174-standalone-date-brand-coercion-order.md
@@ -4,7 +4,7 @@ title: "standalone: Date receiver brand checks + ToPrimitive coercion order (get
 status: done
 assignee: ttraenkler/sendev-date-3174
 created: 2026-07-12
-updated: 2026-07-16
+updated: 2026-07-19
 completed: 2026-07-16
 priority: high
 feasibility: hard
@@ -14,7 +14,7 @@ es_edition: multi
 language_feature: date
 goal: standalone
 umbrella: 2860
-sprint: current
+sprint: 72
 horizon: m
 related: [2860, 2671, 2891, 3171]
 loc-budget-allow:

--- a/plan/issues/3192-bloat-s2-route-dataview-regexp-brand-checks.md
+++ b/plan/issues/3192-bloat-s2-route-dataview-regexp-brand-checks.md
@@ -4,7 +4,7 @@ title: "bloat S2: route DataView + RegExp brand checks through receiver-brand.ts
 status: done
 completed: 2026-07-14
 created: 2026-07-12
-updated: 2026-07-14
+updated: 2026-07-19
 priority: high
 feasibility: medium
 task_type: refactor
@@ -12,7 +12,7 @@ area: codegen
 es_edition: n/a
 language_feature: brand-check
 goal: maintainability
-sprint: current
+sprint: 72
 horizon: m
 umbrella: 3182
 depends_on: [3191]

--- a/plan/issues/3193-bloat-s3-delete-shape-path-array-call-clones.md
+++ b/plan/issues/3193-bloat-s3-delete-shape-path-array-call-clones.md
@@ -5,7 +5,7 @@ status: done
 assignee: dev-3193
 completed: 2026-07-17
 created: 2026-07-12
-updated: 2026-07-17
+updated: 2026-07-19
 priority: medium
 feasibility: medium
 task_type: refactor
@@ -13,7 +13,7 @@ area: codegen
 es_edition: n/a
 language_feature: array-methods
 goal: maintainability
-sprint: current
+sprint: 72
 horizon: m
 umbrella: 3182
 related: [3029, 3102, 3185]

--- a/plan/issues/3196-bloat-s6-deinline-standalone-dynamic-hof-onto-steppers.md
+++ b/plan/issues/3196-bloat-s6-deinline-standalone-dynamic-hof-onto-steppers.md
@@ -14,7 +14,7 @@ area: codegen
 es_edition: n/a
 language_feature: array-methods
 goal: maintainability
-sprint: fable-final
+sprint: current
 horizon: l
 umbrella: 3182
 related: [3098, 3029, 3102, 3185]

--- a/plan/issues/3202-typedarray-set-bigint-oob-traps.md
+++ b/plan/issues/3202-typedarray-set-bigint-oob-traps.md
@@ -10,7 +10,7 @@ task_type: bug
 area: ci
 language_feature: typed-array
 goal: crash-free
-sprint: current
+sprint: 72
 horizon: m
 related: [3189, 3173]
 # loc-budget-allow retired by #3358: the +LOC this granted was the

--- a/plan/issues/3229-object-keys-inline-length-vec-type-mismatch.md
+++ b/plan/issues/3229-object-keys-inline-length-vec-type-mismatch.md
@@ -3,9 +3,9 @@ id: 3229
 title: "Object.keys/values/entries(closedStruct).length INLINE returns 0 — static-enumeration vec type (vec-of-externref) mismatches the `.length` dispatch type (vec-of-string); mode-agnostic"
 status: done
 assignee: ttraenkler/dev-conform
-sprint: current
+sprint: 72
 created: 2026-07-13
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: medium
 feasibility: medium

--- a/plan/issues/3243-standalone-object-strict-eq-refeq-identity.md
+++ b/plan/issues/3243-standalone-object-strict-eq-refeq-identity.md
@@ -3,7 +3,7 @@ id: 3243
 title: "standalone: native object === identity — extend #2734 ref.eq fast path to inline strict-eq (retire tag-5 string-content fold for objects)"
 status: done
 completed: 2026-07-13
-sprint: current
+sprint: 72
 priority: high
 feasibility: hard
 reasoning_effort: max

--- a/plan/issues/3245-async-gen-dstr-hostfree-fail-cluster-decomposition.md
+++ b/plan/issues/3245-async-gen-dstr-hostfree-fail-cluster-decomposition.md
@@ -4,7 +4,7 @@ title: "async-gen dstr host-free-FAIL cluster: root decomposition + error-path m
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-s2
-sprint: current
+sprint: 72
 priority: medium
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/3254-string-requireobjectcoercible.md
+++ b/plan/issues/3254-string-requireobjectcoercible.md
@@ -5,7 +5,7 @@ title: "Standalone: RequireObjectCoercible + ToString for borrowed String.protot
 status: done
 completed: 2026-07-13
 assignee: opus-tabrand
-sprint: current
+sprint: 72
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3256-selfhost-string-family-tier1.md
+++ b/plan/issues/3256-selfhost-string-family-tier1.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/sendev-3256
 completed: 2026-07-16
 pr: 3119
-sprint: current
+sprint: 72
 priority: high
 horizon: xl
 feasibility: hard

--- a/plan/issues/3257-selfhost-array-family-tier2.md
+++ b/plan/issues/3257-selfhost-array-family-tier2.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/sendev-3256
 completed: 2026-07-16
 pr: 3122
-sprint: current
+sprint: 72
 priority: high
 horizon: xl
 feasibility: hard

--- a/plan/issues/3259-bloat-quickwins-knip-jscpd.md
+++ b/plan/issues/3259-bloat-quickwins-knip-jscpd.md
@@ -3,7 +3,7 @@ id: 3259
 title: "Bloat quick-wins: knip dead-export sweep + jscpd duplication scan of src/codegen"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 horizon: s
 feasibility: easy

--- a/plan/issues/3260-whitepaper-autoupdate-conformance-numbers-date.md
+++ b/plan/issues/3260-whitepaper-autoupdate-conformance-numbers-date.md
@@ -4,7 +4,7 @@ title: "Whitepaper: auto-update Test262 numbers + date AND surface the JS-host v
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-s2
-sprint: current
+sprint: 72
 priority: medium
 horizon: s
 feasibility: easy

--- a/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
+++ b/plan/issues/3261-standalone-eq-tostring-date-helper-env-leaks.md
@@ -3,7 +3,7 @@ id: 3261
 title: "standalone: __host_loose_eq / __extern_toString / __date_format leak env::* imports (missing native-helper set membership)"
 status: done
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-07-14
 priority: medium
 feasibility: medium

--- a/plan/issues/3263-split-native-strings.md
+++ b/plan/issues/3263-split-native-strings.md
@@ -3,7 +3,7 @@ id: 3263
 title: "Split TextEncoder/TextDecoder helpers out of native-strings.ts god-file"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3264-split-array-methods.md
+++ b/plan/issues/3264-split-array-methods.md
@@ -2,7 +2,7 @@
 id: 3264
 title: "Split array-methods.ts — extract Array.prototype-borrow subsystem into array-prototype-borrow.ts"
 status: done
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3265-split-object-runtime.md
+++ b/plan/issues/3265-split-object-runtime.md
@@ -4,7 +4,7 @@ title: "Split object-runtime.ts — extract standalone Proxy dispatch subsystem 
 status: done
 completed: 2026-07-14
 assignee: ttraenkler/senior-dev-splitproxy
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3266-split-assignment.md
+++ b/plan/issues/3266-split-assignment.md
@@ -3,7 +3,7 @@ id: 3266
 title: "Split operator-assignment subsystem out of assignment.ts god-file"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3267-split-property-access.md
+++ b/plan/issues/3267-split-property-access.md
@@ -3,7 +3,7 @@ id: 3267
 title: "Split property-access.ts — extract builtin static/prototype VALUE-read subsystem into builtin-value-read.ts"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3268-refactor-declarations.md
+++ b/plan/issues/3268-refactor-declarations.md
@@ -3,7 +3,7 @@ id: 3268
 title: "Break up god-file src/codegen/declarations.ts (extractions + DRY dedup)"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3269-refactor-loops.md
+++ b/plan/issues/3269-refactor-loops.md
@@ -3,7 +3,7 @@ id: 3269
 title: "refactor(codegen): break up loops.ts god-file — extract analysis + for-of-destructuring + for-await helpers, DRY dedups"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3270-refactor-closures.md
+++ b/plan/issues/3270-refactor-closures.md
@@ -3,7 +3,7 @@ id: 3270
 title: "refactor(codegen): break down + DRY closures.ts god-file (behaviour-preserving)"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3271-refactor-generators-native.md
+++ b/plan/issues/3271-refactor-generators-native.md
@@ -3,7 +3,7 @@ id: 3271
 title: "refactor(codegen): break up generators-native.ts god-file + DRY cleanup"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3272-refactor-index.md
+++ b/plan/issues/3272-refactor-index.md
@@ -3,7 +3,7 @@ id: 3272
 title: "refactor(codegen): break up src/codegen/index.ts god-file + DRY cleanup (behaviour-preserving)"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 model: opus

--- a/plan/issues/3273-oracle-ratchet-change-scoped.md
+++ b/plan/issues/3273-oracle-ratchet-change-scoped.md
@@ -3,9 +3,9 @@ id: 3273
 title: "Oracle ratchet gate: make change-scoped (net) — stop whole-tree re-flagging sibling split modules"
 status: done
 assignee: ttraenkler/senior-dev-oracle
-sprint: current
+sprint: 72
 created: 2026-07-14
-updated: 2026-07-14
+updated: 2026-07-19
 completed: 2026-07-14
 priority: high
 horizon: m

--- a/plan/issues/3274-split-object-runtime.md
+++ b/plan/issues/3274-split-object-runtime.md
@@ -3,7 +3,7 @@ id: 3274
 title: "Decompose ensureObjectRuntime into cohesive sibling modules (WAVE-B, slices 1-3)"
 status: done
 created: 2026-07-14
-updated: 2026-07-14
+updated: 2026-07-19
 completed: 2026-07-14
 priority: high
 feasibility: hard
@@ -12,7 +12,7 @@ reasoning_effort: max
 task_type: refactor
 area: codegen
 goal: maintainability
-sprint: current
+sprint: 72
 subtask_of: 3182
 assignee: ttraenkler/Dev-WaveB-ObjRuntime
 related: [3182, 742, 808]

--- a/plan/issues/3275-split-native-strings.md
+++ b/plan/issues/3275-split-native-strings.md
@@ -3,7 +3,7 @@ id: 3275
 title: "Decompose ensureNativeStringHelpers — extract String.prototype method helpers (search/trim/transform/rewrite) into sibling modules (slice 1)"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: hard
 model: opus

--- a/plan/issues/3276-split-property-access.md
+++ b/plan/issues/3276-split-property-access.md
@@ -3,7 +3,7 @@ id: 3276
 title: "refactor: decompose compilePropertyAccess (property-access.ts mega-function)"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: medium
 horizon: l
 feasibility: hard

--- a/plan/issues/3277-split-native-strings-core.md
+++ b/plan/issues/3277-split-native-strings-core.md
@@ -3,7 +3,7 @@ id: 3277
 title: "Decompose ensureNativeStringHelpers — extract the rope/flatten/UTF-8 core + concat/compare/slice builders (slice 2, empties the god-function)"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: hard
 model: opus

--- a/plan/issues/3278-split-closures-arrow.md
+++ b/plan/issues/3278-split-closures-arrow.md
@@ -3,7 +3,7 @@ id: 3278
 title: "Decompose compileArrowAsClosure — extract capture-analysis / struct-minting / destructuring / construction phases into named phase helpers"
 status: done
 completed: 2026-07-14
-sprint: current
+sprint: 72
 priority: high
 feasibility: hard
 model: opus

--- a/plan/issues/3279-coercion-sites-net-per-field.md
+++ b/plan/issues/3279-coercion-sites-net-per-field.md
@@ -3,9 +3,9 @@ id: 3279
 title: "Coercion-site drift gate: net-per-vocabulary — stop relocation-shift failures on god-file splits"
 status: done
 assignee: ttraenkler/senior-dev-coercion
-sprint: current
+sprint: 72
 created: 2026-07-14
-updated: 2026-07-14
+updated: 2026-07-19
 completed: 2026-07-14
 priority: high
 horizon: m

--- a/plan/issues/3280-split-binary-ops.md
+++ b/plan/issues/3280-split-binary-ops.md
@@ -2,7 +2,7 @@
 id: 3280
 title: "Decompose compileBinaryExpression — extract typed-operand dispatch + `in` operator into sibling modules"
 status: done
-sprint: current
+sprint: 72
 priority: high
 feasibility: hard
 model: opus

--- a/plan/issues/3281-split-new-super.md
+++ b/plan/issues/3281-split-new-super.md
@@ -4,7 +4,7 @@ title: "refactor: decompose compileNewExpression mega-function (WAVE-C)"
 status: done
 completed: 2026-07-14
 assignee: ttraenkler/Dev-WaveC-New
-sprint: current
+sprint: 72
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/3285-rewritten-test262-harness-silently-weakens-assertions.md
+++ b/plan/issues/3285-rewritten-test262-harness-silently-weakens-assertions.md
@@ -4,7 +4,7 @@ title: "wrapTest()'s synthetic harness silently deletes/weakens real test262 ass
 status: done
 assignee: ttraenkler/sendev-3303
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-15
 priority: high
 feasibility: medium

--- a/plan/issues/3286-land-3285-slice1-baseline-reseed.md
+++ b/plan/issues/3286-land-3285-slice1-baseline-reseed.md
@@ -4,7 +4,7 @@ title: "Land #3285 slice-1 (PR #3104) — oracle-version bump alone doesn't clea
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-s2
-sprint: current
+sprint: 72
 created: 2026-07-15
 priority: high
 feasibility: medium

--- a/plan/issues/3287-wrong-error-type-thrown-compiler-audit.md
+++ b/plan/issues/3287-wrong-error-type-thrown-compiler-audit.md
@@ -3,7 +3,7 @@ id: 3287
 title: "Compiler throws the wrong error type in multiple builtins — revealed by #3285 slice-1's assert.throws tightening"
 status: done
 completed: 2026-07-15
-sprint: current
+sprint: 72
 created: 2026-07-15
 priority: high
 feasibility: medium

--- a/plan/issues/3301-eval-inline-regex-flags-dynamic-read.md
+++ b/plan/issues/3301-eval-inline-regex-flags-dynamic-read.md
@@ -4,14 +4,14 @@ title: "eval-inlined regex literal: dynamic property read of .flags returns unde
 status: done
 assignee: ttraenkler/dev-conform
 created: 2026-07-16
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: medium
 feasibility: medium
 task_type: bug
 language_feature: eval
 goal: runtime-eval
-sprint: current
+sprint: 72
 es_edition: ES5
 # (#3102) The externClasses "RegExp" guard in compileRegExpLiteral (the correct
 # home for regex-literal lowering) grows typeof-delete.ts a few LOC; net across

--- a/plan/issues/3302-standalone-native-capturing-generators.md
+++ b/plan/issues/3302-standalone-native-capturing-generators.md
@@ -14,7 +14,7 @@ es_edition: multi
 language_feature: generators
 goal: standalone-mode
 umbrella: 3178
-sprint: current
+sprint: 72
 horizon: m
 related: [3178, 3164, 3032, 2864, 2566, 2662]
 # (#3302) Intended growth at the canonical subsystem sites: capturing fn-expr

--- a/plan/issues/3303-regressions-allow-mechanism.md
+++ b/plan/issues/3303-regressions-allow-mechanism.md
@@ -12,7 +12,7 @@ task_type: feature
 area: ci-infra
 goal: test-infrastructure
 model: fable
-sprint: current
+sprint: 72
 related: [3104, 3286, 3202, 3003, 3086, 1668, 1897]
 ---
 

--- a/plan/issues/3304-standalone-string-bracket-indexing.md
+++ b/plan/issues/3304-standalone-string-bracket-indexing.md
@@ -4,7 +4,7 @@ title: "standalone: primitive-string bracket indexing (s[i]) returns garbage —
 status: done
 assignee: ttraenkler/sendev-date-3174
 created: 2026-07-16
-updated: 2026-07-16
+updated: 2026-07-19
 completed: 2026-07-16
 priority: high
 feasibility: medium
@@ -15,7 +15,7 @@ es_edition: multi
 language_feature: string
 goal: standalone
 umbrella: 2860
-sprint: current
+sprint: 72
 horizon: s
 related: [3174, 1910, 3027, 2891]
 loc-budget-allow:

--- a/plan/issues/3306-standalone-tostring-only-tonumber.md
+++ b/plan/issues/3306-standalone-tostring-only-tonumber.md
@@ -4,7 +4,7 @@ title: "standalone: ToNumber of a toString-only object drops the native-string r
 status: done
 assignee: ttraenkler/sendev-date-3174
 created: 2026-07-16
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: high
 feasibility: medium
@@ -15,7 +15,7 @@ es_edition: multi
 language_feature: coercion
 goal: standalone
 umbrella: 2860
-sprint: current
+sprint: 72
 horizon: s
 related: [3174, 3304, 2891, 866, 1806]
 origin: "root-caused during #3174 residual analysis (Date ctor coercion-order rows); carried through #3304 as the next-next candidate"

--- a/plan/issues/3307-trap-tolerance-guard-env.md
+++ b/plan/issues/3307-trap-tolerance-guard-env.md
@@ -10,7 +10,7 @@ feasibility: easy
 task_type: bug
 area: ci-infra
 goal: test-infrastructure
-sprint: current
+sprint: 72
 related: [3303, 3202, 3189, 3104]
 ---
 

--- a/plan/issues/3308-e0-in-wasm-ast-consumer-probe.md
+++ b/plan/issues/3308-e0-in-wasm-ast-consumer-probe.md
@@ -13,7 +13,7 @@ task_type: test
 area: runtime, dogfood
 language_feature: eval
 goal: runtime-eval
-sprint: current
+sprint: 72
 parent: 2927
 depends_on: []
 related: [2928, 1584, 1710, 1712, 2841, 2851, 2852, 2847, 3343, 3348]

--- a/plan/issues/3309-g1-mapset-any-receiver-native-brand-arms.md
+++ b/plan/issues/3309-g1-mapset-any-receiver-native-brand-arms.md
@@ -13,7 +13,7 @@ task_type: bugfix
 area: codegen, standalone
 language_feature: collections
 goal: runtime-eval
-sprint: current
+sprint: 72
 parent: 2927
 related: [2928, 1584, 2151, 1103, 2162, 3171, 3098]
 # (#3102/#3131) intended growth: the standalone refusal must live in the

--- a/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
+++ b/plan/issues/3310-g2-standalone-generic-method-call-args-arity.md
@@ -13,7 +13,7 @@ task_type: feature
 area: codegen, standalone
 language_feature: dynamic-dispatch
 goal: runtime-eval
-sprint: current
+sprint: 72
 parent: 2927
 related: [2928, 1584, 2151, 1888, 3098]
 # (#3102/#3131) The arity lift adds a small named-constant + comment to the

--- a/plan/issues/3311-g4-string-vec-push-pop-carrier.md
+++ b/plan/issues/3311-g4-string-vec-push-pop-carrier.md
@@ -12,7 +12,7 @@ task_type: bugfix
 area: codegen, standalone
 language_feature: arrays
 goal: runtime-eval
-sprint: current
+sprint: 72
 parent: 2927
 related: [2784, 2928, 1584]
 ---

--- a/plan/issues/3314-frontmatter-allow-list-parser-drops-items-after-comments.md
+++ b/plan/issues/3314-frontmatter-allow-list-parser-drops-items-after-comments.md
@@ -2,7 +2,7 @@
 id: 3314
 title: "scripts/lib/change-scope.mjs frontmatter parser silently drops allow-list items after a leading comment line"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-16
 completed: 2026-07-16
 priority: high

--- a/plan/issues/3315-standalone-extra-arg-sibling-destructuring-corruption.md
+++ b/plan/issues/3315-standalone-extra-arg-sibling-destructuring-corruption.md
@@ -11,7 +11,7 @@ reasoning_effort: max
 task_type: bug
 area: codegen-standalone
 goal: standalone
-sprint: current
+sprint: 72
 related: [3285, 3104, 2379, 2873]
 # (#3102/#3131) Intended growth: the fix lands in the modules that own the
 # broken logic (rep decision, coercion arm, destructure conversion loop,

--- a/plan/issues/3316-standalone-accessor-merge-regression-jul11-jul16.md
+++ b/plan/issues/3316-standalone-accessor-merge-regression-jul11-jul16.md
@@ -4,7 +4,7 @@ title: "standalone: 4/18 accessor-merge tests regressed between main 026f40f771 
 status: done
 assignee: ttraenkler/fable-3316
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: high
 feasibility: medium

--- a/plan/issues/3317-standalone-array-search-methods-tonumber-getter-coercion.md
+++ b/plan/issues/3317-standalone-array-search-methods-tonumber-getter-coercion.md
@@ -4,7 +4,7 @@ title: "standalone: Array.prototype.{indexOf,lastIndexOf,includes} — ToNumber-
 status: done
 assignee: ttraenkler/fable-3317
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: medium
 feasibility: hard

--- a/plan/issues/3318-declaredtype-property-on-number-crash.md
+++ b/plan/issues/3318-declaredtype-property-on-number-crash.md
@@ -4,7 +4,7 @@ title: 'Compiler crash: "Cannot create property ''declaredType'' on number ''1''
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-s2
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: high
 feasibility: medium

--- a/plan/issues/3319-standalone-gopd-miss-undefined-singleton.md
+++ b/plan/issues/3319-standalone-gopd-miss-undefined-singleton.md
@@ -4,7 +4,7 @@ title: "standalone: gOPD miss + descriptor undefined-slots materialize as null, 
 status: done
 assignee: ttraenkler/fable-3316
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: high
 horizon: m

--- a/plan/issues/3320-1888-guardrails-refusal-closures.md
+++ b/plan/issues/3320-1888-guardrails-refusal-closures.md
@@ -4,7 +4,7 @@ title: "stale #1888 S6/S6-b guardrails: builtin value-read compile-refusal contr
 status: done
 assignee: ttraenkler/fable-3316
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: medium
 horizon: s

--- a/plan/issues/3321-gc-gopd-miss-host-undefined.md
+++ b/plan/issues/3321-gc-gopd-miss-host-undefined.md
@@ -4,7 +4,7 @@ title: "gc/host lane: typed-receiver gOPD miss answers null extern instead of th
 status: done
 assignee: ttraenkler/fable-3316
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: medium
 horizon: s

--- a/plan/issues/3322-stale-standalone-highwater-mark-clobbered-post3104.md
+++ b/plan/issues/3322-stale-standalone-highwater-mark-clobbered-post3104.md
@@ -2,7 +2,7 @@
 id: 3322
 title: "#2097 standalone high-water mark clobbered to a stale, too-high value by a race with #3104's landing — wedged the entire merge queue"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-16
 completed: 2026-07-16
 priority: critical

--- a/plan/issues/3324-boolToStringEmitter-module-init-cycle.md
+++ b/plan/issues/3324-boolToStringEmitter-module-init-cycle.md
@@ -4,7 +4,7 @@ title: "tests/issue-2949-s5-2-eq.test.ts fails standalone with a module-init cyc
 status: done
 assignee: ttraenkler/fable-3317
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: medium
 feasibility: medium

--- a/plan/issues/3325-declared-function-host-dep-call-dropped.md
+++ b/plan/issues/3325-declared-function-host-dep-call-dropped.md
@@ -2,7 +2,7 @@
 id: 3325
 title: "declare function host-dep call is silently dropped (env import bound but never called)"
 status: done
-sprint: current
+sprint: 72
 assignee: ttraenkler/opus-b
 goal: npm-library-support
 feasibility: medium
@@ -13,7 +13,7 @@ language_feature: host-interop
 task_type: bug
 horizon: s
 created: 2026-07-16
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 loc-budget-allow:
   - src/runtime.ts

--- a/plan/issues/3326-issue-2036-refuse-loudly-expectations-stale.md
+++ b/plan/issues/3326-issue-2036-refuse-loudly-expectations-stale.md
@@ -4,7 +4,7 @@ title: "tests/issue-2036.test.ts: 7 'refuses loudly' expectations are stale — 
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/opus-e
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: low
 feasibility: trivial

--- a/plan/issues/3327-issue-1917-unexpected-ref-cast-null.md
+++ b/plan/issues/3327-issue-1917-unexpected-ref-cast-null.md
@@ -4,7 +4,7 @@ title: "tests/issue-1917-coercion-plan.test.ts: 1 failure — unexpected ref.cas
 status: done
 assignee: ttraenkler/fable-3317
 completed: 2026-07-16
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: low
 feasibility: medium

--- a/plan/issues/3328-capturing-closure-toprimitive-dispatch.md
+++ b/plan/issues/3328-capturing-closure-toprimitive-dispatch.md
@@ -4,7 +4,7 @@ title: "standalone: `+=` on a captured string inside a closure compiles to f64.a
 status: done
 assignee: ttraenkler/sendev-date-3174
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 completed: 2026-07-17
 priority: high
 feasibility: hard
@@ -15,7 +15,7 @@ es_edition: multi
 language_feature: closures
 goal: standalone
 umbrella: 2860
-sprint: current
+sprint: 72
 horizon: m
 related: [3306, 3174, 795, 2120, 2873]
 origin: "root-caused during #3306 (toString-only ToNumber); initially presumed to be the #2873 funcref-RTT dispatch class — WAT tracing disproved that"

--- a/plan/issues/3329-host-callback-shared-mutable-capture-divergence.md
+++ b/plan/issues/3329-host-callback-shared-mutable-capture-divergence.md
@@ -5,7 +5,7 @@ horizon: m
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-s2
-sprint: current
+sprint: 72
 created: 2026-07-16
 priority: medium
 feasibility: medium

--- a/plan/issues/3331-singleton-nullguard-class-audit.md
+++ b/plan/issues/3331-singleton-nullguard-class-audit.md
@@ -6,13 +6,13 @@ status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-gamma
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 feasibility: medium
 task_type: bug
 area: runtime
 goal: spec-completeness
-sprint: current
+sprint: 72
 related: [2106, 3316, 3319, 3328, 2606, 3008]
 loc-budget-allow:
   - src/codegen/map-runtime.ts

--- a/plan/issues/3332-linear-direct-push-return-and-multiarg.md
+++ b/plan/issues/3332-linear-direct-push-return-and-multiarg.md
@@ -4,7 +4,7 @@ title: "linear direct path: arr.push returns 0 (not new length) and drops extra 
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/dev-standalone2
-sprint: current
+sprint: 72
 goal: backend-agnostic-ir
 feasibility: medium
 depends_on: []
@@ -15,7 +15,7 @@ task_type: bug
 area: codegen-linear
 horizon: s
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 related: [2956, 1854]
 loc-budget-allow:
   # Intended +13 LOC in the direct-path push lowering: evaluate the receiver

--- a/plan/issues/3333-standalone-pattern-param-default-literal.md
+++ b/plan/issues/3333-standalone-pattern-param-default-literal.md
@@ -8,7 +8,7 @@ assignee: ttraenkler/fable-s2
 loc-budget-allow:
   - src/codegen/closures.ts
   - src/codegen/function-body.ts
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 task_type: bugfix

--- a/plan/issues/3334-json-stringify-value-object-tojson-singleton-regression.md
+++ b/plan/issues/3334-json-stringify-value-object-tojson-singleton-regression.md
@@ -6,14 +6,14 @@ status: done
 completed: 2026-07-17
 assignee: ttraenkler/fable-gamma
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 feasibility: medium
 task_type: bug
 area: runtime
 language_feature: json
 goal: spec-completeness
-sprint: current
+sprint: 72
 related: [2933, 2106, 3008, 2166]
 # The fix must live at the toJSON guard inside the codec builder.
 loc-budget-allow:

--- a/plan/issues/3335-bigint-ta-set-oob-trap-mode-regression-baked-into-baseline.md
+++ b/plan/issues/3335-bigint-ta-set-oob-trap-mode-regression-baked-into-baseline.md
@@ -4,7 +4,7 @@ title: "Six TypedArray/set/BigInt failures worsened catchable-error → uncatcha
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/opus-3335
-sprint: current
+sprint: 72
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
+++ b/plan/issues/3338-cli-refuse-invalid-wasm-artifacts.md
@@ -5,7 +5,7 @@ status: done
 assignee: dev-refactor
 completed: 2026-07-17
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -13,7 +13,7 @@ task_type: bugfix
 area: cli, compiler, optimizer
 language_feature: compiler-output-validation
 goal: trustworthiness
-sprint: current
+sprint: 72
 horizon: s
 es_edition: n/a
 complexity: S

--- a/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
+++ b/plan/issues/3342-standalone-object-values-join-typedarray-misclassify.md
@@ -4,7 +4,7 @@ title: "standalone: Object.values(o).join / Object.getOwnPropertyNames(o).join m
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/opus-e
-sprint: current
+sprint: 72
 created: 2026-07-17
 priority: medium
 horizon: s

--- a/plan/issues/3343-inwasm-object-recursive-read-runaway-at-scale.md
+++ b/plan/issues/3343-inwasm-object-recursive-read-runaway-at-scale.md
@@ -4,7 +4,7 @@ title: "In-Wasm dynamic-$Object recursive read runs away at scale (spurious back
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/senior-dev
-sprint: current
+sprint: 72
 created: 2026-07-17
 priority: high
 horizon: m

--- a/plan/issues/3344-catastrophic-guard-honor-regressions-allow.md
+++ b/plan/issues/3344-catastrophic-guard-honor-regressions-allow.md
@@ -3,7 +3,7 @@ id: 3344
 title: "CI: baseline promote pipeline can hang indefinitely + emergency workflow_dispatch retrigger loses change-set scoping"
 status: done
 completed: 2026-07-17
-sprint: current
+sprint: 72
 priority: critical
 horizon: m
 feasibility: medium

--- a/plan/issues/3349-propertyhelper-verifyenumerable-index-shift.md
+++ b/plan/issues/3349-propertyhelper-verifyenumerable-index-shift.md
@@ -3,7 +3,7 @@ id: 3349
 title: "propertyHelper.js fails to compile at all (verifyEnumerable index-shift, #2043 class) — blocks up to 9.8% of test262 by inclusion count"
 status: done
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-07-17
 priority: high
 feasibility: medium

--- a/plan/issues/3356-interp-gt-toprimitive-order.md
+++ b/plan/issues/3356-interp-gt-toprimitive-order.md
@@ -13,7 +13,7 @@ task_type: bug
 area: interp, codegen
 language_feature: relational-operators
 goal: runtime-eval
-sprint: current
+sprint: 72
 # (#3102/#3131) +5-line growth is the #3310 comment correction itself — a note
 # about fillApplyClosure's measured byte cost (+114 B/standalone module) cannot
 # live anywhere except at that code, so "move to a subsystem module" does not

--- a/plan/issues/3358-typedarray-set-bounds-relocation.md
+++ b/plan/issues/3358-typedarray-set-bounds-relocation.md
@@ -4,7 +4,7 @@ title: "codegen: relocate TypedArray.prototype.set bounds check out of array-met
 status: done
 assignee: dev-refactor
 completed: 2026-07-17
-sprint: current
+sprint: 72
 created: 2026-07-17
 priority: low
 horizon: s

--- a/plan/issues/3363-standalone-array-flat-native-depth1.md
+++ b/plan/issues/3363-standalone-array-flat-native-depth1.md
@@ -3,7 +3,7 @@ id: 3363
 title: "standalone: Array.prototype.flat() has no native arm — depth-1 homogeneous nested-array flatten (child of #2717 follow-up / #3180)"
 status: done
 assignee: ttraenkler/dev-j
-sprint: current
+sprint: 72
 created: 2026-07-17
 completed: 2026-07-17
 priority: medium

--- a/plan/issues/3364-widened-object-same-name-shape-collision.md
+++ b/plan/issues/3364-widened-object-same-name-shape-collision.md
@@ -4,7 +4,7 @@ title: "Widened empty-object struct shape clobbered by a same-named var in an un
 status: done
 completed: 2026-07-17
 assignee: ttraenkler/dev-i
-sprint: current
+sprint: 72
 created: 2026-07-17
 priority: high
 horizon: m

--- a/plan/issues/3384-standalone-json-parse-crash.md
+++ b/plan/issues/3384-standalone-json-parse-crash.md
@@ -4,9 +4,9 @@ title: "standalone/wasi: member access on a wrapped JSON.parse() call crashes co
 status: done
 completed: 2026-07-17
 assignee: dev-2961
-sprint: current
+sprint: 72
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 priority: medium
 horizon: s
 feasibility: easy

--- a/plan/issues/3386-standalone-syncgen-pattern-param-widening.md
+++ b/plan/issues/3386-standalone-syncgen-pattern-param-widening.md
@@ -4,9 +4,9 @@ title: "standalone: native sync-generator DESTRUCTURING-pattern params — metho
 status: done
 assignee: ttraenkler/fable-dev-4
 completed: 2026-07-18
-sprint: current
+sprint: 72
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/3387-standalone-nested-asyncgen-forawait-drive.md
+++ b/plan/issues/3387-standalone-nested-asyncgen-forawait-drive.md
@@ -4,9 +4,9 @@ title: "standalone: NESTED async generators with for-await bodies leak the host 
 status: done
 assignee: ttraenkler/fable-dev-3
 completed: 2026-07-18
-sprint: current
+sprint: 72
 created: 2026-07-17
-updated: 2026-07-18
+updated: 2026-07-19
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/3388-standalone-asyncgen-yieldstar-delegation.md
+++ b/plan/issues/3388-standalone-asyncgen-yieldstar-delegation.md
@@ -5,9 +5,9 @@ status: done
 completed: 2026-07-18
 assignee: ttraenkler/fable-dev-2
 pr: 3332
-sprint: current
+sprint: 72
 created: 2026-07-17
-updated: 2026-07-18
+updated: 2026-07-19
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/3393-standalone-oracle-v8-highwater-reseed.md
+++ b/plan/issues/3393-standalone-oracle-v8-highwater-reseed.md
@@ -9,7 +9,7 @@ feasibility: trivial
 task_type: ci-infra
 area: test-infrastructure
 goal: test-infrastructure
-sprint: current
+sprint: 72
 horizon: s
 assignee: "loopdive/porffor-scrum"
 related: [2097, 2961, 3288, 3370]

--- a/plan/issues/3403-object-integrity-tracking-bare-name-cross-function-collision.md
+++ b/plan/issues/3403-object-integrity-tracking-bare-name-cross-function-collision.md
@@ -3,7 +3,7 @@ id: 3403
 title: "Object-integrity tracking maps (frozenVars/sealedVars/nonExtensibleVars/definedPropertyFlags/widenedDefinePropertyKeys) keyed by BARE variable name → cross-function collision (same archetype as #3364)"
 status: done
 completed: 2026-07-18
-sprint: current
+sprint: 72
 priority: high
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/3418-standalone-harness-shim-import-leak.md
+++ b/plan/issues/3418-standalone-harness-shim-import-leak.md
@@ -12,7 +12,7 @@ task_type: bugfix
 area: codegen-standalone
 goal: standalone-mode
 model: fable
-sprint: current
+sprint: 72
 horizon: l
 related: [3370, 3393, 2961, 2860, 1781, 3417]
 loc-budget-allow:

--- a/plan/issues/3419-harness-duplicate-identifier-isprimitive.md
+++ b/plan/issues/3419-harness-duplicate-identifier-isprimitive.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: compiler-early-errors
 goal: test262-conformance
 model: fable
-sprint: current
+sprint: 72
 horizon: m
 related: [3370, 3417, 3188]
 # Small, site-required growth: last-wins skips must live in the exact

--- a/plan/issues/3425-align-test262-pool-baseline.md
+++ b/plan/issues/3425-align-test262-pool-baseline.md
@@ -2,9 +2,9 @@
 id: 3425
 title: "Align merge-group Test262 compiler pool with published baseline"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 completed: 2026-07-18
 priority: critical
 horizon: s

--- a/plan/issues/3427-harness-assembly-duplicate-identifier-isprimitive.md
+++ b/plan/issues/3427-harness-assembly-duplicate-identifier-isprimitive.md
@@ -4,9 +4,9 @@ title: "Harness-assembly compile error: Duplicate identifier 'isPrimitive' at L1
 status: done
 completed: 2026-07-18
 assignee: ttraenkler/opus-dev-b
-sprint: current
+sprint: 72
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 priority: high
 horizon: s
 feasibility: medium

--- a/plan/issues/3428-async-completion-marker-not-observed.md
+++ b/plan/issues/3428-async-completion-marker-not-observed.md
@@ -4,9 +4,9 @@ title: "Host async-verdict: 'async completion marker not observed' on 4,617 asyn
 status: done
 assignee: ttraenkler/opus-dev-d
 completed: 2026-07-18
-sprint: current
+sprint: 72
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3431-consolidate-mergegroup-test262-shards.md
+++ b/plan/issues/3431-consolidate-mergegroup-test262-shards.md
@@ -2,9 +2,9 @@
 id: 3431
 title: "Consolidate test262 shards for merge_group validation (~60min -> ~20-30min)"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 completed: 2026-07-18
 priority: high
 horizon: m

--- a/plan/issues/3432-decl-closure-array-element-bind-noncallable.md
+++ b/plan/issues/3432-decl-closure-array-element-bind-noncallable.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: codegen-closures
 goal: test262-conformance
 model: fable
-sprint: current
+sprint: 72
 horizon: m
 related: [3419, 3417, 3370]
 # Site-required: the skip-gate + rationale live at the exact match-and-recast

--- a/plan/issues/3435-function-typed-dynamic-ctor-param.md
+++ b/plan/issues/3435-function-typed-dynamic-ctor-param.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: codegen-new
 goal: test262-conformance
 model: fable
-sprint: current
+sprint: 72
 horizon: s
 related: [3432, 3419, 3087, 3074]
 # Site-required: the builtin:Function acceptance + rationale live inside the

--- a/plan/issues/3436-standalone-prelude-leak.md
+++ b/plan/issues/3436-standalone-prelude-leak.md
@@ -13,7 +13,7 @@ area: codegen
 language_feature: standalone, console, structuredClone
 goal: standalone-conformance
 related: [3380, 3381]
-sprint: current
+sprint: 72
 loc-budget-allow:
   - src/codegen/declarations/import-collector.ts
   - src/codegen/expressions/builtins.ts

--- a/plan/issues/3438-test262-shard-rebalance-post-3374.md
+++ b/plan/issues/3438-test262-shard-rebalance-post-3374.md
@@ -4,7 +4,7 @@ title: Rebalance test262 CI shards from post-#3374 timings (weight-map refresh)
 status: done
 assignee: ttraenkler/sendev-shards
 completed: 2026-07-18
-sprint: current
+sprint: 72
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3447-ci-compile-timeout-guard-contention-tolerant.md
+++ b/plan/issues/3447-ci-compile-timeout-guard-contention-tolerant.md
@@ -3,7 +3,7 @@ id: 3447
 title: "ci(test262): make the #1942 compile-timeout count guard contention-tolerant"
 status: done
 completed: 2026-07-19
-sprint: current
+sprint: 72
 priority: high
 horizon: s
 task_type: ci

--- a/plan/issues/3448-ci-promote-baseline-from-mergegroup-artifacts.md
+++ b/plan/issues/3448-ci-promote-baseline-from-mergegroup-artifacts.md
@@ -2,7 +2,7 @@
 id: 3448
 title: "ci(test262): promote push:main baseline from the merge_group's own artifacts (skip the 114-job rerun)"
 status: done
-sprint: current
+sprint: 72
 priority: high
 horizon: m
 task_type: ci

--- a/plan/issues/3453-ci-publish-npm-node24-ebadengine.md
+++ b/plan/issues/3453-ci-publish-npm-node24-ebadengine.md
@@ -9,7 +9,7 @@ completed: 2026-07-19
 priority: high
 horizon: s
 feasibility: easy
-task_type: bug
+task_type: infrastructure
 area: ci, release
 goal: release-pipeline
 related: [3454, 3455]

--- a/plan/issues/3453-ci-publish-npm-node24-ebadengine.md
+++ b/plan/issues/3453-ci-publish-npm-node24-ebadengine.md
@@ -2,7 +2,7 @@
 id: 3453
 title: "CI publish: bump publish-npm.yml Node 20 → 24 (npm 12 EBADENGINE)"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-19
 updated: 2026-07-19
 completed: 2026-07-19

--- a/plan/issues/3454-release-jsr-json-lockstep.md
+++ b/plan/issues/3454-release-jsr-json-lockstep.md
@@ -9,7 +9,7 @@ completed: 2026-07-19
 priority: high
 horizon: s
 feasibility: easy
-task_type: bug
+task_type: infrastructure
 area: ci, release
 goal: release-pipeline
 related: [3453, 3455]

--- a/plan/issues/3454-release-jsr-json-lockstep.md
+++ b/plan/issues/3454-release-jsr-json-lockstep.md
@@ -2,7 +2,7 @@
 id: 3454
 title: "release.mjs: bump jsr.json version in lockstep (JSR frozen at 0.60.1)"
 status: done
-sprint: current
+sprint: 72
 created: 2026-07-19
 updated: 2026-07-19
 completed: 2026-07-19

--- a/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
+++ b/plan/issues/3457-regression-ratio-gate-flap-tolerant.md
@@ -3,7 +3,7 @@ id: 3457
 title: "ci(test262): make the merge_group regression-ratio gate flap-tolerant (stop false-parking symmetric content-current churn)"
 status: done
 assignee: ttraenkler/senior-dev-3457
-sprint: current
+sprint: 72
 created: 2026-07-19
 updated: 2026-07-19
 completed: 2026-07-19

--- a/plan/issues/3458-landing-standalone-edition-cumulative-mismatch.md
+++ b/plan/issues/3458-landing-standalone-edition-cumulative-mismatch.md
@@ -2,7 +2,7 @@
 id: 3458
 title: "fix(website): standalone edition conformance is per-edition, not cumulative — total mismatches js-host on the landing page"
 status: done
-sprint: current
+sprint: 72
 priority: medium
 horizon: s
 task_type: fix

--- a/plan/issues/3469-standalone-async-completion-marker-host-free-channel.md
+++ b/plan/issues/3469-standalone-async-completion-marker-host-free-channel.md
@@ -2,7 +2,7 @@
 id: 3469
 title: "Standalone async tests: originalHarness completion marker unobservable host-free (channel + drain gate)"
 status: done
-sprint: current
+sprint: 72
 priority: high
 horizon: l
 area: tooling

--- a/plan/issues/3470-host-verifyproperty-name-length-realm-restore.md
+++ b/plan/issues/3470-host-verifyproperty-name-length-realm-restore.md
@@ -4,7 +4,7 @@ title: "Host-lane test262: verifyProperty name/length delete leaks across shared
 status: done
 completed: 2026-07-19
 assignee: ttraenkler/senior-dev
-sprint: current
+sprint: 72
 created: 2026-07-19
 priority: high
 feasibility: low

--- a/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
+++ b/plan/issues/3471-host-strict-assign-readonly-property-uncaught-typeerror.md
@@ -4,7 +4,7 @@ title: "Host lane: polymorphic comparator (isSameValue) param unsoundly narrowed
 status: done
 assignee: ttraenkler/senior-dev
 completed: 2026-07-19
-sprint: current
+sprint: 72
 created: 2026-07-19
 priority: high
 feasibility: hard

--- a/plan/issues/684-any-typed-variable-inference-from.md
+++ b/plan/issues/684-any-typed-variable-inference-from.md
@@ -6,12 +6,12 @@ status: done
 completed: 2026-07-17
 assignee: dev-684
 created: 2026-03-20
-updated: 2026-07-17
+updated: 2026-07-19
 priority: high
 feasibility: hard
 reasoning_effort: max
 goal: builtin-methods
-sprint: current
+sprint: 72
 # (#684) Intended god-file growth: a new context field + option and the
 # wiring at the three local-slot minting sites. The analysis itself lives in
 # the new module src/checker/usage-inference.ts (not a god file).

--- a/plan/issues/742-extract-and-refactor-compilecallexpression-3.md
+++ b/plan/issues/742-extract-and-refactor-compilecallexpression-3.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-07-14
 assignee: ttraenkler/sendev-waveb
 created: 2026-03-17
-updated: 2026-07-14
+updated: 2026-07-19
 priority: high
 # (#742 Wave B, PR by sendev-waveb) The identifier-callee dispatch arm was moved
 # verbatim into the new sibling module call-identifier.ts. Two change-scoped
@@ -30,7 +30,7 @@ coercion-sites-allow:
 # src/codegen/expressions/calls.ts and table-drive the dispatch chain.
 feasibility: medium
 goal: maintainability
-sprint: current
+sprint: 72
 depends_on: [688]
 files:
   src/codegen/expressions.ts:

--- a/plan/issues/745-tagged-union-representation-to-replace.md
+++ b/plan/issues/745-tagged-union-representation-to-replace.md
@@ -13,7 +13,7 @@ feasibility: hard
 model: fable
 reasoning_effort: max
 goal: performance
-sprint: fable-final
+sprint: current
 related: [1624, 2104, 2105, 2106, 2107, 2141, 2949, 1852, 1471, 1917, 743, 744]
 # S2 flag plumbing (CompileOptions -> CodegenOptions -> ctx) + the resolveWasmType
 # mapping necessarily touch the option/driver files; the predicate itself lives

--- a/plan/issues/808-extract-string-import-infrastructure-from.md
+++ b/plan/issues/808-extract-string-import-infrastructure-from.md
@@ -4,13 +4,13 @@ title: "Extract string/import infrastructure from index.ts → imports.ts"
 status: done
 assignee: ttraenkler/senior-dev
 created: 2026-03-26
-updated: 2026-07-14
+updated: 2026-07-19
 completed: 2026-07-14
 priority: high
 feasibility: medium
 reasoning_effort: high
 goal: maintainability
-sprint: current
+sprint: 72
 subtask_of: 688
 related: [3182]
 # LOC-regrowth ratchet (#3102/#3131): this extraction MOVES ~1.8k LOC of import

--- a/plan/issues/838-bigint64array-biguint64array-typed-arrays.md
+++ b/plan/issues/838-bigint64array-biguint64array-typed-arrays.md
@@ -5,12 +5,12 @@ status: done
 assignee: ttraenkler/dev-spec
 completed: 2026-07-17
 created: 2026-03-28
-updated: 2026-07-17
+updated: 2026-07-19
 priority: low
 feasibility: medium
 reasoning_effort: high
 goal: spec-completeness
-sprint: current
+sprint: 72
 test262_skip: 19
 test262_ce: 25
 # Intended registry growth: registering a new typed-array family (BigInt64Array/

--- a/plan/issues/908-remove-redundant-codegen-in-inlined.md
+++ b/plan/issues/908-remove-redundant-codegen-in-inlined.md
@@ -5,12 +5,12 @@ status: done
 assignee: dev-refactor
 completed: 2026-07-17
 created: 2026-04-02
-updated: 2026-07-17
+updated: 2026-07-19
 priority: medium
 feasibility: medium
 reasoning_effort: high
 goal: performance
-sprint: current
+sprint: 72
 depends_on: [906, 907]
 files:
   src/codegen/index.ts:

--- a/plan/issues/sprints/72.md
+++ b/plan/issues/sprints/72.md
@@ -1,0 +1,334 @@
+# Sprint 72
+
+Frozen 2026-07-19 — trigger: --force.
+
+This is a **budget window** record (rolling-sprint model, #2751): the set
+of issues completed before the token budget rolled over, frozen from
+`sprint: current` into `sprint: 72`. Not-done work rolled forward and
+stays `sprint: current`.
+
+## Completed this window (139)
+
+- #1004 — Optimize repeated string concatenation via compile-time folding and counted-loop aggregation
+- #1044 — Node builtin modules as host imports (NODE_HOST_IMPORT_MODULES, node: prefix normalization)
+- #1102 — Wasm-native eval: ahead-of-time compilation strategy for eval() and Function()
+- #1315 — import.defer / import.source missing early error detection — 157 negative tests false-pass
+- #1373 — IR: claim async functions (async/await through IR path)
+- #1792 — node:url — URL / URLSearchParams as host constructors
+- #1793 — node:buffer + global Buffer — host class with from/concat/toString
+- #1794 — node:events / EventEmitter — host class + closure-callback contract
+- #1795 — node:http (+ https) — GET round-trip host import (axios unblocker)
+- #2040 — standalone: generator/destructuring runtime-semantics residual — rest-pattern iterator consumption, lazy defaults, private elements (~1,750 tests)
+- #2509 — referencedNames over-collects property-access names → spurious env.<name> ambient-global imports (e.g. obj.close)
+- #2578 — standalone dynamic property multi-read mangles inferred-typed values (writes fine, combined read → 0)
+- #2649 — Standalone: TypedArray.prototype.subarray returns an empty view (.length === 0)
+- #2650 — Standalone: member-read on String.prototype.at result returns empty (.length/.charCodeAt)
+- #2728 — Object(Symbol()) should box to a Symbol-wrapper object (typeof → 'object')
+- #2739 — for-in does not enumerate setPrototypeOf / constructor-prototype-chain properties; Object.defineProperty ordering
+- #2903 — standalone: residual env.__make_callback leak is host-backed builtin methods (Promise.then/.catch, Iterator helpers), NOT a callback-representation gap
+- #2953 — Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait
+- #2958 — Standalone: unhandled-rejection tracking — report rejected promises with no handler at drain/event-loop exit
+- #2961 — Extend the strictNoHostImports leak guarantee to `--target standalone` (today wasi-only)
+- #2970 — codegen: import.meta is not a distinct per-module object (identity shared/absent across modules)
+- #3008 — process gap: tests/issue-*.test.ts are not uniformly wired into required CI (silent regressions)
+- #3022 — UMBRELLA: Object.defineProperty(ies) descriptor fidelity + non-object-receiver tail (~728 default-lane fails)
+- #3041 — get-accessor via an any-typed receiver on a class declared inside a function returns NaN/undefined (dynamic accessor dispatch gap)
+- #3101 — Bytecode interpreter ISA + `$Frame`/`$EnvRec` ABI pre-spec (E1 executable-cold): opcode set, encoding, exception table, AOT↔interp call protocol
+- #3107 — Cast-debt codemod: eliminate 10,678 'as Instr' + 129 'as unknown as Instr' + shrink 579 'as any'
+- #3132 — Standalone native ASYNC GENERATORS — retire env::__create_async_generator leaky-passes (~2,800 files)
+- #3136 — Standalone: object read back through a boxed-capture cell loses `===` identity with the outer variable
+- #3142 — IR module-level (top-level statement) adoption — clears gate G3 of the legacy-frontend retirement
+- #3145 — standalone: Atomics.* on non-shared views (the non-SAB subset — ~29 __get_builtin CEs)
+- #3148 — standalone: BigInt.asIntN / asUintN (20 __get_builtin CEs)
+- #3150 — standalone: Uint8Array.fromBase64 / fromHex (+ toBase64/toHex/setFrom*) (12 __get_builtin CEs)
+- #3155 — standalone: object spread / Object.assign / Object.keys-values order + object→primitive gaps (unmasked by the #86 vacuous-standalone audit)
+- #3163 — `new (Fn as any)()` on a function-style constructor returns null (dynamic-callee construct drops the instance)
+- #3170 — standalone: Array.prototype.indexOf/lastIndexOf/includes — method-as-value + array-like receivers (125 gap tests)
+- #3174 — standalone: Date receiver brand checks + ToPrimitive coercion order (get*/set*/toISOString/Symbol.toPrimitive — 107 gap tests)
+- #3192 — bloat S2: route DataView + RegExp brand checks through receiver-brand.ts
+- #3193 — bloat S3: delete the 5 shape-path Array.prototype.*.call clones, route through the synthetic-call rewrite
+- #3202 — CI-sharded-only +4 oob on 4 unsupported-BigInt TypedArray.set tests — nondeterministic ratchet classification (main is 58, NOT 62)
+- #3229 — Object.keys/values/entries(closedStruct).length INLINE returns 0 — static-enumeration vec type (vec-of-externref) mismatches the `.length` dispatch type (vec-of-string); mode-agnostic
+- #3243 — standalone: native object === identity — extend #2734 ref.eq fast path to inline strict-eq (retire tag-5 string-content fold for objects)
+- #3245 — async-gen dstr host-free-FAIL cluster: root decomposition + error-path mirage + runner warm/cold artifact
+- #3254 — Standalone: RequireObjectCoercible + ToString for borrowed String.prototype.<m>.call receiver
+- #3256 — Self-host stdlib: convert native-strings.ts hand-emitted Instr[] to TS (Tier-1 resolver-widening)
+- #3257 — Self-host stdlib: convert array-methods.ts hand-emitted Instr[] to TS (Tier-2)
+- #3259 — Bloat quick-wins: knip dead-export sweep + jscpd duplication scan of src/codegen
+- #3260 — Whitepaper: auto-update Test262 numbers + date AND surface the JS-host vs standalone lane distinction with both figures
+- #3261 — standalone: __host_loose_eq / __extern_toString / __date_format leak env::* imports (missing native-helper set membership)
+- #3263 — Split TextEncoder/TextDecoder helpers out of native-strings.ts god-file
+- #3264 — Split array-methods.ts — extract Array.prototype-borrow subsystem into array-prototype-borrow.ts
+- #3265 — Split object-runtime.ts — extract standalone Proxy dispatch subsystem into object-runtime-proxy.ts
+- #3266 — Split operator-assignment subsystem out of assignment.ts god-file
+- #3267 — Split property-access.ts — extract builtin static/prototype VALUE-read subsystem into builtin-value-read.ts
+- #3268 — Break up god-file src/codegen/declarations.ts (extractions + DRY dedup)
+- #3269 — refactor(codegen): break up loops.ts god-file — extract analysis + for-of-destructuring + for-await helpers, DRY dedups
+- #3270 — refactor(codegen): break down + DRY closures.ts god-file (behaviour-preserving)
+- #3271 — refactor(codegen): break up generators-native.ts god-file + DRY cleanup
+- #3272 — refactor(codegen): break up src/codegen/index.ts god-file + DRY cleanup (behaviour-preserving)
+- #3273 — Oracle ratchet gate: make change-scoped (net) — stop whole-tree re-flagging sibling split modules
+- #3274 — Decompose ensureObjectRuntime into cohesive sibling modules (WAVE-B, slices 1-3)
+- #3275 — Decompose ensureNativeStringHelpers — extract String.prototype method helpers (search/trim/transform/rewrite) into sibling modules (slice 1)
+- #3276 — refactor: decompose compilePropertyAccess (property-access.ts mega-function)
+- #3277 — Decompose ensureNativeStringHelpers — extract the rope/flatten/UTF-8 core + concat/compare/slice builders (slice 2, empties the god-function)
+- #3278 — Decompose compileArrowAsClosure — extract capture-analysis / struct-minting / destructuring / construction phases into named phase helpers
+- #3279 — Coercion-site drift gate: net-per-vocabulary — stop relocation-shift failures on god-file splits
+- #3280 — Decompose compileBinaryExpression — extract typed-operand dispatch + `in` operator into sibling modules
+- #3281 — refactor: decompose compileNewExpression mega-function (WAVE-C)
+- #3285 — wrapTest()'s synthetic harness silently deletes/weakens real test262 assertions instead of translating them
+- #3286 — Land #3285 slice-1 (PR #3104) — oracle-version bump alone doesn't clear the #3086 auto-rebase gate for wasm-changing verdict flips
+- #3287 — Compiler throws the wrong error type in multiple builtins — revealed by #3285 slice-1's assert.throws tightening
+- #3301 — eval-inlined regex literal: dynamic property read of .flags returns undefined
+- #3302 — standalone: native lowering for CAPTURING generators — thread enclosing-scope ref cells into the generator state struct (retire the eager-buffer host fallback for #3178 S3) [SENIOR-DEV/opus — design-heavy]
+- #3303 — CI: add a PR-scoped regressions-allow mechanism for honest verdict-logic reclassifications (unifies the #1668/#1897/#3086 gates, unblocks #3104's landing without the temporary-lever dance)
+- #3304 — standalone: primitive-string bracket indexing (s[i]) returns garbage — falls to __extern_get, no native-string arm
+- #3306 — standalone: ToNumber of a toString-only object drops the native-string result to NaN (§7.1.1.1 OrdinaryToPrimitive → §7.1.4.1 StringToNumber)
+- #3307 — CI: pass TRAP_RATCHET_TOLERANCE to the #1668/#1897 guard steps — post-#3303 the guards' exit-1 fallback makes the tolerance omission disagree with the regression-gate job on identical data
+- #3308 — E0 — in-Wasm AST consumer probe: walk compiled-acorn's AST inside Wasm to arbitrate parser bugs vs host-marshalling losses
+- #3309 — G1 — Map/Set methods on an `any` receiver leak env.WeakMap_*/Set_* host imports standalone: native $Map brand arm in the closed-method dispatcher
+- #3310 — G2 — args-passing on the standalone generic method-call path + `__apply_closure` arity>4 lift (wantArgs is host-gated)
+- #3311 — G4 — `string[]` push/pop under standalone is a no-op: native-string vec carrier missing from `__vec_push`/`__vec_pop` mutEntries
+- #3314 — scripts/lib/change-scope.mjs frontmatter parser silently drops allow-list items after a leading comment line
+- #3315 — standalone codegen: adding a 2nd argument to a call inside an object-method silently CORRUPTS sibling destructured bindings in the enclosing method (wrong values, no crash)
+- #3316 — standalone: 4/18 accessor-merge tests regressed between main 026f40f771 (2026-07-11) and f01f7fbb6e (2026-07-16) — illegal cast traps, invisible to CI
+- #3317 — standalone: Array.prototype.{indexOf,lastIndexOf,includes} — ToNumber-of-object length/fromIndex + includes abrupt-getter length reads
+- #3318 — Compiler crash: "Cannot create property ''declaredType'' on number ''1''" (prototype-delete pattern)
+- #3319 — standalone: gOPD miss + descriptor undefined-slots materialize as null, not the $undefined singleton (#2106-flip family — the two #3316 residuals and friends)
+- #3320 — stale #1888 S6/S6-b guardrails: builtin value-read compile-refusal contract was retired by #2984 (runtime refusal closures) — update to the current contract
+- #3321 — gc/host lane: typed-receiver gOPD miss answers null extern instead of the host undefined sentinel — the host twin of #3319's miss family
+- #3322 — #2097 standalone high-water mark clobbered to a stale, too-high value by a race with #3104's landing — wedged the entire merge queue
+- #3324 — tests/issue-2949-s5-2-eq.test.ts fails standalone with a module-init cycle: 'Cannot access boolToStringEmitter before initialization'
+- #3325 — declare function host-dep call is silently dropped (env import bound but never called)
+- #3326 — tests/issue-2036.test.ts: 7 'refuses loudly' expectations are stale — #3169 gave these methods a working native path, they now succeed instead of refusing
+- #3327 — tests/issue-1917-coercion-plan.test.ts: 1 failure — unexpected ref.cast_null in a pinned coercion instruction shape
+- #3328 — standalone: `+=` on a captured string inside a closure compiles to f64.add + a trapping null placeholder (kills every capturing toString/valueOf — coercion-order.js class)
+- #3329 — host-callback closures: two closures sharing one mutable captured local get SEPARATE ref cells — writes diverge (last writeback wins)
+- #3331 — AUDIT: #2106 $undefined-singleton null-guard bug class — systematic sweep + Map get-miss fix (4th instance)
+- #3332 — linear direct path: arr.push returns 0 (not new length) and drops extra args
+- #3333 — standalone: whole-pattern param default OBJECT LITERAL never binds — `function f({a,b}: any = {a:5,b:3}); f()` reads garbage/NaN
+- #3334 — standalone JSON.stringify serialises every object as "null" through any/closure paths — toJSON miss-guard vs $undefined singleton
+- #3335 — Six TypedArray/set/BigInt failures worsened catchable-error → uncatchable oob trap on main; scheduled baseline refresh baked the worse mode in
+- #3338 — cli: refuse to write invalid Wasm artifacts after optimizer fallback
+- #3342 — standalone: Object.values(o).join / Object.getOwnPropertyNames(o).join misclassify receiver as Uint8ClampedArray → leak env::Uint8ClampedArray_join
+- #3343 — In-Wasm dynamic-$Object recursive read runs away at scale (spurious back-edge on ~60+-node ASTs)
+- #3344 — CI: baseline promote pipeline can hang indefinitely + emergency workflow_dispatch retrigger loses change-set scoping
+- #3349 — propertyHelper.js fails to compile at all (verifyEnumerable index-shift, #2043 class) — blocks up to 9.8% of test262 by inclusion count
+- #3356 — interp: `>`/`>=` run ToPrimitive in reversed order (swap-desugar is LeftFirst=true) + #3310 byte-identical comment is inaccurate
+- #3358 — codegen: relocate TypedArray.prototype.set bounds check out of array-methods.ts (validated design, #3202 took the allowance route instead)
+- #3363 — standalone: Array.prototype.flat() has no native arm — depth-1 homogeneous nested-array flatten (child of #2717 follow-up / #3180)
+- #3364 — Widened empty-object struct shape clobbered by a same-named var in an unrelated function (bare-name keying)
+- #3384 — standalone/wasi: member access on a wrapped JSON.parse() call crashes codegen
+- #3386 — standalone: native sync-generator DESTRUCTURING-pattern params — methods, fn-expressions, element defaults, untyped array patterns (~1,860 host_import_leak rows)
+- #3387 — standalone: NESTED async generators with for-await bodies leak the host buffer — close the nested-vs-module-scope drivability gap (~577 for-await-of rows)
+- #3388 — standalone: async-gen `yield*` over non-literal sources in NESTED/method producers — runtime delegation with §27.6.3.7 GetIterator error semantics (~600 rows)
+- #3393 — Re-seed the standalone high-water floor for the original-harness oracle v8
+- #3403 — Object-integrity tracking maps (frozenVars/sealedVars/nonExtensibleVars/definedPropertyFlags/widenedDefinePropertyKeys) keyed by BARE variable name → cross-function collision (same archetype as #3364)
+- #3418 — Standalone: unused harness-shim host refs leak console_log/structuredClone imports — deflates standalone conformance ~18–30k
+- #3419 — Concatenated harness: duplicate function decl (isPrimitive) errors instead of last-wins — blocks ~2k tests both lanes
+- #3425 — Align merge-group Test262 compiler pool with published baseline
+- #3427 — Harness-assembly compile error: Duplicate identifier 'isPrimitive' at L1:10 (host 2,054 + standalone 2,051 TypedArray/Array tests)
+- #3428 — Host async-verdict: 'async completion marker not observed' on 4,617 async tests + 'asyncTest called without async flag' (225) under oracle v8
+- #3431 — Consolidate test262 shards for merge_group validation (~60min -> ~20-30min)
+- #3432 — Top-level function-declaration closures stored in array literals read back host-non-callable inside nested functions (testTypedArray harness, ~1.8k tests)
+- #3435 — new TA() on a JSDoc Function-typed callback param falls to the __new_TA extern import — TypedArray harness wall
+- #3436 — Eliminate standalone harness-prelude host-import leak (console_log_externref + structuredClone)
+- #3438 — Rebalance test262 CI shards from post-#3374 timings (weight-map refresh)
+- #3447 — ci(test262): make the #1942 compile-timeout count guard contention-tolerant
+- #3448 — ci(test262): promote push:main baseline from the merge_group's own artifacts (skip the 114-job rerun)
+- #3453 — CI publish: bump publish-npm.yml Node 20 → 24 (npm 12 EBADENGINE)
+- #3454 — release.mjs: bump jsr.json version in lockstep (JSR frozen at 0.60.1)
+- #3457 — ci(test262): make the merge_group regression-ratio gate flap-tolerant (stop false-parking symmetric content-current churn)
+- #3458 — fix(website): standalone edition conformance is per-edition, not cumulative — total mismatches js-host on the landing page
+- #3469 — Standalone async tests: originalHarness completion marker unobservable host-free (channel + drain gate)
+- #3470 — Host-lane test262: verifyProperty name/length delete leaks across shared-realm strict rerun (runner-only, extends #3318)
+- #3471 — Host lane: polymorphic comparator (isSameValue) param unsoundly narrowed to f64, corrupting string compares → false isWritable revert → uncaught TypeError (~433 test262 name/length tests)
+- #684 — Any-typed variable inference from usage patterns
+- #742 — Extract and refactor compileCallExpression (3,350 lines)
+- #808 — Extract string/import infrastructure from index.ts → imports.ts
+- #838 — BigInt64Array / BigUint64Array typed arrays
+- #908 — Remove redundant codegen in inlined top-level numeric loops
+
+## Rolled forward (176 still `sprint: current`)
+
+- #1032 [in-progress] — Compile axios to Wasm — Node builtins routed as host imports; harvest error patterns
+- #1046 [ready] — Separate ES-module compilation with consumer-driven import/export type specialization
+- #1712 [in-progress] — acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn
+- #1916 [in-progress] — Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery
+- #1917 [in-progress] — One coercion engine — four divergent coercion matrices disagree about lossiness
+- #1930 [in-progress] — TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)
+- #1985 [blocked] — stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental)
+- #2001 [in-progress] — sparse arrays: holes materialize as element-type defaults and HOFs visit them — [1,,3].forEach runs 3×, b[5]=9 join shows zeros
+- #2039 [in-progress] — UMBRELLA: standalone invalid-Wasm residual bucket — 203 live rows split into children #3394-#3398 (bigint box, extern boxing, closure/struct type, scalar unbox, tail-call long tail)
+- #2106 [in-progress] — value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton
+- #2141 [in-progress] — Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing
+- #2161 [blocked] — Standalone RegExp engine conformance residual (~579 tests)
+- #2175 [in-progress] — architect spec: standalone builtin-prototype object representation + native-method-closure dispatch
+- #2580 [in-progress] — `.length` on an any/dynamically-mutated receiver returns numeric 0, not undefined (runtime property-presence)
+- #2585 [blocked] — standalone: getPrototypeOf(Object.create(p)) === p is false — object identity lost in __any_strict_eq tag-5 arm
+- #2613 [blocked] — await on a thenable/non-Promise: assimilate via host (PromiseResolve) instead of returning the raw object (~15 fails)
+- #2614 [blocked] — Promise.{all,allSettled,any,race}: read constructor's own `resolve` + callable resolve/reject element functions (~45 fails)
+- #2618 [blocked] — Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)
+- #2622 [backlog] — Standalone native `class X extends Set/Map/WeakMap/WeakSet` subclass — construction + [[SetData]] algebra + iteration + instanceof
+- #2623 [ready] — Promise capability-cluster: multi-hop host→wasm resolve-element callback cast + ctx-ctor species/prototype identity through the bridge — ANCHOR for the unified Promise semantics spec (§P)
+- #2626 [backlog] — tag-5 boxed-VALUE equality classifier (numeric #2040 f64.eq + object #2585 ref.eq) — value-rep substrate (deferred from #1888)
+- #2651 [blocked] — standalone: builtin constructor + prototype as a first-class VALUE (TypedArray ctor-iteration substrate)
+- #2660 [in-progress] — Whole-program escape/dynamic-use gate for reconstructing `new F()` instances as `$Object` (value-rep infra)
+- #2662 [ready] — host (gc) generator backend is EAGER-buffered — breaks lazy/suspension semantics on the default path (architecture)
+- #2669 [ready] — ES2015: destructuring correctness residual umbrella (~696 fails — iterator-close, defaults, holes, rest across for-of/assignment/binding/params)
+- #2671 [ready] — ES2015 builtin/feature spec residuals: Date, RegExp, Promise, JSON, super (~400 fails — tracking, slice per area)
+- #2690 [ready] — ESLint rule-tester.js: cloneDeeplyExcludesParent polymorphic return widens i32 into anyref slot
+- #2694 [blocked] — acorn parse() 11th wall — Scope.flags read loop (local-receiver slot/sidecar asymmetry, needs #2660)
+- #2700 [ready] — esquery@1.7.0 bundle fails to compile — multi-blocker (PEG parser codegen index-shift + syntax + hard-type errors)
+- #2710 [in-progress] — Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class
+- #2726 [ready] — delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete
+- #2732 [blocked] — operators: unary +/-/~/>>> ToPrimitive(object) trap; strict-equals boxed-wrapper/funcref trap
+- #2763 [ready] — [SUBSTRATE][ARCH] instanceof value-rep residual: cross-realm Object/Function identity + .prototype access on dynamic Function values
+- #2768 [wont-fix] — bare-var receiver recovery: per-type externref→ref recovery hardening + safelist expansion (follow-on of #2767's Date-only gate)
+- #2773 [in-progress] — [EPIC][ARCH] Value-rep substrate: consistent native dispatch for reconstructed-struct field access + DCE/finalize-stable typeIdx
+- #2793 [blocked] — [ARCH][SUBSTRATE] Structural-narrowing struct COPY at call boundary breaks reference semantics (mutation through interface/structural-class param lost)
+- #2802 [ready] — [DEFERRED] nested `any`-vec multi-push then read drops the first element (S3-class vec-identity edge)
+- #2803 [ready] — Infer function-parameter types from call-site arguments (usage-based inference) — untyped/.js-stripped params default to `any`
+- #2826 [blocked] — Bug C (CPS-capture half): block-scoped let immutably captured by a hoisted async/generator declaration reads the stale pre-hoisted slot
+- #2847 [ready] — compiled-acorn cosmetic marshalling quirks — spurious `sourceFile: null` on every node + booleans as i32 0/1
+- #2855 [ready] — IR front-end migration: ratchet unintended fallback buckets to zero + promote to STRICT_IR_REASONS
+- #2856 [in-progress] — IR: drive body-shape-rejected fallback bucket to zero (dominant unintended bucket)
+- #2860 [ready] — Umbrella: close the standalone-vs-js-host test262 gap (~20,500 host-free, honest metric #2879/#2360)
+- #2864 [in-progress] — Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports
+- #2865 [in-progress] — Standalone: no Wasm-native async-generator / for-await carrier — leaks __create_async_generator + Promise_* host imports
+- #2866 [in-progress] — Standalone: Symbol values leak __box_symbol — no Wasm-native Symbol carrier
+- #2867 [in-progress] — Standalone: Promise / async microtask leaks Promise_resolve/reject/then + __make_callback host imports
+- #2872 [in-progress] — Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)
+- #2873 [in-progress] — Standalone: language/expressions cluster (276 host-pass/standalone-fail, de-masked from #2862)
+- #2875 [in-progress] — Standalone: String.prototype.* cluster (159 host-pass/standalone-fail, de-masked from #2862)
+- #2895 [ready] — Standalone: genuinely-pending await needs true frame suspension (AG1 / PATH B) — await-on-$Frame + microtask resume
+- #2906 [in-progress] — Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)
+- #2911 [in-review] — Review: test262 setup + host-vs-standalone classification and pass-rate computation
+- #2916 [in-progress] — [SUBSTRATE][ARCH] Standalone native instanceof operator + isPrototypeOf residual (~31 leaky-PASS conversions)
+- #2917 [ready] — [SUBSTRATE][ARCH] Standalone native `class X extends <Builtin>` super-construction (~10 generic conversions)
+- #2927 [ready] — Interpreter foundation: Acorn-via-js2wasm runtime parser + generic-built-in audit
+- #2933 [ready] — Standalone: Math/JSON/Reflect/Atomics namespace static VALUE reads refuse — fold constants / native static-method closures
+- #2949 [in-progress] — IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)
+- #2950 [backlog] — IR-first default flip: JS2WASM_IR_FIRST default-ON, then delete the flag + compile-twice path
+- #2951 [in-progress] — IR-first skip set: include generators and class members (retire the two #2138 standing exclusions)
+- #2952 [in-progress] — IR multi-exit control flow: labeled break/continue, switch (br_table), do-while, for-in adoption
+- #2955 [ready] — De-polymorph the IR front-end on string mode: abstract IR string ops resolved at lower time
+- #2956 [in-review] — Linear backend consumes the IR front-end: wire the selector + LinearEmitter into generateLinearModule
+- #2957 [in-progress] — Async activation for arrows / methods / function expressions (both CPS + drive hooks are declaration-only)
+- #2963 [in-progress] — Reify builtins as first-class values: retire the `__get_builtin` dynamic-shape CE cluster (~400 compile errors)
+- #2984 [in-progress] — Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)
+- #3001 [blocked] — Remove (or ratchet) the TEMPORARY #2940 vacuous-reclassification gate excusal once the standalone baseline promotes to new-policy
+- #3021 [in-progress] — spec gap: class elements — static/private field & method placement residual (~1,522 default-lane fails)
+- #3024 [ready] — codegen: invalid Wasm binary emission residual — default (JS-host) lane (~131 fails, externref/f64 type-mismatch emitter bugs)
+- #3029 [in-progress] — Clean compiler architecture umbrella: layered module map, five-part backend contract, reviewability ratchets
+- #3030 [in-progress] — Stable serializable IR contract (interchange v1): versioned canonical JSON + schema, verified types, external-consumer ready
+- #3032 [in-progress] — Lazy-first-resume generator thunks: stop running eager-buffer generator bodies at creation (unblocks #2141 S3 / #2626 classifier)
+- #3037 [in-progress] — Object-identity canonicalization substrate for standalone dynamic reads (foundation under #3027 / V2-S3b reader-arm)
+- #3053 [in-progress] — Unified dynamic-reader carrier substrate — one __dyn_member_get primitive under #3037 CS3 (identity) AND #2949 S5.4 (IR claim-rate)
+- #3055 [in-progress] — Standalone `any === any` on boxed numbers returns equal-for-unequal when an object-runtime/class is present
+- #3056 [blocked] — Standalone numeric assertions are vacuous — add `assert_sameValue_num` harness routing (measurement re-baseline)
+- #3086 [in-progress] — Honest vacuity re-baseline: partial-vacuity callback scorer + oracle_version bump (1→2) + forward-bump auto-rebase enabler
+- #3089 [wont-fix] — codegen: BigInt TypedArray tests fail to compile — 'Binary emit error: RangeError: offset is out of bounds' (i64 codegen, ~22/30 sampled, pre-existing)
+- #3090 [blocked] — Shrink codegen: delete dormant legacy direct-codegen handlers superseded by IR (~40–55K net LOC)
+- #3103 [in-progress] — Split src/runtime.ts (15,032 LOC) host runtime by concern; decompose resolveImport (6,517-line function)
+- #3104 [in-progress] — Re-split codegen/index.ts (16,566 LOC, regrown 2.6x) into subsystem modules; driver-only index
+- #3105 [in-progress] — Emit-idiom builder library: dedupe repeated Wasm instruction scaffolds (throw-guard x17, counter-loop x21, proxy-guard x12, hash-probe x10)
+- #3108 [ready] — Decompose the ensureObjectRuntime entangled property-storage core (3,494 LOC) into cohesive sibling modules
+- #3109 [ready] — Test-helper consolidation: 132 test files re-declare compileAndRun (10+ signature variants) across 292k test LOC
+- #3111 [ready] — Decompose the five call-shape god functions (#742 residue) into per-family probe modules
+- #3113 [in-progress] — Fix IR->codegen reverse layering: move shared vocabulary (js-tag) below IR; contain the bridge to ir/integration.ts
+- #3115 [in-progress] — Refresh workflow stale-checkout guard: recompute source-derived baselines after re-anchor
+- #3152 [ready] — array-pattern destructuring DRAINS the source iterator (materialize-then-index) instead of per-element IteratorStep — observable side-effect over-stepping
+- #3159 [in-progress] — Self-hosted stdlib, array family slice 1: timsort kernels as TS source through our own IR pipeline
+- #3166 [in-progress] — Class fields/accessors with RUNTIME computed property names are silently dropped ([f()] = 1 → read returns 0) — ~150 cpn tests
+- #3175 [in-progress] — standalone: Number.prototype.toString(radix)/toFixed/valueOf spec semantics + prototype surface (74 gap tests)
+- #3176 [in-progress] — standalone: JSON.parse/stringify spec residual — reviver array walk illegal-cast, SyntaxError strictness, replacer/space edges (67 gap tests)
+- #3177 [in-progress] — standalone: TypedArrayConstructors internals + ctors — integer-indexed MOP internals, ctor arg protocols, from/of, per-ctor identity (356 gap tests)
+- #3178 [ready] — UMBRELLA: retire the generator/async/Promise HOST machinery in standalone — the 4,467-leaky-pass (10.3 pt) family, measured slice map + shared-substrate design
+- #3180 [ready] — standalone: Array.prototype HOF residual gap buckets after the #3169 receiver ladder (~306 tests, 6 mechanisms)
+- #3182 [ready] — Code-bloat elimination EPIC: consolidate duplicated codegen scaffolding into the existing shared machinery
+- #3184 [ready] — default lane: for-await-of / async-dstr vacuous cluster — 489 fails (383 'callback never executed'), async paths silently no-op
+- #3185 [ready] — UMBRELLA default lane: Array.prototype generics + observable-semantics cluster (~1,057 fails — largest untracked builtin bucket)
+- #3188 [ready] — UMBRELLA: ES module-code semantics (~174 fails) — namespace objects, cross-module TDZ, module early errors + wrapTest export collision
+- #3196 [in-progress] — bloat S6: de-inline the standalone dynamic-HOF lane in compileArrayLikePrototypeCall onto the #3098 __hof_* steppers
+- #3197 [in-progress] — default lane: drive the for-await-of / async-dstr callback chain to completion (383 vacuous fails)
+- #3198 [blocked] — default lane: Promise combinator callbacks never execute — vacuous slice (218 fails)
+- #3200 [in-progress] — default lane: Array.prototype iteration/producer generics (forEach/map/filter/flatMap) over real + array-like receivers (~204 fails)
+- #3201 [in-progress] — default lane: Array.prototype search + structural generics (indexOf/lastIndexOf/slice/splice/sort/concat/pop) (~312 fails)
+- #3218 [wont-fix] — standalone: ValidateTypedArray for native __ta_dyn_{fill,copyWithin,reverse} — WONT-FIX (verify-first: target tests already pass; residual is elsewhere)
+- #3227 [in-progress] — default (JS-host) lane: async-completion harness callbacks never execute → 1,690 vacuous fails (#2940 detector), dominated by for-await-of / dynamic-import / Promise
+- #3230 [blocked] — Object.defineProperty: dynamic (non-literal) descriptor read-lane — struct-widening splits read/write stores (accessor read + data write-back both leak)
+- #3236 [in-progress] — standalone: native sync generator-prototype intrinsic chain — retire env::__get_generator_function_prototype / __get_generator_prototype (13 sole leaks)
+- #3240 [ready] — Standalone: faithful native constructors for the remaining subclass-builtins (Array/Function/Date/RegExp/ArrayBuffer/DataView/Promise)
+- #3251 [in-progress] — standalone: array-descriptor OVERLAY substrate — $Vec receivers have no per-index/expando property-descriptor storage (blocks array-exotic defineProperty + Array generic-method-over-accessor-index)
+- #3258 [ready] — Self-host stdlib: convert object-runtime.ts hand-emitted Instr[] to TS (Tier-3)
+- #3282 [in-progress] — Decompose the second-level god-functions created by the Wave-B/C extractions (+ ensureAnyHelpers, + deferred object-runtime core)
+- #3283 [wont-fix] — standalone dstr runtime-semantics — Opus-now unblocked slices (lazy-defaults, obj-rest ToPrimitive, abrupt-step errors, gen brand-check)
+- #3284 [ready] — Make the compiler compatible with the original (unmodified) test262 harness — assert.js property-call dispatch + Promise.then microtask gap
+- #3305 [in-progress] — Self-host stdlib: convert parse-number-native.ts + number-format-native.ts hand-emitted Instr[] to TS (family #2)
+- #3337 [ready] — wasi: materialize process.argv through args_get instead of a silent empty vector
+- #3341 [in-progress] — STRICT_IR_REASONS hardening — per-reason (NOT a corpus-zero flip); doc-correction shipped, real per-reason work remains
+- #3359 [in-progress] — standalone: Array.prototype.filter (and callback methods) ignore the thisArg argument — closure runs with wrong `this`
+- #3360 [ready] — default lane: async-generator `yield*` delegation drops iterator-protocol abrupt completions (690 honest fails, oracle-7 #3227 S5)
+- #3375 [in-progress] — baseline-summary-sync host drift-check compares the wrong baseline → landing page silently strands stale/inflated test262 number
+- #3378 [ready] — deepEqual.js fails to compile — stale LOCAL index in deeply-nested format/lazyResult closures (#2043 class, local not funcIdx)
+- #3379 [in-progress] — baseline-summary-sync staleness guard measures the in-repo file, not public/ → busy queue skips the sync forever
+- #3380 [ready] — Standalone-lane test262 dashboard number appears frozen — promote-pipeline fragility + single-scalar visibility gap masks real churn (not a cache/skip bug)
+- #3381 [in-progress] — refresh-baseline.yml refreshes HOST only, never standalone — public standalone number strands stale
+- #3382 [in-progress] — Baseline goes stale under high PR velocity — main-audit push loses all retries; make baselines-repo push resilient
+- #3389 [in-progress] — standalone: `return` completion in driven async-gen bodies (settleReturn terminator) + AsyncGeneratorPrototype.return/.throw residual (~300 rows)
+- #3390 [ready] — standalone: Promise combinators with non-Promise receivers — `Promise.all.call(nonCtor)` TypeError + custom-constructor admission (~119 rows)
+- #3391 [ready] — standalone: S7 mechanical — assert-zero `__gen_*`/`__get_caught_exception` registration + eager-buffer dead-path accounting (umbrella #3178 closeout)
+- #3392 [in-progress] — promote-baseline dies at the baselines-repo clone — runs/ cache growth pushed full-blob clone past the 10-min step timeout
+- #3394 [ready] — standalone: bigint (i64) value reaches externref coercion via extern.convert_any instead of __box_bigint — invalid Wasm (~59 tests)
+- #3395 [ready] — standalone: object/closure GC ref not boxed (or double-boxed) at externref boundaries — any.convert_extern / extern.convert_any invalid Wasm (~34 tests)
+- #3396 [in-progress] — standalone: closure-env / promise-reaction / for-loop struct type A used where type B expected — struct.set/get/call-param invalid Wasm (~70 tests)
+- #3397 [ready] — standalone: boxed value used directly in scalar op (f64.ne/i32 cmp/ref.is_null) without unbox — invalid Wasm (~27 tests)
+- #3398 [in-progress] — standalone: tail-call ABI mismatch / block-result fallthru / call arity / ref.test-cast long tail — invalid Wasm (~13 tests)
+- #3399 [ready] — Architecture modularization + bloat-reduction roadmap: 2026-07-18 re-grounding + god-function enforcement axis
+- #3400 [ready] — R-FUNC: per-function LOC ceiling ratchet (check:func-budget) — enforce the 300-LOC function criterion (#3102 slice 2)
+- #3404 [ready] — Baseline promote is blocked by a single test262 shard artifact-upload flake — tolerate ≥N-1 shards or retry the upload
+- #3406 [ready] — Dynamic any-callee with zero closure candidates silently returns null instead of invoking or throwing
+- #3407 [in-review] — test262 fixture runner emits duplicate and contradictory verdict rows; enforce one canonical result per file
+- #3408 [in-review] — Retire non-atomic issue-ID entrypoints and stale collision-remediation guidance
+- #3409 [ready] — Pre-push format gate hard-depends on GNU timeout and falsely blocks macOS pushes
+- #3410 [in-review] — Private labs pre-push guard misses the legacy public js2wasm origin URL
+- #3417 [ready] — UMBRELLA: oracle-v8 (original-harness) reclassification triage — the honest v7→v8 gap
+- #3420 [ready] — Write to non-writable/frozen Array element traps oob instead of throwing TypeError (verifyProperty corpus)
+- #3421 [ready] — Async tests: literal-harness completion marker ($DONE) not observed — 2,653 default-lane reclassifications
+- #3422 [ready] — Strict-mode rerun: read-only assign / delete non-configurable don't match spec — ~666 default reclassifications
+- #3423 [ready] — Module-global representation: top-level bindings read as undefined under literal harness — ~600 default reclassifications
+- #3426 [in-review] — Quarantine exact same-SHA unstable host Test262 paths from fine gates
+- #3429 [ready] — Host assert.throws: expected error constructor rendered as internal 'wasmClosureDynamicBridge' (544 records) under oracle v8
+- #3430 [ready] — Host conformance: integrity-level operations do not throw expected TypeError (1,316 records, newly honest under oracle v8)
+- #3437 [ready] — CI speed gate: enforce test262 harness compile-time budget so a harness switch can never silently tank CI
+- #3439 [ready] — Classify the 186 standalone failures #3369 exposed; ratchet --max-unclassified-root-causes 300→0
+- #3440 [ready] — js-host uncatchable-trap growth baked into baseline by the 64.5% hand-promote — trace culprit codegen PR and lower the floor
+- #3441 [ready] — TypedArray constructor cluster throws 'Cannot convert null to object' at __module_init (2,069 default-lane fails)
+- #3442 [ready] — standalone: null-deref residual (789 gap tests) — general __module_init + sync destructuring-rest traps, no open tracker
+- #3443 [ready] — standalone: illegal-cast residual (92 gap tests) — general __module_init + __str_to_number/parseInt, no open tracker
+- #3444 [ready] — negative_test_fail residual (v8 harvest): early-error not detected + negative test mis-passes — 89 default / 45 standalone
+- #3445 [ready] — compiler internal-error / stack-overflow crash residual (v8 harvest): 'Cannot read properties of undefined' + 'Maximum call stack' — ~28 both lanes
+- #3446 [ready] — long-tail low-count residual (v8 harvest): array-too-large, float-unrepresentable, runtime max-call-stack, timeouts
+- #3449 [ready] — ci(#3431 follow-up): re-derive merge_group shard constants from post-#3374 timings
+- #3450 [blocked] — decision(test262): JS-host lane native-JS harness — oracle v9 policy proposal [DECISION — needs sign-off]
+- #3451 [backlog] — arch(#1046/#33/#34): linked harness .wasm as the driving use case for separate compilation
+- #3452 [ready] — ci(test262): cache pnpm store / prebuilt compiler-bundle artifact across shard jobs
+- #3455 [in-review] — CI publish: auto-publish the GitHub release on tag push (was stuck draft)
+- #3456 [in-progress] — queue-unstick.yml re-enqueue churn cancels in-flight merge_group runs
+- #3459 [ready] — merge_group drift check reports negative baseline clock age (-43m) — clock-skew bug in instrumentation
+- #3460 [ready] — Uncatchable null_deref trap when a typed callable var (no matched closure sig) read off a host object is direct-called
+- #3466 [ready] — promote-baseline job skips on ALL merge-queue merges (github.actor == github-actions[bot]) → baseline never auto-refreshes
+- #3467 [in-review] — test262 regression gate: compare each PR against its REAL merge-base commit (per-SHA cache), not a drifting promoted snapshot
+- #3468 [blocked] — Standalone: method calls on function objects silently swallow assertions (assert.sameValue/throws never fire) — root cause is function-object own-property gap, NOT a catch_all swallow
+- #743 [ready] — Whole-program type flow analysis
+- #745 [in-progress] — Tagged union representation to replace externref boxing
+- #773 [ready] — Monomorphize functions: compile with call-site types, not generic externref
+- #779 [ready] — Assert failures: tests compile and run but produce wrong values (8,674 tests)
+- #802 [in-progress] — - Dynamic prototype support (Object.setPrototypeOf, Object.create with dynamic proto)
+- #869 [ready] — Refactor default params: caller-side insertion instead of sNaN sentinel
+
+## Retrospective
+
+- test262 conformance at freeze: see `benchmarks/results/test262-current.json`.
+- _(Tech-lead: add what went well / what didn't / action items here.)_


### PR DESCRIPTION
Freezes the current budget window as **sprint 72**.

- Relabeled 21 `sprint: fable-final` issues → `sprint: current` first (freeze-sprint.mjs only matches `current`, so fable-final done work would otherwise be skipped).
- `freeze-sprint.mjs --force`: 139 done issues re-tagged `sprint: 72`; not-done issues rolled forward as `sprint: current` (carried to next sprint); wrote `plan/issues/sprints/72.md`.
- Local tag `sprint/72` created (push after merge).

After merge: `git push upstream sprint/72` and `node scripts/sync-current-tasklist.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)