### PR TITLE
release: v0.65.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.64.1",
+  "version": "0.65.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {
@@ -9,14 +9,7 @@
     "./optimize": "./src/optimize.ts"
   },
   "publish": {
-    "include": [
-      "src/**/*.ts",
-      "README.md",
-      "LICENSE",
-      "jsr.json"
-    ],
-    "exclude": [
-      "src/**/*.test.ts"
-    ]
+    "include": ["src/**/*.ts", "README.md", "LICENSE", "jsr.json"],
+    "exclude": ["src/**/*.test.ts"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.64.1",
+  "version": "0.65.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.64.1",
+  "version": "0.65.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.64.1"
+    "@loopdive/js2": "0.65.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
## Summary

- bump `@loopdive/js2` from 0.64.1 to 0.65.0
- bump the `js2wasm` proxy and its `@loopdive/js2` dependency to 0.65.0
- bump the JSR manifest to 0.65.0

## Validation

- all four version carriers are exactly `0.65.0`
- `tests/issue-3516-release-proxy-dependency-lockstep.test.ts`: 4/4
- lint, formatting, typecheck, and production build passed
- root and proxy `npm pack --dry-run` passed
- local annotated tag `v0.65.0` points to the release commit and remains unpushed

The tag will be pushed only after this release commit lands in `main` and passes the ancestry check.