### PR TITLE
perf(ci): saturate the serial merge queue

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -208,9 +208,10 @@ jobs:
       # TEST262_PATH_FILTER) and by every diff-based gate (as --path-filter)
       # so a scoped candidate JSONL is never diffed against the full baseline.
       test262_scope: ${{ steps.scope.outputs.scope }}
-      # #3431 — the merge_group-CONSOLIDATED shard matrix (fewer, bigger
-      # shards than the 57x2=114-job pull_request/push/workflow_dispatch
-      # matrix). Only computed for merge_group; empty for every other event
+      # #3431 — the merge_group capacity-sized shard matrix. The live queue is
+      # serial (`max_entries_to_build=1`), so it uses 106 of the 120 runners
+      # and reserves 14 for overlapping required workflows. Only computed for
+      # merge_group; empty for every other event
       # (those keep using the static chunk/target arrays on `test262-shard`,
       # unchanged). See scripts/gen-test262-mg-matrix.mjs for the shard-count
       # rationale and evidence.
@@ -321,10 +322,10 @@ jobs:
   #   queued change          changes.run_shards   test262-shard-mg   merge-report
   #   ---------------------  ------------------   ----------------   -------------------
   #   src/** (or any         true                 RUNS (#3431         runs, real result
-  #     &test262-paths)                              53-job matrix)
+  #     &test262-paths)                             106-job matrix)
   #   website/plan/doc-only  false                SKIPPED             runs, trivial PASS
   #   base_sha empty /       true (fail-safe)     RUNS (#3431         runs, real result
-  #     diff fails / empty                           53-job matrix)
+  #     diff fails / empty                          106-job matrix)
   #
   # In ALL three rows the required check "merge shard reports" is produced.
   # It is green only when shards succeeded or the merge_group no-shards skip is
@@ -403,10 +404,10 @@ jobs:
     # (it fails there and is ejected) rather than at PR-open time.
     #
     # #3431 — merge_group NO LONGER runs this job. It has its own
-    # consolidated matrix in `test262-shard-mg` below (fewer, bigger shards
-    # sized to fit the same per-shard timeout, sized to reduce the job-count
-    # contention footprint when the merge queue builds multiple entries
-    # concurrently — see scripts/gen-test262-mg-matrix.mjs). This job keeps
+    # capacity-sized, target-balanced matrix in `test262-shard-mg` below.
+    # The serial merge queue uses most of the runner pool for its one stable
+    # entry while retaining headroom for other required checks — see
+    # scripts/gen-test262-mg-matrix.mjs. This job keeps
     # its ORIGINAL 57-shard x 2-target matrix, UNCHANGED, for push (baseline
     # update) and workflow_dispatch (manual reruns).
     needs: [changes, mg-artifact-probe]
@@ -592,11 +593,7 @@ jobs:
           if-no-files-found: warn
 
   test262-shard-mg:
-    # #3431 — the merge_group-ONLY, CONSOLIDATED test262 shard matrix. Fewer,
-    # bigger shards than `test262-shard`'s 57x2=114-job matrix, sized to cut
-    # the job-count contention footprint when the merge queue builds
-    # multiple entries concurrently (`max_entries_to_build: 5`,
-    # docs/ci-policy.md).
+    # #3431 — the merge_group-ONLY, capacity-sized test262 shard matrix.
     #
     # Evidence (2026-07-18): an ISOLATED, uncontended 114-job merge_group run
     # (run 29631214965) finished the shard matrix in ~15-19 min total, with
@@ -610,16 +607,18 @@ jobs:
     # across up to 5 concurrently-building queue entries (5x114=570 jobs
     # contending for runner slots), is what was driving multi-hour merge
     # queue drains (~1 PR/hour) despite any single uncontended run being fast.
+    # Queue membership churn also invalidated descendant speculative groups,
+    # cancelling their expensive runs. The active ruleset now builds exactly
+    # one merge-group entry at a time (`max_entries_to_build=1`).
     #
-    # Reducing the per-entry job count from 114 to 53 (see
-    # scripts/gen-test262-mg-matrix.mjs for the current js-host=34/
-    # standalone=19 split and the measured-work scaling math) cuts the
-    # contention footprint by ~53% without changing pull_request/push/
-    # workflow_dispatch behavior at all (they keep using `test262-shard`
-    # above, completely unchanged).
+    # With the queue serialized, the matrix instead uses 106 of the 120
+    # four-core runners: js-host=72 and standalone=34, based on the 2.13:1
+    # measured work ratio from run 29807524490. The remaining 14 runners cover
+    # the overlapping CI/equivalence/differential/gate jobs. pull_request,
+    # push, and workflow_dispatch behavior remains unchanged.
     #
     # Uses the SAME dynamic entry point (tests/test262-chunk-dynamic.test.ts)
-    # for every matrix cell instead of 34/19 hand-written per-chunk files —
+    # for every matrix cell instead of hand-written per-chunk files —
     # the partition logic (assignBalancedChunk in test262-shared.ts) is a
     # pure function of (chunkIndex, totalChunks), so this is behaviorally
     # equivalent to the static tests/test262-chunkN.test.ts files, just
@@ -628,10 +627,9 @@ jobs:
     if: github.event_name == 'merge_group' && needs.changes.outputs.run_shards == 'true'
     name: test262 ${{ matrix.target_name }} shard ${{ matrix.chunk_label }}/${{ matrix.chunk_total }}
     runs-on: ubuntu-latest
-    # Same 25-min timeout as `test262-shard`. The consolidated per-target
-    # counts (js-host=34, standalone=19) are derived from six post-#3461 runs;
-    # both lanes' measured long pole is ~12 min, leaving ample headroom — see
-    # scripts/gen-test262-mg-matrix.mjs.
+    # Same 25-min timeout as `test262-shard`. The per-target counts
+    # (js-host=72, standalone=34) target ~6-8 minutes from the first #3470
+    # production run while leaving ample timeout headroom — see the generator.
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -705,7 +703,7 @@ jobs:
           # (test262-*-shard-*) pick these up with no changes there — only
           # one of the two shard jobs ever runs per workflow run, so there is
           # no naming collision risk even though chunk_label ranges overlap
-          # (1..34 / 1..19 here vs 1..57 in test262-shard).
+          # (1..72 / 1..34 here vs 1..57 in test262-shard).
           name: test262-${{ matrix.target_name }}-shard-${{ matrix.chunk_label }}
           path: |
             benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
@@ -778,7 +776,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "-> merge_group queued only non-test262-relevant changes"
-            echo "   (changes.run_shards=='false'); the consolidated 53-job matrix (#3431,"
+            echo "   (changes.run_shards=='false'); the capacity-sized 106-job matrix (#3431,"
             echo "   test262-shard-mg) was intentionally skipped. Reporting 'merge shard"
             echo "   reports' green."
           elif [ "${{ github.event_name }}" = "push" ]; then
@@ -789,7 +787,7 @@ jobs:
           else
             echo "-> pull_request: heavy test262 shards are merge_group-only under the"
             echo "   #2519 slim-down, so they do not run at PR-time. The cheap gate"
-            echo "   (typecheck + lint) validated this PR; the consolidated 53-job matrix"
+            echo "   (typecheck + lint) validated this PR; the capacity-sized 106-job matrix"
             echo "   (#3431, test262-shard-mg) runs in the merge_group when the PR reaches"
             echo "   the front of the queue."
           fi
@@ -1104,8 +1102,8 @@ jobs:
         env:
           # CT_SOFT: contention-flake floor. A CT above this is only actionable
           #   when the aggregate arm agrees (see the combined trigger). Scaled
-          #   with per-shard test density (#3431). The current 53-job matrix is
-          #   denser than the original 114-job matrix, but the count cannot fail
+          #   with per-shard test density (#3431). The current 106-job matrix is
+          #   close to the original 114-job density, but the count cannot fail
           #   alone: the aggregate arm must corroborate it below. Keep 50 as a
           #   deliberately sensitive warning/combined-trigger threshold.
           CT_SOFT: "50"
@@ -2295,7 +2293,7 @@ jobs:
           # #1951 — DEFER this commit while the merge queue is non-empty. Any
           # push to main (even [skip ci]) makes GitHub rebuild EVERY queued
           # merge group: each rebuild costs a full shard-matrix validation
-          # (#3431: 59 consolidated jobs, was 114) per
+          # (#3431: 106 capacity-sized jobs, was 114 static jobs) per
           # queued PR plus ~10 min of added queue latency (observed 2026-06-10:
           # PR #1283 validated 3× because baseline pushes kept landing under
           # it). The baselines-REPO push above is unaffected — it doesn't move

--- a/plan/ci-acceleration-review.md
+++ b/plan/ci-acceleration-review.md
@@ -7,24 +7,40 @@
 
 ## 2026-07-21 implementation update
 
-The three highest-priority levers from this review have since landed: L1
-(merge-group artifact reuse on push), L2 (contention-tolerant compile-timeout
-guard), and L3 (the separately-versioned fast native-harness host lane).
+The highest-priority levers from this review have since landed: merge-group
+artifact reuse on push, a contention-tolerant compile-timeout guard, the
+native-harness implementation behind a separate oracle mode, cached setup,
+and a target-weighted merge-group matrix.
 
-Six successful post-L3 merge-group runs (29791392339..29799448439) now show
-all 59 old matrix jobs starting within 1–2 seconds, with these execution times:
+The first matrix revision used 34 host + 19 standalone jobs because the old
+queue configuration allowed five speculative merge groups to build at once.
+That configuration caused both runner oversubscription and cancellation churn:
+adding, removing, or ejecting an earlier entry invalidated descendant groups
+and restarted their full matrices. The live main ruleset now deliberately has
+`max_entries_to_build=1`, so retaining the contention-sized 53-job matrix would
+leave more than half of the 120-runner pool idle.
 
-| lane       | old shards | mean job | mean per-run max |
-| ---------- | ---------: | -------: | ---------------: |
-| js-host    |         40 |  9.0 min |         10.5 min |
-| standalone |         19 | 10.4 min |         12.0 min |
+Production merge-group run 29807524490 validated the serial-queue model: all 53
+jobs started within one second, with no runner queue. Its `Run shard` timings
+were:
 
-The host lane's timing map still described the pre-native-harness cost model.
-The follow-up therefore regenerates it from the per-test median of all six
-runs and changes the merge-group split to 34 host / 19 standalone (53 jobs).
-After subtracting the measured ~25-second setup envelope, the two lanes carry
-~20,600 vs ~11,400 runner-seconds of work, a 1.80 ratio; 34/19 matches it at
-1.79 while removing six more jobs without lengthening the measured long pole.
+| lane       | shards | total runner-s | mean job |  max job |
+| ---------- | -----: | -------------: | -------: | -------: |
+| js-host    |     34 |         24,071 | 11.8 min | 13.6 min |
+| standalone |     19 |         11,284 |  9.9 min | 10.9 min |
+
+The measured 2.13:1 work ratio maps to 72 host + 34 standalone jobs (2.12:1).
+That uses 106 runners and reserves 14 for the overlapping quality, equivalence,
+differential, Test262-gate, and orchestration jobs. Perfect distribution is
+about 334 vs 332 seconds of shard work per runner, targeting a 6–8 minute shard
+phase while keeping the existing 25-minute safety ceiling.
+
+The host cost is compilation, not corpus size. Both lanes in the production
+run used the honest full in-Wasm harness (the fast native-host mode was not set
+in the merge-group environment). Host compile time totaled 77.7M ms versus
+42.3M ms standalone; execution totaled only 2.4M versus 0.7M ms. Host interop
+codegen is costlier and more host tests reach pass, which also triggers more
+strict-mode recompilations.
 
 Other implemented pipeline reductions:
 
@@ -36,16 +52,13 @@ Other implemented pipeline reductions:
   `equivalence-gate` is a status fan-in instead of a second checkout/install
   plus eight artifact uploads and downloads.
 
-Running js-host then standalone on one runner was rejected for the current
-capacity profile. Repartitioning both targets into 34 identical subsets would
-cut the matrix from 53 to 34 jobs and reuse checkout/install/build, but the
-measured total work predicts a ~16-minute paired shard instead of today's
-~12-minute parallel long pole. All jobs in the six-run sample started within
-1–2 seconds, so the extra serialization currently loses wall time; pairing is
-a valid contingency if runner queueing returns. Shared linked harness/runtime
-code remains the #2527/#2514 end-state; mutable compiler/checker and
-execution-realm state stays process-isolated and is reused only behind the
-existing periodic recreation, poison retry, and realm-canary recycle guards.
+Running js-host then standalone on one runner remains a poor fit for the serial
+queue and available capacity: it saves setup work but serializes two compiler-
+heavy lanes while idle runners are available. Pairing is a contingency only if
+runner capacity shrinks. Shared linked harness/runtime code remains the
+#2527/#2514 end-state; mutable compiler/checker and execution-realm state stays
+process-isolated and is reused only behind the existing periodic recreation,
+poison retry, and realm-canary recycle guards.
 
 ## 0. Executive summary — the brief is partially stale (good news)
 

--- a/scripts/gen-test262-mg-matrix.mjs
+++ b/scripts/gen-test262-mg-matrix.mjs
@@ -2,42 +2,37 @@
 // gen-test262-mg-matrix.mjs — computes the merge_group-CONSOLIDATED test262
 // shard matrix (#3431).
 //
-// Why a separate, smaller matrix just for merge_group: the merge queue can
-// build up to `max_entries_to_build: 5` groups concurrently (docs/ci-policy.md
-// #1956), each running the full test262-sharded.yml workflow. At the
-// pull_request-era 57-shard x 2-target = 114-job matrix, 5 concurrent groups
-// contend for up to 570 runner slots at once, and evidence from real
-// merge_group runs (2026-07-18, runs 29632953272 et al.) shows job start
-// times trickling over ~20 minutes under that contention — vs. an isolated,
-// uncontended 114-job run finishing in ~15-19 minutes total. That contention
-// wave, not fixed per-job setup cost (measured at ~30-45s: checkout + node +
-// pnpm + bundle build), is what stretches merge_group validation to ~60+
-// minutes and drains the queue at ~1 PR/hour.
+// Why merge_group has its own matrix: the queue previously allowed five
+// speculative groups to build concurrently. At 114 jobs per group that meant
+// up to 570 shard jobs competing for the 120-runner pool; enqueue/dequeue churn
+// also invalidated descendant groups and restarted work that could never land.
+// The active main ruleset was therefore changed to `max_entries_to_build: 1`.
+// With only one stable group in flight, throughput now comes from parallelism
+// *inside* that group rather than from keeping the per-group matrix small.
 //
-// Fewer, bigger shards reduce the per-entry job count, and therefore the
-// contention footprint under a busy queue, at the cost of a longer
-// best-case (uncontended) per-shard runtime. js-host and standalone get
-// DIFFERENT shard counts because the lanes have different total work. The
-// original 40/19 split used pre-#3374 timings and became stale again when the
-// fast native-harness host lane (#3461) removed most repeated harness compile
-// work. Six successful, uncontended merge_group runs on 2026-07-21
-// (29791392339..29799448439) measured:
-//   js-host at 40:    avg job 9.0 min, mean max 10.5 min
-//   standalone at 19: avg job 10.4 min, mean max 12.0 min
-// After subtracting the measured ~25 s setup/build envelope, total work is
-// ~20,600 runner-seconds for host and ~11,400 for standalone: a 1.80 ratio.
-// A 34/19 split matches that ratio (1.79), so both targets reach the fan-in at
-// approximately the same time. The host timing weights are refreshed from the
-// same six runs so persistent fast/slow partitions are also redistributed.
-// Both stay under the existing 25-minute per-shard timeout (test262-shard-mg
-// uses 28 min for a small safety margin instead of raising the timeout
-// aggressively) with no change needed to pull_request/push/workflow_dispatch,
-// which keep the full 57-shard matrix untouched.
+// The pool has 120 four-core runners and every shard intentionally uses all
+// four cores (`COMPILER_POOL_SIZE=4`). Reserve 14 runners for the overlapping
+// CI quality/equivalence jobs, the differential workflow, the Test262 gate,
+// and short-lived orchestration jobs. The remaining 106 runners are assigned
+// to Test262, so a serial queue entry can use the fleet without starving its
+// other required checks.
 //
-// Job count: 34 + 19 = 53, vs. the static 114-job push/manual matrix — a 53%
-// reduction in the merge_group matrix's job count (and therefore its
-// contention footprint under a busy queue), while the measured long-pole
-// remains around 12 minutes, well inside the existing timeout.
+// js-host and standalone get DIFFERENT counts because their measured work is
+// not equal. The first 34/19 run after #3470 (merge_group run 29807524490,
+// 2026-07-21) started all 53 jobs within one second and measured the `Run shard`
+// steps as:
+//   js-host:    24,071 runner-seconds total, 818 s max (34 jobs)
+//   standalone: 11,284 runner-seconds total, 654 s max (19 jobs)
+// The 2.13 work ratio is matched by 72/34 = 2.12. At perfect distribution that
+// is about 334 vs. 332 seconds of measured shard work per runner, plus setup
+// and tail skew. Both lanes therefore target the same ~6-8 minute window while
+// retaining ample margin under the 25-minute job timeout.
+//
+// The host lane is costlier primarily because both lanes still compile the
+// honest full in-Wasm harness, while the host target emits JS/Wasm interop glue.
+// In run 29807524490 host compilation totaled 77.7M ms vs. 42.3M ms for
+// standalone; execution was only 2.4M vs. 0.7M ms. Host also reaches more
+// passing tests and therefore performs more strict-mode recompilations.
 //
 // The underlying partition (assignBalancedChunk, test262-shared.ts) is a
 // pure function of (chunkIndex, totalChunks): it re-derives the FULL test262
@@ -50,8 +45,10 @@
 // matrix cell invokes (index/total supplied via env vars instead of being
 // baked into a per-shard filename).
 
-export const JS_HOST_CHUNKS = 34;
-export const STANDALONE_CHUNKS = 19;
+export const MERGE_GROUP_RUNNER_CAPACITY = 120;
+export const MERGE_GROUP_RESERVED_RUNNERS = 14;
+export const JS_HOST_CHUNKS = 72;
+export const STANDALONE_CHUNKS = 34;
 
 /**
  * @param {string} targetName matrix job-name suffix, e.g. "js-host"

--- a/tests/issue-3431-mg-matrix.test.ts
+++ b/tests/issue-3431-mg-matrix.test.ts
@@ -13,7 +13,13 @@
 // same corpus at totalChunks=16 for local dev, vs. 57 in CI, with matching
 // pass counts).
 import { describe, expect, it } from "vitest";
-import { JS_HOST_CHUNKS, STANDALONE_CHUNKS, buildMergeGroupMatrix } from "../scripts/gen-test262-mg-matrix.mjs";
+import {
+  JS_HOST_CHUNKS,
+  MERGE_GROUP_RESERVED_RUNNERS,
+  MERGE_GROUP_RUNNER_CAPACITY,
+  STANDALONE_CHUNKS,
+  buildMergeGroupMatrix,
+} from "../scripts/gen-test262-mg-matrix.mjs";
 
 describe("#3431 gen-test262-mg-matrix", () => {
   it("produces exactly JS_HOST_CHUNKS + STANDALONE_CHUNKS entries", () => {
@@ -63,12 +69,11 @@ describe("#3431 gen-test262-mg-matrix", () => {
     expect(standalone.result_prefix).toBe("test262-standalone");
   });
 
-  it("53 total shards is a >50% reduction from the static 114-job matrix (57 chunks x 2 targets)", () => {
+  it("uses the serial queue's runner budget while reserving capacity for other required checks", () => {
     const matrix = buildMergeGroupMatrix();
-    const staticTotal = 57 * 2;
-    const reduction = 1 - matrix.length / staticTotal;
-    expect(matrix).toHaveLength(53);
-    expect(reduction).toBeGreaterThan(0.5);
+    expect(matrix).toHaveLength(106);
+    expect(matrix.length).toBe(MERGE_GROUP_RUNNER_CAPACITY - MERGE_GROUP_RESERVED_RUNNERS);
+    expect(JS_HOST_CHUNKS / STANDALONE_CHUNKS).toBeCloseTo(2.12, 2);
   });
 });
 
@@ -85,16 +90,16 @@ describe("#3431 test262-chunk-dynamic.test.ts env-var contract", () => {
   }
 
   it("accepts valid index/total pairs", () => {
-    expect(validateChunkEnv("0", "34")).toBe(true);
+    expect(validateChunkEnv("0", "72")).toBe(true);
+    expect(validateChunkEnv("71", "72")).toBe(true);
     expect(validateChunkEnv("33", "34")).toBe(true);
-    expect(validateChunkEnv("18", "19")).toBe(true);
   });
 
   it("rejects missing, out-of-range, or non-numeric env vars", () => {
     expect(validateChunkEnv("", "")).toBe(false);
-    expect(validateChunkEnv("34", "34")).toBe(false); // index == total (out of range)
-    expect(validateChunkEnv("-1", "34")).toBe(false);
-    expect(validateChunkEnv("abc", "34")).toBe(false);
+    expect(validateChunkEnv("72", "72")).toBe(false); // index == total (out of range)
+    expect(validateChunkEnv("-1", "72")).toBe(false);
+    expect(validateChunkEnv("abc", "72")).toBe(false);
     expect(validateChunkEnv("0", "0")).toBe(false); // total must be > 0
   });
 });


### PR DESCRIPTION
## Summary

- scale the serial merge-group Test262 matrix from 53 to 106 jobs
- allocate 72 js-host and 34 standalone shards from production timing data
- reserve 14 of the 120 four-core runners for overlapping required workflows
- replace stale five-speculative-group assumptions in the generator, workflow, tests, and CI review

## Why

The live main ruleset uses `max_entries_to_build=1` to prevent merge-queue cancellation churn when entries are added, removed, or ejected. The existing 34/19 matrix was sized for the former five-entry queue and left more than half of the runner fleet idle once the queue became serial.

Merge-group run 29807524490 measured 24,071 runner-seconds for js-host and 11,284 for standalone, a 2.13:1 ratio. The new 72/34 split matches that ratio at 2.12:1 and targets a 6–8 minute shard phase.

The same run also showed why host needs more capacity: host compilation totaled 77.7M ms versus 42.3M ms for standalone, while execution was only 2.4M versus 0.7M ms.

## Validation

- generated matrix: 106 unique entries, 72 js-host / 34 standalone
- `pnpm exec vitest run tests/issue-3431-mg-matrix.test.ts`
- workflow YAML parse
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run check:issues`
- `pnpm run sync:conformance:check`
- committed-tree integrity check: 3,082 issues
