### PR TITLE
fix(#3340): keep inverted expected-failure sentinels out of the root baseline

### DIFF
--- a/plan/issues/3340-issue-tests-unexpected-pass-baseline.md
+++ b/plan/issues/3340-issue-tests-unexpected-pass-baseline.md
@@ -1,9 +1,11 @@
 ---
 id: 3340
 title: "issue-tests: keep inverted expected-failure sentinels out of the root baseline"
-status: ready
+status: done
+completed: 2026-07-24
+assignee: ttraenkler/dev-opus-search
 created: 2026-07-17
-updated: 2026-07-17
+updated: 2026-07-24
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -162,3 +164,44 @@ improvements from regressions.
   pass and a genuine failure; inspect the partial JSON and merged report.
 - Validate the baseline diff against the current external baseline and confirm
   exactly the three stale IDs are removed by this slice.
+
+## Progress — LANDED (dev-opus-search, 2026-07-24)
+
+Unmasked the 3 stale inverted sentinels + built the durable gate-level
+distinction (per lead: the durable part is the gate, not just the unmask).
+
+**Unmask (the 3 banked improvements now assert CORRECT behavior):**
+- `tests/issue-2143-validate-unoptimized.test.ts` — `array/02-push-pop.js` +
+  `control/12-for-in-object.js` moved from `KNOWN_MALFORMED` (asserting
+  `validate === false`) to `NOW_VALID` positive guards (compile + validate). The
+  malformed-set is now empty with a one-way-ratchet comment; the #2143 detection
+  mechanism stays.
+- `tests/real-world-wasi.test.ts` — the `reads process.argv` `it.fails` (now an
+  unexpected pass: the native-string codegen defect that made it emit an invalid
+  binary is fixed) → a positive validity guard. Runtime argv semantics remain
+  and are pointed at **#3337** (validity only asserted here).
+
+**Durable gate (`scripts/issue-tests-gate.mjs`):** a new `unexpectedPasses`
+classification — an `it.fails` whose body passes (vitest status "failed" +
+"Expect test to fail") is split OUT of `failing` into `unexpectedPasses`, which
+(a) is never seeded into `knownFailures` (bootstrap/`--update`) and (b) hard-
+fails the run BEFORE any baseline write, forcing promotion. Threaded through the
+shard partial artifact + `mergePartials` so sharded runs preserve it.
+
+**Fixture:** `tests/issue-3340.test.ts` (3/3) drives the gate CLI in merge mode:
+unexpected-pass → exit 1 + `UNEXPECTED PASS` (never baselined); ordinary
+baselined failure → exit 0 (control); genuine new regression → exit 1 +
+`REGRESSION` (gate not weakened).
+
+**Baseline:** the 3 stale IDs ratchet out post-merge — the converted tests no
+longer fail, so the post-merge `--update` (full-rewrite from current `failing`)
+drops them; they can never be re-absorbed because an inverted sentinel now
+hard-fails.
+
+**Deferred (noted, not blocking):** the optional static "policy check" (approach
+step 6 — reject a NEW positive fixture asserting valid source must fail
+`WebAssembly.validate`, exempting encoder-negative tests) is a secondary
+write-time guard on top of the runtime `unexpectedPasses` gate; left as a
+follow-up since the runtime gate already catches the class at maintenance time.
+
+**Validated:** issue-2143 3/3, real-world-wasi 7/7, issue-3340 3/3; tsc clean.

--- a/scripts/issue-tests-gate.mjs
+++ b/scripts/issue-tests-gate.mjs
@@ -141,6 +141,16 @@ function runVitest() {
   const report = JSON.parse(readFileSync(outFile, "utf8"));
   const failing = new Set();
   const passing = new Set();
+  // (#3340) An `it.fails` test whose body UNEXPECTEDLY PASSES is reported by
+  // vitest with status "failed" + a "Expect test to fail" message. Left in
+  // `failing`, such an inverted sentinel is silently absorbed into the baseline
+  // (knownFailures) as accepted rot — main stays green while the test demands
+  // obsolete bad behavior, masking the real improvement that made it pass. Split
+  // these into a distinct `unexpectedPasses` set: NEVER seeded into the baseline,
+  // and a hard gate failure (the test must be promoted, i.e. its `.fails`
+  // removed / its assertion corrected — not absorbed).
+  const unexpectedPasses = new Set();
+  const isUnexpectedPass = (a) => (a.failureMessages || []).some((m) => /Expect test to fail/i.test(m));
   for (const file of report.testResults || []) {
     const rel = relName(file.name);
     const asserts = file.assertionResults || [];
@@ -152,37 +162,67 @@ function runVitest() {
     }
     for (const a of asserts) {
       const id = testId(rel, a.fullName || a.title);
-      if (a.status === "failed") failing.add(id);
-      else if (a.status === "passed") passing.add(id);
+      if (a.status === "failed") {
+        if (isUnexpectedPass(a)) unexpectedPasses.add(id);
+        else failing.add(id);
+      } else if (a.status === "passed") passing.add(id);
     }
   }
-  return { failing, passing };
+  return { failing, passing, unexpectedPasses };
 }
 
 function mergePartials(dir) {
   const failing = new Set();
   const passing = new Set();
+  const unexpectedPasses = new Set();
   for (const f of readdirSync(dir)) {
     if (!f.endsWith(".json")) continue;
     const p = JSON.parse(readFileSync(join(dir, f), "utf8"));
     for (const id of p.failing || []) failing.add(id);
     for (const id of p.passing || []) passing.add(id);
+    // (#3340) Preserve the inverted-sentinel classification across shard merge.
+    for (const id of p.unexpectedPasses || []) unexpectedPasses.add(id);
   }
-  return { failing, passing };
+  return { failing, passing, unexpectedPasses };
 }
 
-const { failing, passing } = MERGE_DIR ? mergePartials(MERGE_DIR) : runVitest();
+const { failing, passing, unexpectedPasses } = MERGE_DIR ? mergePartials(MERGE_DIR) : runVitest();
 
 // Shard mode: emit a partial artifact and exit 0 — the merge job gates.
 if (SHARD && !MERGE_DIR && !UPDATE && !RATCHET) {
   const partialPath = process.env.PARTIAL_OUT || join(REPO_ROOT, `issue-tests-partial-${SHARD.replace("/", "-")}.json`);
-  writeFileSync(partialPath, JSON.stringify({ failing: [...failing], passing: [...passing] }, null, 2));
-  console.log(`issue-tests-gate: wrote partial ${partialPath} (${failing.size} fail / ${passing.size} pass)`);
+  writeFileSync(
+    partialPath,
+    JSON.stringify({ failing: [...failing], passing: [...passing], unexpectedPasses: [...unexpectedPasses] }, null, 2),
+  );
+  console.log(
+    `issue-tests-gate: wrote partial ${partialPath} (${failing.size} fail / ${passing.size} pass / ${unexpectedPasses.size} unexpected-pass)`,
+  );
   process.exit(0);
 }
 
 function writeBaseline(knownFailures) {
   writeFileSync(BASELINE_PATH, JSON.stringify({ knownFailures: [...knownFailures].sort() }, null, 2) + "\n");
+}
+
+// (#3340) Inverted-sentinel gate — runs in EVERY non-shard mode (normal gate,
+// --update, bootstrap) BEFORE any baseline write. An `it.fails` test whose body
+// unexpectedly passes is a stale sentinel demanding obsolete bad behavior; it
+// must be PROMOTED (remove `.fails` / correct the assertion), never absorbed.
+// `unexpectedPasses` is disjoint from `failing`, so it can never be seeded into
+// knownFailures; exiting here additionally refuses to (re)bank a baseline while
+// an inverted sentinel is unaddressed, forcing the promotion.
+if (unexpectedPasses.size) {
+  console.error(
+    `\n✗ ${unexpectedPasses.size} UNEXPECTED PASS (stale inverted sentinel — an it.fails test now passes):`,
+  );
+  for (const id of [...unexpectedPasses].sort()) console.error(`    UNEXPECTED PASS: ${id}`);
+  console.error(
+    "\nA real improvement made a `.fails` test pass. PROMOTE it — remove `.fails` and assert the now-correct" +
+      " behavior (or re-characterize the remaining gap under its own issue). Do NOT let the baseline absorb it as" +
+      " accepted rot (#3340).",
+  );
+  process.exit(1);
 }
 
 if (UPDATE) {

--- a/tests/issue-2143-validate-unoptimized.test.ts
+++ b/tests/issue-2143-validate-unoptimized.test.ts
@@ -12,10 +12,23 @@
  * (`scripts/diff-test-gate.ts`) then fails CI loudly if any corpus program
  * regresses from `match` to `malformed_wasm`.
  *
- * This test pins the two known invalid-unoptimized corpus programs (#1941's
- * corpus work) so the detection can't silently regress. If a future fix makes
- * one of these validate cleanly, this test will flag it — move the now-valid
- * program out of `KNOWN_MALFORMED` (ratchet direction).
+ * This test pins the #2143 corpus programs so the detection can't silently
+ * regress. The ratchet direction is one-way: once a fix makes a formerly-
+ * malformed program validate cleanly, it moves OUT of `KNOWN_MALFORMED` into
+ * `NOW_VALID` (a positive compile-and-validate guard) — it must NEVER go back
+ * to asserting the old bad behavior.
+ *
+ * (#3340) `array/02-push-pop.js` and `control/12-for-in-object.js` — formerly
+ * `KNOWN_MALFORMED` — now compile AND validate on current main (a real compiler
+ * improvement). Left asserting `validate === false`, they were stale INVERTED
+ * sentinels: the improvement made them FAIL, and the root issue-tests baseline
+ * silently absorbed those failures as accepted rot, so main stayed green while
+ * the tests demanded obsolete malformed output. They are now positive guards.
+ * `KNOWN_MALFORMED` is intentionally empty — the #2143 detection mechanism
+ * (`scripts/diff-test.ts` malformed_wasm classification + the per-file delta
+ * gate) stays; there is simply no unintentionally-malformed corpus program
+ * left to pin. A genuine future regression to `malformed_wasm` is caught by the
+ * delta gate, and a NEW malformed corpus program would be added back here.
  */
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -24,31 +37,37 @@ import { compile } from "../src/index.js";
 
 const CORPUS_DIR = resolve(import.meta.dirname, "differential", "corpus");
 
-// Programs that compile (`success: true`) but whose DEFAULT-pipeline binary
-// fails WebAssembly.validate — the malformed-wasm class #2143 makes visible.
-const KNOWN_MALFORMED = ["array/02-push-pop.js", "control/12-for-in-object.js"];
+// (#3340) Formerly-malformed programs that now compile AND validate — a
+// one-way ratchet out of the malformed set. Asserting validity here means a
+// regression that re-breaks them fails loudly instead of being re-absorbed.
+const NOW_VALID = ["array/02-push-pop.js", "control/12-for-in-object.js"];
+
+// Unintentionally-malformed default-pipeline corpus programs (compile
+// `success: true` but fail WebAssembly.validate). Currently empty: the #2143
+// detection still runs, but no corpus program triggers it. Add a program here
+// ONLY for a genuinely-malformed default binary — never to re-pin a fixed one.
+const KNOWN_MALFORMED: string[] = [];
 
 // A representative valid program: must compile AND validate (guards against the
 // detection over-firing / a regression breaking a clean program).
 const KNOWN_VALID = "numeric/01-basic-arithmetic.js";
 
 describe("#2143 — default-pipeline Wasm validation", () => {
+  for (const rel of [KNOWN_VALID, ...NOW_VALID]) {
+    it(`${rel}: compiles success:true AND its default binary validates`, async () => {
+      const src = readFileSync(resolve(CORPUS_DIR, rel), "utf-8");
+      const r = await compile(src, { fileName: rel });
+      expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+      expect(WebAssembly.validate(r.binary)).toBe(true);
+    });
+  }
+
   for (const rel of KNOWN_MALFORMED) {
     it(`${rel}: compiles success:true but the default binary fails WebAssembly.validate`, async () => {
       const src = readFileSync(resolve(CORPUS_DIR, rel), "utf-8");
       const r = await compile(src, { fileName: rel });
-      // The whole point of #2143: `success` is NOT a sufficient signal of a
-      // valid binary. (If `success` ever becomes false here the program now
-      // hard-errors — also acceptable, but then update this list.)
       expect(r.success).toBe(true);
       expect(WebAssembly.validate(r.binary)).toBe(false);
     });
   }
-
-  it(`${KNOWN_VALID}: a clean program still compiles AND validates (detection isn't over-eager)`, async () => {
-    const src = readFileSync(resolve(CORPUS_DIR, KNOWN_VALID), "utf-8");
-    const r = await compile(src, { fileName: KNOWN_VALID });
-    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
-    expect(WebAssembly.validate(r.binary)).toBe(true);
-  });
 });

--- a/tests/issue-3340.test.ts
+++ b/tests/issue-3340.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3340 — the root issue-tests gate must keep INVERTED expected-failure
+ * sentinels out of the baseline. An `it.fails` test whose body unexpectedly
+ * PASSES (vitest: status "failed" + "Expect test to fail") is a stale sentinel
+ * demanding obsolete bad behavior; left in the `failing` set it is silently
+ * absorbed into `knownFailures`, so main stays green while a real improvement is
+ * masked. `scripts/issue-tests-gate.mjs` now splits these into a distinct
+ * `unexpectedPasses` set that (a) is NEVER seeded into the baseline and (b) hard-
+ * fails the run so the test must be promoted.
+ *
+ * This exercises the gate CLI directly via its merge-mode env contract
+ * (MERGE_PARTIALS_DIR): a partial carrying an `unexpectedPasses` id must fail
+ * with UNEXPECTED PASS, while an ordinary baselined failure still passes.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const GATE = resolve(import.meta.dirname, "..", "scripts", "issue-tests-gate.mjs");
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "issue-3340-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+function runGate(partial: Record<string, string[]>, baseline: { knownFailures: string[] }) {
+  const mergeDir = mkTmp();
+  writeFileSync(join(mergeDir, "partial-1.json"), JSON.stringify(partial));
+  const baselinePath = join(mkTmp(), "baseline.json");
+  writeFileSync(baselinePath, JSON.stringify(baseline));
+  return spawnSync(process.execPath, [GATE], {
+    encoding: "utf8",
+    env: { ...process.env, MERGE_PARTIALS_DIR: mergeDir, ISSUE_TESTS_BASELINE: baselinePath },
+  });
+}
+
+describe("#3340 — inverted-sentinel (unexpected-pass) gate", () => {
+  it("hard-fails on an unexpected-pass id and never seeds it into the baseline", () => {
+    const r = runGate(
+      { failing: [], passing: [], unexpectedPasses: ["tests/foo.test.ts :: foo does the thing"] },
+      { knownFailures: [] },
+    );
+    expect(r.status).toBe(1);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/UNEXPECTED PASS/);
+    expect(`${r.stdout}${r.stderr}`).toContain("tests/foo.test.ts :: foo does the thing");
+  });
+
+  it("does NOT trip on an ordinary baselined failure (control — real known failure still accepted)", () => {
+    const id = "tests/bar.test.ts :: bar known-broken";
+    const r = runGate({ failing: [id], passing: [], unexpectedPasses: [] }, { knownFailures: [id] });
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(/UNEXPECTED PASS/);
+  });
+
+  it("still flags a genuine NEW regression (control — gate not weakened)", () => {
+    const r = runGate(
+      { failing: ["tests/baz.test.ts :: baz newly broke"], passing: [], unexpectedPasses: [] },
+      { knownFailures: [] },
+    );
+    expect(r.status).toBe(1);
+    expect(`${r.stdout}${r.stderr}`).toMatch(/REGRESSION/);
+  });
+});

--- a/tests/real-world-wasi.test.ts
+++ b/tests/real-world-wasi.test.ts
@@ -36,14 +36,17 @@ describe("real-world: WASI command-line programs", () => {
     expect(WebAssembly.validate(result.binary)).toBe(true);
   });
 
-  // KNOWN BUG (pre-existing, unrelated to #1801): `process.argv.length` under
-  // --target wasi reports success but emits an invalid binary — instantiation
-  // fails in `__str_flatten` with "call[1] expected type (ref null 5), found
-  // i32.const of type i32" (a native-string codegen type mismatch, NOT the
-  // process.exit i32/f64 defect fixed here). This was already red on main;
-  // `it.fails` documents it and keeps the suite green until the native-string
-  // argv path is fixed under its own issue, at which point remove `.fails`.
-  it.fails("reads process.argv as a valid WASI module", async () => {
+  // (#3340) Formerly an `it.fails` documenting a native-string codegen defect
+  // that made a `process.argv.length` WASI program emit an INVALID binary
+  // (instantiation failed in `__str_flatten`). That codegen defect is FIXED on
+  // current main — the binary now compiles AND validates — so the `it.fails`
+  // was a stale inverted sentinel: the improvement made the test "unexpectedly
+  // pass", which the root issue-tests baseline absorbed as accepted rot. This is
+  // now a positive validity guard. NOTE: only the binary VALIDITY is asserted
+  // here; the actual `process.argv` RUNTIME semantics (reading real command-line
+  // args) is still missing and is tracked separately under #3337 — do NOT assert
+  // runtime argv behavior here.
+  it("compiles process.argv under --target wasi to a valid module (validity only; runtime argv → #3337)", async () => {
     const result = await compile(
       `
         declare const process: { argv: string[] };


### PR DESCRIPTION
## Summary
The root issue-tests gate classified every failed vitest assertion as an ordinary known failure, so an `it.fails` test whose body UNEXPECTEDLY PASSES (a real improvement) was silently absorbed into `knownFailures` — main stayed green while the test demanded obsolete bad behavior. Three banked improvements were masked this way (measured, reproduces on current main).

## Unmask (sentinels now assert CORRECT behavior)
- **`tests/issue-2143-validate-unoptimized.test.ts`** — `array/02-push-pop.js` + `control/12-for-in-object.js` moved from `KNOWN_MALFORMED` (asserting `WebAssembly.validate === false`) to `NOW_VALID` positive guards: both now compile AND validate. The #2143 malformed-detection mechanism stays; the malformed-set is now empty with a one-way-ratchet comment.
- **`tests/real-world-wasi.test.ts`** — the `process.argv` `it.fails` (now an unexpected pass: the native-string codegen defect that made it emit an invalid binary is fixed) → a positive validity guard. Runtime argv semantics remain and point at **#3337** (validity only asserted here).

## Durable gate (`scripts/issue-tests-gate.mjs`) — the part that prevents recurrence
A new `unexpectedPasses` classification: an `it.fails` whose body passes (vitest status `failed` + `Expect test to fail`) is split OUT of `failing` into a distinct set that (a) is **never** seeded into `knownFailures` (bootstrap/`--update`) and (b) **hard-fails** the run BEFORE any baseline write — forcing the test to be promoted, not absorbed. Threaded through the shard partial artifact + `mergePartials` so sharded runs preserve it.

## Fixture — `tests/issue-3340.test.ts` (3/3)
Drives the gate CLI in merge mode: unexpected-pass → exit 1 + `UNEXPECTED PASS` (never baselined); ordinary baselined failure → exit 0 (control); genuine new regression → exit 1 + `REGRESSION` (gate not weakened).

## Validation
issue-2143 **3/3**, real-world-wasi **7/7**, issue-3340 **3/3**, tsc clean. The 3 stale baseline IDs ratchet out post-merge (converted tests no longer fail; the post-merge `--update` full-rewrite drops them, and they can never be re-absorbed).

Deferred (noted in the issue, not blocking): the optional static write-time "policy check" (reject a NEW positive fixture asserting valid source must fail validate) — a secondary guard on top of the runtime `unexpectedPasses` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)