### PR TITLE
docs(#3628): attribute the ≤ES3 gap — 41 of 43 host failures are one defect

### DIFF
--- a/plan/issues/2899-es3-function-caller-poison-pill-set.md
+++ b/plan/issues/2899-es3-function-caller-poison-pill-set.md
@@ -1,10 +1,10 @@
 ---
 id: 2899
 title: "≤ES3: Function `.caller` poison-pill must throw TypeError on set (`bound.caller = {}`)"
-status: done
+status: ready
 completed: 2026-06-30
 priority: high
-sprint: 69
+sprint: current
 created: 2026-06-30
 feasibility: medium
 task_type: bug
@@ -20,21 +20,26 @@ related: [2897]
 One of the **8 tests blocking 100% ≤ES3 conformance**.
 
 ## Failing test
+
 `test/language/statements/function/13.2-30-s.js`
 
 → **`returned 5 — assert #4 at L22: assert.throws(TypeError, function() { bound.caller = {}; })`** — assigning to `.caller` should throw `TypeError`, but doesn't.
 
 ## What it checks
+
 `Function.prototype.caller` / `Function.prototype.arguments` are "poison-pill" accessor properties: their `[[Get]]`/`[[Set]]` throw a `TypeError` (especially on a bound/strict function). `bound.caller = {}` must throw. We currently allow the assignment (the property isn't a throwing accessor).
 
 ## Root-cause direction
+
 The function-object property model needs `caller`/`arguments` realized as poison-pill accessors (throwing getter+setter) on the relevant functions (bound functions, strict functions). Look at how function objects expose `caller`/`arguments` and the assignment path for those keys. (Technically an ES5-strict semantic that the edition heuristic buckets as ≤ES3.)
 
 ## Acceptance
+
 - `bound.caller = {}` (and `.arguments` set/get) throw `TypeError`; the test passes.
 - No regression in normal function-property tests.
 
 ## Resolution (2026-06-30)
+
 Already fixed on `main` when re-verified against the live tree — the filed
 baseline was stale. `test/language/statements/function/13.2-30-s.js` returns
 `status: pass` via `runTest262File` (and the runner was sanity-checked to
@@ -57,9 +62,41 @@ get/set arms each throw `TypeError`, bound functions have no own
 unaffected, plus an end-to-end `runTest262File` check (skipped when the
 test262 submodule isn't present). No compiler-source change was required.
 
-Note (out of scope for #2899): a *narrow, separate* quirk surfaced while
+Note (out of scope for #2899): a _narrow, separate_ quirk surfaced while
 probing — reading `bound.caller` inside a nested `(fn: any)` callback that
 captures a **module-level** `bound` returns `null` instead of throwing
-(the production test262 wrapper declares `bound` *local* to `test()` with a
+(the production test262 wrapper declares `bound` _local_ to `test()` with a
 `() => void` callback, so it is unaffected and the conformance test passes).
 Flagged to the lead as a possible follow-up; does not block this issue.
+
+## REOPENED 2026-07-25 — still failing on current main
+
+Marked `done` on 2026-06-30, but the target test **still fails today**. Reopened
+(`status: ready`, `sprint: current`); the `completed:` date is left in place as
+history rather than deleted.
+
+Measured against a **force-fetched** baseline (`fetch-baseline-jsonl.mjs --force`
+— the bare command is a silent no-op, see #3629):
+
+```
+test/language/statements/function/13.2-30-s.js
+  status : fail
+  category: other
+  error  : Expected a TypeError to be thrown but no exception was thrown at all
+```
+
+**Contributes to #3628 (close the ≤ES3 edition).** This is 1 of only 3 issues
+standing between the host lane and a fully-closed ≤ES3 edition — currently
+230/273 (84.2 %), with 41 of the 43 failures owned by #3486.
+
+### What to determine first
+
+The failure is _"no exception was thrown at all"_, so before re-implementing:
+establish whether the original fix **regressed**, was **never effective for this
+test**, or the test fails for a **different reason** than the one this issue
+describes. A `done` issue whose test still fails is a false-done until proven
+otherwise, and the three cases have different remedies.
+
+Check the CI path (`assembleOriginalHarness` → `CompilerPool(n,"unified")` →
+`scripts/test262-worker.mjs`) rather than `runTest262File` — the latter's error
+**category and location are both unreliable** (only pass/fail is trustworthy).

--- a/plan/issues/2900-es3-module-indirect-default-binding-update.md
+++ b/plan/issues/2900-es3-module-indirect-default-binding-update.md
@@ -1,9 +1,9 @@
 ---
 id: 2900
 title: "≤ES3 (edition bucket): module indirect default-export binding update returns wrong value"
-status: done
+status: ready
 priority: high
-sprint: 69
+sprint: current
 created: 2026-06-30
 completed: 2026-07-02
 feasibility: hard
@@ -182,3 +182,39 @@ Split into three issues (each independently valuable and testable):
 live-binding still fail). Repro scripts used for this analysis are ephemeral
 (`.tmp/`); the key controls are the `.ts`-fixture probes above (no `.js`/allowJs
 needed to reproduce RC2 and RC3).
+
+## REOPENED 2026-07-25 — still failing, and the failure mode has CHANGED
+
+Marked `done` on 2026-07-02, but the target test **still fails today** — with an
+error that does not match this issue's description. Reopened (`status: ready`,
+`sprint: current`); `completed:` left as history.
+
+Measured against a **force-fetched** baseline (`--force`; the bare command is a
+silent no-op, see #3629):
+
+```
+test/language/module-code/eval-gtbndng-indirect-update-dflt.js
+  status : fail
+  category: type_error
+  error  : TypeError: sameValue is not a function
+```
+
+**Contributes to #3628 (close the ≤ES3 edition)** — 1 of only 3 issues between
+the host lane and a closed ≤ES3 edition (currently 230/273, 84.2 %).
+
+### The error suggests this is no longer a module-binding bug
+
+`sameValue is not a function` means the **harness's `assert` object lost its
+method** — the test never reaches the binding semantics this issue is about. So
+the original fix may well have worked, and a _different_, later defect is now
+masking it.
+
+That symptom is the signature of the **own-properties-on-function-objects**
+class (assert.\* methods read as `undefined` ⇒ never invoked). See the
+lane-parity F1 finding and #3468. Related: the same class produced the ~5,000
+vacuous standalone passes fixed on 2026-07-25 via #3592.
+
+**So: diagnose before implementing.** If the cause is the harness class, this
+issue should be re-pointed (or closed as blocked on that defect) rather than
+re-implementing module-binding logic that may already be correct. Verify on the
+CI path — `runTest262File`'s category and location are unreliable.

--- a/plan/issues/3486-caught-custom-exception-constructor-resolves-to-array.md
+++ b/plan/issues/3486-caught-custom-exception-constructor-resolves-to-array.md
@@ -4,8 +4,8 @@ title: "Host: caught custom-exception instance's .constructor resolves to Array,
 status: ready
 sprint: current
 created: 2026-07-20
-updated: 2026-07-20
-priority: medium
+updated: 2026-07-25
+priority: high
 horizon: l
 feasibility: hard
 task_type: bug
@@ -13,7 +13,7 @@ area: codegen
 language_feature: error-constructors, exceptions
 es_edition: multi
 goal: test262-conformance
-related: [3429, 3430]
+related: [3429, 3430, 3628, 3614]
 origin: "Found while implementing #3429 (assert.throws expected-constructor name-mangling fix) — isolated repro traced to a separate, deeper bug unrelated to the #3429 fix."
 ---
 
@@ -26,8 +26,8 @@ this.message = msg; }`), when instantiated with `new`, thrown, and caught on
 the JS-host side, presents `.constructor` as a function whose `.name` is
 `"Array"` — not the real declaring function. This is unrelated to the
 `wasmClosureDynamicBridge` argument-identity bug fixed in #3429 (which is
-about the *expected*-constructor argument passed *into* a host-delegated
-call); this bug is about the *actual thrown value's* constructor identity
+about the _expected_-constructor argument passed _into_ a host-delegated
+call); this bug is about the _actual thrown value's_ constructor identity
 once it round-trips through a `try`/`catch` on the host side.
 
 ## Isolated repro (zero interaction with #3429's fix — pure try/catch)
@@ -53,6 +53,7 @@ Confirmed via `runTest262File` (host lane): `typeof caught.constructor ===
 ## Impact
 
 Potentially high — any test262 test that:
+
 - catches a custom/local error constructor instance and reads
   `.constructor`/`.constructor.name`, or
 - uses the extremely common test262 idiom `assert.throws(MyError, fn)` /
@@ -115,3 +116,73 @@ driven tracing here rather than static reasoning alone).
 - #3430 (integrity-level TypeError-not-thrown triage umbrella) — same
   "oracle v8 newly honest" origin wave, same host-conformance area, may share
   a similar host-mirror-defaulting root cause worth checking together.
+
+## ES3 edition impact — measured 2026-07-25 (priority raised medium → high)
+
+**This single defect is 95 % of the remaining ≤ES3 gap.** It contributes to
+**#3628 (close the ≤ES3 edition)**, which is the edition closest to complete.
+
+Host (`gc`) lane, fresh baseline, classified with the exact `classifyEdition`
+rules from `scripts/generate-editions.ts` (reproduces the published editions
+figure exactly — 273 scored / 43 failing, so the attribution is validated):
+
+| ≤ES3                          |        count |
+| ----------------------------- | -----------: |
+| scored                        |          273 |
+| passing                       | 230 (84.2 %) |
+| failing                       |           43 |
+| compile errors                |        **0** |
+| **failing due to THIS issue** |       **41** |
+
+The 41 are 33 × `language/expressions/compound-assignment/S11.13.2_A7.*` and
+8 × prefix/postfix `++`/`--` (`S11.4.4_A6`, `S11.4.5_A6`, `S11.3.1_A6`,
+`S11.3.2_A6`). All fail with the identical message:
+
+```
+Expected a DummyError but got a Array
+```
+
+Representative source — a left-to-right evaluation-order test whose property key
+throws a user-defined error:
+
+```js
+function DummyError() {}
+assert.throws(DummyError, function () {
+  var base = null;
+  var prop = function () {
+    throw new DummyError();
+  };
+  base[prop()] *= expr();
+});
+```
+
+**The correct exception is thrown; the harness cannot identify it.** So the
+evaluation-order semantics these tests actually target are very likely already
+correct, and are being masked. Expect the fix to flip all 41 at once — but
+**measure rather than assume**, since a cluster sharing one root cause is a
+population, not a forecast (proven repeatedly on 2026-07-25).
+
+### Cross-lane note — a fix for the sibling defect already landed
+
+**#3614** is the standalone-lane twin: `Test262Error`'s `.constructor` read
+`undefined` there, for the same structural reason, and the harness's
+`thrown.constructor !== expectedErrorConstructor` check therefore rejected
+correct throws (up to 854 tests; fixed 2026-07-25, PR #3607).
+
+Its remedy is worth reading before starting here: answer `.constructor` with the
+same `__fn_closure_<Name>` global the bare identifier resolves to, so `===`
+holds by `ref.eq` — and **only read** that global, never materialise it, which
+avoids minting a `ref.func` trampoline at finalize (the late-funcidx-shift
+hazard). Whether the host lane can use the same mechanism is the first question
+to answer.
+
+**#3617** tracks the standalone residual (non-`Test262Error` fnctor instances)
+and is described there as the counterpart of this issue — the two are the same
+defect on opposite lanes and should be kept in sync.
+
+### Scope beyond ES3
+
+Any test using a **custom error constructor** with `assert.throws` hits this,
+so the true blast radius is larger than the ES3 number. Quantify it across all
+editions when fixing, and report the ES3 subset separately so #3628 can be
+closed against a measured figure.

--- a/plan/issues/3628-es3-edition-close-remaining-host-failures.md
+++ b/plan/issues/3628-es3-edition-close-remaining-host-failures.md
@@ -1,0 +1,110 @@
+---
+id: 3628
+title: "≤ES3 edition: close the remaining 43 host-lane failures (230/273 → 273/273)"
+status: ready
+sprint: current
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: m
+complexity: M
+feasibility: medium
+task_type: bugfix
+area: codegen, conformance
+language_feature: core-semantics
+es_edition: es3
+goal: spec-completeness
+related: [3486, 2899, 2900]
+origin: "2026-07-25 lead measurement: ES3 is the oldest edition and the closest to complete; the remaining gap is 3 issues, not a feature list."
+---
+
+# #3628 — ≤ES3 edition: close the remaining 43 host-lane failures
+
+## Why this issue exists
+
+**≤ES3 is the edition closest to done and the cheapest to finish.** The gap is
+**not a list of missing features** — every ES3 test compiles. It is three
+already-identified defects, one of which accounts for 95% of the failures.
+
+Finishing ES3 gives the project a **fully-closed edition** to point at, and the
+dominant defect (#3486) suppresses results well beyond ES3, so the true value
+exceeds the ES3 number.
+
+## Measured state (host / `gc` lane, 2026-07-25)
+
+Baseline `test262-current.jsonl` fetched fresh (`--force`; see #3629 — the bare
+command is a silent no-op), classified with the exact `classifyEdition` rules
+from `scripts/generate-editions.ts`. **Reproduces the published editions figure
+exactly: 273 scored / 43 failing** — so these numbers are validated, not
+approximated.
+
+|                    |            count |
+| ------------------ | ---------------: |
+| ≤ES3 scored        |          **273** |
+| passing            | **230 (84.2 %)** |
+| failing            |           **43** |
+| **compile errors** |            **0** |
+
+**Zero compile errors is the headline.** Nothing in ES3 is unimplemented at the
+language level; all 43 are runtime-semantics defects.
+
+## The 43, fully attributed
+
+|  count | cluster                                                     | owning issue                                       |
+| -----: | ----------------------------------------------------------- | -------------------------------------------------- |
+| **41** | custom-exception `.constructor` identity                    | **#3486**                                          |
+|      1 | `language/statements/function/13.2-30-s.js`                 | **#2899** (currently `done` — reopened, see below) |
+|      1 | `language/module-code/eval-gtbndng-indirect-update-dflt.js` | **#2900** (currently `done` — reopened, see below) |
+
+### The 41 — one defect, not a family (#3486)
+
+33 × `language/expressions/compound-assignment/S11.13.2_A7.*` plus 8 ×
+prefix/postfix `++`/`--` (`S11.4.4_A6`, `S11.4.5_A6`, `S11.3.1_A6`,
+`S11.3.2_A6`). Every one fails with:
+
+```
+Expected a DummyError but got a Array
+```
+
+They share one shape — a left-to-right evaluation-order test whose property key
+throws a user-defined error:
+
+```js
+function DummyError() {}
+assert.throws(DummyError, function () {
+  var base = null;
+  var prop = function () {
+    throw new DummyError();
+  };
+  base[prop()] *= expr();
+});
+```
+
+**The correct exception IS thrown.** The harness simply cannot identify it: a
+user-defined constructor's instance, once thrown and caught on the host side,
+reports `.constructor` as a function named `Array`. So the evaluation-order
+semantics under test are very likely already correct — this is an identity
+defect standing in front of them.
+
+This is the **host-lane twin of #3614**, where `Test262Error`'s `.constructor`
+read `undefined` in the standalone lane (fixed 2026-07-25, up to 854 tests).
+Same class: constructor identity lost across the throw/catch boundary.
+
+## Acceptance
+
+- [ ] #3486 fixed; re-measure the ≤ES3 bucket and confirm the 41 flip.
+- [ ] #2899 and #2900 re-verified against current main (both are marked `done`
+      while their tests still fail — see each issue).
+- [ ] ≤ES3 reaches 273/273, or every residual failure has a named owning issue
+      and a recorded reason.
+- [ ] Re-measure with a **force-fetched** baseline (#3629).
+
+## Method note (for whoever re-measures)
+
+Classification is `classifyEdition` in `scripts/generate-editions.ts`. Edition 0
+(≤ES3) is the **fall-through**: no `es5id`, no `es6id`, no `features:`, **no
+`esid:`** (esid ⇒ ES2015), frontmatter present (absent ⇒ ES5), and no
+path heuristic match. A first attempt here that omitted the `esid` and
+no-frontmatter rules reported **1,545** failures instead of 43 — a 20× error.
+**Validate any re-implementation against the published 273/43 before trusting
+it.**

--- a/plan/issues/3629-fetch-baseline-jsonl-silent-noop-without-force.md
+++ b/plan/issues/3629-fetch-baseline-jsonl-silent-noop-without-force.md
@@ -1,0 +1,90 @@
+---
+id: 3629
+title: "fetch-baseline-jsonl.mjs is a silent no-op without --force — exits 0, prints nothing, leaves a week-stale cache"
+status: ready
+sprint: current
+created: 2026-07-25
+updated: 2026-07-25
+priority: high
+horizon: s
+complexity: S
+feasibility: easy
+task_type: ci
+area: ci, tooling
+language_feature: n/a
+goal: test-infrastructure
+related: [3628, 1528]
+origin: "2026-07-25: the lead and multiple dev lanes were instructed to 'fetch fresh' with the bare command and silently received a 7-day-stale baseline."
+---
+
+# #3629 — `fetch-baseline-jsonl.mjs` silently serves a stale cache
+
+## Problem
+
+`node scripts/fetch-baseline-jsonl.mjs` is **cache-aware and no-ops if a cache
+file exists**, regardless of its age. It then **exits 0 and prints nothing**.
+
+The failure mode is the dangerous one: it is indistinguishable from a
+successful fresh fetch.
+
+Observed 2026-07-25:
+
+```
+$ node scripts/fetch-baseline-jsonl.mjs
+EXIT=0                                    # no output at all
+$ ls -la .test262-cache/test262-current.jsonl
+Jul 18 10:03                              # SEVEN DAYS OLD
+# contents: pass 25,545  — while main was at 30,931
+```
+
+Only `--force` refetches:
+
+```
+$ node scripts/fetch-baseline-jsonl.mjs --force
+[fetch-baseline-jsonl] downloaded ... (66,854,653 bytes, 47,874 entries).
+# contents: pass 30,931 / fail 14,814 / compile_error 657
+```
+
+That is a **5,386-test difference** — an entire session's landed work invisible.
+
+## Why it matters
+
+The baseline JSONL is the **authoritative input** for regression triage, trap
+censuses, edition/bucket analysis, and de-vacuification sizing. Analysis run on
+the stale cache is silently wrong in a way that looks perfectly healthy, and the
+error scales with cache age.
+
+Concretely, on 2026-07-25 several dev lanes were told to "fetch fresh" with the
+bare command as part of their briefs. Any that did received a 7-day-old file.
+One lane independently hit the sibling case: the local standalone cache was a
+snapshot from a run where the lane was compile-erroring wholesale
+(`compile_error 43,469 / pass 4,508`), so **every "pass" in it was a negative
+test** — an input that would have yielded a confident _"standalone lane: 0 %
+vacuous, all clean"_ from any detector without a vacuity guard.
+
+This is the same shape as the other silent-zero defects found the same day: a
+tool returning a benign-looking answer that is not a measurement.
+
+## Proposed fix (weigh these)
+
+1. **Always report what it did**, even on the cache-hit path — one line naming
+   the path, the byte count, the entry count, and **the cache's age**. Silence
+   is what makes this invisible.
+2. **Warn or refuse on a stale cache.** A cache older than N hours (or older
+   than the current `origin/main` baseline SHA) should either refetch
+   automatically or print a loud warning. Prefer comparing the cached
+   `baseline_sha` against the current one over a wall-clock heuristic.
+3. **Make the default safe.** Callers overwhelmingly want current data;
+   consider inverting so freshness is the default and `--cached`/`--offline` is
+   the opt-in. Keep the graceful-fallback semantics for the genuinely offline
+   case (exit 1 only when upstream is unreachable AND no cache exists).
+4. Update the standing instructions and `CLAUDE.md` so the documented incantation
+   is the one that actually fetches.
+
+## Acceptance
+
+- [ ] A cache-hit run prints what it served and how old it is.
+- [ ] A stale cache cannot be served silently — refetch or warn loudly.
+- [ ] A test pins the behaviour: with a stale cache present, the command either
+      refetches or emits a warning; it must not exit 0 silently.
+- [ ] Docs/briefs updated to the correct incantation.


### PR DESCRIPTION
## What

Measured the **≤ES3 edition** on the host (`gc`) lane and attributed every remaining failure to an owning issue. Plan/docs only — no source changes.

The classification reproduces the published editions figure **exactly (273 scored / 43 failing)**, so these numbers are validated rather than estimated.

## The finding

**Zero compile errors.** Nothing in ES3 is unimplemented at the language level — all 43 failures are runtime-semantics defects, and **41 of them are a single identity bug**.

| count | cluster | owner |
|---:|---|---|
| **41** | custom-exception `.constructor` identity | **#3486** |
| 1 | `language/statements/function/13.2-30-s.js` | #2899 (reopened) |
| 1 | `language/module-code/eval-gtbndng-indirect-update-dflt.js` | #2900 (reopened) |

The 41 are 33 compound-assignment plus 8 prefix/postfix `++`/`--` evaluation-order tests, all failing with `Expected a DummyError but got a Array`. **The correct exception is thrown** — the harness just can't identify it, because a user-defined constructor's instance reports `.constructor` as a function named `Array` once caught host-side. So the evaluation-order semantics under test are likely already correct and merely masked.

This is the **host-lane twin of #3614**, where `Test262Error`'s `.constructor` read `undefined` in the standalone lane (fixed today, up to 854 tests).

## Changes

- **NEW #3628** — ≤ES3 umbrella. ES3 is the edition closest to complete; the gap is 3 issues, not a feature list.
- **NEW #3629** — `fetch-baseline-jsonl.mjs` is a **silent no-op without `--force`**: exits 0, prints nothing, serves a 7-day-stale cache. Observed delta: 25,545 vs 30,931 passes. Analysis run on it is wrong in a way that looks healthy.
- **#3486 `medium` → `high`** — it is 95% of the ES3 gap, and its blast radius extends well beyond ES3 (any test using a custom error constructor with `assert.throws`).
- **#2899 / #2900 reopened** — both marked `done` in sprint 69, both tests still fail today. #2900's failure mode has *changed* (`TypeError: sameValue is not a function` — a harness own-property symptom), so it likely needs re-pointing rather than re-implementing.

## Note on method

A first pass at the classifier omitted two rules (`esid:` ⇒ ES2015, no-frontmatter ⇒ ES5) and reported **1,545** failures instead of 43 — a 20× error that looked entirely plausible. It was caught only by checking against the published 273/43. The method note in #3628 records this so any re-implementation validates against the known figure first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)