### PR TITLE
feat(ir): canonicalize callable boundary ABI

### DIFF
--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -1343,16 +1343,18 @@ selection is widened.
 
 ### Prerequisite B0 (zero delta) — one callable boundary ABI
 
-The legacy front end carries callable parameters and results as `externref`
-wrappers rooted in `__fn_wrap_*`; the current IR closure types use a private
-`__ir_closure_base_*` hierarchy. Direct all-IR tests hide that mismatch, but an
-M0 mixed-front-end call can expose an invalid signature or cast. Before any
-imported call or top-level function value is claimed, #3214 must establish one
-boundary representation: keep typed closures internal, pack them into the
-legacy wrapper carrier at callable positions, and unpack through the exact
-signature wrapper before `call_ref`. B0 must prove both IR→legacy and legacy→IR
-callable parameters/results while preserving **12 → 12** and zero post-claim
-demotions.
+The legacy front end carries callable parameters as `externref` wrappers rooted
+in `__fn_wrap_*`; the pre-B0 IR closure types used a private
+`__ir_closure_base_*` hierarchy. Direct all-IR tests hid that mismatch, but an
+M0 mixed-front-end call could expose an invalid signature or cast. #3214 B0 now
+keeps typed closures internal, packs them into the legacy carrier at callable
+parameter boundaries, and unpacks through one permanently open canonical
+wrapper root. Exact signature checking happens on the extracted funcref before
+`call_ref`; it never depends on a module-local signature-wrapper RTT. Mixed
+legacy→IR runtime coverage in both adversarial wrapper orders plus the
+compositional IR→legacy pack path preserve **12 → 12** with zero post-claim
+demotions. Function-valued results and storage/escape remain deliberately
+deferred; B0 does not claim them.
 
 ### Capability A (M) — imported-callee calls (first half of the 8 mains)
 

--- a/plan/issues/3214-ir-first-class-function-values.md
+++ b/plan/issues/3214-ir-first-class-function-values.md
@@ -4,7 +4,7 @@ title: "IR: first-class function values (pass a top-level function / arrow as a 
 status: backlog
 sprint: Backlog
 created: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-21
 priority: medium
 horizon: l
 feasibility: hard
@@ -16,6 +16,16 @@ language_feature: closures
 goal: ir-full-coverage
 parent: 2855
 related: [2856, 1276, 1382]
+loc-budget-allow:
+  - src/ir/lower.ts
+  - src/ir/from-ast.ts
+  - src/ir/nodes.ts
+  - src/ir/builder.ts
+  - src/codegen/expressions/calls-closures.ts
+  - src/ir/integration.ts
+  - src/codegen/expressions/call-tail-dispatch.ts
+  - src/codegen/async-scheduler.ts
+  - src/codegen/expressions/calls.ts
 ---
 
 # #3214 — IR: first-class function values
@@ -35,7 +45,7 @@ addBenchCard(wrap, "fib(30)", "…", bench_fib);
 
 // benchmarks/helpers.ts addBenchCard — an arrow-closure value + its use:
 card.addEventListener("click", () => {
-  const v = fn();              // fn: () => number invoked
+  const v = fn(); // fn: () => number invoked
   out.textContent = v.toString();
 });
 ```
@@ -64,7 +74,135 @@ ALL land together. So this issue is tracked/prioritised as a **general IR
 capability** on its own merits, not as a corpus-bucket lever. Do not schedule it
 expecting a gate delta.
 
-## Acceptance criteria
+## B0 implementation result — canonical callable ABI (2026-07-21)
+
+B0 is implemented as an ABI foundation **before** either selector/storage
+expansion (A/B below). The overall issue remains `backlog`: B0 deliberately does
+not claim the motivating inline-arrow or top-level-function argument shapes.
+
+### Root cause and design
+
+The legacy backend already represents a callback boundary as `externref`
+carrying a descendant of the canonical `__fn_wrap_*` family. The IR path instead
+typed a function parameter as its private `(ref $__ir_closure_base_*)` hierarchy.
+Direct all-IR tests hid that structural mismatch; a legacy closure reaching an
+IR callback consumer could fail its RTT cast even though the source signatures
+matched.
+
+B0 separates the two roles:
+
+- `IrType.closure<S>` remains compiler-owned and lowers to the canonical
+  `__fn_wrap_*` root carrier. A `closure.new` still allocates S's signature
+  wrapper (or a captured subtype beneath it); allocation identity is not the
+  SSA/cross-module carrier.
+- `IrType.callable<S>` is the source boundary carrier and lowers to `externref`,
+  matching legacy exactly. B0 permits it in parameter positions only; callable
+  results and storage/escape remain deferred.
+- An exact `closure<S> -> callable<S>` pack reuses `coerce.to_externref` /
+  `extern.convert_any`. Mismatched signatures, covariance, and the reverse
+  conversion remain illegal.
+- A callable invocation performs `any.convert_extern`, casts to the module-wide
+  wrapper root, extracts field 0 from that root, casts the funcref to S's exact
+  lifted func type, and only then emits `call_ref`. The root unpack is emitted
+  twice because the lifted ABI needs root `self` as well as the field-0
+  funcref; there is no root-to-signature-wrapper cast, and the wrapper object
+  itself is never passed as the `call_ref` operand.
+- `ClosureStructRegistry` now delegates to
+  `getOrCreateFuncRefWrapperTypes()`. A no-capture IR closure constructs the
+  exact wrapper. A captured IR closure is a declared subtype of that exact
+  wrapper and registers exact params/result plus `hasCaptures: true` in
+  `closureInfoByTypeIdx`. The parallel `__ir_closure_base_*` hierarchy is gone.
+- Every shared lifted wrapper func takes canonical-root `self`. Captured bodies
+  downcast root self only to recover their capture subtype. Private/named
+  function-expression funcs retain concrete self, and generic dispatch derives
+  param 0 from the actual func type so those arms remain type-valid.
+- The canonical wrapper root is exempt from leaf finalization even in a module
+  with no child wrapper. Finality participates in WasmGC canonical identity, so
+  this is required for minimal separately compiled modules to agree.
+- Callable keys/traversal are distinct across equality, diagnostics,
+  monomorphization, linear-memory planning, and backend legality. Linear rejects
+  callable call/coercion at its legality boundary, before emitter hooks run.
+
+This avoids the three relevant prior failure classes: wrapper creation order no
+longer chooses an arbitrary per-signature cast target (#2873), a module with no
+wrapper child cannot finalize its ABI root into a different canonical type, and
+`call_ref` always sees the extracted typed funcref rather than a wrapper struct
+(#2193).
+
+### Deliberate B0 boundary
+
+`src/ir/select.ts` logic is unchanged, including `hasCallableParam`'s
+caller-direction demotion (comments now record that it is a B0 claim-set freeze,
+not an ABI mismatch). The M0 cross-file callable gate is also unchanged. B0
+does not add inline arrow arguments, bare top-level function identifiers,
+imported calls, host-JS functions, callback covariance, optional/rest/default or
+void callbacks, `call`/`apply`/`bind`, callable storage/escape, or any
+function-valued result position. The selector continues to report a
+FunctionTypeNode return as `return-type-not-resolvable`.
+
+The sequencing is intentional:
+
+1. **B0 (this result):** canonical structural ABI, exact pack/root unpack, and
+   mixed legacy/IR proof with zero selection delta.
+2. **A (follow-up):** widen selection/lowering for the motivating inline-arrow
+   and named top-level function arguments only after the boundary is safe.
+3. **B (follow-up):** separately design storage/escape and function-valued
+   result positions; do not smuggle those semantics into A.
+
+### Measured result
+
+- `tests/issue-3214-callable-abi.test.ts`: **11/11**. Covers the existing #2859
+  result `68`, externref params in legacy and IR WAT, no-capture/captured/
+  forwarded callbacks, real string callback carriers in host and native-string
+  modes, optimize parity, exact-signature rejection, linear pre-emitter
+  legality, dynamic `undefined` guards, permanent-root finality, private/named
+  candidate validity, and no selector/result widening.
+- Mixed proof: separately compiled legacy producers and genuine IR consumers run
+  captured closures in both adversarial wrapper orders (producer root/consumer
+  child and producer child/consumer root), returning `42`. A legacy child
+  consumer also accepts the producer-root closure while an unrelated same-arity
+  private/named function-expression candidate is present. Minimal no-capture
+  modules pass with `optimize: false` and `optimize: true`. The reverse
+  IR-caller direction remains pinned compositionally by the `closure.new` ->
+  `callable pack` -> `externref direct-call arg` chain plus the legacy
+  consumer's root unpack body; B0 intentionally does not widen selection enough
+  to execute that cross-module caller end-to-end.
+- Existing `tests/issue-2859.test.ts`: **8/8**, including the callback program
+  returning `68` with zero post-claim demotions.
+- Closure/funcref regression coverage (`issue-1169c`, `issue-2873`,
+  `issue-2876`, and `funcref-emit-guard`): **58/58**.
+- `tests/equivalence/optimize-differential.test.ts`: **4/4**; the focused B0
+  suite also executes optimized/unoptimized callback output and validates both.
+- `pnpm run check:ir-fallbacks`: `body-shape-rejected` **12 -> 12**,
+  module-level **2 -> 2**, and **zero** post-claim demotions.
+- `pnpm run typecheck`: clean.
+- `pnpm run check:loc-budget`: clean with issue-scoped allowances for only the
+  nine touched god-files reported by the gate; the shared baseline is unchanged.
+- Fresh post-rebase byte-neutrality A/B (merged M0 `558f597866425b` versus the
+  rebased B0 code tree `923dc4d7923cd7`, before this documentation-only
+  measurement update) is exact for two closure-free numeric probes under both
+  `{ fileName: "t.ts" }` and `{ fileName: "t.ts", nativeStrings: true }`:
+  `cf169943...`, `b4bd707c...`, `8021f746...`, and `f3bc4ce3...` are unchanged.
+  This is the precise invariant: mandatory canonicalization intentionally
+  changes the type shape of sources that already lower internal IR closures,
+  even if they do not yet expose an `IrType.callable` boundary.
+
+## Sequenced acceptance criteria
+
+### B0 — complete
+
+1. Function-typed source parameter positions resolve to `callable<S>` /
+   externref while internal closure values remain `closure<S>` root refs and
+   construction retains exact allocation wrappers/subtypes.
+2. Exact pack plus root -> field-0 -> exact-funcref invocation works in legacy,
+   IR, mixed-module, host, and native-string coverage; shared lifted funcs take
+   root self while private/named funcs retain their actual concrete self.
+3. The canonical root stays open through finalization, including minimal
+   no-child optimized modules.
+4. No private IR base hierarchy, no wrapper-to-`call_ref`, no stack/type-index
+   instability, no selector/result widening, and no fallback-gate regression.
+
+### A/B — deferred full-issue acceptance
 
 1. `select.ts` accepts a named-function / arrow argument at a `() => T`
    parameter position (JS-host lane; standalone per the closure ABI's existing
@@ -75,7 +213,7 @@ expecting a gate delta.
    it), anti-vacuity (`irFirstSkipped` / byte-diff).
 4. No `check:ir-fallbacks` regression; no test262 regression.
 
-## Files
+## Follow-up files
 
 - `src/ir/select.ts` — function-value argument + arrow-value acceptance.
 - `src/ir/from-ast.ts` — closure-wrap lowering + closure-call.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -29,7 +29,7 @@ import { inLiveShiftRange } from "../emit/resolve-layout.js"; // (#1916 S3) stab
 // this module; both bindings are only dereferenced inside function bodies,
 // never at module evaluation). The other three are cycle-free leaves relative
 // to this module.
-import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
+import { getClosureFuncSelfTypeIdx, getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { reserveClosedMethodDispatchVararg } from "./closed-method-dispatch.js";
@@ -925,10 +925,10 @@ export interface PromiseExecutorClosures {
  * site `ref.test (ref $wrap)` and dispatches natively. It inherits field 0
  * (`func: funcref`) and adds field 1 (`cap_promise: (ref $Promise)`).
  *
- * Each trampoline has EXACTLY the canonical lifted func type
- * (`(ref null $wrap, externref) -> ()`) so the call site's
- * `ref.cast (ref $wrapFuncType); call_ref` succeeds; the body downcasts self to
- * the `cap` subtype to recover the promise.
+ * Each trampoline has exactly the canonical lifted func type
+ * (`(ref $wrapperRoot, externref) -> ()`) so the call site's typed-funcref cast
+ * and `call_ref` succeed; the body downcasts root self to the `cap` subtype to
+ * recover the promise.
  */
 export function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecutorClosures | null {
   const cache = ctx as unknown as { __promiseExecutorClosures?: PromiseExecutorClosures };
@@ -972,7 +972,7 @@ export function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecu
   // settle helpers (buildPromiseSettleBody), so double-settle / settle-after-
   // throw is a spec-correct no-op by construction.
   const makeBody = (settleFuncIdx: number): Instr[] => [
-    { op: "local.get", index: 0 }, // self: (ref null $wrap)
+    { op: "local.get", index: 0 }, // self: (ref $wrapperRoot)
     { op: "ref.cast", typeIdx: capTypeIdx }, // downcast to the cap subtype (non-null)
     { op: "struct.get", typeIdx: capTypeIdx, fieldIdx: 1 }, // captured (ref $Promise)
     { op: "local.get", index: 1 }, // value: externref
@@ -1733,10 +1733,11 @@ function emitThenWrapperFunction(
   const callbackLocal = 3;
   const resultLocal = 4;
   const funcIdx = mintDefinedFunc(ctx);
+  const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, info.funcTypeIdx) ?? info.structTypeIdx;
 
   const locals: LocalDef[] = [
     { name: "$caps", type: { kind: "ref", typeIdx: capsTypeIdx } },
-    { name: "$callback", type: { kind: "ref", typeIdx: info.structTypeIdx } },
+    { name: "$callback", type: { kind: "ref", typeIdx: selfTypeIdx } },
     { name: "$result", type: { kind: "externref" } },
   ];
   const body: Instr[] = [
@@ -1747,7 +1748,7 @@ function emitThenWrapperFunction(
     { op: "local.get", index: capLocal },
     { op: "struct.get", typeIdx: capsTypeIdx, fieldIdx: 0 },
     { op: "any.convert_extern" },
-    { op: "ref.cast", typeIdx: info.structTypeIdx },
+    { op: "ref.cast", typeIdx: selfTypeIdx },
     { op: "local.set", index: callbackLocal },
   ];
 
@@ -1776,7 +1777,7 @@ function emitThenWrapperFunction(
   }
   tryBody.push(
     { op: "local.get", index: callbackLocal },
-    { op: "struct.get", typeIdx: info.structTypeIdx, fieldIdx: 0 },
+    { op: "struct.get", typeIdx: selfTypeIdx, fieldIdx: 0 },
     { op: "ref.cast", typeIdx: info.funcTypeIdx },
     { op: "call_ref", typeIdx: info.funcTypeIdx },
   );
@@ -3575,13 +3576,14 @@ export function emitTimerCallbackWrapper(ctx: CodegenContext, info: ClosureInfo)
   const wrapperName = `__timer_cb_${wrapperId}`;
   const callbackLocal = 2; // decoded closure struct
   const funcIdx = mintDefinedFunc(ctx);
+  const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, info.funcTypeIdx) ?? info.structTypeIdx;
 
-  const locals: LocalDef[] = [{ name: "$callback", type: { kind: "ref", typeIdx: info.structTypeIdx } }];
+  const locals: LocalDef[] = [{ name: "$callback", type: { kind: "ref", typeIdx: selfTypeIdx } }];
   const body: Instr[] = [
     // caps (param 0) is the closure struct, lifted to externref. Decode it.
     { op: "local.get", index: 0 },
     { op: "any.convert_extern" },
-    { op: "ref.cast", typeIdx: info.structTypeIdx },
+    { op: "ref.cast", typeIdx: selfTypeIdx },
     { op: "local.set", index: callbackLocal },
 
     // call_ref shape: [closure_self, ...default_args, typed_funcref]
@@ -3592,7 +3594,7 @@ export function emitTimerCallbackWrapper(ctx: CodegenContext, info: ClosureInfo)
   }
   body.push(
     { op: "local.get", index: callbackLocal },
-    { op: "struct.get", typeIdx: info.structTypeIdx, fieldIdx: 0 },
+    { op: "struct.get", typeIdx: selfTypeIdx, fieldIdx: 0 },
     { op: "ref.cast", typeIdx: info.funcTypeIdx },
     { op: "call_ref", typeIdx: info.funcTypeIdx },
   );
@@ -4070,10 +4072,11 @@ function emitFinallyWrapperFunction(ctx: CodegenContext, info: ClosureInfo, isRe
   const resultLocal = 4;
   const reasonLocal = 5;
   const funcIdx = mintDefinedFunc(ctx);
+  const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, info.funcTypeIdx) ?? info.structTypeIdx;
 
   const locals: LocalDef[] = [
     { name: "$caps", type: { kind: "ref", typeIdx: capsTypeIdx } },
-    { name: "$callback", type: { kind: "ref", typeIdx: info.structTypeIdx } },
+    { name: "$callback", type: { kind: "ref", typeIdx: selfTypeIdx } },
     { name: "$result", type: { kind: "externref" } },
     { name: "$reason", type: { kind: "externref" } },
   ];
@@ -4085,7 +4088,7 @@ function emitFinallyWrapperFunction(ctx: CodegenContext, info: ClosureInfo, isRe
     { op: "local.get", index: capLocal },
     { op: "struct.get", typeIdx: capsTypeIdx, fieldIdx: 0 },
     { op: "any.convert_extern" },
-    { op: "ref.cast", typeIdx: info.structTypeIdx },
+    { op: "ref.cast", typeIdx: selfTypeIdx },
     { op: "local.set", index: callbackLocal },
   ];
 
@@ -4096,7 +4099,7 @@ function emitFinallyWrapperFunction(ctx: CodegenContext, info: ClosureInfo, isRe
   for (const paramType of info.paramTypes) pushDefaultForType(tryBody, paramType);
   tryBody.push(
     { op: "local.get", index: callbackLocal },
-    { op: "struct.get", typeIdx: info.structTypeIdx, fieldIdx: 0 },
+    { op: "struct.get", typeIdx: selfTypeIdx, fieldIdx: 0 },
     { op: "ref.cast", typeIdx: info.funcTypeIdx },
     { op: "call_ref", typeIdx: info.funcTypeIdx },
   );

--- a/src/codegen/builtin-static-gopd.ts
+++ b/src/codegen/builtin-static-gopd.ts
@@ -414,7 +414,7 @@ function ensureStandaloneSpeciesGetterClosure(
   const funcName = `__builtin_species_get_${builtinName}`;
   let funcIdx = ctx.funcMap.get(funcName);
   if (funcIdx === undefined) {
-    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
+    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.liftedSelfTypeIdx };
     const closureFctx = makeBuiltinClosureFctx(funcName, selfType, userParams, { kind: "externref" });
     // Step 1 (the whole algorithm): Return the this value.
     closureFctx.body.push({ op: "local.get", index: 1 });

--- a/src/codegen/builtin-value-read.ts
+++ b/src/codegen/builtin-value-read.ts
@@ -1012,7 +1012,7 @@ export function ensureStandaloneBuiltinStaticMethodClosure(
   const funcName = `__builtin_static_${builtinName}_${propName}`;
   let funcIdx = ctx.funcMap.get(funcName);
   if (funcIdx === undefined) {
-    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
+    const selfType: ValType = { kind: "ref", typeIdx: wrapperTypes.liftedSelfTypeIdx };
     const closureFctx = makeBuiltinClosureFctx(funcName, selfType, paramTypes, returnType);
 
     if (key === "Array.isArray") {

--- a/src/codegen/closure-exports.ts
+++ b/src/codegen/closure-exports.ts
@@ -204,10 +204,10 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
 
   if (entries.length === 0) return;
 
-  // Fallback to any base wrapper if none was found at the target arity.
-  // V8 isorecursive canonicalization collapses single-funcref-field
-  // base structs to the same type regardless of arity, so any base
-  // wrapper works for the initial ref.test + struct.get.
+  // Fall back to the module's canonical wrapper root if no target-arity entry
+  // selected it. Shared signature wrappers are distinct children, not
+  // canonicalized peers; only the permanently-open root admits every shared
+  // signature wrapper for the initial ref.test + struct.get.
   if (baseWrapperIdx === undefined) {
     for (const [typeIdx] of ctx.closureInfoByTypeIdx) {
       const typeDef = mod.types[typeIdx];
@@ -391,17 +391,13 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
     ];
   }
 
-  // (#1712) Funcref extraction must succeed for EVERY closure struct shape in
-  // the dispatch entries. Capture-carrying closures are emitted as standalone
-  // struct types (compiler-side superTypeIdx === -1, no Wasm subtype relation
-  // to the 1-field base wrapper), so the previous single
-  // `ref.test <representative base>` excluded them and the dispatcher silently
-  // returned null for any capturing closure — acorn's prototype methods all
-  // capture their fnctor, which made every compiled `parse()` come back null.
-  // Mirror `__is_closure` (collectClosureBaseWrapperTypeIdxs): chain a
-  // `ref.test` per distinct self-struct shape, extracting field 0 (funcref)
-  // from whichever matches. `funcLocal` stays null when nothing matches and
-  // the funcref dispatch below falls through to `ref.null.extern` as before.
+  // (#1712) Funcref extraction must succeed for EVERY self-carrier shape in the
+  // dispatch entries. Shared capture structs now subtype their signature
+  // wrapper and canonical root, but private/named function-expression structs
+  // retain unrelated concrete self types. Mirror `__is_closure`
+  // (collectClosureBaseWrapperTypeIdxs): chain a `ref.test` per distinct self
+  // shape, extracting field 0 from whichever matches. `funcLocal` stays null
+  // when nothing matches and the dispatch falls through as before.
   body.push(...buildFuncrefExtraction(entries, anyLocal, funcLocal));
   body.push(...funcrefDispatch);
 
@@ -696,12 +692,11 @@ export function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number)
   }
 
   // (#1712) Per-shape funcref extraction — same rationale as
-  // `emitClosureCallExportN` / `buildFuncrefExtraction`: capture-carrying
-  // closure structs have no Wasm subtype relation to the 1-field base
-  // wrapper, so a single representative `ref.test` excluded them and every
-  // capturing prototype method dispatched to null. The funcref dispatch
-  // below leaves its externref result on the stack (null fallthrough when
-  // `funcLocal` stayed null because no shape matched).
+  // `emitClosureCallExportN` / `buildFuncrefExtraction`: shared captures pass
+  // the canonical-root test, while private/named closure self structs still
+  // require their own shape arms. The funcref dispatch below leaves its
+  // externref result on the stack (null fallthrough when `funcLocal` stayed
+  // null because no shape matched).
   body.push(...buildFuncrefExtraction(entries, anyLocal, funcLocal));
   body.push(...funcrefDispatch);
 

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1917,19 +1917,17 @@ export function compileArrowAsClosure(
   // getOrCreateFuncRefWrapperTypes. This ensures all no-capture closures with
   // the same signature share the same struct type, enabling consistent call_ref
   // dispatch when closures are passed as callable parameters (externref).
-  let structTypeIdx: number;
-  let liftedFuncTypeIdx: number;
-  let liftedSelfTypeIdx: number;
-  let liftedParams: ValType[];
   const isNamedFuncExpr = ts.isFunctionExpression(arrow) && arrow.name;
 
-  ({ structTypeIdx, liftedFuncTypeIdx, liftedSelfTypeIdx, liftedParams } = mintClosureStructTypes(ctx, {
+  const mintedTypes = mintClosureStructTypes(ctx, {
     captures,
     arrowParams,
     closureResults,
     closureName,
     isNamedFuncExpr: !!isNamedFuncExpr,
-  }));
+  });
+  let { structTypeIdx, liftedFuncTypeIdx, liftedParams } = mintedTypes;
+  const { liftedSelfTypeIdx } = mintedTypes;
 
   // 5. Build the lifted function body
   // Shared-wrapper lifted functions receive the canonical wrapper ROOT,

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -100,11 +100,12 @@ import type { NativeGeneratorInfo } from "./context/types.js";
 // (#3270) Extracted closure subsystems. Re-exported below so external importers
 // that reference these symbols via `./closures.js` are unaffected.
 import {
+  getClosureFuncSelfTypeIdx,
   getFuncSignature,
   getOrCreateFuncRefWrapperTypes,
   getFuncRefWrapperRootTypeIdx,
 } from "./closures/funcref-wrapper-types.js";
-export { getFuncSignature, getOrCreateFuncRefWrapperTypes, getFuncRefWrapperRootTypeIdx };
+export { getClosureFuncSelfTypeIdx, getFuncSignature, getOrCreateFuncRefWrapperTypes, getFuncRefWrapperRootTypeIdx };
 import {
   isVecOrArrayRefType,
   isHostCallbackArgument,
@@ -1918,10 +1919,11 @@ export function compileArrowAsClosure(
   // dispatch when closures are passed as callable parameters (externref).
   let structTypeIdx: number;
   let liftedFuncTypeIdx: number;
+  let liftedSelfTypeIdx: number;
   let liftedParams: ValType[];
   const isNamedFuncExpr = ts.isFunctionExpression(arrow) && arrow.name;
 
-  ({ structTypeIdx, liftedFuncTypeIdx, liftedParams } = mintClosureStructTypes(ctx, {
+  ({ structTypeIdx, liftedFuncTypeIdx, liftedSelfTypeIdx, liftedParams } = mintClosureStructTypes(ctx, {
     captures,
     arrowParams,
     closureResults,
@@ -1930,16 +1932,13 @@ export function compileArrowAsClosure(
   }));
 
   // 5. Build the lifted function body
-  // For no-capture closures using wrapper types, self param is non-null ref.
-  // For captured closures sharing wrapper types, self param uses the WRAPPER struct
-  // type (non-null ref) — captures are accessed via ref.cast to the subtype.
-  // For named func exprs, self param is ref_null (var hoisting support).
-  const usesWrapperFuncType =
-    captures.length > 0 && !isNamedFuncExpr && !!getOrCreateFuncRefWrapperTypes(ctx, arrowParams, closureResults);
+  // Shared-wrapper lifted functions receive the canonical wrapper ROOT,
+  // regardless of their per-signature allocation wrapper. Captured bodies
+  // downcast that root to their concrete environment subtype. Named function
+  // expressions retain their private nullable self type for var hoisting.
+  const usesWrapperFuncType = liftedSelfTypeIdx !== structTypeIdx;
   const selfParamKind = isNamedFuncExpr ? ("ref_null" as const) : ("ref" as const);
-  const selfTypeIdx = usesWrapperFuncType
-    ? getOrCreateFuncRefWrapperTypes(ctx, arrowParams, closureResults)!.structTypeIdx
-    : structTypeIdx;
+  const selfTypeIdx = liftedSelfTypeIdx;
   const liftedFctx: FunctionContext = {
     name: closureName,
     params: [
@@ -2147,10 +2146,10 @@ export function compileArrowAsClosure(
   // (#2118) Register the self-recursive const/let arrow binding so recursive
   // calls compile as closure calls dispatched through __self. The struct.get
   // that fetches the funcref runs against __self's *actual* param type
-  // (selfTypeIdx — the wrapper base struct when capture-subtyping is used, else
-  // the specific struct), not necessarily the concrete subtype, so use
-  // selfTypeIdx as the call-site struct type. Field 0 (funcref) is inherited
-  // from the wrapper base, so the lifted func type still drives call_ref.
+  // (`selfTypeIdx`: the canonical wrapper root for shared wrappers, or the
+  // private struct for named function expressions), not necessarily the
+  // concrete allocation subtype. Field 0 is available on that root, and the
+  // lifted func type still drives call_ref.
   let savedSelfBindingClosureInfo: ClosureInfo | undefined;
   let hadSavedSelfBindingClosureInfo = false;
   if (selfBindingName !== undefined && selfBindingName !== funcExprName) {

--- a/src/codegen/closures/arrow-phases.ts
+++ b/src/codegen/closures/arrow-phases.ts
@@ -374,17 +374,19 @@ export function mintClosureStructTypes(
     closureName: string;
     isNamedFuncExpr: boolean;
   },
-): { structTypeIdx: number; liftedFuncTypeIdx: number; liftedParams: ValType[] } {
+): { structTypeIdx: number; liftedFuncTypeIdx: number; liftedSelfTypeIdx: number; liftedParams: ValType[] } {
   const { captures, arrowParams, closureResults, closureName, isNamedFuncExpr } = opts;
   let structTypeIdx: number;
   let liftedFuncTypeIdx: number;
+  let liftedSelfTypeIdx: number;
   let liftedParams: ValType[];
   if (captures.length === 0 && !isNamedFuncExpr) {
     const wrapperTypes = getOrCreateFuncRefWrapperTypes(ctx, arrowParams, closureResults);
     if (wrapperTypes) {
       structTypeIdx = wrapperTypes.structTypeIdx;
       liftedFuncTypeIdx = wrapperTypes.liftedFuncTypeIdx;
-      liftedParams = [{ kind: "ref", typeIdx: structTypeIdx }, ...arrowParams];
+      liftedSelfTypeIdx = wrapperTypes.liftedSelfTypeIdx;
+      liftedParams = [{ kind: "ref", typeIdx: liftedSelfTypeIdx }, ...arrowParams];
     } else {
       // Fallback: create a unique struct type
       const structFields = [{ name: "func", type: { kind: "funcref" as const }, mutable: false }];
@@ -394,7 +396,8 @@ export function mintClosureStructTypes(
         name: `${closureName}_struct`,
         fields: structFields,
       });
-      liftedParams = [{ kind: "ref", typeIdx: structTypeIdx }, ...arrowParams];
+      liftedSelfTypeIdx = structTypeIdx;
+      liftedParams = [{ kind: "ref", typeIdx: liftedSelfTypeIdx }, ...arrowParams];
       liftedFuncTypeIdx = addFuncType(ctx, liftedParams, closureResults, `${closureName}_type`);
     }
   } else {
@@ -435,10 +438,11 @@ export function mintClosureStructTypes(
         superTypeIdx: wrapperTypes.structTypeIdx,
       });
       // Share the wrapper's lifted func type so call_ref dispatches correctly.
-      // The __self param is (ref $wrapperStruct), and the lifted body will
-      // ref.cast to the specific subtype to access captures.
+      // The __self param is the canonical wrapper ROOT, and the lifted body
+      // ref.casts to the specific subtype to access captures.
       liftedFuncTypeIdx = wrapperTypes.liftedFuncTypeIdx;
-      liftedParams = [{ kind: "ref_null", typeIdx: structTypeIdx }, ...arrowParams];
+      liftedSelfTypeIdx = wrapperTypes.liftedSelfTypeIdx;
+      liftedParams = [{ kind: "ref", typeIdx: liftedSelfTypeIdx }, ...arrowParams];
     } else {
       ctx.mod.types.push({
         kind: "struct",
@@ -448,11 +452,12 @@ export function mintClosureStructTypes(
       // 4. Create the lifted function type: (ref_null $closure_struct, ...arrowParams) → results
       // Use ref_null for __self so that var-hoisted variables shadowing the function name
       // (e.g. `var g` inside `function g()`) can be default-initialized to null.
-      liftedParams = [{ kind: "ref_null", typeIdx: structTypeIdx }, ...arrowParams];
+      liftedSelfTypeIdx = structTypeIdx;
+      liftedParams = [{ kind: "ref_null", typeIdx: liftedSelfTypeIdx }, ...arrowParams];
       liftedFuncTypeIdx = addFuncType(ctx, liftedParams, closureResults, `${closureName}_type`);
     }
   }
-  return { structTypeIdx, liftedFuncTypeIdx, liftedParams };
+  return { structTypeIdx, liftedFuncTypeIdx, liftedSelfTypeIdx, liftedParams };
 }
 
 /**

--- a/src/codegen/closures/funcref-wrapper-types.ts
+++ b/src/codegen/closures/funcref-wrapper-types.ts
@@ -35,13 +35,23 @@ export function getOrCreateFuncRefWrapperTypes(
   ctx: CodegenContext,
   userParams: ValType[],
   resultTypes: ValType[],
-): { structTypeIdx: number; liftedFuncTypeIdx: number; closureInfo: ClosureInfo } | null {
+): {
+  structTypeIdx: number;
+  liftedFuncTypeIdx: number;
+  liftedSelfTypeIdx: number;
+  closureInfo: ClosureInfo;
+} | null {
   // Build cache key from param types and result types
   const sigKey = `${userParams.map((p) => p.kind + ((p as any).typeIdx ?? "")).join(",")}->${resultTypes.map((r) => r.kind + ((r as any).typeIdx ?? "")).join(",")}`;
 
   const cached = ctx.funcRefWrapperCache.get(sigKey);
   if (cached) {
-    return { structTypeIdx: cached.structTypeIdx, liftedFuncTypeIdx: cached.funcTypeIdx, closureInfo: cached };
+    return {
+      structTypeIdx: cached.structTypeIdx,
+      liftedFuncTypeIdx: cached.funcTypeIdx,
+      liftedSelfTypeIdx: getFuncRefWrapperRootTypeIdx(ctx) ?? cached.structTypeIdx,
+      closureInfo: cached,
+    };
   }
 
   // Create the closure struct type: just (field $func funcref), no captures.
@@ -57,12 +67,18 @@ export function getOrCreateFuncRefWrapperTypes(
     fields: structFields,
     superTypeIdx: rootWrapperTypeIdx ?? -1, // first wrapper is the root; later signatures subtype it
   });
+  const liftedSelfTypeIdx = rootWrapperTypeIdx ?? structTypeIdx;
   if (rootWrapperTypeIdx === undefined) {
     (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx = structTypeIdx;
   }
 
-  // Create the lifted function type: (ref $struct, ...userParams) -> results
-  const liftedParams: ValType[] = [{ kind: "ref", typeIdx: structTypeIdx }, ...userParams];
+  // Cross-module callable ABI: every lifted funcref takes the structurally
+  // canonical ROOT as `self`, never the per-signature allocation wrapper.
+  // Wrapper creation order is module-local, so embedding the latter here
+  // makes identical source signatures disagree across separately compiled
+  // modules. Captured bodies recover their environment with a root→subtype
+  // cast; the user-visible params/results still identify the funcref exactly.
+  const liftedParams: ValType[] = [{ kind: "ref", typeIdx: liftedSelfTypeIdx }, ...userParams];
   const liftedFuncTypeIdx = addFuncType(ctx, liftedParams, resultTypes, `${closureName}_type`);
 
   const closureInfo: ClosureInfo = {
@@ -74,28 +90,48 @@ export function getOrCreateFuncRefWrapperTypes(
   ctx.closureInfoByTypeIdx.set(structTypeIdx, closureInfo);
   ctx.funcRefWrapperCache.set(sigKey, closureInfo);
 
-  return { structTypeIdx, liftedFuncTypeIdx, closureInfo };
+  return { structTypeIdx, liftedFuncTypeIdx, liftedSelfTypeIdx, closureInfo };
 }
 
 /**
  * (#2873 park fix) The ROOT funcref-wrapper struct type — the FIRST wrapper
  * `getOrCreateFuncRefWrapperTypes` created in this module. Every later
- * per-signature wrapper struct is a `sub final` of it (see the star chaining
- * above), so the root is the ONLY wrapper type a `ref.test`/`ref.cast` is
- * guaranteed to accept for a closure value of ANY signature's wrapper.
+ * per-signature wrapper struct is a direct subtype of it. It is also the
+ * canonical lifted-function `self` type for EVERY signature, so function type
+ * identity does not depend on which signature created the root locally. The
+ * finalization pass explicitly keeps this root open even in a minimal module
+ * with no child wrapper: WasmGC canonical identity includes finality, so an
+ * opportunistically-final root would not match another module's open root.
+ * The root is therefore the ONLY wrapper type a `ref.test`/`ref.cast` is
+ * guaranteed to accept for a closure value of ANY shared signature wrapper.
  *
  * Why callers need it: wrapper structs are all layout-identical
  * `(struct (field funcref))`, but WasmGC isorecursive canonicalization keys on
- * (fields, supertype, finality) — a `sub final $root` sibling does NOT
- * canonicalize with the root or with another sibling. A call site that casts a
+ * (fields, supertype, finality) — a direct `$root` subtype does NOT canonicalize
+ * with the root or with another sibling. A call site that casts a
  * closure value to the wrapper of its *declared* signature therefore nulls out
  * whenever the value was allocated under a different signature's wrapper
  * (e.g. an activated async closure: its wrapper is minted for the REWRITTEN
  * `... -> externref` Promise signature, while an `fn: () => void` param casts
  * to the void wrapper) — unless creation ORDER happened to make the declared
- * wrapper the root. Cast to the root instead and discriminate on the funcref's
- * exact type (which encodes the true signature).
+ * wrapper the root. Cast/read/pass `self` through the root instead and
+ * discriminate only on the funcref's exact type (which encodes the true
+ * signature).
  */
 export function getFuncRefWrapperRootTypeIdx(ctx: CodegenContext): number | undefined {
   return (ctx as unknown as { __funcRefWrapperRootTypeIdx?: number }).__funcRefWrapperRootTypeIdx;
+}
+
+/**
+ * Return the concrete struct type used by a closure funcref's leading `self`
+ * parameter. Shared wrapper funcs return the canonical root; private/named
+ * function-expression funcs return their concrete nullable struct. Dispatch
+ * sites use this distinction to avoid foreign per-signature wrapper casts
+ * without breaking private closure types.
+ */
+export function getClosureFuncSelfTypeIdx(ctx: CodegenContext, funcTypeIdx: number): number | undefined {
+  const type = ctx.mod.types[funcTypeIdx];
+  if (!type || type.kind !== "func") return undefined;
+  const self = type.params[0];
+  return self && (self.kind === "ref" || self.kind === "ref_null") ? self.typeIdx : undefined;
 }

--- a/src/codegen/expressions/call-identifier.ts
+++ b/src/codegen/expressions/call-identifier.ts
@@ -12,7 +12,7 @@ import { ts } from "../../ts-api.js";
 import { isBooleanType, isPromiseType, isStringType, isVoidType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { resolveArrayInfo } from "../array-methods.js";
-import { compileArrowAsClosure, getFuncRefWrapperRootTypeIdx, getOrCreateFuncRefWrapperTypes } from "../closures.js";
+import { compileArrowAsClosure, getClosureFuncSelfTypeIdx, getOrCreateFuncRefWrapperTypes } from "../closures.js";
 import { emitToNumber, emitToString } from "../coercion-engine.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
@@ -1022,7 +1022,6 @@ export function compileIdentifierCall(
 
         if (wrapperTypes) {
           const matchedClosureInfo = wrapperTypes.closureInfo;
-          const matchedStructTypeIdx = wrapperTypes.structTypeIdx;
           // (#2174) When the callee's signature returns `Promise<T>`,
           // `resolveWasmType` strips the Promise wrapper and yields the awaited
           // value's wasm type (e.g. f64 for `() => Promise<number>`). But an
@@ -1107,24 +1106,24 @@ export function compileIdentifierCall(
           // Save closure ref to a local
           let closureLocal: number;
           let rawCalleeLocal: number | undefined;
-          // (#2873 park fix) Struct type the externref callee is cast to. The
-          // declared-signature wrapper (`matchedStructTypeIdx`) only accepts
+          // (#2873 park fix) Struct type the externref callee is cast to. A
+          // declared-signature allocation wrapper only accepts
           // values whose ACTUAL signature wrapper is the same type — but the
-          // wrapper chain is a star of `sub final` siblings under the FIRST
-          // wrapper created, so a value allocated under a different signature's
+          // wrapper family is a star of distinct children under the FIRST,
+          // permanently-open wrapper root, so a value allocated under a different signature's
           // wrapper (an activated ASYNC closure whose result was rewritten to
           // externref/Promise while the param says `() => void`; a covariant
           // sync closure like `() => string` passed as `() => void`) nulls the
           // guarded cast and the funcref fetch below traps "dereferencing a
           // null pointer" (the 32-file asyncTest() merge_group cluster on PR
-          // #2873 — creation ORDER decided which modules survived). Cast to the
-          // wrapper ROOT instead — the guaranteed supertype of every wrapper —
-          // and let the per-candidate funcref `ref.test` (which encodes the
-          // exact signature) discriminate; each dispatch arm re-casts self to
-          // its own candidate's struct type.
-          let closureCastStructIdx = matchedStructTypeIdx;
+          // #2873 — creation ORDER decided which modules survived). Cast/read
+          // and pass self through the wrapper ROOT — the guaranteed supertype
+          // of every wrapper. The per-candidate funcref `ref.test`/cast encodes
+          // the exact signature; narrowing the struct after that would still
+          // be wrong across modules because their same-signature allocation
+          // wrappers can occupy different places in the local hierarchy.
+          const closureCastStructIdx = wrapperTypes.liftedSelfTypeIdx;
           if (innerResultType?.kind === "externref") {
-            closureCastStructIdx = getFuncRefWrapperRootTypeIdx(ctx) ?? matchedStructTypeIdx;
             const closureRefType: ValType = {
               kind: "ref_null",
               typeIdx: closureCastStructIdx,
@@ -1141,9 +1140,9 @@ export function compileIdentifierCall(
             emitGuardedRefCast(fctx, closureCastStructIdx);
             fctx.body.push({ op: "local.set", index: closureLocal });
           } else {
-            const closureRefType: ValType = innerResultType ?? {
-              kind: "ref",
-              typeIdx: matchedStructTypeIdx,
+            const closureRefType: ValType = {
+              kind: innerResultType?.kind === "ref_null" ? "ref_null" : "ref",
+              typeIdx: closureCastStructIdx,
             };
             closureLocal = allocLocal(fctx, `__callable_param_${fctx.locals.length}`, closureRefType);
             fctx.body.push({ op: "local.set", index: closureLocal });
@@ -1353,14 +1352,13 @@ export function compileIdentifierCall(
             // Push self (null-check)
             fctx.body.push({ op: "local.get", index: closureLocal });
             emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: closureCastStructIdx });
-            // (#2873) Root-typed local → the single candidate's self param type.
-            // The guarded funcref cast below already gates the call (TypeError
-            // on signature mismatch); a value that passes it is of the matched
-            // wrapper (or a capture subtype), so this cast succeeds for every
-            // value that reaches the call — and traps no earlier than the old
-            // struct.get-on-null did for mismatched shapes.
-            if (closureCastStructIdx !== matchedStructTypeIdx) {
-              fctx.body.push({ op: "ref.cast_null", typeIdx: matchedStructTypeIdx });
+            // Shared funcs use root self; private funcs retain a concrete self
+            // type. The matched wrapper candidate is shared, but derive rather
+            // than assume so the invariant stays local to the func type.
+            const matchedSelfTypeIdx =
+              getClosureFuncSelfTypeIdx(ctx, matchedClosureInfo.funcTypeIdx) ?? closureCastStructIdx;
+            if (matchedSelfTypeIdx !== closureCastStructIdx) {
+              fctx.body.push({ op: "ref.cast", typeIdx: matchedSelfTypeIdx });
             }
             // Push args
             for (const al of argLocals) {
@@ -1413,10 +1411,12 @@ export function compileIdentifierCall(
             // arm is dead-arm-safe (#2174 — no late-import index shifts).
             if (variadic !== undefined) {
               const armBody: Instr[] = [];
-              // self (root-typed local → the variadic wrapper struct)
+              // self (canonical root for shared variadic wrappers; concrete
+              // self only if this ever becomes a private func type).
               armBody.push({ op: "local.get", index: closureLocal });
-              if (variadic.structTypeIdx !== closureCastStructIdx) {
-                armBody.push({ op: "ref.cast", typeIdx: variadic.structTypeIdx });
+              const variadicSelfTypeIdx = getClosureFuncSelfTypeIdx(ctx, variadic.funcTypeIdx) ?? closureCastStructIdx;
+              if (variadicSelfTypeIdx !== closureCastStructIdx) {
+                armBody.push({ op: "ref.cast", typeIdx: variadicSelfTypeIdx });
               }
               // Pack args: declared-slot locals up to the TRUE call-site count
               // (argLocals beyond expr.arguments.length are synthesized padding),
@@ -1488,25 +1488,19 @@ export function compileIdentifierCall(
             }
 
             for (const fc of [...funcCandidates].reverse()) {
-              // Each candidate needs: push self, push args, push typed funcref, call_ref
-              // The self struct type must match the funcref's expected first param.
-              // All wrapper struct types have the same layout so closureLocal works,
-              // but call_ref expects (ref $specificStruct). We use ref.cast to cast
-              // closureLocal to the funcref's expected struct type.
+              // Each candidate needs root self, args, typed funcref, call_ref.
+              // Exactness belongs solely to the funcref type; wrapper subtypes
+              // are module-local allocation identities.
               const fcCallBody: Instr[] = [];
-              // Push self (cast to the funcref's expected struct type).
-              // (#2873) Compare against the LOCAL's static type (the wrapper
-              // root on the externref path), not the declared wrapper: an arm
-              // only runs when its funcref `ref.test` matched, and a closure's
-              // struct is always its funcref-signature's wrapper (or a capture
-              // subtype of it), so the downcast from the root succeeds exactly
-              // on the live arm. NB the old "V8 canonicalizes same-layout
-              // structs" claim is FALSE for the wrapper chain — `sub final
-              // $root` siblings do not canonicalize together; only root-casts
-              // are universal.
+              // Shared func types use canonical-root self. A private/named
+              // closure func type still names its concrete self, so its arm
+              // needs a concrete cast to remain statically call_ref-valid.
+              // An unrelated private carrier cannot pass the wrapper-root gate;
+              // that candidate arm may therefore be runtime-unreachable.
               fcCallBody.push({ op: "local.get", index: closureLocal });
-              if (fc.structTypeIdx !== closureCastStructIdx) {
-                fcCallBody.push({ op: "ref.cast", typeIdx: fc.structTypeIdx });
+              const candidateSelfTypeIdx = getClosureFuncSelfTypeIdx(ctx, fc.funcTypeIdx) ?? closureCastStructIdx;
+              if (candidateSelfTypeIdx !== closureCastStructIdx) {
+                fcCallBody.push({ op: "ref.cast", typeIdx: candidateSelfTypeIdx });
               }
               // Push args
               for (const al of argLocals) {

--- a/src/codegen/expressions/call-tail-dispatch.ts
+++ b/src/codegen/expressions/call-tail-dispatch.ts
@@ -13,7 +13,12 @@ import { forEachChild, ts } from "../../ts-api.js";
 import { isNumberType, isStringType, isVoidType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, resolveArrayInfo } from "../array-methods.js";
-import { compileArrowAsClosure, compileArrowFunction, getOrCreateFuncRefWrapperTypes } from "../closures.js";
+import {
+  compileArrowAsClosure,
+  compileArrowFunction,
+  getClosureFuncSelfTypeIdx,
+  getOrCreateFuncRefWrapperTypes,
+} from "../closures.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal } from "../context/locals.js";
@@ -1473,31 +1478,28 @@ export function compileTailDispatch(
       if (matchedClosureInfo && matchedStructTypeIdx !== undefined) {
         // Compile the inner call expression to get the closure on the stack
         const innerResultType = compileExpression(ctx, fctx, expr.expression);
+        const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, matchedClosureInfo.funcTypeIdx) ?? matchedStructTypeIdx;
+        const closureRefType: ValType = { kind: "ref_null", typeIdx: selfTypeIdx };
 
-        // Save closure ref to a local so we can extract both args and funcref
-        let closureLocal: number;
+        // Save closure ref to a local so we can extract both args and funcref.
+        // Erased shared closures normalize to the canonical root; private/named
+        // funcs retain the concrete self encoded in their func type.
+        const closureLocal = allocLocal(fctx, `__call_ret_${fctx.locals.length}`, closureRefType);
         if (innerResultType?.kind === "externref") {
-          // Need to convert externref back to the closure struct ref (guarded)
-          const closureRefType: ValType = {
-            kind: "ref_null",
-            typeIdx: matchedStructTypeIdx,
-          };
-          closureLocal = allocLocal(fctx, `__call_ret_${fctx.locals.length}`, closureRefType);
           fctx.body.push({ op: "any.convert_extern" });
-          emitGuardedRefCast(fctx, matchedStructTypeIdx);
-          fctx.body.push({ op: "local.set", index: closureLocal });
-        } else {
-          const closureRefType: ValType = innerResultType ?? {
-            kind: "ref",
-            typeIdx: matchedStructTypeIdx,
-          };
-          closureLocal = allocLocal(fctx, `__call_ret_${fctx.locals.length}`, closureRefType);
-          fctx.body.push({ op: "local.set", index: closureLocal });
+          emitGuardedRefCast(fctx, selfTypeIdx);
+        } else if (
+          innerResultType &&
+          (innerResultType.kind === "ref" || innerResultType.kind === "ref_null") &&
+          innerResultType.typeIdx !== selfTypeIdx
+        ) {
+          emitGuardedRefCast(fctx, selfTypeIdx);
         }
+        fctx.body.push({ op: "local.set", index: closureLocal });
 
         // Push closure ref as first arg (self param) — null-check → TypeError (#728)
         fctx.body.push({ op: "local.get", index: closureLocal });
-        emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: matchedStructTypeIdx });
+        emitNullCheckThrow(ctx, fctx, closureRefType);
 
         // Push call arguments (only up to declared param count)
         const crParamCnt = matchedClosureInfo.paramTypes.length;
@@ -1522,10 +1524,10 @@ export function compileTailDispatch(
 
         // Push the funcref from the closure struct (field 0) — null-check → TypeError (#728)
         fctx.body.push({ op: "local.get", index: closureLocal });
-        emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: matchedStructTypeIdx });
+        emitNullCheckThrow(ctx, fctx, closureRefType);
         fctx.body.push({
           op: "struct.get",
-          typeIdx: matchedStructTypeIdx,
+          typeIdx: selfTypeIdx,
           fieldIdx: 0,
         });
         // Guard funcref cast to avoid illegal cast (#778)
@@ -1655,6 +1657,7 @@ export function compileTailDispatch(
         const closureInfo = wrapperTypes.closureInfo;
         const structTypeIdx = wrapperTypes.structTypeIdx;
         const funcTypeIdx = closureInfo.funcTypeIdx;
+        const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, funcTypeIdx) ?? structTypeIdx;
 
         // 1. Compile the callee once. It must be a ref-shaped value (we can't
         //    `ref.test` an i32 / f64). For non-ref callees, drop value + args
@@ -1746,7 +1749,7 @@ export function compileTailDispatch(
         if (innerResultType.kind === "externref") {
           fctx.body.push({ op: "any.convert_extern" });
         }
-        fctx.body.push({ op: "ref.test", typeIdx: structTypeIdx });
+        fctx.body.push({ op: "ref.test", typeIdx: selfTypeIdx });
 
         // 5. then branch — ref.test passed, do the dispatch.
         // (#1395 fix) Use pushBody/popBody so the saved body is tracked in
@@ -1772,10 +1775,10 @@ export function compileTailDispatch(
         if (innerResultType.kind === "externref") {
           fctx.body.push({ op: "any.convert_extern" });
         }
-        fctx.body.push({ op: "ref.cast", typeIdx: structTypeIdx });
+        fctx.body.push({ op: "ref.cast", typeIdx: selfTypeIdx });
         const closureLocal = allocLocal(fctx, `__cb_closure_${fctx.locals.length}`, {
           kind: "ref",
-          typeIdx: structTypeIdx,
+          typeIdx: selfTypeIdx,
         });
         fctx.body.push({ op: "local.set", index: closureLocal });
 
@@ -1809,7 +1812,7 @@ export function compileTailDispatch(
 
         // Push funcref from closure struct, guarded cast + null-check, call_ref.
         fctx.body.push({ op: "local.get", index: closureLocal });
-        fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: 0 });
+        fctx.body.push({ op: "struct.get", typeIdx: selfTypeIdx, fieldIdx: 0 });
         emitGuardedFuncRefCast(fctx, funcTypeIdx);
         emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: funcTypeIdx });
         fctx.body.push({ op: "call_ref", typeIdx: funcTypeIdx });

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -10,7 +10,11 @@
 import { ts } from "../../ts-api.js";
 import { isVoidType, isPromiseType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
-import { getFuncRefWrapperRootTypeIdx, getOrCreateFuncRefWrapperTypes } from "../closures.js";
+import {
+  getClosureFuncSelfTypeIdx,
+  getFuncRefWrapperRootTypeIdx,
+  getOrCreateFuncRefWrapperTypes,
+} from "../closures.js";
 import { compileArrayJoinExtern } from "../array-methods.js";
 import { tryCompileNativeDisposableStackAnyMethodCall } from "../disposable-runtime.js";
 import { noJsHost } from "../js-errors.js";
@@ -107,8 +111,9 @@ type FuncCandidate = { funcTypeIdx: number; structTypeIdx: number; returnType: V
  * (`() => number` stored in a `() => void` field) or an activated async closure
  * (its result was rewritten to externref/Promise). Every no-capture wrapper
  * struct is a layout-identical `(struct (field funcref))`, but
- * `getOrCreateFuncRefWrapperTypes` chains each later signature `sub final` under
- * the module's FIRST wrapper (the chain root). WasmGC isorecursive
+ * `getOrCreateFuncRefWrapperTypes` places each later signature in a distinct
+ * direct child under the module's FIRST wrapper (the permanently-open root).
+ * WasmGC isorecursive
  * canonicalization keys on (fields, supertype, finality), so the siblings do NOT
  * merge: a `ref.cast` of the value to the DECLARED wrapper (and of its funcref
  * to the declared funcref type) nulls out whenever the value's actual wrapper
@@ -225,8 +230,8 @@ function collectPropertyCallArgLocals(
  * every wrapper struct) and already null-checked; `argLocals` hold the
  * coerced+padded arguments. The funcref is fetched off the root's field 0
  * (valid for a closure of ANY wrapper subtype), then dispatched on its exact
- * type: each arm re-casts self to that candidate's struct and coerces the
- * return to `expectedReturn`. When no candidate's funcref matches, a TypeError
+ * type. Each arm passes root self unchanged and coerces the return to
+ * `expectedReturn`. When no candidate's funcref matches, a TypeError
  * is thrown (the callee was not a closure of any admitted signature). Mirrors
  * the calls.ts callable-param multi-funcref dispatch (#1131 / #2873).
  */
@@ -254,13 +259,15 @@ function emitRootFuncrefDispatch(
   let funcDispatch: Instr[] = typeErrorThrowInstrs(ctx);
   for (const fc of [...funcCandidates].reverse()) {
     const fcCallBody: Instr[] = [];
-    // Self: root-typed local downcast to this candidate's struct. The arm only
-    // runs when its funcref `ref.test` matched, and a closure's struct is always
-    // its funcref-signature's wrapper (or a capture subtype of it), so the
-    // downcast succeeds exactly on the live arm — and yields the non-null self
-    // that `call_ref` requires.
+    // Shared lifted funcs take canonical-root self. Private/named closure funcs
+    // retain a concrete self type, so their arms need a concrete cast to remain
+    // statically call_ref-valid. An unrelated private carrier cannot pass the
+    // wrapper-root gate; that candidate arm may therefore be unreachable.
     fcCallBody.push({ op: "local.get", index: closureLocal });
-    fcCallBody.push({ op: "ref.cast", typeIdx: fc.structTypeIdx });
+    const candidateSelfTypeIdx = getClosureFuncSelfTypeIdx(ctx, fc.funcTypeIdx) ?? rootIdx;
+    if (candidateSelfTypeIdx !== rootIdx) {
+      fcCallBody.push({ op: "ref.cast", typeIdx: candidateSelfTypeIdx });
+    }
     for (const al of argLocals) fcCallBody.push({ op: "local.get", index: al });
     fcCallBody.push({ op: "local.get", index: funcrefLocal });
     fcCallBody.push({ op: "ref.cast", typeIdx: fc.funcTypeIdx });
@@ -311,6 +318,13 @@ export function compileClosureCall(
   const moduleIdx = localIdx === undefined ? ctx.moduleGlobals.get(varName) : undefined;
   if (localIdx === undefined && moduleIdx === undefined) return null;
 
+  // The lifted function type is authoritative for its self carrier. Shared
+  // `__fn_wrap_*` functions use the canonical wrapper root; private/named
+  // closure functions retain their concrete self struct. Reading this from the
+  // func type avoids reintroducing module-local signature-wrapper order into
+  // externref unpacking while preserving the private-closure path.
+  const selfStructTypeIdx = getClosureFuncSelfTypeIdx(ctx, info.funcTypeIdx) ?? info.structTypeIdx;
+
   // Determine how to push the closure ref (local vs module global).
   // If the value is externref (e.g. captured in a __cb_N callback or a module
   // global like `var f; f = () => {...}`), we need to convert to the expected
@@ -324,7 +338,7 @@ export function compileClosureCall(
     // (#1048).
     const boxed = fctx.boxedCaptures?.get(varName);
     if (boxed) {
-      const castType: ValType = { kind: "ref_null", typeIdx: info.structTypeIdx };
+      const castType: ValType = { kind: "ref_null", typeIdx: selfStructTypeIdx };
       const castLocal = allocLocal(fctx, `__closure_cast_${fctx.locals.length}`, castType);
       fctx.body.push({ op: "local.get", index: localIdx });
       // struct.get $refCell $value — unwrap to underlying externref/ref
@@ -332,17 +346,17 @@ export function compileClosureCall(
       if (boxed.valType.kind === "externref") {
         fctx.body.push({ op: "any.convert_extern" });
       }
-      emitGuardedRefCast(fctx, info.structTypeIdx);
+      emitGuardedRefCast(fctx, selfStructTypeIdx);
       fctx.body.push({ op: "local.set", index: castLocal });
       effectiveLocalIdx = castLocal;
     } else if (localType?.kind === "externref") {
-      // Convert externref → anyref → ref $closure_struct, store in a new local
-      const castType: ValType = { kind: "ref_null", typeIdx: info.structTypeIdx };
+      // Convert externref → anyref → the lifted function's self carrier.
+      const castType: ValType = { kind: "ref_null", typeIdx: selfStructTypeIdx };
       const castLocal = allocLocal(fctx, `__closure_cast_${fctx.locals.length}`, castType);
       fctx.body.push({ op: "local.get", index: localIdx });
       fctx.body.push({ op: "any.convert_extern" });
       // Guard cast to avoid illegal cast traps (#778)
-      emitGuardedRefCast(fctx, info.structTypeIdx);
+      emitGuardedRefCast(fctx, selfStructTypeIdx);
       fctx.body.push({ op: "local.set", index: castLocal });
       effectiveLocalIdx = castLocal;
     }
@@ -352,11 +366,11 @@ export function compileClosureCall(
     const globalDef = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)];
     const globalType = globalDef?.type;
     if (globalType?.kind === "externref") {
-      const castType: ValType = { kind: "ref_null", typeIdx: info.structTypeIdx };
+      const castType: ValType = { kind: "ref_null", typeIdx: selfStructTypeIdx };
       const castLocal = allocLocal(fctx, `__closure_cast_${fctx.locals.length}`, castType);
       fctx.body.push({ op: "global.get", index: moduleIdx });
       fctx.body.push({ op: "any.convert_extern" });
-      emitGuardedRefCast(fctx, info.structTypeIdx);
+      emitGuardedRefCast(fctx, selfStructTypeIdx);
       fctx.body.push({ op: "local.set", index: castLocal });
       effectiveLocalIdx = castLocal;
     }
@@ -385,11 +399,11 @@ export function compileClosureCall(
       fctx.body.push({ op: "global.get", index: liveModuleIdx });
     }
     // Null-check → TypeError instead of trap on struct.get (#728, #441)
-    emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: info.structTypeIdx });
+    emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: selfStructTypeIdx });
   };
 
   // Stack for call_ref needs: [closure_ref, ...args, funcref]
-  // where the lifted func type is (ref $closure_struct, ...arrowParams) → results
+  // where shared-wrapper lifted funcs use (ref $wrapperRoot, ...args) → results.
 
   // Push closure ref as first arg (self param of the lifted function)
   pushClosureRef();
@@ -416,7 +430,7 @@ export function compileClosureCall(
   pushClosureRef();
   fctx.body.push({
     op: "struct.get",
-    typeIdx: info.structTypeIdx,
+    typeIdx: selfStructTypeIdx,
     fieldIdx: 0,
   });
   // Guard funcref cast to avoid illegal cast (#778)
@@ -918,18 +932,20 @@ export function compileCallablePropertyCall(
       fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
 
       if (funcCandidates.length <= 1) {
-        // ── Single-candidate path (byte-identical to pre-#3205) ──
+        // ── Single-candidate path ──
         // The only closure of this arity in the module is the declared
-        // signature, so the value can only be it (or a capture subtype), and the
-        // declared-wrapper cast + single funcref cast are safe.
-        // Convert externref -> closure struct ref (guarded to avoid illegal cast)
+        // signature, so dispatch needs only one funcref test. The wrapper itself
+        // still crosses an externref boundary and must normalize to the lifted
+        // function's self carrier (canonical root for shared wrapper funcs), not
+        // the module-local per-signature allocation wrapper.
+        const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, matchedClosureInfo.funcTypeIdx) ?? wrapperStructIdx;
         const closureRefType: ValType = {
           kind: "ref_null",
-          typeIdx: wrapperStructIdx,
+          typeIdx: selfTypeIdx,
         };
         const closureLocal = allocLocal(fctx, `__cprop_ext_${fctx.locals.length}`, closureRefType);
         fctx.body.push({ op: "any.convert_extern" });
-        emitGuardedRefCast(fctx, wrapperStructIdx);
+        emitGuardedRefCast(fctx, selfTypeIdx);
         fctx.body.push({ op: "local.set", index: closureLocal });
 
         // Push closure ref as first arg (self param) — null-check → TypeError (#728)
@@ -959,7 +975,7 @@ export function compileCallablePropertyCall(
         emitNullCheckThrow(ctx, fctx, closureRefType);
         fctx.body.push({
           op: "struct.get",
-          typeIdx: wrapperStructIdx,
+          typeIdx: selfTypeIdx,
           fieldIdx: 0,
         });
         // Guard funcref cast to avoid illegal cast (#778)
@@ -974,7 +990,7 @@ export function compileCallablePropertyCall(
       }
 
       // ── (#3205) Multi-candidate order-independent dispatch ──
-      // The value's actual wrapper may be a different `sub final` sibling than
+      // The value's actual wrapper may be a different root-child sibling than
       // the declared wrapper (covariant return, activated async closure). Cast to
       // the wrapper ROOT (supertype of every wrapper), fetch the funcref off the
       // root, and dispatch on its exact type. When the field's declared return is
@@ -1166,18 +1182,21 @@ export function compileCallableElementAccessCall(
   }
 
   if (funcCandidates.length <= 1) {
-    // ── Single-candidate path (byte-identical to pre-#3205) ──
-    // 4. Coerce to closure-struct ref (mirror calls-closures.ts:507-519)
-    const closureRefType: ValType = { kind: "ref_null", typeIdx: wrapperStructIdx };
+    // ── Single-candidate path ──
+    // 4. Normalize to the lifted function's self carrier. Shared wrapper funcs
+    // use the canonical root even when this module's signature wrapper is a
+    // child; private/named funcs retain concrete self.
+    const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, closureInfo.funcTypeIdx) ?? wrapperStructIdx;
+    const closureRefType: ValType = { kind: "ref_null", typeIdx: selfTypeIdx };
     const closureLocal = allocLocal(fctx, `__cea_${fctx.locals.length}`, closureRefType);
     if (elemResult.kind === "externref") {
       fctx.body.push({ op: "any.convert_extern" });
-      emitGuardedRefCast(fctx, wrapperStructIdx);
+      emitGuardedRefCast(fctx, selfTypeIdx);
     } else {
       // Already a struct ref — guard cast if the shape differs from the
-      // wrapper we resolved by signature.
-      if ((elemResult as { typeIdx: number }).typeIdx !== wrapperStructIdx) {
-        emitGuardedRefCast(fctx, wrapperStructIdx);
+      // self carrier the lifted function expects.
+      if ((elemResult as { typeIdx: number }).typeIdx !== selfTypeIdx) {
+        emitGuardedRefCast(fctx, selfTypeIdx);
       }
     }
     fctx.body.push({ op: "local.set", index: closureLocal });
@@ -1203,7 +1222,7 @@ export function compileCallableElementAccessCall(
     // 7. Extract funcref + call_ref (mirror lines 543-557)
     fctx.body.push({ op: "local.get", index: closureLocal });
     emitNullCheckThrow(ctx, fctx, closureRefType);
-    fctx.body.push({ op: "struct.get", typeIdx: wrapperStructIdx, fieldIdx: 0 });
+    fctx.body.push({ op: "struct.get", typeIdx: selfTypeIdx, fieldIdx: 0 });
     emitGuardedFuncRefCast(fctx, closureInfo.funcTypeIdx);
     emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: closureInfo.funcTypeIdx });
     fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx });

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -73,6 +73,7 @@ import {
   compileArrowAsClosure,
   compileArrowFunction,
   computeClosureWrapperSig,
+  getClosureFuncSelfTypeIdx,
   getFuncRefWrapperRootTypeIdx,
   getFuncSignature,
   getOrCreateFuncRefWrapperTypes,
@@ -1286,28 +1287,31 @@ function emitReflectiveNativeProtoClosureCall(
   if (userArgs === undefined) return undefined; // dynamic apply args → fall through
 
   // Recover the closure value the variable HOLDS — compile the receiver `m`
-  // (an externref carrying the `$wrap` struct), then `any.convert_extern` +
-  // `ref.cast` to the wrapper struct type. Using the freshly-emitted closure
+  // (an externref carrying a `$wrap` struct), then `any.convert_extern` +
+  // `ref.cast` to the lifted function's actual self carrier. Shared wrapper
+  // funcs use the canonical root; private/named funcs retain concrete self.
+  // Using the freshly-emitted closure
   // (`ref.func`+`struct.new`) instead tripped a wrapper-struct type-idx
   // consistency check at finalize (the probe vs final wrapper in
   // `ensureStandaloneNativeMethodClosure` register distinct struct types). The
-  // receiver's runtime value is exactly the value-read closure, so casting it to
-  // `closureInfo.structTypeIdx` yields a `(ref structTypeIdx)` whose type lines
-  // up with the lifted func type's self param.
-  const structRefT: ValType = { kind: "ref", typeIdx: closureInfo.structTypeIdx };
+  // receiver's runtime value is exactly the value-read closure. Do not cast a
+  // shared closure to the module-local per-signature allocation wrapper: the
+  // same signature may occupy a different child position in another module.
+  const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, closureInfo.funcTypeIdx) ?? closureInfo.structTypeIdx;
+  const structRefT: ValType = { kind: "ref", typeIdx: selfTypeIdx };
   const closureLocal = allocLocal(fctx, `__protocall_${fctx.locals.length}`, structRefT);
   const recvType = compileExpression(ctx, fctx, receiver);
   // The receiver is externref (type-erased) or already a (ref $wrap). Normalize
-  // to the concrete wrapper struct via any.convert_extern + ref.cast.
+  // to the function's self carrier via any.convert_extern + ref.cast.
   if (recvType && recvType.kind === "externref") {
     fctx.body.push({ op: "any.convert_extern" });
   }
-  fctx.body.push({ op: "ref.cast", typeIdx: closureInfo.structTypeIdx });
+  fctx.body.push({ op: "ref.cast", typeIdx: selfTypeIdx });
   fctx.body.push({ op: "local.set", index: closureLocal });
 
   // call_ref ABI mirrors the canonical closure-call sequence
   // (calls-closures.ts compileClosureCall): the lifted func type is
-  //   (ref $wrapStruct, ...userParams) -> result
+  //   (ref $selfCarrier, ...userParams) -> result
   // so the wasm stack must be [self_struct, ...userParams, funcref], where the
   // trailing operand is the FUNCREF extracted from the wrapper's field 0 — NOT
   // the wrapper struct itself. The earlier draft pushed the struct as the
@@ -1337,7 +1341,7 @@ function emitReflectiveNativeProtoClosureCall(
   // the lifted func type, null-checked (→ TypeError, never a trap) — exactly
   // the canonical closure-call tail (calls-closures.ts ~lines 138-150).
   fctx.body.push({ op: "local.get", index: closureLocal });
-  fctx.body.push({ op: "struct.get", typeIdx: closureInfo.structTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "struct.get", typeIdx: selfTypeIdx, fieldIdx: 0 });
   emitGuardedFuncRefCast(fctx, closureInfo.funcTypeIdx);
   emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: closureInfo.funcTypeIdx });
   fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx });
@@ -7617,30 +7621,27 @@ function compileExpressionCallee(
     if (matchedClosureInfo && matchedStructTypeIdx !== undefined) {
       // Compile the callee expression to get the closure on the stack
       const innerResultType = compileExpression(ctx, fctx, calleeExpr);
+      const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, matchedClosureInfo.funcTypeIdx) ?? matchedStructTypeIdx;
+      const closureRefType: ValType = { kind: "ref_null", typeIdx: selfTypeIdx };
 
-      // Save closure ref to a local
-      let closureLocal: number;
+      // Normalize an erased shared closure to the canonical root. Private/named
+      // closure funcs still resolve to their concrete self type.
+      const closureLocal = allocLocal(fctx, `__expr_call_${fctx.locals.length}`, closureRefType);
       if (innerResultType?.kind === "externref") {
-        const closureRefType: ValType = {
-          kind: "ref_null",
-          typeIdx: matchedStructTypeIdx,
-        };
-        closureLocal = allocLocal(fctx, `__expr_call_${fctx.locals.length}`, closureRefType);
         fctx.body.push({ op: "any.convert_extern" });
-        emitGuardedRefCast(fctx, matchedStructTypeIdx);
-        fctx.body.push({ op: "local.set", index: closureLocal });
-      } else {
-        const closureRefType: ValType = innerResultType ?? {
-          kind: "ref",
-          typeIdx: matchedStructTypeIdx,
-        };
-        closureLocal = allocLocal(fctx, `__expr_call_${fctx.locals.length}`, closureRefType);
-        fctx.body.push({ op: "local.set", index: closureLocal });
+        emitGuardedRefCast(fctx, selfTypeIdx);
+      } else if (
+        innerResultType &&
+        (innerResultType.kind === "ref" || innerResultType.kind === "ref_null") &&
+        innerResultType.typeIdx !== selfTypeIdx
+      ) {
+        emitGuardedRefCast(fctx, selfTypeIdx);
       }
+      fctx.body.push({ op: "local.set", index: closureLocal });
 
       // Push closure ref as first arg (self param) — null-check → TypeError (#728)
       fctx.body.push({ op: "local.get", index: closureLocal });
-      emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: matchedStructTypeIdx });
+      emitNullCheckThrow(ctx, fctx, closureRefType);
 
       // Push call arguments (only up to declared param count)
       const ecParamCnt = matchedClosureInfo.paramTypes.length;
@@ -7662,10 +7663,10 @@ function compileExpressionCallee(
 
       // Push the funcref from closure struct and call_ref — null-check → TypeError (#728)
       fctx.body.push({ op: "local.get", index: closureLocal });
-      emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: matchedStructTypeIdx });
+      emitNullCheckThrow(ctx, fctx, closureRefType);
       fctx.body.push({
         op: "struct.get",
-        typeIdx: matchedStructTypeIdx,
+        typeIdx: selfTypeIdx,
         fieldIdx: 0,
       });
       // Guard funcref cast to avoid illegal cast (#778)

--- a/src/codegen/fixups.ts
+++ b/src/codegen/fixups.ts
@@ -37,8 +37,17 @@ import { absoluteFuncIndexCached } from "../emit/resolve-layout.js"; // (#1916 S
  * runtime that doesn't support custom-descriptors (today: wasmtime / standalone
  * Wasm consumers). Pass `true` to leave subtypes as plain `(sub $parent ...)`
  * so wasm-opt has nothing to convert into an exact ref.
+ *
+ * `keepOpenTypeIdxs` holds ABI roots whose non-finality is observable across
+ * separately compiled modules. In particular, the canonical funcref-wrapper
+ * root must remain open even in a module with no wrapper child: finality is
+ * part of WasmGC canonical type identity.
  */
-export function markLeafStructsFinal(mod: WasmModule, skipFinal = false): void {
+export function markLeafStructsFinal(
+  mod: WasmModule,
+  skipFinal = false,
+  keepOpenTypeIdxs: ReadonlySet<number> = new Set<number>(),
+): void {
   if (skipFinal) return;
   // Collect all type indices that are used as a supertype
   const hasSubtypes = new Set<number>();
@@ -63,7 +72,7 @@ export function markLeafStructsFinal(mod: WasmModule, skipFinal = false): void {
   // Mark leaf struct types as final
   for (let i = 0; i < mod.types.length; i++) {
     const td = mod.types[i];
-    if (td.kind === "struct" && td.superTypeIdx !== undefined && !hasSubtypes.has(i)) {
+    if (td.kind === "struct" && td.superTypeIdx !== undefined && !hasSubtypes.has(i) && !keepOpenTypeIdxs.has(i)) {
       td.final = true;
     } else if (td.kind === "rec") {
       // Types inside rec groups have their own indices (rec groups occupy consecutive indices)
@@ -71,7 +80,12 @@ export function markLeafStructsFinal(mod: WasmModule, skipFinal = false): void {
       // Actually, rec group members are indexed consecutively starting at i
       let innerIdx = i;
       for (const inner of td.types) {
-        if (inner.kind === "struct" && inner.superTypeIdx !== undefined && !hasSubtypes.has(innerIdx)) {
+        if (
+          inner.kind === "struct" &&
+          inner.superTypeIdx !== undefined &&
+          !hasSubtypes.has(innerIdx) &&
+          !keepOpenTypeIdxs.has(innerIdx)
+        ) {
           inner.final = true;
         }
         innerIdx++;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -118,7 +118,7 @@ import {
   repairStructTypeMismatches,
 } from "./fixups.js";
 import { emitInlineMathFunctions } from "./math-helpers.js";
-import { finalizeMethodTrampolines } from "./closures.js";
+import { finalizeMethodTrampolines, getFuncRefWrapperRootTypeIdx } from "./closures.js";
 import { peepholeOptimize } from "./peephole.js";
 import { brandCollidingShapeTypes } from "./shape-brand.js";
 import {
@@ -870,16 +870,19 @@ function resolvePositionType(
       if (ir) return ir;
       throw new Error(`object TypeNode ${ts.SyntaxKind[node.kind]} could not be lowered to IrType.object`);
     }
-    // #2859 — function-typed position (`fn: () => number`). Mirrors the
-    // selector's `resolveParamType` FunctionTypeNode arm: the signature is
+    // #2859 / #3214 B0 — function-typed PARAMETER (`fn: () => number`). Mirrors
+    // the selector's `resolveParamType` FunctionTypeNode arm: the signature is
     // built by the SAME helper, so the override the lowerer receives compares
     // `irTypeEquals`-equal to the signature a slice-3 closure literal argument
     // produces. A claimed function reaching the throw below means selector and
     // override builder diverged (the standard out-of-sync guard → legacy).
+    // Callable RESULTS remain deliberately unclaimable: the selector rejects a
+    // FunctionTypeNode return as `return-type-not-resolvable` before this shared
+    // position resolver can be reached for it (#3214 B0 parameter-only invariant).
     if (ts.isFunctionTypeNode(node)) {
       const signature = irClosureSignatureFromFunctionTypeNode(node);
-      if (signature) return { kind: "closure", signature };
-      throw new Error(`function TypeNode not expressible as an IR closure signature`);
+      if (signature) return { kind: "callable", signature };
+      throw new Error(`function TypeNode not expressible as an IR callable signature`);
     }
     throw new Error(`unsupported TypeNode kind ${ts.SyntaxKind[node.kind]}`);
   }
@@ -3304,7 +3307,8 @@ export function generateModule(
     // BEFORE dead-type elimination so the brand-chain refs get remapped.
     brandCollidingShapeTypes(mod, ctx.noBrandShapeTypes);
 
-    markLeafStructsFinal(mod, ctx.wasi);
+    const callableRootTypeIdx = getFuncRefWrapperRootTypeIdx(ctx);
+    markLeafStructsFinal(mod, ctx.wasi, callableRootTypeIdx === undefined ? undefined : new Set([callableRootTypeIdx]));
 
     // Dead import and type elimination pass
     eliminateDeadImports(mod, ctx); // #1899 ctx → remap helper side-tables on import removal
@@ -5154,7 +5158,8 @@ export function generateMultiModule(
     // emission, before dead-type elimination.
     brandCollidingShapeTypes(mod, ctx.noBrandShapeTypes);
 
-    markLeafStructsFinal(mod, ctx.wasi);
+    const callableRootTypeIdx = getFuncRefWrapperRootTypeIdx(ctx);
+    markLeafStructsFinal(mod, ctx.wasi, callableRootTypeIdx === undefined ? undefined : new Set([callableRootTypeIdx]));
 
     // Dead import and type elimination pass
     eliminateDeadImports(mod, ctx); // #1899 ctx → remap helper side-tables on import removal

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -465,7 +465,7 @@ export function ensureStandaloneNativeMethodClosure(
   // fctx, then keep that body (it's the real body — no double emission).
   const wrapperProbe = getOrCreateFuncRefWrapperTypes(ctx, userParams, []);
   if (!wrapperProbe) return null;
-  const selfType: ValType = { kind: "ref", typeIdx: wrapperProbe.structTypeIdx };
+  const selfType: ValType = { kind: "ref", typeIdx: wrapperProbe.liftedSelfTypeIdx };
   const bodyFctx = makeNativeClosureFctx(`__probe_${brand}_${member}`, selfType, userParams, null);
   const probedResult = glue.emitMemberBody(ctx, bodyFctx, member, kind);
   // (#2984 Phase 2) Refusal + opted-in fallback (methods only): keep going with
@@ -499,10 +499,10 @@ export function ensureStandaloneNativeMethodClosure(
   const funcName = kind === "getter" ? `__proto_method_${brand}_get_${member}` : `__proto_method_${brand}_${member}`;
   let funcIdx = ctx.funcMap.get(funcName);
   if (funcIdx === undefined) {
-    // Re-emit the body against the final (result-typed) wrapper self param so the
+    // Re-emit the body against the final signature's canonical-root self param so the
     // funcIdx-bearing function carries the right lifted type. (The probe above
     // only computed the result type; this is the committed emission.)
-    const finalSelf: ValType = { kind: "ref", typeIdx: wrapperTypes.structTypeIdx };
+    const finalSelf: ValType = { kind: "ref", typeIdx: wrapperTypes.liftedSelfTypeIdx };
     const closureFctx = makeNativeClosureFctx(funcName, finalSelf, userParams, resultType);
     if (useRefusalBody) {
       // (#2984 Phase 2) Degrade-to-catchable body: a real TypeError instance +

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -1455,8 +1455,8 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           // stay) externref — the #962 guard already refuses to narrow it — the
           // sequence was `any.convert_extern` + guarded cast to ONE
           // signature-matched closure struct + widen back to externref: a pure
-          // round-trip whose else-arm NULLS the value. Closure wrapper structs
-          // are sibling `sub final` types with creation-ORDER-dependent RTTs
+          // round-trip whose else-arm NULLS the value. Signature wrapper structs
+          // are distinct root-child siblings with creation-ORDER-dependent RTTs
           // (see reference #2873), and `closureInfoByTypeIdx` iteration picks an
           // arbitrary first match, so a perfectly good closure of a SIBLING
           // wrapper type read out of an array (`var f = factories[k]`) was

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -10,6 +10,7 @@ import { ts } from "../ts-api.js";
 import { emitIsUndefinedSingletonExternAt, isAnyValue, undefinedSingletonActive } from "./any-helpers.js";
 import { compileNumericBinaryOp } from "./binary-ops.js";
 import { reserveClosedMethodDispatch } from "./closed-method-dispatch.js";
+import { getClosureFuncSelfTypeIdx } from "./closures.js";
 import { compileAndEmitToString, emitToString } from "./coercion-engine.js";
 import { registerStringHelperEmitters } from "./string-emitter-registry.js";
 import { popBody, pushBody } from "./context/bodies.js";
@@ -1283,27 +1284,23 @@ export function compileTaggedTemplateExpression(
     if (matchedClosureInfo && matchedStructTypeIdx !== undefined) {
       // Compile the tag expression to get the closure on the stack
       const tagResult = compileExpression(ctx, fctx, expr.tag);
+      const selfTypeIdx = getClosureFuncSelfTypeIdx(ctx, matchedClosureInfo.funcTypeIdx) ?? matchedStructTypeIdx;
+      const closureRefType: ValType = { kind: "ref_null", typeIdx: selfTypeIdx };
 
-      // Save closure ref to a local
-      let closureLocal: number;
+      // Normalize erased shared closures to the canonical root. Private/named
+      // funcs retain their concrete self carrier.
+      const closureLocal = allocLocal(fctx, `__tt_tag_${fctx.locals.length}`, closureRefType);
       if (tagResult?.kind === "externref") {
-        // Need to convert externref back to the closure struct ref (guarded)
-        const closureRefType: ValType = {
-          kind: "ref_null",
-          typeIdx: matchedStructTypeIdx,
-        };
-        closureLocal = allocLocal(fctx, `__tt_tag_${fctx.locals.length}`, closureRefType);
         fctx.body.push({ op: "any.convert_extern" });
-        emitGuardedRefCast(fctx, matchedStructTypeIdx);
-        fctx.body.push({ op: "local.set", index: closureLocal });
-      } else {
-        const closureRefType: ValType = tagResult ?? {
-          kind: "ref",
-          typeIdx: matchedStructTypeIdx,
-        };
-        closureLocal = allocLocal(fctx, `__tt_tag_${fctx.locals.length}`, closureRefType);
-        fctx.body.push({ op: "local.set", index: closureLocal });
+        emitGuardedRefCast(fctx, selfTypeIdx);
+      } else if (
+        tagResult &&
+        (tagResult.kind === "ref" || tagResult.kind === "ref_null") &&
+        tagResult.typeIdx !== selfTypeIdx
+      ) {
+        emitGuardedRefCast(fctx, selfTypeIdx);
       }
+      fctx.body.push({ op: "local.set", index: closureLocal });
 
       // Push closure ref as self param (first arg of lifted function)
       fctx.body.push({ op: "local.get", index: closureLocal });
@@ -1333,7 +1330,7 @@ export function compileTaggedTemplateExpression(
       fctx.body.push({ op: "ref.as_non_null" });
       fctx.body.push({
         op: "struct.get",
-        typeIdx: matchedStructTypeIdx,
+        typeIdx: selfTypeIdx,
         fieldIdx: 0,
       });
       emitGuardedFuncRefCast(fctx, matchedClosureInfo.funcTypeIdx);

--- a/src/ir/analysis/linear-memory-plan.ts
+++ b/src/ir/analysis/linear-memory-plan.ts
@@ -871,6 +871,7 @@ function collectLayoutsFromType(type: IrType, layouts: Map<string, LinearLayoutP
       internLayout(layouts, planLinearStringLayout());
       return;
     case "closure":
+    case "callable":
       for (const param of type.signature.params) collectLayoutsFromType(param, layouts);
       collectLayoutsFromType(type.signature.returnType, layouts);
       return;
@@ -946,6 +947,8 @@ function linearIrTypeKey(type: IrType): string {
         .join(";")}`;
     case "closure":
       return `closure:(${type.signature.params.map(linearIrTypeKey).join(",")})->${linearIrTypeKey(type.signature.returnType)}`;
+    case "callable":
+      return `callable:(${type.signature.params.map(linearIrTypeKey).join(",")})->${linearIrTypeKey(type.signature.returnType)}`;
     case "extern":
       return `extern:${JSON.stringify(type.className)}`;
     case "union":

--- a/src/ir/backend/handles.ts
+++ b/src/ir/backend/handles.ts
@@ -111,24 +111,22 @@ export interface LinearObjectLowering extends PlannedObjectLowering {
 }
 
 /**
- * Slice 3 (#1169c): WasmGC type info for a closure value. Two structs
- * are involved per closure construction site:
- *   - The SUPERTYPE struct (`structTypeIdx`): contains only the funcref
- *     field. Carried by the IrType.closure ValType so all closures
- *     sharing a signature have the same Wasm-level type.
- *   - The SUBTYPE struct (resolved via `resolveClosureSubtype`): adds
- *     the capture fields. Constructed at the closure's creation site
- *     (`struct.new <subtype>`) and `ref.cast`-ed inside the lifted
- *     body to read captures.
+ * Slice 3 / #3214 B0: WasmGC allocation/type info for a closure:
+ *   - A signature wrapper (`structTypeIdx`) contains field 0's funcref and is
+ *     shared with the legacy `__fn_wrap_*` registry. A no-capture closure
+ *     constructs it directly; it is not the cross-module carrier.
+ *   - An optional captured subtype extends that signature wrapper with capture
+ *     fields and is downcast from root `self` inside the lifted body.
  *
- * `funcTypeIdx` is the lifted function's Wasm func type
- * `(ref $base, ...sig.params) -> sig.returnType` -- used by `call_ref`
- * at the call site.
+ * `funcTypeIdx` is the exact lifted function signature
+ * `(ref $wrapperRoot, ...sig.params) -> sig.returnType`. The root self type,
+ * field-0 read, and funcref signature together are independent of per-module
+ * signature-wrapper creation order.
  */
 export interface IrClosureLowering {
   readonly structTypeIdx: number;
   readonly funcFieldIdx: number;
-  /** Field index for capture position `i` (0-based). Valid only for subtype lowerings. */
+  /** Field index for capture position `i` (0-based). Valid only for captured-subtype lowerings. */
   capFieldIdx(index: number): number;
   readonly funcTypeIdx: number;
 }

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -419,6 +419,7 @@ function checkNestedTypeShapes(
       for (const field of type.shape.fields) checkType(field.type, block, `${where}.${field.name}`);
       return;
     case "closure":
+    case "callable":
       for (let i = 0; i < type.signature.params.length; i++)
         checkType(type.signature.params[i]!, block, `${where}.param${i}`);
       if (type.signature.returnType) checkType(type.signature.returnType, block, `${where}.return`);

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -10,6 +10,7 @@ import {
   asBlockId,
   asLabelId,
   asValueId,
+  closureSignatureEquals,
   irVal,
   irDynamic,
   AllocKind,
@@ -1450,6 +1451,24 @@ export class IrFunctionBuilder {
   emitCoerceToExternref(value: IrValueId): IrValueId {
     const result = this.allocator.fresh();
     const resultType: IrType = irVal({ kind: "externref" });
+    this.valueTypes.set(result, resultType);
+    this.pushInstr({ kind: "coerce.to_externref", value, result, resultType });
+    return result;
+  }
+
+  /**
+   * Pack an internal closure into the canonical externref callable ABI.
+   * This is intentionally the only closure→callable conversion: signatures
+   * must match exactly, so the boundary does not introduce callback
+   * covariance or broaden selection.
+   */
+  emitCallablePack(value: IrValueId, signature: IrClosureSignature): IrValueId {
+    const valueType = this.typeOf(value);
+    if (valueType.kind !== "closure" || !closureSignatureEquals(valueType.signature, signature)) {
+      throw new Error(`IrFunctionBuilder: callable pack requires an exact closure signature (func ${this.name})`);
+    }
+    const result = this.allocator.fresh();
+    const resultType: IrType = { kind: "callable", signature };
     this.valueTypes.set(result, resultType);
     this.pushInstr({ kind: "coerce.to_externref", value, result, resultType });
     return result;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -2266,6 +2266,10 @@ function describeIrType(t: IrType): string {
     const ps = t.signature.params.map(describeIrType).join(",");
     return `closure(${ps})->${describeIrType(t.signature.returnType)}`;
   }
+  if (t.kind === "callable") {
+    const ps = t.signature.params.map(describeIrType).join(",");
+    return `callable(${ps})->${describeIrType(t.signature.returnType)}`;
+  }
   if (t.kind === "class") return `class<${t.shape.className}>`;
   if (t.kind === "extern") return `extern<${t.className}>`;
   // #1926 — union members / boxed inner are IrTypes; recurse.
@@ -2852,6 +2856,11 @@ function isIrTypeNullable(t: IrType): boolean {
     case "string":
     case "closure":
       return false;
+    case "callable":
+      // Boundary callables are externref carriers. A host can still supply
+      // null despite the source annotation, so optional access must retain a
+      // runtime null check / legacy fallback.
+      return true;
     case "extern":
       // Host-class externref values (Map, RegExp, ...) — externref is
       // nullable at the JS host level. Treat as nullable for `?.` gating.
@@ -3719,11 +3728,11 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
   // Slice 3 (#1169c): local-binding lookups WIN over top-level callees
   // because the source-level identifier resolution puts inner-scope
   // names first. The dispatcher picks one of three paths:
-  //   - `local` binding whose IrType is closure → closure.call
+  //   - `local` binding whose IrType is closure/callable → closure.call
   //   - `nestedFunc` binding → direct call with prepended captures
   //   - top-level callee in calleeTypes → vanilla `call`
   const binding = cx.scope.get(calleeName);
-  if (binding?.kind === "local" && binding.type.kind === "closure") {
+  if (binding?.kind === "local" && (binding.type.kind === "closure" || binding.type.kind === "callable")) {
     return lowerClosureCall(binding.value, binding.type.signature, expr.arguments, cx);
   }
   if (binding?.kind === "nestedFunc") {
@@ -3748,8 +3757,20 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
   for (let i = 0; i < expandedArgExprs.length; i++) {
     const argExpr = expandedArgExprs[i]!;
     const expected = calleeSig.params[i]!;
-    const argVal = lowerExpr(argExpr, cx, expected);
-    const argType = cx.builder.typeOf(argVal);
+    let argVal = lowerExpr(argExpr, cx, expected);
+    let argType = cx.builder.typeOf(argVal);
+    // #3214 B0 — source-function callable params use externref, while closure
+    // literals remain compiler-owned root-carrier refs. Cross that boundary
+    // only for an exact signature match. Already-packed callables forward
+    // unchanged; reverse or covariant conversions remain rejected below.
+    if (
+      argType.kind === "closure" &&
+      expected.kind === "callable" &&
+      closureSignatureEquals(argType.signature, expected.signature)
+    ) {
+      argVal = cx.builder.emitCallablePack(argVal, expected.signature);
+      argType = cx.builder.typeOf(argVal);
+    }
     if (!irTypeArgAssignable(argType, expected)) {
       throw new Error(
         `ir/from-ast: arg ${i} of call to ${calleeName} is ${describeIrType(argType)}, expected ${describeIrType(expected)} in ${cx.funcName}`,
@@ -3844,11 +3865,11 @@ function expandStaticSpreadArgs(args: readonly ts.Expression[], cx: LowerCtx): t
 }
 
 /**
- * Slice 3 (#1169c): lower a call-by-value to a closure binding.
- * `callee` is the SSA value of the closure struct. The lowered
- * `closure.call` instr emits `<callee>; args; <callee>; struct.get
- * $func; call_ref` — the second `<callee>` use is forced into a Wasm
- * local by `collectIrUses`'s double count.
+ * Slice 3 / #3214 B0: lower a call-by-value to an internal closure or a
+ * boundary callable binding. The lowered `closure.call` emits canonical-root
+ * self, args, root self again, field-0 funcref extraction, and call_ref.
+ * Boundary callables unpack externref through a root cast on each self use;
+ * `collectIrUses`'s double count forces the source SSA value into a local.
  */
 function lowerClosureCall(
   callee: IrValueId,
@@ -6686,11 +6707,11 @@ function findClassMember(
  * Class-typed LHS → `class.instanceof` (runtime `__tag` compare against C's
  * tag + descendant tags — exactly legacy `compileInstanceOf`'s non-null-ref
  * path). LHS representations that can never hold a user-class instance
- * (unboxed scalars, strings, plain-object structs, closures) fold to
+ * (unboxed scalars, strings, plain-object structs, internal closures) fold to
  * constant false with the operand still evaluated for effects (legacy
- * parity: `drop; i32.const 0`). Everything else (externref, dynamic, union,
- * boxed, vec refs) demotes cleanly to legacy, which has the full dynamic
- * `__instanceof_dyn` path.
+ * parity: `drop; i32.const 0`). Everything else (boundary callables/externref,
+ * dynamic, union, boxed, vec refs) demotes cleanly to legacy, which has the
+ * full dynamic `__instanceof_dyn` path.
  */
 function lowerInstanceOf(expr: ts.BinaryExpression, cx: LowerCtx): IrValueId {
   if (!ts.isIdentifier(expr.right)) {
@@ -6780,7 +6801,7 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
 
   // (#2856 C3) STRICT undefined-compare — `hit !== undefined`. Dispatch on
   // the non-undefined operand's IrType (mirrors the selector's acceptance):
-  //   - externref-shaped (externref val / extern class / host string):
+  //   - externref-shaped (externref val / extern class / callable / host string):
   //     runtime `__extern_is_undefined(v)` (the legacy check for the same
   //     shape), inverted for `!==`.
   //   - representations that can never hold the JS `undefined` VALUE
@@ -7262,7 +7283,8 @@ function typeOfValue(v: IrValueId, cx: LowerCtx): IrType {
  * the normal lowering).
  *
  * Dispatch by the non-undefined operand's IrType:
- *   - externref-shaped (externref val / extern class / host-mode string) —
+ *   - externref-shaped (externref val / extern class / callable /
+ *     host-mode string) —
  *     the runtime CAN hold the host `undefined`: emit the same
  *     `__extern_is_undefined(v)` check legacy emits for this shape (import
  *     registered by legacy's own lowering of the identical site in the
@@ -7311,6 +7333,7 @@ function tryLowerUndefinedCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, 
   const externrefShaped =
     (tv !== null && tv.kind === "externref") ||
     t.kind === "extern" ||
+    t.kind === "callable" ||
     (t.kind === "string" && cx.resolver?.stringIsExternref?.() === true);
   if (externrefShaped) {
     const flag = cx.builder.emitCall({ kind: "func", name: "__extern_is_undefined" }, [v], irVal({ kind: "i32" }));
@@ -7389,8 +7412,8 @@ function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Lo
     const flag = cx.builder.emitRefIsNull(v);
     return isNeq ? cx.builder.emitUnary("i32.eqz", flag, irVal({ kind: "i32" })) : flag;
   }
-  // #1981: `class`, `object`, and `closure` IrTypes lower to nullable WasmGC
-  // ref shapes (`(ref null $Struct)`). A class/object/closure-typed value can
+  // #1981 / #3214: `class`, `object`, `closure`, and boundary `callable`
+  // IrTypes are reference-shaped. A class/object/closure/callable value can
   // be `null` at runtime (e.g. a host call passing `null` for a class-typed
   // parameter), so the defensive `=== null` / `!== null` guard must NOT be
   // folded to a constant — folding it deletes the guard, which either returns
@@ -7398,7 +7421,12 @@ function tryFoldNullCompare(expr: ts.BinaryExpression, op: ts.SyntaxKind, cx: Lo
   // true, then `p.v` traps). Bail so the caller falls back to legacy, which
   // emits a runtime `ref.is_null` check. The slice-1 fold is only sound for
   // statically non-nullable kinds.
-  if (otherType.kind === "class" || otherType.kind === "object" || otherType.kind === "closure") {
+  if (
+    otherType.kind === "class" ||
+    otherType.kind === "object" ||
+    otherType.kind === "closure" ||
+    otherType.kind === "callable"
+  ) {
     return null;
   }
   // #2713 — a `string` IrType lowers to a nullable ref shape: host-strings

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -60,6 +60,10 @@ import {
 } from "../codegen/registry/types.js";
 import type { CodegenContext, FunctionContext } from "../codegen/context/types.js";
 import { applyIrTailCalls } from "../codegen/ir-tail-call.js";
+import {
+  getFuncRefWrapperRootTypeIdx,
+  getOrCreateFuncRefWrapperTypes,
+} from "../codegen/closures/funcref-wrapper-types.js";
 import { ensureFmod, FMOD_FN } from "../codegen/fmod.js"; // #2945 — on-demand `%` helper materialization
 // (#3156) — on-demand guarded charCodeAt helper materialization
 import {
@@ -1704,6 +1708,9 @@ function makeResolver(
     resolveClosure(sig: IrClosureSignature): IrClosureLowering | null {
       return closureResolver.resolveBase(sig);
     },
+    resolveClosureRoot(): number | null {
+      return getFuncRefWrapperRootTypeIdx(ctx) ?? null;
+    },
     resolveClosureSubtype(sig: IrClosureSignature, fields: readonly IrType[]): IrClosureLowering | null {
       return closureResolver.resolveSubtype(sig, fields);
     },
@@ -2858,6 +2865,10 @@ function irTypeKey(t: IrType): string {
     const ps = t.signature.params.map(irTypeKey).join(",");
     return `closure(${ps})->${irTypeKey(t.signature.returnType)}`;
   }
+  if (t.kind === "callable") {
+    const ps = t.signature.params.map(irTypeKey).join(",");
+    return `callable(${ps})->${irTypeKey(t.signature.returnType)}`;
+  }
   // Slice 4 (#1169d): class is keyed by name — uniqueness across the
   // compilation unit makes this safe.
   if (t.kind === "class") return `class:${t.shape.className}`;
@@ -2896,10 +2907,12 @@ function legacyFieldsHashKey(fields: readonly FieldDef[]): string {
 // ---------------------------------------------------------------------------
 
 /**
- * Slice 3 (#1169c): per-signature closure struct registry. Maintains:
- *   - **base** structs (one per signature) — single-funcref-field
- *     supertype; carried by `IrType.closure` so all closures of the same
- *     signature share one Wasm value type.
+ * Slice 3 / #3214 B0: closure allocation registry. Maintains:
+ *   - **base** structs (one per signature) — the canonical legacy
+ *     `__fn_wrap_*` allocation wrapper returned by
+ *     `getOrCreateFuncRefWrapperTypes`. Every lifted funcref and closure SSA
+ *     carrier uses the module-wide wrapper root instead, making its type stable
+ *     across modules with different wrapper creation order.
  *   - **subtype** structs (one per `(signature, captureFieldTypes)`
  *     pair) — extends the base with capture fields. Constructed at
  *     each `closure.new` site; lifted bodies `ref.cast` __self to
@@ -2919,26 +2932,10 @@ class ClosureStructRegistry {
     const cached = this.baseCache.get(key);
     if (cached) return cached;
 
-    // Synthesize the base struct: just the funcref field, no captures.
-    // Mark as `superTypeIdx: -1` (root of hierarchy, non-final) so
-    // subtypes can extend it. A bare struct with `superTypeIdx`
-    // undefined is emitted as final by the Wasm spec, which would
-    // make the subtype declaration invalid (`type N extends final
-    // type M`).
-    const baseStructIdx = this.ctx.mod.types.length;
-    const baseStructName = `__ir_closure_base_${this.baseCache.size}`;
-    const baseFields: FieldDef[] = [{ name: "func", type: { kind: "funcref" }, mutable: false }];
-    this.ctx.mod.types.push({
-      kind: "struct",
-      name: baseStructName,
-      fields: baseFields,
-      superTypeIdx: -1,
-    } as StructTypeDef);
-    this.ctx.structMap.set(baseStructName, baseStructIdx);
-    this.ctx.typeIdxToStructName.set(baseStructIdx, baseStructName);
-    this.ctx.structFields.set(baseStructName, baseFields);
-
-    // Lifted func type: (ref $base, ...sig.params) -> sig.returnType.
+    // Resolve the source signature first, then delegate both the allocation
+    // wrapper and lifted func type to the canonical legacy registry. This is
+    // the ABI join point: legacy and IR share allocation metadata, while the
+    // helper makes the lifted func's self type the module-wide wrapper root.
     let paramTypes: ValType[];
     let resultTypes: ValType[];
     try {
@@ -2947,26 +2944,27 @@ class ClosureStructRegistry {
     } catch {
       return null;
     }
-    const liftedFuncTypeIdx = addFuncType(
-      this.ctx,
-      [{ kind: "ref", typeIdx: baseStructIdx }, ...paramTypes],
-      resultTypes,
-      `${baseStructName}_funcType`,
-    );
+    const wrapper = getOrCreateFuncRefWrapperTypes(this.ctx, paramTypes, resultTypes);
+    if (!wrapper) return null;
 
     const lowering: IrClosureLowering = {
-      structTypeIdx: baseStructIdx,
+      structTypeIdx: wrapper.structTypeIdx,
       funcFieldIdx: 0,
       capFieldIdx: () => {
         throw new Error("ir/integration: base closure struct has no captures");
       },
-      funcTypeIdx: liftedFuncTypeIdx,
+      funcTypeIdx: wrapper.liftedFuncTypeIdx,
     };
     this.baseCache.set(key, lowering);
     return lowering;
   }
 
   resolveSubtype(sig: IrClosureSignature, captureFieldTypes: readonly IrType[]): IrClosureLowering | null {
+    // A no-capture closure allocates the signature wrapper directly. Creating
+    // a redundant empty subtype would add an unnecessary RTT; invocation reads
+    // every wrapper through the root and discriminates on the funcref type.
+    if (captureFieldTypes.length === 0) return this.resolveBase(sig);
+
     const key = `${sigKey(sig)}#${captureFieldTypes.map(irTypeKey).join(",")}`;
     const cached = this.subCache.get(key);
     if (cached) return cached;
@@ -2997,6 +2995,18 @@ class ClosureStructRegistry {
     this.ctx.typeIdxToStructName.set(subIdx, subName);
     this.ctx.structFields.set(subName, fields);
 
+    const baseInfo = this.ctx.closureInfoByTypeIdx.get(base.structTypeIdx);
+    if (!baseInfo) {
+      throw new Error(`ir/integration: canonical wrapper ${base.structTypeIdx} has no closure metadata`);
+    }
+    this.ctx.closureInfoByTypeIdx.set(subIdx, {
+      structTypeIdx: subIdx,
+      funcTypeIdx: base.funcTypeIdx,
+      paramTypes: [...baseInfo.paramTypes],
+      returnType: baseInfo.returnType,
+      hasCaptures: true,
+    });
+
     const fieldIdxByCap = new Map<number, number>();
     for (let i = 0; i < captureFieldTypes.length; i++) fieldIdxByCap.set(i, i + 1);
 
@@ -3008,7 +3018,9 @@ class ClosureStructRegistry {
         if (v === undefined) throw new Error(`ir/integration: closure subtype has no capture index ${i}`);
         return v;
       },
-      // call_ref dispatches via the BASE func type — subtype shares it.
+      // call_ref dispatches via the signature-specific lifted func type. Its
+      // self param is the wrapper root; the captured body downcasts that root
+      // to this concrete subtype before reading captures.
       funcTypeIdx: base.funcTypeIdx,
     };
     this.subCache.set(key, lowering);

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -134,17 +134,25 @@ export interface IrLowerResolver {
    */
   resolveObject?(shape: IrObjectShape, alloc?: AllocSiteId): IrObjectStructLowering | null;
   /**
-   * Slice 3 (#1169c): resolve the SUPERTYPE WasmGC struct for a closure
-   * signature. Carried by the IrType.closure ValType so all
-   * same-signature closures share one Wasm type. Returns `null` if the
-   * signature contains an IrType the backend can't lower (e.g. a
-   * nested object shape the slice-2 resolver hasn't pre-walked).
+   * Slice 3 / #3214 B0: resolve the per-signature allocation wrapper and its
+   * exact lifted funcref type. The wrapper is used by `closure.new` (and as the
+   * parent of captured environments), but is not the cross-module carrier or
+   * lifted `self` type; those use `resolveClosureRoot`. Returns `null` if the
+   * signature contains an IrType the backend can't lower.
    */
   resolveClosure?(signature: IrClosureSignature): IrClosureLowering | null;
   /**
-   * Slice 3 (#1169c): resolve the SUBTYPE WasmGC struct for a specific
-   * closure-construction site. Different `(signature, captureFieldTypes)`
-   * pairs produce different subtypes of the supertype struct, so the
+   * #3214 B0: resolve the canonical root shared by every legacy/IR
+   * funcref-wrapper struct. This is the stable closure carrier, field-0 read
+   * type, and lifted `self` type. Only allocation and capture recovery use a
+   * narrower per-signature wrapper/subtype.
+   */
+  resolveClosureRoot?(): number | null;
+  /**
+   * Slice 3 (#1169c): resolve the captured SUBTYPE WasmGC struct for a specific
+   * closure-construction site. Different non-empty
+   * `(signature, captureFieldTypes)` pairs produce different subtypes of the
+   * signature's exact canonical wrapper, so the
    * lifted body's `ref.cast` recovers capture-field positions.
    */
   resolveClosureSubtype?(signature: IrClosureSignature, captureFieldTypes: readonly IrType[]): IrClosureLowering | null;
@@ -1703,22 +1711,40 @@ export function lowerIrFunctionBody<S, Slot>(
       }
       case "closure.call": {
         const calleeT = typeOf(instr.callee);
-        if (calleeT.kind !== "closure") {
-          throw new Error(`ir/lower: closure.call callee must be closure IrType, got ${calleeT.kind} (${func.name})`);
+        if (calleeT.kind !== "closure" && calleeT.kind !== "callable") {
+          throw new Error(
+            `ir/lower: closure.call callee must be closure/callable IrType, got ${calleeT.kind} (${func.name})`,
+          );
         }
         const cl = resolver.resolveClosure?.(calleeT.signature);
         if (!cl) {
           throw new Error(`ir/lower: resolver cannot lower closure for call (${func.name})`);
         }
-        // Push __self (closure value), then user args, then the closure
-        // value AGAIN to extract the funcref. The double-emit is the
-        // reason `collectIrUses` returns `callee` twice — that forces
-        // the closure SSA value into a Wasm local so the second emit
-        // is just `local.get`, not a re-emission of the producing tree.
-        emitValue(instr.callee, out);
+        // The wrapper ROOT is the only cross-module-stable struct identity:
+        // per-signature wrappers depend on which signature a module happened
+        // to register first. It is therefore both the lifted `self` carrier and
+        // the type used for field-0 extraction. The funcref cast below performs
+        // the exact signature check without narrowing the struct itself.
+        // Resolving `cl` first creates the root when necessary.
+        const rootTypeIdx = resolver.resolveClosureRoot?.() ?? null;
+        if (rootTypeIdx === null) {
+          throw new Error(`ir/lower: resolver cannot lower closure wrapper root (${func.name})`);
+        }
+        const emitRootSelf = (): void => {
+          emitValue(instr.callee, out);
+          if (calleeT.kind === "callable") {
+            emitter.emitFromExternref({ typeIdx: rootTypeIdx }, out);
+          }
+        };
+
+        // Push root __self, then user args, then the callee value AGAIN to
+        // extract field 0. The double-emit is the reason
+        // `collectIrUses` returns `callee` twice — it forces the SSA value
+        // into a Wasm local instead of re-emitting its producing tree.
+        emitRootSelf();
         for (const a of instr.args) emitValue(a, out);
-        emitValue(instr.callee, out);
-        emitter.emitClosureFuncGet(cl, out);
+        emitRootSelf();
+        emitter.emitClosureFuncGet({ ...cl, structTypeIdx: rootTypeIdx }, out);
         // The struct's `func` field is typed as the abstract `funcref`
         // (matches the legacy `getOrCreateFuncRefWrapperTypes` pattern,
         // which avoids a circular type reference between the struct and
@@ -2309,6 +2335,7 @@ export function lowerIrFunctionBody<S, Slot>(
         const opTy = typeOf(instr.value);
         const alreadyExternref =
           (opTy.kind === "val" && opTy.val.kind === "externref") ||
+          opTy.kind === "callable" ||
           (opTy.kind === "string" && resolver.resolveString?.()?.kind === "externref");
         if (!alreadyExternref) {
           emitter.emitToExternref(out);
@@ -3448,6 +3475,10 @@ function memberValType(t: IrType, funcName: string): ValType {
 
 export function lowerIrTypeToValType(t: IrType, resolver: IrLowerResolver, funcName: string): ValType {
   if (t.kind === "val") return t.val;
+  // #3214 B0 — source-level callable boundaries use the same externref ABI as
+  // legacy callbacks. The signature remains in IrType for exact unpack/call
+  // lowering; it has no distinct Wasm parameter representation.
+  if (t.kind === "callable") return { kind: "externref" };
   if (t.kind === "string") {
     const sty = resolver.resolveString?.();
     if (!sty) {
@@ -3468,17 +3499,19 @@ export function lowerIrTypeToValType(t: IrType, resolver: IrLowerResolver, funcN
     return { kind: "ref", typeIdx: obj.typeIdx };
   }
   if (t.kind === "closure") {
-    // Slice 3 (#1169c): a closure value lowers to a (ref $base_struct)
-    // — the supertype struct shared by all closures with this signature.
-    // `call_ref` against the base func type accepts any subtype value,
-    // so the same Wasm-level type works for both construction (subtype)
-    // and call (supertype). The resolver registers the supertype lazily
-    // on first use.
+    // Slice 3 / #3214 B0: allocation still resolves the per-signature wrapper,
+    // but closure SSA values and lifted `__self` use the canonical root. The
+    // same signature can be the root in one separately compiled module and a
+    // child in another, so its allocation wrapper is not an ABI-stable carrier.
     const cl = resolver.resolveClosure?.(t.signature);
     if (!cl) {
       throw new Error(`ir/lower: resolver cannot lower closure (${funcName})`);
     }
-    return { kind: "ref", typeIdx: cl.structTypeIdx };
+    const rootTypeIdx = resolver.resolveClosureRoot?.() ?? null;
+    if (rootTypeIdx === null) {
+      throw new Error(`ir/lower: resolver cannot lower closure wrapper root (${funcName})`);
+    }
+    return { kind: "ref", typeIdx: rootTypeIdx };
   }
   if (t.kind === "class") {
     // Slice 4 (#1169d): class instances lower to a non-null `(ref
@@ -3553,6 +3586,10 @@ function describeIrTypeShallow(t: IrType): string {
   if (t.kind === "closure") {
     const ps = t.signature.params.map(describeIrTypeShallow).join(",");
     return `closure(${ps})->${describeIrTypeShallow(t.signature.returnType)}`;
+  }
+  if (t.kind === "callable") {
+    const ps = t.signature.params.map(describeIrTypeShallow).join(",");
+    return `callable(${ps})->${describeIrTypeShallow(t.signature.returnType)}`;
   }
   if (t.kind === "class") return `class<${t.shape.className}>`;
   if (t.kind === "extern") return `extern<${t.className}>`;

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -103,6 +103,13 @@ export interface IrTypeRef {
 //                                inner IrType's ValType as its `$val`
 //                                (unwrapped via `asVal` at the resolver
 //                                boundary).
+//   { kind: "closure", signature }
+//                              → ref to the canonical `__fn_wrap_*` ROOT.
+//                                Construction still allocates the signature
+//                                wrapper or a declared captured subtype.
+//   { kind: "callable", signature }
+//                              → externref boundary carrier for that canonical
+//                                wrapper family (#3214 B0).
 //   { kind: "dynamic", tag? }  → `resolver.resolveDynamic()` — the module's
 //                                canonical boxed-any carrier (#2949/#1852:
 //                                `ref_null $AnyValue` in fast/standalone,
@@ -128,9 +135,9 @@ export interface IrObjectShape {
 /**
  * Slice 3 (#1169c) — a closure's caller-visible signature. Used both as
  * the IR-level type discriminator for closure values and as the resolver
- * lookup key for the supertype struct + lifted func type. The implicit
- * `__self` struct param at index 0 of the lifted body is NOT present in
- * `params` — it's added by the resolver when synthesizing the func type.
+ * lookup key for the signature allocation wrapper + exact lifted func type.
+ * The implicit canonical-root `__self` param at index 0 of the lifted body is
+ * NOT present in `params` — the resolver adds it to the func type.
  */
 export interface IrClosureSignature {
   readonly params: readonly IrType[];
@@ -232,14 +239,20 @@ export type IrType =
   // and `boxed`, the IR carries enough information to drive the resolver
   // without committing to a specific Wasm typeIdx until lowering time.
   | { readonly kind: "object"; readonly shape: IrObjectShape }
-  // Backend-agnostic closure marker (#1169c). Carries the caller-visible
-  // signature only — captures are an implementation detail of the
-  // closure-construction site, not a type-system property. Two closure
-  // values with the same signature but different captures share the same
-  // IrType (matches the legacy funcref-wrapper supertype pattern). The
-  // resolver registers a base WasmGC struct per signature plus a subtype
-  // struct per (signature, captureFieldTypes) pair.
+  // Backend-agnostic INTERNAL closure marker (#1169c). Carries the
+  // caller-visible signature only — captures are an implementation detail of
+  // the closure-construction site, not a type-system property. This type is
+  // compiler-owned and lowers to the canonical wrapper ROOT carrier. A
+  // closure.new site still allocates the signature wrapper (or its captured
+  // subtype), both of which are valid root subtypes.
   | { readonly kind: "closure"; readonly signature: IrClosureSignature }
+  // #3214 B0 — callable values crossing a source-function boundary. Legacy
+  // already exposes callbacks as externref-wrapped `__fn_wrap_*` values, so
+  // IR parameters must use the same ABI rather than leaking the internal
+  // closure struct reference. `callable<S>` is deliberately distinct from
+  // `closure<S>`: only an explicit closure→callable pack may cross the
+  // boundary, while callable→callable forwards without representation churn.
+  | { readonly kind: "callable"; readonly signature: IrClosureSignature }
   // Slice 4 (#1169d) — symbolic class instance reference. The Wasm-level
   // value type is `(ref $ClassStruct)` where the struct is registered by
   // the legacy `collectClassDeclaration` pass; the resolver maps
@@ -379,6 +392,9 @@ export function irTypeEquals(a: IrType, b: IrType): boolean {
     return objectShapeEquals(a.shape, b.shape);
   }
   if (a.kind === "closure" && b.kind === "closure") {
+    return closureSignatureEquals(a.signature, b.signature);
+  }
+  if (a.kind === "callable" && b.kind === "callable") {
     return closureSignatureEquals(a.signature, b.signature);
   }
   if (a.kind === "class" && b.kind === "class") {
@@ -1136,18 +1152,19 @@ export interface IrInstrObjectSet extends IrInstrBase {
 /**
  * Materialize a closure value. `liftedFunc` names the lifted top-level
  * function (registered in the IR module as a synthesized BuiltFn).
- * `signature` is the caller-visible signature (used to look up the
- * supertype struct + funcref type). `captures` populates the subtype's
- * capture fields parallel to `captureFieldTypes`.
+ * `signature` is the caller-visible signature (used to look up its allocation
+ * wrapper + exact funcref type). `captures` populates an optional
+ * captured subtype's fields parallel to `captureFieldTypes`; an empty capture
+ * list constructs the exact wrapper itself.
  *
  * Lowering emits:
  *   ref.func $lifted
  *   <push each capture>
  *   struct.new $closure_<signature>_<captureSig>
  *
- * Result type: `{ kind: "closure"; signature }`. The Wasm-level value
- * type is the supertype struct so call_ref against the base func type
- * accepts any subtype.
+ * Result type: `{ kind: "closure"; signature }`. The Wasm-level SSA carrier is
+ * the canonical wrapper root; construction still creates the signature
+ * wrapper or a captured subtype beneath it.
  */
 export interface IrInstrClosureNew extends IrInstrBase {
   readonly kind: "closure.new";
@@ -1178,15 +1195,20 @@ export interface IrInstrClosureCap extends IrInstrBase {
 }
 
 /**
- * Invoke a closure value. `callee` must be `IrType.closure`. `args` must
- * match the signature's params arity and types.
+ * Invoke a compiler-owned closure or a boundary callable. `args` must match
+ * the callee signature's params arity and types.
  *
  * Lowering emits:
- *   <emit callee>          ;; pushes self
+ *   <emit/unpack callee>   ;; pushes canonical-root self
  *   <emit args>
- *   <emit callee>          ;; pushes self again — second use forces a Wasm local
- *   struct.get $base_struct $func
- *   call_ref $base_funcType
+ *   <emit/unpack callee>   ;; pushes self again — second use forces a Wasm local
+ *   struct.get $wrapper_root $func
+ *   ref.cast $lifted_func_type
+ *   call_ref $lifted_func_type
+ *
+ * A `callable<S>` unpack converts externref→anyref and casts once to the
+ * canonical wrapper root. The typed funcref cast performs the exact signature
+ * check; `call_ref` receives that field-0 funcref, never the wrapper itself.
  *
  * Result type: `signature.returnType`.
  */
@@ -1622,7 +1644,9 @@ export interface IrInstrForOfVec extends IrInstrBase {
  *   - val/externref input → no-op (input already externref)
  *   - any other ref input → `extern.convert_any` after pushing the value.
  *
- * Result type: `irVal({ kind: "externref" })`.
+ * Result type is normally `irVal({ kind: "externref" })`. The explicit
+ * closure-boundary pack reuses this representation operation with result
+ * type `{ kind: "callable"; signature }`; both lower to externref.
  */
 export interface IrInstrCoerceToExternref extends IrInstrBase {
   readonly kind: "coerce.to_externref";

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -429,6 +429,10 @@ function irTypeKey(t: IrType): string {
     const ps = t.signature.params.map(irTypeKey).join(",");
     return `c:(${ps})->${irTypeKey(t.signature.returnType)}`;
   }
+  if (t.kind === "callable") {
+    const ps = t.signature.params.map(irTypeKey).join(",");
+    return `cb:(${ps})->${irTypeKey(t.signature.returnType)}`;
+  }
   // Slice 4 (#1169d): class is keyed by name — one declaration per
   // unit, so the name uniquely identifies the shape.
   if (t.kind === "class") return `cls:${t.shape.className}`;

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -764,21 +764,14 @@ export function planIrCompilation(
   //     bodies are rejected up front by the body-shape work (#2856/#2857).
   // -------------------------------------------------------------------------
   const demoteOnLegacyCaller = options?.jsHostExterns !== true;
-  // #2858 host-mode narrowing (BANKED 2026-07-06 regression fix). Relaxing the
-  // caller-direction demotion in host mode is sound for value-param leaf helpers
-  // (the #2949 slice-3b `any`-ABI unification makes a legacy caller of an IR
-  // callee signature-safe). It is NOT sound when the claimed helper takes a
-  // **callable/closure param** (a `FunctionTypeNode` parameter, e.g.
-  // `fn: () => number`): #2949's `any`-ABI unification does not cover the
-  // closure-as-callable-param ABI. If such a helper is claimed for IR only
-  // because its lone unclaimed edge is a legacy caller passing it a
-  // captured-closure argument, the IR lowering illegal-casts that legacy
-  // captured-closure struct (legacy closure ABI ≠ IR callable/funcref
-  // signature) and diverges from the legacy output (the 3 equivalence-gate
-  // regressions on #2752). Keep the conservative caller-direction demotion for
-  // any function carrying a callable param so it stays on the legacy path
-  // alongside its legacy caller; value-param leaves keep the relaxation
-  // (bucket→0 win + the 24 tagged-template fixes preserved).
+  // #2858 host-mode narrowing (BANKED 2026-07-06 regression fix). #3214 B0 now
+  // makes a legacy caller and IR callee ABI-compatible for function-typed
+  // parameters: both cross the boundary as externref and unpack through the
+  // canonical wrapper root. Keep this callable-param caller demotion for B0
+  // anyway to freeze the selector claim set. Function-valued argument lowering
+  // (inline arrows and named top-level functions) belongs to follow-up A; that
+  // slice can deliberately remove this conservative gate with its own coverage.
+  // Value-param leaves retain the existing host-mode relaxation.
   const hasCallableParam = (name: string): boolean => {
     const fn = declByName.get(name);
     if (!fn) return false;
@@ -805,8 +798,8 @@ export function planIrCompilation(
       const myCallees = callees.get(name) ?? new Set<string>();
       let safe = true;
       // Caller-direction demotion: always in standalone/wasi (#2858), and in
-      // host mode only for functions with a callable/closure param (BANKED
-      // 2026-07-06 — see `hasCallableParam` above).
+      // host mode only for functions with a callable param (B0 scope freeze;
+      // see `hasCallableParam` above).
       if (demoteOnLegacyCaller || hasCallableParam(name)) {
         const myCallers = callers.get(name) ?? new Set<string>();
         for (const c of myCallers) {
@@ -1282,10 +1275,11 @@ function isIrClaimable(
 //     `return;` / fall-through tails. `void` in param position is rejected
 //     (no JS source emits a `void`-typed param value, so there's nothing to
 //     accept).
-// #2859 — `closure` (param only): a FunctionTypeNode annotation whose params
+// #2859 / #3214 B0 — `closure` selector kind (param only): a FunctionTypeNode annotation whose params
 //   and return are all primitive-annotated (the same surface slice-3 closure
-//   literals support). Lowers to `IrType.closure`; calls through the param
-//   dispatch via `lowerClosureCall` exactly like a closure-typed local.
+//   literals support). The override lowers the source parameter to
+//   `IrType.callable` / externref; calls unpack it through the canonical wrapper
+//   root. `IrType.closure` remains the compiler-owned local literal carrier.
 // #2949 slice 2 — `dynamic`: an UNANNOTATED position whose propagated lattice
 //   type converged to `unknown` (no evidence) or `dynamic` (top). Lowers to
 //   `IrType.dynamic` → the module's boxed-any carrier via
@@ -1380,10 +1374,10 @@ function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | unde
     // unannotated dynamics: non-move uses now reject PRE-claim (no
     // demotion), and the claimed ones share legacy's ABI in both modes.
     if (effectiveType.kind === ts.SyntaxKind.AnyKeyword) return "dynamic";
-    // #2859 — function-typed param (`fn: () => number`). Accepted when the
-    // signature is expressible with the slice-3 closure surface; the param
-    // lowers to the closure supertype struct and `fn()` dispatches through
-    // `lowerClosureCall`. Inexpressible function types stay rejected.
+    // #2859 / #3214 B0 — function-typed param (`fn: () => number`). Accepted
+    // when the signature is expressible with the slice-3 closure surface; the
+    // source boundary lowers to callable/externref and `fn()` unpacks through
+    // the canonical wrapper root. Inexpressible function types stay rejected.
     if (ts.isFunctionTypeNode(effectiveType)) {
       return irClosureSignatureFromFunctionTypeNode(effectiveType) ? "closure" : null;
     }
@@ -4666,9 +4660,9 @@ function collectLocalClasses(sourceFile: ts.SourceFile): Set<string> {
 function collectLocalClosureBindings(fn: ts.FunctionDeclaration): Set<string> {
   const names = new Set<string>();
   if (!fn.body) return names;
-  // #2859 — function-typed params (`fn: () => number`). A call through such a
-  // param dispatches via the IR's closure machinery (`lowerClosureCall`),
-  // exactly like a slice-3 closure local — it is NOT an external call. Only
+  // #2859 / #3214 B0 — function-typed params (`fn: () => number`). A call
+  // through such a param dispatches via the IR callable/root machinery — it is
+  // NOT an external call. Only
   // expressible signatures count; an inexpressible function type keeps the
   // function on `param-type-not-resolvable` anyway, so its call sites never
   // reach the IR.

--- a/tests/issue-3214-callable-abi.test.ts
+++ b/tests/issue-3214-callable-abi.test.ts
@@ -1,0 +1,603 @@
+// #3214 B0 — canonical callable ABI shared by legacy and IR.
+//
+// Function-typed source parameters are boundary carriers (`callable<S>`) and
+// therefore lower to externref, matching the legacy `__fn_wrap_*` ABI. Local
+// closure literals remain internal root-carrier refs and cross that boundary
+// only through an exact-signature closure→callable pack. Invocation reverses
+// the pack by casting externref to the wrapper root, extracting field 0, then
+// call_ref'ing the typed funcref (never the wrapper struct itself).
+
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { verifyIrBackendLegality } from "../src/ir/backend/legality.js";
+import { LinearEmitter } from "../src/ir/backend/linear-emitter.js";
+import { IrFunctionBuilder } from "../src/ir/builder.js";
+import { irTypeEquals, irVal, type IrClosureSignature, type IrType } from "../src/ir/nodes.js";
+import { lowerIrFunctionBody, wasmValueTypeConverter, type IrLowerResolver } from "../src/ir/lower.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { buildTypeMap } from "../src/ir/propagate.js";
+import { planIrCompilation } from "../src/ir/select.js";
+
+type CompileOptions = NonNullable<Parameters<typeof compile>[1]>;
+
+const F64: IrType = irVal({ kind: "f64" });
+
+const ISSUE_2859_PROGRAM = `
+function apply(fn: () => number): number {
+  const v = fn();
+  return v + 1;
+}
+function applyWith(x: number, f: (a: number) => number): number {
+  return f(x) * 2;
+}
+export function test(): number {
+  const g = (): number => 41;
+  const h = (a: number): number => a + 3;
+  return apply(g) + applyWith(10, h);
+}
+`;
+
+// `choose` deliberately creates a different wrapper signature before
+// `apply`. That makes apply's () => number wrapper a non-root descendant and
+// catches creation-order bugs that cast a callable to the module-local exact
+// signature wrapper instead of the canonical root.
+// `p` has no captures; `g` captures bias; `forward` passes an already-packed
+// callable onward without a second pack.
+const ORDERED_CAPTURE_PROGRAM = `
+function choose(fn: (x: number) => boolean): number {
+  return fn(2) ? 10 : 0;
+}
+function apply(fn: () => number): number {
+  return fn();
+}
+function forward(fn: () => number): number {
+  return apply(fn) + 1;
+}
+function applyText(fn: (s: string) => string): number {
+  return fn("a").length;
+}
+export function test(): number {
+  const p = (x: number): boolean => x > 0;
+  const bias: number = 7;
+  const g = (): number => bias + 5;
+  const decorate = (s: string): string => s + "!";
+  return choose(p) + forward(g) + applyText(decorate);
+}
+`;
+
+async function compileAndRun(
+  source: string,
+  options: CompileOptions,
+): Promise<{ result: CompileResult; value: unknown }> {
+  const result = await compile(source, options);
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  const exports = await instantiate(result);
+  const test = (exports as Record<string, unknown>).test;
+  expect(typeof test).toBe("function");
+  return { result, value: (test as () => unknown)() };
+}
+
+async function instantiate(result: CompileResult): Promise<WebAssembly.Exports> {
+  const imports = buildImports(result.imports, undefined, result.stringPool) as WebAssembly.Imports & {
+    setExports?: (exports: WebAssembly.Exports) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports);
+  return instance.exports;
+}
+
+function watTypeLines(wat: string): string[] {
+  return wat
+    .split("\n")
+    .map((line) => line.trimStart())
+    .filter((line) => line.startsWith("(type "));
+}
+
+function expectFunctionFirstParamExternref(wat: string, name: string): void {
+  const header = wat.split("\n").find((line) => line.startsWith(`  (func $${name}`));
+  expect(header, `missing $${name} WAT function`).toBeDefined();
+  if (header!.includes("(param externref")) return;
+
+  const typeRef = header!.match(/\(type ([^)]+)\)/)?.[1];
+  expect(typeRef, `$${name} has neither inline params nor a type use`).toBeDefined();
+  const types = watTypeLines(wat);
+  const typeLine = /^\d+$/.test(typeRef!)
+    ? types[Number(typeRef)]
+    : types.find((line) => line.startsWith(`  (type ${typeRef} `));
+  expect(typeLine, `missing WAT type ${typeRef} used by $${name}`).toContain("(param externref");
+}
+
+function functionBody(wat: string, name: string): string {
+  const start = wat.indexOf(`  (func $${name}`);
+  expect(start, `missing $${name}`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? wat.length : next);
+}
+
+function expectCanonicalCapturedSubtypeAndCallUnpack(wat: string): void {
+  const types = watTypeLines(wat);
+  const rootStruct = types.find((line) => /\$__fn_wrap_\d+_struct \(sub \(struct/.test(line));
+  expect(rootStruct, "canonical wrapper root missing").toBeDefined();
+  expect(rootStruct).not.toContain("(sub final");
+  const rootSuffix = rootStruct!.match(/\$__fn_wrap_(\d+)_struct/)?.[1];
+  expect(rootSuffix).toBeDefined();
+  const rootLifted = types.find((line) => line.includes(`$__fn_wrap_${rootSuffix}_type`));
+  expect(rootLifted, "canonical wrapper root has no lifted func type").toBeDefined();
+  const rootIdxText = rootLifted!.match(/\(ref(?: null)? (\d+)\)/)?.[1];
+  expect(rootIdxText, "canonical wrapper root has no lifted self type").toBeDefined();
+  const rootIdx = Number(rootIdxText);
+  expect(rootLifted).toMatch(new RegExp(`\\(param \\(ref(?: null)? ${rootIdx}\\)`));
+
+  const irCaptured = types.filter((line) => line.includes("(type $__ir_closure_"));
+  // Exactly one captured IR literal. The no-capture literal must use its exact
+  // wrapper directly rather than manufacture an empty IR subtype.
+  expect(irCaptured).toHaveLength(1);
+  const exactIdxText = irCaptured[0]!.match(/\(sub(?: final)? \$type(\d+)/)?.[1];
+  expect(exactIdxText, "captured IR closure has no declared exact-wrapper supertype").toBeDefined();
+  const exactIdx = Number(exactIdxText);
+  const exactLifted = types.find((line) =>
+    new RegExp(`\\$__fn_wrap_(\\d+)_type \\(func \\(param \\(ref(?: null)? ${rootIdx}\\)\\) \\(result f64\\)\\)`).test(
+      line,
+    ),
+  );
+  const exactSuffix = exactLifted?.match(/\$__fn_wrap_(\d+)_type/)?.[1];
+  expect(exactSuffix, "zero-arg number signature has no lifted func type").toBeDefined();
+  const exactWrapper = types.find((line) => line.includes(`$__fn_wrap_${exactSuffix}_struct`));
+  expect(exactWrapper, "zero-arg number signature has no allocation wrapper").toBeDefined();
+  expect(exactWrapper).toContain(`$type${rootIdx}`);
+  expect(exactLifted).toMatch(new RegExp(`\\(param \\(ref(?: null)? ${rootIdx}\\)`));
+  expect(exactIdx, "test did not force a non-root callback wrapper").not.toBe(rootIdx);
+
+  const apply = functionBody(wat, "apply");
+  const unpack = new RegExp(`any\\.convert_extern\\s+ref\\.cast \\(ref ${rootIdx}\\)`, "g");
+  // Once for lifted `self`, once for field-0 extraction.
+  expect(apply.match(unpack)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  expect(apply).not.toMatch(new RegExp(`ref\\.cast \\(ref ${exactIdx}\\)`));
+  expect(apply).toMatch(
+    new RegExp(`struct\\.get ${rootIdx} 0\\s+ref\\.cast \\(ref (\\d+)\\)\\s+(?:return_)?call_ref \\1`),
+  );
+  // Forwarding receives an already-packed callable and must not perform a
+  // second closure→externref pack.
+  expect(functionBody(wat, "forward")).not.toContain("extern.convert_any");
+}
+
+function expectZeroArgNumberWrapperPosition(wat: string, expected: "root" | "child"): void {
+  const types = watTypeLines(wat);
+  const rootStruct = types.find((line) => /\$__fn_wrap_\d+_struct \(sub \(struct/.test(line));
+  expect(rootStruct, "canonical wrapper root missing").toBeDefined();
+  expect(rootStruct).not.toContain("(sub final");
+  const rootSuffix = rootStruct!.match(/\$__fn_wrap_(\d+)_struct/)?.[1];
+  expect(rootSuffix).toBeDefined();
+  const rootLifted = types.find((line) => line.includes(`$__fn_wrap_${rootSuffix}_type`));
+  const rootIdxText = rootLifted?.match(/\(ref(?: null)? (\d+)\)/)?.[1];
+  expect(rootIdxText, "canonical wrapper root has no lifted self type").toBeDefined();
+  const rootIdx = Number(rootIdxText);
+  const targetLifted = types.find((line) =>
+    new RegExp(`\\$__fn_wrap_(\\d+)_type \\(func \\(param \\(ref(?: null)? ${rootIdx}\\)\\) \\(result f64\\)\\)`).test(
+      line,
+    ),
+  );
+  const targetSuffix = targetLifted?.match(/\$__fn_wrap_(\d+)_type/)?.[1];
+  expect(targetSuffix, "zero-arg number wrapper missing").toBeDefined();
+  if (expected === "root") {
+    expect(targetSuffix).toBe(rootSuffix);
+  } else {
+    expect(targetSuffix).not.toBe(rootSuffix);
+  }
+}
+
+function expectNamedPrivateCandidateArm(wat: string, callerName: string): void {
+  const privateLifted = watTypeLines(wat).find((line) =>
+    /\$__closure_\d+_type \(func \(param \(ref null \d+\)\) \(result f64\)\)/.test(line),
+  );
+  expect(privateLifted, "same-arity named/private closure func type missing").toBeDefined();
+  const privateSelfIdx = privateLifted!.match(/\(param \(ref null (\d+)\)\)/)?.[1];
+  expect(privateSelfIdx).toBeDefined();
+  expect(functionBody(wat, callerName)).toMatch(new RegExp(`ref\\.cast \\(ref(?: null)? ${privateSelfIdx}\\)`));
+}
+
+function selectorPlan(source: string): ReturnType<typeof planIrCompilation> {
+  const sourceFile = ts.createSourceFile("issue-3214-selector.ts", source, ts.ScriptTarget.ES2022, true);
+  return planIrCompilation(
+    sourceFile,
+    { experimentalIR: true, trackFallbacks: true, jsHostExterns: true },
+    buildTypeMap(sourceFile),
+  );
+}
+
+function selectorClaims(source: string): ReadonlySet<string> {
+  return selectorPlan(source).funcs;
+}
+
+function minimalResolver(): IrLowerResolver {
+  return {
+    resolveFunc: () => 0,
+    resolveGlobal: () => 0,
+    resolveType: () => 0,
+    internFuncType: () => 0,
+  };
+}
+
+describe("#3214 B0 — canonical callable ABI", () => {
+  it("keeps the #2859 callback ABI externref in legacy and IR, and IR still returns 68", async () => {
+    const legacy = await compileAndRun(ISSUE_2859_PROGRAM, {
+      fileName: "issue-3214-legacy.ts",
+      experimentalIR: false,
+    });
+    const ir = await compileAndRun(ISSUE_2859_PROGRAM, {
+      fileName: "issue-3214-ir.ts",
+      experimentalIR: true,
+      trackFallbacks: true,
+    });
+
+    expect(legacy.value).toBe(68);
+    expect(ir.value).toBe(68);
+    expectFunctionFirstParamExternref(legacy.result.wat, "apply");
+    expectFunctionFirstParamExternref(ir.result.wat, "apply");
+    expect(ir.result.irPostClaimErrors ?? []).toEqual([]);
+    expect(ir.result.irCompiledFuncs).toEqual(
+      expect.arrayContaining(["apply", "applyWith", "test", "test__closure_0", "test__closure_1"]),
+    );
+    expect(ir.result.wat).toContain("__fn_wrap_");
+    expect(ir.result.wat).not.toContain("__ir_closure_base_");
+  });
+
+  it.each([
+    ["host", false],
+    ["nativeStrings", true],
+  ] as const)("runs no-capture, captured, and forwarded callables in %s mode", async (_label, nativeStrings) => {
+    const { result, value } = await compileAndRun(ORDERED_CAPTURE_PROGRAM, {
+      fileName: `issue-3214-${nativeStrings ? "native" : "host"}.ts`,
+      experimentalIR: true,
+      trackFallbacks: true,
+      nativeStrings,
+    });
+
+    expect(value).toBe(25);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs).toEqual(
+      expect.arrayContaining([
+        "choose",
+        "apply",
+        "forward",
+        "applyText",
+        "test",
+        "test__closure_0",
+        "test__closure_1",
+        "test__closure_2",
+      ]),
+    );
+    expect(result.wat).toContain("__fn_wrap_");
+    expect(result.wat).not.toContain("__ir_closure_base_");
+    expectCanonicalCapturedSubtypeAndCallUnpack(result.wat);
+  });
+
+  it("optimized callable output validates and matches the unoptimized result", async () => {
+    const unoptimized = await compileAndRun(ORDERED_CAPTURE_PROGRAM, {
+      fileName: "issue-3214-unoptimized.ts",
+      experimentalIR: true,
+      trackFallbacks: true,
+      optimize: false,
+    });
+    const optimized = await compileAndRun(ORDERED_CAPTURE_PROGRAM, {
+      fileName: "issue-3214-optimized.ts",
+      experimentalIR: true,
+      trackFallbacks: true,
+      optimize: true,
+    });
+
+    expect(optimized.value).toBe(unoptimized.value);
+    expect(optimized.value).toBe(25);
+    expect(unoptimized.result.irPostClaimErrors ?? []).toEqual([]);
+    expect(optimized.result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps callable call/coercion outside the linear backend before lowering", () => {
+    const signature: IrClosureSignature = { params: [], returnType: F64 };
+    const callable: IrType = { kind: "callable", signature };
+    const closure: IrType = { kind: "closure", signature };
+    expect(irTypeEquals(callable, { kind: "callable", signature: { params: [], returnType: F64 } })).toBe(true);
+    expect(irTypeEquals(callable, closure)).toBe(false);
+
+    const callBuilder = new IrFunctionBuilder("linearCallableCall", [F64]);
+    const callee = callBuilder.addParam("fn", callable);
+    callBuilder.openBlock();
+    const called = callBuilder.emitClosureCall(callee, [], F64);
+    callBuilder.terminate({ kind: "return", values: [called] });
+    const callFunc = callBuilder.finish();
+    expect(verifyIrBackendLegality(callFunc, "wasmgc")).toEqual([]);
+    const callErrors = verifyIrBackendLegality(callFunc, "linear");
+    expect(callErrors.some((e) => e.instr === "closure.call")).toBe(true);
+    expect(callErrors.some((e) => e.message.includes("IR type 'callable'"))).toBe(true);
+    const callResolver = minimalResolver();
+    expect(() =>
+      lowerIrFunctionBody(
+        callFunc,
+        callResolver,
+        new LinearEmitter(),
+        wasmValueTypeConverter("linear", callResolver, callFunc.name),
+      ),
+    ).toThrow(/linear backend legality failed/);
+
+    const packBuilder = new IrFunctionBuilder("linearCallablePack", [F64]);
+    const internal = packBuilder.addParam("internal", closure);
+    packBuilder.openBlock();
+    packBuilder.emitCallablePack(internal, signature);
+    const zero = packBuilder.emitConst({ kind: "f64", value: 0 }, F64);
+    packBuilder.terminate({ kind: "return", values: [zero] });
+    const packFunc = packBuilder.finish();
+    expect(verifyIrBackendLegality(packFunc, "wasmgc")).toEqual([]);
+    expect(verifyIrBackendLegality(packFunc, "linear").some((e) => e.instr === "coerce.to_externref")).toBe(true);
+    const packResolver = minimalResolver();
+    expect(() =>
+      lowerIrFunctionBody(
+        packFunc,
+        packResolver,
+        new LinearEmitter(),
+        wasmValueTypeConverter("linear", packResolver, packFunc.name),
+      ),
+    ).toThrow(/linear backend legality failed/);
+
+    const mismatched: IrClosureSignature = { params: [F64], returnType: F64 };
+    const mismatchBuilder = new IrFunctionBuilder("exactPackOnly", []);
+    const value = mismatchBuilder.addParam("internal", closure);
+    mismatchBuilder.openBlock();
+    expect(() => mismatchBuilder.emitCallablePack(value, mismatched)).toThrow(/exact closure signature/);
+  });
+
+  it("runs a legacy captured closure through a genuine-IR callee in both wrapper orders", async () => {
+    const legacyProducer = await compile(
+      `
+        export function make(): () => number {
+          const bias: number = 40;
+          return (): number => bias + 1;
+        }
+        function seed(fn: (x: number) => boolean): number {
+          return fn(1) ? 1 : 0;
+        }
+      `,
+      { fileName: "issue-3214-legacy-producer.ts", experimentalIR: false },
+    );
+    const irConsumer = await compile(
+      `
+        function seed(fn: (x: number) => boolean): number {
+          return fn(1) ? 1 : 0;
+        }
+        export function apply(fn: () => number): number {
+          return fn() + 1;
+        }
+      `,
+      {
+        fileName: "issue-3214-ir-consumer.ts",
+        experimentalIR: true,
+        trackFallbacks: true,
+      },
+    );
+    expect(legacyProducer.success, legacyProducer.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(irConsumer.success, irConsumer.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(irConsumer.irPostClaimErrors ?? []).toEqual([]);
+    expect(irConsumer.irCompiledFuncs).toEqual(expect.arrayContaining(["seed", "apply"]));
+    expectFunctionFirstParamExternref(irConsumer.wat, "apply");
+    expect(legacyProducer.wat).toContain("__fn_wrap_");
+    expect(irConsumer.wat).toContain("__fn_wrap_");
+    expect(irConsumer.wat).not.toContain("__ir_closure_base_");
+    expectZeroArgNumberWrapperPosition(legacyProducer.wat, "root");
+    expectZeroArgNumberWrapperPosition(irConsumer.wat, "child");
+
+    const producerExports = (await instantiate(legacyProducer)) as Record<string, unknown>;
+    const consumerExports = (await instantiate(irConsumer)) as Record<string, unknown>;
+    expect(typeof producerExports.make).toBe("function");
+    expect(typeof consumerExports.apply).toBe("function");
+    const rawLegacyClosure = (producerExports.make as () => unknown)();
+    expect((consumerExports.apply as (fn: unknown) => unknown)(rawLegacyClosure)).toBe(42);
+
+    const legacyConsumer = await compile(
+      `
+        function seed(fn: (x: number) => boolean): number {
+          return fn(1) ? 1 : 0;
+        }
+        export function privateProbe(): number {
+          let remaining: number = 1;
+          const privateFn = function recur(): number {
+            if (remaining === 0) return 7;
+            remaining = remaining - 1;
+            return recur();
+          };
+          return privateFn();
+        }
+        export function apply(fn: () => number): number {
+          return fn() + 1;
+        }
+      `,
+      { fileName: "issue-3214-legacy-child-consumer.ts", experimentalIR: false },
+    );
+    expect(legacyConsumer.success, legacyConsumer.errors.map((e) => e.message).join("\n")).toBe(true);
+    expectZeroArgNumberWrapperPosition(legacyConsumer.wat, "child");
+    expectNamedPrivateCandidateArm(legacyConsumer.wat, "apply");
+    const legacyConsumerExports = (await instantiate(legacyConsumer)) as Record<string, unknown>;
+    expect((legacyConsumerExports.privateProbe as () => unknown)()).toBe(7);
+    expect((legacyConsumerExports.apply as (fn: unknown) => unknown)(rawLegacyClosure)).toBe(42);
+
+    const childProducer = await compile(
+      `
+        function seed(fn: (x: number) => boolean): number {
+          return fn(1) ? 1 : 0;
+        }
+        export function make(): () => number {
+          const bias: number = 40;
+          return (): number => bias + 1;
+        }
+      `,
+      { fileName: "issue-3214-legacy-child-producer.ts", experimentalIR: false },
+    );
+    const rootConsumer = await compile(
+      `
+        export function apply(fn: () => number): number {
+          return fn() + 1;
+        }
+        function seed(fn: (x: number) => boolean): number {
+          return fn(1) ? 1 : 0;
+        }
+      `,
+      {
+        fileName: "issue-3214-ir-root-consumer.ts",
+        experimentalIR: true,
+        trackFallbacks: true,
+      },
+    );
+    expect(childProducer.success, childProducer.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(rootConsumer.success, rootConsumer.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(rootConsumer.irPostClaimErrors ?? []).toEqual([]);
+    expect(rootConsumer.irCompiledFuncs).toEqual(expect.arrayContaining(["apply", "seed"]));
+    expectZeroArgNumberWrapperPosition(childProducer.wat, "child");
+    expectZeroArgNumberWrapperPosition(rootConsumer.wat, "root");
+    const childProducerExports = (await instantiate(childProducer)) as Record<string, unknown>;
+    const rootConsumerExports = (await instantiate(rootConsumer)) as Record<string, unknown>;
+    const rawChildLegacyClosure = (childProducerExports.make as () => unknown)();
+    expect((rootConsumerExports.apply as (fn: unknown) => unknown)(rawChildLegacyClosure)).toBe(42);
+  });
+
+  it.each([false, true])(
+    "keeps a minimal no-capture wrapper root open across separately compiled modules (optimize=%s)",
+    async (optimize) => {
+      const producer = await compile(`export function make(): () => number { return (): number => 41; }`, {
+        fileName: `issue-3214-minimal-producer-${optimize}.ts`,
+        experimentalIR: false,
+        optimize,
+      });
+      const consumer = await compile(
+        `
+        function seed(fn: (x: number) => boolean): number {
+          return fn(1) ? 1 : 0;
+        }
+        export function apply(fn: () => number): number {
+          return fn() + 1;
+        }
+      `,
+        {
+          fileName: `issue-3214-minimal-consumer-${optimize}.ts`,
+          experimentalIR: true,
+          trackFallbacks: true,
+          optimize,
+        },
+      );
+      expect(producer.success, producer.errors.map((e) => e.message).join("\n")).toBe(true);
+      expect(consumer.success, consumer.errors.map((e) => e.message).join("\n")).toBe(true);
+      expect(consumer.irPostClaimErrors ?? []).toEqual([]);
+      expect(consumer.irCompiledFuncs).toEqual(expect.arrayContaining(["seed", "apply"]));
+      expectZeroArgNumberWrapperPosition(producer.wat, "root");
+      expectZeroArgNumberWrapperPosition(consumer.wat, "child");
+      const producerExports = (await instantiate(producer)) as Record<string, unknown>;
+      const consumerExports = (await instantiate(consumer)) as Record<string, unknown>;
+      const rawClosure = (producerExports.make as () => unknown)();
+      expect((consumerExports.apply as (fn: unknown) => unknown)(rawClosure)).toBe(42);
+    },
+  );
+
+  it("keeps callable undefined guards dynamic at the externref boundary", async () => {
+    const result = await compile(
+      `
+        export function apply(fn: () => number): number {
+          if (fn === undefined) return 99;
+          return fn();
+        }
+      `,
+      {
+        fileName: "issue-3214-callable-undefined.ts",
+        experimentalIR: true,
+        trackFallbacks: true,
+      },
+    );
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irCompiledFuncs).toContain("apply");
+    expect(result.imports.some((i) => i.module === "env" && i.name === "__extern_is_undefined")).toBe(true);
+    const exports = (await instantiate(result)) as Record<string, unknown>;
+    expect((exports.apply as (fn: unknown) => unknown)(undefined)).toBe(99);
+  });
+
+  it("builds an exact IR closure pack for a legacy-compatible direct-call slot", async () => {
+    const signature: IrClosureSignature = { params: [F64], returnType: F64 };
+    const callable: IrType = { kind: "callable", signature };
+    const sourceFile = ts.createSourceFile(
+      "issue-3214-ir-caller.ts",
+      `
+        export function test(): number {
+          const bias: number = 3;
+          const addBias = (x: number): number => x + bias;
+          return apply(addBias, 5);
+        }
+      `,
+      ts.ScriptTarget.ES2022,
+      true,
+    );
+    const declaration = sourceFile.statements.find(ts.isFunctionDeclaration);
+    expect(declaration).toBeDefined();
+    const lowered = lowerFunctionAstToIr(declaration!, {
+      exported: true,
+      paramTypeOverrides: [],
+      returnTypeOverride: F64,
+      calleeTypes: new Map([["apply", { params: [callable, F64], returnType: F64 }]]),
+    });
+    const instrs = lowered.main.blocks.flatMap((block) => block.instrs);
+    const closureNew = instrs.find((instr) => instr.kind === "closure.new");
+    const pack = instrs.find((instr) => instr.kind === "coerce.to_externref" && instr.resultType?.kind === "callable");
+    const call = instrs.find((instr) => instr.kind === "call" && instr.target.name === "apply");
+    expect(closureNew?.kind).toBe("closure.new");
+    expect(pack?.kind).toBe("coerce.to_externref");
+    expect(call?.kind).toBe("call");
+    if (closureNew?.kind !== "closure.new" || pack?.kind !== "coerce.to_externref" || call?.kind !== "call") {
+      throw new Error("expected closure.new → callable pack → direct call");
+    }
+    expect(pack.value).toBe(closureNew.result);
+    expect(pack.resultType).toEqual(callable);
+    expect(call.args[0]).toBe(pack.result);
+
+    // The opposite frontend's consumer independently pins the exact same
+    // direct-call ABI: externref param, canonical wrapper family, no private
+    // IR base hierarchy. Together with the all-IR runtime tests above, this is
+    // a compositional IR-caller→legacy-callee proof without forcing ownership.
+    const legacyConsumer = await compile(
+      `export function apply(fn: (x: number) => number, x: number): number { return fn(x) + 1; }`,
+      { fileName: "issue-3214-legacy-consumer.ts", experimentalIR: false },
+    );
+    expect(legacyConsumer.success, legacyConsumer.errors.map((e) => e.message).join("\n")).toBe(true);
+    expectFunctionFirstParamExternref(legacyConsumer.wat, "apply");
+    expect(legacyConsumer.wat).toContain("__fn_wrap_");
+    expect(legacyConsumer.wat).not.toContain("__ir_closure_base_");
+  });
+
+  it("does not widen selection to function-valued arguments or results", () => {
+    const inlineClaims = selectorClaims(`
+      function apply(fn: () => number): number { return fn(); }
+      export function inlineCaller(): number { return apply((): number => 1); }
+    `);
+    expect(inlineClaims.has("inlineCaller")).toBe(false);
+
+    const namedClaims = selectorClaims(`
+      function apply(fn: () => number): number { return fn(); }
+      function named(): number { return 1; }
+      export function namedCaller(): number { return apply(named); }
+    `);
+    expect(namedClaims.has("namedCaller")).toBe(false);
+
+    const resultPlan = selectorPlan(`
+      function make(): () => number { return (): number => 1; }
+      export function consume(): number {
+        const fn = make();
+        return fn();
+      }
+    `);
+    expect(resultPlan.funcs.has("make")).toBe(false);
+    expect(resultPlan.funcs.has("consume")).toBe(false);
+    expect(resultPlan.fallbacks?.find((fallback) => fallback.name === "make")?.reason).toBe(
+      "return-type-not-resolvable",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- use one permanently open canonical `__fn_wrap_*` root as the lifted closure self carrier across separately compiled modules
- add a distinct exact-signature `IrType.callable` externref carrier for function-typed parameter boundaries, with closure-to-callable packing and root/funcref unpacking
- preserve concrete self types for private/named closures while making legacy and IR wrapper dispatch creation-order independent
- document the zero-delta B0 foundation in the markdown-tracked IR migration issues

## Scope

This is the B0 ABI prerequisite for the IR migration. It deliberately does not widen selector claims. Function-valued results, storage/escape, inline arrow arguments, imported calls, and named top-level function values remain deferred to later markdown-tracked slices.

## Validation

- B0 callable ABI: 11/11
- focused B0 + M0 + builtins: 29/29
- post-rebase conflict-sensitive reviewer matrix: 83/83
- closure/funcref regressions: 69/70 locally; the sole non-code assertion references the already-absent `benchmarks/compare-runtimes.ts` fixture, while all 69 codegen/runtime cases pass
- optimize differential: 4/4
- typecheck, Prettier, oracle ratchet, linear-IR, LOC, issue checks: clean
- fallback gate: function-level 12 -> 12, module-level 2 -> 2, zero post-claim demotions
- full equivalence: 1,607 passing / 36 known failures / zero new regressions
- fresh merged-M0 vs rebased-B0 byte-neutrality spot check: four closure-free host/nativeStrings binaries identical

Tracked in `plan/issues/3214-ir-first-class-function-values.md` and `plan/issues/2856-ir-body-shape-rejected-to-zero.md`.