### PR TITLE
feat(interp): add parser-injected dynamic Function factory

### DIFF
--- a/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
+++ b/plan/issues/2928-bytecode-interpreter-core-standalone-eval.md
@@ -279,8 +279,41 @@ standalone compile currently refuses dynamic RegExp construction (#1539) and
 RegExp-based `String.prototype.match`/`replace` (#1474). #2927 must provide a
 host-free parser acceptance gate before E2 can wire real runtime source text.
 
-Still required for E2 acceptance: the #2927 parser artifact, callable
-materialization and AOT/interpreter classification at the #3098 seam, and the
-`new Function(<dynamic>)` routing change in `new-super.ts`. The landed canary is
-the lower-level prerequisite, not a claim that either public dynamic-code API
-is routed yet.
+## Implementation findings (parser-injected Function factory, 2026-07-26)
+
+The interpreter now exposes a host-free parser boundary matching the measured
+Acorn artifact:
+
+```text
+parse(source: native string, options: $Object) -> ESTree $Object
+```
+
+`compileDynamicFunctionMeta` wraps the flattened parameter/body strings as a
+synthetic `function anonymous`, parses with `ecmaVersion: 2025` and
+`sourceType: "script"`, and emits the declaration through a new `emitFunction`
+entry point. `createDynamicFunction` then roots the metadata at a global
+`$EnvRec` and returns an ordinary interpreted callable. The E2 canary proves
+that entire injected-parser → emitter → callable → `interpEnter` path in a
+zero-import standalone module: `fn(1, 2) === 3`. Node fixtures also preserve
+the observable `name === "anonymous"` and `length === 2`.
+
+The callable materializer needs eight explicit formal slots, matching the
+Phase-1 generic closure ceiling; a rest-only trampoline is classified as arity
+zero and drops the call arguments. The function expression must also remain
+anonymous: naming it `interpTrampoline` currently selects the standalone
+fnctor-escape path and loses the returned closure carrier. WeakMap branding and
+best-effort `name`/`length` definition are safe after materialization and remain
+unchanged.
+
+The synchronized Acorn slice now separately measures Acorn 8.16.0 at 23/23
+exact AST parity, a 1,699,827-byte zero-import standalone artifact, and a
+successful returned-closure gate. It preserves the boundary above without
+introducing a callable or rec-group ABI. Its publication remains owned by
+#2927.
+
+Still required for public E2 acceptance: land and package the #2927 parser
+artifact, then replace the standalone `new Function(<dynamic>)` Tier-3 stub in
+`new-super.ts` with this factory. Indirect eval remains E3, and on-demand
+ordered-initializer packaging remains E6/#2527. This canary proves the
+production seam but does not yet claim either public dynamic-code API is
+routed.

--- a/src/interp/dynamic-function.ts
+++ b/src/interp/dynamic-function.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2928 E2 — parser-injected standalone Function-constructor factory.
+//
+// Parsing remains owned by #2927/Acorn and packaging by E6/#2527. This file is
+// the interpreter-owned boundary between them: it accepts Acorn's native-string
+// `parse(source, options) -> ESTree $Object` entry, emits a FuncMeta, roots the
+// function at the module global environment, and materializes an ordinary
+// callable through the interpreter's existing closure seam.
+
+import { emitFunction } from "./emitter.js";
+import { makeInterpClosure, type InterpCallable } from "./loop.js";
+import { ENV_GLOBAL, EnvRec, type FuncMeta, type JSValue } from "./types.js";
+
+/** Host-free Acorn entry shape. `source` uses the compiler's native string
+ * carrier; both `options` and the result use the shared open-$Object carrier. */
+export type DynamicParser = (source: string, options: JSValue) => JSValue;
+
+/** Build the source text parsed by the Function constructor.
+ *
+ * The newlines are intentional: they keep a trailing line comment in the
+ * parameter or body text from swallowing the wrapper delimiter. Parameter and
+ * body strings have already undergone ToString and comma-flattening at the
+ * call-site routing layer.
+ */
+export function dynamicFunctionSource(paramString: string, bodyString: string): string {
+  return "function anonymous(" + paramString + "\n) {\n" + bodyString + "\n}";
+}
+
+/** Parse and emit a Function-constructor body without materializing a value. */
+export function compileDynamicFunctionMeta(parse: DynamicParser, paramString: string, bodyString: string): FuncMeta {
+  const options: JSValue = {};
+  options.ecmaVersion = 2025;
+  options.sourceType = "script";
+
+  const ast: JSValue = parse(dynamicFunctionSource(paramString, bodyString), options);
+  const body: JSValue = ast.body;
+  const declaration: JSValue = body[0];
+  if (declaration === undefined || declaration.type !== "FunctionDeclaration") {
+    throw new SyntaxError("runtime parser did not return a FunctionDeclaration");
+  }
+  return emitFunction(declaration);
+}
+
+/** Construct a global-scope interpreted function from dynamic parameter/body
+ * strings. Parse and early errors propagate at construction time; invocation
+ * enters the interpreter through the ordinary closure call protocol. */
+export function createDynamicFunction(
+  parse: DynamicParser,
+  paramString: string,
+  bodyString: string,
+  globalObject: JSValue,
+): InterpCallable {
+  const meta = compileDynamicFunctionMeta(parse, paramString, bodyString);
+  const env = new EnvRec(ENV_GLOBAL, null, null, null, globalObject);
+  return makeInterpClosure(meta, env);
+}

--- a/src/interp/emitter.ts
+++ b/src/interp/emitter.ts
@@ -1023,3 +1023,26 @@ export function emitProgram(ast: Node): FuncMeta {
   const emitter = new FunctionEmitter([], ast, "", /*isScript*/ true, /*isExpressionBody*/ false);
   return emitter.emit();
 }
+
+/** Emit one parsed function node to callable metadata.
+ *
+ * `new Function` is parsed through a synthetic `FunctionDeclaration`, then
+ * handed here instead of compiling the enclosing `Program` as an eval script.
+ * The resulting metadata binds the parsed parameters in `regs[1..]`, returns
+ * from the function body normally, and carries the synthetic `anonymous` name
+ * without installing it as a global declaration.
+ */
+export function emitFunction(node: Node): FuncMeta {
+  if (
+    node.type !== "FunctionDeclaration" &&
+    node.type !== "FunctionExpression" &&
+    node.type !== "ArrowFunctionExpression"
+  ) {
+    throw new UnsupportedNodeError(`function entry ${node.type}`, node.type);
+  }
+  const isArrow = node.type === "ArrowFunctionExpression";
+  const isExpressionBody = isArrow && node.body.type !== "BlockStatement";
+  const name = node.id && node.id.name ? node.id.name : "";
+  const emitter = new FunctionEmitter(node.params, node.body, name, /*isScript*/ false, isExpressionBody);
+  return emitter.emit();
+}

--- a/src/interp/index.ts
+++ b/src/interp/index.ts
@@ -14,9 +14,15 @@ import { ENV_GLOBAL, EnvRec, type FuncMeta, type JSValue } from "./types.js";
 
 export { Op, Builtin, OP_INFO, OP_COUNT } from "./opcodes.js";
 export { Encoder } from "./encoder.js";
-export { emitProgram, UnsupportedNodeError } from "./emitter.js";
+export { emitFunction, emitProgram, UnsupportedNodeError } from "./emitter.js";
 export { disassemble, decodeInstr } from "./disasm.js";
-export { interpEnter, makeInterpClosure, isInterpClosure, InterpInternalError } from "./loop.js";
+export { interpEnter, makeInterpClosure, isInterpClosure, InterpInternalError, type InterpCallable } from "./loop.js";
+export {
+  compileDynamicFunctionMeta,
+  createDynamicFunction,
+  dynamicFunctionSource,
+  type DynamicParser,
+} from "./dynamic-function.js";
 export { FuncMeta, Frame, EnvRec, type JSValue } from "./types.js";
 
 /** Build a global environment record whose backing is `globalObject`. */

--- a/src/interp/loop.ts
+++ b/src/interp/loop.ts
@@ -81,16 +81,47 @@ interface InterpBinding {
 }
 const INTERP_BINDINGS: WeakMap<object, InterpBinding> = new WeakMap();
 
+/** Callable carrier shared with the standalone generic closure ABI. */
+export type InterpCallable = (
+  a0?: JSValue,
+  a1?: JSValue,
+  a2?: JSValue,
+  a3?: JSValue,
+  a4?: JSValue,
+  a5?: JSValue,
+  a6?: JSValue,
+  a7?: JSValue,
+) => JSValue;
+
 /** Is `v` an interpreted-function value (a branded closure)? */
 export function isInterpClosure(v: JSValue): boolean {
   return typeof v === "function" && INTERP_BINDINGS.has(v as object);
 }
 
 /** Build an interpreted-function value from a FuncMeta + captured env record. */
-export function makeInterpClosure(meta: FuncMeta, envRec: EnvRec | null): JSValue {
-  // A regular (non-arrow) function so `.prototype` exists for construct/instanceof.
-  const closure = function interpTrampoline(this: JSValue, ...args: JSValue[]): JSValue {
-    return interpEnter(meta, envRec, this, args);
+export function makeInterpClosure(meta: FuncMeta, envRec: EnvRec | null): InterpCallable {
+  // A regular (non-arrow) function so `.prototype` exists for
+  // construct/instanceof. Keep eight explicit formal slots: the standalone
+  // generic closure dispatcher classifies a rest-only function as arity zero,
+  // which would discard the AOT call's arguments before this trampoline runs.
+  // Eight is the shared Phase-1 closure ABI ceiling (#3310). Keep the body free
+  // of `arguments`: the standalone compiler already pads under-applied closure
+  // calls to their declared arity, and its `arguments` side channel belongs to
+  // `__apply_closure`, not a statically typed returned closure.
+  // Keep this expression anonymous. A named expression currently takes the
+  // standalone fnctor-escape path and loses the returned closure carrier.
+  const closure: InterpCallable = function (
+    this: JSValue,
+    a0?: JSValue,
+    a1?: JSValue,
+    a2?: JSValue,
+    a3?: JSValue,
+    a4?: JSValue,
+    a5?: JSValue,
+    a6?: JSValue,
+    a7?: JSValue,
+  ): JSValue {
+    return interpEnter(meta, envRec, this, [a0, a1, a2, a3, a4, a5, a6, a7]);
   };
   const nm = typeof meta.name === "string" ? meta.name : "";
   try {

--- a/tests/interp/fixtures.test.ts
+++ b/tests/interp/fixtures.test.ts
@@ -7,7 +7,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { Encoder } from "../../src/interp/encoder.js";
 import { Op, OP_COUNT, OP_INFO } from "../../src/interp/opcodes.js";
-import { compileScript, disassemble } from "../../src/interp/index.js";
+import { compileScript, createDynamicFunction, disassemble } from "../../src/interp/index.js";
 import { loadAcorn, parse, runInterp } from "./harness.js";
 
 beforeAll(async () => {
@@ -20,6 +20,20 @@ function expectValue(body: string, expected: unknown): void {
   expect(r.ok, `body threw: ${r.errName} — ${body}`).toBe(true);
   expect(r.value).toEqual(expected);
 }
+
+describe("#2928 dynamic Function factory", () => {
+  it("constructs a global-scope interpreted function through an injected parser", () => {
+    const globalObject: Record<string, unknown> = {};
+    const fn = createDynamicFunction((source) => parse(source), "a,b", "return a + b", globalObject) as (
+      a: number,
+      b: number,
+    ) => number;
+
+    expect(fn(1, 2)).toBe(3);
+    expect(fn.name).toBe("anonymous");
+    expect(fn.length).toBe(2);
+  });
+});
 
 describe("#3101 encoder — packing + operand fields", () => {
   it("packs op/a/b into one word and the opcode survives the WIDE mask", () => {

--- a/tests/issue-2928.test.ts
+++ b/tests/issue-2928.test.ts
@@ -13,7 +13,15 @@ import { relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 
-const INTERP_FILES = ["types.ts", "opcodes.ts", "encoder.ts", "runtime-ops.ts", "emitter.ts", "loop.ts"] as const;
+const INTERP_FILES = [
+  "types.ts",
+  "opcodes.ts",
+  "encoder.ts",
+  "runtime-ops.ts",
+  "emitter.ts",
+  "loop.ts",
+  "dynamic-function.ts",
+] as const;
 
 function stripModuleSyntax(source: string): string {
   return source
@@ -54,17 +62,89 @@ function e2BundleSource(): string {
         return ast;
       }
 
-      export function test(): number {
+      function makeFunctionAst(): any {
+        const left: any = {};
+        left.type = "Identifier";
+        left.name = "a";
+        const right: any = {};
+        right.type = "Identifier";
+        right.name = "b";
+        const binary: any = {};
+        binary.type = "BinaryExpression";
+        binary.operator = "+";
+        binary.left = left;
+        binary.right = right;
+        const ret: any = {};
+        ret.type = "ReturnStatement";
+        ret.argument = binary;
+        const block: any = {};
+        block.type = "BlockStatement";
+        block.body = [ret];
+        const a: any = {};
+        a.type = "Identifier";
+        a.name = "a";
+        const b: any = {};
+        b.type = "Identifier";
+        b.name = "b";
+        const id: any = {};
+        id.type = "Identifier";
+        id.name = "anonymous";
+        const declaration: any = {};
+        declaration.type = "FunctionDeclaration";
+        declaration.id = id;
+        declaration.params = [a, b];
+        declaration.body = block;
+        const ast: any = {};
+        ast.type = "Program";
+        ast.sourceType = "script";
+        ast.body = [declaration];
+        return ast;
+      }
+
+      function parse(source: string, options: any): any {
+        if (source !== "function anonymous(a,b\\n) {\\nreturn a + b\\n}") {
+          throw new SyntaxError("unexpected Function-constructor source");
+        }
+        if (options.ecmaVersion !== 2025 || options.sourceType !== "script") {
+          throw new TypeError("unexpected parser options");
+        }
+        return makeFunctionAst();
+      }
+
+      export function testProgram(): number {
         const globalObject: any = {};
         const env = new EnvRec(ENV_GLOBAL, null, null, null, globalObject);
         return interpEnter(emitProgram(makeAst()), env, globalObject, []) as number;
+      }
+
+      export function testDynamicFunction(): number {
+        const globalObject: any = {};
+        const fn = createDynamicFunction(parse, "a,b", "return a + b", globalObject);
+        return fn(1, 2) as number;
+      }
+
+      export function testDynamicClosureCreated(): number {
+        const globalObject: any = {};
+        const fn = createDynamicFunction(parse, "a,b", "return a + b", globalObject);
+        return fn === undefined ? 0 : 1;
+      }
+
+      export function testDynamicMetaParamCount(): number {
+        return compileDynamicFunctionMeta(parse, "a,b", "return a + b").paramCount;
+      }
+
+      export function testDynamicDirect(): number {
+        const globalObject: any = {};
+        const env = new EnvRec(ENV_GLOBAL, null, null, null, globalObject);
+        const meta = compileDynamicFunctionMeta(parse, "a,b", "return a + b");
+        return interpEnter(meta, env, globalObject, [1, 2]) as number;
       }
     `,
   ].join("\n");
 }
 
 describe("#2928 E2 — self-compiled standalone interpreter canary", () => {
-  it("emits bytecode and evaluates an ESTree 1 + 2 program entirely inside Wasm", async () => {
+  it("evaluates ESTree plus a parser-injected dynamic Function entirely inside Wasm", async () => {
     const result = await compile(e2BundleSource(), {
       fileName: "issue-2928-e2-bundle.ts",
       skipSemanticDiagnostics: true,
@@ -81,6 +161,10 @@ describe("#2928 E2 — self-compiled standalone interpreter canary", () => {
     expect(WebAssembly.Module.imports(new WebAssembly.Module(result.binary))).toEqual([]);
 
     const { instance } = await WebAssembly.instantiate(result.binary, {});
-    expect((instance.exports.test as () => number)()).toBe(3);
+    expect((instance.exports.testProgram as () => number)()).toBe(3);
+    expect((instance.exports.testDynamicMetaParamCount as () => number)()).toBe(2);
+    expect((instance.exports.testDynamicDirect as () => number)()).toBe(3);
+    expect((instance.exports.testDynamicClosureCreated as () => number)()).toBe(1);
+    expect((instance.exports.testDynamicFunction as () => number)()).toBe(3);
   }, 120_000);
 });


### PR DESCRIPTION
## Summary

- add the interpreter-owned `parse(source, options) -> ESTree` boundary for dynamic `Function`
- emit parsed function declarations directly as `FuncMeta`
- materialize global-scope interpreted callables through the existing standalone closure ABI
- extend the zero-import E2 self-compile canary through callable invocation

## Why

The original E2 canary proved only ESTree-to-bytecode execution for a fixed
`1 + 2` program. Runtime `new Function` also needs a stable seam to the
independently compiled Acorn parser and a callable that can re-enter the
interpreter.

This keeps parser ownership and packaging separate: Acorn remains injected,
while this slice owns source wrapping, function metadata emission, global
environment creation, and callable materialization.

During the standalone canary, a named trampoline function expression selected
the fnctor-escape path and lost the returned closure carrier. Keeping the
materialized expression anonymous preserves the callable; WeakMap branding and
best-effort `name`/`length` metadata remain intact.

Advances #2928. Public `new Function(<dynamic>)` routing, indirect eval, and
on-demand Acorn/interpreter packaging remain follow-up slices.

## Validation

- `vitest run tests/interp/fixtures.test.ts tests/interp/differential.test.ts tests/issue-2928.test.ts` — 130 passed, 2 skipped
- `tsc --noEmit`
- standalone E2 artifact validates, has zero imports, and returns `3` from the injected-parser `fn(1, 2)` canary
