### PR TITLE
chore(issues): reopen 4 more false-done (#2717/#2620/#1907/#1888)

### DIFF
--- a/plan/issues/1888-openany-dispatch.md
+++ b/plan/issues/1888-openany-dispatch.md
@@ -1,7 +1,7 @@
 ---
 id: 1888
 title: "standalone open-any method dispatch + built-ins-as-static-globals (prototype vtable)"
-status: done
+status: ready
 pr: 1273
 created: 2026-06-05
 updated: 2026-06-11
@@ -983,3 +983,7 @@ Validation:
 
 PR #1273 remains the review vehicle; status stays `in-review` until the PR
 status poller marks it done after merge.
+
+## Reopened 2026-07-20 (stale false-done review)
+
+Marked `done` but live test262 shows: BigUint64Array built-in static property value read still unsupported (standalone). Reopened as `ready`. See #3474 (done-status integrity).

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,7 +1,7 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: done
+status: ready
 pr: 1292
 sprint: 61
 created: 2026-06-07
@@ -213,3 +213,7 @@ Runtime-side coercion counterpart: the ToPrimitive bucket under #1917.
 > wiring (D2) + dynamic-`new` brand-dispatch (D3) + `%TypedArray%` intrinsic
 > identity (D4, coordinates #2580 M3). This is the constructor-tier extension of
 > this issue's case-(c). See `plan/issues/2651-builtin-constructor-prototype-as-value-substrate.md`.
+
+## Reopened 2026-07-20 (stale false-done review)
+
+Marked `done` but live test262 shows: BigUint64Array built-in static property value read still unsupported (standalone). Reopened as `ready`. See #3474 (done-status integrity).

--- a/plan/issues/2620-standalone-extends-set-late-import-desync.md
+++ b/plan/issues/2620-standalone-extends-set-late-import-desync.md
@@ -1,7 +1,7 @@
 ---
 id: 2620
 title: "Standalone `class X extends Set/Map` — synthetic accessor late-import index-shift (-1 global) + host-import leak"
-status: done
+status: ready
 sprint: Backlog
 created: 2026-06-22
 completed: 2026-06-22
@@ -141,3 +141,7 @@ Test: `tests/issue-2620-extends-set-standalone-refusal.test.ts`.
 native iteration + `instanceof` discrimination) → the real +7
 subclass-receiver-methods rows. Value-rep / collection-runtime lane (#2162/#2580
 M2).
+
+## Reopened 2026-07-20 (stale false-done review)
+
+Marked `done` but live test262 shows: class extends WeakSet still 'not yet supported in --target standalone'. Reopened as `ready`. See #3474 (done-status integrity).

--- a/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
+++ b/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
@@ -1,7 +1,7 @@
 ---
 id: 2717
 title: "Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard"
-status: done
+status: ready
 sprint: 67
 created: 2026-06-26
 updated: 2026-06-26
@@ -78,3 +78,7 @@ host `flat()` → 4, `flatMap()` → 6 unchanged. Existing `flatmap-closure` /
 
 **Follow-up (not in scope):** a Wasm-native flat/flatMap arm (and the linear
 backend lowering) to turn the compile-error into compile+run in standalone.
+
+## Reopened 2026-07-20 (stale false-done review)
+
+Marked `done` but live test262 shows: Array.prototype.flatMap() still 'not yet supported in --target standalone'. Reopened as `ready`. See #3474 (done-status integrity).


### PR DESCRIPTION
Stale-content review follow-up to #3427. These were `status: done` but test262 still fails with explicit *'not yet supported in --target standalone'* refusals:
- #2717 Array `flatMap`, #2620 `class extends WeakSet`, #1907/#1888 BigUint64Array static reads → set `status: ready`.

**Audit-noise correction:** the earlier 'citation' counts over-flagged #221/#222/#223/#230/#258 — those `#NNNN` were **wasm function indices** in error strings (`Compiling function #221`), not issue refs; correctly left `done`. **#3474's gate must match the `(#NNNN)` citation format, not bare `#NNNN`.** Also flagged: #2043 shows a *regression* ('local index out of range') on a done architecture issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)