### PR TITLE
feat(#2906 3c-ii-b): combined try/catch/finally regions — two-region model, producer-only

### DIFF
--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -1166,8 +1166,38 @@ identical to the pre-existing main set.
   once, before settle — 1042), rejection via the reject route (1), leads +
   return-await (1052). Byte matrix still identical on all 8 controls.
 
-**Remaining after 3c-ii:** try/catch/finally COMBINED regions (a region with
-both catchState and a finalizer — the catch chain must run the finally on all
-its completion paths; needs a finally-only sibling region or the full
-finallyState machinery); nested regions (3c-iii). D4 (#2864) still waits on
-those.
+## Slice 3c-ii-b — COMBINED try/catch/finally regions (LANDED, 2026-07-23, fable dev-laneB, stacked on 3c-ii)
+
+**Producer-only, as predicted by the two-region model.** A combined
+`try { …await… } catch (e) { … } finally { F }` group (F await-free — the
+Gap-3 invariant) mints TWO handler regions:
+
+- the **catch region** `r` — `catchState` + `finalizer: F`, covering the TRY
+  chunk. Abrupt-in-try → route → catch (F not yet — spec ordering); `return`
+  in try → the hook replays F; `return await` in try → the settleSent replay
+  runs F (both landed in 3c-ii and index `handlers[id-1]`, so they picked up
+  the combined region for free).
+- the **finally-only region** `rFin` — `finalizer: F`, NO catchState,
+  covering the CATCH chunk (its leads/suspends/resumeFrom all tagged `rFin`).
+  A throw / rejected await in the catch → no route branch (no catchState) →
+  the reject tail's `inSrcTry == rFin` guard replays F → reject. A `return`
+  in the catch → hook replays F.
+
+Normal completions run F as inline handler-0 leads appended at the try-exit
+and catch-exit states. Region ids stay dense via a running counter (a
+combined group consumes two ids); the route loop skips catchState-less
+regions; the reject tail's per-region guard for `r` is unreachable in the
+routed dispatcher (the route branches to the catch first) — dead but
+harmless, F never double-runs.
+
+**Measured:** 8 new tests (32/32 total): fulfil/reject/throw-in-catch/
+return-in-try/return-in-catch/await-in-catch/rejected-await-in-catch/
+return-await-in-try — every completion path observes F exactly once in spec
+order (104/142/105/1050/1042/150/100/1077). Byte matrix: all 8 controls
+unchanged across 3 lanes.
+
+**Remaining after 3c-ii-b:** nested regions (3c-iii — static handler tagging
+covers nested try/CATCH: tag the inner catch chunk with the ENCLOSING region
+id + set `parent`, lift the validator; nested finalizer CHAINS on one abrupt
+need the reject tail to replay all enclosing finalizers innermost-first and
+stay banked). D4 (#2864) still waits on 3c-iii.

--- a/src/codegen/async-cps.ts
+++ b/src/codegen/async-cps.ts
@@ -1374,13 +1374,24 @@ function lowerChunk(
   return { segs: st.segments, tail: st.lead, sawReturnAwait: st.sawReturnAwait };
 }
 
-/** One `[pre-chunk, try/catch]` group of the (multi-region) 3c shape. */
+/** One `[pre-chunk, try/catch(/finally)]` group of the (multi-region) 3c shape. */
 interface TryCatchGroup {
   /** Await-capable chunk of statements BEFORE this group's try (handler 0). */
   readonly pre: TryCatchChunk;
   readonly tryChunk: TryCatchChunk;
   readonly catchChunk: TryCatchChunk;
   readonly catchParamName: string | null;
+  /**
+   * (#2906 3c-ii-b) The group's await-free `finally` body, or null. A combined
+   * try/catch/finally group mints TWO handler regions: the catch region
+   * (catchState + this finalizer — covers the TRY chunk: abrupt → catch,
+   * `return`/`return await` → finalizer replay then settle) and a
+   * finally-only region (this finalizer, no catchState — covers the CATCH
+   * chunk: a throw there replays the finalizer in the reject route; a
+   * `return` there replays it via the return hook). Normal completions run
+   * the finalizer as inline handler-0 leads at the try/catch exits.
+   */
+  readonly finallyStmts: ts.Statement[] | null;
 }
 
 /**
@@ -1417,7 +1428,15 @@ export function analyzeTryCatchAsync(
   for (const tryIdx of tryIdxs) {
     const tryStmt = body.statements[tryIdx] as ts.TryStatement;
     if (!tryStmt.catchClause) return null; // awaited try/finally → the Gap-3 linear path
-    if (tryStmt.finallyBlock) return null; // try/catch/finally — 3c-ii-b follow-up
+    // (#2906 3c-ii-b) try/catch/FINALLY: admitted when the finally is
+    // await-free (the Gap-3 invariant — replays must not suspend).
+    let finallyStmts: ts.Statement[] | null = null;
+    if (tryStmt.finallyBlock) {
+      for (const f of tryStmt.finallyBlock.statements) {
+        if (countAwaitsInStatement(f, awaitSet) > 0) return null; // await-in-finally
+      }
+      finallyStmts = [...tryStmt.finallyBlock.statements];
+    }
     const decl = tryStmt.catchClause.variableDeclaration;
     if (decl !== undefined && !ts.isIdentifier(decl.name)) return null; // destructured catch param
     const catchParamName = decl !== undefined ? (decl.name as ts.Identifier).text : null;
@@ -1429,7 +1448,7 @@ export function analyzeTryCatchAsync(
     if (tryChunk.sawReturnAwait && tryIdx !== tryIdxs[tryIdxs.length - 1]) return null; // later trys unreachable on the try path — keep bounded
     const catchChunk = lowerChunk(tryStmt.catchClause.block.statements, awaitSet);
     if (catchChunk === null) return null;
-    groups.push({ pre, tryChunk, catchChunk, catchParamName });
+    groups.push({ pre, tryChunk, catchChunk, catchParamName, finallyStmts });
     total += pre.segs.length + tryChunk.segs.length + catchChunk.segs.length;
     cursor = tryIdx + 1;
   }
@@ -1481,42 +1500,56 @@ export function planTryCatchCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPl
     }
   };
 
-  for (let g = 0; g < shape.groups.length; g++) {
-    const group = shape.groups[g]!;
-    const r = g + 1; // 1-based dense region id
+  let nextRegionId = 1; // regions must be dense 1..N (validateAsyncCfg)
+  for (const group of shape.groups) {
+    const fin = group.finallyStmts;
+    // Region ids: `r` = the catch region (covers the TRY chunk; carries the
+    // catchState AND — for a combined try/catch/finally — the finalizer, so
+    // the return hook / settleSent replay run F on `return` from the try).
+    // `rFin` = the finally-only region (covers the CATCH chunk of a combined
+    // group; a throw there replays F in the reject route, a `return` there
+    // replays F via the hook). Catch-only groups keep one region (rFin = 0 ⇒
+    // catch chunk handler 0, byte-identical to 3c-ii-a).
+    const r = nextRegionId++;
+    const rFin = fin !== null ? nextRegionId++ : 0;
     // Pre chunk (handler 0), its tail fused into the first try state.
     pushSuspendChain(group.pre.segs, 0);
     pendingLeads.push(...asLead(group.pre.tail, 0));
     // Try chunk (handler r).
     pushSuspendChain(group.tryChunk.segs, r);
     // Try-exit: deliver the last try await (handler r — a rejection routes to
-    // this region's catch), run the try tail, jump to the join.
+    // this region's catch), run the try tail (+ the inline finalizer, NOT
+    // in-region — a throw inside F must not re-run it), jump to the join.
     const tryExitId = states.length;
     const catchEntry = tryExitId + 1;
     const catchCount = group.catchChunk.segs.length === 0 ? 1 : group.catchChunk.segs.length + 1;
     const join = catchEntry + catchCount;
+    const finLeads = fin !== null ? asLead(fin, 0) : [];
     states.push({
       id: tryExitId,
       resumeFrom: pendingResume,
-      lead: group.tryChunk.sawReturnAwait ? [] : asLead(group.tryChunk.tail, r),
+      lead: group.tryChunk.sawReturnAwait ? [] : [...asLead(group.tryChunk.tail, r), ...finLeads],
       terminator: group.tryChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
     });
     pendingResume = null;
     pendingLeads = [];
-    // Catch chain (handler 0 — no enclosing region; a throw here rejects).
+    // Catch chain (handler rFin: 0 for catch-only groups — a throw rejects
+    // directly; the finally-only region id for combined groups — a throw
+    // replays F in the reject route first). The inline F leads at the exit
+    // cover the catch chain's NORMAL completion.
     if (group.catchChunk.segs.length === 0) {
       states.push({
         id: catchEntry,
         resumeFrom: null,
-        lead: asLead(group.catchChunk.tail, 0),
+        lead: [...asLead(group.catchChunk.tail, rFin), ...finLeads],
         terminator: { kind: "goto", target: join },
       });
     } else {
-      pushSuspendChain(group.catchChunk.segs, 0);
+      pushSuspendChain(group.catchChunk.segs, rFin);
       states.push({
         id: states.length,
         resumeFrom: pendingResume,
-        lead: group.catchChunk.sawReturnAwait ? [] : asLead(group.catchChunk.tail, 0),
+        lead: group.catchChunk.sawReturnAwait ? [] : [...asLead(group.catchChunk.tail, rFin), ...finLeads],
         terminator: group.catchChunk.sawReturnAwait ? { kind: "settleSent" } : { kind: "goto", target: join },
       });
       pendingResume = null;
@@ -1525,10 +1558,13 @@ export function planTryCatchCfg(fn: ts.FunctionLikeDeclaration, plan: AsyncCpsPl
     handlers.push({
       id: r,
       parent: 0,
-      finalizer: [],
+      finalizer: fin ?? [],
       catchState: catchEntry,
       ...(group.catchParamName !== null ? { catchParamName: group.catchParamName } : {}),
     });
+    if (fin !== null) {
+      handlers.push({ id: rFin, parent: 0, finalizer: fin });
+    }
     // Invariant: the next state pushed is the join (states.length === join).
   }
   // Post chunk.

--- a/tests/issue-2906-3c-trycatch.test.ts
+++ b/tests/issue-2906-3c-trycatch.test.ts
@@ -456,6 +456,177 @@ export function getCap(): number { return cap; }`),
   });
 });
 
+// #2906 3c-ii-b — COMBINED try/catch/finally regions. A combined group mints
+// TWO handler regions: the catch region (catchState + the finalizer — covers
+// the TRY chunk: abrupt → catch, `return`/`return await` → finalizer replay
+// then settle) and a finally-only region (finalizer, no catchState — covers
+// the CATCH chunk: a throw there replays the finalizer in the reject route, a
+// `return` there replays it via the hook). Normal completions run the
+// finalizer as inline handler-0 leads at the try/catch exits. Producer-only:
+// every emitter mechanism (route, reject-tail replay, return hook, settleSent
+// replay) already handles the two regions generically.
+describe("#2906 3c-ii-b — combined try/catch/finally (wasi lane)", () => {
+  it("fulfil path: catch skipped, finalizer once", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    const x = await Promise.resolve(4);
+    cap = x as number;
+  } catch (e) {
+    cap = -1;
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(104);
+  });
+
+  it("rejection: catch runs, then the finalizer", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("x"));
+    cap = 1;
+  } catch (e) {
+    cap = 42;
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(142);
+  });
+
+  it("a throw INSIDE the catch replays the finalizer before rejecting", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("a"));
+  } catch (e) {
+    cap = 5;
+    throw new Error("b");
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(105);
+  });
+
+  it("return inside the TRY runs the finalizer once, before the settle", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    const x = await Promise.resolve(50);
+    return x as number;
+  } catch (e) {
+    return -1;
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1050);
+  });
+
+  it("return inside the CATCH runs the finalizer once, before the settle", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    await Promise.reject(new Error("y"));
+    return 1;
+  } catch (e) {
+    return 42;
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1042);
+  });
+
+  it("an await INSIDE the catch suspends/resumes; finalizer after", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("z"));
+    cap = 1;
+  } catch (e) {
+    const r = await Promise.resolve(8);
+    cap = 42 + (r as number);
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(150);
+  });
+
+  it("a REJECTED await inside the catch replays the finalizer before rejecting", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+async function f(): Promise<void> {
+  try {
+    await Promise.reject(new Error("p"));
+    cap = 1;
+  } catch (e) {
+    await Promise.reject(new Error("q"));
+    cap = 2;
+  } finally {
+    cap = cap + 100;
+  }
+}
+export function kick(): number { f() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(100);
+  });
+
+  it("return await inside the TRY: finalizer once via the settleSent replay", async () => {
+    expect(
+      await driveCap(`let cap: number = 0;
+let flag: number = 0;
+async function f(): Promise<number> {
+  try {
+    return await Promise.resolve(77);
+  } catch (e) {
+    return -1;
+  } finally {
+    flag = flag + 1;
+  }
+}
+async function g(): Promise<void> {
+  const v = await f();
+  cap = (v as number) + flag * 1000;
+}
+export function kick(): number { g() as any; return 0; }
+export function getCap(): number { return cap; }`),
+    ).toBe(1077);
+  });
+});
+
 describe("#2906 3c — try/catch-around-await drive (standalone carrier lane)", () => {
   it("the core rejection→catch case drives on standalone too", async () => {
     expect(


### PR DESCRIPTION
## Summary

**#2906 slice 3c-ii-b**, STACKED on #3524 (3c-ii) — draft until it lands (will re-merge main + mark ready once the predecessor merges; the diff then shrinks to this slice).

Combined `try { …await… } catch (e) { … } finally { F }` (F await-free — the Gap-3 invariant) now drives on the native lane via a **two-region model**, with **zero emitter changes**:

- **catch region** (`catchState` + finalizer F) covers the TRY chunk: an abrupt routes to the catch first (spec ordering — F runs after the catch completes); `return`/`return await` in the try replay F via the 3c-ii return-hook / settleSent replay, which index `handlers[id-1]` and picked the combined region up for free.
- **finally-only region** (finalizer F, no `catchState`) covers the CATCH chunk: a throw or rejected await there replays F in the reject route before rejecting; a `return` there replays F via the hook.
- Normal completions run F as inline handler-0 leads at the try/catch exit states. Region ids stay dense via a running counter; the route loop skips catchState-less regions.

## Validation (measured)

- 8 new tests → **32/32** in `tests/issue-2906-3c-trycatch.test.ts`: every completion path observes F exactly once in spec order — fulfil 104, reject→catch→F 142, throw-in-catch→F→reject 105, return-in-try 1050, return-in-catch 1042, await-in-catch 150, rejected-await-in-catch→F→reject 100, return-await-in-try 1077.
- **Byte matrix**: all 8 control programs (incl. every previously-driven shape) sha256-identical across gc/standalone/wasi.

## Banked

3c-iii nested regions: nested try/CATCH is static-handler-tagging + `parent` + validator lift; nested finalizer CHAINS (multiple enclosing finallys replaying innermost-first on one abrupt) stay banked. D4 (#2864 sync-generator convergence) waits on 3c-iii.

🤖 Generated with [Claude Code](https://claude.com/claude-code)