### PR TITLE
fix(#3422): strict-mode delete of non-configurable prop throws real TypeError instance

### DIFF
--- a/plan/issues/3422-strict-mode-rerun-failures.md
+++ b/plan/issues/3422-strict-mode-rerun-failures.md
@@ -1,7 +1,8 @@
 ---
 id: 3422
 title: "Strict-mode rerun: read-only assign / delete non-configurable don't match spec — ~666 default reclassifications"
-status: ready
+status: in-progress
+assignee: ttraenkler/senior-dev
 created: 2026-07-18
 priority: medium
 feasibility: medium

--- a/plan/issues/3422-strict-mode-rerun-failures.md
+++ b/plan/issues/3422-strict-mode-rerun-failures.md
@@ -1,7 +1,8 @@
 ---
 id: 3422
 title: "Strict-mode rerun: read-only assign / delete non-configurable don't match spec — ~666 default reclassifications"
-status: in-progress
+status: done
+completed: 2026-07-20
 assignee: ttraenkler/senior-dev
 created: 2026-07-18
 priority: medium
@@ -60,3 +61,58 @@ that passed in sloppy mode now fail the strict rerun. Measured (oracle-v8):
 - Scoped: `language/expressions/assignment/**` read-only + `language/expressions/delete/**`
   non-configurable tests pass the strict rerun.
 - Zero-regression on sloppy-mode runs of the same tests.
+
+## Resolution (2026-07-20)
+
+**Verify-first re-scoping against the current oracle-v8 baseline** (fetched from
+`loopdive/js2wasm-baselines`, timestamped 19:05 on 2026-07-19 — *after* both
+sibling PRs merged). The two originally-cited families had already diverged:
+
+| Family (strict-rerun signature) | issue estimate | baseline residual |
+| --- | --- | --- |
+| `Cannot assign to read only property …` | 419 | **2** (fixed by #3471) |
+| `Cannot delete non-configurable property …` | 247 | **313** (this fix) |
+
+So #3470 (name/length realm-restore) and #3471 (read-only-assign real-TypeError
+via the isSameValue param-inference fix) already retired the read-only-assign
+family. The **residual after them is the `delete` non-configurable family**, and
+it is **NOT realm-pollution** — it reproduces on a fresh, never-mutated realm.
+
+**Root cause.** `src/codegen/typeof-delete.ts` threw the strict-mode
+non-configurable-`delete` refusal (§13.5.1.2 step 6.b) as a **bare string** on the
+shared exception tag (`deleteThrowInstrs`/`emitDeleteThrow`). The legacy `wrapTest`
+harness stripped `assert.throws`' expected constructor, so a string sufficed. The
+authentic harness (#3370) runs the real `propertyHelper.js::isConfigurable()`:
+`try { delete obj[name] } catch (e) { if (!(e instanceof TypeError)) throw
+Test262Error("Expected TypeError, got " + e) }`. A thrown string is not
+`instanceof TypeError`, so the guard tripped — hence "Expected TypeError, got
+TypeError: Cannot delete non-configurable property in strict mode" (the string
+carried its own "TypeError:" prefix). Exactly the `delete` counterpart of #3471's
+read-only-assign fix.
+
+**Fix.** Route the three delete-refusal throw sites (strict non-configurable
+TypeError ×2, super-reference ReferenceError ×1) through the canonical
+`buildThrowJsErrorInstrs` (`js-errors.ts`), which builds a **real** error instance
+— host `__new_<Kind>` import in JS-host mode, in-module `emitWasiErrorConstructor`
+in standalone/wasi — with the established `{ flush: fctx }` late-import-shift
+handling. `deleteThrowInstrs`/`emitDeleteThrow` now take `(ctx, fctx, kind,
+message)`; the "Kind:" prefix moved out of the message (the constructor supplies
+it). Dual-mode: standalone `delete` refusals now throw a real `instanceof
+TypeError` too.
+
+## Test Results
+- New `tests/issue-3422.test.ts` (7 cases): host + standalone `instanceof TypeError`
+  probes, plus 5 real test262 files from the 313-cluster passing primary + strict
+  rerun end-to-end. All green.
+- Real-file honest-harness sweep (`runTest262File` on the fixed build):
+  **60/60 random** + **32/32 category-spread** of the 313 flip to `pass`, zero
+  remaining error buckets ⇒ essentially the full **~313 host flips**.
+- Regression: the 8 existing delete/typeof vitest suites show an **identical**
+  3-fail/36-pass on main and on this branch — **zero new failures**. (Those 3
+  pre-existing failures are a *separate*, out-of-scope **sloppy**-mode bug: a
+  sloppy non-configurable `delete` currently throws instead of returning `false`.)
+
+**Honest scope.** This fix targets the `delete` non-configurable family (313 of
+the 347 total `strict rerun:` failures on the baseline). The read-only-assign
+residual (2) is already handled by #3471; the remaining ~32 are other, unrelated
+families and are out of scope for this issue.

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -38,30 +38,16 @@ import { emitDynamicWithDelete, findWithBinding, resolveWithBinding } from "./wi
 const NON_CONFIGURABLE_GLOBALS = new Set(["NaN", "Infinity", "undefined"]);
 
 /**
- * (#2703, #3422) Build the terminal `throw` sequence for the spec error cases of
- * `delete` (§13.5.1.2): a super reference (ReferenceError), a null/undefined
- * base, or a strict-mode non-configurable property refusal (TypeError).
- *
- * Historically this threw a **bare string** on the shared exception tag, relying
- * on the legacy `wrapTest` harness stripping the expected constructor out of
- * `assert.throws`. Under the authentic test262 harness (#3370) that assumption is
- * false: the real `propertyHelper.js::isConfigurable()` probes the refusal with
- * `try { delete obj[name] } catch (e) { if (!(e instanceof TypeError)) throw … }`,
- * and a thrown STRING is not `instanceof TypeError` — so ~313 strict-rerun cases
- * failed with "Expected TypeError, got TypeError: Cannot delete non-configurable
- * property in strict mode" (the string carried its own "TypeError:" prefix, which
- * is why the `+ e` message looked like a TypeError yet the `instanceof` guard
- * still tripped). Building a **real** error instance via `buildThrowJsErrorInstrs`
- * (host `__new_<Kind>` import / standalone in-module constructor) makes
- * `instanceof` match in both lanes — the same fix #3471 landed for the
- * strict-mode read-only-assignment sibling family.
- *
- * `message` is the bare human message (NO "Kind:" prefix — the constructor adds
- * it). `opts.flush` MUST be the enclosing `FunctionContext` so the late
- * `__new_<Kind>` import's funcIdx shifts are applied to already-emitted body
- * instructions (the #1839 late-import ordering hazard). After the throw the rest
- * of the enclosing expression is unreachable, so the `delete` expression's
- * nominal i32 result is supplied stack-polymorphically.
+ * (#2703, #3422) Terminal `throw` for `delete`'s spec error cases (§13.5.1.2):
+ * super reference → ReferenceError; null/undefined base or strict-mode
+ * non-configurable refusal → TypeError. Emits a REAL error instance via
+ * `buildThrowJsErrorInstrs` (host `__new_<Kind>` / standalone in-module ctor),
+ * NOT a bare string: the authentic harness (#3370)
+ * `propertyHelper.js::isConfigurable()` rethrows unless `e instanceof TypeError`,
+ * so the pre-#3422 bare-string throw broke ~313 strict reruns (the `delete`
+ * counterpart of #3471). `message` carries no "Kind:" prefix (the ctor adds it);
+ * `opts.flush` = fctx applies the late `__new_<Kind>` funcIdx shift to the
+ * already-emitted body (#1839). The throw is terminal / stack-polymorphic.
  */
 function deleteThrowInstrs(ctx: CodegenContext, fctx: FunctionContext, kind: JsErrorKind, message: string): Instr[] {
   return buildThrowJsErrorInstrs(ctx, kind, message, { flush: fctx });

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -22,9 +22,9 @@ import {
 import { resolveStructName } from "./expressions/misc.js";
 import { addUnionImports, parseRegExpLiteral, resolveWasmType } from "./index.js";
 import { emitExternrefDestructureGuard } from "./destructuring-params.js";
-import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { buildThrowJsErrorInstrs, type JsErrorKind } from "./js-errors.js";
 import { compileStandaloneRegExpLiteral } from "./regexp-standalone.js";
-import { addImport, addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { addImport } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, isAnyValue } from "./shared.js";
@@ -38,24 +38,37 @@ import { emitDynamicWithDelete, findWithBinding, resolveWithBinding } from "./wi
 const NON_CONFIGURABLE_GLOBALS = new Set(["NaN", "Infinity", "undefined"]);
 
 /**
- * (#2703) Emit an unconditional `throw` of a string-valued exception, used for
- * the spec error cases of `delete` (§13.5.1.2): a super reference, a null/
- * undefined base, or a strict-mode non-configurable property. The test262
- * `assert.throws` harness catches *any* thrown value (the expected constructor
- * is stripped during the source transform), and a string carried on the
- * standard exception tag is catchable in both the JS-host and standalone lanes
- * (the same pattern `object-runtime.ts` uses for descriptor TypeErrors). After
- * the throw the rest of the enclosing expression is unreachable, so the
- * `delete` expression's nominal i32 result is supplied stack-polymorphically.
+ * (#2703, #3422) Build the terminal `throw` sequence for the spec error cases of
+ * `delete` (§13.5.1.2): a super reference (ReferenceError), a null/undefined
+ * base, or a strict-mode non-configurable property refusal (TypeError).
+ *
+ * Historically this threw a **bare string** on the shared exception tag, relying
+ * on the legacy `wrapTest` harness stripping the expected constructor out of
+ * `assert.throws`. Under the authentic test262 harness (#3370) that assumption is
+ * false: the real `propertyHelper.js::isConfigurable()` probes the refusal with
+ * `try { delete obj[name] } catch (e) { if (!(e instanceof TypeError)) throw … }`,
+ * and a thrown STRING is not `instanceof TypeError` — so ~313 strict-rerun cases
+ * failed with "Expected TypeError, got TypeError: Cannot delete non-configurable
+ * property in strict mode" (the string carried its own "TypeError:" prefix, which
+ * is why the `+ e` message looked like a TypeError yet the `instanceof` guard
+ * still tripped). Building a **real** error instance via `buildThrowJsErrorInstrs`
+ * (host `__new_<Kind>` import / standalone in-module constructor) makes
+ * `instanceof` match in both lanes — the same fix #3471 landed for the
+ * strict-mode read-only-assignment sibling family.
+ *
+ * `message` is the bare human message (NO "Kind:" prefix — the constructor adds
+ * it). `opts.flush` MUST be the enclosing `FunctionContext` so the late
+ * `__new_<Kind>` import's funcIdx shifts are applied to already-emitted body
+ * instructions (the #1839 late-import ordering hazard). After the throw the rest
+ * of the enclosing expression is unreachable, so the `delete` expression's
+ * nominal i32 result is supplied stack-polymorphically.
  */
-function deleteThrowInstrs(ctx: CodegenContext, message: string): Instr[] {
-  const tagIdx = ensureExnTag(ctx);
-  addStringConstantGlobal(ctx, message);
-  return [...stringConstantExternrefInstrs(ctx, message), { op: "throw", tagIdx }];
+function deleteThrowInstrs(ctx: CodegenContext, fctx: FunctionContext, kind: JsErrorKind, message: string): Instr[] {
+  return buildThrowJsErrorInstrs(ctx, kind, message, { flush: fctx });
 }
 
-function emitDeleteThrow(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
-  for (const instr of deleteThrowInstrs(ctx, message)) fctx.body.push(instr);
+function emitDeleteThrow(ctx: CodegenContext, fctx: FunctionContext, kind: JsErrorKind, message: string): void {
+  fctx.body.push(...deleteThrowInstrs(ctx, fctx, kind, message));
 }
 
 /**
@@ -83,7 +96,7 @@ function maybeEmitNonConfigurableAccessorDelete(
   if (recvType) fctx.body.push({ op: "drop" });
   // Strict mode: a refused non-configurable delete is a TypeError.
   if (isStrictContext(expr)) {
-    emitDeleteThrow(ctx, fctx, "TypeError: Cannot delete non-configurable property in strict mode");
+    emitDeleteThrow(ctx, fctx, "TypeError", "Cannot delete non-configurable property in strict mode");
   }
   // Sloppy mode: the delete expression evaluates to `false`.
   fctx.body.push({ op: "i32.const", value: 0 });
@@ -106,7 +119,7 @@ function emitStrictDeleteCheck(ctx: CodegenContext, fctx: FunctionContext, expr:
   fctx.body.push({
     op: "if",
     blockType: { kind: "empty" },
-    then: deleteThrowInstrs(ctx, "TypeError: Cannot delete non-configurable property in strict mode"),
+    then: deleteThrowInstrs(ctx, fctx, "TypeError", "Cannot delete non-configurable property in strict mode"),
     else: [],
   });
   fctx.body.push({ op: "local.get", index: resLocal });
@@ -202,7 +215,7 @@ function emitStructDeleteOutcome(
     fctx.body.push({
       op: "if",
       blockType: { kind: "empty" },
-      then: deleteThrowInstrs(ctx, "TypeError: Cannot delete non-configurable property in strict mode"),
+      then: deleteThrowInstrs(ctx, fctx, "TypeError", "Cannot delete non-configurable property in strict mode"),
       else: [],
     });
   }
@@ -253,7 +266,7 @@ export function compileDeleteExpression(
     (ts.isPropertyAccessExpression(inner) || ts.isElementAccessExpression(inner)) &&
     inner.expression.kind === ts.SyntaxKind.SuperKeyword
   ) {
-    emitDeleteThrow(ctx, fctx, "ReferenceError: 'super' property cannot be deleted");
+    emitDeleteThrow(ctx, fctx, "ReferenceError", "'super' property cannot be deleted");
     return { kind: "i32" };
   }
 

--- a/tests/issue-3422.test.ts
+++ b/tests/issue-3422.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#3422) Strict-mode rerun: `delete` of a non-configurable property must throw
+// a **real** TypeError instance, not a bare string.
+//
+// test262's authentic harness (#3370) runs each test a second time with
+// `"use strict";` prepended. Under strict mode `propertyHelper.js::isConfigurable()`
+// probes a non-configurable property's refusal with
+//
+//     try { delete obj[name]; } catch (e) {
+//       if (!(e instanceof TypeError)) throw new Test262Error("Expected TypeError, got " + e);
+//     }
+//
+// Before this fix the compiler threw the strict-mode refusal as a BARE STRING
+// ("TypeError: Cannot delete non-configurable property in strict mode") on the
+// shared exception tag. A string is not `instanceof TypeError`, so the guard
+// tripped and ~313 strict-rerun cases failed with
+// "Expected TypeError, got TypeError: Cannot delete non-configurable property in
+// strict mode" (the string carried its own "TypeError:" prefix, which is why the
+// `+ e` text looked like a TypeError yet `instanceof` still returned false).
+//
+// The read-only-assignment sibling family (isWritable's `obj[name] = v` refusal)
+// was already fixed to throw a real instance (#3471); this is the `delete`
+// counterpart. The fix routes typeof-delete.ts's delete-refusal throws through
+// `buildThrowJsErrorInstrs` (host `__new_TypeError` / standalone in-module
+// constructor), so `e instanceof TypeError` is true in both lanes.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+// A strict-mode delete of a non-configurable own property, caught in a
+// Wasm-level try/catch that returns 1 when the caught value is `instanceof
+// <Ctor>` and 2 when it is caught but NOT an instance (the pre-fix bug).
+const INSTANCEOF_PROBE = `
+"use strict";
+export function test(): number {
+  const o: any = {};
+  Object.defineProperty(o, "p", { value: 1, configurable: false });
+  try { delete o.p; return 0; } catch (e) { return (e instanceof TypeError) ? 1 : 2; }
+}
+`;
+
+async function runInstanceofProbe(target?: "standalone"): Promise<number> {
+  const result = await compile(INSTANCEOF_PROBE, target ? { target } : undefined);
+  expect(result.success, result.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const imports = target
+    ? {}
+    : (buildImports(result.imports, undefined, result.stringPool) as unknown as WebAssembly.Imports);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#3422 strict-mode delete of a non-configurable property throws a real TypeError", () => {
+  it("host lane: the caught value is `instanceof TypeError` (not a bare string)", async () => {
+    expect(await runInstanceofProbe()).toBe(1);
+  });
+
+  it("standalone lane: the in-module TypeError constructor also satisfies `instanceof`", async () => {
+    expect(await runInstanceofProbe("standalone")).toBe(1);
+  });
+
+  // End-to-end: real test262 files from the pre-fix 313-failure cluster now
+  // reach a full `pass` (primary + strict rerun) through the authentic honest
+  // harness — the same `assembleOriginalHarness` assembly CI's oracle uses.
+  // This locks in the NEXT-layer guard: `isConfigurable()` returns
+  // `!__hasOwnProperty(obj, name)` after the caught delete, and any later
+  // `verifyProperty` assertion must also hold (cf. #3470 → #3471, where fixing
+  // one probe unblocked a deeper bug in the next).
+  const CITED_TESTS = [
+    "built-ins/Object/defineProperty/15.2.3.6-3-85.js",
+    "built-ins/Object/defineProperties/15.2.3.7-6-a-72.js",
+    "built-ins/Symbol/toPrimitive/prop-desc.js",
+    "built-ins/Math/PI/prop-desc.js",
+    "built-ins/Number/MAX_SAFE_INTEGER.js",
+  ] as const;
+
+  for (const rel of CITED_TESTS) {
+    it(`test262 ${rel} passes primary + strict rerun`, async () => {
+      const res = await runTest262File(resolve("test262/test", rel), rel.split("/")[0]!);
+      restoreHostBuiltins();
+      expect(res.status, `${rel}: ${res.error ?? ""}`).toBe("pass");
+    }, 60_000);
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the dominant residual of the #3370 strict-rerun failures: the **`delete` non-configurable** family (**313** host-lane cases on the current oracle-v8 baseline).

**Verify-first re-scoping.** The issue estimated two families (read-only assign 419, delete non-config 247). Against the current baseline (fetched from `loopdive/js2wasm-baselines`, timestamped after the sibling PRs merged) the read-only-assign family is already down to **2** — retired by #3470 (name/length realm-restore) + #3471 (read-only-assign real-TypeError via the isSameValue param-inference fix). The **residual is the `delete` family (313)**, and it is **NOT realm pollution** — it reproduces on a fresh, never-mutated realm.

## Root cause

`src/codegen/typeof-delete.ts` threw the strict-mode non-configurable-`delete` refusal (§13.5.1.2 step 6.b) — and the super-reference ReferenceError — as a **bare string** on the shared exception tag. The legacy `wrapTest` harness stripped `assert.throws`' expected constructor, so a string sufficed. The authentic test262 harness (#3370) runs the real `propertyHelper.js::isConfigurable()`:

```js
try { delete obj[name]; }
catch (e) { if (!(e instanceof TypeError)) throw new Test262Error("Expected TypeError, got " + e); }
```

A thrown **string** is not `instanceof TypeError`, so the guard tripped → "Expected TypeError, got TypeError: Cannot delete non-configurable property in strict mode" (the string carried its own `TypeError:` prefix, which is why the `+ e` text still read like a TypeError). This is the `delete` counterpart of #3471's read-only-assignment fix.

## Fix

Route the three delete-refusal throw sites through the canonical `buildThrowJsErrorInstrs` (`js-errors.ts`), which builds a **real** error instance — host `__new_<Kind>` import in JS-host mode, in-module `emitWasiErrorConstructor` in standalone/wasi — with the established `{ flush: fctx }` late-import-shift handling. `deleteThrowInstrs`/`emitDeleteThrow` now take `(ctx, fctx, kind, message)` and the `Kind:` prefix moves out of the message (the constructor supplies it). Dual-mode: standalone `delete` refusals now also throw a real `instanceof TypeError`.

## Results

- **60/60 random** + **32/32 category-spread** of the 313 flip to `pass` via the honest harness (`runTest262File`), zero remaining error buckets ⇒ essentially the full ~313 host flips.
- New `tests/issue-3422.test.ts` (7 cases): host + standalone `instanceof TypeError` probes + 5 real test262 files passing primary + strict rerun end-to-end. All green.
- **Zero regressions**: the 8 existing delete/typeof vitest suites show an identical 3-fail/36-pass on `main` and this branch. (Those 3 pre-existing failures are a *separate*, out-of-scope **sloppy**-mode bug — a sloppy non-configurable `delete` throws instead of returning `false`.)

## Honest scope

Targets the `delete` non-configurable family (313 of the 347 total `strict rerun:` failures). The read-only-assign residual (2) is #3471's; the remaining ~32 are other, unrelated families and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb