### PR TITLE
fix(#3558): reconcile 2 stale guard tests (2906 wasi exn-printer imports, 2980 drivable carrier) + promote to guard suite

### DIFF
--- a/plan/issues/3558-stale-guard-tests-import-shape.md
+++ b/plan/issues/3558-stale-guard-tests-import-shape.md
@@ -1,0 +1,142 @@
+---
+id: 3558
+title: Two guard tests red on main for 10–19 days — import-shape assertions went stale after intended compiler changes (#2968 wasi exn printer, #3132 PR-2 drivable carrier)
+status: done
+created: 2026-07-23
+completed: 2026-07-23
+updated: 2026-07-23
+priority: high
+task_type: bug
+feasibility: hard
+horizon: s
+goal: standalone
+sprint: current
+assignee: ttraenkler/senior-dev
+---
+
+# Two guard tests red on unmodified main — bisected, both culprits are INTENDED changes; tests reconciled + promoted to the guard suite
+
+## Symptom (verified on main `b9b89b8` and again on `4d076a4`, 2026-07-23)
+
+`npx vitest run tests/issue-2906-gap3-tryfinally.test.ts tests/issue-2980-carrier-fallback.test.ts`
+→ **5 failed / 5 passed (10 total)**, two distinct signatures:
+
+1. **issue-2906-gap3-tryfinally — 3 of 6 fail** (SYNCHRONOUS-THROW,
+   SYNCHRONOUS-THROW-BEFORE-AWAIT, PENDING-then-REJECTED):
+   `WebAssembly.instantiate(): Import #0 "wasi_snapshot_preview1": module is not
+an object or function`. The wasi binary really imports
+   `wasi_snapshot_preview1.fd_write` + `proc_exit`; the test instantiates with
+   bare `{}`.
+2. **issue-2980-carrier-fallback — 2 of 4 fail**:
+   `expected [] to include 'Promise_reject'` / `'Promise_resolve'` — the
+   async-gen standalone module compiles with ZERO imports where the test
+   expected the host-Promise fallback imports.
+
+(The dispatch note said 2906=2 / 2980=3; measured split is 2906=**3/6**,
+2980=**2/4** — total 5 either way, verified at HEAD, at the culprits, and at
+07-10.)
+
+## Bisect (first-parent, `git bisect run` with binary-import probes; validated by full vitest runs on both sides of each culprit)
+
+Two **separate** culprits, in **disjoint windows** — NOT one shared cause, and
+NOT yesterday's commits:
+
+| Signature                    | GOOD                                       | BAD                        | First-bad (first-parent)                     | Inner commit                                                                             |
+| ---------------------------- | ------------------------------------------ | -------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| 1 (2906, wasi import "leak") | `a4702ed` 07-01 (PR #2416 merge, 6/6 pass) | `1aedd65` 07-10 (3/6 fail) | **`7012743` — Merge PR #2533** (07-04 00:19) | `d4d19d0` `fix(#2968): wasi _start uncaught-exception printer`                           |
+| 2 (2980, fallback gone)      | `1aedd65` 07-10 (4/4 pass)                 | `8914a4c` 07-23 (2/4 fail) | **`d7d0db8` — Merge PR #3013** (07-13 14:20) | `90ba2a8` `feat(#3132 PR-2): native $Promise carrier for all-drivable async-gen modules` |
+
+Both dispatch-suspects **refuted by the bisect**: `9d123cd` (#3538 async-gen
+abrupt completion, 07-23) and `3c9a01d` (callable boundary ABI, 07-21) are
+both _later_ than either culprit window.
+
+Note: the local repo was **shallow** (graft at 07-05) — every file "appears
+added" at the boundary merge, which initially mis-attributed the 2906 test's
+add date. `git fetch origin main --shallow-since=2026-06-28` deepened it;
+the real GOOD anchor is PR #2416's merge (07-01).
+
+## Mechanism
+
+### Signature 1 — #2968 (PR #2533), by design
+
+`registerWasiImports` registers `fd_write` + `proc_exit` **whenever the wasi
+module's source contains a `throw`** (anywhere — including inside a `.then`
+callback), for the `_start` uncaught-exception printer ("uncaught exception
+renders to stderr + `proc_exit(1)` instead of silent exit 0"). Non-throwing
+modules stay byte-identical — which is exactly the 3-pass/3-fail split in the
+2906 file (the 3 failing cases contain `throw` in source; the 3 passing don't).
+
+Two test-side latencies made this invisible:
+
+- `r.imports` **omits wasi system imports entirely** (it listed only `env.*`),
+  so the test's `expect(r.imports).toEqual([])` was vacuous for wasi modules —
+  it never guarded anything; only the bare-`{}` instantiate caught the change.
+- Semantics were NEVER broken: with a `wasi_snapshot_preview1` stub the
+  throw-path cases run and produce the exact expected values (probe: 101).
+
+### Signature 2 — #3132 PR-2 (PR #3013), by design
+
+The #2980 blanket fallback (`moduleHasAsyncGen` ⇒ both carrier gates OFF ⇒
+whole Promise lane host) was deliberately refined to
+`moduleHasNonDrivableAsyncGen` (`widenAsyncGenFallback`,
+src/codegen/async-scheduler.ts): an **all-drivable** async-gen module keeps the
+native `$Promise` carrier and loses ALL `env.*` imports — the host-free floor
+this was measured for (07-10/07-13 A/Bs). The 2980 test's gens are simple
+top-level drivable shapes ⇒ native ⇒ imports `[]`.
+
+Additionally the `JS2WASM_ASYNC_CARRIER_WIDEN` env toggle the test set was
+**retired** on 2026-07-10 (widen flipped to production, PR #2867) — the test's
+whole measure-lane framing was stale.
+
+## Verdict + fix (this PR)
+
+**No compiler change.** Both culprit changes are intended, documented, and
+measured; the guard tests asserted superseded properties. Reconciled test-side:
+
+- `tests/issue-2906-gap3-tryfinally.test.ts` — assert host-free from the
+  **binary** import section (`env.*` forbidden; `wasi_snapshot_preview1`
+  allowed per #2968) and instantiate with a minimal wasi stub whose
+  `proc_exit` throws (loud). All 6 semantics assertions unchanged → 6/6.
+- `tests/issue-2980-carrier-fallback.test.ts` — rewritten to the CURRENT
+  intended lane split: all-drivable async-gen module ⇒ imports `[]`;
+  **new** non-drivable case (object-literal stem collision `o1.g`/`o2.g`) ⇒
+  legacy host lane fires (`env.__gen_next` + `env.__get_caught_exception`
+  present — the still-live #2980 no-mixing lane); non-async-gen ⇒ native;
+  compile spot-check kept; retired env-toggle plumbing removed → 5/5.
+- Probed non-drivable shapes for the new case: rest-param and loop-body gens
+  **CE** in standalone (#680 legacy numeric-only), unused/DCE'd method gens
+  emit nothing; the stem-collision (and `arguments`-method) shapes are the
+  ones that reach the legacy host buffer and stay compilable — 2/6 probed
+  shapes usable.
+
+## Visibility gap (#3552) — closed for this class
+
+Both files added to `tests/guard-suite.json` (required `quality` gate,
+#3514): they meet all three entry criteria (invariant-guard with a proven
+silent break; ~4–5s each locally, no test262/harness inputs; green on this
+PR's tree). Suite grows 3 → 5 files, ~+10s against the ~2-min budget.
+
+This is the third and fourth instance of the untouched-guard-test class
+(#3503→#3471 ~2 days; #3483→#1539 ~2 days; here 19 and 10 days — the
+longest yet), reinforcing #3552's premise: per-PR CI runs only PR-touched
+test files, so a semantics/import-shape change breaks untouched guards
+silently.
+
+## Possible follow-ups (not in this PR)
+
+- `r.imports` omits wasi system imports — any consumer using it to prove
+  "import-free" for wasi modules gets a vacuous `[]`. Consider including
+  them (or a `systemImports` field).
+- #2968's printer gate is "source contains `throw` anywhere", coarser than
+  "module-init can throw" — harmless for real WASI hosts (they always
+  provide fd_write/proc_exit), but it makes every throwing wasi module
+  carry the printer. A reachability-based gate would shrink binaries.
+
+## Repro / validation commands
+
+```bash
+# regression (pre-fix, on 4d076a4): 5 failed / 5 passed
+npx vitest run tests/issue-2906-gap3-tryfinally.test.ts tests/issue-2980-carrier-fallback.test.ts
+# bisect predicates: compile probe + WebAssembly.Module.imports() shape check
+# post-fix: 11/11 pass, ~8s
+```

--- a/tests/guard-suite.json
+++ b/tests/guard-suite.json
@@ -37,6 +37,16 @@
       "path": "tests/issue-3551.test.ts",
       "guards": "IR ABI-parity withdrawal cascades to committed IR callers — no partial commit of a calleeTypes cluster",
       "broken_by": "#3503 partial-commit semantics"
+    },
+    {
+      "path": "tests/issue-2906-gap3-tryfinally.test.ts",
+      "guards": "wasi async try/finally runs on every completion path AND the module stays JS-host-free (no env.* imports; wasi_snapshot_preview1 system imports allowed per #2968)",
+      "broken_by": "#2968/PR #2533 (2026-07-04) invalidated the bare-{} instantiation silently — red 19 days, found+reconciled by #3558"
+    },
+    {
+      "path": "tests/issue-2980-carrier-fallback.test.ts",
+      "guards": "standalone Promise carrier lane split: all-drivable async-gen modules import-free (native $Promise), non-drivable ones host-consistent (legacy __gen_* buffer, no mixing)",
+      "broken_by": "#3132 PR-2/PR #3013 (2026-07-13) superseded the blanket #2980 fallback silently — red 10 days, found+reconciled by #3558"
     }
   ]
 }

--- a/tests/issue-2906-gap3-tryfinally.test.ts
+++ b/tests/issue-2906-gap3-tryfinally.test.ts
@@ -5,15 +5,40 @@
 // (single, non-nested, await-free F, no catch, no return-in-try — richer shapes
 // fall back to the legacy path). gc/host + standalone byte-inertness is proven by
 // hash in the PR notes; non-try async stays byte-identical to slice 1.
+//
+// (#3558) "Host-free" means NO JS-host (`env.*`) imports — asserted from the
+// BINARY's import section, because `r.imports` metadata omits WASI system
+// imports entirely (an empty `r.imports` proves nothing for a wasi module).
+// Since #2968 (PR #2533, 2026-07-04) any wasi module whose SOURCE contains a
+// `throw` imports `wasi_snapshot_preview1.fd_write`/`proc_exit` for the
+// `_start` uncaught-exception printer — designed WASI system imports that
+// every WASI host provides, NOT a host leak. The original bare-`{}`
+// instantiation treated them as a failure and left the three throw-path cases
+// red for 19 days (#3558 root-cause); we now stub exactly that one system
+// module and keep the env.* guard strict.
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
 
 async function instantiateWasi(src: string): Promise<WebAssembly.Exports> {
   const r = await compile(src, { fileName: "test.ts", target: "wasi" });
   expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
-  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
   expect(WebAssembly.validate(r.binary)).toBe(true);
-  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  // The real host-free guard: no imports outside wasi_snapshot_preview1.
+  const nonWasi = WebAssembly.Module.imports(new WebAssembly.Module(r.binary)).filter(
+    (i) => i.module !== "wasi_snapshot_preview1",
+  );
+  expect(nonWasi.map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {
+    // Minimal WASI stub (#2968 exn printer). fd_write only runs on an uncaught
+    // exception escaping `_start` — none of these cases does; proc_exit
+    // throwing makes an unexpected exit loud instead of silent.
+    wasi_snapshot_preview1: {
+      fd_write: () => 0,
+      proc_exit: (code: number) => {
+        throw new Error(`unexpected proc_exit(${code})`);
+      },
+    },
+  });
   return instance.exports;
 }
 

--- a/tests/issue-2980-carrier-fallback.test.ts
+++ b/tests/issue-2980-carrier-fallback.test.ts
@@ -1,54 +1,55 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * #2980 conservative Promise-lane fallback — a module containing ANY async
- * generator keeps BOTH carrier gates OFF on the widened-standalone measure lane
- * (`isStandalonePromiseActive` / `isStandaloneThenChainNativeActive` →
- * `ctx.standalone && !ctx.moduleHasAsyncGen`), so its whole promise pipeline
- * stays host-consistent (a native `$Promise` never feeds the legacy `__gen_*`
- * buffer / a host `.then` over `__gen_next` — the 07-09 async-generator −4 in
- * the carrier A/B).
+ * #2980 conservative Promise-lane fallback, as refined by #3132 PR-2
+ * (rewritten by #3558 — the original assertions guarded superseded behavior
+ * and sat red for 10 days, invisible to per-PR CI).
  *
- * The widen is measured via `JS2WASM_ASYNC_CARRIER_WIDEN` (read at
- * async-scheduler module-load), so this file sets the env BEFORE a DYNAMIC
- * import of the compiler — a fresh module graph (vitest isolates test files) so
- * the toggle is live. CI never sets the env, so the fallback is dead code there;
- * this test exercises the measure path directly.
+ * History of the gate this file guards
+ * (`widenAsyncGenFallback` in src/codegen/async-scheduler.ts):
+ *  - #2980 (2026-07-09, `b66d7e2`): ANY async generator in the module kept
+ *    BOTH standalone carrier gates OFF (`moduleHasAsyncGen`) so a native
+ *    `$Promise` never fed the legacy `__gen_*` host buffer (the 07-09
+ *    async-generator −4). Measured via the `JS2WASM_ASYNC_CARRIER_WIDEN` env
+ *    toggle, which this file originally set.
+ *  - 2026-07-10: the widen FLIPPED to production (`2a2aa49`/PR #2867) and the
+ *    env toggle was RETIRED — the on-arm is now the default standalone
+ *    behavior, so setting the env is a no-op.
+ *  - #3132 PR-2 (2026-07-13, `90ba2a8`/PR #3013): the blanket fallback was
+ *    refined to `moduleHasNonDrivableAsyncGen` — a module whose async gens are
+ *    ALL drivable under the carrier keeps the carrier ON (native `$Promise`,
+ *    NO host imports: the host-free floor). Only a module with at least one
+ *    NON-drivable gen (method exclusions / rest param / unbounded body /
+ *    unsafe spill / stem collision) still falls back to the host lane, because
+ *    only there a legacy `__gen_*` buffer exists to mix into.
+ *
+ * So the CURRENT invariants, asserted from the binary's import section:
+ *  1. all-drivable async-gen module → native carrier, ZERO imports;
+ *  2. non-drivable async-gen module → host lane fires (legacy `__gen_*` /
+ *     `__get_caught_exception` imports present — no native/legacy mixing);
+ *  3. non-async-gen module → native carrier, no host Promise imports.
  */
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let compile: (src: string, opts: any) => Promise<any>;
-
-beforeAll(async () => {
-  process.env.JS2WASM_ASYNC_CARRIER_WIDEN = "1";
-  ({ compile } = await import("../src/index.js"));
-});
-
-// Belt-and-suspenders: vitest isolates test files (fresh module registry per
-// file), but unset the process-wide toggle so a reused worker can't leak the
-// widen into a later file's compiler load.
-afterAll(() => {
-  // Empty (≠ "1") is equivalent to absent for the `=== "1"` gate.
-  process.env.JS2WASM_ASYNC_CARRIER_WIDEN = "";
-});
-
-async function standaloneImports(src: string): Promise<string[]> {
+async function standaloneBinaryImports(src: string): Promise<string[]> {
   const r = await compile(src, { fileName: "t.ts", target: "standalone", nativeStrings: true });
   expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
-  return (r.imports ?? []).map((i: { name: string }) => i.name);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  return WebAssembly.Module.imports(new WebAssembly.Module(r.binary)).map((i) => `${i.module}.${i.name}`);
 }
 
-describe("#2980 conservative Promise-lane fallback (widened-standalone measure)", () => {
-  it("async-gen module: Promise.reject falls BACK to host (whole lane host-consistent)", async () => {
-    const imports = await standaloneImports(`
+describe("#2980/#3132 Promise-lane carrier gates (standalone, post-widen)", () => {
+  it("all-drivable async-gen module: Promise.reject stays NATIVE (#3132 PR-2 — no host imports at all)", async () => {
+    const imports = await standaloneBinaryImports(`
       export async function* g() { yield Promise.reject(new Error("x")); }
     `);
-    // Fallback fired → host Promise construction is present, NOT the native $Promise.
-    expect(imports).toContain("Promise_reject");
+    // The whole point of the #3132 PR-2 refinement: an all-drivable module
+    // keeps the carrier ON and loses every env.* import (host-free floor).
+    expect(imports).toEqual([]);
   });
 
-  it("async-gen module: a Promise.resolve elsewhere ALSO stays host under the fallback", async () => {
-    const imports = await standaloneImports(`
+  it("all-drivable async-gen module: a Promise.resolve elsewhere ALSO stays native", async () => {
+    const imports = await standaloneBinaryImports(`
       async function* g(): AsyncGenerator<number> { yield 1; }
       export async function f(): Promise<number> {
         const p = await Promise.resolve(7);
@@ -56,21 +57,40 @@ describe("#2980 conservative Promise-lane fallback (widened-standalone measure)"
         return p;
       }
     `);
-    expect(imports).toContain("Promise_resolve");
+    expect(imports).toEqual([]);
   });
 
-  it("NON-async-gen module: Promise.reject stays NATIVE (fallback is scoped, widen still wins)", async () => {
-    const imports = await standaloneImports(`
+  it("NON-drivable async-gen module (stem collision): the #2980 host fallback still fires", async () => {
+    // Two object-literal async-gen methods share the stem `g` → the second is
+    // non-drivable (stem collision) → `moduleHasNonDrivableAsyncGen` → both
+    // carrier gates OFF → the gens run on the legacy `__gen_*` HOST buffer.
+    // This is the still-live #2980 lane: the module must be host-consistent
+    // (legacy buffer imports present), never a native $Promise mixed into it.
+    const imports = await standaloneBinaryImports(`
+      const o1 = { async *g(): AsyncGenerator<number> { yield 1; } };
+      const o2 = { async *g(): AsyncGenerator<number> { yield 2; } };
+      export async function f(): Promise<number> {
+        const p = await Promise.resolve(7);
+        for await (const x of o1.g()) { void x; }
+        for await (const x of o2.g()) { void x; }
+        return p;
+      }
+    `);
+    expect(imports).toContain("env.__gen_next");
+    expect(imports).toContain("env.__get_caught_exception");
+  });
+
+  it("NON-async-gen module: Promise.reject stays NATIVE (widen wins, unchanged since #2980)", async () => {
+    const imports = await standaloneBinaryImports(`
       export async function f(): Promise<number> {
         try { await Promise.reject(new Error("x")); return 0; } catch (e) { return 1; }
       }
     `);
-    // No async generator → widen active → native $Promise construction, no host import.
-    expect(imports).not.toContain("Promise_reject");
-    expect(imports).not.toContain("Promise_resolve");
+    expect(imports).not.toContain("env.Promise_reject");
+    expect(imports).not.toContain("env.Promise_resolve");
   });
 
-  it("the 5 A/B async-gen regressions pass host-consistently under the fallback (spot-check one)", async () => {
+  it("the 5 A/B async-gen regressions compile host-consistently (spot-check one)", async () => {
     // named-yield-promise-reject-next shape: rejecting yield + close, .next().then().
     const r = await compile(
       `
@@ -81,7 +101,6 @@ describe("#2980 conservative Promise-lane fallback (widened-standalone measure)"
     `,
       { fileName: "t.ts", target: "standalone", nativeStrings: true },
     );
-    // Must compile (the widen no longer feeds a native $Promise into the legacy gen).
     expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
   });
 });


### PR DESCRIPTION
## Root cause (bisected, not assumed)

Two guard tests sat red on unmodified `main` — invisible because untouched test files don't run per-PR (the #3552 class). `npx vitest run tests/issue-2906-gap3-tryfinally.test.ts tests/issue-2980-carrier-fallback.test.ts` → 5 failed / 5 passed.

**Two separate culprits (first-parent `git bisect run`, validated by full test runs on both sides of each merge):**

| Signature | First-bad merge | Inner commit | Red since |
| --- | --- | --- | --- |
| 2906: `wasi_snapshot_preview1` import at bare-`{}` instantiate (3/6 tests) | `7012743` (PR #2533, 07-04) | `d4d19d0` fix(#2968) wasi \_start uncaught-exception printer | 19 days |
| 2980: expected host `Promise_reject/resolve` imports, got `[]` (2/4 tests) | `d7d0db8` (PR #3013, 07-13) | `90ba2a8` feat(#3132 PR-2) native $Promise carrier for all-drivable async-gen modules | 10 days |

Suspects `9d123cd` (#3538) and `3c9a01d` (callable-boundary ABI) **refuted** — both post-date the culprit windows.

## Mechanism

- **#2968 (by design):** `registerWasiImports` adds `fd_write`+`proc_exit` to any wasi module whose source contains `throw` (the \_start exn printer). Exactly the 3-fail/3-pass split: the failing cases contain `throw`, the passing don't. The test's `expect(r.imports).toEqual([])` was **vacuous** — `r.imports` omits wasi system imports entirely; only the bare-`{}` instantiate caught it. Semantics never broke (probe: throw-before-await returns 101 under a wasi stub).
- **#3132 PR-2 (by design):** the blanket #2980 fallback (`moduleHasAsyncGen`) was refined to `moduleHasNonDrivableAsyncGen`; all-drivable async-gen modules keep the native carrier and lose ALL env.* imports (the host-free floor). The `JS2WASM_ASYNC_CARRIER_WIDEN` env toggle the test set was retired 07-10 (no-op).

## Fix — test-side only, no compiler edits

- **2906 test:** host-free asserted from the BINARY import section (no `env.*`; `wasi_snapshot_preview1` allowed per #2968), instantiate with a minimal wasi stub (`proc_exit` throws = loud). All 6 semantics assertions unchanged → 6/6.
- **2980 test:** rewritten to the current intended lane split — all-drivable ⇒ imports `[]`; NEW non-drivable case (object-literal stem collision) proves the still-live #2980 host lane fires (`env.__gen_next`/`__get_caught_exception` present); non-async-gen ⇒ native; compile spot-check kept → 5/5.
- **Visibility gap:** both files added to `tests/guard-suite.json` (#3552/#3514 required `quality` gate). Suite 3→5 files; measured locally 27/27 pass in 11.3s (budget ~2 min).

Full analysis: `plan/issues/3558-stale-guard-tests-import-shape.md` (includes follow-up notes: `r.imports` omits wasi imports; #2968 gate is coarser than module-init reachability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ