### PR TITLE
fix(delete): model sloppy global property deletion

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -1,7 +1,8 @@
 ---
 id: 2726
 title: "delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete"
-status: ready
+status: done
+completed: 2026-07-26
 sprint: current
 goal: es5
 feasibility: medium
@@ -10,10 +11,21 @@ priority: medium
 es_edition: ES5
 language_feature: delete
 task_type: bug
+loc-budget-allow:
+  - src/codegen/context/types.ts
+  - src/codegen/expressions/identifiers.ts
+  - src/codegen/index.ts
+  - src/codegen/typeof-delete.ts
+  - src/ir/select.ts
 created: 2026-06-26
-updated: 2026-07-05
+updated: 2026-07-26
 ---
 
+> **Final resolution (2026-07-26, codex-2726).** Group **(b)** is now **4/4**:
+> the two structural residuals `S11.4.1_A3.1` and
+> `S11.4.1_A3.3_T1` pass in both host/gc and standalone. The implementation
+> follows the architect specification and resolution below.
+>
 > **Partial resolution (2026-07-05, dev-2726).** Group **(a)** DONE (sloppy
 > `delete <unresolvable identifier>` → `true`; +4 test262). Groups **(c)** and
 > **(d)** DONE earlier (+6 test262). Group **(b)** is now **2/4**: the
@@ -30,8 +42,8 @@ updated: 2026-07-05
 > test262 `S8.12.7_A2_T2`, 0 delete-dir regressions — see `## Resolution — group (g)`).
 > **(f)** (`11.4.1-5-a-27-s` — strict assign to a `preventExtensions`'d object)
 > re-routes to its owning strict-mode/preventExtensions feature issue. This issue
-> stays open (`status: ready`) for the 2 structural (b) tests — route to architect
-> before further dispatch.
+> therefore stayed open at that point for the 2 structural (b) tests — route to
+> architect before further dispatch.
 
 # #2726 — delete residual (non-throw) semantics
 
@@ -41,10 +53,84 @@ Split out of #2703, which delivered the **throw** cases of `delete`
 that each need a distinct subsystem fix; they are tracked here so #2703 can close
 on its throw-semantics scope.
 
+## Architect specification — residual group (b) global environment
+
+The remaining two tests need one bounded GlobalEnvironmentRecord slice rather
+than another return-value constant:
+
+1. **Discover implicit-global candidates before body compilation.** A
+   whole-source AST scan records simple sloppy assignments whose identifier LHS
+   has no value binding according to the checker oracle. This set is computed
+   before any function or `__module_init` body is emitted, so a reader compiled
+   before its writer gets the same lowering as a reader compiled after it.
+2. **Use one target-aware global-object carrier.** Host/gc reads the current
+   sandbox through `__get_globalThis`; standalone/WASI uses the existing cached
+   native `$Object` returned by `emitNativeGlobalThisObject`. Assignment,
+   identifier read, and delete must all request this carrier through the same
+   helper.
+3. **Keep the three operations symmetric.** Sloppy unresolvable `x = value`
+   performs `__extern_set(globalObject, "x", value)` (default attributes,
+   including `configurable:true`). A later candidate read first tests own
+   presence, throws `ReferenceError` when absent, and otherwise performs
+   `__extern_get`. `delete x` performs
+   `__delete_property(globalObject, "x")`, so it removes the property rather
+   than merely returning a compile-time `true`.
+4. **Record non-configurable script declarations separately from storage.**
+   Top-level script `var` bindings remain in their existing typed Wasm globals,
+   but their names are also recorded as non-configurable global-object
+   bindings. A direct top-level `delete this.name`/`delete globalThis.name`
+   consults that record and returns `false` (or takes the existing strict
+   TypeError path). `let`/`const` names are deliberately excluded because global
+   lexical bindings are not properties of the global object.
+5. **Gate every new path.** Sources without a sloppy implicit-global assignment
+   or direct delete of a recorded script `var` retain the current local/global
+   lowering. Dynamic aliases of the global object and full reflective mirroring
+   of typed Wasm globals are follow-up GlobalEnvironmentRecord work, not needed
+   for these two ES5 assertions.
+
+The acceptance invariants are: assignment creates an own configurable property
+on both targets; a read observes it while present; delete removes it; the next
+read throws a real `ReferenceError`; and a script `var` remains non-deletable
+through direct top-level `this`.
+
+## Resolution — group (b) structural residuals (2026-07-26, codex-2726)
+
+**Root causes.**
+
+- Sloppy unresolvable assignment used the host global object only in host/gc;
+  standalone allocated a function local. Bare-identifier delete returned a
+  compile-time `true` without deleting that host property, and identifier reads
+  had no compile-order-independent record that the property could exist.
+- Script `var` values use typed Wasm globals, but no companion binding-attribute
+  record told `delete this.y` that `y` is a non-configurable global property.
+  In the full harness, the checker additionally gave top-level `this` a
+  structural global shape, so field-specialized delete lowering ran before the
+  generic property path.
+- The IR module-init selector admitted `delete this.y` even though its delete
+  lowerer only evaluates the receiver and returns constant `true`.
+
+**Fix.** A checker-oracle pre-scan records simple sloppy implicit-global
+assignment targets before any body compiles. The new shared
+`global-environment.ts` selects the host sandbox global or native standalone
+`$Object`; assignment uses `__extern_set`, reads use
+`__hasOwnProperty` + `__extern_get` (throwing a real `ReferenceError` when
+absent), and bare delete uses `__delete_property`. Script `var` names are tracked
+separately from `let`/`const` and consulted before all property-specialized
+delete paths. IR module init conservatively demotes direct top-level
+`delete this.name` until IR owns global binding attributes.
+
+**Results.** Focused regression coverage exercises both targets, property
+presence with an `undefined`-distinguishing read, real deletion, post-delete
+`ReferenceError`, non-configurable script `var`, and the IR selector boundary.
+The authoritative original-harness runner reports **pass** for both
+`S11.4.1_A3.1` and `S11.4.1_A3.3_T1` in host/gc and standalone.
+
 ## Sub-groups (14 tests, all `test/language/expressions/delete/` unless noted)
 
 ### (a) Sloppy-mode `delete <unresolvable identifier>` → `true` (3) — DONE (2026-06-29)
+
 `S11.4.1_A2.2_T1.js`, `S11.4.1_A3.3_T6.js`, `11.4.1-3-1.js`
+
 - `delete x` where `x` resolves to **no binding anywhere** returns `true` in
   sloppy mode (§13.5.1.2: unresolvable Reference ⇒ true). We previously returned
   `false` for every bare identifier (variables-not-deletable path in
@@ -61,15 +147,19 @@ on its throw-semantics scope.
   bucket. +4 test262 (the 3 targets + bonus implicit-global `S11.4.1_A3.2_T1`).
 
 ### (b) Sloppy global-object model (4)
+
 `S11.4.1_A3.1.js` (#2 `delete this.y === false`), `S11.4.1_A3.2_T1.js`
 (`x = 1; delete x === true` — implicit global), `S11.4.1_A3.3_T1.js`
 (`delete x; x` then ReferenceError), `11.4.1-4.a-8.js` (`delete JSON === true`).
+
 - Requires modelling top-level `this` as the global object and tracking
   `var`/function-declared globals as non-configurable vs implicitly-created
   globals as configurable. Structural; likely architect-spec first.
 
 ### (c) `hasOwnProperty` false after a configurable `Object.defineProperty` delete (3)
+
 `11.4.1-4.a-1.js`, `11.4.1-4.a-2.js`, `11.4.1-4-a-4-s.js`
+
 - After `delete obj.prop` of a `configurable:true` defineProperty'd property,
   `obj.hasOwnProperty("prop")` still reports `true`. The `__delete_property`
   tombstone (`_wasmStructDeletedKeys`) / `__hasOwnProperty` predicate is not
@@ -77,27 +167,35 @@ on its throw-semantics scope.
   `built-ins/Object/defineProperty/15.2.3.6-3-*.js` share this root cause.
 
 ### (d) Non-configurable accessor descriptor not consulted by delete (1+)
+
 `11.4.1-4-a-2-s.js`
+
 - `delete obj.prop` of a **non-configurable accessor** wrongly returns `true`
   (host `__delete_property` does not see the accessor's `configurable:false`
   flag). Runtime descriptor-storage fix in `src/runtime.ts`.
 
 ### (e) Mapped-arguments delete (1) — DONE (2026-07-05)
+
 `11.4.1-4.a-17.js`
+
 - `delete arguments[0]` in a mapped-arguments function: `=== true` and the slot
   reads `undefined` afterward. Routes through the `mappedArgsInfo` bookkeeping in
   `compileDeleteExpression` plus the element-delete on `arguments`.
 - **Resolved** — see `## Resolution — group (e)`.
 
 ### (f) preventExtensions interaction (1)
+
 `11.4.1-5-a-27-s.js`
+
 - Not really a delete bug: after `delete a.x; Object.preventExtensions(a)`, a
   strict-mode `a.x = 1` must throw (assign to a property of a non-extensible
   object). Belongs with strict-mode assignment / preventExtensions support.
 
 ### (g) Prototype-chain read (1)
+
 `S8.12.7_A2_T2.js`
-- Fails at the inherited-property *read* (`__palette.red`), before the delete —
+
+- Fails at the inherited-property _read_ (`__palette.red`), before the delete —
   a prototype-chain read gap, not a delete bug.
 
 ## Acceptance
@@ -131,7 +229,7 @@ wrongly flip `undefined`/`arguments`/`globalThis`.
 (`getSymbolAtLocation === undefined`), emit `i32.const 1` (true); otherwise keep
 the `false`. **Eval guard**: an identifier inside an inlined `eval("<literal>")`
 body lives in a foreign `SourceFile` (`EVAL_SOURCE_FILENAME`, exported from
-`expressions/eval-inline.ts`) the checker never bound, so its symbol is *always*
+`expressions/eval-inline.ts`) the checker never bound, so its symbol is _always_
 `undefined` even for a name resolving to an outer var. The flip is gated to skip
 eval-body nodes (`ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME`),
 preserving `var x = 1; eval('delete x') === false` (`11.4.1-4.a-7`). Precise
@@ -140,10 +238,10 @@ eval-scope delete resolution stays out of scope (eval-substrate lane).
 
 ### Test Results — group (a) (host/gc lane, authoritative `runTest262File`)
 
-| cluster | baseline → fix |
-|---|---|
-| `language/expressions/delete` | 59 → **63** pass, **0 regressions** |
-| 98 other test262 files containing a bare-identifier `delete` | no change (0 collateral) |
+| cluster                                                      | baseline → fix                      |
+| ------------------------------------------------------------ | ----------------------------------- |
+| `language/expressions/delete`                                | 59 → **63** pass, **0 regressions** |
+| 98 other test262 files containing a bare-identifier `delete` | no change (0 collateral)            |
 
 Net **+4** test262. Flipped fail→pass: `S11.4.1_A2.2_T1`, `S11.4.1_A3.3_T6`,
 `11.4.1-3-1` (group (a)) plus bonus `S11.4.1_A3.2_T1` (group (b) implicit-global
@@ -157,8 +255,8 @@ Net **+4** test262. Flipped fail→pass: `S11.4.1_A2.2_T1`, `S11.4.1_A3.3_T6`,
 (`S11.4.1_A3.1`, `S11.4.1_A3.3_T1`) remain STRUCTURAL and out of this slice
 (see the top note / Residual).
 
-**Root cause.** After group (a) flipped only the *unresolvable* bare-identifier
-`delete` to `true`, every *resolvable* bare identifier still emitted `false`
+**Root cause.** After group (a) flipped only the _unresolvable_ bare-identifier
+`delete` to `true`, every _resolvable_ bare identifier still emitted `false`
 ("variables are not deletable"). But §13.5.1.2 step 5 makes `delete` of a
 **configurable** property of the global object return `true`. Per ECMA-262 §19
 **every** built-in global (`JSON`/`Object`/`Math`/`parseInt`/…) is
@@ -170,22 +268,23 @@ non-configurable. So `delete JSON` must be `true`, not `false`.
 **symbol provenance**: a built-in's `symbol.declarations` are ALL in ambient
 `.d.ts` lib files (`decl.getSourceFile().isDeclarationFile`), whereas a user
 binding is declared in the program's own source. Two guards make it precise:
+
 - name-exclude the three non-configurable intrinsics
   `NON_CONFIGURABLE_GLOBALS = {NaN, Infinity, undefined}` (all three are
   ambient-declared, so provenance alone wouldn't separate them);
 - require `decls.length > 0`, which keeps `undefined`/`globalThis`/`arguments`
   (empty `declarations`) out of the `true` branch.
-Eval-body nodes never reach this branch (their symbol is `undefined`, already
-handled by the group-(a) arm). Front-end constant flip (`i32.const 1`), so the
-host and standalone lanes agree — **no new host import**.
-`src/codegen/typeof-delete.ts` (bare-identifier arm + `NON_CONFIGURABLE_GLOBALS`).
+  Eval-body nodes never reach this branch (their symbol is `undefined`, already
+  handled by the group-(a) arm). Front-end constant flip (`i32.const 1`), so the
+  host and standalone lanes agree — **no new host import**.
+  `src/codegen/typeof-delete.ts` (bare-identifier arm + `NON_CONFIGURABLE_GLOBALS`).
 
 ### Test Results — group (b) 11.4.1-4.a-8 (host/gc lane, authoritative `runTest262File`)
 
-| cluster | baseline → fix |
-|---|---|
-| `language/expressions/delete` (full dir, 69 files) | 63 → **64** pass, **0 regressions** |
-| collateral (`delete <builtin>` elsewhere: `built-ins/undefined`, `staging/sm`) | no change (0 collateral) |
+| cluster                                                                        | baseline → fix                      |
+| ------------------------------------------------------------------------------ | ----------------------------------- |
+| `language/expressions/delete` (full dir, 69 files)                             | 63 → **64** pass, **0 regressions** |
+| collateral (`delete <builtin>` elsewhere: `built-ins/undefined`, `staging/sm`) | no change (0 collateral)            |
 
 Net **+1** test262. Flipped fail→pass: `11.4.1-4.a-8`. Guards verified unchanged:
 `delete NaN`/`delete undefined`/`delete <user var|func>` stay `false`
@@ -219,9 +318,9 @@ untouched. Front-end only — no new host import; standalone and host lanes agre
 
 ### Test Results — group (e) (host/gc lane, authoritative `runTest262File`)
 
-| cluster | baseline → fix |
-|---|---|
-| `language/expressions/delete` (69 files) | 64 → **65** pass, **0 regressions** |
+| cluster                                       | baseline → fix                                                     |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| `language/expressions/delete` (69 files)      | 64 → **65** pass, **0 regressions**                                |
 | `language/arguments-object/mapped` (43 files) | 39 → 39 (no change; 4 pre-existing defineProperty fails unchanged) |
 
 Net **+1** test262. Flipped fail→pass: `11.4.1-4.a-17`. Remaining `delete`-dir
@@ -235,7 +334,7 @@ architect-first), `11.4.1-5-a-27-s` (f, preventExtensions), `S8.12.7_A2_T2`
 **Root cause (c).** `var o = {}` infers an empty struct type, so the receiver
 takes the WasmGC-struct lowering path (not the `any`/host path #2731 fixed).
 `o.hasOwnProperty('foo')` was **constant-folded to `i32.const 1`** against the
-static struct shape (which `Object.defineProperty` *widens* to include `foo`),
+static struct shape (which `Object.defineProperty` _widens_ to include `foo`),
 ignoring a later configurable `delete`'s `_wasmStructDeletedKeys` tombstone. The
 fold's runtime-routing guard (`needsRuntime`) only consulted
 `ctx.definedPropertyFlags`, which is populated **only for inline object-literal
@@ -269,12 +368,12 @@ issuing the runtime call (which would otherwise add a spurious tombstone).
 
 ### Test Results (host/gc lane, authoritative `runTest262File`)
 
-| cluster | baseline → fix |
-|---|---|
+| cluster                                                                         | baseline → fix                    |
+| ------------------------------------------------------------------------------- | --------------------------------- |
 | `expressions/delete` + `Object.prototype/{hasOwnProperty,propertyIsEnumerable}` | 117 → 121 pass, **0 regressions** |
-| `Object/{defineProperty,getOwnPropertyDescriptor,defineProperties}` | 207 → 207 (no change) |
-| `Object/{freeze,seal,preventExtensions,create,getOwnPropertyNames}` | 400 → 402 pass, **0 regressions** |
-| `for-in` + `Object/keys` + `expressions/object` | 363 → 363 (no change) |
+| `Object/{defineProperty,getOwnPropertyDescriptor,defineProperties}`             | 207 → 207 (no change)             |
+| `Object/{freeze,seal,preventExtensions,create,getOwnPropertyNames}`             | 400 → 402 pass, **0 regressions** |
+| `for-in` + `Object/keys` + `expressions/object`                                 | 363 → 363 (no change)             |
 
 Net **+6** test262, **0 regressions** across ~4,500 most-related tests. Targets
 flipped fail→pass: `11.4.1-4.a-1`, `11.4.1-4.a-2`, `11.4.1-4-a-4-s` (c),
@@ -303,9 +402,9 @@ architect before further dispatch.
 **Scope.** `S8.12.7_A2_T2.js` — `delete __palette.red` where `red` is inherited
 from `Palette.prototype`, then the prototype-chain read `__palette.red` must
 still see the inherited value (CHECK#3). (The issue's original "fails at the
-inherited *read* before the delete" note is stale — CHECK#1's initial inherited
+inherited _read_ before the delete" note is stale — CHECK#1's initial inherited
 read already passes on current main; the sole remaining failure is CHECK#3, the
-read *after* the delete.)
+read _after_ the delete.)
 
 **Root cause (g).** The WasmGC-struct arm of `__delete_property`
 (`src/runtime.ts`) unconditionally dropped the sidecar/descriptor entries **and
@@ -331,8 +430,8 @@ own-delete case are untouched. `src/runtime.ts` (`__delete_property` struct arm)
 
 ### Test Results — group (g) (host/gc lane, authoritative `runTest262File`)
 
-| cluster | baseline → fix |
-|---|---|
+| cluster                                            | baseline → fix                      |
+| -------------------------------------------------- | ----------------------------------- |
 | `language/expressions/delete` (full dir, 69 files) | 65 → **66** pass, **0 regressions** |
 
 Net **+1** test262. Flipped fail→pass: `S8.12.7_A2_T2`. The other 3 dir failures

--- a/src/checker/oracle.ts
+++ b/src/checker/oracle.ts
@@ -101,6 +101,8 @@ export interface TypeOracle {
   typeKeyOf(node: ts.Node): OracleTypeKey;
   /** Declared type NAME when the node's type has a named symbol. */
   declaredNameOf(node: ts.Node): string | undefined;
+  /** Whether an identifier has no value binding in the checker environment. */
+  isUnresolvableIdentifier(id: ts.Identifier): boolean;
   /**
    * (#869) Immutable-`const` binding resolution for compile-time default-param
    * folding. If `id` is an identifier that references a `const` variable
@@ -259,6 +261,14 @@ export class TsCheckerOracle implements TypeOracle {
       this.keyCache.set(t, key);
     }
     return key;
+  }
+
+  isUnresolvableIdentifier(id: ts.Identifier): boolean {
+    try {
+      return this.checker.getSymbolAtLocation(id) === undefined;
+    } catch {
+      return true;
+    }
   }
 
   declaredNameOf(node: ts.Node): string | undefined {

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1961,6 +1961,10 @@ export interface CodegenContext {
   preRegisteredBodyless?: Set<string>;
   /** Map from module-level variable name → global index in mod.globals */
   moduleGlobals: Map<string, number>;
+  /** Script `var` names whose global-object properties are non-configurable. */
+  globalObjectVarBindings?: Set<string>;
+  /** Sloppy unresolvable assignment targets discovered before body compilation. */
+  sloppyImplicitGlobals?: Set<string>;
   /**
    * (#2931) Names of function declarations that are *reassigned* somewhere in the
    * realm (`fn = …`). ES function bindings are live/mutable, so such a name is

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -57,6 +57,11 @@ import { tryCompileFnctorPrototypeAssign } from "./fnctor-prototype.js";
 import { reserveAccessorSetDriver } from "../accessor-driver.js";
 import { S5C_STRUCT_ACCESSOR_CLOSURE } from "../struct-accessor-closure.js";
 import {
+  emitGlobalEnvironmentKey,
+  emitGlobalEnvironmentObject,
+  ensureGlobalEnvironmentOperation,
+} from "../global-environment.js";
+import {
   arrayIteratorOverrideGlobalIdx,
   emitArrayProtoIteratorDrive,
   maybeCaptureArrayProtoOverride,
@@ -99,7 +104,7 @@ import {
   emitDynamicWithSet,
   resolveWithBinding,
 } from "../with-scope.js";
-import { isStrictFunction } from "../helpers/is-strict-function.js";
+import { isStrictContext } from "../helpers/is-strict-function.js";
 
 /**
  * Emit a null/undefined guard for an externref-typed destructuring source.
@@ -560,57 +565,27 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
       fctx.body.push({ op: "global.get", index: moduleIdxPost });
       return globalType ?? resultType;
     }
-    // §6.2.5.6 PutValue steps 2.b–2.d: assigning to an unresolvable
-    // reference in non-strict code creates/updates a property on the current
-    // realm's global object. The old fallback allocated a function local, so
-    // the assignment itself appeared to work but reflective reads through
-    // globalThis/Object.getOwnPropertyDescriptor could not observe it
-    // (test262 11.13.1-4-1). Keep this host-only: standalone/WASI need a
-    // separate native-global-object write path and must not leak host imports.
-    if (
-      !ctx.standalone &&
-      !ctx.wasi &&
-      !isStrictContext(expr.left, ctx.inferModuleStrictArguments) &&
-      isUnresolvableIdent(ctx, fctx, expr.left)
-    ) {
-      const gtIdx = ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
-      const setIdx = ensureLateImport(
-        ctx,
-        "__extern_set",
-        [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
-        [],
-      );
-      flushLateImportShifts(ctx, fctx);
+    // §6.2.5.6 PutValue: a sloppy unresolvable assignment creates/updates a
+    // configurable property on the realm's global object. Host and host-free
+    // targets share the same target-aware carrier (#2726).
+    if (!isStrictContext(expr.left, ctx.inferModuleStrictArguments) && isUnresolvableIdent(ctx, fctx, expr.left)) {
+      (ctx.sloppyImplicitGlobals ??= new Set()).add(name);
+      const resultType = compileExpression(ctx, fctx, expr.right);
+      if (!resultType) return null;
+      const resultTmp = allocLocal(fctx, `__implicit_global_rhs_${fctx.locals.length}`, resultType);
+      fctx.body.push({ op: "local.set", index: resultTmp });
 
-      if (gtIdx !== undefined && setIdx !== undefined) {
-        // §13.15.2 evaluates the RHS once, PutValue consumes that value, and
-        // the assignment expression then returns the same RHS value. Preserve
-        // its native representation in a temp while boxing only the copy sent
-        // through the host object's [[Set]] bridge.
-        const resultType = compileExpression(ctx, fctx, expr.right);
-        if (!resultType) return null;
-        const resultTmp = allocLocal(fctx, `__implicit_global_rhs_${fctx.locals.length}`, resultType);
-        fctx.body.push({ op: "local.set", index: resultTmp });
-
-        // RHS compilation may have registered additional late imports, so use
-        // the current function indices rather than the pre-RHS snapshots.
-        const finalGtIdx = ctx.funcMap.get("__get_globalThis");
-        if (finalGtIdx === undefined) return null;
-        fctx.body.push({ op: "call", funcIdx: finalGtIdx });
-        addStringConstantGlobal(ctx, name);
-        fctx.body.push(...stringConstantExternrefInstrs(ctx, name));
-        fctx.body.push({ op: "local.get", index: resultTmp });
-        if (resultType.kind !== "externref") {
-          coerceType(ctx, fctx, resultType, { kind: "externref" });
-        }
-        // Boxing may itself register a late import and shift every later
-        // function index; resolve the setter only after that coercion.
-        const finalSetIdx = ctx.funcMap.get("__extern_set");
-        if (finalSetIdx === undefined) return null;
-        fctx.body.push({ op: "call", funcIdx: finalSetIdx });
-        fctx.body.push({ op: "local.get", index: resultTmp });
-        return resultType;
+      if (!emitGlobalEnvironmentObject(ctx, fctx)) return null;
+      emitGlobalEnvironmentKey(ctx, fctx, name);
+      fctx.body.push({ op: "local.get", index: resultTmp });
+      if (resultType.kind !== "externref") {
+        coerceType(ctx, fctx, resultType, { kind: "externref" });
       }
+      const setIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__extern_set");
+      if (setIdx === undefined) return null;
+      fctx.body.push({ op: "call", funcIdx: setIdx });
+      fctx.body.push({ op: "local.get", index: resultTmp });
+      return resultType;
     }
 
     // Graceful fallback for other unresolved identifiers: auto-allocate a
@@ -839,62 +814,7 @@ function emitIdentifierWriteFromLocal(
   fctx.body.push({ op: "local.set", index: newLocalIdx });
 }
 
-/**
- * Detect strict-mode context for a node (§10.2.1).
- * A node is in strict mode if:
- *   - Containing source file starts with `"use strict";` directive.
- *   - Inside a class body (classes are always strict).
- *   - Inside a function whose body begins with `"use strict";`.
- */
-export function isStrictContext(node: ts.Node, inferModuleStrict = true): boolean {
-  let current: ts.Node | undefined = node;
-  while (current) {
-    if (
-      ts.isFunctionDeclaration(current) ||
-      ts.isFunctionExpression(current) ||
-      ts.isArrowFunction(current) ||
-      ts.isMethodDeclaration(current) ||
-      ts.isGetAccessorDeclaration(current) ||
-      ts.isSetAccessorDeclaration(current) ||
-      ts.isConstructorDeclaration(current)
-    ) {
-      return isStrictFunction(current, inferModuleStrict);
-    }
-    if (ts.isSourceFile(current)) {
-      for (const stmt of current.statements) {
-        if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
-          if (stmt.expression.text === "use strict") return true;
-        } else {
-          break;
-        }
-      }
-      const internal = current as ts.SourceFile & { externalModuleIndicator?: ts.Node };
-      return (
-        inferModuleStrict &&
-        (internal.externalModuleIndicator !== undefined || current.impliedNodeFormat === ts.ModuleKind.ESNext)
-      );
-    }
-    if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) return true;
-    if (
-      ts.isFunctionDeclaration(current) ||
-      ts.isFunctionExpression(current) ||
-      ts.isArrowFunction(current) ||
-      ts.isMethodDeclaration(current)
-    ) {
-      if (current.body && ts.isBlock(current.body)) {
-        for (const stmt of current.body.statements) {
-          if (ts.isExpressionStatement(stmt) && ts.isStringLiteral(stmt.expression)) {
-            if (stmt.expression.text === "use strict") return true;
-          } else {
-            break;
-          }
-        }
-      }
-    }
-    current = current.parent;
-  }
-  return false;
-}
+export { isStrictContext } from "../helpers/is-strict-function.js";
 
 /** True when this binding is the receiver of a static Object.defineProperty call. */
 function sourceDefinesProperty(ctx: CodegenContext, receiver: ts.Identifier, propName: string): boolean {

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -53,6 +53,7 @@ import {
   isSupportedBuiltinNamespace,
 } from "../builtin-static-globals.js";
 import { tryEmitPromiseSubclassValue } from "./promise-subclass.js";
+import { emitImplicitGlobalRead } from "../global-environment.js";
 
 /**
  * #1473 — Build the set of `$Error_struct` `$tag` values compatible with an
@@ -809,7 +810,7 @@ function compileIdentifierCore(ctx: CodegenContext, fctx: FunctionContext, id: t
     }
     return mType;
   }
-
+  if (ctx.sloppyImplicitGlobals?.has(name)) return emitImplicitGlobalRead(ctx, fctx, name);
   // Standalone built-in namespace values (Array/Object) materialize as lazy
   // open-object singletons before ambient lib declarations can route them to
   // host globals.

--- a/src/codegen/global-environment.ts
+++ b/src/codegen/global-environment.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Bounded GlobalEnvironmentRecord lowering shared by identifier reads, writes,
+ * and deletes (#2726). Host/gc uses the current sandbox global; host-free
+ * targets use the existing native `$Object` singleton.
+ */
+import type { ValType } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { emitNativeGlobalThisObject } from "./array-object-proto.js";
+import { popBody, pushBody } from "./context/bodies.js";
+import { allocLocal } from "./context/locals.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { emitThrowReferenceError } from "./expressions/helpers.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { isStrictContext } from "./helpers/is-strict-function.js";
+import { buildThrowJsErrorInstrs } from "./js-errors.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+
+export function emitGlobalEnvironmentObject(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  if (ctx.standalone || ctx.wasi) {
+    return emitNativeGlobalThisObject(ctx, fctx);
+  }
+
+  const getGlobalIdx = ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (getGlobalIdx === undefined) return null;
+  fctx.body.push({ op: "call", funcIdx: getGlobalIdx });
+  return { kind: "externref" };
+}
+
+export function emitGlobalEnvironmentKey(ctx: CodegenContext, fctx: FunctionContext, name: string): void {
+  addStringConstantGlobal(ctx, name);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, name));
+}
+
+export function ensureGlobalEnvironmentOperation(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  name: "__extern_get" | "__extern_set" | "__delete_property" | "__hasOwnProperty",
+): number | undefined {
+  const externref: ValType = { kind: "externref" };
+  const signature =
+    name === "__extern_set"
+      ? { params: [externref, externref, externref], results: [] }
+      : name === "__extern_get"
+        ? { params: [externref, externref], results: [externref] }
+        : name === "__delete_property" || name === "__hasOwnProperty"
+          ? { params: [externref, externref], results: [{ kind: "i32" } satisfies ValType] }
+          : { params: [], results: [] };
+  const idx = ensureLateImport(ctx, name, signature.params, signature.results);
+  flushLateImportShifts(ctx, fctx);
+  return idx;
+}
+
+/** Read a pre-scanned sloppy implicit global, throwing when it was deleted. */
+export function emitImplicitGlobalRead(ctx: CodegenContext, fctx: FunctionContext, name: string): ValType | null {
+  if (!emitGlobalEnvironmentObject(ctx, fctx)) return null;
+  const objectLocal = allocLocal(fctx, `__implicit_global_obj_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: objectLocal });
+  const hasOwnIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__hasOwnProperty");
+  const getIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__extern_get");
+  if (hasOwnIdx === undefined || getIdx === undefined) return null;
+
+  fctx.body.push({ op: "local.get", index: objectLocal });
+  emitGlobalEnvironmentKey(ctx, fctx, name);
+  fctx.body.push({ op: "call", funcIdx: hasOwnIdx }, { op: "i32.eqz" });
+  const saved = pushBody(fctx);
+  emitThrowReferenceError(ctx, fctx, `${name} is not defined`);
+  const throwBody = fctx.body;
+  popBody(fctx, saved);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwBody, else: [] });
+
+  fctx.body.push({ op: "local.get", index: objectLocal });
+  emitGlobalEnvironmentKey(ctx, fctx, name);
+  fctx.body.push({ op: "call", funcIdx: getIdx });
+  return { kind: "externref" };
+}
+
+/** Delete a global-object property; an absent property succeeds. */
+export function emitGlobalEnvironmentDelete(ctx: CodegenContext, fctx: FunctionContext, name: string): void {
+  if (!emitGlobalEnvironmentObject(ctx, fctx)) {
+    fctx.body.push({ op: "i32.const", value: 1 });
+    return;
+  }
+  emitGlobalEnvironmentKey(ctx, fctx, name);
+  const deleteIdx = ensureGlobalEnvironmentOperation(ctx, fctx, "__delete_property");
+  if (deleteIdx === undefined) {
+    fctx.body.push({ op: "drop" }, { op: "drop" }, { op: "i32.const", value: 1 });
+    return;
+  }
+  fctx.body.push({ op: "call", funcIdx: deleteIdx });
+}
+
+/** Whether a direct module-init member delete targets a script var/function. */
+export function isNonConfigurableGlobalObjectDelete(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  operand: ts.Expression,
+): boolean {
+  if (!ts.isPropertyAccessExpression(operand) || fctx.name !== "__module_init" || ctx.sourceIsModule) return false;
+  let receiver: ts.Expression = operand.expression;
+  while (
+    ts.isParenthesizedExpression(receiver) ||
+    ts.isAsExpression(receiver) ||
+    ts.isNonNullExpression(receiver) ||
+    ts.isTypeAssertionExpression(receiver)
+  ) {
+    receiver = receiver.expression;
+  }
+  const isGlobalObject =
+    receiver.kind === ts.SyntaxKind.ThisKeyword ||
+    (ts.isIdentifier(receiver) && receiver.text === "globalThis" && !ctx.moduleGlobals.has("globalThis"));
+  return (
+    isGlobalObject &&
+    (ctx.globalObjectVarBindings?.has(operand.name.text) || ctx.topLevelFunctionNames.has(operand.name.text))
+  );
+}
+
+/** Emit the known outcome for a direct delete of a script var/function property. */
+export function tryEmitNonConfigurableGlobalObjectDelete(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.DeleteExpression,
+): ValType | null {
+  if (!isNonConfigurableGlobalObjectDelete(ctx, fctx, expr.expression)) return null;
+  if (isStrictContext(expr, ctx.inferModuleStrictArguments)) {
+    fctx.body.push(
+      ...buildThrowJsErrorInstrs(ctx, "TypeError", "Cannot delete non-configurable property in strict mode", {
+        flush: fctx,
+      }),
+    );
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 });
+  }
+  return { kind: "i32" };
+}

--- a/src/codegen/helpers/is-strict-function.ts
+++ b/src/codegen/helpers/is-strict-function.ts
@@ -102,6 +102,28 @@ export function isStrictFunction(
   return result;
 }
 
+/** Decide whether an arbitrary node is evaluated as strict-mode code. */
+export function isStrictContext(node: ts.Node, inferModuleStrict = true): boolean {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (
+      ts.isFunctionDeclaration(current) ||
+      ts.isFunctionExpression(current) ||
+      ts.isArrowFunction(current) ||
+      ts.isMethodDeclaration(current) ||
+      ts.isGetAccessorDeclaration(current) ||
+      ts.isSetAccessorDeclaration(current) ||
+      ts.isConstructorDeclaration(current)
+    ) {
+      return isStrictFunction(current, inferModuleStrict);
+    }
+    if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) return true;
+    if (ts.isSourceFile(current)) {
+      return hasUseStrictPrologue(current.statements) || (inferModuleStrict && isModuleSourceFile(current));
+    }
+  }
+  return false;
+}
+
 /**
  * (#2743) IsSimpleParameterList (ECMA-262 §15.1.3). A FormalParameters list is
  * "simple" iff every element is a plain `BindingIdentifier` with no default

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -128,6 +128,8 @@ import { fillAccessorDrivers } from "./accessor-driver.js";
 import { fillVecOverlayHelpers } from "./vec-overlay.js"; // (#3251 S1)
 import { fillDisposableStackDisposeDriver } from "./disposable-runtime.js";
 import {
+  recordSloppyImplicitGlobalNames,
+  recordScriptVarBindingNames,
   sourceContainsClass,
   sourceContainsDelete,
   sourceHasDynamicTaConstruct,
@@ -3070,6 +3072,16 @@ function prepareMultiIrImportedLowering(
   return blocked.size === 0 ? selection : closeIrBlockedComponent(sourceFile, selection, blocked);
 }
 
+function recordSourceGlobalEnvironment(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
+  recordScriptVarBindingNames((ctx.globalObjectVarBindings ??= new Set()), sourceFile);
+  recordSloppyImplicitGlobalNames(
+    (ctx.sloppyImplicitGlobals ??= new Set()),
+    sourceFile,
+    ctx.oracle,
+    ctx.inferModuleStrictArguments ?? true,
+  );
+}
+
 /** Compile a typed AST into a WasmModule IR */
 export function generateModule(
   ast: TypedAST,
@@ -3096,6 +3108,7 @@ export function generateModule(
     : undefined;
   const sourceFileInternal = ast.sourceFile as ts.SourceFile & { externalModuleIndicator?: ts.Node };
   ctx.sourceIsModule = sourceFileInternal.externalModuleIndicator !== undefined;
+  recordSourceGlobalEnvironment(ctx, ast.sourceFile);
   // (#2138) Populated only under JS2WASM_IR_FIRST=1 — the top-level functions
   // whose legacy body emission was skipped (IR owns the slot). Declared out
   // here so the return statement below (outside the try) can surface it.
@@ -3168,7 +3181,6 @@ export function generateModule(
         reserveLinearU8AllocType(ctx);
       }
     }
-
     // (#2357/#47) Reserve the standalone TypedArray `$__subview_<elem>` struct
     // types up-front, here — at the SAME deterministic point in every codegen
     // pass — so the subview type index is identical across the hoist pass (which
@@ -5552,7 +5564,6 @@ export function generateMultiModule(
     if (ctx.wasi) {
       registerWasiImports(ctx, multiAst.entryFile);
     }
-
     // $AnyValue struct type is now registered lazily via ensureAnyValueType()
 
     // Phase 1: Collect extern declarations first (needed before import collectors)
@@ -5659,6 +5670,7 @@ export function generateMultiModule(
       if (sourceOverridesArrayIterator(sf)) {
         ctx.arrayIteratorMaybeOverridden = true;
       }
+      recordSourceGlobalEnvironment(ctx, sf);
     }
 
     // Phase 2: Collect all declarations — only entry file gets Wasm exports

--- a/src/codegen/source-scan-predicates.ts
+++ b/src/codegen/source-scan-predicates.ts
@@ -9,6 +9,8 @@
 // walk-until-found shape and have no dependency on `CodegenContext`.
 
 import { ts, forEachChild } from "../ts-api.js";
+import type { TypeOracle } from "../checker/oracle.js";
+import { isStrictContext } from "./helpers/is-strict-function.js";
 import { TYPED_ARRAY_NAMES } from "./index.js";
 
 export function sourceContainsClass(sourceFile: ts.SourceFile): boolean {
@@ -48,6 +50,70 @@ export function sourceContainsDelete(sourceFile: ts.SourceFile): boolean {
   }
   walk(sourceFile);
   return found;
+}
+
+/**
+ * Names that a simple sloppy assignment may create as configurable properties
+ * of the global object. The pre-scan makes read lowering independent of
+ * function/body compilation order (#2726).
+ */
+export function collectSloppyImplicitGlobalNames(
+  sourceFile: ts.SourceFile,
+  oracle: TypeOracle,
+  inferModuleStrict: boolean,
+): Set<string> {
+  const names = new Set<string>();
+  function walk(node: ts.Node): void {
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      let lhs = node.left;
+      while (
+        ts.isParenthesizedExpression(lhs) ||
+        ts.isAsExpression(lhs) ||
+        ts.isNonNullExpression(lhs) ||
+        ts.isTypeAssertionExpression(lhs)
+      ) {
+        lhs = lhs.expression;
+      }
+      if (ts.isIdentifier(lhs) && !isStrictContext(lhs, inferModuleStrict) && oracle.isUnresolvableIdentifier(lhs)) {
+        names.add(lhs.text);
+      }
+    }
+    forEachChild(node, walk);
+  }
+  walk(sourceFile);
+  return names;
+}
+
+export function recordSloppyImplicitGlobalNames(
+  target: Set<string>,
+  sourceFile: ts.SourceFile,
+  oracle: TypeOracle,
+  inferModuleStrict: boolean,
+): void {
+  for (const name of collectSloppyImplicitGlobalNames(sourceFile, oracle, inferModuleStrict)) target.add(name);
+}
+
+/** Script `var` binding names, including declarations nested in top-level control flow. */
+export function recordScriptVarBindingNames(target: Set<string>, sourceFile: ts.SourceFile): void {
+  const recordName = (name: ts.BindingName): void => {
+    if (ts.isIdentifier(name)) {
+      target.add(name.text);
+      return;
+    }
+    for (const element of name.elements) {
+      if (!ts.isOmittedExpression(element)) recordName(element.name);
+    }
+  };
+  const walk = (node: ts.Node): void => {
+    if (node !== sourceFile && (ts.isFunctionLike(node) || ts.isClassDeclaration(node) || ts.isClassExpression(node))) {
+      return;
+    }
+    if (ts.isVariableDeclarationList(node) && (node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0) {
+      for (const declaration of node.declarations) recordName(declaration.name);
+    }
+    forEachChild(node, walk);
+  };
+  walk(sourceFile);
 }
 
 /**

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -30,6 +30,7 @@ import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, isAnyValue } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
 import { emitDynamicWithDelete, findWithBinding, resolveWithBinding } from "./with-scope.js";
+import { emitGlobalEnvironmentDelete, tryEmitNonConfigurableGlobalObjectDelete } from "./global-environment.js";
 
 // (#2726 group (b), partial) The only value properties of the global object with
 // `[[Configurable]]: false` (ECMA-262 §19.1). `delete <bareIdentifier>` of any of
@@ -297,7 +298,6 @@ export function compileDeleteExpression(
     emitDeleteThrow(ctx, fctx, "ReferenceError", "'super' property cannot be deleted");
     return { kind: "i32" };
   }
-
   if (ts.isIdentifier(inner)) {
     // (#2663 Slice 3) `delete name` inside a dynamic `with`: if the with-object
     // has the binding ⇒ delete the object property (configurability-aware
@@ -355,7 +355,7 @@ export function compileDeleteExpression(
     const identSym = ctx.checker.getSymbolAtLocation(ident);
     const notEvalBody = ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME;
     if (identSym === undefined && notEvalBody) {
-      fctx.body.push({ op: "i32.const", value: 1 });
+      emitGlobalEnvironmentDelete(ctx, fctx, ident.text);
       return { kind: "i32" };
     }
     // (#2726 group (b), partial) §13.5.1.2 step 5: a `delete IdentifierReference`
@@ -385,7 +385,8 @@ export function compileDeleteExpression(
     fctx.body.push({ op: "i32.const", value: 0 });
     return { kind: "i32" };
   }
-
+  const globalObjectDelete = tryEmitNonConfigurableGlobalObjectDelete(ctx, fctx, expr);
+  if (globalObjectDelete) return globalObjectDelete;
   // (#1511) `delete arguments[i]` on a mapped index severs the param↔arguments
   // mapping for that slot (ECMA-262 §10.4.4.5 step 5.b): after a successful
   // delete the property no longer mirrors the named parameter. Record the

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -5230,6 +5230,19 @@ function collectDirectNestedFunctionNames(body: ts.Block): Set<string> {
   return names;
 }
 
+/**
+ * The IR delete lowerer returns constant true and has no global binding
+ * attributes. Keep direct module-init `delete this.name` on legacy until the IR
+ * owns the GlobalEnvironmentRecord model (#2726).
+ */
+function isUnsupportedModuleGlobalObjectDelete(expr: ts.DeleteExpression): boolean {
+  return (
+    currentSubjectIsModuleInit &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    expr.expression.expression.kind === ts.SyntaxKind.ThisKeyword
+  );
+}
+
 function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClasses: ReadonlySet<string>): boolean {
   if (
     (expressionTouchesModuleExtern(expr) || expressionTouchesModuleMapGetAlias(expr)) &&
@@ -5238,8 +5251,7 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     return shapeNo("expr-module-extern-consumer", expr);
   }
   if (ts.isParenthesizedExpression(expr)) return isPhase1Expr(expr.expression, scope, localClasses);
-  // (#1373b C-1) `await <e>` inside a C-1-claimed async body. Shape-accept
-  // mirrors the legacy sync-model lowering from-ast emits:
+  // (#1373b C-1) `await <e>` inside a C-1 async body mirrors legacy sync-model lowering:
   //   - `await Promise.resolve(x)` → the settled expression `x` (#3227
   //     static substitution) — check THAT shape; the zero-arg form settles
   //     to `undefined`, which from-ast has no value lowering for → reject.
@@ -6064,9 +6076,10 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
   //   - `void <expr>`         → lower expr for side effects, push
   //                              `f64 NaN` (the undefined sentinel
   //                              the IR uses in f64-typed contexts).
-  if (ts.isDeleteExpression(expr)) {
-    return isPhase1Expr(expr.expression, scope, localClasses);
-  }
+  if (ts.isDeleteExpression(expr))
+    return isUnsupportedModuleGlobalObjectDelete(expr)
+      ? shapeNo("expr-delete-module-global-object", expr)
+      : isPhase1Expr(expr.expression, scope, localClasses);
   if (ts.isVoidExpression(expr)) {
     return isPhase1Expr(expr.expression, scope, localClasses);
   }

--- a/tests/issue-2726-global-environment-delete.test.ts
+++ b/tests/issue-2726-global-environment-delete.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runScript(source: string, target?: "standalone"): Promise<Record<string, unknown>> {
+  const result = await compile(source, {
+    allowJs: true,
+    fileName: "issue-2726-global-environment-delete.js",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+    deferTopLevelInit: true,
+    ...(target ? { target } : {}),
+  });
+  expect(result.success, result.errors.map((error) => error.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+
+  const sandbox: Record<string, unknown> = {};
+  const imports = target ? {} : buildImports(result.imports, undefined, result.stringPool, { globalSandbox: sandbox });
+  if (target) {
+    expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  if (!target) {
+    (imports as ReturnType<typeof buildImports>).setExports?.(instance.exports as Record<string, Function>);
+  }
+  const moduleInit = (instance.exports as { __module_init?: () => void }).__module_init;
+  expect(typeof moduleInit).toBe("function");
+  moduleInit?.();
+  return sandbox;
+}
+
+const declaredVarSource = `
+  var __issue_2726_declared_var__ = 1;
+  if (delete __issue_2726_declared_var__ !== false) {
+    throw new Error("bare var binding became deletable");
+  }
+  if (delete this.__issue_2726_declared_var__ !== false) {
+    throw new Error("script var property became deletable");
+  }
+`;
+
+const implicitGlobalSource = `
+  try {
+    __issue_2726_implicit_global__ = 1;
+    if (__issue_2726_implicit_global__ !== 1) {
+      throw new Error("implicit-global read missed its property");
+    }
+    if (delete __issue_2726_implicit_global__ !== true) {
+      throw new Error("implicit-global delete was refused");
+    }
+    __issue_2726_implicit_global__;
+    throw new Error("deleted implicit global remained resolvable");
+  } catch (error) {
+    if (!(error instanceof ReferenceError)) throw error;
+  }
+`;
+
+describe("#2726 residual global-environment delete semantics", () => {
+  it("keeps top-level this property deletes off the constant-true IR path", () => {
+    const sourceFile = ts.createSourceFile(
+      "issue-2726.js",
+      "var y = 1; delete this.y;",
+      ts.ScriptTarget.ES2022,
+      true,
+      ts.ScriptKind.JS,
+    );
+    const selection = planIrCompilation(sourceFile, { experimentalIR: true, trackFallbacks: true });
+    expect(selection.moduleInit?.reason).toBe("body-shape-rejected");
+  });
+
+  it("keeps a script var non-configurable through top-level this (host)", async () => {
+    await runScript(declaredVarSource);
+  });
+
+  it("keeps a script var non-configurable through top-level this (standalone)", async () => {
+    await runScript(declaredVarSource, "standalone");
+  });
+
+  it("creates, reads, deletes, and unresolves an implicit global (host)", async () => {
+    const sandbox = await runScript(implicitGlobalSource);
+    expect(Object.hasOwn(sandbox, "__issue_2726_implicit_global__")).toBe(false);
+  });
+
+  it("creates, reads, deletes, and unresolves an implicit global (standalone)", async () => {
+    await runScript(implicitGlobalSource, "standalone");
+  });
+});


### PR DESCRIPTION
## Summary

- route sloppy implicit-global assignment, reads, and deletion through one target-aware global environment for host/gc and standalone
- track script `var` bindings as non-configurable for direct top-level global-object deletes
- keep unsupported module-init global-object deletes off the IR constant-result path
- add focused host/standalone regression coverage and close the remaining ES5 delete residuals

## Root cause

The compiler stored host implicit globals on the sandbox but used a standalone local fallback, returned a constant for bare-identifier deletion without removing the property, and had no binding-attribute record for `delete this.y` when `y` came from a script `var`. The IR module-init delete path also assumed a constant successful result.

## Impact

`S11.4.1_A3.1` and `S11.4.1_A3.3_T1` now pass in both host/gc and standalone: script `var` properties remain non-deletable, while implicit globals are created as configurable properties, deleted for real, and become unresolvable afterward.

## Validation

- `pnpm run typecheck`
- focused issue regression suite: 20/20 passing
- authoritative Test262: both residual files passing in host/gc and standalone (4/4)
- LOC budget, function budget, checker-oracle ratchet, and IR fallback gates
- Prettier formatting check
- Biome lint (existing warnings only)

## Plan issue

Completes residual group (b) in `plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md`.

## CLA

- [ ] I have read and agree to the CLA
