### PR TITLE
fix(#3459): non-negative baseline clock age — clamp fresher-than-main-HEAD baseline to 0

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1554,10 +1554,17 @@ jobs:
           MAIN_HEAD_TS=$(git log -1 --format=%ct origin/main 2>/dev/null || git log -1 --format=%ct main 2>/dev/null || echo 0)
           BASELINE_TS="${{ steps.fetch_baseline.outputs.baseline_ts }}"
           BASELINE_SHA="${{ steps.fetch_baseline.outputs.baseline_sha }}"
-          DIFF_M=0
-          if [ "$MAIN_HEAD_TS" != "0" ] && [ "$BASELINE_TS" != "0" ]; then
-            DIFF_M=$(( (MAIN_HEAD_TS - BASELINE_TS) / 60 ))
-          fi
+          # #3459 — compute a NON-NEGATIVE clock age from a single documented
+          # clock source (git %ct, Unix epoch SECONDS). The baselines-repo HEAD
+          # commit is produced by promote-baseline AFTER the main commit it was
+          # generated from, and on a merge_group re-validation can reflect a
+          # NEWER main state than this speculative checkout's origin/main — so
+          # the raw (MAIN_HEAD_TS - BASELINE_TS) is frequently negative, which
+          # previously printed a nonsensical "-43m clock age". The helper clamps
+          # a fresher-than-main-HEAD baseline to age 0 (with an honest stderr
+          # note) instead of emitting a negative age. Pure logic is unit-tested
+          # in tests/issue-3459-baseline-clock-age.test.ts.
+          DIFF_M=$(node scripts/baseline-clock-age.mjs "$MAIN_HEAD_TS" "$BASELINE_TS")
           echo "stale_minutes=$DIFF_M" >> "$GITHUB_OUTPUT"
 
           # Parse the baseline's recorded main-sha from the baselines-repo commit

--- a/plan/issues/3459-drift-check-negative-clock-age.md
+++ b/plan/issues/3459-drift-check-negative-clock-age.md
@@ -1,10 +1,11 @@
 ---
 id: 3459
 title: "merge_group drift check reports negative baseline clock age (-43m) — clock-skew bug in instrumentation"
-status: ready
+status: done
+completed: 2026-07-24
 sprint: current
 created: 2026-07-19
-updated: 2026-07-19
+updated: 2026-07-24
 priority: low
 horizon: s
 feasibility: easy
@@ -45,10 +46,33 @@ and clamp/flag rather than print a negative age.
 
 ## Acceptance criteria
 
-- [ ] The baseline clock-age value is never negative.
-- [ ] The age is computed from a single, documented clock source and epoch
+- [x] The baseline clock-age value is never negative.
+- [x] The age is computed from a single, documented clock source and epoch
       unit.
-- [ ] A quick unit/sanity check covers the sign.
+- [x] A quick unit/sanity check covers the sign.
+
+## Resolution (2026-07-24)
+
+Root cause: the age was computed inline in `test262-sharded.yml`'s "Check
+baseline staleness" step as `(MAIN_HEAD_TS - BASELINE_TS) / 60`, where
+`BASELINE_TS` is the git `%ct` of the **baselines-repo** HEAD commit and
+`MAIN_HEAD_TS` is the `%ct` of **this checkout's** main HEAD. Both are already
+Unix epoch **seconds**, so the epoch unit matched — the defect was a clock-
+**source** mismatch: the baselines-repo commit is produced by `promote-baseline`
+*after* the main commit it was generated from, and on a `merge_group`
+re-validation it can reflect a **newer** main state than the speculative
+checkout's `origin/main`. So `MAIN_HEAD_TS - BASELINE_TS` was frequently
+negative (the observed `-43m`).
+
+Fix: extracted the computation into `scripts/baseline-clock-age.mjs`
+(`computeClockAge`), which documents the single clock source/unit (git `%ct`,
+Unix seconds) and **clamps** a fresher-than-main-HEAD baseline to age `0` with
+an honest stderr note (`baselineAhead`) instead of emitting a negative age. The
+staleness step now calls the helper. Unit + CLI tests in
+`tests/issue-3459-baseline-clock-age.test.ts` cover the sign (the `-43m` repro,
+identity, sub-minute truncation, invalid/sentinel timestamps). This also fixes
+the minor functional side-effect where a negative value silently skipped the
+`-ge 30` clock-based fallback warning.
 
 ## Notes
 

--- a/scripts/baseline-clock-age.mjs
+++ b/scripts/baseline-clock-age.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3459 — Compute the test262 baseline "clock age" in whole minutes, guaranteed
+// NON-NEGATIVE, from a single documented clock source and epoch unit.
+//
+// Background / the bug this fixes:
+//   The baseline-drift/staleness check in test262-sharded.yml printed a
+//   NEGATIVE clock age ("-43m clock age") during a merge_group re-validation.
+//   The age was computed inline as `(MAIN_HEAD_TS - BASELINE_TS) / 60`, where:
+//     • MAIN_HEAD_TS = git `%ct` (committer timestamp) of THIS checkout's main
+//       HEAD commit.
+//     • BASELINE_TS  = git `%ct` of the loopdive/js2wasm-baselines repo HEAD
+//       commit — the baseline JSONL being diffed against.
+//   Both are Unix epoch SECONDS, so the epoch UNIT already matched. The defect
+//   is a clock-SOURCE mismatch: the baselines-repo commit is produced by the
+//   `promote-baseline` job AFTER the main commit it was generated from, and —
+//   during a merge_group run — the baseline can reflect a NEWER main state than
+//   this speculative checkout's `origin/main` (main advanced while the group was
+//   queued). So `MAIN_HEAD_TS - BASELINE_TS` is frequently negative, which is
+//   nonsensical as an "age" and misreports the staleness signal.
+//
+// Semantics (documented, single source):
+//   ageMinutes answers "how many whole minutes OLDER than this checkout's main
+//   HEAD is the baseline" (i.e. staleness). Inputs are git `%ct` committer
+//   timestamps in Unix epoch SECONDS. A raw difference < 0 means the baseline is
+//   FRESHER than this checkout's main HEAD (baseline is AHEAD) → it is NOT stale
+//   → the age is clamped to 0 and `baselineAhead` is flagged so the caller can
+//   log the honest reason instead of a bogus negative number. Invalid / missing
+//   timestamps (<= 0 or non-numeric) yield age 0 with `valid: false`.
+//
+// Usage:
+//   node scripts/baseline-clock-age.mjs <MAIN_HEAD_TS> <BASELINE_TS>
+//     → prints the clamped non-negative minute count to stdout (for
+//       `DIFF_M=$(node scripts/baseline-clock-age.mjs "$MAIN_HEAD_TS" "$BASELINE_TS")`).
+//   node scripts/baseline-clock-age.mjs <MAIN_HEAD_TS> <BASELINE_TS> --json
+//     → prints { ageMinutes, rawMinutes, baselineAhead, valid } for tooling.
+//   Flags may also be given as --main-head-ts <n> / --baseline-ts <n>.
+
+/**
+ * Compute the baseline clock age in whole minutes, clamped to be non-negative.
+ * Pure + exported for unit testing — no I/O, no process.exit.
+ *
+ * @param {number|string} mainHeadTs  git `%ct` of the checkout's main HEAD (Unix seconds)
+ * @param {number|string} baselineTs  git `%ct` of the baselines-repo HEAD (Unix seconds)
+ * @returns {{ ageMinutes: number; rawMinutes: number; baselineAhead: boolean; valid: boolean }}
+ *   ageMinutes    — whole minutes, always >= 0 (the value to print/gate on).
+ *   rawMinutes    — the un-clamped signed difference (negative ⇒ baseline ahead);
+ *                   diagnostic only.
+ *   baselineAhead — true when the baseline is fresher than this checkout's main
+ *                   HEAD (rawMinutes < 0); not stale.
+ *   valid         — false when either timestamp is missing / non-positive /
+ *                   non-numeric (age forced to 0).
+ */
+export function computeClockAge(mainHeadTs, baselineTs) {
+  const main = Number(mainHeadTs);
+  const base = Number(baselineTs);
+  const valid = Number.isFinite(main) && Number.isFinite(base) && main > 0 && base > 0;
+  if (!valid) {
+    return { ageMinutes: 0, rawMinutes: 0, baselineAhead: false, valid: false };
+  }
+  // Both timestamps are Unix epoch SECONDS (git %ct). Truncate toward zero so a
+  // partial minute never rounds a fresh baseline up to "1m stale".
+  const rawMinutes = Math.trunc((main - base) / 60);
+  const baselineAhead = rawMinutes < 0;
+  const ageMinutes = baselineAhead ? 0 : rawMinutes;
+  return { ageMinutes, rawMinutes, baselineAhead, valid };
+}
+
+function parsePositionalAndFlags(argv) {
+  const positional = [];
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+function main() {
+  const { positional, flags } = parsePositionalAndFlags(process.argv.slice(2));
+  const mainHeadTs = flags["main-head-ts"] ?? positional[0] ?? "0";
+  const baselineTs = flags["baseline-ts"] ?? positional[1] ?? "0";
+
+  const result = computeClockAge(mainHeadTs, baselineTs);
+
+  if (flags.json === "true") {
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  if (result.baselineAhead) {
+    // Honest note (stderr, so stdout stays a clean integer for `$(...)`): a
+    // fresher-than-main-HEAD baseline is expected on merge_group runs.
+    console.error(
+      `#3459 baseline is FRESHER than this checkout's main HEAD by ${Math.abs(result.rawMinutes)}m ` +
+        `(baseline commit newer than main HEAD commit) — reporting clock age 0 (not stale).`,
+    );
+  }
+  console.log(String(result.ageMinutes));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/issue-3459-baseline-clock-age.test.ts
+++ b/tests/issue-3459-baseline-clock-age.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3459 — the merge_group baseline-drift check printed a NEGATIVE clock age
+// ("-43m clock age"). Root cause: the age was computed as
+// `(MAIN_HEAD_TS - BASELINE_TS) / 60`, but the baselines-repo HEAD commit is
+// produced by promote-baseline AFTER the main commit it was generated from and
+// can (on a merge_group re-validation) reflect a NEWER main state than the
+// speculative checkout's origin/main — so BASELINE_TS > MAIN_HEAD_TS and the
+// raw difference goes negative. These tests lock in that the reported clock age
+// is NEVER negative and is derived from a single documented clock source /
+// epoch unit (git %ct Unix SECONDS), covering the sign per the acceptance
+// criteria.
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { computeClockAge } from "../scripts/baseline-clock-age.mjs";
+
+const SCRIPT = resolve(__dirname, "../scripts/baseline-clock-age.mjs");
+const MIN = 60; // seconds per minute
+
+describe("#3459 computeClockAge — sign & clamping", () => {
+  it("reports a positive age when the baseline is genuinely older than main HEAD", () => {
+    const mainTs = 1_700_000_000;
+    const baseTs = mainTs - 45 * MIN; // baseline 45 min older
+    const r = computeClockAge(mainTs, baseTs);
+    expect(r.ageMinutes).toBe(45);
+    expect(r.rawMinutes).toBe(45);
+    expect(r.baselineAhead).toBe(false);
+    expect(r.valid).toBe(true);
+  });
+
+  it("clamps to 0 (never negative) when the baseline is FRESHER than main HEAD — the -43m repro", () => {
+    const mainTs = 1_700_000_000;
+    const baseTs = mainTs + 43 * MIN; // baseline commit 43 min NEWER than main HEAD
+    const r = computeClockAge(mainTs, baseTs);
+    expect(r.ageMinutes).toBe(0); // NOT -43
+    expect(r.ageMinutes).toBeGreaterThanOrEqual(0);
+    expect(r.rawMinutes).toBe(-43); // raw signed diff preserved for diagnostics
+    expect(r.baselineAhead).toBe(true);
+    expect(r.valid).toBe(true);
+  });
+
+  it("reports age 0 for identical timestamps", () => {
+    const r = computeClockAge(1_700_000_000, 1_700_000_000);
+    expect(r.ageMinutes).toBe(0);
+    expect(r.baselineAhead).toBe(false);
+    expect(r.valid).toBe(true);
+  });
+
+  it("truncates a sub-minute difference toward zero (a fresh baseline never rounds up to 1m stale)", () => {
+    const mainTs = 1_700_000_000;
+    const baseTs = mainTs - 59; // 59 seconds older → 0 whole minutes
+    const r = computeClockAge(mainTs, baseTs);
+    expect(r.ageMinutes).toBe(0);
+    expect(r.valid).toBe(true);
+  });
+
+  it("treats missing / non-positive / non-numeric timestamps as invalid with age 0", () => {
+    for (const [m, b] of [
+      [0, 1_700_000_000],
+      [1_700_000_000, 0],
+      ["", "abc"],
+      [-1, 1_700_000_000],
+      [NaN, 1_700_000_000],
+    ] as Array<[unknown, unknown]>) {
+      const r = computeClockAge(m as number, b as number);
+      expect(r.ageMinutes).toBe(0);
+      expect(r.valid).toBe(false);
+    }
+  });
+
+  it("accepts string timestamps (as the workflow passes them via argv)", () => {
+    const r = computeClockAge("1700002700", "1700000000");
+    expect(r.ageMinutes).toBe(45);
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe("#3459 CLI — stdout is a clean non-negative integer for $(...)", () => {
+  function run(args: string[]): string {
+    return execFileSync("node", [SCRIPT, ...args], { encoding: "utf-8" }).trim();
+  }
+
+  it("prints the positive age on the stale path", () => {
+    expect(run(["1700002700", "1700000000"])).toBe("45");
+  });
+
+  it("prints 0 (never a negative string) when the baseline is ahead", () => {
+    const out = run(["1700000000", "1700002580"]); // baseline 43m newer
+    expect(out).toBe("0");
+    expect(out.startsWith("-")).toBe(false);
+  });
+
+  it("prints 0 for the missing-timestamp sentinel (BASELINE_TS=0)", () => {
+    expect(run(["1700000000", "0"])).toBe("0");
+  });
+
+  it("emits the full record with --json", () => {
+    const out = run(["1700000000", "1700002580", "--json"]);
+    const parsed = JSON.parse(out);
+    expect(parsed.ageMinutes).toBe(0);
+    expect(parsed.rawMinutes).toBe(-43);
+    expect(parsed.baselineAhead).toBe(true);
+    expect(parsed.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The `merge_group` baseline-drift/staleness check in `test262-sharded.yml` printed a **negative** clock age (`-43m clock age`). A negative "age" is nonsensical and makes the staleness signal untrustworthy (a genuinely stale baseline could be misreported, obscuring `baseline_staleness_commits`).

## Root cause

The "Check baseline staleness" step computed the age inline as `(MAIN_HEAD_TS - BASELINE_TS) / 60`, where:
- `BASELINE_TS` = git `%ct` (committer timestamp) of the **loopdive/js2wasm-baselines** repo HEAD commit.
- `MAIN_HEAD_TS` = git `%ct` of **this checkout's** `origin/main` HEAD.

Both are already Unix epoch **seconds**, so the epoch unit matched — the defect is a clock-**source** mismatch. The baselines-repo commit is produced by `promote-baseline` **after** the main commit it was generated from, and on a `merge_group` re-validation it can reflect a **newer** main state than the speculative checkout's `origin/main` (main advanced while the group was queued). So `MAIN_HEAD_TS - BASELINE_TS` is frequently negative.

## Fix

- New `scripts/baseline-clock-age.mjs` (`computeClockAge`) documents the single clock source/unit (git `%ct`, Unix seconds) and **clamps** a fresher-than-main-HEAD baseline to age `0` with an honest stderr note (`baselineAhead`) instead of emitting a negative age.
- The staleness step now calls the helper: `DIFF_M=$(node scripts/baseline-clock-age.mjs "$MAIN_HEAD_TS" "$BASELINE_TS")`.
- Also fixes a minor functional side-effect: a negative value previously slipped past the `-ge 30` clock-based fallback warning; the clamp restores correct behaviour (0 age ⇒ not stale, which is right when the baseline is ahead).

## Validation

- `tests/issue-3459-baseline-clock-age.test.ts` — 10 unit + CLI tests covering the sign: the `-43m` repro (→ 0), a genuine stale baseline (→ positive), identity (→ 0), sub-minute truncation, invalid/`0`-sentinel timestamps, and the exact `node scripts/... "$MAIN_HEAD_TS" "$BASELINE_TS"` CLI stdout the workflow consumes.
- prettier / biome / `tsc --noEmit` all clean.

Instrumentation-only — does not change any gate pass/fail decision.

Closes #3459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)