### PR TITLE
fix(ir): resolve JavaScript JSDoc landing signatures

### DIFF
--- a/plan/issues/3497-linear-jsdoc-landing-signatures.md
+++ b/plan/issues/3497-linear-jsdoc-landing-signatures.md
@@ -1,0 +1,164 @@
+---
+id: 3497
+title: "Resolve exact-source JSDoc signatures for the linear IR landing benchmarks"
+status: in-progress
+sprint: current
+created: 2026-07-20
+updated: 2026-07-20
+priority: high
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ir, codegen-linear, benchmarking
+language_feature: jsdoc-function-signatures
+es_edition: multi
+goal: backend-agnostic-ir
+depends_on: []
+related: [2949, 2956, 3498]
+origin: "2026-07-20 explicit user request: unblock the exact landing benchmark JavaScript sources without source rewriting"
+files:
+  - src/ir/select.ts
+  - src/ir/from-ast.ts
+  - tests/issue-3497-linear-jsdoc-landing-signatures.test.ts
+---
+
+# #3497 — Exact-source JSDoc signatures for linear IR landing benchmarks
+
+## Problem
+
+The four checked-in landing programs are ordinary JavaScript files whose
+exported `run` functions use standard `@param {number}` and
+`@returns {number}` JSDoc annotations. Compiling the exact bytes with
+`target: "linear"` and `allocator: "analysis-stack"` currently selects no IR
+functions. Each annotated `run` is rejected as
+`select:return-type-not-resolvable`.
+
+The recursive program also contains an unannotated local `fib(n)`. Its type can
+only become concrete through call-graph/body propagation from the annotated
+export. `string-hash` has separate unsupported `.charAt()` / `.charCodeAt()`
+lowering after signature selection; those methods are explicitly outside this
+issue.
+
+## Reproduction on current main
+
+Verified against `origin/main` `4b6cccfe8c79278093313fbb8efef3253f089e67`
+with each source read directly from
+`website/public/benchmarks/competitive/programs/<name>.js` and passed to:
+
+```ts
+compile(source, {
+  target: "linear",
+  allocator: "analysis-stack",
+  fileName: exactPath,
+});
+```
+
+| Program         | IR compiled | Selector rejection(s)                         | Compile result |
+| --------------- | ----------- | --------------------------------------------- | -------------- |
+| `fib`           | none        | `run: return-type-not-resolvable`             | success        |
+| `fib-recursive` | none        | `fib`, `run: return-type-not-resolvable`      | success        |
+| `array-sum`     | none        | `run: return-type-not-resolvable`             | success        |
+| `string-hash`   | none        | `run: return-type-not-resolvable`             | string methods unsupported |
+
+## Root cause
+
+TypeScript represents a JavaScript JSDoc signature through its effective type
+annotation APIs/checker facts; it does not populate
+`ParameterDeclaration.type` or `FunctionDeclaration.type`. The checker-backed
+`buildTypeMap` used by the WasmGC overlay therefore sees these annotations, but
+the linear selector path calls `planIrCompilation` without that map.
+
+At the final selector/build boundary, both `src/ir/select.ts` and the shared
+AST-to-IR signature resolver in `src/ir/from-ast.ts` inspect only the raw
+`.type` properties. A standard JSDoc primitive consequently looks exactly like
+an unannotated dynamic signature and is rejected before IR lowering.
+
+## Implementation plan
+
+1. Centralize effective parameter/return type-node lookup at the selector
+   boundary using TypeScript's own effective annotation APIs. Prefer explicit
+   TypeScript syntax and accept only the same primitive/function-type nodes the
+   selector already accepts.
+2. Reuse that lookup in the shared AST-to-IR signature resolver so a function
+   selected from JSDoc receives the same IR parameter/result types during
+   lowering. Do not parse comment text, synthesize annotations, rewrite source,
+   or special-case benchmark paths/names.
+3. Preserve the existing `any`/dynamic move-only gate and rejection of
+   unsupported union/non-primitive signatures.
+4. Add focused JavaScript/JSDoc selector and exact-source linear compile tests,
+   including a negative unannotated dynamic case.
+5. Probe all four exact landing files and record the post-fix selection/build
+   matrix. The string-method failures remain expected and out of scope.
+
+## Acceptance criteria
+
+- [x] Exact `fib.js` selects and IR-compiles its annotated `run` export.
+- [x] Every annotated landing `run` stops failing with
+      `select:return-type-not-resolvable`.
+- [x] Standard JSDoc `number`, `boolean`, and `string` signatures resolve
+      without source rewriting or filename/function-name special cases.
+- [x] Explicit/dynamic `any`, unannotated dynamic operations, unions, and
+      unsupported non-primitive signatures are not widened into primitive IR
+      claims.
+- [x] `fib-recursive` is reported honestly; infer its internal `fib` only when
+      the existing call-graph/type evidence makes that safe.
+- [x] Focused tests, typecheck, lint, and format checks pass; no local Test262
+      run is performed.
+
+## Test results
+
+- `pnpm exec vitest run tests/issue-3497-linear-jsdoc-landing-signatures.test.ts`
+  — 6/6 passed.
+- `pnpm exec vitest run tests/issue-2859.test.ts tests/issue-2949-slice3b-any-dynamic.test.ts tests/linear-integration.test.ts`
+  — 19/19 passed.
+- `tests/issue-1169q.test.ts` — 9/10 passed on both this branch and unchanged
+  `origin/main`; the pre-existing async telemetry assertion expects
+  `non-export-modifier` although current main reports `async-function`.
+- `pnpm run typecheck` — passed.
+- `pnpm run lint` — passed.
+- `pnpm run format:check` — passed.
+- `pnpm run check:ir-fallbacks` — passed with no baseline delta.
+- `pnpm run check:linear-ir` — passed (`compiled=8`, baseline `8`; no baseline
+  update required).
+- No local Test262 run, per scope.
+
+### Post-fix exact-source matrix
+
+| Program         | IR compiled | IR rejection(s) | Compile result |
+| --------------- | ----------- | --------------- | -------------- |
+| `fib`           | `run`       | none            | success; `run(10) === 55` |
+| `fib-recursive` | none        | `fib: select:return-type-not-resolvable`; `run: select:call-graph-closure` | success through direct fallback |
+| `array-sum`     | none        | `run: build` (`empty array literal needs a vec-typed hint`) | success through direct fallback |
+| `string-hash`   | none        | `run: build` (string compound-assignment representation) | expected direct-path `.charAt()` / `.charCodeAt()` errors |
+
+Every annotated `run` now passes the selector's signature gate. The latter
+three rows expose independent, explicitly out-of-scope body/lowering gaps
+rather than losing the JSDoc signature.
+
+The internal recursive `fib` remains conservative. TypeScript's checker/oracle
+reports its unannotated recursive signature as `any -> any`; inferring `f64`
+there would require threading the existing checker-backed `TypeMap` into the
+linear selector/build driver. That driver is outside this issue's ownership,
+so this change does not guess a primitive type or create a second propagation
+engine.
+
+## Implementation summary
+
+- Added one shared effective-signature lookup in `src/ir/select.ts` using
+  TypeScript's `getEffectiveTypeAnnotationNode` and
+  `getEffectiveReturnTypeNode` APIs. These APIs preserve ordinary TypeScript
+  annotations and expose standard JavaScript JSDoc without parsing comments or
+  mutating the AST.
+- Routed the selector's existing primitive/object/dynamic classification
+  through the effective nodes. Existing `any`, union, and unsupported type
+  handling remains unchanged.
+- Reused the same lookup at the narrow signature boundary in
+  `src/ir/from-ast.ts`, ensuring a selected JSDoc function is built with the
+  same parameter/result types.
+- Added focused selector, linear-builder, exact-source, behavior, and negative
+  dynamic/union tests in
+  `tests/issue-3497-linear-jsdoc-landing-signatures.test.ts`.
+
+No benchmark source, runner, backend adapter, workflow, package script,
+website file, fallback baseline, or #3498 artifact changed.

--- a/plan/issues/3497-linear-jsdoc-landing-signatures.md
+++ b/plan/issues/3497-linear-jsdoc-landing-signatures.md
@@ -1,10 +1,11 @@
 ---
 id: 3497
 title: "Resolve exact-source JSDoc signatures for the linear IR landing benchmarks"
-status: in-progress
+status: in-review
 sprint: current
 created: 2026-07-20
 updated: 2026-07-20
+pr: 3446
 priority: high
 horizon: s
 feasibility: medium
@@ -162,3 +163,5 @@ engine.
 
 No benchmark source, runner, backend adapter, workflow, package script,
 website file, fallback baseline, or #3498 artifact changed.
+
+Implementation PR: https://github.com/loopdive/js2/pull/3446

--- a/plan/issues/3497-linear-jsdoc-landing-signatures.md
+++ b/plan/issues/3497-linear-jsdoc-landing-signatures.md
@@ -22,6 +22,9 @@ files:
   - src/ir/select.ts
   - src/ir/from-ast.ts
   - tests/issue-3497-linear-jsdoc-landing-signatures.test.ts
+loc-budget-allow:
+  - src/ir/select.ts
+  - src/ir/from-ast.ts
 ---
 
 # #3497 — Exact-source JSDoc signatures for linear IR landing benchmarks

--- a/plan/issues/3497-linear-jsdoc-landing-signatures.md
+++ b/plan/issues/3497-linear-jsdoc-landing-signatures.md
@@ -77,10 +77,9 @@ an unannotated dynamic signature and is rejected before IR lowering.
 
 ## Implementation plan
 
-1. Centralize effective parameter/return type-node lookup at the selector
-   boundary using TypeScript's own effective annotation APIs. Prefer explicit
-   TypeScript syntax and accept only the same primitive/function-type nodes the
-   selector already accepts.
+1. Centralize parameter/return type-node lookup at the selector boundary using
+   TypeScript's public JSDoc APIs. Prefer explicit TypeScript syntax and accept
+   only the same primitive/function-type nodes the selector already accepts.
 2. Reuse that lookup in the shared AST-to-IR signature resolver so a function
    selected from JSDoc receives the same IR parameter/result types during
    lowering. Do not parse comment text, synthesize annotations, rewrite source,
@@ -108,6 +107,12 @@ an unannotated dynamic signature and is rejected before IR lowering.
       run is performed.
 
 ## Test results
+
+CI initially exposed that TypeScript's public declarations do not include the
+internal `getEffectiveTypeAnnotationNode` / `getEffectiveReturnTypeNode`
+helpers. The fix-forward uses `param.type ?? ts.getJSDocType(param)` and
+`fn.type ?? ts.getJSDocReturnType(fn)`, preserving explicit annotation
+precedence and the tested selector behavior.
 
 - `pnpm exec vitest run tests/issue-3497-linear-jsdoc-landing-signatures.test.ts`
   — 6/6 passed.
@@ -146,11 +151,10 @@ engine.
 
 ## Implementation summary
 
-- Added one shared effective-signature lookup in `src/ir/select.ts` using
-  TypeScript's `getEffectiveTypeAnnotationNode` and
-  `getEffectiveReturnTypeNode` APIs. These APIs preserve ordinary TypeScript
-  annotations and expose standard JavaScript JSDoc without parsing comments or
-  mutating the AST.
+- Added one shared effective-signature lookup in `src/ir/select.ts`, preferring
+  ordinary TypeScript annotation nodes and falling back to TypeScript's public
+  `getJSDocType` / `getJSDocReturnType` APIs. This exposes standard JavaScript
+  JSDoc without parsing comments or mutating the AST.
 - Routed the selector's existing primitive/object/dynamic classification
   through the effective nodes. Existing `any`, union, and unsupported type
   handling remains unchanged.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -55,7 +55,7 @@ import {
   stringIndexProvenBelow,
 } from "./capability.js";
 import type { IrLowerResolver, IrVecLowering } from "./lower.js";
-import { mathUnaryToIrOp } from "./select.js";
+import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode, mathUnaryToIrOp } from "./select.js";
 import { JsTag } from "./js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
 import {
   asVal,
@@ -578,8 +578,12 @@ export function lowerFunctionAstToIr(
     !isCtor &&
     ts.isFunctionDeclaration(fn) &&
     !!fn.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword);
-  const asyncUnwrappedReturn = isAsync ? unwrapPromiseTypeNode(fn.type) : null;
-  const effectiveReturnTypeNode = isAsync ? (asyncUnwrappedReturn ?? undefined) : fn.type;
+  const declaredReturnTypeNode =
+    ts.isFunctionDeclaration(fn) || ts.isMethodDeclaration(fn) || ts.isGetAccessorDeclaration(fn)
+      ? effectiveIrReturnTypeNode(fn)
+      : undefined;
+  const asyncUnwrappedReturn = isAsync ? unwrapPromiseTypeNode(declaredReturnTypeNode) : null;
+  const effectiveReturnTypeNode = isAsync ? (asyncUnwrappedReturn ?? undefined) : declaredReturnTypeNode;
   const isVoidReturn =
     !isGenerator &&
     !isCtor &&
@@ -606,7 +610,7 @@ export function lowerFunctionAstToIr(
     if (ts.isObjectBindingPattern(p.name) || ts.isArrayBindingPattern(p.name)) {
       return {
         name: `__pattern_param_${idx}`,
-        type: resolveIrType(p.type, override, `pattern param #${idx} of ${name}`),
+        type: resolveIrType(effectiveIrParamTypeNode(p), override, `pattern param #${idx} of ${name}`),
       };
     }
     if (!ts.isIdentifier(p.name)) {
@@ -625,7 +629,7 @@ export function lowerFunctionAstToIr(
     }
     return {
       name: p.name.text,
-      type: resolveIrType(p.type, override, `param ${p.name.text} of ${name}`),
+      type: resolveIrType(effectiveIrParamTypeNode(p), override, `param ${p.name.text} of ${name}`),
     };
   });
 

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1248,14 +1248,13 @@ type ResolvedKind = "f64" | "bool" | "string" | "object" | "void" | "closure" | 
  *
  * For TypeScript this is the ordinary `param.type`. For JavaScript, the TS
  * parser/checker boundary exposes a standard `@param {T}` annotation through
- * `getEffectiveTypeAnnotationNode` while deliberately leaving `param.type`
- * unset. Keeping this lookup in one helper prevents the selector and the
- * shared AST-to-IR signature resolver from disagreeing about the same source
- * declaration. No comment text is parsed and no synthetic annotation is
- * attached to the AST.
+ * `getJSDocType` while deliberately leaving `param.type` unset. Keeping this
+ * lookup in one helper prevents the selector and the shared AST-to-IR
+ * signature resolver from disagreeing about the same source declaration. No
+ * comment text is parsed and no synthetic annotation is attached to the AST.
  */
 export function effectiveIrParamTypeNode(param: ts.ParameterDeclaration): ts.TypeNode | undefined {
-  return ts.getEffectiveTypeAnnotationNode(param);
+  return param.type ?? ts.getJSDocType(param);
 }
 
 /**
@@ -1269,7 +1268,7 @@ export function effectiveIrParamTypeNode(param: ts.ParameterDeclaration): ts.Typ
 export function effectiveIrReturnTypeNode(
   fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
 ): ts.TypeNode | undefined {
-  return ts.getEffectiveReturnTypeNode(fn);
+  return fn.type ?? ts.getJSDocReturnType(fn);
 }
 
 /**

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -1244,6 +1244,35 @@ function isIrClaimable(
 type ResolvedKind = "f64" | "bool" | "string" | "object" | "void" | "closure" | "dynamic" | null;
 
 /**
+ * Return the declaration's effective parameter type node.
+ *
+ * For TypeScript this is the ordinary `param.type`. For JavaScript, the TS
+ * parser/checker boundary exposes a standard `@param {T}` annotation through
+ * `getEffectiveTypeAnnotationNode` while deliberately leaving `param.type`
+ * unset. Keeping this lookup in one helper prevents the selector and the
+ * shared AST-to-IR signature resolver from disagreeing about the same source
+ * declaration. No comment text is parsed and no synthetic annotation is
+ * attached to the AST.
+ */
+export function effectiveIrParamTypeNode(param: ts.ParameterDeclaration): ts.TypeNode | undefined {
+  return ts.getEffectiveTypeAnnotationNode(param);
+}
+
+/**
+ * Return the declaration's effective return type node, including a JavaScript
+ * JSDoc `@returns {T}` annotation when present.
+ *
+ * The caller still applies the existing narrow primitive/object/dynamic
+ * mapping. In particular, this helper does not turn an unannotated, `any`,
+ * union, or otherwise unsupported signature into a primitive claim.
+ */
+export function effectiveIrReturnTypeNode(
+  fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
+): ts.TypeNode | undefined {
+  return ts.getEffectiveReturnTypeNode(fn);
+}
+
+/**
  * #2859 — build an `IrClosureSignature` from an explicit function-type
  * annotation (`(a: number, b: string) => number`), or return `null` when the
  * annotation is outside the expressible surface. The primitive mapping MUST
@@ -1279,10 +1308,11 @@ export function irClosureSignatureFromFunctionTypeNode(node: ts.FunctionTypeNode
 }
 
 function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | undefined): ResolvedKind {
-  if (p.type) {
-    if (p.type.kind === ts.SyntaxKind.NumberKeyword) return "f64";
-    if (p.type.kind === ts.SyntaxKind.BooleanKeyword) return "bool";
-    if (p.type.kind === ts.SyntaxKind.StringKeyword) return "string";
+  const effectiveType = effectiveIrParamTypeNode(p);
+  if (effectiveType) {
+    if (effectiveType.kind === ts.SyntaxKind.NumberKeyword) return "f64";
+    if (effectiveType.kind === ts.SyntaxKind.BooleanKeyword) return "bool";
+    if (effectiveType.kind === ts.SyntaxKind.StringKeyword) return "string";
     // (#2949 slice 3b) `any` IS the dynamic type. The historical #1228
     // mapping ("any" kind → externref override) claimed EVERY any-param
     // function unconditionally and relied on from-ast throwing for
@@ -1292,13 +1322,13 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
     // routes any-params through the SAME move-only scan + carrier as
     // unannotated dynamics: non-move uses now reject PRE-claim (no
     // demotion), and the claimed ones share legacy's ABI in both modes.
-    if (p.type.kind === ts.SyntaxKind.AnyKeyword) return "dynamic";
+    if (effectiveType.kind === ts.SyntaxKind.AnyKeyword) return "dynamic";
     // #2859 — function-typed param (`fn: () => number`). Accepted when the
     // signature is expressible with the slice-3 closure surface; the param
     // lowers to the closure supertype struct and `fn()` dispatches through
     // `lowerClosureCall`. Inexpressible function types stay rejected.
-    if (ts.isFunctionTypeNode(p.type)) {
-      return irClosureSignatureFromFunctionTypeNode(p.type) ? "closure" : null;
+    if (ts.isFunctionTypeNode(effectiveType)) {
+      return irClosureSignatureFromFunctionTypeNode(effectiveType) ? "closure" : null;
     }
     // Slice 2 (#1169b) — accept TypeLiteral / TypeReference at the
     // selector level. The actual shape resolution happens in
@@ -1311,7 +1341,12 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
     // Slice 6 part 2 (#1181) — accept ArrayTypeNode (`T[]`) too.
     // `Array<T>` already resolves via TypeReferenceNode. Both shapes
     // route to a vec ref in `resolvePositionType`.
-    if (ts.isTypeLiteralNode(p.type) || ts.isTypeReferenceNode(p.type) || ts.isArrayTypeNode(p.type)) return "object";
+    if (
+      ts.isTypeLiteralNode(effectiveType) ||
+      ts.isTypeReferenceNode(effectiveType) ||
+      ts.isArrayTypeNode(effectiveType)
+    )
+      return "object";
     return null;
   }
   if (mapped?.kind === "f64") return "f64";
@@ -1357,8 +1392,9 @@ function resolveReturnType(
   fn: ts.FunctionDeclaration | ts.MethodDeclaration | ts.GetAccessorDeclaration,
   mapped: LatticeType | undefined,
 ): ResolvedKind {
-  if (fn.type) {
-    return resolveReturnTypeNode(fn.type);
+  const effectiveType = effectiveIrReturnTypeNode(fn);
+  if (effectiveType) {
+    return resolveReturnTypeNode(effectiveType);
   }
   if (mapped?.kind === "f64") return "f64";
   if (mapped?.kind === "bool") return "bool";

--- a/tests/issue-3497-linear-jsdoc-landing-signatures.test.ts
+++ b/tests/issue-3497-linear-jsdoc-landing-signatures.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3497 — JavaScript JSDoc signatures must reach the shared IR selector and
+// AST-to-IR builder without rewriting the source into TypeScript.
+
+import { readFileSync } from "node:fs";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { getLastLinearIrReport } from "../src/ir/backend/linear-integration.js";
+import { planIrCompilation } from "../src/ir/select.js";
+
+const LANDING_ROOT = "website/public/benchmarks/competitive/programs";
+const LANDING_PROGRAMS = ["fib", "fib-recursive", "array-sum", "string-hash"] as const;
+
+function selectJavaScript(source: string) {
+  const sourceFile = ts.createSourceFile("issue-3497.js", source, ts.ScriptTarget.ES2022, true, ts.ScriptKind.JS);
+  return planIrCompilation(sourceFile, { experimentalIR: true, trackFallbacks: true });
+}
+
+function fallbackReason(source: string, name: string): string | undefined {
+  return selectJavaScript(source).fallbacks?.find((fallback) => fallback.name === name)?.reason;
+}
+
+describe("#3497 — TypeScript-effective JSDoc signatures", () => {
+  it("claims standard JavaScript number, boolean, and string signatures", () => {
+    const selection = selectJavaScript(`
+      /** @param {number} value @returns {number} */
+      export function numberIdentity(value) { return value; }
+
+      /** @param {boolean} value @returns {boolean} */
+      export function booleanIdentity(value) { return value; }
+
+      /** @param {string} value @returns {string} */
+      export function stringIdentity(value) { return value; }
+    `);
+
+    expect([...selection.funcs].sort()).toEqual(["booleanIdentity", "numberIdentity", "stringIdentity"]);
+    expect(selection.fallbacks).toEqual([]);
+  });
+
+  it("lowers those effective primitive signatures through the linear IR builder", async () => {
+    const result = await compile(
+      `
+        /** @param {number} value @returns {number} */
+        export function numberIdentity(value) { return value; }
+
+        /** @param {boolean} value @returns {boolean} */
+        export function booleanIdentity(value) { return value; }
+
+        /** @param {string} value @returns {string} */
+        export function stringIdentity(value) { return value; }
+      `,
+      { fileName: "issue-3497.js", target: "linear", allocator: "analysis-stack" },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(getLastLinearIrReport()?.compiled).toEqual(["numberIdentity", "booleanIdentity", "stringIdentity"]);
+    expect(getLastLinearIrReport()?.rejected).toEqual([]);
+  });
+
+  it("keeps unannotated and any-valued operations on the dynamic rejection path", () => {
+    const unannotated = `export function dynamicAdd(value) { return value + 1; }`;
+    const explicitAny = `
+      /** @param {any} value @returns {any} */
+      export function dynamicAdd(value) { return value + 1; }
+    `;
+
+    expect(selectJavaScript(unannotated).funcs.has("dynamicAdd")).toBe(false);
+    expect(fallbackReason(unannotated, "dynamicAdd")).toBe("return-type-not-resolvable");
+    expect(selectJavaScript(explicitAny).funcs.has("dynamicAdd")).toBe(false);
+    expect(fallbackReason(explicitAny, "dynamicAdd")).toBe("param-type-not-resolvable");
+  });
+
+  it("does not reinterpret JSDoc unions as primitive signatures", () => {
+    const source = `
+      /** @param {number|string} value @returns {number|string} */
+      export function unionIdentity(value) { return value; }
+    `;
+
+    expect(selectJavaScript(source).funcs.has("unionIdentity")).toBe(false);
+    expect(fallbackReason(source, "unionIdentity")).toBe("return-type-not-resolvable");
+  });
+});
+
+describe("#3497 — exact landing benchmark sources", () => {
+  it("IR-compiles the exact fib.js run export and preserves behavior", async () => {
+    const path = `${LANDING_ROOT}/fib.js`;
+    const result = await compile(readFileSync(path, "utf8"), {
+      target: "linear",
+      allocator: "analysis-stack",
+      fileName: path,
+    });
+    const report = getLastLinearIrReport();
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(report?.compiled).toContain("run");
+    expect(report?.rejected.find((rejection) => rejection.func === "run")).toBeUndefined();
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+    expect((instance.exports.run as (n: number) => number)(10)).toBe(55);
+  });
+
+  it("removes return-type-not-resolvable from every annotated landing export", async () => {
+    for (const program of LANDING_PROGRAMS) {
+      const path = `${LANDING_ROOT}/${program}.js`;
+      await compile(readFileSync(path, "utf8"), {
+        target: "linear",
+        allocator: "analysis-stack",
+        fileName: path,
+      });
+      const runRejection = getLastLinearIrReport()?.rejected.find((rejection) => rejection.func === "run");
+
+      expect(runRejection?.reason, `${program}: ${runRejection?.detail ?? "no detail"}`).not.toBe(
+        "select:return-type-not-resolvable",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- resolve standard JavaScript JSDoc primitive signatures through TypeScript effective annotation nodes in the IR selector
- reuse the same signature boundary in shared AST-to-IR lowering without rewriting source or special-casing benchmark names
- preserve conservative unannotated, any, union, and unsupported-type rejection
- add exact-source landing probes and focused negative tests for plan issue #3497

## Exact landing matrix

- fib: run IR-compiled; run(10) = 55
- fib-recursive: annotated run passes signature selection, then remains closed with the unannotated local fib
- array-sum: annotated run passes selection, then reaches the existing empty-array element inference gap
- string-hash: annotated run passes selection, then reaches the existing string lowering and charAt/charCodeAt gaps

## Validation

- pnpm exec vitest run tests/issue-3497-linear-jsdoc-landing-signatures.test.ts (6/6)
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm run check:ir-fallbacks (no delta)
- pnpm run check:linear-ir (compiled 8, baseline 8)

No local Test262 run. No benchmark runner, website, Porffor adapter, package script, workflow, fallback baseline, or #3498 artifact changed.