### PR TITLE
fix(test262): handle absent trap baselines as unknown

### DIFF
--- a/plan/issues/2098-flake-classification-diff-test262.md
+++ b/plan/issues/2098-flake-classification-diff-test262.md
@@ -4,7 +4,7 @@ title: "encode flake-classification rules in diff-test262: ct_flake/ct_suspect s
 status: done
 sprint: 63
 created: 2026-06-11
-updated: 2026-06-16
+updated: 2026-07-21
 completed: 2026-06-16
 assignee: ttraenkler/dev-b
 priority: low
@@ -69,3 +69,34 @@ Documented in `.claude/skills/regression-triage.md` (new Step 2b). Tests:
 `tests/issue-2098.test.ts` (3 cases — ct split with flake/suspect/unknown,
 signature stable across reorder+wasm_sha, signature changes when cluster
 differs). All pass. Stacked on the #2096 branch (shares diff-test262.ts).
+
+## Follow-up resolution (2026-07-21 — absent trap baseline rows)
+
+The predecessor merge-group artifact from run `29801056655` omitted two host
+rows. Candidate run `29801877164` compiled and retried those tests and reported
+`oob`, so the trap ratchet's former `!base` branch classified both as newly
+trapping. That conclusion was unsupported: an absent JSONL row records no
+baseline runtime outcome.
+
+Direct `runTest262File` controls confirmed the failure mode independently. Both
+tests were run three times on predecessor `1aef2ea8` and B0 `01ef0f6`; every run
+produced the identical OOB message. The predecessor Wasm hashes were
+`eb448e75ca22` / `8b9477e75bf1`, while B0 produced `c01964041b67` /
+`c70a3d758a1a`. The standalone lane also passed both tests on both commits. The
+host traps therefore pre-existed B0; only the predecessor CI row omission
+manufactured apparent growth.
+
+The CLI's same-corpus artifact comparison now explicitly asks
+`evaluateTrapCategoryGrowth` to apply the same evidence rule to missing rows as
+it already applies to an explicit baseline `compile_timeout`. The helper's
+default remains strict for direct callers modeling a genuinely new candidate
+test:
+
+- candidate traps with no baseline row are excluded from category growth;
+- the paths remain visible under `Trap baseline unknowns`, annotated with
+  `baseline absent` or `baseline compile_timeout`;
+- a baseline row with any observed non-trap runtime outcome changing to a trap
+  still increments the category and hard-fails the ratchet.
+
+Focused coverage in `tests/issue-2098.test.ts` pins both halves: absent→trap is
+diagnostic-only, while observed `assertion_fail`→`oob` remains a gate failure.

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -542,6 +542,21 @@ export interface TrapCategoryGrowth {
    * timed out. They are unknown baseline outcomes, not observed trap growth.
    */
   unknownBaselineTimeouts: Record<TrapCategory, string[]>;
+  /**
+   * Candidate traps with no corresponding baseline row. An absent row carries
+   * no runtime evidence, so it cannot establish that the candidate newly traps.
+   */
+  unknownBaselineMissingRows: Record<TrapCategory, string[]>;
+}
+
+export interface TrapCategoryGrowthOptions {
+  /**
+   * Treat candidate-only rows as unknown instead of newly trapping. Enable this
+   * for baseline artifacts that are expected to cover the same Test262 corpus:
+   * there an absent row is an incomplete observation, not evidence of a new
+   * test. The pure helper defaults to strict candidate-only/new-test semantics.
+   */
+  missingBaselineRowsAreUnknown?: boolean;
 }
 
 /**
@@ -565,11 +580,11 @@ export interface TrapCategoryGrowth {
  * filter (#1222). This prevents a flaky pass→trap flip on an identical binary
  * from tripping the ratchet.
  *
- * A baseline `compile_timeout` is also not an observed runtime outcome. If the
- * candidate compiles that file and exposes a trap, the ratchet must not claim a
- * new trap: the predecessor run did not establish that the file was trap-free.
- * Such rows stay visible in the compile-time recovery diagnostics, while the
- * hard ratchet remains unchanged for every baseline row that reached runtime.
+ * A baseline `compile_timeout` or an absent baseline row is also not an observed
+ * runtime outcome. If the candidate compiles that file and exposes a trap, the
+ * ratchet must not claim a new trap: the predecessor run did not establish that
+ * the file was trap-free. Such rows stay visible in diagnostics, while the hard
+ * ratchet remains unchanged for every baseline row that reached runtime.
  */
 export function evaluateTrapCategoryGrowth(
   baseline: Map<string, TrapRatchetRow>,
@@ -582,6 +597,7 @@ export function evaluateTrapCategoryGrowth(
    * wedging the merge queue. Growth fails only when it EXCEEDS the tolerance.
    */
   tolerancePerCategory = 0,
+  options: TrapCategoryGrowthOptions = {},
 ): TrapCategoryGrowth {
   const zero = () => Object.fromEntries(TRAP_ERROR_CATEGORIES.map((c) => [c, 0])) as Record<TrapCategory, number>;
   const baseCounts = zero();
@@ -594,6 +610,9 @@ export function evaluateTrapCategoryGrowth(
     TrapCategory,
     string[]
   >;
+  const unknownBaselineMissingRows = Object.fromEntries(
+    TRAP_ERROR_CATEGORIES.map((c) => [c, [] as string[]]),
+  ) as Record<TrapCategory, string[]>;
 
   const isTrap = (cat: string | undefined): cat is TrapCategory =>
     !!cat && (TRAP_ERROR_CATEGORIES as readonly string[]).includes(cat);
@@ -605,6 +624,12 @@ export function evaluateTrapCategoryGrowth(
   for (const [file, row] of newer) {
     if (row.status === "compile_timeout" || !isTrap(row.error_category)) continue;
     const base = baseline.get(file);
+    // A missing shard/artifact row says nothing about the baseline runtime
+    // outcome. Treat it as unknown rather than manufacturing trap growth.
+    if (!base && options.missingBaselineRowsAreUnknown) {
+      unknownBaselineMissingRows[row.error_category].push(file);
+      continue;
+    }
     // A compile timeout never observed the baseline's runtime behavior. A
     // subsequent trap is therefore unknown, not evidence that this change
     // introduced one. Keep it out of category growth and report it separately.
@@ -635,7 +660,14 @@ export function evaluateTrapCategoryGrowth(
       );
     }
   }
-  return { failures, baseCounts, newCounts, newlyTrapping, unknownBaselineTimeouts };
+  return {
+    failures,
+    baseCounts,
+    newCounts,
+    newlyTrapping,
+    unknownBaselineTimeouts,
+    unknownBaselineMissingRows,
+  };
 }
 
 interface TestResult {
@@ -1828,21 +1860,27 @@ async function run(
     for (const note of loaded.notes) console.log(note);
   }
   const effectiveTrapTolerance = Math.max(trapTolerance, trapAllowance?.count ?? 0);
-  const trapGrowth = evaluateTrapCategoryGrowth(baseline, newer, effectiveTrapTolerance);
+  const trapGrowth = evaluateTrapCategoryGrowth(baseline, newer, effectiveTrapTolerance, {
+    // CI compares artifacts for the same pinned Test262 corpus. A missing
+    // baseline row is therefore an incomplete predecessor observation, not a
+    // newly-added test whose first observed result should ratchet.
+    missingBaselineRowsAreUnknown: true,
+  });
   console.log(
     `=== Trap categories (baseline → candidate): ` +
       TRAP_ERROR_CATEGORIES.map((c) => `${c} ${trapGrowth.baseCounts[c]}→${trapGrowth.newCounts[c]}`).join(", ") +
       ` (#3189 ratchet) ===`,
   );
-  const trapTimeoutUnknowns = TRAP_ERROR_CATEGORIES.flatMap((category) =>
-    trapGrowth.unknownBaselineTimeouts[category].map((file) => ({ category, file })),
-  );
-  if (trapTimeoutUnknowns.length > 0) {
+  const trapBaselineUnknowns = TRAP_ERROR_CATEGORIES.flatMap((category) => [
+    ...trapGrowth.unknownBaselineTimeouts[category].map((file) => ({ category, file, baseline: "compile_timeout" })),
+    ...trapGrowth.unknownBaselineMissingRows[category].map((file) => ({ category, file, baseline: "absent" })),
+  ]);
+  if (trapBaselineUnknowns.length > 0) {
     console.log(
-      `=== Trap baseline unknowns (compile_timeout → trap; excluded from #3189, retained in CT recovery diagnostics): ${trapTimeoutUnknowns.length} ===`,
+      `=== Trap baseline unknowns (absent/compile_timeout → trap; excluded from #3189): ${trapBaselineUnknowns.length} ===`,
     );
-    for (const { category, file } of trapTimeoutUnknowns) {
-      console.log(`  ${category}: ${file}`);
+    for (const { category, file, baseline: baselineStatus } of trapBaselineUnknowns) {
+      console.log(`  ${category}: ${file} (baseline ${baselineStatus})`);
     }
   }
   for (const reason of trapGrowth.failures) {

--- a/tests/issue-2098.test.ts
+++ b/tests/issue-2098.test.ts
@@ -82,6 +82,54 @@ describe("#2098 flake classification + bucket signature in diff-test262", () => 
     expect(out).not.toMatch(/GATE FAIL: trap category/);
   });
 
+  it("treats a candidate trap with no baseline row as unknown and surfaces the missing evidence", () => {
+    const p = paths();
+    writeJsonl(p.base, [{ oracle_version: 1, file: "control.js", status: "pass", wasm_sha: "same" }]);
+    writeJsonl(p.cand, [
+      { oracle_version: 1, file: "control.js", status: "pass", wasm_sha: "same" },
+      {
+        oracle_version: 1,
+        file: "omitted-by-baseline.js",
+        status: "fail",
+        error_category: "oob",
+        wasm_sha: "candidate-only",
+      },
+    ]);
+
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(0);
+    expect(out).toMatch(/Trap baseline unknowns \(absent\/compile_timeout → trap; excluded from #3189\): 1 ===/);
+    expect(out).toMatch(/oob: omitted-by-baseline\.js \(baseline absent\)/);
+    expect(out).not.toMatch(/GATE FAIL: trap category/);
+  });
+
+  it("still ratchets an observed baseline nontrap into a candidate trap", () => {
+    const p = paths();
+    writeJsonl(p.base, [
+      {
+        oracle_version: 1,
+        file: "observed-nontrap.js",
+        status: "fail",
+        error_category: "assertion_fail",
+        wasm_sha: "before",
+      },
+    ]);
+    writeJsonl(p.cand, [
+      {
+        oracle_version: 1,
+        file: "observed-nontrap.js",
+        status: "fail",
+        error_category: "oob",
+        wasm_sha: "after",
+      },
+    ]);
+
+    const { code, out } = runDiff(p.base, p.cand);
+    expect(code).toBe(1);
+    expect(out).toMatch(/GATE FAIL: trap category "oob" grew 0 → 1/);
+    expect(out).toMatch(/Newly trapping: observed-nontrap\.js/);
+  });
+
   it("emits a bucket signature stable across row order and wasm_sha (cluster identity)", () => {
     const p = paths();
     writeJsonl(p.base, [


### PR DESCRIPTION
## Summary

- treat missing predecessor rows as unknown in same-corpus artifact comparisons
- preserve strict helper behavior for genuinely new candidate-only tests
- record the exact merge-queue and local predecessor/B0 evidence in the markdown issue

## Validation

- pnpm exec vitest run tests/issue-2098.test.ts tests/issue-3189.test.ts --maxWorkers=1
- pnpm run typecheck
- pnpm run lint
- pnpm exec prettier --check scripts/diff-test262.ts tests/issue-2098.test.ts plan/issues/2098-flake-classification-diff-test262.md
- exact artifacts 29801056655 → 29801877164 replay with exit 0 and two baseline-absent diagnostics