### PR TITLE
feat(ir): compile the builtins example through IR

### DIFF
--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -24,12 +24,15 @@ loc-budget-allow:
   - scripts/check-ir-fallbacks.ts
   - scripts/ir-fallback-baseline.json
   - src/codegen/index.ts
+  - src/ir/backend/linear-integration.ts
+  - src/ir/capability.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
   - src/ir/lower.ts
   - src/ir/module-bindings.ts
   - src/ir/select.ts
   - tests/issue-2856-module-bindings.test.ts
+  - tests/issue-2856-builtins-component.test.ts
 ---
 
 # #2856 — IR: `body-shape-rejected` → 0
@@ -1284,6 +1287,42 @@ pre-claim consumer guards); 52 adjacent #3142 module-init, C3 Map,
 extern-in-IR, #3343, selector-attribution, and non-terminating-guard tests green;
 full equivalence gate at 1,607 passing / 36 known failures with no new
 regressions; typecheck clean; fallback baseline ratcheted to 13.
+
+### Builtins component result (2026-07-21) — Math, `~`, `toFixed`, and `replace`
+
+The next independently measurable component clears
+`website/playground/examples/js/builtins.ts::main` without widening general
+dynamic coercion:
+
+- One exact-arity Math table is shared by the selector, call-graph scan, and
+  builder. `abs`/`sqrt`/`floor`/`ceil`/`trunc` remain direct Wasm unary ops;
+  `sin`/`cos`/`exp`/`log`/`log2`, `pow`, and `atan2` lower to the existing
+  symbolic self-hosted `Math_<method>` functions. Checker identity preserves
+  ambient `Math`; module/local/parameter shadows and wrong arities reject
+  before claim. Every argument must be checker-proven numeric.
+- Unary `~` is now a partial claim lowering through the established
+  `js.bitxor(value, -1)` ToInt32 composite. Only checker-proven numbers enter
+  it, keeping string, boolean, bigint, symbol, and dynamic coercions on the
+  legacy path.
+- Number `.toFixed(digits)` lowers through `number_toFixed` only in the
+  host-string lane and only for one integer literal in `[0, 100]`. Dynamic,
+  out-of-range, native-string, fast, standalone, and WASI forms remain
+  pre-claim rejections.
+- String `.replace(search, replacement)` reuses the existing string-method
+  backend plan for exactly two literal-string arguments. RegExp, callback,
+  custom/coercive, wrong-arity, and unsupported linear forms remain
+  legacy-owned; class/extern methods with the same name keep their ordinary
+  dispatch.
+
+Measured gate result: function-level `body-shape-rejected` **13 → 12**;
+`builtins.ts::main` appears in `irCompiledFuncs`; module-level remains **2**;
+all post-claim build/verify/lower/backend buckets remain zero. Validation:
+12 focused component tests covering the real playground source, direct and
+self-hosted Math parity, ToInt32 edge cases, literal formatting/replacement,
+shadow/arity/type/backend negatives, receiver-name collisions, linear
+pre-claim routing, and representation-mode gates; typecheck and the fallback
+gate clean; full equivalence gate at 1,607 passing / 36 known failures with no
+new regressions.
 
 ### Capability A (M) — imported-callee calls (first half of the 8 mains)
 

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -58,7 +58,11 @@ import ts from "typescript";
 import { buildTypeMap } from "../src/ir/propagate.js";
 import { planIrCompilation, type IrFallbackReason } from "../src/ir/select.js";
 import { makeIrHostGlobalResolver } from "../src/ir/host-extern.js";
-import { makeIrModuleBindingResolver } from "../src/ir/module-bindings.js";
+import {
+  makeIrDeclaredPrimitiveExpressionClassifier,
+  makeIrModuleBindingResolver,
+  makeIrPrimitiveExpressionClassifier,
+} from "../src/ir/module-bindings.js";
 import { compile } from "../src/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -260,6 +264,10 @@ async function aggregate(): Promise<{
           allowHostExterns: true,
           allowBuiltinMapExtern: true,
         }),
+        classifyPrimitiveExpression: makeIrPrimitiveExpressionClassifier(checker),
+        classifyDeclaredPrimitiveExpression: makeIrDeclaredPrimitiveExpressionClassifier(checker),
+        supportsSymbolicMathHelpers: true,
+        supportsLiteralStringReplace: true,
       },
       typeMap,
     );

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
-  "generated": "2026-07-20",
+  "generated": "2026-07-21",
   "unintended": {
-    "body-shape-rejected": 13
+    "body-shape-rejected": 12
   },
   "deferred": {
     "async-function": 4

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -29,7 +29,11 @@ import { asVal, irDynamic, isDynamic, irVal, type IrType } from "../ir/nodes.js"
 import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import { planIrCompilation, irClosureSignatureFromFunctionTypeNode, type IrFallbackReason } from "../ir/select.js";
 import { makeIrHostGlobalResolver } from "../ir/host-extern.js"; // (#2856)
-import { makeIrModuleBindingResolver } from "../ir/module-bindings.js"; // (#2856 Capability C)
+import {
+  makeIrDeclaredPrimitiveExpressionClassifier,
+  makeIrModuleBindingResolver,
+  makeIrPrimitiveExpressionClassifier,
+} from "../ir/module-bindings.js"; // (#2856 Capability C)
 import { asyncEngineWouldActivate } from "./async-activation.js"; // (#1373b C-1)
 import { unwrapPromiseTypeNode } from "./async-static.js"; // (#1373b C-1)
 import { createCodegenContext } from "./context/create-context.js";
@@ -1753,6 +1757,8 @@ function planIrOverlay(ctx: CodegenContext, ast: TypedAST): IrOverlayPlan {
     allowHostExterns: jsHostExterns && !ctx.nativeStrings,
     allowBuiltinMapExtern: jsHostExterns && !ctx.nativeStrings,
   });
+  const classifyPrimitiveExpression = makeIrPrimitiveExpressionClassifier(ast.checker);
+  const classifyDeclaredPrimitiveExpression = makeIrDeclaredPrimitiveExpressionClassifier(ast.checker);
   // (#3053 U2) The gc `__dyn_member_get` body is sound in every config EXCEPT
   // fast host-js-string (`fast && !standalone && !wasi`): there the carrier is
   // the gc `$AnyValue` but strings are host js-string externrefs, so the native
@@ -1770,6 +1776,10 @@ function planIrOverlay(ctx: CodegenContext, ast: TypedAST): IrOverlayPlan {
       dynMemberReadBuildable,
       resolveHostGlobal: makeIrHostGlobalResolver(ast.checker),
       resolveModuleBinding,
+      classifyPrimitiveExpression,
+      classifyDeclaredPrimitiveExpression,
+      supportsSymbolicMathHelpers: true,
+      supportsLiteralStringReplace: true,
       // (#1373b C-1) Async claim gate: IR claims an async fn IFF the ONE
       // async engine ($AsyncFrame drive / host-drive) declines it — the
       // legacy sync-pass-through population. Engine-activated functions keep

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -79,6 +79,11 @@ import {
   type IrTypeRef,
 } from "../nodes.js";
 import { buildTypeMap, type LatticeType } from "../propagate.js";
+import {
+  makeIrAmbientBindingPredicate,
+  makeIrDeclaredPrimitiveExpressionClassifier,
+  makeIrPrimitiveExpressionClassifier,
+} from "../module-bindings.js";
 import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode, planIrCompilation } from "../select.js";
 import { buildRecursiveTypeEvidence } from "../type-evidence.js";
 import type { FuncTypeDef, Instr, ValType, WasmFunction } from "../types.js";
@@ -189,7 +194,16 @@ export function compileLinearIrFunctions(
   const evidenceChecker = overlayCertifiedCheckerTypes(ctx.checker, recursiveTypeEvidence.checkerTypeOverrides);
   const selection = planIrCompilation(
     sourceFile,
-    { experimentalIR: true, trackFallbacks: true, recursiveTypeEvidence },
+    {
+      experimentalIR: true,
+      trackFallbacks: true,
+      recursiveTypeEvidence,
+      classifyPrimitiveExpression: makeIrPrimitiveExpressionClassifier(ctx.checker),
+      classifyDeclaredPrimitiveExpression: makeIrDeclaredPrimitiveExpressionClassifier(ctx.checker),
+      isAmbientBinding: makeIrAmbientBindingPredicate(ctx.checker),
+      supportsSymbolicMathHelpers: false,
+      supportsLiteralStringReplace: false,
+    },
     recursiveTypeEvidence.typeMap,
   );
   for (const fallback of selection.fallbacks ?? []) {

--- a/src/ir/capability.ts
+++ b/src/ir/capability.ts
@@ -125,7 +125,9 @@ const PREFIX_OP_CAPABILITY: ReadonlyMap<ts.PrefixUnaryOperator, IrOpCapability> 
   [ts.SyntaxKind.MinusToken, "claim"], // f64.neg
   [ts.SyntaxKind.PlusToken, "claim"], // numeric identity
   [ts.SyntaxKind.ExclamationToken, "claim"], // i32.eqz over bool
-  [ts.SyntaxKind.TildeToken, "defer"], // ToInt32 + i32.xor -1 — not lowered yet
+  // `~x` is the same ToInt32 composite as `x ^ -1`. The selector only
+  // admits operands proven numeric; wider JS coercions remain legacy-owned.
+  [ts.SyntaxKind.TildeToken, "claim-partial"],
 ]);
 
 // ── Host-extern member access (#2856 — document/console et al.) ────────────

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -63,7 +63,7 @@ import {
   stringIndexProvenBelow,
 } from "./capability.js";
 import type { IrLowerResolver, IrVecLowering } from "./lower.js";
-import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode, mathUnaryToIrOp } from "./select.js";
+import { effectiveIrParamTypeNode, effectiveIrReturnTypeNode, IR_MATH_METHOD_TABLE } from "./select.js";
 import { JsTag } from "./js-tag.js"; // #2949 S5.2 — box-refinement tags for dynamic equality operands
 import {
   asVal,
@@ -4246,7 +4246,9 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
     return null;
   }
 
-  // (#1371) Math.<whitelisted>(arg) — pure-Wasm f64 unary op. Recognise
+  // (#1371/#2856) Exact-arity Math builtin. Direct Wasm unary ops remain
+  // direct; transcendental methods call the self-hosted Math_<method> helper
+  // already registered by the legacy declaration scan.
   // the shape BEFORE lowering the receiver, because `Math` is a host
   // global with no IR type binding (lowerExpr on `Math` would throw
   // "unknown identifier"). The selector's `isPhase1Expr` already
@@ -4258,18 +4260,29 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   if (
     ts.isIdentifier(expr.expression.expression) &&
     expr.expression.expression.text === "Math" &&
-    !receiverIsDirectModuleBinding
+    !receiverIsDirectModuleBinding &&
+    cx.scope.get("Math") === undefined &&
+    // The self-host stdlib builder has no checker-backed ambient callback;
+    // user-source builds do, and an explicit `false` preserves shadow safety.
+    cx.resolver?.isAmbientBinding?.(expr.expression.expression) !== false
   ) {
-    const irOp = mathUnaryToIrOp(methodName);
-    if (irOp !== null && expr.arguments.length === 1) {
-      const arg = lowerExpr(expr.arguments[0]!, cx, irVal({ kind: "f64" }));
-      const argType = cx.builder.typeOf(arg);
-      if (argType.kind !== "val" || argType.val.kind !== "f64") {
-        throw new Error(
-          `ir/from-ast: Math.${methodName} arg must be f64, got ${describeIrType(argType)} (${cx.funcName})`,
-        );
-      }
-      return cx.builder.emitUnary(irOp, arg, irVal({ kind: "f64" }));
+    const plan = IR_MATH_METHOD_TABLE[methodName];
+    if (plan !== undefined && expr.arguments.length === plan.arity) {
+      const args = expr.arguments.map((argExpr) => {
+        const arg = lowerExpr(argExpr, cx, irVal({ kind: "f64" }));
+        const argType = cx.builder.typeOf(arg);
+        if (argType.kind !== "val" || argType.val.kind !== "f64") {
+          throw new Error(
+            `ir/from-ast: Math.${methodName} arg must be f64, got ${describeIrType(argType)} (${cx.funcName})`,
+          );
+        }
+        return arg;
+      });
+      if ("op" in plan) return cx.builder.emitUnary(plan.op, args[0]!, irVal({ kind: "f64" }));
+      const result = cx.builder.emitCall({ kind: "func", name: plan.helper }, args, irVal({ kind: "f64" }));
+      if (result === null)
+        throw new Error(`ir/from-ast: Math.${methodName} helper produced no result (${cx.funcName})`);
+      return result;
     }
     throw new Error(`ir/from-ast: Math.${methodName} not in IR whitelist (${cx.funcName})`);
   }
@@ -4350,6 +4363,28 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
     return r;
   }
 
+  // #2856 builtins slice — a bounded literal fraction-digits argument needs
+  // no runtime RangeError guard. Host-string mode owns number_toFixed's
+  // `(f64, f64) -> externref` ABI; native-string modes stay pre-claim
+  // deferred until the front-end has a representation-polymorphic formatter.
+  if (
+    methodName === "toFixed" &&
+    expr.arguments.length === 1 &&
+    ts.isNumericLiteral(expr.arguments[0]!) &&
+    recvType.kind === "val" &&
+    recvType.val.kind === "f64" &&
+    cx.resolver?.hasHostNumberToString?.() === true
+  ) {
+    const digits = Number(expr.arguments[0]!.text.replace(/_/g, ""));
+    if (!Number.isInteger(digits) || digits < 0 || digits > 100) {
+      throw new Error(`ir/from-ast: number.toFixed digits not a bounded integer literal (${cx.funcName})`);
+    }
+    const digitValue = cx.builder.emitConst({ kind: "f64", value: digits }, irVal({ kind: "f64" }));
+    const r = cx.builder.emitCall({ kind: "func", name: "number_toFixed" }, [recv, digitValue], { kind: "string" });
+    if (r === null) throw new Error(`ir/from-ast: number_toFixed produced no result in ${cx.funcName}`);
+    return r;
+  }
+
   // Slice 13c (#1232) — String prototype method dispatch. When the receiver
   // is `IrType.string`, look up the method in the synthetic String pseudo-
   // extern registry (#1238) and dispatch to either the native helper
@@ -4357,6 +4392,13 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
   // the active string backend. Returns null when the method isn't supported
   // by Phase 1 (caller falls through to the existing `string` arm below).
   if (recvType.kind === "string") {
+    if (
+      methodName === "replace" &&
+      (expr.arguments.length !== 2 ||
+        !expr.arguments.every((arg) => ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)))
+    ) {
+      throw new Error(`ir/from-ast: String.replace requires two literal-string arguments (${cx.funcName})`);
+    }
     const r = lowerStringMethodCall(methodName, recv, expr.expression.expression, expr.arguments, cx);
     if (r !== null) return r;
     // Method not in slice 13c table — fall through to the recvType.kind !== "class"
@@ -4685,6 +4727,11 @@ export const STRING_METHOD_TABLE: Readonly<Record<string, StringMethodSig>> = {
     hostArgs: [{ kind: "externref" }, { kind: "f64" }],
     result: irVal({ kind: "i32" }),
     requiredArgs: 1,
+  },
+  replace: {
+    hostArgs: [{ kind: "externref" }, { kind: "externref" }],
+    result: { kind: "string" },
+    requiredArgs: 2,
   },
 };
 
@@ -6455,6 +6502,14 @@ function lowerPrefixUnary(expr: ts.PrefixUnaryExpression, cx: LowerCtx): IrValue
         throw new Error(`ir/from-ast: unary '!' expects bool in ${cx.funcName}`);
       }
       return cx.builder.emitUnary("i32.eqz", rand, irVal({ kind: "i32" }));
+    }
+    case ts.SyntaxKind.TildeToken: {
+      const randType = typeOfValue(rand, cx);
+      if (asVal(randType)?.kind !== "f64") {
+        throw new Error(`ir/from-ast: unary '~' expects a proven number in ${cx.funcName}`);
+      }
+      const minusOne = cx.builder.emitConst({ kind: "f64", value: -1 }, irVal({ kind: "f64" }));
+      return cx.builder.emitBinary("js.bitxor", rand, minusOne, irVal({ kind: "f64" }));
     }
     default:
       throw new Error(`ir/from-ast: unsupported prefix operator ${ts.SyntaxKind[expr.operator]} in ${cx.funcName}`);

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -76,7 +76,9 @@ import {
   type ModuleBindingGlobal,
 } from "./from-ast.js";
 import {
+  makeIrDeclaredPrimitiveExpressionClassifier,
   makeIrModuleBindingResolver,
+  makeIrPrimitiveExpressionClassifier,
   type IrModuleBindingIdentity,
   type IrModuleBindingResolver,
 } from "./module-bindings.js";
@@ -164,12 +166,18 @@ export function compileIrPathFunctions(
     allowHostExterns: !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports) && !ctx.nativeStrings,
     allowBuiltinMapExtern: !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports) && !ctx.nativeStrings,
   });
+  const classifyPrimitiveExpression = makeIrPrimitiveExpressionClassifier(ctx.checker);
+  const classifyDeclaredPrimitiveExpression = makeIrDeclaredPrimitiveExpressionClassifier(ctx.checker);
   const selected =
     selection ??
     planIrCompilation(sourceFile, {
       experimentalIR: true,
       jsHostExterns: !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports),
       resolveModuleBinding: moduleBindingResolver,
+      classifyPrimitiveExpression,
+      classifyDeclaredPrimitiveExpression,
+      supportsSymbolicMathHelpers: true,
+      supportsLiteralStringReplace: true,
     });
   // (#3142 Slice 2) A claimable, non-empty module-init unit keeps the
   // pipeline alive even with no claimed functions/class members.

--- a/src/ir/module-bindings.ts
+++ b/src/ir/module-bindings.ts
@@ -7,6 +7,141 @@
 import { isExternalDeclaredClass } from "../checker/type-mapper.js";
 import { ts } from "../ts-api.js";
 
+export type IrPrimitiveExpressionFamily = "number" | "boolean" | "string";
+export type IrDeclaredPrimitiveExpressionFamily = IrPrimitiveExpressionFamily | "primitive-union";
+
+/**
+ * Build a checker-only ambient-binding predicate. Unlike the full module
+ * binding resolver, this exposes no source storage capability, so backends
+ * without module-global lowering can still distinguish the real lib `Math`
+ * object from a source declaration or parameter with the same name.
+ */
+export function makeIrAmbientBindingPredicate(checker: ts.TypeChecker): (node: ts.Identifier) => boolean {
+  return (node) => {
+    try {
+      const symbol = checker.getSymbolAtLocation(node);
+      return (
+        symbol !== undefined &&
+        [symbol.valueDeclaration, ...(symbol.declarations ?? [])].some(
+          (declaration) => declaration?.getSourceFile().isDeclarationFile === true,
+        )
+      );
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
+ * Classify the receiver's declared checker surface for builtin-name routing.
+ * This is intentionally distinct from the provenance-safe classifier below:
+ * an invalid `const x: string = 1` must still be recognised as a primitive
+ * builtin receiver and rejected before claim, while class/extern receivers
+ * with the same method name keep ordinary dispatch. Mixed or nullable unions
+ * containing a primitive get a sentinel family so they reject conservatively;
+ * `any` and `unknown` remain unproven.
+ */
+export function makeIrDeclaredPrimitiveExpressionClassifier(
+  checker: ts.TypeChecker,
+): (expr: ts.Expression) => IrDeclaredPrimitiveExpressionFamily | undefined {
+  const classifyType = (type: ts.Type): IrDeclaredPrimitiveExpressionFamily | undefined => {
+    if ((type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) return undefined;
+    if (type.isUnion()) {
+      const families = new Set<IrPrimitiveExpressionFamily>();
+      let sawNonPrimitive = false;
+      let sawNullish = false;
+      for (const member of type.types) {
+        if ((member.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Never)) !== 0) {
+          sawNullish = true;
+          continue;
+        }
+        const family = classifyType(member);
+        if (family === "primitive-union") {
+          sawNonPrimitive = true;
+        } else if (family !== undefined) {
+          families.add(family);
+        } else {
+          sawNonPrimitive = true;
+        }
+      }
+      if (families.size === 0) return undefined;
+      if (families.size !== 1 || sawNonPrimitive || sawNullish) return "primitive-union";
+      return families.values().next().value;
+    }
+    if ((type.flags & ts.TypeFlags.NumberLike) !== 0) return "number";
+    if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return "boolean";
+    if ((type.flags & ts.TypeFlags.StringLike) !== 0) return "string";
+    return undefined;
+  };
+
+  return (expr) => {
+    try {
+      return classifyType(checker.getTypeAtLocation(unwrapParens(expr)));
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+/**
+ * Build a provenance-safe primitive classifier for coercion-sensitive
+ * builtin acceptance. This follows local initializers and ignores type
+ * assertions, so diagnostics-off annotations cannot masquerade as runtime
+ * evidence. Use makeIrDeclaredPrimitiveExpressionClassifier for routing.
+ */
+export function makeIrPrimitiveExpressionClassifier(
+  checker: ts.TypeChecker,
+): (expr: ts.Expression) => IrPrimitiveExpressionFamily | undefined {
+  const classifyType = (type: ts.Type): IrPrimitiveExpressionFamily | undefined => {
+    if (type.isUnion()) {
+      const families = type.types.map(classifyType);
+      const first = families[0];
+      return first !== undefined && families.every((family) => family === first) ? first : undefined;
+    }
+    if ((type.flags & ts.TypeFlags.NumberLike) !== 0) return "number";
+    if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return "boolean";
+    if ((type.flags & ts.TypeFlags.StringLike) !== 0) return "string";
+    return undefined;
+  };
+
+  const classifyExpression = (
+    expr: ts.Expression,
+    seen: Set<ts.VariableDeclaration>,
+  ): IrPrimitiveExpressionFamily | undefined => {
+    try {
+      const candidate = unwrapParens(expr);
+      // A type assertion is not runtime evidence. Follow the represented
+      // value so diagnostics-off inputs such as `"x" as number` cannot make
+      // a coercion-sensitive builtin claim the function.
+      if (
+        ts.isAsExpression(candidate) ||
+        ts.isTypeAssertionExpression(candidate) ||
+        ts.isSatisfiesExpression(candidate) ||
+        ts.isNonNullExpression(candidate)
+      ) {
+        return classifyExpression(candidate.expression, seen);
+      }
+      const family = classifyType(checker.getTypeAtLocation(candidate));
+      if (family === undefined || !ts.isIdentifier(candidate)) return family;
+
+      const symbol = checker.getSymbolAtLocation(candidate);
+      const declaration = [symbol?.valueDeclaration, ...(symbol?.declarations ?? [])].find(
+        (node): node is ts.VariableDeclaration =>
+          node !== undefined && ts.isVariableDeclaration(node) && node.getSourceFile() === candidate.getSourceFile(),
+      );
+      if (!declaration) return family; // parameters and checker-owned nonlocals
+      if (!declaration.initializer || seen.has(declaration)) return undefined;
+      const nextSeen = new Set(seen);
+      nextSeen.add(declaration);
+      return classifyExpression(declaration.initializer, nextSeen) === family ? family : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  return (expr) => classifyExpression(expr, new Set());
+}
+
 export type IrModuleBindingValueKind =
   | { readonly kind: "f64" }
   | { readonly kind: "i32"; readonly semantic: "boolean" }
@@ -313,6 +448,7 @@ export function makeIrModuleBindingResolver(
   checker: ts.TypeChecker,
   options: IrModuleBindingResolverOptions,
 ): IrModuleBindingResolver {
+  const isAmbientBinding = makeIrAmbientBindingPredicate(checker);
   const resolve = (node: ts.Identifier, writeValue?: ts.Expression): IrModuleBindingIdentity | undefined => {
     try {
       const declaration = directTopLevelDeclaration(node, checker);
@@ -359,17 +495,7 @@ export function makeIrModuleBindingResolver(
       }
     },
     isAmbientBinding(node: ts.Identifier): boolean {
-      try {
-        const symbol = checker.getSymbolAtLocation(node);
-        return (
-          symbol !== undefined &&
-          [symbol.valueDeclaration, ...(symbol.declarations ?? [])].some(
-            (declaration) => declaration?.getSourceFile().isDeclarationFile === true,
-          )
-        );
-      } catch {
-        return false;
-      }
+      return isAmbientBinding(node);
     },
     localVariableDeclaration(node: ts.Identifier): ts.VariableDeclaration | undefined {
       try {

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -61,7 +61,11 @@ import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codeg
 import type { IrClosureSignature, IrType } from "./nodes.js";
 
 import { binaryOpCapability, hostExternCapability, prefixOpCapability } from "./capability.js";
-import type { IrModuleBindingResolver } from "./module-bindings.js";
+import type {
+  IrDeclaredPrimitiveExpressionFamily,
+  IrModuleBindingResolver,
+  IrPrimitiveExpressionFamily,
+} from "./module-bindings.js";
 import type { LatticeType, TypeMap } from "./propagate.js";
 import type { RecursiveTypeEvidence } from "./type-evidence.js";
 
@@ -149,18 +153,41 @@ function takeShapeRejectDetail(): string | undefined {
   return d;
 }
 
+export type IrMathMethodPlan =
+  | {
+      readonly arity: 1;
+      readonly op: "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc";
+    }
+  | { readonly arity: 1 | 2; readonly helper: `Math_${string}` };
+
 /**
- * (#1371) Whitelist of `Math.<name>(arg)` unary calls the IR can lower to a
- * plain Wasm `f64.<op>` instruction without any host import. Each entry maps
- * 1:1 to an op in the `IrUnop` extended set (`src/ir/nodes.ts`). Restricting
- * the whitelist to ops with direct Wasm equivalents preserves bit-exact JS
- * semantics:
- *  - `Math.round` is intentionally excluded — JS rounds 0.5 → 1 (away from
- *    zero) but `f64.nearest` rounds to even, so a 1:1 lowering is unsound.
- *  - `Math.min` / `Math.max` are binary and live in `IR_MATH_BINARY_WHITELIST`
- *    (deferred — needs an `IrBinop` extension).
+ * Exact-arity Math surface shared by selection, call-graph closure, and the
+ * AST→IR builder. Direct Wasm unary operations stay direct; transcendental
+ * functions call the already-registered self-hosted `Math_<method>` helper.
+ * Keeping arity in this table prevents selector/builder drift and preserves
+ * ambient-Math identity checks at each consumer.
  */
-export const IR_MATH_UNARY_WHITELIST: ReadonlySet<string> = new Set(["abs", "sqrt", "floor", "ceil", "trunc"]);
+export const IR_MATH_METHOD_TABLE: Readonly<Record<string, IrMathMethodPlan>> = {
+  abs: { arity: 1, op: "f64.abs" },
+  sqrt: { arity: 1, op: "f64.sqrt" },
+  floor: { arity: 1, op: "f64.floor" },
+  ceil: { arity: 1, op: "f64.ceil" },
+  trunc: { arity: 1, op: "f64.trunc" },
+  sin: { arity: 1, helper: "Math_sin" },
+  cos: { arity: 1, helper: "Math_cos" },
+  exp: { arity: 1, helper: "Math_exp" },
+  log: { arity: 1, helper: "Math_log" },
+  log2: { arity: 1, helper: "Math_log2" },
+  pow: { arity: 2, helper: "Math_pow" },
+  atan2: { arity: 2, helper: "Math_atan2" },
+};
+
+/** Compatibility view for callers/tests that only need the method names. */
+export const IR_MATH_UNARY_WHITELIST: ReadonlySet<string> = new Set(
+  Object.entries(IR_MATH_METHOD_TABLE)
+    .filter(([, plan]) => plan.arity === 1)
+    .map(([name]) => name),
+);
 
 /**
  * Map a whitelisted `Math.<name>` to its corresponding IR `f64.<op>` tag.
@@ -168,20 +195,8 @@ export const IR_MATH_UNARY_WHITELIST: ReadonlySet<string> = new Set(["abs", "sqr
  * source of truth.
  */
 export function mathUnaryToIrOp(name: string): "f64.abs" | "f64.sqrt" | "f64.floor" | "f64.ceil" | "f64.trunc" | null {
-  switch (name) {
-    case "abs":
-      return "f64.abs";
-    case "sqrt":
-      return "f64.sqrt";
-    case "floor":
-      return "f64.floor";
-    case "ceil":
-      return "f64.ceil";
-    case "trunc":
-      return "f64.trunc";
-    default:
-      return null;
-  }
+  const plan = IR_MATH_METHOD_TABLE[name];
+  return plan && "op" in plan ? plan.op : null;
 }
 
 export interface IrSelection {
@@ -315,6 +330,36 @@ export interface IrSelectionOptions {
   /** (#2856) True iff the compile targets a JS host (NOT standalone / wasi /
    *  strictNoHostImports). Gates the host-extern capability. */
   readonly jsHostExterns?: boolean;
+  /**
+   * Proven primitive value family used by coercion-sensitive builtin
+   * acceptance. Invalid local annotations and type assertions return
+   * `undefined`; this is evidence, not receiver routing.
+   */
+  readonly classifyPrimitiveExpression?: (expr: ts.Expression) => IrPrimitiveExpressionFamily | undefined;
+  /**
+   * Declared checker family used only to route builtin-named method calls.
+   * Mixed/nullable primitive unions return `primitive-union`; pure
+   * class/extern and any/unknown receivers return `undefined` so they keep
+   * ordinary conservative dispatch.
+   */
+  readonly classifyDeclaredPrimitiveExpression?: (
+    expr: ts.Expression,
+  ) => IrDeclaredPrimitiveExpressionFamily | undefined;
+  /**
+   * Checker-only ambient identity proof used by Math call selection when a
+   * backend deliberately does not install the module-binding capability.
+   * Absent means unproven: bare selector callers stay shadow-safe.
+   */
+  readonly isAmbientBinding?: (node: ts.Identifier) => boolean;
+  /** True only when the active backend can resolve `Math_<method>` helpers. */
+  readonly supportsSymbolicMathHelpers?: boolean;
+  /**
+   * True when the active backend explicitly supports the selector's exact
+   * literal-string `String.replace(search, replacement)` slice. Backends
+   * without a matching method plan reject before claim instead of becoming a
+   * build demotion.
+   */
+  readonly supportsLiteralStringReplace?: boolean;
   /**
    * (#3053 U2) True iff the unified gc member-read primitive `__dyn_member_get`
    * (#3053 U0) has a SOUND body in this compile config. The gc `$AnyValue` body
@@ -3453,6 +3498,137 @@ function isPhase1ConditionExpr(
   return isPhase1Expr(expr, scope, localClasses);
 }
 
+/** Numeric proof used by coercion-sensitive builtin slices (`~`, toFixed). */
+function expressionIsProvenNumber(expr: ts.Expression, seen = new Set<ts.VariableDeclaration>()): boolean {
+  const candidate = unwrapPhase1Parens(expr);
+  if (ts.isNumericLiteral(candidate)) return true;
+  if (ts.isIdentifier(candidate)) {
+    const checkerProvesNumber = currentSelectionOptions?.classifyPrimitiveExpression?.(candidate) === "number";
+    if (currentModuleBindingResolver?.scalarExpressionFamily(candidate) !== "f64" && !checkerProvesNumber) return false;
+    const declaration = currentModuleBindingResolver?.localVariableDeclaration(candidate);
+    // Parameters and checker-proven non-local numeric bindings have no local
+    // initializer to audit. Local variables do: with semantic diagnostics
+    // skipped, their annotation may say `number` while the initializer is a
+    // string/boolean. Trace the initializer before allowing a coercion-
+    // sensitive builtin to claim the function.
+    if (!declaration) return checkerProvesNumber || currentModuleBindingResolver !== null;
+    if (seen.has(declaration)) return false;
+    if (declaration.type !== undefined && !typeNodeIsNumberOnly(declaration.type)) return false;
+    if (!declaration.initializer) return false;
+    const nextSeen = new Set(seen);
+    nextSeen.add(declaration);
+    return expressionIsProvenNumber(declaration.initializer, nextSeen);
+  }
+  if (ts.isPrefixUnaryExpression(candidate)) {
+    return (
+      (candidate.operator === ts.SyntaxKind.PlusToken ||
+        candidate.operator === ts.SyntaxKind.MinusToken ||
+        candidate.operator === ts.SyntaxKind.TildeToken) &&
+      expressionIsProvenNumber(candidate.operand, seen)
+    );
+  }
+  if (
+    ts.isAsExpression(candidate) ||
+    ts.isTypeAssertionExpression(candidate) ||
+    ts.isSatisfiesExpression(candidate) ||
+    ts.isNonNullExpression(candidate)
+  ) {
+    return expressionIsProvenNumber(candidate.expression, seen);
+  }
+  if (ts.isCallExpression(candidate) && ts.isPropertyAccessExpression(candidate.expression)) {
+    const recv = candidate.expression.expression;
+    const plan = IR_MATH_METHOD_TABLE[candidate.expression.name.text];
+    return (
+      ts.isIdentifier(recv) &&
+      recv.text === "Math" &&
+      selectorSeesAmbientBinding(recv) &&
+      plan !== undefined &&
+      selectorSupportsMathPlan(plan) &&
+      candidate.arguments.length === plan.arity &&
+      candidate.arguments.every((arg) => !ts.isSpreadElement(arg) && expressionIsProvenNumber(arg, seen))
+    );
+  }
+  return (
+    currentModuleBindingResolver?.scalarExpressionFamily(candidate) === "f64" ||
+    currentSelectionOptions?.classifyPrimitiveExpression?.(candidate) === "number"
+  );
+}
+
+function selectorSeesAmbientBinding(node: ts.Identifier): boolean {
+  return (
+    currentSelectionOptions?.isAmbientBinding?.(node) === true ||
+    currentModuleBindingResolver?.isAmbientBinding(node) === true
+  );
+}
+
+function selectorSupportsMathPlan(plan: IrMathMethodPlan): boolean {
+  return "op" in plan || currentSelectionOptions?.supportsSymbolicMathHelpers === true;
+}
+
+function isBoundedToFixedCall(expr: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(expr.expression) || expr.expression.name.text !== "toFixed") return false;
+  if (currentModuleBindingResolver?.supportsHostNumberToString !== true) return false;
+  if (expr.arguments.length !== 1 || !ts.isNumericLiteral(expr.arguments[0]!)) return false;
+  const digits = Number(expr.arguments[0]!.text.replace(/_/g, ""));
+  return (
+    Number.isInteger(digits) && digits >= 0 && digits <= 100 && expressionIsProvenNumber(expr.expression.expression)
+  );
+}
+
+function expressionIsProvenString(expr: ts.Expression, seen = new Set<ts.VariableDeclaration>()): boolean {
+  const candidate = unwrapPhase1Parens(expr);
+  if (ts.isStringLiteral(candidate) || ts.isNoSubstitutionTemplateLiteral(candidate)) return true;
+  if (!ts.isIdentifier(candidate)) return false;
+  // Literal provenance alone is insufficient when an explicit annotation
+  // gives the local a different IR representation. With semantic diagnostics
+  // skipped, `const s: number = "aba"` is still a valid input to codegen; the
+  // old proof admitted `s.replace(...)`, then the builder failed after claim
+  // while trying to initialize an f64 local with a string. Inferred locals are
+  // checker-proven by their literal initializer. Explicit annotations need an
+  // equally narrow string-only certificate here; aliases and mixed unions stay
+  // conservatively legacy-owned until the resolver exposes string type proof.
+  if (currentModuleBindingResolver?.scalarExpressionFamily(candidate) !== undefined) return false;
+  const declaration = currentModuleBindingResolver?.localVariableDeclaration(candidate);
+  if (!declaration || seen.has(declaration)) return false;
+  if (declaration.type !== undefined && !typeNodeIsStringOnly(declaration.type)) return false;
+  if (!declaration.initializer) return false;
+  seen.add(declaration);
+  return expressionIsProvenString(declaration.initializer, seen);
+}
+
+function typeNodeIsStringOnly(typeNode: ts.TypeNode): boolean {
+  if (typeNode.kind === ts.SyntaxKind.StringKeyword) return true;
+  if (ts.isParenthesizedTypeNode(typeNode)) return typeNodeIsStringOnly(typeNode.type);
+  if (ts.isLiteralTypeNode(typeNode)) return ts.isStringLiteral(typeNode.literal);
+  if (ts.isUnionTypeNode(typeNode)) return typeNode.types.every(typeNodeIsStringOnly);
+  return false;
+}
+
+function typeNodeIsNumberOnly(typeNode: ts.TypeNode): boolean {
+  if (typeNode.kind === ts.SyntaxKind.NumberKeyword) return true;
+  if (ts.isParenthesizedTypeNode(typeNode)) return typeNodeIsNumberOnly(typeNode.type);
+  if (ts.isLiteralTypeNode(typeNode)) {
+    if (ts.isNumericLiteral(typeNode.literal)) return true;
+    return (
+      ts.isPrefixUnaryExpression(typeNode.literal) &&
+      (typeNode.literal.operator === ts.SyntaxKind.PlusToken ||
+        typeNode.literal.operator === ts.SyntaxKind.MinusToken) &&
+      ts.isNumericLiteral(typeNode.literal.operand)
+    );
+  }
+  if (ts.isUnionTypeNode(typeNode)) return typeNode.types.every(typeNodeIsNumberOnly);
+  return false;
+}
+
+function isLiteralStringReplaceCall(expr: ts.CallExpression): boolean {
+  if (!ts.isPropertyAccessExpression(expr.expression) || expr.expression.name.text !== "replace") return false;
+  if (expr.arguments.length !== 2) return false;
+  return (
+    expressionIsProvenString(expr.expression.expression) &&
+    expr.arguments.every((arg) => ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg))
+  );
+}
+
 function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClasses: ReadonlySet<string>): boolean {
   if (
     (expressionTouchesModuleExtern(expr) || expressionTouchesModuleMapGetAlias(expr)) &&
@@ -3559,6 +3735,9 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     }
     if (expressionMayBeModuleExtern(expr.operand)) {
       return shapeNo("expr-module-extern-prefix", expr);
+    }
+    if (expr.operator === ts.SyntaxKind.TildeToken && !expressionIsProvenNumber(expr.operand)) {
+      return shapeNo("expr-tilde-nonnumeric", expr.operand);
     }
     return isPhase1Expr(expr.operand, scope, localClasses);
   }
@@ -3730,15 +3909,54 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
       // generic receiver check below would reject these. Recognise the shape
       // here and accept it; the lowerer in from-ast.ts emits a plain unary
       // f64 op for the call.
+      const mathPlan = IR_MATH_METHOD_TABLE[expr.expression.name.text];
       if (
         ts.isIdentifier(expr.expression.expression) &&
         expr.expression.expression.text === "Math" &&
-        currentModuleBindingResolver?.isDirectModuleBinding(expr.expression.expression) !== true &&
-        IR_MATH_UNARY_WHITELIST.has(expr.expression.name.text) &&
-        expr.arguments.length === 1 &&
-        !ts.isSpreadElement(expr.arguments[0]!)
+        selectorSeesAmbientBinding(expr.expression.expression) &&
+        !scope.has(expr.expression.expression.text) &&
+        mathPlan !== undefined &&
+        selectorSupportsMathPlan(mathPlan) &&
+        expr.arguments.length === mathPlan.arity
       ) {
-        return isPhase1Expr(expr.arguments[0]!, scope, localClasses);
+        return expr.arguments.every(
+          (arg) => !ts.isSpreadElement(arg) && expressionIsProvenNumber(arg) && isPhase1Expr(arg, scope, localClasses),
+        );
+      }
+      if (
+        ts.isIdentifier(expr.expression.expression) &&
+        expr.expression.expression.text === "Math" &&
+        selectorSeesAmbientBinding(expr.expression.expression)
+      ) {
+        return shapeNo("expr-math-call-shape", expr);
+      }
+      const builtinReceiver = expr.expression.expression;
+      const checkerReceiverFamily = currentSelectionOptions?.classifyDeclaredPrimitiveExpression?.(builtinReceiver);
+      const scalarReceiverFamily = currentModuleBindingResolver?.scalarExpressionFamily(builtinReceiver);
+      const builtinReceiverFamily =
+        checkerReceiverFamily ??
+        (scalarReceiverFamily === "f64" ? "number" : scalarReceiverFamily === "boolean" ? "boolean" : undefined);
+      const isNumberReceiver = builtinReceiverFamily === "number" || expressionIsProvenNumber(builtinReceiver);
+      const isStringReceiver = builtinReceiverFamily === "string" || expressionIsProvenString(builtinReceiver);
+      if (expr.expression.name.text === "toFixed" && isNumberReceiver) {
+        if (!isBoundedToFixedCall(expr)) return shapeNo("expr-number-tofixed-shape", expr);
+        return (
+          isPhase1Expr(builtinReceiver, scope, localClasses) && isPhase1Expr(expr.arguments[0]!, scope, localClasses)
+        );
+      }
+      if (expr.expression.name.text === "toFixed" && (builtinReceiverFamily !== undefined || isStringReceiver)) {
+        return shapeNo("expr-number-tofixed-receiver", expr);
+      }
+      if (expr.expression.name.text === "replace" && isStringReceiver) {
+        if (currentSelectionOptions?.supportsLiteralStringReplace !== true) {
+          return shapeNo("expr-string-replace-backend", expr);
+        }
+        if (!isLiteralStringReplaceCall(expr)) return shapeNo("expr-string-replace-shape", expr);
+        if (!isPhase1Expr(builtinReceiver, scope, localClasses)) return false;
+        return expr.arguments.every((arg) => isPhase1Expr(arg, scope, localClasses));
+      }
+      if (expr.expression.name.text === "replace" && builtinReceiverFamily !== undefined) {
+        return shapeNo("expr-string-replace-receiver", expr);
       }
       // (#2856 C3/Capability C) Preserve the exact Map.get/set arity guard,
       // but identify the receiver through its checker-owned declaration.
@@ -4381,11 +4599,14 @@ function buildLocalCallGraph(
           // receiver — `Math` is a host global that the receiver-walk
           // would otherwise mark as external. We still walk args to
           // catch nested external calls.
+          const mathPlan = IR_MATH_METHOD_TABLE[node.expression.name.text];
           if (
             ts.isIdentifier(node.expression.expression) &&
             node.expression.expression.text === "Math" &&
-            currentModuleBindingResolver?.isDirectModuleBinding(node.expression.expression) !== true &&
-            IR_MATH_UNARY_WHITELIST.has(node.expression.name.text)
+            selectorSeesAmbientBinding(node.expression.expression) &&
+            mathPlan !== undefined &&
+            selectorSupportsMathPlan(mathPlan) &&
+            node.arguments.length === mathPlan.arity
           ) {
             for (const a of node.arguments) visit(a);
             return;

--- a/tests/issue-2856-builtins-component.test.ts
+++ b/tests/issue-2856-builtins-component.test.ts
@@ -1,0 +1,365 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2856 builtins component: exact Math helpers, bounded number formatting,
+// literal String.replace, and numeric bitwise-not. Positive cases assert
+// genuine IR emission; unsupported coercive/dynamic shapes reject pre-claim.
+
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { analyzeSource } from "../src/checker/index.js";
+import { compile } from "../src/index.js";
+import { getLastLinearIrReport } from "../src/ir/backend/linear-integration.js";
+import {
+  makeIrAmbientBindingPredicate,
+  makeIrDeclaredPrimitiveExpressionClassifier,
+  makeIrPrimitiveExpressionClassifier,
+} from "../src/ir/module-bindings.js";
+import { buildTypeMap } from "../src/ir/propagate.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { buildImports } from "../src/runtime.js";
+
+const JS_STRING = {
+  concat: (a: string, b: string) => a + b,
+  length: (s: string) => s.length,
+  equals: (a: string, b: string) => (a === b ? 1 : 0),
+  substring: (s: string, start: number, end: number) => s.substring(start, end),
+  charCodeAt: (s: string, i: number) => s.charCodeAt(i),
+  fromCharCode: (c: number) => String.fromCharCode(c),
+  cast: (s: unknown) => String(s),
+  test: (v: unknown) => (typeof v === "string" ? 1 : 0),
+};
+
+async function compileSource(source: string, extra: Record<string, unknown> = {}) {
+  const result = await compile(source, {
+    fileName: "issue-2856-builtins-component.ts",
+    experimentalIR: true,
+    trackFallbacks: true,
+    ...extra,
+  });
+  expect(result.success, result.errors[0]?.message).toBe(true);
+  expect(result.irPostClaimErrors ?? []).toStrictEqual([]);
+  return result;
+}
+
+async function instantiate(source: string, experimentalIR: boolean) {
+  const result = await compile(source, {
+    fileName: "issue-2856-builtins-runtime.ts",
+    experimentalIR,
+    trackFallbacks: true,
+  });
+  expect(result.success, result.errors[0]?.message).toBe(true);
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const imports: WebAssembly.Imports = { env: built.env, string_constants: built.string_constants };
+  imports["wasm:js-string"] = JS_STRING as unknown as WebAssembly.ModuleImports;
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return {
+    result,
+    exports: instance.exports as Record<string, (...args: number[]) => number | string>,
+  };
+}
+
+describe("#2856 builtins component", () => {
+  it("genuinely IR-compiles the playground builtins main", async () => {
+    const source = await readFile("website/playground/examples/js/builtins.ts", "utf8");
+    const result = await compileSource(source, { fileName: "website/playground/examples/js/builtins.ts" });
+    expect(result.irCompiledFuncs ?? []).toContain("main");
+  });
+
+  it("matches legacy for direct and self-hosted Math methods", async () => {
+    const source = `
+      export function abs(): number { return Math.abs(-3.5); }
+      export function sqrt(): number { return Math.sqrt(144); }
+      export function floor(): number { return Math.floor(3.9); }
+      export function ceil(): number { return Math.ceil(3.1); }
+      export function trunc(): number { return Math.trunc(-3.9); }
+      export function sin(): number { return Math.sin(0.75); }
+      export function cos(): number { return Math.cos(0.75); }
+      export function exp(): number { return Math.exp(1.25); }
+      export function log(): number { return Math.log(3.5); }
+      export function log2(): number { return Math.log2(32); }
+      export function pow(): number { return Math.pow(2.5, 3); }
+      export function atan2(): number { return Math.atan2(1, -1); }
+    `;
+    const [ir, legacy] = await Promise.all([instantiate(source, true), instantiate(source, false)]);
+    for (const name of ["abs", "sqrt", "floor", "ceil", "trunc", "sin", "cos", "exp", "log", "log2", "pow", "atan2"]) {
+      expect(ir.result.irCompiledFuncs ?? []).toContain(name);
+      expect(ir.exports[name]!()).toBe(legacy.exports[name]!());
+    }
+  });
+
+  it("matches legacy for ToInt32 bitwise-not edge values", async () => {
+    const source = `
+      export function zero(): number { return ~0; }
+      export function minusOne(): number { return ~-1; }
+      export function highBit(): number { return ~2147483648; }
+      export function uintMax(): number { return ~4294967295; }
+      export function uintWrap(): number { return ~4294967296; }
+      export function belowIntMin(): number { return ~-2147483649; }
+      export function fraction(): number { return ~1.9; }
+      export function negativeZero(): number { return ~-0; }
+      export function nan(): number { return ~(0 / 0); }
+      export function positiveInfinity(): number { return ~(1 / 0); }
+      export function negativeInfinity(): number { return ~(-1 / 0); }
+    `;
+    const [ir, legacy] = await Promise.all([instantiate(source, true), instantiate(source, false)]);
+    for (const name of [
+      "zero",
+      "minusOne",
+      "highBit",
+      "uintMax",
+      "uintWrap",
+      "belowIntMin",
+      "fraction",
+      "negativeZero",
+      "nan",
+      "positiveInfinity",
+      "negativeInfinity",
+    ]) {
+      expect(ir.result.irCompiledFuncs ?? []).toContain(name);
+      expect(ir.exports[name]!()).toBe(legacy.exports[name]!());
+    }
+  });
+
+  it("matches legacy for bounded literal toFixed and literal replace", async () => {
+    const source = `
+      export function fixedOne(): string { return Math.log2(1024).toFixed(1); }
+      export function fixedSix(): string { return Math.atan2(1, 1).toFixed(6); }
+      export function replaceLiteral(): string {
+        const hello = "Hello, WebAssembly!";
+        return hello.replace("Hello", "Hi");
+      }
+    `;
+    const [ir, legacy] = await Promise.all([instantiate(source, true), instantiate(source, false)]);
+    for (const name of ["fixedOne", "fixedSix", "replaceLiteral"]) {
+      expect(ir.result.irCompiledFuncs ?? []).toContain(name);
+      expect(ir.exports[name]!()).toBe(legacy.exports[name]!());
+    }
+  });
+
+  it("rejects shadowed Math, wrong arities, and unsafe builtin arguments before claim", async () => {
+    const shadowed = await compileSource(
+      `
+      const Math = { pow: (a: number, b: number): number => a + b };
+      export function shadow(): number { return Math.pow(2, 3); }
+      export function shadowParam(Math: any): number { return Math.pow(2, 3); }
+    `,
+      { skipSemanticDiagnostics: true },
+    );
+    expect(shadowed.irCompiledFuncs ?? []).not.toContain("shadow");
+    expect(shadowed.irCompiledFuncs ?? []).not.toContain("shadowParam");
+
+    const source = `
+      export function wrongUnary(): number { return Math.sin(); }
+      export function wrongBinary(): number { return Math.pow(2); }
+      export function nonNumericMath(): number { return Math.sin(true); }
+      export function dynamicFixed(digits: number): string { return (1.25).toFixed(digits); }
+      export function outOfRangeFixed(): string { return (1.25).toFixed(101); }
+      export function regexpReplace(): string { return "aba".replace(/a/g, "x"); }
+      export function callbackReplace(): string { return "aba".replace("a", () => "x"); }
+      export function numberReplace(): string { return (123).replace("1", "x"); }
+      export function stringTilde(): number { return ~("1" as any); }
+    `;
+    const result = await compileSource(source, { skipSemanticDiagnostics: true });
+    for (const name of [
+      "wrongUnary",
+      "wrongBinary",
+      "nonNumericMath",
+      "dynamicFixed",
+      "outOfRangeFixed",
+      "regexpReplace",
+      "callbackReplace",
+      "numberReplace",
+      "stringTilde",
+    ]) {
+      expect(result.irCompiledFuncs ?? []).not.toContain(name);
+    }
+  });
+
+  it("rejects a literal initialized with a non-string local representation before claim", async () => {
+    const result = await compileSource(
+      `
+      export function annotatedNumberReplace(): string {
+        const value: number = "aba";
+        return value.replace("a", "x");
+      }
+      export function annotatedStringReplace(): string {
+        const value: string = 123;
+        return value.replace("1", "x");
+      }
+    `,
+      { skipSemanticDiagnostics: true },
+    );
+    expect(result.irCompiledFuncs ?? []).not.toContain("annotatedNumberReplace");
+    expect(result.irCompiledFuncs ?? []).not.toContain("annotatedStringReplace");
+    expect(result.irPostClaimErrors ?? []).toStrictEqual([]);
+  });
+
+  it("keeps class methods named like builtins on ordinary class dispatch", async () => {
+    const source = `
+      class Formatter {
+        replace(value: number): number { return value + 1; }
+        toFixed(value: number): number { return value * 2; }
+      }
+      export function classNamedMethods(): number {
+        const formatter = new Formatter();
+        return formatter.replace(4) + formatter.toFixed(3);
+      }
+    `;
+    const [ir, legacy] = await Promise.all([instantiate(source, true), instantiate(source, false)]);
+    expect(ir.result.irCompiledFuncs ?? []).toContain("classNamedMethods");
+    expect(ir.exports.classNamedMethods!()).toBe(legacy.exports.classNamedMethods!());
+    expect(ir.exports.classNamedMethods!()).toBe(11);
+  });
+
+  it("rejects invalid annotated numeric initializers before builtin claims", async () => {
+    const source = `
+      export function invalidFixed(): string {
+        const value: number = "aba";
+        return value.toFixed(1);
+      }
+      export function invalidMath(): number {
+        const value: number = "aba";
+        return Math.sin(value);
+      }
+      export function invalidTilde(): number {
+        const value: number = "aba";
+        return ~value;
+      }
+      export function inferredFixed(): string {
+        const value = 1.25;
+        return value.toFixed(1);
+      }
+      export function inferredMath(): number {
+        const value = 0.5;
+        return Math.sin(value);
+      }
+      export function inferredTilde(): number {
+        const value = 1.9;
+        return ~value;
+      }
+    `;
+    const result = await compileSource(source, { skipSemanticDiagnostics: true });
+    for (const name of ["invalidFixed", "invalidMath", "invalidTilde"]) {
+      expect(result.irCompiledFuncs ?? []).not.toContain(name);
+    }
+    for (const name of ["inferredFixed", "inferredMath", "inferredTilde"]) {
+      expect(result.irCompiledFuncs ?? []).toContain(name);
+    }
+  });
+
+  it("rejects literal replace before claim when the linear planner has no method plan", async () => {
+    const result = await compile(
+      `
+        export function linearReplace(value: string): string { return value.replace("a", "x"); }
+        export function linearFixedParam(value: number): string { return value.toFixed(1); }
+        export function linearFixedLocal(): string {
+          const value = 1.25;
+          return value.toFixed(1);
+        }
+        export function linearInvalidStringReplace(): string {
+          const value: string = 123;
+          return value.replace("1", "x");
+        }
+        export function linearMixedReplace(flag: boolean): string {
+          const value: string | number = flag ? "aba" : 123;
+          return value.replace("a", "x");
+        }
+        export function linearNullableReplace(flag: boolean): string {
+          const value: string | null = flag ? "aba" : null;
+          return value.replace("a", "x");
+        }
+      `,
+      {
+        fileName: "issue-2856-linear-builtins.ts",
+        experimentalIR: true,
+        trackFallbacks: true,
+        target: "linear",
+        skipSemanticDiagnostics: true,
+      },
+    );
+    expect(result.irPostClaimErrors ?? []).toStrictEqual([]);
+    const report = getLastLinearIrReport();
+    expect(report).toBeDefined();
+    for (const name of [
+      "linearReplace",
+      "linearFixedParam",
+      "linearFixedLocal",
+      "linearInvalidStringReplace",
+      "linearMixedReplace",
+      "linearNullableReplace",
+    ]) {
+      expect(report?.compiled).not.toContain(name);
+      const rejected = report?.rejected.filter((entry) => entry.func === name) ?? [];
+      expect(rejected.some((entry) => entry.reason === "select:body-shape-rejected")).toBe(true);
+      expect(rejected.some((entry) => entry.reason === "build")).toBe(false);
+    }
+  });
+
+  it("keeps direct ambient Math ops on linear IR without admitting a shadow", async () => {
+    const result = await compile(`export function absolute(value: number): number { return Math.abs(value); }`, {
+      fileName: "issue-2856-linear-math.ts",
+      experimentalIR: true,
+      trackFallbacks: true,
+      target: "linear",
+    });
+    expect(result.success, result.errors[0]?.message).toBe(true);
+    expect(getLastLinearIrReport()?.compiled).toContain("absolute");
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect((instance.exports.absolute as (value: number) => number)(-3.5)).toBe(3.5);
+
+    const shadowed = analyzeSource(`
+      const Math = { abs: (value: number): number => value };
+      export function shadowed(): number { return Math.abs(-3.5); }
+    `);
+    const shadowedSelection = planIrCompilation(
+      shadowed.sourceFile,
+      {
+        experimentalIR: true,
+        trackFallbacks: true,
+        classifyPrimitiveExpression: makeIrPrimitiveExpressionClassifier(shadowed.checker),
+        classifyDeclaredPrimitiveExpression: makeIrDeclaredPrimitiveExpressionClassifier(shadowed.checker),
+        isAmbientBinding: makeIrAmbientBindingPredicate(shadowed.checker),
+        supportsSymbolicMathHelpers: false,
+      },
+      buildTypeMap(shadowed.sourceFile, shadowed.checker),
+    );
+    expect(shadowedSelection.funcs).not.toContain("shadowed");
+    expect(shadowedSelection.fallbacks).toContainEqual(
+      expect.objectContaining({ name: "shadowed", reason: "body-shape-rejected" }),
+    );
+
+    await compile(`export function invalid(): number { const value: number = "oops"; return Math.abs(value); }`, {
+      fileName: "issue-2856-linear-invalid-math.ts",
+      experimentalIR: true,
+      trackFallbacks: true,
+      target: "linear",
+      skipSemanticDiagnostics: true,
+    });
+    const invalidReport = getLastLinearIrReport();
+    expect(invalidReport?.compiled).not.toContain("invalid");
+    expect(invalidReport?.rejected.some((entry) => entry.func === "invalid" && entry.reason === "build")).toBe(false);
+  });
+
+  it("preserves typed-string replace fallback in host and native string modes", async () => {
+    const source = `export function typedReplace(value: string): string { return value.replace("a", "x"); }`;
+    for (const extra of [{}, { nativeStrings: true }]) {
+      const result = await compileSource(source, extra);
+      expect(result.irCompiledFuncs ?? []).not.toContain("typedReplace");
+    }
+  });
+
+  it("keeps bounded toFixed out of unsupported representation modes", async () => {
+    const source = `export function fixed(): string { return (1.25).toFixed(1); }`;
+    for (const extra of [{ nativeStrings: true }, { fast: true }, { target: "standalone" }, { target: "wasi" }]) {
+      const result = await compileSource(source, extra);
+      expect(result.irCompiledFuncs ?? []).not.toContain("fixed");
+    }
+
+    const nativeReplace = await compileSource(
+      `export function replacedLength(): number { return "aba".replace("a", "x").length; }`,
+      { nativeStrings: true },
+    );
+    expect(nativeReplace.irCompiledFuncs ?? []).toContain("replacedLength");
+  });
+});


### PR DESCRIPTION
## Description

- Compile `website/playground/examples/js/builtins.ts::main` through the IR path with a shared exact-arity Math plan, numeric `~`, bounded host `toFixed`, and literal-string `replace`.
- Keep selector and lowerer capabilities aligned across WasmGC and linear backends, with checker-backed ambient and primitive provenance guards for shadowed, coercive, invalid-annotation, and unsupported-mode cases.
- Ratchet the markdown-tracked function-level `body-shape-rejected` baseline from 13 to 12 while preserving module-level 2 and zero post-claim demotions.

## Validation

- Focused and adjacent IR suites: 154/154
- IR fallback gate: 12 function-level, 2 module-level, zero post-claim
- Typecheck, Prettier, LOC budget, and diff checks
- Full equivalence gate: 1,607 passing / 36 known failures / zero regressions

## CLA

- [x] I have read and agree to the CLA
