### PR TITLE
feat(#3437): deterministic pre-merge test262 harness compile-time budget gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,19 @@ jobs:
           git fetch --no-tags --depth=200 origin main 2>/dev/null || true
           pnpm run check:loc-budget
 
+      - name: test262 harness compile-time budget gate (#3437)
+        # DETERMINISTIC, load-independent pre-merge budget for source-scan compile
+        # WORK: compiles a FIXED representative harness-shaped assembly and counts
+        # shared-forEachChild traversals (src/ts-api.ts). The oracle-v8 harness
+        # switch tanked CI via an O(call-sites × file-size) per-file scan (#3433,
+        # fixed by #3374) that was INVISIBLE until the merge queue crawled. Unlike
+        # the wall-clock #1942 guard (flaky, post-merge), this count is a pure
+        # function of the AST + scans, so it gates that regression class HERE,
+        # before the queue. Rebank an intentional slowdown with
+        # `pnpm run check:harness-compile-budget -- --update`. Budget:
+        # scripts/harness-compile-budget.json (set from post-#3433 main).
+        run: pnpm run check:harness-compile-budget
+
       - name: IR adoption table freshness (#2145)
         # Fails when plan/log/ir-adoption.md drifts from its generator data or
         # from the IrFallbackReason union in src/ir/select.ts. Regenerate with

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "check:oracle-ratchet": "node scripts/check-oracle-ratchet.mjs",
     "check:pushraw": "node scripts/check-pushraw.mjs",
     "check:loc-budget": "node scripts/check-loc-budget.mjs",
+    "check:harness-compile-budget": "npx tsx scripts/check-harness-compile-budget.ts",
     "check:dead-exports": "node scripts/audit-legacy-reachability.mjs --check",
     "check:godfiles": "node scripts/profile-godfiles.mjs --check",
     "profile:godfiles": "node scripts/profile-godfiles.mjs",

--- a/plan/issues/3437-test262-harness-speed-gate.md
+++ b/plan/issues/3437-test262-harness-speed-gate.md
@@ -1,7 +1,9 @@
 ---
 id: 3437
 title: "CI speed gate: enforce test262 harness compile-time budget so a harness switch can never silently tank CI"
-status: ready
+status: done
+completed: 2026-07-24
+task_type: ci
 sprint: current
 priority: high
 horizon: m
@@ -49,6 +51,46 @@ crawling queue.
   ratchets) when a slowdown is intentional and justified.
 - Validates that #3433 (PR #3374) brought the harness back under budget; the
   committed baseline is set from post-#3433 main.
+
+## Resolution (2026-07-24)
+
+Shipped a deterministic, load-independent, PRE-MERGE budget gate.
+
+**The proxy (load-independent).** Rather than wall-clock (the flaky, post-merge
+#1942 guard), the gate measures a DETERMINISTIC proxy for source-scan compile
+WORK: the number of shared-`forEachChild` traversal-helper invocations
+(`src/ts-api.ts`) while compiling a FIXED, self-contained representative
+harness-shaped assembly. That count is a pure function of the AST + the scans
+performed — no wall-clock, no runner load, no parallelism — so it is
+reproducible bit-for-bit and safe to gate in the pre-merge `quality` job. An
+opt-in meter (`enableForEachChildMeter`/`readForEachChildCalls`) keeps it zero
+behavioural effect and near-zero cost off the gate path.
+
+**Coverage of the #3433 class.** The `symbolBindsAsyncFunction` async-assign
+scan (the exact O(call-sites × file-size) walk #3433 memoized) used
+`ts.forEachChild` directly; it was migrated to the shared helper so the gate
+counts it. Verified: temporarily de-memoizing that scan explodes the fixture
+count **98,089 → 1,120,948** (11.4×), far past the +15% ceiling, and the gate
+FAILS — proving it catches the regression class. The per-file source-scan
+predicates (`src/codegen/source-scan-predicates.ts`) already flow through the
+shared helper.
+
+**Deliverables.**
+- `scripts/check-harness-compile-budget.ts` — gate; `--update` reseeds (like the
+  LOC/IR ratchets); `--json`; a vacuity floor fails if the meter/fixture breaks.
+- `scripts/harness-compile-budget.json` — budget set from post-#3433 main
+  (`forEachChildCalls: 98089`, `marginPct: 15`).
+- `src/ts-api.ts` — opt-in traversal meter.
+- `src/codegen/expressions.ts` — async-assign scan migrated to the shared helper.
+- `.github/workflows/ci.yml` — wired as a required `quality` step.
+- `package.json` — `check:harness-compile-budget`.
+- `tests/issue-3437-harness-compile-budget.test.ts` — pure verdict + fixture
+  determinism + end-to-end "current main is within budget" (acceptance #4).
+
+**Scope caveat (follow-up).** `ts.forEachChild` is a getter-only export (not
+monkey-patchable), so DIRECT `ts.forEachChild` call sites are not counted — the
+meter covers the shared-helper traversal class. New per-file scans should use the
+shared helper; broadening coverage to the remaining direct sites is a follow-up.
 
 ## Notes
 

--- a/scripts/check-harness-compile-budget.ts
+++ b/scripts/check-harness-compile-budget.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env -S npx tsx
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3437 — deterministic, PRE-MERGE compile-time budget gate for the test262
+// harness path.
+//
+// WHY. The oracle-v8 harness switch (#3267/#3370) prepended the ~6–18 KB
+// upstream harness prelude to every one of ~43k tests. That exposed a
+// quadratic per-file AST scan (`symbolBindsAsyncFunction` walking the whole
+// source per call-site), exploding per-compile cost (host shards ~2 min →
+// ~13.6 min) — INVISIBLE until it hit the merge queue, where each merge_group
+// validation ballooned to ~30–90 min. #3433 (PR #3374) fixed the current
+// slowness (memoize the per-file scans), but nothing GATED a future harness /
+// codegen change from silently reintroducing the same class of regression.
+//
+// THE PROXY (load-independent, deterministic). The pre-existing #1942
+// compile-time guard measures WALL-CLOCK under runner load — flaky, and it runs
+// post-merge (too late). This gate instead measures a DETERMINISTIC proxy for
+// source-scan compile WORK: the number of times the shared `forEachChild`
+// traversal helper (src/ts-api.ts) is invoked while compiling a FIXED,
+// self-contained representative harness-shaped assembly. That count is a pure
+// function of the AST + the scans performed — no wall-clock, no runner load, no
+// parallelism — so it is reproducible bit-for-bit and safe to gate in the
+// pre-merge `quality` job. The per-file source-scan predicates and the
+// (now-migrated, #3437) async-assign scan — the exact O(call-sites × file-size)
+// class that tanked CI — all flow through this helper, so a change that
+// re-de-memoizes or adds a per-call-site full-file scan re-explodes the count
+// and fails this gate before it ever reaches the queue.
+//
+// SCOPE / caveat. `ts.forEachChild` is a getter-only export (not
+// monkey-patchable), so DIRECT `ts.forEachChild` call sites are not counted —
+// the meter covers the SHARED-helper traversal class. New per-file source scans
+// should use the shared helper (src/codegen/source-scan-predicates.ts already
+// does); broadening coverage to the remaining direct sites is a follow-up.
+//
+// USAGE
+//   npx tsx scripts/check-harness-compile-budget.ts            # gate (CI)
+//   npx tsx scripts/check-harness-compile-budget.ts --update   # reseed budget
+//   npx tsx scripts/check-harness-compile-budget.ts --json
+//
+// The committed budget lives in scripts/harness-compile-budget.json. A slowdown
+// beyond `marginPct` fails; an intentional/justified slowdown is banked with
+// `--update` (like the LOC / IR ratchets). Set from post-#3433 main.
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { compile } from "../src/index.js";
+import { enableForEachChildMeter, disableForEachChildMeter, readForEachChildCalls } from "../src/ts-api.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUDGET_PATH = join(__dirname, "harness-compile-budget.json");
+
+// A hard vacuity floor: if the measured work drops below this, the fixture or
+// the meter has broken and the gate has gone blind — fail loudly rather than
+// pass vacuously.
+const VACUITY_FLOOR = 800;
+
+interface Budget {
+  forEachChildCalls: number;
+  marginPct: number;
+  fixtureCallSites: number;
+  updated: string;
+  note: string;
+}
+
+/**
+ * Build a FIXED, self-contained, harness-shaped assembly. It deliberately does
+ * NOT read the test262 submodule (the `quality` job checks out without
+ * submodules, and a vendored copy would drift with the corpus) — a synthetic
+ * fixture isolates COMPILER work from corpus churn, which is exactly what a
+ * compiler-regression budget wants. It mimics propertyHelper's shape: many
+ * `Object.defineProperty` + assertion call-sites (the axis the #3433 quadratic
+ * scaled on), plus a class, a delete, and an async-assign pattern so the
+ * per-file source-scan predicates and the async-assign scan all traverse.
+ *
+ * Exported (pure) for unit testing — same string every call.
+ */
+export function buildRepresentativeAssembly(callSites: number): string {
+  const lines: string[] = [
+    "// #3437 representative harness-shaped assembly (synthetic, deterministic).",
+    "class Marker { tag() { return 1; } }",
+    "var asyncRef;",
+    "asyncRef = async function () { return 1; };",
+    "var obj = {};",
+    "function check(name, cond) { if (!cond) { throw new Error(name); } }",
+  ];
+  for (let i = 0; i < callSites; i++) {
+    lines.push(
+      `Object.defineProperty(obj, "p${i}", { value: ${i}, writable: true, enumerable: true, configurable: true });`,
+    );
+    lines.push(`check("p${i}", obj["p${i}"] === ${i});`);
+    if (i % 7 === 0) lines.push(`delete obj["p${i}"];`);
+    if (i % 11 === 0) lines.push(`var m${i} = new Marker(); check("m${i}", m${i}.tag() === 1);`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+export interface BudgetVerdict {
+  measured: number;
+  budget: number;
+  marginPct: number;
+  ceiling: number;
+  overBudget: boolean;
+  vacuous: boolean;
+  wellBelow: boolean;
+}
+
+/**
+ * Pure budget comparison — exported for unit testing. `overBudget` is the hard
+ * fail (a real slowdown past the margin); `vacuous` is the safety fail (the
+ * meter/fixture broke and the gate went blind); `wellBelow` is an advisory to
+ * rebank an improvement.
+ */
+export function evaluateBudget(
+  measured: number,
+  budget: number,
+  marginPct: number,
+  vacuityFloor: number,
+): BudgetVerdict {
+  const ceiling = Math.ceil(budget * (1 + marginPct / 100));
+  return {
+    measured,
+    budget,
+    marginPct,
+    ceiling,
+    overBudget: measured > ceiling,
+    vacuous: measured < vacuityFloor,
+    wellBelow: measured < Math.floor(budget * (1 - marginPct / 100)),
+  };
+}
+
+async function measureCompileWork(callSites: number): Promise<number> {
+  const source = buildRepresentativeAssembly(callSites);
+  enableForEachChildMeter();
+  try {
+    // The assembly may not compile cleanly (as the real harness does not) — the
+    // WORK is what we measure, not success. Both are deterministic.
+    await compile(source, { fileName: "harness-budget-fixture.ts" });
+  } finally {
+    // read BEFORE disable clears nothing (disable only flips the flag), but read
+    // first to be safe against any future change.
+  }
+  const count = readForEachChildCalls();
+  disableForEachChildMeter();
+  return count;
+}
+
+function readBudget(): Budget | null {
+  if (!existsSync(BUDGET_PATH)) return null;
+  return JSON.parse(readFileSync(BUDGET_PATH, "utf-8")) as Budget;
+}
+
+function writeBudget(b: Budget): void {
+  writeFileSync(BUDGET_PATH, JSON.stringify(b, null, 2) + "\n");
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const isUpdate = argv.includes("--update");
+  const isJson = argv.includes("--json");
+
+  // The fixture call-site count is pinned in the budget so measurement and gate
+  // always agree; default to 120 on a fresh --update.
+  const existing = readBudget();
+  const callSites = existing?.fixtureCallSites ?? 120;
+  const marginPct = existing?.marginPct ?? 15;
+
+  const measured = await measureCompileWork(callSites);
+
+  if (isUpdate) {
+    const budget: Budget = {
+      forEachChildCalls: measured,
+      marginPct,
+      fixtureCallSites: callSites,
+      updated: new Date().toISOString().slice(0, 10),
+      note:
+        "Deterministic shared-forEachChild traversal count for the #3437 representative harness " +
+        "assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a " +
+        "slowdown is intentional and justified. See the script header.",
+    };
+    writeBudget(budget);
+    console.log(`#3437 budget reseeded: forEachChildCalls=${measured} (callSites=${callSites}, margin=${marginPct}%).`);
+    process.exit(0);
+  }
+
+  if (!existing) {
+    console.error(
+      "#3437 no budget file (scripts/harness-compile-budget.json). Seed it with:\n" +
+        "  npx tsx scripts/check-harness-compile-budget.ts --update",
+    );
+    process.exit(2);
+  }
+
+  const verdict = evaluateBudget(measured, existing.forEachChildCalls, marginPct, VACUITY_FLOOR);
+  const { ceiling } = verdict;
+
+  if (isJson) {
+    console.log(JSON.stringify({ ...verdict, callSites }, null, 2));
+  } else {
+    console.log(
+      `#3437 harness compile-work: measured=${measured} budget=${existing.forEachChildCalls} ` +
+        `ceiling=${ceiling} (+${marginPct}%) callSites=${callSites}.`,
+    );
+  }
+
+  if (verdict.vacuous) {
+    console.error(
+      `\n✖ FAIL: measured work ${measured} is below the vacuity floor ${VACUITY_FLOOR} — the meter or ` +
+        `fixture has broken and this gate is no longer measuring compile work. Investigate before trusting it.`,
+    );
+    process.exit(1);
+  }
+
+  if (verdict.overBudget) {
+    console.error(
+      `\n✖ FAIL: test262 harness compile work grew ${existing.forEachChildCalls} → ${measured} ` +
+        `(+${measured - existing.forEachChildCalls}, over the +${marginPct}% ceiling ${ceiling}).\n` +
+        `A change materially slowed harness-shaped compilation (the #3433 regression class). If the ` +
+        `slowdown is intentional and justified, rebank with:\n` +
+        `  npx tsx scripts/check-harness-compile-budget.ts --update\n` +
+        `Otherwise fix the added/de-memoized per-file scan. See #3437.`,
+    );
+    process.exit(1);
+  }
+
+  if (verdict.wellBelow) {
+    console.log(
+      `  ℹ compile work dropped well below budget (${existing.forEachChildCalls} → ${measured}); ` +
+        `bank the improvement with --update so the ceiling tracks it.`,
+    );
+  }
+  console.log("  ✓ harness compile work within budget.");
+  process.exit(0);
+}
+
+// Only run as a CLI; the assembly builder is imported by the unit test.
+const invokedAsScript = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedAsScript) {
+  main().catch((e) => {
+    console.error("#3437 gate error:", e);
+    process.exit(2);
+  });
+}

--- a/scripts/harness-compile-budget.json
+++ b/scripts/harness-compile-budget.json
@@ -1,0 +1,7 @@
+{
+  "forEachChildCalls": 98089,
+  "marginPct": 15,
+  "fixtureCallSites": 120,
+  "updated": "2026-07-23",
+  "note": "Deterministic shared-forEachChild traversal count for the #3437 representative harness assembly. Reseed with `npx tsx scripts/check-harness-compile-budget.ts --update` when a slowdown is intentional and justified. See the script header."
+}

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -351,11 +351,7 @@ function asyncAssignedSymbolsInFile(ctx: CodegenContext, sf: ts.SourceFile): Rea
       const assigned = ctx.checker.getSymbolAtLocation(node.left);
       if (assigned) set.add(assigned);
     }
-    // (#3437) Use the shared forEachChild helper so this per-file scan — the
-    // exact O(call-sites × file-size) walk #3433 memoized — is counted by the
-    // compile-work budget meter (a future regression that de-memoizes it would
-    // re-explode this count and fail the gate).
-    forEachChild(node, visit);
+    forEachChild(node, visit); // #3437: shared helper so this per-file scan is counted by the compile-work budget meter
   };
   visit(sf);
   cache.set(sf, set);

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -11,7 +11,7 @@
  *   3. Provides emitCoercedLocalSet and coerceType (used by statements and index)
  *   4. Registers delegates in shared.ts (registerCompileExpression, etc.)
  */
-import { ts } from "../ts-api.js";
+import { ts, forEachChild } from "../ts-api.js";
 import { isBooleanType, isPromiseType, mapTsTypeToWasm } from "../checker/type-mapper.js";
 import {
   classifyAsyncConsumer,
@@ -351,7 +351,11 @@ function asyncAssignedSymbolsInFile(ctx: CodegenContext, sf: ts.SourceFile): Rea
       const assigned = ctx.checker.getSymbolAtLocation(node.left);
       if (assigned) set.add(assigned);
     }
-    ts.forEachChild(node, visit);
+    // (#3437) Use the shared forEachChild helper so this per-file scan — the
+    // exact O(call-sites × file-size) walk #3433 memoized — is counted by the
+    // compile-work budget meter (a future regression that de-memoizes it would
+    // re-explode this count and fail the gate).
+    forEachChild(node, visit);
   };
   visit(sf);
   cache.set(sf, set);

--- a/src/ts-api.ts
+++ b/src/ts-api.ts
@@ -161,11 +161,34 @@ export const tsRuntime: typeof import("typescript") = isTs7 ? loadTs7Module() : 
  * `ts.forEachChild` directly so that codegen can iterate over either backend's
  * AST without per-call-site changes.
  */
+// (#3437) Opt-in compile-work meter. The oracle-v8 harness switch tanked CI via
+// an O(call-sites × file-size) per-file AST scan (#3433); that scan work flows
+// through this shared traversal helper, so counting its invocations is a
+// DETERMINISTIC, runner-load-independent proxy for source-scan compile cost.
+// Off by default (a single boolean check per call — negligible), enabled only by
+// the budget gate (scripts/check-harness-compile-budget.ts). Zero behavioural
+// effect. NOTE: ts.forEachChild is a getter-only export (not monkey-patchable),
+// and direct `ts.forEachChild` call sites are NOT counted — the meter covers the
+// shared-helper traversal class only (see the gate for scope).
+let forEachChildMeterOn = false;
+let forEachChildCalls = 0;
+export function enableForEachChildMeter(): void {
+  forEachChildMeterOn = true;
+  forEachChildCalls = 0;
+}
+export function disableForEachChildMeter(): void {
+  forEachChildMeterOn = false;
+}
+export function readForEachChildCalls(): number {
+  return forEachChildCalls;
+}
+
 export function forEachChild<T>(
   node: ts.Node,
   cbNode: (node: ts.Node) => T | undefined,
   cbNodeArray?: (nodes: ts.NodeArray<ts.Node>) => T | undefined,
 ): T | undefined {
+  if (forEachChildMeterOn) forEachChildCalls++;
   // TS7 native-preview AST nodes carry `forEachChild` as a prototype method.
   // typescript@5 nodes do NOT have this method on the prototype, so this check
   // distinguishes the two without a backend-detection round-trip.

--- a/tests/issue-3437-harness-compile-budget.test.ts
+++ b/tests/issue-3437-harness-compile-budget.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3437 — deterministic pre-merge compile-time budget gate for the test262
+// harness path. The oracle-v8 harness switch tanked CI via a quadratic per-file
+// AST scan (#3433) that was invisible until the merge queue crawled. This gate
+// measures a DETERMINISTIC, load-independent proxy — shared-forEachChild
+// traversal count for a fixed representative assembly — against a committed
+// budget. These tests lock in:
+//   • the pure budget verdict (over / vacuous / wellBelow / ceiling),
+//   • the fixture builder's determinism + scaling,
+//   • that the committed budget actually HOLDS on current main (acceptance #4:
+//     #3433 brought the harness back under budget), and
+//   • that the meter is deterministic run-to-run.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { compile } from "../src/index.js";
+import { enableForEachChildMeter, disableForEachChildMeter, readForEachChildCalls } from "../src/ts-api.js";
+import { evaluateBudget, buildRepresentativeAssembly } from "../scripts/check-harness-compile-budget.js";
+
+const BUDGET = JSON.parse(readFileSync(resolve(__dirname, "../scripts/harness-compile-budget.json"), "utf-8")) as {
+  forEachChildCalls: number;
+  marginPct: number;
+  fixtureCallSites: number;
+};
+const VACUITY_FLOOR = 800;
+
+describe("#3437 evaluateBudget — pure verdict", () => {
+  it("passes when measured equals the budget", () => {
+    const v = evaluateBudget(1000, 1000, 15, VACUITY_FLOOR);
+    expect(v.overBudget).toBe(false);
+    expect(v.vacuous).toBe(false);
+    expect(v.ceiling).toBe(1150);
+  });
+
+  it("passes at the ceiling, fails one over it", () => {
+    expect(evaluateBudget(1150, 1000, 15, VACUITY_FLOOR).overBudget).toBe(false);
+    expect(evaluateBudget(1151, 1000, 15, VACUITY_FLOOR).overBudget).toBe(true);
+  });
+
+  it("flags a large regression as over budget (the #3433 class)", () => {
+    const v = evaluateBudget(1_120_948, 98_089, 15, VACUITY_FLOOR);
+    expect(v.overBudget).toBe(true);
+  });
+
+  it("flags a below-floor measurement as vacuous (meter/fixture broke)", () => {
+    const v = evaluateBudget(10, 98_089, 15, VACUITY_FLOOR);
+    expect(v.vacuous).toBe(true);
+  });
+
+  it("flags a well-below-budget measurement as an improvement to rebank", () => {
+    expect(evaluateBudget(800, 1000, 15, VACUITY_FLOOR).wellBelow).toBe(true); // < floor(850)
+    expect(evaluateBudget(900, 1000, 15, VACUITY_FLOOR).wellBelow).toBe(false);
+  });
+
+  it("rounds the ceiling up (Math.ceil), so a fractional margin never under-gates", () => {
+    expect(evaluateBudget(0, 97, 15, VACUITY_FLOOR).ceiling).toBe(Math.ceil(97 * 1.15)); // 112
+  });
+});
+
+describe("#3437 buildRepresentativeAssembly — deterministic fixture", () => {
+  it("is byte-identical across calls (same input, same string)", () => {
+    expect(buildRepresentativeAssembly(120)).toBe(buildRepresentativeAssembly(120));
+  });
+
+  it("grows with the call-site count and includes the scanned constructs", () => {
+    const small = buildRepresentativeAssembly(5);
+    const big = buildRepresentativeAssembly(120);
+    expect(big.length).toBeGreaterThan(small.length);
+    // Exercises the async-assign scan (#3433 site), a class, a delete, defineProperty.
+    expect(big).toContain("asyncRef = async function");
+    expect(big).toContain("class Marker");
+    expect(big).toContain("delete obj[");
+    expect(big).toContain("Object.defineProperty(obj");
+  });
+});
+
+describe("#3437 committed budget holds on current main", () => {
+  async function measure(callSites: number): Promise<number> {
+    enableForEachChildMeter();
+    await compile(buildRepresentativeAssembly(callSites), { fileName: "harness-budget-fixture.ts" });
+    const n = readForEachChildCalls();
+    disableForEachChildMeter();
+    return n;
+  }
+
+  it("the meter is deterministic run-to-run", async () => {
+    const a = await measure(BUDGET.fixtureCallSites);
+    const b = await measure(BUDGET.fixtureCallSites);
+    expect(a).toBe(b);
+    expect(a).toBeGreaterThan(VACUITY_FLOOR);
+  });
+
+  it("current main is within the committed ceiling (#3433 kept it fast)", async () => {
+    const measured = await measure(BUDGET.fixtureCallSites);
+    const v = evaluateBudget(measured, BUDGET.forEachChildCalls, BUDGET.marginPct, VACUITY_FLOOR);
+    expect(v.overBudget, `measured ${measured} exceeded ceiling ${v.ceiling}`).toBe(false);
+    expect(v.vacuous).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The oracle-v8 harness switch (#3267/#3370) prepended the ~6–18 KB upstream harness prelude to every one of ~43k tests, exposing a quadratic per-file AST scan (`symbolBindsAsyncFunction` walking the whole source per call-site). Per-compile cost exploded (host shards ~2 min → ~13.6 min) — **invisible until it hit the merge queue**, where each `merge_group` validation ballooned to ~30–90 min and the queue crawled. #3433 (PR #3374) fixed the *current* slowness (memoize the per-file scans), but **nothing gated** a future harness/codegen change from silently reintroducing the class.

## Fix — a deterministic, load-independent, pre-merge budget gate

Instead of wall-clock (the flaky, post-merge #1942 guard), the gate measures a **deterministic** proxy for source-scan compile *work*: the number of shared-`forEachChild` traversal-helper invocations (`src/ts-api.ts`, opt-in meter) while compiling a **fixed** representative harness-shaped assembly. That count is a pure function of the AST + the scans performed — no wall-clock, no runner load, no parallelism — so it is reproducible bit-for-bit and safe to run in the pre-merge `quality` job.

**Coverage of the #3433 class (verified).** The async-assign scan used `ts.forEachChild` directly (getter-only, so uncounted); it's migrated to the shared helper so the gate counts it. De-memoizing that scan explodes the fixture count **98,089 → 1,120,948 (11.4×)**, far past the +15% ceiling, and the gate **FAILS** — proving it catches the exact regression class.

## Deliverables

- `scripts/check-harness-compile-budget.ts` — gate; `--update` reseeds (like the LOC/IR ratchets); `--json`; a vacuity floor fails if the meter/fixture breaks.
- `scripts/harness-compile-budget.json` — budget from post-#3433 main (`forEachChildCalls: 98089`, `marginPct: 15`).
- `src/ts-api.ts` — opt-in traversal meter (off by default, zero behavioural effect).
- `src/codegen/expressions.ts` — async-assign scan → shared helper (net-0 LOC).
- `.github/workflows/ci.yml` — wired as a required `quality` step.
- `package.json` — `check:harness-compile-budget`.
- `tests/issue-3437-harness-compile-budget.test.ts` — 10 tests: pure verdict, fixture determinism, and end-to-end "current main is within budget" (acceptance #4).

## Acceptance criteria

- [x] Deterministic, load-independent proxy (node-count-walked), committed budget, fails on > small margin.
- [x] Runs pre-merge in `quality` (not just post-merge); no runner-load dependence.
- [x] Refreshable via `--update`.
- [x] Validates #3433 brought the harness under budget (budget set from post-#3433 main; e2e test asserts it holds).

## Scope caveat (follow-up)

`ts.forEachChild` is a getter-only export (not monkey-patchable), so **direct** `ts.forEachChild` call sites are not counted — the meter covers the shared-helper traversal class. New per-file scans should use the shared helper (`src/codegen/source-scan-predicates.ts` already does); broadening coverage is a follow-up.

Closes #3437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)