### PR TITLE
test(#3561): refresh stale #2961 standalone leak-scan guard + fold into required guard suite

### DIFF
--- a/plan/issues/3561-refresh-stale-2961-leak-scan-guard.md
+++ b/plan/issues/3561-refresh-stale-2961-leak-scan-guard.md
@@ -1,0 +1,75 @@
+---
+id: 3561
+title: "test(#2961): refresh stale standalone leak-scan guard test (console.log went host-free) + fold into required guard suite"
+status: done
+completed: 2026-07-24
+assignee: ttraenkler/dev-opus-2
+sprint: current
+created: 2026-07-24
+priority: medium
+horizon: s
+feasibility: easy
+task_type: test-hygiene
+area: testing, ci
+goal: infrastructure
+related: [2961, 3552, 3558]
+---
+
+# #3561 — refresh the stale #2961 standalone leak-scan guard test
+
+## Problem
+
+`tests/issue-2961.test.ts` had **4 silently-rotted assertions** (a #3558-class
+stale guard test, invisible outside required checks because untouched root
+tests don't run at PR time — #3008). Its leak example — `console.log("hello")`
+leaking the native-string bridge `__str_from_mem`/`__str_to_mem`/
+`__str_extern_len` in `--target standalone` — no longer leaks: native strings
++ a native console retired that bridge, so standalone `console.log` now emits
+**zero imports**.
+
+## Verify-first (measured on current main, 2026-07-24)
+
+- Standalone `console.log("hello")` → **0 binary imports** (authoritative
+  `WebAssembly.Module.imports`); the string bridge is retired (0 imports for
+  concat / `String()` / `JSON.stringify` / template literals too).
+- **The leak-scan MECHANISM is healthy**, NOT a regression:
+  - `assertNoLeakedHostImports` still runs for standalone at warning severity
+    (`src/codegen/index.ts:4066-4077`).
+  - `scanForLeakedHostImports` unit-flags a synthetic `env::__str_from_mem` and
+    correctly ignores allowlisted `Math_random`/`console_log_string` +
+    always-allowed `wasi_snapshot_preview1::fd_write`.
+  - End-to-end, a `declare class Widget` extern still leaks `env::Widget_new`/
+    `Widget_render` and produces real `Host import leak (warning, #2961)`
+    diagnostics.
+  - `Math_random`'s silence is correct — `Math_` is on the allowlist.
+- So no bisect: nothing broke; `console.log`'s lowering went native (a win).
+
+## Fix
+
+Rewrote the 4 stale console.log-leak cases in `tests/issue-2961.test.ts` to use
+a **user-declared extern class** (`declare class Widget` → non-allowlisted
+`env::Widget_*`) as the leak example. Extern-class methods are explicitly never
+auto-allowlisted, so — unlike a builtin — this example cannot drift host-free
+and silently stop exercising the scan. Also:
+
+- Replaced the "allowlisted tolerated silently" case with `Math.random`
+  (emits `env::Math_random`, correctly unwarned).
+- Added a POSITIVE assertion that standalone `console.log` is now host-free
+  (documents the improvement that made the old example stale).
+- Kept the passing cases (host-free program, wasi guard, `JS2WASM_STANDALONE_
+  LEAK_SCAN=0`, `buildLeakedHostImportError` wording).
+
+**Folded into the required guard suite** (`tests/guard-suite.json`, run by the
+`quality` job via `pnpm run test:guard`, #3552) — the whole point of the #3558
+closure: this is the 3rd stale/invisible guard test the program has found
+(#3558 ×2, now #2961). The refreshed file runs in ~6s (guard-suite budget is
+60s/file, ~2min total; the full suite is ~15s with this entry).
+
+## Acceptance
+
+- [x] `tests/issue-2961.test.ts` green on current main (11 tests).
+- [x] Leak example is durable (non-allowlisted extern class, cannot go
+      host-free).
+- [x] Positive assertion pins console.log's host-free improvement.
+- [x] Added to `tests/guard-suite.json`; `pnpm run test:guard` green, within
+      the time budget.

--- a/tests/guard-suite.json
+++ b/tests/guard-suite.json
@@ -47,6 +47,11 @@
       "path": "tests/issue-2980-carrier-fallback.test.ts",
       "guards": "standalone Promise carrier lane split: all-drivable async-gen modules import-free (native $Promise), non-drivable ones host-consistent (legacy __gen_* buffer, no mixing)",
       "broken_by": "#3132 PR-2/PR #3013 (2026-07-13) superseded the blanket #2980 fallback silently — red 10 days, found+reconciled by #3558"
+    },
+    {
+      "path": "tests/issue-2961.test.ts",
+      "guards": "standalone host-import leak scan (warning severity): a non-allowlisted leak (user extern class → env::Widget_*) WARNS + still emits (floor-neutral); an allowlisted import (Math_random) is silent; console.log is host-free (native strings+console); the wasi strict path stays a hard error",
+      "broken_by": "native strings + native console retired the __str_from_mem string bridge, so the old console.log leak example went host-free and the 4 console.log assertions silently rotted — a #3558-class invisible stale guard; refreshed to the durable extern-class example + folded into the required gate by #3561"
     }
   ]
 }

--- a/tests/issue-2961.test.ts
+++ b/tests/issue-2961.test.ts
@@ -4,24 +4,42 @@
  * `--target standalone` (today wasi-only), PHASE 1 = warning-first.
  *
  * Under plain `--target standalone` (NOT `strictNoHostImports`) the emit-time
- * import-section scan (`assertNoLeakedHostImports`) now runs at **warning**
- * severity: every host import that survives into the finished standalone binary
- * gets a source-located advisory diagnostic, but:
+ * import-section scan (`assertNoLeakedHostImports`) runs at **warning**
+ * severity: every NON-allowlisted host import that survives into the finished
+ * standalone binary gets a source-located advisory diagnostic, but:
  *   - the binary is emitted UNCHANGED (the per-call `addImport` gate stays
  *     strict-only, so no import is dropped) — the `host_free_pass` floor,
  *     which keys on emitted `env::` imports, does not move; and
  *   - the compile stays `success: true` (warnings are non-fatal).
  *
  * This is the warning-first step before the gate ratchets to a hard error
- * (mirroring wasi's `strictNoHostImports`). These tests pin that contract:
- *   1. A standalone program that leaks a host import (console.log → the
- *      native-string↔extern bridge helpers) warns, but still succeeds AND
- *      still emits the env imports (floor-neutral).
- *   2. A host-free standalone program produces ZERO leak warnings.
- *   3. `JS2WASM_STANDALONE_LEAK_SCAN=0` disables the scan (A/B control).
- *   4. `--target wasi` is unchanged: host-free programs stay host-free, and a
+ * (mirroring wasi's `strictNoHostImports`).
+ *
+ * REFRESH (#3561, 2026-07-24): the ORIGINAL leak example — `console.log("hello")`
+ * leaking the native-string bridge `__str_from_mem`/`__str_to_mem`/
+ * `__str_extern_len` — went **host-free**: native strings + a native console
+ * retired that bridge, so standalone `console.log` now emits ZERO imports and
+ * the four console.log-based assertions silently rotted (a #3558-class stale
+ * guard test, invisible outside required checks). The leak-scan MECHANISM was
+ * never broken (verified: a synthetic `env::__str_from_mem` and an end-to-end
+ * user extern class both still warn; `Math_random` is correctly
+ * allowlisted-silent). The leak example is now a **user-declared extern class**
+ * (`declare class Widget` → non-allowlisted `env::Widget_*`), which — unlike a
+ * builtin — is NEVER auto-allowlisted, so it cannot drift host-free and stop
+ * exercising the scan. A positive assertion pins that console.log is now
+ * host-free (the improvement that made the old example stale).
+ *
+ * These tests pin the contract:
+ *   1. A standalone program that leaks a NON-allowlisted host import (extern
+ *      class) warns, but still succeeds AND still emits the env imports
+ *      (floor-neutral).
+ *   2. An ALLOWLISTED host import (`Math_random`) is emitted but NOT flagged.
+ *   3. `console.log` is now fully host-free under standalone (zero leak).
+ *   4. A host-free standalone program produces ZERO leak warnings.
+ *   5. `JS2WASM_STANDALONE_LEAK_SCAN=0` disables the scan (A/B control).
+ *   6. `--target wasi` is unchanged: host-free programs stay host-free, and a
  *      genuine leak is still a hard ERROR, not a warning.
- *   5. The warning-severity message is worded as a non-fatal advisory (no
+ *   7. The warning-severity message is worded as a non-fatal advisory (no
  *      `Codegen error:` hard-fail marker) and cites #2961; the error-severity
  *      message keeps the original `Codegen error:` wording.
  */
@@ -38,8 +56,23 @@ function envImportNames(wat: string): string[] {
   return out;
 }
 
-/** A program whose standalone lowering leaks the native-string extern bridge. */
-const CONSOLE_LEAK_SRC = `export function test(): number { console.log("hello"); return 1; }`;
+/**
+ * A user-declared extern class whose standalone lowering leaks NON-allowlisted
+ * host imports (`env::Widget_new` / `env::Widget_render`). Extern-class methods
+ * are explicitly never auto-allowlisted (host-import-allowlist.ts: "user-declared
+ * extern classes are NOT auto-allowed"), so this is a DURABLE leak example — it
+ * cannot silently go host-free the way `console.log` did.
+ */
+const EXTERN_LEAK_SRC = `
+declare class Widget {
+  constructor(n: number);
+  render(): number;
+}
+export function test(): number { const w = new Widget(3); return w.render(); }`;
+/** `console.log` — now FULLY host-free under standalone (native console + strings). */
+const CONSOLE_HOSTFREE_SRC = `export function test(): number { console.log("hello"); return 1; }`;
+/** `Math.random` — still a host import, but ALLOWLISTED (`Math_` prefix) → tolerated silently. */
+const ALLOWLISTED_SRC = `export function test(): number { return Math.random() >= 0 ? 1 : 0; }`;
 /** A pure-arithmetic program: host-free under standalone. */
 const HOST_FREE_SRC = `export function test(): number { let x = 0; for (let i = 0; i < 10; i++) x += i * 2; return x; }`;
 
@@ -50,19 +83,18 @@ function hardErrors(errors: { message: string; severity: "error" | "warning" }[]
   return errors.filter((e) => e.severity === "error");
 }
 
-describe("#2961 — standalone host-import leak scan (phase 1, warning-first)", () => {
-  describe("standalone WARNS on a leak but stays success + binary-neutral", () => {
-    it("console.log leak → warning diagnostics naming the string-bridge helpers", async () => {
-      const result = await compile(CONSOLE_LEAK_SRC, { target: "standalone" });
+describe("#2961 — standalone host-import leak scan (phase 1, warning-first; #3561 refresh)", () => {
+  describe("standalone WARNS on a non-allowlisted leak but stays success + binary-neutral", () => {
+    it("extern-class host imports → warning diagnostics naming the leaked imports", async () => {
+      const result = await compile(EXTERN_LEAK_SRC, { target: "standalone" });
       // Non-fatal: warnings do not fail the build.
       expect(result.success).toBe(true);
       const warns = leakWarnings(result.errors);
       expect(warns.length).toBeGreaterThan(0);
-      // The un-allowlisted native-string↔extern bridge helpers are named.
+      // The un-allowlisted extern-class imports are named.
       const joined = warns.map((w) => w.message).join("\n");
-      expect(joined).toContain("__str_from_mem");
-      expect(joined).toContain("__str_to_mem");
-      expect(joined).toContain("__str_extern_len");
+      expect(joined).toContain("Widget_new");
+      expect(joined).toContain("Widget_render");
       // Every leak warning cites #2961 and is NOT a hard-fail `Codegen error:`.
       for (const w of warns) {
         expect(w.message).toContain("#2961");
@@ -71,24 +103,32 @@ describe("#2961 — standalone host-import leak scan (phase 1, warning-first)", 
     });
 
     it("floor-neutral: the leaked env imports are still EMITTED (binary unchanged)", async () => {
-      const result = await compile(CONSOLE_LEAK_SRC, { target: "standalone" });
+      const result = await compile(EXTERN_LEAK_SRC, { target: "standalone" });
       const env = envImportNames(result.wat);
       // The warning scan does not drop imports — they survive into the binary,
-      // exactly as before #2961, so host_free_pass accounting is unchanged.
-      expect(env).toContain("__str_from_mem");
-      expect(env).toContain("__str_to_mem");
-      expect(env).toContain("__str_extern_len");
+      // so host_free_pass accounting is unchanged.
+      expect(env).toContain("Widget_new");
+      expect(env).toContain("Widget_render");
     });
+  });
 
-    it("allowlisted host imports (console_*) are tolerated silently — no warning", async () => {
-      const result = await compile(CONSOLE_LEAK_SRC, { target: "standalone" });
-      const warnedNames = leakWarnings(result.errors)
-        .map((w) => w.message.match(/host import "env\.([^"]+)"/)?.[1])
-        .filter(Boolean);
-      // `console_log_string` is on the allowlist (via the `console_` prefix),
-      // so it is emitted but NOT flagged as a leak.
-      expect(envImportNames(result.wat)).toContain("console_log_string");
-      expect(warnedNames).not.toContain("console_log_string");
+  describe("allowlisted host imports are tolerated silently — no warning", () => {
+    it("Math.random emits the allowlisted env.Math_random but is NOT flagged as a leak", async () => {
+      const result = await compile(ALLOWLISTED_SRC, { target: "standalone" });
+      expect(result.success).toBe(true);
+      // `Math_random` is emitted (still a host import)…
+      expect(envImportNames(result.wat)).toContain("Math_random");
+      // …but the `Math_` allowlist prefix means it is NOT flagged as a leak.
+      expect(leakWarnings(result.errors)).toEqual([]);
+    });
+  });
+
+  describe("console.log is now host-free under standalone (native console + strings)", () => {
+    it("console.log leaks nothing: zero env imports, zero leak warnings (the improvement that made the old example stale)", async () => {
+      const result = await compile(CONSOLE_HOSTFREE_SRC, { target: "standalone" });
+      expect(result.success).toBe(true);
+      expect(envImportNames(result.wat)).toEqual([]);
+      expect(leakWarnings(result.errors)).toEqual([]);
     });
   });
 
@@ -106,11 +146,11 @@ describe("#2961 — standalone host-import leak scan (phase 1, warning-first)", 
       const prev = process.env.JS2WASM_STANDALONE_LEAK_SCAN;
       process.env.JS2WASM_STANDALONE_LEAK_SCAN = "0";
       try {
-        const result = await compile(CONSOLE_LEAK_SRC, { target: "standalone" });
+        const result = await compile(EXTERN_LEAK_SRC, { target: "standalone" });
         expect(result.success).toBe(true);
         expect(leakWarnings(result.errors)).toEqual([]);
         // The binary is byte-for-byte the same either way — imports still emitted.
-        expect(envImportNames(result.wat)).toContain("__str_from_mem");
+        expect(envImportNames(result.wat)).toContain("Widget_new");
       } finally {
         // Reflect.deleteProperty (not `delete`, which trips biome noDelete; not
         // `= undefined`, which would set the literal string "undefined").
@@ -122,7 +162,7 @@ describe("#2961 — standalone host-import leak scan (phase 1, warning-first)", 
 
   describe("wasi is unchanged (regression guard)", () => {
     it("console.log stays host-free under --target wasi (no env imports)", async () => {
-      const result = await compile(CONSOLE_LEAK_SRC, { target: "wasi" });
+      const result = await compile(CONSOLE_HOSTFREE_SRC, { target: "wasi" });
       expect(result.success).toBe(true);
       expect(envImportNames(result.wat)).toEqual([]);
       // wasi is strict → if anything leaked it would be a hard ERROR, not a warning.


### PR DESCRIPTION
## #3561 — refresh the stale #2961 standalone leak-scan guard test

`tests/issue-2961.test.ts` had **4 silently-rotted assertions** — a #3558-class stale guard test, invisible outside required checks (untouched root tests don't run at PR time, #3008). Its leak example — `console.log("hello")` leaking the native-string bridge `__str_from_mem`/`__str_to_mem`/`__str_extern_len` in `--target standalone` — no longer leaks: native strings + a native console retired that bridge, so standalone `console.log` now emits **zero imports**.

### Verify-first (measured on current main)
- Standalone `console.log` → **0 binary imports** (authoritative `WebAssembly.Module.imports`); the string bridge is retired (concat / `String()` / `JSON.stringify` / template literals all 0 imports too).
- The leak-scan **mechanism is healthy**, not a regression (no bisect — `console.log` went native, a win):
  - runs for standalone at warning severity (`src/codegen/index.ts:4066-4077`);
  - `scanForLeakedHostImports` unit-flags a synthetic `env::__str_from_mem`, ignores allowlisted `Math_random`/`console_log_string` + always-allowed `wasi::fd_write`;
  - a `declare class Widget` extern still produces real `Host import leak (warning, #2961)` diagnostics end-to-end;
  - `Math_random`'s silence is correct (`Math_` is allowlisted).

### Fix
- Leak example → **user-declared extern class** (`declare class Widget` → non-allowlisted `env::Widget_*`), which is never auto-allowlisted, so it **cannot drift host-free** and silently rot the way `console.log` did.
- Allowlisted-tolerated case → `Math.random` (emits `env::Math_random`, correctly unwarned).
- Added a **positive assertion** that standalone `console.log` is now host-free (documents the improvement).
- Kept the passing cases (host-free program, wasi guard, `JS2WASM_STANDALONE_LEAK_SCAN=0`, `buildLeakedHostImportError` wording). 11 tests green.

### Closure (the point)
Folded `tests/issue-2961.test.ts` into the **required guard suite** (`tests/guard-suite.json`, run by `quality` via `pnpm run test:guard`, #3552) — the #3558 pattern. This is the 3rd stale/invisible guard test the program has surfaced (#3558 ×2, now #2961); folding them into the required gate is what stops the class from silently rotting. Runs ~6s (budget 60s/file); full suite ~15s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ