### PR TITLE
chore(test262): stop tracking local run log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ benchmarks/results/*.txt
 # but it must never be re-committed to this repo.
 benchmarks/results/test262-current.jsonl
 benchmarks/results/test262-results.jsonl
+benchmarks/results/test262-run.log
 .pnpm-store/
 .claude/settings.local.json
 .claude/max-load

--- a/benchmarks/results/test262-run.log
+++ b/benchmarks/results/test262-run.log
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b74bcb3ef22c60c65d3aefe1245de7a70064a2ccda152a2b85dab54b2de2cdbb
-size 21435015


### PR DESCRIPTION
## What changed

- Ignore `benchmarks/results/test262-run.log`.
- Remove the tracked Git LFS pointer for the generated run log.

## Why

`scripts/run-test262.sh` creates this file as local console capture and only
truncates/appends it; no workflow, test, report generator, or package script
reads it. Tracking the generated log makes full Test262 runs dirty the
worktree and can accidentally refresh a 21.4 MB LFS object.

The runner continues to produce the local log at the same path, but Git now
leaves it untracked.

## Validation

- `git diff --check`
- `git check-ignore -v --no-index benchmarks/results/test262-run.log`
- Repository-wide reference audit confirming no functional consumer reads the
  file

No test suite was run because this changes only generated-artifact tracking.
The historical LFS object remains in repository history; this PR does not
rewrite history.
