### PR TITLE
fix(#3404): retry transient shard artifact-upload flake so it can't abort the promote

### DIFF
--- a/.github/workflows/refresh-baseline.yml
+++ b/.github/workflows/refresh-baseline.yml
@@ -248,11 +248,34 @@ jobs:
           fi
 
       - name: Upload shard artifacts
+        id: upload_shard
         uses: actions/upload-artifact@v6
         if: always()
+        # #3404 — continue on a transient upload flake so the retry below can
+        # run; only if BOTH attempts fail does the shard (and thus the
+        # merge-and-promote job that `needs:` it) fail. Observed 2026-07-18:
+        # standalone shard 49's upload timed out (ETIMEDOUT on CreateArtifact)
+        # and aborted the entire standalone-heal promote until a human reran it.
+        continue-on-error: true
         with:
           retention-days: 1
           name: emergency-${{ matrix.target.name }}-shard-${{ matrix.chunk }}
+          path: |
+            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
+          if-no-files-found: warn
+
+      # #3404 — retry a transient artifact-upload flake once. Idempotent +
+      # `overwrite` clears any partially finalized artifact. A genuinely empty
+      # shard (no result file) is a `warn`, not a failure, so it never triggers
+      # this retry and the merge step's incomplete-data guard still catches a
+      # real missing chunk.
+      - name: Retry shard artifact upload on transient flake (#3404)
+        if: always() && steps.upload_shard.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          retention-days: 1
+          name: emergency-${{ matrix.target.name }}-shard-${{ matrix.chunk }}
+          overwrite: true
           path: |
             benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
           if-no-files-found: warn

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -583,11 +583,34 @@ jobs:
           echo "vitest_exit_code=$exit_code" >> "$GITHUB_OUTPUT"
 
       - name: Upload shard artifacts
+        id: upload_shard
         uses: actions/upload-artifact@v6
         if: always()
+        # #3404 — continue on a transient upload flake so the retry below can
+        # run; only if BOTH attempts fail does the shard (and thus the promote,
+        # which `needs:` the shard job) fail.
+        continue-on-error: true
         with:
           retention-days: 1
           name: test262-${{ matrix.target.name }}-shard-${{ matrix.chunk }}
+          path: |
+            benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
+          if-no-files-found: warn
+
+      # #3404 — a single transient artifact-upload flake (e.g. `Failed to
+      # CreateArtifact: … ETIMEDOUT` on the upload step, NOT a test failure) on
+      # ONE of the 100+ shards otherwise aborts the whole promote. Retry the
+      # upload once; it is idempotent and `overwrite` clears any partially
+      # finalized artifact from the first attempt. This does NOT weaken the
+      # merge step's incomplete-data sanity floor: a genuinely empty shard
+      # (no files) is a `warn`, not a failure, so it never triggers this retry.
+      - name: Retry shard artifact upload on transient flake (#3404)
+        if: always() && steps.upload_shard.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          retention-days: 1
+          name: test262-${{ matrix.target.name }}-shard-${{ matrix.chunk }}
+          overwrite: true
           path: |
             benchmarks/results/${{ matrix.target.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
           if-no-files-found: warn
@@ -694,8 +717,13 @@ jobs:
           echo "vitest_exit_code=$exit_code" >> "$GITHUB_OUTPUT"
 
       - name: Upload shard artifacts
+        id: upload_shard_mg
         uses: actions/upload-artifact@v6
         if: always()
+        # #3404 — continue on a transient upload flake so the retry below can
+        # run; only if BOTH attempts fail does the shard (and thus the
+        # merge_group promote path that consumes these artifacts) fail.
+        continue-on-error: true
         with:
           retention-days: 1
           # Same naming convention as `test262-shard` (test262-<target>-shard-<N>)
@@ -705,6 +733,21 @@ jobs:
           # no naming collision risk even though chunk_label ranges overlap
           # (1..72 / 1..34 here vs 1..57 in test262-shard).
           name: test262-${{ matrix.target_name }}-shard-${{ matrix.chunk_label }}
+          path: |
+            benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
+          if-no-files-found: warn
+
+      # #3404 — retry a transient artifact-upload flake once (see the matching
+      # rationale on `test262-shard`'s upload above). Idempotent + `overwrite`;
+      # a genuinely empty shard is a `warn`, not a failure, so the incomplete-
+      # data sanity floor at the merge step is preserved.
+      - name: Retry shard artifact upload on transient flake (#3404)
+        if: always() && steps.upload_shard_mg.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          retention-days: 1
+          name: test262-${{ matrix.target_name }}-shard-${{ matrix.chunk_label }}
+          overwrite: true
           path: |
             benchmarks/results/${{ matrix.result_prefix }}-results-${{ env.RUN_TIMESTAMP }}.jsonl
           if-no-files-found: warn

--- a/plan/issues/3404-promote-tolerate-single-shard-upload-flake.md
+++ b/plan/issues/3404-promote-tolerate-single-shard-upload-flake.md
@@ -1,7 +1,8 @@
 ---
 id: 3404
 title: "Baseline promote is blocked by a single test262 shard artifact-upload flake — tolerate ≥N-1 shards or retry the upload"
-status: ready
+status: done
+completed: 2026-07-24
 sprint: current
 created: 2026-07-18
 priority: medium
@@ -57,9 +58,38 @@ Option 2 is a backstop and must not weaken the corrupt/incomplete-data guard.
 
 ## Acceptance criteria
 
-- A single transient shard artifact-upload flake no longer aborts the promote
-  (retry succeeds, or N-1 tolerance proceeds with the sanity floor intact).
-- The corrupt/incomplete-data sanity guard (pass≥1000/total≥40000) is NOT
+- [x] A single transient shard artifact-upload flake no longer aborts the
+  promote (retry succeeds, or N-1 tolerance proceeds with the sanity floor
+  intact).
+- [x] The corrupt/incomplete-data sanity guard (pass≥1000/total≥40000) is NOT
   weakened — a genuinely-missing large chunk still aborts.
-- Applies to both `refresh-baseline.yml` and `test262-sharded.yml`'s promote
+- [x] Applies to both `refresh-baseline.yml` and `test262-sharded.yml`'s promote
   shard→merge path (same pattern in both).
+
+## Resolution (2026-07-24)
+
+Implemented **option 1 (retry the upload)** — the issue's preferred fix, since
+it preserves report completeness. Each shard's `Upload shard artifacts` step
+now carries `id:` + `continue-on-error: true`, followed by a
+`Retry shard artifact upload on transient flake (#3404)` step gated on
+`steps.<id>.outcome == 'failure'` with `overwrite: true`. Applied to all three
+shard-upload sites:
+
+- `test262-sharded.yml` — `test262-shard` (PR/push path) and `test262-shard-mg`
+  (merge_group promote path).
+- `refresh-baseline.yml` — the scheduled/emergency shard upload (the exact step
+  that flaked on 2026-07-18).
+
+**Why the sanity floor is NOT weakened.** `continue-on-error` masks attempt 1's
+failure only long enough for attempt 2 to run; attempt 2 has no
+`continue-on-error`, so if BOTH attempts fail the shard (and the promote that
+`needs:` it) still fails. A *genuinely empty* shard (no result file) is handled
+by the pre-existing `if-no-files-found: warn` — that is a step **success** with
+a warning, so it never triggers the retry and produces no artifact, leaving the
+merge step's `pass≥1000 / total≥40000` incomplete-data guard to catch a real
+missing chunk exactly as before. There is no path where a valid-data shard
+silently uploads nothing yet the job passes.
+
+`overwrite: true` on the retry (already used on other upload-artifact steps in
+these workflows) clears any partially finalized artifact from the flaked first
+attempt, avoiding an "artifact already exists" error on the second try.

--- a/plan/issues/3404-promote-tolerate-single-shard-upload-flake.md
+++ b/plan/issues/3404-promote-tolerate-single-shard-upload-flake.md
@@ -8,7 +8,12 @@ created: 2026-07-18
 priority: medium
 feasibility: medium
 horizon: s
-task_type: bug
+# task_type: ci — this is a GitHub Actions workflow-resilience fix with no
+# compiler/runtime repro (the fix is pure workflow YAML). It is exempt from the
+# #2093 issue→probe coverage gate by design ("Infra/tooling/docs/process issues
+# are exempt — they have no runtime repro"); the earlier `bug` value was a
+# misclassification for a shard artifact-upload retry.
+task_type: ci
 area: ci, infra
 goal: infrastructure
 lane: A


### PR DESCRIPTION
## Problem

At 100+ shards, a single transient GitHub Actions **artifact-upload** flake (e.g. `Failed to CreateArtifact: … ETIMEDOUT` — the test itself passed, only the upload timed out) aborts the whole baseline promote, because the merge/promote job `needs:` the shard job. Observed 2026-07-18: standalone shard 49's upload timed out and blocked the standalone-heal refresh until a human ran `gh run rerun --failed`. At 114 shards the probability of ≥1 upload flake per run is materially higher than at 57, so this recurs.

## Fix

Implements the issue's **preferred option 1 (retry the upload)** — it preserves report completeness. Each `Upload shard artifacts` step gets `id:` + `continue-on-error: true`, followed by a `Retry shard artifact upload on transient flake (#3404)` step gated on `steps.<id>.outcome == 'failure'` with `overwrite: true`. Applied to all three shard-upload sites:

- `test262-sharded.yml` — `test262-shard` (PR/push path) and `test262-shard-mg` (merge_group promote path).
- `refresh-baseline.yml` — the scheduled/emergency shard upload (the exact step that flaked).

## Why the sanity floor is NOT weakened (acceptance criterion)

`continue-on-error` masks attempt 1's failure only long enough for attempt 2 to run; attempt 2 has **no** `continue-on-error`, so if **both** attempts fail the shard (and the promote that `needs:` it) still fails. A *genuinely empty* shard (no result file) is handled by the pre-existing `if-no-files-found: warn` — a step **success** with a warning — so it never triggers the retry and produces no artifact, leaving the merge step's `pass≥1000 / total≥40000` incomplete-data guard to catch a real missing chunk exactly as before. There is no path where a valid-data shard silently uploads nothing yet the job passes.

`overwrite: true` (already used on other upload-artifact steps in these workflows) clears any partially finalized artifact from the flaked first attempt, avoiding an "artifact already exists" error on the retry.

## Validation

- Both workflows parse cleanly and match prettier code style.
- CI-only change; no compiler/test262 impact.

Closes #3404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)