### PR TITLE
fix(#3409): portable pre-push format-gate watchdog (no GNU timeout dep)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -122,13 +122,37 @@ if grep -q '"format:check"' package.json 2>/dev/null; then
   # wedging agents in push wait-loops). CI's `quality` job re-runs the exact same
   # `format:check`, so on a LOCAL hang we degrade to a warning and let the push
   # proceed; on a genuine format failure (prettier exits non-zero fast) we block.
-  fmt_out=$(timeout 90 pnpm run format:check 2>&1)
+  #
+  # The watchdog is PORTABLE (#3409): stock macOS ships no GNU `timeout`, so an
+  # unconditional `timeout 90 …` used to exit 127 (command-not-found) before
+  # prettier ran and get mislabeled as a format failure, blocking every macOS
+  # push with a blank "Offending files" list. run_format_watchdog probes for
+  # `timeout`/`gtimeout` and falls open to a direct (un-watchdogged) run when
+  # neither exists — never synthesizing a 127. It lives in a sourced helper so it
+  # can be unit-tested (tests/hooks/pre-push-format-timeout.test.ts), mirroring
+  # the #3410 push-remote-classify.sh split.
+  fmt_lib="$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/format-gate.sh"
+  if [ -r "$fmt_lib" ]; then
+    . "$fmt_lib"
+    fmt_out=$(run_format_watchdog 90 pnpm run format:check 2>&1)
+  else
+    echo "Pre-push: WARNING — cannot read $fmt_lib; running format:check without a watchdog." >&2
+    fmt_out=$(pnpm run format:check 2>&1)
+  fi
   fmt_rc=$?
   if [ "$fmt_rc" -eq 124 ]; then
     echo "Pre-push: format:check TIMED OUT (90s) — skipping local check, CI 'quality' will enforce it."
   elif [ "$fmt_rc" -ne 0 ]; then
     echo "Pre-push: format:check FAILED. Offending files:"
-    echo "$fmt_out" | grep -iE '\[warn\]|^\S+\.ts$' | head -30
+    # Prefer the prettier warning / *.ts filter, but if it matches nothing (e.g.
+    # a runner/setup error rather than a formatting defect) show the RAW output
+    # instead of an empty section, so the real cause is visible (#3409).
+    fmt_filtered=$(echo "$fmt_out" | grep -iE '\[warn\]|^\S+\.ts$' | head -30)
+    if [ -n "$fmt_filtered" ]; then
+      echo "$fmt_filtered"
+    else
+      echo "$fmt_out" | head -30
+    fi
     echo ""
     echo "Fix with: pnpm run format:write   (or: npx prettier --write <file>)"
     echo "Then re-push. (Or --no-verify to defer to CI.)"

--- a/plan/issues/3409-portable-prepush-format-timeout.md
+++ b/plan/issues/3409-portable-prepush-format-timeout.md
@@ -1,9 +1,11 @@
 ---
 id: 3409
 title: "Pre-push format gate hard-depends on GNU timeout and falsely blocks macOS pushes"
-status: ready
+status: done
+assignee: ttraenkler/sr-3409
+completed: 2026-07-21
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-21
 priority: high
 horizon: s
 feasibility: easy
@@ -76,14 +78,36 @@ pre-push safety/integrity guard.
 
 ## Acceptance criteria
 
-- [ ] A normal push on stock macOS reaches and executes `pnpm run format:check`.
-- [ ] A correctly formatted branch is not blocked when GNU `timeout` is absent.
-- [ ] A real Prettier failure still blocks and names the offending file(s).
-- [ ] A watchdog expiry emits the documented warning and defers to CI without
-      being mislabeled as a formatting defect.
-- [ ] An unexpected runner/setup failure exposes its real stderr and does not
-      print an empty `Offending files` section.
-- [ ] Linux behavior and the 90-second hang protection remain covered.
+- [x] A normal push on stock macOS reaches and executes `pnpm run format:check`.
+      (`run_format_watchdog` falls open to a direct run when no watchdog exists.)
+- [x] A correctly formatted branch is not blocked when GNU `timeout` is absent.
+      (Test: "no watchdog on PATH: success returns 0, NOT a spurious 127".)
+- [x] A real Prettier failure still blocks and names the offending file(s).
+      (Tests: watchdog-present + no-watchdog "genuine format failure blocks (rc 1)".)
+- [x] A watchdog expiry emits the documented warning and defers to CI without
+      being mislabeled as a formatting defect. (rc 124 branch unchanged; test:
+      "a hung check yields the 124 timeout code, not a format failure".)
+- [x] An unexpected runner/setup failure exposes its real stderr and does not
+      print an empty `Offending files` section. (Hook now falls back to the raw
+      `$fmt_out` when the `[warn]`/`*.ts` filter matches nothing.)
+- [x] Linux behavior and the 90-second hang protection remain covered.
+      (Watchdog-present path retained verbatim; covered by the 124/rc-0/rc-1 tests.)
+
+## Resolution (2026-07-21)
+
+Watchdog logic extracted into a sourced POSIX-sh helper
+`scripts/hooks/format-gate.sh` (`find_watchdog` + `run_format_watchdog`),
+mirroring the #3410 `push-remote-classify.sh` split. `.husky/pre-push` sources it
+and calls `run_format_watchdog 90 pnpm run format:check`; the 124/nonzero/0
+branching is unchanged. When neither `timeout` nor `gtimeout` is on PATH the
+helper runs the command directly (never synthesizes a 127) and prints a
+one-line stderr notice. The FAILED branch now prints the raw output when the
+`[warn]`/`*.ts` filter matches nothing, so setup errors are no longer blank.
+Covered by `tests/hooks/pre-push-format-timeout.test.ts` (7 cases: watchdog
+present rc 0/1/124; no-watchdog rc 0-not-127 / rc 1 / stderr notice;
+`find_watchdog` bare-PATH). Shell files are outside the `format:check` glob
+(`*.ts` only), so no formatter-scope change. Watchdog-present cases `skipIf` no
+ambient `timeout` so the suite is itself portable.
 
 ## Validation plan
 

--- a/scripts/hooks/format-gate.sh
+++ b/scripts/hooks/format-gate.sh
@@ -1,0 +1,60 @@
+# shellcheck shell=sh
+# #3409 — portable format-gate watchdog for the pre-push hook.
+#
+# The pre-push prettier gate (.husky/pre-push, section 3b) must bound how long
+# `pnpm run format:check` may run so a hung check never SIGTERMs at git's 300s
+# limit and silently aborts the push. It previously called GNU `timeout`
+# UNCONDITIONALLY:
+#
+#     fmt_out=$(timeout 90 pnpm run format:check 2>&1)
+#
+# Stock macOS ships no `timeout` (and Homebrew's `gtimeout` may be absent), so
+# the shell returned 127 (command-not-found) BEFORE prettier ever ran. The hook
+# treats any code other than 124 as a genuine format failure and blocked the
+# push — with a blank "Offending files" section, because the real
+# `timeout: command not found` error was filtered out. `--no-verify` was the
+# only escape, and it bypasses every other pre-push guard.
+#
+# This helper is sourced by `.husky/pre-push` and unit-tested directly
+# (tests/hooks/pre-push-format-timeout.test.ts), mirroring the #3410
+# push-remote-classify.sh split. POSIX sh only.
+
+# find_watchdog: echo the available bounded-run binary (`timeout` or the
+# Homebrew-coreutils `gtimeout`), or nothing when neither is on PATH.
+find_watchdog() {
+  if command -v timeout >/dev/null 2>&1; then
+    echo timeout
+  elif command -v gtimeout >/dev/null 2>&1; then
+    echo gtimeout
+  fi
+}
+
+# run_format_watchdog SECS CMD [ARG...]
+#
+# Runs CMD under a SECS-second watchdog when one is available; otherwise runs
+# CMD directly (no local bound — CI's `quality` job re-runs the identical
+# `format:check`, so a rare local hang defers to git's own limit rather than
+# manufacturing a failure). CMD's combined stdout+stderr is emitted on stdout so
+# the caller can capture and grep it. Returns:
+#
+#   0        CMD succeeded
+#   124      the watchdog expired (only possible when a watchdog exists)
+#   <rc>     CMD's own non-zero exit (a genuine format failure)
+#
+# The load-bearing fix: when no watchdog exists we run CMD ITSELF, so the return
+# code is always CMD's real result — NEVER a 127 from a missing `timeout` that
+# the caller would mislabel as a format failure. The watchdog-absent notice goes
+# to stderr with a non-prettier prefix so it does not pollute the caller's
+# `[warn]`/`*.ts` offending-files filter.
+run_format_watchdog() {
+  _fw_secs=$1
+  shift
+  _fw_wd=$(find_watchdog)
+  if [ -n "$_fw_wd" ]; then
+    "$_fw_wd" "$_fw_secs" "$@"
+    return $?
+  fi
+  echo "Pre-push: no 'timeout'/'gtimeout' on PATH — running format:check without a local ${_fw_secs}s watchdog (CI 'quality' enforces it)." >&2
+  "$@"
+  return $?
+}

--- a/tests/hooks/pre-push-format-timeout.test.ts
+++ b/tests/hooks/pre-push-format-timeout.test.ts
@@ -1,0 +1,109 @@
+// #3409 — the pre-push prettier gate's watchdog must be PORTABLE: on a host
+// with no GNU `timeout`/`gtimeout` (stock macOS) it must run `format:check`
+// directly and return the command's REAL exit code, never a spurious 127 that
+// the hook would mislabel as a format failure. These tests exercise the sourced
+// POSIX-sh helper (scripts/hooks/format-gate.sh) directly — the same code
+// `.husky/pre-push` sources — mirroring tests/hooks/pre-push-labs-remote.test.ts.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const LIB = join(REPO_ROOT, "scripts", "hooks", "format-gate.sh");
+
+// Run `. LIB; <script>` under /bin/sh with a chosen PATH. Returns exit status +
+// combined output. `pathEnv` overrides the child PATH (empty dir = no watchdog).
+function runSh(script: string, args: string[], pathEnv?: string): { status: number; output: string } {
+  try {
+    const out = execFileSync("/bin/sh", ["-c", `. "$0"; ${script}`, LIB, ...args], {
+      encoding: "utf8",
+      env: pathEnv === undefined ? process.env : { ...process.env, PATH: pathEnv },
+    });
+    return { status: 0, output: out };
+  } catch (e: any) {
+    return { status: e.status ?? -1, output: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+describe("#3409 pre-push format-gate watchdog", () => {
+  let dir: string;
+  let emptyPath: string;
+  let OK: string;
+  let FAIL: string;
+  let HANG: string;
+
+  // Is a real watchdog available in the ambient env? The watchdog-present cases
+  // (which need GNU `timeout`) are skipped on hosts without one (e.g. macOS),
+  // where the whole point is that the no-watchdog path takes over.
+  const ambientWatchdog = runSh("find_watchdog", []).output.trim();
+  const HAS_WATCHDOG = ambientWatchdog.length > 0;
+
+  const stub = (path: string, body: string) => {
+    writeFileSync(path, `#!/bin/sh\n${body}\n`);
+    chmodSync(path, 0o755);
+  };
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "fmt-gate-"));
+    emptyPath = join(dir, "emptybin");
+    mkdirSync(emptyPath, { recursive: true });
+    OK = join(dir, "ok.sh");
+    FAIL = join(dir, "fail.sh");
+    HANG = join(dir, "hang.sh");
+    stub(OK, 'echo "all good"; exit 0');
+    stub(FAIL, 'echo "[warn] src/x.ts"; exit 1');
+    stub(HANG, "sleep 5; exit 0");
+  });
+
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("find_watchdog names timeout/gtimeout when present, nothing when PATH is bare", () => {
+    if (HAS_WATCHDOG) {
+      expect(["timeout", "gtimeout"]).toContain(runSh("find_watchdog", []).output.trim());
+    }
+    // With an empty PATH, neither binary resolves → empty.
+    expect(runSh("find_watchdog", [], emptyPath).output.trim()).toBe("");
+  });
+
+  it.skipIf(!HAS_WATCHDOG)("watchdog present: success passes through (rc 0, output captured)", () => {
+    const r = runSh('run_format_watchdog 90 "$1"', [OK]);
+    expect(r.status).toBe(0);
+    expect(r.output).toMatch(/all good/);
+  });
+
+  it.skipIf(!HAS_WATCHDOG)("watchdog present: a genuine format failure blocks (rc 1)", () => {
+    const r = runSh('run_format_watchdog 90 "$1"', [FAIL]);
+    expect(r.status).toBe(1);
+    expect(r.output).toMatch(/\[warn\] src\/x\.ts/);
+  });
+
+  it.skipIf(!HAS_WATCHDOG)("watchdog present: a hung check yields the 124 timeout code, not a format failure", () => {
+    const r = runSh('run_format_watchdog 1 "$1"', [HANG]);
+    expect(r.status).toBe(124);
+  });
+
+  // The load-bearing regression: no `timeout`/`gtimeout` on PATH.
+  it("no watchdog on PATH: success returns 0, NOT a spurious 127", () => {
+    const r = runSh('run_format_watchdog 90 "$1"', [OK], emptyPath);
+    expect(r.status).toBe(0);
+    expect(r.status).not.toBe(127);
+    expect(r.output).toMatch(/all good/);
+  });
+
+  it("no watchdog on PATH: a real format failure is still reported (rc 1)", () => {
+    const r = runSh('run_format_watchdog 90 "$1"', [FAIL], emptyPath);
+    expect(r.status).toBe(1);
+    expect(r.output).toMatch(/\[warn\] src\/x\.ts/);
+  });
+
+  it("no watchdog on PATH: emits the 'running without a watchdog' notice to stderr", () => {
+    // Merge stderr so the success-path notice (helper writes it to fd 2) is
+    // visible to execFileSync, which otherwise returns only stdout on exit 0.
+    const r = runSh('run_format_watchdog 90 "$1" 2>&1', [OK], emptyPath);
+    expect(r.output).toMatch(/without a local .*watchdog/);
+  });
+});


### PR DESCRIPTION
## Problem
The pre-push prettier gate called `timeout 90 pnpm run format:check` unconditionally. Stock macOS ships no GNU `timeout`, so the shell returned 127 (command-not-found) before prettier ran; the hook treats any code != 124 as a format failure and blocked every macOS push — with a **blank** "Offending files" section, because the real `timeout: command not found` error was filtered out.

## Fix
- Extract the watchdog into a sourced POSIX-sh helper `scripts/hooks/format-gate.sh` (`find_watchdog` + `run_format_watchdog`), mirroring the #3410 `push-remote-classify.sh` split so it is unit-testable.
- `run_format_watchdog` probes for `timeout`/`gtimeout`; when neither exists it runs the command **directly** (returning the command's real rc, never a spurious 127) and prints a one-line stderr notice. CI's `quality` job re-runs the identical `format:check`, so the un-watchdogged local run is safe.
- `.husky/pre-push` sources the helper; the 124/nonzero/0 branching is unchanged. The FAILED branch now prints the raw output when the `[warn]`/`*.ts` filter matches nothing, so a runner/setup error is no longer an empty section.
- New `tests/hooks/pre-push-format-timeout.test.ts` (7 cases): watchdog-present rc 0/1/124, no-watchdog rc-0-not-127 / rc-1 / stderr-notice, `find_watchdog` on a bare PATH. Watchdog-present cases `skipIf` no ambient `timeout`, so the suite is itself portable.

## Notes
Shell files are outside the `format:check` glob (`*.ts` only) — no formatter scope change. All acceptance criteria in the issue are checked off; local gates green (7/7 hook tests, `sh -n`, prettier on the `.ts`, biome lint, `tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb