### PR TITLE
docs(plan): reconcile stale issue status (#3379 #3375 done, #3466 superseded, #3420 re-scope)

### DIFF
--- a/plan/issues/3375-baseline-sync-host-compare-wrong-baseline-strands-landing-page.md
+++ b/plan/issues/3375-baseline-sync-host-compare-wrong-baseline-strands-landing-page.md
@@ -8,7 +8,7 @@ created: 2026-07-17
 priority: high
 feasibility: easy
 horizon: s
-task_type: bug
+task_type: infrastructure
 area: ci, infra, pages
 goal: infrastructure
 related: [1951, 1528, 1078, 2562]

--- a/plan/issues/3375-baseline-sync-host-compare-wrong-baseline-strands-landing-page.md
+++ b/plan/issues/3375-baseline-sync-host-compare-wrong-baseline-strands-landing-page.md
@@ -1,7 +1,8 @@
 ---
 id: 3375
 title: "baseline-summary-sync host drift-check compares the wrong baseline → landing page silently strands stale/inflated test262 number"
-status: ready
+status: done
+completed: 2026-07-24
 sprint: current
 created: 2026-07-17
 priority: high
@@ -14,6 +15,12 @@ related: [1951, 1528, 1078, 2562]
 ---
 
 # #3375 — baseline-summary-sync host drift-check uses the wrong `--baseline`, stranding the public landing-page number
+
+> **DONE (2026-07-24, status reconcile).** Fix `fix(#3375): baseline-sync host
+> drift-check must compare the public file it overwrites` merged to `main` via
+> **PR #3272** (`git log origin/main --grep="#3375"`); a `chore(#3375): mark
+> done` commit followed but the issue frontmatter stayed `ready`. Reconciled to
+> `done` here.
 
 ## Symptom
 

--- a/plan/issues/3379-baseline-sync-age-guard-measures-wrong-file.md
+++ b/plan/issues/3379-baseline-sync-age-guard-measures-wrong-file.md
@@ -1,7 +1,8 @@
 ---
 id: 3379
 title: "baseline-summary-sync staleness guard measures the in-repo file, not public/ → busy queue skips the sync forever"
-status: ready
+status: done
+completed: 2026-07-24
 sprint: current
 created: 2026-07-17
 priority: high
@@ -14,6 +15,11 @@ related: [3375, 1951, 2562]
 ---
 
 # #3379 — baseline-summary-sync age guard measures the wrong file (follow-up to #3375)
+
+> **DONE (2026-07-24, status reconcile).** Fix `fix(#3379): baseline-sync
+> staleness guard must measure public/, not the in-repo copy` merged to `main`
+> via **PR #3298** (`git log origin/main --grep="#3379"`). The issue was left at
+> `status: ready` after the merge; reconciled to `done` here.
 
 ## Context
 

--- a/plan/issues/3379-baseline-sync-age-guard-measures-wrong-file.md
+++ b/plan/issues/3379-baseline-sync-age-guard-measures-wrong-file.md
@@ -8,7 +8,7 @@ created: 2026-07-17
 priority: high
 feasibility: easy
 horizon: s
-task_type: bug
+task_type: infrastructure
 area: ci, infra, pages
 goal: infrastructure
 related: [3375, 1951, 2562]

--- a/plan/issues/3420-nonwritable-array-element-write-traps-oob.md
+++ b/plan/issues/3420-nonwritable-array-element-write-traps-oob.md
@@ -16,6 +16,21 @@ related: [3370, 3417, 3335, 3189]
 
 # #3420 — non-writable Array element write traps `oob` instead of throwing TypeError
 
+> **RE-SCOPE (2026-07-24).** Per measurement, this splits into two very
+> different-sized pieces:
+> - **Tractable now (narrow):** the **2-test `filter`/`map` `Symbol.species`
+>   result-backing** slice — the HOF result array's element store traps `oob`
+>   instead of honoring the (species-constructed) result backing. That is a
+>   bounded result-array-write fix, dev/Fable-tier.
+> - **NOT tractable as a point-fix (the bulk):** general **frozen / non-writable
+>   Array element write** semantics (strict→TypeError, sloppy→no-op) require the
+>   **#2744 extensibility-slot substrate** (per-element `[[Writable]]` +
+>   frozen/sealed/preventExtensions queries on the fast array-store path). This
+>   is senior-dev / Fable-tier substrate, not a scoped codegen tweak.
+>
+> Kept `status: ready` but **flagged**: only the narrow species-result slice is
+> dev-claimable; the frozen-write bulk is blocked on #2744. `model: fable` stays.
+
 ## Problem
 Under the honest v8 harness, `propertyHelper.js::verifyProperty` and frozen-array
 tests exercise writes to non-writable / frozen Array elements. Instead of throwing a

--- a/plan/issues/3466-promote-baseline-bot-actor-skip.md
+++ b/plan/issues/3466-promote-baseline-bot-actor-skip.md
@@ -1,10 +1,11 @@
 ---
 id: 3466
 title: "promote-baseline job skips on ALL merge-queue merges (github.actor == github-actions[bot]) → baseline never auto-refreshes"
-status: ready
+status: wont-fix
+completed: 2026-07-24
 sprint: current
 created: 2026-07-19
-updated: 2026-07-19
+updated: 2026-07-24
 priority: high
 horizon: m
 feasibility: medium
@@ -16,6 +17,18 @@ origin: "2026-07-19 tech-lead diagnosis while triaging recurring ratio-drift par
 ---
 
 # #3466 — baseline auto-promote skips on every merge-queue merge
+
+> **SUPERSEDED → wont-fix (2026-07-24, status reconcile).** The motivating
+> symptom — a stale auto-promoted main baseline causing the regression-ratio
+> gate to false-park net-positive PRs — is handled by **#3467/#3468**: the
+> regression gate now diffs against the **real per-SHA merge-base cache**
+> (`fix(ci): compare test262 gate against real merge-base per-SHA cache
+> (#3467)`, merged), not the auto-promoted `main` baseline, so the actor-guard
+> promote-skip no longer drives ratio-drift parks. #3468 closed with the honest
+> floor rebaselined. The actor-guard cleanup in this issue is therefore no
+> longer load-bearing for the queue; closing as superseded rather than doing a
+> now-redundant workflow edit. (If landing-page/other-consumer staleness needs a
+> dedicated promote-on-queue-merge fix later, file a fresh scoped issue.)
 
 ## Problem
 


### PR DESCRIPTION
Doc-only reconcile — keeps the plan honest against `origin/main` (verify-then-close via `git log origin/main --grep`).

- **#3379 → done** — fix merged **PR #3298** (`fix(#3379): baseline-sync staleness guard must measure public/, not the in-repo copy`). Was stranded at `ready` post-merge.
- **#3375 → done** — fix merged **PR #3272** (`fix(#3375): baseline-sync host drift-check must compare the public file it overwrites`); a `chore(#3375) mark done` commit followed but the frontmatter stayed `ready`.
- **#3466 → wont-fix (superseded)** — the motivating symptom (stale auto-promoted baseline → regression-ratio false-parks) is handled by **#3467/#3468**: the gate now diffs the real **per-SHA merge-base cache**, not the auto-promoted `main` baseline, so the actor-guard cleanup is no longer load-bearing. One-line note added; if landing-page/other-consumer staleness needs its own fix later, file fresh.
- **#3420 → re-scoped (kept `ready`, flagged)** — tractable slice = the 2-test `filter`/`map` `Symbol.species` result-backing write; general frozen/non-writable Array-element write needs the **#2744** extensibility-slot substrate (senior-dev/Fable-tier).

No source/test changes. (#3105's own re-scope is deferred to after its in-flight slice PRs #3531/#3534 land, to avoid a same-file conflict — handled separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)