### PR TITLE
fix(#3644): read trap-growth-allow in the baseline writers, not just on the PR

### DIFF
--- a/plan/issues/3644-trap-growth-allow-unreadable-in-baseline-writers.md
+++ b/plan/issues/3644-trap-growth-allow-unreadable-in-baseline-writers.md
@@ -1,6 +1,6 @@
 ---
 id: 3644
-title: "P0: `trap-growth-allow` is honored on the PR but unreadable in the baseline writers — one landed allowance wedges promotion permanently and stops the queue"
+title: "`trap-growth-allow` is honored on the PR but unreadable in the baseline writers — one landed allowance wedges promotion permanently, forcing the blanket emergency valve"
 status: done
 sprint: current
 created: 2026-07-26
@@ -19,6 +19,43 @@ origin: "Live outage 2026-07-25 19:52 → 2026-07-26. Diagnosed by the tech lead
 ---
 
 # #3644 — an allowance must be readable everywhere it is enforced
+
+## Status update — the outage was cleared OPERATIONALLY while this was in flight
+
+**Do not read this issue as the thing that unblocked the queue. It is not.**
+Measured 2026-07-26 shortly after the fix was written:
+
+| when (UTC) | what |
+| --- | --- |
+| 19:54 | `write-run-cache-bot` fails: `previous illegal_cast=74`, `candidate=75`, `(tolerance 0)` |
+| 22:43:12 | the same job, re-run, succeeds: `previous=74`, `candidate=75`, **`(tolerance 1)`** |
+| 22:44:21 | repo variable `BASELINE_TRAP_GROWTH_ALLOW` reset `1 → 0` |
+| 22:46:52 | next promote: `previous=75`, `candidate=75`, `(tolerance 0)` — clean |
+
+So the wedge was cleared by **option (c)** — the repo Actions variable
+`BASELINE_TRAP_GROWTH_ALLOW=1` for one cycle, correctly reset one minute later.
+Verified: the baseline now reports `illegal_cast` = **75**
+(`grep -ac '"error_category":"illegal_cast"'` on the force-fetched JSONL), the
+declared test's row is `status: fail`, `error_category: illegal_cast`, and the
+variable currently reads `0`. **No manual `workflow_dispatch` is needed, and the
+emergency valve is not left open.**
+
+Note the 22:43 log has **no** `using change-scoped per-category ceiling` line —
+the tolerance came from `--allow`, not from the declaration. That distinction is
+the whole point of this issue:
+
+**What (c) cost, and why this fix still matters.** `BASELINE_TRAP_GROWTH_ALLOW=1`
+is a **blanket +1 for every trap category**, unscoped and unverified, for the
+duration of the cycle. It banked the growth into the floor rather than attributing
+it. Had this fix been in place, #3629's declaration would have been consumed
+instead: **scoped to one named test, machine-verified as non-passing on the
+baseline, and self-expiring** (later refreshes see no granting issue in their
+change-set). Same promotion, but the ratchet stays sharp for every other category
+and every other file, and the reason is recorded in the issue file rather than in
+a repo variable someone must remember to reset.
+
+So this is a **durability fix, not the unblock**: it stops the *next* correctly
+declared allowance from wedging the pipeline and forcing the blunt lever again.
 
 ## The rule this violates
 
@@ -142,7 +179,11 @@ exits **1** at `tolerance 0` with no ceiling line (allowance never read); the fi
 exits **0** at `tolerance 1` with the VERIFIED note. `tsc --noEmit` clean;
 `tests/issue-3303.test.ts` 44/44 pass unchanged.
 
-## ⚠️ This fix does NOT self-trigger — a manual dispatch is required
+## ⚠️ This fix does NOT self-trigger (kept for the record — no longer needed)
+
+*Superseded by the status update above: the baseline is already at 75, so no
+dispatch is required now. The mechanics below remain true and will matter the
+next time a promote needs triggering.*
 
 `test262-sharded.yml`'s `push` trigger carries the `&test262-paths` filter
 (`:33-35`). This PR deliberately touches only
@@ -168,9 +209,20 @@ which suppress a gate:
 - **#3645** — the regression test. Deliberately **not** in this PR: a file under
   `tests/` pulls the change-set into the shard matrix and would block the very
   fix that unblocks it. Not an oversight.
-- Whether `scripts/check-baseline-trap-growth.ts` *should* be on `&test262-paths`
-  (it gates the baseline, so arguably yes) is a real question — but adding it is
-  self-blocking today and must wait until the queue moves.
+- **Should `scripts/check-baseline-trap-growth.ts` go on `&test262-paths`?
+  RULED: no — on principle, not on expedience.** (Raised during this PR and
+  settled, so nobody reopens it as an oversight.) That path list answers exactly
+  one question: *could this change alter test **results**, such that the 106-shard
+  matrix must re-run?* A gate script cannot alter results — it alters the
+  **verdict**. Adding it would (i) charge a full matrix run for every
+  gate-logic change, and (ii) **make the gate's own repair path depend on the
+  gate passing** — which is precisely the deadlock this issue exists to unwind.
+  A gate whose fix is gated by itself has no repair path; that property is the
+  bug, and it must not be deliberately re-created in a second place. The correct
+  validation for a gate script is **unit tests on its verdicts** (#3645), not the
+  shard matrix — the four-row exit-code table above already proves more about
+  this gate than a matrix run would. If belt-and-braces is ever wanted, the right
+  form is a required check that runs the gate's unit tests, not a paths entry.
 - Same family as the open task on `regressions-allow` being rebase-mode only.
   The durable framing for both: **an allowance must be readable everywhere it is
   enforced.**

--- a/plan/issues/3644-trap-growth-allow-unreadable-in-baseline-writers.md
+++ b/plan/issues/3644-trap-growth-allow-unreadable-in-baseline-writers.md
@@ -1,0 +1,186 @@
+---
+id: 3644
+title: "P0: `trap-growth-allow` is honored on the PR but unreadable in the baseline writers — one landed allowance wedges promotion permanently and stops the queue"
+status: done
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+completed: 2026-07-26
+priority: high
+horizon: m
+feasibility: medium
+task_type: ci
+area: ci, merge-queue
+es_edition: multi
+goal: release-pipeline
+assignee: ttraenkler/opus-loop-b
+related: [3596, 3370, 3335, 3189, 3303, 3629, 3634, 3611, 3645]
+origin: "Live outage 2026-07-25 19:52 → 2026-07-26. Diagnosed by the tech lead from a parked PR traced back four hops; root cause corrected during implementation (see below)."
+---
+
+# #3644 — an allowance must be readable everywhere it is enforced
+
+## The rule this violates
+
+**A gate that runs after merge and can only ever say "no" has no repair path.**
+The code is already on `main`; refusing to promote does not undo it — it only
+blinds every downstream gate and blocks the fix for the very condition it
+detects. So any post-merge gate must either be advisory, or read the **same
+allowances the pre-merge gate reads**. This one did neither.
+
+## Root cause — one conditional
+
+`scripts/check-baseline-trap-growth.ts` read the change-scoped declaration
+**only across a forward oracle bump**:
+
+```ts
+let scopedAllow = 0;
+if (forwardOracleBump) {                       // ← the entire bug
+  const loaded = await readChangeScopedNumericAllowance({ key: TRAP_GROWTH_ALLOW_KEY, … });
+```
+
+That is the pre-#3596 rule. #3596 replaced it on the PR side with a
+**shape-driven** contract — a declaration carrying a nested `tests:` list is
+honoured in *both* modes and machine-verified — but the baseline writers were
+never updated. So the same frontmatter was honoured at PR and `merge_group`
+level and then ignored by the post-merge writers.
+
+### The hypothesis this replaces
+
+The outage was first diagnosed as *"the promote job runs on a `push` event with
+no PR context and cannot read the allowance."* **That is not what happened.**
+`resolveChangeBase` (`scripts/lib/change-scope.mjs:68-85`) explicitly handles
+`pull_request`, `merge_group`, `push` **and** `workflow_dispatch` via `HEAD^1`
+of the synthetic merge commit, and `tests/issue-3303.test.ts:126` already pins
+`fetch-depth: 2` on the writer's checkout so that parent resolves. The context
+was reachable; the code simply never looked.
+
+**The evidence that distinguishes the two** — from the failing run (job
+`89715789577`): the log prints `(tolerance 0)` and **no** `oracle vN → vM: using
+change-scoped per-category ceiling` line and **no** reader notes. That is the
+allowance *never being read*, not being read and rejected. A wrong root cause
+here would have produced a much larger and entirely unnecessary change.
+
+## What it cost (measured)
+
+1. **PR #3629** landed a correct, named, verifiable declaration in
+   `plan/issues/2900-…md` for one fail→fail reclassification of
+   `test/language/module-code/top-level-await/pending-async-dep-from-cycle.js`.
+   Nothing wrong was done.
+2. The queue-merge writer hard-failed `illegal_cast 74 → 75`. **Permanently, not
+   transiently** — nothing on `main` will ever lower that count again.
+3. Baseline froze at 74 while `main` sat at 75. Verified directly against the
+   force-fetched baseline: `grep -ac '"error_category":"illegal_cast"'` → **74**,
+   and the declared test's row is `status: fail`, `error_category: type_error`,
+   `oracle_version: 11` — i.e. genuinely non-passing, genuinely same-oracle.
+4. **Cascade:** every later PR's `merge_group` compared merged-state 75 against
+   the frozen 74 and failed on a trap belonging to `main`. PR #3627 — `scripts/`
+   + `tests/` + `plan/` only, and a healthy **+56 pass** — was parked twice on
+   the identical trap on the identical test that `main`'s own writer cites.
+
+**The `merge_group` half needs no separate valve, and must not get one.** It is
+a cascade of (2), not a second defect: once promotion succeeds the baseline
+becomes 75 and every PR compares 75 vs 75. A per-PR valve would also be *wrong*
+in principle — **a change-scoped allowance is correctly unreachable for a change
+you did not make.** Fixing the writer fixes both.
+
+## Fix
+
+The declaration's **shape** selects the contract, in every enforcement context —
+byte-for-byte the rule `diff-test262.ts` already applies:
+
+| declaration shape | PR / `merge_group` | baseline writers (was) | baseline writers (now) |
+| --- | --- | --- | --- |
+| `tests:` present | honoured, verified | **ignored unless oracle bumped** | honoured, verified |
+| bare `count:` | oracle-bump only | oracle-bump only | oracle-bump only (unchanged) |
+
+Verification is `evaluateTrapReclassification` — the existing pure function, so
+the two enforcement points cannot drift: every named test must be non-passing on
+the previous baseline (a `pass → trap` transition is a real regression and still
+hard-fails), and every file responsible for the growth must be named.
+
+Both writers in `test262-sharded.yml` — `promote-baseline` **and**
+`write-run-cache-bot` (the queue-merge writer, which is the one that actually
+wedged) — call this one script, so the single change covers both.
+
+### Two secondary fixes in the same PR
+
+- **A false comment.** The header claimed *"The FORCED refresh path bypasses the
+  gate."* True of `refresh-baseline.yml` (`:490` guards on `IS_FORCED`), **false
+  of `test262-sharded.yml`**, where the wedge lives and there is no force guard
+  at all — `force_baseline_refresh` is consulted only by the separate
+  `regression-gate` job (hence its narrow "regardless of **regressions**"
+  wording) and by an audit step that merely echoes a warning. A comment that
+  asserts a guarantee holding in one caller and not another is worse than no
+  comment; it is now stated per caller. *(This is the third inert-or-misstated
+  mechanism found in one day, alongside the retired `ci-status` feed and
+  `refresh-baseline.yml` itself being `disabled_manually`. **Establish that a
+  mechanism is live in the caller you mean before relying on it.**)*
+- **Silent-vs-loud.** When the gate refuses and no declaration was found, it now
+  prints the resolved base, how it was resolved, and the change-set's
+  `plan/issues` files — including an explicit *"diff failed — scoping is BROKEN,
+  not merely empty"*. Previously "never read" and "read and rejected" looked
+  identical in the log, which is why this took four hops to diagnose.
+
+## Validation
+
+Local reproduction of the real row (`.tmp/repro/`, not committed), driven through
+the documented `TRAP_GROWTH_ALLOW_FILE` hook so it is hermetic. **Real** exit
+codes (the first harness reported a vacuous `EXIT=0` for every case via a `sh`
+bashism — `${PIPESTATUS:-$?}` after a pipe returns `sed`'s status; fixed before
+drawing any conclusion):
+
+| case | expected | got |
+| --- | --- | --- |
+| no declaration | fail | **exit 1** — strict ratchet intact |
+| the real #3629 declaration (named, same oracle) | pass | **exit 0**, `tolerance 1`, VERIFIED |
+| bare `count:`, no oracle bump | fail | **exit 1** — inert, #3370 unchanged |
+| names a test that was **passing** on baseline | fail | **exit 1** — not an escape hatch |
+
+A/B against stock `main` with the **identical** declaration file present: stock
+exits **1** at `tolerance 0` with no ceiling line (allowance never read); the fix
+exits **0** at `tolerance 1` with the VERIFIED note. `tsc --noEmit` clean;
+`tests/issue-3303.test.ts` 44/44 pass unchanged.
+
+## ⚠️ This fix does NOT self-trigger — a manual dispatch is required
+
+`test262-sharded.yml`'s `push` trigger carries the `&test262-paths` filter
+(`:33-35`). This PR deliberately touches only
+`scripts/check-baseline-trap-growth.ts`, which is **not** on that list — that is
+what lets it green-skip the shard matrix and land at all (a PR that ran the
+shards would hit the very trap it fixes and be parked, as #3627 was).
+
+The same property means **merging it produces no push-triggered run, so the
+promote job never fires and the baseline stays at 74.** To take effect it needs a
+plain, **non-forced** `workflow_dispatch` of `test262-sharded.yml` on `main`:
+that satisfies the `workflow_dispatch` arm of `promote-baseline`'s `if`, runs the
+corrected gate, reads and verifies the allowance, promotes to 75, and reopens the
+queue. **Nothing is banked or bypassed — every gate still enforces; it is only
+being triggered manually.** Strictly better than the two alternatives, both of
+which suppress a gate:
+
+- `BASELINE_TRAP_GROWTH_ALLOW=1` for one cycle — banks the growth into the floor.
+- a forced `refresh-baseline.yml` dispatch — bypasses the gate by design, **and
+  is not available anyway: that workflow is currently `disabled_manually`.**
+
+## Follow-ups
+
+- **#3645** — the regression test. Deliberately **not** in this PR: a file under
+  `tests/` pulls the change-set into the shard matrix and would block the very
+  fix that unblocks it. Not an oversight.
+- Whether `scripts/check-baseline-trap-growth.ts` *should* be on `&test262-paths`
+  (it gates the baseline, so arguably yes) is a real question — but adding it is
+  self-blocking today and must wait until the queue moves.
+- Same family as the open task on `regressions-allow` being rebase-mode only.
+  The durable framing for both: **an allowance must be readable everywhere it is
+  enforced.**
+
+## Acceptance criteria
+
+- [x] A same-oracle named declaration is honoured by both baseline writers.
+- [x] It is **verified**, not trusted — pass→trap and undeclared growth still fail.
+- [x] Bare-count semantics unchanged (`effectiveBaselineTrapTolerance` intact,
+      its 4 existing assertions still pass).
+- [x] The false force-bypass comment corrected per caller.
+- [x] A refusal with no declaration prints why the scoping came up empty.
+- [ ] Regression test — tracked as #3645.

--- a/plan/issues/3645-allowance-readable-everywhere-regression-test.md
+++ b/plan/issues/3645-allowance-readable-everywhere-regression-test.md
@@ -1,0 +1,82 @@
+---
+id: 3645
+title: "Regression test: an allowance must be readable everywhere it is enforced (trap-growth-allow in the baseline writers)"
+status: ready
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+priority: high
+horizon: s
+feasibility: easy
+task_type: ci
+area: ci
+es_edition: multi
+goal: release-pipeline
+related: [3644, 3596, 3370, 3335, 3189, 3303]
+origin: "Split out of #3644. Deliberately NOT landed with the fix: a file under tests/ pulls the change-set into the &test262-paths shard matrix, which would have blocked the very PR that unblocks the queue."
+---
+
+# #3645 — regression test for #3644
+
+## Why this is a separate issue
+
+#3644 fixed a P0 outage: a `trap-growth-allow` that was honoured on the PR and
+then **unreadable** in the post-merge baseline writers, which wedged promotion
+permanently and stopped the queue. The fix had to land while the queue was
+wedged, and **any file under `tests/` is on `&test262-paths`** — adding the test
+in the same PR would have pulled it into the shard matrix, where it would have
+hit the very trap it fixes and been auto-parked. So the test waits until the
+queue moves. Not an oversight; see #3644's PR body.
+
+## What to assert
+
+The property, stated once so it generalises beyond this one gate:
+
+> **An allowance must be readable in every context where it is enforced.**
+> A declaration landing on `main` must not fail (i) the next baseline promote,
+> or (ii) an unrelated PR's `merge_group`.
+
+Concretely, in `tests/issue-3303.test.ts` (which already covers this family) or a
+new `tests/issue-3644-*.test.ts`:
+
+1. **The contract selector** — `baselineTrapAllowanceContract` (exported from
+   `scripts/check-baseline-trap-growth.ts`) returns:
+   - `named-verified` when `tests:` is present, **regardless of** `forwardOracleBump`;
+   - `bare-oracle-bump` for a bare count **with** a bump;
+   - `inert` for a bare count **without** one.
+2. **End-to-end through the CLI**, driven by the `TRAP_GROWTH_ALLOW_FILE` hook so
+   it is hermetic (the ambient repo diff must not be able to leak an allowance
+   in). Fixtures mirroring the real #3629 row — baseline `status: fail`,
+   `error_category: type_error`, `oracle_version: 11` on **both** sides, i.e. no
+   oracle bump — and these four cases with their **real** exit codes:
+
+   | case | expect |
+   | --- | --- |
+   | no declaration | exit 1 (strict ratchet intact) |
+   | named declaration, same oracle | **exit 0** — this is the #3644 regression |
+   | bare `count:`, no oracle bump | exit 1 (inert; #3370 unchanged) |
+   | declaration naming a **passing** test | exit 1 (not an escape hatch) |
+
+   `.tmp/repro/run.sh` on the #3644 branch is a working prototype of exactly
+   this; lift it.
+3. **The workflow invariant** — extend the existing `fetch-depth: 2` assertion
+   (`tests/issue-3303.test.ts:126`) to cover **`write-run-cache-bot`** as well as
+   `promote-baseline`. That job is the queue-merge writer and is the one that
+   actually wedged; its checkout depth is what makes `HEAD^1` — and therefore the
+   whole change-scoped mechanism — resolvable there.
+
+## Trap to avoid when writing it
+
+The first #3644 harness reported `EXIT=0` for **every** case, including ones
+labelled "must fail", because `${PIPESTATUS:-$?}` is a bashism: under `sh` after
+a pipeline it yields `sed`'s status, not the script's. Capture to a file and read
+`$?` directly. **A test asserting an exit code must be shown to produce a
+non-zero one at least once**, or it is asserting nothing.
+
+## Acceptance criteria
+
+- [ ] All four CLI cases asserted on **real** exit codes, with the harness
+      demonstrated to report a failure correctly.
+- [ ] `baselineTrapAllowanceContract` unit-tested across the three arms.
+- [ ] `fetch-depth: 2` asserted for `write-run-cache-bot`.
+- [ ] Each assertion verified to fail against #3644's merge base.

--- a/plan/issues/3648-gate-baseline-fetched-at-gate-time-not-pinned.md
+++ b/plan/issues/3648-gate-baseline-fetched-at-gate-time-not-pinned.md
@@ -73,6 +73,24 @@ the shard matrix) and #3611 (promote skipping on the reuse path). Those concern
 which baseline gets **written**; this one concerns which baseline gets **read**,
 and specifically that it is not pinned.
 
+## The consequence, stated plainly
+
+**A `merge_group` failure is no longer a property of the change.** It is a
+property of the change **and the wall-clock position of the gate step relative to
+the last promote.**
+
+That is precisely the assumption `auto-park` is built on. If it does not hold:
+
+- **a park is not evidence of a regression**, and
+- **every park-triage rule inherits the uncertainty** — including the rule that a
+  bot park-hold marks a real merged-baseline regression and must never be cleared
+  without diagnosing the cited run. That rule is still right in *direction*, but
+  "the cited run failed" no longer implies "the change caused it".
+
+Concretely, from one evening: **some fraction of the parks were clock artifacts,
+and at least one green certainly was** (#3637). Neither is distinguishable from
+the genuine article in the logs as they stand — which is the whole problem.
+
 ## Why it stayed invisible
 
 The failure is *silent and self-correcting in the favourable direction*: a PR
@@ -81,7 +99,24 @@ anomalous in it. Only the unfavourable direction is visible — as an auto-park
 that then "mysteriously" clears on re-run, which reads as flake. There is no line
 in the log recording **which baseline commit** the verdict was computed against.
 
-## Proposed fix
+## The recurring disease, and its one cure
+
+This is the **fifth** instance in a single session of one failure shape: *the
+benign-looking outcome is indistinguishable from the broken one, and no line
+records which happened.*
+
+| instance | benign reading | actual |
+| --- | --- | --- |
+| this issue | "gate passed" | gate compared against a different baseline |
+| #3644 | "no allowance applied" | allowance never **read** vs read-and-rejected |
+| `grep` on `diff-test262.ts` | "no matches" | binary-classified; needs `-a` |
+| `${PIPESTATUS:-$?}` under `sh` | "EXIT=0, all cases pass" | reported `sed`'s status |
+| `fetch-baseline-jsonl.mjs` without `--force` | "fetched" | silent no-op on a stale cache |
+
+The cure has been identical every time: **print the provenance.** Not "did it
+work" but *what did it use, where did that come from, and which arm ran.*
+
+## Proposed fix (scope approved)
 
 1. **Pin and record.** Resolve the baselines-repo commit **once per run** (at the
    probe/setup step that already exists for #3467/#3468), export it, and have
@@ -92,9 +127,13 @@ in the log recording **which baseline commit** the verdict was computed against.
    baseline commit it was handed. "Which baseline said this?" is currently
    unanswerable from the log alone — the same silent-empty class as #3644's
    "never read vs. read-and-rejected" ambiguity.
-3. Consider whether auto-park should **re-verify against the pinned baseline**
-   before labelling, since a park computed against a since-superseded baseline is
-   a false positive by construction.
+3. **Follow-on, not a blocker for (1)+(2):** `auto-park` should **re-verify
+   against the pinned baseline** before labelling. A park computed against a
+   since-superseded baseline is a false positive **by construction**.
+
+**(2) ships even if (1) slips.** It is a one-line change that converts a silent
+ambiguity into a readable fact and makes every future verdict auditable —
+including retrospectively, once the line exists in enough runs to compare.
 
 ## Acceptance criteria
 

--- a/plan/issues/3648-gate-baseline-fetched-at-gate-time-not-pinned.md
+++ b/plan/issues/3648-gate-baseline-fetched-at-gate-time-not-pinned.md
@@ -1,0 +1,105 @@
+---
+id: 3648
+title: "The regression gate clones the baseline AT GATE TIME, so two PRs in the same queue are judged against different baselines — pass/park becomes a race with the promote job"
+status: ready
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+priority: high
+horizon: m
+feasibility: medium
+task_type: ci
+area: ci, merge-queue
+es_edition: multi
+goal: release-pipeline
+related: [3644, 3467, 3468, 3611, 3303, 1956]
+origin: "Found closing an 'unexplained green': PR #3637 passed the trap ratchet at 22:44 while #3627/#3636 failed it on the identical test minutes earlier. The difference was 64 seconds, not merit."
+---
+
+# #3648 — the gate's baseline is fetched at gate time, not pinned to the run
+
+## The observation that exposed it
+
+During the 2026-07-25 trap-ratchet wedge, three PRs met the *same* main-side
+`illegal_cast 74 → 75` and got **different verdicts**:
+
+| PR | outcome |
+| --- | --- |
+| #3627 (`+56 pass`, no compiled code) | **parked** |
+| #3636 | **parked** |
+| #3637 (`src/**`, full shard matrix) | **passed, merged** |
+
+The natural reading — "#3637's change retired the trap" — is **wrong**. Measured
+timeline from the run logs:
+
+| time (UTC) | event |
+| --- | --- |
+| 22:32:31 | #3637's `merge_group` run starts; shards run against its merged state |
+| **22:43:12** | an operator's re-run promotes the baseline `illegal_cast` 74 → **75** (`tolerance 1`, `BASELINE_TRAP_GROWTH_ALLOW`) |
+| **22:44:16** | #3637's gate step **freshly clones** `js2wasm-baselines` — now at 75 |
+| 22:44:21 | `Catastrophic guard: diff-test262 gate PASS (exit 0, authoritative — #3303): 3 raw wasm-change regressions` |
+
+**#3637 passed by 64 seconds.** Its gate compared 75 against 75. Had the same
+run reached that step a minute earlier it would have compared 75 against 74 and
+parked exactly like the other two. Nothing about the change decided it.
+
+## Root cause
+
+The gate step clones the baseline **inline, at the moment the step runs**:
+
+```sh
+git clone --depth=1 --filter=blob:none --no-checkout \
+  https://github.com/loopdive/js2wasm-baselines.git /tmp/cat-baselines \
+  && git -C /tmp/cat-baselines sparse-checkout set --no-cone /test262-current.jsonl … \
+  && git -C /tmp/cat-baselines checkout main
+npx tsx scripts/diff-test262.ts /tmp/cat-baselines/test262-current.jsonl …
+```
+
+`checkout main` resolves to whatever the baselines repo holds **at that instant**.
+The comparison is therefore against a **moving target**, while the candidate side
+was measured minutes earlier. Two consequences:
+
+1. **Verdicts are not reproducible.** Re-running a parked PR can flip it to
+   green with no change to the PR, main, or the corpus — purely because a promote
+   landed in between. Conversely a PR can park because a promote landed *after*
+   its shards but *before* its gate, in the unfavourable direction.
+2. **Queue-position bias.** Within one merge queue, entries whose gate step runs
+   on either side of a promote are judged against different baselines. That
+   breaks the assumption behind auto-park: that a `merge_group` failure is a
+   property of the change.
+
+This is adjacent to but distinct from #3467/#3468 (per-SHA baseline *reuse* for
+the shard matrix) and #3611 (promote skipping on the reuse path). Those concern
+which baseline gets **written**; this one concerns which baseline gets **read**,
+and specifically that it is not pinned.
+
+## Why it stayed invisible
+
+The failure is *silent and self-correcting in the favourable direction*: a PR
+that passes because of a well-timed promote produces a green log with nothing
+anomalous in it. Only the unfavourable direction is visible — as an auto-park
+that then "mysteriously" clears on re-run, which reads as flake. There is no line
+in the log recording **which baseline commit** the verdict was computed against.
+
+## Proposed fix
+
+1. **Pin and record.** Resolve the baselines-repo commit **once per run** (at the
+   probe/setup step that already exists for #3467/#3468), export it, and have
+   every gate step check out **that SHA** rather than `main`. Any consumer that
+   cannot be pinned should at minimum **log the resolved baseline commit +
+   timestamp**, so a verdict can be reproduced and two runs can be compared.
+2. **Make the provenance a required line.** `diff-test262.ts` should print the
+   baseline commit it was handed. "Which baseline said this?" is currently
+   unanswerable from the log alone — the same silent-empty class as #3644's
+   "never read vs. read-and-rejected" ambiguity.
+3. Consider whether auto-park should **re-verify against the pinned baseline**
+   before labelling, since a park computed against a since-superseded baseline is
+   a false positive by construction.
+
+## Acceptance criteria
+
+- [ ] Every gate step reads a baseline pinned for the run, not `checkout main`.
+- [ ] The resolved baseline commit is logged by `diff-test262.ts` on every run.
+- [ ] A test proves two gate invocations in one run cannot see different
+      baselines.
+- [ ] Recorded: a park is a property of the change, not of the clock.

--- a/scripts/check-baseline-trap-growth.ts
+++ b/scripts/check-baseline-trap-growth.ts
@@ -19,11 +19,29 @@
  * trap-mode worsening needs an explicit acknowledgment instead of
  * self-legalizing.
  *
- * Intentional oracle rebaselines declare a change-scoped
- * `trap-growth-allow:` per-category ceiling in their own issue frontmatter.
- * The landed merge's push consumes it once, while later refreshes see no
- * granting issue in their change-set. `BASELINE_TRAP_GROWTH_ALLOW` remains the
- * operational emergency valve. The FORCED refresh path bypasses the gate.
+ * Intentional reclassifications declare a change-scoped `trap-growth-allow:`
+ * per-category ceiling in their own issue frontmatter. The landed merge's push
+ * consumes it once, while later refreshes see no granting issue in their
+ * change-set. Since #3644 the DECLARATION'S SHAPE selects the contract, exactly
+ * as on the PR side (#3596): a nested `tests:` list is honoured here whether or
+ * not the oracle bumped, and is machine-verified; a bare `count:` stays
+ * oracle-bump-only. See `baselineTrapAllowanceContract`.
+ *
+ * `BASELINE_TRAP_GROWTH_ALLOW` remains the operational emergency valve.
+ *
+ * ⚠️ WHICH FORCED PATH BYPASSES THIS GATE — the previous wording ("The FORCED
+ * refresh path bypasses the gate") was TRUE of one caller and FALSE of the
+ * other, which is worse than saying nothing:
+ *   • `refresh-baseline.yml` — the gate is skipped when `IS_FORCED` (its
+ *     `if [ "${IS_FORCED}" != "true" ] && …` guard). Bypass is real there.
+ *   • `test262-sharded.yml` (`promote-baseline` AND `write-run-cache-bot`, the
+ *     queue-merge writer) — there is NO force guard. `force_baseline_refresh`
+ *     is consulted only by the separate `regression-gate` job (hence its
+ *     "regardless of regressions" wording) and by an audit step that merely
+ *     echoes a warning. A forced dispatch of THAT workflow still runs this gate
+ *     in full. Its only lever is `--allow`/`BASELINE_TRAP_GROWTH_ALLOW`.
+ * Establish that a bypass is live in the caller you actually mean before
+ * relying on it.
  *
  * Usage:
  *   npx tsx scripts/check-baseline-trap-growth.ts \
@@ -35,6 +53,7 @@
 import { readFileSync, existsSync } from "fs";
 import {
   evaluateTrapCategoryGrowth,
+  evaluateTrapReclassification,
   readChangeScopedNumericAllowance,
   TRAP_ERROR_CATEGORIES,
   TRAP_GROWTH_ALLOW_KEY,
@@ -74,6 +93,13 @@ function oracleVersion(rows: Map<string, Row>): number | undefined {
   return versions.size === 1 ? [...versions][0] : undefined;
 }
 
+/**
+ * #3370 contract — a BARE `count:`/`reason:` declaration (no `tests:` list) is
+ * honoured only across a forward oracle bump, because the bump is itself the
+ * containment: an uncheckable number is trusted only where the whole corpus is
+ * being deliberately re-measured. Unchanged by #3644; the named-tests contract
+ * below is a separate arm.
+ */
 export function effectiveBaselineTrapTolerance(
   configured: number,
   baseOracle: number | undefined,
@@ -83,6 +109,43 @@ export function effectiveBaselineTrapTolerance(
   return typeof baseOracle === "number" && typeof candidateOracle === "number" && candidateOracle > baseOracle
     ? Math.max(configured, scopedCeiling)
     : configured;
+}
+
+/**
+ * (#3644) Which contract does a `trap-growth-allow` declaration get in the
+ * BASELINE WRITER? Mirrors `diff-test262.ts`'s PR-side rule exactly: **the
+ * declaration's own shape selects the contract, not the run context.**
+ *
+ *   • `tests:` PRESENT → honoured whether or not the oracle bumped, and then
+ *     MACHINE-VERIFIED (`evaluateTrapReclassification`). Strictly a tightening:
+ *     verification can only ever refuse a declaration, never admit one the
+ *     ceiling alone would have rejected.
+ *   • `tests:` ABSENT → #3370 semantics, unchanged: bare count, oracle-bump only.
+ *
+ * WHY THIS EXISTS. Before #3644 this writer read the allowance **only** when the
+ * oracle had bumped forward, so a same-oracle #3596-shaped declaration was
+ * invisible here — the allowance was honoured at PR and `merge_group` level and
+ * then IGNORED by the post-merge promote job that every downstream gate depends
+ * on. Measured consequence (2026-07-25): PR #3629 landed a correct, named,
+ * verifiable `trap-growth-allow` for one fail→fail reclassification; the promote
+ * job hard-failed `illegal_cast 74 → 75`, and because nothing on main will ever
+ * lower that count again, promotion was wedged PERMANENTLY, not transiently.
+ * The freeze then cascaded: every later PR's `merge_group` compared the merged
+ * state (75) against the frozen baseline (74) and failed on a trap belonging to
+ * main, with no valve legitimately available to it — a change-scoped allowance
+ * is correctly unreachable for a change you did not make. The queue stopped.
+ *
+ * THE GENERAL RULE: **an allowance must be readable everywhere it is enforced.**
+ * A post-merge gate that can only ever say "no" has no repair path — the code is
+ * already on main, so refusing to promote does not undo it, it only blinds every
+ * downstream gate and blocks the fix for the very condition it detects.
+ */
+export function baselineTrapAllowanceContract(opts: {
+  hasNamedTests: boolean;
+  forwardOracleBump: boolean;
+}): "named-verified" | "bare-oracle-bump" | "inert" {
+  if (opts.hasNamedTests) return "named-verified";
+  return opts.forwardOracleBump ? "bare-oracle-bump" : "inert";
 }
 
 async function sendBaselineFreezeAlert(failures: string[]): Promise<void> {
@@ -138,32 +201,97 @@ async function main(): Promise<void> {
   const candidateOracle = oracleVersion(candidate);
   const forwardOracleBump =
     typeof baseOracle === "number" && typeof candidateOracle === "number" && candidateOracle > baseOracle;
-  let scopedAllow = 0;
-  if (forwardOracleBump) {
-    const loaded = await readChangeScopedNumericAllowance({
-      key: TRAP_GROWTH_ALLOW_KEY,
-      label: "trap-growth-allow (#3370)",
-      overrideEnv: "TRAP_GROWTH_ALLOW_FILE",
-    });
-    for (const note of loaded.notes) console.log(note);
-    if (loaded.allowance) {
-      scopedAllow = loaded.allowance.count;
-      console.log(
-        `[trap-growth] oracle v${baseOracle} → v${candidateOracle}: using change-scoped per-category ceiling ${scopedAllow} ` +
-          `(${loaded.allowance.reason}; ${loaded.allowance.sources.join(", ")}).`,
-      );
-    }
+  // (#3644) Read the declaration UNCONDITIONALLY. It used to be read only when
+  // `forwardOracleBump` was true, which made a same-oracle #3596-shaped
+  // declaration invisible to this writer even though the PR gate honoured it —
+  // see `baselineTrapAllowanceContract` for the outage that caused.
+  const loaded = await readChangeScopedNumericAllowance({
+    key: TRAP_GROWTH_ALLOW_KEY,
+    label: "trap-growth-allow (#3644)",
+    overrideEnv: "TRAP_GROWTH_ALLOW_FILE",
+  });
+  for (const note of loaded.notes) console.log(note);
+  const allowance = loaded.allowance;
+  const contract = baselineTrapAllowanceContract({
+    hasNamedTests: (allowance?.tests ?? []).length > 0,
+    forwardOracleBump,
+  });
+  const scopedAllow = allowance && contract !== "inert" ? allowance.count : 0;
+  if (allowance) {
+    const why =
+      contract === "named-verified"
+        ? `named-tests contract (#3596 shape) — ${allowance.tests?.length ?? 0} declared test(s), verified below`
+        : contract === "bare-oracle-bump"
+          ? `bare count across oracle v${baseOracle} → v${candidateOracle} (#3370)`
+          : `INERT — a bare count grants nothing without a forward oracle bump; ` +
+            `add a nested \`tests:\` list to make the claim machine-checkable (#3596)`;
+    console.log(
+      `[trap-growth] change-scoped declaration found: ceiling ${allowance.count}, ${why} ` +
+        `(${allowance.reason}; ${allowance.sources.join(", ")}).`,
+    );
   }
-  const effectiveAllow = effectiveBaselineTrapTolerance(allow, baseOracle, candidateOracle, scopedAllow);
+  const effectiveAllow =
+    contract === "named-verified"
+      ? Math.max(allow, scopedAllow)
+      : effectiveBaselineTrapTolerance(allow, baseOracle, candidateOracle, scopedAllow);
   const growth = evaluateTrapCategoryGrowth(baseline, candidate, effectiveAllow);
 
   const fmt = (counts: Record<string, number>) => TRAP_ERROR_CATEGORIES.map((c) => `${c}=${counts[c]}`).join(" ");
   console.log(`[trap-growth] previous: ${fmt(growth.baseCounts)}`);
   console.log(`[trap-growth] candidate: ${fmt(growth.newCounts)} (tolerance ${effectiveAllow})`);
 
+  // (#3644) A named declaration is VERIFIED, not trusted — the same
+  // `evaluateTrapReclassification` contract the PR gate applies. Every named
+  // test must be non-passing on the previous baseline (a `pass → trap`
+  // transition is a real regression and still hard-fails), and every file
+  // actually responsible for the growth must be named (so `count: 1` cannot
+  // silently excuse an unrelated new trap). Only runs when the allowance did
+  // some work — a declaration that excused nothing needs no proof.
+  if (allowance && contract === "named-verified" && growth.failures.length === 0) {
+    const maxGrowth = Math.max(0, ...TRAP_ERROR_CATEGORIES.map((c) => growth.newCounts[c] - growth.baseCounts[c]));
+    if (maxGrowth > 0) {
+      const recheck = evaluateTrapReclassification({ allowance, baseline, growth });
+      for (const note of recheck.notes) console.log(note);
+      if (recheck.failures.length > 0) {
+        for (const f of recheck.failures) console.error(`::error title=Baseline trap growth (#3644)::${f}`);
+        console.error(
+          "[trap-growth] REFUSING baseline push — the change-scoped trap-growth-allow did NOT verify.\n" +
+            "The ceiling alone never admits growth: the declaration must name the reclassified tests, each must be\n" +
+            "non-passing on the previous baseline, and no undeclared trap growth may remain. See #3596/#3644.",
+        );
+        await sendBaselineFreezeAlert(recheck.failures);
+        process.exit(1);
+      }
+      console.log(
+        `[trap-growth] change-scoped allowance CONSUMED: maximum category growth ${maxGrowth} within the declared ` +
+          `ceiling ${allowance.count}, reclassification verified. Promoting.`,
+      );
+    }
+  }
+
   if (growth.failures.length > 0) {
     for (const f of growth.failures) {
       console.error(`::error title=Baseline trap growth (#3335)::${f}`);
+    }
+    // (#3644) When the gate refuses and NO declaration was found, say why the
+    // scoping came up empty. Previously this path was silent about the
+    // allowance entirely, so "the declaration was never read" and "the
+    // declaration was read and rejected" looked identical in the log — the
+    // ambiguity that made the 2026-07-25 wedge take four hops to diagnose. A
+    // shallow checkout whose `HEAD^1` diff fails would also land here, and that
+    // failure mode must be visible rather than degrade into a silent refusal.
+    if (!allowance) {
+      const { resolveChangeBase, changedPaths } = await import("./lib/change-scope.mjs");
+      const { base, how } = resolveChangeBase(process.cwd());
+      const issueFiles = base ? [...(changedPaths(process.cwd(), base, "plan/issues") ?? [])] : undefined;
+      console.error(
+        `[trap-growth] no change-scoped trap-growth-allow was found for this change-set.\n` +
+          `             base=${base ?? "(unresolved)"} via ${how}\n` +
+          `             plan/issues files in the change-set: ` +
+          `${issueFiles === undefined ? "(diff failed — scoping is BROKEN, not merely empty)" : issueFiles.length === 0 ? "(none)" : issueFiles.join(", ")}\n` +
+          `             If a declaration exists in one of those files and was still not read, the\n` +
+          `             scoping is at fault, not the declaration — check the checkout's fetch-depth.`,
+      );
     }
     console.error(
       "[trap-growth] REFUSING baseline push — an uncatchable-trap category grew vs the previous baseline.\n" +


### PR DESCRIPTION
## P0 — this reopens the merge queue

**An allowance must be readable everywhere it is enforced.** This one was not:
`scripts/check-baseline-trap-growth.ts` read the change-scoped `trap-growth-allow`
**only across a forward oracle bump**, so a same-oracle #3596-shaped declaration
was honoured at PR and `merge_group` level and then **ignored** by the post-merge
baseline writers that every downstream gate depends on.

## Root cause — one conditional, and it is not the one first suspected

```ts
let scopedAllow = 0;
if (forwardOracleBump) {                       // ← the entire bug
  const loaded = await readChangeScopedNumericAllowance({ key: TRAP_GROWTH_ALLOW_KEY, … });
```

That is the pre-#3596 rule. #3596 replaced it on the PR side with a
**shape-driven** contract; the baseline writers were never updated.

The outage was first diagnosed as *"the promote job runs on `push`, has no PR
context, and cannot read the allowance."* **Not what happened.**
`resolveChangeBase` (`scripts/lib/change-scope.mjs:68-85`) handles
`pull_request`, `merge_group`, `push` and `workflow_dispatch` via `HEAD^1`, and
`tests/issue-3303.test.ts:126` already pins `fetch-depth: 2` so that parent
resolves. The context was reachable; the code never looked.

**Distinguishing evidence** (failing job `89715789577`): the log prints
`(tolerance 0)` with **no** `oracle vN → vM: using change-scoped ceiling` line
and **no** reader notes — the allowance was never *read*, not read-and-rejected.

## Cost (measured)

PR #3629 landed a correct, named, verifiable allowance for one fail→fail
reclassification. The queue-merge writer hard-failed `illegal_cast 74 → 75`
— **permanently**, since nothing on `main` lowers that count again. Baseline
froze at 74 (verified: `grep -ac '"error_category":"illegal_cast"'` on the
force-fetched JSONL → **74**; the declared test's row is `status: fail`,
`error_category: type_error`, `oracle_version: 11`). Every later PR then compared
merged-state 75 against 74 and parked on a trap belonging to `main` — #3627, with
a healthy **+56 pass**, was parked twice.

**The `merge_group` half needs no separate valve and must not get one.** It is a
cascade: once promotion succeeds the baseline is 75 and PRs compare 75 vs 75. A
per-PR valve would also be wrong in principle — *a change-scoped allowance is
correctly unreachable for a change you did not make.*

## Fix

The declaration's **shape** selects the contract, in every context — the rule
`diff-test262.ts` already applies:

| shape | PR / `merge_group` | writers (was) | writers (now) |
| --- | --- | --- | --- |
| `tests:` present | honoured, verified | **ignored unless oracle bumped** | honoured, verified |
| bare `count:` | oracle-bump only | oracle-bump only | oracle-bump only (unchanged) |

Verification reuses the existing pure `evaluateTrapReclassification`, so the two
enforcement points cannot drift. Both writers (`promote-baseline` **and**
`write-run-cache-bot`, the queue-merge one that actually wedged) call this one
script.

Plus two secondary fixes: the header comment claiming *"The FORCED refresh path
bypasses the gate"* was true of `refresh-baseline.yml` and **false of
`test262-sharded.yml`** where the wedge lives — corrected per caller; and a
refusal with no declaration found now prints the resolved base and the
change-set's `plan/issues` files, so "never read" and "read and rejected" stop
looking identical.

## Validation — real exit codes

Local repro of the real row via the `TRAP_GROWTH_ALLOW_FILE` hook:

| case | expect | got |
| --- | --- | --- |
| no declaration | fail | **exit 1** |
| the real #3629 declaration (named, same oracle) | pass | **exit 0**, `tolerance 1`, VERIFIED |
| bare `count:`, no oracle bump | fail | **exit 1** (inert) |
| names a **passing** test | fail | **exit 1** (not an escape hatch) |

A/B with the identical declaration present: stock `main` exits **1** at
`tolerance 0`; this branch exits **0** at `tolerance 1`. `tsc --noEmit` clean;
`tests/issue-3303.test.ts` 44/44 unchanged.

*(The first harness reported `EXIT=0` for every case — `${PIPESTATUS:-$?}` is a
bashism returning `sed`'s status under `sh`. Fixed before drawing any
conclusion.)*

## ⚠️ Merging this does NOT self-trigger — a manual dispatch is required

`test262-sharded.yml`'s `push` trigger is path-filtered (`:33-35`). This PR
deliberately touches only `scripts/check-baseline-trap-growth.ts`, which is
**not** on `&test262-paths` — that is what lets it green-skip the shards and land
at all (a shard-running PR would hit the very trap it fixes and be parked, as
#3627 was).

The same property means **merging it fires no promote run; the baseline stays at
74.** It needs a plain, **non-forced** `workflow_dispatch` of
`test262-sharded.yml` on `main`. That suppresses **no** gate — the corrected gate
runs in full, reads and verifies the allowance, promotes to 75, and the queue
reopens. Strictly better than the alternatives: `BASELINE_TRAP_GROWTH_ALLOW=1`
banks the growth into the floor, and a forced `refresh-baseline.yml` dispatch
bypasses the gate by design **and is unavailable — that workflow is
`disabled_manually`**.

## Not in this PR, on purpose

The regression test is **#3645**. Any file under `tests/` joins `&test262-paths`
and would pull this change-set into the shard matrix, blocking the very fix that
unblocks it. Filed, not forgotten.

Closes #3644.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
