### PR TITLE
refactor(#3105): emit-idiom builder for linear hash-probe init (slice 2)

### DIFF
--- a/plan/issues/3105-emit-idiom-builder-library-dedupe-instruction-scaffolds.md
+++ b/plan/issues/3105-emit-idiom-builder-library-dedupe-instruction-scaffolds.md
@@ -1,10 +1,11 @@
 ---
 id: 3105
 title: "Emit-idiom builder library: dedupe repeated Wasm instruction scaffolds (throw-guard x17, counter-loop x21, proxy-guard x12, hash-probe x10)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-opus-1
 sprint: current
 created: 2026-07-09
-updated: 2026-07-14
+updated: 2026-07-24
 priority: high
 horizon: m
 feasibility: medium
@@ -156,3 +157,37 @@ touched here.
 **Remaining slices (issue stays `in-progress`):** hash-probe *initial* modulo
 `idx = hash % cap` ×10 (same file, next obvious slice), throw-guard×17
 (`expressions/calls.ts`), counter-loop×21, proxy-guard×12, param-object×24.
+
+### Slice 2 — hash-probe init `idx = hash % cap` ×10 (linear backend) — DONE (2026-07-24, dev-opus-1)
+
+**Idiom chosen:** the open-addressing probe **init** `idx = hash % cap` — the
+head of every linear probe loop, computing the first slot from the key hash
+before the loop begins. It is the companion to slice 1's advance (loop tail);
+the "next obvious slice" the slice-1 log named.
+
+**What landed:**
+
+- New builder `hashProbeInitInstrs(hashLocal, capLocal, idxLocal): Instr[]` in
+  `src/codegen-linear/emit-idioms.ts`, returning the exact four instructions
+  `local.get hash · local.get cap · i32.rem_u · local.set idx`. Per-backend by
+  design (#1527); these are linear-memory locals with no WasmGC analogue.
+- All **10** hand-rolled init copies in `src/codegen-linear/runtime.ts` migrated
+  to `...hashProbeInitInstrs(hashLocal, capLocal, idxLocal)` — across the string
+  Map (`__map_set`/`get`/`has`/delete) & Set, and the numeric Map & Set runtimes.
+  Every copy was byte-identical (same op sequence, same `hashLocal`/`capLocal`/
+  `idxLocal` operands), **zero diverged copies** to exclude. **runtime.ts: 40
+  inline lines → 10 call sites (−30 net;** 1 import extended, 0 new import line).
+  After this slice, `codegen-linear/runtime.ts` has **zero** inline `i32.rem_u`
+  (both probe idioms — head + tail — now flow through the builders).
+
+**Byte-identity proof:** `scripts/prove-emit-identity.mjs` baseline (56
+`(file,target)` records, 14 files × 4 targets) captured pre-migration, then
+`check` after migration → **IDENTICAL — all 56 match** (incl.
+`collections.ts::linear`, sha `743dc21e7eea` unchanged). `tsc --noEmit` clean;
+`tests/issue-3105.test.ts` extended with the init-builder shape guards (5 tests
+green; the Map/Set linear compile/run test exercises the init path at each loop
+head, keeping the proof non-vacuous).
+
+**Running total (slices 1+2): 20 of the ≥40 target idiom copies replaced.**
+Remaining: throw-guard×17 (`expressions/calls.ts`), counter-loop×21,
+proxy-guard×12, param-object×24. Issue stays `in-progress`.

--- a/src/codegen-linear/emit-idioms.ts
+++ b/src/codegen-linear/emit-idioms.ts
@@ -45,3 +45,29 @@ export function hashProbeAdvanceInstrs(idxLocal: number, capLocal: number): Inst
     { op: "local.set", index: idxLocal },
   ];
 }
+
+/**
+ * Open-addressing probe initialization: `idx = hash % cap`.
+ *
+ * This is the ×10 hash-probe-INIT idiom of #3105 — the head of every linear
+ * probe loop, computing the initial slot index from the key's hash before the
+ * loop begins (`__map_set`/`__map_get`/`__map_has`/delete, and the set/numeric
+ * variants). It is the companion to {@link hashProbeAdvanceInstrs} (the loop
+ * tail); all 10 copies are byte-identical across the string Map/Set and numeric
+ * Map/Set runtimes, using the same `hashLocal`/`capLocal`/`idxLocal` operands.
+ *
+ * Returns exactly four instructions, in this order:
+ *   local.get hash · local.get cap · i32.rem_u · local.set idx
+ *
+ * @param hashLocal local index holding the (non-zero) key hash
+ * @param capLocal  local index holding the table capacity
+ * @param idxLocal  local index that receives the initial probe slot index
+ */
+export function hashProbeInitInstrs(hashLocal: number, capLocal: number, idxLocal: number): Instr[] {
+  return [
+    { op: "local.get", index: hashLocal },
+    { op: "local.get", index: capLocal },
+    { op: "i32.rem_u" },
+    { op: "local.set", index: idxLocal },
+  ];
+}

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -6,7 +6,7 @@ import {
   LINEAR_STRING_PAYLOAD_SIZE_OFFSET,
 } from "../ir/analysis/linear-memory-plan.js";
 import type { LinearContext } from "./context.js";
-import { hashProbeAdvanceInstrs } from "./emit-idioms.js";
+import { hashProbeAdvanceInstrs, hashProbeInitInstrs } from "./emit-idioms.js";
 
 /** Heap starts at byte offset 1024 (leave low addresses for null/sentinel) */
 const HEAP_START = 1024;
@@ -2676,10 +2676,7 @@ export function addMapRuntime(mod: WasmModule): void {
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
         // idx = hash % cap (unsigned)
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         // Linear probe loop
         {
           op: "block",
@@ -2790,10 +2787,7 @@ export function addMapRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -2877,10 +2871,7 @@ export function addMapRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3046,10 +3037,7 @@ export function addSetRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3145,10 +3133,7 @@ export function addSetRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3318,10 +3303,7 @@ export function addNumericMapRuntime(mod: WasmModule): void {
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
         // idx = hash % cap
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3427,10 +3409,7 @@ export function addNumericMapRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3514,10 +3493,7 @@ export function addNumericMapRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3678,10 +3654,7 @@ export function addNumericSetRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },
@@ -3776,10 +3749,7 @@ export function addNumericSetRuntime(mod: WasmModule): void {
         { op: "local.get", index: 0 },
         { op: "i32.load", align: 2, offset: 12 },
         { op: "local.set", index: capLocal },
-        { op: "local.get", index: hashLocal },
-        { op: "local.get", index: capLocal },
-        { op: "i32.rem_u" },
-        { op: "local.set", index: idxLocal },
+        ...hashProbeInitInstrs(hashLocal, capLocal, idxLocal),
         {
           op: "block",
           blockType: { kind: "empty" },

--- a/tests/issue-3105.test.ts
+++ b/tests/issue-3105.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
-import { hashProbeAdvanceInstrs } from "../src/codegen-linear/emit-idioms.js";
+import { hashProbeAdvanceInstrs, hashProbeInitInstrs } from "../src/codegen-linear/emit-idioms.js";
 
 /**
  * #3105 slice 1 — emit-idiom builder library (linear backend).
@@ -85,5 +85,33 @@ describe("#3105 emit-idioms (linear) — hash-probe advance", () => {
     const r2 = await compile(source, { target: "linear" });
     const { instance: i2 } = await WebAssembly.instantiate(r2.binary, {});
     expect((i2.exports as { run(): number }).run()).toBe(ret);
+  });
+});
+
+/**
+ * #3105 slice 2 — hash-probe INIT (`idx = hash % cap`, the head of every
+ * open-addressing probe loop). Lifted out of the same 10 sites in
+ * `src/codegen-linear/runtime.ts` (string/numeric Map & Set) into
+ * `hashProbeInitInstrs`. Byte-identity across the corpus (including the
+ * `linear` target) is proved by `scripts/prove-emit-identity.mjs`; the Map/Set
+ * program above exercises the init path at each loop head, keeping the proof
+ * non-vacuous.
+ */
+describe("#3105 emit-idioms (linear) — hash-probe init", () => {
+  it("hashProbeInitInstrs returns the exact idx=hash%cap sequence", () => {
+    expect(hashProbeInitInstrs(4, 3, 5)).toEqual([
+      { op: "local.get", index: 4 },
+      { op: "local.get", index: 3 },
+      { op: "i32.rem_u" },
+      { op: "local.set", index: 5 },
+    ]);
+  });
+
+  it("threads distinct hash/cap/idx locals through unchanged (4 instrs, no extra ops)", () => {
+    const seq = hashProbeInitInstrs(9, 2, 7);
+    expect(seq).toHaveLength(4);
+    expect(seq[0]).toEqual({ op: "local.get", index: 9 }); // read hash
+    expect(seq[1]).toEqual({ op: "local.get", index: 2 }); // read cap
+    expect(seq[3]).toEqual({ op: "local.set", index: 7 }); // store idx
   });
 });


### PR DESCRIPTION
## #3105 slice 2 — hash-probe INIT (`idx = hash % cap`)

Companion to slice 1 (PR #3095, hash-probe *advance*). Lifts the ×10
open-addressing probe-**init** scaffold — the head of every linear probe loop,
computing the first slot from the key hash — out of `src/codegen-linear/runtime.ts`
into a new builder `hashProbeInitInstrs(hashLocal, capLocal, idxLocal)` in
`src/codegen-linear/emit-idioms.ts`.

### What changed
- **New builder** returns the exact 4 instructions the sites hand-rolled:
  `local.get hash · local.get cap · i32.rem_u · local.set idx`. Per-backend by
  design (#1527) — linear-memory locals, no WasmGC analogue.
- **All 10 copies migrated** (string Map `set/get/has/delete` & Set, numeric Map
  & Set) to `...hashProbeInitInstrs(...)`. Every copy was byte-identical, zero
  diverged. `runtime.ts` now has **zero inline `i32.rem_u`** (both probe idioms —
  head + tail — flow through builders).

### Safety story (byte-identity provable)
- `scripts/prove-emit-identity.mjs` baseline (56 `(file,target)` records, 14 files
  × 4 targets incl. `linear`) captured **pre**-migration, `check` **IDENTICAL**
  after — `collections.ts::linear` sha `743dc21e7eea` unchanged. The refactor is
  provably a no-op for every emitted binary.
- `tsc --noEmit` clean; prettier + biome clean.
- `tests/issue-3105.test.ts` extended with init-builder shape guards (5 tests
  green; the Map/Set linear compile/run test exercises the init path at each loop
  head — non-vacuous).

### Scope
Multi-slice issue stays `in-progress`. Running total slices 1+2: **20 of ≥40**
target idiom copies replaced. Remaining: throw-guard×17, counter-loop×21,
proxy-guard×12, param-object×24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)