### PR TITLE
fix(#3551): cascade IR ABI-parity withdrawal to committed callers

### DIFF
--- a/plan/issues/3551-ir-parity-withdraw-cascade.md
+++ b/plan/issues/3551-ir-parity-withdraw-cascade.md
@@ -1,0 +1,136 @@
+---
+id: 3551
+title: "IR ABI-parity withdrawal must cascade to committed IR callers — #3503 partial-commit broke tests/issue-3471.test.ts on main (invalid Wasm: expected f64, found externref)"
+status: done
+created: 2026-07-23
+updated: 2026-07-23
+completed: 2026-07-23
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: ir
+goal: ir-full-coverage
+sprint: current
+horizon: m
+assignee: ttraenkler/senior-dev-3551
+related: [3503, 3536, 3471, 3552, 1370, 3142]
+# The growth is the fix itself, in the owning module: the cascade must sit
+# between the pendingPatches collection loop and the apply loop (both in
+# integration.ts's Phase 3), the fresh-slot ledger beside the allocation loop
+# it annotates, and the stub pass beside the apply loop whose skipped patches
+# it repairs. ~55 of the +81 lines are the rationale comments the parity
+# guard's existing style requires.
+loc-budget-allow:
+  - src/ir/integration.ts
+---
+
+# IR ABI-parity withdrawal must cascade to committed IR callers
+
+## Problem
+
+`tests/issue-3471.test.ts` ("numeric args to isSameValue still compare
+correctly (no over-fix)") went red ON MAIN with:
+
+```
+CompileError: Compiling function "check" failed: call[0] expected type f64, found call of type externref
+```
+
+Bisected (definitive): green at `6f95f9855fa5e6`, red at the #3503 merge
+(`8507682f516375`). No required check runs untouched root test files, so the
+regression landed silently (the CI-gap half is #3552).
+
+## Root cause — half (b) of #3503, the abi-signature-parity withdraw
+
+#3503 had two halves: (a) standalone-gated object-literal `expectedType`
+routing in `literals.ts` (`ctx.standalone &&` — verified NOT implicated in
+this host-lane failure), and (b) extending the IR patch-time typeIdx-parity
+guard to top-level FunctionDeclarations with a soft "withdraw the claim"
+fallback. (b) is responsible — but the withdrawal itself is correct; what was
+missing is that it must not be **per-function**:
+
+- Every IR body is compiled against `calleeTypes` — the IR's **shared view**
+  of every claimed function's signature (built from the Phase-2 TypeMap
+  overrides, `src/codegen/index.ts` ~line 2258 → `src/ir/integration.ts`
+  ~line 318).
+- The IR TypeMap legitimately types DEEPER than legacy inference: in the
+  repro, `check(1, 1)` narrows `check`'s params to f64, and the TypeMap
+  propagates f64 through `isSameValue(a, b)` → IR view `(f64, f64)`. Legacy
+  (post-#3471) keeps the polymorphic comparator boxed: `(externref,
+externref)`. The divergence is by design, not a bug.
+- Pre-#3503, top-level functions were patched UNCONDITIONALLY, so the whole
+  IR cluster committed together — mutually consistent (that unconditional
+  patch is what broke legacy callers in #3536).
+- Post-#3503, `isSameValue` withdraws on the typeIdx mismatch (legacy
+  externref ABI kept) while `check` — whose OWN typeIdx matched — still
+  committed its IR body, whose call args were baked for the now-dead
+  `(f64, f64)` IR view. The stack-balance repair then mangled the call
+  (observed final body: `local.get 0; call $__box_number; call $__box_number;
+local.get 1; return_call $isSameValue` — arg 0 double-boxed, arg 1 raw f64)
+  and instantiation failed.
+
+**Invariant**: a pending IR patch may commit only if every function its body
+references still carries the ABI the body was compiled against.
+
+## Fix (this PR)
+
+`src/ir/integration.ts`, patch phase:
+
+1. Collect every name withdrawn by the typeIdx-parity guard (all three arms:
+   class-member/module-init invariant, top-level soft withdraw) in
+   `abiDivergentNames`.
+2. **Cascade** (after the collection loop, before applying patches): withdraw
+   any still-pending patch whose IR body references a withdrawn name — `call`
+   targets and `closure.new` lifted-func refs, the only two `IrFuncRef`
+   carriers. One level is a fixpoint: a cascade-withdrawn caller passed the
+   guard itself (IR typeIdx == legacy typeIdx), so keeping its legacy body
+   changes nothing about the ABI its own callers compiled against.
+3. **Stub orphaned fresh slots**: a mono-clone/lifted slot whose owner failed
+   after allocation would be emitted with an EMPTY body (invalid Wasm for any
+   non-void signature, and reachable from a healthy owner's committed body).
+   Fill with a lone `unreachable` — validates against every signature,
+   localizes the failure to paths that actually enter the orphan. This
+   mitigates the one hazard class the cascade makes more frequent (it
+   pre-exists for ordinary lower-stage owner failures).
+
+Why not revert #3503: it fixed a real standalone defect (#3536) that stays
+fixed (its guard + tests are untouched and still green). Why not withdraw at
+overrideMap-build time instead: comparing IrType-vs-ValType signatures early
+would need the Phase-3 resolver/registries (not yet built) and would
+re-implement the canonical comparison `addFuncType` dedup already gives the
+patch loop for free.
+
+## Residual (pre-existing, NOT introduced here; follow-up candidate)
+
+A claim that fails at **build/verify/lower** stage (not the parity guard)
+also leaves `calleeTypes`-baked callers committed. If that function's IR-view
+signature diverges from legacy, the same inconsistency arises — but at those
+stages the IR typeIdx is unknown (never lowered), so the cascade can't know
+whether the ABI diverged without lowering the `calleeTypes` signature via the
+resolver (side-effectful type interning). This hole predates #3503 (it has
+existed since `calleeTypes` was introduced) and did not cause this
+regression; closing it should be its own issue if it ever fires.
+
+Also observed while diagnosing (separate, masked): the stack-balance repair
+pass "fixed" the two-arg coercion mismatch by inserting BOTH `__box_number`
+calls after the first `local.get` (double-box + raw pass-through) instead of
+one per operand — a positional-insertion bug in the repair, moot for this
+regression once the cascade fires, relevant to #1918's strict-mode ambitions.
+
+## Validation
+
+- `tests/issue-3471.test.ts` — 7/7 green (was 6/7 on main).
+- `tests/issue-3536.test.ts` — 5/5 green (the #3503 fix is preserved).
+- `tests/issue-3551.test.ts` (new) — cascade fires, module instantiates,
+  values correct, no over-withdrawal of healthy callees.
+- `pnpm run check:ir-fallbacks` — OK, no bucket growth (the corpus has zero
+  parity withdrawals, so the cascade adds nothing there).
+- IR suites: ir-frontend-widening, ir-backend-emitter, ir-propagate-i32,
+  ir-vec-two-backend, issue-1372/1374/1982, ir-if-else/let-const/numeric-bool/
+  ternary/algorithms — green. (ir-scaffold 2 fails + ir-nullish-coalesce 3
+  fails are PRE-EXISTING on main — verified by control run with unmodified
+  `src/ir/integration.ts`.)
+- Equivalence function/closure shards (10 files, 120 tests) — green.
+
+Note: `tests/call-arg-type-coercion.test.ts` has 2 pre-existing failures on
+main (present at #3503's parent) — deliberately NOT absorbed here.

--- a/plan/issues/3551-ir-parity-withdraw-cascade.md
+++ b/plan/issues/3551-ir-parity-withdraw-cascade.md
@@ -85,13 +85,18 @@ references still carries the ABI the body was compiled against.
    carriers. One level is a fixpoint: a cascade-withdrawn caller passed the
    guard itself (IR typeIdx == legacy typeIdx), so keeping its legacy body
    changes nothing about the ABI its own callers compiled against.
-3. **Stub orphaned fresh slots**: a mono-clone/lifted slot whose owner failed
-   after allocation would be emitted with an EMPTY body (invalid Wasm for any
-   non-void signature, and reachable from a healthy owner's committed body).
-   Fill with a lone `unreachable` — validates against every signature,
-   localizes the failure to paths that actually enter the orphan. This
-   mitigates the one hazard class the cascade makes more frequent (it
-   pre-exists for ordinary lower-stage owner failures).
+3. **Stub orphaned empty slots**: two slot families can be stranded bodyless
+   when their owner fails after allocation — fresh slots (mono clones /
+   lifted fns) and pre-allocated slots with an empty legacy body (a
+   branch-hoisted nested declaration, the guard's empty-slot fall-through
+   case, e.g. cascade-withdrawn because its body called a parity-withdrawn
+   function). An empty body is invalid Wasm for any signature WITH results
+   and can be reachable from a healthy owner's committed body. Fill with a
+   lone `unreachable` — validates against every signature, localizes the
+   failure to paths that actually enter the orphan. Empty VOID bodies are
+   valid fall-through Wasm and are left as-is (no silent-no-op → trap
+   conversion). This mitigates the one hazard class the cascade makes more
+   frequent (it pre-exists for ordinary lower-stage owner failures).
 
 Why not revert #3503: it fixed a real standalone defect (#3536) that stays
 fixed (its guard + tests are untouched and still green). Why not withdraw at

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1539,18 +1539,30 @@ export function compileIrPathFunctions(
     compiled.push(patch.entry.name);
   }
 
-  // (#3551) Stub orphaned fresh slots. A fresh slot (mono clone / lifted fn)
-  // whose owner failed after allocation — at lower time or via the cascade
-  // above — would otherwise be emitted with an EMPTY body: invalid Wasm for
-  // any non-void signature, and reachable when a HEALTHY owner committed a
-  // body that calls the failed owner's clone. A lone `unreachable` validates
+  // (#3551) Stub orphaned empty slots. Two slot families can be stranded
+  // BODYLESS when their owner fails after allocation (at lower time or via
+  // the cascade above): fresh slots (mono clones / lifted fns), and
+  // pre-allocated slots whose legacy body was empty (a branch-hoisted nested
+  // declaration — the guard's empty-slot fall-through case, where the IR body
+  // was the only body on offer). An empty body is invalid Wasm for any
+  // signature WITH results, and the slot can be reachable (a HEALTHY owner
+  // may have committed a body that calls it). A lone `unreachable` validates
   // against every signature, keeps the rest of the module working, and traps
-  // only on a path that actually enters the orphaned artifact.
+  // only on a path that actually enters the orphaned artifact. Empty VOID
+  // bodies are already valid Wasm (fall-through) — leave those as-is rather
+  // than converting today's silent no-op into a trap.
+  const stubIfOrphanedEmpty = (funcIdx: number): void => {
+    const orphan = definedFuncAt(ctx, funcIdx);
+    if (!orphan || orphan.body.length > 0) return;
+    const typeDef = ctx.mod.types[orphan.typeIdx];
+    if (!typeDef || typeDef.kind !== "func" || typeDef.results.length === 0) return;
+    replaceDefinedFuncAt(ctx, funcIdx, { ...orphan, body: [{ op: "unreachable" }] });
+  };
   for (const slot of freshSlots) {
-    if (!failedOwners.has(slot.ownerName)) continue;
-    const orphan = definedFuncAt(ctx, slot.funcIdx);
-    if (!orphan || orphan.body.length > 0) continue;
-    replaceDefinedFuncAt(ctx, slot.funcIdx, { ...orphan, body: [{ op: "unreachable" }] });
+    if (failedOwners.has(slot.ownerName)) stubIfOrphanedEmpty(slot.funcIdx);
+  }
+  for (const patch of pendingPatches) {
+    if (failedOwners.has(patch.entry.ownerName)) stubIfOrphanedEmpty(patch.funcIdx);
   }
 
   const dropTerminal = process.env.JS2WASM_TEST_DROP_IR_TERMINAL;

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1150,6 +1150,11 @@ export function compileIrPathFunctions(
   // The placeholder body is overwritten with the real lowered body in the
   // Phase-3 loop below.
   // -------------------------------------------------------------------------
+  // (#3551) Track freshly-allocated slots so an owner failure AFTER
+  // allocation (e.g. the ABI-parity withdrawal cascade in Phase 3) can stub
+  // the orphaned slot instead of leaving an EMPTY body in the module (see
+  // the stub pass after the patch loop below).
+  const freshSlots: Array<{ readonly funcIdx: number; readonly ownerName: string }> = [];
   for (const entry of healthyForLower) {
     // Top-level (non-synthesized) functions already have a funcIdx
     // allocated by `compileDeclarations`. Skip them.
@@ -1171,6 +1176,7 @@ export function compileIrPathFunctions(
       exported: false,
     });
     ctx.funcMap.set(entry.name, funcIdx);
+    freshSlots.push({ funcIdx, ownerName: entry.ownerName });
   }
 
   // -------------------------------------------------------------------------
@@ -1323,6 +1329,14 @@ export function compileIrPathFunctions(
     readonly finalBody: Instr[];
   };
   const pendingPatches: PendingPatch[] = [];
+  // (#3551) Function names withdrawn by the typeIdx-parity guard below. Every
+  // IR body was compiled against `calleeTypes` — the IR's shared view of each
+  // claimed function's signature — so when a callee's claim is withdrawn on a
+  // parity mismatch (its slot keeps the LEGACY ABI, which the mismatch just
+  // proved differs from the IR view), any committed IR caller of it would call
+  // through the wrong ABI. The cascade after this loop withdraws those callers
+  // too; collecting the names here is its input.
+  const abiDivergentNames = new Set<string>();
   for (const entry of healthyForLower) {
     const name = entry.name;
     try {
@@ -1397,6 +1411,7 @@ export function compileIrPathFunctions(
         if (entry.classMember || entry.moduleInit) {
           // Pre-#3536 semantics unchanged: for these units a mismatch means
           // the lowering itself went wrong — a hard invariant.
+          abiDivergentNames.add(name);
           markOwnerInvariant(
             entry.ownerName,
             name,
@@ -1412,6 +1427,7 @@ export function compileIrPathFunctions(
           // shape-struct param) — a soft withdraw-the-claim fallback, NOT a
           // compile error. The legacy body stays; callers keep the ABI they
           // compiled against.
+          abiDivergentNames.add(name);
           markOwnerFailure(
             entry.ownerName,
             name,
@@ -1475,6 +1491,39 @@ export function compileIrPathFunctions(
     }
   }
 
+  // (#3551) ABI-parity withdrawal CASCADE. A withdrawal above keeps the
+  // callee's LEGACY body and typeIdx — but every IR body was compiled against
+  // `calleeTypes`, the IR's shared view of each claimed function's signature,
+  // which the parity mismatch just proved DIFFERS from that legacy ABI for the
+  // withdrawn name. Committing a caller while withdrawing its callee therefore
+  // strands the caller on the wrong ABI: the #3503 partial-commit regression
+  // (tests/issue-3471.test.ts) committed `check`'s IR body — which passed raw
+  // f64 args per the IR view of `isSameValue` — while `isSameValue` withdrew
+  // to its legacy `(externref, externref)` signature, producing invalid Wasm
+  // ("call[0] expected type f64, found call of type externref") after the
+  // stack-balance repair mangled the arg coercions. So: withdraw every still-
+  // pending patch whose IR body references a parity-withdrawn name. One level
+  // is a fixpoint — a cascade-withdrawn caller PASSED the guard itself (its
+  // IR typeIdx equals its legacy typeIdx), so keeping its legacy body changes
+  // nothing about the ABI its own callers compiled against.
+  if (abiDivergentNames.size > 0) {
+    for (const patch of pendingPatches) {
+      if (failedOwners.has(patch.entry.ownerName)) continue;
+      const referenced = findReferencedFuncName(patch.entry.fn, abiDivergentNames);
+      if (referenced === undefined) continue;
+      markOwnerFailure(
+        patch.entry.ownerName,
+        patch.entry.name,
+        new IrUnsupportedError(
+          "abi-signature-parity",
+          "resolve",
+          `body references ${referenced}, whose claim was withdrawn on a typeIdx parity mismatch — the call ABI baked from calleeTypes no longer matches; keeping legacy body`,
+        ),
+        "patch",
+      );
+    }
+  }
+
   // Patch only after every artifact lowered successfully. A lifted/clone
   // failure invalidates its whole source owner, including an already-lowered
   // main artifact, so the ledger can never report emitted+fatal for one row.
@@ -1488,6 +1537,20 @@ export function compileIrPathFunctions(
       exported: patch.existing.exported,
     });
     compiled.push(patch.entry.name);
+  }
+
+  // (#3551) Stub orphaned fresh slots. A fresh slot (mono clone / lifted fn)
+  // whose owner failed after allocation — at lower time or via the cascade
+  // above — would otherwise be emitted with an EMPTY body: invalid Wasm for
+  // any non-void signature, and reachable when a HEALTHY owner committed a
+  // body that calls the failed owner's clone. A lone `unreachable` validates
+  // against every signature, keeps the rest of the module working, and traps
+  // only on a path that actually enters the orphaned artifact.
+  for (const slot of freshSlots) {
+    if (!failedOwners.has(slot.ownerName)) continue;
+    const orphan = definedFuncAt(ctx, slot.funcIdx);
+    if (!orphan || orphan.body.length > 0) continue;
+    replaceDefinedFuncAt(ctx, slot.funcIdx, { ...orphan, body: [{ op: "unreachable" }] });
   }
 
   const dropTerminal = process.env.JS2WASM_TEST_DROP_IR_TERMINAL;
@@ -1506,6 +1569,24 @@ export function compileIrPathFunctions(
 
 function hasExportModifier(fn: ts.FunctionDeclaration): boolean {
   return !!fn.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+/**
+ * (#3551) Scan an IR function for any symbolic reference to one of `names`.
+ * `IrFuncRef` has exactly two carriers in the instruction set — direct `call`
+ * targets and `closure.new` lifted-func refs — and terminators carry none, so
+ * a flat walk over every block's instrs is complete. Returns the first
+ * referenced name (for the withdrawal detail), or undefined when the body
+ * references none of them.
+ */
+function findReferencedFuncName(fn: IrFunction, names: ReadonlySet<string>): string | undefined {
+  for (const block of fn.blocks) {
+    for (const instr of block.instrs) {
+      if (instr.kind === "call" && names.has(instr.target.name)) return instr.target.name;
+      if (instr.kind === "closure.new" && names.has(instr.liftedFunc.name)) return instr.liftedFunc.name;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/tests/issue-3551.test.ts
+++ b/tests/issue-3551.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3551 — IR ABI-parity withdrawal must CASCADE to committed IR callers.
+//
+// Every IR body is compiled against `calleeTypes` — the IR's shared view of
+// each claimed function's signature. #3503 (the #3536 fix) taught the
+// patch-time typeIdx-parity guard to WITHDRAW a top-level function whose
+// IR-resolved signature diverges from the legacy-registered one (keeping the
+// legacy body + ABI). But withdrawal was per-function: a caller whose own
+// typeIdx matched still COMMITTED its IR body — a body whose call arguments
+// were baked against the withdrawn callee's IR-view signature, which the
+// parity mismatch just proved is NOT the callee's final ABI.
+//
+// Concrete regression (tests/issue-3471.test.ts, "numeric args to isSameValue
+// still compare correctly"): the IR TypeMap propagated f64 through
+// `check(1, 1) → isSameValue(a, b)` and typed `isSameValue` as `(f64, f64)`,
+// while legacy inference (post-#3471) kept its polymorphic params boxed as
+// `(externref, externref)`. `isSameValue` withdrew on the mismatch (legacy
+// externref ABI kept); `check` committed an IR body passing raw f64s. The
+// stack-balance repair then mangled the args (double-boxed arg 0, raw-f64
+// arg 1) and instantiation failed:
+//   "Compiling function "check" failed: call[0] expected type f64, found
+//    call of type externref"
+//
+// Fix: collect every parity-withdrawn name; before applying patches, withdraw
+// any still-pending patch whose IR body references one of them (`call` target
+// or `closure.new` lifted-func ref). One level is a fixpoint: a
+// cascade-withdrawn caller passed the guard itself, so its legacy body keeps
+// the exact ABI its own callers compiled against.
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { describe, expect, it } from "vitest";
+
+/** Compile in host mode, instantiate, and return the exported `test()` value. */
+async function runTest(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts" });
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if ((imports as { setExports?: (e: unknown) => void }).setExports) {
+    (imports as { setExports: (e: unknown) => void }).setExports(exports);
+  }
+  return exports.test();
+}
+
+// The exact divergence shape: `poly`'s params stay boxed under legacy
+// inference (polymorphic — post-#3471), while the IR TypeMap propagates the
+// numeric call-site types and re-types them f64 → parity withdrawal.
+const POLY = `
+function poly(a, b) {
+  if (a === 0 && b === 0) return 1 / a === 1 / b;
+  if (a !== a && b !== b) return true;
+  return a === b;
+}`;
+
+describe("#3551 — parity withdrawal cascades to committed IR callers", () => {
+  it("caller of a parity-withdrawn callee instantiates and runs (the #3503 regression shape)", async () => {
+    const src = `${POLY}
+      function mid(a, b) { return poly(a, b); }
+      export function test() {
+        var eq = mid(1, 1) ? 1 : 0;    // 1
+        var ne = mid(1, 2) ? 10 : 0;   // 0
+        return eq + ne;                // expect 1
+      }`;
+    // Pre-fix: WebAssembly.instantiate CompileError ("call[0] expected type
+    // f64, found call of type externref") — `mid` committed its IR body
+    // (raw-f64 call per the IR view) while `poly` withdrew to its legacy
+    // (externref, externref) ABI.
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("cascade withdrawal surfaces on the IR fallback channel, not as an invalid module", async () => {
+    const src = `${POLY}
+      function mid(a, b) { return poly(a, b); }
+      export function test() { return mid(2, 2) ? 1 : 0; }`;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+    const warnings = r.errors.map((e) => e.message).join("\n");
+    // The callee withdraws on the parity mismatch...
+    expect(warnings).toMatch(/poly: function typeIdx parity mismatch/);
+    // ...and the caller is withdrawn BY THE CASCADE (references the callee),
+    // rather than committing a body baked against the dead IR-view ABI.
+    expect(warnings).toMatch(/mid: body references poly, whose claim was withdrawn on a typeIdx parity mismatch/);
+  });
+
+  it("a two-level chain through the withdrawn callee still computes correct values", async () => {
+    const src = `${POLY}
+      function mid(a, b) { return poly(a, b); }
+      function outer(a, b) { return mid(a, b); }
+      export function test() {
+        var eq = outer(3, 3) ? 1 : 0;   // 1
+        var ne = outer(3, 4) ? 10 : 0;  // 0
+        return eq + ne;                 // expect 1
+      }`;
+    // `mid` is cascade-withdrawn; `outer`'s ABI expectation of `mid` is
+    // unchanged (mid passed the guard — legacy typeIdx === IR typeIdx), so
+    // one cascade level suffices whether `outer` commits or not.
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("does not over-withdraw: an IR caller of a HEALTHY callee still commits", async () => {
+    const src = `
+      function twice(n: number): number { return n * 2; }
+      function callTwice(n: number): number { return twice(n) + 1; }
+      export function test() { return callTwice(20); }`;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+    // No parity mismatch anywhere in this module → the cascade must not fire.
+    expect(r.errors.map((e) => e.message).join("\n")).not.toMatch(/parity mismatch/);
+    const imports = buildImports(r.imports, {}, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+    const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+    expect(exports.test()).toBe(41);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the main-branch regression introduced by #3503 (bisected: green at `6f95f9855fa5e6`, red at the #3503 merge): `tests/issue-3471.test.ts` — "numeric args to isSameValue still compare correctly (no over-fix)" — failed with

```
CompileError: Compiling function "check" failed: call[0] expected type f64, found call of type externref
```

**Root cause — half (b) of #3503** (the abi-signature-parity withdraw; half (a), the object-literal `expectedType` routing, is `ctx.standalone`-gated and not implicated). The withdraw was **per-function**, but every IR body is compiled against `calleeTypes` — the IR's shared view of each claimed function's signature. The IR TypeMap legitimately types deeper than legacy inference (here: `(f64, f64)` for `isSameValue` via numeric call-site propagation, vs legacy's post-#3471 polymorphic `(externref, externref)`). When `isSameValue` withdrew on the typeIdx mismatch (keeping the legacy externref ABI), its IR caller `check` — whose own typeIdx matched — still committed a body baked for the dead `(f64, f64)` view. The stack-balance repair then mangled the call args (double-boxed arg 0, raw-f64 arg 1) and instantiation failed.

**Invariant restored**: a pending IR patch may commit only if every function its body references still carries the ABI the body was compiled against.

## Fix (`src/ir/integration.ts`, Phase 3)

1. Collect every parity-withdrawn name (all three guard arms).
2. **Cascade** before applying patches: withdraw any still-pending patch whose IR body references a withdrawn name (`call` targets + `closure.new` lifted refs — the only `IrFuncRef` carriers). One level is a fixpoint: a cascade-withdrawn caller passed the guard itself, so its legacy body keeps exactly the ABI its own callers compiled against.
3. Stub orphaned fresh slots (mono clones / lifted fns of a failed owner) with a lone `unreachable` so they can't be emitted with an empty body.

Not a revert: #3503's standalone fix (#3536) is preserved — its guard and tests are untouched and green. `tests/issue-3471.test.ts` is landed green **unweakened**.

## Validation

- `tests/issue-3471.test.ts` 7/7 (was 6/7 on main); `tests/issue-3536.test.ts` 5/5; new `tests/issue-3551.test.ts` 4/4
- `check:ir-fallbacks` OK (no bucket growth), oracle/stack-balance/LOC ratchets OK (`loc-budget-allow` granted in the issue file)
- IR suites + 10 function/closure equivalence shards (120 tests) green; ir-scaffold/ir-nullish-coalesce failures verified pre-existing via control run with unmodified `integration.ts`
- `tests/call-arg-type-coercion.test.ts`'s 2 failures are pre-existing at #3503's parent — deliberately not absorbed

Companion (separate PR, stacked): #3552 brings this class of untouched guard test into a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvU8vk2ntmbYbHoewNrMDb