### PR TITLE
fix(#1325): host-free instanceof Date/RegExp in standalone; reconcile #2933 done

### DIFF
--- a/plan/issues/1325-instanceof-builtin-type-tag-registry.md
+++ b/plan/issues/1325-instanceof-builtin-type-tag-registry.md
@@ -3,7 +3,7 @@ id: 1325
 title: "instanceof against built-in types: compile-time type-tag registry eliminates JS host for common cases"
 status: ready
 created: 2026-05-07
-updated: 2026-06-19
+updated: 2026-07-24
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -12,6 +12,11 @@ area: codegen
 language_feature: instanceof
 goal: standalone-mode
 sprint: Backlog
+# (#1325 Date/RegExp slice) the Date/RegExp cases land in
+# `nativeBuiltinInstanceOfTypeIdxs`, which lives in the instanceof god-file;
+# +17 LOC for the two switch cases + imports is the fix itself, not barrel spill.
+loc-budget-allow:
+  - src/codegen/expressions/identifiers.ts
 ---
 # #1325 — instanceof built-in type-tag registry
 
@@ -123,3 +128,57 @@ End-to-end behavioural tests:
 ## Frontmatter reconcile (2026-06-12)
 
 Was `in-progress` with no open PR, no active agent, and no Suspended Work section (session died sprints 42-52). Reset to `ready` during the sprint-62 issue review; re-validate against current main before claiming (#2148).
+
+## Progress (2026-07-24, dev-std-3) — headline cases verified done + Date/RegExp slice landed
+
+**Verify-first re-measure against current main (the #2148 note vindicated).** The
+headline acceptance criteria are ALREADY MET on main — all host-free, no
+`__instanceof` import:
+
+- `[] instanceof Array`, `{} instanceof Array === false`
+- `new TypeError() instanceof Error` / `instanceof TypeError`
+- `catch (e) { e instanceof TypeError }`, `new Error() instanceof Error`
+- `new Map()/Set()/WeakMap()/WeakSet() instanceof <same>`
+
+The mechanism for a **dynamic (`any`-typed / opaque function-param) LHS** in
+standalone is `nativeBuiltinInstanceOfTypeIdxs` (`expressions/identifiers.ts`,
+#2916): it maps a builtin ctor name → the WasmGC struct type idx of its native
+representation and `emitNativeInstanceOfMembership` answers via `ref.test`
+(host-free). A statically-typed LHS is already covered by `tryStaticInstanceOf`.
+
+**This slice adds `Date` and `RegExp`** to that map — both lower to distinct
+WasmGC structs standalone (`$__Date`, one i64 field; `$__StandaloneRegExp`), so
+`ref.test` against their (idempotent, type-only registered) struct type answers
+`x instanceof Date` / `x instanceof RegExp` host-free even for a dynamic LHS.
+Measured flips (fail→pass, all host-free, zero false positives — negatives like
+`{} instanceof Date`, `Date instanceof RegExp`, `123 instanceof Date` stay
+`false`):
+
+- `const d: any = new Date(); d instanceof Date` — was `0`, now `1`
+- `function f(d:any){return d instanceof Date} f(new Date())` — was `0`, now `1`
+  (cross-function opaque param; the runtime `ref.test` path)
+- `const r: any = /a/ | new RegExp("a"); r instanceof RegExp` — was `0`, now `1`
+- opaque-param RegExp — was `0`, now `1`
+
+Host/gc mode is untouched (the branch is `noJsHost`-gated → byte-identical).
+Tests: `tests/issue-1325.test.ts` (new standalone describe block, 11 cases).
+
+### Remaining (per-rep construction-tagging — NOT this slice, follow-on)
+
+The residual is scattered **per-representation** work, each its own increment
+(measured 2026-07-24, all `any`-typed dynamic LHS, standalone):
+
+- `Promise`, `ArrayBuffer`, `DataView`, and the concrete `TypedArray` views
+  (`Int8Array`…`BigUint64Array`) — each lowers to its own rep; needs the
+  matching struct type idx wired into `nativeBuiltinInstanceOfTypeIdxs` (or a
+  brand where the rep is shared, e.g. TypedArray views share `$Vec` with plain
+  arrays today — #2893/#2872).
+- `x instanceof Object` — NOT a clean universal `ref.test`: native strings are
+  also GC structs, so a naive "any struct → Object" over-matches; needs a
+  struct-minus-string-minus-boxed-primitive discriminator (Slice-A #2916
+  deferral).
+- `func instanceof Function` currently **traps** on a closure LHS (separate
+  from the `undefined`-return edges) — needs a guarded cast.
+- `Map`/`Set` through a truly-opaque param still answer `0` (they pass only via
+  the static-type path today; the native-collection structs share `$Map`, so a
+  runtime `ref.test` is imprecise until a per-collection brand lands).

--- a/plan/issues/2933-standalone-namespace-static-value-read.md
+++ b/plan/issues/2933-standalone-namespace-static-value-read.md
@@ -1,9 +1,10 @@
 ---
 id: 2933
 title: "Standalone: Math/JSON/Reflect/Atomics namespace static VALUE reads refuse — fold constants / native static-method closures"
-status: ready
+status: done
+completed: 2026-07-24
 created: 2026-07-02
-updated: 2026-07-16
+updated: 2026-07-24
 priority: medium
 feasibility: medium
 task_type: feature
@@ -78,6 +79,25 @@ Still refusing / wrong (this issue):
       2026-07-02, see Progress.
 - [x] No host-mode regression (`ctx.standalone`-gated). — the reflective fold is
       observationally identical in host mode.
+
+## Closed done (2026-07-24, dev-std-3) — verify-first reconcile
+
+All acceptance criteria PASS host-free on current main (measured 2026-07-24 via
+standalone compile + `imports === []` + run). The 2026-07-16 "JSON.stringify
+object-arg regressed" caveat on criterion 1 is **STALE** — re-measured and it
+now passes:
+
+- `const f: any = JSON.stringify; f({a:1}) === '{"a":1}'` → pass, host-free
+- `const f: any = JSON.stringify; f(5) === '5'` → pass, host-free
+- `const g: any = Math.max; g(1,2,3) === 3` → pass, host-free
+- `const o: any = {a:1,b:2}; Reflect.ownKeys(o).length === 2` → pass, host-free
+- `const f: any = Reflect.get; f({a:7},"a") === 7` → pass, host-free
+- `const k: any = "PI"; (Math as any)[k]` reads π → pass, host-free
+
+Nothing left to implement; this was a false-`ready` (acceptance met but status
+never flipped). Marked `done`. Any deeper namespace edges (`toExponential`/
+`toPrecision` no-arg delegation, `globalThis.Math.PI` trap) are tracked with the
+Number/namespace work (#3175/#3081), not here.
 
 ## Progress (2026-07-02, opus-12c) — reflective namespace-constant read landed
 

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -35,6 +35,8 @@ import { emitUndefined, ensureLateImport, flushLateImportShifts, shiftLateImport
 import { emitStringBuilderRead, getBuilderInfo } from "../string-builder.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { BUILTIN_TYPE_TAGS, isBuiltinSubtype, isBuiltinTypeName } from "../builtin-tags.js";
+import { ensureDateStruct } from "./builtins.js"; // (#1325) native $__Date struct for host-free `instanceof Date`
+import { ensureStandaloneRegExpStruct } from "../regexp-standalone.js"; // (#1325) native RegExp struct for host-free `instanceof RegExp`
 import { getOrRegisterErrorStructType, isWasiErrorName } from "../registry/error-types.js";
 import { allocLocal } from "../context/locals.js";
 import { popBody, pushBody } from "../context/bodies.js";
@@ -1670,6 +1672,19 @@ function nativeBuiltinInstanceOfTypeIdxs(ctx: CodegenContext, ctorName: string):
       return keep(ctx.wrapperStringTypeIdx);
     case "Boolean":
       return keep(ctx.wrapperBooleanTypeIdx);
+    case "Date":
+      // (#1325) `new Date()` lowers to a distinct `$__Date` WasmGC struct
+      // (one i64 timestamp field). Register-or-fetch its type idx so
+      // `ref.test $__Date` answers `d instanceof Date` host-free even when the
+      // LHS is `any` (the static `tryStaticInstanceOf` path already covers a
+      // statically-typed `Date` LHS). `ensureDateStruct` is idempotent and
+      // type-only (no funcidx shift), so calling it here is compile-order-safe.
+      return keep(ensureDateStruct(ctx));
+    case "RegExp":
+      // (#1325) A RegExp literal / `new RegExp(...)` lowers to the distinct
+      // `$__StandaloneRegExp` struct; `ref.test` against it answers
+      // `r instanceof RegExp` host-free. Idempotent, type-only registration.
+      return keep(ensureStandaloneRegExpStruct(ctx));
     default:
       return undefined;
   }
@@ -1910,9 +1925,11 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   // answer can only CONVERT a failing test — never regress a passing one; and
   // gc/host stays byte-identical (this branch is skipped when a JS host is
   // present). Error-family RHS was already handled natively above. A builtin we
-  // do not yet model natively (Object, Date, RegExp, Promise, ArrayBuffer, ...)
-  // or an unresolvable non-builtin ctor falls to a conservative `0` (a missed
-  // conversion, never a wrong `true` — #2916). NEVER emit the host import here.
+  // do not yet model natively (Object, Promise, ArrayBuffer, DataView, typed
+  // arrays, ...) or an unresolvable non-builtin ctor falls to a conservative `0`
+  // (a missed conversion, never a wrong `true` — #2916). Date and RegExp ARE now
+  // modeled (#1325, distinct $__Date / $__StandaloneRegExp structs). NEVER emit
+  // the host import here.
   if (noJsHost(ctx)) {
     const typeIdxs = nativeBuiltinInstanceOfTypeIdxs(ctx, ctorName);
     if (typeIdxs !== undefined) {

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -733,7 +733,7 @@ export function escapeRegExpPattern(pattern: string): string {
   return out;
 }
 
-function ensureStandaloneRegExpStruct(ctx: CodegenContext): number {
+export function ensureStandaloneRegExpStruct(ctx: CodegenContext): number {
   const existing = ctx.structMap.get(STANDALONE_REGEXP_STRUCT_NAME);
   if (existing !== undefined) return existing;
 

--- a/tests/issue-1325.test.ts
+++ b/tests/issue-1325.test.ts
@@ -233,3 +233,106 @@ describe("#1325 instanceof BuiltIn — static elimination", () => {
     ).toBe(0);
   });
 });
+
+// ── Standalone (host-free) instanceof for native Date / RegExp structs ──
+//
+// (#1325 residual slice) `new Date()` and a RegExp literal / `new RegExp(...)`
+// lower to distinct WasmGC structs ($__Date / $__StandaloneRegExp) in
+// `--target standalone`. Before this slice, `nativeBuiltinInstanceOfTypeIdxs`
+// returned undefined for Date/RegExp so a dynamic (`any`-typed / function-param)
+// LHS answered a conservative `0` even for a genuine instance. Now it returns
+// the struct type idx and `emitNativeInstanceOfMembership` answers via a native
+// `ref.test` — no `__instanceof` host import. Statically-typed LHS was already
+// handled by `tryStaticInstanceOf`; these tests pin the dynamic/opaque forms.
+describe("#1325 instanceof Date/RegExp — standalone native (host-free)", () => {
+  async function runStandalone(src: string): Promise<number> {
+    const r = await compile(src, { target: "standalone" });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    // No host import may leak under standalone (host-free pass).
+    expect(r.imports ?? []).toEqual([]);
+    expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as { test(): number }).test();
+  }
+
+  it("`any`-typed Date instance instanceof Date → true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const d: any = new Date(); return (d instanceof Date) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("opaque function-param Date instanceof Date → true (runtime ref.test, cross-function)", async () => {
+    expect(
+      await runStandalone(
+        `function f(d: any): number { return (d instanceof Date) ? 1 : 0; } export function test(): number { return f(new Date()); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("`any`-typed RegExp literal instanceof RegExp → true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const r: any = /a/; return (r instanceof RegExp) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("`any`-typed new RegExp(...) instanceof RegExp → true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const r: any = new RegExp("a"); return (r instanceof RegExp) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("opaque function-param RegExp instanceof RegExp → true", async () => {
+    expect(
+      await runStandalone(
+        `function f(r: any): number { return (r instanceof RegExp) ? 1 : 0; } export function test(): number { return f(/a/); }`,
+      ),
+    ).toBe(1);
+  });
+
+  // ── Negatives / no false positives ──
+  it("{} instanceof Date → false", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const o: any = {}; return (o instanceof Date) ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("[] instanceof Date → false", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a: any = []; return (a instanceof Date) ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("123 instanceof Date → false (numeric primitive)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const n: any = 123; return (n instanceof Date) ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("Date instance instanceof RegExp → false (distinct structs, no cross-match)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const d: any = new Date(); return (d instanceof RegExp) ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("RegExp instance instanceof Date → false", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const r: any = /a/; return (r instanceof Date) ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("{} instanceof RegExp → false", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = {}; return (o instanceof RegExp) ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Standalone `x instanceof Date` / `x instanceof RegExp` answered a conservative `0` for a **dynamic** (`any`-typed / opaque function-param) LHS: `nativeBuiltinInstanceOfTypeIdxs` (#2916) had no case for them, even though `new Date()` and a RegExp literal / `new RegExp(...)` already lower to distinct WasmGC structs (`$__Date`, `$__StandaloneRegExp`). This adds the two cases so `emitNativeInstanceOfMembership` answers via a native `ref.test` against the (idempotent, type-only registered) struct type — **no `__instanceof` host import**. A statically-typed LHS was already covered by `tryStaticInstanceOf`.

## Measured flips (standalone, verify-first, all host-free)

| case | before | after |
| --- | --- | --- |
| `const d: any = new Date(); d instanceof Date` | 0 | 1 |
| `function f(d:any){return d instanceof Date} f(new Date())` (cross-fn opaque param) | 0 | 1 |
| `const r: any = /a/ \| new RegExp("a"); r instanceof RegExp` | 0 | 1 |
| opaque-param RegExp | 0 | 1 |

**No false positives** — negatives stay `false`: `{} instanceof Date`, `[] instanceof Date`, `123 instanceof Date`, `Date instanceof RegExp`, `RegExp instanceof Date`, `{} instanceof RegExp`. Host/gc mode is `noJsHost`-gated → **byte-identical**.

## Also: #2933 → done (false-ready reconcile)

Verify-first re-measure shows all of #2933's acceptance criteria pass host-free on current main (the 2026-07-16 "JSON.stringify obj-arg regressed" note is stale — re-verified passing). Marked `done`; no code needed.

## Scope

#1325 stays open with a narrowed note: headline cases + Date/RegExp done; per-representation tagging for Promise/ArrayBuffer/DataView/TypedArray + the `instanceof Object` / `func instanceof Function` edges remain as follow-on.

## Tests

`tests/issue-1325.test.ts` — new standalone describe block (11 cases: positive dynamic/opaque + negative/no-false-positive). Full file 24/24 green. Adjacent `instanceof`/`date-native`/`regex` suites: no new failures (pre-existing host-harness `string_constants`/`__date_now` import gaps only). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ
