### PR TITLE
fix(#3479): class static methods answer hasOwnProperty via host proxy traps

### DIFF
--- a/plan/issues/3479-static-class-member-hasown-reflection.md
+++ b/plan/issues/3479-static-class-member-hasown-reflection.md
@@ -14,6 +14,12 @@ model: opus
 sprint: current
 horizon: m
 related: [3417, 1395, 1047, 1364]
+loc-budget-allow:
+  # +28 lines in the host runtime's _wrapForHost has/getOwnPropertyDescriptor
+  # traps to consult _staticMethodNames (Slice A). This IS the correct
+  # subsystem — the host proxy that materializes class objects lives here,
+  # alongside _wasmStructHasOwn / _readOwnDescriptor which it mirrors.
+  - src/runtime.ts
 ---
 
 # #3479 — static class members invisible to `hasOwnProperty` via the host proxy

--- a/plan/issues/3479-static-class-member-hasown-reflection.md
+++ b/plan/issues/3479-static-class-member-hasown-reflection.md
@@ -1,0 +1,132 @@
+---
+id: 3479
+title: "Host reflection: Object.prototype.hasOwnProperty.call(C, staticMember) misses class static members (verifyProperty own-property cluster, ~547 host fails)"
+status: done
+completed: 2026-07-20
+assignee: ttraenkler/senior-dev
+created: 2026-07-20
+priority: high
+feasibility: medium
+task_type: bugfix
+area: runtime
+goal: test262-conformance
+model: opus
+sprint: current
+horizon: m
+related: [3417, 1395, 1047, 1364]
+---
+
+# #3479 — static class members invisible to `hasOwnProperty` via the host proxy
+
+## Problem
+Under the oracle-v8 honest host harness, the `verifyProperty` corpus fails ~547
+host tests in the class-elements family with:
+- `obj should have an own property m` (312) — static **method** `m` on class `C`
+- `foo doesn't appear as an own property on the C constructor` (156) — static
+  **field** `foo` on `C`
+
+`propertyHelper.js` line 63 does
+`assert(__hasOwnProperty(obj, name), "obj should have an own property " + name)`
+where `__hasOwnProperty = Function.prototype.call.bind(Object.prototype.hasOwnProperty)`.
+That is the **`.call.bind` uncurried form**, and it is the exact shape that fails.
+
+## Root cause (verified on origin/main)
+Measured on a `class C { static m() {…} static foo = 7 }`:
+
+| reflective op | static method `m` | static field `foo` |
+| --- | --- | --- |
+| `"m" in C` (`__extern_has`) | ✓ | — |
+| `Object.getOwnPropertyDescriptor(C, k)` (value → `__getOwnPropertyDescriptor`) | ✓ | ✗ |
+| `Object.getOwnPropertyNames(C)` | ✓ | ✗ |
+| `Object.prototype.hasOwnProperty.call(C, k)` | **✗** | ✗ |
+| `C.hasOwnProperty(k)` (direct method call) | ✓ | ✗ |
+
+Two independent gaps:
+
+1. **`hasOwnProperty.call` misses static METHODS (312).** `Object.prototype.
+   hasOwnProperty.call(obj, key)` invokes `[[GetOwnProperty]]` — i.e. the
+   receiver's `getOwnPropertyDescriptor` trap. When `C` is marshalled to the
+   host it becomes a `_wrapForHost` **proxy**, but that proxy's
+   `getOwnPropertyDescriptor` trap (`src/runtime.ts` ~5627) and `has` trap
+   (~5590) do **not** consult `_staticMethodNames` / `_prototypeMethodNames`.
+   The canonical direct-import paths DO: `_readOwnDescriptor`
+   (`runtime.ts:4381`, used by `__getOwnPropertyDescriptor`) and
+   `_wasmStructHasOwn` (`runtime.ts:2748`, used by `__extern_has`) both handle
+   the static-method allowlist — which is why `in` / `Object.getOwnProperty*`
+   succeed while `hasOwnProperty.call` (routed through the proxy trap) fails.
+   NB: plain-object fields and prototype-method names DO work through the proxy
+   (they are struct fields / sidecar), so this is specific to the class
+   constructor's virtual static members — confirming ~547, not broader.
+
+2. **Static FIELDS have no reflection at all (156).** Static fields compile to
+   **module globals** (`class-bodies.ts:800` "Skip static properties — they
+   become module globals, not struct fields") and are registered nowhere the
+   reflective ops look. Only static *methods* get an allowlist
+   (`_staticMethodNames`, #1395); static *fields* have no analog, so `in` /
+   gOPD / getOwnPropertyNames / hasOwnProperty all miss them.
+
+This is a **host-runtime reflective-dispatch gap, not a class-codegen
+residual** — #1051/#1144/#1364 (static/private method fidelity) are all `done`;
+this is the untouched reflection surface behind them.
+
+## Implementation Plan
+**Slice A (static methods, ~312) — proxy-trap parity, contained:**
+- `src/runtime.ts` `_wrapForHost` **`has` trap** (~5594): after the deleted-prop
+  guard, additively return `true` for a `key` in `_prototypeMethodNames` or
+  `_staticMethodNames` (not tombstoned) — mirroring `_wasmStructHasOwn:2748`.
+- `_wrapForHost` **`getOwnPropertyDescriptor` trap** (~5627): near the top (after
+  the tombstone guard), for a `key` in `_staticMethodNames`/`_prototypeMethodNames`
+  delegate to `_readOwnDescriptor(obj, key, exports)` (returns the spec descriptor
+  `{writable:true, enumerable:false, configurable:true}` with the method bridge
+  value), mirror onto `target` for the Proxy invariant, and return it.
+- Purely additive (only answers for allowlisted class-method names previously
+  missed); preserves the #1047 instance-field-leak exclusion.
+
+**Slice B (static fields, ~156) — new registry:**
+- Register static-field names at class-object registration (analog of
+  `_staticMethodNames`; populate from `class-bodies.ts` static-field members +
+  the `__register_class_object` host import) into a `_staticFieldNames` WeakMap,
+  with the field VALUE resolvable (read the module global) for the descriptor
+  `value`. Consult it in `_readOwnDescriptor`, `_wasmStructHasOwn`, the proxy
+  traps, and the getOwnPropertyNames enumeration. Descriptor per spec: static
+  data field → `{writable:true, enumerable:true, configurable:true}`.
+
+## What this PR ships — Slice A (static methods, ~312)
+`src/runtime.ts` `_wrapForHost` proxy: the **`has`** trap (class-object branch)
+and **`getOwnPropertyDescriptor`** trap now consult `_staticMethodNames` and
+delegate to `_readOwnDescriptor`, so `Object.prototype.hasOwnProperty.call(C, "m")`
+(and the `.call.bind` form propertyHelper uses) answer for a class's static
+methods the same way `in` / `Object.getOwnPropertyDescriptor` already do.
+Purely additive (only answers for the static-method allowlist previously
+missed); proto-method and plain-object paths untouched. Regression test:
+`tests/issue-3479.test.ts`.
+
+Validated: `after-same-line-static-method-private-method-usage.js`,
+`regular-definitions-rs-static-method-privatename-identifier.js`,
+`new-sc-line-method-rs-static-method-privatename-identifier.js`,
+`after-same-line-static-method-private-names.js` now PASS; control
+verifyProperty tests on plain objects/builtins unchanged.
+
+## Remaining follow-ups (separate issues — NOT in this PR)
+- **Slice C (instance-field leak, ~156 "foo doesn't appear on the C
+  constructor")**: a class's INSTANCE field name (`foo = "x"`) wrongly reports
+  `true` from `hasOwnProperty(C, "foo")` — the constructor object exposes the
+  instance struct fields. #1047-family (marked done, residual on the
+  constructor object). The `*-rs-static-*` templates that combine a static
+  method + instance field fail here first. Fix: restrict the class-OBJECT proxy
+  traps to the static allowlist + sidecar, not instance struct fields.
+- **Slice B (static-field reflection)**: `static foo = 7` compiles to a module
+  global (`class-bodies.ts:800`) with no reflection registry; `in`/gOPD/names/
+  hasOwnProperty all miss it. Needs a `_staticFieldNames` registry analog to
+  `_staticMethodNames`.
+
+## Verification
+- Scoped: static-method class-elements templates pass; `hasOwnProperty.call(C, "m")`
+  returns true. Zero-regression on the passing verifyProperty corpus (plain
+  objects, prototype methods) — full CI validates the shared host proxy.
+
+## Notes
+Filed from the #3417 host-fail triage (`plan/log/host-fail-triage-2026-07-20.md`,
+cluster #5). Prize bounded to ~547 by breadth probe (plain-object/prototype
+`hasOwnProperty.call` already works). This PR is Slice A (~312 static-method
+sub-cluster); Slices B/C above cover the rest.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5591,6 +5591,13 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
       // #1364b — class object: a deleted static-method name must not appear in
       // `obj.method in C` checks anymore.
       if (typeof key === "string" && _isDeletedClassProp(obj, key)) return false;
+      // (#3479) Registered class-OBJECT static method — the host proxy must
+      // answer `"m" in C` / GetOwnProperty for static methods the same way the
+      // direct `__extern_has` path (_wasmStructHasOwn:2748) already does via the
+      // allowlist. Without this, `Object.prototype.hasOwnProperty.call(C, "m")`
+      // (the `.call.bind` form propertyHelper uses) misses static methods.
+      const staticMethods = _staticMethodNames.get(obj);
+      if (staticMethods !== undefined && typeof key === "string" && staticMethods.includes(key)) return true;
       if (safeGetField(key) !== undefined) return true;
       const sc = _wasmStructProps.get(obj);
       if (sc && key in sc) return true;
@@ -5630,6 +5637,27 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
       // reflection operation. Do not let the host proxy resurrect it during
       // Object.assign/object spread enumeration.
       if (isTombstoned(key)) return undefined;
+      // (#3479) Registered class-OBJECT static method — return the spec
+      // descriptor the direct `__getOwnPropertyDescriptor` path already produces
+      // (_readOwnDescriptor:4381 → {writable:true, enumerable:false,
+      // configurable:true} with the static-method bridge value). `[[GetOwnProperty]]`
+      // is what `Object.prototype.hasOwnProperty.call(C, "m")` (propertyHelper's
+      // `.call.bind` form) invokes, so without this the host proxy reports static
+      // methods absent even though `in` / `Object.getOwnPropertyDescriptor` see them.
+      if (typeof key === "string" && !_isDeletedClassProp(obj, key)) {
+        const staticMethods = _staticMethodNames.get(obj);
+        if (staticMethods !== undefined && staticMethods.includes(key)) {
+          const cd = _readOwnDescriptor(obj, key, exports);
+          if (cd !== undefined) {
+            try {
+              Object.defineProperty(target, key, cd);
+            } catch {
+              /* already defined with different flags — ignore */
+            }
+            return cd;
+          }
+        }
+      }
       // For Proxy invariants, getOwnPropertyDescriptor must match target's
       // non-configurable keys. Our target is an empty extensible object, so
       // we can return any descriptor we like. We must also reflect the

--- a/tests/issue-3479.test.ts
+++ b/tests/issue-3479.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+// #3479 — a class's static method must be a real own property of the constructor
+// visible to the reflective host operations, INCLUDING the uncurried
+// `Object.prototype.hasOwnProperty.call(C, "m")` form (propertyHelper.js's
+// `__hasOwnProperty = Function.prototype.call.bind(Object.prototype.hasOwnProperty)`).
+// Before the fix, the `_wrapForHost` proxy's has/getOwnPropertyDescriptor traps
+// did not consult `_staticMethodNames`, so `hasOwnProperty.call(C, "m")` was
+// false even though `"m" in C` and `Object.getOwnPropertyDescriptor(C, "m")` were true.
+describe("#3479 static class method own-property reflection via hasOwnProperty.call", () => {
+  it("hasOwnProperty.call(C, staticMethod) is true", async () => {
+    const src = `
+      class C { static m() { return 42; } }
+      export function test(): number {
+        return Object.prototype.hasOwnProperty.call(C, "m") ? 1 : 0;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("the .call.bind uncurried form (propertyHelper shape) is true", async () => {
+    const src = `
+      class C { static m() { return 42; } }
+      export function test(): number {
+        const __hasOwn: any = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+        return __hasOwn(C, "m") ? 1 : 0;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("getOwnPropertyDescriptor(C, staticMethod) has spec flags {w:true,e:false,c:true}", async () => {
+    const src = `
+      class C { static m() { return 42; } }
+      export function test(): number {
+        const d: any = Object.getOwnPropertyDescriptor(C, "m");
+        if (!d) return 0;
+        return (d.writable === true && d.enumerable === false && d.configurable === true) ? 1 : 0;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("does not fabricate an own property for an absent static method name", async () => {
+    const src = `
+      class C { static m() { return 42; } }
+      export function test(): number {
+        return Object.prototype.hasOwnProperty.call(C, "nope") ? 1 : 0;
+      }
+    `;
+    expect(await run(src)).toBe(0);
+  });
+
+  it("in / hasOwnProperty / getOwnPropertyDescriptor agree for a static method", async () => {
+    const src = `
+      class C { static m() { return 42; } }
+      export function test(): number {
+        const a = ("m" in C) ? 1 : 0;
+        const b = Object.prototype.hasOwnProperty.call(C, "m") ? 1 : 0;
+        const c = Object.getOwnPropertyDescriptor(C, "m") ? 1 : 0;
+        return a + b + c; // expect 3 — all agree
+      }
+    `;
+    expect(await run(src)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem
Under the oracle-v8 honest host harness, ~547 `verifyProperty` class-elements tests fail. The static-**method** sub-cluster (~312, `obj should have an own property m`) is caused by `Object.prototype.hasOwnProperty.call(C, "m")` — the `.call.bind` uncurried form propertyHelper's `__hasOwnProperty` uses — reporting a class static method **absent**, even though `"m" in C` and `Object.getOwnPropertyDescriptor(C, "m")` already see it.

## Root cause
`hasOwnProperty.call(obj, key)` invokes `[[GetOwnProperty]]` — the receiver's `getOwnPropertyDescriptor` trap. When `C` is marshalled to the host it becomes a `_wrapForHost` proxy, but that proxy's `getOwnPropertyDescriptor` trap (and `has` trap) did **not** consult `_staticMethodNames`. The direct-import paths do: `_readOwnDescriptor` (used by `__getOwnPropertyDescriptor`) and `_wasmStructHasOwn` (used by `__extern_has`) — hence the divergence.

## Fix (Slice A, static methods)
`src/runtime.ts` `_wrapForHost`: the `has` and `getOwnPropertyDescriptor` traps now consult `_staticMethodNames`, delegating gOPD to `_readOwnDescriptor` for the spec descriptor `{writable:true, enumerable:false, configurable:true}`. Purely additive — proto-method and plain-object paths untouched.

## Validation
- `tests/issue-3479.test.ts` (5 cases) pass.
- Scoped test262: `after-same-line-static-method-private-method-usage.js`, `regular-definitions-rs-static-method-privatename-identifier.js`, `new-sc-line-method-rs-static-method-privatename-identifier.js`, `after-same-line-static-method-private-names.js` now PASS.
- Regression guard: `hasownproperty-call`, `issue-1364a/b-class-method-*`, `define-property-patterns` all pass; plain-object/builtin verifyProperty controls unchanged.

## Scope
Slice A of the #3479 cluster. Slices **B** (static-field reflection) and **C** (instance-field leak onto the constructor, #1047-family — the `foo doesn't appear on the C constructor` ~156 sub-cluster) are documented as separate follow-ups in the issue.

From the #3417 host-fail triage (`plan/log/host-fail-triage-2026-07-20.md`, cluster #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb