### PR TITLE
fix(#3610): static receiver brand gate for <Builtin>.prototype.<member> in the standalone lane

### DIFF
--- a/plan/issues/3610-standalone-missing-receiver-brand-checks-trap-cluster.md
+++ b/plan/issues/3610-standalone-missing-receiver-brand-checks-trap-cluster.md
@@ -19,6 +19,11 @@ created: 2026-07-25
 loc-budget-allow:
   - src/codegen/property-access.ts
   - src/codegen/expressions/call-receiver-method.ts
+# Same +20: the gate must be the FIRST arm of compileReceiverMethodCall (any
+# later position lets a receiver-name-keyed arm claim the call first), so the
+# registration is necessarily inside this function.
+func-budget-allow:
+  - src/codegen/expressions/call-receiver-method.ts::compileReceiverMethodCall
 ---
 
 ## Problem

--- a/plan/issues/3610-standalone-missing-receiver-brand-checks-trap-cluster.md
+++ b/plan/issues/3610-standalone-missing-receiver-brand-checks-trap-cluster.md
@@ -10,6 +10,15 @@ feasibility: hard
 goal: standalone-gap
 related: [3592, 3596, 3601]
 created: 2026-07-25
+# The gate's BODY lives in the new subsystem module
+# src/codegen/builtin-prototype-brand.ts. What lands in these two files is the
+# dispatch WIRING only (+13 / +20 lines, the majority of it the comment
+# explaining why the new arm must run BEFORE tryBufferViewAttributeReads /
+# before any receiver-name arm can claim the call). Both files ARE the dispatch
+# chains — there is nowhere else a new dispatch step can be registered.
+loc-budget-allow:
+  - src/codegen/property-access.ts
+  - src/codegen/expressions/call-receiver-method.ts
 ---
 
 ## Problem

--- a/plan/issues/3610-standalone-missing-receiver-brand-checks-trap-cluster.md
+++ b/plan/issues/3610-standalone-missing-receiver-brand-checks-trap-cluster.md
@@ -1,7 +1,8 @@
 ---
 id: 3610
 title: "Standalone builtins are missing receiver brand checks — 65-test trap cluster (illegal_cast/null_deref/oob) unmasked by the #3592 de-vacuification"
-status: ready
+status: in-progress
+assignee: ttraenkler/opus-3610
 sprint: current
 priority: high
 horizon: l
@@ -98,3 +99,137 @@ illegal_cast baseline rows).
 - [ ] The 65 cluster tests flip trap → honest fail or pass; the #3189 trap
       categories shrink accordingly.
 - [ ] No `oracle_version` bump needed (codegen change, not verdict logic).
+
+---
+
+## Slice 1 — the STATIC `<Builtin>.prototype.<member>` brand gate (landed)
+
+`src/codegen/builtin-prototype-brand.ts`.
+
+### Root cause (measured, not assumed)
+
+The clusters were assumed to need a *runtime* brand check. Measurement says the
+first and largest slice needs **no runtime check at all** — the receiver is
+statically decidable.
+
+Nearly every native builtin arm keys its receiver off the **TypeScript type
+name** (`objType.getSymbol()?.name` / `ctx.oracle.builtinReceiverOf`). lib.d.ts
+declares `interface DateConstructor { prototype: Date }` and
+`interface Uint8ClampedArrayConstructor { prototype: Uint8ClampedArray }` — so
+`Uint8ClampedArray.prototype` has TS type `Uint8ClampedArray` and
+`Date.prototype` has TS type `Date`. Every such arm therefore treats the
+**prototype object** as an **instance** and emits the instance lowering:
+
+- `src/codegen/property-access-dispatch.ts:1003-1013` (`.buffer`) — an
+  unconditional `ref.cast` of the receiver to the backing view vec →
+  `illegal cast`.
+- same file `:688-723` (`.maxByteLength` / `.resizable`) — `ref.cast` to
+  `$__vec_i32_byte` → `illegal cast`.
+- `src/codegen/expressions/builtins.ts` `compileDateMethodCall` — compiles the
+  receiver at `(ref $Date)`, gets a null, then `struct.get` → `null reference`.
+- `%TypedArray%.prototype.set([])` did not even produce a **valid module**
+  (`array.set[2] expected type …`) — strictly worse than a trap.
+
+`#3062` had already patched exactly two members (`byteLength`/`byteOffset`) by
+nulling out `recvName` for a `.prototype` receiver inline; that one-off is what
+this slice generalises.
+
+### Why STATIC, not a runtime `ref.test`
+
+Every gated member's spec step 1 is `RequireInternalSlot` /
+`ValidateTypedArray` / `thisTimeValue`, and a builtin's `.prototype` is an
+ordinary object that **provably never** carries that slot (§23.2.7, §21.4.4,
+§25.1.5, …). So `<Ctor>.prototype.<member>` is a compile-time-decidable
+unconditional TypeError. Compiling the check away costs nothing on the instance
+hot path, which a blanket `ref.test` in `compileDateMethodCall` would not — and
+that arm is shared with the JS-host lane, so widening it there was the riskier
+design.
+
+The runtime sibling already exists: `receiver-brand.ts`'s
+`emitReceiverBrandCheck` (non-trapping `ref.test` → catchable TypeError),
+used by the reflective closure bodies. The two are complementary — this gate
+covers the syntactic prototype receiver that never reaches a reflective closure.
+
+### Shadow safety
+
+Fires only when the base identifier's own type symbol is the lib
+`<Name>Constructor` interface (`ctx.oracle.declaredNameOf(id) === name + "Constructor"`,
+i.e. `declare var Date: DateConstructor`). A user `class Date {}` types its
+identifier as `typeof Date` (symbol name `Date`) and is never gated — strictly
+tighter than the `getSymbol()?.name` test the surrounding arms use, and
+answered entirely through `ctx.oracle` (no raw-checker growth).
+
+### Lane scope
+
+`noJsHost || strictNoHostImports` only. In JS-host mode these reads/calls
+already route to the host getter and throw a genuine host TypeError; the
+JS-host lane is a separate required gate at 30,405 and is not broken here.
+
+### Measured result
+
+Re-ran all 65 `standalone-devacuification-allow` tests before/after on this
+branch (`runTest262File(..., "standalone")`):
+
+| | before | after |
+| --- | ---: | ---: |
+| trap-category failures (illegal_cast/null_deref/oob) | **65** | **49** |
+| pass | 0 | **14** |
+
+- **14 trap → pass**: 11 `TypedArrayConstructors/*/prototype/not-typedarray-object.js`,
+  `ArrayBuffer/prototype/maxByteLength/invoked-as-accessor.js`,
+  `Date/prototype/no-date-value.js`, `Date/prototype/setFullYear/15.9.5.40_1.js`.
+- **1 trap → honest non-trap fail**: `Date/prototype/toString/non-date-receiver.js`
+  — its first assertion now throws correctly; the remaining
+  `Date.prototype.toString.call(<primitive>)` sub-cases are the reflective path
+  (Slice 2), so the file still fails, but no longer fatally.
+- Direct compile+instantiate probes (independent of the runner's payload
+  renderer) confirm each gated form returns `2` = `e instanceof TypeError` was
+  observably true **inside** the compiled module.
+
+Additional uncatchable traps fixed that the corpus does not currently exercise
+(same defect, verified by probe: all were `illegal cast` before, all are
+catchable TypeErrors now):
+`%TypedArray%.prototype.{fill,slice,subarray,join,set}`,
+`ArrayBuffer.prototype.slice`, `Map.prototype.{get,set}`,
+`Set.prototype.{add,has}`, `WeakMap.prototype.get`.
+
+Negative controls: the full positive-control battery (TypedArray/Date/Map/Set
+instance accessors + methods, reflective `X.prototype.m.call(realInstance)`,
+user-class shadowing) produces **byte-identical output before and after** on
+both `standalone` and `gc` targets.
+
+### Honest scope note — this is NOT most of the 753
+
+Census of the standalone baseline JSONL (461 trap rows at the pre-#3592
+baseline; 753 post-landing) by innermost frame shows the trap population is
+**heterogeneous** and mostly NOT missing receiver brand checks:
+
+| bucket | count | in this lane? |
+| --- | ---: | --- |
+| `illegal cast [in __module_init()]` | 79 | no |
+| `illegal cast [in C_method() ← __module_init]` (class-dstr gen-methods) | 69+19 | no |
+| async continuation `illegal cast` (Promise combinators / for-await dstr) | 111 | no |
+| `illegal cast [in __closure ← __closure ← __call_fn_method_3 ← __apply_closure]` (abrupt-completion payload) | 40 | partly (Slice 3) |
+| `illegal cast [… ← __call_accessor_get ← __extern_get]` (compound-assign poisoned accessor) | 30 | no |
+| `<Ctor>.prototype.<member>` static receiver | 12 baseline + 4 unmasked | **yes — fixed** |
+
+Do not expect a brand-check mechanism to move the other buckets; they need
+their own root-cause work (the class-dstr and async-continuation buckets are
+the two big rocks).
+
+## Remaining work (Slice 2+)
+
+1. **Reflective receivers** — `X.prototype.m.call(<non-instance>)` and
+   `gOPD(X.prototype, p).get.call(<non-instance>)`. Some families already have
+   the runtime check (`receiver-brand.ts`); `Date.prototype.toString.call(0)`
+   does not. ~1 test in the 65.
+2. **`Function.prototype[Symbol.hasInstance]`** (3 tests, null_deref) —
+   OrdinaryHasInstance error paths; not a prototype-receiver shape.
+3. **`Proxy` gOPD / deleteProperty invariant checks** (5 tests, null_deref).
+4. **`Array.prototype.{fill,copyWithin,find,findLast,findLastIndex}`
+   return-abrupt** (11 tests) — the trap is on the *thrown value*, not the
+   receiver; despite the issue's original grouping this is an
+   abrupt-completion-payload defect, not a brand check.
+5. **Non-trap correctness gaps found while measuring** (wrong value, no trap):
+   `RegExp.prototype.exec()`, `Symbol.prototype.{toString,valueOf,description}`
+   on the prototype return a value instead of throwing.

--- a/src/codegen/builtin-prototype-brand.ts
+++ b/src/codegen/builtin-prototype-brand.ts
@@ -1,0 +1,367 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#3610) **Static** receiver brand gate for `<Builtin>.prototype.<member>`.
+ *
+ * ## The defect this closes
+ *
+ * Nearly every native builtin arm under `src/codegen/` discriminates its
+ * receiver by the **TypeScript type name** (`objType.getSymbol()?.name` /
+ * `ctx.oracle.builtinReceiverOf`). For a `<Ctor>.prototype` receiver TypeScript
+ * reports the *instance* type name — `Uint8ClampedArray.prototype` has type
+ * `Uint8ClampedArray`, `Date.prototype` has type `Date` — because lib.d.ts
+ * declares `interface DateConstructor { prototype: Date }`. So the arms treat
+ * the **prototype object** as an **instance** and emit the instance lowering:
+ * an unconditional `ref.cast` to the backing vec/struct (→ uncatchable
+ * `illegal cast`) or a bare `struct.get` on a null receiver (→ uncatchable
+ * `null reference`).
+ *
+ * A trap is strictly worse than a wrong answer: it aborts the whole module and
+ * escapes `try`/`catch`, so `assert.throws(TypeError, …)` can never observe the
+ * TypeError the spec requires.
+ *
+ * ## Why a STATIC gate is the right general mechanism here
+ *
+ * Every member in the tables below begins with `RequireInternalSlot(O, [[…]])`
+ * (or `ValidateTypedArray` / `thisTimeValue`), and a builtin's `.prototype` is
+ * an **ordinary object that provably never carries that slot** (§23.2.7
+ * "The %TypedArray% prototype object … is not a TypedArray instance",
+ * §21.4.4 "The Date prototype object … is not a Date instance", …). So
+ * `<Ctor>.prototype.<member>` is a *compile-time-decidable* unconditional
+ * TypeError. We compile the brand check away (project principle: compile away,
+ * don't emulate) instead of paying a runtime `ref.test` on every instance call.
+ *
+ * The complementary DYNAMIC gate — `ref.test` + catchable TypeError for a
+ * receiver that is only known at runtime not to carry the slot — already
+ * exists as {@link ./receiver-brand.ts}'s `emitReceiverBrandCheck` and is used
+ * by the reflective closure bodies (`gOPD(X.prototype, m).get.call(recv)`).
+ * The two are siblings, not alternatives: this one covers the *syntactic*
+ * prototype receiver that never reaches a reflective closure at all.
+ *
+ * ## Shadow safety
+ *
+ * The gate fires only when the base identifier's own type symbol is the lib
+ * `<Name>Constructor` interface (`declare var Date: DateConstructor`). A
+ * user-declared `class Date {}` types its identifier as `typeof Date` with
+ * symbol name `Date`, so it never matches — the gate cannot hijack a
+ * user-defined class that happens to share a builtin name. This is strictly
+ * tighter than the `getSymbol()?.name` test the surrounding arms use, and it
+ * is answered entirely through `ctx.oracle` (no raw checker use).
+ *
+ * ## Lane scope
+ *
+ * `noJsHost` only (standalone / WASI). In JS-host mode these reads/calls
+ * already route to the host getter, which throws a genuine host TypeError;
+ * re-routing them to a wasm-constructed one would be a behavioural change to a
+ * lane that is not broken. See #3610.
+ */
+import ts from "typescript";
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { emitThrowTypeError, noJsHost } from "./js-errors.js";
+
+/** WasmGC `none` bottom heap type (signed LEB −18) — `ref.null none`, the
+ *  canonical `anyref` null (mirrors receiver-brand.ts / map-runtime.ts). */
+const NONE_HEAP = -18;
+
+const TYPED_ARRAY_CTORS = [
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+] as const;
+
+/**
+ * Accessor getters whose spec step 1–2 is `RequireInternalSlot` — reading one
+ * off the constructor's `.prototype` object throws TypeError unconditionally.
+ *
+ * Deliberately EXCLUDED — these have an explicit spec carve-out that returns a
+ * value instead of throwing when `this` is the prototype, so a gate here would
+ * be a wrong answer:
+ *   - `RegExp.prototype.{source,flags,global,…}` (§22.2.6: `SameValue(R, %RegExp.prototype%)`
+ *     → `"(?:)"` / `""` / `undefined`).
+ *   - `Array.prototype.length` / `String.prototype.length` — own data properties
+ *     of the prototype object itself (0), not brand-checked accessors.
+ */
+const BRANDED_PROTO_GETTERS: ReadonlyMap<string, ReadonlySet<string>> = new Map<string, ReadonlySet<string>>([
+  ...TYPED_ARRAY_CTORS.map(
+    (name) => [name, new Set(["buffer", "byteLength", "byteOffset", "length"])] as [string, ReadonlySet<string>],
+  ),
+  // §25.1.6 — get ArrayBuffer.prototype.{byteLength,maxByteLength,resizable,detached}
+  ["ArrayBuffer", new Set(["byteLength", "maxByteLength", "resizable", "detached"])],
+  // §25.2.5 — get SharedArrayBuffer.prototype.{byteLength,maxByteLength,growable}
+  ["SharedArrayBuffer", new Set(["byteLength", "maxByteLength", "growable"])],
+  // §25.3.4 — get DataView.prototype.{buffer,byteLength,byteOffset}
+  ["DataView", new Set(["buffer", "byteLength", "byteOffset"])],
+]);
+
+/**
+ * §23.2.3 — every `%TypedArray%.prototype` method starts at
+ * `ValidateTypedArray(this)` → `RequireInternalSlot(O, [[TypedArrayName]])`.
+ *
+ * `toString` / `toLocaleString` are EXCLUDED: `%TypedArray%.prototype.toString`
+ * IS `Array.prototype.toString` (§23.2.3.32), a generic function, so gating it
+ * would be gating a member the prototype legitimately shares with Array.
+ * (It still throws — via the `join` it forwards to — just not from here.)
+ */
+const TYPED_ARRAY_PROTO_METHODS: ReadonlySet<string> = new Set([
+  "at",
+  "copyWithin",
+  "entries",
+  "every",
+  "fill",
+  "filter",
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+  "forEach",
+  "includes",
+  "indexOf",
+  "join",
+  "keys",
+  "lastIndexOf",
+  "map",
+  "reduce",
+  "reduceRight",
+  "reverse",
+  "set",
+  "slice",
+  "some",
+  "sort",
+  "subarray",
+  "toReversed",
+  "toSorted",
+  "values",
+  "with",
+]);
+
+/**
+ * §21.4.4 — every `Date.prototype` method starts at `thisTimeValue(this)` (or
+ * `ToObject` + an inherited `valueOf` that does), which throws TypeError when
+ * `this` has no [[DateValue]]. `Date.prototype` provably has none. Mirrors the
+ * `DATE_METHODS` set in `expressions/builtins.ts` (`compileDateMethodCall`),
+ * which is exactly the set that lowers to a `struct.get $Date` on the receiver
+ * — i.e. exactly the set that traps `null reference` today.
+ *
+ * Inherited `Object.prototype` members (`hasOwnProperty`, `isPrototypeOf`, …)
+ * are NOT here: they are generic and must keep working on a prototype object.
+ *
+ * RegExp is absent on purpose: `RegExp.prototype.test()` already throws a
+ * catchable TypeError via the native RegExp lowering, and `RegExp.prototype.exec()`
+ * is claimed by an earlier dispatch arm that this gate never sees (it returns a
+ * wrong value rather than trapping — a correctness gap, not a trap; tracked in
+ * #3610). Its accessors additionally have the §22.2.6 prototype carve-out
+ * (`source` → `"(?:)"`), so the family is not a uniform "always throws" one.
+ */
+const BRANDED_PROTO_METHODS: ReadonlyMap<string, ReadonlySet<string>> = new Map<string, ReadonlySet<string>>([
+  ...TYPED_ARRAY_CTORS.map((name) => [name, TYPED_ARRAY_PROTO_METHODS] as [string, ReadonlySet<string>]),
+  // §25.1.6 / §25.2.5 — RequireInternalSlot([[ArrayBufferData]]).
+  ["ArrayBuffer", new Set(["slice", "resize", "transfer", "transferToFixedLength", "transferToImmutable"])],
+  ["SharedArrayBuffer", new Set(["slice", "grow"])],
+  // §24.1.3 / §24.2.4 — RequireInternalSlot([[MapData]] / [[SetData]]).
+  ["Map", new Set(["get", "set", "has", "delete", "clear", "forEach", "entries", "keys", "values"])],
+  [
+    "Set",
+    new Set([
+      "add",
+      "has",
+      "delete",
+      "clear",
+      "forEach",
+      "entries",
+      "keys",
+      "values",
+      "union",
+      "intersection",
+      "difference",
+      "symmetricDifference",
+      "isSubsetOf",
+      "isSupersetOf",
+      "isDisjointFrom",
+    ]),
+  ],
+  ["WeakMap", new Set(["get", "set", "has", "delete"])],
+  ["WeakSet", new Set(["add", "has", "delete"])],
+  [
+    "Date",
+    new Set([
+      "getTime",
+      "valueOf",
+      "getFullYear",
+      "getMonth",
+      "getDate",
+      "getHours",
+      "getMinutes",
+      "getSeconds",
+      "getMilliseconds",
+      "getDay",
+      "setTime",
+      "setMilliseconds",
+      "setSeconds",
+      "setMinutes",
+      "setHours",
+      "setUTCMilliseconds",
+      "setUTCSeconds",
+      "setUTCMinutes",
+      "setUTCHours",
+      "setDate",
+      "setUTCDate",
+      "setMonth",
+      "setUTCMonth",
+      "setFullYear",
+      "setUTCFullYear",
+      "setYear",
+      "getYear",
+      "getTimezoneOffset",
+      "getUTCFullYear",
+      "getUTCMonth",
+      "getUTCDate",
+      "getUTCHours",
+      "getUTCMinutes",
+      "getUTCSeconds",
+      "getUTCMilliseconds",
+      "getUTCDay",
+      "toISOString",
+      "toJSON",
+      "toString",
+      "toDateString",
+      "toTimeString",
+      "toLocaleDateString",
+      "toLocaleTimeString",
+      "toLocaleString",
+      "toUTCString",
+      "toGMTString",
+    ]),
+  ],
+]);
+
+/**
+ * When `recv` is syntactically `<Id>.prototype` and `<Id>` is the LIB global
+ * constructor of that name, return the constructor name; otherwise undefined.
+ *
+ * The lib-identity test is `declaredNameOf(<Id>) === "<Id>Constructor"` — the
+ * uniform lib.d.ts shape (`declare var Date: DateConstructor`). A user
+ * `class Date {}` gives `declaredNameOf` === `"Date"`, so it is rejected.
+ */
+export function builtinPrototypeReceiver(ctx: CodegenContext, recv: ts.Expression): string | undefined {
+  if (!ts.isPropertyAccessExpression(recv) || recv.name.text !== "prototype") return undefined;
+  const base = recv.expression;
+  if (!ts.isIdentifier(base)) return undefined;
+  const name = base.text;
+  return ctx.oracle.declaredNameOf(base) === `${name}Constructor` ? name : undefined;
+}
+
+/**
+ * Emit the unconditional catchable TypeError plus a typed, unreachable sentinel
+ * so the surrounding expression keeps its static ValType and the stack stays
+ * well-typed (`throw` is stack-polymorphic, but the emitters downstream of a
+ * property read still reason about a concrete result type).
+ */
+function emitBrandThrowWithSentinel(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  message: string,
+  result: ValType,
+): ValType {
+  emitThrowTypeError(ctx, fctx, message);
+  for (const instr of sentinelInstrs(result)) fctx.body.push(instr);
+  return result;
+}
+
+/** A zero/null value of `t`, emitted after the (terminal) throw purely to keep
+ *  the surrounding expression's static ValType and the stack well-typed. */
+function sentinelInstrs(t: ValType): Instr[] {
+  switch (t.kind) {
+    case "i32":
+      return [{ op: "i32.const", value: 0 }];
+    case "i64":
+      return [{ op: "i64.const", value: 0n }];
+    case "f64":
+      return [{ op: "f64.const", value: 0 }];
+    case "externref":
+      return [{ op: "ref.null.extern" }];
+    case "funcref":
+      return [{ op: "ref.null.func" }];
+    case "anyref":
+      return [{ op: "ref.null", typeIdx: NONE_HEAP }];
+    case "ref":
+      return [{ op: "ref.null", typeIdx: t.typeIdx }, { op: "ref.as_non_null" }];
+    case "ref_null":
+      return [{ op: "ref.null", typeIdx: t.typeIdx }];
+    default:
+      return [{ op: "f64.const", value: 0 }];
+  }
+}
+
+/**
+ * Property-read arm: `<Builtin>.prototype.<brandedGetter>`.
+ *
+ * Returns the result ValType when the gate fired (a TypeError throw was
+ * emitted), or `undefined` to fall through to the normal dispatch chain.
+ *
+ * The receiver is NOT compiled: it is syntactically an identifier plus a
+ * `.prototype` read, which is observably side-effect-free, so skipping it
+ * preserves evaluation order.
+ */
+export function tryBuiltinPrototypeGetterBrandThrow(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+  propName: string,
+): ValType | undefined {
+  if (!noJsHost(ctx) && !ctx.strictNoHostImports) return undefined;
+  const ctor = builtinPrototypeReceiver(ctx, expr.expression);
+  if (ctor === undefined) return undefined;
+  if (BRANDED_PROTO_GETTERS.get(ctor)?.has(propName) !== true) return undefined;
+  const result: ValType = propName === "buffer" ? { kind: "externref" } : ctx.fast ? { kind: "i32" } : { kind: "f64" };
+  return emitBrandThrowWithSentinel(
+    ctx,
+    fctx,
+    `TypeError: Method get ${ctor}.prototype.${propName} called on incompatible receiver ${ctor}.prototype`,
+    result,
+  );
+}
+
+/**
+ * Method-call arm: `<Builtin>.prototype.<brandedMethod>(...args)`.
+ *
+ * Arguments ARE compiled (and dropped): per §13.3.6.1 EvaluateCall runs
+ * ArgumentListEvaluation BEFORE Call(), so `Date.prototype.setFullYear(f())`
+ * must still observe `f()`'s side effects before the TypeError.
+ *
+ * `compileArg` is injected to avoid a module cycle with `expressions.ts`.
+ */
+export function tryBuiltinPrototypeMethodBrandThrow(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  compileArg: (arg: ts.Expression) => ValType | null,
+  expectedType?: ValType,
+): ValType | undefined {
+  if (!noJsHost(ctx) && !ctx.strictNoHostImports) return undefined;
+  const ctor = builtinPrototypeReceiver(ctx, propAccess.expression);
+  if (ctor === undefined) return undefined;
+  const method = propAccess.name.text;
+  if (BRANDED_PROTO_METHODS.get(ctor)?.has(method) !== true) return undefined;
+  for (const arg of expr.arguments) {
+    const t = compileArg(arg);
+    if (t !== null) fctx.body.push({ op: "drop" });
+  }
+  // Honour the contextual type when the caller has one: these methods return
+  // arrays / views / iterators, and handing back an f64 where a `(ref $vec)`
+  // was requested would force a coercion the (dead) sentinel cannot satisfy.
+  return emitBrandThrowWithSentinel(
+    ctx,
+    fctx,
+    `TypeError: Method ${ctor}.prototype.${method} called on incompatible receiver ${ctor}.prototype`,
+    expectedType ?? (ctx.fast ? { kind: "i32" } : { kind: "f64" }),
+  );
+}

--- a/src/codegen/expressions/call-receiver-method.ts
+++ b/src/codegen/expressions/call-receiver-method.ts
@@ -77,6 +77,7 @@ import {
 } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
 import { brandExternMethodResult, coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
+import { tryBuiltinPrototypeMethodBrandThrow } from "../builtin-prototype-brand.js";
 import { emitSetExtrasArgv, maybeSetArgcForKnownCall } from "../statements/nested-declarations.js";
 import {
   compileGuardedNativeStringMethodCall,
@@ -286,6 +287,25 @@ export function compileReceiverMethodCall(
   propAccess: ts.PropertyAccessExpression,
   expectedType?: ValType,
 ): InnerResult | undefined {
+  // (#3610) `<Builtin>.prototype.<brandedMethod>(...)` — e.g.
+  // `Date.prototype.getTime()`. The prototype object carries no [[DateValue]],
+  // so `thisTimeValue` throws TypeError (§21.4.4). Without this gate the
+  // receiver compiles to a null `$Date` ref (TS types `Date.prototype` as
+  // `Date`, so `compileDateMethodCall` engages) and the following `struct.get`
+  // traps UNCATCHABLY on a null reference. Runs first so no downstream arm can
+  // claim the call.
+  {
+    const __r = tryBuiltinPrototypeMethodBrandThrow(
+      ctx,
+      fctx,
+      expr,
+      propAccess,
+      (arg) => compileExpression(ctx, fctx, arg),
+      expectedType,
+    );
+    if (__r !== undefined) return __r;
+  }
+
   // Check if receiver is an externref object
   let receiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
   // (#2767) When the static type resolves NO nominal symbol and the receiver

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -197,6 +197,7 @@ export {
   TYPED_ARRAY_BYTES_PER_ELEMENT,
   tryEnsureNativeProtoBrand,
 } from "./builtin-value-read.js";
+import { tryBuiltinPrototypeGetterBrandThrow } from "./builtin-prototype-brand.js";
 import {
   finalizeStructAndDynamicMemberGet,
   PA_FALLTHROUGH,
@@ -2822,6 +2823,18 @@ export function compilePropertyAccess(
   {
     const __r = tryBuiltinNamespaceDeferredReads(ctx, fctx, expr, propName, objType);
     if (__r !== PA_FALLTHROUGH) return __r;
+  }
+
+  // (#3610) `<Builtin>.prototype.<brandedGetter>` — the prototype object never
+  // carries the [[ViewedArrayBuffer]] / [[ArrayBufferData]] / [[DataView]]
+  // internal slot the getter requires, so the spec's step-1 RequireInternalSlot
+  // throws unconditionally. Must run BEFORE `tryBufferViewAttributeReads`, whose
+  // arms key on the TS type NAME (`Uint8Array.prototype` has type `Uint8Array`)
+  // and would `ref.cast` the prototype object to the backing vec — an
+  // UNCATCHABLE `illegal cast` trap where a catchable TypeError is required.
+  {
+    const __r = tryBuiltinPrototypeGetterBrandThrow(ctx, fctx, expr, propName);
+    if (__r !== undefined) return __r;
   }
 
   {

--- a/tests/issue-3610-standalone-prototype-receiver-brand.test.ts
+++ b/tests/issue-3610-standalone-prototype-receiver-brand.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3610 — standalone builtins were missing the receiver brand check on a
+// `<Builtin>.prototype.<member>` receiver.
+//
+// TypeScript types `Uint8ClampedArray.prototype` as `Uint8ClampedArray` and
+// `Date.prototype` as `Date` (lib.d.ts declares `interface DateConstructor {
+// prototype: Date }`), so every native arm that discriminates by receiver TYPE
+// NAME treated the PROTOTYPE OBJECT as an INSTANCE and emitted the instance
+// lowering — an unconditional `ref.cast` to the backing vec (uncatchable
+// `illegal cast` trap) or a `struct.get` on a null `$Date` (uncatchable
+// `null reference` trap). `%TypedArray%.prototype.set([])` did not even produce
+// a valid module.
+//
+// The spec requires a CATCHABLE TypeError there (RequireInternalSlot /
+// ValidateTypedArray / thisTimeValue). A trap aborts the module and escapes
+// `try`/`catch`, so `assert.throws(TypeError, …)` can never observe it.
+//
+// Every assertion below checks an OBSERVABLE VALUE returned from the compiled
+// module: `2` means the module itself caught the throw and `e instanceof
+// TypeError` was true inside Wasm. "It compiles" is never asserted.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const io = r.importObject as WebAssembly.Imports & { __setExports?: (e: Record<string, unknown>) => void };
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports as Record<string, unknown>);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+/** 1 = no throw (wrong), 2 = caught a TypeError (spec), 3 = caught something else. */
+const guarded = (body: string) =>
+  `export function test() { try { ${body} return 1; } catch (e) { return e instanceof TypeError ? 2 : 3; } }`;
+
+const TYPED_ARRAYS = ["Int8Array", "Uint8Array", "Uint8ClampedArray", "Int32Array", "Float64Array"] as const;
+
+describe("#3610 TypedArray prototype accessors throw a catchable TypeError (were: illegal_cast trap)", () => {
+  for (const ta of TYPED_ARRAYS) {
+    for (const prop of ["buffer", "byteLength", "byteOffset", "length"] as const) {
+      it(`${ta}.prototype.${prop}`, async () => {
+        expect(await runStandalone(guarded(`${ta}.prototype.${prop};`))).toBe(2);
+      });
+    }
+  }
+});
+
+describe("#3610 buffer-family prototype accessors throw a catchable TypeError", () => {
+  const cases: Array<[string, string]> = [
+    ["ArrayBuffer.prototype.byteLength", "ArrayBuffer.prototype.byteLength;"],
+    ["ArrayBuffer.prototype.maxByteLength", "ArrayBuffer.prototype.maxByteLength;"],
+    ["ArrayBuffer.prototype.resizable", "ArrayBuffer.prototype.resizable;"],
+    ["DataView.prototype.buffer", "DataView.prototype.buffer;"],
+    ["DataView.prototype.byteLength", "DataView.prototype.byteLength;"],
+    ["DataView.prototype.byteOffset", "DataView.prototype.byteOffset;"],
+  ];
+  for (const [name, body] of cases) {
+    it(name, async () => {
+      expect(await runStandalone(guarded(body))).toBe(2);
+    });
+  }
+});
+
+describe("#3610 Date.prototype methods throw a catchable TypeError (were: null_deref trap)", () => {
+  const methods = ["getTime", "valueOf", "getFullYear", "toString", "toISOString", "getTimezoneOffset"] as const;
+  for (const m of methods) {
+    it(`Date.prototype.${m}()`, async () => {
+      expect(await runStandalone(guarded(`Date.prototype.${m}();`))).toBe(2);
+    });
+  }
+  it("Date.prototype.setFullYear(2012)", async () => {
+    expect(await runStandalone(guarded("Date.prototype.setFullYear(2012);"))).toBe(2);
+  });
+  it("evaluates arguments before throwing (§13.3.6.1 ArgumentListEvaluation)", async () => {
+    // The spec runs ArgumentListEvaluation BEFORE Call(), so the side effect
+    // must be observable even though the call itself throws.
+    const src = `let seen = 0;
+      function arg() { seen = 5; return 2012; }
+      export function test() {
+        try { Date.prototype.setFullYear(arg()); } catch (e) { return seen; }
+        return -1;
+      }`;
+    expect(await runStandalone(src)).toBe(5);
+  });
+});
+
+describe("#3610 collection / view prototype methods throw a catchable TypeError", () => {
+  const cases: Array<[string, string]> = [
+    ["Uint8Array.prototype.fill(0)", "Uint8Array.prototype.fill(0);"],
+    ["Uint8Array.prototype.slice()", "Uint8Array.prototype.slice();"],
+    ["Uint8Array.prototype.subarray()", "Uint8Array.prototype.subarray();"],
+    ["Uint8Array.prototype.join()", "Uint8Array.prototype.join();"],
+    // Produced an INVALID module before the gate (array.set type mismatch),
+    // which is strictly worse than a trap.
+    ["Uint8Array.prototype.set([])", "Uint8Array.prototype.set([]);"],
+    ["ArrayBuffer.prototype.slice(0)", "ArrayBuffer.prototype.slice(0);"],
+    ["Map.prototype.get(1)", "Map.prototype.get(1);"],
+    ["Map.prototype.set(1, 2)", "Map.prototype.set(1, 2);"],
+    ["Set.prototype.add(1)", "Set.prototype.add(1);"],
+    ["Set.prototype.has(1)", "Set.prototype.has(1);"],
+    ["WeakMap.prototype.get({})", "WeakMap.prototype.get({});"],
+  ];
+  for (const [name, body] of cases) {
+    it(name, async () => {
+      expect(await runStandalone(guarded(body))).toBe(2);
+    });
+  }
+});
+
+describe("#3610 the gate does not over-throw", () => {
+  it("real TypedArray instances keep their accessors", async () => {
+    expect(
+      await runStandalone(`export function test() { const a = new Uint8Array(4); return a.byteLength + a.length; }`),
+    ).toBe(8);
+  });
+  it("real TypedArray instances keep their methods", async () => {
+    expect(
+      await runStandalone(
+        `export function test() { const a = new Uint8Array([1,2,3]); a.fill(7); return a.slice(1).length + a[0]; }`,
+      ),
+    ).toBe(9);
+  });
+  it("real Date instances keep their methods", async () => {
+    expect(await runStandalone(`export function test() { const d = new Date(1234); return d.getTime(); }`)).toBe(1234);
+  });
+  it("real Set instances keep their methods", async () => {
+    expect(
+      await runStandalone(`export function test() { const s = new Set(); s.add(3); return s.has(3) ? 1 : 0; }`),
+    ).toBe(1);
+  });
+  it("a reflective `.call` on a real instance is NOT gated", async () => {
+    // The CALL's receiver here is `Uint8Array.prototype.join`, not
+    // `Uint8Array.prototype`, so the static gate must not claim it. Asserted as
+    // "does not throw a TypeError" (1), not on the returned string: the
+    // standalone reflective-`.call` return path is a separate pre-existing gap
+    // (it yields a non-primitive here) and is deliberately not this test's
+    // subject — what matters is that the gate stays out of the way.
+    expect(
+      await runStandalone(guarded(`const a = new Uint8Array([1,2]); (Uint8Array.prototype.join as any).call(a, "-");`)),
+    ).toBe(1);
+  });
+  it("a user class shadowing a builtin name is NOT gated", async () => {
+    // The gate keys on the LIB identity of the base identifier
+    // (`declare var Date: DateConstructor`); a user `class Date` types its
+    // identifier as `typeof Date`, so the gate must skip it.
+    expect(
+      await runStandalone(
+        `class Date { m() { return 7; } }
+         export function test() { const d = new Date(); return d.m(); }`,
+      ),
+    ).toBe(7);
+  });
+});


### PR DESCRIPTION
Closes the first and largest slice of #3610 — the uncatchable-trap cluster on standalone builtin prototype receivers.

## The defect

`Uint8ClampedArray.prototype.buffer` and `Date.prototype.getTime()` die with an **uncatchable** `illegal cast` / `null reference` trap where the spec requires a **catchable** `TypeError`. A trap aborts the whole module and escapes `try`/`catch`, so `assert.throws(TypeError, …)` can never observe it. `%TypedArray%.prototype.set([])` did not even produce a *valid module*.

## Root cause

lib.d.ts declares `interface DateConstructor { prototype: Date }`, so TypeScript types `Date.prototype` as `Date` and `Uint8ClampedArray.prototype` as `Uint8ClampedArray`. Every native arm that discriminates its receiver by **type name** (`objType.getSymbol()?.name`) therefore treats the **prototype object** as an **instance** and emits the instance lowering:

- `property-access-dispatch.ts:1003-1013` (`.buffer`) — unconditional `ref.cast` to the backing view vec → `illegal cast`
- same file `:688-723` (`.maxByteLength` / `.resizable`) — `ref.cast` to `$__vec_i32_byte` → `illegal cast`
- `expressions/builtins.ts` `compileDateMethodCall` — receiver compiles to a null `(ref $Date)`, then `struct.get` → `null reference`

`#3062` had already patched exactly two members (`byteLength`/`byteOffset`) inline; this generalises that one-off.

## The shared mechanism — one gate, not 65 patches

`src/codegen/builtin-prototype-brand.ts`. Every gated member's spec step 1 is `RequireInternalSlot` / `ValidateTypedArray` / `thisTimeValue`, and a builtin's `.prototype` **provably never** carries that slot (§23.2.7, §21.4.4, §25.1.5). So the TypeError is **compile-time-decidable** — the brand check compiles away and costs nothing on the instance hot path, which a blanket runtime `ref.test` in the shared `compileDateMethodCall` would not.

The runtime sibling already exists (`receiver-brand.ts`'s `emitReceiverBrandCheck`, used by the reflective closure bodies). The two are complementary: this one covers the syntactic prototype receiver that never reaches a reflective closure.

Arguments are still compiled and dropped — §13.3.6.1 runs `ArgumentListEvaluation` **before** `Call()`, so `Date.prototype.setFullYear(f())` must still observe `f()`.

**Shadow-safe.** Fires only when the base identifier's own type symbol is the lib `<Name>Constructor` interface (`declare var Date: DateConstructor`). A user `class Date {}` types its identifier as `typeof Date` and is never gated — strictly tighter than the `getSymbol()?.name` test the surrounding arms use, and answered entirely through `ctx.oracle` (oracle-ratchet: +0/+0).

**Lane scope:** `noJsHost || strictNoHostImports` only. The JS-host lane routes these to the host getter already and is untouched.

## Measured result

All 65 `standalone-devacuification-allow` tests, before/after on this branch:

| | before | after |
| --- | ---: | ---: |
| trap-category failures (illegal_cast/null_deref/oob) | **65** | **49** |
| pass | 0 | **14** |

14 trap → pass: 11 `TypedArrayConstructors/*/prototype/not-typedarray-object.js`, `ArrayBuffer/prototype/maxByteLength/invoked-as-accessor.js`, `Date/prototype/no-date-value.js`, `Date/prototype/setFullYear/15.9.5.40_1.js`. One more (`Date/prototype/toString/non-date-receiver.js`) goes trap → honest non-trap fail.

Also converts these same-defect uncatchable traps that the corpus does not currently exercise: `%TypedArray%.prototype.{fill,slice,subarray,join,set}`, `ArrayBuffer.prototype.slice`, `Map.prototype.{get,set}`, `Set.prototype.{add,has}`, `WeakMap.prototype.get`.

**Honest scope note:** this is *not* most of the 753-trap population. A census by innermost frame shows that population is dominated by class-dstr generator methods (~88), async continuations in Promise combinators / for-await destructuring (~111), and `__module_init` casts (~79) — none of which are receiver-brand defects. Remaining slices are enumerated in the issue file.

## Verification

- `tests/issue-3610-standalone-prototype-receiver-brand.test.ts` — 51 assertions, all on **observable values** returned from the compiled module (`2` ⇔ `e instanceof TypeError` was true *inside* Wasm). Never "it compiles".
- Positive-control battery (instance accessors + methods for TypedArray/Date/Map/Set/ArrayBuffer/DataView, reflective `X.prototype.m.call(realInstance)`, user-class shadowing) produces **byte-identical output before and after** on both `standalone` and `gc` targets — measured by reverting only the wiring and re-running.
- No `oracle_version` bump (codegen change, not verdict logic).

Budget allowances (`loc-budget-allow` / `func-budget-allow`) are granted in the issue frontmatter for the two dispatch-chain wiring sites only; the gate body lives in the new subsystem module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)