### PR TITLE
fix(#3024): eliminate 68-file Function.prototype.toString invalid-Wasm cluster (funcref-cell self-carrier rebuild)

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -716,3 +716,65 @@ cross-statement eval-promotion family (broad-impact, needs a full-CI window) and
 `__anon_#_method` global-get numeric desync, `Parent_new` tail-call, `__new_function_#`
 funcref-cast). The 8 files here still need genuine resizable-ArrayBuffer support
 to reach `pass`.
+
+---
+
+## Landed: boxed-capture funcref-cell self-carrier rebuild — 68-file `Function.prototype.toString` cluster (sr-3024, 2026-07-22)
+
+**PR:** `issue-3024-toString-closure-funcref` — eliminates the largest live
+invalid-Wasm cluster: **68** `built-ins/Function/prototype/toString/*` files that
+failed Wasm validation at *instantiate* (they bucket as `fail`, not
+`compile_error`, which is why the earlier `compile_error`-only harvests
+undercounted — see the 2026-07-22 dev-serve handoff).
+
+### Root cause (verified: `Array.prototype.push` monkeypatch pinned the emit site + type dump)
+
+The test262 `nativeFunctionMatcher.js` harness defines mutually-recursive
+module-`const` closures (`assertToStringOrNativeFunction` → `assertNativeFunction`
+→ `validateNativeFunctionSource` → inner `eat`/`test`/…). Such a closure is boxed
+into a ref cell whose field-0 stores a **bare funcref**, and its lifted self
+carrier is a no-capture funcref-WRAPPER struct `(struct (field funcref))`. In
+`compileClosureCall` (`calls-closures.ts` boxed-capture branch) the recorded
+`boxed.valType` stale-reads `externref` while the cell field-0 is genuinely
+`funcref`, so the legacy path emitted `any.convert_extern` on the unwrapped
+funcref — `any.convert_extern[0] expected type externref, found struct.get of
+type funcref` — followed by a struct `emitGuardedRefCast` (also invalid on a
+funcref). Confirmed by dumping `boxed.valType={externref}`, `cellField0={funcref}`,
+`selfStruct.fields=[funcref only]`, `funcType.params=[ref <wrapper>, externref]`.
+
+### Fix (`calls-closures.ts` only; +37/-4)
+
+Trust the ACTUAL ref-cell field-0 type (`refCellValueType`) instead of the stale
+`boxed.valType`: when it is `funcref` AND the lifted self carrier is a
+single-funcref-field wrapper (`isSingleFuncRefWrapperStruct`), rebuild the self
+carrier by wrapping the funcref back with `struct.new` — never
+`any.convert_extern` / struct-guarded-cast. Guarded so a self carrier that holds
+real capture fields never takes it.
+
+### Proofs
+
+- 68-file cluster: **CE → valid Wasm on BOTH lanes** (gc `__closure_24` and
+  standalone `__closure_11` were INVALID; both now VALID).
+- **+11 host passes** (files whose `assert.sameValue("" + fn, expected)` matches
+  and never invoke the native matcher); status tally over the 80-file dir went
+  `compile_error 80 → 0`.
+- **Byte-inert / zero-regression** (airtight): the old branch on a funcref cell
+  ALWAYS emitted invalid Wasm, so only previously-invalid modules are touched —
+  no previously-valid module changes. Confirmed byte-identical (sha256) across a
+  10-program closure-heavy corpus (incl. mutually-recursive even/odd, which uses
+  externref cells and correctly does NOT take the new branch).
+- New `tests/issue-3024-tostring-closure-funcref.test.ts` (asserts
+  `status !== "compile_error"` and the `any.convert_extern … funcref` signature
+  is gone) passes.
+
+### Still open (roll forward → #3534)
+
+Files that INVOKE the native matcher (`bound-function.js`,
+`built-in-function-object.js`, …) now **validate but TRAP at runtime**
+(`illegal cast` inside `validateNativeFunctionSource` as it constructs its
+cross-referencing inner closures) — a DISTINCT construct-site funcref-cell RTT
+desync (#2873 star-topology family), proven NOT caused by this call-site fix
+(dev-serve's "valid" reference layout traps identically; its "VALID" only meant
+`WebAssembly.compile`, never a matcher run). Tracked in **#3534** with the
+unified closure-funcref-cell representation design plan. dev-serve's 34-file
+`class C { c = fn }` cluster is the value-read instance of the same family.

--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -22,6 +22,7 @@ loc-budget-allow:
   - src/codegen/index.ts
   - src/codegen/property-access.ts
   - src/codegen/destructuring-params.ts
+  - src/codegen/expressions/calls-closures.ts
 ---
 
 # #3024 — invalid Wasm binary emission residual (default lane)

--- a/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
+++ b/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
@@ -13,7 +13,7 @@ task_type: bugfix
 area: codegen
 language_feature: closures
 goal: correctness
-related: [3024, 2873]
+related: [3024, 3533, 2873]
 ---
 
 # #3534 — matcher-invoking `Function.prototype.toString` files trap at runtime (construct-site funcref-cell RTT desync)
@@ -91,3 +91,123 @@ validateNativeFunctionSource("function f() { [native code] }");  // validates, t
 - Matcher-invoking `Function.prototype.toString` files run without trapping
   (`illegal cast`), reaching a genuine oracle pass/fail.
 - No regression on the closure byte-inert corpus or the standalone floor.
+
+---
+
+## Unified closure-value representation — design plan (sr-3024, 2026-07-22)
+
+Owner-drafted per lead request (verify-first understanding beats a cold architect
+re-derivation). Covers the whole **closure-value representation desync FAMILY**,
+folding in the two sibling clusters.
+
+### The family: one root, three sites
+
+A *closure value* (an arrow/function-expression bound to a `const`/module global
+and later read, called, or stored) has **no single canonical wasm
+representation**. Different emit sites assume different types, and phase-ordering
+(the binding is DECLARED before its closure type is known, then RETRO-narrowed)
+breaks already-emitted reads. Three confirmed instances:
+
+| # | site | symptom | mechanism |
+|---|------|---------|-----------|
+| **#3024** (LANDED, call) | `compileClosureCall` boxed-capture branch | `any.convert_extern` on a funcref → invalid Wasm | ref cell field-0 is `funcref`; `boxed.valType` stale-reads `externref`; self carrier is a no-capture funcref-WRAPPER `(struct (field funcref))` |
+| **#3534** (construct) | `validateNativeFunctionSource` building cross-referencing inner closures | runtime `illegal cast` | funcref-WRAPPER RTT star-topology (#2873): sibling `(struct (field funcref))` wrappers do NOT merge under isorecursive canonicalization, so `ref.cast` to a non-root wrapper traps |
+| **#3533** (value-read, dev-serve) | `class C { c = fn }` field init reads `$__mod_<name>` | `struct.set expected externref, found global.get of (ref null N)` → invalid Wasm | `$__mod_<name>` global DECLARED `externref` (type unknown at decl), then `__module_init` NARROWS it `externref → (ref null N)`, retroactively invalidating the already-emitted `global.get` |
+
+**The `$__mod_<name>` global is SHARED** (dev-serve, verified): read by BOTH
+value-reads (want `externref`) AND `fn()` calls via `compileClosureCall` (want a
+raw ref / funcref). So **no value-read-only fix exists** — any type/store change
+at the global touches the call read. This is why #3533 is `blocked-on` this plan
+and why the sites cannot be fixed in isolation at the value-read/call boundary.
+
+### Root invariant to restore
+
+The closure binding's wasm type must be **stable and knowable across decl →
+`__module_init`(store/construct) → read/call phases**, with a representation ALL
+consumers agree on. Two ways to get there:
+
+### Option (a) — Uniform `externref` boxed representation (RECOMMENDED)
+
+Keep every closure-VALUE binding (`$__mod_<name>` global, boxed ref cell)
+**`externref` for its whole lifetime — never narrow**. On store, box the closure
+struct with `extern.convert_any`. Consumers:
+- **value-read** → the `externref` global.get is valid as-emitted; the retro-narrow
+  that caused #3533 is simply removed. ✔
+- **call** → route through the EXISTING externref arm of `compileClosureCall`
+  (`localType?.kind === "externref"` / module-global externref branch,
+  `any.convert_extern` + guarded `ref.cast` to the self struct). The value is a
+  boxed **struct** (not a bare funcref), so the guarded ref.cast is valid — this
+  **supersedes the #3024 funcref-cell stopgap** (a boxed struct never takes the
+  new `struct.new` branch). ✔
+- **construct** → inner closures cross-reference via `externref`, sidestepping the
+  #2873 funcref-wrapper RTT star-topology entirely (no sibling-wrapper `ref.cast`).
+  Likely resolves #3534 as a side effect. ✔ (verify)
+
+**Blast radius / risk (HIGH — core closure representation):**
+- Perf: extra `extern.convert_any`/`any.convert_extern` round-trips + guarded casts
+  on closure-value reads/calls that previously used a precise ref. Measure on the
+  playground benchmark sidebar; likely negligible (these are cold config/harness
+  paths, not hot loops), but must be measured.
+- Correctness regression surface: any site that RELIES on the narrowed precise
+  ref type of `$__mod_<name>` (e.g. a direct `struct.get` on the closure struct
+  without a guarded cast, or a `call_ref` that assumed the non-null precise self).
+  These would need the externref→struct guarded cast inserted. **Measurement step
+  REQUIRED before code:** harvest currently-PASSING closure-heavy tests
+  (module-const arrows, mutual recursion, HOFs, callbacks-in-arrays, closures
+  stored in class fields / objects) and confirm byte-inert OR quantify the delta.
+- Standalone lane: `extern.convert_any`/`any.convert_extern` exist in both lanes;
+  re-check the standalone floor (the payoff was framed as standalone flips).
+
+### Option (b) — Precise stable struct representation
+
+Forward-declare each closure binding's struct type at DECL time (before
+`__module_init`), so the global is `(ref null $closureStruct)` from the start (no
+retro-narrow), and make the funcref-wrapper RTT #2873-consistent (cast to the
+wrapper ROOT via `getFuncRefWrapperRootTypeIdx`, discriminate on the funcref's
+exact type — the landed #2873 pattern).
+
+**Blast radius / risk (HIGHER):** requires (i) knowing the closure struct type at
+decl — a type-index phase-ordering problem (the struct is minted during closure
+compilation, AFTER the binding decl); (ii) the full #2873 root-discrimination at
+every construct/call site; (iii) value-reads must then BOX the precise ref to
+externref at each `externref`-typed sink (the inverse of today's bug). More
+moving parts, more type-index-shift hazards (cf. `reference_subview_type_idx_stability`,
+`project_type_index_shift_and_deadelim`), for a perf win on cold paths.
+
+### Recommendation
+
+**Option (a).** The desync is fundamentally that the binding is type-erased at
+decl then retro-typed; keeping it type-erased (`externref`) for its lifetime is
+the minimal, phase-order-safe invariant, reuses existing externref call/read
+arms, and supersedes the #3024 stopgap cleanly. Option (b) chases a cold-path perf
+win at materially higher type-index-shift risk. Take (a); revisit (b) only if
+measurement shows a real hot-path regression.
+
+### Decomposition (option a) — reviewable, full-CI-validated steps
+
+1. **Measure-first (no src):** harvest the currently-PASSING closure-value corpus
+   (module-const arrows, mutual recursion, HOFs, array/object/class-field-stored
+   closures) + the #3024/#3533 repros; snapshot sha256 + pass set. Defines the
+   byte-inert/blast-radius baseline.
+2. **Stop the retro-narrow (#3533 core):** keep `$__mod_<name>` closure globals
+   `externref`; box on store (`extern.convert_any`). Insert externref→struct
+   guarded casts at any precise-ref consumer the measurement flags. Validate: #3533
+   value-read CE→valid; #3024 still valid; corpus byte-inert or measured delta.
+3. **Route calls through the externref arm:** ensure `compileClosureCall` on an
+   externref closure global/cell takes the guarded-struct-cast path; remove the
+   #3024 funcref-cell `struct.new` stopgap once it's provably dead (the cell is no
+   longer funcref-typed).
+4. **Construct site (#3534):** re-run the matcher oracle; if the boxed-externref
+   inner-closure cross-references clear the illegal cast, done; else apply the
+   #2873 wrapper-ROOT discrimination locally.
+5. **Full-CI + standalone floor** each step; playground perf diff on step 2/3.
+
+### Scope call
+
+This touches **core closure representation** (highest-risk subsystem) across 3
+sites + 2 sibling issues, needs a measurement gate, and is **multi-PR** — it
+exceeds a clean single session. Recommendation to lead: I can OWN it as the
+serialized step-list above (each step its own full-CI PR), but given the
+core-representation risk a **design partner / architect review on step 2's
+consumer-cast audit** would de-risk it. Not a one-shot. #3533 stays `blocked-on`
+this until step 2 lands.

--- a/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
+++ b/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
@@ -1,0 +1,93 @@
+---
+id: 3534
+title: "codegen: mutually-recursive const-closure funcref-cell RTT desync — matcher-invoking Function.prototype.toString files trap (illegal cast) at construct site"
+status: ready
+sprint: current
+created: 2026-07-22
+updated: 2026-07-22
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: closures
+goal: correctness
+related: [3024, 2873]
+---
+
+# #3534 — matcher-invoking `Function.prototype.toString` files trap at runtime (construct-site funcref-cell RTT desync)
+
+## Context / provenance
+
+Follow-up to **#3024 slice** `issue-3024-toString-closure-funcref` (the boxed-capture
+CALL-site fix in `calls-closures.ts`). That slice eliminated the 68-file
+`built-ins/Function/prototype/toString/*` invalid-Wasm cluster (CE → valid on both
+gc and standalone lanes; +11 host passes on files whose `assert.sameValue("" + fn,
+expected)` matches and never invoke the native matcher).
+
+## Problem
+
+Files that DO invoke the native matcher (`assert.sameValue` fails → `catch` →
+`assertNativeFunction` → `validateNativeFunctionSource` → inner `eat`/`test`/…)
+now **validate but trap at runtime**:
+
+```
+RuntimeError: illegal cast in __closure_41() at source L25
+  (via __closure_53@L214 ← __module_init@L16)
+```
+
+`__closure_53` = `assertNativeFunction` (`const actual = "" + fn`, then
+`validateNativeFunctionSource(actual)`); `__closure_41` =
+`validateNativeFunctionSource`; the illegal cast is at its ENTRY (L25), where it
+constructs its cross-referencing inner closures (`eat` captures `test`'s box, etc.).
+
+**Verified NOT caused by the #3024 call-site fix:** even dev-serve's "valid"
+reference layout (`validateNativeFunctionSource` + a direct call) validates but
+traps identically — dev-serve's "VALID" rows only checked `WebAssembly.compile`,
+never RAN the matcher. So NO layout currently runs the matcher correctly.
+
+## Root cause (hypothesis, to confirm)
+
+The `nativeFunctionMatcher` module-level `const` closures are mutually recursive.
+They are boxed into ref cells that store a **bare funcref** (no environment
+struct); their lifted self carriers are no-capture funcref-WRAPPER structs
+`(struct (field funcref))`. This is a **funcref-wrapper RTT-identity** problem
+(cf. #2873 star-topology: sibling `(struct (field funcref))` wrappers do NOT
+merge under WasmGC isorecursive canonicalization, so `ref.cast` to a non-root
+wrapper traps). The desync spans multiple sites:
+
+- **call site** — fixed in #3024 (`compileClosureCall`, funcref cell → rebuild
+  self carrier via `struct.new`).
+- **construct site** — `validateNativeFunctionSource` building `eat`/`test` that
+  cross-reference each other's funcref cells (the trap here).
+- **value-read site** — likely the same family as the 34-file
+  `class C { c = fn }` cluster (dev-serve owns that): a module-global
+  closure-VALUE read reported `externref` but emitted `global.get <ref>` with no
+  `extern.convert_any`.
+
+## Suggested direction (architect-worthy)
+
+Unify the closure funcref-cell representation so `boxed.valType`, the ref-cell
+field-0 type, and the lifted self-carrier type AGREE — likely by storing the
+closure STRUCT (or externref-boxed closure) in the cell rather than a bare
+funcref, so no per-site reconstruction (and no RTT-sibling cast) is needed. A
+single spec should cover the call / construct / value-read sites and the #2873
+wrapper-root discrimination.
+
+## Repro
+
+```
+[assert.js, sta.js, nativeFunctionMatcher.js, bound-function.js]  → validates, traps
+```
+or minimal:
+```js
+// nativeFunctionMatcher.js + :
+validateNativeFunctionSource("function f() { [native code] }");  // validates, traps (illegal cast)
+```
+
+## Acceptance criteria
+
+- Matcher-invoking `Function.prototype.toString` files run without trapping
+  (`illegal cast`), reaching a genuine oracle pass/fail.
+- No regression on the closure byte-inert corpus or the standalone floor.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -21,6 +21,7 @@ import { noJsHost } from "../js-errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
 import { addFuncType, addImport, localGlobalIdx, resolveWasmType } from "../index.js";
+import { refCellValueType } from "../registry/types.js";
 import { emitNullCheckThrow, typeErrorThrowInstrs } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
@@ -306,6 +307,21 @@ function emitRootFuncrefDispatch(
   fctx.body.push(...funcDispatch);
 }
 
+/**
+ * (#3024) True when `typeIdx` is a no-capture closure funcref-WRAPPER struct —
+ * exactly one field whose type is `funcref` (`(struct (field funcref))`). This is
+ * the self carrier for a closure that keeps no environment in its self struct, so
+ * it can be losslessly reconstructed from a bare funcref via `struct.new`. Guards
+ * the #3024 rebuild so a self carrier that DOES hold capture fields (which
+ * `struct.new` from a lone funcref would leave under-populated) never takes it.
+ */
+function isSingleFuncRefWrapperStruct(ctx: CodegenContext, typeIdx: number): boolean {
+  const def = ctx.mod.types[typeIdx];
+  if (!def || def.kind !== "struct") return false;
+  const fields = (def as { fields: { type: ValType }[] }).fields;
+  return fields.length === 1 && fields[0]?.type.kind === "funcref";
+}
+
 /** Compile a call to a closure variable: closureVar(args...) */
 export function compileClosureCall(
   ctx: CodegenContext,
@@ -341,12 +357,29 @@ export function compileClosureCall(
       const castType: ValType = { kind: "ref_null", typeIdx: selfStructTypeIdx };
       const castLocal = allocLocal(fctx, `__closure_cast_${fctx.locals.length}`, castType);
       fctx.body.push({ op: "local.get", index: localIdx });
-      // struct.get $refCell $value — unwrap to underlying externref/ref
+      // struct.get $refCell $value — unwrap to underlying value.
       fctx.body.push({ op: "struct.get", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 });
-      if (boxed.valType.kind === "externref") {
-        fctx.body.push({ op: "any.convert_extern" });
+      // (#3024) The ref cell may store the closure as a BARE FUNCREF: a
+      // mutually-recursive `const` closure (e.g. the test262
+      // `nativeFunctionMatcher` `eat`→`test` pair) whose self carrier is a
+      // no-capture funcref-WRAPPER struct `(struct (field funcref))`. There
+      // `boxed.valType` stale-reads `externref` while the cell field-0 is
+      // genuinely `funcref`, so the legacy path emitted `any.convert_extern` on
+      // a funcref (invalid — funcref is not in the anyref hierarchy) followed by
+      // a struct `emitGuardedRefCast` (also invalid). Trust the ACTUAL cell
+      // field type: when it is `funcref` AND the lifted self carrier is a
+      // single-funcref-field wrapper, rebuild the self carrier by wrapping the
+      // funcref back into that wrapper via `struct.new`. Byte-inert for every
+      // other cell shape — the funcref-cell call path was 100% invalid Wasm.
+      const cellFieldType = refCellValueType(ctx, boxed.refCellTypeIdx);
+      if (cellFieldType?.kind === "funcref" && isSingleFuncRefWrapperStruct(ctx, selfStructTypeIdx)) {
+        fctx.body.push({ op: "struct.new", typeIdx: selfStructTypeIdx });
+      } else {
+        if (boxed.valType.kind === "externref") {
+          fctx.body.push({ op: "any.convert_extern" });
+        }
+        emitGuardedRefCast(fctx, selfStructTypeIdx);
       }
-      emitGuardedRefCast(fctx, selfStructTypeIdx);
       fctx.body.push({ op: "local.set", index: castLocal });
       effectiveLocalIdx = castLocal;
     } else if (localType?.kind === "externref") {

--- a/tests/issue-3024-tostring-closure-funcref.test.ts
+++ b/tests/issue-3024-tostring-closure-funcref.test.ts
@@ -1,0 +1,66 @@
+/**
+ * #3024 — `Function.prototype.toString` invalid-Wasm cluster (68 files).
+ *
+ * The test262 `nativeFunctionMatcher.js` harness defines mutually-recursive
+ * `const` closures (`assertToStringOrNativeFunction` → `assertNativeFunction` →
+ * `validateNativeFunctionSource` → inner `eat`/`test`/…). Such a closure is
+ * boxed into a ref cell that stores a BARE FUNCREF, and its lifted self carrier
+ * is a no-capture funcref-WRAPPER struct `(struct (field funcref))`. The
+ * boxed-capture call path (`calls-closures.ts` `compileClosureCall`) stale-read
+ * `boxed.valType` as `externref` and emitted `any.convert_extern` on the
+ * unwrapped funcref — `any.convert_extern[0] expected type externref, found
+ * struct.get of type funcref` — so EVERY `built-ins/Function/prototype/toString/*`
+ * file that pulls in this harness failed Wasm validation at *instantiate*.
+ *
+ * The fix trusts the actual ref-cell field-0 type: when it is `funcref` and the
+ * self carrier is a single-funcref-field wrapper, the self carrier is rebuilt by
+ * wrapping the funcref via `struct.new` instead of the invalid
+ * `any.convert_extern` + struct guarded-cast.
+ *
+ * This asserts the *validation* failure is gone (CE → valid Wasm). Files that
+ * additionally INVOKE the native matcher surface a DISTINCT construct-site
+ * closure-funcref-cell runtime trap tracked separately (#3534); this slice is
+ * scoped to eliminating the invalid-Wasm compile errors, mirroring the earlier
+ * #3024 slices (CE→valid, not a runtime-pass claim).
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.ts";
+
+const T262 = join(process.cwd(), "test262");
+const CAT = "built-ins/Function";
+const DIR = "test/built-ins/Function/prototype/toString";
+
+// Representative files from the 68-file cluster (all failed Wasm validation with
+// the `any.convert_extern … found … funcref` signature before the fix).
+const FILES = [
+  "arrow-function.js",
+  "async-function-declaration.js",
+  "bound-function.js",
+  "built-in-function-object.js",
+  "Function.js",
+  "GeneratorFunction.js",
+  "getter-class-expression.js",
+  "line-terminator-normalisation-CR.js",
+  "setter-object.js",
+];
+
+describe("#3024 — Function.prototype.toString closure funcref-cell invalid-Wasm", () => {
+  it.runIf(existsSync(T262))(
+    "no longer emits invalid Wasm (any.convert_extern on a funcref)",
+    async () => {
+      for (const f of FILES) {
+        const abs = join(T262, DIR, f);
+        if (!existsSync(abs)) continue; // tolerate submodule pathing drift
+        const r = await runTest262File(abs, CAT, 20000);
+        const msg = String(r.error ?? r.reason ?? "");
+        expect(r.status, `${f}: ${r.status} — ${msg}`).not.toBe("compile_error");
+        expect(msg).not.toMatch(
+          /any\.convert_extern.*funcref|expected type externref, found struct\.get of type funcref/,
+        );
+      }
+    },
+    120000,
+  );
+});


### PR DESCRIPTION
## Summary

Eliminates the largest live invalid-Wasm cluster in #3024: **68**
`built-ins/Function/prototype/toString/*` files that failed Wasm validation at
*instantiate* (`any.convert_extern[0] expected type externref, found struct.get
of type funcref`).

**Honest scope:** this is a **CE → valid** slice (the established #3024
precedent), **not** a claim that the 68 files pass. It yields **+11 host passes**
(files whose `assert.sameValue("" + fn, expected)` matches and never invoke the
native matcher). Matcher-invoking files (`bound-function.js`,
`built-in-function-object.js`, …) now **validate but trap at runtime** on a
DISTINCT construct-site closure-funcref-cell issue → follow-up **#3534**.

## Root cause

The test262 `nativeFunctionMatcher.js` harness defines mutually-recursive
module-`const` closures. Such a closure is boxed into a ref cell whose field-0
stores a **bare funcref**, and its lifted self carrier is a no-capture
funcref-WRAPPER struct `(struct (field funcref))`. In `compileClosureCall`
(`calls-closures.ts`, boxed-capture branch) the recorded `boxed.valType`
stale-reads `externref` while the cell field-0 is genuinely `funcref`, so the
legacy path emitted `any.convert_extern` on the unwrapped funcref (invalid —
funcref is not in the anyref hierarchy) followed by a struct
`emitGuardedRefCast` (also invalid). Pinned via an `Array.prototype.push`
emit-trace + a type dump (`boxed.valType={externref}`, `cellField0={funcref}`,
`selfStruct.fields=[funcref only]`).

## Fix (`calls-closures.ts` only)

Trust the ACTUAL ref-cell field-0 type (`refCellValueType`) instead of the stale
`boxed.valType`: when it is `funcref` AND the lifted self carrier is a
single-funcref-field wrapper (`isSingleFuncRefWrapperStruct`), rebuild the self
carrier by wrapping the funcref back with `struct.new`. Guarded so a self carrier
with real capture fields never takes it.

## Verification

- 68-file cluster: **CE → valid Wasm on BOTH lanes** (gc `__closure_24` +
  standalone `__closure_11` were INVALID; both now VALID). `compile_error 80 → 0`
  over the toString dir; **+11 host passes**.
- **Byte-inert / zero-regression** (airtight): the old branch on a funcref cell
  ALWAYS emitted invalid Wasm, so only previously-invalid modules are touched.
  Confirmed byte-identical (sha256) across a 10-program closure-heavy corpus
  (incl. mutually-recursive even/odd, which uses externref cells and correctly
  does NOT take the new branch).
- New `tests/issue-3024-tostring-closure-funcref.test.ts` passes.

## Follow-up

**#3534** — matcher-invoking files validate-but-trap on a construct-site
funcref-cell RTT desync (#2873 family); shares the module-global closure-type
mechanism with dev-serve's 34-file `class C { c = fn }` value-read cluster
(#3533). Unified-representation design plan to be drafted into #3534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb