### PR TITLE
fix(#3596): make the reclassification check declaration-shape-driven, not mode-driven

### DIFF
--- a/plan/issues/3596-trap-ratchet-per-pr-reclassification-valve.md
+++ b/plan/issues/3596-trap-ratchet-per-pr-reclassification-valve.md
@@ -125,6 +125,28 @@ integer, mandatory reason, declared in the granting issue's frontmatter,
 change-set scoped (an allowance that lands on `main` grants nothing to later
 PRs), ceiling-not-blank-cheque, and declarations do not sum.
 
+### The declaration's SHAPE selects the contract — not the run mode
+
+The verification is **not** conditioned on rebase vs non-rebase. It is
+conditioned on whether the declaration opted in:
+
+| declaration            | rebase mode                   | non-rebase mode               |
+| ---------------------- | ----------------------------- | ----------------------------- |
+| **has `tests:`**       | **verified** (#3596 contract) | **verified** (#3596 contract) |
+| **bare `count:` only** | accepted (#3370, unchanged)   | refused as uncheckable        |
+
+Why shape and not mode: whether a PR happens to land during an oracle
+re-baseline is **not predictable by the person writing the frontmatter**. Having
+identical frontmatter enforced strictly or loosely depending on timing is a trap
+nobody could anticipate from reading it — and it is exactly what happened on
+#3583 (see the field-exercise note below).
+
+This is **strictly additive**. Verification can only ever _refuse_ a declaration,
+never admit one the ceiling alone would have rejected, so opting in cannot weaken
+anything. And a bare `count:` keeps #3370 semantics exactly, so existing
+rebase-mode declarations cannot start hard-failing mid-re-baseline — which is why
+the check is not simply made unconditional.
+
 ## Changes
 
 - `scripts/lib/change-scope.mjs` — `parseFrontmatterCountReason` gained an
@@ -170,8 +192,44 @@ named `fail → trap` reclassification is honoured.
   and reads as a confident "not present". **Use `grep -a`.** This produced a
   wrong conclusion about the valve's existence once during this very
   investigation.
-- Follow-up: #3563 and #3583 are expected to need **no declaration** — their
-  newly-trapping files have `compile_error` baselines, which #3595 excludes
-  outright. Re-check each against main once #3595 lands and clear the holds if
-  the gate no longer fires. Only a file with a genuine `fail` baseline should
-  ever reach for this issue's mechanism.
+- Outcome of the two motivating parks:
+  - **#3563** — newly-trapping file had a `compile_error` baseline ⇒ excluded by
+    #3595. Merged with **no declaration**, as it should have.
+  - **#3583** — newly-trapping file had a **`fail`** baseline
+    (`negative_test_fail`), so #3595 correctly does not cover it. Declared a
+    bounded +1 naming `await-dynamic-import-rejection.js`; merged.
+
+## ⚠️ The non-rebase path is NOT yet field-exercised
+
+**Do not read #3583's merge as proof this works in production.** It is not, and
+assuming otherwise was a real mistake made while landing this.
+
+#3583 merged with its `trap-growth-allow` honoured, but the `merge_group`
+artifact shows the summary line labelled **`(#3370)`**, not `(#3596)`:
+
+```
+ORACLE forward-bump auto-rebase (#3086) — comparing across oracle versions (baseline v10 → new v11)
+=== Trap categories: … unreachable 2→3 (#3189 ratchet) ===
+=== trap-growth-allow (#3370): maximum category growth 1 within declared per-category ceiling 1 … ===
+```
+
+An oracle **v10 → v11** bump happened to be in flight, so `rebaseMode` was true
+and the declaration was honoured by the **pre-existing #3370 path**.
+`evaluateTrapReclassification` never executed, and the `tests:` list went
+unverified in that run.
+
+Two things follow:
+
+1. The declaration **was** load-bearing — `unreachable 2→3` with
+   `TRAP_RATCHET_TOLERANCE: 0` would have failed the gate without it. So the
+   mechanism was necessary; only the _verification half_ was skipped.
+2. This valve is **unit-proven, not field-proven**. It carries 11 unit tests plus
+   CLI-level tests, but no real `merge_group` has taken the non-rebase path yet.
+   **When a genuine `fail → trap` reclassification eventually lands outside a
+   re-baseline, pull the regressions artifact and confirm the label reads
+   `(#3596)`.** That is the run that actually validates it — a green gate alone
+   says nothing about _which_ mechanism passed it.
+
+That gap is what motivated the shape-driven contract above: mode is incidental
+and unpredictable to the declaration's author, so it must not decide how strictly
+the declaration is enforced.

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -2019,11 +2019,26 @@ async function run(
       0,
       ...TRAP_ERROR_CATEGORIES.map((c) => trapGrowth.newCounts[c] - trapGrowth.baseCounts[c]),
     );
-    // #3596 — on a non-rebase PR the declared ceiling alone is not enough: the
-    // reclassification claim must machine-check. Only run the check when the
-    // allowance actually did some work (growth > 0); a declaration that excused
-    // nothing needs no proof and should not fail the PR.
-    if (!rebaseMode && maxGrowth > 0) {
+    // #3596 — the DECLARATION'S OWN SHAPE selects the contract, not the run mode.
+    // This matters because mode is incidental: whether a given PR happens to run
+    // during an oracle re-baseline is not something the declaration's author can
+    // predict, and it would be a trap for the same frontmatter to receive weaker
+    // enforcement purely because of when it ran.
+    //
+    //   • `tests:` PRESENT → verify it, in BOTH modes. The author opted into the
+    //     stronger contract, so it is enforced regardless of mode. Strictly a
+    //     tightening: verification can only ever refuse a declaration, never
+    //     admit one the ceiling alone would have rejected.
+    //   • `tests:` ABSENT → #3370 semantics, unchanged. A bare bounded count
+    //     remains valid in rebase mode (existing declarations keep working and
+    //     cannot start hard-failing mid-re-baseline) and is still refused
+    //     outside one, as uncheckable.
+    //
+    // Either way the check only runs when the allowance actually did some work
+    // (growth > 0) — a declaration that excused nothing needs no proof.
+    const declaredTests = trapAllowance.tests ?? [];
+    const checkedContract = declaredTests.length > 0 || !rebaseMode;
+    if (checkedContract && maxGrowth > 0) {
       const recheck = evaluateTrapReclassification({
         allowance: trapAllowance,
         baseline,
@@ -2036,7 +2051,7 @@ async function run(
       }
     }
     console.log(
-      `=== ${rebaseMode ? "trap-growth-allow (#3370)" : "trap-growth-allow (#3596)"}: maximum category growth ${maxGrowth} within declared per-category ceiling ${trapAllowance.count} — ` +
+      `=== ${checkedContract ? "trap-growth-allow (#3596)" : "trap-growth-allow (#3370)"}: maximum category growth ${maxGrowth} within declared per-category ceiling ${trapAllowance.count} — ` +
         `reason: ${trapAllowance.reason} (declared in ${trapAllowance.sources.join(", ")}). ===`,
     );
   }

--- a/tests/issue-3303.test.ts
+++ b/tests/issue-3303.test.ts
@@ -446,6 +446,67 @@ describe("#3303 — CLI gate behaviour (rebase-mode, REGRESSIONS_ALLOW_FILE hook
     expect(r.status).toBe(0);
   });
 
+  // #3596 MODE-INDEPENDENCE. The declaration's own SHAPE selects the contract,
+  // not the run mode. Motivation is concrete: #3583 declared a `tests:` list and
+  // merged, but an oracle v10→v11 bump happened to be in flight, so the run took
+  // the rebase path and the named list was never verified. Whether a PR lands
+  // during a re-baseline is not something the author can predict, so identical
+  // frontmatter must not receive weaker enforcement purely because of timing.
+  describe("#3596 — a `tests:` list is enforced in BOTH modes", () => {
+    const namedButPassingAllowance = (dir: string, name: string) => {
+      const f = join(dir, name);
+      writeFileSync(
+        f,
+        fm(
+          `regressions-allow:\n  count: 100\n  reason: "fixture reclassification"\n` +
+            `trap-growth-allow:\n  count: 100\n  reason: "fixture claim"\n  tests:\n    - test/trap0/a/b/c/t.js`,
+        ),
+      );
+      return f;
+    };
+
+    // `rebaseRows`' trap rows are `pass` on the baseline, so naming one is a
+    // REGRESSION claim. Before this change, rebase mode accepted it unchecked.
+    it("REBASE mode: refuses a named test that was passing on the baseline", () => {
+      const allowFile = namedButPassingAllowance(tmp, "9999-named-passing-rebase.md");
+      const r = runDiffCli(rebaseRows(1, { traps: 1 }), {
+        REGRESSIONS_ALLOW_FILE: allowFile,
+        TRAP_GROWTH_ALLOW_FILE: allowFile,
+        TRAP_RATCHET_TOLERANCE: "0",
+      });
+      expect(r.out).toMatch(/was "pass" on the baseline/);
+      expect(r.status).toBe(1);
+    });
+
+    it("NON-REBASE mode: refuses the same declaration identically", () => {
+      const allowFile = namedButPassingAllowance(tmp, "9999-named-passing-same-oracle.md");
+      const r = runDiffCli(rebaseRows(1, { sameOracle: true, traps: 1 }), {
+        REGRESSIONS_ALLOW_FILE: allowFile,
+        TRAP_GROWTH_ALLOW_FILE: allowFile,
+        TRAP_RATCHET_TOLERANCE: "0",
+      });
+      expect(r.out).toMatch(/was "pass" on the baseline/);
+      expect(r.status).toBe(1);
+    });
+
+    // Backward compatibility, the reason this is shape-driven rather than
+    // "always check": a BARE count with no `tests:` list is a valid #3370
+    // declaration and must keep working in rebase mode. Making the check
+    // unconditional would hard-fail these mid-re-baseline.
+    it("REBASE mode: a bare count (no tests:) keeps #3370 semantics and is NOT checked", () => {
+      const allowFile = join(tmp, "9999-bare-rebase.md");
+      writeFileSync(allowFile, combinedAllowanceFileText(100, 1));
+      const r = runDiffCli(rebaseRows(5, { traps: 1 }), {
+        REGRESSIONS_ALLOW_FILE: allowFile,
+        TRAP_GROWTH_ALLOW_FILE: allowFile,
+        TRAP_RATCHET_TOLERANCE: "0",
+      });
+      expect(r.out).toContain("trap-growth-allow (#3370): maximum category growth 1 within declared");
+      expect(r.out).not.toMatch(/must NAME the reclassified tests/);
+      expect(r.status).toBe(0);
+    });
+  });
+
   it("resets compile-time gate signals when an oracle bump changes the harness workload (#3370)", () => {
     const allowFile = writeAllowanceFile(tmp, 100);
     const rows = {


### PR DESCRIPTION
Closes the enforcement gap #3583 exposed. Strictly additive — no existing declaration changes behaviour.

## The gap

#3583 declared a `tests:` list and merged, but an oracle **v10 → v11** bump was in flight, so the run took the **rebase** path. The `merge_group` artifact's summary line reads `(#3370)`, not `(#3596)` — `evaluateTrapReclassification` never executed and the named list went **unverified**.

Whether a PR lands during a re-baseline is **not predictable by whoever writes the frontmatter**. Identical frontmatter receiving strict or loose enforcement purely because of timing is a trap nobody could anticipate from reading it.

## The fix — shape selects the contract, not mode

| declaration | rebase mode | non-rebase mode |
|---|---|---|
| **has `tests:`** | **verified** (#3596) | **verified** (#3596) |
| **bare `count:` only** | accepted (#3370, unchanged) | refused as uncheckable |

**Why shape-driven and not simply unconditional:** a bare `count:` is a *valid #3370 declaration today*. Making the check unconditional would start hard-failing those mid-re-baseline — wedging a rebase at the worst possible moment. Shape-driven keeps them working while giving anyone who opted in the stronger contract full enforcement.

**Why this is safe:** verification can only ever *refuse* a declaration, never admit one the ceiling alone would have rejected. Opting in cannot weaken anything.

## Tests

3 new CLI tests pinning **mode-independence**:
- rebase mode: a named-but-previously-`pass` test is **refused** (this is the case that previously slipped through unchecked)
- non-rebase mode: the same declaration is refused **identically**
- rebase mode: a bare `count:` keeps #3370 semantics and is **not** checked (backward-compat)

**55 pass** across `issue-3303` + `issue-3596`.

## Also records the field-exercise caveat

#3596 now states plainly that the non-rebase path is **unit-proven, not field-proven**, with the artifact evidence — so nobody mistakes #3583's merge for validation it didn't provide. When a genuine `fail → trap` reclassification lands outside a re-baseline, pull the regressions artifact and confirm the label reads `(#3596)`. A green gate alone says nothing about *which* mechanism passed it.
