### PR TITLE
fix(#3441): worker-lane test262 sandbox parity — TypedArray cluster + Atomics

### DIFF
--- a/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
+++ b/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
@@ -1,8 +1,10 @@
 ---
 id: 3441
 title: "TypedArray constructor cluster throws 'Cannot convert null to object' at __module_init (2,069 default-lane fails)"
-status: ready
+status: done
 created: 2026-07-19
+completed: 2026-07-20
+assignee: ttraenkler/senior-dev
 priority: high
 task_type: bug
 area: test262-conformance
@@ -171,3 +173,39 @@ now #3419-vs-worker) — the two hand-maintained twins are the root problem.
 Runner-side fix only; no compiler change, no host-import surface change. The
 standalone lane's TypedArray intrinsic story stays #2375/#2651/#2901
 (`src/codegen/builtin-value-read.ts:652-671`).
+
+## Resolution (2026-07-20, senior-dev)
+
+Confirmed the architect diagnosis end-to-end before touching code:
+
+- Read both twin lists: `tests/test262-runner.ts` `SANDBOX_GLOBAL_NAMES` had
+  the #3419 TypedArray cluster; `scripts/test262-worker.mjs`
+  `ORIGINAL_HARNESS_SANDBOX_GLOBALS` stopped at `Reflect`. `Atomics` was on
+  neither.
+- `test262/harness/testTypedArray.js:64` reads
+  `var TypedArray = Object.getPrototypeOf(Int8Array);` at module-init top level;
+  the trap string originates at `src/runtime.ts:9996` (`__getPrototypeOf`).
+- Isolated before/after repro (compile once, instantiate + `__module_init`
+  twice): the 22-name worker list traps `Cannot convert undefined to object`;
+  the extended list runs clean. Sandbox is the sole difference. (Local
+  `Object.create(null)` sandbox yields the `undefined` wording; the harvest's
+  `null` wording is the same `__getPrototypeOf` site — both fixed by seeding the
+  globals.)
+- Real-sample runner probe: `use-default-proto-if-custom-proto-is-not-object.js`
+  and `internals/Set/detached-buffer.js` now progress PAST module init into the
+  test body (residual honest TypedArray-semantics fails), no module-init trap.
+
+**Fix (chosen: shared-list extraction — kills the drift class):**
+
+- New `scripts/test262-sandbox-globals.mjs` exports the single
+  `SANDBOX_GLOBAL_NAMES` (base + #3419 cluster + `Atomics`), side-effect-free.
+- `scripts/test262-worker.mjs` and `tests/test262-runner.ts` both import it; the
+  two hand-maintained twins are gone, so this parity class (#3227, #3428 B,
+  #3419-vs-worker) can't recur.
+- Regression test `tests/issue-3441.test.ts` asserts the shared list ⊇ the
+  cluster + `Atomics` and that the built sandbox exposes `Int8Array`/`Atomics`.
+
+Expected: the ~2,069 `Cannot convert null to object [in __module_init()]`
+default-lane bucket (+90 Atomics) collapses; the honest fail→pass flip is a
+fraction of that (residuals reclassify to real TypedArray-semantics fails). This
+is an intended large baseline change — not a regression.

--- a/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
+++ b/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
@@ -209,3 +209,32 @@ Expected: the ~2,069 `Cannot convert null to object [in __module_init()]`
 default-lane bucket (+90 Atomics) collapses; the honest fail→pass flip is a
 fraction of that (residuals reclassify to real TypedArray-semantics fails). This
 is an intended large baseline change — not a regression.
+
+## Accepted trap-growth collateral + one-cycle #3189 override (2026-07-20)
+
+Landing this fix required a **one-cycle** widening of the #3189 uncatchable-trap
+ratchet. It is NOT a silent floor raise — the rationale and the fix-forward are
+recorded here so the override is auditable and provably transitional.
+
+**What happened.** The sandbox-parity fix lets the TypedArray harness run PAST
+`__module_init` for the first time. 28 tests that previously died there (catchable
+"Cannot convert null to object") now execute their body and hit PRE-EXISTING
+compiler trap-gaps: `null_deref` +19 (166→185), `oob` +9 (48→57). All 28
+`include: [testTypedArray.js]` and were ALREADY failing before this PR — a
+failure-MODE change (catchable → uncatchable), **zero pass-loss**. Net host delta
+is **+647** (656 improvements − 9 non-timeout regressions), measured in the #3430
+merge_group run 29711072322.
+
+**The override (both reset to 0 after #3430 lands + baseline promotes).**
+- merge_group gate (`scripts/diff-test262.ts`, per-category): `TRAP_RATCHET_TOLERANCE=25`
+  — covers null_deref +19 and oob +9.
+- promote-baseline gate (`scripts/check-baseline-trap-growth.ts`): `BASELINE_TRAP_GROWTH_ALLOW=25`.
+
+The change-scoped `trap-growth-allow:` frontmatter mechanism was NOT usable here:
+both gates read it only in rebase mode (forward oracle bump, `diff-test262.ts:1766`),
+and this is a same-oracle runner-only change, so the frontmatter is inert. The
+repo-var valves are the only effective lever.
+
+**Fix-forward:** #3488 tracks IMPLEMENTING the unmasked TypedArray trap-gaps
+(`.set` arg-coercion / bounds, `bit-precision` codecs, `*-invoked-as-func`
+reflective null-receiver guards) so the ratchet tightens back to its prior floor.

--- a/scripts/test262-sandbox-globals.mjs
+++ b/scripts/test262-sandbox-globals.mjs
@@ -1,0 +1,82 @@
+/**
+ * Single source of truth for the test262 "original harness" sandbox globals.
+ *
+ * The oracle-v8 literal-harness sandbox is an `Object.create(null)` object that
+ * is contextified via `vm.createContext`; each name below is pulled out of the
+ * fresh realm with `runInContext(name, ctx)` and copied onto the sandbox so the
+ * compiled body can resolve it through the `globalSandbox` bridge
+ * (`__extern_get(globalThis, name)`). A name that is NOT on this list resolves
+ * to undefined/null in the sandbox, so any harness `Object.getPrototypeOf(name)`
+ * (or other `ToObject` coercion) throws `TypeError: Cannot convert null/undefined
+ * to object` — during `__module_init`, before the test body runs.
+ *
+ * This list is imported by BOTH lanes that build such a sandbox:
+ *   - `scripts/test262-worker.mjs` (sharded-CI / baseline lane)
+ *   - `tests/test262-runner.ts`    (local vitest runner lane)
+ *
+ * They were previously two hand-maintained twins that drifted (#3227, #3428 B,
+ * and #3419-vs-worker). The #3419 TypedArray cluster was added to the runner
+ * list but never to the worker's, which stranded ~2,069 default-lane
+ * TypedArray-constructor tests at `Cannot convert null to object [in
+ * __module_init()]` (#3441). Extracting the one shared list makes drift
+ * structurally impossible.
+ *
+ * NOTE: This module must stay a plain, side-effect-free `.mjs` — it is imported
+ * by the forked worker (plain node, no TS loader) AND by the vitest runner. Do
+ * NOT add top-level side effects here.
+ */
+export const SANDBOX_GLOBAL_NAMES = Object.freeze([
+  "Array",
+  "Object",
+  "Function",
+  "String",
+  "Number",
+  "Boolean",
+  "Symbol",
+  "Promise",
+  "Map",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+  "Date",
+  "RegExp",
+  "Error",
+  "TypeError",
+  "RangeError",
+  "SyntaxError",
+  "ReferenceError",
+  "Math",
+  "JSON",
+  "Reflect",
+  // (#3419) The TypedArray cluster + binary-data builtins. The oracle-v8
+  // literal harness (testTypedArray.js:64) reads these as VALUES off globalThis
+  // (`Object.getPrototypeOf(Int8Array)`, `[Int8Array, Uint8Array, …]`); without
+  // them, `__extern_get(globalThis, "Int8Array")` returns undefined in the
+  // sandbox and the whole TypedArray harness dies at
+  // `Object.getPrototypeOf(undefined)` — ~2k tests. Same vm realm as the rest
+  // of the sandbox, so intra-sandbox identities hold.
+  "ArrayBuffer",
+  "SharedArrayBuffer",
+  "DataView",
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float16Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+  "BigInt",
+  "EvalError",
+  "URIError",
+  "AggregateError",
+  "Proxy",
+  // (#3441) `Atomics` operates on SharedArrayBuffer views; the
+  // `built-ins/Atomics/*` harness reads it the same way. It was on NEITHER twin
+  // list, so those ~90 tests trapped identically at module init.
+  "Atomics",
+]);

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -18,6 +18,7 @@ import { compile, createIncrementalCompiler } from "./compiler-bundle.mjs";
 import { buildImports } from "./runtime-bundle.mjs";
 import { poisonRecycleReason } from "./test262-poison-error.mjs";
 import { negativeCompileErrorMatches, negativeCompileSucceededVerdict } from "./negative-verdict.mjs";
+import { SANDBOX_GLOBAL_NAMES } from "./test262-sandbox-globals.mjs";
 
 // ── Bundle hash (#1521) ────────────────────────────────────────────────
 // Each cache entry written below carries a `bundle_hash` field. When the
@@ -44,30 +45,13 @@ function computeBundleHash() {
 }
 const BUNDLE_HASH = computeBundleHash();
 
-const ORIGINAL_HARNESS_SANDBOX_GLOBALS = [
-  "Array",
-  "Object",
-  "Function",
-  "String",
-  "Number",
-  "Boolean",
-  "Symbol",
-  "Promise",
-  "Map",
-  "Set",
-  "WeakMap",
-  "WeakSet",
-  "Date",
-  "RegExp",
-  "Error",
-  "TypeError",
-  "RangeError",
-  "SyntaxError",
-  "ReferenceError",
-  "Math",
-  "JSON",
-  "Reflect",
-];
+// (#3441) The sandbox-globals list is now the single shared source in
+// scripts/test262-sandbox-globals.mjs — imported by BOTH this worker and
+// tests/test262-runner.ts so the two lanes can never drift again. It formerly
+// stopped at "Reflect" here (missing the #3419 TypedArray cluster + Atomics),
+// stranding ~2,069 default-lane TypedArray-ctor tests at "Cannot convert null
+// to object [in __module_init()]".
+const ORIGINAL_HARNESS_SANDBOX_GLOBALS = SANDBOX_GLOBAL_NAMES;
 
 function buildOriginalHarnessSandbox(consoleProxy) {
   const sandbox = Object.create(null);

--- a/tests/issue-3441.test.ts
+++ b/tests/issue-3441.test.ts
@@ -1,0 +1,86 @@
+// #3441 — TypedArray-ctor tests trapped "Cannot convert null to object" at
+// __module_init in the sharded-CI worker lane.
+//
+// Root cause: the oracle-v8 harness sandbox globals were maintained as two
+// hand-kept twins — tests/test262-runner.ts had the #3419 TypedArray cluster,
+// scripts/test262-worker.mjs (the sharded-CI/baseline lane) did NOT. The
+// harness file testTypedArray.js reads TypedArray constructors as bare VALUES
+// at module-init top level (`var TypedArray = Object.getPrototypeOf(Int8Array)`);
+// when `Int8Array` was absent from the worker sandbox the read resolved to
+// null/undefined and `Object.getPrototypeOf` threw during __module_init,
+// stranding ~2,069 default-lane tests (+90 built-ins/Atomics that were on
+// NEITHER list).
+//
+// Fix: one shared list in scripts/test262-sandbox-globals.mjs imported by both
+// lanes, so drift is structurally impossible; Atomics added for both.
+//
+// These assertions guard the regression: if the TypedArray cluster or Atomics
+// is dropped from the shared list, or if the sandbox stops exposing them, they
+// fail.
+import { describe, it, expect } from "vitest";
+import { createContext, runInContext } from "node:vm";
+import { SANDBOX_GLOBAL_NAMES } from "../scripts/test262-sandbox-globals.mjs";
+
+// The #3419 TypedArray cluster + binary-data builtins + Atomics that the
+// TypedArray/Atomics harness corpus reads at module init.
+const REQUIRED_TYPEDARRAY_CLUSTER = [
+  "ArrayBuffer",
+  "SharedArrayBuffer",
+  "DataView",
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float16Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+  "BigInt",
+  "Atomics",
+];
+
+// Mirror of the worker/runner sandbox-build (buildOriginalHarnessSandbox /
+// _buildFreshSandbox) — the single behavior under test.
+function buildSandbox(names: readonly string[]): Record<string, unknown> {
+  const sandbox: Record<string, unknown> = Object.create(null);
+  const context = createContext(sandbox);
+  for (const name of names) {
+    try {
+      sandbox[name] = runInContext(name, context);
+    } catch {
+      /* engine lacks this global — tolerated */
+    }
+  }
+  sandbox.globalThis = sandbox;
+  return sandbox;
+}
+
+describe("#3441 shared test262 sandbox globals", () => {
+  it("shared list includes the full TypedArray cluster + Atomics", () => {
+    for (const name of REQUIRED_TYPEDARRAY_CLUSTER) {
+      expect(SANDBOX_GLOBAL_NAMES, `missing sandbox global: ${name}`).toContain(name);
+    }
+  });
+
+  it("sandbox exposes Int8Array so `Object.getPrototypeOf(Int8Array)` does not trap", () => {
+    // This is the exact operation testTypedArray.js:64 performs during
+    // __module_init. Before the fix, Int8Array was absent → null/undefined →
+    // "Cannot convert null to object".
+    const sandbox = buildSandbox(SANDBOX_GLOBAL_NAMES);
+    expect(typeof sandbox.Int8Array).toBe("function");
+    const proto = Object.getPrototypeOf(sandbox.Int8Array);
+    expect(typeof proto).toBe("function"); // %TypedArray% intrinsic
+    // Intra-sandbox identity the harness relies on.
+    expect(Object.getPrototypeOf(sandbox.Uint8Array)).toBe(proto);
+  });
+
+  it("sandbox exposes Atomics as an object", () => {
+    const sandbox = buildSandbox(SANDBOX_GLOBAL_NAMES);
+    expect(typeof sandbox.Atomics).toBe("object");
+    expect(sandbox.Atomics).not.toBeNull();
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -18,6 +18,7 @@ import { ts } from "../src/ts-api.js";
 import { negativeCompileErrorMatches } from "../scripts/negative-verdict.mjs";
 import { restoreHostBuiltins } from "./test262-restore-builtins.js";
 import { assembleOriginalHarness, type OriginalHarnessVariant } from "./test262-original-harness.js";
+import { SANDBOX_GLOBAL_NAMES } from "../scripts/test262-sandbox-globals.mjs";
 
 // #1310: per-shard global isolation for test262.
 //
@@ -40,57 +41,12 @@ import { assembleOriginalHarness, type OriginalHarnessVariant } from "./test262-
 // vm realm's built-ins as properties on it — `ctx.Array` is `undefined`.
 // We therefore use `vm.runInContext("...")` to extract the realm's
 // built-ins explicitly and copy the references onto the sandbox object.
-const SANDBOX_GLOBAL_NAMES: ReadonlyArray<string> = [
-  "Array",
-  "Object",
-  "Function",
-  "String",
-  "Number",
-  "Boolean",
-  "Symbol",
-  "Promise",
-  "Map",
-  "Set",
-  "WeakMap",
-  "WeakSet",
-  "Date",
-  "RegExp",
-  "Error",
-  "TypeError",
-  "RangeError",
-  "SyntaxError",
-  "ReferenceError",
-  "Math",
-  "JSON",
-  "Reflect",
-  // (#3419) The TypedArray cluster + binary-data builtins. The oracle-v8
-  // literal harness (testTypedArray.js) reads these as VALUES off globalThis
-  // (`Object.getPrototypeOf(Int8Array)`, `[Int8Array, Uint8Array, …]`); before
-  // this list included them, `__extern_get(globalThis, "Int8Array")` returned
-  // undefined in the sandbox and the whole TypedArray harness died at
-  // `Object.getPrototypeOf(undefined)` — ~2k tests. Same vm realm as the rest
-  // of the sandbox, so intra-sandbox identities hold.
-  "ArrayBuffer",
-  "SharedArrayBuffer",
-  "DataView",
-  "Int8Array",
-  "Uint8Array",
-  "Uint8ClampedArray",
-  "Int16Array",
-  "Uint16Array",
-  "Int32Array",
-  "Uint32Array",
-  "Float16Array",
-  "Float32Array",
-  "Float64Array",
-  "BigInt64Array",
-  "BigUint64Array",
-  "BigInt",
-  "EvalError",
-  "URIError",
-  "AggregateError",
-  "Proxy",
-];
+//
+// (#3441) The name list itself now lives in the single shared source
+// scripts/test262-sandbox-globals.mjs (imported above as SANDBOX_GLOBAL_NAMES),
+// so this runner lane and the sharded-CI worker (scripts/test262-worker.mjs)
+// can never drift again — the #3419 TypedArray cluster (+ Atomics) is applied
+// to both by construction.
 
 const SENTINEL_KEYS: ReadonlyArray<readonly string[]> = [
   ["Array", "prototype", "push"],


### PR DESCRIPTION
## #3441 — TypedArray ctor `Cannot convert null to object` at `__module_init`

### Root cause (verified end-to-end, NOT codegen — a worker↔runner sandbox-parity gap)

The oracle-v8 harness sandbox globals were **two hand-maintained twins**:

- `tests/test262-runner.ts` `SANDBOX_GLOBAL_NAMES` had the #3419 TypedArray cluster.
- `scripts/test262-worker.mjs` `ORIGINAL_HARNESS_SANDBOX_GLOBALS` (the **sharded-CI/baseline lane**) stopped at `Reflect`.
- `Atomics` was on **neither** list.

`test262/harness/testTypedArray.js:64` reads `var TypedArray = Object.getPrototypeOf(Int8Array);` at module-init top level. With `Int8Array` absent from the worker sandbox, `__extern_get(globalThis, "Int8Array")` resolves to null/undefined and `__getPrototypeOf` (`src/runtime.ts:9996`) throws `TypeError: Cannot convert null to object` **in `__module_init()`**, before the test body — stranding **~2,069** default-lane TypedArray-ctor fails (+90 `built-ins/Atomics`).

### Verification (verify-first)

- Read both twin lists — confirmed the delta is exactly the #3419 cluster + Atomics.
- **Isolated before/after** (compile the snippet once, instantiate + `__module_init` twice): the 22-name worker list traps `Cannot convert … to object`; the extended list runs clean. Sandbox is the sole difference.
- **Real-sample runner probe**: `use-default-proto-if-custom-proto-is-not-object.js` and `internals/Set/detached-buffer.js` now progress **past** module init into the test body (residual honest TypedArray-semantics fails), no module-init trap.

### Fix — shared-list extraction (kills the drift class)

- New **`scripts/test262-sandbox-globals.mjs`** exports the single `SANDBOX_GLOBAL_NAMES` (base + #3419 cluster + `Atomics`), side-effect-free.
- `scripts/test262-worker.mjs` and `tests/test262-runner.ts` both **import** it — the two twins are gone, so this parity class (#3227, #3428 B, #3419-vs-worker) can't recur.
- **`tests/issue-3441.test.ts`** regression guard: shared list ⊇ cluster + `Atomics`; the built sandbox exposes `Int8Array`/`Atomics` and `Object.getPrototypeOf(Int8Array)` no longer traps.

### Expected CI impact

Intended **large baseline increase**: the ~2,069 `Cannot convert null to object [in __module_init()]` bucket collapses. Honest fail→pass flip is a **fraction** of 2,069 — most residuals reclassify to real TypedArray-semantics fails (a different signature), not passes. Coordinate baseline promotion; this is not a regression.

Closes #3441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb