### PR TITLE
feat(#3598): issue-id gate now detects collisions against OPEN PRs, not only main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,29 @@ jobs:
         run: |
           git fetch --no-tags --depth=50 origin main 2>/dev/null || true
           GATE_BASE=origin/main pnpm run check:issue-ids:against-main
+      - name: Issue-ID open-PR collision gate (#3598)
+        # PR-vs-PR half of the id defence: two open PRs adding the same
+        # plan/issues/<id>-*.md are BOTH green against main (neither file is on
+        # main yet); the collision then surfaces only when the first merges —
+        # at best a late red re-check, at worst a merge_group auto-park (#2547)
+        # that strands the loser behind a `hold`. This step compares the
+        # branch's introduced issue files against every OTHER open PR's added
+        # issue files, via the SAME batched scan `claim-issue.mjs --allocate`
+        # uses (scripts/lib/open-pr-issue-files.mjs). Same filename in both PRs
+        # = a modification, NOT flagged; only same id under a different
+        # filename fails. FAIL-OPEN (warn, exit 0) when the scan can't run — a
+        # network-dependent gate must not be able to freeze every PR on a
+        # GitHub blip; the merge_group duplicate-id gate stays the hard
+        # backstop. pull_request only: in the merge_group the head already
+        # contains main and the dup gate above re-validates the merged tree.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CLAIM_PR_REPO: ${{ github.repository }}
+          GATE_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags --depth=50 origin main 2>/dev/null || true
+          GATE_BASE=origin/main pnpm run check:issue-ids:against-open-prs
       - name: Issue integrity vs. merged main (#2530)
         # Stale-base dup-ID gate. The check above runs on the PR's OWN tip, which
         # was cut from an older main; an id that a sibling PR has since merged is

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "check:issue-ids": "node scripts/check-issue-ids.mjs",
     "check:issue-ids:staged": "node scripts/check-issue-ids.mjs --staged",
     "check:issue-ids:against-main": "node scripts/check-issue-ids.mjs --against-main",
+    "check:issue-ids:against-open-prs": "node scripts/check-issue-ids.mjs --against-open-prs",
     "new:issue-id:allocate": "node scripts/claim-issue.mjs --allocate"
   },
   "dependencies": {

--- a/plan/issues/3598-issue-id-gate-should-check-open-prs.md
+++ b/plan/issues/3598-issue-id-gate-should-check-open-prs.md
@@ -214,7 +214,8 @@ Four properties, **all empirically verified against the live repo**:
 1. **Different filename, same id ⇒ FAIL.** Probe added
    `3607-synthetic-collision-probe.md`; correctly reported
    `#3607: this branch adds … but open PR #3590 already adds
-plan/issues/3607-standalone-current-summary-never-committed.md`.
+…/3607-standalone-current-summary-never-committed.md` (link-checker note:
+   path prefix elided — that file exists only in PR #3590, not on this branch).
 2. **Same filename ⇒ PASS.** Renamed the probe to #3590's exact filename → not
    flagged. Two PRs touching one issue file is a modification, not a collision.
    An id-only comparison flags all of these (a first pass flagged five, all
@@ -325,8 +326,9 @@ handed out 3597, yet the open-PR scan did not see its added file." That framing
 is subtly WRONG, and the correction matters. PR #3585's commit timeline:
 
 - at allocation time (23:27:46Z) its head was `068b33490` (pushed 23:20:41Z),
-  whose issue file was **`plan/issues/3590-auto-park-step-aware.md`** — the PR
-  was still numbered #3590;
+  whose issue file was **`3590-auto-park-step-aware.md`** (path prefix elided
+  for the link checker — that pre-rename filename no longer exists anywhere) —
+  the PR was still numbered #3590;
 - the commit `fix(#3597): renumber 3590 -> 3597` was authored **23:45:28Z — 18
   minutes AFTER the allocation**, itself resolving a _different_ collision
   (3590), and it hand-picked 3597 without consulting `--allocate` or the

--- a/plan/issues/3598-issue-id-gate-should-check-open-prs.md
+++ b/plan/issues/3598-issue-id-gate-should-check-open-prs.md
@@ -169,3 +169,106 @@ A pre-emptive sweep script is in use by the PR-queue shepherd — it walks every
 open PR's added issue files and compares against `main`, distinguishing
 modifications from real collisions. Cheap to run once per sweep loop until this
 gate lands.
+
+## Handover (PR-queue shepherd → incoming dev, 2026-07-25)
+
+Reassigned mid-implementation. **What survives on branch `issue-3598-gate-open-prs`
+is `scripts/lib/open-pr-issue-files.mjs` — complete and verified live.** The two
+call-site edits were lost to a `git reset --hard` that also caught uncommitted
+work (my error; the probe commits only captured a `.md`). They were verified
+working end-to-end before that, so this section records exactly what they did —
+reimplementing them is ~150 lines of mechanical work, but the _findings_ below
+are the expensive part and should not be re-derived.
+
+### Design intent — one scan, not two
+
+The root asymmetry is that `claim-issue.mjs --allocate` already scans
+`main ∪ every open PR's added issue files ∪ the reservation ref`, while the CI
+gate only ever compared against `main`. **Do not write a second scanner** — that
+guarantees drift, and the allocator's copy carries hard-won #2943 hardening
+(one batched GraphQL query instead of 1+N calls, REST `--paginate` fallback for
+
+> 100-file PRs, 3× retry with backoff, and `complete: false` on total failure so
+> callers degrade _loudly_).
+
+So the module was extracted **verbatim** from `idsFromOpenPRs`, generalised to
+return `{ byPr: Map<prNumber, paths[]>, complete }`. Paths-per-PR is the richer
+primitive: ids derive from paths, not the reverse, and the gate needs the PR
+number so a failure can _name the PR you raced_. `openPrIssueIds()` is the thin
+id-only wrapper preserving the allocator's exact `{ ids, complete }` contract.
+
+`claim-issue.mjs` then delegates to it (keeping its own loud warning at the call
+site) and drops its now-dead `PR_FILES_QUERY` / `PR_SCAN_*_TIMEOUT_MS` consts.
+**Verified after refactor:** `--allocate --dry-run` → `#3609 (scanned 3128 used
+ids; PR-scan on)`.
+
+### The gate — `check-issue-ids.mjs --against-open-prs`
+
+A `mode` alongside `against-main`, sharing an extracted `introducedFiles(base)`
+helper (present at HEAD, absent at the merge-base with base) so both modes agree
+on what "this branch added" means.
+
+Four properties, **all empirically verified against the live repo**:
+
+1. **Different filename, same id ⇒ FAIL.** Probe added
+   `3607-synthetic-collision-probe.md`; correctly reported
+   `#3607: this branch adds … but open PR #3590 already adds
+plan/issues/3607-standalone-current-summary-never-committed.md`.
+2. **Same filename ⇒ PASS.** Renamed the probe to #3590's exact filename → not
+   flagged. Two PRs touching one issue file is a modification, not a collision.
+   An id-only comparison flags all of these (a first pass flagged five, all
+   ordinary modifications) — **compare filenames**.
+3. **Self-exclusion.** `GATE_PR_NUMBER`/`PR_NUMBER` excludes the PR being
+   validated, or it always collides with itself. Verified: setting
+   `GATE_PR_NUMBER=3590` made case 1 pass.
+4. **Fail-soft.** `complete: false` ⇒ warn and `exit 0`. See below.
+
+Failure output names both sides, states the tie-break (merged/queued PR keeps the
+id; otherwise the earlier `origin/issue-assignments` reservation wins), and gives
+the `--allocate` + `git mv` recipe.
+
+### Fail-open vs fail-closed — deliberate, and it matters
+
+**Fail-OPEN (warn, exit 0).** This gate needs network on every PR; fail-closed
+would wedge _every_ PR on a GitHub blip or rate-limit, converting an outage into
+a total merge freeze. It is **additive**: `--against-main` stays hard, and the
+merged-state dup gate remains the backstop. Degrading loudly (never silently) is
+the same posture #2943 chose for the allocator, and for the same reason.
+
+### Dead ends / hazards already hit
+
+- **Rate limits & pagination** — solved by inheriting #2943's batched query +
+  REST fallback + retry. Don't reimplement naively; `gh pr view --json files`
+  silently truncates at 100 files.
+- **Renames.** A PR that _renames_ an issue file shows both paths in its file
+  list, so the old id can still appear as "added" by that PR. Not observed
+  causing a false positive (every renumber this week renamed _away from_ the
+  contested id, so the surviving path is the new one), but it is the most
+  likely false-positive source — worth a test.
+- **`grep` lies on some files.** Plain `grep` returns nothing on
+  `scripts/diff-test262.ts` (treated as binary despite clean UTF-8). Use
+  `grep -a` when auditing these scripts; it produced one confidently-wrong
+  conclusion during this work.
+- **Don't `git reset --hard` with uncommitted work.** How the call-site edits
+  were lost. Commit real work _before_ stacking throwaway probe commits.
+
+### The probe was scaffolding, not a test
+
+The synthetic-collision commits were deliberately throwaway (they add a fake
+issue file). **They should not survive to merge.** But the three behaviours they
+proved (1/2/3 above) deserve real coverage — ideally with `openPrIssueFiles`
+stubbed so the test is hermetic and needs no network, rather than hitting the
+live API.
+
+### Stale-head (Collision D) — genuinely a separate fix
+
+Collision D park-held a PR whose renumber had **already landed**: the
+`merge_group` run started before the push, so the queue validated a stale head.
+**This gate cannot fix that** — it is a PR-level check, and by construction the
+stale-head case is the queue evaluating an older commit than the branch has.
+The fix belongs where the park is _raised or acted on_: either re-evaluate a
+park against the PR's current head before applying the `hold`, or have the park
+comment state the SHA it judged so a reader can see it is stale. Recommend
+keeping it out of #3598's scope and filing it separately against the auto-park
+bot (#2547/#3597 territory) — folding it in would blur a clean PR-level gate
+with queue-lifecycle logic.

--- a/plan/issues/3598-issue-id-gate-should-check-open-prs.md
+++ b/plan/issues/3598-issue-id-gate-should-check-open-prs.md
@@ -1,10 +1,11 @@
 ---
 id: 3598
 title: "check:issue-ids should detect collisions against OPEN PRs, not only main — the gap that silently parks PRs"
-status: ready
+status: done
+completed: 2026-07-25
 sprint: current
 created: 2026-07-24
-updated: 2026-07-24
+updated: 2026-07-25
 priority: high
 horizon: s
 feasibility: medium
@@ -272,3 +273,83 @@ comment state the SHA it judged so a reader can see it is stale. Recommend
 keeping it out of #3598's scope and filing it separately against the auto-park
 bot (#2547/#3597 territory) — folding it in would blur a clean PR-level gate
 with queue-lifecycle logic.
+
+## Implementation notes (senior-dev, 2026-07-25)
+
+Landed on branch `issue-3598-gate-open-prs`, building on the handover module.
+Probe/test coverage: `tests/issue-3598-open-pr-id-gate.test.ts` (hermetic — the
+scan result is injected, no network).
+
+### What landed, and WHY it is shaped this way
+
+- **`check-issue-ids.mjs --against-open-prs`** — new mode, wired into the
+  `quality` job (ci.yml, `pull_request` only) as
+  `check:issue-ids:against-open-prs`, with `GATE_PR_NUMBER` from the event for
+  self-exclusion. It shares `introducedIssueFiles(base)` with `--against-main`
+  (extracted, behaviour-preserving) so both modes agree on what "this branch
+  added" means, and calls the API **only when the branch actually introduces
+  issue files** — the common no-issue-file PR pays zero network cost, which is
+  what keeps the per-PR rate-limit budget trivial (one batched GraphQL query
+  even in the paying case, inherited from #2943).
+- **One scan, one code path**: the gate and `claim-issue.mjs --allocate` both
+  consume `scripts/lib/open-pr-issue-files.mjs` (the shepherd's extraction,
+  preserved verbatim in its hardened parts). `claim-issue.mjs` now delegates —
+  its local `PR_FILES_QUERY`/`idsFromOpenPRs` body and `ISSUE_ID_RE` copy are
+  gone, so the allocator and the enforcement point cannot drift.
+- **Fail-OPEN on scan failure (deliberate, stated in the PR):** the scan needs
+  network on every gated PR; fail-closed would convert a GitHub blip or
+  rate-limit into a red check on EVERY open PR at once — a total merge freeze
+  caused by the very gate meant to prevent stalls. It degrades LOUDLY
+  (`⚠ … DEGRADED … passing WITHOUT PR-vs-PR coverage`) and the `merge_group`
+  duplicate-id `--check` remains the hard backstop. `--against-main` (pure git,
+  no network) stays hard-fail.
+- **Rename hazard closed at the scan layer**: the GraphQL query now requests
+  `changeType` and `liveIssuePaths()` drops `DELETED` entries (REST fallback:
+  `select(.status != "removed")`). A _detected_ rename lists only the new path,
+  but an UNdetected one (similarity too low) appears as ADDED-new +
+  DELETED-old — without the filter, a PR that renumbered AWAY from a contested
+  id would still read as claiming it: the top false-positive source, now unit-
+  tested. This also stops a genuinely-deleted issue file from claiming its id.
+- **Same-filename ⇒ PASS** (two PRs modifying one issue file) and
+  **self-exclusion** are implemented in a pure `findOpenPrCollisions()` in the
+  lib, hermetically tested. All four behaviours were ALSO re-verified live
+  against the real repo with a throwaway probe commit (collision vs PR #3590
+  correctly named; self-exclusion via `GATE_PR_NUMBER=3590`; same-filename
+  pass; degraded-scan fail-open) — the probe commit was dropped before push,
+  per the handover ("scaffolding, not a test").
+
+### Collision C root-caused — the allocator's scan was NOT unreliable
+
+The evidence section above says PR #3585 "was already open when `--allocate`
+handed out 3597, yet the open-PR scan did not see its added file." That framing
+is subtly WRONG, and the correction matters. PR #3585's commit timeline:
+
+- at allocation time (23:27:46Z) its head was `068b33490` (pushed 23:20:41Z),
+  whose issue file was **`plan/issues/3590-auto-park-step-aware.md`** — the PR
+  was still numbered #3590;
+- the commit `fix(#3597): renumber 3590 -> 3597` was authored **23:45:28Z — 18
+  minutes AFTER the allocation**, itself resolving a _different_ collision
+  (3590), and it hand-picked 3597 without consulting `--allocate` or the
+  reservation ref (which already held `3597.json`, reserved 23:27:46Z).
+
+So the scan returned exactly what existed; the colliding id materialised on the
+branch later. A live cross-check of the batched scan against per-PR REST file
+lists (all open PRs) found **zero mismatches**. Conclusion: there is no
+allocation-time fix — ids appear on branches at arbitrary times, which is
+precisely why enforcement had to move to verdict time (this gate). Had the gate
+existed, the moment the 3597 renumber was pushed while both PRs were open, the
+loser would have gone red at PR level instead of auto-parking in the queue.
+
+Residual forensic gap closed: the reservation entry on
+`origin/issue-assignments` now records `pr_scan: ok|degraded|off`, so any
+future collision can be root-caused post-hoc instead of guessing whether the
+scan was degraded (the stderr-only warning was the reason Collision C initially
+resisted diagnosis).
+
+### Stale-head (Collision D): DEFERRED — filed as #3609
+
+Confirmed out of scope, per the handover's reasoning: a PR-level gate
+structurally cannot fix the queue validating an older commit than the branch
+has. Filed **#3609** against the auto-park bot (re-evaluate the park against
+the PR's current head before applying `hold`, or at minimum record the judged
+SHA in the park comment).

--- a/plan/issues/3609-auto-park-stale-head-revalidation.md
+++ b/plan/issues/3609-auto-park-stale-head-revalidation.md
@@ -1,0 +1,49 @@
+---
+id: 3609
+title: "auto-park bot judges a stale head — re-validate against the PR's current head before applying `hold`"
+status: ready
+sprint: Backlog
+created: 2026-07-25
+updated: 2026-07-25
+priority: medium
+horizon: s
+feasibility: medium
+task_type: ci
+area: ci, merge-queue
+goal: release-pipeline
+related: [2547, 3598]
+origin: "Split out of #3598 (Collision D) — deliberately kept out of the PR-level gate's scope."
+---
+
+# #3609 — auto-park re-validation: don't park a PR the branch has already fixed
+
+## Problem
+
+Collision D of #3598: PR #3589 was auto-parked (`hold` label) by the
+`merge_group` duplicate-id gate for a collision whose **renumber had already
+landed on the branch** — the merge-group run had started _before_ that push, so
+the queue validated a **stale head** and parked a PR that was already correct.
+
+A PR-level gate structurally cannot fix this (#3598 covers the PR-vs-PR
+collision itself): the stale-head case is by construction the queue evaluating
+an older commit than the branch has. The fix belongs where the park is raised
+or acted on — the auto-park bot (#2547).
+
+## Proposed fix (either or both)
+
+1. **Re-evaluate before parking.** When the bot is about to apply `hold` for a
+   `merge_group` failure, compare the SHA the failed run validated against the
+   PR's _current_ head. If the head has advanced, skip the park (the queue will
+   re-validate the new head anyway) or downgrade to a comment.
+2. **Record the judged SHA.** At minimum, the park comment should state the SHA
+   the verdict was formed on, so a shepherd reading the park can immediately see
+   it is stale instead of re-diagnosing (per the #3598 auto-park handling rules,
+   a bot park-hold must be diagnosed before removal — make that diagnosis cheap).
+
+## Acceptance criteria
+
+1. A PR whose head advanced after the failed `merge_group` run started is not
+   parked (or its park comment clearly states the stale judged SHA).
+2. Existing park behaviour for genuinely-failing current heads is unchanged.
+3. The park comment names the failing run, the judged SHA, and the current head
+   SHA at comment time.

--- a/scripts/check-issue-ids.mjs
+++ b/scripts/check-issue-ids.mjs
@@ -274,7 +274,7 @@ function checkAgainstOpenPrs() {
   if (collisions.length === 0) {
     if (!args.includes("--quiet")) {
       console.log(
-        `✓ --against-open-prs OK: ${introduced.length} introduced issue file${introduced.length > 1 ? "s" : ""} collide with none of ${scan.byPr.size} open PR${scan.byPr.size === 1 ? "" : "s"} touching issue files`,
+        `✓ --against-open-prs OK: ${introduced.length} introduced issue file${introduced.length > 1 ? "s collide" : " collides"} with none of ${scan.byPr.size} open PR${scan.byPr.size === 1 ? "" : "s"} touching issue files`,
       );
     }
     process.exit(0);

--- a/scripts/check-issue-ids.mjs
+++ b/scripts/check-issue-ids.mjs
@@ -8,6 +8,7 @@
  *   node scripts/check-issue-ids.mjs --staged      # check git-staged files only (pre-commit)
  *   node scripts/check-issue-ids.mjs --committed   # check committed tree (HEAD)
  *   node scripts/check-issue-ids.mjs --against-main # PR-time fresh-claim gate (#2531)
+ *   node scripts/check-issue-ids.mjs --against-open-prs # PR-vs-PR collision gate (#3598)
  *
  * --against-main is the REQUIRED-CI half of the atomic-allocation defense
  * (#2531). A PR that *introduces* a plan/issues/<id>-*.md whose id already
@@ -21,20 +22,37 @@
  * that one re-checks the simulated merge tree; this one rejects at PR time with
  * a precise "use claim-issue.mjs --allocate" message so the dev never wedges
  * the queue in the first place.
+ *
+ * --against-open-prs (#3598) is the PR-vs-PR half --against-main cannot see:
+ * two OPEN PRs each adding plan/issues/<id>-*.md are BOTH green against main
+ * (neither file is on main yet), and the collision surfaces only when the
+ * first merges — at best a late red re-check, at worst a merge_group
+ * auto-park (#2547) that strands the loser behind a `hold` label. This mode
+ * compares the branch's introduced issue files against every OTHER open PR's
+ * added issue files, via the SAME batched scan `claim-issue.mjs --allocate`
+ * uses (scripts/lib/open-pr-issue-files.mjs — one code path, no drift).
+ * FAIL-OPEN on scan failure: this check needs network on every PR, and
+ * failing closed would convert a GitHub blip into a total merge freeze; it
+ * degrades loudly and the merge_group duplicate-id gate remains the hard
+ * backstop. Set GATE_PR_NUMBER (or PR_NUMBER) to the PR under validation so
+ * it never collides with itself.
  */
 
 import { execSync } from "child_process";
 import { readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
+import { openPrIssueFiles, findOpenPrCollisions } from "./lib/open-pr-issue-files.mjs";
 
 const args = process.argv.slice(2);
 const mode = args.includes("--against-main")
   ? "against-main"
-  : args.includes("--staged")
-    ? "staged"
-    : args.includes("--committed")
-      ? "committed"
-      : "workspace";
+  : args.includes("--against-open-prs")
+    ? "against-open-prs"
+    : args.includes("--staged")
+      ? "staged"
+      : args.includes("--committed")
+        ? "committed"
+        : "workspace";
 
 /**
  * Extract the issue ID from a filename: "1799-foo.md" → "1799", "779a-bar.md" → "779a".
@@ -137,10 +155,37 @@ function fileIdsInRef(ref) {
   return map;
 }
 
+// Files this branch INTRODUCED = (id, filename) pairs present at HEAD but
+// absent at the merge-base with `base`. Using the merge-base (not base itself)
+// avoids flagging files an earlier `git merge origin/main` legitimately
+// carried in — only files genuinely new on this branch count. Shared by
+// --against-main and --against-open-prs so both modes agree on what "this
+// branch added" means (#3598). Returns null when the base ref isn't present.
+function introducedIssueFiles(base) {
+  const baseTree = fileIdsInRef(base);
+  if (baseTree === null) return null;
+  let mergeBase = "HEAD";
+  try {
+    mergeBase = execSync(`git merge-base ${base} HEAD`, { encoding: "utf8" }).trim() || "HEAD";
+  } catch {
+    /* fall back to HEAD (treats every HEAD file as introduced — safe, stricter) */
+  }
+  const headFiles = fileIdsInRef("HEAD") || new Map();
+  const mergeBaseFiles = fileIdsInRef(mergeBase) || new Map();
+  const introduced = [];
+  for (const [id, fnames] of headFiles) {
+    const atMergeBase = mergeBaseFiles.get(id) || new Set();
+    for (const fname of fnames) {
+      if (!atMergeBase.has(fname)) introduced.push({ id, fname });
+    }
+  }
+  return { baseTree, introduced };
+}
+
 function checkAgainstMain() {
   const base = process.env.GATE_BASE || "origin/main";
-  const mainFiles = fileIdsInRef(base);
-  if (mainFiles === null) {
+  const r = introducedIssueFiles(base);
+  if (r === null) {
     // Base ref unavailable (shallow clone without it). Skip cleanly rather than
     // block a build we can't reason about — the merged-state gate (#2530) is the
     // backstop. Mirrors the issue-spec-coverage gate's "skip when no base" rule.
@@ -149,36 +194,18 @@ function checkAgainstMain() {
     );
     process.exit(0);
   }
-
-  // Files this branch INTRODUCED = (id, filename) pairs present at HEAD but
-  // absent at the merge-base with base. Using the merge-base (not base itself)
-  // avoids flagging files an earlier `git merge origin/main` legitimately
-  // carried in — only files genuinely new on this branch count.
-  let mergeBase = "HEAD";
-  try {
-    mergeBase = execSync(`git merge-base ${base} HEAD`, { encoding: "utf8" }).trim() || "HEAD";
-  } catch {
-    /* fall back to HEAD (treats every HEAD file as introduced — safe, stricter) */
-  }
-  const headFiles = fileIdsInRef("HEAD") || new Map();
-  const baseFiles = fileIdsInRef(mergeBase) || new Map();
+  const { baseTree: mainFiles, introduced } = r;
 
   // collisions: an introduced filename whose id already exists on base under a
   // DIFFERENT filename. (Same filename on base = the branch just modified an
   // existing issue — fine. Different filename = the wedge dup.)
   const collisions = [];
-  for (const [id, fnames] of headFiles) {
+  for (const { id, fname } of introduced) {
     const baseFnamesForId = mainFiles.get(id);
     if (!baseFnamesForId) continue; // id not on base at all → genuinely fresh, fine
-    const baseMergeFnames = baseFiles.get(id) || new Set();
-    for (const fname of fnames) {
-      // introduced on this branch?
-      if (baseMergeFnames.has(fname)) continue; // already at merge-base → not new
-      // does base/main carry this id under a DIFFERENT filename?
-      const conflictsOnMain = [...baseFnamesForId].filter((bf) => bf !== fname);
-      if (conflictsOnMain.length) {
-        collisions.push({ id, fname, conflictsOnMain });
-      }
+    const conflictsOnMain = [...baseFnamesForId].filter((bf) => bf !== fname);
+    if (conflictsOnMain.length) {
+      collisions.push({ id, fname, conflictsOnMain });
     }
   }
 
@@ -205,8 +232,76 @@ function checkAgainstMain() {
   process.exit(1);
 }
 
+// --against-open-prs (#3598): the PR-vs-PR collision --against-main is blind
+// to. Compares this branch's introduced issue files against every OTHER open
+// PR's added issue files. Same id + same filename = both PRs touching one
+// issue file (a modification) → PASS; same id + DIFFERENT filename = the
+// race that ends in a merge_group auto-park → FAIL loudly at PR level, naming
+// the PR raced. FAIL-OPEN when the scan can't run (network gate must not be
+// able to freeze all of CI); the merge_group dup gate stays the hard backstop.
+function checkAgainstOpenPrs() {
+  const base = process.env.GATE_BASE || "origin/main";
+  const r = introducedIssueFiles(base);
+  if (r === null) {
+    console.log(
+      `✓ --against-open-prs skipped: base ref '${base}' not present (shallow checkout); merge_group dup gate covers it`,
+    );
+    process.exit(0);
+  }
+  const { introduced } = r;
+  if (introduced.length === 0) {
+    // No network call when the branch adds no issue files — the common case.
+    console.log("✓ --against-open-prs OK: this branch introduces no issue files (open-PR scan skipped)");
+    process.exit(0);
+  }
+
+  const selfPr = process.env.GATE_PR_NUMBER || process.env.PR_NUMBER || null;
+  const scan = openPrIssueFiles();
+  if (!scan.complete) {
+    // FAIL-OPEN, loudly (#3598 design decision): warn, never block. A red
+    // check here on a GitHub blip/rate-limit would wedge EVERY open PR at
+    // once. --against-main stays hard; merge_group --check is the backstop.
+    console.warn(
+      "⚠ --against-open-prs DEGRADED: open-PR scan failed/timed out (gh offline, unauthenticated, or rate-limited).",
+    );
+    console.warn(
+      "  Passing WITHOUT PR-vs-PR collision coverage — the merge_group duplicate-id gate remains the backstop.",
+    );
+    process.exit(0);
+  }
+
+  const collisions = findOpenPrCollisions(introduced, scan.byPr, { selfPr });
+  if (collisions.length === 0) {
+    if (!args.includes("--quiet")) {
+      console.log(
+        `✓ --against-open-prs OK: ${introduced.length} introduced issue file${introduced.length > 1 ? "s" : ""} collide with none of ${scan.byPr.size} open PR${scan.byPr.size === 1 ? "" : "s"} touching issue files`,
+      );
+    }
+    process.exit(0);
+  }
+
+  console.error(
+    `✗ --against-open-prs FAILED: ${collisions.length} issue-id collision${collisions.length > 1 ? "s" : ""} with other OPEN PRs (#3598):`,
+  );
+  for (const { id, fname, prNumber, otherPath } of collisions) {
+    console.error(`  #${id}: this branch adds plan/issues/${fname}`);
+    console.error(`         but open PR #${prNumber} already adds ${otherPath}`);
+  }
+  console.error("");
+  console.error("Two open PRs claim the same issue id. If neither renumbers, the one that");
+  console.error("merges second gets auto-parked in the merge queue (`hold` label) and strands.");
+  console.error("Tie-break: the merged/queued PR keeps the id; otherwise the EARLIER");
+  console.error("reservation on origin/issue-assignments wins. The losing branch renumbers:");
+  console.error("  NEW=$(node scripts/claim-issue.mjs --allocate)   # prints the reserved id");
+  console.error("  git mv plan/issues/<old>-<slug>.md plan/issues/$NEW-<slug>.md");
+  console.error("  # then update the file's frontmatter id: to $NEW");
+  process.exit(1);
+}
+
 if (mode === "against-main") {
   checkAgainstMain();
+} else if (mode === "against-open-prs") {
+  checkAgainstOpenPrs();
 }
 
 const map =

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -66,6 +66,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { openPrIssueIds, ISSUE_ID_RE } from "./lib/open-pr-issue-files.mjs";
 
 const ASSIGN_REF = "issue-assignments";
 // The issue-assignments orphan ref lives on the FORK (origin) — keep REMOTE =
@@ -91,14 +92,12 @@ const MAIN_REF = `${MAIN_REMOTE}/main`;
 // `--allocate` must NEVER hang indefinitely. `execFileSync` has no default
 // timeout, so a single stuck `gh`/`git` call under API contention (many
 // concurrent agents) previously blocked the WHOLE team's issue filing. Every
-// network call in the allocate path is now capped; the open-PR scan
-// additionally carries an overall wall-clock budget, after which it degrades to
-// the pre-existing fail-open fallback (allocate against main ∪ reservations
-// only — the PR-time `check:issue-ids:against-main` gate is the hard backstop).
-// All three are env-overridable for tuning under different load.
+// network call in the allocate path is now capped; the open-PR scan (now in
+// scripts/lib/open-pr-issue-files.mjs, with its own CLAIM_PR_SCAN_*_TIMEOUT_MS
+// budget) degrades to the pre-existing fail-open fallback (allocate against
+// main ∪ reservations only — the PR-time `check:issue-ids` gates are the hard
+// backstop). Env-overridable for tuning under different load.
 const MAIN_FETCH_TIMEOUT_MS = Number(process.env.CLAIM_MAIN_FETCH_TIMEOUT_MS) || 15000;
-const PR_SCAN_CALL_TIMEOUT_MS = Number(process.env.CLAIM_PR_SCAN_CALL_TIMEOUT_MS) || 12000;
-const PR_SCAN_TOTAL_TIMEOUT_MS = Number(process.env.CLAIM_PR_SCAN_TOTAL_TIMEOUT_MS) || 25000;
 
 // Best-effort refresh of the main tip — only when allocating (frequent
 // --check/--list calls shouldn't pay a network round-trip). Bounded so a hung
@@ -237,7 +236,9 @@ function mainIssueStatus(id) {
 // `allUsedIds()` unions all three; the next id is max(union)+1 (monotonic — we
 // never reuse a gap that might be reserved on a branch this scan can't see).
 
-const ISSUE_ID_RE = /(?:^|\/)plan\/issues\/(\d+)[a-z]?-[^/]*\.md$/;
+// ISSUE_ID_RE is imported from scripts/lib/open-pr-issue-files.mjs (#3598) so
+// the main-tree scan here and the open-PR scans (allocator + CI gate) agree on
+// what an issue file IS — one regex, no drift.
 
 // Stray ids separated from the contiguous body by a large gap (a mis-typed
 // 6406 when the real range is ~2500) must not poison max+1 and hand out a 2194
@@ -334,28 +335,6 @@ function idsFromAssignRef(sha) {
   return out;
 }
 
-// Ids added by currently-open PRs. Uses `gh` when available (the only way to
-// see a fork-headed PR whose branch is NOT a refs/remotes/origin/* ref here).
-//
-// #2943 hardening — the original implementation fanned out 1 + N gh calls
-// (`gh pr list` then `gh pr view --json files` per PR), which made EVERY open
-// PR an independent, silently-swallowed failure point. Under gh rate-limit /
-// API contention (many concurrent agents), a dropped call narrowed the id
-// universe with NO signal: on 2026-07-02 an --allocate returned 2920 while
-// open PR #2424 already added plan/issues/2920-*.md (same pattern hit 2921 /
-// PR #2425; downstream, one analysis file burned the 2921→2931→2937→2940
-// re-id chain on parallel-session collisions). Now:
-//   - ONE batched GraphQL query (100 PRs × 100 files per page, paginated)
-//     replaces the fan-out — two orders of magnitude fewer API calls, one
-//     failure point instead of N;
-//   - a per-PR REST `--paginate` fallback covers the rare >100-file PR
-//     (`gh pr view --json files` also silently truncates at 100 — a second
-//     latent miss source in the old code);
-//   - the whole scan retries 3× with backoff, and on total failure returns
-//     `complete: false` so the caller can WARN LOUDLY instead of proceeding
-//     silently. Still fail-open by design (offline/unauthenticated use keeps
-//     working; the PR-time CI gate check-issue-ids --against-main is the hard
-//     backstop) — but no longer fail-SILENT.
 function sleepMs(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
@@ -374,91 +353,26 @@ function raceBackoffMs(attempt) {
   return Math.floor(Math.random() * ceil);
 }
 
-const PR_FILES_QUERY = `query($owner:String!,$name:String!,$cursor:String){
-  repository(owner:$owner,name:$name){
-    pullRequests(states:OPEN,first:100,after:$cursor){
-      pageInfo{hasNextPage endCursor}
-      nodes{number files(first:100){pageInfo{hasNextPage} nodes{path}}}
-    }
-  }
-}`;
-
+// Ids added by currently-open PRs. Uses `gh` when available (the only way to
+// see a fork-headed PR whose branch is NOT a refs/remotes/origin/* ref here).
+//
+// The scan itself lives in scripts/lib/open-pr-issue-files.mjs (#3598) — ONE
+// implementation shared with the CI gate `check-issue-ids.mjs
+// --against-open-prs`, so the allocator and the enforcement point can never
+// drift apart. The lib preserves the full #2943 hardening (one batched GraphQL
+// query instead of 1+N calls, REST --paginate fallback for >100-file PRs, 3×
+// retry with backoff, `complete: false` on total failure). This wrapper keeps
+// the allocator's loud fail-open warning at the call site.
 function idsFromOpenPRs() {
-  const repo = process.env.CLAIM_PR_REPO || "loopdive/js2";
-  const [owner, name] = repo.split("/");
-  // Overall wall-clock budget for the whole scan (all attempts + pagination).
-  // Past this the scan bails to the fail-open fallback rather than hanging.
-  const deadline = Date.now() + PR_SCAN_TOTAL_TIMEOUT_MS;
-  // A single gh invocation, capped at min(per-call limit, remaining budget).
-  // On budget exhaustion it throws a tagged error so the loop bails cleanly;
-  // on a per-call timeout `execFileSync` throws ETIMEDOUT (process SIGKILLed),
-  // which the retry/backoff path below handles like any transient gh failure.
-  const ghBounded = (args) => {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      const e = new Error("open-PR scan budget exhausted");
-      e.scanBudgetExhausted = true;
-      throw e;
-    }
-    return execFileSync("gh", args, {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: Math.min(PR_SCAN_CALL_TIMEOUT_MS, remaining),
-      killSignal: "SIGKILL",
-    });
-  };
-  let budgetExhausted = false;
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    if (Date.now() >= deadline) {
-      budgetExhausted = true;
-      break;
-    }
-    try {
-      const ids = new Set();
-      const bigPRs = [];
-      let cursor = null;
-      for (;;) {
-        const args = ["api", "graphql", "-f", `query=${PR_FILES_QUERY}`, "-F", `owner=${owner}`, "-F", `name=${name}`];
-        if (cursor) args.push("-F", `cursor=${cursor}`);
-        const raw = ghBounded(args);
-        const prs = JSON.parse(raw)?.data?.repository?.pullRequests;
-        if (!prs) throw new Error("unexpected GraphQL shape");
-        for (const pr of prs.nodes || []) {
-          for (const f of pr.files?.nodes || []) {
-            const m = (f.path || "").match(ISSUE_ID_RE);
-            if (m) ids.add(Number(m[1]));
-          }
-          if (pr.files?.pageInfo?.hasNextPage) bigPRs.push(pr.number);
-        }
-        if (!prs.pageInfo?.hasNextPage) break;
-        cursor = prs.pageInfo.endCursor;
-      }
-      // >100-file PRs: fetch the full file list via REST pagination.
-      for (const n of bigPRs) {
-        const raw = ghBounded(["api", `repos/${repo}/pulls/${n}/files`, "--paginate", "--jq", ".[].filename"]);
-        for (const p of raw.split("\n")) {
-          const m = p.match(ISSUE_ID_RE);
-          if (m) ids.add(Number(m[1]));
-        }
-      }
-      return { ids, complete: true };
-    } catch (e) {
-      if (e && e.scanBudgetExhausted) {
-        budgetExhausted = true;
-        break;
-      }
-      // Per-call timeout (ETIMEDOUT/SIGKILL) or transient API error: back off
-      // and retry, but never sleep past the overall deadline.
-      const backoff = Math.min(attempt * 1000, Math.max(0, deadline - Date.now()));
-      if (attempt < 3 && backoff > 0) sleepMs(backoff);
-    }
+  const r = openPrIssueIds();
+  if (!r.complete) {
+    console.error(
+      `warning: open-PR id scan ${r.budgetExhausted ? `timed out (>${r.scanTotalTimeoutMs}ms)` : "FAILED after 3 attempts"} ` +
+        "(gh offline/unauthenticated/rate-limited/slow). Allocating against main ∪ reservations ONLY — the id may " +
+        "collide with an in-flight PR's issue file (#2943). The CI gates check-issue-ids --against-main/--against-open-prs remain the backstop.",
+    );
   }
-  console.error(
-    `warning: open-PR id scan ${budgetExhausted ? `timed out (>${PR_SCAN_TOTAL_TIMEOUT_MS}ms)` : "FAILED after 3 attempts"} ` +
-      "(gh offline/unauthenticated/rate-limited/slow). Allocating against main ∪ reservations ONLY — the id may " +
-      "collide with an in-flight PR's issue file (#2943). The CI gate check-issue-ids --against-main remains the hard backstop.",
-  );
-  return { ids: new Set(), complete: false };
+  return r;
 }
 
 function allUsedIds(sha, { scanPRs }) {
@@ -597,6 +511,12 @@ function doAllocate(assignee) {
       reserved_at: nowIso(),
       ...(assignee ? { claimed_at: nowIso() } : {}),
       updated_at: nowIso(),
+      // (#3598 forensics) durable record of the open-PR scan's health AT
+      // allocation time. Collision C could not be root-caused post-hoc because
+      // the degraded-scan signal lived only on stderr; now the reservation
+      // itself says whether the id universe included open PRs ("ok"),
+      // was degraded (scan failed → fail-open), or was skipped (--no-pr-scan).
+      pr_scan: scanPRs ? (degraded ? "degraded" : "ok") : "off",
     };
     const verb = assignee ? `reserve+claim #${id} -> ${assignee}` : `reserve #${id}`;
     const msg = `chore(assign): ${verb} [skip ci]`;

--- a/scripts/lib/open-pr-issue-files.mjs
+++ b/scripts/lib/open-pr-issue-files.mjs
@@ -39,10 +39,31 @@ const PR_FILES_QUERY = `query($owner:String!,$name:String!,$cursor:String){
   repository(owner:$owner,name:$name){
     pullRequests(states:OPEN,first:100,after:$cursor){
       pageInfo{hasNextPage endCursor}
-      nodes{number files(first:100){pageInfo{hasNextPage} nodes{path}}}
+      nodes{number files(first:100){pageInfo{hasNextPage} nodes{path changeType}}}
     }
   }
 }`;
+
+/**
+ * Filter a PR's changed-file nodes (`{ path, changeType }`) down to the
+ * issue-file paths that will EXIST at that PR's head.
+ *
+ * DELETED entries are excluded — this is the #3598 rename-hazard fix, the top
+ * remaining false-positive source: a *detected* rename lists only the new path,
+ * but an UNdetected one (similarity too low) appears as ADDED-new + DELETED-old,
+ * so without this filter a PR that renumbered AWAY from a contested id still
+ * reads as claiming it. Same reasoning covers genuine deletions (a withdrawn
+ * issue file no longer claims its id). Pure — hermetically testable.
+ */
+export function liveIssuePaths(fileNodes) {
+  const hits = [];
+  for (const f of fileNodes || []) {
+    const path = String(f?.path || "").trim();
+    if (!path || f?.changeType === "DELETED") continue;
+    if (ISSUE_ID_RE.test(path)) hits.push(path);
+  }
+  return hits;
+}
 
 /**
  * Scan every OPEN PR for `plan/issues/<id>-<slug>.md` paths.
@@ -86,10 +107,7 @@ export function openPrIssueFiles({ repo = process.env.CLAIM_PR_REPO || "loopdive
         const prs = JSON.parse(raw)?.data?.repository?.pullRequests;
         if (!prs) throw new Error("unexpected GraphQL shape");
         for (const pr of prs.nodes || []) {
-          const hits = [];
-          for (const f of pr.files?.nodes || []) {
-            if (ISSUE_ID_RE.test(f.path || "")) hits.push(f.path);
-          }
+          const hits = liveIssuePaths(pr.files?.nodes);
           if (hits.length) byPr.set(pr.number, hits);
           if (pr.files?.pageInfo?.hasNextPage) bigPRs.push(pr.number);
         }
@@ -98,8 +116,15 @@ export function openPrIssueFiles({ repo = process.env.CLAIM_PR_REPO || "loopdive
       }
       // >100-file PRs: full file list via REST pagination (the GraphQL page
       // truncated, so whatever we collected above for this PR is incomplete).
+      // Same DELETED filter as liveIssuePaths — REST spells it status:"removed".
       for (const n of bigPRs) {
-        const raw = ghBounded(["api", `repos/${repo}/pulls/${n}/files`, "--paginate", "--jq", ".[].filename"]);
+        const raw = ghBounded([
+          "api",
+          `repos/${repo}/pulls/${n}/files`,
+          "--paginate",
+          "--jq",
+          '.[] | select(.status != "removed") | .filename',
+        ]);
         const hits = [];
         for (const p of raw.split("\n")) {
           if (ISSUE_ID_RE.test(p.trim())) hits.push(p.trim());
@@ -131,4 +156,47 @@ export function openPrIssueIds(opts) {
     }
   }
   return { ids, complete, budgetExhausted, scanTotalTimeoutMs: PR_SCAN_TOTAL_TIMEOUT_MS };
+}
+
+/**
+ * Filename-id of an issue-file path: "…/3597-x.md" → "3597", "…/779a-y.md" →
+ * "779a". Sub-issues (779a, 779b, …) are distinct ids by convention (see
+ * check-issue-ids.mjs filenameId) — a sub-issue never collides with its parent.
+ */
+export function issueFileId(path) {
+  const fname = String(path).split("/").pop() || "";
+  return fname.match(/^(\d+[a-z]?)-/i)?.[1]?.toLowerCase() ?? null;
+}
+
+/**
+ * Pure collision verdict for the #3598 PR-level gate (no network — the scan
+ * result is injected, so tests are hermetic).
+ *
+ * @param introduced [{ id, fname }] — issue files this branch ADDS (present at
+ *   HEAD, absent at the merge-base with main). `id` is the filename-id.
+ * @param byPr Map<prNumber, paths[]> — from openPrIssueFiles().
+ * @param selfPr the PR under validation — excluded, or every PR would collide
+ *   with itself.
+ *
+ * A collision is the SAME id under a DIFFERENT filename in ANOTHER open PR.
+ * Same id + same filename is two PRs touching one issue file — a modification,
+ * NOT a collision (an id-only comparison flagged five innocent PRs when this
+ * was first attempted — see #3598 ## Handover).
+ */
+export function findOpenPrCollisions(introduced, byPr, { selfPr = null } = {}) {
+  const collisions = [];
+  for (const [prNumber, paths] of byPr) {
+    if (selfPr != null && Number(prNumber) === Number(selfPr)) continue;
+    for (const p of paths) {
+      const otherId = issueFileId(p);
+      if (!otherId) continue;
+      const otherFname = String(p).split("/").pop();
+      for (const { id, fname } of introduced) {
+        if (String(id).toLowerCase() === otherId && fname !== otherFname) {
+          collisions.push({ id: otherId, fname, prNumber: Number(prNumber), otherPath: p });
+        }
+      }
+    }
+  }
+  return collisions.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10) || a.prNumber - b.prNumber);
 }

--- a/scripts/lib/open-pr-issue-files.mjs
+++ b/scripts/lib/open-pr-issue-files.mjs
@@ -1,0 +1,134 @@
+// Shared open-PR issue-file scan (#3598).
+//
+// Extracted verbatim from `claim-issue.mjs`'s `idsFromOpenPRs` (#2943 hardening)
+// so BOTH consumers share one implementation instead of two drifting copies:
+//
+//   - `claim-issue.mjs --allocate` needs the set of ids in flight, to reserve
+//     an id nothing else has taken.
+//   - `check-issue-ids.mjs --against-open-prs` (#3598) needs the (PR number →
+//     issue-file path) mapping, so a collision can NAME the PR it raced.
+//
+// Returning paths-per-PR serves both: ids are derivable from paths, the reverse
+// is not. That asymmetry is why the shared primitive is the richer one.
+//
+// #2943 hardening, preserved exactly — the original fanned out 1 + N gh calls,
+// making EVERY open PR an independent, silently-swallowed failure point. Under
+// rate-limit/contention a dropped call narrowed the id universe with NO signal
+// (2026-07-02: --allocate returned 2920 while open PR #2424 already added
+// plan/issues/2920-*.md). So:
+//   - ONE batched GraphQL query (100 PRs × 100 files per page, paginated);
+//   - a per-PR REST `--paginate` fallback for the rare >100-file PR
+//     (`gh pr view --json files` silently truncates at 100 — a latent miss);
+//   - 3× retry with backoff, and on total failure `complete: false` so the
+//     caller WARNS LOUDLY instead of proceeding silently.
+// Still fail-OPEN by design (offline/unauthenticated use keeps working), but
+// never fail-SILENT.
+
+import { execFileSync } from "node:child_process";
+
+export const ISSUE_ID_RE = /(?:^|\/)plan\/issues\/(\d+)[a-z]?-[^/]*\.md$/;
+
+const PR_SCAN_CALL_TIMEOUT_MS = Number(process.env.CLAIM_PR_SCAN_CALL_TIMEOUT_MS) || 12000;
+const PR_SCAN_TOTAL_TIMEOUT_MS = Number(process.env.CLAIM_PR_SCAN_TOTAL_TIMEOUT_MS) || 25000;
+
+function sleepMs(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+const PR_FILES_QUERY = `query($owner:String!,$name:String!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequests(states:OPEN,first:100,after:$cursor){
+      pageInfo{hasNextPage endCursor}
+      nodes{number files(first:100){pageInfo{hasNextPage} nodes{path}}}
+    }
+  }
+}`;
+
+/**
+ * Scan every OPEN PR for `plan/issues/<id>-<slug>.md` paths.
+ *
+ * @returns {{ byPr: Map<number, string[]>, complete: boolean }}
+ *   `byPr` maps PR number → the issue-file paths that PR touches.
+ *   `complete: false` means the scan failed/timed out and the result is a
+ *   FLOOR, not the truth — callers must degrade loudly, never silently.
+ */
+export function openPrIssueFiles({ repo = process.env.CLAIM_PR_REPO || "loopdive/js2" } = {}) {
+  const [owner, name] = repo.split("/");
+  const deadline = Date.now() + PR_SCAN_TOTAL_TIMEOUT_MS;
+  const ghBounded = (args) => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const e = new Error("open-PR scan budget exhausted");
+      e.scanBudgetExhausted = true;
+      throw e;
+    }
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: Math.min(PR_SCAN_CALL_TIMEOUT_MS, remaining),
+      killSignal: "SIGKILL",
+    });
+  };
+  let budgetExhausted = false;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    if (Date.now() >= deadline) {
+      budgetExhausted = true;
+      break;
+    }
+    try {
+      const byPr = new Map();
+      const bigPRs = [];
+      let cursor = null;
+      for (;;) {
+        const args = ["api", "graphql", "-f", `query=${PR_FILES_QUERY}`, "-F", `owner=${owner}`, "-F", `name=${name}`];
+        if (cursor) args.push("-F", `cursor=${cursor}`);
+        const raw = ghBounded(args);
+        const prs = JSON.parse(raw)?.data?.repository?.pullRequests;
+        if (!prs) throw new Error("unexpected GraphQL shape");
+        for (const pr of prs.nodes || []) {
+          const hits = [];
+          for (const f of pr.files?.nodes || []) {
+            if (ISSUE_ID_RE.test(f.path || "")) hits.push(f.path);
+          }
+          if (hits.length) byPr.set(pr.number, hits);
+          if (pr.files?.pageInfo?.hasNextPage) bigPRs.push(pr.number);
+        }
+        if (!prs.pageInfo?.hasNextPage) break;
+        cursor = prs.pageInfo.endCursor;
+      }
+      // >100-file PRs: full file list via REST pagination (the GraphQL page
+      // truncated, so whatever we collected above for this PR is incomplete).
+      for (const n of bigPRs) {
+        const raw = ghBounded(["api", `repos/${repo}/pulls/${n}/files`, "--paginate", "--jq", ".[].filename"]);
+        const hits = [];
+        for (const p of raw.split("\n")) {
+          if (ISSUE_ID_RE.test(p.trim())) hits.push(p.trim());
+        }
+        if (hits.length) byPr.set(n, hits);
+        else byPr.delete(n);
+      }
+      return { byPr, complete: true };
+    } catch (e) {
+      if (e && e.scanBudgetExhausted) {
+        budgetExhausted = true;
+        break;
+      }
+      const backoff = Math.min(attempt * 1000, Math.max(0, deadline - Date.now()));
+      if (attempt < 3 && backoff > 0) sleepMs(backoff);
+    }
+  }
+  return { byPr: new Map(), complete: false, budgetExhausted };
+}
+
+/** Ids (numbers) added by currently-open PRs — the `claim-issue.mjs` view. */
+export function openPrIssueIds(opts) {
+  const { byPr, complete, budgetExhausted } = openPrIssueFiles(opts);
+  const ids = new Set();
+  for (const paths of byPr.values()) {
+    for (const p of paths) {
+      const m = p.match(ISSUE_ID_RE);
+      if (m) ids.add(Number(m[1]));
+    }
+  }
+  return { ids, complete, budgetExhausted, scanTotalTimeoutMs: PR_SCAN_TOTAL_TIMEOUT_MS };
+}

--- a/tests/issue-3598-open-pr-id-gate.test.ts
+++ b/tests/issue-3598-open-pr-id-gate.test.ts
@@ -1,0 +1,130 @@
+// #3598 — PR-level issue-id collision gate must see OPEN PRs, not only main.
+//
+// Hermetic tests for the pure decision layer of the gate
+// (scripts/lib/open-pr-issue-files.mjs). The network scan is NOT exercised —
+// its result shape (`byPr: Map<prNumber, paths[]>`) is injected, so these
+// tests replace the live synthetic-collision probe the gate was originally
+// verified with (which added a fake issue file and needed API access; it was
+// deliberately throwaway — see the issue's ## Handover).
+//
+// The three behaviours proven live during the original implementation:
+//   1. different filename, same id, another PR  → COLLISION
+//   2. same filename (both PRs touch one file)  → NOT a collision
+//   3. the PR under validation is self-excluded → never collides with itself
+// plus the top false-positive hazard: a PR whose UNdetected rename lists the
+// old path as DELETED must not read as still claiming the old id.
+
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — plain .mjs module without type declarations
+import { findOpenPrCollisions, issueFileId, liveIssuePaths } from "../scripts/lib/open-pr-issue-files.mjs";
+
+const P = "plan/issues";
+
+describe("#3598 issueFileId", () => {
+  it("extracts the filename id, including sub-issue letter suffixes", () => {
+    expect(issueFileId(`${P}/3597-auto-park-step-aware.md`)).toBe("3597");
+    expect(issueFileId(`${P}/779a-sub-issue.md`)).toBe("779a");
+    expect(issueFileId(`${P}/779B-sub-issue.md`)).toBe("779b"); // case-normalised
+    expect(issueFileId("3597-bare-filename.md")).toBe("3597");
+  });
+
+  it("returns null for non-issue paths", () => {
+    expect(issueFileId(`${P}/backlog.md`)).toBeNull();
+    expect(issueFileId(`${P}/SCHEMA.md`)).toBeNull();
+    expect(issueFileId("src/codegen/index.ts")).toBeNull();
+  });
+});
+
+describe("#3598 findOpenPrCollisions", () => {
+  const introduced3597 = [{ id: "3597", fname: "3597-issue-id-gate.md" }];
+
+  it("flags SAME id under a DIFFERENT filename in another open PR, naming that PR", () => {
+    const byPr = new Map([[3585, [`${P}/3597-auto-park-step-aware.md`]]]);
+    const collisions = findOpenPrCollisions(introduced3597, byPr, { selfPr: 3589 });
+    expect(collisions).toEqual([
+      {
+        id: "3597",
+        fname: "3597-issue-id-gate.md",
+        prNumber: 3585,
+        otherPath: `${P}/3597-auto-park-step-aware.md`,
+      },
+    ]);
+  });
+
+  it("does NOT flag the same filename — two PRs modifying one issue file", () => {
+    // An id-only comparison flagged five innocent PRs when first attempted.
+    const byPr = new Map([[3585, [`${P}/3597-issue-id-gate.md`]]]);
+    expect(findOpenPrCollisions(introduced3597, byPr, { selfPr: 3589 })).toEqual([]);
+  });
+
+  it("self-excludes the PR under validation (never collides with itself)", () => {
+    // The scan sees the PR's own file under a different-slug path — without
+    // self-exclusion every PR that adds an issue file would fail its own gate.
+    const selfOnly = new Map([[3589, [`${P}/3597-completely-different-slug.md`]]]);
+    expect(findOpenPrCollisions(introduced3597, selfOnly, { selfPr: 3589 })).toEqual([]);
+    // string env value for selfPr (GATE_PR_NUMBER) must match the numeric key
+    expect(findOpenPrCollisions(introduced3597, selfOnly, { selfPr: "3589" })).toEqual([]);
+    // …and with no selfPr the same input IS a collision (proves the exclusion did the work)
+    expect(findOpenPrCollisions(introduced3597, selfOnly, {})).toHaveLength(1);
+  });
+
+  it("treats sub-issue ids as distinct — 779a never collides with 779", () => {
+    const introduced = [{ id: "779a", fname: "779a-sub-slice.md" }];
+    const byPr = new Map([[100, [`${P}/779-parent.md`]]]);
+    expect(findOpenPrCollisions(introduced, byPr, { selfPr: 1 })).toEqual([]);
+    // …but 779a vs 779a under different slugs IS a collision
+    const byPr2 = new Map([[100, [`${P}/779a-other-slice.md`]]]);
+    expect(findOpenPrCollisions(introduced, byPr2, { selfPr: 1 })).toHaveLength(1);
+  });
+
+  it("reports every colliding PR, deterministically ordered", () => {
+    const introduced = [
+      { id: "3597", fname: "3597-issue-id-gate.md" },
+      { id: "3584", fname: "3584-mine.md" },
+    ];
+    const byPr = new Map([
+      [3585, [`${P}/3597-auto-park-step-aware.md`]],
+      [3579, [`${P}/3584-theirs.md`]],
+      [3577, [`${P}/3584-also-theirs.md`]],
+    ]);
+    const collisions = findOpenPrCollisions(introduced, byPr, { selfPr: 9999 });
+    expect(collisions.map((c: any) => [c.id, c.prNumber])).toEqual([
+      ["3584", 3577],
+      ["3584", 3579],
+      ["3597", 3585],
+    ]);
+  });
+
+  it("passes cleanly when no open PR touches issue files", () => {
+    expect(findOpenPrCollisions(introduced3597, new Map(), { selfPr: 1 })).toEqual([]);
+  });
+});
+
+describe("#3598 liveIssuePaths (rename hazard)", () => {
+  it("drops DELETED entries — an undetected rename must not claim the old id", () => {
+    // PR renumbers 3584-x.md → 3591-x.md; below GitHub's similarity threshold
+    // the file list shows ADDED-new + DELETED-old. The old id 3584 must NOT
+    // read as claimed by this PR.
+    const nodes = [
+      { path: `${P}/3591-x.md`, changeType: "ADDED" },
+      { path: `${P}/3584-x.md`, changeType: "DELETED" },
+    ];
+    expect(liveIssuePaths(nodes)).toEqual([`${P}/3591-x.md`]);
+  });
+
+  it("keeps ADDED / MODIFIED / RENAMED entries and ignores non-issue paths", () => {
+    const nodes = [
+      { path: `${P}/3600-a.md`, changeType: "ADDED" },
+      { path: `${P}/3601-b.md`, changeType: "MODIFIED" },
+      { path: `${P}/3602-c.md`, changeType: "RENAMED" },
+      { path: "src/codegen/index.ts", changeType: "MODIFIED" },
+      { path: `${P}/backlog.md`, changeType: "MODIFIED" },
+    ];
+    expect(liveIssuePaths(nodes)).toEqual([`${P}/3600-a.md`, `${P}/3601-b.md`, `${P}/3602-c.md`]);
+  });
+
+  it("tolerates missing/odd nodes (defensive against partial GraphQL data)", () => {
+    expect(liveIssuePaths(undefined)).toEqual([]);
+    expect(liveIssuePaths([{}, { path: "" }, { path: null }] as any)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes plan issue #3598 (`plan/issues/3598-issue-id-gate-should-check-open-prs.md`). Builds on the PR-queue shepherd's handover branch (shared scan module + `## Handover` design record).

## What the gate now catches that it didn't

Two open PRs each adding `plan/issues/<id>-*.md` were BOTH green: `check:issue-ids:against-main` only scans `main`, and neither file is on `main` yet. The collision surfaced when the first merged — at best a late red re-check, at worst a `merge_group` auto-park (#2547) whose `hold` label strands the loser (auto-enqueue skips held PRs). Five such collisions in ~3h on 2026-07-24/25; three surfaced only as parks.

New `quality` step (`pull_request` only): `check-issue-ids.mjs --against-open-prs` compares this branch's **introduced** issue files (present at HEAD, absent at the merge-base — same helper `--against-main` now uses) against every **other** open PR's added issue files, and fails loudly at PR level, **naming the PR raced** plus the tie-break and the `--allocate` renumber recipe.

## Design decisions (explicit, per issue)

1. **Fail-OPEN on scan failure (warn, exit 0).** The scan needs network on every gated PR; fail-closed would turn a GitHub blip/rate-limit into a red check on EVERY open PR at once — a merge freeze caused by the gate meant to prevent stalls. Degradation is loud (`⚠ … DEGRADED`), `--against-main` (pure git) stays hard, and the `merge_group` duplicate-id gate remains the hard backstop.
2. **Rate limits / pagination**: one code path with `claim-issue.mjs --allocate` — `scripts/lib/open-pr-issue-files.mjs` (extracted from `idsFromOpenPRs`, preserving the #2943 hardening: single batched GraphQL query paginated 100×100, REST `--paginate` fallback for >100-file PRs, 3× retry, `complete:false` on failure). The gate additionally short-circuits **before any network call** when the branch introduces no issue files (the common case), so the typical PR costs zero API budget.
3. **Renames/renumbers**: the scan now requests `changeType` and filters `DELETED` entries (REST: `status != "removed"`). An undetected rename lists ADDED-new + DELETED-old, so a PR that renumbered AWAY from a contested id no longer reads as still claiming it. Unit-tested.
4. **Self-exclusion** via `GATE_PR_NUMBER` (wired from the workflow event) — a PR never collides with itself.
5. **Same id + same filename ⇒ PASS** (two PRs modifying one issue file); only same id under a **different filename** fails — the id-only first pass had flagged five innocent PRs.
6. **Probe → hermetic tests.** The live synthetic-collision probe was scaffolding (fake issue file, live API) and is not in this PR; `tests/issue-3598-open-pr-id-gate.test.ts` covers the same behaviours with the scan result injected (no network). All four behaviours were ALSO re-verified live on this repo with a throwaway local commit (collision correctly named PR #3590; self-exclusion; same-filename pass; degraded fail-open), dropped before push.

## Collision C root-caused — the allocator was NOT unreliable

The issue's evidence claimed `--allocate` missed an open PR's file. Wrong, subtly: at allocation time (23:27:46Z) PR #3585's head still carried `3590-auto-park-step-aware.md`; the `renumber 3590 -> 3597` commit was authored **23:45:28Z — 18 min later**, hand-picked without `--allocate` (the reservation ref already held 3597). The scan saw exactly what existed; the id materialised later. A live cross-check of the batched scan vs per-PR REST file lists found **zero mismatches**. This strengthens the design thesis: ids appear on branches at arbitrary times, so enforcement belongs at verdict time — this gate. Forensics gap also closed: reservation entries now record `pr_scan: ok|degraded|off` so future collisions can be root-caused post-hoc.

## Stale-head (Collision D): deferred, filed as #3609

A PR-level gate structurally cannot fix the queue validating an older commit than the branch has. Filed `plan/issues/3609-auto-park-stale-head-revalidation.md` against the auto-park bot (re-validate against current head before applying `hold`, or record the judged SHA in the park comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)