### PR TITLE
docs(#3605,#3606): audit for further vacuity cases + unit-test the test262 harness

### DIFF
--- a/plan/issues/3605-audit-further-silent-no-op-vacuity-cases.md
+++ b/plan/issues/3605-audit-further-silent-no-op-vacuity-cases.md
@@ -1,0 +1,110 @@
+---
+id: 3605
+title: "Audit: are there further silent-no-op / vacuity cases beyond the three already found?"
+status: ready
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+feasibility: medium
+model: fable
+task_type: investigation
+area: codegen, runtime, testing
+goal: standalone-mode
+sprint: current
+horizon: m
+related: [3592, 3603, 3468, 3606]
+---
+
+# #3605 — audit for further silent-no-op / vacuity cases
+
+## Problem
+
+Three separate mechanisms have been found that make test262 report **pass for tests that
+should fail**. Each was hidden behind the previous one, and each was found by accident
+rather than by a systematic search:
+
+| #   | Mechanism                                                                                                                                                                                                                                      | Where                                                                                                              | Status                                                      |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| 1   | Standalone closures cannot carry own properties, so `assert.*` methods were never invoked at all                                                                                                                                               | property dispatch gated on `ref.test $Object`                                                                      | **fixed** — #3468 / PR #3523, ~3,545 vacuous passes removed |
+| 2   | Under-applied calls silently return the undefined sentinel, so `assert.sameValue(1,2)` (2 args, 3 formals) does nothing                                                                                                                        | `fillApplyClosure` dispatches on `args.length`; `emitClosureMethodCallExportN` filters `paramTypes.length > arity` | **#3592**, landing                                          |
+| 3   | `verifyProperty` is vacuous on **both** lanes — standalone: object literals have no `$Object` own-property table so every runtime MOP query reports zero own properties; host: uncurried `__push` is a silent no-op so `failures.length === 0` | `emitHasOwn` (`object-runtime.ts` ~2630-2677); the uncurryThis family                                              | **#3603**, unfixed                                          |
+
+Plus a fourth, narrower one: a bare top-level `throw` statement was silently dropped in
+**both** lanes (`declarations.ts:1522`, a `ctx.wasi` gate) — 40 files, fixed in #3592.
+
+**We do not know how many more there are.** Every fix so far has exposed the next layer,
+because the failure mode is indistinguishable from success unless probed deliberately.
+
+## The pattern to hunt
+
+Every instance is the same shape: **a silent `false` / `0` / `undefined` sentinel on a path
+that should either succeed or throw.**
+
+- a guard returns `0` instead of raising (`emitHasOwn`: `if (!ref.test $Object) return 0`)
+- a dispatcher matches no arm and returns an undefined sentinel instead of erroring
+- an append (`__push`) quietly does nothing
+- a statement kind is `continue`-d past during collection
+
+None of these surface anywhere. The harness runs to completion and the test scores pass.
+
+## Scope
+
+Find the remaining instances **before** they are discovered one at a time by accident.
+
+1. **Static sweep.** Enumerate every site in `src/codegen/` and `src/runtime/` that returns a
+   sentinel (`0` / `undefined` / `null` / a "missing" marker) from a _guard_ or _dispatch_
+   arm rather than raising or falling back. Classify each: intended fallback vs. silent
+   failure. The three known instances must all appear in the output — if the sweep misses a
+   known one, the sweep is wrong, not the code.
+2. **Dynamic probe.** Extend the **A/B wrong-expectation control** (see Method) beyond
+   `assert.*` and `verifyProperty` to every other harness primitive test262 relies on:
+   `compareArray`, `assert.throws` sub-cases, `propertyHelper`'s other exports,
+   `deepEqual`, `assertRelativeDateMs`, `testWithTypedArrayConstructors`, the async
+   `doneprintHandle` channel, `wellKnownIntrinsicObjects`, `nativeFunctionMatcher`.
+   For each: feed a deliberately wrong expectation and confirm it **fails**.
+3. **Both lanes, always.** Layer 3 was assumed standalone-only and turned out to affect host
+   too by a different mechanism. Never conclude "standalone-only" without running the host
+   arm.
+
+## Method — do not invent a new one
+
+**The A/B wrong-expectation control.** Feed the harness a deliberately WRONG expectation and
+see whether it still reports pass. Then re-run with the candidate cause force-disabled; if
+behaviour is identical in both arms, the vacuity is pre-existing rather than introduced.
+
+Supporting controls that made the earlier work measurable rather than anecdotal:
+
+- **Local-vs-local A/B** — same runner, same process, only the toggle changed. **Never diff a
+  local sweep against the committed baseline JSONL**; sharded-CI-worker vs in-process
+  differences manufacture phantom deltas (this produced a bogus "+118" once already).
+- **Attribution control** — re-run with all instrumentation present but its throws removed.
+  If that does not reproduce stock exactly, you are measuring your scaffolding.
+- **Calibrate before sampling** — positive control must fire, negative must stay silent, so a
+  null result means "nothing there" rather than "detector broken".
+
+### Known detector trap
+
+Do **not** use `Object.keys(desc)` / `getOwnPropertyNames(desc)` as a yardstick in a
+standalone detector. On a directly-named module global `Object.keys(DESC).length` is `4`
+(compile-time fold); on the **same object** through an `any` parameter it is `0`. A detector
+built on it never fires and returns a null result that looks like a clean bill of health.
+
+## Acceptance
+
+- A written inventory of every sentinel-returning guard/dispatch arm, each classified
+  intended-fallback vs silent-failure, with the three known instances present.
+- Every harness primitive above probed with a wrong expectation on **both** lanes, with the
+  result recorded (fires / vacuous) and denominators given.
+- Any newly found vacuity filed as its own issue with a minimal repro.
+- If the answer is genuinely "no more", say so with the evidence — a negative result here is
+  a valid and valuable deliverable.
+
+## Notes
+
+- **Expect any fix to push the measured floor DOWN.** That is correct, not a regression —
+  see the landing recipe used for #3468/#3523 and #3592.
+- Sizing must be **measured, never extrapolated**. Cluster labels have over-counted actual
+  flips by large factors in this project; report real denominators and an honest pass/fail
+  split.
+- #3606 is the durable counterpart to this issue: this one _finds_ the remaining cases,
+  #3606 makes new ones **impossible to introduce silently**.

--- a/plan/issues/3606-unit-tests-for-the-test262-harness-machinery.md
+++ b/plan/issues/3606-unit-tests-for-the-test262-harness-machinery.md
@@ -1,0 +1,103 @@
+---
+id: 3606
+title: "Unit-test the test262 harness machinery itself — assertions must FAIL when they should"
+status: ready
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+feasibility: medium
+model: opus
+task_type: testing
+area: testing, runtime
+goal: standalone-mode
+sprint: current
+horizon: m
+related: [3605, 3592, 3603, 3468, 3008]
+---
+
+# #3606 — unit-test the code that does the testing
+
+## Problem
+
+test262's harness (`assert.js`, `propertyHelper.js`, `compareArray.js`, …) is **compiled by
+our compiler and executed as our output**. It is the instrument every conformance number is
+measured with — and **nothing tests the instrument**.
+
+We currently verify that tests _pass_. We never verify that they _can fail_. Three separate
+mechanisms have now been found that silently disabled the assertion machinery:
+
+1. `assert.*` methods never invoked at all — standalone closures could not carry own
+   properties (#3468, fixed, ~3,545 vacuous passes).
+2. Under-applied calls silently return the undefined sentinel, so `assert.sameValue(1,2)`
+   does nothing while `assert.sameValue(1,2,"msg")` throws correctly (#3592, ~18.9% of
+   sampled standalone passes).
+3. `verifyProperty` vacuous on **both** lanes, by two unrelated causes (#3603, unfixed).
+
+**Every one of these would have been caught within minutes by a test asserting "a wrong
+expectation must throw".** Instead each was found by accident, months apart, after inflating
+the published conformance number.
+
+This is the same disease as the "vacuous / stale / invisible test outside required checks"
+family (#3558, #3552, #3008) — but one level deeper: the _test harness_ is the thing that
+rotted.
+
+## Scope
+
+A vitest suite that compiles the **real** test262 harness through the **real** compiler and
+asserts, for every assertion primitive, that it **fails on wrong input** — on **both** the
+js-host and standalone lanes.
+
+### Required cases (each must FAIL; a pass is a bug)
+
+- `assert(false)`
+- `assert.sameValue(1, 2)` — **2 args, no message**. This exact shape is what #3592 exposed;
+  it must be tested _separately_ from the 3-arg form, which already worked.
+- `assert.sameValue(1, 2, "msg")` — 3 args
+- `assert.notSameValue(1, 1)`
+- `assert.throws(TypeError, function () {})` — throws nothing
+- `assert.throws(TypeError, function () { throw new RangeError(); })` — wrong error type
+- `assert.compareArray([1,2], [1,3])`
+- `verifyProperty(obj, key, {value: <wrong>})` and independently wrong `writable`,
+  `enumerable`, `configurable` — **all four attributes separately**, because #3603 showed the
+  a1 (own-property-exists) gate can be live while all four descriptor checks are dead
+- a bare top-level `throw new Test262Error("x")` — must FAIL (the #3592 RC1 bug)
+- the async channel: a rejected/failed async test must FAIL, not time out into a pass
+
+### Also assert the positive direction
+
+Correct expectations must still **pass** — otherwise the suite is satisfied by a harness that
+throws unconditionally, which is the opposite failure and equally useless.
+
+### Both lanes, always
+
+#3603's host root cause was found only because someone ran the host arm on a bug everyone
+assumed was standalone-only. Any lane-specific expectation must be justified in a comment.
+
+## Make it load-bearing
+
+- Add the suite to `tests/guard-suite.json` so it runs in the required gate. The #3008 gate
+  only runs PR-_touched_ root tests, which is exactly why the previous guard tests rotted
+  invisibly for five days.
+- Where a case is known-broken today (e.g. the #3603 `verifyProperty` attributes), pin it as
+  an explicit **KNOWN-OPEN** assertion — assert the _current wrong_ behaviour with a pointer
+  to the owning issue — so the real fix flips it **loudly** instead of silently. This
+  convention is already used in the #3594 static-super tests.
+
+## Acceptance
+
+- Suite exists, runs both lanes, and is in `guard-suite.json`.
+- Introducing any of the three known historical bugs makes it fail. **Verify this by
+  actually reverting each fix** — a test that passes with and without the fix is decoration.
+  (This is the same load-bearing check used on the #3595 trap-ratchet tests.)
+- Every KNOWN-OPEN pin cites its issue.
+
+## Why this is worth doing now
+
+The conformance numbers are the project's headline metric and the basis for prioritisation
+decisions. Both the standalone and host figures are currently overstated — and were for
+months — because the measuring instrument was broken and nothing watched it. This suite is
+the cheapest possible guarantee that the next such bug is caught on the PR that introduces
+it, rather than after it has silently inflated the published number.
+
+#3605 is the complementary issue: it _finds_ the remaining vacuity cases; this one makes new
+ones impossible to introduce silently.


### PR DESCRIPTION
Files two issues arising from the vacuity work in sprint 77. **Docs only** — no source or test changes.

## Background

Three separate mechanisms have now been found that made test262 report **PASS for tests that should FAIL**, each hidden behind the previous one, and each found *by accident* rather than by a systematic search:

| # | Mechanism | Status |
|---|---|---|
| 1 | Standalone closures could not carry own properties, so `assert.*` methods were never invoked at all | **fixed** — #3468 / PR #3523, ~3,545 vacuous passes |
| 2 | Under-applied calls silently return the undefined sentinel: `assert.sameValue(1,2)` does nothing, while `assert.sameValue(1,2,"msg")` throws correctly | **#3592**, landing (~18.9% of sampled standalone passes) |
| 3 | `verifyProperty` vacuous on **both** lanes, by two unrelated causes | **#3603**, unfixed |

Plus a narrower fourth: a bare top-level `throw` was silently dropped in both lanes (fixed in #3592).

They all share one shape: **a silent `false` / `0` / `undefined` sentinel on a path that should either succeed or throw.** Nothing surfaces, the harness runs to completion, and the test scores pass. That is also why each fix exposes the next layer — the failure mode is indistinguishable from success unless probed deliberately.

## #3605 — audit for further cases

Find the remaining instances *before* they are discovered one at a time by accident.

- **Static sweep** of sentinel-returning guard/dispatch arms in `src/codegen/` and `src/runtime/`, each classified intended-fallback vs silent-failure. Self-check: all three known instances must appear in the output — if the sweep misses a known one, the sweep is wrong.
- **Dynamic probe** extending the A/B wrong-expectation control to every other harness primitive (`compareArray`, `deepEqual`, `propertyHelper`'s other exports, the async channel, …).
- **Both lanes, always** — #3603 was assumed standalone-only and turned out to affect host too, by a different mechanism.

Records the method and its supporting controls (local-vs-local A/B, attribution control, calibrate-before-sampling) and the known detector trap: `Object.keys(desc).length` reads 4 on a directly-named module global but **0** through an `any` parameter, so a detector built on it never fires and returns a false clean bill of health.

A negative result is an acceptable and valuable outcome here, provided it comes with evidence.

## #3606 — unit-test the harness itself

The test262 harness is compiled by our compiler and is the instrument every conformance number is measured with — and nothing tests the instrument. **We verify that tests pass; we never verify that they can fail.**

A vitest suite that compiles the real harness and asserts each assertion primitive **fails on wrong input**, on both lanes — including `assert.sameValue(1,2)` tested *separately* from the 3-arg form (the exact shape #3592 exposed), and all four `verifyProperty` attributes separately (because #3603 showed the own-property gate can be live while all four descriptor checks are dead). Plus the positive direction, so the suite isn't satisfied by a harness that throws unconditionally.

Folded into `guard-suite.json` so it runs in the required gate — the #3008 gate only runs PR-*touched* root tests, which is exactly why earlier guard tests rotted invisibly. Acceptance requires **reverting each historical fix to prove the suite is load-bearing**; a test that passes with and without the fix is decoration.

Every one of the three bugs above would have been caught in minutes by this suite. Instead they were found months apart, after inflating the published conformance numbers.

## Verification

`check-issue-ids --check` (3163 issues, no duplicates) and `check-issue-ids --against-main` both pass. IDs allocated one at a time with the full PR scan.
