### PR TITLE
docs(sprint): close Sprint 74 with final evidence

### DIFF
--- a/plan/diary.md
+++ b/plan/diary.md
@@ -315,13 +315,14 @@ boundary instead of being excused. Sprint bookkeeping drift was also repaired:
 16 completed issues were normalized into sprint 73, and all unfinished work was
 carried forward without retagging it to a numbered sprint.
 
-### 2026-07-21 — v0.64.0 proxy metadata follow-up
+### 2026-07-21 — v0.64.1 proxy metadata correction
 
 Post-publish verification found that `js2wasm@0.64.0` still depended on
 `@loopdive/js2@0.60.1`: the release script bumped the proxy package version but
-not its dependency. #3516 carries the repair into the current sprint: update the
-dependency in the same release transaction, reject mismatched tag publishes,
-and supersede the immutable npm metadata with a patch release.
+not its dependency. #3516 repaired the release transaction, added a tag-publish
+lockstep check, and superseded the immutable npm metadata with v0.64.1. The
+published `js2wasm@0.64.1` proxy now depends exactly on
+`@loopdive/js2@0.64.1`, and npm, JSR, and the GitHub release were verified.
 
 ## Sprint 74 (2026-07-21) — IR R0 truth boundary
 
@@ -338,6 +339,9 @@ bodies. The broader #3518 program remains open: #3520 is the next ready R1
 slice, and R2–R8 stay blocked behind it and their dependency chain.
 
 The previous v0.64.1 patch is published and verified, including the matching
-`js2wasm` proxy dependency on `@loopdive/js2@0.64.1`. Sprint 74 closes at a
-clean R0 boundary; v0.65.0 is cut from the resulting `main` before execution
-pauses.
+`js2wasm` proxy dependency on `@loopdive/js2@0.64.1`. PR #3483's advisory
+merge-group differential then caught one lost boolean brand in
+`closures/10-mutual.js`; PR #3486 retained the brand through IR and boxed it
+with `__box_boolean`, restoring the 99 / 104 differential floor without a
+baseline update. Sprint 74 closes at that corrected R0 boundary; v0.65.0 is cut
+from the resulting `main` before execution pauses.

--- a/plan/diary.md
+++ b/plan/diary.md
@@ -343,5 +343,11 @@ The previous v0.64.1 patch is published and verified, including the matching
 merge-group differential then caught one lost boolean brand in
 `closures/10-mutual.js`; PR #3486 retained the brand through IR and boxed it
 with `__box_boolean`, restoring the 99 / 104 differential floor without a
-baseline update. Sprint 74 closes at that corrected R0 boundary; v0.65.0 is cut
-from the resulting `main` before execution pauses.
+baseline update. Sprint 74 closed at that corrected R0 boundary,
+`a9b276c0eed97b2ce29b7ccaa29ebc5f4853e08d`, and the exact `sprint/74` tag is
+published there. Authoritative merge-group Test262 run 29857062450 passed at
+the same SHA: JS-host remained 30,282 / 43,099 and standalone improved by 13
+passes to 28,149 / 43,106. The close harvest cross-referenced all >50-row
+failure families and filed only one new Markdown owner: Backlog #3531 for 216
+standalone array-concat/JS-array host-import leaks. v0.65.0 is cut from the
+resulting `main` before execution pauses.

--- a/plan/issues/3531-standalone-array-concat-host-import-leak.md
+++ b/plan/issues/3531-standalone-array-concat-host-import-leak.md
@@ -1,0 +1,74 @@
+---
+id: 3531
+title: "standalone: retire __array_concat_any / __js_array_new / __js_array_push host-import leak (216 tests)"
+status: ready
+sprint: Backlog
+created: 2026-07-21
+updated: 2026-07-21
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen, standalone, arrays
+language_feature: array-methods, typed-arrays
+goal: standalone-mode
+related: [1359, 1461, 1969, 2860]
+test262_bucket: standalone-array-concat-host-import-leak
+test262_count: 216
+---
+
+# #3531 — retire standalone array-concat host-import leakage
+
+## Problem
+
+The Sprint 74 close harvest found **216 official standalone Test262 rows** that
+still emit the JS-host `__array_concat_any` bridge together with
+`__js_array_new` and `__js_array_push`. A standalone build rejects those host
+imports before the test can execute.
+
+This is not the already-fixed #1969 host-bridge spreading bug: the failing
+programs must avoid the host bridge entirely and lower the array construction
+and concat operation through standalone-native representations.
+
+## Evidence
+
+- Fresh source: published `test262-standalone-current.jsonl`, fetched after the
+  Sprint 74 final code landing.
+- **201 rows** share the exact three-import signature
+  `__array_concat_any` + `__js_array_new` + `__js_array_push`.
+- **15 rows** have the concat leak plus additional imports and should be
+  reclassified after the dominant shape is fixed.
+- Dominant families: `Array/prototype` (**102**) and
+  `TypedArray/prototype` (**90**).
+- Representative files:
+  - `test/built-ins/Array/prototype/concat_sloppy-arguments-with-dupes.js`
+  - `test/built-ins/TypedArray/prototype/copyWithin/resizable-buffer.js`
+
+All other fresh clusters above the 50-row harvest threshold already map to
+active Markdown issues: #3395 owns the funcref/externref invalid-Wasm family,
+#2161 owns the RegExp `buildString` property-escape family, and #1354 owns the
+SharedArrayBuffer/Atomics family.
+
+## Investigation anchors
+
+- Trace why the affected standalone array/typed-array expressions select
+  `compileArrayConcatExtern` or materialize a JS array instead of the native
+  concat/vector path.
+- Split the 201 exact-signature rows by receiver and argument representation;
+  do not assume the Array and TypedArray families share one semantic cause.
+- Reproduce through the standalone Test262 wrapper before changing code. The
+  historical root-cause report is not authoritative; the JSONL signatures are.
+- Preserve concat species, holes, arguments-object behavior, and resizable
+  TypedArray semantics tracked by #1359 and #1461.
+
+## Acceptance criteria
+
+- A focused `tests/issue-3531.test.ts` covers representative Array and
+  TypedArray cases in standalone mode.
+- Targeted modules import none of `__array_concat_any`, `__js_array_new`, or
+  `__js_array_push` and produce the same observable result as JavaScript.
+- The 201-row exact-signature cluster is eliminated or narrowed with every
+  remaining row assigned to a concrete Markdown owner.
+- The 15 mixed-import rows are remeasured after the dominant fix and either
+  pass or are explicitly classified.
+- Host-mode equivalence and the standalone Test262 floor do not regress.

--- a/plan/issues/sprints/74.md
+++ b/plan/issues/sprints/74.md
@@ -8,8 +8,9 @@ wrap_checklist:
   dashboard_regenerated: true
   retro_written: true
   diary_updated: true
+  test262_verified: true
   begin_tag_pushed: true
-  end_tag_pushed: false
+  end_tag_pushed: true
 ---
 
 # Sprint 74
@@ -48,8 +49,19 @@ stays `sprint: current`.
   console boundary. Follow-up PR #3486 retained that brand, emitted the
   canonical `__box_boolean` call, and restored **99 / 104 with zero new
   regressions and no baseline update**.
-- Test262 artifacts were not modified or rerun locally. The authoritative
-  merge-queue CI run and URL are recorded in the final tag-check follow-up.
+- The authoritative Test262 [merge-group run
+  29857062450](https://github.com/loopdive/js2/actions/runs/29857062450)
+  passed at `a9b276c0eed97b2ce29b7ccaa29ebc5f4853e08d`, including the nonempty
+  `merge shard reports` job. JS-host closed at **30,282 / 43,099** (no change
+  from Sprint 73); standalone closed at **28,149 / 43,106** (**+13 passes**,
+  unchanged total). The reports were harvested from the CI artifacts without
+  modifying committed Test262 artifacts or baselines.
+- The fresh end-of-sprint failure harvest cross-referenced every normalized
+  cluster above 50 rows. Existing issues #1354, #2161, and #3395 own the large
+  SharedArrayBuffer/Atomics, RegExp `buildString`, and funcref-boundary
+  families. The sole unowned cluster became Backlog issue #3531: 216
+  standalone rows leaking `__array_concat_any` and JS-array construction
+  imports.
 
 ## Rolled forward (200 still `sprint: current`)
 
@@ -268,11 +280,19 @@ The central lesson is that a hybrid-green gate proves honest fallback and
 complete accounting, not readiness to remove the fallback. Sprint 74 closed
 the R0 truth boundary while keeping strict mode visibly red.
 
-## Closure follow-up
+## Closure evidence
 
-The begin tag is published. After this closure lands on `main`, push only the
-explicit `sprint/74` end tag, record the authoritative merge-queue Test262 run,
-regenerate the dashboard, and flip the two remaining checklist values.
+- `sprint-74/begin` is published at
+  `5d345e5d7e33834c499992b6d8fb8e9ed54d4c90`.
+- `sprint/74` is published at the corrected final code boundary,
+  `a9b276c0eed97b2ce29b7ccaa29ebc5f4853e08d` (PR #3486).
+- The authoritative Test262 evidence is merge-group run
+  [29857062450](https://github.com/loopdive/js2/actions/runs/29857062450)
+  at that same SHA. All jobs passed and the merged-report artifact was
+  nonempty.
+- The tag-aware sprint dashboard was regenerated after closing the window.
+- The post-merge Test262 harvest was completed and its only new >50-row owner,
+  #3531, was filed in the Markdown Backlog.
 
 <!-- GENERATED_ISSUE_TABLES_START -->
 ## Issue Tables

--- a/plan/issues/sprints/74.md
+++ b/plan/issues/sprints/74.md
@@ -42,6 +42,12 @@ stays `sprint: current`.
   async functions (unchanged), 0 module-level body-shape rejections, and no
   post-claim demotions.
 - Typecheck, lint, and formatting checks passed.
+- The merge-queue differential gate exposed one R0 producer seam after PR
+  #3483: `closures/10-mutual.js` fell from the 99 / 104 baseline to 98 / 104
+  because an inferred boolean return lost its i32 brand at an `externref`
+  console boundary. Follow-up PR #3486 retained that brand, emitted the
+  canonical `__box_boolean` call, and restored **99 / 104 with zero new
+  regressions and no baseline update**.
 - Test262 artifacts were not modified or rerun locally. The authoritative
   merge-queue CI run and URL are recorded in the final tag-check follow-up.
 

--- a/plan/log/issues-log.md
+++ b/plan/log/issues-log.md
@@ -532,8 +532,9 @@ sprint: 0
 | 2856 | 2026-07-21 | IR body-shape fallback corpus to zero | Sprint 73 |
 | 2950 | 2026-07-13 | IR-first default flip (historical milestone; retirement transferred to #3518) | Sprint 71 |
 | 2855 | 2026-07-21 | IR fallback-corpus ratchet completed; IR-only retirement transferred to #3518 | Sprint 73 |
-| 3529 | 2026-07-21 | IR R0 typed-producer equivalence parity restored: 1,608 pass / 35 fail, one baseline-known improvement, zero new regressions, unchanged baseline | Current |
-| 3519 | 2026-07-21 | IR R0 typed outcomes and honest gate: hybrid 5/5, 37 terminal, 31 IR, 6 Unsupported, 0 Invariants, 37 legacy | Current |
+| 3516 | 2026-07-21 | Release proxy dependency lockstep; v0.64.1 published and verified with js2wasm depending on @loopdive/js2@0.64.1 | Sprint 74 |
+| 3529 | 2026-07-21 | IR R0 typed-producer equivalence parity restored: 1,608 pass / 35 fail, one baseline-known improvement, zero new regressions, unchanged baseline; merge-queue boolean-boundary correction restored differential 99/104 | Sprint 74 |
+| 3519 | 2026-07-21 | IR R0 typed outcomes and honest gate: hybrid 5/5, 37 terminal, 31 IR, 6 Unsupported, 0 Invariants, 37 legacy | Sprint 74 |
 
 > **IR retirement checkpoint:** #3518 remains in progress; #3520 is ready as
 > the next R1 slice. R2–R8 remain blocked on the dependency spine.

--- a/plan/log/retrospectives/sprint-74.md
+++ b/plan/log/retrospectives/sprint-74.md
@@ -21,6 +21,13 @@ accounting. Strict remains intentionally non-green on those six typed blockers
 and the separately reported 37 legacy-emitted bodies; R0 does not claim that
 the compiler is IR-only.
 
+PR #3483's merge-group differential workflow exposed one release-boundary
+regression that branch protection did not block: inferred mutually recursive
+boolean returns lost their i32 brand before an `externref` console call, moving
+the corpus from 99 / 104 to 98 / 104. Follow-up PR #3486 fixed the producer
+seam with the canonical `__box_boolean` helper and restored 99 / 104 without
+widening either the differential or equivalence baseline.
+
 ## Process lessons
 
 - Run full equivalence early when changing failure classification: focused
@@ -31,6 +38,9 @@ the compiler is IR-only.
   green hybrid policy is evidence of honest fallback, not strict readiness.
 - Keep baseline cleanup separate from recovery work; the one newly passing
   known case can be ratcheted without obscuring the zero-regression result.
+- Treat an advisory differential failure as release-blocking evidence even
+  when branch protection permits the queue merge. Close the sprint only after
+  the defect is fixed and a fresh merge-group run proves the restored floor.
 
 ## Carry-over
 

--- a/plan/log/retrospectives/sprint-74.md
+++ b/plan/log/retrospectives/sprint-74.md
@@ -48,3 +48,19 @@ widening either the differential or equivalence baseline.
 `IrUnitId` and `ProgramAbiMap`; R2–R8 remain blocked behind R1 and their declared
 dependency chain. The v0.65.0 release follows this sprint boundary; execution
 pauses after that release is published and verified.
+
+The fresh close harvest mapped all normalized Test262 clusters above 50 rows
+to existing Markdown owners except one. Backlog issue #3531 now owns the 216
+standalone rows that leak `__array_concat_any`, `__js_array_new`, and
+`__js_array_push`.
+
+## Close validation
+
+- PR #3486 merged as `a9b276c0eed97b2ce29b7ccaa29ebc5f4853e08d`,
+  which is also the published `sprint/74` tag target.
+- Authoritative Test262 merge-group run
+  [29857062450](https://github.com/loopdive/js2/actions/runs/29857062450)
+  passed at that SHA, including the nonempty merged-report job.
+- JS-host closed at **30,282 / 43,099**, unchanged from Sprint 73. Standalone
+  closed at **28,149 / 43,106**, a **+13-pass** improvement with no total-count
+  change.


### PR DESCRIPTION
## Summary

- close the Sprint 74 Markdown record with the final merge-group differential and Test262 evidence
- record the published sprint boundary, retrospective lessons, and issue-log corrections
- file Backlog issue #3531 for the sole unowned >50-row fresh Test262 cluster

## Validation

- `node scripts/check-sprint-closed.mjs 74`
- `node scripts/check-issue-ids.mjs --staged`
- `node scripts/check-issue-ids.mjs --against-main`
- `pnpm run check:issues` (no issue-file rewrites; known historical index drift remains)
- `pnpm exec prettier --check plan/issues/3531-standalone-array-concat-host-import-leak.md`
- `git diff --check`

No Test262 artifacts or committed baselines were modified.