### PR TITLE
chore(sprint-73): add bounded standalone false-dones to current sprint

### DIFF
--- a/plan/issues/1888-openany-dispatch.md
+++ b/plan/issues/1888-openany-dispatch.md
@@ -13,7 +13,7 @@ task_type: feat
 area: codegen, runtime
 language_feature: objects, prototype chain, method dispatch, built-ins
 goal: host-independence
-sprint: 61
+sprint: current
 related: [1472, 2177, 1629, 1104, 1539, 1103]
 parent: 1472
 claimed_by: codex-developer

--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -3,7 +3,7 @@ id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
 status: ready
 pr: 1292
-sprint: 61
+sprint: current
 created: 2026-06-07
 updated: 2026-06-10
 completed: 2026-06-10

--- a/plan/issues/2620-standalone-extends-set-late-import-desync.md
+++ b/plan/issues/2620-standalone-extends-set-late-import-desync.md
@@ -2,7 +2,7 @@
 id: 2620
 title: "Standalone `class X extends Set/Map` — synthetic accessor late-import index-shift (-1 global) + host-import leak"
 status: ready
-sprint: Backlog
+sprint: current
 created: 2026-06-22
 completed: 2026-06-22
 assignee: sendev-flatten

--- a/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
+++ b/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
@@ -2,7 +2,7 @@
 id: 2717
 title: "Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard"
 status: ready
-sprint: 67
+sprint: current
 created: 2026-06-26
 updated: 2026-06-26
 completed: 2026-06-26


### PR DESCRIPTION
Adds the 4 bounded standalone false-done issues (reopened in #3434) to the active sprint via `sprint: current`:
- #2717 Array `flatMap`, #2620 `class extends WeakSet`, #1907/#1888 BigUint64Array static reads.

Existing priorities kept (#1907 critical, #2717/#1888 high, #2620 medium). #1472 (Proxy, large/frontier), #2026, #680 left for separate scheduling per stakeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)