### PR TITLE
docs(#3593): file the Iterator.zip module-shape null_deref (pre-existing, senior-dev)

### DIFF
--- a/plan/issues/3593-iterator-zip-module-shape-null-deref.md
+++ b/plan/issues/3593-iterator-zip-module-shape-null-deref.md
@@ -1,0 +1,158 @@
+---
+id: 3593
+title: "codegen: Iterator.zip over object-literal iterators null-derefs in __module_init (shape-sensitive, pre-existing) — uncatchable trap"
+status: ready
+sprint: current
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: iterator-helpers
+goal: correctness
+related: [3024, 3189]
+---
+
+# #3593 — `Iterator.zip` over object-literal iterators traps (`dereferencing a null pointer` in `__module_init`)
+
+**Routing: senior-dev.** This is a shape-sensitive module-lowering defect, not a
+one-liner. Hand-written snippets do **not** reproduce it — it needs the real
+test262 harness module shape.
+
+Surfaced while landing the #3024 iterator-dispatcher slice (PR #3563). The trap
+**pre-dates that PR**; #3563 only made the affected file compile far enough to
+reach it. See "Attribution" — that is measured, not assumed.
+
+## Symptom
+
+`test/built-ins/Iterator/zip/iterables-iteration.js` (default gc lane):
+
+```
+RuntimeError: dereferencing a null pointer in __module_init()
+```
+
+Classified `null_deref` by the #3189 uncatchable-trap ratchet. This is an
+**uncatchable trap**, the worst failure class — the module aborts rather than
+throwing a catchable `TypeError`.
+
+## Minimized repro (verbatim — keep the `includes:` line, it is load-bearing)
+
+```js
+/*---
+esid: sec-iterator.zip
+description: minimized repro
+includes: [proxyTrapsHelper.js, compareArray.js]
+features: [joint-iteration]
+---*/
+var throwingIterator = {
+  next() {},
+  return() {},
+};
+var iterableReturningThrowingIterator = {
+  [Symbol.iterator]() {},
+};
+assert.throws(TypeError, function () {
+  Iterator.zip(Object.create(null));
+});
+Iterator.zip([throwingIterator, iterableReturningThrowingIterator]);
+```
+
+Obtained by greedy line-deletion minimization of the real file, run through the
+real runner (`runTest262File`). Note the method bodies are **empty** after
+minimization — the original `throw new Test262Error()` bodies are not needed.
+
+## Attribution — PROVEN pre-existing (the important part)
+
+The identical minimized file was run **twice**, changing only one thing:
+
+| `src/codegen/index.ts`      | result                                                         |
+| --------------------------- | -------------------------------------------------------------- |
+| PR #3563's version          | `TRAP=true :: dereferencing a null pointer in __module_init()` |
+| restored from `origin/main` | `TRAP=true :: dereferencing a null pointer in __module_init()` |
+
+Byte-identical trap with the dispatcher change **absent** ⇒ the defect is not
+caused by #3563.
+
+**Stated precisely** (so this can't be poked at): the trap reproduced _from that
+file by deletion-minimization_ occurs on `main` with the dispatcher change
+absent. The **real** file cannot itself be A/B'd, because on `main` it is a
+`compile_error` (invalid Wasm) and never instantiates — which is exactly why the
+#3189 ratchet's baseline could not testify about it, and why the
+`compile_error` baseline-unknown exclusion (#3594-era work) is the correct
+unblock for #3563.
+
+## Shape sensitivity — 8 variants, only the full combination traps
+
+Every **simpler** shape yields a clean, **catchable** `TypeError`, never the trap:
+
+| #    | shape                                                                     | result                                                 |
+| ---- | ------------------------------------------------------------------------- | ------------------------------------------------------ |
+| min1 | full minimized repro above                                                | **TRAP**                                               |
+| min2 | `Iterator.zip([{[Symbol.iterator](){}}])`                                 | `TypeError: Iterator helper: argument is not iterable` |
+| min3 | `Iterator.zip([{next(){}, return(){}}])`                                  | `TypeError: ... not iterable` (see "second defect")    |
+| min4 | min3 but `next()` returns `{done:true, value:undefined}`                  | `TypeError: ... not iterable`                          |
+| min5 | min3 plus draining `z.next()`                                             | `TypeError: ... not iterable`                          |
+| min6 | `assert.throws(TypeError, () => Iterator.zip(Object.create(null)))` alone | **passes**                                             |
+| min7 | `try { Iterator.zip(Object.create(null)); } catch (e) {}` alone           | **passes**                                             |
+| min8 | min6 + `Iterator.zip([{[Symbol.iterator](){}}])`                          | `TypeError: ... not iterable`                          |
+
+So the trap needs **both** object-literal iterators **and** the preceding
+`assert.throws` **and** the `includes:` harness injection. That combination
+changes the module's struct/closure shape — which is why standalone
+`compile()` snippets (tried, 4 variants) never reproduce it.
+
+## Ruled out — do not re-chase
+
+The obvious suspect is `_getFlattenable` in `src/runtime/iterator-polyfills.ts`
+(~L577): `it = sym.call(obj)` can yield `undefined`, and per ES2025
+GetIteratorFlattenable step 5 a non-Object must throw a `TypeError`. **It is
+already guarded** — `_getIteratorDirect` (~L547) starts with
+`if (!_isObject(iter)) throw new TypeError(...)`. The JS-host polyfill is
+spec-correct here.
+
+The trap is in **compiled Wasm** (`__module_init`), not in the polyfill.
+
+## Suggested next step (not yet done)
+
+Source-level minimization stopped converging. The file **compiles on the #3563
+branch**, so the direct move is to dump its **WAT** (`compile(src, { emitWat:
+true })`, or the `/analyze-wat` skill), locate `__module_init`, and find the
+`ref.as_non_null` / `ref.cast` / `struct.get`-on-null site. Reconstruct the
+assembled source using the runner's harness-prelude builder
+(`tests/test262-runner.ts` ~L2405-2450 for the `allowProxyTraps` shim).
+
+Worth also diffing the real file's WAT against min1's, to confirm they are the
+**same** trap site — both report `dereferencing a null pointer in
+__module_init()`, which alone does not distinguish them.
+
+## Second defect found alongside (record, distinct)
+
+`min3` — `Iterator.zip([{ next(){}, return(){} }])` — reports
+`TypeError: Iterator helper: argument is not iterable`. Per
+GetIteratorFlattenable that is **wrong**: with no `@@iterator`, step 3a sets
+`iterator = obj`, and GetIteratorDirect then succeeds because `.next` **is** a
+function. So a compiled object literal's `.next` is not visible as a function to
+the host polyfill. That is evidence about the mechanism (host↔Wasm objlit method
+visibility) and may share a root cause with the trap.
+
+## Accepted risk (recorded deliberately, not glossed)
+
+PR #3563 is being unblocked via the trap-ratchet `compile_error`
+baseline-unknown exclusion rather than by fixing this defect. That means **the
+corpus gains one genuinely-trapping test** (`iterables-iteration.js`) until this
+issue is fixed. This trade was made knowingly: the defect predates #3563, and
+blocking a +33-net / 8-CE-elimination PR on an unrelated deep defect is bad
+economics. Whoever picks this up should expect a live trap in the corpus
+pointing at this issue — it is not a new regression.
+
+## Acceptance criteria
+
+- `test/built-ins/Iterator/zip/iterables-iteration.js` no longer produces an
+  uncatchable trap; any failure is a catchable `TypeError`/`Test262Error`.
+- The minimized repro above runs without `dereferencing a null pointer`.
+- The `null_deref` trap-category count does not increase.
+- Ideally: `min3` reports the spec-correct behaviour (objlit `.next` visible to
+  GetIteratorFlattenable), or that is split into its own issue.


### PR DESCRIPTION
Files **#3593** — the `Iterator.zip` uncatchable trap surfaced by PR #3563, captured so nobody has to re-derive the expensive parts.

## The headline: the trap is PRE-EXISTING, and that is measured

The identical minimized file was run twice, changing only `src/codegen/index.ts`:

| `src/codegen/index.ts` | result |
|---|---|
| PR #3563's version | `TRAP: dereferencing a null pointer in __module_init()` |
| restored from `origin/main` | `TRAP: dereferencing a null pointer in __module_init()` |

Byte-identical trap with the dispatcher change **absent** ⇒ #3563 does not cause it; it only made the file compile far enough to reach it.

Stated precisely in the issue, so it can't be poked at: the trap reproduced *from that file by deletion-minimization* occurs on `main`. The **real** file cannot itself be A/B'd, because on `main` it is a `compile_error` that never instantiates — which is exactly why the #3189 ratchet's baseline could not testify about it, and is the direct justification for the `compile_error` baseline-unknown exclusion.

## What the issue preserves

- **The minimized repro verbatim**, including its load-bearing `includes: [proxyTrapsHelper.js, compareArray.js]` line.
- **An 8-variant discrimination table.** Every *simpler* shape produces a clean, **catchable** `TypeError`; only the full combination traps. That establishes shape-sensitive module lowering rather than a one-liner — and records that hand-written standalone snippets (4 tried) never reproduce it, which would otherwise be the next person's first hour.
- **The ruled-out lead.** `_getFlattenable` looks wrong (`it = sym.call(obj)` can yield `undefined`), but `_getIteratorDirect` already guards with `if (!_isObject(iter)) throw new TypeError(...)`. The host polyfill is spec-correct; the deref is in compiled Wasm.
- **The next step nobody has taken:** the file *compiles* on the #3563 branch, so dump its WAT, locate `__module_init`, and find the `ref.as_non_null`/`ref.cast`/`struct.get`-on-null site — then diff against the repro's WAT to confirm they are the same trap site (both report the same message, which alone does not distinguish them).

## A second, distinct defect recorded

`Iterator.zip([{ next(){}, return(){} }])` reports `argument is not iterable`. Per GetIteratorFlattenable step 3a, a missing `@@iterator` means `iterator = obj`, and GetIteratorDirect then succeeds because `.next` **is** a function. So a compiled object literal's `.next` is not visible as a function to the host polyfill — evidence about the mechanism, possibly a shared root cause.

## Accepted risk, written down rather than discovered later

Unblocking #3563 via the trap-ratchet `compile_error` exclusion means **the corpus gains one genuinely-trapping test until #3593 is fixed**. Deliberate trade — the defect predates #3563, and blocking a +33-net / 8-CE-elimination PR on an unrelated deep defect is bad economics. Whoever picks up #3593 should expect a live trap pointing at their issue; it is not a new regression.

Docs-only: adds one issue file, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)