### PR TITLE
feat(ir): lower ambient void event callbacks

### DIFF
--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -1440,12 +1440,15 @@ module-unique.
 The gate ratchets function-level `body-shape-rejected` **5 -> 4** with zero
 post-claim demotions. The exact remaining histogram is calendar `renderCal`,
 `onDay`, and `main`, plus async `delay`; module-level remains **2** and deferred
-async functions remain **4**. The 22-test B2 suite covers optimized and
+async functions remain **4**. The 23-test B2 suite covers optimized and
 unoptimized runtime dispatch, callback identity/undefined/nonconstructibility,
 unchanged legacy positive-id dispatch, IR shape, strict negatives including
 symbol-vs-spelling capture ambiguity including destructured bindings,
 cross-source name safety, maker/lifted collision demotion, and standalone
-containment. Calendar and Promise/async executor shapes are unchanged.
+containment. A replay regression additionally keeps any local call component
+containing a planned B2 owner out of the IR-first skip set until final-context
+maker/lifted-name proofs complete, preventing skipped-body placeholders after a
+safe demotion. Calendar and Promise/async executor shapes are unchanged.
 
 ### Ordering and landability
 

--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -1423,6 +1423,30 @@ re-bucketing `delay`'s reject to `deferred` with a recorded rationale**
 (flag to PO) rather than forcing an unsound claim — the corpus must not
 dictate an unshippable capability.
 
+#### B2 result (2026-07-21) — one ambient void event callback
+
+The measured slice is intentionally narrower than the general arrow-value
+forecast above. It checker-certifies exactly one direct, discarded ambient
+`addEventListener(type, () => { ... })` site per top-level owner, with a
+zero-parameter synchronous block-bodied void arrow, strict lexical/nesting
+guards, and symbol-proven readonly captures. Lowering reuses B0's canonical
+callable pack and crosses the host boundary through the existing
+`__make_callback` import using sentinel `-1`; the runtime produces a cached,
+nonconstructible JS arrow that returns `undefined` and ignores event arguments.
+Single and multi overlays both validate the final import name/signature and the
+deterministic lifted-name slot before claim, while captured subtype names are
+module-unique.
+
+The gate ratchets function-level `body-shape-rejected` **5 -> 4** with zero
+post-claim demotions. The exact remaining histogram is calendar `renderCal`,
+`onDay`, and `main`, plus async `delay`; module-level remains **2** and deferred
+async functions remain **4**. The 22-test B2 suite covers optimized and
+unoptimized runtime dispatch, callback identity/undefined/nonconstructibility,
+unchanged legacy positive-id dispatch, IR shape, strict negatives including
+symbol-vs-spelling capture ambiguity including destructured bindings,
+cross-source name safety, maker/lifted collision demotion, and standalone
+containment. Calendar and Promise/async executor shapes are unchanged.
+
 ### Ordering and landability
 
 1. Step 0 (landed) → 2. Capability C (landed, measured −1) → 3. builtins

--- a/plan/issues/3214-ir-first-class-function-values.md
+++ b/plan/issues/3214-ir-first-class-function-values.md
@@ -315,18 +315,21 @@ It validates the actual function-import ordinal as exactly
 `<owner>__closure_0` before integration, and closes the affected local call
 component. Captured IR subtype names allocate against the module-wide struct
 registry, so separate source overlays and user structs cannot reuse or
-overwrite `__ir_closure_N`.
+overwrite `__ir_closure_N`. Because those final proofs require the completed
+legacy import/function registries, every selected local call component that
+contains a planned B2 owner remains compile-twice under IR-first; a later safe
+demotion can therefore never expose an unreachable skipped-body placeholder.
 
 ### Measured result
 
-- `tests/issue-3214-void-host-callback.test.ts`: **22/22**. Runtime dispatch
+- `tests/issue-3214-void-host-callback.test.ts`: **23/23**. Runtime dispatch
   twice, sentinel identity/cache, distinct-closure identity, `undefined`,
   arity zero, `Reflect.construct` rejection, and unchanged positive-id legacy
   dispatch; optimized/unoptimized genuine IR execution; exact
   `-1`/maker/zero-result shape; strict pre-claim negatives including
   symbol-vs-spelling capture ambiguity (including destructured bindings);
   wrong maker/lifted-name collision demotion; cross-source subtype uniqueness;
-  and standalone containment.
+  IR-first skipped-slot containment; and standalone containment.
 - The production gate genuinely IR-emits `addBenchCard` and ratchets
   `body-shape-rejected` **5 -> 4**. Module-level remains **2**, async-function
   remains **4**, and every post-claim bucket remains zero.

--- a/plan/issues/3214-ir-first-class-function-values.md
+++ b/plan/issues/3214-ir-first-class-function-values.md
@@ -26,9 +26,16 @@ loc-budget-allow:
   - src/ir/builder.ts
   - src/codegen/expressions/calls-closures.ts
   - src/ir/integration.ts
+  - src/ir/host-extern.ts
+  - src/ir/analysis/linear-memory-plan.ts
+  - src/ir/passes/monomorphize.ts
   - src/codegen/expressions/call-tail-dispatch.ts
   - src/codegen/async-scheduler.ts
   - src/codegen/expressions/calls.ts
+  - src/runtime.ts
+  - scripts/check-ir-fallbacks.ts
+  - scripts/ir-fallback-baseline.json
+  - tests/issue-3214-void-host-callback.test.ts
 ---
 
 # #3214 — IR: first-class function values
@@ -279,6 +286,54 @@ requires a mode-aware boundary plan rather than an unsafe cast.
   alone could not move the bucket: the prerequisite imported-call and host DOM
   capabilities now exist, so the combined A+B1 slice genuinely unlocks the
   seven benchmark entry functions.
+
+## B2 implementation result — ambient zero-argument void callbacks (2026-07-21)
+
+B2 closes the benchmark helper without widening general arrow arguments. The
+accepted shape is one direct, discarded ambient
+`receiver.addEventListener(type, () => { ... })` call in a top-level function.
+The checker proves the declaration-file method/extern receiver, exactly two
+arguments, a synchronous zero-parameter non-empty block arrow with void result,
+no lexical `this`/`arguments`/`super`/`new.target`, no nested or sibling runtime
+declarations, and symbol-exact readonly captures. User-defined same-name
+methods, options arguments, parameters, concise/async/non-void arrows, mutable
+or later-written captures, and multiple callback sites remain legacy-owned.
+
+The planned arrow lowers to B0's canonical closure family with the new exact
+`{ params: [], returnType: null }` signature; `null` means a zero-result Wasm
+function and is threaded through type equality/keys, the closure registry,
+linear planning, monomorphization, and diagnostics. The extern argument path
+alone packs that closure as the canonical callable carrier and invokes the
+existing `env.__make_callback` import with reserved id `-1`. The runtime sentinel
+returns a cached outer JS arrow, ignores host event arguments, dispatches via
+`__call_fn_0`, explicitly returns `undefined`, and is nonconstructible. Existing
+non-negative legacy `__cb_N` callbacks are unchanged.
+
+Final-context preparation is shared by single- and multi-source compilation.
+It validates the actual function-import ordinal as exactly
+`env.__make_callback: (i32, externref) -> externref`, rejects an occupied
+`<owner>__closure_0` before integration, and closes the affected local call
+component. Captured IR subtype names allocate against the module-wide struct
+registry, so separate source overlays and user structs cannot reuse or
+overwrite `__ir_closure_N`.
+
+### Measured result
+
+- `tests/issue-3214-void-host-callback.test.ts`: **22/22**. Runtime dispatch
+  twice, sentinel identity/cache, distinct-closure identity, `undefined`,
+  arity zero, `Reflect.construct` rejection, and unchanged positive-id legacy
+  dispatch; optimized/unoptimized genuine IR execution; exact
+  `-1`/maker/zero-result shape; strict pre-claim negatives including
+  symbol-vs-spelling capture ambiguity (including destructured bindings);
+  wrong maker/lifted-name collision demotion; cross-source subtype uniqueness;
+  and standalone containment.
+- The production gate genuinely IR-emits `addBenchCard` and ratchets
+  `body-shape-rejected` **5 -> 4**. Module-level remains **2**, async-function
+  remains **4**, and every post-claim bucket remains zero.
+- The four residual body rejections are exactly calendar `renderCal`, `onDay`,
+  and `main`, plus async `delay`. B2 does not widen Calendar, Promise executors,
+  async callbacks, general arrow storage/escape, callback parameters, or
+  multiple host callback sites.
 
 ## Sequenced acceptance criteria
 

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -58,7 +58,7 @@ import { fileURLToPath } from "node:url";
 import { analyzeFiles } from "../src/checker/index.js";
 import { buildTypeMap } from "../src/ir/propagate.js";
 import { planIrCompilation, type IrFallbackReason } from "../src/ir/select.js";
-import { makeIrHostGlobalResolver } from "../src/ir/host-extern.js";
+import { makeIrHostGlobalResolver, makeIrHostVoidCallbackResolver } from "../src/ir/host-extern.js";
 import {
   makeIrDeclaredPrimitiveExpressionClassifier,
   makeIrModuleBindingResolver,
@@ -247,6 +247,7 @@ async function aggregate(): Promise<{
         trackFallbacks: true,
         jsHostExterns: true,
         resolveHostGlobal: makeIrHostGlobalResolver(checker),
+        hostVoidCallbacks: makeIrHostVoidCallbackResolver(checker),
         importedFunctions,
         resolveModuleBinding: makeIrModuleBindingResolver(checker, {
           numberStorage: "f64",

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-07-21",
   "unintended": {
-    "body-shape-rejected": 5
+    "body-shape-rejected": 4
   },
   "deferred": {
     "async-function": 4

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1806,6 +1806,26 @@ function computeIrFirstSkipSet(
       }
     }
   }
+
+  // #3214 B2 final-context preparation runs only AFTER legacy declaration /
+  // import collection, because only then can it prove the actual
+  // `env.__make_callback` slot/signature and deterministic lifted-name slot.
+  // Any B2 owner may therefore still be demoted after this pre-body decision.
+  // Keep its whole selected local call component compile-twice: otherwise a
+  // pure-f64 caller can enter `skip`, final preparation can remove that caller
+  // through bidirectional graph closure, and its unreachable placeholder ships
+  // as an IR-first skipped-slot hard error. Use the exact same component
+  // closure as final preparation, but treat every planned B2 owner as
+  // potentially blocked because final ctx state is deliberately unavailable.
+  if (plan.hostVoidCallbacks.size > 0 && skip.size > 0) {
+    const potentiallyBlockedOwners = new Set(
+      [...plan.hostVoidCallbacks.values()].map((callback) => callback.ownerName),
+    );
+    const retained = closeMultiIrBlockedComponent(_sourceFile, plan.safeSelection, potentiallyBlockedOwners);
+    for (const name of skip) {
+      if (!retained.funcs.has(name)) skip.delete(name);
+    }
+  }
   return skip;
 }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -39,11 +39,12 @@ import {
 } from "../ir/select.js";
 import { makeIrImportedFunctionResolver, type IrImportedFunctionResolver } from "../ir/imported-functions.js";
 import type {
+  IrHostVoidCallbackLoweringPlan,
   IrImportedCallLoweringPlan,
   IrImportedOptionalParamPlan,
   IrTopLevelFunctionValueLoweringPlan,
 } from "../ir/from-ast.js";
-import { makeIrHostGlobalResolver } from "../ir/host-extern.js"; // (#2856)
+import { makeIrHostGlobalResolver, makeIrHostVoidCallbackResolver } from "../ir/host-extern.js"; // (#2856/#3214)
 import {
   makeIrDeclaredPrimitiveExpressionClassifier,
   makeIrModuleBindingResolver,
@@ -1592,6 +1593,8 @@ interface IrOverlayPlan {
   readonly importedCalls: Map<ts.CallExpression, IrImportedCallLoweringPlan>;
   /** Bare same-file function values admitted only at certified HOF positions. */
   readonly topLevelFunctionValues: Map<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
+  /** Exact ambient addEventListener void arrows admitted by B2. */
+  readonly hostVoidCallbacks: Map<ts.ArrowFunction, IrHostVoidCallbackLoweringPlan>;
   readonly importedFunctionResolver?: IrImportedFunctionResolver;
 }
 
@@ -1847,6 +1850,7 @@ function planIrOverlay(
         });
   const classifyPrimitiveExpression = makeIrPrimitiveExpressionClassifier(ast.checker);
   const classifyDeclaredPrimitiveExpression = makeIrDeclaredPrimitiveExpressionClassifier(ast.checker);
+  const resolveHostVoidCallback = jsHostExterns ? makeIrHostVoidCallbackResolver(ast.checker) : undefined;
   // (#3053 U2) The gc `__dyn_member_get` body is sound in every config EXCEPT
   // fast host-js-string (`fast && !standalone && !wasi`): there the carrier is
   // the gc `$AnyValue` but strings are host js-string externrefs, so the native
@@ -1863,6 +1867,7 @@ function planIrOverlay(
       jsHostExterns,
       dynMemberReadBuildable,
       resolveHostGlobal: makeIrHostGlobalResolver(ast.checker),
+      ...(resolveHostVoidCallback ? { hostVoidCallbacks: resolveHostVoidCallback } : {}),
       ...(resolveModuleBinding ? { resolveModuleBinding } : {}),
       classifyPrimitiveExpression,
       classifyDeclaredPrimitiveExpression,
@@ -2032,6 +2037,7 @@ function planIrOverlay(
   }
   const importedCalls = new Map<ts.CallExpression, IrImportedCallLoweringPlan>();
   const topLevelFunctionValues = new Map<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>();
+  const hostVoidCallbacks = new Map<ts.ArrowFunction, IrHostVoidCallbackLoweringPlan>();
   if (jsHostExterns && options.importedFunctions) {
     for (const [ownerName, declaration] of declByName) {
       if (!safeSelection.funcs.has(ownerName) || !declaration.body) continue;
@@ -2103,6 +2109,27 @@ function planIrOverlay(
       }
     }
   }
+  if (resolveHostVoidCallback) {
+    for (const [ownerName, declaration] of declByName) {
+      if (!safeSelection.funcs.has(ownerName) || !declaration.body) continue;
+      const visit = (node: ts.Node): void => {
+        if (node !== declaration && ts.isFunctionLike(node)) return;
+        if (ts.isCallExpression(node)) {
+          const certified = resolveHostVoidCallback(node);
+          if (certified) {
+            hostVoidCallbacks.set(certified.callback, {
+              ownerName,
+              signature: { params: [], returnType: null },
+              captureNames: certified.captureNames,
+            });
+            return;
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(declaration.body);
+    }
+  }
   return {
     selection,
     classShapes,
@@ -2112,6 +2139,7 @@ function planIrOverlay(
     declByName,
     importedCalls,
     topLevelFunctionValues,
+    hostVoidCallbacks,
     ...(options.importedFunctions ? { importedFunctionResolver: options.importedFunctions } : {}),
   };
 }
@@ -2374,11 +2402,17 @@ function functionBodyHasUnsupportedImportUse(fn: ts.FunctionDeclaration, plan: I
 }
 
 /** Nested functions mint flat synthetic names that M0 cannot collision-prove. */
-function functionBodyContainsNestedRuntimeDeclaration(fn: ts.FunctionDeclaration): boolean {
+function functionBodyContainsNestedRuntimeDeclaration(fn: ts.FunctionDeclaration, plan: IrOverlayPlan): boolean {
   if (!fn.body) return false;
   let found = false;
   const visit = (node: ts.Node): void => {
     if (found) return;
+    if (ts.isArrowFunction(node) && plan.hostVoidCallbacks.has(node)) {
+      // B2 owns this one synthesized closure. Keep walking its body so a
+      // nested function/class still trips the conservative M0 collision gate.
+      ts.forEachChild(node.body, visit);
+      return;
+    }
     if (
       ts.isFunctionDeclaration(node) ||
       ts.isFunctionExpression(node) ||
@@ -2449,6 +2483,29 @@ function multiIrTargetHasExactRegistryEntry(
   return idx !== undefined && idx >= ctx.numImportFuncs && definedFuncAt(ctx, idx)?.name === targetName;
 }
 
+/** Final-context proof for B2's symbolic `__make_callback` dependency. */
+function hasExactHostVoidCallbackMakerImport(ctx: CodegenContext): boolean {
+  const makerIdx = ctx.funcMap.get("__make_callback");
+  if (makerIdx === undefined || makerIdx < 0 || makerIdx >= ctx.numImportFuncs) return false;
+
+  let functionIndex = 0;
+  for (const imported of ctx.mod.imports) {
+    if (imported.desc.kind !== "func") continue;
+    if (functionIndex++ !== makerIdx) continue;
+    if (imported.module !== "env" || imported.name !== "__make_callback") return false;
+    const type = ctx.mod.types[imported.desc.typeIdx];
+    return (
+      type?.kind === "func" &&
+      type.params.length === 2 &&
+      type.params[0]?.kind === "i32" &&
+      type.params[1]?.kind === "externref" &&
+      type.results.length === 1 &&
+      type.results[0]?.kind === "externref"
+    );
+  }
+  return false;
+}
+
 function closeMultiIrBlockedComponent(
   sourceFile: ts.SourceFile,
   selection: IrSelection,
@@ -2481,6 +2538,36 @@ function closeMultiIrBlockedComponent(
   return { funcs, classMembers: new Set(), moduleInit: undefined };
 }
 
+/**
+ * Apply B2's final-context safety proof after legacy declaration/import
+ * collection. This is shared by single- and multi-file compilation: planning
+ * cannot prove the eventual import slot/signature or whether a user function
+ * occupies the deterministic lifted name.
+ */
+function prepareHostVoidCallbackLowering(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  plan: IrOverlayPlan,
+  selection: IrSelection,
+): IrSelection {
+  const activePlans = [...plan.hostVoidCallbacks.values()].filter((callback) =>
+    selection.funcs.has(callback.ownerName),
+  );
+  if (activePlans.length === 0) return selection;
+
+  const blocked = new Set<string>();
+  if (!hasExactHostVoidCallbackMakerImport(ctx)) {
+    for (const callback of activePlans) blocked.add(callback.ownerName);
+  }
+  for (const callback of activePlans) {
+    const liftedName = `${callback.ownerName}__closure_0`;
+    if (ctx.funcMap.has(liftedName) || ctx.mod.functions.some((fn) => fn.name === liftedName)) {
+      blocked.add(callback.ownerName);
+    }
+  }
+  return blocked.size === 0 ? selection : closeMultiIrBlockedComponent(sourceFile, selection, blocked);
+}
+
 function makeMultiIrSafeSelection(
   ctx: CodegenContext,
   plan: IrOverlayPlan,
@@ -2500,7 +2587,6 @@ function makeMultiIrSafeSelection(
   for (const valuePlan of plan.topLevelFunctionValues.values()) {
     if (!multiIrTargetHasExactRegistryEntry(ctx, valuePlan.targetName, safety)) blocked.add(valuePlan.ownerName);
   }
-
   for (const name of funcs) {
     const declaration = plan.declByName.get(name);
     if (!declaration) {
@@ -2514,7 +2600,7 @@ function makeMultiIrSafeSelection(
     if (
       safety.collisions.has(name) ||
       functionBodyHasUnsupportedImportUse(declaration, plan) ||
-      functionBodyContainsNestedRuntimeDeclaration(declaration) ||
+      functionBodyContainsNestedRuntimeDeclaration(declaration, plan) ||
       (declaration.typeParameters?.length ?? 0) > 0 ||
       safety.importAliasNames.has(name) ||
       safety.occupiedFunctionNameCounts.get(name) !== 1 ||
@@ -3042,8 +3128,13 @@ export function generateModule(
       // planning code verbatim (typeMap → selection → STRICT_IR_REASONS →
       // classShapes → overrideMap → safeSelection → new.target gate).
       const plan = irPlan ?? planIrOverlay(ctx, ast);
-      const { selection, classShapes, overrideMap, safeSelection, trackFallbacks } = plan;
-      const report = compileIrPathFunctions(ctx, ast.sourceFile, safeSelection, overrideMap, classShapes);
+      const { selection, classShapes, overrideMap, trackFallbacks } = plan;
+      const safeSelection = prepareHostVoidCallbackLowering(ctx, ast.sourceFile, plan, plan.safeSelection);
+      const report = compileIrPathFunctions(ctx, ast.sourceFile, safeSelection, overrideMap, classShapes, {
+        importedCalls: plan.importedCalls,
+        topLevelFunctionValues: plan.topLevelFunctionValues,
+        hostVoidCallbacks: plan.hostVoidCallbacks,
+      });
       consumeIrOverlayReport(ctx, report, selection, trackFallbacks, ast.sourceFile.fileName, irSkipBodies);
     }
 
@@ -5199,9 +5290,11 @@ export function generateMultiModule(
         });
         let safeSelection = makeMultiIrSafeSelection(ctx, plan, sourceFile, safety);
         safeSelection = prepareMultiIrImportedLowering(ctx, sourceFile, plan, safeSelection);
+        safeSelection = prepareHostVoidCallbackLowering(ctx, sourceFile, plan, safeSelection);
         const report = compileIrPathFunctions(ctx, sourceFile, safeSelection, plan.overrideMap, plan.classShapes, {
           importedCalls: plan.importedCalls,
           topLevelFunctionValues: plan.topLevelFunctionValues,
+          hostVoidCallbacks: plan.hostVoidCallbacks,
         });
         consumeIrOverlayReport(ctx, report, plan.selection, plan.trackFallbacks, sourceFile.fileName);
       }

--- a/src/ir/analysis/linear-memory-plan.ts
+++ b/src/ir/analysis/linear-memory-plan.ts
@@ -873,7 +873,7 @@ function collectLayoutsFromType(type: IrType, layouts: Map<string, LinearLayoutP
     case "closure":
     case "callable":
       for (const param of type.signature.params) collectLayoutsFromType(param, layouts);
-      collectLayoutsFromType(type.signature.returnType, layouts);
+      if (type.signature.returnType !== null) collectLayoutsFromType(type.signature.returnType, layouts);
       return;
     case "union":
       for (const member of type.members) collectLayoutsFromType(member, layouts);
@@ -946,9 +946,9 @@ function linearIrTypeKey(type: IrType): string {
         .map((field) => `${JSON.stringify(field.name)}=${linearIrTypeKey(field.type)}`)
         .join(";")}`;
     case "closure":
-      return `closure:(${type.signature.params.map(linearIrTypeKey).join(",")})->${linearIrTypeKey(type.signature.returnType)}`;
+      return `closure:(${type.signature.params.map(linearIrTypeKey).join(",")})->${type.signature.returnType === null ? "void" : linearIrTypeKey(type.signature.returnType)}`;
     case "callable":
-      return `callable:(${type.signature.params.map(linearIrTypeKey).join(",")})->${linearIrTypeKey(type.signature.returnType)}`;
+      return `callable:(${type.signature.params.map(linearIrTypeKey).join(",")})->${type.signature.returnType === null ? "void" : linearIrTypeKey(type.signature.returnType)}`;
     case "extern":
       return `extern:${JSON.stringify(type.className)}`;
     case "union":

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -434,6 +434,8 @@ export interface AstToIrOptions {
   readonly importedCalls?: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
   /** (#3214 B1) Exact bare top-level function-value sites, keyed by AST node. */
   readonly topLevelFunctionValues?: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
+  /** (#3214 B2) Exact ambient-host void arrows, keyed by their AST node. */
+  readonly hostVoidCallbacks?: ReadonlyMap<ts.ArrowFunction, IrHostVoidCallbackLoweringPlan>;
   /**
    * Slice 4 (#1169d): map from class name to that class's IR shape
    * (fields + methods + constructor signature). Consulted when lowering
@@ -513,6 +515,12 @@ export interface IrTopLevelFunctionValueLoweringPlan {
   readonly signature: IrClosureSignature;
   readonly trampolineName: string;
   readonly cacheGlobalName: string;
+}
+
+export interface IrHostVoidCallbackLoweringPlan {
+  readonly ownerName: string;
+  readonly signature: IrClosureSignature;
+  readonly captureNames: ReadonlySet<string>;
 }
 
 /**
@@ -749,6 +757,7 @@ export function lowerFunctionAstToIr(
     calleeTypes: options.calleeTypes,
     importedCalls: options.importedCalls,
     topLevelFunctionValues: options.topLevelFunctionValues,
+    hostVoidCallbacks: options.hostVoidCallbacks,
     classShapes: options.classShapes,
     resolver: options.resolver,
     lifted,
@@ -1408,6 +1417,7 @@ interface LowerCtx {
   readonly calleeTypes?: ReadonlyMap<string, { params: readonly IrType[]; returnType: IrType | null }>;
   readonly importedCalls?: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
   readonly topLevelFunctionValues?: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
+  readonly hostVoidCallbacks?: ReadonlyMap<ts.ArrowFunction, IrHostVoidCallbackLoweringPlan>;
   /** Slice 4 (#1169d) — class shape registry, keyed by className. */
   readonly classShapes?: ReadonlyMap<string, IrClassShape>;
   /**
@@ -2361,11 +2371,11 @@ function describeIrType(t: IrType): string {
   }
   if (t.kind === "closure") {
     const ps = t.signature.params.map(describeIrType).join(",");
-    return `closure(${ps})->${describeIrType(t.signature.returnType)}`;
+    return `closure(${ps})->${t.signature.returnType === null ? "void" : describeIrType(t.signature.returnType)}`;
   }
   if (t.kind === "callable") {
     const ps = t.signature.params.map(describeIrType).join(",");
-    return `callable(${ps})->${describeIrType(t.signature.returnType)}`;
+    return `callable(${ps})->${t.signature.returnType === null ? "void" : describeIrType(t.signature.returnType)}`;
   }
   if (t.kind === "class") return `class<${t.shape.className}>`;
   if (t.kind === "extern") return `extern<${t.className}>`;
@@ -4078,6 +4088,9 @@ function lowerClosureCall(
   argExprs: readonly ts.Expression[],
   cx: LowerCtx,
 ): IrValueId {
+  if (signature.returnType === null) {
+    throw new Error(`ir/from-ast: void closure calls are not in value position scope (${cx.funcName})`);
+  }
   if (argExprs.length !== signature.params.length) {
     throw new Error(`ir/from-ast: closure call arity mismatch in ${cx.funcName}`);
   }
@@ -4116,6 +4129,9 @@ function lowerNestedFuncCall(
   argExprs: readonly ts.Expression[],
   cx: LowerCtx,
 ): IrValueId {
+  if (binding.signature.returnType === null) {
+    throw new Error(`ir/from-ast: void nested calls are not in value position scope (${cx.funcName})`);
+  }
   if (argExprs.length !== binding.signature.params.length) {
     throw new Error(`ir/from-ast: nested func call arity mismatch in ${cx.funcName}`);
   }
@@ -4658,7 +4674,34 @@ function lowerMethodCall(expr: ts.CallExpression, cx: LowerCtx, statementPositio
     const args: IrValueId[] = [];
     for (let i = 0; i < expr.arguments.length; i++) {
       const expected = userParams[i]!;
-      const argVal = lowerExpr(expr.arguments[i]!, cx, irVal(expected));
+      const argument = expr.arguments[i]!;
+      const hostCallbackArrow = ts.isArrowFunction(argument) ? argument : undefined;
+      const hostCallbackPlan = hostCallbackArrow ? cx.hostVoidCallbacks?.get(hostCallbackArrow) : undefined;
+      if (hostCallbackPlan && hostCallbackArrow) {
+        if (
+          methodName !== "addEventListener" ||
+          i !== 1 ||
+          expected.kind !== "externref" ||
+          hostCallbackPlan.signature.params.length !== 0 ||
+          hostCallbackPlan.signature.returnType !== null
+        ) {
+          throw new Error(`ir/from-ast: invalid host void callback plan for ${definingClass}.${methodName}`);
+        }
+        const closure = lowerHostVoidCallbackExpression(hostCallbackArrow, hostCallbackPlan, cx);
+        const packed = cx.builder.emitCallablePack(closure, hostCallbackPlan.signature);
+        const sentinel = cx.builder.emitConst({ kind: "i32", value: -1 }, irVal({ kind: "i32" }));
+        const wrapped = cx.builder.emitCall(
+          { kind: "func", name: "__make_callback" },
+          [sentinel, packed],
+          irVal({ kind: "externref" }),
+        );
+        if (wrapped === null) {
+          throw new Error(`ir/from-ast: __make_callback produced no value in ${cx.funcName}`);
+        }
+        args.push(wrapped);
+        continue;
+      }
+      const argVal = lowerExpr(argument, cx, irVal(expected));
       args.push(coerceToExpectedExtern(argVal, expected, cx, `arg ${i} of ${definingClass}.${methodName}`));
     }
     // (#2856) Pad missing OPTIONAL args with default sentinels: the host
@@ -7869,7 +7912,48 @@ function lowerClosureExpression(expr: ts.ArrowFunction | ts.FunctionExpression, 
   const returnType = typeNodeToIr(expr.type, `return type of ${cx.funcName}.<closure>`);
   const signature: IrClosureSignature = { params, returnType };
 
+  return lowerClosureExpressionWithSignature(expr, signature, undefined, cx);
+}
+
+/**
+ * #3214 B2 — materialise the one certified ambient-host callback as a
+ * canonical zero-result IR closure. The checker/selector plan owns the narrow
+ * syntax and readonly-capture proof; this defensive comparison prevents a
+ * stale or node-mismatched plan from widening lowering after selection.
+ */
+function lowerHostVoidCallbackExpression(
+  expr: ts.ArrowFunction,
+  plan: IrHostVoidCallbackLoweringPlan,
+  cx: LowerCtx,
+): IrValueId {
+  if (
+    !ts.isBlock(expr.body) ||
+    expr.parameters.length !== 0 ||
+    plan.signature.params.length !== 0 ||
+    plan.signature.returnType !== null
+  ) {
+    throw new Error(`ir/from-ast: malformed host void callback plan (${cx.funcName})`);
+  }
+  return lowerClosureExpressionWithSignature(expr, plan.signature, plan.captureNames, cx);
+}
+
+function lowerClosureExpressionWithSignature(
+  expr: ts.ArrowFunction | ts.FunctionExpression,
+  signature: IrClosureSignature,
+  expectedReadonlyCaptures: ReadonlySet<string> | undefined,
+  cx: LowerCtx,
+): IrValueId {
   const captures = analyseCaptures(expr, cx);
+  if (expectedReadonlyCaptures) {
+    const actual = new Set(captures.map((capture) => capture.name));
+    if (
+      captures.some((capture) => capture.mutable) ||
+      actual.size !== expectedReadonlyCaptures.size ||
+      [...actual].some((name) => !expectedReadonlyCaptures.has(name))
+    ) {
+      throw new Error(`ir/from-ast: host void callback capture proof diverged (${cx.funcName})`);
+    }
+  }
 
   const liftedName = `${cx.funcName}__closure_${cx.liftedCounter.value++}`;
 
@@ -7970,6 +8054,9 @@ function liftNestedFunction(
   captures: readonly NestedCapture[],
   cx: LowerCtx,
 ): IrFunction {
+  if (signature.returnType === null) {
+    throw new Error(`ir/from-ast: void nested function signatures are outside slice 3 (${liftedName})`);
+  }
   const builder = new IrFunctionBuilder(liftedName, [signature.returnType], false, cx.allocRegistry);
   const scope = new Map<string, ScopeBinding>();
 
@@ -7999,6 +8086,7 @@ function liftNestedFunction(
     calleeTypes: cx.calleeTypes,
     importedCalls: cx.importedCalls,
     topLevelFunctionValues: cx.topLevelFunctionValues,
+    hostVoidCallbacks: cx.hostVoidCallbacks,
     classShapes: cx.classShapes,
     resolver: cx.resolver,
     lifted: cx.lifted,
@@ -8046,7 +8134,12 @@ function liftClosureBody(
   captureFieldTypes: readonly IrType[],
   cx: LowerCtx,
 ): IrFunction {
-  const builder = new IrFunctionBuilder(liftedName, [signature.returnType], false, cx.allocRegistry);
+  const builder = new IrFunctionBuilder(
+    liftedName,
+    signature.returnType === null ? [] : [signature.returnType],
+    false,
+    cx.allocRegistry,
+  );
   const scope = new Map<string, ScopeBinding>();
 
   const selfType: IrType = { kind: "closure", signature };
@@ -8079,6 +8172,7 @@ function liftClosureBody(
     calleeTypes: cx.calleeTypes,
     importedCalls: cx.importedCalls,
     topLevelFunctionValues: cx.topLevelFunctionValues,
+    hostVoidCallbacks: cx.hostVoidCallbacks,
     classShapes: cx.classShapes,
     resolver: cx.resolver,
     lifted: cx.lifted,
@@ -8102,6 +8196,9 @@ function liftClosureBody(
   };
 
   if (ts.isArrowFunction(expr) && !ts.isBlock(expr.body)) {
+    if (signature.returnType === null) {
+      throw new Error(`ir/from-ast: void host callbacks must be block-bodied (${liftedName})`);
+    }
     // Concise body — wrap as `return <expr>`.
     const v = lowerExpr(expr.body, innerCx, signature.returnType);
     if (!irTypeEquals(builder.typeOf(v), signature.returnType)) {

--- a/src/ir/host-extern.ts
+++ b/src/ir/host-extern.ts
@@ -14,6 +14,271 @@ import { ts } from "../ts-api.js";
 import { isExternalDeclaredClass } from "../checker/type-mapper.js";
 
 /**
+ * #3214 B2 — one checker-certified host callback site.
+ *
+ * The capture list is declaration-identity based. Selection uses it to prove
+ * the names are live in its lexical scope, while lowering rechecks the same
+ * set against the IR capture analysis before materialising the closure.
+ */
+export interface IrHostVoidCallbackCertification {
+  readonly call: ts.CallExpression;
+  readonly callback: ts.ArrowFunction & { readonly body: ts.Block };
+  readonly captureNames: ReadonlySet<string>;
+}
+
+export type IrHostVoidCallbackResolver = (call: ts.CallExpression) => IrHostVoidCallbackCertification | undefined;
+
+function containsNode(ancestor: ts.Node, candidate: ts.Node): boolean {
+  for (let current: ts.Node | undefined = candidate; current; current = current.parent) {
+    if (current === ancestor) return true;
+  }
+  return false;
+}
+
+function simpleAssignmentTargetContains(node: ts.Node, target: ts.Symbol, checker: ts.TypeChecker): boolean {
+  if (ts.isIdentifier(node)) return checker.getSymbolAtLocation(node) === target;
+  if (ts.isArrayLiteralExpression(node)) {
+    return node.elements.some((element) =>
+      ts.isOmittedExpression(element)
+        ? false
+        : simpleAssignmentTargetContains(ts.isSpreadElement(element) ? element.expression : element, target, checker),
+    );
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    return node.properties.some((property) => {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        return checker.getSymbolAtLocation(property.name) === target;
+      }
+      if (ts.isPropertyAssignment(property)) {
+        return simpleAssignmentTargetContains(property.initializer, target, checker);
+      }
+      if (ts.isSpreadAssignment(property)) {
+        return simpleAssignmentTargetContains(property.expression, target, checker);
+      }
+      return false;
+    });
+  }
+  return false;
+}
+
+function symbolIsWrittenIn(
+  root: ts.Node,
+  ignoredFunction: ts.ArrowFunction,
+  target: ts.Symbol,
+  checker: ts.TypeChecker,
+): boolean {
+  let written = false;
+  const visit = (node: ts.Node): void => {
+    if (written) return;
+    if (node !== ignoredFunction && ts.isFunctionLike(node)) return;
+    if (ts.isBinaryExpression(node)) {
+      const op = node.operatorToken.kind;
+      if (
+        (op === ts.SyntaxKind.EqualsToken ||
+          (op >= ts.SyntaxKind.FirstCompoundAssignment && op <= ts.SyntaxKind.LastCompoundAssignment)) &&
+        simpleAssignmentTargetContains(node.left, target, checker)
+      ) {
+        written = true;
+        return;
+      }
+    }
+    if (
+      (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) &&
+      ts.isIdentifier(node.operand) &&
+      checker.getSymbolAtLocation(node.operand) === target
+    ) {
+      written = true;
+      return;
+    }
+    if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+      if (
+        !ts.isVariableDeclarationList(node.initializer) &&
+        simpleAssignmentTargetContains(node.initializer, target, checker)
+      ) {
+        written = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(root, visit);
+  return written;
+}
+
+/**
+ * Build the exact B2 resolver shared by production planning and the fallback
+ * gate. It deliberately recognises only the browser-host EventTarget method
+ * shape needed by the benchmark helper:
+ *
+ *   ambientExtern.addEventListener(type, () => { ... })
+ *
+ * The callback must be a zero-parameter, block-bodied, synchronous void arrow.
+ * Lexical `this`/`arguments`/`super`/`new.target`, nested runtime declarations,
+ * and mutable captures are rejected. Captures may only be simple outer
+ * parameters or `const` declarations; symbol identity (not spelling) proves
+ * both capture ownership and immutability.
+ */
+export function makeIrHostVoidCallbackResolver(checker: ts.TypeChecker): IrHostVoidCallbackResolver {
+  return (call: ts.CallExpression): IrHostVoidCallbackCertification | undefined => {
+    try {
+      if (
+        call.questionDotToken ||
+        (call.typeArguments?.length ?? 0) > 0 ||
+        call.arguments.length !== 2 ||
+        !ts.isExpressionStatement(call.parent) ||
+        !ts.isPropertyAccessExpression(call.expression) ||
+        call.expression.questionDotToken ||
+        call.expression.name.text !== "addEventListener" ||
+        !ts.isArrowFunction(call.arguments[1]!)
+      ) {
+        return undefined;
+      }
+      const callback = call.arguments[1]!;
+      if (
+        callback.parameters.length !== 0 ||
+        !ts.isBlock(callback.body) ||
+        callback.body.statements.length === 0 ||
+        (callback.typeParameters?.length ?? 0) > 0 ||
+        callback.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword) ||
+        (callback.type !== undefined && callback.type.kind !== ts.SyntaxKind.VoidKeyword)
+      ) {
+        return undefined;
+      }
+
+      let owner: ts.Node | undefined = callback.parent;
+      while (owner && !ts.isFunctionLike(owner) && !ts.isSourceFile(owner)) owner = owner.parent;
+      if (!owner || !ts.isFunctionDeclaration(owner) || !owner.body || !ts.isSourceFile(owner.parent)) {
+        return undefined;
+      }
+
+      // Keep B2's synthesized name deterministic: the benchmark owner has
+      // exactly one runtime closure, so lowering must mint `<owner>__closure_0`.
+      // A sibling closure/function/class would consume another lift ordinal
+      // whose collision proof is outside this slice. Nested declarations in
+      // the callback are rejected again by the lexical scan below.
+      let hasOtherRuntimeDeclaration = false;
+      const findOtherRuntimeDeclaration = (node: ts.Node): void => {
+        if (hasOtherRuntimeDeclaration || node === callback) return;
+        if (ts.isFunctionLike(node) || ts.isClassLike(node)) {
+          hasOtherRuntimeDeclaration = true;
+          return;
+        }
+        ts.forEachChild(node, findOtherRuntimeDeclaration);
+      };
+      ts.forEachChild(owner.body, findOtherRuntimeDeclaration);
+      if (hasOtherRuntimeDeclaration) return undefined;
+
+      const resolved = checker.getResolvedSignature(call);
+      const declaration = resolved?.declaration;
+      if (!resolved || !declaration || !declaration.getSourceFile().isDeclarationFile) return undefined;
+      const declarationName = "name" in declaration ? declaration.name : undefined;
+      if (!declarationName || !ts.isIdentifier(declarationName) || declarationName.text !== "addEventListener") {
+        return undefined;
+      }
+      if ((checker.getReturnTypeOfSignature(resolved).flags & ts.TypeFlags.Void) === 0) return undefined;
+
+      const receiverType = checker.getNonNullableType(checker.getTypeAtLocation(call.expression.expression));
+      if (!isExternalDeclaredClass(receiverType, checker)) return undefined;
+      const callbackSignature = checker.getSignatureFromDeclaration(callback);
+      if (!callbackSignature || (checker.getReturnTypeOfSignature(callbackSignature).flags & ts.TypeFlags.Void) === 0) {
+        return undefined;
+      }
+
+      // The existing IR capture materializer is keyed by lexical spelling.
+      // Pre-claim reject an owner binding whose spelling is also used by a
+      // different identifier symbol inside the callback (for example an outer
+      // `textContent` parameter plus `sink.textContent`). Without this guard,
+      // lowering would mistake the property name for an extra capture even
+      // though the checker correctly resolves it to the ambient property.
+      const ownerBindingsByName = new Map<string, ts.Symbol>();
+      const registerOwnerBindingName = (name: ts.BindingName): void => {
+        if (ts.isIdentifier(name)) {
+          const symbol = checker.getSymbolAtLocation(name);
+          if (symbol) ownerBindingsByName.set(name.text, symbol);
+          return;
+        }
+        for (const element of name.elements) {
+          if (!ts.isOmittedExpression(element)) registerOwnerBindingName(element.name);
+        }
+      };
+      for (const parameter of owner.parameters) {
+        registerOwnerBindingName(parameter.name);
+      }
+      const collectOwnerBindings = (node: ts.Node): void => {
+        if (node === callback || (node !== owner && (ts.isFunctionLike(node) || ts.isClassLike(node)))) return;
+        if (ts.isVariableDeclaration(node)) registerOwnerBindingName(node.name);
+        ts.forEachChild(node, collectOwnerBindings);
+      };
+      ts.forEachChild(owner.body, collectOwnerBindings);
+
+      let invalidLexicalShape = false;
+      const captureSymbols = new Map<ts.Symbol, string>();
+      const visit = (node: ts.Node): void => {
+        if (invalidLexicalShape) return;
+        if (node !== callback && (ts.isFunctionLike(node) || ts.isClassLike(node))) {
+          invalidLexicalShape = true;
+          return;
+        }
+        if (
+          node.kind === ts.SyntaxKind.ThisKeyword ||
+          node.kind === ts.SyntaxKind.SuperKeyword ||
+          ts.isMetaProperty(node) ||
+          ts.isYieldExpression(node) ||
+          (ts.isIdentifier(node) && node.text === "arguments")
+        ) {
+          invalidLexicalShape = true;
+          return;
+        }
+        if (ts.isIdentifier(node)) {
+          const symbol = checker.getSymbolAtLocation(node);
+          const sameSpellingOwnerBinding = ownerBindingsByName.get(node.text);
+          if (sameSpellingOwnerBinding && symbol !== sameSpellingOwnerBinding) {
+            invalidLexicalShape = true;
+            return;
+          }
+          const captureDeclaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
+          if (
+            symbol &&
+            captureDeclaration &&
+            containsNode(owner!, captureDeclaration) &&
+            !containsNode(callback, captureDeclaration)
+          ) {
+            if (ts.isParameter(captureDeclaration) && ts.isIdentifier(captureDeclaration.name)) {
+              captureSymbols.set(symbol, captureDeclaration.name.text);
+            } else if (
+              ts.isVariableDeclaration(captureDeclaration) &&
+              ts.isIdentifier(captureDeclaration.name) &&
+              ts.isVariableDeclarationList(captureDeclaration.parent) &&
+              (captureDeclaration.parent.flags & ts.NodeFlags.Const) !== 0
+            ) {
+              captureSymbols.set(symbol, captureDeclaration.name.text);
+            } else {
+              invalidLexicalShape = true;
+              return;
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      ts.forEachChild(callback.body, visit);
+      if (invalidLexicalShape) return undefined;
+
+      for (const symbol of captureSymbols.keys()) {
+        if (symbolIsWrittenIn(owner.body, callback, symbol, checker)) return undefined;
+      }
+      return {
+        call,
+        callback: callback as ts.ArrowFunction & { readonly body: ts.Block },
+        captureNames: new Set(captureSymbols.values()),
+      };
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+/**
  * Build the selector's host-global resolver: identifier node → extern class
  * name ("Document", "Console"), or undefined when the identifier is not an
  * ambient host global the legacy backend would service.

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -77,6 +77,7 @@ import {
   lowerFunctionAstToIr,
   STRING_METHOD_TABLE,
   type IrFromAstResolver,
+  type IrHostVoidCallbackLoweringPlan,
   type IrImportedCallLoweringPlan,
   type IrTopLevelFunctionValueLoweringPlan,
   type ModuleBindingGlobal,
@@ -164,6 +165,7 @@ export interface IrTypeOverrideMap {
 export interface IrIntegrationLoweringPlans {
   readonly importedCalls: ReadonlyMap<ts.CallExpression, IrImportedCallLoweringPlan>;
   readonly topLevelFunctionValues: ReadonlyMap<ts.Identifier, IrTopLevelFunctionValueLoweringPlan>;
+  readonly hostVoidCallbacks: ReadonlyMap<ts.ArrowFunction, IrHostVoidCallbackLoweringPlan>;
 }
 
 export function compileIrPathFunctions(
@@ -315,6 +317,7 @@ export function compileIrPathFunctions(
         calleeTypes,
         importedCalls: loweringPlans?.importedCalls,
         topLevelFunctionValues: loweringPlans?.topLevelFunctionValues,
+        hostVoidCallbacks: loweringPlans?.hostVoidCallbacks,
         classShapes,
         // Slice 6 part 4 refactor (#1185): thread the from-ast subset
         // of the IR resolver. Replaces the per-feature `nativeStrings:
@@ -453,6 +456,7 @@ export function compileIrPathFunctions(
             calleeTypes,
             importedCalls: loweringPlans?.importedCalls,
             topLevelFunctionValues: loweringPlans?.topLevelFunctionValues,
+            hostVoidCallbacks: loweringPlans?.hostVoidCallbacks,
             classShapes,
             resolver: fromAstResolver,
             allocRegistry,
@@ -543,6 +547,7 @@ export function compileIrPathFunctions(
         calleeTypes,
         importedCalls: loweringPlans?.importedCalls,
         topLevelFunctionValues: loweringPlans?.topLevelFunctionValues,
+        hostVoidCallbacks: loweringPlans?.hostVoidCallbacks,
         classShapes,
         resolver: fromAstResolver,
         allocRegistry,
@@ -2878,11 +2883,11 @@ function irTypeKey(t: IrType): string {
   }
   if (t.kind === "closure") {
     const ps = t.signature.params.map(irTypeKey).join(",");
-    return `closure(${ps})->${irTypeKey(t.signature.returnType)}`;
+    return `closure(${ps})->${t.signature.returnType === null ? "void" : irTypeKey(t.signature.returnType)}`;
   }
   if (t.kind === "callable") {
     const ps = t.signature.params.map(irTypeKey).join(",");
-    return `callable(${ps})->${irTypeKey(t.signature.returnType)}`;
+    return `callable(${ps})->${t.signature.returnType === null ? "void" : irTypeKey(t.signature.returnType)}`;
   }
   // Slice 4 (#1169d): class is keyed by name — uniqueness across the
   // compilation unit makes this safe.
@@ -2955,7 +2960,7 @@ class ClosureStructRegistry {
     let resultTypes: ValType[];
     try {
       paramTypes = sig.params.map((p) => this.resolveValType(p));
-      resultTypes = [this.resolveValType(sig.returnType)];
+      resultTypes = sig.returnType === null ? [] : [this.resolveValType(sig.returnType)];
     } catch {
       return null;
     }
@@ -2999,7 +3004,16 @@ class ClosureStructRegistry {
     }
 
     const subIdx = this.ctx.mod.types.length;
-    const subName = `__ir_closure_${this.subCache.size}`;
+    // `compileIrPathFunctions` is invoked once per source file in the M0
+    // overlay, so this registry-local cache restarts at zero. Allocate against
+    // the module-wide struct registry to keep B2 captured subtypes unique and
+    // avoid overwriting a user class (or an earlier file's IR closure) named
+    // `__ir_closure_N`.
+    let subOrdinal = this.subCache.size;
+    let subName = `__ir_closure_${subOrdinal}`;
+    while (this.ctx.structMap.has(subName)) {
+      subName = `__ir_closure_${++subOrdinal}`;
+    }
     this.ctx.mod.types.push({
       kind: "struct",
       name: subName,
@@ -3045,7 +3059,7 @@ class ClosureStructRegistry {
 
 function sigKey(sig: IrClosureSignature): string {
   const ps = sig.params.map(irTypeKey).join(",");
-  return `(${ps})->${irTypeKey(sig.returnType)}`;
+  return `(${ps})->${sig.returnType === null ? "void" : irTypeKey(sig.returnType)}`;
 }
 
 /**

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -3585,11 +3585,11 @@ function describeIrTypeShallow(t: IrType): string {
   if (t.kind === "object") return `object{${describeShape(t.shape)}}`;
   if (t.kind === "closure") {
     const ps = t.signature.params.map(describeIrTypeShallow).join(",");
-    return `closure(${ps})->${describeIrTypeShallow(t.signature.returnType)}`;
+    return `closure(${ps})->${t.signature.returnType === null ? "void" : describeIrTypeShallow(t.signature.returnType)}`;
   }
   if (t.kind === "callable") {
     const ps = t.signature.params.map(describeIrTypeShallow).join(",");
-    return `callable(${ps})->${describeIrTypeShallow(t.signature.returnType)}`;
+    return `callable(${ps})->${t.signature.returnType === null ? "void" : describeIrTypeShallow(t.signature.returnType)}`;
   }
   if (t.kind === "class") return `class<${t.shape.className}>`;
   if (t.kind === "extern") return `extern<${t.className}>`;

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -141,7 +141,8 @@ export interface IrObjectShape {
  */
 export interface IrClosureSignature {
   readonly params: readonly IrType[];
-  readonly returnType: IrType;
+  /** `null` is the canonical zero-result / JavaScript `void` signature. */
+  readonly returnType: IrType | null;
 }
 
 /**
@@ -440,7 +441,9 @@ export function closureSignatureEquals(a: IrClosureSignature, b: IrClosureSignat
   for (let i = 0; i < a.params.length; i++) {
     if (!irTypeEquals(a.params[i]!, b.params[i]!)) return false;
   }
-  return irTypeEquals(a.returnType, b.returnType);
+  return a.returnType === null || b.returnType === null
+    ? a.returnType === b.returnType
+    : irTypeEquals(a.returnType, b.returnType);
 }
 
 /**

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -427,11 +427,11 @@ function irTypeKey(t: IrType): string {
   }
   if (t.kind === "closure") {
     const ps = t.signature.params.map(irTypeKey).join(",");
-    return `c:(${ps})->${irTypeKey(t.signature.returnType)}`;
+    return `c:(${ps})->${t.signature.returnType === null ? "void" : irTypeKey(t.signature.returnType)}`;
   }
   if (t.kind === "callable") {
     const ps = t.signature.params.map(irTypeKey).join(",");
-    return `cb:(${ps})->${irTypeKey(t.signature.returnType)}`;
+    return `cb:(${ps})->${t.signature.returnType === null ? "void" : irTypeKey(t.signature.returnType)}`;
   }
   // Slice 4 (#1169d): class is keyed by name — one declaration per
   // unit, so the name uniquely identifies the shape.

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -60,6 +60,7 @@ import { ts, forEachChild } from "../ts-api.js";
 import { staticPromiseResolveSettledExpr, unwrapPromiseTypeNode } from "../codegen/async-static.js";
 import { closureSignatureEquals, type IrClosureSignature, type IrType } from "./nodes.js";
 import type { IrImportedFunctionResolver, IrResolvedFunctionTarget } from "./imported-functions.js";
+import type { IrHostVoidCallbackResolver } from "./host-extern.js";
 
 import { binaryOpCapability, hostExternCapability, prefixOpCapability } from "./capability.js";
 import type {
@@ -384,6 +385,12 @@ export interface IrSelectionOptions {
    * pre-slice conservative boundary.
    */
   readonly importedFunctions?: IrImportedFunctionResolver;
+  /**
+   * (#3214 B2) Checker-certified direct ambient `addEventListener` callback
+   * sites. Omitted in host-free modes and bare selector callers so arrows do
+   * not widen accidentally outside the production/gate shared proof.
+   */
+  readonly hostVoidCallbacks?: IrHostVoidCallbackResolver;
 }
 
 /**
@@ -4107,6 +4114,37 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
         return true;
       }
       if (!isPhase1Expr(expr.expression.expression, scope, localClasses)) return false;
+      // (#3214 B2) One exact host callback widening. The checker resolver
+      // proves this is the ambient EventTarget `addEventListener` surface and
+      // that the zero-param block arrow is synchronous, void, nested-decl
+      // free, and capture-readonly. Selection still owns ordinary expression
+      // coverage: the event type and the callback body must both fit the
+      // complete Phase-1 surface, and every certified capture must already be
+      // live in this lexical scope. No other arrow argument bypasses the
+      // generic `isPhase1Expr` rejection below.
+      const hostVoidCallback = currentSelectionOptions?.hostVoidCallbacks?.(expr);
+      if (hostVoidCallback) {
+        for (const capture of hostVoidCallback.captureNames) {
+          if (!scope.has(capture)) return shapeNo("expr-host-void-callback-capture-scope", hostVoidCallback.callback);
+        }
+        const eventType = expr.arguments[0]!;
+        if (ts.isSpreadElement(eventType) || !isPhase1Expr(eventType, scope, localClasses)) {
+          return shapeNo("expr-host-void-callback-event", eventType);
+        }
+        const callbackScope = new Set(scope);
+        if (
+          !isPhase1StatementList(
+            hostVoidCallback.callback.body.statements,
+            callbackScope,
+            localClasses,
+            /* isGenerator */ false,
+            /* isVoidReturn */ true,
+          )
+        ) {
+          return shapeNo("expr-host-void-callback-body", hostVoidCallback.callback.body);
+        }
+        return true;
+      }
       for (const arg of expr.arguments) {
         // Slice 8a (#1169g): spread args restricted to method calls is
         // out of scope — methods on classes have known signatures and

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1013,6 +1013,10 @@ const _wasmClosureWrapperSource = new WeakMap<Function, { closure: any; arity: n
 const _wasmClosureDynamicWrapperCache = new WeakMap<object, Function>();
 const _wasmClosureWrapperCache = new WeakMap<object, Map<number, Function>>();
 const _wasmClosureWrapperTargets = new WeakMap<Function, object>();
+// #3214 B2 — `__make_callback(-1, closure)` bridges a canonical void IR
+// closure without minting a legacy `__cb_N` export. Cache the non-constructible
+// JS arrow per raw closure so repeated boundary conversion preserves identity.
+const _wasmVoidHostCallbackCache = new WeakMap<object, Function>();
 const _test262ErrorConstructors = new WeakSet<Function>();
 
 // (#3369) Callback bridges must remain usable while the evaluated program has
@@ -1475,6 +1479,28 @@ function _maybeWrapCallable(
   if (!_isWasmStruct(val)) return val;
   const wrapped = _wrapWasmClosure(val, arity, callbackState);
   return wrapped ?? val;
+}
+
+function _wrapVoidHostCallback(
+  closure: any,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): any {
+  if (!_canBeWeakKey(closure)) return closure;
+  const cached = _wasmVoidHostCallbackCache.get(closure as object);
+  if (cached) return cached;
+  const dispatch = _maybeWrapCallable(closure, 0, callbackState);
+  if (typeof dispatch !== "function") return dispatch;
+
+  // Arrow functions have no [[Construct]], matching the source arrow. The
+  // block intentionally discards the Wasm dispatcher's result so a `void`
+  // callback observes JavaScript `undefined` even though the generic
+  // `__call_fn_0` bridge itself has an externref result carrier.
+  const wrapped = (..._args: any[]): void => {
+    dispatch();
+  };
+  _wasmVoidHostCallbackCache.set(closure as object, wrapped);
+  _wasmClosureWrapperTargets.set(wrapped, closure as object);
+  return wrapped;
 }
 
 /**
@@ -13695,8 +13721,12 @@ assert._isSameValue = isSameValue;
       return () => {};
     }
     case "callback_maker":
-      return (id: number, cap: any) =>
-        (...args: any[]) => {
+      return (id: number, cap: any) => {
+        // #3214 B2 reserves -1 for an already-materialised canonical IR
+        // closure. Legacy callbacks keep their non-negative `__cb_N` ids and
+        // therefore remain byte-for-byte on the existing dispatch path.
+        if (id === -1) return _wrapVoidHostCallback(cap, callbackState);
+        return (...args: any[]) => {
           const exports = callbackState?.getExports();
           // (#3284) A callback whose reaction fires DURING WebAssembly.instantiate
           // — e.g. a top-level `Promise.resolve(x).then(cb)` whose microtask
@@ -13720,6 +13750,7 @@ assert._isSameValue = isSameValue;
           }
           return exports?.[`__cb_${id}`]?.(cap, ...args);
         };
+      };
     case "getter_callback_maker":
       return (id: number, cap: any) =>
         // Regular function (not arrow) so 'this' is bound to the receiver;

--- a/tests/issue-3214-void-host-callback.test.ts
+++ b/tests/issue-3214-void-host-callback.test.ts
@@ -193,6 +193,29 @@ describe("#3214 B2 — ambient void host callbacks", () => {
     expect(result.irPostClaimErrors ?? []).toEqual([]);
   });
 
+  it("keeps a potentially final-demoted B2 call component out of the IR-first skip set", async () => {
+    const result = await compileHostCallback(`
+      type i32 = number;
+      function __make_callback(_id: i32, capture: object): object { return capture; }
+      function install(n: number): number {
+        document.body.addEventListener("tick", () => { n + 1; });
+        return n;
+      }
+      export function caller(n: number): number { return install(n); }
+      export function independent(n: number): number { return n + 1; }
+    `);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("install");
+    expect(result.irCompiledFuncs ?? []).not.toContain("caller");
+    expect(result.irCompiledFuncs ?? []).toContain("independent");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    expect(result.irFirstSkipped ?? []).not.toContain("install");
+    expect(result.irFirstSkipped ?? []).not.toContain("caller");
+    expect(result.irFirstSkipped ?? []).toContain("independent");
+  });
+
   it.each([
     [
       "property",

--- a/tests/issue-3214-void-host-callback.test.ts
+++ b/tests/issue-3214-void-host-callback.test.ts
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+
+import { compile, compileMulti, type CompileOptions, type CompileResult, type ImportDescriptor } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const HOST_CALLBACK_SOURCE = `
+export function install(target: EventTarget, sink: HTMLElement, value: number): void {
+  target.addEventListener("tick", () => {
+    sink.textContent = value.toString();
+  });
+}
+`;
+
+async function compileHostCallback(
+  source: string = HOST_CALLBACK_SOURCE,
+  options: CompileOptions = {},
+): Promise<CompileResult> {
+  return compile(source, {
+    fileName: "issue-3214-b2.ts",
+    experimentalIR: true,
+    trackFallbacks: true,
+    skipSemanticDiagnostics: true,
+    ...options,
+  });
+}
+
+function watFunctionBody(wat: string, name: string): string {
+  const start = wat.indexOf(`  (func $${name}`);
+  expect(start, `missing $${name}`).toBeGreaterThanOrEqual(0);
+  const next = wat.indexOf("\n  (func $", start + 1);
+  return wat.slice(start, next < 0 ? wat.length : next);
+}
+
+function wasmFunctionImportIndex(binary: Uint8Array, name: string): number {
+  let functionIndex = 0;
+  for (const entry of WebAssembly.Module.imports(new WebAssembly.Module(binary))) {
+    if (entry.kind !== "function") continue;
+    if (entry.name === name) return functionIndex;
+    functionIndex++;
+  }
+  return -1;
+}
+
+describe("#3214 B2 — ambient void host callbacks", () => {
+  it("caches a nonconstructible, undefined-returning sentinel wrapper", () => {
+    const manifest: ImportDescriptor[] = [
+      {
+        module: "env",
+        name: "__make_callback",
+        kind: "func",
+        intent: { type: "callback_maker" },
+      },
+    ];
+    const imports = buildImports(manifest);
+    let dispatches = 0;
+    const closure = (): number => ++dispatches;
+    const otherClosure = (): number => 0;
+
+    const callback = imports.env.__make_callback(-1, closure);
+    expect(callback).toBe(imports.env.__make_callback(-1, closure));
+    expect(callback).not.toBe(imports.env.__make_callback(-1, otherClosure));
+    expect(callback.length).toBe(0);
+    expect(callback({ type: "tick" })).toBeUndefined();
+    expect(callback()).toBeUndefined();
+    expect(dispatches).toBe(2);
+    expect(() => Reflect.construct(callback, [])).toThrow(TypeError);
+
+    const legacyCapture = { value: 20 };
+    const legacyCallback = imports.env.__make_callback(7, legacyCapture);
+    imports.setExports?.({
+      __cb_7: (capture: typeof legacyCapture, add: number): number => capture.value + add,
+    });
+    expect(legacyCallback(22)).toBe(42);
+  });
+
+  it.each([false, true])("dispatches the IR callback twice (optimize=%s)", async (optimize) => {
+    const result = await compileHostCallback(HOST_CALLBACK_SOURCE, { optimize });
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irCompiledFuncs ?? []).toContain("install");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+
+    const installBody = watFunctionBody(result.wat, "install");
+    expect(installBody).toContain("i32.const -1");
+    const callbackMakerIndex = wasmFunctionImportIndex(result.binary, "__make_callback");
+    expect(callbackMakerIndex).toBeGreaterThanOrEqual(0);
+    expect(installBody).toContain(`call ${callbackMakerIndex}`);
+    expect(result.wat).toContain("(func $install__closure_0");
+    const voidWrapperType = result.wat
+      .split("\n")
+      .find((line) => /\$__fn_wrap_\d+_type \(func/.test(line) && !line.includes("(result "));
+    expect(voidWrapperType, "missing canonical zero-result closure type").toBeDefined();
+
+    const imports = buildImports(result.imports, undefined, result.stringPool);
+    const { instance } = await WebAssembly.instantiate(result.binary, imports);
+    imports.setExports?.(instance.exports as Record<string, Function>);
+
+    const listeners: Function[] = [];
+    const target = {
+      addEventListener(_type: string, listener: Function): void {
+        listeners.push(listener);
+      },
+    };
+    const sink = { textContent: "" };
+    (instance.exports.install as (target: object, sink: object, value: number) => void)(target, sink, 42);
+
+    expect(listeners).toHaveLength(1);
+    const listener = listeners[0]!;
+    expect(listener({ type: "tick" })).toBeUndefined();
+    expect(sink.textContent).toBe("42");
+    sink.textContent = "";
+    expect(listener({ type: "tick" })).toBeUndefined();
+    expect(sink.textContent).toBe("42");
+    expect(() => Reflect.construct(listener, [])).toThrow(TypeError);
+  });
+
+  it.each([
+    ["wrong method", `target.removeEventListener("tick", () => { sink.textContent = "x"; });`],
+    ["options argument", `target.addEventListener("tick", () => { sink.textContent = "x"; }, false);`],
+    ["parameter", `target.addEventListener("tick", (_event: Event) => { sink.textContent = "x"; });`],
+    ["concise body", `target.addEventListener("tick", () => sink.textContent = "x");`],
+    ["async", `target.addEventListener("tick", async () => { sink.textContent = "x"; });`],
+    ["non-void", `target.addEventListener("tick", (): number => { return 1; });`],
+    [
+      "mutable capture",
+      `let count: number = 0; target.addEventListener("tick", () => { count++; sink.textContent = count.toString(); });`,
+    ],
+    ["outer write", `target.addEventListener("tick", () => { sink.textContent = value.toString(); }); value = 1;`],
+    [
+      "nested arrow",
+      `target.addEventListener("tick", () => { const nested = (): number => 1; sink.textContent = nested().toString(); });`,
+    ],
+    [
+      "multiple callback sites",
+      `target.addEventListener("tick", () => { sink.textContent = "first"; }); target.addEventListener("tock", () => { sink.textContent = "second"; });`,
+    ],
+    [
+      "lexical arguments",
+      `target.addEventListener("tick", () => { sink.textContent = arguments.length.toString(); });`,
+    ],
+  ] as const)("rejects %s before the IR claim", async (_label, body) => {
+    const result = await compileHostCallback(`
+      export function install(target: EventTarget, sink: HTMLElement, value: number): void {
+        ${body}
+      }
+    `);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("install");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("rejects a user-defined same-name method", async () => {
+    const result = await compileHostCallback(`
+      class LocalTarget {
+        addEventListener(_type: string, callback: () => void): void { callback(); }
+      }
+      export function install(target: LocalTarget, sink: HTMLElement): void {
+        target.addEventListener("tick", () => { sink.textContent = "x"; });
+      }
+    `);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("install");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("demotes before lowering when the deterministic lifted name is occupied", async () => {
+    const result = await compileHostCallback(`
+      function install__closure_0(): number { return 0; }
+      export function install(target: EventTarget, sink: HTMLElement): void {
+        target.addEventListener("tick", () => { sink.textContent = "x"; });
+      }
+    `);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("install");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("demotes when __make_callback resolves to a defined function instead of the exact host import", async () => {
+    const result = await compileHostCallback(`
+      type i32 = number;
+      function __make_callback(_id: i32, capture: object): object { return capture; }
+      export function install(target: EventTarget, sink: HTMLElement): void {
+        target.addEventListener("tick", () => { sink.textContent = "x"; });
+      }
+    `);
+
+    expect(result.irCompiledFuncs ?? []).not.toContain("install");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each([
+    [
+      "property",
+      `
+        export function install(target: EventTarget, sink: HTMLElement, textContent: number): void {
+          target.addEventListener("tick", () => { sink.textContent = "x"; });
+        }
+      `,
+    ],
+    [
+      "method",
+      `
+        export function install(target: EventTarget, sink: HTMLElement, value: number, toString: number): void {
+          target.addEventListener("tick", () => { sink.textContent = value.toString(); });
+        }
+      `,
+    ],
+    [
+      "property and destructured binding",
+      `
+        export function install(target: EventTarget, sink: HTMLElement): void {
+          const [textContent] = [1];
+          target.addEventListener("tick", () => { sink.textContent = "x"; });
+        }
+      `,
+    ],
+  ] as const)("rejects an outer binding colliding with a callback %s name before claim", async (_label, source) => {
+    const result = await compileHostCallback(source);
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(result.irCompiledFuncs ?? []).not.toContain("install");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("allocates captured closure subtype names uniquely across source overlays", async () => {
+    const result = await compileMulti(
+      {
+        "./other.ts": `
+          export function installOther(target: EventTarget, sink: HTMLElement): void {
+            target.addEventListener("other", () => { sink.textContent = "other"; });
+          }
+        `,
+        "./entry.ts": `
+          import { installOther } from "./other.ts";
+          export function installEntry(target: EventTarget, sink: HTMLElement): void {
+            target.addEventListener("entry", () => { sink.textContent = "entry"; });
+          }
+          export function retainOther(target: EventTarget, sink: HTMLElement): void {
+            installOther(target, sink);
+          }
+        `,
+      },
+      "./entry.ts",
+      {
+        experimentalIR: true,
+        trackFallbacks: true,
+        skipSemanticDiagnostics: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+    expect(result.irCompiledFuncs ?? []).toEqual(expect.arrayContaining(["installOther", "installEntry"]));
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+    const subtypeNames = [...result.wat.matchAll(/\(type \$(__ir_closure_\d+)/g)].map((match) => match[1]);
+    expect(new Set(subtypeNames).size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("keeps B2 disabled and import-free in standalone", async () => {
+    const [irOn, irOff] = await Promise.all([
+      compileHostCallback(HOST_CALLBACK_SOURCE, { target: "standalone" }),
+      compileHostCallback(HOST_CALLBACK_SOURCE, { target: "standalone", experimentalIR: false }),
+    ]);
+
+    expect(irOn.success).toBe(irOff.success);
+    expect(irOn.irCompiledFuncs ?? []).not.toContain("install");
+    expect(irOn.irPostClaimErrors ?? []).toEqual([]);
+    if (irOn.success && irOff.success) {
+      const importNames = (result: CompileResult): string[] =>
+        WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).map(
+          (entry) => `${entry.module}.${entry.name}`,
+        );
+      expect(importNames(irOn)).toEqual(importNames(irOff));
+      expect(importNames(irOn)).not.toContain("env.__make_callback");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- checker-certify exact ambient addEventListener argument callbacks for IR overlay lowering
- carry zero-result closures through the canonical callable ABI and a verified env.__make_callback sentinel bridge
- preserve callback identity, undefined returns, nonconstructibility, positive callback IDs, and standalone containment
- preclaim-demote ambiguous captures and synthetic-name/type collisions
- keep every potentially final-demotable callback component compile-twice so IR-first cannot strand an unreachable caller slot
- ratchet body-shape fallbacks from 5 to 4; remaining shapes are the three Calendar functions and async delay

## Validation

- combined B2 + B0 + A/B1 + M0 tests: 60 passed
- B2 focused suite: 23 passed
- exact IR-first final-demotion regression with unrelated skip anti-vacuity
- pnpm exec tsc --noEmit --incremental false
- pnpm run check:ir-fallbacks
- focused Biome and Prettier checks
- LOC and git diff checks

Tracking is maintained in plan/issues/2856-ir-body-shape-rejected-to-zero.md and plan/issues/3214-ir-first-class-function-values.md; this PR does not close a GitHub Issue.