### PR TITLE
fix(#3649): honour regressions-allow on ordinary PRs — shape-driven, machine-checked

### DIFF
--- a/plan/issues/3649-regressions-allow-inert-on-ordinary-prs.md
+++ b/plan/issues/3649-regressions-allow-inert-on-ordinary-prs.md
@@ -1,0 +1,151 @@
+---
+id: 3649
+title: "`regressions-allow` is read only in rebase mode, so it is inert on ordinary PRs — a well-formed declaration is theatre, not a machine check"
+status: done
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+completed: 2026-07-26
+priority: high
+horizon: m
+feasibility: medium
+task_type: ci
+area: ci, merge-queue
+es_edition: multi
+goal: release-pipeline
+assignee: ttraenkler/opus-loop-b
+related: [3596, 3303, 3370, 3644, 3648, 3650]
+origin: "Found by the harness lane while landing #3615; sharpened by opus-loop-a, which hit the composed form of it. Same family as #3644 — an allowance honoured in one context and silently absent in another."
+---
+
+# #3649 — an allowance must be readable in every context where it is enforced
+
+This is the second instance of one defect. **#3644** was `trap-growth-allow`
+honoured on the PR and unreadable in the baseline writers. This is
+`regressions-allow` honoured in rebase mode and unreadable on an ordinary PR.
+Same shape, same fix, and the generalisation is the durable deliverable:
+
+> **An allowance must be readable in every context where it is enforced — and
+> each enforcement point needs a test proving it reads one.**
+
+## The gap
+
+`regressions-allow` was read **only** inside the `if (rebaseMode)` branch, and
+
+```ts
+const rebaseMode =
+  oracleRebase || (typeof baseOracle === "number" && typeof newOracle === "number" && newOracle > baseOracle);
+```
+
+so it required `ORACLE_REBASE=1` or a forward `ORACLE_VERSION` bump. On an
+ordinary PR the declaration **parsed correctly and did nothing**. A dev with a
+genuine, proven, intentional `pass → fail` had no way to declare it that any gate
+would read.
+
+**The failure was also undiagnosable**, which is the worse half: the gate fails
+whether the ceiling was too small *or* the declaration was never consulted, and
+nothing in the log distinguished them. `opus-loop-a` caught the composed form
+only by looking for the reader's own output line and noticing its **absence**.
+
+## Measured
+
+`REGRESSIONS_ALLOW_FILE` hermetic hook; same-oracle fixtures (so: not rebase
+mode); two `pass → fail` regressions with changed `wasm_sha`. **Real** exit codes
+— captured to a file, never through a pipe (`${PIPESTATUS:-$?}` is a `sh`
+bashism that reports the *last* command's status; it produced a vacuous
+all-green table for #3644's first harness).
+
+| case | before (stock main) | after |
+| --- | --- | --- |
+| **named** declaration (`tests:` naming both) | **exit 1**, and *no mention of the declaration anywhere in the log* | **exit 0**, `EXCUSING 2 named wasm-change regression(s)` |
+| bare `count:` | exit 1, silent | exit 1, but now states it is INERT here and why |
+| names a test that is **not** regressed | — | **exit 1**, named and refused |
+| names 2, ceiling 1 | — | **exit 1**, ceiling refused |
+| no declaration | exit 1 | exit 1 (unchanged) |
+
+The first row is the issue: a correct, well-formed, honest declaration was worth
+exactly nothing, and the log did not say so.
+
+## Fix — the declaration's shape selects the contract
+
+Identical rule to #3596/#3644, so all three enforcement points now agree:
+
+- **`tests:` present** → verified and honoured in **both** modes. The named files
+  are excused from the regression set the net/ratio/bucket gates see — the same
+  mechanism `devacExcusedFiles` already uses.
+- **bare `count:`** → #3303 semantics **byte-for-byte unchanged**: a ceiling,
+  rebase mode only. No existing declaration changes behaviour. *(This matters
+  operationally: `opus-loop-a` is landing a bare `{count, reason}` form right
+  now, and it is safe by construction — the bare form parses to `tests: []`.)*
+
+Verification (`evaluateNamedRegressionsAllowance`, pure) requires two things:
+
+1. **Real** — every named test must actually be among this diff's wasm-change
+   regressions. A name that is not is stale or speculative; both are refused, so
+   a declaration cannot be written ahead of the evidence.
+2. **Bounded** — the number excused may not exceed the declared `count`.
+
+Deliberately **not** required: completeness. Undeclared regressions are simply
+not excused and still gate normally. That is strictly safer than failing outright
+on undeclared collateral, and it means an honest under-declaration degrades
+gracefully instead of becoming a hard stop.
+
+**Silence removed too:** a bare declaration on an ordinary PR now prints that it
+is inert and how to make it checkable, so "ceiling too small" and "never read"
+can never look alike again.
+
+## A correction worth recording
+
+The task brief said `changeSetNumericAllowances` "has no `tests:` support, unlike
+its sibling `parseFrontmatterCountReason`". **That is wrong** — they are not
+siblings; the former *calls* the latter and spreads its result, and
+`readChangeScopedNumericAllowance` carries `tests` through. Measured directly:
+
+```
+with tests -> {"count":12,"reason":"r","tests":["test/a.js","test/b.js"]}
+bare       -> {"count":12,"reason":"r","tests":[]}
+```
+
+#3596 added `tests:` to the **shared, key-agnostic** parser, not to a
+trap-specific path. So this was **one** gap (mode-scoping), not two, and the fix
+is correspondingly smaller. `opus-loop-a` reached the same conclusion
+independently. Recorded because designing around the false constraint would have
+meant re-implementing parsing that already worked.
+
+## Not fixed here
+
+**#3650** — `check-verdict-oracle-bump.mjs` watches five harness files but not
+the runtime layer, so a verdict-changing `src/runtime.ts` PR is never asked to
+bump the oracle, which is what put loop-a in non-rebase mode in the first place.
+Filed separately because it is a scope question about that gate, not about
+allowance plumbing, and the answer is *not* simply "add `src/**`".
+
+## Validation
+
+- `tsc --noEmit -p tsconfig.json` clean. `scripts/tsconfig.json` reports 9
+  `diff-test262.ts` errors — **A/B'd: main's version reports the same 9**, so
+  none is introduced (they are pre-existing, and my insertion only shifted the
+  line numbers).
+- `tests/issue-3303.test.ts` 44/44 pass unchanged.
+- Behavioural repro above, five cases, real exit codes.
+
+⚠️ This PR touches `scripts/diff-test262.ts`, which **is** on `&test262-paths`,
+so it runs the full shard matrix — and per **#3648** its verdict is computed
+against a baseline cloned at gate time, so a re-run can legitimately differ.
+Record the baseline provenance if triaging it.
+
+## Acceptance criteria
+
+- [x] `regressions-allow` with a `tests:` list is verified and honoured in both
+      modes; bare `count:` keeps current behaviour exactly.
+- [x] Each named test must be shown to be a genuine regression in this diff —
+      the property that stops it becoming a general escape hatch.
+- [x] The ceiling still binds.
+- [x] An unread/inert declaration now says so in the log.
+- [ ] Unit tests pinning mode-independence — folded into **#3645**, which should
+      assert the **general property** (an allowance is readable at every
+      enforcement point) with one test per point, rather than two tests asserting
+      two instances of it.
+- [ ] Record that the non-rebase path is **not yet field-exercised** until a real
+      run proves it: a green gate says nothing about *which* mechanism passed it.
+      Pull the artifact and confirm the `EXCUSING` line before believing it.

--- a/plan/issues/3650-verdict-oracle-bump-gate-misses-runtime-layer.md
+++ b/plan/issues/3650-verdict-oracle-bump-gate-misses-runtime-layer.md
@@ -1,0 +1,90 @@
+---
+id: 3650
+title: "`check-verdict-oracle-bump.mjs` watches five harness files but not the runtime layer — a verdict-changing `src/runtime.ts` PR is never asked to bump the oracle"
+status: ready
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+priority: high
+horizon: m
+feasibility: medium
+task_type: ci
+area: ci
+es_edition: multi
+goal: release-pipeline
+related: [3649, 3303, 3370, 3596, 3648, 3644]
+origin: "Found by opus-loop-a while landing the #3603 host arm; filed by opus-loop-b so it is not lost while that measurement is in flight. Credit: opus-loop-a."
+---
+
+# #3650 — the oracle-bump gate's file list misses the layer that changes verdicts
+
+**Found by `opus-loop-a`**, filed here so it survives that agent's in-flight
+measurement cycle.
+
+## The gap
+
+`scripts/check-verdict-oracle-bump.mjs` demands an `ORACLE_VERSION` bump when a
+PR changes how verdicts are computed. It watches exactly five files:
+
+```
+PURE:  scripts/negative-verdict.mjs
+MIXED: scripts/test262-worker.mjs, tests/test262-shared.ts,
+       tests/test262-vitest.test.ts, tests/test262-runner.ts
+```
+
+`src/runtime.ts` and `src/runtime/**` are **not** on that list. But the runtime
+is a verdict-determining layer: loop-a's #3603 host arm flips on the order of a
+**thousand** verdicts corpus-wide from `src/runtime.ts` alone, and the gate never
+asks for a bump. (This is not hypothetical — my own #3637 changed
+`for (x of {})` from "iterates zero times" to `TypeError`, which is a verdict
+change for every test that shape reaches.)
+
+## Why it is worse than a missing nag
+
+Composed with the `regressions-allow` mode-scoping, it produced a **silent,
+undiagnosable** failure — and this is the part that makes it high priority
+rather than cosmetic:
+
+1. A dev declares `regressions-allow: {count, reason}` — well-formed, parses fine.
+2. No oracle bump happens, because **nothing demands one** for a runtime change.
+3. `rebaseMode` is therefore false, so (pre-#3649) the allowance is **never read**.
+4. The gate fails on regressions ⇒ the PR parks.
+5. The park is **indistinguishable from "your ceiling was too small"**.
+
+loop-a only caught it by going looking for the reader's own output line
+(`=== regressions-allow (#3303): excused N of M …`) and noticing its **absence**,
+rather than trusting the red/green outcome. Absence-as-diagnosis again — the same
+silent-ambiguity class as #3644 (`never read` vs `read-and-rejected`) and #3648
+(which baseline produced the verdict).
+
+**#3649 removes step 3** (the allowance is now read in both modes, shape-driven),
+which resolves the immediate trap and is the higher-value half. This issue is the
+remaining half: the *gate that decides when the corpus is being re-measured* does
+not watch the layer that most often re-measures it.
+
+## Scope question to settle first
+
+This is arguably a **`check-verdict-oracle-bump.mjs` scope bug**, not a
+`change-scope.mjs` one, and the fix is not simply "add `src/**`":
+
+- `src/**` is the compiler. A codegen change alters what the *program* does — a
+  genuine pass/fail change, not a re-measurement. Demanding an oracle bump for
+  every codegen PR would be wrong and would make the bump meaningless.
+- `src/runtime.ts` is a **host-boundary semantics** layer: a change there can
+  alter how an *already-compiled* module's behaviour is observed and classified,
+  which is much closer to what the harness files do.
+
+So the real question is **which parts of the runtime are verdict-determining**,
+and the answer probably is not the whole file. Worth measuring rather than
+guessing: take a known verdict-flipping runtime change (#3603's host arm, or
+#3637) and identify what distinguishes it from an ordinary runtime bugfix.
+
+## Acceptance criteria
+
+- [ ] A decision, recorded with reasoning, on which runtime paths are
+      verdict-determining for oracle purposes.
+- [ ] `check-verdict-oracle-bump.mjs` watches them.
+- [ ] A test proving a verdict-changing runtime PR is asked for a bump, and an
+      ordinary runtime bugfix is not.
+- [ ] The composed failure above cannot recur silently: if an allowance is not
+      read, the log says so (already true after #3649 — keep it true).

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -368,6 +368,92 @@ export function evaluateRebaseGate(opts: {
 }
 
 /**
+ * (#3649) Machine-check a NAMED `regressions-allow` declaration so it can be
+ * honoured on an ORDINARY (non-rebase) PR without becoming a blank cheque.
+ *
+ * WHY THIS EXISTS. `regressions-allow` was read **only** inside
+ * `evaluateRebaseGate`, i.e. only when `rebaseMode` holds — which requires
+ * `ORACLE_REBASE=1` or a forward `ORACLE_VERSION` bump. On an ordinary PR the
+ * declaration was therefore **inert**: it parsed, it was well-formed, and it did
+ * nothing. A dev with a genuine, proven, intentional pass→fail had no way to
+ * declare it that any gate would read — the declaration was theatre, not a
+ * machine check. Worse, the failure is **indistinguishable from "ceiling too
+ * small"**: the gate fails either way and nothing in the log says which. (The
+ * tell is the ABSENCE of this function's own note; absence-as-diagnosis is the
+ * same silent-ambiguity class as #3644 and #3648.)
+ *
+ * This mirrors `evaluateTrapReclassification` (#3596) exactly, and the contract
+ * is selected by the DECLARATION'S SHAPE, never by the run mode:
+ *
+ *   • `tests:` PRESENT → verified and honoured in both modes (this function).
+ *   • `tests:` ABSENT  → #3303 semantics, byte-for-byte unchanged: a bare
+ *     ceiling, rebase mode only. Existing declarations cannot change behaviour.
+ *
+ * Two conditions, both required:
+ *
+ *   1. **Real** — every named test must actually be among this diff's
+ *      wasm-change regressions. A name that is not is either stale (copied from
+ *      an earlier run) or speculative (pre-naming tests to bank future
+ *      breakage); both are refused, so the declaration cannot be written ahead
+ *      of the evidence.
+ *   2. **Bounded** — the number excused may not exceed the declared `count`.
+ *      The count remains a ceiling the PR commits to, not a blank cheque.
+ *
+ * Note what is deliberately NOT required: completeness. Undeclared regressions
+ * are simply *not excused* and continue through the net/ratio/bucket gates
+ * normally. That is strictly safer than failing outright on undeclared
+ * collateral, and it means a partial declaration degrades gracefully instead of
+ * turning an honest under-declaration into a hard stop.
+ *
+ * Pure (no I/O) so the unit test drives it with fixture lists.
+ */
+export function evaluateNamedRegressionsAllowance(opts: {
+  allowance: RegressionsAllowance;
+  regressedFiles: string[];
+}): { excused: Set<string>; failures: string[]; notes: string[] } {
+  const { allowance, regressedFiles } = opts;
+  const failures: string[] = [];
+  const notes: string[] = [];
+  const declared = allowance.tests ?? [];
+  const where = allowance.sources.join(", ");
+  const regressedSet = new Set(regressedFiles);
+
+  const excused = new Set<string>();
+  const notRegressed: string[] = [];
+  for (const file of declared) {
+    if (regressedSet.has(file)) excused.add(file);
+    else notRegressed.push(file);
+  }
+
+  if (notRegressed.length > 0) {
+    const sample = notRegressed.slice().sort().slice(0, 10);
+    const more = notRegressed.length > sample.length ? ` (+${notRegressed.length - sample.length} more)` : "";
+    failures.push(
+      `regressions-allow (#3649): ${notRegressed.length} declared test(s) are NOT among this diff's wasm-change ` +
+        `regressions — ${sample.join(", ")}${more} (declared in ${where}). A declaration must describe THIS diff: ` +
+        `name only tests it actually regresses, so the claim cannot be written ahead of the evidence`,
+    );
+  }
+
+  if (excused.size > allowance.count) {
+    failures.push(
+      `regressions-allow (#3649) ceiling exceeded: ${excused.size} named regression(s) > declared count ` +
+        `${allowance.count} (declared in ${where}). The count is a ceiling the PR commits to — re-measure and ` +
+        `re-declare honestly`,
+    );
+  }
+
+  if (failures.length === 0 && excused.size > 0) {
+    notes.push(
+      `=== regressions-allow (#3649): EXCUSING ${excused.size} named wasm-change regression(s) of a declared ` +
+        `ceiling ${allowance.count}, each verified to be a regression in this diff. Undeclared regressions are ` +
+        `NOT excused and still gate. reason: ${allowance.reason} (declared in ${where}). ===`,
+    );
+  }
+  return { excused: failures.length === 0 ? excused : new Set(), failures, notes };
+}
+
+/**
  * #3303 — read the change-set-scoped `regressions-allow:` declaration (CLI
  * path only; never called when this module is imported for its pure helpers).
  * Resolution:
@@ -2055,7 +2141,7 @@ async function run(
       for (const note of devacResult.notes) console.log(note);
     }
   }
-  const noiseFiltered = regressions.filter(
+  const noiseFilteredBase = regressions.filter(
     (r) =>
       !r.hostQuarantined &&
       !r.wasmUnchanged &&
@@ -2065,6 +2151,45 @@ async function run(
       !isExcusedVacuous(r) &&
       !devacExcusedFiles.has(r.file),
   );
+
+  // (#3649) Read `regressions-allow` ONCE, here, for BOTH modes. It used to be
+  // read lazily inside the rebase branch only, which made it inert on an
+  // ordinary PR — a well-formed declaration that no gate consulted. The
+  // declaration's SHAPE now selects the contract:
+  //   • `tests:` present → verified here and honoured in either mode, by
+  //     excusing exactly the named files from the regression set the
+  //     net/ratio/bucket gates see (mirroring how `devacExcusedFiles` works).
+  //   • bare `count:`    → untouched #3303 semantics; consumed by
+  //     `evaluateRebaseGate` in rebase mode and inert elsewhere, as before.
+  // The exclusion is applied only OUTSIDE rebase mode: in rebase mode the bare
+  // ceiling already supersedes the drift/concentration checks, and excusing the
+  // files as well would apply the same leniency twice.
+  const { allowance: regressionsAllowance, notes: regressionsAllowanceNotes } = await readRegressionsAllowance();
+  for (const note of regressionsAllowanceNotes) console.log(note);
+  const namedRegressionsAllowance = (regressionsAllowance?.tests ?? []).length > 0;
+  let regressionsAllowExcused = new Set<string>();
+  const regressionsAllowFailures: string[] = [];
+  if (regressionsAllowance && namedRegressionsAllowance && !rebaseMode) {
+    const verdict = evaluateNamedRegressionsAllowance({
+      allowance: regressionsAllowance,
+      regressedFiles: noiseFilteredBase.map((r) => r.file),
+    });
+    for (const note of verdict.notes) console.log(note);
+    regressionsAllowFailures.push(...verdict.failures);
+    regressionsAllowExcused = verdict.excused;
+  } else if (regressionsAllowance && !namedRegressionsAllowance && !rebaseMode) {
+    // Say so out loud. Silence here is exactly what made the old behaviour
+    // unreadable: the gate would fail and the author could not tell whether the
+    // ceiling was too small or the declaration was never consulted at all.
+    console.log(
+      `=== regressions-allow: declaration found (count ${regressionsAllowance.count}, declared in ` +
+        `${regressionsAllowance.sources.join(", ")}) but it is INERT on this ordinary PR — a bare count is only ` +
+        `honoured across an oracle re-baseline (#3303). Add a nested \`tests:\` list naming the regressions to ` +
+        `make the claim machine-checkable and have it honoured here (#3649). ===`,
+    );
+  }
+
+  const noiseFiltered = noiseFilteredBase.filter((r) => !regressionsAllowExcused.has(r.file));
   const regressionsWasmChange = noiseFiltered.length;
   const wasmIdenticalNoise = regressions.filter((r) => r.wasmUnchanged && r.to !== "compile_timeout").length;
   console.log(`=== Wasm-identical noise (pass → other, same wasm_sha): ${wasmIdenticalNoise} ===`);
@@ -2224,6 +2349,14 @@ async function run(
     gateFailed = true;
   }
 
+  // (#3649) A named `regressions-allow` that did not verify is a hard failure —
+  // the declaration excused nothing (its `excused` set is empty on failure), so
+  // the regressions it named still count AND the dishonest claim is reported.
+  for (const reason of regressionsAllowFailures) {
+    console.log(`=== GATE FAIL: ${reason} ===`);
+    gateFailed = true;
+  }
+
   // #3189 — uncatchable-trap GROWTH ratchet. A regressions-allow declaration
   // never affects this ratchet. #3370 adds a separate, change-scoped
   // trap-growth-allow ceiling for an oracle bump whose literal harness changes
@@ -2336,17 +2469,20 @@ async function run(
     // the PR declares a #3303 `regressions-allow:` ceiling in its own issue
     // file (an honest reclassification larger than drift, e.g. #3285/#3286),
     // which supersedes both checks up to the declared count and hard-fails
-    // above it. The allowance is read lazily HERE (rebase mode only) so an
-    // ordinary same-oracle run never consults it — a declared allowance grants
-    // nothing without the oracle bump that makes this a deliberate re-baseline.
-    // Since #3303 the #1668/#1897 workflow guards treat this exit code as
-    // authoritative when it passes, so this branch IS the rebase verdict.
-    const { allowance, notes: allowanceNotes } = await readRegressionsAllowance();
-    for (const note of allowanceNotes) console.log(note);
+    // above it. Since #3303 the #1668/#1897 workflow guards treat this exit code
+    // as authoritative when it passes, so this branch IS the rebase verdict.
+    //
+    // (#3649) The allowance is now read ONCE, before the mode split, rather than
+    // lazily here. Rebase-mode behaviour is byte-for-byte unchanged — the same
+    // allowance object reaches `evaluateRebaseGate`, with the same ceiling logic
+    // — but it is no longer true that "an ordinary same-oracle run never
+    // consults it". THAT was the bug: it made a well-formed declaration silently
+    // inert on every normal PR, and indistinguishable from a ceiling that was
+    // simply too small.
     const rebaseGate = evaluateRebaseGate({
       regressionsWasmChange,
       regressedFiles: noiseFiltered.map((r) => r.file),
-      allowance,
+      allowance: regressionsAllowance,
     });
     for (const reason of rebaseGate.failures) {
       console.log(`=== GATE FAIL: ${reason} ===`);


### PR DESCRIPTION
## Second instance of one defect

**#3644** was `trap-growth-allow` honoured on the PR and unreadable in the
baseline writers. This is `regressions-allow` honoured in rebase mode and
unreadable on an ordinary PR. Same shape, same fix. The generalisation is the
durable deliverable:

> **An allowance must be readable in every context where it is enforced — and
> each enforcement point needs a test proving it reads one.**

## The gap

`regressions-allow` was read **only** inside `if (rebaseMode)`, which requires
`ORACLE_REBASE=1` or a forward `ORACLE_VERSION` bump. On an ordinary PR a
correct, well-formed declaration **parsed and did nothing** — a dev with a
genuine, proven, intentional `pass → fail` had no way to declare it that any gate
would read.

The failure was also **undiagnosable**: the gate fails whether the ceiling was
too small *or* the declaration was never consulted, and nothing in the log
distinguished them. `opus-loop-a` caught the composed form only by looking for
the reader's own output line and noticing its **absence**.

## Measured — real exit codes

Hermetic via `REGRESSIONS_ALLOW_FILE`; same-oracle fixtures (⇒ not rebase mode);
two `pass → fail` regressions with changed `wasm_sha`.

| case | stock main | this branch |
| --- | --- | --- |
| **named** declaration | **exit 1**, *no mention of the declaration anywhere* | **exit 0**, `EXCUSING 2 named wasm-change regression(s)` |
| bare `count:` | exit 1, silent | exit 1, now states it is INERT here and why |
| names a test that is **not** regressed | — | **exit 1**, named and refused |
| names 2, ceiling 1 | — | **exit 1**, ceiling refused |
| no declaration | exit 1 | exit 1 (unchanged) |

*(Exit codes captured to a file, not through a pipe — `${PIPESTATUS:-$?}` is a
`sh` bashism that produced a vacuous all-green table on #3644's first harness.)*

## Fix — the declaration's shape selects the contract

Identical rule to #3596/#3644, so all three enforcement points now agree:

- **`tests:` present** → verified and honoured in **both** modes; the named files
  are excused from the regression set the net/ratio/bucket gates see (the same
  mechanism `devacExcusedFiles` already uses).
- **bare `count:`** → #3303 semantics **byte-for-byte unchanged**. No existing
  declaration changes behaviour — including the bare `{count, reason}` form
  `opus-loop-a` is landing right now, which is safe by construction (it parses to
  `tests: []`).

`evaluateNamedRegressionsAllowance` (pure) requires: every named test must
actually be a regression **in this diff** (so a claim cannot be written ahead of
the evidence), and the ceiling still binds. Completeness is deliberately **not**
required — undeclared regressions are simply not excused and still gate, so an
honest under-declaration degrades gracefully instead of hard-failing.

Silence removed too: a bare declaration on an ordinary PR now prints that it is
inert and how to make it checkable.

## A correction to the brief

It said `changeSetNumericAllowances` "has no `tests:` support, unlike its sibling
`parseFrontmatterCountReason`". **Wrong** — the former *calls* the latter and
spreads its result. Measured: `with tests -> {...,"tests":["test/a.js",…]}`,
`bare -> {...,"tests":[]}`. #3596 added `tests:` to the shared, **key-agnostic**
parser. So this was **one** gap (mode-scoping), not two. `opus-loop-a` reached
the same conclusion independently.

## Not fixed here

**#3650** (filed) — `check-verdict-oracle-bump.mjs` watches five harness files
but not the runtime layer, so a verdict-changing `src/runtime.ts` PR is never
asked to bump the oracle, which is what put loop-a in non-rebase mode to begin
with. Separate because it is a scope question about that gate, and the answer is
*not* simply "add `src/**`".

## Validation

- `tsc --noEmit -p tsconfig.json` clean. `scripts/tsconfig.json` reports 9
  `diff-test262.ts` errors — **A/B'd: main reports the same 9**, so none is
  introduced.
- `tests/issue-3303.test.ts` 44/44 unchanged.

⚠️ This touches `scripts/diff-test262.ts`, which **is** on `&test262-paths`, so
it runs the full shard matrix — and per **#3648** the verdict is computed against
a baseline cloned at gate time, so a re-run can legitimately differ. Record the
baseline provenance if triaging.

Unit tests are folded into **#3645**, which should assert the **general
property** with one test per enforcement point rather than two tests asserting
two instances of it.

Closes #3649.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
