### PR TITLE
docs(#3634,#3635,#3636): file three lead-level infrastructure findings

### DIFF
--- a/plan/issues/3634-baseline-promote-silent-failure-needs-alerting.md
+++ b/plan/issues/3634-baseline-promote-silent-failure-needs-alerting.md
@@ -1,0 +1,75 @@
+---
+id: 3634
+title: "Baseline-promote can fail silently for hours, degrading every PR's regression gate — needs alerting + retry"
+status: ready
+created: 2026-07-25
+priority: high
+horizon: m
+feasibility: medium
+area: ci
+goal: ci-hardening
+related: [3467, 3468, 2562, 1235, 2547]
+---
+
+# #3634 — baseline-promote fails silently; every PR's regression gate degrades
+
+## What happened (measured, 2026-07-24/25)
+
+The job **"promote root baseline + cache per-SHA for queue merge (#3467/#3468)"**, step
+*"Promote root baseline + per-SHA cache to baselines repo"*, **failed on SIX CONSECUTIVE
+push-to-main runs** over ~2h45m:
+
+| run | time | merge |
+|---|---|---|
+| 30130790253 | 22:23Z | #3574 |
+| 30134053780 | 23:32Z | #3581 |
+| 30134654044 | 23:46Z | #3580 |
+| 30135274700 | 00:01Z | #3586 |
+| 30137169278 | 00:49Z | #3563 |
+| 30137847398 | 01:07Z | #3589 |
+
+It then self-recovered from 01:41Z onward.
+
+## Why it matters far beyond one job
+
+Every failed promote leaves the baselines-repo reference un-refreshed, so **each subsequent
+PR's regression gate diffs against an ever-staler baseline**. Observed on PR #3583:
+`SRC_BEHIND` climbed **3 → 8** in ~70 minutes with `CONTENT_CURRENT="false"` on both runs.
+
+#3583 was then **parked twice** on 26 then 32 "regressions" that were entirely Temporal
+`skip → compile_error` rows with **zero non-Temporal regressions** — transitions it did not
+cause. It merged unaided at 01:41Z once the promote recovered. **No code change was ever
+needed.** Three separate manual investigations that day traced back to this single cause.
+
+## The actual defect: nothing alerts
+
+The push-to-main runs show as `failure` in the Actions list and **nobody watches them** —
+the team watches PR checks. A silent multi-hour outage of the baseline publisher degrades
+the regression gate for *every open PR* and surfaces as unrelated PRs mysteriously parking.
+That misdirection is the expensive part, not the outage itself.
+
+## Fix, in order of value
+
+1. **ALERT on a failed baseline-promote.** This is the big one; the failure is currently
+   invisible and its blast radius is every open PR.
+2. **RETRY the promote step.** Six sequential merges each pushing to the baselines repo
+   smells like a push race — a retry-with-rebase would likely have absorbed all six.
+   Confirm against the six job logs before assuming.
+3. **Consider making the regression gate REFUSE TO VERDICT when `SRC_BEHIND` exceeds a
+   threshold**, rather than confidently diffing against a known-stale baseline and emitting
+   false regressions. A gate that says *"baseline too stale to judge"* is far cheaper than a
+   spurious park plus the investigation it triggers.
+
+## Discarded hypothesis — do not chase it
+
+The `github.actor != 'github-actions[bot]'` guard on *"promote merged report to main
+baseline"* is **NOT** the problem: the actor is `github-merge-queue[bot]`, which passes that
+clause. That job legitimately skips on push because the shard matrix has been
+merge_group-only since the #2519 slim-down.
+
+## Documentation bug found alongside
+
+CLAUDE.md states `test262-current.json` is *"refreshed by the promote-baseline job (every
+push to main)"*. Observed behaviour differs: **"promote merged report to main baseline" is
+SKIPPED on push**; the job that actually publishes is **"promote root baseline + cache
+per-SHA"**. Anyone diagnosing this from the docs looks at the wrong job first — I did.

--- a/plan/issues/3635-actions-artifact-storage-exhaustion.md
+++ b/plan/issues/3635-actions-artifact-storage-exhaustion.md
@@ -1,0 +1,75 @@
+---
+id: 3635
+title: "~985k Actions artifacts accumulated — storage exhaustion, likely cause of the artifact 403s"
+status: ready
+created: 2026-07-25
+priority: high
+horizon: s
+feasibility: easy
+area: ci
+goal: ci-hardening
+related: [3634, 2547, 2519]
+---
+
+# #3635 — ~985k Actions artifacts; storage exhaustion
+
+## The measurement
+
+`GET repos/loopdive/js2/actions/artifacts` reports **`total_count = 984,897`**, with **0
+expired** on the sampled page. The most recent 100 artifacts total **120 MB** (~1.2 MB
+average).
+
+**DO NOT QUOTE A TOTAL SIZE FROM THAT AVERAGE.** The sampled page is biased — those names
+are small `issue-tests-partial-*` files at ~0 MB each, whereas the test262 report/group
+artifacts are 15-30 MB. A naive scale gives ~1.2 TB but the true figure could be well
+either side. Read the real number from **Settings → Billing → Actions/Packages storage**;
+the REST billing endpoints need `admin:org` (the container token has only `gist, read:org,
+repo, workflow`).
+
+## Why this is the explanation for the "used up minutes" report
+
+Public repos get **unlimited standard-runner minutes**, and this repo uses only standard
+runners — verified: **61× `ubuntu-latest`, 2× `ubuntu-24.04`, zero larger-runner labels**.
+All three relevant repos are public (`loopdive/js2`, `ttraenkler/js2`,
+`loopdive/js2wasm-baselines`). So it was never minutes.
+
+**Actions artifact STORAGE is billed and enforced regardless of repo visibility.**
+
+## Why it accumulated
+
+The sharded test262 matrix produces **114 jobs per merge_group run**, most uploading
+artifacts, and the queue runs many times a day. With default 90-day retention and nothing
+pruning, this compounds continuously.
+
+## Suspected knock-on — VERIFY, do not assume
+
+A quota-exceeded state can surface as a 403 on artifact operations. Two failures on
+2026-07-24/25 fit that shape:
+
+- **#3566's false park**: `Failed to ListArtifacts: (403) Forbidden` on *"Download shard
+  artifacts"*, which skipped the verdict step entirely and parked a healthy PR.
+- **The six consecutive baseline-promote failures** (#3634), which also touch
+  artifact/storage operations.
+
+If storage exhaustion is the cause, those are **not independent bugs** and #3634's
+retry/alerting is treating a symptom. Confirm by checking whether the 403s stop once
+storage is reclaimed.
+
+## Fix
+
+1. **Set a short artifact retention** for this repo (Settings → Actions → Artifact and log
+   retention). Default is 90 days; for a 114-artifact-per-run matrix, days rather than
+   months. Shard artifacts have no value once the merged report exists.
+2. Add explicit **`retention-days:`** to the heavy upload steps in `test262-sharded.yml` so
+   they self-expire regardless of the repo default.
+3. **Bulk-delete the backlog** (`DELETE /repos/{o}/{r}/actions/artifacts/{id}`) — needs
+   care and rate-limiting at ~985k objects.
+4. **Re-check whether the artifact 403s and promote failures stop** once reclaimed.
+
+## Ruled out (probably) but worth confirming
+
+The org has **41 private repos** sharing the account quota. Nearly all are dormant (last
+pushed 2020-2025); the only recent ones are `company-website` (2026-05-20),
+`html-device-mockup` (2026-02-25), `cloudflare-worker-openai` (2025-07-26). Private-repo
+Actions **do** consume minutes, so glance at their recent run activity before concluding
+this is entirely artifacts.

--- a/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
+++ b/plan/issues/3636-claim-issue-allocator-hands-out-taken-ids.md
@@ -1,0 +1,68 @@
+---
+id: 3636
+title: "claim-issue.mjs --allocate hands out already-taken ids, even WITH the full PR scan"
+status: ready
+created: 2026-07-25
+priority: high
+horizon: s
+feasibility: medium
+area: tooling
+goal: ci-hardening
+related: [2531, 1616]
+---
+
+# #3636 — the id allocator hands out taken ids
+
+## Five collisions in one sprint
+
+| # | shape | detail |
+|---|---|---|
+| 1 | cross-lane | `--allocate` gave 3585; another lane landed `3585-*` on main mid-flight → renumbered to 3592 |
+| 2 | **self**-collision | one agent filing two issues in quick succession got **3589 twice** → parked PR #3581 on the #1616 integrity gate |
+| 3 | main-vs-PR | PR #3614 introduces `3620-*` while main already has a different `3620-*` |
+| 4 | cross-lane, **full scan enabled** | `--allocate` **with** the PR scan returned **3619**, already used by open PR #3614; **3620 and 3621 likewise taken** (#3614/#3615) → renumbered to 3622 |
+| 5 | main-vs-PR | PR #3627 adds `3630-*` after PR #3626 merged a different `3630-*` |
+
+## The regression
+
+The earlier working theory was that `--no-pr-scan` was the proximate cause — one agent's
+*both* collisions came from it, while every full-scan allocation held. **Case 4 refutes
+that**: the full scan returned an id already used by an open PR, and the next two were
+taken as well.
+
+So the open-PR half of the scan is **not reliably seeing in-flight ids**. That is the bug.
+
+## Why each one is expensive
+
+The collision is invisible at PR level and only fails in the **`merge_group`** — via
+`check:issue-ids:against-main` (id already on main) or the **Issue integrity + link gate
+(#1616)** (two files with the same id in one tree). Both live in `quality`. So a green PR
+gets parked later, costing a full CI round-trip plus a manual diagnosis each time.
+
+**Note the two distinct gates** — don't pattern-match on one; case 2 hit #1616, case 3 hits
+`against-main`.
+
+## Investigate
+
+1. Does the open-PR scan paginate? At the current PR volume an unpaginated first page would
+   silently miss in-flight ids — that shape would explain case 4 exactly.
+2. Is there a caching or a stale-fetch step between the scan and the reservation?
+3. Does the reservation on the orphan `issue-assignments` ref propagate fast enough for a
+   second `--allocate` seconds later? Case 2 (self-collision) suggests not.
+
+## Guard rails to add regardless of root cause
+
+- **Verify-after-allocate**: re-check the returned id against `main` ∪ open PRs ∪ the
+  assignments ref immediately before writing files, and fail loudly on a hit.
+- **Renumbering is itself a trap**: a `git mv` that leaves the in-file `id:` unstaged
+  produced a *re-collision* this sprint. The only signal was gh's
+  `Warning: 1 uncommitted change` on `pr create`. After any renumber, **grep the whole
+  change-set for the old id and require zero hits** — filename, `id:` frontmatter, heading,
+  cross-refs, test names, PR title, and rationale comments in code.
+- **Verify the incumbent with `git ls-tree origin/main`, not by assumption.** The lead
+  asserted which of two same-id files was already on main and had it exactly inverted.
+
+## NOT the same issue
+
+#3602 is `compile-timeout dstr-iter family` — unrelated. It was mis-cited as covering this
+class; it does not.


### PR DESCRIPTION
Three infrastructure findings diagnosed during sprint 77 that lived only in the session TaskList — which does not survive the session. Filing so they aren't lost.

Docs only. No source changes, no deletions.

## #3634 — baseline-promote can fail silently for hours

It failed on **six consecutive push-to-main runs** over ~2h45m (22:23Z–01:07Z), then self-recovered. Each failure leaves the baselines reference un-refreshed, so every subsequent PR's regression gate diffs against an ever-staler baseline — `SRC_BEHIND` climbed **3 → 8** in ~70 minutes.

PR #3583 was parked **twice** on transitions it did not cause (26 then 32 "regressions", all Temporal `skip → compile_error`, **zero** non-Temporal) and merged unaided once the promote recovered. **No code change was ever needed.** Three separate manual investigations that day traced back to this one cause.

**The real defect is that nothing alerts.** The team watches PR checks, not push-to-main runs, so a multi-hour outage of the baseline publisher is invisible and surfaces as unrelated PRs mysteriously parking.

Includes a discarded hypothesis (the `github-actions[bot]` actor guard — the actor is `github-merge-queue[bot]`, which passes it) so nobody re-chases it, and a documentation bug: CLAUDE.md names the wrong job as the publisher.

## #3635 — ~985k Actions artifacts, none expired

Public repos get unlimited **standard-runner** minutes, and this repo uses only standard runners (verified: 61× `ubuntu-latest`, 2× `ubuntu-24.04`, zero larger-runner labels). So the reported quota exhaustion was **never minutes** — artifact **storage** is billed regardless of visibility, and the sharded matrix produces 114 artifacts per merge_group run with 90-day retention and nothing pruning.

**Deliberately does not quote a total size.** The sampled page is biased toward small files; extrapolating from it would be precisely the error this sprint kept making. The real figure needs the billing page (`admin:org` scope).

Flags a suspected knock-on to verify rather than assume: the #3566 artifact **403** and #3634's promote failures may not be independent bugs.

## #3636 — the id allocator hands out already-taken ids

**Five collisions this sprint.** Case 4 refutes the earlier working theory that `--no-pr-scan` was the cause: the **full** scan returned an id already used by an open PR, and the next two were taken as well. So the open-PR half of the scan is not reliably seeing in-flight ids.

Each collision costs a full CI round-trip, because it's invisible at PR level and only fails in the `merge_group` — via **either of two distinct gates**, so don't pattern-match on one.

Also records the renumbering trap that caused a *re*-collision (a `git mv` leaving the in-file `id:` unstaged, with gh's uncommitted-change warning as the only signal), and notes that **#3602 does not cover this class** despite being cited as such.
