### PR TITLE
feat(ir): add a bounded multi-module overlay

### DIFF
--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -8,7 +8,7 @@ pipeline_unblocked: 1927
 spec: ready
 sprint: 69
 created: 2026-06-12
-updated: 2026-07-03
+updated: 2026-07-21
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -17,7 +17,9 @@ task_type: architecture
 area: compiler
 language_feature: compiler-internals
 goal: maintainability
-related: [1530, 1916, 1927, 2135, 2945, 2947, 2972, 2973]
+related: [1530, 1916, 1927, 2135, 2856, 2945, 2947, 2972, 2973]
+loc-budget-allow:
+  - src/codegen/index.ts
 origin: "2026-06-12 sprint-62 architecture analysis (pipeline workstream N2)"
 ---
 
@@ -636,3 +638,52 @@ gate 4 is latent, so results are comparable). Raw JSON:
   load-bearing) — rerun the sweep; the skip set should stay trap-free while
   the claim rate rises. The suite-scale per-run stat still needs the small
   runner extension (`irFirstSkipped` into the JSONL rows) if wanted.
+
+## Slice 4 M0 — bounded multi-module overlay (2026-07-21)
+
+`generateMultiModule` now runs the WasmGC IR overlay after **all** source
+files have emitted their legacy bodies and after `finalizeMethodTrampolines`.
+This is deliberately compile-twice only: M0 never supplies a body-skip set,
+never patches the graph's shared `__module_init`, and keeps class members on
+legacy. Each source is planned without `resolveModuleBinding`, so imported
+calls remain selector-external until the cross-module call capability lands.
+
+The flat-name safety boundary is explicit. Cross-file top-level function-name
+collisions and their selected local call components stay legacy-owned. The M0
+copy of the selection also excludes functions that reference import bindings,
+nested/generic bodies whose synthesized names are not graph-unique, and the
+remaining cross-file caller ABI hazards, including checker-resolved global
+script references with no import syntax (all cross-file targets in
+standalone/WASI, callable-parameter or callable-result targets in host mode).
+The IR integration report is consumed through the same diagnostic path as
+single-source codegen;
+`irCompiledFuncs` aggregates genuine emission across source files and every
+post-claim failure still reaches `irPostClaimErrors` plus the established
+fallback diagnostic.
+
+Measured by `tests/issue-2138-multi-module-ir-overlay.test.ts`:
+
+- `compileMulti` genuinely IR-emits one pure numeric function in the dependency
+  (`depPure`) and one in the entry (`entryPure`), while a renamed imported
+  caller, module-binding reader, module-init callee, and `<module-init>` remain
+  absent from `irCompiledFuncs`.
+- IR-on and `experimentalIR: false` both produce runtime values
+  `[9, 15, 42]`; the `42` is initialized by the preserved legacy module-init
+  body. `irFirstSkipped` remains absent on both multi paths.
+- A two-module flat-name collision keeps both colliding declarations and their
+  local callers on legacy while unrelated leaves in both files still IR-emit.
+- Standalone keeps the cross-file imported target on legacy (caller-side ABI
+  closure) while an independent entry function still genuinely IR-emits; the
+  same `[9, 15, 42]` runtime values hold.
+- Checker-resolved global-script calls follow the same closure: host targets
+  with callable parameters/results stay legacy and preserve runtime parity,
+  while a scalar target may IR-emit only in host mode; standalone keeps every
+  cross-file target on legacy.
+- A top-level function that constructs and reads a local class can IR-emit with
+  runtime parity while the constructor and method slots remain legacy-owned.
+- The same anti-vacuity/import-boundary assertions pass through `compileFiles`
+  and `compileProject`.
+- All focused probes report **zero post-claim demotions**. Rebasing M0 after
+  the builtins component preserves its banked floor: the repository fallback
+  ratchet reports exact zero delta (`body-shape-rejected` 12→12,
+  module-level 2→2, post-claim none) via `pnpm run check:ir-fallbacks`.

--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -1324,6 +1324,36 @@ pre-claim routing, and representation-mode gates; typecheck and the fallback
 gate clean; full equivalence gate at 1,607 passing / 36 known failures with no
 new regressions.
 
+### Prerequisite M0 (zero delta) — bounded multi-module IR overlay
+
+Imported-callee coverage cannot be measured honestly until the multi-source
+entry points actually run the IR overlay. M0 adds that compile-twice seam to
+`compileMulti`, `compileFiles`, and `compileProject` only after every legacy
+body and method trampoline exists. It deliberately leaves module init, class
+members, imports, ambiguous flat names, and unsafe cross-file callable ABI
+components legacy-owned. Graph-wide collision pruning and checker-resolved
+global-script edges prevent an IR body from patching or calling the wrong flat
+function slot.
+
+M0 is an enabling slice, not a bucket-serving claim widening. Its focused
+multi-source probes genuinely IR-emit safe leaves with runtime parity while
+the fallback gate remains exactly **12 → 12**, module-level **2 → 2**, and
+post-claim buckets stay empty. This prerequisite must land before imported-call
+selection is widened.
+
+### Prerequisite B0 (zero delta) — one callable boundary ABI
+
+The legacy front end carries callable parameters and results as `externref`
+wrappers rooted in `__fn_wrap_*`; the current IR closure types use a private
+`__ir_closure_base_*` hierarchy. Direct all-IR tests hide that mismatch, but an
+M0 mixed-front-end call can expose an invalid signature or cast. Before any
+imported call or top-level function value is claimed, #3214 must establish one
+boundary representation: keep typed closures internal, pack them into the
+legacy wrapper carrier at callable positions, and unpack through the exact
+signature wrapper before `call_ref`. B0 must prove both IR→legacy and legacy→IR
+callable parameters/results while preserving **12 → 12** and zero post-claim
+demotions.
+
 ### Capability A (M) — imported-callee calls (first half of the 8 mains)
 
 Root: the gate compiles each corpus file as its own program
@@ -1360,13 +1390,13 @@ Design (mirror the extern-in-IR split — selection runs early, from-ast late):
 `external-call`** — measure with `--shape-diag` + `--verbose`; if the mains
 still reject on the function-reference args, A+B must land together.
 
-### Capability B (L) — first-class function references + arrow values
+### Capability B1/B2 (L) — first-class function references + arrow values
 
 Two arms, both required by the mains' `addBenchCard("fib", bench_fib)`-style
 calls and by `addBenchCard` itself (`expr-unhandled:ArrowFunction`, the
 `addEventListener("click", () => …)` callback):
 
-1. **Top-level function reference as a value** — an Identifier referencing a
+1. **B1: top-level function reference as a value** — an Identifier referencing a
    FunctionDeclaration in argument position with a function-typed param.
    Lower to the closure ABI legacy uses for the same site (`$__fn_wrap` /
    `builtin-fn-meta.ts`, `closures.ts`) — the emitter primitives already
@@ -1375,7 +1405,7 @@ calls and by `addBenchCard` itself (`expr-unhandled:ArrowFunction`, the
    bar** (a legacy callee will `call_ref` through the same wrapper type —
    mind the #2873 wrapper-RTT creation-order hazard: cast to ROOT + funcref
    sig-dispatch, don't depend on RTT order).
-2. **Arrow-function expressions as values in argument position** —
+2. **B2: arrow-function expressions as values in argument position** —
    `isPhase1ClosureLiteral` (`select.ts:2490`) exists but is only consulted
    from var-decl initializer position (`:2357`). Widen to call-argument
    position; from-ast reuses the same closure-literal lowering. Captures:
@@ -1393,9 +1423,16 @@ dictate an unshippable capability.
 
 ### Ordering and landability
 
-1. Step 0 (S, landed) → 2. Capability C (M–L, independently landable,
-   measured −1) → 3. Capability A (M) → 4. Capability B (L; A+B together if
-   A alone is net-zero) → 5. `delay` decision.
+1. Step 0 (landed) → 2. Capability C (landed, measured −1) → 3. builtins
+   component (measured −1) → 4. M0 multi-module overlay (zero delta) → 5. B0
+   canonical callable ABI (zero delta) → 6. Capability A + B1 atomically → 7.
+   B2 arrow values → 8. remaining calendar shapes → 9. `delay` support or an
+   explicitly approved deferred rebucket.
+
+The expected measurement sequence from the current 12 floor is
+**12 → 12 → 12 → 5 → 4 → 1 → 0**. Treat those intermediate numbers as routing
+forecasts, not acceptance substitutes: each slice banks only its observed gate
+result, and any mismatch is diagnosed before widening the next claim surface.
 
 Each slice: prove claims via byte-diff/`irFirstSkipped` (anti-vacuity, the
 established pattern), zero post-claim demotions, bank via

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -8,6 +8,7 @@ import { isLinearU8RepresentableNew } from "./linear-uint8-signatures.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
 import { emitVecDefineWritebackExports } from "./vec-define-writeback.js"; // (#3116)
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
+import type { TypeFact } from "../checker/oracle.js";
 import {
   isBigIntType,
   isBooleanType,
@@ -2256,25 +2257,24 @@ function functionBodyContainsNestedRuntimeDeclaration(fn: ts.FunctionDeclaration
   return found;
 }
 
-function typeContainsCallSignature(type: ts.Type): boolean {
-  if (type.getCallSignatures().length > 0) return true;
-  return type.isUnionOrIntersection() && type.types.some(typeContainsCallSignature);
+function typeFactCouldBeCallable(fact: TypeFact): boolean {
+  if (fact.kind === "function") return true;
+  if (fact.kind === "union") return fact.parts.some(typeFactCouldBeCallable);
+  // This is a safety gate: an incomplete fact must reduce M0 coverage rather
+  // than let a legacy caller cross an ABI boundary we have not proven.
+  return fact.kind === "any" || fact.kind === "unknown" || fact.kind === "unresolvable";
 }
 
 /** Callable parameters/returns still have a legacy↔IR wrapper ABI boundary. */
 function functionHasCallableBoundary(ctx: CodegenContext, declaration: ts.FunctionDeclaration): boolean {
-  try {
-    for (const parameter of declaration.parameters) {
-      if (parameter.type !== undefined && ts.isFunctionTypeNode(parameter.type)) return true;
-      if (typeContainsCallSignature(ctx.checker.getTypeAtLocation(parameter))) return true;
-    }
-    const signature = ctx.checker.getSignatureFromDeclaration(declaration);
-    return signature !== undefined && typeContainsCallSignature(ctx.checker.getReturnTypeOfSignature(signature));
-  } catch {
-    // Unknown callable shape is ABI-sensitive until the canonical callable ABI
-    // slice makes legacy/IR wrappers interchangeable.
-    return true;
+  for (const parameter of declaration.parameters) {
+    if (parameter.type !== undefined && ts.isFunctionTypeNode(parameter.type)) return true;
+    if (typeFactCouldBeCallable(ctx.oracle.typeFactOf(parameter))) return true;
   }
+  const signature = ctx.oracle.signatureOf(declaration);
+  // Unknown callable shape is ABI-sensitive until the canonical callable ABI
+  // slice makes legacy/IR wrappers interchangeable.
+  return signature === undefined || typeFactCouldBeCallable(signature.returns);
 }
 
 /**

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -24,10 +24,15 @@ import {
 } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, StructTypeDef, ValType, WasmFunction, WasmModule } from "../ir/types.js";
 import { createEmptyModule } from "../ir/types.js";
-import { compileIrPathFunctions, type IrIntegrationError } from "../ir/integration.js";
+import { compileIrPathFunctions, type IrIntegrationError, type IrIntegrationReport } from "../ir/integration.js";
 import { asVal, irDynamic, isDynamic, irVal, type IrType } from "../ir/nodes.js";
 import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
-import { planIrCompilation, irClosureSignatureFromFunctionTypeNode, type IrFallbackReason } from "../ir/select.js";
+import {
+  planIrCompilation,
+  irClosureSignatureFromFunctionTypeNode,
+  type IrFallbackReason,
+  type IrSelection,
+} from "../ir/select.js";
 import { makeIrHostGlobalResolver } from "../ir/host-extern.js"; // (#2856)
 import {
   makeIrDeclaredPrimitiveExpressionClassifier,
@@ -37,7 +42,12 @@ import {
 import { asyncEngineWouldActivate } from "./async-activation.js"; // (#1373b C-1)
 import { unwrapPromiseTypeNode } from "./async-static.js"; // (#1373b C-1)
 import { createCodegenContext } from "./context/create-context.js";
-import { collectLocalCallEdges, irFirstBodyIsProvenLowerable, type ValueDomain } from "./ir-first-gate.js";
+import {
+  collectLocalCallEdges,
+  irFirstBodyIsProvenLowerable,
+  MODULE_INIT_CALLER,
+  type ValueDomain,
+} from "./ir-first-gate.js";
 import type { FallbackCounts } from "./fallback-telemetry.js";
 import { truthyEnv } from "./fallback-telemetry.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
@@ -1728,7 +1738,11 @@ function computeIrFirstSkipSet(
   return skip;
 }
 
-function planIrOverlay(ctx: CodegenContext, ast: TypedAST): IrOverlayPlan {
+function planIrOverlay(
+  ctx: CodegenContext,
+  ast: TypedAST,
+  options: { readonly resolveModuleBindings?: boolean } = {},
+): IrOverlayPlan {
   const typeMap = buildTypeMap(ast.sourceFile, ast.checker);
   // #1169q telemetry — when JS2WASM_LOG_IR_FALLBACKS is set, request the
   // selector to track every top-level FunctionDeclaration that didn't
@@ -1752,11 +1766,14 @@ function planIrOverlay(ctx: CodegenContext, ast: TypedAST): IrOverlayPlan {
   // time from-ast lowers (post-`compileDeclarations`), which is where member
   // resolution happens.
   const jsHostExterns = !(ctx.standalone || ctx.wasi || ctx.strictNoHostImports);
-  const resolveModuleBinding = makeIrModuleBindingResolver(ast.checker, {
-    numberStorage: ctx.fast ? "i32" : "f64",
-    allowHostExterns: jsHostExterns && !ctx.nativeStrings,
-    allowBuiltinMapExtern: jsHostExterns && !ctx.nativeStrings,
-  });
+  const resolveModuleBinding =
+    options.resolveModuleBindings === false
+      ? undefined
+      : makeIrModuleBindingResolver(ast.checker, {
+          numberStorage: ctx.fast ? "i32" : "f64",
+          allowHostExterns: jsHostExterns && !ctx.nativeStrings,
+          allowBuiltinMapExtern: jsHostExterns && !ctx.nativeStrings,
+        });
   const classifyPrimitiveExpression = makeIrPrimitiveExpressionClassifier(ast.checker);
   const classifyDeclaredPrimitiveExpression = makeIrDeclaredPrimitiveExpressionClassifier(ast.checker);
   // (#3053 U2) The gc `__dyn_member_get` body is sound in every config EXCEPT
@@ -1775,7 +1792,7 @@ function planIrOverlay(ctx: CodegenContext, ast: TypedAST): IrOverlayPlan {
       jsHostExterns,
       dynMemberReadBuildable,
       resolveHostGlobal: makeIrHostGlobalResolver(ast.checker),
-      resolveModuleBinding,
+      ...(resolveModuleBinding ? { resolveModuleBinding } : {}),
       classifyPrimitiveExpression,
       classifyDeclaredPrimitiveExpression,
       supportsSymbolicMathHelpers: true,
@@ -1942,6 +1959,409 @@ function planIrOverlay(ctx: CodegenContext, ast: TypedAST): IrOverlayPlan {
     safeSelection.moduleInit = undefined;
   }
   return { selection, classShapes, overrideMap, safeSelection, trackFallbacks, declByName };
+}
+
+/** Consume one IR overlay attempt through the shared diagnostics/telemetry path. */
+function consumeIrOverlayReport(
+  ctx: CodegenContext,
+  report: IrIntegrationReport,
+  selection: IrSelection,
+  trackFallbacks: boolean,
+  fileLabel: string,
+  irSkipBodies?: ReadonlySet<string>,
+): void {
+  // #3000 — aggregate genuine emission across every source-file overlay. A
+  // selector claim alone is not evidence that an existing function slot was
+  // patched successfully.
+  ctx.irCompiledFuncs = [...(ctx.irCompiledFuncs ?? []), ...report.compiled];
+
+  for (const err of report.errors) {
+    // #1923 — selector-claimed functions that fail build/verify/lower are
+    // metered even when their already-emitted legacy bodies remain usable.
+    (ctx.irPostClaimErrors ??= []).push({
+      kind: err.kind ?? "lower",
+      func: err.func,
+      message: err.message,
+    });
+    const diag = formatIrPathFallbackDiagnostic(err);
+    // #2138 — only the single-source IR-first path can omit a legacy body. The
+    // multi-module overlay never passes a skip set and therefore always keeps
+    // the ordinary warning demotion available.
+    const skippedTrap = irSkipBodies !== undefined && irSkipBodies.has(err.func);
+    ctx.errors.push({
+      message:
+        skippedTrap && diag.severity !== "error"
+          ? `Codegen error: ${diag.message} [IR-FIRST skipped-slot, #2138]`
+          : diag.message,
+      line: 0,
+      column: 0,
+      severity: skippedTrap ? "error" : diag.severity,
+    });
+  }
+
+  // #2138 — a skipped legacy slot must have been filled or have failed loud.
+  if (irSkipBodies !== undefined && irSkipBodies.size > 0) {
+    const compiledSet = new Set(report.compiled);
+    const erroredSet = new Set(report.errors.map((e) => e.func));
+    for (const name of irSkipBodies) {
+      if (!compiledSet.has(name) && !erroredSet.has(name)) {
+        reportErrorNoNode(
+          ctx,
+          `IR-first (#2138): legacy body for "${name}" was skipped but the IR path neither compiled it nor reported an error — the unreachable placeholder would ship. Selector/integration divergence; file an issue.`,
+        );
+      }
+    }
+  }
+
+  // #1169q — retain the existing selector-fallback log format, now once per
+  // source file for a multi-module compilation.
+  if (trackFallbacks && selection.fallbacks) {
+    const total = selection.funcs.size + selection.fallbacks.length;
+    const reasonHist: Record<string, number> = {};
+    for (const fb of selection.fallbacks) {
+      reasonHist[fb.reason] = (reasonHist[fb.reason] ?? 0) + 1;
+    }
+    const reasonStr = Object.entries(reasonHist)
+      .sort((a, b) => b[1] - a[1])
+      .map(([r, n]) => `${r}=${n}`)
+      .join(",");
+    process.stderr.write(
+      `[ir-fallback] file=${fileLabel || "<source>"} total=${total} claimed=${selection.funcs.size} fallback=${selection.fallbacks.length} reasons=${reasonStr}\n`,
+    );
+  }
+}
+
+/** Flat function names shared by two or more source files are not safe IR keys. */
+function collectMultiIrFunctionNameCollisions(sourceFiles: readonly ts.SourceFile[]): ReadonlySet<string> {
+  const owner = new Map<string, ts.SourceFile>();
+  const collisions = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    const namesInFile = new Set<string>();
+    for (const stmt of sourceFile.statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body && !hasDeclareModifier(stmt)) {
+        namesInFile.add(stmt.name.text);
+      }
+    }
+    for (const name of namesInFile) {
+      const previous = owner.get(name);
+      if (previous && previous !== sourceFile) collisions.add(name);
+      else owner.set(name, sourceFile);
+    }
+  }
+  return collisions;
+}
+
+function collectImportBindingNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      const clause = stmt.importClause;
+      if (!clause) continue;
+      if (clause.name) names.add(clause.name.text);
+      if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+        names.add(clause.namedBindings.name.text);
+      } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const element of clause.namedBindings.elements) names.add(element.name.text);
+      }
+    } else if (ts.isImportEqualsDeclaration(stmt)) {
+      names.add(stmt.name.text);
+    }
+  }
+  return names;
+}
+
+/** Import locals that can overwrite an unrelated flat `ctx.funcMap` key. */
+function collectMultiImportAliasNames(sourceFiles: readonly ts.SourceFile[]): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    for (const stmt of sourceFile.statements) {
+      if (ts.isImportDeclaration(stmt)) {
+        const clause = stmt.importClause;
+        if (!clause) continue;
+        if (clause.name) names.add(clause.name.text);
+        if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+          names.add(clause.namedBindings.name.text);
+        } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+          for (const element of clause.namedBindings.elements) {
+            const target = (element.propertyName ?? element.name).text;
+            if (element.name.text !== target) names.add(element.name.text);
+          }
+        }
+      } else if (ts.isImportEqualsDeclaration(stmt)) {
+        names.add(stmt.name.text);
+      }
+    }
+  }
+  return names;
+}
+
+/** Resolve cross-file import aliases back to their declared function names. */
+function collectMultiImportedFunctionNames(
+  sourceFiles: readonly ts.SourceFile[],
+  checker: ts.TypeChecker,
+): ReadonlySet<string> {
+  const names = new Set<string>();
+  const addFunctionDeclarations = (symbol: ts.Symbol | undefined): void => {
+    if (!symbol) return;
+    const target = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+    for (const declaration of target.declarations ?? []) {
+      if (ts.isFunctionDeclaration(declaration) && declaration.name) names.add(declaration.name.text);
+    }
+    if (target.flags & ts.SymbolFlags.Module) {
+      for (const exported of checker.getExportsOfModule(target)) {
+        const value = exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported;
+        for (const declaration of value.declarations ?? []) {
+          if (ts.isFunctionDeclaration(declaration) && declaration.name) names.add(declaration.name.text);
+        }
+      }
+    }
+  };
+  const addTarget = (local: ts.Identifier, syntacticTarget?: string): void => {
+    addFunctionDeclarations(checker.getSymbolAtLocation(local));
+    if (syntacticTarget) names.add(syntacticTarget);
+  };
+
+  for (const sourceFile of sourceFiles) {
+    for (const stmt of sourceFile.statements) {
+      if (!ts.isImportDeclaration(stmt)) continue;
+      const clause = stmt.importClause;
+      if (!clause) continue;
+      if (clause.name) addTarget(clause.name);
+      if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+        addTarget(clause.namedBindings.name);
+      } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const element of clause.namedBindings.elements) {
+          addTarget(element.name, (element.propertyName ?? element.name).text);
+        }
+      }
+    }
+    for (const stmt of sourceFile.statements) {
+      if (ts.isImportEqualsDeclaration(stmt)) addTarget(stmt.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Top-level function declarations referenced from a different source file.
+ *
+ * Import syntax covers ordinary ESM edges, but `compileMulti` also accepts
+ * global-script roots. A module can call a function declared by one of those
+ * roots without an `ImportDeclaration`; TypeScript still resolves the
+ * identifier to the other file's declaration. Treat that checker-resolved
+ * edge exactly like an imported target so a legacy caller never observes an
+ * IR-only callable ABI (the M0 overlay has no cross-file call closure yet).
+ */
+function collectMultiCrossFileFunctionNames(
+  sourceFiles: readonly ts.SourceFile[],
+  checker: ts.TypeChecker,
+): ReadonlySet<string> {
+  // Preserve the deliberately conservative namespace/default/re-export import
+  // handling above, then add all symbol-resolved cross-file references.
+  const names = new Set(collectMultiImportedFunctionNames(sourceFiles, checker));
+  // External modules can only cross source-file boundaries through the import
+  // surface already collected above. Pay the full checker walk only when a
+  // global-script root makes import-free cross-file references possible.
+  if (!sourceFiles.some((sourceFile) => !ts.isExternalModule(sourceFile))) return names;
+  const sourceSet = new Set(sourceFiles);
+  const allFunctionNames = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    for (const stmt of sourceFile.statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.name && stmt.body) allFunctionNames.add(stmt.name.text);
+    }
+  }
+  const markUnknownTargetConservatively = (): void => {
+    for (const name of allFunctionNames) names.add(name);
+  };
+
+  const addResolvedTarget = (symbol: ts.Symbol | undefined, referenceFile: ts.SourceFile): void => {
+    if (!symbol) return;
+    let target = symbol;
+    if (target.flags & ts.SymbolFlags.Alias) {
+      try {
+        target = checker.getAliasedSymbol(target);
+      } catch {
+        markUnknownTargetConservatively();
+        return;
+      }
+    }
+    for (const declaration of target.declarations ?? []) {
+      if (
+        ts.isFunctionDeclaration(declaration) &&
+        declaration.name &&
+        declaration.body &&
+        sourceSet.has(declaration.getSourceFile()) &&
+        declaration.getSourceFile() !== referenceFile
+      ) {
+        names.add(declaration.name.text);
+      }
+    }
+  };
+
+  for (const sourceFile of sourceFiles) {
+    const visit = (node: ts.Node): void => {
+      if (ts.isIdentifier(node)) {
+        try {
+          addResolvedTarget(checker.getSymbolAtLocation(node), sourceFile);
+        } catch {
+          // Safety scan uncertainty must only reduce M0 coverage. In host mode
+          // this blocks callable boundaries; standalone/WASI block every name.
+          markUnknownTargetConservatively();
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+  return names;
+}
+
+function functionBodyReferencesAnyName(fn: ts.FunctionDeclaration, names: ReadonlySet<string>): boolean {
+  if (!fn.body || names.size === 0) return false;
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isIdentifier(node) && names.has(node.text)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(fn.body);
+  return found;
+}
+
+/** Nested functions mint flat synthetic names that M0 cannot collision-prove. */
+function functionBodyContainsNestedRuntimeDeclaration(fn: ts.FunctionDeclaration): boolean {
+  if (!fn.body) return false;
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(fn.body, visit);
+  return found;
+}
+
+function typeContainsCallSignature(type: ts.Type): boolean {
+  if (type.getCallSignatures().length > 0) return true;
+  return type.isUnionOrIntersection() && type.types.some(typeContainsCallSignature);
+}
+
+/** Callable parameters/returns still have a legacy↔IR wrapper ABI boundary. */
+function functionHasCallableBoundary(ctx: CodegenContext, declaration: ts.FunctionDeclaration): boolean {
+  try {
+    for (const parameter of declaration.parameters) {
+      if (parameter.type !== undefined && ts.isFunctionTypeNode(parameter.type)) return true;
+      if (typeContainsCallSignature(ctx.checker.getTypeAtLocation(parameter))) return true;
+    }
+    const signature = ctx.checker.getSignatureFromDeclaration(declaration);
+    return signature !== undefined && typeContainsCallSignature(ctx.checker.getReturnTypeOfSignature(signature));
+  } catch {
+    // Unknown callable shape is ABI-sensitive until the canonical callable ABI
+    // slice makes legacy/IR wrappers interchangeable.
+    return true;
+  }
+}
+
+/**
+ * Bound the M0 multi-module overlay to unambiguous top-level functions.
+ *
+ * `ctx.funcMap` and IR overrides are still keyed by flat function name. Drop a
+ * cross-file collision and every local caller that can reach a dropped name so
+ * no IR body can resolve or patch the wrong module's slot. Class members and
+ * the shared `__module_init` stay legacy-owned in M0.
+ */
+interface MultiIrGraphSafety {
+  readonly collisions: ReadonlySet<string>;
+  readonly crossFileFunctionNames: ReadonlySet<string>;
+  readonly importAliasNames: ReadonlySet<string>;
+  readonly occupiedFunctionKeys: readonly string[];
+  readonly occupiedFunctionNameCounts: ReadonlyMap<string, number>;
+}
+
+function makeMultiIrSafeSelection(
+  ctx: CodegenContext,
+  plan: IrOverlayPlan,
+  sourceFile: ts.SourceFile,
+  safety: MultiIrGraphSafety,
+): IrSelection {
+  const funcs = new Set(plan.safeSelection.funcs);
+  const blocked = new Set<string>([...safety.collisions, MODULE_INIT_CALLER]);
+  for (const name of plan.selection.funcs) {
+    if (!plan.safeSelection.funcs.has(name)) blocked.add(name);
+  }
+  const importBindings = collectImportBindingNames(sourceFile);
+  const conservativeCrossFileCallers = ctx.standalone || ctx.wasi || ctx.strictNoHostImports;
+
+  for (const name of funcs) {
+    const declaration = plan.declByName.get(name);
+    if (!declaration) {
+      blocked.add(name);
+      continue;
+    }
+    const crossFileTarget = safety.crossFileFunctionNames.has(name);
+    const hasCallableBoundary = crossFileTarget && functionHasCallableBoundary(ctx, declaration);
+    const registeredIdx = ctx.funcMap.get(name);
+    const registeredFunction = registeredIdx === undefined ? undefined : definedFuncAt(ctx, registeredIdx);
+    if (
+      safety.collisions.has(name) ||
+      functionBodyReferencesAnyName(declaration, importBindings) ||
+      functionBodyContainsNestedRuntimeDeclaration(declaration) ||
+      (declaration.typeParameters?.length ?? 0) > 0 ||
+      safety.importAliasNames.has(name) ||
+      safety.occupiedFunctionNameCounts.get(name) !== 1 ||
+      registeredFunction?.name !== name ||
+      safety.occupiedFunctionKeys.some((key) => key.startsWith(`${name}$`)) ||
+      (crossFileTarget && (conservativeCrossFileCallers || hasCallableBoundary))
+    ) {
+      blocked.add(name);
+    }
+  }
+  for (const name of blocked) funcs.delete(name);
+
+  // A collision/dangerous removal re-opens the selector's graph-closure
+  // invariant in both directions. Drop its whole selected weak component.
+  const callEdges = collectLocalCallEdges(sourceFile);
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (const [caller, callees] of callEdges) {
+      if (blocked.has(caller)) {
+        for (const callee of callees) {
+          if (!funcs.delete(callee)) continue;
+          blocked.add(callee);
+          changed = true;
+        }
+      } else if (funcs.has(caller)) {
+        for (const callee of callees) {
+          if (!blocked.has(callee)) continue;
+          funcs.delete(caller);
+          blocked.add(caller);
+          changed = true;
+          break;
+        }
+      }
+    }
+  }
+
+  return {
+    funcs,
+    classMembers: new Set<string>(),
+    moduleInit: undefined,
+  };
 }
 
 /** Compile a typed AST into a WasmModule IR */
@@ -2388,105 +2808,7 @@ export function generateModule(
       const plan = irPlan ?? planIrOverlay(ctx, ast);
       const { selection, classShapes, overrideMap, safeSelection, trackFallbacks } = plan;
       const report = compileIrPathFunctions(ctx, ast.sourceFile, safeSelection, overrideMap, classShapes);
-      // #3000 — record the set of functions/class-members whose slots were
-      // actually patched with an IR body (genuine-emission signal; a mere
-      // selector claim does not imply this — see `irCompiledFuncs` doc).
-      ctx.irCompiledFuncs = report.compiled;
-      // Slice 12 (#1169o) — most IR-path failures are NOT compile errors. The
-      // legacy path has already produced a working `body` for every function
-      // before `compileIrPathFunctions` runs; an ordinary IR throw here is a
-      // "we tried to optimise this function via IR, it didn't fit the IR's
-      // claim shape, falling back to legacy" event.
-      //
-      // Emit as severity-"warning" so they remain visible to the
-      // bridge tests (#1181's `irErrors` filter still sees them) but
-      // don't affect the test262 `result.success || severity==="error"`
-      // gate. Cleaner long-term: thread an `IrPathReport` channel through
-      // `CompileResult` separate from compile diagnostics; tracked as a
-      // follow-up.
-      //
-      // #1530 — the demotion is gated by `STRICT_IR_BUILD_ERRORS`: if any
-      // pattern in that set matches the build-error message, the
-      // diagnostic is promoted to "error" instead. The set starts empty
-      // (non-behavioural change); once a build-error class is known to
-      // be permanently fixed in the IR path, the matching pattern is
-      // added here and the legacy fallback path is closed for that
-      // class. This is the per-kind scoping hook the long-term retire
-      // plan wires through (see plan/log/ir-adoption.md).
-      for (const err of report.errors) {
-        // #1923 — meter post-claim demotions for the ratchet gate. These are
-        // functions the selector CLAIMED that then failed build/verify/lower/
-        // backend-legality and fell back to legacy through this warning channel
-        // — counted by no selector-level metric (`IrFallbackReason`). Always
-        // collected (cheap: the errors are already iterated here) and surfaced
-        // on `CompileResult.irPostClaimErrors`, mirroring `fallbackCounts`,
-        // which is likewise always counted; the gate buckets by kind +
-        // normalized message class. Pure telemetry; the demotion below is
-        // unchanged.
-        (ctx.irPostClaimErrors ??= []).push({
-          kind: err.kind ?? "lower",
-          func: err.func,
-          message: err.message,
-        });
-        const diag = formatIrPathFallbackDiagnostic(err);
-        // (#2138) Under IR-first, a post-claim IR failure on a function whose
-        // LEGACY body was SKIPPED cannot demote to a warning: there is no
-        // legacy body to fall back to — the slot holds an `unreachable`
-        // placeholder that would be a live runtime trap. Promote to a hard
-        // compile error. This is the intended investigation behavior: the
-        // flag's job is to surface exactly these selector↔builder
-        // divergences as loud, filable failures (#2135) instead of silent
-        // legacy demotes. Functions NOT in the skip set keep today's
-        // graceful demotion.
-        const skippedTrap = irSkipBodies !== undefined && irSkipBodies.has(err.func);
-        ctx.errors.push({
-          message:
-            skippedTrap && diag.severity !== "error"
-              ? `Codegen error: ${diag.message} [IR-FIRST skipped-slot, #2138]`
-              : diag.message,
-          line: 0,
-          column: 0,
-          severity: skippedTrap ? "error" : diag.severity,
-        });
-      }
-      // (#2138) Backstop for the skip contract: every function whose legacy
-      // body was skipped MUST have been IR-compiled into its slot. A skipped
-      // function that neither appears in `report.compiled` nor produced an
-      // entry in `report.errors` (which the loop above already promoted)
-      // means its placeholder would ship silently — fail the compile.
-      if (irSkipBodies !== undefined && irSkipBodies.size > 0) {
-        const compiledSet = new Set(report.compiled);
-        const erroredSet = new Set(report.errors.map((e) => e.func));
-        for (const name of irSkipBodies) {
-          if (!compiledSet.has(name) && !erroredSet.has(name)) {
-            reportErrorNoNode(
-              ctx,
-              `IR-first (#2138): legacy body for "${name}" was skipped but the IR path neither compiled it nor reported an error — the unreachable placeholder would ship. Selector/integration divergence; file an issue.`,
-            );
-          }
-        }
-      }
-      // #1169q telemetry — when JS2WASM_LOG_IR_FALLBACKS=1, log a one-line
-      // summary per compile to stderr: total top-level FunctionDeclarations
-      // claimed vs. fallback, with rejection reason histogram. This is the
-      // gating measurement before retiring the legacy path: drive the
-      // claim rate to ~100% (excluding deferred features) and only THEN
-      // delete expressions.ts / statements.ts. See #1169q.
-      if (trackFallbacks && selection.fallbacks) {
-        const total = selection.funcs.size + selection.fallbacks.length;
-        const reasonHist: Record<string, number> = {};
-        for (const fb of selection.fallbacks) {
-          reasonHist[fb.reason] = (reasonHist[fb.reason] ?? 0) + 1;
-        }
-        const fileLabel = ast.sourceFile.fileName || "<source>";
-        const reasonStr = Object.entries(reasonHist)
-          .sort((a, b) => b[1] - a[1])
-          .map(([r, n]) => `${r}=${n}`)
-          .join(",");
-        process.stderr.write(
-          `[ir-fallback] file=${fileLabel} total=${total} claimed=${selection.funcs.size} fallback=${selection.fallbacks.length} reasons=${reasonStr}\n`,
-        );
-      }
+      consumeIrOverlayReport(ctx, report, selection, trackFallbacks, ast.sourceFile.fileName, irSkipBodies);
     }
 
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.
@@ -4595,6 +4917,40 @@ export function generateMultiModule(
 
     // (#1602) Rebuild method-closure trampolines against final method sigs.
     finalizeMethodTrampolines(ctx);
+
+    // (#2138 M0) Compile-twice IR overlay for multi-module top-level functions.
+    // Every legacy body in every source file is already present, and method
+    // trampolines are final, before planning starts. Imported calls remain an
+    // external selector boundary in M0 (no module-binding resolver); class
+    // members, module init, and IR-first body skipping are deliberately out of
+    // scope. In particular, never patch the one shared `__module_init` once per
+    // source file.
+    if (options?.experimentalIR) {
+      const occupiedFunctionNameCounts = new Map<string, number>();
+      for (const fn of ctx.mod.functions) {
+        occupiedFunctionNameCounts.set(fn.name, (occupiedFunctionNameCounts.get(fn.name) ?? 0) + 1);
+      }
+      const safety: MultiIrGraphSafety = {
+        collisions: collectMultiIrFunctionNameCollisions(multiAst.sourceFiles),
+        crossFileFunctionNames: collectMultiCrossFileFunctionNames(multiAst.sourceFiles, multiAst.checker),
+        importAliasNames: collectMultiImportAliasNames(multiAst.sourceFiles),
+        occupiedFunctionKeys: [...ctx.funcMap.keys()],
+        occupiedFunctionNameCounts,
+      };
+      for (const sourceFile of multiAst.sourceFiles) {
+        const sourceAst: TypedAST = {
+          sourceFile,
+          checker: multiAst.checker,
+          program: multiAst.program,
+          diagnostics: multiAst.diagnostics,
+          syntacticDiagnostics: multiAst.syntacticDiagnostics,
+        };
+        const plan = planIrOverlay(ctx, sourceAst, { resolveModuleBindings: false });
+        const safeSelection = makeMultiIrSafeSelection(ctx, plan, sourceFile, safety);
+        const report = compileIrPathFunctions(ctx, sourceFile, safeSelection, plan.overrideMap, plan.classShapes);
+        consumeIrOverlayReport(ctx, report, plan.selection, plan.trackFallbacks, sourceFile.fileName);
+      }
+    }
 
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.
     fixupStructNewArgCounts(ctx);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -997,7 +997,7 @@ function runPipeline(input: PipelineInput): CompileResult {
       }
       capturedIrCompiledFuncs = result.irCompiledFuncs;
       capturedIrFirstSkipped = multiAst
-        ? undefined // generateMultiModule has no IR overlay yet — the #2138 multi seam is a follow-on slice
+        ? undefined // #2138 M0 multi overlay is compile-twice only; it never enables IR-first body skipping
         : (result as ReturnType<typeof generateModule>).irFirstSkipped;
       // Propagate codegen errors with source locations. #1921 — a deliberate
       // "degrade" diagnostic is surfaced as a non-fatal "warning"; the fatal

--- a/tests/issue-2138-multi-module-ir-overlay.test.ts
+++ b/tests/issue-2138-multi-module-ir-overlay.test.ts
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2138 M0 — bounded multi-module IR overlay. Multi-source WasmGC compiles
+// legacy bodies first, then lets IR replace only unambiguous top-level function
+// slots. Cross-file imports, class members, module init, and IR-first body
+// skipping remain legacy-owned until their dedicated capabilities land.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { compileFiles, compileMulti, compileProject, type CompileResult } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+const MULTI_FILES = {
+  "./dep.ts": `
+    export function depPure(x: number): number {
+      return x * 3;
+    }
+  `,
+  "./entry.ts": `
+    import { depPure as renamedPure } from "./dep";
+
+    let initialized: number = 40;
+
+    function initHelper(x: number): number {
+      return x + 2;
+    }
+
+    initialized = initHelper(initialized);
+
+    export function entryPure(x: number): number {
+      return x + 4;
+    }
+
+    export function callRenamed(x: number): number {
+      return renamedPure(x);
+    }
+
+    export function readInit(): number {
+      return initialized;
+    }
+  `,
+} as const;
+
+function expectSuccess(result: CompileResult, label: string): void {
+  expect(
+    result.success,
+    `${label} failed:\n${result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")}`,
+  ).toBe(true);
+}
+
+async function instantiate(result: CompileResult): Promise<Record<string, (...args: number[]) => number>> {
+  const instance = await instantiateWithRuntime(result);
+  return instance.exports as unknown as Record<string, (...args: number[]) => number>;
+}
+
+describe("#2138 M0 — multi-module top-level IR overlay", () => {
+  it("IR-emits pure functions in dependency and entry while imported calls and module init stay legacy", async () => {
+    const ir = await compileMulti(MULTI_FILES, "./entry.ts", { experimentalIR: true });
+    const legacy = await compileMulti(MULTI_FILES, "./entry.ts", { experimentalIR: false });
+    expectSuccess(ir, "IR multi compile");
+    expectSuccess(legacy, "legacy multi compile");
+
+    const compiled = new Set(ir.irCompiledFuncs ?? []);
+    // Anti-vacuity: one independent pure function from EACH source file really
+    // had its existing slot patched by the IR integration pass.
+    expect(compiled.has("depPure")).toBe(true);
+    expect(compiled.has("entryPure")).toBe(true);
+
+    // Capability A is not part of M0: the renamed imported call remains an
+    // external selector edge, and module state/module init remain legacy-owned.
+    expect(compiled.has("callRenamed")).toBe(false);
+    expect(compiled.has("readInit")).toBe(false);
+    expect(compiled.has("initHelper")).toBe(false);
+    expect(compiled.has("<module-init>")).toBe(false);
+    expect(ir.irFirstSkipped).toBeUndefined();
+    expect(ir.irPostClaimErrors ?? []).toEqual([]);
+
+    // `experimentalIR: false` remains an exact opt-out for every multi entry.
+    expect(legacy.irCompiledFuncs ?? []).toEqual([]);
+    expect(legacy.irFirstSkipped).toBeUndefined();
+    expect(legacy.irPostClaimErrors ?? []).toEqual([]);
+
+    const irExports = await instantiate(ir);
+    const legacyExports = await instantiate(legacy);
+    const observed = (exports: typeof irExports) => [
+      exports.entryPure!(5),
+      exports.callRenamed!(5),
+      exports.readInit!(),
+    ];
+    expect(observed(irExports)).toEqual([9, 15, 42]);
+    expect(observed(irExports)).toEqual(observed(legacyExports));
+  });
+
+  it("keeps flat cross-file name collisions and their local callers on legacy", async () => {
+    const files = {
+      "./dep.ts": `
+        export function shared(x: number): number { return x + 1; }
+        export function depCaller(x: number): number { return shared(x); }
+        export function depLeaf(x: number): number { return x * 2; }
+      `,
+      "./entry.ts": `
+        import { depCaller } from "./dep";
+        function shared(x: number): number { return x + 10; }
+        export function entryCaller(x: number): number { return shared(x); }
+        export function entryLeaf(x: number): number { return x - 1; }
+        export function runDep(x: number): number { return depCaller(x); }
+      `,
+    };
+    const ir = await compileMulti(files, "./entry.ts", { experimentalIR: true });
+    const legacy = await compileMulti(files, "./entry.ts", { experimentalIR: false });
+    expectSuccess(ir, "collision IR compile");
+    expectSuccess(legacy, "collision legacy compile");
+
+    const compiled = new Set(ir.irCompiledFuncs ?? []);
+    expect(compiled.has("shared")).toBe(false);
+    expect(compiled.has("depCaller")).toBe(false);
+    expect(compiled.has("entryCaller")).toBe(false);
+    expect(compiled.has("runDep")).toBe(false);
+    // The guard is component-local, not a blanket shutdown of either file.
+    expect(compiled.has("depLeaf")).toBe(true);
+    expect(compiled.has("entryLeaf")).toBe(true);
+    expect(ir.irPostClaimErrors ?? []).toEqual([]);
+
+    const irExports = await instantiate(ir);
+    const legacyExports = await instantiate(legacy);
+    for (const name of ["entryCaller", "entryLeaf", "runDep"] as const) {
+      expect(irExports[name]!(7), `${name} must retain legacy runtime parity`).toBe(legacyExports[name]!(7));
+    }
+  });
+
+  it("keeps imported targets legacy-owned on standalone while retaining independent entry coverage", async () => {
+    const result = await compileMulti(MULTI_FILES, "./entry.ts", {
+      experimentalIR: true,
+      target: "standalone",
+    });
+    expectSuccess(result, "standalone multi compile");
+
+    const compiled = new Set(result.irCompiledFuncs ?? []);
+    expect(compiled.has("depPure"), "legacy imported caller is outside the dependency call graph").toBe(false);
+    expect(compiled.has("entryPure"), "independent entry function still proves genuine emission").toBe(true);
+    expect(compiled.has("callRenamed")).toBe(false);
+    expect(compiled.has("initHelper")).toBe(false);
+    expect(compiled.has("<module-init>")).toBe(false);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const exports = await instantiate(result);
+    expect([exports.entryPure!(5), exports.callRenamed!(5), exports.readInit!()]).toEqual([9, 15, 42]);
+  });
+
+  it("closes checker-resolved global-script caller ABI edges without import syntax", async () => {
+    const files = {
+      "./globals.ts": `
+        function apply(fn: (x: number) => number, x: number): number {
+          return fn(x);
+        }
+
+        function identity(fn: (x: number) => number): (x: number) => number {
+          return fn;
+        }
+
+        function triple(x: number): number {
+          return x * 3;
+        }
+
+        function dependencyLeaf(x: number): number {
+          return x + 10;
+        }
+      `,
+      "./entry.ts": `
+        function increment(x: number): number {
+          return x + 1;
+        }
+
+        export function callApply(x: number): number {
+          return apply(increment, x);
+        }
+
+        export function callIdentity(x: number): number {
+          const fn = identity(increment);
+          return fn(x);
+        }
+
+        export function callTriple(x: number): number {
+          return triple(x);
+        }
+
+        export function entryLeaf(x: number): number {
+          return x - 1;
+        }
+      `,
+    };
+
+    for (const [label, options] of [
+      ["host", {}],
+      ["standalone", { target: "standalone" as const }],
+    ] as const) {
+      const ir = await compileMulti(files, "./entry.ts", { experimentalIR: true, ...options });
+      const legacy = await compileMulti(files, "./entry.ts", { experimentalIR: false, ...options });
+      expectSuccess(ir, `${label} global-script IR compile`);
+      expectSuccess(legacy, `${label} global-script legacy compile`);
+
+      const compiled = new Set(ir.irCompiledFuncs ?? []);
+      // `apply` is checker-resolved across source files even though there is no
+      // import declaration. Patching it behind the legacy `callApply` body used
+      // to make the callable wrapper cast trap at runtime.
+      expect(compiled.has("apply"), `${label}: callable target stays legacy`).toBe(false);
+      expect(compiled.has("identity"), `${label}: callable-result target stays legacy`).toBe(false);
+      expect(compiled.has("callApply"), `${label}: cross-file caller stays legacy`).toBe(false);
+      expect(compiled.has("callIdentity"), `${label}: callable-result caller stays legacy`).toBe(false);
+      // Host numeric calls share the scalar ABI; standalone/WASI conservatively
+      // keep every cross-file target legacy-owned until the canonical ABI slice.
+      expect(compiled.has("triple"), `${label}: numeric target mode gate`).toBe(label === "host");
+      expect(compiled.has("callTriple"), `${label}: numeric caller stays legacy`).toBe(false);
+      expect(compiled.has("dependencyLeaf"), `${label}: dependency anti-vacuity`).toBe(true);
+      expect(compiled.has("entryLeaf"), `${label}: entry anti-vacuity`).toBe(true);
+      expect(ir.irPostClaimErrors ?? []).toEqual([]);
+
+      const irExports = await instantiate(ir);
+      const legacyExports = await instantiate(legacy);
+      expect(irExports.callApply!(5), `${label}: callable runtime parity`).toBe(legacyExports.callApply!(5));
+      expect(irExports.callIdentity!(5), `${label}: callable-result runtime parity`).toBe(
+        legacyExports.callIdentity!(5),
+      );
+      expect(irExports.callTriple!(5), `${label}: numeric runtime parity`).toBe(legacyExports.callTriple!(5));
+      expect([irExports.callApply!(5), irExports.callIdentity!(5), irExports.callTriple!(5)]).toEqual([6, 6, 15]);
+    }
+  });
+
+  it("keeps class member slots legacy-owned while overlaying an eligible top-level user", async () => {
+    const files = {
+      "./dep.ts": `
+        export class Box {
+          value: number;
+
+          constructor(value: number) {
+            this.value = value;
+          }
+
+          get(): number {
+            return this.value;
+          }
+        }
+
+        export function classUser(x: number): number {
+          return new Box(x).get();
+        }
+      `,
+      "./entry.ts": `
+        import { classUser } from "./dep";
+
+        export function runClass(x: number): number {
+          return classUser(x);
+        }
+      `,
+    };
+    const ir = await compileMulti(files, "./entry.ts", { experimentalIR: true });
+    const legacy = await compileMulti(files, "./entry.ts", { experimentalIR: false });
+    expectSuccess(ir, "class boundary IR compile");
+    expectSuccess(legacy, "class boundary legacy compile");
+
+    const compiled = new Set(ir.irCompiledFuncs ?? []);
+    expect(compiled.has("classUser"), "top-level anti-vacuity").toBe(true);
+    expect(compiled.has("Box_new"), "constructor stays legacy").toBe(false);
+    expect(compiled.has("Box_get"), "method stays legacy").toBe(false);
+    expect(ir.irPostClaimErrors ?? []).toEqual([]);
+
+    const irExports = await instantiate(ir);
+    const legacyExports = await instantiate(legacy);
+    expect(irExports.runClass!(8)).toBe(legacyExports.runClass!(8));
+    expect(irExports.runClass!(8)).toBe(8);
+  });
+
+  it("reaches the same bounded overlay through compileFiles and compileProject", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "js2wasm-2138-m0-"));
+    const depPath = join(dir, "dep.ts");
+    const entryPath = join(dir, "entry.ts");
+    writeFileSync(depPath, MULTI_FILES["./dep.ts"]);
+    writeFileSync(entryPath, MULTI_FILES["./entry.ts"]);
+    try {
+      for (const [label, compileDisk] of [
+        ["compileFiles", compileFiles],
+        ["compileProject", compileProject],
+      ] as const) {
+        const result = await compileDisk(entryPath, { experimentalIR: true });
+        expectSuccess(result, label);
+        const compiled = new Set(result.irCompiledFuncs ?? []);
+        expect(compiled.has("depPure"), `${label}: dependency anti-vacuity`).toBe(true);
+        expect(compiled.has("entryPure"), `${label}: entry anti-vacuity`).toBe(true);
+        expect(compiled.has("callRenamed"), `${label}: imported caller stays legacy`).toBe(false);
+        expect(compiled.has("initHelper"), `${label}: module-init callee stays legacy`).toBe(false);
+        expect(compiled.has("<module-init>"), `${label}: shared module init stays legacy`).toBe(false);
+        expect(result.irPostClaimErrors ?? []).toEqual([]);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- run the WasmGC IR overlay for `compileMulti`, `compileFiles`, and `compileProject` after every legacy body and method trampoline has been emitted
- keep M0 compile-twice and bound selection with graph-wide flat-name, import, nested/generic, and cross-file callable-ABI safety pruning
- aggregate genuine IR emission and post-claim telemetry through the same report path as single-source compilation
- record the M0 and B0 prerequisites plus the measured migration order in the markdown sprint issues

Tracking lives in `plan/issues/2138-ir-first-compile-once-inversion.md` and `plan/issues/2856-ir-body-shape-rejected-to-zero.md`.

## Validation

- `pnpm exec vitest run tests/issue-2138-multi-module-ir-overlay.test.ts` — 6/6
- `pnpm exec vitest run tests/issue-2138.test.ts tests/issue-2856-module-bindings.test.ts tests/issue-3142.test.ts` — 71/71
- `pnpm exec vitest run tests/equivalence/multi-file-compilation.test.ts tests/issue-2771-relative-import-standalone-wasi.test.ts` — 8/8
- `pnpm run check:ir-fallbacks` — `body-shape-rejected` 12→12, module 2→2, zero post-claim demotions
- `pnpm run test:equivalence:gate` — 1,607 passing / 36 known failures / zero regressions
- `pnpm run typecheck`
- Prettier, LOC budget, and `git diff --check`

Two broader legacy suites were also sampled and reproduce the same existing failures on the green builtins base: `tests/multi-file.test.ts` lacks the `string_constants` instantiation import, and `tests/import-resolver.test.ts` still asserts the pre-structured-return API.
