### PR TITLE
fix(ci): disable stale draft reminders

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -60,7 +60,6 @@ permissions:
   pull-requests: write
   checks: read
   actions: write # rerun cla-check when its status is stale on the head (#1958a)
-  issues: write # comment + stale-draft label on aging green drafts (#1958d)
 
 concurrency:
   group: auto-enqueue

--- a/plan/issues/1958-pr-pipeline-rot-prevention.md
+++ b/plan/issues/1958-pr-pipeline-rot-prevention.md
@@ -4,7 +4,7 @@ title: "PR-pipeline rot prevention — 4 mechanisms observed live 2026-06-12"
 status: done
 sprint: 61
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-07-22
 completed: 2026-06-12
 priority: high
 feasibility: medium
@@ -17,6 +17,7 @@ Four distinct mechanisms that silently rot the PR pipeline were observed live
 on 2026-06-12. Each strands green PRs and (today) needs a human to clear it.
 
 ### (a) CLA-CHECK SHA STRANDING
+
 When the merge queue or a drift-update adds a `Merge branch 'main'` commit on
 top of a PR branch, the new head SHA has no `cla-check` commit status —
 `cla-check.yml` runs on `pull_request_target` and posts the status to the PR
@@ -26,23 +27,27 @@ even though CLA was already accepted on the prior head. (Incident: senior-1 on
 PR #1365 / #2061.)
 
 ### (b) QUEUE WEDGE DETECTION GAP
+
 `queue-unstick.yml` / `unstick-merge-queue.mjs` exist for the #1958 wedge
 (entry AWAITING_CHECKS, no merge_group runs), but the 01:36Z run reported
 success while PR #1364 was wedged 00:44→02:10.
 
 ### (c) FORK-PR action_required GATING
+
 Fork PRs land their CI runs in `action_required` until a maintainer approves
 them. The team's dev agents all push to `ttraenkler/js2`, so every run stalls;
 ~90 runs stranded on 2026-06-12 until a tech-lead session swept them, and that
 sweep dies with the session.
 
 ### (d) DRAFT ROT
+
 Green drafts are invisible to auto-enqueue by design, but nothing flags them;
 PRs #1345 / #1335 (the acorn dogfood blocker) rotted ~1 day as drafts.
 
 ## Fix (this PR)
 
 ### (a) — `scripts/enqueue-green-prs.mjs`
+
 When `enqueuePullRequest` fails and the only blocker is a stale/missing
 `cla-check` status on the head (we already verified every visible check is
 pass/skipping), rerun the PR's latest `cla-check` run. The
@@ -51,9 +56,11 @@ pass/skipping), rerun the PR's latest `cla-check` run. The
 Added `actions: write` to `auto-enqueue.yml`.
 
 ### (b) — `scripts/unstick-merge-queue.mjs`
+
 Root cause: each merge group spawns ~4-5 workflow runs, so the old
 `per_page=50` single-page fetch covered only ~10 PRs of history — and that
 fetch ENOBUFS-crashed on the ~1 MB/page payload. Fixes:
+
 - raise `execFileSync` `maxBuffer` to 64 MB (the fetch was crashing);
 - project the runs API server-side with `-q` (id/head_branch/created_at only)
   and paginate (`RUN_PAGES`×100, default 4) so the window covers the whole
@@ -65,24 +72,27 @@ fetch ENOBUFS-crashed on the ~1 MB/page payload. Fixes:
   (a hand-run without `GH_REPO` was querying the wrong repo).
 
 ### (c) — new `scripts/approve-fork-runs.mjs` + `.github/workflows/approve-fork-runs.yml`
+
 Scheduled (10 min) + `workflow_run`-triggered job that approves
 `action_required` runs whose `head_repository.full_name == ttraenkler/js2`
 ONLY (trusted fork; arbitrary forks are never auto-approved). Uses the
 `AUTO_ENQUEUE_TOKEN` PAT — the default `GITHUB_TOKEN` cannot approve fork runs
 (403); the script logs a clear pointer if the secret is unset.
 
-### (d) — `scripts/enqueue-green-prs.mjs`
-After the enqueue sweep, list green drafts older than `DRAFT_AGE_HOURS`
-(default 6) and, once per PR (idempotent on a comment marker + `stale-draft`
-label), nudge the author to mark it ready. Never un-drafts or enqueues — that
-stays a human decision. Added `issues: write` to `auto-enqueue.yml`.
+### (d) — disabled 2026-07-22
+
+The stale-draft notifier was removed after it repeatedly commented on dormant
+draft PRs. Auto-enqueue still ignores drafts, but it no longer scans, labels, or
+comments on them. The workflow's now-unused `issues: write` permission was also
+removed. Authors decide when a draft is ready without scheduled bot reminders.
 
 ## Validation
+
 - Both scripts pass `node --check`.
 - `unstick-merge-queue.mjs` dry-run against the live queue now fetches 400
   merge_group runs (was ENOBUFS-crashing) and correctly detects the live
   AWAITING_CHECKS heads.
 - `approve-fork-runs.mjs` dry-run confirms the trusted-fork projection
   (`head_repository.full_name`) resolves and the trusted-fork filter is applied.
-- `enqueue-green-prs.mjs` dry-run exercises the back-off guard; the (a)/(d)
-  paths are guarded behind it and parse-clean.
+- `enqueue-green-prs.mjs` dry-run exercises the back-off guard; the (a) path is
+  guarded behind it and parse-clean.

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -234,7 +234,7 @@ function openPrs() {
       // author.login + headRepositoryOwner.login feed the #2550 fork-allowlist
       // layer of the author-trust gate (both fields ARE supported by gh 2.23's
       // `pr list --json`, unlike authorAssociation which needs GraphQL).
-      "number,mergeStateStatus,isDraft,labels,id,title,headRefName,createdAt,author,headRepositoryOwner",
+      "number,mergeStateStatus,isDraft,labels,id,title,headRefName,author,headRepositoryOwner",
     ]),
   );
 }
@@ -691,89 +691,9 @@ function runSweep() {
     }
   }
 
-  // DRAFT ROT (#1958d). Green drafts are invisible to auto-enqueue BY DESIGN —
-  // but nothing flags them, so a finished draft can rot for ~a day (PRs
-  // #1345/#1335 — the acorn dogfood blocker — sat green as drafts). This pass
-  // lists drafts older than DRAFT_AGE_HOURS whose visible checks are all green
-  // and, ONCE per PR (idempotent on the comment marker + label), nudges the
-  // author to mark it ready. It never un-drafts or enqueues — that stays a human
-  // decision.
-  const DRAFT_AGE_HOURS = Number(process.env.DRAFT_AGE_HOURS ?? "6");
-  const DRAFT_AGE_MS = DRAFT_AGE_HOURS * 60 * 60 * 1000;
-  const STALE_DRAFT_LABEL = "stale-draft";
-  const DRAFT_MARKER = "<!-- enqueue-bot:stale-draft -->";
-  // Marker-scoped issue-comments lookup, used to dedupe the nag below. This is
-  // the REQUIRED floor — the label alone is NOT reliable: `gh pr edit
-  // --add-label` silently no-ops (the GraphQL updatePullRequest mutation
-  // aborts on a deprecated projectCards field, returning rc=0 with the label
-  // left unapplied — see reference_gh_remove_label_rest_not_pr_edit memory),
-  // so relying on the label to detect "already flagged" let the comment
-  // repost on every single sweep (31x duplicate comments on PR #3111 before
-  // this fix). Always check comment bodies for DRAFT_MARKER regardless of
-  // whether the label stuck.
-  function hasStaleDraftComment(prNumber) {
-    const r = ghMaybe(["api", `repos/${REPO}/issues/${prNumber}/comments`, "--paginate", "-q", ".[].body"]);
-    if (!r.ok) return { found: false, checkFailed: true };
-    return { found: r.stdout.includes(DRAFT_MARKER), checkFailed: false };
-  }
-  const draftFlagged = [];
-  for (const pr of prs) {
-    if (!pr.isDraft) continue;
-    const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
-    if (labels.some((l) => HOLD_LABELS.has(l))) continue; // wip/hold drafts are intentional
-    if (labels.includes(STALE_DRAFT_LABEL)) {
-      draftFlagged.push([pr.number, "already-flagged"]);
-      continue; // idempotent — flagged on a prior sweep
-    }
-    const ageMs = Date.now() - Date.parse(pr.createdAt);
-    if (!Number.isFinite(ageMs) || ageMs < DRAFT_AGE_MS) continue; // too fresh
-    const checks = visibleCheckState(pr.number);
-    if (checks.error || checks.failed.length > 0 || checks.pending.length > 0) continue; // not green
-    // Marker dedupe: skip re-commenting if a prior nag is already on the PR,
-    // even though the label check above just said "not flagged" (label may
-    // have silently failed to apply last time). On a lookup failure, also
-    // skip posting — safer to miss a nag than to spam another duplicate.
-    const existing = hasStaleDraftComment(pr.number);
-    if (existing.found) {
-      draftFlagged.push([pr.number, "already-commented (label was stale — re-applying)"]);
-      // Best-effort: re-apply the label via REST so future sweeps short-circuit
-      // on the cheap label check instead of re-listing comments every time.
-      ghMaybe(["api", `repos/${REPO}/issues/${pr.number}/labels`, "-f", `labels[]=${STALE_DRAFT_LABEL}`]);
-      continue;
-    }
-    if (existing.checkFailed) {
-      draftFlagged.push([pr.number, "comment-lookup-failed — skip-to-be-safe"]);
-      continue;
-    }
-    const ageH = (ageMs / 3_600_000).toFixed(1);
-    if (DRY) {
-      draftFlagged.push([pr.number, `would-flag (green draft ${ageH}h old)`]);
-      continue;
-    }
-    // Post one comment + add the label. Both are guarded so re-running is a
-    // no-op. Label add MUST go via REST — `gh pr edit --add-label` silently
-    // no-ops (see comment on hasStaleDraftComment above).
-    const comment = ghMaybe([
-      "pr",
-      "comment",
-      String(pr.number),
-      "--repo",
-      REPO,
-      "--body",
-      `${DRAFT_MARKER}\nThis PR has been a green draft for ${ageH}h. If it is ready, mark it **Ready for review** so auto-enqueue can pick it up; otherwise add a \`wip\`/\`hold\` label so it stops showing up here.`,
-    ]);
-    const label = ghMaybe(["api", `repos/${REPO}/issues/${pr.number}/labels`, "-f", `labels[]=${STALE_DRAFT_LABEL}`]);
-    const why =
-      comment.ok && label.ok
-        ? `flagged (green draft ${ageH}h)`
-        : `flag-partial (comment=${comment.ok} label=${label.ok})`;
-    draftFlagged.push([pr.number, why]);
-  }
-
   console.log(
     `enqueue-green-prs: ${prs.length} open, ${inQueue.size} already queued, grace=${GRACE_MINUTES}m${DRY ? " (DRY RUN)" : ""}`,
   );
-  for (const [n, why] of draftFlagged) console.log(`  ! #${n} draft ${why}`);
   for (const [n, why] of updated) console.log(`  ~ #${n} ${why}`);
   for (const [n, why] of enqueued) console.log(`  + #${n} ${why}`);
   for (const [n, why] of skipped) console.log(`  - #${n} skip (${why})`);

--- a/tests/issue-1958-no-stale-draft-comments.test.ts
+++ b/tests/issue-1958-no-stale-draft-comments.test.ts
@@ -1,0 +1,18 @@
+// #1958d — intentionally dormant draft PRs must not receive scheduled nags.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const enqueueScript = readFileSync(new URL("../scripts/enqueue-green-prs.mjs", import.meta.url), "utf8");
+const enqueueWorkflow = readFileSync(new URL("../.github/workflows/auto-enqueue.yml", import.meta.url), "utf8");
+
+describe("#1958 auto-enqueue leaves draft PRs silent", () => {
+  it("contains no stale-draft reminder path", () => {
+    expect(enqueueScript).not.toContain("enqueue-bot:stale-draft");
+    expect(enqueueScript).not.toContain("DRAFT_AGE_HOURS");
+  });
+
+  it("does not grant issue-write permission", () => {
+    expect(enqueueWorkflow).not.toMatch(/^\s*issues:\s*write\b/m);
+  });
+});


### PR DESCRIPTION
## Summary

- remove the scheduled stale-draft scan, comment, and label path from auto-enqueue
- stop requesting issue-write permission in the workflow
- stop fetching draft creation timestamps that are no longer used
- add a regression guard that prevents the reminder marker and permission from returning

## Why

The stale-draft notifier repeatedly posts reminders on intentionally dormant pull requests. Draft state is already an explicit instruction not to enqueue, so the scheduler should leave those pull requests silent until an author marks them ready.

## Impact

Auto-enqueue continues to skip draft pull requests and all non-draft queue behavior is unchanged. The bot no longer scans, labels, or comments on drafts.

## Validation

- `node --check scripts/enqueue-green-prs.mjs`
- 27/27 related auto-enqueue tests pass
- `pnpm run typecheck`
- scoped Prettier check
- `git diff --check`
