### PR TITLE
fix(ci): cancel Test262 when merge-group quality fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,67 @@ jobs:
       #       fi
       #     fi
 
+  # Keep Test262 parallel on the green path: making it depend on `quality`
+  # would add the full quality duration to every successful merge group. On a
+  # quality failure, however, the Test262 result cannot make the group
+  # mergeable. Cancel only the exact sibling run so a failing group stops
+  # consuming the large shard matrix while later groups keep running.
+  cancel-test262-on-quality-failure:
+    name: Cancel Test262 after quality failure
+    needs: quality
+    if: ${{ always() && github.event_name == 'merge_group' && needs.quality.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Cancel the exact Test262 sibling
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+
+          # One exact-SHA lookup, with no polling or retry loop. Treat API
+          # trouble as a warning: quality is already the authoritative failure,
+          # and this best-effort job must not obscure its diagnostics.
+          CANDIDATES=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?event=merge_group&head_sha=${HEAD_SHA}&per_page=100" \
+            --jq '.workflow_runs[] | [.id, .name, .path, .head_sha, .event, .status] | @tsv' \
+            2>&1) || {
+            echo "::warning::Could not list Test262 siblings; quality has already failed."
+            printf '%s\n' "$CANDIDATES"
+            exit 0
+          }
+
+          REQUESTED=0
+          while IFS=$'\t' read -r run_id run_name run_path run_sha run_event run_status; do
+            [ -n "${run_id:-}" ] || continue
+            [ "$run_name" = "Test262 Sharded" ] || continue
+            [ "$run_path" = ".github/workflows/test262-sharded.yml" ] || continue
+            [ "$run_sha" = "$HEAD_SHA" ] || continue
+            [ "$run_event" = "merge_group" ] || continue
+            case "$run_status" in
+              queued|in_progress) ;;
+              *) continue ;;
+            esac
+
+            echo "Cancelling Test262 run ${run_id} for failed merge-group SHA ${HEAD_SHA}."
+            if gh api -X POST \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null 2>&1; then
+              REQUESTED=$((REQUESTED + 1))
+            else
+              echo "::warning::GitHub rejected cancellation of Test262 run ${run_id}."
+            fi
+          done <<< "$CANDIDATES"
+
+          if [ "$REQUESTED" -eq 0 ]; then
+            echo "No queued or in-progress Test262 sibling matched this merge-group SHA."
+          else
+            echo "Requested cancellation of ${REQUESTED} Test262 sibling run(s)."
+          fi
+
   # #2139 — Execute the linear-backend (linear-memory lowering), C-ABI, and
   # SIMD test suites in CI. These 20 files (tests/linear-*.test.ts,
   # tests/c-abi.test.ts, tests/simd*.test.ts) sat at tests/ root with NO CI

--- a/tests/ci-quality-failfast.test.ts
+++ b/tests/ci-quality-failfast.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * The required quality gate and the expensive Test262 matrix start in parallel
+ * for merge groups. Once quality fails, Test262 cannot rescue that group, so CI
+ * cancels only the exact sibling run instead of spending the rest of its shard
+ * wave. These workflow-contract assertions keep the cancellation fail-safe.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname ?? ".", "..");
+const workflow = readFileSync(resolve(ROOT, ".github/workflows/ci.yml"), "utf8");
+const jobStart = workflow.indexOf("  cancel-test262-on-quality-failure:");
+const jobEnd = workflow.indexOf("\n  linear-tests:", jobStart);
+const job = workflow.slice(jobStart, jobEnd);
+
+describe("quality-failure Test262 cancellation", () => {
+  it("runs only after merge-group quality has actually failed", () => {
+    expect(jobStart).toBeGreaterThanOrEqual(0);
+    expect(jobEnd).toBeGreaterThan(jobStart);
+    expect(job).toContain("needs: quality");
+    expect(job).toContain(
+      "if: ${{ always() && github.event_name == 'merge_group' && needs.quality.result == 'failure' }}",
+    );
+    expect(job).toContain("actions: write");
+  });
+
+  it("selects only the active Test262 sibling for the exact merge-group SHA", () => {
+    expect(job).toContain("event=merge_group&head_sha=${HEAD_SHA}&per_page=100");
+    expect(job).toContain('[ "$run_name" = "Test262 Sharded" ]');
+    expect(job).toContain('[ "$run_path" = ".github/workflows/test262-sharded.yml" ]');
+    expect(job).toContain('[ "$run_sha" = "$HEAD_SHA" ]');
+    expect(job).toContain('[ "$run_event" = "merge_group" ]');
+    expect(job).toContain("queued|in_progress");
+    expect(job).toContain("actions/runs/${run_id}/cancel");
+  });
+
+  it("does one lookup without polling or retrying", () => {
+    expect(job).toContain("One exact-SHA lookup, with no polling or retry loop");
+    expect(job).not.toContain("sleep ");
+    expect(job).not.toContain("for attempt in");
+  });
+});


### PR DESCRIPTION
## Summary

- keep Test262 and quality parallel on successful merge groups
- after required quality fails, cancel only the queued/in-progress Test262 sibling with the exact SHA, event, name, and workflow path
- use one API lookup with no polling or retry loop, and pin the fail-safe selector in a workflow-contract test

## Validation

- `pnpm exec vitest run tests/ci-quality-failfast.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- YAML parse and extracted-shell syntax checks
- selector simulation with mixed SHA/path/event/status fixtures