### PR TITLE
refactor(#1917): extract guardedRefCastInstrs — dedup 11 guarded-cast copies (Stage A)

### DIFF
--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -1,11 +1,12 @@
 ---
 id: 1917
 title: "One coercion engine — four divergent coercion matrices disagree about lossiness"
-status: ready
+status: in-progress
+assignee: ttraenkler/sdev-1917
 sprint: current
 model: opus
 created: 2026-06-10
-updated: 2026-06-24
+updated: 2026-07-24
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -15,6 +16,59 @@ language_feature: compiler-internals
 goal: correctness
 ---
 # #1917 — One coercion engine
+
+## Current state (2026-07-24, sdev-1917) — LANDED vs REMAINING
+
+**The bulk of this issue has already landed.** The stale narrative below (Problem,
+the original "Proposed approach", and the per-step Implementation sections) predates
+those merges — read this section first for the accurate status.
+
+### LANDED (on `origin/main`)
+
+- **Step 0 — single ValType `coercionPlan` table.** `src/codegen/coercion-plan.ts`
+  exists (pure `coercionPlan(from, to, {boxNumberIdx, unboxNumberIdx})`). All four
+  headline sites delegate to it: `callArgCoercionInstrs` (stack-balance.ts:1480),
+  `fixBranchType` (stack-balance.ts:903), `coercionInstrs` (type-coercion.ts:3529),
+  and `coerceType`'s scalar rows.
+- **The headline `externref→f64` divergence is GONE.** `fixBranchType` no longer
+  emits lossy `drop; f64.const 0`; it routes box/unbox through `coercionPlan` and
+  unboxes identically to the call-arg path (the acceptance-criterion-1 fix).
+- **Steps 1/2(partial)/3/4 — the JS-semantic engine.**
+  `src/codegen/coercion-engine.ts` exports `emitToString`/`compileAndEmitToString`,
+  `emitToNumber`, `emitToBoolean`, `emitStrictEq`/`emitLooseEq`/
+  `emitAnyEqFromExternTemps`, and `coercionMode`. The ToString, ToNumber, ToBoolean,
+  and equality dispatch sites migrated into it (see the per-step sections below for
+  the migration detail; those are accurate history now that they merged).
+- **Step 5 drift gate (#2108) is BUILT, WIRED, and GREEN.**
+  `scripts/check-coercion-sites.mjs` + `scripts/coercion-sites-baseline.json`,
+  run as `check:coercion-sites` in the `quality` CI job. It sanctions
+  `coercion-engine.ts`/`any-helpers.ts`/`native-strings.ts` and fails on per-file
+  vocabulary growth. It is NOT yet flipped to the hard per-token seal.
+
+### Acceptance criterion #2 — SUPERSEDED (not unfixed)
+
+The original spec asked that the `ref→f64` divergence (`coercionInstrs` →
+`f64.const NaN` vs the call-arg/branch unbox) also be forced to ValType identity.
+That is now understood to be a **deliberate provenance-dependent policy**, not an
+accidental divergence: a *bare* GC object-ref has ToNumber `NaN` (§7.1.4 — object
+with no numeric `valueOf`), whereas a ref *carrying a boxed number* must unbox.
+Forcing a single ValType-keyed answer would REGRESS one of the two. The
+`staticJsType`-hinted engine owns this split by provenance; ValType alone cannot.
+So criterion #2 is retired as originally worded — the `externref→f64` half (the
+real accidental bug) is fixed; the `ref→f64` half is correct-by-policy.
+
+### REMAINING (this branch, `issue-1917-stage-b-coercion`)
+
+- **(a) `guardedRefCast` dedup** — extract one helper for the `local.tee → ref.test
+  → if (cast_null / null)` idiom copy-pasted 4× in `coercionInstrs`
+  (type-coercion.ts) + ~6× in `coerceType`. Pure byte-neutral code-motion.
+- **(b) Stage B `emitToPrimitive` façade** over `coerceType`'s inline ref→f64
+  ToPrimitive dispatch — the actual remaining semantic close (Step 2 tail).
+  High-risk; gated on both-lane byte-SHA + full equivalence + a host test262 slice;
+  measured delta reported to the coordinator before landing.
+- **(c) Seal the #2108 gate** (per-token hard fail) after (b) lands.
+
+---
 
 ## Problem
 

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -82,6 +82,48 @@ export function emitGuardedFuncRefCast(fctx: FunctionContext, funcTypeIdx: numbe
 }
 
 /**
+ * (#1917 Stage A) Byte-neutral extraction of the guarded-ref-cast idiom that was
+ * copy-pasted across `coerceType` (~6×) and `coercionInstrs` (4×): tee the
+ * incoming (any/eq/`from`)ref into a temp, `ref.test` the target `toIdx`, and `if`
+ * it — `ref.cast_null` on success, `ref.null` on failure (so a wrong runtime
+ * struct type yields null instead of an illegal-cast trap). Returns the
+ * instruction SEQUENCE (the value to guard must already be on the stack, e.g.
+ * after a prefix `any.convert_extern` / `struct.get`). Instr[]-returning callers
+ * (`coercionInstrs`) prepend their prefix and `return`; push-style callers
+ * (`coerceType`) spread the result into `fctx.body`.
+ *
+ * Distinct from `emitGuardedRefCast` on three points these 10 sites require: it
+ * does NOT record `__lastGuardedCastBackup` (#792 — none of these sites did), it
+ * lets the caller choose the temp's ValType (`anyref` vs `eqref` vs the exact
+ * `from` type), and it appends the trailing `ref.as_non_null` only when
+ * `nonNull` (a non-null `(ref)` target). The `if` blockType is always
+ * `ref_null $toIdx`.
+ */
+function guardedRefCastInstrs(
+  fctx: FunctionContext,
+  toIdx: number,
+  opts: { tempType: ValType; nonNull: boolean },
+): Instr[] {
+  const tmp = allocTempLocal(fctx, opts.tempType);
+  const instrs: Instr[] = [
+    { op: "local.tee", index: tmp },
+    { op: "ref.test", typeIdx: toIdx },
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
+      then: [
+        { op: "local.get", index: tmp },
+        { op: "ref.cast_null", typeIdx: toIdx },
+      ],
+      else: [{ op: "ref.null", typeIdx: toIdx }],
+    },
+  ];
+  if (opts.nonNull) instrs.push({ op: "ref.as_non_null" });
+  releaseTempLocal(fctx, tmp);
+  return instrs;
+}
+
+/**
  * Callback type for compiling a string literal onto the Wasm stack.
  * Used by coerceType when it needs to push a @@toPrimitive hint string.
  * The caller (expressions.ts) passes its local compileStringLiteral function.
@@ -1388,56 +1430,25 @@ export function coerceType(
           ctx.nativeStrings &&
           (toIdxStr === ctx.anyStrTypeIdx || (ctx.nativeStrTypeIdx >= 0 && toIdxStr === ctx.nativeStrTypeIdx));
         if (isNativeStrTarget) {
-          const tmpStr = allocTempLocal(fctx, { kind: "anyref" } as ValType);
           fctx.body.push({ op: "struct.get", typeIdx: ctx.anyValueTypeIdx, fieldIdx: 4 }); // externval
           fctx.body.push({ op: "any.convert_extern" });
-          fctx.body.push({ op: "local.tee", index: tmpStr });
-          fctx.body.push({ op: "ref.test", typeIdx: toIdxStr });
-          fctx.body.push({
-            op: "if",
-            blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdxStr } as ValType },
-            then: [
-              { op: "local.get", index: tmpStr },
-              { op: "ref.cast_null", typeIdx: toIdxStr },
-            ],
-            else: [{ op: "ref.null", typeIdx: toIdxStr }],
-          });
-          if (to.kind === "ref") {
-            fctx.body.push({ op: "ref.as_non_null" });
-          }
-          releaseTempLocal(fctx, tmpStr);
+          fctx.body.push(
+            ...guardedRefCastInstrs(fctx, toIdxStr, {
+              tempType: { kind: "anyref" } as ValType,
+              nonNull: to.kind === "ref",
+            }),
+          );
           return;
         }
         // Get the refval field (eqref), then guarded ref.cast to target type
         fctx.body.push({ op: "struct.get", typeIdx: ctx.anyValueTypeIdx, fieldIdx: 3 });
         // Guard: ref.test before ref.cast to avoid illegal cast traps
-        const tmpEq = allocTempLocal(fctx, { kind: "eqref" } as ValType);
-        fctx.body.push({ op: "local.tee", index: tmpEq });
-        fctx.body.push({ op: "ref.test", typeIdx: toIdx });
-        if (to.kind === "ref_null") {
-          fctx.body.push({
-            op: "if",
-            blockType: { kind: "val", type: to },
-            then: [
-              { op: "local.get", index: tmpEq },
-              { op: "ref.cast_null", typeIdx: toIdx },
-            ],
-            else: [{ op: "ref.null", typeIdx: toIdx }],
-          });
-        } else {
-          // Non-null target: cast if test passes, otherwise unreachable (type error)
-          fctx.body.push({
-            op: "if",
-            blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-            then: [
-              { op: "local.get", index: tmpEq },
-              { op: "ref.cast_null", typeIdx: toIdx },
-            ],
-            else: [{ op: "ref.null", typeIdx: toIdx }],
-          });
-          fctx.body.push({ op: "ref.as_non_null" });
-        }
-        releaseTempLocal(fctx, tmpEq);
+        // Non-null `(ref)` target appends `ref.as_non_null` (nonNull); the
+        // `ref_null` target's original `if` blockType `to` is byte-identical to
+        // the helper's `ref_null $toIdx`.
+        fctx.body.push(
+          ...guardedRefCastInstrs(fctx, toIdx, { tempType: { kind: "eqref" } as ValType, nonNull: to.kind === "ref" }),
+        );
         return;
       }
       // Different struct types, neither is AnyValue.
@@ -1453,35 +1464,11 @@ export function coerceType(
       // (#2853 park fix) If from/to are same-layout sibling shapes, this guarded
       // downcast would trap post-brand — exclude both from nominal branding.
       markNoBrandSiblingShapes(ctx.mod.types, ctx.noBrandShapeTypes, fromIdx, toIdx);
-      {
-        const guardFrom = from.kind === "ref_null" ? ({ kind: "anyref" } as ValType) : ({ kind: "anyref" } as ValType);
-        const tmpGuard = allocTempLocal(fctx, guardFrom);
-        fctx.body.push({ op: "local.tee", index: tmpGuard });
-        fctx.body.push({ op: "ref.test", typeIdx: toIdx });
-        if (to.kind === "ref_null") {
-          fctx.body.push({
-            op: "if",
-            blockType: { kind: "val", type: to },
-            then: [
-              { op: "local.get", index: tmpGuard },
-              { op: "ref.cast_null", typeIdx: toIdx },
-            ],
-            else: [{ op: "ref.null", typeIdx: toIdx }],
-          });
-        } else {
-          fctx.body.push({
-            op: "if",
-            blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-            then: [
-              { op: "local.get", index: tmpGuard },
-              { op: "ref.cast_null", typeIdx: toIdx },
-            ],
-            else: [{ op: "ref.null", typeIdx: toIdx }],
-          });
-          fctx.body.push({ op: "ref.as_non_null" });
-        }
-        releaseTempLocal(fctx, tmpGuard);
-      }
+      // `guardFrom` was always `anyref` (both ternary arms), preserved as tempType;
+      // non-null `(ref)` target appends `ref.as_non_null` via nonNull.
+      fctx.body.push(
+        ...guardedRefCastInstrs(fctx, toIdx, { tempType: { kind: "anyref" } as ValType, nonNull: to.kind === "ref" }),
+      );
       return;
     }
     return;
@@ -1503,20 +1490,11 @@ export function coerceType(
       if (!emitSafeStructConversion(ctx, fctx, fromRefIdx, toRefNullIdx)) {
         // (#2853 park fix) same-layout sibling shapes → exclude from branding.
         markNoBrandSiblingShapes(ctx.mod.types, ctx.noBrandShapeTypes, fromRefIdx, toRefNullIdx);
-        // Guarded cast: ref $X → ref_null $Y — avoid illegal cast trap
-        const tmpRefNull = allocTempLocal(fctx, { kind: "anyref" } as ValType);
-        fctx.body.push({ op: "local.tee", index: tmpRefNull });
-        fctx.body.push({ op: "ref.test", typeIdx: toRefNullIdx });
-        fctx.body.push({
-          op: "if",
-          blockType: { kind: "val", type: to },
-          then: [
-            { op: "local.get", index: tmpRefNull },
-            { op: "ref.cast_null", typeIdx: toRefNullIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toRefNullIdx }],
-        });
-        releaseTempLocal(fctx, tmpRefNull);
+        // Guarded cast: ref $X → ref_null $Y — avoid illegal cast trap. Original
+        // `if` blockType `to` is byte-identical to the helper's `ref_null $toIdx`.
+        fctx.body.push(
+          ...guardedRefCastInstrs(fctx, toRefNullIdx, { tempType: { kind: "anyref" } as ValType, nonNull: false }),
+        );
       }
     }
     return;
@@ -1537,40 +1515,16 @@ export function coerceType(
         ctx.nativeStrings &&
         (toIdx === ctx.anyStrTypeIdx || (ctx.nativeStrTypeIdx >= 0 && toIdx === ctx.nativeStrTypeIdx));
       if (isNativeStrTarget) {
-        const tmpStr = allocTempLocal(fctx, { kind: "anyref" } as ValType);
         fctx.body.push({ op: "struct.get", typeIdx: ctx.anyValueTypeIdx, fieldIdx: 4 }); // externval
         fctx.body.push({ op: "any.convert_extern" });
-        fctx.body.push({ op: "local.tee", index: tmpStr });
-        fctx.body.push({ op: "ref.test", typeIdx: toIdx });
-        fctx.body.push({
-          op: "if",
-          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-          then: [
-            { op: "local.get", index: tmpStr },
-            { op: "ref.cast_null", typeIdx: toIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toIdx }],
-        });
-        fctx.body.push({ op: "ref.as_non_null" });
-        releaseTempLocal(fctx, tmpStr);
+        fctx.body.push(
+          ...guardedRefCastInstrs(fctx, toIdx, { tempType: { kind: "anyref" } as ValType, nonNull: true }),
+        );
         return;
       }
       fctx.body.push({ op: "struct.get", typeIdx: ctx.anyValueTypeIdx, fieldIdx: 3 });
       // Guarded cast: eqref → ref $X
-      const tmpUnbox = allocTempLocal(fctx, { kind: "eqref" } as ValType);
-      fctx.body.push({ op: "local.tee", index: tmpUnbox });
-      fctx.body.push({ op: "ref.test", typeIdx: toIdx });
-      fctx.body.push({
-        op: "if",
-        blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-        then: [
-          { op: "local.get", index: tmpUnbox },
-          { op: "ref.cast_null", typeIdx: toIdx },
-        ],
-        else: [{ op: "ref.null", typeIdx: toIdx }],
-      });
-      fctx.body.push({ op: "ref.as_non_null" });
-      releaseTempLocal(fctx, tmpUnbox);
+      fctx.body.push(...guardedRefCastInstrs(fctx, toIdx, { tempType: { kind: "eqref" } as ValType, nonNull: true }));
       return;
     }
     // ref_null $X → ref $Y: cast and assert non-null at runtime
@@ -1581,19 +1535,11 @@ export function coerceType(
         // (#2853 park fix) same-layout sibling shapes → exclude from branding.
         markNoBrandSiblingShapes(ctx.mod.types, ctx.noBrandShapeTypes, fromNullIdx, toNonNullIdx);
         // Guarded cast: ref_null $X → ref $Y
-        const tmpCast = allocTempLocal(fctx, { kind: "anyref" } as ValType);
-        fctx.body.push({ op: "local.tee", index: tmpCast });
-        fctx.body.push({ op: "ref.test", typeIdx: toNonNullIdx });
-        fctx.body.push({
-          op: "if",
-          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toNonNullIdx } as ValType },
-          then: [
-            { op: "local.get", index: tmpCast },
-            { op: "ref.cast_null", typeIdx: toNonNullIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toNonNullIdx }],
-        });
-        releaseTempLocal(fctx, tmpCast);
+        // nonNull: false — the trailing `ref.as_non_null` is emitted CONDITIONALLY
+        // below (the #2161 native-string-target exception), NOT unconditionally here.
+        fctx.body.push(
+          ...guardedRefCastInstrs(fctx, toNonNullIdx, { tempType: { kind: "anyref" } as ValType, nonNull: false }),
+        );
       }
     }
     // (#2161 family B0) NATIVE-STRING targets skip the non-null assert: a null
@@ -3640,23 +3586,10 @@ export function coercionInstrs(ctx: CodegenContext, from: ValType, to: ValType, 
     const vecMatIdx = vecFromExternFuncIdx(ctx, toIdx);
     if (vecMatIdx !== undefined) return [{ op: "call", funcIdx: vecMatIdx }];
     if (fctx) {
-      const tmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
-      const result: Instr[] = [
+      return [
         { op: "any.convert_extern" },
-        { op: "local.tee", index: tmp },
-        { op: "ref.test", typeIdx: toIdx },
-        {
-          op: "if",
-          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-          then: [
-            { op: "local.get", index: tmp },
-            { op: "ref.cast_null", typeIdx: toIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toIdx }],
-        },
+        ...guardedRefCastInstrs(fctx, toIdx, { tempType: { kind: "anyref" } as ValType, nonNull: false }),
       ];
-      releaseTempLocal(fctx, tmp);
-      return result;
     }
     // No fctx available — use original ref.cast (may trap as illegal_cast,
     // but that's more informative than silently returning null).
@@ -3672,23 +3605,12 @@ export function coercionInstrs(ctx: CodegenContext, from: ValType, to: ValType, 
     const vecMatIdx = vecFromExternFuncIdx(ctx, toIdx);
     if (vecMatIdx !== undefined) return [{ op: "call", funcIdx: vecMatIdx }, { op: "ref.as_non_null" }];
     if (fctx) {
-      const tmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
-      const result: Instr[] = [
+      // NOTE: no trailing `ref.as_non_null` even though `to.kind === "ref"` — this
+      // arm has always yielded a `ref_null` (nonNull: false), preserved exactly.
+      return [
         { op: "any.convert_extern" },
-        { op: "local.tee", index: tmp },
-        { op: "ref.test", typeIdx: toIdx },
-        {
-          op: "if",
-          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-          then: [
-            { op: "local.get", index: tmp },
-            { op: "ref.cast_null", typeIdx: toIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toIdx }],
-        },
+        ...guardedRefCastInstrs(fctx, toIdx, { tempType: { kind: "anyref" } as ValType, nonNull: false }),
       ];
-      releaseTempLocal(fctx, tmp);
-      return result;
     }
     // No fctx available — use ref.cast_null (passes null through instead of trapping)
     return [{ op: "any.convert_extern" }, { op: "ref.cast_null", typeIdx: toIdx }];
@@ -3697,22 +3619,7 @@ export function coercionInstrs(ctx: CodegenContext, from: ValType, to: ValType, 
   if ((from.kind === "eqref" || from.kind === "anyref") && to.kind === "ref_null") {
     const toIdx = (to as { typeIdx: number }).typeIdx;
     if (fctx) {
-      const tmp = allocTempLocal(fctx, from);
-      const result: Instr[] = [
-        { op: "local.tee", index: tmp },
-        { op: "ref.test", typeIdx: toIdx },
-        {
-          op: "if",
-          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-          then: [
-            { op: "local.get", index: tmp },
-            { op: "ref.cast_null", typeIdx: toIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toIdx }],
-        },
-      ];
-      releaseTempLocal(fctx, tmp);
-      return result;
+      return guardedRefCastInstrs(fctx, toIdx, { tempType: from, nonNull: false });
     }
     return [{ op: "ref.cast_null", typeIdx: toIdx }];
   }
@@ -3720,22 +3627,9 @@ export function coercionInstrs(ctx: CodegenContext, from: ValType, to: ValType, 
   if ((from.kind === "eqref" || from.kind === "anyref") && to.kind === "ref") {
     const toIdx = (to as { typeIdx: number }).typeIdx;
     if (fctx) {
-      const tmp = allocTempLocal(fctx, from);
-      const result: Instr[] = [
-        { op: "local.tee", index: tmp },
-        { op: "ref.test", typeIdx: toIdx },
-        {
-          op: "if",
-          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: toIdx } as ValType },
-          then: [
-            { op: "local.get", index: tmp },
-            { op: "ref.cast_null", typeIdx: toIdx },
-          ],
-          else: [{ op: "ref.null", typeIdx: toIdx }],
-        },
-      ];
-      releaseTempLocal(fctx, tmp);
-      return result;
+      // NOTE: no trailing `ref.as_non_null` even though `to.kind === "ref"` — this
+      // arm has always yielded a `ref_null` (nonNull: false), preserved exactly.
+      return guardedRefCastInstrs(fctx, toIdx, { tempType: from, nonNull: false });
     }
     return [{ op: "ref.cast", typeIdx: toIdx }];
   }

--- a/tests/issue-1917-guarded-ref-cast.test.ts
+++ b/tests/issue-1917-guarded-ref-cast.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1917 Stage A — regression smoke for the `guardedRefCastInstrs` extraction.
+ *
+ * The `local.tee → ref.test → if (ref.cast_null / ref.null)` guarded-downcast
+ * idiom was copy-pasted 11× across `coerceType` (7×) and `coercionInstrs` (4×)
+ * in type-coercion.ts; Stage A folds all 11 into one helper.
+ *
+ * The AUTHORITATIVE neutrality proof is a both-lane (gc host + standalone)
+ * Wasm-byte-SHA diff of the example corpus + targeted coercion snippets against
+ * origin/main (0 diffs across 62 real binaries) — this refactor emits
+ * byte-identical Wasm. These cases are a lightweight live-path smoke: two
+ * coercion-heavy programs that route through `coerceType`'s ref-conversion
+ * dispatch and are stable on `main`, so a gross breakage of that function would
+ * still surface here even though the guarded-cast trap arms themselves are
+ * exercised only by any→named-struct unboxing patterns that pre-existingly trap.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string, standalone: boolean): Promise<unknown> {
+  const r = await compile(src, standalone ? { fileName: "t.ts", target: "standalone" } : { fileName: "t.ts" });
+  expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+  const importObj = standalone ? {} : (r.importObject ?? {});
+  const { instance } = await WebAssembly.instantiate(r.binary, importObj as WebAssembly.Imports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+// Array → tuple guarded conversion on a destructuring param (coerceType's
+// struct-conversion dispatch); stable on both lanes.
+const vecToTuple = `export function test(): number {
+  function g([a, b]: [number, number]): number { return a + b; }
+  return g([3, 4] as [number, number]);
+}`;
+
+// any → native-string unbox from $AnyValue (externval field-4 path), standalone.
+const anyToStringLen = `export function test(): number {
+  const x: any = "abc";
+  const s: string = x;
+  return s.length;
+}`;
+
+describe("#1917 Stage A — guarded-cast extraction keeps coercion paths stable", () => {
+  it("array → tuple destructuring param (host)", async () => expect(await run(vecToTuple, false)).toBe(7));
+  it("array → tuple destructuring param (standalone)", async () => expect(await run(vecToTuple, true)).toBe(7));
+  it("any → native-string unbox length (standalone)", async () => expect(await run(anyToStringLen, true)).toBe(3));
+});


### PR DESCRIPTION
## #1917 Stage A — extract `guardedRefCastInstrs` (pure byte-neutral dedup)

The `local.tee → ref.test → if (ref.cast_null / ref.null)` guarded-downcast idiom
was copy-pasted **11×** in `src/codegen/type-coercion.ts`: 7× in `coerceType`
(any→object / any→native-string unbox, vec→tuple sibling guard, ref↔ref_null
diff-typeIdx) and 4× in `coercionInstrs` (externref/eqref/anyref → ref/ref_null).
This folds all 11 into one helper (net **−106 lines** in type-coercion.ts).

This is Stage A of the remaining #1917 work (the engine, `coercion-plan.ts`, and
the #2108 drift gate already landed — see the issue file's updated "Current state"
section). Stages B (`emitToPrimitive` façade) and C (gate seal) are separate PRs.

### Why a new helper (not the existing `emitGuardedRefCast`)

The existing `emitGuardedRefCast` differs on three points these 11 sites need, so
reusing it would change behaviour:
- it records `__lastGuardedCastBackup` (#792) — **none** of these 11 sites did;
- it hardcodes an `anyref` temp — these sites need `anyref` / `eqref` / the exact
  `from` type;
- it never appends `ref.as_non_null` — several of these sites do.

`guardedRefCastInstrs(fctx, toIdx, { tempType, nonNull })` returns the instruction
sequence; Instr[]-returning callers prepend their prefix and `return`, push-style
callers spread into `fctx.body`.

### Preserved exactly (byte-for-byte)

- the `coercionInstrs` externref→ref quirk (yields `ref_null`, `nonNull: false`, no
  trailing `ref.as_non_null` even for a `(ref)` target);
- Site G's #2161 native-string-target **conditional** `ref.as_non_null`, left in the
  caller (`nonNull: false`);
- each site's prefix (`any.convert_extern` / `struct.get`) and its non-`fctx` `else`
  fallback (bare `ref.cast` / `ref.cast_null`, which differs per arm).

### Neutrality proof (authoritative)

Both-lane (gc host + standalone) **Wasm-byte-SHA diff** over the example corpus +
targeted coercion snippets vs `origin/main`: **0 diffs across 62 real binaries**;
runtime-outcome identity on all probe cases. The helper is demonstrably on the live
compile path (any→object and any-typed call-arg both invoke it) and those outputs
are byte-identical to `origin/main`.

- `tsc --noEmit` clean
- `check:coercion-sites` (#2108) OK — no per-file vocabulary growth
- new `tests/issue-1917-guarded-ref-cast.test.ts` (3 cases) green
- the 2 pre-existing `call-arg-type-coercion` IR-fallback failures reproduce
  identically on `origin/main` (not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
