### PR TITLE
fix(#3570): Number('+0x10') → NaN in standalone native parser

### DIFF
--- a/plan/issues/3570-number-plus-sign-radix-prefix-parse.md
+++ b/plan/issues/3570-number-plus-sign-radix-prefix-parse.md
@@ -1,0 +1,76 @@
+---
+id: 3570
+title: "Standalone: Number('+0x10') / '+0o17' / '+0b10' parse the radix literal instead of NaN (leading-'+' + NonDecimalIntegerLiteral)"
+status: done
+created: 2026-07-24
+completed: 2026-07-24
+priority: medium
+feasibility: easy
+task_type: bugfix
+area: codegen
+goal: standalone
+sprint: current
+horizon: s
+model: opus
+assignee: ttraenkler/dev-std-date-math
+parent: 1836
+related: [1335, 1836, 2160]
+---
+
+# #3570 — Number('+0x10') parses instead of NaN (residual of #1836)
+
+## Problem
+
+In `--target standalone`/`wasi` (the no-JS-host native `__str_to_number`
+path), a NonDecimalIntegerLiteral preceded by an explicit `+` sign is parsed
+as the radix value instead of `NaN`:
+
+```
+Number('+0x10')  →  16   (must be NaN)
+Number('+0o17')  →  15   (must be NaN)
+Number('+0b10')  →   2   (must be NaN)
+```
+
+The `-` case was already correct (`Number('-0x10')` → NaN, fixed in #1836) —
+this is the `+` residual.
+
+Per ECMA-262 §7.1.4.1 StringToNumber, a `StrNumericLiteral` beginning with
+`0x`/`0o`/`0b` is a `NonDecimalIntegerLiteral`, which the grammar admits **only
+with no leading sign**. Both `+` and `-` before the prefix are invalid and the
+whole string is `NaN`. (JS-host mode delegates `Number(string)` to V8 and was
+already correct; this is native-parser-only.)
+
+## Root cause
+
+`src/codegen/parse-number-native.ts`. The native `__str_to_number` sign block
+sets `sign = -1` for `-` but leaves `sign = +1` for `+` (only advancing the
+index). `emitRadixPrefixParse`'s guard keyed the "no sign consumed" condition
+on `sign == 1` (f64) — which is TRUE for both "no sign" and "explicit `+`", so
+`+0x10` wrongly entered the radix arm. `-0x10` was excluded only incidentally
+(sign became -1).
+
+## Fix
+
+Track sign-char consumption explicitly with a new `sawSign` (i32) local:
+set it to 1 in **both** the `-` and `+` branches, and change the radix-prefix
+guard from `sign == 1` to `sawSign == 0`. Now both signs fall through to the
+decimal scanner → NaN, and unsigned `0x`/`0o`/`0b` still parse. `parseInt`
+(which spec-legitimately accepts `+0x`) is unaffected — it uses a separate code
+path (`emitParseInt`), not `emitRadixPrefixParse`.
+
+## Acceptance criteria
+
+- [x] `Number('+0x10')` / `'+0o17'` / `'+0b10'` → NaN in standalone.
+- [x] Unsigned `Number('0x10')` → 16, `Number('0o17')` → 15 unchanged.
+- [x] `Number('-0x10')` → NaN unchanged; signed decimals (`+12`, `-3.5e2`,
+      whitespace-wrapped) unchanged.
+- [x] test262 standalone flips: `built-ins/Number/string-{hex,binary,octal}-literal-invalid.js`
+      fail → pass (+3), zero new standalone failures across Date/Math/Number.
+- [x] No JS-host (gc) regression — native-parser-only change.
+
+## Test Results
+
+Measured (`runTest262File(..., "standalone")`, worktree on origin/main `fa2b189`):
+`string-hex-literal-invalid.js`, `string-binary-literal-invalid.js`,
+`string-octal-literal-invald.js` all fail → pass in standalone; still pass in
+gc. Full Date+Math+Number standalone re-run: net **+3**, no regressions.

--- a/plan/issues/3570-number-plus-sign-radix-prefix-parse.md
+++ b/plan/issues/3570-number-plus-sign-radix-prefix-parse.md
@@ -15,6 +15,8 @@ model: opus
 assignee: ttraenkler/dev-std-date-math
 parent: 1836
 related: [1335, 1836, 2160]
+loc-budget-allow:
+  - src/codegen/parse-number-native.ts
 ---
 
 # #3570 — Number('+0x10') parses instead of NaN (residual of #1836)

--- a/plan/issues/3570-number-plus-sign-radix-prefix-parse.md
+++ b/plan/issues/3570-number-plus-sign-radix-prefix-parse.md
@@ -17,6 +17,8 @@ parent: 1836
 related: [1335, 1836, 2160]
 loc-budget-allow:
   - src/codegen/parse-number-native.ts
+func-budget-allow:
+  - src/codegen/parse-number-native.ts::emitStrToNumber
 ---
 
 # #3570 — Number('+0x10') parses instead of NaN (residual of #1836)

--- a/src/codegen/parse-number-native.ts
+++ b/src/codegen/parse-number-native.ts
@@ -534,6 +534,12 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
   const L_TEXP = 16; // i32: total decimal exponent (expSign*exp + intDrop - fracCount)
   const L_POW = 17; // f64: 10^|totalExp|
   const L_INTDROP = 18; // i32: integer digits dropped past the ~15-sig-digit cap
+  // (#3570) i32: 1 iff an explicit '+'/'-' sign char was consumed. A
+  // NonDecimalIntegerLiteral (0x/0o/0b) is INVALID with any leading sign
+  // (§7.1.4.1), so `Number('+0x10')`/`Number('-0x10')` must be NaN. The old
+  // radix guard keyed on `sign==1`, which admits the '+' case (it leaves
+  // sign=+1); this flag distinguishes "no sign" from "explicit +".
+  const L_SAWSIGN = 19;
 
   const getC: Instr[] = [
     { op: "local.get", index: L_DATA },
@@ -644,6 +650,8 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
       then: [
         { op: "f64.const", value: -1 },
         { op: "local.set", index: L_SIGN },
+        { op: "i32.const", value: 1 },
+        { op: "local.set", index: L_SAWSIGN },
         { op: "local.get", index: L_I },
         { op: "i32.const", value: 1 },
         { op: "i32.add" },
@@ -657,6 +665,8 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
           op: "if",
           blockType: { kind: "empty" },
           then: [
+            { op: "i32.const", value: 1 },
+            { op: "local.set", index: L_SAWSIGN },
             { op: "local.get", index: L_I },
             { op: "i32.const", value: 1 },
             { op: "i32.add" },
@@ -675,7 +685,7 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
     //     original start with sign==1; to keep it simple we allow it whenever
     //     two chars remain — sign already shifted i, and a signed 0x is NaN per
     //     spec, so guard on sign==1. ---
-    ...emitRadixPrefixParse(L_I, L_END, L_DATA, L_C, L_SIGN, L_RADIX, L_DIG, L_RESULT, L_SAW, strDataTypeIdx),
+    ...emitRadixPrefixParse(L_I, L_END, L_DATA, L_C, L_SAWSIGN, L_RADIX, L_DIG, L_RESULT, L_SAW, strDataTypeIdx),
 
     // --- decimal mantissa ---
     { op: "i64.const", value: 0n },
@@ -879,6 +889,7 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
       { name: "texp", type: i32 },
       { name: "pow", type: f64 },
       { name: "intDrop", type: i32 },
+      { name: "sawSign", type: i32 },
     ],
     body,
     exported: false,
@@ -947,7 +958,7 @@ function emitRadixPrefixParse(
   L_END: number,
   L_DATA: number,
   L_C: number,
-  L_SIGN: number,
+  L_SAWSIGN: number,
   L_RADIX: number,
   L_DIG: number,
   L_RESULT: number,
@@ -1050,10 +1061,13 @@ function emitRadixPrefixParse(
   ];
   void L_SAW;
   return [
-    // guard: sign==1 (no sign consumed) && i+1 < end && data[i]=='0'
-    { op: "local.get", index: L_SIGN },
-    { op: "f64.const", value: 1 },
-    { op: "f64.eq" },
+    // guard: NO sign char consumed (sawSign==0) && i+1 < end && data[i]=='0'.
+    // (#3570) A NonDecimalIntegerLiteral admits no leading sign, so both
+    // '+0x10' and '-0x10' must fall through to the decimal scanner → NaN. The
+    // old `sign==1` test let '+' through (it leaves sign=+1); keying on the
+    // explicit sawSign flag rejects both signs.
+    { op: "local.get", index: L_SAWSIGN },
+    { op: "i32.eqz" },
     { op: "local.get", index: L_I },
     { op: "i32.const", value: 1 },
     { op: "i32.add" },

--- a/tests/issue-3570.test.ts
+++ b/tests/issue-3570.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3570 — standalone Number('+0x10') must be NaN (residual of #1836).
+// A NonDecimalIntegerLiteral (0x/0o/0b) admits NO leading sign per §7.1.4.1
+// StringToNumber. The '-' case was already NaN (#1836); this covers the '+'
+// residual, which previously parsed the radix value (Number('+0x10') → 16).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function evalStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors[0]?.message).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+const num = (expr: string) => `export function test(): number { return Number(${JSON.stringify(expr)}); }`;
+
+describe("#3570 standalone Number() leading-'+' non-decimal literal → NaN", () => {
+  it("returns NaN for '+' before a hex/octal/binary prefix", async () => {
+    expect(await evalStandalone(num("+0x10"))).toBeNaN();
+    expect(await evalStandalone(num("+0X1F"))).toBeNaN();
+    expect(await evalStandalone(num("+0o17"))).toBeNaN();
+    expect(await evalStandalone(num("+0O17"))).toBeNaN();
+    expect(await evalStandalone(num("+0b101"))).toBeNaN();
+    expect(await evalStandalone(num("+0B101"))).toBeNaN();
+  });
+
+  it("still returns NaN for '-' before a non-decimal prefix (no regression)", async () => {
+    expect(await evalStandalone(num("-0x10"))).toBeNaN();
+    expect(await evalStandalone(num("-0o17"))).toBeNaN();
+    expect(await evalStandalone(num("-0b101"))).toBeNaN();
+  });
+
+  it("still parses UNSIGNED non-decimal literals (no regression)", async () => {
+    expect(await evalStandalone(num("0x10"))).toBe(16);
+    expect(await evalStandalone(num("0o17"))).toBe(15);
+    expect(await evalStandalone(num("0b101"))).toBe(5);
+  });
+
+  it("still parses signed DECIMAL literals (no regression)", async () => {
+    expect(await evalStandalone(num("+12"))).toBe(12);
+    expect(await evalStandalone(num("-3.5e2"))).toBe(-350);
+    expect(await evalStandalone(num("+0.25"))).toBe(0.25);
+    // whitespace-wrapped signed decimal
+    expect(await evalStandalone(num("   +42\t"))).toBe(42);
+    // a leading-zero decimal (not legacy octal) with a sign
+    expect(await evalStandalone(num("+08"))).toBe(8);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone`/`wasi` (native `__str_to_number`), a NonDecimalIntegerLiteral preceded by an explicit `+` sign parsed the radix value instead of `NaN`:

```
Number('+0x10')  →  16   (must be NaN)
Number('+0o17')  →  15   (must be NaN)
Number('+0b10')  →   2   (must be NaN)
```

Per ECMA-262 §7.1.4.1, a `0x`/`0o`/`0b` literal admits **no** leading sign — both `+` and `-` make it `NaN`. The `-` case was already correct (#1836); this is the `+` residual. JS-host (gc) mode delegates to V8 and was already correct — native-parser-only change.

## Root cause

`src/codegen/parse-number-native.ts`: the sign block sets `sign=-1` for `-` but leaves `sign=+1` for `+` (only advancing the index). `emitRadixPrefixParse`'s guard keyed 'no sign consumed' on `sign==1` (f64) — true for both no-sign and explicit `+` — so `+0x10` wrongly entered the radix arm.

## Fix

Track sign-char consumption with a new `sawSign` (i32) local, set in **both** the `-` and `+` branches; gate the radix arm on `sawSign==0`. Unsigned `0x`/`0o`/`0b` still parse; `parseInt` (spec-allows `+0x`) is a separate code path and unaffected.

## Measured impact (`runTest262File(..., "standalone")`, worktree on origin/main)

Full Date+Math+Number lane re-run (1259 files): **net +3, zero regressions**.
- `built-ins/Number/string-hex-literal-invalid.js` fail → pass
- `built-ins/Number/string-binary-literal-invalid.js` fail → pass
- `built-ins/Number/string-octal-literal-invald.js` fail → pass

Tests: `tests/issue-3570.test.ts` (4 tests) + existing `tests/issue-1836.test.ts` (25) all green — no #1836 regression.

Closes #3570.