### PR TITLE
fix(#1712): restrict PR #3267's exact-struct-field read lane to defineProperty-widened structs (acorn parse regression)

### DIFF
--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -1,9 +1,12 @@
 ---
 id: 1712
 title: "acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn"
-status: ready
+status: in-progress
+assignee: ttraenkler/sendev-acorn
 created: 2026-05-29
-updated: 2026-07-02
+updated: 2026-07-23
+loc-budget-allow:
+  - src/codegen/property-access-dispatch.ts
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -544,3 +547,64 @@ Landed since the last note above:
 
 This remains an integration gate satisfied by fixing its dependency gap issues,
 not by direct dispatch.
+
+## Regression 2026-07-23 (sendev-acorn) — parse regression bisected + fixed
+
+**Measured regression** (unattributed for ~6 days; the probe/corpus are not in
+the default CI sweep, `DOGFOOD_ACORN=1`-gated): `dogfood:acorn-corpus`
+**23/23 → 13/23** equal±quirks (10 inputs `compiled-parse-threw`);
+`dogfood:acorn-probe` **13/13 → 8/13** (objects.js, spread-rest.js,
+arrow-params.js, destructuring.js, classes.js `wasm-threw`) plus the
+single-construct `"function g(a, b) { return a + b; }"` → in-Wasm=null. The
+throws are GENUINE acorn SyntaxErrors: `'return' outside of function`,
+`'new.target' can only be used in functions…`, `Unexpected token` after
+`yield`.
+
+**Culprit (git bisect, first-parent b9b89b8→9bc9454, then intra-PR):** merge
+`852c40a9f516` = **PR #3267** (`codex/test262-original-harness-parity`, merged
+2026-07-18 04:50Z); exact commit **`479f747c4292ff`** "fix(test262): preserve
+widened descriptor data reads" — added an exact-struct-field read lane to
+`finalizeStructAndDynamicMemberGet` (property-access-dispatch.ts): when
+`typeName` is unrecoverable but the receiver's checker type resolves to a
+struct typeIdx with a same-named field, read `struct.get` directly instead of
+the dynamic host-MOP path.
+
+**Mechanism (measured via compile-time lane logging + minimal repros):** the
+unrestricted guard also hijacked receivers whose RUNTIME value is a growable
+host `$Object` — the anon struct exists statically but is never instantiated.
+acorn's `types$1` token table and `prototypeAccessors` descriptor tables are
+both growable-marked (depth-2 writes `types$1.parenR.updateContext = …`,
+`prototypeAccessors.inFunction.get = …`). The load-bearing break: for a
+ref_null-typed field (`prototypeAccessors.inFunction`, an inline
+`{configurable:true}` descriptor struct), `emitExternrefToStructGet`'s
+`__extern_get` fallback ref.tests the HOST result against the struct type,
+fails, and substitutes **ref.null** (defaultValueInstrs arm,
+property-access.ts:1609). So `prototypeAccessors.<k>.get = fn` wrote onto
+null, `Object.defineProperties(Parser.prototype, prototypeAccessors)`
+installed getterless accessors, and every scope predicate (`inFunction`,
+`inGenerator`, `inAsync`, `allowNewDotTarget`) answered undefined→false —
+exactly the three SyntaxErrors. Same family as #2694's warning: a read-only
+struct-slot shortcut without matching the write lane diverges.
+
+**Hypothesis audit (bisect-first discipline):** H1 (#3506 `__extern_get`
+vec-props fallthrough, merged 07-23) — **REFUTED**: regression predates it by
+5 days. H2 (re-regression of #2848) — **REFUTED as mechanism**: #2848's fix
+family (#2838/#2325 dynamic prototype-accessor dispatch) is intact; the same
+SYMPTOMS re-appeared through a new, unrelated read-lane defect. Neither
+hypothesis named the culprit; the bisect did.
+
+**Fix (this branch):** restrict the lane to defineProperty-WIDENED structs
+(`widenedVarStructMap` + `widenedDefinePropertyKeys` — the widening pre-pass
+only widens EMPTY literals, so a widened receiver's runtime value IS the
+struct and the exact-field read is sound; acorn's non-empty tables can never
+qualify). A pure revert would re-break #3267's widened-descriptor reads
+(measured: `var obj = {}; Object.defineProperty(obj,"prop",{value:2010})` read
+→ `undefined` with the lane off). Regression guard:
+`tests/issue-1712-exactfield-lane-guard.test.ts` (4 cheap tests in the DEFAULT
+sweep — the probe/corpus guards are `DOGFOOD_ACORN=1`-gated, which is why this
+landed unnoticed). Post-fix measurements: probe **13/13** (+15/15
+single-construct, up from 14/15 pre-regression), corpus **23/23**
+equal±quirks, 0 throws, 0 real gaps.
+
+`loc-budget-allow` note: +35 lines on property-access-dispatch.ts are the
+narrowed guard + the mechanism documentation comment.

--- a/plan/issues/2694-acorn-scope-flags-loop.md
+++ b/plan/issues/2694-acorn-scope-flags-loop.md
@@ -72,3 +72,34 @@ investigation.
 - `parse("x")` / `parse("var x = 1;")` advance past the Scope.flags loop (return
   or hit the next wall, not spin).
 - Full merge_group / test262 floor (broad value-rep change via #2660).
+
+## Correctness datapoint (2026-07-23, sendev-acorn — from the #1712 regression bisect)
+
+This issue frames the Scope.flags surface as a PERF loop (read-count ~800k×).
+The 2026-07-23 acorn parse regression (bisected to PR #3267 commit
+`479f747c4292ff`, fixed under #1712) adds a **correctness** datapoint on the
+same read/write-lane-asymmetry family — and empirically validates this issue's
+own warning ("a read-only slot fix without the write/compound match caused a
+35.9M-iter loop"):
+
+- The regression was EXACTLY a read-only struct-slot shortcut: an
+  exact-struct-field `struct.get` lane added for reads whose `typeName` is
+  unrecoverable, while the receiver's writes/runtime representation stayed on
+  the dynamic host-`$Object` lane. Result was not a loop but a WRONG VALUE
+  (ref.null substituted by the `__extern_get` fallback's default arm for
+  ref_null-typed fields) → acorn's scope-accessor table
+  (`prototypeAccessors.inFunction.get = fn`) lost its getters → `inFunction`
+  / `inGenerator` / `allowNewDotTarget` answered undefined→false → genuine
+  SyntaxErrors ("'return' outside of function", new.target, yield).
+- NOTE the mechanism was NOT a `Scope.flags` read (instrumented: the hijacked
+  reads were `types$1.<token>` and `prototypeAccessors.<accessor>`); the
+  scope-state symptom arose one level up, via the accessor-install path. The
+  `Scope.flags` __extern_get loop this issue tracks is still the separate,
+  #2660-blocked receiver-typing gap.
+- Design constraint reaffirmed for the eventual #2660 fix: any struct-slot
+  routing for these receivers must cover read + write + compound TOGETHER, and
+  must be gated on the receiver's RUNTIME representation actually being the
+  struct (see the #1712 fix's `widenedVarStructMap`/`widenedDefinePropertyKeys`
+  gate for the pattern) — a statically-resolvable struct typeIdx alone is NOT
+  evidence the runtime value is that struct (growable/`$Object`-poisoned vars
+  resolve statically but hold host objects).

--- a/plan/issues/2847-acorn-cosmetic-marshalling-quirks.md
+++ b/plan/issues/2847-acorn-cosmetic-marshalling-quirks.md
@@ -1,29 +1,32 @@
 ---
 id: 2847
-title: "compiled-acorn cosmetic marshalling quirks — spurious `sourceFile: null` on every node + booleans as i32 0/1"
+title: "compiled-acorn cosmetic marshalling quirk — spurious `sourceFile: null` on every node"
 status: ready
 sprint: current
 priority: low
 horizon: m
 feasibility: medium
-updated: 2026-07-03
+updated: 2026-07-23
 created: 2026-06-29
 task_type: bugfix
 area: runtime
 language_feature: host-marshalling
 goal: acorn-dogfood
-related: [1712]
+related: [1712, 3557]
 umbrella: 1712
 ---
 
-# #2847 — compiled-acorn cosmetic marshalling quirks (sourceFile + i32 booleans)
+# #2847 — compiled-acorn cosmetic marshalling quirk (spurious `sourceFile`)
 
 Surfaced by the wider acorn differential corpus
-(`tests/dogfood/acorn-corpus.mjs`, #1712 umbrella). These are **cosmetic** —
-they do NOT corrupt tree structure or drop identifiers — but they make every
-compiled-acorn AST differ from node-acorn on nearly every node, which is why the
-corpus harness classifies them as a dedicated `QUIRK` bucket so the REAL gaps
-stay legible. Tracking them in one low-priority issue.
+(`tests/dogfood/acorn-corpus.mjs`, #1712 umbrella).
+
+> **SPLIT 2026-07-23 (sendev-acorn):** this issue originally lumped TWO quirks
+> as "cosmetic". Quirk B (booleans marshalled as i32 0/1) is **NOT cosmetic** —
+> `node.computed === false` fails, `typeof node.computed` is `"number"`, and
+> JSON serialization differs; it is a systemic wrong-TYPE-crossing-the-boundary
+> gap. It now lives in **#3557** (value-rep track, related #2773). This issue
+> keeps only the genuinely-cosmetic Quirk A below.
 
 ## Quirk A — spurious `sourceFile` extra field
 
@@ -35,113 +38,54 @@ extra-field   $.body[*]...sourceFile   expected (absent)   actual null
 ```
 
 Seen on essentially every node of every input (45–85 occurrences per corpus
-file). Fix: omit `sourceFile` from the marshalled node when unset, matching
-node-acorn (it only appears when `options.sourceFile` is set).
+file; 2298 total across the corpus, measured 2026-07-03). Fix: omit
+`sourceFile` from the marshalled node when unset, matching node-acorn (it only
+appears when `options.sourceFile` is set).
 
-## Quirk B — booleans marshalled as i32 0/1
+## Why low priority (holds for Quirk A only)
 
-Boolean AST fields (`computed`, `optional`, `static`, `generator`, `async`,
-`prefix`, `delegate`, `tail`, `method`, `shorthand`, …) marshal across the host
-boundary as the **number** `0`/`1` instead of a JS `false`/`true`.
-
-```
-primitive-mismatch  $...computed   expected false   actual 0
-primitive-mismatch  $...optional   expected false   actual 0
-```
-
-Seen 2–31 times per corpus file. Fix: coerce i32-backed boolean node fields to
-real JS booleans during host marshalling (a field-name allowlist, or a typed
-`bool` marker in the export signatures).
-
-## Why low priority
-
-Neither quirk changes the SHAPE of the tree or the identity/value of any
-identifier or literal — a consumer that reads `node.computed` still gets a
-truthy/falsy value, and `sourceFile: null` is ignorable. They are tracked
-because they block a _byte-exact_ differential pass and clutter the diff, not
-because they break parsing.
+The quirk does not change the SHAPE of the tree or the identity/value of any
+identifier or literal — `sourceFile: null` is ignorable by consumers. It is
+tracked because it blocks a _byte-exact_ differential pass and clutters the
+diff, not because it breaks parsing. (This rationale previously also claimed
+"a consumer that reads `node.computed` still gets a truthy/falsy value" for
+the boolean quirk — that under-sold it; see #3557 for why type-fidelity is a
+real decision, not an allowance.)
 
 ## Acceptance
 
-- Marshalled boolean node fields are JS booleans; `sourceFile` is absent when
-  unset.
-- `tests/dogfood/acorn-corpus.mjs` reports `quirkCounts` ≈ 0 across the corpus.
+- `sourceFile` is absent from marshalled nodes when unset.
+- `tests/dogfood/acorn-corpus.mjs` reports `quirk-sourceFile` ≈ 0 across the
+  corpus.
 - No test262 regression.
 
-## Investigation (2026-07-03, dev-team-a) — sizing correction + root causes
+## Investigation (2026-07-03, dev-team-a) — root cause
 
-Measured against current `upstream/main` (e29c8c5b2) with the corpus harness
+Measured against `upstream/main` (e29c8c5b2) with the corpus harness
 (`ACORN_CORPUS_NO_ACORN_SELF=1 npx tsx tests/dogfood/acorn-corpus.mjs --json`).
-**Correction: this is NOT a host-marshalling fix, and NOT horizon-`s`.** The
-original "fix in host marshalling — a field-name allowlist or typed `bool`
-marker in the export signatures" framing is wrong for both quirks; the marshaller
-already does the right thing when it has the information, and it fundamentally
-cannot for the rest.
-
-### Current state (verified)
-
-| quirk               | count | notes                                    |
-| ------------------- | ----- | ---------------------------------------- |
-| `quirk-sourceFile`  | 2298  | dominant                                 |
-| `quirk-bool-as-i32` | 467   | fields: `async await computed delegate generator optional` |
-
-Corpus is `equal-modulo-quirks` on 21/22 inputs, **0 real divergences** — so any
-fix must drive quirks down without introducing real divergences.
-
-### Quirk B (bool-as-i32) is a CODEGEN brand-preservation gap, NOT a marshalling gap
-
-The `__box_boolean` path (#1788) already boxes a **boolean-branded** i32 struct
-field (`{kind:"i32", boolean:true}`) as a JS boolean on the host read — verified
-directly: both a TS-typed `boolean` field AND a simple untyped-JS
-(`skipSemanticDiagnostics`) `this.computed = false` / `this.optional = false`
-constructor marshal back as real JS booleans (`typeof === "boolean"`). So the
-runtime marshalling layer is NOT where this bites.
-
-The 6 acorn fields degrade because their boolean **brand is lost during
-struct-field-type computation** across acorn's many untyped assignment sites —
-these fields are assigned via boolean-returning method calls
-(`node.generator = this.eat(types.star)`, `node.delegate = this.eat(...)`,
-`node.await = …`) whose return type is inferred as plain `f64`/`i32`-number, not
-boolean-branded, in the untyped `.mjs`. When a field is assigned by a mix of
-boolean literals and unbranded method-call results, the merged field type drops
-`boolean:true`, and the getter emits raw-i32/`__box_number` instead of
-`__box_boolean` (getter emission at `src/codegen/index.ts:_emitStructFieldGettersInner`
-— the `hasBool` fork keys off `(fieldType as {boolean?:true}).boolean`).
-
-- **Real fix location**: `src/codegen` struct-field-type inference /
-  brand-preservation (and/or branding boolean-returning method returns), NOT
-  `src/runtime.ts`. A field-name allowlist or `sourceFile`/`bool` special-case
-  in the generic marshaller would regress real user programs (a legit struct
-  field named `computed`/`sourceFile`, or a genuine 0/1-valued field) and
-  violates the no-bespoke-builtins principle.
-- **Blast radius**: branding changes flow into `typeof`/boxing across the whole
-  test262 surface (exactly what #1788 had to be careful about) — must validate
-  IN BATCH. Not locally verifiable by a dev agent.
-
-### Quirk A (sourceFile) has no clean runtime signal — needs per-instance presence tracking
 
 acorn's `Node` constructor assigns `sourceFile` (and `loc`, `range`) **only
 conditionally** (`if (parser.options.directSourceFile) this.sourceFile = …`,
-acorn.mjs Node ctor). With the option off, node-acorn never creates the property;
-compiled WasmGC has a **fixed struct shape**, so the `sourceFile` slot always
-exists and defaults to `null`. (`loc`/`range` are the same class but the differ's
-`ignorePositions` hides them.)
+acorn.mjs Node ctor). With the option off, node-acorn never creates the
+property; compiled WasmGC has a **fixed struct shape**, so the `sourceFile`
+slot always exists and defaults to `null`. (`loc`/`range` are the same class
+but the differ's `ignorePositions` hides them.)
 
-At marshalling time a never-assigned ref field (`null`) is **indistinguishable**
-from a legitimately assigned-`null` field (`FunctionExpression.id = null`,
-`SwitchCase.test = null`) — both are `null` struct slots, and node-acorn *keeps*
-the latter (verified: 0 real divergences, so those null fields agree). So there
-is **no runtime signal** that lets the generic marshaller
-(`_structToPlainObject` in `src/runtime.ts`) omit `sourceFile` while keeping
-`id`/`test`. A correct general fix needs a **per-instance field-presence bitmap**
-for conditionally-assigned fields (a real feature, not a one-liner) — or the
-quirk is accepted as cosmetic per this issue's own "why low priority" section.
+At marshalling time a never-assigned ref field (`null`) is
+**indistinguishable** from a legitimately assigned-`null` field
+(`FunctionExpression.id = null`, `SwitchCase.test = null`) — both are `null`
+struct slots, and node-acorn *keeps* the latter (verified: 0 real divergences,
+so those null fields agree). So there is **no runtime signal** that lets the
+generic marshaller (`_structToPlainObject` in `src/runtime.ts`) omit
+`sourceFile` while keeping `id`/`test`. A correct general fix needs a
+**per-instance field-presence bitmap** for conditionally-assigned fields (a
+real feature, not a one-liner) — or the quirk is accepted as cosmetic per the
+"why low priority" section. A field-name special-case in the generic
+marshaller would regress real user programs (a legit struct field named
+`sourceFile`) and violates the no-bespoke-builtins principle.
 
 ### Sizing verdict
 
-Re-size from `horizon: s` → at least `m`, split into two independent codegen
-tracks: (B) struct-field boolean brand-preservation (validate IN BATCH), and
-(A) per-instance presence tracking for conditionally-assigned fields (larger;
-arguably not worth it for a cosmetic dogfood quirk). Neither is a bounded,
-locally-test262-validatable slice; the marshalling-layer framing was the
-mis-scope. Banked so the next attempt starts from the mechanism.
+`horizon: m` — per-instance presence tracking for conditionally-assigned
+fields (arguably not worth it for a cosmetic dogfood quirk). Not a bounded,
+locally-test262-validatable slice.

--- a/plan/issues/3557-boolean-i32-marshalling-type-gap.md
+++ b/plan/issues/3557-boolean-i32-marshalling-type-gap.md
@@ -1,0 +1,101 @@
+---
+id: 3557
+title: "booleans cross the host boundary as i32 0/1 — systemic wrong-TYPE marshalling (boolean brand lost in struct-field type inference)"
+status: ready
+sprint: Backlog
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: high
+model: opus
+created: 2026-07-23
+updated: 2026-07-23
+task_type: bugfix
+area: runtime, codegen
+language_feature: host-marshalling, value-rep
+goal: acorn-dogfood
+related: [2773, 1712, 2847, 1788]
+umbrella: 1712
+origin: "Split out of #2847 (2026-07-23, sendev-acorn) — mis-filed there as a cosmetic quirk. The tech lead's 2026-07-23 review flagged it as a real fidelity gap; this issue reframes it as the wrong-TYPE-crossing-the-boundary defect it is."
+---
+
+# #3557 — booleans marshal as the number 0/1: a real type-fidelity gap, not a cosmetic quirk
+
+Split from #2847 (which now keeps only the genuinely-cosmetic `sourceFile`
+quirk). Surfaced by the acorn differential corpus
+(`tests/dogfood/acorn-corpus.mjs`, #1712 umbrella), but the defect is
+**systemic**, not acorn-specific.
+
+## Problem — this is wrong TYPE, not wrong truthiness
+
+Boolean-valued struct fields (`computed`, `optional`, `static`, `generator`,
+`async`, `prefix`, `delegate`, `tail`, `method`, `shorthand`, …) marshal across
+the host boundary as the **number** `0`/`1` instead of JS `false`/`true`:
+
+```
+primitive-mismatch  $...computed   expected false   actual 0
+```
+
+Why "cosmetic" was the wrong frame (the original #2847 rationale said "a
+consumer that reads `node.computed` still gets a truthy/falsy value"):
+
+- `node.computed === false` → **false** (it's `0`); strict-equality consumers
+  break silently.
+- `typeof node.computed` → `"number"`, not `"boolean"`.
+- `JSON.stringify` emits `0`/`1`, so serialized output differs from every
+  spec-conformant producer.
+- Any downstream tool with a type check (validators, TS consumers of the AST,
+  structural differs) sees a different VALUE TYPE, which is exactly the class
+  of divergence the dogfood program exists to catch.
+
+Measured 467 occurrences across the 2026-07-03 corpus run (fields: `async`
+`await` `computed` `delegate` `generator` `optional`).
+
+## Root cause (verified 2026-07-03, dev-team-a — carried over from #2847)
+
+**This is a CODEGEN brand-preservation gap, NOT a marshalling gap.** The
+`__box_boolean` path (#1788) already boxes a boolean-branded i32 struct field
+(`{kind:"i32", boolean:true}`) as a JS boolean on host read — verified for
+both TS-typed `boolean` fields and untyped-JS `this.computed = false`
+constructor assignments. The runtime marshaller does the right thing when the
+brand survives.
+
+The brand is **lost during struct-field-type computation** when a field is
+assigned via boolean-returning method calls in untyped JS
+(`node.generator = this.eat(types.star)`) whose inferred return type is plain
+number-i32, not boolean-branded. When a field's assignment mix includes
+unbranded method-call results, the merged field type drops `boolean: true`,
+and getter emission (`src/codegen/index.ts` `_emitStructFieldGettersInner`,
+the `hasBool` fork) emits raw-i32/`__box_number` instead of `__box_boolean`.
+
+- **Real fix location**: struct-field-type inference / brand-preservation in
+  `src/codegen` (brand boolean-returning method returns, or preserve the brand
+  through the field-type merge), NOT `src/runtime.ts`. A field-name allowlist
+  in the generic marshaller would regress real user programs and violates the
+  no-bespoke-builtins principle.
+- **Blast radius**: branding changes flow into `typeof`/boxing across the
+  whole test262 surface (exactly what #1788 had to guard) — must validate IN
+  BATCH via the full merge_group, not locally. This is value-rep territory —
+  hence `related: [2773]` (value-rep epic); coordinate with any in-flight
+  brand/rep work before implementing.
+
+## Fix-vs-accept is a REAL decision — record it, don't default it
+
+This issue must end in one of two explicit outcomes, decided with the value-rep
+epic (#2773) owner / tech lead — NOT silently parked as an allowance:
+
+1. **Fix**: preserve the boolean brand through field-type merging (per the
+   root cause above), validated in batch. This is the type-fidelity-correct
+   outcome and the default recommendation.
+2. **Accept**: a recorded decision that i32-boolean marshalling is a permitted
+   representation divergence, with the differ's quirk bucket as the permanent
+   normalization layer. This weakens every strict-equality/typeof consumer of
+   compiled output and should require explicit sign-off.
+
+## Acceptance
+
+- Marshalled boolean struct fields are JS booleans (`typeof === "boolean"`,
+  `=== false` works), OR a recorded accept-decision with sign-off in this file.
+- `tests/dogfood/acorn-corpus.mjs` reports `quirk-bool-as-i32` ≈ 0 (fix path).
+- Full merge_group validation (batch blast-radius check) — no test262
+  regression, no standalone-floor regression.

--- a/src/codegen/property-access-dispatch.ts
+++ b/src/codegen/property-access-dispatch.ts
@@ -3791,12 +3791,47 @@ export function finalizeStructAndDynamicMemberGet(
     // field before the last-resort host-MOP path. Runtime-sidecar properties
     // and accessors were handled above, so this is the ordinary static field
     // lane that a successfully resolved typeName would have taken.
-    const exactStructField =
-      structObjTypeIdx === undefined
-        ? undefined
-        : findAlternateStructsForField(ctx, propName, -1).find(
-            (candidate) => candidate.structTypeIdx === structObjTypeIdx,
-          );
+    //
+    // (#1712 regression fix — PR #3267's 479f747c broke compiled-acorn) This
+    // lane MUST be restricted to receivers whose runtime representation is
+    // KNOWN to be the exact widened struct: `widenedVarStructMap` structs whose
+    // `propName` was recorded by a data-descriptor `Object.defineProperty`
+    // widening (`widenedDefinePropertyKeys`). The original unrestricted guard
+    // ("any struct typeIdx that has a same-named field") also hijacked reads
+    // whose receiver merely RESOLVES statically to an anon struct while its
+    // runtime value is a growable host `$Object` (acorn's `types$1` token table
+    // and `prototypeAccessors` descriptor tables — both take depth-2 writes, so
+    // `collectGrowableObjectLiterals` routes them to the externref builder and
+    // the anon struct is never instantiated). For a ref_null-typed field the
+    // `emitExternrefToStructGet` __extern_get fallback then ref.tests the HOST
+    // result against the struct type, fails, and substitutes ref.null — so
+    // `prototypeAccessors.inFunction.get = fn` wrote onto null, the scope
+    // accessors installed by `Object.defineProperties(Parser.prototype, …)`
+    // lost their getters, and every scope predicate (inFunction / inGenerator /
+    // allowNewDotTarget) answered undefined→false: "'return' outside of
+    // function", new.target/yield parse throws (probe 13/13 → 8/13). The
+    // widening pre-pass only widens EMPTY literals, so a widened receiver's
+    // runtime value IS the struct and the exact-field read stays sound there —
+    // while non-widened receivers keep the pre-#3267 dynamic host-MOP lane that
+    // matches where their writes land.
+    let exactStructField: ReturnType<typeof findAlternateStructsForField>[number] | undefined;
+    if (!typeName && structObjTypeIdx !== undefined) {
+      const structName = ctx.typeIdxToStructName.get(structObjTypeIdx);
+      let widenedDefinePropStruct = false;
+      if (structName) {
+        for (const [varKey, widenedName] of ctx.widenedVarStructMap) {
+          if (widenedName === structName && ctx.widenedDefinePropertyKeys.has(`${varKey}:${propName}`)) {
+            widenedDefinePropStruct = true;
+            break;
+          }
+        }
+      }
+      if (widenedDefinePropStruct) {
+        exactStructField = findAlternateStructsForField(ctx, propName, -1).find(
+          (candidate) => candidate.structTypeIdx === structObjTypeIdx,
+        );
+      }
+    }
     if (!typeName && exactStructField) {
       const structExprType = compileExpression(ctx, fctx, expr.expression);
       if (structExprType?.kind === "ref_null") {

--- a/tests/issue-1712-exactfield-lane-guard.test.ts
+++ b/tests/issue-1712-exactfield-lane-guard.test.ts
@@ -1,0 +1,108 @@
+// (#1712) Regression guard for PR #3267's 479f747c exact-struct-field read lane
+// (property-access-dispatch.ts, `finalizeStructAndDynamicMemberGet`).
+//
+// The lane reads `recv.prop` directly from a compiled struct field when the
+// receiver's typeName is unrecoverable but its checker type resolves to an
+// exact struct typeIdx with a same-named field. Unrestricted, it also hijacked
+// receivers whose RUNTIME representation is a growable host `$Object` (the anon
+// struct exists but is never instantiated — acorn's `types$1` token table and
+// `prototypeAccessors` descriptor tables, both marked growable by their depth-2
+// writes). For a ref_null-typed field the `emitExternrefToStructGet`
+// __extern_get fallback ref.tests the HOST result against the struct type,
+// fails, and substitutes ref.null — so `prototypeAccessors.<k>.get = fn` wrote
+// onto null, `Object.defineProperties(Parser.prototype, …)` installed
+// getterless accessors, and every acorn scope predicate (inFunction /
+// inGenerator / allowNewDotTarget) answered undefined→false: genuine
+// "'return' outside of function" / new.target / yield SyntaxErrors
+// (acorn-probe 13/13 → 8/13, acorn-corpus 23/23 → 13/23).
+//
+// The fix restricts the lane to defineProperty-WIDENED structs
+// (`widenedVarStructMap` + `widenedDefinePropertyKeys`), whose runtime value IS
+// the struct. These tests pin both sides:
+//   - the descriptor-table shape must read back the live host value (42), and
+//   - the widened defineProperty data read the lane was built for (#3367) must
+//     keep returning its struct-stored value (2010).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// acorn's prototypeAccessors shape: descriptor table with depth-2 writes
+// (growable → runtime host $Object), accessors installed from it. On the
+// regressed compiler the base read `protoAcc.flagB` returned ref.null, the
+// .get write was dropped, and probeAccessor() returned undefined/null.
+const PROTO_ACCESSOR_TABLE_SRC = `
+var protoAcc = { flagA: { configurable: true }, flagB: { configurable: true } };
+protoAcc.flagA.get = function () { return 41; };
+protoAcc.flagB.get = function () { return 42; };
+var P = function P() {};
+Object.defineProperties(P.prototype, protoAcc);
+export function probeAccessor() {
+  var p = new P();
+  return p.flagB;
+}
+`;
+
+// acorn's types$1 shape: token table holding constructed instances, marked
+// growable by depth-2 updateContext writes; token identity must hold across
+// the tokenizer-assignment lane and the direct table-read lane.
+const TOKEN_TABLE_SRC = `
+var TokenType = function TokenType(label) {
+  this.label = label;
+};
+var types = { a: new TokenType("a"), b: new TokenType("b") };
+types.a.updateContext = types.b.updateContext = function () { return 0; };
+var Parser = function Parser() {
+  this.type = types.a;
+};
+Parser.prototype.check = function () {
+  return this.type === types.a ? 1 : 0;
+};
+export function probeIdentity() {
+  var p = new Parser();
+  return p.check();
+}
+export function probeLabel() {
+  var p = new Parser();
+  return types.b.label;
+}
+`;
+
+// The positive case the lane was added for (#3367): a widened
+// Object.defineProperty data value on a module-global \`var obj = {}\` lives in
+// the widened struct field; the sidecar's value bit is deliberately absent, so
+// ONLY the exact-field lane serves this read.
+const WIDENED_DEFINE_PROPERTY_SRC = `
+var obj = {};
+Object.defineProperty(obj, "prop", { value: 2010, writable: false });
+export function probeWidened() {
+  return obj.prop;
+}
+`;
+
+async function compileAndRun(source: string, fn: string): Promise<unknown> {
+  const result = await compile(source, { skipSemanticDiagnostics: true });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]();
+}
+
+describe("#1712 exact-struct-field read lane guard (PR #3267 479f747c regression)", () => {
+  it("descriptor-table base read returns the live host descriptor, not ref.null", async () => {
+    expect(await compileAndRun(PROTO_ACCESSOR_TABLE_SRC, "probeAccessor")).toBe(42);
+  });
+
+  it("token-table identity holds across assignment and direct-read lanes", async () => {
+    expect(await compileAndRun(TOKEN_TABLE_SRC, "probeIdentity")).toBe(1);
+  });
+
+  it("token-table instance field reads stay live", async () => {
+    expect(await compileAndRun(TOKEN_TABLE_SRC, "probeLabel")).toBe("b");
+  });
+
+  it("widened defineProperty data read keeps its struct-stored value (#3367)", async () => {
+    expect(await compileAndRun(WIDENED_DEFINE_PROPERTY_SRC, "probeWidened")).toBe(2010);
+  });
+});


### PR DESCRIPTION
## Root cause (bisected, not hypothesized)

The 2026-07-23 acorn dogfood parse regression — `dogfood:acorn-corpus` **23/23 → 13/23** (10 inputs throw genuine acorn SyntaxErrors: `'return' outside of function`, `'new.target' can only be used in functions…`, `Unexpected token` after `yield`), `dogfood:acorn-probe` **13/13 → 8/13** — was bisected (`git bisect --first-parent` b9b89b8→9bc9454, then intra-PR) to:

- **Merge:** `852c40a9f516` = PR #3267 (`codex/test262-original-harness-parity`, merged 2026-07-18)
- **Exact commit:** `479f747c4292ff` "fix(test262): preserve widened descriptor data reads"

Both prior hypotheses REFUTED by the bisect: H1 (#3506 `__extern_get` vec-props fallthrough, merged 07-23) postdates the regression by 5 days; H2 (#2848 re-regression) — that fix family is intact, the same symptoms re-appeared via a new lane.

## Mechanism (measured via lane instrumentation + minimal repros)

479f747c added an exact-struct-field `struct.get` read lane to `finalizeStructAndDynamicMemberGet` for receivers whose `typeName` is unrecoverable but whose checker type resolves to a struct typeIdx with a same-named field. Unrestricted, it hijacked receivers whose **runtime** value is a growable host `$Object` (the anon struct is never instantiated): acorn's `types$1` token table and `prototypeAccessors` descriptor tables (both growable-marked by depth-2 writes). For a ref_null-typed field, `emitExternrefToStructGet`'s `__extern_get` fallback ref.tests the host result against the struct type, fails, and substitutes **ref.null** — so `prototypeAccessors.inFunction.get = fn` wrote onto null, `Object.defineProperties(Parser.prototype, …)` installed getterless accessors, and every scope predicate (`inFunction`/`inGenerator`/`allowNewDotTarget`) answered undefined→false. That is exactly the three SyntaxErrors.

## Fix

Gate the lane on `widenedVarStructMap` + `widenedDefinePropertyKeys`: the widening pre-pass only widens **empty** literals, so a widened receiver's runtime value IS the struct (exact-field read sound); acorn's non-empty tables can never qualify and return to the pre-#3267 dynamic host-MOP lane. A pure revert is NOT safe — the #3367 widened-descriptor read the lane was built for measurably regresses to `undefined` with the lane off (pinned in the new test).

## Measurements after fix

| gate | before | after |
|---|---|---|
| `dogfood:acorn-probe` | 8/13 (5 wasm-threw) | **13/13**, single-construct **15/15** (pre-regression was 14/15) |
| `dogfood:acorn-corpus` | 13/23 (10 threw) | **23/23** equal±quirks, 0 throws, 0 real gaps |
| widened defineProperty read (#3367 case) | 2010 | **2010** (kept) |

New **default-sweep** regression guard: `tests/issue-1712-exactfield-lane-guard.test.ts` (4 tests, ~4s — the probe/corpus guards are `DOGFOOD_ACORN=1`-gated, which is why this regression landed unnoticed).

Local checks: typecheck, lint, format, godfiles OK; loc-budget granted via `loc-budget-allow` in #1712 (+35 = guard + mechanism docs). Pre-existing failure in `issue-1712-capture-closure-dispatch.test.ts` (`__call_fn_1` arity-0) verified identical on unmodified origin/main.

## Issue bookkeeping in this PR

- **#1712**: bisect findings, culprit, mechanism, H1/H2 refutations; `assignee`/`in-progress`.
- **#2694**: correctness datapoint — this regression is that issue's own warned failure mode (read-only struct-slot shortcut without write-lane match); design constraint recorded for the #2660 fix.
- **#2847**: split — retitled to the genuinely-cosmetic `sourceFile` quirk only.
- **#3557** (new, allocated): boolean-as-i32 marshalling reframed as a real wrong-TYPE-crossing-the-boundary gap (`=== false` fails, `typeof` is `"number"`, JSON differs); value-rep track, related #2773; fix-vs-accept is a recorded decision, not an allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)