### PR TITLE
chore(issues): reopen false-done #2026/#1472/#680 (live test262 failures)

### DIFF
--- a/plan/issues/1472-no-js-host-object-property-ops.md
+++ b/plan/issues/1472-no-js-host-object-property-ops.md
@@ -1,7 +1,7 @@
 ---
 id: 1472
 title: "host-independence: eliminate JS host object/property ops for standalone Wasm"
-status: done
+status: ready
 pr: 1047
 created: 2026-05-20
 updated: 2026-06-03
@@ -1311,3 +1311,7 @@ honest refusals (protects the conformance number) before the real generic arm.
 - Bare method-call forms (`o.hasOwnProperty(k)`, `o.isPrototypeOf(x)`) route
   through `__extern_method_call` / `__proto_method_call` — the any-receiver method
   dispatch slice (#2151), already a separate task.
+
+## Reopened 2026-07-20 (harvest cross-reference)
+
+Marked `status: done` but the test262 harvest shows **942 live failures still citing #1472** in the error field. Premature close — reopened as `ready`. See the sprint-73 harvest note.

--- a/plan/issues/2026-class-as-first-class-value.md
+++ b/plan/issues/2026-class-as-first-class-value.md
@@ -1,7 +1,7 @@
 ---
 id: 2026
 title: "classes are not first-class values: new K() on a parameter throws 'No dependency provided for extern class', .constructor identity broken"
-status: done
+status: ready
 assignee: ttraenkler/cs-2158
 sprint: 63
 created: 2026-06-10
@@ -415,3 +415,7 @@ provided for extern class "K"` — confirmed. Traced the live path precisely:
   pure-Wasm (no host import) so both modes must pass.
 - Confirm no test262 `built-ins/`/`language/` regressions in the
   classes/new buckets (CI).
+
+## Reopened 2026-07-20 (harvest cross-reference)
+
+Marked `status: done` but the test262 harvest shows **1464 live failures still citing #2026** in the error field. Premature close — reopened as `ready`. See the sprint-73 harvest note.

--- a/plan/issues/680-wasm-native-generators-state-machines.md
+++ b/plan/issues/680-wasm-native-generators-state-machines.md
@@ -1,7 +1,7 @@
 ---
 id: 680
 title: "Wasm-native generators (state machines) with optional JS host fallback"
-status: done
+status: ready
 completed: 2026-06-12
 created: 2026-03-20
 updated: 2026-06-03
@@ -288,3 +288,7 @@ it flips ~0. The "sequential numeric yields" harvest label was misleading (it
 appeared in a sampled error string but is not a meaningfully-occurring gate, same
 class as the #68 BigInt64Array_new mislabel). If non-numeric yields are wanted
 for completeness, treat as a low-priority #680 follow-up, not a conformance slice.
+
+## Reopened 2026-07-20 (harvest cross-reference)
+
+Marked `status: done` but the test262 harvest shows **398 live failures still citing #680** in the error field. Premature close — reopened as `ready`. See the sprint-73 harvest note.


### PR DESCRIPTION
Harvest cross-reference (2026-07-20) found three issues marked `status: done` that still cite live test262 failures in the error field:

| Issue | Live failures | Feature |
|---|---|---|
| #2026 | 1,464 | classes not first-class (`new K()` on a param) |
| #1472 | 942 | Proxy on standalone |
| #680 | 398 | Wasm-native generators (still leak `env::__gen_result_*`) |

All three set `status: ready` so they surface as real work. (#2046 Reflect was already honestly `in-progress`; #2961 is correctly done — it's the leak *detector*, not a fixable cause.) These are top sprint-73 standalone/host levers.

Follow-up worth considering: a CI gate that blocks `status: done` while an issue's #NNNN still has >N live test citations (like the #2093 probe gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)