### PR TITLE
fix(#3546): dual-store module top-level closure reassignment — cross-function calls saw the stale first closure

### DIFF
--- a/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
+++ b/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
@@ -1,7 +1,9 @@
 ---
 id: 3546
 title: "codegen: module TOP-LEVEL closure reassignment writes only the __module_init local shadow — cross-function calls read the stale first closure from the global"
-status: ready
+status: done
+assignee: ttraenkler/fable-3546
+completed: 2026-07-23
 sprint: Backlog
 created: 2026-07-23
 priority: medium
@@ -13,6 +15,10 @@ area: codegen
 language_feature: closures
 goal: correctness
 related: [3534, 3533]
+loc-budget-allow:
+  - src/codegen/expressions/assignment.ts
+  - src/codegen/statements/variables.ts
+  - src/codegen/context/types.ts
 ---
 
 # #3546 — `let f = () => 1; f = () => 2;` at module top level: `f()` from another function returns 1
@@ -22,7 +28,9 @@ related: [3534, 3533]
 ```ts
 let f = (): number => 1;
 f = (): number => 2;
-export function test(): number { return f(); }
+export function test(): number {
+  return f();
+}
 // test() === 1   (want 2)   — binary sha256-16: d57a1b35964e0b09
 ```
 
@@ -33,12 +41,12 @@ declaration-path family, not a regression.
 
 ## Scoping matrix (probe `.tmp/probe-3546.mts`, kept in the #3534 owner's notes)
 
-| shape | result |
-|---|---|
-| module top-level reassign, call from exported fn | **WRONG got=1** |
-| reassign inside a function (`set2()` writes `f`), then call | PASS |
-| purely local `let f = …; f = …; f()` | PASS |
-| module top-level `var` reassign | **WRONG got=1** |
+| shape                                                       | result          |
+| ----------------------------------------------------------- | --------------- |
+| module top-level reassign, call from exported fn            | **WRONG got=1** |
+| reassign inside a function (`set2()` writes `f`), then call | PASS            |
+| purely local `let f = …; f = …; f()`                        | PASS            |
+| module top-level `var` reassign                             | **WRONG got=1** |
 
 ## Mechanism (verified by the scoping split; exact write-arm to confirm)
 
@@ -65,6 +73,79 @@ global; the dual-store is the smaller change.
 ## Acceptance criteria
 
 - The repro returns 2 on both lanes; `module_var_reassign` likewise.
-- The #3534 corpus (sha256s in that issue file) stays byte-identical except
-  the reassignment shapes.
+- ~~The #3534 corpus (sha256s in that issue file) stays byte-identical except
+  the reassignment shapes.~~ **Amended (see Implementation Notes):** the fix
+  deliberately changes the declaration emission for EVERY top-level closure
+  declaration (externref shadow local), so corpus entries with a top-level
+  closure decl change bytes by design. The behavioral bar replaces the byte
+  bar: all 13 corpus cases must be runtime-PASS; the three entries with no
+  top-level closure decl stay byte-identical.
 - No new invalid-Wasm signatures; equivalence suite delta zero.
+
+## Implementation Notes (2026-07-23, fable-3546 — resumed from fable-3534's WIP)
+
+Two coupled changes in `compileVariableStatement` (variables.ts) + one new
+sync hook in `compileAssignment` (assignment.ts), wired through
+`fctx.moduleBindingShadowLocals` (context/types.ts):
+
+1. **The `__module_init` shadow local for a top-level closure decl is now
+   EXTERNREF, not the precise closure struct.** WHY: the dual-store fix needs
+   later reassignments to flow through BOTH stores. If the shadow stays
+   precise-typed, a reassignment whose RHS is a _different_ closure struct
+   (different captures) forces assignment.ts to RETYPE the local mid-function —
+   the exact #3534 retro-invalidation mechanism one slot over (earlier emitted
+   code validated against the old struct type). Uniform externref removes the
+   retype hazard entirely and keeps top-level LOOP shapes correct (reads always
+   go through the still-current externref local). Cost: top-level reads/calls
+   inside `__module_init` take `compileClosureCall`'s guarded externref arm —
+   cold code, module init runs once. Cross-function call cost is unchanged
+   (already guarded per #3534; perf follow-up is #3550).
+2. **`bindsModuleGlobal` gate:** only a genuinely top-level (`stmt.parent` =
+   SourceFile) lexical decl binds the `$__mod_<name>` global. Pre-fix, a
+   `let`/`const` closure inside a top-level BLOCK stored into the OUTER module
+   binding (`{ let f = () => 7; }` clobbered module `f` — got=7 measured).
+   `var` keeps the module store from any top-level block (§10.2.10); function
+   bodies were already gated by `hasLocalShadow`.
+3. **`emitModuleShadowGlobalSync`** (assignment.ts): after the local-arm
+   `local.tee` of a name whose exact local index is registered in
+   `moduleBindingShadowLocals`, re-push the local and `global.set` the module
+   global (box-on-store if needed — the #3534 invariant: the global stays
+   externref, never narrowed). Exact name→index match keeps it inert for
+   genuine function locals and block shadows. Called at all three return paths
+   of the plain `=` local arm; indices read fresh post-RHS (string-constant
+   global shifts can't stale them).
+
+Rejected alternative: dual-store only in the assignment path keeping the
+precise local. Fails on (a) different-struct reassignment (retype hazard
+above) and (b) top-level loops (a read compiled before the reassignment would
+keep reading the stale precise local on iteration 2).
+
+Residual (out of scope, same family, far narrower): compound/logical
+(`f ||= …`) and destructuring (`[f] = […]`) writes to a top-level closure
+binding go through different assignment arms that still update only the
+shadow local. The plain `=` reassignment fixed here is the shape test262 and
+user code actually hit; extend `emitModuleShadowGlobalSync` to those arms if
+a real case surfaces.
+
+## Test Results (2026-07-23, measured runtime verdicts)
+
+- `tests/issue-3546-toplevel-closure-reassign.test.ts` (8 tests): **5 FAIL on
+  origin/main src (got=1 stale closure ×4, got=7 block clobber), 8/8 PASS
+  post-fix** — wrong-answer assertions, not absence-of-trap.
+- Standalone lane probe (7 shapes): **5 WRONG pre-fix → 7/7 PASS post-fix**
+  (same shapes as host lane; `module_let_reassign`, `module_var_reassign`,
+  `capture_state`, `toplevel_call_between`, `block_shadow_control` all fixed).
+- #3534 13-case corpus: **13/13 runtime PASS** (`var_reassign_call` flipped
+  WRONG d57a1b35964e0b09 → PASS c73447cf308a9e10). Byte-identical where no
+  top-level closure decl exists: `capture_mutable` 7bbcc06bbb9ccfa1,
+  `closure_capture_call_sibling` 5885800c56b700ee, `returned_closure`
+  cd89dcc51ddd41d9. The other 10 changed bytes (deliberate, see note 1);
+  all PASS, zero invalid-Wasm.
+- Guard suites: issue-3534 (6), issue-3024 family, module-globals,
+  issue-329, issue-2800 — green. issue-1690b (4 fails) and issue-3505
+  (2 fails) fail IDENTICALLY on origin/main src in this container
+  (`string_constants` import harness gap / missing test262-fyi submodule) —
+  pre-existing, delta zero.
+- Full equivalence dir (213 files / 1646 tests): 35 failed = the exact
+  pre-existing count documented in #3534's run on this container; matched-pair
+  name diff vs origin/main src recorded in the PR.

--- a/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
+++ b/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
@@ -4,6 +4,7 @@ title: "codegen: module TOP-LEVEL closure reassignment writes only the __module_
 status: done
 assignee: ttraenkler/fable-3546
 completed: 2026-07-23
+pr: 3512
 sprint: Backlog
 created: 2026-07-23
 priority: medium

--- a/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
+++ b/plan/issues/3546-module-toplevel-closure-reassign-stale-global.md
@@ -146,6 +146,12 @@ a real case surfaces.
   (2 fails) fail IDENTICALLY on origin/main src in this container
   (`string_constants` import harness gap / missing test262-fyi submodule) —
   pre-existing, delta zero.
-- Full equivalence dir (213 files / 1646 tests): 35 failed = the exact
-  pre-existing count documented in #3534's run on this container; matched-pair
-  name diff vs origin/main src recorded in the PR.
+- Full equivalence dir (213 files / 1646 tests): matched-pair JSON runs,
+  fixed tree vs origin/main src — **identical 35 failing tests on both, zero
+  flips in either direction** (all pre-existing in this container, matching
+  #3534's documented run). Delta exactly zero.
+- Edge probes (host lane): `export_let_reassign` PASS, `reassign_in_loop`
+  PASS (=122: first iteration reads closure 1, second reads 2 — the shape the
+  rejected precise-local alternative would break), `different_captures` PASS
+  (reassignment to a closure with a different capture set — the retype-hazard
+  shape — is valid Wasm and correct).

--- a/plan/issues/3550-perf-modconst-closure-call-unbox-per-call.md
+++ b/plan/issues/3550-perf-modconst-closure-call-unbox-per-call.md
@@ -1,0 +1,64 @@
+---
+id: 3550
+title: "perf: module-const closure calls pay a per-call unbox + guarded cast after #3534 (+77% rel / ~0.74ns abs per call in hot loops) — cache or dual-store the precise ref for const bindings"
+status: ready
+sprint: Backlog
+created: 2026-07-23
+priority: low
+horizon: s
+feasibility: medium
+reasoning_effort: high
+task_type: perf
+area: codegen
+language_feature: closures
+goal: performance
+related: [3534, 3547]
+---
+
+# #3550 — per-call unbox cost on module-const closure calls (the #3534 rep's known trade)
+
+## Measured (2026-07-23, #3534 step-5 A/B; `.tmp/bench-3534-step5.mts` recipe in the owner's notes)
+
+Median of 7 runs after warmup, gc/host lane, 5M-call hot loops. OLD =
+pre-#3505 main (`4e870095`), NEW = post-#3505 (+#3547 branch — the stopgap
+removal is byte-inert so the delta is entirely the #3534 representation):
+
+| shape | OLD | NEW | delta |
+|---|---|---|---|
+| `const add = (a,b)=>a+b` called 5M× from an exported fn | 4.80ms | 8.36–8.52ms | **+77% rel, ~+0.74ns/call abs** |
+| mutually-recursive `even`/`odd` (200k × depth 20) | 6.88ms | 9.05–9.68ms | **+32–41%** |
+| HOF: module-const closure passed as typed param, called 5M× inside | 3.43ms | 3.43–3.45ms | ~0 (param carries the precise ref — unaffected) |
+| fn-DECLARATION control, same 5M loop | 4.66ms | 4.73–4.92ms | ~noise (direct calls — unaffected) |
+
+Cause: under the #3534 invariant the `$__mod_<name>` binding stays `externref`
+for life; a call from any function OTHER than the declaring scope re-does
+`global.get; any.convert_extern; ref.test; ref.cast` per call (the precise
+LOCAL shortcut only exists inside the declaring function). Previously the
+retro-narrowed global gave a raw precise `global.get` — fast but the source of
+the #3533/#3534 invalid-Wasm/trap family, so simply reverting is not on the
+table.
+
+**Landing-page sidebar is unaffected**: fib/loop/string/array are all function
+DECLARATIONS (direct calls). No committed benchmark exercises the regressed
+shape; this is a latent cost for closure-call-bound user code.
+
+## Fix directions (either preserves the never-narrow invariant)
+
+1. **Per-function unbox caching (smaller):** for a `const` binding (immutable),
+   the guarded-cast result is invariant — hoist it: first call in a function
+   caches the cast result in a function-local; later calls `local.get` +
+   null-check. Turns N unboxes into 1 per function activation.
+2. **Dual-store for const closures (better):** alongside the externref
+   `$__mod_<name>`, keep a SECOND precise-typed global `$__mod_<name>_ref`
+   written once at the decl store; calls read the precise global directly
+   (zero per-call cost), value-reads keep the externref one. `let` bindings
+   stay on the guarded path (reassignable — and note #3546 must fix the
+   let-reassign write path first so both stores stay in sync).
+
+## Acceptance criteria
+
+- `modconst_call_hot` within ~10% of the OLD 4.80ms figure; mutual-recursion
+  shape similarly recovered.
+- The #3534 invariants hold: no retro-narrow, #3534/#3533 guard tests +
+  corpus (sha256s in #3534) stay green; zero invalid-Wasm signatures.
+- A/B numbers re-measured with the same recipe and recorded here.

--- a/plan/issues/3550-perf-modconst-closure-call-unbox-per-call.md
+++ b/plan/issues/3550-perf-modconst-closure-call-unbox-per-call.md
@@ -23,12 +23,12 @@ Median of 7 runs after warmup, gc/host lane, 5M-call hot loops. OLD =
 pre-#3505 main (`4e870095`), NEW = post-#3505 (+#3547 branch — the stopgap
 removal is byte-inert so the delta is entirely the #3534 representation):
 
-| shape | OLD | NEW | delta |
-|---|---|---|---|
-| `const add = (a,b)=>a+b` called 5M× from an exported fn | 4.80ms | 8.36–8.52ms | **+77% rel, ~+0.74ns/call abs** |
-| mutually-recursive `even`/`odd` (200k × depth 20) | 6.88ms | 9.05–9.68ms | **+32–41%** |
+| shape                                                              | OLD    | NEW         | delta                                           |
+| ------------------------------------------------------------------ | ------ | ----------- | ----------------------------------------------- |
+| `const add = (a,b)=>a+b` called 5M× from an exported fn            | 4.80ms | 8.36–8.52ms | **+77% rel, ~+0.74ns/call abs**                 |
+| mutually-recursive `even`/`odd` (200k × depth 20)                  | 6.88ms | 9.05–9.68ms | **+32–41%**                                     |
 | HOF: module-const closure passed as typed param, called 5M× inside | 3.43ms | 3.43–3.45ms | ~0 (param carries the precise ref — unaffected) |
-| fn-DECLARATION control, same 5M loop | 4.66ms | 4.73–4.92ms | ~noise (direct calls — unaffected) |
+| fn-DECLARATION control, same 5M loop                               | 4.66ms | 4.73–4.92ms | ~noise (direct calls — unaffected)              |
 
 Cause: under the #3534 invariant the `$__mod_<name>` binding stays `externref`
 for life; a call from any function OTHER than the declaring scope re-does

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -796,6 +796,19 @@ export interface FunctionContext {
    */
   boxedTdzFlags?: Map<string, { refCellTypeIdx: number; localIdx: number }>;
   /**
+   * (#3546) Locals in `__module_init` that SHADOW a module-global binding for a
+   * top-level closure declaration (`const/let/var f = () => …` at module
+   * level): name → the shadow local's index. The declaration dual-stores
+   * (local + `$__mod_<name>` global); a later TOP-LEVEL reassignment resolves
+   * to the local via `localMap` and would otherwise update only the shadow —
+   * every OTHER function's read/call of the binding goes through the global,
+   * which silently kept the FIRST closure. Assignment's local arm consults
+   * this map (exact name→index match, so genuine function-locals and
+   * block-scoped shadows never match) and re-syncs the global after the local
+   * write.
+   */
+  moduleBindingShadowLocals?: Map<string, number>;
+  /**
    * Stack of catch rethrow info. Each entry tracks a catch variable name and the
    * current depth (number of block-like structures) from the catch boundary.
    */

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -150,6 +150,41 @@ function emitExternrefAssignDestructureGuard(ctx: CodegenContext, fctx: Function
   }
 }
 
+/**
+ * (#3546) After a local write to a `__module_init` MODULE-BINDING shadow local
+ * (recorded by the top-level closure declaration in
+ * `fctx.moduleBindingShadowLocals`), re-sync the `$__mod_<name>` global so the
+ * reassignment is visible to every OTHER function's read/call (which resolve
+ * through the global, not the shadow). Pre-fix, `let f = () => 1; f = () => 2;`
+ * at module top level updated only the shadow — cross-function `f()` silently
+ * kept the FIRST closure.
+ *
+ * Exact name→index match keeps this inert for genuine function-locals and
+ * block-scoped shadows (they use different local slots). Expects the assigned
+ * value to be ON THE STACK (post-`local.tee`); net stack effect is zero.
+ */
+function emitModuleShadowGlobalSync(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  name: string,
+  localIdx: number,
+  stackType: ValType,
+): void {
+  if (fctx.moduleBindingShadowLocals?.get(name) !== localIdx) return;
+  const moduleIdx = ctx.moduleGlobals.get(name);
+  if (moduleIdx === undefined) return;
+  const globalDef = ctx.mod.globals[localGlobalIdx(ctx, moduleIdx)];
+  const globalType = globalDef?.type;
+  fctx.body.push({ op: "local.get", index: localIdx });
+  if (globalType?.kind === "externref" && (stackType.kind === "ref" || stackType.kind === "ref_null")) {
+    // Box on store — the #3534 invariant: the global stays externref.
+    fctx.body.push({ op: "extern.convert_any" });
+  } else if (globalType && !valTypesMatch(stackType, globalType)) {
+    coerceType(ctx, fctx, stackType, globalType);
+  }
+  fctx.body.push({ op: "global.set", index: moduleIdx });
+}
+
 export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): InnerResult {
   // Unwrap parenthesized LHS: (x) = 1 → x = 1
   let lhs = expr.left;
@@ -444,14 +479,17 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
           updateLocalType(fctx, localIdx, resultType);
           fctx.body.push({ op: "local.tee", index: localIdx });
           emitMappedArgParamSync(ctx, fctx, localIdx, resultType);
+          emitModuleShadowGlobalSync(ctx, fctx, name, localIdx, resultType);
           return resultType;
         }
         fctx.body.push({ op: "local.tee", index: localIdx });
         emitMappedArgParamSync(ctx, fctx, localIdx, effectiveLocalType);
+        emitModuleShadowGlobalSync(ctx, fctx, name, localIdx, effectiveLocalType);
         return effectiveLocalType;
       }
       fctx.body.push({ op: "local.tee", index: localIdx });
       emitMappedArgParamSync(ctx, fctx, localIdx, resultType);
+      emitModuleShadowGlobalSync(ctx, fctx, name, localIdx, resultType);
       return resultType;
     }
     // (#3039) Boxed captured global — write THROUGH the ref cell (struct.set

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -844,7 +844,18 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       // so other functions can access the closure via global.get.
       // #1690b: skip the module-global path when a function-local shadow
       // exists — the inner declaration must bind to the local, not the global.
-      const modGlobalIdx = hasLocalShadow ? undefined : ctx.moduleGlobals.get(name);
+      // (#3546) Additionally: only a genuinely TOP-LEVEL declaration binds the
+      // module global. A `let`/`const` inside a top-level BLOCK is a
+      // block-scoped SHADOW — `saveBlockScopedShadows` removed the outer
+      // binding's localMap entry on block entry, so `hasLocalShadow` is false
+      // here and the pre-fix code stored the block's closure into the OUTER
+      // module binding (`{ let f = () => 7; }` clobbered module `f`). `var`
+      // keeps the module store from any top-level block (§10.2.10 var
+      // scoping); function bodies are unaffected (their hoister pre-allocates
+      // the local, so `hasLocalShadow` gates them already).
+      const declIsLexical = (stmt.declarationList.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0;
+      const bindsModuleGlobal = !declIsLexical || ts.isSourceFile(stmt.parent);
+      const modGlobalIdx = hasLocalShadow || !bindsModuleGlobal ? undefined : ctx.moduleGlobals.get(name);
       if (modGlobalIdx !== undefined) {
         // (#3534 step 2, option a) NEVER retro-narrow the pre-declared
         // `$__mod_<name>` global. It is declared `externref` before the closure
@@ -873,14 +884,35 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
             globalDef.init = [{ op: "ref.null", typeIdx: (nullableType as { typeIdx: number }).typeIdx }];
           }
         }
-        // Duplicate value on stack: one for the global, one for the local
-        const localIdx = allocLocal(fctx, name, closureType);
-        fctx.body.push({ op: "local.tee", index: localIdx });
-        if (globalIsExternref && (closureType.kind === "ref" || closureType.kind === "ref_null")) {
-          // Box on store: precise closure struct → externref (A2).
-          fctx.body.push({ op: "extern.convert_any" });
+        if (globalIsExternref) {
+          // (#3546) The `__module_init` shadow local is EXTERNREF — the same
+          // uniform representation as the global (#3534 option a): convert
+          // ONCE, tee the boxed value into the local, store the same value to
+          // the global. Top-level reads return externref (consumers coerce);
+          // top-level calls take `compileClosureCall`'s guarded externref arm
+          // (cold — module init runs once). Keeping the local PRECISE while
+          // the binding is reassignable forced assignment.ts to RETYPE the
+          // local on reassignment — the exact #3534 retro-invalidation
+          // mechanism, one slot over. Record the shadow so a later top-level
+          // reassignment (which resolves to this local via localMap) re-syncs
+          // the module global (#3546 — pre-fix it updated only the shadow and
+          // every cross-function call kept the FIRST closure).
+          const localIdx = allocLocal(fctx, name, { kind: "externref" });
+          if (closureType.kind === "ref" || closureType.kind === "ref_null") {
+            // Box on store: precise closure struct → externref (A2).
+            fctx.body.push({ op: "extern.convert_any" });
+          }
+          fctx.body.push({ op: "local.tee", index: localIdx });
+          fctx.body.push({ op: "global.set", index: modGlobalIdx });
+          (fctx.moduleBindingShadowLocals ??= new Map()).set(name, localIdx);
+        } else {
+          // Legacy non-externref pre-decl arm (closure globals never take
+          // this): duplicate value on stack — one for the global, one for the
+          // (precise) local.
+          const localIdx = allocLocal(fctx, name, closureType);
+          fctx.body.push({ op: "local.tee", index: localIdx });
+          fctx.body.push({ op: "global.set", index: modGlobalIdx });
         }
-        fctx.body.push({ op: "global.set", index: modGlobalIdx });
         // Set TDZ flag to 1 (initialized)
         emitTdzInit(ctx, fctx, name);
       } else {

--- a/tests/issue-3546-toplevel-closure-reassign.test.ts
+++ b/tests/issue-3546-toplevel-closure-reassign.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #3546 — module TOP-LEVEL closure reassignment must be visible to
+ * cross-function reads/calls.
+ *
+ * Pre-fix, `let f = () => 1; f = () => 2;` at module top level wrote only the
+ * `__module_init` local shadow that the DECLARATION created (variables.ts
+ * arrow path: `local.tee` + box-on-store `global.set`); the top-level
+ * REASSIGNMENT then hit the localMap entry inside `__module_init` and took
+ * assignment.ts's LOCAL arm — the `$__mod_f` global (which every OTHER
+ * function's `f()` resolves through) silently kept the FIRST closure. A
+ * silent wrong answer: no trap, no diagnostic, `test()` returned 1.
+ *
+ * These assertions FAIL on the unfixed compiler (they assert the SECOND
+ * closure is observed — got=1 pre-fix), per the wrong-answer-bug gating rule:
+ * the guard is a positive behavioral assertion, not absence-of-trap.
+ */
+import { describe, expect, it } from "vitest";
+import { compileSource } from "../src/compiler.ts";
+import { buildImports } from "../src/runtime.ts";
+import { instantiateWasm } from "../src/runtime-instantiate.ts";
+
+async function run(source: string): Promise<unknown> {
+  const r = await compileSource(source);
+  expect(r.success, r.errors?.[0]?.message).toBe(true);
+  const binary = new Uint8Array(r.binary);
+  await WebAssembly.compile(binary as BufferSource);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await instantiateWasm(binary, imports.env, imports.string_constants, imports.string_constants16);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#3546 — top-level closure reassignment visible cross-function", () => {
+  it("let: top-level reassign, called from an exported fn, sees the SECOND closure", async () => {
+    const got = await run(`let f = (): number => 1;
+f = (): number => 2;
+export function test(): number { return f(); }`);
+    expect(got).toBe(2);
+  });
+
+  it("var: same shape", async () => {
+    const got = await run(`var f = (): number => 1;
+f = (): number => 2;
+export function test(): number { return f(); }`);
+    expect(got).toBe(2);
+  });
+
+  it("reassigned closure capturing state behaves (not just constants)", async () => {
+    const got = await run(`let base = 10;
+let f = (): number => base + 1;
+f = (): number => base + 2;
+export function test(): number { return f(); }`);
+    expect(got).toBe(12);
+  });
+
+  it("top-level call between the two assignments sees the FIRST closure", async () => {
+    const got = await run(`let observed = 0;
+let f = (): number => 1;
+observed = f();
+f = (): number => 2;
+export function test(): number { return observed * 10 + f(); }`);
+    expect(got).toBe(12); // 1 (before reassign) *10 + 2 (after)
+  });
+
+  // Controls — passed BEFORE the fix; must keep passing (no dual-store leaks).
+  it("control: reassignment inside a function still works", async () => {
+    const got = await run(`let f = (): number => 1;
+export function set2(): void { f = (): number => 2; }
+export function test(): number { set2(); return f(); }`);
+    expect(got).toBe(2);
+  });
+
+  it("control: purely local shadow does NOT clobber the module binding", async () => {
+    const got = await run(`const f = (): number => 1;
+function inner(): number {
+  const f = (): number => 5;
+  return f();
+}
+export function test(): number { return inner() * 10 + f(); }`);
+    expect(got).toBe(51);
+  });
+
+  it("control: top-level BLOCK-scoped shadow does not clobber the module binding", async () => {
+    const got = await run(`let f = (): number => 1;
+{
+  let f = (): number => 7;
+  f = (): number => 8;
+}
+export function test(): number { return f(); }`);
+    expect(got).toBe(1);
+  });
+
+  it("control: scalar module let reassignment unaffected", async () => {
+    const got = await run(`let x = 1;
+x = 2;
+export function test(): number { return x; }`);
+    expect(got).toBe(2);
+  });
+});


### PR DESCRIPTION
## Bug (silent wrong answer)

At module top level, `let f = () => 1; f = () => 2;` wrote only the `__module_init` local shadow created by the declaration; the `$__mod_f` externref global — which every OTHER function's `f()` resolves through — silently kept the FIRST closure. No trap, no diagnostic: `test()` returned 1. `var` behaved identically. Pre-existing relative to #3534/#3505 (assignment-path sibling of that declaration-path family).

A second latent wrong answer fixed by the same gate: a `let`/`const` closure inside a top-level BLOCK stored into the OUTER module binding (`{ let f = () => 7; }` clobbered module `f` — measured got=7).

## Fix

- **variables.ts**: the `__module_init` shadow local for a top-level closure declaration is now **externref** (uniform rep, one `extern.convert_any` at the decl). New `bindsModuleGlobal` gate: only genuinely top-level lexical decls bind `$__mod_<name>`; `var` keeps the module store from any top-level block (§10.2.10).
- **assignment.ts**: new `emitModuleShadowGlobalSync` — after the local-arm `local.tee` of a registered shadow (exact name→index match, inert for genuine locals/block shadows), re-push and `global.set` the module global (box-on-store; the #3534 invariant: the global stays externref, never narrowed). Wired at all three return paths of the plain `=` local arm.
- **context/types.ts**: `FunctionContext.moduleBindingShadowLocals` map.

Resumes and completes the preserved WIP from the #3534 owner's session (commit `ee440466`), rebased onto current main (post-#3509/#3534 representation).

## Why the issue's byte-identity criterion was amended (deliberate, not drift)

The issue originally asked for the #3534 corpus to stay byte-identical except reassignment shapes. **That criterion is unachievable for any correct fix of this class, and was amended in the issue file — here is the reasoning inline:**

The dual-store must keep the shadow local and the module global in sync across _later_ reassignments. If the shadow local keeps its PRECISE closure-struct type, a reassignment whose RHS is a _different_ closure struct (different capture set) forces assignment.ts to RETYPE the local mid-function — the exact #3534 retro-invalidation mechanism one slot over: every already-emitted instruction that consumed the local validated against the OLD struct type, so the retype mints invalid Wasm. And even absent retype, a top-level LOOP read compiled before the reassignment would keep reading the stale precise local on iteration 2. Typing the shadow **externref at declaration** (the same uniform rep the global carries per #3534 option a) removes both hazards: reads always flow through the still-current externref local, reassignment coerces once and syncs both stores, and no local is ever retyped.

That one-line representation change necessarily alters the emitted bytes of EVERY module with a top-level closure declaration — hence 10 of 13 corpus entries change hash. The behavioral bar replaces the byte bar: **13/13 corpus entries runtime PASS, zero invalid-Wasm; the 3 entries with no top-level closure decl remain byte-identical** (`capture_mutable`, `closure_capture_call_sibling`, `returned_closure`). Cost honestly stated: top-level reads/calls inside `__module_init` now take the guarded externref arm — cold code, module init runs once; cross-function call cost is unchanged (already guarded per #3534; perf follow-up is #3550).

## Measured (before → after, with denominators)

- `tests/issue-3546-toplevel-closure-reassign.test.ts` (8 tests): **5 FAIL on origin/main src** (wrong-answer assertions: got=1 stale closure ×4, got=7 block clobber) → **8/8 PASS**. The guards assert the SECOND closure is called, not absence-of-trap.
- Standalone lane (7 probe shapes): **5 WRONG → 7/7 PASS** (same shapes).
- #3534 13-case corpus: **13/13 runtime PASS** (`var_reassign_call` WRONG→PASS). Byte detail above.
- Full equivalence dir, matched-pair JSON runs fixed vs origin/main src: **identical 35/1646 failing on both, zero flips either direction**.
- Edge probes: `export let` reassign PASS; reassign-in-loop PASS (=122 — first iteration sees closure 1, second sees 2); different-captures reassign PASS (the retype-hazard shape compiles to valid Wasm and answers correctly).
- Gates local: tsc, prettier, biome, oracle-ratchet, ir-fallbacks, stack-balance, codegen-fallbacks, any-box-sites, coercion-sites, issue-ids-against-main all green; loc-budget growth (+83 across the three god-files) granted via `loc-budget-allow:` in the issue file.
- issue-1690b (4) and issue-3505 (2) test failures in this container reproduce IDENTICALLY on origin/main src (harness `string_constants` gap / missing test262-fyi submodule) — pre-existing, delta zero. Known-failing-on-main unit tests `tests/issue-3471.test.ts` / `tests/call-arg-type-coercion.test.ts` (#3503 fallout, being fixed by another agent) are likewise NOT touched by this PR.

Also carries the predecessor's perf follow-up issue file **#3550** (per-call unbox cost on module-const closure calls; id reserved via `claim-issue.mjs --allocate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb
