### PR TITLE
fix(#3616): first-class BigInt TypedArray constructor values in standalone

### DIFF
--- a/plan/agent-context/opus-typeerror-family.md
+++ b/plan/agent-context/opus-typeerror-family.md
@@ -1,0 +1,227 @@
+# opus-typeerror-family — context dump (PAUSED 2026-07-25)
+
+Lane: standalone `type_error` (3,038) + `runtime_error` (113) + `promise_error`
+(54) + `range_error` (18). Paused mid-flight by the tech lead for box
+oversubscription. **Work in progress is committed-ready on branch
+`issue-3616-standalone-bigint-ta-ctor-value`** in worktree
+`/workspace/.claude/worktrees/agent-ac28deeda1c1e07e1/` (uncommitted at pause —
+see "Resume steps").
+
+## Data provenance
+
+- Post-#3592 standalone merged artifact:
+  `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/mg3601/test262-standalone-results-merged.jsonl`
+  (ts 10:02:53, oracle 11 honest) — pass 22,621 · fail 18,325 · CE 7,002.
+- Pre-#3592 baseline:
+  `/workspace/.claude/worktrees/agent-aeb44e25b6597e676/.tmp/standalone-baseline.jsonl`
+  (ts 04:43:57) — pass 27,709 · fail 13,236 · CE 7,003.
+- Diff scripts (mine, reusable):
+  `.tmp/diff.mjs`, `.tmp/bucket.mjs`, `.tmp/bucket-full.mjs`, `.tmp/sub.mjs`,
+  `.tmp/split2.mjs`, `.tmp/sample.mjs` in this worktree.
+- Local single/batch test runner: `.tmp/run-one.mts`, `.tmp/batch.mts`
+  (4th arg of `runTest262File` = `"standalone"`; there is **no env var** for the
+  lane — that cost me a wasted first run). Direct-compile probe: `.tmp/p1.mts`
+  (note `compile()` is **async** — `await` it or `r.errors` is undefined).
+
+## Newly-revealed subset (the lead's stated priority)
+
+pass→non-pass = **5,129**. Split by `error_category`:
+
+| category | n |
+|---|---|
+| assertion_fail | 4,496 |
+| other | 371 |
+| **type_error** | **179** |
+| illegal_cast | 43 |
+| null_deref | 21 |
+| (none) | 15 |
+| range_error | 3 |
+| oob | 1 |
+
+**My lane is only 182 of the 5,129 newly-revealed.** The bulk of my 3,038
+`type_error`s are PRE-EXISTING, not de-vacuified today. So within my lane the
+highest-yield work is in the pre-existing population, not the flip set.
+
+## Cause taxonomy — full post-landing lane (n = 3,223, 132 distinct signatures)
+
+| n | signature | verdict |
+|---|---|---|
+| 1,128 | `TypeError: Cannot access property on null or undefined at N:N` | **REAL standalone gap** — see root cause below |
+| 527 | `dynamic eval is not supported in standalone mode` | wont-fix (deliberate) |
+| 400 | `Cannot convert undefined or null to object` | unexamined |
+| 137 | `Cannot access property on null or undefined` (no loc) | unexamined |
+| 235 | `Array.prototype.<m> is not yet callable as a value in --target standalone` (34 methods; `map` alone 117) | **SECONDARY — do not chase, see below** |
+| 111 | `Cannot read properties of undefined (reading a class field)` | unexamined |
+| 83 | `Object method called on null or undefined` (annexB 64) | unexamined |
+| 78 | `Object.defineProperties unsupported descriptor shape` | narrow, self-describing |
+| 51+43 | `Cannot destructure 'X' or 'X'` (+ async variant) | unexamined |
+| 37 | `Generator.prototype.next requires that 'X' be a Generator` | unexamined |
+| 31 | `Reduce of empty array with no initial value` | unexamined |
+
+### The distinction the lead asked for (spec-correct vs missing-builtin)
+
+Two findings, both verified with real repros, not bucket labels:
+
+**(1) `Array.prototype.<m> is not yet callable as a value` (235) is NOT a
+standalone-gap win — it is a MASKING artifact. Do not spend a PR on it.**
+Emitted at `src/codegen/array-object-proto.ts:733` (`emitArrayProtoMemberBody`
+— only `slice` has a `*FromVecLocal` core; #2193 PR-C never landed). The reason
+it is secondary: the call site is the real test262 harness
+`harness/assert.js:140`
+
+```js
+compareArray.format = function (arrayLike) {
+  return `[${Array.prototype.map.call(arrayLike, String).join(', ')}]`;
+};
+```
+
+and `assert.compareArray` (line 120–124) **returns early on success** — `format`
+is reached ONLY on the failure branch. So every one of these tests had ALREADY
+failed its content comparison; the missing `map`-as-value merely replaces the
+honest `Test262Error: Actual [...] and expected [...]` message with a TypeError.
+Verified: `built-ins/Object/keys/order-after-define-property-with-function.js`
+fails identically in the JS-host lane with the honest message
+(`Actual [length] and expected [length, a] should have the same contents`).
+Landing the `*FromVecLocal` cores would yield **zero** passes; it would only
+un-mask ~235 rows into the `assertion_fail` lane. Worth telling
+`opus-assertfail-triage` — it means ~235 of their future rows are currently
+hiding in my bucket, and their true error text is only visible in the host lane.
+
+**(2) `Cannot access property on null or undefined at N:N` (1,128) IS a real
+standalone-gap defect, and 627 of them share ONE root cause.** Split:
+BigInt-path 627 · Temporal 213 · rest 288.
+
+## ROOT CAUSE FOUND (627 tests) — BigInt TypedArray ctors are `null` as VALUES in standalone
+
+`BigInt64Array` / `BigUint64Array` used in **value position** (not `new X()` /
+type position) evaluate to `ref.null.extern` under `--target standalone`.
+
+Chain: `src/codegen/expressions/identifiers.ts:1220` gates the first-class
+`$__ta_ctor` value on `taCtorKindOf(name) >= 0`; `taCtorKindOf`
+(`src/codegen/registry/types.ts:356`) indexes `TA_CTOR_KINDS`, which listed only
+the **9 non-BigInt** views. So the two BigInt names fall through to the
+`reportSilentFallback("const-fallback", "identifiers:unimplemented-global-default")`
+default at line 1248 → `ref.null.extern`.
+
+The host/gc lane was already fixed by #3087 (`identifiers.ts:834-862` routes
+both names through `__extern_get(globalThis, name)`, comment explicitly says
+"Covers the BigInt views too (not in the standalone `taCtorKindOf` list)"). Only
+the host-free lane was left behind. This is a **third residual of #2401**,
+distinct from its recorded (a) `BUILTIN_TYPES` method routing and (b) unsigned
+i64 semantics.
+
+Why it hits 627 rows: the test262 runner's shim
+(`tests/test262-runner.ts:2157`) is
+`const constructors = [BigInt64Array, BigUint64Array]; … fn(constructors[i], …)`
+— so `TA` is `null` in every `testWithBigIntTypedArrayConstructors` callback and
+`new TA(...)` yields null, then `sample.<anything>` is the reported TypeError.
+
+### Verified probes (all in `.tmp/`, standalone lane)
+
+- `.tmp/t5.ts` — `[Int8Array, Uint8Array, Int32Array, Float64Array,
+  BigInt64Array, BigUint64Array]`: indices 0–3 non-null, **index 4 is `null`**
+  (returned 104). After the fix: returns 1 (all six non-null, and dynamic
+  `new TA(4)` gives `.length === 4` for all six).
+- `.tmp/t3.ts` / `.tmp/t2.ts` — reproduce the exact harness shape
+  (`fn(constructors[i], makeCtorArg)` → `new TA(makeCtorArg([...]))`), returned
+  21 = "sample is null" before the fix.
+- `.tmp/t1.ts` — direct `new BigInt64Array(4)` **already worked** (`.length === 4`),
+  confirming #838's native i64-vec landed and isolating the defect to the
+  VALUE-position path only.
+- `.tmp/t6.ts` — separate, narrower gap found in passing: `new names[i](4)`
+  (`new` directly on an element-access callee) returns null even for the
+  non-BigInt views, while `const TA = names[i]; new TA(4)` works. NOT fixed by
+  this change; worth its own issue if anyone wants it (the harness uses the
+  working shape, so low yield).
+
+### Corpus size / regression surface
+
+BigInt TypedArray corpus in the post-landing artifact: **pass 28 · fail 685 · CE 64**.
+Small pass surface ⇒ low regression risk, large upside. Note the 8 sampled
+passes include vacuous ones (e.g. `byteoffset-is-symbol-throws` —
+`assert.throws(TypeError, …)` is satisfied by *any* TypeError, including
+"TA is null"), so a few of the 28 may honestly flip to fail; that must be
+measured, not assumed.
+
+## Change implemented (uncommitted at pause)
+
+Branch `issue-3616-standalone-bigint-ta-ctor-value`, issue id **#3616**
+allocated via `claim-issue.mjs --allocate`, lock taken for
+`ttraenkler/opus-typeerror-lane`. Three edits:
+
+1. `src/codegen/registry/types.ts` — **append** (never insert) `BigInt64Array`,
+   `BigUint64Array` to `TA_CTOR_KINDS` as kinds 9/10, and `8, 8` to
+   `TA_CTOR_BYTES`. Appending is load-bearing: the `kind` index is baked into
+   the `$__ta_ctor` singleton globals and into every `if`-chain arm of the
+   decode/encode/BYTES_PER_ELEMENT dispatches, so inserting would silently
+   repoint existing kinds.
+2. `src/codegen/dataview-native.ts` — `TA_VIEW_DECODE` gains the two rows with
+   `bytes: 8, float: false, int64: true` (signed / unsigned respectively). The
+   `int64` flag matters: without it an 8-byte non-float read takes the
+   `f64.reinterpret_i64` path (correct for `Float64Array`, garbage for an
+   integer view). These rows are **inert for the static lane** — `taViewDecode`
+   resolves names via `getTaViewName` over `ctx.taViewTypeMap`, and #838 gave
+   the BigInt views a native i64 vec rather than a `$__ta_view_<name>`, so no
+   static BigInt view type is ever registered.
+3. Same file — `emitDynDecodeDispatch` / `emitDynEncodeDispatch` thread
+   `int64: desc.int64` into `emitReadBytes`/`emitWriteBytes`, and the decode
+   arm appends `f64.convert_i64_s` / `_u` after the read. Required because
+   `emitReadBytes` deliberately LEAVES the i64 on the stack for an `int64`
+   accessor (the DataView `getBigInt64` BigInt carrier), while every arm of this
+   dispatch's `if` is typed `f64` — the BigInt arms must converge to the same
+   carrier. **Convert, not reinterpret.**
+
+Scope note: element VALUES in a dynamically-constructed BigInt view remain the
+f64 carrier, NOT i64-branded BigInts. That representation split is
+#1349/#2401(b) and is deliberately out of scope. This change buys the
+STRUCTURE — non-null identity-stable ctor, correct 8-byte width, working
+`length`/`byteLength`/MOP — which is what the harness rows gate on. Content
+assertions keep failing honestly.
+
+`f64.convert_i64_s`/`_u` are both already in the `Instr` union
+(`src/ir/types.ts:258-259`) — no union extension needed.
+
+## Resume steps
+
+1. `cd /workspace/.claude/worktrees/agent-ac28deeda1c1e07e1` — branch
+   `issue-3616-standalone-bigint-ta-ctor-value` is checked out; the three edits
+   above are **in the working tree, uncommitted**. `git diff` to confirm.
+2. Re-claim if needed: `node scripts/claim-issue.mjs 3616
+   ttraenkler/<agent> --branch issue-3616-standalone-bigint-ta-ctor-value --force`.
+3. **The measurement that was interrupted** — this is the one thing that must
+   finish before the PR: `npx tsx .tmp/batch.mts after.json` and diff against
+   `.tmp/before.json`. BEFORE is already captured and matches CI exactly
+   (14 fail / 8 pass on the 22-test stride sample — local harness verified
+   faithful). AFTER was killed at the PAUSE. If AFTER shows net-positive,
+   widen the sample (`.tmp/sample.mjs`, raise the `pick` counts to ~60) for a
+   confident before/after count, then write the issue file
+   `plan/issues/3616-standalone-bigint-ta-ctor-value.md` (`sprint: current`,
+   `status: done`, `umbrella: 2860`, `related: [2401, 3054, 3087, 3177, 838]`)
+   and open the PR.
+4. `npx tsc --noEmit -p tsconfig.json` had not completed at the pause — rerun.
+5. Run `prettier --write` on the two touched files before pushing (CI `quality`
+   uses prettier, not biome).
+6. Push to **`fork`**, `gh pr create -R loopdive/js2 --head ttraenkler:<branch>`,
+   verify the URL starts with `github.com/loopdive/`.
+
+## Unexamined, ranked, for whoever picks this lane up next
+
+1. **Temporal 213** rows inside the same `Cannot access property on null or
+   undefined` signature — likely the same "constructor/namespace is null as a
+   value" shape, different builtin. Cheapest next probe: repeat the `.tmp/t5.ts`
+   pattern with `Temporal.*` names.
+2. **`Cannot convert undefined or null to object` (400)** — TypedArray 64,
+   Date 53, annexB 38, Symbol 21. Not yet root-caused.
+3. **`Cannot read properties of undefined (reading a class field)` (111)** —
+   evenly split language/expressions 56 / language/statements 55, so likely one
+   codegen shape.
+4. **`Object method called on null or undefined` (83)** — annexB-dominated (64).
+
+## Out-of-lane handoffs
+
+- `opus-3610-brandchecks` (trap lane): nothing handed over yet. The
+  `illegal_cast` 43 / `null_deref` 21 in the newly-revealed set are theirs.
+- `opus-assertfail-triage`: see finding (1) — ~235 rows of theirs are currently
+  masked inside my `type_error` bucket by the missing
+  `Array.prototype.map`-as-value; their true assertion text is only readable in
+  the JS-host lane until #2193 PR-C lands.

--- a/plan/agent-context/opus-typeerror-family.md
+++ b/plan/agent-context/opus-typeerror-family.md
@@ -27,16 +27,16 @@ see "Resume steps").
 
 pass→non-pass = **5,129**. Split by `error_category`:
 
-| category | n |
-|---|---|
-| assertion_fail | 4,496 |
-| other | 371 |
+| category       | n       |
+| -------------- | ------- |
+| assertion_fail | 4,496   |
+| other          | 371     |
 | **type_error** | **179** |
-| illegal_cast | 43 |
-| null_deref | 21 |
-| (none) | 15 |
-| range_error | 3 |
-| oob | 1 |
+| illegal_cast   | 43      |
+| null_deref     | 21      |
+| (none)         | 15      |
+| range_error    | 3       |
+| oob            | 1       |
 
 **My lane is only 182 of the 5,129 newly-revealed.** The bulk of my 3,038
 `type_error`s are PRE-EXISTING, not de-vacuified today. So within my lane the
@@ -44,19 +44,19 @@ highest-yield work is in the pre-existing population, not the flip set.
 
 ## Cause taxonomy — full post-landing lane (n = 3,223, 132 distinct signatures)
 
-| n | signature | verdict |
-|---|---|---|
-| 1,128 | `TypeError: Cannot access property on null or undefined at N:N` | **REAL standalone gap** — see root cause below |
-| 527 | `dynamic eval is not supported in standalone mode` | wont-fix (deliberate) |
-| 400 | `Cannot convert undefined or null to object` | unexamined |
-| 137 | `Cannot access property on null or undefined` (no loc) | unexamined |
-| 235 | `Array.prototype.<m> is not yet callable as a value in --target standalone` (34 methods; `map` alone 117) | **SECONDARY — do not chase, see below** |
-| 111 | `Cannot read properties of undefined (reading a class field)` | unexamined |
-| 83 | `Object method called on null or undefined` (annexB 64) | unexamined |
-| 78 | `Object.defineProperties unsupported descriptor shape` | narrow, self-describing |
-| 51+43 | `Cannot destructure 'X' or 'X'` (+ async variant) | unexamined |
-| 37 | `Generator.prototype.next requires that 'X' be a Generator` | unexamined |
-| 31 | `Reduce of empty array with no initial value` | unexamined |
+| n     | signature                                                                                                 | verdict                                        |
+| ----- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| 1,128 | `TypeError: Cannot access property on null or undefined at N:N`                                           | **REAL standalone gap** — see root cause below |
+| 527   | `dynamic eval is not supported in standalone mode`                                                        | wont-fix (deliberate)                          |
+| 400   | `Cannot convert undefined or null to object`                                                              | unexamined                                     |
+| 137   | `Cannot access property on null or undefined` (no loc)                                                    | unexamined                                     |
+| 235   | `Array.prototype.<m> is not yet callable as a value in --target standalone` (34 methods; `map` alone 117) | **SECONDARY — do not chase, see below**        |
+| 111   | `Cannot read properties of undefined (reading a class field)`                                             | unexamined                                     |
+| 83    | `Object method called on null or undefined` (annexB 64)                                                   | unexamined                                     |
+| 78    | `Object.defineProperties unsupported descriptor shape`                                                    | narrow, self-describing                        |
+| 51+43 | `Cannot destructure 'X' or 'X'` (+ async variant)                                                         | unexamined                                     |
+| 37    | `Generator.prototype.next requires that 'X' be a Generator`                                               | unexamined                                     |
+| 31    | `Reduce of empty array with no initial value`                                                             | unexamined                                     |
 
 ### The distinction the lead asked for (spec-correct vs missing-builtin)
 
@@ -71,7 +71,7 @@ it is secondary: the call site is the real test262 harness
 
 ```js
 compareArray.format = function (arrayLike) {
-  return `[${Array.prototype.map.call(arrayLike, String).join(', ')}]`;
+  return `[${Array.prototype.map.call(arrayLike, String).join(", ")}]`;
 };
 ```
 
@@ -119,7 +119,7 @@ Why it hits 627 rows: the test262 runner's shim
 ### Verified probes (all in `.tmp/`, standalone lane)
 
 - `.tmp/t5.ts` — `[Int8Array, Uint8Array, Int32Array, Float64Array,
-  BigInt64Array, BigUint64Array]`: indices 0–3 non-null, **index 4 is `null`**
+BigInt64Array, BigUint64Array]`: indices 0–3 non-null, **index 4 is `null`**
   (returned 104). After the fix: returns 1 (all six non-null, and dynamic
   `new TA(4)` gives `.length === 4` for all six).
 - `.tmp/t3.ts` / `.tmp/t2.ts` — reproduce the exact harness shape
@@ -139,7 +139,7 @@ Why it hits 627 rows: the test262 runner's shim
 BigInt TypedArray corpus in the post-landing artifact: **pass 28 · fail 685 · CE 64**.
 Small pass surface ⇒ low regression risk, large upside. Note the 8 sampled
 passes include vacuous ones (e.g. `byteoffset-is-symbol-throws` —
-`assert.throws(TypeError, …)` is satisfied by *any* TypeError, including
+`assert.throws(TypeError, …)` is satisfied by _any_ TypeError, including
 "TA is null"), so a few of the 28 may honestly flip to fail; that must be
 measured, not assumed.
 
@@ -187,7 +187,7 @@ assertions keep failing honestly.
    `issue-3616-standalone-bigint-ta-ctor-value` is checked out; the three edits
    above are **in the working tree, uncommitted**. `git diff` to confirm.
 2. Re-claim if needed: `node scripts/claim-issue.mjs 3616
-   ttraenkler/<agent> --branch issue-3616-standalone-bigint-ta-ctor-value --force`.
+ttraenkler/<agent> --branch issue-3616-standalone-bigint-ta-ctor-value --force`.
 3. **The measurement that was interrupted** — this is the one thing that must
    finish before the PR: `npx tsx .tmp/batch.mts after.json` and diff against
    `.tmp/before.json`. BEFORE is already captured and matches CI exactly
@@ -207,7 +207,7 @@ assertions keep failing honestly.
 ## Unexamined, ranked, for whoever picks this lane up next
 
 1. **Temporal 213** rows inside the same `Cannot access property on null or
-   undefined` signature — likely the same "constructor/namespace is null as a
+undefined` signature — likely the same "constructor/namespace is null as a
    value" shape, different builtin. Cheapest next probe: repeat the `.tmp/t5.ts`
    pattern with `Temporal.*` names.
 2. **`Cannot convert undefined or null to object` (400)** — TypedArray 64,

--- a/plan/issues/3616-standalone-bigint-ta-ctor-value.md
+++ b/plan/issues/3616-standalone-bigint-ta-ctor-value.md
@@ -150,13 +150,81 @@ returns null even for the **non-BigInt** views, while
 the test262 harness uses the working shape, so the yield is low. File separately
 if anyone wants it.
 
-## Test Results
+## Test Results — measured, and WEAKER than the root cause implied
 
-Pending — the before/after batch measurement was interrupted by a capacity
-pause. BEFORE is captured (`.tmp/before.json`: 14 fail / 8 pass on the 22-test
-stride sample) and matches the CI artifact exactly, confirming the local harness
-is faithful. AFTER must be run before this PR opens; see
-`plan/agent-context/opus-typeerror-family.md` for the resume steps.
+22-test deterministic stride sample of the BigInt TypedArray corpus (14 drawn
+from the `fail` population, 8 from `pass`), standalone lane, single-threaded.
+BEFORE reproduced the CI artifact exactly (14 fail / 8 pass), so the local
+harness is faithful **for this cluster**.
+
+| | before | after |
+|---|---|---|
+| fail | 14 | 13 |
+| pass | 8 | 9 |
+
+**Gross +2 fixed, −1 regressed, net +1. 19 of 22 unchanged.**
+
+Fixed (both were `fail` → `pass`):
+
+- `TypedArrayConstructors/internals/GetOwnProperty/BigInt/key-is-not-canonical-index.js`
+- `TypedArrayConstructors/ctors-bigint/object-arg/undefined-newtarget-throws.js`
+
+Regressed (`pass` → `fail`):
+
+- `TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-fixed.js`
+
+### The honest reading
+
+The hit rate is **2 of 14 failing rows (14 %)**, not the near-total conversion
+the 627-row root cause suggested. The null constructor was **necessary but not
+sufficient**: most BigInt rows fail for further downstream reasons that surface
+only once the ctor is real. Naive extrapolation over the 685-row failing corpus
+gives roughly +98 gains and, at 1-in-8 of the 28 passes, roughly −3 to −4
+regressions — net positive but modest, and the confidence interval on 2/14 is
+very wide (~2 %–43 %).
+
+### The regression is NOT classifiable locally — this is the blocker
+
+`resizable-array-buffer-fixed.js` now throws at L16,
+`assert.sameValue(typeof ArrayBuffer.prototype.resize, "function")` — a
+**top-level** assertion that has nothing to do with BigInt constructors.
+Investigated rather than assumed:
+
+- A standalone probe of `typeof ArrayBuffer.prototype.resize` **throws on the
+  PRE-change compiler too** (`.tmp/t8.ts`, verified by reverting both source
+  files to `HEAD~2` and re-running). So the throwing read is **pre-existing**,
+  not introduced here.
+- The probes therefore do NOT reproduce the row's flip — the test module's
+  composition differs. The plausible mechanism is second-order: with a real
+  ctor the harness callback goes live, `ab.resize(...)` becomes reachable, and
+  the ArrayBuffer proto glue is registered differently, so the pre-existing
+  `resize` value-read gap becomes reachable. That would make the flip a
+  **consequence of de-vacuification** over a pre-existing defect — but this is
+  a hypothesis, not a verified finding, and it is not being recorded as one.
+- The payload is opaque locally: `tryNativeExnRender` returns null, so the row
+  reads as `uncaught Wasm-GC exception (non-stringifiable payload)` →
+  `classifyError` = `other`, `trapInnermostFrame` = **null (frameless)**.
+
+That last point is the blocker. Per `DEVACUIFICATION_ALLOW_KEY` in
+`scripts/diff-test262.ts`, a non-trap `pass → fail` flip is excusable under a
+declared ceiling alone — but **"a frameless trap message cannot be verified and
+is NOT excused."** The local renderer is the known-weak one (it is why the
+message is opaque at all); CI's `describeWasmError` may well classify this row
+into a trap category. If it does, and the frame is still unextractable, the row
+hard-fails the #3189 ratchet and **no declaration can excuse it**. I cannot
+settle that locally.
+
+### Consequence
+
+Not opening the PR on this evidence. Net +1 on n=22 with one flip I cannot
+classify is too thin a basis, and the failure mode if I am wrong is a wedged
+merge queue rather than a clean park. Awaiting a decision between (a) a larger
+sample (~60–80 rows, ~1 h single-threaded) to pin the gain/regression rates,
+or (b) landing it and treating the `merge_group` floor gate as the measurement,
+per the established `park = measurement` recipe
+(`reference_f1_honest_floor_deinflation_landing_recipe`). Option (b) would need
+a `standalone-devacuification-allow` ceiling declared in this frontmatter with
+the 1-in-8 sampled basis above.
 
 ## Source
 

--- a/plan/issues/3616-standalone-bigint-ta-ctor-value.md
+++ b/plan/issues/3616-standalone-bigint-ta-ctor-value.md
@@ -1,0 +1,164 @@
+---
+id: 3616
+title: "standalone: BigInt64Array / BigUint64Array are null in VALUE position — 627 type_error rows"
+status: in-progress
+assignee: ttraenkler/opus-typeerror-lane
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: multi
+language_feature: typedarray
+goal: standalone
+umbrella: 2860
+sprint: current
+horizon: m
+related: [2401, 838, 3054, 3087, 3177, 1349]
+origin: "opus-typeerror-lane triage of the post-#3592 standalone type_error family (3,038 rows), 2026-07-25"
+# loc-budget-allow (#3616): src/codegen/dataview-native.ts +25. This file OWNS
+# the runtime-kind TypedArray dispatch (TA_VIEW_DECODE, emitDynDecodeDispatch,
+# emitDynEncodeDispatch, emitTaCtorValue). The change is two table rows plus the
+# int64 flag threaded through the two dispatch builders — an in-place extension
+# of this subsystem's own per-kind tables, exactly the shape #3177 was granted.
+# Splitting two Record rows into a new module would leave the dispatch loop
+# reading its descriptors from somewhere other than the table it iterates.
+loc-budget-allow:
+  - src/codegen/dataview-native.ts
+---
+
+# #3616 — standalone: BigInt TypedArray constructors are `null` in VALUE position
+
+## Problem
+
+Under `--target standalone`, `BigInt64Array` and `BigUint64Array` used in
+**value position** (not `new X()`, not type position) evaluate to
+`ref.null.extern`. Direct construction already works — #838 landed the native
+i64-element vec, so `new BigInt64Array(4).length === 4` — but
+
+```ts
+const ctors: any[] = [BigInt64Array, BigUint64Array]; // → [null, null]
+const TA = ctors[0];
+const s = new TA(4); // → null
+s.length; // TypeError: Cannot access property on null or undefined
+```
+
+### Root cause
+
+`src/codegen/expressions/identifiers.ts:1220` gates the first-class
+`$__ta_ctor` value emission on `taCtorKindOf(name) >= 0`. `taCtorKindOf`
+(`src/codegen/registry/types.ts`) indexes `TA_CTOR_KINDS`, which listed only the
+**9 non-BigInt** views. Both BigInt names therefore missed the gate and fell
+through to the `reportSilentFallback("const-fallback",
+"identifiers:unimplemented-global-default")` default at line 1248, which emits
+`ref.null.extern`.
+
+The host/gc lane was already fixed by **#3087** — `identifiers.ts:834-862`
+routes the same two names through `__extern_get(globalThis, name)`, and its
+comment says outright *"Covers the BigInt views too (not in the standalone
+`taCtorKindOf` list). Standalone/WASI keeps the native `$__ta_ctor` value
+below"*. The native path never grew the BigInt kinds, so only the host-free lane
+was left behind.
+
+This is a **third residual of #2401**, distinct from the two already recorded
+there (its (a) `BUILTIN_TYPES` method routing and (b) unsigned i64 semantics).
+
+### Why it costs 627 tests
+
+The test262 runner's BigInt harness shim (`tests/test262-runner.ts:2157`) is
+
+```ts
+function testWithBigIntTypedArrayConstructors(fn: any): void {
+  const constructors = [BigInt64Array, BigUint64Array];
+  for (let i = 0; i < constructors.length; i++) fn(constructors[i], __ta_makeCtorArgBigIntCompat);
+}
+```
+
+so `TA` is `null` in every callback, `new TA(...)` yields null, and the reported
+failure is whatever member the test touches next. 627 of the 1,128 standalone
+`TypeError: Cannot access property on null or undefined at N:N` rows sit under
+BigInt TypedArray paths. Corpus size in the post-#3592 merged standalone
+artifact: **pass 28 · fail 685 · compile_error 64**.
+
+## Scope
+
+Structure only. Element **values** in a dynamically-constructed BigInt view stay
+on the f64 carrier the rest of the dyn-view substrate uses, NOT i64-branded
+BigInts — that representation split is #1349 / #2401(b) and is deliberately out
+of scope. This issue buys the non-null identity-stable constructor, the correct
+8-byte element width, and working `length` / `byteLength` / MOP, which is what
+the harness rows actually gate on. Content assertions keep failing honestly.
+
+## Fix
+
+1. `src/codegen/registry/types.ts` — **append** (never insert) `BigInt64Array`,
+   `BigUint64Array` to `TA_CTOR_KINDS` as kinds 9/10, and `8, 8` to
+   `TA_CTOR_BYTES`. Appending is load-bearing: the `kind` index is baked into
+   the `$__ta_ctor` singleton globals and into every `if`-chain arm of the
+   decode / encode / `BYTES_PER_ELEMENT` dispatches, so an insertion would
+   silently repoint every existing kind.
+2. `src/codegen/dataview-native.ts` — two `TA_VIEW_DECODE` rows with
+   `bytes: 8, float: false, int64: true` (signed / unsigned). The `int64` flag
+   is required: without it an 8-byte non-float read takes the
+   `f64.reinterpret_i64` path, which is correct for `Float64Array` and garbage
+   for an integer view. The rows are **inert for the static lane** —
+   `taViewDecode` resolves names via `getTaViewName` over `ctx.taViewTypeMap`,
+   and #838 gave the BigInt views a native i64 vec rather than a
+   `$__ta_view_<name>`, so no static BigInt view type is ever registered.
+3. Same file — `emitDynDecodeDispatch` / `emitDynEncodeDispatch` thread
+   `int64: desc.int64` into `emitReadBytes` / `emitWriteBytes`; the decode arm
+   appends `f64.convert_i64_s` / `_u` after the read. Necessary because
+   `emitReadBytes` deliberately LEAVES the i64 on the stack for an `int64`
+   accessor (that is the DataView `getBigInt64` BigInt carrier), while every arm
+   of this dispatch's `if` is typed `f64` — the BigInt arms must converge to the
+   same carrier. Convert, not reinterpret.
+
+`f64.convert_i64_s` / `_u` are already in the `Instr` union
+(`src/ir/types.ts:258-259`); no union extension needed.
+
+## Acceptance criteria
+
+- Standalone: `[BigInt64Array, BigUint64Array]` contains two distinct non-null
+  values; `BigInt64Array === BigInt64Array` (singleton identity holds via the
+  `$__ta_ctor` per-kind global, as #3177 established for the other 9).
+- Standalone: `const TA = ctors[i]; new TA(4)` is non-null with `.length === 4`
+  and `TA.BYTES_PER_ELEMENT === 8` for both BigInt views.
+- Measured before/after count on a stride sample of the BigInt TypedArray
+  corpus, net positive, recorded below.
+- JS-host lane byte-neutral (the change is gated behind the standalone-only
+  `emitTaCtorValue` path; the host lane keeps #3087's `__extern_get` route).
+
+## Verification probes
+
+Standalone lane, via `.tmp/p1.mts` (note `compile()` is async):
+
+- `.tmp/t5.ts` — six ctor names in an array. **Before: returns 104**
+  (`names[4]`, i.e. `BigInt64Array`, is `null`). **After: returns 1** — all six
+  non-null and dynamic `new TA(4)` gives `.length === 4` for each.
+- `.tmp/t2.ts` / `.tmp/t3.ts` — reproduce the exact harness shape; returned 21
+  ("sample is null") before the fix.
+- `.tmp/t1.ts` — direct `new BigInt64Array(4)` already worked before the fix,
+  isolating the defect to the VALUE-position path.
+
+## Adjacent finding (NOT this issue)
+
+`new names[i](4)` — `new` applied directly to an element-access callee —
+returns null even for the **non-BigInt** views, while
+`const TA = names[i]; new TA(4)` works (`.tmp/t6.ts`). Separate, narrower gap;
+the test262 harness uses the working shape, so the yield is low. File separately
+if anyone wants it.
+
+## Test Results
+
+Pending — the before/after batch measurement was interrupted by a capacity
+pause. BEFORE is captured (`.tmp/before.json`: 14 fail / 8 pass on the 22-test
+stride sample) and matches the CI artifact exactly, confirming the local harness
+is faithful. AFTER must be run before this PR opens; see
+`plan/agent-context/opus-typeerror-family.md` for the resume steps.
+
+## Source
+
+`opus-typeerror-lane` triage of the post-#3592 standalone `type_error` family
+(3,038 rows), 2026-07-25.

--- a/plan/issues/3616-standalone-bigint-ta-ctor-value.md
+++ b/plan/issues/3616-standalone-bigint-ta-ctor-value.md
@@ -27,6 +27,30 @@ origin: "opus-typeerror-lane triage of the post-#3592 standalone type_error fami
 # reading its descriptors from somewhere other than the table it iterates.
 loc-budget-allow:
   - src/codegen/dataview-native.ts
+standalone-devacuification-allow:
+  count: 30
+  reason: "#3616: making BigInt64Array/BigUint64Array real VALUES in standalone
+    de-vacuifies the test262 `testWithBigIntTypedArrayConstructors` harness. Its
+    callbacks previously received a null TA, so `new TA(...)` was null and every
+    callback body was dead — the row passed without asserting anything. With a
+    real ctor the bodies execute and pre-existing downstream defects surface as
+    ordinary honest assertion failures. Measured basis: a 22-row deterministic
+    stride sample of the BigInt TypedArray corpus (14 baseline-fail + 8
+    baseline-pass) gave 2 fail->pass gains and 1 pass->fail flip, i.e. 1 of 8
+    sampled baseline-passes (12.5%); the corpus holds 28 baseline passes, so the
+    point estimate is ~4 flips. The sole observed flip
+    (TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-fixed.js) was
+    verified through the CI-equivalent path (assembleOriginalHarness ->
+    CompilerPool('unified') -> test262-worker.mjs) and is category
+    `assertion_fail` — NOT a trap category — reading `Test262Error: following
+    shrink (out of bounds) Expected SameValue(«16», «0») to be true`, i.e. a
+    genuine pre-existing byteLength-after-out-of-bounds-resize defect the vacuous
+    pass never reached. No `tests:` list is needed because no pass->trap flip was
+    observed; any trap flip remains unexcused and still hard-fails #3189. The
+    ceiling of 30 covers the wide binomial interval on n=8 (upper bound ~15 over
+    the 28-pass BigInt corpus) plus margin for the two extra
+    ensureTypedArrayViewNativeProtoGlue registrations now performed by the
+    TA_CTOR_KINDS-driven loops in any module carrying a dynamic TA view."
 ---
 
 # #3616 — standalone: BigInt TypedArray constructors are `null` in VALUE position
@@ -57,9 +81,9 @@ through to the `reportSilentFallback("const-fallback",
 
 The host/gc lane was already fixed by **#3087** — `identifiers.ts:834-862`
 routes the same two names through `__extern_get(globalThis, name)`, and its
-comment says outright *"Covers the BigInt views too (not in the standalone
+comment says outright _"Covers the BigInt views too (not in the standalone
 `taCtorKindOf` list). Standalone/WASI keeps the native `$__ta_ctor` value
-below"*. The native path never grew the BigInt kinds, so only the host-free lane
+below"_. The native path never grew the BigInt kinds, so only the host-free lane
 was left behind.
 
 This is a **third residual of #2401**, distinct from the two already recorded
@@ -157,10 +181,10 @@ from the `fail` population, 8 from `pass`), standalone lane, single-threaded.
 BEFORE reproduced the CI artifact exactly (14 fail / 8 pass), so the local
 harness is faithful **for this cluster**.
 
-| | before | after |
-|---|---|---|
-| fail | 14 | 13 |
-| pass | 8 | 9 |
+|      | before | after |
+| ---- | ------ | ----- |
+| fail | 14     | 13    |
+| pass | 8      | 9     |
 
 **Gross +2 fixed, −1 regressed, net +1. 19 of 22 unchanged.**
 
@@ -183,7 +207,58 @@ gives roughly +98 gains and, at 1-in-8 of the 28 passes, roughly −3 to −4
 regressions — net positive but modest, and the confidence interval on 2/14 is
 very wide (~2 %–43 %).
 
-### The regression is NOT classifiable locally — this is the blocker
+### Do NOT read 627 as a forecast
+
+The 627-row cluster identified in "Why it costs 627 tests" is the population
+that _shares this root cause_, **not** the number of rows this fix converts.
+At a 14 % sampled hit rate the expected conversion is on the order of ~100.
+The null constructor is the FIRST rung of a ladder: removing it lets each row
+proceed to whatever defect sits behind it, and for ~6 of 7 rows that next defect
+is still fatal. Anyone planning follow-up work should treat the remaining BigInt
+corpus as a stack of distinct downstream defects needing their own triage, not
+as residue of this one.
+
+### The regression, resolved: an honest de-vacuification (CONFIRMED)
+
+Initially unclassifiable locally, and recorded here as an open question rather
+than a guess. It is now settled by re-running the row through the
+**CI-equivalent path** (`assembleOriginalHarness` → `CompilerPool(1, "unified")`
+→ `scripts/test262-worker.mjs`, harness `.tmp/run-pool.mts`):
+
+```
+status   : fail
+error    : Test262Error: following shrink (out of bounds) Expected SameValue(«16», «0») to be true
+category : assertion_fail
+frame    : null
+dispIntro: false
+```
+
+Three conclusions:
+
+1. **The earlier "frameless / `other`" reading was a `runTest262File` artifact,
+   not a property of the row.** That runner does not use `tryNativeExnRender`,
+   so the payload rendered as `uncaught Wasm-GC exception (non-stringifiable
+payload)` and mis-classified as `other`. The CI path renders the real
+   `Test262Error`.
+2. **The `at L16` attribution was also an artifact.** The real failure is deep
+   in the harness callback (`assert.sameValue(array.byteLength, expected,
+"following shrink (out of bounds)")`), not at the top-level
+   `typeof ArrayBuffer.prototype.resize` assertion. This **confirms** the
+   previously-hypothesised second-order mechanism: with a real ctor the callback
+   goes live and a pre-existing `byteLength`-after-out-of-bounds-resize defect
+   surfaces. The row was a **vacuous pass** — TA was null, so the entire callback
+   body was dead and nothing was asserted.
+3. **`assertion_fail` is not in `TRAP_ERROR_CATEGORIES`**
+   (`["null_deref", "illegal_cast", "oob", "unreachable"]`, `scripts/diff-test262.ts:246`),
+   so `isDevacuificationExcusableFlip` returns true under the declared ceiling
+   alone — the frame check applies only to trap-tier rows and is irrelevant
+   here. The #3189 trap ratchet never engages.
+
+The `standalone-devacuification-allow` ceiling declared in this file's
+frontmatter covers it. No `tests:` list is required (that is the trap tier); a
+pass→trap flip would still be unexcused and would still hard-fail #3189.
+
+### Superseded: why this was briefly blocked
 
 `resizable-array-buffer-fixed.js` now throws at L16,
 `assert.sameValue(typeof ArrayBuffer.prototype.resize, "function")` — a
@@ -216,15 +291,19 @@ settle that locally.
 
 ### Consequence
 
-Not opening the PR on this evidence. Net +1 on n=22 with one flip I cannot
-classify is too thin a basis, and the failure mode if I am wrong is a wedged
-merge queue rather than a clean park. Awaiting a decision between (a) a larger
-sample (~60–80 rows, ~1 h single-threaded) to pin the gain/regression rates,
-or (b) landing it and treating the `merge_group` floor gate as the measurement,
-per the established `park = measurement` recipe
-(`reference_f1_honest_floor_deinflation_landing_recipe`). Option (b) would need
-a `standalone-devacuification-allow` ceiling declared in this frontmatter with
-the 1-in-8 sampled basis above.
+Resolved — landing with the declared ceiling. The `merge_group` standalone floor
+gate is the authoritative measurement of the real gain/regression counts; the
+local sample's job was only to establish direction and to classify the flip
+tier, and it has done both.
+
+**Lesson worth keeping:** `runTest262File` is not the CI path and must not be
+used to classify a standalone failure's _category_ or _location_ — only its
+pass/fail status is trustworthy. Classification questions go through
+`assembleOriginalHarness` → `CompilerPool(n, "unified")` →
+`scripts/test262-worker.mjs` (see `.tmp/run-pool.mts`; it needs
+`scripts/compiler-bundle.mjs` + `scripts/runtime-bundle.mjs`, both gitignored,
+built with the two `esbuild` commands recorded in the assertion_fail lane's
+context dump).
 
 ## Source
 

--- a/plan/issues/3616-standalone-bigint-ta-ctor-value.md
+++ b/plan/issues/3616-standalone-bigint-ta-ctor-value.md
@@ -1,10 +1,11 @@
 ---
 id: 3616
 title: "standalone: BigInt64Array / BigUint64Array are null in VALUE position — 627 type_error rows"
-status: in-progress
+status: done
 assignee: ttraenkler/opus-typeerror-lane
 created: 2026-07-25
 updated: 2026-07-25
+completed: 2026-07-25
 priority: high
 feasibility: medium
 reasoning_effort: high

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -2063,7 +2063,10 @@ function emitWriteBytes(
 // ---------------------------------------------------------------------------
 
 /** Per-view-name byte-decode descriptor (width, signedness, float, clamp-on-write). */
-const TA_VIEW_DECODE: Record<string, { bytes: number; signed: boolean; float: boolean; clamp: boolean }> = {
+const TA_VIEW_DECODE: Record<
+  string,
+  { bytes: number; signed: boolean; float: boolean; clamp: boolean; int64?: boolean }
+> = {
   Int8Array: { bytes: 1, signed: true, float: false, clamp: false },
   Uint8Array: { bytes: 1, signed: false, float: false, clamp: false },
   Uint8ClampedArray: { bytes: 1, signed: false, float: false, clamp: true },
@@ -2073,6 +2076,18 @@ const TA_VIEW_DECODE: Record<string, { bytes: number; signed: boolean; float: bo
   Uint32Array: { bytes: 4, signed: false, float: false, clamp: false },
   Float32Array: { bytes: 4, signed: false, float: true, clamp: false },
   Float64Array: { bytes: 8, signed: false, float: true, clamp: false },
+  // (#3613) The two BigInt views. 8-byte INTEGER elements (`int64`), NOT the
+  // bit-reinterpreted doubles `Float64Array` uses — without the flag an 8-byte
+  // non-float read would `f64.reinterpret_i64` the integer bit pattern and read
+  // back garbage. These entries exist ONLY to serve the runtime-kind dynamic
+  // dispatch (`emitDynDecodeDispatch` / `emitDynEncodeDispatch`, both driven by
+  // `TA_CTOR_KINDS`); the STATIC per-view path resolves names through
+  // `getTaViewName` over `ctx.taViewTypeMap`, and #838 gave the BigInt views a
+  // native i64-element vec instead of a `$__ta_view_<name>`, so no static
+  // `$__ta_view_BigInt64Array` is ever registered and `taViewDecode` cannot
+  // reach these rows. Adding them is therefore inert for the static lane.
+  BigInt64Array: { bytes: 8, signed: true, float: false, clamp: false, int64: true },
+  BigUint64Array: { bytes: 8, signed: false, float: false, clamp: false, int64: true },
 };
 
 /** Resolve a `$__ta_view` typeIdx to its byte-decode descriptor, or undefined. */
@@ -2448,12 +2463,22 @@ export function emitDynDecodeDispatch(
     emitReadBytes(
       ctx,
       fctx,
-      { kind: "get", bytes: desc.bytes, signed: desc.signed, float: desc.float },
+      { kind: "get", bytes: desc.bytes, signed: desc.signed, float: desc.float, int64: desc.int64 },
       arrLocal,
       offLocal,
       leLocal,
       arrTypeIdx,
     );
+    if (desc.int64) {
+      // (#3613) `emitReadBytes` deliberately LEAVES the i64 on the stack for an
+      // `int64` accessor (the DataView getBigInt64 result is the i64-branded
+      // BigInt carrier). This dispatch's `if` arms are all typed `f64`, so the
+      // BigInt arms must converge to the same carrier — convert rather than
+      // reinterpret. Exact for |v| < 2^53, the range the conformance corpus's
+      // small BigInt literals occupy; the true i64 element representation is
+      // #1349/#2401(b).
+      fctx.body.push({ op: desc.signed ? "f64.convert_i64_s" : "f64.convert_i64_u" });
+    }
     fctx.body = saved;
     chain = [
       { op: "local.get", index: kindLocal },
@@ -2507,7 +2532,7 @@ export function emitDynEncodeDispatch(
     emitWriteBytes(
       ctx,
       fctx,
-      { kind: "set", bytes: desc.bytes, signed: desc.signed, float: desc.float },
+      { kind: "set", bytes: desc.bytes, signed: desc.signed, float: desc.float, int64: desc.int64 },
       arrLocal,
       offLocal,
       valForWrite,

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -334,8 +334,27 @@ export function getTaViewName(ctx: CodegenContext, typeIdx: number): string | un
  * (#3054 D) Canonical ordered list of TypedArray element kinds a first-class
  * `$__ta_ctor` value can name. The array INDEX is the runtime `kind` stored in the
  * struct; every dynamic-construct / `BYTES_PER_ELEMENT` dispatch iterates this list
- * so the ordering is the single source of truth. BigInt64/Float16 views are omitted
+ * so the ordering is the single source of truth. Float16 views are omitted
  * (unsupported elsewhere in the standalone lane).
+ *
+ * (#3613) The two BigInt views are APPENDED at kinds 9/10 — never inserted — so
+ * every already-emitted `kind` constant (baked into the `$__ta_ctor` singleton
+ * globals and into the `if`-chain arms of the decode/encode/BYTES dispatches)
+ * keeps its value. Before this they were absent, so a bare `BigInt64Array` /
+ * `BigUint64Array` in VALUE position fell through `emitTaCtorValue` to the
+ * `ref.null.extern` unimplemented-global default in identifiers.ts — i.e.
+ * `[BigInt64Array, BigUint64Array]` was `[null, null]` and the test262
+ * `testWithBigIntTypedArrayConstructors` harness's `new TA(...)` produced null
+ * for every BigInt row. The host/gc lane had already been fixed (#3087 routes
+ * the same two names through `__extern_get(globalThis, name)`); only the
+ * host-free lane was left behind.
+ *
+ * Element VALUES in a dynamically-constructed BigInt view are still the f64
+ * carrier the rest of the dyn-view substrate uses, NOT i64-branded BigInts —
+ * that representation split is #1349/#2401(b) and deliberately out of scope
+ * here. This entry buys the STRUCTURE (non-null identity-stable ctor, correct
+ * 8-byte element width, working length/byteLength/MOP), which is what the
+ * harness rows actually gate on.
  */
 export const TA_CTOR_KINDS: readonly string[] = [
   "Int8Array",
@@ -347,10 +366,12 @@ export const TA_CTOR_KINDS: readonly string[] = [
   "Uint32Array",
   "Float32Array",
   "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
 ];
 
 /** (#3054 D) Element byte width per `TA_CTOR_KINDS` entry (BYTES_PER_ELEMENT). */
-export const TA_CTOR_BYTES: readonly number[] = [1, 1, 1, 2, 2, 4, 4, 4, 8];
+export const TA_CTOR_BYTES: readonly number[] = [1, 1, 1, 2, 2, 4, 4, 4, 8, 8, 8];
 
 /** (#3054 D) The `kind` index for a TS TypedArray name, or -1 if not a first-class TA ctor. */
 export function taCtorKindOf(name: string): number {


### PR DESCRIPTION
## Problem

Under `--target standalone`, `BigInt64Array` / `BigUint64Array` used in **value
position** evaluate to `ref.null.extern`. Direct construction already works
(#838 landed the native i64-element vec), but:

```ts
const ctors: any[] = [BigInt64Array, BigUint64Array]; // → [null, null]
const TA = ctors[0];
new TA(4); // → null  ⇒ TypeError: Cannot access property on null or undefined
```

## Root cause

`src/codegen/expressions/identifiers.ts:1220` gates the first-class `$__ta_ctor`
value on `taCtorKindOf(name) >= 0`. `taCtorKindOf` indexes `TA_CTOR_KINDS`,
which listed only the **9 non-BigInt** views — so both BigInt names missed the
gate and fell through to the `identifiers:unimplemented-global-default` at line
1248.

The host/gc lane was already fixed by **#3087**; its comment says outright
*"Covers the BigInt views too (not in the standalone `taCtorKindOf` list).
Standalone/WASI keeps the native `$__ta_ctor` value below"* — but the native
path never grew the BigInt kinds. Only the host-free lane was left behind. This
is a third residual of **#2401**, distinct from the two recorded there.

It matters because the test262 BigInt harness shim is
`const constructors = [BigInt64Array, BigUint64Array]; … fn(constructors[i], …)`,
so `TA` was null in **every** `testWithBigIntTypedArrayConstructors` callback.
627 of the 1,128 standalone `Cannot access property on null or undefined` rows
sit under BigInt TypedArray paths.

## Fix (3 edits, 2 files)

1. `registry/types.ts` — **append** (never insert) the two names to
   `TA_CTOR_KINDS` as kinds 9/10 and `8, 8` to `TA_CTOR_BYTES`. Appending is
   load-bearing: the `kind` index is baked into the `$__ta_ctor` singleton
   globals and every `if`-chain arm of the decode/encode/BYTES dispatches.
2. `dataview-native.ts` — two `TA_VIEW_DECODE` rows with
   `bytes: 8, float: false, int64: true`. Without `int64` an 8-byte non-float
   read takes `f64.reinterpret_i64` — correct for `Float64Array`, garbage for an
   integer view. Inert for the static lane (no `$__ta_view_BigInt64Array` is
   ever registered; #838 gave these views an i64 vec instead).
3. Same file — thread `int64` into the two dyn dispatch builders and append
   `f64.convert_i64_s`/`_u` after the read, because `emitReadBytes` deliberately
   leaves the i64 on the stack for an `int64` accessor while every arm of that
   dispatch's `if` is typed `f64`. **Convert, not reinterpret.**

**Scope:** structure only. Element *values* stay on the f64 carrier, NOT
i64-branded BigInts — that split is #1349/#2401(b) and deliberately out of
scope. This buys the non-null identity-stable ctor, correct 8-byte width, and
working `length`/`byteLength`/MOP, which is what the harness rows gate on.

## Measured

22-row deterministic stride sample of the BigInt TypedArray corpus
(14 baseline-fail + 8 baseline-pass), standalone, single-threaded. BEFORE
reproduced the CI artifact exactly (14 fail / 8 pass).

| | before | after |
|---|---|---|
| fail | 14 | 13 |
| pass | 8 | 9 |

**Gross +2 fixed, −1 flipped, net +1.** 19 of 22 unchanged.

### Read 627 as a population, not a forecast

The hit rate is **2 of 14 failing rows (14 %)**. The null ctor was **necessary
but not sufficient** — most BigInt rows fail for further downstream reasons that
only surface once the ctor is real. Expected conversion is on the order of ~100,
not 627. The remaining corpus is a stack of distinct downstream defects needing
their own triage.

### The one flip is an honest de-vacuification (verified, not assumed)

`TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-fixed.js`.
Re-run through the **CI-equivalent path** (`assembleOriginalHarness` →
`CompilerPool(1, "unified")` → `test262-worker.mjs`):

```
status   : fail
error    : Test262Error: following shrink (out of bounds) Expected SameValue(«16», «0») to be true
category : assertion_fail
```

The row was a **vacuous pass** — TA was null, so the whole callback body was
dead and nothing was asserted. With a real ctor the body runs and a pre-existing
`byteLength`-after-out-of-bounds-resize defect surfaces honestly.
`assertion_fail` is **not** in `TRAP_ERROR_CATEGORIES`, so the #3189 trap ratchet
does not engage and the declared ceiling covers it. No `tests:` list is needed
(that is the trap tier); any pass→trap flip remains unexcused.

Declared in the issue frontmatter: `standalone-devacuification-allow: count: 30`
(point estimate ~4 from 1-of-8 sampled passes over a 28-pass corpus; 30 covers
the wide binomial interval plus margin for the two extra
`ensureTypedArrayViewNativeProtoGlue` registrations).

**Worth recording:** `runTest262File` is NOT the CI path — it skips
`tryNativeExnRender`, so it reported this row as a frameless
`uncaught Wasm-GC exception (non-stringifiable payload)` / category `other`, and
misattributed the line. Only pass/fail status from that runner is trustworthy;
classification must go through the pool path.

## Verification

- `[Int8Array, …, BigInt64Array, BigUint64Array]`: index 4 was `null` before,
  all six non-null after, and `new TA(4)` gives `.length === 4` for each.
- Direct `new BigInt64Array(4)` already worked before the fix — isolating the
  defect to the value-position path.
- JS-host lane untouched: the change sits behind the standalone-only
  `emitTaCtorValue` path; host keeps #3087's `__extern_get` route.

Issue: `plan/issues/3616-standalone-bigint-ta-ctor-value.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
