### PR TITLE
feat(#2864 D2): yield* delegation abrupt forwarding + dedicated self-suspend states

### DIFF
--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -1,9 +1,10 @@
 ---
 id: 2864
 title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-laneB
 created: 2026-06-30
-updated: 2026-07-04
+updated: 2026-07-23
 priority: high
 feasibility: hard
 model: fable

--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -15,6 +15,8 @@ horizon: xl
 related: [2860, 680, 2865]
 umbrella: 2860
 architect_spec: candidate
+loc-budget-allow:
+  - src/codegen/generators-native.ts
 ---
 
 # Standalone: Wasm-native generator carrier (sync)

--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -1,8 +1,7 @@
 ---
 id: 2864
 title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
-status: in-progress
-assignee: ttraenkler/dev-laneB
+status: ready
 created: 2026-06-30
 updated: 2026-07-23
 priority: high
@@ -367,20 +366,15 @@ open dispatch) all pass. What was actually missing on the sync-carrier side:
 ### Remaining protocol gaps (banked slices, exact contracts)
 
 - **D2 — delegation abrupt forwarding (iterator close through yield\*)**:
-  `.return(v)` / `.throw(e)` on the OUTER while suspended in a `yield-star`
-  state must forward to the INNER (`inner.return`/`inner.throw`, §27.5.3.7
-  steps 7.b/7.c) so the inner's `finally` blocks run, then continue the
-  outer's abrupt path. Today the outer's per-state abrupt block completes the
-  outer WITHOUT closing the inner (inner finalizers silently skipped).
-  Contract: in the yield-star state's abrupt block (mode != 0), when the
-  delegation slot is non-null, drive the inner's resume once with the SAME
-  mode + abrupt/error payload (write inner's `MODE`/`ABRUPT`/`ERROR` fields,
-  call its resume fn), discard the inner's result, null the slot, then run the
-  outer's own finalizers as today. Wasm-level: mirrors F2's mode-2 wiring, one
-  extra call in the abrupt block, gated on `delegationSlots` non-empty —
-  byte-inert for non-delegating generators. Test: M3 probe shape
-  (`inner try/finally`, outer `.return()` mid-delegation → inner `log`
-  written + outer completes with the return value).
+  **LANDED 2026-07-23** (see the D2 section below). `.return(v)` / `.throw(e)`
+  on the OUTER while suspended in a `yield-star` state forwards to the INNER
+  (§27.5.3.7 steps 7.b/7.c) so the inner's `finally` blocks run, then
+  continues the outer's abrupt path. Also fixed en route: the self-suspending
+  yield-star state is now DEDICATED (never state 0, empty prelude, no resume
+  bindings), closing three protocol bugs — first-statement `yield*`
+  suspensions misclassified as NOT-STARTED by the dispatch, prelude
+  re-execution on every mid-delegation `.next()`, and resume-binding clobber
+  by mid-delegation `.next(v)` values.
 - **D3 — general-iterable `yield*`**: lives in #2173 (vec-cursor for numeric
   arrays — slice-2a there, NOT blocked by #2106; generic `{next()}` +
   `.return()` close as slice-2b, which SHOULD reuse D2's forwarding shape).
@@ -428,6 +422,93 @@ trigger — do not port the sync carrier now.** Rationale:
    frames — building async gens on `generators-native.ts` instead would be a
    third machine. Rule of thumb going forward: **new control-flow capability →
    CFG planner; carrier/value-rep capability → generators-native.**
+
+## D2 — delegation abrupt forwarding + dedicated yield-star states (landed 2026-07-23)
+
+**Scope shipped:** `.return(v)` / `.throw(e)` on the OUTER generator while
+suspended mid-`yield*` now closes the INNER native generator first — driving
+its resume once with the same abrupt mode/payloads so its `finally` blocks run
+(§27.5.3.7 steps 7.b/7.c) — then continues the outer's own abrupt path
+(finalizers → complete/throw). Verify-first (M3 probe, standalone, host-free
+asserted): inner `try { yield 1; yield 2 } finally { log = 100 }`, outer
+`yield* inner()`, `.return(7)` mid-delegation → **before:** `log` stayed 0 and
+(first-statement shape) the outer completed via the NOT-STARTED dispatch arm;
+**after:** `log === 100`, result `{7, done: true}` — matches Node exactly, as
+do `.throw()` forwarding, inner+outer finally ordering (inner first), a
+finally-thrown replacement error (return→throw completion upgrade), and the
+loop-carried two-pass close.
+
+### Why these decisions (root-cause, not symptom)
+
+- **Dedicated self-suspend state (plan builder).** A yield-star terminator
+  re-enters its OWN state on every resume (`state = THIS`), which surfaced
+  three latent protocol bugs beyond the missing close: (a) a first-statement
+  `yield*` suspends in **state 0**, which the `.return()`/`.throw()` dispatch
+  reads as NOT-STARTED (§27.5.3.4/.3.6) — it completed/threw WITHOUT resuming,
+  skipping inner AND outer finalizers; (b) the state's prelude statements
+  re-ran on every mid-delegation `.next()` (side effects repeated, measured
+  `calls=3` vs Node 1); (c) a preceding `const x = yield …` resume binding
+  re-copied `sent` per re-entry, clobbering `x` with later `.next(v)` values
+  (measured 7 vs Node 5). The `emitYield` asterisk branch now splits: if the
+  current state has prelude statements, resume bindings, or IS state 0, it is
+  finished with a `jump` and the yield-star terminator gets a fresh dedicated
+  state. It also always carries an `abruptResume` (finalizers recomputed from
+  the yield\* position's replay chain, empty outside try) so a mid-delegation
+  abrupt is handled even when the yield\* was the generator's first suspend
+  point. Applies to all three delegation kinds (native-gen / vec / iterable).
+- **Forwarding lives in the generic per-state abrupt block** (`compileState`,
+  `abruptResume` branch), gated on the state's terminator being a native-gen
+  `yield-star` AND the delegation slot being non-null at runtime — so an
+  abrupt at the plain-yield suspension BEFORE delegation starts (slot null)
+  skips it, and non-delegating generators are **byte-identical** (verified:
+  8-program × 3-lane sha256 matrix unchanged; only delegating programs differ,
+  and only in standalone/wasi — the gc lane is byte-identical even for
+  delegation, the native yield\* path being standalone-gated).
+- **Inner drive is wrapped in wasm `try`/`catch $exn`.** A mode-2 inner
+  re-throws after its finalizers (F2 wiring), and an inner `finally` that
+  itself throws surfaces a NEW error; both are caught, stored into the outer's
+  `ERROR` field, and upgrade the outer's mode to THROW — so the outer's own
+  finalizers still run before the error reaches the caller, and a `.return()`
+  whose close throws becomes a throw completion (spec). Host-mode foreign JS
+  exceptions recover via the #3050 `__get_caught_exception` catch_all when the
+  resume emitter acquired it.
+- **Inner abrupt payload:** inners are f64-gated, so the inner's `abrupt`
+  field takes the outer's `.return(v)` value when the outer carrier is f64,
+  else the undefined sentinel — unobservable either way (the inner's close
+  result is discarded; the outer completes with its OWN abrupt field, which is
+  observably equivalent for every supported shape since a yield-free `finally`
+  cannot override the return value).
+
+### Residuals (pre-existing, NOT D2)
+
+- Mid-delegation `.next(v)` does not forward `v` to the inner's `sent` field
+  (two-way communication through a running delegation) — same class as the
+  buffer-model gaps tracked under #3032; the host lane has the same behavior.
+- Generic-iterable (`$__IterRec`) close (`inner.return()` protocol for
+  non-generator iterators) is #2173 slice-2b's D2-shape reuse, unchanged here
+  (the outer now completes correctly; the foreign iterator is simply not
+  notified).
+- try/CATCH across yield (D4) stays on the host path — #2906 3c convergence.
+
+### Files (D2)
+
+- `src/codegen/generators-native.ts` — dedicated-state split + always-abrupt
+  in the `emitYield` asterisk branch; delegate-close forwarding at the top of
+  the `abruptResume` block in `compileState`.
+- `tests/issue-2864-standalone-generator-carrier.test.ts` — 10 D2 standalone
+  cases (zero-host-import asserted), covering the M3 probe, throw forwarding,
+  finally ordering, pre-delegation abrupt, finally-throw upgrade, loop-carried
+  close, done protocol, vec first-statement close, prelude-once, and
+  resume-binding survival.
+
+## Slice routing after D2 (what remains where)
+
+All remaining carrier work is tracked in OTHER issues: D3 general-iterable
+`yield*` close → #2173 slice-2b; D4 try/catch-across-yield → #2906 3c planner
+convergence; IR-lane `gen.setReturn` → #2951; boxed-any resume bindings (F1c)
+→ blocked on #2151; spread/`Array.from` precision for the boxed-any carrier —
+small, unowned, listed in F1's deferred notes. This issue stays open only as
+the umbrella record for those pointers.
 
 ### Composition with #3032 lazy-first-resume thunks
 

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -801,6 +801,29 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
       // could not be routed into the region's catch/finally. Bail to the host
       // path (legacy replay-only regions keep today's behavior).
       if (unwind.some((e) => e.kind !== "replay")) return fail();
+      // (#2864 D2) A yield-star terminator SELF-SUSPENDS (its yield arm re-enters
+      // the SAME state on the next resume), so it must live in a DEDICATED state:
+      //  (a) empty prelude / no resume bindings — otherwise the prelude statements
+      //      re-ran and the `sent`-copy re-executed (clobbering the binding with
+      //      later `.next(v)` values) on EVERY mid-delegation resume;
+      //  (b) never state 0 — the `.return()`/`.throw()` dispatch reads state 0 as
+      //      NOT-STARTED (§27.5.3.4/§27.5.3.6), so a first-statement `yield*`
+      //      suspension was misclassified and completed/threw WITHOUT closing the
+      //      delegate (and without running the outer's own finalizers);
+      //  (c) always carrying an abrupt block — recomputed below from the yield*
+      //      position's replay chain (empty outside any try/finally) — so a
+      //      mid-delegation `.return()`/`.throw()` resume is handled instead of
+      //      silently ignored; the block hosts the D2 delegate-close forwarding.
+      // Split only when needed so already-dedicated states keep their ids.
+      if (curStatements.length > 0 || curResumeBindings.length > 0 || curId === 0) {
+        const starId = reserveState();
+        finishState(curId, { kind: "jump", next: starId });
+        resetCursor(starId);
+      }
+      curAbrupt = {
+        finalizers: unwind.map((e) => [...(e as { statements: readonly ts.Statement[] }).statements]).reverse(),
+      };
+      curUnwind = undefined;
       const subject = yieldExpr.expression;
       const innerName = subject ? nativeGeneratorDelegationName(subject) : undefined;
       if (subject && innerName === undefined) {
@@ -2875,6 +2898,100 @@ function compileState(
     const abruptBody: Instr[] = [];
     const savedAbrupt = fctx.body;
     fctx.body = abruptBody;
+    // (#2864 D2) Delegation abrupt forwarding — iterator close through `yield*`
+    // (§27.5.3.7 steps 7.b/7.c). A `.return(v)` / `.throw(e)` on the OUTER while
+    // suspended in a native-gen yield-star state must forward the abrupt to the
+    // INNER first (drive its resume once with the SAME mode + payloads) so the
+    // inner's `finally` blocks run, then continue the outer's own abrupt path
+    // (its finalizers + completion) exactly as before. Gated on the state's
+    // terminator being a native-gen delegation AND the slot being non-null
+    // (mid-delegation) — byte-inert for non-delegating generators, and inert at
+    // runtime for an abrupt resume at the plain-yield suspension that precedes
+    // the delegation (slot still null). A mode-2 inner re-throws after its
+    // finalizers (F2), and a `finally` that itself throws surfaces a NEW error —
+    // both are caught here, stored as the outer's error, and upgrade the outer
+    // to the throw path (a return completion whose close throws becomes a throw
+    // completion, per spec).
+    if (state.terminator.kind === "yield-star" && state.terminator.delegationKind === "native-gen") {
+      const closeSlot = info.delegationSlots?.[state.terminator.siteIndex];
+      const closeInner = closeSlot ? ctx.nativeGenerators.get(closeSlot.innerName) : undefined;
+      if (closeSlot && closeInner) {
+        const closeResumeIdx = ensureNativeGeneratorResumeFunction(ctx, closeInner);
+        const closeDelegLocal = allocLocal(fctx, `__gen_close_deleg_${fctx.locals.length}`, {
+          kind: "ref",
+          typeIdx: closeInner.stateTypeIdx,
+        });
+        const closeErrLocal = allocLocal(fctx, `__gen_close_err_${fctx.locals.length}`, { kind: "externref" });
+        // The inner is f64-gated (delegation admission), so its `abrupt` field is
+        // f64: copy the outer's `.return(v)` value when the outer's carrier is
+        // also f64; a boxed-any outer's externref abrupt has no unbox seam here —
+        // deliver undefined (the value is unobservable: the inner result is
+        // discarded and the outer completes with its OWN abrupt field).
+        const closeAbruptPayload: Instr[] =
+          genCarrierFieldType(info.elemValType).kind === "f64"
+            ? [
+                { op: "local.get", index: selfLocal },
+                { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
+              ]
+            : [{ op: "f64.const", value: NaN }];
+        const closeCatch: Instr[] = [
+          { op: "local.set", index: closeErrLocal },
+          { op: "local.get", index: selfLocal },
+          { op: "local.get", index: closeErrLocal },
+          { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
+          ...setModeInstrs(info, selfLocal, MODE_THROW),
+        ];
+        abruptBody.push(
+          { op: "local.get", index: selfLocal },
+          { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+          { op: "ref.is_null" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: selfLocal },
+              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+              { op: "ref.as_non_null" },
+              { op: "local.set", index: closeDelegLocal },
+              // inner.mode = outer.mode; inner.abrupt = payload; inner.error = outer.error
+              { op: "local.get", index: closeDelegLocal },
+              { op: "local.get", index: selfLocal },
+              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
+              { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: closeInner.modeFieldIdx },
+              { op: "local.get", index: closeDelegLocal },
+              ...closeAbruptPayload,
+              { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: closeInner.abruptFieldIdx },
+              { op: "local.get", index: closeDelegLocal },
+              { op: "local.get", index: selfLocal },
+              { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD },
+              { op: "struct.set", typeIdx: closeInner.stateTypeIdx, fieldIdx: ERROR_FIELD },
+              // Drive the inner ONCE (result discarded); catch its mode-2
+              // re-throw / a finally-thrown replacement error. Foreign JS
+              // exceptions (host mode) recover via __get_caught_exception when
+              // the resume emitter acquired it (#3050 wrap parity).
+              {
+                op: "try",
+                blockType: { kind: "empty" },
+                body: [
+                  { op: "local.get", index: closeDelegLocal },
+                  { op: "call", funcIdx: closeResumeIdx },
+                  { op: "drop" },
+                ],
+                catches: [{ tagIdx: ensureExnTag(ctx), body: closeCatch }],
+                catchAll:
+                  getCaughtExnIdx !== undefined ? [{ op: "call", funcIdx: getCaughtExnIdx }, ...closeCatch] : undefined,
+              },
+              // Close complete — clear the slot.
+              { op: "local.get", index: selfLocal },
+              { op: "ref.null", typeIdx: closeInner.stateTypeIdx },
+              { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: closeSlot.fieldIdx },
+            ],
+            else: [],
+          },
+        );
+      }
+    }
     for (const finalizer of state.abruptResume.finalizers) {
       for (const stmt of finalizer) compileStatement(ctx, fctx, stmt);
     }

--- a/tests/issue-2864-standalone-generator-carrier.test.ts
+++ b/tests/issue-2864-standalone-generator-carrier.test.ts
@@ -348,3 +348,168 @@ export function test(): number { let n = 0; for (const x of g()) n++; return n; 
     expect(r.errors?.[0]?.message ?? "").toContain("#680");
   });
 });
+
+// #2864 D2 — delegation abrupt forwarding (iterator close through `yield*`,
+// §27.5.3.7 steps 7.b/7.c). A `.return(v)` / `.throw(e)` on the OUTER while
+// suspended mid-delegation now (a) drives the INNER's resume once with the same
+// abrupt mode + payloads — so the inner's `finally` blocks run — then (b)
+// continues the outer's own abrupt path (its finalizers, then complete/throw).
+// Previously the outer completed WITHOUT closing the inner (inner finalizers
+// silently skipped). The slice also dedicates a state to every self-suspending
+// yield-star terminator, fixing three protocol bugs at once: a first-statement
+// `yield*` suspension was misclassified as NOT-STARTED by the dispatch (state
+// 0), the state's prelude statements re-ran on every mid-delegation `.next()`,
+// and a preceding `const x = yield …` resume binding was clobbered by later
+// `.next(v)` values during delegation.
+describe("#2864 D2 delegation abrupt forwarding (standalone)", () => {
+  it("M3 probe: .return(v) mid-delegation runs the inner finally, completes with v", async () => {
+    expect(
+      await runStandalone(`let log = 0;
+function* inner() { try { yield 1; yield 2; } finally { log = 100; } }
+function* outer() { yield* inner(); }
+export function test(): number {
+  const it = outer();
+  it.next();                       // 1 — suspended mid-delegation
+  const r = it.return(7 as any);
+  return log * 1000 + (r.value as number) * 10 + (r.done ? 1 : 0);
+}`),
+    ).toBe(100071); // inner finally ran (100), value 7, done
+  });
+
+  it(".throw(e) mid-delegation runs the inner finally then propagates to the caller", async () => {
+    expect(
+      await runStandalone(`let log = 0;
+function* inner() { try { yield 1; yield 2; } finally { log = 100; } }
+function* outer() { yield* inner(); }
+export function test(): number {
+  const it = outer();
+  it.next();
+  let caught = 0;
+  try { it.throw(new Error("boom")); } catch (e) { caught = 1; }
+  return log * 10 + caught;
+}`),
+    ).toBe(1001);
+  });
+
+  it("outer finally around the yield* also runs — inner first, outer second", async () => {
+    expect(
+      await runStandalone(`let ord = 0;
+let innerAt = 0;
+let outerAt = 0;
+function* inner() { try { yield 1; } finally { ord = ord + 1; innerAt = ord; } }
+function* outer() { try { yield* inner(); } finally { ord = ord + 1; outerAt = ord; } }
+export function test(): number {
+  const it = outer();
+  it.next();
+  it.return(5 as any);
+  return innerAt * 10 + outerAt;
+}`),
+    ).toBe(12);
+  });
+
+  it(".return(v) at a plain-yield suspension BEFORE delegation starts skips the inner", async () => {
+    expect(
+      await runStandalone(`let log = 0;
+function* inner() { try { yield 1; } finally { log = 100; } }
+function* outer() { yield 0; yield* inner(); }
+export function test(): number {
+  const it = outer();
+  it.next(); // 0 — inner NOT constructed yet
+  const r = it.return(7 as any);
+  return log * 1000 + (r.value as number) * 10 + (r.done ? 1 : 0);
+}`),
+    ).toBe(71); // inner never ran → its finally must not run
+  });
+
+  it("an inner finally that throws during close converts .return into a throw completion", async () => {
+    expect(
+      await runStandalone(`let log = 0;
+function* inner() { try { yield 1; } finally { log = 100; throw new Error("replace"); } }
+function* outer() { yield* inner(); }
+export function test(): number {
+  const it = outer();
+  it.next();
+  let caught = 0;
+  try { it.return(7 as any); } catch (e) { caught = 1; }
+  return log * 10 + caught;
+}`),
+    ).toBe(1001);
+  });
+
+  it("loop-carried yield*: normal pass completes the inner, close hits only the live one", async () => {
+    expect(
+      await runStandalone(`let log = 0;
+function* inner() { try { yield 1; yield 2; } finally { log = log + 100; } }
+function* outer() { for (let i = 0; i < 2; i = i + 1) { yield* inner(); } }
+export function test(): number {
+  const it = outer();
+  it.next(); // 1 (pass 0)
+  it.next(); // 2
+  it.next(); // 1 (pass 1) — first inner completed normally (finally ran)
+  const r = it.return(7 as any);   // closes the second inner
+  return log * 1000 + (r.value as number) * 10 + (r.done ? 1 : 0);
+}`),
+    ).toBe(200071);
+  });
+
+  it(".next() after a mid-delegation close follows the done protocol", async () => {
+    expect(
+      await runStandalone(`function* inner() { yield 1; yield 2; }
+function* outer() { yield* inner(); }
+export function test(): number {
+  const it = outer();
+  it.next();
+  it.return(7 as any);
+  const r = it.next();
+  return r.done ? 1 : 0;
+}`),
+    ).toBe(1);
+  });
+
+  it("first-statement yield* suspension is not misclassified as not-started (vec delegate)", async () => {
+    expect(
+      await runStandalone(`function* g() { yield* [1, 2, 3]; }
+export function test(): number {
+  const it = g();
+  it.next(); // 1
+  const r = it.return(7 as any);
+  return (r.value as number) * 10 + (r.done ? 1 : 0);
+}`),
+    ).toBe(71);
+  });
+
+  it("yield-star state prelude runs ONCE, not per mid-delegation .next()", async () => {
+    expect(
+      await runStandalone(`let calls = 0;
+function count(): number { calls = calls + 1; return calls; }
+function* inner2() { yield 1; yield 2; }
+function* outer2() { const a = count(); yield* inner2(); yield a; }
+export function test(): number {
+  const it = outer2();
+  it.next(); // runs count() once → a=1, delegates → 1
+  it.next(); // 2 — must NOT re-run count()
+  const r3 = it.next(); // inner done → yield a
+  return calls * 10 + (r3.value as number);
+}`),
+    ).toBe(11);
+  });
+
+  it("a resume binding preceding the yield* survives mid-delegation .next(v) values", async () => {
+    expect(
+      await runStandalone(`function* inner3() { yield 10; yield 20; }
+function* outer3(): Generator<number, void, number> {
+  const x = yield 1;
+  yield* inner3();
+  yield x;
+}
+export function test(): number {
+  const it = outer3();
+  it.next(0); // → 1
+  it.next(5); // x=5, delegation starts → 10
+  it.next(9); // mid-delegation → 20 (must not clobber x)
+  const r = it.next(7); // inner done → yield x
+  return r.value as number;
+}`),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

**#2864 D2** (banked slice, exact contract in the issue's carrier-completion design): `.return(v)` / `.throw(e)` on the OUTER native generator while suspended mid-`yield*` now closes the INNER first — driving its resume once with the same abrupt mode/payloads so its `finally` blocks run (§27.5.3.7 steps 7.b/7.c) — then continues the outer's own abrupt path. An inner `finally` that throws during close upgrades a return completion to a throw completion (wasm try/catch around the inner drive stores the surfaced error and flips the outer to the throw path, so the outer's finalizers still run first).

En route, the self-suspending yield-star terminator now gets a **dedicated state** (never state 0, empty prelude, no resume bindings, always carrying an abrupt block), fixing three latent protocol bugs measured against Node:

| shape | main | Node/this PR |
|---|---|---|
| M3 probe: `.return(7)` mid-delegation (inner try/finally) | 71 (finally skipped) | **100071** |
| `.throw(e)` mid-delegation | 1 (finally skipped) | **1001** |
| inner+outer finally ordering on close | 0 (both skipped) | **12** |
| first-statement `yield*` prelude re-runs per `.next()` | 33 | **11** |
| resume binding clobbered by mid-delegation `.next(v)` | 7 | **5** |
| loop-carried close (2nd inner live) | — | **200071** |

## Validation (measured)

- 10 new standalone D2 tests (zero-host-import asserted) — `tests/issue-2864-standalone-generator-carrier.test.ts` now 34/34.
- Generator suites: 2170/2171/2172/2173(a+b)/1665/2079/2079-ctrl/2169×3/2662/3132×3/3302/generators/generator-* — ~280 tests, all green except 2 **pre-existing main failures** (verified failing on unmodified main): `issue-2079-…` "purely-sequential generator still lowers natively" (IR compound-assign externref, unrelated) and `issue-3132-s2` mixed-module case.
- **Byte-inertness**: 8 non-delegating programs × 3 lanes (gc/standalone/wasi) sha256-identical to main; only delegating programs change, and only in standalone/wasi (gc lane byte-identical even for delegation — the native yield* path is standalone-gated). Host-lane behavior probes identical before/after.
- `loc-budget-allow` granted in the issue frontmatter for `generators-native.ts` (+117, new state-machine-emitter capability; #2662 precedent, +155 same file).

## Residuals (pre-existing, documented in the issue)

- Mid-delegation `.next(v)` does not forward v to the inner (`sent` two-way, #3032 class; host lane identical).
- Generic-iterable close protocol → #2173 slice-2b; try/CATCH across yield (D4) → #2906 3c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)