### PR TITLE
feat(ir): claim exact generic Map module init

### DIFF
--- a/plan/issues/3517-ir-generic-map-module-init.md
+++ b/plan/issues/3517-ir-generic-map-module-init.md
@@ -1,0 +1,128 @@
+---
+id: 3517
+title: "IR: claim the exact generic Map module initializer"
+status: done
+completed: 2026-07-21
+sprint: 73
+created: 2026-07-21
+updated: 2026-07-21
+priority: high
+horizon: s
+feasibility: easy
+reasoning_effort: high
+task_type: feature
+area: ir, codegen
+language_feature: compiler-internals
+es_edition: es2015
+goal: ir-full-coverage
+parent: 2855
+depends_on: [2856]
+related: [2138, 3142]
+origin: "2026-07-21 IR-only migration: eliminate the last playground module-init fallback without widening generic constructor selection"
+files:
+  - plan/issues/3517-ir-generic-map-module-init.md
+  - src/ir/select.ts
+  - src/ir/from-ast.ts
+  - tests/issue-3517-map-module-init.test.ts
+  - scripts/ir-fallback-baseline.json
+  - scripts/gen-ir-adoption.mjs
+  - plan/log/ir-adoption.md
+loc-budget-allow:
+  - src/ir/select.ts
+---
+
+# #3517 — IR: claim the exact generic Map module initializer
+
+## Problem
+
+After #2856 drove function-level `body-shape-rejected` to zero and made
+Calendar's module initializer IR-owned, the playground fallback gate retained
+one module-level rejection:
+
+```ts
+const fibCache = new Map<number, number>();
+```
+
+The storage, constructor, and later `Map.get`/`Map.set` operations were already
+supported. Erasing the type arguments produced a source shape that selected,
+lowered, validated, and ran. The remaining rejection came solely from the
+selector's blanket `NewExpression.typeArguments` guard.
+
+Removing that guard generally would be unsound. It would admit generic local
+classes and shadowable constructor names without proving that the erased type
+arguments agree with the selected runtime ABI.
+
+## Implementation
+
+Admit one checker-certified exception to the generic-constructor guard. A
+`NewExpression` with type arguments is accepted only when all of these facts
+hold:
+
+- it is the initializer itself of a direct top-level `const` identifier;
+- the constructor is the ambient `Map` symbol, not a same-named local;
+- there are exactly two type arguments and zero runtime arguments;
+- the declaration's already-allocated module storage is extern `Map`;
+- the shared module-binding resolver accepts the extern call ABI; and
+- selection is currently assessing the single-source `<module-init>` unit.
+
+No storage, AST-to-IR lowering, Wasm lowering, host runtime, or import behavior
+is added. The accepted type arguments are erased exactly as they already are on
+the legacy path. Local generic constructors, wrapped initializers, `let`,
+shadowed `Map`, constructor arguments, native strings, fast mode,
+standalone/WASI, strict-no-host, and the M0 multi-source overlay remain outside
+the exception.
+
+## Acceptance criteria
+
+- [x] The exact live `website/playground/examples/js/algorithms.ts` source
+      genuinely IR-emits `<module-init>` under both IR-first settings.
+- [x] Its module Map is constructed once, persists across calls, and uses only
+      the exact `Map_new`, `Map_get`, and `Map_set` imports.
+- [x] The fallback gate records module-level `body-shape-rejected` at zero with
+      no function-level or post-claim increase.
+- [x] Unsupported generic constructors and every non-host/single-source lane
+      reject before claim.
+- [x] No direct-codegen, module-storage, lowering, or runtime implementation is
+      changed.
+
+## Implementation Summary
+
+### What was done
+
+- Added the exact ambient generic-Map module-initializer certification to the
+  selector and documented the erased-generic boundary beside lowering.
+- Added a focused live-source runtime suite with IR-first on/off anti-vacuity,
+  import-set checks, persistent Map read/write checks, and negative containment.
+- Banked the module-level fallback baseline from one to zero and regenerated
+  the IR-adoption record.
+
+### What worked
+
+- Reusing the checker-backed module-binding resolver proved every property the
+  existing builder and runtime require, so no new IR node or runtime path was
+  necessary.
+- Keeping the exception at direct top-level `const` initialization preserved
+  the general generic-constructor rejection and the M0/host-free boundaries.
+
+### What did not work
+
+- Broadly treating all constructor type arguments as erasable was rejected:
+  erasure alone does not prove constructor identity, storage representation, or
+  argument ABI.
+
+### Files changed
+
+- `src/ir/select.ts` and the corresponding boundary comment in
+  `src/ir/from-ast.ts`.
+- `tests/issue-3517-map-module-init.test.ts`.
+- The fallback baseline, generated IR-adoption record, and this issue file.
+
+## Test Results
+
+- Focused #3517 live-source and containment suite: 14/14 passed.
+- Combined Algorithms, module-binding, module-init, and M0 matrix (including
+  the focused suite): 108/108 passed across five suites.
+- Fallback gate: module-level body-shape 0; function body-shape 0; deferred
+  async 4; no post-claim demotions.
+- Typecheck, adoption generation/check, formatting, LOC, and diff gates:
+  passed.

--- a/plan/issues/3517-ir-generic-map-module-init.md
+++ b/plan/issues/3517-ir-generic-map-module-init.md
@@ -28,6 +28,7 @@ files:
   - scripts/gen-ir-adoption.mjs
   - plan/log/ir-adoption.md
 loc-budget-allow:
+  - src/ir/from-ast.ts
   - src/ir/select.ts
 ---
 

--- a/plan/log/ir-adoption.md
+++ b/plan/log/ir-adoption.md
@@ -128,8 +128,8 @@ MODULE whose module-init unit is not claimable (gated must-not-increase by
 `check:ir-fallbacks`). Slice 2 wires the actual lowering + the
 `__module_init` slot patch; only then do legacy statement handlers become
 per-file deletable (gate G3 in `plan/log/3090-phase0-legacy-delete-list.md`).
-The current corpus floor is **1**: Calendar's nine-statement initializer is
-IR-owned; Algorithms' top-level Map initializer is the remaining unit.
+The current corpus floor is **0** (#3517): Calendar's nine-statement initializer
+and Algorithms' top-level generic Map initializer are both IR-owned.
 
 | Bucket reason                 | Category   | What promotes a row                                                                                                                                   |
 | ----------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/scripts/gen-ir-adoption.mjs
+++ b/scripts/gen-ir-adoption.mjs
@@ -281,8 +281,8 @@ MODULE whose module-init unit is not claimable (gated must-not-increase by
 \`check:ir-fallbacks\`). Slice 2 wires the actual lowering + the
 \`__module_init\` slot patch; only then do legacy statement handlers become
 per-file deletable (gate G3 in \`plan/log/3090-phase0-legacy-delete-list.md\`).
-The current corpus floor is **1**: Calendar's nine-statement initializer is
-IR-owned; Algorithms' top-level Map initializer is the remaining unit.`;
+The current corpus floor is **0** (#3517): Calendar's nine-statement initializer
+and Algorithms' top-level generic Map initializer are both IR-owned.`;
 
 const FOOTER = `## How to update this table
 

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -13,6 +13,6 @@
     "backend-legality": {}
   },
   "moduleLevel": {
-    "body-shape-rejected": 1
+    "body-shape-rejected": 0
   }
 }

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -4232,7 +4232,10 @@ function lowerNestedFuncCall(
  *
  * The class shape is looked up against `cx.classShapes`. Argument types
  * must match the constructor's declared `constructorParams`. Generic
- * type-arguments are not supported (the selector rejects them).
+ * type-arguments are normally rejected by the selector; #3517 admits only a
+ * checker-certified direct module `const Map<K, V>` initializer because those
+ * arguments are erased and its extern storage/constructor ABI is already
+ * proven.
  *
  * Returns the SSA value of the constructed instance — its IrType is
  * `{ kind: "class", shape }` so subsequent property accesses / method

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -3559,6 +3559,32 @@ function exactModuleMapMethod(expr: ts.CallExpression): string | undefined {
 }
 
 /**
+ * #3517: certify the sole erased-generic constructor shape admitted by the
+ * module-init selector. This deliberately requires the NewExpression itself
+ * to initialize a direct top-level `const`; wrappers, locals, `let`, runtime
+ * arguments, shadowed `Map`, and non-extern storage all retain the generic
+ * constructor rejection.
+ */
+function isExactModuleMapGenericInitializer(expr: ts.NewExpression): boolean {
+  const resolver = currentModuleBindingResolver;
+  if (!currentSubjectIsModuleInit || resolver === null) return false;
+  if (!ts.isIdentifier(expr.expression) || expr.expression.text !== "Map") return false;
+  if (expr.typeArguments?.length !== 2 || (expr.arguments?.length ?? 0) !== 0) return false;
+  if (!resolver.isAmbientBinding(expr.expression) || !resolver.externCallArgumentsMatch(expr)) return false;
+
+  const declaration = expr.parent;
+  if (!ts.isVariableDeclaration(declaration) || declaration.initializer !== expr) return false;
+  if (!ts.isIdentifier(declaration.name)) return false;
+  const declarationList = declaration.parent;
+  if (!ts.isVariableDeclarationList(declarationList) || !(declarationList.flags & ts.NodeFlags.Const)) return false;
+  const statement = declarationList.parent;
+  if (!ts.isVariableStatement(statement) || !ts.isSourceFile(statement.parent)) return false;
+
+  const storage = resolver(declaration.name);
+  return storage?.valueKind.kind === "extern" && storage.valueKind.className === "Map";
+}
+
+/**
  * The one scalar method whose current host-string lowering is
  * representation-safe. The receiver proof deliberately covers numeric call
  * results as well as direct module globals/aliases: calendar::renderCal calls
@@ -4292,7 +4318,15 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     }
     if (!localClasses.has(ctorName) && !isKnownExternClass(ctorName))
       return shapeNo("expr-new-ctor-unknown", expr.expression);
-    if (expr.typeArguments && expr.typeArguments.length > 0) return shapeNo("expr-new-type-args", expr); // defer generics
+    // Type arguments are erased before lowering, but accepting them in the
+    // general constructor surface would silently widen generic local classes
+    // and shadowable builtin names. The one certified exception is the direct
+    // module initializer `const cache = new Map<K, V>()`: its ambient
+    // constructor identity, extern Map storage, arity, and host ABI are all
+    // checker-proven by the shared module-binding resolver.
+    if (expr.typeArguments && expr.typeArguments.length > 0 && !isExactModuleMapGenericInitializer(expr)) {
+      return shapeNo("expr-new-type-args", expr);
+    }
     if (currentModuleBindingResolver && !currentModuleBindingResolver.externCallArgumentsMatch(expr)) {
       return shapeNo("expr-new-module-extern-call-brand", expr);
     }

--- a/tests/issue-3517-map-module-init.test.ts
+++ b/tests/issue-3517-map-module-init.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { compile, compileMulti, type CompileOptions, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+const ALGORITHMS_URL = new URL("../website/playground/examples/js/algorithms.ts", import.meta.url);
+const ALGORITHMS_SOURCE = readFileSync(ALGORITHMS_URL, "utf8");
+const MAP_SOURCE = `
+  const cache = new Map<number, number>();
+  export function memo(n: number): number {
+    if (n < 2) return n;
+    const hit = cache.get(n);
+    if (hit !== undefined) return hit;
+    const value = memo(n - 1) + memo(n - 2);
+    cache.set(n, value);
+    return value;
+  }
+`;
+
+const previousIrFirst = process.env.JS2WASM_IR_FIRST;
+afterEach(() => {
+  if (previousIrFirst === undefined) Reflect.deleteProperty(process.env, "JS2WASM_IR_FIRST");
+  else process.env.JS2WASM_IR_FIRST = previousIrFirst;
+});
+
+function expectSuccess(result: CompileResult): void {
+  expect(result.success, result.errors.map((error) => `${error.severity}: ${error.message}`).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+}
+
+function mapImportNames(result: CompileResult): string[] {
+  return WebAssembly.Module.imports(new WebAssembly.Module(result.binary))
+    .filter((entry) => entry.kind === "function" && entry.module === "env" && entry.name.startsWith("Map_"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+async function tracked(source: string, options: CompileOptions = {}): Promise<CompileResult> {
+  return compile(source, {
+    fileName: "issue-3517-map-module-init.ts",
+    experimentalIR: true,
+    trackFallbacks: true,
+    skipSemanticDiagnostics: true,
+    ...options,
+  });
+}
+
+describe("#3517 exact generic Map module initializer", () => {
+  for (const irFirst of ["0", "1"] as const) {
+    it(`IR-emits and runs the exact algorithms source with JS2WASM_IR_FIRST=${irFirst}`, async () => {
+      process.env.JS2WASM_IR_FIRST = irFirst;
+      const result = await tracked(ALGORITHMS_SOURCE, { fileName: ALGORITHMS_URL.pathname });
+
+      expectSuccess(result);
+      expect(result.irCompiledFuncs ?? []).toContain("<module-init>");
+      expect(result.irPostClaimErrors ?? []).toEqual([]);
+      expect(mapImportNames(result)).toEqual(["Map_get", "Map_new", "Map_set"]);
+
+      const built = buildImports(result.imports, undefined, result.stringPool);
+      const env = built.env as Record<string, (...args: unknown[]) => unknown>;
+      const originalNew = env.Map_new!;
+      const originalGet = env.Map_get!;
+      const originalSet = env.Map_set!;
+      const maps: unknown[] = [];
+      let getCalls = 0;
+      let setCalls = 0;
+      const logs: string[] = [];
+      env.console_log_string = (value: unknown) => logs.push(String(value));
+      env.Map_new = (...args: unknown[]) => {
+        const map = originalNew(...args);
+        maps.push(map);
+        return map;
+      };
+      env.Map_get = (receiver: unknown, ...args: unknown[]) => {
+        getCalls++;
+        expect(receiver).toBe(maps[0]);
+        return originalGet(receiver, ...args);
+      };
+      env.Map_set = (receiver: unknown, ...args: unknown[]) => {
+        setCalls++;
+        expect(receiver).toBe(maps[0]);
+        return originalSet(receiver, ...args);
+      };
+
+      const imports: WebAssembly.Imports = { env: built.env, string_constants: built.string_constants };
+      imports["wasm:js-string"] = built["wasm:js-string"] as unknown as WebAssembly.ModuleImports;
+      const { instance } = await WebAssembly.instantiate(result.binary, imports);
+      built.setExports?.(instance.exports as Record<string, Function>);
+      expect(maps).toHaveLength(1);
+
+      const main = instance.exports.main as () => void;
+      main();
+      const firstLogs = [...logs];
+      const firstGets = getCalls;
+      const firstSets = setCalls;
+      expect(firstGets).toBeGreaterThan(0);
+      expect(firstSets).toBeGreaterThan(0);
+      expect(firstLogs.at(-1)).toBe("after  = [0,1,2,3,4,5,6,7,8,9]");
+
+      main();
+      expect(logs.slice(firstLogs.length)).toEqual(firstLogs);
+      expect(getCalls).toBeGreaterThan(firstGets);
+      expect(setCalls, "the second run reuses the populated module Map").toBe(firstSets);
+      expect(maps).toHaveLength(1);
+    });
+  }
+
+  it.each([
+    ["let binding", `let cache = new Map<number, number>(); export function read(): number { return 1; }`],
+    ["one type argument", `const cache = new Map<number>(); export function read(): number { return 1; }`],
+    [
+      "runtime argument",
+      `const cache = new Map<number, number>([[1, 2]]); export function read(): number { return 1; }`,
+    ],
+    [
+      "conditional wrapper",
+      `const cache = true ? new Map<number, number>() : new Map<number, number>(); export function read(): number { return 1; }`,
+    ],
+    [
+      "shadowed Map",
+      `class Map<K, V> {} const cache = new Map<number, number>(); export function read(): number { return 1; }`,
+    ],
+  ])("keeps the unsupported %s module shape on the direct initializer", async (_label, source) => {
+    const result = await tracked(source);
+    expectSuccess(result);
+    expect(result.irCompiledFuncs ?? []).not.toContain("<module-init>");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps typed local constructors outside the exception", async () => {
+    const result = await tracked(`
+      class Box<T, U> {}
+      export function make(): number {
+        const value = new Box<number, number>();
+        return value === null ? 0 : 1;
+      }
+    `);
+    expectSuccess(result);
+    expect(result.irCompiledFuncs ?? []).not.toContain("make");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it.each([
+    ["native strings", { nativeStrings: true }],
+    ["fast", { fast: true }],
+    ["standalone", { target: "standalone" as const }],
+    ["WASI", { target: "wasi" as const }],
+    ["strict no-host", { strictNoHostImports: true }],
+  ])("keeps the Map module initializer legacy-owned in %s", async (_label, options) => {
+    const result = await tracked(MAP_SOURCE, options);
+    expectSuccess(result);
+    expect(result.irCompiledFuncs ?? []).not.toContain("<module-init>");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+
+  it("keeps module init legacy-owned in the M0 multi-source overlay", async () => {
+    const result = await compileMulti(
+      {
+        "./dep.ts": `export function identity(value: number): number { return value; }`,
+        "./entry.ts": `
+          import { identity } from "./dep";
+          ${MAP_SOURCE}
+          export function run(n: number): number { return identity(memo(n)); }
+        `,
+      },
+      "./entry.ts",
+      {
+        experimentalIR: true,
+        trackFallbacks: true,
+        skipSemanticDiagnostics: true,
+      },
+    );
+    expectSuccess(result);
+    expect(result.irCompiledFuncs ?? []).not.toContain("<module-init>");
+    expect(result.irPostClaimErrors ?? []).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- certify the erased `Map<K, V>` constructor only when it directly initializes an extern-backed top-level `const` through the ambient host `Map` ABI
- make the exact checked-in Algorithms module initializer IR-owned under both IR-first settings
- bank the module-level `body-shape-rejected` fallback floor from 1 to 0 and update the generated adoption record
- retain pre-claim refusal for local or shadowed constructors, runtime arguments, `let`, native-string/fast/host-free lanes, and M0 multi-source compilation

## Why

The last playground module-init residual already had supported storage, lowering, and runtime behavior. It was rejected only by the selector's blanket generic-constructor guard. This change adds a checker-certified exception at that boundary without widening generic construction generally or adding a second runtime path.

The repository-local work item and acceptance evidence are recorded in `plan/issues/3517-ir-generic-map-module-init.md`; no GitHub Issue is used.

## Validation

- `pnpm exec vitest run tests/issue-3517-map-module-init.test.ts --reporter=dot` — 14/14
- adjacent Algorithms/module-binding/module-init/M0 matrix — 108/108
- `pnpm run check:ir-fallbacks -- --verbose` — function body 0, module body 0, deferred async 4, no post-claim demotions
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run check:loc-budget`
- `pnpm run check:ir-adoption`
- `pnpm run check:issues`
- committed-tree issue integrity and diff checks

No Test262 results, run logs, baselines, or benchmark artifacts are changed.
