### PR TITLE
fix(#3534, #3533): never retro-narrow closure-value bindings — box on store

### DIFF
--- a/plan/issues/3533-class-field-function-value-invalid-wasm.md
+++ b/plan/issues/3533-class-field-function-value-invalid-wasm.md
@@ -1,0 +1,123 @@
+---
+id: 3533
+title: "codegen: class field initialized to a function value (`c = fn`) emits invalid Wasm — closure-value read reports externref but stores a raw ref"
+status: done
+sprint: current
+assignee: ttraenkler/fable-3534
+created: 2026-07-22
+updated: 2026-07-23
+completed: 2026-07-23
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: codegen-correctness
+goal: correctness
+parent: 3024
+related: [3024, 3534]
+---
+
+# #3533 — class field = function value → invalid Wasm (closure-value read desync)
+
+**Parent:** #3024 (default-lane invalid-Wasm residual). **Distinct root cause**
+from #3024's 68-file `Function.prototype.toString` cluster (that one is the
+funcIdx/closure-type-index SHIFT family, layout-fragile, owned by sr-3024 in
+`calls-closures.ts` `compileClosureCall`). This one is **non-layout-fragile**
+(persists with an export) and lives on the closure-value **READ** path —
+verified disjoint from sr-3024's fix (its repro still fails with sr-3024's fix
+applied).
+
+## Problem (34-file cluster)
+
+A class field initialized to a function value emits a module that fails
+validation at instantiate:
+
+```ts
+const fn = function () {};
+class C {
+  c = fn;
+} // C_init: struct.set[1] expected externref, found global.get of type (ref null N)
+```
+
+The 34 affected test262 files are all
+`language/expressions/class/elements/*-literal-names.js` (regular / static /
+gen / async-gen / method / getter / setter field definitions whose literal
+field is initialized to a function const), harvested from the current-main
+default-lane invalid-Wasm sweep.
+
+## Root cause (global-type PHASE-ORDERING desync on the SHARED `$__mod_fn` global)
+
+Refined by instrumentation (`CF_DEBUG` at the field-init + the module-global
+read + the emitted-instruction/global-type dump):
+
+For a module-global function const (`const fn = function(){}`), the binding gets
+a promoted module global `$__mod_<name>`. That global is **declared `externref`**
+first (its closure struct type is not yet known at declaration time). The class
+field-init compiles `c = fn` while the global is still `externref`, so the read
+correctly emits `global.get $__mod_fn` and correctly reports `externref`
+(`valTypesMatch(externref, externref-field)` == true → no coercion) — **valid at
+read time**. LATER, when the actual closure is assigned in `__module_init`
+(`ref.func; struct.new N; global.set`), the global's type is **narrowed
+`externref` → `(ref null N)`** to match the stored closure. That narrowing
+**retroactively invalidates the already-emitted `global.get`** in `C_init`: it
+now loads a `(ref null N)` where `struct.set` (externref field) expects
+externref → invalid Wasm.
+
+Verified timeline: at field-init compile time `ctx.mod.globals[$__mod_fn].type`
+== `externref`; in the final module it is `(ref null N)`.
+
+## Why this is NOT cleanly disjoint from sr-3024 (guardrail trip)
+
+The `$__mod_fn` global is **read by BOTH**: (a) closure-VALUE reads (want
+`externref` — this bug), and (b) `fn()` CALLS via `compileClosureCall`
+(`calls-closures.ts`, **sr-3024's**), which read the raw `(ref null N)` to
+`call_ref`. Any fix that touches `$__mod_fn`'s type or store — keep it externref
++ box the store (breaks the call read), or keep it `(ref null N)` + box at every
+value-read (needs the read to see the FINAL type, i.e. a phase-ordering/post-pass
+change) — is entangled with sr-3024's call path. A field-init/struct.set-only fix
+is impossible because the global still looks `externref` at field-init time; the
+desync only exists after finalization.
+
+Per the coordination guardrail (fix must not change a closure identifier's global
+type / must stay disjoint from the call path), this is escalated to sr-3024 for a
+joint approach — most likely: declare `$__mod_<name>` as its closure type up-front
+(or a deferred re-coercion post-pass) so value-reads box and calls read the raw
+ref consistently.
+
+## Acceptance criteria
+
+- The 34 `class/elements/*-literal-names.js` files flip from invalid-Wasm
+  (`struct.set expected externref, found ref`) to valid (pass or a distinct
+  semantic result — never invalid Wasm).
+- Host/gc mode byte-unchanged for code that does not read a function value into
+  an externref context.
+- No new invalid-Wasm signatures; no default-lane regression.
+
+---
+
+## Resolution (fable-3534, 2026-07-23) — fixed by #3534 step 2 (option a)
+
+Resolved by the unified closure-value representation fix (see #3534's
+implementation notes for the full mechanism). Exactly as this issue's root
+cause section predicted, the fix is at the STORE side, not the read side:
+
+- `$__mod_<name>` is **never retro-narrowed** — it stays `externref` for its
+  whole lifetime (A1).
+- The `__module_init` store **boxes on store** (`extern.convert_any` of the
+  precise closure struct, A2).
+- The entanglement concern ("keep it externref + box the store breaks the call
+  read") did not materialize: `compileClosureCall`'s module-global arm
+  LIVE-reads `globalDef.type` and already has a guarded externref arm
+  (`any.convert_extern` + guarded cast to the lifted self carrier), which now
+  always fires for closure globals. The local binding keeps the precise type,
+  so in-function calls keep the precise-ref arm.
+
+Measured (gc lane): the 34-file
+`language/expressions/class/elements/*-literal-names.js` cluster goes
+**15 → 30 pass (+15, 0 lost)**; the `struct.set expected externref, found
+(ref null N)` invalid-Wasm signature is eliminated (0 occurrences). The 4
+residual fails are async-gen semantics (distinct family). The minimal repro
+(`const fn = function(){}; class C { c = fn; }`) flips INVALID → measured
+runtime PASS. Guard: `tests/issue-3534-closure-value-representation.test.ts`.

--- a/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
+++ b/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
@@ -16,6 +16,8 @@ area: codegen
 language_feature: closures
 goal: correctness
 related: [3024, 3533, 2873, 3540]
+loc-budget-allow:
+  - src/codegen/statements/variables.ts
 ---
 
 # #3534 — matcher-invoking `Function.prototype.toString` files trap at runtime (construct-site funcref-cell RTT desync)
@@ -341,3 +343,12 @@ still green.
 - **#3540**: the fn-stringification gap dominating the residual toString fails.
 - `var_reassign_call` (module `let f = …; f = …; f()` returns the FIRST value)
   — assignment-path sibling, pre-existing.
+
+## LOC-budget allowance note
+
+`variables.ts` +58 lines (mostly rationale comments on the two new arms). The
+declaration path is where the retro-narrow lived, so the fix belongs there;
+the file now carries THREE copies of the null-guarded cell write-through
+pattern (#1177/#3396/this) — extracting a shared `emitBoxedCellInitStore`
+helper is a clean consolidation-plan follow-up, deliberately not bundled into
+this core-codegen PR.

--- a/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
+++ b/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
@@ -1,10 +1,12 @@
 ---
 id: 3534
 title: "codegen: mutually-recursive const-closure funcref-cell RTT desync — matcher-invoking Function.prototype.toString files trap (illegal cast) at construct site"
-status: ready
+status: done
 sprint: current
+assignee: ttraenkler/fable-3534
 created: 2026-07-22
-updated: 2026-07-22
+updated: 2026-07-23
+completed: 2026-07-23
 priority: medium
 horizon: l
 feasibility: hard
@@ -13,7 +15,7 @@ task_type: bugfix
 area: codegen
 language_feature: closures
 goal: correctness
-related: [3024, 3533, 2873]
+related: [3024, 3533, 2873, 3540]
 ---
 
 # #3534 — matcher-invoking `Function.prototype.toString` files trap at runtime (construct-site funcref-cell RTT desync)
@@ -211,3 +213,131 @@ serialized step-list above (each step its own full-CI PR), but given the
 core-representation risk a **design partner / architect review on step 2's
 consumer-cast audit** would de-risk it. Not a one-shot. #3533 stays `blocked-on`
 this until step 2 lands.
+
+---
+
+## Step 2 implementation notes (fable-3534, 2026-07-23) — root cause REFUTES the RTT hypothesis
+
+### What the trap actually was (instrumented, not hypothesized)
+
+The design plan (and the consumer-cast audit's A3 row) hypothesized a
+funcref-wrapper **RTT star-topology desync** (#2873 family) at the construct
+site. Instrumentation refuted that. The actual mechanism, pinned by raw-byte
+decode of the trapping binary + an env-gated trace of the capture/boxing
+pipeline (repro: the exact runner assembly of `bound-function.js`,
+`allowJs + deferTopLevelInit`, which is what makes it reproduce — a plain
+TS-mode compile of the same source lays out differently and does NOT trap):
+
+1. `validateNativeFunctionSource`'s inner closures forward-reference the
+   sibling const `test`. The FIRST closure construction
+   (`emitClosureConstruction`) boxes `test` into an **externref ref cell**
+   (`struct.new $__ref_cell_externref` of the pre-hoist externref local) and
+   re-aims `localMap["test"]` at the fresh `__boxed_test` CELL local. Correct
+   so far.
+2. When the declaration `const test = function(){}` itself compiles, the
+   arrow/function-expression branch of `variables.ts` looked up
+   `priorIdx = localMap.get(name)` — now the **cell local** — reused it as the
+   value slot, **retyped it to the precise closure struct**
+   (`slot.type = closureType`, the local-slot analog of the #3533 module-global
+   retro-narrow), and raw-stored the closure over the cell.
+3. The final `stack-balance` pass (`fixLocalSetCoercion`) then saw the
+   earlier `struct.new <cell>; local.tee <slot>` disagree with the slot's new
+   closure-struct type and "repaired" it by splicing a **statically-impossible
+   unguarded `ref.cast_null <closure-struct>`** between the `struct.new` and
+   the `local.tee` (binaryen renders it `ref.cast (ref none)`) — a guaranteed
+   `illegal cast` the moment the function is ENTERED. That is the
+   `illegal cast in __closure_41() at source L25` trap.
+
+### The #3024 unification (write this on your hand)
+
+The same retype also re-registered the **closure STRUCT itself as the ref
+cell** (`boxedCaptures[name].refCellTypeIdx` = the closure struct type — whose
+field 0 is `funcref`). This is exactly what the #3024 call-site slice observed
+as "the ref cell stores a bare funcref": there never was a funcref CELL. The
+#3024 call-site symptom and the #3534 construct-site trap are **one defect
+seen from both ends**. Consequence for step 3: with this fix landed, the
+`calls-closures.ts` funcref-cell `struct.new` stopgap has no remaining
+producer (probe evidence below) — its removal (step 3, separate PR per the
+ordering constraint) is now evidence-based rather than speculative.
+
+### What landed (all in `src/codegen/statements/variables.ts`)
+
+- **A1 (never narrow)**: the module-global arrow branch no longer retypes the
+  pre-declared externref `$__mod_<name>` global (legacy retype kept only for
+  the non-externref pre-decl arm, which closure globals never take).
+- **A2 (box on store)**: `extern.convert_any` before `global.set` when the
+  global is externref and the value is a precise closure ref. The LOCAL stays
+  precise (in-function calls keep the precise-ref arm). Calls from elsewhere
+  take `compileClosureCall`'s existing guarded externref arm (live-read of
+  `globalDef.type`); value-reads (identifiers.ts) are valid as-emitted →
+  fixes #3533 directly.
+- **Construct site (the trap)**: when the binding is boxed-before-declared
+  (`fctx.boxedCaptures.has(name)`), write the closure value THROUGH the cell
+  (null-guarded `struct.set` field 0, the #3396/#1177 `boxedForInitStore`
+  convention; `coerceType` boxes the precise ref to the cell's externref
+  field), leave the cell slot's type alone, and `emitLocalTdzInit` so captured
+  forward references pass their TDZ checks. Also added `emitLocalTdzInit` to
+  the plain prior-slot arm (declaration = initialization; no-op when no flag).
+
+### A3 disposition — vacuously satisfied (probe evidence)
+
+The audit's A3 row (flip ref-cell field-0 to externref for closure-valued
+captures) was justified by the now-refuted RTT mechanism. An env-gated probe
+in `getOrRegisterRefCellType` (flag any cell minted over `funcref` or a
+`__closure_*`/`__fn_cap_*`/`__fn_wrap_*` ref) produced **ZERO hits** across:
+the 13-case closure corpus, 5 dedicated mutual-recursion / nested-fndecl /
+accessor-transitive shapes (including the module-level and function-local
+mutually-recursive-const shapes that produced the defect), all 7
+matcher-invoking files, and the full 80-file toString dir. The retype was the
+only producer of closure-struct-as-cell; post-fix, closure-value cells are
+externref by construction. A3-as-audited needs no code.
+
+## Test Results (measured RUNTIME verdicts, not compile-validity)
+
+GC (host) lane:
+- `built-ins/Function/prototype/toString` (80 files): **11 → 23 pass (+12, 0
+  lost)**; `illegal cast` rows **67 → 0**. The 57 remaining fails are genuine
+  Test262Error oracle verdicts from a DIFFERENT defect (`"" + fn` yields
+  `[object Object]` / callback-shim source instead of NativeFunction syntax)
+  → filed as **#3540**, out of scope here.
+- `language/expressions/class/elements/*-literal-names.js` (34 files, the
+  #3533 cluster): **15 → 30 pass (+15, 0 lost)**; the
+  `struct.set expected externref` invalid-Wasm signature is gone; 4 residual
+  fails are async-gen semantics, distinct family.
+- Full equivalence suite (213 files / 1646 tests): **delta ZERO** (35 failing
+  tests identical before/after — all pre-existing on main in this container).
+
+Standalone lane:
+- toString dir: 66/80 pass both before and after (**no regression**; note the
+  standalone pass count is known-inflated by assert vacuity, #3468);
+  `illegal cast` trap rows **12 → 0** (flip to genuine thrown-exception
+  verdicts). Trap-category delta is NEGATIVE on both lanes.
+
+Step-1 closure corpus (13 cases, post-fix sha256-16):
+```
+mod_const_arrow_call           PASS  5cd835b9edc3f9c7
+mutual_even_odd                PASS  f15b0d22c88ecf4b
+value_read_call                PASS  c023ffa55f8c4ca2
+capture_mutable                PASS  7bbcc06bbb9ccfa1  (byte-identical to baseline)
+closure_capture_call_sibling   PASS  5885800c56b700ee
+mod_fn_expr_tostring_family    PASS  b185ae4304dd5d0c
+returned_closure               PASS  cd89dcc51ddd41d9  (byte-identical to baseline)
+arr_of_closures                PASS  645f9dead22c4b7a
+hof_pass                       PASS  32c6e0e594944840
+var_reassign_call              WRONG d57a1b35964e0b09  (pre-existing on baseline: got 1, want 2 — reassignment path, follow-up)
+class_field_fn_3533            PASS  e8e766358a3c4d54  (baseline: INVALID ab0bda040f78d549)
+obj_literal_field_fn           PASS  5fb66af6f5d7e0ee
+local_mutual_matcher_shape     PASS  9d1b9af197bc366e
+```
+
+Guard test: `tests/issue-3534-closure-value-representation.test.ts` (6 tests,
+green), plus the existing `tests/issue-3024-tostring-closure-funcref.test.ts`
+still green.
+
+## Remaining (follow-ups, NOT this PR)
+
+- **Step 3**: remove the #3024 funcref-cell `struct.new` stopgap in
+  `calls-closures.ts` — now evidence-based (zero-producer probe above).
+- **#3540**: the fn-stringification gap dominating the residual toString fails.
+- `var_reassign_call` (module `let f = …; f = …; f()` returns the FIRST value)
+  — assignment-path sibling, pre-existing.

--- a/plan/issues/3540-function-tostring-source-text-gap.md
+++ b/plan/issues/3540-function-tostring-source-text-gap.md
@@ -1,0 +1,71 @@
+---
+id: 3540
+title: "spec gap: Function.prototype.toString source text — compiled closures stringify as `[object Object]` / callback-shim source instead of NativeFunction syntax (57/80 toString-dir fails)"
+status: ready
+sprint: Backlog
+created: 2026-07-23
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: codegen, runtime
+language_feature: function
+goal: spec-completeness
+related: [3024, 3534, 1337, 1632]
+---
+
+# #3540 — `"" + fn` does not produce NativeFunction (or source) text for compiled closures
+
+## Provenance
+
+Split out of #3534 (per lead direction). After the #3534 closure-representation
+fix eliminated every `illegal cast` trap in
+`built-ins/Function/prototype/toString/` (67 → 0 trap rows, 11 → 23 pass on the
+gc lane), the **residual 57/80 fails in that directory are dominated by ONE
+distinct defect**: stringifying a compiled function value does not yield
+anything the `nativeFunctionMatcher.js` harness accepts.
+
+## Signature (measured 2026-07-23, gc lane, post-#3534)
+
+`assertNativeFunction(fn)` / `assertToStringOrNativeFunction(fn, expected)`
+compute `const actual = "" + fn` and validate it against NativeFunction
+syntax (`function <name>? (<params>) { [native code] }`). For compiled values,
+`actual` comes back as one of:
+
+- `"[object Object]"` — closure struct boxed to externref, default
+  Object-toString path (e.g. `arrow-function.js`, `unicode.js`).
+- `"null"` / `"undefined"` — the value read loses the closure entirely
+  (e.g. `Function.js`, `method-computed-property-name.js`).
+- **The host callback-shim's OWN JS source** — `getter-object.js` stringifies
+  the `__cb_N` dispatch shim (`function(...args){const exports=callbackState…`),
+  leaking internal runtime source text to user code.
+
+Example rows:
+
+```
+fail arrow-function.js  Test262Error: Conforms to NativeFunction Syntax: "[object Object]" (…)
+fail Function.js        Test262Error: Conforms to NativeFunction Syntax: "null" (function anonymous…)
+fail getter-object.js   Test262Error: Conforms to NativeFunction Syntax: "function(...args){const exports=callbackState?.getExports()…"
+```
+
+## Scope note
+
+This spans far more than the 57 files in this directory — every
+`Function.prototype.toString` conformance path over a compiled function hits
+it. Spec §20.2.3.5 permits an implementation-defined NativeFunction form for
+functions whose source is unavailable, so the cheap conforming fix is to make
+function-valued externref boxing carry a host `Function` facade (or intercept
+`toString`/`Symbol.toPrimitive` on the closure box) that yields
+`function <name>() { [native code] }` — the callback-shim leak in
+`getter-object.js` additionally needs the shim to override its own `toString`.
+
+## Acceptance criteria
+
+- `"" + fn` for a compiled closure yields a NativeFunction-conforming string
+  (accepted by `validateNativeFunctionSource`), never `[object Object]`,
+  `null`/`undefined`, or internal shim source.
+- Measured pass delta on `built-ins/Function/prototype/toString/` (gc lane;
+  post-#3534 baseline: 23/80).
+- No closure-representation change (that is #3534's settled invariant:
+  externref-boxed closure values, never narrowed).

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -846,15 +846,29 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       // exists — the inner declaration must bind to the local, not the global.
       const modGlobalIdx = hasLocalShadow ? undefined : ctx.moduleGlobals.get(name);
       if (modGlobalIdx !== undefined) {
-        // Update the global's type to match the actual closure ref type
+        // (#3534 step 2, option a) NEVER retro-narrow the pre-declared
+        // `$__mod_<name>` global. It is declared `externref` before the closure
+        // type is known; narrowing it here to the precise `(ref null N)`
+        // retroactively invalidated every ALREADY-EMITTED `global.get` whose
+        // consumer took the externref at face value (the #3533 class-field
+        // `struct.set expected externref, found (ref null N)` invalid-Wasm
+        // family). Keep the binding `externref` for its whole lifetime and BOX
+        // ON STORE instead (`extern.convert_any`); readers get a stable
+        // externref (identifiers.ts C1) and calls take `compileClosureCall`'s
+        // existing externref arm (guarded cast to the lifted self carrier).
+        // The LOCAL keeps the precise closure type — its reads use the
+        // precise-ref call arm (no unbox round-trip inside this function).
         const globalDef = ctx.mod.globals[localGlobalIdx(ctx, modGlobalIdx)];
-        if (globalDef) {
+        const globalIsExternref = globalDef?.type.kind === "externref";
+        if (globalDef && !globalIsExternref) {
+          // Pre-declared as something other than externref (not the closure
+          // pre-decl convention) — keep the legacy retype so init and type
+          // agree. Closure globals never take this arm.
           const nullableType: ValType =
             closureType.kind === "ref"
               ? { kind: "ref_null", typeIdx: (closureType as { typeIdx: number }).typeIdx }
               : closureType;
           globalDef.type = nullableType;
-          // Also fix the init expression to match the new type
           if (nullableType.kind === "ref_null") {
             globalDef.init = [{ op: "ref.null", typeIdx: (nullableType as { typeIdx: number }).typeIdx }];
           }
@@ -862,10 +876,53 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         // Duplicate value on stack: one for the global, one for the local
         const localIdx = allocLocal(fctx, name, closureType);
         fctx.body.push({ op: "local.tee", index: localIdx });
+        if (globalIsExternref && (closureType.kind === "ref" || closureType.kind === "ref_null")) {
+          // Box on store: precise closure struct → externref (A2).
+          fctx.body.push({ op: "extern.convert_any" });
+        }
         fctx.body.push({ op: "global.set", index: modGlobalIdx });
         // Set TDZ flag to 1 (initialized)
         emitTdzInit(ctx, fctx, name);
       } else {
+        // (#3534 construct site) Boxed-before-declared: an EARLIER
+        // (forward-referencing) closure construction boxed this binding into a
+        // ref cell and re-aimed `localMap[name]` at the `__boxed_<name>` CELL
+        // local. Reusing that slot as the value slot below would (a) RETYPE
+        // the cell local to the closure struct — retroactively invalidating
+        // the already-emitted `struct.new <cell>; local.tee` (stack-balance
+        // then "repairs" the tee with a statically-impossible `ref.cast_null`
+        // → guaranteed `illegal cast` at runtime: the nativeFunctionMatcher
+        // mutually-recursive `eat`/`test` trap) and (b) alias the raw value
+        // over the cell, so captures never observe the initialization. Write
+        // the closure value THROUGH the cell instead (the #3396/#1177
+        // `boxedForInitStore` convention) and leave the slot's ref-cell type
+        // untouched.
+        const boxedClosureCell = fctx.boxedCaptures?.get(name);
+        const boxedCellLocalIdx = boxedClosureCell !== undefined ? fctx.localMap.get(name) : undefined;
+        if (boxedClosureCell !== undefined && boxedCellLocalIdx !== undefined) {
+          if (!valTypesMatch(closureType, boxedClosureCell.valType)) {
+            // Precise closure struct → externref cell field: extern.convert_any.
+            coerceType(ctx, fctx, closureType, boxedClosureCell.valType);
+          }
+          const tmpVal = allocLocal(fctx, `__box_init_tmp_${fctx.locals.length}`, boxedClosureCell.valType);
+          fctx.body.push({ op: "local.set", index: tmpVal });
+          fctx.body.push({ op: "local.get", index: boxedCellLocalIdx });
+          fctx.body.push({ op: "ref.is_null" });
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [],
+            else: [
+              { op: "local.get", index: boxedCellLocalIdx },
+              { op: "local.get", index: tmpVal },
+              { op: "struct.set", typeIdx: boxedClosureCell.refCellTypeIdx, fieldIdx: 0 },
+            ],
+          });
+          // The binding is initialized now — flip the (possibly boxed) local
+          // TDZ flag so captured forward references pass their checks.
+          emitLocalTdzInit(fctx, name);
+          continue;
+        }
         // Reuse pre-hoisted slot if it exists.
         // Do NOT narrow externref → ref: the hoisting pass already emitted
         // __get_undefined() targeting externref; mutating the type causes
@@ -878,6 +935,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           if (slot && slot.type.kind !== "externref") slot.type = closureType;
         }
         emitCoercedLocalSet(ctx, fctx, localIdx, closureType);
+        emitLocalTdzInit(fctx, name);
       }
       continue;
     }

--- a/tests/issue-3534-closure-value-representation.test.ts
+++ b/tests/issue-3534-closure-value-representation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #3534 / #3533 — unified closure-value representation (option a, step 2).
+ *
+ * Root defect (single, seen from three sites): a closure binding is declared
+ * type-erased (`externref` module global / externref pre-hoist local), then the
+ * declaration compile RETRO-narrows it to the precise closure struct:
+ *
+ *  - module global (`$__mod_<name>`): the narrow retroactively invalidated
+ *    every already-emitted `global.get` whose consumer took externref at face
+ *    value — `class C { c = fn }` → `struct.set expected externref, found
+ *    (ref null N)` invalid Wasm (#3533, 34-file
+ *    `language/expressions/class/elements/*-literal-names.js` cluster).
+ *
+ *  - function-local slot: forward-referencing sibling closures box the binding
+ *    into an externref ref cell and re-aim `localMap[name]` at the CELL local;
+ *    the declaration then reused that slot, retyped it to the closure struct
+ *    and raw-stored the closure over it. stack-balance's fixLocalSetCoercion
+ *    "repaired" the earlier `struct.new <cell>; local.tee` with a statically
+ *    impossible unguarded `ref.cast_null` — a GUARANTEED `illegal cast` trap
+ *    at runtime (#3534: nativeFunctionMatcher's mutually-referencing
+ *    `eat`/`test` closures; 67 illegal-cast rows across the
+ *    built-ins/Function/prototype/toString dir).
+ *
+ * The same retype also re-registered the closure STRUCT itself as the ref cell
+ * (`boxedCaptures[name].refCellTypeIdx` = the closure struct, whose field 0 is
+ * funcref) — which is what #3024's call-site slice observed as a "bare funcref
+ * cell". One defect, three symptoms.
+ *
+ * Fix (variables.ts, arrow/function-expression declaration path):
+ *  - NEVER retro-narrow the externref `$__mod_<name>` global; box on store
+ *    (`extern.convert_any`). Calls take `compileClosureCall`'s existing guarded
+ *    externref arm; value-reads are valid as-emitted.
+ *  - When the binding was boxed-before-declared, write the closure value
+ *    THROUGH the ref cell (`boxedForInitStore` convention) instead of retyping
+ *    the cell slot, and flip the (possibly boxed) local TDZ flag.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compileSource } from "../src/compiler.ts";
+import { buildImports } from "../src/runtime.ts";
+import { instantiateWasm } from "../src/runtime-instantiate.ts";
+import { runTest262File } from "./test262-runner.ts";
+
+const T262 = join(process.cwd(), "test262");
+
+async function run(source: string): Promise<unknown> {
+  const r = await compileSource(source);
+  expect(r.success, r.errors?.[0]?.message).toBe(true);
+  const binary = new Uint8Array(r.binary);
+  // Must validate (the #3533 signature was an instantiate-time validation error).
+  await WebAssembly.compile(binary as BufferSource);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await instantiateWasm(binary, imports.env, imports.string_constants, imports.string_constants16);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#3534/#3533 — closure-value representation (never-narrow + box-on-store)", () => {
+  it("#3533: class field initialized to a module-const function value runs (was invalid Wasm)", async () => {
+    const got = await run(`const fn = function (): number { return 4; };
+class C { c = fn; }
+export function test(): number { const o = new C(); return o.c(); }`);
+    expect(got).toBe(4);
+  });
+
+  it("module-const closure still callable through the boxed global (call arm)", async () => {
+    const got = await run(`const f = (x: number): number => x + 1;
+export function test(): number { return f(41); }`);
+    expect(got).toBe(42);
+  });
+
+  it("mutually-recursive module consts still work (boxed global, guarded cast)", async () => {
+    const got = await run(`const even = (n: number): boolean => n === 0 ? true : odd(n - 1);
+const odd = (n: number): boolean => n === 0 ? false : even(n - 1);
+export function test(): number { return even(10) && !odd(10) ? 1 : 0; }`);
+    expect(got).toBe(1);
+  });
+
+  it("boxed-before-declared local closure initializes THROUGH the cell (no slot retype)", async () => {
+    // Forward-referencing sibling closures force the `check` binding into a
+    // ref cell before its declaration compiles — the #3534 construct shape.
+    const got = await run(`const outer = function (s: string): number {
+  let pos = 0;
+  const eat = (tok: string): number => { pos += tok.length; return check(tok); };
+  const check = (tok: string): number => (tok.length > 0 ? pos : eat("x"));
+  return eat(s);
+};
+export function test(): number { return outer("ab"); }`);
+    expect(got).toBe(2);
+  });
+
+  it.runIf(existsSync(T262))(
+    "#3534: matcher-invoking toString files no longer trap (bound-function.js passes)",
+    async () => {
+      const abs = join(T262, "test/built-ins/Function/prototype/toString/bound-function.js");
+      if (!existsSync(abs)) return;
+      const r = await runTest262File(abs, "built-ins/Function", 30000);
+      const msg = String((r as { error?: unknown }).error ?? "");
+      expect(msg).not.toMatch(/illegal cast/);
+      expect(r.status).toBe("pass");
+    },
+    120000,
+  );
+
+  it.runIf(existsSync(T262))(
+    "#3534: validateNativeFunctionSource construct site reaches a genuine verdict (no illegal cast)",
+    async () => {
+      for (const f of ["arrow-function.js", "Function.js"]) {
+        const abs = join(T262, "test/built-ins/Function/prototype/toString", f);
+        if (!existsSync(abs)) continue;
+        const r = await runTest262File(abs, "built-ins/Function", 30000);
+        const msg = String((r as { error?: unknown }).error ?? "");
+        // Pass or a genuine Test262Error oracle verdict — never the construct trap.
+        expect(msg, `${f}: ${r.status} — ${msg}`).not.toMatch(/illegal cast/);
+      }
+    },
+    180000,
+  );
+});


### PR DESCRIPTION
## Summary

**#3534 step 2** of the unified closure-value representation plan (option a) — plus **#3533**, which the same fix resolves. Single root defect, three symptoms: a closure binding is declared type-erased (`externref` module global / externref pre-hoist local boxed into an externref ref cell), then the declaration compile **retro-narrows it to the precise closure struct**, retroactively invalidating already-emitted consumers.

## Root cause (instrumented — REFUTES the audit's RTT hypothesis)

The design plan hypothesized a #2873 funcref-wrapper RTT desync at the construct site. Raw-byte decode of the trapping binary + a capture-pipeline trace showed otherwise:

1. `validateNativeFunctionSource`'s inner closures forward-reference the sibling const `test` → construct-site boxing creates an **externref ref cell** and re-aims `localMap["test"]` at the cell local (correct).
2. The declaration `const test = function(){}` then **reused that cell slot, retyped it to the closure struct** (`slot.type = closureType` — the local-slot analog of the #3533 module-global retro-narrow) and raw-stored the closure over it.
3. `stack-balance`'s `fixLocalSetCoercion` "repaired" the now-mismatched `struct.new <cell>; local.tee` by splicing a **statically-impossible unguarded `ref.cast_null`** → guaranteed `illegal cast` at function entry.

**#3024 unification:** the same retype re-registered the closure STRUCT itself as the ref cell (field 0 = funcref) — the "bare funcref cell" #3024's call-site slice observed was never a cell. One defect, both ends. This makes step 3 (stopgap removal) evidence-based; it is deliberately NOT in this PR per the ordering constraint.

## Fix (`src/codegen/statements/variables.ts` only)

- **A1**: never retype the pre-declared externref `$__mod_<name>` global (legacy retype kept only for the non-externref pre-decl arm, which closure globals never take).
- **A2**: box on store (`extern.convert_any`); the LOCAL keeps the precise type; external calls take `compileClosureCall`'s existing guarded externref arm (live type read).
- **Construct site**: when boxed-before-declared, write the closure value THROUGH the cell (null-guarded `struct.set`, the #3396/#1177 `boxedForInitStore` convention) + `emitLocalTdzInit`, instead of retyping the cell slot.
- **A3 disposition**: vacuously satisfied — an env-gated probe in `getOrRegisterRefCellType` found ZERO ref cells minted over funcref/closure-struct carriers across the closure corpus, dedicated mutual-recursion shapes, all matcher-invoking files, and the full 80-file toString dir. The retype was the only producer. Details in the issue file.

## Measured results (runtime PASS, not compile-validity)

GC (host) lane:
- `built-ins/Function/prototype/toString` (80 files): **11 → 23 pass (+12, 0 lost)**; `illegal cast` rows **67 → 0** (incl. `bound-function.js` TRAP → PASS). Remaining 57 fails are genuine oracle verdicts from the distinct fn-stringification gap → filed as **#3540**.
- `language/expressions/class/elements/*-literal-names.js` (34 files, the #3533 cluster): **15 → 30 pass (+15, 0 lost)**; the `struct.set expected externref` invalid-Wasm signature eliminated. Minimal repro `const fn = function(){}; class C { c = fn; }` INVALID → measured PASS.
- **Full equivalence suite (213 files / 1646 tests): delta ZERO** (35 failures identical before/after, all pre-existing on main).
- 13-case closure corpus: 12 PASS unchanged + 1 pre-existing WRONG unchanged; sha256s recorded in the issue file.

Standalone lane:
- toString dir: 66/80 pass unchanged (no regression; count known-inflated by #3468 assert vacuity); `illegal cast` rows **12 → 0**.

## Trap-gate note

**The trap-category delta is NEGATIVE on both lanes** (67 + 12 `illegal_cast` rows → 0). Unlike #3497 (CE→trap conversions that GREW `illegal_cast` and tripped the merge-group ratchet), this PR pays the ratchet back — traps become genuine verdicts or passes.

## Included

- `tests/issue-3534-closure-value-representation.test.ts` — 6 guard tests (green; existing #3024 guard also still green).
- `plan/issues/3533-*.md` (from the fork branch, folded in with resolution, `status: done`), `plan/issues/3534-*.md` (implementation notes + measurements, `status: done`), `plan/issues/3540-*.md` (new follow-up: fn stringification, 57-file evidence).
- `loc-budget-allow` for `variables.ts` (+58, comment-dominated) granted in #3534's frontmatter; extracting the now-triplicated cell write-through helper is flagged as a consolidation follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb