### PR TITLE
fix(#3573): Set/Map.forEach non-callable guard + Symbol.matchAll drift (standalone)

### DIFF
--- a/plan/issues/3573-standalone-set-foreach-noncallable-symbol-matchall.md
+++ b/plan/issues/3573-standalone-set-foreach-noncallable-symbol-matchall.md
@@ -1,0 +1,79 @@
+---
+id: 3573
+title: "standalone: Set/Map.forEach non-callable guard + Symbol.matchAll table-drift"
+status: done
+completed: 2026-07-24
+created: 2026-07-24
+updated: 2026-07-24
+priority: medium
+feasibility: easy
+task_type: conformance
+area: codegen
+language_feature: collections
+goal: standalone
+sprint: current
+horizon: s
+assignee: ttraenkler/dev-mapset-opus
+related: [2162, 1907, 3571]
+loc-budget-allow:
+  - src/codegen/map-runtime.ts
+---
+
+# standalone: Set/Map.forEach non-callable guard + Symbol.matchAll table-drift
+
+Two small, independent standalone residuals harvested from the
+Map/Set/WeakMap/WeakSet/Symbol lane measurement (2026-07-24).
+
+## (1) `Set`/`Map`.prototype.forEach with a non-callable literal argument
+
+The native forEach path (`tryCompileNativeCollectionForEach`, map-runtime.ts)
+only handles Wasm-closure callbacks. A statically non-callable **literal**
+argument — `s.forEach(null)` / `undefined` / a number / boolean / string —
+failed the `willBeClosure` check and fell through to the host
+`Set_forEach`/`Map_forEach` import, which a pure-Wasm engine can't satisfy →
+`compile_error` under `--target standalone`.
+
+Spec 24.1.3.5 / 24.2.3.6: *"If IsCallable(callbackfn) is false, throw a
+TypeError."* Fix: when the callback is a clearly non-callable literal, emit a
+native `TypeError` (real instance, so `assert.throws(TypeError, …)` catches it)
+instead of falling through. A dynamic value (variable / call result) still
+routes to the general path — only literals are statically decided, so no false
+positives.
+
+### Measured flip (real runner, `--target standalone`, 0 regressions)
+
+`built-ins/Set/prototype/forEach/` — **+5 pass** (per-file, all
+`reached_test=true`, `vacuous=false`):
+`callback-not-callable-{null,undefined,number,boolean,string}.js`. No Map
+forEach test was leaking (Map already covered those), but the guard applies to
+both. Zero pass→non-pass regressions.
+
+## (2) `Symbol.matchAll` value-read table drift
+
+`builtin-value-read.ts`'s `WELL_KNOWN_SYMBOLS` mirror (used by
+`hasNativeBuiltinConstantHandler`) was missing `matchAll` (id 15 in the
+`literals.ts` source of truth). Its absence made `Symbol.matchAll` value reads
+refuse under standalone (`#1907` refusal) even though the downstream constant
+emitter supports it. Restored `matchAll: 15`.
+
+This is a **correctness / drift fix with 0 immediate pass-flip**: the one CE
+test (`Symbol/matchAll/prop-desc.js`) is blocked by the shared
+`Function.prototype.call/apply/bind` uncurryThis path (#3571), so it moves
+`compile_error → fail` (neutral for `host_free_pass`) rather than to pass. It
+flips green once #3571 lands. Carried because a real table-drift correction is
+worth fixing regardless.
+
+## Acceptance criteria
+
+- [x] `Set/Map.prototype.forEach(<non-callable literal>)` throws a native
+  `TypeError`, host-import-free, under standalone.
+- [x] `forEach(<closure>)` unaffected (regression guard).
+- [x] `Symbol.matchAll` value read compiles host-free under standalone.
+- [x] Measured non-negative flip on the real runner (+5, 0 regressions).
+
+## Notes
+
+Final contained slice of the lane. Everything else measured is substrate:
+set-like `.size` getter/method dispatch (#2580), `Set.prototype.entries`
+reified iterator (#1664), and the dominant `Function.prototype.call/bind`
+uncurryThis blocker (#3571). Lane is measured-exhausted after this.

--- a/src/codegen/builtin-value-read.ts
+++ b/src/codegen/builtin-value-read.ts
@@ -158,6 +158,11 @@ const WELL_KNOWN_SYMBOLS: Record<string, number> = {
   asyncIterator: 12,
   dispose: 13,
   asyncDispose: 14,
+  // (#3573) `matchAll` drifted out of this mirror of the literals.ts table
+  // (id 15 there) — its absence made `hasNativeBuiltinConstantHandler` refuse
+  // `Symbol.matchAll` value reads under --target standalone even though the
+  // downstream constant emitter supports it. Keep in sync with literals.ts.
+  matchAll: 15,
 };
 
 function getWellKnownSymbolId(name: string): number | undefined {

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -34,6 +34,7 @@ import type { InnerResult } from "./shared.js";
 import { compileArrowAsClosure, compileExpression, VOID_RESULT } from "./shared.js";
 import { isNullOrUndefinedLiteral } from "./destructuring-params.js";
 import { emitReceiverBrandCheck, type ReceiverBrandSpec } from "./receiver-brand.js";
+import { emitThrowTypeError } from "./js-errors.js";
 import { coercionInstrs } from "./type-coercion.js";
 import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
@@ -1707,7 +1708,33 @@ export function tryCompileNativeCollectionForEach(
     ts.isArrowFunction(cbArg) ||
     ts.isFunctionExpression(cbArg) ||
     (ts.isIdentifier(cbArg) && (ctx.funcMap.has(cbArg.text) || ctx.closureMap.has(cbArg.text)));
-  if (!willBeClosure) return undefined;
+  if (!willBeClosure) {
+    // (#3573) Spec 24.1.3.5 / 24.2.3.6: "If IsCallable(callbackfn) is false,
+    // throw a TypeError". A statically non-callable LITERAL argument (`null` /
+    // `undefined` / number / boolean / string) can never be a closure, so emit
+    // the TypeError natively rather than fall through to the host
+    // `Map_forEach`/`Set_forEach` import (a standalone host-leak → compile
+    // error). A dynamic value (variable / call result) still routes to the
+    // general path.
+    const staticNonCallable =
+      cbArg.kind === ts.SyntaxKind.NullKeyword ||
+      cbArg.kind === ts.SyntaxKind.TrueKeyword ||
+      cbArg.kind === ts.SyntaxKind.FalseKeyword ||
+      ts.isNumericLiteral(cbArg) ||
+      ts.isStringLiteral(cbArg) ||
+      ts.isNoSubstitutionTemplateLiteral(cbArg) ||
+      (ts.isIdentifier(cbArg) && cbArg.text === "undefined" && !fctx.localMap.has("undefined"));
+    if (!staticNonCallable) return undefined;
+    // Evaluate the receiver for its side effects first (this native path only
+    // fires for a statically Set/Map receiver, so its [[SetData]]/[[MapData]]
+    // brand check is already satisfied), then throw. The throw is terminal /
+    // stack-polymorphic, so nothing is left on the value stack (VOID_RESULT).
+    const recvExpr = reflective !== undefined ? reflective.recvExpr : propAccess.expression;
+    compileExpression(ctx, fctx, recvExpr);
+    fctx.body.push({ op: "drop" });
+    emitThrowTypeError(ctx, fctx, `${isSet ? "Set" : "Map"}.prototype.forEach callback is not a function`);
+    return VOID_RESULT;
+  }
 
   // Map struct field layout (matches ensureMapHelpers' local constants).
   const M_ENTRIES = 1;

--- a/tests/issue-3573.test.ts
+++ b/tests/issue-3573.test.ts
@@ -1,0 +1,96 @@
+// #3573 — Set/Map.prototype.forEach with a non-callable literal argument, and
+// Symbol.matchAll value-read (standalone / nativeStrings).
+//
+// (1) forEach: the native forEach path (tryCompileNativeCollectionForEach) only
+// handles Wasm-closure callbacks. A statically non-callable LITERAL argument
+// (`null` / `undefined` / number / boolean / string) fell through to the host
+// `Set_forEach`/`Map_forEach` import → compile_error under standalone. Spec
+// 24.1.3.5 / 24.2.3.6 require a `TypeError` when callbackfn is not callable;
+// we now emit that natively.
+//
+// (2) Symbol.matchAll: the builtin-value-read `WELL_KNOWN_SYMBOLS` mirror was
+// missing `matchAll` (drifted from literals.ts), so `Symbol.matchAll` value
+// reads refused under standalone. Restored.
+//
+// `skipSemanticDiagnostics: true` mirrors the test262 runner (JS tests pass
+// `s.forEach(null)`, which strict TS would reject before codegen).
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+async function run(source: string): Promise<{ value: number; collImports: number; valid: boolean }> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi", skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const valid = WebAssembly.validate(result.binary);
+  const module = await WebAssembly.compile(result.binary);
+  const collImports = WebAssembly.Module.imports(module).filter((i) => /^(Set|Map)_/.test(i.name)).length;
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  const value = (exports.test as () => number)();
+  return { value, collImports, valid };
+}
+
+describe("#3573 Set/Map.forEach non-callable literal → native TypeError (standalone)", () => {
+  for (const [label, arg] of [
+    ["null", "null"],
+    ["undefined", "undefined"],
+    ["number", "3"],
+    ["boolean", "true"],
+    ["string", '"nope"'],
+  ] as const) {
+    it(`Set.forEach(${label}) throws, host-import-free`, async () => {
+      const { value, collImports, valid } = await run(
+        `export function test(): number {
+           const s = new Set([1]);
+           try { s.forEach(${arg}); return 0; } catch (e) { return 1; }
+         }`,
+      );
+      expect(valid).toBe(true);
+      expect(collImports).toBe(0);
+      expect(value).toBe(1); // threw
+    });
+  }
+
+  it("Map.forEach(null) throws, host-import-free", async () => {
+    const { value, collImports, valid } = await run(
+      `export function test(): number {
+         const m = new Map([[1, 2]]);
+         try { m.forEach(null); return 0; } catch (e) { return 1; }
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("Set.forEach(closure) still drives the callback (regression guard)", async () => {
+    const { value, collImports, valid } = await run(
+      `export function test(): number {
+         const s = new Set([1, 2, 3]);
+         let sum = 0;
+         s.forEach((v) => { sum += v; });
+         return sum;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(6);
+  });
+});
+
+describe("#3573 Symbol.matchAll value read (standalone)", () => {
+  it("Symbol.matchAll reads host-import-free as a symbol", async () => {
+    const { value, valid } = await run(
+      `export function test(): number {
+         return typeof Symbol.matchAll === "symbol" ? 1 : 0;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(value).toBe(1);
+  });
+});


### PR DESCRIPTION
Two small independent standalone residuals harvested from the Map/Set/WeakMap/WeakSet/Symbol lane measurement (the final contained slices of the lane).

## (1) `Set`/`Map`.prototype.forEach with a non-callable literal

The native forEach path (`tryCompileNativeCollectionForEach`) only handled Wasm-closure callbacks. A statically non-callable **literal** argument — `s.forEach(null)` / `undefined` / a number / boolean / string — failed the `willBeClosure` check and fell through to the host `Set_forEach`/`Map_forEach` import → `compile_error` under `--target standalone`.

Spec 24.1.3.5 / 24.2.3.6: *"If IsCallable(callbackfn) is false, throw a TypeError."* Fix: emit a native `TypeError` (real instance, so `assert.throws(TypeError, …)` catches it) for clearly non-callable literals. Dynamic values still route to the general path — only literals are statically decided, so **no false positives**.

**Measured** (real runner, `--target standalone`): `built-ins/Set/prototype/forEach` **+5 pass, 0 regressions** (per-file; all flips `reached_test=true`, `vacuous=false`): `callback-not-callable-{null,undefined,number,boolean,string}.js`. The guard applies to Map too (no Map forEach test was leaking).

## (2) `Symbol.matchAll` value-read table drift

`builtin-value-read.ts`'s `WELL_KNOWN_SYMBOLS` mirror was missing `matchAll` (id 15 in the `literals.ts` source of truth), so `Symbol.matchAll` value reads refused under standalone. Restored. **Correctness/drift fix with 0 immediate pass-flip** — the one CE test is blocked by the shared `Function.prototype.call/bind` uncurryThis path (#3571) so it moves `CE → fail` (neutral for `host_free_pass`); it flips green once #3571 lands. Carried because it's a real table-drift correction.

## Tests

`tests/issue-3573.test.ts` — 8 tests (wasi polyfill, `skipSemanticDiagnostics: true` to mirror the JS test262 runner): Set/Map forEach with each non-callable literal throws host-import-free; closure callback still drives; `Symbol.matchAll` reads host-free. All pass.

`loc-budget-allow` granted for the +27 LOC in the god-file `map-runtime.ts` (small guard cohesive with the forEach dispatch; per-function ceiling unaffected).

Final contained slice of the lane; remainder is substrate (#2580 set-like getter dispatch / #1664 reified iterator / #3571 uncurryThis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)