### PR TITLE
fix(#1325): host-free instanceof Promise in standalone (distinct $Promise struct)

### DIFF
--- a/plan/issues/1325-instanceof-builtin-type-tag-registry.md
+++ b/plan/issues/1325-instanceof-builtin-type-tag-registry.md
@@ -163,22 +163,34 @@ Measured flips (fail→pass, all host-free, zero false positives — negatives l
 Host/gc mode is untouched (the branch is `noJsHost`-gated → byte-identical).
 Tests: `tests/issue-1325.test.ts` (new standalone describe block, 11 cases).
 
-### Remaining (per-rep construction-tagging — NOT this slice, follow-on)
+## Progress (2026-07-24, dev-std-3, slice 2) — Promise landed; per-rep map measured
 
-The residual is scattered **per-representation** work, each its own increment
-(measured 2026-07-24, all `any`-typed dynamic LHS, standalone):
+`Promise` added to `nativeBuiltinInstanceOfTypeIdxs` via
+`getOrRegisterPromiseType` (the distinct `$Promise` struct — state/value/
+callbacks; exported, idempotent, type-only). Flips `p instanceof Promise` 0→1
+host-free for a dynamic LHS (`Promise.resolve(1)`, `new Promise(...)`,
+cross-function opaque param); 5 negatives stay false (no false positives:
+`{} instanceof Promise`, `Date instanceof Promise`, `123`, `Promise instanceof
+Date`, `[]`). `noJsHost`-gated → host/gc byte-identical. Tests:
+`tests/issue-1325.test.ts` (+6 Promise cases, 30 total).
 
-- `Promise`, `ArrayBuffer`, `DataView`, and the concrete `TypedArray` views
-  (`Int8Array`…`BigUint64Array`) — each lowers to its own rep; needs the
-  matching struct type idx wired into `nativeBuiltinInstanceOfTypeIdxs` (or a
-  brand where the rep is shared, e.g. TypedArray views share `$Vec` with plain
-  arrays today — #2893/#2872).
-- `x instanceof Object` — NOT a clean universal `ref.test`: native strings are
-  also GC structs, so a naive "any struct → Object" over-matches; needs a
-  struct-minus-string-minus-boxed-primitive discriminator (Slice-A #2916
-  deferral).
-- `func instanceof Function` currently **traps** on a closure LHS (separate
-  from the `undefined`-return edges) — needs a guarded cast.
-- `Map`/`Set` through a truly-opaque param still answer `0` (they pass only via
-  the static-type path today; the native-collection structs share `$Map`, so a
-  runtime `ref.test` is imprecise until a per-collection brand lands).
+**Measured per-rep map for the rest (verify-first, 2026-07-24) — the remaining
+types are NOT contained `ref.test` slices; they are value-rep substrate:**
+
+| type | rep | verdict |
+| --- | --- | --- |
+| `Date` | distinct `$__Date` struct | ✅ landed (#3547) |
+| `RegExp` | distinct `$__StandaloneRegExp` struct | ✅ landed (#3547) |
+| `Promise` | distinct `$Promise` struct | ✅ landed (this slice) |
+| `ArrayBuffer` | **byte `$Vec`** (shared with plain arrays / DataView — `dataview-native.ts:17,3422`) | ❌ substrate — `ref.test $Vec` false-positives on arrays/DataView; needs a brand field |
+| `DataView` | **byte `$Vec`** (same pun) | ❌ substrate — same shared-`$Vec` imprecision |
+| `Int8Array`…`BigUint64Array` | **shared `$__ta_view`** (length/buf/byteOffset, NO kind field) | ❌ substrate — one struct for all TA kinds; `int8 instanceof Uint8Array` can't be distinguished until a kind brand lands (#2893/#2872) |
+| `Map`/`Set`/`WeakMap`/`WeakSet` (opaque LHS) | shared `$Map` backing | ❌ substrate — pass only via static-type path; runtime `ref.test $Map` is cross-collection imprecise |
+| `Object` (universal) | any GC struct incl. native strings | ❌ needs struct-minus-string-minus-boxed discriminator (Slice-A #2916 deferral) |
+| `Function` (closure LHS) | closure struct | ❌ currently **traps** — needs a guarded cast |
+
+**Conclusion:** every distinct-struct builtin (Date/RegExp/Promise) is now
+host-free; the residual is uniformly blocked on a **per-rep brand** for
+struct-sharing families (ArrayBuffer/DataView/TypedArray/Map-Set) — value-rep
+substrate, not a dev-sized `nativeBuiltinInstanceOfTypeIdxs` case. Route the
+brand work with #2893/#2872 (TypedArray) and the collection value-rep track.

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -37,6 +37,7 @@ import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { BUILTIN_TYPE_TAGS, isBuiltinSubtype, isBuiltinTypeName } from "../builtin-tags.js";
 import { ensureDateStruct } from "./builtins.js"; // (#1325) native $__Date struct for host-free `instanceof Date`
 import { ensureStandaloneRegExpStruct } from "../regexp-standalone.js"; // (#1325) native RegExp struct for host-free `instanceof RegExp`
+import { getOrRegisterPromiseType } from "../async-scheduler.js"; // (#1325) native $Promise struct for host-free `instanceof Promise`
 import { getOrRegisterErrorStructType, isWasiErrorName } from "../registry/error-types.js";
 import { allocLocal } from "../context/locals.js";
 import { popBody, pushBody } from "../context/bodies.js";
@@ -1685,6 +1686,13 @@ function nativeBuiltinInstanceOfTypeIdxs(ctx: CodegenContext, ctorName: string):
       // `$__StandaloneRegExp` struct; `ref.test` against it answers
       // `r instanceof RegExp` host-free. Idempotent, type-only registration.
       return keep(ensureStandaloneRegExpStruct(ctx));
+    case "Promise":
+      // (#1325) A Promise lowers to the distinct `$Promise` struct
+      // (state/value/callbacks). `ref.test` against it answers
+      // `p instanceof Promise` host-free. `getOrRegisterPromiseType` is
+      // idempotent and type-only (registers the struct type + scheduler state
+      // bookkeeping; no funcidx shift), so calling it here is compile-order-safe.
+      return keep(getOrRegisterPromiseType(ctx));
     default:
       return undefined;
   }

--- a/tests/issue-1325.test.ts
+++ b/tests/issue-1325.test.ts
@@ -335,4 +335,53 @@ describe("#1325 instanceof Date/RegExp — standalone native (host-free)", () =>
       ),
     ).toBe(0);
   });
+
+  // ── Promise (distinct $Promise struct — same mechanism as Date/RegExp) ──
+  it("`any`-typed Promise.resolve instanceof Promise → true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = Promise.resolve(1); return (p instanceof Promise) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("`any`-typed new Promise instanceof Promise → true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = new Promise((res: any) => { res(1); }); return (p instanceof Promise) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("opaque function-param Promise instanceof Promise → true", async () => {
+    expect(
+      await runStandalone(
+        `function f(p: any): number { return (p instanceof Promise) ? 1 : 0; } export function test(): number { return f(Promise.resolve(1)); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("{} instanceof Promise → false", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = {}; return (o instanceof Promise) ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("Date instance instanceof Promise → false (distinct structs)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const d: any = new Date(); return (d instanceof Promise) ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("Promise instance instanceof Date → false", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = Promise.resolve(1); return (p instanceof Date) ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Slice 2 of the #1325 per-representation follow-on (after Date/RegExp in #3547). Adds `Promise` to `nativeBuiltinInstanceOfTypeIdxs` (`expressions/identifiers.ts`) via `getOrRegisterPromiseType` — the distinct `$Promise` struct (state/value/callbacks), exported/idempotent/type-only. A **dynamic** (`any`-typed / opaque function-param) LHS now answers `p instanceof Promise` host-free via a native `ref.test` — **no `__instanceof` host import**. Same proven mechanism as the Date/RegExp slice.

## Measured (standalone, verify-first, host-free, zero false positives)

| case | before | after |
| --- | --- | --- |
| `const p: any = Promise.resolve(1); p instanceof Promise` | 0 | 1 |
| `const p: any = new Promise(...); p instanceof Promise` | 0 | 1 |
| `function f(p:any){return p instanceof Promise} f(Promise.resolve(1))` | 0 | 1 |

Negatives stay `false`: `{} instanceof Promise`, `Date instanceof Promise`, `123 instanceof Promise`, `Promise instanceof Date`, `[] instanceof Promise`. Host/gc mode is `noJsHost`-gated → **byte-identical**.

## Per-rep map recorded (closes the #1325 investigation)

Every **distinct-struct** builtin is now host-free: `Date` + `RegExp` (#3547) + `Promise` (here). The rest are **struct-sharing reps** where a `ref.test` would false-positive — value-rep substrate, not a `nativeBuiltinInstanceOfTypeIdxs` case:

- `ArrayBuffer` / `DataView` — byte-`$Vec` (shared with plain arrays; `dataview-native.ts:17,3422`)
- `Int8Array`…`BigUint64Array` — shared `$__ta_view`, no kind field → cross-kind imprecise (#2893/#2872)
- opaque `Map`/`Set` — shared `$Map` backing
- `Object` universal — any GC struct incl. native strings → needs a discriminator
- `Function` (closure LHS) — currently traps; needs a guarded cast

These need a per-rep brand; routed to #2893/#2872 + the collection value-rep track (documented in the issue).

## Tests

`tests/issue-1325.test.ts` — +6 Promise cases in the standalone describe block (30 total, all green). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ
