### PR TITLE
fix(#3024): coerce module-global writes to slot type — object-literal runtime-computed-key + for-of array-rest desync

### DIFF
--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -22,6 +22,8 @@ loc-budget-allow:
   - src/codegen/property-access.ts
   - src/codegen/destructuring-params.ts
   - src/codegen/expressions/calls-closures.ts
+  - src/codegen/statements/for-of-destructuring.ts
+  - src/codegen/declarations.ts
 ---
 
 # #3024 — invalid Wasm binary emission residual (default lane)

--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -24,6 +24,8 @@ loc-budget-allow:
   - src/codegen/expressions/calls-closures.ts
   - src/codegen/statements/for-of-destructuring.ts
   - src/codegen/declarations.ts
+func-budget-allow:
+  - src/codegen/declarations.ts::collectDeclarations
 ---
 
 # #3024 — invalid Wasm binary emission residual (default lane)

--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -843,3 +843,38 @@ NOT the "quick per-root-cause singleton" this issue's residual was framed as.
 Confirmed repro for the next owner: `[assert.js, sta.js, nativeFunctionMatcher.js,
 <any toString test>]` OR the raw `nativeFunctionMatcher.js` with NO exported
 function. Suggest routing to `senior-developer`.
+
+---
+
+## Fresh re-measurement (agent-a3fa3add / Opus 4.8, 2026-07-24)
+
+Re-harvested current `origin/main` (post the merged 68-file `toString` cluster,
+#3509/#3547) via `runTest262File` (default gc lane, full harness) over the
+baseline candidate set = 529 `compile_error`-official ∪ 58 `fail`/`reached_test=false`-official
+= 587 candidates. Detected invalid-Wasm by the `wasm_compile` classifier
+signature (`/invalid Wasm binary|Compiling function/i`).
+
+**LIVE COUNT: 97 invalid-Wasm files / 587 candidates** (reconciles: dev-serve's
+202 minus the merged 68-file toString cluster minus later slices).
+
+### Top coarse validator-error buckets (op+types; fn/assert stripped)
+
+| count | signature | cluster |
+| ----: | --------- | ------- |
+| 14 | `global.set` expected `(ref null T)`, found `local.get` externref | computed-property-names + Object.assign/keys/Reflect.ownKeys |
+| 11 | `global.set` expected externref, found `local.tee` `(ref null T)` | for-of / for-await-of array-rest destructuring |
+|  2 | `global.set` expected `(ref null T)`, found `call` f64 | class ident-name-method-def-new-escaped |
+| 10 | not enough arguments on the stack for call | `__call_next`/`__call_return`/`C_method` (iterator + super) |
+|  9 | `struct.get` expected `(ref null T)`, found `local.get` `(ref null T)` | RangeError / DataView buffer-verified |
+|  8 | `f64.add`/`f64.sub` expected f64, found `global.get` i32/i64 | ++/-- on boolean(i32)/bigint(i64) globals |
+|  5 | `call` expected externref, found `local.tee` i32 | Uint8Array toBase64/toHex |
+|  4 | `local.set` expected `(ref null T)`, found `struct.get` f64 | `__closure` toLocaleString |
+|  4 | type error in fallthru (expected `(ref null T)`, got i32) | `__closure_24` |
+
+The first 3 rows (27 files) are ONE family: a **module-level global whose slot
+type disagrees with the value stored into it** (a global-write coercion desync,
+distinct from #3343's control-flow aliasing). Remaining rows are ≤3-file
+per-root-cause singletons. By failing fn: 58 `__module_init`, 10 `__closure`,
+9 `__cb`, 6 `fn`, 5 `__call_next`, 3 `__call_return`, 3 `Parent_new`.
+
+**In progress:** root-causing the 27-file module-global slot-desync family.

--- a/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
+++ b/plan/issues/3024-invalid-wasm-default-lane-emitter-residual.md
@@ -4,7 +4,7 @@ title: "codegen: invalid Wasm binary emission residual — default (JS-host) lan
 status: ready
 sprint: current
 created: 2026-07-03
-updated: 2026-07-13
+updated: 2026-07-24
 priority: high
 horizon: m
 feasibility: medium
@@ -877,4 +877,76 @@ distinct from #3343's control-flow aliasing). Remaining rows are ≤3-file
 per-root-cause singletons. By failing fn: 58 `__module_init`, 10 `__closure`,
 9 `__cb`, 6 `fn`, 5 `__call_next`, 3 `__call_return`, 3 `Parent_new`.
 
-**In progress:** root-causing the 27-file module-global slot-desync family.
+### Landed: module-global slot-type-vs-stored-value desync (agent-a3fa3add / Opus 4.8, 2026-07-24)
+
+**PR:** `issue-3024-invalid-wasm-remeasure` — clears **25 of the 27-file
+module-global slot-desync family** (Bucket A object-literal-runtime-computed-key,
+14 + Bucket B for-of array-rest destructuring-assignment, 11). Full 587-candidate
+re-harvest: **97 → 72 still-invalid**, exactly these 25, **zero new invalid
+signatures**.
+
+#### Root cause (one family, two write paths — verified by WAT)
+
+A module-level `var`/`let` becomes a Wasm module global whose declared slot type
+is derived from the STATIC TS type, but the value actually stored can have a
+different Wasm representation, and the write site did not coerce.
+
+- **Bucket A** — `var o = { a, [foo()]: v }` (RUNTIME computed key).
+  `compileObjectLiteral` builds these as a host `$Object` (externref) via
+  `_hasRuntimeComputedKey`, but `moduleInitForcesExternref` (declarations.ts) did
+  NOT mirror that predicate, so the global stayed struct-typed →
+  `global.set expected (ref null N), found externref` (the read's
+  `extern.convert_any` on the struct slot was invalid too — masked by the
+  validator stopping at the first error). Literal computed keys `[1]` still fold
+  to a static struct, unchanged.
+- **Bucket B** — `var x, y; for ([x, ...y] of …) {}`. `emitGlobalSyncWriteback`
+  (for-of-destructuring.ts) did a raw `local.get; global.set`; the rest slice
+  materializes a `(ref null vec)` local while the untyped `var y` global is
+  `externref` → `global.set expected externref, found (ref null N)`.
+
+Distinct from #3343 (control-flow module-global ALIASING); this is a value/slot
+TYPE desync at the write.
+
+#### Fix (three files; mirrors existing precedents)
+
+- `src/codegen/statements/for-of-destructuring.ts` — `emitGlobalSyncWriteback`
+  coerces local→global type before `global.set` (mirrors the binding-form
+  `syncDestructuredLocalsToGlobals`, destructuring.ts). All 10 call sites pass
+  `ctx`.
+- `src/codegen/declarations.ts` — `moduleInitForcesExternref` returns externref
+  for a runtime-computed-key literal (mirrors the function-local
+  `resolveSpillLocalValType`, variables.ts).
+- `src/codegen/literals.ts` — export `_hasRuntimeComputedKey`.
+
+Both guards fire ONLY on shapes that were ALWAYS invalid Wasm before (a
+type-mismatch that can't validate), so **no previously-valid module changes**
+(byte-inert). `narrow-A` confirms literal-computed-key `[1]` cases stay on the
+struct path.
+
+#### Proofs
+
+- **17 real run-pass gains** + 8 CE→fail (valid Wasm now; fail on DISTINCT
+  semantics — proxy-keys, put-const/let, symbol computed keys,
+  frozen/sealed/non-extensible `Object.assign` — improvements, not regressions).
+- Full 587-candidate re-harvest: 97 → 72, exactly these 25, **0 new invalid
+  signatures**.
+- **Standalone lane (criterion #2):** the 25 fixed files also validate on
+  `--target standalone` (21 pass + 4 valid-but-fail); the only invalid remaining
+  are the 2 deferred class files (invalid on BOTH lanes, untouched). Both guards
+  are lane-agnostic and fire only on already-invalid shapes → no new standalone
+  invalid.
+- Adjacent suites green (61 tests): issue-2602-forof-assign-rest, computed-props,
+  issue-2804 (spread host path), issue-3024/-incdec-element/-packed-array-dstr,
+  issue-2934, issue-3241, issue-1128-dstr-tdz.
+- New `tests/issue-3024-module-global-slot-desync.test.ts` (5 tests) passes.
+
+#### Still open (roll forward — NOT this PR)
+
+- The 2 `class ident-name-method-def-new-escaped` files
+  (`global.set expected (ref null T), found call f64`) — a class-expression-to-
+  global desync, distinct root cause.
+- The remaining ~72 default-lane invalid-Wasm files: the per-root-cause
+  singletons in the map above (`not enough arguments on the stack for call`
+  iterator/super, `struct.get (ref null T)` RangeError/DataView, `f64.add/sub`
+  ++/-- on boolean(i32)/bigint(i64) globals, Uint8Array toBase64/toHex,
+  `__closure` toLocaleString, `__closure_24` fallthru).

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -33,6 +33,7 @@ import { addFunctionOwnLocals } from "./binding-info.js"; // (#2103) memoized ow
 import { reportError } from "./context/errors.js";
 import type { CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
 import { compileFunctionBody, registerInlinableFunction } from "./function-body.js";
+import { _hasRuntimeComputedKey } from "./literals.js"; // (#3024) module-global externref routing for runtime-computed-key literals
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 import {
   addArrayIteratorImports,
@@ -1299,6 +1300,17 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       const widened = ctx.widenedTypeProperties.get(name);
       if ((!widened || widened.length === 0) && !ctx.shapeMap.has(name)) return true;
     }
+    // (#3024) A literal with a RUNTIME computed key (`[expr]` that neither folds
+    // to a compile-time string nor names a well-known Symbol — e.g.
+    // `{ a: 'A', [foo()]: 'B' }`) is built as a host `$Object` (externref) by the
+    // literals.ts routing (`_hasRuntimeComputedKey`, compileObjectLiteral). The
+    // receiving module GLOBAL must be externref to match; otherwise the externref
+    // is stored into a struct-typed global (`global.set expected (ref null N),
+    // found externref` — invalid Wasm) and the read side's `extern.convert_any`
+    // is likewise invalid on the struct slot. Mirrors the function-local sites
+    // (statements/variables.ts `resolveSpillLocalValType`), keeping the module
+    // global in lockstep with the same routing predicate.
+    if (_hasRuntimeComputedKey(ctx, decl.initializer)) return true;
     for (const p of decl.initializer.properties) {
       if (ts.isGetAccessorDeclaration(p) || ts.isSetAccessorDeclaration(p)) return true;
       if (ts.isMethodDeclaration(p) && ts.isComputedPropertyName(p.name)) {

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1072,7 +1072,7 @@ function _hasDisposalMethod(expr: ts.ObjectLiteralExpression): boolean {
  * fields from compile-time names only, so these literals must take the host
  * plain-object path, which evaluates the key expression at runtime.
  */
-function _hasRuntimeComputedKey(ctx: CodegenContext, expr: ts.ObjectLiteralExpression): boolean {
+export function _hasRuntimeComputedKey(ctx: CodegenContext, expr: ts.ObjectLiteralExpression): boolean {
   for (const p of expr.properties) {
     if (!ts.isPropertyAssignment(p) && !ts.isMethodDeclaration(p)) continue;
     if (!ts.isComputedPropertyName(p.name)) continue;

--- a/src/codegen/statements/for-of-destructuring.ts
+++ b/src/codegen/statements/for-of-destructuring.ts
@@ -61,10 +61,30 @@ import { collectInstrs } from "./shared.js";
  * `if (syncGlobalIdx !== undefined) { local.get targetLocal; global.set … }`.
  * Extracted from 10 identical inline copies (#3269 DRY). NOT for the
  * boxed-capture variants that struct.get through the cell first (different shape).
+ *
+ * (#3024) A module global's declared slot type can differ from the
+ * destructured local's type — e.g. an array-rest target `for ([...y] of …)`
+ * materializes a `(ref null vec)` local while the untyped module `var y` global
+ * is `externref`. The raw `local.get; global.set` then emits invalid Wasm
+ * (`global.set expected externref, found local.get of type (ref null N)`).
+ * Coerce local→global type before the store, mirroring the binding-form
+ * `syncDestructuredLocalsToGlobals` (destructuring.ts). Byte-inert whenever the
+ * types already match (the previously-valid shapes); the coercion only fires on
+ * shapes that were ALWAYS invalid Wasm before, so no valid module changes.
  */
-function emitGlobalSyncWriteback(fctx: FunctionContext, targetLocal: number, syncGlobalIdx: number | undefined): void {
+function emitGlobalSyncWriteback(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  targetLocal: number,
+  syncGlobalIdx: number | undefined,
+): void {
   if (syncGlobalIdx !== undefined) {
     fctx.body.push({ op: "local.get", index: targetLocal });
+    const localType = getLocalType(fctx, targetLocal);
+    const globalType = ctx.mod.globals[localGlobalIdx(ctx, syncGlobalIdx)]?.type;
+    if (localType && globalType && !valTypesMatch(localType, globalType)) {
+      coerceType(ctx, fctx, localType, globalType);
+    }
     fctx.body.push({ op: "global.set", index: syncGlobalIdx });
   }
 }
@@ -891,7 +911,7 @@ export function compileForOfAssignDestructuring(
         coerceType(ctx, fctx, fieldType, targetType);
       }
       emitCoercedLocalSet(ctx, fctx, targetLocal, effectiveStackType);
-      emitGlobalSyncWriteback(fctx, targetLocal, targetSyncGlobalIdx);
+      emitGlobalSyncWriteback(ctx, fctx, targetLocal, targetSyncGlobalIdx);
     }
   } else if (ts.isArrayLiteralExpression(expr)) {
     // for ([x, y] of arr) — elem is a vec struct or tuple struct, extract by index
@@ -951,7 +971,7 @@ export function compileForOfAssignDestructuring(
               fctx.body.push({ op: "local.set", index: oobLocal! });
             });
             fctx.body.push(...instrs);
-            emitGlobalSyncWriteback(fctx, oobLocal, oobSyncGlobalIdx);
+            emitGlobalSyncWriteback(ctx, fctx, oobLocal, oobSyncGlobalIdx);
           }
         }
       }
@@ -1005,7 +1025,7 @@ export function compileForOfAssignDestructuring(
                 fctx.body.push({ op: "local.set", index: oobLocal! });
               });
               fctx.body.push(...instrs);
-              emitGlobalSyncWriteback(fctx, oobLocal, oobSyncGlobalIdx);
+              emitGlobalSyncWriteback(ctx, fctx, oobLocal, oobSyncGlobalIdx);
             }
           }
           continue;
@@ -1105,7 +1125,7 @@ export function compileForOfAssignDestructuring(
           fctx.body.push({ op: "local.set", index: targetLocal });
         }
 
-        emitGlobalSyncWriteback(fctx, targetLocal, tupleSyncGlobalIdx);
+        emitGlobalSyncWriteback(ctx, fctx, targetLocal, tupleSyncGlobalIdx);
       }
     } else {
       // Vec array assignment destructuring
@@ -1343,7 +1363,7 @@ export function compileForOfAssignDestructuring(
           }
         }
 
-        emitGlobalSyncWriteback(fctx, targetLocal, vecSyncGlobalIdx);
+        emitGlobalSyncWriteback(ctx, fctx, targetLocal, vecSyncGlobalIdx);
       }
     }
   }
@@ -1437,7 +1457,7 @@ function emitForOfRestAssignment(
   }
   fctx.body.push({ op: "local.set", index: targetLocal });
 
-  emitGlobalSyncWriteback(fctx, targetLocal, restSyncGlobalIdx);
+  emitGlobalSyncWriteback(ctx, fctx, targetLocal, restSyncGlobalIdx);
   return true;
 }
 
@@ -1557,7 +1577,7 @@ function emitVecRestAssignment(
   }
   fctx.body.push({ op: "local.set", index: targetLocal });
 
-  emitGlobalSyncWriteback(fctx, targetLocal, restSyncGlobalIdx);
+  emitGlobalSyncWriteback(ctx, fctx, targetLocal, restSyncGlobalIdx);
 }
 
 /**
@@ -1820,7 +1840,7 @@ function compileForOfAssignDestructuringExternref(
       emitCoercedLocalSet(ctx, fctx, targetLocal, { kind: "externref" });
     }
 
-    emitGlobalSyncWriteback(fctx, targetLocal, extSyncGlobalIdx);
+    emitGlobalSyncWriteback(ctx, fctx, targetLocal, extSyncGlobalIdx);
   }
 }
 
@@ -1892,7 +1912,7 @@ export function compileForOfIteratorAssignDestructuring(
       // Coerce externref to target local's type and set
       emitCoercedLocalSet(ctx, fctx, targetLocal, { kind: "externref" });
 
-      emitGlobalSyncWriteback(fctx, targetLocal, iterObjSyncGlobalIdx);
+      emitGlobalSyncWriteback(ctx, fctx, targetLocal, iterObjSyncGlobalIdx);
     }
   } else if (ts.isArrayLiteralExpression(expr)) {
     // for ([x, y] of iterable) — use __extern_get(elem, box(i)) for each element
@@ -2105,7 +2125,7 @@ export function compileForOfIteratorAssignDestructuring(
         emitCoercedLocalSet(ctx, fctx, targetLocal, { kind: "externref" });
       }
 
-      emitGlobalSyncWriteback(fctx, targetLocal, iterArrSyncGlobalIdx);
+      emitGlobalSyncWriteback(ctx, fctx, targetLocal, iterArrSyncGlobalIdx);
     }
   }
 }

--- a/tests/issue-3024-module-global-slot-desync.test.ts
+++ b/tests/issue-3024-module-global-slot-desync.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3024 — module-global slot-type-vs-stored-value desync emitted INVALID Wasm.
+ *
+ * A module-level `var`/`let` becomes a Wasm module global whose declared slot
+ * type is derived from the STATIC TS type, but the value actually stored can
+ * have a different Wasm representation, and the write site did not coerce. Two
+ * write paths, one family:
+ *
+ *  (A) Object literal with a RUNTIME computed key — `var o = { a, [foo()]: v }`.
+ *      `compileObjectLiteral` builds these as a host `$Object` (externref) via
+ *      `_hasRuntimeComputedKey`, but `moduleInitForcesExternref`
+ *      (declarations.ts) did NOT mirror that predicate, so the global stayed
+ *      struct-typed → `global.set expected (ref null N), found externref` (and
+ *      the read's `extern.convert_any` on the struct slot was also invalid).
+ *      Literal computed keys `[1]` still fold to a static struct — unchanged.
+ *
+ *  (B) for-of / for-await array-rest destructuring-ASSIGNMENT —
+ *      `var x, y; for ([x, ...y] of …) {}`. `emitGlobalSyncWriteback`
+ *      (for-of-destructuring.ts) did a raw `local.get; global.set`; the rest
+ *      slice materializes a `(ref null vec)` local while the untyped `var y`
+ *      global is `externref` → `global.set expected externref, found
+ *      (ref null N)`.
+ *
+ * Both guards fire ONLY on shapes that were ALWAYS invalid Wasm before, so no
+ * previously-valid module changes (byte-inert). Fix mirrors the already-correct
+ * function-local typing (`resolveSpillLocalValType`) and the binding-form
+ * `syncDestructuredLocalsToGlobals` coercion precedent.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { runTest262File } from "./test262-runner.ts";
+
+const T262 = join(process.cwd(), "test262");
+
+async function validates(src: string): Promise<{ ok: boolean; msg: string }> {
+  const r: any = await compile(src, { fileName: "t.ts" });
+  if (!r.success) return { ok: false, msg: `compile failed: ${(r.errors ?? [])[0]?.message ?? "?"}` };
+  if (WebAssembly.validate(r.binary)) return { ok: true, msg: "" };
+  let msg = "invalid";
+  try {
+    await WebAssembly.compile(r.binary);
+  } catch (e: any) {
+    msg = String(e.message).split("\n")[0];
+  }
+  return { ok: false, msg };
+}
+
+describe("#3024 — module-global slot-type-vs-value desync", () => {
+  it("A: module var object literal with a runtime computed key validates", async () => {
+    const cases = [
+      `function ID(x) { return x; }\nvar object = { a: 'A', [1]: 'B', c: 'C', [ID(2)]: 'D' };`,
+      `var o = { a: 'A', [foo()]: 'B' }; function foo(){return 2;}`,
+    ];
+    for (const src of cases) {
+      const { ok, msg } = await validates(src);
+      expect(ok, `${msg}\n---\n${src}`).toBe(true);
+    }
+  });
+
+  it("A: literal computed keys stay on the struct path (unchanged, still valid)", async () => {
+    // Narrowness guard: `[1]`/`[2]` fold to a compile-time key, so these keep the
+    // struct representation and must NOT be affected by the externref routing.
+    for (const src of [
+      `var o = { a: 'A', [1]: 'B' };`,
+      `var o = { a: 'A', [1]: 'B', c: 'C', [2]: 'D' };`,
+      `var o = { [1]: 'A', [2]: 'B' };`,
+    ]) {
+      const { ok, msg } = await validates(src);
+      expect(ok, `${msg}\n---\n${src}`).toBe(true);
+    }
+  });
+
+  it("B: module var for-of array-rest destructuring-assignment validates", async () => {
+    for (const src of [
+      `var x, y;\nfor ([x, ...y] of [[1, 2, 3]]) {}`,
+      `var x, y;\nvar counter = 0;\nfor ([, , x, , ...y] of [[1, 2, 3, 4, 5, 6]]) { counter += 1; }`,
+    ]) {
+      const { ok, msg } = await validates(src);
+      expect(ok, `${msg}\n---\n${src}`).toBe(true);
+    }
+  });
+
+  // Representative real test262 files from both sub-clusters. The regression
+  // guard is "no invalid-Wasm signature" (the CE→valid flip); several also reach
+  // a genuine `pass`, asserted below.
+  const NO_INVALID: [rel: string, category: string][] = [
+    ["test/language/computed-property-names/basics/number.js", "language/computed-property-names"],
+    ["test/language/computed-property-names/basics/string.js", "language/computed-property-names"],
+    ["test/built-ins/Object/assign/target-is-sealed-existing-data-property.js", "built-ins/Object"],
+    ["test/built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index.js", "built-ins/Reflect"],
+    ["test/language/statements/for-of/dstr/array-rest-elision.js", "language/statements/for-of"],
+    ["test/language/statements/for-of/dstr/array-rest-after-element.js", "language/statements/for-of"],
+    [
+      "test/language/statements/for-await-of/async-gen-decl-dstr-array-rest-elision.js",
+      "language/statements/for-await-of",
+    ],
+  ];
+
+  it.runIf(existsSync(T262))(
+    "representative test262 files no longer emit invalid Wasm (were CE/instantiate-fail)",
+    async () => {
+      for (const [rel, category] of NO_INVALID) {
+        const abs = join(T262, rel);
+        if (!existsSync(abs)) continue;
+        const r = await runTest262File(abs, category, 20000);
+        const msg = String(r.error ?? r.reason ?? "");
+        expect(msg, `${rel}: ${r.status} — ${msg}`).not.toMatch(/invalid Wasm binary|Compiling function/i);
+      }
+    },
+    60000,
+  );
+
+  it.runIf(existsSync(T262))(
+    "representative files now reach a genuine pass",
+    async () => {
+      const PASS: [rel: string, category: string][] = [
+        ["test/language/computed-property-names/basics/number.js", "language/computed-property-names"],
+        ["test/language/statements/for-of/dstr/array-rest-elision.js", "language/statements/for-of"],
+      ];
+      for (const [rel, category] of PASS) {
+        const abs = join(T262, rel);
+        if (!existsSync(abs)) continue;
+        const r = await runTest262File(abs, category, 20000);
+        expect(r.status, `${rel}: ${r.status} — ${String(r.error ?? r.reason ?? "")}`).toBe("pass");
+      }
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
## #3024 — module-global slot-type-vs-stored-value desync (25 files, 17 real passes)

Clears **25 of the 27-file module-global slot-desync family** on the default gc lane (also validated on standalone). One family, two write paths where a module-level global's declared slot type disagreed with the stored value's Wasm representation, with no coercion at `global.set`:

- **Bucket A (14)** — `var o = { a, [foo()]: v }` (RUNTIME computed key). `compileObjectLiteral` builds these as a host `$Object` (externref) via `_hasRuntimeComputedKey`, but `moduleInitForcesExternref` (declarations.ts) did not mirror that predicate, so the global stayed struct-typed → `global.set expected (ref null N), found externref` (the read's `extern.convert_any` on the struct slot was invalid too — masked by the validator stopping at the first error). Literal computed keys `[1]` still fold to a static struct, unchanged. Fix mirrors the function-local `resolveSpillLocalValType`.
- **Bucket B (11)** — `var x, y; for ([x, ...y] of …)`. `emitGlobalSyncWriteback` (for-of-destructuring.ts) did a raw `local.get; global.set`; the rest slice materializes a `(ref null vec)` local while the untyped `var y` global is `externref`. Fix coerces local→global type (mirrors `syncDestructuredLocalsToGlobals`).

Distinct from #3343 (control-flow module-global *aliasing*); this is a value/slot *type* desync at the write.

## Measured (default gc lane, `runTest262File`, full harness)

- Full 587-candidate re-harvest: **97 → 72 invalid-Wasm, net −25**, exactly these 25, **0 new invalid signatures**.
- **17 real run-pass gains** + 8 CE→fail (valid Wasm now; fail on distinct semantics — proxy-keys, put-const/let, symbol computed keys, frozen/sealed `Object.assign` — improvements, not regressions).
- **Standalone lane (criterion #2):** the 25 fixed files also validate on `--target standalone` (21 pass + 4 valid-but-fail); 0 new standalone invalid.

## Byte-inert by construction

Both guards fire ONLY on shapes that were ALWAYS invalid Wasm before (a type-mismatch that can't validate), so no previously-valid module changes on either lane. `narrow-A` confirms literal-computed-key `[1]` cases stay on the struct path.

## Tests

New `tests/issue-3024-module-global-slot-desync.test.ts` (5 tests). Adjacent suites green (61 tests): issue-2602-forof-assign-rest, computed-props, issue-2804, issue-3024/-incdec-element/-packed-array-dstr, issue-2934, issue-3241, issue-1128-dstr-tdz.

## Deferred (roll forward)

The 2 `class ident-name-method-def-new-escaped` files (`global.set expected (ref null T), found call f64`) — a distinct class-expression-to-global desync; and the remaining ~72 per-root-cause singletons tracked in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ