### PR TITLE
docs(#3631,#3632,#3633): partition the ES5 eval gap — 78.5% is AnnexB B.3.3, not eval

### DIFF
--- a/plan/issues/1066-support-eval-in-standalone-mode.md
+++ b/plan/issues/1066-support-eval-in-standalone-mode.md
@@ -17,6 +17,7 @@ depends_on: [1164, 1058]
 required_by: [1584]
 es_edition: multi
 ---
+
 # #1066 — Support `eval` in standalone mode via host-compiled Wasm child module
 
 Companion to **#1006** (eval via JS host import). #1006 covers the JS-host mode
@@ -145,7 +146,6 @@ differs.
 - [§19.2.1 eval(x)](https://tc39.es/ecma262/#sec-eval-x) — global eval semantics
 - [§19.2.1.1 PerformEval](https://tc39.es/ecma262/#sec-performeval) — parsing and evaluation in the caller's variable environment
 
-
 ## Acceptance criteria
 
 - [ ] WIT interface draft for `eval-host` committed under `wit/eval-host.wit`
@@ -199,12 +199,14 @@ is widely available.
 ## Implementation Plan (added 2026-05-21)
 
 ### Entry points
+
 - New `wit/eval-host.wit` — interface definition (Option A reference)
 - New `runtimes/eval-host-wasmtime/` (Rust crate) — reference standalone host
 - `src/codegen/typeof-delete.ts` — wherever `eval(...)` is currently lowered (`grep -n eval`); ensure WASI target emits the same import shape
 - `src/cli.ts` — accept `--eval-host=auto|wasm|disabled`
 
 ### Algorithm
+
 1. **Guest-side codegen** (unchanged from #1006): every `eval(s)` becomes:
    ```wasm
    local.get $s_externref
@@ -220,12 +222,15 @@ is widely available.
 3. **Cache**: source → compiled-module map, sized to e.g. 64 entries with LRU eviction.
 
 ### Wasm output (guest side)
+
 ```wasm
 (import "env" "__eval_host_eval" (func $eval (param externref i32) (result externref)))
 ```
+
 For WASI target, the import module name becomes `"eval-host"` to match the WIT mapping.
 
 ### Edge cases
+
 - **Direct eval scope capture**: standalone mode cannot reify the caller's variable environment. Per the design, treat direct eval as indirect in standalone mode (document limitation).
 - **Throws**: the host returns a "result" envelope `{ ok | throw }` via a 2-cell struct, or the import returns externref and re-throws on the guest side via a sentinel tag.
 - **Strict mode propagation**: pass a third arg `strict: i32`.
@@ -233,6 +238,7 @@ For WASI target, the import module name becomes `"eval-host"` to match the WIT m
 - **Security**: gate behind explicit `--enable-dynamic-codegen` flag in the standalone host; default OFF.
 
 ### Test plan
+
 - `tests/issue-1066-standalone-eval.test.ts`:
   - `eval("1+2")` → 3
   - `eval("throw 1")` → caught by guest's `try/catch`
@@ -240,11 +246,13 @@ For WASI target, the import module name becomes `"eval-host"` to match the WIT m
 - Cross-mode parity: same test files compiled with `--target js` and `--target wasi` produce identical results for indirect-eval cases.
 
 ### Dependencies
+
 - **Hard**: #1006 (JS-host eval) — lands first; this issue mirrors its import shape
 - **Hard**: #1058 (js2wasm self-host) — required to embed compiler as a library; until then, shell out to CLI
 - **Soft**: #1165 `func.new` proposal — eventually replaces this approach
 
 ### Files touched
+
 - new `wit/eval-host.wit`
 - new `runtimes/eval-host-wasmtime/` (Rust crate)
 - `src/codegen/typeof-delete.ts` (eval call lowering, if target-aware)
@@ -265,7 +273,7 @@ For WASI target, the import module name becomes `"eval-host"` to match the WIT m
 
 ### Where this issue now fits: "Tier 1w" — host-provided eval for pure-Wasm embedders
 
-The ladder's Tier 1 assumes a *JS* host. This issue's surviving, real use
+The ladder's Tier 1 assumes a _JS_ host. This issue's surviving, real use
 case is an embedder running wasmtime/wasmer-class runtimes who is willing to
 ship js2wasm on the host side and wants eval without paying Tier 2's
 in-module interpreter size (§16 E6 floor). That is a **host-choice rung
@@ -317,7 +325,7 @@ interface eval-host {
 
 The load-bearing delta vs the old draft is `js-env`: a WasmGC `$Object`
 cannot cross a WIT boundary, so the parent module exports the object-record
-*protocol* (get/set/has/delete over its globalThis) and the host threads it
+_protocol_ (get/set/has/delete over its globalThis) and the host threads it
 into every child module it compiles — child free-identifier misses walk this
 record and throw the §14 root-miss `ReferenceError`, and an eval'd
 `var x = 1` lands in the PARENT's globals (visible to AOT code, §4.3), not
@@ -341,7 +349,7 @@ throw with an execution — the only allowed direction.
 natural reference host is a **Node-based WASI runner embedding the compiler
 in-process** (`compileSourceSync`, LRU keyed on source hash — the same cache
 discipline as `createEvalShim`), landed under `runtimes/eval-host-node/`.
-A Rust+wasmtime host that shells out to the CLI is the *portability proof*,
+A Rust+wasmtime host that shells out to the CLI is the _portability proof_,
 second, and only if an embedder actually asks — do not gate the issue on
 writing Rust. Security: the host gates dynamic codegen behind an explicit
 opt-in, default off.
@@ -363,3 +371,37 @@ guest). Assert the §14 semantics specifically: free-var miss →
   "Long-term native path" section stands).
 - #1102 is **done** (PR #3113) — its Tier-0 leg is landed; nothing in this
   issue reopens it.
+
+---
+
+## Measured evidence — the standalone-only eval cost (2026-07-25, #3631 partition)
+
+Baselines: `test262-current.jsonl` and `test262-standalone-current.jsonl`
+(`loopdive/js2wasm-baselines`), both fetched 2026-07-25 18:21. Population =
+ES5-classified (post-#3626 classifier), `eval`-dependent, **775 tests** in both
+lanes. Standalone uses the host-free pass definition (`--host-free`: a `pass`
+carrying `host_import_leak_class` is demoted).
+
+| lane                   | pass | not passing |
+| ---------------------- | ---- | ----------- |
+| host                   | 291  | 484         |
+| standalone (host-free) | 143  | **632**     |
+
+**149 of these tests pass in the host lane and fail in standalone.** Of those,
+**110 fail with literally `TypeError: dynamic eval is not supported in
+standalone mode`** — the folded path declined the body (constant string, but a
+node kind `allNodesInlineSupported` rejects) and there is no host fallback to
+catch it. Path split of the 149: 88 `annexB/language/eval-code`, 18
+`language/statements/function`, 5 each `language/eval-code/{direct,indirect}`,
+5 `language/expressions/object`, 5 `built-ins/String/prototype`, 4
+`language/literals/regexp`, remainder in ones and twos.
+
+This is the concrete, measured statement of the asymmetry that motivates this
+issue: **in the host lane a folder bail is harmless (it routes to a working host
+eval); in the standalone lane a folder bail is a hard failure.** Any claim that
+"widening the constant folder is not worth it" is a **host-lane-only** claim —
+it does not transfer here.
+
+Sizing caveat (gates ≠ flips): 88 of the 110 are `annexB/language/eval-code`,
+which pass at only 19 % in the host lane even with a working eval. Removing the
+standalone bail unmasks them; it does not by itself flip them. See #2200.

--- a/plan/issues/2200-annexb-block-level-function-hoisting.md
+++ b/plan/issues/2200-annexb-block-level-function-hoisting.md
@@ -29,8 +29,8 @@ origin: "2026-06-19 sprint-64 standalone failure mining: annexB/language/functio
 
 ECMA-262 **Annex B.3.3** ("Changes to FunctionDeclarationInstantiation /
 GlobalDeclarationInstantiation / EvalDeclarationInstantiation") governs the
-web-compat semantics of a `FunctionDeclaration` nested inside a *block* (not a
-function body). The spec creates an *additional, var-scoped* outer binding for
+web-compat semantics of a `FunctionDeclaration` nested inside a _block_ (not a
+function body). The spec creates an _additional, var-scoped_ outer binding for
 the block-local function name, but **only when** doing so "would not produce any
 Early Errors" — e.g. a colliding `let`/`const`/parameter binding in the
 enclosing scope cancels the Annex B hoist.
@@ -43,9 +43,9 @@ guard conditions. Two observable failures result:
    shadow (or the B.3.3 "would produce an early error" condition) should block
    the hoist, the compiler still exposes `f` in the outer scope, so a
    `ReferenceError` that the spec mandates does not throw.
-2. **Outer binding initialized too eagerly** — even when the outer binding *is*
+2. **Outer binding initialized too eagerly** — even when the outer binding _is_
    created, B.3.3 requires it to start **uninitialized** (`typeof f ===
-   "undefined"`, reading `f` before the block executes throws `ReferenceError`),
+"undefined"`, reading `f` before the block executes throws `ReferenceError`),
    then become initialized to the function value **only after** the block's
    inner `function` declaration is evaluated. The compiler initializes it at
    function entry.
@@ -73,15 +73,19 @@ the `FunctionDeclaration` with a `var F` would not produce an early error
 
 ```js
 // (A) let-shadow cancels the Annex B outer binding (B.3.3 guard).
-(function() {
+(function () {
   // Outer `f` must NOT be created — a `let f` shadow lives between.
   let threw = false;
-  try { f; } catch (e) { threw = e instanceof ReferenceError; }
+  try {
+    f;
+  } catch (e) {
+    threw = e instanceof ReferenceError;
+  }
   // assert threw === true   (compiler: f is wrongly visible → no throw)
   {
     let f = 123;
     {
-      function f() {}   // block-level fn decl, but `let f` blocks the hoist
+      function f() {} // block-level fn decl, but `let f` blocks the hoist
     }
   }
   return threw ? 1 : 0;
@@ -90,12 +94,16 @@ the `FunctionDeclaration` with a `var F` would not produce an early error
 
 ```js
 // (B) outer binding starts uninitialized, becomes the fn value after the block.
-(function() {
+(function () {
   // `f` exists (var-scoped) but is uninitialized here.
-  const before = typeof f;          // must be "undefined" (binding uninitialized)
-  { function f() { return 42; } }   // after this block, outer f === the function
-  const after = typeof f;           // must be "function"
-  return (before === "undefined" && after === "function") ? 1 : 0;
+  const before = typeof f; // must be "undefined" (binding uninitialized)
+  {
+    function f() {
+      return 42;
+    }
+  } // after this block, outer f === the function
+  const after = typeof f; // must be "function"
+  return before === "undefined" && after === "function" ? 1 : 0;
 })();
 ```
 
@@ -125,7 +133,7 @@ the enclosing scope):
    (`let`/`const`/class) binding for the name exists in an intervening scope, or
    the name is a parameter. This makes case (A) throw the spec `ReferenceError`.
 2. Make the hoisted outer binding **uninitialized at entry** (TDZ-like for the
-   var-scoped Annex B binding), and emit the *initialization-to-function-value*
+   var-scoped Annex B binding), and emit the _initialization-to-function-value_
    at the point the inner block-level declaration is evaluated, not at function
    entry. This fixes case (B).
 
@@ -157,8 +165,9 @@ compiled by the SAME path as a direct function-body declaration
 (`compileNestedFunctionDeclaration`, `statements.ts:218`), which registers `f`
 in the **module-global `ctx.funcMap`**. Identifier resolution then finds it
 unconditionally:
+
 - `src/codegen/expressions/identifiers.ts:766` — `const funcRefIdx =
-  ctx.funcMap.get(name)` resolves ANY function name as a value, regardless of
+ctx.funcMap.get(name)` resolves ANY function name as a value, regardless of
   the lexical scope it was declared in. So the outer `(f as any)` read in case A
   finds the block-nested `f` and does NOT throw (the `let f` shadow is never
   consulted).
@@ -176,6 +185,7 @@ deliberate Annex B hoist — it is an accident of `funcMap` being module-global.
 
 A spec-correct B.3.3 requires changing the **function-binding model**, not a
 localized patch:
+
 1. **Scope the visibility of a block-nested function name** so it does NOT leak
    into the module-global `funcMap` lookup at outer read sites — the resolver at
    `identifiers.ts:766` would need a lexical-scope-aware lookup (today it is a
@@ -183,7 +193,7 @@ localized patch:
 2. **Apply the B.3.3 guard** (no intervening `let`/`const`/class binding for the
    name; name is not a parameter) to decide whether to create the var-scoped
    outer binding at all (case A).
-3. **Model the outer binding lifecycle** as a var that is *uninitialized* at
+3. **Model the outer binding lifecycle** as a var that is _uninitialized_ at
    function/global entry and assigned the function value only when the inner
    block-level declaration executes (case B) — i.e. a TDZ-like var local plus a
    deferred init at the declaration's textual position.
@@ -211,12 +221,12 @@ that is the hottest identifier path and the highest regression risk.
 (`identifiers.ts:482`) resolves names in a fixed order, and **`localMap`
 (line 499, with its `tdzFlagLocals` TDZ check at 502–511) and `moduleGlobals`
 (line 592, with `tdzGlobals` at 596) are both consulted BEFORE the funcMap
-function-ref-as-value branch at line 766.** So if the Annex B *outer binding* is
+function-ref-as-value branch at line 766.** So if the Annex B _outer binding_ is
 materialised as a real var-binding (a function-local with a `tdzFlagLocals` entry,
 or — at global scope — a module global with a `tdzGlobals` entry), the read is
 intercepted by the earlier branch and the funcMap lookup at 766 is **never reached
 for that name**. The block-local function itself stays in `funcMap` and keeps
-working for *calls inside the block* and for the post-declaration assignment.
+working for _calls inside the block_ and for the post-declaration assignment.
 
 This converts the problem from "make the hottest lookup scope-aware" (tail-risk)
 into "model the Annex B outer var-binding using the existing TDZ-var machinery"
@@ -255,12 +265,12 @@ whose nearest enclosing function/global scope is `S`:
    → ReferenceError, or nothing → ReferenceError). sd1 has a **validated static
    detector** for this (`cancels=true`); reuse it verbatim.
 2. **Lifecycle when eligible (case B).** The var-scoped binding for `F` in `S` is
-   created at entry but **uninitialised** (`undefined` is the *value*, but per the
+   created at entry but **uninitialised** (`undefined` is the _value_, but per the
    FunctionDeclarationInstantiation/var semantics a `var` binding is initialised to
    `undefined` — see the subtlety note below). At the **point the block-level
    `FunctionDeclaration` is evaluated** (its textual position, when control reaches
    the block), the spec performs `SetMutableBinding(F, fobj)` on the **function-level
-   outer** binding — i.e. the outer `F` becomes the function object *only after* the
+   outer** binding — i.e. the outer `F` becomes the function object _only after_ the
    block runs.
 3. **Strict mode disables Annex B entirely** — no outer binding is ever created;
    the block function is purely block-scoped (`typeof f` outside the block is
@@ -269,17 +279,17 @@ whose nearest enclosing function/global scope is `S`:
 
 **Subtlety — `typeof f` "undefined" before the block (repro B).** Strictly, a
 plain `var f` is initialised to `undefined` at entry (so `typeof f` is
-`"undefined"` because the *value* is `undefined`, not because the binding is in
+`"undefined"` because the _value_ is `undefined`, not because the binding is in
 TDZ). But the test262 function-code cluster's dominant assertion is
 `assert.throws(ReferenceError, function() { f; }, 'An initialized binding is not
 created prior to evaluation')` — i.e. several of these tests want a **ReferenceError
 on read before the block**, which is the TDZ behaviour, not the `undefined`-value
-behaviour. The distinction is per-test: the *function-code* skip-tests want a
+behaviour. The distinction is per-test: the _function-code_ skip-tests want a
 binding that is **absent/TDZ before the block** (read → ReferenceError) and present
-after; the *repro B* in this issue wants `typeof f === "undefined"` before. **Both
+after; the _repro B_ in this issue wants `typeof f === "undefined"` before. **Both
 are satisfied by a single mechanism: model the outer binding as a TDZ var** (a
 local + a `__tdz_f` flag, flag=0 at entry, flag=1 after the block's declaration
-runs). A *direct read* of `f` before the block emits `emitLocalTdzCheck` →
+runs). A _direct read_ of `f` before the block emits `emitLocalTdzCheck` →
 ReferenceError (satisfies the function-code cluster). A `typeof f` before the block
 is special-cased to return `"undefined"` when the flag is 0 (satisfies repro B and
 ES `typeof`-on-uninitialised… see the note in Phase 2 below). This is exactly how
@@ -288,13 +298,13 @@ ES `typeof`-on-uninitialised… see the note in Phase 2 below). This is exactly 
 ### Phased rollout (case-A guard first — it is independently shippable)
 
 **Phase 1 (case A — the cancellation guard). ~Half the cluster, lowest risk.**
-Make an *ineligible* block-nested function name **not** resolve as an outer value.
+Make an _ineligible_ block-nested function name **not** resolve as an outer value.
 Today the bug is that `funcMap.get(name)` finds it unconditionally. Phase 1 does
-NOT add an outer binding at all — it *suppresses* the accidental outer visibility
+NOT add an outer binding at all — it _suppresses_ the accidental outer visibility
 when sd1's detector says `cancels=true`, so the existing `let`/`const` TDZ binding
 (or the genuine ReferenceError fallback) takes over.
 
-**Phase 2 (case B — the uninitialised-then-init lifecycle).** For *eligible*
+**Phase 2 (case B — the uninitialised-then-init lifecycle).** For _eligible_
 block-nested functions, create the TDZ outer var-binding, mark it initialised at
 the declaration's textual position, and special-case `typeof`.
 
@@ -305,7 +315,7 @@ Phase 2 builds on Phase 1's plumbing. Ship them as two PRs; Phase 1 is the floor
 
 ### Phase 1 — case-A cancellation guard
 
-**Goal:** when a block-nested `function F` is *ineligible* for the Annex B outer
+**Goal:** when a block-nested `function F` is _ineligible_ for the Annex B outer
 binding (intervening lexical shadow or param), a read of `F` in the enclosing scope
 outside the block must NOT resolve via `funcMap`.
 
@@ -327,23 +337,23 @@ outside the block must NOT resolve via `funcMap`.
   - **Important scoping nuance:** the detector must distinguish "direct function-body
     declaration" (a top-level statement of the function body — NOT block-nested, must
     keep current unconditional hoist) from "block-nested declaration" (reached via the
-    block recursion). The recursion structure already separates these: the *direct*
+    block recursion). The recursion structure already separates these: the _direct_
     decls are handled in the first `for` loop pass at lines 917–950 over the function
-    body's own `stmts`; the *block-nested* ones are reached via the recursive descent
+    body's own `stmts`; the _block-nested_ ones are reached via the recursive descent
     at 954–1005. Only the latter are Annex B candidates. Tag candidacy at the
     descent boundary so a direct decl is never marked cancelled.
 
 **File: `src/codegen/expressions/identifiers.ts`**
 
 - At the function-ref-as-value branch (line 766, `const funcRefIdx =
-  ctx.funcMap.get(name)`), add a guard **before** the `if (funcRefIdx !== undefined
-  && …)` block at line 778: if `fctx.annexBCancelled?.has(name)` AND the read site is
-  lexically *outside* the declaring block (use the TS checker / node position: the
+ctx.funcMap.get(name)`), add a guard **before** the `if (funcRefIdx !== undefined
+&& …)` block at line 778: if `fctx.annexBCancelled?.has(name)` AND the read site is
+  lexically _outside_ the declaring block (use the TS checker / node position: the
   identifier's position is not within the block that contains the
   `FunctionDeclaration`), skip the funcMap-as-value resolution and fall through to
   the undeclared-identifier path (lines 820+), which already emits a proper
   `ReferenceError` instance for a name with no in-scope value binding.
-  - **Do not** broadly disable funcMap resolution for the name — calls/reads *inside*
+  - **Do not** broadly disable funcMap resolution for the name — calls/reads _inside_
     the block must still resolve. The position check ("is this read inside the
     declaring block?") is what keeps the block-local binding intact. sd1's detector
     already computes the block boundary; expose the block node so the read site can
@@ -361,20 +371,20 @@ outside the block must NOT resolve via `funcMap`.
 
 ### Phase 2 — case-B uninitialised-then-init lifecycle (eligible functions)
 
-**Goal:** for an *eligible* block-nested `function F`, the enclosing scope gets a
+**Goal:** for an _eligible_ block-nested `function F`, the enclosing scope gets a
 var-binding for `F` that is in TDZ before the block and holds the function value
 after.
 
 **File: `src/codegen/statements/nested-declarations.ts` (in `hoistFunctionDeclarations`)**
 
-- For an *eligible* block-nested decl (detector `cancels===false`), during the
+- For an _eligible_ block-nested decl (detector `cancels===false`), during the
   hoist pass **pre-allocate the outer binding as a TDZ var** in the enclosing
   `fctx`, mirroring `ensureLetConstBindingPatternTdzFlags`
   (`index.ts:12151`) and `hoistLetConstWithTdz`:
   - `allocLocal(fctx, F, externref)` if not already present (the function value as a
     closure is an externref/closure-struct ref — match the type
     `emitCachedFuncClosureAccess` returns; externref is the safe widening).
-  - `allocLocal(fctx, `__tdz_${F}`, { kind: "i32" })` and register it in
+  - `allocLocal(fctx, `\__tdz_${F}`, { kind: "i32" })` and register it in
     `fctx.tdzFlagLocals.set(F, flagIdx)` — flag starts 0 (uninitialised) by Wasm
     zero-init.
   - Record `F` in a new `fctx.annexBOuterBindings: Set<string>` so the
@@ -396,6 +406,7 @@ branch, lines 218–236) — the textual-position init.**
   i32.const 1
   local.set $__tdz_F              ;; mark the Annex B outer binding initialised
   ```
+
   - Gate on `fctx.annexBOuterBindings?.has(F)` so non-Annex-B function decls are
     untouched (byte-identical).
   - Because the declaration is inside a block, this init runs only when control
@@ -407,7 +418,7 @@ branch, lines 218–236) — the textual-position init.**
 
 **File: `src/codegen/expressions/identifiers.ts` (read site).**
 
-- No new code needed for the *direct read*: once `F` is in `localMap` with a
+- No new code needed for the _direct read_: once `F` is in `localMap` with a
   `tdzFlagLocals` entry, the existing branch at lines 499–511 emits
   `emitLocalTdzCheck` (or static throw / skip) automatically. `analyzeTdzAccess`
   (called at line 504) already decides check-vs-throw-vs-skip from positions, and a
@@ -418,7 +429,7 @@ branch, lines 218–236) — the textual-position init.**
 **File: `src/codegen/typeof-delete.ts` (the `typeof F` special-case).**
 
 - `compileTypeofExpression` (`typeof-delete.ts:787`) currently const-folds `typeof
-  F` to `"function"` via `staticTypeofForType` (line 863) because the TS checker
+F` to `"function"` via `staticTypeofForType` (line 863) because the TS checker
   reports `F`'s symbol as a function type (it models the hoist). For an Annex B
   outer binding this is wrong before the block runs. Add a check **before** the
   static-fold at line 860–866: if the operand is a bare identifier `F` with
@@ -446,13 +457,13 @@ flag branch) plus the reused `emitLocalTdzCheck` IR (already exists,
 ### Edge cases (both phases)
 
 - **Direct (function-body-top-level) function decls are NOT Annex B** — they keep
-  the current unconditional hoist. Only declarations reached through the *block*
+  the current unconditional hoist. Only declarations reached through the _block_
   recursion are candidates. Verify the detector never marks a direct decl.
 - **Strict mode** — Annex B is disabled. Detect strictness (module code is always
   strict; a `"use strict"` directive in the function/global body, or an enclosing
   strict scope). When strict: do not create the outer binding and do not mark
   cancelled — the block function is purely block-scoped. test262 has explicit
-  strict-mode `function-code` variants asserting *no* outer binding; treat strict as
+  strict-mode `function-code` variants asserting _no_ outer binding; treat strict as
   "skip the whole Annex B path." (sd1's detector should already gate on strictness;
   confirm.)
 - **Name collides with a real `var F` in the enclosing scope** — then the outer
@@ -471,12 +482,12 @@ flag branch) plus the reused `emitLocalTdzCheck` IR (already exists,
 - **`for`/`while` block-nested decl** — the hoist recursion already descends into
   loop bodies (lines 980–993). The outer binding is allocated once; the init runs
   each iteration (idempotent: re-sets the same closure + flag).
-- **Nested intervening blocks** — the detector must scan *all* scopes between the
+- **Nested intervening blocks** — the detector must scan _all_ scopes between the
   declaring block and the enclosing function/global for a lexical shadow, not just
   the immediate parent. sd1's detector reportedly does this ("intervening" shadow);
   confirm it walks the full chain.
 - **`funcMap` value-read inside the block stays intact** — the Phase 1 guard is
-  position-scoped to *outside* the block; calls/reads of `F` inside its own block
+  position-scoped to _outside_ the block; calls/reads of `F` inside its own block
   resolve normally.
 
 ### Regression-mitigation & validation strategy
@@ -501,28 +512,28 @@ with no cancelled/eligible Annex B function emits byte-identical Wasm. Concretel
   Wasm is unchanged — proves the gating sets are truly inert when empty.
 - **CI is the conformance authority** — the dev does NOT run full test262 locally.
   The acceptance bar is `>=120` of the ~186 `annexB/language/{function-code,
-  global-code}` flipping to pass with **no regression** in the function/block
+global-code}` flipping to pass with **no regression** in the function/block
   suites. If Phase 1 alone lands the case-A ReferenceError subset cleanly, ship it
   and let Phase 2 take the case-B `typeof`/lifecycle subset.
 
 ### Exact change list
 
-| Phase | File | Function / line | Change |
-|-------|------|-----------------|--------|
-| both | `src/codegen/context/types.ts` | `FunctionContext` | add optional `annexBCancelled?: Set<string>` and `annexBOuterBindings?: Set<string>` |
-| 1 | `src/codegen/statements/nested-declarations.ts` | `hoistFunctionDeclarations` (832; block recursion 954–1005) | run sd1's `cancels` detector for block-nested decls; on cancel, record name in `fctx.annexBCancelled` (still compile body) |
-| 1 | `src/codegen/expressions/identifiers.ts` | before funcMap-as-value branch (~778) | skip funcMap resolution for `annexBCancelled` names read *outside* the declaring block → fall to ReferenceError path (826+) |
-| 2 | `src/codegen/statements/nested-declarations.ts` | `hoistFunctionDeclarations` | for *eligible* block-nested decls, pre-allocate outer TDZ var (`allocLocal` + `__tdz_${F}` flag in `tdzFlagLocals`); record in `annexBOuterBindings` |
-| 2 | `src/codegen/statements.ts` | `compileStatement` `isFunctionDeclaration` (218–236) | at textual position, `local.set` outer binding to the closure value + set `__tdz_${F}` flag to 1 (gated on `annexBOuterBindings`) |
-| 2 | `src/codegen/typeof-delete.ts` | `compileTypeofExpression` (787; before static fold 860–866) | for `annexBOuterBindings` identifier operand, emit `if $__tdz_F → "function" else "undefined"` instead of const-folding |
-| both | `tests/issue-2200-annexb-block-fn-hoist.test.ts` | new | repros A + B in sloppy + strict mode |
+| Phase | File                                             | Function / line                                             | Change                                                                                                                                               |
+| ----- | ------------------------------------------------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| both  | `src/codegen/context/types.ts`                   | `FunctionContext`                                           | add optional `annexBCancelled?: Set<string>` and `annexBOuterBindings?: Set<string>`                                                                 |
+| 1     | `src/codegen/statements/nested-declarations.ts`  | `hoistFunctionDeclarations` (832; block recursion 954–1005) | run sd1's `cancels` detector for block-nested decls; on cancel, record name in `fctx.annexBCancelled` (still compile body)                           |
+| 1     | `src/codegen/expressions/identifiers.ts`         | before funcMap-as-value branch (~778)                       | skip funcMap resolution for `annexBCancelled` names read _outside_ the declaring block → fall to ReferenceError path (826+)                          |
+| 2     | `src/codegen/statements/nested-declarations.ts`  | `hoistFunctionDeclarations`                                 | for _eligible_ block-nested decls, pre-allocate outer TDZ var (`allocLocal` + `__tdz_${F}` flag in `tdzFlagLocals`); record in `annexBOuterBindings` |
+| 2     | `src/codegen/statements.ts`                      | `compileStatement` `isFunctionDeclaration` (218–236)        | at textual position, `local.set` outer binding to the closure value + set `__tdz_${F}` flag to 1 (gated on `annexBOuterBindings`)                    |
+| 2     | `src/codegen/typeof-delete.ts`                   | `compileTypeofExpression` (787; before static fold 860–866) | for `annexBOuterBindings` identifier operand, emit `if $__tdz_F → "function" else "undefined"` instead of const-folding                              |
+| both  | `tests/issue-2200-annexb-block-fn-hoist.test.ts` | new                                                         | repros A + B in sloppy + strict mode                                                                                                                 |
 
 ### Handoff
 
 sd1 holds the implementation claim and owns the validated case-A `cancels`
 detector + root-cause. This plan deliberately builds on that detector and does NOT
 re-derive it. Open question for sd1 to confirm against the detector: (a) does it
-walk the *full* intervening scope chain (not just the immediate parent) for the
+walk the _full_ intervening scope chain (not just the immediate parent) for the
 lexical shadow; (b) does it already gate on strict mode; (c) can it expose the
 declaring-block node (or a position range) so the Phase-1 read-site containment
 check is cheap. If the detector already returns the block boundary, Phase 1 is a
@@ -577,10 +588,11 @@ floor is banked regardless; Phase 2 is parked here for a focused follow-up.
 
 **Regression profile (gate bucket output, baseline e6cf3a7, signature
 `d57ce880bc38ea96`):**
+
 - categories: `wasm_compile: 625`, `null_deref: 593`, `type_error: 143`, other 41.
 - top buckets (each >50): `Array/prototype/{some 115, every 113, filter 109,
-  map 93, forEach 86, reduceRight 69, reduce 58}`, `language/statements/
-  {function/dstr 88, generators/dstr 88, async-generator/dstr 52}`.
+map 93, forEach 86, reduceRight 69, reduce 58}`, `language/statements/
+{function/dstr 88, generators/dstr 88, async-generator/dstr 52}`.
 
 **Why it is genuinely Phase 2 (not drift):** PR #1767 ran its regression gate
 against the SAME fresh baseline seconds apart and was clean (+21, signature
@@ -620,3 +632,49 @@ correct typeof-resolution fix). PR #1769 lands **docs-only** (the Phase-2 source
 was reverted to origin/main so it carries ZERO source change — Phase 1 is already
 on main via #1764); it records the deferral and creates the #2552 rework issue.
 #2200 stays `in-progress` (Phase-1 shipped, Phase-2 → #2552).
+
+---
+
+## Measured evidence — the "eval blocker" is mostly this issue (2026-07-25, #3631 partition)
+
+Partitioning the ES5 `eval`-dependent failures re-attributes the large majority
+of them to **this** issue rather than to eval.
+
+Baseline: `loopdive/js2wasm-baselines` `test262-current.jsonl`, fetched
+2026-07-25 18:21. Population = ES5-classified (post-#3626 classifier),
+`eval`-dependent (`*/eval-code/` ∪ `built-ins/eval` ∪ source matches `eval(`),
+host lane: **775 tests, 484 not passing**.
+
+| bucket                                         | tests   | share      |
+| ---------------------------------------------- | ------- | ---------- |
+| `annexB/language/eval-code/*` (**this issue**) | **380** | **78.5 %** |
+| everything else                                | 104     | 21.5 %     |
+
+Every one of the 380 carries a **constant** eval string that the folder reaches
+and then deliberately declines, on the `funcDeclNeedsDynamicEvalPath` guard —
+i.e. precisely because the body contains a block/if/switch-nested
+`FunctionDeclaration` whose B.3.3 dual-binding semantics the splice does not
+implement. Static bail-reason breakdown of the 380: 204 `direct-const |
+FunctionDeclaration`, 112 `indirect-const | FunctionDeclaration`, 64 with an
+additional `FunctionExpression`/`ForIn`/`ForOf` node.
+
+Lane split for the whole `annexB/language/eval-code` directory (469 tests):
+
+| lane                   | pass    | rate      |
+| ---------------------- | ------- | --------- |
+| host                   | 89 /469 | 19 %      |
+| standalone (host-free) | 1 /469  | **0.2 %** |
+
+Within the host lane the family splits by where the `assert` call sits:
+
+| shape                                        | pass     | rate       |
+| -------------------------------------------- | -------- | ---------- |
+| `assert` **inside** the eval string (masked) | 0 / 144  | 0 %        |
+| `assert` **outside** the eval string         | 89 / 325 | **27.4 %** |
+
+The masked half is blocked earlier by #3633 (module bindings invisible to
+`__extern_eval`) and cannot be scored against B.3.3 until that lands. Treat
+27.4 % as the honest post-unmasking predictor, **not** 100 %.
+
+**Consequence for sizing:** the ES5 `eval` programme is not worth ~484 tests to
+eval work. It is worth ~104 to eval work and ~380 to this issue plus #3633.

--- a/plan/issues/3631-eval-completion-value-non-expression-last-statement.md
+++ b/plan/issues/3631-eval-completion-value-non-expression-last-statement.md
@@ -1,0 +1,87 @@
+---
+id: 3631
+title: "eval returns `undefined` when the last statement is not an ExpressionStatement — completion value not implemented"
+status: ready
+sprint: current
+goal: es5-complete
+priority: medium
+horizon: m
+feasibility: medium
+---
+
+# eval completion value: non-ExpressionStatement last statement returns `undefined`
+
+## Problem
+
+`tryStaticEvalInline` (`src/codegen/expressions/eval-inline.ts`) computes the
+eval result from the **last statement only**, and only when that statement is an
+`ExpressionStatement`. Every other last-statement kind falls into this arm:
+
+```ts
+// Non-expression last statement (throw, var, if, etc.) — compile it and
+// push `undefined` as the eval result.
+compileStatement(ctx, fctx, last);
+emitUndefined(ctx, fctx);
+return { kind: "externref" };
+```
+
+Per §19.2.1.1 / the Script evaluation semantics, `eval` returns the **completion
+value** of the Script, which propagates out of `if`, `while`, `do-while`, `for`,
+`try`, `switch` and plain blocks. It is not `undefined` merely because the
+outermost node is a statement rather than an expression.
+
+## Probe (current HEAD, host mode, `tests/probe-eval-mvp.test.ts` — gitignored)
+
+| probe                                            | got         | spec | verdict  |
+| ------------------------------------------------ | ----------- | ---- | -------- |
+| `eval("if (true) { 41 + 1 }")`                   | `undefined` | `42` | **FAIL** |
+| `eval("var i=0; do { i=i+1; 7 } while (i < 1)")` | `undefined` | `7`  | **FAIL** |
+
+Both were re-run against unmodified `origin/main` (`3a262054c6`).
+
+## Measured denominator — honest, and small
+
+Baseline: `loopdive/js2wasm-baselines` `test262-current.jsonl`, fetched
+2026-07-25 18:21. Population = ES5-classified (post-#3626 classifier),
+`eval`-dependent, host lane: **775 tests, 484 not passing**.
+
+Inside that population, the failures whose reported signature is a
+completion-value mismatch are the `do-while` / `while` families:
+
+| test                                         | reported failure                       |
+| -------------------------------------------- | -------------------------------------- |
+| `language/statements/do-while/S12.6.1_A3.js` | `__evaluated === 1. Actual: undefined` |
+| `language/statements/do-while/S12.6.1_A5.js` | `__evaluated === 1. Actual: undefined` |
+| `language/statements/do-while/S12.6.1_A7.js` | `do-while returns (normal, V, empty)`  |
+| `language/statements/do-while/S12.6.1_A8.js` | `__evaluated === 4. Actual: undefined` |
+| `language/statements/while/S12.6.2_A5.js`    | `__evaluated === 1. Actual: undefined` |
+| `language/statements/while/S12.6.2_A7.js`    | `while returns (normal, V, empty)`     |
+| `language/statements/while/S12.6.2_A8.js`    | `__evaluated === 4. Actual: undefined` |
+
+**7 ES5 tests measured.** Corpus-wide (all editions) was **not** measured — do
+not quote a larger number without measuring it. All 7 are in the _folded_ path,
+so the fix is host-free and applies to **both** the host and standalone lanes;
+the standalone lane is where a folded-path fix has no host fallback masking it.
+
+## Why this is not a 5-line change
+
+Correct completion-value semantics need a **completion-value slot** that
+statement codegen writes to (the last _value-producing_ statement wins, and
+`if`/loops/`try`/`switch`/blocks propagate their inner value), not a special case
+on the outermost node. That is why this is filed rather than patched inline: the
+change touches `compileStatement`'s contract for eval bodies. A narrower first
+slice — propagate the completion value out of `Block`, `IfStatement`,
+`WhileStatement`, `DoStatement` and `ForStatement` only — covers all 7 measured
+tests.
+
+## Acceptance criteria
+
+- `eval("if (true) { 41 + 1 }")` returns `42`; `eval("var i=0; do { i=i+1; 7 } while (i<1)")` returns `7`.
+- The 7 tests listed above pass in the host lane.
+- No regression in `tests/issue-2923-eval-const-broaden.test.ts` (the folded-path
+  standalone contract: no `__extern_eval` import leak).
+
+## Not covered here
+
+Direct eval with a runtime string (#3630), eval in standalone mode (#1066),
+AnnexB B.3.3 function-in-block hoisting (#2200 / #2552).

--- a/plan/issues/3632-folded-eval-body-skips-early-errors.md
+++ b/plan/issues/3632-folded-eval-body-skips-early-errors.md
@@ -1,0 +1,97 @@
+---
+id: 3632
+title: "folded eval body skips Script early errors — strict-mode reserved words and stray break/continue silently compile"
+status: ready
+sprint: current
+goal: es5-complete
+priority: medium
+horizon: m
+feasibility: medium
+---
+
+# The folded eval path does not run the eval Script's early errors
+
+## Problem
+
+`tryStaticEvalInline` parses the constant eval string with
+`ts.createSourceFile(..., ScriptKind.JS)` and rejects only on
+`parseDiagnostics`. TypeScript's parser reports **syntactic** diagnostics; it
+does **not** report the ECMAScript **early errors** that an eval Script must
+raise before evaluating anything:
+
+- strict-mode early errors when the body has a `"use strict"` prologue —
+  `var public = 1`, `var implements`, assignment to `eval`/`arguments`,
+  duplicate parameter names, octal literals;
+- `break` / `continue` with no enclosing iteration or labelled statement
+  (an eval body is its own Script — a `break` inside it can never bind to a
+  loop in the _caller_).
+
+Because the splice skips them, the body compiles and runs, and the expected
+`SyntaxError` never arrives.
+
+**The important part: on this axis the folded path is _less_ correct than the
+dynamic path it is meant to replace.** `__extern_eval` routes to a real host
+eval that does enforce the early errors. So the constant-folding fast path is a
+correctness _regression_ against its own fallback here — which is why widening
+the folder's reach without also giving it an early-error pass would make things
+worse, not better.
+
+## Probe (current HEAD, host mode, `tests/probe-eval-mvp.test.ts` — gitignored)
+
+| probe                                   | got      | spec          | verdict  |
+| --------------------------------------- | -------- | ------------- | -------- |
+| `eval("'use strict'; var public = 1;")` | no throw | `SyntaxError` | **FAIL** |
+| `eval("break;")`                        | no throw | `SyntaxError` | **FAIL** |
+
+Re-run against unmodified `origin/main` (`3a262054c6`).
+
+## Measured denominator
+
+Baseline: `test262-current.jsonl` fetched 2026-07-25 18:21. Population =
+ES5-classified (post-#3626 classifier), `eval`-dependent, host lane: 775 tests,
+**484 not passing**. Of those, the failures reporting a _missing_ `SyntaxError`
+and reaching a body the folder accepts:
+
+| family                                                     | tests | signature                                           |
+| ---------------------------------------------------------- | ----- | --------------------------------------------------- |
+| `language/directive-prologue/10.1.1-{5,8,14,30,31,32}-s`   | 6     | `Expected a SyntaxError…` / `public is not defined` |
+| `language/statements/variable/12.2.1-{7,8,18,19}-s`        | 4     | `Expected a SyntaxError to be thrown…`              |
+| `language/eval-code/{direct,indirect}/parse-failure-{3,4}` | 4     | `break`/`continue` must throw `SyntaxError`         |
+| `language/statements/{break/S12.8_A7,continue/S12.7_A7}`   | 2     | `break`/`continue` within eval inside an iteration  |
+
+**16 ES5 tests measured** — a floor, not a flip prediction: a test whose first
+assertion is the missing `SyntaxError` may have further assertions behind it.
+Corpus-wide was not measured.
+
+Additionally **21 standalone-lane** failures report
+`Expected a SyntaxError but got a undefined` (standalone baseline, same date),
+consistent with the same missing early-error pass in the folded path — the
+folded path is the _only_ path in standalone mode.
+
+## Implementation direction
+
+Add an early-error validation walk over the parsed eval `SourceFile` between the
+`parseDiagnostics` check and `allNodesInlineSupported`, returning `undefined`
+(fall through to the dynamic path) is **not** sufficient in standalone mode
+where there is no dynamic path — so the walk should instead emit a
+`SyntaxError` **throw** at the eval call site. Minimum ruleset:
+
+1. `bodyIsStrict` (already computed at
+   `src/codegen/expressions/eval-inline.ts`, `evalBodyHasUseStrictDirective`)
+   ⇒ reject strict reserved words as binding identifiers
+   (`implements interface let package private protected public static yield`),
+   assignment to `eval`/`arguments`, and octal literals.
+2. `break` / `continue` with no enclosing iteration/labelled statement **inside
+   the eval Script** ⇒ `SyntaxError`. The eval body is a fresh Script; the
+   caller's loops are not in scope for it.
+
+## Acceptance criteria
+
+- `eval("'use strict'; var public = 1;")` and `eval("break;")` both throw `SyntaxError`.
+- The 16 tests listed above pass in the host lane.
+- `tests/issue-2923-eval-const-broaden.test.ts` still green (no `__extern_eval` leak in the standalone folded modules).
+
+## Not covered here
+
+Full strict-mode semantics inside eval (`this` binding, var-environment
+isolation), direct eval with a runtime string (#3630), standalone eval (#1066).

--- a/plan/issues/3633-extern-eval-cannot-see-compiled-module-bindings.md
+++ b/plan/issues/3633-extern-eval-cannot-see-compiled-module-bindings.md
@@ -1,0 +1,100 @@
+---
+id: 3633
+title: "__extern_eval evaluates in a scope containing none of the compiled module's bindings (184 test262 tests die on `assert is not defined`)"
+status: ready
+sprint: current
+goal: es5-complete
+priority: high
+horizon: l
+feasibility: hard
+---
+
+# The dynamic eval path cannot see the enclosing module's bindings
+
+## Problem
+
+When `tryStaticEvalInline` declines a constant eval body — most often on the
+deliberate `funcDeclNeedsDynamicEvalPath` guard (a nested `FunctionDeclaration`,
+i.e. AnnexB B.3.3 territory, see the #2923 park note in
+`src/codegen/expressions/eval-inline.ts`) — the call routes to the
+`__extern_eval` host import.
+
+`__extern_eval` (`src/runtime.ts` ~L8040) **compiles the eval string as a fresh,
+standalone js2wasm module** and instantiates it, with a `(0, eval)` host
+fallback. Neither route can see the _calling_ module's bindings: the fresh
+module is compiled from the string alone, and the host fallback runs in the JS
+global scope, where functions compiled into the Wasm module simply do not exist.
+
+Any identifier the eval body inherits from its enclosing program is therefore
+unresolvable. In test262 that identifier is almost always the harness itself.
+
+## Probe (current HEAD, host mode, `tests/probe-eval-mvp.test.ts` — gitignored)
+
+```ts
+function helper(): number {
+  return 5;
+}
+// direct:   eval("if (true) { function f() { return 1; } } helper();")
+// indirect: (0, eval)("if (true) { function f() { return 1; } } helper();")
+```
+
+| probe                            | got               | spec      | verdict  |
+| -------------------------------- | ----------------- | --------- | -------- |
+| direct eval, non-foldable body   | `value=undefined` | `value=5` | **FAIL** |
+| indirect eval, non-foldable body | `value=undefined` | `value=5` | **FAIL** |
+
+Mechanism confirmed (the body does not see `helper`). **Symptom differs from
+test262**: locally the call yields `undefined` without throwing; in test262 the
+body does `assert.sameValue(...)`, so the property read on the unresolved
+`assert` throws and is reported as `assert is not defined`. Both are the same
+root cause — the binding is not in scope — but the local repro does _not_
+reproduce the throw, and that discrepancy is itself worth understanding before
+implementing.
+
+## Measured denominator — and why the flip count is NOT 184
+
+Baseline: `test262-current.jsonl` fetched 2026-07-25 18:21. Population =
+ES5-classified (post-#3626 classifier), `eval`-dependent, host lane: 775 tests,
+**484 not passing**.
+
+- **184** of the 484 report literally `assert is not defined`.
+- All 184 are `annexB/language/eval-code/*` — procedurally generated AnnexB
+  B.3.3 tests. That family comes in two shapes: the `assert` call is either
+  **inside** the eval string or **outside** it.
+
+| shape (ES5, `annexB/language/eval-code`, host lane) | pass    | rate       |
+| --------------------------------------------------- | ------- | ---------- |
+| `assert` **inside** the eval string (masked)        | 0 / 144 | **0 %**    |
+| `assert` **outside** the eval string (unmasked)     | 89 /325 | **27.4 %** |
+
+The unmasked shape is the honest predictor for what the masked shape does once
+the masking is removed: both shapes test the same B.3.3 rules. So fixing scope
+visibility **unmasks** ~184 tests and would be expected to **flip ≈ 27 %** of
+them (≈ 50), with the remainder then failing on AnnexB B.3.3 semantics — which
+is #2200 / #2552's work, not this issue's.
+
+**Do not quote 184 as a flip count.** It is a gate count.
+
+## Why this is `hard`
+
+Making module bindings visible to `__extern_eval` means exporting a live
+binding view (read _and_ write — B.3.3 requires the eval body to create bindings
+the caller then observes) across the Wasm/host boundary. #1073 (`done`) injects
+_caller locals_; this is the module/global-scope half, and it has to work for
+the fresh-module compile route as well as the host-eval fallback. The
+alternative framing — teach the folded path to handle nested function
+declarations correctly so these bodies never reach `__extern_eval` — is
+tracked by #2200 / #2552 and would resolve the same 184 from the other side.
+
+## Acceptance criteria
+
+- The probe above returns `value=5` for both direct and indirect eval.
+- The `assert is not defined` signature disappears from the `annexB/language/eval-code`
+  bucket (the tests then pass or fail on B.3.3 assertions, which is the correct next gate).
+- Standalone lane behaviour is unchanged or improved — `__extern_eval` is absent
+  there, so this must not introduce a host import into a standalone module.
+
+## Not covered here
+
+AnnexB B.3.3 hoisting semantics (#2200 / #2552), eval in standalone mode
+(#1066), direct eval with a runtime string (#3630).

--- a/plan/issues/3633-extern-eval-cannot-see-compiled-module-bindings.md
+++ b/plan/issues/3633-extern-eval-cannot-see-compiled-module-bindings.md
@@ -67,13 +67,20 @@ ES5-classified (post-#3626 classifier), `eval`-dependent, host lane: 775 tests,
 | `assert` **inside** the eval string (masked)        | 0 / 144 | **0 %**    |
 | `assert` **outside** the eval string (unmasked)     | 89 /325 | **27.4 %** |
 
-The unmasked shape is the honest predictor for what the masked shape does once
-the masking is removed: both shapes test the same B.3.3 rules. So fixing scope
-visibility **unmasks** ~184 tests and would be expected to **flip ≈ 27 %** of
-them (≈ 50), with the remainder then failing on AnnexB B.3.3 semantics — which
-is #2200 / #2552's work, not this issue's.
+So fixing scope visibility **unmasks** ~184 tests; the remainder then fail on
+AnnexB B.3.3 semantics, which is #2200 / #2552's work, not this issue's.
 
-**Do not quote 184 as a flip count.** It is a gate count.
+**27.4 % is an UPPER BOUND on the post-unmasking flip rate, not a point
+estimate.** The two shapes are not equivalent populations: the masked variants
+put the `assert` call _inside_ the eval body, so after unmasking they exercise
+strictly more machinery inside the splice (harness property access, call
+dispatch, and the B.3.3 binding under test, all within the eval Script) than the
+unmasked variants do, where the assert runs in ordinary compiled code. The true
+rate is lower than 27.4 %; how much lower is only knowable from a post-fix
+re-run.
+
+**Do not quote 184 as a flip count** — it is a gate count. Do not quote 27.4 %
+as a flip count either; quote it as a ceiling.
 
 ## Why this is `hard`
 


### PR DESCRIPTION
## What this is

A measured partition of the ES5 `eval` gap, plus the three issues it justifies. Census-only; no compiler source changes.

**Baselines**: `loopdive/js2wasm-baselines` host + standalone JSONL, both fetched 2026-07-25 18:21, post-#3626 edition classifier.
**Population**: ES5-classified, `eval`-dependent (`*/eval-code/` ∪ `built-ins/eval` ∪ source matches `eval(`) = **775 tests, 484 not passing** in the host lane.

## Headline: the premise was wrong, in a useful direction

| bucket                                                     | tests   | share      |
| ---------------------------------------------------------- | ------- | ---------- |
| `annexB/language/eval-code/*` — **AnnexB B.3.3, not eval** | **380** | **78.5 %** |
| everything else                                            | 104     | 21.5 %     |

Every one of the 380 carries a **constant** eval string that the folder reaches and then _deliberately_ declines, on the `funcDeclNeedsDynamicEvalPath` guard. There is no "widen the constant folder" MVP in the host lane — ~475/484 already have a constant argument, and a bail routes to a host eval that is _more_ correct than the splice would be.

**That conclusion is lane-specific.** In standalone a bail is fatal: 149 eval-dependent ES5 tests pass in host and fail standalone, **110 with literally `dynamic eval is not supported in standalone mode`**. `annexB/language/eval-code` passes 89/469 (19 %) in host and **1/469 (0.2 %)** standalone.

## Issues filed (one per root cause, each probe-confirmed on stock `main` @ `3a262054c6`)

| #     | root cause                                                                                     | probe                                                    | measured denominator             |
| ----- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------- |
| #3631 | eval completion value: a non-`ExpressionStatement` last statement returns `undefined`          | `eval("if (true) { 41 + 1 }")` → `undefined`, spec `42`  | 7 ES5 tests                      |
| #3632 | folded eval body skips Script early errors (strict reserved words, stray `break`/`continue`)   | `eval("'use strict'; var public = 1;")` → no throw       | 16 ES5 tests (+21 standalone)    |
| #3633 | `__extern_eval` evaluates in a scope with none of the compiled module's bindings                | module fn invisible to both direct and indirect eval     | 184 **gated**; ≤27 % flip ceiling |

#3633's flip prediction is derived, not guessed: the same AnnexB family splits into `assert`-inside-the-eval-string (**0/144 pass**, masked) and `assert`-outside (**89/325 = 27.4 %**, unmasked). The unmasked rate is a **ceiling**, not a point estimate — the masked variants exercise strictly more machinery inside the splice after unmasking. **184 is a gate count; 27.4 % is a ceiling. Neither is a flip count.**

## Deliberately not filed

Already covered: #3630 (direct eval, runtime string), #1066 (standalone eval), #671 (`with`-in-eval), #2666 (compound-assignment `innerX`), #2742 (`charAt`/`charCodeAt` receivers), #2200/#2552 (AnnexB B.3.3). Evidence appended to **#2200** (the 380) and **#1066** (the 110 standalone-only) instead of duplicating them.

## Count reconciliation vs the #3626 census

The census reported 826 eval-dependent / 512 failing; this PR reports 775 / 484. Reconciled: ES5 totals agree exactly (8,930 vs 8,931 — one baseline entry), `existsSync` drops **0** files, and the `ce` apparent gap was a status-name mismatch (`compile_error`/`compile_timeout`, not `ce`). The residual is entirely **eval-detection breadth**: `/eval\(/` → 775/484, `/\beval\b/` → 913/552. All figures here use the narrower, exactly-specified `/eval\(/` rule.

## Related

The `#3630` `blocked-by: [1102, 1066]` correction (#1102 is already `done`) is pushed separately to `issue-3630-runtime-eval-compilation` — that file exists only on PR #3626's branch, not on `main`, so it cannot ride in this PR without stacking on a BLOCKED PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
