### PR TITLE
fix(#3542): standalone async-fn rejections carry the thrown value (unfinished #1326 Phase-1C payload wiring)

### DIFF
--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -16,8 +16,8 @@ task_type: architecture
 area: codegen, standalone
 language_feature: generators, async-generators, promises, async-functions
 goal: standalone-mode
-related: [1781, 2860, 3164, 3132, 3032, 2903, 2906, 2865, 2895, 1326, 2959, 2040, 3386, 3387, 3388, 3389, 3390, 3391, 3538]
-children: [3386, 3387, 3388, 3389, 3390, 3391, 3538]
+related: [1781, 2860, 3164, 3132, 3032, 2903, 2906, 2865, 2895, 1326, 2959, 2040, 3386, 3387, 3388, 3389, 3390, 3391, 3538, 3542]
+children: [3386, 3387, 3388, 3389, 3390, 3391, 3538, 3542]
 origin: "2026-07-12 architect (arch-standalone-family-plans): plan/log/standalone-gap-map.md finding — 4,456 leaky passes ride host-import shims, ~90% the generator/async-gen/Promise host machinery. This umbrella is the substrate spec + measured slice ranking the family builds on."
 ---
 
@@ -39,6 +39,17 @@ value. Probed 70/70 PASS on a stride-4 cohort sample. Residuals noted in
 #3538: untyped member reads `r.done` still leak legacy `__gen_result_*` host
 imports (separate pre-existing cohort), sync-gen STATIC typed reads surface
 0/1 / NaN.
+
+Second head, same day: the ~130-row `Cannot destructure/access/convert`
+cluster (98 for-await-dstr) was a DECOY message — the real defect is that
+every synchronously-unwinding standalone async-fn throw rejected with a
+**NULL reason** (`wrapAsyncCallInTryCatch`'s standalone arm never wired the
+#1326 Phase-1C catch-payload; the handler's own destructure-of-null
+manufactured the corpus message). Fixed in child **#3542** (done): a
+`catch $exn` arm uses the tag payload as the rejection reason. Probed 30/33
+PASS on a stride-4 cluster sample; 3 residuals =
+`language/arguments-object/*async-gen*` (`Cannot access property on null or
+undefined`) — distinct root cause, still open here.
 
 ## Decomposition 2026-07-17 (fable-3178) — child issues #3386–#3391
 

--- a/plan/issues/3542-standalone-async-rejection-reason-null.md
+++ b/plan/issues/3542-standalone-async-rejection-reason-null.md
@@ -15,9 +15,27 @@ parents: [3178]
 related: [3417, 3538, 1326, 2865, 3228]
 created: 2026-07-23
 completed: 2026-07-23
+# (#3102) Intended growth: the fix replaces the catch_all arm INSIDE
+# wrapAsyncCallInTryCatch, which lives in expressions.ts — net +14 lines,
+# mostly the WHY comment. Extracting the wrapper is out of scope here.
+loc-budget-allow:
+  - src/codegen/expressions.ts
 ---
 
 # #3542 — standalone async-fn rejection reason is always NULL
+
+## Method note — the signature was manufactured DOWNSTREAM of the defect
+
+The load-bearing lesson of this issue: **the corpus error text was produced
+by the test harness REACTING to the bug, not by the bug itself.** The defect
+was a null rejection reason; the "Cannot destructure 'null' or 'undefined'"
+signature came from the test TEMPLATE's own rejection handler
+(`({ constructor }) => …`) destructuring that null. Grepping the compiler for
+the signature string finds the (correct!) RequireObjectCoercible throw
+helper and sends you chasing a phantom destructuring bug. When triaging a
+cluster, always probe what the HANDLER received before trusting the message
+— a signature can be an echo. (Same family as the #3468 vacuous-pass and
+#2860 `(start)`-throw-masking lessons: harness-reaction artifacts.)
 
 ## Problem (measured, verify-first)
 

--- a/plan/issues/3542-standalone-async-rejection-reason-null.md
+++ b/plan/issues/3542-standalone-async-rejection-reason-null.md
@@ -1,0 +1,79 @@
+---
+id: 3542
+title: "Standalone async-fn rejections lose the thrown value — reason is always NULL (unfinished #1326 Phase-1C payload wiring)"
+status: done
+assignee: ttraenkler/fable-3417
+sprint: current
+priority: high
+horizon: s
+feasibility: medium
+task_type: bugfix
+area: codegen, standalone, async
+language_feature: async-functions, promises
+goal: standalone-mode
+parents: [3178]
+related: [3417, 3538, 1326, 2865, 3228]
+created: 2026-07-23
+completed: 2026-07-23
+---
+
+# #3542 — standalone async-fn rejection reason is always NULL
+
+## Problem (measured, verify-first)
+
+Second head of the F2 newly-scored standalone async FAIL surface (#3417):
+the ~130-row `Cannot destructure/access/convert` cluster (98 in
+`language/statements/for-await-of` — the `async-func-dstr-*` template
+family). The corpus message was a decoy: probing showed the async fn DOES
+reject with a correct TypeError path, but the **rejection reason arriving at
+the handler is `null`** — the thrown instance is dropped. The test template's
+rejection handler `({ constructor }) => assert.sameValue(constructor,
+TypeError)` then destructures NULL, and its OWN "Cannot destructure 'null' or
+'undefined'" TypeError propagates to `$DONE` — manufacturing the corpus
+message. Minimal bisection: `async function f(){ throw new TypeError(...) }`
+and `await Promise.resolve(1); throw ...` both reject with NULL; direct
+`Promise.reject(new TypeError())`, executor `rej(...)`, and late pending
+rejections all preserve the reason.
+
+## Root cause
+
+`wrapAsyncCallInTryCatch` (`src/codegen/expressions.ts`), standalone arm — a
+**documented, never-finished TODO** from #1326 Phase 1B: the call-site
+wrapper caught a synchronously-unwinding async-body throw with a bare
+`catch_all` (payload inaccessible) and minted the rejected `$Promise` with
+`ref.null.extern` as the reason, with a comment saying "Phase 1C will wire
+the catch-payload binding". Phase 1C never did. Every standalone async call
+whose body unwinds synchronously (sync throw, AG0 sync-unwrapped await
+continuation, sync-settling for-await drive — i.e. most of the corpus
+shapes) rejected with NULL.
+
+## Fix
+
+Add a `catch $exn` arm (the native `__exn` tag, `ensureExnTag`) ahead of the
+`catch_all`: its externref payload — the thrown JS value — becomes the
+rejection reason (`$Promise.value`). `catch_all` remains as the reason-less
+fallback for foreign, non-`__exn` exceptions only. One small arm; no new
+imports, no host surface, #2961 gate untouched.
+
+## Validation (measured)
+
+- Bisection probes all flip: sync-throw / throw-after-await async fns reject
+  with the real TypeError (`instanceof` + `.message` hold); for-await-dstr
+  rejections carry the genuine IteratorBindingInitialization TypeError.
+- Real corpus: **30/33 PASS** on a stride-4 sample of the 130-row cluster
+  (runtime PASS via the #3469 channel). The 3 residuals are a distinct
+  `language/arguments-object/*async-gen*` sub-family
+  (`Cannot access property on null or undefined`) — separate root cause,
+  left for the umbrella.
+- Scoped suites green post-fix: async set (66 tests), Promise machinery
+  (issue-1326/1326c/2623/2671×2/28/2903-finally — 58 tests). The single
+  1326 host-lane WAT expectation failure is control-verified pre-existing on
+  clean sources.
+
+## Notes
+
+- Sequenced after #3538 (same umbrella lane; measured on the combined tree).
+- Follow-ups spotted while probing (not addressed): standalone
+  `console.log(null-externref)` renders `[object Object]` instead of `null`;
+  an uncaught trap inside a microtask job silently ends the drain (swallows
+  subsequent jobs' output).

--- a/plan/issues/3542-standalone-async-rejection-reason-null.md
+++ b/plan/issues/3542-standalone-async-rejection-reason-null.md
@@ -75,6 +75,11 @@ imports, no host surface, #2961 gate untouched.
 
 ## Validation (measured)
 
+- Permanent repro: `tests/issue-3542.test.ts` (4 cases — sync throw,
+  throw-after-await, the for-await-dstr cluster shape, and the
+  direct/executor no-regression control; all through the real standalone
+  sink/drain channel).
+
 - Bisection probes all flip: sync-throw / throw-after-await async fns reject
   with the real TypeError (`instanceof` + `.message` hold); for-await-dstr
   rejections carry the genuine IteratorBindingInitialization TypeError.

--- a/plan/issues/3545-standalone-microtask-trap-silently-ends-drain.md
+++ b/plan/issues/3545-standalone-microtask-trap-silently-ends-drain.md
@@ -1,0 +1,84 @@
+---
+id: 3545
+title: "Standalone: an uncaught trap inside a microtask job silently ends __drain_microtasks — async scoring INTEGRITY defect"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+task_type: bug
+area: codegen, standalone, async, test262-runner
+language_feature: promises, async-functions
+goal: standalone-mode
+related: [3178, 3417, 3469, 3542, 1326]
+created: 2026-07-23
+origin: "2026-07-23 fable-3417, discovered probing the #3542 null-reason cluster: a rejection handler that read `e.message` off a null reason trapped, and every subsequent console.log in that job AND the rest of the drain silently vanished."
+---
+
+# #3545 — uncaught microtask trap silently ends the drain
+
+## Problem
+
+On `--target standalone`, when a job running on the native microtask ring
+(`__drain_microtasks`, `src/codegen/async-scheduler.ts`) hits an **uncaught
+wasm trap** (e.g. `null` dereference — observed concretely: reading
+`e.message` when the rejection reason was null, pre-#3542), the trap
+propagates out of the job and **terminates the whole drain silently**:
+
+- the remaining statements of that job never run;
+- every job still queued BEHIND it never runs;
+- the runner's drain call site catches/ignores, reads the stdout sink, and
+  scores whatever partial output exists.
+
+Observed repro (pre-#3542 tree, but the mechanism is independent of that fix):
+
+```js
+async function fn() { for await (let [{ x }] of [[]]) { return; } }
+fn().then(_ => { console.log("resolved"); }, (e) => {
+  console.log("rejected");     // printed
+  console.log(e.message);      // e was null -> TRAP; nothing after this line
+  console.log("never");        //  ran, in THIS job or any queued job
+});
+```
+
+Sink contained only `rejected` — no error, no marker, no signal that the run
+was truncated.
+
+## Why this is an INTEGRITY defect, not a cosmetic one
+
+This can corrupt async scoring in BOTH directions — the same class of
+observability failure as the vacuous-pass (#3468) and `(start)`-throw-masking
+(#2860) problems:
+
+- a test whose `$DONE()` job is queued behind a trapping job is scored
+  `async completion marker not observed` (or on partial output) — a FALSE
+  fail or wrong signature;
+- a test whose FAILURE path traps before printing `AsyncTestFailure` can look
+  like a hang instead of a fail — or, if a pass marker was already printed by
+  an earlier job, the truncation is invisible entirely;
+- every measurement of standalone async (including the #3538 70/70 and #3542
+  30/33 cohort probes) implicitly trusts that the drain ran to quiescence.
+
+## Direction (for whoever takes it — do NOT assume, verify first)
+
+- Decide the contract: per spec, HostEnqueuePromiseJob jobs that throw abort
+  the job, not the queue; a wasm TRAP is outside JS semantics but the drain
+  loop should at minimum (a) survive to run the remaining queued jobs, or
+  (b) surface the trap loudly to the runner (a `__drain_trapped` flag /
+  re-throw after queue exhaustion) so a truncated run is never scored
+  silently.
+- Ground in `__drain_microtasks`'s loop (`src/codegen/async-scheduler.ts`)
+  and the runner-side drain call sites (`scripts/test262-worker.mjs` ~1264,
+  `tests/test262-runner.ts` ~4245, `tests/test262-shared.ts` ~812 — the
+  #3469 channel): check what each does with a drain exception today.
+- Any fix must keep the #2961 zero-import discipline and be
+  verdict-accounted: making truncation LOUD will re-bucket some current
+  passes/fails — that is truth becoming visible, measure and report the
+  split (observability-unblocker rule, #3417 F2 precedent).
+
+## Acceptance
+
+- A trapping job cannot silently swallow subsequent queued jobs' output; the
+  runner can distinguish "drain completed" from "drain truncated by trap".
+- Measured before/after split of affected corpus rows reported (both
+  directions), not just the improvements.

--- a/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
+++ b/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
@@ -32,7 +32,43 @@ separate sub-cause — verify, #3443-adjacent).
 **NOT the #3542 null-reason echo** — re-probed post-#3542: a stride-6 sample
 (33 files) still traps identically.
 
-## Minimal repro (probe-bisected 2026-07-23 — surprisingly tight)
+## COLLAPSED root cause (WAT-confirmed, same day) — it is an ARITY-FILL bug; promises/closures are irrelevant
+
+The WAT of the trapping closure ends:
+
+```wat
+;; $DONE("m") branch: builds the native string, call — fine.  Then:
+ref.null 6        ;; the ZERO-ARG $DONE() call's missing-argument fill
+ref.as_non_null   ;; ← TRAPS unconditionally
+call $DONE
+```
+
+When a module-level function is called BOTH with a string literal AND with
+zero args, the param is inferred as a NON-NULLABLE native-string ref; the
+zero-arg site fills the missing argument with `ref.null` and then coerces
+through `ref.as_non_null` — an unconditional null-deref trap **on the
+zero-arg (usually the PASS) path**. Per spec a missing argument is
+`undefined`. Two-line module-scope repro (standalone, traps in
+`__module_init`):
+
+```js
+function d(x) { console.log('called'); }
+d('m');
+d();     // RuntimeError: dereferencing a null pointer
+```
+
+The Promise/then/closure/comparison ingredients in the original fence were
+all incidental — they only determined WHERE the trap surfaced
+(`__closure_N ← __then_fulfill_*`). The corpus hits it constantly because
+the canonical test262 template calls `$DONE('msg')` on failure paths and
+bare `$DONE()` on the pass path. Scope note: this likely affects MORE than
+the async cluster — any standalone function under-applied at one site and
+string-applied at another; measure corpus-wide when fixing. Fix direction:
+the param typing must degrade to a nullable/undefined-capable carrier when
+any call site under-applies (or the fill must pass the canonical undefined),
+never a trapping non-null cast.
+
+## Original bisection fence (kept for the record; superseded by the above)
 
 ```js
 function $DONE(x) { console.log("OK"); }

--- a/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
+++ b/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
@@ -1,0 +1,81 @@
+---
+id: 3548
+title: "Standalone: then-callback closure with branch-guarded module-fn calls traps null-deref — the ~193-row 'async continuation threw' Promise cluster"
+status: ready
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+task_type: bug
+area: codegen, standalone, async, closures
+language_feature: promises, closures
+goal: standalone-mode
+parents: [3178]
+related: [3417, 3442, 3443, 3542, 3545, 2865]
+created: 2026-07-23
+origin: "2026-07-23 fable-3417 umbrella triage: third head of the F2-unmasked standalone async FAIL surface, after #3538 (280) and #3542 (130)."
+---
+
+# #3548 — then-closure branch-call null-deref (the 193-row cluster)
+
+## Problem (measured)
+
+The remaining big standalone async FAIL bucket on the 2026-07-21 baseline:
+**193 rows** `async continuation threw before completion: dereferencing a
+null pointer / illegal cast [in __closure_N() ← __then_{fulfill,reject}_M ←
+__drain_microtasks]`. Dirs: `built-ins/Promise/{prototype,any,race,
+allSettled,all,resolve}` (~151) + `language/statements/for-await-of` (16) +
+tail. Signature split: ~150 null-deref in a `__closure_N` invoked from a
+then-reaction wrapper; ~33 `illegal cast [in __then_fulfill_*]` (possibly a
+separate sub-cause — verify, #3443-adjacent).
+
+**NOT the #3542 null-reason echo** — re-probed post-#3542: a stride-6 sample
+(33 files) still traps identically.
+
+## Minimal repro (probe-bisected 2026-07-23 — surprisingly tight)
+
+```js
+function $DONE(x) { console.log("OK"); }
+var value = {};
+var p1 = new Promise(function(_, reject) { reject(); });
+var p2 = p1.then(function() {}, function() { return value; });
+p2.then(function(x) {
+  if (x !== value) { $DONE("m"); return; }
+  $DONE();
+}, function() { console.log("rejected BAD"); });
+```
+
+→ `RuntimeError: dereferencing a null pointer` in
+`__closure_17 ← __then_fulfill_6 ← __drain_microtasks` (standalone,
+zero-import instantiate + drain).
+
+The bisection fence (all probed):
+- same body with `console.log` instead of the `$DONE(...)` calls → WORKS;
+- `$DONE()` / `$DONE(1)` calls WITHOUT the `if (x !== value)` comparison →
+  WORK (zero-arg call, missing-param ternary, string concat all fine);
+- comparison present + $DONE declared but NOT called in the branches → WORKS;
+- comparison + branch-guarded `$DONE("m")` / `$DONE()` calls → **TRAPS**.
+
+So the trigger is the COMBINATION: an any-`!==` comparison plus
+branch-guarded calls to a module-level function (with an early `return`)
+inside a then-callback closure. NO harness files needed (earlier
+harness-scale hypothesis was disproven by this fence). The `__closure_N`
+frame suggests the closure body itself dereferences a null — plausibly a
+capture/local slot the branching layout leaves null on one path, or an
+any-comparison spill consumed after the branch. Ground in how
+`compileFunctionExpression`/closure lowering emits the if/early-return shape
+for an externref param, and what `__then_fulfill_*` passes as the closure
+env.
+
+## Why it matters
+
+These are exactly the test262 Promise-verification templates
+(`if (x !== value) { $DONE(msg); return; } $DONE();` is THE canonical
+then-assert shape) — fixing this single lowering plausibly flips most of the
+~150 null-deref sub-family across all Promise built-ins dirs. Gate any claim
+on measured runtime PASS (stride sample), per the #3417 discipline.
+
+## Note
+
+An uncaught trap here also SILENTLY ENDS the drain (#3545) — fixing #3545
+first would at least make this cluster's residuals scoreable.

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -617,7 +617,7 @@ function wrapAsyncCallInTryCatch(ctx: CodegenContext, fctx: FunctionContext, sta
       catches: [{ tagIdx, body: catchExn }],
       catchAll,
     });
-    releaseTempLocal(fctx, reasonLocal, { kind: "externref" });
+    releaseTempLocal(fctx, reasonLocal);
     return;
   }
   const rejectIdx = ensureLateImport(ctx, "Promise_reject", [{ kind: "externref" }], [{ kind: "externref" }]);

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -32,6 +32,7 @@ import {
   PROMISE_STATE_REJECTED,
 } from "./async-scheduler.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
+import { ensureExnTag } from "./registry/imports.js"; // (#3178) async-call rejection payload
 import { allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -581,15 +582,27 @@ function wrapAsyncCallInTryCatch(ctx: CodegenContext, fctx: FunctionContext, sta
   // construction in the catch_all instead.
   if (isStandalonePromiseActive(ctx)) {
     const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+    // (#3178) Complete the #1326 Phase-1C payload wiring this arm deferred:
+    // catch the native `__exn` tag and use its externref payload — the thrown
+    // JS value (e.g. the TypeError instance a sync-unwound async body threw) —
+    // as the rejection reason ($Promise.value). Before this, the reason was
+    // ALWAYS `ref.null.extern`, so every synchronously-unwinding async-fn
+    // throw rejected with NULL: handlers destructuring the reason
+    // (`({ constructor }) => …`, the for-await-dstr test262 template tail)
+    // then threw their OWN "Cannot destructure 'null' or 'undefined'" — the
+    // ~81-test cluster in the F2 harvest (#3417). catch_all stays as the
+    // reason-less fallback for foreign (non-`__exn`) exceptions only.
+    const tagIdx = ensureExnTag(ctx);
+    const reasonLocal = allocTempLocal(fctx, { kind: "externref" });
     const inner = fctx.body.splice(start);
-    // The thrown value is on the catch_all stack as externref (the
-    // `__exn` tag's externref payload); standalone catch_all consumes
-    // it and uses it as the rejection reason. We don't have access to
-    // the wasm exception payload op without `ensureExnTag`, so fall
-    // back to `ref.null.extern` as the reason — Phase 1B doesn't
-    // yet wire the catch-payload binding (Phase 1C will). Most async
-    // throws produce undefined-typed rejections at this stage, so
-    // null-extern is safe.
+    const catchExn: Instr[] = [
+      { op: "local.set", index: reasonLocal },
+      { op: "i32.const", value: PROMISE_STATE_REJECTED },
+      { op: "local.get", index: reasonLocal },
+      { op: "ref.null.extern" },
+      { op: "struct.new", typeIdx: promiseTypeIdx },
+      { op: "extern.convert_any" },
+    ];
     const catchAll: Instr[] = [
       { op: "i32.const", value: PROMISE_STATE_REJECTED },
       { op: "ref.null.extern" },
@@ -601,9 +614,10 @@ function wrapAsyncCallInTryCatch(ctx: CodegenContext, fctx: FunctionContext, sta
       op: "try",
       blockType: { kind: "val", type: { kind: "externref" } },
       body: inner,
-      catches: [],
+      catches: [{ tagIdx, body: catchExn }],
       catchAll,
     });
+    releaseTempLocal(fctx, reasonLocal, { kind: "externref" });
     return;
   }
   const rejectIdx = ensureLateImport(ctx, "Promise_reject", [{ kind: "externref" }], [{ kind: "externref" }]);

--- a/tests/issue-3542.test.ts
+++ b/tests/issue-3542.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3542 — standalone async-fn rejections must carry the THROWN VALUE.
+//
+// `wrapAsyncCallInTryCatch`'s standalone arm caught a synchronously-unwinding
+// async-body throw with a bare `catch_all` and minted the rejected `$Promise`
+// with `ref.null.extern` as the reason — an unfinished #1326 Phase-1C TODO.
+// Every sync-unwinding async throw (sync throw, AG0 sync-unwrapped await
+// continuation, sync-settling for-await drive) rejected with NULL; test262's
+// for-await-dstr rejection handlers then destructured null and manufactured
+// the "Cannot destructure 'null' or 'undefined'" corpus signature (~130 rows
+// — an ECHO of the defect, not the defect). Fix: a `catch $exn` arm whose tag
+// payload becomes the rejection reason; `catch_all` remains the reason-less
+// fallback for foreign exceptions only.
+
+async function runStandalone(src: string): Promise<string> {
+  const r = await compile(src, {
+    fileName: "test.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(r.imports.filter((i) => i.module === "env").map((i) => i.name)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const exp = instance.exports as Record<string, unknown>;
+  const drain = exp.__drain_microtasks;
+  if (typeof drain === "function") (drain as () => void)();
+  const prepare = exp.__stdout_prepare;
+  const charAt = exp.__stdout_char;
+  if (typeof prepare !== "function" || typeof charAt !== "function") return "<no sink>";
+  const len = ((prepare as () => number)() | 0) as number;
+  let out = "";
+  for (let i = 0; i < len; i++) out += String.fromCharCode(((charAt as (i: number) => number)(i) | 0) & 0xffff);
+  return out;
+}
+
+describe("#3542 standalone async-fn rejection reason carries the thrown value", () => {
+  it("sync throw in an async fn rejects with the real TypeError (not null)", async () => {
+    const out = await runStandalone(`
+      async function f() { throw new TypeError("boom-sync"); }
+      f().catch(function (e) {
+        if (e === null) console.log("reason NULL");
+        else if (e instanceof TypeError) console.log("TypeError:" + e.message);
+        else console.log("other:" + typeof e);
+      });
+    `);
+    expect(out).toContain("TypeError:boom-sync");
+    expect(out).not.toContain("reason NULL");
+  });
+
+  it("throw after a sync-unwrapped await rejects with the real TypeError", async () => {
+    const out = await runStandalone(`
+      async function f() { await Promise.resolve(1); throw new TypeError("boom-await"); }
+      f().catch(function (e) {
+        if (e === null) console.log("reason NULL");
+        else if (e instanceof TypeError) console.log("TypeError:" + e.message);
+        else console.log("other:" + typeof e);
+      });
+    `);
+    expect(out).toContain("TypeError:boom-await");
+    expect(out).not.toContain("reason NULL");
+  });
+
+  it("for-await dstr TypeError reaches the rejection handler intact (the #3417 cluster shape)", async () => {
+    // `[{ x }]` against `[]` → ObjectBindingPattern vs undefined → TypeError.
+    // Pre-fix the handler received NULL and its own destructure-of-null threw.
+    const out = await runStandalone(`
+      async function fn() { for await (let [{ x }] of [[]]) { return; } }
+      fn().then(function () { console.log("resolved BAD"); }, function (e) {
+        if (e === null) console.log("reason NULL");
+        else if (e instanceof TypeError) console.log("TypeError ok");
+        else console.log("other:" + typeof e);
+      });
+    `);
+    expect(out).toContain("TypeError ok");
+    expect(out).not.toContain("reason NULL");
+    expect(out).not.toContain("resolved BAD");
+  });
+
+  it("no-regression: direct and executor rejections still carry their reason", async () => {
+    const out = await runStandalone(`
+      Promise.reject(new TypeError("direct")).catch(function (e) {
+        console.log(e instanceof TypeError ? "direct ok" : "direct broken");
+      });
+      new Promise(function (res, rej) { rej(new TypeError("exec")); }).catch(function (e) {
+        console.log(e instanceof TypeError ? "exec ok" : "exec broken");
+      });
+    `);
+    expect(out).toContain("direct ok");
+    expect(out).toContain("exec ok");
+  });
+});


### PR DESCRIPTION
## What

Second #3178-umbrella slice from the #3417 F2 harvest: the ~130-row `Cannot destructure/access/convert` standalone async cluster (98 for-await-dstr). **Stacked on PR #3504** (`issue-3178-async-not-iterable`, #3538) — opened as DRAFT until it lands; will mark ready then.

## Root cause (probe-bisected; the corpus message was a decoy)

`wrapAsyncCallInTryCatch`'s standalone arm (src/codegen/expressions.ts) caught a synchronously-unwinding async-body throw with a bare `catch_all` and minted the rejected `$Promise` with `ref.null.extern` as the reason — a **documented #1326 Phase-1B TODO** ("Phase 1C will wire the catch-payload binding") that was never finished. Every standalone async call whose body unwinds synchronously (sync throw, AG0 sync-unwrapped await continuation, sync-settling for-await drive) rejected with **NULL**. The test262 template's rejection handler `({ constructor }) => …` then destructured null, and its OWN "Cannot destructure 'null' or 'undefined'" TypeError propagated to $DONE — manufacturing the corpus signature.

## Fix

Add a `catch $exn` arm (native `__exn` tag) ahead of `catch_all`: its externref payload — the thrown JS value — becomes the rejection reason (`$Promise.value`). `catch_all` remains the reason-less fallback for foreign exceptions only. No new imports; #2961 gate untouched. loc-budget allowance in #3542's frontmatter (+14 in the wrapper's own module).

## Measured

- Bisection probes flip: `async function f(){ throw new TypeError() }` and throw-after-await now reject with the real TypeError (`instanceof` + `.message` hold); direct/executor/late rejections were already correct (control).
- **30/33 PASS** on a stride-4 sample of the 130-row cluster (runtime PASS via the #3469 channel). 3 residuals = distinct `language/arguments-object/*async-gen*` sub-family, left open in #3178.
- Scoped suites green: async set (66), Promise machinery (58). The single issue-1326 host-lane WAT expectation failure is control-verified pre-existing on clean sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb