### PR TITLE
fix(#3579): default sort() on any/union-element array orders by ToString (host)

### DIFF
--- a/plan/issues/3579-default-sort-any-element-tostring.md
+++ b/plan/issues/3579-default-sort-any-element-tostring.md
@@ -15,6 +15,15 @@ language_feature: array-methods
 goal: builtin-methods
 umbrella: 3185
 related: [3185, 3201, 2502, 3251]
+# (#3102 LOC ratchet) The host ToString-sort fix adds the boxed-any stringify
+# arm to compileArrayDefaultToStringSort (array-methods.ts, +38) and the any/
+# union sort-import registration to the import-collector (+18) — both behavioral
+# arms in existing god-files, not a new subsystem. Grant this change-set the
+# allowance. NOTE: block list — the gate's parseFrontmatterList does not read a
+# multi-line flow array.
+loc-budget-allow:
+  - src/codegen/array-methods.ts
+  - src/codegen/declarations/import-collector.ts
 origin: "2026-07-24 #3201 measurement — contained default-sort slice split out of #3201"
 ---
 

--- a/plan/issues/3579-default-sort-any-element-tostring.md
+++ b/plan/issues/3579-default-sort-any-element-tostring.md
@@ -83,6 +83,10 @@ Two-part gap:
 
 ## Measured (default gc lane, fork-per-file)
 
+**Permanent conformance repro (#2093):**
+`test262/test/built-ins/Array/prototype/sort/S15.4.4.11_A2.1_T3.js` (the flipped
+file) + the regression guard `tests/issue-2502-sort-externref.test.ts`.
+
 - `built-ins/Array/prototype/sort`: **47→48… (dir 8→9 pass), +1 genuine flip
   `S15.4.4.11_A2.1_T3` (mixed `[-1, obj, 1, "X", …]` ToString sort), 0
   regressions.** (Other A2.* are comparator-path sorts — `.sort(cmp)` via

--- a/plan/issues/3579-default-sort-any-element-tostring.md
+++ b/plan/issues/3579-default-sort-any-element-tostring.md
@@ -28,6 +28,13 @@ loc-budget-allow:
 # branches to the import-collector's dispatch visitor. Grant the function.
 func-budget-allow:
   - src/codegen/declarations/import-collector.ts::unifiedVisitNode
+# (#2108 coercion-site drift) The host boxed-any sort stringify REUSES the
+# existing `__extern_toString` runtime ToString (the same primitive emitToString
+# wraps) — +1 hand-rolled coercion vocabulary in array-methods.ts, intentional
+# (calling the coercion-engine wrapper needs a ts.Type the oracle can't vend;
+# direct primitive reuse is the ratchet-clean path). Grant the file.
+coercion-sites-allow:
+  - src/codegen/array-methods.ts
 origin: "2026-07-24 #3201 measurement — contained default-sort slice split out of #3201"
 ---
 

--- a/plan/issues/3579-default-sort-any-element-tostring.md
+++ b/plan/issues/3579-default-sort-any-element-tostring.md
@@ -24,6 +24,10 @@ related: [3185, 3201, 2502, 3251]
 loc-budget-allow:
   - src/codegen/array-methods.ts
   - src/codegen/declarations/import-collector.ts
+# (#3400 R-FUNC per-function ceiling) The any/union sort-import arm adds two
+# branches to the import-collector's dispatch visitor. Grant the function.
+func-budget-allow:
+  - src/codegen/declarations/import-collector.ts::unifiedVisitNode
 origin: "2026-07-24 #3201 measurement — contained default-sort slice split out of #3201"
 ---
 

--- a/plan/issues/3579-default-sort-any-element-tostring.md
+++ b/plan/issues/3579-default-sort-any-element-tostring.md
@@ -1,0 +1,91 @@
+---
+id: 3579
+title: "default lane: Array.prototype.sort() on an any/union-element array no-ops (host ToString sort unregistered)"
+status: done
+completed: 2026-07-24
+assignee: ttraenkler/dev-opus-search
+created: 2026-07-24
+updated: 2026-07-24
+priority: medium
+feasibility: medium
+task_type: bug
+area: codegen
+es_edition: es5
+language_feature: array-methods
+goal: builtin-methods
+umbrella: 3185
+related: [3185, 3201, 2502, 3251]
+origin: "2026-07-24 #3201 measurement — contained default-sort slice split out of #3201"
+---
+
+# #3579 — default `sort()` on an `any`/union-element array silently no-op'd
+
+Contained slice split out of **#3201**. The default (no-comparator)
+`Array.prototype.sort()` on an **untyped / `any[]` / mixed-union** array
+compiled to a **no-op** (elements never reordered): `[10, 9, 1].sort()` on an
+untyped array returned `[10, 9, 1]` instead of the §23.1.3.30 ToString order
+`[1, 10, 9]`.
+
+## Root cause (host lane)
+
+Two-part gap:
+
+1. **`compileArrayDefaultToStringSort` never ran** — its `string_compare` host
+   import was resolved via `ctx.funcMap.get("string_compare")`, which is only
+   populated by the **import-collector pre-pass** for `number`/`boolean`/
+   `string` element `.sort()` (import-collector.ts). For an `any`/union element
+   the collector registered nothing → `compareIdx === undefined` → the helper
+   returned `null` → the caller no-op'd the sort (the #2502 externref-safety
+   no-op).
+2. **`stringifyTail` assumed a real string** — even had the compare been
+   registered, the host non-numeric branch emitted only `ref.as_non_null`, i.e.
+   it fed the RAW boxed element to `string_compare`, which cannot order boxed
+   numbers/undefined.
+
+## Fix (host lane only; standalone/native keeps its externref-bail no-op)
+
+- **import-collector.ts** — pre-register `string_compare` for a no-comparator
+  `.sort()` whose element type is `any`/`unknown`/union (the externref-boxing
+  cases). Gated by the existing `!ctx.nativeStrings` guard on the actual
+  `addImport`, and `compileArrayDefaultToStringSort` gates on the real
+  `externref` ValType, so a union that lowers to a ref simply no-ops (inert).
+- **array-methods.ts `compileArrayDefaultToStringSort`** — reuse the existing
+  runtime import `__extern_toString` (already used in this file for
+  `compileArrayJoinExtern`; the same primitive `emitToString`'s dynamic branch
+  wraps — needs **no `ts.Type`/checker query**, so it's oracle-ratchet-clean and
+  does not touch sdev-1917's #1917 coercion tree) to ToString each boxed element
+  before `string_compare`. The RAW (nullable) externref is passed straight to
+  `__extern_toString` (which handles `null`→"null") — a `new Array(N)` all-holes
+  array must NOT be `ref.as_non_null`'d (that traps the null holes — the #2502
+  regression the guard test caught). A safety bail returns `null` (no-op) for a
+  host ref/ref_null (struct) element that cannot flow into
+  `string_compare(externref, externref)`.
+
+## Measured (default gc lane, fork-per-file)
+
+- `built-ins/Array/prototype/sort`: **47→48… (dir 8→9 pass), +1 genuine flip
+  `S15.4.4.11_A2.1_T3` (mixed `[-1, obj, 1, "X", …]` ToString sort), 0
+  regressions.** (Other A2.* are comparator-path sorts — `.sort(cmp)` via
+  `tryCompileComparatorSort`, not this default path; A1.1/A1.2 are the
+  hole-read substrate #3251/#2001; A1.4 needs the undefined-read substrate — all
+  out of scope here per measurement, not the ~4 I first extrapolated.)
+- Broader latent value: **every** untyped-array `.sort()` now orders instead of
+  silently no-op'ing (a real correctness fix beyond the single test262 flip).
+
+## Guard
+
+- Full sort test262 dir: +1 / 0 regressions.
+- `issue-2502-sort-externref` 8/8 (the all-holes `new Array(N).sort()` trap
+  regression was caught and fixed here), `issue-2379-standalone-sort-rep`,
+  `issue-3201-sort-includes`, `issue-1589-tosorted-hang`: 28/28.
+- array-methods / array-prototype-methods / functional-array-methods: 59/59.
+- The 14 array-capacity/fast-arrays/arrays-enums fails are **pre-existing on
+  origin/main** (verified with the change reverted), unrelated.
+- tsc clean.
+
+## Standalone note (dual-mode)
+
+`__extern_toString` is an existing HOST import (zero new imports). Standalone/
+native mode keeps its pre-existing externref-bail no-op for `any`-element sorts
+— a pre-existing gap tracked under the value-rep substrate (#3251/#2379), NOT a
+regression introduced here.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -6816,6 +6816,14 @@ function compileArrayDefaultToStringSort(
 ): ValType | null {
   const isNumeric = elemType.kind === "f64" || elemType.kind === "i32";
   const native = ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0;
+  // (#3579) HOST default sort only supports numeric or externref (boxed-any /
+  // js-string) elements. A ref/ref_null (struct) element cannot flow into the
+  // `string_compare(externref, externref)` host import, so bail to the caller's
+  // no-op rather than emit an invalid `string_compare(ref struct, …)`. (Native
+  // mode already bailed above for the externref case.)
+  if (!native && !isNumeric && elemType.kind !== "externref") {
+    return null;
+  }
 
   // #2379 — in NATIVE-string mode this ToString sort's non-numeric branch
   // `ref.cast`s each `array.get` element to `$AnyString` (see `stringifyTail`),
@@ -6839,6 +6847,18 @@ function compileArrayDefaultToStringSort(
   let compareIdx: number | undefined;
   let numToStrIdx: number | undefined;
   let anyStrTypeIdx = -1;
+  // (#3579) HOST mode, non-numeric (boxed-`any`/externref element) branch: the
+  // element must be ToString'd via the runtime `__extern_toString` before the
+  // string comparison. Previously `stringifyTail` assumed the element was ALREADY
+  // a string (`ref.as_non_null` only) — true for `string[]` but NOT for an
+  // `any[]` whose elements are boxed numbers/undefined, so `string_compare` on
+  // raw boxed values could not order them and the default sort silently no-op'd
+  // (`[10,9,1].sort()` on an untyped array stayed unordered). `__extern_toString`
+  // is the SAME runtime primitive `emitToString`'s dynamic branch wraps and is
+  // already used directly in this file (compileArrayJoinExtern); reusing it needs
+  // no `ts.Type`/checker query. Ensured BEFORE the `string_compare` funcMap lookup
+  // so the captured `compareIdx` reflects any import-insertion index shift.
+  let externToStrIdx: number | undefined;
   if (native) {
     ensureNativeStringHelpers(ctx);
     anyStrTypeIdx = ctx.anyStrTypeIdx;
@@ -6849,8 +6869,13 @@ function compileArrayDefaultToStringSort(
       numToStrIdx = ctx.funcMap.get("number_toString");
     }
   } else {
-    compareIdx = ctx.funcMap.get("string_compare");
     cmpStrType = { kind: "externref" };
+    if (!isNumeric) {
+      externToStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+      if (externToStrIdx === undefined) return null;
+    }
+    compareIdx = ctx.funcMap.get("string_compare");
     if (isNumeric) numToStrIdx = ctx.funcMap.get("number_toString");
   }
   if (compareIdx === undefined || (isNumeric && numToStrIdx === undefined)) {
@@ -6888,6 +6913,19 @@ function compileArrayDefaultToStringSort(
   // Stringify an element value (already on the stack as elemType) to cmpStrType.
   const stringifyTail = (): Instr[] => {
     if (!isNumeric) {
+      if (!native && externToStrIdx !== undefined && elemType.kind === "externref") {
+        // (#3579) HOST boxed-`any`/string element → runtime ToString before the
+        // string comparison. A real string passes through (`ToString(str)===str`);
+        // a boxed number/undefined is stringified ("10"/"undefined"), so an
+        // untyped-array default sort orders by ToString per §23.1.3.30 instead of
+        // no-op'ing. Pass the RAW (nullable) externref straight to
+        // `__extern_toString` — it handles null (`String(null)`→"null"), so a
+        // `new Array(N)` all-holes array must NOT be `ref.as_non_null`'d first
+        // (that traps on the null holes; #2502 regression). Only the externref
+        // (boxed-any) element kind is retargeted — every other kind keeps its
+        // exact prior lowering (no regression surface).
+        return [{ op: "call", funcIdx: externToStrIdx }];
+      }
       // String element: ensure non-null, and (native) cast NativeString → AnyString.
       const out: Instr[] = [{ op: "ref.as_non_null" }];
       if (native) out.push({ op: "ref.cast", typeIdx: anyStrTypeIdx });

--- a/src/codegen/declarations/import-collector.ts
+++ b/src/codegen/declarations/import-collector.ts
@@ -325,6 +325,24 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
           state.primitiveNeeded.add("string_compare");
         } else if (elemType && isStringType(elemType)) {
           state.primitiveNeeded.add("string_compare");
+        } else if (elemType && (elemType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) {
+          // (#3579) `any`/`unknown` element → boxed externref. The default sort
+          // ToStrings each element via the runtime `__extern_toString` then
+          // compares with `string_compare` (§23.1.3.30). Pre-register the compare
+          // import here so `compileArrayDefaultToStringSort` finds it (else it
+          // returns null and the sort silently no-ops — `[10,9,1].sort()` on an
+          // untyped array stayed unordered). HOST lane only; native/standalone
+          // keeps its externref-bail no-op (a pre-existing gap, unchanged here).
+          state.primitiveNeeded.add("string_compare");
+        } else if (elemType && elemType.isUnion()) {
+          // (#3579) A mixed union element (e.g. `(number|string|undefined)[]`,
+          // the `[-1, obj, 1, "X", …]` shape) also boxes to externref on the host
+          // lane → same ToString+compare path. `string_compare` is only actually
+          // imported when `!ctx.nativeStrings` (see the addImport gate below), and
+          // `compileArrayDefaultToStringSort` gates on the real `externref` ValType,
+          // so a union that lowers to a ref (unreached today) simply no-ops —
+          // registering the import is inert in every other lane.
+          state.primitiveNeeded.add("string_compare");
         }
       }
     }


### PR DESCRIPTION
## Summary
Contained default-sort slice split out of **#3201**. The default (no-comparator) `Array.prototype.sort()` on an **untyped / `any[]` / mixed-union** array silently **no-op'd** — `[10,9,1].sort()` on an untyped array returned `[10,9,1]` instead of the §23.1.3.30 ToString order `[1,10,9]`.

## Root cause (host lane)
1. `compileArrayDefaultToStringSort` never ran — its `string_compare` host import is populated by the **import-collector pre-pass**, which only registered it for number/boolean/string element sorts. For an `any`/union element → `compareIdx === undefined` → helper returns `null` → caller no-op'd.
2. `stringifyTail` fed the RAW boxed element to `string_compare`, which cannot order boxed numbers/undefined.

## Fix (host only; standalone/native keeps its externref-bail no-op)
- **import-collector.ts** — pre-register `string_compare` for `any`/`unknown`/union element no-comparator sorts (actual `addImport` still gated on `!nativeStrings`; codegen gates on the real `externref` ValType so a ref-lowering union stays an inert no-op).
- **array-methods.ts `compileArrayDefaultToStringSort`** — reuse the existing `__extern_toString` runtime import (already used in this file; **no `ts.Type`/checker query** → oracle-ratchet-clean, no #1917 coercion-tree touch) to ToString each boxed element before compare. Pass the RAW nullable externref (handles `null` holes as "null") — do **not** `ref.as_non_null` (that traps `new Array(N)` all-holes; the #2502 case). Safety bail to no-op for a host ref/ref_null (struct) element.

## Measured (default gc lane, fork-per-file)
- `built-ins/Array/prototype/sort`: **+1 flip (`S15.4.4.11_A2.1_T3`, mixed `[-1, obj, 1, "X", …]` ToString sort), 0 regressions.** (Other A2.* are comparator-path sorts; A1.1/A1.2 are the hole-read substrate #3251/#2001; A1.4 needs the undefined-read substrate — measured out of scope, not the ~4 first extrapolated.)
- Broad latent value: **every** untyped-array `.sort()` now orders instead of no-op'ing.

## Guard (shared default-sort path)
- Full sort test262 dir: +1 / 0 regressions.
- `issue-2502-sort-externref` **8/8** (caught + fixed an all-holes `new Array(N).sort()` trap regression), + `issue-2379-standalone-sort-rep`, `issue-3201-sort-includes`, `issue-1589-tosorted-hang`: **28/28**.
- array-methods / array-prototype-methods / functional-array-methods: **59/59**.
- The 14 array-capacity/fast-arrays/arrays-enums fails are **pre-existing on origin/main** (verified with the change reverted), unrelated.
- tsc clean.

## Standalone (dual-mode)
`__extern_toString` is an existing HOST import (zero new). Standalone/native keeps its pre-existing externref-bail no-op for `any`-element sorts — a pre-existing gap tracked under the value-rep substrate (#3251/#2379), NOT a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)