### PR TITLE
feat(#2984): seed builtin-ctor $Object carrier with length/name/prototype own props (runtime-receiver axis)

### DIFF
--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -1,7 +1,8 @@
 ---
 id: 2984
 title: "Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)"
-status: in-progress
+status: done
+completed: 2026-07-24
 updated: 2026-07-24
 assignee: ttraenkler/dev-opus5-mop
 sprint: current
@@ -21,6 +22,16 @@ loc-budget-allow:
 ---
 
 # #2984 — standalone gOPD-on-builtin descriptor MOP
+
+> **RESIDUAL — `status: done` here closes the ISSUE FILE, not the work.** This
+> is an `horizon: xl` issue and eight slices have landed against it. The
+> 2026-07-24 re-measurement (below) shows the newly-identified RUNTIME axis
+> still has, under `test/built-ins/` alone, **199 native-proto + 62 namespace +
+> 48 global-`this` + 27 TypedArray-ctor** `hasOwnProperty`-miss rows open, plus
+> the `__extern_set` non-writable-store gap that gates the `{writable:true}`
+> families. **A successor issue must be filed** for that axis — do not read
+> this `done` as "the standalone descriptor MOP is finished". See "The next
+> slice on this axis" at the end of the top section.
 
 ## Slice "ctor-carrier own props" LANDED (2026-07-24, dev-opus5-mop) — the runtime (any-param receiver) axis
 
@@ -119,9 +130,38 @@ The one hold-out is `AggregateError/prototype/prop-desc.js`, which fails BEFORE
 `verifyProperty` on `assert.sameValue(typeof AggregateError.prototype,
 'object')` — unrelated, pre-existing.
 
+**Regression sweep — 2,137 files** (the touched ctor dirs + the MOP-sensitive
+`Object/{getOwnPropertyNames,getOwnPropertyDescriptor{,s},keys,freeze,seal,
+prototype}` dirs), diffed **local-vs-local**, i.e. the SAME runner in the SAME
+process shape with the seed force-disabled behind a temporary env switch vs
+enabled:
+
+- **0 regressions** (pass → non-pass)
+- **0 changed error signatures** on fail→fail rows — so the #3439 hard-0
+  unclassified-root-causes gate has nothing new to park on
+- **+50 improvements**, of which 46 are in the target set and **all 4 outside it
+  are directly attributable to the seeded `prototype`**:
+  `Error/prototype/S15.11.3.1_A{1,2,4}_T1.js` (`Error.hasOwnProperty('prototype')`
+  / `delete Error.prototype === false`) and `Object/prototype/S15.2.3.1_A3.js`
+  (`delete Object.prototype === false`).
+
+> **Do NOT diff a local sweep against the committed standalone baseline JSONL.**
+> I tried that first and got a plausible-looking "0 regressions / +118
+> improvements" — it is **contaminated**. The baseline comes from the sharded CI
+> worker (`scripts/test262-worker.mjs`); a local in-process `runTest262File` run
+> differs on things unrelated to any code change (the `L:N ` error-prefix, and a
+> large `standalone target emitted host imports: env::X` (#2961) population that
+> does not reproduce locally). 611 rows showed a changed signature purely from
+> that. Local-vs-local with the change force-disabled is the only sound control.
+
+`prove-emit-identity`: **IDENTICAL** — all 60 (file,target) emits across
+gc/standalone/wasi/linear match the pre-change baseline.
+
 `tests/issue-2984-ctor-carrier-own-props.test.ts` 11/11, asserting each
 attribute and value **independently** (numeric `length`, object-identity
 `prototype`) rather than trusting a test262 verdict — see the honesty note.
+Related suites: 2984 ×6 + 3006 + 2896 = 85/85; #1888 guardrails 23/23;
+`check:loc-budget` OK; `check:oracle-ratchet` +0/+0.
 
 ### HONESTY NOTE — how much of the +49 is earned (read this before citing it)
 

--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -1,8 +1,9 @@
 ---
 id: 2984
 title: "Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)"
-status: ready
-updated: 2026-07-17
+status: in-progress
+updated: 2026-07-24
+assignee: ttraenkler/dev-opus5-mop
 sprint: current
 priority: high
 horizon: xl
@@ -21,6 +22,174 @@ loc-budget-allow:
 
 # #2984 — standalone gOPD-on-builtin descriptor MOP
 
+## Slice "ctor-carrier own props" LANDED (2026-07-24, dev-opus5-mop) — the runtime (any-param receiver) axis
+
+> PR branch: `issue-2984-ctor-carrier-own-props`. Base = `origin/main` @
+> `bb5b414a05b6d0`. Standalone baseline JSONL = the 2026-07-24 13:38 promote
+> (oracle_version 10, lane `honest`, 48,088 rows).
+
+### Re-measurement — the issue's own narrative was pointing at the wrong axis
+
+The "## Measured current-main state (2026-07-03, sr-gopd)" section below is
+marked STALE and it is: **every landed slice so far fixes the SYNTACTIC axis**
+(a gOPD call site whose receiver expression the compiler can resolve at
+compile time). But the dominant remaining test262 cluster does not go through
+that axis at all.
+
+Census over the fresh standalone baseline (measured, denominators given):
+
+- `Test262Error: obj should have an own property <k>` ("a1") — **1,938 rows**
+  total; **673** under `test/built-ins/`, **1,246** under `test/language/`
+  (the language ones are the ambiguous ceiling — `verifyProperty` is only the
+  assert harness there; do NOT bank them on this issue).
+- The companion "a2" bucket (`descriptor should (not) be writable/…`) is
+  **0 rows** — because a1 throws first, so the attribute asserts are never
+  reached.
+- 4,735 test262 files call `verifyProperty()`; only **1,190 pass** standalone
+  (25 %).
+
+`propertyHelper.js:63` is `assert(__hasOwnProperty(obj, name), "obj should have
+an own property " + nameStr)`, i.e. a1 is a **`hasOwnProperty` miss, not a gOPD
+miss**, and `obj` is the harness's own **untyped parameter**.
+
+### Root cause (probe-measured on main @ bb5b414a05b6d0, real `runTest262File`)
+
+Routing the receiver through `function ho(a,b){return
+Object.prototype.hasOwnProperty.call(a,b);}` — the exact shape `verifyProperty`
+has — splits cleanly:
+
+| receiver kind                                                     | `ho(X,k)` | why                                       |
+| ----------------------------------------------------------------- | --------- | ----------------------------------------- |
+| native METHOD/STATIC closure (`Math.abs`, `Array.prototype.flat`) | **true**  | #2896 `__builtinfn_*` reflective natives  |
+| builtin CTOR (`WeakMap`, `Map`, `RangeError`)                     | false     | #3006/#2907 carrier is an EMPTY `$Object` |
+| native proto (`Date.prototype`, `String.prototype`)               | false     | `$NativeProto`, not `$Object`             |
+| builtin namespace (`Math`, `Reflect`)                             | false     | carrier is an empty `$Object`             |
+| plain object literal                                              | false     | lowers to a typed struct                  |
+
+Same split for `Object.getOwnPropertyDescriptor` through an any-param. The
+DIRECT (syntactic) forms of the same expressions answer correctly — that is
+exactly the Phase-2/3 work, and exactly why it never reached `prop-desc.js`.
+
+Crucially, the `$Object` runtime **already honours per-property attributes** on
+every dynamic path. Witness measured on main with
+`Object.defineProperty(Math,"zz",{value:1,writable:false,enumerable:false,
+configurable:true})`: runtime `hasOwnProperty` true, runtime gOPD returns the
+full correct triple, `for-in` skips it, and `verifyProperty` passes end-to-end
+for both `configurable:true` and `configurable:false`. So the ctor carriers
+were simply **empty** — nothing about the MOP itself was missing.
+
+### Fix
+
+New subsystem module `src/codegen/builtin-ctor-own-props.ts` —
+`pushBuiltinCtorOwnPropSeed(ctx, fctx, builtinName, objLocal)` installs, at
+carrier materialization time and via the existing native
+`__defineProperty_value`:
+
+- `length` §20.2.4.1 `{w:F,e:F,c:T}`, value = `BUILTIN_CTOR_ARITY[name]`
+- `name` §20.2.4.2 `{w:F,e:F,c:T}`, value = the ctor name string
+- `prototype` `{w:F,e:F,c:F}`, value = the `$NativeProto` from
+  `emitLazyNativeProtoGet` — i.e. the SAME object the syntactic
+  `<Ctor>.prototype` read yields, so `desc.value === X.prototype` holds
+
+Two thin call sites in `builtin-static-globals.ts`:
+`emitBuiltinConstructorIdentity` (#3006: Set/Map/WeakMap/WeakSet/WeakRef/RegExp/
+FinalizationRegistry/DisposableStack/AsyncDisposableStack/SuppressedError) —
+restructured to the proven initBody + local + `ctx.liveBodies` swap pattern so
+the `__box_number` late import is shift-safe — and `emitBuiltinNamespaceObject`
+(#2907: the Error family, `Array`, `Object`). The seed **no-ops for true
+namespaces** (`Math`/`JSON`/`Reflect` are not in `BUILTIN_CTOR_ARITY` and own
+none of the three). Pattern mirrors `emitGeneratorPrototypeSingleton`
+(#3236 S1). `ctx.standalone`-gated; strictly additive (the carriers had ZERO
+own properties before, and all three are non-enumerable so `Object.keys` /
+for-in are unchanged).
+
+Ctors with no `$NativeProto` brand (`AggregateError`) keep only
+`length`/`name`; `AggregateError`'s arity lives in a LOCAL supplement rather
+than widening the shared `BUILTIN_CTOR_ARITY` (that table also drives the
+compile-time `.length` / gOPD folds, which are outside this slice's measured
+set).
+
+### Measured (real runner, standalone lane, base = origin/main @ bb5b414a05b6d0)
+
+| Sweep                                                                          | before     | after       | Δ                      |
+| ------------------------------------------------------------------------------ | ---------- | ----------- | ---------------------- |
+| the 50 a1 rows with a seedable-ctor receiver and key ∈ {name,length,prototype} | **0 / 50** | **49 / 50** | **+49, 0 regressions** |
+
+The one hold-out is `AggregateError/prototype/prop-desc.js`, which fails BEFORE
+`verifyProperty` on `assert.sameValue(typeof AggregateError.prototype,
+'object')` — unrelated, pre-existing.
+
+`tests/issue-2984-ctor-carrier-own-props.test.ts` 11/11, asserting each
+attribute and value **independently** (numeric `length`, object-identity
+`prototype`) rather than trusting a test262 verdict — see the honesty note.
+
+### HONESTY NOTE — how much of the +49 is earned (read this before citing it)
+
+A deliberately-wrong-expectation control set (`.tmp/ctrl`, A/B'd with the seed
+force-disabled) shows **`verifyProperty` is VACUOUS past its a1 gate on the
+standalone lane, on main, today**:
+
+| control                                                                      | seed OFF | seed ON  | expected |
+| ---------------------------------------------------------------------------- | -------- | -------- | -------- |
+| `verifyProperty(WeakMap,"length",{value:0,…})`                               | fail     | pass     | pass ✓   |
+| `verifyProperty(WeakMap,"length",{value:12345,…})`                           | fail     | **pass** | fail ✗   |
+| `…{value:0,writable:TRUE,…}` (wrong attr)                                    | fail     | **pass** | fail ✗   |
+| `verifyProperty(WeakMap,"absentKey",…)`                                      | fail     | fail     | fail ✓   |
+| `verifyProperty(Math.abs,"name",{…writable:TRUE})` — an UNTOUCHED #2896 path | **pass** | **pass** | fail ✗   |
+
+The last row is the control that matters: the vacuity reproduces with the seed
+disabled, on a path this slice does not touch, so it is **pre-existing and
+independent of this change**. Mechanism: `verifyProperty` accumulates into
+`failures` via `__push`/`__join` — `Function.prototype.call.bind(Array.prototype.
+push|join)` — the **uncurryThis** family; those aliases misbehave standalone, so
+`failures.length` stays 0 and the final `assert(false, …)` never fires. Only the
+a1 assert (a plain `assert(cond, msg)`) is live.
+
+So the honest split of this slice is:
+
+- **REAL and independently verified** — builtin-ctor carriers now own
+  spec-correct, correctly-attributed `length` / `name` / `prototype`, readable
+  through the runtime MOP. Verified by direct `===` reads in the vitest suite,
+  not by the harness.
+- **HARNESS-CREDITED** — the 49 test262 flips are earned only at the a1 gate.
+  Their attribute assertions are vacuous for a reason outside this slice. Cite
+  this as "+49 rows, a1-gate-earned", not "+49 conforming descriptors".
+
+### Two verdict-oracle holes found while measuring (NOT fixed here — file separately)
+
+Both inflate the standalone floor and both reproduce on main:
+
+1. A test whose ONLY statement is `throw new Test262Error("HELLO")` reports
+   **pass** in the standalone lane — a top-level `throw` statement is silently
+   dropped. (`assert.sameValue(1,2)` correctly fails, so it is specific to a
+   bare top-level `throw`.)
+2. `assert.sameValue(<dynamic string>, <literal string>)` false-positives:
+   `assert.sameValue("" + true, "SHOWME")` **passes**. Any test whose only
+   discrimination is a string `sameValue` can pass vacuously.
+3. (Related, this issue's own family) the `verifyProperty` `__push`/`__join`
+   vacuity above — the uncurryThis half of the PH wall.
+
+### Known gap left behind (pinned by a test, pre-existing)
+
+A dynamic `o[k] = v` store bypasses the `$PropEntry` non-writable flag
+(`__extern_set` does not consult flags), so a runtime write to a seeded
+`writable:false` property lands even though the descriptor correctly reports
+`writable:false`. Reproduces for ANY `Object.defineProperty`-defined
+non-writable property, not just these carriers. Pinned in the test suite as a
+KNOWN GAP so a future store-path fix is noticed.
+
+### The next slice on this axis (measured, in priority order)
+
+Remaining a1 rows under `built-ins/`, by receiver kind:
+**native-proto 199** (`Array.prototype` 41, `TypedArrayPrototype` 25,
+`String.prototype` 16, `Iterator.prototype` 11, `RegExp.prototype` 9 …),
+**namespace 62** (`Math` 45, `Reflect` 13, `JSON` 4), **global (`this`) 48**,
+TypedArray ctors 27 (no `$Object` carrier at all — `typeof id(Uint16Array) !==
+"object"`, so they need a carrier first). Note the namespace/proto rows mostly
+carry `{writable:true, …}` descriptors, so flipping them for the RIGHT reason
+additionally needs a working write path — i.e. the `__extern_set` flag gap
+above is a prerequisite there, unlike for the `{writable:false}` ctor triple.
+
 ## Slice "@@species key" LANDED (2026-07-11, fable-sub1) — builtin receiver + non-literal key
 
 > PR: `issue-2984-gopd-builtin-key-dispatch`. Takes the "builtin receiver +
@@ -28,7 +197,7 @@ loc-budget-allow:
 > suite-wide `__get_builtin` non-pass cluster is 565; the gOPD-at-flagged-line
 > subset is only **38**, decomposing (measured 2026-07-11 off the standalone
 > baseline JSONL + flagged-source-line classification): **26 × `gOPD(<Ctor>,
-> Symbol.species)`** (the dominant non-literal-key shape) + 12 × RegExp annex-B
+Symbol.species)`** (the dominant non-literal-key shape) + 12 × RegExp annex-B
 > legacy accessors (open universe — deliberately refused). The remaining ~527
 > are NOT gOPD — they are direct unimplemented static-method calls
 > (`Atomics.*` 213, `Iterator.zip/zipKeyed/concat/from` ~99, `String.raw` 22,
@@ -64,15 +233,15 @@ dynamic fallback, which routes a builtin-identifier receiver through
   signature-wrapper base is untouched) so a statically-resolvable
   `g.call(thisVal)` threads the receiver.
 - Thin gate in calls.ts after the Phase-3 arm (`ctx.standalone && propLiteral
-  === undefined && isSymbolSpeciesKeyExpression`), receiver via the bucket-1
+=== undefined && isSymbolSpeciesKeyExpression`), receiver via the bucket-1
   alias resolver. Host/gc byte-inert.
 
 ### Measured (real runner, standalone lane, base = origin/main @ 026f40f771 merged)
 
-| Sweep                                             | before          | after              | Δ                        |
-| ------------------------------------------------- | --------------- | ------------------ | ------------------------ |
-| `built-ins/*/Symbol.species/*` (29)               | 0 / 5 / 24 CE   | **18 / 11 / 0 CE** | **+18 pass, 0 regressions** |
-| `built-ins/Object/getOwnPropertyDescriptor{,s}` (328) | 281 / 47 / 0 | **281 / 47 / 0**   | unchanged (0 regressions) |
+| Sweep                                                 | before        | after              | Δ                           |
+| ----------------------------------------------------- | ------------- | ------------------ | --------------------------- |
+| `built-ins/*/Symbol.species/*` (29)                   | 0 / 5 / 24 CE | **18 / 11 / 0 CE** | **+18 pass, 0 regressions** |
+| `built-ins/Object/getOwnPropertyDescriptor{,s}` (328) | 281 / 47 / 0  | **281 / 47 / 0**   | unchanged (0 regressions)   |
 
 - `prove-emit-identity`: **IDENTICAL** — all 39 (file,target) emits match the
   main-state baseline (host/gc/wasi inert; corpus has no species gOPD).
@@ -216,7 +385,7 @@ key — every previously-answered shape keeps its exact answer.
 
 > PR: `issue-2984-gopd-runtime-dispatch`. Takes the "obj-VAR receivers"
 > entry of "Still remaining after Phase 3" bucket 1 — `var m = Math;
-> gOPD(m, "atan2")`, the dominant 15.2.3.3-4-* fixture shape, which fell to
+gOPD(m, "atan2")`, the dominant 15.2.3.3-4-\* fixture shape, which fell to
 > the dynamic `__getOwnPropertyDescriptor` path and silently answered
 > `undefined` standalone (probe-verified on main @ 4ac4b6e01a).
 
@@ -241,7 +410,7 @@ key — every previously-answered shape keeps its exact answer.
 > PR: `issue-2984-gopd-ctor-receivers`. Takes the **72 CE ctor/namespace
 > receivers** bucket (bucket 1 of "Still remaining after Phase 2" below) —
 > `gOPD(Math, "atan2")`, `gOPD(Date, "prototype")`, `gOPD(Number,
-> "MAX_VALUE")`, `gOPD(String, "length")`, `gOPD(JSON, "stringify")`.
+"MAX_VALUE")`, `gOPD(String, "length")`, `gOPD(JSON, "stringify")`.
 
 ### Root cause (re-measured on main @ d7a1feaa1cf, 72 CE confirmed intact)
 
@@ -270,21 +439,21 @@ statics.
    `tryEmitStandaloneBuiltinStaticGopd`, called from a new synthesis site in
    the calls.ts gOPD handler (after Site-2, before the `__get_builtin`
    fallback; gate = standalone + unshadowed `BUILTIN_CLASS_NAMES` identifier
-   + literal key). Classification: static method → `{w:true,e:false,c:true}`
-   + singleton `.value` (same value the plain read yields — identity holds);
-   Math/Number constants + `<TypedArray>.BYTES_PER_ELEMENT` → all-false
-   value descriptors; `prototype` (ctors only; Proxy §28.2 and the
-   namespaces own none) → all-false + `$NativeProto` value via
-   `emitLazyNativeProtoGet`; `length`/`name` → `{w:false,e:false,c:true}`;
-   unknown string keys on CLOSED-universe receivers → `undefined`
-   (`gOPD(Math,"caller")`). **Symbol + RegExp unknown members keep the loud
-   refusal** (open universes: well-known-symbol own props / annex-B legacy
-   statics — refuse-loud > silent-wrong).
+   - literal key). Classification: static method → `{w:true,e:false,c:true}`
+   - singleton `.value` (same value the plain read yields — identity holds);
+     Math/Number constants + `<TypedArray>.BYTES_PER_ELEMENT` → all-false
+     value descriptors; `prototype` (ctors only; Proxy §28.2 and the
+     namespaces own none) → all-false + `$NativeProto` value via
+     `emitLazyNativeProtoGet`; `length`/`name` → `{w:false,e:false,c:true}`;
+     unknown string keys on CLOSED-universe receivers → `undefined`
+     (`gOPD(Math,"caller")`). **Symbol + RegExp unknown members keep the loud
+     refusal** (open universes: well-known-symbol own props / annex-B legacy
+     statics — refuse-loud > silent-wrong).
 
 ### Measured (real runner, standalone lane, base = main @ d7a1feaa1cf)
 
 | Sweep                                                                                       | main                       | branch               | Δ                      |
-| -------------------------------------------------------------------------------------------- | -------------------------- | -------------------- | ---------------------- |
+| ------------------------------------------------------------------------------------------- | -------------------------- | -------------------- | ---------------------- |
 | `built-ins/Object/getOwnPropertyDescriptor{,s}` (328)                                       | 199 pass / 57 fail / 72 CE | **270 / 58 / 0**     | **+71, 0 regressions** |
 | collateral (defineProperty + gOPN + Boolean + Function + Error + **Math** + **JSON**, 2286) | 1122 / 1063 / 101 CE       | **1165 / 1068 / 53** | **+43, 0 regressions** |
 

--- a/src/codegen/builtin-ctor-own-props.ts
+++ b/src/codegen/builtin-ctor-own-props.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2984 slice "ctor-carrier own props") Seed the standalone reified
+ * builtin-CONSTRUCTOR carrier object with its §17/§20 own data properties
+ * (`length`, `name`, `prototype`).
+ *
+ * ## Why this exists — the measured gap
+ *
+ * test262's `propertyHelper.js verifyProperty(obj, key, desc)` receives its
+ * receiver as an **untyped harness parameter**, so EVERY descriptor query it
+ * makes is a RUNTIME one: `Function.prototype.call.bind(Object.prototype.
+ * hasOwnProperty)(obj, key)`, `Object.getOwnPropertyDescriptor(obj, key)`,
+ * `for (k in obj)`, `obj[key] = …`, `delete obj[key]`. None of the compiler's
+ * SYNTACTIC builtin-descriptor synthesis (#2984 Phase 2/3,
+ * `builtin-static-gopd.ts`) can fire there — those all key on a
+ * compile-time-resolvable receiver expression.
+ *
+ * Measured on `origin/main` @ `bb5b414a05b6d0` (standalone lane, real
+ * `runTest262File`) through a `function ho(a,b){return Object.prototype.
+ * hasOwnProperty.call(a,b);}` any-param indirection:
+ *
+ * | receiver kind                                                      | `ho(X,k)` | why                                      |
+ * | ------------------------------------------------------------------ | --------- | ---------------------------------------- |
+ * | native METHOD/STATIC closure (`Math.abs`, `Array.prototype.flat`)  | **true**  | #2896 `__builtinfn_*` reflective natives |
+ * | builtin CTOR (`WeakMap`, `Map`, `RangeError`)                      | false     | carrier is an EMPTY `$Object`            |
+ * | native proto (`Date.prototype`)                                    | false     | `$NativeProto`, not `$Object`            |
+ * | plain object literal                                               | false     | lowers to a typed struct                 |
+ *
+ * The ctor row is the one this module closes, and it is the CHEAP one: #3006 /
+ * #2907 already give every ctor in scope a genuine, identity-stable **`$Object`
+ * carrier** (`emitBuiltinConstructorIdentity` / `emitBuiltinNamespaceObject`).
+ * The `$Object` runtime ALREADY honours per-property attributes on every
+ * dynamic path — probe-verified on main with a `Object.defineProperty(Math,
+ * "zz", {value:1,writable:false,enumerable:false,configurable:true})` witness:
+ * runtime `hasOwnProperty` true, runtime gOPD returns the full correct triple,
+ * `for-in` skips it, a non-writable write does not stick, and `verifyProperty`
+ * passes end-to-end for both `configurable:true` and `configurable:false`. So
+ * the carriers were simply EMPTY; nothing about the MOP itself was missing.
+ *
+ * We therefore install the three spec own data properties at carrier
+ * materialization time via the existing native `__defineProperty_value`,
+ * exactly as `emitGeneratorPrototypeSingleton` (#3236 S1, array-object-proto.ts)
+ * installs `next`/`return`/`throw` on `%GeneratorPrototype%`.
+ *
+ * ## Attributes (ECMA-262)
+ *
+ * - `length` — §20.2.4.1 `{ [[Writable]]: false, [[Enumerable]]: false,
+ *   [[Configurable]]: true }`, value = the ctor's declared arity.
+ * - `name` — §20.2.4.2, same attributes, value = the ctor's name string.
+ * - `prototype` — §20.x per-ctor `{ [[Writable]]: false, [[Enumerable]]: false,
+ *   [[Configurable]]: false }`, value = the `$NativeProto` object, i.e. the
+ *   SAME value the syntactic `<Ctor>.prototype` read yields
+ *   (`emitLazyNativeProtoGet`), so descriptor-vs-read identity holds.
+ *
+ * Insert order is spec own-key order for a function object (`length`, `name`,
+ * `prototype`), so `Object.getOwnPropertyNames(<Ctor>)` reports them in the
+ * conforming order.
+ *
+ * ## Scope / safety
+ *
+ * - **Standalone only.** Every call site is already `ctx.standalone`-gated and
+ *   this module re-checks; gc/wasi emits stay byte-identical.
+ * - **Additive only.** The carriers had ZERO own properties before, so no
+ *   previously-observable read changes: a dynamic `X["name"]` went from
+ *   `undefined` to the spec value, `Object.keys(X)` stays `[]` (all three are
+ *   non-enumerable), and every SYNTACTIC `X.name` / `X.length` / `X.prototype`
+ *   read is intercepted upstream by the existing compile-time folds and never
+ *   reaches the carrier.
+ * - Ctors with no `$NativeProto` brand simply skip `prototype` (the other two
+ *   still land) — declining is always safe.
+ */
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { BUILTIN_CTOR_ARITY, tryEnsureNativeProtoBrand } from "./builtin-value-read.js";
+import { emitLazyNativeProtoGet } from "./native-proto.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
+
+/**
+ * Spec `length` for ctors that DO get a runtime carrier but are absent from the
+ * shared `BUILTIN_CTOR_ARITY` table (which is keyed off `BUILTIN_CTOR_NAMES`).
+ * Kept local rather than widening the shared table, because that table also
+ * drives the `<Builtin>.length` / gOPD compile-time folds — widening it would
+ * change reads outside this slice's measured set.
+ */
+const EXTRA_CTOR_ARITY: Record<string, number> = { AggregateError: 2 };
+
+/**
+ * Host descriptor-flag value bit decoded by `__defineProperty_value`
+ * (bit 0 = writable, bit 1 = enumerable, bit 2 = configurable; omitted
+ * attributes default to false per CompletePropertyDescriptor §6.2.6.4).
+ */
+const HOST_FLAG_CONFIGURABLE = 0x04;
+
+/**
+ * `true` when `builtinName` names a builtin CONSTRUCTOR (not a namespace like
+ * `Math`/`JSON`/`Reflect`, which own no `length`/`name`/`prototype`).
+ */
+export function isSeedableBuiltinCtorCarrier(builtinName: string): boolean {
+  return builtinName in BUILTIN_CTOR_ARITY || builtinName in EXTRA_CTOR_ARITY;
+}
+
+/**
+ * Emit — into `fctx.body`, which the caller has already swapped to the
+ * carrier's lazy-init body — the `__defineProperty_value` calls that install
+ * `length` / `name` / `prototype` on the carrier object held in `objLocal`.
+ *
+ * No-op (nothing pushed) when the target is not a constructor, when the module
+ * is not standalone, or when the object runtime is unavailable. Stack-neutral.
+ */
+export function pushBuiltinCtorOwnPropSeed(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  builtinName: string,
+  objLocal: number,
+): void {
+  if (!ctx.standalone) return;
+  const arity = BUILTIN_CTOR_ARITY[builtinName] ?? EXTRA_CTOR_ARITY[builtinName];
+  if (arity === undefined) return;
+
+  const defineIdx = ctx.funcMap.get("__defineProperty_value");
+  if (defineIdx === undefined) return;
+
+  // `__box_number` is a late import; the caller registered the OUTER body in
+  // `ctx.liveBodies` before swapping `fctx.body`, so a shift here walks both.
+  const boxIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
+  if (boxIdx === undefined) return;
+  flushLateImportShifts(ctx, fctx);
+
+  // §20.2.4.1 `length` — { w:false, e:false, c:true }.
+  fctx.body.push({ op: "local.get", index: objLocal });
+  addStringConstantGlobal(ctx, "length");
+  for (const instr of stringConstantExternrefInstrs(ctx, "length")) fctx.body.push(instr);
+  fctx.body.push({ op: "f64.const", value: arity });
+  fctx.body.push({ op: "call", funcIdx: boxIdx });
+  fctx.body.push({ op: "f64.const", value: HOST_FLAG_CONFIGURABLE });
+  fctx.body.push({ op: "call", funcIdx: defineIdx });
+  fctx.body.push({ op: "drop" }); // helper returns the target; discard
+
+  // §20.2.4.2 `name` — { w:false, e:false, c:true }.
+  fctx.body.push({ op: "local.get", index: objLocal });
+  addStringConstantGlobal(ctx, "name");
+  for (const instr of stringConstantExternrefInstrs(ctx, "name")) fctx.body.push(instr);
+  addStringConstantGlobal(ctx, builtinName);
+  for (const instr of stringConstantExternrefInstrs(ctx, builtinName)) fctx.body.push(instr);
+  fctx.body.push({ op: "f64.const", value: HOST_FLAG_CONFIGURABLE });
+  fctx.body.push({ op: "call", funcIdx: defineIdx });
+  fctx.body.push({ op: "drop" });
+
+  // `prototype` — { w:false, e:false, c:false }, value = the `$NativeProto`
+  // singleton (identical to the syntactic `<Ctor>.prototype` read). Ctors with
+  // no registered brand keep only `length`/`name`.
+  const brand = tryEnsureNativeProtoBrand(ctx, builtinName);
+  if (brand === undefined) return;
+  const mark = fctx.body.length;
+  fctx.body.push({ op: "local.get", index: objLocal });
+  addStringConstantGlobal(ctx, "prototype");
+  for (const instr of stringConstantExternrefInstrs(ctx, "prototype")) fctx.body.push(instr);
+  if (!emitLazyNativeProtoGet(ctx, fctx, brand)) {
+    // Roll back the partial `prototype` sequence — leave the body exactly as it
+    // was after `name` (stack-neutral).
+    fctx.body.length = mark;
+    return;
+  }
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "call", funcIdx: defineIdx });
+  fctx.body.push({ op: "drop" });
+}

--- a/src/codegen/builtin-ctor-own-props.ts
+++ b/src/codegen/builtin-ctor-own-props.ts
@@ -70,6 +70,7 @@
  *   still land) — declining is always safe.
  */
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { withSpeculativeCompile } from "./context/speculative.js";
 import { BUILTIN_CTOR_ARITY, tryEnsureNativeProtoBrand } from "./builtin-value-read.js";
 import { emitLazyNativeProtoGet } from "./native-proto.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
@@ -144,17 +145,19 @@ export function pushBuiltinCtorOwnPropSeed(
   // no registered brand keep only `length`/`name`.
   const brand = tryEnsureNativeProtoBrand(ctx, builtinName);
   if (brand === undefined) return;
-  const mark = fctx.body.length;
-  fctx.body.push({ op: "local.get", index: objLocal });
-  addStringConstantGlobal(ctx, "prototype");
-  for (const instr of stringConstantExternrefInstrs(ctx, "prototype")) fctx.body.push(instr);
-  if (!emitLazyNativeProtoGet(ctx, fctx, brand)) {
-    // Roll back the partial `prototype` sequence — leave the body exactly as it
-    // was after `name` (stack-neutral).
-    fctx.body.length = mark;
-    return;
-  }
-  fctx.body.push({ op: "f64.const", value: 0 });
-  fctx.body.push({ op: "call", funcIdx: defineIdx });
-  fctx.body.push({ op: "drop" });
+  // Speculative: `emitLazyNativeProtoGet` may decline, and it can allocate
+  // locals / late imports before doing so. A raw `body.length = mark` would undo
+  // only the body and strand those — hence the #1919 transactional helper, which
+  // rolls back body + locals + imports + errors together. On decline the body is
+  // left exactly as it was after `name` (stack-neutral).
+  withSpeculativeCompile(ctx, fctx, () => {
+    fctx.body.push({ op: "local.get", index: objLocal });
+    addStringConstantGlobal(ctx, "prototype");
+    for (const instr of stringConstantExternrefInstrs(ctx, "prototype")) fctx.body.push(instr);
+    if (!emitLazyNativeProtoGet(ctx, fctx, brand)) return { commit: false, value: undefined };
+    fctx.body.push({ op: "f64.const", value: 0 });
+    fctx.body.push({ op: "call", funcIdx: defineIdx });
+    fctx.body.push({ op: "drop" });
+    return { commit: true, value: undefined };
+  });
 }

--- a/src/codegen/builtin-ctor-own-props.ts
+++ b/src/codegen/builtin-ctor-own-props.ts
@@ -93,14 +93,6 @@ const EXTRA_CTOR_ARITY: Record<string, number> = { AggregateError: 2 };
 const HOST_FLAG_CONFIGURABLE = 0x04;
 
 /**
- * `true` when `builtinName` names a builtin CONSTRUCTOR (not a namespace like
- * `Math`/`JSON`/`Reflect`, which own no `length`/`name`/`prototype`).
- */
-export function isSeedableBuiltinCtorCarrier(builtinName: string): boolean {
-  return builtinName in BUILTIN_CTOR_ARITY || builtinName in EXTRA_CTOR_ARITY;
-}
-
-/**
  * Emit — into `fctx.body`, which the caller has already swapped to the
  * carrier's lazy-init body — the `__defineProperty_value` calls that install
  * `length` / `name` / `prototype` on the carrier object held in `objLocal`.

--- a/src/codegen/builtin-static-globals.ts
+++ b/src/codegen/builtin-static-globals.ts
@@ -11,6 +11,7 @@ import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 import { ts } from "../ts-api.js";
 import { emitCachedFuncClosureAccess } from "./closures.js";
+import { pushBuiltinCtorOwnPropSeed } from "./builtin-ctor-own-props.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { allocLocal } from "./context/locals.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
@@ -137,16 +138,37 @@ export function emitBuiltinConstructorIdentity(
     ctx.builtinObjectGlobals.set(key, globalIdx);
   }
 
+  // (#2984 ctor-carrier own props) The carrier is materialized through a local
+  // so the §17/§20 own data properties (`length`/`name`/`prototype`) can be
+  // installed on it before it is published to the global. Without them the
+  // carrier is an EMPTY `$Object`, and every RUNTIME descriptor query
+  // test262's `verifyProperty` makes through its any-typed harness parameter
+  // (`hasOwnProperty`, `gOPD`, for-in, write, delete) answers "absent".
+  const objLocal = allocLocal(fctx, `__builtin_ctor_${builtinName}_obj_${fctx.locals.length}`, {
+    kind: "externref",
+  });
+  const initBody: Instr[] = [
+    { op: "call", funcIdx: newObjectIdx },
+    { op: "local.set", index: objLocal },
+  ];
+
+  // (#2182 pattern) `savedBody` is detached during the swap; register it in
+  // `liveBodies` so a late-import funcidx shift walks it too.
+  const savedBody = fctx.body;
+  fctx.body = initBody;
+  ctx.liveBodies.add(savedBody);
+  try {
+    pushBuiltinCtorOwnPropSeed(ctx, fctx, builtinName, objLocal);
+    fctx.body.push({ op: "local.get", index: objLocal });
+    fctx.body.push({ op: "global.set", index: globalIdx });
+  } finally {
+    fctx.body = savedBody;
+    ctx.liveBodies.delete(savedBody);
+  }
+
   fctx.body.push({ op: "global.get", index: globalIdx });
   fctx.body.push({ op: "ref.is_null" });
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "empty" },
-    then: [
-      { op: "call", funcIdx: newObjectIdx },
-      { op: "global.set", index: globalIdx },
-    ],
-  });
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: initBody, else: [] });
   fctx.body.push({ op: "global.get", index: globalIdx });
   return { kind: "externref" };
 }
@@ -317,6 +339,11 @@ export function emitBuiltinNamespaceObject(
       coerceTopToExternref(fctx, valueType);
       fctx.body.push({ op: "call", funcIdx: setIdx });
     }
+    // (#2984 ctor-carrier own props) The Error-family / `Array` / `Object`
+    // carriers are CONSTRUCTOR objects, so they also own `length`/`name`/
+    // `prototype`. No-op for the true namespaces (`Math`/`JSON`/`Reflect`),
+    // which own none of the three.
+    pushBuiltinCtorOwnPropSeed(ctx, fctx, builtinName, objLocal);
     fctx.body.push({ op: "local.get", index: objLocal });
     fctx.body.push({ op: "global.set", index: globalIdx });
   } finally {

--- a/tests/issue-2984-ctor-carrier-own-props.test.ts
+++ b/tests/issue-2984-ctor-carrier-own-props.test.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2984 slice "ctor-carrier own props" — the standalone reified builtin
+// CONSTRUCTOR carrier (#3006 `emitBuiltinConstructorIdentity` / #2907
+// `emitBuiltinNamespaceObject`) now owns its §17/§20 `length` / `name` /
+// `prototype` data properties.
+//
+// WHY this matters (measured on main @ bb5b414a05b6d0, standalone lane):
+// test262's `propertyHelper.js verifyProperty(obj, key, desc)` takes its
+// receiver as an UNTYPED harness parameter, so every descriptor query it makes
+// is a RUNTIME one. None of #2984's syntactic Phase-2/3 synthesis can fire
+// there. Probing through a `function ho(a,b){return
+// Object.prototype.hasOwnProperty.call(a,b);}` indirection showed native method
+// closures answer correctly (#2896 `__builtinfn_*`) while builtin CTORS answer
+// "absent" — their carrier was an EMPTY `$Object`. The `$Object` runtime
+// already honours per-property attributes on every dynamic path, so seeding the
+// three spec properties at materialization is all that was missing.
+//
+// The assertions below deliberately read `writable`/`enumerable`/
+// `configurable`/`value` INDEPENDENTLY (and prefer NUMERIC and OBJECT-IDENTITY
+// comparisons over string ones) rather than trusting a test262 verdict — a
+// string `assert.sameValue` can false-positive on the standalone lane, so a
+// string-only check would not be evidence the descriptor is right.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors?.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+// Route the receiver through an `any`-typed parameter, exactly as
+// `verifyProperty` does — this is the shape the whole slice is about.
+const THRU_FN = `
+  var hits = 0;
+  var check = function (a: any, b: any): void { if (a === b) { hits = hits + 1; } };
+  var gg = function (o: any, k: any): any { return Object.getOwnPropertyDescriptor(o, k); };
+  var ho = function (o: any, k: any): any { return Object.prototype.hasOwnProperty.call(o, k); };
+`;
+
+describe("#2984 ctor-carrier own props: runtime descriptor MOP on builtin constructors", () => {
+  it("WeakMap.name — runtime hasOwnProperty + full attribute triple (§20.2.4.2)", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      check(ho(WeakMap, "name"), true);
+      var d = gg(WeakMap, "name");
+      check(typeof d, "object");
+      check(d.writable, false);
+      check(d.enumerable, false);
+      check(d.configurable, true);
+      return hits;
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("WeakMap.length — NUMERIC value 0 through the runtime descriptor (§20.2.4.1)", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      check(ho(WeakMap, "length"), true);
+      var d = gg(WeakMap, "length");
+      check(d.value, 0);
+      check(d.writable, false);
+      check(d.enumerable, false);
+      check(d.configurable, true);
+      return hits;
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("RangeError.length — NUMERIC value 1 (Error-family namespace carrier)", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      var d = gg(RangeError, "length");
+      check(d.value, 1);
+      check(d.configurable, true);
+      check(d.writable, false);
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("Map.prototype — OBJECT IDENTITY with the syntactic read, all-false attributes", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      check(ho(Map, "prototype"), true);
+      var d = gg(Map, "prototype");
+      check(d.value, Map.prototype);
+      check(d.writable, false);
+      check(d.enumerable, false);
+      check(d.configurable, false);
+      return hits;
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("distinct ctors carry distinct prototypes (not a null-null tautology)", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      var a = gg(Map, "prototype");
+      var b = gg(Set, "prototype");
+      if (a.value !== b.value) { hits = hits + 1; }
+      if (a.value === Map.prototype) { hits = hits + 1; }
+      if (b.value === Set.prototype) { hits = hits + 1; }
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("the seeded properties are NON-ENUMERABLE (Object.keys / for-in unchanged)", async () => {
+    const ret = await runStandalone(`
+      var hits = 0;
+      if (Object.keys(WeakMap).length === 0) { hits = hits + 1; }
+      var n = 0;
+      for (var k in WeakMap) { n = n + 1; }
+      if (n === 0) { hits = hits + 1; }
+      if (Object.keys(RangeError).length === 0) { hits = hits + 1; }
+      return hits;
+    `);
+    expect(ret).toBe(3);
+  });
+
+  it("GUARD: true NAMESPACES (Math/JSON/Reflect) get no name/length/prototype", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      check(ho(Math, "name"), false);
+      check(ho(Math, "length"), false);
+      check(ho(Math, "prototype"), false);
+      check(ho(JSON, "name"), false);
+      check(ho(Reflect, "name"), false);
+      return hits;
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("GUARD: the syntactic folds and #3006 ctor identity are unchanged", async () => {
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      check(WeakMap.name, "WeakMap");
+      check(WeakMap.length, 0);
+      check(Map.prototype.constructor, Map);
+      if (Set !== Map) { hits = hits + 1; }
+      if (Set === Set) { hits = hits + 1; }
+      return hits;
+    `);
+    expect(ret).toBe(5);
+  });
+
+  it("configurable:true seeded props delete; configurable:false ones survive", async () => {
+    // `verifyProperty`'s `isConfigurable` does `delete obj[name]` inside a
+    // TypeError-tolerant try/catch and then requires `hasOwnProperty` to agree.
+    // Our runtime is over-strict for the non-configurable case (sloppy-mode
+    // `delete` should return false rather than throw — a pre-existing
+    // `$Object` behaviour, harness-tolerated), so the probe mirrors the
+    // harness and catches. What must hold is the POST-STATE.
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      var del = function (o: any, k: any): number { try { delete o[k]; return 0; } catch (e) { return 1; } };
+      del(WeakSet, "name");
+      check(ho(WeakSet, "name"), false);
+      del(WeakSet, "prototype");
+      check(ho(WeakSet, "prototype"), true);
+      return hits;
+    `);
+    expect(ret).toBe(2);
+  });
+
+  it("KNOWN GAP (pre-existing): a dynamic write bypasses the non-writable flag", async () => {
+    // The DESCRIPTOR correctly reports `writable:false`, but the dynamic
+    // `o[k] = v` store path (`__extern_set`) does not consult `$PropEntry`
+    // flags, so the write lands. This is a pre-existing `$Object` runtime gap
+    // (it reproduces for any `Object.defineProperty`-defined non-writable
+    // property, not just these carriers) — pinned here so a future fix in the
+    // store path is noticed rather than silently changing this slice's shape.
+    const ret = await runStandalone(`
+      ${THRU_FN}
+      var wr = function (o: any, k: any, v: any): void { o[k] = v; };
+      var rd = function (o: any, k: any): any { return o[k]; };
+      check(gg(WeakRef, "length").writable, false);
+      wr(WeakRef, "length", 99);
+      check(rd(WeakRef, "length"), 99);
+      return hits;
+    `);
+    expect(ret).toBe(2);
+  });
+
+  it("host (gc) lane still compiles the same sources", async () => {
+    const src = `export function test(): number {
+      var d: any = Object.getOwnPropertyDescriptor(WeakMap, "name");
+      return d === undefined ? 0 : 1;
+    }`;
+    const r = await compile(src, { skipSemanticDiagnostics: true });
+    expect(r.success, r.errors?.map((e) => e.message).join("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Slice "ctor-carrier own props" — #2984, the RUNTIME (any-param receiver) axis

Base = `origin/main` @ `bb5b414a05b6d0`. Standalone baseline = the 2026-07-24 13:38 promote (oracle_version 10, lane `honest`, 48,088 rows).

### Why this axis (re-measurement)

Every #2984 slice so far fixes the **syntactic** axis — a gOPD call site whose receiver expression the compiler can resolve at compile time. But test262's `propertyHelper.js verifyProperty(obj, key, desc)` takes its receiver as an **untyped harness parameter**, so every descriptor query it makes is a RUNTIME one and no syntactic synthesis can fire there.

Measured on main, routing the receiver through `function ho(a,b){return Object.prototype.hasOwnProperty.call(a,b);}`:

| receiver kind | `ho(X,k)` | why |
| --- | --- | --- |
| native METHOD/STATIC closure (`Math.abs`, `Array.prototype.flat`) | **true** | #2896 `__builtinfn_*` reflective natives |
| builtin CTOR (`WeakMap`, `Map`, `RangeError`) | false | #3006/#2907 carrier is an **empty** `$Object` |
| native proto (`Date.prototype`) | false | `$NativeProto`, not `$Object` |
| plain object literal | false | lowers to a typed struct |

The ctor row is the cheap one: the `$Object` runtime **already** honours per-property attributes on every dynamic path (probe-verified with an `Object.defineProperty(Math,"zz",...)` witness — runtime `hasOwnProperty`, gOPD triple, `for-in` skip, non-writable write, both delete polarities). The carriers were simply empty.

### Change

New subsystem module `src/codegen/builtin-ctor-own-props.ts` installs, at carrier materialization time via the existing native `__defineProperty_value`:

- `length` §20.2.4.1 `{w:F,e:F,c:T}` — `BUILTIN_CTOR_ARITY[name]`
- `name` §20.2.4.2 `{w:F,e:F,c:T}` — the ctor name
- `prototype` `{w:F,e:F,c:F}` — the `$NativeProto` the syntactic `<Ctor>.prototype` read yields, so `desc.value === X.prototype` holds

Two thin call sites in `builtin-static-globals.ts` (`emitBuiltinConstructorIdentity` #3006, `emitBuiltinNamespaceObject` #2907). Pattern mirrors `emitGeneratorPrototypeSingleton` (#3236 S1). `ctx.standalone`-gated. No-op for true namespaces (`Math`/`JSON`/`Reflect` own none of the three).

### Measured

| sweep | before | after | delta |
| --- | --- | --- | --- |
| the 50 a1 rows with a seedable-ctor receiver, key in {name,length,prototype} | **0 / 50** | **49 / 50** | **+49** |
| 2,137-file regression sweep over the touched ctor dirs + MOP-sensitive `Object/*` dirs, **local-vs-local A/B** (same runner, seed force-disabled vs enabled) | — | — | **0 regressions, 0 changed error signatures, +50 improvements** |

- `prove-emit-identity`: **IDENTICAL** — all 60 (file,target) emits across gc/standalone/wasi/linear match the pre-change baseline.
- `tests/issue-2984-ctor-carrier-own-props.test.ts` 11/11; the 8 related suites (2984 x6, 3006, 2896) 85/85.
- `check:loc-budget` OK, `check:oracle-ratchet` OK (+0/+0).
- Hold-out: `AggregateError/prototype/prop-desc.js` fails *before* `verifyProperty` on `assert.sameValue(typeof AggregateError.prototype,'object')` — unrelated, pre-existing.

### HONESTY NOTE — how much of the +49 is earned

An A/B-controlled wrong-expectation set (seed force-disabled vs enabled) shows **`verifyProperty` is vacuous past its a1 gate on the standalone lane, on main, today**: a deliberately wrong `value`/`writable`/`enumerable`/`configurable` still reports **pass**. The decisive control is `verifyProperty(Math.abs,"name",{...writable:TRUE})` — an **untouched** #2896 path — which passes with the seed disabled too. Mechanism: `verifyProperty` accumulates into `failures` through `__push`/`__join` (`Function.prototype.call.bind(...)` — the uncurryThis family), which misbehaves standalone, so the final `assert(false, ...)` never fires. Only the a1 assert is live.

So: the **descriptors themselves are real and independently verified** (the vitest suite asserts each attribute/value with direct `===` reads — numeric `length`, object-identity `prototype`), but the test262 flips are **a1-gate-earned**, not "+49 conforming descriptors". Full write-up + the control table are in the issue file.

Two further verdict-oracle holes found while measuring (**not** fixed here, both pre-existing): a test whose only statement is `throw new Test262Error("HELLO")` reports **pass** standalone; and `assert.sameValue("" + true, "SHOWME")` **passes**.

Issue: `plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Measurement correction (author self-reported)

An earlier revision of this description claimed **+118 improvements**. That number was measured by diffing a *local* sweep against the *committed* standalone baseline JSONL, which is contaminated: the baseline is produced by the sharded CI worker, and a local in-process `runTest262File` differs on the `L:N ` error-prefix and on a large `standalone target emitted host imports: env::X` (#2961) population that does not reproduce locally — 611 rows showed a changed signature from that alone, and most of the phantom gain was `env::WeakMap_new`-class rows this change cannot explain.

Re-run as a proper **local-vs-local A/B**: **0 regressions, 0 changed error signatures on fail→fail rows** (so the #3439 hard-0 unclassified-root-causes gate has nothing new to park on), **+50 improvements** — 46 in the target set, and all 4 outside it attributable to the seeded `prototype` (`Error/prototype/S15.11.3.1_A{1,2,4}_T1.js`, `Object/prototype/S15.2.3.1_A3.js`). The headline **0/50 → 49/50** on the target set is unchanged.
