### PR TITLE
feat(#3481): host BigInt binop delegation for wrapper coercion (prereq for #3328 flip)

### DIFF
--- a/plan/issues/3481-bigint-symbol-coercion-value-rep.md
+++ b/plan/issues/3481-bigint-symbol-coercion-value-rep.md
@@ -14,6 +14,9 @@ model: opus
 sprint: current
 horizon: xl
 related: [3422, 3328]
+loc-budget-allow:
+  - src/codegen/binary-ops.ts
+  - src/runtime.ts
 ---
 
 # #3481 — bigint/symbol coercion fidelity (value substrate)

--- a/plan/issues/3481-bigint-symbol-coercion-value-rep.md
+++ b/plan/issues/3481-bigint-symbol-coercion-value-rep.md
@@ -1,7 +1,8 @@
 ---
 id: 3481
 title: "bigint/symbol coercion: value-substrate ToPrimitive/ToNumeric fidelity (host ~164 fails) — architect-spec hand-off"
-status: ready
+status: in-progress
+assignee: ttraenkler/senior-dev
 created: 2026-07-20
 priority: medium
 feasibility: hard
@@ -12,7 +13,7 @@ goal: test262-conformance
 model: opus
 sprint: current
 horizon: xl
-related: [3422]
+related: [3422, 3328]
 ---
 
 # #3481 — bigint/symbol coercion fidelity (value substrate)
@@ -70,3 +71,72 @@ BigInt re-check on ToPrimitive results, (3) the isolated operator/arg-validation
   `instanceof TypeError` at the coercion site.
 - The ~10 isolated cases (`>>>`, toFixed order, sort comparefn, species, fromCharCode) throw.
 - Zero regression on the arithmetic-coercion cases that already pass.
+
+## Implementation Notes — senior-dev, 2026-07-21 (branch `issue-3481-value-rep-coercion`)
+
+**Verify-first disproved the "bigint-wrapper is a tight slice" premise. This IS the
+epic the issue predicted — there is no single-PR slice that flips a whole host
+test262 file.** What landed on the branch is a correct, low-regression *prerequisite*,
+not a self-merge. Escalated to the tech lead for sequencing (do NOT enqueue).
+
+### What the branch implements (step 1 of the issue's own sequence — "wrapper-object ToPrimitive unwrap")
+A new internal host import `__host_bigint_binop(op:i32, a:externref, b:externref)->externref`
+(mirrors the existing `host_add`/`host_compare`/`host_eq` precedent — compiler-emitted,
+not user-facing, so the host-import allowlist gate does not bite):
+- `src/index.ts` — `ImportIntent` union: `{ type: "host_bigint_binop" }`.
+- `src/compiler/import-manifest.ts` — name→intent mapping.
+- `src/runtime.ts` (`case "host_bigint_binop"`) — struct operands ToPrimitive-reduced via
+  `_toPrimitiveSync` (hint `default` for `+`, `number` otherwise), then JS applies the
+  operator → ToNumeric + the mix-TypeError check + BigInt arithmetic + `>>>`-on-BigInt
+  throw, all for free. i32 opcode is a private ABI shared with `bigIntHostBinopOpcode`.
+- `src/codegen/binary-ops.ts` — in the mixed-BigInt arithmetic block, BEFORE the
+  `emitThrowTypeError("Cannot mix BigInt…")`, delegate to the host binop when the
+  **non-bigint operand is `Any|Unknown|Object`** and mode is JS-host + default
+  (`anyValueTypeIdx < 0`). Standalone/WASI keeps the throw (no JS host). Gate includes
+  `Object` (not just `Any`) deliberately — object-literal operands are `TypeFlags.Object`,
+  and broadening is safe *because* the binop pre-reduces structs via `_toPrimitiveSync`
+  (the #1374 regression was raw `a<b` on opaque structs with NO pre-reduction).
+
+**Regression surface = zero on passing tests**: the delegated arm replaces a path that
+*currently always throws at runtime*. Only outcomes are throw→compute (fix) or
+TypeError-msgA→TypeError-msgB (benign — `assert.throws(TypeError)` still passes).
+Empirically verified: `Object(2n)*2n=4n`, `2n*Object(2n)=4n`, `-`/`+`/`**`/`|`/`>>` on
+`Object(bigint)` correct; `(5 as any)*2n` and `2n*(3 as number)` still throw TypeError;
+`Object(4n) >>> 1n` throws; plain `2n*2n`/`5n+3n`/`1n<<4n` untouched.
+
+### Why it flips 0 whole host files ALONE (inferred from assertion-path analysis)
+test262 aborts on the FIRST failed `assert.*`, and every failing FILE bundles the
+wrapper case with an assertion this slice does NOT cover:
+- **`.../bigint-wrapped-values.js` (13 files)** — assertion #3 (before the passing
+  `Object(2n)` rows finish the file) is `{[Symbol.toPrimitive](){return 2n}} * 2n`, then
+  `{valueOf}`/`{toString}`. These are WasmGC structs; two substrate gaps block them:
+  - **Gap A** — a compiled `valueOf`/`toString` dispatched via a method-call-through-`any`
+    loses the BigInt brand: it returns `2` (number), not `2n`, so `2 * 2n` throws the JS
+    mix error. (A *direct* closure return preserves the brand — the loss is in the
+    method-via-any / `__call_fn_method_0` return boxing.)
+  - **Gap B** — an object-literal computed `[Symbol.toPrimitive]` is NOT dispatched by
+    `_hostToPrimitive` at all (no sidecar / no `__call_@@toPrimitive` for object literals)
+    → falls to `"[object Object]"`.
+  Both are `_hostToPrimitive` / nominal-struct ToPrimitive substrate — **the same lane as
+  the active `issue-3328-capturing-closure-toprimitive-dispatch` worktree.** Not touched
+  here to avoid duplicate-work collision (lane-partition rule). Once #3328's dispatch
+  lands, this binop is what routes the reduced primitive back into a BigInt op → the
+  wrapped-values files flip. The binop is a genuine dependency of that flip, not redundant.
+- **`.../bigint-and-number.js` (9 files)** — assertions like `Object(1n) * 1` and
+  `Object(1n) * Object(1)` have **neither** operand statically bigint, so they never enter
+  the mixed-BigInt block; they need general `any`-arithmetic host delegation, which changes
+  the result type of ALL `any * number` from f64→externref (blast radius across every
+  any-arithmetic site + the AnyValue fast-mode ABI) — explicitly NOT a low-regression first
+  slice (#1374 lesson). Deferred.
+
+### Remaining slices (for the architect/PO to sequence)
+1. **Gap A + Gap B in `_hostToPrimitive`** (coordinate with #3328) — unblocks the 13
+   `bigint-wrapped-values.js` files given the binop above.
+2. **General `any`-arithmetic host delegation** (multiplicative/bitwise) — unblocks the 9
+   `bigint-and-number.js` files; needs its own regression budget (result-type f64→externref).
+3. **Symbol ×79 cluster** — the larger, unexplored lever (localized property-access Symbol-key
+   coercion per the scope notes). Needs a short feasibility probe (single coercion site vs
+   shared substrate) before commit; likely the better flip-positive host win this session,
+   but a different subsystem from the bigint work here.
+4. Family-B ToString/ToInteger/ToIndex Symbol/BigInt re-check on ToPrimitive results, and the
+   isolated operator/arg-validation cases.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -299,6 +299,46 @@ function tryFlattenBinaryChain(
   return resultType;
 }
 
+/**
+ * (#3481) Compact opcode for `__host_bigint_binop`, the JS-host delegation used
+ * when a BigInt is combined with a dynamically-object/any operand that ToNumeric
+ * may reduce to a BigInt (`Object(2n) * 2n`, `{valueOf(){return 2n}} - 2n`, …).
+ * Returns `undefined` for operators that never reach the mixed-BigInt arithmetic
+ * throw (equality/relational are handled earlier), so the caller keeps its
+ * existing path. The numbering is a private ABI shared only with the
+ * `host_bigint_binop` runtime intent — keep the two in lockstep.
+ */
+function bigIntHostBinopOpcode(op: ts.SyntaxKind): number | undefined {
+  switch (op) {
+    case ts.SyntaxKind.PlusToken:
+      return 0;
+    case ts.SyntaxKind.MinusToken:
+      return 1;
+    case ts.SyntaxKind.AsteriskToken:
+      return 2;
+    case ts.SyntaxKind.SlashToken:
+      return 3;
+    case ts.SyntaxKind.PercentToken:
+      return 4;
+    case ts.SyntaxKind.AsteriskAsteriskToken:
+      return 5;
+    case ts.SyntaxKind.AmpersandToken:
+      return 6;
+    case ts.SyntaxKind.BarToken:
+      return 7;
+    case ts.SyntaxKind.CaretToken:
+      return 8;
+    case ts.SyntaxKind.LessThanLessThanToken:
+      return 9;
+    case ts.SyntaxKind.GreaterThanGreaterThanToken:
+      return 10;
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+      return 11;
+    default:
+      return undefined;
+  }
+}
+
 export function compileBinaryExpression(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1172,6 +1212,67 @@ export function compileBinaryExpression(
       // BigInt side (`1n + "" === "1"` per §13.15.4).
       if (op === ts.SyntaxKind.PlusToken && (isStringType(leftTsType) || isStringType(rightTsType))) {
         return compileStringBinaryOp(ctx, fctx, expr, op);
+      }
+      // (#3481) BigInt wrapper / ToPrimitive-yields-BigInt. When the NON-bigint
+      // operand is dynamically an object/any (`Object(2n)`, `{valueOf(){return
+      // 2n}}`, `{[Symbol.toPrimitive](){return 2n}}`), we cannot statically know
+      // it is a real "mix": ToNumeric (§7.1.3) may reduce it to a BigInt, in
+      // which case the operator is a valid BigInt op (`Object(2n) * 2n === 4n`),
+      // not a TypeError. In JS-host mode delegate the whole operator to JS via
+      // `__host_bigint_binop` — that gives ToPrimitive (incl. the wrapper /
+      // @@toPrimitive / valueOf reduction, with struct operands routed through
+      // the in-module dispatcher), the mix TypeError check, and BigInt
+      // arithmetic for free. Gate: the non-bigint side is Any|Unknown|Object (a
+      // statically number/string/boolean operand is a *provable* mix — keep the
+      // cheap throw; JS would throw the same TypeError anyway). Default mode only
+      // (`anyValueTypeIdx < 0`), mirroring emitAnyAdd's host-import ABI rule.
+      // Standalone/WASI has no JS host, so it keeps the throw (existing
+      // limitation — a native ToNumeric reduction is the follow-up slice).
+      const noJsHost3481 = ctx.standalone === true || ctx.wasi === true;
+      const nonBigIntTsType = leftIsBigInt ? rightTsType : leftTsType;
+      const nonBigIntIsObjectish =
+        (nonBigIntTsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Object)) !== 0;
+      const hostBinopCode = bigIntHostBinopOpcode(op);
+      if (!noJsHost3481 && ctx.anyValueTypeIdx < 0 && nonBigIntIsObjectish && hostBinopCode !== undefined) {
+        // Evaluate operands left→right, box each to externref, store in temps.
+        // The statically-bigint side is a branded i64 → __box_bigint yields a JS
+        // bigint (force the brand: isBigIntType already proved it is a bigint).
+        const lHint: ValType = leftIsBigInt ? { kind: "i64" } : { kind: "externref" };
+        const lType = compileExpression(ctx, fctx, expr.left, lHint);
+        if (!lType) return null;
+        if (lType.kind === "i64") {
+          coerceType(ctx, fctx, { kind: "i64", bigint: true }, { kind: "externref" });
+        } else if (lType.kind !== "externref") {
+          coerceType(ctx, fctx, lType, { kind: "externref" });
+        }
+        const lTmp = allocTempLocal(fctx, { kind: "externref" });
+        fctx.body.push({ op: "local.set", index: lTmp });
+        const rHint: ValType = rightIsBigInt ? { kind: "i64" } : { kind: "externref" };
+        const rType = compileExpression(ctx, fctx, expr.right, rHint);
+        if (!rType) return null;
+        if (rType.kind === "i64") {
+          coerceType(ctx, fctx, { kind: "i64", bigint: true }, { kind: "externref" });
+        } else if (rType.kind !== "externref") {
+          coerceType(ctx, fctx, rType, { kind: "externref" });
+        }
+        const rTmp = allocTempLocal(fctx, { kind: "externref" });
+        fctx.body.push({ op: "local.set", index: rTmp });
+        const hostIdx = ensureLateImport(
+          ctx,
+          "__host_bigint_binop",
+          [{ kind: "i32" }, { kind: "externref" }, { kind: "externref" }],
+          [{ kind: "externref" }],
+        );
+        flushLateImportShifts(ctx, fctx);
+        const finalIdx = ctx.funcMap.get("__host_bigint_binop") ?? hostIdx;
+        if (finalIdx === undefined) throw new Error("Missing import after ensureLateImport: __host_bigint_binop");
+        fctx.body.push({ op: "i32.const", value: hostBinopCode });
+        fctx.body.push({ op: "local.get", index: lTmp });
+        fctx.body.push({ op: "local.get", index: rTmp });
+        releaseTempLocal(fctx, rTmp);
+        releaseTempLocal(fctx, lTmp);
+        fctx.body.push({ op: "call", funcIdx: finalIdx });
+        return { kind: "externref" };
       }
       // Compile both sides for side effects, drop their values, then throw.
       const lt = compileExpression(ctx, fctx, expr.left);

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -135,6 +135,14 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
   // string-if-either-is-string rule come free from JS `+`. (#2058)
   if (name === "__host_add") return { type: "host_add" };
 
+  // Host BigInt-mixed binary operator for a BigInt combined with a
+  // dynamically-object/any operand whose ToNumeric may reduce to a BigInt
+  // (`Object(2n) * 2n`, `{valueOf(){return 2n}} - 2n`). The i32 opcode selects
+  // the operator; struct operands are ToPrimitive-reduced via the in-module
+  // dispatcher, then JS applies ToNumeric + the mix-TypeError check + BigInt
+  // arithmetic. (#3481)
+  if (name === "__host_bigint_binop") return { type: "host_bigint_binop" };
+
   // Host relational compare for two externref operands (§7.2.13 IsLessThan).
   // Returns a 4-way result -1/0/1/2 (2 = NaN/undefined-incomparable) so the
   // four relational operators (<,<=,>,>=) map without separate imports, and

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export type ImportIntent =
   | { type: "host_eq" }
   | { type: "host_loose_eq" }
   | { type: "host_add" }
+  | { type: "host_bigint_binop" }
   | { type: "host_compare" }
   | { type: "same_value_zero" }
   | { type: "dynamic_import" }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -14003,6 +14003,59 @@ assert._isSameValue = isSameValue;
           b != null && typeof b === "object" && _isWasmStruct(b) ? _toPrimitiveSync(b, "default", callbackState) : b;
         return av + bv;
       };
+    case "host_bigint_binop":
+      // #3481 — a BigInt combined with a dynamically-object/any operand whose
+      // ToNumeric (§7.1.3) may reduce to a BigInt: `Object(2n) * 2n === 4n`,
+      // `{valueOf(){return 2n}} - 2n === 0n`, `{[Symbol.toPrimitive](){return
+      // 2n}} ** 2n === 4n`. The compiler can't decide statically whether this is
+      // a real BigInt/Number *mix* (a TypeError) or a valid BigInt op, so it
+      // delegates the operator to JS here. A WasmGC-struct operand (an object
+      // literal / class instance carrying a COMPILED valueOf / toString /
+      // @@toPrimitive) is first reduced via `_toPrimitiveSync` — the same proxy
+      // `host_add` uses — because native JS `a * b` would otherwise throw
+      // "Cannot convert object to primitive value" on the opaque struct. `+`
+      // takes the "default" hint (string-if-either-is-string), every other
+      // operator the "number" hint, per §13.15.3 / §7.1.3. Once both operands
+      // are primitives, the JS operator gives ToNumeric + the mix-TypeError
+      // check + BigInt arithmetic for free (a Number-vs-BigInt mix throws a real
+      // `instanceof TypeError`; `>>>` on BigInt throws, matching the spec).
+      // The i32 opcode is a private ABI shared with `bigIntHostBinopOpcode` in
+      // binary-ops.ts — keep them in lockstep.
+      return (op: number, a: any, b: any) => {
+        const hint = op === 0 ? "default" : "number";
+        const av =
+          a != null && typeof a === "object" && _isWasmStruct(a) ? _toPrimitiveSync(a, hint, callbackState) : a;
+        const bv =
+          b != null && typeof b === "object" && _isWasmStruct(b) ? _toPrimitiveSync(b, hint, callbackState) : b;
+        switch (op) {
+          case 0:
+            return av + bv;
+          case 1:
+            return av - bv;
+          case 2:
+            return av * bv;
+          case 3:
+            return av / bv;
+          case 4:
+            return av % bv;
+          case 5:
+            return av ** bv;
+          case 6:
+            return av & bv;
+          case 7:
+            return av | bv;
+          case 8:
+            return av ^ bv;
+          case 9:
+            return av << bv;
+          case 10:
+            return av >> bv;
+          case 11:
+            return av >>> bv;
+          default:
+            throw new TypeError("Cannot mix BigInt and other types, use explicit conversions");
+        }
+      };
     case "host_compare":
       // #2059 — relational compare for two externref operands (§7.2.13
       // IsLessThan). JS `<`/`>` give ToPrimitive (hint "number"), the


### PR DESCRIPTION
## Summary

Adds a new internal host import `__host_bigint_binop` so a **BigInt combined with a dynamically-object/any operand** delegates the operator to JS, giving spec-correct **ToNumeric (§7.1.3)** + the mix-`TypeError` check + BigInt arithmetic for free. Mirrors the existing `host_add` / `host_compare` / `host_eq` precedent (compiler-emitted, not user-facing — the host-import allowlist gate does not apply).

Fixes the BigInt **wrapper-object** rows, e.g. `Object(2n) * 2n === 4n`, `2n * Object(2n) === 4n`, and the `-`/`+`/`**`/`|`/`>>` equivalents — **step 1 of #3481's own sequence** ("wrapper-object ToPrimitive unwrap").

## ⚠️ This is a 0-whole-file-flip building block — do NOT expect a conformance number bump

Landing it early **helps** #3328 build on it rather than rotting un-PR'd. test262 aborts on the first failed `assert`, and every failing host file bundles the wrapper case with an assertion this PR does not yet cover:

- **`bigint-wrapped-values.js` (13 files)** — the struct-method variants (`{[Symbol.toPrimitive]}`, `{valueOf}`, `{toString}`) hit two `_hostToPrimitive` nominal-struct dispatch gaps (BigInt brand lost through a method-call-via-`any`; object-literal `@@toPrimitive` not dispatched). Those are **#3328's lane** and are intentionally not touched here. **Once #3328's dispatch lands, this binop is what routes the reduced primitive back into a BigInt op → the 13 files flip.**
- **`bigint-and-number.js` (9 files)** — assertions like `Object(1n) * 1` have neither operand statically bigint; they need general any-arithmetic delegation (a separate, higher-regression slice — #1374 lesson). Deferred.

## Regression surface: zero on passing tests

The delegated arm replaces a path that **currently always throws at runtime** (`emitThrowTypeError("Cannot mix BigInt…")`). The only outcomes are throw→compute (fix) or TypeError-msgA→TypeError-msgB (benign — `assert.throws(TypeError)` still passes). Gate: non-bigint operand is `Any|Unknown|Object`, JS-host + default mode only (`anyValueTypeIdx < 0`); standalone/WASI keeps the throw. `Object`-flag inclusion is safe **because** the binop pre-reduces struct operands via `_toPrimitiveSync` — unlike the raw `a < b` of the #1374 regression.

Empirically verified: `Object(2n)*2n=4n`, `2n*Object(2n)=4n`, `-`/`+`/`**`/`|`/`>>` on `Object(bigint)` correct; `(5 as any)*2n` and `2n*(3 as number)` still throw `TypeError`; `Object(4n) >>> 1n` throws; plain `2n*2n`/`5n+3n`/`1n<<4n` untouched.

## Changes
- `src/index.ts` — `ImportIntent` union entry.
- `src/compiler/import-manifest.ts` — name→intent mapping.
- `src/runtime.ts` — `case "host_bigint_binop"` handler (struct operands ToPrimitive-reduced, then JS operator via i32 opcode).
- `src/codegen/binary-ops.ts` — delegation arm in the mixed-BigInt block + `bigIntHostBinopOpcode` helper.
- `plan/issues/3481-…md` — Implementation Notes with the full dependency structure; `loc-budget-allow` for the two god-files.

Local gates green: `tsc`, `check:oracle-ratchet` (0 growth), `check:loc-budget`, `format:check`, `lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb