### PR TITLE
feat(#2906 3c-i): try/catch-around-await drives — catch regions as states + routed dispatcher

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -1,7 +1,8 @@
 ---
 id: 2906
 title: "Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-laneB
 created: 2026-07-01
 priority: high
 feasibility: hard

--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -15,6 +15,9 @@ horizon: xl
 related: [2895, 2867, 2864, 2865, 2367]
 umbrella: 2860
 architect_spec: authored
+loc-budget-allow:
+  - src/codegen/async-cps.ts
+  - src/codegen/async-frame.ts
 ---
 
 # Generalize the async drive layer to a multi-state CFG-aware CPS resume machine
@@ -1034,3 +1037,76 @@ This is the native-`$Promise` identity-preservation family (cf. #3134), below th
 async-frame lane — the yield-await classifier cannot reach it. `any`-typed runtime
 thenables need a runtime thenable probe in the settle arm (the #3120 follow-up).
 Issue stays `in-progress` for the remaining 3d-iii edges + the slice-1d carrier widen.
+
+## Slice 3c-i — try/CATCH-around-await: catch regions as states + the routed dispatcher (LANDED, 2026-07-23, fable dev-laneB)
+
+**Scope shipped (native drive lane — wasi + standalone-carrier; host lane
+byte-identical):** `try { …await… } catch (e) { … }` now DRIVES. Verify-first:
+the shape previously fell to the AG0 sync unwrap, which read the rejected
+`$Promise`'s field 1 — the REASON — as the awaited VALUE (measured `cap=NaN`,
+catch never entered, on every rejection probe); now all 12 wasi probes + 2
+standalone probes match spec (catch entered with the reason bound: 42/45/50/
+142/…; fulfil paths keep the try continuation).
+
+### What landed (the 3c design's step 1 + the catchState half of step 2)
+
+- **Routed dispatcher** — `block { loop { try { chain } catch $exn { route } } }`,
+  exactly the design's restructure, but **conditional**: only a plan whose
+  handlers carry a `catchState` gets it. Every pre-3c plan (linear, Gap-3
+  try/finally, 3a/3b loops, async gens) keeps the old
+  `try { block { loop { chain } } } catch` wrap **byte-identically** (proven:
+  7-program × 3-lane sha256 matrix unchanged; only the newly-admitted shape
+  differs, and only on wasi/standalone — gc is byte-identical even for it).
+  The depth shift is the designed single site (`loopDepth = st.id + (routed ?
+  3 : 2)` in `buildStateBody`).
+- **Route** = state transition: for the active region id (the existing
+  `__async_in_try` local — the prelude re-throw arm already arms it), bind the
+  reason to the catch param (local + spill field, so it survives catch-chain
+  suspends), **consume the throw (MODE=NEXT** — without this the stale
+  MODE_THROW would re-fire the next prelude's re-throw arm), STATE=catchState,
+  `br` the loop. No active region → the pre-3c reject tail (region finalizer
+  replay + settle-reject + the #3178 async-gen COMPLETED repoint), now shared
+  by both dispatcher shapes. One mechanism covers all three abrupt sources:
+  sync-REJECTED classify, pending reject step-adapter delivery (both →
+  prelude re-throw), and a synchronous `throw` in an in-try lead.
+- **`AsyncHandlerRegion.catchState`/`catchParamName`** (async-cps.ts) +
+  `validateAsyncCfg`: catchState in range and NO resume prelude (route enters
+  it like a goto).
+- **Producer `planTryCatchCfg`** (+ `analyzeTryCatchAsync` / `lowerChunk`):
+  bounded shape = flat body, ONE top-level try/catch (no finally, no awaited
+  try/finally elsewhere — a nested region would claim the same handler id 1),
+  pre/try/catch/post chunks each linear-canonical, awaits allowed in ALL
+  chunks (including the catch — its chain suspends/resumes normally; its
+  handler is 0, so a throw there rejects the result promise). Catch param:
+  plain identifier or absent; a destructured param bails.
+- **Spills `computeTryCatchSpills`**: the 3a widened rule (every own body
+  local; resume bindings typed via `resumeBindingValType`) + the catch param
+  (externref). Gate: `asyncFnNeedsDrive` accepts the shape when every spill is
+  spill-safe; `planAsyncCfg` gains `allowTryCatch` (set `!info.host`, like
+  `allowLoops`). NOTE: `collectVarDeclsByName` picks up the CATCH clause's own
+  variableDeclaration (it IS a `ts.VariableDeclaration`) — the spill/shadow
+  logic must exempt it (this initially self-rejected every bound catch).
+
+### Measured
+
+- 14/14 new tests (`tests/issue-2906-3c-trycatch.test.ts`): rejection→catch,
+  fulfil-continues, pre-try await + catch-on-2nd, await-inside-catch,
+  post-join on both paths, sync-throw-in-lead, throw-in-catch (rejects, no
+  loop), unbound catch, widened spills, genuinely-PENDING reject/fulfil, and
+  2 standalone-carrier duplicates.
+- Async corpus: 243 passing across 31 files; 14 failures ALL pre-existing on
+  unmodified main (issue-2906-gap3-tryfinally ×3, issue-2980 ×2 — a
+  wasi-import leak on throw paths that predates this branch — plus 1672 ×5 /
+  2865 ×2 / symbol-async-iterator ×2). Byte matrix above.
+
+### Remaining (banked, unchanged from the design)
+
+- **3c-ii — return-through-finally + finallyState**: the `replay` terminator,
+  `MODE=RETURN; ABRUPT=value; goto(finallyState)` for `return` inside a try,
+  `try/catch/finally` combined regions. The routed dispatcher + route are the
+  substrate; this is planner + one new terminator.
+- **3c-iii — nested regions**: lift `validateAsyncCfg`'s `parent !== 0`
+  rejection once the route walks the parent chain; sibling regions (two
+  sequential try/catches) need the producer to admit >1 region first.
+- The D4 sync-generator convergence (#2864) waits on 3c-ii/iii per the
+  alignment decision there.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -951,6 +951,19 @@ export interface AsyncHandlerRegion {
   readonly parent: number;
   /** Await-free finally body, compiled a second time into the outer catch. */
   readonly finalizer: readonly ts.Statement[];
+  /**
+   * (#2906 3c) Entry state of this region's CATCH block. When present, the
+   * routed dispatcher (`block { loop { try { chain } catch { route } } }`)
+   * turns an abrupt completion raised while this region is active into a STATE
+   * TRANSITION: bind the reason to `catchParamName` (local + spill), consume
+   * the throw (MODE=NEXT), set STATE=catchState, and `br` the re-dispatch loop
+   * — the catch body is ordinary states and MAY await. Absent for the slice-2
+   * replay-only finally regions (their finalizer replays in the reject route).
+   * The target state must have no resume prelude (`resumeFrom === null`).
+   */
+  readonly catchState?: number;
+  /** Catch-clause binding name (absent for `catch { … }`). Spilled externref. */
+  readonly catchParamName?: string;
 }
 
 /** The full machine plan the drive-layer emitter consumes. */
@@ -1035,6 +1048,12 @@ export interface AsyncCfgOptions {
    * N microtask rounds; correct but needs its own corpus check).
    */
   readonly allowLoops: boolean;
+  /**
+   * (#2906 3c) Accept the bounded try/catch-around-await shape (catch region as
+   * states, routed dispatcher). Native drive lane only, same rationale as
+   * `allowLoops`; the host lane keeps its current shapes byte-identically.
+   */
+  readonly allowTryCatch?: boolean;
 }
 
 /**
@@ -1063,7 +1082,13 @@ export function planAsyncCfg(
     if (genConsumer !== null) return genConsumer;
     // (#2906 slice 3b) `for await (… of …)` over a boxed array — the sync
     // async-iterator carrier drive.
-    return planForAwaitCfg(fn, plan);
+    const forAwaitCfg = planForAwaitCfg(fn, plan);
+    if (forAwaitCfg !== null) return forAwaitCfg;
+  }
+  // (#2906 3c) Bounded try/catch-around-await — catch region as states.
+  if (opts.allowTryCatch) {
+    const tryCatchCfg = planTryCatchCfg(fn, plan);
+    if (tryCatchCfg !== null) return tryCatchCfg;
   }
   return null;
 }
@@ -1276,6 +1301,249 @@ export function loopAsyncSpillInfo(
   };
   walk(shape.whileStmt);
   return { names, segments: shape.segments };
+}
+
+// ---------------------------------------------------------------------------
+// try/catch-around-await drive (#2906 slice 3c — catch regions as states).
+//
+// `try { …await… } catch (e) { … }` could not be driven: `planLinearAwaits`
+// rejects any try with a catch clause, so the shape fell to the AG0 one-level
+// unwrap, which returns the PENDING `$Promise.value` (null/stale) — the catch
+// never observed the rejection. 3c lowers the catch block to ORDINARY STATES
+// (which may themselves await) and records the region's `catchState` on the
+// handler region; the routed dispatcher (async-frame) turns an abrupt
+// completion raised while the region is active into a state transition into
+// that catch chain. Rejection delivery needs no new machinery: a rejected
+// in-try await resumes with MODE=THROW, the resume prelude re-throws (arming
+// the region id first — the existing Gap-3 wiring), and the route catches it.
+// ---------------------------------------------------------------------------
+
+/** One linear-lowered statement chunk of the 3c shape. */
+interface TryCatchChunk {
+  readonly segs: LinearAwaitSegment[];
+  /** Trailing statements after the chunk's last await (or the whole chunk). */
+  readonly tail: ts.Statement[];
+  /** Chunk ended with `return await P` (tail is then empty). */
+  readonly sawReturnAwait: boolean;
+}
+
+/** Lower one statement list with a FRESH linear state; null on non-canonical. */
+function lowerChunk(
+  statements: readonly ts.Statement[],
+  awaitSet: ReadonlySet<ts.AwaitExpression>,
+): TryCatchChunk | null {
+  const st: LowerState = {
+    segments: [],
+    lead: [],
+    leadInTry: [],
+    finalizer: null,
+    theFinalizer: null,
+    usedFinally: false,
+    sawReturnAwait: false,
+  };
+  if (!lowerLinearStatements(statements, st, awaitSet)) return null;
+  // A try/finally INSIDE a chunk would claim handler id 1 (colliding with the
+  // 3c catch region) — bounded slice: no awaited try/finally inside the shape.
+  if (st.theFinalizer !== null) return null;
+  return { segs: st.segments, tail: st.lead, sawReturnAwait: st.sawReturnAwait };
+}
+
+/**
+ * (#2906 3c) Structural analysis of the bounded try/catch-around-await body:
+ * a flat statement block with exactly ONE top-level `try { … } catch (e?) { … }`
+ * (no finally, no nesting), where the try block carries ≥1 canonical await and
+ * the pre/post/catch chunks are themselves linear-canonical (awaits allowed).
+ * Returns `null` (→ legacy/AG0 fallback) for anything outside the slice.
+ */
+export function analyzeTryCatchAsync(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): {
+  pre: TryCatchChunk;
+  tryChunk: TryCatchChunk;
+  catchChunk: TryCatchChunk;
+  post: TryCatchChunk;
+  catchParamName: string | null;
+  tryStmt: ts.TryStatement;
+} | null {
+  if (plan.awaitPoints.length === 0) return null;
+  const body = fn.body;
+  if (body === undefined || !ts.isBlock(body)) return null;
+  const awaitSet = new Set<ts.AwaitExpression>(plan.awaitPoints);
+
+  // Exactly one top-level try statement; it must carry ≥1 await.
+  let tryIdx = -1;
+  for (let i = 0; i < body.statements.length; i++) {
+    const stmt = body.statements[i]!;
+    if (!ts.isTryStatement(stmt)) continue;
+    if (countAwaitsInStatement(stmt, awaitSet) === 0) continue; // await-free try — an ordinary lead
+    if (tryIdx !== -1) return null; // two awaited trys — not this shape
+    tryIdx = i;
+  }
+  if (tryIdx === -1) return null;
+  const tryStmt = body.statements[tryIdx] as ts.TryStatement;
+  if (!tryStmt.catchClause) return null; // try/finally → the Gap-3 linear path
+  if (tryStmt.finallyBlock) return null; // try/catch/finally — 3c-ii (return-through-finally)
+  const decl = tryStmt.catchClause.variableDeclaration;
+  if (decl !== undefined && !ts.isIdentifier(decl.name)) return null; // destructured catch param
+  const catchParamName = decl !== undefined ? (decl.name as ts.Identifier).text : null;
+
+  const pre = lowerChunk(body.statements.slice(0, tryIdx), awaitSet);
+  if (pre === null || pre.sawReturnAwait) return null; // `return await` before the try — unreachable try
+  const tryChunk = lowerChunk(tryStmt.tryBlock.statements, awaitSet);
+  if (tryChunk === null || tryChunk.segs.length === 0) return null;
+  const catchChunk = lowerChunk(tryStmt.catchClause.block.statements, awaitSet);
+  if (catchChunk === null) return null;
+  const post = lowerChunk(body.statements.slice(tryIdx + 1), awaitSet);
+  if (post === null) return null;
+
+  // Every await must be accounted for by the four chunks (no stray positions).
+  const total = pre.segs.length + tryChunk.segs.length + catchChunk.segs.length + post.segs.length;
+  if (total !== plan.awaitPoints.length) return null;
+
+  return { pre, tryChunk, catchChunk, post, catchParamName, tryStmt };
+}
+
+/**
+ * (#2906 3c) Build the CFG for the bounded try/catch shape. State layout
+ * (dense ids in push order; M = pre.segs + try.segs suspend states):
+ *   0..M-1      pre+try suspend chain (pre awaits handler 0, try awaits handler 1;
+ *               the pre tail runs as leading statements of the first try state)
+ *   M           try-exit: deliver the last try await, run the try tail,
+ *               `goto(join)` — or `settleSent` for a trailing `return await`
+ *   M+1..       catch chain (entry has NO resume prelude — the route enters it
+ *               like a goto; its awaits are handler 0: a throw in the catch
+ *               body rejects the result promise)
+ *   join..      post chain → settleUndefined (or settleSent)
+ * Handlers: one region { id: 1, catchState: M+1, catchParamName }.
+ */
+export function planTryCatchCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): AsyncCfgPlan | null {
+  const shape = analyzeTryCatchAsync(fn, plan);
+  if (shape === null) return null;
+  const { pre, tryChunk, catchChunk, post, catchParamName } = shape;
+
+  const asLead = (stmts: readonly ts.Statement[], handler: number): AsyncCfgStmt[] =>
+    stmts.map((stmt) => ({ stmt, handler }));
+
+  // Fused pre+try suspend steps (the pre tail leads into the first try step).
+  interface Step {
+    readonly leads: AsyncCfgStmt[];
+    readonly seg: LinearAwaitSegment;
+    readonly handler: number;
+  }
+  const steps: Step[] = [];
+  for (const seg of pre.segs) steps.push({ leads: asLead(seg.leadStmts, 0), seg, handler: 0 });
+  for (let i = 0; i < tryChunk.segs.length; i++) {
+    const seg = tryChunk.segs[i]!;
+    steps.push({
+      leads: [...(i === 0 ? asLead(pre.tail, 0) : []), ...asLead(seg.leadStmts, 1)],
+      seg,
+      handler: 1,
+    });
+  }
+  const M = steps.length; // ≥ 1 (tryChunk.segs.length ≥ 1)
+
+  const catchEntry = M + 1;
+  const catchStateCount = catchChunk.segs.length === 0 ? 1 : catchChunk.segs.length + 1;
+  const join = catchEntry + catchStateCount;
+  const finalSettle: AsyncCfgTerminator = post.sawReturnAwait ? { kind: "settleSent" } : { kind: "settleUndefined" };
+
+  const states: AsyncCfgState[] = [];
+  // Pre+try suspend chain.
+  for (let k = 0; k < M; k++) {
+    const step = steps[k]!;
+    states.push({
+      id: k,
+      resumeFrom: k === 0 ? null : { binding: steps[k - 1]!.seg.resumeBinding, handler: steps[k - 1]!.handler },
+      lead: step.leads,
+      terminator: { kind: "suspend", awaited: step.seg.awaitedExpr, resumeState: k + 1, handler: step.handler },
+    });
+  }
+  // Try-exit: deliver the last try await (handler 1 — a rejection routes to the
+  // catch), then the try tail, then join (or settle with SENT for return-await).
+  const lastStep = steps[M - 1]!;
+  states.push({
+    id: M,
+    resumeFrom: { binding: lastStep.seg.resumeBinding, handler: lastStep.handler },
+    lead: tryChunk.sawReturnAwait ? [] : asLead(tryChunk.tail, 1),
+    terminator: tryChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
+  });
+  // Catch chain (handler 0 throughout — no enclosing region).
+  if (catchChunk.segs.length === 0) {
+    states.push({
+      id: catchEntry,
+      resumeFrom: null,
+      lead: asLead(catchChunk.tail, 0),
+      terminator: { kind: "goto", target: join },
+    });
+  } else {
+    for (let j = 0; j < catchChunk.segs.length; j++) {
+      const seg = catchChunk.segs[j]!;
+      states.push({
+        id: catchEntry + j,
+        resumeFrom: j === 0 ? null : { binding: catchChunk.segs[j - 1]!.resumeBinding, handler: 0 },
+        lead: asLead(seg.leadStmts, 0),
+        terminator: { kind: "suspend", awaited: seg.awaitedExpr, resumeState: catchEntry + j + 1, handler: 0 },
+      });
+    }
+    states.push({
+      id: catchEntry + catchChunk.segs.length,
+      resumeFrom: { binding: catchChunk.segs[catchChunk.segs.length - 1]!.resumeBinding, handler: 0 },
+      lead: catchChunk.sawReturnAwait ? [] : asLead(catchChunk.tail, 0),
+      terminator: catchChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
+    });
+  }
+  // Post chain.
+  if (post.segs.length === 0) {
+    states.push({ id: join, resumeFrom: null, lead: asLead(post.tail, 0), terminator: { kind: "settleUndefined" } });
+  } else {
+    for (let j = 0; j < post.segs.length; j++) {
+      const seg = post.segs[j]!;
+      states.push({
+        id: join + j,
+        resumeFrom: j === 0 ? null : { binding: post.segs[j - 1]!.resumeBinding, handler: 0 },
+        lead: asLead(seg.leadStmts, 0),
+        terminator: { kind: "suspend", awaited: seg.awaitedExpr, resumeState: join + j + 1, handler: 0 },
+      });
+    }
+    states.push({
+      id: join + post.segs.length,
+      resumeFrom: { binding: post.segs[post.segs.length - 1]!.resumeBinding, handler: 0 },
+      lead: post.sawReturnAwait ? [] : asLead(post.tail, 0),
+      terminator: finalSettle,
+    });
+  }
+
+  return {
+    states,
+    handlers: [
+      {
+        id: 1,
+        parent: 0,
+        finalizer: [],
+        catchState: catchEntry,
+        ...(catchParamName !== null ? { catchParamName } : {}),
+      },
+    ],
+  };
+}
+
+/**
+ * (#2906 3c) Spill-set inputs for the bounded try/catch shape: the shape's
+ * suspend segments (for resume-binding types) and the catch-param name. The
+ * widened own-local set is computed by the caller (async-frame owns
+ * `collectVarDeclsByName`/`resolveSpillLocalValType`). Null off-shape.
+ */
+export function tryCatchAsyncSpillInfo(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): { segments: readonly LinearAwaitSegment[]; catchParamName: string | null } | null {
+  const shape = analyzeTryCatchAsync(fn, plan);
+  if (shape === null) return null;
+  return {
+    segments: [...shape.pre.segs, ...shape.tryChunk.segs, ...shape.catchChunk.segs, ...shape.post.segs],
+    catchParamName: shape.catchParamName,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -57,6 +57,7 @@ import {
   planAsyncCfg,
   planAsyncGenCfg,
   planLinearAwaits,
+  tryCatchAsyncSpillInfo,
 } from "./async-cps.js";
 import { ensureNativeGeneratorResultType } from "./generators-native.js";
 import { undefinedExternInstrs } from "./any-helpers.js"; // (#3178) canonical undefined for the done-result value
@@ -76,6 +77,7 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 import {
   ERROR_FIELD,
   MODE_FIELD,
+  MODE_NEXT,
   MODE_THROW,
   PARAM_FIELD_OFFSET,
   RESULT_DONE_FIELD,
@@ -625,8 +627,12 @@ export function asyncFnNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclar
     // non-spill-safe field (e.g. a non-nullable ref with no inert default) would
     // make the frame layout invalid, so those fall back to legacy.
     const loop = computeLoopSpills(ctx, fn, plan);
-    if (loop === null) return false;
-    return loop.spillTypes.every(isSpillSafeType);
+    if (loop !== null) return loop.spillTypes.every(isSpillSafeType);
+    // (#2906 3c) try/catch-around-await shape (native drive lane only) — same
+    // widened spill-safe rule as the loop machine.
+    const tc = computeTryCatchSpills(ctx, fn, plan);
+    if (tc !== null) return tc.spillTypes.every(isSpillSafeType);
+    return false;
   }
   // Parity with asyncFnNeedsCps: a lone `await Promise.all(...)`/`.race`/… already
   // yields a real Promise — keep it on the legacy identity path.
@@ -711,6 +717,57 @@ function computeForAwaitSpills(
 }
 
 /**
+ * (#2906 3c) The spill layout for the bounded try/catch-around-await shape:
+ * EVERY own body local, conservatively (the catch chain can read pre-try
+ * locals after any number of suspends, so per-await liveness buys little), a
+ * resume-binding name typed via {@link resumeBindingValType} (matching the
+ * SENT-coercion target), others via `resolveSpillLocalValType` defaulting to
+ * externref — the same widened rule the 3a loop machine uses — PLUS the catch
+ * param (externref: the exn-tag payload / rejection reason). Returns `null`
+ * when the body is not the bounded shape, or when the catch param SHADOWS an
+ * own local / fn param (the shared local slot would alias — bounded slice).
+ */
+function computeTryCatchSpills(
+  ctx: CodegenContext,
+  decl: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): { spillNames: string[]; spillTypes: ValType[] } | null {
+  const info = tryCatchAsyncSpillInfo(decl, plan);
+  if (info === null) return null;
+  const declByName = collectVarDeclsByName(decl);
+  // `collectVarDeclsByName` also picks up the CATCH clause's own
+  // variableDeclaration (it IS a ts.VariableDeclaration) — that entry is the
+  // catch param itself, not a shadowing body local.
+  const isCatchClauseDecl = (node: ts.VariableDeclaration): boolean =>
+    node.parent !== undefined && ts.isCatchClause(node.parent);
+  const paramNames = new Set<string>();
+  for (const p of decl.parameters) if (ts.isIdentifier(p.name)) paramNames.add(p.name.text);
+  if (info.catchParamName !== null) {
+    const existing = declByName.get(info.catchParamName);
+    if (existing !== undefined && !isCatchClauseDecl(existing)) return null; // shadows a body local
+    if (paramNames.has(info.catchParamName)) return null; // shadows a fn param
+  }
+  const rbTypeByName = new Map<string, ValType>();
+  for (const seg of info.segments) {
+    if (seg.resumeBinding) rbTypeByName.set(seg.resumeBinding.name, resumeBindingValType(ctx, seg.resumeBinding));
+  }
+  const spillNames: string[] = [];
+  const spillTypes: ValType[] = [];
+  for (const [name, node] of declByName) {
+    if (paramNames.has(name)) continue;
+    if (isCatchClauseDecl(node)) continue; // the catch param spill is added below (externref)
+    const rbType = rbTypeByName.get(name);
+    spillNames.push(name);
+    spillTypes.push(rbType ?? resolveSpillLocalValType(ctx, node) ?? { kind: "externref" });
+  }
+  if (info.catchParamName !== null) {
+    spillNames.push(info.catchParamName);
+    spillTypes.push({ kind: "externref" });
+  }
+  return { spillNames, spillTypes };
+}
+
+/**
  * The body locals that are live across ANY await and so must be spilled into the
  * frame (the multi-await generalization of the generator's `bodySpills`).
  *
@@ -772,9 +829,12 @@ function computeAsyncSpills(
   if (linear === null) {
     // (#2906 slice 3a) `while`-with-await loop: widened spill set (all loop
     // own-locals). (#2906 slice 3b) for-await drive: loop own-locals + the
-    // synthetic async-iterator carrier local. Returns empty for any other body.
+    // synthetic async-iterator carrier local. (#2906 3c) try/catch-around-await:
+    // widened own-local set + the catch param. Returns empty for any other body.
     return (
-      computeLoopSpills(ctx, decl, plan) ?? computeForAwaitSpills(ctx, decl, plan) ?? { spillNames: [], spillTypes: [] }
+      computeLoopSpills(ctx, decl, plan) ??
+      computeForAwaitSpills(ctx, decl, plan) ??
+      computeTryCatchSpills(ctx, decl, plan) ?? { spillNames: [], spillTypes: [] }
     );
   }
   const paramSet = new Set(paramNames);
@@ -987,8 +1047,16 @@ function validateAsyncCfg(cfg: AsyncCfgPlan): string | null {
   for (let i = 0; i < cfg.handlers.length; i++) {
     const h = cfg.handlers[i]!;
     if (h.id !== i + 1) return `handler ids not dense (handlers[${i}].id === ${h.id})`;
-    // Nested regions need parent-chain replay in the catch — 3c follow-up.
+    // Nested regions need parent-chain replay in the catch — 3c-iii follow-up.
     if (h.parent !== 0) return `nested handler region ${h.id} (parent ${h.parent}) not yet supported`;
+    // (#2906 3c) A routed catch region: the route enters catchState like a goto,
+    // so it must exist and carry no resume prelude.
+    if (h.catchState !== undefined) {
+      if (!inRange(h.catchState)) return `handler ${h.id} catchState ${h.catchState} out of range`;
+      if (cfg.states[h.catchState]!.resumeFrom !== null) {
+        return `handler ${h.id} catchState ${h.catchState} has a resume prelude (route enters it like a goto)`;
+      }
+    }
   }
   return null;
 }
@@ -1056,7 +1124,7 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
         // always see the same segment shape.
         asyncGenDelegatesForPlan(ctx, info.decl, isStandalonePromiseActive(ctx) ? "carrier" : "awaitFree"),
       )
-    : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host });
+    : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host, allowTryCatch: !info.host });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
     info.resumeFuncIdx = -1;
@@ -1350,6 +1418,14 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     { op: "i32.const", value: v },
     { op: "local.set", index: inSrcTryLocal },
   ];
+  // (#2906 3c) ROUTED dispatcher: when any region carries a catchState, the
+  // per-call try/catch moves INSIDE the re-dispatch loop
+  // (`block { loop { try { chain } catch { route } } }`) so an abrupt
+  // completion can become a state transition into the region's catch chain
+  // (`br` back to the loop). Every arm's br-to-loop depth shifts by +1 (the
+  // try wraps the chain). Plans without a catchState keep the pre-3c
+  // `try { block { loop { chain } } } catch` wrap BYTE-IDENTICALLY.
+  const routedDispatch = cfg.handlers.some((h) => h.catchState !== undefined);
 
   // Emit a state's resume prelude: re-throw a rejected predecessor await
   // (MODE_THROW — arming its handler region first so the finalizer runs), then
@@ -1424,7 +1500,9 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
     // arm's own `if`, br1..br(st.id) = the enclosing if-chain arms, br(st.id+1)
     // = if(state==0), br(st.id+2) = the loop. Valid because state ids are dense
     // and equal to their if-chain nesting depth (validateAsyncCfg).
-    const loopDepth = st.id + 2;
+    // (#2906 3c) The routed dispatcher wraps the chain in an in-loop `try`,
+    // adding one block level — the single depth-accounting site.
+    const loopDepth = st.id + (routedDispatch ? 3 : 2);
     try {
       // Reset the handler-region local at arm entry (a resume enters here
       // fresh; a fast-path advance may re-dispatch from an in-region state).
@@ -1954,47 +2032,116 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // Wrap the whole `block { loop { if-chain } }` dispatch in `try`/`catch $exn`.
   // Suspend / settle `return`s exit cleanly (a `return` in `try` skips `catch`),
   // so only a real throw reaches the handler.
-  const dispatch: Instr[] = [
-    {
+  //
+  // (#2906 3c) The shared reject tail (also the routed dispatcher's default
+  // route): replay any region's await-free finalizer, reject the result
+  // promise, and (async gens) re-point at the synthetic COMPLETED arm.
+  const rejectTail: Instr[] = [
+    // (#2906 Gap 3) run the finally before rejecting, if the throw crossed
+    // the try region (inline no-op array when the body has no finally).
+    ...catchFinallyInstrs,
+    { op: "local.get", index: resultPromiseLocal },
+    { op: "local.get", index: reasonLocal },
+    { op: "call", funcIdx: settleRejectIdx },
+    { op: "drop" },
+    // (#3178) §27.6.3.5 AsyncGeneratorStart step 4.f–g: an uncaught throw
+    // COMPLETES an async generator ([[AsyncGeneratorState]] = "completed")
+    // in addition to rejecting the current result promise. Re-point
+    // frame.STATE at the synthetic leads-free COMPLETED arm so a
+    // subsequent `.next()` fulfills `{value: undefined, done: true}`
+    // instead of re-driving the throwing step and rejecting again (the
+    // 280-test yield*-GetIterator/next error-semantics cohort surfaced
+    // by the F2 async-completion channel, #3417). NOT the settleDone
+    // state — that one carries trailing body statements as leads and
+    // would re-execute them. Plain async FUNCTIONS are untouched (no
+    // re-entry exists; gate keeps their bytes identical).
+    ...(info.asyncGen && info.completedStateId !== undefined
+      ? setStateI32FromConst(info, frameLocal, STATE_FIELD, info.completedStateId)
+      : []),
+  ];
+  if (routedDispatch) {
+    // (#2906 3c) ROUTED dispatcher: `block { loop { try { chain } catch $exn {
+    // route } } }`. The route turns an abrupt completion raised while a
+    // catch-carrying region is active into a STATE TRANSITION: bind the reason
+    // to the catch param (local now, spill for later suspends), consume the
+    // throw (MODE=NEXT — the prelude re-throw arm must not re-fire on stale
+    // MODE inside the catch chain), point STATE at the region's catch entry,
+    // and `br` the loop (depth 2 from inside the route's `if`: if=0, try=1,
+    // loop=2). No active region (or a region without a catchState) falls
+    // through to the shared reject tail, exactly the pre-3c behavior.
+    const route: Instr[] = [{ op: "local.set", index: reasonLocal }];
+    for (const region of cfg.handlers) {
+      if (region.catchState === undefined) continue;
+      const bindInstrs: Instr[] = [];
+      if (region.catchParamName !== undefined) {
+        const paramLocal = resumeFctx.localMap.get(region.catchParamName);
+        if (paramLocal !== undefined) {
+          bindInstrs.push({ op: "local.get", index: reasonLocal }, { op: "local.set", index: paramLocal });
+        }
+        const spillIdx = info.spillNames.indexOf(region.catchParamName);
+        if (spillIdx >= 0) {
+          bindInstrs.push(
+            { op: "local.get", index: frameLocal },
+            { op: "local.get", index: reasonLocal },
+            { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + spillIdx },
+          );
+        }
+      }
+      route.push(
+        { op: "local.get", index: inSrcTryLocal },
+        { op: "i32.const", value: region.id },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            ...bindInstrs,
+            ...setStateI32FromConst(info, frameLocal, MODE_FIELD, MODE_NEXT),
+            ...setStateI32FromConst(info, frameLocal, STATE_FIELD, region.catchState),
+            { op: "br", depth: 2 }, // if(0) → try(1) → loop(2): re-dispatch
+          ],
+        },
+      );
+    }
+    route.push(...rejectTail);
+    resumeFctx.body.push({
       op: "block",
       blockType: { kind: "empty" },
-      body: [{ op: "loop", blockType: { kind: "empty" }, body: chain }],
-    },
-  ];
-  resumeFctx.body.push({
-    op: "try",
-    blockType: { kind: "empty" },
-    body: dispatch,
-    catches: [
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "try",
+              blockType: { kind: "empty" },
+              body: chain,
+              catches: [{ tagIdx: exnTag, body: route }],
+            },
+          ],
+        },
+      ],
+    });
+  } else {
+    const dispatch: Instr[] = [
       {
-        tagIdx: exnTag,
-        body: [
-          { op: "local.set", index: reasonLocal },
-          // (#2906 Gap 3) run the finally before rejecting, if the throw crossed
-          // the try region (inline no-op array when the body has no finally).
-          ...catchFinallyInstrs,
-          { op: "local.get", index: resultPromiseLocal },
-          { op: "local.get", index: reasonLocal },
-          { op: "call", funcIdx: settleRejectIdx },
-          { op: "drop" },
-          // (#3178) §27.6.3.5 AsyncGeneratorStart step 4.f–g: an uncaught throw
-          // COMPLETES an async generator ([[AsyncGeneratorState]] = "completed")
-          // in addition to rejecting the current result promise. Re-point
-          // frame.STATE at the synthetic leads-free COMPLETED arm so a
-          // subsequent `.next()` fulfills `{value: undefined, done: true}`
-          // instead of re-driving the throwing step and rejecting again (the
-          // 280-test yield*-GetIterator/next error-semantics cohort surfaced
-          // by the F2 async-completion channel, #3417). NOT the settleDone
-          // state — that one carries trailing body statements as leads and
-          // would re-execute them. Plain async FUNCTIONS are untouched (no
-          // re-entry exists; gate keeps their bytes identical).
-          ...(info.asyncGen && info.completedStateId !== undefined
-            ? setStateI32FromConst(info, frameLocal, STATE_FIELD, info.completedStateId)
-            : []),
-        ],
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [{ op: "loop", blockType: { kind: "empty" }, body: chain }],
       },
-    ],
-  });
+    ];
+    resumeFctx.body.push({
+      op: "try",
+      blockType: { kind: "empty" },
+      body: dispatch,
+      catches: [
+        {
+          tagIdx: exnTag,
+          body: [{ op: "local.set", index: reasonLocal }, ...rejectTail],
+        },
+      ],
+    });
+  }
 
   resumePlaceholder.locals = resumeFctx.locals;
   resumePlaceholder.body = resumeFctx.body;

--- a/tests/issue-2906-3c-trycatch.test.ts
+++ b/tests/issue-2906-3c-trycatch.test.ts
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2906 slice 3c — try/CATCH-around-await on the host-free async drive machine.
+//
+// `try { …await… } catch (e) { … }` could not be driven: `planLinearAwaits`
+// rejects any try with a catch clause, so the shape fell to the AG0 one-level
+// unwrap and the catch never observed a rejection (the rejected `$Promise`'s
+// reason field was read as the VALUE — silently wrong). 3c adds:
+//   - a CFG producer (`planTryCatchCfg`) lowering the bounded shape — pre
+//     statements, one top-level try/catch (no finally), post statements, each
+//     chunk linear-canonical with awaits allowed (including INSIDE the catch);
+//   - `AsyncHandlerRegion.catchState`: the region's catch chain entry;
+//   - the ROUTED dispatcher: `block { loop { try { chain } catch { route } } }`
+//     — an abrupt completion raised while the region is active (a rejected
+//     in-try await re-thrown by the resume prelude, or a synchronous throw in
+//     an in-try lead) becomes a STATE TRANSITION into the catch chain (reason
+//     bound to the catch param local + spill, MODE consumed, `br` re-dispatch).
+//     A throw with no active region falls to the pre-3c reject tail; plans
+//     without a catchState keep the pre-3c dispatcher BYTE-IDENTICALLY.
+//
+// Native (wasi/standalone-carrier) drive lane only — the host lane keeps its
+// current shapes byte-identically (`allowTryCatch: !info.host`).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+type Target = "wasi" | "standalone";
+
+/** Compile + instantiate; kick the async fn, drain microtasks, read the side channel. */
+async function driveCap(src: string, target: Target = "wasi"): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  // Some throw paths pull the wasi fd_write error sink — stub it; no JS host.
+  const imports = { wasi_snapshot_preview1: { fd_write: () => 0, proc_exit: () => {} } };
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  const ex = instance.exports as {
+    kick: () => number;
+    getCap: () => number;
+    __drain_microtasks?: () => void;
+  };
+  ex.kick();
+  ex.__drain_microtasks?.();
+  return ex.getCap();
+}
+
+describe("#2906 3c — try/catch-around-await drive (wasi lane)", () => {
+  it("verify-first: a rejected in-try await enters the catch with the reason bound", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.reject(new Error("boom"));
+    cap = (x as number) + 1000;
+  } catch (e) {
+    cap = 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(42);
+  });
+
+  it("a fulfilled in-try await takes the try continuation (catch not entered)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.resolve(7);
+    cap = (x as number) + 1000;
+  } catch (e) {
+    cap = 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1007);
+  });
+
+  it("pre-try await delivers, rejection on the 2nd (in-try) await routes", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  const a = await Promise.resolve(3);
+  try {
+    const b = await Promise.reject(new Error("y"));
+    cap = (a as number) + (b as number);
+  } catch (e) {
+    cap = (a as number) + 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(45);
+  });
+
+  it("the catch body may itself await (catch chain suspends + resumes)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("z"));
+    cap = 1;
+  } catch (e) {
+    const r = await Promise.resolve(8);
+    cap = 42 + (r as number);
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(50);
+  });
+
+  it("post statements after the try run on the catch path too (join state)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("q"));
+    cap = 1;
+  } catch (e) {
+    cap = 42;
+  }
+  const t = await Promise.resolve(100);
+  cap = cap + (t as number);
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(142);
+  });
+
+  it("a SYNCHRONOUS throw in an in-try lead routes to the catch (not reject)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+function boom(): number { throw new Error("sync"); }
+async function f(): Promise<void> {
+  try {
+    const a = await Promise.resolve(1);
+    cap = boom() + (a as number);
+  } catch (e) {
+    cap = 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(42);
+  });
+
+  it("a throw INSIDE the catch body rejects the result promise (no route loop)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("a"));
+  } catch (e) {
+    cap = 5;
+    throw new Error("b");
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(5);
+  });
+
+  it("catch WITHOUT a binding routes (reason dropped)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("nobind"));
+    cap = 1;
+  } catch {
+    cap = 77;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(77);
+  });
+
+  it("locals crossing the try + a post await survive (widened frame spills)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  let acc: number = 5;
+  try {
+    const x = await Promise.resolve(10);
+    acc = acc + (x as number);
+  } catch (e) {
+    acc = -1;
+  }
+  const y = await Promise.resolve(100);
+  cap = acc + (y as number);
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(115);
+  });
+
+  it("GENUINELY-PENDING rejection routes on resume (reject step adapter → prelude re-throw → route)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.resolve(1).then((v: number) => { throw new Error("later"); });
+    cap = (x as number) + 1000;
+  } catch (e) {
+    cap = 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(42);
+  });
+
+  it("GENUINELY-PENDING fulfil keeps the try continuation", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.resolve(1).then((v: number) => v + 4);
+    cap = (x as number) + 1000;
+  } catch (e) {
+    cap = 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1005);
+  });
+
+  it("pending rejection + await inside the catch after routing", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.resolve(1).then((v: number) => { throw new Error("later"); });
+    cap = 1;
+  } catch (e) {
+    const r = await Promise.resolve(1).then((v: number) => v + 7);
+    cap = 42 + (r as number);
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(50);
+  });
+});
+
+describe("#2906 3c — try/catch-around-await drive (standalone carrier lane)", () => {
+  it("the core rejection→catch case drives on standalone too", async () => {
+    expect(
+      await driveCap(
+        `let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.reject(new Error("boom"));
+    cap = (x as number) + 1000;
+  } catch (e) {
+    cap = 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`,
+        "standalone",
+      ),
+    ).toBe(42);
+  });
+
+  it("catch-with-await + post-join drives on standalone", async () => {
+    expect(
+      await driveCap(
+        `let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("z"));
+    cap = 1;
+  } catch (e) {
+    const r = await Promise.resolve(8);
+    cap = 42 + (r as number);
+  }
+  const t = await Promise.resolve(100);
+  cap = cap + (t as number);
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`,
+        "standalone",
+      ),
+    ).toBe(150);
+  });
+});


### PR DESCRIPTION
## Summary

**#2906 slice 3c-i** (per the issue's banked 3c design): `try { …await… } catch (e) { … }` now DRIVES on the native async lane (wasi + standalone-carrier). Previously the shape fell to the AG0 sync unwrap, which read a rejected `$Promise`'s REASON field as the awaited VALUE — measured `cap=NaN`, catch never entered, on every rejection probe.

**What landed** (design step 1 + the catchState half of step 2):
- `AsyncHandlerRegion.catchState`/`catchParamName` + `validateAsyncCfg` checks (in-range, no resume prelude on the catch entry).
- `planTryCatchCfg` producer: bounded flat body, ONE top-level try/catch (no finally), pre/try/catch/post chunks each linear-canonical — awaits allowed in EVERY chunk including the catch chain (which suspends/resumes normally).
- **Routed dispatcher** `block{loop{try{chain}catch{route}}}`: an abrupt completion raised while the region is active becomes a STATE TRANSITION into the catch chain (reason → param local+spill, MODE consumed, `br` re-dispatch). One mechanism covers sync-REJECTED classify, pending reject step-adapter delivery, and synchronous throws in in-try leads. No active region → the shared pre-3c reject tail. **Conditional**: plans without a catchState keep the pre-3c dispatcher byte-identically.
- `computeTryCatchSpills`: 3a widened own-local rule + externref catch param (exempting the catch clause's own `variableDeclaration` from the shadow gate — it IS a `ts.VariableDeclaration`).
- `planAsyncCfg` gains `allowTryCatch` (native lane only, mirroring `allowLoops`) — host lane admission untouched.

## Validation (measured)

- **14/14 new tests** `tests/issue-2906-3c-trycatch.test.ts`: rejection→catch with reason bound, fulfil-continues, pre-try await + catch-on-2nd, await-INSIDE-catch, post-join on both paths, sync-throw-in-lead, throw-in-catch (rejects, no route loop), unbound catch, widened spills, genuinely-PENDING reject/fulfil via step adapters, 2 standalone-carrier cases.
- **Byte-inertness**: 7 existing driven shapes (linear single/multi, Gap-3 try/finally, 3a while, 3b for-await, 3d async-gen, sync-only) × 3 lanes sha256-IDENTICAL to main; only the newly-admitted shape differs, and only on wasi/standalone — gc/host lane fully untouched.
- **Async corpus**: 243 passing across 31 files; 14 failures ALL verified pre-existing on unmodified main (gap3-tryfinally ×3 / #2980 ×2 — a wasi-import leak on throw paths that predates this branch — plus 1672 ×5, 2865 ×2, symbol-async-iterator ×2).
- `loc-budget-allow` granted in #2906 frontmatter for async-cps.ts/async-frame.ts (planner+emitter capability in the machine's own files).

## Banked (recorded in the issue)

- **3c-ii**: return-through-finally + finallyState (`replay` terminator, MODE=RETURN routing, try/catch/finally combos).
- **3c-iii**: nested regions (parent-chain walk in the route; >1 region admission).
- The #2864 D4 sync-generator convergence waits on 3c-ii/iii per the alignment decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)