### PR TITLE
fix(#3015): standalone-native call_ref for dynamic function-typed array callbacks

### DIFF
--- a/plan/issues/3015-standalone-array-callback-hostbridge-opaque-externref.md
+++ b/plan/issues/3015-standalone-array-callback-hostbridge-opaque-externref.md
@@ -1,10 +1,12 @@
 ---
 id: 3015
 title: "Standalone: array predicate methods route an opaque-externref (dynamic function-typed param) callback to the __call_1_f64 host bridge instead of native call_ref"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-24
+completed: 2026-07-24
+assignee: ttraenkler/dev-std-1
 priority: low
 feasibility: medium
 task_type: feature
@@ -13,6 +15,19 @@ language_feature: closures, array-methods
 goal: standalone-mode
 related: [1851, 1852, 2939]
 origin: "2026-07-03 leak-analysis round-6 §5 (__call_1_f64, 6 GENUINE sole-import passes) — measured down to the exact trigger, correcting the round-6 'routing artifact' framing"
+# (#3015) The dynamic-callback wrapper key is a wasm-lowering ValType question
+# (resolveWasmType), deliberately above ctx.oracle — the sanctioned raw-checker
+# exception (CLAUDE.md "New codegen needing type info"). Mirrors
+# compileArrowAsClosure's computeClosureWrapperSig lowering so the wrapper cache
+# key matches the arrow value-site's.
+oracle-ratchet-allow:
+  - src/codegen/array-methods.ts
+# (#3015) Genuine feature growth: the standalone dynamic-callback native-call_ref
+# branch + its signature→wrapper resolver live in setupArrayCallback's own
+# subsystem module (array-methods.ts). Co-located with its only caller; keeping
+# the foundational funcref-wrapper-types.ts checker-free is the better split.
+loc-budget-allow:
+  - src/codegen/array-methods.ts
 ---
 
 # #3015 — array-method callback that is an opaque externref leaks `__call_1_f64`
@@ -129,6 +144,48 @@ paths call, so the per-method sites stay uniform.
   (`computeClosureWrapperSig` :1436, `emitFuncRefAsClosure` :3522,
   `emitCachedFuncClosureAccess` :4358) and `ClosureInfo`
   (`src/codegen/context/types.ts:208`).
+
+## Resolution (2026-07-24)
+
+Implemented in `src/codegen/array-methods.ts`. The measured trigger held on
+current `main`: only the **dynamic function-typed param** callback shape leaked
+(`__call_1_f64` for some/every/forEach/map/filter/find*, `__call_2_f64` for
+reduce/reduceRight); inline arrow, named fn and typed-array callbacks were
+already native.
+
+**Direction as-written was not viable; the param is externref.** A function-typed
+parameter's local ValType is `externref` (measured), so there is no closure
+struct to "preserve" (issue's Direction 1). Instead (Direction 2, standalone-
+gated): a new branch in `setupArrayCallback` resolves the callback SIGNATURE's
+canonical funcref wrapper via `getOrCreateFuncRefWrapperTypes` — the same
+cache-keyed wrapper the arrow value-site registers (`resolveDynamicCallbackClosure`
+mirrors `computeClosureWrapperSig`'s `resolveWasmType` lowering so the key
+matches) — converts the externref value to the wrapper self carrier
+(`any.convert_extern` + guarded `ref.cast` + `ref.as_non_null`), and populates
+`setup.closureInfo/closureTypeIdx/closureTmp`. The existing native `call_ref`
+path (`buildClosureCallInstrs` + reduce's inline builder) then runs unchanged, so
+all 11 methods are fixed by the one setup change.
+
+**Risk contained by standalone-gating** (`ctx.standalone`): host (gc) mode keeps
+the working `__call_1_*`/`__call_2_*` bridge fast-path untouched (verified: host
+gc still emits `__call_1_f64`). In standalone the externref branch had zero
+passing tests to regress (the bridge import was non-instantiable), so a
+wrapper-key mismatch on some exotic signature is no worse than the current
+failure. Uses the sanctioned raw-checker exception for the wasm-lowering ValType
+question (`oracle-ratchet-allow` frontmatter).
+
+## Test Results
+
+`tests/issue-3015.test.ts` (9 tests, all pass) — standalone value assertions +
+no-`__call_*`-import check for some/every/forEach/map/filter/find/findIndex/reduce
+(with & without init), 2-/3-param plumbing, byte-neutral already-native cases, and
+a host-mode compile check. Local ad-hoc matrix: 13/13 correct return values,
+no bridge, including an `any[]` (externref-element) receiver. No host regression:
+`tests/functional-array-methods.test.ts` + `array-methods.test.ts` +
+`array-prototype-methods.test.ts` (59) and equivalence/standalone callback suites
+(26) all green. `tsc --noEmit` clean. True standalone flip count is measured by
+the merge_group standalone floor (dev agents run no local test262); the issue's
+"6 sole-import passes" is the pre-fix estimate, not a post-fix measurement.
 
 ## Related
 

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -7,7 +7,7 @@
  * shared.ts (NOT expressions.ts) to avoid circular dependencies.
  */
 import { ts } from "../ts-api.js";
-import { isBooleanType, isStringType } from "../checker/type-mapper.js";
+import { isBooleanType, isStringType, isVoidType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType } from "./context/locals.js";
@@ -19,8 +19,10 @@ import {
   addStringImports,
   addUnionImports,
   resolveWasmType,
+  resolveWasmTypeForClosureReturn,
   typedArrayPackedSignedness,
 } from "./index.js";
+import { getClosureFuncSelfTypeIdx, getOrCreateFuncRefWrapperTypes } from "./closures/funcref-wrapper-types.js";
 import { addStringConstantGlobal, localGlobalIdx } from "./registry/imports.js";
 import { buildThrowJsErrorInstrs, emitThrowTypeError, noJsHost } from "./js-errors.js";
 import { emitTypedArraySetBoundsCheck } from "./typed-array-set-bounds.js";
@@ -59,7 +61,7 @@ import { emitNativeNumberFormat } from "./number-format-native.js";
 import { ensureNativeArrayHof } from "./hof-native.js";
 import { allocJoinFoldLocals, emitStringJoinFold, hostStringRepr, nativeStringRepr } from "./builtin-scaffold.js";
 import { ensureTimsortHelper } from "./timsort.js";
-import { coerceType, coercionInstrs, defaultValueInstrs } from "./type-coercion.js";
+import { coerceType, coercionInstrs, defaultValueInstrs, emitGuardedRefCast } from "./type-coercion.js";
 
 // (#3264) Array.prototype-borrow subsystem extracted to array-prototype-borrow.ts;
 // re-export the two public entries so existing importers keep resolving.
@@ -4709,6 +4711,54 @@ function compileThisArg(
 }
 
 /**
+ * (#3015) Resolve the canonical funcref-wrapper closure for a DYNAMIC
+ * function-typed callback value that compiled to an opaque `externref` — i.e. a
+ * function PARAMETER (`function run(cb){ return arr.some(cb); }`), the one
+ * callback shape that still routed through the `__call_1_*` / `__call_2_*` host
+ * bridge. In standalone (host-free) mode that import makes the module
+ * non-instantiable, so those tests never ran.
+ *
+ * The value IS a wasm closure struct at runtime (the caller passed an arrow /
+ * function value), so we recover a native `call_ref` by resolving the
+ * callback SIGNATURE's canonical wrapper via `getOrCreateFuncRefWrapperTypes` —
+ * the SAME cache-keyed wrapper the arrow value-site registers, so the runtime
+ * closure struct (a subtype of the wrapper root) casts and calls cleanly. We
+ * return the `ClosureInfo` plus the lifted self carrier (the wrapper root) that
+ * the externref is cast to.
+ *
+ * Returns `undefined` (→ host-bridge fallback, unchanged) when the callback has
+ * no single resolvable call signature.
+ */
+function resolveDynamicCallbackClosure(
+  ctx: CodegenContext,
+  cbArg: ts.Expression,
+): { closureInfo: ClosureInfo; selfStructTypeIdx: number } | undefined {
+  // oracle-ratchet-allow (#3015): the wrapper cache key is a wasm-lowering
+  // ValType question (`resolveWasmType`), deliberately ABOVE `ctx.oracle`. This
+  // mirrors `compileArrowAsClosure`'s `computeClosureWrapperSig` lowering so the
+  // key MATCHES the arrow value-site's — they share the wrapper struct + func
+  // type, which is exactly what makes the runtime `ref.cast` + `call_ref` valid.
+  const cbType = ctx.checker.getTypeAtLocation(cbArg);
+  const sigs = cbType.getCallSignatures();
+  if (sigs.length !== 1) return undefined;
+  const sig = sigs[0]!;
+  const paramValTypes: ValType[] = [];
+  for (const p of sig.parameters) {
+    const loc = p.valueDeclaration ?? p.declarations?.[0] ?? cbArg;
+    paramValTypes.push(resolveWasmType(ctx, ctx.checker.getTypeOfSymbolAtLocation(p, loc)));
+  }
+  const retTsType = ctx.checker.getReturnTypeOfSignature(sig);
+  const results: ValType[] =
+    isVoidType(retTsType) || (retTsType.flags & ts.TypeFlags.Never) !== 0
+      ? []
+      : [resolveWasmTypeForClosureReturn(ctx, retTsType)];
+  const wrapper = getOrCreateFuncRefWrapperTypes(ctx, paramValTypes, results);
+  if (!wrapper) return undefined;
+  const selfStructTypeIdx = getClosureFuncSelfTypeIdx(ctx, wrapper.liftedFuncTypeIdx) ?? wrapper.structTypeIdx;
+  return { closureInfo: wrapper.closureInfo, selfStructTypeIdx };
+}
+
+/**
  * Compile the callback argument and set up either a closure (call_ref) path
  * or a host bridge fallback. Returns null if setup fails (error pushed).
  *
@@ -4742,6 +4792,32 @@ function setupArrayCallback(
     closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
     if (closureInfo) {
       closureTmp = allocLocal(fctx, `__arr_${tag}_clcb_${fctx.locals.length}`, cbResult);
+      fctx.body.push({ op: "local.set", index: closureTmp });
+    }
+  } else if (ctx.standalone && cbResult && cbResult.kind === "externref") {
+    // (#3015) Standalone: a dynamic function-typed callback value (a function
+    // PARAMETER, e.g. `arr.some(cb)`) arrives as an opaque externref and would
+    // otherwise route through the `__call_1_*`/`__call_2_*` host bridge — a
+    // host import that is not instantiable host-free. Recover a native
+    // `call_ref` via the callback signature's canonical funcref wrapper. Host
+    // mode is untouched (this branch is standalone-gated) and keeps the bridge
+    // as its fast path per the dual-mode principle.
+    const dyn = resolveDynamicCallbackClosure(ctx, cbArg);
+    if (dyn) {
+      closureInfo = dyn.closureInfo;
+      closureTypeIdx = dyn.selfStructTypeIdx;
+      // The externref callback value is on the stack: convert it to the wrapper
+      // self carrier and store a NON-NULL closure ref. The native invocation
+      // path (`buildClosureCallInstrs` / reduce) pushes `closureTmp` as the
+      // `call_ref` self argument, whose param type is `(ref root)` — non-null,
+      // matching the arrow branch's `(ref …)` `closureTmp`.
+      fctx.body.push({ op: "any.convert_extern" });
+      emitGuardedRefCast(fctx, dyn.selfStructTypeIdx);
+      fctx.body.push({ op: "ref.as_non_null" });
+      closureTmp = allocLocal(fctx, `__arr_${tag}_dyncb_${fctx.locals.length}`, {
+        kind: "ref",
+        typeIdx: dyn.selfStructTypeIdx,
+      });
       fctx.body.push({ op: "local.set", index: closureTmp });
     }
   }

--- a/tests/issue-3015.test.ts
+++ b/tests/issue-3015.test.ts
@@ -1,0 +1,137 @@
+// #3015 — standalone: array predicate methods routed an opaque-externref
+// (dynamic function-typed param) callback to the `__call_1_f64` / `__call_2_f64`
+// host bridge instead of a native `call_ref`. That import makes a standalone
+// (host-free) module non-instantiable, so every such test failed.
+//
+// Fix (src/codegen/array-methods.ts, setupArrayCallback): when the callback
+// value compiles to an opaque `externref` (a function PARAMETER) in standalone
+// mode, resolve the callback signature's canonical funcref wrapper
+// (getOrCreateFuncRefWrapperTypes — the SAME cache-keyed wrapper the arrow
+// value-site registers) and convert the externref to it, so the existing native
+// call_ref path runs. Host mode is untouched (branch is `ctx.standalone`-gated)
+// and keeps the bridge fast-path (dual-mode principle).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const CALL_BRIDGES = ["__call_1_f64", "__call_1_i32", "__call_2_f64", "__call_2_i32"];
+
+async function runStandalone(src: string): Promise<number | undefined> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // No host call-bridge import may remain (the whole point of #3015).
+  const importNames = (r.imports ?? []).map((i) => i.name);
+  for (const bridge of CALL_BRIDGES) {
+    expect(importNames, `standalone module must not import ${bridge}`).not.toContain(bridge);
+  }
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)?.();
+}
+
+describe("#3015 — dynamic function-typed array callback is native in standalone", () => {
+  it("some (true / false) via a dynamic param callback", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>boolean):boolean{const a=[1,2,3];return a.some(cb);}` +
+          `export function test():number{return run(x=>x>2)?1:0;}`,
+      ),
+    ).toBe(1);
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>boolean):boolean{const a=[1,2,3];return a.some(cb);}` +
+          `export function test():number{return run(x=>x>9)?1:0;}`,
+      ),
+    ).toBe(0);
+  });
+
+  it("every via a dynamic param callback", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>boolean):boolean{const a=[2,4,6];return a.every(cb);}` +
+          `export function test():number{return run(x=>x%2===0)?1:0;}`,
+      ),
+    ).toBe(1);
+  });
+
+  it("forEach accumulates via a dynamic param callback", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>void):void{const a=[1,2,3,4];a.forEach(cb);}` +
+          `export function test():number{let s=0;run(x=>{s+=x;});return s;}`,
+      ),
+    ).toBe(10);
+  });
+
+  it("map / filter via a dynamic param callback", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>number):number[]{const a=[1,2,3];return a.map(cb);}` +
+          `export function test():number{return run(x=>x*10)[2];}`,
+      ),
+    ).toBe(30);
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>boolean):number[]{const a=[1,2,3,4,5];return a.filter(cb);}` +
+          `export function test():number{return run(x=>x>2).length;}`,
+      ),
+    ).toBe(3);
+  });
+
+  it("find / findIndex via a dynamic param callback", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>boolean):number|undefined{const a=[1,2,3,4];return a.find(cb);}` +
+          `export function test():number{return run(x=>x>2) as number;}`,
+      ),
+    ).toBe(3);
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number)=>boolean):number{const a=[10,20,30];return a.findIndex(cb);}` +
+          `export function test():number{return run(x=>x===20);}`,
+      ),
+    ).toBe(1);
+  });
+
+  it("reduce (with and without initial value) via a dynamic param callback", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(acc:number,x:number)=>number):number{const a=[1,2,3,4];return a.reduce(cb,0);}` +
+          `export function test():number{return run((acc,x)=>acc+x);}`,
+      ),
+    ).toBe(10);
+    expect(
+      await runStandalone(
+        `function run(cb:(acc:number,x:number)=>number):number{const a=[5,6,7];return a.reduce(cb);}` +
+          `export function test():number{return run((acc,x)=>acc+x);}`,
+      ),
+    ).toBe(18);
+  });
+
+  it("index / array callback params are plumbed", async () => {
+    expect(
+      await runStandalone(
+        `function run(cb:(x:number,i:number,arr:number[])=>boolean):boolean{const a=[1,2,3];return a.some(cb);}` +
+          `export function test():number{return run((x,i,arr)=>arr.length===3&&i===2&&x===3)?1:0;}`,
+      ),
+    ).toBe(1);
+  });
+
+  it("byte-neutral: already-native inline arrow / named fn callbacks still work", async () => {
+    expect(await runStandalone(`export function test():number{const a=[1,2,3];return a.some(x=>x>2)?1:0;}`)).toBe(1);
+    expect(
+      await runStandalone(
+        `function isEven(x:number):boolean{return x%2===0;}` +
+          `export function test():number{const a=[1,2,4];return a.some(isEven)?1:0;}`,
+      ),
+    ).toBe(1);
+  });
+
+  it("host (gc) mode still compiles the dynamic-param callback (bridge path untouched)", async () => {
+    const r = await compile(
+      `function run(cb:(x:number)=>boolean):boolean{const a=[1,2,3];return a.some(cb);}` +
+        `export function test():number{return run(x=>x>2)?1:0;}`,
+      { fileName: "test.ts", target: "gc" },
+    );
+    expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (#3015)

In standalone (host-free) mode, `Array.prototype` predicate methods
(`some`/`every`/`forEach`/`find`/`filter`/`map`/`reduce`/…) emitted the
`env::__call_1_f64` / `__call_2_f64` **host callback bridge** when the callback
argument was a **dynamic function-typed parameter** (`function run(cb){ return arr.some(cb); }`).
That import makes a standalone module non-instantiable, so every such test failed.
(Inline arrows, named functions and typed-array callbacks were already native.)

## Fix

The callback value IS a wasm closure struct at runtime (the caller passed an
arrow / function value), so recover a native `call_ref` instead of the bridge.
`setupArrayCallback` (`src/codegen/array-methods.ts`) gains a
**`ctx.standalone`-gated** branch: when the callback compiles to an opaque
`externref`, `resolveDynamicCallbackClosure` resolves the callback SIGNATURE's
canonical funcref wrapper via `getOrCreateFuncRefWrapperTypes` — the **same
cache-keyed wrapper the arrow value-site registers**, so the runtime closure
struct (a subtype of the wrapper root) casts and calls cleanly. It converts the
externref to the wrapper self carrier (`any.convert_extern` + guarded `ref.cast`
+ `ref.as_non_null`) and populates `closureInfo/closureTypeIdx/closureTmp`, so
the existing native invocation path (`buildClosureCallInstrs` + reduce's inline
builder) runs unchanged for **all 11 methods**.

## Why it's low-risk

- **Host mode untouched.** The branch is `ctx.standalone`-gated; host (gc) mode
  keeps the working `__call_1_*`/`__call_2_*` bridge fast-path (dual-mode
  principle — verified host gc still emits `__call_1_f64`).
- The `ref`/`ref_null` branch (inline arrow, named fn — already native) is
  untouched → byte-neutral for those.
- In standalone the externref branch had **zero passing tests to regress** (the
  bridge import was non-instantiable), so a wrapper-key mismatch on an exotic
  signature is no worse than the current failure.

## Validation

- `tests/issue-3015.test.ts` (9 tests): standalone **value assertions** +
  no-`__call_*`-import checks for some/every/forEach/map/filter/find/findIndex/
  reduce (with & without init), 2-/3-param plumbing, byte-neutral already-native
  cases, and a host-mode compile check.
- Local matrix: 13/13 correct return values, no bridge, incl. an `any[]`
  (externref-element) receiver.
- No host regression: `functional-array-methods` + `array-methods` +
  `array-prototype-methods` (59) and equivalence/standalone callback suites (26)
  all green. `tsc --noEmit` clean.
- True standalone flip count is measured by the merge_group standalone floor
  (dev agents run no local test262).

Uses the sanctioned raw-checker exception (wasm-lowering ValType question) via
`oracle-ratchet-allow` + `loc-budget-allow` in the issue frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)