### PR TITLE
fix(#3569): well-formed surrogate escaping in standalone JSON.stringify

### DIFF
--- a/plan/issues/3569-json-wellformed-stringify.md
+++ b/plan/issues/3569-json-wellformed-stringify.md
@@ -1,0 +1,78 @@
+---
+id: 3569
+title: "Standalone JSON.stringify: well-formed surrogate escaping (lone surrogate → \\uXXXX)"
+status: done
+assignee: ttraenkler/agent-json-object-reflect
+sprint: current
+created: 2026-07-24
+updated: 2026-07-24
+completed: 2026-07-24
+priority: low
+feasibility: easy
+task_type: conformance
+area: standalone
+language_feature: json
+goal: standalone
+horizon: s
+related: [1599, 2166, 2933]
+---
+
+# Standalone JSON.stringify: well-formed surrogate escaping
+
+## Problem
+
+Measured on the standalone lane (`run-test262-fyi.mjs --target standalone`),
+`built-ins/JSON/stringify/value-string-escape-unicode.js` failed: the host-free
+native codec (`__json_quote_string`, `src/codegen/json-runtime.ts`) copied every
+UTF-16 code unit ≥ 0x20 verbatim, so a **lone** surrogate leaked through
+unescaped.
+
+ES2019 §25.5.4.3 `QuoteJSONString` (feature `well-formed-json-stringify`)
+requires:
+- a lone (unpaired) surrogate code unit U+D800–U+DFFF → escaped as `\uXXXX`;
+- the two code units of a valid high+low pair → copied through verbatim.
+
+Host (WasmGC/JS) mode delegates to the JS host `JSON.stringify` (V8 already does
+this), so this only affected `--target standalone` / `--target wasi`.
+
+## Fix
+
+`emitJsonQuoteString` in `src/codegen/json-runtime.ts`:
+- Added an `escapeSurr` predicate that classifies the code unit at `data[i]` as a
+  lone surrogate (escape) vs. part of a valid pair (verbatim), using
+  immediate-neighbour lookahead/lookbehind (`data[i+1]` for a high, `data[i-1]`
+  for a low) bounded by the string's `[off, end)`. Both the sizing pass and the
+  fill pass call it, so widths and emitted bytes stay in lock-step.
+- Generalised the `\uXXXX` emitter to write all four hex nibbles with the full
+  `0-9`/`a-f` mapping (the prior control-char path emitted only `\u00XX`; the top
+  two nibbles are still 0 for control chars, so that output is byte-identical).
+
+No new host imports; the fix stays entirely on the pure-Wasm codec.
+
+## Acceptance criteria
+
+- [x] `built-ins/JSON/stringify/value-string-escape-unicode.js` passes under
+      `--target standalone`.
+- [x] No standalone regression across `built-ins/JSON` (diff: exactly one
+      FAIL→PASS flip, zero PASS→FAIL).
+- [x] Host lane unaffected (native codec is standalone/wasi-only).
+- [x] Repro added as `tests/issue-3569.test.ts`.
+
+## Test Results
+
+Harness: `node scripts/run-test262-fyi.mjs --target standalone` (authoritative
+`test262-worker.mjs`, standalone target).
+
+- `built-ins/JSON` standalone: **129/165 → 130/165** (+1).
+- Before/after per-file diff: **1 flip, FAIL→PASS**
+  (`value-string-escape-unicode.js`), **0 regressions**.
+- Host lane `built-ins/JSON` (gc): 117/165 (unchanged — native codec not on the
+  host path).
+- `tests/issue-3569.test.ts`: 5/5 pass (lone high, lone low, valid pair verbatim,
+  mixed, control-char + pair regression guard).
+- `tsc --noEmit`: clean.
+
+Note: `tests/issue-1599-runtime.test.ts > parses true and false` fails on
+`origin/main` independently of this change (a JSON.**parse** boolean-unbox
+value-rep gap, not touched here) — verified by reverting `json-runtime.ts` to
+`origin/main` and re-running.

--- a/src/codegen/json-runtime.ts
+++ b/src/codegen/json-runtime.ts
@@ -15,6 +15,9 @@
  *   - escape `\b` (U+0008), `\t` (U+0009), `\n` (U+000A), `\f` (U+000C),
  *     `\r` (U+000D) with their short forms
  *   - escape every other control char U+0000–U+001F as `\u00XX`
+ *   - escape a **lone** UTF-16 surrogate (unpaired U+D800–U+DFFF) as `\uXXXX`
+ *     (well-formed JSON.stringify, ES2019 §25.5.4.3); copy the two code units
+ *     of a valid high+low pair through verbatim
  *   - copy all other code units verbatim
  *
  * Result is returned as an `externref` (the WasmGC `$NativeString` widened via
@@ -55,6 +58,13 @@ const C_LC_R = 114; // 'r'
 const C_LC_U = 117; // 'u'
 const C_ZERO = 48; // '0'
 const C_LC_A_MINUS_10 = 87; // 'a' - 10  (for hex digit a-f)
+// UTF-16 surrogate ranges (well-formed JSON.stringify, ES2019 §25.5.4.3):
+// a lone surrogate code unit must be escaped as \uXXXX; a valid high+low pair
+// is copied through verbatim (the astral code point).
+const SURR_HIGH_LO = 0xd800; // high (leading) surrogate range 0xD800..0xDBFF
+const SURR_HIGH_HI = 0xdbff;
+const SURR_LOW_LO = 0xdc00; // low (trailing) surrogate range 0xDC00..0xDFFF
+const SURR_LOW_HI = 0xdfff;
 
 /**
  * Emit `__json_quote_string(s: externref) -> externref` and register it in
@@ -85,7 +95,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
   // locals:
   //  1 flat:ref $NativeString   2 data:ref $__str_data   3 end:i32   4 i:i32
   //  5 c:i32   6 outLen:i32   7 out:ref $__str_data   8 w:i32 (write cursor)
-  //  9 off:i32  10 nib:i32 (scratch nibble)
+  //  9 off:i32  10 nib:i32 (scratch nibble)  11 nb:i32 (neighbor code unit)
   const L_FLAT = 1;
   const L_DATA = 2;
   const L_END = 3;
@@ -96,6 +106,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
   const L_W = 8;
   const L_OFF = 9;
   const L_NIB = 10;
+  const L_NB = 11;
 
   // c = data[i]
   const getC: Instr[] = [
@@ -125,6 +136,86 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
     { op: "i32.eq" },
   ];
 
+  // (local at `idx`) is in the inclusive unsigned range [lo, hi]  (leaves i32)
+  const localInRange = (idx: number, lo: number, hi: number): Instr[] => [
+    { op: "local.get", index: idx },
+    { op: "i32.const", value: lo },
+    { op: "i32.ge_u" },
+    { op: "local.get", index: idx },
+    { op: "i32.const", value: hi },
+    { op: "i32.le_u" },
+    { op: "i32.and" },
+  ];
+
+  // Well-formed JSON.stringify (ES2019 §25.5.4.3, feature well-formed-json-
+  // stringify): a code unit at data[i] that is a LONE surrogate must be escaped
+  // as \uXXXX; a code unit that is part of a valid high+low pair is copied
+  // verbatim. This predicate leaves i32 (1 = c is a lone surrogate → escape).
+  //
+  // Adjacency is unambiguous: a high surrogate pairs forward with the
+  // immediately-following low; a low pairs backward with the immediately-
+  // preceding high. Both passes (sizing + fill) iterate the same indices with
+  // the same bounds, so they compute identical decisions. Uses L_NB scratch.
+  const escapeSurr: Instr[] = [
+    ...localInRange(L_C, SURR_HIGH_LO, SURR_HIGH_HI), // c is a high surrogate?
+    {
+      op: "if",
+      blockType: { kind: "val", type: i32 },
+      // High: escape unless the NEXT unit (i+1 < end) is a low surrogate.
+      then: [
+        { op: "local.get", index: L_I },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.get", index: L_END },
+        { op: "i32.lt_u" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: i32 },
+          then: [
+            { op: "local.get", index: L_DATA },
+            { op: "local.get", index: L_I },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "local.set", index: L_NB },
+            ...localInRange(L_NB, SURR_LOW_LO, SURR_LOW_HI),
+          ],
+          else: [{ op: "i32.const", value: 0 }], // no next unit → lone high
+        },
+        { op: "i32.eqz" }, // escape = !nextIsLow
+      ],
+      else: [
+        ...localInRange(L_C, SURR_LOW_LO, SURR_LOW_HI), // c is a low surrogate?
+        {
+          op: "if",
+          blockType: { kind: "val", type: i32 },
+          // Low: escape unless the PREV unit (i > off) is a high surrogate.
+          then: [
+            { op: "local.get", index: L_I },
+            { op: "local.get", index: L_OFF },
+            { op: "i32.gt_u" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: i32 },
+              then: [
+                { op: "local.get", index: L_DATA },
+                { op: "local.get", index: L_I },
+                { op: "i32.const", value: 1 },
+                { op: "i32.sub" },
+                { op: "array.get_u", typeIdx: strDataTypeIdx },
+                { op: "local.set", index: L_NB },
+                ...localInRange(L_NB, SURR_HIGH_LO, SURR_HIGH_HI),
+              ],
+              else: [{ op: "i32.const", value: 0 }], // no prev unit → lone low
+            },
+            { op: "i32.eqz" }, // escape = !prevIsHigh
+          ],
+          else: [{ op: "i32.const", value: 0 }], // not a surrogate → not escaped
+        },
+      ],
+    },
+  ];
+
   // Shared preamble: flatten s, load data/off, compute end = off + len.
   const preamble: Instr[] = [
     { op: "local.get", index: 0 },
@@ -146,7 +237,8 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
     { op: "local.set", index: L_END }, // end = off + len (exclusive)
   ];
 
-  // width(c): '"','\',\b\t\n\f\r -> 2 ; other ctrl (<0x20) -> 6 ; else 1
+  // width(c): '"','\',\b\t\n\f\r -> 2 ; ctrl (<0x20) or lone surrogate -> 6 ;
+  // else 1 (verbatim, incl. code units of a valid surrogate pair)
   const widthExpr: Instr[] = [
     ...cEq(C_QUOTE),
     ...cEq(C_BACKSLASH),
@@ -173,7 +265,15 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
           op: "if",
           blockType: { kind: "val", type: i32 },
           then: [{ op: "i32.const", value: 6 }],
-          else: [{ op: "i32.const", value: 1 }],
+          else: [
+            ...escapeSurr,
+            {
+              op: "if",
+              blockType: { kind: "val", type: i32 },
+              then: [{ op: "i32.const", value: 6 }],
+              else: [{ op: "i32.const", value: 1 }],
+            },
+          ],
         },
       ],
     },
@@ -212,25 +312,11 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
   // short escape: backslash + letter
   const emitShort = (letter: number): Instr[] => [...putConst(C_BACKSLASH), ...putConst(letter)];
 
-  // \u00XX for control chars (c is 0x00..0x1f so high hex nibbles are 0,0,0..1)
-  const emitUnicode: Instr[] = [
-    ...putConst(C_BACKSLASH),
-    ...putConst(C_LC_U),
-    ...putConst(C_ZERO),
-    ...putConst(C_ZERO),
-    // high nibble = (c >> 4) & 0xf  → always 0 or 1 → '0'+n
-    ...put([
+  // Emit one hex digit for nibble `(c >> shift) & 0xf`, mapped '0'-'9'/'a'-'f'.
+  const emitHexNibble = (shift: number): Instr[] =>
+    put([
       { op: "local.get", index: L_C },
-      { op: "i32.const", value: 4 },
-      { op: "i32.shr_u" },
-      { op: "i32.const", value: 0xf },
-      { op: "i32.and" },
-      { op: "i32.const", value: C_ZERO },
-      { op: "i32.add" },
-    ]),
-    // low nibble = c & 0xf  → '0'+n (n<10) else 'a'+(n-10)
-    ...put([
-      { op: "local.get", index: L_C },
+      ...(shift > 0 ? [{ op: "i32.const", value: shift } as Instr, { op: "i32.shr_u" } as Instr] : []),
       { op: "i32.const", value: 0xf },
       { op: "i32.and" },
       { op: "local.tee", index: L_NIB },
@@ -242,7 +328,19 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         then: [{ op: "local.get", index: L_NIB }, { op: "i32.const", value: C_ZERO }, { op: "i32.add" }],
         else: [{ op: "local.get", index: L_NIB }, { op: "i32.const", value: C_LC_A_MINUS_10 }, { op: "i32.add" }],
       },
-    ]),
+    ]);
+
+  // \uXXXX for control chars (U+0000–U+001F) and lone surrogates. All four hex
+  // nibbles are emitted with the full 0-9/a-f mapping — for control chars the
+  // top two nibbles are 0, reproducing the prior `\u00XX`; for surrogates the
+  // top nibble is `d`, giving e.g. `\ud834`.
+  const emitUnicode: Instr[] = [
+    ...putConst(C_BACKSLASH),
+    ...putConst(C_LC_U),
+    ...emitHexNibble(12),
+    ...emitHexNibble(8),
+    ...emitHexNibble(4),
+    ...emitHexNibble(0),
   ];
 
   // copy verbatim
@@ -299,7 +397,18 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
                                   op: "if",
                                   blockType: { kind: "empty" },
                                   then: emitUnicode,
-                                  else: emitVerbatim,
+                                  // Not a control char: a lone surrogate is
+                                  // escaped \uXXXX; everything else (incl. the
+                                  // units of a valid pair) is copied verbatim.
+                                  else: [
+                                    ...escapeSurr,
+                                    {
+                                      op: "if",
+                                      blockType: { kind: "empty" },
+                                      then: emitUnicode,
+                                      else: emitVerbatim,
+                                    },
+                                  ],
                                 },
                               ],
                             },
@@ -353,6 +462,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
       { count: 1, type: i32 }, // L_W
       { count: 1, type: i32 }, // L_OFF
       { count: 1, type: i32 }, // L_NIB
+      { count: 1, type: i32 }, // L_NB
     ],
     body,
     exported: false,

--- a/src/codegen/json-runtime.ts
+++ b/src/codegen/json-runtime.ts
@@ -66,53 +66,39 @@ const SURR_HIGH_HI = 0xdbff;
 const SURR_LOW_LO = 0xdc00; // low (trailing) surrogate range 0xDC00..0xDFFF
 const SURR_LOW_HI = 0xdfff;
 
+const I32: ValType = { kind: "i32" };
+
+// __json_quote_string local index layout, shared by the sizing and fill passes:
+//  1 flat  2 data  3 end  4 i  5 c  6 outLen  7 out  8 w  9 off  10 nib  11 nb
+const L_FLAT = 1;
+const L_DATA = 2;
+const L_END = 3;
+const L_I = 4;
+const L_C = 5;
+const L_OUTLEN = 6;
+const L_OUT = 7;
+const L_W = 8;
+const L_OFF = 9;
+const L_NIB = 10;
+const L_NB = 11;
+
 /**
- * Emit `__json_quote_string(s: externref) -> externref` and register it in
- * `ctx.funcMap`. Idempotent. Must run after `ensureNativeStringHelpers` (called
- * here) so `__str_flatten` exists, and before any function body that calls it.
- *
- * Algorithm: flatten the input to a `$NativeString`, walk its `[off, off+len)`
- * code units twice — first to size the output buffer, then to fill it — so the
- * output `$__str_data` is allocated exactly once at the right capacity.
+ * Instr builders for `__json_quote_string`, factored out of `emitJsonQuoteString`
+ * so neither function trips the per-function LOC ceiling (#3400). `d` is the
+ * `$__str_data` (array (mut i16)) type index. Returns only the pieces the outer
+ * emitter assembles; the smaller helpers stay closed over `d` internally.
  */
-export function emitJsonQuoteString(ctx: CodegenContext): number {
-  const existing = ctx.funcMap.get("__json_quote_string");
-  if (existing !== undefined) return existing;
-
-  ensureNativeStringHelpers(ctx);
-  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
-  const strTypeIdx = ctx.nativeStrTypeIdx; // $NativeString (FlatString): len, off, data
-  const strDataTypeIdx = ctx.nativeStrDataTypeIdx; // (array (mut i16))
-  const i32: ValType = { kind: "i32" };
-  const extern: ValType = { kind: "externref" };
-
-  const strRef = nativeStringType(ctx);
-  const typeIdx = addFuncType(ctx, [extern], [strRef]);
-  const funcIdx = mintDefinedFunc(ctx);
-  ctx.funcMap.set("__json_quote_string", funcIdx);
-
-  // params: 0 s:externref
-  // locals:
-  //  1 flat:ref $NativeString   2 data:ref $__str_data   3 end:i32   4 i:i32
-  //  5 c:i32   6 outLen:i32   7 out:ref $__str_data   8 w:i32 (write cursor)
-  //  9 off:i32  10 nib:i32 (scratch nibble)  11 nb:i32 (neighbor code unit)
-  const L_FLAT = 1;
-  const L_DATA = 2;
-  const L_END = 3;
-  const L_I = 4;
-  const L_C = 5;
-  const L_OUTLEN = 6;
-  const L_OUT = 7;
-  const L_W = 8;
-  const L_OFF = 9;
-  const L_NIB = 10;
-  const L_NB = 11;
-
+function qQuoteBuilders(d: number): {
+  getC: Instr[];
+  putConst: (v: number) => Instr[];
+  widthExpr: Instr[];
+  fillCharDispatch: Instr[];
+} {
   // c = data[i]
   const getC: Instr[] = [
     { op: "local.get", index: L_DATA },
     { op: "local.get", index: L_I },
-    { op: "array.get_u", typeIdx: strDataTypeIdx },
+    { op: "array.get_u", typeIdx: d },
     { op: "local.set", index: L_C },
   ];
 
@@ -121,7 +107,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
     { op: "local.get", index: L_OUT },
     { op: "local.get", index: L_W },
     ...valueInstrs,
-    { op: "array.set", typeIdx: strDataTypeIdx },
+    { op: "array.set", typeIdx: d },
     { op: "local.get", index: L_W },
     { op: "i32.const", value: 1 },
     { op: "i32.add" },
@@ -160,7 +146,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
     ...localInRange(L_C, SURR_HIGH_LO, SURR_HIGH_HI), // c is a high surrogate?
     {
       op: "if",
-      blockType: { kind: "val", type: i32 },
+      blockType: { kind: "val", type: I32 },
       // High: escape unless the NEXT unit (i+1 < end) is a low surrogate.
       then: [
         { op: "local.get", index: L_I },
@@ -170,13 +156,13 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         { op: "i32.lt_u" },
         {
           op: "if",
-          blockType: { kind: "val", type: i32 },
+          blockType: { kind: "val", type: I32 },
           then: [
             { op: "local.get", index: L_DATA },
             { op: "local.get", index: L_I },
             { op: "i32.const", value: 1 },
             { op: "i32.add" },
-            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "array.get_u", typeIdx: d },
             { op: "local.set", index: L_NB },
             ...localInRange(L_NB, SURR_LOW_LO, SURR_LOW_HI),
           ],
@@ -188,7 +174,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         ...localInRange(L_C, SURR_LOW_LO, SURR_LOW_HI), // c is a low surrogate?
         {
           op: "if",
-          blockType: { kind: "val", type: i32 },
+          blockType: { kind: "val", type: I32 },
           // Low: escape unless the PREV unit (i > off) is a high surrogate.
           then: [
             { op: "local.get", index: L_I },
@@ -196,13 +182,13 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
             { op: "i32.gt_u" },
             {
               op: "if",
-              blockType: { kind: "val", type: i32 },
+              blockType: { kind: "val", type: I32 },
               then: [
                 { op: "local.get", index: L_DATA },
                 { op: "local.get", index: L_I },
                 { op: "i32.const", value: 1 },
                 { op: "i32.sub" },
-                { op: "array.get_u", typeIdx: strDataTypeIdx },
+                { op: "array.get_u", typeIdx: d },
                 { op: "local.set", index: L_NB },
                 ...localInRange(L_NB, SURR_HIGH_LO, SURR_HIGH_HI),
               ],
@@ -214,27 +200,6 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         },
       ],
     },
-  ];
-
-  // Shared preamble: flatten s, load data/off, compute end = off + len.
-  const preamble: Instr[] = [
-    { op: "local.get", index: 0 },
-    { op: "any.convert_extern" },
-    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
-    { op: "call", funcIdx: flattenIdx },
-    { op: "ref.cast", typeIdx: strTypeIdx },
-    { op: "local.set", index: L_FLAT },
-    { op: "local.get", index: L_FLAT },
-    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // data
-    { op: "local.set", index: L_DATA },
-    { op: "local.get", index: L_FLAT },
-    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // off
-    { op: "local.set", index: L_OFF },
-    { op: "local.get", index: L_FLAT },
-    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }, // len
-    { op: "local.get", index: L_OFF },
-    { op: "i32.add" },
-    { op: "local.set", index: L_END }, // end = off + len (exclusive)
   ];
 
   // width(c): '"','\',\b\t\n\f\r -> 2 ; ctrl (<0x20) or lone surrogate -> 6 ;
@@ -255,7 +220,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
     { op: "i32.or" },
     {
       op: "if",
-      blockType: { kind: "val", type: i32 },
+      blockType: { kind: "val", type: I32 },
       then: [{ op: "i32.const", value: 2 }],
       else: [
         { op: "local.get", index: L_C },
@@ -263,13 +228,13 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         { op: "i32.lt_s" },
         {
           op: "if",
-          blockType: { kind: "val", type: i32 },
+          blockType: { kind: "val", type: I32 },
           then: [{ op: "i32.const", value: 6 }],
           else: [
             ...escapeSurr,
             {
               op: "if",
-              blockType: { kind: "val", type: i32 },
+              blockType: { kind: "val", type: I32 },
               then: [{ op: "i32.const", value: 6 }],
               else: [{ op: "i32.const", value: 1 }],
             },
@@ -277,36 +242,6 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         },
       ],
     },
-  ];
-
-  // Pass 1: outLen = 2 + Σ width(c)
-  const sizingLoop: Instr[] = [
-    { op: "i32.const", value: 2 },
-    { op: "local.set", index: L_OUTLEN },
-    { op: "local.get", index: L_OFF },
-    { op: "local.set", index: L_I },
-    ...counterLoopInstrs({
-      i: L_I,
-      bound: [{ op: "local.get", index: L_END }],
-      body: [
-        ...getC,
-        { op: "local.get", index: L_OUTLEN },
-        ...widthExpr,
-        { op: "i32.add" },
-        { op: "local.set", index: L_OUTLEN },
-      ],
-    }),
-  ];
-
-  // Allocate out buffer (outLen), w=0, write opening quote.
-  const allocOut: Instr[] = [
-    { op: "i32.const", value: 0 },
-    { op: "local.get", index: L_OUTLEN },
-    { op: "array.new", typeIdx: strDataTypeIdx },
-    { op: "local.set", index: L_OUT },
-    { op: "i32.const", value: 0 },
-    { op: "local.set", index: L_W },
-    ...putConst(C_QUOTE),
   ];
 
   // short escape: backslash + letter
@@ -324,7 +259,7 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
       { op: "i32.lt_s" },
       {
         op: "if",
-        blockType: { kind: "val", type: i32 },
+        blockType: { kind: "val", type: I32 },
         then: [{ op: "local.get", index: L_NIB }, { op: "i32.const", value: C_ZERO }, { op: "i32.add" }],
         else: [{ op: "local.get", index: L_NIB }, { op: "i32.const", value: C_LC_A_MINUS_10 }, { op: "i32.add" }],
       },
@@ -424,6 +359,88 @@ export function emitJsonQuoteString(ctx: CodegenContext): number {
         },
       ],
     },
+  ];
+
+  return { getC, putConst, widthExpr, fillCharDispatch };
+}
+
+/**
+ * Emit `__json_quote_string(s: externref) -> externref` and register it in
+ * `ctx.funcMap`. Idempotent. Must run after `ensureNativeStringHelpers` (called
+ * here) so `__str_flatten` exists, and before any function body that calls it.
+ *
+ * Algorithm: flatten the input to a `$NativeString`, walk its `[off, off+len)`
+ * code units twice — first to size the output buffer, then to fill it — so the
+ * output `$__str_data` is allocated exactly once at the right capacity.
+ */
+export function emitJsonQuoteString(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__json_quote_string");
+  if (existing !== undefined) return existing;
+
+  ensureNativeStringHelpers(ctx);
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+  const strTypeIdx = ctx.nativeStrTypeIdx; // $NativeString (FlatString): len, off, data
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx; // (array (mut i16))
+  const i32: ValType = { kind: "i32" };
+  const extern: ValType = { kind: "externref" };
+
+  const strRef = nativeStringType(ctx);
+  const typeIdx = addFuncType(ctx, [extern], [strRef]);
+  const funcIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__json_quote_string", funcIdx);
+
+  // params: 0 s:externref; locals L_FLAT..L_NB (see the module index layout).
+  const { getC, putConst, widthExpr, fillCharDispatch } = qQuoteBuilders(strDataTypeIdx);
+
+  // Shared preamble: flatten s, load data/off, compute end = off + len.
+  const preamble: Instr[] = [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+    { op: "call", funcIdx: flattenIdx },
+    { op: "ref.cast", typeIdx: strTypeIdx },
+    { op: "local.set", index: L_FLAT },
+    { op: "local.get", index: L_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // data
+    { op: "local.set", index: L_DATA },
+    { op: "local.get", index: L_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // off
+    { op: "local.set", index: L_OFF },
+    { op: "local.get", index: L_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }, // len
+    { op: "local.get", index: L_OFF },
+    { op: "i32.add" },
+    { op: "local.set", index: L_END }, // end = off + len (exclusive)
+  ];
+
+  // Pass 1: outLen = 2 + Σ width(c)
+  const sizingLoop: Instr[] = [
+    { op: "i32.const", value: 2 },
+    { op: "local.set", index: L_OUTLEN },
+    { op: "local.get", index: L_OFF },
+    { op: "local.set", index: L_I },
+    ...counterLoopInstrs({
+      i: L_I,
+      bound: [{ op: "local.get", index: L_END }],
+      body: [
+        ...getC,
+        { op: "local.get", index: L_OUTLEN },
+        ...widthExpr,
+        { op: "i32.add" },
+        { op: "local.set", index: L_OUTLEN },
+      ],
+    }),
+  ];
+
+  // Allocate out buffer (outLen), w=0, write opening quote.
+  const allocOut: Instr[] = [
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: L_OUTLEN },
+    { op: "array.new", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: L_OUT },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: L_W },
+    ...putConst(C_QUOTE),
   ];
 
   // Pass 2: fill

--- a/tests/issue-3569.test.ts
+++ b/tests/issue-3569.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// Issue #3569 — Standalone JSON.stringify: well-formed surrogate escaping
+// (ES2019 §25.5.4.3 QuoteJSONString, feature well-formed-json-stringify).
+//
+// The host-free native codec (`__json_quote_string`, src/codegen/json-runtime.ts)
+// previously copied every code unit ≥ 0x20 verbatim, so a LONE UTF-16 surrogate
+// leaked through unescaped. The spec requires a lone surrogate to be emitted as
+// `\uXXXX` while the two units of a valid high+low pair are copied verbatim.
+//
+// Verdicts are checked via `charCodeAt` on the returned native string to avoid
+// backslash-escaping ambiguity in the expected literal.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const src = "export function test(): number {\n" + body + "\n}";
+  const result = await compile(src, { target: "standalone" });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Guard: no JSON host import — the fix stays on the pure-Wasm codec.
+  const labels = result.imports.map((i) => `${i.module}::${i.name}`);
+  expect(labels.filter((l) => /env::JSON_(parse|stringify)/.test(l))).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#3569 standalone JSON.stringify well-formed surrogate escaping", () => {
+  it("escapes a lone HIGH surrogate as \\uXXXX", async () => {
+    // "\uD834" (unpaired high) -> "\ud834"  → codes " \ u d 8 3 4 "
+    const r = await runStandalone(`
+      const s: string = "\\uD834";
+      const r: string = JSON.stringify(s);
+      return (r.length === 8
+        && r.charCodeAt(0) === 34 && r.charCodeAt(1) === 92
+        && r.charCodeAt(2) === 117 && r.charCodeAt(3) === 100
+        && r.charCodeAt(4) === 56 && r.charCodeAt(5) === 51
+        && r.charCodeAt(6) === 52 && r.charCodeAt(7) === 34) ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("escapes a lone LOW surrogate as \\uXXXX", async () => {
+    // "\uDF06" (unpaired low) -> "\udf06"  → codes " \ u d f 0 6 "
+    const r = await runStandalone(`
+      const s: string = "\\uDF06";
+      const r: string = JSON.stringify(s);
+      return (r.length === 8
+        && r.charCodeAt(0) === 34 && r.charCodeAt(1) === 92
+        && r.charCodeAt(2) === 117 && r.charCodeAt(3) === 100
+        && r.charCodeAt(4) === 102 && r.charCodeAt(5) === 48
+        && r.charCodeAt(6) === 54 && r.charCodeAt(7) === 34) ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("copies a valid high+low surrogate pair through verbatim", async () => {
+    // "𝌆" (U+1D306) -> the two units unchanged inside quotes
+    const r = await runStandalone(`
+      const s: string = "\\uD834\\uDF06";
+      const r: string = JSON.stringify(s);
+      return (r.length === 4
+        && r.charCodeAt(0) === 34
+        && r.charCodeAt(1) === 0xD834 && r.charCodeAt(2) === 0xDF06
+        && r.charCodeAt(3) === 34) ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("handles mixed lone + paired surrogates (\\ud834 𝌆 \\ud834)", async () => {
+    // "\uD834𝌆\uD834" -> "\ud834" + <pair verbatim> + "\ud834"
+    // length = 1 + 6 + 2 + 6 + 1 = 16
+    const r = await runStandalone(`
+      const s: string = "\\uD834\\uD834\\uDF06\\uD834";
+      const r: string = JSON.stringify(s);
+      return (r.length === 16
+        && r.charCodeAt(0) === 34
+        && r.charCodeAt(1) === 92 && r.charCodeAt(2) === 117
+        && r.charCodeAt(7) === 0xD834 && r.charCodeAt(8) === 0xDF06
+        && r.charCodeAt(9) === 92 && r.charCodeAt(10) === 117
+        && r.charCodeAt(15) === 34) ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("still escapes control chars and quotes alongside a valid pair", async () => {
+    // regression guard: "\n𝌆\"" -> \n escaped, pair verbatim, quote escaped
+    const r = await runStandalone(`
+      const s: string = "\\n\\uD834\\uDF06\\"";
+      const r: string = JSON.stringify(s);
+      // " \ n <D834> <DF06> \ " "
+      return (r.length === 8
+        && r.charCodeAt(0) === 34
+        && r.charCodeAt(1) === 92 && r.charCodeAt(2) === 110
+        && r.charCodeAt(3) === 0xD834 && r.charCodeAt(4) === 0xDF06
+        && r.charCodeAt(5) === 92 && r.charCodeAt(6) === 34
+        && r.charCodeAt(7) === 34) ? 1 : 0;
+    `);
+    expect(r).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Measured on the standalone lane, `built-ins/JSON/stringify/value-string-escape-unicode.js` failed: the host-free native codec (`__json_quote_string`, `src/codegen/json-runtime.ts`) copied every UTF-16 code unit ≥ 0x20 verbatim, so a **lone** surrogate leaked through unescaped.

ES2019 §25.5.4.3 `QuoteJSONString` (feature `well-formed-json-stringify`) requires a lone (unpaired) surrogate U+D800–U+DFFF to be escaped as `\uXXXX`, while the two units of a valid high+low pair are copied verbatim. Host (WasmGC/JS) mode delegates to the JS host `JSON.stringify` (V8 already correct), so this affected only `--target standalone` / `--target wasi`.

## Fix

In `emitJsonQuoteString`:
- Added an `escapeSurr` predicate classifying `data[i]` as a lone surrogate (escape) vs. part of a valid pair (verbatim) via immediate-neighbour lookahead/lookbehind, bounded by `[off, end)`. Both the sizing and fill passes call it, so widths and emitted bytes stay in lock-step.
- Generalised the `\uXXXX` emitter to all four hex nibbles with the full `0-9`/`a-f` mapping (control-char output stays byte-identical — top two nibbles are 0).

No new host imports; the native codec is standalone/wasi-only, so the host lane is untouched.

## Test Results

Harness: `node scripts/run-test262-fyi.mjs --target standalone` (authoritative `test262-worker.mjs`).

- `built-ins/JSON` standalone: **129/165 → 130/165** (+1).
- Per-file before/after diff: **1 flip FAIL→PASS** (`value-string-escape-unicode.js`), **0 regressions**.
- Host lane `built-ins/JSON`: 117/165 (unchanged).
- `tests/issue-3569.test.ts`: 5/5 pass (lone high, lone low, valid pair verbatim, mixed, control-char + pair guard).
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)