### PR TITLE
chore(hooks): stop notifying on the contentless "waiting for your input"

### DIFF
--- a/.claude/hooks/notify-gate.sh
+++ b/.claude/hooks/notify-gate.sh
@@ -49,6 +49,18 @@ if printf '%s' "$MSG" | grep -qiE '(idle_notification|is idle|idleReason|waiting
   exit 0
 fi
 
+# Suppress the CONTENTLESS turn-end prompt (user request, 2026-07-25).
+# "Claude is waiting for your input" fires every time a turn ends with no
+# question pending. It carries zero information — the user cannot tell from it
+# whether anything is actually needed, so it trains them to ignore the channel.
+# Real asks still get through, because they carry their own text:
+#   - permission prompts name the tool ("needs your permission to use Bash")
+#   - anything sent via the PushNotification tool carries an explicit message
+# So gate on CONTENT, not on the fact that a turn ended.
+if printf '%s' "$MSG" | grep -qiE 'waiting for (your|user) input|is waiting for input|awaiting (your )?input'; then
+  exit 0
+fi
+
 # Suppress all agent chatter when a ci-pending sentinel exists.
 # Tech lead sets this with: touch ~/.claude/ci-pending
 # Clear it with: rm -f ~/.claude/ci-pending


### PR DESCRIPTION
## Problem

The ntfy channel was dominated by **"Claude is waiting for your input"**, which fires on every turn end regardless of whether anything is actually needed.

It carries no information — you cannot tell from it whether a decision is required. So it trains the reader to ignore the channel, and then the notification that *does* matter gets missed. User-reported.

## Change

Gate on **content**, not on the fact that a turn ended. One suppression rule for the contentless prompt, sitting alongside the existing idle / CI-wait suppression (which is unchanged).

Real asks still get through, because they carry their own text:

- permission prompts name the tool (`needs your permission to use Bash`)
- anything sent via the `PushNotification` tool carries an explicit message
- anything containing an actual question or result

## Verification

Matched the new pattern against real message shapes:

| Message | Result |
|---|---|
| `Claude is waiting for your input` | **suppressed** |
| `Claude is waiting for input` | **suppressed** |
| `Claude needs your permission to use Bash` | delivered |
| `de-inflation A/B finished: 4,812 flips, 0 invalid-Wasm` | delivered |
| `Which option do you want: land now or wait?` | delivered |

`bash -n` clean.

## Note for future edits to this hook

`NTFY_URL=disabled` exits at the top of the script, **before any matching logic** — so it cannot be used to test the filters. It will make every test look like it passed. Test the regex directly instead. (I caught myself running exactly that meaningless test.)
