### PR TITLE
fix(#3200): flatMap non-callable mapper → TypeError (§23.1.3.11 step 3)

### DIFF
--- a/plan/issues/3200-default-array-iteration-producer-methods-generics.md
+++ b/plan/issues/3200-default-array-iteration-producer-methods-generics.md
@@ -1,11 +1,13 @@
 ---
 id: 3200
 title: "default lane: Array.prototype iteration/producer generics (forEach/map/filter/flatMap) over real + array-like receivers (~204 fails)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-opus-arrayhof
 created: 2026-07-12
-updated: 2026-07-17
+updated: 2026-07-24
 loc-budget-allow:
   - src/runtime.ts
+  - src/codegen/array-methods.ts
 priority: high
 feasibility: hard
 task_type: bug

--- a/plan/issues/3200-default-array-iteration-producer-methods-generics.md
+++ b/plan/issues/3200-default-array-iteration-producer-methods-generics.md
@@ -1,8 +1,7 @@
 ---
 id: 3200
 title: "default lane: Array.prototype iteration/producer generics (forEach/map/filter/flatMap) over real + array-like receivers (~204 fails)"
-status: in-progress
-assignee: ttraenkler/dev-opus-arrayhof
+status: ready
 created: 2026-07-12
 updated: 2026-07-24
 loc-budget-allow:
@@ -105,3 +104,71 @@ arrays (~23), thisArg (~9), flatMap array-like (.call not in
 ARRAY_LIKE_METHOD_SET at all). Note: probe batches are contaminated by
 Object.prototype getter pollution + the #3318 `declaredType` CE — measure
 single-test, fresh process.
+
+## Slice 2 (2026-07-24, dev-opus-arrayhof) — flatMap correctness (trap-first, fully owned)
+
+Fresh MEASURE at HEAD def8f82 (default gc lane, real runner, per-file unit;
+includes slice-1 + a64f272 length fix). Scoped map/filter/forEach/flatMap:
+**672 / 462 pass / 210 non-pass (68.8%)**. Per-method non-pass: map 74,
+filter 68, forEach 52, flatMap 16. (204→210 vs 2026-07-12 = corpus growth:
+new resizable-buffer + this-value-ctor tests, NOT a slice-1 regression.)
+
+Receiver-kind partition of the 210 (source-grepped every file — the real
+tractability axis):
+- **direct-real-array 115** (map39/filter38/forEach27/flatMap11) — dominated
+  by defineProperty-index=55, accessor/getter=53, species=25, delete=16,
+  proto-chain-index=14. = HARD value-rep MOP substrate (typed WasmGC vecs
+  don't implement per-index accessor / prototype-chain HasProperty /
+  delete-during-iteration). Same wall as suspended #2773; the host lane hits
+  it too, not just standalone. **No m-slice closes this — routed as a
+  substrate finding (see below).**
+- **arraylike-.call 86** (map32/filter27/forEach22/flatMap5) — SHARED path
+  with #3201 (a64f272 length fix landed here). Mostly still needs accessor/
+  defineProperty observability on the array-like object.
+- **primitive-.call 9** (map3/filter3/forEach3) — `.call(false,cb)`
+  ToObject(primitive) bails to the legacy `__proto_method_call` bridge that
+  can't invoke the closure → "object is not a function".
+
+Trap subset (soundness, 6): map/filter target-array-with-non-writable
+(OOB, Symbol.species result), map/filter create-revoked-proxy (illegal cast,
+Proxy), flatMap depth-always-one (illegal cast, array-of-array return),
+flatMap array-like-objects-nested (null-deref). Most are species/Proxy-rooted
+(hard); depth-always-one is the clean one.
+
+### Landed in this slice (in-budget: src/codegen/array-methods.ts)
+1. **flatMap non-callable mapper → TypeError** (§23.1.3.11 step 3). flatMap
+   skipped the shared `emitCallbackTypeCheck` gate that map/filter/forEach run,
+   so a missing/non-callable mapper fell through to host `__array_flatMap`,
+   which wraps the value in an always-callable arrow — hiding the non-callable
+   from native flatMap's IsCallable check → no throw. Added the gate at the top
+   of `compileArrayFlatMap` (above the standalone arm → both lanes). Flips
+   `flatMap/non-callable-argument-throws.js`.
+2. **`ts.TypeFlags.ESSymbolLike` added to `isKnownNonCallable`'s
+   NON_CALLABLE_FLAGS** — a symbol is never callable, so `[].flatMap(Symbol())`
+   (and `.map/.filter/.forEach(Symbol())`) throw the spec TypeError. Covers the
+   8th (symbol) assertion of non-callable-argument-throws and helps the whole
+   HOF family. (Coordinated with #3201/dev-c-2 — owned here to avoid a shared-
+   helper double-edit.)
+
+### Routed OUT of this slice
+- **depth-always-one illegal-cast trap** (priority a) — root-caused: host-lane
+  flatMap returns an externref JS-array; the result coerces to the declared
+  `T[][]` vec via `buildVecFromExternref` (type-coercion.ts:~450). Its
+  `buildElemCoerce` (~:398) handles a **vec-typed ref element** with a naked
+  `any.convert_extern; ref.cast_null` — but a nested JS sub-array is NOT a
+  WasmGC struct → `illegal cast`. Fix = recurse: call the reserved
+  `__vec_from_extern_<elemTypeIdx>` materializer (`vecFromExternFuncIdx`)
+  instead of the naked cast. BUT the reserve pass
+  (`reserveVecFieldMaterializers`, member-set-dispatch.ts) only reserves
+  materializers for struct-FIELD vecs — the flatMap result is a local/expression
+  coercion target it never sees, so no element materializer is reserved and the
+  recursion can't be wired post-freeze. Needs reserve-pass support for nested-vec
+  element types (type-coercion.ts + member-set-dispatch.ts — OUT of this issue's
+  loc-budget, hot shared coercion infra). Filed for a coercion-infra task.
+- **thisArg-argument** — host `__array_flatMap`'s `wrapped` drops `this`, and a
+  compiled closure can't take an injected `this` through the JS bridge; needs
+  the map/filter/forEach thisArg-closure machinery, not the host bridge. Deferred.
+- **array-like-objects*** (null-deref traps) — flatMap absent from
+  ARRAY_LIKE_METHOD_SET; `.call(arraylike,fn)` needs the shared array-like path
+  + full FlattenIntoArray HasProperty-skip semantics. Shared with #3201, deferred.
+- **this-value-ctor-*** — ArraySpeciesCreate @@species; species mechanism, hard.

--- a/plan/issues/3577-nested-vec-element-materializer-reserve-pass.md
+++ b/plan/issues/3577-nested-vec-element-materializer-reserve-pass.md
@@ -1,0 +1,87 @@
+---
+id: 3577
+title: "nested-vec element materializer reserve-pass (flatMap depth-always-one illegal-cast + related host-lane T[][] coercion traps)"
+status: blocked
+created: 2026-07-24
+updated: 2026-07-24
+priority: medium
+feasibility: medium
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: array-methods
+goal: builtin-methods
+sprint: current
+horizon: m
+blocked-on: "#1917 Stage B (sdev is actively refactoring src/codegen/type-coercion.ts — the emitToPrimitive façade); land after that settles to avoid a guaranteed conflict"
+related: [3200, 1917, 2831]
+origin: "2026-07-24 #3200 Slice-2 (flatMap) — routed out; the depth-always-one illegal-cast trap"
+loc-budget-allow:
+  - src/codegen/type-coercion.ts
+  - src/codegen/member-set-dispatch.ts
+---
+
+# #3577 — nested-vec element materializer reserve-pass
+
+Routed out of **#3200 Slice-2** (flatMap correctness). The priority-(a)
+trap `built-ins/Array/prototype/flatMap/depth-always-one.js` (illegal cast)
+is a **host-lane nested-`T[][]` coercion** gap, not a flatMap-specific bug.
+
+## Root cause (measured, #3200 Slice-2)
+
+Host-lane `flatMap` (`compileArrayFlatMap`) delegates to the JS host import
+`__array_flatMap`, which returns an **externref JS array**. When the callback
+returns arrays (`[1,2,3].flatMap(e => [[e*2]])` → `number[][]`), the result
+externref is coerced to the declared vec type via `buildVecFromExternref`
+(`src/codegen/type-coercion.ts:~450`). Its inner `buildElemCoerce` (`~:398`)
+handles a **vec-typed ref element** with a naked:
+
+```
+any.convert_extern
+ref.cast_null <elemVecTypeIdx>     // e.g. (ref null __vec_f64)
+```
+
+But each element of the host result is itself a **plain JS sub-array**
+(externref), NOT a WasmGC `__vec_*` struct → `ref.cast` fails → **illegal cast
+[in __module_init()]** (uncatchable trap).
+
+## Fix sketch
+
+1. **`buildElemCoerce`** (type-coercion.ts): when the element type `et` is a
+   ref to a **vec struct** (not a tuple), recurse — call the reserved
+   per-target materializer `__vec_from_extern_<elemTypeIdx>`
+   (`vecFromExternFuncIdx`, `buildVecFromExternMaterializer`, #2831) instead of
+   the naked `ref.cast_null`. That helper already handles null / same-rep /
+   host-array-materialize and (once it recurses) deeper nesting is
+   self-consistent.
+2. **Reserve pass** (`reserveVecFieldMaterializers`, member-set-dispatch.ts):
+   today it reserves `__vec_from_extern_*` only for **struct-FIELD** vec types.
+   The flatMap result is a **local / expression coercion target** the reserve
+   pass never sees, and the index space is **frozen at emit** so the element
+   materializer can't be reserved lazily inside `buildElemCoerce`. Extend the
+   reserve pass to also reserve materializers for the **element type of every
+   registered vec-of-vec type** (iterate `ctx` vec types; for any whose element
+   is itself a vec, `buildVecFromExternMaterializer(elemTypeIdx)`), so the
+   recursion in (1) resolves post-freeze.
+
+## Risk / low blast radius
+
+The `ref`-element non-tuple arm currently **always** illegal-cast-traps for a
+host-array nested element, so (1) can only convert a 100%-trapping path into a
+correct value — it cannot regress a passing test. (2) reserves extra defined
+funcs; verify no interaction with index-space freeze / dead-func elimination.
+
+## Blocked-on
+
+**#1917 Stage B** — sdev is actively refactoring `type-coercion.ts` (the
+`emitToPrimitive` façade). Two agents editing that file in parallel is a
+guaranteed conflict. Land this after #1917 Stage B settles; the coercion-infra
+owner picks it up then.
+
+## Acceptance
+
+1. `flatMap/depth-always-one.js` passes (host lane); nested `T[][]` flatMap
+   results materialize correctly.
+2. No test262 regressions (gc + standalone floors).
+3. Repro in a `tests/issue-3577.test.ts` (`[1,2,3].flatMap(e => [[e*2]])` →
+   `[[2],[4],[6]]`).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -188,7 +188,10 @@ function isKnownNonCallable(ctx: CodegenContext, arg: ts.Expression): boolean {
     ts.TypeFlags.BooleanLike |
     ts.TypeFlags.NumberLike |
     ts.TypeFlags.StringLike |
-    ts.TypeFlags.BigIntLike;
+    ts.TypeFlags.BigIntLike |
+    // A symbol is never callable → spec-correct §23.1.3.* step-3 TypeError for
+    // every array HOF (e.g. `[].flatMap(Symbol())`, `[].map(Symbol())`). (#3200)
+    ts.TypeFlags.ESSymbolLike;
   if (tsType.flags & NON_CALLABLE_FLAGS) return true;
   // (#2934 host-bridge A) A plain OBJECT type with NO call and NO construct
   // signatures is statically non-callable — `arr.map(new Object())`
@@ -8368,6 +8371,14 @@ function compileArrayFlatMap(
   arrTypeIdx: number,
   elemType: ValType,
 ): ValType | null {
+  // §23.1.3.11 step 3: IsCallable(mapperFunction) is false → throw TypeError,
+  // BEFORE any flatten work. Mirrors map/filter/forEach; covers the missing
+  // callback (`[].flatMap()`) and known-non-callable args (`{}`, `0`, `null`,
+  // `Symbol()`, …). Placed above the standalone arm so both lanes get it.
+  if (emitCallbackTypeCheck(ctx, fctx, callExpr, "Array.prototype.flatMap")) {
+    fctx.body.push({ op: "unreachable" });
+    return { kind: "externref" };
+  }
   if (callExpr.arguments.length < 1) return null; // flatMap requires a callback
 
   // (#2717) On the host-free lanes `flatMap` has no host `__array_flatMap` to

--- a/tests/issue-3200.test.ts
+++ b/tests/issue-3200.test.ts
@@ -86,3 +86,87 @@ export function test(): any {
     expect(out).toBe(2);
   });
 });
+
+// (#3200 flatMap slice) §23.1.3.11 step 3 — IsCallable(mapperFunction) is false
+// → throw TypeError BEFORE any flatten work. flatMap did not run the shared
+// `emitCallbackTypeCheck` gate (map/filter/forEach do), so a missing or
+// non-callable mapper silently fell through to the host `__array_flatMap`
+// bridge, which wrapped the value in an always-callable arrow — hiding the
+// non-callable from native flatMap's IsCallable check → no throw
+// (built-ins/Array/prototype/flatMap/non-callable-argument-throws.js). The
+// `Symbol()` arm additionally needs `ts.TypeFlags.ESSymbolLike` in
+// `isKnownNonCallable`'s NON_CALLABLE_FLAGS (a symbol is never callable).
+//
+// Uses `skipSemanticDiagnostics` to mirror the test262 runner (raw JS: a
+// non-function passed to `.flatMap` is a TS assignability error the runner
+// suppresses, then compiles + runs).
+async function compileAndRunLoose(source: string): Promise<unknown> {
+  const r = await compile(source, {
+    fileName: "test.ts",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, r.errors?.[0]?.message).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool) as unknown as WebAssembly.Imports & {
+    setExports?: (e: Record<string, Function>) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(r.binary!, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#3200 flatMap slice: non-callable mapper → TypeError (§23.1.3.11 step 3)", () => {
+  it("throws TypeError for every non-callable mapper form", async () => {
+    // Mirrors non-callable-argument-throws.js: object, number, implicit-undefined
+    // (no arg), explicit undefined, null, boolean, string, symbol.
+    const out = await compileAndRunLoose(`
+export function test(): number {
+  let thrown = 0;
+  const s = Symbol();
+  const cases: any[] = [
+    () => [].flatMap({}),
+    () => [].flatMap(0),
+    () => [].flatMap(),
+    () => [].flatMap(undefined),
+    () => [].flatMap(null),
+    () => [].flatMap(false),
+    () => [].flatMap(''),
+    () => [].flatMap(s),
+  ];
+  for (const c of cases) {
+    try { c(); } catch (e) { if (e instanceof TypeError) thrown++; }
+  }
+  return thrown;
+}`);
+    expect(out).toBe(8);
+  });
+
+  it("GUARD: a valid array-returning mapper still flattens one level", async () => {
+    const out = await compileAndRunLoose(`
+export function test(): number {
+  const r = [1, 2].flatMap((e: number) => [e, e * 2]);
+  // [1,2,2,4]
+  return r.length * 100 + r[0] * 10 + r[3];
+}`);
+    // length 4, r[0]=1, r[3]=4
+    expect(out).toBe(414);
+  });
+
+  it("ESSymbolLike: map / filter / forEach also throw TypeError for a symbol callback", async () => {
+    const out = await compileAndRunLoose(`
+export function test(): number {
+  let thrown = 0;
+  const s = Symbol();
+  const cases: any[] = [
+    () => [1].map(s),
+    () => [1].filter(s),
+    () => [1].forEach(s),
+  ];
+  for (const c of cases) {
+    try { c(); } catch (e) { if (e instanceof TypeError) thrown++; }
+  }
+  return thrown;
+}`);
+    expect(out).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of #3200 (default gc-lane Array iteration/producer generics) — the **flatMap correctness family**, fully owned (flatMap is not in `ARRAY_LIKE_METHOD_SET`; disjoint from #3201).

`Array.prototype.flatMap` skipped the shared `emitCallbackTypeCheck` gate that `map`/`filter`/`forEach` run. A missing or non-callable mapper silently fell through to the host `__array_flatMap` bridge, which wraps the value in an always-callable arrow — hiding the non-callable from native flatMap's IsCallable check, so **no TypeError was thrown** (spec §23.1.3.11 step 3 requires it before any flatten work).

## Changes (in-budget: `src/codegen/array-methods.ts`)
1. Add `emitCallbackTypeCheck(…, "Array.prototype.flatMap")` at the top of `compileArrayFlatMap`, above the standalone arm so **both lanes** get it. Covers the missing-callback (`[].flatMap()`) and known-non-callable (`{}`, `0`, `null`, …) forms.
2. Add `ts.TypeFlags.ESSymbolLike` to `isKnownNonCallable`'s `NON_CALLABLE_FLAGS` — a symbol is never callable → spec TypeError for every array HOF (covers the `Symbol()` assertion; helps `.map/.filter/.forEach(Symbol())` too). Coordinated with #3201/dev-c-2 to avoid a shared-helper double-edit.

## Measured (honest, per-file, MEASURE-not-extrapolate)
Scoped real test262 runner, default gc target, `map|filter|forEach|flatMap`:
- **462 → 463 pass** (+1), **0 regressions**, 0 other status changes.
- Flip: `built-ins/Array/prototype/flatMap/non-callable-argument-throws.js` (all 8 assertion forms now throw TypeError).
- Standalone valid flatMap still compiles (no host-free-lane regression).

The ESSymbolLike change is spec-correct but flipped 0 *additional* corpus files (no failing map/filter/forEach test uses a bare symbol callback).

## Routed out of this slice (issue notes updated)
- **depth-always-one illegal-cast trap** (priority a): root-caused to `buildElemCoerce` in `type-coercion.ts` doing a naked `ref.cast_null` on a nested JS sub-array; needs recursive `__vec_from_extern_*` materialization + reserve-pass support for nested-vec element types — out of this slice's loc-budget (hot coercion infra).
- thisArg (closure this-binding), array-like-objects (shared array-like path + FlattenIntoArray), this-value-ctor (@@species) — deferred with root causes in the issue file.

## Test
`tests/issue-3200.test.ts` — 3 new cases (8-form non-callable, valid-flatMap regression guard, map/filter/forEach symbol). All 7 in file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ