### PR TITLE
feat(#3177): standalone %TypedArray%.of / .from statics (slice 5)

### DIFF
--- a/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
+++ b/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
@@ -55,6 +55,14 @@ loc-budget-allow:
   - src/codegen/expressions/calls.ts
   - src/codegen/object-ops.ts
   - src/codegen/object-runtime-descriptors.ts
+  # (slice 5, of/from statics): the shared native `__ta_from_arraylike`
+  # builder lives in dataview-native.ts (the TA-construct subsystem, already
+  # allowed above); the `$__ta_ctor` `.of`/`.from` runtime two-arm MUST sit at
+  # the any-receiver method-dispatch site in call-receiver-method.ts — the same
+  # emitter the #2872 dyn-view `.fill`/`.reverse` two-arm and the #3140 `.bind`
+  # arm already extend (extracting that dispatch chain is the #3182 epic's call,
+  # not this slice's).
+  - src/codegen/expressions/call-receiver-method.ts
 # coercion-sites-allow: the NEW module's 4 uses (number_toString ×2,
 # __str_to_number, __unbox_number) are the exact §7.1.21
 # CanonicalNumericIndexString round-trip + the finalize-safe ToNumber the
@@ -250,9 +258,8 @@ the upgraded static-windowed RangeError path.
 - `Object.getPrototypeOf(ta) === TA.prototype` identity (≈10 rows across
   ctors/\*: defined-length/-offset, returns-new-instance, returns-object,
   as-array-returns, same-ctor-returns-new-cloned…) needs per-kind PROTO
-  $Object singletons + a "prototype" [[Get]] arm on `$__ta_ctor` + a
-  `__getPrototypeOf` dyn-view arm — the W-C mechanism; composes #2901's
-  intrinsic-ctor pattern (`emitTypedArrayIntrinsicCtorObject`).
+  $Object singletons + a "prototype" [[Get]] arm on `$**ta_ctor`+ a`**getPrototypeOf` dyn-view arm — the W-C mechanism; composes #2901's
+intrinsic-ctor pattern (`emitTypedArrayIntrinsicCtorObject`).
 - `TA(1)` WITHOUT new → TypeError (§23.2.5.1 step 1, undefined-newtarget-
   throws ×8): calling a `$__ta_ctor` value as a function currently returns
   undefined silently — needs a `ref.test $__ta_ctor → throw TypeError` arm
@@ -338,10 +345,10 @@ What landed:
   exists; set/reflect_set lazily create it. Flipped the whole
   `key-is-not-numeric-index` / `key-is-not-canonical-index` /
   `detached-buffer-key-is-*` / `key-is-symbol` families across
-  Get/Set/Delete/HasProperty (§10.4.5 "Otherwise, return Ordinary*").
+  Get/Set/Delete/HasProperty (§10.4.5 "Otherwise, return Ordinary\*").
 - **§10.4.5.1 [[GetOwnProperty]]** — `__getOwnPropertyDescriptor` dyn-view
   arm: valid canonical index → fresh data descriptor `{value, w:T, e:T,
-  c:T}` (via `__new_plain_object`/`__extern_set`/`__box_boolean`); invalid →
+c:T}` (via `__new_plain_object`/`__extern_set`/`__box_boolean`); invalid →
   undefined; ordinary keys → expando read-back.
 - **§10.4.5.3 [[DefineOwnProperty]]** — dyn-view arms in
   `__defineProperty_value` (validate: invalid index / accessor bit /
@@ -386,6 +393,69 @@ Known residuals:
   the same sentinel discipline — a follow-on, NOT this issue).
 - `__object_keys` does not append expando keys yet (OwnPropertyKeys
   enumeration of non-index own props).
+
+### Slice 5 — `%TypedArray%.of` / `.from` statics (PR: issue-3177-slice5-from-of, 2026-07-24, dev-std-2/Opus)
+
+Measured gap (current main, host vs standalone over `TypedArray{,Constructors}/
+{from,of}`, 73 files): 55 host-pass / 38 sa-pass / **23 gap**. Branch:
+50 sa-pass / **11 gap** = **+12 fail→pass, 0 regressions** (host-pass count
+unchanged at 55; every flip is a construction row). Verified against a clean
+`origin/main` worktree — the one remaining scoped-suite failure
+(`tests/issue-3177.test.ts` `[[Delete]]: valid index → false`) reproduces on
+main HEAD, i.e. PRE-EXISTING, not this slice.
+
+`TA.of(v0,…)` / `TA.from(src[, mapfn[, thisArg]])` on a `$__ta_ctor` receiver
+VALUE (the `testWithTypedArrayConstructors` harness shape) were unimplemented —
+the call fell to the open-object dispatcher, returned an empty/undefined result,
+and every `result.length` read trapped ("uncaught Wasm-GC exception").
+
+What landed:
+
+- **`__ta_from_arraylike(ctor, carrier) → externref`** (dataview-native.ts) —
+  the shared native builder. Reads `carrier` through the dynamic
+  `__extern_length` / `__extern_get_idx` arm (so a `$ObjVec`, an array-like
+  `$Object`, or a plain vec are all indexable uniformly), builds a fresh
+  same-kind `$__ta_dyn_view` of length `max(ToInteger(carrier.length), 0)`, and
+  byte-encodes each `ToNumber`'d element on the ctor's RUNTIME kind
+  (Uint8Clamped clamp included) via the existing `emitDynEncodeDispatch` codec.
+  The dyn-view rep yields `.constructor` / `Object.getPrototypeOf` identity for
+  free (slices 1/3). noJsHost + defined-func only (no import shift).
+- **Runtime `ref.test $__ta_ctor` two-arm** at the any-receiver method-dispatch
+  site (call-receiver-method.ts, alongside the #2872 `.fill`/#3140 `.bind`
+  arms). THEN builds the carrier — `of` packs its args into a `$ObjVec`; `from`
+  normalizes its source via `__array_from_iter_n` (no/undefined mapfn) or
+  `__array_from_mapped` (a present, non-nullish mapfn — composes
+  `__array_from_iter_n` + `__hof_map`, a compile-time-known-argc runtime nullish
+  branch on the mapfn) — then calls `__ta_from_arraylike`. ELSE is the ordinary
+  dispatcher, byte-identical to today (Array.of/from, user objects unaffected).
+  Gated `noJsHost && ctx.taCtorTypeIdx >= 0`, so host/gc and TA-free modules are
+  byte-inert.
+
+Flipped (12): of/{new-instance-empty, new-instance, nan-conversion}, from/
+{new-instance-empty, new-instance-without-mapfn, new-instance-with-mapfn,
+new-instance-from-zero, new-instance-from-ordinary-object,
+new-instance-from-sparse-array, nan-conversion, mapfn-arguments} + the
+`TypedArray/of/new-instance` twin. Verified: tests/issue-3177-fromof.test.ts
+(16/16 — of values/null-coerce/clamp/signed + identity, from array/array-like/
+mapfn/(value,index)/undefined-mapfn + identity, Array.of/from non-hijack guard);
+scoped suites issue-3177 / issue-2872-ta-dynview-reduce-includes green (the
+pre-existing `[[Delete]]` row excepted).
+
+Deferred (documented boundary — NOT this slice):
+
+- **Iterable (non-array-like) source** — `TA.from(new Set(…))` reads length 0
+  (the `__array_from_iter_n` drain doesn't yet normalize a builtin iterable into
+  an indexable carrier); the "true iterable-protocol ctor arm". A test pins the
+  current non-crashing behavior.
+- **`mapfn-is-not-callable` TypeError** — needs a finalize-fill IsCallable check
+  (`buildClosureRefTestArms`, reserve-then-fill like `__bind_dyn`); a
+  non-callable mapfn currently traps rather than throwing TypeError.
+- **`this`-as-ctor / custom-ctor** rows (`new-instance-using-custom-ctor`,
+  `custom-ctor-returns-smaller-instance-throws`) — need `.of`/`.from` to honor a
+  caller-supplied `this` constructor (species-style).
+- **Reflective `%TypedArray%.{of,from}.{length,name}` + `prop-desc`** (6 rows) —
+  a different mechanism (reflective descriptor synthesis over the intrinsic
+  method), not construction.
 
 ### Remaining (next slices — release+reclaim per phase)
 

--- a/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
+++ b/plan/issues/3177-standalone-typedarrayconstructors-internals-ctors.md
@@ -63,6 +63,14 @@ loc-budget-allow:
   # arm already extend (extracting that dispatch chain is the #3182 epic's call,
   # not this slice's).
   - src/codegen/expressions/call-receiver-method.ts
+# func-budget-allow (slice 5): the of/from two-arm was EXTRACTED to a new
+# module-level `tryEmitTaStaticOfFrom` (~130 LOC, under the 300 ceiling), so the
+# already-over-300 `compileReceiverMethodCall` grows only +6 — the minimal
+# gated dispatch call (`if (…) { const r = tryEmitTaStaticOfFrom(…); if (r) …}`).
+# The god-function itself is not further splittable in this slice (the #3182
+# consolidation epic owns that); +6 for a new method dispatch is intended.
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
 # coercion-sites-allow: the NEW module's 4 uses (number_toString ×2,
 # __str_to_number, __unbox_number) are the exact §7.1.21
 # CanonicalNumericIndexString round-trip + the finalize-safe ToNumber the

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -4209,6 +4209,174 @@ export function emitTaDynCtorConstructFromLocals(
 }
 
 /**
+ * (#3177 slice 5) Mint the shared native `__ta_from_arraylike(ctor, carrier) →
+ * externref` — the builder behind the standalone `%TypedArray%.of` /
+ * `%TypedArray%.from` statics. `ctor` is a `$__ta_ctor` value (its `kind` field
+ * selects the element codec); `carrier` is ANY indexable read through the
+ * dynamic `__extern_length` / `__extern_get_idx` arm — a native `$ObjVec` (the
+ * packed `of(...)` args), an array-like `$Object`, a plain vec, or the
+ * normalized carrier of `__array_from_iter_n` / `__array_from_mapped` (the
+ * `from(...)` source, optionally mapped). Builds a fresh same-kind
+ * `$__ta_dyn_view` of length `max(ToInteger(carrier.length), 0)` with every
+ * element `ToNumber`'d and byte-encoded on the ctor's RUNTIME kind
+ * (Uint8Clamped clamp included). The dyn-view rep gives `.constructor` /
+ * `Object.getPrototypeOf` identity for free (slices 1/3).
+ *
+ * noJsHost lane only; every dependency is a native DEFINED function
+ * (append-only — no import add / funcIdx shift). Idempotent via funcMap.
+ */
+export function ensureTaFromArrayLikeHelper(ctx: CodegenContext): number | undefined {
+  if (!noJsHost(ctx)) return undefined;
+  const helperName = "__ta_from_arraylike";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  // The array-like reader (`$ObjVec` / `$Object {length}` / vec / host array)
+  // is the object runtime's `__extern_length` / `__extern_get_idx`.
+  ensureObjectRuntime(ctx);
+  const externLengthIdx = ctx.funcMap.get("__extern_length");
+  const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx");
+  if (externLengthIdx === undefined || externGetIdxIdx === undefined) return undefined;
+
+  const taCtorTypeIdx = getOrRegisterTaCtorType(ctx);
+  const dynIdx = getOrRegisterTaDynViewType(ctx);
+  const { vecTypeIdx: byteVecIdx, arrTypeIdx: byteArrIdx } = i32ByteVec(ctx);
+
+  const params: ValType[] = [
+    { kind: "externref" }, // ctor ($__ta_ctor)
+    { kind: "externref" }, // carrier (indexable)
+  ];
+  const typeIdx = addFuncType(ctx, params, [{ kind: "externref" }]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const fctx: FunctionContext = {
+    name: helperName,
+    params: [
+      { name: "ctor", type: { kind: "externref" } },
+      { name: "carrier", type: { kind: "externref" } },
+    ],
+    locals: [],
+    localMap: new Map(),
+    returnType: { kind: "externref" },
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+
+  const kindLocal = allocLocal(fctx, "kind", { kind: "i32" });
+  const esLocal = allocLocal(fctx, "es", { kind: "i32" });
+  const nLocal = allocLocal(fctx, "n", { kind: "i32" });
+  const blLocal = allocLocal(fctx, "bl", { kind: "i32" });
+  const arrLocal = allocLocal(fctx, "arr", { kind: "ref", typeIdx: byteArrIdx });
+  const leLocal = allocLocal(fctx, "le", { kind: "i32" });
+  const iLocal = allocLocal(fctx, "i", { kind: "i32" });
+  const offLocal = allocLocal(fctx, "off", { kind: "i32" });
+  const vLocal = allocLocal(fctx, "v", { kind: "f64" });
+  const lenF64Local = allocLocal(fctx, "lenf", { kind: "f64" });
+
+  // kind = ctor.kind; es = elemSize(kind); le = 1 (little-endian).
+  fctx.body.push({ op: "local.get", index: 0 });
+  fctx.body.push({ op: "any.convert_extern" });
+  fctx.body.push({ op: "ref.cast", typeIdx: taCtorTypeIdx });
+  fctx.body.push({ op: "struct.get", typeIdx: taCtorTypeIdx, fieldIdx: 0 });
+  fctx.body.push({ op: "local.set", index: kindLocal });
+  pushElemSizeForKind(fctx, kindLocal);
+  fctx.body.push({ op: "local.set", index: esLocal });
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "local.set", index: leLocal });
+
+  // n = max(trunc_sat_f64_s(carrier.length), 0)  — NaN→0, negatives clamp.
+  fctx.body.push({ op: "local.get", index: 1 });
+  fctx.body.push({ op: "call", funcIdx: externLengthIdx });
+  fctx.body.push({ op: "local.set", index: lenF64Local });
+  fctx.body.push({ op: "local.get", index: lenF64Local });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+  fctx.body.push({ op: "local.set", index: nLocal });
+  fctx.body.push({ op: "local.get", index: nLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: nLocal },
+    ],
+    else: [],
+  });
+
+  // bl = n * es; arr = new zeroed byte array[bl].
+  fctx.body.push({ op: "local.get", index: nLocal });
+  fctx.body.push({ op: "local.get", index: esLocal });
+  fctx.body.push({ op: "i32.mul" });
+  fctx.body.push({ op: "local.set", index: blLocal });
+  fctx.body.push({ op: "local.get", index: blLocal });
+  fctx.body.push({ op: "array.new_default", typeIdx: byteArrIdx });
+  fctx.body.push({ op: "local.set", index: arrLocal });
+
+  // for (i = 0; i < n; i++) { v = ToNumber(get_idx(carrier, i)); encode at i*es }
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: iLocal });
+  const loopBody: Instr[] = [];
+  {
+    const saved = fctx.body;
+    fctx.body = loopBody;
+    fctx.body.push({ op: "local.get", index: iLocal });
+    fctx.body.push({ op: "local.get", index: nLocal });
+    fctx.body.push({ op: "i32.ge_s" });
+    fctx.body.push({ op: "br_if", depth: 1 });
+    fctx.body.push({ op: "local.get", index: 1 });
+    fctx.body.push({ op: "local.get", index: iLocal });
+    fctx.body.push({ op: "f64.convert_i32_s" });
+    fctx.body.push({ op: "call", funcIdx: externGetIdxIdx });
+    coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" });
+    fctx.body.push({ op: "local.set", index: vLocal });
+    fctx.body.push({ op: "local.get", index: iLocal });
+    fctx.body.push({ op: "local.get", index: esLocal });
+    fctx.body.push({ op: "i32.mul" });
+    fctx.body.push({ op: "local.set", index: offLocal });
+    fctx.body.push(...emitDynEncodeDispatch(ctx, fctx, kindLocal, arrLocal, offLocal, vLocal, leLocal, byteArrIdx));
+    fctx.body.push({ op: "local.get", index: iLocal });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "i32.add" });
+    fctx.body.push({ op: "local.set", index: iLocal });
+    fctx.body.push({ op: "br", depth: 0 });
+    fctx.body = saved;
+  }
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody }],
+  });
+
+  // view = { length: n, buf: {byteLength: bl, data: arr}, byteOffset: 0, kind,
+  //          expando: null, constructProto: null }.
+  fctx.body.push({ op: "local.get", index: nLocal });
+  fctx.body.push({ op: "local.get", index: blLocal });
+  fctx.body.push({ op: "local.get", index: arrLocal });
+  fctx.body.push({ op: "struct.new", typeIdx: byteVecIdx });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.get", index: kindLocal });
+  fctx.body.push({ op: "ref.null.extern" }); // expando (#3177 slice 4) — lazily created
+  fctx.body.push({ op: "ref.null.extern" }); // #3371 constructProto (intrinsic default)
+  fctx.body.push({ op: "struct.new", typeIdx: dynIdx });
+  fctx.body.push({ op: "extern.convert_any" });
+
+  pushDefinedFunc(ctx, funcIdx, {
+    name: helperName,
+    typeIdx,
+    locals: fctx.locals,
+    body: fctx.body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/**
  * (#2872) Mint the native `__ta_dyn_fill(recv, value, start, end, argc) →
  * externref` helper — `%TypedArray%.prototype.fill` (§23.2.3.8) over a
  * `$__ta_dyn_view` receiver (a dynamically-constructed TA view reached through

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -153,6 +153,132 @@ import {
  * dispatch (identifier / IIFE / super / element-access / conditional). Moved
  * unchanged so the emitted Wasm is byte-identical.
  */
+/**
+ * (#3177 slice 5) `%TypedArray%.of` / `%TypedArray%.from` STATIC methods on a
+ * `$__ta_ctor` receiver VALUE (the testWithTypedArrayConstructors harness
+ * shape: `TA.of(v0,…)` / `TA.from(src[, mapfn[, thisArg]])`). Emits a runtime
+ * `ref.test $__ta_ctor` two-arm: a TA-constructor receiver builds a fresh
+ * same-kind dyn-view (`__ta_from_arraylike` over an indexable carrier — the
+ * packed `of` args as a `$ObjVec`, or the `from` source normalized via
+ * `__array_from_iter_n` / `__array_from_mapped`); ANY other runtime value
+ * (Array.of/from, user objects) falls through to the ordinary dispatcher,
+ * byte-identical to today. Caller gates noJsHost + a live TA ctor type, so
+ * host/gc and TA-free modules never reach here. Returns `{ kind: "externref" }`
+ * when handled, or `null` when the shared builder is unavailable (caller keeps
+ * its existing routing).
+ */
+function tryEmitTaStaticOfFrom(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  dispatchArgs: readonly ts.Expression[],
+  methodName: string,
+  dispatchIdx: number,
+): InnerResult | null {
+  const taFromIdx = ensureTaFromArrayLikeHelper(ctx);
+  if (taFromIdx === undefined) return null;
+
+  // Receiver (the ctor value) → local.
+  const recvT = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+  if (recvT && recvT.kind !== "externref") coerceType(ctx, fctx, recvT, { kind: "externref" });
+  else if (recvT === null) fctx.body.push({ op: "ref.null.extern" });
+  const recvLocal = allocLocal(fctx, `__tastat_recv_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: recvLocal });
+
+  // Args → locals (evaluated once, spec order — the else arm reuses them).
+  const argLocals: number[] = [];
+  for (const arg of dispatchArgs) {
+    const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
+    if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+    else if (at === null) fctx.body.push({ op: "ref.null.extern" });
+    const aLocal = allocLocal(fctx, `__tastat_arg_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: aLocal });
+    argLocals.push(aLocal);
+  }
+
+  // THEN arm: build an indexable carrier, then __ta_from_arraylike(recv, carrier).
+  const thenArm: Instr[] = [];
+  {
+    const savedT = fctx.body;
+    fctx.body = thenArm;
+    const carrierLocal = allocLocal(fctx, `__tastat_carrier_${fctx.locals.length}`, { kind: "externref" });
+    if (methodName === "of") {
+      // Pack the of-args into a native `$ObjVec` (read by __extern_*).
+      const { newIdx, pushIdx } = ensureObjVecBuilders(ctx);
+      fctx.body.push({ op: "call", funcIdx: newIdx });
+      fctx.body.push({ op: "local.set", index: carrierLocal });
+      for (const aLocal of argLocals) {
+        fctx.body.push({ op: "local.get", index: carrierLocal });
+        fctx.body.push({ op: "local.get", index: aLocal });
+        fctx.body.push({ op: "call", funcIdx: pushIdx });
+      }
+    } else {
+      // from(src[, mapfn[, thisArg]]): normalize src (+ optional mapfn) to a
+      // carrier the array-like reader consumes. A present, non-nullish mapfn
+      // routes through __array_from_mapped (composes __array_from_iter_n +
+      // __hof_map); no/undefined mapfn drains via __array_from_iter_n directly.
+      const iterNIdx = ensureNativeArrayFromIterN(ctx);
+      const src = argLocals[0];
+      if (src === undefined) {
+        const { newIdx } = ensureObjVecBuilders(ctx);
+        fctx.body.push({ op: "call", funcIdx: newIdx });
+        fctx.body.push({ op: "local.set", index: carrierLocal });
+      } else if (dispatchArgs.length >= 2) {
+        const mappedIdx = ensureNativeArrayFromMapped(ctx);
+        const nullishIdx = ctx.funcMap.get("__nullish_to_null");
+        const mapfn = argLocals[1]!;
+        const thisArg = argLocals[2];
+        const iterArm: Instr[] = [
+          { op: "local.get", index: src },
+          { op: "f64.const", value: -1 },
+          { op: "call", funcIdx: iterNIdx },
+          { op: "local.set", index: carrierLocal },
+        ];
+        if (mappedIdx !== undefined) {
+          const mapArm: Instr[] = [
+            { op: "local.get", index: src },
+            { op: "local.get", index: mapfn },
+            thisArg !== undefined ? { op: "local.get", index: thisArg } : { op: "ref.null.extern" },
+            { op: "call", funcIdx: mappedIdx },
+            { op: "local.set", index: carrierLocal },
+          ];
+          fctx.body.push({ op: "local.get", index: mapfn });
+          if (nullishIdx !== undefined) fctx.body.push({ op: "call", funcIdx: nullishIdx });
+          fctx.body.push({ op: "ref.is_null" });
+          fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: iterArm, else: mapArm });
+        } else {
+          for (const ins of iterArm) fctx.body.push(ins);
+        }
+      } else {
+        fctx.body.push({ op: "local.get", index: src });
+        fctx.body.push({ op: "f64.const", value: -1 });
+        fctx.body.push({ op: "call", funcIdx: iterNIdx });
+        fctx.body.push({ op: "local.set", index: carrierLocal });
+      }
+    }
+    fctx.body.push({ op: "local.get", index: recvLocal });
+    fctx.body.push({ op: "local.get", index: carrierLocal });
+    fctx.body.push({ op: "call", funcIdx: taFromIdx });
+    fctx.body = savedT;
+  }
+
+  // ELSE arm: the ordinary dynamic dispatcher (recv + args), i.e. what this
+  // call site does today for these method names.
+  const elseArm: Instr[] = [{ op: "local.get", index: recvLocal }];
+  for (const aLocal of argLocals) elseArm.push({ op: "local.get", index: aLocal });
+  elseArm.push({ op: "call", funcIdx: dispatchIdx });
+  fctx.body.push({ op: "local.get", index: recvLocal });
+  fctx.body.push({ op: "any.convert_extern" });
+  fctx.body.push({ op: "ref.test", typeIdx: ctx.taCtorTypeIdx });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } },
+    then: thenArm,
+    else: elseArm,
+  });
+  return { kind: "externref" };
+}
+
 export function compileReceiverMethodCall(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -2699,116 +2825,10 @@ export function compileReceiverMethodCall(
         }
         flushLateImportShifts(ctx, fctx);
         // (#3177 slice 5) `%TypedArray%.of` / `%TypedArray%.from` STATIC methods
-        // on a `$__ta_ctor` receiver VALUE (the testWithTypedArrayConstructors
-        // harness shape: `TA.of(v0,…)` / `TA.from(src[, mapfn[, thisArg]])`).
-        // Runtime `ref.test $__ta_ctor` two-arm: a TA-constructor receiver builds
-        // a fresh same-kind dyn-view (`__ta_from_arraylike` over an indexable
-        // carrier — the packed `of` args as a `$ObjVec`, or the `from` source
-        // normalized via `__array_from_iter_n` / `__array_from_mapped`); ANY
-        // other runtime value (Array.of/from, user objects) falls through to the
-        // ordinary dispatcher, byte-identical to today. noJsHost + a live TA ctor
-        // type only, so host/gc and TA-free modules are inert.
+        // on a `$__ta_ctor` receiver VALUE — see `tryEmitTaStaticOfFrom`.
         if (noJsHost(ctx) && ctx.taCtorTypeIdx >= 0 && (methodName === "of" || methodName === "from")) {
-          const taFromIdx = ensureTaFromArrayLikeHelper(ctx);
-          if (taFromIdx !== undefined) {
-            // Receiver (the ctor value) → local.
-            const recvT2 = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
-            if (recvT2 && recvT2.kind !== "externref") coerceType(ctx, fctx, recvT2, { kind: "externref" });
-            else if (recvT2 === null) fctx.body.push({ op: "ref.null.extern" });
-            const recvLocal = allocLocal(fctx, `__tastat_recv_${fctx.locals.length}`, { kind: "externref" });
-            fctx.body.push({ op: "local.set", index: recvLocal });
-            // Args → locals (evaluated once, spec order — the else arm reuses them).
-            const staticArgLocals: number[] = [];
-            for (const arg of dispatchArgs) {
-              const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
-              if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
-              else if (at === null) fctx.body.push({ op: "ref.null.extern" });
-              const aLocal = allocLocal(fctx, `__tastat_arg_${fctx.locals.length}`, { kind: "externref" });
-              fctx.body.push({ op: "local.set", index: aLocal });
-              staticArgLocals.push(aLocal);
-            }
-            // THEN arm: build an indexable carrier, then __ta_from_arraylike(recv, carrier).
-            const thenArm: Instr[] = [];
-            {
-              const savedT = fctx.body;
-              fctx.body = thenArm;
-              const carrierLocal = allocLocal(fctx, `__tastat_carrier_${fctx.locals.length}`, { kind: "externref" });
-              if (methodName === "of") {
-                // Pack the of-args into a native `$ObjVec` (read by __extern_*).
-                const { newIdx, pushIdx } = ensureObjVecBuilders(ctx);
-                fctx.body.push({ op: "call", funcIdx: newIdx });
-                fctx.body.push({ op: "local.set", index: carrierLocal });
-                for (const aLocal of staticArgLocals) {
-                  fctx.body.push({ op: "local.get", index: carrierLocal });
-                  fctx.body.push({ op: "local.get", index: aLocal });
-                  fctx.body.push({ op: "call", funcIdx: pushIdx });
-                }
-              } else {
-                // from(src[, mapfn[, thisArg]]): normalize src (+ optional mapfn)
-                // to a carrier the array-like reader consumes. A present,
-                // non-nullish mapfn routes through __array_from_mapped (composes
-                // __array_from_iter_n + __hof_map); no/undefined mapfn drains via
-                // __array_from_iter_n directly.
-                const iterNIdx = ensureNativeArrayFromIterN(ctx);
-                const src = staticArgLocals[0];
-                if (src === undefined) {
-                  const { newIdx } = ensureObjVecBuilders(ctx);
-                  fctx.body.push({ op: "call", funcIdx: newIdx });
-                  fctx.body.push({ op: "local.set", index: carrierLocal });
-                } else if (dispatchArgs.length >= 2) {
-                  const mappedIdx = ensureNativeArrayFromMapped(ctx);
-                  const nullishIdx = ctx.funcMap.get("__nullish_to_null");
-                  const mapfn = staticArgLocals[1]!;
-                  const thisArg = staticArgLocals[2];
-                  const iterArm: Instr[] = [
-                    { op: "local.get", index: src },
-                    { op: "f64.const", value: -1 },
-                    { op: "call", funcIdx: iterNIdx },
-                    { op: "local.set", index: carrierLocal },
-                  ];
-                  if (mappedIdx !== undefined) {
-                    const mapArm: Instr[] = [
-                      { op: "local.get", index: src },
-                      { op: "local.get", index: mapfn },
-                      thisArg !== undefined ? { op: "local.get", index: thisArg } : { op: "ref.null.extern" },
-                      { op: "call", funcIdx: mappedIdx },
-                      { op: "local.set", index: carrierLocal },
-                    ];
-                    fctx.body.push({ op: "local.get", index: mapfn });
-                    if (nullishIdx !== undefined) fctx.body.push({ op: "call", funcIdx: nullishIdx });
-                    fctx.body.push({ op: "ref.is_null" });
-                    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: iterArm, else: mapArm });
-                  } else {
-                    for (const ins of iterArm) fctx.body.push(ins);
-                  }
-                } else {
-                  fctx.body.push({ op: "local.get", index: src });
-                  fctx.body.push({ op: "f64.const", value: -1 });
-                  fctx.body.push({ op: "call", funcIdx: iterNIdx });
-                  fctx.body.push({ op: "local.set", index: carrierLocal });
-                }
-              }
-              fctx.body.push({ op: "local.get", index: recvLocal });
-              fctx.body.push({ op: "local.get", index: carrierLocal });
-              fctx.body.push({ op: "call", funcIdx: taFromIdx });
-              fctx.body = savedT;
-            }
-            // ELSE arm: the ordinary dynamic dispatcher (recv + args), i.e. what
-            // this call site does today for these method names.
-            const elseArm: Instr[] = [{ op: "local.get", index: recvLocal }];
-            for (const aLocal of staticArgLocals) elseArm.push({ op: "local.get", index: aLocal });
-            elseArm.push({ op: "call", funcIdx: dispatchIdx });
-            fctx.body.push({ op: "local.get", index: recvLocal });
-            fctx.body.push({ op: "any.convert_extern" });
-            fctx.body.push({ op: "ref.test", typeIdx: ctx.taCtorTypeIdx });
-            fctx.body.push({
-              op: "if",
-              blockType: { kind: "val", type: { kind: "externref" } },
-              then: thenArm,
-              else: elseArm,
-            });
-            return { kind: "externref" };
-          }
+          const taStatic = tryEmitTaStaticOfFrom(ctx, fctx, propAccess, dispatchArgs, methodName, dispatchIdx);
+          if (taStatic !== null) return taStatic;
         }
         // (#2872) A mutating `%TypedArray%.prototype` method on a receiver
         // that is a `$__ta_dyn_view` at RUNTIME (a dynamically-constructed TA

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -45,8 +45,10 @@ import {
   ensureTaDynCopyWithinHelper,
   ensureTaDynFillHelper,
   ensureTaDynReverseHelper,
+  ensureTaFromArrayLikeHelper,
   isDataViewAccessor,
 } from "../dataview-native.js";
+import { ensureNativeArrayFromIterN, ensureNativeArrayFromMapped } from "../iterator-native.js";
 import { tryCompileNativeGeneratorMethodCall } from "../generators-native.js";
 import { NATIVE_HOF_METHODS } from "../hof-native.js";
 import {
@@ -2696,6 +2698,118 @@ export function compileReceiverMethodCall(
           ensureDvAccessorHelper(ctx, methodName);
         }
         flushLateImportShifts(ctx, fctx);
+        // (#3177 slice 5) `%TypedArray%.of` / `%TypedArray%.from` STATIC methods
+        // on a `$__ta_ctor` receiver VALUE (the testWithTypedArrayConstructors
+        // harness shape: `TA.of(v0,…)` / `TA.from(src[, mapfn[, thisArg]])`).
+        // Runtime `ref.test $__ta_ctor` two-arm: a TA-constructor receiver builds
+        // a fresh same-kind dyn-view (`__ta_from_arraylike` over an indexable
+        // carrier — the packed `of` args as a `$ObjVec`, or the `from` source
+        // normalized via `__array_from_iter_n` / `__array_from_mapped`); ANY
+        // other runtime value (Array.of/from, user objects) falls through to the
+        // ordinary dispatcher, byte-identical to today. noJsHost + a live TA ctor
+        // type only, so host/gc and TA-free modules are inert.
+        if (noJsHost(ctx) && ctx.taCtorTypeIdx >= 0 && (methodName === "of" || methodName === "from")) {
+          const taFromIdx = ensureTaFromArrayLikeHelper(ctx);
+          if (taFromIdx !== undefined) {
+            // Receiver (the ctor value) → local.
+            const recvT2 = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+            if (recvT2 && recvT2.kind !== "externref") coerceType(ctx, fctx, recvT2, { kind: "externref" });
+            else if (recvT2 === null) fctx.body.push({ op: "ref.null.extern" });
+            const recvLocal = allocLocal(fctx, `__tastat_recv_${fctx.locals.length}`, { kind: "externref" });
+            fctx.body.push({ op: "local.set", index: recvLocal });
+            // Args → locals (evaluated once, spec order — the else arm reuses them).
+            const staticArgLocals: number[] = [];
+            for (const arg of dispatchArgs) {
+              const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
+              if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+              else if (at === null) fctx.body.push({ op: "ref.null.extern" });
+              const aLocal = allocLocal(fctx, `__tastat_arg_${fctx.locals.length}`, { kind: "externref" });
+              fctx.body.push({ op: "local.set", index: aLocal });
+              staticArgLocals.push(aLocal);
+            }
+            // THEN arm: build an indexable carrier, then __ta_from_arraylike(recv, carrier).
+            const thenArm: Instr[] = [];
+            {
+              const savedT = fctx.body;
+              fctx.body = thenArm;
+              const carrierLocal = allocLocal(fctx, `__tastat_carrier_${fctx.locals.length}`, { kind: "externref" });
+              if (methodName === "of") {
+                // Pack the of-args into a native `$ObjVec` (read by __extern_*).
+                const { newIdx, pushIdx } = ensureObjVecBuilders(ctx);
+                fctx.body.push({ op: "call", funcIdx: newIdx });
+                fctx.body.push({ op: "local.set", index: carrierLocal });
+                for (const aLocal of staticArgLocals) {
+                  fctx.body.push({ op: "local.get", index: carrierLocal });
+                  fctx.body.push({ op: "local.get", index: aLocal });
+                  fctx.body.push({ op: "call", funcIdx: pushIdx });
+                }
+              } else {
+                // from(src[, mapfn[, thisArg]]): normalize src (+ optional mapfn)
+                // to a carrier the array-like reader consumes. A present,
+                // non-nullish mapfn routes through __array_from_mapped (composes
+                // __array_from_iter_n + __hof_map); no/undefined mapfn drains via
+                // __array_from_iter_n directly.
+                const iterNIdx = ensureNativeArrayFromIterN(ctx);
+                const src = staticArgLocals[0];
+                if (src === undefined) {
+                  const { newIdx } = ensureObjVecBuilders(ctx);
+                  fctx.body.push({ op: "call", funcIdx: newIdx });
+                  fctx.body.push({ op: "local.set", index: carrierLocal });
+                } else if (dispatchArgs.length >= 2) {
+                  const mappedIdx = ensureNativeArrayFromMapped(ctx);
+                  const nullishIdx = ctx.funcMap.get("__nullish_to_null");
+                  const mapfn = staticArgLocals[1]!;
+                  const thisArg = staticArgLocals[2];
+                  const iterArm: Instr[] = [
+                    { op: "local.get", index: src },
+                    { op: "f64.const", value: -1 },
+                    { op: "call", funcIdx: iterNIdx },
+                    { op: "local.set", index: carrierLocal },
+                  ];
+                  if (mappedIdx !== undefined) {
+                    const mapArm: Instr[] = [
+                      { op: "local.get", index: src },
+                      { op: "local.get", index: mapfn },
+                      thisArg !== undefined ? { op: "local.get", index: thisArg } : { op: "ref.null.extern" },
+                      { op: "call", funcIdx: mappedIdx },
+                      { op: "local.set", index: carrierLocal },
+                    ];
+                    fctx.body.push({ op: "local.get", index: mapfn });
+                    if (nullishIdx !== undefined) fctx.body.push({ op: "call", funcIdx: nullishIdx });
+                    fctx.body.push({ op: "ref.is_null" });
+                    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: iterArm, else: mapArm });
+                  } else {
+                    for (const ins of iterArm) fctx.body.push(ins);
+                  }
+                } else {
+                  fctx.body.push({ op: "local.get", index: src });
+                  fctx.body.push({ op: "f64.const", value: -1 });
+                  fctx.body.push({ op: "call", funcIdx: iterNIdx });
+                  fctx.body.push({ op: "local.set", index: carrierLocal });
+                }
+              }
+              fctx.body.push({ op: "local.get", index: recvLocal });
+              fctx.body.push({ op: "local.get", index: carrierLocal });
+              fctx.body.push({ op: "call", funcIdx: taFromIdx });
+              fctx.body = savedT;
+            }
+            // ELSE arm: the ordinary dynamic dispatcher (recv + args), i.e. what
+            // this call site does today for these method names.
+            const elseArm: Instr[] = [{ op: "local.get", index: recvLocal }];
+            for (const aLocal of staticArgLocals) elseArm.push({ op: "local.get", index: aLocal });
+            elseArm.push({ op: "call", funcIdx: dispatchIdx });
+            fctx.body.push({ op: "local.get", index: recvLocal });
+            fctx.body.push({ op: "any.convert_extern" });
+            fctx.body.push({ op: "ref.test", typeIdx: ctx.taCtorTypeIdx });
+            fctx.body.push({
+              op: "if",
+              blockType: { kind: "val", type: { kind: "externref" } },
+              then: thenArm,
+              else: elseArm,
+            });
+            return { kind: "externref" };
+          }
+        }
         // (#2872) A mutating `%TypedArray%.prototype` method on a receiver
         // that is a `$__ta_dyn_view` at RUNTIME (a dynamically-constructed TA
         // — `new TA([…]).fill(8, 1)` / `.copyWithin(0,2)` / `.reverse()` in

--- a/tests/issue-3177-fromof.test.ts
+++ b/tests/issue-3177-fromof.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #3177 slice 5 — standalone `%TypedArray%.of` / `%TypedArray%.from` statics.
+//
+// `TA.of(v0,…)` / `TA.from(src[, mapfn[, thisArg]])` on a `$__ta_ctor` receiver
+// value (the testWithTypedArrayConstructors harness shape) build a fresh
+// same-kind dyn-view via the shared native `__ta_from_arraylike(ctor, carrier)`
+// helper reading the carrier through `__extern_length`/`__extern_get_idx`:
+//  - `of` packs its args into a `$ObjVec` carrier.
+//  - `from` normalizes its source (+ optional mapfn) via
+//    `__array_from_iter_n` / `__array_from_mapped`.
+// The dyn-view rep gives `.constructor` / `Object.getPrototypeOf` identity for
+// free (slices 1/3). A runtime `ref.test $__ta_ctor` two-arm keeps every other
+// `.of`/`.from` receiver (Array.of/from, user objects) on the ordinary path.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+const wrap = (body: string) => `export function test(): number {\n  const TA: any = Uint8Array;\n  ${body}\n}`;
+
+describe("#3177 slice 5 — TypedArray.of (standalone, host-free)", () => {
+  it("of() builds an empty view", async () => {
+    expect(await run(wrap(`const r: any = TA.of(); return r.length === 0 ? 1 : 0;`))).toBe(1);
+  });
+
+  it("of(v0,v1,v2) builds a length-3 view with the given elements", async () => {
+    expect(
+      await run(
+        wrap(
+          `const r: any = TA.of(42, 43, 7); return (r.length === 3 && r[0] === 42 && r[1] === 43 && r[2] === 7) ? 1 : 0;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("of() ToNumbers null to +0", async () => {
+    expect(await run(wrap(`const r: any = TA.of(42, 43, null); return (r.length === 3 && r[2] === 0) ? 1 : 0;`))).toBe(
+      1,
+    );
+  });
+
+  it("of() constructor identity: TA.of(1).constructor === TA", async () => {
+    expect(await run(wrap(`const r: any = TA.of(1); return r.constructor === TA ? 1 : 0;`))).toBe(1);
+  });
+
+  it("of() prototype identity: getPrototypeOf(TA.of(1)) === TA.prototype", async () => {
+    expect(await run(wrap(`const r: any = TA.of(1); return Object.getPrototypeOf(r) === TA.prototype ? 1 : 0;`))).toBe(
+      1,
+    );
+  });
+
+  it("Uint8ClampedArray.of clamps out-of-range values", async () => {
+    expect(
+      await run(
+        `export function test(): number {\n  const TA: any = Uint8ClampedArray;\n  const r: any = TA.of(300, -5); return (r[0] === 255 && r[1] === 0) ? 1 : 0;\n}`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Int16Array.of preserves signed values", async () => {
+    expect(
+      await run(
+        `export function test(): number {\n  const TA: any = Int16Array;\n  const r: any = TA.of(-1, 1000); return (r[0] === -1 && r[1] === 1000) ? 1 : 0;\n}`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#3177 slice 5 — TypedArray.from (standalone, host-free)", () => {
+  it("from(array) copies elements", async () => {
+    expect(
+      await run(
+        wrap(`const r: any = TA.from([1, 2, 3]); return (r.length === 3 && r[0] === 1 && r[2] === 3) ? 1 : 0;`),
+      ),
+    ).toBe(1);
+  });
+
+  it("from(arrayLike) reads length + indexed props", async () => {
+    expect(
+      await run(
+        wrap(
+          `const src: any = { length: 2, 0: 5, 1: 6 }; const r: any = TA.from(src); return (r.length === 2 && r[0] === 5 && r[1] === 6) ? 1 : 0;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("from(source, mapfn) maps each element", async () => {
+    expect(
+      await run(
+        wrap(
+          `const r: any = TA.from([1, 2, 3], (x: number) => x * 2); return (r.length === 3 && r[0] === 2 && r[2] === 6) ? 1 : 0;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("from(source, mapfn) passes (value, index)", async () => {
+    expect(
+      await run(
+        wrap(
+          `const r: any = TA.from([9, 9, 9], (_x: number, i: number) => i); return (r[0] === 0 && r[1] === 1 && r[2] === 2) ? 1 : 0;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("from(source, undefined) treats an undefined mapfn as absent", async () => {
+    expect(
+      await run(
+        wrap(`const r: any = TA.from([4, 5], undefined); return (r.length === 2 && r[0] === 4 && r[1] === 5) ? 1 : 0;`),
+      ),
+    ).toBe(1);
+  });
+
+  // NOTE (deferred follow-on): an ITERABLE (non-array-like) source — e.g. a
+  // `Set` — is drained through `__array_from_iter_n`'s iterator ladder, which
+  // does not yet normalize a builtin iterable into a carrier the array-like
+  // reader can index (length reads 0). Array / array-like / mapfn sources (the
+  // corpus `new-instance-*` rows) all work; the "true iterable-protocol ctor
+  // arm" is explicitly deferred in the #3177 plan. This pins the current
+  // (non-crashing) behavior so a future fix flips it deliberately.
+  it("from(iterable Set) is a documented follow-on (empty view, no trap)", async () => {
+    expect(await run(wrap(`const r: any = TA.from(new Set([7, 8, 9])); return r.length === 0 ? 1 : 0;`))).toBe(1);
+  });
+
+  it("from() constructor + prototype identity", async () => {
+    expect(
+      await run(
+        wrap(
+          `const r: any = TA.from([1]); return (r.constructor === TA && Object.getPrototypeOf(r) === TA.prototype) ? 1 : 0;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#3177 slice 5 — non-TA receivers keep their behavior", () => {
+  it("Array.of is unaffected (plain array, no dyn-view hijack)", async () => {
+    expect(
+      await run(
+        `export function test(): number {\n  const a: any = Array.of(1, 2, 3); return (a.length === 3 && a[0] === 1 && a[2] === 3) ? 1 : 0;\n}`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Array.from is unaffected (plain array)", async () => {
+    expect(
+      await run(
+        `export function test(): number {\n  const a: any = Array.from([4, 5]); return (a.length === 2 && a[0] === 4 && a[1] === 5) ? 1 : 0;\n}`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Standalone `%TypedArray%.of` / `%TypedArray%.from` static methods (#3177 slice 5, umbrella #2860).

`TA.of(v0,…)` / `TA.from(src[, mapfn[, thisArg]])` on a `$__ta_ctor` receiver value (the `testWithTypedArrayConstructors` harness shape) were unimplemented — the call fell to the open-object dispatcher, returned an empty result, and every `result.length` read trapped ("uncaught Wasm-GC exception").

## What landed

- **`__ta_from_arraylike(ctor, carrier) → externref`** (`dataview-native.ts`) — shared native builder. Reads `carrier` via the dynamic `__extern_length` / `__extern_get_idx` arm (so `$ObjVec`, array-like `$Object`, and plain vecs are all indexable uniformly), builds a fresh same-kind `$__ta_dyn_view` of length `max(ToInteger(carrier.length), 0)`, and ToNumber+byte-encodes each element on the ctor's runtime kind (Uint8Clamped clamp included) via the existing `emitDynEncodeDispatch` codec. The dyn-view rep yields `.constructor` / `Object.getPrototypeOf` identity for free (slices 1/3).
- **Runtime `ref.test $__ta_ctor` two-arm** at the any-receiver method-dispatch site (`call-receiver-method.ts`, alongside the #2872 `.fill` / #3140 `.bind` arms). THEN builds the carrier — `of` packs its args into a `$ObjVec`; `from` normalizes its source via `__array_from_iter_n` (no/undefined mapfn) or `__array_from_mapped` (present, non-nullish mapfn). ELSE is the ordinary dispatcher, byte-identical to today.

Gated `noJsHost && ctx.taCtorTypeIdx >= 0` → host/gc and TA-free modules are byte-inert; `Array.of` / `Array.from` (the ELSE arm) are unchanged.

## Measured (host vs standalone, `TypedArray{,Constructors}/{from,of}`, 73 files)

Baseline: 55 host-pass / 38 sa-pass / **23 gap**. Branch: 50 sa-pass / **11 gap** = **+12 fail→pass, 0 regressions** (host-pass count unchanged; every flip is a construction row).

Verified against a clean `origin/main` worktree — the one scoped-suite failure (`issue-3177.test.ts` `[[Delete]]`) reproduces on main HEAD (PRE-EXISTING, not this slice).

## Tests

`tests/issue-3177-fromof.test.ts` (16/16): of values/null-coerce/clamp/signed + identity; from array/array-like/mapfn/(value,index)/undefined-mapfn + identity; `Array.of`/`Array.from` non-hijack guards. Scoped suites `issue-3177` / `issue-2872-ta-dynview-reduce-includes` green (pre-existing `[[Delete]]` row excepted). `tsc` clean, prettier clean, loc-budget + coercion-sites gates pass.

## Deferred (documented in the issue)

Iterable-source `from`, `mapfn-is-not-callable` TypeError, `this`-as-ctor / custom-ctor, reflective `name`/`length`/`prop-desc` (different mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)