### PR TITLE
feat(#2906 3c-ii-a): return-through-finally + sibling try/catch regions

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -18,6 +18,8 @@ architect_spec: authored
 loc-budget-allow:
   - src/codegen/async-cps.ts
   - src/codegen/async-frame.ts
+  - src/codegen/context/types.ts
+  - src/codegen/statements/control-flow.ts
 ---
 
 # Generalize the async drive layer to a multi-state CFG-aware CPS resume machine
@@ -1110,3 +1112,49 @@ standalone probes match spec (catch entered with the reason bound: 42/45/50/
   sequential try/catches) need the producer to admit >1 region first.
 - The D4 sync-generator convergence (#2864) waits on 3c-ii/iii per the
   alignment decision there.
+
+## Slice 3c-ii-a — return-through-finally + sibling regions (LANDED, 2026-07-23, fable dev-laneB, stacked on 3c-i)
+
+**Scope shipped (native drive lane):**
+
+- **return-through-finally** — `return v` inside `try { …await… } finally { F }`
+  was a `planLinearAwaits` reject (→ AG0; measured: the value never surfaced,
+  the .then-consumer control also exposed that a `.catch/.then` CHAIN on a
+  driven promise is a separate pre-existing gap — probe consumers must await).
+  Landed WITHOUT the full finallyState machinery: the await-free finalizer
+  (the Gap-3 invariant) is REPLAYED by the return hook — `asyncDriveReturn`
+  gains `pendingFinalizer`/`handlerLocal`, armed per-lead by `buildStateBody`
+  from the lead's region id; the hook evaluates the operand FIRST (§14.15.3),
+  resets the region local (a throw in the finally must not re-enter the
+  region), replays, then settles. `pendingFinalizer` clears during the replay
+  so a `return` inside the finally settles directly (its completion
+  overrides). Admission is native-gated end-to-end: `LowerState.
+  allowReturnInTry` → `planLinearAwaits(fn, plan, opts)` (default reject —
+  every host-lane caller byte-identical) → set by `asyncFnNeedsDrive`,
+  `planAsyncCfg` (`AsyncCfgOptions.allowReturnInTry = !info.host`) and
+  `computeAsyncSpills` (from `buildAsyncFrameInfo`'s `hostImports ===
+  undefined`) so gate, producer, and spill computation see the SAME plan.
+  Deferred within this lane: `return await P` inside the try (the L653 bail
+  stays — its settle is a TERMINATOR, needs the same replay before settleSent).
+- **Sibling try/catch regions** — the 3c producer generalizes to ANY number of
+  sequential top-level try/catches: `analyzeTryCatchAsync` walks
+  `[chunk, try/catch]* chunk` groups, `planTryCatchCfg` rebuilt as a running
+  state-counter builder (invariant: after each group's catch chain,
+  `states.length === join`), one handler region per group (dense ids, own
+  `catchState`; catch params DEDUPED across regions — never live
+  simultaneously, they share one externref slot). The routed dispatcher's
+  id-equality route needed NO change. A mid-sequence `return await` in a
+  non-last try keeps the conservative bail.
+
+**Measured:** 6 new tests (20/20 total in `tests/issue-2906-3c-trycatch.test.ts`):
+return-through-finally with the finalizer observed BEFORE settle (1105),
+conditional return (finalizer exactly once, 1077), normal (104) + throw (100)
+paths unchanged, sibling both-reject (11) and fulfil+reject (142). Byte
+matrix: all 8 control programs (incl. the 3c-i try/catch shape) byte-identical
+to the 3c-i base across 3 lanes. Async corpus re-run: 89+36 passing, failures
+identical to the pre-existing main set.
+
+**Remaining after 3c-ii-a:** try/catch/finally combined regions +
+`return await`-in-try (3c-ii-b, needs the replay on the settleSent terminator
+or the full finallyState machinery); nested regions (3c-iii). D4 (#2864)
+still waits on those.

--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -729,13 +729,13 @@ measured contract and a de-risked slice plan, mirroring the 3b banking.
 `async function* g(){ yield await Promise.resolve(1); yield 2 }` consumed by
 `for await (const x of g())`, compiled three ways:
 
-| target             | result                                                                                                                                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **wasi**           | **compile FAILS** — `function-body.ts:1016` gate: *"native generator lowering currently supports only sequential numeric yields in standalone/WASI targets (#680)."*        |
-| **standalone**     | **compile FAILS** — same #680 gate.                                                                                                                                        |
-| **gc (JS host)**   | compiles, but imports `__create_async_generator`, `__gen_create_buffer`, `__gen_push_f64`, `__gen_push_ref`, `__async_iterator`, `__iterator_next`, `Promise_resolve`, … — **host-backed, not host-free.** |
+| target           | result                                                                                                                                                                                                     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **wasi**         | **compile FAILS** — `function-body.ts:1016` gate: _"native generator lowering currently supports only sequential numeric yields in standalone/WASI targets (#680)."_                                       |
+| **standalone**   | **compile FAILS** — same #680 gate.                                                                                                                                                                        |
+| **gc (JS host)** | compiles, but imports `__create_async_generator`, `__gen_create_buffer`, `__gen_push_f64`, `__gen_push_ref`, `__async_iterator`, `__iterator_next`, `Promise_resolve`, … — **host-backed, not host-free.** |
 
-Even a *plain-numeric* `async function*(){ yield 1; yield 2 }` fails in wasi: an
+Even a _plain-numeric_ `async function*(){ yield 1; yield 2 }` fails in wasi: an
 `async function*` routes through the generator-buffer path
 (`function-body.ts` `isGenerator` branch, ~L1012), whose standalone arm is the
 #680 numeric-only native-generator lowering + the `__create_async_generator`
@@ -747,24 +747,24 @@ comment at `function-body.ts:1087`).
 ### Why "planner-only `settleYield` + queue" is wrong (three missing substrates)
 
 1. **No host-free async-gen PRODUCER object.** The drive machine
-   (`emitAsyncFrameStateMachine`) drives an async *function* to completion,
+   (`emitAsyncFrameStateMachine`) drives an async _function_ to completion,
    settling **one** `result_promise`, and returns that promise. An async
-   *generator* is **called → returns an async-iterator object** (not a promise,
+   _generator_ is **called → returns an async-iterator object** (not a promise,
    not driven to completion), whose `next(v)` allocates a **fresh** pending
-   promise, drives the frame to the next `yield`, and settles *that* promise with
+   promise, drives the frame to the next `yield`, and settles _that_ promise with
    `{value, done:false}`. There is no such object host-free: even **sync**
    generator objects are built by the **host** import `__create_generator`
-   (host-free sync generators only work when for-of drives the resume *inline* via
+   (host-free sync generators only work when for-of drives the resume _inline_ via
    `emitNativeGeneratorToVec` — there is no escaping object). So a host-free
    async-gen object is strictly harder than a host-free sync-gen object, which
-   itself does not exist. `settleYield` needs *a promise to settle that a
-   re-entrant `next()` created* — that `next()` is the missing piece.
+   itself does not exist. `settleYield` needs _a promise to settle that a
+   re-entrant `next()` created_ — that `next()` is the missing piece.
 
 2. **No async-iterator for-await CONSUMER.** The 3b carrier drives a **sync**
-   `__iterator` over a **boxed array** and `await`s each *element*
+   `__iterator` over a **boxed array** and `await`s each _element_
    (`Await(value)`); `it.next()` is synchronous `(done, value)`. Consuming an
    async generator is a **different** protocol: `p = it.next()` returns a
-   **Promise**, you `await p` (suspend on the *next()-promise*), then read
+   **Promise**, you `await p` (suspend on the _next()-promise_), then read
    `done`/`value` from the resolved `IteratorResult`. `forAwaitNeedsDrive` gates
    on `oracle.elementFactOf(source)` being a boxed **array** element — `g()`
    (a call returning an AsyncGenerator) is not an array, so for-await over an
@@ -772,7 +772,7 @@ comment at `function-body.ts:1087`).
    promise, read IteratorResult fields via emit hooks) is required — a sibling of
    `planForAwaitCfg`, not a tweak to it.
 
-3. **The #680 routing gate.** `async function*` must be *intercepted before* the
+3. **The #680 routing gate.** `async function*` must be _intercepted before_ the
    generator-buffer branch and routed to a new host-free async-gen emitter
    (`function-body.ts` `isGenerator` arm, gated like 3b's
    `isStandalonePromiseActive`), or it errors out before any of the above runs.
@@ -791,14 +791,14 @@ the **current-next()-promise** slot (mutable — `next()` overwrites it per call
     added to `AsyncCfgTerminator` (async-cps.ts) + `validateAsyncCfg`
     (async-frame.ts). Emitter: build `IteratorResult{value, done:0}`, `fulfill`
     the frame's current `result_promise` with it, `STATE = resumeState`, spill,
-    `return`. (Do NOT ship it dead — land it *with* its producer + a test that
+    `return`. (Do NOT ship it dead — land it _with_ its producer + a test that
     exercises it, per the #2367 graveyard rule; slice-3 only shipped goto/condGoto
     unreachable because 3a exercised them in the same effort.)
   - **New planner** `planAsyncGenCfg(fn, plan)`: number a mixed `yield`/`await`
     body into states — each `await e` → `suspend` (resume writes SENT), each
     `yield e` → `settleYield` (resume-on-next), body completion →
     `settleDone` (a `settleUndefined` sibling that settles `{value:ret,
-    done:1}`). Bounded first shape: linear body, identifier bindings, the same
+done:1}`). Bounded first shape: linear body, identifier bindings, the same
     spill-safe-type gate as slice 1/3a.
   - **New call-site** `emitAsyncGenerator`: build the frame parked at STATE=0
     **without** kicking resume; return a native async-gen **carrier** (the frame
@@ -817,13 +817,13 @@ the **current-next()-promise** slot (mutable — `next()` overwrites it per call
     delivers `1` then `2` then `done`, `imports [] `. This proves suspend+settle
     without needing the consumer slice. Inject-throw probes on the
     suspend/settle arms (a rejected awaited promise inside the gen must reject the
-    *current* next()-promise).
+    _current_ next()-promise).
 - **3d-ii — async-iterator for-await CONSUMER.** `planForAwaitAsyncCfg` sibling of
   `planForAwaitCfg`: `it = source` (the async gen IS its own async iterator);
   head emits `p = <per-gen next>(it)`; `suspend(await p)`; resume reads
   `res.done`/`res.value` from the awaited `IteratorResult` via emit hooks;
   back-edge `goto(head)`. Gate for-await on an async-iterator source
-  (`oracle` async-iterable fact). This is what makes the *task's* headline proof —
+  (`oracle` async-iterable fact). This is what makes the _task's_ headline proof —
   `for await (const x of g())` → `[1,2]`, imports `[]` — pass end-to-end.
 - **3d-iii — edges (bank):** `return()`/`throw()` on the async gen; `yield*`
   (async delegation); yielded-thenable adoption (`yield await` vs `yield P` —
@@ -859,7 +859,7 @@ on the drain**. Previously this hit the #680 native-generator gate
 
 - **`async-cps.ts`** — `planAsyncGenCfg(fn)` + `isBoundedAsyncGenBody(fn)`. Two
   new `AsyncCfgTerminator` kinds: **`settleYield`** (`{value|fromSent,
-  resumeState}`) fulfils the current `next()`-promise `{value, done:false}` and
+resumeState}`) fulfils the current `next()`-promise `{value, done:false}` and
   suspends (NO reaction registered — the next `next()` kick is the sole
   resumption driver); **`settleDone`** fulfils `{undefined, done:true}` at body
   end. `yield await P` lowers to `suspend(P) → settleYield(fromSent)`; the await
@@ -893,6 +893,7 @@ move — this slice does not touch it.
 
 **Bounded slice (everything else → legacy gen path / #680, never a wrong
 machine).** A FLAT body of `yield <E>` statements where `E` is plain / `await
+
 <P>` / absent; NO own-local declarations (a local crossing a yield needs the
 frame-spill widening the linear/loop drives already have — params ARE fine,
 captured in frame fields); no `yield*`, no yields nested in expressions/control
@@ -920,9 +921,9 @@ gap3-tryfinally throw-path, 2× promise-combinators host, 2× issue-2865 AG0 was
 **pre-existing on origin/main** — verified identical failure set in a base
 worktree. `tsc --noEmit` clean.
 
-**Answers the 3d dispatch questions.** *Does async-gen drive host-free now?*
+**Answers the 3d dispatch questions.** _Does async-gen drive host-free now?_
 **Yes** — for the bounded producer shape, in wasi, imports `[]`, with genuine
-suspension. *Is 3d-ii / #2865 unblocked?* **Yes** — the frame carrier +
+suspension. _Is 3d-ii / #2865 unblocked?_ **Yes** — the frame carrier +
 `__async_gen_next_<name>` driver + settleYield/settleDone suspend-resume
 substrate are exactly what the `for await (x of g())` consumer (3d-ii) drives:
 that headline is now a consumer-side wiring slice (dispatch
@@ -981,7 +982,8 @@ gen. `planAsyncCfg` gained a `ctx` param and tries `planForAwaitAsyncCfg` **befo
 the 3b array carrier; it self-gates to async-gen sources (returns `null` otherwise),
 so an array for-await falls through **byte-identically**. The consumer's frame layout
 is the SAME as a 3b for-await (own-locals + iterator spill), so `computeForAwaitSpills`
-+ the spill-safe gate are reused unchanged.
+
+- the spill-safe gate are reused unchanged.
 
 **Byte-inertness proof (the −16/−29 discipline).** sha256 of 6 programs (plainSync /
 plainAsync / arrayForAwait / numArrayForAwait / whileAwait / asyncGenConsumer) ×
@@ -1004,9 +1006,9 @@ ONLY failures (3× gap3-tryfinally throw-path, 2× promise-combinators, 2× issu
 each is a non-async-gen program compiled **byte-identically to base** (proven by the
 hash probe), so it cannot be a 3d-ii regression. `tsc --noEmit` clean.
 
-**Answers the dispatch questions.** *Does `for await (x of asyncGen())` work
-host-free now?* **Yes** — bounded shape, wasi, imports `[]`, with genuine
-suspend/resume across the consumer↔producer boundary. *What's left for 3d-iii?*
+**Answers the dispatch questions.** _Does `for await (x of asyncGen())` work
+host-free now?_ **Yes** — bounded shape, wasi, imports `[]`, with genuine
+suspend/resume across the consumer↔producer boundary. _What's left for 3d-iii?_
 `next(v)` argument delivery into the pending yield's SENT_FIELD; `.throw()`/`.return()`
 close-forwarding; the concurrent-`next()` result-promise QUEUE (a single
 current-promise slot suffices for the serial for-await drive proven here);
@@ -1060,7 +1062,7 @@ standalone probes match spec (catch entered with the reason bound: 42/45/50/
   7-program × 3-lane sha256 matrix unchanged; only the newly-admitted shape
   differs, and only on wasi/standalone — gc is byte-identical even for it).
   The depth shift is the designed single site (`loopDepth = st.id + (routed ?
-  3 : 2)` in `buildStateBody`).
+3 : 2)` in `buildStateBody`).
 - **Route** = state transition: for the active region id (the existing
   `__async_in_try` local — the prelude re-throw arm already arms it), bind the
   reason to the catch param (local + spill field, so it survives catch-chain
@@ -1129,13 +1131,12 @@ standalone probes match spec (catch entered with the reason bound: 42/45/50/
   region), replays, then settles. `pendingFinalizer` clears during the replay
   so a `return` inside the finally settles directly (its completion
   overrides). Admission is native-gated end-to-end: `LowerState.
-  allowReturnInTry` → `planLinearAwaits(fn, plan, opts)` (default reject —
+allowReturnInTry` → `planLinearAwaits(fn, plan, opts)` (default reject —
   every host-lane caller byte-identical) → set by `asyncFnNeedsDrive`,
   `planAsyncCfg` (`AsyncCfgOptions.allowReturnInTry = !info.host`) and
   `computeAsyncSpills` (from `buildAsyncFrameInfo`'s `hostImports ===
-  undefined`) so gate, producer, and spill computation see the SAME plan.
-  Deferred within this lane: `return await P` inside the try (the L653 bail
-  stays — its settle is a TERMINATOR, needs the same replay before settleSent).
+undefined`) so gate, producer, and spill computation see the SAME plan.
+  `return await P` inside the try landed in the SAME slice (see below).
 - **Sibling try/catch regions** — the 3c producer generalizes to ANY number of
   sequential top-level try/catches: `analyzeTryCatchAsync` walks
   `[chunk, try/catch]* chunk` groups, `planTryCatchCfg` rebuilt as a running
@@ -1154,7 +1155,19 @@ matrix: all 8 control programs (incl. the 3c-i try/catch shape) byte-identical
 to the 3c-i base across 3 lanes. Async corpus re-run: 89+36 passing, failures
 identical to the pre-existing main set.
 
-**Remaining after 3c-ii-a:** try/catch/finally combined regions +
-`return await`-in-try (3c-ii-b, needs the replay on the settleSent terminator
-or the full finallyState machinery); nested regions (3c-iii). D4 (#2864)
-still waits on those.
+- **`return await P` inside try/finally** (same PR): the `settleSent`
+  terminator replays the state's region finalizer BEFORE fulfilling — the
+  delivered value sits stably in SENT (an await-free finalizer cannot
+  overwrite it), region local reset first (throw-in-finally rejects without
+  re-entering the region). `linearPlanToCfg` already drops the inline tail
+  for `isReturnAwait` states, so the replay is the ONLY finalizer run — no
+  double-execution. The L653 bail lifts under the same `allowReturnInTry`
+  gate. 4 more tests (24/24 total): sync/pending fulfil (finalizer exactly
+  once, before settle — 1042), rejection via the reject route (1), leads +
+  return-await (1052). Byte matrix still identical on all 8 controls.
+
+**Remaining after 3c-ii:** try/catch/finally COMBINED regions (a region with
+both catchState and a finalizer — the catch chain must run the finally on all
+its completion paths; needs a finally-only sibling region or the full
+finallyState machinery); nested regions (3c-iii). D4 (#2864) still waits on
+those.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -517,7 +517,11 @@ export interface LinearAwaitPlan {
  * Pure — no `ctx`/`fctx` mutation; type-eligibility (spill-safe resume-binding
  * types) is a separate gate applied by the drive layer.
  */
-export function planLinearAwaits(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): LinearAwaitPlan | null {
+export function planLinearAwaits(
+  fn: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+  opts?: { allowReturnInTry?: boolean },
+): LinearAwaitPlan | null {
   if (plan.awaitPoints.length === 0) return null;
   const body = fn.body;
   if (body === undefined) return null;
@@ -561,6 +565,7 @@ export function planLinearAwaits(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsP
     theFinalizer: null,
     usedFinally: false,
     sawReturnAwait: false,
+    allowReturnInTry: opts?.allowReturnInTry === true,
   };
   if (!lowerLinearStatements(body.statements, st, awaitSet)) return null;
 
@@ -588,6 +593,13 @@ interface LowerState {
   /** A finally has already been consumed — a second try/finally falls back (single-try slice). */
   usedFinally: boolean;
   sawReturnAwait: boolean;
+  /**
+   * (#2906 3c-ii) Admit `return v` INSIDE a try/finally region. The emitter's
+   * `asyncDriveReturn` hook replays the active region's finalizer before the
+   * settle (native drive lane only — every other caller keeps the historical
+   * reject so admission is unchanged).
+   */
+  allowReturnInTry: boolean;
 }
 
 /**
@@ -631,7 +643,10 @@ function lowerLinearStatements(
       if (!stmt.finallyBlock) return false; // a try with no finally + await — fall back
       const finallyStmts = stmt.finallyBlock.statements;
       for (const f of finallyStmts) if (countAwaitsInStatement(f, awaitSet) > 0) return false; // await-in-finally
-      if (blockHasTopLevelReturn(stmt.tryBlock)) return false; // return-in-try (return-through-finally) — follow-up
+      // (#2906 3c-ii) return-in-try (return-through-finally): admitted on the
+      // native drive lane via the hook's finalizer replay; historical reject
+      // everywhere else (host lane byte-identical).
+      if (!st.allowReturnInTry && blockHasTopLevelReturn(stmt.tryBlock)) return false;
       st.finalizer = [...finallyStmts];
       st.theFinalizer = st.finalizer;
       st.usedFinally = true;
@@ -1054,6 +1069,12 @@ export interface AsyncCfgOptions {
    * `allowLoops`; the host lane keeps its current shapes byte-identically.
    */
   readonly allowTryCatch?: boolean;
+  /**
+   * (#2906 3c-ii) Admit `return v` inside a try/finally region on the linear
+   * plan (the emitter's return hook replays the active region's finalizer
+   * before settling). Native drive lane only.
+   */
+  readonly allowReturnInTry?: boolean;
 }
 
 /**
@@ -1069,7 +1090,7 @@ export function planAsyncCfg(
   plan: AsyncCpsPlan,
   opts: AsyncCfgOptions,
 ): AsyncCfgPlan | null {
-  const linear = planLinearAwaits(fn, plan);
+  const linear = planLinearAwaits(fn, plan, { allowReturnInTry: opts.allowReturnInTry === true });
   if (linear !== null) return linearPlanToCfg(linear);
   if (opts.allowLoops) {
     const whileCfg = planWhileLoopCfg(fn, plan);
@@ -1154,6 +1175,7 @@ function analyzeWhileAsync(
     theFinalizer: null,
     usedFinally: false,
     sawReturnAwait: false,
+    allowReturnInTry: false,
   };
   if (!lowerLinearStatements(bodyStmts, st, awaitSet)) return null;
   if (st.segments.length === 0) return null; // no canonical await in the body
@@ -1340,210 +1362,217 @@ function lowerChunk(
     theFinalizer: null,
     usedFinally: false,
     sawReturnAwait: false,
+    allowReturnInTry: false,
   };
   if (!lowerLinearStatements(statements, st, awaitSet)) return null;
-  // A try/finally INSIDE a chunk would claim handler id 1 (colliding with the
-  // 3c catch region) — bounded slice: no awaited try/finally inside the shape.
+  // A try/finally INSIDE a chunk would claim a colliding handler id — bounded
+  // slice: no awaited try/finally inside the multi-region try/catch shape.
   if (st.theFinalizer !== null) return null;
   return { segs: st.segments, tail: st.lead, sawReturnAwait: st.sawReturnAwait };
 }
 
+/** One `[pre-chunk, try/catch]` group of the (multi-region) 3c shape. */
+interface TryCatchGroup {
+  /** Await-capable chunk of statements BEFORE this group's try (handler 0). */
+  readonly pre: TryCatchChunk;
+  readonly tryChunk: TryCatchChunk;
+  readonly catchChunk: TryCatchChunk;
+  readonly catchParamName: string | null;
+}
+
 /**
- * (#2906 3c) Structural analysis of the bounded try/catch-around-await body:
- * a flat statement block with exactly ONE top-level `try { … } catch (e?) { … }`
- * (no finally, no nesting), where the try block carries ≥1 canonical await and
- * the pre/post/catch chunks are themselves linear-canonical (awaits allowed).
- * Returns `null` (→ legacy/AG0 fallback) for anything outside the slice.
+ * (#2906 3c / 3c-ii) Structural analysis of the bounded try/catch-around-await
+ * body: a flat statement block with one or more SIBLING top-level
+ * `try { … } catch (e?) { … }` statements (no finally, no nesting), each try
+ * block carrying ≥1 canonical await; the chunks between/around them and the
+ * catch blocks are themselves linear-canonical (awaits allowed). Returns
+ * `null` (→ legacy/AG0 fallback) for anything outside the slice.
  */
 export function analyzeTryCatchAsync(
   fn: ts.FunctionLikeDeclaration,
   plan: AsyncCpsPlan,
-): {
-  pre: TryCatchChunk;
-  tryChunk: TryCatchChunk;
-  catchChunk: TryCatchChunk;
-  post: TryCatchChunk;
-  catchParamName: string | null;
-  tryStmt: ts.TryStatement;
-} | null {
+): { groups: TryCatchGroup[]; post: TryCatchChunk } | null {
   if (plan.awaitPoints.length === 0) return null;
   const body = fn.body;
   if (body === undefined || !ts.isBlock(body)) return null;
   const awaitSet = new Set<ts.AwaitExpression>(plan.awaitPoints);
 
-  // Exactly one top-level try statement; it must carry ≥1 await.
-  let tryIdx = -1;
+  // Split the top level at every AWAITED try statement (an await-free try is an
+  // ordinary lead and stays inside its chunk).
+  const tryIdxs: number[] = [];
   for (let i = 0; i < body.statements.length; i++) {
     const stmt = body.statements[i]!;
     if (!ts.isTryStatement(stmt)) continue;
-    if (countAwaitsInStatement(stmt, awaitSet) === 0) continue; // await-free try — an ordinary lead
-    if (tryIdx !== -1) return null; // two awaited trys — not this shape
-    tryIdx = i;
+    if (countAwaitsInStatement(stmt, awaitSet) === 0) continue;
+    tryIdxs.push(i);
   }
-  if (tryIdx === -1) return null;
-  const tryStmt = body.statements[tryIdx] as ts.TryStatement;
-  if (!tryStmt.catchClause) return null; // try/finally → the Gap-3 linear path
-  if (tryStmt.finallyBlock) return null; // try/catch/finally — 3c-ii (return-through-finally)
-  const decl = tryStmt.catchClause.variableDeclaration;
-  if (decl !== undefined && !ts.isIdentifier(decl.name)) return null; // destructured catch param
-  const catchParamName = decl !== undefined ? (decl.name as ts.Identifier).text : null;
+  if (tryIdxs.length === 0) return null;
 
-  const pre = lowerChunk(body.statements.slice(0, tryIdx), awaitSet);
-  if (pre === null || pre.sawReturnAwait) return null; // `return await` before the try — unreachable try
-  const tryChunk = lowerChunk(tryStmt.tryBlock.statements, awaitSet);
-  if (tryChunk === null || tryChunk.segs.length === 0) return null;
-  const catchChunk = lowerChunk(tryStmt.catchClause.block.statements, awaitSet);
-  if (catchChunk === null) return null;
-  const post = lowerChunk(body.statements.slice(tryIdx + 1), awaitSet);
+  const groups: TryCatchGroup[] = [];
+  let cursor = 0;
+  let total = 0;
+  for (const tryIdx of tryIdxs) {
+    const tryStmt = body.statements[tryIdx] as ts.TryStatement;
+    if (!tryStmt.catchClause) return null; // awaited try/finally → the Gap-3 linear path
+    if (tryStmt.finallyBlock) return null; // try/catch/finally — 3c-ii-b follow-up
+    const decl = tryStmt.catchClause.variableDeclaration;
+    if (decl !== undefined && !ts.isIdentifier(decl.name)) return null; // destructured catch param
+    const catchParamName = decl !== undefined ? (decl.name as ts.Identifier).text : null;
+
+    const pre = lowerChunk(body.statements.slice(cursor, tryIdx), awaitSet);
+    if (pre === null || pre.sawReturnAwait) return null; // `return await` → the try is unreachable
+    const tryChunk = lowerChunk(tryStmt.tryBlock.statements, awaitSet);
+    if (tryChunk === null || tryChunk.segs.length === 0) return null;
+    if (tryChunk.sawReturnAwait && tryIdx !== tryIdxs[tryIdxs.length - 1]) return null; // later trys unreachable on the try path — keep bounded
+    const catchChunk = lowerChunk(tryStmt.catchClause.block.statements, awaitSet);
+    if (catchChunk === null) return null;
+    groups.push({ pre, tryChunk, catchChunk, catchParamName });
+    total += pre.segs.length + tryChunk.segs.length + catchChunk.segs.length;
+    cursor = tryIdx + 1;
+  }
+  const post = lowerChunk(body.statements.slice(cursor), awaitSet);
   if (post === null) return null;
+  total += post.segs.length;
 
-  // Every await must be accounted for by the four chunks (no stray positions).
-  const total = pre.segs.length + tryChunk.segs.length + catchChunk.segs.length + post.segs.length;
+  // Every await must be accounted for by the chunks (no stray positions).
   if (total !== plan.awaitPoints.length) return null;
 
-  return { pre, tryChunk, catchChunk, post, catchParamName, tryStmt };
+  return { groups, post };
 }
 
 /**
- * (#2906 3c) Build the CFG for the bounded try/catch shape. State layout
- * (dense ids in push order; M = pre.segs + try.segs suspend states):
- *   0..M-1      pre+try suspend chain (pre awaits handler 0, try awaits handler 1;
- *               the pre tail runs as leading statements of the first try state)
- *   M           try-exit: deliver the last try await, run the try tail,
- *               `goto(join)` — or `settleSent` for a trailing `return await`
- *   M+1..       catch chain (entry has NO resume prelude — the route enters it
- *               like a goto; its awaits are handler 0: a throw in the catch
- *               body rejects the result promise)
- *   join..      post chain → settleUndefined (or settleSent)
- * Handlers: one region { id: 1, catchState: M+1, catchParamName }.
+ * (#2906 3c / 3c-ii) Build the CFG for the bounded (multi-region sibling)
+ * try/catch shape. Per group g (region id r, in source order): the pre chunk's
+ * suspend chain (handler 0, its tail fused into the first try state's leads),
+ * the try chunk's suspend chain (handler r), a try-exit state
+ * (deliver the last try await → try tail → `goto(join)`, or `settleSent` for a
+ * trailing `return await`), then the catch chain (handler 0; entry has NO
+ * resume prelude — the route enters it like a goto) → `goto(join)`. `join` is
+ * the next group's entry (or the post chain). Handlers: one region per group
+ * `{ id: r, catchState, catchParamName? }`.
  */
 export function planTryCatchCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPlan): AsyncCfgPlan | null {
   const shape = analyzeTryCatchAsync(fn, plan);
   if (shape === null) return null;
-  const { pre, tryChunk, catchChunk, post, catchParamName } = shape;
 
   const asLead = (stmts: readonly ts.Statement[], handler: number): AsyncCfgStmt[] =>
     stmts.map((stmt) => ({ stmt, handler }));
 
-  // Fused pre+try suspend steps (the pre tail leads into the first try step).
-  interface Step {
-    readonly leads: AsyncCfgStmt[];
-    readonly seg: LinearAwaitSegment;
-    readonly handler: number;
-  }
-  const steps: Step[] = [];
-  for (const seg of pre.segs) steps.push({ leads: asLead(seg.leadStmts, 0), seg, handler: 0 });
-  for (let i = 0; i < tryChunk.segs.length; i++) {
-    const seg = tryChunk.segs[i]!;
-    steps.push({
-      leads: [...(i === 0 ? asLead(pre.tail, 0) : []), ...asLead(seg.leadStmts, 1)],
-      seg,
-      handler: 1,
-    });
-  }
-  const M = steps.length; // ≥ 1 (tryChunk.segs.length ≥ 1)
-
-  const catchEntry = M + 1;
-  const catchStateCount = catchChunk.segs.length === 0 ? 1 : catchChunk.segs.length + 1;
-  const join = catchEntry + catchStateCount;
-  const finalSettle: AsyncCfgTerminator = post.sawReturnAwait ? { kind: "settleSent" } : { kind: "settleUndefined" };
-
   const states: AsyncCfgState[] = [];
-  // Pre+try suspend chain.
-  for (let k = 0; k < M; k++) {
-    const step = steps[k]!;
+  const handlers: AsyncHandlerRegion[] = [];
+  // Leads/resume carried into the NEXT pushed suspend/settle state.
+  let pendingLeads: AsyncCfgStmt[] = [];
+  let pendingResume: AsyncResumePoint | null = null;
+
+  /** Push one suspend state per segment; the last delivers into the NEXT push. */
+  const pushSuspendChain = (segs: readonly LinearAwaitSegment[], handler: number): void => {
+    for (const seg of segs) {
+      states.push({
+        id: states.length,
+        resumeFrom: pendingResume,
+        lead: [...pendingLeads, ...asLead(seg.leadStmts, handler)],
+        terminator: { kind: "suspend", awaited: seg.awaitedExpr, resumeState: states.length + 1, handler },
+      });
+      pendingResume = { binding: seg.resumeBinding, handler };
+      pendingLeads = [];
+    }
+  };
+
+  for (let g = 0; g < shape.groups.length; g++) {
+    const group = shape.groups[g]!;
+    const r = g + 1; // 1-based dense region id
+    // Pre chunk (handler 0), its tail fused into the first try state.
+    pushSuspendChain(group.pre.segs, 0);
+    pendingLeads.push(...asLead(group.pre.tail, 0));
+    // Try chunk (handler r).
+    pushSuspendChain(group.tryChunk.segs, r);
+    // Try-exit: deliver the last try await (handler r — a rejection routes to
+    // this region's catch), run the try tail, jump to the join.
+    const tryExitId = states.length;
+    const catchEntry = tryExitId + 1;
+    const catchCount = group.catchChunk.segs.length === 0 ? 1 : group.catchChunk.segs.length + 1;
+    const join = catchEntry + catchCount;
     states.push({
-      id: k,
-      resumeFrom: k === 0 ? null : { binding: steps[k - 1]!.seg.resumeBinding, handler: steps[k - 1]!.handler },
-      lead: step.leads,
-      terminator: { kind: "suspend", awaited: step.seg.awaitedExpr, resumeState: k + 1, handler: step.handler },
+      id: tryExitId,
+      resumeFrom: pendingResume,
+      lead: group.tryChunk.sawReturnAwait ? [] : asLead(group.tryChunk.tail, r),
+      terminator: group.tryChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
     });
+    pendingResume = null;
+    pendingLeads = [];
+    // Catch chain (handler 0 — no enclosing region; a throw here rejects).
+    if (group.catchChunk.segs.length === 0) {
+      states.push({
+        id: catchEntry,
+        resumeFrom: null,
+        lead: asLead(group.catchChunk.tail, 0),
+        terminator: { kind: "goto", target: join },
+      });
+    } else {
+      pushSuspendChain(group.catchChunk.segs, 0);
+      states.push({
+        id: states.length,
+        resumeFrom: pendingResume,
+        lead: group.catchChunk.sawReturnAwait ? [] : asLead(group.catchChunk.tail, 0),
+        terminator: group.catchChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
+      });
+      pendingResume = null;
+      pendingLeads = [];
+    }
+    handlers.push({
+      id: r,
+      parent: 0,
+      finalizer: [],
+      catchState: catchEntry,
+      ...(group.catchParamName !== null ? { catchParamName: group.catchParamName } : {}),
+    });
+    // Invariant: the next state pushed is the join (states.length === join).
   }
-  // Try-exit: deliver the last try await (handler 1 — a rejection routes to the
-  // catch), then the try tail, then join (or settle with SENT for return-await).
-  const lastStep = steps[M - 1]!;
-  states.push({
-    id: M,
-    resumeFrom: { binding: lastStep.seg.resumeBinding, handler: lastStep.handler },
-    lead: tryChunk.sawReturnAwait ? [] : asLead(tryChunk.tail, 1),
-    terminator: tryChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
-  });
-  // Catch chain (handler 0 throughout — no enclosing region).
-  if (catchChunk.segs.length === 0) {
+  // Post chunk.
+  if (shape.post.segs.length === 0) {
     states.push({
-      id: catchEntry,
+      id: states.length,
       resumeFrom: null,
-      lead: asLead(catchChunk.tail, 0),
-      terminator: { kind: "goto", target: join },
+      lead: [...pendingLeads, ...asLead(shape.post.tail, 0)],
+      terminator: { kind: "settleUndefined" },
     });
   } else {
-    for (let j = 0; j < catchChunk.segs.length; j++) {
-      const seg = catchChunk.segs[j]!;
-      states.push({
-        id: catchEntry + j,
-        resumeFrom: j === 0 ? null : { binding: catchChunk.segs[j - 1]!.resumeBinding, handler: 0 },
-        lead: asLead(seg.leadStmts, 0),
-        terminator: { kind: "suspend", awaited: seg.awaitedExpr, resumeState: catchEntry + j + 1, handler: 0 },
-      });
-    }
+    pushSuspendChain(shape.post.segs, 0);
     states.push({
-      id: catchEntry + catchChunk.segs.length,
-      resumeFrom: { binding: catchChunk.segs[catchChunk.segs.length - 1]!.resumeBinding, handler: 0 },
-      lead: catchChunk.sawReturnAwait ? [] : asLead(catchChunk.tail, 0),
-      terminator: catchChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
-    });
-  }
-  // Post chain.
-  if (post.segs.length === 0) {
-    states.push({ id: join, resumeFrom: null, lead: asLead(post.tail, 0), terminator: { kind: "settleUndefined" } });
-  } else {
-    for (let j = 0; j < post.segs.length; j++) {
-      const seg = post.segs[j]!;
-      states.push({
-        id: join + j,
-        resumeFrom: j === 0 ? null : { binding: post.segs[j - 1]!.resumeBinding, handler: 0 },
-        lead: asLead(seg.leadStmts, 0),
-        terminator: { kind: "suspend", awaited: seg.awaitedExpr, resumeState: join + j + 1, handler: 0 },
-      });
-    }
-    states.push({
-      id: join + post.segs.length,
-      resumeFrom: { binding: post.segs[post.segs.length - 1]!.resumeBinding, handler: 0 },
-      lead: post.sawReturnAwait ? [] : asLead(post.tail, 0),
-      terminator: finalSettle,
+      id: states.length,
+      resumeFrom: pendingResume,
+      lead: shape.post.sawReturnAwait ? [] : asLead(shape.post.tail, 0),
+      terminator: shape.post.sawReturnAwait ? { kind: "settleSent" } : { kind: "settleUndefined" },
     });
   }
 
-  return {
-    states,
-    handlers: [
-      {
-        id: 1,
-        parent: 0,
-        finalizer: [],
-        catchState: catchEntry,
-        ...(catchParamName !== null ? { catchParamName } : {}),
-      },
-    ],
-  };
+  return { states, handlers };
 }
 
 /**
  * (#2906 3c) Spill-set inputs for the bounded try/catch shape: the shape's
- * suspend segments (for resume-binding types) and the catch-param name. The
- * widened own-local set is computed by the caller (async-frame owns
+ * suspend segments (for resume-binding types) and the catch-param names
+ * (deduped — two catches may share a name; the params are never live
+ * simultaneously so they share one externref slot). The widened own-local set
+ * is computed by the caller (async-frame owns
  * `collectVarDeclsByName`/`resolveSpillLocalValType`). Null off-shape.
  */
 export function tryCatchAsyncSpillInfo(
   fn: ts.FunctionLikeDeclaration,
   plan: AsyncCpsPlan,
-): { segments: readonly LinearAwaitSegment[]; catchParamName: string | null } | null {
+): { segments: readonly LinearAwaitSegment[]; catchParamNames: string[] } | null {
   const shape = analyzeTryCatchAsync(fn, plan);
   if (shape === null) return null;
-  return {
-    segments: [...shape.pre.segs, ...shape.tryChunk.segs, ...shape.catchChunk.segs, ...shape.post.segs],
-    catchParamName: shape.catchParamName,
-  };
+  const segments: LinearAwaitSegment[] = [];
+  const catchParamNames: string[] = [];
+  for (const g of shape.groups) {
+    segments.push(...g.pre.segs, ...g.tryChunk.segs, ...g.catchChunk.segs);
+    if (g.catchParamName !== null && !catchParamNames.includes(g.catchParamName)) {
+      catchParamNames.push(g.catchParamName);
+    }
+  }
+  segments.push(...shape.post.segs);
+  return { segments, catchParamNames };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -665,7 +665,10 @@ function lowerLinearStatements(
 
     // The await must be DIRECTLY one of the three canonical positions.
     if (ts.isReturnStatement(stmt) && stmt.expression === awaitNode) {
-      if (awaitInTry) return false; // `return await` in a try → return-through-finally, follow-up
+      // (#2906 3c-ii-b) `return await P` in a try/finally: the settleSent
+      // terminator replays the region's finalizer before fulfilling (native
+      // drive lane only — historical reject elsewhere).
+      if (awaitInTry && !st.allowReturnInTry) return false;
       st.segments.push({
         leadStmts,
         awaitedExpr: awaitNode.expression,

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -432,6 +432,9 @@ export function buildAsyncFrameInfo(
     decl,
     plan,
     derived.length === 0 ? paramNames : paramNames.concat(derived.map((d) => d.name)),
+    // (#2906 3c-ii) The native backend admits return-in-try; the spill
+    // computation must see the SAME plan the gate/producer admitted.
+    hostImports === undefined,
   );
   const derivedSpillInit = new Map<number, number>();
   for (const d of derived) {
@@ -620,7 +623,9 @@ export function asyncFnNeedsDrive(ctx: CodegenContext, fn: ts.FunctionLikeDeclar
   }
   const anyRealSuspension = plan.awaitPoints.some((a) => plan.awaitedStaticallyResolved.get(a) !== true);
   if (!anyRealSuspension) return false; // fully await-elidable → sync + resolved promise
-  const linear = planLinearAwaits(fn, plan);
+  // (#2906 3c-ii) The native gate admits return-in-try (return-through-finally
+  // via the return hook's finalizer replay); the host gate does not.
+  const linear = planLinearAwaits(fn, plan, { allowReturnInTry: true });
   if (linear === null) {
     // (#2906 slice 3a) `while`-with-await loop shape (native drive lane only).
     // Eligible when every widened loop spill local has a spill-safe type — a
@@ -735,17 +740,17 @@ function computeTryCatchSpills(
   const info = tryCatchAsyncSpillInfo(decl, plan);
   if (info === null) return null;
   const declByName = collectVarDeclsByName(decl);
-  // `collectVarDeclsByName` also picks up the CATCH clause's own
-  // variableDeclaration (it IS a ts.VariableDeclaration) — that entry is the
-  // catch param itself, not a shadowing body local.
+  // `collectVarDeclsByName` also picks up a CATCH clause's own
+  // variableDeclaration (it IS a ts.VariableDeclaration) — those entries are
+  // the catch params themselves, not shadowing body locals.
   const isCatchClauseDecl = (node: ts.VariableDeclaration): boolean =>
     node.parent !== undefined && ts.isCatchClause(node.parent);
   const paramNames = new Set<string>();
   for (const p of decl.parameters) if (ts.isIdentifier(p.name)) paramNames.add(p.name.text);
-  if (info.catchParamName !== null) {
-    const existing = declByName.get(info.catchParamName);
+  for (const cp of info.catchParamNames) {
+    const existing = declByName.get(cp);
     if (existing !== undefined && !isCatchClauseDecl(existing)) return null; // shadows a body local
-    if (paramNames.has(info.catchParamName)) return null; // shadows a fn param
+    if (paramNames.has(cp)) return null; // shadows a fn param
   }
   const rbTypeByName = new Map<string, ValType>();
   for (const seg of info.segments) {
@@ -755,13 +760,13 @@ function computeTryCatchSpills(
   const spillTypes: ValType[] = [];
   for (const [name, node] of declByName) {
     if (paramNames.has(name)) continue;
-    if (isCatchClauseDecl(node)) continue; // the catch param spill is added below (externref)
+    if (isCatchClauseDecl(node)) continue; // catch-param spills are added below (externref)
     const rbType = rbTypeByName.get(name);
     spillNames.push(name);
     spillTypes.push(rbType ?? resolveSpillLocalValType(ctx, node) ?? { kind: "externref" });
   }
-  if (info.catchParamName !== null) {
-    spillNames.push(info.catchParamName);
+  for (const cp of info.catchParamNames) {
+    spillNames.push(cp);
     spillTypes.push({ kind: "externref" });
   }
   return { spillNames, spillTypes };
@@ -789,6 +794,9 @@ function computeAsyncSpills(
   decl: ts.FunctionLikeDeclaration,
   plan: AsyncCpsPlan,
   paramNames: string[],
+  // (#2906 3c-ii) True on the native backend — mirrors the native gate's
+  // `allowReturnInTry` so the spill computation sees the SAME linear plan.
+  allowReturnInTry = false,
 ): { spillNames: string[]; spillTypes: ValType[] } {
   // (#2865) Async GENERATOR (`async function*` — the only asterisked shape that
   // reaches the async frame): EVERY yield is a suspend point (the resume fn
@@ -825,7 +833,7 @@ function computeAsyncSpills(
     }
     return { spillNames, spillTypes };
   }
-  const linear = planLinearAwaits(decl, plan);
+  const linear = planLinearAwaits(decl, plan, { allowReturnInTry });
   if (linear === null) {
     // (#2906 slice 3a) `while`-with-await loop: widened spill set (all loop
     // own-locals). (#2906 slice 3b) for-await drive: loop own-locals + the
@@ -1124,7 +1132,11 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
         // always see the same segment shape.
         asyncGenDelegatesForPlan(ctx, info.decl, isStandalonePromiseActive(ctx) ? "carrier" : "awaitFree"),
       )
-    : planAsyncCfg(ctx, info.decl, plan, { allowLoops: !info.host, allowTryCatch: !info.host });
+    : planAsyncCfg(ctx, info.decl, plan, {
+        allowLoops: !info.host,
+        allowTryCatch: !info.host,
+        allowReturnInTry: !info.host,
+      });
   if (cfg === null) {
     reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2906 slice 1/3a)");
     info.resumeFuncIdx = -1;
@@ -1518,12 +1530,23 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
       // in an in-region statement (or the terminator's own evaluation) runs the
       // region's finalizer; a throw outside (or in the inline finally itself)
       // does not.
+      // (#2906 3c-ii) While a lead is IN a region with a non-empty finalizer,
+      // arm the return hook's `pendingFinalizer` so a `return v` in that lead
+      // replays the finalizer before settling (return-through-finally).
       for (const { stmt, handler } of st.lead) {
         if (hasHandlers && handler !== curHandler) {
           curHandler = handler;
           out.push(...setHandler(curHandler));
         }
+        if (resumeFctx.asyncDriveReturn !== undefined) {
+          const fin = handler !== 0 ? cfg.handlers[handler - 1]?.finalizer : undefined;
+          resumeFctx.asyncDriveReturn.pendingFinalizer = fin !== undefined && fin.length > 0 ? fin : undefined;
+          resumeFctx.asyncDriveReturn.handlerLocal = hasHandlers ? inSrcTryLocal : undefined;
+        }
         compileStatement(ctx, resumeFctx, stmt);
+      }
+      if (resumeFctx.asyncDriveReturn !== undefined) {
+        resumeFctx.asyncDriveReturn.pendingFinalizer = undefined;
       }
 
       // (#2906 slice 3b) State-level injected step — the for-await planner uses

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -1800,6 +1800,20 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
         }
         case "settleSent": {
           // `return await P` — fulfil the result promise with SENT directly.
+          // (#2906 3c-ii-b) When this settle state was entered from an IN-REGION
+          // await (`return await P` inside a try/finally), replay the region's
+          // await-free finalizer BEFORE fulfilling — the delivered value sits
+          // stably in SENT (the finalizer cannot await, so nothing overwrites
+          // it). Region local resets first: a throw inside the finally rejects
+          // WITHOUT re-entering the region (same rule as the inline finally
+          // leads and the return hook's replay). Empty finalizers (the 3c
+          // catch-only regions) emit nothing — byte-identical.
+          const settleRegion = st.resumeFrom !== null && st.resumeFrom.handler !== 0 ? st.resumeFrom.handler : 0;
+          const settleFin = settleRegion !== 0 ? cfg.handlers[settleRegion - 1]?.finalizer : undefined;
+          if (settleFin !== undefined && settleFin.length > 0) {
+            if (hasHandlers) out.push(...setHandler(0));
+            for (const f of settleFin) compileStatement(ctx, resumeFctx, f);
+          }
           out.push({ op: "local.get", index: resultPromiseLocal });
           out.push({ op: "local.get", index: frameLocal });
           out.push({

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -593,6 +593,22 @@ export interface FunctionContext {
     promiseTypeIdx: number;
     /** `__promise_fulfill(promise, value) -> value` funcIdx. */
     fulfillFuncIdx: number;
+    /**
+     * (#2906 3c-ii) The ACTIVE handler region's await-free finalizer at the
+     * lead statement currently being compiled — set/cleared per-lead by
+     * `buildStateBody`. A `return v` compiled while this is non-empty replays
+     * it between evaluating `v` and settling (return-through-finally). Cleared
+     * during the replay itself so a `return` INSIDE the finally settles
+     * directly (the finally's completion overrides, §14.15.3).
+     */
+    pendingFinalizer?: readonly ts.Statement[];
+    /**
+     * (#2906 3c-ii) The `__async_in_try` region-id local. The replay resets it
+     * to 0 first so a throw INSIDE the replayed finally does not re-enter the
+     * same region's catch/finalizer (mirrors the inline finally leads, which
+     * are flagged not-in-try).
+     */
+    handlerLocal?: number;
   };
   /** Set of variable names that are read-only bindings (e.g. named function expression name) */
   readOnlyBindings?: Set<string>;

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -175,7 +175,46 @@ export function compileReturnStatement(ctx: CodegenContext, fctx: FunctionContex
   // void — the resume function carries the async result through the promise, not
   // its wasm return value. Mirrors the generator arm above.
   if (fctx.asyncDriveReturn) {
-    const { resultPromiseLocal, fulfillFuncIdx } = fctx.asyncDriveReturn;
+    const hook = fctx.asyncDriveReturn;
+    const { resultPromiseLocal, fulfillFuncIdx } = hook;
+    // (#2906 3c-ii) return-through-finally: when this `return` sits inside a
+    // try/finally region (buildStateBody armed `pendingFinalizer`), evaluate
+    // the operand FIRST (§14.15.3 ordering), replay the region's await-free
+    // finalizer, then settle. The region local resets to 0 before the replay
+    // (a throw in the finally must not re-enter the region — same rule as the
+    // inline finally leads) and `pendingFinalizer` is cleared during it (a
+    // `return` inside the finally settles directly — its completion overrides).
+    const finalizer = hook.pendingFinalizer;
+    if (finalizer !== undefined && finalizer.length > 0) {
+      const tmp = allocLocal(fctx, `__async_ret_${fctx.locals.length}`, { kind: "externref" });
+      if (stmt.expression) {
+        const t = compileExpression(ctx, fctx, stmt.expression);
+        if (t !== null && t !== undefined) {
+          coerceType(ctx, fctx, t as ValType, { kind: "externref" });
+        } else {
+          fctx.body.push({ op: "ref.null.extern" });
+        }
+      } else {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+      fctx.body.push({ op: "local.set", index: tmp });
+      if (hook.handlerLocal !== undefined) {
+        fctx.body.push({ op: "i32.const", value: 0 });
+        fctx.body.push({ op: "local.set", index: hook.handlerLocal });
+      }
+      hook.pendingFinalizer = undefined;
+      try {
+        for (const f of finalizer) compileStatement(ctx, fctx, f);
+      } finally {
+        hook.pendingFinalizer = finalizer;
+      }
+      fctx.body.push({ op: "local.get", index: resultPromiseLocal });
+      fctx.body.push({ op: "local.get", index: tmp });
+      fctx.body.push({ op: "call", funcIdx: fulfillFuncIdx });
+      fctx.body.push({ op: "drop" }); // __promise_fulfill returns the value
+      fctx.body.push({ op: "return" });
+      return;
+    }
     fctx.body.push({ op: "local.get", index: resultPromiseLocal });
     if (stmt.expression) {
       const t = compileExpression(ctx, fctx, stmt.expression);

--- a/tests/issue-2906-3c-trycatch.test.ts
+++ b/tests/issue-2906-3c-trycatch.test.ts
@@ -373,6 +373,87 @@ export function kick(): number { f() as any; return 0; }
 export function getCap(): number { return cap; }`),
     ).toBe(142);
   });
+
+  // (#2906 3c-ii-b) `return await P` inside try/finally — the settleSent
+  // terminator replays the region's finalizer BEFORE fulfilling (the value
+  // sits stably in SENT; the finalizer cannot await). linearPlanToCfg drops
+  // the inline tail for isReturnAwait states, so the replay is the ONLY run.
+  it("return await inside try/finally: finalizer exactly once, before the settle (sync fulfil)", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    return await Promise.resolve(42);
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1042);
+  });
+
+  it("return await inside try/finally: genuinely-pending fulfil replays once on resume", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    return await Promise.resolve(41).then((v: number) => v + 1);
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1042);
+  });
+
+  it("return await inside try/finally: a rejection still replays via the reject route", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    return await Promise.reject(new Error("x"));
+  } finally {
+    flag = flag + 1;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return flag; }`),
+    ).toBe(1);
+  });
+
+  it("leads before the return-await run once; finalizer once", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    const a = await Promise.resolve(10);
+    return await Promise.resolve((a as number) + 42);
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1052);
+  });
 });
 
 describe("#2906 3c — try/catch-around-await drive (standalone carrier lane)", () => {

--- a/tests/issue-2906-3c-trycatch.test.ts
+++ b/tests/issue-2906-3c-trycatch.test.ts
@@ -244,6 +244,137 @@ export function getCap(): number { return cap; }`),
   });
 });
 
+// #2906 3c-ii — return-through-finally + sibling regions.
+//
+// (a) `return v` INSIDE a `try { …await… } finally { F }` was rejected by
+//     `planLinearAwaits` (return-through-finally), demoting the whole fn to
+//     AG0. The native lane now admits it (`allowReturnInTry`): the return
+//     hook evaluates the operand, replays the region's await-free finalizer
+//     (region local reset first — a throw in the finally must not re-enter
+//     the region; a `return` in the finally overrides, §14.15.3), THEN
+//     settles. Normal/throw paths keep their existing inline/reject-route
+//     replay byte-identically.
+// (b) SIBLING try/catch regions: the 3c producer generalizes to any number of
+//     sequential top-level `try/catch`es — one handler region each (dense ids,
+//     own catchState), the shared route dispatching by the region-id local.
+describe("#2906 3c-ii — return-through-finally + sibling regions (wasi lane)", () => {
+  it("return-through-finally: the finalizer runs BEFORE the settle, value kept", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    const x = await Promise.resolve(5);
+    return (x as number) + 100;
+  } finally {
+    flag = 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1105); // 105 + finally-flag observed at settle time
+  });
+
+  it("conditional return inside the try replays the finalizer on the taken branch", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(n: number): Promise<number> {
+  try {
+    const x = await Promise.resolve(n);
+    if ((x as number) > 3) { return 77; }
+    return 1;
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const a = await f(5);
+  cap = (a as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1077); // finalizer ran exactly once
+  });
+
+  it("normal-completion finally stays on the inline path", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.resolve(4);
+    cap = x as number;
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(104);
+  });
+
+  it("throw-path finally stays on the reject-route replay", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("r"));
+    cap = 1;
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(100);
+  });
+
+  it("sibling regions: two sequential try/catches route to their own catch", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("a"));
+  } catch (e) {
+    cap = 1;
+  }
+  try {
+    await Promise.reject(new Error("b"));
+  } catch (e) {
+    cap = cap + 10;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(11);
+  });
+
+  it("sibling regions: first fulfils, second rejects — only the second catch runs", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const a = await Promise.resolve(100);
+    cap = a as number;
+  } catch (e) {
+    cap = -1;
+  }
+  try {
+    await Promise.reject(new Error("b"));
+  } catch (e2) {
+    cap = cap + 42;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(142);
+  });
+});
+
 describe("#2906 3c — try/catch-around-await drive (standalone carrier lane)", () => {
   it("the core rejection→catch case drives on standalone too", async () => {
     expect(


### PR DESCRIPTION
## Summary

**#2906 slice 3c-ii-a**, STACKED on #3522 (3c-i) — draft until it lands (drafts are never auto-enqueued; will mark ready + re-merge main once the predecessor merges, shrinking the diff to this slice only).

Two shapes join the native drive lane:

- **return-through-finally** — `return v` inside `try { …await… } finally { F }` was a `planLinearAwaits` reject (→ AG0, the value never surfaced). The await-free finalizer (Gap-3 invariant) is now REPLAYED by the `asyncDriveReturn` hook: armed per-lead by `buildStateBody` from the lead's region id; the hook evaluates the operand first (§14.15.3), resets the region local (a throw in the finally must not re-enter the region), replays, then settles. `pendingFinalizer` clears during the replay so a `return` inside the finally overrides. Admission is native-gated end-to-end (`LowerState.allowReturnInTry` → `planLinearAwaits` opts default-reject → `asyncFnNeedsDrive` / `planAsyncCfg` / `computeAsyncSpills` all see the same plan; every host-lane caller byte-identical). `return await`-in-try keeps its bail (3c-ii-b).
- **Sibling try/catch regions** — the 3c producer generalizes to ANY number of sequential top-level try/catches: `[chunk, try/catch]* chunk` groups, running state-counter builder (invariant: `states.length === join` after each group's catch chain), one handler region per group with its own `catchState`; catch params deduped across regions (never live simultaneously → one externref slot). The routed dispatcher's id-equality route needed NO change.

## Validation (measured)

- 6 new tests → **20/20** in `tests/issue-2906-3c-trycatch.test.ts`: finalizer observed BEFORE the settle (1105), conditional return runs it exactly once (1077), normal (104) / throw (100) paths unchanged, sibling both-reject (11) and fulfil+reject (142).
- **Byte matrix**: all 8 control programs (incl. the 3c-i try/catch shape) sha256-identical to the 3c-i base across gc/standalone/wasi.
- Async corpus re-run: failures identical to the pre-existing main set (2980 ×2, 2865 ×2, gap3 ×3 — the fd_write import-leak under Lane-A triage).
- `loc-budget-allow` extended in #2906 frontmatter (context/types.ts +16, control-flow.ts +39 — hook capability at the hook's site).

## Banked

3c-ii-b: try/catch/finally combined + `return await`-in-try (replay on the settleSent terminator or full finallyState). 3c-iii: nested regions. D4 (#2864) still waits on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)