### PR TITLE
fix(#3576): nested rest-param tag functions — register funcRestParams + push tdz-flag captures

### DIFF
--- a/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
+++ b/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
@@ -1,11 +1,12 @@
 ---
 id: 3576
 title: "deepEqual.js `format` closure fails Wasm validation — call_ref arity mismatch (need 4, got 3)"
-status: in-progress
+status: done
 assignee: ttraenkler/sdev-3576
 sprint: current
 created: 2026-07-24
 updated: 2026-07-24
+completed: 2026-07-24
 priority: high
 feasibility: hard
 model: opus

--- a/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
+++ b/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
@@ -24,6 +24,11 @@ related: [3378, 3559, 3560, 3563, 2873, 2043]
 loc-budget-allow:
   - src/codegen/string-ops.ts
   - src/codegen/statements/nested-declarations.ts
+# (#3400 / R-FUNC) Same rationale as loc-budget-allow: the added arity/rest-param
+# handling lives inside these two functions by construction.
+func-budget-allow:
+  - src/codegen/string-ops.ts::compileTaggedTemplateExpression
+  - src/codegen/statements/nested-declarations.ts::compileNestedFunctionDeclaration
 ---
 
 # #3576 — `deepEqual.js` `format` closure: `call_ref` arity mismatch (need 4, got 3)

--- a/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
+++ b/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
@@ -1,8 +1,8 @@
 ---
 id: 3576
 title: "deepEqual.js `format` closure fails Wasm validation — call_ref arity mismatch (need 4, got 3)"
-status: ready
-assignee: ttraenkler/dev-opus-arrayhof
+status: in-progress
+assignee: ttraenkler/sdev-3576
 sprint: current
 created: 2026-07-24
 updated: 2026-07-24
@@ -12,10 +12,9 @@ model: opus
 horizon: l
 reasoning_effort: high
 task_type: bugfix
-area: codegen, closures, array-methods, emit
+area: codegen, closures, string-ops, nested-declarations
 language_feature: compiler-internals
 goal: test262-conformance
-blocked-on: "REPRODUCE needs #3559 (#3378 stale-local fix — on plain main the #3378 RangeError aborts before the arity error is reached); EDIT of array-methods.ts needs #3560 landed. Both in the merge queue 2026-07-24. Do repro→WAT-trace→pad→verify→PR in ONE clean pass on main once both land."
 related: [3378, 3559, 3560, 3563, 2873, 2043]
 ---
 
@@ -197,3 +196,75 @@ land** (don't predecessor-stack at low budget).
   binary); update #3378 accordingly.
 - No regression in the JS-host test262 pass rate; validate on the full
   equivalence suite (broad closure/array-method codegen surface).
+
+## RESOLUTION — verified mechanism + fix (sdev-3576, 2026-07-24)
+
+**dev-c-1's read-only writeup above (buildClosureCallInstrs / array-callback
+trampoline / shared canonical wrapper) is DISPROVEN by measurement.** Once the
+repro was runnable (post #3559), instrumenting `buildClosureCallInstrs` showed
+all 4 array-callback dispatches in `__closure_6` are consistent
+(`funcArity=2, numParams=1, pushed=2`) — the failing `call_ref` is NOT an
+array-method callback at all. The real mechanism, WAT-traced + instrument-
+confirmed:
+
+### Root cause — tagged-template call to a nested REST function
+
+`__closure_6` is `assert.deepEqual.format`. Its body calls the nested function
+`lazyResult(strings, ...subs)` as a **tagged template** (`lazyResult`...``) at
+9 sites with VARYING substitution counts (1 sub at lines 106/110/113/…, 2 subs
+at 119/138). `lazyResult` has a rest param `...subs` AND a TDZ-flagged capture
+(`usage`, a `let`). Its lifted wasm signature is 4 params:
+`[usageVal, usageTdzFlag, strings, subsVec]`.
+
+Two independent gaps made the tagged-template call under-push the stack:
+
+1. **`nested-declarations.ts` never registered the rest param in
+   `ctx.funcRestParams`** (the top-level `declarations.ts:801` path does; the
+   nested path was missing the `dotDotDotToken` arm). So `restInfo` was absent
+   and the tagged-template dispatch treated the single `subsVec` param as
+   positional sub slots — dropping the vec-packing and under-arity-ing.
+2. **`string-ops.ts` tagged-template KNOWN-FUNC dispatch** pushed only the VALUE
+   captures (never the TDZ-flag boxes) and computed `captureCount` as the value
+   count only — so `strings`/substitutions landed at the wrong wasm slots and
+   the TDZ-flag param was never supplied. → `call ... need 4, got 3`.
+
+The naive "pad-to-arity" candidate from the writeup is **semantically wrong
+here**: padding the `subsVec` slot with `undefined` produces a valid binary that
+silently renders a spurious trailing element in `subs`.
+
+### Fix (3 coupled parts)
+
+- `src/codegen/statements/nested-declarations.ts` — add the `dotDotDotToken`
+  arm to the param loop: lower `...args` to one `(ref null $vec)` param **and**
+  register it in `ctx.funcRestParams` (mirrors `declarations.ts`).
+- `src/codegen/string-ops.ts` KNOWN-FUNC tagged-template path — push the boxed
+  TDZ-flag capture refs after the value captures (minimal replication of
+  `call-identifier.ts`, gated on `tdzFlaggedNested.length > 0` so the common
+  no-TDZ tag stays byte-inert), set `captureCount = values + tdzFlags`, and
+  offset `strings` / positional-subs / rest-packing by that captureCount.
+
+### Verification (measured, not extrapolated)
+
+- `stub-assert + deepEqual.js` repro → `WebAssembly.compile` **OK** (arity error
+  gone). ✓ (primary acceptance criterion)
+- Isolation battery (`.tmp`): nested rest tag with no / const / let(TDZ) capture
+  all render byte-correct vs node; **direct** calls to nested rest functions
+  (`f("p",1,2,3)`) now render correctly — these were **BROKEN on `main`**
+  (`undefined` / null-deref), so the fix is a strict improvement across the
+  whole nested-rest-function surface, not just deepEqual.
+- Equivalence suite (changed paths: tagged templates, rest params, closures,
+  array callbacks, nested recursion): no NEW failures. The 2 failures observed
+  (`optional-direct-closure-call`, an unrelated `?.()` IR-slice-11 fallback)
+  reproduce identically on `main` — pre-existing, not this change.
+
+### Known-orthogonal follow-up (NOT #3576, pre-existing on main)
+
+A nested rest tag whose BODY uses the rest param as an ARRAY (`subs.map(...)` /
+`subs[i]`) — as `lazyResult`'s `acceptMappers` does — mis-reads the tagged-
+template `strings` param (a template-object struct coerced to externref):
+`strings.join(...)` returns `undefined`. This reproduces on `main` too (worse:
+null-deref), is independent of the arity fix (direct calls with `.map` render
+correctly — only the tagged-template-strings path is affected), and blocks the
+full runtime RENDERING of `format`. It does not affect the #3576 acceptance
+criterion (validation). Carve a separate issue for the template-struct /
+late-import interaction.

--- a/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
+++ b/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
@@ -16,6 +16,14 @@ area: codegen, closures, string-ops, nested-declarations
 language_feature: compiler-internals
 goal: test262-conformance
 related: [3378, 3559, 3560, 3563, 2873, 2043]
+# (#3102/#3131) The fix adds logic intrinsic to the tagged-template
+# known-function dispatch (string-ops.ts) and the nested-function param loop
+# (nested-declarations.ts) — the arity/rest-param handling belongs exactly in
+# those functions; extracting it to a subsystem module would add indirection
+# for a targeted bugfix. Allow the small net growth in both god-files.
+loc-budget-allow:
+  - src/codegen/string-ops.ts
+  - src/codegen/statements/nested-declarations.ts
 ---
 
 # #3576 — `deepEqual.js` `format` closure: `call_ref` arity mismatch (need 4, got 3)

--- a/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
+++ b/plan/issues/3576-deepequal-format-callref-arity-mismatch.md
@@ -2,8 +2,10 @@
 id: 3576
 title: "deepEqual.js `format` closure fails Wasm validation — call_ref arity mismatch (need 4, got 3)"
 status: ready
+assignee: ttraenkler/dev-opus-arrayhof
 sprint: current
 created: 2026-07-24
+updated: 2026-07-24
 priority: high
 feasibility: hard
 model: opus
@@ -13,7 +15,8 @@ task_type: bugfix
 area: codegen, closures, array-methods, emit
 language_feature: compiler-internals
 goal: test262-conformance
-related: [3378, 2043]
+blocked-on: "REPRODUCE needs #3559 (#3378 stale-local fix — on plain main the #3378 RangeError aborts before the arity error is reached); EDIT of array-methods.ts needs #3560 landed. Both in the merge queue 2026-07-24. Do repro→WAT-trace→pad→verify→PR in ONE clean pass on main once both land."
+related: [3378, 3559, 3560, 3563, 2873, 2043]
 ---
 
 # #3576 — `deepEqual.js` `format` closure: `call_ref` arity mismatch (need 4, got 3)
@@ -99,6 +102,90 @@ then determining whether the arity is wrong on the callback CONSTRUCTION side
 pushing too few args). Likely lives in `src/codegen/array-methods.ts`
 (callback-wrapper / trampoline ABI) and/or `src/codegen/closures/*`
 (funcref-as-closure wrapper types).
+
+## Mechanism analysis + fix candidate (dev-opus-arrayhof, 2026-07-24)
+
+**Read-only source trace — NOT yet verified against the live repro (blocked on
+#3559; see blockers). Documented durably so the fix survives a fresh re-spawn.**
+
+### The 4-param funcref IS the array-callback ABI → it is a .map/.filter callback
+
+`(env, value, index, array)` = `(ref null <closure_struct>) externref externref
+externref` is *exactly* the spec-arity-3 array-callback ABI (map/filter/forEach
+callbacks receive `value, index, array`; +1 for the closure env). A plain
+`(mappers[i]||String)(sub)` call would be a 1-user-arg funcref (2 params), not
+4. So the failing `call_ref` is an **array-method callback invocation**, and
+"got 3" = `env + value + index` pushed with the trailing **`array`** arg missing.
+
+### Where the under-push happens: `buildClosureCallInstrs` (array-methods.ts:~4957)
+
+That trampoline pushes the callback args **gated on `numParams`**
+(`= closureInfo.paramTypes.length`):
+
+- `value` if `numParams >= 1` (~line 5015)
+- `index` if `numParams >= 2` (~line 5033)
+- **`array` if `numParams >= 3` (~line 5040)**  ← the skipped slot
+
+and the `call_ref` uses `closureInfo.funcTypeIdx` (~line 5055). So it pushes
+`numParams + 1` values but the call_ref demands `arity(funcTypeIdx)`. These
+match **only when `arity(funcTypeIdx) === paramTypes.length + 1`**.
+
+### The divergence: shared canonical-wrapper closureInfo (closures.ts:~2155, #2873-adjacent)
+
+`setupArrayCallback` (array-methods.ts:~4804) resolves
+`closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx)` off the callback
+value's **struct type**. Per `closures.ts:~2155`, that struct can be a **shared
+"canonical wrapper root"** used by multiple closures with the same param
+*types* (e.g. all-externref params) but different declared *arities*. So a
+2-declared-param callback (`(sub, i) => …`) can resolve to a `closureInfo`
+whose `funcTypeIdx` is a **4-param** wrapper (inherited from a 3-user-param
+sibling that shares the canonical wrapper) while its `paramTypes.length` is 2.
+Result: `buildClosureCallInstrs` pushes `env + sub + i` = 3, the shared
+`funcTypeIdx` needs 4 → **`need 4, got 3`**. Same shared-wrapper / RTT-arity
+hazard family as #2873. (`ClosureInfo` sets `funcTypeIdx: liftedFuncTypeIdx`
+and `paramTypes: arrowParams` *together* at construction — closures.ts:~2142 —
+so the divergence is NOT a single arrow's own registration; it is introduced by
+the **shared-struct lookup** returning a sibling's `closureInfo`.)
+
+### Fix candidate — arity-pad to the funcref's ACTUAL arity (mirrors #3563)
+
+In `buildClosureCallInstrs`, push callback args up to the **actual arity of
+`closureInfo.funcTypeIdx`**, not `numParams`. For each param slot beyond
+`numParams` (the `array` slot = `loop.vecTmp`, then any tail), emit the spec
+value if known else the **missing-trailing-arg default** per param type —
+exactly dev-d-1's `padMissingArg` helper in PR #3563 (`fix(#3024)`,
+`src/codegen/index.ts emitMethodDispatch`): `__get_undefined` /
+`ref.null.extern` for externref, sNaN / typed-zero otherwise. A `call_ref` MUST
+push exactly the funcref's declared arity, so padding-to-`funcTypeIdx`-arity is
+**always correct** and byte-inert whenever `arity == paramTypes.length + 1`
+(the common case). Alternative (heavier): make `setupArrayCallback` reconcile
+the resolved `closureInfo` so a shared-wrapper lookup can't return a sibling's
+higher-arity `funcTypeIdx` — prefer the trampoline arity-pad first.
+
+### Verification still needed (do these when unblocked)
+
+1. **Reproduce** with #3559 applied (the repro above). Dump WAT
+   (`emitWat:true`); locate the failing `call_ref` at `__closure_6 @+15349`;
+   read its `funcTypeIdx` arity and the callback's `closureInfo.paramTypes.length`
+   at that site — **confirm** the `4 vs 3` divergence and that it is the shared
+   canonical-wrapper lookup (not a construction-side over-build).
+2. Apply the `buildClosureCallInstrs` arity-pad; re-run repro →
+   `WebAssembly.compile` passes (no `need 4, got 3`).
+3. Full real-harness combo (`assert.js + sta.js + propertyHelper.js +
+   compareArray.js + deepEqual.js` + trivial body) validates (`__closure_28`).
+4. Equivalence suite (broad closure/array-method surface) + no test262 JS-host
+   regression.
+
+### Blockers (both in the merge queue 2026-07-24)
+
+- **REPRODUCE → #3559** (#3378 stale-local fix): OPEN. On plain `main` the
+  #3378 `RangeError` aborts binary emit before `WebAssembly.compile` runs.
+- **EDIT → #3560** (array-methods.ts, a #3200 flatMap slice): OPEN in queue.
+  Branch/edit `array-methods.ts` from a `main` that includes #3560 (and #3561,
+  already merged) to avoid a rebase.
+
+Per tech-lead decision 2026-07-24: **defer, single clean pass on main once both
+land** (don't predecessor-stack at low budget).
 
 ## Acceptance criteria
 

--- a/plan/issues/3581-tagged-template-rest-body-strings-param-corruption.md
+++ b/plan/issues/3581-tagged-template-rest-body-strings-param-corruption.md
@@ -1,0 +1,85 @@
+---
+id: 3581
+title: "Tagged template to a nested rest function whose body uses the rest param as an array corrupts the `strings` param (renders `undefined`)"
+status: ready
+sprint: current
+created: 2026-07-24
+priority: medium
+feasibility: hard
+model: opus
+horizon: m
+reasoning_effort: high
+task_type: bugfix
+area: codegen, string-ops, tagged-templates, nested-declarations
+language_feature: tagged-templates
+goal: test262-conformance
+related: [3576, 2008, 2510, 2029]
+---
+
+# #3581 — tagged-template `strings` param corrupted when a nested rest tag body uses the rest param as an array
+
+## Summary
+
+Carved out of #3576 (which fixed the `call_ref` arity VALIDATION error for
+nested rest tag functions). This is a **runtime rendering** defect that is
+independent of the arity fix and **pre-existing on `main`** (where it manifests
+worse — `dereferencing a null pointer` — because on `main` the rest param is
+also mis-lowered). It blocks the full runtime rendering of `deepEqual.js`'s
+`format` (`format` validates after #3576 but renders `undefined` for the
+`strings` parts of array/object/function values).
+
+## Mechanism (measured)
+
+When a tagged template `tag\`...\`` targets a nested function
+`tag(strings, ...subs)` **and `tag`'s body uses the rest param as an ARRAY**
+(`subs.map(...)` or `subs[i]`), the `strings` parameter — a tagged-template
+**template-object struct** coerced to `externref` via `extern.convert_any` at
+the call site — reads as `undefined` inside the body (`strings.join(...)` →
+`"undefined"`).
+
+Key isolation results (`.tmp` battery, wasm vs node):
+
+| body uses `subs` via | call form | result |
+| -------------------- | --------- | ------ |
+| `subs.length` only | tagged template | strings correct ✓ (with #3576) |
+| `subs.map(...)` / `subs[i]` | tagged template | **strings = `undefined`** ✗ |
+| `subs.map(...)` / `subs[i]` | DIRECT call `tag(["A","B"], 1)` | correct ✓ |
+
+The direct-call column passing (its first arg is a plain array literal, not a
+template struct) narrows the defect to the **tagged-template `strings`
+value** — a `templateVecTypeIdx` struct (cooked + raw fields) coerced to
+`externref` — being consumed by a host array method (`.join`) **only when the
+body also materialises the rest param as a data array**. The `subs.length`
+path (reads vec field 0) does not trip it, so the trigger is the rest-array
+materialisation shifting/late-importing something that the already-emitted
+`strings.join` (`local.get; global.get; call; call`) then resolves against
+stale indices — a late-import / detached-body fixup interaction in the
+tagged-template lowering, OR the template-struct→externref host-method dispatch.
+Needs a WAT + index-fixup trace (compare `global.get`/`call` targets between the
+`subs.length` and `subs.map` variants).
+
+## Repro
+
+`.tmp/min-direct.mts` (in the #3576 branch) — the `tagged-map` / `tagged-index`
+cells reproduce; `direct-map` is the passing control. Minimal:
+
+```ts
+function tag(strings, ...subs) {
+  let j = subs.map(s => String(s)).join(",");
+  return strings.join("|") + "[" + j + "]";
+}
+// tagged template -> strings renders "undefined"
+let out = tag`A${1}B` + ";" + tag`A${1}B${2}C`;
+// node: "A|B[1];A|B|C[1,2]"   wasm: "undefined[1];undefined[1,2]"
+```
+
+## Acceptance criteria
+
+- A nested rest tag function whose body uses `subs.map(...)` / `subs[i]`,
+  invoked as a tagged template, renders the `strings` parts correctly
+  (byte-equal to node).
+- `deepEqual.js` `format` renders array/object/function values correctly at
+  runtime (`String(format([1,2,3]))` === `"[1, 2, 3]"`, etc.), closing the
+  runtime half of the deepEqual.js harness (the validation half landed in
+  #3576).
+- No regression in the equivalence suite / tagged-template tests.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -261,33 +261,6 @@ export function compileNestedFunctionDeclaration(
   const paramTypes: ValType[] = [];
   for (let pi = 0; pi < stmt.parameters.length; pi++) {
     const p = stmt.parameters[pi]!;
-    // (#3576) Rest parameter `...args: T[]` → a single `(ref null $__vec_elem)`
-    // param, AND register it in `ctx.funcRestParams` so call sites (notably the
-    // tagged-template known-function dispatch in string-ops.ts) pack the
-    // trailing arguments into the vec instead of pushing them as positional
-    // slots. Top-level `declarations.ts` already does this; the nested-function
-    // path was silently missing it, so a nested rest tag function (e.g.
-    // deepEqual.js `lazyResult(strings, ...subs)`) got a fixed-arity funcType
-    // with NO rest info — under-arity tag calls then under-pushed the stack
-    // (`call ... need N, got N-1`, a hard Wasm-validation failure).
-    if (p.dotDotDotToken) {
-      const restParamType = ctx.checker.getTypeAtLocation(p);
-      const typeArgs = ctx.checker.getTypeArguments(restParamType as ts.TypeReference);
-      const elemTsType = typeArgs[0];
-      const elemType: ValType = elemTsType ? resolveWasmType(ctx, elemTsType) : { kind: "f64" };
-      const elemKey =
-        elemType.kind === "ref" || elemType.kind === "ref_null" ? `ref_${elemType.typeIdx}` : elemType.kind;
-      const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
-      const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
-      paramTypes.push({ kind: "ref_null", typeIdx: vecTypeIdx });
-      ctx.funcRestParams.set(funcName, {
-        restIndex: pi,
-        elemType,
-        arrayTypeIdx: arrTypeIdx,
-        vecTypeIdx,
-      });
-      continue;
-    }
     const paramType = ctx.checker.getTypeAtLocation(p);
     let wasmType: ValType = restBindingOverridesToExternref(p)
       ? { kind: "externref" }
@@ -298,6 +271,30 @@ export function compileNestedFunctionDeclaration(
       wasmType = { kind: "ref_null", typeIdx: (wasmType as { kind: "ref"; typeIdx: number }).typeIdx };
     }
     paramTypes.push(wasmType);
+    // (#3576) Rest parameter `...args: T[]` lowers (via resolveWasmType above)
+    // to a single `(ref null $__vec_elem)` param. Register it in
+    // `ctx.funcRestParams` so call sites — notably the tagged-template
+    // known-function dispatch in string-ops.ts — pack the trailing arguments
+    // into that vec instead of pushing them as positional slots. Top-level
+    // `declarations.ts` already registers rest params; the nested-function path
+    // silently did not, so a nested rest tag function (e.g. deepEqual.js
+    // `lazyResult(strings, ...subs)`) got a fixed-arity funcType with NO rest
+    // info and under-arity tag calls under-pushed the stack (`call ... need N,
+    // got N-1`, a hard Wasm-validation failure). The vec/array/element types are
+    // read back off the lowered param via `getVecInfo` — no extra checker query
+    // (oracle-ratchet-neutral) and guaranteed consistent with the param type.
+    if (p.dotDotDotToken && (wasmType.kind === "ref" || wasmType.kind === "ref_null")) {
+      const vecTypeIdx = (wasmType as { typeIdx: number }).typeIdx;
+      const vecInfo = getVecInfo(ctx, vecTypeIdx);
+      if (vecInfo) {
+        ctx.funcRestParams.set(funcName, {
+          restIndex: pi,
+          elemType: vecInfo.elemType,
+          arrayTypeIdx: vecInfo.arrTypeIdx,
+          vecTypeIdx,
+        });
+      }
+    }
   }
 
   // Check if this is a generator function declaration (function* name() { ... })

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -259,7 +259,35 @@ export function compileNestedFunctionDeclaration(
     return false;
   };
   const paramTypes: ValType[] = [];
-  for (const p of stmt.parameters) {
+  for (let pi = 0; pi < stmt.parameters.length; pi++) {
+    const p = stmt.parameters[pi]!;
+    // (#3576) Rest parameter `...args: T[]` → a single `(ref null $__vec_elem)`
+    // param, AND register it in `ctx.funcRestParams` so call sites (notably the
+    // tagged-template known-function dispatch in string-ops.ts) pack the
+    // trailing arguments into the vec instead of pushing them as positional
+    // slots. Top-level `declarations.ts` already does this; the nested-function
+    // path was silently missing it, so a nested rest tag function (e.g.
+    // deepEqual.js `lazyResult(strings, ...subs)`) got a fixed-arity funcType
+    // with NO rest info — under-arity tag calls then under-pushed the stack
+    // (`call ... need N, got N-1`, a hard Wasm-validation failure).
+    if (p.dotDotDotToken) {
+      const restParamType = ctx.checker.getTypeAtLocation(p);
+      const typeArgs = ctx.checker.getTypeArguments(restParamType as ts.TypeReference);
+      const elemTsType = typeArgs[0];
+      const elemType: ValType = elemTsType ? resolveWasmType(ctx, elemTsType) : { kind: "f64" };
+      const elemKey =
+        elemType.kind === "ref" || elemType.kind === "ref_null" ? `ref_${elemType.typeIdx}` : elemType.kind;
+      const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
+      const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+      paramTypes.push({ kind: "ref_null", typeIdx: vecTypeIdx });
+      ctx.funcRestParams.set(funcName, {
+        restIndex: pi,
+        elemType,
+        arrayTypeIdx: arrTypeIdx,
+        vecTypeIdx,
+      });
+      continue;
+    }
     const paramType = ctx.checker.getTypeAtLocation(p);
     let wasmType: ValType = restBindingOverridesToExternref(p)
       ? { kind: "externref" }

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -15,7 +15,7 @@ import { compileAndEmitToString, emitToString } from "./coercion-engine.js";
 import { registerStringHelperEmitters } from "./string-emitter-registry.js";
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
-import { allocLocal } from "./context/locals.js";
+import { allocLocal, getLocalType } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext, HoistedCharRead } from "./context/types.js";
 import { emitThrowTypeError, getFuncParamTypes, noJsHost } from "./expressions/helpers.js";
 import { addStringImports, flatStringType, nativeStringType, resolveIdentifierType, resolveWasmType } from "./index.js";
@@ -39,7 +39,12 @@ import {
   tryCompileStandaloneStringSplit,
 } from "./regexp-standalone.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
-import { getArrTypeIdxFromVec, getOrRegisterTemplateVecType, getOrRegisterVecType } from "./registry/types.js";
+import {
+  getArrTypeIdxFromVec,
+  getOrRegisterRefCellType,
+  getOrRegisterTemplateVecType,
+  getOrRegisterVecType,
+} from "./registry/types.js";
 import { compileExpression, ensureLateImport, flushLateImportShifts, registerCompileStringLiteral } from "./shared.js";
 import {
   coerceType,
@@ -1160,35 +1165,77 @@ export function compileTaggedTemplateExpression(
     // Case 2: tag is a known function
     const funcIdx = ctx.funcMap.get(tagName);
     if (funcIdx !== undefined) {
-      // Prepend captured values for nested functions with captures.
+      // Prepend captured values for nested functions with captures. The lifted
+      // signature is [valueCap_0..N-1, tdzFlagBox_0..K-1, strings, ...userParams]
+      // (mirrors nested-declarations.ts + call-identifier.ts). BOTH the value
+      // captures AND the TDZ-flag boxes are real leading params, so the capture
+      // count that offsets `strings`/substitutions below is value + tdz-flag
+      // count — not just the value count (#3576).
       const nestedCaptures = ctx.nestedFuncCaptures.get(tagName);
+      const tdzFlaggedNested = nestedCaptures ? nestedCaptures.filter((c) => c.hasTdzFlag) : [];
       if (nestedCaptures) {
         for (const cap of nestedCaptures) {
           fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });
         }
+        // #1205 Stage 3: after all value captures, push the boxed TDZ-flag refs.
+        // Minimal replication of call-identifier.ts's cap-prepend (kept gated so
+        // the common no-TDZ tag stays byte-inert): share an existing box, else
+        // box the live i32 flag, else treat as initialized (`i32.const 1`).
+        if (tdzFlaggedNested.length > 0) {
+          const i32RefCellTypeIdx = getOrRegisterRefCellType(ctx, { kind: "i32" });
+          for (const cap of tdzFlaggedNested) {
+            const existing = fctx.boxedTdzFlags?.get(cap.name);
+            if (existing) {
+              fctx.body.push({ op: "local.get", index: existing.localIdx });
+              continue;
+            }
+            const liveFlagIdx = fctx.tdzFlagLocals?.get(cap.name);
+            const liveType = liveFlagIdx !== undefined ? getLocalType(fctx, liveFlagIdx) : undefined;
+            const liveOk = liveType?.kind === "i32";
+            if (liveOk && liveFlagIdx !== undefined) {
+              fctx.body.push({ op: "local.get", index: liveFlagIdx });
+            } else {
+              fctx.body.push({ op: "i32.const", value: 1 });
+            }
+            fctx.body.push({ op: "struct.new", typeIdx: i32RefCellTypeIdx });
+            const flagBoxLocal = allocLocal(fctx, `__tdz_box_${cap.name}`, {
+              kind: "ref",
+              typeIdx: i32RefCellTypeIdx,
+            });
+            fctx.body.push({ op: "local.tee", index: flagBoxLocal });
+            if (liveOk) {
+              if (!fctx.boxedTdzFlags) fctx.boxedTdzFlags = new Map();
+              fctx.boxedTdzFlags.set(cap.name, { refCellTypeIdx: i32RefCellTypeIdx, localIdx: flagBoxLocal });
+              if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+              fctx.tdzFlagLocals.set(cap.name, flagBoxLocal);
+            }
+          }
+        }
       }
+      // Total leading capture params (value captures + TDZ-flag boxes).
+      const captureCount = nestedCaptures ? nestedCaptures.length + tdzFlaggedNested.length : 0;
 
       const restInfo = ctx.funcRestParams.get(tagName);
       const paramTypes = getFuncParamTypes(ctx, funcIdx);
 
-      // Push the strings array as argument 0
+      // Push the strings array as the first USER param (wasm index captureCount).
       fctx.body.push({ op: "local.get", index: stringsLocal });
-      // Coerce if needed (e.g. ref_null vec → externref)
-      if (paramTypes?.[0] && paramTypes[0].kind === "externref") {
+      // Coerce if the callee expects externref for the strings param.
+      if (paramTypes?.[captureCount] && paramTypes[captureCount]!.kind === "externref") {
         fctx.body.push({ op: "extern.convert_any" });
       }
 
       if (restInfo) {
-        // Tag function has rest param: push positional args before rest, then pack rest
-        const captureCount = nestedCaptures ? nestedCaptures.length : 0;
-        const restIdx = restInfo.restIndex - captureCount; // restIndex in user params (0-based after captures)
-        // Push positional substitutions before the rest param
-        for (let i = 0; i < Math.min(substitutions.length, restIdx - 1); i++) {
-          compileExpression(ctx, fctx, substitutions[i]!, paramTypes?.[i + 1 + captureCount]);
+        // Tag function has rest param: push positional user substitutions before
+        // the rest param, then pack the remainder into the rest vec. `restIndex`
+        // is in USER-param space (strings is user param 0), so the number of
+        // positional subs between strings and the rest is `restIndex - 1`.
+        const positionalSubs = Math.max(0, restInfo.restIndex - 1);
+        for (let i = 0; i < Math.min(substitutions.length, positionalSubs); i++) {
+          compileExpression(ctx, fctx, substitutions[i]!, paramTypes?.[captureCount + 1 + i]);
         }
         // Pack remaining substitutions into a vec for the rest param
-        const restStart = Math.max(0, restIdx - 1);
-        const restSubs = substitutions.slice(restStart);
+        const restSubs = substitutions.slice(positionalSubs);
         const restArgCount = restSubs.length;
         fctx.body.push({ op: "i32.const", value: restArgCount });
         for (const sub of restSubs) {
@@ -1203,12 +1250,11 @@ export function compileTaggedTemplateExpression(
       } else {
         // No rest param — push substitutions as positional args
         // Only push up to the number of declared params (excluding captures and strings array)
-        const captureCount = nestedCaptures ? nestedCaptures.length : 0;
         const maxSubs = paramTypes
           ? Math.min(substitutions.length, paramTypes.length - 1 - captureCount)
           : substitutions.length;
         for (let i = 0; i < maxSubs; i++) {
-          compileExpression(ctx, fctx, substitutions[i]!, paramTypes?.[i + 1 + captureCount]);
+          compileExpression(ctx, fctx, substitutions[i]!, paramTypes?.[captureCount + 1 + i]);
         }
 
         // Supply defaults for missing optional params

--- a/tests/issue-3576.test.ts
+++ b/tests/issue-3576.test.ts
@@ -1,0 +1,78 @@
+// #3576 — `deepEqual.js` `format` closure failed Wasm validation with
+// `call_ref ... need 4, got 3`. Root cause (measured — NOT the array-callback
+// trampoline the original writeup guessed): `format` calls the nested function
+// `lazyResult(strings, ...subs)` as a TAGGED TEMPLATE at varying substitution
+// counts. `lazyResult` has a rest param AND a TDZ-flagged capture (`usage`), so
+// its lifted signature is `[usageVal, usageTdzFlag, strings, subsVec]`. Two
+// gaps under-pushed the stack: (1) `nested-declarations.ts` never registered
+// the rest param in `ctx.funcRestParams`; (2) `string-ops.ts` tagged-template
+// KNOWN-FUNC dispatch pushed only the value captures (not the TDZ-flag box) and
+// mis-counted `captureCount`. Fix registers the rest param + pushes the tdz-flag
+// box + offsets by the correct capture count.
+//
+// These guards are self-contained (no test262 submodule dependency): they
+// reproduce the exact nested-rest-tag-with-tdz-capture shape.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileGc(src: string) {
+  return (await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as any)) as any;
+}
+
+async function runExport(src: string, name = "test"): Promise<unknown> {
+  const r = await compileGc(src);
+  expect(r.success).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  (imports as { setExports?: (e: unknown) => void }).setExports?.(instance.exports);
+  return (instance.exports as Record<string, () => unknown>)[name]!();
+}
+
+describe("#3576 — nested rest-param tag function (deepEqual.js format arity fix)", () => {
+  it("a nested `(strings, ...subs)` tag with a TDZ-flagged capture, called as a tagged template at VARYING substitution counts, compiles to a VALID binary (no `call_ref need N, got N-1`)", async () => {
+    // The exact #3576 shape: rest param + a `let` (TDZ-flagged) capture + a
+    // body that materialises the rest as an array, called with 1 AND 2 subs.
+    const src = `export function test(): string {
+      let usage = "U";                       // let => TDZ-flagged capture
+      function lazyResult(strings, ...subs) {
+        let r = subs.map(s => String(s)).join(",");
+        return strings.length + "|" + r + usage;
+      }
+      let a = lazyResult\`A\${1}B\`;             // 1 sub
+      let b = lazyResult\`A\${1}B\${2}C\`;        // 2 subs
+      return a + ";" + b;
+    }`;
+    const r = await compileGc(src);
+    expect(r.success).toBe(true);
+    // The regression was a hard WebAssembly validation failure at the tag call.
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+  });
+
+  it("renders a nested rest tag (with a TDZ capture) byte-correctly across substitution counts", async () => {
+    // Broader guard: the rest param is packed into a vec (correct arity + values)
+    // and the capture is threaded. Direct-analogue of the isolation battery.
+    const body = (tag: string) => `${tag}\`A\${1}B\` + ";" + ${tag}\`A\${1}B\${2}C\``;
+    const src = `export function test(): string {
+      let marker = "M";
+      function tag(strings, ...subs) { return strings.join("|") + "#" + subs.length + marker; }
+      return ${body("tag")};
+    }`;
+    const got = await runExport(src);
+    const expected = new Function(
+      'let marker="M"; function tag(strings,...subs){return strings.join("|")+"#"+subs.length+marker;} return ' +
+        body("tag") +
+        ";",
+    )();
+    expect(got).toBe(expected);
+  });
+
+  it("a nested rest function called DIRECTLY (not as a tagged template) at varying arity renders correctly (was broken on main: undefined / null-deref)", async () => {
+    const src = `export function test(): string {
+      function f(a, ...xs) { return a + ":" + xs.map(x => String(x)).join(",") + "/" + xs.length; }
+      return f("p", 1, 2, 3) + ";" + f("q", 9) + ";" + f("r");
+    }`;
+    const got = await runExport(src);
+    expect(got).toBe("p:1,2,3/3;q:9/1;r:/0");
+  });
+});


### PR DESCRIPTION
## #3576 — `deepEqual.js` `format` closure `call_ref` arity mismatch (`need 4, got 3`)

### Mechanism (measured — overturns the prior read-only writeup)
`buildClosureCallInstrs` / the array-callback trampoline is **not** the locus (all 4 of `__closure_6`'s array-callback dispatches are arity-consistent). The real culprit: `format` calls the nested function `lazyResult(strings, ...subs)` as a **tagged template** at varying substitution counts. `lazyResult` has a rest param **and** a TDZ-flagged capture (`usage`), so its lifted signature is `[usageVal, usageTdzFlag, strings, subsVec]` (4 params). Two gaps made the tagged-template dispatch under-push the stack:

1. `nested-declarations.ts` never registered the rest param in `ctx.funcRestParams` (the top-level `declarations.ts` path does) → the single `subsVec` param was treated as positional sub slots.
2. `string-ops.ts` tagged-template KNOWN-FUNC dispatch pushed only the **value** captures (never the TDZ-flag boxes) and mis-counted `captureCount` → `strings`/subs landed at the wrong slots and the tdz-flag param was omitted → `need 4, got 3`.

The prior "pad-to-arity" candidate is **semantically wrong** here (padding a rest-vec slot with `undefined` → valid binary, wrong output); rejected on measurement.

### Fix (2 source files)
- **`nested-declarations.ts`** — add the `dotDotDotToken` arm to the param loop: lower `...args` to one `(ref null $vec)` param **and** register it in `funcRestParams` (mirrors `declarations.ts`).
- **`string-ops.ts` KNOWN-FUNC path** — push the boxed TDZ-flag capture refs after the value captures (gated on `tdzFlaggedNested.length > 0` → byte-inert for the common no-tdz tag), set `captureCount = values + tdzFlags`, and offset `strings` / positional-subs / rest-packing by `captureCount`.

### Verification (measured, denominators)
- Repro `stub-assert + deepEqual.js` → `WebAssembly.compile` **OK**, arity error gone ✓ (primary AC).
- Full real-harness combo (`sta+assert+propertyHelper+compareArray+deepEqual.js` + trivial body) → validates ✓ (2nd AC). On `main` it fails identically at `__closure_28` (`need 4, got 3`).
- Direct calls to nested rest functions (`f("p",1,2,3)`) — **broken on main** (undefined / null-deref) — now render byte-correct vs node → strict improvement across the whole nested-rest-function surface.
- A `deepEqual.js` passing-assertion test (the common test262 shape — `format` is only invoked on assertion FAILURE) compiles + runs to completion (**CE→PASS** class). 74 test262 tests include `deepEqual.js`.
- **Equivalence gate: no new regressions** (35 failing / 1608 passing / 36 baseline; +1 baseline failure incidentally now passes). Typecheck + prettier + biome green.

### Orthogonal follow-up (filed as #3581, NOT this PR's AC)
A nested rest tag whose BODY uses the rest param as an array (`subs.map`/`subs[i]`) mis-reads the tagged-template `strings` param (template-struct→externref → `strings.join` → `undefined`). Pre-existing (worse on main); blocks full runtime rendering of `format` but not the validation AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ