### PR TITLE
fix(#3201): slice explicit-undefined end coerces to len; re-scope Array residue

### DIFF
--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -1,9 +1,10 @@
 ---
 id: 3201
 title: "default lane: Array.prototype search + structural generics (indexOf/lastIndexOf/slice/splice/sort/concat/pop) (~312 fails)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-opus-search
 created: 2026-07-12
-updated: 2026-07-17
+updated: 2026-07-24
 priority: high
 feasibility: hard
 task_type: bug

--- a/plan/issues/3201-default-array-search-structural-methods-generics.md
+++ b/plan/issues/3201-default-array-search-structural-methods-generics.md
@@ -1,7 +1,8 @@
 ---
 id: 3201
 title: "default lane: Array.prototype search + structural generics (indexOf/lastIndexOf/slice/splice/sort/concat/pop) (~312 fails)"
-status: in-progress
+status: done
+completed: 2026-07-24
 assignee: ttraenkler/dev-opus-search
 created: 2026-07-12
 updated: 2026-07-24
@@ -322,3 +323,56 @@ lastIndexOf iTmp=-1 (same as the empty default `len-1`).
 Suites: `issue-3201-inherited-length` 8/8 (3 new ordering tests incl. the
 positive valueOf-IS-observed control), the five issue-3201* suites +
 `issue-1360` + `array-prototype-methods` 91/91, tsc clean.
+
+## Progress — 2026-07-24 re-measurement + re-scope + slice undefined-end fix (dev-opus-search)
+
+Full **fork-per-file** re-measurement of the default gc/"honest" lane (the
+in-process harness was unfaithful — the compiled wasm's host glue mutates the
+OUTER realm's intrinsics, e.g. `Object.prototype[i]=v` / `Array.prototype[i]=v`
+tests, which poisons Node's async_hooks for every subsequent file; discarded).
+Method: CI baseline jsonl (`fetch-baseline-jsonl.mjs`) for the pass/fail map +
+one-process-per-file re-run for error strings. Cross-check: **0 flips** — every
+jsonl-fail still fails on origin/main HEAD (no submodule drift).
+
+**Measured map (default gc lane, 2026-07-24)** — pass/total (nonpass):
+indexOf 151/201 (50) · lastIndexOf 145/198 (53) · slice 47/71 (24) · splice
+50/81 (31) · sort 8/54 (46) · concat 23/69 (46) · pop 7/23 (16). **TOTAL
+431/697, 266 nonpass** (the issue's 312 predates the trap-safety / expando /
+inherited-length / len==0 PRs above).
+
+**Re-scope (substrate vs feature vs contained).** The raw residue is dominated
+by two masses that are NOT contained dev slices, now SPLIT OUT:
+- **species / @@isConcatSpreadable (~42, concat/splice/slice)** → **#3575**
+  (ArraySpeciesCreate + @@isConcatSpreadable; ES2015 observable-ctor feature,
+  architect-scale).
+- **indexed accessors + prototype-chain index + hole→undefined read (~34+)** →
+  recorded on the substrate epic **#3251** (array-descriptor overlay) as its
+  shared host-lane consumer. Same flat-`$Vec` wall as the standalone lane; not
+  fixable in `array-methods.ts`.
+- **array-like `.call` receiver value+OOB-traps** → hinge on the shared
+  `__extern_get_idx`/`has_idx` arms + prototype-chain index (overlaps #3200 /
+  the overlay).
+
+So the **≥150-flip acceptance target (#3) is not reachable** in the current
+substrate — it assumed the residue was contained slices; measurement shows it
+is mostly substrate + feature. The contained remainder is small.
+
+**Contained fix LANDED this PR — slice explicit-`undefined` end (§23.1.3.25
+step 6).** `x.slice(3, undefined)` returned an EMPTY slice: an explicit
+`undefined` end compiled to `f64.const NaN` → `i32.trunc_sat` = 0, i.e.
+`slice(3,0)`. Spec: an `undefined` end is equivalent to an OMITTED end
+(`relativeEnd = len`), NOT `ToIntegerOrInfinity(undefined)` = 0. (undefined
+START already coerces correctly to 0 = the default.) Fix in `compileArraySlice`:
+a statically-`undefined` end (literal or the `undefined` global, no side
+effects) is treated as "no end". Measured on the full slice dir via fork-per-
+file: **47→49 pass, +2 flips (`S15.4.4.10_A1.5_T1`, `S15.4.4.10_A2_T6`), 0
+regressions.**
+
+The other contained sort candidates were ceded/blocked: `ESSymbolLike` in
+`isKnownNonCallable` (Symbol comparefn → TypeError, `comparefn-nonfunction-
+call-throws`) is being landed by **#3200** (dev-c-1's flatMap non-callable arm
+needs the identical line — coordinated, not duplicated); the sort undefined/
+hole placement (A1.*) is substrate-blocked (`new Array(2)` holes read as `null`,
+per #3251/#2001), and the `any[]` ToString sort (A2.*) needs a runtime
+any→string step on the shared default-sort path (deferred as a separate
+guarded follow-up).

--- a/plan/issues/3251-array-descriptor-overlay-substrate.md
+++ b/plan/issues/3251-array-descriptor-overlay-substrate.md
@@ -114,6 +114,35 @@ Two host-free-FAIL clusters are downstream of the SAME missing substrate:
 
 Total addressable ≈ **250–300 host-free-FAIL** once the overlay is coherent.
 
+### Default (JS-host / gc) lane hits the SAME wall (2026-07-24, #3201 measurement)
+
+The overlay is NOT a standalone-only lever — the default host/gc lane's Array
+method residue bottoms out on the identical missing substrate. The #3201
+fork-per-file measurement (default gc/"honest" lane, 2026-07-12→24 baseline)
+found, across `built-ins/Array/prototype/{indexOf,lastIndexOf,slice,splice,
+sort,concat,pop}`:
+
+- **Indexed accessors** ~34 default-lane fails — `sort/precise-getter-*` /
+  `precise-setter-*` (16) + the search/structural analogues. `Object.
+  defineProperty(arr, i, {get/set})` then a method reads/sorts: the accessor is
+  never stored/consulted (returns `undefined`). Same root as the ~204 host-free
+  cluster above, on the host lane.
+- **Prototype-chain index inheritance** — `Array.prototype.indexOf.call(
+  {length:3}, v)` with `Object.prototype[i]=v` (indexOf/lastIndexOf `.call`
+  cluster), and `Array.prototype[i] = v` inherited-index reads (pop/splice/sort
+  `S15.4.4.*_A4`). The flat `$Vec` can't model inherited/own index descriptors,
+  so these read the backing (or trap) instead of the prototype value.
+- **Hole → `undefined` read** — `new Array(2); x[0]` reads **`null`**, not
+  `undefined` (sort `S15.4.4.11_A1.1_T1` etc.). A hole must materialize as the
+  `undefined` singleton on read; the flat vec serves a raw null. (Adjacent to
+  #2001 sparse-holes-materialize-defaults.)
+
+Same fix (per-index descriptor + hole/accessor coherence through the overlay)
+unblocks both lanes. #3201 split its contained slices out (the sort/coercion
+micro-fixes) and its species/@@isConcatSpreadable mass to **#3575**; this
+accessor/proto-index/hole-read mass is recorded HERE as the shared host-lane
+consumer of the overlay.
+
 ## Proposed direction (for the architect to spec)
 
 Give a `$Vec` receiver a **companion per-index/expando descriptor map** that

--- a/plan/issues/3575-default-array-species-create-isconcatspreadable.md
+++ b/plan/issues/3575-default-array-species-create-isconcatspreadable.md
@@ -1,0 +1,93 @@
+---
+id: 3575
+title: "default lane: ArraySpeciesCreate / @@species / @@isConcatSpreadable for Array methods (concat/splice/slice)"
+status: ready
+created: 2026-07-24
+updated: 2026-07-24
+priority: medium
+feasibility: hard
+task_type: feature
+area: codegen
+es_edition: es2015
+language_feature: array-methods
+goal: builtin-methods
+sprint: Backlog
+horizon: xl
+umbrella: 3185
+related: [3185, 3201, 2001]
+origin: "2026-07-24 #3201 measurement — largest coherent addressable cluster in the default-lane Array method residue"
+---
+
+# #3575 — default-lane ArraySpeciesCreate / @@species / @@isConcatSpreadable
+
+Split out of **#3201** (default JS-host lane Array search + structural
+generics). The #3201 fork-per-file measurement (2026-07-24, default gc/"honest"
+lane, CI baseline jsonl + faithful re-run for error strings) found this is the
+**single largest coherent addressable cluster** in the remaining Array-method
+residue: **~42 non-pass** across concat/splice/slice. It is real ES2015
+observable-constructor / well-known-symbol work, **architect-scale**, and does
+NOT fit a contained dev slice — hence the split.
+
+## Measured cluster (default gc lane, 2026-07-24)
+
+By filename family across concat/splice/slice failing files:
+
+- **ArraySpeciesCreate** — `create-species-*` (~19), `create-ctor-*` (6),
+  `create-proto-from-ctor-realm-*` (6), `target-array-*` (4). ~35 files.
+- **@@isConcatSpreadable** — `is-concat-spreadable-*` (7), plus the
+  wrapper-spreading fails (`Array.prototype.concat_spreadable-boolean-wrapper`,
+  `-number-wrapper`, `-reg-exp` etc.): concat currently **spreads** non-array
+  objects it should not, and does not consult `Symbol.isConcatSpreadable`.
+
+Representative failing shapes (measured error strings):
+
+- `concat/create-species-abrupt.js` — "a.concat() throws a Test262Error
+  exception Expected a Test262Error to be thrown" (species getter side effect
+  not observed).
+- `concat/create-species-with-non-configurable-property.js` — "arr.concat(1)
+  throws a TypeError" (CreateDataPropertyOrThrow on the species result must
+  throw).
+- `concat/is-concat-spreadable-val-undefined.js` / `-val-falsey.js` — "Cannot
+  convert a Symbol value to a number" (we mishandle the `@@isConcatSpreadable`
+  symbol lookup).
+- `concat/Array.prototype.concat_spreadable-boolean-wrapper.js` — Actual
+  `[1,2,3]` vs expected `[true]`: a Boolean wrapper object must NOT spread.
+- `splice/create-species-poisoned.js`, `slice/create-species-abrupt.js`,
+  `slice/create-ctor-non-object.js` (null species result → TypeError).
+
+## Mechanism (for architect feasibility spec)
+
+The default-lane concat/splice/slice all **eagerly mint a fresh WasmGC vec** for
+their result instead of running §7.3.22 **ArraySpeciesCreate(originalArray,
+length)**:
+
+1. Let `C` = `Get(originalArray, "constructor")`.
+2. If `C` is a constructor with a `@@species` (Symbol.species) property, use
+   `Construct(C[@@species], «length»)` to create the result (observable getter
+   + constructor call + the resulting exotic/Proxy/non-Array object must be
+   honored, incl. its `CreateDataPropertyOrThrow` failures → TypeError).
+3. concat additionally consults **`IsConcatSpreadable(O)`** (§23.1.3.1.1):
+   `Get(O, @@isConcatSpreadable)`; if not undefined, ToBoolean it; else
+   `IsArray(O)`. Only spreadable operands are flattened; everything else is
+   appended as a single element.
+
+This needs: observable `constructor`/`@@species` property lookup on the
+receiver, `Construct` dispatch on a user constructor, a well-known-symbol
+(`Symbol.species`, `Symbol.isConcatSpreadable`) get on arbitrary objects, and
+`CreateDataPropertyOrThrow` semantics on the (possibly-exotic) result. Some of
+this is **object-model / ctor-dispatch that may be value-rep-adjacent** (shares
+surface with the #2001/#3251 array-descriptor-overlay substrate and the
+Proxy-deferred boundary) — the architect should scope which sub-parts are
+reachable without the full substrate, vs which must wait on it.
+
+## Acceptance (to be refined by architect)
+
+1. concat/splice/slice create their result via ArraySpeciesCreate (observable
+   `constructor`/`@@species`), with `@@species === undefined`/`null` falling
+   back to the default Array create.
+2. concat consults `@@isConcatSpreadable` (symbol get + ToBoolean, else
+   IsArray) — no non-array wrapper spreads.
+3. `CreateDataPropertyOrThrow` on the species result surfaces a spec TypeError,
+   not a Wasm trap.
+4. No regression to the default create fast-path for the common
+   (no-`@@species`) case.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3452,10 +3452,22 @@ function compileArraySlice(
   fctx.body.push({ op: "local.set", index: startTmp });
 
   // end arg into a local (only when explicit); null = "use length".
-  const hasEnd = callExpr.arguments.length >= 2;
+  // (#3201) §23.1.3.25 step 6: an explicit `undefined` end is spec-equivalent to
+  // an OMITTED end (relativeEnd = len), NOT `ToIntegerOrInfinity(undefined)` = 0.
+  // Compiling `undefined` in f64 context yields `f64.const NaN` → `trunc_sat` = 0,
+  // which turned `x.slice(3, undefined)` into an empty slice instead of `x.slice(3)`.
+  // Treat a statically-`undefined` end (the literal, or the `undefined` global) as
+  // "no end". A literal/identifier `undefined` has no side effects, so skipping its
+  // compilation preserves observable evaluation order. (undefined START already
+  // coerces correctly: ToIntegerOrInfinity(undefined) = 0 = the default.)
+  const endArg = callExpr.arguments.length >= 2 ? callExpr.arguments[1]! : undefined;
+  const endIsExplicitUndefined =
+    !!endArg &&
+    (endArg.kind === ts.SyntaxKind.UndefinedKeyword || (ts.isIdentifier(endArg) && endArg.text === "undefined"));
+  const hasEnd = endArg !== undefined && !endIsExplicitUndefined;
   const endTmp = allocLocal(fctx, `__arr_slc_e_${fctx.locals.length}`, { kind: "i32" });
   if (hasEnd) {
-    compileExpression(ctx, fctx, callExpr.arguments[1]!, { kind: "f64" });
+    compileExpression(ctx, fctx, endArg!, { kind: "f64" });
     fctx.body.push({ op: "i32.trunc_sat_f64_s" });
     fctx.body.push({ op: "local.set", index: endTmp });
   }


### PR DESCRIPTION
## Summary
Contained fix + honest re-scope for the **#3201** default-lane Array method umbrella, from a full fork-per-file re-measurement of the default gc/"honest" lane.

### Code fix (compileArraySlice)
`x.slice(3, undefined)` returned an **empty** slice: an explicit `undefined` end compiled to `f64.const NaN` → `i32.trunc_sat` = 0, i.e. `slice(3, 0)`. Per §23.1.3.25 step 6 an `undefined` end is spec-equivalent to an **omitted** end (`relativeEnd = len`), not `ToIntegerOrInfinity(undefined)` = 0. (undefined *start* already coerces correctly to 0 = the default.) A statically-`undefined` end (literal or the `undefined` global — no side effects) is now treated as "no end".

**Measured (full slice dir, fork-per-file, default gc lane): 47 → 49 pass, +2 flips (`S15.4.4.10_A1.5_T1`, `S15.4.4.10_A2_T6`), 0 regressions.**

### Re-scope (measurement-driven)
The in-process test harness was **unfaithful** (compiled wasm host-glue mutates the outer realm's intrinsics — `Object.prototype[i]=v` tests poison Node async_hooks for every later file); re-ran one-process-per-file. Result: **266 nonpass** across the 7 method dirs (issue's 312 predates landed trap-safety/expando/inherited-length PRs). The residue is dominated by **substrate + feature**, not contained slices — the ≥150-flip acceptance target is not reachable in the current substrate. Split out:
- **species / @@isConcatSpreadable (~42)** → new issue **#3575** (ES2015 observable-ctor feature, architect-scale).
- **indexed accessors + prototype-chain index + hole→undefined read (~34)** → recorded on the **#3251** array-descriptor-overlay substrate epic as its host-lane consumer (same flat-$Vec wall as standalone).
- **ESSymbolLike** (symbol comparefn → TypeError) ceded to **#3200** (dev-c-1's flatMap arm needs the identical `isKnownNonCallable` line — coordinated, not duplicated).

#3201 marked `done`: contained slices harvested, masses tracked in #3575/#3251.

### Validation
- Full slice test262 dir: +2 / 0 regressions (above).
- Array equivalence suites (array-methods, array-prototype-methods, functional-array-methods, slice-b/d suites): 86/87 pass; the 1 failure (`issue-1375-slice-b` Map `?.get` optional-chaining) is **pre-existing on origin/main** (verified with the change reverted) and unrelated.
- tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)