### PR TITLE
fix(tests/#3183): re-pin stale undefined→0 expectations to NaN; file #3543 (anytuple read traps)

### DIFF
--- a/plan/issues/3543-standalone-heterogeneous-anytuple-nested-read-traps.md
+++ b/plan/issues/3543-standalone-heterogeneous-anytuple-nested-read-traps.md
@@ -1,0 +1,79 @@
+---
+id: 3543
+title: "standalone: heterogeneous inner-tuple (anytuple) nested reads broken — numbers read back NaN, strings trap 'dereferencing a null pointer' (5 red tests on main)"
+status: ready
+created: 2026-07-23
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: arrays, tuples, any
+es_edition: es5
+goal: standalone
+umbrella: 2860
+sprint: current
+horizon: m
+related: [2190, 2873, 3497]
+origin: "Red-suite triage 2026-07-23 (fable-exposed): 5 tests in tests/issue-2190.test.ts (#2190b block) fail on clean origin/main; bisect (tech lead) shows identical failures at aa203fdc5b7b3b, the commit BEFORE #3497 — long-standing, not caused by anything landed 2026-07-23."
+---
+
+# #3543 — standalone heterogeneous anytuple nested reads: NaN / null-deref traps
+
+## Confirmed symptom (vitest, red on clean `origin/main` today)
+
+`npx vitest run tests/issue-2190.test.ts` — the 5 failures in the
+`#2190b heterogeneous inner-tuple read-back` block:
+
+| test | expected | actual |
+| --- | --- | --- |
+| `[["a", 7]]` — `e[0][1]` reads the number | 7 | **NaN** |
+| `[["a", 7]]` — `e[0][0]` still reads the string | "a" | **trap: dereferencing a null pointer** |
+| `[[7, "ab"]]` — `e[0][1]` reads the string | "ab" | **trap: dereferencing a null pointer** |
+| `[[7, "ab"]]` — `e[0][0]` still reads the number | 7 | **NaN** |
+| three-element mixed `[string, number, string]` | — | **trap: dereferencing a null pointer** |
+
+The sibling cases in the same block PASS: boolean+number heterogeneous tuple,
+flat `any[]` `[0, "last"]`, pure `number[][]` nested, pure `string[]`. So the
+break is specific to **string⊕number heterogeneous INNER tuples read through
+the nested `e[0][k]` dynamic path**.
+
+## Diagnosis (triage-level, verbatim from the red-suite investigation)
+
+- This is a **trap-class** failure (NaN garbage / null-pointer deref), NOT a
+  miss-value-class one — do not confuse it with the two (now re-pinned)
+  `issue-3183` miss-value expectations in the same triage batch.
+- Numbers reading back **NaN** + strings **null-deref** through the same path
+  smells like the inner tuple's element representation and the reader's
+  expected representation diverging per element kind — i.e. the nested read
+  unboxes with the WRONG per-kind arm (a number slot read as a ref → null →
+  deref trap; a ref slot read as a number → NaN).
+- Plausibly value-rep / RTT-creation-order territory: cf.
+  `reference_2873_funcref_wrapper_chain_rtt_order` (wrapper RTT identity is
+  creation-ORDER-dependent) and the #2379 boxed-any element-rep notes
+  (`reference_2379_new_array_n_boxed_any_elem_rep`). The heterogeneous literal
+  path may register/choose a `__vec_<kind>` carrier whose runtime `ref.test`
+  ordering in `__extern_get_idx`'s spliced vec arms
+  (`fillExternGetIdxVecArms`, src/codegen/object-runtime.ts ~5317) resolves a
+  DIFFERENT carrier than the one the literal actually built.
+- Long-standing: identical 7-failure state (these 5 + the 2 since-re-pinned
+  #3183 ones) at `aa203fdc5b7b3b` (pre-#3497). #3497 and #3506/#3537 are both
+  exonerated (verified by running the suite against clean main src and against
+  the #3537 branch — identical failures on both).
+
+## Repro
+
+```bash
+npx vitest run tests/issue-2190.test.ts   # 5 failures in the #2190b block
+```
+
+Minimal shape: `var e: any = [["a", 7]]; e[0][1]` (NaN) / `e[0][0]` (trap).
+
+## Acceptance criteria
+
+- The 5 `#2190b` tests pass on `--target standalone`.
+- No regressions in the passing siblings (boolean+number tuple, flat any[],
+  pure nested number/string matrices) or the #3183 suite.
+- Fix lands with a root-cause note: WHICH representation/arm divergence caused
+  the per-kind misread (carrier registration vs reader test order), so the
+  #3251 overlay work can build on a stable answer.

--- a/plan/issues/3544-standalone-dynamic-call-apply-dispatch-on-callables.md
+++ b/plan/issues/3544-standalone-dynamic-call-apply-dispatch-on-callables.md
@@ -1,0 +1,100 @@
+---
+id: 3544
+title: "standalone: dynamic `.call`/`.apply` on callable values silently answers undefined — gates the entire builtin receiver-validation cluster (~232 projected #3468-cliff tests)"
+status: ready
+created: 2026-07-23
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: function-call, call, apply, dynamic-dispatch
+es_edition: es5
+goal: standalone
+umbrella: 2860
+sprint: current
+horizon: m
+related: [3468, 1596, 3140, 2984, 3537]
+origin: "#3468 cliff clustering (fable-exposed, 2026-07-23): cluster 3 (builtin receiver-validation, 29/458 sampled ≈ 232 projected) concentration scoping — traced to ONE dispatch arm, not 232 per-builtin gaps"
+---
+
+# #3544 — dynamic `.call`/`.apply` on callables answers undefined (standalone)
+
+## Traced mechanism (WAT-verified 2026-07-23, exact chain)
+
+`var s = String.prototype.slice; s.call(undefined, 0)` compiles to:
+
+1. `__call_m_call_2(s, thisArg, box(0))` — builds key `"call"` + an `$ObjVec`
+   argvec `[thisArg, arg0]` — then
+2. `__extern_method_call(s, "call", argvec)` (`src/codegen/object-runtime.ts`
+   ~4055). Receiver `s` is a **builtin proto-method closure** (a funcref-wrapper
+   struct minted by `ensureStandaloneNativeMethodClosure`,
+   `src/codegen/native-proto.ts` ~417 — `$__proto_method_<brand>_slice`), which
+   is neither `$Object` nor `$Vec` nor a CAPTURING closure, so the else-arm
+   chain (vec → closure-prop-carrier) falls through to **`ref.null.extern` —
+   silent undefined. The call never dispatches.**
+
+Probe matrix (r=1 threw ✓spec / r=3 silent no-throw ✗):
+`String.slice/concat .call(undefined)` ✗ · `Uint8Array.filter.call({})` ✗ ·
+`ArrayBuffer.slice.call({})` ✗ · `Promise.resolve.call(undefined)` ✗ ·
+`Date.setTime.call({})` ✓ (Date routes elsewhere — statically resolved).
+
+## Why ONE fix covers the cluster
+
+The minted closures ALREADY have TypeError-bearing bodies: wired members carry
+real receiver checks, un-wired members carry the #2984 refusal body
+(`"<Builtin>.prototype.<m> is not yet implemented in --target standalone"` — a
+REAL catchable TypeError). The cluster-3 tests assert only the CONSTRUCTOR
+(`assert.throws(TypeError, () => m.call(badReceiver))`), so **dispatching the
+call is sufficient to flip them — wired or refusal alike**. The gap is purely
+the `.call`/`.apply` routing arm in `__extern_method_call`, not 232 per-builtin
+receiver checks. (Harness `assert.throws` ctor-identity for a thrown TypeError
+verified working — probe3, 2026-07-23.)
+
+## Fix sketch (slice 1: `.call`)
+
+In `__extern_method_call`'s else-arm chain (COMPOSED like #3537 — do not edit
+closure-props.ts): a new leading arm
+`if (name == "call" && __is_callable(recv)) → __dispatch_fn_call(recv, argvec)`:
+- `__is_callable` — the #3140 `buildClosureRefTestArms` callable-gate
+  classification already enumerates every funcref-wrapper struct (it powers
+  `__bind_dyn`); reuse it.
+- `__dispatch_fn_call(recv, argvec)` — thisArg = argvec[0], rest = argvec[1..]
+  re-pushed into a fresh `$ObjVec`, then `__apply_closure(recv, thisArg, rest)`.
+  Native-string compare for the `"call"` key via the `fillBuiltinFnMeta`
+  classify pattern (same as #3537's "length" refusal).
+- Arm ORDER: before the closure-prop-carrier arm (a capturing closure's
+  `f.call(x)` must invoke `f`, not consult its expando bag; an own expando
+  literally named "call" is pathological and broken today anyway).
+- `.apply` = follow-on slice (needs array-arg spreading; check what the
+  DONE #1596 static path already has as helpers).
+
+## ⚠ Measured-floor HAZARD — must be quantified before PR (do NOT skip)
+
+Dispatching makes the #2984 **refusal-stub bodies reachable**: today
+`m.call(x)` on an un-wired member silently answers undefined; after the fix it
+THROWS the refusal TypeError. That is spec-directionally better (fail-loud) and
+flips the cluster-3 assert.throws tests green, but any today-passing standalone
+test that *tolerates* the silent undefined would flip pass→fail at module init.
+The #2984 comment explicitly measured this class of regression once before
+(`hasOwnProperty.call` idioms rely on the null-return fall-through of
+`emitReflectiveNativeProtoClosureCall` — note that is a DIFFERENT, static
+route; verify it stays untouched). Validation protocol (the #3537 template):
+1. stride-8 floor run (main vs main+fix) — regressions MUST be ~0; every
+   regression individually triaged (a refusal-throw regression means the
+   member needs a real wired body or the arm needs a narrower gate);
+2. re-run the 458 #3468-cliff sample on routing-harness ± fix — report
+   measured flips ONLY (coordinator directive: a sibling agent's 29% signature
+   share measured 2/198 — size on flips, never share);
+3. `hasOwnProperty.call` / `propertyIsEnumerable.call` harness idioms explicitly
+   re-tested.
+
+## Measurement infrastructure (reusable, in the fable-exposed worktree)
+
+`/workspace/.claude/worktrees/agent-a5ae601287feed137/.tmp/m3468/`:
+`driver.mts` (CI-exact worker-pool runner), `extract.mts` (deferTopLevelInit
+payload extractor), `measure-all.sh` (4-phase template), bundles under
+`bundles/{main2,fix,harness2,harnessfix}`, sample lists
+(`sample-stride8.txt`, `regressed.txt`), and branch `tmp-harness2` /
+`tmp-harnessfix` (origin/main ± routing-revert cherry-pick 5a71adf7c4eee3 +
+compat shim) for cliff re-measurement.

--- a/plan/issues/3544-standalone-dynamic-call-apply-dispatch-on-callables.md
+++ b/plan/issues/3544-standalone-dynamic-call-apply-dispatch-on-callables.md
@@ -89,6 +89,42 @@ route; verify it stays untouched). Validation protocol (the #3537 template):
 3. `hasOwnProperty.call` / `propertyIsEnumerable.call` harness idioms explicitly
    re-tested.
 
+## WIP FINDING (2026-07-23, fable-exposed) — prototype built; convention split found
+
+A working prototype of the arm exists on branch **`issue-3544-call-dispatch`**
+(pushed to the fork; stacked on `issue-3537-vec-expando-props`; NOT a PR):
+`src/codegen/fn-call-dispatch.ts` (reserve/fill: `__fn_call_name_gate`,
+`__is_fn_callable`, `__fn_call_invoke`) + arm wiring. Measured behavior:
+
+- `Promise.resolve.call(undefined, 1)` **now throws ✓** — the arm + name gate +
+  invoke work end-to-end for static-shape builtin closures.
+- `String.prototype.slice.call(undefined, 0)` **still silent ✗** — and the WHY
+  is the key discovery: **two calling conventions coexist.**
+  - Ordinary user closures: lifted sig `(self, ...args)`; `this` flows via the
+    `__current_this` global → `.call(t, a)` must split argvec: thisArg=t,
+    rest=[a] → `__apply_closure(m, t, [a])` (what the prototype does).
+  - Builtin proto-method closures (`ensureStandaloneNativeMethodClosure`):
+    lifted sig `(self, THIS-AS-PARAM, ...args)` — userParams `[this, p0, …]`
+    (`native-proto.ts` ~461). `.call(t, a)` must pass the ORIGINAL argvec
+    `[t, a]` (this folded as first arg) padded to the member's paramSlots.
+    The prototype's uniform split mis-arities these into the wrong
+    `__call_fn_method_N` (no matching per-type arm at that N) → silent null →
+    the observed undefined. `emitReflectiveNativeProtoClosureCall` (the static
+    `hasOwnProperty.call` route) is the existing precedent for the folded
+    convention — study it before finishing.
+- Also fixed en route: `__is_fn_callable` must use PER-CONCRETE-TYPE arms over
+  `ctx.closureInfoByTypeIdx` (the same set `__call_fn_method_N` tests), NOT
+  `collectClosureBaseWrapperTypeIdxs` — the base-root walk misses the
+  proto-method wrapper structs (measured: gate matched Promise, missed String).
+
+**Next implementer:** distinguish the two conventions inside
+`__fn_call_invoke` — e.g. a fill-time `ref.test` chain over the proto-method
+wrapper types (they are enumerable at finalize from the funcMap
+`__proto_method_*` names / a registry added at mint time) choosing
+argvec-as-is + pad vs split; or normalize the convention at mint time. Then
+run the pre-authorized measurement (stride-8 floor + full-458 cliff; decision
+rule: floor≈0 → ship; material loss → STOP, report per-member).
+
 ## Measurement infrastructure (reusable, in the fable-exposed worktree)
 
 `/workspace/.claude/worktrees/agent-a5ae601287feed137/.tmp/m3468/`:

--- a/tests/issue-3183.test.ts
+++ b/tests/issue-3183.test.ts
@@ -108,22 +108,33 @@ describe("#3183 — standalone dynamic-path for-in / string-key over an any-type
     ).toBe(18);
   });
 
-  it("OOB string-key read answers undefined (→ 0 in a number context)", async () => {
+  // (2026-07-23 re-pin, tech-lead authorized) These two originally pinned the
+  // legacy undefined→0-in-f64 shortcut. That shortcut belongs to `null`, not
+  // `undefined`: ToNumber(undefined) is NaN (`Number(undefined) === NaN`), and
+  // the coercion table's documented split is "null → f64.const 0 / undefined →
+  // f64.const NaN". The current pipeline answers the spec-correct NaN, so the
+  // old `toBe(0)` encoded a superseded convention — this is a stale-test fix,
+  // not behavior-bending. `Number.isNaN` because `NaN !== NaN`.
+  it("OOB string-key read answers undefined (→ NaN in a number context)", async () => {
     expect(
-      await runStandaloneNum(`export function test(): number {
+      Number.isNaN(
+        await runStandaloneNum(`export function test(): number {
         var a: any = [1, 2];
         return a["5"];
       }`),
-    ).toBe(0);
+      ),
+    ).toBe(true);
   });
 
-  it("non-numeric non-length string key answers undefined (→ 0)", async () => {
+  it("non-numeric non-length string key answers undefined (→ NaN)", async () => {
     expect(
-      await runStandaloneNum(`export function test(): number {
+      Number.isNaN(
+        await runStandaloneNum(`export function test(): number {
         var a: any = [1, 2];
         return a["foo"];
       }`),
-    ).toBe(0);
+      ),
+    ).toBe(true);
   });
 
   it("regression guard: for-in over a plain any-typed object is unchanged", async () => {


### PR DESCRIPTION
## 1. Re-pin two stale #3183 expectations (tech-lead authorized)

`tests/issue-3183.test.ts` had two long-red tests asserting that a vec miss-value read (`a[\"foo\"]`, OOB `a[\"5\"]`) coerces to **0** in an f64 context. That pinned the legacy undefined→0 shortcut — which belongs to `null`, not `undefined`: **`Number(undefined) === NaN`**, and the documented coercion split is `null → f64.const 0` / `undefined → f64.const NaN`. The pipeline answers the spec-correct NaN today (verified red on clean main and at `aa203fdc`, pre-#3497 — long-standing staleness, no recent regression). This is a stale-test fix, not behavior-bending; asserts `Number.isNaN(...)` since `NaN !== NaN`. Suite: 11/11 green after re-pin.

## 2. File #3543 — heterogeneous anytuple nested-read traps (NOT fixed here)

The remaining 5 red tests in `tests/issue-2190.test.ts` (#2190b block) are a REAL long-standing defect: string⊕number heterogeneous inner tuples read through `e[0][k]` return **NaN for numbers** and **trap 'dereferencing a null pointer' for strings** — a per-element-kind representation/reader divergence (plausibly carrier-registration vs `fillExternGetIdxVecArms` test-order; cf. the #2873 RTT-order memory). Filed as `plan/issues/3543-*.md`, `status: ready`, unassigned — diagnosis captured for whoever claims it.

No compiler source changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb