### PR TITLE
fix(#3535): standalone lane defers top-level init so (start) throws render real signatures (#2860 F3)

### DIFF
--- a/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
+++ b/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
@@ -1,9 +1,9 @@
 ---
 id: 2860
 title: "Umbrella: close the standalone-vs-js-host test262 gap (~20,500 host-free, honest metric #2879/#2360)"
-status: ready
+status: in-progress
 created: 2026-06-30
-updated: 2026-07-17
+updated: 2026-07-23
 priority: high
 feasibility: hard
 model: fable
@@ -13,7 +13,37 @@ area: codegen
 goal: standalone
 sprint: current
 horizon: xl
-related: [2861, 2862, 2863, 2864, 2865, 2866, 2867, 2868, 2872, 2873, 2874, 2875, 2876, 2877, 2878, 2879, 3027, 3169, 3170, 3171, 3172, 3173, 3174, 3175, 3176, 3177]
+assignee: ttraenkler/fable-2860
+related:
+  [
+    2861,
+    2862,
+    2863,
+    2864,
+    2865,
+    2866,
+    2867,
+    2868,
+    2872,
+    2873,
+    2874,
+    2875,
+    2876,
+    2877,
+    2878,
+    2879,
+    3027,
+    3169,
+    3170,
+    3171,
+    3172,
+    3173,
+    3174,
+    3175,
+    3176,
+    3177,
+    3535,
+  ]
 ---
 
 # Umbrella: close the standalone-vs-js-host test262 gap
@@ -67,16 +97,16 @@ can leak a host import AND fail at ToPrimitive); the "pure" column is the count
 where that cluster is the sole blocker (no host-import leak), i.e. the count a
 single fix flips directly.
 
-| # | Cluster | total | pure | tractability | issue |
-| - | ------- | ----- | ---- | ------------ | ----- |
-| 1 | built-in static/proto value read refused (CE) | 882 | 882 | mechanical (glue pattern) | **2861 — done** |
-| 2 | ToPrimitive over built-in exotics + inherited valueOf/toString | 2,039 | 728 | medium (extend `__to_primitive`) | **2862 — wont-fix (superseded)** |
-| 3 | dynamic-shape object/property codegen (`__get_builtin`, `__extern_toLocaleString`) CE | 365 | 365 | medium codegen | **2863 — done** |
-| 4 | sync generators — no standalone carrier (`__gen_*`/`__create_generator`) | 697 | — | hard (new carrier) | **2864 — in-progress** |
-| 5 | async generators — no standalone carrier (`__create_async_generator`) | 986 | — | hard (dep #2864) | **2865 — in-progress** |
-| 6 | Symbol — standalone carrier (`__box_symbol`) | 418 | — | medium-hard | **2866 — in-progress** |
-| 7 | Promise / async microtask — standalone carrier (`Promise_*`, `__make_callback`) | 375 | — | hard | **2867 — in-progress** |
-| 8 | invalid Wasm binary emitted in standalone (correctness) | 523 | 118 | triage-then-fix | **2868 — done** |
+| #   | Cluster                                                                               | total | pure | tractability                     | issue                            |
+| --- | ------------------------------------------------------------------------------------- | ----- | ---- | -------------------------------- | -------------------------------- |
+| 1   | built-in static/proto value read refused (CE)                                         | 882   | 882  | mechanical (glue pattern)        | **2861 — done**                  |
+| 2   | ToPrimitive over built-in exotics + inherited valueOf/toString                        | 2,039 | 728  | medium (extend `__to_primitive`) | **2862 — wont-fix (superseded)** |
+| 3   | dynamic-shape object/property codegen (`__get_builtin`, `__extern_toLocaleString`) CE | 365   | 365  | medium codegen                   | **2863 — done**                  |
+| 4   | sync generators — no standalone carrier (`__gen_*`/`__create_generator`)              | 697   | —    | hard (new carrier)               | **2864 — in-progress**           |
+| 5   | async generators — no standalone carrier (`__create_async_generator`)                 | 986   | —    | hard (dep #2864)                 | **2865 — in-progress**           |
+| 6   | Symbol — standalone carrier (`__box_symbol`)                                          | 418   | —    | medium-hard                      | **2866 — in-progress**           |
+| 7   | Promise / async microtask — standalone carrier (`Promise_*`, `__make_callback`)       | 375   | —    | hard                             | **2867 — in-progress**           |
+| 8   | invalid Wasm binary emitted in standalone (correctness)                               | 523   | 118  | triage-then-fix                  | **2868 — done**                  |
 
 ### Not-yet-issued follow-ons (tracked here)
 
@@ -177,26 +207,27 @@ match) is **12,801** rows. After mapping every existing sub-front, nine
 genuinely-uncovered method-family clusters were sliced (all `sprint: current`,
 `priority: high`, `umbrella: 2860`):
 
-| issue | cluster | measured gap | horizon |
-| ----- | ------- | -----------: | ------- |
-| **3169** | Array.prototype callback HOFs over array-like receivers | 519 | l |
-| **3170** | Array.prototype indexOf/lastIndexOf/includes as-value + array-likes | 125 | m |
-| **3171** | Map/Set/WeakMap/WeakSet receiver brand-check protocol | ~142 (+ share of 113 residual) | m |
-| **3172** | Set-algebra set-like protocol + getOrInsert(Computed) | 120 | m |
-| **3173** | DataView.prototype get\*/set\* spec semantics | 230 | l |
-| **3174** | Date brand checks + ToPrimitive coercion order | 107 | m |
-| **3175** | Number.prototype toString(radix)/toFixed/valueOf | 74 | m |
-| **3176** | JSON.parse/stringify residual (reviver array walk, strictness) | 67 | m |
-| **3177** | TypedArrayConstructors internals + ctor protocols (the #3027 "~350" slice) | 356 | l |
+| issue    | cluster                                                                    |                   measured gap | horizon |
+| -------- | -------------------------------------------------------------------------- | -----------------------------: | ------- |
+| **3169** | Array.prototype callback HOFs over array-like receivers                    |                            519 | l       |
+| **3170** | Array.prototype indexOf/lastIndexOf/includes as-value + array-likes        |                            125 | m       |
+| **3171** | Map/Set/WeakMap/WeakSet receiver brand-check protocol                      | ~142 (+ share of 113 residual) | m       |
+| **3172** | Set-algebra set-like protocol + getOrInsert(Computed)                      |                            120 | m       |
+| **3173** | DataView.prototype get\*/set\* spec semantics                              |                            230 | l       |
+| **3174** | Date brand checks + ToPrimitive coercion order                             |                            107 | m       |
+| **3175** | Number.prototype toString(radix)/toFixed/valueOf                           |                             74 | m       |
+| **3176** | JSON.parse/stringify residual (reviver array walk, strictness)             |                             67 | m       |
+| **3177** | TypedArrayConstructors internals + ctor protocols (the #3027 "~350" slice) |                            356 | l       |
 
 Deliberately NOT sliced (covered or in-flight): `Object/defineProperty(-ies)`
-+ `Object/create` (492 — routes through the in-progress #2992 defineProperties
-MOP + #2984 lane), `Object` statics order/spread (#3155 ready),
-`Function.prototype.bind` residual (63 — fnctor lane #3138/#3139),
-`Array/fromAsync` (#2967 blocked on #3134), Atomics (#3145),
-`Iterator.*` (#3146/#3049), DisposableStack (needs the #2866 Symbol carrier),
-`language/*` (carriers #2864/#2865/#2867 + #2873), annexB residual (~180,
-follow-on candidate after #3069's pattern).
+
+- `Object/create` (492 — routes through the in-progress #2992 defineProperties
+  MOP + #2984 lane), `Object` statics order/spread (#3155 ready),
+  `Function.prototype.bind` residual (63 — fnctor lane #3138/#3139),
+  `Array/fromAsync` (#2967 blocked on #3134), Atomics (#3145),
+  `Iterator.*` (#3146/#3049), DisposableStack (needs the #2866 Symbol carrier),
+  `language/*` (carriers #2864/#2865/#2867 + #2873), annexB residual (~180,
+  follow-on candidate after #3069's pattern).
 
 ## Definition of done (umbrella)
 
@@ -212,10 +243,10 @@ Fresh honest re-measure from tonight's promoted lane baselines
 (`test262-standalone-current.jsonl` @ 2026-07-18 01:08Z vs `test262-current.jsonl`,
 official scope, matched by `file|strict`):
 
-| metric | 2026-06-30 | 2026-07-12 | **2026-07-18** |
-| ------ | ---------: | ---------: | -------------: |
-| host-free standalone official pass | 12,883 | ~13.0k | **24,726** |
-| honest gap (host pass ∧ standalone not-pass) | ~20,500 | 12,801 | **8,228** |
+| metric                                       | 2026-06-30 | 2026-07-12 | **2026-07-18** |
+| -------------------------------------------- | ---------: | ---------: | -------------: |
+| host-free standalone official pass           |     12,883 |     ~13.0k |     **24,726** |
+| honest gap (host pass ∧ standalone not-pass) |    ~20,500 |     12,801 |      **8,228** |
 
 The carrier + method-family work (#3132/#3164/#3302/#3386, #3169–#3177, #3173/#3181,
 #2861/#2863/#2868, …) landed a **~12k-row swing**. The gap is now **8,228**.
@@ -224,22 +255,22 @@ The carrier + method-family work (#3132/#3164/#3302/#3386, #3169–#3177, #3173/
 
 Break the 8,228 gap by `error_category` (from the standalone JSONL rows):
 
-| error_category | rows | note |
-| -------------- | ---: | ---- |
-| **assertion_fail** | **4,079** | host-free binary, WRONG runtime value — the new frontier |
-| host_import_leak | 2,991 | of which `iterator_protocol` = 2,309 → **#3178** sub-umbrella (#3386–#3391) |
-| type_error | 677 | standalone throws / mis-throws TypeError |
-| other | 180 | |
-| illegal_cast | 112 | ref.test-before-cast misses (fold into #2863/#2868 triage) |
-| null_deref | 66 | mostly `__str_flatten`/RegExp (#2935) |
-| wasm_compile | 58 | invalid binary residual (#2878/#3024) |
-| runtime_error / oob / syntax / range / promise | 65 | long tail |
+| error_category                                 |      rows | note                                                                        |
+| ---------------------------------------------- | --------: | --------------------------------------------------------------------------- |
+| **assertion_fail**                             | **4,079** | host-free binary, WRONG runtime value — the new frontier                    |
+| host_import_leak                               |     2,991 | of which `iterator_protocol` = 2,309 → **#3178** sub-umbrella (#3386–#3391) |
+| type_error                                     |       677 | standalone throws / mis-throws TypeError                                    |
+| other                                          |       180 |                                                                             |
+| illegal_cast                                   |       112 | ref.test-before-cast misses (fold into #2863/#2868 triage)                  |
+| null_deref                                     |        66 | mostly `__str_flatten`/RegExp (#2935)                                       |
+| wasm_compile                                   |        58 | invalid binary residual (#2878/#3024)                                       |
+| runtime_error / oob / syntax / range / promise |        65 | long tail                                                                   |
 
 **Read this:** the carriers largely WORKED — `host_import_leak` (2,991, and
 2,309 of it is the already-carved #3178 generator/iterator territory) is no
 longer the dominant blocker. The new #1 lever is **`assertion_fail` (4,079):
 tests that compile host-free in standalone but compute the WRONG VALUE at
-runtime** — standalone-lane runtime *semantic fidelity*, not carrier existence.
+runtime** — standalone-lane runtime _semantic fidelity_, not carrier existence.
 
 ### assertion_fail (4,079) cluster → owning-issue map (coverage is ~complete)
 
@@ -248,18 +279,18 @@ counts are LARGER than each issue's original estimate (scope grew as the metric
 de-masked runtime failures), so this is a **re-scope + re-prioritise** signal,
 not a new-issue signal:
 
-| cluster (assertion_fail rows) | owner | status | orig. est → now |
-| ----------------------------- | ----- | ------ | --------------- |
-| Object/defineProperty+defineProperties (389) | #3022 (default, done) · #2984/#2992 (standalone MOP) | in-progress | 728 → 389 std |
-| TypedArray/prototype (532) | **#2872** | in-progress | 294 → **532** |
-| Array/prototype (418) | #3180 (std HOF) · #3185 (default generics) | ready | ~300 → 418 |
-| String/prototype (282) | **#2875** | in-progress | 159 → **282** |
-| language/expressions+statements (580) | #2873 + carriers | mixed | — |
-| RegExp (223) | #2876 · #2935 (null-deref) | — | 125 → 223 |
-| Iterator/prototype (182) | #3049/#3146 **done** — see NEW-1 below | — | helper *residual* |
-| TypedArrayConstructors (111) | **#3177** | in-progress | 356 → refresh |
-| Promise (110) | #2867 · #3198 (blocked) | in-progress | — |
-| Function (94) · Proxy (63, mostly deferred) · Number (52) · Date (51) · JSON (44) · DataView (36→#3173 done) · Reflect (28) | assorted (see 07-12 groom) | — | — |
+| cluster (assertion_fail rows)                                                                                               | owner                                                | status      | orig. est → now   |
+| --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ----------- | ----------------- |
+| Object/defineProperty+defineProperties (389)                                                                                | #3022 (default, done) · #2984/#2992 (standalone MOP) | in-progress | 728 → 389 std     |
+| TypedArray/prototype (532)                                                                                                  | **#2872**                                            | in-progress | 294 → **532**     |
+| Array/prototype (418)                                                                                                       | #3180 (std HOF) · #3185 (default generics)           | ready       | ~300 → 418        |
+| String/prototype (282)                                                                                                      | **#2875**                                            | in-progress | 159 → **282**     |
+| language/expressions+statements (580)                                                                                       | #2873 + carriers                                     | mixed       | —                 |
+| RegExp (223)                                                                                                                | #2876 · #2935 (null-deref)                           | —           | 125 → 223         |
+| Iterator/prototype (182)                                                                                                    | #3049/#3146 **done** — see NEW-1 below               | —           | helper _residual_ |
+| TypedArrayConstructors (111)                                                                                                | **#3177**                                            | in-progress | 356 → refresh     |
+| Promise (110)                                                                                                               | #2867 · #3198 (blocked)                              | in-progress | —                 |
+| Function (94) · Proxy (63, mostly deferred) · Number (52) · Date (51) · JSON (44) · DataView (36→#3173 done) · Reflect (28) | assorted (see 07-12 groom)                           | —           | —                 |
 
 **Action for tech-lead/PO:** bump the fresh counts into #2872 (→532), #2875
 (→282), #3177, #2984/#2992; #2872 + #2875 are now the two single largest
@@ -286,11 +317,11 @@ defineProperties (27 → #2992), String/proto (20 → #2875), String.raw (12 →
 - **NEW-1 — Iterator.prototype helper OBSERVABLE-SEMANTICS residual (~223).**
   #3049 (map/filter/take/drop/flatMap) and #3146 (zip/concat/from) both landed
   as `done`, yet `built-ins/Iterator/prototype` still shows 182 `assertion_fail`
-  + 41 `type_error` in the gap — the helpers EXIST but diverge on spec
-  observables (abrupt-completion IteratorClose ordering, `this`/brand
-  TypeErrors, counter/limit edge values). A spec-fidelity follow-on, distinct
-  from helper existence. Recommend a `#31xx` child once #2872/#2875 land (Symbol
-  `@@iterator`/`@@toStringTag` fidelity may share root cause with #2866).
+  - 41 `type_error` in the gap — the helpers EXIST but diverge on spec
+    observables (abrupt-completion IteratorClose ordering, `this`/brand
+    TypeErrors, counter/limit edge values). A spec-fidelity follow-on, distinct
+    from helper existence. Recommend a `#31xx` child once #2872/#2875 land (Symbol
+    `@@iterator`/`@@toStringTag` fidelity may share root cause with #2866).
 - **NEW-2 — URI carrier ROUTING regression → filed as #3401.** #2500 (native
   `decodeURI`/`encodeURI`/`decodeURIComponent`/`encodeURIComponent`) is `done`,
   yet **48 official `built-ins/{decode,encode}URI*` conformance tests still leak
@@ -307,6 +338,7 @@ levers (#2872/#2875/#3177/#2984-2992), and carved exactly one genuinely-new
 slice (#3401). No duplicate children were minted (verified each cluster's
 pointer against an existing owner first — the `avoid-code-bloat-deduplicate`
 memory applied to issues).
+
 ## Implementation Plan (Fable, 2026-07-18) — fresh census @ main 9d216ada + the priority ladder
 
 > Measured from the 2026-07-18 baselines-repo refresh (commit `5c6d3092`,
@@ -320,14 +352,14 @@ memory applied to issues).
 
 ### The gap, by mechanism (2026-07-18)
 
-| Rows | Mechanism | Owner(s) |
-| ---: | --- | --- |
-| 2,991 | `compile_error: host_import_leak` | the carrier track (below) |
-| 4,079 | `fail: assertion_fail` | behavioral clusters (below) |
-| 677 | `fail: type_error` | behavioral clusters |
-| 112 / 66 | `illegal_cast` / `null_deref` | mostly inside carrier machinery + #2935 |
-| 261 | `compile_error: other/wasm/runtime` | #2878-class triage residual |
-| 45 | timeout/syntax/oob/misc | long tail |
+|     Rows | Mechanism                           | Owner(s)                                |
+| -------: | ----------------------------------- | --------------------------------------- |
+|    2,991 | `compile_error: host_import_leak`   | the carrier track (below)               |
+|    4,079 | `fail: assertion_fail`              | behavioral clusters (below)             |
+|      677 | `fail: type_error`                  | behavioral clusters                     |
+| 112 / 66 | `illegal_cast` / `null_deref`       | mostly inside carrier machinery + #2935 |
+|      261 | `compile_error: other/wasm/runtime` | #2878-class triage residual             |
+|       45 | timeout/syntax/oob/misc             | long tail                               |
 
 **Leak half (2,991), by leaked import:** generator family
 (`__create_generator` 1,672 + `__gen_next` 106 + `__create_async_generator`
@@ -340,18 +372,18 @@ Slice B — spec'd 2026-07-18), `Set_constructor` 17, misc ≤17 each.
 
 **Behavioral half, by cluster (assertion_fail + type_error combined):**
 
-| Rows | Cluster | Owner |
-| ---: | --- | --- |
-| ~960 | TypedArray (`TypedArray/prototype` 532+63, `TypedArrayConstructors` 68+38+30, DataView 33+, ArrayBuffer 40) | #3177 / #3173 / #2872 |
-| ~550 | property model (`Object/defineProperty` 247 + `defineProperties` 142+27 + `create` 55+14 + `Object/prototype` 62) | #3251 S2/S3 (PR #3327 in flight) + #739 + #2992/#2984 |
-| ~512 | `Array/prototype` behavioral (418+94) | #3169 / #3170 + #3251 read-side |
-| ~350 | String (`String/prototype` 282+20 + annexB/String 46) | #2875 |
-| ~223 | `Iterator/prototype` (182+41) | #3146 / #3049 |
-| ~212 | class semantics (`language/*/class` 106+106) | #2873 + the #2963/#3037 method-identity residue |
-| ~169 | `RegExp/prototype` | #2876 / #2935 |
-| ~136 | annexB eval-code type_errors (123) + direct eval (13) | eval Tier-0 sound-bail residue (#1102-adjacent; see the ladder doc §2 bail list) |
-| ~76 | `Function/prototype` (61+15) | #3138 / #3139 bind residual |
-| ~109 | `assert.sameValue(rest.a, undefined)`-signature family (44+31+33 shapes) | the value-rep trio — #2106 numeric-carrier leg + #745 (see their 2026-07-18 plans) |
+| Rows | Cluster                                                                                                           | Owner                                                                              |
+| ---: | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| ~960 | TypedArray (`TypedArray/prototype` 532+63, `TypedArrayConstructors` 68+38+30, DataView 33+, ArrayBuffer 40)       | #3177 / #3173 / #2872                                                              |
+| ~550 | property model (`Object/defineProperty` 247 + `defineProperties` 142+27 + `create` 55+14 + `Object/prototype` 62) | #3251 S2/S3 (PR #3327 in flight) + #739 + #2992/#2984                              |
+| ~512 | `Array/prototype` behavioral (418+94)                                                                             | #3169 / #3170 + #3251 read-side                                                    |
+| ~350 | String (`String/prototype` 282+20 + annexB/String 46)                                                             | #2875                                                                              |
+| ~223 | `Iterator/prototype` (182+41)                                                                                     | #3146 / #3049                                                                      |
+| ~212 | class semantics (`language/*/class` 106+106)                                                                      | #2873 + the #2963/#3037 method-identity residue                                    |
+| ~169 | `RegExp/prototype`                                                                                                | #2876 / #2935                                                                      |
+| ~136 | annexB eval-code type_errors (123) + direct eval (13)                                                             | eval Tier-0 sound-bail residue (#1102-adjacent; see the ladder doc §2 bail list)   |
+|  ~76 | `Function/prototype` (61+15)                                                                                      | #3138 / #3139 bind residual                                                        |
+| ~109 | `assert.sameValue(rest.a, undefined)`-signature family (44+31+33 shapes)                                          | the value-rep trio — #2106 numeric-carrier leg + #745 (see their 2026-07-18 plans) |
 
 ### Priority ladder (order of expected yield per unit work)
 
@@ -361,7 +393,7 @@ Slice B — spec'd 2026-07-18), `Set_constructor` 17, misc ≤17 each.
 2. **TypedArray family** (#3177 → #3173 → #2872) — ~960 rows; #3177's 356
    estimate from 07-12 has GROWN in share as other clusters closed.
 3. **Property model** — ~550 rows riding the in-flight #3251 (S2 write-side
-   + S3 ArraySetLength are the spec'd next slices) + #739.
+   - S3 ArraySetLength are the spec'd next slices) + #739.
 4. **Array behavioral** (#3169/#3170) — ~512; partially overlaps 3 (many
    defineProperty-on-array rows count in both — de-dup at claim time).
 5. **String** (#2875) ~350, **Iterator** (#3146/#3049) ~223, **class**
@@ -393,3 +425,29 @@ a pinned commit), filter `scope_official`, key `file|strict`, and group as
 above. Re-run at each window boundary; the ladder re-orders on measured
 counts, never on stale estimates (this census corrected three of the 07-12
 weights).
+
+## 2026-07-23 — F3 observability unblocker landed (#3535, fable-2860)
+
+The 2026-07-19 lane-parity investigation (Cluster B, `.tmp/parity-findings.md`)
+found the single biggest triage blocker was not a feature gap but MASKING:
+under the standalone lane's `(start)`-init model every top-level throw — i.e.
+every runtime failure in original-harness mode — surfaced from
+`WebAssembly.instantiate` with `instance === null`, making the #2962 native
+exception render unreachable and collapsing **8,610 baseline rows** onto the
+opaque `wasm exception during module init` label.
+
+**#3535 (done)** makes the standalone lane join the host lane's
+`deferTopLevelInit` rule (worker + both local-runner arms). Measured
+(verify-first, main @ aa203fdc): 152-row stratified masked sample → 0 verdict
+flips, 152/152 un-masked; all 7 runtime-negative masked rows probed
+exhaustively → 6 honest fail→pass; 101-row stratified pass sample → 0
+pass→fail (floor-safe). Un-masked signatures now route the residual to real
+owners — top revealed clusters: Temporal deferred-feature refs (~15%),
+`Test262Error: obj should have an own property …` (the #3468 function-object
+own-property residual, ~11%), `TypeError: Cannot convert undefined or null to
+object`, positional null-deref TypeErrors, eval-shim #2928 refusals.
+
+**Next for this umbrella**: after the next baseline promote re-labels the
+8,610 rows, re-run the error-signature census on the standalone lane and
+re-weight the priority ladder — the de-masked buckets land in the EXISTING
+children (no new slices expected beyond what the ladder already tracks).

--- a/plan/issues/3535-standalone-start-throw-unrenderable.md
+++ b/plan/issues/3535-standalone-start-throw-unrenderable.md
@@ -1,0 +1,121 @@
+---
+id: 3535
+title: "Standalone (start) top-level throws unrenderable (instance===null) — 8,610 baseline rows masked as 'wasm exception during module init'"
+status: done
+created: 2026-07-23
+updated: 2026-07-23
+completed: 2026-07-23
+priority: high
+feasibility: medium
+task_type: bugfix
+area: test262-runner
+goal: standalone
+sprint: current
+horizon: s
+umbrella: 2860
+assignee: ttraenkler/fable-2860
+related: [2860, 2877, 2962, 3049, 3123, 3468, 3417, 3439]
+files:
+  - scripts/test262-worker.mjs
+  - tests/test262-runner.ts
+  - tests/issue-3535.test.ts
+---
+
+# Standalone `(start)` top-level throws render as one opaque label
+
+## Problem (the F3 observability blocker under #2860)
+
+The standalone test262 lane compiled every test with the wasm `(start)`-section
+init model. In original-harness mode ALL test code is top-level, so **every
+runtime failure** was a top-level throw that surfaced out of
+`WebAssembly.instantiate` — with `instance === null`. The #2962 native
+exception-render path (`__exn_render_prepare` / `__exn_render_char`) needs a
+live instance, so it was structurally unreachable for these throws, and
+`extractWasmExceptionMessage(err, null)` collapsed **8,610 heterogeneous
+standalone failures** (current `test262-standalone-current.jsonl`) onto the one
+opaque string `wasm exception during module init`.
+
+This was harness-only masking, not a codegen bug: a stratified 152-sample from
+the 3-agent parity investigation (`.tmp/parity-findings.md`, Cluster B) found
+**0 CompileError / 0 LinkError** — every binary is valid Wasm whose top-level
+code runs and throws for dozens of independent, real, pre-existing reasons.
+Until this landed, standalone triage worked off garbage: #3417 measured the
+bucket at 7,063 rows and could only cite it as "diffuse"; #3439's report gate
+needed a dedicated opaque-residual bucket to swallow it.
+
+## Fix
+
+The standalone lane joins the host lane's `deferTopLevelInit` rule (#3049 C1 /
+#3123): compile with `deferTopLevelInit: true`, so `__module_init` is exported
+instead of wired to `(start)`; the existing exec paths already call the export
+right after `setExports` (feature-detected, both runners). A top-level throw
+now happens at the explicit `__module_init()` call with a live instance and
+renders its real signature through the module's own #2962 exports.
+
+- `scripts/test262-worker.mjs` `doCompile`: defer rule becomes
+  `(target && target !== "standalone") || (!originalHarness && inferModuleStrictArguments) ? {} : { deferTopLevelInit: true }`
+  — wasi/linear keep their `_start`/`(start)` models; the project-runner
+  module-goal carve-out (#2835/#2839 dup-`__module_init` guard) is preserved.
+- `tests/test262-runner.ts` `runOriginalVariant` + `runTest262File`
+  (baseline-validator lane): same rule, same carve-out. Exec paths unchanged —
+  both already call `__module_init` when exported.
+- `scripts/compiler-fork-worker.mjs` needs no change (host-lane only).
+- Compiler needs no change: `exportModuleInit = ctx.deferTopLevelInit &&
+!ctx.wasi` (src/codegen/declarations.ts) already covers standalone.
+
+No verdict-logic change: the same scoring rule (runtime-negative → pass, else
+honest fail) is re-hosted from the instantiate-catch to the `__module_init`
+call site — the same oracle-version-exempt precedent as the #3123 host-lane
+arm. No ORACLE_VERSION bump needed.
+
+## Measured impact (verify-first, 2026-07-23, main @ aa203fdc)
+
+- **152-row stratified sample of the 8,610 masked rows: 0 verdict flips;
+  152/152 un-masked** (mode A all opaque, mode B zero opaque). Revealed
+  signatures are exactly the triage signal #2860 needs — top clusters:
+  `ReferenceError: Temporal is not defined` (23, deferred-feature),
+  `Test262Error: obj should have an own property m` (14+, the #3468
+  function-object own-property residual), `TypeError: Cannot convert undefined
+or null to object` (13), positional null-deref TypeErrors, eval-shim #2928
+  refusals (7).
+- **Runtime-negative masked subset measured EXHAUSTIVELY (all 7 rows): 6 flip
+  fail→pass** — the thrown error TYPE becomes observable via the exported tag
+  with a live instance and now correctly matches. Max 7 corpus-wide flips,
+  all honest, all upward.
+- **100-row stratified sample of the 29,410 currently-passing rows: 0
+  pass→fail flips** (see `## Floor safety` below) — defer is
+  semantics-neutral for passing tests, so the standalone high-water floor
+  (`check-standalone-highwater.mjs`, tolerance 50) is safe.
+- End-to-end through the real edited worker (IPC drive): masked rows return
+  `fail  Test262Error: obj should have an own property a` etc.; runtime
+  negatives return `pass`.
+
+## Floor safety
+
+Deferring init changes only WHERE init runs (explicit export call vs `(start)`
+during instantiate) — nothing observable happens between instantiate and the
+`__module_init()` call in either runner. Binary content is identical except
+the export entry and start-section removal. The `__in_module_init` flag
+(#2800) is set/cleared inside `__module_init` itself, so its semantics are
+model-independent. Non-test262 embedders are untouched — standalone WITHOUT
+`deferTopLevelInit` keeps the `(start)` model (pinned by a test).
+
+## Why this is 0-flip by design but still high-value
+
+It converts one 8,610-row opaque bucket into honest per-row signatures that
+distribute across the existing #2860 children (Temporal-class deferred
+features, #3468 own-property residuals, null-deref substrate, eval #2928,
+annexB methods, defineProperty #1906 …). Every subsequent standalone fix can
+now be measured against real signatures instead of an undifferentiated blob.
+The ~6-7 runtime-negative flips and any baseline-lag drift (~160 rows already
+green on HEAD per the parity findings) surface as small upward motion on the
+next promote.
+
+## Test plan
+
+- `tests/issue-3535.test.ts` — pins the compiler contract end to end:
+  standalone+defer exports `__module_init`, instantiate does NOT throw, the
+  init throw renders "TypeError: boom" via `__exn_render_prepare`/`__exn_render_char`;
+  standalone WITHOUT defer keeps `(start)` (embedder model unchanged); a
+  structural drift-guard on the worker's lane rule.
+- CI: standalone matrix + `merge_group` standalone floor validate at 43k scale.

--- a/scripts/test262-worker.mjs
+++ b/scripts/test262-worker.mjs
@@ -1080,12 +1080,33 @@ async function doCompile(
   // section, and the exec path below calls it right after `setExports` so
   // top-level code runs against a fully-wired runtime. Aligned with
   // compiler-fork-worker.mjs + tests/test262-runner.ts (#1251 both-paths
-  // rule). Standalone/wasi/linear targets keep their own `_start` init model.
+  // rule). Wasi/linear targets keep their own `_start` init model.
   // compileMulti fixture graphs follow the same host rule after #3505: its
   // progressively accumulated dependency-order initializers retain only the
   // final `__module_init` export, so the graph can be wired before that one
   // initializer runs without producing duplicate Wasm exports.
-  const deferOpt = target || (!originalHarness && inferModuleStrictArguments) ? {} : { deferTopLevelInit: true };
+  //
+  // (#2860 F3) The STANDALONE lane joins the defer rule. Under the `(start)`
+  // model a top-level throw — which in originalHarness mode is EVERY runtime
+  // failure, since all test code is top-level — surfaces out of
+  // `WebAssembly.instantiate` with `instance === null`, so the #2962 native
+  // exception-render path (`__exn_render_prepare`/`__exn_render_char`, which
+  // needs a live instance) is unreachable and ~8,600 heterogeneous standalone
+  // failures collapse onto the one opaque "wasm exception during module init"
+  // label. Deferring init makes the throw happen at the explicit
+  // `__module_init()` call below, with a live instance, so the real failure
+  // signature (Test262Error message, TypeError, …) is rendered. Verdicts are
+  // unchanged (same scoring rule, richer error text); the only measured flips
+  // are ≤7 corpus-wide runtime-negative tests whose thrown error TYPE becomes
+  // observable via the tag and now correctly scores pass.
+  // oracle-version-exempt: same re-hosting exemption as the #3123 host-lane
+  // arm below — the EXISTING instantiate-throw classification moves to the
+  // explicit __module_init call site; the scoring rule is byte-identical, so
+  // rows are re-LABELLED (error text), not re-scored by policy.
+  const deferOpt =
+    (target && target !== "standalone") || (!originalHarness && inferModuleStrictArguments)
+      ? {}
+      : { deferTopLevelInit: true };
   if (hasFixtureGraph(fixtureFiles)) {
     if (!originalHarness || typeof entryFile !== "string" || entryFile.length === 0) {
       throw new Error("fixture graph requires an original-harness entryFile");

--- a/tests/issue-3535.test.ts
+++ b/tests/issue-3535.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #3535 (#2860 F3) — standalone `(start)` top-level throws were unrenderable.
+ *
+ * Under the `(start)`-section init model, a top-level throw in a
+ * `--target standalone` module surfaces out of `WebAssembly.instantiate`
+ * with `instance === null`, so the #2962 native exception-render path
+ * (`__exn_render_prepare` / `__exn_render_char`, which needs a live
+ * instance) is unreachable and every runtime failure collapses onto the
+ * opaque "wasm exception during module init" label (~8,600 baseline rows).
+ *
+ * The fix: the standalone test262 lane compiles with
+ * `deferTopLevelInit: true` (same rule the host lane adopted in #3049 C1 /
+ * #3123): `__module_init` is exported instead of wired to `(start)`, the
+ * runner instantiates, then calls it explicitly — a top-level throw now
+ * happens with a live instance and renders its real signature.
+ *
+ * This test pins the compiler contract the fix depends on, end to end:
+ *   1. standalone + deferTopLevelInit emits a host-free binary that
+ *      EXPORTS `__module_init` and does NOT run top-level code at
+ *      instantiate time;
+ *   2. calling `__module_init()` raises the top-level throw as a
+ *      `WebAssembly.Exception` whose payload renders through the module's
+ *      own `__exn_render_prepare`/`__exn_render_char` exports to the real
+ *      error text ("TypeError: boom"), not an opaque label.
+ * Plus a structural drift-guard on the worker's lane rule.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// NOTE: not a bare `throw new TypeError("boom")` — a throw-only top level is
+// currently dropped entirely in standalone (#3468 "Bug 2": empty module, no
+// init), which would vacuously pass/fail these assertions. The conditional
+// throw over a live binding survives codegen and provably runs.
+const THROWING_SOURCE = 'var obj = {};\nif (!obj.m) { throw new TypeError("boom"); }\nvar keep = obj;\n';
+
+describe("#3535 standalone deferTopLevelInit renders top-level throws (#2860 F3)", () => {
+  it("defers init to an exported __module_init and renders the real throw signature", async () => {
+    const result = await compile(THROWING_SOURCE, {
+      allowJs: true,
+      fileName: "test.js",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+      deferTopLevelInit: true,
+    });
+    expect(result.success).toBe(true);
+    // Host-free: the standalone #2961 gate must still hold under defer.
+    expect(result.imports).toHaveLength(0);
+
+    const importObj = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown>;
+    // (1) Instantiate must NOT throw — top-level code is deferred, not in (start).
+    const { instance } = await WebAssembly.instantiate(result.binary, importObj as WebAssembly.Imports);
+    const exports = instance.exports as Record<string, unknown>;
+    const moduleInit = exports.__module_init;
+    expect(typeof moduleInit).toBe("function");
+
+    // (2) The explicit init call raises the throw with a LIVE instance…
+    let thrown: unknown;
+    try {
+      (moduleInit as () => void)();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(WebAssembly.Exception);
+
+    // …so the #2962 render path is reachable and yields the real signature.
+    const tag = (exports.__exn_tag ?? exports.__tag) as WebAssembly.Tag;
+    expect(tag).toBeDefined();
+    const payload = (thrown as WebAssembly.Exception).getArg(tag, 0);
+    const prep = exports.__exn_render_prepare as (p: unknown) => number;
+    const chr = exports.__exn_render_char as (i: number) => number;
+    expect(typeof prep).toBe("function");
+    expect(typeof chr).toBe("function");
+    const len = prep(payload);
+    expect(len).toBeGreaterThan(0);
+    let rendered = "";
+    for (let i = 0; i < len; i++) rendered += String.fromCharCode(chr(i));
+    expect(rendered).toContain("TypeError");
+    expect(rendered).toContain("boom");
+  });
+
+  it("standalone without deferTopLevelInit keeps the (start) model (non-test262 embedders unchanged)", async () => {
+    const result = await compile(THROWING_SOURCE, {
+      allowJs: true,
+      fileName: "test.js",
+      skipSemanticDiagnostics: true,
+      target: "standalone",
+    });
+    expect(result.success).toBe(true);
+    const importObj = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown>;
+    let instantiateThrew = false;
+    try {
+      await WebAssembly.instantiate(result.binary, importObj as WebAssembly.Imports);
+    } catch {
+      instantiateThrew = true;
+    }
+    expect(instantiateThrew).toBe(true);
+  });
+
+  it("worker lane rule: standalone joins the deferTopLevelInit arm (drift guard)", () => {
+    const worker = readFileSync("scripts/test262-worker.mjs", "utf8");
+    // The doCompile defer rule must exclude only NON-standalone targets
+    // (wasi/linear) from the defer arm — i.e. standalone defers like host.
+    expect(worker).toContain('(target && target !== "standalone") || (!originalHarness && inferModuleStrictArguments)');
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -4159,7 +4159,16 @@ async function runOriginalHarnessVariant(
         emitWat: false,
         skipSemanticDiagnostics: true,
         inferModuleStrictArguments: meta.flags?.includes("module") === true,
-        ...(target ? { target } : { deferTopLevelInit: true }),
+        // (#2860 F3) Standalone joins the host lane's deferTopLevelInit rule
+        // (mirrors scripts/test262-worker.mjs doCompile): under the `(start)`
+        // model every top-level throw — i.e. every runtime failure in
+        // original-harness mode — surfaced from WebAssembly.instantiate with
+        // instance === null, making the #2962 native exception render
+        // unreachable and collapsing ~8,600 standalone failures onto the
+        // opaque "wasm exception during module init" label. The exec path
+        // below already calls the exported __module_init after setExports.
+        ...(target ? { target } : {}),
+        ...(target === undefined || target === "standalone" ? { deferTopLevelInit: true } : {}),
       });
     } catch (error) {
       compileMs = performance.now() - compileStarted;
@@ -4539,14 +4548,21 @@ export async function runSyntheticTest262File(
       // `__module_init`, no wasm `(start)` section) so top-level code runs
       // AFTER `setExports` has wired the runtime — aligned with
       // `scripts/compiler-fork-worker.mjs` (#1251 both-paths rule). The
-      // standalone/wasi lane keeps its own `_start` model and is untouched.
+      // wasi/linear lanes keep their own `_start` model and are untouched.
+      // (#2860 F3) The STANDALONE lane joins the defer rule (mirrors the
+      // worker's doCompile): under `(start)` a top-level throw surfaced from
+      // instantiate with instance === null, so the #2962 native exception
+      // render was unreachable and standalone failures collapsed onto the
+      // opaque "wasm exception during module init" label. The exec path
+      // below already calls the exported __module_init after setExports.
       // MODULE-GOAL tests are EXCLUDED: the multi-module (FIXTURE) link
       // already synthesizes per-module init plumbing, and adding the
       // deferred-export flag there emitted a SECOND `__module_init` export in
       // one binary — V8 rejects it ("Duplicate export name '__module_init'"),
       // which is exactly the 6-file `language/module-code/*` regression that
       // parked the stack PR #2835/#2839 in the merge queue.
-      ...(target ? { target } : moduleGoal ? {} : { deferTopLevelInit: true }),
+      ...(target ? { target } : {}),
+      ...(moduleGoal || (target !== undefined && target !== "standalone") ? {} : { deferTopLevelInit: true }),
       // #1251: align with the sharded runner — both `scripts/compiler-fork-worker.mjs`
       // (the production path that records the committed JSONL) and `tests/test262-vitest.test.ts`
       // FIXTURE multi-compile pass `skipSemanticDiagnostics: true`. Without this flag,


### PR DESCRIPTION
## What

The standalone test262 lane joins the host lane's `deferTopLevelInit` rule (#3049 C1 / #3123). Under the `(start)`-init model every standalone runtime failure — all test code is top-level in original-harness mode — surfaced from `WebAssembly.instantiate` with `instance === null`, making the #2962 native exception-render path unreachable. **8,610 baseline rows** collapsed onto the one opaque label `wasm exception during module init`, so all standalone triage under #2860 worked off garbage.

Now the binary exports `__module_init` (no `(start)` section), the existing exec paths call it right after `setExports`, and a top-level throw renders its real signature (`Test262Error: obj should have an own property m`, `TypeError: Cannot convert undefined or null to object`, …) through the module's own `__exn_render_prepare`/`__exn_render_char` exports.

## Changes

- `scripts/test262-worker.mjs` `doCompile`: defer rule now excludes only wasi/linear from the defer arm; the project-runner module-goal carve-out (#2835/#2839 dup-`__module_init` guard) is preserved. In-diff `oracle-version-exempt:` (same re-hosting precedent as the #3123 host arm — scoring rule byte-identical, rows re-labelled not re-scored; `check-verdict-oracle-bump` passes).
- `tests/test262-runner.ts` `runOriginalVariant` + `runTest262File` (baseline-validator lane): same rule. Exec paths unchanged — both already call `__module_init` feature-detected.
- Compiler unchanged (`exportModuleInit = deferTopLevelInit && !wasi` already covers standalone); `compiler-fork-worker.mjs` unchanged (host-only). Non-test262 embedders keep the `(start)` model (pinned by test).
- `tests/issue-3535.test.ts`: end-to-end contract + worker drift guard.
- Issues: new child `plan/issues/3535-*.md` (done), #2860 umbrella F3 note.

## Measured (verify-first, main @ aa203fdc)

| population | sample | result |
| --- | --- | --- |
| masked rows (8,610) | 152 stratified | **0 verdict flips, 152/152 un-masked** |
| runtime-negative masked | all 7 (exhaustive) | **6 honest fail→pass** (thrown error TYPE now observable via tag) |
| currently-passing rows (29,410) | 101 stratified | **0 pass→fail** (standalone floor safe, tolerance 50) |

End-to-end through the real edited worker (IPC): masked rows return honest signatures; runtime negatives return pass.

## Expected CI effect

Standalone lane: ~8.6k rows change **error text only** (fail→fail re-label), ≤7 fail→pass, 0 pass→fail by measurement; host/wasi/linear lanes byte-identical. This is the #2860 observability unblocker — the de-masked signatures route the residual to the existing children (#3468 own-property residuals, Temporal deferred, eval #2928, null-deref substrate, …).

Refs #2860, #3535. Supersedes the masking half of #2877's diagnosis; complements #3417/#3439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb