### PR TITLE
fix(ir): preserve boolean identity at extern boundaries

### DIFF
--- a/plan/issues/3529-ir-r0-typed-producer-equivalence-parity.md
+++ b/plan/issues/3529-ir-r0-typed-producer-equivalence-parity.md
@@ -28,23 +28,27 @@ loc-budget-allow:
   - src/ir/select.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
+  - src/ir/backend/linear-integration.ts
   - src/ir/module-bindings.ts
   - src/ir/backend/legality.ts
   - src/ir/passes/tagged-unions.ts
   - src/ir/passes/tagged-union-types.ts
   - src/ir/verify.ts
   - src/codegen/index.ts
+  - src/codegen/stdlib-selfhost.ts
 files:
   - src/ir/outcomes.ts
   - src/ir/select.ts
   - src/ir/from-ast.ts
   - src/ir/integration.ts
+  - src/ir/backend/linear-integration.ts
   - src/ir/module-bindings.ts
   - src/ir/backend/legality.ts
   - src/ir/passes/tagged-unions.ts
   - src/ir/passes/tagged-union-types.ts
   - src/ir/verify.ts
   - src/codegen/index.ts
+  - src/codegen/stdlib-selfhost.ts
   - tests/equivalence/helpers.ts
   - tests/issue-3529-producer-contract.test.ts
   - tests/issue-3529-selector-preclaim.test.ts
@@ -52,6 +56,7 @@ files:
   - tests/issue-3529-tagged-union-dynamic.test.ts
   - tests/issue-3529-integration-preflight.test.ts
   - tests/issue-3529-result-errors.test.ts
+  - tests/issue-3529-ir-producer-parity.test.ts
 ---
 
 # #3529 — IR R0 prerequisite: typed producer equivalence parity
@@ -343,7 +348,11 @@ exit and remains within that slice's locked files.
 - **What was done:** classified the 141 capability gaps at checker-aware
   preclaim or narrow typed producer sites, repaired all 13 genuine producer/
   pass invariants, and made the two formerly opaque equivalence assertions
-  include fatal compiler diagnostics.
+  include fatal compiler diagnostics. A merge-queue differential then exposed
+  one missed producer seam: inferred mutually recursive boolean returns lost
+  their i32 boolean brand before an `externref` console boundary. The IR now
+  retains that brand and emits the canonical `__box_boolean` call when the
+  host lane owns it; native/self-host lanes explicitly decline the capability.
 - **What worked:** unknown throws stayed fatal Invariants, while stable typed
   Unsupported reasons preserved hybrid behavior for known capability gaps.
   The nine legal dynamic-box/tagged-union cases, two mutation-prepass misses,
@@ -359,7 +368,10 @@ exit and remains within that slice's locked files.
   known failures, with one baseline-known case now passing, zero new
   regressions, and an unchanged baseline. The hybrid gate is green with 0
   Invariants; strict remains intentionally red on the six typed Unsupported
-  units and all 37 legacy-emitted bodies.
+  units and all 37 legacy-emitted bodies. The exact
+  `tests/differential/corpus/closures/10-mutual.js` probe now compiles through
+  IR and prints `true\ntrue`; the #2788, #2795, and #3529 focused suites pin
+  valid Wasm, boolean identity, and an emitted `<module-init>` IR outcome.
 
 ## Required validation
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -719,7 +719,7 @@ export function extractConstantDefault(
  */
 function latticeToIr(t: LatticeType): IrType {
   if (t.kind === "f64") return irVal({ kind: "f64" });
-  if (t.kind === "bool") return irVal({ kind: "i32" });
+  if (t.kind === "bool") return irVal({ kind: "i32", boolean: true });
   // #1169a — strings flow as the backend-agnostic `IrType.string`; the
   // resolver picks the concrete Wasm representation at lowering time.
   if (t.kind === "string") return { kind: "string" };

--- a/src/codegen/stdlib-selfhost.ts
+++ b/src/codegen/stdlib-selfhost.ts
@@ -173,6 +173,9 @@ const NATIVE_STRINGS_FROMAST_RESOLVER: IrFromAstResolver = {
   hasHostNumberBox(): boolean {
     return false;
   },
+  hasHostBooleanBox(): boolean {
+    return false;
+  },
   hasHostNumberToString(): boolean {
     return false;
   },

--- a/src/ir/backend/linear-integration.ts
+++ b/src/ir/backend/linear-integration.ts
@@ -409,7 +409,7 @@ export function compileLinearIrFunctions(
 
 function latticeEvidenceToIr(type: LatticeType | undefined, context: string): IrType {
   if (type?.kind === "f64") return irVal({ kind: "f64" });
-  if (type?.kind === "bool") return irVal({ kind: "i32" });
+  if (type?.kind === "bool") return irVal({ kind: "i32", boolean: true });
   if (type?.kind === "string") return { kind: "string" };
   throw new Error(`linear-ir: ${context} has no certified scalar type`);
 }
@@ -617,6 +617,9 @@ function makeLinearIrResolver(
       return false;
     },
     hasHostNumberBox(): boolean {
+      return false;
+    },
+    hasHostBooleanBox(): boolean {
       return false;
     },
     hasHostNumberToString(): boolean {

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -146,7 +146,7 @@ export interface IrExternClassMeta {
  * (#2955) The raw `nativeStrings()` mode discriminator is deliberately NOT
  * on this interface anymore: every former from-ast mode read is now a
  * narrow resolver-owned capability/rep/strategy query (`stringIsExternref`,
- * `hasHostNumberBox`, `hasHostNumberToString`, `stringMethodPlan`,
+ * `hasHostNumberBox`, `hasHostBooleanBox`, `hasHostNumberToString`, `stringMethodPlan`,
  * `stringForOfPlan`). Keeping the raw discriminator off the front-end
  * surface makes a new representation-polymorphic IR-build branch a compile
  * error instead of a drift channel. (`IrLowerResolver` still carries it —
@@ -179,6 +179,13 @@ export interface IrFromAstResolver {
    * standalone `$AnyValue` boxing) is a semantic follow-up tracked in #2955.
    */
   hasHostNumberBox?(): boolean;
+  /**
+   * Does this compile's lane own the host `__box_boolean` import? Boolean
+   * values use the same i32 carrier as integer-shaped numbers, so this
+   * capability is deliberately separate from `hasHostNumberBox`: callers
+   * must prove the boolean brand before selecting the boolean boxer.
+   */
+  hasHostBooleanBox?(): boolean;
   /**
    * (#2955 slice 3) Rep predicate: is `IrType.string`'s carrier ValType
    * externref (the host-strings backend), so a string SSA value can flow
@@ -2390,7 +2397,7 @@ export function typeNodeToIr(node: ts.TypeNode | undefined, where: string): IrTy
     case ts.SyntaxKind.NumberKeyword:
       return irVal({ kind: "f64" });
     case ts.SyntaxKind.BooleanKeyword:
-      return irVal({ kind: "i32" });
+      return irVal({ kind: "i32", boolean: true });
     case ts.SyntaxKind.StringKeyword:
       return { kind: "string" };
     default:
@@ -4465,6 +4472,23 @@ function coerceToExpectedExtern(value: IrValueId, expected: ValType, cx: LowerCt
     const boxed = cx.builder.emitCall({ kind: "func", name: "__box_number" }, [value], irVal({ kind: "externref" }));
     if (boxed === null) {
       throw new Error(`ir/from-ast: __box_number produced no result in ${cx.funcName}`);
+    }
+    return boxed;
+  }
+  // Boolean-branded i32 -> externref: preserve JS identity by using the
+  // boolean boxer. An unbranded i32 is intentionally not accepted here: that
+  // carrier may represent an integer-shaped number or a symbol handle, whose
+  // boxing semantics differ.
+  if (
+    expected.kind === "externref" &&
+    got !== null &&
+    got.kind === "i32" &&
+    got.boolean === true &&
+    cx.resolver?.hasHostBooleanBox?.() === true
+  ) {
+    const boxed = cx.builder.emitCall({ kind: "func", name: "__box_boolean" }, [value], irVal({ kind: "externref" }));
+    if (boxed === null) {
+      throw new Error(`ir/from-ast: __box_boolean produced no result in ${cx.funcName}`);
     }
     return boxed;
   }

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1925,6 +1925,12 @@ function makeFromAstResolver(ctx: CodegenContext, moduleBindingResolver?: IrModu
     hasHostNumberBox(): boolean {
       return !ctx.nativeStrings;
     },
+    // Boolean values share the host union-import family with numbers, but
+    // retain their own boxer so `true` never crosses an externref boundary as
+    // the number `1`.
+    hasHostBooleanBox(): boolean {
+      return !ctx.nativeStrings;
+    },
     // (#2955 slice 3) Rep predicate: the string carrier is externref (host
     // strings), so string SSA values flow unchanged into externref-expected
     // positions (`coerceToExpectedExtern` host-call args) and take the

--- a/tests/issue-3529-ir-producer-parity.test.ts
+++ b/tests/issue-3529-ir-producer-parity.test.ts
@@ -10,6 +10,33 @@ function terminal(result: Awaited<ReturnType<typeof compile>>): readonly IrObser
 }
 
 describe("#3529 — typed AST-to-IR producer capability gaps", () => {
+  it("preserves inferred boolean identity across an externref console boundary", async () => {
+    const result = await compile(
+      `function isEven(n) {
+        return n === 0 ? true : isOdd(n - 1);
+      }
+      function isOdd(n) {
+        return n === 0 ? false : isEven(n - 1);
+      }
+      console.log(isEven(10));
+      console.log(isOdd(7));`,
+      {
+        fileName: "mutual-recursion.js",
+        experimentalIR: true,
+        trackIrOutcomes: true,
+        deferTopLevelInit: true,
+      },
+    );
+
+    expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+    expect(terminal(result).find((outcome) => outcome.displayName === "<module-init>")).toMatchObject({
+      kind: "emitted",
+      legacyBodyEmitted: true,
+      irBodyEmitted: true,
+    });
+    expect(result.wat).toContain("__box_boolean");
+  });
+
   it("types array-literal widening as an unsupported representation", async () => {
     const result = await compile(
       `export function test(): number {


### PR DESCRIPTION
## Summary

- preserve inferred boolean brands through direct and linear IR signatures
- box branded i32 values with the canonical host boolean boxer at externref boundaries
- pin the exact mutual-recursion module-init regression and record it in Markdown issue #3529

## Validation

- issue #2788, #2795, and #3529 focused tests: 17/17 passing
- exact closures/10-mutual corpus: true / true, outcome match
- differential gate: 99/104, zero regressions
- optimize differential gate: zero outcome regressions
- cross-backend differential: 29/29 passing
- hybrid IR readiness: READY, zero invariants
- fallback ratchet: unchanged
- typecheck, lint, formatting, issue ID, and LOC gates: passing

No equivalence or Test262 baseline files changed.