### PR TITLE
fix(#3548): infer under-applied declared-function params NULLABLE — zero-arg call of a string-applied function trapped unconditionally

### DIFF
--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -57,9 +57,12 @@ the canonical `$DONE('msg')`/`$DONE()` template shape is just where the
 corpus exercises under-applied+string-applied functions). Fixed in child
 **#3548** (done): under-applied call sites make a non-nullable ref param
 inference NULLABLE + a null-guarded `__str_truthy` ToBoolean for nullable
-strings. Measured stride-4: 2 → 20 of 49 PASS. **Residual 29 = the
-`illegal cast [in __then_fulfill_*]` then-reaction-wrapper sub-family** —
-a distinct marshalling defect, the next open head here (also #3443).
+strings. Measured stride-4: 0 → 19 of 49 PASS (baseline: all cluster rows
+FAIL on the 2026-07-23 promote; ≈75 of 193 extrapolated). **Residual 30
+all now fail as `illegal cast [in __then_fulfill_*]`** — the
+then-reaction-wrapper sub-family (only 9 showed it originally; 21 were
+masked behind the arity trap) — a distinct marshalling defect, the next
+open head here (also #3443).
 
 ## Decomposition 2026-07-17 (fable-3178) — child issues #3386–#3391
 

--- a/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
+++ b/plan/issues/3178-standalone-host-async-machinery-retirement-umbrella.md
@@ -51,6 +51,16 @@ PASS on a stride-4 cluster sample; 3 residuals =
 `language/arguments-object/*async-gen*` (`Cannot access property on null or
 undefined`) — distinct root cause, still open here.
 
+Fourth slice, same day: the ~193-row `async continuation threw` null-deref
+cluster collapsed to an ARITY-FILL soundness bug (nothing async about it —
+the canonical `$DONE('msg')`/`$DONE()` template shape is just where the
+corpus exercises under-applied+string-applied functions). Fixed in child
+**#3548** (done): under-applied call sites make a non-nullable ref param
+inference NULLABLE + a null-guarded `__str_truthy` ToBoolean for nullable
+strings. Measured stride-4: 2 → 20 of 49 PASS. **Residual 29 = the
+`illegal cast [in __then_fulfill_*]` then-reaction-wrapper sub-family** —
+a distinct marshalling defect, the next open head here (also #3443).
+
 ## Decomposition 2026-07-17 (fable-3178) — child issues #3386–#3391
 
 State change since this umbrella was written (2026-07-12): **S1 (#3164), S2

--- a/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
+++ b/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
@@ -2,7 +2,7 @@
 id: 3548
 title: "Standalone: then-callback closure with branch-guarded module-fn calls traps null-deref — the ~193-row 'async continuation threw' Promise cluster"
 status: done
-assignee: ttraenkler/fable-3417
+assignee: ttraenkler/sendev-3548
 sprint: current
 priority: high
 horizon: m
@@ -27,7 +27,20 @@ origin: "2026-07-23 fable-3417 umbrella triage: third head of the F2-unmasked st
 
 # #3548 — then-closure branch-call null-deref (the 193-row cluster)
 
-## FIXED (2026-07-23, fable-3417) — two coupled halves; measured flips
+## FIXED (2026-07-23, started fable-3417, landed sendev-3548) — two coupled halves; measured flips
+
+### Why the fix is UPSTREAM (inference), not at the pad site — hold this line
+
+A non-nullable `(ref N)` has **no undefined inhabitant** — there is nothing a
+zero-arg pad could legally push (`pushDefaultValue`'s "ref" case documents
+the `ref.null` + `ref.as_non_null` landmine explicitly). So patching the pad
+is impossible; the *inference* that produced a non-nullable type for a
+sometimes-absent param is what is unsound. Widening to `ref null N` (not
+externref) keeps the precise type and the string fast paths. Rejected
+alternatives: a sentinel/optional-param transform (a workaround over an
+inference that is still wrong), and never-narrowing declared-function params
+(the narrowing is a deliberate hot-path optimisation; the bug is only the
+under-applied case).
 
 1. **Inference soundness** (`src/codegen/declarations/param-return-inference.ts`,
    `inferParamTypeFromCallSites`): an under-applied call site now records
@@ -46,13 +59,20 @@ origin: "2026-07-23 fable-3417 umbrella triage: third head of the F2-unmasked st
 collapsed repro, truthiness triple T/F/F, the canonical $DONE template shape
 completing on the zero-arg PASS path, fully-applied no-regression).
 
-**Measured corpus flips** (stride-4 over the 193-row cluster, real files via
-the #3469 channel): **2 → 20 of 49 PASS** (+18 measured; est. ~70–80 of the
-193). The **residual 29 are the OTHER sub-family** — `illegal cast [in
-__then_fulfill_*]`, a then-reaction-wrapper marshalling defect, NOT the
-arity fill — route via #3443 (standalone illegal-cast tracker) / a follow-up
-umbrella slice. Honest sizing: corpus-wide static candidates ≈ 106 rows
-(hundreds, not thousands); the fix is justified on SOUNDNESS — a
+**Measured corpus flips** (stride-4 over the 193-row cluster — 49 files,
+sorted by path, every 4th — run locally via the #3469 channel,
+`TEST262_TARGET=standalone` + `TEST262_PATH_FILTER`): **0 → 19 of 49 PASS**.
+"Before" is the 2026-07-23 promoted standalone baseline (oracle v9, all 193
+cluster rows FAIL by definition); "after" is the local rerun on this branch
+(results jsonl 20260723-155434). Extrapolated ≈ 75 of the 193. The
+**residual 30 all fail with ONE signature**: `illegal cast [in
+__then_fulfill_*/__then_reject_*]` — the then-reaction-wrapper marshalling
+defect. Only 9 of the 30 showed illegal-cast originally; the other 21 were
+null-deref rows whose arity-fill trap fired FIRST and masked the cast
+defect. So the arity fix fully retires its own signature in the sample and
+UNMASKS the #3443 lane (route residuals there / a follow-up umbrella
+slice). Honest sizing: corpus-wide static candidates ≈ 106 rows (hundreds,
+not thousands); the fix is justified on SOUNDNESS — a
 documented-but-false assumption emitting a guaranteed trap on the ubiquitous
 optional-argument shape — not on corpus yield.
 

--- a/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
+++ b/plan/issues/3548-standalone-then-closure-branch-call-null-deref.md
@@ -1,7 +1,8 @@
 ---
 id: 3548
 title: "Standalone: then-callback closure with branch-guarded module-fn calls traps null-deref — the ~193-row 'async continuation threw' Promise cluster"
-status: ready
+status: done
+assignee: ttraenkler/fable-3417
 sprint: current
 priority: high
 horizon: m
@@ -13,10 +14,47 @@ goal: standalone-mode
 parents: [3178]
 related: [3417, 3442, 3443, 3542, 3545, 2865]
 created: 2026-07-23
+completed: 2026-07-23
+# (#3102) In-subsystem growth: the null-guarded ToBoolean helper belongs in
+# native-strings (next to the other __str_* helpers); the widening lands in
+# the inference module; the arm wiring in the coercion engine.
+loc-budget-allow:
+  - src/codegen/native-strings.ts
+  - src/codegen/coercion-engine.ts
+  - src/codegen/declarations/param-return-inference.ts
 origin: "2026-07-23 fable-3417 umbrella triage: third head of the F2-unmasked standalone async FAIL surface, after #3538 (280) and #3542 (130)."
 ---
 
 # #3548 — then-closure branch-call null-deref (the 193-row cluster)
+
+## FIXED (2026-07-23, fable-3417) — two coupled halves; measured flips
+
+1. **Inference soundness** (`src/codegen/declarations/param-return-inference.ts`,
+   `inferParamTypeFromCallSites`): an under-applied call site now records
+   `sawUnderApplied`, and a non-nullable `ref` inference widens to
+   `ref_null` of the SAME type (approved direction — nullable, NOT
+   externref; keeps the precise type + fast paths). The zero-arg pad then
+   emits a plain `ref.null` the callee accepts.
+2. **Null-guarded string ToBoolean** (`src/codegen/native-strings.ts`
+   `ensureStrTruthyHelper` + the coercion-engine arm): with the param now
+   nullable, `if (err)` in the callee routed the nullable string through
+   `__str_flatten(null)` — a second trap. `ref_null` strings now ToBoolean
+   via `__str_truthy` (null → falsy, rope-len > 0 otherwise, no flatten);
+   the non-null `ref` arm keeps its historical flatten path byte-identical.
+
+**Permanent repro**: `tests/issue-3548.test.ts` (4 cases — the 2-line
+collapsed repro, truthiness triple T/F/F, the canonical $DONE template shape
+completing on the zero-arg PASS path, fully-applied no-regression).
+
+**Measured corpus flips** (stride-4 over the 193-row cluster, real files via
+the #3469 channel): **2 → 20 of 49 PASS** (+18 measured; est. ~70–80 of the
+193). The **residual 29 are the OTHER sub-family** — `illegal cast [in
+__then_fulfill_*]`, a then-reaction-wrapper marshalling defect, NOT the
+arity fill — route via #3443 (standalone illegal-cast tracker) / a follow-up
+umbrella slice. Honest sizing: corpus-wide static candidates ≈ 106 rows
+(hundreds, not thousands); the fix is justified on SOUNDNESS — a
+documented-but-false assumption emitting a guaranteed trap on the ubiquitous
+optional-argument shape — not on corpus yield.
 
 ## Problem (measured)
 

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -40,7 +40,7 @@ import { boxToAny } from "./value-tags.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { noJsHost } from "./expressions/helpers.js";
 import { addUnionImports, nativeStringType } from "./index.js";
-import { ensureAnyToStringHelper } from "./native-strings.js";
+import { ensureAnyToStringHelper, ensureStrTruthyHelper } from "./native-strings.js";
 import { getBoolToStringEmitter, getNativeStringRefFromExternrefEmitter } from "./string-emitter-registry.js";
 import {
   compileExpression,
@@ -418,6 +418,18 @@ export function emitToBoolean(ctx: CodegenContext, valType: ValType | null, sink
     }
     // Native string ref — empty string is falsy (check len > 0 after flatten).
     if (valType.typeIdx === ctx.anyStrTypeIdx && ctx.anyStrTypeIdx >= 0) {
+      // (#3548) NULLABLE string: `__str_flatten(null)` traps — a nullable
+      // string param (an under-applied call site's `undefined`, now inferred
+      // `ref_null` by inferParamTypeFromCallSites) must be FALSY when null.
+      // Route through the null-guarded `__str_truthy` helper. The non-null
+      // `ref` arm below keeps its historical flatten path byte-identical.
+      if (kind === "ref_null") {
+        const truthyIdx = ensureStrTruthyHelper(ctx);
+        if (truthyIdx !== undefined) {
+          sink.push({ op: "call", funcIdx: truthyIdx });
+          return sink;
+        }
+      }
       const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
       if (flattenIdx !== undefined && ctx.nativeStrTypeIdx >= 0) {
         sink.push(

--- a/src/codegen/declarations/param-return-inference.ts
+++ b/src/codegen/declarations/param-return-inference.ts
@@ -91,6 +91,7 @@ export function inferParamTypeFromCallSites(
   let agreed: ValType | null = null;
   let conflict = false;
   let sawCallSite = false;
+  let sawUnderApplied = false;
 
   function visit(node: ts.Node) {
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === funcName) {
@@ -98,6 +99,14 @@ export function inferParamTypeFromCallSites(
       // internally, so its params are determined by runtime call args, not the
       // body-usage fallback. Record this before any conflict short-circuit.
       sawCallSite = true;
+      // (#3548) An UNDER-APPLIED call site (`d('m'); d();`) passes `undefined`
+      // for this param — record it so a non-nullable ref inference is widened
+      // to nullable below. Skipping absent args entirely made the inference
+      // UNSOUND: the agreed type became a non-nullable `(ref N)` that the
+      // zero-arg call site's pad could only satisfy with `ref.null` +
+      // `ref.as_non_null` — an unconditional runtime trap on the (usually
+      // passing) zero-arg path.
+      if (node.arguments.length <= paramIndex) sawUnderApplied = true;
       if (!conflict) {
         const arg = node.arguments[paramIndex];
         if (arg) {
@@ -126,7 +135,20 @@ export function inferParamTypeFromCallSites(
   }
 
   forEachChild(sourceFile, visit);
-  return { type: conflict ? null : agreed, sawCallSite };
+  // (TS control-flow can't see the closure mutation of `agreed` — assert its
+  // declared type so the property narrowing below typechecks.)
+  let type: ValType | null = conflict ? null : (agreed as ValType | null);
+  // (#3548) Soundness: if ANY call site under-applies this param, the value can
+  // be `undefined` at runtime, so a NON-NULLABLE ref inference has no valid
+  // filler — widen to the nullable ref of the same type (NOT all the way to
+  // externref: keeps the precise type and the fast paths; approved direction,
+  // see plan/issues/3548). The zero-arg pad then emits a plain `ref.null`,
+  // which the callee (whose body compiles against this same nullable
+  // signature) handles as the absent/undefined case.
+  if (type !== null && type.kind === "ref" && sawUnderApplied) {
+    type = { kind: "ref_null", typeIdx: type.typeIdx };
+  }
+  return { type, sawCallSite };
 }
 
 /**

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -375,6 +375,52 @@ function ensureErrorToStringHelper(ctx: CodegenContext): number | undefined {
   return funcIdx;
 }
 
+/**
+ * (#3548) `__str_truthy(ref null $AnyString) -> i32` — §7.1.2 ToBoolean for a
+ * NULLABLE native string: `null` (an under-applied param's `undefined`, or a
+ * genuinely-null binding) is falsy; otherwise empty-string falsy via the rope
+ * `len` field (field 0 — maintained on concat, no flatten needed). The
+ * non-null ToBoolean arm in coercion-engine.ts keeps its historical
+ * flatten+len path byte-identical; only `ref_null` strings route here (they
+ * previously called `__str_flatten(null)` → an unconditional trap — the
+ * residual half of the #3548 zero-arg-call fix). Registration is append-only
+ * (a defined func mints at the end of the index space — no shifts).
+ */
+export function ensureStrTruthyHelper(ctx: CodegenContext): number | undefined {
+  const existing = ctx.funcMap.get("__str_truthy");
+  if (existing !== undefined) return existing;
+  if (ctx.anyStrTypeIdx < 0) return undefined;
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const body: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 0 }],
+      else: [
+        { op: "local.get", index: 0 },
+        { op: "ref.as_non_null" },
+        { op: "struct.get", typeIdx: anyStrTypeIdx, fieldIdx: 0 }, // rope len
+        { op: "i32.const", value: 0 },
+        { op: "i32.gt_s" },
+      ],
+    },
+  ];
+  const typeIdx = addFuncType(ctx, [{ kind: "ref_null", typeIdx: anyStrTypeIdx }], [{ kind: "i32" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.nativeStrHelpers.set("__str_truthy", funcIdx);
+  ctx.funcMap.set("__str_truthy", funcIdx);
+  pushDefinedFunc(ctx, funcIdx, {
+    name: "__str_truthy",
+    typeIdx,
+    locals: [],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
 export function ensureAnyToStringHelper(ctx: CodegenContext): number {
   ensureNativeStringHelpers(ctx);
   const existing = ctx.nativeStrHelpers.get("__any_to_string");

--- a/tests/issue-3548.test.ts
+++ b/tests/issue-3548.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #3548 — a ZERO-ARG call of a function whose other call site passes a string
+// literal trapped unconditionally on the zero-arg (usually PASS) path:
+// `inferParamTypeFromCallSites` skipped absent args entirely, so the param was
+// inferred as a NON-NULLABLE native-string ref, and the zero-arg pad's only
+// filler was `ref.null` + `ref.as_non_null` — a guaranteed null-deref trap.
+// The soundness fix: an under-applied call site means the param can be
+// `undefined`, so a non-nullable ref inference widens to `ref_null` (NOT
+// externref — keeps the precise type). The second half: ToBoolean of a
+// nullable native string routed through the null-guarded `__str_truthy`
+// helper (`__str_flatten(null)` also trapped).
+//
+// This was the canonical test262 template shape ($DONE('msg') on fail paths,
+// bare $DONE() on the pass path) — but nothing about it is async: the minimal
+// repro is two lines at module scope. Optional arguments are ubiquitous in
+// real user code, so the fix is justified on soundness, not corpus yield.
+
+async function runStandalone(src: string): Promise<string> {
+  const r = await compile(src, {
+    fileName: "test.js",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+    target: "standalone",
+  });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(r.imports.filter((i) => i.module === "env").map((i) => i.name)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const exp = instance.exports as Record<string, unknown>;
+  const drain = exp.__drain_microtasks;
+  if (typeof drain === "function") (drain as () => void)();
+  const prepare = exp.__stdout_prepare;
+  const charAt = exp.__stdout_char;
+  if (typeof prepare !== "function" || typeof charAt !== "function") return "<no sink>";
+  const len = ((prepare as () => number)() | 0) as number;
+  let out = "";
+  for (let i = 0; i < len; i++) out += String.fromCharCode(((charAt as (i: number) => number)(i) | 0) & 0xffff);
+  return out;
+}
+
+describe("#3548 under-applied + string-applied function params", () => {
+  it("the collapsed 2-line repro: d('m'); d(); runs both calls (was an unconditional trap)", async () => {
+    const out = await runStandalone(`
+      function d(x) { console.log("called"); }
+      d("m");
+      d();
+    `);
+    expect(out.split("called").length - 1).toBe(2);
+  });
+
+  it("truthiness of the missing (undefined) param is falsy; string param truthy; empty string falsy", async () => {
+    const out = await runStandalone(`
+      function d(x) { console.log(x ? "T" : "F"); }
+      d("m");
+      d();
+      d("");
+    `);
+    expect(out).toBe("T\nF\nF\n");
+  });
+
+  it("the canonical $DONE-style template shape completes on the zero-arg pass path", async () => {
+    const out = await runStandalone(`
+      function DONE(err) {
+        if (err) { console.log("FAIL:" + err); } else { console.log("PASS"); }
+      }
+      var value = {};
+      var p2 = new Promise(function (_, reject) { reject(); })
+        .then(function () {}, function () { return value; });
+      p2.then(function (x) {
+        if (x !== value) { DONE("mismatch"); return; }
+        DONE();
+      }, function () { DONE("rejected"); });
+    `);
+    expect(out).toBe("PASS\n");
+  });
+
+  it("no-regression: fully-applied string params keep the precise non-null path", async () => {
+    const out = await runStandalone(`
+      function greet(name) { console.log("hi " + name); }
+      greet("a");
+      greet("b");
+    `);
+    expect(out).toBe("hi a\nhi b\n");
+  });
+});


### PR DESCRIPTION
## Root cause (soundness, not async)

`function d(x){...}; d('m'); d();` **traps unconditionally in standalone** on the zero-arg (usually passing) path. `inferParamTypeFromCallSites` skipped absent arguments entirely, so the param was inferred as a NON-NULLABLE native-string `(ref $AnyString)`; the zero-arg site's arity pad has no undefined inhabitant for a non-nullable ref and could only emit `ref.null` + `ref.as_non_null` — a guaranteed null-deref trap. The landmine was even documented in `pushDefaultValue`'s "ref" case ("parameter-padding contexts typically don't reach non-null ref params with null values") — they do: this is the canonical test262 template shape (`$DONE('msg')` on fail paths, bare `$DONE()` on the pass path), which is where the 193-row 'async continuation threw' Promise cluster came from. Nothing about it is async.

## Fix — upstream in inference, NOT at the pad site

A non-nullable ref has no valid filler, so the pad cannot be fixed; the **inference** that produced a non-nullable type for a sometimes-absent param is what is unsound.

1. **`param-return-inference.ts`**: any under-applied call site records `sawUnderApplied`; a non-nullable `ref` inference widens to `ref null N` of the SAME type — **not** externref, keeping the precise type and the fast paths. The zero-arg pad then emits a plain `ref.null` against the same nullable signature the callee compiles with.
2. **`native-strings.ts` / `coercion-engine.ts`**: with the param now nullable, `if (err)` routed the nullable string through `__str_flatten(null)` — a second trap. ToBoolean of a `ref_null` native string now goes through a new null-guarded `__str_truthy` helper (null → falsy, rope-len > 0 otherwise); the non-null `ref` arm keeps its historical flatten path byte-identical.

Rejected alternatives (arbitrated): sentinel/optional-param transform (a workaround over a still-wrong inference); never-narrowing declared-function params (the narrowing is a deliberate hot-path optimisation — the bug is only the under-applied case).

## Gate + measured flips (real runs, not candidate counts)

- **Traps before / passes after**: the 2-line repro traps with `RuntimeError: dereferencing a null pointer` on pre-fix main, passes on this branch. Permanent tests: `tests/issue-3548.test.ts` (repro, truthiness T/F/F, canonical $DONE template completing on the zero-arg PASS path, fully-applied no-regression). Probes also verified object-shape, array, and f64 under-applied params behave correctly.
- **Stride-4 over the 193-row cluster** (49 files, `TEST262_TARGET=standalone` + path filter): **0 → 19 of 49 PASS** (baseline: all 193 rows FAIL on the 2026-07-23 promote). Extrapolated ≈ 75 of 193. Residual 30 all fail with ONE signature — `illegal cast [in __then_fulfill_*]` (21 previously masked behind the arity trap) — the separate then-reaction marshalling defect, routed to #3443.

**Honest sizing**: corpus-wide static candidates ≈ 106 rows — hundreds, not thousands, overwhelmingly the $DONE family. This PR is justified on **soundness** (a documented-but-false assumption emitting a guaranteed trap; optional arguments are ubiquitous in real user code), not on corpus yield — do not read the modest count as 'not worth it'.

## Safety

- IR path: the #3536 signature-parity guard keeps the legacy body on any ABI mismatch, so the widened signature cannot produce an invalid module via IR patching.
- Scoped suites: issue-866/869/default-params/arguments-object/issue-1025 all green. The 3 failures in `tests/issue-3471.test.ts`/`tests/call-arg-type-coercion.test.ts` are **pre-existing on main** (verified identical on the base checkout) — not introduced here.
- Local gates: tsc, prettier, oracle-ratchet (+0), LOC budget (granted in the issue file) all green.

Resumes and lands the fable-3417 WIP (predecessor hit its API limit mid-implementation).

Closes #3548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb