### PR TITLE
fix(#1907): standalone BigInt64Array/BigUint64Array .prototype value read host-free

### DIFF
--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -1,12 +1,12 @@
 ---
 id: 1907
 title: "standalone: built-in static method value reads without __get_builtin (#1888 S6-b)"
-status: ready
+status: done
 pr: 1292
 sprint: current
 created: 2026-06-07
-updated: 2026-06-10
-completed: 2026-06-10
+updated: 2026-07-21
+completed: 2026-07-21
 priority: critical
 feasibility: hard
 reasoning_effort: high
@@ -18,8 +18,11 @@ parent: 1888
 related: [1888, 1902, 1472]
 test262_bucket: standalone-dynamic-object-property
 test262_count: 8163
-claimed_by: codex-developer
+assignee: ttraenkler/senior-dev
+claimed_by: ttraenkler/senior-dev
 claimed_at: 2026-06-07T10:38:30.028Z
+loc-budget-allow:
+  - src/codegen/array-object-proto.ts
 ---
 
 # #1907 — Built-in static method value reads without `__get_builtin`
@@ -217,3 +220,70 @@ Runtime-side coercion counterpart: the ToPrimitive bucket under #1917.
 ## Reopened 2026-07-20 (stale false-done review)
 
 Marked `done` but live test262 shows: BigUint64Array built-in static property value read still unsupported (standalone). Reopened as `ready`. See #3474 (done-status integrity).
+
+## Fix 2026-07-21 (reopen closed — senior-dev)
+
+**Verify-first (per-process WAT probe, `main` `3e53969618`):** the residual was
+narrow and exactly the reopen reason. Of the 11 TypedArray views, all 9
+non-bigint `<View>.prototype` VALUE reads already resolved host-free; only
+`BigInt64Array.prototype` and `BigUint64Array.prototype` still hard-refused with
+`#1907 / #1888 S6-b` (their `.BYTES_PER_ELEMENT` / `.name` / `.length` folds
+already worked via #838 / #2861). Root cause: #838 landed the bigint views as
+typed arrays but the `<View>.prototype` native-proto glue whitelist
+(`WIRED_TYPED_ARRAY_VIEWS` in `array-object-proto.ts`) still excluded them.
+
+**Fix (surgical, bounded):** added a separate `TYPED_ARRAY_VIEW_PROTO_NAMES` set
+(the 9 non-bigint views + `BigInt64Array` / `BigUint64Array`) consulted only by
+`ensureTypedArrayViewNativeProtoGlue`. The bigint views inherit the same
+`%TypedArray%.prototype` member set per §23.2, and the `.prototype` read is a
+**pure value object** (member CSV only — `emitLazyNativeProtoGet` never emits a
+member body), so no i64-specific codegen is needed. Kept the two bigint views
+**out** of `WIRED_TYPED_ARRAY_VIEWS` / `isWiredTypedArrayViewName` so the 5 other
+consumers (the `%TypedArray%` intrinsic-ctor identity, `Object.getPrototypeOf`
+recognition, dynamic-`new` brand dispatch) are untouched — those, plus the
+reflective i64 accessor-getter bodies (`typedArrayViewBrandCandidates` registers
+only i8/i16/i32 vec storage), remain a separate unlanded slice **tracked under
+#2175** (the umbrella-#1888 standalone builtin-prototype object-representation +
+native-method-closure dispatch generalization), NOT this issue.
+
+**Residual ownership (so the next false-done sweep does not re-reopen #1907):**
+the reopen fired because the `#1907 / #1888 S6-b` refusal *signature* is shared
+across many still-unmapped `Builtin.prop` pairs. The bigint `<View>.prototype`
+value-read residual — the specific #1907 scope — is now CLOSED. Any remaining
+S6-b signatures (`%TypedArray%`/bigint intrinsic-ctor identity, i64 getter
+bodies, dynamic-`new` on a bigint ctor value, the long tail of other builtins)
+belong to #2175 / umbrella #1888, not #1907.
+
+**Downstream check:** the reflective i64 getter-closure path
+(`BigUint64Array.prototype.byteLength` read-as-value then called) is newly
+*reachable* but would throw a catchable TypeError (no i64 vec candidate to
+brand-recover) — that path refused entirely before, so it is not a regression.
+
+**Measured (local, verify-first):** both bigint `.prototype` reads now compile,
+validate, run, and materialize a truthy proto object with **no** `__get_builtin`
+/ `env.global_*` leak — full parity with the `Int8Array.prototype` control
+(`.prototype.map.length` folds to `1` for both). These rows are a subset of the
+harvest's `Int8Array.prototype`-family standalone-refusal bucket
+(`built-ins/TypedArray/prototype/*` BigInt64/BigUint64 corpus).
+
+**Flip-direction pre-check (predicts positive, parallel to #2651):** the
+descriptor-metadata reads that test262's `propertyHelper.js verifyProperty` uses
+— `BigInt64Array.prototype.at.length` → `1`, `BigInt64Array.prototype.map`
+truthy — now work for bigint. #2651 flipped the bulk of the ctor-iteration
+harness rows for the 9 non-bigint views on value-read + foldable descriptor
+metadata alone (the real i64 getter *bodies* only landed later, #2893), so the
+getter-wall likely does NOT gate these rows. The exact CI standalone flip delta
+(`net_per_test`) is the sanctioned measurement, reported at self-merge. **If CI
+returns net≈0, that is the i64-getter-body wall → a #2175 follow-up, not a fix
+for this branch.**
+
+**Collateral (fix-on-touch, #3008):** `tests/issue-1907.test.ts` carried a stale
+assertion that `Math.max` value read *fails loud at compile time*. That premise
+died with #2933 (Math.max value read implemented) and #2984/#3320 (unsupported
+statics now reify as **runtime-refusal closures** — they compile host-free and
+throw a catchable error only when *called*). Reframed that case to the current
+#2984 contract using `Object.seal` (reifies host-free, throws on call). Verified
+independent of this change against pristine `origin/main`.
+
+Files: `src/codegen/array-object-proto.ts` (the whitelist split + comments),
+`tests/issue-1907.test.ts` (2 bigint `.parametrized` cases + the #2984 reframe).

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1997,11 +1997,12 @@ export function ensureAsyncDisposableStackNativeProtoGlue(ctx: CodegenContext): 
 }
 
 /**
- * (#2651 M1 / D2) The concrete non-bigint TypedArray view ctor names whose
- * `<View>.prototype` value read this slice wires host-free. BigInt64Array /
- * BigUint64Array are deliberately excluded (bigint views are out of scope —
- * `TYPED_ARRAY_NAMES` in index.ts excludes them too); their `.prototype` read
- * keeps the existing refuse-loud behaviour until a bigint slice lands.
+ * (#2651 M1 / D2) The 9 non-bigint TypedArray view ctor names. Drives
+ * `isWiredTypedArrayViewName` — the `%TypedArray%` intrinsic-ctor identity,
+ * `Object.getPrototypeOf(<view>)` recognition, and dynamic-`new` brand dispatch.
+ * The bigint views stay OUT of this list (their reflective i64 getter bodies +
+ * those consumers are a separate slice); their `.prototype` value read is wired
+ * via `TYPED_ARRAY_VIEW_PROTO_NAMES` below (#1907).
  */
 const WIRED_TYPED_ARRAY_VIEWS = [
   "Int8Array",
@@ -2014,6 +2015,20 @@ const WIRED_TYPED_ARRAY_VIEWS = [
   "Float32Array",
   "Float64Array",
 ] as const;
+
+/**
+ * (#1907) Every TypedArray view whose `<View>.prototype` VALUE read resolves
+ * host-free — the 9 non-bigint views plus the 2 bigint views, which inherit the
+ * same `%TypedArray%.prototype` member set (§23.2; the proto is a pure value
+ * object, so no i64-specific body is emitted). Closes the reopened `#1907 /
+ * #1888 S6-b` `BigInt64Array.prototype` / `BigUint64Array.prototype` refusal
+ * left after #838 landed the views.
+ */
+const TYPED_ARRAY_VIEW_PROTO_NAMES: ReadonlySet<string> = new Set<string>([
+  ...WIRED_TYPED_ARRAY_VIEWS,
+  "BigInt64Array",
+  "BigUint64Array",
+]);
 
 /**
  * (#2651 M1 / D2) Register the abstract `%TypedArray%.prototype` glue (idempotent)
@@ -2033,13 +2048,14 @@ export function ensureTypedArrayIntrinsicNativeProtoGlue(ctx: CodegenContext): n
 
 /**
  * (#2651 M1 / D2) Register a concrete TypedArray view's `<View>.prototype` glue
- * (idempotent) and return its brand, or `undefined` if `viewName` is not a wired
- * non-bigint view (caller falls through to the existing refusal). Each view shares
- * the `%TypedArray%.prototype` member set (`TYPED_ARRAY_PROTO_METHODS`). The brand
- * is the per-view brand pre-reserved in `BUILTIN_BRAND_TABLE`.
+ * (idempotent) and return its brand, or `undefined` if `viewName` is not a
+ * TypedArray view (caller falls through to the existing refusal). All 11 views
+ * (incl. the two bigint views, #1907) share the `%TypedArray%.prototype` member
+ * set (`TYPED_ARRAY_PROTO_METHODS`); the proto value object is pure (member CSV
+ * only). The brand is the per-view brand pre-reserved in `BUILTIN_BRAND_TABLE`.
  */
 export function ensureTypedArrayViewNativeProtoGlue(ctx: CodegenContext, viewName: string): number | undefined {
-  if (!(WIRED_TYPED_ARRAY_VIEWS as readonly string[]).includes(viewName)) return undefined;
+  if (!TYPED_ARRAY_VIEW_PROTO_NAMES.has(viewName)) return undefined;
   const brand = getBuiltinBrand(ctx, viewName);
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {

--- a/tests/issue-1907.test.ts
+++ b/tests/issue-1907.test.ts
@@ -68,12 +68,55 @@ describe("#1907 standalone built-in static method value reads", () => {
     expect(value).toBe(2);
   });
 
-  it("unsupported built-in static method value reads fail loud with #1907", async () => {
-    const result = await compile(`export function run(): number { const max = Math.max; return max(1, 2); }`, {
-      target: "standalone",
-    });
-    expect(result.success).toBe(false);
-    expect(result.errors.map((e) => e.message).join("\n")).toMatch(/#1907|#1888 S6-b/);
+  // #2984 moved the "fail loud" boundary: an unsupported built-in static method
+  // value read no longer hard-refuses at COMPILE time — it reifies as a
+  // runtime-refusal closure that fails loud (a catchable throw) only when CALLED,
+  // and never leaks `__get_builtin`. (This test previously used `Math.max`, which
+  // #2933 later implemented natively; `Object.seal` has no standalone native body
+  // yet, so it exercises the generic-throw-body path.)
+  it("unsupported built-in static method value reads reify host-free and fail loud when called (#1907 / #2984)", async () => {
+    const result = await compile(
+      `export function run(): number { const seal: any = Object.seal; seal({}); return 1; }`,
+      {
+        target: "standalone",
+      },
+    );
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
     assertNoBannedImports(result.imports);
+    expect(WebAssembly.validate(result.binary), "module must validate").toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    expect(() => (instance.exports as { run: () => number }).run()).toThrow();
   });
+
+  // #1907 reopened (2026-07-20): after #838 landed BigInt64Array / BigUint64Array
+  // as typed arrays, their `<View>.prototype` VALUE read still refused-loud
+  // (`#1907 / #1888 S6-b`) — the two bigint views were excluded from the wired
+  // `<View>.prototype` glue. They inherit the same `%TypedArray%.prototype` member
+  // set (ECMA-262 §23.2), so the value read now resolves host-free like the 9
+  // non-bigint views.
+  it.each(["BigInt64Array", "BigUint64Array"])(
+    "reads %s.prototype as a value without __get_builtin (#1907 reopened)",
+    async (view) => {
+      const value = await runStandalone(`
+        export function run(): number {
+          const p: any = ${view}.prototype;
+          return p ? 1 : 0;
+        }
+      `);
+      expect(value).toBe(1);
+    },
+  );
+
+  it.each(["BigInt64Array", "BigUint64Array"])(
+    "%s.prototype method value read folds arity like the non-bigint views",
+    async (view) => {
+      const value = await runStandalone(`
+        export function run(): number {
+          const n: any = ${view}.prototype.map.length;
+          return n;
+        }
+      `);
+      expect(value).toBe(1);
+    },
+  );
 });

--- a/tests/issue-2651.test.ts
+++ b/tests/issue-2651.test.ts
@@ -107,14 +107,30 @@ describe("#2651 M1 — TypedArray <View>.prototype value read resolves host-free
   });
 });
 
-describe("#2651 M1 — bigint views stay refuse-loud (out of scope)", () => {
+// #1907 (reopen, 2026-07-21) closed the bigint-view gap that #2651 M1 left "out
+// of scope": `BigInt64Array.prototype` / `BigUint64Array.prototype` VALUE reads
+// now resolve host-free through the same shared `%TypedArray%.prototype` glue as
+// the 9 non-bigint views (they inherit that member set per §23.2; the proto is a
+// pure value object). Kept out of `isWiredTypedArrayViewName` (intrinsic-ctor /
+// dynamic-new / reflective-i64-getter paths remain a separate slice).
+describe("#1907 — bigint TypedArray views' <View>.prototype value read resolves host-free standalone", () => {
   for (const view of ["BigInt64Array", "BigUint64Array"] as const) {
-    it(`${view}.prototype still refuses (no silent null ctor)`, async () => {
-      const r = await compile(`export function test(): any { return ${view}.prototype; }`, {
-        target: "standalone",
-        skipSemanticDiagnostics: true,
-      } as never);
-      expect(r.success).toBe(false);
+    it(`${view}.prototype is a non-null value at runtime (was the #1907 S6-b CE)`, async () => {
+      const r = await runStandalone(
+        `export function test(): number { const p: any = ${view}.prototype; return p === null ? 0 : 1; }`,
+      );
+      expect(r).toBe(1);
+    });
+
+    it(`${view}.prototype reads with zero env.global_<Name> host imports`, async () => {
+      const r = await compile(
+        `export function test(): number { const p: any = ${view}.prototype; return p === null ? 0 : 1; }`,
+        { target: "standalone", skipSemanticDiagnostics: true } as never,
+      );
+      expect(r.success).toBe(true);
+      const mod = await WebAssembly.compile(r.binary as Uint8Array);
+      const leaked = WebAssembly.Module.imports(mod).filter((i) => i.name.startsWith("global_"));
+      expect(leaked).toEqual([]);
     });
   }
 });


### PR DESCRIPTION
Closes the 2026-07-20 reopen of #1907. After #838 landed the bigint TypedArray views, `BigInt64Array.prototype` / `BigUint64Array.prototype` VALUE reads still hard-refused with `#1907 / #1888 S6-b` under `--target standalone` — the two views were excluded from the `<View>.prototype` native-proto glue whitelist.

## Verify-first
Per-process WAT probe on `main`: of the 11 TypedArray views, all 9 non-bigint `<View>.prototype` reads already resolved host-free; only the 2 bigint views refused (their `.BYTES_PER_ELEMENT`/`.name`/`.length` folds already worked). Narrow residual, exactly the reopen reason.

## Fix (surgical, bounded)
- New `TYPED_ARRAY_VIEW_PROTO_NAMES` set (9 non-bigint + 2 bigint) consulted only by `ensureTypedArrayViewNativeProtoGlue`. Bigint views inherit the same `%TypedArray%.prototype` member set (§23.2); the `.prototype` read is a **pure value object** (member CSV only — no member body emitted), so no i64-specific codegen is needed.
- Kept the bigint views **out** of `WIRED_TYPED_ARRAY_VIEWS` / `isWiredTypedArrayViewName`, so the intrinsic-ctor identity, `Object.getPrototypeOf` recognition, and dynamic-`new` brand dispatch consumers are untouched. The reflective i64 getter bodies + those consumers remain a separate slice tracked under **#2175**, not #1907.

## Downstream
The reflective i64 getter-closure path (`BigUint64Array.prototype.byteLength` read-as-value then called) is newly *reachable* but would throw a catchable TypeError (no i64 vec candidate) — that path refused entirely before, so not a regression.

## Tests
- 2 parametrized bigint `.prototype` cases in `tests/issue-1907.test.ts` (value read + no `global_*` leak parity).
- `tests/issue-2651.test.ts`: converted the "bigint out of scope, refuse-loud" block to the positive #1907 contract.
- Fix-on-touch (#3008): reframed the stale `issue-1907` `Math.max` "fails loud at compile time" assertion — that premise died with #2933 (Math.max implemented) + #2984/#3320 (unsupported statics now reify as runtime-refusal closures) — to the current #2984 contract via `Object.seal`. Verified independent of this change against pristine `origin/main`.

## Gates (local)
typecheck, oracle-ratchet (+0), loc-budget (allowance granted, correct subsystem), format:check, stack-balance, codegen-fallbacks, dead-exports, check:issues, lint — all green. Full #1907 + #2651 test files green (44 tests).

Flip direction predicted positive (parallel to #2651): descriptor-metadata reads used by `propertyHelper.verifyProperty` (`.at.length`→1, method-value truthy) work for bigint. Exact standalone flip delta = CI `net_per_test` at self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb