### PR TITLE
release: v0.64.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {
@@ -9,7 +9,14 @@
     "./optimize": "./src/optimize.ts"
   },
   "publish": {
-    "include": ["src/**/*.ts", "README.md", "LICENSE", "jsr.json"],
-    "exclude": ["src/**/*.test.ts"]
+    "include": [
+      "src/**/*.ts",
+      "README.md",
+      "LICENSE",
+      "jsr.json"
+    ],
+    "exclude": [
+      "src/**/*.test.ts"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",

--- a/plan/diary.md
+++ b/plan/diary.md
@@ -294,3 +294,23 @@ close (sprint/66 tag, PR #2146). **Net +305 passes.** 22 issues done + 1 wont-fi
 fnctor-reconstruct, IR effect-model lane (#2134–#2141), async/Promise (#2613/#2614),
 Proxy (#1355/#2618), standalone residual tails, type-oracle/pipeline refactors, and
 the newly-unblocked substrate slices (#2710/#2722/#2724 for implementation in s67).
+
+## Sprint 73 (2026-07-19 → 2026-07-21) — honest Test262 parity and external runner
+
+**Baseline**: JS-host 28,294 / 43,106 (65.6%) → **30,282 / 43,099
+(70.3%)**; standalone 27,378 / 43,106 (63.5%) → **28,136 / 43,106
+(65.3%)**. 28 issues completed; 191 remain `sprint: current`.
+
+The project runner and test262.fyi path now execute the original harness with
+matching source assembly, fixture graphs, negative-test checks, async completion,
+and verdict classification. The stricter oracle exposed silent false passes;
+compiler and runner fixes converted the real supported cases back to passes.
+`@loopdive/js2` gained the reusable `js2-test262` CLI for a first standalone-only
+test262.fyi publication. Early IR/self-host/Porffor integration slices also
+landed, while the architecture epics remain open.
+
+The merge queue caught a 29-test illegal-cast regression in the JS-host closure
+ABI before landing. It was fixed at the standalone `Reflect.construct` marker
+boundary instead of being excused. Sprint bookkeeping drift was also repaired:
+16 completed issues were normalized into sprint 73, and all unfinished work was
+carried forward without retagging it to a numbered sprint.

--- a/plan/issues/3258-selfhost-object-family-tier3.md
+++ b/plan/issues/3258-selfhost-object-family-tier3.md
@@ -4,7 +4,7 @@ title: "Self-host stdlib: convert object-runtime.ts hand-emitted Instr[] to TS (
 status: done
 assignee: ttraenkler/symphony-3258-object-runtime-tier3
 completed: 2026-07-20
-sprint: current
+sprint: 73
 priority: medium
 horizon: xl
 feasibility: hard
@@ -14,7 +14,7 @@ area: codegen, stdlib, ir
 language_feature: compiler-internals
 goal: ir-full-coverage
 created: 2026-07-14
-updated: 2026-07-20
+updated: 2026-07-21
 depends_on: [3257]
 related: [3141, 3256, 3257]
 origin: "sprint-71 bloat audit — object-runtime.ts = 11.6k LOC / 3,738 hand-emitted Instr[] sites (largest single lever)"

--- a/plan/issues/3371-standalone-reflect-construct-newtarget.md
+++ b/plan/issues/3371-standalone-reflect-construct-newtarget.md
@@ -5,7 +5,7 @@ status: done
 created: 2026-07-17
 updated: 2026-07-21
 completed: 2026-07-20
-sprint: Backlog
+sprint: 73
 priority: medium
 horizon: l
 feasibility: hard

--- a/plan/issues/3422-strict-mode-rerun-failures.md
+++ b/plan/issues/3422-strict-mode-rerun-failures.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: codegen
 goal: test262-conformance
 model: fable
-sprint: current
+sprint: 73
 horizon: m
 related: [3370, 3417]
 ---

--- a/plan/issues/3429-assert-throws-constructor-identity-wasmclosuredynamicbridge.md
+++ b/plan/issues/3429-assert-throws-constructor-identity-wasmclosuredynamicbridge.md
@@ -3,9 +3,9 @@ id: 3429
 title: "Host assert.throws: expected error constructor rendered as internal 'wasmClosureDynamicBridge' (544 records) under oracle v8"
 status: done
 completed: 2026-07-20
-sprint: current
+sprint: 73
 created: 2026-07-18
-updated: 2026-07-20
+updated: 2026-07-21
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/3430-integrity-level-typeerror-not-thrown.md
+++ b/plan/issues/3430-integrity-level-typeerror-not-thrown.md
@@ -2,9 +2,9 @@
 id: 3430
 title: "Host conformance: integrity-level operations do not throw expected TypeError (1,316 records, newly honest under oracle v8)"
 status: done
-sprint: current
+sprint: 73
 created: 2026-07-18
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 assignee: ttraenkler/senior-dev
 priority: medium

--- a/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
+++ b/plan/issues/3441-typedarray-ctor-cannot-convert-null-module-init.md
@@ -10,7 +10,7 @@ task_type: bug
 area: test262-conformance
 goal: test262-conformance
 model: fable
-sprint: current
+sprint: 73
 horizon: m
 related: [3417, 2375, 1623]
 ---

--- a/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
+++ b/plan/issues/3472-standalone-fnexpr-strconcat-param-invalid-wasm.md
@@ -4,7 +4,7 @@ title: "Standalone: native-string-reassigned `any`/externref param that is then 
 status: done
 assignee: ttraenkler/senior-dev
 completed: 2026-07-19
-sprint: current
+sprint: 73
 created: 2026-07-19
 priority: high
 feasibility: hard

--- a/plan/issues/3473-fyi-runner-parity-extraction.md
+++ b/plan/issues/3473-fyi-runner-parity-extraction.md
@@ -2,7 +2,7 @@
 id: 3473
 title: Extract fyi-runner parity plumbing from stale #3415
 status: done
-sprint: current
+sprint: 73
 priority: medium
 horizon: m
 assignee: ttraenkler/extract-3415-agent

--- a/plan/issues/3477-rangeerror-bare-string-ctors.md
+++ b/plan/issues/3477-rangeerror-bare-string-ctors.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: test262-conformance
 goal: test262-conformance
-sprint: current
+sprint: 73
 horizon: m
 related: [3422, 3175, 3191, 3429]
 ---

--- a/plan/issues/3478-porffor-source-to-native-canary.md
+++ b/plan/issues/3478-porffor-source-to-native-canary.md
@@ -3,9 +3,9 @@ id: 3478
 renumbered_from: 3476
 title: "Porffor source-to-native canary: real TypeScript through shared linear-memory planning"
 status: done
-sprint: porffor-backend
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 priority: high
 horizon: m

--- a/plan/issues/3479-static-class-member-hasown-reflection.md
+++ b/plan/issues/3479-static-class-member-hasown-reflection.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: runtime
 goal: test262-conformance
 model: opus
-sprint: current
+sprint: 73
 horizon: m
 related: [3417, 1395, 1047, 1364]
 loc-budget-allow:

--- a/plan/issues/3482-direct-porffor-js2-ir-ab.md
+++ b/plan/issues/3482-direct-porffor-js2-ir-ab.md
@@ -2,9 +2,9 @@
 id: 3482
 title: "Benchmark direct Porffor against JS2 typed SSA and shared-plan Porffor IR"
 status: done
-sprint: Backlog
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 pr: 3439
 priority: high

--- a/plan/issues/3489-test262-module-goal-classification.md
+++ b/plan/issues/3489-test262-module-goal-classification.md
@@ -2,9 +2,10 @@
 id: 3489
 title: "Test262 module-goal classification must ignore import/export text in comments and strings"
 status: done
+sprint: 73
 completed: 2026-07-20
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: s
 feasibility: easy

--- a/plan/issues/3490-test262-fyi-node25-runtime-parity.md
+++ b/plan/issues/3490-test262-fyi-node25-runtime-parity.md
@@ -2,8 +2,9 @@
 id: 3490
 title: "Test262 FYI comparisons must use the same Node 25 and Unicode 17 host runtime as CI"
 status: done
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 priority: high
 horizon: s

--- a/plan/issues/3491-test262-fyi-module-fixture-linking.md
+++ b/plan/issues/3491-test262-fyi-module-fixture-linking.md
@@ -2,8 +2,9 @@
 id: 3491
 title: "Test262 FYI original-harness lane must link static _FIXTURE module graphs"
 status: done
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/3492-test262-fyi-top-level-await-parity.md
+++ b/plan/issues/3492-test262-fyi-top-level-await-parity.md
@@ -2,9 +2,10 @@
 id: 3492
 title: "Test262 runners must not false-pass omitted fixture module graphs"
 status: done
+sprint: 73
 completed: 2026-07-20
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/3493-compile-multi-globalthis-property-representation.md
+++ b/plan/issues/3493-compile-multi-globalthis-property-representation.md
@@ -2,9 +2,10 @@
 id: 3493
 title: "compileMulti must execute top-level globalThis property assignments"
 status: done
+sprint: 73
 completed: 2026-07-20
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3494-standalone-literal-dynamic-import-from-compile-multi-graph.md
+++ b/plan/issues/3494-standalone-literal-dynamic-import-from-compile-multi-graph.md
@@ -2,6 +2,7 @@
 id: 3494
 title: "Standalone compileMulti must resolve literal dynamic imports from its module graph"
 status: blocked
+sprint: current
 created: 2026-07-20
 updated: 2026-07-20
 priority: high

--- a/plan/issues/3495-compile-multi-globalthis-array-index-reads.md
+++ b/plan/issues/3495-compile-multi-globalthis-array-index-reads.md
@@ -2,8 +2,9 @@
 id: 3495
 title: "compileMulti must finalize standalone vec indexed reads"
 status: done
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/3496-fyi-original-harness-module-init-null-property.md
+++ b/plan/issues/3496-fyi-original-harness-module-init-null-property.md
@@ -2,8 +2,9 @@
 id: 3496
 title: "FYI original harness must initialize module fixtures without null global properties"
 status: done
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/3503-test262-dynamic-fixture-discovery-must-not-abort.md
+++ b/plan/issues/3503-test262-dynamic-fixture-discovery-must-not-abort.md
@@ -2,9 +2,10 @@
 id: 3503
 title: "Test262 dynamic fixture discovery must not abort the corpus"
 status: done
+sprint: 73
 completed: 2026-07-20
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: s
 feasibility: easy

--- a/plan/issues/3504-test262-fyi-flag-only-module-goal.md
+++ b/plan/issues/3504-test262-fyi-flag-only-module-goal.md
@@ -2,8 +2,9 @@
 id: 3504
 title: "Test262 FYI worker must preserve flag-only Module goal"
 status: done
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 priority: high
 horizon: s

--- a/plan/issues/3505-host-compilemulti-harness-callable-init.md
+++ b/plan/issues/3505-host-compilemulti-harness-callable-init.md
@@ -2,9 +2,10 @@
 id: 3505
 title: "Host compileMulti must initialize harness callables after exports wiring"
 status: done
+sprint: 73
 completed: 2026-07-20
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 priority: high
 horizon: s
 feasibility: hard

--- a/plan/issues/3506-test262-fyi-negative-fixture-js-roots.md
+++ b/plan/issues/3506-test262-fyi-negative-fixture-js-roots.md
@@ -2,8 +2,9 @@
 id: 3506
 title: "Test262 FYI negative fixture graphs must retain JavaScript roots"
 status: done
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 priority: high
 horizon: m

--- a/plan/issues/3507-standalone-native-regexp-carrier-dispatch.md
+++ b/plan/issues/3507-standalone-native-regexp-carrier-dispatch.md
@@ -2,9 +2,9 @@
 id: 3507
 title: "Standalone native RegExp values lose identity across function, object, and array carriers"
 status: done
-sprint: current
+sprint: 73
 created: 2026-07-20
-updated: 2026-07-20
+updated: 2026-07-21
 completed: 2026-07-20
 priority: high
 horizon: m

--- a/plan/issues/3508-porffor-prealpha9-pin.md
+++ b/plan/issues/3508-porffor-prealpha9-pin.md
@@ -2,6 +2,7 @@
 id: 3508
 title: "Advance the optional Porffor integration pin to pre-alpha 9"
 status: done
+sprint: 73
 assignee: ttraenkler/codex-senior-3508
 created: 2026-07-21
 updated: 2026-07-21

--- a/plan/issues/3509-standalone-deferred-dynamic-import-runtime-trap.md
+++ b/plan/issues/3509-standalone-deferred-dynamic-import-runtime-trap.md
@@ -2,6 +2,7 @@
 id: 3509
 title: "Standalone deferred dynamic import must trap only when invoked"
 status: done
+sprint: 73
 created: 2026-07-21
 updated: 2026-07-21
 completed: 2026-07-21

--- a/plan/issues/3510-test262-fyi-publish-js2-two-lanes.md
+++ b/plan/issues/3510-test262-fyi-publish-js2-two-lanes.md
@@ -1,7 +1,8 @@
 ---
 id: 3510
-title: "Publish js2 host and standalone lanes on test262.fyi"
+title: "Publish js2 standalone on test262.fyi"
 status: in-progress
+sprint: current
 created: 2026-07-21
 updated: 2026-07-21
 priority: high
@@ -22,19 +23,18 @@ files:
   - tests/issue-3510-test262-fyi-two-lane-cli.test.ts
 ---
 
-# #3510 — Publish js2 host and standalone lanes on test262.fyi
+# #3510 — Publish js2 standalone on test262.fyi
 
 ## Problem
 
-js2 can run the literal test262.fyi source assembly locally in both JS-host and
-standalone modes, but test262.fyi cannot publish either result. Its engine
-contract intentionally invokes every engine through an isolated command-line
-process, while js2's original-harness executor was only available as an
-in-process project runner.
+js2 can run the literal test262.fyi source assembly locally in standalone mode,
+but test262.fyi cannot publish the result. Its engine contract intentionally
+invokes every engine through an isolated command-line process, while js2's
+original-harness executor was only available as an in-process project runner.
 
-The public site also needs two independent result identities: JS-host permits
-the declared JavaScript host imports while standalone must remain host-free.
-Combining them into one score would hide the capability boundary.
+The first public integration is deliberately one standalone WebAssembly GC
+result. A single target keeps the upstream engine shape small while preserving
+the host-free capability boundary in the published score.
 
 ## Design
 
@@ -44,7 +44,7 @@ Combining them into one score would hide the capability boundary.
   it.
 - Discover static and dynamic fixture metadata from the external Test262 clone,
   rather than assuming js2's optional submodule path.
-- Allow the external engine wrapper to select `gc` or `standalone` explicitly.
+- Default the external engine wrapper to `standalone`.
 - Run one isolated compiler worker per CLI invocation and report through the
   standard exit-code/stdout/stderr contract.
 - Leave strict reruns and final process-result classification with
@@ -52,23 +52,20 @@ Combining them into one score would hide the capability boundary.
   checks inside the CLI before encoding the ordinary child-process result.
 
 The corresponding upstream data integration installs `@loopdive/js2` once,
-then registers `js2_host` and `js2_standalone` using ordinary `setup.js`,
-`runtime.js`, and synchronous `run.js` engine files. It does not modify the
-shared runner. The frontend integration gives both result identities distinct
-names and descriptions.
+then registers one `js2` engine using ordinary `setup.js`, `runtime.js`, and
+synchronous `run.js` files. It does not modify the shared runner.
 
 ## Acceptance criteria
 
 - An external Test262 checkout can supply a fixture graph without using the
   repository's `test262` submodule.
-- Both `gc` and `standalone` execute through the same one-shot CLI contract.
+- Standalone executes through the one-shot CLI contract.
 - The published npm package contains the CLI and isolated worker artifacts.
 - Unsupported target names fail before any test is published.
 - test262.fyi can invoke js2 without changes to its shared runner.
-- The generated site data contains separate host and standalone engine keys.
-- The frontend exposes both keys with unambiguous labels.
+- The generated site data contains one unambiguous `js2` engine key.
 - Focused adapter, FYI runner and fixture-graph tests pass, followed by one
-  original-harness smoke sample in both modes.
+  original-harness standalone smoke sample.
 
 ## Validation
 

--- a/plan/issues/3511-symbol-key-index-probe-tonumber.md
+++ b/plan/issues/3511-symbol-key-index-probe-tonumber.md
@@ -11,7 +11,7 @@ task_type: bug
 area: codegen
 goal: test262-conformance
 model: opus
-sprint: current
+sprint: 73
 horizon: m
 related: [3481]
 loc-budget-allow:

--- a/plan/issues/3512-instance-field-leak-class-constructor-proxy.md
+++ b/plan/issues/3512-instance-field-leak-class-constructor-proxy.md
@@ -11,7 +11,7 @@ task_type: bugfix
 area: runtime
 goal: test262-conformance
 model: opus
-sprint: current
+sprint: 73
 horizon: m
 related: [3479, 1047, 1395]
 loc-budget-allow:

--- a/plan/issues/sprints/73.md
+++ b/plan/issues/sprints/73.md
@@ -1,0 +1,254 @@
+# Sprint 73
+
+Frozen 2026-07-21 — trigger: --force.
+
+This is a **budget window** record (rolling-sprint model, #2751): the set
+of issues completed before the token budget rolled over, frozen from
+`sprint: current` into `sprint: 73`. Not-done work rolled forward and
+stays `sprint: current`.
+
+## Completed this window (28)
+
+- #3258 — Self-host stdlib: convert object-runtime.ts hand-emitted Instr[] to TS (Tier-3)
+- #3371 — standalone: Reflect.construct (with NewTarget) refused — ~160 tests (proto-from-ctor-realm, subclassing) on the #1472 Phase-C refusal path
+- #3422 — Strict-mode rerun: read-only assign / delete non-configurable don't match spec — ~666 default reclassifications
+- #3429 — Host assert.throws: expected error constructor rendered as internal 'wasmClosureDynamicBridge' (544 records) under oracle v8
+- #3430 — Host conformance: integrity-level operations do not throw expected TypeError (1,316 records, newly honest under oracle v8)
+- #3441 — TypedArray constructor cluster throws 'Cannot convert null to object' at \_\_module_init (2,069 default-lane fails)
+- #3472 — Standalone: native-string-reassigned `any`/externref param that is then `+=` string-concatenated compiles to INVALID Wasm (\_\_str_concat gets externref for arg0)
+- #3473 — Extract fyi-runner parity plumbing from stale #3415
+- #3477 — Indexed/number-method RangeError gates throw bare strings — fail authentic-harness `e instanceof RangeError`
+- #3478 — Porffor source-to-native canary: real TypeScript through shared linear-memory planning
+- #3479 — Host reflection: Object.prototype.hasOwnProperty.call(C, staticMember) misses class static members (verifyProperty own-property cluster, ~547 host fails)
+- #3482 — Benchmark direct Porffor against JS2 typed SSA and shared-plan Porffor IR
+- #3489 — Test262 module-goal classification must ignore import/export text in comments and strings
+- #3490 — Test262 FYI comparisons must use the same Node 25 and Unicode 17 host runtime as CI
+- #3491 — Test262 FYI original-harness lane must link static \_FIXTURE module graphs
+- #3492 — Test262 runners must not false-pass omitted fixture module graphs
+- #3493 — compileMulti must execute top-level globalThis property assignments
+- #3495 — compileMulti must finalize standalone vec indexed reads
+- #3496 — FYI original harness must initialize module fixtures without null global properties
+- #3503 — Test262 dynamic fixture discovery must not abort the corpus
+- #3504 — Test262 FYI worker must preserve flag-only Module goal
+- #3505 — Host compileMulti must initialize harness callables after exports wiring
+- #3506 — Test262 FYI negative fixture graphs must retain JavaScript roots
+- #3507 — Standalone native RegExp values lose identity across function, object, and array carriers
+- #3508 — Advance the optional Porffor integration pin to pre-alpha 9
+- #3509 — Standalone deferred dynamic import must trap only when invoked
+- #3511 — Symbol-keyed property access eagerly ToNumber-coerces the key via the **unbox_number index-probe → symbol-safe **any_to_index
+- #3512 — Host reflection: class INSTANCE fields leak as own properties of the constructor via the \_wrapForHost has/gOPD proxy traps (#3479 Slice C, ~142 host fails)
+
+## Rolled forward (191 still `sprint: current`)
+
+- #1032 [in-progress] — Compile axios to Wasm — Node builtins routed as host imports; harvest error patterns
+- #1046 [ready] — Separate ES-module compilation with consumer-driven import/export type specialization
+- #1712 [in-progress] — acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn
+- #1888 [ready] — standalone open-any method dispatch + built-ins-as-static-globals (prototype vtable)
+- #1907 [ready] — standalone: built-in static method value reads without \_\_get_builtin (#1888 S6-b)
+- #1916 [in-progress] — Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery
+- #1917 [in-progress] — One coercion engine — four divergent coercion matrices disagree about lossiness
+- #1930 [in-progress] — TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)
+- #1985 [blocked] — stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental)
+- #2001 [in-progress] — sparse arrays: holes materialize as element-type defaults and HOFs visit them — [1,,3].forEach runs 3×, b[5]=9 join shows zeros
+- #2039 [in-progress] — UMBRELLA: standalone invalid-Wasm residual bucket — 203 live rows split into children #3394-#3398 (bigint box, extern boxing, closure/struct type, scalar unbox, tail-call long tail)
+- #2106 [in-progress] — value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton
+- #2141 [in-progress] — Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing
+- #2161 [blocked] — Standalone RegExp engine conformance residual (~579 tests)
+- #2175 [in-progress] — architect spec: standalone builtin-prototype object representation + native-method-closure dispatch
+- #2580 [in-progress] — `.length` on an any/dynamically-mutated receiver returns numeric 0, not undefined (runtime property-presence)
+- #2585 [blocked] — standalone: getPrototypeOf(Object.create(p)) === p is false — object identity lost in \_\_any_strict_eq tag-5 arm
+- #2613 [blocked] — await on a thenable/non-Promise: assimilate via host (PromiseResolve) instead of returning the raw object (~15 fails)
+- #2614 [blocked] — Promise.{all,allSettled,any,race}: read constructor's own `resolve` + callable resolve/reject element functions (~45 fails)
+- #2618 [blocked] — Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)
+- #2620 [ready] — Standalone `class X extends Set/Map` — synthetic accessor late-import index-shift (-1 global) + host-import leak
+- #2622 [backlog] — Standalone native `class X extends Set/Map/WeakMap/WeakSet` subclass — construction + [[SetData]] algebra + iteration + instanceof
+- #2623 [ready] — Promise capability-cluster: multi-hop host→wasm resolve-element callback cast + ctx-ctor species/prototype identity through the bridge — ANCHOR for the unified Promise semantics spec (§P)
+- #2626 [backlog] — tag-5 boxed-VALUE equality classifier (numeric #2040 f64.eq + object #2585 ref.eq) — value-rep substrate (deferred from #1888)
+- #2651 [blocked] — standalone: builtin constructor + prototype as a first-class VALUE (TypedArray ctor-iteration substrate)
+- #2660 [in-progress] — Whole-program escape/dynamic-use gate for reconstructing `new F()` instances as `$Object` (value-rep infra)
+- #2662 [ready] — host (gc) generator backend is EAGER-buffered — breaks lazy/suspension semantics on the default path (architecture)
+- #2669 [ready] — ES2015: destructuring correctness residual umbrella (~696 fails — iterator-close, defaults, holes, rest across for-of/assignment/binding/params)
+- #2671 [ready] — ES2015 builtin/feature spec residuals: Date, RegExp, Promise, JSON, super (~400 fails — tracking, slice per area)
+- #2690 [ready] — ESLint rule-tester.js: cloneDeeplyExcludesParent polymorphic return widens i32 into anyref slot
+- #2694 [blocked] — acorn parse() 11th wall — Scope.flags read loop (local-receiver slot/sidecar asymmetry, needs #2660)
+- #2700 [ready] — esquery@1.7.0 bundle fails to compile — multi-blocker (PEG parser codegen index-shift + syntax + hard-type errors)
+- #2710 [in-progress] — Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class
+- #2717 [ready] — Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard
+- #2726 [ready] — delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete
+- #2732 [blocked] — operators: unary +/-/~/>>> ToPrimitive(object) trap; strict-equals boxed-wrapper/funcref trap
+- #2763 [ready] — [SUBSTRATE][ARCH] instanceof value-rep residual: cross-realm Object/Function identity + .prototype access on dynamic Function values
+- #2768 [wont-fix] — bare-var receiver recovery: per-type externref→ref recovery hardening + safelist expansion (follow-on of #2767's Date-only gate)
+- #2773 [in-progress] — [EPIC][ARCH] Value-rep substrate: consistent native dispatch for reconstructed-struct field access + DCE/finalize-stable typeIdx
+- #2793 [blocked] — [ARCH][SUBSTRATE] Structural-narrowing struct COPY at call boundary breaks reference semantics (mutation through interface/structural-class param lost)
+- #2802 [ready] — [DEFERRED] nested `any`-vec multi-push then read drops the first element (S3-class vec-identity edge)
+- #2803 [ready] — Infer function-parameter types from call-site arguments (usage-based inference) — untyped/.js-stripped params default to `any`
+- #2826 [blocked] — Bug C (CPS-capture half): block-scoped let immutably captured by a hoisted async/generator declaration reads the stale pre-hoisted slot
+- #2847 [ready] — compiled-acorn cosmetic marshalling quirks — spurious `sourceFile: null` on every node + booleans as i32 0/1
+- #2855 [ready] — IR front-end migration: ratchet unintended fallback buckets to zero + promote to STRICT_IR_REASONS
+- #2856 [in-progress] — IR: drive body-shape-rejected fallback bucket to zero (dominant unintended bucket)
+- #2860 [ready] — Umbrella: close the standalone-vs-js-host test262 gap (~20,500 host-free, honest metric #2879/#2360)
+- #2864 [in-progress] — Standalone: no Wasm-native generator carrier — sync generators leak **create_generator/**gen\_\* host imports
+- #2865 [in-progress] — Standalone: no Wasm-native async-generator / for-await carrier — leaks \__create_async_generator + Promise_\* host imports
+- #2866 [in-progress] — Standalone: Symbol values leak \_\_box_symbol — no Wasm-native Symbol carrier
+- #2867 [in-progress] — Standalone: Promise / async microtask leaks Promise_resolve/reject/then + \_\_make_callback host imports
+- #2872 [in-progress] — Standalone: TypedArray.prototype.\* cluster (294 host-pass/standalone-fail, de-masked from #2862)
+- #2873 [in-progress] — Standalone: language/expressions cluster (276 host-pass/standalone-fail, de-masked from #2862)
+- #2875 [in-progress] — Standalone: String.prototype.\* cluster (159 host-pass/standalone-fail, de-masked from #2862)
+- #2895 [ready] — Standalone: genuinely-pending await needs true frame suspension (AG1 / PATH B) — await-on-$Frame + microtask resume
+- #2906 [in-progress] — Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)
+- #2911 [in-review] — Review: test262 setup + host-vs-standalone classification and pass-rate computation
+- #2916 [in-progress] — [SUBSTRATE][ARCH] Standalone native instanceof operator + isPrototypeOf residual (~31 leaky-PASS conversions)
+- #2917 [ready] — [SUBSTRATE][ARCH] Standalone native `class X extends <Builtin>` super-construction (~10 generic conversions)
+- #2927 [ready] — Interpreter foundation: Acorn-via-js2wasm runtime parser + generic-built-in audit
+- #2933 [ready] — Standalone: Math/JSON/Reflect/Atomics namespace static VALUE reads refuse — fold constants / native static-method closures
+- #2949 [in-progress] — IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)
+- #2950 [backlog] — IR-first default flip: JS2WASM_IR_FIRST default-ON, then delete the flag + compile-twice path
+- #2951 [in-progress] — IR-first skip set: include generators and class members (retire the two #2138 standing exclusions)
+- #2952 [in-progress] — IR multi-exit control flow: labeled break/continue, switch (br_table), do-while, for-in adoption
+- #2955 [ready] — De-polymorph the IR front-end on string mode: abstract IR string ops resolved at lower time
+- #2956 [in-review] — Linear backend consumes the IR front-end: wire the selector + LinearEmitter into generateLinearModule
+- #2957 [in-progress] — Async activation for arrows / methods / function expressions (both CPS + drive hooks are declaration-only)
+- #2963 [in-progress] — Reify builtins as first-class values: retire the `__get_builtin` dynamic-shape CE cluster (~400 compile errors)
+- #2984 [in-progress] — Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)
+- #3001 [blocked] — Remove (or ratchet) the TEMPORARY #2940 vacuous-reclassification gate excusal once the standalone baseline promotes to new-policy
+- #3021 [in-progress] — spec gap: class elements — static/private field & method placement residual (~1,522 default-lane fails)
+- #3024 [ready] — codegen: invalid Wasm binary emission residual — default (JS-host) lane (~131 fails, externref/f64 type-mismatch emitter bugs)
+- #3029 [in-progress] — Clean compiler architecture umbrella: layered module map, five-part backend contract, reviewability ratchets
+- #3030 [in-progress] — Stable serializable IR contract (interchange v1): versioned canonical JSON + schema, verified types, external-consumer ready
+- #3032 [in-progress] — Lazy-first-resume generator thunks: stop running eager-buffer generator bodies at creation (unblocks #2141 S3 / #2626 classifier)
+- #3037 [in-progress] — Object-identity canonicalization substrate for standalone dynamic reads (foundation under #3027 / V2-S3b reader-arm)
+- #3053 [in-progress] — Unified dynamic-reader carrier substrate — one \_\_dyn_member_get primitive under #3037 CS3 (identity) AND #2949 S5.4 (IR claim-rate)
+- #3055 [in-progress] — Standalone `any === any` on boxed numbers returns equal-for-unequal when an object-runtime/class is present
+- #3056 [blocked] — Standalone numeric assertions are vacuous — add `assert_sameValue_num` harness routing (measurement re-baseline)
+- #3086 [in-progress] — Honest vacuity re-baseline: partial-vacuity callback scorer + oracle_version bump (1→2) + forward-bump auto-rebase enabler
+- #3089 [wont-fix] — codegen: BigInt TypedArray tests fail to compile — 'Binary emit error: RangeError: offset is out of bounds' (i64 codegen, ~22/30 sampled, pre-existing)
+- #3090 [blocked] — Shrink codegen: delete dormant legacy direct-codegen handlers superseded by IR (~40–55K net LOC)
+- #3103 [in-progress] — Split src/runtime.ts (15,032 LOC) host runtime by concern; decompose resolveImport (6,517-line function)
+- #3104 [in-progress] — Re-split codegen/index.ts (16,566 LOC, regrown 2.6x) into subsystem modules; driver-only index
+- #3105 [in-progress] — Emit-idiom builder library: dedupe repeated Wasm instruction scaffolds (throw-guard x17, counter-loop x21, proxy-guard x12, hash-probe x10)
+- #3108 [ready] — Decompose the ensureObjectRuntime entangled property-storage core (3,494 LOC) into cohesive sibling modules
+- #3109 [ready] — Test-helper consolidation: 132 test files re-declare compileAndRun (10+ signature variants) across 292k test LOC
+- #3111 [ready] — Decompose the five call-shape god functions (#742 residue) into per-family probe modules
+- #3113 [in-progress] — Fix IR->codegen reverse layering: move shared vocabulary (js-tag) below IR; contain the bridge to ir/integration.ts
+- #3115 [in-progress] — Refresh workflow stale-checkout guard: recompute source-derived baselines after re-anchor
+- #3152 [ready] — array-pattern destructuring DRAINS the source iterator (materialize-then-index) instead of per-element IteratorStep — observable side-effect over-stepping
+- #3159 [in-progress] — Self-hosted stdlib, array family slice 1: timsort kernels as TS source through our own IR pipeline
+- #3166 [in-progress] — Class fields/accessors with RUNTIME computed property names are silently dropped ([f()] = 1 → read returns 0) — ~150 cpn tests
+- #3175 [in-progress] — standalone: Number.prototype.toString(radix)/toFixed/valueOf spec semantics + prototype surface (74 gap tests)
+- #3176 [in-progress] — standalone: JSON.parse/stringify spec residual — reviver array walk illegal-cast, SyntaxError strictness, replacer/space edges (67 gap tests)
+- #3177 [in-progress] — standalone: TypedArrayConstructors internals + ctors — integer-indexed MOP internals, ctor arg protocols, from/of, per-ctor identity (356 gap tests)
+- #3178 [ready] — UMBRELLA: retire the generator/async/Promise HOST machinery in standalone — the 4,467-leaky-pass (10.3 pt) family, measured slice map + shared-substrate design
+- #3180 [ready] — standalone: Array.prototype HOF residual gap buckets after the #3169 receiver ladder (~306 tests, 6 mechanisms)
+- #3182 [ready] — Code-bloat elimination EPIC: consolidate duplicated codegen scaffolding into the existing shared machinery
+- #3184 [ready] — default lane: for-await-of / async-dstr vacuous cluster — 489 fails (383 'callback never executed'), async paths silently no-op
+- #3185 [ready] — UMBRELLA default lane: Array.prototype generics + observable-semantics cluster (~1,057 fails — largest untracked builtin bucket)
+- #3188 [ready] — UMBRELLA: ES module-code semantics (~174 fails) — namespace objects, cross-module TDZ, module early errors + wrapTest export collision
+- #3196 [in-progress] — bloat S6: de-inline the standalone dynamic-HOF lane in compileArrayLikePrototypeCall onto the #3098 \__hof_\* steppers
+- #3197 [in-progress] — default lane: drive the for-await-of / async-dstr callback chain to completion (383 vacuous fails)
+- #3198 [blocked] — default lane: Promise combinator callbacks never execute — vacuous slice (218 fails)
+- #3200 [in-progress] — default lane: Array.prototype iteration/producer generics (forEach/map/filter/flatMap) over real + array-like receivers (~204 fails)
+- #3201 [in-progress] — default lane: Array.prototype search + structural generics (indexOf/lastIndexOf/slice/splice/sort/concat/pop) (~312 fails)
+- #3218 [wont-fix] — standalone: ValidateTypedArray for native \__ta_dyn_{fill,copyWithin,reverse} — WONT-FIX (verify-first: target tests already pass; residual is elsewhere)
+- #3227 [in-progress] — default (JS-host) lane: async-completion harness callbacks never execute → 1,690 vacuous fails (#2940 detector), dominated by for-await-of / dynamic-import / Promise
+- #3230 [blocked] — Object.defineProperty: dynamic (non-literal) descriptor read-lane — struct-widening splits read/write stores (accessor read + data write-back both leak)
+- #3236 [in-progress] — standalone: native sync generator-prototype intrinsic chain — retire env::**get_generator_function_prototype / **get_generator_prototype (13 sole leaks)
+- #3240 [ready] — Standalone: faithful native constructors for the remaining subclass-builtins (Array/Function/Date/RegExp/ArrayBuffer/DataView/Promise)
+- #3251 [in-progress] — standalone: array-descriptor OVERLAY substrate — $Vec receivers have no per-index/expando property-descriptor storage (blocks array-exotic defineProperty + Array generic-method-over-accessor-index)
+- #3282 [in-progress] — Decompose the second-level god-functions created by the Wave-B/C extractions (+ ensureAnyHelpers, + deferred object-runtime core)
+- #3283 [wont-fix] — standalone dstr runtime-semantics — Opus-now unblocked slices (lazy-defaults, obj-rest ToPrimitive, abrupt-step errors, gen brand-check)
+- #3284 [ready] — Make the compiler compatible with the original (unmodified) test262 harness — assert.js property-call dispatch + Promise.then microtask gap
+- #3305 [in-progress] — Self-host stdlib: convert parse-number-native.ts + number-format-native.ts hand-emitted Instr[] to TS (family #2)
+- #3337 [ready] — wasi: materialize process.argv through args_get instead of a silent empty vector
+- #3341 [in-progress] — STRICT_IR_REASONS hardening — per-reason (NOT a corpus-zero flip); doc-correction shipped, real per-reason work remains
+- #3359 [in-progress] — standalone: Array.prototype.filter (and callback methods) ignore the thisArg argument — closure runs with wrong `this`
+- #3360 [ready] — default lane: async-generator `yield*` delegation drops iterator-protocol abrupt completions (690 honest fails, oracle-7 #3227 S5)
+- #3375 [in-progress] — baseline-summary-sync host drift-check compares the wrong baseline → landing page silently strands stale/inflated test262 number
+- #3378 [ready] — deepEqual.js fails to compile — stale LOCAL index in deeply-nested format/lazyResult closures (#2043 class, local not funcIdx)
+- #3379 [in-progress] — baseline-summary-sync staleness guard measures the in-repo file, not public/ → busy queue skips the sync forever
+- #3380 [ready] — Standalone-lane test262 dashboard number appears frozen — promote-pipeline fragility + single-scalar visibility gap masks real churn (not a cache/skip bug)
+- #3381 [in-progress] — refresh-baseline.yml refreshes HOST only, never standalone — public standalone number strands stale
+- #3382 [in-progress] — Baseline goes stale under high PR velocity — main-audit push loses all retries; make baselines-repo push resilient
+- #3389 [in-progress] — standalone: `return` completion in driven async-gen bodies (settleReturn terminator) + AsyncGeneratorPrototype.return/.throw residual (~300 rows)
+- #3390 [ready] — standalone: Promise combinators with non-Promise receivers — `Promise.all.call(nonCtor)` TypeError + custom-constructor admission (~119 rows)
+- #3391 [ready] — standalone: S7 mechanical — assert-zero `__gen_*`/`__get_caught_exception` registration + eager-buffer dead-path accounting (umbrella #3178 closeout)
+- #3392 [in-progress] — promote-baseline dies at the baselines-repo clone — runs/ cache growth pushed full-blob clone past the 10-min step timeout
+- #3394 [ready] — standalone: bigint (i64) value reaches externref coercion via extern.convert_any instead of \_\_box_bigint — invalid Wasm (~59 tests)
+- #3395 [ready] — standalone: object/closure GC ref not boxed (or double-boxed) at externref boundaries — any.convert_extern / extern.convert_any invalid Wasm (~34 tests)
+- #3396 [in-progress] — standalone: closure-env / promise-reaction / for-loop struct type A used where type B expected — struct.set/get/call-param invalid Wasm (~70 tests)
+- #3397 [ready] — standalone: boxed value used directly in scalar op (f64.ne/i32 cmp/ref.is_null) without unbox — invalid Wasm (~27 tests)
+- #3398 [in-progress] — standalone: tail-call ABI mismatch / block-result fallthru / call arity / ref.test-cast long tail — invalid Wasm (~13 tests)
+- #3399 [ready] — Architecture modularization + bloat-reduction roadmap: 2026-07-18 re-grounding + god-function enforcement axis
+- #3400 [ready] — R-FUNC: per-function LOC ceiling ratchet (check:func-budget) — enforce the 300-LOC function criterion (#3102 slice 2)
+- #3404 [ready] — Baseline promote is blocked by a single test262 shard artifact-upload flake — tolerate ≥N-1 shards or retry the upload
+- #3406 [ready] — Dynamic any-callee with zero closure candidates silently returns null instead of invoking or throwing
+- #3407 [in-review] — test262 fixture runner emits duplicate and contradictory verdict rows; enforce one canonical result per file
+- #3408 [in-review] — Retire non-atomic issue-ID entrypoints and stale collision-remediation guidance
+- #3409 [ready] — Pre-push format gate hard-depends on GNU timeout and falsely blocks macOS pushes
+- #3410 [in-review] — Private labs pre-push guard misses the legacy public js2wasm origin URL
+- #3417 [ready] — UMBRELLA: oracle-v8 (original-harness) reclassification triage — the honest v7→v8 gap
+- #3420 [ready] — Write to non-writable/frozen Array element traps oob instead of throwing TypeError (verifyProperty corpus)
+- #3421 [ready] — Async tests: literal-harness completion marker ($DONE) not observed — 2,653 default-lane reclassifications
+- #3423 [ready] — Module-global representation: top-level bindings read as undefined under literal harness — ~600 default reclassifications
+- #3426 [in-review] — Quarantine exact same-SHA unstable host Test262 paths from fine gates
+- #3437 [ready] — CI speed gate: enforce test262 harness compile-time budget so a harness switch can never silently tank CI
+- #3439 [ready] — Classify the 186 standalone failures #3369 exposed; ratchet --max-unclassified-root-causes 300→0
+- #3440 [ready] — js-host uncatchable-trap growth baked into baseline by the 64.5% hand-promote — trace culprit codegen PR and lower the floor
+- #3442 [ready] — standalone: null-deref residual (789 gap tests) — general \_\_module_init + sync destructuring-rest traps, no open tracker
+- #3443 [ready] — standalone: illegal-cast residual (92 gap tests) — general **module_init + **str_to_number/parseInt, no open tracker
+- #3444 [ready] — negative_test_fail residual (v8 harvest): early-error not detected + negative test mis-passes — 89 default / 45 standalone
+- #3445 [ready] — compiler internal-error / stack-overflow crash residual (v8 harvest): 'Cannot read properties of undefined' + 'Maximum call stack' — ~28 both lanes
+- #3446 [ready] — long-tail low-count residual (v8 harvest): array-too-large, float-unrepresentable, runtime max-call-stack, timeouts
+- #3449 [ready] — ci(#3431 follow-up): re-derive merge_group shard constants from post-#3374 timings
+- #3450 [blocked] — decision(test262): JS-host lane native-JS harness — oracle v9 policy proposal [DECISION — needs sign-off]
+- #3451 [backlog] — arch(#1046/#33/#34): linked harness .wasm as the driving use case for separate compilation
+- #3452 [ready] — ci(test262): cache pnpm store / prebuilt compiler-bundle artifact across shard jobs
+- #3455 [in-review] — CI publish: auto-publish the GitHub release on tag push (was stuck draft)
+- #3456 [in-progress] — queue-unstick.yml re-enqueue churn cancels in-flight merge_group runs
+- #3459 [ready] — merge_group drift check reports negative baseline clock age (-43m) — clock-skew bug in instrumentation
+- #3460 [ready] — Uncatchable null_deref trap when a typed callable var (no matched closure sig) read off a host object is direct-called
+- #3466 [ready] — promote-baseline job skips on ALL merge-queue merges (github.actor == github-actions[bot]) → baseline never auto-refreshes
+- #3467 [in-review] — test262 regression gate: compare each PR against its REAL merge-base commit (per-SHA cache), not a drifting promoted snapshot
+- #3468 [blocked] — Standalone: method calls on function objects silently swallow assertions (assert.sameValue/throws never fire) — root cause is function-object own-property gap, NOT a catch_all swallow
+- #3474 [ready] — Done-status integrity: complete the false-done triage + add a CI gate blocking status:done while an issue has live test262 citations
+- #3475 [ready] — &&= on a defineProperty-added externref/dynamic property never takes the truthy (assign) branch
+- #3476 [in-progress] — Landing-page baseline frozen — promote-baseline env-gate skips on queue merges
+- #3481 [in-progress] — bigint/symbol coercion: value-substrate ToPrimitive/ToNumeric fidelity (host ~164 fails) — architect-spec hand-off
+- #3484 [blocked] — Iterator Helpers (host lane): Iterator global + Iterator.prototype.{map,filter,take,drop,flatMap,reduce,find,some,every,forEach,toArray} — ~84 host fails
+- #3486 [ready] — Host: caught custom-exception instance's .constructor resolves to Array, not its real constructor
+- #3487 [ready] — String.prototype.valueOf non-generic receiver traps illegal_cast (uncatchable) instead of throwing catchable TypeError
+- #3488 [in-progress] — TypedArray compiler trap-gaps (.set / bit-precision / invoked-as-func) — unmasked by #3441, tighten the #3189 ratchet back
+- #3494 [blocked] — Standalone compileMulti must resolve literal dynamic imports from its module graph
+- #3497 [in-review] — Resolve exact-source JSDoc signatures for the linear IR landing benchmarks
+- #3498 [in-progress] — Landing benchmark: four honest backend/runtime lanes
+- #3499 [in-review] — Lower typed JavaScript bitwise composites through the Porffor backend
+- #3500 [in-review] — Carry checker-backed type evidence through recursive linear-IR call-graph closure
+- #3501 [in-review] — Infer typed linear vectors from empty-array read/write evidence
+- #3502 [in-review] — Lower landing string construction and char methods through shared IR
+- #3510 [in-progress] — Publish js2 standalone on test262.fyi
+- #743 [ready] — Whole-program type flow analysis
+- #745 [in-progress] — Tagged union representation to replace externref boxing
+- #773 [ready] — Monomorphize functions: compile with call-site types, not generic externref
+- #779 [ready] — Assert failures: tests compile and run but produce wrong values (8,674 tests)
+- #802 [in-progress] — - Dynamic prototype support (Object.setPrototypeOf, Object.create with dynamic proto)
+- #869 [ready] — Refactor default params: caller-side insertion instead of sNaN sentinel
+
+## Retrospective
+
+- Test262 JS-host: **30,282 / 43,099 (70.3%)**, from 28,294 /
+  43,106 (65.6%) at the start of the window.
+- Test262 standalone: **28,136 / 43,106 (65.3%)**, from 27,378 /
+  43,106 (63.5%).
+- The original Test262 harness and the project runner now use the same source,
+  fixture graph, negative-test, async-completion, and result-classification
+  rules. The stricter oracle exposed silent false passes before the runner and
+  compiler fixes restored real passes.
+- The merge-queue trap ratchet caught a host closure-ABI regression introduced
+  while adding standalone `Reflect.construct`; the fix was made at the shared
+  ABI boundary rather than weakening the allowance.
+- The npm package now contains a reusable `js2-test262` process adapter for the
+  standalone test262.fyi integration. Publication remains live work in #3510
+  until v0.64.0 is available and the upstream PR is accepted.
+- 16 completed issues whose sprint metadata had drifted were normalized before
+  the freeze. Future work should assign `sprint: current` when an issue starts,
+  not reconstruct the window at release time.
+- Full detail: `plan/log/retrospectives/sprint-73.md`.

--- a/plan/log/retrospectives/sprint-73.md
+++ b/plan/log/retrospectives/sprint-73.md
@@ -1,0 +1,76 @@
+# Sprint 73 retrospective
+
+**Window:** 2026-07-19 → 2026-07-21
+
+**Release:** v0.64.0
+
+**Completed:** 28 issues
+
+**Carried forward:** 191 issues
+
+## Outcome
+
+Sprint 73 made Test262 results honest and portable. At the start of the window,
+the JS-host lane reported 28,294 / 43,106 (65.6%) and standalone reported
+27,378 / 43,106 (63.5%). Merge-queue run 29799448439 closed the window with:
+
+| Lane       |                   Start |                   Close |                 Change |
+| ---------- | ----------------------: | ----------------------: | ---------------------: |
+| JS-host    | 28,294 / 43,106 (65.6%) | 30,282 / 43,099 (70.3%) | +1,988 passes; +4.7 pp |
+| Standalone | 27,378 / 43,106 (63.5%) | 28,136 / 43,106 (65.3%) |   +758 passes; +1.8 pp |
+
+The headline gain is useful, but the more important result is measurement
+parity: the project runner and the external test262.fyi path now execute the
+original harness with the same fixture, negative-test, async-completion, and
+result-classification rules. Passes are no longer created by weakening or
+silently omitting parts of the upstream harness.
+
+## What went well
+
+- The original-harness investigation found and removed silent false passes in
+  module-goal detection, missing fixture graphs, expected-negative handling,
+  top-level await, and dynamic fixture discovery.
+- Compiler fixes addressed the newly visible causes instead of patching test
+  expectations: module-global `globalThis` storage, callable harness exports,
+  standalone vector reads, RegExp value carriers, deferred dynamic imports,
+  authentic RangeError objects, and `Reflect.construct`/NewTarget support.
+- `@loopdive/js2` now ships a one-shot `js2-test262` CLI. The proposed upstream
+  integration uses the unchanged generic test262.fyi runner and publishes one
+  standalone WebAssembly GC result.
+- The IR work advanced in bounded slices: the object-runtime self-host family,
+  checker-backed multi-module overlays, builtin lowering, and the optional
+  Porffor source-to-native canary all landed without pretending the broader IR
+  migration is complete.
+- The merge-queue trap ratchet did its job. It rejected a 29-test illegal-cast
+  increase caused by a standalone constructor marker changing the JS-host
+  closure ABI. The recovery scoped that representation change to host-free
+  compilation and added direct regression coverage.
+
+## What did not go well
+
+- Full FYI comparisons were initially run too broadly and serially, making
+  stopped sessions expensive. Deterministic samples and live error harvesting
+  should precede a whole-corpus confirmation.
+- Stricter classification initially looked like a pass-rate regression. The
+  project needed clearer separation between newly honest failures and actual
+  compiler regressions.
+- Sixteen completed issues were missing `sprint: current` or carried unrelated
+  sprint labels, so the release wrap had to reconstruct their membership.
+  Sprint metadata should be set when work begins.
+
+## Carry-over
+
+All 191 unfinished issues remain `sprint: current`. The immediate release-tail
+items are #3510, publishing the standalone test262.fyi engine after v0.64.0 is
+verified, and blocked #3494, real standalone loading for executable literal
+dynamic-import module graphs. The wider carry remains the value-representation,
+async/Promise, generator, module, and IR-retirement program; sprint 73 landed
+useful slices but did not close those architecture epics.
+
+## Keep
+
+1. Treat the original unmodified Test262 harness as the semantic oracle.
+2. Compare runner classifications before interpreting pass-rate movement.
+3. Let the merge-queue trap ratchets block unsafe representation changes.
+4. Fix shared compiler/runtime causes; do not add path-specific pass allowances.
+5. Start external publication with the smallest independently meaningful lane.


### PR DESCRIPTION
## Summary

- freeze sprint 73 with 28 completed issues and carry 191 open issues forward
- record the final original-harness Test262 results and scope the test262.fyi follow-up to standalone
- bump the npm, proxy, and JSR package versions to 0.64.0

## Validation

- PR #3456 merge-group Test262 run 29799448439: all 59 shards and regression gates passed
- JS-host official: 30,282 / 43,099 (70.3%)
- standalone official: 28,136 / 43,106 (65.3%)
- focused Prettier and staged issue-ID checks passed

The local v0.64.0 and sprint/73 tags are intentionally not pushed until this PR merges.