### PR TITLE
feat(ir): lower imported higher-order calls

### DIFF
--- a/plan/issues/3214-ir-first-class-function-values.md
+++ b/plan/issues/3214-ir-first-class-function-values.md
@@ -17,9 +17,12 @@ goal: ir-full-coverage
 parent: 2855
 related: [2856, 1276, 1382]
 loc-budget-allow:
+  - src/codegen/index.ts
+  - src/codegen/closures.ts
   - src/ir/lower.ts
   - src/ir/from-ast.ts
   - src/ir/nodes.ts
+  - src/ir/select.ts
   - src/ir/builder.ts
   - src/codegen/expressions/calls-closures.ts
   - src/ir/integration.ts
@@ -186,6 +189,96 @@ The sequencing is intentional:
   This is the precise invariant: mandatory canonicalization intentionally
   changes the type shape of sources that already lower internal IR closures,
   even if they do not yet expose an `IrType.callable` boundary.
+
+## A+B1 implementation result — imported direct HOF calls (2026-07-21)
+
+The first claim-set widening is complete for the production non-fast multi-file
+host lane. It deliberately combines the two pieces needed by the benchmark entry
+functions: a checker-certified imported direct call (A), and an exact bare
+same-file top-level `FunctionDeclaration` value in a function-typed parameter
+position (B1). The broader arrow/storage/result surface remains deferred.
+
+### Root cause and design
+
+M0 treated every imported call as an external selector boundary, and the IR
+lowerer had no representation for a bare declaration value such as
+`bench_fib`. Text-based import/name checks were insufficient: renamed/default
+imports, barrel aliases, shadowing, reassignment, overloads, and the compiler's
+flat function registry could otherwise select one symbol and lower another.
+
+The implementation therefore uses one realm-wide checker resolver shared by
+selection and overlay planning. It accepts only value named/default imports
+whose alias chain resolves to one non-ambient function body in the exact
+compiled source set. Namespace/import-equals/type-only/external/cyclic or
+ambiguous aliases, overload sets, flat-name collisions, and reassigned/live
+bindings are rejected before claim. Reassignment detection is symbol-exact and
+covers updates, destructuring, and `for-in`/`for-of` assignment targets.
+
+Selection admits a bare function identifier only when it is a same-file
+top-level declaration at an exact, required `FunctionTypeNode` argument
+position and its primitive signature exactly matches. Arrows, aliases/stored
+values, callable results, optional supplied callbacks, generics, rest/spread,
+and extra arguments remain on legacy. Imported calls are symbolic external
+edges, not local call-graph edges; standalone/WASI retain the conservative M0
+boundary.
+
+The overlay records AST-node-keyed symbolic plans (`targetName`, signature,
+defaults, argc requirement), never pre-shift numeric indices. Before lowering,
+it proves each target against the final flat `funcMap`, settles any late
+`__get_undefined` import shift, registers `__argc` when required, and extracts
+the legacy cached function-singleton creation path. IR then emits the same
+lazy `__fn_closure_<target>` / `__fn_tramp_<target>_cached` protocol and packs
+the canonical wrapper as `callable<S>`. A second trampoline finalization pass
+handles declarations created after legacy compilation. Host function
+declarations remain ordinary/non-constructible; the standalone #3371
+constructible-wrapper path is unchanged.
+
+Missing imported arguments mirror legacy: constants are inlined, numeric
+expression defaults use the exact `0x7ff00000deadc0de` signaling-NaN sentinel,
+i32 uses zero plus `__argc`, and host extern/callable carriers use
+`__get_undefined`. Unsupported preparation removes the owner's entire local
+call component before integration, keeping the post-claim channel at zero.
+Cached singleton reuse is provenance-paired: a source function occupying
+`__fn_tramp_<target>_cached` cannot be mistaken for the generated trampoline,
+so A+B1 preparation demotes rather than creating a mismatched cache. Legacy
+value-producing sites instead use the existing per-site `emitFuncRefAsClosure`
+path when the canonical pair is unavailable; this includes reassigned-function
+live-binding seeds, Annex-B bindings, fnctor registration, and identifier
+reads. Void-return expressions share recursive discard lowering through
+parentheses, `void`, conditionals, and comma expressions in final and loop
+early returns. A zero-result imported call outside those proven discarded
+contexts is rejected during planning, before the legacy body can be skipped.
+Fast multi-file overlays remain pre-claim disabled because legacy uses i32 for
+numeric function boundaries while the current IR plans f64; full fast support
+requires a mode-aware boundary plan rather than an unsafe cast.
+
+### Measured result
+
+- `tests/issue-3214-imported-hof.test.ts`: **20/20**. Runtime execution,
+  runtime identity plus one cached singleton, renamed/default/barrel imports,
+  void, constant and expression defaults, host `undefined`, argc semantics,
+  optimize off/on, namespace/storage/arrow/reassigned-callback/live-target/
+  spread/extra/overload negatives, synthetic-trampoline collision demotion,
+  collision-safe reassigned live-binding seeding, recursively wrapped
+  final/loop-early/conditional void-return effects, value-context void-call
+  pre-claim rejection, standalone and fast-mode pins, and zero post-claim
+  demotions.
+- `tests/issue-3214-callable-abi.test.ts`: **11/11**. The B0 canonical callable
+  ABI and mixed wrapper-order proofs remain green.
+- `tests/issue-2138-multi-module-ir-overlay.test.ts`: **6/6**, updated to prove
+  the bounded host import widening while retaining collision, global-script,
+  standalone, class-member, module-init, compileFiles, and compileProject
+  guards.
+- The production fallback gate now compiles disk dependency graphs through
+  `compileFiles`, asserts all seven benchmark entry `main` functions appear in
+  `irCompiledFuncs`, and measures `body-shape-rejected` **12 -> 5**,
+  module-level **2 -> 2**, with **zero** post-claim demotions.
+- The five residual body rejections are exactly: benchmark helper
+  `addBenchCard` (inline arrow; B2), calendar `renderCal`, `onDay`, and `main`,
+  plus async `delay`. This supersedes the older statement above that #3214
+  alone could not move the bucket: the prerequisite imported-call and host DOM
+  capabilities now exist, so the combined A+B1 slice genuinely unlocks the
+  seven benchmark entry functions.
 
 ## Sequenced acceptance criteria
 

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -52,9 +52,10 @@
  * Corpus: every `.ts` file under `playground/examples/` (excluding `.d.ts`).
  */
 import { readFileSync, writeFileSync, existsSync, statSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join, dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import ts from "typescript";
+import { analyzeFiles } from "../src/checker/index.js";
 import { buildTypeMap } from "../src/ir/propagate.js";
 import { planIrCompilation, type IrFallbackReason } from "../src/ir/select.js";
 import { makeIrHostGlobalResolver } from "../src/ir/host-extern.js";
@@ -63,12 +64,30 @@ import {
   makeIrModuleBindingResolver,
   makeIrPrimitiveExpressionClassifier,
 } from "../src/ir/module-bindings.js";
-import { compile } from "../src/index.js";
+import { makeIrImportedFunctionResolver } from "../src/ir/imported-functions.js";
+import { compileFiles } from "../src/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+// `analyzeFiles` is also consumed from the published CJS-compatible surface
+// and currently obtains node:path through `require`. The gate executes source
+// directly as ESM, so supply the same Node require binding before compileFiles.
+(globalThis as typeof globalThis & { require?: ReturnType<typeof createRequire> }).require ??= createRequire(
+  import.meta.url,
+);
 const REPO_ROOT = resolve(__dirname, "..");
 const BASELINE_PATH = join(REPO_ROOT, "scripts/ir-fallback-baseline.json");
 const CORPUS_ROOTS = [join(REPO_ROOT, "website/playground/examples")];
+const IMPORTED_HOF_ENTRY_FILES = new Set(
+  [
+    "website/playground/examples/benchmarks.ts",
+    "website/playground/examples/benchmarks/array.ts",
+    "website/playground/examples/benchmarks/dom.ts",
+    "website/playground/examples/benchmarks/fib.ts",
+    "website/playground/examples/benchmarks/loop.ts",
+    "website/playground/examples/benchmarks/string.ts",
+    "website/playground/examples/benchmarks/style.ts",
+  ].map((file) => resolve(REPO_ROOT, file)),
+);
 
 /** Reasons that must NOT increase vs. baseline. */
 const UNINTENDED: ReadonlySet<IrFallbackReason> = new Set([
@@ -184,13 +203,13 @@ async function aggregate(): Promise<{
 }> {
   const corpus = CORPUS_ROOTS.flatMap(listTsFiles);
 
-  // One in-memory program per file is fine for a 10-file corpus and keeps the
-  // checker scope local. Each file's TypeMap is independent.
+  // One disk-backed program per entry mirrors compileFiles: imports and barrel
+  // re-exports participate in the same checker realm and exact source set.
   const unintended: Partial<Record<IrFallbackReason, number>> = {};
   const deferred: Partial<Record<IrFallbackReason, number>> = {};
-  // #1923 — post-claim demotions, collected from a real `compile()` of each
-  // corpus file (the selector-level `planIrCompilation` below cannot see them
-  // — they happen during build/verify/lower AFTER the selector claims).
+  // #1923 — post-claim demotions, collected from a real `compileFiles()` graph
+  // for each corpus entry (the selector-level `planIrCompilation` below cannot
+  // see them — they happen during build/verify/lower AFTER the selector claims).
   const postClaim = emptyPostClaim();
   const moduleLevel: Partial<Record<IrFallbackReason, number>> = {};
   const moduleLevelInfo = { claimable: 0, empty: 0 };
@@ -198,44 +217,13 @@ async function aggregate(): Promise<{
   const perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }> = [];
   const shapeDetails: Array<{ file: string; name: string; detail: string }> = [];
 
-  const compilerOptions: ts.CompilerOptions = {
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.ESNext,
-    strict: true,
-    moduleResolution: ts.ModuleResolutionKind.NodeNext,
-    skipLibCheck: true,
-    noEmit: true,
-    // (#2856) The host-extern selector arm resolves ambient globals
-    // (`document`, `console`) through the checker — the program needs the
-    // REAL default libs (es + dom) for those `declare var`s to exist. The
-    // previous hand-rolled host declared `lib.d.ts` but had no lib dir on
-    // its search path, so the program ran lib-less and every ambient global
-    // was unresolvable — fine before #2856 (the selector was lib-blind),
-    // WRONG after (the gate would never see host-extern claims the real
-    // compiler makes).
-    lib: ["lib.es2022.d.ts", "lib.dom.d.ts"],
-  };
-
   for (const filePath of corpus) {
-    const source = readFileSync(filePath, "utf-8");
-    const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.ES2022, true);
-
-    // Build a program over just this file so we can derive a checker for the
-    // type-propagation pass AND (#2856) ambient-global resolution. The
-    // disk-backed default host resolves the bundled typescript lib files;
-    // only `filePath` is served from the pre-parsed in-memory source.
-    const baseHost = ts.createCompilerHost(compilerOptions, /* setParentNodes */ true);
-    const host: ts.CompilerHost = {
-      ...baseHost,
-      getSourceFile: (name, languageVersion, ...rest) => {
-        if (name === filePath) return sf;
-        return baseHost.getSourceFile(name, languageVersion, ...rest);
-      },
-      writeFile: () => {},
-    };
-    const program = ts.createProgram([filePath], compilerOptions, host);
-    const checker = program.getTypeChecker();
-    const sourceFile = program.getSourceFile(filePath) ?? sf;
+    // Use the exact production disk graph and checker that compileFiles uses,
+    // including dependency order and the emitted user-source set.
+    const graph = analyzeFiles(filePath);
+    const checker = graph.checker;
+    const sourceFile = graph.entryFile;
+    const importedFunctions = makeIrImportedFunctionResolver(checker, graph.sourceFiles);
 
     let typeMap;
     try {
@@ -259,6 +247,7 @@ async function aggregate(): Promise<{
         trackFallbacks: true,
         jsHostExterns: true,
         resolveHostGlobal: makeIrHostGlobalResolver(checker),
+        importedFunctions,
         resolveModuleBinding: makeIrModuleBindingResolver(checker, {
           numberStorage: "f64",
           allowHostExterns: true,
@@ -297,18 +286,21 @@ async function aggregate(): Promise<{
       }
     }
 
-    // #1923 — post-claim demotions: compile the file for real and aggregate
-    // `irPostClaimErrors` by kind + normalized message class. A compile that
-    // throws contributes nothing (same tolerance as the selector pass above).
+    // #1923 — post-claim demotions: compile the full production graph for real
+    // and aggregate `irPostClaimErrors` by kind + normalized message class.
     try {
-      const result = await compile(source, { fileName: filePath, experimentalIR: true });
+      const result = await compileFiles(filePath, { experimentalIR: true });
+      if (IMPORTED_HOF_ENTRY_FILES.has(resolve(filePath)) && !(result.irCompiledFuncs ?? []).includes("main")) {
+        throw new Error(`#3214 A+B1 gate invariant: ${relative(REPO_ROOT, filePath)}::main was not emitted through IR`);
+      }
       for (const e of result.irPostClaimErrors ?? []) {
         const kind = (POST_CLAIM_KINDS as readonly string[]).includes(e.kind) ? (e.kind as PostClaimKind) : "lower";
         const cls = normalizeMessageClass(e.message);
         postClaim[kind][cls] = (postClaim[kind][cls] ?? 0) + 1;
       }
-    } catch {
-      // ignore — example-file compile failures are not the gate's concern
+    } catch (error) {
+      if (IMPORTED_HOF_ENTRY_FILES.has(resolve(filePath))) throw error;
+      // Other example-file compile failures are not the gate's concern.
     }
   }
   return { unintended, deferred, postClaim, moduleLevel, moduleLevelInfo, modulePerFile, perFile, shapeDetails };

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-21",
   "unintended": {
-    "body-shape-rejected": 12
+    "body-shape-rejected": 5
   },
   "deferred": {
     "async-function": 4

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -128,6 +128,7 @@ import {
   finalizeMethodTrampolines,
   emitCachedMethodClosureAccess,
   ensureMethodClosureSingleton,
+  ensureFuncClosureSingleton,
   emitCachedFuncClosureAccess,
 } from "./closures/method-trampolines.js";
 export {
@@ -135,6 +136,7 @@ export {
   finalizeMethodTrampolines,
   emitCachedMethodClosureAccess,
   ensureMethodClosureSingleton,
+  ensureFuncClosureSingleton,
   emitCachedFuncClosureAccess,
 };
 

--- a/src/codegen/closures/method-trampolines.ts
+++ b/src/codegen/closures/method-trampolines.ts
@@ -13,7 +13,7 @@ import type { Instr, LocalDef, ValType } from "../../ir/types.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "../func-space.js";
 import { inLiveShiftRange } from "../../emit/resolve-layout.js";
-import { addStringConstantGlobal } from "../registry/imports.js";
+import { addStringConstantGlobal, localGlobalIdx } from "../registry/imports.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { noJsHost } from "../expressions/helpers.js";
 import { emitWasiErrorConstructor } from "../registry/error-types.js";
@@ -30,6 +30,7 @@ import {
   getOrCreateConstructibleFuncRefWrapperTypes,
   getOrCreateFuncRefWrapperTypes,
 } from "./funcref-wrapper-types.js";
+import { emitFuncRefAsClosure } from "./funcref-as-closure.js";
 
 /**
  * (#2015) Build the `this`-slot prologue for an object-method trampoline.
@@ -727,32 +728,64 @@ export function ensureMethodClosureSingleton(
  * than the externref-bridge slow path through `__call_2_f64`). Returns
  * `null` when the signature couldn't be resolved (caller falls back).
  */
-export function emitCachedFuncClosureAccess(
+export interface FuncClosureSingleton {
+  readonly cacheGlobalIdx: number;
+  readonly trampolineFuncIdx: number;
+  readonly closureStructTypeIdx: number;
+}
+
+/**
+ * Ensure the declarations behind a cached top-level function value exist,
+ * without emitting an access into a legacy FunctionContext.
+ *
+ * #3214 B1 uses this planning half before AST→IR lowering, then emits the same
+ * `__fn_closure_<name>` lazy cache protocol with symbolic IR global/function
+ * references. Keeping creation here guarantees both front-ends share the
+ * trampoline, wrapper registry, cache global, declared-ref enrollment, and
+ * late signature finalization machinery.
+ */
+export function ensureFuncClosureSingleton(
   ctx: CodegenContext,
-  fctx: FunctionContext,
   funcName: string,
   funcIdx: number,
   constructible = false,
-): ValType | null {
+): FuncClosureSingleton | null {
   const sig = getFuncSignature(ctx, funcIdx);
   if (!sig) return null;
 
   const userParams = sig.params;
   const results = sig.results;
-
   const wrapperTypes = constructible
     ? getOrCreateConstructibleFuncRefWrapperTypes(ctx, userParams, results)
     : getOrCreateFuncRefWrapperTypes(ctx, userParams, results);
   if (!wrapperTypes) return null;
   const { structTypeIdx, liftedFuncTypeIdx } = wrapperTypes;
 
-  // Reuse the canonical trampoline if one was already registered for this
-  // function; otherwise build it once.
   const trampolineName = `__fn_tramp_${funcName}_cached`;
   let trampolineFuncIdx = ctx.funcMap.get(trampolineName);
-  if (trampolineFuncIdx === undefined) {
-    // Forward user params (skip self at param 0) — function declarations
-    // don't have a hidden `this` param like methods do.
+  let cacheGlobalIdx = ctx.funcClosureGlobals.get(funcName);
+
+  // The generated trampoline and cache are one provenance pair. A source
+  // declaration may legally occupy the synthetic trampoline name before the
+  // first value read; accepting that funcMap entry and then minting only the
+  // cache would pair an arbitrary user function with our closure wrapper. The
+  // resulting module can validate yet trap when the wrapper is invoked. Only
+  // reuse an existing trampoline when this helper previously registered its
+  // companion cache, and validate both records against the requested ABI.
+  if ((trampolineFuncIdx === undefined) !== (cacheGlobalIdx === undefined)) return null;
+  if (trampolineFuncIdx !== undefined && cacheGlobalIdx !== undefined) {
+    const trampoline = definedFuncAt(ctx, trampolineFuncIdx);
+    const cache = ctx.mod.globals[localGlobalIdx(ctx, cacheGlobalIdx)];
+    if (
+      trampoline?.name !== trampolineName ||
+      trampoline.typeIdx !== liftedFuncTypeIdx ||
+      cache?.name !== `__fn_closure_${funcName}` ||
+      cache.type.kind !== "externref" ||
+      !cache.mutable
+    ) {
+      return null;
+    }
+  } else {
     const trampolineBody: Instr[] = [];
     for (let i = 0; i < userParams.length; i++) {
       trampolineBody.push({ op: "local.get", index: i + 1 });
@@ -769,37 +802,18 @@ export function emitCachedFuncClosureAccess(
     ctx.funcMap.set(trampolineName, trampolineFuncIdx);
     ctx.mod.declaredFuncRefs.push(trampolineFuncIdx);
 
-    // (#1669-style) Mirror the late-finalization guard used by
-    // `emitCachedMethodClosureAccess`. The function's `func.typeIdx` may
-    // still be re-resolved after this first cached access (default-param /
-    // generator funcs finalize param types during body compile). Enroll
-    // the trampoline so `finalizeMethodTrampolines` rebuilds the body
-    // against the function's final signature.
     ctx.pendingMethodTrampolines.push({
       trampolineBody,
       trampolineFuncIdx,
       methodFuncIdx: funcIdx,
-      // No `this` param for a plain function decl — `noThisParam: true`
-      // tells the finalizer to skip both the `sig.params.slice(1)` strip
-      // and the `ref.null <objStruct>` prologue. `objStructTypeIdx` is
-      // unused on this path.
       objStructTypeIdx: -1,
       userParamCount: userParams.length,
       wrapperUserParams: userParams,
       wrapperResult: results[0],
       noThisParam: true,
-      // (#1809) A name resolved through `funcMap` can point at a host import
-      // (e.g. a DOM/host global `resizeTo`/`scrollBy`, or a `declare`d function)
-      // used as a first-class value. The forwarding trampoline legitimately
-      // `call`s the import, and import indices never shift, so flag it so the
-      // finalizer does not mistake the import target for a missed shift.
       methodTargetsImport: funcIdx < ctx.numImportFuncs,
     });
-  }
 
-  // Reuse or allocate the cache global.
-  let cacheGlobalIdx = ctx.funcClosureGlobals.get(funcName);
-  if (cacheGlobalIdx === undefined) {
     cacheGlobalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
     ctx.mod.globals.push({
       name: `__fn_closure_${funcName}`,
@@ -809,6 +823,25 @@ export function emitCachedFuncClosureAccess(
     });
     ctx.funcClosureGlobals.set(funcName, cacheGlobalIdx);
   }
+
+  return { cacheGlobalIdx, trampolineFuncIdx, closureStructTypeIdx: structTypeIdx };
+}
+
+export function emitCachedFuncClosureAccess(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  funcName: string,
+  funcIdx: number,
+  constructible = false,
+): ValType | null {
+  const singleton = ensureFuncClosureSingleton(ctx, funcName, funcIdx, constructible);
+  // A synthetic-name collision makes the canonical pair unavailable, but
+  // legacy value-producing sites still need a closure on the stack (module
+  // live-binding seeds, Annex-B bindings, fnctor registration, and ordinary
+  // identifier reads). Preserve their historical per-site path; A+B1 planning
+  // calls `ensureFuncClosureSingleton` directly and therefore still demotes.
+  if (!singleton) return emitFuncRefAsClosure(ctx, fctx, funcName, funcIdx, constructible);
+  const { cacheGlobalIdx, trampolineFuncIdx, closureStructTypeIdx: structTypeIdx } = singleton;
 
   // Emit the lazy-init access (mirrors emitCachedMethodClosureAccess), but
   // recover the closure-struct ref on read so downstream consumers like

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -29,11 +29,20 @@ import { compileIrPathFunctions, type IrIntegrationError, type IrIntegrationRepo
 import { asVal, irDynamic, isDynamic, irVal, type IrType } from "../ir/nodes.js";
 import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import {
+  certifyImportedIrCall,
+  effectiveIrParamTypeNode,
+  effectiveIrReturnTypeNode,
   planIrCompilation,
   irClosureSignatureFromFunctionTypeNode,
   type IrFallbackReason,
   type IrSelection,
 } from "../ir/select.js";
+import { makeIrImportedFunctionResolver, type IrImportedFunctionResolver } from "../ir/imported-functions.js";
+import type {
+  IrImportedCallLoweringPlan,
+  IrImportedOptionalParamPlan,
+  IrTopLevelFunctionValueLoweringPlan,
+} from "../ir/from-ast.js";
 import { makeIrHostGlobalResolver } from "../ir/host-extern.js"; // (#2856)
 import {
   makeIrDeclaredPrimitiveExpressionClassifier,
@@ -119,7 +128,7 @@ import {
   repairStructTypeMismatches,
 } from "./fixups.js";
 import { emitInlineMathFunctions } from "./math-helpers.js";
-import { finalizeMethodTrampolines, getFuncRefWrapperRootTypeIdx } from "./closures.js";
+import { ensureFuncClosureSingleton, finalizeMethodTrampolines, getFuncRefWrapperRootTypeIdx } from "./closures.js";
 import { peepholeOptimize } from "./peephole.js";
 import { brandCollidingShapeTypes } from "./shape-brand.js";
 import {
@@ -1579,6 +1588,60 @@ interface IrOverlayPlan {
   };
   readonly trackFallbacks: boolean;
   readonly declByName: ReadonlyMap<string, ts.FunctionDeclaration>;
+  /** Checker-certified A+B1 imported-call sites, keyed by exact AST node. */
+  readonly importedCalls: Map<ts.CallExpression, IrImportedCallLoweringPlan>;
+  /** Bare same-file function values admitted only at certified HOF positions. */
+  readonly topLevelFunctionValues: Map<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
+  readonly importedFunctionResolver?: IrImportedFunctionResolver;
+}
+
+/**
+ * A zero-result imported call is lowerable only where JavaScript discards its
+ * value. Keep this check in the pre-claim planner: ordinary expression
+ * lowering requires an SSA result and must never discover the missing value
+ * after the legacy body has already been skipped.
+ */
+function importedVoidCallIsDiscarded(call: ts.CallExpression, owner: ts.FunctionDeclaration): boolean {
+  let current: ts.Expression = call;
+  for (;;) {
+    const parent = current.parent;
+    if (ts.isParenthesizedExpression(parent) && parent.expression === current) {
+      current = parent;
+      continue;
+    }
+    // `void` always discards its operand, even when the resulting undefined
+    // value is itself consumed by an outer expression.
+    if (ts.isVoidExpression(parent) && parent.expression === current) return true;
+    // A conditional arm is discarded only when the conditional as a whole is
+    // discarded. Its condition is a value position and deliberately stops.
+    if (ts.isConditionalExpression(parent) && (parent.whenTrue === current || parent.whenFalse === current)) {
+      current = parent;
+      continue;
+    }
+    // Discard lowering evaluates comma operands in source order. Ascend to
+    // require the whole comma expression to reach a discarded context.
+    if (ts.isCommaListExpression(parent) && parent.elements.some((element) => element === current)) {
+      current = parent;
+      continue;
+    }
+    if (
+      ts.isBinaryExpression(parent) &&
+      parent.operatorToken.kind === ts.SyntaxKind.CommaToken &&
+      (parent.left === current || parent.right === current)
+    ) {
+      current = parent;
+      continue;
+    }
+    break;
+  }
+
+  const parent = current.parent;
+  if (ts.isExpressionStatement(parent) && parent.expression === current) return true;
+  return (
+    ts.isReturnStatement(parent) &&
+    parent.expression === current &&
+    effectiveIrReturnTypeNode(owner)?.kind === ts.SyntaxKind.VoidKeyword
+  );
 }
 
 /**
@@ -1746,7 +1809,10 @@ function computeIrFirstSkipSet(
 function planIrOverlay(
   ctx: CodegenContext,
   ast: TypedAST,
-  options: { readonly resolveModuleBindings?: boolean } = {},
+  options: {
+    readonly resolveModuleBindings?: boolean;
+    readonly importedFunctions?: IrImportedFunctionResolver;
+  } = {},
 ): IrOverlayPlan {
   const typeMap = buildTypeMap(ast.sourceFile, ast.checker);
   // #1169q telemetry — when JS2WASM_LOG_IR_FALLBACKS is set, request the
@@ -1802,6 +1868,7 @@ function planIrOverlay(
       classifyDeclaredPrimitiveExpression,
       supportsSymbolicMathHelpers: true,
       supportsLiteralStringReplace: true,
+      ...(jsHostExterns && options.importedFunctions ? { importedFunctions: options.importedFunctions } : {}),
       // (#1373b C-1) Async claim gate: IR claims an async fn IFF the ONE
       // async engine ($AsyncFrame drive / host-drive) declines it — the
       // legacy sync-pass-through population. Engine-activated functions keep
@@ -1963,7 +2030,90 @@ function planIrOverlay(
     // (#3142 Slice 2) The module-init unit routes through legacy too.
     safeSelection.moduleInit = undefined;
   }
-  return { selection, classShapes, overrideMap, safeSelection, trackFallbacks, declByName };
+  const importedCalls = new Map<ts.CallExpression, IrImportedCallLoweringPlan>();
+  const topLevelFunctionValues = new Map<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>();
+  if (jsHostExterns && options.importedFunctions) {
+    for (const [ownerName, declaration] of declByName) {
+      if (!safeSelection.funcs.has(ownerName) || !declaration.body) continue;
+      let planningFailed = false;
+      const visit = (node: ts.Node): void => {
+        if (planningFailed) return;
+        if (node !== declaration && ts.isFunctionLike(node)) return;
+        if (ts.isCallExpression(node)) {
+          const certified = certifyImportedIrCall(node, options.importedFunctions);
+          if (certified) {
+            try {
+              const params = certified.target.declaration.parameters.map((parameter) =>
+                resolvePositionType(effectiveIrParamTypeNode(parameter), undefined, ctx, classShapes),
+              );
+              const returnNode = effectiveIrReturnTypeNode(certified.target.declaration);
+              const returnType =
+                returnNode?.kind === ts.SyntaxKind.VoidKeyword
+                  ? null
+                  : resolvePositionType(returnNode, undefined, ctx, classShapes);
+              if (returnType === null && !importedVoidCallIsDiscarded(node, declaration)) {
+                throw new Error("void imported result is used in a value context");
+              }
+              if (returnType?.kind === "callable") {
+                throw new Error("callable imported results are outside A+B1");
+              }
+              const optionalParams = new Map<number, IrImportedOptionalParamPlan>();
+              for (const optional of ctx.funcOptionalParams.get(certified.target.targetName) ?? []) {
+                optionalParams.set(optional.index, {
+                  ...(optional.constantDefault ? { constantDefault: optional.constantDefault } : {}),
+                  ...(optional.hasExpressionDefault ? { hasExpressionDefault: true } : {}),
+                });
+              }
+              importedCalls.set(node, {
+                ownerName,
+                targetName: certified.target.targetName,
+                params,
+                returnType,
+                optionalParams,
+                needsArgc:
+                  ctx.funcUsesArguments.has(certified.target.targetName) ||
+                  ctx.funcOptionalParams.has(certified.target.targetName),
+              });
+              for (const functionArgument of certified.functionArguments) {
+                topLevelFunctionValues.set(functionArgument.argument, {
+                  ownerName,
+                  targetName: functionArgument.target.targetName,
+                  signature: functionArgument.signature,
+                  trampolineName: `__fn_tramp_${functionArgument.target.targetName}_cached`,
+                  cacheGlobalName: `__fn_closure_${functionArgument.target.targetName}`,
+                });
+              }
+            } catch {
+              planningFailed = true;
+              return;
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(declaration.body);
+      if (planningFailed) {
+        safeSelection.funcs.delete(ownerName);
+        for (const [call, plan] of importedCalls) {
+          if (plan.ownerName === ownerName) importedCalls.delete(call);
+        }
+        for (const [identifier, plan] of topLevelFunctionValues) {
+          if (plan.ownerName === ownerName) topLevelFunctionValues.delete(identifier);
+        }
+      }
+    }
+  }
+  return {
+    selection,
+    classShapes,
+    overrideMap,
+    safeSelection,
+    trackFallbacks,
+    declByName,
+    importedCalls,
+    topLevelFunctionValues,
+    ...(options.importedFunctions ? { importedFunctionResolver: options.importedFunctions } : {}),
+  };
 }
 
 /** Consume one IR overlay attempt through the shared diagnostics/telemetry path. */
@@ -2054,25 +2204,6 @@ function collectMultiIrFunctionNameCollisions(sourceFiles: readonly ts.SourceFil
     }
   }
   return collisions;
-}
-
-function collectImportBindingNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
-  const names = new Set<string>();
-  for (const stmt of sourceFile.statements) {
-    if (ts.isImportDeclaration(stmt)) {
-      const clause = stmt.importClause;
-      if (!clause) continue;
-      if (clause.name) names.add(clause.name.text);
-      if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
-        names.add(clause.namedBindings.name.text);
-      } else if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
-        for (const element of clause.namedBindings.elements) names.add(element.name.text);
-      }
-    } else if (ts.isImportEqualsDeclaration(stmt)) {
-      names.add(stmt.name.text);
-    }
-  }
-  return names;
 }
 
 /** Import locals that can overwrite an unrelated flat `ctx.funcMap` key. */
@@ -2221,14 +2352,20 @@ function collectMultiCrossFileFunctionNames(
   return names;
 }
 
-function functionBodyReferencesAnyName(fn: ts.FunctionDeclaration, names: ReadonlySet<string>): boolean {
-  if (!fn.body || names.size === 0) return false;
+function functionBodyHasUnsupportedImportUse(fn: ts.FunctionDeclaration, plan: IrOverlayPlan): boolean {
+  if (!fn.body || !plan.importedFunctionResolver) return false;
   let found = false;
   const visit = (node: ts.Node): void => {
     if (found) return;
-    if (ts.isIdentifier(node) && names.has(node.text)) {
-      found = true;
-      return;
+    if (node !== fn && ts.isFunctionLike(node)) return;
+    if (ts.isIdentifier(node) && plan.importedFunctionResolver?.isImportBinding(node)) {
+      const parent = node.parent;
+      const isCertifiedDirectCall =
+        ts.isCallExpression(parent) && parent.expression === node && plan.importedCalls.has(parent);
+      if (!isCertifiedDirectCall) {
+        found = true;
+        return;
+      }
     }
     ts.forEachChild(node, visit);
   };
@@ -2272,7 +2409,11 @@ function typeFactCouldBeCallable(fact: TypeFact): boolean {
 /** Callable parameters/returns still have a legacy↔IR wrapper ABI boundary. */
 function functionHasCallableBoundary(ctx: CodegenContext, declaration: ts.FunctionDeclaration): boolean {
   for (const parameter of declaration.parameters) {
-    if (parameter.type !== undefined && ts.isFunctionTypeNode(parameter.type)) return true;
+    const typeNode = effectiveIrParamTypeNode(parameter);
+    // A checker-certified exact FunctionTypeNode uses the same canonical
+    // callable ABI in both front-ends. Host A+B1 can therefore retain an
+    // imported HOF target instead of demoting its whole cross-file component.
+    if (typeNode && ts.isFunctionTypeNode(typeNode) && irClosureSignatureFromFunctionTypeNode(typeNode)) continue;
     if (typeFactCouldBeCallable(ctx.oracle.typeFactOf(parameter))) return true;
   }
   const signature = ctx.oracle.signatureOf(declaration);
@@ -2297,48 +2438,25 @@ interface MultiIrGraphSafety {
   readonly occupiedFunctionNameCounts: ReadonlyMap<string, number>;
 }
 
-function makeMultiIrSafeSelection(
+function multiIrTargetHasExactRegistryEntry(
   ctx: CodegenContext,
-  plan: IrOverlayPlan,
-  sourceFile: ts.SourceFile,
+  targetName: string,
   safety: MultiIrGraphSafety,
+): boolean {
+  if (safety.occupiedFunctionNameCounts.get(targetName) !== 1) return false;
+  if (safety.occupiedFunctionKeys.some((key) => key.startsWith(`${targetName}$`))) return false;
+  const idx = ctx.funcMap.get(targetName);
+  return idx !== undefined && idx >= ctx.numImportFuncs && definedFuncAt(ctx, idx)?.name === targetName;
+}
+
+function closeMultiIrBlockedComponent(
+  sourceFile: ts.SourceFile,
+  selection: IrSelection,
+  initialBlocked: ReadonlySet<string>,
 ): IrSelection {
-  const funcs = new Set(plan.safeSelection.funcs);
-  const blocked = new Set<string>([...safety.collisions, MODULE_INIT_CALLER]);
-  for (const name of plan.selection.funcs) {
-    if (!plan.safeSelection.funcs.has(name)) blocked.add(name);
-  }
-  const importBindings = collectImportBindingNames(sourceFile);
-  const conservativeCrossFileCallers = ctx.standalone || ctx.wasi || ctx.strictNoHostImports;
-
-  for (const name of funcs) {
-    const declaration = plan.declByName.get(name);
-    if (!declaration) {
-      blocked.add(name);
-      continue;
-    }
-    const crossFileTarget = safety.crossFileFunctionNames.has(name);
-    const hasCallableBoundary = crossFileTarget && functionHasCallableBoundary(ctx, declaration);
-    const registeredIdx = ctx.funcMap.get(name);
-    const registeredFunction = registeredIdx === undefined ? undefined : definedFuncAt(ctx, registeredIdx);
-    if (
-      safety.collisions.has(name) ||
-      functionBodyReferencesAnyName(declaration, importBindings) ||
-      functionBodyContainsNestedRuntimeDeclaration(declaration) ||
-      (declaration.typeParameters?.length ?? 0) > 0 ||
-      safety.importAliasNames.has(name) ||
-      safety.occupiedFunctionNameCounts.get(name) !== 1 ||
-      registeredFunction?.name !== name ||
-      safety.occupiedFunctionKeys.some((key) => key.startsWith(`${name}$`)) ||
-      (crossFileTarget && (conservativeCrossFileCallers || hasCallableBoundary))
-    ) {
-      blocked.add(name);
-    }
-  }
+  const funcs = new Set(selection.funcs);
+  const blocked = new Set(initialBlocked);
   for (const name of blocked) funcs.delete(name);
-
-  // A collision/dangerous removal re-opens the selector's graph-closure
-  // invariant in both directions. Drop its whole selected weak component.
   const callEdges = collectLocalCallEdges(sourceFile);
   for (let changed = true; changed; ) {
     changed = false;
@@ -2360,12 +2478,126 @@ function makeMultiIrSafeSelection(
       }
     }
   }
+  return { funcs, classMembers: new Set(), moduleInit: undefined };
+}
 
-  return {
-    funcs,
-    classMembers: new Set<string>(),
-    moduleInit: undefined,
-  };
+function makeMultiIrSafeSelection(
+  ctx: CodegenContext,
+  plan: IrOverlayPlan,
+  sourceFile: ts.SourceFile,
+  safety: MultiIrGraphSafety,
+): IrSelection {
+  const funcs = new Set(plan.safeSelection.funcs);
+  const blocked = new Set<string>([...safety.collisions, MODULE_INIT_CALLER]);
+  for (const name of plan.selection.funcs) {
+    if (!plan.safeSelection.funcs.has(name)) blocked.add(name);
+  }
+  const conservativeCrossFileCallers = ctx.standalone || ctx.wasi || ctx.strictNoHostImports;
+
+  for (const callPlan of plan.importedCalls.values()) {
+    if (!multiIrTargetHasExactRegistryEntry(ctx, callPlan.targetName, safety)) blocked.add(callPlan.ownerName);
+  }
+  for (const valuePlan of plan.topLevelFunctionValues.values()) {
+    if (!multiIrTargetHasExactRegistryEntry(ctx, valuePlan.targetName, safety)) blocked.add(valuePlan.ownerName);
+  }
+
+  for (const name of funcs) {
+    const declaration = plan.declByName.get(name);
+    if (!declaration) {
+      blocked.add(name);
+      continue;
+    }
+    const crossFileTarget = safety.crossFileFunctionNames.has(name);
+    const hasCallableBoundary = crossFileTarget && functionHasCallableBoundary(ctx, declaration);
+    const registeredIdx = ctx.funcMap.get(name);
+    const registeredFunction = registeredIdx === undefined ? undefined : definedFuncAt(ctx, registeredIdx);
+    if (
+      safety.collisions.has(name) ||
+      functionBodyHasUnsupportedImportUse(declaration, plan) ||
+      functionBodyContainsNestedRuntimeDeclaration(declaration) ||
+      (declaration.typeParameters?.length ?? 0) > 0 ||
+      safety.importAliasNames.has(name) ||
+      safety.occupiedFunctionNameCounts.get(name) !== 1 ||
+      registeredFunction?.name !== name ||
+      safety.occupiedFunctionKeys.some((key) => key.startsWith(`${name}$`)) ||
+      (crossFileTarget && (conservativeCrossFileCallers || hasCallableBoundary))
+    ) {
+      blocked.add(name);
+    }
+  }
+  for (const name of blocked) funcs.delete(name);
+
+  // A collision/dangerous removal re-opens the selector's graph-closure
+  // invariant in both directions. Drop its whole selected weak component.
+  return closeMultiIrBlockedComponent(
+    sourceFile,
+    { funcs, classMembers: new Set<string>(), moduleInit: undefined },
+    blocked,
+  );
+}
+
+function importedMissingArgNeedsUndefined(type: IrType): boolean {
+  const val = asVal(type);
+  return (
+    type.kind === "extern" ||
+    type.kind === "callable" ||
+    type.kind === "string" ||
+    type.kind === "dynamic" ||
+    val?.kind === "externref" ||
+    val?.kind === "ref_extern"
+  );
+}
+
+/**
+ * Materialize the legacy-owned runtime declarations referenced symbolically by
+ * A+B1 before the IR builder runs. Any uncertainty removes the owner's whole
+ * local call component, so an admitted site can never become a post-claim
+ * symbolic-resolution failure.
+ */
+function prepareMultiIrImportedLowering(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  plan: IrOverlayPlan,
+  selection: IrSelection,
+): IrSelection {
+  if (plan.importedCalls.size === 0) return selection;
+  const blocked = new Set<string>();
+  let requestedLateImport = false;
+
+  for (const [call, callPlan] of plan.importedCalls) {
+    if (!selection.funcs.has(callPlan.ownerName)) continue;
+    if (callPlan.needsArgc) ensureArgcGlobal(ctx);
+    for (let i = call.arguments.length; i < callPlan.params.length; i++) {
+      if (!importedMissingArgNeedsUndefined(callPlan.params[i]!)) continue;
+      if (ensureGetUndefined(ctx) === undefined) blocked.add(callPlan.ownerName);
+      else requestedLateImport = true;
+    }
+  }
+
+  // A new host import shifts every defined funcIdx. Settle that once before
+  // looking up callback targets or creating trampolines that capture an index.
+  if (requestedLateImport) flushLateImportShifts(ctx, null);
+
+  for (const valuePlan of plan.topLevelFunctionValues.values()) {
+    if (!selection.funcs.has(valuePlan.ownerName) || blocked.has(valuePlan.ownerName)) continue;
+    const funcIdx = ctx.funcMap.get(valuePlan.targetName);
+    if (
+      funcIdx === undefined ||
+      funcIdx < ctx.numImportFuncs ||
+      definedFuncAt(ctx, funcIdx)?.name !== valuePlan.targetName
+    ) {
+      blocked.add(valuePlan.ownerName);
+      continue;
+    }
+    const singleton = ensureFuncClosureSingleton(ctx, valuePlan.targetName, funcIdx, false);
+    const trampoline = singleton ? definedFuncAt(ctx, singleton.trampolineFuncIdx) : undefined;
+    const cache = singleton ? ctx.mod.globals[localGlobalIdx(ctx, singleton.cacheGlobalIdx)] : undefined;
+    if (!singleton || trampoline?.name !== valuePlan.trampolineName || cache?.name !== valuePlan.cacheGlobalName) {
+      blocked.add(valuePlan.ownerName);
+    }
+  }
+
+  return blocked.size === 0 ? selection : closeMultiIrBlockedComponent(sourceFile, selection, blocked);
 }
 
 /** Compile a typed AST into a WasmModule IR */
@@ -4932,7 +5164,16 @@ export function generateMultiModule(
     // members, module init, and IR-first body skipping are deliberately out of
     // scope. In particular, never patch the one shared `__module_init` once per
     // source file.
-    if (options?.experimentalIR) {
+    // Fast-mode legacy declarations use i32 for `number`, while the current IR
+    // overlay uses f64. A multi-file target can be reached by a legacy caller,
+    // so replacing only that target would change its live Wasm ABI. Keep the
+    // whole multi-file overlay pre-claim disabled until those numeric boundary
+    // representations are planned mode-aware.
+    if (options?.experimentalIR && !ctx.fast) {
+      const hostImportedFunctions =
+        ctx.standalone || ctx.wasi || ctx.strictNoHostImports
+          ? undefined
+          : makeIrImportedFunctionResolver(multiAst.checker, multiAst.sourceFiles);
       const occupiedFunctionNameCounts = new Map<string, number>();
       for (const fn of ctx.mod.functions) {
         occupiedFunctionNameCounts.set(fn.name, (occupiedFunctionNameCounts.get(fn.name) ?? 0) + 1);
@@ -4952,11 +5193,22 @@ export function generateMultiModule(
           diagnostics: multiAst.diagnostics,
           syntacticDiagnostics: multiAst.syntacticDiagnostics,
         };
-        const plan = planIrOverlay(ctx, sourceAst, { resolveModuleBindings: false });
-        const safeSelection = makeMultiIrSafeSelection(ctx, plan, sourceFile, safety);
-        const report = compileIrPathFunctions(ctx, sourceFile, safeSelection, plan.overrideMap, plan.classShapes);
+        const plan = planIrOverlay(ctx, sourceAst, {
+          resolveModuleBindings: false,
+          ...(hostImportedFunctions ? { importedFunctions: hostImportedFunctions } : {}),
+        });
+        let safeSelection = makeMultiIrSafeSelection(ctx, plan, sourceFile, safety);
+        safeSelection = prepareMultiIrImportedLowering(ctx, sourceFile, plan, safeSelection);
+        const report = compileIrPathFunctions(ctx, sourceFile, safeSelection, plan.overrideMap, plan.classShapes, {
+          importedCalls: plan.importedCalls,
+          topLevelFunctionValues: plan.topLevelFunctionValues,
+        });
         consumeIrOverlayReport(ctx, report, plan.selection, plan.trackFallbacks, sourceFile.fileName);
       }
+      // A+B1 may create callback singleton trampolines after the legacy
+      // finalization pass. Rebuild those late declarations against the target's
+      // final signature before any fixup/validation pass observes them.
+      finalizeMethodTrampolines(ctx);
     }
 
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.

--- a/src/ir/backend/porffor/sink.ts
+++ b/src/ir/backend/porffor/sink.ts
@@ -693,6 +693,8 @@ export class PorfforEmitter implements BackendEmitter<PorfforSink> {
       case "f64.neg":
         out.push({ kind: "unary", type: "f64", effects: value.effects, op: "neg", value });
         return;
+      case "f64.reinterpret_i64":
+        throw new Error(`porffor backend does not support unary op '${op}'`);
       case "i32.eqz":
         out.push({ kind: "unary", type: "i32", effects: value.effects, op: "!", value });
         return;

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -430,6 +430,10 @@ export interface AstToIrOptions {
    * for void; calls in statement position (`f();`) are fine.
    */
   readonly calleeTypes?: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+  /** (#3214 A) Exact imported direct calls certified by the shared selector. */
+  readonly importedCalls?: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
+  /** (#3214 B1) Exact bare top-level function-value sites, keyed by AST node. */
+  readonly topLevelFunctionValues?: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
   /**
    * Slice 4 (#1169d): map from class name to that class's IR shape
    * (fields + methods + constructor signature). Consulted when lowering
@@ -485,6 +489,30 @@ export interface AstToIrOptions {
    * unsupported storage still demotes.
    */
   readonly moduleBindings?: ReadonlyMap<string, ModuleBindingGlobal>;
+}
+
+export interface IrImportedOptionalParamPlan {
+  readonly constantDefault?:
+    | { readonly kind: "f64"; readonly value: number }
+    | { readonly kind: "i32"; readonly value: number };
+  readonly hasExpressionDefault?: boolean;
+}
+
+export interface IrImportedCallLoweringPlan {
+  readonly ownerName: string;
+  readonly targetName: string;
+  readonly params: readonly IrType[];
+  readonly returnType: IrType | null;
+  readonly optionalParams: ReadonlyMap<number, IrImportedOptionalParamPlan>;
+  readonly needsArgc: boolean;
+}
+
+export interface IrTopLevelFunctionValueLoweringPlan {
+  readonly ownerName: string;
+  readonly targetName: string;
+  readonly signature: IrClosureSignature;
+  readonly trampolineName: string;
+  readonly cacheGlobalName: string;
 }
 
 /**
@@ -719,6 +747,8 @@ export function lowerFunctionAstToIr(
     funcName: name,
     returnType,
     calleeTypes: options.calleeTypes,
+    importedCalls: options.importedCalls,
+    topLevelFunctionValues: options.topLevelFunctionValues,
     classShapes: options.classShapes,
     resolver: options.resolver,
     lifted,
@@ -1044,6 +1074,65 @@ function lowerStatementList(stmts: readonly ts.Statement[], cx: LowerCtx): void 
 }
 
 /**
+ * Lower an expression whose value is discarded while preserving its effects.
+ * Calls need an explicit statement-position bit because a void callee has no
+ * SSA result. Routing `return voidCall()` through ordinary expression lowering
+ * incorrectly treated that absence as a value-use error; the same bug affected
+ * early returns nested in loop/body buffers.
+ */
+function lowerDiscardedExpression(expr: ts.Expression, cx: LowerCtx): void {
+  if (ts.isParenthesizedExpression(expr)) {
+    lowerDiscardedExpression(expr.expression, cx);
+    return;
+  }
+  if (ts.isVoidExpression(expr)) {
+    lowerDiscardedExpression(expr.expression, cx);
+    return;
+  }
+  if (ts.isConditionalExpression(expr)) {
+    const rawCond = lowerExpr(expr.condition, cx, irVal({ kind: "i32" }));
+    const condType = cx.builder.typeOf(rawCond);
+    const cond = condType.kind === "dynamic" ? cx.builder.emitDynTruthy(rawCond) : rawCond;
+    if (condType.kind !== "dynamic" && asVal(condType)?.kind !== "i32") {
+      throw new Error(`ir/from-ast: discarded ternary condition must be bool in ${cx.funcName}`);
+    }
+
+    const branchScope = new Map(cx.scope);
+    const thenCx: LowerCtx = { ...cx, scope: new Map(branchScope) };
+    const thenBody = cx.builder.collectBodyInstrs(() => {
+      lowerDiscardedExpression(expr.whenTrue, thenCx);
+    });
+    const elseCx: LowerCtx = { ...cx, scope: new Map(branchScope) };
+    const elseBody = cx.builder.collectBodyInstrs(() => {
+      lowerDiscardedExpression(expr.whenFalse, elseCx);
+    });
+    cx.builder.emitIfStmt({ cond, then: thenBody, else: elseBody });
+    joinScopeStringEncodingFacts(cx.scope, [thenCx.scope, elseCx.scope]);
+    return;
+  }
+  if (ts.isCommaListExpression(expr)) {
+    for (const element of expr.elements) lowerDiscardedExpression(element, cx);
+    return;
+  }
+  if (ts.isBinaryExpression(expr) && expr.operatorToken.kind === ts.SyntaxKind.CommaToken) {
+    lowerDiscardedExpression(expr.left, cx);
+    lowerDiscardedExpression(expr.right, cx);
+    return;
+  }
+  if (ts.isCallExpression(expr)) {
+    if (ts.isPropertyAccessExpression(expr.expression) && !expr.questionDotToken) {
+      void lowerMethodCall(expr, cx, /* statementPosition */ true);
+      return;
+    }
+    if (ts.isIdentifier(expr.expression)) {
+      void lowerCall(expr, cx, /* statementPosition */ true);
+      return;
+    }
+  }
+  void lowerExpr(expr, cx, irVal({ kind: "externref" }));
+}
+
+/**
  * Lower a "tail" statement — one that must end in a return on every path.
  * Phase 1 tails are: `return <expr>;`, a `Block { ... }` whose own tail is a
  * tail, or `if (<cond>) <tail> else <tail>`.
@@ -1103,8 +1192,7 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
     // (the value is discarded). Terminate with empty values.
     if (cx.returnType === null) {
       if (stmt.expression) {
-        // Lower for side effects but discard the value.
-        lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
+        lowerDiscardedExpression(stmt.expression, cx);
       }
       cx.builder.terminate({ kind: "return", values: [] });
       return;
@@ -1122,22 +1210,8 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
   // We accept ExpressionStatement (e.g., `f();`) as a tail in void
   // functions and synthesize the implicit return.
   if (cx.returnType === null && ts.isExpressionStatement(stmt)) {
-    // (#2856) Method-shaped tail call in a void function — statement
-    // position, so void extern/console methods are legal here too.
-    if (
-      ts.isCallExpression(stmt.expression) &&
-      ts.isPropertyAccessExpression(stmt.expression.expression) &&
-      !stmt.expression.questionDotToken
-    ) {
-      void lowerMethodCall(stmt.expression, cx, /* statementPosition */ true);
-      cx.builder.terminate({ kind: "return", values: [] });
-      return;
-    }
-    // (#2856 C4) Direct-call tail in a void function — `quicksort(arr, p +
-    // 1, hi);` as the last statement. Statement position, so a void callee
-    // is legal.
-    if (ts.isCallExpression(stmt.expression) && ts.isIdentifier(stmt.expression.expression)) {
-      void lowerCall(stmt.expression, cx, /* statementPosition */ true);
+    if (ts.isCallExpression(stmt.expression)) {
+      lowerDiscardedExpression(stmt.expression, cx);
       cx.builder.terminate({ kind: "return", values: [] });
       return;
     }
@@ -1176,8 +1250,7 @@ function lowerTail(stmt: ts.Statement, cx: LowerCtx): void {
       cx.builder.terminate({ kind: "return", values: [] });
       return;
     }
-    // Lower the expression for side effects, discard the value.
-    lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
+    lowerDiscardedExpression(stmt.expression, cx);
     cx.builder.terminate({ kind: "return", values: [] });
     return;
   }
@@ -1333,6 +1406,8 @@ interface LowerCtx {
   // `lowerTail` checks this to accept bare `return;` / fall-through tails.
   readonly returnType: IrType | null;
   readonly calleeTypes?: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
+  readonly importedCalls?: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
+  readonly topLevelFunctionValues?: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
   /** Slice 4 (#1169d) — class shape registry, keyed by className. */
   readonly classShapes?: ReadonlyMap<string, IrClassShape>;
   /**
@@ -1489,6 +1564,28 @@ function sameScopeStorage(a: StringEncodingScopeBinding, b: ScopeBinding | undef
     case "slot":
       return b.kind === "slot" && b.slotIndex === a.slotIndex;
   }
+}
+
+/**
+ * (#3214 B1) Read/create the canonical cached wrapper for one exact bare
+ * top-level function-value site.  The codegen planning phase has already
+ * materialized the matching symbolic trampoline/global declarations through
+ * `ensureFuncClosureSingleton`; IR owns only the lazy access sequence.
+ */
+function lowerTopLevelFunctionValue(plan: IrTopLevelFunctionValueLoweringPlan, cx: LowerCtx): IrValueId {
+  const cache = { kind: "global" as const, name: plan.cacheGlobalName };
+  const cached = cx.builder.emitGlobalGet(cache, irVal({ kind: "externref" }));
+  const isNull = cx.builder.emitRefIsNull(cached);
+  const thenBody = cx.builder.collectBodyInstrs(() => {
+    const closure = cx.builder.emitClosureNew({ kind: "func", name: plan.trampolineName }, plan.signature, [], []);
+    const external = cx.builder.emitCoerceToExternref(closure);
+    cx.builder.emitGlobalSet(cache, external);
+  });
+  cx.builder.emitIfStmt({ cond: isNull, then: thenBody, else: [] });
+  // `callable<S>` is the source boundary type and lowers to the exact same
+  // externref global carrier. Retagging the final read avoids an unsound
+  // externref→closure cast while preserving singleton identity.
+  return cx.builder.emitGlobalGet(cache, { kind: "callable", signature: plan.signature });
 }
 
 /**
@@ -2452,6 +2549,8 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
     return p.value;
   }
   if (ts.isIdentifier(expr)) {
+    const topLevelFunction = cx.topLevelFunctionValues?.get(expr);
+    if (topLevelFunction) return lowerTopLevelFunctionValue(topLevelFunction, cx);
     const p = cx.scope.get(expr.text);
     // (#2856) Host ambient global (`document`, `window`, …): not a scope
     // binding — resolves through the legacy declared-globals registry to the
@@ -2585,7 +2684,7 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
   // emit a proper undefined-typed value; for slice 11, throw if the
   // operand context demands a non-f64 result.
   if (ts.isVoidExpression(expr)) {
-    void lowerExpr(expr.expression, cx, irVal({ kind: "f64" }));
+    lowerDiscardedExpression(expr.expression, cx);
     return cx.builder.emitConst({ kind: "f64", value: NaN }, irVal({ kind: "f64" }));
   }
   throw new Error(`ir/from-ast: unsupported expression kind ${ts.SyntaxKind[expr.kind]} in ${cx.funcName}`);
@@ -3667,6 +3766,105 @@ function requireSuperParentShape(cx: LowerCtx): IrClassShape {
   return parent;
 }
 
+function importedMissingArgument(
+  expected: IrType,
+  optional: IrImportedOptionalParamPlan | undefined,
+  cx: LowerCtx,
+): IrValueId {
+  const constant = optional?.constantDefault;
+  if (constant?.kind === "f64") {
+    return cx.builder.emitConst({ kind: "f64", value: constant.value }, expected);
+  }
+  if (constant?.kind === "i32") {
+    return cx.builder.emitConst({ kind: "i32", value: constant.value }, expected);
+  }
+
+  const val = asVal(expected);
+  if (val?.kind === "f64") {
+    if (optional?.hasExpressionDefault) {
+      // Exact legacy default-expression sentinel. Construct from its bits so
+      // JS number canonicalization can never quiet/change the NaN payload.
+      const bits = cx.builder.emitConst({ kind: "i64", value: 0x7ff00000deadc0den }, irVal({ kind: "i64" }));
+      return cx.builder.emitUnary("f64.reinterpret_i64", bits, expected);
+    }
+    return cx.builder.emitConst({ kind: "f64", value: 0 }, expected);
+  }
+  if (val?.kind === "i32") {
+    // i32 defaults use __argc to distinguish an absent arg from a supplied 0.
+    return cx.builder.emitConst({ kind: "i32", value: 0 }, expected);
+  }
+
+  const hostExternCarrier =
+    expected.kind === "extern" ||
+    expected.kind === "callable" ||
+    expected.kind === "string" ||
+    expected.kind === "dynamic" ||
+    val?.kind === "externref" ||
+    val?.kind === "ref_extern";
+  if (hostExternCarrier) {
+    const undefinedValue = cx.builder.emitCall({ kind: "func", name: "__get_undefined" }, [], expected);
+    if (undefinedValue === null) {
+      throw new Error(`ir/from-ast: __get_undefined unexpectedly returned void (${cx.funcName})`);
+    }
+    return undefinedValue;
+  }
+  throw new Error(
+    `ir/from-ast: missing imported-call argument of ${describeIrType(expected)} is outside A+B1 (${cx.funcName})`,
+  );
+}
+
+function lowerImportedCall(
+  expr: ts.CallExpression,
+  plan: IrImportedCallLoweringPlan,
+  cx: LowerCtx,
+  statementPosition: boolean,
+): IrValueId | null {
+  if (expr.arguments.length > plan.params.length || expr.arguments.some(ts.isSpreadElement)) {
+    throw new Error(`ir/from-ast: imported call shape diverged after certification (${cx.funcName})`);
+  }
+  const args: IrValueId[] = [];
+  for (let i = 0; i < plan.params.length; i++) {
+    const expected = plan.params[i]!;
+    let value: IrValueId;
+    if (i < expr.arguments.length) {
+      value = lowerExpr(expr.arguments[i]!, cx, expected);
+      let actual = cx.builder.typeOf(value);
+      if (
+        actual.kind === "closure" &&
+        expected.kind === "callable" &&
+        closureSignatureEquals(actual.signature, expected.signature)
+      ) {
+        value = cx.builder.emitCallablePack(value, expected.signature);
+        actual = cx.builder.typeOf(value);
+      }
+      if (!irTypeArgAssignable(actual, expected)) {
+        throw new Error(
+          `ir/from-ast: arg ${i} of imported call to ${plan.targetName} is ${describeIrType(actual)}, expected ${describeIrType(expected)} in ${cx.funcName}`,
+        );
+      }
+    } else {
+      value = importedMissingArgument(expected, plan.optionalParams.get(i), cx);
+    }
+    args.push(value);
+  }
+
+  // Argument evaluation can itself call a default/arguments-sensitive
+  // function, so mirror legacy ordering and publish this callee's argc only
+  // after every argument value has been evaluated.
+  if (plan.needsArgc) {
+    const argc = cx.builder.emitConst({ kind: "i32", value: expr.arguments.length }, irVal({ kind: "i32" }));
+    cx.builder.emitGlobalSet({ kind: "global", name: "__argc" }, argc);
+  }
+
+  const result = cx.builder.emitCall({ kind: "func", name: plan.targetName }, args, plan.returnType);
+  if (result === null && !statementPosition) {
+    throw new Error(
+      `ir/from-ast: imported call to ${plan.targetName} returned void used as expression in ${cx.funcName}`,
+    );
+  }
+  return result;
+}
+
 function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = false): IrValueId | null {
   // Optional call (`fn?.()` / `obj?.method()`, #1281). The IR has no
   // short-circuit primitive for nullable callees, and at this point we
@@ -3738,6 +3936,9 @@ function lowerCall(expr: ts.CallExpression, cx: LowerCtx, statementPosition = fa
   if (binding?.kind === "nestedFunc") {
     return lowerNestedFuncCall(binding, expr.arguments, cx);
   }
+
+  const imported = cx.importedCalls?.get(expr);
+  if (imported) return lowerImportedCall(expr, imported, cx, statementPosition);
 
   const calleeSig = cx.calleeTypes?.get(calleeName);
   if (!calleeSig) {
@@ -5965,14 +6166,7 @@ function lowerStmt(stmt: ts.Statement, cx: LowerCtx): void {
   }
   if (ts.isExpressionStatement(stmt)) {
     if (ts.isCallExpression(stmt.expression)) {
-      // (#2856) Method-shaped statement calls in body position — statement
-      // position, so void extern/console methods are legal.
-      if (ts.isPropertyAccessExpression(stmt.expression.expression) && !stmt.expression.questionDotToken) {
-        void lowerMethodCall(stmt.expression, cx, /* statementPosition */ true);
-        return;
-      }
-      // (#2856 C4) Statement position — a VOID direct call is legal.
-      void lowerCall(stmt.expression, cx, /* statementPosition */ true);
+      lowerDiscardedExpression(stmt.expression, cx);
       return;
     }
     // Slice 7a (#1169f): `yield <expr>;` inside a for-of body. The
@@ -6153,8 +6347,7 @@ function lowerEarlyReturn(stmt: ts.ReturnStatement, cx: LowerCtx): void {
   }
   if (cx.returnType === null) {
     if (stmt.expression) {
-      // Lower for side effects but discard the value (void function).
-      lowerExpr(stmt.expression, cx, irVal({ kind: "externref" }));
+      lowerDiscardedExpression(stmt.expression, cx);
     }
     cx.builder.emitEarlyReturn(null);
     return;
@@ -7804,6 +7997,8 @@ function liftNestedFunction(
     funcName: liftedName,
     returnType: signature.returnType,
     calleeTypes: cx.calleeTypes,
+    importedCalls: cx.importedCalls,
+    topLevelFunctionValues: cx.topLevelFunctionValues,
     classShapes: cx.classShapes,
     resolver: cx.resolver,
     lifted: cx.lifted,
@@ -7882,6 +8077,8 @@ function liftClosureBody(
     funcName: liftedName,
     returnType: signature.returnType,
     calleeTypes: cx.calleeTypes,
+    importedCalls: cx.importedCalls,
+    topLevelFunctionValues: cx.topLevelFunctionValues,
     classShapes: cx.classShapes,
     resolver: cx.resolver,
     lifted: cx.lifted,

--- a/src/ir/imported-functions.ts
+++ b/src/ir/imported-functions.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Checker-backed resolution for the deliberately narrow imported-function IR
+// slice (#3214 A+B1).  This module is intentionally a leaf: it knows about
+// TypeScript symbols/declarations, but not about selector or lowering state.
+// Both the selector and the overlay planner consume the same resolver so a
+// call cannot be selected under one alias interpretation and lowered under
+// another.
+
+import { ts } from "../ts-api.js";
+
+export interface IrResolvedFunctionTarget {
+  /** Canonical flat key used by the legacy declaration/funcMap pipeline. */
+  readonly targetName: string;
+  readonly declaration: ts.FunctionDeclaration;
+}
+
+export interface IrImportedFunctionResolver {
+  /** Resolve only a default/named ESM import binding to a compiled function. */
+  resolveImportedFunction(node: ts.Identifier): IrResolvedFunctionTarget | undefined;
+  /** Resolve only a direct same-file top-level FunctionDeclaration value. */
+  resolveTopLevelFunctionValue(node: ts.Identifier): IrResolvedFunctionTarget | undefined;
+  /** True for every import binding, including deliberately unsupported forms. */
+  isImportBinding(node: ts.Identifier): boolean;
+}
+
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return ts.canHaveModifiers(node) && !!ts.getModifiers(node)?.some((m) => m.kind === kind);
+}
+
+function canonicalTargetName(declaration: ts.FunctionDeclaration): string | undefined {
+  if (declaration.name) return declaration.name.text;
+  return hasModifier(declaration, ts.SyntaxKind.DefaultKeyword) ? "default" : undefined;
+}
+
+function importClauseOfSpecifier(specifier: ts.ImportSpecifier): ts.ImportClause | undefined {
+  const named = specifier.parent;
+  const clause = named.parent;
+  return ts.isImportClause(clause) ? clause : undefined;
+}
+
+function isAnyImportDeclaration(node: ts.Declaration): boolean {
+  return (
+    ts.isImportSpecifier(node) ||
+    ts.isImportClause(node) ||
+    ts.isNamespaceImport(node) ||
+    ts.isImportEqualsDeclaration(node)
+  );
+}
+
+function isSupportedValueImportDeclaration(node: ts.Declaration): boolean {
+  if (ts.isImportSpecifier(node)) {
+    const clause = importClauseOfSpecifier(node);
+    return node.isTypeOnly !== true && clause?.isTypeOnly !== true;
+  }
+  // The symbol for a default import is declared on its ImportClause.
+  if (ts.isImportClause(node)) return !!node.name && node.isTypeOnly !== true;
+  return false;
+}
+
+/**
+ * Build one realm-wide resolver over the exact source set compileMulti will
+ * emit.  Targets outside this set (package imports, declaration files, ambient
+ * declarations) are external even when the TypeChecker can see their symbol.
+ */
+export function makeIrImportedFunctionResolver(
+  checker: ts.TypeChecker,
+  sourceFiles: readonly ts.SourceFile[],
+): IrImportedFunctionResolver {
+  const sourceSet = new Set(sourceFiles);
+
+  // funcMap remains keyed by a flat canonical name.  More than one body with
+  // the same key is therefore ambiguous for symbolic IR lowering, even when
+  // TypeScript's module namespace would otherwise distinguish them.
+  const canonicalNameCounts = new Map<string, number>();
+  for (const sourceFile of sourceFiles) {
+    for (const statement of sourceFile.statements) {
+      if (!ts.isFunctionDeclaration(statement) || !statement.body) continue;
+      const name = canonicalTargetName(statement);
+      if (name) canonicalNameCounts.set(name, (canonicalNameCounts.get(name) ?? 0) + 1);
+    }
+  }
+
+  const deAlias = (symbol: ts.Symbol | undefined): ts.Symbol | undefined => {
+    if (!symbol) return undefined;
+    let current = symbol;
+    const seen = new Set<ts.Symbol>();
+    for (let depth = 0; depth < 32 && current.flags & ts.SymbolFlags.Alias; depth++) {
+      if (seen.has(current)) return undefined;
+      seen.add(current);
+      try {
+        const next = checker.getAliasedSymbol(current);
+        if (!next || next === current) return undefined;
+        current = next;
+      } catch {
+        return undefined;
+      }
+    }
+    return current.flags & ts.SymbolFlags.Alias ? undefined : current;
+  };
+
+  // Live/reassigned function bindings cannot be represented by a cached ref to
+  // the original funcIdx.  Record canonical symbols, not text, so shadowed
+  // locals and same-named declarations in different modules do not poison one
+  // another.
+  const reassigned = new Set<ts.Symbol>();
+  const noteSymbolWrite = (candidate: ts.Symbol | undefined): void => {
+    const symbol = deAlias(candidate);
+    if (symbol && (symbol.declarations ?? []).some(ts.isFunctionDeclaration)) reassigned.add(symbol);
+  };
+  const noteWrite = (identifier: ts.Identifier): void => {
+    try {
+      noteSymbolWrite(checker.getSymbolAtLocation(identifier));
+    } catch {
+      // An unresolved write has no exact symbol that can safely be recorded.
+    }
+  };
+  const scanAssignmentTargetWrites = (target: ts.Expression): void => {
+    while (
+      ts.isParenthesizedExpression(target) ||
+      ts.isAsExpression(target) ||
+      ts.isTypeAssertionExpression(target) ||
+      ts.isSatisfiesExpression(target) ||
+      ts.isNonNullExpression(target)
+    ) {
+      target = target.expression;
+    }
+
+    if (ts.isIdentifier(target)) {
+      noteWrite(target);
+      return;
+    }
+    if (ts.isBinaryExpression(target) && target.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      // Destructuring defaults write only their left-hand target.  The default
+      // expression is a read/evaluation and must not poison same-named symbols.
+      scanAssignmentTargetWrites(target.left);
+      return;
+    }
+    if (ts.isArrayLiteralExpression(target)) {
+      for (const element of target.elements) {
+        if (ts.isOmittedExpression(element)) continue;
+        scanAssignmentTargetWrites(ts.isSpreadElement(element) ? element.expression : element);
+      }
+      return;
+    }
+    if (ts.isObjectLiteralExpression(target)) {
+      for (const property of target.properties) {
+        if (ts.isShorthandPropertyAssignment(property)) {
+          // getSymbolAtLocation(property.name) is the synthetic object-property
+          // symbol; the checker API below returns the actual assignment target.
+          try {
+            noteSymbolWrite(checker.getShorthandAssignmentValueSymbol(property));
+          } catch {
+            // See noteWrite: an unresolved shorthand cannot certify a target.
+          }
+        } else if (ts.isPropertyAssignment(property)) {
+          scanAssignmentTargetWrites(property.initializer);
+        } else if (ts.isSpreadAssignment(property)) {
+          scanAssignmentTargetWrites(property.expression);
+        }
+      }
+    }
+    // Property/element accesses write a member, not an identifier binding.
+  };
+  const scanBindingNameWrites = (name: ts.BindingName): void => {
+    if (ts.isIdentifier(name)) {
+      noteWrite(name);
+      return;
+    }
+    for (const element of name.elements) {
+      if (!ts.isOmittedExpression(element)) scanBindingNameWrites(element.name);
+    }
+  };
+  const scanWrites = (node: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+    ) {
+      scanAssignmentTargetWrites(node.left);
+    } else if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken)
+    ) {
+      scanAssignmentTargetWrites(node.operand);
+    } else if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+      if (ts.isVariableDeclarationList(node.initializer)) {
+        // A declaration usually introduces a distinct loop binding, but a
+        // same-scope `var` may merge with and overwrite a function declaration.
+        // Symbol comparison in noteWrite distinguishes those cases.
+        for (const declaration of node.initializer.declarations) scanBindingNameWrites(declaration.name);
+      } else {
+        scanAssignmentTargetWrites(node.initializer);
+      }
+    }
+    ts.forEachChild(node, scanWrites);
+  };
+  for (const sourceFile of sourceFiles) scanWrites(sourceFile);
+
+  const targetForSymbol = (symbol: ts.Symbol | undefined): IrResolvedFunctionTarget | undefined => {
+    const target = deAlias(symbol);
+    if (!target || reassigned.has(target)) return undefined;
+    const declarations = target.declarations ?? [];
+    const functions = declarations.filter(ts.isFunctionDeclaration);
+    // Overload sets and declaration merging are outside this exact slice.  A
+    // single implementation plus one or more overload signatures is still an
+    // overload set, so require exactly one FunctionDeclaration total.
+    if (functions.length !== 1) return undefined;
+    const declaration = functions[0]!;
+    if (
+      !declaration.body ||
+      declaration.getSourceFile().isDeclarationFile ||
+      !sourceSet.has(declaration.getSourceFile()) ||
+      hasModifier(declaration, ts.SyntaxKind.DeclareKeyword)
+    ) {
+      return undefined;
+    }
+    // A different valueDeclaration means the symbol is merged/ambiguous even
+    // when only one FunctionDeclaration happened to appear in declarations.
+    if (target.valueDeclaration && target.valueDeclaration !== declaration) return undefined;
+    const targetName = canonicalTargetName(declaration);
+    if (!targetName || canonicalNameCounts.get(targetName) !== 1) return undefined;
+    return { targetName, declaration };
+  };
+
+  const symbolAt = (node: ts.Identifier): ts.Symbol | undefined => {
+    try {
+      return checker.getSymbolAtLocation(node);
+    } catch {
+      return undefined;
+    }
+  };
+
+  const importDeclarations = (node: ts.Identifier): readonly ts.Declaration[] => symbolAt(node)?.declarations ?? [];
+
+  return {
+    resolveImportedFunction(node) {
+      const symbol = symbolAt(node);
+      if (!symbol) return undefined;
+      const declarations = symbol.declarations ?? [];
+      // Namespace imports, import-equals, type-only imports, and identifiers
+      // that merely happen to share an imported name are never direct-call
+      // evidence.
+      if (!declarations.some(isSupportedValueImportDeclaration)) return undefined;
+      if (declarations.some((d) => isAnyImportDeclaration(d) && !isSupportedValueImportDeclaration(d))) {
+        return undefined;
+      }
+      return targetForSymbol(symbol);
+    },
+
+    resolveTopLevelFunctionValue(node) {
+      const target = targetForSymbol(symbolAt(node));
+      if (!target) return undefined;
+      const sourceFile = node.getSourceFile();
+      if (target.declaration.getSourceFile() !== sourceFile) return undefined;
+      if (!sourceFile.statements.some((statement) => statement === target.declaration)) return undefined;
+      return target;
+    },
+
+    isImportBinding(node) {
+      return importDeclarations(node).some(isAnyImportDeclaration);
+    },
+  };
+}

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -77,6 +77,8 @@ import {
   lowerFunctionAstToIr,
   STRING_METHOD_TABLE,
   type IrFromAstResolver,
+  type IrImportedCallLoweringPlan,
+  type IrTopLevelFunctionValueLoweringPlan,
   type ModuleBindingGlobal,
 } from "./from-ast.js";
 import {
@@ -158,12 +160,19 @@ export interface IrTypeOverrideMap {
   get(name: string): { readonly params: readonly IrType[]; readonly returnType: IrType | null } | undefined;
 }
 
+/** Exact AST-node plans shared by selection and AST-to-IR lowering. */
+export interface IrIntegrationLoweringPlans {
+  readonly importedCalls: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
+  readonly topLevelFunctionValues: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
+}
+
 export function compileIrPathFunctions(
   ctx: CodegenContext,
   sourceFile: ts.SourceFile,
   selection?: IrSelection,
   overrides?: IrTypeOverrideMap,
   classShapes?: ReadonlyMap<string, IrClassShape>,
+  loweringPlans?: IrIntegrationLoweringPlans,
 ): IrIntegrationReport {
   const moduleBindingResolver = makeIrModuleBindingResolver(ctx.checker, {
     numberStorage: ctx.fast ? "i32" : "f64",
@@ -304,6 +313,8 @@ export function compileIrPathFunctions(
         paramTypeOverrides: o?.params,
         returnTypeOverride: o?.returnType,
         calleeTypes,
+        importedCalls: loweringPlans?.importedCalls,
+        topLevelFunctionValues: loweringPlans?.topLevelFunctionValues,
         classShapes,
         // Slice 6 part 4 refactor (#1185): thread the from-ast subset
         // of the IR resolver. Replaces the per-feature `nativeStrings:
@@ -440,6 +451,8 @@ export function compileIrPathFunctions(
               ? { constructorClassShape: classShape }
               : { selfParam: { type: { kind: "class", shape: classShape } as IrType }, returnTypeOverride }),
             calleeTypes,
+            importedCalls: loweringPlans?.importedCalls,
+            topLevelFunctionValues: loweringPlans?.topLevelFunctionValues,
             classShapes,
             resolver: fromAstResolver,
             allocRegistry,
@@ -528,6 +541,8 @@ export function compileIrPathFunctions(
         moduleInitUnit: true,
         moduleBindings,
         calleeTypes,
+        importedCalls: loweringPlans?.importedCalls,
+        topLevelFunctionValues: loweringPlans?.topLevelFunctionValues,
         classShapes,
         resolver: fromAstResolver,
         allocRegistry,

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -686,6 +686,8 @@ export type IrBinop =
  */
 export type IrUnop =
   | "f64.neg"
+  // (#3214 A) Bit-exact caller-side sNaN sentinel for expression defaults.
+  | "f64.reinterpret_i64"
   | "i32.eqz"
   | "i32.trunc_sat_f64_s"
   // (#3168) boolean → f64 ToNumber for unary `+`/`-` (§7.1.4: false/true →

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -58,7 +58,8 @@ import { ts, forEachChild } from "../ts-api.js";
 // (#1373b C-1) Pure-syntactic async helpers from the LEAF module (safe for
 // ir/* — async-static.ts imports only ts-api, so no codegen/index cycle).
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
-import type { IrClosureSignature, IrType } from "./nodes.js";
+import { closureSignatureEquals, type IrClosureSignature, type IrType } from "./nodes.js";
+import type { IrImportedFunctionResolver, IrResolvedFunctionTarget } from "./imported-functions.js";
 
 import { binaryOpCapability, hostExternCapability, prefixOpCapability } from "./capability.js";
 import type {
@@ -376,6 +377,13 @@ export interface IrSelectionOptions {
    * default (undefined ⇒ true) is correct for the default-host fallback path.
    */
   readonly dynMemberReadBuildable?: boolean;
+  /**
+   * (#3214 A+B1) Realm-wide, checker-backed imported-function resolution.
+   * Present only for host/component multi-file compilation.  Bare selector
+   * callers and standalone/WASI intentionally omit it, preserving the
+   * pre-slice conservative boundary.
+   */
+  readonly importedFunctions?: IrImportedFunctionResolver;
 }
 
 /**
@@ -764,19 +772,11 @@ export function planIrCompilation(
   //     bodies are rejected up front by the body-shape work (#2856/#2857).
   // -------------------------------------------------------------------------
   const demoteOnLegacyCaller = options?.jsHostExterns !== true;
-  // #2858 host-mode narrowing (BANKED 2026-07-06 regression fix). #3214 B0 now
-  // makes a legacy caller and IR callee ABI-compatible for function-typed
-  // parameters: both cross the boundary as externref and unpack through the
-  // canonical wrapper root. Keep this callable-param caller demotion for B0
-  // anyway to freeze the selector claim set. Function-valued argument lowering
-  // (inline arrows and named top-level functions) belongs to follow-up A; that
-  // slice can deliberately remove this conservative gate with its own coverage.
-  // Value-param leaves retain the existing host-mode relaxation.
-  const hasCallableParam = (name: string): boolean => {
-    const fn = declByName.get(name);
-    if (!fn) return false;
-    return fn.parameters.some((p) => p.type !== undefined && ts.isFunctionTypeNode(p.type));
-  };
+  // #3214 A+B1 — B0 made an exact FunctionTypeNode source boundary use the
+  // canonical externref callable ABI in both front-ends.  Host mode can now use
+  // the same caller-direction relaxation for callable-param functions as for
+  // scalar leaves. Standalone/WASI retain the conservative closure until B1 is
+  // explicitly implemented for their carrier/runtime.
   const { callers, callees, hasExternalCall } = buildLocalCallGraph(declByName, localClasses);
 
   const claimed = new Set(individuallyClaimed);
@@ -797,10 +797,8 @@ export function planIrCompilation(
     for (const name of [...claimed]) {
       const myCallees = callees.get(name) ?? new Set<string>();
       let safe = true;
-      // Caller-direction demotion: always in standalone/wasi (#2858), and in
-      // host mode only for functions with a callable param (B0 scope freeze;
-      // see `hasCallableParam` above).
-      if (demoteOnLegacyCaller || hasCallableParam(name)) {
+      // Caller-direction demotion remains only in standalone/wasi (#2858).
+      if (demoteOnLegacyCaller) {
         const myCallers = callers.get(name) ?? new Set<string>();
         for (const c of myCallers) {
           if (!claimed.has(c)) {
@@ -1356,6 +1354,123 @@ export function irClosureSignatureFromFunctionTypeNode(node: ts.FunctionTypeNode
   const returnType = prim(node.type);
   if (!returnType) return null;
   return { params, returnType };
+}
+
+/**
+ * Exact callback signature for a bare top-level FunctionDeclaration value.
+ * B1 deliberately requires explicit primitive annotations and ordinary,
+ * fixed-arity functions: no inference, generators/async, generics,
+ * optional/rest/default parameters, destructuring, or callable/void results.
+ */
+export function irClosureSignatureFromFunctionDeclaration(
+  declaration: ts.FunctionDeclaration,
+): IrClosureSignature | null {
+  if (
+    !declaration.body ||
+    declaration.asteriskToken ||
+    (declaration.typeParameters?.length ?? 0) > 0 ||
+    declaration.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)
+  ) {
+    return null;
+  }
+  const params: IrType[] = [];
+  for (const parameter of declaration.parameters) {
+    if (
+      !ts.isIdentifier(parameter.name) ||
+      parameter.questionToken ||
+      parameter.dotDotDotToken ||
+      parameter.initializer
+    ) {
+      return null;
+    }
+    const type = effectiveIrParamTypeNode(parameter);
+    if (!type) return null;
+    if (type.kind === ts.SyntaxKind.NumberKeyword) params.push({ kind: "val", val: { kind: "f64" } });
+    else if (type.kind === ts.SyntaxKind.BooleanKeyword) params.push({ kind: "val", val: { kind: "i32" } });
+    else if (type.kind === ts.SyntaxKind.StringKeyword) params.push({ kind: "string" });
+    else return null;
+  }
+  const resultNode = effectiveIrReturnTypeNode(declaration);
+  let returnType: IrType;
+  if (resultNode?.kind === ts.SyntaxKind.NumberKeyword) returnType = { kind: "val", val: { kind: "f64" } };
+  else if (resultNode?.kind === ts.SyntaxKind.BooleanKeyword) returnType = { kind: "val", val: { kind: "i32" } };
+  else if (resultNode?.kind === ts.SyntaxKind.StringKeyword) returnType = { kind: "string" };
+  else return null;
+  return { params, returnType };
+}
+
+export interface IrImportedFunctionArgumentCertification {
+  readonly argument: ts.Identifier;
+  readonly target: IrResolvedFunctionTarget;
+  readonly signature: IrClosureSignature;
+}
+
+export interface IrImportedCallCertification {
+  readonly call: ts.CallExpression;
+  readonly target: IrResolvedFunctionTarget;
+  readonly functionArguments: readonly IrImportedFunctionArgumentCertification[];
+}
+
+/**
+ * Certify the exact cross-file direct-call surface shared by selection and
+ * overlay planning.  Ordinary arguments are left to `isPhase1Expr`; this
+ * helper owns only the imported callee/arity contract and the B1 exception for
+ * a bare same-file top-level FunctionDeclaration in an exact FunctionTypeNode
+ * parameter position.
+ */
+export function certifyImportedIrCall(
+  call: ts.CallExpression,
+  resolver: IrImportedFunctionResolver | undefined,
+): IrImportedCallCertification | undefined {
+  if (
+    !resolver ||
+    call.questionDotToken ||
+    (call.typeArguments?.length ?? 0) > 0 ||
+    !ts.isIdentifier(call.expression) ||
+    call.arguments.some(ts.isSpreadElement)
+  ) {
+    return undefined;
+  }
+  const target = resolver.resolveImportedFunction(call.expression);
+  if (!target) return undefined;
+  const declaration = target.declaration;
+  const returnNode = effectiveIrReturnTypeNode(declaration);
+  if (
+    !declaration.body ||
+    declaration.asteriskToken ||
+    (declaration.typeParameters?.length ?? 0) > 0 ||
+    declaration.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ||
+    declaration.parameters.some((p) => p.dotDotDotToken || !ts.isIdentifier(p.name)) ||
+    (returnNode !== undefined && ts.isFunctionTypeNode(returnNode))
+  ) {
+    return undefined;
+  }
+  if (call.arguments.length > declaration.parameters.length) return undefined;
+  for (let i = call.arguments.length; i < declaration.parameters.length; i++) {
+    const parameter = declaration.parameters[i]!;
+    if (!parameter.questionToken && !parameter.initializer) return undefined;
+  }
+
+  const functionArguments: IrImportedFunctionArgumentCertification[] = [];
+  for (let i = 0; i < call.arguments.length; i++) {
+    const argument = call.arguments[i]!;
+    const parameter = declaration.parameters[i]!;
+    const parameterType = effectiveIrParamTypeNode(parameter);
+    if (!parameterType || !ts.isFunctionTypeNode(parameterType)) continue;
+    // A supplied callback is B1 only when it is the exact bare declaration
+    // value. Arrows, aliases, stored values, and widened callable types stay on
+    // legacy. Optional/default callback parameters may be omitted, but a
+    // present callback parameter itself must be the exact required shape.
+    if (parameter.questionToken || parameter.initializer || !ts.isIdentifier(argument)) {
+      return undefined;
+    }
+    const expected = irClosureSignatureFromFunctionTypeNode(parameterType);
+    const functionTarget = resolver.resolveTopLevelFunctionValue(argument);
+    const actual = functionTarget ? irClosureSignatureFromFunctionDeclaration(functionTarget.declaration) : null;
+    if (!expected || !functionTarget || !actual || !closureSignatureEquals(actual, expected)) return undefined;
+    functionArguments.push({ argument, target: functionTarget, signature: actual });
+  }
+  return { call, target, functionArguments };
 }
 
 function resolveParamType(p: ts.ParameterDeclaration, mapped: LatticeType | undefined): ResolvedKind {
@@ -4012,6 +4127,20 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     if (currentAsyncDeclNames.has(expr.expression.text) && !scope.has(expr.expression.text)) {
       return shapeNo("expr-async-callee-not-awaited", expr);
     }
+    // (#3214 A+B1) A checker-certified imported direct call is a stable
+    // in-module funcMap target, not an external call.  Bare top-level function
+    // identifiers are accepted ONLY at the exact FunctionTypeNode argument
+    // positions certified by the shared helper; ordinary arguments still
+    // recurse through the complete Phase-1 shape checker.
+    const imported = certifyImportedIrCall(expr, currentSelectionOptions?.importedFunctions);
+    if (imported) {
+      const functionArgs = new Set<ts.Expression>(imported.functionArguments.map((entry) => entry.argument));
+      for (const arg of expr.arguments) {
+        if (functionArgs.has(arg)) continue;
+        if (!isPhase1Expr(arg, scope, localClasses)) return false;
+      }
+      return true;
+    }
     for (const arg of expr.arguments) {
       // Slice 8a (#1169g): accept `f(...source)` where the spread source
       // is an ArrayLiteralExpression with no nested spread. The lowerer
@@ -4565,6 +4694,14 @@ function buildLocalCallGraph(
       }
       if (ts.isCallExpression(node)) {
         if (ts.isIdentifier(node.expression)) {
+          const imported = certifyImportedIrCall(node, currentSelectionOptions?.importedFunctions);
+          if (imported) {
+            // Imported direct calls are neither local graph edges nor external
+            // calls. Walk arguments so nested calls retain their own graph
+            // classification; the imported callee identifier itself is inert.
+            for (const argument of node.arguments) visit(argument);
+            return;
+          }
           const callee = node.expression.text;
           if (decls.has(callee)) {
             callees.get(callerName)!.add(callee);

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -1120,6 +1120,7 @@ function binopOperandKind(op: import("./nodes.js").IrBinop): ValType["kind"] | n
 function unopResultKind(op: import("./nodes.js").IrUnop): ValType["kind"] | null {
   switch (op) {
     case "f64.neg":
+    case "f64.reinterpret_i64":
     // (#3168) boolean → f64 ToNumber for unary `+`/`-`.
     case "f64.convert_i32_s":
       return "f64";
@@ -1139,6 +1140,8 @@ function unopOperandKind(op: import("./nodes.js").IrUnop): ValType["kind"] | nul
     case "f64.neg":
     case "i32.trunc_sat_f64_s":
       return "f64";
+    case "f64.reinterpret_i64":
+      return "i64";
     case "i32.eqz":
     // (#3168) the boolean-ToNumber conversion consumes the i32 0/1.
     case "f64.convert_i32_s":

--- a/tests/issue-2138-multi-module-ir-overlay.test.ts
+++ b/tests/issue-2138-multi-module-ir-overlay.test.ts
@@ -2,8 +2,9 @@
 //
 // #2138 M0 — bounded multi-module IR overlay. Multi-source WasmGC compiles
 // legacy bodies first, then lets IR replace only unambiguous top-level function
-// slots. Cross-file imports, class members, module init, and IR-first body
-// skipping remain legacy-owned until their dedicated capabilities land.
+// slots. #3214 A+B1 additionally admits checker-certified host imported direct
+// calls (including exact bare top-level callbacks). Class members, module init,
+// and IR-first body skipping remain legacy-owned.
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -57,7 +58,7 @@ async function instantiate(result: CompileResult): Promise<Record<string, (...ar
 }
 
 describe("#2138 M0 — multi-module top-level IR overlay", () => {
-  it("IR-emits pure functions in dependency and entry while imported calls and module init stay legacy", async () => {
+  it("IR-emits pure functions and certified imported calls while module init stays legacy", async () => {
     const ir = await compileMulti(MULTI_FILES, "./entry.ts", { experimentalIR: true });
     const legacy = await compileMulti(MULTI_FILES, "./entry.ts", { experimentalIR: false });
     expectSuccess(ir, "IR multi compile");
@@ -69,9 +70,9 @@ describe("#2138 M0 — multi-module top-level IR overlay", () => {
     expect(compiled.has("depPure")).toBe(true);
     expect(compiled.has("entryPure")).toBe(true);
 
-    // Capability A is not part of M0: the renamed imported call remains an
-    // external selector edge, and module state/module init remain legacy-owned.
-    expect(compiled.has("callRenamed")).toBe(false);
+    // #3214 A+B1: the checker-certified renamed import is now a symbolic IR
+    // call to the existing legacy/IR target slot. Module state/init stay legacy.
+    expect(compiled.has("callRenamed")).toBe(true);
     expect(compiled.has("readInit")).toBe(false);
     expect(compiled.has("initHelper")).toBe(false);
     expect(compiled.has("<module-init>")).toBe(false);
@@ -118,7 +119,9 @@ describe("#2138 M0 — multi-module top-level IR overlay", () => {
     expect(compiled.has("shared")).toBe(false);
     expect(compiled.has("depCaller")).toBe(false);
     expect(compiled.has("entryCaller")).toBe(false);
-    expect(compiled.has("runDep")).toBe(false);
+    // The imported caller itself is safe: it symbolically calls depCaller's
+    // retained legacy slot and does not join the collided local component.
+    expect(compiled.has("runDep")).toBe(true);
     // The guard is component-local, not a blanket shutdown of either file.
     expect(compiled.has("depLeaf")).toBe(true);
     expect(compiled.has("entryLeaf")).toBe(true);
@@ -203,10 +206,10 @@ describe("#2138 M0 — multi-module top-level IR overlay", () => {
       expectSuccess(legacy, `${label} global-script legacy compile`);
 
       const compiled = new Set(ir.irCompiledFuncs ?? []);
-      // `apply` is checker-resolved across source files even though there is no
-      // import declaration. Patching it behind the legacy `callApply` body used
-      // to make the callable wrapper cast trap at runtime.
-      expect(compiled.has("apply"), `${label}: callable target stays legacy`).toBe(false);
+      // B0's canonical callable ABI makes the target itself safe in host mode.
+      // The caller is still outside A+B1 because this global-script edge has no
+      // supported ESM import binding; standalone remains conservative.
+      expect(compiled.has("apply"), `${label}: callable target mode gate`).toBe(label === "host");
       expect(compiled.has("identity"), `${label}: callable-result target stays legacy`).toBe(false);
       expect(compiled.has("callApply"), `${label}: cross-file caller stays legacy`).toBe(false);
       expect(compiled.has("callIdentity"), `${label}: callable-result caller stays legacy`).toBe(false);
@@ -289,7 +292,7 @@ describe("#2138 M0 — multi-module top-level IR overlay", () => {
         const compiled = new Set(result.irCompiledFuncs ?? []);
         expect(compiled.has("depPure"), `${label}: dependency anti-vacuity`).toBe(true);
         expect(compiled.has("entryPure"), `${label}: entry anti-vacuity`).toBe(true);
-        expect(compiled.has("callRenamed"), `${label}: imported caller stays legacy`).toBe(false);
+        expect(compiled.has("callRenamed"), `${label}: imported caller is IR-emitted`).toBe(true);
         expect(compiled.has("initHelper"), `${label}: module-init callee stays legacy`).toBe(false);
         expect(compiled.has("<module-init>"), `${label}: shared module init stays legacy`).toBe(false);
         expect(result.irPostClaimErrors ?? []).toEqual([]);

--- a/tests/issue-3214-imported-hof.test.ts
+++ b/tests/issue-3214-imported-hof.test.ts
@@ -1,0 +1,309 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compileMulti, type CompileOptions, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileGraph(files: Record<string, string>, options: CompileOptions = {}): Promise<CompileResult> {
+  return compileMulti(files, "./entry.ts", {
+    experimentalIR: true,
+    trackFallbacks: true,
+    skipSemanticDiagnostics: true,
+    ...options,
+  });
+}
+
+async function runMain(result: CompileResult): Promise<number> {
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports.main as () => number)();
+}
+
+describe("#3214 A+B1 — imported HOF calls", () => {
+  it("runs a checker-certified imported HOF with one cached bare function value", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `
+        export function apply(fn: () => number): number { return fn() + 1; }
+        export function identical(a: () => number, b: () => number): number {
+          try { return a === b ? 1 : 0; } catch (_) { return 0; }
+        }
+      `,
+      "./entry.ts": `
+        import { apply, identical } from "./hof.ts";
+        function fortyOne(): number { return 41; }
+        export function main(): number { return apply(fortyOne) + identical(fortyOne, fortyOne); }
+      `,
+    });
+
+    expect(await runMain(result)).toBe(43);
+    expect(result.irCompiledFuncs ?? []).toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat.match(/\(global \$__fn_closure_fortyOne\b/g)).toHaveLength(1);
+  });
+
+  it("demotes safely when a user function occupies the cached trampoline name", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `export function apply(fn: () => number): number { return fn() + 1; }`,
+      "./entry.ts": `
+        import { apply } from "./hof.ts";
+        function fortyOne(): number { return 41; }
+        function __fn_tramp_fortyOne_cached(): number { return -1; }
+        export function main(): number { return apply(fortyOne); }
+      `,
+    });
+
+    expect(await runMain(result)).toBe(42);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).not.toContain("(global $__fn_closure_fortyOne");
+  });
+
+  it("seeds a reassigned live function through the per-site fallback on collision", async () => {
+    const result = await compileGraph({
+      "./entry.ts": `
+        function value(): number { return 41; }
+        function __fn_tramp_value_cached(): number { return -1; }
+        export function main(): number {
+          const before: any = value;
+          value = function (): number { return 1; };
+          return before() + (value as any)();
+        }
+      `,
+    });
+
+    expect(await runMain(result)).toBe(42);
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.wat).not.toContain("(global $__fn_closure_value");
+  });
+
+  it.each([
+    ["renamed", `import { apply as run } from "./barrel.ts";`, "run"],
+    ["default", `import run from "./barrel.ts";`, "run"],
+  ] as const)("resolves %s imports through a barrel", async (_label, importLine, callee) => {
+    const result = await compileGraph({
+      "./hof.ts": `export default function (fn: () => number): number { return fn() + 1; }`,
+      "./barrel.ts": `export { default, default as apply } from "./hof.ts";`,
+      "./entry.ts": `
+        ${importLine}
+        function fortyOne(): number { return 41; }
+        export function main(): number { return ${callee}(fortyOne); }
+      `,
+    });
+
+    expect(await runMain(result)).toBe(42);
+    expect(result.irCompiledFuncs ?? []).toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each([false, true])("preserves void calls and constant defaults (optimize=%s)", async (optimize) => {
+    const result = await compileGraph(
+      {
+        "./hof.ts": `
+          export function apply(fn: () => number, add: number = 1): number { return fn() + add; }
+          export function consume(fn: () => number): void { fn(); }
+        `,
+        "./entry.ts": `
+          import { apply, consume } from "./hof.ts";
+          function fortyOne(): number { return 41; }
+          export function main(): number { consume(fortyOne); return apply(fortyOne); }
+        `,
+      },
+      { optimize },
+    );
+
+    expect(await runMain(result)).toBe(42);
+    expect(result.irCompiledFuncs ?? []).toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("preserves wrapped imported void-call effects in final and loop early returns", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `
+        export function consume(fn: () => number): void { fn(); }
+      `,
+      "./entry.ts": `
+        import { consume } from "./hof.ts";
+        let total: number = 0;
+        function bump(): number { total += 21; return total; }
+        function finalReturn(): void { return (void consume(bump)); }
+        function loopEarlyReturn(): void {
+          while (true) { return ((consume(bump))); }
+          return;
+        }
+        function conditionalReturn(flag: boolean): void {
+          return flag ? consume(bump) : consume(bump);
+        }
+        export function main(): number {
+          finalReturn();
+          loopEarlyReturn();
+          conditionalReturn(true);
+          return total;
+        }
+      `,
+    });
+
+    expect(await runMain(result)).toBe(63);
+    expect(result.irCompiledFuncs ?? []).toEqual(
+      expect.arrayContaining(["finalReturn", "loopEarlyReturn", "conditionalReturn"]),
+    );
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("rejects an imported void result used by a value composite before claiming", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `export function consume(fn: () => number): void { fn(); }`,
+      "./entry.ts": `
+        import { consume } from "./hof.ts";
+        function value(): number { return 41; }
+        export function main(): number { return !consume(value) ? 42 : 0; }
+      `,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps fast-mode numeric imported HOF calls representation-safe", async () => {
+    const result = await compileGraph(
+      {
+        "./hof.ts": `
+          export function apply(fn: (value: number) => number, value: number): number {
+            return fn(value) + 1;
+          }
+        `,
+        "./entry.ts": `
+          import { apply } from "./hof.ts";
+          function double(value: number): number { return value * 2; }
+          export function main(): number { return apply(double, 20) + 1; }
+        `,
+      },
+      { fast: true },
+    );
+
+    expect(await runMain(result)).toBe(42);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("preserves expression-default sentinels, host undefined, and arguments.length", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `
+        function one(): number { return 1; }
+        export function expressionDefault(fn: () => number, add: number = one()): number {
+          return arguments.length * 10 + fn() + add;
+        }
+        export function optionalLabel(fn: () => number, label?: string): number {
+          return arguments.length * 100 + (label === undefined ? fn() + 1 : 0);
+        }
+      `,
+      "./entry.ts": `
+        import { expressionDefault, optionalLabel } from "./hof.ts";
+        function fortyOne(): number { return 41; }
+        export function main(): number {
+          return expressionDefault(fortyOne) + optionalLabel(fortyOne);
+        }
+      `,
+    });
+
+    expect(await runMain(result)).toBe(194);
+    expect(result.irCompiledFuncs ?? []).toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.imports.some((entry) => entry.name === "__get_undefined")).toBe(true);
+  });
+
+  it.each([
+    [
+      "namespace import",
+      `import * as hof from "./hof.ts"; function fortyOne(): number { return 41; } export function main(): number { return hof.apply(fortyOne); }`,
+    ],
+    [
+      "stored import",
+      `import { apply } from "./hof.ts"; const stored = apply; function fortyOne(): number { return 41; } export function main(): number { return stored(fortyOne); }`,
+    ],
+    [
+      "arrow callback",
+      `import { apply } from "./hof.ts"; export function main(): number { return apply((): number => 41); }`,
+    ],
+    [
+      "reassigned callback",
+      `import { apply } from "./hof.ts"; function value(): number { return 41; } value = function (): number { return 40; }; export function main(): number { return apply(value); }`,
+    ],
+    [
+      "spread arguments",
+      `import { apply } from "./hof.ts"; function value(): number { return 41; } export function main(): number { return apply(...[value]); }`,
+    ],
+    [
+      "extra arguments",
+      `import { apply } from "./hof.ts"; function value(): number { return 41; } export function main(): number { return apply(value, 1); }`,
+    ],
+  ] as const)("rejects %s before claiming", async (_label, entry) => {
+    const result = await compileGraph({
+      "./hof.ts": `export function apply(fn: () => number): number { return fn() + 1; }`,
+      "./entry.ts": entry,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("rejects an imported overload set before claiming", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `
+        function apply(fn: () => number): number;
+        function apply(fn: () => number): number { return fn() + 1; }
+        export { apply };
+      `,
+      "./entry.ts": `
+        import { apply } from "./hof.ts";
+        function fortyOne(): number { return 41; }
+        export function main(): number { return apply(fortyOne); }
+      `,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("rejects an imported live/reassigned target before claiming", async () => {
+    const result = await compileGraph({
+      "./hof.ts": `
+        export function apply(fn: () => number): number { return fn() + 1; }
+        [apply] = [function (fn: () => number): number { return fn() + 2; }];
+      `,
+      "./entry.ts": `
+        import { apply } from "./hof.ts";
+        function fortyOne(): number { return 41; }
+        export function main(): number { return apply(fortyOne); }
+      `,
+    });
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps the imported-function widening disabled for standalone", async () => {
+    const result = await compileGraph(
+      {
+        "./hof.ts": `export function apply(fn: () => number): number { return fn() + 1; }`,
+        "./entry.ts": `
+          import { apply } from "./hof.ts";
+          function fortyOne(): number { return 41; }
+          export function main(): number { return apply(fortyOne); }
+        `,
+      },
+      { target: "standalone" },
+    );
+
+    expect(await runMain(result)).toBe(42);
+    expect(result.irCompiledFuncs ?? []).not.toContain("main");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve exact imported named, default, and barrel bindings for IR overlay planning
- lower supported imported higher-order calls through the canonical callable ABI
- preserve closure identity, default arguments, argc, undefined returns, and safe legacy fallback behavior
- ratchet body-shape fallbacks from 12 to 5 and document the remaining slices in plan/issues/3214-ir-first-class-function-values.md

## Validation

- pnpm exec vitest run tests/issue-3214-imported-hof.test.ts tests/issue-3214-callable-abi.test.ts tests/issue-2138-multi-module-ir-overlay.test.ts (37 passed)
- pnpm exec tsc --noEmit --incremental false
- pnpm run check:ir-fallbacks
- pnpm run lint
- pnpm run format:check

Tracking is maintained in repository markdown files; this PR does not close a GitHub Issue.