### PR TITLE
refactor(#3547): remove the #3024 funcref-cell struct.new stopgap (dead after #3534)

### DIFF
--- a/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
+++ b/plan/issues/3534-tostring-matcher-closure-construct-runtime-trap.md
@@ -298,7 +298,11 @@ externref by construction. A3-as-audited needs no code.
 
 GC (host) lane:
 - `built-ins/Function/prototype/toString` (80 files): **11 → 23 pass (+12, 0
-  lost)**; `illegal cast` rows **67 → 0**. The 57 remaining fails are genuine
+  lost)**; `illegal cast` rows **67 → 1** (corrected in #3547: the residual 1,
+  `S15.3.4.2_A16.js`, is PRE-EXISTING with an identical signature on the
+  pre-fix baseline — a distinct `__module_init` toString.call mechanism;
+  family-attributable elimination is 66. The original "0" was read from an
+  accidentally head-truncated sweep capture). The 57 remaining fails are genuine
   Test262Error oracle verdicts from a DIFFERENT defect (`"" + fn` yields
   `[object Object]` / callback-shim source instead of NativeFunction syntax)
   → filed as **#3540**, out of scope here.

--- a/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
+++ b/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
@@ -1,0 +1,70 @@
+---
+id: 3546
+title: "codegen: module TOP-LEVEL closure reassignment writes only the __module_init local shadow — cross-function calls read the stale first closure from the global"
+status: ready
+sprint: Backlog
+created: 2026-07-23
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: closures
+goal: correctness
+related: [3534, 3533]
+---
+
+# #3546 — `let f = () => 1; f = () => 2;` at module top level: `f()` from another function returns 1
+
+## Repro (verified 2026-07-23 on post-#3505 main; gc lane)
+
+```ts
+let f = (): number => 1;
+f = (): number => 2;
+export function test(): number { return f(); }
+// test() === 1   (want 2)   — binary sha256-16: d57a1b35964e0b09
+```
+
+`var` behaves identically (`module_var_reassign` → WRONG got=1). This is
+PRE-EXISTING relative to #3534/#3505 (same WRONG result + same binary hash on
+the pre-#3505 baseline) — it is the ASSIGNMENT-path sibling of the #3534
+declaration-path family, not a regression.
+
+## Scoping matrix (probe `.tmp/probe-3546.mts`, kept in the #3534 owner's notes)
+
+| shape | result |
+|---|---|
+| module top-level reassign, call from exported fn | **WRONG got=1** |
+| reassign inside a function (`set2()` writes `f`), then call | PASS |
+| purely local `let f = …; f = …; f()` | PASS |
+| module top-level `var` reassign | **WRONG got=1** |
+
+## Mechanism (verified by the scoping split; exact write-arm to confirm)
+
+The declaration's arrow path in `variables.ts` dual-stores the closure: it
+`local.tee`s a **local shadow of `f` inside `__module_init`** and boxes the
+value into the `$__mod_f` externref global. A LATER top-level reassignment
+statement compiles inside the same `__module_init` fctx, where
+`fctx.localMap.has("f")` is true — the assignment takes the LOCAL write arm and
+updates only the shadow local. The module global — which every OTHER function's
+read/call of `f` resolves through — still holds the first closure. The
+function-scope variant passes precisely because `set2`'s fctx has no local
+shadow, so the assignment writes the global.
+
+## Suggested direction
+
+In the assignment path, when the write target has BOTH a local shadow in the
+current fctx AND a module global (`ctx.moduleGlobals.has(name)`), mirror the
+declaration's dual-store: write the local AND box-on-store
+(`extern.convert_any` for a precise closure ref — the #3534 invariant: the
+global stays externref, never narrowed) into the global. Alternatively drop the
+`__module_init` local shadow entirely and route top-level reads through the
+global; the dual-store is the smaller change.
+
+## Acceptance criteria
+
+- The repro returns 2 on both lanes; `module_var_reassign` likewise.
+- The #3534 corpus (sha256s in that issue file) stays byte-identical except
+  the reassignment shapes.
+- No new invalid-Wasm signatures; equivalence suite delta zero.

--- a/plan/issues/3547-remove-3024-funcref-cell-stopgap.md
+++ b/plan/issues/3547-remove-3024-funcref-cell-stopgap.md
@@ -1,0 +1,80 @@
+---
+id: 3547
+title: "codegen: remove the #3024 funcref-cell struct.new stopgap in compileClosureCall (dead after #3534 — producer eliminated + zero-producer probe)"
+status: done
+sprint: current
+assignee: ttraenkler/fable-3534
+created: 2026-07-23
+updated: 2026-07-23
+completed: 2026-07-23
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: closures
+goal: correctness
+related: [3024, 3534, 3533]
+---
+
+# #3547 — remove the #3024 funcref-cell stopgap (design step 3 of #3534)
+
+## What was removed
+
+`compileClosureCall`'s boxed-capture arm (`src/codegen/expressions/calls-closures.ts`)
+carried a #3024 stopgap: when the ref cell's field-0 was a bare `funcref` AND the
+lifted self carrier was a single-funcref-field wrapper, rebuild the carrier via
+`struct.new` instead of the externref unwrap + guarded cast. This PR removes the
+branch and its `isSingleFuncRefWrapperStruct` helper (and the now-unused
+`refCellValueType` import).
+
+## Why removal is EVIDENCE-BASED, not optimistic (two halves, both load-bearing)
+
+1. **The one known producer is gone.** #3534's instrumented root cause showed
+   funcref-typed "cells" were never real ref cells: the `variables.ts`
+   declaration path RETYPED a boxed capture's cell local to the closure STRUCT
+   and re-registered that struct as `boxed.refCellTypeIdx` (a closure struct's
+   field 0 is `funcref` — hence the "bare funcref cell" the #3024 call site
+   observed). #3534/#3505 fixed the retype at the source: the declaration now
+   writes THROUGH the cell and never retypes it, so this producer cannot mint
+   funcref-cells anymore.
+2. **A probe confirms no OTHER producers exist.** "No producers found" alone
+   would be weaker — a probe can only show absence on the surfaces it covers.
+   Combined with (1), the argument closes: the only mechanism ever observed to
+   create the shape is eliminated, and an env-gated probe in
+   `getOrRegisterRefCellType` (flag any cell minted over `funcref` or a
+   `__closure_*`/`__fn_cap_*`/`__fn_wrap_*`/`closureInfoByTypeIdx` ref) shows
+   ZERO hits on the POST-#3505-merge tree (which also includes #3504 and the
+   other codegen PRs landed 2026-07-23) across:
+   - the 13-case closure corpus (#3534 issue file),
+   - 5 dedicated shapes: module-level + function-local mutually-recursive
+     consts, nested-fndecl mutual recursion, accessor-transitive capture,
+     `var pf = fn-using-forward-const`,
+   - the 4 module-reassignment shapes (#3546 probe),
+   - all 7 matcher-invoking `Function/prototype/toString` files,
+   - the full 80-file `Function/prototype/toString` dir,
+   - the 34-file `class/elements/*-literal-names` dir.
+
+   Probe recipe (temporary edit, env-gated `JS2WASM_PROBE_A3`, removed before
+   commit): log in `getOrRegisterRefCellType` when `valType.kind === "funcref"`
+   or the target type is a registered closure struct / funcref wrapper.
+
+## Post-removal validation (all measured)
+
+- 13-case corpus: **byte-identical** (every sha256 unchanged vs pre-removal).
+- `Function/prototype/toString` sweep: identical 23 pass / 57 fail; the single
+  `illegal cast` row (`S15.3.4.2_A16.js`, `__module_init` toString.call shape)
+  is PRE-EXISTING with an identical signature on the pre-#3534 baseline —
+  distinct mechanism, untouched by this family.
+- `class/elements/*-literal-names`: identical 30 pass / 4 fail.
+- Guard tests `issue-3534-closure-value-representation` (6) +
+  `issue-3024-tostring-closure-funcref` (1): green.
+
+## Bookkeeping correction to #3534's notes (recorded here + amended there)
+
+#3534's Test Results overstated the toString-dir trap elimination as "67 → 0";
+the accurate figure is **67 → 1**, the 1 being the pre-existing
+`S15.3.4.2_A16.js` row above (present with the identical signature in the
+pre-fix baseline sweep). The "0" was read from an accidentally head-truncated
+sweep capture. Family-attributable elimination: 66 rows.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -21,7 +21,6 @@ import { noJsHost } from "../js-errors.js";
 import { allocLocal } from "../context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
 import { addFuncType, addImport, localGlobalIdx, resolveWasmType } from "../index.js";
-import { refCellValueType } from "../registry/types.js";
 import { emitNullCheckThrow, typeErrorThrowInstrs } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
@@ -307,21 +306,6 @@ function emitRootFuncrefDispatch(
   fctx.body.push(...funcDispatch);
 }
 
-/**
- * (#3024) True when `typeIdx` is a no-capture closure funcref-WRAPPER struct —
- * exactly one field whose type is `funcref` (`(struct (field funcref))`). This is
- * the self carrier for a closure that keeps no environment in its self struct, so
- * it can be losslessly reconstructed from a bare funcref via `struct.new`. Guards
- * the #3024 rebuild so a self carrier that DOES hold capture fields (which
- * `struct.new` from a lone funcref would leave under-populated) never takes it.
- */
-function isSingleFuncRefWrapperStruct(ctx: CodegenContext, typeIdx: number): boolean {
-  const def = ctx.mod.types[typeIdx];
-  if (!def || def.kind !== "struct") return false;
-  const fields = (def as { fields: { type: ValType }[] }).fields;
-  return fields.length === 1 && fields[0]?.type.kind === "funcref";
-}
-
 /** Compile a call to a closure variable: closureVar(args...) */
 export function compileClosureCall(
   ctx: CodegenContext,
@@ -359,27 +343,27 @@ export function compileClosureCall(
       fctx.body.push({ op: "local.get", index: localIdx });
       // struct.get $refCell $value — unwrap to underlying value.
       fctx.body.push({ op: "struct.get", typeIdx: boxed.refCellTypeIdx, fieldIdx: 0 });
-      // (#3024) The ref cell may store the closure as a BARE FUNCREF: a
-      // mutually-recursive `const` closure (e.g. the test262
-      // `nativeFunctionMatcher` `eat`→`test` pair) whose self carrier is a
-      // no-capture funcref-WRAPPER struct `(struct (field funcref))`. There
-      // `boxed.valType` stale-reads `externref` while the cell field-0 is
-      // genuinely `funcref`, so the legacy path emitted `any.convert_extern` on
-      // a funcref (invalid — funcref is not in the anyref hierarchy) followed by
-      // a struct `emitGuardedRefCast` (also invalid). Trust the ACTUAL cell
-      // field type: when it is `funcref` AND the lifted self carrier is a
-      // single-funcref-field wrapper, rebuild the self carrier by wrapping the
-      // funcref back into that wrapper via `struct.new`. Byte-inert for every
-      // other cell shape — the funcref-cell call path was 100% invalid Wasm.
-      const cellFieldType = refCellValueType(ctx, boxed.refCellTypeIdx);
-      if (cellFieldType?.kind === "funcref" && isSingleFuncRefWrapperStruct(ctx, selfStructTypeIdx)) {
-        fctx.body.push({ op: "struct.new", typeIdx: selfStructTypeIdx });
-      } else {
-        if (boxed.valType.kind === "externref") {
-          fctx.body.push({ op: "any.convert_extern" });
-        }
-        emitGuardedRefCast(fctx, selfStructTypeIdx);
+      // (#3547) The #3024 funcref-cell `struct.new` stopgap that used to live
+      // here (rebuild the self carrier when the cell field-0 was a bare
+      // funcref) is REMOVED on two grounds, both load-bearing:
+      //   1. The one known PRODUCER of funcref-typed "cells" is gone: those
+      //      cells were never real ref cells — the variables.ts declaration
+      //      path retyped the capture's cell local to the closure STRUCT and
+      //      re-registered that struct as `boxed.refCellTypeIdx` (field 0 =
+      //      funcref). #3534/#3505 fixed the retype at the source (the
+      //      declaration now writes THROUGH the cell and never retypes it).
+      //   2. A zero-producer probe in `getOrRegisterRefCellType` (env-gated,
+      //      see #3547's issue file for the recipe) confirmed NO ref cell is
+      //      minted over funcref or any closure-struct carrier on the
+      //      post-#3505 tree — across the closure corpus, dedicated
+      //      mutual-recursion shapes, all matcher-invoking files, and the full
+      //      `Function/prototype/toString` + class-elements test262 dirs.
+      // Cells storing closures are externref cells; the externref arm below
+      // unwraps and guard-casts them to the lifted self carrier.
+      if (boxed.valType.kind === "externref") {
+        fctx.body.push({ op: "any.convert_extern" });
       }
+      emitGuardedRefCast(fctx, selfStructTypeIdx);
       fctx.body.push({ op: "local.set", index: castLocal });
       effectiveLocalIdx = castLocal;
     } else if (localType?.kind === "externref") {


### PR DESCRIPTION
## Summary

Design **step 3** of #3534's option-(a) plan: removes the #3024 funcref-cell `struct.new` rebuild branch in `compileClosureCall` (`src/codegen/expressions/calls-closures.ts`), its `isSingleFuncRefWrapperStruct` helper, and the now-unused `refCellValueType` import. Net −12 LOC of codegen.

## Why removal is evidence-based, not optimistic (two halves, both load-bearing)

1. **The one known producer is eliminated.** #3534's instrumented root cause showed the funcref-typed "cells" this stopgap served were never real ref cells: the `variables.ts` declaration path retyped a boxed capture's cell local to the closure STRUCT and re-registered that struct as `boxed.refCellTypeIdx` (a closure struct's field 0 is `funcref` — hence the "bare funcref cell" the #3024 call site observed). #3534/#3505 fixed the retype at the source; the declaration now writes THROUGH the cell and never retypes it.
2. **A probe confirms no others exist.** "No producers found" alone would be weaker evidence — a probe only shows absence on covered surfaces. Combined with (1) the argument closes: an env-gated probe in `getOrRegisterRefCellType` (flags any cell minted over `funcref` or a closure-struct/wrapper ref) shows **ZERO hits on the POST-#3505-merge tree** (which includes #3504 and today's other codegen merges) across: the 13-case closure corpus, 5 dedicated mutual-recursion / nested-fndecl / accessor-transitive shapes, the 4 module-reassignment shapes, all 7 matcher-invoking files, the full 80-file `Function/prototype/toString` dir, and the 34-file `class/elements/*-literal-names` dir. Recipe in #3547's issue file.

## Post-removal validation (all measured)

- **13-case corpus: byte-identical** — every sha256 unchanged vs pre-removal (recorded in #3534's issue file).
- toString dir sweep: identical **23 pass / 57 fail**; the single `illegal cast` row (`S15.3.4.2_A16.js`) is **pre-existing** with an identical signature on the pre-#3534 baseline (distinct `__module_init` toString.call mechanism).
- class-elements cluster: identical **30 / 4**.
- Guard tests `issue-3534-closure-value-representation` (6) + `issue-3024-tostring-closure-funcref` (1): green. `tsc --noEmit` + prettier clean.

## Also in this PR

- **Files #3546** (allocated via claim-issue): module TOP-LEVEL closure reassignment (`let f = () => 1; f = () => 2;`) writes only the `__module_init` local shadow, so cross-function `f()` returns the stale first closure from the global. Verified scoping matrix (function-scope reassign PASSES; top-level `let`/`var` both WRONG) + repro + sha256. Pre-existing (identical result + hash on pre-#3505 baseline) — the assignment-path sibling of #3534, status `ready`/Backlog.
- **Corrects #3534's bookkeeping**: toString-dir trap elimination is **67 → 1**, not 67 → 0 (the residual 1 is the pre-existing `S15.3.4.2_A16.js` row; family-attributable elimination = 66; the "0" was read from an accidentally head-truncated sweep capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb