### PR TITLE
fix(#2875): reflective String proto RequireObjectCoercible throws on undefined receiver

### DIFF
--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -349,3 +349,45 @@ ToString now correct across all reflective String methods.
   — a separate, shared slice (also fixes the pre-existing `*.call(undefined)
 throws` assertions in `issue-2875*.test.ts`, which fail on main today).
 - RegExp-arg family (~114), case family (25), substring/slice/normalize.
+
+## Slice B (LANDED, dev-std-4) — undefined-receiver RequireObjectCoercible
+
+The `undefined`-receiver residual flagged above is now fixed for all four wired
+reflective String proto member-body families. Root cause confirmed by
+measurement on `origin/main`: under the #2106 `undefinedSingleton` regime
+(default-on in standalone) `undefined` is a DISTINCT non-null sentinel externref,
+so the glue's bare `ref.is_null` RequireObjectCoercible guard caught `null` but
+MISSED `undefined` — `charAt.call(undefined)` etc. silently ToString'd it to
+`"undefined"` and returned a value instead of throwing a TypeError.
+
+**Fix** (`src/codegen/array-object-proto.ts`): a shared
+`emitStringRequireObjectCoercible` helper OR-s in the canonical native
+`__extern_is_undefined` predicate alongside the `ref.is_null` test, applied to
+all four families (index-accessor `charAt`/`at`/`charCodeAt`/`codePointAt`;
+search-numeric `indexOf`/`lastIndexOf`; search-boolean
+`includes`/`startsWith`/`endsWith`; `trim`/`trimStart`/`trimEnd`). The native is
+registered up front (`ensureStringRocUndefinedNative` → `ensureObjectRuntime` +
+`flushLateImportShifts`) so its funcIdx is post-shift-correct at the guard site.
+Host-free (native predicate, no host import). Gated on `undefinedSingletonActive`
+— host lane and the non-singleton regime keep the bare `ref.is_null` (undefined
+≡ `ref.null` there), so byte-identical.
+
+**Measured impact** (standalone lane, base-vs-head diff, 0 regressions):
+
+- **+6 test262 files** flip FAIL→PASS:
+  `{charAt,charCodeAt,indexOf,lastIndexOf,trimEnd,trimStart}/this-value-not-obj-coercible.js`.
+- **+3 committed vitest tests** fixed (previously RED on main):
+  `charAt.call(undefined) throws`, `lastIndexOf.call(undefined,'a') throws`,
+  `endsWith.call(undefined,'') throws`.
+- Byte-neutral for the host lane and for standalone programs outside the
+  reflective-String-closure blast radius (5/5 sample hashes identical).
+
+Covered by `tests/issue-2875-slice-b-undefined-roc.test.ts` (20 cases: all 12
+wired members throw on undefined, null-receiver + valid-receiver regression
+guards). `tsc --noEmit` clean.
+
+**Still residual (unchanged, NOT this slice):** the `at`/`codePointAt`
+out-of-range `=== undefined` return-value comparison (a separate return-path
+undefined-singleton mismatch), the case family (`toUpperCase`/`toLowerCase`,
+un-wired), the RegExp-arg family (~114), and the #2862 ToPrimitive
+object-receiver bucket.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -42,6 +42,7 @@ import { compileArraySliceFromVecLocal } from "./array-methods.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
+import { undefinedSingletonActive } from "./any-helpers.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import {
   ensureAnyToStringHelper,
@@ -766,6 +767,51 @@ function emitArrayProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, me
 }
 
 /**
+ * (#2875) Register the native `__extern_is_undefined` predicate early — BEFORE a
+ * reflective String proto body's other late-import-adding ops — so the
+ * RequireObjectCoercible guard can fetch its post-shift funcIdx by name. Gated on
+ * the #2106 undefinedSingleton regime (standalone/native-strings): only there is
+ * `undefined` a DISTINCT non-null sentinel externref that a bare `ref.is_null`
+ * misses. Idempotent; `flushLateImportShifts` keeps `fctx.body` consistent if the
+ * ensure added an import batch (matters for the trim body, which has no other
+ * late-import op of its own).
+ */
+function ensureStringRocUndefinedNative(ctx: CodegenContext, fctx: FunctionContext): void {
+  if (!undefinedSingletonActive(ctx)) return;
+  ensureObjectRuntime(ctx);
+  flushLateImportShifts(ctx, fctx);
+}
+
+/**
+ * (#2875) Emit RequireObjectCoercible(this) (§22.1.3.1 step 1) for a reflective
+ * `String.prototype.<member>` closure body: throw a catchable TypeError when
+ * `this` (closure param 1, externref) is null OR undefined.
+ *
+ * In standalone under the #2106 undefinedSingleton regime, `undefined` is a
+ * DISTINCT non-null sentinel externref, so a bare `ref.is_null` catches `null`
+ * but MISSES `undefined` — `String.prototype.<m>.call(undefined)` wrongly
+ * ToString'd it to "undefined" and returned a value instead of throwing. OR-in
+ * the canonical native `__extern_is_undefined` (host-free; registered up front by
+ * `ensureStringRocUndefinedNative` so its funcIdx is post-shift-correct here).
+ * When the regime is inactive, `undefined` ≡ `ref.null.extern` and the bare
+ * `ref.is_null` already covers both.
+ */
+function emitStringRequireObjectCoercible(ctx: CodegenContext, fctx: FunctionContext, member: string): void {
+  const rocThrow: Instr[] = [];
+  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
+  fctx.body.push({ op: "local.get", index: 1 });
+  fctx.body.push({ op: "ref.is_null" });
+  const isUndefIdx = undefinedSingletonActive(ctx) ? ctx.funcMap.get("__extern_is_undefined") : undefined;
+  if (isUndefIdx !== undefined) {
+    // `undefined` is a non-null sentinel externref here → also test it explicitly.
+    fctx.body.push({ op: "local.get", index: 1 });
+    fctx.body.push({ op: "call", funcIdx: isUndefIdx });
+    fctx.body.push({ op: "i32.or" });
+  }
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+}
+
+/**
  * (#2875 slice 1) Native body for a reflective `String.prototype.<member>`
  * closure. `this` is closure-param 1 (externref); user args at 2.. (externref-
  * boxed). Implements §22.1.3.x steps: `? RequireObjectCoercible(this)` →
@@ -808,6 +854,7 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
   if (!IN_SCOPE.has(member)) return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
 
   ensureNativeStringHelpers(ctx);
+  ensureStringRocUndefinedNative(ctx, fctx); // (#2875) register the undefined-sentinel predicate first
   const needsNumBox = member === "charCodeAt" || member === "codePointAt";
   // Do ALL late-import-adding ops FIRST (mirrors emitArrayProtoMemberBody), so
   // every helper funcIdx fetched by NAME afterwards is post-shift-correct.
@@ -826,14 +873,11 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
     return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
   }
 
-  // (1) RequireObjectCoercible(this): param 1 externref. In standalone,
-  // undefined is conflated with null as `ref.null.extern`, so a bare
-  // `ref.is_null` catches both → throw a catchable TypeError.
-  const rocThrow: Instr[] = [];
-  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
-  fctx.body.push({ op: "local.get", index: 1 });
-  fctx.body.push({ op: "ref.is_null" });
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+  // (1) RequireObjectCoercible(this) [param 1]: throw a catchable TypeError when
+  // `this` is null OR undefined. Under the #2106 undefinedSingleton regime
+  // `undefined` is a DISTINCT non-null sentinel, so a bare `ref.is_null` would
+  // miss it — see emitStringRequireObjectCoercible.
+  emitStringRequireObjectCoercible(ctx, fctx, member);
 
   // (2) S = ToString(this): externref → anyref → $__any_to_string → $AnyString →
   // flatten. Store the flat string in a local.
@@ -1047,6 +1091,7 @@ function emitStringProtoMemberBody(ctx: CodegenContext, fctx: FunctionContext, m
  */
 function emitStringSearchNumericMemberBody(ctx: CodegenContext, fctx: FunctionContext, member: string): ValType | null {
   ensureNativeStringHelpers(ctx);
+  ensureStringRocUndefinedNative(ctx, fctx); // (#2875) register the undefined-sentinel predicate first
   const isLast = member === "lastIndexOf";
   const helperName = isLast ? "__str_lastIndexOf" : "__str_indexOf";
 
@@ -1066,13 +1111,11 @@ function emitStringSearchNumericMemberBody(ctx: CodegenContext, fctx: FunctionCo
     return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
   }
 
-  // (3) RequireObjectCoercible(this) [param 1]: undefined≡null≡ref.null.extern in
-  // standalone, so a bare ref.is_null throw covers both → catchable TypeError.
-  const rocThrow: Instr[] = [];
-  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
-  fctx.body.push({ op: "local.get", index: 1 });
-  fctx.body.push({ op: "ref.is_null" });
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+  // (3) RequireObjectCoercible(this) [param 1]: throw a catchable TypeError when
+  // `this` is null OR undefined. Under the #2106 undefinedSingleton regime
+  // `undefined` is a DISTINCT non-null sentinel, so a bare `ref.is_null` would
+  // miss it — see emitStringRequireObjectCoercible.
+  emitStringRequireObjectCoercible(ctx, fctx, member);
 
   // (4) lastIndexOf default position: §22.1.3.9 — an absent / `undefined` position
   // is ToIntegerOrInfinity → +∞ ⇒ search from the end. In standalone both map to a
@@ -1137,6 +1180,7 @@ function emitStringSearchNumericMemberBody(ctx: CodegenContext, fctx: FunctionCo
  */
 function emitStringSearchBooleanMemberBody(ctx: CodegenContext, fctx: FunctionContext, member: string): ValType | null {
   ensureNativeStringHelpers(ctx);
+  ensureStringRocUndefinedNative(ctx, fctx); // (#2875) register the undefined-sentinel predicate first
   const helperName =
     member === "includes" ? "__str_includes" : member === "startsWith" ? "__str_startsWith" : "__str_endsWith";
 
@@ -1156,13 +1200,11 @@ function emitStringSearchBooleanMemberBody(ctx: CodegenContext, fctx: FunctionCo
     return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
   }
 
-  // (3) RequireObjectCoercible(this) [param 1]: undefined≡null≡ref.null.extern in
-  // standalone, so a bare ref.is_null throw covers both → catchable TypeError.
-  const rocThrow: Instr[] = [];
-  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
-  fctx.body.push({ op: "local.get", index: 1 });
-  fctx.body.push({ op: "ref.is_null" });
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+  // (3) RequireObjectCoercible(this) [param 1]: throw a catchable TypeError when
+  // `this` is null OR undefined. Under the #2106 undefinedSingleton regime
+  // `undefined` is a DISTINCT non-null sentinel, so a bare `ref.is_null` would
+  // miss it — see emitStringRequireObjectCoercible.
+  emitStringRequireObjectCoercible(ctx, fctx, member);
 
   // (4) endsWith default endPosition: §22.1.3.6 step 6 — absent/`undefined`
   // endPosition ⇒ end = len. Mirror the DIRECT path's 0x7fffffff sentinel
@@ -1221,6 +1263,7 @@ function emitStringSearchBooleanMemberBody(ctx: CodegenContext, fctx: FunctionCo
  */
 function emitStringTrimMemberBody(ctx: CodegenContext, fctx: FunctionContext, member: string): ValType | null {
   ensureNativeStringHelpers(ctx);
+  ensureStringRocUndefinedNative(ctx, fctx); // (#2875) register the undefined-sentinel predicate first
   const helperName = member === "trim" ? "__str_trim" : member === "trimStart" ? "__str_trimStart" : "__str_trimEnd";
 
   // Fetch helper funcIdxs. `ensureAnyToStringHelper` is the last ensure that
@@ -1239,13 +1282,11 @@ function emitStringTrimMemberBody(ctx: CodegenContext, fctx: FunctionContext, me
     return emitProtoMemberBodyRefusal(ctx, fctx, "String", member);
   }
 
-  // (1) RequireObjectCoercible(this) [param 1]: in standalone undefined≡null≡
-  // ref.null.extern, so a bare ref.is_null throw covers both → catchable TypeError.
-  const rocThrow: Instr[] = [];
-  emitBrandCheckTypeError(ctx, rocThrow, `String.prototype.${member} called on null or undefined`);
-  fctx.body.push({ op: "local.get", index: 1 });
-  fctx.body.push({ op: "ref.is_null" });
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rocThrow });
+  // (1) RequireObjectCoercible(this) [param 1]: throw a catchable TypeError when
+  // `this` is null OR undefined. Under the #2106 undefinedSingleton regime
+  // `undefined` is a DISTINCT non-null sentinel, so a bare `ref.is_null` would
+  // miss it — see emitStringRequireObjectCoercible.
+  emitStringRequireObjectCoercible(ctx, fctx, member);
 
   // (2) S = ToString(this); FLATTEN; __str_trim*(S) → native string; → externref.
   fctx.body.push({ op: "local.get", index: 1 });

--- a/tests/issue-2875-slice-b-undefined-roc.test.ts
+++ b/tests/issue-2875-slice-b-undefined-roc.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2875 slice B — reflective `String.prototype.<m>.call(undefined)` must throw a
+// TypeError (RequireObjectCoercible, §22.1.3.1 step 1) in `--target standalone`.
+//
+// Before this slice, the four reflective String proto member-body families
+// (index-accessor charAt/at/charCodeAt/codePointAt, search-numeric indexOf/
+// lastIndexOf, search-boolean includes/startsWith/endsWith, trim/trimStart/
+// trimEnd) guarded RequireObjectCoercible with a bare `ref.is_null`. Under the
+// #2106 undefinedSingleton regime `undefined` is a DISTINCT non-null sentinel
+// externref, so `ref.is_null` caught `null` but MISSED `undefined`:
+// `charAt.call(undefined)` silently ToString'd it to "undefined" and returned a
+// value instead of throwing. This slice OR-s in the native `__extern_is_undefined`
+// predicate (host-free) via a shared `emitStringRequireObjectCoercible` helper.
+//
+// Results are host-opaque WasmGC refs, so tests assert via a number computed
+// INSIDE the module (1 = threw TypeError, 0/2 = did not / wrong error kind).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // No host import may leak: the undefined test is the native __extern_is_undefined.
+  expect(r.imports ?? []).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+// `.call(recv, ...args)` wrapped in try/catch → 1 iff it threw a TypeError.
+const throwsTypeError = (member: string, recv: string, args = ""): string =>
+  `export function test(): number { try { (String.prototype.${member} as any).call(${recv}${args}); return 0; } ` +
+  `catch (e) { return (e instanceof TypeError) ? 1 : 2; } }`;
+
+// Every member that has a native reflective proto body, one per family arm.
+const UNDEF_CASES: ReadonlyArray<[string, string]> = [
+  // index-accessor family (emitStringProtoMemberBody)
+  ["charAt", ", 0"],
+  ["at", ", 0"],
+  ["charCodeAt", ", 0"],
+  ["codePointAt", ", 0"],
+  // search-numeric family (emitStringSearchNumericMemberBody)
+  ["indexOf", ', "x"'],
+  ["lastIndexOf", ', "x"'],
+  // search-boolean family (emitStringSearchBooleanMemberBody)
+  ["includes", ', "x"'],
+  ["startsWith", ', "x"'],
+  ["endsWith", ', "x"'],
+  // trim family (emitStringTrimMemberBody)
+  ["trim", ""],
+  ["trimStart", ""],
+  ["trimEnd", ""],
+];
+
+describe("#2875 slice B — String.prototype.<m>.call(undefined) throws (RequireObjectCoercible)", () => {
+  for (const [member, args] of UNDEF_CASES) {
+    it(`${member}.call(undefined) throws TypeError`, async () => {
+      expect(await runStandalone(throwsTypeError(member, "undefined", args))).toBe(1);
+    });
+  }
+
+  // Regression guard: `null` receivers must STILL throw (ref.is_null half).
+  for (const [member, args] of [
+    ["charAt", ", 0"],
+    ["indexOf", ', "x"'],
+    ["includes", ', "x"'],
+    ["trim", ""],
+  ] as ReadonlyArray<[string, string]>) {
+    it(`${member}.call(null) still throws TypeError`, async () => {
+      expect(await runStandalone(throwsTypeError(member, "null", args))).toBe(1);
+    });
+  }
+
+  // Regression guard: valid string receivers still produce the correct result.
+  it("charAt.call('abc', 1) === 'b'", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const c: any = (String.prototype.charAt as any).call("abc", 1); return c === "b" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("indexOf.call('abcb', 'b') === 1", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const c: any = (String.prototype.indexOf as any).call("abcb", "b"); return c === 1 ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("includes.call('abc', 'b') === true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const c: any = (String.prototype.includes as any).call("abc", "b"); return c === true ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("trim.call('  hi ') === 'hi'", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const c: any = (String.prototype.trim as any).call("  hi "); return c === "hi" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2875 slice B — `String.prototype.<m>.call(undefined)` must throw (standalone)

### Problem (measured on `origin/main`)
Under the #2106 `undefinedSingleton` regime (default-on in `--target standalone`), `undefined` is a **distinct non-null sentinel** externref. The four reflective `String.prototype.<m>.call(...)` glue member-body families guarded RequireObjectCoercible (§22.1.3.1 step 1) with a bare `ref.is_null`, which catches `null` but **misses `undefined`** — so `charAt.call(undefined)`, `trim.call(undefined)`, etc. silently `ToString`'d it to `"undefined"` and returned a value instead of throwing a `TypeError`. `null` receivers correctly threw.

### Fix
A shared `emitStringRequireObjectCoercible` helper OR-s in the canonical native `__extern_is_undefined` predicate alongside `ref.is_null`, applied to all four families:
- index-accessor `charAt`/`at`/`charCodeAt`/`codePointAt`
- search-numeric `indexOf`/`lastIndexOf`
- search-boolean `includes`/`startsWith`/`endsWith`
- `trim`/`trimStart`/`trimEnd`

The native predicate is registered up front (`ensureStringRocUndefinedNative` → `ensureObjectRuntime` + `flushLateImportShifts`) so its funcIdx is post-shift-correct at the guard site. **Host-free** (native predicate, no host import). Gated on `undefinedSingletonActive` — the host lane and the non-singleton regime keep the bare `ref.is_null` (`undefined ≡ ref.null` there), so byte-identical.

### Measured impact (standalone lane, base-vs-head diff, **0 regressions**)
- **+6 test262 files** flip FAIL→PASS: `{charAt,charCodeAt,indexOf,lastIndexOf,trimEnd,trimStart}/this-value-not-obj-coercible.js`.
- **+3 committed vitest tests** fixed (RED on main): `charAt.call(undefined) throws`, `lastIndexOf.call(undefined,'a') throws`, `endsWith.call(undefined,'') throws`.
- Broader 77-file receiver-coercion sweep: 46→52 pass, diff shows exactly those 6 flips and **no PASS→FAIL**.
- Byte-neutral: host lane + standalone programs outside the reflective-String-closure blast radius (5/5 sample binary hashes identical base vs fix).

### Tests
- New: `tests/issue-2875-slice-b-undefined-roc.test.ts` (20 cases: all 12 wired members throw on `undefined`, null-receiver + valid-receiver regression guards). All green.
- `tsc --noEmit` clean.

### Out of scope (documented, pre-existing)
`at`/`codePointAt` out-of-range `=== undefined` return-value mismatch (separate return-path bug), case family (`toUpperCase`/`toLowerCase`, un-wired), RegExp-arg family, and the #2862 ToPrimitive object-receiver bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ