### PR TITLE
fix(release): keep js2wasm dependency in lockstep

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -17,15 +17,16 @@ on:
 
 permissions:
   contents: read
-  id-token: write   # for npm provenance + JSR OIDC
+  id-token: write # for npm provenance + JSR OIDC
 
 jobs:
   # Guard against the drift bug (loopdive/js2#389): a `v*` tag is cut as a bare
   # lightweight tag that never bumps package.json, so publish-npm would publish
   # whatever stale version package.json happens to carry. This job fails the
-  # publish unless BOTH package.json versions equal the tag version. It only
-  # runs on the real publish path (tag push); the workflow_dispatch dry-run has
-  # no version tag in github.ref_name, so it is skipped there.
+  # publish unless BOTH package.json versions and the proxy's canonical-package
+  # dependency equal the tag version. It only runs on the real publish path
+  # (tag push); the workflow_dispatch dry-run has no version tag in
+  # github.ref_name, so it is skipped there.
   verify-version:
     name: verify tag matches package.json versions
     runs-on: ubuntu-latest
@@ -39,9 +40,11 @@ jobs:
           version="${tag#v}"
           root_version=$(node -p "require('./package.json').version")
           proxy_version=$(node -p "require('./packages/js2wasm/package.json').version")
+          proxy_dependency=$(node -p "require('./packages/js2wasm/package.json').dependencies['@loopdive/js2']")
           echo "tag=$tag → version=$version"
           echo "root package.json: $root_version"
           echo "proxy package.json (packages/js2wasm): $proxy_version"
+          echo "proxy dependency on @loopdive/js2: $proxy_dependency"
           fail=0
           if [ "$root_version" != "$version" ]; then
             echo "::error::root package.json version ($root_version) does not match tag version ($version)."
@@ -51,11 +54,15 @@ jobs:
             echo "::error::proxy package.json version ($proxy_version) does not match tag version ($version)."
             fail=1
           fi
+          if [ "$proxy_dependency" != "$version" ]; then
+            echo "::error::proxy dependency on @loopdive/js2 ($proxy_dependency) does not match tag version ($version)."
+            fail=1
+          fi
           if [ "$fail" -ne 0 ]; then
-            echo "::error::Refusing to publish. Run 'node scripts/release.mjs <x.y.z>' to bump both package.json files in lockstep, land it as a release PR, then tag the merge commit. See docs/releasing.md."
+            echo "::error::Refusing to publish. Run 'node scripts/release.mjs <x.y.z>' to bump both package manifests and the proxy dependency in lockstep, land it as a release PR, then tag the merge commit. See docs/releasing.md."
             exit 1
           fi
-          echo "Tag and package versions match ($version) — proceeding to publish."
+          echo "Tag, package versions, and proxy dependency match ($version) — proceeding to publish."
 
   # Three independent publish targets, each gated ONLY on verify-version so a
   # not-yet-configured registry can't block the others (e.g. a missing js2wasm

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.64.0"
+    "@loopdive/js2": "0.64.1"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.60.1"
+    "@loopdive/js2": "0.64.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",

--- a/plan/diary.md
+++ b/plan/diary.md
@@ -314,3 +314,11 @@ ABI before landing. It was fixed at the standalone `Reflect.construct` marker
 boundary instead of being excused. Sprint bookkeeping drift was also repaired:
 16 completed issues were normalized into sprint 73, and all unfinished work was
 carried forward without retagging it to a numbered sprint.
+
+### 2026-07-21 — v0.64.0 proxy metadata follow-up
+
+Post-publish verification found that `js2wasm@0.64.0` still depended on
+`@loopdive/js2@0.60.1`: the release script bumped the proxy package version but
+not its dependency. #3516 carries the repair into the current sprint: update the
+dependency in the same release transaction, reject mismatched tag publishes,
+and supersede the immutable npm metadata with a patch release.

--- a/plan/issues/3516-release-proxy-dependency-lockstep.md
+++ b/plan/issues/3516-release-proxy-dependency-lockstep.md
@@ -1,0 +1,50 @@
+---
+id: 3516
+title: "Keep the js2wasm proxy dependency in release lockstep"
+status: in-progress
+sprint: current
+created: 2026-07-21
+updated: 2026-07-21
+priority: high
+horizon: s
+feasibility: easy
+task_type: bug
+area: ci, release
+goal: release-pipeline
+related: [2196, 3454, 3455]
+files:
+  - scripts/release.mjs
+  - packages/js2wasm/package.json
+  - .github/workflows/publish-npm.yml
+  - tests/issue-3516-release-proxy-dependency-lockstep.test.ts
+---
+
+# #3516 — Keep the js2wasm proxy dependency in release lockstep
+
+## Problem
+
+`v0.64.0` correctly published all three package versions, but registry
+verification showed that the unscoped `js2wasm@0.64.0` proxy still depended on
+`@loopdive/js2@0.60.1`. `scripts/release.mjs` updated the proxy's own version but
+never updated its canonical-package dependency, even though the script and
+publish workflow documented that dependency as lockstep state.
+
+Because npm versions are immutable, fixing the checked-in manifest alone cannot
+repair `js2wasm@0.64.0`; a patch release must supersede it.
+
+## Acceptance criteria
+
+- [ ] The release script pins `packages/js2wasm`'s `@loopdive/js2` dependency to
+      the target release version.
+- [ ] The tag verification job refuses to publish when that dependency differs
+      from the tag.
+- [ ] Regression coverage checks the pure manifest update and checked-in
+      root/proxy/dependency equality.
+- [ ] A patch release publishes `js2wasm` with a dependency on the matching
+      `@loopdive/js2` version.
+
+## Validation
+
+- `tests/issue-3516-release-proxy-dependency-lockstep.test.ts`
+- Prettier, typecheck, issue-ID, and issue-spec gates.
+- Registry metadata verification after the patch tag is published.

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -17,7 +17,8 @@
 // What it does (the plain `pnpm version` experience, but covering BOTH packages
 // in a single commit + tag):
 //   1. Resolve a concrete target version V.
-//   2. Bump root + packages/js2wasm package.json to V (no per-package commit/tag).
+//   2. Bump root + packages/js2wasm package.json to V and pin the proxy's
+//      @loopdive/js2 dependency to V (no per-package commit/tag).
 //   3. Make ONE commit `release: vV` with both package.jsons (+ lockfile if it
 //      changed) and ONE annotated tag `vV` pointing at it.
 //   4. It does NOT push — pushing the tag before the PR merges would fire
@@ -28,13 +29,33 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const releaseScriptPath = fileURLToPath(import.meta.url);
+const __dirname = dirname(releaseScriptPath);
 const repoRoot = resolve(__dirname, "..");
 const proxyDir = join(repoRoot, "packages", "js2wasm");
 
 function readVersion(dir) {
   const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
   return pkg.version;
+}
+
+export function pinProxyDependency(pkg, version) {
+  if (typeof pkg.dependencies?.["@loopdive/js2"] !== "string") {
+    throw new Error('proxy package.json must depend on "@loopdive/js2"');
+  }
+  return {
+    ...pkg,
+    dependencies: {
+      ...pkg.dependencies,
+      "@loopdive/js2": version,
+    },
+  };
+}
+
+function setProxyDependency(dir, version) {
+  const path = join(dir, "package.json");
+  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  writeFileSync(path, `${JSON.stringify(pinProxyDependency(pkg, version), null, 2)}\n`);
 }
 
 function fail(msg) {
@@ -124,6 +145,7 @@ function main() {
 
   setVersion(repoRoot, target);
   setVersion(proxyDir, target);
+  setProxyDependency(proxyDir, target);
 
   // Bump the JSR manifest (jsr.json) in lockstep too. It carries its OWN
   // "version" field that pnpm/setVersion never touches — so without this,
@@ -137,14 +159,20 @@ function main() {
   // Assert both ended up identical — guards against pnpm version surprises.
   const newRoot = readVersion(repoRoot);
   const newProxy = readVersion(proxyDir);
-  if (newRoot !== target || newProxy !== target) {
-    fail(`lockstep bump failed: root=${newRoot} proxy=${newProxy} expected=${target}`);
+  const proxyPkg = JSON.parse(readFileSync(join(proxyDir, "package.json"), "utf8"));
+  const newProxyDependency = proxyPkg.dependencies?.["@loopdive/js2"];
+  if (newRoot !== target || newProxy !== target || newProxyDependency !== target) {
+    fail(
+      `lockstep bump failed: root=${newRoot} proxy=${newProxy} ` +
+        `proxy dependency=${newProxyDependency} expected=${target}`,
+    );
   }
 
   console.log(
     `\nBumped both packages to ${target}:\n` +
       `  - package.json (@loopdive/js2)            → ${newRoot}\n` +
-      `  - packages/js2wasm/package.json (proxy)   → ${newProxy}\n`,
+      `  - packages/js2wasm/package.json (proxy)   → ${newProxy}\n` +
+      `  - proxy dependency on @loopdive/js2       → ${newProxyDependency}\n`,
   );
 
   // Stage exactly the files the bump touches: both package.jsons plus the
@@ -169,9 +197,11 @@ function main() {
   console.log(
     `     history), push the tag to trigger publish:\n` +
       `       git push origin ${tag}\n` +
-      `     publish-npm.yml's verify-version job confirms tag == both package.json`,
+      `     publish-npm.yml's verify-version job confirms the tag, manifests,`,
   );
-  console.log(`     versions before publishing. See docs/releasing.md.`);
+  console.log(`     and proxy dependency all match before publishing. See docs/releasing.md.`);
 }
 
-main();
+if (resolve(process.argv[1] || "") === releaseScriptPath) {
+  main();
+}

--- a/tests/issue-3516-release-proxy-dependency-lockstep.test.ts
+++ b/tests/issue-3516-release-proxy-dependency-lockstep.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3516 — the unscoped js2wasm package version moved with each release while
+// its dependency stayed at @loopdive/js2@0.60.1. Pin the dependency in the same
+// release transaction and reject a tag whose three version carriers diverge.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { pinProxyDependency } from "../scripts/release.mjs";
+
+const readJson = (rel: string) => JSON.parse(readFileSync(new URL(rel, import.meta.url), "utf8"));
+
+describe("#3516 js2wasm proxy dependency lockstep", () => {
+  it("pins @loopdive/js2 without mutating the input manifest", () => {
+    const pkg = {
+      name: "js2wasm",
+      dependencies: { "@loopdive/js2": "0.60.1", other: "1.0.0" },
+    };
+    const pinned = pinProxyDependency(pkg, "0.64.1");
+
+    expect(pinned.dependencies).toEqual({ "@loopdive/js2": "0.64.1", other: "1.0.0" });
+    expect(pkg.dependencies["@loopdive/js2"]).toBe("0.60.1");
+  });
+
+  it("refuses to invent the canonical dependency when the proxy contract is missing", () => {
+    expect(() => pinProxyDependency({ name: "js2wasm", dependencies: {} }, "0.64.1")).toThrow(
+      'proxy package.json must depend on "@loopdive/js2"',
+    );
+  });
+
+  it("keeps the checked-in proxy version and dependency equal to the canonical version", () => {
+    const root = readJson("../package.json");
+    const proxy = readJson("../packages/js2wasm/package.json");
+
+    expect(proxy.version).toBe(root.version);
+    expect(proxy.dependencies["@loopdive/js2"]).toBe(root.version);
+  });
+
+  it("guards the proxy dependency in the tag-publish workflow", () => {
+    const workflow = readFileSync(new URL("../.github/workflows/publish-npm.yml", import.meta.url), "utf8");
+    expect(workflow).toContain("proxy_dependency=$(node -p");
+    expect(workflow).toContain('if [ "$proxy_dependency" != "$version" ]');
+  });
+});


### PR DESCRIPTION
## Summary

- pin the unscoped `js2wasm` package's `@loopdive/js2` dependency during every release
- reject tag publishes when the proxy dependency differs from the release version
- add regression coverage and cut the corrective v0.64.1 manifests

## Root cause

The release script bumped the proxy package's own version but never updated its dependency. As a result, `js2wasm@0.64.0` was published with `@loopdive/js2@0.60.1` even though the canonical package was at 0.64.0.

## Impact

After this PR merges, pushing the local `v0.64.1` tag will publish `js2wasm@0.64.1` with an exact dependency on `@loopdive/js2@0.64.1`. Future tag publishes fail closed if this metadata drifts again.

## Validation

- focused Vitest regression: 4/4 passed
- full TypeScript check passed
- Biome lint and Prettier checks passed
- issue-ID and issue-spec gates passed
- `npm pack --dry-run` produced `js2wasm@0.64.1`
- root package, proxy package, proxy dependency, and JSR manifest all report 0.64.1

The annotated `v0.64.1` tag is intentionally local until the reviewed PR merges.
