### PR TITLE
fix(#2864 D4): doneState must be the real fallthrough state, not states.length-1

### DIFF
--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -1,9 +1,10 @@
 ---
 id: 2864
 title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-opus5-gen
 created: 2026-06-30
-updated: 2026-07-23
+updated: 2026-07-24
 priority: high
 feasibility: hard
 model: fable
@@ -380,10 +381,13 @@ open dispatch) all pass. What was actually missing on the sync-carrier side:
 - **D3 — general-iterable `yield*`**: lives in #2173 (vec-cursor for numeric
   arrays — slice-2a there, NOT blocked by #2106; generic `{next()}` +
   `.return()` close as slice-2b, which SHOULD reuse D2's forwarding shape).
-- **D4 — try/CATCH across yield** (F2 deferral): do NOT extend the ad-hoc
-  region modeling in `generators-native.ts` for this — see the alignment
-  decision below; catch-region routing is exactly what #2906 slice 3c builds
-  for async. Trigger point for the planner convergence.
+- **D4 — try/CATCH across yield** (F2 deferral): ~~do NOT extend the ad-hoc
+  region modeling in `generators-native.ts` for this~~ — **SUPERSEDED, see the
+  D4 section below.** #3050 landed `lowerTryRegion` in `generators-native.ts`
+  (catch across yield + yielding finally) BEFORE this note was written, so the
+  "still bails / converge at the planner" framing was already stale when D4 was
+  dispatched. The remaining D4 work was a `doneState` misroute, not a missing
+  capability.
 
 ### Alignment decision: sync generators vs the #2906 AsyncCfgPlan machine
 
@@ -490,7 +494,9 @@ loop-carried two-pass close.
   non-generator iterators) is #2173 slice-2b's D2-shape reuse, unchanged here
   (the outer now completes correctly; the foreign iterator is simply not
   notified).
-- try/CATCH across yield (D4) stays on the host path — #2906 3c convergence.
+- ~~try/CATCH across yield (D4) stays on the host path — #2906 3c convergence.~~
+  **Stale** — see the D4 section below; #3050 had already landed the region
+  machinery natively.
 
 ### Files (D2)
 
@@ -502,6 +508,127 @@ loop-carried two-pass close.
   finally ordering, pre-delegation abrupt, finally-throw upgrade, loop-carried
   close, done protocol, vec first-statement close, prelude-once, and
   resume-binding survival.
+
+## D4 — try/catch across yield: `doneState` misroute (landed 2026-07-24)
+
+### Verify-first: the F2/D2 deferral note was STALE
+
+The dispatch framed D4 as "try/CATCH across a yield still bails to the host
+path (`generators-native.ts` try-statement lowering: `if (stmt.catchClause)
+fail()`) — converge onto the #2906 CFG planner." **That is not current main.**
+#3050 (`fdc11cbd`, "try-region state machine for native generators — catch
+across yield + yielding finally") landed `lowerTryRegion` in
+`generators-native.ts` well before the note was written; there is no
+`if (stmt.catchClause) fail()` anywhere in the file. No planner convergence was
+needed, and none was done.
+
+Measured on main (12-shape probe, `--target standalone`, host-free asserted,
+each compared against Node on the same source) **9/12 already passed**:
+runtime-throw-after-resume caught, `gen.throw()` routed into a catch, catch
+that re-yields, try/catch/finally across a yield, `yield` inside a catch,
+`yield` inside a finally, catch param read after a yield in the catch, nested
+try/catch across a yield, and the boxed-any carrier through a catch.
+
+The 3 that did not:
+
+| shape                                      | before                                           | now                     |
+| ------------------------------------------ | ------------------------------------------------ | ----------------------- |
+| try/catch across yield **inside a loop**   | raw wasm exception escaped (catch skipped)       | **fixed here**          |
+| `return v` inside try + yield-free finally | finally SKIPPED, silent wrong answer (15 vs 315) | spun off as **#3582**   |
+| `yield*` inside a try-region               | clean #680 CE refusal (documented bail)          | unchanged, out of scope |
+
+### Root cause (not the symptom)
+
+`registerNativeGenerator` derived `doneState: plan.states.length - 1`. That
+coincides with the final `done` state **only for a straight-line body**. Every
+structural lowering — `lowerFor` / `lowerWhile` / `lowerDoWhile` / `lowerIf`
+and the #3050 `lowerTryRegion` — reserves its exit/join state **before**
+lowering the nested body, so a body that ENDS in one of those leaves the
+fallthrough cursor at a LOWER id, and `states.length - 1` is then a **live
+yield-successor state**.
+
+Measured plans (`curId` = the state given the final `done` terminator):
+
+| body shape                         | states | fallthrough | `states.length-1` |
+| ---------------------------------- | ------ | ----------- | ----------------- |
+| straight-line (control)            | 7      | 6           | 6 ✅              |
+| `try { yield } catch {}` as body   | 5      | **3**       | 4 ❌ (yield succ) |
+| `for … { try { yield } catch {} }` | 9      | **4**       | 8 ❌ (yield succ) |
+| `if (…) { yield } else { yield }`  | 6      | **3**       | 5 ❌ (yield succ) |
+| nested `for`/`for`                 | 10     | **4**       | 9 ❌ (yield succ) |
+
+The consumer's suspension test is
+`suspended = state != START && state != doneState`
+(`generators-native-consumer.ts`). With the alias in place, a generator
+genuinely suspended at that last-reserved yield state reported **DONE**, so
+`.throw(e)` / `.return(v)` took the §27.5.3.4 _already-completed_ arm and
+**never resumed** — the enclosing `catch` across the yield never ran and the
+error escaped raw. The same alias also made the `done` terminator store a LIVE
+state id as "completed", so a post-exhaustion `.next()` re-entered live states
+(benignly idempotent for a simple loop, but it re-ran the loop's update
+expression).
+
+Why the failure looked try/catch-specific but is not: without a handler the
+already-completed arm's observable behaviour _coincides_ with the correct one
+(`.return(v)` → `{v, done:true}`, `.throw(e)` → throws `e`). Only when there is
+a finalizer/handler to run does the misroute become visible. So the bug is
+**loop/if/try-TAIL-shaped**, not try/catch-shaped, and it was latent in every
+such generator since the structural lowerings were added.
+
+### The fix
+
+`buildNativeGeneratorPlan` now returns the real `doneState` — the fallthrough
+cursor, or the dedicated empty placeholder it already minted when that state
+carries trailing statements (#3050's re-run guard) — and
+`registerNativeGenerator` consumes `plan.doneState`. Three lines of behaviour;
+the rest is the explanation above, banked at both definition sites.
+
+Safety argument, verified rather than asserted: a `yield` terminator always
+mints a FRESH successor as the new cursor, so the state that receives the final
+`done` terminator can only coincide with a suspension point when the body's
+last statement is itself a `yield` — in which case the two ids were already
+equal before this change and the pre-existing (spec-equivalent, handler-free)
+behaviour is preserved bit-for-bit.
+
+### Measured delta (8-shape × 3-lane matrix, host-free asserted)
+
+| shape                                                      | before (standalone/wasi) | after        |
+| ---------------------------------------------------------- | ------------------------ | ------------ |
+| M1 `try { yield } catch {}` as whole body, `.throw()`      | raw wasm exception       | ✅ 511       |
+| M2 `for … { try { yield } catch {} }`, `.throw()`          | raw wasm exception       | ✅ 101       |
+| M3 `while … { try { yield } catch {} }`, `.throw()`        | raw wasm exception       | ✅ 101       |
+| M8 nested `for`/`for` under one try, `.throw()`            | raw wasm exception       | ✅ 301       |
+| M4/M5/M7 `.return()` through a finally (loop/if/loop-tail) | already correct          | ✅ unchanged |
+| M6 straight-line try/catch + trailing yield (control)      | already correct          | ✅ unchanged |
+
+**4 measured shapes flip from a raw escaping exception to spec behaviour; 4
+controls unchanged.** The gc lane is untouched for every try/catch shape above
+— all still route to the eager-buffer host path (`__gen_*` present), so this is
+a standalone + wasi delta. A PLAIN loop-tail generator (no try) DOES route
+native on gc, so gc bytes change there; observable behaviour does not (see the
+handler-free coincidence above), and the byte matrix covers it.
+
+### Files (D4)
+
+- `src/codegen/generators-native.ts` — `NativeGeneratorPlan.doneState` (new,
+  with the root-cause note), computed at the final fallthrough in
+  `buildNativeGeneratorPlan`, consumed by `registerNativeGenerator`.
+- `tests/issue-2864-d4-catch-across-yield.test.ts` — standalone regression
+  suite (zero-host-import asserted).
+
+### Deferred out of D4 (each has a clean, non-silent fallback today)
+
+- **#3582** — `return v` inside a try with a yield-free finally skips the
+  finally (silent wrong answer). Root cause + the recommended fix shape are
+  recorded there.
+- **`yield*` inside a try-region** — clean #680 CE refusal
+  (`generators-native.ts`, the `unwind.some(e => e.kind !== "replay")` bail in
+  `emitYield`'s asterisk branch). Needs the delegation states to observe the
+  resume mode so an abrupt can route into the region.
+- **`return` inside a try whose finally is STATE-LOWERED** (yielding finally) —
+  clean #680 CE refusal (the `unwind.some(e => e.kind === "finally")` bail in
+  the `isReturnStatement` branch). This is the return-through-a-suspending-
+  finally path; #2906 3c-ii-b solved the analogous async case.
 
 ## Slice routing after D2 (what remains where)
 

--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -18,6 +18,16 @@ umbrella: 2860
 architect_spec: candidate
 loc-budget-allow:
   - src/codegen/generators-native.ts
+func-budget-allow:
+  # D4 (+10 LOC): buildNativeGeneratorPlan must now compute the REAL fallthrough
+  # state instead of assuming states.length-1. That assumption only holds for a
+  # straight-line body — every structural lowering (lowerFor/lowerWhile/
+  # lowerDoWhile/lowerIf and #3050's lowerTryRegion) reserves its exit/join state
+  # BEFORE the nested body, so a loop/if/try-TAIL body leaves the fallthrough at a
+  # lower id. Deriving it correctly is inherently a few lines inside the planner;
+  # extracting it would split the state-reservation invariant across two units.
+  # Same rationale as the D2 loc-budget-allow grant (#2662 precedent).
+  - src/codegen/generators-native.ts::buildNativeGeneratorPlan
 ---
 
 # Standalone: Wasm-native generator carrier (sync)

--- a/plan/issues/3582-native-generator-return-skips-replay-finally.md
+++ b/plan/issues/3582-native-generator-return-skips-replay-finally.md
@@ -1,0 +1,127 @@
+---
+id: 3582
+title: "Native generator: `return v` inside try/finally SKIPS the finally (silent wrong answer, standalone/wasi)"
+status: ready
+created: 2026-07-24
+updated: 2026-07-24
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2864, 3050]
+umbrella: 2864
+---
+
+# Native generator: an explicit `return` inside try/finally skips the finally
+
+## Problem
+
+In a Wasm-native (standalone / wasi) generator, an explicit `return <expr>`
+inside a `try` whose `finally` is **yield-free** does **not** run the finally.
+This is a **silent wrong answer**, not a refusal — the generator completes with
+the right value but the cleanup never happens.
+
+Verify-first repro (`--target standalone`, compiles host-free, `imports = []`):
+
+```ts
+let log = 0;
+function* g() {
+  try {
+    yield 1;
+    return 5;
+  } finally {
+    log = 3;
+  }
+}
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const r = it.next();
+  return log * 100 + a * 10 + (r.value as number);
+}
+```
+
+| lane              | result                      |
+| ----------------- | --------------------------- |
+| Node              | `315` (log=3, a=1, value=5) |
+| standalone / wasi | **`15`** — `log` stayed 0   |
+
+Also reproduces with **no yield inside the try** at all
+(`yield 1; try { return 5 } finally { log = 3 }` → `15` vs `315`), so it is not
+a suspension-crossing issue: it is the `return` lowering itself.
+
+Split out of #2864 D4 (2026-07-24) so the D4 `doneState` fix ships as its own
+slice.
+
+## Root cause
+
+`buildNativeGeneratorPlan` → `lowerStatements`, the `ts.isReturnStatement`
+branch (`src/codegen/generators-native.ts`). It bails only when the unwind
+chain contains a **state-lowered** finally:
+
+```ts
+if (unwind.some((e) => e.kind === "finally")) return fail();
+collectSpillsIn(stmt);
+finishState(curId, { kind: "return", expr: stmt.expression });
+```
+
+A **legacy kind-L region** (finally-only with a yield-free finally, the
+byte-identical pre-#3050 path) contributes `replay` entries to `unwind`, not
+`finally` entries. `replay` entries are neither run nor bailed on here — so the
+finalizer statements are simply dropped on the `return` path. They ARE run on
+the normal fallthrough path (`lowerStatements` pushes them into the current
+state's prelude after lowering the try body) and on the abrupt-resume path
+(`startStateAfterYield` captures them into `abruptResume.finalizers`); only the
+explicit-`return` path misses them.
+
+## Implementation notes (read before coding)
+
+**Do the finalizers on the `return` TERMINATOR, not in the state prelude.**
+JS order is: evaluate the return expression FIRST, then run the finally
+(`try { return f() } finally { g() }` calls `f()` before `g()`). Pushing the
+finalizer statements into `curStatements` runs them **before** the terminator
+compiles `expr` — wrong order, observable whenever the finally writes anything
+the return expression reads.
+
+So: add an optional `finalizers?: ts.Statement[][]` to the `return` terminator
+and, at emit time, compile `expr` into the result local first, then run the
+finalizers, then complete. This mirrors what the abrupt tail already does
+(`storeSpills` → set done → build result) and what
+`emitUnwindWalk`'s `replay` arm does.
+
+**Do NOT** try to introduce a synthetic `const __genret = expr;`
+`VariableStatement` to hold the value: a factory-created identifier has no
+checker type, so `resolveSpillLocalValType` (and the whole spill-typing
+cascade) cannot type it. The existing synthetic nodes in this file all re-use
+REAL declaration lists / expressions for exactly this reason.
+
+**Ordering:** `unwind` is threaded **outermost-first**; every existing consumer
+(`startStateAfterYield`, the `emitYield` asterisk branch) `.reverse()`s it to
+innermost-first before use. Match that — innermost finally runs first.
+
+**Scope note:** only `replay` entries need handling here. The
+state-lowered-`finally` case keeps its existing clean `fail()` bail (that is
+the return-through-a-_suspending_-finally path, a separate capability — the
+async analogue is #2906 3c-ii-b).
+
+## Acceptance criteria
+
+- The repro above returns `315` on `--target standalone` and `--target wasi`,
+  host-free (`result.imports` empty).
+- The no-yield-in-try variant returns `315` too.
+- Nested try/finally around a `return` runs finalizers innermost-first.
+- A finally that MUTATES a variable read by the return expression still
+  observes JS order (expression evaluated first).
+- Byte-stability: generators with no `return`-inside-a-replay-region are
+  byte-identical across gc / standalone / wasi.
+
+## Test plan
+
+Extend `tests/issue-2864-standalone-generator-carrier.test.ts` (or a new
+`tests/issue-3582-*.test.ts`) with the standalone cases above, zero-host-import
+asserted. test262: `test/language/statements/return/**` and
+`test/language/statements/generators/**` shapes that pair `return` with
+`finally`.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -251,6 +251,26 @@ interface NativeGeneratorState {
 
 interface NativeGeneratorPlan {
   states: NativeGeneratorState[];
+  /**
+   * (#2864 D4) Id of the state that COMPLETES the generator — the state whose
+   * terminator is the final `done`, or the dedicated empty placeholder minted
+   * for it when the fallthrough carries trailing statements.
+   *
+   * This is **not** `states.length - 1`. Every structural lowering
+   * (`for`/`while`/`do`/`if`, and the #3050 try-region) reserves its exit/join
+   * state BEFORE lowering the nested body, so a generator body that ENDS in one
+   * of those leaves the fallthrough cursor at a LOWER id than the last reserved
+   * state — and the last reserved state is then a LIVE yield successor. The
+   * pre-D4 `states.length - 1` therefore aliased "generator completed" onto a
+   * real suspension point, which made `buildNativeGeneratorDispatch`'s
+   * `suspended = state != START && state != doneState` test report DONE for a
+   * genuinely suspended generator: `.throw(e)` / `.return(v)` took the
+   * §27.5.3.4 already-completed arm and never resumed, so an enclosing `catch`
+   * across the yield was skipped and the error escaped raw. Measured on
+   * standalone + wasi for `try { yield … } catch {}` as the whole body, the
+   * same inside `for`/`while`, and nested loops under one try.
+   */
+  doneState: number;
   spills: string[];
   /**
    * (#2864 F1b) The wasm ValType for each spilled local, keyed by name. A local
@@ -1387,15 +1407,24 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
 
   // (#3050) When the final fallthrough state carries trailing statements
   // (`… yield x; trailing();`), it doubles as BOTH the last executable state
-  // and the completed-generator dispatch target (doneState = last id) — so
-  // every post-completion `.next()` re-dispatched into it and RE-RAN the
-  // trailing prelude (observable via a `unreachable += 1` after the last
-  // yield, GeneratorPrototype/throw/try-*-following-*). Mint a DEDICATED empty
-  // done state in that case; generators whose final state is already empty
-  // keep their exact state graph (byte-identical).
-  if (states[curId]!.statements.length > 0) {
-    reserveState(); // empty placeholder — its default terminator IS `done`
-  }
+  // and the completed-generator dispatch target — so every post-completion
+  // `.next()` re-dispatched into it and RE-RAN the trailing prelude
+  // (observable via a `unreachable += 1` after the last yield,
+  // GeneratorPrototype/throw/try-*-following-*). Mint a DEDICATED empty done
+  // state in that case; generators whose final state is already empty keep
+  // their exact state graph (byte-identical).
+  //
+  // (#2864 D4) `doneState` is the id of the state that COMPLETES the generator,
+  // which is the final fallthrough cursor (or the placeholder just minted for
+  // it) — NOT `states.length - 1`. Those coincide only for a straight-line
+  // body: every structural lowering (`for`/`while`/`do`/`if`/try-region)
+  // reserves its exit/join state BEFORE the nested body's states, so a body
+  // ENDING in one leaves the fallthrough at a LOWER id than the last reserved
+  // state. See the doneState note in `NativeGeneratorPlan`.
+  const doneState =
+    states[curId]!.statements.length > 0
+      ? reserveState() // empty placeholder — its default terminator IS `done`
+      : curId;
 
   // (#3050) Apply the runtime-throw route stamps now that every state object is
   // final (finishState rebuilds them, so stamping placeholders would be lost).
@@ -1478,6 +1507,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
 
   return {
     states,
+    doneState,
     spills,
     spillTypes,
     elemValType,
@@ -2497,7 +2527,10 @@ export function registerNativeGenerator(
     undefWidenedPatternBindings:
       plan.undefWidenedPatternBindings.size > 0 ? plan.undefWidenedPatternBindings : undefined,
     yieldCount,
-    doneState: plan.states.length - 1, // the final `done` state id
+    // (#2864 D4) The state that COMPLETES the generator, taken from the plan —
+    // NOT `states.length - 1`, which aliases onto a live yield successor for any
+    // body ending in a loop / if / try-region (see `NativeGeneratorPlan.doneState`).
+    doneState: plan.doneState,
     elemValType,
     delegationSlots: delegationSlots.length > 0 ? delegationSlots : undefined,
     vecDelegationSlots: vecDelegationSlots.length > 0 ? vecDelegationSlots : undefined,

--- a/tests/issue-2864-d4-catch-across-yield.test.ts
+++ b/tests/issue-2864-d4-catch-across-yield.test.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2864 D4 — try/catch across a `yield` in a Wasm-native (standalone / wasi)
+ * generator.
+ *
+ * Verify-first finding: the catch-region MACHINERY already existed (#3050
+ * `lowerTryRegion`). What was broken was `doneState`, which
+ * `registerNativeGenerator` derived as `plan.states.length - 1`. That id is the
+ * final `done` state only for a STRAIGHT-LINE body: every structural lowering
+ * (`for` / `while` / `do` / `if`, and the #3050 try-region) reserves its
+ * exit/join state BEFORE lowering the nested body, so a body ENDING in one
+ * leaves the fallthrough at a LOWER id and `states.length - 1` is a LIVE yield
+ * successor.
+ *
+ * The dispatch's suspension test is
+ * `suspended = state != START && state != doneState`, so with the alias in
+ * place a genuinely suspended generator reported DONE: `.throw(e)` / `.return(v)`
+ * took the §27.5.3.4 already-completed arm and NEVER resumed — the enclosing
+ * `catch` across the yield was skipped and the error escaped as a raw wasm
+ * exception.
+ *
+ * The bug is loop/if/try-TAIL-shaped, not try/catch-shaped; it is only
+ * OBSERVABLE when there is a handler or finalizer to run, because without one
+ * the already-completed arm coincides with the correct behaviour.
+ *
+ * Every case below compiles standalone with ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNoHost(src: string, target: "standalone" | "wasi" = "standalone"): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, `${target} module must have zero host imports`).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2864 D4 — doneState aliasing broke abrupt resume at a loop/try-tail suspension", () => {
+  it("verify-first: try/catch as the WHOLE body — .throw() enters the catch", async () => {
+    // Plan: fallthrough (the region's join) is state 3, but states.length-1 is
+    // state 4 — the yield successor carrying the catch unwind. Pre-fix the
+    // dispatch read state 4 as DONE and threw the error straight back at the
+    // caller without ever running `catch`.
+    expect(
+      await runNoHost(`let log = 0;
+function* g() { try { yield 1; } catch (e) { log = 5; } }
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const r = it.throw(new Error("x"));
+  return log * 100 + a * 10 + (r.done ? 1 : 0);
+}`),
+    ).toBe(511); // catch ran (log=5), first yield was 1, generator completed
+  });
+
+  it("for-loop body with try/catch across the yield — .throw() enters the catch and the loop continues", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g() { for (let i = 0; i < 3; i++) { try { yield i; } catch (e) { log += 1; } } }
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const b = it.throw(new Error("a")).value as number;
+  return log * 100 + a * 10 + b;
+}`),
+    ).toBe(101); // caught once, yielded 0 then (after i++) 1
+  });
+
+  it("while-loop body with try/catch across the yield", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g() { let i = 0; while (i < 3) { try { yield i; } catch (e) { log += 1; } i++; } }
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const b = it.throw(new Error("a")).value as number;
+  return log * 100 + a * 10 + b;
+}`),
+    ).toBe(101);
+  });
+
+  it("nested for-loops under one try — .throw() reaches the enclosing catch", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g() {
+  try { for (let i = 0; i < 2; i++) { for (let j = 0; j < 2; j++) { yield j; } } } catch (e) { log = 3; }
+}
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const r = it.throw(new Error("x"));
+  return log * 100 + a * 10 + (r.done ? 1 : 0);
+}`),
+    ).toBe(301);
+  });
+
+  it("loop try/catch across yield — repeated .throw() keeps the loop alive (3 iterations)", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g() { for (let i = 0; i < 3; i++) { try { yield i; } catch (e) { log += 1; } } }
+export function test(): number {
+  const it = g();
+  let s = 0;
+  s += it.next().value as number;
+  s += it.throw(new Error("a")).value as number;
+  s += it.throw(new Error("b")).value as number;
+  return log * 100 + s;
+}`),
+    ).toBe(203); // 2 catches, values 0 + 1 + 2
+  });
+
+  it("wasi lane gets the same fix (loop + try/catch, .throw())", async () => {
+    expect(
+      await runNoHost(
+        `let log = 0;
+function* g() { for (let i = 0; i < 3; i++) { try { yield i; } catch (e) { log += 1; } } }
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const b = it.throw(new Error("a")).value as number;
+  return log * 100 + a * 10 + b;
+}`,
+        "wasi",
+      ),
+    ).toBe(101);
+  });
+
+  it("loop tail + enclosing try/finally — .return() still runs the finally (control, was already green)", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g(): Generator<number, number, unknown> {
+  try { for (let i = 0; i < 3; i++) { yield i; } } finally { log = 8; }
+  return 0;
+}
+export function test(): number {
+  const it = g();
+  it.next();
+  const r = it.return(7);
+  return log * 100 + (r.value as number);
+}`),
+    ).toBe(807);
+  });
+
+  it("straight-line try/catch + trailing yield — unchanged (control: curId == lastId)", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g() { try { yield 1; } catch (e) { log = 5; } yield 2; }
+export function test(): number {
+  const it = g();
+  const a = it.next().value as number;
+  const b = it.throw(new Error("x")).value as number;
+  return log * 100 + a * 10 + b;
+}`),
+    ).toBe(512);
+  });
+
+  it("if-tail with a try/finally in the taken branch — .return() runs the finally", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g(): Generator<number, number, unknown> {
+  if (1) { try { yield 5; } finally { log = 4; } } else { yield 6; }
+  return 0;
+}
+export function test(): number {
+  const it = g();
+  it.next();
+  const r = it.return(7);
+  return log * 100 + (r.value as number);
+}`),
+    ).toBe(407);
+  });
+
+  it("loop-tail generator: exhausting past the end stays done and re-runs nothing", async () => {
+    // doneState is now the real fallthrough, so a post-completion .next() lands
+    // on the empty done state instead of re-entering the loop's update state.
+    expect(
+      await runNoHost(`let calls = 0;
+function* g() { for (let i = 0; i < 2; i++) { yield i; } }
+export function test(): number {
+  const it = g();
+  let s = 0;
+  for (let k = 0; k < 5; k++) {
+    const r = it.next();
+    if (r.done) { s += 100; } else { s += (r.value as number) + 1; }
+  }
+  calls += 1;
+  return s + calls;
+}`),
+    ).toBe(304); // (0+1)+(1+1) = 3, then 3 dones = 300, +1
+  });
+
+  it("catch across yield inside a loop, boxed-any carrier", async () => {
+    expect(
+      await runNoHost(`let log = 0;
+function* g() { for (let i = 0; i < 3; i++) { try { yield {a: i}; } catch (e) { log += 1; } } }
+export function test(): number {
+  const it = g();
+  const a = (it.next().value as any).a as number;
+  const b = (it.throw(new Error("x")).value as any).a as number;
+  return log * 100 + a * 10 + b;
+}`),
+    ).toBe(101);
+  });
+});


### PR DESCRIPTION
## #2864 D4 — sync-generator try/catch across yield

**Verify-first outcome: the F2-deferral note was STALE.** #3050 (`fdc11cbd`) had already
landed `lowerTryRegion` in `generators-native.ts` (catch-across-yield + yielding finally).
There is no `if (stmt.catchClause) fail()` in the file. No CFG-planner convergence was
needed or performed. A 12-shape probe on main showed 9/12 already passing host-free.

**Real root cause (1 of the 3 remaining failures).** `registerNativeGenerator` derived
`doneState: plan.states.length - 1`. That is the final `done` state only for a
straight-line body — every structural lowering (for / while / do / if, and the #3050
try-region) reserves its exit/join state *before* the nested body, so a loop/if/try-TAIL
body leaves the fallthrough at a lower id and `states.length - 1` is a live yield
successor. The dispatcher's `suspended = state != START && state != doneState` then read
a suspended generator as DONE, took the §27.5.3.4 already-completed arm, and never
resumed — so the enclosing catch was skipped and the error escaped raw.

This is **not try/catch-specific**: it is loop/if/try-TAIL-shaped, latent since the
structural lowerings landed, and only observable when there is a handler to run.

### Measured delta
8 shapes x 3 lanes, host-free asserted: **4 flip** from raw escaping exception to spec
behaviour, **4 controls unchanged**. Affects the **js-host (gc) lane too** (#3032 W6
routes host-lane generators native) — verified against the real `buildImports` harness.
Byte matrix, 12 programs x 3 lanes: **24/24 controls byte-identical vs origin/main**;
the 12 changed entries are exactly the 4 predicted `curId != lastId` shapes.

### Gates (local)
`equivalence-gate` exit 0 (no new regressions) · new suite 11/11 · ~25 generator suites
green · loc-budget, oracle-ratchet (+0), godfiles, stack-balance, issue-ids, format,
typecheck all green.

### Notes
- Spun off **#3582**: `return v` inside `try` with a yield-free `finally` skips the
  finally (standalone 15 vs Node 315; reproduces with no yield in the try). Deliberately
  not bundled — different lowering, larger byte surface, XL-slice discipline.
- Pre-existing and unrelated: `tests/issue-3164.test.ts` (3) and `tests/issue-3386.test.ts`
  (1) fail identically on unmodified `origin/main`. Tracked separately.

Authored by dev-opus5-gen (Opus 5). Opened by the tech lead because REST `POST /pulls`
returned a persistent HTTP 500 for this head/base pair (GitHub-side; `compare` returned
200 and the endpoint returned a normal 422 for invalid input).
