### PR TITLE
fix(#3488): route reflective gOPD().get callees through the host-callable arm

### DIFF
--- a/plan/issues/3488-typedarray-trap-gaps-unmasked-by-3441.md
+++ b/plan/issues/3488-typedarray-trap-gaps-unmasked-by-3441.md
@@ -1,7 +1,7 @@
 ---
 id: 3488
 title: "TypedArray compiler trap-gaps (.set / bit-precision / invoked-as-func) — unmasked by #3441, tighten the #3189 ratchet back"
-status: ready
+status: in-progress
 created: 2026-07-20
 priority: medium
 task_type: bug
@@ -10,6 +10,8 @@ goal: test262-conformance
 sprint: current
 horizon: m
 related: [3441, 3189, 3202, 3335]
+loc-budget-allow:
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3488 — TypedArray trap-gaps unmasked by #3441
@@ -91,3 +93,67 @@ Filed as the #3441 fix-forward so the temporary trap-tolerance valve is provably
 transitional, not a permanent floor raise. Suggest splitting into two slices:
 (a) `invoked-as-func` reflective null-receiver TypeError (overlaps #728), and
 (b) `TypedArray.prototype.set` OOB → catchable RangeError.
+
+## Slice (a) — LANDED (reflective accessor `invoked-as-func`)
+
+**Corrected root cause (verify-first, NOT the filed "getter null-receiver guard"
+framing).** The getter body is already correct: `getter.call(undefined)` from JS
+throws a catchable `TypeError` ("Method get TypedArray.prototype.length called on
+incompatible receiver"), and both `prop-desc.js` and `invoked-as-accessor.js`
+already pass. The trap was in the **compiled call path**, not the getter and not
+the descriptor:
+
+- `var getter = Object.getOwnPropertyDescriptor(proto, "length").get; getter();`
+  resolves `.get` to a **HOST-function-valued externref** (a host callable, NOT a
+  wasm closure struct). The bare-identifier call dispatch (`call-identifier.ts`)
+  tests it against the closure-struct type, the `ref.test` fails → a null closure
+  cast, and because the raw callee is non-null the guarded null-check does **not**
+  throw — it falls through to `struct.get <closure> 0` on the null and
+  `null_deref`-traps.
+- The `__call_function` host-callable fallback arm already exists
+  (`call-identifier.ts:1625`, #1712/#3335) but is gated by
+  `calleeMayBeHostCallable` (`calls.ts`), which only recognised
+  `var f = Object.hasOwn`-style host-builtin-member inits — NOT the reflective
+  `gOPD(o, k).get`/`.set` accessor extraction. So the host arm was never emitted
+  and the trapping path ran.
+
+**Fix**: `calleeMayBeHostCallable` now recognises the syntactic
+`Object.getOwnPropertyDescriptor(o, k).get`/`.set` extraction shape (no checker
+query → oracle-ratchet-safe; narrow → `#1941` dual-mode host-import-free guarantee
+for pure local-closure programs preserved). The `__call_function` arm is then
+emitted, the reflective getter dispatches through the host, and `getter()` with an
+undefined `this` throws the CATCHABLE `TypeError` the harness asserts.
+
+**Measured (host lane, verify-first, pre vs post over all 51 `*/invoked-as-func.js`):**
+
+- `28 pass / 5 fail / 18 fail(TRAP)` → `44 pass / 5 fail / 2 fail(TRAP)`.
+- **+16 host flips**, 16 `null_deref` traps eliminated, **0 regressions**.
+- Remaining 2 traps are `intl402/NumberFormat/*` (Intl — unrelated skip-feature
+  territory); remaining fails are `TypedArrayConstructors/{from,of}` statics + an
+  Intl PluralRules test (different shapes, out of scope).
+- Broad regression sweep (62 tests: TypedArray `prop-desc` + `invoked-as-accessor`
+  + `Object.getOwnPropertyDescriptor` + RegExp `invoked-as-func`) is byte-identical
+  pre/post — zero conformance regressions.
+
+Covered by `tests/issue-3488.test.ts`.
+
+## Remaining slices (NOT in this PR — re-scope / re-file)
+
+- **(b) `TypedArray.prototype.set` OOB (+9).** Verify-first correction: this is
+  **NOT** an offset-coercion bug — offset `ToInteger` works in a statically-typed
+  `compileTypedArraySet` context (confirmed: `sample.set([42], "")` / `1.9` on a
+  real `Float64Array` passes). The listed tests fail because `sample = new TA(
+  makeCtorArg([...]))` (an `any`-typed receiver) constructs a **length-0 host view**
+  via the source-array→host-`%TypedArray%`-ctor **marshaling** gap — this is
+  **#3335 value-rep territory**, already partly guarded to a *catchable* TypeError.
+  Making these PASS needs real marshaling work (produce a correct-length view), not
+  a `.set` bounds change. Warrants its own value-rep issue.
+- **(c) `*/bit-precision.js` (null_deref).** These trap **inside the test262
+  harness catch block** (`testTypedArray.js`: `e.message += " (Testing with …)";
+  throw e`), i.e. a separate error-object/`.name`/string-concat root cause in the
+  harness rethrow path — NOT the element codec the filing guessed. Warrants its own
+  scoped issue.
+
+The `TRAP_RATCHET_TOLERANCE` / `BASELINE_TRAP_GROWTH_ALLOW` reset + full ratchet
+tightening stays blocked on (b)+(c); this PR removes the 16 `invoked-as-func`
+`null_deref` traps.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2379,11 +2379,30 @@ export function calleeMayBeHostCallable(ctx: CodegenContext, expr: ts.Expression
     return false;
   };
 
+  // (#3488) `Object.getOwnPropertyDescriptor(o, k).get`/`.set` extracts a HOST
+  // accessor function (not a wasm closure), e.g. a builtin-proto getter like
+  // `%TypedArray%.prototype.length`. Invoked as a bare `getter()` it must reach
+  // the `__call_function` host arm, else the closure-struct dispatch nulls the
+  // cast and `struct.get`-traps on it (the `*/invoked-as-func.js` trap-gap #3441
+  // unmasked: `getter()` with undefined `this` must throw a CATCHABLE TypeError,
+  // not null-deref). Syntactic (no checker query → ratchet-safe); narrow — pure
+  // local-closure programs stay host-import-free (#1941 dual-mode).
+  const unparen = (n: ts.Expression): ts.Expression => (ts.isParenthesizedExpression(n) ? n.expression : n);
+  const isReflectiveAccessorExtraction = (node: ts.Expression): boolean => {
+    const inner = unparen(node);
+    if (!ts.isPropertyAccessExpression(inner) || (inner.name.text !== "get" && inner.name.text !== "set")) return false;
+    const recv = unparen(inner.expression);
+    if (!ts.isCallExpression(recv)) return false;
+    const callee = unparen(recv.expression);
+    return ts.isPropertyAccessExpression(callee) && callee.name.text === "getOwnPropertyDescriptor";
+  };
+
   // Unwrap `<host> || fn` / `<host> ?? fn` short-circuit fallbacks (and nested
   // chains), checking whether any reachable left operand is a host builtin.
   const initMayBeHost = (node: ts.Expression): boolean => {
     const inner = ts.isParenthesizedExpression(node) ? node.expression : node;
     if (isHostBuiltinMember(inner)) return true;
+    if (isReflectiveAccessorExtraction(inner)) return true;
     if (
       ts.isBinaryExpression(inner) &&
       (inner.operatorToken.kind === ts.SyntaxKind.BarBarToken ||

--- a/tests/issue-3488.test.ts
+++ b/tests/issue-3488.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#3488, slice a) `%TypedArray%.prototype` accessor getters extracted
+// reflectively via `Object.getOwnPropertyDescriptor(proto, name).get` and
+// invoked as a BARE function (`getter()`, i.e. an undefined `this`) must throw a
+// CATCHABLE TypeError — not die on an uncatchable Wasm `null_deref` trap.
+//
+// Root cause (verify-first): the getter body itself is correct (it throws a
+// catchable TypeError for a non-view `this`). The trap was in the CALL PATH: a
+// non-null HOST-function-valued callee (the reflective `.get`, a host callable,
+// NOT a wasm closure struct) fell through the closure-struct dispatch, which
+// `struct.get`-trapped on the nulled cast. `calleeMayBeHostCallable`
+// (src/codegen/expressions/calls.ts) now recognises the `gOPD(o, k).get`/`.set`
+// reflective-accessor extraction, so the `__call_function` host-callable arm is
+// emitted and the call routes through the host (throwing the catchable
+// TypeError). #3441 unmasked this by letting the TypedArray harness run past
+// __module_init.
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { restoreHostBuiltins } from "./test262-restore-builtins.js";
+import { runTest262File } from "./test262-runner.js";
+
+// The reflective-getter `*/invoked-as-func.js` family that previously trapped
+// (null_deref) and now passes (throws a catchable TypeError the harness asserts).
+const INVOKED_AS_FUNC_GETTERS = [
+  "built-ins/TypedArray/prototype/buffer/invoked-as-func.js",
+  "built-ins/TypedArray/prototype/byteLength/invoked-as-func.js",
+  "built-ins/TypedArray/prototype/byteOffset/invoked-as-func.js",
+  "built-ins/TypedArray/prototype/length/invoked-as-func.js",
+  "built-ins/TypedArray/prototype/Symbol.toStringTag/invoked-as-func.js",
+  "built-ins/TypedArray/prototype/Symbol.toStringTag/BigInt/invoked-as-func.js",
+] as const;
+
+const TRAP_SIGNATURE = /dereferencing a null pointer|out of bounds|illegal cast|unreachable/;
+
+describe("#3488 reflective accessor getter invoked-as-func — catchable TypeError, not a trap", () => {
+  it("TypedArray proto getters extracted via gOPD().get and called bare no longer trap (pass)", async () => {
+    for (const rel of INVOKED_AS_FUNC_GETTERS) {
+      const result = await runTest262File(resolve("test262/test", rel), rel.split("/")[0]!, 15000);
+      restoreHostBuiltins();
+      const err = String((result as { error?: unknown }).error ?? "");
+      expect(err, `${rel} must not hit an uncatchable Wasm trap`).not.toMatch(TRAP_SIGNATURE);
+      expect(result.status, `${rel} should pass (getter() throws a catchable TypeError)`).toBe("pass");
+    }
+  }, 180_000);
+
+  it("a real view receiver still reads the accessor correctly (no dispatch regression)", async () => {
+    // invoked-as-accessor.js: reading `.length` off the PROTOTYPE (a non-view,
+    // non-null `this`) must still throw a catchable TypeError — the fix must not
+    // perturb the valid-receiver / prototype-receiver paths.
+    const rel = "built-ins/TypedArray/prototype/length/invoked-as-accessor.js";
+    const result = await runTest262File(resolve("test262/test", rel), "built-ins", 15000);
+    restoreHostBuiltins();
+    expect(result.status).toBe("pass");
+  }, 60_000);
+});


### PR DESCRIPTION
Slice (a) of #3488 — the `%TypedArray%.prototype` accessor-getter
`*/invoked-as-func.js` family. Extracting a getter reflectively via
`Object.getOwnPropertyDescriptor(proto, name).get` and invoking it as a bare
function (`getter()`, i.e. undefined `this`) trapped with an uncatchable
`null_deref` instead of throwing the catchable `TypeError` the harness asserts.
#3441 unmasked this by letting the TypedArray harness run past `__module_init`.

## Root cause (verify-first — NOT the filed "getter null-receiver guard" framing)

The getter body is already correct: `getter.call(undefined)` from JS throws a
catchable `TypeError`, and `prop-desc.js` / `invoked-as-accessor.js` already
pass. The trap was in the compiled **call path**: the reflective `.get` resolves
to a **HOST-function externref** (a host callable, not a wasm closure struct).
The bare-identifier dispatch (`call-identifier.ts`) `ref.test`s it against the
closure-struct type, the test fails → null closure cast, and because the raw
callee is non-null the guarded null-check does not throw — it falls through to
`struct.get <closure> 0` on the null and `null_deref`-traps.

The `__call_function` host-callable fallback arm (`call-identifier.ts:1625`,
#1712/#3335) already exists but is gated by `calleeMayBeHostCallable`, which only
recognised `var f = Object.hasOwn`-style host-builtin-member inits — not the
reflective `gOPD(o, k).get`/`.set` extraction. So the arm was never emitted.

## Fix

`calleeMayBeHostCallable` now recognises the syntactic
`Object.getOwnPropertyDescriptor(o, k).get`/`.set` extraction shape (no checker
query → oracle-ratchet-safe; narrow → the #1941 dual-mode host-import-free
guarantee for pure local-closure programs is preserved). The reflective getter
then dispatches through the host and throws the catchable `TypeError`.

## Measured (host lane, verify-first)

- All 51 `*/invoked-as-func.js`, pre vs post: `28 pass / 18 traps` → `44 pass /
  2 traps` = **+16 host flips**, 16 `null_deref` traps removed, **0 regressions**
  (remaining 2 traps are `intl402/NumberFormat/*`, unrelated).
- Broad 62-test sweep (TypedArray `prop-desc` + `invoked-as-accessor` +
  `Object.getOwnPropertyDescriptor` + RegExp `invoked-as-func`) byte-identical
  pre/post — zero conformance regressions.
- Local gates: typecheck, oracle-ratchet, loc-budget (allowance granted in the
  issue file), format:check, check:issues all green.

Covered by `tests/issue-3488.test.ts`.

## Not in this PR (documented in the issue for re-filing)

- **(b) `.set` OOB (+9)** — verified NOT offset-coercion (that works in a typed
  context); it's the source-array→host-`%TypedArray%`-ctor **marshaling** gap
  (#3335 value-rep), a length-0 view. Separate value-rep issue.
- **(c) `bit-precision` null_deref** — traps inside the test262 harness catch
  block (`e.message += …; throw e`), a separate error-object root cause.

The `TRAP_RATCHET_TOLERANCE` reset stays blocked on (b)+(c); this PR removes the
16 `invoked-as-func` `null_deref` traps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb