### PR TITLE
fix(ci): stop polling for missing Test262 baselines

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1369,10 +1369,10 @@ jobs:
         if: env.SHARDS_RAN == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         env:
           # #3467 — on merge_group the REAL parent commit the queue built this
-          # group on. The sequential merge queue writes runs/<sha> for every
-          # landed commit (write-run-cache-bot job), so runs/<base_sha> is the
-          # exact pre-PR state → the diff is purely this PR's effect, with none
-          # of the promoted-snapshot lag that false-parked 6 PRs on 2026-07-19.
+          # group on. Test262-running landed commits write runs/<sha> through
+          # write-run-cache-bot, so a present runs/<base_sha> is the exact
+          # pre-PR state → the diff is purely this PR's effect, with none of the
+          # promoted-snapshot lag that false-parked 6 PRs on 2026-07-19.
           MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           # #1081/#3467 — prefer the hash-indexed run cache for the PR's REAL
@@ -1405,46 +1405,27 @@ jobs:
           # runs/<base>.json when the cache hit (#49). The .json is sparse-
           # checked-out below alongside the .jsonl.
           echo "merge_base=${MERGE_BASE}" >> "$GITHUB_OUTPUT"
-          # #3467 (poll) — RACE FIX for the distance-1 settle under sustained
-          # queue velocity. On merge_group, base_sha is the tip the PREVIOUS
-          # queue merge just produced, and write-run-cache-bot is still writing
-          # runs/<base_sha> to the baselines repo when this job first cloned it
-          # → the exact base MISSES → the resolver walks to the distance-1
-          # ancestor → the ratio gate nips the 1-commit residual and PARKS a
-          # clean, net-positive PR. But base_sha is FIXED at build start, its
-          # cache lands within a few min, and this PR's own build takes ~30 min —
-          # so the base cache RELIABLY exists well before the gate compares; it
-          # was merely queried too early. Poll the EXACT base for up to ~3 min
-          # (6×30s) so back-to-back merges resolve at DISTANCE 0.
+          # #3467 — one-shot exact-base probe. The baselines repo was cloned in
+          # the immediately preceding step, after this run's shards completed,
+          # so its origin/main is already a fresh view of any cache written by a
+          # Test262-running predecessor. Query it once and never wait here.
           #
-          # Non-perturbing: we refresh origin/main and materialize the blob to
-          # the path the resolver reads WITHOUT moving HEAD (a `reset`/`checkout`
-          # here would advance the shared baselines clone and confuse the #1235/
-          # #1668 staleness steps that parse its commit subject). A genuinely
-          # uncached base (e.g. a doc-only merge that wrote no cache) simply
-          # falls through to the ancestor-walk below, where the nearest cached
-          # ancestor carries identical test262 data (drift-free at distance N).
+          # A missing entry may be permanent (for example, a doc-only predecessor
+          # that intentionally ran no shards), so polling cannot distinguish a
+          # race from an entry that will never arrive. Fall through immediately
+          # to the ancestor walk; the #1956 predecessor-group artifact step that
+          # follows can still replace it with a stronger exact baseline.
+          # Materialize blobs without moving HEAD so the #1235/#1668 staleness
+          # checks keep reading the clone commit fetched above.
           if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$MERGE_BASE" ]; then
             mkdir -p "/tmp/js2wasm-baselines/runs"
-            WAITED=0
-            for attempt in 1 2 3 4 5 6; do
-              # Refresh origin/main (depth 1 — runs/<base> persists in every later
-              # tree, so the current tip's tree contains it once written).
-              git -C /tmp/js2wasm-baselines fetch --depth=1 --filter=blob:none origin main 2>/dev/null || true
-              if git -C /tmp/js2wasm-baselines cat-file -e "origin/main:runs/${MERGE_BASE}.jsonl" 2>/dev/null; then
-                git -C /tmp/js2wasm-baselines show "origin/main:runs/${MERGE_BASE}.jsonl" > "/tmp/js2wasm-baselines/runs/${MERGE_BASE}.jsonl" 2>/dev/null || true
-                git -C /tmp/js2wasm-baselines show "origin/main:runs/${MERGE_BASE}.json"  > "/tmp/js2wasm-baselines/runs/${MERGE_BASE}.json"  2>/dev/null || true
-                echo "#3467 base cache runs/${MERGE_BASE}.jsonl present after ${WAITED}s → distance-0 diff."
-                break
-              fi
-              if [ "$attempt" -eq 6 ]; then
-                echo "::warning::#3467 base cache runs/${MERGE_BASE}.jsonl still absent after ${WAITED}s; falling through to the ancestor-walk (nearest cached ancestor — drift-free but distance>0)."
-                break
-              fi
-              echo "#3467 base cache runs/${MERGE_BASE}.jsonl not yet present (waited ${WAITED}s) — write-run-cache-bot likely still pushing; re-checking in 30s."
-              sleep 30
-              WAITED=$((WAITED + 30))
-            done
+            if git -C /tmp/js2wasm-baselines cat-file -e "origin/main:runs/${MERGE_BASE}.jsonl" 2>/dev/null; then
+              git -C /tmp/js2wasm-baselines show "origin/main:runs/${MERGE_BASE}.jsonl" > "/tmp/js2wasm-baselines/runs/${MERGE_BASE}.jsonl" 2>/dev/null || true
+              git -C /tmp/js2wasm-baselines show "origin/main:runs/${MERGE_BASE}.json"  > "/tmp/js2wasm-baselines/runs/${MERGE_BASE}.json"  2>/dev/null || true
+              echo "#3467 base cache runs/${MERGE_BASE}.jsonl present → distance-0 diff."
+            else
+              echo "::notice::#3467 base cache runs/${MERGE_BASE}.jsonl absent; continuing immediately to the ancestor-walk (nearest cached ancestor — drift-free but distance>0)."
+            fi
           fi
           # #3467 — build an ORDERED candidate list: the exact base first, then
           # its nearest-first ancestors. If the exact base's shards were skipped

--- a/plan/ci-acceleration-review.md
+++ b/plan/ci-acceleration-review.md
@@ -52,6 +52,26 @@ Other implemented pipeline reductions:
   `equivalence-gate` is a status fan-in instead of a second checkout/install
   plus eight artifact uploads and downloads.
 
+Production merge-group run 29810082992 then validated the 106-job matrix. The
+Test262 workflow took 13:09 end to end, split across the critical path as:
+
+| phase                                                | wall  | notes                                                           |
+| ---------------------------------------------------- | ----: | --------------------------------------------------------------- |
+| workflow start → first shard                         |  0:39 | change detection plus matrix release                            |
+| first shard start → last shard finish                |  7:47 | 106 jobs; the final standalone job started 50 s after the first |
+| post-shard regression gate                           |  4:41 | ran in parallel with the 0:45 report merge                      |
+| └ merge-base cache lookup                            |  3:40 | six fetch/probe attempts, including five 30 s sleeps             |
+| └ checkout, setup, install, baseline fetch, and diff |  1:01 | all remaining regression-gate work                              |
+
+The cache poll was therefore 78% of the post-shard gate and 28% of the entire
+workflow. It also waited on cache entries that can never appear when the
+predecessor is doc-only and intentionally ran no shards. The workflow now makes
+one immediate exact-base probe against the freshly cloned baseline repository,
+then falls through without sleeping to the nearest cached ancestor. The later
+predecessor-group artifact lookup remains the strongest exact fallback. This
+keeps distance-0 reuse when it is already available without turning a cache
+miss into a multi-minute critical-path stall.
+
 Running js-host then standalone on one runner remains a poor fit for the serial
 queue and available capacity: it saves setup work but serializes two compiler-
 heavy lanes while idle runners are available. Pairing is a contingency only if

--- a/tests/issue-3467.test.ts
+++ b/tests/issue-3467.test.ts
@@ -7,10 +7,12 @@
 // then nearest-first ancestors, with the commit DISTANCE surfaced so a cold base
 // is never silent.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { resolveFromCandidates } from "../scripts/resolve-merge-base-baseline.mjs";
+
+const ROOT = resolve(import.meta.dirname ?? ".", "..");
 
 describe("#3467 resolveFromCandidates ancestor-walk", () => {
   let dir: string;
@@ -92,5 +94,28 @@ describe("#3467 resolveFromCandidates ancestor-walk", () => {
     // the blank slot is filtered out, so anc1 is index 0 of the filtered list.
     expect(r.sha).toBe("anc1");
     expect(r.distance).toBe(0);
+  });
+});
+
+describe("#3467 merge-base cache workflow contract", () => {
+  const workflow = readFileSync(resolve(ROOT, ".github/workflows/test262-sharded.yml"), "utf8");
+  const stepStart = workflow.indexOf("- name: Load cached baseline for merge-base (#1081, base_sha #3467)");
+  const stepEnd = workflow.indexOf("- name: Resolve predecessor-group baseline (#1956)", stepStart);
+  const step = workflow.slice(stepStart, stepEnd);
+
+  it("probes the exact base once without blocking the regression gate", () => {
+    expect(stepStart).toBeGreaterThanOrEqual(0);
+    expect(stepEnd).toBeGreaterThan(stepStart);
+    expect(step).toContain("one-shot exact-base probe");
+    expect(step).toContain("continuing immediately to the ancestor-walk");
+    expect(step).not.toContain("WAITED=");
+    expect(step).not.toContain("for attempt in");
+    expect(step).not.toContain("sleep 30");
+  });
+
+  it("retains both safe fallbacks after an exact-cache miss", () => {
+    expect(step).toContain("--max-count=25");
+    expect(step).toContain("resolve-merge-base-baseline.mjs");
+    expect(workflow.indexOf("- name: Resolve predecessor-group baseline (#1956)")).toBeGreaterThan(stepStart);
   });
 });


### PR DESCRIPTION
## Summary

- replace the six-attempt merge-base result poll with one non-blocking exact-base probe
- fall through immediately to the nearest cached ancestor and predecessor-group artifact paths
- document the measured 13:09 critical path and add a workflow contract test against reintroducing sleeps

## Measured impact

Run 29810082992 spent 3:40 of its 4:41 post-shard regression gate in this polling step. The change removes five 30-second sleeps and repeated fetches, while retaining exact baseline reuse when it is already available.

## Validation

- workflow YAML parse
- 59 focused regression/workflow-contract tests
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run check:issues`
- `pnpm run sync:conformance:check`
