### PR TITLE
docs(#3589,#3590): file the two defects found diagnosing the #3563 park

### DIFF
--- a/plan/issues/3589-assert-harness-null-deref-unmasked-by-3563.md
+++ b/plan/issues/3589-assert-harness-null-deref-unmasked-by-3563.md
@@ -1,0 +1,171 @@
+---
+id: 3589
+title: "latent null-deref in the compiled test262 `assert` harness, unmasked (not caused) by #3563"
+status: ready
+sprint: current
+created: 2026-07-24
+updated: 2026-07-24
+priority: high
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen, test262
+goal: core-semantics
+related: [3024, 3563, 3189, 3590]
+origin: "PR-queue shepherd diagnosis of the #3563 auto-park, 2026-07-24. Reproduced both sides locally by swapping only src/codegen/index.ts."
+---
+
+# #3589 — latent null-deref in the compiled test262 `assert` harness
+
+## Problem
+
+`test/built-ins/Iterator/zip/iterables-iteration.js` traps with an **uncatchable
+null dereference inside the compiled test262 `assert` harness**. The trap is
+**pre-existing**; it was invisible only because the module never validated, so
+execution never reached `assert`.
+
+PR #3563 (`fix(#3024)`: pad missing method args in the iterator `next`/`return`
+dispatcher) makes the module validate. The moment it does, the latent deref
+becomes reachable and the test starts trapping — which trips the #3189
+uncatchable-trap ratchet and auto-parked the PR.
+
+**#3563 does not introduce this bug. It unmasks it.** Blocking #3563 on it would
+block a net-positive change (+11 pass, 0 pass-regressions) on an unrelated
+pre-existing defect.
+
+## Evidence — both-sides reproduction
+
+Run locally with `runTest262File()`, swapping **only** `src/codegen/index.ts`
+between `origin/main` and the #3563 head (`432573a07`); everything else identical:
+
+| tree                   | status | error                                                                                                                                                |
+| ---------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `origin/main`          | `fail` | `CompileError: WebAssembly.instantiate(): Compiling function #2083:"__call_next" failed: not enough arguments on the stack for call (need 2, got 1)` |
+| PR #3563 (`432573a07`) | `fail` | `RuntimeError: dereferencing a null pointer in __module_init() at source L76`                                                                        |
+
+Key reading of that table:
+
+- The test is `fail` on **both** sides — it has **never** passed. There is no
+  pass-regression here; only the _flavour_ of the failure changed.
+- The `main` error is exactly the invalid-Wasm bug #3563 exists to fix, which
+  confirms #3563 does what it claims.
+- The trap therefore sits **behind** a module that previously could not even be
+  instantiated.
+
+## Localisation
+
+Dumping the assembled harness for this test (`assembleOriginalHarness`) shows
+**source L76 is the `assert` harness function itself**:
+
+```
+  69 /*---
+  70 description: |
+  71     Collection of assertion functions used throughout test262
+  72 defines: [assert]
+  73 ---*/
+  74
+  75
+  76 function assert(mustBeTrue, message) {
+  77   if (mustBeTrue === true) {
+  78     return;
+  79   }
+  80
+  81   if (message === undefined) {
+  82     message = 'Expected true but got ' + assert._toString(mustBeTrue);
+  83   }
+  84   throw new Test262Error(message);
+  85 }
+```
+
+The failing path is the **non-trivial branch** of `assert` (`mustBeTrue !== true`),
+i.e. the `message === undefined` / `assert._toString(mustBeTrue)` /
+`throw new Test262Error(message)` sequence. The prime suspect is the
+`assert._toString` **static-property access on the function object** and/or the
+`Test262Error` construction — a null receiver being dereferenced rather than a
+proper object.
+
+**Ruled out — the #3563 argument padding is NOT the trap source.** The dispatcher
+was instrumented to log every padded parameter for this test; the only padded
+param is:
+
+```
+[pad] next __anon_7 [{"kind":"f64"}]
+```
+
+That is the numeric NaN missing-arg sentinel (`i64.const 0x7ff00000deadc0de` +
+`f64.reinterpret_i64`), a value type — it cannot produce a null dereference. The
+null comes from the now-reachable `assert` body, not from the pad.
+
+## Why this is worth `priority: high`
+
+`assert` is injected into **every** test262 assembly (it is the harness's core
+assertion primitive). A null-deref reachable in its failure path is therefore
+likely to be a **class** defect, not a single-test curiosity: any test whose
+module currently fails to validate is hiding whatever `assert` would have done.
+As other invalid-Wasm bugs get fixed (which is active work — #3024 has ~15
+merged slices), more tests will start reaching this path and start trapping,
+each one tripping the #3189 ratchet and parking an otherwise-good PR. Expect
+this to recur until the root cause is fixed.
+
+## Reproduction
+
+```bash
+# in a worktree at the #3563 head (or any tree where the module validates)
+npx tsx -e "
+import { runTest262File } from './tests/test262-runner.ts';
+const r = await runTest262File(
+  process.cwd() + '/test262/test/built-ins/Iterator/zip/iterables-iteration.js',
+  'probe', 120000);
+console.log(r.status, r.error);
+"
+# → fail  RuntimeError: dereferencing a null pointer in __module_init() at source L76
+```
+
+## Acceptance criteria
+
+1. `test/built-ins/Iterator/zip/iterables-iteration.js` no longer traps; it fails
+   (or passes) through a **catchable** path.
+2. The failing construct inside `assert` is identified precisely (static property
+   access on a function object vs `Test262Error` construction vs string concat)
+   and covered by an equivalence test, not just fixed for this one file.
+3. `null_deref` trap-category count does not grow.
+4. Re-running #3563's `merge_group` regression job no longer reports
+   `null_deref 159 → 160`.
+
+## Notes
+
+- Discovered while diagnosing the #3563 auto-park
+  (`auto-park-bot:merge-group-failure`, `merge_group` run 30129091219, job
+  `check for test262 regressions`). #3563's own numbers were otherwise strongly
+  positive: net **+11 pass** (30918→30929), host stable-path fine-gate net **+33**
+  (35 improvements − 2 regressions), compile_timeout **−12**, all other trap
+  categories flat, baseline content-current (0 test262-relevant commits behind,
+  so not drift).
+- #3563 remains parked pending a **per-PR** valve for the #3189 ratchet that is
+  usable by an ordinary same-oracle PR. The global `TRAP_RATCHET_TOLERANCE` repo
+  variable was deliberately **not** used — it is queue-wide (it would blind the
+  gate for every other PR in the queue while open), and the repo has a prior
+  incident of it being left open, which is why
+  `.github/workflows/trap-tolerance-staleness-alert.yml` exists.
+- **State of the change-scoped valve (verified, not assumed).**
+  `scripts/diff-test262.ts` **already** implements both the #3189 ratchet and the
+  change-scoped allowance: `TRAP_GROWTH_ALLOW_KEY = "trap-growth-allow"` (line
+  295), read via `readChangeScopedNumericAllowance` (line 1854), then
+  `effectiveTrapTolerance = Math.max(trapTolerance, trapAllowance?.count ?? 0)`
+  (line 1862). **But the read is wrapped in `if (rebaseMode)` (line 1853)** and is
+  documented as inert for same-oracle changes — it was built for the #3370 oracle
+  bump. #3563 is an ordinary same-oracle PR, so the allowance never fires for it
+  and the global env var really is the only existing lever. The Lane A fix is
+  therefore to **extend the existing rebase-gated allowance to a genuine
+  non-rebase reclassification**, not to build a new mechanism — ideally
+  machine-checked (the declaration names the tests, and the gate verifies those
+  tests were not `pass` on the baseline) so it cannot degrade into a general
+  trap-growth escape hatch.
+- ⚠️ **Tooling trap when investigating this file: plain `grep` returns NOTHING on
+  `scripts/diff-test262.ts`** — it silently treats the file as binary (even though
+  `file` reports clean UTF-8), so `grep -n "trap" scripts/diff-test262.ts` exits 1
+  and looks like a confident "not present". **Use `grep -a`** (or an AST/TS
+  scanner). This produced a wrong conclusion about the valve's existence once
+  already during this very diagnosis.
+- See #3590 for a separate, currently-unexercised trap landmine found in the same
+  #3563 code.

--- a/plan/issues/3590-padmissingarg-ref-unconditional-trap-landmine.md
+++ b/plan/issues/3590-padmissingarg-ref-unconditional-trap-landmine.md
@@ -1,0 +1,126 @@
+---
+id: 3590
+title: "padMissingArg `ref` case emits ref.null + ref.as_non_null — an unconditional trap that passes validation"
+status: ready
+sprint: current
+created: 2026-07-24
+updated: 2026-07-24
+priority: medium
+horizon: s
+feasibility: medium
+task_type: bug
+area: codegen
+goal: core-semantics
+related: [3024, 3563, 3189, 3589]
+origin: "Found by the PR-queue shepherd while diagnosing the #3563 auto-park, 2026-07-24. Currently unexercised; filed so it is fixed before it is reached."
+---
+
+# #3590 — `padMissingArg`'s `ref` case is an unconditional null-deref trap
+
+## Problem
+
+The iterator-dispatcher argument padding added by #3563
+(`emitMethodDispatch` → `padMissingArg`, `src/codegen/index.ts`) pads a missing
+trailing method argument per parameter type. The **non-nullable GC-ref** case is:
+
+```ts
+case "ref":
+  return [{ op: "ref.null", typeIdx: (pt as { typeIdx: number }).typeIdx }, { op: "ref.as_non_null" }];
+```
+
+`ref.null $T` pushes a null, and `ref.as_non_null` **traps if its operand is
+null**. Because the operand is _literally_ `ref.null`, this sequence traps
+**100% of the time it executes**.
+
+It is not a validation error — it type-checks correctly as `(ref $T)`, which is
+exactly what makes it dangerous: the module compiles and validates cleanly, and
+the failure only appears at runtime, as an **uncatchable** trap.
+
+The adjacent `ref_null` case is a softer version of the same problem:
+
+```ts
+case "ref_null":
+  return [{ op: "ref.null", typeIdx: (pt as { typeIdx: number }).typeIdx }];
+```
+
+This does not trap at the pad site, but it hands the callee a null that the
+callee will dereference on any field access — relocating the same uncatchable
+trap one frame deeper.
+
+The general point: **a GC-ref parameter has no trap-free default value.** Unlike
+`i32`/`f64` (which have a genuine zero / NaN missing-arg sentinel) and
+`externref` (which has a real host `undefined` via `__get_undefined`), there is
+no inhabitant of `(ref $T)` that can be synthesised without allocating one.
+
+## Impact
+
+**Currently unexercised** — no test in the suite hits it today. The dispatcher
+instrumentation run during the #3563 diagnosis showed the only padded parameter
+in the observed failing case was `{"kind":"f64"}`, the numeric sentinel.
+
+But it is a landmine on a path that is actively growing (#3024 has ~15 merged
+slices, each making more modules validate and therefore more dispatch arms
+reachable). The first user iterator with a typed `next(v: SomeClass)` parameter
+that reaches this dispatcher will trap uncatchably — and, because
+`ref.as_non_null` cannot be caught, it will trip the **#3189 uncatchable-trap
+ratchet** in the `merge_group` and auto-park whichever PR happens to be in
+flight. That is a hard-to-attribute failure landing on an innocent PR, which is
+precisely the expensive kind.
+
+## Proposed fix (prototyped, then deliberately reverted — see Notes)
+
+Do not pad what cannot be padded: **omit the dispatch entry entirely** when any
+extra parameter is a GC ref.
+
+```ts
+// A GC-ref extra param has NO trap-free default, so it must NOT be padded.
+if (extraParams.some((pt) => pt.kind === "ref" || pt.kind === "ref_null")) continue;
+```
+
+Why this is safe:
+
+- The module **still validates** — which is the entire point of #3563. The
+  omitted arm simply falls through to the dispatcher's existing
+  `ref.null.extern` default, i.e. the protocol call yields `undefined`.
+- It **cannot re-introduce** the `not enough arguments on the stack` invalid-Wasm
+  failure, because no call is emitted for the omitted entry at all.
+- The outcome degrades from an **uncatchable trap** to a **catchable** protocol
+  failure (a `TypeError`-shaped result), which is strictly better and is what the
+  #3189 ratchet is asking for.
+- Semantically nothing is lost: calling `.next()` with no argument on an iterator
+  whose `next` requires a typed parameter is already a type error in TypeScript,
+  and the previous behaviour for that arm was a guaranteed trap.
+
+The `ref` / `ref_null` cases should then be **removed** from `padMissingArg`
+rather than left dead. If the guard is ever dropped, the `default` arm's
+`externref` value fails Wasm validation **loudly** at build time, instead of
+silently re-emitting a null-deref trap — a much better failure mode.
+
+## Acceptance criteria
+
+1. No emitted instruction sequence in `emitMethodDispatch` can trap
+   unconditionally; specifically `ref.null` immediately followed by
+   `ref.as_non_null` is gone.
+2. A regression test compiles a user iterator whose `next`/`return` declares a
+   **typed (class) parameter**, asserts the module **validates**, and asserts the
+   protocol call does **not** trap.
+3. `null_deref` / `illegal_cast` trap-category counts do not grow.
+4. The existing #3024 iterator-dispatch arity tests still pass (the CE
+   eliminations are preserved).
+
+## Notes
+
+- Found while diagnosing the #3563 auto-park; **not** the cause of that park (see
+  #3589 for the actual cause — a pre-existing `assert`-harness null-deref that
+  #3563 unmasks).
+- The fix above **was prototyped** against the #3563 head during the
+  investigation, and confirmed to keep the module valid. It was then
+  **deliberately reverted and NOT shipped**, for two reasons: (1) it did not fix
+  the failure actually being diagnosed, so it would have been unvalidated
+  behaviour change riding along on an unrelated park; and (2) it belongs to the
+  branch's owner / a proper dev cycle with its own regression test, not to a
+  shepherd editing someone else's PR under them. Recording the reasoning here so
+  the prototype is not silently lost.
+- Best landed either as a follow-up to #3563 once it un-parks, or folded into
+  #3563 itself by whoever picks that branch back up — with criterion 2's
+  regression test attached.


### PR DESCRIPTION
**Planning-artifact only** — two new `plan/issues/` files, no source changes. Ids allocated via `claim-issue.mjs --allocate`.

Both were found while diagnosing the `auto-park-bot:merge-group-failure` on **#3563** (`merge_group` run 30129091219, job `check for test262 regressions`, `null_deref 159 → 160`). #3563 stays parked; these record what the diagnosis turned up so it isn't lost.

## #3589 — latent null-deref in the compiled test262 `assert` harness (priority: high)

Reproduced both sides locally by swapping **only** `src/codegen/index.ts`:

| tree | status | error |
|---|---|---|
| `origin/main` | `fail` | `CompileError: ... not enough arguments on the stack for call (need 2, got 1)` in `__call_next` |
| #3563 head | `fail` | `RuntimeError: dereferencing a null pointer in __module_init() at source L76` |

The test **never passed on either side** — only the flavour of failure changed. Source L76 of the assembled harness is `function assert(mustBeTrue, message)`, so the trap is a **pre-existing** null-deref in `assert`'s failure path, reachable only once the module validates. **#3563 unmasks it, it does not cause it.** Ruled out the new padding as the source by instrumenting the dispatcher: the only padded param on this test is `{"kind":"f64"}` (the NaN sentinel), a value type.

`assert` is injected into every test262 assembly, so this is likely a class defect that will recur as more invalid-Wasm bugs get fixed and more modules start validating.

## #3590 — `padMissingArg` `ref` case is an unconditional trap (priority: medium)

`ref.null $T` followed by `ref.as_non_null` type-checks as `(ref $T)` and so **validates cleanly**, but `ref.as_non_null` traps on null — and the operand is literally `ref.null`, so it traps 100% of the time it executes. Currently unexercised, but a landmine on an actively-growing path (#3024 has ~15 merged slices, each making more dispatch arms reachable), and it would trip this same #3189 ratchet and park an unrelated in-flight PR.

Fix is prototyped in the issue (omit dispatch entries whose extra params are GC refs — the module stays valid, the arm falls through to the `ref.null.extern` default) and was **deliberately reverted rather than shipped**: it didn't fix the failure being diagnosed, and it belongs to the branch owner with its own regression test, not to a shepherd editing someone else's PR. Reasoning recorded so the prototype isn't lost.

## Also recorded

`scripts/diff-test262.ts` **already** carries a change-scoped `trap-growth-allow` (`TRAP_GROWTH_ALLOW_KEY` L295, `readChangeScopedNumericAllowance` L1854, `effectiveTrapTolerance` L1862) — but the read is wrapped in `if (rebaseMode)` (L1853), so it is inert for an ordinary same-oracle PR like #3563.

Plus a tooling gotcha worth knowing: **plain `grep` silently returns nothing on `scripts/diff-test262.ts`** (treated as binary despite clean UTF-8), so it reports a confident false "not present". Use `grep -a`.