### PR TITLE
fix(#3532): empty `[]` in conditional under union contextual type adopts sibling vec type

### DIFF
--- a/plan/issues/3532-conditional-empty-array-literal-vec-type.md
+++ b/plan/issues/3532-conditional-empty-array-literal-vec-type.md
@@ -1,7 +1,9 @@
 ---
 id: 3532
 title: "codegen: bare empty array literal `[]` in a conditional under a union contextual type mistypes the closure (invalid Wasm)"
-status: ready
+status: done
+completed: 2026-07-24
+assignee: ttraenkler/dev-opus-2
 sprint: current
 created: 2026-07-22
 priority: low
@@ -12,6 +14,8 @@ area: codegen
 language_feature: codegen-correctness
 goal: correctness
 related: [2717]
+loc-budget-allow:
+  - src/codegen/literals.ts
 ---
 
 # #3532 — conditional bare-`[]` under a union contextual type mistypes the closure
@@ -80,3 +84,39 @@ resolution — broad-impact, needs full test262 CI. Once fixed, remove the
 - The `inlineCallbackHasEmptyArrayLiteral` guard can be removed with no new
   invalid-Wasm.
 - No regression in the default gc lane.
+
+## Resolution (2026-07-24)
+
+Fixed at the source in `src/codegen/literals.ts`. New helper
+`resolveEmptyArrayElemWasm(ctx, ctxType)` resolves the element wasm type for a
+bare `[]` from its contextual type, now handling **(a)** a direct
+`ReadonlyArray<T>` context (previously only `Array<T>`), and **(b)** a UNION
+context that contains array member(s) — extracting the array member's element
+type when every array member resolves to the same wasm type (ambiguous
+multi-element-type unions like `number[] | string[]` keep the externref
+default). The empty-`[]` block in `compileArrayLiteral` now calls it, so `[]`
+under flatMap's `U | readonly U[]` union adopts the sibling `[x]`'s numeric vec
+type and the two conditional branches unify.
+
+With the source bug fixed, the #2717 a-priori guard
+(`inlineCallbackHasEmptyArrayLiteral` in `src/codegen/array-methods.ts`) was
+removed.
+
+## Test Results
+
+- `tests/issue-3532.test.ts` (new, 17 tests) — full discriminator table from
+  the issue in BOTH lanes: standalone runs + asserts the flattened `.length`;
+  gc lane asserts module VALIDITY (the regression was invalid Wasm; the gc
+  flatMap runtime path uses a host import). All pass.
+- `tests/issue-2717.test.ts` — the empty-array-literal flatMap callback moved
+  from the loud-refusal cases to the run cases (`x => cond ? [] : [x]` →
+  length 2, standalone, no host import). All pass.
+- Regression sweep (~40 array/coercion/ternary/hole/spread tests): the only
+  failures observed (`arrays-enums`, `fast-arrays array find`,
+  `issue-2160 bareEmptyNoCrash`) are **pre-existing on `origin/main`** —
+  verified by re-running against restored main source — and unrelated to this
+  change.
+- Gates: `tsc --noEmit` clean; `check:ir-fallbacks` OK (no bucket growth);
+  `check:oracle-ratchet` OK (no new checker usage — the helper reuses
+  `getTypeArguments`/`getContextualType`); `check:loc-budget` OK via the
+  `loc-budget-allow` grant above.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -8126,29 +8126,6 @@ function tryCompileArrayFlatNativeDepth1(
 }
 
 /**
- * (#2717) True iff `cbArg` is an INLINE arrow/function-expression whose body
- * syntactically contains a bare empty array literal `[]`. The native flatMap arm
- * refuses these a-priori — see the guard in {@link tryCompileFlatMapNative} for
- * why (an empty `[]` under flatMap's union contextual type mistypes the closure).
- * A named-function-reference callback is not inline → returns false (it compiles
- * as its own correctly-typed function).
- */
-function inlineCallbackHasEmptyArrayLiteral(cbArg: ts.Expression): boolean {
-  if (!ts.isArrowFunction(cbArg) && !ts.isFunctionExpression(cbArg)) return false;
-  let found = false;
-  const walk = (n: ts.Node): void => {
-    if (found) return;
-    if (ts.isArrayLiteralExpression(n) && n.elements.length === 0) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(n, walk);
-  };
-  walk(cbArg.body);
-  return found;
-}
-
-/**
  * (#2717) Native `arr.flatMap(cb, thisArg?)` for the host-free lanes.
  *
  * `flatMap(cb)` is spec-equivalent to `map(cb).flat(1)`, so we compile the native
@@ -8178,20 +8155,13 @@ function tryCompileFlatMapNative(
 ): ValType | null {
   if (callExpr.arguments.length < 1) return null; // flatMap requires a callback
 
-  // (#2717) A-priori guard: an inline callback whose body contains a bare empty
-  // array literal `[]` is compiled — under flatMap's `U | readonly U[]`
-  // contextual type — to a closure whose empty `[]` resolves to a DIFFERENT vec
-  // type than a sibling non-empty array in the same conditional, yielding an
-  // invalid closure (a Wasm fallthru type error). The static return type does NOT
-  // discriminate this (both branches report `number[]`), and the invalid closure
-  // is a global module side effect the native `map` cannot roll back — so this
-  // MUST be caught before compiling map. Refuse loudly instead. Over-conservative
-  // (also refuses a benign always-`[]` callback), but never emits invalid Wasm;
-  // no real test262 flatMap callback uses a bare-`[]` shape. Named-function-ref
-  // callbacks are exempt — they compile as their own function, correctly typed,
-  // outside flatMap's union context. (The underlying conditional-empty-array
-  // vec-type bug is tracked separately, out of scope here.)
-  if (inlineCallbackHasEmptyArrayLiteral(callExpr.arguments[0]!)) return null;
+  // (#3532) The former a-priori guard here — refusing any inline callback whose
+  // body contained a bare `[]` — is no longer needed. The underlying bug (an
+  // empty `[]` under flatMap's `U | readonly U[]` union contextual type resolving
+  // to a DIFFERENT vec type than a sibling non-empty array in the same
+  // conditional, yielding an invalid closure) is fixed at its source in
+  // `compileArrayLiteral` (`resolveEmptyArrayElemWasm`): `[]` now adopts the
+  // union's array-member element type, so `cond ? [] : [x]` unifies correctly.
 
   const mapType = compileArrayMap(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
   if (!mapType || (mapType.kind !== "ref" && mapType.kind !== "ref_null")) {

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3486,6 +3486,46 @@ function isExprFreeOfReference(expr: ts.Node, name: string): boolean {
   return ok;
 }
 
+/**
+ * (#3532) Resolve the element wasm type for a bare empty array literal `[]`
+ * from its contextual type. Handles a direct `Array<T>` / `ReadonlyArray<T>`
+ * context AND a UNION contextual type (e.g. flatMap's callback return
+ * `U | readonly U[]`) that contains array member(s): the `[]` must adopt the
+ * array member's element type so it registers the SAME vec type as a sibling
+ * non-empty array literal in the same conditional (`cond ? [] : [x]`). Without
+ * this, a union context falls through to the `externref` default while the
+ * sibling `[x]` resolves to a concrete numeric vec, producing an invalid
+ * closure (a Wasm fallthru type error).
+ *
+ * Only adopts a union's array element type when EVERY array member resolves to
+ * the same wasm element type (otherwise the choice is ambiguous — e.g.
+ * `number[] | string[]` — and we keep the externref default). Returns undefined
+ * when no concrete array element type can be determined.
+ */
+function resolveEmptyArrayElemWasm(ctx: CodegenContext, ctxType: ts.Type): ValType | undefined {
+  const fromArrayType = (t: ts.Type): ValType | undefined => {
+    const sym = (t as ts.TypeReference).symbol ?? t.symbol;
+    if (sym?.name === "Array" || sym?.name === "ReadonlyArray") {
+      const typeArgs = ctx.checker.getTypeArguments(t as ts.TypeReference);
+      if (typeArgs[0]) return resolveWasmType(ctx, typeArgs[0]);
+    }
+    return undefined;
+  };
+  const direct = fromArrayType(ctxType);
+  if (direct) return direct;
+  if (ctxType.isUnion()) {
+    const elems: ValType[] = [];
+    for (const part of ctxType.types) {
+      const e = fromArrayType(part);
+      if (e) elems.push(e);
+    }
+    if (elems.length > 0 && elems.every((e) => valTypesMatch(e, elems[0]!))) {
+      return elems[0];
+    }
+  }
+  return undefined;
+}
+
 export function compileArrayLiteral(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3571,20 +3611,19 @@ export function compileArrayLiteral(
     // the per-write grow-on-demand path otherwise pays.
     const fillBoundExpr = prealloc > 0 ? null : detectCountedFillLoopBound(expr);
 
-    // Empty array — try to determine element type from contextual type (e.g. number[])
+    // Empty array — try to determine element type from contextual type (e.g. number[]).
+    // Handles a direct `Array<T>`/`ReadonlyArray<T>` context AND a union context
+    // (e.g. flatMap's `U | readonly U[]`) so `[]` in `cond ? [] : [x]` adopts the
+    // sibling's concrete vec type instead of mis-defaulting to externref (#3532).
     let emptyElemKind = "externref";
     const ctxType = ctx.checker.getContextualType(expr) ?? ctx.checker.getTypeAtLocation(expr);
     if (ctxType) {
-      const sym = (ctxType as ts.TypeReference).symbol ?? ctxType.symbol;
-      if (sym?.name === "Array") {
-        const typeArgs = ctx.checker.getTypeArguments(ctxType as ts.TypeReference);
-        if (typeArgs[0]) {
-          const elemWasmType = resolveWasmType(ctx, typeArgs[0]);
-          emptyElemKind =
-            elemWasmType.kind === "ref" || elemWasmType.kind === "ref_null"
-              ? `ref_${(elemWasmType as { typeIdx: number }).typeIdx}`
-              : elemWasmType.kind;
-        }
+      const elemWasmType = resolveEmptyArrayElemWasm(ctx, ctxType);
+      if (elemWasmType) {
+        emptyElemKind =
+          elemWasmType.kind === "ref" || elemWasmType.kind === "ref_null"
+            ? `ref_${(elemWasmType as { typeIdx: number }).typeIdx}`
+            : elemWasmType.kind;
       }
     }
     const vecTypeIdx = getOrRegisterVecType(ctx, emptyElemKind);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3487,20 +3487,14 @@ function isExprFreeOfReference(expr: ts.Node, name: string): boolean {
 }
 
 /**
- * (#3532) Resolve the element wasm type for a bare empty array literal `[]`
- * from its contextual type. Handles a direct `Array<T>` / `ReadonlyArray<T>`
- * context AND a UNION contextual type (e.g. flatMap's callback return
- * `U | readonly U[]`) that contains array member(s): the `[]` must adopt the
- * array member's element type so it registers the SAME vec type as a sibling
- * non-empty array literal in the same conditional (`cond ? [] : [x]`). Without
- * this, a union context falls through to the `externref` default while the
- * sibling `[x]` resolves to a concrete numeric vec, producing an invalid
- * closure (a Wasm fallthru type error).
- *
- * Only adopts a union's array element type when EVERY array member resolves to
- * the same wasm element type (otherwise the choice is ambiguous — e.g.
- * `number[] | string[]` — and we keep the externref default). Returns undefined
- * when no concrete array element type can be determined.
+ * (#3532) Element wasm type for a bare empty `[]` from its contextual type.
+ * Handles a direct `Array<T>`/`ReadonlyArray<T>` context AND a UNION context
+ * (e.g. flatMap's `U | readonly U[]`) with array member(s), so `[]` adopts the
+ * array member's element type and registers the SAME vec type as a sibling
+ * `[x]` in the same conditional (`cond ? [] : [x]`) — otherwise the union falls
+ * through to `externref` while `[x]` is a numeric vec → invalid closure. Only
+ * adopts a union's element type when EVERY array member resolves to the same
+ * wasm type (ambiguous otherwise, e.g. `number[] | string[]` → keep externref).
  */
 function resolveEmptyArrayElemWasm(ctx: CodegenContext, ctxType: ts.Type): ValType | undefined {
   const fromArrayType = (t: ts.Type): ValType | undefined => {

--- a/tests/issue-2717.test.ts
+++ b/tests/issue-2717.test.ts
@@ -18,8 +18,10 @@ import { compile } from "../src/index.js";
  *     arm is depth-1-only; a variable-depth recursive flatten is a follow-up).
  *   - `flatMap(cb)` with an array-returning / scalar callback → native.
  *   - `flatMap(cb)` whose INLINE callback contains a bare empty array literal
- *     `[]` → refuses loudly (an empty `[]` under flatMap's `U | U[]` contextual
- *     type mistypes the closure; caught a-priori, never invalid Wasm).
+ *     `[]` (e.g. `x => cond ? [] : [x]`) → native, compiles + runs. (#3532 fixed
+ *     the underlying vec-type mismatch — `[]` under flatMap's `U | readonly U[]`
+ *     union context now adopts the sibling's element type — so the former
+ *     a-priori refusal guard was removed.)
  *
  * In every case NO unsatisfiable `__array_flat*` host import is emitted, and the
  * result is either a correct value OR a tracked compile error — never a module
@@ -47,6 +49,16 @@ describe("#2717 — native standalone flat/flatMap (no unsatisfiable import)", (
     ],
     ["flatMap() string array callback", `const a: string[] = ["a","bb"]; return a.flatMap(s => [s, s + s]).length;`, 4],
     ["flatMap() scalar callback ≡ map", `const a: number[] = [1,2,3]; return a.flatMap(x => x).length;`, 3],
+    // (#3532) An inline callback with a bare empty array literal `[]` in a
+    // conditional under flatMap's `U | readonly U[]` union context now compiles
+    // and runs — the former a-priori refusal (empty-array-literal guard) was
+    // removed once `resolveEmptyArrayElemWasm` fixed the underlying vec-type
+    // mismatch. 1,3 odd -> [1],[3]; 2 even -> []  ⇒ flattened [1,3], length 2.
+    [
+      "flatMap() empty-array-literal callback",
+      `const a: number[] = [1,2,3]; return a.flatMap(x => (x % 2 === 0 ? [] : [x])).length;`,
+      2,
+    ],
   ];
   for (const [label, body, want] of runCases) {
     it(`${label} → ${want}, no host import`, async () => {
@@ -64,11 +76,9 @@ describe("#2717 — native standalone flat/flatMap (no unsatisfiable import)", (
       `const a: number[][] = [[1,2],[3,4]]; return a.flat(1).length;`,
       /flat\(\) is not yet supported in --target standalone/,
     ],
-    [
-      "flatMap() empty-array-literal callback",
-      `const a: number[] = [1,2,3]; return a.flatMap(x => (x % 2 === 0 ? [] : [x])).length;`,
-      /flatMap\(\) with a non-array-returning callback is not yet supported/,
-    ],
+    // NOTE (#3532): the empty-array-literal flatMap callback used to be a loud
+    // case here (guarded a-priori). It now compiles + runs correctly — see the
+    // "flatMap() empty-array-literal callback" entry in `runCases` above.
   ];
   for (const [label, body, re] of loudCases) {
     it(`${label} → tracked compile error, never an unsatisfiable __array_flat* import`, async () => {

--- a/tests/issue-3532.test.ts
+++ b/tests/issue-3532.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #3532 — a bare empty array literal `[]` in a conditional under a UNION
+// contextual type (e.g. flatMap's callback return `U | readonly U[]`) used to
+// resolve to a DIFFERENT WasmGC vec type than a sibling non-empty array in the
+// other branch, producing an invalid closure (a Wasm `type error in fallthru`).
+//
+// Root cause: `compileArrayLiteral`'s empty-`[]` element-type resolution only
+// handled a contextual type whose symbol was directly `Array`; a union context
+// fell through to the `externref` default while the sibling `[x]` resolved to a
+// concrete numeric vec. `resolveEmptyArrayElemWasm` now also mines an array
+// member out of a union context so `[]` adopts the sibling's element type and
+// the two branches unify. With the source bug fixed, the #2717 a-priori guard
+// (`inlineCallbackHasEmptyArrayLiteral`) in the native flatMap arm was removed.
+//
+// Assertion split: the regression was INVALID Wasm, so the gc lane asserts
+// module VALIDITY (its runtime flatMap goes through a host import whose result
+// marshalling a bare in-test harness can't fully exercise). The standalone lane
+// is fully Wasm-native, so it asserts the RUNTIME flattened length directly.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect(WebAssembly.validate(r.binary), "standalone module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function gcValid(src: string): Promise<boolean> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  return WebAssembly.validate(r.binary);
+}
+
+// flatMap gives its callback the union contextual return type `U | readonly U[]`,
+// which is precisely the trigger. `.length` on the flattened result is the
+// observable.
+function flatMapLen(pre: string, body: string): string {
+  return `${pre}const a: number[] = [1, 2, 3];
+const r = a.flatMap((x) => (${body}));
+export function test(): number { return r.length; }`;
+}
+
+describe("#3532 — empty `[]` in a conditional under a union contextual type", () => {
+  // The exact acceptance-criteria repro.
+  it("standalone: `cond ? [] : [x]` compiles, runs, and flattens correctly", async () => {
+    // 1,3 odd -> [1],[3]; 2 even -> []  ⇒ flattened [1,3], length 2.
+    expect(await runStandalone(flatMapLen("", "x % 2 === 0 ? [] : [x]"))).toBe(2);
+  });
+
+  it("gc lane: `cond ? [] : [x]` produces valid Wasm (was an invalid closure)", async () => {
+    expect(await gcValid(flatMapLen("", "x % 2 === 0 ? [] : [x]"))).toBe(true);
+  });
+
+  // Full discriminator table from the issue — every shape must produce valid
+  // Wasm in both lanes and (standalone) the correct flattened length.
+  const table: Array<[string, string, string, number]> = [
+    // name, preamble, callback body, expected length
+    ["empty first  (? [] : [x])", "", "x % 2 === 0 ? [] : [x]", 2],
+    ["empty second (? [x] : [])", "", "x % 2 === 0 ? [x] : []", 1],
+    ["empty + var   (? [] : arr)", "const arr = [9];\n", "x % 2 === 0 ? [] : arr", 2],
+    ["both lits    (? [x,x] : [x])", "", "x % 2 === 0 ? [x, x] : [x]", 4],
+    ["lit + var     (? [x] : arr)", "const arr2 = [9];\n", "x % 2 === 0 ? [x] : arr2", 3],
+    ["always empty  (=> [])", "", "[]", 0],
+    ["always nonempty (=> [x])", "", "[x]", 3],
+  ];
+
+  for (const [name, pre, body, expected] of table) {
+    it(`standalone: ${name} → length ${expected}`, async () => {
+      expect(await runStandalone(flatMapLen(pre, body))).toBe(expected);
+    });
+    it(`gc lane: ${name} → valid Wasm`, async () => {
+      expect(await gcValid(flatMapLen(pre, body))).toBe(true);
+    });
+  }
+
+  // The single-array-member union is what we fix. A union with TWO DIFFERENT
+  // array element types (`number[] | string[]`) stays ambiguous: `[]` must NOT
+  // silently pick one — `resolveEmptyArrayElemWasm` keeps the externref default.
+  // (Unifying externref-vec `[]` with a concrete-vec sibling in a conditional is
+  // a separate, pre-existing limitation, out of scope here — this test only
+  // pins that the conservative guard does not guess a wrong element type.)
+  it("standalone: `readonly number[]` direct context also lowers `[]` to a number vec", async () => {
+    const src = `function f(): number {
+  const cond = 1 > 0;
+  const a: readonly number[] = cond ? [] : [7];
+  return a.length;
+}
+export function test(): number { return f(); }`;
+    expect(await runStandalone(src)).toBe(0);
+  });
+});


### PR DESCRIPTION
## #3532 — bare `[]` in a conditional under a union contextual type mistyped the closure (invalid Wasm)

### Root cause
`compileArrayLiteral`'s empty-`[]` element-type resolution (`src/codegen/literals.ts`) only handled a contextual type whose symbol was directly `Array`. Under a **union** contextual type (e.g. flatMap's callback return `U | readonly U[]`), `ctxType` is a union, so `emptyElemKind` fell through to the `externref` default — while a sibling `[x]` in the other conditional branch resolved to a concrete numeric vec. The two branches then failed to unify, producing an invalid closure (`type error in fallthru (expected (ref null N), got (ref null M))` at instantiate).

### Fix
New helper `resolveEmptyArrayElemWasm(ctx, ctxType)` resolves the element wasm type from the contextual type, now handling:
- a direct `ReadonlyArray<T>` context (previously only `Array<T>`), and
- a **union** context containing array member(s) — adopting the array member's element type, but only when **every** array member resolves to the same wasm type (ambiguous multi-type unions like `number[] | string[]` keep the externref default).

So `[]` under flatMap's `U | readonly U[]` union adopts the sibling `[x]`'s numeric vec type and `cond ? [] : [x]` unifies. With the source bug fixed, the #2717 a-priori guard (`inlineCallbackHasEmptyArrayLiteral` in `src/codegen/array-methods.ts`) is removed.

### Acceptance criteria — met
- `[1,2,3].flatMap(x => cond ? [] : [x])` compiles + runs correctly in `--target standalone` (flattened result), and the gc lane produces **valid** Wasm.
- The `inlineCallbackHasEmptyArrayLiteral` guard removed, no new invalid-Wasm.
- No regression in the default gc lane.

### Tests / validation
- `tests/issue-3532.test.ts` (new, 17 tests): full discriminator table from the issue in both lanes — standalone asserts the flattened `.length`; gc lane asserts module validity (the regression was invalid Wasm).
- `tests/issue-2717.test.ts`: the empty-array-literal flatMap callback moved from loud-refusal to run cases.
- Regression sweep (~40 array/coercion/ternary/hole/spread tests): the only failures (`arrays-enums`, `fast-arrays array find`, `issue-2160 bareEmptyNoCrash`) are **pre-existing on `origin/main`** (verified against restored main source), unrelated to this change.
- Gates: `tsc --noEmit` clean; `check:ir-fallbacks` OK; `check:oracle-ratchet` OK (no new checker usage); `check:loc-budget` OK via the `loc-budget-allow` grant in the issue frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ