### PR TITLE
fix(#3477): indexed/number-method RangeError gates throw real instances

### DIFF
--- a/plan/issues/3477-rangeerror-bare-string-ctors.md
+++ b/plan/issues/3477-rangeerror-bare-string-ctors.md
@@ -1,0 +1,78 @@
+---
+id: 3477
+title: "Indexed/number-method RangeError gates throw bare strings — fail authentic-harness `e instanceof RangeError`"
+status: done
+created: 2026-07-20
+completed: 2026-07-20
+assignee: ttraenkler/senior-dev
+priority: high
+task_type: bug
+area: test262-conformance
+goal: test262-conformance
+sprint: current
+horizon: m
+related: [3422, 3175, 3191, 3429]
+---
+
+# #3477 — bare-string RangeError throws at indexed/number-method construction
+
+## Summary
+
+Several RangeError gates emit a **bare string** via the shared `$exc` tag
+instead of a real `RangeError` **instance**:
+
+```ts
+then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }]
+```
+
+Under the authentic oracle-v8 harness, `assert.throws(RangeError, fn)` checks
+`e instanceof RangeError` (constructor identity), so a bare string fails →
+**host FAIL** today. This is the same `instanceof`-guard failure family that gave
+**#3422** a 313-flip win (bare-string strict-delete → `buildThrowJsErrorInstrs`,
+for TypeError) and that **#3175** already fixed for the *dot-access*
+`Number.prototype.toString/toFixed` twins.
+
+## Affected sites (all converted)
+
+**`src/codegen/expressions/new-indexed.ts`** (7 sites — indexed built-in ctors):
+
+- `new ArrayBuffer(-1)` → "Invalid array buffer length" (×2: plain + resizable)
+- resizable `maxByteLength < 0` → "Invalid array buffer max byte length"
+- `byteLength > maxByteLength` → "ArrayBuffer byteLength exceeds maxByteLength"
+- `new DataView(buf, offset)` OOB → "Start offset is outside the bounds of the buffer"
+- `new DataView(buf, off, len)` OOB → "Invalid DataView length"
+- `new Array(-1)` / `new Array(2**32)` → "Invalid array length"
+
+**`src/codegen/expressions/call-tail-dispatch.ts`** (2 sites — computed-access
+`Number.prototype` methods, the twins of the already-fixed dot-access sites in
+`call-receiver-method.ts`):
+
+- `n["toString"](radix)` radix ∉ 2..36 → "toString() radix must be between 2 and 36"
+- `n["toFixed"](digits)` digits ∉ 0..100 → "toFixed() digits argument must be between 0 and 100"
+
+## Fix
+
+Route every site through `buildThrowJsErrorInstrs(ctx, "RangeError", msg, { flush: fctx })`
+(the #3175/#3191 real-instance builder in `src/codegen/js-errors.ts`). Dual-mode:
+in `--target standalone`/`wasi` the builder emits the in-module Wasm-native
+`__new_RangeError` constructor, so no unsatisfiable host import — the #2029
+sentinel concern the bare-string form worked around is handled internally. The
+now-dead `addStringConstantGlobal` / `ensureExnTag` /
+`stringConstantExternrefInstrs` imports were removed from both files.
+
+## Verification
+
+- `tsc --noEmit` clean; biome + prettier clean.
+- Behavioral (`tests/issue-3477.test.ts`): `new ArrayBuffer(-1)`, `new Array(-1)`,
+  `(5)["toString"](40)`, `(5)["toFixed"](200)` each caught as a **RangeError
+  instance** (`e instanceof RangeError` → 1), not a bare string (would be 2).
+- CI measures the authoritative host flip count.
+
+## Notes
+
+Scope grew from the 3 sites first reported to all 7 in `new-indexed.ts` — they
+are the identical mechanical conversion in the same construction file and include
+the high-value `new Array(-1)` + DataView-bounds test262 clusters. Strictly a
+correctness improvement (bare-string → real instance); it cannot regress a
+passing test (any harness comparing the caught value to `RangeError` was already
+failing on the bare string).

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -19,16 +19,8 @@ import { reportError } from "../context/errors.js";
 import { allocLocal } from "../context/locals.js";
 import { rollbackSpeculative } from "../context/speculative.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
-import {
-  addStringConstantGlobal,
-  ensureExnTag,
-  getArrTypeIdxFromVec,
-  getOrRegisterVecType,
-  hoistLetConstWithTdz,
-  resolveWasmType,
-} from "../index.js";
+import { getArrTypeIdxFromVec, getOrRegisterVecType, hoistLetConstWithTdz, resolveWasmType } from "../index.js";
 import { objectLiteralTakesStandaloneAnyObjectPath, resolveComputedKeyExpression } from "../literals.js";
-import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { emitNullCheckThrow, typeErrorThrowInstrs } from "../property-access.js";
 import { tryCompileStandaloneRegExpSymbolCall } from "../regexp-standalone.js";
 import type { InnerResult } from "../shared.js";
@@ -44,7 +36,13 @@ import {
   pushParamSentinel,
 } from "../type-coercion.js";
 import { compileCallableElementAccessCall, compileClosureCall } from "./calls-closures.js";
-import { getFuncParamTypes, getWasmFuncReturnType, isEffectivelyVoidReturn, wasmFuncReturnsVoid } from "./helpers.js";
+import {
+  buildThrowJsErrorInstrs,
+  getFuncParamTypes,
+  getWasmFuncReturnType,
+  isEffectivelyVoidReturn,
+  wasmFuncReturnsVoid,
+} from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { resolveStructName } from "./misc.js";
 import { compileSuperElementMethodCall } from "./new-super.js";
@@ -1047,17 +1045,16 @@ export function compileTailDispatch(
           fctx.body.push({ op: "i32.or" });
           {
             const rangeErrMsg = "RangeError: toString() radix must be between 2 and 36";
-            // (#2029 family C) Dual-mode message push — the raw
-            // `global.get stringGlobalMap.get(msg)!` baked the -1 sentinel
-            // under standalone/nativeStrings (`5["toString"](2)` emit-crashed
-            // with "global index out of range — -1"); the dot-access twin of
-            // this site already uses the helper. Host mode is byte-identical.
-            addStringConstantGlobal(ctx, rangeErrMsg);
-            const tagIdx = ensureExnTag(ctx);
+            // (#3477) Throw a real RangeError INSTANCE via buildThrowJsErrorInstrs
+            // so the authentic-harness `assert.throws(RangeError, …)` /
+            // `e instanceof RangeError` guard passes — matches the dot-access twin
+            // (call-receiver-method.ts). Formerly a bare-string throw (only
+            // `e === "RangeError: …"`). buildThrowJsErrorInstrs handles the dual
+            // -mode message push + tag internally (the #2029 sentinel concern).
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
-              then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+              then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
               else: [],
             });
           }
@@ -1082,15 +1079,13 @@ export function compileTailDispatch(
           fctx.body.push({ op: "i32.or" });
           {
             const rangeErrMsg = "RangeError: toFixed() digits argument must be between 0 and 100";
-            // (#2029 family C) Dual-mode message push — see the toString()
-            // radix twin above (`1["toFixed"](5)` was the standalone
-            // emit-crash repro for property-accessors/S11.2.1_A3_T2).
-            addStringConstantGlobal(ctx, rangeErrMsg);
-            const tagIdx = ensureExnTag(ctx);
+            // (#3477) Real RangeError INSTANCE via buildThrowJsErrorInstrs — see
+            // the toString() radix twin above; matches the dot-access twin so
+            // `assert.throws(RangeError, …)` passes.
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
-              then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+              then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
               else: [],
             });
           }

--- a/src/codegen/expressions/new-indexed.ts
+++ b/src/codegen/expressions/new-indexed.ts
@@ -15,17 +15,9 @@ import { ts } from "../../ts-api.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { allocLocal } from "../context/locals.js";
 import { getOrRegisterDvWindowType } from "../dataview-native.js";
-import {
-  addStringConstantGlobal,
-  ensureExnTag,
-  getArrTypeIdxFromVec,
-  getOrRegisterResizableAbType,
-  getOrRegisterVecType,
-  resolveWasmType,
-} from "../index.js";
-import { stringConstantExternrefInstrs } from "../native-strings.js";
+import { getArrTypeIdxFromVec, getOrRegisterResizableAbType, getOrRegisterVecType, resolveWasmType } from "../index.js";
 import { compileExpression } from "../shared.js";
-import { noJsHost } from "./helpers.js";
+import { buildThrowJsErrorInstrs, noJsHost } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { inferArrayElementType } from "./new-super.js";
 
@@ -91,12 +83,10 @@ export function tryCompileIndexedBuiltinNew(
       fctx.body.push({ op: "i32.or" });
       {
         const rangeErrMsg = "RangeError: Invalid array buffer length";
-        addStringConstantGlobal(ctx, rangeErrMsg);
-        const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+          then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
           else: [],
         });
       }
@@ -133,12 +123,10 @@ export function tryCompileIndexedBuiltinNew(
       fctx.body.push({ op: "f64.lt" });
       {
         const rangeErrMsg = "RangeError: Invalid array buffer max byte length";
-        addStringConstantGlobal(ctx, rangeErrMsg);
-        const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+          then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
           else: [],
         });
       }
@@ -153,12 +141,10 @@ export function tryCompileIndexedBuiltinNew(
       fctx.body.push({ op: "i32.gt_s" });
       {
         const rangeErrMsg = "RangeError: ArrayBuffer byteLength exceeds maxByteLength";
-        addStringConstantGlobal(ctx, rangeErrMsg);
-        const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+          then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
           else: [],
         });
       }
@@ -197,12 +183,10 @@ export function tryCompileIndexedBuiltinNew(
       fctx.body.push({ op: "i32.or" });
       {
         const rangeErrMsg = "RangeError: Invalid array buffer length";
-        addStringConstantGlobal(ctx, rangeErrMsg);
-        const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+          then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
           else: [],
         });
       }
@@ -300,12 +284,10 @@ export function tryCompileIndexedBuiltinNew(
 
         {
           const rangeErrMsg = "RangeError: Start offset is outside the bounds of the buffer";
-          addStringConstantGlobal(ctx, rangeErrMsg);
-          const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+            then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
             else: [],
           });
         }
@@ -364,12 +346,10 @@ export function tryCompileIndexedBuiltinNew(
 
         {
           const rangeErrMsg = "RangeError: Invalid DataView length";
-          addStringConstantGlobal(ctx, rangeErrMsg);
-          const tagIdx = ensureExnTag(ctx);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+            then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
             else: [],
           });
         }
@@ -640,12 +620,10 @@ export function tryCompileIndexedBuiltinNew(
       // If any check true, throw RangeError
       {
         const rangeErrMsg = "RangeError: Invalid array length";
-        addStringConstantGlobal(ctx, rangeErrMsg);
-        const tagIdx = ensureExnTag(ctx);
         fctx.body.push({
           op: "if",
           blockType: { kind: "empty" },
-          then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }],
+          then: buildThrowJsErrorInstrs(ctx, "RangeError", rangeErrMsg, { flush: fctx }),
           else: [],
         });
       }

--- a/tests/issue-3477.test.ts
+++ b/tests/issue-3477.test.ts
@@ -1,0 +1,55 @@
+// #3477 — bare-string RangeError throws at indexed/number-method construction
+// sites now throw real RangeError INSTANCES.
+//
+// Root cause: several RangeError gates in indexed built-in construction
+// (`new ArrayBuffer(-1)`, resizable ArrayBuffer maxByteLength, DataView bounds,
+// `new Array(-1)`) and the computed-access Number.prototype.toString(radix) /
+// toFixed(digits) gates emitted a BARE STRING via the shared `$exc` tag
+// (`[...stringConstantExternrefInstrs(msg), {op:"throw",tagIdx}]`) instead of a
+// real Error instance. Under the authentic oracle-v8 harness,
+// `assert.throws(RangeError, fn)` checks `e instanceof RangeError` (constructor
+// identity), so a bare string fails → host FAIL. Same `instanceof`-guard family
+// as #3422 (313-flip TypeError win) / #3175 (the dot-access toString/toFixed
+// twins already fixed).
+//
+// Fix: route every site through `buildThrowJsErrorInstrs(ctx, "RangeError", …)`
+// (src/codegen/js-errors.ts, the #3175/#3191 real-instance builder). These
+// assertions are the regression guard: before the fix each returns 2
+// (bare-string caught), after it returns 1 (RangeError instance caught).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(src: string): Promise<unknown> {
+  const result = await compile(src);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as any).test();
+}
+
+// Each case: try the throwing construction; return 1 iff the caught value is a
+// real RangeError instance, 2 if it's a non-RangeError (the old bare-string), 0
+// if it did not throw at all.
+const RANGEERR_CASES: Array<[string, string]> = [
+  ["new ArrayBuffer(-1)", "const b = new ArrayBuffer(-1);"],
+  ["new Array(-1)", "const a = new Array(-1);"],
+  ['(5)["toString"](40)', 'const n: number = 5; const s = n["toString"](40);'],
+  ['(5)["toFixed"](200)', 'const n: number = 5; const s = n["toFixed"](200);'],
+];
+
+describe("#3477 indexed/number-method RangeError gates throw real instances", () => {
+  for (const [label, body] of RANGEERR_CASES) {
+    it(`${label} throws a RangeError instance (not a bare string)`, async () => {
+      const src = `
+        export function test(): number {
+          try { ${body} return 0; }
+          catch (e) { return e instanceof RangeError ? 1 : 2; }
+        }`;
+      expect(await runTest(src)).toBe(1);
+    });
+  }
+});


### PR DESCRIPTION
## #3477 — bare-string RangeError throws break authentic-harness `e instanceof RangeError`

### Problem

Several RangeError gates emitted a **bare string** via the shared `$exc` tag instead of a real `RangeError` **instance**:

```ts
then: [...stringConstantExternrefInstrs(ctx, rangeErrMsg), { op: "throw", tagIdx }]
```

Under the authentic oracle-v8 harness, `assert.throws(RangeError, fn)` checks `e instanceof RangeError` (constructor identity), so a bare string **fails → host FAIL**. This is the same `instanceof`-guard failure family that gave **#3422** a 313-flip win (bare-string strict-delete → real TypeError) and that **#3175** already fixed for the *dot-access* `Number.prototype.toString/toFixed` twins.

### Fix

Route every site through `buildThrowJsErrorInstrs(ctx, "RangeError", msg, { flush: fctx })` — the #3175/#3191 dual-mode real-instance builder in `src/codegen/js-errors.ts` (host: `__new_RangeError` import; standalone/wasi: in-module Wasm-native ctor, so no unsatisfiable host import — the #2029 sentinel concern is handled internally).

**`src/codegen/expressions/new-indexed.ts`** (7 sites — indexed built-in construction):
- `new ArrayBuffer(-1)` "Invalid array buffer length" (plain + resizable)
- resizable `maxByteLength < 0` / `byteLength > maxByteLength`
- `new DataView(buf, offset)` / `new DataView(buf, off, len)` OOB
- `new Array(-1)` / `new Array(2**32)` "Invalid array length"

**`src/codegen/expressions/call-tail-dispatch.ts`** (2 sites — computed-access `Number.prototype` methods, twins of the already-fixed dot-access sites in `call-receiver-method.ts`):
- `n["toString"](radix)` radix ∉ 2..36
- `n["toFixed"](digits)` digits ∉ 0..100

Removed the now-dead `addStringConstantGlobal` / `ensureExnTag` / `stringConstantExternrefInstrs` imports from both files (net −55/+161, the src files shrank).

### Verification

- `tsc --noEmit` clean; biome + prettier clean.
- `tests/issue-3477.test.ts` (4 cases): `new ArrayBuffer(-1)`, `new Array(-1)`, `(5)["toString"](40)`, `(5)["toFixed"](200)` each caught as a **RangeError instance** (`e instanceof RangeError` → 1), not a bare string (would be 2).

Strict correctness improvement — it cannot regress a passing test (any harness comparing the caught value to `RangeError` was already failing on the bare string). CI measures the authoritative host flip count.

Closes #3477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb