### PR TITLE
release: v0.66.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "license": "Apache-2.0",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.65.0",
+  "version": "0.66.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@loopdive/js2": "0.65.0"
+    "@loopdive/js2": "0.66.0"
   },
   "author": "Thomas Tränkler <git@thomas.traenkler.com>",
   "license": "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
## release: v0.66.0

Minor bump `0.65.0 → 0.66.0` — **12 `feat` commits** since `v0.65.0` (284 commits total).

Cut with `node scripts/release.mjs 0.66.0` — lockstep version bump across both published packages + the JSR manifest, in a single `release: v0.66.0` commit:

| file | version |
| --- | --- |
| `package.json` (`@loopdive/js2`) | 0.66.0 |
| `packages/js2wasm/package.json` (proxy) | 0.66.0 |
| proxy dep on `@loopdive/js2` | 0.66.0 |
| `jsr.json` | 0.66.0 |

The annotated `v0.66.0` tag is created **locally only** and is intentionally **NOT pushed** — pushing the tag fires `publish-npm.yml` (npm + JSR publish) and is the deliberate, user-gated final step after this PR merges (see `docs/releasing.md`).

### Post-merge (maintainer)
After merge, push the tag to trigger publish:
```
git fetch origin && git push origin v0.66.0
```
`publish-npm.yml`'s `verify-version` job confirms the tag == both package.json versions before publishing.

> ⚠️ Do **not** self-merge/enqueue with the tag pushed. Branch-only push; tag stays local until merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tr2Qx6KzQVhnXcGu167zeZ