### PR TITLE
chore(#3592): re-raise the standalone high-water mark to the measured post-de-vacuification floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Conformance is tracked along the two compile paths — both figures auto-update 
 The line above is the **JS-host path** (default `gc` target): runs alongside the js2wasm JS runtime, which supplies host imports for some built-ins.
 
 <!-- AUTO:conformance-standalone-start -->
-**standalone (host-free) test262 conformance**: 18,400 / 43,106 (42.7 %)
+**standalone (host-free) test262 conformance**: 22,394 / 43,106 (52.0 %)
 <!-- AUTO:conformance-standalone-end -->
 
 The line above is the **standalone path** (`--target standalone`/`wasi`): pure WasmGC with no JS host, measured host-free on the same official denominator. Lower today and actively hardening — this is where the current gap is.

--- a/benchmarks/results/test262-standalone-highwater.json
+++ b/benchmarks/results/test262-standalone-highwater.json
@@ -1,9 +1,9 @@
 {
-  "pass": 19400,
-  "host_free_pass": 19400,
-  "official_pass": 18400,
+  "pass": 22626,
+  "host_free_pass": 22626,
+  "official_pass": 22394,
   "official_total": 43106,
-  "sha": "3592-devacuification-estimate",
-  "generated_at": "2026-07-25T00:00:00Z",
+  "sha": "31139d0a902cf2944fc4f2a412b83901f43f019f",
+  "generated_at": "2026-07-25T09:00:48Z",
   "tolerance": 50
 }


### PR DESCRIPTION
Follow-up to #3601 closing the permissive gap it left in the #2097 absolute floor.

**Why**: the #3601 landing lowered the committed mark to a conservative estimate (19,400; official 18,400) expecting the post-merge `promote-baseline` job to re-raise it from measurement. The merge-commit push took the #3467/#3468 per-SHA-reuse path and the classic `promote merged report to main baseline` job — the only place `check-standalone-highwater --update` runs — was **skipped**. Result: the mark stayed at the estimate while measured reality is higher, leaving a **~3,276-test permissive gap** (floor 19,350 vs measured 22,626) in the compounding-slide backstop. Wrong in the permissive direction, so worth fixing now rather than waiting for the scheduled refresh. (The baseline JSONL itself DID refresh — baselines commit `4cdd23955fa0` — so the #1897 moving gate is correct and the queue is not wedged; this PR deliberately avoids the emergency-refresh lever.)

**Values are the promoted measurement, not an estimate** (`test262-standalone-current.json` generated from merge commit `31139d0a902c`):
- full-corpus `host_free_pass`: **22,626** / 48,088
- official: **22,394 / 43,106 (51.9 %)**

README standalone line re-synced from the mark via `sync:conformance` (18,400/42.7 % estimate → 22,394/52.0 % measured).

Raise-only correction; `tolerance` unchanged at 50. Next promote/refresh `--update` takes over normally from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)