### PR TITLE
fix(#3557): brand `!`/`!!` result as boolean so booleans marshal as JS booleans

### DIFF
--- a/plan/issues/3557-boolean-i32-marshalling-type-gap.md
+++ b/plan/issues/3557-boolean-i32-marshalling-type-gap.md
@@ -1,7 +1,8 @@
 ---
 id: 3557
 title: "booleans cross the host boundary as i32 0/1 — systemic wrong-TYPE marshalling (boolean brand lost in struct-field type inference)"
-status: ready
+status: in-progress
+assignee: sendev-bool-marshal
 sprint: current
 priority: medium
 horizon: m
@@ -99,3 +100,82 @@ epic (#2773) owner / tech lead — NOT silently parked as an allowance:
 - `tests/dogfood/acorn-corpus.mjs` reports `quirk-bool-as-i32` ≈ 0 (fix path).
 - Full merge_group validation (batch blast-radius check) — no test262
   regression, no standalone-floor regression.
+
+## Increment landed — `!`/`!!` operator brand (2026-07-24, sendev, Opus)
+
+**Corrected root cause (traced to the emitting site, not inferred).** The
+original #2847-carryover note pointed at the struct-field getter
+(`_emitStructFieldGettersInner` / `hasBool` fork). Tracing one field
+(`generator`) through the actual WAT proved that is NOT where acorn's boolean
+fields marshal:
+
+- The `__sget_*` getter path (#1788) and `coerceType`'s i32→externref arm
+  (`type-coercion.ts:1971`, `if (from.boolean === true) __box_boolean`) **already
+  pick `__box_boolean` when the ValType carries `boolean:true`**. Verified: only
+  `prefix`/`generator` are ever struct-field getters, and both are branded — yet
+  `generator` still read `0/1` for some nodes.
+- Acorn's node boolean fields (`computed`/`async`/`optional`/…) are **dynamic
+  sidecar properties** set on open objects (`node.async = !!isAsync`), boxed to
+  externref by the dynamic-set helpers (`tryEmitDeleteAwareDynamicSet`,
+  `compilePropertyAssignmentExternSet`). Those helpers compile the RHS in its
+  natural type then `coerceType(→externref)` — which honours `boolean:true`.
+- **So the entire defect is brand-LOSS before boxing, not a boxing-site bug.**
+  Instrumenting the dynamic-set site showed the surviving loss forms:
+  - boolean **literal** RHS (`= false`) → already branded → boxes as boolean ✓
+  - **`!x` / `!!x`** (PrefixUnary) → born **unbranded** i32 (`unary.ts` returned
+    `{kind:"i32"}`) → boxed as the number `0/1` ✗ (dominant: `async`, `computed`)
+
+**Fix (contained, dual-mode).** Brand the `!`/`!!` result as
+`{kind:"i32", boolean:true}` in `src/codegen/expressions/unary.ts` — the missing
+prefix-unary member of the boolean-producing-operator family that #2712's
+`brandBooleanBinaryResult` already brands for `===`/`<`/`in`/`instanceof`. `!x` is
+definitionally a JS boolean, so this is semantically correct and structurally
+inert (still `.kind === "i32"`). Lane-agnostic: the `from.boolean` check fires in
+gc/host **and** standalone.
+
+**Measured corpus impact** (`pnpm run dogfood:acorn-corpus`, denominators honest):
+
+| input          | `quirk-bool-as-i32` before | after |
+| -------------- | -------------------------- | ----- |
+| real/acorn.mjs | 11,843                     | 6,781 |
+| real/edge.js   | 258                        | 148   |
+| corpus total   | ~12,556                    | ~7,025 (**−44 %**) |
+
+`REAL=0` unchanged (no new structural divergence); `equal` stays 0 because it is
+gated by the *separate* `quirk-sourceFile` (#2847, out of scope), present in
+every input.
+
+Test: `tests/issue-3557-not-operator-bool-brand.test.ts` (10/10) — `typeof (!x)`,
+dynamic-property write of `!!cond`, `=== false`, `JSON.stringify`, Set-element,
+plus structural-inertia guards (`!x` in arithmetic stays number; branch cond
+works; number fields unaffected).
+
+## Residual — the genuine value-rep slice (#2773), NOT ground here
+
+After the operator fix, the remaining `quirk-bool-as-i32` (acorn self-parse,
+measured per-field) is:
+
+- **`optional`: 6,427 (94 % of residual)** — acorn line 2923
+  `var optional = optionalSupported && this.eat(types.questionDot)`. The value is
+  a boolean at runtime but its boolean-ness is lost through **`&&` where one
+  operand (`this.eat(...)`) is `any`/externref-typed**, then through **variable
+  storage** (the local is not boolean-branded). `&&`/`||` return the operand type
+  and deliberately do **not** brand (branding a number would be a bug), and the
+  `any`-typed method return has already boxed as a number upstream — so this is
+  not cleanly brandable at any single site without value-rep work.
+- **`generator`: 354** — chained `node.generator = node.expression = false`
+  (acorn 3491): the inner assignment returns an already-boxed externref that the
+  outer set re-stores; the externref lost its boolean tag upstream.
+
+Both are the **"any-passage" residual**: boolean-ness dropped while a value
+transits `any`/externref before reaching the marshalling boundary. Fixing them
+means preserving a boolean tag through `&&`/`||` operand typing, `any`-typed
+method-call return boxing, and boolean-local storage — i.e. the #2773 value-rep
+brand-propagation work, explicitly out of scope for this contained increment.
+**Recommend:** keep #3557 open tracking this residual under #2773; route the
+value-rep slice deliberately (do not grind a substrate rewrite here).
+
+**Gate note:** the operator brand is exactly the typeof/boxing blast-radius class
+#1788/#2712 had to guard. PR-level test262 is a designed no-op — the real
+regression/standalone-floor gate is the **merge_group** re-validation; expect a
+possible auto-park and treat merge_group green as the acceptance evidence.

--- a/src/codegen/expressions/unary.ts
+++ b/src/codegen/expressions/unary.ts
@@ -142,7 +142,16 @@ function compilePrefixUnary(
       const operandType = compileExpression(ctx, fctx, expr.operand);
       ensureI32Condition(fctx, operandType, ctx);
       fctx.body.push({ op: "i32.eqz" });
-      return { kind: "i32" };
+      // (#3557) `!x` (and `!!x`) is ALWAYS a JS boolean — brand the i32 result so
+      // downstream boxing at the host boundary reifies a JS `true`/`false`
+      // (`__box_boolean`) rather than the number `1`/`0` (`__box_number`), and
+      // `typeof (!x) === "boolean"` holds. This is the missing prefix-unary
+      // member of the boolean-producing operator family that
+      // `brandBooleanBinaryResult` already brands for `===`/`<`/`in`/… (#2712).
+      // Lane-agnostic: `coerceType(i32→externref)` honours `boolean:true` in both
+      // gc/host and standalone. Structurally inert — still matches every
+      // `.kind === "i32"` check.
+      return { kind: "i32", boolean: true };
     }
     case ts.SyntaxKind.TildeToken: {
       // Bitwise ~ applies ToNumber (§7.1.4) → ToInt32; Symbol must throw TypeError.

--- a/tests/issue-3557-not-operator-bool-brand.test.ts
+++ b/tests/issue-3557-not-operator-bool-brand.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+// #3557 — the logical-NOT (`!` / `!!`) result is ALWAYS a JS boolean, so its
+// i32 result must carry the boolean brand (`{kind:"i32", boolean:true}`). Before
+// this fix `!x`/`!!x` was born brandless, so when the value crossed the host
+// boundary (a dynamic property write, a Set/Map key, `typeof`) it boxed via
+// `__box_number` and reified as the NUMBER 1/0 instead of `true`/`false`.
+//
+// Surfaced by the acorn differential corpus: `node.async = !!isAsync` (and the
+// whole `computed`/`async`/… family) marshalled as i32 0/1, so
+// `node.async === false` was false (it was 0) and `typeof node.async` was
+// "number". This is the missing prefix-unary member of the boolean-producing
+// operator family that #2712 already brands for `===`/`<`/`in`/`instanceof`.
+//
+// Fix: brand the `!`/`!!` result in expressions/unary.ts (lane-agnostic — the
+// `from.boolean` check in coerceType's i32→externref arm picks `__box_boolean`
+// in both gc/host and standalone).
+
+async function run<T>(src: string): Promise<T> {
+  const exports = await compileAndInstantiate(src);
+  return (exports as { f: () => T }).f();
+}
+
+describe("#3557 logical-NOT result is a boolean at the host boundary", () => {
+  describe("the acorn repro — `node.<flag> = !!cond` marshals as a boolean", () => {
+    it("`typeof (!x)` is 'boolean'", async () => {
+      expect(await run(`export function f(): string { const x = 0; return typeof (!x); }`)).toBe("boolean");
+    });
+
+    it("`typeof (!!x)` is 'boolean'", async () => {
+      expect(await run(`export function f(): string { const x: any = 5; return typeof (!!x); }`)).toBe("boolean");
+    });
+
+    it("dynamic property write of `!!cond` reads back as a boolean (typeof)", async () => {
+      // Mirrors `node.async = !!isAsync` on acorn's open node objects.
+      expect(
+        await run(`export function f(): string {
+          const isAsync = 1;
+          const node: any = {};
+          node.async = !!isAsync;
+          return typeof node.async;
+        }`),
+      ).toBe("boolean");
+    });
+
+    it("dynamic property write of `!cond` strict-equals false (not 0)", async () => {
+      expect(
+        await run(`export function f(): number {
+          const node: any = {};
+          node.computed = !true;   // false
+          return node.computed === false ? 1 : 0; // 1 iff a real boolean
+        }`),
+      ).toBe(1);
+    });
+
+    it("`(!!cond) as any` boxed into a Set is a boolean element (not the number 1)", async () => {
+      expect(
+        await run(`export function f(): number {
+          const x: any = 3;
+          return new Set<any>([(!!x) as any]).has(1) ? 1 : 0; // 0 — the element is boolean true
+        }`),
+      ).toBe(0);
+    });
+
+    it("`(!!cond) as any` boxed into a Set matches has(true)", async () => {
+      expect(
+        await run(`export function f(): number {
+          const x: any = 3;
+          return new Set<any>([(!!x) as any]).has(true) ? 1 : 0;
+        }`),
+      ).toBe(1);
+    });
+
+    it("JSON.stringify surfaces a `!!cond` field as a boolean, not 0/1", async () => {
+      // The exact acorn surface: a serialized AST node's boolean flags.
+      expect(
+        await run(`export function f(): string {
+          const isAsync = 0;
+          const node: any = {};
+          node.async = !!isAsync;   // false
+          node.generator = !isAsync; // true
+          return JSON.stringify(node);
+        }`),
+      ).toBe('{"async":false,"generator":true}');
+    });
+  });
+
+  describe("brand is structurally inert — no arithmetic/branch regression", () => {
+    it("`!x` used in arithmetic still coerces to number 1/0", async () => {
+      expect(
+        await run(`export function f(): number { const x = 0; return (!x as any) ? ((!x as any) + 1) : -1; }`),
+      ).toBe(2);
+    });
+
+    it("`!x` as a branch condition still works", async () => {
+      expect(await run(`export function f(): number { const x = 0; if (!x) return 7; return 0; }`)).toBe(7);
+    });
+
+    it("a genuine number field is unaffected (still a number)", async () => {
+      expect(
+        await run(`export function f(): number {
+          const node: any = {};
+          node.start = 5;
+          return typeof node.start === "number" ? node.start : -1;
+        }`),
+      ).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
## #3557 — booleans marshalled across the host boundary as the number `0`/`1`

Boolean-valued fields (`computed`, `async`, `optional`, …) crossed the host
boundary as the **number** `0`/`1` instead of JS `false`/`true`, so
`node.computed === false` was false and `typeof node.computed` was `"number"`.
Surfaced by the acorn differential corpus (`tests/dogfood/acorn-corpus.mjs`,
#1712).

### Root cause (traced to the emitting site, not inferred)

The `__sget_*` getter path (#1788) and `coerceType`'s i32→externref arm
(`type-coercion.ts:1971`, `if (from.boolean === true) __box_boolean`) **already**
box as a JS boolean when the ValType carries `boolean:true`. The whole defect is
brand-**loss before boxing**. Acorn's node flags are dynamic sidecar writes
(`node.async = !!isAsync`) boxed via the dynamic-set helpers, which honour
`boolean:true`. The dominant lost form is **`!x` / `!!x`**, which
`expressions/unary.ts` returned as an **unbranded** i32 → boxed via `__box_number`.

### Fix (contained, dual-mode)

Brand the `!`/`!!` result `{kind:"i32", boolean:true}` — the missing prefix-unary
member of the boolean-producing-operator family that #2712's
`brandBooleanBinaryResult` already brands for `===`/`<`/`in`/`instanceof`. `!x` is
definitionally a JS boolean; structurally inert (still `.kind === "i32"`);
lane-agnostic (the `from.boolean` check fires in gc/host **and** standalone).

### Measured impact (`pnpm run dogfood:acorn-corpus`)

| input          | `quirk-bool-as-i32` before | after |
| -------------- | -------------------------- | ----- |
| real/acorn.mjs | 11,843                     | 6,781 |
| real/edge.js   | 258                        | 148   |
| corpus total   | ~12,556                    | ~7,025 (**−44 %**) |

`REAL=0` unchanged. `equal` stays 0 — gated by the *separate* `quirk-sourceFile`
(#2847, out of scope).

### Residual (recorded in the issue — the #2773 value-rep slice, not ground here)

`optional` (6,427) and chained `generator` (354) lose boolean-ness while transiting
`any`/externref (`&&` with an `any`-typed method-call operand + boolean-local
storage) — the "any-passage" residual. #3557 stays open tracking it under #2773.

### Tests

`tests/issue-3557-not-operator-bool-brand.test.ts` (10/10): `typeof (!x)`,
dynamic-property write of `!!cond`, `=== false`, `JSON.stringify`, Set-element,
plus structural-inertia guards.

### Validation note

The operator brand is exactly the typeof/boxing blast-radius class #1788/#2712 had
to guard. PR-level test262 is a designed no-op — the **merge_group** re-validation
(regression diff + standalone floor) is the real gate; treat merge_group green as
the acceptance evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ