### PR TITLE
docs(plan): reconcile #3392 to done (promote-baseline sparse-clone fix merged)

### DIFF
--- a/plan/issues/3392-baselines-promote-clone-timeout.md
+++ b/plan/issues/3392-baselines-promote-clone-timeout.md
@@ -1,7 +1,9 @@
 ---
 id: 3392
 title: "promote-baseline dies at the baselines-repo clone — runs/ cache growth pushed full-blob clone past the 10-min step timeout"
-status: ready
+status: done
+completed: 2026-07-24
+task_type: infrastructure
 sprint: current
 priority: high
 goal: standalone-mode
@@ -10,6 +12,17 @@ horizon: s
 related: [3380, 3381, 3382, 2942, 1081]
 created: 2026-07-17
 ---
+
+> **DONE (2026-07-24, status reconcile).** Fix `fix(#3392): blob-less sparse
+> clone in baseline promote/refresh — runs/ growth broke the 10-min clone`
+> merged to `main` (commit `ed37396`); the `--filter=blob:none --no-checkout` +
+> sparse-checkout pattern is present at all clone sites in
+> `.github/workflows/test262-sharded.yml` (10 occurrences). Left at
+> `status: ready` after the merge; reconciled to `done` here. `task_type:
+> infrastructure` set (was unset) — this is a pure CI-workflow clone fix with no
+> compiler/runtime repro, matching the #2093 gate's infra exemption. The
+> unbounded-`runs/`-growth follow-up (retention policy) remains PO-owned and
+> out of scope for this issue.
 
 ## Problem
 


### PR DESCRIPTION
Stale-status fold-in (verify-then-close via git).

**#3392 → done** — the promote-baseline clone-timeout fix merged to `main` via commit `ed37396` (`fix(#3392): blob-less sparse clone in baseline promote/refresh — runs/ growth broke the 10-min clone`); the `--filter=blob:none --no-checkout` + sparse-checkout pattern is present at all **10** clone sites in `.github/workflows/test262-sharded.yml`. The issue was stranded at `status: ready`.

Reconciled to `done` + `completed`. Set `task_type: infrastructure` (was unset) — a pure CI-workflow clone fix with no compiler/runtime repro, matching the #2093 Issue→probe coverage gate's documented infra exemption (same honest reclassification rationale as #3375/#3379 in PR #3535, approved by the lead).

The unbounded `runs/`-growth follow-up (retention policy) stays PO-owned, out of scope here.

Doc-only; no source/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)