### PR TITLE
fix(#3378): don't capture member/property names as free variables (deepEqual.js stale-local crash)

### DIFF
--- a/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
+++ b/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
@@ -1,7 +1,8 @@
 ---
 id: 3378
 title: "deepEqual.js fails to compile — stale LOCAL index in deeply-nested format/lazyResult closures (#2043 class, local not funcIdx)"
-status: ready
+status: in-progress
+assignee: sendev-3378
 sprint: current
 created: 2026-07-17
 priority: high
@@ -104,3 +105,80 @@ pattern.
 - The `Cannot access 'contents' before initialization` warnings on this file
   are gone (or confirmed a legitimate spec TDZ and intentionally kept).
 - No regression in the existing JS-host test262 pass rate.
+
+## Root cause (CONFIRMED 2026-07-24, sendev-3378) + fix
+
+The filed root-cause direction ("a captured-local slot computed against the
+wrong function's local space", pointing at `closures.ts` / call-site
+capture-emission) was a symptom description. The ACTUAL root cause is one level
+up, in the **free-variable analysis** itself:
+
+`src/codegen/closures.ts::collectReferencedIdentifiers` walked the AST with a
+generic `forEachChild` and added **every** `Identifier` it saw — including the
+NAME side of a member access. `deepEqual.js` has a module-scope
+`let join = arr => arr.join(', ')`, and `stringFromTemplate` contains
+`parts.join('')`. The property name `join` in `parts.join('')` was therefore
+mis-collected as a free-variable reference, so `stringFromTemplate` recorded a
+**SPURIOUS capture** of the outer `join` local. That capture's
+`outerLocalIdx` (the index of `join` in the IIFE frame that declares it, `6`)
+is only meaningful in that declaring frame. When `stringFromTemplate` is
+invoked from the deeply-nested `toString` closure (`__closure_12`, a different,
+smaller frame with 5 locals), the capture-prepend
+(`call-identifier.ts` non-mutable branch, `local.get cap.outerLocalIdx`) baked
+`local.get 6` into a 5-local function ⇒ the binary-emit
+`local index out of range — 6 (valid: [0, 5))` fatal.
+
+**Why the naive `localMap`-first fix (reverted, 100+ regressions) was the wrong
+layer:** that change altered the *emission* (which slot to read) for
+IN-RANGE, valid-Wasm captures that were load-bearing. The real defect is that
+the capture *should never have existed*. A non-computed member/property name is
+never a variable reference; removing it from the free-var set is the canonical
+free-variable-analysis rule and can only drop semantically-impossible
+captures (no valid-Wasm behavior can depend on a spurious property-name
+capture). This is a strictly-narrower, lower-risk change than touching the
+emission site.
+
+**Fix** (`collectReferencedIdentifiers`): recurse only into the
+reference-bearing children of member/property nodes, skipping the NAME —
+`PropertyAccessExpression` → `.expression` only; `QualifiedName` → `.left`
+only; `PropertyAssignment` → `.initializer` (+ computed key). Shorthand
+(`{ x }`, a real reference) and element access (`a[b]`, `b` a real reference)
+are untouched.
+
+Regression test: `tests/issue-3378.test.ts` (compiles the real
+`test262/harness/deepEqual.js` + stub assert; asserts the stale-local-index
+fatal is gone). Verified to FAIL on main (`local index out of range — 6 …
+__closure_12`) and PASS on branch.
+
+**Regression floor (the #1177-minefield gate):** full local equivalence suite
+= **1608 passing, 0 new regressions** (35 pre-existing baseline failures
+unchanged); the fix additionally flips **1** prior baseline failure to PASS
+(`math-pow-test262-pattern`). `tsc --noEmit`, prettier, biome all clean. The
+naive `localMap`-first *emission* fix regressed 100+; this narrower
+*analysis* fix regresses 0, confirming the layer choice.
+
+## SEPARATE, INDEPENDENT bug surfaced by this fix (NOT #3378)
+
+Once the stale-local-index crash is fixed, `deepEqual.js` compilation proceeds
+to binary emit and now fails **WebAssembly validation** with a DIFFERENT,
+pre-existing defect:
+
+```
+CompileError: … function '__closure_6' (format): not enough arguments on the
+stack for call (need 4, got 3)   — a call_ref arity mismatch
+```
+
+Proven independent of both this fix and the `join` collision by a controlled
+experiment: with the fix OFF and the harness `join` VARIABLE renamed (so the
+member-name collision cannot occur), the stale-local crash disappears but the
+`need 4, got 3` arity error **still** reproduces. It was simply MASKED before —
+the stale-local RangeError aborted binary emit before Wasm validation could
+run. It resists minimization (6 targeted snippets + a faithful
+format→lazyResult→acceptMappers→toString→stringFromTemplate skeleton all
+compile cleanly), so it needs its own investigation.
+
+**Consequence for AC #1/#2**: this fix is *necessary but not sufficient* for a
+fully-valid deepEqual binary — the arity bug still blocks it. Recommend a new
+issue for the `call_ref` arity mismatch and landing this fix as the stale-local
+half. The `Cannot access 'contents'` warnings are pre-existing, non-fatal
+(severity: warning), present on main, and orthogonal to this fix.

--- a/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
+++ b/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
@@ -15,6 +15,8 @@ area: codegen, closures, emit
 language_feature: compiler-internals
 goal: test262-conformance
 related: [2043, 3349]
+loc-budget-allow:
+  - src/codegen/closures.ts
 ---
 
 # #3378 — `deepEqual.js` fails to compile: stale LOCAL index in nested closures

--- a/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
+++ b/plan/issues/3378-deepequal-nested-closure-stale-local-index.md
@@ -180,7 +180,13 @@ format→lazyResult→acceptMappers→toString→stringFromTemplate skeleton all
 compile cleanly), so it needs its own investigation.
 
 **Consequence for AC #1/#2**: this fix is *necessary but not sufficient* for a
-fully-valid deepEqual binary — the arity bug still blocks it. Recommend a new
-issue for the `call_ref` arity mismatch and landing this fix as the stale-local
-half. The `Cannot access 'contents'` warnings are pre-existing, non-fatal
-(severity: warning), present on main, and orthogonal to this fix.
+fully-valid deepEqual binary — the arity bug still blocks it. The `call_ref`
+arity mismatch is now tracked as **#3576** (filed 2026-07-24 with the
+controlled-experiment evidence). deepEqual.js → valid binary (this issue's AC
+#1/#2) needs **both #3378 (this, landed via PR #3559) AND #3576**. This issue
+stays `in-progress` until #3576 lands. The `Cannot access 'contents'` warnings
+are pre-existing, non-fatal (severity: warning), present on main, and
+orthogonal to this fix.
+
+**Status:** bug #1 (stale-local crash) FIXED via PR #3559 (fork branch
+`issue-3378-spurious-property-name-capture`); remaining AC blocker = #3576.

--- a/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
+++ b/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
@@ -1,0 +1,112 @@
+---
+id: 3576
+title: "deepEqual.js `format` closure fails Wasm validation — call_ref arity mismatch (need 4, got 3)"
+status: ready
+sprint: current
+created: 2026-07-24
+priority: high
+feasibility: hard
+model: opus
+horizon: l
+reasoning_effort: high
+task_type: bugfix
+area: codegen, closures, array-methods, emit
+language_feature: compiler-internals
+goal: test262-conformance
+related: [3378, 2043]
+---
+
+# #3576 — `deepEqual.js` `format` closure: `call_ref` arity mismatch (need 4, got 3)
+
+## How this was found
+
+Surfaced by #3378 (PR #3559). #3378 fixed a stale-LOCAL-index binary-emit crash
+in `deepEqual.js` (a spurious property-name capture). That crash **masked** a
+SECOND, independent defect: once compilation proceeds past binary emit, the
+module fails **WebAssembly validation**:
+
+```
+CompileError: WebAssembly.compile(): Compiling function #NN:"__closure_6"
+failed: not enough arguments on the stack for call (need 4, got 3) @+15349
+```
+
+`__closure_6` is `assert.deepEqual.format` (locals `join`,
+`getOwnPropertyDescriptor`, `basic`, `usage`, `format`, `contents`, `tag`,
+`keys` — format's body). The failing instruction is a `call_ref` whose target
+funcref TYPE has **4 params** but only **3** values are on the stack. The
+4-param types in play are the array-callback wrapper ABI
+(`(ref null <closure_struct>) externref externref externref` — i.e.
+`env, value, index, array`), so the most likely shape is a `.map`/`.filter`
+callback trampoline calling a callback closure with `env + value + index`
+(3) where the callback's funcref type expects `env + value + index + array`
+(4) — or the inverse mismatch between how the callback closure's type is built
+vs. how it is invoked.
+
+## Proven INDEPENDENT of #3378 (controlled experiment)
+
+This is NOT a regression from #3378 and NOT caused by the `join` property-name
+collision. Controlled experiment (2026-07-24), 4 cells:
+
+| capture-fix | harness `join` var | result |
+| ----------- | ------------------ | ------ |
+| ON  | original | `need 4, got 3` (validation fail) |
+| ON  | renamed (`joinFn`, collision removed) | `need 4, got 3` |
+| OFF (main) | original | stale-local crash (#3378) — aborts before validation |
+| **OFF (main)** | **renamed** | **`need 4, got 3`** |
+
+The bottom-right cell is decisive: with the #3378 fix OFF and the `join`
+VARIABLE renamed so the member-name collision cannot occur, the stale-local
+crash disappears (nothing to crash on) but the `need 4, got 3` arity error
+**still reproduces**. So the arity bug is pre-existing on `main` and was simply
+never reached — the stale-local `RangeError` aborted binary emit before
+`WebAssembly.compile` could run.
+
+## Repro (current main OR #3559 branch)
+
+```ts
+import { compile } from "./src/index.ts";
+import { readFileSync } from "fs";
+const rd = (f) => readFileSync("test262/harness/" + f, "utf8");
+const stub = `function assert(x, m){ if(!x) throw new Error(m); }\nassert.x=1;\n`;
+const src = `export function test() {\n${stub + rd("deepEqual.js")}\nconsole.log("x");\n}`;
+const r = await compile(src, { target: "gc", fileName: "test.ts",
+  skipSemanticDiagnostics: true } as any);
+// r.success === true  (compiler emits a binary)
+await WebAssembly.compile(r.binary); // throws: need 4, got 3 at __closure_6
+```
+
+On `main` the same input throws the #3378 stale-local RangeError first; on the
+#3559 branch (or after #3559 merges) it reaches the arity failure. The full
+real-harness combo (`assert.js + sta.js + propertyHelper.js + compareArray.js +
+deepEqual.js` + a trivial `Object.entries` body) fails identically at
+`__closure_28`.
+
+## Why `feasibility: hard` — resists minimization
+
+The arity mismatch did NOT reproduce in any of 6 targeted minimal snippets
+(plain `.map`, nested-fn `.map`, tagged-template-basic, a mapper-in-`.map`
+pattern, `.map` with a 3-arg callback, `filter+map` over an object) NOR in a
+faithful `format → lazyResult → acceptMappers → toString → stringFromTemplate`
+skeleton (with and without outer-frame padding) — all compile to valid
+binaries. So the trigger needs most of `format`'s real structure (the
+tagged-template `lazyResult`/`lazyString` machinery returning a mapper-accepting
+function, the `subs.map((sub,i) => (mappers[i]||String)(sub))` mapper
+application, the `.filter(...).map(...)` over `Reflect.ownKeys`, the
+TDZ-flagged `usage`/`format` captures, etc.). Localizing needs a WAT/`call_ref`
+trace of the specific failing site in `format` (the byte offset is `@+15349`),
+then determining whether the arity is wrong on the callback CONSTRUCTION side
+(funcref type built with too many params) or the INVOCATION side (trampoline
+pushing too few args). Likely lives in `src/codegen/array-methods.ts`
+(callback-wrapper / trampoline ABI) and/or `src/codegen/closures/*`
+(funcref-as-closure wrapper types).
+
+## Acceptance criteria
+
+- The `stub-assert + deepEqual.js` repro compiles to a binary that PASSES
+  `WebAssembly.compile` / `WebAssembly.validate` (no `need 4, got 3`).
+- The full real-harness combo (`assert.js + sta.js + propertyHelper.js +
+  compareArray.js + deepEqual.js` + trivial body) validates.
+- Together with #3378 this closes deepEqual.js's AC (`deepEqual.js` → valid
+  binary); update #3378 accordingly.
+- No regression in the JS-host test262 pass rate; validate on the full
+  equivalence suite (broad closure/array-method codegen surface).

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -327,6 +327,35 @@ export function collectReferencedIdentifiers(node: ts.Node, names: Set<string>, 
     if (!shadowed || !shadowed.has("this")) names.add("this");
     return;
   }
+  // (#3378) A non-computed MEMBER/PROPERTY NAME is never a free-variable
+  // reference — `a.join`, the key of `{ join: x }`, or `ns.Type` name a
+  // property, not a binding. The generic `forEachChild` walk below would
+  // otherwise collect the `.name` Identifier and, if it collides with an
+  // outer local (e.g. `parts.join('')` vs. a module-scope `let join`), record
+  // a SPURIOUS capture. That capture's `outerLocalIdx` is valid only in the
+  // declaring frame, so baking it into a differently-framed nested closure
+  // emits a `local.get` past the closure's local count ("local index out of
+  // range" — the deepEqual.js `__closure_NN` crash). Recurse only into the
+  // reference-bearing children (the object/expression, the initializer, and
+  // any computed key), skipping the member NAME. Optional chaining
+  // (`a?.b`, `a?.[k]`) shares the same node kinds.
+  if (ts.isPropertyAccessExpression(node)) {
+    collectReferencedIdentifiers(node.expression, names, shadowed);
+    return;
+  }
+  if (ts.isQualifiedName(node)) {
+    collectReferencedIdentifiers(node.left, names, shadowed);
+    return;
+  }
+  if (ts.isPropertyAssignment(node)) {
+    // A computed key (`{ [k]: v }`) IS a reference; a plain identifier / string
+    // / numeric key is a property name. Always recurse the initializer.
+    if (ts.isComputedPropertyName(node.name)) {
+      collectReferencedIdentifiers(node.name, names, shadowed);
+    }
+    collectReferencedIdentifiers(node.initializer, names, shadowed);
+    return;
+  }
   if (isFunctionScopeBoundary(node)) {
     // Augment shadow set with this nested function's own locals before
     // recursing into its body. Function/method names declared by nested

--- a/tests/issue-3378.test.ts
+++ b/tests/issue-3378.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3378 — the real, unmodified test262 harness file `deepEqual.js` (which
+// backs `assert.deepEqual` across many built-in/language test262 files)
+// previously failed to compile with a STALE LOCAL index error (the #2043
+// class, but a local — not a funcIdx — went stale):
+//
+//   Binary emit error: RangeError: Codegen error: local index out of range —
+//   6 (valid: [0, 5)) at function '__closure_NN'.
+//
+// Root cause (fixed in src/codegen/closures.ts `collectReferencedIdentifiers`):
+// the free-variable walker collected the NAME side of a member access
+// (`parts.join('')`) as an identifier reference. `deepEqual.js` has a
+// module-scope `let join = arr => arr.join(', ')`, so the property name `join`
+// in `stringFromTemplate`'s `parts.join('')` was mis-recorded as a free
+// variable and thus a SPURIOUS capture of `stringFromTemplate`. That capture's
+// `outerLocalIdx` is only valid in the IIFE frame that declares `join`; when
+// `stringFromTemplate` is invoked from the deeply-nested `toString` closure
+// (a different, smaller frame), the capture-prepend baked `join`'s outer index
+// (6) into a closure whose local count is 5 → "local index out of range".
+// A property name is never a variable reference, so skipping it is the
+// canonical free-variable-analysis rule and removes the spurious capture.
+//
+// This is a compilation-progress guard: it asserts the deepEqual.js compile no
+// longer aborts with the `local index out of range` fatal. NOTE: a SEPARATE,
+// pre-existing and independent defect (a `call_ref` arity mismatch, "not enough
+// arguments on the stack for call (need 4, got 3)" in the `format` closure) was
+// MASKED by this crash and is surfaced once it is fixed — it still blocks a
+// fully WebAssembly-valid binary and is tracked separately. Hence this test
+// checks that the specific #3378 fatal is gone, not full module validation.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+const HARNESS = join(process.cwd(), "test262", "harness");
+
+describe("#3378 deepEqual.js — spurious property-name capture / stale local index", () => {
+  it.runIf(existsSync(HARNESS))(
+    "stub-assert + deepEqual.js compiles without the 'local index out of range' fatal",
+    async () => {
+      const rd = (f: string) => readFileSync(join(HARNESS, f), "utf8");
+      // A tiny local `assert` callable is what makes deepEqual.js actually
+      // compile its `assert.deepEqual.format = function(){…}` closures (rather
+      // than treating them as dynamic/host writes) — the minimal trigger.
+      const stub = "function assert(x, m){ if(!x) throw new Error(m); }\nassert.x=1;\n";
+      const body = stub + rd("deepEqual.js") + '\nconsole.log("x");\n';
+      const src = `export function test() {\n${body}\n}`;
+      const r = await compile(src, {
+        target: "gc",
+        fileName: "test.ts",
+        skipSemanticDiagnostics: true,
+        emitWat: false,
+      } as Parameters<typeof compile>[1]);
+
+      const fatal = r.errors.filter((e) => (e as { severity?: string }).severity !== "warning");
+      const oor = fatal.filter((e) => /local index out of range/.test(e.message));
+      // The #3378 fix: the stale-local-index fatal must be gone.
+      expect(
+        oor.length,
+        `the #3378 stale-local-index fatal is still present:\n${oor.map((e) => e.message).join("\n")}`,
+      ).toBe(0);
+      // Compilation as a whole must no longer abort (it did on main with the
+      // above RangeError). A binary is emitted.
+      expect(r.success, fatal.map((e) => e.message).join("\n")).toBe(true);
+      expect(r.binary != null && r.binary.length > 0, "empty binary").toBe(true);
+    },
+    30000,
+  );
+});


### PR DESCRIPTION
## #3378 — `deepEqual.js` stale-LOCAL-index compile crash

Fixes the documented root cause of #3378: the real `test262/harness/deepEqual.js`
failed to compile with a binary-emit fatal

```
Codegen error: local index out of range — 6 (valid: [0, 5)) at __closure_12
```

### Root cause (one level up from where the issue pointed)

The fatal is a **stale LOCAL index**, and the actual defect is in the
**free-variable analysis**, not the capture-emission site. `collectReferencedIdentifiers`
(`src/codegen/closures.ts`) walked the AST with a generic `forEachChild` and
added **every** `Identifier` — including the NAME side of a member access.

`deepEqual.js` has a module-scope `let join = arr => arr.join(', ')`, and
`stringFromTemplate` contains `parts.join('')`. The property name `join` in
that method call was mis-recorded as a free-variable reference, so
`stringFromTemplate` recorded a **spurious capture** of the outer `join`. That
capture's `outerLocalIdx` is only valid in the IIFE frame that declares `join`;
when `stringFromTemplate` is invoked from the deeply-nested `toString` closure
(`__closure_12`, a different, smaller 5-local frame), the capture-prepend baked
`local.get 6` into it → the out-of-range fatal.

### Fix

A non-computed member/property name is never a variable reference, so skip it:

- `PropertyAccessExpression` → recurse `.expression` only
- `QualifiedName` → recurse `.left` only
- `PropertyAssignment` → recurse `.initializer` (+ computed key)

Shorthand (`{ x }`), computed keys (`{ [k]: v }`), and element access (`a[b]`)
are untouched. This is the canonical free-variable-analysis rule and is
**strictly narrower / lower-risk** than the reverted #1177 `localMap`-first
*emission* change (which regressed 100+): an analysis fix can only drop
semantically-impossible captures — no valid-Wasm behavior can depend on a
spurious property-name capture.

### Regression floor (the #1177-minefield gate)

- **Full local equivalence suite: 1608 passing, 0 new regressions** (35
  pre-existing baseline failures unchanged).
- The fix additionally flips **1** prior baseline failure to PASS
  (`math-pow-test262-pattern`).
- `tsc --noEmit`, prettier, biome all clean.

Regression test `tests/issue-3378.test.ts` compiles the real `deepEqual.js` +
a stub `assert` and asserts the stale-local-index fatal is gone — verified to
**fail on `main`** (`local index out of range — 6 … __closure_12`) and **pass
here**.

### ⚠️ Partial: a separate, independent bug still blocks a fully-valid binary

Once this crash is fixed, `deepEqual.js` compilation proceeds to binary emit
and now fails **WebAssembly validation** with a DIFFERENT, pre-existing defect:

```
CompileError: __closure_6 (format): not enough arguments on the stack for call (need 4, got 3)
```

a `call_ref` arity mismatch. Proven **independent** of this fix and of the
`join` collision by a controlled experiment (fix OFF + `join` variable renamed
→ the stale-local crash disappears but `need 4, got 3` still reproduces). It
was simply MASKED before — the RangeError aborted binary emit before Wasm
validation could run. It resists minimization (6 targeted snippets + a faithful
`format→lazyResult→acceptMappers→toString→stringFromTemplate` skeleton all
compile cleanly), so it needs its own investigation.

**Consequence**: this PR is *necessary but not sufficient* for a fully-valid
`deepEqual.js` binary — the arity bug still blocks AC #1/#2. It lands the
stale-local half (a general spurious-property-name-capture fix that helps any
code where a method name collides with an outer variable) and a follow-up
should track the `call_ref` arity defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ
