### PR TITLE
fix(#3543): preserve nested anytuple element carrier

### DIFF
--- a/plan/issues/3543-standalone-heterogeneous-anytuple-nested-read-traps.md
+++ b/plan/issues/3543-standalone-heterogeneous-anytuple-nested-read-traps.md
@@ -1,8 +1,9 @@
 ---
 id: 3543
 title: "standalone: heterogeneous inner-tuple (anytuple) nested reads broken — numbers read back NaN, strings trap 'dereferencing a null pointer' (5 red tests on main)"
-status: ready
+status: in-review
 created: 2026-07-23
+updated: 2026-07-26
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -15,7 +16,13 @@ umbrella: 2860
 sprint: current
 horizon: m
 related: [2190, 2873, 3497]
-origin: "Red-suite triage 2026-07-23 (fable-exposed): 5 tests in tests/issue-2190.test.ts (#2190b block) fail on clean origin/main; bisect (tech lead) shows identical failures at aa203fdc5b7b3b, the commit BEFORE #3497 — long-standing, not caused by anything landed 2026-07-23."
+origin: "Red-suite triage 2026-07-23 (fable-exposed): 5 tests in tests/issue-2190.test.ts (#2190b block) fail on clean origin/main. A scoped source bisection on 2026-07-26 identified 570c816bbea429b81e672ccc2f9b9caed44ba33a (#745 S4.5 unionAnyRep native-lane default flip) as the first bad commit."
+# The fix belongs at compileArrayLiteral's carrier-selection seam: it must align
+# the outer expected vec type with the inner literal writer before construction.
+loc-budget-allow:
+  - src/codegen/literals.ts
+func-budget-allow:
+  - src/codegen/literals.ts::compileArrayLiteral
 ---
 
 # #3543 — standalone heterogeneous anytuple nested reads: NaN / null-deref traps
@@ -25,41 +32,44 @@ origin: "Red-suite triage 2026-07-23 (fable-exposed): 5 tests in tests/issue-219
 `npx vitest run tests/issue-2190.test.ts` — the 5 failures in the
 `#2190b heterogeneous inner-tuple read-back` block:
 
-| test | expected | actual |
-| --- | --- | --- |
-| `[["a", 7]]` — `e[0][1]` reads the number | 7 | **NaN** |
-| `[["a", 7]]` — `e[0][0]` still reads the string | "a" | **trap: dereferencing a null pointer** |
-| `[[7, "ab"]]` — `e[0][1]` reads the string | "ab" | **trap: dereferencing a null pointer** |
-| `[[7, "ab"]]` — `e[0][0]` still reads the number | 7 | **NaN** |
-| three-element mixed `[string, number, string]` | — | **trap: dereferencing a null pointer** |
+| test                                             | expected | actual                                 |
+| ------------------------------------------------ | -------- | -------------------------------------- |
+| `[["a", 7]]` — `e[0][1]` reads the number        | 7        | **NaN**                                |
+| `[["a", 7]]` — `e[0][0]` still reads the string  | "a"      | **trap: dereferencing a null pointer** |
+| `[[7, "ab"]]` — `e[0][1]` reads the string       | "ab"     | **trap: dereferencing a null pointer** |
+| `[[7, "ab"]]` — `e[0][0]` still reads the number | 7        | **NaN**                                |
+| three-element mixed `[string, number, string]`   | —        | **trap: dereferencing a null pointer** |
 
 The sibling cases in the same block PASS: boolean+number heterogeneous tuple,
 flat `any[]` `[0, "last"]`, pure `number[][]` nested, pure `string[]`. So the
 break is specific to **string⊕number heterogeneous INNER tuples read through
 the nested `e[0][k]` dynamic path**.
 
-## Diagnosis (triage-level, verbatim from the red-suite investigation)
+## Confirmed root cause
 
-- This is a **trap-class** failure (NaN garbage / null-pointer deref), NOT a
-  miss-value-class one — do not confuse it with the two (now re-pinned)
-  `issue-3183` miss-value expectations in the same triage batch.
-- Numbers reading back **NaN** + strings **null-deref** through the same path
-  smells like the inner tuple's element representation and the reader's
-  expected representation diverging per element kind — i.e. the nested read
-  unboxes with the WRONG per-kind arm (a number slot read as a ref → null →
-  deref trap; a ref slot read as a number → NaN).
-- Plausibly value-rep / RTT-creation-order territory: cf.
-  `reference_2873_funcref_wrapper_chain_rtt_order` (wrapper RTT identity is
-  creation-ORDER-dependent) and the #2379 boxed-any element-rep notes
-  (`reference_2379_new_array_n_boxed_any_elem_rep`). The heterogeneous literal
-  path may register/choose a `__vec_<kind>` carrier whose runtime `ref.test`
-  ordering in `__extern_get_idx`'s spliced vec arms
-  (`fillExternGetIdxVecArms`, src/codegen/object-runtime.ts ~5317) resolves a
-  DIFFERENT carrier than the one the literal actually built.
-- Long-standing: identical 7-failure state (these 5 + the 2 since-re-pinned
-  #3183 ones) at `aa203fdc5b7b3b` (pre-#3497). #3497 and #3506/#3537 are both
-  exonerated (verified by running the suite against clean main src and against
-  the #3537 branch — identical failures on both).
+- The first bad commit is
+  `570c816bbea429b81e672ccc2f9b9caed44ba33a`, which made `unionAnyRep` the
+  native-string-lane default. `JS2WASM_UNION_ANYREP=0` restores all 20 focused
+  tests, confirming the representation switch as the causal boundary.
+- The inner `["a", 7]` literal is initially correct: its bare-`any` context
+  activates the existing #2190b/#2106 widening and builds `__vec_externref`,
+  with each element boxed according to its actual JS type.
+- The outer literal instead resolves the inner expression's inferred
+  `(string | number)[]` type under `unionAnyRep`, so it expects
+  `__vec_ref_<AnyValue>`. Generic vec-to-vec coercion immediately copies the
+  correct externref elements through `__any_box_extern_s1` into that different
+  carrier.
+- `__extern_get_idx` then matches the **correct** AnyValue-vec RTT arm; arm
+  creation/test order is not the bug. Its generic GC-ref boxing returns an
+  externref wrapping the `$AnyValue` struct rather than the JS payload. Numeric
+  consumers therefore see an unrecognized wrapper and produce NaN, while
+  native-string casts miss and null-deref.
+- The implementation re-keys only this proven construction mismatch: when both
+  nested literals are contextually `any`, the inferred carrier is specifically
+  `Vec<AnyValue>`, and neither literal spreads, the outer carrier expects the
+  canonical `Vec<externref>` that the inner writer actually emits. Typed unions,
+  homogeneous matrices, flat arrays, spread construction, and the flag-off
+  lane stay outside the predicate.
 
 ## Repro
 

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -148,6 +148,16 @@ function arrayLiteralIsUndefinedOrHoleOnly(arr: ts.ArrayLiteralExpression): bool
 }
 
 /**
+ * Is an array literal produced directly into an unconstrained `any` element
+ * position? Accept bare `any` (an inner literal of `any[]`) and
+ * `Array<any>`/`ReadonlyArray<any>` (the outer literal), but not typed unions.
+ */
+function arrayLiteralHasAnyElementContext(ctx: CodegenContext, arr: ts.ArrayLiteralExpression): boolean {
+  const contextual = ctx.oracle.contextualFactOf(arr);
+  return contextual?.kind === "any" || (contextual?.kind === "array" && contextual.element.kind === "any");
+}
+
+/**
  * Ensure that a struct registered for an object literal includes fields for
  * computed property names that TypeScript cannot statically resolve.
  * When TS returns 0 properties (e.g. { [1+1]: 2 }), we resolve the computed
@@ -3982,6 +3992,38 @@ export function compileArrayLiteral(
         }
       }
     }
+  }
+  // (#3543) Preserve the carrier that a nested heterogeneous literal ACTUALLY
+  // builds in an `any` context. With `unionAnyRep` enabled, the outer literal's
+  // first-element TS type `(string | number)[]` resolves to
+  // `__vec_ref_<AnyValue>`. The inner literal's existing #2190b/#2106 writer,
+  // however, correctly widens its mixed elements to canonical
+  // `__vec_externref`. Compiling that inner value against the inferred outer
+  // carrier immediately copies every externref element into `$AnyValue`; the
+  // dynamic vec reader then externalizes the wrapper rather than its payload,
+  // so numbers become NaN and native-string casts null-deref. The RTT arm order
+  // is not involved: the correct AnyValue vec arm matches.
+  //
+  // Re-key only this proven writer/inference mismatch. Both literals must be in
+  // a genuine any context, the inferred element must specifically be a vec of
+  // AnyValue, and neither construction may contain a spread. Typed union
+  // matrices, homogeneous matrices, flat arrays, and the flag-off lane remain
+  // byte-identical.
+  const inferredInnerVec =
+    elemWasm.kind === "ref" || elemWasm.kind === "ref_null" ? getVecInfo(ctx, elemWasm.typeIdx) : null;
+  if (
+    ctx.unionAnyRep &&
+    !hasSpread &&
+    ts.isArrayLiteralExpression(firstElem) &&
+    !firstElem.elements.some(ts.isSpreadElement) &&
+    arrayLiteralHasAnyElementContext(ctx, expr) &&
+    arrayLiteralHasAnyElementContext(ctx, firstElem) &&
+    inferredInnerVec &&
+    (inferredInnerVec.elemType.kind === "ref" || inferredInnerVec.elemType.kind === "ref_null") &&
+    inferredInnerVec.elemType.typeIdx === ctx.anyValueTypeIdx
+  ) {
+    const innerVecIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+    elemWasm = { kind: "ref_null", typeIdx: innerVecIdx };
   }
   // (#2769) for-of over a direct array LITERAL whose binding pattern has an
   // element default / nested sub-pattern: the OUTER literal must not coerce an


### PR DESCRIPTION
## Summary

- preserve the canonical `Vec<externref>` emitted by nested heterogeneous array literals in contextual-`any` positions
- gate the carrier re-key to the exact `unionAnyRep` mismatch: both literals contextually `any`, inferred `Vec<AnyValue>`, and no spreads
- update the current-sprint issue with the scoped bisection and confirmed representation trace

## Root cause

The inner `["a", 7]` literal correctly widens to `__vec_externref`, but the outer literal sees the inferred `(string | number)[]` type. With `unionAnyRep` enabled by default on standalone, that inference predicts `__vec_ref_<AnyValue>`, so generic vec-to-vec coercion immediately rewrites the correct inner carrier.

`__extern_get_idx` later matches the correct AnyValue-vec RTT arm; arm order is not the problem. The reader externalizes the `$AnyValue` wrapper rather than its payload, which makes numeric consumers return NaN and native-string casts become null before dereference.

The fix aligns the outer expected carrier with the inner writer only for this proven mismatch. Typed unions, homogeneous matrices, flat arrays, spread construction, and `unionAnyRep:false` remain outside the predicate.

## Impact

The five current-main failures in the `#2190b heterogeneous inner-tuple read-back` block now pass: string-first, number-first, and three-element mixed nested tuples retain both numeric and string values.

## Validation

- `tests/issue-2190.test.ts`: 20/20 passed (was 15 passed, 5 failed)
- `tests/issue-3183.test.ts` + `tests/issue-745.test.ts`: 41/41 passed
- `pnpm run typecheck`
- Prettier check and Biome lint on changed files
- `check:loc-budget`, `check:func-budget`, `check:oracle-ratchet`, and `check:issues`
- refreshed and fast-forwarded to `origin/main` at `363ae6857639a3`

No local Test262 sweep was run; merge-group CI remains the authoritative conformance gate.

Plan issue: #3543

Co-authored-by: Codex <codex@openai.com>
