### PR TITLE
fix(#3541): native reflective String.fromCharCode/fromCodePoint .call/.apply (stacked on #3503)

### DIFF
--- a/plan/issues/3541-standalone-fromcodepoint-apply-vec-null.md
+++ b/plan/issues/3541-standalone-fromcodepoint-apply-vec-null.md
@@ -1,9 +1,10 @@
 ---
 id: 3541
-title: "Standalone: String.fromCodePoint.apply(null, vec) returns null (__str_concat null-deref) — sole remaining gate on the RegExp property-escapes 311-row family"
-status: ready
+title: "Standalone: String.fromCodePoint.apply(null, vec) returns null (__str_concat null-deref) — the then-current gate on the RegExp property-escapes 311-row family"
+status: done
 created: 2026-07-23
 updated: 2026-07-23
+completed: 2026-07-23
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -13,9 +14,15 @@ goal: standalone
 sprint: current
 horizon: m
 umbrella: 2860
-related: [2860, 3536, 3535, 2088, 3138, 3139]
-files:
+assignee: ttraenkler/fable-2860
+related: [2860, 3536, 3535, 2088, 3138, 3139, 3549]
+loc-budget-allow:
+  - src/codegen/expressions/call-builtin-static.ts
   - src/codegen/expressions/calls.ts
+files:
+  - src/codegen/expressions/call-builtin-static.ts
+  - src/codegen/expressions/calls.ts
+  - tests/issue-3541.test.ts
 ---
 
 # Standalone: `String.fromCodePoint.apply(null, vec)` returns null
@@ -83,3 +90,50 @@ before choosing):
   unicode-property RegExp matching — measure, don't assume; if the RegExp
   engine lacks the property tables, record the residual honestly).
 - Zero host-lane changes (standalone-scoped or verified byte-identical).
+
+## Implementation (landed 2026-07-23; stacked on #3536)
+
+Option 1, in the subsystem module: `tryCompileFromCharCodeFamilyReflective`
+(`src/codegen/expressions/call-builtin-static.ts`), wired as a precise-match
+arm in the `.call/.apply` dispatch of `compileCallExpression`
+(`expressions/calls.ts`). Native-string lanes only; the host lane and every
+non-matching shape fall through byte-identically.
+
+- `.call(thisArg, …codes)` → synthetic direct `String.fromX(…codes)` (reuses
+  the #2088 fold + #2601/#2875 guards wholesale; thisArg evaluated first).
+- `.apply(thisArg)` / empty array → `""`.
+- `.apply(thisArg, arr)` with a STATICALLY-typed native vec → destructure +
+  shared `emitStringJoinFold` over the elements: §7.1.8 ToUint16 in the f64
+  domain (fromCharCode) / §22.1.2.2 integral+[0,0x10FFFF] RangeError guard
+  (fromCodePoint); i8/i16/i32/f64/externref(boxed) elements; #3224-style
+  backing bounds check (absent index ⇒ undefined semantics); null argArray ⇒
+  empty list.
+- `.apply(thisArg, arr)` with an EXTERNREF value (the #3536 struct-narrowed
+  callee shape — `const lone = args.pts` reads through the dynamic member
+  path, wrapping the vec) → `any.convert_extern` + guarded 2-way `ref.test`
+  dispatch over `$vec_f64` / `$vec_externref`, nullish ⇒ empty list, other
+  non-array-like ⇒ §Function.prototype.apply TypeError.
+- Re-eval-safety gate (identifier / literal / null / single member access on
+  an identifier / array literal) so the bail-to-legacy path can never double
+  side effects.
+
+## Measured results (2026-07-23, combined #3536+#3541 tree)
+
+- All 7 repro probes pass (top-level vec, struct-field, in-function
+  struct-narrowed; each buildString body variant incl. the grown
+  `codePoints` shape that formerly hit `illegal cast`).
+- `tests/issue-3541.test.ts`: 8/8 (ToUint16, RangeError, surrogate pairs,
+  empty/absent arrays, `.call`).
+- **Full 311-row property-escapes family through the real worker: 0/311
+  flips.** The apply layer is fixed and the wall MOVED one layer deeper —
+  304/311 now die at `RangeError: regular expression step limit exceeded`
+  in the native RegExp engine matching `^\p{…}+$` over the built
+  multi-thousand-char strings; 6 are `RGI_Emoji…`/`Basic_Emoji` sequence
+  properties; 1 misc. Filed as **#3549** with the per-signature tally —
+  the honest lesson of the #3536 census (2/198 vs the ~1,190 naive
+  extrapolation) applied: this fix's direct test262 yield is whatever the
+  CI baselines show for non-PE `fromCharCode/fromCodePoint.apply` users,
+  NOT the 311.
+- Battery: typecheck · string-methods/arrow-call-apply/iife equivalence
+  (123 tests) · issue-3536+3541 tests (13) · check:ir-fallbacks ·
+  oracle-ratchet (no new checker usage) · prettier/biome — all green.

--- a/plan/issues/3549-standalone-regexp-step-limit-unicode-property.md
+++ b/plan/issues/3549-standalone-regexp-step-limit-unicode-property.md
@@ -1,0 +1,63 @@
+---
+id: 3549
+title: "Standalone: native RegExp step limit exceeded on `\\p{...}+` over long strings — measured 304/311 gate on RegExp property-escapes"
+status: ready
+created: 2026-07-23
+updated: 2026-07-23
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+umbrella: 2860
+related: [2860, 3541, 3536, 2876, 3507, 2935]
+files:
+  - src/codegen/regexp-standalone.ts
+---
+
+# Native RegExp: step limit exceeded on `\p{…}+` over long strings
+
+## Measured discovery (the #3536 → #3541 chain, 2026-07-23)
+
+With #3536 (call-boundary) and #3541 (reflective `fromCodePoint.apply`)
+landed, ALL 311 `built-ins/RegExp/property-escapes/generated/` tests were run
+through the real sharded worker. **0/311 pass — the measured wall moved to
+the native RegExp engine itself:**
+
+| count | signature                                                                                                 |
+| ----: | --------------------------------------------------------------------------------------------------------- |
+|   304 | `RangeError: regular expression step limit exceeded`                                                      |
+|     6 | `Test262Error: \p{RGI_Emoji…}/\p{Basic_Emoji} should match …` (sequence properties, `v`-mode string sets) |
+|     1 | misc                                                                                                      |
+
+The tests build multi-thousand-character strings (`buildString` — every
+matching code point of a Unicode property) and assert
+`RegExp("^\\p{Prop}+$", "u")` matches the whole string (and its negation
+misses per-char). The 304 rows are the engine's backtracking-step cap firing
+on that shape — i.e. the `\p{…}` class match is super-linear (likely a large
+alternation / per-char backtrack instead of an O(1) class test per char),
+so a `+` over N chars blows the step budget.
+
+## Direction (verify against src/codegen/regexp-standalone.ts first)
+
+1. Measure where the steps go: is `\p{…}` compiled to a range-set test
+   (good) that the step counter over-charges, or expanded to alternations
+   (bad)? A greedy `X+$` over N chars with an O(1) per-char class test
+   should cost O(N) steps.
+2. Candidate fixes, cheapest first: (a) charge class-set tests as ONE step;
+   (b) raise/scale the step limit with subject length; (c) compile `\p{…}`
+   to binary-searched range tables if it is not already.
+3. The 6 emoji-sequence rows are a DIFFERENT feature (`RGI_Emoji…` string
+   properties, `v`-flag territory) — do not conflate; split out if the range
+   fix lands without them.
+
+## Acceptance
+
+- Re-run the full 311 through the real worker (the #3541 method —
+  `.tmp/drive-worker.mjs` + `.tmp/pe-all.txt` in the fable-2860 worktree)
+  and report the REAL flip count. Target: the 304 step-limit rows pass.
+- No step-limit regressions on existing passing RegExp rows (the limit
+  exists as a runaway-backtracking guard — keep pathological cases bounded).

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -3309,7 +3309,17 @@ export function tryCompileFromCharCodeFamilyReflective(
     e.kind === ts.SyntaxKind.FalseKeyword ||
     ts.isNumericLiteral(e) ||
     ts.isStringLiteralLike(e);
-  if (!reEvalSafe(thisArg) || !(reEvalSafe(argsVal) || ts.isArrayLiteralExpression(argsVal))) {
+  // The argsArray additionally admits `obj.prop` (single member access on an
+  // identifier — the `buildString(args){ …apply(null, args.pts) }` shape) and
+  // array literals. The bail-after-compile path only re-evaluates when the
+  // compiled type is NOT a supported vec; a getter-bearing read of that shape
+  // is already broken on the legacy path today, so the residual double-eval
+  // exposure is strictly smaller than the bug this replaces.
+  const argsReEvalSafe =
+    reEvalSafe(argsVal) ||
+    ts.isArrayLiteralExpression(argsVal) ||
+    (ts.isPropertyAccessExpression(argsVal) && ts.isIdentifier(argsVal.expression));
+  if (!reEvalSafe(thisArg) || !argsReEvalSafe) {
     return undefined;
   }
 
@@ -3317,187 +3327,279 @@ export function tryCompileFromCharCodeFamilyReflective(
 
   const argType = compileExpression(ctx, fctx, argsVal);
   if (argType === null) return null;
-  if (argType.kind !== "ref" && argType.kind !== "ref_null") {
-    fctx.body.push({ op: "drop" });
-    return undefined; // re-eval-safe by the gate above
-  }
-  const vecTypeIdx = argType.typeIdx;
-  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
-  if (arrTypeIdx < 0) {
-    fctx.body.push({ op: "drop" });
-    return undefined;
-  }
-  const arrDef = ctx.mod.types[arrTypeIdx] as { kind: "array"; element: ValType };
-  const elemType = arrDef.element;
-  if (
-    elemType.kind !== "f64" &&
-    elemType.kind !== "i32" &&
-    elemType.kind !== "i8" &&
-    elemType.kind !== "i16" &&
-    elemType.kind !== "externref"
-  ) {
-    fctx.body.push({ op: "drop" });
-    return undefined;
-  }
 
-  // vec destructure — a null argArray spreads as the empty list (len stays 0).
-  const vecTmp = allocLocal(fctx, `__fccapply_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
-  const dataTmp = allocLocal(fctx, `__fccapply_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
-  const foldLocals = allocJoinFoldLocals(fctx, repr, "fccapply");
-  fctx.body.push({ op: "local.set", index: vecTmp });
-  fctx.body.push({ op: "local.get", index: vecTmp });
-  fctx.body.push({ op: "ref.is_null" });
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "empty" },
-    then: [
-      { op: "i32.const", value: 0 },
-      { op: "local.set", index: foldLocals.lenTmp },
-    ],
-    else: [
-      { op: "local.get", index: vecTmp },
-      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
-      { op: "local.set", index: foldLocals.lenTmp },
-      { op: "local.get", index: vecTmp },
-      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
-      { op: "local.set", index: dataTmp },
-    ],
-  });
-  fctx.body.push(...repr.literal(""));
-  fctx.body.push({ op: "local.set", index: foldLocals.resultTmp });
-  fctx.body.push(...repr.literal(""));
-  fctx.body.push({ op: "local.set", index: foldLocals.sepTmp });
-  fctx.body.push({ op: "i32.const", value: 0 });
-  fctx.body.push({ op: "local.set", index: foldLocals.iTmp });
+  const vecElemSupported = (k: string): boolean =>
+    k === "f64" || k === "i32" || k === "i8" || k === "i16" || k === "externref";
 
-  // elem → 1-char string. Built via a body swap so emitThrowRangeError (a
-  // late-import-bearing emitter) targets the buffer; registered with
-  // ctx.liveBodies so a later late-import shift still fixes baked indices
-  // (the #2088 family pattern), and de-registered after the splice.
-  const elemBuf: Instr[] = [];
-  ctx.liveBodies.add(elemBuf);
-  const savedBody = fctx.body;
-  fctx.body = elemBuf;
-  try {
-    const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
-    elemBuf.push({ op: "local.get", index: dataTmp });
-    elemBuf.push({ op: "local.get", index: foldLocals.iTmp });
-    elemBuf.push({ op: getOp, typeIdx: arrTypeIdx } as Instr);
-    if (elemType.kind === "externref") {
-      // Boxed-any element → numeric code via the shared coercion engine
-      // (unboxes `__box_number` payloads; undefined → NaN).
-      coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" });
-    }
-    const elemIsF64 = elemType.kind === "f64" || elemType.kind === "externref";
-    if (isFromCodePoint) {
-      if (elemIsF64) {
-        // §22.1.2.2 2b/2c — non-integral (incl. NaN) or out-of-[0,0x10FFFF]
-        // code points throw RangeError (mirrors the direct-call family arm).
-        const cpTmp = allocTempLocal(fctx, { kind: "f64" });
-        elemBuf.push({ op: "local.tee", index: cpTmp });
-        elemBuf.push({ op: "local.get", index: cpTmp });
-        elemBuf.push({ op: "f64.trunc" });
-        elemBuf.push({ op: "f64.ne" });
-        elemBuf.push({ op: "local.get", index: cpTmp });
-        elemBuf.push({ op: "f64.const", value: 0 });
-        elemBuf.push({ op: "f64.lt" });
-        elemBuf.push({ op: "local.get", index: cpTmp });
-        elemBuf.push({ op: "f64.const", value: 0x10ffff });
-        elemBuf.push({ op: "f64.gt" });
-        elemBuf.push({ op: "i32.or" });
-        elemBuf.push({ op: "i32.or" });
-        const throwBuf: Instr[] = [];
-        fctx.body = throwBuf;
-        emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
-        fctx.body = elemBuf;
-        elemBuf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf });
-        elemBuf.push({ op: "local.get", index: cpTmp });
-        elemBuf.push({ op: "i32.trunc_sat_f64_s" });
-        releaseTempLocal(fctx, cpTmp);
-      } else {
-        // Integral by construction; range-check in the i32 domain.
-        const cpTmp = allocTempLocal(fctx, { kind: "i32" });
-        elemBuf.push({ op: "local.tee", index: cpTmp });
-        elemBuf.push({ op: "i32.const", value: 0 });
-        elemBuf.push({ op: "i32.lt_s" });
-        elemBuf.push({ op: "local.get", index: cpTmp });
-        elemBuf.push({ op: "i32.const", value: 0x10ffff });
-        elemBuf.push({ op: "i32.gt_s" });
-        elemBuf.push({ op: "i32.or" });
-        const throwBuf: Instr[] = [];
-        fctx.body = throwBuf;
-        emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
-        fctx.body = elemBuf;
-        elemBuf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf });
-        elemBuf.push({ op: "local.get", index: cpTmp });
-        releaseTempLocal(fctx, cpTmp);
-      }
-    } else if (elemIsF64) {
-      // fromCharCode: §7.1.8 ToUint16 in the f64 domain BEFORE the i32
-      // conversion (the #2875 slice-5 pattern — NaN/±Inf → 0, |x| ≥ 2^31 keeps
-      // its true modulo; a bare trunc_sat saturates first and gets both wrong).
-      const u16Tmp = allocTempLocal(fctx, { kind: "f64" });
-      elemBuf.push({ op: "f64.trunc" });
-      elemBuf.push({ op: "local.tee", index: u16Tmp });
-      elemBuf.push({ op: "local.get", index: u16Tmp });
-      elemBuf.push({ op: "f64.const", value: 65536 });
-      elemBuf.push({ op: "f64.div" });
-      elemBuf.push({ op: "f64.floor" });
-      elemBuf.push({ op: "f64.const", value: 65536 });
-      elemBuf.push({ op: "f64.mul" });
-      elemBuf.push({ op: "f64.sub" });
-      elemBuf.push({ op: "i32.trunc_sat_f64_s" });
-      releaseTempLocal(fctx, u16Tmp);
-    }
-    // i32/i8/i16 fromCharCode: the helper's low-16 mask IS ToUint16.
-    elemBuf.push({ op: "call", funcIdx: helperIdx });
-  } finally {
-    fctx.body = savedBody;
-  }
+  /**
+   * Emit the destructure + join fold for ONE concrete vec type. Precondition:
+   * a `(ref null vecTypeIdx)` value is on the stack. Leaves one
+   * `repr.resultType` value. A null argArray spreads as the empty list
+   * (len stays 0 → "").
+   */
+  const emitVecSpreadFold = (vecTypeIdx: number, arrTypeIdx: number, elemType: ValType): void => {
+    const vecTmp = allocLocal(fctx, `__fccapply_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+    const dataTmp = allocLocal(fctx, `__fccapply_data_${fctx.locals.length}`, {
+      kind: "ref_null",
+      typeIdx: arrTypeIdx,
+    });
+    const foldLocals = allocJoinFoldLocals(fctx, repr, "fccapply");
+    fctx.body.push({ op: "local.set", index: vecTmp });
+    fctx.body.push({ op: "local.get", index: vecTmp });
+    fctx.body.push({ op: "ref.is_null" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: foldLocals.lenTmp },
+      ],
+      else: [
+        { op: "local.get", index: vecTmp },
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+        { op: "local.set", index: foldLocals.lenTmp },
+        { op: "local.get", index: vecTmp },
+        { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+        { op: "local.set", index: dataTmp },
+      ],
+    });
+    fctx.body.push(...repr.literal(""));
+    fctx.body.push({ op: "local.set", index: foldLocals.resultTmp });
+    fctx.body.push(...repr.literal(""));
+    fctx.body.push({ op: "local.set", index: foldLocals.sepTmp });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "local.set", index: foldLocals.iTmp });
 
-  // (#3224-style) Bounds-check against the physical backing: a grown/sparse
-  // array's logical length can exceed it; an absent index spreads as
-  // `undefined` — RangeError for fromCodePoint (NaN is not integral), code 0
-  // for fromCharCode.
-  const oobBuf: Instr[] = [];
-  if (isFromCodePoint) {
-    ctx.liveBodies.add(oobBuf);
-    fctx.body = oobBuf;
+    // elem → 1-char string. Built via a body swap so emitThrowRangeError (a
+    // late-import-bearing emitter) targets the buffer; registered with
+    // ctx.liveBodies so a later late-import shift still fixes baked indices
+    // (the #2088 family pattern), and de-registered after the splice.
+    const elemBuf: Instr[] = [];
+    ctx.liveBodies.add(elemBuf);
+    const savedBody = fctx.body;
+    fctx.body = elemBuf;
     try {
-      emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+      const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
+      elemBuf.push({ op: "local.get", index: dataTmp });
+      elemBuf.push({ op: "local.get", index: foldLocals.iTmp });
+      elemBuf.push({ op: getOp, typeIdx: arrTypeIdx } as Instr);
+      if (elemType.kind === "externref") {
+        // Boxed-any element → numeric code via the shared coercion engine
+        // (unboxes `__box_number` payloads; undefined → NaN).
+        coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" });
+      }
+      const elemIsF64 = elemType.kind === "f64" || elemType.kind === "externref";
+      if (isFromCodePoint) {
+        if (elemIsF64) {
+          // §22.1.2.2 2b/2c — non-integral (incl. NaN) or out-of-[0,0x10FFFF]
+          // code points throw RangeError (mirrors the direct-call family arm).
+          const cpTmp = allocTempLocal(fctx, { kind: "f64" });
+          elemBuf.push({ op: "local.tee", index: cpTmp });
+          elemBuf.push({ op: "local.get", index: cpTmp });
+          elemBuf.push({ op: "f64.trunc" });
+          elemBuf.push({ op: "f64.ne" });
+          elemBuf.push({ op: "local.get", index: cpTmp });
+          elemBuf.push({ op: "f64.const", value: 0 });
+          elemBuf.push({ op: "f64.lt" });
+          elemBuf.push({ op: "local.get", index: cpTmp });
+          elemBuf.push({ op: "f64.const", value: 0x10ffff });
+          elemBuf.push({ op: "f64.gt" });
+          elemBuf.push({ op: "i32.or" });
+          elemBuf.push({ op: "i32.or" });
+          const throwBuf: Instr[] = [];
+          fctx.body = throwBuf;
+          emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+          fctx.body = elemBuf;
+          elemBuf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf });
+          elemBuf.push({ op: "local.get", index: cpTmp });
+          elemBuf.push({ op: "i32.trunc_sat_f64_s" });
+          releaseTempLocal(fctx, cpTmp);
+        } else {
+          // Integral by construction; range-check in the i32 domain.
+          const cpTmp = allocTempLocal(fctx, { kind: "i32" });
+          elemBuf.push({ op: "local.tee", index: cpTmp });
+          elemBuf.push({ op: "i32.const", value: 0 });
+          elemBuf.push({ op: "i32.lt_s" });
+          elemBuf.push({ op: "local.get", index: cpTmp });
+          elemBuf.push({ op: "i32.const", value: 0x10ffff });
+          elemBuf.push({ op: "i32.gt_s" });
+          elemBuf.push({ op: "i32.or" });
+          const throwBuf: Instr[] = [];
+          fctx.body = throwBuf;
+          emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+          fctx.body = elemBuf;
+          elemBuf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf });
+          elemBuf.push({ op: "local.get", index: cpTmp });
+          releaseTempLocal(fctx, cpTmp);
+        }
+      } else if (elemIsF64) {
+        // fromCharCode: §7.1.8 ToUint16 in the f64 domain BEFORE the i32
+        // conversion (the #2875 slice-5 pattern — NaN/±Inf → 0, |x| ≥ 2^31
+        // keeps its true modulo; a bare trunc_sat saturates first and gets
+        // both wrong).
+        const u16Tmp = allocTempLocal(fctx, { kind: "f64" });
+        elemBuf.push({ op: "f64.trunc" });
+        elemBuf.push({ op: "local.tee", index: u16Tmp });
+        elemBuf.push({ op: "local.get", index: u16Tmp });
+        elemBuf.push({ op: "f64.const", value: 65536 });
+        elemBuf.push({ op: "f64.div" });
+        elemBuf.push({ op: "f64.floor" });
+        elemBuf.push({ op: "f64.const", value: 65536 });
+        elemBuf.push({ op: "f64.mul" });
+        elemBuf.push({ op: "f64.sub" });
+        elemBuf.push({ op: "i32.trunc_sat_f64_s" });
+        releaseTempLocal(fctx, u16Tmp);
+      }
+      // i32/i8/i16 fromCharCode: the helper's low-16 mask IS ToUint16.
+      elemBuf.push({ op: "call", funcIdx: helperIdx });
     } finally {
       fctx.body = savedBody;
     }
-    oobBuf.push(...repr.literal(""));
-  } else {
-    oobBuf.push({ op: "i32.const", value: 0 });
-    oobBuf.push({ op: "call", funcIdx: helperIdx });
+
+    // (#3224-style) Bounds-check against the physical backing: a grown/sparse
+    // array's logical length can exceed it; an absent index spreads as
+    // `undefined` — RangeError for fromCodePoint (NaN is not integral),
+    // code 0 for fromCharCode.
+    const oobBuf: Instr[] = [];
+    if (isFromCodePoint) {
+      ctx.liveBodies.add(oobBuf);
+      fctx.body = oobBuf;
+      try {
+        emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+      } finally {
+        fctx.body = savedBody;
+      }
+      oobBuf.push(...repr.literal(""));
+    } else {
+      oobBuf.push({ op: "i32.const", value: 0 });
+      oobBuf.push({ op: "call", funcIdx: helperIdx });
+    }
+    const boundsCheckedElem: Instr[] = [
+      { op: "local.get", index: dataTmp },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: repr.resultType },
+        then: [...oobBuf],
+        else: [
+          { op: "local.get", index: foldLocals.iTmp },
+          { op: "local.get", index: dataTmp },
+          { op: "array.len" },
+          { op: "i32.lt_s" },
+          {
+            op: "if",
+            blockType: { kind: "val", type: repr.resultType },
+            then: elemBuf,
+            else: [...oobBuf],
+          },
+        ],
+      },
+    ];
+
+    emitStringJoinFold(ctx, fctx, repr, foldLocals, boundsCheckedElem);
+    ctx.liveBodies.delete(elemBuf);
+    ctx.liveBodies.delete(oobBuf);
+    fctx.body.push({ op: "local.get", index: foldLocals.resultTmp });
+  };
+
+  // Statically-typed native vec argument: fold it directly.
+  if (argType.kind === "ref" || argType.kind === "ref_null") {
+    const vecTypeIdx = argType.typeIdx;
+    const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+    if (arrTypeIdx < 0) {
+      fctx.body.push({ op: "drop" });
+      return undefined;
+    }
+    const elemType = (ctx.mod.types[arrTypeIdx] as { kind: "array"; element: ValType }).element;
+    if (!vecElemSupported(elemType.kind)) {
+      fctx.body.push({ op: "drop" });
+      return undefined;
+    }
+    emitVecSpreadFold(vecTypeIdx, arrTypeIdx, elemType);
+    return repr.resultType;
   }
-  const boundsCheckedElem: Instr[] = [
-    { op: "local.get", index: dataTmp },
-    { op: "ref.is_null" },
-    {
+
+  // EXTERNREF argument — the shape inside a struct-narrowed callee (#3536):
+  // `const lone = args.loneCodePoints` reads through the dynamic member path,
+  // so the local carries the vec WRAPPED as externref. Unwrap and dispatch on
+  // the two vec representations a JS `number[]` can take here ($vec_f64 for
+  // typed literals, $vec_externref for boxed/grown arrays); anything else is
+  // not array-like spreadable — §Function.prototype.apply step 4 TypeError.
+  if (argType.kind === "externref") {
+    const vecF64Idx = getOrRegisterVecType(ctx, "f64", { kind: "f64" });
+    const arrF64Idx = getArrTypeIdxFromVec(ctx, vecF64Idx);
+    const vecExtIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+    const arrExtIdx = getArrTypeIdxFromVec(ctx, vecExtIdx);
+    if (arrF64Idx < 0 || arrExtIdx < 0) {
+      fctx.body.push({ op: "drop" });
+      return undefined;
+    }
+    const anyTmp = allocLocal(fctx, `__fccapply_any_${fctx.locals.length}`, { kind: "anyref" });
+    fctx.body.push({ op: "any.convert_extern" });
+    fctx.body.push({ op: "local.set", index: anyTmp });
+
+    const savedBody = fctx.body;
+    const buildArm = (vecIdx: number, arrIdx: number, elemType: ValType): Instr[] => {
+      const buf: Instr[] = [];
+      ctx.liveBodies.add(buf);
+      fctx.body = buf;
+      try {
+        buf.push({ op: "local.get", index: anyTmp });
+        buf.push({ op: "ref.cast_null", typeIdx: vecIdx });
+        emitVecSpreadFold(vecIdx, arrIdx, elemType);
+      } finally {
+        fctx.body = savedBody;
+      }
+      ctx.liveBodies.delete(buf);
+      return buf;
+    };
+    const f64Arm = buildArm(vecF64Idx, arrF64Idx, { kind: "f64" });
+    const extArm = buildArm(vecExtIdx, arrExtIdx, { kind: "externref" });
+    const throwArm: Instr[] = [];
+    ctx.liveBodies.add(throwArm);
+    fctx.body = throwArm;
+    try {
+      // Also covers null/undefined argArray: §Function.prototype.apply treats
+      // those as the empty list — test nullish BEFORE the TypeError.
+      throwArm.push({ op: "local.get", index: anyTmp });
+      throwArm.push({ op: "ref.is_null" });
+      const emptyArm: Instr[] = [...repr.literal("")];
+      const teBuf: Instr[] = [];
+      fctx.body = teBuf;
+      emitThrowTypeError(ctx, fctx, "TypeError: CreateListFromArrayLike called on non-object");
+      fctx.body = throwArm;
+      teBuf.push(...repr.literal("")); // unreachable filler after throw; keeps the arm typed
+      throwArm.push({
+        op: "if",
+        blockType: { kind: "val", type: repr.resultType },
+        then: emptyArm,
+        else: teBuf,
+      });
+    } finally {
+      fctx.body = savedBody;
+    }
+    ctx.liveBodies.delete(throwArm);
+
+    fctx.body.push({ op: "local.get", index: anyTmp });
+    fctx.body.push({ op: "ref.test", typeIdx: vecF64Idx });
+    fctx.body.push({
       op: "if",
       blockType: { kind: "val", type: repr.resultType },
-      then: [...oobBuf],
+      then: f64Arm,
       else: [
-        { op: "local.get", index: foldLocals.iTmp },
-        { op: "local.get", index: dataTmp },
-        { op: "array.len" },
-        { op: "i32.lt_s" },
+        { op: "local.get", index: anyTmp },
+        { op: "ref.test", typeIdx: vecExtIdx },
         {
           op: "if",
           blockType: { kind: "val", type: repr.resultType },
-          then: elemBuf,
-          else: [...oobBuf],
+          then: extArm,
+          else: throwArm,
         },
       ],
-    },
-  ];
+    });
+    return repr.resultType;
+  }
 
-  emitStringJoinFold(ctx, fctx, repr, foldLocals, boundsCheckedElem);
-  ctx.liveBodies.delete(elemBuf);
-  ctx.liveBodies.delete(oobBuf);
-  fctx.body.push({ op: "local.get", index: foldLocals.resultTmp });
-  return repr.resultType;
+  fctx.body.push({ op: "drop" });
+  return undefined; // re-eval-safe by the gate above
 }

--- a/src/codegen/expressions/call-builtin-static.ts
+++ b/src/codegen/expressions/call-builtin-static.ts
@@ -25,7 +25,13 @@ import {
 } from "../array-object-proto.js";
 import { undefinedExternInstrs } from "../any-helpers.js";
 import { BUILTIN_STATIC_METHOD_ARITY, pushBuiltinFnSingletonValueInstrs } from "../builtin-fn-meta.js";
-import { emitVariadicStringConcat } from "../builtin-scaffold.js";
+import {
+  allocJoinFoldLocals,
+  emitStringJoinFold,
+  emitVariadicStringConcat,
+  nativeStringRepr,
+} from "../builtin-scaffold.js";
+import { emitThrowRangeError } from "../js-errors.js";
 import {
   isSymbolSpeciesKeyExpression,
   resolveBuiltinReceiverName,
@@ -36,7 +42,7 @@ import {
 import { compileArrowAsClosure } from "../closures.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
-import { allocLocal } from "../context/locals.js";
+import { allocLocal, allocTempLocal, releaseTempLocal } from "../context/locals.js";
 import { rollbackSpeculative, snapshotSpeculative } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { emitGlobalThisGopdFold } from "../dyn-read.js";
@@ -66,6 +72,7 @@ import {
   ensureNativeStringExternBridge,
   ensureNativeStringHelpers,
   ensureStrToCharVecHelper,
+  nativeStringLiteralInstrs,
   stringConstantExternrefInstrs,
 } from "../native-strings.js";
 import {
@@ -3210,4 +3217,287 @@ export function compileBuiltinStaticCall(
     return { kind: "externref" };
   }
   return undefined;
+}
+
+/**
+ * (#3541) `String.fromCharCode` / `String.fromCodePoint` invoked REFLECTIVELY —
+ * `.call(thisArg, …codes)` or `.apply(thisArg, codesArray)` — on the native
+ * string lanes (`ctx.nativeStrings`, standalone/WASI).
+ *
+ * Why this exists: the generic reflective path wraps the builtin static in a
+ * closure and routes through the runtime apply machinery, which cannot spread
+ * a native `$vec` argv into the builtin's variadic lowering — the result is a
+ * null string and the first consumer null-derefs in `__str_concat`. That is
+ * the SOLE remaining gate on the 311 `built-ins/RegExp/property-escapes`
+ * baseline rows (every one runs `regExpUtils.js`'s `buildString`, whose two
+ * `String.fromCodePoint.apply(null, <array>)` calls die here). See
+ * plan/issues/3541-standalone-fromcodepoint-apply-vec-null.md.
+ *
+ * Lowering:
+ *   - `.call(thisArg, a, b)`  → direct `String.fromX(a, b)` (§22.1.2.* never
+ *     reads `this`); thisArg is evaluated first for argument order.
+ *   - `.apply(thisArg)`       → `""` (empty code-unit list).
+ *   - `.apply(thisArg, arr)`  → runtime fold over the native vec: per element
+ *     load → ToUint16 (`fromCharCode`) or the §22.1.2.2 integral/[0,0x10FFFF]
+ *     RangeError guard (`fromCodePoint`) → the 1-char native helper → shared
+ *     `emitStringJoinFold` concat (sep "", `""` for the empty/null array).
+ *
+ * Precision gates (fall through to the legacy path, `undefined`):
+ *   - host lane (js-string) — untouched, it has a working host `.apply`;
+ *   - thisArg / argsArray not re-eval-safe (identifier, literal, null, …) —
+ *     bailing after compilation would double side effects on the legacy
+ *     recompile;
+ *   - argsArray does not compile to a native `$vec` of f64/i32/i8/i16/externref
+ *     elements (the compiled value is dropped; the gate above makes that safe).
+ */
+export function tryCompileFromCharCodeFamilyReflective(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  innerExpr: ts.Expression,
+  isCall: boolean,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings || ctx.nativeStrTypeIdx < 0) return undefined;
+  let target: ts.Expression = innerExpr;
+  while (ts.isParenthesizedExpression(target) || ts.isAsExpression(target) || ts.isNonNullExpression(target)) {
+    target = target.expression;
+  }
+  if (!ts.isPropertyAccessExpression(target)) return undefined;
+  if (!ts.isIdentifier(target.expression) || target.expression.text !== "String") return undefined;
+  const mName = target.name.text;
+  if (mName !== "fromCharCode" && mName !== "fromCodePoint") return undefined;
+  const isFromCodePoint = mName === "fromCodePoint";
+  ensureNativeStringHelpers(ctx);
+  const repr = nativeStringRepr(ctx);
+  const helperIdx = ctx.nativeStrHelpers.get(isFromCodePoint ? "__str_fromCodePoint" : "__str_fromCharCode");
+  if (repr === undefined || helperIdx === undefined) return undefined;
+
+  const dropCompiled = (t: ValType | null): void => {
+    if (t !== null) fctx.body.push({ op: "drop" });
+  };
+
+  // `.call(thisArg, …codes)` → direct family call (reuses the #2088 fold and
+  // the #2601/#2875 per-argument coercion + guards wholesale).
+  if (isCall) {
+    if (expr.arguments.length > 0) dropCompiled(compileExpression(ctx, fctx, expr.arguments[0]!));
+    const synthetic = ts.factory.createCallExpression(
+      target as ts.LeftHandSideExpression,
+      undefined,
+      expr.arguments.slice(1),
+    );
+    ts.setTextRange(synthetic, expr);
+    (synthetic as { parent?: ts.Node }).parent = expr.parent;
+    return compileExpression(ctx, fctx, synthetic);
+  }
+
+  // `.apply()` / `.apply(thisArg)` — §: argArray absent → empty list → "".
+  if (expr.arguments.length < 2) {
+    if (expr.arguments.length === 1) dropCompiled(compileExpression(ctx, fctx, expr.arguments[0]!));
+    fctx.body.push(...repr.literal(""));
+    return repr.resultType;
+  }
+
+  const thisArg = expr.arguments[0]!;
+  let argsVal: ts.Expression = expr.arguments[1]!;
+  while (ts.isParenthesizedExpression(argsVal) || ts.isAsExpression(argsVal) || ts.isNonNullExpression(argsVal)) {
+    argsVal = argsVal.expression;
+  }
+  const reEvalSafe = (e: ts.Expression): boolean =>
+    ts.isIdentifier(e) ||
+    e.kind === ts.SyntaxKind.NullKeyword ||
+    e.kind === ts.SyntaxKind.TrueKeyword ||
+    e.kind === ts.SyntaxKind.FalseKeyword ||
+    ts.isNumericLiteral(e) ||
+    ts.isStringLiteralLike(e);
+  if (!reEvalSafe(thisArg) || !(reEvalSafe(argsVal) || ts.isArrayLiteralExpression(argsVal))) {
+    return undefined;
+  }
+
+  dropCompiled(compileExpression(ctx, fctx, thisArg));
+
+  const argType = compileExpression(ctx, fctx, argsVal);
+  if (argType === null) return null;
+  if (argType.kind !== "ref" && argType.kind !== "ref_null") {
+    fctx.body.push({ op: "drop" });
+    return undefined; // re-eval-safe by the gate above
+  }
+  const vecTypeIdx = argType.typeIdx;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) {
+    fctx.body.push({ op: "drop" });
+    return undefined;
+  }
+  const arrDef = ctx.mod.types[arrTypeIdx] as { kind: "array"; element: ValType };
+  const elemType = arrDef.element;
+  if (
+    elemType.kind !== "f64" &&
+    elemType.kind !== "i32" &&
+    elemType.kind !== "i8" &&
+    elemType.kind !== "i16" &&
+    elemType.kind !== "externref"
+  ) {
+    fctx.body.push({ op: "drop" });
+    return undefined;
+  }
+
+  // vec destructure — a null argArray spreads as the empty list (len stays 0).
+  const vecTmp = allocLocal(fctx, `__fccapply_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+  const dataTmp = allocLocal(fctx, `__fccapply_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
+  const foldLocals = allocJoinFoldLocals(fctx, repr, "fccapply");
+  fctx.body.push({ op: "local.set", index: vecTmp });
+  fctx.body.push({ op: "local.get", index: vecTmp });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: foldLocals.lenTmp },
+    ],
+    else: [
+      { op: "local.get", index: vecTmp },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: foldLocals.lenTmp },
+      { op: "local.get", index: vecTmp },
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 },
+      { op: "local.set", index: dataTmp },
+    ],
+  });
+  fctx.body.push(...repr.literal(""));
+  fctx.body.push({ op: "local.set", index: foldLocals.resultTmp });
+  fctx.body.push(...repr.literal(""));
+  fctx.body.push({ op: "local.set", index: foldLocals.sepTmp });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: foldLocals.iTmp });
+
+  // elem → 1-char string. Built via a body swap so emitThrowRangeError (a
+  // late-import-bearing emitter) targets the buffer; registered with
+  // ctx.liveBodies so a later late-import shift still fixes baked indices
+  // (the #2088 family pattern), and de-registered after the splice.
+  const elemBuf: Instr[] = [];
+  ctx.liveBodies.add(elemBuf);
+  const savedBody = fctx.body;
+  fctx.body = elemBuf;
+  try {
+    const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
+    elemBuf.push({ op: "local.get", index: dataTmp });
+    elemBuf.push({ op: "local.get", index: foldLocals.iTmp });
+    elemBuf.push({ op: getOp, typeIdx: arrTypeIdx } as Instr);
+    if (elemType.kind === "externref") {
+      // Boxed-any element → numeric code via the shared coercion engine
+      // (unboxes `__box_number` payloads; undefined → NaN).
+      coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" });
+    }
+    const elemIsF64 = elemType.kind === "f64" || elemType.kind === "externref";
+    if (isFromCodePoint) {
+      if (elemIsF64) {
+        // §22.1.2.2 2b/2c — non-integral (incl. NaN) or out-of-[0,0x10FFFF]
+        // code points throw RangeError (mirrors the direct-call family arm).
+        const cpTmp = allocTempLocal(fctx, { kind: "f64" });
+        elemBuf.push({ op: "local.tee", index: cpTmp });
+        elemBuf.push({ op: "local.get", index: cpTmp });
+        elemBuf.push({ op: "f64.trunc" });
+        elemBuf.push({ op: "f64.ne" });
+        elemBuf.push({ op: "local.get", index: cpTmp });
+        elemBuf.push({ op: "f64.const", value: 0 });
+        elemBuf.push({ op: "f64.lt" });
+        elemBuf.push({ op: "local.get", index: cpTmp });
+        elemBuf.push({ op: "f64.const", value: 0x10ffff });
+        elemBuf.push({ op: "f64.gt" });
+        elemBuf.push({ op: "i32.or" });
+        elemBuf.push({ op: "i32.or" });
+        const throwBuf: Instr[] = [];
+        fctx.body = throwBuf;
+        emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+        fctx.body = elemBuf;
+        elemBuf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf });
+        elemBuf.push({ op: "local.get", index: cpTmp });
+        elemBuf.push({ op: "i32.trunc_sat_f64_s" });
+        releaseTempLocal(fctx, cpTmp);
+      } else {
+        // Integral by construction; range-check in the i32 domain.
+        const cpTmp = allocTempLocal(fctx, { kind: "i32" });
+        elemBuf.push({ op: "local.tee", index: cpTmp });
+        elemBuf.push({ op: "i32.const", value: 0 });
+        elemBuf.push({ op: "i32.lt_s" });
+        elemBuf.push({ op: "local.get", index: cpTmp });
+        elemBuf.push({ op: "i32.const", value: 0x10ffff });
+        elemBuf.push({ op: "i32.gt_s" });
+        elemBuf.push({ op: "i32.or" });
+        const throwBuf: Instr[] = [];
+        fctx.body = throwBuf;
+        emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+        fctx.body = elemBuf;
+        elemBuf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf });
+        elemBuf.push({ op: "local.get", index: cpTmp });
+        releaseTempLocal(fctx, cpTmp);
+      }
+    } else if (elemIsF64) {
+      // fromCharCode: §7.1.8 ToUint16 in the f64 domain BEFORE the i32
+      // conversion (the #2875 slice-5 pattern — NaN/±Inf → 0, |x| ≥ 2^31 keeps
+      // its true modulo; a bare trunc_sat saturates first and gets both wrong).
+      const u16Tmp = allocTempLocal(fctx, { kind: "f64" });
+      elemBuf.push({ op: "f64.trunc" });
+      elemBuf.push({ op: "local.tee", index: u16Tmp });
+      elemBuf.push({ op: "local.get", index: u16Tmp });
+      elemBuf.push({ op: "f64.const", value: 65536 });
+      elemBuf.push({ op: "f64.div" });
+      elemBuf.push({ op: "f64.floor" });
+      elemBuf.push({ op: "f64.const", value: 65536 });
+      elemBuf.push({ op: "f64.mul" });
+      elemBuf.push({ op: "f64.sub" });
+      elemBuf.push({ op: "i32.trunc_sat_f64_s" });
+      releaseTempLocal(fctx, u16Tmp);
+    }
+    // i32/i8/i16 fromCharCode: the helper's low-16 mask IS ToUint16.
+    elemBuf.push({ op: "call", funcIdx: helperIdx });
+  } finally {
+    fctx.body = savedBody;
+  }
+
+  // (#3224-style) Bounds-check against the physical backing: a grown/sparse
+  // array's logical length can exceed it; an absent index spreads as
+  // `undefined` — RangeError for fromCodePoint (NaN is not integral), code 0
+  // for fromCharCode.
+  const oobBuf: Instr[] = [];
+  if (isFromCodePoint) {
+    ctx.liveBodies.add(oobBuf);
+    fctx.body = oobBuf;
+    try {
+      emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+    } finally {
+      fctx.body = savedBody;
+    }
+    oobBuf.push(...repr.literal(""));
+  } else {
+    oobBuf.push({ op: "i32.const", value: 0 });
+    oobBuf.push({ op: "call", funcIdx: helperIdx });
+  }
+  const boundsCheckedElem: Instr[] = [
+    { op: "local.get", index: dataTmp },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: repr.resultType },
+      then: [...oobBuf],
+      else: [
+        { op: "local.get", index: foldLocals.iTmp },
+        { op: "local.get", index: dataTmp },
+        { op: "array.len" },
+        { op: "i32.lt_s" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: repr.resultType },
+          then: elemBuf,
+          else: [...oobBuf],
+        },
+      ],
+    },
+  ];
+
+  emitStringJoinFold(ctx, fctx, repr, foldLocals, boundsCheckedElem);
+  ctx.liveBodies.delete(elemBuf);
+  ctx.liveBodies.delete(oobBuf);
+  fctx.body.push({ op: "local.get", index: foldLocals.resultTmp });
+  return repr.resultType;
 }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -277,7 +277,7 @@ import { emitSymbolToString, ensureSymbolRegistry } from "../symbol-native.js";
 import { resolveStructName } from "./misc.js";
 import { compileSuperElementMethodCall, compileSuperMethodCall } from "./new-super.js";
 import { compileIdentifierCall } from "./call-identifier.js";
-import { compileBuiltinStaticCall } from "./call-builtin-static.js";
+import { compileBuiltinStaticCall, tryCompileFromCharCodeFamilyReflective } from "./call-builtin-static.js";
 import { compileNamespaceStaticCall } from "./call-namespace-static.js";
 import { compileReceiverMethodCall } from "./call-receiver-method.js";
 import { compileTailDispatch } from "./call-tail-dispatch.js";
@@ -6284,6 +6284,17 @@ function compileCallExpression(
         // Slice-1 brand-check fires on the bad `this`. Standalone-gated.
         const genProtoResult = tryEmitGeneratorProtoReflectiveCall(ctx, fctx, expr, recv, isCall);
         if (genProtoResult !== undefined) return genProtoResult;
+      }
+
+      // (#3541) Reflective `String.fromCharCode/fromCodePoint` .call/.apply on
+      // the native-string lanes: the generic closure-wrapper apply machinery
+      // cannot spread a native $vec argv into the builtin's variadic lowering
+      // (null string → __str_concat null-deref — the sole gate on the 311
+      // built-ins/RegExp/property-escapes rows). Precise-match arm; falls
+      // through (undefined) for the host lane and any non-vec/unsafe shape.
+      {
+        const fccResult = tryCompileFromCharCodeFamilyReflective(ctx, fctx, expr, innerExpr, isCall);
+        if (fccResult !== undefined) return fccResult;
       }
 
       // Sub-fix 3 (#1596): Function.prototype.{apply,call}.call(fn, ...) reshape.

--- a/tests/issue-3541.test.ts
+++ b/tests/issue-3541.test.ts
@@ -1,0 +1,132 @@
+/**
+ * #3541 (#2860) — standalone: `String.fromCodePoint.apply(null, vec)` returned
+ * null (the `__str_concat` null-deref), the sole remaining gate on the 311
+ * `built-ins/RegExp/property-escapes` baseline rows (all via regExpUtils.js
+ * `buildString`).
+ *
+ * The reflective forms now lower natively on the native-string lanes
+ * (`tryCompileFromCharCodeFamilyReflective` in call-builtin-static.ts):
+ * `.call` → direct family call; `.apply(thisArg)` → ""; `.apply(thisArg, arr)`
+ * → runtime fold over the native vec with the spec coercions (§7.1.8 ToUint16
+ * for fromCharCode; §22.1.2.2 integral/[0,0x10FFFF] RangeError for
+ * fromCodePoint).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<{ ok: boolean; error?: string }> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "test.js",
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+    deferTopLevelInit: true,
+  });
+  if (!result.success || result.errors.some((e) => e.severity === "error")) {
+    return {
+      ok: false,
+      error: `compile: ${result.errors
+        .filter((e) => e.severity === "error")
+        .map((e) => e.message)
+        .join("; ")}`,
+    };
+  }
+  expect(result.imports).toHaveLength(0);
+  const importObj = buildImports(result.imports, undefined, result.stringPool) as Record<string, unknown>;
+  let instance: WebAssembly.Instance;
+  try {
+    ({ instance } = await WebAssembly.instantiate(result.binary, importObj as WebAssembly.Imports));
+  } catch (err) {
+    return { ok: false, error: `instantiate: ${String(err)}` };
+  }
+  const init = (instance.exports as Record<string, unknown>).__module_init;
+  try {
+    if (typeof init === "function") (init as () => void)();
+  } catch (err) {
+    return { ok: false, error: `init threw: ${String(err)}` };
+  }
+  return { ok: true };
+}
+
+async function expectPass(source: string): Promise<void> {
+  const r = await runStandalone(source);
+  expect(r.error ?? "").toBe("");
+  expect(r.ok).toBe(true);
+}
+
+describe("#3541 reflective fromCharCode/fromCodePoint on the native-string lane", () => {
+  it("fromCodePoint.apply over a vec identifier (the minimal repro)", async () => {
+    await expectPass(`
+var v = [0x41, 0x42, 0x43];
+var s = String.fromCodePoint.apply(null, v);
+if (s !== "ABC") throw new Error("bad: " + s);
+`);
+  });
+
+  it("fromCodePoint.apply over a struct-field vec (obj.pts)", async () => {
+    await expectPass(`
+var obj = { pts: [0x41, 0x42, 0x43] };
+var s = String.fromCodePoint.apply(null, obj.pts);
+if (s !== "ABC") throw new Error("bad: " + s);
+`);
+  });
+
+  it("fromCodePoint.apply over a grown array (the buildString codePoints shape)", async () => {
+    await expectPass(`
+var codePoints = [];
+for (var length = 0, cp = 0x41; cp <= 0x45; cp++) {
+  codePoints[length++] = cp;
+}
+var s = String.fromCodePoint.apply(null, codePoints);
+if (s !== "ABCDE") throw new Error("bad: " + s);
+`);
+  });
+
+  it("fromCharCode.apply applies ToUint16 per element", async () => {
+    await expectPass(`
+var v = [65, 65 + 65536, -65471];
+var s = String.fromCharCode.apply(null, v);
+if (s !== "AAA") throw new Error("bad: " + s);
+`);
+  });
+
+  it("fromCodePoint.apply throws RangeError on an invalid code point", async () => {
+    await expectPass(`
+var v = [0x41, 0x110000];
+var threw = false;
+try {
+  String.fromCodePoint.apply(null, v);
+} catch (e) {
+  threw = true;
+  if (String(e).indexOf("RangeError") < 0) throw new Error("wrong error: " + e);
+}
+if (!threw) throw new Error("expected RangeError");
+`);
+  });
+
+  it("empty and absent arg arrays yield the empty string", async () => {
+    await expectPass(`
+var empty = [];
+var a = String.fromCodePoint.apply(null, empty);
+var b = String.fromCharCode.apply(null);
+if (a !== "" || b !== "") throw new Error("bad: [" + a + "][" + b + "]");
+`);
+  });
+
+  it(".call routes to the direct family lowering", async () => {
+    await expectPass(`
+var s = String.fromCodePoint.call(null, 0x41, 0x42);
+var t = String.fromCharCode.call(null, 67);
+if (s + t !== "ABC") throw new Error("bad: " + s + t);
+`);
+  });
+
+  it("supplementary-plane code points survive the fold", async () => {
+    await expectPass(`
+var v = [0x1f600];
+var s = String.fromCodePoint.apply(null, v);
+if (s.length !== 2) throw new Error("bad surrogate pair: " + s.length);
+`);
+  });
+});


### PR DESCRIPTION
## What

**STACKED on #3503 (#3536)** — opened as DRAFT until the predecessor lands; its commits will drop out of this diff when main advances. Do not enqueue before #3503 merges (draft status enforces that).

Fixes the defect that gated the 311 `built-ins/RegExp/property-escapes` rows after #3536: the generic reflective path wrapped `String.fromCodePoint` in a closure and routed through the runtime apply machinery, which cannot spread a native `$vec` argv — null string → `__str_concat` null-deref (reproduces at plain top level on main).

New `tryCompileFromCharCodeFamilyReflective` (subsystem module `call-builtin-static.ts`, per the LOC ratchet), precise-match arm in the `.call/.apply` dispatch: `.call` → synthetic direct family call (reuses the #2088 fold + #2601/#2875 guards); `.apply` over a typed native vec → shared `emitStringJoinFold` with spec per-element coercions (ToUint16 / RangeError guard), bounds-checked; `.apply` over an externref-wrapped vec (the #3536 struct-narrowed callee shape) → guarded 2-way `ref.test` dispatch ($vec_f64/$vec_externref), nullish → empty list, non-array-like → apply TypeError. Native-string lanes only; host byte-identical; re-eval-safety gate prevents double side effects on legacy bail.

## Measured (the #3536 600× lesson applied)

- 7/7 repro probes + the exact regExpUtils `buildString` bodies pass; `tests/issue-3541.test.ts` 8/8 (ToUint16, RangeError, surrogate pairs, empty/absent arrays, `.call`).
- **Full 311-row property-escapes family through the real worker: 0/311 flips.** The wall moved one layer deeper — 304× `regular expression step limit exceeded` matching `^\p{…}+$` over the built strings, 6× RGI_Emoji sequence properties → filed **#3549** with the tally. This PR's direct yield is the non-PE `fromCharCode/fromCodePoint.apply` corpus; CI baselines will show it.
- Battery: typecheck · 123 equivalence tests (string-methods, arrow-call-apply, iife) · 13 issue tests · check:ir-fallbacks · oracle-ratchet · prettier/biome — green.

Refs #2860, #3541, #3549. LOC allowances granted in the issue frontmatter (code added to the subsystem module + an 11-line dispatch arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb