### PR TITLE
fix(#3439): ratchet standalone unclassified-root-cause gate 300 → 0

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -852,7 +852,7 @@ jobs:
             --input merged-reports/test262-standalone-results-merged.jsonl \
             --output merged-reports/test262-standalone-report-merged.json \
             --target standalone \
-            --max-unclassified-root-causes 300 \
+            --max-unclassified-root-causes 0 \
             --baseline-sha "${{ github.sha }}" \
             --baseline-generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             ${{ github.event_name != 'workflow_dispatch' && '--include-proposals' || (inputs.include_proposals && '--include-proposals' || '') }}

--- a/plan/issues/3439-standalone-186-unclassified-post-3369.md
+++ b/plan/issues/3439-standalone-186-unclassified-post-3369.md
@@ -1,10 +1,12 @@
 ---
 id: 3439
 title: "Classify the 186 standalone failures #3369 exposed; ratchet --max-unclassified-root-causes 300→0"
-status: ready
+status: done
+completed: 2026-07-24
+assignee: ttraenkler/dev-opus-2
 sprint: current
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-24
 priority: high
 horizon: m
 feasibility: medium
@@ -15,6 +17,53 @@ language_feature: n/a
 goal: standalone-mode
 related: [3426, 2961, 3369, 3378]
 ---
+
+## Resolution (2026-07-24, dev-opus-2, verify-first)
+
+**The bucket work the issue anticipated is no longer needed — the fix is the
+gate flip alone.** Measured against CURRENT main (the standalone merged jsonl
+from the merge_group runs of pr-3530 `30053686236` and pr-3531 `30053051082`,
+both 2026-07-23):
+
+- The #3369-era signature `wasm exception during module init` has **0 records**
+  on current main (down from 185), and `error_category: "unreachable"` has **0**
+  (the single import.meta record is gone too). Six days of main movement
+  fixed/reclassified the 186.
+- Running `scripts/build-test262-report.mjs --target standalone
+  --max-unclassified-root-causes 0 --include-proposals` on BOTH runs' merged
+  jsonl exits **0** with the EXISTING `STANDALONE_ROOT_CAUSE_BUCKETS` —
+  `root_cause_map.unclassified.count === 0` on each (20,424 / 20,420
+  non-pass-non-skip records, all classified). The broad residual buckets
+  (`misc-spec-tail`, `demasked-native-assertion`, `nonstringifiable-wasmgc-exception`,
+  `standalone-host-import-leak-reclassification`) absorb every current failure.
+
+So adding a bucket keyed on `wasm exception during module init` would be **dead
+code catching 0 records** — and worse, if that signature ever reappears a
+pre-existing catch-all would silently absorb it, hiding the very regression the
+gate exists to surface (issue acceptance criterion #3 forbids exactly this). No
+bucket added.
+
+**Enforcement confirmed live** before flipping: a fixture with one unclassified
+`fail` record at `--max-unclassified-root-causes 0` exits **1**
+("…1 unclassified failures; threshold is 0."); the enforcement lives at
+`build-test262-report.mjs` ~L1101-1108 (`process.exitCode = 1` when
+`unclassified.count > threshold`). So restoring 300→0 restores a genuinely
+armed gate, not a no-op.
+
+**Change:** `.github/workflows/test262-sharded.yml` "Build merged standalone
+test262 report" step — `--max-unclassified-root-causes 300` → `0` (reverting
+#3378's temporary relaxation). No `scripts/build-test262-report.mjs` change.
+
+**Test:** `tests/issue-3439.test.ts` (4 tests) locks the load-bearing invariant
+— the gate is ARMED at 0 (unclassified → non-zero exit), PASSES when all
+failures are classified, is opt-in (no flag → no enforcement), and the relaxed
+300 masked a single unclassified (why the flip matters).
+
+**Exposure note:** flipping to a hard 0 arms the gate with zero margin — the
+merge_group run gating this PR (or any PR landing while unclassified > 0) will
+park if a NEW/transient unclassified signature appears. That is the designed
+behavior; the fix for a park is to classify the new signature, not to revert
+this flip.
 
 ## Problem
 

--- a/tests/issue-3439.test.ts
+++ b/tests/issue-3439.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * #3439 — restore the strict standalone root-cause gate
+ * (`--max-unclassified-root-causes 0`, reverting #3378's temporary 300 relaxation).
+ *
+ * Verify-first finding (2026-07-24): the #3369-era 186 unclassified failures
+ * (signature `wasm exception during module init`) no longer appear on current
+ * main (0 records), and the existing `STANDALONE_ROOT_CAUSE_BUCKETS` classify
+ * every current standalone failure (0 unclassified on the merge_group runs for
+ * pr-3530 / pr-3531, 2026-07-23). So the fix is the gate flip alone — a new
+ * bucket would be dead code (criterion #3 forbids catch-alls for absent signals).
+ *
+ * The load-bearing invariant this locks: with `--max-unclassified-root-causes 0`
+ * the report builder ACTUALLY ENFORCES the gate — it exits non-zero when any
+ * standalone failure is unclassified, and exits zero when all are classified.
+ * A future weakening of that enforcement would silently turn the merge_group
+ * triage gate back into a no-op (the real risk behind the 300→0 flip).
+ */
+describe("#3439 — standalone unclassified-root-cause gate enforcement", () => {
+  let tmpDir: string;
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-3439-"));
+  });
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function run(records: object[], threshold?: number): { code: number; stderr: string; outPath: string } {
+    const jsonl = join(tmpDir, `in-${Math.random().toString(36).slice(2)}.jsonl`);
+    const out = join(tmpDir, `out-${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(jsonl, records.map((r) => JSON.stringify(r)).join("\n"));
+    const thresholdArg = threshold === undefined ? "" : ` --max-unclassified-root-causes ${threshold}`;
+    try {
+      execSync(
+        `node scripts/build-test262-report.mjs --input ${jsonl} --output ${out} --target standalone --include-proposals${thresholdArg}`,
+        { cwd: process.cwd(), stdio: "pipe" },
+      );
+      return { code: 0, stderr: "", outPath: out };
+    } catch (e: unknown) {
+      const err = e as { status?: number; stderr?: Buffer };
+      return { code: err.status ?? 1, stderr: err.stderr?.toString() ?? "", outPath: out };
+    }
+  }
+
+  // A standalone `fail` whose signature matches no bucket → unclassified.
+  const unclassified = {
+    file: "test/zzz-novel-unbucketed/aaa.js",
+    category: "zzz-novel-unbucketed",
+    status: "fail",
+    error_category: "other",
+    error: "zzz totally novel qqq signature with no bucket match",
+  };
+  // A standalone `fail` whose error_category text (`assertion_fail`) is caught by
+  // the `misc-spec-tail` residual bucket → classified.
+  const classified = {
+    file: "test/language/expressions/addition/basic.js",
+    category: "language",
+    status: "fail",
+    error_category: "assertion_fail",
+    error: "assertion_fail: expected 3 got 4",
+  };
+  const passRow = { file: "test/built-ins/Array/prototype/map/basic.js", category: "built-ins", status: "pass" };
+
+  it("gate ARMED at 0: an unclassified standalone failure fails the build (non-zero exit)", () => {
+    const r = run([unclassified, passRow], 0);
+    expect(r.code).not.toBe(0);
+    expect(r.stderr).toMatch(/unclassified failures; threshold is 0/);
+  });
+
+  it("gate at 0 PASSES when every standalone failure is classified", () => {
+    const r = run([classified, passRow], 0);
+    expect(r.code).toBe(0);
+    const report = JSON.parse(readFileSync(r.outPath, "utf-8"));
+    expect(report.root_cause_map.unclassified.count).toBe(0);
+    expect(report.root_cause_map.unclassified_threshold).toBe(0);
+  });
+
+  it("without the flag, an unclassified failure does NOT fail the build (gate is opt-in)", () => {
+    const r = run([unclassified, passRow]); // no --max-unclassified-root-causes
+    expect(r.code).toBe(0);
+    const report = JSON.parse(readFileSync(r.outPath, "utf-8"));
+    // still recorded as unclassified in the map, just not enforced
+    expect(report.root_cause_map.unclassified.count).toBe(1);
+    expect(report.root_cause_map.unclassified_threshold).toBe(null);
+  });
+
+  it("the relaxed 300 threshold masks a single unclassified (documents why the flip matters)", () => {
+    const r = run([unclassified, passRow], 300);
+    expect(r.code).toBe(0); // 1 <= 300, so #3378's relaxation let it through
+  });
+});


### PR DESCRIPTION
## #3439 — restore the strict standalone unclassified-root-cause gate

Reverts #3378's temporary `--max-unclassified-root-causes 300` relaxation in the `test262-sharded.yml` "Build merged standalone test262 report" step back to the strict **0** (#2961 policy).

### Verify-first: no new bucket needed (the issue's premise expired)

The issue (filed 2026-07-18) anticipated adding root-cause bucket(s) for the 186 failures #3369 exposed. Measured against **current** main (the standalone merged jsonl from the merge_group runs of pr-3530 `30053686236` and pr-3531 `30053051082`, both 2026-07-23):

- The #3369-era signature `wasm exception during module init` has **0 records** on current main (down from 185); `error_category: "unreachable"` has **0** (the single import.meta record is gone too).
- `build-test262-report.mjs --target standalone --max-unclassified-root-causes 0 --include-proposals` exits **0** on BOTH runs' merged jsonl with the **existing** `STANDALONE_ROOT_CAUSE_BUCKETS` — `root_cause_map.unclassified.count === 0` (20,424 / 20,420 non-pass-non-skip records, all classified). The broad residual buckets (`misc-spec-tail`, `demasked-native-assertion`, `nonstringifiable-wasmgc-exception`, `standalone-host-import-leak-reclassification`) absorb every current failure.

So a bucket keyed on the vanished signature would be **dead code catching 0 records** — and if the signature reappears, a pre-existing catch-all would silently mask the regression the gate exists to surface (acceptance criterion #3 forbids exactly this). **No `scripts/build-test262-report.mjs` change.**

### Enforcement confirmed live before flipping

A fixture with one unclassified `fail` record at `--max-unclassified-root-causes 0` exits **1** (`…1 unclassified failures; threshold is 0.`). The enforcement lives at `build-test262-report.mjs` (~L1101-1108: `process.exitCode = 1` when `unclassified.count > threshold`). So 300→0 restores a genuinely armed gate, not a no-op.

### Change
- `.github/workflows/test262-sharded.yml`: `--max-unclassified-root-causes 300` → `0` (one line).
- `tests/issue-3439.test.ts` (4 tests): locks the gate-enforcement invariant — armed at 0 (unclassified → non-zero exit), passes when all classified, opt-in (no flag → no enforcement), and 300 masks a single unclassified.

### Exposure note (designed behavior, not a defect)
Flipping to a hard 0 arms the gate with zero margin. The `merge_group` run gating this PR (or any PR landing while unclassified > 0) will park if a **new/transient** unclassified signature appears. That is intended — the fix for a park is to classify the new signature, not to revert this flip. The broad residual buckets are the structural safety margin (unclassified is ~0 by construction).

Coordinated with dev-opus-3 on the shared `test262-sharded.yml` (their #3459/#3404 landed; merged origin/main cleanly, my L855 flip intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ