### PR TITLE
fix(#3614): standalone Test262Error instance .constructor identity (854-test cluster)

### DIFF
--- a/plan/agent-context/opus-assertfail-triage.md
+++ b/plan/agent-context/opus-assertfail-triage.md
@@ -6,11 +6,11 @@ Everything below is measured, not inferred.
 
 ## 1. Data used
 
-| Artifact                                                                                                  | What it is                          |
-| --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/standalone-baseline.jsonl`                     | PRE-#3592 standalone (27,709 pass)  |
+| Artifact                                                                                                   | What it is                          |
+| ---------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/standalone-baseline.jsonl`                      | PRE-#3592 standalone (27,709 pass)  |
 | `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/mg3601/test262-standalone-results-merged.jsonl` | POST-#3592 standalone (22,621 pass) |
-| `/workspace/.claude/worktrees/agent-a9035bbe084665a85/.tmp/flipped.jsonl`                                 | the 5,114 `pass`→`fail` flips        |
+| `/workspace/.claude/worktrees/agent-a9035bbe084665a85/.tmp/flipped.jsonl`                                  | the 5,114 `pass`→`fail` flips       |
 
 Status deltas across the two: `pass` 27,709 → 22,621 · `fail` 13,236 → 18,325 ·
 `compile_error` 7,003 → 7,002. **5,114 tests flipped `pass`→`fail`** — that is
@@ -23,22 +23,22 @@ By `error_category`: `assertion_fail` 4,496 · `other` 371 · `type_error` 179 �
 
 By normalised message (top clusters):
 
-|     Count | Normalised message                                                                 |
-| --------: | ------------------------------------------------------------------------------------ |
-|       938 | `Expected a TypeError to be thrown but no exception was thrown at all`             |
-| **924**   | **`Expected a undefined but got a different error constructor with the same name`** |
-|       386 | `Expected a undefined to be thrown but no exception was thrown at all`             |
-|       222 | `Expected SameValue(«"S"», «"S"») to be true`                                       |
-|       213 | `Expected a RangeError to be thrown but no exception was thrown at all`            |
-|       181 | `Expected SameValue(«N», «N») to be true`                                           |
-|       166 | `Expected a SyntaxError to be thrown but no exception was thrown at all`           |
-|       162 | `Expected SameValue(«undefined», «N») to be true`                                   |
-|       134 | `Expected SameValue(«null», «[object Object]») to be true`                          |
-|       131 | `Expected SameValue(«undefined», «"S"») to be true`                                 |
-|       107 | `Expected SameValue(«NaN», «undefined») to be true`                                 |
-|       104 | `TypeError: Cannot access property on null or undefined`                           |
-|       101 | `Expected a ReferenceError to be thrown but no exception was thrown at all`        |
-|        75 | `Array.prototype.map is not yet callable as a value in --target standalone`        |
+|   Count | Normalised message                                                                  |
+| ------: | ----------------------------------------------------------------------------------- |
+|     938 | `Expected a TypeError to be thrown but no exception was thrown at all`              |
+| **924** | **`Expected a undefined but got a different error constructor with the same name`** |
+|     386 | `Expected a undefined to be thrown but no exception was thrown at all`              |
+|     222 | `Expected SameValue(«"S"», «"S"») to be true`                                       |
+|     213 | `Expected a RangeError to be thrown but no exception was thrown at all`             |
+|     181 | `Expected SameValue(«N», «N») to be true`                                           |
+|     166 | `Expected a SyntaxError to be thrown but no exception was thrown at all`            |
+|     162 | `Expected SameValue(«undefined», «N») to be true`                                   |
+|     134 | `Expected SameValue(«null», «[object Object]») to be true`                          |
+|     131 | `Expected SameValue(«undefined», «"S"») to be true`                                 |
+|     107 | `Expected SameValue(«NaN», «undefined») to be true`                                 |
+|     104 | `TypeError: Cannot access property on null or undefined`                            |
+|     101 | `Expected a ReferenceError to be thrown but no exception was thrown at all`         |
+|      75 | `Array.prototype.map is not yet callable as a value in --target standalone`         |
 
 The `…to be thrown but no exception was thrown at all` family (938 + 386 + 213 +
 166 + 101 ≈ 1,804) is **heterogeneous** — each is a separate missing-throw

--- a/plan/agent-context/opus-assertfail-triage.md
+++ b/plan/agent-context/opus-assertfail-triage.md
@@ -1,0 +1,136 @@
+# opus-sa-assertfail — standalone `assertion_fail` triage (paused 2026-07-25)
+
+Lane: standalone `assertion_fail` bucket (12,038) after the #3592
+de-vacuification. **Paused mid-flight by the lead (box oversubscribed).**
+Everything below is measured, not inferred.
+
+## 1. Data used
+
+| Artifact                                                                                                  | What it is                          |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/standalone-baseline.jsonl`                     | PRE-#3592 standalone (27,709 pass)  |
+| `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/mg3601/test262-standalone-results-merged.jsonl` | POST-#3592 standalone (22,621 pass) |
+| `/workspace/.claude/worktrees/agent-a9035bbe084665a85/.tmp/flipped.jsonl`                                 | the 5,114 `pass`→`fail` flips        |
+
+Status deltas across the two: `pass` 27,709 → 22,621 · `fail` 13,236 → 18,325 ·
+`compile_error` 7,003 → 7,002. **5,114 tests flipped `pass`→`fail`** — that is
+the de-vacuification yield and the whole prioritised subset.
+
+## 2. Taxonomy of the 5,114 newly-revealed failures
+
+By `error_category`: `assertion_fail` 4,496 · `other` 371 · `type_error` 179 ·
+`illegal_cast` 43 · `null_deref` 21 · `range_error` 3 · `oob` 1.
+
+By normalised message (top clusters):
+
+|     Count | Normalised message                                                                 |
+| --------: | ------------------------------------------------------------------------------------ |
+|       938 | `Expected a TypeError to be thrown but no exception was thrown at all`             |
+| **924**   | **`Expected a undefined but got a different error constructor with the same name`** |
+|       386 | `Expected a undefined to be thrown but no exception was thrown at all`             |
+|       222 | `Expected SameValue(«"S"», «"S"») to be true`                                       |
+|       213 | `Expected a RangeError to be thrown but no exception was thrown at all`            |
+|       181 | `Expected SameValue(«N», «N») to be true`                                           |
+|       166 | `Expected a SyntaxError to be thrown but no exception was thrown at all`           |
+|       162 | `Expected SameValue(«undefined», «N») to be true`                                   |
+|       134 | `Expected SameValue(«null», «[object Object]») to be true`                          |
+|       131 | `Expected SameValue(«undefined», «"S"») to be true`                                 |
+|       107 | `Expected SameValue(«NaN», «undefined») to be true`                                 |
+|       104 | `TypeError: Cannot access property on null or undefined`                           |
+|       101 | `Expected a ReferenceError to be thrown but no exception was thrown at all`        |
+|        75 | `Array.prototype.map is not yet callable as a value in --target standalone`        |
+
+The `…to be thrown but no exception was thrown at all` family (938 + 386 + 213 +
+166 + 101 ≈ 1,804) is **heterogeneous** — each is a separate missing-throw
+semantic gap. Not a single-fix cluster.
+
+## 3. ROOT CAUSE FOUND + FIXED (the 924 cluster) — see #3614
+
+Split of the 924 by the constructor passed to `assert.throws`:
+**854 `Test262Error`**, 33 `DummyError+TypeError`, 14 `DummyError`, 9
+`ExpectedError`, 5 `MyError`, 5 `Test262Error+TypeError`, 3 `CustomError`,
+1 `StopReverse`.
+
+Upstream `harness/assert.js` runs `thrown.constructor !== expectedErrorConstructor`
+for **every** caught value. Measured in standalone (probe below):
+
+- `thrown.constructor` on a `new Test262Error(...)` value → **`undefined`**
+- `expectedErrorConstructor.name` (read off a **parameter**) → **`undefined`**
+  → both names compare equal → the "same name" branch → that exact message.
+- `Test262Error === Test262Error` and identity **through a parameter** → already
+  TRUE (the cached closure singleton), so only the back-pointer was missing.
+
+Why: `emitStandaloneTest262Error` (#2902) lowers `new Test262Error(msg)` to an
+`$Error_struct` with `$name = "Test262Error"`. `fillExternGetErrorProps`
+(`src/codegen/registry/error-types.ts`) answers `.constructor` only for genuine
+builtin errors — its `Error`-tag arm is explicitly `$name === "Error"`-guarded,
+so Test262Error fell through to the miss.
+
+**Fix (implemented, branch `issue-3614-standalone-test262error-ctor-identity`):**
+in `fillExternGetErrorProps`, add a `userCtorArms` block ahead of the builtin
+`ctorArms` that, when `$name` matches a `USER_ERROR_CTOR_IDENTITY_NAMES` entry
+(today just `Test262Error`), returns `ctx.funcClosureGlobals.get(name)` — the
+SAME `__fn_closure_<Name>` global the bare identifier resolves to, so `===`
+holds by `ref.eq`. It only **reads** the global (never materialises it), which
+avoids minting a `ref.func` trampoline at finalize — the late-funcidx-shift
+hazard this file already documents.
+
+**Measured, via the CI-equivalent pool path:** probe `.tmp/probes/ctor2.js`
+BITS `231 → 245` — bit 2 (`thrown.constructor === undefined`) cleared, bit 16
+(`thrown.constructor === expected`) set. `tsc --noEmit` clean.
+
+## 4. How to reproduce locally (this cost ~1h to discover — do not redo it)
+
+`runTest262File` (`tests/test262-runner.ts`) is **NOT** the CI path and gives
+misleading results: it renders thrown payloads via `originalHarnessThrownText`,
+which does not use `tryNativeExnRender`, so every standalone Test262Error shows
+as `uncaught Wasm-GC exception (non-stringifiable payload)` instead of its real
+message. The CI shard path is
+`assembleOriginalHarness` → `CompilerPool(n, "unified")` → `scripts/test262-worker.mjs`.
+
+Working reproduction harness: `.tmp/run-pool.mts` in worktree
+`/workspace/.claude/worktrees/agent-a9035bbe084665a85`. Prerequisites (the
+worker imports two generated bundles that are not in the tree):
+
+```
+npx esbuild scripts/compiler-bundle-entry.ts --bundle --platform=node --format=esm \
+  --outfile=scripts/compiler-bundle.mjs --external:typescript --external:binaryen \
+  --external:@typescript/native-preview '--external:@typescript/native-preview/*'
+npx esbuild src/runtime.ts --bundle --platform=node --format=esm \
+  --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen
+```
+
+Probe idiom: a `.js` file with a test262 frontmatter block that accumulates
+`bits` and ends with `throw new Test262Error("BITS=" + bits)` — the thrown
+message is what the runner records, so it is the only reliable output channel.
+Probes live in `.tmp/probes/`.
+
+Note: the standalone lane is ALWAYS `oracle_lane: "honest"`; the #3461 fast
+native-harness oracle is host-lane-only, so it is not a factor here.
+
+## 5. Remaining work in this lane (not started)
+
+1. Land #3614 and measure the real delta on a full standalone shard run.
+2. `expectedErrorConstructor.name` on a compiled closure read **through a
+   parameter** is still `undefined` (a static `Test262Error.name` read works).
+   This is the standalone twin of #3429 (host), whose
+   `maybeStampCompiledFunctionArgName` is gated `if (ctx.standalone) return false`.
+   Fixing it does not flip tests by itself but repairs many failure MESSAGES,
+   which currently mislabel clusters.
+3. The 70 non-Test262Error members of the 924 (`DummyError`, `MyError`,
+   `ExpectedError`, `CustomError`, `StopReverse`) are plain fnctor instances,
+   not `$Error_struct`s — they need the general fnctor `.constructor`
+   back-pointer. This is the standalone counterpart of open issue **#3486**.
+4. `SameValue` clusters (222 + 181 + 162 + 134 + 131 + 107 + …) are untriaged;
+   they need per-cluster repros — the bucket label is a symptom, not a cause.
+5. The ~1,804 "no exception was thrown at all" family is heterogeneous —
+   triage by which operation failed to throw, not by directory.
+
+## 6. State
+
+- Branch `issue-3614-standalone-test262error-ctor-identity` in worktree
+  `/workspace/.claude/worktrees/agent-a9035bbe084665a85`, based on
+  `upstream/main` @ `c429f7800`. Fix committed; issue file NOT yet written;
+  no PR opened; no regression test written yet.
+- Claim held: `node scripts/claim-issue.mjs --release 3614 ttraenkler/opus-sa-assertfail`
+  to hand it off.

--- a/plan/issues/3614-standalone-test262error-constructor-identity.md
+++ b/plan/issues/3614-standalone-test262error-constructor-identity.md
@@ -1,0 +1,216 @@
+---
+id: 3614
+title: "Standalone: a Test262Error instance's .constructor reads undefined, so assert.throws rejects correct throws (924 tests)"
+status: done
+completed: 2026-07-25
+assignee: ttraenkler/opus-sa-assertfail
+sprint: current
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: m
+feasibility: hard
+task_type: bug
+area: codegen
+language_feature: error-constructors, exceptions
+es_edition: multi
+goal: standalone-mode
+related: [2902, 3006, 3133, 3429, 3486, 3592]
+origin: "Triage of the post-#3592 de-vacuification standalone `assertion_fail` bucket (12,038). Largest homogeneous cluster of the 5,114 newly-revealed pass→fail flips."
+loc-budget-allow:
+  - src/codegen/registry/error-types.ts
+---
+
+# #3614 — standalone `Test262Error` instance `.constructor` reads `undefined`
+
+## Problem
+
+`#3592` de-vacuified the standalone lane: `__apply_closure` had been
+under-applying arguments, so `assert.sameValue(a, b)` (2 args into 3 formals)
+never invoked the callee and ~5,000 tests reported a pass without executing a
+single assertion. With the dispatch fixed, **5,114 tests flipped `pass`→`fail`**
+(standalone `pass` 27,709 → 22,621). Those are the honest failures the fake
+passes were hiding.
+
+Clustering the 5,114 by their **actual assertion message** (not by the
+`assertion_fail` bucket label, which is a symptom) produces one dominant
+homogeneous group:
+
+|   Count | Message                                                                             |
+| ------: | ----------------------------------------------------------------------------------- |
+|     938 | `Expected a TypeError to be thrown but no exception was thrown at all`              |
+| **924** | **`Expected a undefined but got a different error constructor with the same name`** |
+|     386 | `Expected a undefined to be thrown but no exception was thrown at all`              |
+|     222 | `Expected SameValue(«"…"», «"…"») to be true`                                       |
+
+The `…no exception was thrown at all` families are heterogeneous (one missing
+throw each). The **924** are not: they are one defect. Split by the constructor
+handed to `assert.throws`:
+
+| Count | Expected constructor         |
+| ----: | ---------------------------- |
+|   854 | `Test262Error`               |
+|    33 | `DummyError` + `TypeError`   |
+|    14 | `DummyError`                 |
+|     9 | `ExpectedError`              |
+|     5 | `MyError`                    |
+|     5 | `Test262Error` + `TypeError` |
+|     3 | `CustomError`                |
+|     1 | `StopReverse`                |
+
+### Why the message says "undefined … with the same name"
+
+Upstream `harness/assert.js`:
+
+```js
+} else if (thrown.constructor !== expectedErrorConstructor) {
+  expectedName = expectedErrorConstructor.name;
+  actualName = thrown.constructor.name;
+  if (expectedName === actualName) {
+    message += 'Expected a ' + expectedName + ' but got a different error constructor with the same name';
+  }
+```
+
+Measured in standalone (probe `.tmp/probes/ctor2.js`, run through the CI-equivalent
+pool path — see "Reproduction" below):
+
+| Probe                                                  | before  | after   |
+| ------------------------------------------------------ | ------- | ------- |
+| `thrown.constructor === undefined`                     | `true`  | `false` |
+| `thrown.constructor === expected` (via a parameter)    | `false` | `true`  |
+| `expected === Test262Error` (identity via a parameter) | `true`  | `true`  |
+| `Test262Error.name === 'Test262Error'` (static read)   | `true`  | `true`  |
+| `expected.name === undefined` (read via a parameter)   | `true`  | `true`  |
+
+So `thrown.constructor` is `undefined`; `undefined.name` does not trap in
+standalone and yields `undefined`; `expectedErrorConstructor.name` read off a
+**parameter** is also `undefined` — the two "names" compare equal and the
+harness takes the "same name" branch. **The compiler threw exactly the right
+error; only the `.constructor` back-pointer was missing.**
+
+Note the identity substrate was already sound: `Test262Error === Test262Error`
+holds, and holds **through a function parameter**. Only the back-pointer from
+the instance was absent.
+
+### Root cause
+
+`emitStandaloneTest262Error` (#2902) lowers `new Test262Error(msg)` to the same
+`$Error_struct` the WASI error constructors use, tagged `Error` with
+`$name = "Test262Error"`. `fillExternGetErrorProps`
+(`src/codegen/registry/error-types.ts`) is the reader that answers named keys on
+an `$Error_struct` — and its `constructor` key arm answers **only** builtin
+error constructors. Its `Error` arm is deliberately `$name === "Error"`-guarded,
+with the comment _"Test262Error keeps today's miss"_, because Test262Error
+SHARES the `Error` tag. Nothing else claimed the key, so the read fell through
+to the standard miss and produced `undefined`.
+
+## Fix
+
+Add a `userCtorArms` block ahead of the builtin `ctorArms` in
+`fillExternGetErrorProps`. When `$name` matches a
+`USER_ERROR_CTOR_IDENTITY_NAMES` entry (today exactly `Test262Error` — the only
+non-builtin `__new_<Name>` for which an `$Error_struct` is minted), answer with
+`ctx.funcClosureGlobals.get(name)`: the **same** `__fn_closure_<Name>` global
+(`method-trampolines.ts`) that a bare `Test262Error` mention resolves to. That
+is the global the `expectedErrorConstructor` argument was itself read from, so
+`===` holds by `ref.eq` — a genuine identity, not a null≡null tautology of the
+kind #3006 replaced.
+
+Two deliberate design constraints:
+
+- **Read-only.** The arm only performs `global.get`; it never lazily
+  materialises the closure. Materialising would require minting a `ref.func`
+  trampoline at **finalize**, which is exactly the late-funcidx-shift hazard
+  this file's own `ensureErrorCtorCarrierGlobal` note documents.
+
+  The consequence, measured and pinned by a dedicated test rather than left
+  implicit: `__fn_closure_Test262Error` is non-null only once the identifier
+  has been **evaluated as a value** somewhere in the module. When it never is,
+  the arm declines and `.constructor` keeps the historical `undefined`. That is
+  harmless — with nothing holding the other side, no identity comparison is
+  expressible — and it is exactly satisfied by the cluster this fixes, since
+  `assert.throws(Test262Error, fn)` evaluates the identifier as its first
+  argument.
+
+- **Keyed on `$name`, not the tag.** Test262Error shares the `Error` tag, so a
+  tag test would also claim genuine `new Error()` instances. The `$name` field
+  is immutable and set at construction, and the existing `Error` arm already
+  uses exactly this discriminator.
+
+Scope gates: `__new_<Name>` must be present (the module actually lowered such a
+constructor) **and** a `funcClosureGlobals` entry must exist. Every builtin
+error name fails the second gate — builtins have no user function declaration
+and therefore no closure singleton — so no builtin behaviour can shift.
+
+## Acceptance criteria
+
+- [x] `thrown.constructor === Test262Error` is `true` in standalone for a value
+      thrown as `new Test262Error(...)` and compared **through a function
+      parameter** (the harness's own shape).
+- [x] The identity is genuine, not vacuous: `thrown.constructor === Error` and
+      `thrown.constructor === someOtherFunction` stay `false`, and
+      `thrown.constructor` is not `undefined`.
+- [x] A genuine `new Error()` instance keeps answering the `Error` carrier —
+      the `$name` guard is not bypassed.
+- [x] JS-host lane untouched (the arm lives in a `ctx.wasi || ctx.standalone`
+      guarded filler).
+
+## Reproduction
+
+`runTest262File` (`tests/test262-runner.ts`) is **NOT** the CI path and will
+mislead: it renders thrown payloads via `originalHarnessThrownText`, which does
+not call `tryNativeExnRender`, so every standalone `Test262Error` surfaces as
+`uncaught Wasm-GC exception (non-stringifiable payload)` instead of its real
+assertion message. The CI shard path is
+`assembleOriginalHarness` → `CompilerPool(n, "unified")` →
+`scripts/test262-worker.mjs`. The worker additionally imports two generated
+bundles that are not in the tree:
+
+```bash
+npx esbuild scripts/compiler-bundle-entry.ts --bundle --platform=node --format=esm \
+  --outfile=scripts/compiler-bundle.mjs --external:typescript --external:binaryen \
+  --external:@typescript/native-preview '--external:@typescript/native-preview/*'
+npx esbuild src/runtime.ts --bundle --platform=node --format=esm \
+  --outfile=scripts/runtime-bundle.mjs --external:typescript --external:binaryen
+```
+
+Probe idiom: a `.js` file with test262 frontmatter that accumulates a `bits`
+value and ends with `throw new Test262Error("BITS=" + bits)` — the thrown
+message is what the runner records, so it is the only reliable output channel.
+
+## Test Results
+
+`tests/issue-3614.test.ts` — 7 cases, all green. Direct `compile({ target:
+"standalone", nativeStrings: true })` + instantiate, asserting **observable
+return values** (never "it compiles"); each module is additionally asserted to
+carry an empty import manifest, so the verdicts come from the Wasm and not from
+a JS host.
+
+Two shape requirements are load-bearing and were established empirically —
+getting either wrong makes the test pass vacuously against the wrong code path:
+
+1. `new Test262Error(…)` must use a **bare identifier callee**.
+   `new (Test262Error as any)(…)` is a parenthesized `AsExpression` and fails
+   the `ts.isIdentifier` gate in `new-builtin-globals.ts`, so no
+   `$Error_struct` is minted at all.
+2. Every identity comparison must happen inside a **callee, on a parameter** —
+   the shape `assert.throws` uses. A static identifier-to-identifier comparison
+   takes a different, already-working path.
+
+Confirmed to be a genuine regression test: with the `userCtorArms` spread
+removed, the identity case returns `0` and the `.constructor === undefined`
+case returns `1` (probe `.tmp/probe5.mts`: `test()` `1` with the fix, `2`
+without).
+
+## Follow-ups (filed separately, NOT in scope here)
+
+- **#3617** — the 70 non-`Test262Error` members of the 924 (`DummyError`,
+  `MyError`, `ExpectedError`, `CustomError`, `StopReverse`) are plain fnctor
+  instances, not `$Error_struct`s, so they need the general fnctor
+  `.constructor` back-pointer. Standalone counterpart of #3486.
+- **#3618** — `expectedErrorConstructor.name` read through a parameter is still
+  `undefined` in standalone (a static `Test262Error.name` read works). This
+  flips no verdicts but corrupts failure MESSAGES — it is what collapsed 924
+  heterogeneous-looking rows onto one string here — and is one of three
+  independent mechanisms making message-derived bucket labels unreliable in
+  this lane.

--- a/plan/issues/3617-standalone-fnctor-instance-constructor-backpointer.md
+++ b/plan/issues/3617-standalone-fnctor-instance-constructor-backpointer.md
@@ -1,0 +1,110 @@
+---
+id: 3617
+title: "Standalone: a plain fnctor instance's .constructor reads undefined (standalone counterpart of #3486)"
+status: ready
+sprint: current
+created: 2026-07-25
+updated: 2026-07-25
+priority: medium
+horizon: l
+feasibility: hard
+task_type: bug
+area: codegen
+language_feature: error-constructors, exceptions
+es_edition: multi
+goal: standalone-mode
+related: [3486, 3614, 2660, 2026, 3592]
+origin: "Residual of #3614: the 70 non-Test262Error members of the 924-test `assert.throws` cluster in the post-#3592 standalone de-vacuification."
+---
+
+# #3617 — standalone fnctor instance `.constructor` reads `undefined`
+
+## Problem
+
+#3614 fixed `.constructor` for values built by `new Test262Error(...)`, which
+the compiler lowers to an `$Error_struct` (#2902) — a special, name-keyed path.
+**A user constructor with any other name is not lowered that way**: `function
+MyError(msg) { this.message = msg; }` + `new MyError()` produces an ordinary
+fnctor instance, and reading `.constructor` on it still yields `undefined`.
+
+Measured on the post-#3592 standalone merged report, within the 924-test
+`Expected a undefined but got a different error constructor with the same name`
+cluster:
+
+| Count | Expected constructor         | Covered by #3614 |
+| ----: | ---------------------------- | ---------------- |
+|   854 | `Test262Error`               | yes              |
+|    33 | `DummyError` + `TypeError`   | **no**           |
+|    14 | `DummyError`                 | **no**           |
+|     9 | `ExpectedError`              | **no**           |
+|     5 | `MyError`                    | **no**           |
+|     5 | `Test262Error` + `TypeError` | partially        |
+|     3 | `CustomError`                | **no**           |
+|     1 | `StopReverse`                | **no**           |
+
+So **~70 tests** remain. The mechanism is identical to #3614's: upstream
+`harness/assert.js` runs `thrown.constructor !== expectedErrorConstructor` on
+every caught value, so a missing back-pointer rejects a throw that was exactly
+correct.
+
+Verified repro (standalone, `nativeStrings: true`, probe
+`.tmp/probes/ctor-identity.js` run through the CI-equivalent pool path):
+
+| Probe                               | result  |
+| ----------------------------------- | ------- |
+| `thrown.constructor === undefined`  | `true`  |
+| `thrown.constructor === DummyError` | `false` |
+| `DummyError === DummyError`         | `true`  |
+| `DummyError.name === 'DummyError'`  | `false` |
+
+Note the identity substrate is already sound — the closure singleton is stable
+across textual occurrences and through function parameters. Only the
+instance→constructor back-pointer is absent.
+
+## Relationship to #3486
+
+#3486 is the **JS-host** version of this defect (there, `.constructor` resolves
+to `Array` rather than to `undefined`). This issue is its **standalone**
+counterpart. They are likely to want a shared design — an instance→constructor
+link established at `new F()` — but the two lanes have different substrates
+(host: `_fnctorInstanceCtor` WeakMap in `runtime.ts`; standalone: WasmGC struct
+fields), so they are tracked separately.
+
+## Candidate approach (not a spec — needs design)
+
+`#2660 S2/S3` already establishes a per-fnctor prototype `$Object`
+(`src/codegen/expressions/fnctor-prototype.ts`) and seeds an instance's
+`$proto` from it at `new F()` — a single link location and a single walk. If
+the fnctor prototype object carried a `constructor` slot pointing at the
+`__fn_closure_<Name>` singleton, an inherited read would resolve naturally
+without a parallel mechanism.
+
+Two known obstacles:
+
+1. `resolveUserFnctorName` is gated on `ctx.fnctorEscapeGate.approvedNames` —
+   only constructors with a `reconstruct`-classified `new F()` site
+   participate. The file records that an UNSCOPED interception previously cost
+   the standalone floor −40 (species `Ctor.prototype` identity in
+   `Array/prototype/*/create-proxy`, and `Test262Error.prototype.toString`).
+   The marker-error constructors in this cluster are `keep-typed`, i.e.
+   currently outside the gate — widening it is the risky part.
+2. A `constructor` slot must not become an enumerable own property, or
+   `Object.keys` / `for-in` / `JSON.stringify` on such instances change.
+
+## Acceptance criteria
+
+- [ ] For a user `function MyError(m) { this.message = m; }`, standalone
+      `(new MyError()).constructor === MyError` is `true` when compared through
+      a function parameter (the `assert.throws` shape).
+- [ ] Genuine, not vacuous: the same comparison against a DIFFERENT compiled
+      constructor is `false`, and `.constructor` is not `undefined`.
+- [ ] `Object.keys(new MyError())` is unchanged (no new enumerable own prop).
+- [ ] No standalone floor regression; the #2660 `keep-typed` / species
+      `Ctor.prototype` identity cases named above stay green.
+- [ ] JS-host lane untouched (that is #3486).
+
+## Reproduction
+
+`runTest262File` is **not** the CI path and mangles standalone thrown payloads —
+see #3614's Reproduction section for the `CompilerPool("unified")` harness and
+the two esbuild bundle prerequisites.

--- a/plan/issues/3618-standalone-closure-name-via-parameter-corrupts-failure-text.md
+++ b/plan/issues/3618-standalone-closure-name-via-parameter-corrupts-failure-text.md
@@ -1,0 +1,132 @@
+---
+id: 3618
+title: "Standalone closure .name via a parameter is undefined — corrupts test262 failure text and makes message-derived bucket labels mislead (standalone twin of #3429)"
+status: ready
+sprint: current
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: m
+feasibility: medium
+task_type: bug
+area: codegen, test262-runner
+language_feature: functions, error-constructors
+es_edition: multi
+goal: standalone-mode
+related: [3429, 3486, 3614, 3592, 2962, 2870]
+origin: "Triage of the post-#3592 standalone assertion_fail bucket: one of three independent mechanisms found corrupting standalone failure TEXT, which is why root-cause bucket labels are unreliable in this area."
+---
+
+# #3618 — standalone closure `.name` via a parameter is `undefined`
+
+## Problem
+
+Reading `.name` off a compiled function value works when the receiver is a
+**static identifier** but not when it arrives through a **parameter** — which
+is the shape every harness helper uses.
+
+Measured in standalone (`nativeStrings: true`, probe `.tmp/probes/ctor2.js` via
+the CI-equivalent pool path):
+
+| Probe                                                | result |
+| ---------------------------------------------------- | ------ |
+| `Test262Error.name === 'Test262Error'` (static read) | `true` |
+| `expected.name === undefined` (same fn, as a param)  | `true` |
+| `expected === Test262Error` (same fn, as a param)    | `true` |
+
+So the value's **identity** survives the parameter passing but its `.name`
+does not.
+
+This flips no verdicts by itself. What it does is **corrupt the recorded
+failure text**, because upstream `harness/assert.js` builds its messages from
+exactly that read:
+
+```js
+expectedName = expectedErrorConstructor.name;
+actualName = thrown.constructor.name;
+if (expectedName === actualName) {
+  message += "Expected a " + expectedName + " but got a different error constructor with the same name";
+}
+```
+
+With both sides `undefined`, 924 heterogeneous-looking rows collapsed onto the
+single string `Expected a undefined but got a different error constructor with
+the same name` (see #3614). The real constructor names — the thing you need to
+route the failure — were erased.
+
+## Why this is worth fixing beyond cosmetics
+
+Three **independent** mechanisms currently corrupt standalone failure text.
+Together they are why message-derived root-cause bucket labels are unreliable
+in this lane and why cross-checking against the JS-host lane is necessary:
+
+1. **This issue.** Closure `.name` via a parameter is `undefined`, so harness
+   messages name no constructor.
+2. **`runTest262File` is not the CI path** (`tests/test262-runner.ts`). It
+   renders thrown payloads via `originalHarnessThrownText`, which does not call
+   `tryNativeExnRender`, so every standalone `Test262Error` surfaces locally as
+   `uncaught Wasm-GC exception (non-stringifiable payload)` instead of its real
+   assertion message. The CI shard path is `assembleOriginalHarness` →
+   `CompilerPool(n, "unified")` → `scripts/test262-worker.mjs`.
+3. **`compareArray.format` masking** (from the `type_error` lane, verified with
+   real repros): ~235 rows render as `Array.prototype.<m> is not yet callable
+as a value`, but the call site is `harness/assert.js:140`
+   `compareArray.format`, which `assert.compareArray` reaches **only on its
+   failure branch** (line 121 early-returns on success). Those tests had
+   already failed their content comparison; the missing `map`-as-value merely
+   replaced the honest `Test262Error` text with a `TypeError`. Consequence:
+   fixing the callable-as-a-value gap yields **zero** passes and simply
+   relocates ~235 rows from `type_error` into `assertion_fail`.
+
+## Root cause
+
+The JS-host lane hit the same class of bug and fixed it in #3429:
+`maybeStampCompiledFunctionArgName` (`src/codegen/expressions/helpers.ts`)
+stamps the statically-resolved declared name onto a compiled-closure argument
+before it crosses into a host-delegated call. That helper is gated off for this
+lane:
+
+```ts
+// (#3429) JS-host only. `wasmClosureDynamicBridge` — the bug this fixes —
+// is a JS-host runtime.ts construct; standalone/WASI have no JS host to
+// bridge into, so the bug this fixes cannot occur there.
+if (ctx.standalone || ctx.wasi) return false;
+```
+
+The _stated reason_ for the gate is sound — `wasmClosureDynamicBridge` really is
+a host construct. But standalone has its **own**, distinct reason for
+`.name` being `undefined`: there is no host sidecar at all, and the dynamic
+`__extern_get(closure, "name")` read has no arm for a compiled closure struct.
+So the gate is correct about the host bug and simply leaves the standalone bug
+unowned. Fixing it is NOT "un-gate #3429" — standalone needs a native
+`.name` answer, not a host-sidecar stamp.
+
+## Suggested direction
+
+Answer `name` (and probably `length`) in the dynamic reader for a compiled
+closure struct, keyed the same way #3614 keys `.constructor`: the compiler
+already interns the declared name as a string constant, and
+`ctx.funcClosureGlobals` already provides the identity-stable per-name
+singleton. Prefer a reader arm over a construction-time stamp so no
+enumerable own property appears on function values.
+
+Beware the finalize-time hazard #3614 documents: do not mint `ref.func`
+trampolines from a finalize-phase filler.
+
+## Acceptance criteria
+
+- [ ] Standalone: for a compiled `function MyError() {}` passed as an argument,
+      `fn.name === 'MyError'` inside the callee.
+- [ ] `Object.keys(MyError)` unchanged — no new enumerable own property.
+- [ ] A test262 `assert.throws` mismatch on a wrong-but-real error constructor
+      records a message naming BOTH constructors, not `undefined`.
+- [ ] JS-host lane byte-identical (do not disturb the #3429 stamp).
+- [ ] No standalone floor regression.
+
+## Follow-on value
+
+Once landed, re-cluster the standalone `assertion_fail` bucket: the 924-row
+collapse in #3614's triage was an artifact of this bug, and other clusters are
+likely similarly merged. Until then, treat message-derived buckets as a
+starting point only and confirm each cluster against a real repro and the
+JS-host lane's text.

--- a/src/codegen/registry/error-types.ts
+++ b/src/codegen/registry/error-types.ts
@@ -75,6 +75,19 @@ const WASI_ERROR_NAMES = [
 
 export type WasiErrorName = (typeof WASI_ERROR_NAMES)[number];
 
+/**
+ * (#3614) User-declared constructors that this compiler lowers to an
+ * `$Error_struct` (rather than to a plain fnctor instance), and whose
+ * `.constructor` back-pointer must therefore be answered by the
+ * `$Error_struct` reader in `fillExternGetErrorProps`.
+ *
+ * Today this is exactly `Test262Error` — `emitStandaloneTest262Error` (#2902)
+ * is the only non-builtin `__new_<Name>` an `$Error_struct` is minted for. It
+ * is a list rather than a literal so a future `$Error_struct`-lowered user
+ * constructor only has to be added here.
+ */
+const USER_ERROR_CTOR_IDENTITY_NAMES = ["Test262Error"] as const;
+
 /** Returns true if `name` is one of the 8 Error constructors handled by Phase 1. */
 export function isWasiErrorName(name: string): name is WasiErrorName {
   return (WASI_ERROR_NAMES as readonly string[]).includes(name);
@@ -355,6 +368,79 @@ export function fillExternGetErrorProps(ctx: CodegenContext): void {
     },
   ];
 
+  // (#3614) `<user-fnctor error instance>.constructor` → the SAME cached
+  // closure singleton the bare identifier resolves to.
+  //
+  // `emitStandaloneTest262Error` (#2902) lowers `new Test262Error(msg)` to an
+  // `$Error_struct` carrying `$name = "Test262Error"`. Reading `.constructor`
+  // off that struct fell through every arm below (the `Error`-tag arm is
+  // explicitly guarded to answer only a genuine `new Error(...)`) and returned
+  // `undefined`. The upstream harness's `assert.throws` compares
+  // `thrown.constructor !== expectedErrorConstructor` for EVERY caught value,
+  // so `undefined !== <closure>` made the comparison fail even when the test
+  // threw exactly the expected error — 854 standalone tests whose only defect
+  // was this missing back-pointer (measured against the post-#3592
+  // de-vacuification merged standalone report).
+  //
+  // The answer must be IDENTITY-equal to what a bare `Test262Error` mention
+  // produces, which is `ctx.funcClosureGlobals`' per-name cached closure
+  // singleton (`__fn_closure_<Name>`, method-trampolines.ts) — the same global
+  // the `expectedErrorConstructor` argument was read from, so `===` holds by
+  // `ref.eq`. We deliberately only READ that global (never lazily materialize
+  // it here): materializing would require a `ref.func` trampoline minted at
+  // FINALIZE, which is exactly the late-funcidx-shift hazard this file's
+  // `ensureErrorCtorCarrierGlobal` note calls out. A null read means the
+  // identifier was never evaluated as a value anywhere in the module, in which
+  // case nothing can hold the other side of an identity comparison either —
+  // so falling through to today's miss loses nothing.
+  //
+  // Keyed on the immutable `$name` field (not the tag, which Test262Error
+  // SHARES with `Error`), so a genuine `new Error()` is unaffected. Scoped to
+  // user constructors that this module actually lowered to an `$Error_struct`
+  // (`__new_<Name>` present AND a closure singleton exists), which excludes
+  // every builtin error name (they have no user function declaration and thus
+  // no `funcClosureGlobals` entry).
+  const userCtorArms: Instr[] = [];
+  for (const name of USER_ERROR_CTOR_IDENTITY_NAMES) {
+    if (!ctx.funcMap.has(`__new_${name}`)) continue;
+    const closureGlobalIdx = ctx.funcClosureGlobals.get(name);
+    if (closureGlobalIdx === undefined) continue;
+    userCtorArms.push(
+      ...errRef(),
+      { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 2 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } as ValType },
+        then: [
+          ...errRef(),
+          { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 2 },
+          { op: "any.convert_extern" },
+          { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+          { op: "call", funcIdx: strFlattenIdx },
+          ...nativeStringLiteralInstrs(ctx, name),
+          { op: "call", funcIdx: strEqualsIdx },
+        ],
+        else: [{ op: "i32.const", value: 0 }],
+      },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "global.get", index: closureGlobalIdx },
+          { op: "ref.is_null" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "global.get", index: closureGlobalIdx }, { op: "return" }],
+          },
+        ],
+      },
+    );
+  }
+
   // One `constructor` arm per builtin error ctor EMITTED in this module. The
   // carrier global is get-or-created HERE (append-only; see
   // ensureErrorCtorCarrierGlobal for why finalize-time creation is safe) —
@@ -486,7 +572,7 @@ export function fillExternGetErrorProps(ctx: CodegenContext): void {
                 { op: "struct.get", typeIdx: errTypeIdx, fieldIdx: 4 },
                 { op: "i32.const", value: -1 },
                 { op: "i32.eq" },
-                { op: "if", blockType: { kind: "empty" }, then: ctorArms },
+                { op: "if", blockType: { kind: "empty" }, then: [...userCtorArms, ...ctorArms] },
               ],
             },
           ],

--- a/tests/issue-3614.test.ts
+++ b/tests/issue-3614.test.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3614 — a standalone `Test262Error` instance's `.constructor` read `undefined`.
+ *
+ * `emitStandaloneTest262Error` (#2902) lowers `new Test262Error(msg)` to an
+ * `$Error_struct` with `$name = "Test262Error"`. The `constructor` key arm in
+ * `fillExternGetErrorProps` answered only BUILTIN error constructors — its
+ * `Error` arm is `$name === "Error"`-guarded precisely because Test262Error
+ * SHARES the `Error` tag — so the read fell through to the standard miss.
+ *
+ * Upstream `harness/assert.js` runs
+ * `thrown.constructor !== expectedErrorConstructor` on EVERY caught value, so
+ * `undefined !== <closure>` rejected throws that were exactly correct. 924 of
+ * the 5,114 standalone tests de-vacuified by #3592 failed on this alone (854
+ * of them via `assert.throws(Test262Error, …)`).
+ *
+ * These tests assert OBSERVABLE VALUES returned from the instantiated module —
+ * never merely "it compiles". Two shape requirements are load-bearing and were
+ * both established empirically:
+ *
+ *  1. `new Test262Error(…)` must be written with a BARE IDENTIFIER callee.
+ *     `new (Test262Error as any)(…)` is a parenthesized `AsExpression`, which
+ *     fails the `ts.isIdentifier` gate in `new-builtin-globals.ts`, so no
+ *     `$Error_struct` is minted and the test would silently exercise the
+ *     generic fnctor path instead of the code under test.
+ *  2. Every identity comparison happens inside a CALLEE, on a PARAMETER — the
+ *     shape `assert.throws(Test262Error, fn)` actually uses. A static
+ *     identifier-to-identifier comparison would take a different, already
+ *     working path.
+ *
+ * Verified to be a genuine regression test: with the `userCtorArms` block
+ * removed from `fillExternGetErrorProps`, the first two cases below invert
+ * (`thrown.constructor` is `undefined`, the identity is `false`).
+ */
+
+const PRELUDE = `
+function Test262Error(this: any, message: any) {
+  (this as any).message = message;
+}
+// A second, unrelated compiled constructor — the cross-check that the identity
+// answered is the RIGHT one and not just "any non-undefined object".
+function OtherError(this: any, message: any) {
+  (this as any).message = message;
+}
+// The comparisons live in callees taking their operands as PARAMETERS, which is
+// the shape harness/assert.js's \`assert.throws\` uses.
+function matches(expected: any, thrown: any): boolean {
+  return thrown.constructor === expected;
+}
+function ctorIsUndefined(thrown: any): boolean {
+  return thrown.constructor === undefined;
+}
+function sameCtor(a: any, b: any): boolean {
+  return a.constructor === b.constructor;
+}
+// Evaluates its argument as a VALUE and nothing else. The fix answers
+// \`.constructor\` by READING the \`__fn_closure_Test262Error\` global and never
+// materializes it (materializing would mean minting a \`ref.func\` trampoline at
+// finalize — the late-funcidx-shift hazard). So the global is non-null only
+// once the identifier has been evaluated as a value somewhere in the module.
+// \`assert.throws(Test262Error, fn)\` always does exactly that; \`keep()\` is the
+// minimal stand-in for it.
+function keep(v: any): boolean {
+  return v !== undefined;
+}
+`;
+
+async function runStandalone(body: string): Promise<number> {
+  const src = `${PRELUDE}\nexport function test(): number {\n${body}\n}\n`;
+  const r = await compile(src, { target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Standalone must stay host-free for this shape. If a host import crept in,
+  // the assertions below would be measuring the JS host rather than the Wasm.
+  expect(r.imports).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+/** Throws and catches a Test262Error, leaving it in `thrown`. */
+const THROW_AND_CATCH = `
+  let thrown: any = undefined;
+  try {
+    throw new Test262Error("boom");
+  } catch (e) {
+    thrown = e;
+  }
+`;
+
+describe("#3614 — standalone Test262Error instance .constructor identity", () => {
+  it("thrown.constructor === Test262Error holds through a function parameter", async () => {
+    // Pre-fix: 0. This is the single comparison the 854-test cluster failed on.
+    expect(
+      await runStandalone(`
+        ${THROW_AND_CATCH}
+        return matches(Test262Error, thrown) ? 1 : 0;
+      `),
+    ).toBe(1);
+  });
+
+  it("thrown.constructor is no longer undefined", async () => {
+    // Pre-fix: 1. Separated from the identity check so a regression that makes
+    // `.constructor` answer *something wrong* is distinguishable from one that
+    // makes it answer nothing at all.
+    expect(
+      await runStandalone(`
+        ${THROW_AND_CATCH}
+        keep(Test262Error);
+        return ctorIsUndefined(thrown) ? 1 : 0;
+      `),
+    ).toBe(0);
+  });
+
+  it("the identity is genuine — a different compiled constructor does not match", async () => {
+    // Guards against a vacuous fix: if `.constructor` answered a single shared
+    // carrier (or if both sides collapsed to `undefined`, as pre-fix), this
+    // would also report a match.
+    expect(
+      await runStandalone(`
+        ${THROW_AND_CATCH}
+        return matches(OtherError, thrown) ? 1 : 0;
+      `),
+    ).toBe(0);
+  });
+
+  it("both directions hold in one module: right ctor matches, wrong ctor does not", async () => {
+    // The two cross-checks above, in a SINGLE compilation unit, so a fix that
+    // only works when exactly one constructor exists cannot pass.
+    expect(
+      await runStandalone(`
+        ${THROW_AND_CATCH}
+        if (!matches(Test262Error, thrown)) { return 0; }
+        if (matches(OtherError, thrown)) { return 0; }
+        if (ctorIsUndefined(thrown)) { return 0; }
+        return 1;
+      `),
+    ).toBe(1);
+  });
+
+  it("two Test262Error instances answer the SAME constructor object", async () => {
+    // Cross-instance stability: the arm must answer one identity-stable global,
+    // not a freshly materialized object per read. Paired with the
+    // `!ctorIsUndefined` guard so `undefined === undefined` cannot satisfy it.
+    expect(
+      await runStandalone(`
+        let a: any = undefined;
+        let b: any = undefined;
+        try { throw new Test262Error("one"); } catch (e) { a = e; }
+        try { throw new Test262Error("two"); } catch (e) { b = e; }
+        keep(Test262Error);
+        if (ctorIsUndefined(a)) { return 0; }
+        return sameCtor(a, b) ? 1 : 0;
+      `),
+    ).toBe(1);
+  });
+
+  it("declines (keeps the legacy miss) when the identifier is never read as a value", async () => {
+    // Pins the deliberate read-only contract rather than letting it be an
+    // accident: with no value read of `Test262Error` anywhere in the module the
+    // closure global is null, so the arm falls through to the historical miss.
+    // Harmless — with nothing holding the other side, no identity comparison is
+    // expressible — but it must not change silently, because the alternative
+    // (materializing the closure from `fillExternGetErrorProps`) would require
+    // minting a `ref.func` trampoline at FINALIZE.
+    expect(
+      await runStandalone(`
+        ${THROW_AND_CATCH}
+        return ctorIsUndefined(thrown) ? 1 : 0;
+      `),
+    ).toBe(1);
+  });
+
+  it("a genuine new Error() does not report Test262Error as its constructor", async () => {
+    // The `$name` discriminator must not be bypassed: `Error` and
+    // `Test262Error` SHARE the Error tag, so a tag-keyed arm would cross-wire
+    // them. Also asserts the real Error still answers *something* (#3006's
+    // builtin carrier), so this is not passing merely because the read missed.
+    expect(
+      await runStandalone(`
+        let thrown: any = undefined;
+        try {
+          throw new Error("boom");
+        } catch (e) {
+          thrown = e;
+        }
+        if (ctorIsUndefined(thrown)) { return 0; }
+        return matches(Test262Error, thrown) ? 0 : 1;
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #3614.

## What this fixes

`#3592` de-vacuified the standalone lane (`__apply_closure` had been under-applying
arguments, so ~5,000 tests "passed" without executing a single assertion). That turned
**5,114 tests from `pass` into honest `fail`**. Clustering those 5,114 by their *actual
assertion message* — not by the `assertion_fail` bucket label, which is a symptom —
produces one dominant homogeneous group:

|   Count | Message                                                                             |
| ------: | ----------------------------------------------------------------------------------- |
|     938 | `Expected a TypeError to be thrown but no exception was thrown at all`              |
| **924** | **`Expected a undefined but got a different error constructor with the same name`** |
|     386 | `Expected a undefined to be thrown but no exception was thrown at all`              |

The `…no exception was thrown at all` families are heterogeneous (a separate missing
throw each). The **924** are one defect — **854** of them `assert.throws(Test262Error, …)`.

## Root cause

`emitStandaloneTest262Error` (#2902) lowers `new Test262Error(msg)` to an
`$Error_struct` with `$name = "Test262Error"`. `fillExternGetErrorProps` is the reader
that answers named keys on that struct — and its `constructor` arm answers **only**
builtin error constructors. Its `Error` arm is deliberately `$name === "Error"`-guarded
(*"Test262Error keeps today's miss"*) because Test262Error **shares** the `Error` tag.
Nothing else claimed the key, so the read returned `undefined`.

Upstream `harness/assert.js` runs `thrown.constructor !== expectedErrorConstructor` on
**every** caught value, so `undefined !== <closure>` rejected throws that were exactly
correct. `undefined.name` doesn't trap in standalone and yields `undefined`, and
`expectedErrorConstructor.name` read off a **parameter** is also `undefined` — hence
both "names" comparing equal and the misleading "same name" text.

Measured, standalone, via the CI-equivalent pool path:

| Probe                                                  | before  | after   |
| ------------------------------------------------------ | ------- | ------- |
| `thrown.constructor === undefined`                     | `true`  | `false` |
| `thrown.constructor === expected` (via a parameter)    | `false` | `true`  |
| `expected === Test262Error` (identity via a parameter) | `true`  | `true`  |

Note the identity substrate was already sound — only the instance→constructor
back-pointer was missing. **The compiler was throwing the right error all along.**

## The fix

Add a `userCtorArms` block ahead of the builtin `ctorArms` in
`fillExternGetErrorProps`. When `$name` matches a `USER_ERROR_CTOR_IDENTITY_NAMES`
entry (today exactly `Test262Error` — the only non-builtin `__new_<Name>` an
`$Error_struct` is minted for), answer with `ctx.funcClosureGlobals.get(name)`: the
**same** `__fn_closure_<Name>` global a bare `Test262Error` mention resolves to, i.e.
the global the `expectedErrorConstructor` argument was itself read from. `===` therefore
holds by `ref.eq` — a genuine identity, not the null≡null tautology #3006 replaced.

Two deliberate constraints:

- **Read-only.** The arm only does `global.get`; it never materialises the closure.
  Materialising would require minting a `ref.func` trampoline at **finalize** — exactly
  the late-funcidx-shift hazard this file's own `ensureErrorCtorCarrierGlobal` note
  documents. The consequence (the global is non-null only once the identifier has been
  evaluated as a value) is **pinned by a dedicated test** rather than left implicit. It
  is harmless — with nothing holding the other side, no identity comparison is
  expressible — and `assert.throws(Test262Error, fn)` always satisfies it.
- **Keyed on `$name`, not the tag**, since `Error` and `Test262Error` share the tag and
  a tag test would cross-wire them.

Scope gates: `__new_<Name>` present **and** a `funcClosureGlobals` entry. Every builtin
error name fails the second gate (no user function declaration ⇒ no closure singleton),
so no builtin behaviour can shift. Standalone/WASI only — the whole filler is behind
`ctx.wasi || ctx.standalone`, so the JS-host lane is untouched.

## Tests

`tests/issue-3614.test.ts` — 7 cases, all green. Each asserts an **observable return
value** from the instantiated module (never "it compiles"), and each module is
additionally asserted to have an empty import manifest so the verdicts come from the
Wasm and not from a JS host. Coverage: the parameter-passed identity; `.constructor` no
longer `undefined`; a *different* compiled constructor does **not** match; both
directions in one compilation unit; cross-instance stability; the deliberate
decline-when-never-read contract; and a genuine `new Error()` still answering its own
carrier.

Two shape requirements are load-bearing and were established empirically — getting
either wrong makes the test pass vacuously against the wrong code path:

1. `new Test262Error(…)` must use a **bare identifier callee**. `new (Test262Error as
   any)(…)` is a parenthesized `AsExpression` and fails the `ts.isIdentifier` gate in
   `new-builtin-globals.ts`, so no `$Error_struct` is minted at all.
2. Every identity comparison must happen inside a **callee, on a parameter** — the shape
   `assert.throws` uses. A static identifier-to-identifier comparison takes a different,
   already-working path.

Confirmed a genuine regression test: with the `userCtorArms` spread removed, the
identity case returns `0` and the `.constructor === undefined` case returns `1`.

## Expected conformance effect

Up to **854 standalone tests** whose only defect was this missing back-pointer. The
real delta is measured in the `merge_group` re-validation; the PR-level test262 checks
are designed no-ops. Standalone-only — no JS-host lane change is expected.

## Also filed (not implemented here)

- **#3617** — the 70 residual non-`Test262Error` members of the 924 (`DummyError`,
  `MyError`, `ExpectedError`, `CustomError`, `StopReverse`) are plain fnctor instances,
  not `$Error_struct`s, and need the general fnctor `.constructor` back-pointer.
  Standalone counterpart of #3486.
- **#3618** — standalone closure `.name` read through a parameter is `undefined`. It
  flips no verdicts but **corrupts failure text**: it is what collapsed 924
  heterogeneous-looking rows onto one string here, and it is one of three independent
  mechanisms that make message-derived bucket labels unreliable in this lane.

## Note for anyone reproducing standalone failures locally

`runTest262File` (`tests/test262-runner.ts`) is **not** the CI path and will mislead: it
renders thrown payloads via `originalHarnessThrownText`, which never calls
`tryNativeExnRender`, so every standalone `Test262Error` surfaces as `uncaught Wasm-GC
exception (non-stringifiable payload)` instead of its real assertion message. The CI
shard path is `assembleOriginalHarness` → `CompilerPool(n, "unified")` →
`scripts/test262-worker.mjs`. The issue file records the harness and the two esbuild
bundle prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
