### PR TITLE
docs(#3487): verified root cause + #3524 toString follow-up

### DIFF
--- a/plan/issues/3487-string-valueof-nongeneric-illegal-cast.md
+++ b/plan/issues/3487-string-valueof-nongeneric-illegal-cast.md
@@ -1,15 +1,16 @@
 ---
 id: 3487
 title: "String.prototype.valueOf non-generic receiver traps illegal_cast (uncatchable) instead of throwing catchable TypeError"
-status: ready
+status: blocked
 sprint: current
 priority: high
-horizon: s
-feasibility: medium
+horizon: l
+feasibility: hard
 task_type: bug
 area: test262-conformance
 goal: test262-conformance
 created: 2026-07-20
+blocked_on: closure-value substrate (builtin proto-method stored as an object field, invoked via the generic ToPrimitive `+`/eqref-closure dispatch); needs architect spec — see "Verified root cause (2026-07-21)"
 ---
 
 ## Problem
@@ -44,29 +45,112 @@ Scope is exactly **+1, one test** — no other trap category moved, and it staye
 +1 across the whole host-restore wave (verified at the latest test-bearing tip
 d0cc9028e).
 
-The receiver lowering does a `ref.cast` of the `this` value to the String
-struct type; when `this` is a non-String the cast traps (uncatchable) instead
-of routing to a `TypeError` throw. Historically this test was
-`compile_error`/`fail` (never passing — months of local baseline history), so
-this is a **failure-mode regression (fail/CE → uncatchable trap), not a
-pass→fail loss** — but an uncatchable trap is strictly worse for standalone (it
-aborts the module) and trips the #3189 ratchet.
+Historically this test was `compile_error`/`fail` (never passing — months of
+local baseline history), so this is a **failure-mode regression (fail/CE →
+uncatchable trap), not a pass→fail loss** — but an uncatchable trap is strictly
+worse for standalone (it aborts the module) and trips the #3189 ratchet.
 
-## Bisect range (culprit not yet pinned)
+> **Superseded hypothesis (2026-07-19):** the original guess — "the receiver
+> lowering does a `ref.cast` of `this` to the String struct type; route that
+> cast-failure to a TypeError throw" — is **wrong** and was empirically
+> disproven. See "Verified root cause (2026-07-21)" below. All seven direct
+> `valueOf.call(nonString)` assertions already throw a catchable TypeError
+> correctly; the trap comes from the test's **last** assertion, a ToPrimitive
+> `+` on an object whose `valueOf` field holds the builtin proto method.
 
-Baseline last clean at **#3419** (f48e67e0, illegal_cast=79); first tripped at
-**01862f8a8** (#3421 merge, illegal_cast=80). Candidate merges in that window:
-#3424 (release), #3425/#3426 (chores/plan — unlikely codegen), **#3423**
-(standalone fn-expr strconcat param), **#3428** (#3430 strict compound/logical
-assignment throws on failed [[Set]]), #3429, #3421. Most plausibly an
-error-model codegen change (#3428 or #3423). Confirm by compiling
-`String/prototype/valueOf/non-generic.js` at HEAD^1 of each candidate and
-observing where the illegal_cast trap first appears.
+## Verified root cause (2026-07-21, senior-dev; executable spec)
+
+Pinned by local host-lane probes against current `main` (9c6a1f2c). The trap is
+**not** in `String.prototype.valueOf`'s receiver check — it is in how a
+**builtin proto method stored as an object field value** is invoked through the
+generic ToPrimitive `+` / eqref-closure dispatch.
+
+**What actually fails in `valueOf/non-generic.js`.** All seven direct
+`valueOf.call(nonString)` assertions (`true`, `-0`, `null`, no-arg, `Symbol`,
+`{toString}`, `['s','t','r']`) **already throw a catchable TypeError** — verified
+individually, each returns caught=`TypeError`. The single failing line is the
+tail:
+
+```js
+assert.throws(TypeError, function() { 'str' + {valueOf: valueOf}; });
+```
+
+`'str' + {valueOf: String.prototype.valueOf}` → uncatchable `RuntimeError:
+illegal cast` (trace `illegal cast [in __cb_15() ← __closure_34 ←
+__call_fn_method_3 ← __module_init]`). That one trap fails the file **and** trips
+the #3189 ratchet 79→80.
+
+**Controls that localize it (this is the decisive evidence).**
+
+| Snippet | Result |
+|---|---|
+| `'str' + {valueOf: () => 'hello'}` | `"strhello"` ✅ (user closure, string result) |
+| `'str' + {valueOf: () => 42}` | `"str42"` ✅ (user closure, number result) |
+| `'str' + {valueOf: String.prototype.valueOf}` | **illegal_cast trap** ❌ |
+| `valueOf.call(nonString)` (direct `.call`) | catchable `TypeError` ✅ |
+
+So **user-defined** valueOf closures flow through `+`/ToPrimitive correctly. The
+trap fires **only** when the field holds a reflective **builtin proto method**
+(`String.prototype.valueOf`). The identical builtin throws a catchable TypeError
+via direct `.call` but `ref.cast`-traps when the ToPrimitive dispatch invokes it.
+
+**Why the obvious guard does NOT work.** Narrowing the over-eager static
+ToPrimitive reduction — dropping the untracked closure-ref fallback in
+`structHasStaticNumericToPrimitive` (`src/codegen/binary-ops.ts` ~L1937-1939),
+which fires because `{valueOf: String.prototype.valueOf}` is **untracked**
+(a reflective proto read emits no `struct.new` closure, so `valueOfClosureTypes`
+is never populated for it) — was tried and the trap **persisted**: the operand
+then flows to the **dynamic** `__to_primitive` eqref-closure dispatch, which
+traps the same way. The bug is in the dispatch/closure-value path, not the
+static-reduction trigger.
+
+**Root cause (substrate).** A builtin proto method read reflectively
+(`String.prototype.valueOf` / `toString`) and stored as an object field is a
+closure value whose ABI/receiver handling differs from a user closure. When the
+generic ToPrimitive `+` (and `.concat`) dispatch does `call_ref` on that field,
+the receiver reaches the builtin body as a non-externref ref that gets
+`ref.cast`-ed → uncatchable trap, instead of the catchable-TypeError path the
+direct `.call` machinery takes. This is the **closure-value / builtin-proto-
+method-as-first-class-value** substrate (host-fail triage cluster #5 family),
+not a localized codegen guard.
+
+## Fix approach (for the architect)
+
+Make the generic ToPrimitive/eqref-closure dispatch handle a field-stored
+builtin proto method the same way direct `.call` does. Two candidate directions
+(architect to choose / spec exactly):
+
+1. **Box the receiver to externref before `call_ref`** in the ToPrimitive
+   eqref-closure dispatch, so the builtin body's `RequireObjectCoercible`/brand
+   check runs (which already produces a catchable TypeError), instead of the
+   receiver reaching the body as a raw struct ref that `ref.cast`-traps.
+2. **Route a non-matching receiver to a catchable TypeError at the dispatch
+   site** (a `ref.test` + throw, not a bare `ref.cast`).
+
+Both must hold in **host and standalone** lanes (the ratchet is the standalone
+uncatchable-trap metric). Verify with the four control snippets above plus the
+two test262 files; watch the #1917 coercion-engine byte-diff neutrality gate
+(the fix should be byte-neutral by construction — it only changes a shape that
+currently traps).
+
+## Flip value
+
+- `valueOf/non-generic.js`: **+1** host file (this issue's acceptance).
+- `toString/non-generic.js`: **+1** more with the follow-up **#3524** (toString
+  also needs the non-generic `thisStringValue` check — its first assertion
+  `toString.call(nonString)` returns a generic ToString instead of throwing —
+  AND shares this exact concat-tail trap via `''.concat({toString: toString})`).
+- Returns the `illegal_cast` ratchet **80→79** and removes a standalone
+  module-abort.
 
 ## Acceptance
 
-- `String.prototype.valueOf` on a non-String receiver throws a **catchable
-  TypeError** (not an `illegal_cast` trap) in both host and standalone lanes.
+- The ToPrimitive `+`/`.concat` dispatch invoking a field-stored builtin proto
+  method (`String.prototype.valueOf`) on a non-String receiver throws a
+  **catchable TypeError** (not an `illegal_cast` trap) in both host and
+  standalone lanes. Verified by all four control snippets above.
+- `test/built-ins/String/prototype/valueOf/non-generic.js` passes in the host
+  lane.
 - Baseline `illegal_cast` category returns to **79** (or lower) on the next
   promote, and the repo Actions variable `BASELINE_TRAP_GROWTH_ALLOW` stays at
   the default `0`.

--- a/plan/issues/3524-string-tostring-nongeneric-no-throw.md
+++ b/plan/issues/3524-string-tostring-nongeneric-no-throw.md
@@ -1,0 +1,78 @@
+---
+id: 3524
+title: "String.prototype.toString non-generic receiver: doesn't throw on non-String (generic ToString), plus concat-tail illegal_cast"
+status: ready
+sprint: current
+priority: medium
+horizon: m
+feasibility: hard
+task_type: bug
+area: test262-conformance
+goal: test262-conformance
+created: 2026-07-21
+---
+
+## Problem
+
+`test/built-ins/String/prototype/toString/non-generic.js` requires
+`String.prototype.toString.call(nonString)` to throw a **catchable TypeError**
+(`thisStringValue(this)` throws when `this` is neither a String primitive nor a
+String object). The compiler currently does the wrong thing on **two** fronts:
+
+1. **First (reported) failure — no throw at all.** `toString.call(false)` (and
+   `1`, `null`, no-arg, `Symbol`, `{toString}`, array) does **not** throw —
+   the reflective `String.prototype.toString` closure runs a **generic**
+   `ToString(this)` and returns e.g. `"false"`. test262 reports
+   *"Expected a TypeError to be thrown but no exception was thrown at all."*
+   Verified with per-arg host-lane probes (2026-07-21): every case returns
+   caught=`none`.
+
+2. **Tail — shared illegal_cast trap.** The last assertion
+   `''.concat({toString: toString})` (where `toString =
+   String.prototype.toString`) traps an uncatchable `illegal_cast`, the SAME
+   root cause as **#3487**: a reflective builtin proto method stored as an
+   object field, invoked through the generic ToPrimitive/`.concat` eqref-closure
+   dispatch, hits a `ref.cast` on the receiver instead of the catchable-TypeError
+   path direct `.call` takes.
+
+## Relationship to #3487
+
+Split off from #3487 (String.prototype.**valueOf** non-generic) so #3487 stays
+scoped to its acceptance (+1 host file, ratchet 80→79). This file (`toString`)
+was NOT in #3487's acceptance and needs an **additional** fix beyond the shared
+substrate one. Cross-link: **#3487** carries the verified root cause + fix
+approach for the shared concat-tail trap (front #2). Both files flip together
+once the substrate fix lands AND this file's front #1 is fixed.
+
+## Fixes required
+
+1. **Non-generic `thisStringValue` for the reflective `String.prototype.toString`
+   closure** (front #1): the reflective `toString` closure body must check
+   `this` is a String primitive / String object and throw a **catchable
+   TypeError** otherwise, instead of running generic `ToString(this)`. Host and
+   standalone lanes. In standalone this currently routes to
+   `emitProtoMemberBodyRefusal` (a catchable TypeError) in
+   `emitStringProtoMemberBody` (`src/codegen/array-object-proto.ts` ~L787) — but
+   the **host** lane returns a generic string; align both to the non-generic
+   throw.
+
+2. **Shared concat-tail illegal_cast** (front #2): fixed by the #3487 substrate
+   work (box the receiver to externref before `call_ref`, or route a
+   non-matching receiver to a catchable TypeError at the ToPrimitive/`.concat`
+   dispatch site). Depends on / shares that fix.
+
+## Acceptance
+
+- `toString.call(nonString)` throws a **catchable TypeError** (host + standalone)
+  for all non-String receivers.
+- `''.concat({toString: String.prototype.toString})` throws a **catchable
+  TypeError** (not `illegal_cast`) — via the #3487 shared fix.
+- `test/built-ins/String/prototype/toString/non-generic.js` passes in the host
+  lane (+1).
+
+## Notes
+
+The `*-realm.js` variants (`valueOf/non-generic-realm.js`,
+`toString/non-generic-realm.js`) fail for a DIFFERENT reason (cross-realm setup
+→ `TypeError: Cannot access property on null or undefined`) and need realm
+support; they are out of scope here.


### PR DESCRIPTION
Docs-only. Persists the verify-first root cause of #3487 as an executable spec and files the toString follow-up (#3524). **No code change.**

## #3487 re-scoped (S→L, medium→hard, ready→blocked/needs-architect)
Local host-lane probes against `main` disproved the frontmatter's hypothesis ("route the receiver `ref.cast` to a TypeError"). Verified findings:
- All 7 direct `valueOf.call(nonString)` assertions **already** throw a catchable TypeError. The only failing line is the tail `'str' + {valueOf: valueOf}` → uncatchable `illegal_cast` (this is what trips the #3189 ratchet 79→80).
- Controls: `'str' + {valueOf: () => 42}` and `+ {valueOf: () => 'hello'}` **work**; the trap fires **only** when the field holds a reflective **builtin** proto method (`String.prototype.valueOf`). Same builtin via direct `.call` throws catchable TypeError.
- Narrowing the static ToPrimitive reduction (`structHasStaticNumericToPrimitive` untracked closure-ref fallback) does **not** fix it — the trap persists via the dynamic `__to_primitive` eqref-closure dispatch. Root cause is the **closure-value / builtin-proto-method-as-first-class-value** substrate (host-fail triage cluster #5 family).
- Fix approach for the architect: box the receiver to externref before `call_ref` in the ToPrimitive/`.concat` dispatch, OR route a non-matching receiver to a catchable TypeError at the dispatch site. Host + standalone; byte-neutral by construction.
- Flip value: +1 (valueOf), +2 with #3524; ratchet 80→79.

## #3524 (new, follow-up)
`String.prototype.toString/non-generic.js`: a SEPARATE bug (generic `toString.call(nonString)` returns instead of throwing) **plus** the shared #3487 concat-tail trap. Not in #3487's acceptance. Cross-linked. Id reserved via `claim-issue.mjs --allocate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb