### PR TITLE
refactor(ir): add source-qualified identities and program ABI

### DIFF
--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -68,6 +68,7 @@ files:
   - src/ir/passes/tagged-unions.ts
   - src/index.ts
   - src/compiler.ts
+  - src/compiler/ir-outcome-inventory.ts
   - src/compiler/validation.ts
   - src/import-resolver.ts
   - src/iterator-statics-prelude.ts
@@ -366,7 +367,9 @@ Remaining numbered work:
   harness/expectation failures reproduce identically on the exact pre-branch
   base `d3d2454b`, so the combined nine-file result is **102/108** with no new
   failure attributable to this slice. #2138, #3529, and phase3c are green.
-- `pnpm run typecheck`, `pnpm run lint`, and `pnpm run format:check` pass.
+- `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check`, and
+  `pnpm run check:loc-budget` pass; compiler-driver identity anchoring lives in
+  `src/compiler/ir-outcome-inventory.ts` rather than growing `src/compiler.ts`.
 - `pnpm run check:ir-only -- --policy=hybrid`: **READY**, 37 terminal units,
   31 emitted, 6 typed Unsupported, 0 Invariants; existing labels/counts remain
   unchanged.

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -6,6 +6,7 @@ assignee: ttraenkler/codex-r1
 claimed_by: codex-r1
 claimed_at: 2026-07-21T20:23:19Z
 branch: symphony/3520-r1-identity-abi
+pr: 3490
 sprint: current
 created: 2026-07-21
 updated: 2026-07-21
@@ -65,6 +66,13 @@ files:
   - src/ir/passes/simplify-cfg.ts
   - src/ir/passes/tagged-union-types.ts
   - src/ir/passes/tagged-unions.ts
+  - src/index.ts
+  - src/compiler.ts
+  - src/compiler/validation.ts
+  - src/import-resolver.ts
+  - src/iterator-statics-prelude.ts
+  - src/position-map.ts
+  - src/process-stdin-prelude.ts
   - src/codegen/class-member-keys.ts
   - src/codegen/context/types.ts
   - src/codegen/context/create-context.ts
@@ -73,6 +81,7 @@ files:
   - src/codegen/index.ts
   - src/codegen/stdlib-selfhost.ts
   - tests/issue-3520-ir-unit-identity.test.ts
+  - tests/issue-3520-program-abi.test.ts
 ---
 
 # #3520 — IR-only R1: source-qualified identity and whole-program ABI map
@@ -155,11 +164,14 @@ The inventory exposes two explicit populations rather than conflating nested
 support artifacts with terminal source outcomes:
 
 - `allUnits` is exhaustive over source, nested, lifted, and synthetic support
-  units. Every record has a `terminalOwnerId` and, where applicable, a
-  `lexicalOwnerId`.
+  units. Records rooted in an existing R0 attempt carry `terminalOwnerId` and,
+  where applicable, `lexicalOwnerId`. A genuinely exhaustive unit for which R0
+  has no attempt root carries `terminalOwnerId: null` plus
+  `unownedReason: "no-r0-attempt-root"`; R1 must not fabricate a terminal
+  outcome merely to make ownership total.
 - `terminalUnits` is the exact one-to-one population consumed by the R0 outcome
   ledger. Its count must equal terminal outcomes, while every additional
-  `allUnits` record must resolve to one terminal owner.
+  owned `allUnits` record must resolve to one terminal owner.
 
 An equality check between `allUnits.length` and the R0 outcome count is invalid:
 R0 deliberately attributes lifted/support preparation failures to their source
@@ -175,9 +187,12 @@ Build one whole-program inventory in deterministic source order. The map owns:
    Wasm type intents, exports, class layouts, and support-unit relationships.
 3. Stable source order and dependency order, including explicit parent/child
    links for lifted closures and constructor support units.
-4. The eventual concrete Wasm handle for each identity. Allocation happens
-   once; a second allocation, an unplanned binding, or two identities sharing a
-   non-alias slot is an R0 `Invariant`.
+4. The intention and eventual final-layout Wasm index for each identity.
+   `ProgramAbiMap` is an identity/intention ledger, not an allocator:
+   `ModuleAssembler` remains the sole allocator, and only binds finalized
+   indices after planning. A second binding, an unplanned binding, or two
+   identities sharing a non-alias slot is an R0 `Invariant`. In particular,
+   global/type raw indices are never preallocated or cached by the ABI plan.
 5. Explicit aliases. An import alias, inherited member, or export alias points
    to a canonical binding ID; it is not implemented by copying a display-name
    map entry.
@@ -192,6 +207,11 @@ adapter is the only string-keyed compatibility boundary. It must:
 - reject an ambiguous reverse lookup instead of choosing first/last wins;
 - record intentional aliases separately from accidental collisions; and
 - expose the old display labels for telemetry without making them keys.
+
+Repairing the current runtime/legacy collision behavior through this adapter is
+later R1 work. The first shadow landing proves identity and alias semantics
+without rewiring `funcMap`, `moduleGlobals`, `structMap`, exports, or module
+arrays, so it cannot claim that existing runtime collisions are fixed.
 
 ## Bounded landing sequence
 
@@ -246,6 +266,119 @@ adapter is the only string-keyed compatibility boundary. It must:
   only for a real collision and require runtime evidence.
 - Emit diagnostic tables sorted by canonical source/unit order, never JS `Map`
   accident or filesystem walk order.
+
+## R1a implementation status — PR #3490
+
+This PR is a continuation slice and deliberately leaves the issue
+`in-progress`.
+
+Implemented in the bounded landing:
+
+- opaque, serializable `IrSourceId`, `IrUnitId`, `IrClassId`, and
+  `IrBindingId` encodings whose uniqueness does not use display names;
+- dependency-first source ordering from compiler-resolved edges when available,
+  with authoritative empty/external resolutions, unique relative/bare-specifier
+  fallback only when resolution is unavailable, checkout-independent
+  `@library/` keys, collision rejection, and raw canonical source-key SCC
+  ordering as the disconnected-root/cycle tie-breaker;
+- fixed-width numeric identity components, so the canonical text comparator
+  orders source orders and regular/derived ordinals numerically past 9;
+- producer-tagged provenance for timer, node:path, typed Node import wrappers,
+  generated ambient import classes, eval/super early-error IIFEs,
+  process.stdin, and Iterator source rewrites. Synthetic IDs use semantic
+  producer roles; repeated units with the same parent and role use an explicit
+  sibling ordinal rather than a display spelling;
+- an exhaustive final-target source-AST/compiler-prelude `allUnits` inventory
+  plus the exact R0-compatible `terminalUnits` population, including nullable
+  ownership for compiler support units that have no R0 attempt root. The
+  host-free dead-binding pass snapshots pre-elision ordinals so every retained
+  support node keeps its ID; deliberately removed support nodes remain absent
+  and never manufacture terminal rows;
+- additive `sourceId` / `unitId` fields on compiler-produced terminal outcomes,
+  while legacy outcome key, label, count, and order remain unchanged;
+- a validated `indexIrTerminalDeclarations` AST-node-to-ID join so subsequent
+  declaration planning does not need to rejoin by display name; and
+- a semantic/shadow `ProgramAbiMap` and read-only `LegacyAbiAdapter` data-
+  structure seam with
+  separate plan/final-bind phases, explicit `required | alias | none` policy,
+  deterministic numeric plan order, namespace-aware lookup, and typed
+  alias/export/final-index invariants. Production codegen does not build this
+  map yet, so this landing does not claim whole-program ABI completeness.
+
+Intentionally deferred from this PR:
+
+- changing source planning, call graphs, IR references, passes, or backends to
+  use the new IDs (the remainder of commits 2 and 3);
+- assigning derived identities to pass-created lifted closures,
+  monomorphization clones, and other post-AST support units (Commit 3);
+- giving every nested node inside one compiler helper its own named semantic
+  role. Iterator helper children currently derive from the semantic top-helper
+  parent/role plus structural sibling ordinal; this is deterministic for the
+  current helper AST but internal sibling edits intentionally revise those
+  child IDs;
+- binding current codegen slots into `ProgramAbiMap`, or changing
+  `ModuleAssembler` allocation/finalization order; and
+- routing the legacy runtime maps through `LegacyAbiAdapter` or repairing their
+  current collision cases. Those binding points require the broader locked R1
+  file set and runtime evidence; the shadow seam is interface/invariant
+  groundwork, not runtime-collision completion.
+
+Remaining numbered work:
+
+- **Commit 2:** thread `IrUnitId` from the validated declaration index through
+  selection, propagation, source planning, recursion/SCC, ownership/escape,
+  imported/module binding, promise-delay, class-key, and self-host plans.
+- **Commit 3:** put identities on IR functions/references, key inline and
+  monomorphization edits structurally, derive IDs for pass-created units, and
+  carry the same binding identities through verification/lowering/backends.
+- **Commit 4:** populate the whole-program ABI intentions, bind only
+  ModuleAssembler-final indices, then route legacy maps/exports through the
+  adapter and prove runtime collision behavior plus non-collision byte parity.
+
+### R1a validation evidence
+
+- Representative inventory denominator: **1 source / 2 classes / 12 allUnits /
+  6 terminalUnits**, with **6/6** outcome-ID parity and byte-identical tracked
+  versus untracked output. The definition-expression fixture separately proves
+  **1 / 3 / 10 / 2**, including three unowned implicit constructors.
+- Collision matrix: same-named functions across sources, same-named nested
+  functions/classes across lexical owners, static versus instance methods,
+  get versus set accessors, and two legacy `<computed>` labels all receive
+  distinct structural IDs. Two required ABI bindings sharing display label
+  `same` receive distinct internal names and reject ambiguous reverse lookup;
+  one explicit import alias resolves to its canonical final slot.
+- Determinism: `/checkout-one` and `/different/checkout-two` produce identical
+  IDs; reversing the caller input array preserves IDs/order; `a.ts` importing
+  lexically later `z.ts` orders `z.ts` first, with disconnected sources tied by
+  canonical key. Relocating both a project and an external declaration-library
+  root preserves source IDs; exact resolved-dependency entries override syntax,
+  checker-resolved external modules do not bind unrelated same-basename sources,
+  duplicate final source keys fail, and numeric order/ordinal 10 sorts after 2.
+- The #3520 identity, #3520 ABI, and R0 outcome suites passed **66/66**
+  (**27** identity/provenance, **10** ABI invariants, and **29** R0 outcomes). The
+  identity matrix snapshots exact timer/node:path/typed-Node-wrapper/
+  process.stdin/Iterator R0 rows; proves raw/gc/standalone/WASI user
+  class/member/function IDs and retained host-free-DCE support IDs; and keeps
+  tracked/untracked host-free binaries stable. Removed DCE support units are
+  target-absent and are not claimed as cross-target identities. The green
+  focused matrix passed **93/93**. The separate known-base matrix passed
+  **9/15**: its three existing #1983 type-index failures and three inline-small
+  harness/expectation failures reproduce identically on the exact pre-branch
+  base `d3d2454b`, so the combined nine-file result is **102/108** with no new
+  failure attributable to this slice. #2138, #3529, and phase3c are green.
+- `pnpm run typecheck`, `pnpm run lint`, and `pnpm run format:check` pass.
+- `pnpm run check:ir-only -- --policy=hybrid`: **READY**, 37 terminal units,
+  31 emitted, 6 typed Unsupported, 0 Invariants; existing labels/counts remain
+  unchanged.
+- `pnpm run check:ir-fallbacks -- --verbose`: pass, zero unintended,
+  post-claim, or module-level increases.
+- Full equivalence gate: **1,608 passing**, **35 known failures**, zero new
+  regressions, and one existing baseline failure now passing; the baseline is
+  intentionally unchanged in this identity-only slice.
+- Cross-backend differential validation passed **29/29**.
+- No local Test262 run was performed; neither
+  `benchmarks/results/test262-run.log` nor
+  `scripts/equivalence-baseline.json` is changed.
 
 ## File ownership and locks
 
@@ -327,7 +460,7 @@ multi-file equivalence suite.
   legacy slot. Require a unique structural owner and raise a stable Invariant
   on zero or multiple matches.
 - **Late index shifts:** lazy imports/globals can invalidate numeric slots.
-  Keep symbolic ABI handles until the one planned finalization boundary and
+  Keep symbolic binding identities until the one planned finalization boundary and
   test late-import pressure.
 - **Wide pass blast radius:** identity touches builders, passes, and codegen.
   Land the bounded commits with old/new telemetry parity after each step and
@@ -347,7 +480,7 @@ multi-file equivalence suite.
 ## Required completion evidence
 
 ```bash
-pnpm exec vitest run tests/issue-3520-ir-unit-identity.test.ts tests/issue-1983-funcmap-collision.test.ts tests/issue-2138-multi-module-ir-overlay.test.ts tests/ir/inline-small.test.ts tests/ir/phase3c.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
+pnpm exec vitest run tests/issue-3520-ir-unit-identity.test.ts tests/issue-3520-program-abi.test.ts tests/issue-1983-funcmap-collision.test.ts tests/issue-2138-multi-module-ir-overlay.test.ts tests/ir/inline-small.test.ts tests/ir/phase3c.test.ts --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism
 pnpm run check:ir-only -- --policy=hybrid
 pnpm run check:ir-fallbacks -- --verbose
 pnpm run typecheck

--- a/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
+++ b/plan/issues/3520-ir-r1-source-qualified-identity-program-abi.md
@@ -1,7 +1,11 @@
 ---
 id: 3520
 title: "IR-only R1: source-qualified unit identity and whole-program ABI map"
-status: ready
+status: in-progress
+assignee: ttraenkler/codex-r1
+claimed_by: codex-r1
+claimed_at: 2026-07-21T20:23:19Z
+branch: symphony/3520-r1-identity-abi
 sprint: current
 created: 2026-07-21
 updated: 2026-07-21

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -55,6 +55,14 @@ import { makeIrHostGlobalResolver, makeIrHostVoidCallbackResolver } from "../ir/
 import { makeIrHostDateSnapshotResolver } from "../ir/host-date.js";
 import { supportsIrBackendTargetCapability, type IrBackendTargetCapability } from "../ir/backend/legality.js";
 import { collectModuleInitPopulation, MODULE_INIT_UNIT_NAME } from "../ir/module-init.js";
+import {
+  buildIrUnitInventory,
+  terminalIrUnitsForSource,
+  type BuildIrUnitInventoryOptions,
+  type IrSourceId,
+  type IrUnitId,
+  type IrUnitInventory,
+} from "../ir/identity.js";
 import { makeIrPromiseDelayResolver } from "../ir/promise-delay.js";
 import {
   buildIrPromiseDelayLoweringPlans,
@@ -1645,6 +1653,8 @@ function prepareHostDateSnapshotPreflight(
 
 interface ObservedIrUnit {
   readonly key: string;
+  readonly sourceId: IrSourceId;
+  readonly unitId: IrUnitId;
   readonly matchName: string;
   readonly unitKind: IrObservedOutcome["unitKind"];
   readonly displayName: string;
@@ -1658,163 +1668,43 @@ interface ObservedIrUnit {
   readonly directFailure?: IrPreparationFailure;
 }
 
-const AUTO_TIMER_SHIM_MARKER = "// #1501 timer host-import shim (auto-injected)";
-const AUTO_TIMER_SHIM_LINE =
-  /^(?:declare function __timer_(?:set|clear)_(?:timeout|interval)\(|function (?:setTimeout|setInterval|clearTimeout|clearInterval)\()/;
-
-/**
- * Return the exclusive end of the compiler-injected timer prelude.
- *
- * The outcome ledger inventories user source units. The timer wrappers remain
- * part of the real production compile (and any diagnostics still fail the
- * gate), but they must not silently inflate the source-unit denominator.
- */
-function autoTimerShimEnd(sourceFile: ts.SourceFile): number | null {
-  const markerStart = sourceFile.text.indexOf(AUTO_TIMER_SHIM_MARKER);
-  if (markerStart < 0) return null;
-  let cursor = sourceFile.text.indexOf("\n", markerStart);
-  if (cursor < 0) return null;
-  cursor += 1;
-  while (cursor < sourceFile.text.length) {
-    const newline = sourceFile.text.indexOf("\n", cursor);
-    const end = newline < 0 ? sourceFile.text.length : newline;
-    if (!AUTO_TIMER_SHIM_LINE.test(sourceFile.text.slice(cursor, end))) break;
-    cursor = newline < 0 ? end : newline + 1;
-  }
-  return cursor;
+/** Build the exact legacy R0 terminal view from the structural R1 inventory. */
+function collectObservedIrUnits(
+  sourceFile: ts.SourceFile,
+  _selection?: IrSelection,
+  inventory = buildIrUnitInventory([sourceFile], { entrySource: sourceFile }),
+): ObservedIrUnit[] {
+  return terminalIrUnitsForSource(inventory, sourceFile).map((unit) => ({
+    key: unit.legacyKey,
+    sourceId: unit.sourceId,
+    unitId: unit.id,
+    matchName: unit.legacyMatchName,
+    unitKind: unit.observedKind,
+    displayName: unit.displayName,
+    ordinal: unit.legacyOrdinal,
+    line: unit.line,
+    column: unit.column,
+    staticClassMember: unit.staticClassMember,
+    legacyBodyAvailable: unit.legacyBodyAvailable,
+    ...(unit.directFailure ? { directFailure: unit.directFailure } : {}),
+  }));
 }
 
-function observedClassMemberName(className: string, member: ts.ClassElement): string | null {
-  if (ts.isConstructorDeclaration(member)) return `${className}_new`;
-  if (!ts.isMethodDeclaration(member) && !ts.isGetAccessorDeclaration(member) && !ts.isSetAccessorDeclaration(member)) {
-    return null;
-  }
-  const raw = member.name;
-  const base =
-    raw && (ts.isIdentifier(raw) || ts.isStringLiteral(raw) || ts.isNumericLiteral(raw)) ? raw.text : "<computed>";
-  if (ts.isGetAccessorDeclaration(member)) return `${className}_get_${base}`;
-  if (ts.isSetAccessorDeclaration(member)) return `${className}_set_${base}`;
-  return `${className}_${base}`;
-}
-
-/** Build observational labels only; compiler identity remains legacy-owned until R1. */
-function collectObservedIrUnits(sourceFile: ts.SourceFile, selection?: IrSelection): ObservedIrUnit[] {
-  const units: ObservedIrUnit[] = [];
-  const ordinals = new Map<string, number>();
-  const timerShimEnd = autoTimerShimEnd(sourceFile);
-  let unnamed = 0;
-  let anonymousClass = 0;
-  let firstStaticInitialization: ts.Node | undefined;
-  const push = (
-    matchName: string,
-    unitKind: ObservedIrUnit["unitKind"],
-    node: ts.Node,
-    staticClassMember = false,
-    directFailure?: IrPreparationFailure,
-    legacyBodyAvailable = true,
-  ): void => {
-    const ordinalKey = `${unitKind}\u0000${matchName}`;
-    const ordinal = ordinals.get(ordinalKey) ?? 0;
-    ordinals.set(ordinalKey, ordinal + 1);
-    const pos = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-    units.push({
-      key: `${sourceFile.fileName}::${unitKind}::${matchName}#${ordinal}`,
-      matchName,
-      unitKind,
-      displayName: matchName,
-      ordinal,
-      line: pos.line + 1,
-      column: pos.character + 1,
-      staticClassMember,
-      legacyBodyAvailable,
-      ...(directFailure ? { directFailure } : {}),
-    });
-  };
-
-  for (const statement of sourceFile.statements) {
-    if (ts.isFunctionDeclaration(statement)) {
-      // Overload signatures and ambient declarations allocate no executable
-      // legacy slot, so they are not source-unit denominator entries.
-      if (!statement.body) continue;
-      if (timerShimEnd !== null && statement.getStart(sourceFile) < timerShimEnd) continue;
-      push(statement.name?.text ?? `<unnamed:${unnamed++}>`, "function", statement);
-      continue;
-    }
-    if (!ts.isClassDeclaration(statement)) continue;
-    const isAnonymous = !statement.name;
-    const className = statement.name?.text ?? `<anonymous-default-class:${anonymousClass++}>`;
-    const anonymousFailure: IrPreparationFailure | undefined = isAnonymous
-      ? {
-          kind: "unsupported",
-          code: "anonymous-class",
-          stage: "select",
-          detail: `${className} has no stable direct-codegen class identity for IR patching`,
-        }
-      : undefined;
-    let hasExecutableConstructor = false;
-    let firstInstanceInitializer: ts.PropertyDeclaration | undefined;
-    for (const member of statement.members) {
-      const isStatic = hasStaticModifier(member);
-      if (
-        (ts.isClassStaticBlockDeclaration(member) ||
-          (ts.isPropertyDeclaration(member) && isStatic && member.initializer)) &&
-        firstStaticInitialization === undefined
-      ) {
-        firstStaticInitialization = member;
-      }
-      if (ts.isPropertyDeclaration(member) && !isStatic && member.initializer && !firstInstanceInitializer) {
-        firstInstanceInitializer = member;
-      }
-      const name = observedClassMemberName(className, member);
-      if (name === null) continue;
-      const functionalMember = member as
-        | ts.ConstructorDeclaration
-        | ts.MethodDeclaration
-        | ts.GetAccessorDeclaration
-        | ts.SetAccessorDeclaration;
-      if (!functionalMember.body) continue;
-      if (ts.isConstructorDeclaration(functionalMember)) hasExecutableConstructor = true;
-      push(name, "class-member", member, isStatic, anonymousFailure);
-    }
-    if (!hasExecutableConstructor && firstInstanceInitializer) {
-      push(`${className}_new`, "class-member", firstInstanceInitializer, false, {
-        kind: "unsupported",
-        code: "implicit-class-initializer",
-        stage: "select",
-        detail: `${className} has instance field initialization owned by an implicit direct constructor`,
-      });
-    }
-  }
-
-  const modulePopulation = collectModuleInitPopulation(sourceFile);
-  if ((selection?.moduleInit?.stmtCount ?? modulePopulation.length) > 0 || firstStaticInitialization) {
-    const first = modulePopulation[0] ?? firstStaticInitialization ?? sourceFile;
-    push(
-      MODULE_INIT_UNIT_NAME,
-      "module-init",
-      first,
-      false,
-      firstStaticInitialization
-        ? {
-            kind: "unsupported",
-            code: "static-class-initialization",
-            stage: "select",
-            detail: "class static initialization is still emitted by the direct module-init path",
-          }
-        : undefined,
-    );
-  }
-  return units;
-}
-
-function recordWholeSourceFailure(ctx: CodegenContext, sourceFile: ts.SourceFile, failure: IrPreparationFailure): void {
+function recordWholeSourceFailure(
+  ctx: CodegenContext,
+  sourceFile: ts.SourceFile,
+  failure: IrPreparationFailure,
+  inventory?: IrUnitInventory,
+): void {
   if (ctx.irOutcomes === undefined || ctx.irOutcomes.some((outcome) => outcome.file === sourceFile.fileName)) return;
   const target: IrObservedOutcome["target"] = ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "gc";
-  for (const unit of collectObservedIrUnits(sourceFile)) {
+  for (const unit of collectObservedIrUnits(sourceFile, undefined, inventory)) {
     ctx.irOutcomes.push(
       observedFailure(
         {
           key: unit.key,
+          sourceId: unit.sourceId,
+          unitId: unit.unitId,
           file: sourceFile.fileName,
           unitKind: unit.unitKind,
           displayName: unit.displayName,
@@ -1873,6 +1763,7 @@ function recordObservedIrOutcomes(
   preparedSelection: Pick<IrSelection, "funcs" | "classMembers" | "moduleInit">,
   report: IrIntegrationReport,
   irSkipBodies?: ReadonlySet<string>,
+  inventory?: IrUnitInventory,
 ): void {
   if (ctx.irOutcomes === undefined) return;
 
@@ -1888,11 +1779,13 @@ function recordObservedIrOutcomes(
 
   const target: IrObservedOutcome["target"] = ctx.wasi ? "wasi" : ctx.standalone ? "standalone" : "gc";
   const keys = new Set(ctx.irOutcomes.map((outcome) => outcome.key));
-  for (const unit of collectObservedIrUnits(sourceFile, plan.selection)) {
+  for (const unit of collectObservedIrUnits(sourceFile, plan.selection, inventory)) {
     const legacyBodyEmitted =
       unit.legacyBodyAvailable && !(unit.unitKind === "function" && irSkipBodies?.has(unit.matchName));
     const base = {
       key: unit.key,
+      sourceId: unit.sourceId,
+      unitId: unit.unitId,
       file: sourceFile.fileName,
       unitKind: unit.unitKind,
       displayName: unit.displayName,
@@ -2675,6 +2568,7 @@ function consumeIrOverlayReport(
   preparedSelection: Pick<IrSelection, "funcs" | "classMembers" | "moduleInit">,
   sourceFile: ts.SourceFile,
   irSkipBodies?: ReadonlySet<string>,
+  inventory?: IrUnitInventory,
 ): void {
   const { selection, logFallbacks } = plan;
   // #3000 — aggregate genuine emission across every source-file overlay. A
@@ -2720,7 +2614,7 @@ function consumeIrOverlayReport(
     }
   }
 
-  recordObservedIrOutcomes(ctx, sourceFile, plan, preparedSelection, report, irSkipBodies);
+  recordObservedIrOutcomes(ctx, sourceFile, plan, preparedSelection, report, irSkipBodies, inventory);
 
   // #1169q — retain the existing selector-fallback log format, now once per
   // source file for a multi-module compilation.
@@ -3131,6 +3025,7 @@ function prepareMultiIrImportedLowering(
 export function generateModule(
   ast: TypedAST,
   options?: CodegenOptions,
+  inventoryOptions: BuildIrUnitInventoryOptions = {},
 ): {
   module: WasmModule;
   errors: CodegenError[];
@@ -3147,6 +3042,9 @@ export function generateModule(
 } {
   const mod = createEmptyModule();
   const ctx = createCodegenContext(mod, ast.checker, options);
+  const irUnitInventory = options?.trackIrOutcomes
+    ? buildIrUnitInventory([ast.sourceFile], { ...inventoryOptions, entrySource: ast.sourceFile })
+    : undefined;
   const sourceFileInternal = ast.sourceFile as ts.SourceFile & { externalModuleIndicator?: ts.Node };
   ctx.sourceIsModule = sourceFileInternal.externalModuleIndicator !== undefined;
   // (#2138) Populated only under JS2WASM_IR_FIRST=1 — the top-level functions
@@ -3598,7 +3496,7 @@ export function generateModule(
         hostVoidCallbacks: plan.hostVoidCallbacks,
         promiseDelays: plan.promiseDelays,
       });
-      consumeIrOverlayReport(ctx, report, plan, safeSelection, ast.sourceFile, irSkipBodies);
+      consumeIrOverlayReport(ctx, report, plan, safeSelection, ast.sourceFile, irSkipBodies, irUnitInventory);
     }
 
     // Fixup pass: reconcile struct.new argument counts with actual struct field counts.
@@ -4125,7 +4023,7 @@ export function generateModule(
     // Must run after all other passes since they can introduce invalid coercions.
     fixupExternConvertAny(ctx);
   } catch (e) {
-    recordWholeSourceFailure(ctx, ast.sourceFile, classifyIrFailure(e, "build"));
+    recordWholeSourceFailure(ctx, ast.sourceFile, classifyIrFailure(e, "build"), irUnitInventory);
     reportErrorNoNode(ctx, `Codegen error: ${e instanceof Error ? e.message : String(e)}`);
   }
 
@@ -5545,6 +5443,12 @@ export function generateMultiModule(
 } {
   const mod = createEmptyModule();
   const ctx = createCodegenContext(mod, multiAst.checker, options);
+  const irUnitInventory = options?.trackIrOutcomes
+    ? buildIrUnitInventory(multiAst.sourceFiles, {
+        entrySource: multiAst.entryFile,
+        checker: multiAst.checker,
+      })
+    : undefined;
   // Multi-file compilation is linked through import/export module records.
   ctx.sourceIsModule = true;
   try {
@@ -5772,7 +5676,7 @@ export function generateMultiModule(
           hostVoidCallbacks: plan.hostVoidCallbacks,
           promiseDelays: plan.promiseDelays,
         });
-        consumeIrOverlayReport(ctx, report, plan, safeSelection, sourceFile);
+        consumeIrOverlayReport(ctx, report, plan, safeSelection, sourceFile, undefined, irUnitInventory);
       }
       // A+B1 may create callback singleton trampolines after the legacy
       // finalization pass. Rebuild those late declarations against the target's
@@ -6031,7 +5935,9 @@ export function generateMultiModule(
     fixupExternConvertAny(ctx);
   } catch (e) {
     const failure = classifyIrFailure(e, "build");
-    for (const sourceFile of multiAst.sourceFiles) recordWholeSourceFailure(ctx, sourceFile, failure);
+    for (const sourceFile of multiAst.sourceFiles) {
+      recordWholeSourceFailure(ctx, sourceFile, failure, irUnitInventory);
+    }
     reportErrorNoNode(ctx, `Codegen error: ${e instanceof Error ? e.message : String(e)}`);
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -16,7 +16,6 @@ import type { CodegenOptions } from "./codegen/context/types.js";
 import { assertCodegenRegistrationsComplete } from "./codegen/shared.js";
 import { isFatalCodegenDiagnostic } from "./codegen/context/errors.js";
 import type { WasmModule } from "./ir/types.js";
-import { buildIrUnitInventory, type BuildIrUnitInventoryOptions } from "./ir/identity.js";
 import {
   buildImportManifest,
   checkJsTypeCoverage,
@@ -41,7 +40,7 @@ import { preprocessImports } from "./import-resolver.js";
 import { PositionMap } from "./position-map.js";
 import { injectProcessStdinPrelude } from "./process-stdin-prelude.js";
 import { injectIteratorStaticsPrelude } from "./iterator-statics-prelude.js";
-import { elideDeadTopLevelBindings } from "./deadcode-elide.js";
+import { elideWithIrIds, makeIrInventoryOptions, type IrInventoryOptions } from "./compiler/ir-outcome-inventory.js";
 import type { CompileError, CompileOptions, CompileResult } from "./index.js";
 import { optimizeBinaryAsync } from "./optimize.js";
 import { generateWit } from "./wit-generator.js";
@@ -821,8 +820,7 @@ interface PipelineInput {
   errors: CompileError[];
   /** Resolved codegen option bundle (see buildCodegenOptions). */
   codegenOptions: CodegenOptions;
-  /** Read-only provenance/dependency inputs for the shadow R1 inventory. */
-  irInventoryOptions?: BuildIrUnitInventoryOptions;
+  irInventoryOptions?: IrInventoryOptions;
   /** For source-map sourcesContent: original-name → original text. */
   sourcesContent: Map<string, string>;
   /** Anchor file for pushSourceAnchoredDiagnostic on codegen/emit throws. */
@@ -1311,8 +1309,7 @@ export function compileSourceSync(
   // #1491 — detect named fs imports for both WASI (#1035 syscall path) and the
   // new JS-host imports (non-WASI). Detection is identical; the codegen branch
   // is selected based on `ctx.wasi` + `ctx.allowFs`.
-  // Same-line rewrites still change structural AST offsets and can inject
-  // executable support units, so eval/super contributes a real provenance map.
+  // #1928/#1054 — same-line eval/super rewrites still contribute structural provenance.
   const evalResult = rewriteEvalSuperCallWithMap(cjsRewritten);
   const cjsRewritten2 = evalResult.source;
   const wasiNodeFsFuncs = detectNodeFsImports(cjsRewritten);
@@ -1323,9 +1320,7 @@ export function compileSourceSync(
   const { rawWasi: wasiRawImports, memAccessors: wasiMemAccessors } = detectRawWasiImports(cjsRewritten);
   const preprocessed = preprocessImports(cjsRewritten2, { wasi: options.target === "wasi" });
   let processedSource = preprocessed.source;
-  // Composed map: processedSource → original source. Pipeline output order is
-  // define → stdin-prelude → cjs → eval/super → imports, so compose
-  // outermost-first.
+  // Compose imports → eval/super → CJS → Iterator → stdin → define back to the original source.
   const positionMap = preprocessed.positionMap
     .compose(evalResult.positionMap)
     .compose(cjsResult.positionMap)
@@ -1337,12 +1332,7 @@ export function compileSourceSync(
   let isJsMode = options.allowJs === true || (options.fileName?.endsWith(".js") ?? false);
   const defaultFileName = options.fileName ?? (isJsMode ? "input.js" : "input.ts");
   const effectiveFileName = options.moduleName ?? defaultFileName;
-  let irInventoryOptions: BuildIrUnitInventoryOptions | undefined = options.trackIrOutcomes
-    ? {
-        compilerOriginAt: (_sourceFile: ts.SourceFile, offset: number) =>
-          positionMap.compilerOriginAtOutputOffset(offset),
-      }
-    : undefined;
+  let irInventory = options.trackIrOutcomes ? makeIrInventoryOptions(positionMap) : undefined;
   // #2645/#2736 — `--target node`/`deno` (formerly `--platform node`) implies
   // node-style emulation so the ambient surface and the importable `node:<mod>`
   // capability gate share one target model. This EFFECTIVE flag drives the
@@ -1358,51 +1348,14 @@ export function compileSourceSync(
   // stay intact. Byte-neutral when no prelude was injected.
   const forceTsGrammar = stdinResult.injected || iterStaticsResult.injected;
 
-  // Step 1a: #3418 — host-free targets only: elide provably-dead top-level
-  // pure bindings BEFORE the parse, so never-invoked function bodies (e.g. the
-  // test262 harness shim's `var print = function () { console.log(...) }` /
-  // `var $262 = { detachArrayBuffer: ... structuredClone ... }` when the
-  // program never mentions them) don't register host imports in the unified
-  // collector. Strictly same-length whitespace blanking → identity map, no
-  // positionMap composition needed; bails (source untouched) on any syntax
-  // error. Host `gc`/`linear` targets are excluded and stay byte-identical.
+  // Step 1a: #3418 — host-free targets elide dead pure top-level bindings before
+  // parsing so unreachable bodies do not register host imports. Same-length
+  // whitespace blanking needs no PositionMap; syntax errors leave source intact.
   if (options.target === "standalone" || options.target === "wasi") {
     const scriptKind = isJsMode && !forceTsGrammar ? ts.ScriptKind.JS : ts.ScriptKind.TS;
-    const preElisionSource = processedSource;
-    const elision = elideDeadTopLevelBindings(preElisionSource, scriptKind);
-    if (irInventoryOptions && elision.elided.length > 0) {
-      const identitySource = ts.createSourceFile(
-        effectiveFileName,
-        preElisionSource,
-        ts.ScriptTarget.Latest,
-        true,
-        scriptKind,
-      );
-      const canonical = buildIrUnitInventory([identitySource], {
-        entrySource: identitySource,
-        compilerOriginAt: irInventoryOptions.compilerOriginAt,
-      });
-      const unitOrdinals = new Map(
-        canonical.allUnits.map((unit) => [
-          `${unit.declarationStart}\u0000${unit.declarationEnd}\u0000${unit.kind}`,
-          unit.ordinal,
-        ]),
-      );
-      const classOrdinals = new Map(
-        canonical.classes.map((record) => [
-          `${record.declarationStart}\u0000${record.declarationEnd}\u0000${record.declarationKind}`,
-          record.ordinal,
-        ]),
-      );
-      irInventoryOptions = {
-        ...irInventoryOptions,
-        canonicalUnitOrdinalAt: (_sourceFile, declarationStart, declarationEnd, kind) =>
-          unitOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${kind}`),
-        canonicalClassOrdinalAt: (_sourceFile, declarationStart, declarationEnd, declarationKind) =>
-          classOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${declarationKind}`),
-      };
-    }
+    const elision = elideWithIrIds(processedSource, effectiveFileName, scriptKind, irInventory);
     processedSource = elision.source;
+    irInventory = elision.inventoryOptions;
   }
 
   let ast: TypedAST;
@@ -1564,7 +1517,7 @@ export function compileSourceSync(
       wasiMemAccessors,
       jsxRuntime: preprocessed.jsxRuntime,
     }),
-    ...(irInventoryOptions ? { irInventoryOptions } : {}),
+    ...(irInventory ? { irInventoryOptions: irInventory } : {}),
     sourcesContent,
     diagnosticAnchor: ast.sourceFile,
     // #1958 — single-source: the lone source is the entry, so always run ES

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -16,6 +16,7 @@ import type { CodegenOptions } from "./codegen/context/types.js";
 import { assertCodegenRegistrationsComplete } from "./codegen/shared.js";
 import { isFatalCodegenDiagnostic } from "./codegen/context/errors.js";
 import type { WasmModule } from "./ir/types.js";
+import { buildIrUnitInventory, type BuildIrUnitInventoryOptions } from "./ir/identity.js";
 import {
   buildImportManifest,
   checkJsTypeCoverage,
@@ -26,7 +27,7 @@ import { applyCabiTransform, generateDts, generateImportsHelper, widenNonDefault
 import {
   detectEarlyErrors,
   pushSourceAnchoredDiagnostic,
-  rewriteEvalSuperCall,
+  rewriteEvalSuperCallWithMap,
   validateHardenedMode,
   validateSafeMode,
 } from "./compiler/validation.js";
@@ -820,6 +821,8 @@ interface PipelineInput {
   errors: CompileError[];
   /** Resolved codegen option bundle (see buildCodegenOptions). */
   codegenOptions: CodegenOptions;
+  /** Read-only provenance/dependency inputs for the shadow R1 inventory. */
+  irInventoryOptions?: BuildIrUnitInventoryOptions;
   /** For source-map sourcesContent: original-name → original text. */
   sourcesContent: Map<string, string>;
   /** Anchor file for pushSourceAnchoredDiagnostic on codegen/emit throws. */
@@ -1010,7 +1013,7 @@ function runPipeline(input: PipelineInput): CompileResult {
     } else {
       const result = multiAst
         ? generateMultiModule(multiAst, input.codegenOptions)
-        : generateModule(entryAst, input.codegenOptions);
+        : generateModule(entryAst, input.codegenOptions, input.irInventoryOptions);
       mod = result.module;
       capturedFallbackCounts = result.fallbackCounts;
       capturedIrPostClaimErrors = result.irPostClaimErrors;
@@ -1308,10 +1311,10 @@ export function compileSourceSync(
   // #1491 — detect named fs imports for both WASI (#1035 syscall path) and the
   // new JS-host imports (non-WASI). Detection is identical; the codegen branch
   // is selected based on `ctx.wasi` + `ctx.allowFs`.
-  // #1928 — `rewriteEvalSuperCall` only rewrites `eval("…super()…")` to a
-  // same-line throwing IIFE (a rare early-error edge); it never shifts lines, so
-  // it contributes an identity map and is omitted from the composition.
-  const cjsRewritten2 = rewriteEvalSuperCall(cjsRewritten);
+  // Same-line rewrites still change structural AST offsets and can inject
+  // executable support units, so eval/super contributes a real provenance map.
+  const evalResult = rewriteEvalSuperCallWithMap(cjsRewritten);
+  const cjsRewritten2 = evalResult.source;
   const wasiNodeFsFuncs = detectNodeFsImports(cjsRewritten);
   // #2657 — raw `wasi_snapshot_preview1` fd_read/fd_write imports + the
   // `wasm:memory` inline linear-memory accessors (detected pre-preprocessing,
@@ -1321,9 +1324,10 @@ export function compileSourceSync(
   const preprocessed = preprocessImports(cjsRewritten2, { wasi: options.target === "wasi" });
   let processedSource = preprocessed.source;
   // Composed map: processedSource → original source. Pipeline output order is
-  // define → stdin-prelude → cjs → (eval/super, identity) → imports, so compose
+  // define → stdin-prelude → cjs → eval/super → imports, so compose
   // outermost-first.
   const positionMap = preprocessed.positionMap
+    .compose(evalResult.positionMap)
     .compose(cjsResult.positionMap)
     .compose(iterStaticsResult.positionMap)
     .compose(stdinResult.positionMap)
@@ -1333,6 +1337,12 @@ export function compileSourceSync(
   let isJsMode = options.allowJs === true || (options.fileName?.endsWith(".js") ?? false);
   const defaultFileName = options.fileName ?? (isJsMode ? "input.js" : "input.ts");
   const effectiveFileName = options.moduleName ?? defaultFileName;
+  let irInventoryOptions: BuildIrUnitInventoryOptions | undefined = options.trackIrOutcomes
+    ? {
+        compilerOriginAt: (_sourceFile: ts.SourceFile, offset: number) =>
+          positionMap.compilerOriginAtOutputOffset(offset),
+      }
+    : undefined;
   // #2645/#2736 — `--target node`/`deno` (formerly `--platform node`) implies
   // node-style emulation so the ambient surface and the importable `node:<mod>`
   // capability gate share one target model. This EFFECTIVE flag drives the
@@ -1357,10 +1367,42 @@ export function compileSourceSync(
   // positionMap composition needed; bails (source untouched) on any syntax
   // error. Host `gc`/`linear` targets are excluded and stay byte-identical.
   if (options.target === "standalone" || options.target === "wasi") {
-    processedSource = elideDeadTopLevelBindings(
-      processedSource,
-      isJsMode && !forceTsGrammar ? ts.ScriptKind.JS : ts.ScriptKind.TS,
-    ).source;
+    const scriptKind = isJsMode && !forceTsGrammar ? ts.ScriptKind.JS : ts.ScriptKind.TS;
+    const preElisionSource = processedSource;
+    const elision = elideDeadTopLevelBindings(preElisionSource, scriptKind);
+    if (irInventoryOptions && elision.elided.length > 0) {
+      const identitySource = ts.createSourceFile(
+        effectiveFileName,
+        preElisionSource,
+        ts.ScriptTarget.Latest,
+        true,
+        scriptKind,
+      );
+      const canonical = buildIrUnitInventory([identitySource], {
+        entrySource: identitySource,
+        compilerOriginAt: irInventoryOptions.compilerOriginAt,
+      });
+      const unitOrdinals = new Map(
+        canonical.allUnits.map((unit) => [
+          `${unit.declarationStart}\u0000${unit.declarationEnd}\u0000${unit.kind}`,
+          unit.ordinal,
+        ]),
+      );
+      const classOrdinals = new Map(
+        canonical.classes.map((record) => [
+          `${record.declarationStart}\u0000${record.declarationEnd}\u0000${record.declarationKind}`,
+          record.ordinal,
+        ]),
+      );
+      irInventoryOptions = {
+        ...irInventoryOptions,
+        canonicalUnitOrdinalAt: (_sourceFile, declarationStart, declarationEnd, kind) =>
+          unitOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${kind}`),
+        canonicalClassOrdinalAt: (_sourceFile, declarationStart, declarationEnd, declarationKind) =>
+          classOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${declarationKind}`),
+      };
+    }
+    processedSource = elision.source;
   }
 
   let ast: TypedAST;
@@ -1522,6 +1564,7 @@ export function compileSourceSync(
       wasiMemAccessors,
       jsxRuntime: preprocessed.jsxRuntime,
     }),
+    ...(irInventoryOptions ? { irInventoryOptions } : {}),
     sourcesContent,
     diagnosticAnchor: ast.sourceFile,
     // #1958 — single-source: the lone source is the entry, so always run ES

--- a/src/compiler/ir-outcome-inventory.ts
+++ b/src/compiler/ir-outcome-inventory.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { elideDeadTopLevelBindings } from "../deadcode-elide.js";
+import { buildIrUnitInventory, type BuildIrUnitInventoryOptions } from "../ir/identity.js";
+import type { PositionMap } from "../position-map.js";
+import { ts } from "../ts-api.js";
+
+export type IrInventoryOptions = BuildIrUnitInventoryOptions;
+
+export function makeIrInventoryOptions(positionMap: PositionMap): IrInventoryOptions {
+  return {
+    compilerOriginAt: (_sourceFile, offset) => positionMap.compilerOriginAtOutputOffset(offset),
+  };
+}
+
+/**
+ * Preserve pre-elision structural ordinals for retained support units while
+ * keeping the final inventory limited to nodes that remain in the target AST.
+ */
+export function elideWithIrIds(
+  source: string,
+  fileName: string,
+  scriptKind: ts.ScriptKind,
+  inventoryOptions: IrInventoryOptions | undefined,
+): { source: string; inventoryOptions: IrInventoryOptions | undefined } {
+  const elision = elideDeadTopLevelBindings(source, scriptKind);
+  if (!inventoryOptions || elision.elided.length === 0) {
+    return { source: elision.source, inventoryOptions };
+  }
+
+  const identitySource = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, scriptKind);
+  const canonical = buildIrUnitInventory([identitySource], {
+    entrySource: identitySource,
+    compilerOriginAt: inventoryOptions.compilerOriginAt,
+  });
+  const unitOrdinals = new Map(
+    canonical.allUnits.map((unit) => [
+      `${unit.declarationStart}\u0000${unit.declarationEnd}\u0000${unit.kind}`,
+      unit.ordinal,
+    ]),
+  );
+  const classOrdinals = new Map(
+    canonical.classes.map((record) => [
+      `${record.declarationStart}\u0000${record.declarationEnd}\u0000${record.declarationKind}`,
+      record.ordinal,
+    ]),
+  );
+  return {
+    source: elision.source,
+    inventoryOptions: {
+      ...inventoryOptions,
+      canonicalUnitOrdinalAt: (_sourceFile, declarationStart, declarationEnd, kind) =>
+        unitOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${kind}`),
+      canonicalClassOrdinalAt: (_sourceFile, declarationStart, declarationEnd, declarationKind) =>
+        classOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${declarationKind}`),
+    },
+  };
+}

--- a/src/compiler/validation.ts
+++ b/src/compiler/validation.ts
@@ -1,5 +1,6 @@
 import type { CompileError, CompileOptions } from "../index.js";
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { PositionMap, type CompilerSourceOriginSpan, type SourceEdit } from "../position-map.js";
 import { forEachChild, ts } from "../ts-api.js";
 import { detectEarlyErrors } from "./early-errors/index.js";
 
@@ -253,7 +254,7 @@ function validateHardenedMode(
  * - Direct eval from a derived constructor would legitimately allow
  *   super(), but test262 has no passing tests covering that pattern.
  */
-function rewriteEvalSuperCall(source: string): string {
+function rewriteEvalSuperCallWithMap(source: string): { source: string; positionMap: PositionMap } {
   const hasSuperCall = (s: string) => /\bsuper\s*\(/.test(s);
   const replacement = `((function(){throw new SyntaxError("super() not allowed in eval (early error)")}()))`;
 
@@ -265,11 +266,44 @@ function rewriteEvalSuperCall(source: string): string {
   const directDq = new RegExp(`(^|[^\\w$.])eval\\s*\\(\\s*"(${dqBody})"\\s*\\)`, "g");
 
   let out = source;
-  out = out.replace(indirectSq, (full, body) => (hasSuperCall(body) ? replacement : full));
-  out = out.replace(indirectDq, (full, body) => (hasSuperCall(body) ? replacement : full));
-  out = out.replace(directSq, (full, prefix, body) => (hasSuperCall(body) ? `${prefix}${replacement}` : full));
-  out = out.replace(directDq, (full, prefix, body) => (hasSuperCall(body) ? `${prefix}${replacement}` : full));
-  return out;
+  let positionMap = PositionMap.identity();
+  const apply = (pattern: RegExp, bodyIndex: number, prefixIndex?: number): void => {
+    const edits: SourceEdit[] = [];
+    out = out.replace(pattern, (...args: unknown[]) => {
+      const full = args[0] as string;
+      const body = args[bodyIndex] as string;
+      if (!hasSuperCall(body)) return full;
+      const prefix = prefixIndex === undefined ? "" : (args[prefixIndex] as string);
+      const generated = prefix + replacement;
+      const functionStart = generated.indexOf("function");
+      const compilerOrigins: CompilerSourceOriginSpan[] = [
+        {
+          start: functionStart,
+          end: generated.length,
+          origin: { producer: "eval-super-rewrite", role: "early-error-thrower" },
+        },
+      ];
+      const offset = args.at(-2) as number;
+      edits.push({
+        origStart: offset,
+        origEnd: offset + full.length,
+        newLength: generated.length,
+        compilerOrigins,
+      });
+      return generated;
+    });
+    if (edits.length > 0) positionMap = new PositionMap(edits).compose(positionMap);
+  };
+
+  apply(indirectSq, 1);
+  apply(indirectDq, 1);
+  apply(directSq, 2, 1);
+  apply(directDq, 2, 1);
+  return { source: out, positionMap };
+}
+
+function rewriteEvalSuperCall(source: string): string {
+  return rewriteEvalSuperCallWithMap(source).source;
 }
 
 export {
@@ -279,6 +313,7 @@ export {
   hasExportModifier,
   pushSourceAnchoredDiagnostic,
   rewriteEvalSuperCall,
+  rewriteEvalSuperCallWithMap,
   validateHardenedMode,
   validateSafeMode,
 };

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { ts, forEachChild } from "./ts-api.js";
-import { PositionMap, type SourceEdit } from "./position-map.js";
+import {
+  PositionMap,
+  type CompilerSourceOriginSpan,
+  type CompilerSourceProducer,
+  type SourceEdit,
+} from "./position-map.js";
 
 interface ClassUsageInfo {
   constructorArgCounts: number[];
@@ -244,6 +249,27 @@ const PATH_SHIM_METHODS = [
   "isAbsolute",
   "relative",
 ] as const;
+const PATH_PRELUDE_FUNCTION_ROLES: Readonly<Record<string, string>> = {
+  __js2wasm_path_normStr: "normalize-segments",
+  __js2wasm_path_normalize: "normalize",
+  __js2wasm_path_isAbsolute: "is-absolute",
+  __js2wasm_path_join: "join",
+  __js2wasm_path_resolve: "resolve",
+  __js2wasm_path_dirname: "dirname",
+  __js2wasm_path_basename: "basename",
+  __js2wasm_path_extname: "extname",
+  __js2wasm_path_relative: "relative",
+};
+const PATH_BINDING_FUNCTION_ROLES: Readonly<Record<string, string>> = {
+  join: "named-join",
+  resolve: "named-resolve",
+  normalize: "named-normalize",
+  dirname: "named-dirname",
+  basename: "named-basename",
+  extname: "named-extname",
+  isAbsolute: "named-is-absolute",
+  relative: "named-relative",
+};
 /** Recognised data properties on the `path` module object (posix). */
 const PATH_SHIM_PROPS: Record<string, string> = { sep: '"/"', delimiter: '":"' };
 
@@ -641,16 +667,114 @@ export interface PreprocessResult {
  * `replacements` are expressed in INPUT coordinates as `[start, end) → text`;
  * a prepended `timerShim` is an edit at offset 0 with an empty original span.
  */
+interface PreprocessReplacement {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+  readonly compilerOrigins?: readonly CompilerSourceOriginSpan[];
+}
+
+function generatedFunctionOrigins(
+  text: string,
+  producer: CompilerSourceProducer,
+  roles: Readonly<Record<string, string>>,
+): CompilerSourceOriginSpan[] {
+  const sf = ts.createSourceFile(`__${producer}_origins__.ts`, text, ts.ScriptTarget.Latest, true);
+  const origins: CompilerSourceOriginSpan[] = [];
+  for (const statement of sf.statements) {
+    if (!ts.isFunctionDeclaration(statement) || !statement.body || !statement.name) continue;
+    const role = roles[statement.name.text];
+    if (!role) throw new Error(`missing compiler provenance role for ${producer} helper ${statement.name.text}`);
+    origins.push({
+      start: statement.getStart(sf),
+      end: statement.end,
+      origin: { producer, role },
+    });
+  }
+  return origins;
+}
+
+function generatedClassOrigins(
+  text: string,
+  producer: CompilerSourceProducer,
+  roles: Readonly<Record<string, string>>,
+): CompilerSourceOriginSpan[] {
+  const sf = ts.createSourceFile(`__${producer}_class_origins__.ts`, text, ts.ScriptTarget.Latest, true);
+  const origins: CompilerSourceOriginSpan[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) && node.name) {
+      const role = roles[node.name.text];
+      if (!role) throw new Error(`missing compiler provenance role for ${producer} class ${node.name.text}`);
+      origins.push({
+        start: node.getStart(sf),
+        end: node.end,
+        origin: { producer, role },
+      });
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(sf, visit);
+  return origins;
+}
+
+function pathBindingOrigins(
+  text: string,
+  functionRoles: Readonly<Record<string, string>> = PATH_BINDING_FUNCTION_ROLES,
+): CompilerSourceOriginSpan[] {
+  const sf = ts.createSourceFile("__node_path_binding_origins__.ts", text, ts.ScriptTarget.Latest, true);
+  const origins = generatedFunctionOrigins(text, "node-path-binding", functionRoles);
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isMethodDeclaration(node) &&
+      ts.isObjectLiteralExpression(node.parent) &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    ) {
+      const methodRole = PATH_BINDING_FUNCTION_ROLES[node.name.text];
+      if (!methodRole) throw new Error(`missing compiler provenance role for node:path method ${node.name.text}`);
+      origins.push({
+        start: node.getStart(sf),
+        end: node.end,
+        origin: { producer: "node-path-binding", role: `default-${methodRole.replace(/^named-/, "")}` },
+      });
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  forEachChild(sf, visit);
+  return origins;
+}
+
 function buildPreprocessPositionMap(
-  replacements: { start: number; end: number; text: string }[],
-  timerShimLen: number,
+  replacements: readonly PreprocessReplacement[],
+  pathShim: string,
+  timerShim: string,
 ): PositionMap {
   const edits: SourceEdit[] = [];
-  if (timerShimLen > 0) {
-    edits.push({ origStart: 0, origEnd: 0, newLength: timerShimLen });
+  if (pathShim.length > 0) {
+    edits.push({
+      origStart: 0,
+      origEnd: 0,
+      newLength: pathShim.length,
+      compilerOrigins: generatedFunctionOrigins(pathShim, "node-path-prelude", PATH_PRELUDE_FUNCTION_ROLES),
+    });
+  }
+  if (timerShim.length > 0) {
+    edits.push({
+      origStart: 0,
+      origEnd: 0,
+      newLength: timerShim.length,
+      compilerOrigins: generatedFunctionOrigins(timerShim, "timer-shim", TIMER_FUNCTION_ROLES),
+    });
   }
   for (const r of replacements) {
-    edits.push({ origStart: r.start, origEnd: r.end, newLength: r.text.length });
+    edits.push({
+      origStart: r.start,
+      origEnd: r.end,
+      newLength: r.text.length,
+      ...(r.compilerOrigins ? { compilerOrigins: r.compilerOrigins } : {}),
+    });
   }
   return new PositionMap(edits);
 }
@@ -732,6 +856,13 @@ function buildTimerShim(used: Set<string>, definedNames: Set<string>): string {
   if (lines.length === 0) return "";
   return `// #1501 timer host-import shim (auto-injected)\n${lines.join("\n")}\n`;
 }
+
+const TIMER_FUNCTION_ROLES: Readonly<Record<string, string>> = {
+  setTimeout: "set-timeout",
+  setInterval: "set-interval",
+  clearTimeout: "clear-timeout",
+  clearInterval: "clear-interval",
+};
 
 export function preprocessImports(source: string, opts?: { wasi?: boolean }): PreprocessResult {
   const sf = ts.createSourceFile("__preprocess__.ts", source, ts.ScriptTarget.Latest, true);
@@ -918,7 +1049,7 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
       nodeBuiltins,
       jsxRuntime,
       // #1928 — no imports here; only the (optional) timer-shim prepend shifts positions.
-      positionMap: buildPreprocessPositionMap([], timerShim.length),
+      positionMap: buildPreprocessPositionMap([], "", timerShim),
     };
   }
 
@@ -1072,10 +1203,10 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
   visit(sf);
 
   // Step 3: Generate replacements
-  const replacements: { start: number; end: number; text: string }[] = [];
+  const replacements: PreprocessReplacement[] = [];
 
   // Namespace imports → declare namespace
-  for (const [nsName, { start, end }] of nsImports) {
+  for (const [nsName, { start, end, moduleSpec }] of nsImports) {
     const classes = namespaces.get(nsName)!;
     const nested = nestedNs.get(nsName)!;
 
@@ -1131,7 +1262,18 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
     }
 
     declare += `}`;
-    replacements.push({ start, end, text: declare });
+    const moduleRole = isNodeBuiltin(moduleSpec) ? `node:${normalizeNodeBuiltin(moduleSpec)}` : moduleSpec;
+    const classRoles = Object.fromEntries(
+      [...classes.keys()].map((className) => [className, `namespace-class:${moduleRole}:${className}`]),
+    );
+    replacements.push({
+      start,
+      end,
+      text: declare,
+      ...(Object.keys(classRoles).length > 0
+        ? { compilerOrigins: generatedClassOrigins(declare, "import-wrapper", classRoles) }
+        : {}),
+    });
   }
 
   // Default and named imports → declare stubs
@@ -1160,10 +1302,12 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
           }
         }
       }
+      const replacementText = lines.length > 0 ? lines.join("\n") : `/* node:path shim import removed */`;
       replacements.push({
         start: imp.start,
         end: imp.end,
-        text: lines.length > 0 ? lines.join("\n") : `/* node:path shim import removed */`,
+        text: replacementText,
+        compilerOrigins: pathBindingOrigins(replacementText),
       });
       continue;
     }
@@ -1178,6 +1322,8 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
     // `globalThis.crypto` fallback).
     const isBuiltin = isNodeBuiltin(imp.moduleSpec);
     const moduleName = isBuiltin ? normalizeNodeBuiltin(imp.moduleSpec) : "";
+    const wrapperRoles: Record<string, string> = {};
+    const classRoles: Record<string, string> = {};
     const nodeBuiltinFnTypedStub = (name: string): string | null => {
       if (!isBuiltin) return null;
       const stub = NODE_BUILTIN_FN_TYPED_STUBS[moduleName]?.[name];
@@ -1188,6 +1334,7 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
       // appears in a Node module/fn name); the import-manifest classifier
       // decodes `$` → `/` so the runtime resolves `require("fs/promises")`.
       const hostName = `__nodefn__${moduleName.replace(/\//g, "$")}__${name}`;
+      wrapperRoles[name] = `node-builtin:${moduleName}:${name}`;
       return (
         `declare function ${hostName}(${stub.params}): ${stub.returns};\n` +
         `function ${name}(${stub.params}): ${stub.returns} { return ${hostName}(${stub.passthrough}); }`
@@ -1218,6 +1365,7 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
           const classStub = nodeBuiltinClassStub(moduleName, name);
           if (classStub) {
             lines.push(classStub);
+            classRoles[name] = `node-builtin-class:${moduleName}:${name}`;
             continue;
           }
         }
@@ -1237,10 +1385,20 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
       }
     }
 
+    const replacementText = lines.length > 0 ? lines.join("\n") : `/* side-effect import removed */`;
+    const compilerOrigins = [
+      ...(Object.keys(wrapperRoles).length > 0
+        ? generatedFunctionOrigins(replacementText, "import-wrapper", wrapperRoles)
+        : []),
+      ...(Object.keys(classRoles).length > 0
+        ? generatedClassOrigins(replacementText, "import-wrapper", classRoles)
+        : []),
+    ];
     replacements.push({
       start: imp.start,
       end: imp.end,
-      text: lines.length > 0 ? lines.join("\n") : `/* side-effect import removed */`,
+      text: replacementText,
+      ...(compilerOrigins.length > 0 ? { compilerOrigins } : {}),
     });
   }
 
@@ -1288,7 +1446,7 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
   // #1928 — capture the import-stub edits (in INPUT coordinates) for the
   // position map BEFORE the reverse-order apply mutates `result`. The map
   // constructor re-sorts ascending, so the apply order here is irrelevant to it.
-  const positionMap = buildPreprocessPositionMap(replacements, prelude.length);
+  const positionMap = buildPreprocessPositionMap(replacements, pathShim, timerShim);
 
   // Apply replacements in reverse order to preserve positions
   let result = source;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,9 @@ export type {
   IrOutcomePolicyVerdict,
   IrUnsupportedCode,
 } from "./ir/outcomes.js";
+// Outcome rows expose these opaque IDs; inventory/ABI construction remains an
+// internal IR seam until later R1 commits wire it into compiler ownership.
+export type { IrSourceId, IrUnitId } from "./ir/identity.js";
 import type { ExportSignature } from "./ir/types.js";
 import type { IrObservedOutcome } from "./ir/outcomes.js";
 

--- a/src/ir/identity.ts
+++ b/src/ir/identity.ts
@@ -1,0 +1,1218 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { ts } from "../ts-api.js";
+import type { CompilerSourceOrigin, CompilerSourceProducer } from "../position-map.js";
+import { collectModuleInitPopulation, MODULE_INIT_UNIT_NAME } from "./module-init.js";
+import type { IrPreparationFailure } from "./outcomes.js";
+
+declare const irSourceIdBrand: unique symbol;
+declare const irUnitIdBrand: unique symbol;
+declare const irClassIdBrand: unique symbol;
+declare const irBindingIdBrand: unique symbol;
+
+/** Canonical, program-relative identity for one compiler input source. */
+export type IrSourceId = string & { readonly [irSourceIdBrand]: "IrSourceId" };
+/** Canonical identity for one executable source or synthetic unit. */
+export type IrUnitId = string & { readonly [irUnitIdBrand]: "IrUnitId" };
+/** Canonical identity for one class declaration or expression. */
+export type IrClassId = string & { readonly [irClassIdBrand]: "IrClassId" };
+/** Canonical identity for one program ABI intention. */
+export type IrBindingId = string & { readonly [irBindingIdBrand]: "IrBindingId" };
+
+export type IrLexicalOwnerId = IrUnitId | IrClassId;
+export type IrSourceKind = "entry" | "source" | "library" | "synthetic";
+
+/** Closed role families for compiler/pass-created executable units. */
+export type IrSyntheticUnitRole =
+  | `compiler-unit:${CompilerSourceProducer}:${string}`
+  | "lifted-closure"
+  | "monomorphization-clone";
+/** Compiler-created class roles live in a namespace separate from source classes. */
+export type IrSyntheticClassRole = `compiler-class:${CompilerSourceProducer}:${string}`;
+
+export type IrUnitKind =
+  | "top-level-function"
+  | "nested-function"
+  | "function-expression"
+  | "arrow-function"
+  | "class-constructor"
+  | "class-implicit-constructor"
+  | "class-instance-method"
+  | "class-static-method"
+  | "class-instance-getter"
+  | "class-static-getter"
+  | "class-instance-setter"
+  | "class-static-setter"
+  | "class-instance-field-initializer"
+  | "class-static-field-initializer"
+  | "class-static-block"
+  | "object-method"
+  | "object-getter"
+  | "object-setter"
+  | "export-assignment"
+  | "module-init"
+  | "synthetic-support";
+
+export type IrTerminalObservedKind = "function" | "class-member" | "module-init";
+export type IrUnownedUnitReason = "no-r0-attempt-root";
+
+export interface IrSourceRecord {
+  readonly id: IrSourceId;
+  readonly kind: IrSourceKind;
+  /** Dependency-first order with canonical tie-breaking, never caller Map order. */
+  readonly order: number;
+  /** Normalized program-relative key. Absolute checkout roots are removed. */
+  readonly sourceKey: string;
+  /** Diagnostic label only; it is deliberately not part of semantic lookup. */
+  readonly displayName: string;
+  /** Original TypeScript filename, retained only to join compiler-owned ASTs. */
+  readonly originalFileName: string;
+}
+
+export interface IrClassRecord {
+  readonly id: IrClassId;
+  readonly sourceId: IrSourceId;
+  readonly lexicalOwnerId: IrLexicalOwnerId | null;
+  readonly declarationKind: "declaration" | "expression";
+  readonly ordinal: number;
+  /** Present only when the class identity is derived from a compiler role. */
+  readonly syntheticRole?: IrSyntheticClassRole;
+  readonly displayName: string;
+  readonly line: number;
+  readonly column: number;
+  readonly declarationStart: number;
+  readonly declarationEnd: number;
+}
+
+interface IrUnitRecordBase {
+  readonly id: IrUnitId;
+  readonly sourceId: IrSourceId;
+  readonly lexicalOwnerId: IrLexicalOwnerId | null;
+  readonly kind: IrUnitKind;
+  /** Declaration ordinal within the structural owner and unit kind. */
+  readonly ordinal: number;
+  /** Present only when the unit identity is derived from a compiler/pass role. */
+  readonly syntheticRole?: IrSyntheticUnitRole;
+  /** Diagnostic label only. It is never used to encode the identity. */
+  readonly displayName: string;
+  readonly line: number;
+  readonly column: number;
+  /** Source-relative declaration span for validated AST→identity joins. */
+  readonly declarationStart: number;
+  readonly declarationEnd: number;
+}
+
+export interface IrOwnedSupportUnitRecord extends IrUnitRecordBase {
+  readonly terminal: false;
+  readonly terminalOwnerId: IrUnitId;
+  readonly unownedReason?: never;
+}
+
+export interface IrUnownedSupportUnitRecord extends IrUnitRecordBase {
+  readonly terminal: false;
+  readonly terminalOwnerId: null;
+  readonly unownedReason: IrUnownedUnitReason;
+}
+
+/** Exact structural counterpart of one existing R0 terminal outcome row. */
+export interface IrTerminalUnitRecord extends IrUnitRecordBase {
+  readonly terminal: true;
+  readonly terminalOwnerId: IrUnitId;
+  readonly unownedReason?: never;
+  readonly observedKind: IrTerminalObservedKind;
+  readonly legacyKey: string;
+  readonly legacyMatchName: string;
+  readonly legacyOrdinal: number;
+  readonly staticClassMember: boolean;
+  readonly legacyBodyAvailable: boolean;
+  readonly directFailure?: IrPreparationFailure;
+}
+
+export type IrUnitRecord = IrTerminalUnitRecord | IrOwnedSupportUnitRecord | IrUnownedSupportUnitRecord;
+
+export interface IrUnitInventory {
+  readonly sources: readonly IrSourceRecord[];
+  readonly classes: readonly IrClassRecord[];
+  /** Exhaustive source-AST/compiler-prelude population for the R1a boundary. */
+  readonly allUnits: readonly IrUnitRecord[];
+  /** Exact R0 attempt-root population; no support unit manufactures a row. */
+  readonly terminalUnits: readonly IrTerminalUnitRecord[];
+}
+
+export interface BuildIrUnitInventoryOptions {
+  /** Marks the entry explicitly without deriving it from caller insertion order. */
+  readonly entrySource?: ts.SourceFile | string;
+  /** Compiler-owned provenance; user spellings never classify a node as injected. */
+  readonly compilerOriginAt?: (sourceFile: ts.SourceFile, offset: number) => CompilerSourceOrigin | undefined;
+  /** Exact dependency edges when a compiler driver already resolved the graph. */
+  readonly resolvedDependencies?: ReadonlyMap<ts.SourceFile, readonly ts.SourceFile[]>;
+  /** Optional checker used to resolve module edges before the syntactic fallback. */
+  readonly checker?: ts.TypeChecker;
+  /** Pre-transform ordinal anchors for same-span retained source units. */
+  readonly canonicalUnitOrdinalAt?: (
+    sourceFile: ts.SourceFile,
+    declarationStart: number,
+    declarationEnd: number,
+    kind: IrUnitKind,
+  ) => number | undefined;
+  /** Pre-transform ordinal anchors for same-span retained source classes. */
+  readonly canonicalClassOrdinalAt?: (
+    sourceFile: ts.SourceFile,
+    declarationStart: number,
+    declarationEnd: number,
+    declarationKind: "declaration" | "expression",
+  ) => number | undefined;
+}
+
+export interface CreateIrSourceIdInput {
+  readonly kind: IrSourceKind;
+  readonly order: number;
+  readonly sourceKey: string;
+}
+
+export interface CreateIrUnitIdInput {
+  readonly sourceId: IrSourceId;
+  readonly lexicalOwnerId: IrLexicalOwnerId | null;
+  readonly kind: IrUnitKind;
+  readonly ordinal: number;
+}
+
+export interface CreateDerivedIrUnitIdInput {
+  readonly parentId: IrSourceId | IrLexicalOwnerId;
+  readonly role: IrSyntheticUnitRole;
+  readonly ordinal: number;
+}
+
+export interface CreateIrClassIdInput {
+  readonly sourceId: IrSourceId;
+  readonly lexicalOwnerId: IrLexicalOwnerId | null;
+  readonly declarationKind: "declaration" | "expression";
+  readonly ordinal: number;
+}
+
+export interface CreateDerivedIrClassIdInput {
+  readonly parentId: IrSourceId | IrLexicalOwnerId;
+  readonly role: IrSyntheticClassRole;
+  readonly ordinal: number;
+}
+
+export interface CreateIrBindingIdInput {
+  readonly ownerId: IrSourceId | IrUnitId | IrClassId;
+  readonly domain: "callable" | "global" | "type" | "export" | "class" | "support";
+  readonly role: string;
+  readonly ordinal?: number;
+}
+
+const identityComponent = (value: string): string => encodeURIComponent(value);
+const ownerComponent = (owner: IrLexicalOwnerId | null): string => (owner === null ? "root" : identityComponent(owner));
+const compareCanonicalText = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+const canonicalNumber = (value: number, label: string): string => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError(`${label} must be a non-negative safe integer, received ${value}`);
+  }
+  return value.toString(10).padStart(16, "0");
+};
+
+export function createIrSourceId(input: CreateIrSourceIdInput): IrSourceId {
+  return `ir-source:v1:${canonicalNumber(input.order, "source order")}:${input.kind}:${identityComponent(input.sourceKey)}` as IrSourceId;
+}
+
+export function createIrUnitId(input: CreateIrUnitIdInput): IrUnitId {
+  return `ir-unit:v1:${identityComponent(input.sourceId)}:${ownerComponent(input.lexicalOwnerId)}:${input.kind}:${canonicalNumber(input.ordinal, "unit ordinal")}` as IrUnitId;
+}
+
+/** Derive a unit identity from semantic compiler role, never a display label. */
+export function createDerivedIrUnitId(input: CreateDerivedIrUnitIdInput): IrUnitId {
+  return `ir-unit:v1:derived:${identityComponent(input.parentId)}:${identityComponent(input.role)}:${canonicalNumber(input.ordinal, "derived unit ordinal")}` as IrUnitId;
+}
+
+export function createIrClassId(input: CreateIrClassIdInput): IrClassId {
+  return `ir-class:v1:${identityComponent(input.sourceId)}:${ownerComponent(input.lexicalOwnerId)}:${input.declarationKind}:${canonicalNumber(input.ordinal, "class ordinal")}` as IrClassId;
+}
+
+/** Derive a compiler-created class identity from its parent and semantic role. */
+export function createDerivedIrClassId(input: CreateDerivedIrClassIdInput): IrClassId {
+  return `ir-class:v1:derived:${identityComponent(input.parentId)}:${identityComponent(input.role)}:${canonicalNumber(input.ordinal, "derived class ordinal")}` as IrClassId;
+}
+
+export function createIrBindingId(input: CreateIrBindingIdInput): IrBindingId {
+  return `ir-binding:v1:${input.domain}:${identityComponent(input.ownerId)}:${identityComponent(input.role)}:${canonicalNumber(input.ordinal ?? 0, "binding ordinal")}` as IrBindingId;
+}
+
+export function compareIrIdentity(a: IrSourceId | IrUnitId | IrClassId | IrBindingId, b: typeof a): number {
+  return compareCanonicalText(a, b);
+}
+
+function normalizePathKey(fileName: string): string {
+  const slash = fileName.replace(/\\/g, "/").replace(/^file:\/\//, "");
+  const prefix = slash.match(/^[A-Za-z]:\//)?.[0] ?? (slash.startsWith("/") ? "/" : "");
+  const body = prefix === "/" ? slash.slice(1) : prefix ? slash.slice(prefix.length) : slash;
+  const parts: string[] = [];
+  for (const part of body.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === ".." && parts.length > 0 && parts.at(-1) !== "..") parts.pop();
+    else parts.push(part);
+  }
+  return `${prefix}${parts.join("/")}` || ".";
+}
+
+function pathParts(fileName: string): string[] {
+  return normalizePathKey(fileName)
+    .replace(/^[A-Za-z]:\//, "")
+    .replace(/^\//, "")
+    .split("/")
+    .filter(Boolean);
+}
+
+function commonDirectoryLength(fileNames: readonly string[]): number {
+  if (fileNames.length === 0) return 0;
+  const directories = fileNames.map((name) => pathParts(name).slice(0, -1));
+  let length = directories[0]!.length;
+  for (const directory of directories.slice(1)) {
+    length = Math.min(length, directory.length);
+    for (let i = 0; i < length; i++) {
+      if (directories[0]![i] !== directory[i]) {
+        length = i;
+        break;
+      }
+    }
+  }
+  return length;
+}
+
+function minimalUniquePathSuffix(fileName: string, peers: readonly string[]): string {
+  const parts = pathParts(fileName);
+  for (let length = 1; length <= parts.length; length++) {
+    const suffix = parts.slice(-length);
+    const matches = peers.filter((peer) => {
+      const peerParts = pathParts(peer);
+      return suffix.every((part, index) => peerParts[peerParts.length - suffix.length + index] === part);
+    });
+    if (matches.length === 1) return suffix.join("/");
+  }
+  return parts.join("/") || normalizePathKey(fileName);
+}
+
+function isSyntheticFileName(fileName: string): boolean {
+  return /^<.*>$/.test(fileName) || /^__.*__$/.test(fileName);
+}
+
+function sourceKind(sourceFile: ts.SourceFile, entry: ts.SourceFile | string | undefined): IrSourceKind {
+  if (
+    entry === sourceFile ||
+    (typeof entry === "string" && normalizePathKey(entry) === normalizePathKey(sourceFile.fileName))
+  ) {
+    return "entry";
+  }
+  if (sourceFile.isDeclarationFile) return "library";
+  if (isSyntheticFileName(sourceFile.fileName)) return "synthetic";
+  return "source";
+}
+
+function sourceKeys(
+  sourceFiles: readonly ts.SourceFile[],
+  entry: ts.SourceFile | string | undefined,
+): { sourceFile: ts.SourceFile; kind: IrSourceKind; sourceKey: string }[] {
+  const classified = sourceFiles.map((sourceFile) => ({ sourceFile, kind: sourceKind(sourceFile, entry) }));
+  const projectNames = classified
+    .filter(({ sourceFile, kind }) => kind !== "library" && !isSyntheticFileName(sourceFile.fileName))
+    .map(({ sourceFile }) => sourceFile.fileName);
+  const libraryNames = classified.filter(({ kind }) => kind === "library").map(({ sourceFile }) => sourceFile.fileName);
+  const commonLength = commonDirectoryLength(projectNames);
+  const keyed = classified.map(({ sourceFile, kind }) => {
+    const parts = pathParts(sourceFile.fileName);
+    const sourceKey =
+      kind === "library"
+        ? `@library/${minimalUniquePathSuffix(sourceFile.fileName, libraryNames)}`
+        : isSyntheticFileName(sourceFile.fileName)
+          ? normalizePathKey(sourceFile.fileName)
+          : parts.slice(commonLength).join("/") || parts.at(-1) || normalizePathKey(sourceFile.fileName);
+    return { sourceFile, kind, sourceKey };
+  });
+  const byKey = new Map<string, string>();
+  for (const { sourceFile, sourceKey } of keyed) {
+    const previous = byKey.get(sourceKey);
+    if (previous !== undefined) {
+      throw new Error(`duplicate canonical IR source key ${sourceKey}: ${previous} and ${sourceFile.fileName}`);
+    }
+    byKey.set(sourceKey, sourceFile.fileName);
+  }
+  return keyed;
+}
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
+
+function stripSourceExtension(fileName: string): string {
+  for (const extension of SOURCE_EXTENSIONS) {
+    if (fileName.endsWith(extension)) return fileName.slice(0, -extension.length);
+  }
+  return fileName;
+}
+
+function relativeModuleKey(fromSourceKey: string, specifier: string): string {
+  const directory = fromSourceKey.includes("/") ? fromSourceKey.slice(0, fromSourceKey.lastIndexOf("/")) : ".";
+  return normalizePathKey(`${directory}/${specifier}`).replace(/^\.\//, "");
+}
+
+function sourceDependencies<T extends { sourceFile: ts.SourceFile; sourceKey: string }>(
+  source: T,
+  byKey: ReadonlyMap<string, T>,
+  bySourceFile: ReadonlyMap<ts.SourceFile, T>,
+  options: BuildIrUnitInventoryOptions,
+): readonly T[] {
+  const dependencies = new Set<T>();
+  if (options.resolvedDependencies?.has(source.sourceFile)) {
+    for (const dependencyFile of options.resolvedDependencies.get(source.sourceFile) ?? []) {
+      const dependency = bySourceFile.get(dependencyFile);
+      if (dependency && dependency !== source) dependencies.add(dependency);
+    }
+    return [...dependencies].sort((a, b) => compareCanonicalText(a.sourceKey, b.sourceKey));
+  }
+
+  const resolve = (moduleSpecifier: ts.StringLiteral): void => {
+    const checkerSymbol = options.checker?.getSymbolAtLocation(moduleSpecifier);
+    if (checkerSymbol) {
+      const symbol =
+        (checkerSymbol.flags & ts.SymbolFlags.Alias) !== 0
+          ? options.checker!.getAliasedSymbol(checkerSymbol)
+          : checkerSymbol;
+      const resolved = symbol.declarations
+        ?.map((declaration) => bySourceFile.get(declaration.getSourceFile()))
+        .find((candidate): candidate is T => candidate !== undefined && candidate !== source);
+      if (resolved) {
+        dependencies.add(resolved);
+      }
+      // A checker-resolved declaration outside this inventory is still an
+      // authoritative external edge. Do not rebind it by filename heuristics.
+      return;
+    }
+
+    const specifier = moduleSpecifier.text;
+    const base = specifier.startsWith(".")
+      ? relativeModuleKey(source.sourceKey, specifier)
+      : normalizePathKey(specifier).replace(/^\.\//, "");
+    const extensionless = stripSourceExtension(base);
+    const candidates = [
+      base,
+      extensionless,
+      ...SOURCE_EXTENSIONS.map((extension) => `${extensionless}${extension}`),
+      ...SOURCE_EXTENSIONS.map((extension) => `${extensionless}/index${extension}`),
+    ];
+    for (const candidate of candidates) {
+      const dependency = byKey.get(candidate);
+      if (dependency && dependency !== source) {
+        dependencies.add(dependency);
+        return;
+      }
+    }
+  };
+  for (const statement of source.sourceFile.statements) {
+    if (
+      (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)) &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      resolve(statement.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(statement) &&
+      ts.isExternalModuleReference(statement.moduleReference) &&
+      statement.moduleReference.expression &&
+      ts.isStringLiteral(statement.moduleReference.expression)
+    ) {
+      resolve(statement.moduleReference.expression);
+    }
+  }
+  return [...dependencies].sort((a, b) => compareCanonicalText(a.sourceKey, b.sourceKey));
+}
+
+/** Dependency-first SCC order; canonical source-key order breaks every tie. */
+function orderSourceKeys<T extends { sourceFile: ts.SourceFile; sourceKey: string; kind: IrSourceKind }>(
+  keyed: readonly T[],
+  options: BuildIrUnitInventoryOptions,
+): T[] {
+  const compareSource = (a: T, b: T): number =>
+    compareCanonicalText(a.sourceKey, b.sourceKey) || compareCanonicalText(a.kind, b.kind);
+  const lexical = [...keyed].sort(compareSource);
+  const byKey = new Map(lexical.map((source) => [source.sourceKey, source]));
+  const bySourceFile = new Map(lexical.map((source) => [source.sourceFile, source]));
+  const edges = new Map(lexical.map((source) => [source, sourceDependencies(source, byKey, bySourceFile, options)]));
+  const indices = new Map<T, number>();
+  const lowLinks = new Map<T, number>();
+  const stack: T[] = [];
+  const onStack = new Set<T>();
+  const components: T[][] = [];
+  let nextIndex = 0;
+
+  const connect = (source: T): void => {
+    const index = nextIndex++;
+    indices.set(source, index);
+    lowLinks.set(source, index);
+    stack.push(source);
+    onStack.add(source);
+
+    for (const dependency of edges.get(source) ?? []) {
+      if (!indices.has(dependency)) {
+        connect(dependency);
+        lowLinks.set(source, Math.min(lowLinks.get(source)!, lowLinks.get(dependency)!));
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(source, Math.min(lowLinks.get(source)!, indices.get(dependency)!));
+      }
+    }
+
+    if (lowLinks.get(source) !== indices.get(source)) return;
+    const component: T[] = [];
+    for (;;) {
+      const member = stack.pop()!;
+      onStack.delete(member);
+      component.push(member);
+      if (member === source) break;
+    }
+    components.push(component.sort(compareSource));
+  };
+  for (const source of lexical) if (!indices.has(source)) connect(source);
+  return components.flat();
+}
+
+function hasStaticModifier(node: ts.Node): boolean {
+  return (ts.getCombinedModifierFlags(node as ts.Declaration) & ts.ModifierFlags.Static) !== 0;
+}
+
+function hasDeclareModifier(node: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    const modifiers = (current as { modifiers?: readonly ts.Node[] }).modifiers;
+    if (modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DeclareKeyword)) return true;
+  }
+  return node.getSourceFile().isDeclarationFile;
+}
+
+function decoratorExpressions(node: ts.Node): readonly ts.Expression[] {
+  return ts.canHaveDecorators(node) ? (ts.getDecorators(node)?.map((decorator) => decorator.expression) ?? []) : [];
+}
+
+function memberBaseName(name: ts.PropertyName | undefined): string {
+  if (name && (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name))) return name.text;
+  return "<computed>";
+}
+
+function classMemberLegacyName(className: string, member: ts.ClassElement): string | null {
+  if (ts.isConstructorDeclaration(member)) return `${className}_new`;
+  if (!ts.isMethodDeclaration(member) && !ts.isGetAccessorDeclaration(member) && !ts.isSetAccessorDeclaration(member)) {
+    return null;
+  }
+  const base = memberBaseName(member.name);
+  if (ts.isGetAccessorDeclaration(member)) return `${className}_get_${base}`;
+  if (ts.isSetAccessorDeclaration(member)) return `${className}_set_${base}`;
+  return `${className}_${base}`;
+}
+
+function functionDisplayName(node: ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction): string {
+  if (ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node)) return node.name?.text ?? "<anonymous-function>";
+  const parent = node.parent;
+  if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (ts.isPropertyAssignment(parent)) return memberBaseName(parent.name);
+  return "<arrow>";
+}
+
+function objectMemberDisplayName(
+  node: ts.MethodDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
+): string {
+  const base = memberBaseName(node.name);
+  if (ts.isGetAccessorDeclaration(node)) return `get ${base}`;
+  if (ts.isSetAccessorDeclaration(node)) return `set ${base}`;
+  return base;
+}
+
+const compilerUnitRole = (origin: CompilerSourceOrigin): IrSyntheticUnitRole =>
+  `compiler-unit:${origin.producer}:${origin.role}`;
+const compilerClassRole = (origin: CompilerSourceOrigin): IrSyntheticClassRole =>
+  `compiler-class:${origin.producer}:${origin.role}`;
+
+class SourceInventoryBuilder {
+  readonly classes: IrClassRecord[] = [];
+  readonly allUnits: IrUnitRecord[] = [];
+  readonly terminalUnits: IrTerminalUnitRecord[] = [];
+
+  private readonly unitOrdinals = new Map<string, number>();
+  private readonly classOrdinals = new Map<string, number>();
+  private readonly derivedUnitOrdinals = new Map<string, number>();
+  private readonly derivedClassOrdinals = new Map<string, number>();
+  private readonly legacyOrdinals = new Map<string, number>();
+  private anonymousDefaultClass = 0;
+  private unnamedFunction = 0;
+
+  constructor(
+    private readonly sourceFile: ts.SourceFile,
+    private readonly source: IrSourceRecord,
+    private readonly options: BuildIrUnitInventoryOptions,
+  ) {}
+
+  build(): void {
+    const modulePopulation = collectModuleInitPopulation(this.sourceFile);
+    let firstStaticInitialization: ts.Node | undefined;
+    const deferredModuleInitScans: ((moduleOwner: IrUnitId) => void)[] = [];
+
+    for (const statement of this.sourceFile.statements) {
+      if (ts.isFunctionDeclaration(statement)) {
+        if (!statement.body) continue;
+        const compilerOrigin = this.compilerOrigin(statement);
+        if (compilerOrigin) {
+          const role = compilerUnitRole(compilerOrigin);
+          const timerSynthetic = compilerOrigin.producer === "timer-shim";
+          if (timerSynthetic) {
+            const unit = this.addSupportUnit(
+              "synthetic-support",
+              null,
+              null,
+              statement,
+              statement.name?.text ?? "<timer-shim>",
+              role,
+            );
+            this.scanCallable(statement, unit.id, null);
+          } else {
+            const terminal = this.addTerminalUnit(
+              "synthetic-support",
+              null,
+              statement,
+              statement.name?.text ?? `<unnamed:${this.unnamedFunction++}>`,
+              "function",
+              false,
+              undefined,
+              true,
+              role,
+            );
+            this.scanCallable(statement, terminal.id, terminal.id);
+          }
+        } else {
+          const terminal = this.addTerminalUnit(
+            "top-level-function",
+            null,
+            statement,
+            statement.name?.text ?? `<unnamed:${this.unnamedFunction++}>`,
+            "function",
+          );
+          this.scanCallable(statement, terminal.id, terminal.id);
+        }
+        continue;
+      }
+      if (ts.isClassDeclaration(statement)) {
+        const result = this.processClass(statement, null, null, true, this.compilerOrigin(statement));
+        if (result.firstStaticInitialization && firstStaticInitialization === undefined) {
+          firstStaticInitialization = result.firstStaticInitialization;
+        }
+        deferredModuleInitScans.push(...result.deferredModuleInitScans);
+        continue;
+      }
+      if (ts.isExportAssignment(statement)) {
+        const unit = this.addSupportUnit("export-assignment", null, null, statement, "<export-assignment>");
+        this.scanNode(statement.expression, unit.id, null);
+      }
+    }
+
+    if (modulePopulation.length > 0 || firstStaticInitialization) {
+      const anchor = modulePopulation[0] ?? firstStaticInitialization ?? this.sourceFile;
+      const terminal = this.addTerminalUnit(
+        "module-init",
+        null,
+        anchor,
+        MODULE_INIT_UNIT_NAME,
+        "module-init",
+        false,
+        firstStaticInitialization
+          ? {
+              kind: "unsupported",
+              code: "static-class-initialization",
+              stage: "select",
+              detail: "class static initialization is still emitted by the direct module-init path",
+            }
+          : undefined,
+      );
+      for (const statement of modulePopulation) this.scanNode(statement, terminal.id, terminal.id);
+      for (const scan of deferredModuleInitScans) scan(terminal.id);
+    }
+  }
+
+  private ownerKey(owner: IrLexicalOwnerId | null): string {
+    return owner ?? "<root>";
+  }
+
+  private compilerOrigin(node: ts.Node): CompilerSourceOrigin | undefined {
+    return this.options.compilerOriginAt?.(this.sourceFile, node.getStart(this.sourceFile));
+  }
+
+  private nextUnitOrdinal(owner: IrLexicalOwnerId | null, kind: IrUnitKind, node: ts.Node): number {
+    const key = `${this.ownerKey(owner)}\u0000${kind}`;
+    const canonical = this.options.canonicalUnitOrdinalAt?.(
+      this.sourceFile,
+      node.getStart(this.sourceFile),
+      node.end,
+      kind,
+    );
+    if (canonical !== undefined) {
+      if (!Number.isSafeInteger(canonical) || canonical < 0) {
+        throw new RangeError(`canonical unit ordinal must be a non-negative safe integer, received ${canonical}`);
+      }
+      this.unitOrdinals.set(key, Math.max(this.unitOrdinals.get(key) ?? 0, canonical + 1));
+      return canonical;
+    }
+    const ordinal = this.unitOrdinals.get(key) ?? 0;
+    this.unitOrdinals.set(key, ordinal + 1);
+    return ordinal;
+  }
+
+  private nextDerivedUnitOrdinal(parentId: IrSourceId | IrLexicalOwnerId, role: IrSyntheticUnitRole): number {
+    const key = `${parentId}\u0000${role}`;
+    const ordinal = this.derivedUnitOrdinals.get(key) ?? 0;
+    this.derivedUnitOrdinals.set(key, ordinal + 1);
+    return ordinal;
+  }
+
+  private nextClassOrdinal(
+    owner: IrLexicalOwnerId | null,
+    declarationKind: "declaration" | "expression",
+    node: ts.ClassDeclaration | ts.ClassExpression,
+  ): number {
+    const key = `${this.ownerKey(owner)}\u0000${declarationKind}`;
+    const canonical = this.options.canonicalClassOrdinalAt?.(
+      this.sourceFile,
+      node.getStart(this.sourceFile),
+      node.end,
+      declarationKind,
+    );
+    if (canonical !== undefined) {
+      if (!Number.isSafeInteger(canonical) || canonical < 0) {
+        throw new RangeError(`canonical class ordinal must be a non-negative safe integer, received ${canonical}`);
+      }
+      this.classOrdinals.set(key, Math.max(this.classOrdinals.get(key) ?? 0, canonical + 1));
+      return canonical;
+    }
+    const ordinal = this.classOrdinals.get(key) ?? 0;
+    this.classOrdinals.set(key, ordinal + 1);
+    return ordinal;
+  }
+
+  private nextDerivedClassOrdinal(parentId: IrSourceId | IrLexicalOwnerId, role: IrSyntheticClassRole): number {
+    const key = `${parentId}\u0000${role}`;
+    const ordinal = this.derivedClassOrdinals.get(key) ?? 0;
+    this.derivedClassOrdinals.set(key, ordinal + 1);
+    return ordinal;
+  }
+
+  private position(node: ts.Node): {
+    line: number;
+    column: number;
+    declarationStart: number;
+    declarationEnd: number;
+  } {
+    const declarationStart = node.getStart(this.sourceFile);
+    const position = this.sourceFile.getLineAndCharacterOfPosition(declarationStart);
+    return {
+      line: position.line + 1,
+      column: position.character + 1,
+      declarationStart,
+      declarationEnd: node.end,
+    };
+  }
+
+  private addClass(
+    node: ts.ClassDeclaration | ts.ClassExpression,
+    lexicalOwnerId: IrLexicalOwnerId | null,
+    displayName: string,
+    syntheticRole?: IrSyntheticClassRole,
+  ): IrClassRecord {
+    const effectiveSyntheticRole =
+      syntheticRole ??
+      (() => {
+        const origin = this.compilerOrigin(node);
+        return origin ? compilerClassRole(origin) : undefined;
+      })();
+    const declarationKind = ts.isClassDeclaration(node) ? "declaration" : "expression";
+    const parentId = lexicalOwnerId ?? this.source.id;
+    const ordinal = effectiveSyntheticRole
+      ? this.nextDerivedClassOrdinal(parentId, effectiveSyntheticRole)
+      : this.nextClassOrdinal(lexicalOwnerId, declarationKind, node);
+    const record: IrClassRecord = Object.freeze({
+      id: effectiveSyntheticRole
+        ? createDerivedIrClassId({ parentId, role: effectiveSyntheticRole, ordinal })
+        : createIrClassId({ sourceId: this.source.id, lexicalOwnerId, declarationKind, ordinal }),
+      sourceId: this.source.id,
+      lexicalOwnerId,
+      declarationKind,
+      ordinal,
+      ...(effectiveSyntheticRole ? { syntheticRole: effectiveSyntheticRole } : {}),
+      displayName,
+      ...this.position(node),
+    });
+    this.classes.push(record);
+    return record;
+  }
+
+  private addTerminalUnit(
+    kind: IrUnitKind,
+    lexicalOwnerId: IrLexicalOwnerId | null,
+    node: ts.Node,
+    legacyMatchName: string,
+    observedKind: IrTerminalObservedKind,
+    staticClassMember = false,
+    directFailure?: IrPreparationFailure,
+    legacyBodyAvailable = true,
+    syntheticRole?: IrSyntheticUnitRole,
+  ): IrTerminalUnitRecord {
+    const effectiveSyntheticRole =
+      syntheticRole ??
+      (() => {
+        const origin = this.compilerOrigin(node);
+        return origin ? compilerUnitRole(origin) : undefined;
+      })();
+    const parentId = lexicalOwnerId ?? this.source.id;
+    const ordinal = effectiveSyntheticRole
+      ? this.nextDerivedUnitOrdinal(parentId, effectiveSyntheticRole)
+      : this.nextUnitOrdinal(lexicalOwnerId, kind, node);
+    const id = effectiveSyntheticRole
+      ? createDerivedIrUnitId({ parentId, role: effectiveSyntheticRole, ordinal })
+      : createIrUnitId({ sourceId: this.source.id, lexicalOwnerId, kind, ordinal });
+    const legacyOrdinalKey = `${observedKind}\u0000${legacyMatchName}`;
+    const legacyOrdinal = this.legacyOrdinals.get(legacyOrdinalKey) ?? 0;
+    this.legacyOrdinals.set(legacyOrdinalKey, legacyOrdinal + 1);
+    const record: IrTerminalUnitRecord = Object.freeze({
+      id,
+      sourceId: this.source.id,
+      lexicalOwnerId,
+      kind,
+      ordinal,
+      ...(effectiveSyntheticRole ? { syntheticRole: effectiveSyntheticRole } : {}),
+      displayName: legacyMatchName,
+      ...this.position(node),
+      terminal: true,
+      terminalOwnerId: id,
+      observedKind,
+      legacyKey: `${this.sourceFile.fileName}::${observedKind}::${legacyMatchName}#${legacyOrdinal}`,
+      legacyMatchName,
+      legacyOrdinal,
+      staticClassMember,
+      legacyBodyAvailable,
+      ...(directFailure ? { directFailure } : {}),
+    });
+    this.allUnits.push(record);
+    this.terminalUnits.push(record);
+    return record;
+  }
+
+  private addSupportUnit(
+    kind: IrUnitKind,
+    lexicalOwnerId: IrLexicalOwnerId | null,
+    terminalOwnerId: IrUnitId | null,
+    node: ts.Node,
+    displayName: string,
+    syntheticRole?: IrSyntheticUnitRole,
+  ): IrOwnedSupportUnitRecord | IrUnownedSupportUnitRecord {
+    const effectiveSyntheticRole =
+      syntheticRole ??
+      (() => {
+        const origin = this.compilerOrigin(node);
+        return origin ? compilerUnitRole(origin) : undefined;
+      })();
+    const parentId = lexicalOwnerId ?? this.source.id;
+    const ordinal = effectiveSyntheticRole
+      ? this.nextDerivedUnitOrdinal(parentId, effectiveSyntheticRole)
+      : this.nextUnitOrdinal(lexicalOwnerId, kind, node);
+    const base = {
+      id: effectiveSyntheticRole
+        ? createDerivedIrUnitId({ parentId, role: effectiveSyntheticRole, ordinal })
+        : createIrUnitId({ sourceId: this.source.id, lexicalOwnerId, kind, ordinal }),
+      sourceId: this.source.id,
+      lexicalOwnerId,
+      kind,
+      ordinal,
+      ...(effectiveSyntheticRole ? { syntheticRole: effectiveSyntheticRole } : {}),
+      displayName,
+      ...this.position(node),
+      terminal: false as const,
+    };
+    const record = Object.freeze(
+      terminalOwnerId === null
+        ? { ...base, terminalOwnerId: null, unownedReason: "no-r0-attempt-root" as const }
+        : { ...base, terminalOwnerId },
+    );
+    this.allUnits.push(record);
+    return record;
+  }
+
+  private classMemberKind(
+    member: ts.MethodDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration,
+  ): IrUnitKind {
+    const placement = hasStaticModifier(member) ? "static" : "instance";
+    if (ts.isGetAccessorDeclaration(member)) return `class-${placement}-getter`;
+    if (ts.isSetAccessorDeclaration(member)) return `class-${placement}-setter`;
+    return `class-${placement}-method`;
+  }
+
+  private processClass(
+    node: ts.ClassDeclaration | ts.ClassExpression,
+    lexicalOwnerId: IrLexicalOwnerId | null,
+    inheritedTerminalOwnerId: IrUnitId | null,
+    topLevelDeclaration: boolean,
+    compilerOrigin?: CompilerSourceOrigin,
+  ): {
+    firstStaticInitialization?: ts.Node;
+    deferredModuleInitScans: ((moduleOwner: IrUnitId) => void)[];
+  } {
+    const isAnonymousTopLevel = topLevelDeclaration && !node.name;
+    const displayName =
+      node.name?.text ??
+      (topLevelDeclaration ? `<anonymous-default-class:${this.anonymousDefaultClass++}>` : "<anonymous-class>");
+    const classRecord = this.addClass(
+      node,
+      lexicalOwnerId,
+      displayName,
+      compilerOrigin ? compilerClassRole(compilerOrigin) : undefined,
+    );
+    const deferredModuleInitScans: ((moduleOwner: IrUnitId) => void)[] = [];
+    const definitionExpressions: ts.Expression[] = [...decoratorExpressions(node)];
+    for (const clause of node.heritageClauses ?? []) {
+      for (const heritageType of clause.types) definitionExpressions.push(heritageType.expression);
+    }
+    for (const member of node.members) {
+      definitionExpressions.push(...decoratorExpressions(member));
+      if (
+        ts.isConstructorDeclaration(member) ||
+        ts.isMethodDeclaration(member) ||
+        ts.isGetAccessorDeclaration(member) ||
+        ts.isSetAccessorDeclaration(member)
+      ) {
+        for (const parameter of member.parameters) definitionExpressions.push(...decoratorExpressions(parameter));
+      }
+      if (member.name && ts.isComputedPropertyName(member.name)) definitionExpressions.push(member.name.expression);
+    }
+    const scanDefinitionExpressions = (terminalOwnerId: IrUnitId | null): void => {
+      for (const expression of definitionExpressions) this.scanNode(expression, classRecord.id, terminalOwnerId);
+    };
+    if (topLevelDeclaration) scanDefinitionExpressions(null);
+    else scanDefinitionExpressions(inheritedTerminalOwnerId);
+    const anonymousFailure: IrPreparationFailure | undefined = isAnonymousTopLevel
+      ? {
+          kind: "unsupported",
+          code: "anonymous-class",
+          stage: "select",
+          detail: `${displayName} has no stable direct-codegen class identity for IR patching`,
+        }
+      : undefined;
+    let explicitConstructor: IrUnitRecord | undefined;
+    let hasExecutableConstructor = false;
+    let firstInstanceInitializer: ts.PropertyDeclaration | undefined;
+    let firstStaticInitialization: ts.Node | undefined;
+    const instanceInitializers: ts.PropertyDeclaration[] = [];
+
+    for (const member of node.members) {
+      const isStatic = hasStaticModifier(member);
+      const memberCompilerOrigin = this.compilerOrigin(member) ?? compilerOrigin;
+      const memberSyntheticRole = memberCompilerOrigin ? compilerUnitRole(memberCompilerOrigin) : undefined;
+      if (ts.isClassStaticBlockDeclaration(member)) {
+        firstStaticInitialization ??= member;
+        const scan = (terminalOwnerId: IrUnitId | null): void => {
+          const unit = this.addSupportUnit(
+            "class-static-block",
+            classRecord.id,
+            terminalOwnerId,
+            member,
+            `${displayName}.<static-block>`,
+            memberSyntheticRole,
+          );
+          this.scanNode(member.body, unit.id, terminalOwnerId);
+        };
+        if (topLevelDeclaration) deferredModuleInitScans.push((moduleOwner) => scan(moduleOwner));
+        else scan(inheritedTerminalOwnerId);
+        continue;
+      }
+      if (ts.isPropertyDeclaration(member) && member.initializer) {
+        if (isStatic) {
+          firstStaticInitialization ??= member;
+          const scan = (terminalOwnerId: IrUnitId | null): void => {
+            const unit = this.addSupportUnit(
+              "class-static-field-initializer",
+              classRecord.id,
+              terminalOwnerId,
+              member.initializer!,
+              `${displayName}.${memberBaseName(member.name)}`,
+              memberSyntheticRole,
+            );
+            this.scanNode(member.initializer!, unit.id, terminalOwnerId);
+          };
+          if (topLevelDeclaration) deferredModuleInitScans.push((moduleOwner) => scan(moduleOwner));
+          else scan(inheritedTerminalOwnerId);
+        } else {
+          firstInstanceInitializer ??= member;
+          instanceInitializers.push(member);
+        }
+        continue;
+      }
+
+      const legacyName = classMemberLegacyName(displayName, member);
+      if (legacyName === null) continue;
+      const functionalMember = member as
+        | ts.ConstructorDeclaration
+        | ts.MethodDeclaration
+        | ts.GetAccessorDeclaration
+        | ts.SetAccessorDeclaration;
+      if (!functionalMember.body) continue;
+      if (ts.isConstructorDeclaration(functionalMember)) hasExecutableConstructor = true;
+
+      const unit = topLevelDeclaration
+        ? this.addTerminalUnit(
+            ts.isConstructorDeclaration(functionalMember)
+              ? "class-constructor"
+              : this.classMemberKind(functionalMember),
+            classRecord.id,
+            member,
+            legacyName,
+            "class-member",
+            isStatic,
+            anonymousFailure,
+            true,
+            memberSyntheticRole,
+          )
+        : this.addSupportUnit(
+            ts.isConstructorDeclaration(functionalMember)
+              ? "class-constructor"
+              : this.classMemberKind(functionalMember),
+            classRecord.id,
+            inheritedTerminalOwnerId,
+            member,
+            legacyName,
+            memberSyntheticRole,
+          );
+      if (ts.isConstructorDeclaration(functionalMember)) explicitConstructor = unit;
+      this.scanCallable(functionalMember, unit.id, topLevelDeclaration ? unit.id : inheritedTerminalOwnerId);
+    }
+
+    if (!hasExecutableConstructor && firstInstanceInitializer) {
+      explicitConstructor = topLevelDeclaration
+        ? this.addTerminalUnit(
+            "class-implicit-constructor",
+            classRecord.id,
+            firstInstanceInitializer,
+            `${displayName}_new`,
+            "class-member",
+            false,
+            {
+              kind: "unsupported",
+              code: "implicit-class-initializer",
+              stage: "select",
+              detail: `${displayName} has instance field initialization owned by an implicit direct constructor`,
+            },
+            true,
+            compilerOrigin ? compilerUnitRole(compilerOrigin) : undefined,
+          )
+        : this.addSupportUnit(
+            "class-implicit-constructor",
+            classRecord.id,
+            inheritedTerminalOwnerId,
+            firstInstanceInitializer,
+            `${displayName}_new`,
+            compilerOrigin ? compilerUnitRole(compilerOrigin) : undefined,
+          );
+    } else if (!hasExecutableConstructor && !hasDeclareModifier(node)) {
+      explicitConstructor = this.addSupportUnit(
+        "class-implicit-constructor",
+        classRecord.id,
+        topLevelDeclaration ? null : inheritedTerminalOwnerId,
+        node,
+        `${displayName}_new`,
+        compilerOrigin ? compilerUnitRole(compilerOrigin) : undefined,
+      );
+    }
+
+    const instanceTerminalOwner = topLevelDeclaration ? (explicitConstructor?.id ?? null) : inheritedTerminalOwnerId;
+    for (const field of instanceInitializers) {
+      const fieldCompilerOrigin = this.compilerOrigin(field) ?? compilerOrigin;
+      const unit = this.addSupportUnit(
+        "class-instance-field-initializer",
+        classRecord.id,
+        instanceTerminalOwner,
+        field.initializer!,
+        `${displayName}.${memberBaseName(field.name)}`,
+        fieldCompilerOrigin ? compilerUnitRole(fieldCompilerOrigin) : undefined,
+      );
+      this.scanNode(field.initializer!, unit.id, instanceTerminalOwner);
+    }
+
+    return {
+      ...(firstStaticInitialization ? { firstStaticInitialization } : {}),
+      deferredModuleInitScans,
+    };
+  }
+
+  private scanCallable(
+    node:
+      | ts.FunctionDeclaration
+      | ts.FunctionExpression
+      | ts.ArrowFunction
+      | ts.ConstructorDeclaration
+      | ts.MethodDeclaration
+      | ts.GetAccessorDeclaration
+      | ts.SetAccessorDeclaration,
+    lexicalOwnerId: IrUnitId,
+    terminalOwnerId: IrUnitId | null,
+  ): void {
+    for (const parameter of node.parameters) {
+      this.scanNode(parameter.name, lexicalOwnerId, terminalOwnerId);
+      if (parameter.initializer) this.scanNode(parameter.initializer, lexicalOwnerId, terminalOwnerId);
+    }
+    if (node.body) this.scanNode(node.body, lexicalOwnerId, terminalOwnerId);
+  }
+
+  private scanNode(node: ts.Node, lexicalOwnerId: IrLexicalOwnerId, terminalOwnerId: IrUnitId | null): void {
+    const visit = (child: ts.Node): void => {
+      if (ts.isClassDeclaration(child) || ts.isClassExpression(child)) {
+        this.processClass(child, lexicalOwnerId, terminalOwnerId, false, this.compilerOrigin(child));
+        return;
+      }
+      if (ts.isFunctionDeclaration(child) && child.body) {
+        const unit = this.addSupportUnit(
+          "nested-function",
+          lexicalOwnerId,
+          terminalOwnerId,
+          child,
+          functionDisplayName(child),
+        );
+        this.scanCallable(child, unit.id, terminalOwnerId);
+        return;
+      }
+      if (ts.isFunctionExpression(child) && child.body) {
+        const unit = this.addSupportUnit(
+          "function-expression",
+          lexicalOwnerId,
+          terminalOwnerId,
+          child,
+          functionDisplayName(child),
+        );
+        this.scanCallable(child, unit.id, terminalOwnerId);
+        return;
+      }
+      if (ts.isArrowFunction(child)) {
+        const unit = this.addSupportUnit(
+          "arrow-function",
+          lexicalOwnerId,
+          terminalOwnerId,
+          child,
+          functionDisplayName(child),
+        );
+        this.scanCallable(child, unit.id, terminalOwnerId);
+        return;
+      }
+      if (
+        (ts.isMethodDeclaration(child) || ts.isGetAccessorDeclaration(child) || ts.isSetAccessorDeclaration(child)) &&
+        ts.isObjectLiteralExpression(child.parent) &&
+        child.body
+      ) {
+        if (ts.isComputedPropertyName(child.name)) {
+          this.scanNode(child.name.expression, lexicalOwnerId, terminalOwnerId);
+        }
+        const kind = ts.isGetAccessorDeclaration(child)
+          ? "object-getter"
+          : ts.isSetAccessorDeclaration(child)
+            ? "object-setter"
+            : "object-method";
+        const unit = this.addSupportUnit(kind, lexicalOwnerId, terminalOwnerId, child, objectMemberDisplayName(child));
+        this.scanCallable(child, unit.id, terminalOwnerId);
+        return;
+      }
+      ts.forEachChild(child, visit);
+    };
+    visit(node);
+  }
+}
+
+/**
+ * Build the deterministic source-AST/compiler-prelude inventory without
+ * changing compiler selection, preparation, allocation, or body routing.
+ */
+export function buildIrUnitInventory(
+  sourceFiles: readonly ts.SourceFile[],
+  options: BuildIrUnitInventoryOptions = {},
+): IrUnitInventory {
+  const keyed = orderSourceKeys(sourceKeys(sourceFiles, options.entrySource), options);
+  const sources: IrSourceRecord[] = keyed.map(({ sourceFile, kind, sourceKey }, order) =>
+    Object.freeze({
+      id: createIrSourceId({ kind, order, sourceKey }),
+      kind,
+      order,
+      sourceKey,
+      displayName: sourceFile.fileName,
+      originalFileName: sourceFile.fileName,
+    }),
+  );
+  const classes: IrClassRecord[] = [];
+  const allUnits: IrUnitRecord[] = [];
+  const terminalUnits: IrTerminalUnitRecord[] = [];
+  for (let index = 0; index < keyed.length; index++) {
+    const builder = new SourceInventoryBuilder(keyed[index]!.sourceFile, sources[index]!, options);
+    builder.build();
+    classes.push(...builder.classes);
+    allUnits.push(...builder.allUnits);
+    terminalUnits.push(...builder.terminalUnits);
+  }
+  return Object.freeze({
+    sources: Object.freeze(sources),
+    classes: Object.freeze(classes),
+    allUnits: Object.freeze(allUnits),
+    terminalUnits: Object.freeze(terminalUnits),
+  });
+}
+
+/** Exact source join used by codegen; original filenames remain observational. */
+export function terminalIrUnitsForSource(
+  inventory: IrUnitInventory,
+  sourceFile: ts.SourceFile | string,
+): readonly IrTerminalUnitRecord[] {
+  const fileName = typeof sourceFile === "string" ? sourceFile : sourceFile.fileName;
+  const source = inventory.sources.find((record) => record.originalFileName === fileName);
+  return source ? inventory.terminalUnits.filter((unit) => unit.sourceId === source.id) : [];
+}
+
+/**
+ * Build the validated AST-declaration join R2 can thread into declaration
+ * collection. No display-name lookup participates in this map.
+ */
+export function indexIrTerminalDeclarations(
+  sourceFile: ts.SourceFile,
+  inventory: IrUnitInventory,
+): ReadonlyMap<ts.Node, IrUnitId> {
+  const terminals = terminalIrUnitsForSource(inventory, sourceFile);
+  if (terminals.length === 0) return new Map();
+  const candidates: ts.Node[] = [];
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.body) candidates.push(statement);
+    if (ts.isClassDeclaration(statement)) candidates.push(...statement.members);
+  }
+  const bySpan = new Map<string, ts.Node[]>();
+  for (const node of candidates) {
+    const key = `${node.getStart(sourceFile)}:${node.end}`;
+    const matches = bySpan.get(key);
+    if (matches) matches.push(node);
+    else bySpan.set(key, [node]);
+  }
+  const result = new Map<ts.Node, IrUnitId>();
+  for (const terminal of terminals) {
+    if (terminal.observedKind === "module-init") {
+      if (result.has(sourceFile)) throw new Error(`duplicate module-init identity for ${sourceFile.fileName}`);
+      result.set(sourceFile, terminal.id);
+      continue;
+    }
+    const matches = bySpan.get(`${terminal.declarationStart}:${terminal.declarationEnd}`) ?? [];
+    if (matches.length !== 1) {
+      throw new Error(
+        `terminal identity ${terminal.id} has ${matches.length} AST declaration matches in ${sourceFile.fileName}`,
+      );
+    }
+    const node = matches[0]!;
+    if (result.has(node))
+      throw new Error(`AST declaration maps to multiple terminal identities in ${sourceFile.fileName}`);
+    result.set(node, terminal.id);
+  }
+  if (result.size !== terminals.length) {
+    throw new Error(
+      `terminal declaration index mismatch for ${sourceFile.fileName}: ${result.size} declarations for ${terminals.length} units`,
+    );
+  }
+  return result;
+}

--- a/src/ir/index.ts
+++ b/src/ir/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 export * from "./types.js";
 export * from "./outcomes.js";
+export * from "./identity.js";
+export * from "./program-abi.js";
 export * from "./nodes.js";
 export * from "./alloc-registry.js";
 export * from "./builder.js";

--- a/src/ir/outcomes.ts
+++ b/src/ir/outcomes.ts
@@ -7,6 +7,7 @@
  * detail remains available only to make failures actionable.
  */
 import type { IrFallbackReason } from "./select.js";
+import type { IrSourceId, IrUnitId } from "./identity.js";
 
 export type IrPreparationStage = "select" | "resolve" | "build" | "verify" | "lower" | "backend-legality" | "patch";
 
@@ -127,6 +128,10 @@ export type IrObservedTarget = "gc" | "linear" | "standalone" | "wasi";
 interface IrObservedOutcomeBase {
   /** Observational label only. R1 replaces this with source-qualified identity. */
   readonly key: string;
+  /** R1 structural source identity. Compiler-produced rows always populate it. */
+  readonly sourceId?: IrSourceId;
+  /** R1 structural terminal-unit identity. Compiler-produced rows always populate it. */
+  readonly unitId?: IrUnitId;
   readonly file: string;
   readonly unitKind: IrObservedUnitKind;
   readonly displayName: string;

--- a/src/ir/program-abi.ts
+++ b/src/ir/program-abi.ts
@@ -1,0 +1,632 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import type { IrBindingId, IrClassId, IrUnitId, IrUnitInventory } from "./identity.js";
+
+export type ProgramAbiSlotPolicy = "required" | "alias" | "none";
+/** The three independent index spaces owned by ModuleAssembler. */
+export type ProgramAbiSlotSpace = "function" | "global" | "type";
+/** Namespaces exposed by the temporary string-keyed legacy compatibility view. */
+export type ProgramAbiLegacyNamespace = ProgramAbiSlotSpace | "export";
+
+export interface ProgramAbiCallableSignature {
+  readonly params: readonly string[];
+  readonly result: string | null;
+}
+
+export type ProgramAbiIntent =
+  | {
+      readonly kind: "callable";
+      readonly origin: "source" | "import" | "runtime" | "support";
+      readonly signature: ProgramAbiCallableSignature;
+      readonly unitId?: IrUnitId;
+    }
+  | {
+      readonly kind: "global";
+      readonly origin: "source" | "import" | "runtime" | "support";
+      readonly valueType: string;
+      readonly mutable: boolean;
+    }
+  | {
+      readonly kind: "type";
+      readonly shapeKey: string;
+    }
+  | {
+      readonly kind: "export";
+      readonly externalName: string;
+      readonly targetId: IrBindingId;
+    }
+  | {
+      readonly kind: "class";
+      readonly classId: IrClassId;
+      readonly layoutKey: string;
+    }
+  | {
+      readonly kind: "support";
+      readonly role: string;
+    };
+
+type ProgramAbiSlottedIntent = Exclude<ProgramAbiIntent, { readonly kind: "export" | "support" }>;
+type ProgramAbiAliasIntent = Exclude<ProgramAbiIntent, { readonly kind: "export" | "support" }>;
+type ProgramAbiNonExportIntent = Exclude<ProgramAbiIntent, { readonly kind: "export" }>;
+type ProgramAbiExportIntent = Extract<ProgramAbiIntent, { readonly kind: "export" }>;
+
+/** Numeric structural order supplied by the inventory/planning owner. */
+export interface ProgramAbiOrderKey {
+  /** Dependency-first source order from {@link IrUnitInventory.sources}. */
+  readonly sourceOrder: number;
+  /** Stable declaration/binding order within that source. */
+  readonly declarationOrder: number;
+}
+
+interface ProgramAbiPlanBase<TIntent extends ProgramAbiIntent> {
+  readonly id: IrBindingId;
+  /** Stable whole-program planning order; never inferred from encoded IDs or insertion. */
+  readonly order: ProgramAbiOrderKey;
+  /** Diagnostic/legacy label only. Structural IDs remain the semantic key. */
+  readonly displayName: string;
+  readonly intent: TIntent;
+}
+
+export type ProgramAbiPlanEntry =
+  | (ProgramAbiPlanBase<ProgramAbiSlottedIntent> & {
+      readonly slotPolicy: "required";
+      readonly slotSpace: ProgramAbiSlotSpace;
+      readonly aliasOf?: never;
+    })
+  | (ProgramAbiPlanBase<ProgramAbiAliasIntent> & {
+      readonly slotPolicy: "alias";
+      readonly aliasOf: IrBindingId;
+      readonly slotSpace?: never;
+    })
+  | (ProgramAbiPlanBase<ProgramAbiNonExportIntent> & {
+      readonly slotPolicy: "none";
+      readonly slotSpace?: never;
+      readonly aliasOf?: never;
+    })
+  | (ProgramAbiPlanBase<ProgramAbiExportIntent> & {
+      readonly slotPolicy: "alias";
+      readonly aliasOf: IrBindingId;
+      readonly slotSpace?: never;
+    });
+
+/** A finalized raw index reported by ModuleAssembler; this seam never allocates. */
+export interface ProgramAbiFinalIndex {
+  readonly space: ProgramAbiSlotSpace;
+  readonly index: number;
+}
+
+export type ProgramAbiInvariantCode =
+  | "duplicate-binding-plan"
+  | "invalid-plan-order"
+  | "duplicate-plan-order"
+  | "invalid-slot-policy"
+  | "missing-source-unit"
+  | "unknown-inventory-unit"
+  | "unknown-inventory-class"
+  | "inventory-source-order-mismatch"
+  | "planning-sealed"
+  | "planning-not-sealed"
+  | "binding-complete"
+  | "unknown-binding"
+  | "missing-alias-target"
+  | "alias-cycle"
+  | "alias-intent-kind-mismatch"
+  | "alias-signature-mismatch"
+  | "alias-contract-mismatch"
+  | "alias-slot-space-mismatch"
+  | "intent-slot-space-mismatch"
+  | "export-target-mismatch"
+  | "invalid-export-target"
+  | "duplicate-export-name"
+  | "alias-final-binding"
+  | "slotless-final-binding"
+  | "duplicate-final-binding"
+  | "final-index-space-mismatch"
+  | "final-index-collision"
+  | "unresolved-required-binding"
+  | "missing-legacy-name"
+  | "ambiguous-legacy-name"
+  | "no-internal-wasm-name";
+
+export class ProgramAbiInvariantError extends Error {
+  constructor(
+    readonly code: ProgramAbiInvariantCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProgramAbiInvariantError";
+  }
+}
+
+const indexKey = (finalIndex: ProgramAbiFinalIndex): string => `${finalIndex.space}:${finalIndex.index}`;
+const legacyKey = (namespace: ProgramAbiLegacyNamespace, name: string): string => `${namespace}\u0000${name}`;
+const orderKey = (order: ProgramAbiOrderKey): string => `${order.sourceOrder}:${order.declarationOrder}`;
+
+function compareOrder(a: ProgramAbiOrderKey, b: ProgramAbiOrderKey): number {
+  return a.sourceOrder - b.sourceOrder || a.declarationOrder - b.declarationOrder;
+}
+
+function validOrderComponent(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function intentSlotSpace(intent: ProgramAbiIntent): ProgramAbiSlotSpace | null {
+  if (intent.kind === "callable") return "function";
+  if (intent.kind === "global") return "global";
+  if (intent.kind === "type" || intent.kind === "class") return "type";
+  return null;
+}
+
+function intentLegacyNamespace(intent: ProgramAbiIntent): ProgramAbiLegacyNamespace | null {
+  if (intent.kind === "export") return "export";
+  return intentSlotSpace(intent);
+}
+
+function callableSignaturesEqual(a: ProgramAbiCallableSignature, b: ProgramAbiCallableSignature): boolean {
+  return (
+    a.result === b.result && a.params.length === b.params.length && a.params.every((param, i) => param === b.params[i])
+  );
+}
+
+function freezePlan(entry: ProgramAbiPlanEntry): ProgramAbiPlanEntry {
+  const intent =
+    entry.intent.kind === "callable"
+      ? {
+          ...entry.intent,
+          signature: {
+            params: Object.freeze([...entry.intent.signature.params]),
+            result: entry.intent.signature.result,
+          },
+        }
+      : { ...entry.intent };
+  return Object.freeze({
+    ...entry,
+    order: Object.freeze({ ...entry.order }),
+    intent: Object.freeze(intent),
+  }) as ProgramAbiPlanEntry;
+}
+
+function aliasContractsMatch(alias: ProgramAbiIntent, canonical: ProgramAbiIntent): boolean {
+  if (alias.kind !== canonical.kind) return false;
+  if (alias.kind === "callable" && canonical.kind === "callable") {
+    return callableSignaturesEqual(alias.signature, canonical.signature);
+  }
+  if (alias.kind === "global" && canonical.kind === "global") {
+    return alias.valueType === canonical.valueType && alias.mutable === canonical.mutable;
+  }
+  if (alias.kind === "type" && canonical.kind === "type") return alias.shapeKey === canonical.shapeKey;
+  if (alias.kind === "class" && canonical.kind === "class") {
+    return alias.classId === canonical.classId && alias.layoutKey === canonical.layoutKey;
+  }
+  return alias.kind !== "support" && alias.kind !== "export";
+}
+
+/**
+ * Shadow identity/intention ledger for the eventual whole-program ABI.
+ *
+ * R1a does not populate this from production codegen yet. It proves the
+ * planning/final-index boundary and invariants without changing allocation or
+ * routing. ModuleAssembler remains the sole owner of every Wasm index space.
+ */
+export class ProgramAbiMap {
+  private readonly planned = new Map<IrBindingId, ProgramAbiPlanEntry>();
+  private readonly orderOwners = new Map<string, IrBindingId>();
+  private readonly finalIndices = new Map<IrBindingId, ProgramAbiFinalIndex>();
+  private readonly finalIndexOwners = new Map<string, IrBindingId>();
+  private readonly sourceOrders = new Map<IrUnitInventory["sources"][number]["id"], number>();
+  private readonly units = new Map<IrUnitId, IrUnitInventory["allUnits"][number]>();
+  private readonly classes = new Map<IrClassId, IrUnitInventory["classes"][number]>();
+  private sealed = false;
+  private complete = false;
+
+  constructor(readonly inventory: IrUnitInventory) {
+    for (const source of inventory.sources) this.sourceOrders.set(source.id, source.order);
+    for (const unit of inventory.allUnits) this.units.set(unit.id, unit);
+    for (const classRecord of inventory.classes) this.classes.set(classRecord.id, classRecord);
+  }
+
+  plan(entry: ProgramAbiPlanEntry): void {
+    if (this.sealed) {
+      throw new ProgramAbiInvariantError("planning-sealed", `cannot plan ${entry.id} after ABI planning was sealed`);
+    }
+    if (this.planned.has(entry.id)) {
+      throw new ProgramAbiInvariantError("duplicate-binding-plan", `binding ${entry.id} was planned more than once`);
+    }
+    if (
+      !entry.order ||
+      !validOrderComponent(entry.order.sourceOrder) ||
+      !validOrderComponent(entry.order.declarationOrder)
+    ) {
+      throw new ProgramAbiInvariantError(
+        "invalid-plan-order",
+        `binding ${entry.id} has invalid structural order ${JSON.stringify(entry.order)}`,
+      );
+    }
+    const structuralOrder = orderKey(entry.order);
+    const previousOrderOwner = this.orderOwners.get(structuralOrder);
+    if (previousOrderOwner) {
+      throw new ProgramAbiInvariantError(
+        "duplicate-plan-order",
+        `bindings ${previousOrderOwner} and ${entry.id} share structural order ${structuralOrder}`,
+      );
+    }
+
+    if (entry.intent.kind === "support" && entry.slotPolicy !== "none") {
+      throw new ProgramAbiInvariantError(
+        "invalid-slot-policy",
+        `support binding ${entry.id} must use slot policy none`,
+      );
+    }
+    if (entry.intent.kind === "export" && entry.slotPolicy !== "alias") {
+      throw new ProgramAbiInvariantError(
+        "invalid-slot-policy",
+        `export binding ${entry.id} must alias a callable or global binding`,
+      );
+    }
+    const runtimeEntry = entry as ProgramAbiPlanEntry & {
+      readonly aliasOf?: IrBindingId;
+      readonly slotSpace?: ProgramAbiSlotSpace;
+    };
+    if (entry.slotPolicy !== "required" && runtimeEntry.slotSpace !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "invalid-slot-policy",
+        `non-allocating binding ${entry.id} cannot reserve ${runtimeEntry.slotSpace} index space`,
+      );
+    }
+    if (entry.slotPolicy !== "alias" && runtimeEntry.aliasOf !== undefined) {
+      throw new ProgramAbiInvariantError(
+        "invalid-slot-policy",
+        `non-alias binding ${entry.id} cannot target ${runtimeEntry.aliasOf}`,
+      );
+    }
+    if (entry.slotPolicy === "required") {
+      const expectedSpace = intentSlotSpace(entry.intent);
+      if (expectedSpace === null || entry.slotSpace !== expectedSpace) {
+        throw new ProgramAbiInvariantError(
+          "intent-slot-space-mismatch",
+          `binding ${entry.id} has ${entry.intent.kind} intent but plans ${entry.slotSpace}`,
+        );
+      }
+    }
+    this.validateInventoryMembership(entry);
+    this.planned.set(entry.id, freezePlan(entry));
+    this.orderOwners.set(structuralOrder, entry.id);
+  }
+
+  entries(): readonly ProgramAbiPlanEntry[] {
+    return Object.freeze([...this.planned.values()].sort((a, b) => compareOrder(a.order, b.order)));
+  }
+
+  get(id: IrBindingId): ProgramAbiPlanEntry | undefined {
+    return this.planned.get(id);
+  }
+
+  sealPlan(): void {
+    if (this.sealed) return;
+    const entries = this.entries();
+    const exportNames = new Map<string, IrBindingId>();
+    for (const entry of entries) {
+      if (entry.intent.kind !== "export") continue;
+      const previous = exportNames.get(entry.intent.externalName);
+      if (previous) {
+        throw new ProgramAbiInvariantError(
+          "duplicate-export-name",
+          `exports ${previous} and ${entry.id} share external name ${entry.intent.externalName}`,
+        );
+      }
+      exportNames.set(entry.intent.externalName, entry.id);
+    }
+
+    for (const entry of entries) {
+      if (entry.slotPolicy !== "alias") continue;
+      const directTarget = this.planned.get(entry.aliasOf);
+      if (!directTarget) {
+        throw new ProgramAbiInvariantError(
+          "missing-alias-target",
+          `alias ${entry.id} targets unplanned binding ${entry.aliasOf}`,
+        );
+      }
+      const canonical = this.canonicalEntry(entry.id);
+      if (canonical.slotPolicy !== "required") {
+        throw new ProgramAbiInvariantError(
+          "alias-slot-space-mismatch",
+          `alias ${entry.id} resolves to slotless binding ${canonical.id}`,
+        );
+      }
+
+      if (entry.intent.kind === "export") {
+        const declaredTarget = this.planned.get(entry.intent.targetId);
+        if (!declaredTarget) {
+          throw new ProgramAbiInvariantError(
+            "missing-alias-target",
+            `export ${entry.id} declares unplanned target ${entry.intent.targetId}`,
+          );
+        }
+        if (entry.intent.targetId !== entry.aliasOf) {
+          throw new ProgramAbiInvariantError(
+            "export-target-mismatch",
+            `export ${entry.id} target ${entry.intent.targetId} disagrees with alias ${entry.aliasOf}`,
+          );
+        }
+        if (declaredTarget.intent.kind !== "callable" && declaredTarget.intent.kind !== "global") {
+          throw new ProgramAbiInvariantError(
+            "invalid-export-target",
+            `export ${entry.id} directly targets ${declaredTarget.intent.kind} binding ${declaredTarget.id}`,
+          );
+        }
+        if (canonical.intent.kind !== "callable" && canonical.intent.kind !== "global") {
+          throw new ProgramAbiInvariantError(
+            "invalid-export-target",
+            `export ${entry.id} resolves to ${canonical.intent.kind} binding ${canonical.id}`,
+          );
+        }
+        continue;
+      }
+
+      if (entry.intent.kind !== canonical.intent.kind) {
+        throw new ProgramAbiInvariantError(
+          "alias-intent-kind-mismatch",
+          `alias ${entry.id} has ${entry.intent.kind} intent but resolves to ${canonical.intent.kind} binding ${canonical.id}`,
+        );
+      }
+      const expectedSpace = intentSlotSpace(entry.intent);
+      if (expectedSpace === null || canonical.slotSpace !== expectedSpace) {
+        throw new ProgramAbiInvariantError(
+          "alias-slot-space-mismatch",
+          `alias ${entry.id} expects ${expectedSpace ?? "no index"} but resolves to ${canonical.slotSpace}`,
+        );
+      }
+      if (!aliasContractsMatch(entry.intent, canonical.intent)) {
+        const code = entry.intent.kind === "callable" ? "alias-signature-mismatch" : "alias-contract-mismatch";
+        throw new ProgramAbiInvariantError(
+          code,
+          `${entry.intent.kind} alias ${entry.id} does not match canonical binding ${canonical.id}`,
+        );
+      }
+    }
+    this.sealed = true;
+  }
+
+  get planningSealed(): boolean {
+    return this.sealed;
+  }
+
+  assertPlanSealed(): void {
+    if (!this.sealed) {
+      throw new ProgramAbiInvariantError("planning-not-sealed", "legacy ABI view requires a sealed ProgramAbiMap plan");
+    }
+  }
+
+  /** Record a finalized allocator-owned index; this method never allocates. */
+  bindFinalIndex(id: IrBindingId, finalIndex: ProgramAbiFinalIndex): void {
+    if (!this.sealed) {
+      throw new ProgramAbiInvariantError("planning-not-sealed", `cannot bind ${id} before ABI planning is sealed`);
+    }
+    if (this.complete) {
+      throw new ProgramAbiInvariantError("binding-complete", `cannot bind ${id} after ABI binding completed`);
+    }
+    const entry = this.requireEntry(id);
+    if (entry.slotPolicy === "alias") {
+      throw new ProgramAbiInvariantError(
+        "alias-final-binding",
+        `alias ${id} must resolve through ${entry.aliasOf}; it cannot own a final index`,
+      );
+    }
+    if (entry.slotPolicy === "none") {
+      throw new ProgramAbiInvariantError("slotless-final-binding", `slotless binding ${id} cannot own a final index`);
+    }
+    if (entry.slotSpace !== finalIndex.space || !Number.isSafeInteger(finalIndex.index) || finalIndex.index < 0) {
+      throw new ProgramAbiInvariantError(
+        "final-index-space-mismatch",
+        `binding ${id} planned ${entry.slotSpace} but received ${finalIndex.space}:${finalIndex.index}`,
+      );
+    }
+    if (this.finalIndices.has(id)) {
+      throw new ProgramAbiInvariantError("duplicate-final-binding", `binding ${id} was bound more than once`);
+    }
+    const occupant = this.finalIndexOwners.get(indexKey(finalIndex));
+    if (occupant) {
+      throw new ProgramAbiInvariantError(
+        "final-index-collision",
+        `bindings ${occupant} and ${id} cannot share non-alias index ${indexKey(finalIndex)}`,
+      );
+    }
+    const frozen = Object.freeze({ ...finalIndex });
+    this.finalIndices.set(id, frozen);
+    this.finalIndexOwners.set(indexKey(finalIndex), id);
+  }
+
+  /** Require every canonical required intention to have a finalized index. */
+  finishBinding(): void {
+    if (!this.sealed) {
+      throw new ProgramAbiInvariantError("planning-not-sealed", "cannot finish ABI binding before planning is sealed");
+    }
+    for (const entry of this.entries()) {
+      if (entry.slotPolicy === "required" && !this.finalIndices.has(entry.id)) {
+        throw new ProgramAbiInvariantError(
+          "unresolved-required-binding",
+          `required binding ${entry.id} has no final ModuleAssembler index`,
+        );
+      }
+    }
+    this.complete = true;
+  }
+
+  canonicalId(id: IrBindingId): IrBindingId {
+    return this.canonicalEntry(id).id;
+  }
+
+  resolveFinalIndex(id: IrBindingId): ProgramAbiFinalIndex | undefined {
+    const canonical = this.canonicalEntry(id);
+    return canonical.slotPolicy === "required" ? this.finalIndices.get(canonical.id) : undefined;
+  }
+
+  private validateInventoryMembership(entry: ProgramAbiPlanEntry): void {
+    if (entry.intent.kind === "callable") {
+      if (entry.intent.origin === "source" && entry.intent.unitId === undefined) {
+        throw new ProgramAbiInvariantError(
+          "missing-source-unit",
+          `source callable binding ${entry.id} must identify its inventoried unit`,
+        );
+      }
+      if (entry.intent.unitId !== undefined) {
+        const unit = this.units.get(entry.intent.unitId);
+        if (!unit) {
+          throw new ProgramAbiInvariantError(
+            "unknown-inventory-unit",
+            `callable binding ${entry.id} references unit ${entry.intent.unitId} outside this inventory`,
+          );
+        }
+        this.assertInventorySourceOrder(entry, unit.sourceId);
+      }
+    }
+
+    if (entry.intent.kind === "class") {
+      const classRecord = this.classes.get(entry.intent.classId);
+      if (!classRecord) {
+        throw new ProgramAbiInvariantError(
+          "unknown-inventory-class",
+          `class binding ${entry.id} references class ${entry.intent.classId} outside this inventory`,
+        );
+      }
+      this.assertInventorySourceOrder(entry, classRecord.sourceId);
+    }
+  }
+
+  private assertInventorySourceOrder(
+    entry: ProgramAbiPlanEntry,
+    sourceId: IrUnitInventory["sources"][number]["id"],
+  ): void {
+    const inventoryOrder = this.sourceOrders.get(sourceId);
+    if (inventoryOrder !== entry.order.sourceOrder) {
+      throw new ProgramAbiInvariantError(
+        "inventory-source-order-mismatch",
+        `binding ${entry.id} plans source order ${entry.order.sourceOrder}, expected ${inventoryOrder ?? "unknown"}`,
+      );
+    }
+  }
+
+  private requireEntry(id: IrBindingId): ProgramAbiPlanEntry {
+    const entry = this.planned.get(id);
+    if (!entry) throw new ProgramAbiInvariantError("unknown-binding", `binding ${id} was not planned`);
+    return entry;
+  }
+
+  private canonicalEntry(id: IrBindingId): ProgramAbiPlanEntry {
+    let current = this.requireEntry(id);
+    const visited = new Set<IrBindingId>();
+    while (current.slotPolicy === "alias") {
+      if (visited.has(current.id)) {
+        throw new ProgramAbiInvariantError("alias-cycle", `alias cycle includes binding ${current.id}`);
+      }
+      visited.add(current.id);
+      const target = this.planned.get(current.aliasOf);
+      if (!target) {
+        throw new ProgramAbiInvariantError(
+          "missing-alias-target",
+          `alias ${current.id} targets unplanned binding ${current.aliasOf}`,
+        );
+      }
+      current = target;
+    }
+    return current;
+  }
+}
+
+/**
+ * The only name-keyed compatibility view intended for the legacy frontend.
+ * It is namespace-aware and observes finalized indices without mutating codegen.
+ */
+export class LegacyAbiAdapter {
+  private readonly byLegacyName = new Map<string, readonly IrBindingId[]>();
+  private readonly internalNames = new Map<IrBindingId, string>();
+
+  constructor(readonly abi: ProgramAbiMap) {
+    abi.assertPlanSealed();
+    const entries = abi.entries();
+    const grouped = new Map<string, IrBindingId[]>();
+    for (const entry of entries) {
+      const namespace = intentLegacyNamespace(entry.intent);
+      if (namespace === null) continue;
+      const name = entry.intent.kind === "export" ? entry.intent.externalName : entry.displayName;
+      const key = legacyKey(namespace, name);
+      const ids = grouped.get(key);
+      if (ids) ids.push(entry.id);
+      else grouped.set(key, [entry.id]);
+    }
+    for (const [key, ids] of grouped) this.byLegacyName.set(key, Object.freeze([...ids]));
+
+    const canonicalBySpaceAndName = new Map<string, IrBindingId[]>();
+    const reservedBySpace = new Map<ProgramAbiSlotSpace, Set<string>>();
+    const usedBySpace = new Map<ProgramAbiSlotSpace, Set<string>>();
+    for (const space of ["function", "global", "type"] as const) {
+      reservedBySpace.set(space, new Set());
+      usedBySpace.set(space, new Set());
+    }
+    for (const entry of entries) {
+      if (entry.slotPolicy !== "required") continue;
+      const key = legacyKey(entry.slotSpace, entry.displayName);
+      const ids = canonicalBySpaceAndName.get(key);
+      if (ids) ids.push(entry.id);
+      else canonicalBySpaceAndName.set(key, [entry.id]);
+      reservedBySpace.get(entry.slotSpace)!.add(entry.displayName);
+    }
+    for (const [key, ids] of canonicalBySpaceAndName) {
+      const separator = key.indexOf("\u0000");
+      const space = key.slice(0, separator) as ProgramAbiSlotSpace;
+      const name = key.slice(separator + 1);
+      const reserved = reservedBySpace.get(space)!;
+      const used = usedBySpace.get(space)!;
+      if (ids.length === 1) {
+        this.internalNames.set(ids[0]!, name);
+        used.add(name);
+        continue;
+      }
+      for (const id of ids) {
+        const encoded = encodeURIComponent(id);
+        let candidate = `${name}__ir_${encoded}`;
+        let discriminator = 0;
+        while (reserved.has(candidate) || used.has(candidate)) {
+          candidate = `__ir_identity_${encoded}_${discriminator++}`;
+        }
+        this.internalNames.set(id, candidate);
+        used.add(candidate);
+      }
+    }
+  }
+
+  /** Resolve one namespace/name to its canonical structural owner, never an alias record. */
+  resolveUniqueLegacyName(namespace: ProgramAbiLegacyNamespace, name: string): IrBindingId {
+    const ids = this.byLegacyName.get(legacyKey(namespace, name)) ?? [];
+    if (ids.length === 0) {
+      throw new ProgramAbiInvariantError("missing-legacy-name", `legacy ABI ${namespace} name ${name} was not planned`);
+    }
+    const canonicalIds = new Set(ids.map((id) => this.abi.canonicalId(id)));
+    if (canonicalIds.size !== 1) {
+      throw new ProgramAbiInvariantError(
+        "ambiguous-legacy-name",
+        `legacy ABI ${namespace} name ${name} matches ${canonicalIds.size} canonical structural owners`,
+      );
+    }
+    return canonicalIds.values().next().value!;
+  }
+
+  resolveFinalIndex(namespace: ProgramAbiLegacyNamespace, name: string): ProgramAbiFinalIndex | undefined {
+    return this.abi.resolveFinalIndex(this.resolveUniqueLegacyName(namespace, name));
+  }
+
+  /** Preserve a canonical spelling; qualify only same-index-space collisions. */
+  internalWasmName(id: IrBindingId): string {
+    const entry = this.abi.get(id);
+    if (!entry) throw new ProgramAbiInvariantError("unknown-binding", `binding ${id} was not planned`);
+    const canonicalId = this.abi.canonicalId(id);
+    const name = this.internalNames.get(canonicalId);
+    if (!name) {
+      throw new ProgramAbiInvariantError(
+        "no-internal-wasm-name",
+        `binding ${id} does not resolve to a canonical allocator-owned index`,
+      );
+    }
+    return name;
+  }
+}

--- a/src/iterator-statics-prelude.ts
+++ b/src/iterator-statics-prelude.ts
@@ -43,13 +43,42 @@
  * otherwise. The prelude is inserted AFTER any leading directive prologue so
  * a test's `"use strict"` stays a directive.
  */
-import { PositionMap } from "./position-map.js";
+import { PositionMap, type CompilerSourceOriginSpan } from "./position-map.js";
 import { ts } from "./ts-api.js";
 
 const { forEachChild } = ts;
 
 /** The four rewritten helpers: `Iterator.zip` → `__js2wasm_Iterator_zip`, … */
 const HELPERS = ["zip", "zipKeyed", "concat", "from"] as const;
+
+const ITERATOR_PRELUDE_FUNCTION_ROLES: Readonly<Record<string, string>> = {
+  __j2wIterWrap: "wrapped-source",
+  __j2wIterCloseRev: "reverse-close",
+  __j2wIterCloseAll: "close-all",
+  __j2wIterReadMode: "read-mode",
+  __j2wIterRequireObject: "require-object",
+  __j2wIterZipCore: "zip-core",
+  __js2wasm_Iterator_zip: "zip",
+  __js2wasm_Iterator_zipKeyed: "zip-keyed",
+  __js2wasm_Iterator_concat: "concat",
+  __js2wasm_Iterator_from: "from",
+};
+
+function iteratorPreludeOrigins(prelude: string): CompilerSourceOriginSpan[] {
+  const sf = ts.createSourceFile("__iterator_prelude_origins__.ts", prelude, ts.ScriptTarget.Latest, true);
+  const origins: CompilerSourceOriginSpan[] = [];
+  for (const statement of sf.statements) {
+    if (!ts.isFunctionDeclaration(statement) || !statement.body || !statement.name) continue;
+    const role = ITERATOR_PRELUDE_FUNCTION_ROLES[statement.name.text];
+    if (!role) throw new Error(`missing compiler provenance role for iterator helper ${statement.name.text}`);
+    origins.push({
+      start: statement.getStart(sf),
+      end: statement.end,
+      origin: { producer: "iterator-statics-prelude", role },
+    });
+  }
+  return origins;
+}
 
 export interface IteratorStaticsPreludeResult {
   /** Transformed source (prelude inserted + accesses rewritten), or the input unchanged. */
@@ -158,7 +187,12 @@ export function injectIteratorStaticsPrelude(source: string): IteratorStaticsPre
   // Edits in INPUT coordinates: the prelude insertion plus each
   // `Iterator.<helper>` → `__js2wasm_Iterator_<helper>` replacement.
   const edits = [
-    { origStart: insertAt, origEnd: insertAt, newLength: prelude.length },
+    {
+      origStart: insertAt,
+      origEnd: insertAt,
+      newLength: prelude.length,
+      compilerOrigins: iteratorPreludeOrigins(prelude),
+    },
     ...accesses.map((a) => ({
       origStart: a.start,
       origEnd: a.end,

--- a/src/position-map.ts
+++ b/src/position-map.ts
@@ -34,6 +34,30 @@ export interface SourceEdit {
   readonly origStart: number;
   readonly origEnd: number;
   readonly newLength: number;
+  /** Compiler producer metadata for generated declarations in replacement text. */
+  readonly compilerOrigins?: readonly CompilerSourceOriginSpan[];
+}
+
+export type CompilerSourceProducer =
+  | "timer-shim"
+  | "node-path-prelude"
+  | "node-path-binding"
+  | "import-wrapper"
+  | "eval-super-rewrite"
+  | "process-stdin-prelude"
+  | "iterator-statics-prelude";
+
+export interface CompilerSourceOrigin {
+  readonly producer: CompilerSourceProducer;
+  /** Producer-owned semantic role, independent of a parsed display name. */
+  readonly role: string;
+}
+
+/** Half-open span relative to one edit's generated output text. */
+export interface CompilerSourceOriginSpan {
+  readonly start: number;
+  readonly end: number;
+  readonly origin: CompilerSourceOrigin;
 }
 
 export class PositionMap {
@@ -86,6 +110,36 @@ export class PositionMap {
   toInputOffset(outOffset: number): number {
     const direct = this.toDirectInputOffset(outOffset);
     return this.inner ? this.inner.toInputOffset(direct) : direct;
+  }
+
+  /**
+   * Return compiler-owned provenance for an OUTPUT offset, if any.
+   *
+   * Tagged replacement text wins at the stage that generated it. Untagged
+   * later replacements recurse through their original anchor, so provenance
+   * from an earlier compiler insertion survives composition. Pure insertion
+   * gaps intentionally have no input provenance.
+   */
+  compilerOriginAtOutputOffset(outOffset: number): CompilerSourceOrigin | undefined {
+    if (!Number.isSafeInteger(outOffset) || outOffset < 0) return undefined;
+    let delta = 0;
+    for (const edit of this.edits) {
+      const outEditStart = edit.origStart + delta;
+      const outEditEnd = outEditStart + edit.newLength;
+      if (outOffset < outEditStart) break;
+      if (outOffset < outEditEnd) {
+        const relative = outOffset - outEditStart;
+        const tagged = edit.compilerOrigins
+          ?.filter((span) => relative >= span.start && relative < span.end)
+          .sort((a, b) => a.end - a.start - (b.end - b.start))[0];
+        if (tagged) return tagged.origin;
+        if (edit.origStart === edit.origEnd) return undefined;
+        return this.inner?.compilerOriginAtOutputOffset(edit.origStart);
+      }
+      delta += edit.newLength - (edit.origEnd - edit.origStart);
+    }
+    const direct = this.toDirectInputOffset(outOffset);
+    return this.inner?.compilerOriginAtOutputOffset(direct);
   }
 
   /**

--- a/src/process-stdin-prelude.ts
+++ b/src/process-stdin-prelude.ts
@@ -32,13 +32,76 @@
  * `.d.ts` injection in `checker/index.ts` (#2624) — codegen-level here, type-level
  * there; both inject only the surface the program actually touches.
  */
-import { PositionMap } from "./position-map.js";
+import { PositionMap, type CompilerSourceOriginSpan } from "./position-map.js";
 import { ts } from "./ts-api.js";
 
 const { forEachChild } = ts;
 
 /** The singleton accessor that `process.stdin` rewrites to. */
 const STDIN_ACCESSOR = "__js2wasm_stdin()";
+
+const STDIN_CLASS_MEMBER_ROLES: Readonly<Record<string, string>> = {
+  buf: "byte-buffer",
+  head: "buffer-head",
+  tail: "buffer-tail",
+  dataCbs: "data-listeners",
+  endCbs: "end-listeners",
+  readableCbs: "readable-listeners",
+  closeCbs: "close-listeners",
+  flowing: "flowing-state",
+  paused: "paused-state",
+  ended: "ended-state",
+  armed: "armed-state",
+  eofReadableFired: "eof-readable-state",
+  destroyed: "destroyed-state",
+  avail: "available-bytes",
+  ensure: "ensure-capacity",
+  slice: "materialize-slice",
+  drainBytes: "drain-bytes",
+  emitChunk: "emit-chunk",
+  pump: "pump",
+  arm: "arm-reader",
+  on: "register-listener",
+  read: "read",
+  setEncoding: "set-encoding",
+  pause: "pause",
+  resume: "resume",
+  destroy: "destroy",
+};
+
+function stdinPreludeOrigins(prelude: string): CompilerSourceOriginSpan[] {
+  const sf = ts.createSourceFile("__stdin_prelude_origins__.ts", prelude, ts.ScriptTarget.Latest, true);
+  const origins: CompilerSourceOriginSpan[] = [];
+  for (const statement of sf.statements) {
+    if (ts.isClassDeclaration(statement) && statement.name?.text === "__Js2wasmReadable") {
+      origins.push({
+        start: statement.getStart(sf),
+        end: statement.end,
+        origin: { producer: "process-stdin-prelude", role: "readable-class" },
+      });
+      for (const member of statement.members) {
+        const name = member.name && ts.isIdentifier(member.name) ? member.name.text : undefined;
+        const role = name ? STDIN_CLASS_MEMBER_ROLES[name] : undefined;
+        if (!role)
+          throw new Error(`missing compiler provenance role for process.stdin class member ${name ?? "<unnamed>"}`);
+        origins.push({
+          start: member.getStart(sf),
+          end: member.end,
+          origin: { producer: "process-stdin-prelude", role: `readable-${role}` },
+        });
+      }
+      continue;
+    }
+    if (ts.isFunctionDeclaration(statement) && statement.body && statement.name?.text === "__js2wasm_stdin") {
+      origins.push({
+        start: statement.getStart(sf),
+        end: statement.end,
+        origin: { producer: "process-stdin-prelude", role: "singleton-accessor" },
+      });
+    }
+  }
+  return origins;
+}
 
 export interface StdinPreludeResult {
   /** The transformed source (prelude prepended + `process.stdin` rewritten), or the input unchanged. */
@@ -131,7 +194,12 @@ export function injectProcessStdinPrelude(source: string): StdinPreludeResult {
   // each `process.stdin` → `__js2wasm_stdin()` replacement. The PositionMap takes
   // them in input coordinates; it sorts internally.
   const edits = [
-    { origStart: 0, origEnd: 0, newLength: prelude.length },
+    {
+      origStart: 0,
+      origEnd: 0,
+      newLength: prelude.length,
+      compilerOrigins: stdinPreludeOrigins(prelude),
+    },
     ...accesses.map((a) => ({ origStart: a.start, origEnd: a.end, newLength: STDIN_ACCESSOR.length })),
   ];
   const positionMap = new PositionMap(edits);

--- a/tests/issue-3520-ir-unit-identity.test.ts
+++ b/tests/issue-3520-ir-unit-identity.test.ts
@@ -1,0 +1,923 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { compile, type CompileOptions } from "../src/index.js";
+import { rewriteEvalSuperCallWithMap } from "../src/compiler/validation.js";
+import { elideDeadTopLevelBindings } from "../src/deadcode-elide.js";
+import { preprocessImports } from "../src/import-resolver.js";
+import { injectIteratorStaticsPrelude } from "../src/iterator-statics-prelude.js";
+import { injectProcessStdinPrelude } from "../src/process-stdin-prelude.js";
+import { PositionMap, type CompilerSourceOriginSpan } from "../src/position-map.js";
+import { ts } from "../src/ts-api.js";
+import {
+  buildIrUnitInventory,
+  compareIrIdentity,
+  createDerivedIrClassId,
+  createDerivedIrUnitId,
+  createIrBindingId,
+  createIrClassId,
+  createIrSourceId,
+  createIrUnitId,
+  indexIrTerminalDeclarations,
+  type IrUnitInventory,
+} from "../src/ir/identity.js";
+
+function source(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function taggedSyntheticInventory(entries: readonly { text: string; role: string }[]): IrUnitInventory {
+  let text = "";
+  const compilerOrigins: CompilerSourceOriginSpan[] = [];
+  for (const entry of entries) {
+    const start = text.length;
+    text += `${entry.text}\n`;
+    compilerOrigins.push({
+      start,
+      end: start + entry.text.length,
+      origin: { producer: "iterator-statics-prelude", role: entry.role },
+    });
+  }
+  const positionMap = new PositionMap([{ origStart: 0, origEnd: 0, newLength: text.length, compilerOrigins }]);
+  const fixture = source("synthetic.ts", text);
+  return buildIrUnitInventory([fixture], {
+    entrySource: fixture,
+    compilerOriginAt: (_sourceFile, offset) => positionMap.compilerOriginAtOutputOffset(offset),
+  });
+}
+
+type LegacyProjectionKind = "function" | "class-member" | "module-init";
+type LegacyProjectionStatus = "emitted" | "unsupported" | "invariant";
+
+function expectedLegacyProjection(
+  file: string,
+  rows: readonly (readonly [label: string, unitKind: LegacyProjectionKind, status: LegacyProjectionStatus])[],
+) {
+  return rows.map(([label, unitKind, status]) => ({
+    key: `${file}::${unitKind}::${label}#0`,
+    label,
+    ordinal: 0,
+    unitKind,
+    status,
+  }));
+}
+
+describe("#3520 structural IR identity", () => {
+  it("is checkout-root independent and dependency-first regardless of caller insertion order", () => {
+    const make = (root: string, reverse: boolean): IrUnitInventory => {
+      const entry = source(`${root}/project/src/a.ts`, `import { z } from "./z"; export function a() { return z(); }`);
+      const dependency = source(`${root}/project/src/z.ts`, `export function z() { return 1; }`);
+      const disconnected = source(`${root}/project/src/m.ts`, `export function m() { return 2; }`);
+      const inputs = reverse ? [disconnected, dependency, entry] : [entry, dependency, disconnected];
+      return buildIrUnitInventory(inputs, { entrySource: entry });
+    };
+
+    const left = make("/checkout-one", false);
+    const reversed = make("/checkout-one", true);
+    const otherRoot = make("/different/checkout-two", false);
+    const identityRows = (inventory: IrUnitInventory) =>
+      inventory.sources.map(({ sourceKey, kind, order, id }) => ({ sourceKey, kind, order, id }));
+
+    expect(left.sources.map((record) => record.sourceKey)).toEqual(["z.ts", "a.ts", "m.ts"]);
+    expect(identityRows(reversed)).toEqual(identityRows(left));
+    expect(identityRows(otherRoot)).toEqual(identityRows(left));
+    expect(reversed.terminalUnits.map((unit) => unit.id)).toEqual(left.terminalUnits.map((unit) => unit.id));
+  });
+
+  it("orders import-cycle members by the raw canonical source key", () => {
+    const a = source("/repo/a.ts", `import { b } from "./b"; export function a() { return b(); }`);
+    const b = source("/repo/b.ts", `import { a } from "./a"; export function b() { return a(); }`);
+    const forward = buildIrUnitInventory([a, b], { entrySource: a });
+    const reversed = buildIrUnitInventory([b, a], { entrySource: a });
+
+    expect(forward.sources.map((record) => record.sourceKey)).toEqual(["a.ts", "b.ts"]);
+    expect(reversed.sources.map(({ sourceKey, id }) => ({ sourceKey, id }))).toEqual(
+      forward.sources.map(({ sourceKey, id }) => ({ sourceKey, id })),
+    );
+  });
+
+  it("orders uniquely resolved bare module edges before their importers", () => {
+    const entry = source("/repo/entry.ts", `import { z } from "z"; export function main() { return z(); }`);
+    const dependency = source("/repo/z.ts", `export function z() { return 1; }`);
+    const inventory = buildIrUnitInventory([entry, dependency], { entrySource: entry });
+
+    expect(inventory.sources.map((record) => record.sourceKey)).toEqual(["z.ts", "entry.ts"]);
+  });
+
+  it("treats exact resolved dependency entries as authoritative", () => {
+    const entry = source("/repo/a.ts", `import { z } from "./z"; export function a() { return z(); }`);
+    const middle = source("/repo/m.ts", `export function m() { return 1; }`);
+    const syntactic = source("/repo/z.ts", `export function z() { return 2; }`);
+
+    const syntacticInventory = buildIrUnitInventory([entry, middle, syntactic], { entrySource: entry });
+    const emptyExact = buildIrUnitInventory([entry, middle, syntactic], {
+      entrySource: entry,
+      resolvedDependencies: new Map([[entry, []]]),
+    });
+    const alternateExact = buildIrUnitInventory([entry, middle, syntactic], {
+      entrySource: entry,
+      resolvedDependencies: new Map([[entry, [middle]]]),
+    });
+
+    expect(syntacticInventory.sources.map((record) => record.sourceKey)).toEqual(["z.ts", "a.ts", "m.ts"]);
+    expect(emptyExact.sources.map((record) => record.sourceKey)).toEqual(["a.ts", "m.ts", "z.ts"]);
+    expect(alternateExact.sources.map((record) => record.sourceKey)).toEqual(["m.ts", "a.ts", "z.ts"]);
+  });
+
+  it("does not syntactically rebind a checker-resolved external module", () => {
+    const entry = source("/repo/a.ts", `import { value } from "react"; export function a() { return value; }`);
+    const unrelated = source("/repo/react.ts", `export const value = 1;`);
+    const external = source("/node_modules/react/index.d.ts", `export declare const value: number;`);
+    const externalDeclaration = external.statements[0]!;
+    const checker = {
+      getSymbolAtLocation: () => ({ flags: ts.SymbolFlags.ValueModule, declarations: [externalDeclaration] }),
+    } as unknown as ts.TypeChecker;
+
+    expect(
+      buildIrUnitInventory([entry, unrelated], { entrySource: entry }).sources.map((row) => row.sourceKey),
+    ).toEqual(["react.ts", "a.ts"]);
+    expect(
+      buildIrUnitInventory([entry, unrelated], { entrySource: entry, checker }).sources.map((row) => row.sourceKey),
+    ).toEqual(["a.ts", "react.ts"]);
+  });
+
+  it("keeps external declaration-library keys independent of checkout roots and rejects collisions", () => {
+    const make = (projectRoot: string, libraryRoot: string) => {
+      const entry = source(
+        `${projectRoot}/src/entry.ts`,
+        `import { dep } from "./dep"; export function main() { return dep(); }`,
+      );
+      const dependency = source(`${projectRoot}/src/dep.ts`, `export function dep() { return 1; }`);
+      const library = source(`${libraryRoot}/types/lib.external.d.ts`, `declare const externalValue: number;`);
+      return buildIrUnitInventory([library, entry, dependency], { entrySource: entry });
+    };
+    const first = make("/checkout-one/project", "/sdk-one");
+    const relocated = make("/different/checkout/project", "/relocated/sdk");
+    const rows = (inventory: IrUnitInventory) =>
+      inventory.sources.map(({ kind, sourceKey, id }) => ({ kind, sourceKey, id }));
+
+    expect(rows(relocated)).toEqual(rows(first));
+    expect(first.sources.find((record) => record.kind === "library")?.sourceKey).toBe("@library/lib.external.d.ts");
+
+    const duplicateA = source("/sdk/types/lib.external.d.ts", `declare const a: number;`);
+    const duplicateB = source("/sdk/types/lib.external.d.ts", `declare const b: number;`);
+    expect(() => buildIrUnitInventory([duplicateA, duplicateB])).toThrow(/duplicate canonical IR source key/);
+  });
+
+  it("orders every canonical numeric ID component beyond one digit", () => {
+    const sourceIds = Array.from({ length: 12 }, (_, order) =>
+      createIrSourceId({ kind: order === 10 ? "entry" : "synthetic", order, sourceKey: `source-${order}.ts` }),
+    );
+    const owner = sourceIds[0]!;
+    const regularUnits = Array.from({ length: 12 }, (_, ordinal) =>
+      createIrUnitId({ sourceId: owner, lexicalOwnerId: null, kind: "top-level-function", ordinal }),
+    );
+    const derivedUnits = Array.from({ length: 12 }, (_, ordinal) =>
+      createDerivedIrUnitId({ parentId: owner, role: "lifted-closure", ordinal }),
+    );
+    const regularClasses = Array.from({ length: 12 }, (_, ordinal) =>
+      createIrClassId({ sourceId: owner, lexicalOwnerId: null, declarationKind: "declaration", ordinal }),
+    );
+    const derivedClasses = Array.from({ length: 12 }, (_, ordinal) =>
+      createDerivedIrClassId({ parentId: owner, role: "compiler-class:import-wrapper:test", ordinal }),
+    );
+    const bindings = Array.from({ length: 12 }, (_, ordinal) =>
+      createIrBindingId({ ownerId: owner, domain: "support", role: "test", ordinal }),
+    );
+    const expectCanonicalOrder = (ids: readonly Parameters<typeof compareIrIdentity>[0][]) =>
+      expect([...ids].reverse().sort((a, b) => compareIrIdentity(a, b))).toEqual(ids);
+
+    expectCanonicalOrder(sourceIds);
+    expectCanonicalOrder(regularUnits);
+    expectCanonicalOrder(derivedUnits);
+    expectCanonicalOrder(regularClasses);
+    expectCanonicalOrder(derivedClasses);
+    expectCanonicalOrder(bindings);
+    expect(sourceIds[2]! < sourceIds[10]!).toBe(true);
+  });
+
+  it("keeps tagged helper identities stable when unrelated compiler helpers reorder", () => {
+    const first = taggedSyntheticInventory([
+      { text: "function alpha() { return 1; }", role: "alpha-helper" },
+      { text: "function beta() { return 2; }", role: "beta-helper" },
+    ]);
+    const reversed = taggedSyntheticInventory([
+      { text: "function beta() { return 2; }", role: "beta-helper" },
+      { text: "function alpha() { return 1; }", role: "alpha-helper" },
+    ]);
+    const idsByLabel = (inventory: IrUnitInventory) =>
+      Object.fromEntries(inventory.terminalUnits.map((unit) => [unit.displayName, unit.id]));
+
+    expect(idsByLabel(reversed)).toEqual(idsByLabel(first));
+    expect(first.terminalUnits.every((unit) => unit.kind === "synthetic-support")).toBe(true);
+  });
+
+  it("uses producer roles rather than equal display labels as synthetic identity", () => {
+    const inventory = taggedSyntheticInventory([
+      { text: "function same() { return 1; }", role: "first-semantic-role" },
+      { text: "function same() { return 2; }", role: "second-semantic-role" },
+    ]);
+
+    expect(inventory.terminalUnits.map((unit) => unit.displayName)).toEqual(["same", "same"]);
+    expect(new Set(inventory.terminalUnits.map((unit) => unit.id)).size).toBe(2);
+    expect(new Set(inventory.terminalUnits.map((unit) => unit.syntheticRole)).size).toBe(2);
+  });
+
+  it("propagates tagged insertion provenance through later replacements only", () => {
+    const origin = { producer: "iterator-statics-prelude" as const, role: "helper" };
+    const inserted = new PositionMap([
+      {
+        origStart: 0,
+        origEnd: 0,
+        newLength: 20,
+        compilerOrigins: [{ start: 0, end: 20, origin }],
+      },
+    ]);
+    const laterReplacement = new PositionMap([{ origStart: 4, origEnd: 8, newLength: 6 }]);
+    const composed = laterReplacement.compose(inserted);
+    const userReplacement = new PositionMap([{ origStart: 4, origEnd: 8, newLength: 6 }]);
+
+    expect(composed.compilerOriginAtOutputOffset(5)).toEqual(origin);
+    expect(userReplacement.compilerOriginAtOutputOffset(5)).toBeUndefined();
+  });
+
+  it("distinguishes same-offset node:path and timer insertions without name heuristics", () => {
+    const text = `
+      import { join } from "node:path";
+      export function main() { setTimeout(() => {}, 1); return join("a", "b"); }
+    `;
+    const raw = source("path-timer.ts", text);
+    const rawInventory = buildIrUnitInventory([raw], { entrySource: raw });
+    const transformed = preprocessImports(text);
+    const processed = source("path-timer.ts", transformed.source);
+    const declaration = (name: string) =>
+      processed.statements.find(
+        (statement): statement is ts.FunctionDeclaration =>
+          ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+      )!;
+
+    expect(
+      transformed.positionMap.compilerOriginAtOutputOffset(declaration("__js2wasm_path_join").getStart(processed)),
+    ).toEqual({ producer: "node-path-prelude", role: "join" });
+    expect(transformed.positionMap.compilerOriginAtOutputOffset(declaration("setTimeout").getStart(processed))).toEqual(
+      { producer: "timer-shim", role: "set-timeout" },
+    );
+    expect(transformed.positionMap.compilerOriginAtOutputOffset(declaration("join").getStart(processed))).toEqual({
+      producer: "node-path-binding",
+      role: "named-join",
+    });
+    expect(
+      transformed.positionMap.compilerOriginAtOutputOffset(declaration("main").getStart(processed)),
+    ).toBeUndefined();
+
+    const inventory = buildIrUnitInventory([processed], {
+      entrySource: processed,
+      compilerOriginAt: (_sourceFile, offset) => transformed.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+    expect(inventory.terminalUnits.some((unit) => unit.displayName === "setTimeout")).toBe(false);
+    expect(inventory.terminalUnits.find((unit) => unit.displayName === "main")?.id).toBe(
+      rawInventory.terminalUnits.find((unit) => unit.displayName === "main")?.id,
+    );
+  });
+
+  it("tags every typed Node builtin wrapper by semantic module and export", () => {
+    const families = [
+      ["http", ["get", "request"]],
+      ["https", ["get", "request"]],
+      ["crypto", ["randomBytes", "randomUUID"]],
+      ["url", ["pathToFileURL", "fileURLToPath"]],
+      ["module", ["createRequire"]],
+      ["fs/promises", ["readFile", "writeFile", "unlink", "stat", "mkdir"]],
+      ["os", ["platform", "release"]],
+    ] as const;
+
+    for (const [moduleName, names] of families) {
+      const text = `import { ${names.join(", ")} } from "node:${moduleName}"; export function main() { return 1; }`;
+      const transformed = preprocessImports(text);
+      const processed = source(`${moduleName.replace(/\//g, "-")}.ts`, transformed.source);
+      for (const name of names) {
+        const wrapper = processed.statements.find(
+          (statement): statement is ts.FunctionDeclaration =>
+            ts.isFunctionDeclaration(statement) && statement.body !== undefined && statement.name?.text === name,
+        )!;
+        expect(transformed.positionMap.compilerOriginAtOutputOffset(wrapper.getStart(processed))).toEqual({
+          producer: "import-wrapper",
+          role: `node-builtin:${moduleName}:${name}`,
+        });
+      }
+    }
+
+    expect(preprocessImports(`import randomBytes from "node:crypto";`).source).toContain(
+      `function randomBytes(size: number): Uint8Array`,
+    );
+  });
+
+  it("keeps user IDs stable through a typed Node wrapper and preserves its exact R0 projection", async () => {
+    const text = `
+      import { randomBytes } from "node:crypto";
+      export class User { m() { return 1; } }
+      export function helper() { return new User().m(); }
+      export function main() { return helper(); }
+    `;
+    const raw = source("node-wrapper.ts", text);
+    const rawInventory = buildIrUnitInventory([raw], { entrySource: raw });
+    const transformed = preprocessImports(text);
+    const processed = source("node-wrapper.ts", transformed.source);
+    const inventory = buildIrUnitInventory([processed], {
+      entrySource: processed,
+      compilerOriginAt: (_sourceFile, offset) => transformed.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+    const rawClass = rawInventory.classes.find((record) => record.displayName === "User")!;
+    const processedClass = inventory.classes.find((record) => record.displayName === "User")!;
+
+    expect(processedClass.id).toBe(rawClass.id);
+    for (const label of ["User_m", "helper", "main"]) {
+      expect(inventory.terminalUnits.find((unit) => unit.displayName === label)?.id).toBe(
+        rawInventory.terminalUnits.find((unit) => unit.displayName === label)?.id,
+      );
+    }
+    expect(inventory.terminalUnits.find((unit) => unit.displayName === "randomBytes")?.syntheticRole).toBe(
+      "compiler-unit:import-wrapper:node-builtin:crypto:randomBytes",
+    );
+
+    const result = await compile(text, { fileName: "node-wrapper.ts", trackIrOutcomes: true });
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    expect(
+      (result.irOutcomes ?? []).map((outcome) => ({
+        key: outcome.key,
+        label: outcome.displayName,
+        ordinal: outcome.ordinal,
+        unitKind: outcome.unitKind,
+        status: outcome.kind,
+      })),
+    ).toEqual(
+      expectedLegacyProjection("node-wrapper.ts", [
+        ["randomBytes", "function", "unsupported"],
+        ["User_m", "class-member", "unsupported"],
+        ["helper", "function", "emitted"],
+        ["main", "function", "emitted"],
+      ]),
+    );
+  });
+
+  it("tags ambient import classes without inventing executable constructors", () => {
+    const text = `
+      import { EventEmitter } from "node:events";
+      import * as sdk from "sdk";
+      let client: sdk.Client;
+      if (true) { class Local { m() { return 1; } } }
+      export function main() { return client ? new EventEmitter() : null; }
+    `;
+    const raw = source("ambient-classes.ts", text);
+    const rawInventory = buildIrUnitInventory([raw], { entrySource: raw });
+    const transformed = preprocessImports(text);
+    const processed = source("ambient-classes.ts", transformed.source);
+    const inventory = buildIrUnitInventory([processed], {
+      entrySource: processed,
+      compilerOriginAt: (_sourceFile, offset) => transformed.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+    const localBefore = rawInventory.classes.find((record) => record.displayName === "Local")!;
+    const localAfter = inventory.classes.find((record) => record.displayName === "Local")!;
+    const generated = inventory.classes.filter((record) => record.syntheticRole !== undefined);
+
+    expect(localAfter.id).toBe(localBefore.id);
+    expect(generated.map((record) => record.syntheticRole).sort()).toEqual([
+      "compiler-class:import-wrapper:namespace-class:sdk:Client",
+      "compiler-class:import-wrapper:node-builtin-class:events:EventEmitter",
+    ]);
+    for (const record of generated) {
+      expect(inventory.allUnits.filter((unit) => unit.lexicalOwnerId === record.id)).toEqual([]);
+    }
+  });
+
+  it("isolates eval/super throwing IIFEs from user function-expression ordinals", () => {
+    const text = `export function main() { eval("super()"); const user = function user() { return 1; }; return user(); }`;
+    const raw = source("eval-super.ts", text);
+    const rawInventory = buildIrUnitInventory([raw], { entrySource: raw });
+    const transformed = rewriteEvalSuperCallWithMap(text);
+    const processed = source("eval-super.ts", transformed.source);
+    const inventory = buildIrUnitInventory([processed], {
+      entrySource: processed,
+      compilerOriginAt: (_sourceFile, offset) => transformed.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+    const generated = inventory.allUnits.find(
+      (unit) => unit.syntheticRole === "compiler-unit:eval-super-rewrite:early-error-thrower",
+    );
+
+    expect(generated?.kind).toBe("function-expression");
+    expect(inventory.allUnits.find((unit) => unit.displayName === "user")?.id).toBe(
+      rawInventory.allUnits.find((unit) => unit.displayName === "user")?.id,
+    );
+    expect(inventory.terminalUnits.map((unit) => unit.legacyMatchName)).toEqual(["main"]);
+  });
+
+  it("distinguishes same names by source and lexical owner without using display labels", () => {
+    const a = source(
+      "/repo/a.ts",
+      `
+        export function same() { return 1; }
+        export function outer() {
+          function same() { return 2; }
+          class C { m() { return same(); } }
+          return new C().m();
+        }
+        export class C { m() { return 3; } }
+      `,
+    );
+    const b = source(
+      "/repo/b.ts",
+      `
+        export function same() { return 4; }
+        export function outer() {
+          function same() { return 5; }
+          class C { m() { return same(); } }
+          return new C().m();
+        }
+        export class C { m() { return 6; } }
+      `,
+    );
+    const inventory = buildIrUnitInventory([b, a], { entrySource: b });
+    const sameUnits = inventory.allUnits.filter((unit) => unit.displayName === "same");
+    const cClasses = inventory.classes.filter((record) => record.displayName === "C");
+
+    expect(sameUnits).toHaveLength(4);
+    expect(new Set(sameUnits.map((unit) => unit.id)).size).toBe(4);
+    expect(new Set(sameUnits.map((unit) => unit.sourceId)).size).toBe(2);
+    expect(sameUnits.filter((unit) => unit.kind === "nested-function").every((unit) => unit.lexicalOwnerId)).toBe(true);
+    expect(cClasses).toHaveLength(4);
+    expect(new Set(cClasses.map((record) => record.id)).size).toBe(4);
+    expect(cClasses.filter((record) => record.lexicalOwnerId !== null)).toHaveLength(2);
+  });
+
+  it("encodes static, instance, accessor, private, and computed members as distinct units", () => {
+    const fixture = source(
+      "/repo/members.ts",
+      `
+        const computed = "dynamic";
+        class Shape {
+          m() { return 1; }
+          static m() { return 2; }
+          get x() { return 3; }
+          set x(value: number) {}
+          static get x() { return 4; }
+          static set x(value: number) {}
+          #secret() { return 5; }
+          [computed]() { return 6; }
+        }
+      `,
+    );
+    const inventory = buildIrUnitInventory([fixture], { entrySource: fixture });
+    const members = inventory.terminalUnits.filter((unit) => unit.observedKind === "class-member");
+
+    expect(members.map((unit) => unit.kind)).toEqual([
+      "class-instance-method",
+      "class-static-method",
+      "class-instance-getter",
+      "class-instance-setter",
+      "class-static-getter",
+      "class-static-setter",
+      "class-instance-method",
+      "class-instance-method",
+    ]);
+    expect(new Set(members.map((unit) => unit.id)).size).toBe(members.length);
+    expect(members.filter((unit) => unit.legacyMatchName === "Shape_<computed>")).toHaveLength(2);
+    expect(new Set(members.map((unit) => unit.legacyKey)).size).toBe(members.length);
+  });
+
+  it("keeps allUnits source-AST exhaustive while terminalUnits retain exact R0 outcome parity", async () => {
+    const text = `
+      export function outer(value: number): number {
+        function nested(n: number) { return n + 1; }
+        const arrow = (n: number) => n * 2;
+        const object = { method(n: number) { return n - 1; } };
+        const Local = class C { m(n: number) { return n; } };
+        return nested(arrow(object.method(new Local().m(value))));
+      }
+      class Counter {
+        m() { return 1; }
+        static s() { return 2; }
+        get x() { return 3; }
+        set x(value: number) {}
+      }
+      const initialized = 1;
+    `;
+    const fixture = source("inventory.ts", text);
+    const inventory = buildIrUnitInventory([fixture], { entrySource: fixture });
+    const declarationIndex = indexIrTerminalDeclarations(fixture, inventory);
+    const result = await compile(text, { fileName: "inventory.ts", trackIrOutcomes: true });
+    const untracked = await compile(text, { fileName: "inventory.ts" });
+    const outcomes = result.irOutcomes ?? [];
+
+    expect(inventory.sources).toHaveLength(1);
+    expect(inventory.classes).toHaveLength(2);
+    expect(inventory.allUnits).toHaveLength(12);
+    expect(inventory.terminalUnits).toHaveLength(6);
+    expect(inventory.allUnits.length).toBeGreaterThan(inventory.terminalUnits.length);
+    expect(inventory.terminalUnits.map((unit) => unit.legacyMatchName)).toEqual([
+      "outer",
+      "Counter_m",
+      "Counter_s",
+      "Counter_get_x",
+      "Counter_set_x",
+      "<module-init>",
+    ]);
+    expect(outcomes.map((outcome) => outcome.displayName)).toEqual(
+      inventory.terminalUnits.map((unit) => unit.legacyMatchName),
+    );
+    expect(outcomes.map((outcome) => outcome.key)).toEqual(inventory.terminalUnits.map((unit) => unit.legacyKey));
+    expect(outcomes.map((outcome) => outcome.unitId)).toEqual(inventory.terminalUnits.map((unit) => unit.id));
+    expect(outcomes.map((outcome) => outcome.sourceId)).toEqual(inventory.terminalUnits.map((unit) => unit.sourceId));
+    expect([...declarationIndex.values()]).toEqual(inventory.terminalUnits.map((unit) => unit.id));
+    expect(declarationIndex.get(fixture)).toBe(inventory.terminalUnits.at(-1)!.id);
+    expect(new Set(outcomes.map((outcome) => outcome.unitId)).size).toBe(outcomes.length);
+    expect(result.binary).toEqual(untracked.binary);
+    expect(
+      inventory.allUnits
+        .filter((unit) => !unit.terminal)
+        .every((unit) => unit.terminalOwnerId !== null || unit.unownedReason === "no-r0-attempt-root"),
+    ).toBe(true);
+  });
+
+  it("requires producer provenance before suppressing a timer support row", () => {
+    const text = `// #1501 timer host-import shim (auto-injected)
+function setTimeout(callback: () => void) { callback(); }
+export function user() { return 1; }
+`;
+    const fixture = source("timer.ts", text);
+    const raw = buildIrUnitInventory([fixture], { entrySource: fixture });
+    const timerDeclaration = fixture.statements.find(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) && statement.name?.text === "setTimeout",
+    )!;
+    const positionMap = new PositionMap([
+      {
+        origStart: 0,
+        origEnd: 0,
+        newLength: text.length,
+        compilerOrigins: [
+          {
+            start: timerDeclaration.getStart(fixture),
+            end: timerDeclaration.end,
+            origin: { producer: "timer-shim", role: "set-timeout" },
+          },
+        ],
+      },
+    ]);
+    const tagged = buildIrUnitInventory([fixture], {
+      entrySource: fixture,
+      compilerOriginAt: (_sourceFile, offset) => positionMap.compilerOriginAtOutputOffset(offset),
+    });
+    const timer = tagged.allUnits.find((unit) => unit.displayName === "setTimeout");
+
+    expect(raw.terminalUnits.map((unit) => unit.legacyMatchName)).toEqual(["setTimeout", "user"]);
+    expect(tagged.terminalUnits.map((unit) => unit.legacyMatchName)).toEqual(["user"]);
+    expect(timer).toMatchObject({
+      terminal: false,
+      kind: "synthetic-support",
+      syntheticRole: "compiler-unit:timer-shim:set-timeout",
+      terminalOwnerId: null,
+      unownedReason: "no-r0-attempt-root",
+    });
+  });
+
+  it("isolates process.stdin classes and node:path object methods from user ordinals", () => {
+    const stdinText = `
+      class User { m() { return 1; } }
+      export function main() { process.stdin; return new User().m(); }
+    `;
+    const stdinOriginal = source("stdin.ts", stdinText);
+    const stdinOriginalInventory = buildIrUnitInventory([stdinOriginal], { entrySource: stdinOriginal });
+    const stdinResult = injectProcessStdinPrelude(stdinText);
+    const stdinProcessed = source("stdin.ts", stdinResult.source);
+    const stdinProcessedInventory = buildIrUnitInventory([stdinProcessed], {
+      entrySource: stdinProcessed,
+      compilerOriginAt: (_sourceFile, offset) => stdinResult.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+
+    for (const label of ["User_m", "main"]) {
+      expect(stdinProcessedInventory.terminalUnits.find((unit) => unit.displayName === label)?.id).toBe(
+        stdinOriginalInventory.terminalUnits.find((unit) => unit.displayName === label)?.id,
+      );
+    }
+    expect(
+      stdinProcessedInventory.classes.find((record) => record.displayName === "__Js2wasmReadable")?.syntheticRole,
+    ).toBe("compiler-class:process-stdin-prelude:readable-class");
+
+    const pathText = `
+      import path from "node:path";
+      const userObject = { userMethod() { return path.join("a", "b"); } };
+      export function main() { return userObject.userMethod(); }
+    `;
+    const pathOriginal = source("path.ts", pathText);
+    const pathOriginalInventory = buildIrUnitInventory([pathOriginal], { entrySource: pathOriginal });
+    const pathResult = preprocessImports(pathText);
+    const pathProcessed = source("path.ts", pathResult.source);
+    const pathProcessedInventory = buildIrUnitInventory([pathProcessed], {
+      entrySource: pathProcessed,
+      compilerOriginAt: (_sourceFile, offset) => pathResult.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+
+    for (const label of ["userMethod", "main"]) {
+      expect(pathProcessedInventory.allUnits.find((unit) => unit.displayName === label)?.id).toBe(
+        pathOriginalInventory.allUnits.find((unit) => unit.displayName === label)?.id,
+      );
+    }
+    expect(
+      pathProcessedInventory.allUnits
+        .filter((unit) => unit.displayName === "join")
+        .some((unit) => unit.syntheticRole === "compiler-unit:node-path-binding:default-join"),
+    ).toBe(true);
+  });
+
+  it("keeps user class, member, and function IDs stable from raw source through every target", async () => {
+    const text = `
+      export class User {
+        constructor() {}
+        m() { return 1; }
+      }
+      export function helper() { return new User().m(); }
+      export function main() { return helper() + Iterator.from([1]).next().value; }
+    `;
+    const raw = source("target-matrix.ts", text);
+    const rawInventory = buildIrUnitInventory([raw], { entrySource: raw });
+    const transformed = injectIteratorStaticsPrelude(text);
+    const hostFreeSource = source("target-matrix.ts", transformed.source);
+    const hostFreeInventory = buildIrUnitInventory([hostFreeSource], {
+      entrySource: hostFreeSource,
+      compilerOriginAt: (_sourceFile, offset) => transformed.positionMap.compilerOriginAtOutputOffset(offset),
+    });
+    const rawClass = rawInventory.classes.find((record) => record.displayName === "User")!;
+    const hostFreeClass = hostFreeInventory.classes.find((record) => record.displayName === "User")!;
+    const expectedIds = new Map(rawInventory.terminalUnits.map((unit) => [unit.displayName, unit.id] as const));
+
+    expect(transformed.injected).toBe(true);
+    expect(hostFreeClass.id).toBe(rawClass.id);
+    for (const label of ["User_new", "User_m", "helper", "main"]) {
+      expect(hostFreeInventory.terminalUnits.find((unit) => unit.displayName === label)?.id).toBe(
+        expectedIds.get(label),
+      );
+    }
+
+    for (const target of ["gc", "standalone", "wasi"] as const) {
+      const result = await compile(text, {
+        fileName: "target-matrix.ts",
+        target,
+        trackIrOutcomes: true,
+      });
+      expect(result.success, JSON.stringify(result.errors)).toBe(true);
+      for (const label of ["User_new", "User_m", "helper", "main"]) {
+        expect(result.irOutcomes?.find((outcome) => outcome.displayName === label)?.unitId).toBe(
+          expectedIds.get(label),
+        );
+      }
+    }
+  });
+
+  it("preserves retained support ordinals across host-free dead-binding elision", async () => {
+    const text = `
+      const dead = () => 0;
+      const live = () => 1;
+      export function main() { return live(); }
+    `;
+    const raw = source("dce-support.ts", text);
+    const canonical = buildIrUnitInventory([raw], { entrySource: raw });
+    const elision = elideDeadTopLevelBindings(text);
+    const elided = source("dce-support.ts", elision.source);
+    const unitOrdinals = new Map(
+      canonical.allUnits.map((unit) => [
+        `${unit.declarationStart}\u0000${unit.declarationEnd}\u0000${unit.kind}`,
+        unit.ordinal,
+      ]),
+    );
+    const classOrdinals = new Map(
+      canonical.classes.map((record) => [
+        `${record.declarationStart}\u0000${record.declarationEnd}\u0000${record.declarationKind}`,
+        record.ordinal,
+      ]),
+    );
+    const unanchored = buildIrUnitInventory([elided], { entrySource: elided });
+    const anchored = buildIrUnitInventory([elided], {
+      entrySource: elided,
+      canonicalUnitOrdinalAt: (_sourceFile, declarationStart, declarationEnd, kind) =>
+        unitOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${kind}`),
+      canonicalClassOrdinalAt: (_sourceFile, declarationStart, declarationEnd, declarationKind) =>
+        classOrdinals.get(`${declarationStart}\u0000${declarationEnd}\u0000${declarationKind}`),
+    });
+    const canonicalLive = canonical.allUnits.find((unit) => unit.displayName === "live")!;
+
+    expect(elision.elided).toEqual(["dead"]);
+    expect(unanchored.allUnits.find((unit) => unit.displayName === "live")?.id).not.toBe(canonicalLive.id);
+    expect(anchored.allUnits.find((unit) => unit.displayName === "live")?.id).toBe(canonicalLive.id);
+    expect(anchored.allUnits.some((unit) => unit.displayName === "dead")).toBe(false);
+
+    const gc = await compile(text, { fileName: "dce-support.ts", target: "gc", trackIrOutcomes: true });
+    const standalone = await compile(text, {
+      fileName: "dce-support.ts",
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    expect(gc.success, JSON.stringify(gc.errors)).toBe(true);
+    expect(standalone.success, JSON.stringify(standalone.errors)).toBe(true);
+    for (const label of ["main", "<module-init>"]) {
+      expect(standalone.irOutcomes?.find((outcome) => outcome.displayName === label)?.unitId).toBe(
+        gc.irOutcomes?.find((outcome) => outcome.displayName === label)?.unitId,
+      );
+    }
+  });
+
+  it("keeps the user terminal ID stable across target-specific Iterator prelude injection", async () => {
+    const text = `export function main() { return Iterator.from([1]).next().value; }`;
+    const gc = await compile(text, { fileName: "iterator-target.ts", trackIrOutcomes: true });
+    const standalone = await compile(text, {
+      fileName: "iterator-target.ts",
+      target: "standalone",
+      trackIrOutcomes: true,
+    });
+    const wasi = await compile(text, {
+      fileName: "iterator-target.ts",
+      target: "wasi",
+      trackIrOutcomes: true,
+    });
+    const standaloneUntracked = await compile(text, { fileName: "iterator-target.ts", target: "standalone" });
+    const wasiUntracked = await compile(text, { fileName: "iterator-target.ts", target: "wasi" });
+    const gcOutcomes = gc.irOutcomes ?? [];
+    const standaloneOutcomes = standalone.irOutcomes ?? [];
+    const wasiOutcomes = wasi.irOutcomes ?? [];
+    const gcMain = gcOutcomes.find((outcome) => outcome.displayName === "main")!;
+    const standaloneMain = standaloneOutcomes.find((outcome) => outcome.displayName === "main")!;
+    const wasiMain = wasiOutcomes.find((outcome) => outcome.displayName === "main")!;
+
+    expect(gc.success).toBe(true);
+    expect(standalone.success).toBe(true);
+    expect(wasi.success).toBe(true);
+    expect(gcOutcomes).toHaveLength(1);
+    expect(standaloneOutcomes).toHaveLength(11);
+    expect(wasiOutcomes).toHaveLength(11);
+    expect(standaloneMain.unitId).toBe(gcMain.unitId);
+    expect(wasiMain.unitId).toBe(gcMain.unitId);
+    expect(standaloneMain.key).toBe(gcMain.key);
+    expect(wasiMain.key).toBe(gcMain.key);
+    expect(new Set(standaloneOutcomes.map((outcome) => outcome.unitId)).size).toBe(standaloneOutcomes.length);
+    expect(new Set(wasiOutcomes.map((outcome) => outcome.unitId)).size).toBe(wasiOutcomes.length);
+    expect(standalone.binary).toEqual(standaloneUntracked.binary);
+    expect(wasi.binary).toEqual(wasiUntracked.binary);
+  });
+
+  it("preserves the exact R0 projection for every compiler source-prelude family", async () => {
+    const assertProjection = async (
+      fileName: string,
+      text: string,
+      options: CompileOptions,
+      rows: readonly (readonly [string, LegacyProjectionKind, LegacyProjectionStatus])[],
+    ) => {
+      const result = await compile(text, { ...options, fileName, trackIrOutcomes: true });
+      const projection = (result.irOutcomes ?? []).map((outcome) => ({
+        key: outcome.key,
+        label: outcome.displayName,
+        ordinal: outcome.ordinal,
+        unitKind: outcome.unitKind,
+        status: outcome.kind,
+      }));
+      expect(result.success, JSON.stringify(result.errors)).toBe(true);
+      expect(projection).toEqual(expectedLegacyProjection(fileName, rows));
+    };
+
+    await assertProjection("timer-projection.ts", `export function main() { setTimeout(() => {}, 1); return 1; }`, {}, [
+      ["main", "function", "unsupported"],
+    ]);
+    await assertProjection(
+      "path-projection.ts",
+      `import { join } from "node:path"; export function main() { return join("a", "b"); }`,
+      {},
+      [
+        ["__js2wasm_path_normStr", "function", "unsupported"],
+        ["__js2wasm_path_normalize", "function", "unsupported"],
+        ["__js2wasm_path_isAbsolute", "function", "emitted"],
+        ["__js2wasm_path_join", "function", "unsupported"],
+        ["__js2wasm_path_resolve", "function", "unsupported"],
+        ["__js2wasm_path_dirname", "function", "emitted"],
+        ["__js2wasm_path_basename", "function", "unsupported"],
+        ["__js2wasm_path_extname", "function", "emitted"],
+        ["__js2wasm_path_relative", "function", "unsupported"],
+        ["join", "function", "unsupported"],
+        ["main", "function", "unsupported"],
+      ],
+    );
+    await assertProjection(
+      "stdin-projection.ts",
+      `export function main() { process.stdin; return 1; }`,
+      { target: "wasi" },
+      [
+        ...[
+          "avail",
+          "ensure",
+          "slice",
+          "drainBytes",
+          "emitChunk",
+          "pump",
+          "arm",
+          "on",
+          "read",
+          "setEncoding",
+          "pause",
+          "resume",
+          "destroy",
+          "new",
+        ].map((member) => [`__Js2wasmReadable_${member}`, "class-member", "unsupported"] as const),
+        ["__js2wasm_stdin", "function", "unsupported"],
+        ["main", "function", "unsupported"],
+        ["<module-init>", "module-init", "unsupported"],
+      ],
+    );
+    await assertProjection(
+      "iterator-projection.ts",
+      `export function main() { return Iterator.from([1]).next().value; }`,
+      { target: "standalone" },
+      [
+        ...[
+          "__j2wIterWrap",
+          "__j2wIterCloseRev",
+          "__j2wIterCloseAll",
+          "__j2wIterReadMode",
+          "__j2wIterRequireObject",
+          "__j2wIterZipCore",
+          "__js2wasm_Iterator_zip",
+          "__js2wasm_Iterator_zipKeyed",
+          "__js2wasm_Iterator_concat",
+          "__js2wasm_Iterator_from",
+          "main",
+        ].map((label) => [label, "function", "unsupported"] as const),
+      ],
+    );
+  });
+
+  it("inventories implicit constructors and definition/call-time initializer closures under the right owner", () => {
+    const fixture = source(
+      "definition-expressions.ts",
+      `
+        class Empty {}
+        class Derived extends ((factory: () => any) => factory())(() => class {}) {
+          [(() => "computed")()]() {}
+          method(value = () => 1, { nested = () => 2 } = {}) {}
+        }
+      `,
+    );
+    const inventory = buildIrUnitInventory([fixture], { entrySource: fixture });
+    const implicitConstructors = inventory.allUnits.filter((unit) => unit.kind === "class-implicit-constructor");
+    const arrows = inventory.allUnits.filter((unit) => unit.kind === "arrow-function");
+    const method = inventory.terminalUnits.find((unit) => unit.legacyMatchName === "Derived_method")!;
+
+    expect(inventory.sources).toHaveLength(1);
+    expect(inventory.classes).toHaveLength(3);
+    expect(inventory.allUnits).toHaveLength(10);
+    expect(inventory.terminalUnits.map((unit) => unit.legacyMatchName)).toEqual([
+      "Derived_<computed>",
+      "Derived_method",
+    ]);
+    expect(implicitConstructors).toHaveLength(3);
+    expect(
+      implicitConstructors.every(
+        (unit) => unit.terminalOwnerId === null && unit.unownedReason === "no-r0-attempt-root",
+      ),
+    ).toBe(true);
+    expect(arrows.filter((unit) => unit.terminalOwnerId === null)).toHaveLength(3);
+    expect(arrows.filter((unit) => unit.terminalOwnerId === method.id)).toHaveLength(2);
+    expect(arrows.every((unit) => unit.lexicalOwnerId !== null)).toBe(true);
+  });
+
+  it("keeps export-assignment expressions unowned without manufacturing an R0 row", () => {
+    const fixture = source("default-export.ts", `export default (() => 1);`);
+    const inventory = buildIrUnitInventory([fixture], { entrySource: fixture });
+
+    expect(inventory.terminalUnits).toEqual([]);
+    expect(inventory.allUnits.map((unit) => unit.kind)).toEqual(["export-assignment", "arrow-function"]);
+    expect(
+      inventory.allUnits.every((unit) => unit.terminalOwnerId === null && unit.unownedReason === "no-r0-attempt-root"),
+    ).toBe(true);
+  });
+
+  it("keeps heritage/computed/decorator expressions unowned beside an unrelated module-init root", () => {
+    const fixture = source(
+      "decorators.ts",
+      `
+        const unrelated = 1;
+        @((target: unknown) => target)
+        class Decorated extends (() => class {})() {
+          @((target: unknown, key: string) => undefined)
+          [(() => "method")()]() {}
+        }
+      `,
+    );
+    const inventory = buildIrUnitInventory([fixture], { entrySource: fixture });
+    const decorators = inventory.allUnits.filter((unit) => unit.kind === "arrow-function");
+
+    expect(inventory.terminalUnits.map((unit) => unit.legacyMatchName)).toEqual([
+      "Decorated_<computed>",
+      "<module-init>",
+    ]);
+    expect(decorators).toHaveLength(4);
+    expect(
+      decorators.every((unit) => unit.terminalOwnerId === null && unit.unownedReason === "no-r0-attempt-root"),
+    ).toBe(true);
+  });
+});

--- a/tests/issue-3520-program-abi.test.ts
+++ b/tests/issue-3520-program-abi.test.ts
@@ -1,0 +1,723 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+import { describe, expect, it } from "vitest";
+import { ts } from "../src/ts-api.js";
+import {
+  buildIrUnitInventory,
+  createIrBindingId,
+  type IrBindingId,
+  type IrClassId,
+  type IrSourceId,
+  type IrUnitId,
+  type IrUnitInventory,
+} from "../src/ir/identity.js";
+import {
+  LegacyAbiAdapter,
+  ProgramAbiInvariantError,
+  ProgramAbiMap,
+  type ProgramAbiCallableSignature,
+  type ProgramAbiInvariantCode,
+  type ProgramAbiOrderKey,
+  type ProgramAbiPlanEntry,
+} from "../src/ir/program-abi.js";
+
+const F64_TO_F64 = Object.freeze({
+  params: Object.freeze(["f64"]),
+  result: "f64",
+}) satisfies ProgramAbiCallableSignature;
+
+function source(fileName: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function expectInvariant(action: () => unknown, code: ProgramAbiInvariantCode): ProgramAbiInvariantError {
+  let caught: unknown;
+  try {
+    action();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ProgramAbiInvariantError);
+  expect((caught as ProgramAbiInvariantError).code).toBe(code);
+  return caught as ProgramAbiInvariantError;
+}
+
+interface AbiFixture {
+  readonly inventory: IrUnitInventory;
+  readonly sourceId: IrSourceId;
+  readonly sourceOrder: number;
+  readonly firstUnitId: IrUnitId;
+  readonly secondUnitId: IrUnitId;
+  readonly firstClassId: IrClassId;
+  readonly secondClassId: IrClassId;
+}
+
+function abiFixture(fileName = "/repo/abi.ts"): AbiFixture {
+  const file = source(
+    fileName,
+    `
+      function first(value: number) { return value; }
+      function second(value: number) { return value; }
+      class First {}
+      class Second {}
+    `,
+  );
+  const inventory = buildIrUnitInventory([file], { entrySource: file });
+  const sourceRecord = inventory.sources[0]!;
+  const firstUnit = inventory.allUnits.find(
+    (unit) => unit.kind === "top-level-function" && unit.displayName === "first",
+  );
+  const secondUnit = inventory.allUnits.find(
+    (unit) => unit.kind === "top-level-function" && unit.displayName === "second",
+  );
+  const firstClass = inventory.classes.find((classRecord) => classRecord.displayName === "First");
+  const secondClass = inventory.classes.find((classRecord) => classRecord.displayName === "Second");
+  if (!firstUnit || !secondUnit || !firstClass || !secondClass) throw new Error("invalid ABI test fixture");
+  return {
+    inventory,
+    sourceId: sourceRecord.id,
+    sourceOrder: sourceRecord.order,
+    firstUnitId: firstUnit.id,
+    secondUnitId: secondUnit.id,
+    firstClassId: firstClass.id,
+    secondClassId: secondClass.id,
+  };
+}
+
+function order(fixture: AbiFixture, declarationOrder: number): ProgramAbiOrderKey {
+  return { sourceOrder: fixture.sourceOrder, declarationOrder };
+}
+
+function binding(
+  fixture: AbiFixture,
+  domain: "callable" | "global" | "type" | "export" | "class" | "support",
+  role: string,
+  ownerId: IrSourceId | IrUnitId | IrClassId = fixture.sourceId,
+): IrBindingId {
+  return createIrBindingId({ ownerId, domain, role });
+}
+
+function requiredCallable(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  unitId: IrUnitId = fixture.firstUnitId,
+  signature: ProgramAbiCallableSignature = F64_TO_F64,
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "required",
+    slotSpace: "function",
+    intent: { kind: "callable", origin: "source", signature, unitId },
+  };
+}
+
+function callableAlias(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  targetId: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  signature: ProgramAbiCallableSignature = F64_TO_F64,
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: { kind: "callable", origin: "import", signature },
+  };
+}
+
+function requiredGlobal(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  valueType = "f64",
+  mutable = true,
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "required",
+    slotSpace: "global",
+    intent: { kind: "global", origin: "source", valueType, mutable },
+  };
+}
+
+function globalAlias(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  targetId: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  valueType = "f64",
+  mutable = true,
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: { kind: "global", origin: "import", valueType, mutable },
+  };
+}
+
+function requiredType(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  shapeKey = "struct:x=f64",
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "required",
+    slotSpace: "type",
+    intent: { kind: "type", shapeKey },
+  };
+}
+
+function typeAlias(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  targetId: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  shapeKey = "struct:x=f64",
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: { kind: "type", shapeKey },
+  };
+}
+
+function requiredClass(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  classId: IrClassId = fixture.firstClassId,
+  layoutKey = "class:x=f64",
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "required",
+    slotSpace: "type",
+    intent: { kind: "class", classId, layoutKey },
+  };
+}
+
+function classAlias(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  targetId: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+  classId: IrClassId = fixture.firstClassId,
+  layoutKey = "class:x=f64",
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: { kind: "class", classId, layoutKey },
+  };
+}
+
+function exportAlias(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  targetId: IrBindingId,
+  externalName: string,
+  declarationOrder: number,
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName: externalName,
+    slotPolicy: "alias",
+    aliasOf: targetId,
+    intent: { kind: "export", externalName, targetId },
+  };
+}
+
+function supportPlan(
+  fixture: AbiFixture,
+  id: IrBindingId,
+  displayName: string,
+  declarationOrder: number,
+): ProgramAbiPlanEntry {
+  return {
+    id,
+    order: order(fixture, declarationOrder),
+    displayName,
+    slotPolicy: "none",
+    intent: { kind: "support", role: "inventory-marker" },
+  };
+}
+
+function planAll(abi: ProgramAbiMap, entries: readonly ProgramAbiPlanEntry[]): void {
+  for (const entry of entries) abi.plan(entry);
+}
+
+describe("#3520 ProgramAbiMap invariants", () => {
+  it("uses dependency-first numeric source/declaration order, including ordinals >= 10", () => {
+    const dependency = source(
+      "/repo/z.ts",
+      Array.from({ length: 12 }, (_, index) => `export function z${index}(x: number) { return x; }`).join("\n"),
+    );
+    const entry = source("/repo/a.ts", `import { z0 } from "./z"; export function a(x: number) { return z0(x); }`);
+    const inventory = buildIrUnitInventory([entry, dependency], { entrySource: entry });
+    expect(inventory.sources.map((record) => record.sourceKey)).toEqual(["z.ts", "a.ts"]);
+    const sourceOrderById = new Map(inventory.sources.map((record) => [record.id, record.order]));
+    const units = inventory.allUnits.filter((unit) => unit.kind === "top-level-function");
+    const plans = units.map(
+      (unit): ProgramAbiPlanEntry => ({
+        id: createIrBindingId({ ownerId: unit.id, domain: "callable", role: "body" }),
+        order: { sourceOrder: sourceOrderById.get(unit.sourceId)!, declarationOrder: unit.ordinal },
+        displayName: unit.displayName,
+        slotPolicy: "required",
+        slotSpace: "function",
+        intent: { kind: "callable", origin: "source", signature: F64_TO_F64, unitId: unit.id },
+      }),
+    );
+    const forward = new ProgramAbiMap(inventory);
+    const reversed = new ProgramAbiMap(inventory);
+    planAll(forward, plans);
+    planAll(reversed, [...plans].reverse());
+
+    const expectedNames = [...Array.from({ length: 12 }, (_, index) => `z${index}`), "a"];
+    expect(forward.entries().map((plan) => plan.displayName)).toEqual(expectedNames);
+    expect(reversed.entries().map((plan) => plan.id)).toEqual(forward.entries().map((plan) => plan.id));
+    expect(
+      forward
+        .entries()
+        .slice(8, 12)
+        .map((plan) => plan.order.declarationOrder),
+    ).toEqual([8, 9, 10, 11]);
+
+    const duplicateOrder = new ProgramAbiMap(inventory);
+    duplicateOrder.plan(plans[0]!);
+    expectInvariant(() => duplicateOrder.plan({ ...plans[1]!, order: plans[0]!.order }), "duplicate-plan-order");
+  });
+
+  it("validates structural order, slot space, duplicate IDs, and inventory membership", () => {
+    const fixture = abiFixture();
+    const callableId = binding(fixture, "callable", "body", fixture.firstUnitId);
+    const secondId = binding(fixture, "callable", "second-body", fixture.secondUnitId);
+
+    const duplicate = new ProgramAbiMap(fixture.inventory);
+    duplicate.plan(requiredCallable(fixture, callableId, "first", 0));
+    expectInvariant(
+      () => duplicate.plan(requiredCallable(fixture, callableId, "first-again", 1)),
+      "duplicate-binding-plan",
+    );
+
+    const invalidOrder = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        invalidOrder.plan({
+          ...requiredCallable(fixture, callableId, "first", 0),
+          order: { sourceOrder: fixture.sourceOrder, declarationOrder: 0.5 },
+        }),
+      "invalid-plan-order",
+    );
+
+    const wrongSpace = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        wrongSpace.plan({
+          ...requiredCallable(fixture, callableId, "first", 0),
+          slotSpace: "global",
+        } as ProgramAbiPlanEntry),
+      "intent-slot-space-mismatch",
+    );
+
+    const missingUnit = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        missingUnit.plan({
+          ...requiredCallable(fixture, callableId, "first", 0),
+          intent: { kind: "callable", origin: "source", signature: F64_TO_F64 },
+        }),
+      "missing-source-unit",
+    );
+
+    const foreign = abiFixture("/other/foreign.ts");
+    const foreignUnit = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () => foreignUnit.plan(requiredCallable(fixture, callableId, "first", 0, foreign.firstUnitId)),
+      "unknown-inventory-unit",
+    );
+
+    const foreignClass = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        foreignClass.plan(
+          requiredClass(fixture, binding(fixture, "class", "foreign"), "Foreign", 0, foreign.firstClassId),
+        ),
+      "unknown-inventory-class",
+    );
+
+    const wrongSourceOrder = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        wrongSourceOrder.plan({
+          ...requiredCallable(fixture, secondId, "second", 0, fixture.secondUnitId),
+          order: { sourceOrder: fixture.sourceOrder + 1, declarationOrder: 0 },
+        }),
+      "inventory-source-order-mismatch",
+    );
+  });
+
+  it("resolves exact callable, global, type, class, and export aliases", () => {
+    const fixture = abiFixture();
+    const callableId = binding(fixture, "callable", "body", fixture.firstUnitId);
+    const callableAliasId = binding(fixture, "callable", "renamed-import");
+    const globalId = binding(fixture, "global", "state");
+    const globalAliasId = binding(fixture, "global", "renamed-state");
+    const typeId = binding(fixture, "type", "record");
+    const typeAliasId = binding(fixture, "type", "record-alias");
+    const classId = binding(fixture, "class", "layout", fixture.firstClassId);
+    const classAliasId = binding(fixture, "class", "layout-alias", fixture.firstClassId);
+    const callableExportId = binding(fixture, "export", "run");
+    const globalExportId = binding(fixture, "export", "state");
+    const abi = new ProgramAbiMap(fixture.inventory);
+    planAll(abi, [
+      requiredCallable(fixture, callableId, "first", 0),
+      callableAlias(fixture, callableAliasId, callableId, "renamed", 1),
+      requiredGlobal(fixture, globalId, "state", 2),
+      globalAlias(fixture, globalAliasId, globalId, "renamedState", 3),
+      requiredType(fixture, typeId, "Record", 4),
+      typeAlias(fixture, typeAliasId, typeId, "RecordAlias", 5),
+      requiredClass(fixture, classId, "First", 6),
+      classAlias(fixture, classAliasId, classId, "FirstAlias", 7),
+      exportAlias(fixture, callableExportId, callableAliasId, "run", 8),
+      exportAlias(fixture, globalExportId, globalAliasId, "exportedState", 9),
+    ]);
+    abi.sealPlan();
+
+    abi.bindFinalIndex(callableId, { space: "function", index: 7 });
+    abi.bindFinalIndex(globalId, { space: "global", index: 7 });
+    abi.bindFinalIndex(typeId, { space: "type", index: 10 });
+    abi.bindFinalIndex(classId, { space: "type", index: 11 });
+    abi.finishBinding();
+
+    expect(abi.canonicalId(callableAliasId)).toBe(callableId);
+    expect(abi.canonicalId(callableExportId)).toBe(callableId);
+    expect(abi.canonicalId(globalAliasId)).toBe(globalId);
+    expect(abi.canonicalId(globalExportId)).toBe(globalId);
+    expect(abi.canonicalId(typeAliasId)).toBe(typeId);
+    expect(abi.canonicalId(classAliasId)).toBe(classId);
+    expect(abi.resolveFinalIndex(callableExportId)).toEqual({ space: "function", index: 7 });
+    expect(abi.resolveFinalIndex(globalExportId)).toEqual({ space: "global", index: 7 });
+    expect(abi.resolveFinalIndex(typeAliasId)).toEqual({ space: "type", index: 10 });
+    expect(abi.resolveFinalIndex(classAliasId)).toEqual({ space: "type", index: 11 });
+
+    const adapter = new LegacyAbiAdapter(abi);
+    expect(adapter.resolveUniqueLegacyName("function", "renamed")).toBe(callableId);
+    expect(adapter.resolveUniqueLegacyName("global", "renamedState")).toBe(globalId);
+    expect(adapter.resolveUniqueLegacyName("export", "run")).toBe(callableId);
+    expect(adapter.resolveFinalIndex("export", "exportedState")).toEqual({ space: "global", index: 7 });
+  });
+
+  it("rejects alias cycles and missing targets", () => {
+    const fixture = abiFixture();
+    const firstAlias = binding(fixture, "callable", "cycle-a");
+    const secondAlias = binding(fixture, "callable", "cycle-b");
+    const cycle = new ProgramAbiMap(fixture.inventory);
+    cycle.plan(callableAlias(fixture, firstAlias, secondAlias, "a", 0));
+    cycle.plan(callableAlias(fixture, secondAlias, firstAlias, "b", 1));
+    expectInvariant(() => cycle.sealPlan(), "alias-cycle");
+
+    const missingId = binding(fixture, "callable", "missing");
+    const missing = new ProgramAbiMap(fixture.inventory);
+    missing.plan(callableAlias(fixture, firstAlias, missingId, "missing", 0));
+    expectInvariant(() => missing.sealPlan(), "missing-alias-target");
+
+    const callableId = binding(fixture, "callable", "body", fixture.firstUnitId);
+    const missingExport = new ProgramAbiMap(fixture.inventory);
+    missingExport.plan(requiredCallable(fixture, callableId, "first", 0));
+    missingExport.plan({
+      ...exportAlias(fixture, binding(fixture, "export", "missing"), callableId, "missing", 1),
+      intent: { kind: "export", externalName: "missing", targetId: missingId },
+    });
+    expectInvariant(() => missingExport.sealPlan(), "missing-alias-target");
+  });
+
+  it("rejects cross-kind and non-exact callable/global/type/class aliases", () => {
+    const fixture = abiFixture();
+    const globalId = binding(fixture, "global", "state");
+    const callableAliasId = binding(fixture, "callable", "state-as-callable");
+    const crossKind = new ProgramAbiMap(fixture.inventory);
+    crossKind.plan(requiredGlobal(fixture, globalId, "state", 0));
+    crossKind.plan(callableAlias(fixture, callableAliasId, globalId, "stateFn", 1));
+    expectInvariant(() => crossKind.sealPlan(), "alias-intent-kind-mismatch");
+
+    const callableId = binding(fixture, "callable", "body", fixture.firstUnitId);
+    const wrongSignature = new ProgramAbiMap(fixture.inventory);
+    wrongSignature.plan(requiredCallable(fixture, callableId, "first", 0));
+    wrongSignature.plan(
+      callableAlias(fixture, binding(fixture, "callable", "bad-signature"), callableId, "badSignature", 1, {
+        params: [],
+        result: null,
+      }),
+    );
+    expectInvariant(() => wrongSignature.sealPlan(), "alias-signature-mismatch");
+
+    const wrongGlobal = new ProgramAbiMap(fixture.inventory);
+    wrongGlobal.plan(requiredGlobal(fixture, globalId, "state", 0));
+    wrongGlobal.plan(
+      globalAlias(fixture, binding(fixture, "global", "bad-state"), globalId, "badState", 1, "i32", false),
+    );
+    expectInvariant(() => wrongGlobal.sealPlan(), "alias-contract-mismatch");
+
+    const typeId = binding(fixture, "type", "record");
+    const wrongType = new ProgramAbiMap(fixture.inventory);
+    wrongType.plan(requiredType(fixture, typeId, "Record", 0));
+    wrongType.plan(typeAlias(fixture, binding(fixture, "type", "bad-record"), typeId, "BadRecord", 1, "struct:x=i32"));
+    expectInvariant(() => wrongType.sealPlan(), "alias-contract-mismatch");
+
+    const classId = binding(fixture, "class", "layout", fixture.firstClassId);
+    const wrongClassIdentity = new ProgramAbiMap(fixture.inventory);
+    wrongClassIdentity.plan(requiredClass(fixture, classId, "First", 0));
+    wrongClassIdentity.plan(
+      classAlias(
+        fixture,
+        binding(fixture, "class", "second-layout", fixture.secondClassId),
+        classId,
+        "SecondAlias",
+        1,
+        fixture.secondClassId,
+      ),
+    );
+    expectInvariant(() => wrongClassIdentity.sealPlan(), "alias-contract-mismatch");
+
+    const wrongClassLayout = new ProgramAbiMap(fixture.inventory);
+    wrongClassLayout.plan(requiredClass(fixture, classId, "First", 0));
+    wrongClassLayout.plan(
+      classAlias(
+        fixture,
+        binding(fixture, "class", "bad-layout", fixture.firstClassId),
+        classId,
+        "BadLayout",
+        1,
+        fixture.firstClassId,
+        "class:x=i32",
+      ),
+    );
+    expectInvariant(() => wrongClassLayout.sealPlan(), "alias-contract-mismatch");
+  });
+
+  it("enforces export target agreement, target kind, uniqueness, and zero allocator space", () => {
+    const fixture = abiFixture();
+    const firstId = binding(fixture, "callable", "first", fixture.firstUnitId);
+    const secondId = binding(fixture, "callable", "second", fixture.secondUnitId);
+    const firstExportId = binding(fixture, "export", "first-export");
+    const secondExportId = binding(fixture, "export", "second-export");
+    const duplicate = new ProgramAbiMap(fixture.inventory);
+    planAll(duplicate, [
+      requiredCallable(fixture, firstId, "first", 0),
+      requiredCallable(fixture, secondId, "second", 1, fixture.secondUnitId),
+      exportAlias(fixture, firstExportId, firstId, "same", 2),
+      exportAlias(fixture, secondExportId, secondId, "same", 3),
+    ]);
+    expectInvariant(() => duplicate.sealPlan(), "duplicate-export-name");
+
+    const disagreement = new ProgramAbiMap(fixture.inventory);
+    planAll(disagreement, [
+      requiredCallable(fixture, firstId, "first", 0),
+      requiredCallable(fixture, secondId, "second", 1, fixture.secondUnitId),
+      {
+        ...exportAlias(fixture, firstExportId, firstId, "run", 2),
+        intent: { kind: "export", externalName: "run", targetId: secondId },
+      },
+    ]);
+    expectInvariant(() => disagreement.sealPlan(), "export-target-mismatch");
+
+    const typeId = binding(fixture, "type", "record");
+    const invalidTarget = new ProgramAbiMap(fixture.inventory);
+    invalidTarget.plan(requiredType(fixture, typeId, "Record", 0));
+    invalidTarget.plan(exportAlias(fixture, firstExportId, typeId, "record", 1));
+    expectInvariant(() => invalidTarget.sealPlan(), "invalid-export-target");
+
+    const allocatingExport = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        allocatingExport.plan({
+          ...exportAlias(fixture, firstExportId, firstId, "run", 0),
+          slotSpace: "function",
+        } as ProgramAbiPlanEntry),
+      "invalid-slot-policy",
+    );
+  });
+
+  it("keeps generic support slotless and rejects support allocation", () => {
+    const fixture = abiFixture();
+    const supportId = binding(fixture, "support", "marker");
+    const abi = new ProgramAbiMap(fixture.inventory);
+    abi.plan(supportPlan(fixture, supportId, "shared", 0));
+    abi.sealPlan();
+    expect(abi.resolveFinalIndex(supportId)).toBeUndefined();
+    expectInvariant(() => abi.bindFinalIndex(supportId, { space: "type", index: 0 }), "slotless-final-binding");
+    abi.finishBinding();
+    expectInvariant(() => new LegacyAbiAdapter(abi).internalWasmName(supportId), "no-internal-wasm-name");
+
+    const allocating = new ProgramAbiMap(fixture.inventory);
+    expectInvariant(
+      () =>
+        allocating.plan({
+          ...supportPlan(fixture, supportId, "shared", 0),
+          slotPolicy: "required",
+          slotSpace: "type",
+        } as ProgramAbiPlanEntry),
+      "invalid-slot-policy",
+    );
+  });
+
+  it("collapses same-name aliases to one canonical owner but rejects two canonical owners", () => {
+    const fixture = abiFixture();
+    const callableId = binding(fixture, "callable", "same-owner", fixture.firstUnitId);
+    const aliasId = binding(fixture, "callable", "same-alias");
+    const globalId = binding(fixture, "global", "same-owner");
+    const exportId = binding(fixture, "export", "same-owner");
+    const oneOwner = new ProgramAbiMap(fixture.inventory);
+    planAll(oneOwner, [
+      requiredCallable(fixture, callableId, "same", 0),
+      callableAlias(fixture, aliasId, callableId, "same", 1),
+      requiredGlobal(fixture, globalId, "same", 2),
+      exportAlias(fixture, exportId, aliasId, "same", 3),
+    ]);
+    oneOwner.sealPlan();
+    oneOwner.bindFinalIndex(callableId, { space: "function", index: 4 });
+    oneOwner.bindFinalIndex(globalId, { space: "global", index: 4 });
+    oneOwner.finishBinding();
+
+    const oneOwnerAdapter = new LegacyAbiAdapter(oneOwner);
+    expect(oneOwnerAdapter.resolveUniqueLegacyName("function", "same")).toBe(callableId);
+    expect(oneOwnerAdapter.resolveUniqueLegacyName("global", "same")).toBe(globalId);
+    expect(oneOwnerAdapter.resolveUniqueLegacyName("export", "same")).toBe(callableId);
+    expect(oneOwnerAdapter.resolveFinalIndex("function", "same")).toEqual({ space: "function", index: 4 });
+    expect(oneOwnerAdapter.internalWasmName(callableId)).toBe("same");
+
+    const secondCallableId = binding(fixture, "callable", "other-owner", fixture.secondUnitId);
+    const twoOwners = new ProgramAbiMap(fixture.inventory);
+    planAll(twoOwners, [
+      requiredCallable(fixture, callableId, "same", 0),
+      callableAlias(fixture, aliasId, callableId, "same", 1),
+      requiredCallable(fixture, secondCallableId, "same", 2, fixture.secondUnitId),
+    ]);
+    twoOwners.sealPlan();
+    expectInvariant(
+      () => new LegacyAbiAdapter(twoOwners).resolveUniqueLegacyName("function", "same"),
+      "ambiguous-legacy-name",
+    );
+  });
+
+  it("requires a sealed plan and separates legacy namespaces from internal-name allocation", () => {
+    const fixture = abiFixture();
+    const firstId = binding(fixture, "callable", "first", fixture.firstUnitId);
+    const secondId = binding(fixture, "callable", "second", fixture.secondUnitId);
+    const globalId = binding(fixture, "global", "shared");
+    const typeId = binding(fixture, "type", "shared");
+    const slotlessTypeId = binding(fixture, "type", "semantic-only");
+    const supportId = binding(fixture, "support", "shared");
+    const exportId = binding(fixture, "export", "shared");
+    const plans: ProgramAbiPlanEntry[] = [
+      requiredCallable(fixture, firstId, "shared", 0),
+      requiredCallable(fixture, secondId, "shared", 1, fixture.secondUnitId),
+      requiredGlobal(fixture, globalId, "shared", 2),
+      requiredType(fixture, typeId, "shared", 3),
+      {
+        id: slotlessTypeId,
+        order: order(fixture, 4),
+        displayName: "shared",
+        slotPolicy: "none",
+        intent: { kind: "type", shapeKey: "semantic-only" },
+      },
+      supportPlan(fixture, supportId, "shared", 5),
+      exportAlias(fixture, exportId, firstId, "shared", 6),
+    ];
+    const preSeal = new ProgramAbiMap(fixture.inventory);
+    planAll(preSeal, plans);
+    expectInvariant(() => new LegacyAbiAdapter(preSeal), "planning-not-sealed");
+    preSeal.sealPlan();
+
+    const adapter = new LegacyAbiAdapter(preSeal);
+    expectInvariant(() => adapter.resolveUniqueLegacyName("function", "shared"), "ambiguous-legacy-name");
+    expect(adapter.resolveUniqueLegacyName("global", "shared")).toBe(globalId);
+    expectInvariant(() => adapter.resolveUniqueLegacyName("type", "shared"), "ambiguous-legacy-name");
+    expect(adapter.resolveUniqueLegacyName("export", "shared")).toBe(firstId);
+    expectInvariant(() => adapter.resolveUniqueLegacyName("global", "missing"), "missing-legacy-name");
+
+    expect(adapter.internalWasmName(firstId)).not.toBe(adapter.internalWasmName(secondId));
+    expect(adapter.internalWasmName(firstId)).toContain("shared__ir_");
+    expect(adapter.internalWasmName(globalId)).toBe("shared");
+    expect(adapter.internalWasmName(typeId)).toBe("shared");
+    expect(adapter.internalWasmName(exportId)).toBe(adapter.internalWasmName(firstId));
+    expectInvariant(() => adapter.internalWasmName(slotlessTypeId), "no-internal-wasm-name");
+    expectInvariant(() => adapter.internalWasmName(supportId), "no-internal-wasm-name");
+
+    const reverseInsertion = new ProgramAbiMap(fixture.inventory);
+    planAll(reverseInsertion, [...plans].reverse());
+    reverseInsertion.sealPlan();
+    const reverseAdapter = new LegacyAbiAdapter(reverseInsertion);
+    expect(reverseAdapter.internalWasmName(firstId)).toBe(adapter.internalWasmName(firstId));
+    expect(reverseAdapter.internalWasmName(secondId)).toBe(adapter.internalWasmName(secondId));
+  });
+
+  it("binds only allocator-final raw indices and rejects duplicate/colliding/incomplete binding", () => {
+    const fixture = abiFixture();
+    const firstId = binding(fixture, "callable", "first", fixture.firstUnitId);
+    const secondId = binding(fixture, "callable", "second", fixture.secondUnitId);
+    const aliasId = binding(fixture, "callable", "first-alias");
+    const supportId = binding(fixture, "support", "marker");
+    const abi = new ProgramAbiMap(fixture.inventory);
+    planAll(abi, [
+      requiredCallable(fixture, firstId, "first", 0),
+      requiredCallable(fixture, secondId, "second", 1, fixture.secondUnitId),
+      callableAlias(fixture, aliasId, firstId, "alias", 2),
+      supportPlan(fixture, supportId, "marker", 3),
+    ]);
+
+    expect(abi.resolveFinalIndex(firstId)).toBeUndefined();
+    expectInvariant(() => abi.bindFinalIndex(firstId, { space: "function", index: 0 }), "planning-not-sealed");
+    abi.sealPlan();
+    expectInvariant(() => abi.bindFinalIndex(aliasId, { space: "function", index: 0 }), "alias-final-binding");
+    expectInvariant(() => abi.bindFinalIndex(supportId, { space: "function", index: 0 }), "slotless-final-binding");
+    expectInvariant(() => abi.bindFinalIndex(firstId, { space: "global", index: 0 }), "final-index-space-mismatch");
+    expectInvariant(() => abi.bindFinalIndex(firstId, { space: "function", index: -1 }), "final-index-space-mismatch");
+
+    abi.bindFinalIndex(firstId, { space: "function", index: 0 });
+    expectInvariant(() => abi.bindFinalIndex(firstId, { space: "function", index: 1 }), "duplicate-final-binding");
+    expectInvariant(() => abi.bindFinalIndex(secondId, { space: "function", index: 0 }), "final-index-collision");
+    expectInvariant(() => abi.finishBinding(), "unresolved-required-binding");
+    abi.bindFinalIndex(secondId, { space: "function", index: 1 });
+    abi.finishBinding();
+
+    expect(abi.resolveFinalIndex(aliasId)).toEqual({ space: "function", index: 0 });
+    expectInvariant(() => abi.bindFinalIndex(secondId, { space: "function", index: 2 }), "binding-complete");
+    expectInvariant(
+      () => abi.plan(requiredGlobal(fixture, binding(fixture, "global", "late"), "late", 4)),
+      "planning-sealed",
+    );
+  });
+});


### PR DESCRIPTION
Implements the first bounded landing of Markdown issue #3520, the R1 identity and ABI prerequisite for IR-only preparation.

## What changed

- Added opaque, deterministic source, unit, class, and binding identities with dependency-first source ordering and checkout-independent library keys.
- Added semantic provenance for compiler-generated timer, path, typed Node import, ambient class, eval/super, process.stdin, and Iterator source.
- Replaced the R0 outcome inventory projection with the structural inventory while preserving every existing key, label, count, order, status, and emitted body.
- Added a sealed shadow `ProgramAbiMap` and namespace-aware legacy adapter with explicit aliases and plan/final-index invariants.
- Preserved retained support IDs through host-free dead-binding elision without restoring removed units or manufacturing terminal outcomes.

This PR does **not** change body ownership, selection, allocation, fallback policy, or public export names. The remaining #3520 work threads IDs through source planning and analyses, then IR references/passes/backends, and finally consumes the ABI map at the legacy slot boundary.

## Validation

- Identity + ABI + R0 outcomes: 66/66
- Expanded green R1 matrix: 93/93
- Known-base matrix: 9/15; the same six failures reproduce at the pre-branch base (`d3d2454b`), so there are no new failures
- IR-only hybrid gate: READY (31/37 emitted, 6 typed Unsupported, 0 Invariants)
- IR fallback gate: no unintended, post-claim, or module-level increases
- Equivalence gate: 1,608 passing, 35 known failures, zero new regressions; one existing failure now passes and the baseline is intentionally unchanged
- Cross-backend differential: 29/29
- Typecheck, lint, formatting, diff, and LOC-budget checks pass
- Two independent focused reviews: GO

No local Test262 run was performed. `benchmarks/results/test262-run.log` and `scripts/equivalence-baseline.json` are unchanged.
