### PR TITLE
fix(#3572): native WeakMap/WeakSet iterable constructor (standalone)

### DIFF
--- a/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
+++ b/plan/issues/3571-standalone-fnproto-call-bind-builtin-methods-uncurrythis.md
@@ -1,0 +1,108 @@
+---
+id: 3571
+title: "standalone: Function.prototype.call/apply/bind on builtin methods (uncurryThis/propertyHelper blocker)"
+status: ready
+created: 2026-07-24
+updated: 2026-07-24
+priority: high
+feasibility: hard
+model: fable
+task_type: conformance
+area: codegen
+language_feature: function-dispatch
+goal: standalone
+sprint: current
+horizon: l
+parent: 2860
+related: [2773, 2984, 2744, 2175]
+---
+
+# standalone: `Function.prototype.call`/`apply`/`bind` on builtin methods (uncurryThis / propertyHelper blocker)
+
+## Problem
+
+Under `--target standalone`, invoking a builtin prototype method that has been
+**reified as a value and re-dispatched via `Function.prototype.call` / `.apply`
+/ `.bind`** fails. The dominant real-world trigger is the test262 harness
+`propertyHelper.js`, which builds the "uncurryThis" idiom at include-time:
+
+```js
+var __hasOwnProperty     = Function.prototype.call.bind(Object.prototype.hasOwnProperty);
+var __propertyIsEnumerable = Function.prototype.call.bind(Object.prototype.propertyIsEnumerable);
+```
+
+Calling `__hasOwnProperty(obj, name)` — i.e. `Object.prototype.hasOwnProperty.call(obj, name)`
+via the doubly-bound `Function.prototype.call` — throws
+`TypeError: Cannot convert undefined or null to object` (the bound builtin
+method loses its explicit receiver). A second sub-mode returns a falsy value
+instead of throwing, surfacing as `Test262Error: obj should have an own
+property <X>`.
+
+This is **shared function-dispatch / method-as-value substrate**, NOT specific
+to any one builtin. It surfaces most visibly in every `verifyProperty`
+descriptor test (`propertyHelper.js` is included by ~all of them), so it caps
+the standalone pass rate across **every** builtin lane at once.
+
+## Measured evidence (2026-07-24, current main fa2b189, `--target standalone`)
+
+Measured over the Map/Set/WeakMap/WeakSet/Symbol lane (933 test262 files via
+the real runner). **109 of 217 failures** in this lane trace to this single
+path (error: `Cannot convert undefined or null to object` /
+`Cannot access property on null or undefined`):
+
+| family  | tests in cluster |
+| ------- | ---------------- |
+| Symbol  | 39               |
+| Map     | 23               |
+| Set     | 23               |
+| WeakMap | 8                |
+| WeakSet | 6                |
+| MapIter | 5                |
+| SetIter | 5                |
+| **sum** | **109**          |
+
+Spot-checked one `convert-null` file per family (incl. `Symbol/species/basic.js`,
+`Set/prototype/add/add.js`, `Symbol/match/prop-desc.js`): all route through
+`propertyHelper.js` → `verifyProperty` → the uncurryThis path. No buried
+lane-specific slice — this is genuinely one shared cause. The same lane's
+descriptor tests that DON'T hit this path already pass (native Map/Set wiring
+landed in #1103).
+
+## Root-cause isolation (primary evidence)
+
+Direct repro under `target: "standalone"` (compiler bundle; note the ad-hoc
+harness is imperfect for pass/fail but faithful for the throw):
+
+- `const u = Function.prototype.call.bind(Object.prototype.hasOwnProperty)` —
+  **creating** the bound fn succeeds (`typeof u === "function"`).
+- `u({a:1}, "a")` — **throws** (`Cannot convert undefined or null to object`),
+  even on a plain object — so it is not proto-object-model-specific.
+- `u = Function.prototype.call.bind(userFn); u(recv, arg)` — also throws.
+- By contrast `userFn.bind(recv)(arg)` **works** — plain `.bind` is fine; the
+  break is `.call`/`.apply` (and `call.bind`) threading an explicit receiver
+  into a reified/bound method.
+
+The mechanism (why the receiver is dropped) is **hedged** — it needs a
+Fable-tier look at the funcref-wrapper / method-as-value dispatch. This is the
+same family dev-std-6 flagged as "Array.prototype.map not callable as a value"
+and is Fable-gated (cf. #2773 value-rep, #2984, #2744).
+
+## Acceptance criteria
+
+- `Function.prototype.call(thisArg, ...args)` / `.apply(thisArg, argsArray)` on
+  a reified builtin prototype method dispatches with the explicit receiver.
+- `Function.prototype.call.bind(builtinMethod)` (uncurryThis) produces a
+  function that, when invoked, threads its first arg as the method receiver.
+- `propertyHelper.js`'s `__hasOwnProperty` / `__propertyIsEnumerable` work
+  under standalone → the ~109-test descriptor cluster (this lane) plus the
+  cross-lane equivalents flip toward host parity.
+
+## Notes
+
+- SUBSTRATE / fable-tier — do NOT harvest as a dev slice.
+- High leverage: this is a cross-cutting standalone lever alongside #2773 /
+  #2984 / #2744, registered by the coordinator for the Fable session.
+- Discovered while measuring the Map/Set/WeakMap/WeakSet/Symbol standalone lane
+  (2026-07-24). Contained slices in that lane (WeakMap/WeakSet iterable ctor,
+  Symbol.matchAll whitelist, Set host-leak wiring) are being harvested
+  separately.

--- a/plan/issues/3572-standalone-weakmap-weakset-iterable-constructor.md
+++ b/plan/issues/3572-standalone-weakmap-weakset-iterable-constructor.md
@@ -1,0 +1,97 @@
+---
+id: 3572
+title: "standalone: native WeakMap/WeakSet iterable constructor (host-leak wiring gap)"
+status: done
+completed: 2026-07-24
+created: 2026-07-24
+updated: 2026-07-24
+priority: high
+feasibility: medium
+task_type: conformance
+area: codegen
+language_feature: collections
+goal: standalone
+sprint: current
+horizon: s
+assignee: ttraenkler/dev-mapset-opus
+parent: 2162
+related: [1103, 2162]
+---
+
+# standalone: native WeakMap/WeakSet iterable constructor (host-leak wiring gap)
+
+## Problem
+
+`new WeakMap()` / `new WeakSet()` route to the native weak-collection runtime
+under `--target standalone` (#2162), but **only the no-arg form**. The iterable
+constructor forms — `new WeakSet([o1, o2])`, `new WeakMap([[k, v], …])`,
+`new WeakSet(null)`, `new WeakSet(undefined)`, `new WeakSet([])` — fell through
+to the generic externClass constructor, which emits a `WeakSet_new` /
+`WeakMap_new` host import a pure-Wasm engine can't satisfy → `compile_error`
+under standalone.
+
+The code even flagged it: `new-super.ts` said *"No-arg form only; the iterable
+form falls through."*
+
+## Measured evidence (2026-07-24, `--target standalone`, real test262 runner)
+
+Baseline (current main, before fix), WeakMap/WeakSet families:
+
+| family  | pass | fail | CE |
+| ------- | ---- | ---- | -- |
+| WeakMap | 95   | 23   | 23 |
+| WeakSet | 58   | 14   | 13 |
+
+Of the 36 host-leak CE: 23 array-literal ctor + 2 null/undefined ctor + 11 that
+need the general iterator protocol (deliberate `iterator-*-failure` side-effect
+tests — out of scope for a seeding fast path).
+
+## Fix
+
+Generalise the WeakMap/WeakSet native-ctor branch in
+`src/codegen/expressions/new-super.ts` to mirror the existing
+`new Set([…])` / `new Map([[k,v],…])` native seeding:
+
+- no-arg / `null` / `undefined` → empty branded collection (all spec-empty);
+- array LITERAL → seed (WeakSet elements via `__weakset_add`; WeakMap
+  `[key,value]` pairs via `__map_set`);
+- (WeakSet only) a non-literal array-typed arg → runtime vec walk
+  (`seedNativeSetFromArrayArg`).
+
+Other forms (general iterator with observable protocol steps) still fall
+through — but no longer leak, and are the documented follow-up slice.
+
+Gated on `ctx.nativeStrings` — host (gc) mode is untouched.
+
+## Measured flip (same runner, after fix — 0 regressions)
+
+| family  | Δpass | Δfail | ΔCE  |
+| ------- | ----- | ----- | ---- |
+| WeakMap | +11   | +4    | −15  |
+| WeakSet | +7    | +2    | −9   |
+| **sum** | **+18** | +6  | −24  |
+
+**+18 host-free passes, 0 pass→non-pass regressions** (verified per-file). All
+18 flips are `reached_test=true`, `vacuous=false` (de-inflated, real). The +6
+`fail` and the residual CE are CE→fail moves on the iterator-protocol
+side-effect tests (neutral for `host_free_pass`). Honest caveat: ~4 of the 18
+(`add-not-callable-throws`, `get-add-method-failure`, `set-not-callable-throws`,
+`get-set-method-failure`) pass partly because a *separate* standalone quirk
+(assigning to a native builtin prototype throws) coincidentally satisfies the
+expected `TypeError`; the other ~14 are clean seeding flips. Net is strictly
+positive either way.
+
+## Acceptance criteria
+
+- [x] `new WeakSet([…])` / `new WeakMap([[k,v],…])` / `new WeakSet(null|undefined)`
+  compile host-import-free under standalone (no `WeakSet_new`/`WeakMap_new`).
+- [x] Seeded entries are readable via `has`/`get`/`delete`.
+- [x] No-arg form unaffected; host (gc) mode unaffected.
+- [x] Net non-negative standalone flip, measured on the real runner.
+
+## Notes
+
+Parent (done): #2162. Discovered while measuring the standalone
+Map/Set/WeakMap/WeakSet/Symbol lane (2026-07-24). The dominant remaining lane
+blocker — `Function.prototype.call/apply/bind` on builtin methods (uncurryThis /
+propertyHelper) — is filed separately as substrate #3571.

--- a/plan/issues/3572-standalone-weakmap-weakset-iterable-constructor.md
+++ b/plan/issues/3572-standalone-weakmap-weakset-iterable-constructor.md
@@ -16,6 +16,8 @@ horizon: s
 assignee: ttraenkler/dev-mapset-opus
 parent: 2162
 related: [1103, 2162]
+loc-budget-allow:
+  - src/codegen/expressions/new-super.ts
 ---
 
 # standalone: native WeakMap/WeakSet iterable constructor (host-leak wiring gap)

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2721,6 +2721,113 @@ function seedNativeSetFromArrayArg(
 }
 
 /**
+ * (#2162 / #3572) `new WeakMap()` / `new WeakSet()` and their iterable
+ * constructor forms in standalone / nativeStrings mode → the native
+ * weak-collection runtime, which reuses the Map backing store (`__map_new`
+ * yields the same `$Map`; the brand tag distinguishes them). Handled forms:
+ *   - no-arg / `null` / `undefined` (all spec-empty);
+ *   - an array LITERAL argument — WeakSet elements via `__weakset_add`, WeakMap
+ *     `[key, value]` pairs via `__map_set` (mirrors the `new Set([…])` /
+ *     `new Map([[k,v],…])` native seeding);
+ *   - (WeakSet only) a non-literal array-typed argument → runtime vec walk.
+ * Other forms (a general iterator with observable protocol steps — the
+ * `iterator-*-failure` tests) return `undefined` so the caller falls through to
+ * the generic ctor path, rather than leak a `WeakMap_new`/`WeakSet_new` host
+ * import. Returns the constructed collection's ValType when handled.
+ */
+function tryCompileNativeWeakCollectionNew(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.NewExpression,
+): ValType | undefined {
+  if (
+    !ctx.nativeStrings ||
+    !ts.isIdentifier(expr.expression) ||
+    (expr.expression.text !== "WeakMap" && expr.expression.text !== "WeakSet")
+  ) {
+    return undefined;
+  }
+  const isWeakMap = expr.expression.text === "WeakMap";
+  const wcArgs = expr.arguments ?? ([] as readonly ts.Expression[]);
+  // A single `null` / `undefined` argument is spec-equivalent to no-arg (empty).
+  const nullishArg =
+    wcArgs.length === 1 &&
+    (wcArgs[0]!.kind === ts.SyntaxKind.NullKeyword || (ts.isIdentifier(wcArgs[0]!) && wcArgs[0]!.text === "undefined"));
+  const wcArrArg = wcArgs.length === 1 && ts.isArrayLiteralExpression(wcArgs[0]!) ? wcArgs[0]! : undefined;
+  // WeakMap array-literal seeding requires every element to be a 2-element
+  // array literal (a `[key, value]` pair), mirroring `new Map([[k,v],…])`.
+  const seedableMapPairs =
+    isWeakMap &&
+    wcArrArg !== undefined &&
+    wcArrArg.elements.every(
+      (e) => ts.isArrayLiteralExpression(e) && e.elements.length === 2 && !e.elements.some(ts.isSpreadElement),
+    );
+  const seedableSetElems =
+    !isWeakMap && wcArrArg !== undefined && !wcArrArg.elements.some((e) => ts.isSpreadElement(e));
+  // WeakSet only: a non-literal array-typed argument → runtime vec walk (mirror Set).
+  const wcNonLiteralArrArg =
+    !isWeakMap && wcArgs.length === 1 && wcArrArg === undefined && !nullishArg && isArrayTypedArg(ctx, wcArgs[0]!)
+      ? wcArgs[0]!
+      : undefined;
+  const wcHandled =
+    wcArgs.length === 0 || nullishArg || seedableMapPairs || seedableSetElems || wcNonLiteralArrArg !== undefined;
+  if (!wcHandled) return undefined;
+
+  addUnionImports(ctx);
+  ensureWeakCollectionHelpers(ctx);
+  const mapNewIdx = ctx.mapHelpers.get("__map_new");
+  const mapSetIdx = ctx.mapHelpers.get("__map_set");
+  const weaksetAddIdx = ctx.mapHelpers.get("__weakset_add");
+  if (mapNewIdx === undefined || ctx.mapTypeIdx < 0) return undefined;
+
+  fctx.body.push({
+    op: "i32.const",
+    value: isWeakMap ? COLLECTION_KIND.WEAKMAP : COLLECTION_KIND.WEAKSET,
+  }); // (#3171) brand tag
+  fctx.body.push({ op: "call", funcIdx: mapNewIdx });
+  if (seedableMapPairs && wcArrArg !== undefined && wcArrArg.elements.length > 0 && mapSetIdx !== undefined) {
+    const mTmp = allocLocal(fctx, `__wmctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
+    fctx.body.push({ op: "local.set", index: mTmp });
+    for (const el of wcArrArg.elements) {
+      // every() above narrowed each element to a 2-element array literal.
+      const pair = el as ts.ArrayLiteralExpression;
+      fctx.body.push({ op: "local.get", index: mTmp });
+      const kt = compileExpression(ctx, fctx, pair.elements[0]!);
+      coerceMapKeyToAnyref(ctx, fctx, kt);
+      const vt = compileExpression(ctx, fctx, pair.elements[1]!);
+      coerceMapKeyToAnyref(ctx, fctx, vt);
+      fctx.body.push({ op: "call", funcIdx: mapSetIdx }); // returns ref $Map
+      fctx.body.push({ op: "drop" });
+    }
+    fctx.body.push({ op: "local.get", index: mTmp });
+  } else if (
+    seedableSetElems &&
+    wcArrArg !== undefined &&
+    wcArrArg.elements.length > 0 &&
+    weaksetAddIdx !== undefined
+  ) {
+    const mTmp = allocLocal(fctx, `__wsctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
+    fctx.body.push({ op: "local.set", index: mTmp });
+    for (const el of wcArrArg.elements) {
+      if (ts.isOmittedExpression(el)) continue; // hole → undefined element
+      fctx.body.push({ op: "local.get", index: mTmp });
+      const et = compileExpression(ctx, fctx, el);
+      coerceMapKeyToAnyref(ctx, fctx, et);
+      fctx.body.push({ op: "call", funcIdx: weaksetAddIdx }); // returns ref $Map
+      fctx.body.push({ op: "drop" });
+    }
+    fctx.body.push({ op: "local.get", index: mTmp });
+  } else if (wcNonLiteralArrArg !== undefined && weaksetAddIdx !== undefined) {
+    const mTmp = allocLocal(fctx, `__wsctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
+    fctx.body.push({ op: "local.set", index: mTmp });
+    // On a non-vec / unsupported-element arg the helper leaves the empty
+    // collection on the stack (graceful: empty WeakSet, never a host leak).
+    seedNativeSetFromArrayArg(ctx, fctx, wcNonLiteralArrArg, mTmp, weaksetAddIdx);
+  }
+  return { kind: "ref", typeIdx: ctx.mapTypeIdx };
+}
+
+/**
  * (#2162) Is `arg`'s static type an array (`T[]` / `Array<T>` / readonly array /
  * a tuple)? Used to recognise the non-literal iterable form of `new Set(arr)` /
  * `new Map(pairs)`. Conservative: only a checker-confirmed array/tuple type
@@ -2943,102 +3050,11 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
   }
 
-  // (#2162 / #3572) `new WeakMap()` / `new WeakSet()` and their iterable
-  // constructor forms in standalone / nativeStrings mode → the native
-  // weak-collection runtime, which reuses the Map backing store (`__map_new`
-  // yields the same `$Map`; the brand tag distinguishes them). Handled forms:
-  //   - no-arg / `null` / `undefined` (all spec-empty);
-  //   - an array LITERAL argument — WeakSet elements via `__weakset_add`,
-  //     WeakMap `[key, value]` pairs via `__map_set` (mirrors the `new Set([…])`
-  //     / `new Map([[k,v],…])` native seeding above);
-  //   - (WeakSet only) a non-literal array-typed argument → runtime vec walk.
-  // Other forms (a general iterator with observable protocol steps — the
-  // `iterator-*-failure` tests) fall through to the follow-up slice rather than
-  // leak a `WeakMap_new` / `WeakSet_new` host import.
-  if (
-    ctx.nativeStrings &&
-    ts.isIdentifier(expr.expression) &&
-    (expr.expression.text === "WeakMap" || expr.expression.text === "WeakSet")
-  ) {
-    const isWeakMap = expr.expression.text === "WeakMap";
-    const wcArgs = expr.arguments ?? ([] as readonly ts.Expression[]);
-    // A single `null` / `undefined` argument is spec-equivalent to no-arg (empty).
-    const nullishArg =
-      wcArgs.length === 1 &&
-      (wcArgs[0]!.kind === ts.SyntaxKind.NullKeyword ||
-        (ts.isIdentifier(wcArgs[0]!) && wcArgs[0]!.text === "undefined"));
-    const wcArrArg = wcArgs.length === 1 && ts.isArrayLiteralExpression(wcArgs[0]!) ? wcArgs[0]! : undefined;
-    // WeakMap array-literal seeding requires every element to be a 2-element
-    // array literal (a `[key, value]` pair), mirroring `new Map([[k,v],…])`.
-    const seedableMapPairs =
-      isWeakMap &&
-      wcArrArg !== undefined &&
-      wcArrArg.elements.every(
-        (e) => ts.isArrayLiteralExpression(e) && e.elements.length === 2 && !e.elements.some(ts.isSpreadElement),
-      );
-    const seedableSetElems =
-      !isWeakMap && wcArrArg !== undefined && !wcArrArg.elements.some((e) => ts.isSpreadElement(e));
-    // WeakSet only: a non-literal array-typed argument → runtime vec walk (mirror Set).
-    const wcNonLiteralArrArg =
-      !isWeakMap && wcArgs.length === 1 && wcArrArg === undefined && !nullishArg && isArrayTypedArg(ctx, wcArgs[0]!)
-        ? wcArgs[0]!
-        : undefined;
-    const wcHandled =
-      wcArgs.length === 0 || nullishArg || seedableMapPairs || seedableSetElems || wcNonLiteralArrArg !== undefined;
-    if (wcHandled) {
-      addUnionImports(ctx);
-      ensureWeakCollectionHelpers(ctx);
-      const mapNewIdx = ctx.mapHelpers.get("__map_new");
-      const mapSetIdx = ctx.mapHelpers.get("__map_set");
-      const weaksetAddIdx = ctx.mapHelpers.get("__weakset_add");
-      if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
-        fctx.body.push({
-          op: "i32.const",
-          value: isWeakMap ? COLLECTION_KIND.WEAKMAP : COLLECTION_KIND.WEAKSET,
-        }); // (#3171) brand tag
-        fctx.body.push({ op: "call", funcIdx: mapNewIdx });
-        if (seedableMapPairs && wcArrArg !== undefined && wcArrArg.elements.length > 0 && mapSetIdx !== undefined) {
-          const mTmp = allocLocal(fctx, `__wmctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
-          fctx.body.push({ op: "local.set", index: mTmp });
-          for (const el of wcArrArg.elements) {
-            // every() above narrowed each element to a 2-element array literal.
-            const pair = el as ts.ArrayLiteralExpression;
-            fctx.body.push({ op: "local.get", index: mTmp });
-            const kt = compileExpression(ctx, fctx, pair.elements[0]!);
-            coerceMapKeyToAnyref(ctx, fctx, kt);
-            const vt = compileExpression(ctx, fctx, pair.elements[1]!);
-            coerceMapKeyToAnyref(ctx, fctx, vt);
-            fctx.body.push({ op: "call", funcIdx: mapSetIdx }); // returns ref $Map
-            fctx.body.push({ op: "drop" });
-          }
-          fctx.body.push({ op: "local.get", index: mTmp });
-        } else if (
-          seedableSetElems &&
-          wcArrArg !== undefined &&
-          wcArrArg.elements.length > 0 &&
-          weaksetAddIdx !== undefined
-        ) {
-          const mTmp = allocLocal(fctx, `__wsctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
-          fctx.body.push({ op: "local.set", index: mTmp });
-          for (const el of wcArrArg.elements) {
-            if (ts.isOmittedExpression(el)) continue; // hole → undefined element
-            fctx.body.push({ op: "local.get", index: mTmp });
-            const et = compileExpression(ctx, fctx, el);
-            coerceMapKeyToAnyref(ctx, fctx, et);
-            fctx.body.push({ op: "call", funcIdx: weaksetAddIdx }); // returns ref $Map
-            fctx.body.push({ op: "drop" });
-          }
-          fctx.body.push({ op: "local.get", index: mTmp });
-        } else if (wcNonLiteralArrArg !== undefined && weaksetAddIdx !== undefined) {
-          const mTmp = allocLocal(fctx, `__wsctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
-          fctx.body.push({ op: "local.set", index: mTmp });
-          // On a non-vec / unsupported-element arg the helper leaves the empty
-          // collection on the stack (graceful: empty WeakSet, never a host leak).
-          seedNativeSetFromArrayArg(ctx, fctx, wcNonLiteralArrArg, mTmp, weaksetAddIdx);
-        }
-        return { kind: "ref", typeIdx: ctx.mapTypeIdx };
-      }
-    }
+  // (#2162 / #3572) `new WeakMap()` / `new WeakSet()` + iterable ctor forms →
+  // native weak-collection runtime (see tryCompileNativeWeakCollectionNew).
+  {
+    const weakCollResult = tryCompileNativeWeakCollectionNew(ctx, fctx, expr);
+    if (weakCollResult !== undefined) return weakCollResult;
   }
 
   // (#3242) `new WeakRef(target)` in standalone / nativeStrings mode → the

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2943,26 +2943,101 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
   }
 
-  // (#2162) `new WeakMap()` / `new WeakSet()` in standalone / nativeStrings mode
-  // → the native weak-collection runtime, which reuses the Map backing store
-  // (`__map_new` yields the same empty `$Map`). No-arg form only; the iterable
-  // form falls through.
+  // (#2162 / #3572) `new WeakMap()` / `new WeakSet()` and their iterable
+  // constructor forms in standalone / nativeStrings mode → the native
+  // weak-collection runtime, which reuses the Map backing store (`__map_new`
+  // yields the same `$Map`; the brand tag distinguishes them). Handled forms:
+  //   - no-arg / `null` / `undefined` (all spec-empty);
+  //   - an array LITERAL argument — WeakSet elements via `__weakset_add`,
+  //     WeakMap `[key, value]` pairs via `__map_set` (mirrors the `new Set([…])`
+  //     / `new Map([[k,v],…])` native seeding above);
+  //   - (WeakSet only) a non-literal array-typed argument → runtime vec walk.
+  // Other forms (a general iterator with observable protocol steps — the
+  // `iterator-*-failure` tests) fall through to the follow-up slice rather than
+  // leak a `WeakMap_new` / `WeakSet_new` host import.
   if (
     ctx.nativeStrings &&
     ts.isIdentifier(expr.expression) &&
-    (expr.expression.text === "WeakMap" || expr.expression.text === "WeakSet") &&
-    (expr.arguments?.length ?? 0) === 0
+    (expr.expression.text === "WeakMap" || expr.expression.text === "WeakSet")
   ) {
-    addUnionImports(ctx);
-    ensureWeakCollectionHelpers(ctx);
-    const mapNewIdx = ctx.mapHelpers.get("__map_new");
-    if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
-      fctx.body.push({
-        op: "i32.const",
-        value: expr.expression.text === "WeakMap" ? COLLECTION_KIND.WEAKMAP : COLLECTION_KIND.WEAKSET,
-      }); // (#3171) brand tag
-      fctx.body.push({ op: "call", funcIdx: mapNewIdx });
-      return { kind: "ref", typeIdx: ctx.mapTypeIdx };
+    const isWeakMap = expr.expression.text === "WeakMap";
+    const wcArgs = expr.arguments ?? ([] as readonly ts.Expression[]);
+    // A single `null` / `undefined` argument is spec-equivalent to no-arg (empty).
+    const nullishArg =
+      wcArgs.length === 1 &&
+      (wcArgs[0]!.kind === ts.SyntaxKind.NullKeyword ||
+        (ts.isIdentifier(wcArgs[0]!) && wcArgs[0]!.text === "undefined"));
+    const wcArrArg = wcArgs.length === 1 && ts.isArrayLiteralExpression(wcArgs[0]!) ? wcArgs[0]! : undefined;
+    // WeakMap array-literal seeding requires every element to be a 2-element
+    // array literal (a `[key, value]` pair), mirroring `new Map([[k,v],…])`.
+    const seedableMapPairs =
+      isWeakMap &&
+      wcArrArg !== undefined &&
+      wcArrArg.elements.every(
+        (e) => ts.isArrayLiteralExpression(e) && e.elements.length === 2 && !e.elements.some(ts.isSpreadElement),
+      );
+    const seedableSetElems =
+      !isWeakMap && wcArrArg !== undefined && !wcArrArg.elements.some((e) => ts.isSpreadElement(e));
+    // WeakSet only: a non-literal array-typed argument → runtime vec walk (mirror Set).
+    const wcNonLiteralArrArg =
+      !isWeakMap && wcArgs.length === 1 && wcArrArg === undefined && !nullishArg && isArrayTypedArg(ctx, wcArgs[0]!)
+        ? wcArgs[0]!
+        : undefined;
+    const wcHandled =
+      wcArgs.length === 0 || nullishArg || seedableMapPairs || seedableSetElems || wcNonLiteralArrArg !== undefined;
+    if (wcHandled) {
+      addUnionImports(ctx);
+      ensureWeakCollectionHelpers(ctx);
+      const mapNewIdx = ctx.mapHelpers.get("__map_new");
+      const mapSetIdx = ctx.mapHelpers.get("__map_set");
+      const weaksetAddIdx = ctx.mapHelpers.get("__weakset_add");
+      if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+        fctx.body.push({
+          op: "i32.const",
+          value: isWeakMap ? COLLECTION_KIND.WEAKMAP : COLLECTION_KIND.WEAKSET,
+        }); // (#3171) brand tag
+        fctx.body.push({ op: "call", funcIdx: mapNewIdx });
+        if (seedableMapPairs && wcArrArg !== undefined && wcArrArg.elements.length > 0 && mapSetIdx !== undefined) {
+          const mTmp = allocLocal(fctx, `__wmctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
+          fctx.body.push({ op: "local.set", index: mTmp });
+          for (const el of wcArrArg.elements) {
+            // every() above narrowed each element to a 2-element array literal.
+            const pair = el as ts.ArrayLiteralExpression;
+            fctx.body.push({ op: "local.get", index: mTmp });
+            const kt = compileExpression(ctx, fctx, pair.elements[0]!);
+            coerceMapKeyToAnyref(ctx, fctx, kt);
+            const vt = compileExpression(ctx, fctx, pair.elements[1]!);
+            coerceMapKeyToAnyref(ctx, fctx, vt);
+            fctx.body.push({ op: "call", funcIdx: mapSetIdx }); // returns ref $Map
+            fctx.body.push({ op: "drop" });
+          }
+          fctx.body.push({ op: "local.get", index: mTmp });
+        } else if (
+          seedableSetElems &&
+          wcArrArg !== undefined &&
+          wcArrArg.elements.length > 0 &&
+          weaksetAddIdx !== undefined
+        ) {
+          const mTmp = allocLocal(fctx, `__wsctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
+          fctx.body.push({ op: "local.set", index: mTmp });
+          for (const el of wcArrArg.elements) {
+            if (ts.isOmittedExpression(el)) continue; // hole → undefined element
+            fctx.body.push({ op: "local.get", index: mTmp });
+            const et = compileExpression(ctx, fctx, el);
+            coerceMapKeyToAnyref(ctx, fctx, et);
+            fctx.body.push({ op: "call", funcIdx: weaksetAddIdx }); // returns ref $Map
+            fctx.body.push({ op: "drop" });
+          }
+          fctx.body.push({ op: "local.get", index: mTmp });
+        } else if (wcNonLiteralArrArg !== undefined && weaksetAddIdx !== undefined) {
+          const mTmp = allocLocal(fctx, `__wsctor_m_${fctx.locals.length}`, { kind: "ref", typeIdx: ctx.mapTypeIdx });
+          fctx.body.push({ op: "local.set", index: mTmp });
+          // On a non-vec / unsupported-element arg the helper leaves the empty
+          // collection on the stack (graceful: empty WeakSet, never a host leak).
+          seedNativeSetFromArrayArg(ctx, fctx, wcNonLiteralArrArg, mTmp, weaksetAddIdx);
+        }
+        return { kind: "ref", typeIdx: ctx.mapTypeIdx };
+      }
     }
   }
 

--- a/tests/issue-3572.test.ts
+++ b/tests/issue-3572.test.ts
@@ -1,0 +1,150 @@
+// #3572 — native WeakMap/WeakSet iterable constructor (standalone / nativeStrings).
+//
+// #2162 wired `new WeakMap()`/`new WeakSet()` onto the native weak-collection
+// runtime, but ONLY the no-arg form. The iterable forms
+// (`new WeakSet([o1,o2])`, `new WeakMap([[k,v],…])`, `new WeakSet(null)`, …)
+// fell through to the generic externClass ctor, which emits a
+// `WeakSet_new`/`WeakMap_new` host import a pure-Wasm engine can't satisfy
+// (compile_error under standalone). This wires the array-literal / null /
+// undefined / non-literal-array forms onto `__weakset_add` / `__map_set`,
+// mirroring `new Set([…])` / `new Map([[k,v],…])`.
+//
+// Each test compiles with `target: "wasi"` (nativeStrings; same regime as
+// standalone for this code path) and asserts (a) valid Wasm, (b) ZERO
+// `WeakMap_*`/`WeakSet_*`/`Map_*` host imports, and (c) the expected value.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+async function runWeak(source: string): Promise<{ value: number; collImports: number; valid: boolean }> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const valid = WebAssembly.validate(result.binary);
+  const module = await WebAssembly.compile(result.binary);
+  const collImports = WebAssembly.Module.imports(module).filter((i) => /^(WeakMap|WeakSet|Map)_/.test(i.name)).length;
+
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  const value = (exports.test as () => number)();
+  return { value, collImports, valid };
+}
+
+describe("#3572 native WeakSet iterable constructor (standalone)", () => {
+  it("new WeakSet([o1, o2]) — seeds, host-import-free", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const o1 = {}; const o2 = {};
+         const w = new WeakSet([o1, o2]);
+         return (w.has(o1) && w.has(o2)) ? 1 : 0;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("new WeakSet([]) — empty, host-import-free", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const w = new WeakSet<object>([]);
+         const o = {};
+         return w.has(o) ? 1 : 0;  // not present → 0
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(0);
+  });
+
+  it("new WeakSet(null) — spec-empty, host-import-free, still usable", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const w = new WeakSet(null);
+         const o = {};
+         w.add(o);
+         return w.has(o) ? 1 : 0;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("new WeakSet(arrVar) — non-literal array arg seeds, host-import-free", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const o1 = {}; const o2 = {};
+         const arr = [o1, o2];
+         const w = new WeakSet(arr);
+         return (w.has(o1) && w.has(o2)) ? 1 : 0;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(1);
+  });
+});
+
+describe("#3572 native WeakMap iterable constructor (standalone)", () => {
+  it("new WeakMap([[k1,10],[k2,20]]) — seeds, host-import-free", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const k1 = {}; const k2 = {};
+         const w = new WeakMap<object, number>([[k1, 10], [k2, 20]]);
+         return (w.get(k1) as number) + (w.get(k2) as number);
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(30);
+  });
+
+  it("new WeakMap(undefined) — spec-empty, host-import-free, still usable", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const w = new WeakMap<object, number>(undefined);
+         const k = {};
+         w.set(k, 7);
+         return w.get(k) as number;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(7);
+  });
+
+  it("new WeakMap([[k, v]]) then overwrite — host-import-free", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const k = {};
+         const w = new WeakMap<object, number>([[k, 5]]);
+         w.set(k, 9);
+         return w.get(k) as number;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(9);
+  });
+});
+
+describe("#3572 no-arg regression guard", () => {
+  it("new WeakSet() / new WeakMap() still native (no regression)", async () => {
+    const { value, collImports, valid } = await runWeak(
+      `export function test(): number {
+         const ws = new WeakSet<object>();
+         const wm = new WeakMap<object, number>();
+         const o = {}; ws.add(o); wm.set(o, 3);
+         return (ws.has(o) ? 1 : 0) + (wm.get(o) as number);
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(4);
+  });
+});


### PR DESCRIPTION
## Problem

`new WeakMap()`/`new WeakSet()` route to the native weak-collection runtime under `--target standalone` (#2162), but **only the no-arg form**. The iterable forms — `new WeakSet([o1,o2])`, `new WeakMap([[k,v],…])`, `new WeakSet(null)`, `new WeakSet(undefined)`, `new WeakSet([])` — fell through to the generic externClass ctor and emit a `WeakSet_new`/`WeakMap_new` host import a pure-Wasm engine can't satisfy → `compile_error`. The code even flagged it: *"No-arg form only; the iterable form falls through."*

## Fix

Generalise the WeakMap/WeakSet native-ctor branch in `src/codegen/expressions/new-super.ts` to mirror the existing `new Set([…])` / `new Map([[k,v],…])` native seeding:
- no-arg / `null` / `undefined` → empty branded collection (all spec-empty);
- array **literal** → seed (WeakSet elements via `__weakset_add`; WeakMap `[key,value]` pairs via `__map_set`);
- (WeakSet only) non-literal array-typed arg → runtime vec walk (`seedNativeSetFromArrayArg`).

Other forms (general iterator with observable protocol steps) still fall through — but no longer leak. Gated on `ctx.nativeStrings`; host (gc) mode is untouched.

## Measured flip (real test262 runner, `--target standalone`, 0 regressions)

| family  | Δpass | Δfail | ΔCE |
| ------- | ----- | ----- | --- |
| WeakMap | +11   | +4    | −15 |
| WeakSet | +7    | +2    | −9  |
| **sum** | **+18** | +6  | −24 |

**+18 host-free passes, 0 pass→non-pass regressions** (verified per-file; all 18 flips `reached_test=true`, `vacuous=false` — de-inflated, real). The +6 `fail` / residual CE are CE→fail moves on the iterator-protocol side-effect tests (`iterator-*-failure`), neutral for `host_free_pass`. Honest caveat: ~4 of the 18 pass partly via a separate standalone quirk (assigning to a native builtin prototype throws, coincidentally satisfying the expected `TypeError`); the other ~14 are clean seeding flips. Net strictly positive.

## Tests

`tests/issue-3572.test.ts` — 8 tests (wasi polyfill executor): array-literal / empty / null / undefined / non-literal-array WeakSet & WeakMap ctors are host-import-free and return correct values, plus a no-arg regression guard. All pass.

Also files **#3571** (tracking, no code) for the dominant remaining lane blocker: `Function.prototype.call/apply/bind` on builtin methods (uncurryThis / propertyHelper) — shared substrate, fable-tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)