### PR TITLE
docs(review): substrate + async deep review — 4 proven silent miscompiles (#3585-#3588)

### DIFF
--- a/plan/agent-context/fable-substrate-async-review-2026-07-24.md
+++ b/plan/agent-context/fable-substrate-async-review-2026-07-24.md
@@ -1,0 +1,244 @@
+# Deep review: value-representation substrate + async implementation
+
+Fable architect review, 2026-07-24/25, on main `7652f0337` (upstream tip, post
+#2864-D4). Method: verify-first — every claim below was proven by a
+differential probe (Node reference vs gc-host wasm vs standalone wasm) run
+against current main; probe sources are quoted inline or in the referenced
+issue files. Probe harness: esbuild bundle of `src/index.ts` +
+`buildImports` from `src/runtime.ts`; probes lived in `.tmp/probes/`
+(gitignored, reproducible from the snippets here).
+
+**Companion review**: the parallel IR-boundary review (fable-ir-review) found
+#3566/#3567/#3568; this review confirms the same hazard class from the other
+two directions (async engine selection, generator backend selection).
+
+---
+
+## Part A — value-representation substrate
+
+### Verified current state (do not trust older issue prose)
+
+| Flag                    | Default on main                          | Where                   |
+| ----------------------- | ---------------------------------------- | ----------------------- |
+| `undefinedSingleton`    | **TRUE** (`?? env !== "0"`)              | `create-context.ts:311` |
+| `tag5ValueEqClassifier` | **TRUE**                                 | `create-context.ts:302` |
+| `honestAnyBoxing`       | **FALSE** (the remaining flip, #2141 S4) | `create-context.ts:291` |
+| `unionAnyRep`           | opt-in                                   | `index.ts:353`          |
+
+Note: `compiler.ts:770-778` comments still say "(default off)" for the two
+flipped flags — stale; the effective default is set in `create-context.ts`.
+
+### What was probed and found CORRECT (standalone + gc, vs Node)
+
+- `$Object` dynamic reader with native-string values: `o["s"]` read through an
+  any-typed helper returns the string, `typeof` and `===` both correct
+  (probe s3 — the historical root-cause class is fixed on this shape).
+- tag-5 value eq basics: boxed-string `===` by value, boxed-number `===`,
+  NaN self-inequality through any, `undefined !== null` strict /
+  `undefined == null` loose (probe s4, all 11111).
+- Object identity: `a === arr[0]` after any[]-roundtrip; identity through
+  any-typed aliasing (probe s2, the `===` legs).
+- `Map.get` returning a correct, arithmetic-usable value when materialized
+  into a local (probes s2c/s2g).
+
+### Findings, ranked (silent miscompiles first)
+
+**A1 (HIGH, silent) — `m.get(k) === lit` false in direct call-result
+position; true via a local. An any-keyed Map poisons even typed Maps
+module-wide.** → NEW issue **#3585**.
+Standalone only. `if (m.get(a) === 7)` and `== 7` are FALSE while
+`const g = m.get(a); g === 7` is TRUE in the same module. Worse: a typed
+`Map<object, number>` gets the same wrong answer in direct position iff an
+any-keyed Map exists anywhere in the module (in isolation it is correct) —
+which reader/eq path a call site takes is decided by unrelated module
+contents. This is the cleanest proof in this review of the representation-
+coherence violation the #2773 epic exists to kill: the same value reaches the
+same consumer in two reps depending on syntactic position and module
+composition. Not IR-related (identical with `experimentalIR: false`).
+
+**A2 (LOW likelihood / HIGH principle, silent) — the UNDEF_F64 sentinel
+collides with a user-craftable NaN.** → NEW issue **#3588**.
+Standalone: a DataView-minted f64 with bits `0x7FF00000DEADC0DE` answers
+`typeof` = "number" and `x !== x` = true (a NaN), but **`x === undefined` and
+`x == null` are TRUE**. The #2979 `$BoxedNumber`-carrying-UNDEF_F64 arm of
+the is-undefined predicate (`any-helpers.ts:142`) treats the crafted payload
+as the compiler's own sentinel. Bit-punning is the only mint path (computed
+NaNs canonicalize), so real-world exposure is low — but it is a proven hole
+in the #2106 design and should be either closed (canonicalize at the
+DataView/TypedArray read boundary) or explicitly documented as accepted.
+
+**A3 (assessment) — hybrid-divergence exposure is wider than IR-vs-legacy:
+it is EVERY engine-selection boundary.** The #3566/#3567/#3568 class (IR vs
+legacy claiming the same construct with different reps) is one instance of a
+general pattern this review found in two more places:
+
+| Boundary                                          | Selector                            | Proven divergence                                                    |
+| ------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| IR vs legacy front-end                            | shape checks in `ir/select.ts`      | #3566/#3567/#3568 (parallel review)                                  |
+| async host-drive vs legacy sync                   | `asyncFnNeedsHostDrive`             | **#3587** — declined shapes swallow rejections (Part B)              |
+| native lazy generator vs eager buffer             | native claim gate + escape analysis | **#3586** / #2662 append — `s += yield` or factory-escape → silent 0 |
+| standalone native carrier vs host-import fallback | per-shape carrier gates             | loud (env-import instantiate failure) — the GOOD failure mode        |
+
+The structural fix direction is the same everywhere: a declined shape must
+either (a) be claimed, or (b) fail loudly. The silent third option —
+"declined → different semantics on the fallback engine" — is where all of
+this review's worst findings live. The standalone lane's refusal behavior
+(loud env-import failure) is the model; the host lane's silent fallbacks are
+the anti-model.
+
+**A4 (sentinels survey).** `-1` string-global sentinel: loud at emit time
+(`global.get -1` rejected by the serializer) — recurring bug class but not a
+silent-miscompile risk; guard pattern documented in memory/#51. tag-5 field-4
+three-way classifier: no collision found in probing (s4 clean). UNDEF_F64:
+collision proven (A2). undefined-singleton: no aliasing found in probes
+(undefined vs null distinct through ===/==/typeof).
+
+### Substrate recommendation (priority order)
+
+1. Fix **#3585** (Map.get direct-position eq) — highest blast radius silent
+   wrong answer; also a good forcing function to find the general
+   "call-result-position rep ≠ local rep" seam, which likely affects more
+   call sites than Map.get.
+2. Adopt the loud-refusal invariant for engine-selection boundaries (A3) —
+   cheapest systemic risk reduction; #3587's option (b) is the async
+   instance.
+3. Decide **#3588** (a/b/c options in the issue) — small, bounded.
+4. `honestAnyBoxing` flip (#2141 S4): nothing in this review blocks it, but
+   land #3585 first — the flip changes exactly the boxing paths #3585
+   exercises, and a green flip on top of a silently-wrong eq path would mask
+   the regression signal.
+
+---
+
+## Part B — async implementation
+
+### Verified current state
+
+- ONE async engine, two settle backends (#2967): `maybeActivateAsync` →
+  `asyncFnNeedsDrive` (wasi native `$Promise` carrier) /
+  `asyncGenConsumerNeedsDrive` (standalone, for-await-over-async-gen ONLY,
+  #2980 carrier gate still narrow) / `asyncFnNeedsHostDrive` (gc host,
+  LINEAR multi-await bodies only — `planLinearAwaits`; try/catch/finally
+  across an await is declined). Everything declined → **legacy synchronous
+  pass-through** (await = unwrap-or-identity, result = unwrapped value).
+- IR async C-1 (#1373b) claims only what the engine declines AND only
+  top-level declarations with explicit `Promise<T>` annotation passing
+  Phase-1 shape checks — so the legacy sync population remains large.
+- Generators, host lane: native lazy machine claims top-level (#3032 W6) and
+  capturing-nested (#2662 slice 1) declarations; generator EXPRESSIONS,
+  methods, `yield*`, exported/ESCAPING generators, and (new finding)
+  non-canonical yield positions still fall to the eager buffer
+  (`runtime.ts:~135`).
+- Standalone async: an exported async fn compiles host-free but returns an
+  opaque native carrier struct; the module exports `__drain_microtasks` +
+  `__sget_state`/`__sget_value` accessors. A plain caller cannot observe the
+  result (probe: state=1 after drain, value = boxed struct). This is the
+  known #2895 PATH-B / #2865 gap — REAL, and silent from the caller's seat
+  (you get `[Object: null prototype] {}` instead of your number).
+
+### What was probed and found CORRECT
+
+- Catch-across-yield (#2864 D4, the tip commit): `it.throw(v)` into a
+  suspended try/catch — correct on gc AND standalone, including
+  throw-on-not-started semantics (probe a3, 1111 everywhere).
+- Generator sent values + return value, straight-line body (a4b) and
+  loop bodies in canonical `const t = yield i` form, 1/2/3 iterations,
+  multiple instances, post-loop reads (a4j/a4k/a4l/a4h/a4f/a4i) — correct on
+  BOTH lanes (the #3032-W6 native host routing genuinely works).
+- `it.return(v)` through a yield-suspended try/finally on the HOST lane:
+  finally runs, `{value: 42, done: true}`, post-completion `next()` correct
+  (a2b gc). (Standalone REFUSES this shape loudly — env-import failure; the
+  silent variant of standalone finally-skipping is already filed as #3582.)
+- Host lane finally-across-await incl. `await` INSIDE finally, and
+  completion-value preservation (a1 gc, legacy sync path) — correct as long
+  as nothing rejects.
+- Rejection delivery on ENGINE-CLAIMED shapes: two-callback `.then` on a
+  host-driven async fn's rejected result (a5d) — correct.
+
+### Findings, ranked
+
+**B1 (CRITICAL, silent, DEFAULT lane) — declined async shapes swallow
+awaited rejections.** → NEW issue **#3587**.
+`try { await Promise.reject(7); return -1; } catch (e) { return e; }` returns
+**-1** on the default gc lane: the body CONTINUES past the rejected await,
+the catch never runs, `.catch` handlers never run, and the rejection leaks as
+a host unhandledRejection. Synchronous `throw` inside the same declined shape
+DOES propagate — only promise-carried rejections are lost. The cruel part:
+wrapping an await in try/catch — the construct that declares you care about
+the rejection — is exactly what gets the function declined by
+`planLinearAwaits` (non-linear body) onto the lane that cannot deliver
+rejections. This is the most dangerous thing found in this review: common
+code, default configuration, plausible-looking result, no diagnostic.
+
+**B2 (HIGH, silent, DEFAULT lane) — `s += yield` returns 0.** → NEW issue
+**#3586** (+ Review append on #2662).
+A loop generator accumulating via compound assignment (`s += yield i`)
+returns **0** instead of the accumulated sum on the host lane (eager buffer:
+all sent values read as 0; the yielded values still look right, maximizing
+stealth), while the de-sugared `const t = yield i; s = s + t` is claimed by
+the native machine and fully correct. Standalone fails LOUDLY on the same
+shape (emits env imports → instantiate error). Two spellings of the same
+loop, two engines, two answers.
+
+**B3 (HIGH, silent, host lane) — escaping generators lose sent values /
+return value.** → Review append on **#2662** (known-eager residual, now with
+a wrong-VALUE proof, not just wrong-timing).
+The same correct-inline generator returned from a factory (`return g()`)
+falls to the eager buffer: final value 0 instead of 60. Standalone is
+CORRECT on this shape — a direct host-vs-standalone semantic divergence for
+identical source.
+
+**B4 (known, verified real) — standalone async is not consumable without
+the PATH-B drive layer** (#2895/#2865): async exports return an opaque
+carrier; `__drain_microtasks` + `__sget_*` exist but there is no documented
+caller contract, so every naive standalone async consumer silently gets a
+struct instead of a value. #3545 (microtask-job trap silently ends the
+drain) remains open on top of this; not re-probed here (requires the
+standalone stdout harness), no contradicting evidence found.
+
+**B5 (spill-slot typing, #2873-class).** Not re-proven reachable in probing;
+the `asyncClosureCellSpillHazard` guard (async-frame.ts) currently declines
+the known-hazardous closure shapes into... the legacy sync lane — i.e. the
+guard converts a loud wasm-validation failure into membership in B1's
+silently-rejection-swallowing population. The declaration lane's latent
+hazard flagged in memory (spill fields typed pre-body-compile diverging from
+cell-boxed locals) still has no corpus instance; keep the guard, but note it
+feeds B1.
+
+### Async recommendation (priority order)
+
+1. **#3587** — at minimum land the loud-refusal stopgap (compile
+   error/diagnostic for await-inside-try on the declined lane) THIS window;
+   the full fix is host-side #2906 Gap-3 (try-across-await states on the
+   host settle backend).
+2. **#3586** — small shape-gate fix (or pre-desugar `x op= yield e`); high
+   stealth-to-cost ratio.
+3. #2906 completion + #2980 carrier widen — every standalone async finding
+   (B4, #3545, a2b refusal) is downstream of the carrier/drive gates; the
+   loud failures are fine to leave until then, the silent ones are not.
+4. #2662 Option-(ii) escaping-generator wrapper (B3) — epic-sized, already
+   specced in the issue; until it lands, consider making ESCAPE fall
+   loudly (refuse) rather than eagerly (wrong values), consistent with the
+   A3/B1 loud-refusal invariant.
+
+---
+
+## The one-line summary
+
+Both areas share a single systemic defect shape: **an invisible
+engine/representation selector whose fallback lane has different semantics**.
+Where the fallback fails loudly (standalone refusals), the system is honest;
+where it falls back silently (host eager generators, host legacy-sync async,
+call-result-position rep in standalone eq), it miscompiles common code with
+no signal. The highest-leverage policy change is: **a declined shape must be
+claimed or must refuse — never silently re-lane.**
+
+## Probe index (repro sources)
+
+All probes are inline in the issue files (#3585, #3586, #3587, #3588, #2662
+append) or reconstructible from this doc: s1 sentinel, s2* identity/Map,
+s3 dyn-reader, s4 tag5-eq, a1 finally-await, a2b finally-return, a3
+catch-across-yield, a4* generator state machine, a5\* rejection paths.
+Driver: compile via `src/index.ts` `compile()`; gc lane instantiated with
+`buildImports(r.imports, {}, r.stringPool)` + `setExports`; standalone with
+`{}` imports; Node reference via `ts.transpileModule` + data-URL import.

--- a/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
+++ b/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
@@ -380,3 +380,41 @@ to speed the conformance signal, with semantics-preservation review.
 Design settled (Option ii). Build DEFERRED — multi-session epic, to be prioritized
 against s66 work with this spec in hand. **#1344 stays parked behind this epic**
 (`#1344 depends_on [1665, 2662]`).
+
+## Review (Fable, 2026-07-24)
+
+Empirical confirmation of the ESCAPING-generator residual as a **silent wrong
+VALUE** (not just wrong side-effect timing), on main `7652f0337`, default gc
+lane — and a lane-divergence data point: **standalone gets this right, host
+gets it wrong**.
+
+```ts
+function mk(): Generator<number, number, number> {
+  function* g(): Generator<number, number, number> {
+    let s = 0;
+    for (let i = 0; i < 3; i++) {
+      const t: number = yield i;
+      s = s + t;
+    }
+    return s;
+  }
+  return g(); // ← escapes the factory
+}
+export function test(): number {
+  const it = mk();
+  it.next();
+  it.next(10);
+  it.next(20);
+  return it.next(30).value; // node: 60
+}
+// node: 60 · standalone: 60 ✓ · gc host: 0 ✗ (silent)
+```
+
+The eager buffer runs the whole body up-front, so every `next(v)` SENT value
+is lost (reads as 0) — the yielded values still look right (0,1,2), only the
+accumulated return value is wrong, which makes this maximally silent. The
+same generator NOT escaping (created + driven inline in `test()`) is correct
+on both lanes (post-#3032-W6 native routing). See the review doc
+`plan/agent-context/fable-substrate-async-review-2026-07-24.md` (probes
+a4n/a4k/a4l) and the new narrow shape-gate issue #3586 (`s += yield` knocks
+even a NON-escaping generator onto the eager buffer).

--- a/plan/issues/3585-standalone-mapget-call-result-eq-false.md
+++ b/plan/issues/3585-standalone-mapget-call-result-eq-false.md
@@ -1,0 +1,96 @@
+---
+id: 3585
+title: "Standalone: `m.get(k) === lit` false in direct call-result position (true via a local); an any-keyed Map poisons even typed Maps module-wide"
+status: ready
+sprint: Backlog
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: Map, equality
+goal: standalone-gap
+related: [2773, 2141, 2040, 3053]
+origin: "2026-07-25 Fable substrate/async review (plan/agent-context/fable-substrate-async-review-2026-07-24.md), probe s2h/s2i"
+---
+
+# Standalone: Map.get result compared in direct call-result position answers false
+
+## Problem (verified on main 7652f0337, target: standalone)
+
+Comparing a `Map.get()` call result **directly** against a numeric literal
+answers `false`, while routing the identical value **through a local** answers
+`true` — in the same module, same map, same key:
+
+```ts
+export function test(): number {
+  const a: any = { v: 1 };
+  const arr: any[] = [a];
+  const m = new Map<any, number>();
+  m.set(a, 7);
+  let code = 0;
+  if (m.get(a) == 7) code += 1; // direct loose  — FALSE (wrong)
+  if (m.get(a) === 7) code += 2; // direct strict — FALSE (wrong)
+  const g = m.get(a);
+  if (g == 7) code += 10; // local loose  — true
+  if (g === 7) code += 20; // local strict — true
+  if (arr.length === 1) code += 100;
+  return code; // node/gc: 133 · standalone: 130
+}
+```
+
+**Silent wrong answer** — no trap, no refusal. `if (map.get(k) === v)` is an
+extremely common idiom, so the blast radius is large.
+
+### Module-composition sensitivity (worse)
+
+The presence of an **any-keyed Map elsewhere in the module** poisons even a
+fully **typed** `Map<object, number>`:
+
+```ts
+export function test(): number {
+  const a: any = { v: 1 };
+  const m = new Map<any, number>();
+  m.set(a, 7); // ← any-keyed map present
+  const m2 = new Map<object, number>();
+  const plain = { v: 2 };
+  m2.set(plain, 3);
+  const g = m2.get(plain);
+  let code = 0;
+  if (g === 3) code += 1; // via local  — true
+  if (m2.get(plain) === 3) code += 10; // direct strict — FALSE (wrong)
+  if (m2.get(plain) == 3) code += 100; // direct loose  — FALSE (wrong)
+  return code; // node/gc: 111 · standalone: 1
+}
+```
+
+In **isolation** (no any-keyed Map in the module) the typed-map version passes
+(probe s2c: 111110 everywhere). So which reader/eq path `m2.get` takes is
+decided by unrelated module contents — a representation-coherence violation of
+exactly the #2773 class: the call-result-position value reaches the eq lowering
+in a different representation than the local-materialized one, and the
+module-wide carrier selection shifts when an any-keyed Map exists.
+
+Not IR-related: identical divergence with `experimentalIR: false`.
+
+Host (gc) lane is correct in all variants. `m.has(...)` is correct; arithmetic
+on the value (`(g as number) + 0 === 7`) is correct — only the ==/=== lowering
+against the direct call result is wrong.
+
+## Suspected area
+
+Standalone Map carrier value read (collections codegen) returning an
+externref/boxed rep in expression position, vs the any-eq / tag-5 classifier
+path (`src/codegen/any-eq-helpers.ts`, `any-helpers.ts` tag5 emit) not
+unboxing that rep. The local-assignment path forces an unbox via rep
+inference, which is why the local variant works.
+
+## Acceptance
+
+- Both probes above return the node value (133 / 111) under
+  `target: "standalone"`.
+- Add both as standalone regression tests (direct-position and
+  module-composition variants).

--- a/plan/issues/3586-compound-assign-yield-not-claimed-native-generator.md
+++ b/plan/issues/3586-compound-assign-yield-not-claimed-native-generator.md
@@ -1,0 +1,96 @@
+---
+id: 3586
+title: "`s += yield` (yield in compound-assignment RHS) not claimed by the native generator machine: host lane silently returns 0, standalone emits env imports"
+status: ready
+sprint: Backlog
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: generators
+goal: spec-completeness
+related: [2662, 3032, 2864, 3582]
+umbrella: 2662
+origin: "2026-07-25 Fable substrate/async review (plan/agent-context/fable-substrate-async-review-2026-07-24.md), probes a4d/a4k"
+---
+
+# Compound-assignment yield knocks a generator off the native machine
+
+## Problem (verified on main 7652f0337)
+
+A generator whose yield sits in **compound-assignment RHS position**
+(`s += yield i`) is not claimed by the native lazy state machine:
+
+```ts
+export function test(): number {
+  function* g(): Generator<number, number, number> {
+    let s = 0;
+    for (let i = 0; i < 3; i++) {
+      s += yield i; // ← the trigger
+    }
+    return s;
+  }
+  const it = g();
+  it.next();
+  it.next(10);
+  it.next(20);
+  return it.next(30).value; // node: 60
+}
+```
+
+- **gc (host, default)**: returns **0** — SILENT wrong answer. The generator
+  falls to the eager-buffer backend (#2662): the body runs up-front with all
+  sent values as 0, yields are buffered (yielded `i` values still look right),
+  and the accumulated return value is 0.
+- **standalone**: module demands an `env` import → `WebAssembly.instantiate`
+  fails ("Import #0 env: module is not an object or function"). LOUD, but a
+  standalone compile that silently emits host imports is itself a gap
+  (`strictNoHostImports`-class).
+
+## Control (proves the trigger is the compound-assignment position)
+
+The de-sugared form is claimed and fully correct on **both** lanes, same loop,
+same driver:
+
+```ts
+function* g(): Generator<number, number, number> {
+  let s = 0;
+  for (let i = 0; i < 3; i++) {
+    const t: number = yield i;
+    s = s + t;
+  }
+  return s;
+}
+// node / gc / standalone all: value 60 ✓  (probe a4k)
+```
+
+Note `s = s + (yield i)` (yield nested in a binary RHS) also failed in a
+combined-module probe (a4e-g2) — the claim gate likely rejects any yield that
+is not a statement / variable-initializer position. The fix should cover
+yield in general expression positions, or at minimum pre-desugar
+`x op= yield e` into the claimed form.
+
+## Why this matters
+
+This is the engine-selection-boundary hazard in its sharpest form: two
+spellings of the same accumulation loop — `s += yield i` vs
+`const t = yield i; s = s + t` — get different engines with different
+semantics, and the broken one is the DEFAULT lane with no diagnostic.
+
+## Suspected area
+
+The native-generator shape gate (`src/codegen/generators-native.ts` claim
+predicate / `buildNativeGeneratorPlan`) rejecting yields in non-canonical
+expression positions; host lane then falls back to the eager buffer
+(`src/runtime.ts` buffered generator, #2662), standalone falls back to host
+imports.
+
+## Acceptance
+
+- The probe returns 60 on gc AND standalone (standalone with zero imports).
+- A regression test covering `s += yield`, `s = s + (yield e)`, and yield as a
+  call argument (`f(yield e)`).

--- a/plan/issues/3587-host-declined-async-shapes-swallow-rejections.md
+++ b/plan/issues/3587-host-declined-async-shapes-swallow-rejections.md
@@ -1,0 +1,109 @@
+---
+id: 3587
+title: "Host lane: async shapes the host-drive engine declines (try/catch across await, non-linear bodies) silently SWALLOW awaited rejections — execution continues past the await"
+status: ready
+sprint: Backlog
+created: 2026-07-25
+updated: 2026-07-25
+priority: critical
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: async, promises
+goal: async-model
+related: [1042, 1796, 2906, 2967, 1373b, 3545]
+origin: "2026-07-25 Fable substrate/async review (plan/agent-context/fable-substrate-async-review-2026-07-24.md), probes a5b/a5c/a5d"
+---
+
+# Declined async shapes swallow rejections on the default (gc host) lane
+
+## Problem (verified on main 7652f0337, DEFAULT gc host lane)
+
+When `asyncFnNeedsHostDrive` (src/codegen/async-frame.ts:197) declines an
+async function — e.g. because `planLinearAwaits` rejects try/catch across an
+await — the function falls to the **legacy synchronous pass-through**, where an
+awaited REJECTION does not throw: execution **continues past the `await` as if
+it fulfilled**, catch blocks never run, `.catch` handlers never run, and the
+rejected host promise leaks as an unhandledRejection.
+
+```ts
+export async function test(): Promise<number> {
+  try {
+    await Promise.reject(7);
+    return -1; // must not reach
+  } catch (e) {
+    return e as number; // expect 7
+  }
+}
+// node: 7 · gc host: -1 (reached the must-not-reach line) · SILENT
+```
+
+Wider probe (a5c) — all four rejection shapes swallowed in one declined body:
+
+```ts
+await p; // p = Promise.reject(1) — continues, no throw
+await rejector(); // async fn returning Promise.reject — continues
+await Promise.reject(5).catch(handler); // handler NEVER runs
+await new Promise((_res, rej) => rej(9)); // continues + leaks unhandledRejection "9"
+// node: 9531 · gc host: 7000000 (all three must-not-reach arms hit)
+```
+
+## Control (the engine-claimed shape is correct)
+
+Same rejection, no try/catch in the async fn (single-await linear shape →
+host-drive engine claims it): correct.
+
+```ts
+async function f(): Promise<number> {
+  await Promise.reject(7);
+  return -1;
+}
+export async function test(): Promise<number> {
+  let out = 0;
+  await f().then(
+    (_v: number) => {
+      out = 100;
+    },
+    (e: number) => {
+      out = e;
+    },
+  );
+  return out; // node AND gc host: 7 ✓  (probe a5d)
+}
+```
+
+Synchronous `throw` inside a declined async fn DOES propagate (probe a5:
+first arm caught 42) — only promise-carried rejections are lost.
+
+## Why this is the worst kind of boundary
+
+The decline predicate is invisible to the user. Adding a `try/catch` around an
+`await` — the very construct that signals "I care about this rejection" — is
+what flips the function onto the lane that **cannot deliver rejections**. Same
+syntax, silently different error semantics, on the DEFAULT lane.
+
+This is a known architectural residue (#1796 scope note: only linear shapes
+got the CPS/host-drive model; #2906 is generalizing the machine for
+standalone), but no open issue owned the HOST-lane consequence, and none
+documented that the declined population swallows rejections rather than
+merely being "sync-timed". test262's async harness (`$DONE`) under-detects
+this because harness bodies are often engine-claimed shapes.
+
+## Direction
+
+Either (a) extend `planLinearAwaits`/host-drive to claim try/catch-across-await
+(the #2906 Gap-3 skeleton, host settle backend), or (b) make the legacy sync
+pass-through LOUD for bodies containing an await inside try/catch or any
+rejection-observing construct (compile error / diagnostic), so the silent
+lane cannot host rejection-sensitive code. (b) is a cheap stopgap that converts
+a silent miscompile into a refusal.
+
+## Acceptance
+
+- Probe a5b returns 7 on gc host; a5c returns 9531; no leaked
+  unhandledRejection.
+- A regression test for rejection delivery through try/catch, `.catch`, and
+  the two-callback `.then` on both engine-claimed and previously-declined
+  shapes.

--- a/plan/issues/3588-undef-f64-sentinel-collision-user-reachable.md
+++ b/plan/issues/3588-undef-f64-sentinel-collision-user-reachable.md
@@ -1,0 +1,77 @@
+---
+id: 3588
+title: "UNDEF_F64 sentinel collision is user-reachable: a DataView-crafted NaN (0x7FF00000DEADC0DE) compares `=== undefined` true in standalone"
+status: ready
+sprint: Backlog
+created: 2026-07-25
+updated: 2026-07-25
+priority: low
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: equality, NaN
+goal: standalone-gap
+related: [2106, 2142, 2979, 2773]
+origin: "2026-07-25 Fable substrate/async review (plan/agent-context/fable-substrate-async-review-2026-07-24.md), probe s1"
+---
+
+# The UNDEF_F64 sentinel is observable: crafted NaN === undefined
+
+## Problem (verified on main 7652f0337, target: standalone)
+
+The `undefined`-through-f64-lane representation (#2106/#2142) reserves the sNaN
+payload `0x7FF00000DEADC0DE` (`UNDEF_F64_BITS`, src/codegen/value-tags.ts). The
+`is-undefined` predicate includes a `$BoxedNumber`-carrying-UNDEF_F64 arm
+(#2979; `buildIsUndefinedExternBody`, src/codegen/any-helpers.ts:142). A user
+can mint that exact bit pattern through `DataView`, and the resulting NaN then
+**compares equal to `undefined`**:
+
+```ts
+export function test(): number {
+  const buf = new ArrayBuffer(8);
+  const dv = new DataView(buf);
+  dv.setUint32(0, 0x7ff00000);
+  dv.setUint32(4, 0xdeadc0de);
+  const x: any = dv.getFloat64(0); // a NaN, per spec
+  let code = 0;
+  if (typeof x === "number") code += 1; // correct ("number")
+  if (x === undefined) code += 10; // WRONG — true in standalone
+  if (x !== x) code += 100; // correct (NaN)
+  if (x == null) code += 1000; // WRONG — true in standalone
+  return code; // node/gc: 101 · standalone: 1111
+}
+```
+
+`typeof` and NaN self-inequality classify it as a number, but `=== undefined`
+and `== null` answer true — the value is simultaneously a number and undefined
+depending on which observer asks. Silent, no trap. Not IR-related
+(identical with `experimentalIR: false`).
+
+## Severity assessment
+
+Low likelihood in practice: reaching it requires bit-exact NaN crafting
+(DataView / TypedArray punning / Number parsing cannot produce it otherwise —
+wasm `f64` ops canonicalize NaNs they COMPUTE, but bit-punning is
+load/store-faithful, so the crafted payload survives). But it is a proven,
+spec-observable hole in the #2106 design, and test262's NaN-payload tests
+(e.g. DataView/TypedArray NaN-canonicalization suites) can plausibly hit the
+pattern space.
+
+## Direction options
+
+- (a) Accept + document as a known representation limit in #2106/#2142 design
+  docs (cheapest; this issue then becomes the record).
+- (b) Canonicalize NaN payloads at the DataView/TypedArray f64 READ boundary
+  (`getFloat64`/element read) when the bits equal UNDEF_F64_BITS — flip one
+  mantissa bit. Spec-legal (implementations may canonicalize NaNs) and closes
+  the only known mint path.
+- (c) Restrict the #2979 BoxedNumber arm to sites that can only receive
+  compiler-minted sentinels (audit; risk of regressing #2979's motivating
+  cases).
+
+## Acceptance
+
+Either the probe returns 101 under standalone, or the collision is explicitly
+documented as accepted in #2106/#2142 with this repro attached.


### PR DESCRIPTION
Deep verify-first review of the two most sensitive compiler areas — the value-representation substrate and the async/generator implementation — at the project lead's request. Docs/plan only; no compiler source changes.

Every finding is proven by a differential probe (Node reference vs gc-host wasm vs standalone wasm) on main 7652f033; repros are inline in the issue files.

## New issues
- **#3585** (high, silent, standalone) — `m.get(k) === lit` is FALSE in direct call-result position, TRUE via a local; an any-keyed Map elsewhere in the module poisons even a fully typed `Map<object, number>`.
- **#3586** (high, silent on host / loud on standalone) — `s += yield` is not claimed by the native generator machine: gc host falls to the eager buffer and silently returns 0; standalone emits env imports and fails at instantiate.
- **#3587** (critical, silent, DEFAULT lane) — async shapes the host-drive engine declines (try/catch across await) fall to the legacy sync pass-through, which SWALLOWS awaited rejections: execution continues past `await Promise.reject(7)`, catch/.catch never run, rejection leaks as unhandledRejection.
- **#3588** (low likelihood, proven) — the UNDEF_F64 sentinel collides with a DataView-crafted NaN (0x7FF00000DEADC0DE): `typeof x === "number"" && x !== x` yet `x === undefined` is true in standalone.

## Appends
- `## Review (Fable, 2026-07-24)` on **#2662**: escaping (factory-returned) generators lose sent values → silent wrong VALUE on the host lane while standalone is correct.

## Review doc
`plan/agent-context/fable-substrate-async-review-2026-07-24.md` — verified flag/regime state, what was probed and found CORRECT, findings ranked silent-first, and the systemic conclusion: every worst finding is an invisible engine-selection boundary whose fallback lane has different semantics; a declined shape must be claimed or must refuse — never silently re-lane.

Issue ids reserved via `claim-issue.mjs --allocate` (3585-3588).

🤖 Generated with [Claude Code](https://claude.com/claude-code)