### PR TITLE
fix(#3468 F1): standalone assert-harness routing — closure own-property carriers widened + top-level keep-arm (stakeholder-ruled floor de-inflation)

### DIFF
--- a/plan/issues/3468-standalone-method-dispatch-exception-swallow.md
+++ b/plan/issues/3468-standalone-method-dispatch-exception-swallow.md
@@ -1,11 +1,11 @@
 ---
 id: 3468
 title: "Standalone: method calls on function objects silently swallow assertions (assert.sameValue/throws never fire) — root cause is function-object own-property gap, NOT a catch_all swallow"
-status: blocked
+status: in-progress
 spec: complete
-assignee: ttraenkler/sendev-3468-closure-props
+assignee: ttraenkler/sendev-3468-f1
 created: 2026-07-19
-blocked_reason: "The captured-closure dynamic-runtime substrate is independently mergeable; shared noncapturing wrappers and top-level test262 harness routing remain blocked after an exact-baseline merge-group measurement found 3,608 stable pass→fail transitions (3,540 assertion-time module-init throws). Fix the exposed semantics; do not rebaseline."
+blocked_reason: "SUPERSEDED 2026-07-23 by stakeholder ruling (see '## STAKEHOLDER RULING' below): land F1 harness routing + HONEST floor de-inflation, routing the exposed failures to trackers by cluster. The prior 'do not rebaseline' stance was a PR-shepherd caution ABSENT a stakeholder decision; the stakeholder has now ruled to proceed with a truthful downward re-baseline (the tests were never really passing)."
 priority: high
 feasibility: hard
 task_type: bug
@@ -18,10 +18,13 @@ related: [2860, 3417]
 # src/codegen/closure-props.ts; these three touches are the unavoidable minimum:
 # the three dead arms live in object-runtime.ts, the reserve/fill ctx flags in
 # context/types.ts, and the finalize call in index.ts.
+# (F1) declarations.ts carries the restored standalone top-level `F.<name> = …`
+# keep-arm (the front-end routing for the assert-harness shape) — ~45 LOC.
 loc-budget-allow:
   - src/codegen/object-runtime.ts
   - src/codegen/context/types.ts
   - src/codegen/index.ts
+  - src/codegen/declarations.ts
 ---
 
 # #3468 — Standalone method-dispatch "exception swallow" (root-caused)
@@ -30,7 +33,30 @@ loc-budget-allow:
 > (oracle-v8 reclassification). Origin: the Cluster C / C1 finding in the
 > host↔standalone parity investigation (`/workspace/.tmp/parity-findings.md`).
 
-## STATUS: root-caused, BLOCKED ON A SCOPING + FLOOR-REBASELINE DECISION
+## STAKEHOLDER RULING (2026-07-23) — PROCEED with honest de-inflation
+
+**The user (stakeholder the floor-rebaseline gate defers to) ruled: land F1 +
+honest floor de-inflation.** This SUPERSEDES the "do not rebaseline / explicitly
+rejected" language in the PR-shepherd resolution below — that stance was correct
+*absent a stakeholder decision*; the decision is now made. Execution conditions
+(non-negotiable, they are what make this honest de-inflation and NOT the
+banked-regression path the older note rejected):
+
+1. **Route the exposed vacuous-pass→real-fail tests to TRACKERS by signature
+   cluster** (#3178 iterables, #3442/#2865 async continuation, #1781 module-init
+   throw, #3443 illegal_cast, #2903/#3390 promise; file new issues only for
+   genuinely unowned clusters). Cohort-level, not per-test. This is the condition
+   that distinguishes truthful de-inflation from hiding.
+2. **The honest floor number is MEASURED, never the stale 3,608.** That figure is
+   from the 2026-07-20 merge_group run — F3 (#3501 deferTopLevelInit) has since
+   changed exactly the module-init-throw surface those failures live on. The real
+   number comes from the F1 PR's own merge_group park delta on current main.
+3. **Re-baseline downward to the measured honest number**, with the justification
+   recorded in the PR body + this issue. The floor edit is revert-forward
+   reversible; what must be exactly right is the ACCOUNTING (measured number +
+   real tracker routing), not the mechanics.
+
+## STATUS (historical): root-caused, was BLOCKED ON A SCOPING + FLOOR-REBASELINE DECISION — now RULED, see above
 
 The bug is confirmed and multiply-reproduced. **But the root cause is NOT what
 the parity investigation hypothesised, and the real fix is a substantial
@@ -372,6 +398,64 @@ regression, not the truthful correction). The string bug is a SEPARATE issue
 (function-expression externref-param reassign-to-native-string type unification),
 a prerequisite for landing #3468's routing. #3468 stays `blocked`; PR held; not
 merged.
+
+## F1 IMPLEMENTATION (2026-07-23, per the stakeholder ruling) — harness routing landed in this PR
+
+Branch `issue-3468-f1-harness-routing` (agent `ttraenkler/sendev-3468-f1`).
+Two changes, both standalone-gated (host/GC byte-identical):
+
+1. **Carrier widening** (`src/codegen/closure-props.ts`,
+   `fillClosurePropHelpers`): `__is_closure_prop_carrier`'s `ref.test` chain now
+   covers the full closure BASE-wrapper set via
+   `collectClosureBaseWrapperTypeIdxs` — the same classifier as
+   `__is_closure`/`__typeof_function`. A base-root test matches every capturing
+   subtype instance, so this strictly subsumes the #3418 capturing-only set and
+   additionally admits shared noncapturing wrappers (the `function assert(){}`
+   harness receiver). WHY not a union with the `hasCaptures` subtype list: every
+   entry in `closureInfoByTypeIdx` walks to its root inside
+   `collectClosureBaseWrapperTypeIdxs`, so the base set covers all subtypes by
+   construction. The `hasCaptures` metadata itself is KEPT (an IR-lane consumer
+   landed on it since the narrowing: `src/ir/integration.ts` sets
+   `hasCaptures: true` on canonical capture subtypes) — a straight revert of
+   `81b02624a` would have broken that; this PR is a re-application, not a revert.
+2. **Front-end routing restore** (`src/codegen/declarations.ts`): the standalone
+   top-level `F.<name> = …` keep-arm (dropped by `81b02624a`) is restored so the
+   harness shape (`assert.sameValue = function(){…}`) stays in `__module_init`
+   and reaches the ordinary `__extern_set` write-arm → side table. Reads/calls
+   already routed dynamically from function bodies (and `__module_init` IS a
+   function body).
+
+**Deviation from the pre-narrowing original — `.prototype` is now EXCLUDED from
+the keep-arm.** The #2660 S2 arm was UNSCOPED when the original measured run
+happened (it consumed every top-level fnctor-prototype write first); it has
+since gained the RECONSTRUCT-gate, so a non-reconstruct fnctor's
+`F.prototype = …` now falls through. Admitting it into the side-table bag would
+create a second, S3-invisible prototype storage with divergent identity —
+`issue-2660-s2`'s "S2 off" guard test catches exactly this (verified: it fails
+without the exclusion, passes with it). `.prototype` stays owned end-to-end by
+S2/S3.
+
+**Local verification (measured, this branch):** 14/14 in
+`tests/issue-3468-closure-own-props.test.ts` — including the NEW regression
+guards `assert.sameValue(1,2)` THROWS and `assert.throws(TypeError, ()=>{})`
+THROWS under `--target standalone` (the vacuous-pass correction), plus
+exclusions (class statics, `.call`/`.apply`) and the flipped noncapturing
+round-trip. Adjacent surfaces: `issue-3418` (7/7), `issue-3536` (per-file
+pass), `issue-3537` (11/11), `issue-3472`, `issue-2660-s2` (11/11),
+`issue-1896`, `issue-2671-promise-capability` — 82/82 across the 8 suites.
+A control run with `src/` flipped to `origin/main` showed the 8 failures seen
+in a wider sweep (`illegal-cast-closures-585`, `issue-1712-capture-closure-
+dispatch`, `issue-2660-s3` STRUCT-BINDING guard) fail IDENTICALLY on main —
+pre-existing local-environment failures, not introduced by this PR.
+
+**Floor accounting (per the ruling):** the PR is expected to auto-park in the
+merge_group on the standalone floor gates; the park's regressed-test delta is
+the honest number. The floor mechanism is the COMMITTED file
+`benchmarks/results/test262-standalone-highwater.json` (read by
+`scripts/check-standalone-highwater.mjs`; `--update` only ratchets UP, so the
+intentional downward re-seed is an in-PR edit of that file) — no GitHub
+Actions variable involved. The measured delta, tracker routing, and the
+re-baseline edit are recorded below once the merge_group run completes.
 
 ## PR-shepherd resolution (2026-07-20) — land captured-closure substrate; keep harness rollout blocked
 

--- a/plan/issues/3468-standalone-method-dispatch-exception-swallow.md
+++ b/plan/issues/3468-standalone-method-dispatch-exception-swallow.md
@@ -25,6 +25,17 @@ loc-budget-allow:
   - src/codegen/context/types.ts
   - src/codegen/index.ts
   - src/codegen/declarations.ts
+# (#3303) Ceiling for the stakeholder-ruled F1 de-inflation. DERIVED, not
+# round: 3,637 measured wasm-change regressions (merge_group run 30043224652,
+# vs standalone baseline dbc0162 @2026-07-23T20:20Z, oracle v9=v9) + 13
+# (measured pass→compile_timeout flake rows this run — each can complete on
+# the re-run and convert into a counted regression; conversion bound = all 13)
+# + 25 (ORACLE_REBASE_DRIFT_TOLERANCE, scripts/diff-test262.ts — the repo's
+# codified bound for unavoidable main-side baseline drift during a
+# re-baseline window) = 3,675. Hard-fails above the ceiling (#3303).
+regressions-allow:
+  count: 3675
+  reason: "#3468 F1 stakeholder-ruled assert-harness de-inflation: 3,637 measured vacuous-pass→honest-fail flips (97.5% assertion-time throws; incl. 4 latent #3559 CEs, stakeholder-signed-off) + 13 measured timeout-flake conversion bound + 25 codified drift tolerance"
 ---
 
 # #3468 — Standalone method-dispatch "exception swallow" (root-caused)
@@ -456,6 +467,66 @@ the honest number. The floor mechanism is the COMMITTED file
 intentional downward re-seed is an in-PR edit of that file) — no GitHub
 Actions variable involved. The measured delta, tracker routing, and the
 re-baseline edit are recorded below once the merge_group run completes.
+
+## F1 MEASUREMENT (2026-07-23, merge_group run 30043224652) — the honest numbers
+
+PR #3523 parked as designed; the ONLY failed step was **"Standalone regression
+guard (#1897)"**. Measured (run-log-authoritative, reproduced exactly by a
+local rediff of the run's merged JSONL vs the dbc0162 baseline):
+
+- **Honest floor: host_free_pass = 27,557 / 48,088 full corpus** (official
+  scope 27,093 / 43,106). Baseline was 31,188 → delta −3,631.
+- Guard-exact: **3,637 wasm-change regressions, 18 improvements, net −3,619**;
+  13 pass→compile_timeout flake rows excluded by the guard.
+- **The #2097 high-water floor PASSED**: 27,557 vs mark 25,453 (floor 25,403),
+  **+2,104 headroom** — the mark never ratcheted up with recent standalone
+  gains, so NO highwater reseed is needed. The de-inflation lands entirely via
+  the #1897/#3303 rebase-mode path.
+- Host lane: catastrophic guard PASS (7 raw drift regressions) — corpus-scale
+  confirmation of host byte-neutrality.
+
+**Split of the 3,637** (= 3,633 fail + 4 compile_error):
+- 3,545 (97.5%) assertion-time `Test262Error` throws — the designed
+  vacuous→honest-fail flips. Cohorts: 2,328 value/behavior mismatches
+  (assertions now compare real values), 1,016 expected-throw-NOT-thrown
+  (assert.throws fires; builtin lacks the spec validation throw — Temporal
+  480, annexB 96, TypedArray 83…), 137 async continuation, 31 promise, 45
+  misc.
+- 75 missing-capability TypeErrors ("X is not yet callable as a value" 32,
+  property-on-null 33, …).
+- 17 trap-category rows, only 11 REAL traps (7 null_deref, 4 illegal_cast —
+  both categories SHRANK overall: 295→287, 397→376). The ratchet's oob 39→43
+  "+4" was 100% classifier misclassification (assertion TEXT containing "out
+  of bounds"), fixed by the v10 classifyError reorder in this PR — post-fix
+  all four trap categories shrink vs baseline, so no trap-growth-allow is
+  needed.
+- 4 compile_error — the #2043-class latent bug exposed by the keep-arm
+  (**#3559**): `local index out of range at '__cb_0'`. Root-caused to
+  `call-identifier.ts`'s nested-lifted-fn call-site else-arm baking
+  `local.get cap.outerLocalIdx` (the DECLARING fctx's index) when called from
+  a method-call-arg callback (cbFctx) — the #2029 cross-fctx rescue covers
+  only accessor-promoted globals, and the naive #1177 localMap-first fix was
+  reverted for causing 100+ regressions. Minimal repro: retained
+  `assert.throws = fn` × IIFE with TDZ-referencing inner fn + callback; the 4
+  tests are let/const/using `function-local-closure-{get,set}-before-
+  initialization.js`. Carried inside the allowance with explicit stakeholder
+  sign-off; fix tracked separately.
+
+**Tracker routing (cohort-level, per the ruling):**
+- **#2860** (standalone↔host umbrella, established home of the routed
+  de-masked census): the 3,454 demasked semantic-gap rows (2,328 mismatch +
+  1,016 missing-throw + 45 misc + 33 property-on-null + 32
+  builtin-as-value). Temporal (820 rows) is the proposals-scope subcluster.
+- **#3442/#2865**: 137 async-continuation rows.
+- **#2903/#3390**: 31 promise rows.
+- **#3443**: 4 illegal_cast traps (flatMap/flat/sort poisoned-input callbacks).
+- **#1781**: 7 null_deref traps (module-init + bind/callback dispatch).
+- **#3178** (iterables): no separate standalone cohort — iterable failures
+  surface inside the async-continuation texts routed above.
+- **#3559** (new, filed with this PR): the #2043-class callback cross-fctx
+  capture bug (the 4 CEs) — full root cause + inlined minimal repro in
+  `plan/issues/3559-callback-cross-fctx-capture-local-index.md`; carried
+  inside the allowance with explicit stakeholder sign-off (2026-07-23).
 
 ## PR-shepherd resolution (2026-07-20) — land captured-closure substrate; keep harness rollout blocked
 

--- a/plan/issues/3559-callback-cross-fctx-capture-local-index.md
+++ b/plan/issues/3559-callback-cross-fctx-capture-local-index.md
@@ -1,0 +1,147 @@
+---
+id: 3559
+title: "Nested-lifted-fn call from a method-call-arg callback bakes the DECLARING fctx's local index (invalid Wasm) — #2043-class cross-fctx capture hole in call-identifier.ts"
+status: ready
+created: 2026-07-23
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [3468, 2043, 1177, 2029]
+---
+
+# #3559 — callback cross-fctx capture: `local.get cap.outerLocalIdx` escapes its fctx
+
+## Symptom (measured, merge_group run 30043224652 / PR #3523)
+
+Exactly **4 test262 files** flip pass→`compile_error` under `--target
+standalone` once #3468 F1's keep-arm retains top-level `F.<name> = …` writes:
+
+- `test/language/statements/const/function-local-closure-get-before-initialization.js`
+- `test/language/statements/let/function-local-closure-get-before-initialization.js`
+- `test/language/statements/let/function-local-closure-set-before-initialization.js`
+- `test/language/statements/using/function-local-closure-get-before-initialization.js`
+
+Error: `Binary emit error: RangeError: Codegen error: local index out of range
+— 18 (valid: [0, 2)) at function '__cb_0'` (the #2043 late-import index-shift
+class message, but the mechanism here is a CROSS-FCTX capture, not an import
+shift — see below).
+
+These 4 are carried inside #3468's `regressions-allow` ceiling with explicit
+stakeholder sign-off (2026-07-23); this issue is the routed fix.
+
+## Root cause (fully traced, 2026-07-23)
+
+Two corruptions in the emitted `__cb_0` (the `assert.throws` second-argument
+callback), confirmed via emit-time dump:
+
+```
+;; failing __cb_0 — locals: [__tdz_box_x]; 1 param (captures externref)
+local.get 2          ;; INVALID — this is the DECLARING (IIFE) fctx's local
+                     ;; holding x's ref-cell box, not a cbFctx local
+i32.const 1
+struct.new $cell<i32> ;; fresh TDZ flag box ("treat as initialized")
+local.tee 1          ;; __tdz_box_x (cbFctx-local — this part is correct)
+call 2097330         ;; STABLE_FUNC_BASE+178 — minted but NEVER PUSHED
+drop
+```
+
+**Corruption 1 — the culprit line.** In
+`src/codegen/expressions/call-identifier.ts`, the direct-call path for a
+lifted nested function (`f()` where `f` is a nested hoisted declaration that
+captures outer bindings) prepends f's value captures at the call site. Its
+fallback else-arm is:
+
+```ts
+fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });
+```
+
+`cap.outerLocalIdx` is a local index in the **declaring** function's fctx (the
+IIFE body). When the call site sits in a **different** fctx — here a
+`compileArrowAsCallback`-compiled method-call-argument callback (`cbFctx`) —
+that index is foreign and either out of range (emit error, our case) or
+silently reads the wrong slot.
+
+The existing cross-fctx rescues do NOT cover this route:
+- The **#2029 "family A"** arms rescue only names promoted to
+  `ctx.capturedBoxGlobals` / `ctx.capturedGlobals` by the accessor-capture
+  pass (object-literal accessor bodies). A method-call-arg callback gets no
+  such promotion, so the lookup falls through to the else-arm.
+- The naive fix (`fctx.localMap.get(cap.name) ?? cap.outerLocalIdx`) was
+  **tried as #1177 Stage 1 and REVERTED** — the in-code comment records it
+  caused 100+ test262 regressions where the "wrong-slot" behavior was
+  load-bearing (async-fn-body null-deref-throw tests). Any fix must not
+  reintroduce that.
+
+**Corruption 2 — never-pushed stable handle.** The callee funcIdx baked into
+the call (`2097330 = STABLE_FUNC_BASE + 178`) is a handle that was
+`mintDefinedFunc`-minted but never `pushDefinedFunc`-pushed — the lifted body
+of the nested TDZ-capturing `f` was abandoned on this compile route (a
+speculative-compile rollback that leaves `ctx.funcMap` poisoned, or a lifting
+path that bails after minting). Even with corruption 1 fixed, the call target
+must actually exist; diagnose whether fixing the capture sourcing also fixes
+the lifting bail, or whether the mint-without-push needs its own guard
+(cf. `check:speculative-rollback`).
+
+## Why #3468 F1 exposes it (it is LATENT on main)
+
+The trigger needs a nested TDZ-capturing function called from a
+**method-call-argument callback**. Before F1, `assert.throws = function…` was
+dropped at top level, so the `assert.throws(ReferenceError, function(){ f(); })`
+call site compiled against an undefined member and the callback compiled on a
+path that never prepended f's captures. With F1's keep-arm the statement is
+retained, the harness member exists, and the callback path reaches the
+cross-fctx else-arm. The hole itself predates F1 — any other route that calls
+a TDZ-capturing nested fn from a callback fctx hits the same line.
+
+## Minimal repro (standalone; CE on the F1 branch, OK without the keep-arm)
+
+```ts
+import { compile } from "../src/index.ts";
+const src = `
+function Test262Error(m){ this.message = m; }
+function assert(b, m){ if (b !== true) throw new Test262Error(m); }
+assert.throws = function(err, cb){ try { cb(); } catch(e){ return; } throw new Test262Error("no throw"); };
+(function() {
+  function f() { return x + 1; }
+  assert.throws(ReferenceError, function() { f(); });
+  const x = 1;
+}());
+`;
+const r = await compile(src, { target: "standalone", allowJs: true, fileName: "m.ts", skipSemanticDiagnostics: true });
+// r.success === false; errors: "local index out of range … at '__cb_0'"
+```
+
+Shrink results (each single removal makes it compile): remove the TDZ (`const
+x` after use) → OK; unwrap the IIFE → OK; make `assert.throws` a plain
+function `assertThrows(…)` (no property carrier) → OK.
+
+## Fix directions (in preference order)
+
+1. **Extend the #2029 promotion to the callback route**: when
+   `compileArrowAsCallback` compiles a body whose call graph reaches a nested
+   lifted fn with captures not sourceable in cbFctx, promote those captures to
+   the shared box-global mechanism (`ctx.capturedBoxGlobals`) exactly as the
+   accessor-capture pass does. Preserves the #1177-revert constraint (owner-
+   fctx behavior unchanged; the promotion arms are already localMap-absence-
+   guarded).
+2. **Refuse loudly instead of emitting garbage**: if promotion is infeasible,
+   the else-arm must detect `cap.outerLocalIdx` ∉ current fctx and fail the
+   compile with a diagnostic (or reject the callback path so the arg lowers
+   via the closure path) — a correct CE beats invalid Wasm, and the closure
+   path may simply work.
+3. Whatever the fix, add the 4 test262 files as a vitest guard and re-shrink
+   #3468's `regressions-allow` accounting in the next measurement window.
+
+## Verification plan
+
+- The minimal repro compiles and instantiates; `assert.throws(ReferenceError,
+  …)` fires correctly (the TDZ read throws).
+- The 4 test262 files flip compile_error→pass (or at minimum →honest fail).
+- No regressions in: `tests/issue-1712-capture-closure-dispatch.test.ts`,
+  `tests/illegal-cast-closures-585.test.ts` (pre-existing local failures
+  noted in #3468 — control against origin/main), the #1177/#2029 test
+  families, and the async-fn null-deref tests the #1177 revert protected.

--- a/src/codegen/closure-props.ts
+++ b/src/codegen/closure-props.ts
@@ -13,17 +13,25 @@
  * properties) never invokes anything under standalone — assertions become
  * vacuous passes (#3468 root cause).
  *
- * ## The fix (Approach C-core)
+ * ## The fix (Approach C-core + F1 full-closure rollout)
  * Keep closures as-is and give those three dead arms a fallback: a runtime,
- * closure-identity-keyed side table mapping each property-carrying CAPTURING
- * closure to a fresh `$Object` "bag" that holds its own properties. The initial
- * mergeable slice deliberately excludes shared noncapturing wrapper structs:
- * current-main's test262 harness reaches the dynamic path with noncapturing
- * `assert` functions, and enabling those truthfully de-masks thousands of
- * pre-existing semantic failures. Capturing closure structs have distinct
- * subtype identities, so this is a principled runtime boundary rather than a
- * harness-name exception. The bag reuses the existing `$Object` prop machinery
- * (`__new_plain_object` + `__extern_get`/`__extern_set`).
+ * closure-identity-keyed side table mapping each property-carrying closure to a
+ * fresh `$Object` "bag" that holds its own properties. The bag reuses the
+ * existing `$Object` prop machinery (`__new_plain_object` + `__extern_get`/
+ * `__extern_set`), so reads/writes/method-calls on a function value work exactly
+ * as they do on a plain object.
+ *
+ * (#3468 F1, 2026-07-23 stakeholder ruling) The carrier set covers ALL closure
+ * wrapper structs — including shared noncapturing wrappers, i.e. the test262
+ * `function assert(){}` harness receiver. The first merged slice (#3418) had
+ * deliberately narrowed carriers to capturing subtypes because enabling the
+ * harness truthfully de-masks pre-existing semantic failures (assertions start
+ * FIRING instead of vacuous-passing). The stakeholder ruled to land the honest
+ * de-inflation: widen the carriers, measure the exposed failures from the
+ * merge-group run, route them to trackers by cluster, and re-baseline the
+ * standalone floor DOWN to the truthful number. Identity keying stays correct
+ * for noncapturing declarations: each top-level function's wrapper struct is
+ * instantiated once and reused by reference, so `ref.eq` identity holds.
  *
  * The table is a singly-linked list of `$ClosurePropEntry { next; key; bag }`
  * rooted at the module global `$__closure_prop_head`. Append = prepend (O(1));
@@ -35,8 +43,8 @@
  * function's own funcIdx is NOT in `funcMap` while its body is being built
  * (`registerNative` mints at registration time, after the body array is
  * constructed) — and `__is_closure_prop_carrier`'s `ref.test` chain needs the
- * COMPLETE captured-closure subtype set, which is only known at FINALIZE. So,
- * exactly like `reserveApplyClosure`/
+ * COMPLETE closure base-wrapper type set, which is only known at FINALIZE
+ * (`collectClosureBaseWrapperTypeIdxs`). So, exactly like `reserveApplyClosure`/
  * `fillApplyClosure` (#1888) and the accessor drivers (#1719): reserve the five
  * helper funcIdxs with `unreachable` stubs at object-runtime-emit time (so the
  * `__extern_*` arms bake a stable `call <idx>`), then fill the real bodies in
@@ -57,6 +65,7 @@
  */
 import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
 import { undefinedExternInstrs } from "./any-helpers.js";
+import { collectClosureBaseWrapperTypeIdxs } from "./closure-classifier.js";
 import type { CodegenContext } from "./context/types.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { addFuncType } from "./registry/types.js";
@@ -235,20 +244,16 @@ export function fillClosurePropHelpers(ctx: CodegenContext): void {
   const getMiss = (): Instr[] => undefinedExternInstrs(ctx) ?? [{ op: "ref.null.extern" }];
 
   // ── __is_closure_prop_carrier(externref value) -> i32 ──
-  // Match only concrete CAPTURING closure structs: they are subtypes with
-  // capture fields beyond the wrapper's field-0 funcref. Do not test the shared
-  // root wrappers here — a root test would also accept every noncapturing
-  // top-level harness function and recreate the measured #3418 floor breach.
-  // Constant 0 when the module has no capturing closures.
+  // (#3468 F1) ref.test chain over the closure BASE-wrapper types (same set as
+  // `__is_closure`/`__typeof_function` via `collectClosureBaseWrapperTypeIdxs`);
+  // a base-root test also matches every capturing subtype instance, so this
+  // subsumes the previously narrowed capturing-only carrier set. This is the
+  // stakeholder-ruled widening that lets shared noncapturing wrappers — the
+  // test262 `assert` harness receiver — carry own properties, which makes the
+  // harness assertions FIRE (honest floor de-inflation; see the issue file).
+  // Constant 0 when the module has no closures.
   {
-    const carrierTypeIdxs: number[] = [];
-    for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
-      if (!info?.hasCaptures) continue;
-      const typeDef = ctx.mod.types[typeIdx];
-      if (typeDef?.kind === "struct") {
-        carrierTypeIdxs.push(typeIdx);
-      }
-    }
+    const carrierTypeIdxs = collectClosureBaseWrapperTypeIdxs(ctx);
     const body: Instr[] = [
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -115,6 +115,31 @@ import {
  * No-op when every slot classifies as `"other"` so non-TypedArray modules
  * accumulate no metadata.
  */
+/**
+ * (#3468 F1) Builtin/special function-value member names that must KEEP their
+ * existing (dropped, no-op) standalone lowering when written at top level on a
+ * function declaration — never re-route them into the closure-own-property side
+ * table (which would shadow the builtin). `.prototype` IS excluded here:
+ * `.prototype` is owned end-to-end by the #2660 S2/S3 fnctor machinery — for a
+ * RECONSTRUCT-classified fnctor the S2 keep-arm `continue`s before this one, and
+ * for a non-reconstruct fnctor S2 deliberately declines (the scoped gate that
+ * fixed the species-`Ctor.prototype`-identity ejection). Routing that declined
+ * write into the side-table bag instead would give `F.prototype` a SECOND,
+ * S3-invisible storage with divergent identity — so it keeps its existing
+ * dropped lowering (guarded by issue-2660-s2's "S2 off" test).
+ */
+const STANDALONE_FN_STATIC_KEEP_EXCLUDED = new Set([
+  "name",
+  "length",
+  "call",
+  "apply",
+  "bind",
+  "constructor",
+  "prototype",
+  "caller",
+  "arguments",
+]);
+
 function recordExportSignature(
   ctx: CodegenContext,
   exportName: string,
@@ -1579,6 +1604,48 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         if (ctx.standalone && isFnctorPrototypeAssignTarget(ctx, expr.left)) {
           ctx.moduleInitStatements.push(stmt);
           continue;
+        }
+        // (#3468 F1) STANDALONE counterpart of the #2671 keep below (which is
+        // gated `!ctx.standalone`): a top-level `F.<name> = …` static property
+        // write on a top-level FUNCTION DECLARATION — the test262 assert-harness
+        // shape (`assert.sameValue = function(){…}`, `assert._isSameValue = …`).
+        // `F` is a function, not a module global, so the generic root-identifier
+        // check below dropped the statement from `__module_init` under
+        // standalone: the own property silently never existed, so
+        // `assert.sameValue(1,2)` invoked `undefined` and every assertion was a
+        // VACUOUS PASS (#3468 root cause). The SAME write already worked from
+        // inside a function body — only the top-level collection dropped it —
+        // and the #3468 closure-own-property side table makes the ordinary
+        // `__extern_set` write-arm store it on the function value. Keep it in
+        // `__module_init` so that arm runs. Scoped exactly like the #2671 host
+        // arm: DIRECT bare-identifier receiver only (`F.prototype.m = …` chains
+        // stay excluded — non-identifier receiver); `.prototype` is already kept
+        // by the #2660 S2 arm above. Host/GC is untouched (that lane uses the
+        // `!ctx.standalone` arm below), so it stays byte-identical.
+        if (
+          ctx.standalone &&
+          ts.isPropertyAccessExpression(expr.left) &&
+          !ts.isPrivateIdentifier(expr.left.name) &&
+          // Non-builtin, non-special property names only. `.prototype` is
+          // already kept by the #2660 S2 arm above (it `continue`d), so it never
+          // reaches here; the rest are builtin function metadata/methods whose
+          // top-level write keeps its existing (dropped, no-op) lowering to
+          // avoid shadowing the builtin.
+          !STANDALONE_FN_STATIC_KEEP_EXCLUDED.has(expr.left.name.text)
+        ) {
+          let sReceiver: ts.Expression = expr.left.expression;
+          while (
+            ts.isParenthesizedExpression(sReceiver) ||
+            ts.isAsExpression(sReceiver) ||
+            ts.isNonNullExpression(sReceiver) ||
+            ts.isTypeAssertionExpression(sReceiver)
+          ) {
+            sReceiver = sReceiver.expression;
+          }
+          if (ts.isIdentifier(sReceiver) && ctx.topLevelFunctionNames.has(sReceiver.text)) {
+            ctx.moduleInitStatements.push(stmt);
+            continue;
+          }
         }
         // (#2671) `F.<prop> = …` — a STATIC property write on a top-level
         // FUNCTION DECLARATION (`Test262Error.thrower = function () {…}`, the

--- a/tests/issue-3468-closure-own-props.test.ts
+++ b/tests/issue-3468-closure-own-props.test.ts
@@ -15,14 +15,28 @@
  * `$Object` "bag" reached by `ref.eq` on the closure identity, reusing the
  * existing `$Object` prop machinery.
  *
- * This PR deliberately lands the first runtime slice for CAPTURING closures,
- * verified through the DYNAMIC member path (a receiver via an `any`-typed
- * local). Capturing closures have their own concrete struct subtypes, so the
- * runtime can enable them without also enabling shared noncapturing wrappers.
- * Routing the noncapturing top-level test262 `function assert(){}` harness into
- * the substrate is a separate rollout: its merge-group measurement correctly
- * exposed thousands of pre-existing assertion failures and cannot land without
- * fixing those semantics or an explicitly approved oracle transition.
+ * ## Two parts (#3468 F1 — the full rollout, per the 2026-07-23 stakeholder ruling)
+ * 1. **Runtime substrate** — the closure-own-property side table, reached via
+ *    the DYNAMIC member path (`__extern_set`/`__extern_get`/
+ *    `__extern_method_call` → the closure arms). The carrier classifier now
+ *    covers ALL closure wrapper structs (base-wrapper `ref.test` chain), not
+ *    just capturing subtypes — shared noncapturing wrappers (the harness
+ *    receiver shape) carry own properties too.
+ * 2. **Top-level front-end routing** — a `F.<name> = …` write on a top-level
+ *    FUNCTION DECLARATION (the test262 `assert.sameValue = function(){…}`
+ *    shape) was DROPPED under standalone: the #2671 keep that retains such
+ *    statements in `__module_init` was gated `!ctx.standalone`. So
+ *    `assert.sameValue` never stored and `assert.sameValue(1,2)` invoked
+ *    `undefined` → every assertion was a VACUOUS PASS. A standalone counterpart
+ *    keep (declarations.ts) retains the statement so the ordinary write-arm
+ *    records it in the side table. Reads and calls on a function receiver
+ *    already routed dynamically. Exclusions: `.name`/`.length`/`.call`/
+ *    `.apply`/`.bind`/`.prototype`/`.constructor`, class statics, non-identifier
+ *    receivers. gc/host is untouched (byte-identical).
+ *
+ * The harness assertions FIRING (instead of vacuous-passing) is the designed,
+ * stakeholder-ruled floor de-inflation — the exposed failures are measured from
+ * the merge-group run and routed to trackers; see the issue file.
  */
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
@@ -132,7 +146,9 @@ describe("#3468 C-core — closure own-property side table (dynamic path, verifi
     expect(ret).toBe(0);
   });
 
-  it("leaves shared noncapturing wrapper structs outside this rollout", async () => {
+  it("includes shared noncapturing wrapper structs in the rollout (#3468 F1)", async () => {
+    // Flipped from the #3418 negative control: the F1 widening makes ALL
+    // closure wrappers carriers, so a noncapturing arrow round-trips too.
     const { ret } = await runStandalone(`
       export function test() {
         const fn = () => 1;
@@ -141,6 +157,75 @@ describe("#3468 C-core — closure own-property side table (dynamic path, verifi
         return (g as any).mine === 99 ? 1 : 0;
       }
     `);
-    expect(ret).toBe(0);
+    expect(ret).toBe(1);
+  });
+});
+
+describe("#3468 F1 — top-level function-declaration property write (front-end routing)", () => {
+  it("stores + reads back a top-level `F.p = v` write on a function declaration", async () => {
+    const { ret } = await runStandalone(`
+      function memo(){}
+      memo.cache = 5;
+      export function test(): number { return memo.cache; }
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("invokes a method assigned at top level on a function declaration", async () => {
+    const { ret } = await runStandalone(`
+      function assert(){}
+      assert.sv = function (a) { return a + 1; };
+      export function test(): number { return assert.sv(41); }
+    `);
+    expect(ret).toBe(42);
+  });
+});
+
+// The test262 `assert` harness — bare function-DECLARATION member ops at top
+// level, the exact shape whose vacuous passes motivated #3468. This is the
+// REGRESSION GUARD for the F1 de-inflation: these assertions must FIRE.
+describe("#3468 F1 — assert harness fires (vacuous passes correctly fail)", () => {
+  const HARNESS = `
+    function Test262Error(message) { this.message = message; }
+    function assert(mustBeTrue, message) { if (mustBeTrue === true) { return; } throw new Test262Error(message); }
+    assert._isSameValue = function (a, b) { if (a === b) { return a !== 0 || 1 / a === 1 / b; } return a !== a && b !== b; };
+    assert.sameValue = function (actual, expected, message) { if (assert._isSameValue(actual, expected)) { return; } throw new Test262Error(message); };
+  `;
+
+  it("assert.sameValue(1, 2) throws (correcting a vacuous pass)", async () => {
+    const { threw } = await runStandalone(HARNESS + `assert.sameValue(1, 2, "m");`);
+    expect(threw).toBe(true);
+  });
+
+  it("assert.sameValue(2, 2) does not throw (control)", async () => {
+    const { threw } = await runStandalone(HARNESS + `assert.sameValue(2, 2);`);
+    expect(threw).toBe(false);
+  });
+
+  it("assert.throws(TypeError, () => {}) throws when the callback does not", async () => {
+    const src =
+      HARNESS +
+      `assert.throws = function(errType, fn){ try { fn(); } catch(e){ return; } throw new Test262Error("no throw"); };
+       assert.throws(TypeError, function(){});`;
+    const { threw } = await runStandalone(src);
+    expect(threw).toBe(true);
+  });
+});
+
+describe("#3468 F1 — routing exclusions (no unintended regressions)", () => {
+  it("does not affect a class static method call (class is not a function declaration)", async () => {
+    const { ret } = await runStandalone(`
+      class C { static m(){ return 42; } }
+      export function test(): number { return C.m(); }
+    `);
+    expect(ret).toBe(42);
+  });
+
+  it("leaves fn.call / fn.apply working", async () => {
+    const { ret } = await runStandalone(`
+      function add(a, b){ return a + b; }
+      export function test(): number { return add.call(null, 3, 4) + add.apply(null, [10, 20]); }
+    `);
+    expect(ret).toBe(37);
   });
 });

--- a/tests/test262-oracle-version.ts
+++ b/tests/test262-oracle-version.ts
@@ -31,7 +31,7 @@
  * version or a date. Two runs with the same ORACLE_VERSION are guaranteed to
  * apply identical verdict logic, so their rows are directly comparable.
  */
-export const ORACLE_VERSION = 9;
+export const ORACLE_VERSION = 10;
 
 /**
  * Append-only log of what each oracle version means. Newest last.
@@ -205,6 +205,31 @@ export const ORACLE_VERSION_HISTORY: ReadonlyArray<{ version: number; note: stri
       "that loader policy, including conventional absent targets which evaluation " +
       "must never reach. Rows whose missing fixtures manufactured passes are " +
       "intentionally reclassified and require an ORACLE_REBASE baseline refresh.",
+  },
+  {
+    version: 10,
+    note:
+      "#3468 F1 standalone assert-harness de-inflation (stakeholder-ruled " +
+      "2026-07-23). The standalone lane's test262 assert harness was a vacuous " +
+      "no-op: function objects could not carry own properties, so " +
+      "assert.sameValue/assert.throws resolved to undefined and every " +
+      "assertion silently passed. F1 (closure-own-property carrier widening + " +
+      "the top-level F.<name>= keep-arm) makes assertions FIRE — what a " +
+      "standalone 'pass' MEANS changes: measured on merge_group run " +
+      "30043224652, 3,637 vacuous passes become honest fails (3,545 " +
+      "assertion-time throws, 97.5%), 18 improvements, honest host-free floor " +
+      "27,557/48,088. Like v4/#3285 these flips compile INTO the wasm " +
+      "(wasm-CHANGE regressions), so the re-baseline lands via the bump + a " +
+      "#3303 regressions-allow ceiling declared in the #3468 issue file. " +
+      "ALSO in v10 (label-only, same bump — the exact v4 pattern): " +
+      "classifyError now bins `^Test262Error`-prefixed messages as " +
+      "assertion_fail BEFORE the trap regexes — newly-firing assertion text " +
+      "quoting the test's own words ('following shrink (out of bounds) " +
+      "Expected …') was matching /out of bounds/ and false-positive-tripping " +
+      "the #3189 trap ratchet (6 false NEW-oob rows on the F1 run; the same " +
+      "Temporal/Duration/…/result-out-of-range-1.js file the v4 fix caught " +
+      "for the 'returned N' shape). No pass/fail flips from the relabel; " +
+      "promote-baseline re-seeds host+standalone baselines at v10 on merge.",
   },
 ];
 

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -5064,6 +5064,23 @@ export function classifyError(errorMsg: string | undefined): string | undefined 
   if (/^returned -1\b/.test(errorMsg)) return "exception_in_test";
   if (/^returned \d+/.test(errorMsg)) return "assertion_fail";
 
+  // (#3468 F1) A message beginning with "Test262Error" is by construction a
+  // rendered ASSERTION THROW (the #2962 standalone exception renderer prefixes
+  // the constructor name), never a genuine Wasm trap: a real trap aborts the
+  // module with a host RuntimeError message ("out of bounds memory access",
+  // "unreachable" …) that carries no Test262Error prefix. This rule must sit
+  // BEFORE the trap regexes for exactly the #3285 reason above — assertion
+  // TEXT quoting the test's own words ("following shrink (out of bounds)
+  // Expected SameValue(«8», «0»)…") was matching /out of bounds/ etc. and
+  // mis-binning honest assertion fails as uncatchable traps, false-positive-
+  // tripping the #3189 trap ratchet (seen live on the F1 merge_group run
+  // 30043224652: 6 Test262Error rows counted as NEW oob — including
+  // Temporal/Duration/…/result-out-of-range-1.js, the SAME file the v4 fix
+  // caught for the "returned N" shape; measured baseline also carries 3 such
+  // false "unreachable" rows). Label-only relabel (no pass/fail flips) —
+  // covered by the same ORACLE_VERSION 10 bump as the #3468 F1 de-inflation.
+  if (/^Test262Error\b/.test(errorMsg)) return "assertion_fail";
+
   // Wasm traps
   if (/dereferencing a null/i.test(errorMsg)) return "null_deref";
   if (/illegal cast/i.test(errorMsg)) return "illegal_cast";
@@ -5080,13 +5097,9 @@ export function classifyError(errorMsg: string | undefined): string | undefined 
 
   // (Assertion "returned N" patterns are classified at the TOP of this
   // function — before the trap regexes — see the #3285 comment there.)
-  // (#2962) A thrown Test262Error IS an assertion failure by definition. The
-  // standalone exception renderer (#2962) surfaces these as
-  // "Test262Error: <assert text>" — before it, such failures were the opaque
-  // #2870 label and fell to "other". Host-lane records are unaffected: there
-  // the payload is a real JS Error and the recorded message is `.message`
-  // WITHOUT the constructor-name prefix.
-  if (/^Test262Error\b/.test(errorMsg)) return "assertion_fail";
+  // (#2962/#3468 F1) The `^Test262Error` → assertion_fail rule moved to the
+  // TOP of this function, before the trap regexes — see the #3468 comment
+  // there (assertion text quoting trap words was stealing the row).
 
   // Wasm compile/validation errors (from instantiation). (#3187) Order matters:
   // classify GENUINE invalid-Wasm FIRST so an instantiation error that quotes


### PR DESCRIPTION
## #3468 F1 — standalone assert-harness routing + HONEST floor de-inflation

**This PR lands under an explicit STAKEHOLDER RULING (2026-07-23, recorded in
`plan/issues/3468-standalone-method-dispatch-exception-swallow.md`).** It is
EXPECTED to auto-park in the merge_group on the standalone floor gates — that
park is the DESIGNED measurement signal, not an unjustified regression. Do not
treat the park as a reason to close/reject; the resolution protocol is below.

### What it does

Makes the test262 `assert` harness actually FIRE under `--target standalone`
instead of vacuous-passing. The captured-closure C-core substrate landed in
#3418; this PR adds the missing routing (both restored from the pre-narrowing
`81b02624a` state, re-applied — not a straight revert — because the
`hasCaptures` metadata has since gained an IR-lane consumer):

1. **Carrier widening** (`src/codegen/closure-props.ts`):
   `__is_closure_prop_carrier` now `ref.test`s the full closure BASE-wrapper
   set (`collectClosureBaseWrapperTypeIdxs` — the same classifier as
   `__is_closure`/`__typeof_function`), which subsumes the #3418
   capturing-only set and admits shared noncapturing wrappers — the
   `function assert(){}` harness receiver.
2. **Front-end routing** (`src/codegen/declarations.ts`): restores the
   standalone top-level `F.<name> = …` keep-arm so
   `assert.sameValue = function(){…}` stays in `__module_init` and reaches the
   `__extern_set` write-arm → side table. Exclusions preserved: `.name` /
   `.length` / `.call` / `.apply` / `.bind` / `.constructor` / `.caller` /
   `.arguments` — and, deviating from the pre-narrowing original,
   **`.prototype`** (it is owned end-to-end by the #2660 S2/S3 fnctor
   machinery, which has gained the RECONSTRUCT-gate since; routing an
   S2-declined prototype write into the bag creates a second, S3-invisible
   storage — caught by `issue-2660-s2`'s "S2 off" guard, verified locally).

### Regression guards (in `tests/issue-3468-closure-own-props.test.ts`)

- `assert.sameValue(1, 2)` **THROWS** under standalone (vacuous pass corrected)
- `assert.throws(TypeError, () => {})` **THROWS** under standalone
- controls: `assert.sameValue(2,2)` does not throw; class statics and
  `fn.call`/`fn.apply` unaffected; noncapturing wrapper round-trip now positive.

### Measured local verification

- 14/14 `issue-3468-closure-own-props`; 82/82 across the 8 adjacent suites
  (`issue-3418`, `issue-3536`, `issue-3537`, `issue-3472`, `issue-2660-s2`,
  `issue-1896-typeof-closure`, `issue-2671-promise-capability`).
- Wider sweep found 8 failures in 3 suites (`illegal-cast-closures-585`,
  `issue-1712-capture-closure-dispatch`, one `issue-2660-s3` guard) — a control
  run with `src/` flipped to `origin/main` fails IDENTICALLY (8/8): they are
  pre-existing local-env failures, not from this PR.
- **Host/GC byte-neutrality measured**: probe module compiles to sha256
  `5804530e…` (4,529 bytes) on BOTH this branch and `origin/main` in host mode;
  only standalone output changes.
- typecheck, prettier, biome, loc-budget (granted via issue frontmatter),
  oracle-ratchet (+0), pushraw (+0), godfiles, stack-balance, dead-exports: OK.

### The de-inflation plan (why the merge_group park is expected)

The standalone floor gates are merge_group-only. This PR makes ~thousands of
previously vacuous-passing should-FAIL tests correctly FAIL, so the floor
(committed high-water `benchmarks/results/test262-standalone-highwater.json`,
currently 25,453, tolerance 50) will trip and auto-park the PR. Per the ruling:

1. The park's regressed-test delta is the **measured honest floor number**
   (NEVER the stale 3,608 from 2026-07-20 — F2/F3/#3501/#3536/#3537 have since
   changed exactly that failure surface).
2. The exposed failures get routed to trackers **by signature cluster**
   (#3178 iterables, #3442/#2865 async continuation, #1781 module-init throw,
   #3443 illegal_cast, #2903/#3390 promise; new issues only for genuinely
   unowned clusters) — this routing is the non-negotiable condition that makes
   this truthful de-inflation, not hiding.
3. The high-water JSON is then re-seeded DOWN to the measured number in this
   PR (in-tree edit; the `--update` path only ratchets up), with the number +
   justification recorded here and in #3468.
4. Re-enqueue happens exactly ONCE, after tech-lead confirmation that the
   queue is clear (#3519/#3520 have landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ
