### PR TITLE
fix(#2717): native standalone Array.prototype.flatMap arm

### DIFF
--- a/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
+++ b/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
@@ -1,11 +1,12 @@
 ---
 id: 2717
 title: "Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard"
-status: ready
+status: done
 sprint: current
+assignee: ttraenkler/dev-serve
 created: 2026-06-26
-updated: 2026-06-26
-completed: 2026-06-26
+updated: 2026-07-22
+completed: 2026-07-22
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -82,3 +83,62 @@ backend lowering) to turn the compile-error into compile+run in standalone.
 ## Reopened 2026-07-20 (stale false-done review)
 
 Marked `done` but live test262 shows: Array.prototype.flatMap() still 'not yet supported in --target standalone'. Reopened as `ready`. See #3474 (done-status integrity).
+
+## Resolution 2026-07-22 — native standalone flatMap arm (dev-serve)
+
+**PR:** `issue-2717-flatmap-standalone-native`. Adds the Wasm-native standalone
+`Array.prototype.flatMap` arm, closing the reopened gap. (`flat()`'s native
+depth-1 arm already landed as #3363.)
+
+### Approach — `flatMap(cb)` ≡ `map(cb).flat(1)`, reusing existing native code
+
+`compileArrayFlatMap` (`src/codegen/array-methods.ts`), in the
+`ctx.standalone || ctx.wasi` arm, now tries `tryCompileFlatMapNative` before the
+loud refusal. That helper compiles the native `map` (arg layout — arg0 = cb,
+arg1 = thisArg — matches flatMap's) directly, then dispatches on the RESULT vec's
+element type (ground truth for what the callback returned):
+
+- element is a nested vec (callback returned arrays) → the #3363 depth-1 flatten,
+  refactored into a reusable `emitFlattenDepth1FromVec` + `canFlattenVecElem`
+  (byte-inert extraction — `tryCompileArrayFlatNativeDepth1` and all 11 #3363
+  tests unchanged);
+- element is a concrete scalar / non-array ref (scalar or plain-object callback)
+  → `flatMap` ≡ `map` (a depth-1 flatten of non-arrays is the identity), so the
+  map result is the answer;
+- element is `externref`/`anyref` (dynamic) → drop + refuse loudly.
+
+### A-priori empty-`[]` guard (the one correctness edge)
+
+An inline callback whose body contains a bare empty array literal `[]` compiles —
+under flatMap's `U | readonly U[]` contextual type — to a closure whose empty `[]`
+resolves to a different vec type than a sibling non-empty array (a Wasm fallthru
+type error). The static return type does NOT discriminate this, and the invalid
+closure is a global module side effect the native `map` cannot roll back — so
+`inlineCallbackHasEmptyArrayLiteral` catches it BEFORE compiling map and refuses
+loudly. Over-conservative but never invalid Wasm; the underlying conditional-`[]`
+vec-type bug is tracked as **#3532**.
+
+### Proofs
+
+- Standalone `flatMap` runtime-correct for array callbacks
+  (`[1,2,3].flatMap(x=>[x,x*2])` → 6, sum 18), string arrays (→4), scalar
+  callback (`x=>x` → 3, ≡ map); zero `__array_flatMap` imports.
+- **Zero invalid-Wasm** across the full boundary corpus (array/scalar/variable
+  conditionals run-correct; every bare-`[]` shape and explicit-depth `flat(1)`
+  fail loud, never trap).
+- **test262 standalone lane: 0 → 9 passes** across
+  `built-ins/Array/prototype/flatMap` (all 24 previously fail-louded, so no
+  regression possible; `depth-always-one.js` passes → correct depth-1 semantics).
+- **Host/gc mode byte-unchanged** (native arm gated on standalone||wasi;
+  `issue-2717` host section + `issue-1718-flatmap` pass).
+- `issue-3363` (11), `issue-3098`/`issue-3162` HOF, `array-methods`,
+  `functional-array-methods`, `flatmap-closure` suites pass (the single
+  `issue-2001-s2` reduce-standalone failure is PRE-EXISTING on origin/main,
+  verified by control run). `tsc`/`biome`/`prettier` clean.
+
+### Still open (follow-ups, NOT this PR)
+
+- **#3532** — conditional bare-`[]` under a union contextual type mistypes the
+  closure (removes the a-priori guard once fixed).
+- Variable-depth recursive `flat(depth)` / `flatMap` with dynamic
+  scalar-or-array (heterogeneous) returns — needs a runtime-IsArray flatten.

--- a/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
+++ b/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
@@ -15,6 +15,8 @@ area: codegen
 language_feature: standalone
 goal: standalone-everything
 parent: 2711
+loc-budget-allow:
+  - src/codegen/array-methods.ts
 ---
 # #2717 — Array.prototype.flat / flatMap have no standalone arm
 

--- a/plan/issues/3532-conditional-empty-array-literal-vec-type.md
+++ b/plan/issues/3532-conditional-empty-array-literal-vec-type.md
@@ -1,0 +1,82 @@
+---
+id: 3532
+title: "codegen: bare empty array literal `[]` in a conditional under a union contextual type mistypes the closure (invalid Wasm)"
+status: ready
+sprint: Backlog
+created: 2026-07-22
+priority: low
+horizon: m
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: codegen-correctness
+goal: correctness
+related: [2717]
+---
+
+# #3532 — conditional bare-`[]` under a union contextual type mistypes the closure
+
+**Source:** surfaced while adding the native standalone `Array.prototype.flatMap`
+arm (#2717).
+
+## Problem
+
+When a callback is contextually typed as a union of an array and something else
+(e.g. `Array.prototype.flatMap`'s `(v) => U | readonly U[]`), a **bare empty
+array literal `[]`** in a conditional branch resolves to a DIFFERENT WasmGC vec
+type than a sibling non-empty array in the other branch. The closure's two
+branches then don't unify, producing an invalid closure — a Wasm
+`type error in fallthru (expected (ref null N), got (ref null M))` at instantiate.
+
+Minimal repro (default gc lane compiles fine because map's contextual type is
+`U`, not a union; the bug needs a union contextual type — flatMap in standalone
+is the observed trigger):
+
+```ts
+// --target standalone
+const a: number[] = [1, 2, 3];
+a.flatMap((x) => (x % 2 === 0 ? [] : [x])); // INVALID closure
+```
+
+Discriminators (all verified):
+
+| callback branches            | result  |
+| ---------------------------- | ------- |
+| `? [] : [x]` (empty first)   | INVALID |
+| `? [x] : []` (empty second)  | INVALID |
+| `? [] : arr` (empty + var)   | INVALID |
+| `? [x,x] : [x]` (both lits)  | valid   |
+| `? [x] : arr` (lit + var)    | valid   |
+| `? p : q` (two vars)         | valid   |
+| `=> []` (always empty)       | valid   |
+
+So the trigger is precisely: an empty array literal `[]` **mixed with a
+non-empty array** in a conditional, under a union contextual type. The static
+return type does NOT discriminate (both report `number[]`).
+
+## Current mitigation (#2717)
+
+The native flatMap arm refuses these a-priori: `inlineCallbackHasEmptyArrayLiteral`
+(`src/codegen/array-methods.ts`) rejects any inline arrow/function-expression
+callback whose body contains a bare `[]`, falling back to the loud refusal. This
+is over-conservative (also refuses a benign always-`[]` callback) but never emits
+invalid Wasm. No real test262 flatMap callback uses a bare-`[]` shape, so the flip
+count is unaffected.
+
+## Fix direction
+
+Make the empty array literal `[]` in a conditional coerce to the sibling
+branch's / the contextual-target's concrete vec type (the same way `map`'s
+non-union contextual type already forces `[]` → `number[]`). This is a
+conditional-expression / array-literal-typing change in the closure/element-type
+resolution — broad-impact, needs full test262 CI. Once fixed, remove the
+`inlineCallbackHasEmptyArrayLiteral` a-priori guard in the flatMap arm.
+
+## Acceptance criteria
+
+- `[1,2,3].flatMap(x => cond ? [] : [x])` compiles + runs correctly in
+  `--target standalone` (and any other union-contextual `[]`-in-conditional
+  shape), producing the flattened result.
+- The `inlineCallbackHasEmptyArrayLiteral` guard can be removed with no new
+  invalid-Wasm.
+- No regression in the default gc lane.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -1549,7 +1549,7 @@ export function compileArrayMethodCall(
       result = compileArrayFlat(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
       break;
     case "flatMap":
-      result = compileArrayFlatMap(ctx, fctx, methodAccess, callExpr);
+      result = compileArrayFlatMap(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
       break;
     case "set": {
       const setResult = compileTypedArraySet(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
@@ -7912,18 +7912,17 @@ function compileArrayLastIndexOf(
  * deeper recursion, and heterogeneous array/scalar unions stay deferred to the
  * larger #2717 follow-up.
  */
-function tryCompileArrayFlatNativeDepth1(
+/**
+ * (#2717) Precondition for the native depth-1 flatten: the outer vec's element
+ * must be a `ref`/`ref_null` to an INNER vec struct (an array-of-arrays), and
+ * that inner vec must resolve to a concrete backing array type. Returns the
+ * inner vec + array type indices, or null when the shape is not a homogeneous
+ * nested array (scalar / externref / mixed elements → the caller falls back).
+ */
+function canFlattenVecElem(
   ctx: CodegenContext,
-  fctx: FunctionContext,
-  propAccess: ts.PropertyAccessExpression,
-  callExpr: ts.CallExpression,
-  vecTypeIdx: number,
-  arrTypeIdx: number,
   elemType: ValType,
-): ValType | null {
-  // Default depth only — an explicit `depth` argument falls through to refusal.
-  if (callExpr.arguments.length > 0) return null;
-  // Outer element must be a ref to an inner vec struct.
+): { innerVecTypeIdx: number; innerArrTypeIdx: number } | null {
   if (elemType.kind !== "ref" && elemType.kind !== "ref_null") return null;
   const innerVecTypeIdx = (elemType as { typeIdx?: number }).typeIdx;
   if (innerVecTypeIdx === undefined) return null;
@@ -7931,8 +7930,28 @@ function tryCompileArrayFlatNativeDepth1(
   if (innerArrTypeIdx < 0) return null;
   const innerArrDef = ctx.mod.types[innerArrTypeIdx];
   if (!innerArrDef || innerArrDef.kind !== "array") return null;
+  return { innerVecTypeIdx, innerArrTypeIdx };
+}
 
-  const outerVec = allocLocal(fctx, `__arr_flat_ov_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+/**
+ * (#2717) Emit a native depth-1 flatten of an outer vec-of-vecs. The outer vec
+ * value must be BOTH on the Wasm stack AND stored in the `outerVec` local (the
+ * caller tees it and, for a user receiver, null-guards it first). Consumes the
+ * stack value; returns a fresh inner-element vec holding every non-null inner
+ * vec's elements concatenated in order.
+ *
+ * Shared by `Array.prototype.flat()` (outer vec = the receiver) and the
+ * `Array.prototype.flatMap()` native arm (outer vec = the native `map` result).
+ */
+function emitFlattenDepth1FromVec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  outerVec: number,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  innerVecTypeIdx: number,
+  innerArrTypeIdx: number,
+): ValType {
   const outerData = allocLocal(fctx, `__arr_flat_od_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const outerLen = allocLocal(fctx, `__arr_flat_ol_${fctx.locals.length}`, { kind: "i32" });
   const total = allocLocal(fctx, `__arr_flat_tot_${fctx.locals.length}`, { kind: "i32" });
@@ -7949,10 +7968,7 @@ function tryCompileArrayFlatNativeDepth1(
   });
   const pos = allocLocal(fctx, `__arr_flat_pos_${fctx.locals.length}`, { kind: "i32" });
 
-  // receiver -> outerVec (null-guarded), then unpack len/data.
-  compileExpression(ctx, fctx, propAccess.expression);
-  fctx.body.push({ op: "local.tee", index: outerVec });
-  emitReceiverNullGuard(ctx, fctx, outerVec);
+  // outer vec is on the stack (also in `outerVec`): unpack len/data.
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: outerLen });
   fctx.body.push({ op: "local.get", index: outerVec });
@@ -8075,6 +8091,151 @@ function tryCompileArrayFlatNativeDepth1(
 }
 
 /**
+ * (#3363) Native depth-1 homogeneous nested-array flatten for `arr.flat()` on
+ * the host-free lanes. Default depth only (an explicit `depth` argument falls
+ * through to the loud refusal); the outer element must be a nested vec.
+ */
+function tryCompileArrayFlatNativeDepth1(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+): ValType | null {
+  // Default depth only — an explicit `depth` argument falls through to refusal.
+  if (callExpr.arguments.length > 0) return null;
+  const pre = canFlattenVecElem(ctx, elemType);
+  if (!pre) return null;
+
+  const outerVec = allocLocal(fctx, `__arr_flat_ov_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+  // receiver -> outerVec (null-guarded), leaving the vec on the stack for the flatten.
+  compileExpression(ctx, fctx, propAccess.expression);
+  fctx.body.push({ op: "local.tee", index: outerVec });
+  emitReceiverNullGuard(ctx, fctx, outerVec);
+  return emitFlattenDepth1FromVec(
+    ctx,
+    fctx,
+    outerVec,
+    vecTypeIdx,
+    arrTypeIdx,
+    pre.innerVecTypeIdx,
+    pre.innerArrTypeIdx,
+  );
+}
+
+/**
+ * (#2717) True iff `cbArg` is an INLINE arrow/function-expression whose body
+ * syntactically contains a bare empty array literal `[]`. The native flatMap arm
+ * refuses these a-priori — see the guard in {@link tryCompileFlatMapNative} for
+ * why (an empty `[]` under flatMap's union contextual type mistypes the closure).
+ * A named-function-reference callback is not inline → returns false (it compiles
+ * as its own correctly-typed function).
+ */
+function inlineCallbackHasEmptyArrayLiteral(cbArg: ts.Expression): boolean {
+  if (!ts.isArrowFunction(cbArg) && !ts.isFunctionExpression(cbArg)) return false;
+  let found = false;
+  const walk = (n: ts.Node): void => {
+    if (found) return;
+    if (ts.isArrayLiteralExpression(n) && n.elements.length === 0) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, walk);
+  };
+  walk(cbArg.body);
+  return found;
+}
+
+/**
+ * (#2717) Native `arr.flatMap(cb, thisArg?)` for the host-free lanes.
+ *
+ * `flatMap(cb)` is spec-equivalent to `map(cb).flat(1)`, so we compile the native
+ * `map` directly (its arg layout — arg0 = cb, arg1 = thisArg — matches flatMap's)
+ * and dispatch on the RESULT vec's element type — the ground truth for what the
+ * callback returned:
+ *   - element is a nested vec (callback returned arrays) → depth-1 flatten;
+ *   - element is a concrete scalar / non-array ref (callback returned a scalar or
+ *     a plain object) → `flatMap` ≡ `map` (a depth-1 flatten of non-arrays is the
+ *     identity), so the map result IS the answer;
+ *   - element is `externref`/`anyref` (dynamic — could be an array at runtime) →
+ *     drop + refuse loudly (a runtime-heterogeneous flatten is out of scope; never
+ *     a silent-wrong result), per the #2711 policy.
+ *
+ * Compiling `map` unconditionally (rather than into a throwaway buffer) mirrors
+ * the working `map(cb).flat()` codegen exactly; only the rare dynamic-return case
+ * leaves dead map code before the caller's `unreachable`, which is well-typed.
+ */
+function tryCompileFlatMapNative(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
+): ValType | null {
+  if (callExpr.arguments.length < 1) return null; // flatMap requires a callback
+
+  // (#2717) A-priori guard: an inline callback whose body contains a bare empty
+  // array literal `[]` is compiled — under flatMap's `U | readonly U[]`
+  // contextual type — to a closure whose empty `[]` resolves to a DIFFERENT vec
+  // type than a sibling non-empty array in the same conditional, yielding an
+  // invalid closure (a Wasm fallthru type error). The static return type does NOT
+  // discriminate this (both branches report `number[]`), and the invalid closure
+  // is a global module side effect the native `map` cannot roll back — so this
+  // MUST be caught before compiling map. Refuse loudly instead. Over-conservative
+  // (also refuses a benign always-`[]` callback), but never emits invalid Wasm;
+  // no real test262 flatMap callback uses a bare-`[]` shape. Named-function-ref
+  // callbacks are exempt — they compile as their own function, correctly typed,
+  // outside flatMap's union context. (The underlying conditional-empty-array
+  // vec-type bug is tracked separately, out of scope here.)
+  if (inlineCallbackHasEmptyArrayLiteral(callExpr.arguments[0]!)) return null;
+
+  const mapType = compileArrayMap(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+  if (!mapType || (mapType.kind !== "ref" && mapType.kind !== "ref_null")) {
+    // map couldn't type its result; the caller's unreachable keeps the body valid.
+    return null;
+  }
+  const mapVecTypeIdx = (mapType as { typeIdx?: number }).typeIdx;
+  if (mapVecTypeIdx === undefined) return null;
+  const mapArrTypeIdx = getArrTypeIdxFromVec(ctx, mapVecTypeIdx);
+  const mapArrDef = mapArrTypeIdx >= 0 ? ctx.mod.types[mapArrTypeIdx] : undefined;
+  const mapElemType = mapArrDef && mapArrDef.kind === "array" ? mapArrDef.element : undefined;
+
+  // Callback returned arrays → flatten the map result depth-1.
+  const pre = mapElemType ? canFlattenVecElem(ctx, mapElemType) : null;
+  if (pre) {
+    const mapVec = allocLocal(fctx, `__arr_flatmap_mv_${fctx.locals.length}`, {
+      kind: "ref_null",
+      typeIdx: mapVecTypeIdx,
+    });
+    fctx.body.push({ op: "local.tee", index: mapVec });
+    return emitFlattenDepth1FromVec(
+      ctx,
+      fctx,
+      mapVec,
+      mapVecTypeIdx,
+      mapArrTypeIdx,
+      pre.innerVecTypeIdx,
+      pre.innerArrTypeIdx,
+    );
+  }
+
+  // Dynamic element (externref/anyref) — could be an array at runtime; a native
+  // depth-1 flatten would need per-element runtime IsArray. Out of scope → drop
+  // the map result and refuse loudly.
+  if (mapElemType && (mapElemType.kind === "externref" || mapElemType.kind === "anyref")) {
+    fctx.body.push({ op: "drop" });
+    return null;
+  }
+
+  // Concrete non-array element (scalar or plain-object ref): flatMap ≡ map.
+  return mapType;
+}
+
+/**
  * Compile arr.flat(depth?) — delegates to __array_flat host import (#1136).
  * Converts WasmGC vec receiver to externref, passes depth arg, returns externref.
  */
@@ -8157,23 +8318,30 @@ function compileArrayFlatMap(
   fctx: FunctionContext,
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  elemType: ValType,
 ): ValType | null {
   if (callExpr.arguments.length < 1) return null; // flatMap requires a callback
 
-  // (#2717) `flatMap` has no Wasm-native arm — it delegates to the host
-  // `__array_flatMap` import, which is unsatisfiable under `--target
-  // standalone`/`wasi` (no JS host) and traps at instantiation. Per the #2711
-  // fail-loud policy, refuse loudly instead of emitting the unsatisfiable import.
-  // A native arm (callback invocation + depth-1 flatten of scalar-or-array
-  // returns) is a separate follow-up. Host/gc mode is unchanged.
+  // (#2717) On the host-free lanes `flatMap` has no host `__array_flatMap` to
+  // satisfy. `flatMap(cb)` ≡ `map(cb).flat(1)`, so try the native arm first
+  // (reuses the native `map` + the #3363 depth-1 flatten); it applies when the
+  // callback provably returns arrays. Otherwise fall through to the loud refusal
+  // below (scalar / union / externref returns), per the #2711 fail-loud policy.
+  // Host/gc mode is unchanged — it keeps the fast `__array_flatMap` import path.
   if (ctx.standalone || ctx.wasi) {
+    const native = tryCompileFlatMapNative(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+    if (native) return native;
     reportError(
       ctx,
       callExpr,
-      `Codegen error: Array.prototype.flatMap() is not yet supported in --target standalone/wasi ` +
-        `(#2717) — there is no Wasm-native arm and emitting the host import __array_flatMap ` +
-        `would produce a module that traps at instantiation. Recompile without --target ` +
-        `standalone, or avoid flatMap() in standalone/WASI code.`,
+      `Codegen error: Array.prototype.flatMap() with a non-array-returning callback is not yet ` +
+        `supported in --target standalone/wasi (#2717) — the native arm handles callbacks that ` +
+        `return arrays (flatMap ≡ map+flat(1)); scalar/union/dynamic returns would need a ` +
+        `runtime-heterogeneous flatten. Emitting the host import __array_flatMap would produce a ` +
+        `module that traps at instantiation. Recompile without --target standalone, or have the ` +
+        `flatMap callback return an array.`,
     );
     // Non-null type + `unreachable` so the #1919 speculative wrapper commits and
     // the diagnostic is not rolled back into a silent default (see compileArrayFlat).

--- a/tests/issue-2717.test.ts
+++ b/tests/issue-2717.test.ts
@@ -3,55 +3,81 @@ import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 
 /**
- * #2717 — Array.prototype.flat / flatMap have no standalone native arm.
+ * #2717 — Array.prototype.flat / flatMap on the host-free lanes.
  *
- * Both delegate to the host imports `__array_flat` / `__array_flatMap` with no
- * `ctx.standalone` guard. Under `--target standalone`/`wasi` there is no JS host
- * to satisfy those imports, so the emitted module FAILS TO INSTANTIATE.
+ * Originally both delegated to the host imports `__array_flat` / `__array_flatMap`
+ * with no `ctx.standalone` guard, so under `--target standalone`/`wasi` (no JS
+ * host) the emitted module failed to instantiate. #3363 added a native depth-1
+ * homogeneous flatten for `flat()`, and this issue adds the native `flatMap`
+ * arm: `flatMap(cb)` ≡ `map(cb).flat(1)`, reusing the native `map` + that
+ * depth-1 flatten.
  *
- * Per the #2711 fail-loud policy, the standalone/WASI path now refuses LOUDLY
- * (a tracked compile error) instead of emitting an unsatisfiable import. A full
- * Wasm-native flatten arm (recursive depth + runtime IsArray + dynamic
- * result-array build over heterogeneous WasmGC element types; flatMap also needs
- * callback invocation with mixed scalar/array returns) is a separate, larger
- * follow-up — the busy `Object()`/array-method surface isn't worth a risky
- * partial native flatten for a marginal test gain.
+ * Current standalone/WASI behavior:
+ *   - `flat()` (default depth, nested-array receiver) → native, compiles + runs.
+ *   - `flat(depth)` with an EXPLICIT depth arg → still refuses loudly (the native
+ *     arm is depth-1-only; a variable-depth recursive flatten is a follow-up).
+ *   - `flatMap(cb)` with an array-returning / scalar callback → native.
+ *   - `flatMap(cb)` whose INLINE callback contains a bare empty array literal
+ *     `[]` → refuses loudly (an empty `[]` under flatMap's `U | U[]` contextual
+ *     type mistypes the closure; caught a-priori, never invalid Wasm).
  *
- * Host/gc mode is byte-unchanged (the guard is gated on standalone||wasi).
+ * In every case NO unsatisfiable `__array_flat*` host import is emitted, and the
+ * result is either a correct value OR a tracked compile error — never a module
+ * that traps at instantiation (#2711 fail-loud policy).
+ *
+ * Host/gc mode is byte-unchanged (the native arms are gated on standalone||wasi).
  */
 
 async function compileStandalone(body: string) {
   return compile(`export function test(): number { ${body} }`, { fileName: "t.ts", target: "standalone" });
 }
 
-describe("#2717 — flat/flatMap refuse loudly in standalone (no unsatisfiable import)", () => {
-  const cases: Array<[string, string, RegExp]> = [
+function noFlatImports(r: Awaited<ReturnType<typeof compile>>): string[] {
+  return r.imports.map((i) => i.name).filter((n) => n === "__array_flat" || n === "__array_flatMap");
+}
+
+describe("#2717 — native standalone flat/flatMap (no unsatisfiable import)", () => {
+  const runCases: Array<[string, string, number]> = [
+    ["flat() flattens one level", `const a: number[][] = [[1,2],[3,4]]; return a.flat().length;`, 4],
+    ["flatMap() array callback (length)", `const a: number[] = [1,2,3]; return a.flatMap(x => [x, x*2]).length;`, 6],
     [
-      "flat()",
-      `const a: number[][] = [[1,2],[3,4]]; return a.flat().length;`,
-      /flat\(\) is not yet supported in --target standalone/,
+      "flatMap() array callback (sum)",
+      `const a: number[] = [1,2,3]; const b = a.flatMap(x => [x, x*2]); let s = 0; for (let i = 0; i < b.length; i++) s += b[i]; return s;`,
+      18,
     ],
+    ["flatMap() string array callback", `const a: string[] = ["a","bb"]; return a.flatMap(s => [s, s + s]).length;`, 4],
+    ["flatMap() scalar callback ≡ map", `const a: number[] = [1,2,3]; return a.flatMap(x => x).length;`, 3],
+  ];
+  for (const [label, body, want] of runCases) {
+    it(`${label} → ${want}, no host import`, async () => {
+      const r = await compileStandalone(body);
+      expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+      expect(noFlatImports(r)).toEqual([]);
+      const { instance } = await WebAssembly.instantiate(r.binary, (r.importObject ?? {}) as WebAssembly.Imports);
+      expect((instance.exports as { test: () => number }).test()).toBe(want);
+    });
+  }
+
+  const loudCases: Array<[string, string, RegExp]> = [
     [
-      "flat(depth)",
+      "flat(depth) explicit arg",
       `const a: number[][] = [[1,2],[3,4]]; return a.flat(1).length;`,
       /flat\(\) is not yet supported in --target standalone/,
     ],
     [
-      "flatMap()",
-      `const a: number[] = [1,2,3]; return a.flatMap(x => [x, x*2]).length;`,
-      /flatMap\(\) is not yet supported in --target standalone/,
+      "flatMap() empty-array-literal callback",
+      `const a: number[] = [1,2,3]; return a.flatMap(x => (x % 2 === 0 ? [] : [x])).length;`,
+      /flatMap\(\) with a non-array-returning callback is not yet supported/,
     ],
   ];
-  for (const [label, body, re] of cases) {
+  for (const [label, body, re] of loudCases) {
     it(`${label} → tracked compile error, never an unsatisfiable __array_flat* import`, async () => {
       const r = await compileStandalone(body);
       expect(r.success).toBe(false);
-      const messages = r.errors.map((e) => e.message).join("\n");
-      expect(messages).toMatch(re);
+      expect(r.errors.map((e) => e.message).join("\n")).toMatch(re);
       // The guard runs BEFORE ensureLateImport, so the unsatisfiable host import
       // is never registered.
-      const flatImports = r.imports.map((i) => i.name).filter((n) => n === "__array_flat" || n === "__array_flatMap");
-      expect(flatImports).toEqual([]);
+      expect(noFlatImports(r)).toEqual([]);
     });
   }
 });


### PR DESCRIPTION
## #2717 — native standalone `Array.prototype.flatMap`

Closes the reopened #2717 gap: `flatMap()` now compiles + runs on the host-free lanes (`--target standalone`/`wasi`) instead of fail-louding. (`flat()`'s native depth-1 arm already landed as #3363.)

### Approach — `flatMap(cb)` ≡ `map(cb).flat(1)`, reusing existing native code
`compileArrayFlatMap`, in the `ctx.standalone || ctx.wasi` arm, tries `tryCompileFlatMapNative` before the loud refusal. It compiles the native `map` directly (arg layout matches flatMap's) then dispatches on the **result vec's element type** (ground truth for what the callback returned):
- nested vec (callback returned arrays) → the #3363 depth-1 flatten, refactored into a reusable `emitFlattenDepth1FromVec` + `canFlattenVecElem` (byte-inert — `tryCompileArrayFlatNativeDepth1` and all 11 #3363 tests unchanged);
- concrete scalar / non-array ref → `flatMap` ≡ `map` (depth-1 flatten of non-arrays is the identity);
- dynamic `externref`/`anyref` → drop + refuse loudly.

### The one correctness edge — a-priori empty-`[]` guard
An inline callback whose body contains a bare empty array literal `[]` compiles — under flatMap's `U | readonly U[]` contextual type — to a closure whose empty `[]` resolves to a *different* vec type than a sibling non-empty array (a Wasm fallthru type error). The static return type does **not** discriminate this, and the invalid closure is a global module side effect the native `map` cannot roll back — so `inlineCallbackHasEmptyArrayLiteral` catches it **before** compiling map and refuses loudly. Over-conservative but never invalid Wasm; the underlying conditional-`[]` vec-type bug is filed as **#3532**.

### Proofs
- Standalone `flatMap` runtime-correct: `[1,2,3].flatMap(x=>[x,x*2])` → 6 (sum 18), string arrays → 4, scalar callback (`x=>x`) → 3; **zero `__array_flatMap` imports**.
- **Zero invalid-Wasm** across the full boundary corpus (array/scalar/variable conditionals run-correct; every bare-`[]` shape and explicit-depth `flat(1)` fail loud, never trap).
- **test262 standalone lane: 0 → 9 passes** on `built-ins/Array/prototype/flatMap` (all 24 previously fail-louded, so no regression possible; `depth-always-one.js` passes → correct depth-1 semantics).
- **Host/gc mode byte-unchanged** (native arm gated on standalone||wasi; `issue-2717` host section + `issue-1718-flatmap` pass).
- `issue-3363` (11), `issue-3098`/`issue-3162` HOF, `array-methods`, `functional-array-methods`, `flatmap-closure` pass. The single `issue-2001-s2` reduce-standalone failure is **pre-existing on origin/main** (verified by control run). `tsc`/`biome`/`prettier` clean.

Follow-ups (NOT this PR): **#3532** (conditional bare-`[]` vec-type bug → removes the a-priori guard once fixed); variable-depth `flat(depth)` and dynamic scalar-or-array `flatMap` returns (need a runtime-IsArray flatten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb