### PR TITLE
docs(issues): file #3658/#3659/#3660 — follow-ups from the promote-deadlock session

### DIFF
--- a/plan/issues/3658-summary-sync-succeeds-without-committing.md
+++ b/plan/issues/3658-summary-sync-succeeds-without-committing.md
@@ -1,0 +1,82 @@
+---
+id: 3658
+title: "Landing-page summary sync reports SUCCESS while committing nothing — report page frozen since 15:43Z"
+status: ready
+created: 2026-07-26
+priority: high
+horizon: s
+feasibility: medium
+area: ci
+goal: ci-hardening
+sprint: current
+related: [1951, 3634, 3467]
+---
+
+# #3658 — the summary sync succeeds without committing
+
+## This is the user-visible symptom, and it is NOT the promote deadlock
+
+On 2026-07-25 the report page showed data ~7-9h stale. That was initially — and
+**incorrectly** — attributed entirely to the baseline-promote deadlock (#3634).
+The deadlock was real and was fixed; promotes have flowed since (22:43Z, 22:46Z,
+23:02Z, 00:06Z, 00:37Z). **The report page did not recover.**
+
+## Measured
+
+`benchmarks/results/test262-current.json` on `main` — the file the landing page
+reads — is stuck at:
+
+```
+2026-07-25 15:43:36 +0000  chore(test262): scheduled baseline summary sync — 30390/43098 pass
+```
+
+Verified still stale at **00:06:11Z** after 30 minutes of polling, and again later.
+Meanwhile the promoted baseline in `loopdive/js2wasm-baselines` read
+**30,511/43,104** as of 23:02Z.
+
+**The sync ran and reported SUCCESS in between and committed nothing:**
+
+| sync run | conclusion | committed? |
+|---|---|---|
+| 18:29:43Z | success | no |
+| 19:45:45Z | success | no |
+| 21:27:01Z | success | no |
+| 22:28:35Z | success | no |
+| **23:32:36Z** | **success** | **no** — and fresh 23:02Z baseline data existed |
+
+Commits to that file land only ~3-hourly (09:19, 12:33, 15:43) and stopped
+entirely after 15:43. So the hourly schedule fires, the job is green, and the
+artifact does not move.
+
+## Why it matters
+
+This is the **only** part of the outage a human actually sees. Everything
+downstream of it — landing page, pass/total badges, the trend graph — reports
+numbers that are hours or days old while CI is perfectly healthy. It also made a
+genuine promote outage look like it had been fixed when the visible symptom had
+not changed at all.
+
+## The shape to note
+
+**A green job is not evidence it did its work.** Identical in shape to the
+`quality` fail-fast case (an early `bash -e` abort skips 25 later gates while the
+step that ran reports fine). Any diagnosis here must confirm the *commit*, never
+the *conclusion*.
+
+## Investigate
+
+1. Does the sync compare against a stale local cache, or a ref it never refreshes,
+   so it concludes "no change" while the remote baseline has moved?
+2. Does it commit to a branch other than `main`, or open a PR that nobody merges?
+3. Is a `git diff --cached --quiet` style guard short-circuiting on a path that
+   was never re-staged (cf. #3607, where the standalone summary was not staged in
+   promote)?
+4. Does it need the baselines repo fetched fresh, and is it reading a cached
+   `.test262-cache/` copy instead?
+
+## Acceptance
+
+- A promote to the baselines repo is reflected in committed
+  `benchmarks/results/test262-current.json` within one sync cycle.
+- The job **fails loudly** when it finds new baseline data but produces no commit,
+  rather than exiting 0.

--- a/plan/issues/3659-ratchet-3603-regressions-allow-ceiling-down.md
+++ b/plan/issues/3659-ratchet-3603-regressions-allow-ceiling-down.md
@@ -1,0 +1,59 @@
+---
+id: 3659
+title: "Ratchet #3603's regressions-allow ceiling down from the stakeholder-directed unmeasured 2500"
+status: ready
+created: 2026-07-26
+priority: high
+horizon: s
+feasibility: easy
+area: ci
+goal: correctness
+sprint: current
+related: [3603, 3635, 3370, 3303]
+---
+
+# #3659 — replace the unmeasured 2500 ceiling with a measured one
+
+## What was done, and why it is deliberately provisional
+
+PR #3635 (#3603 S1, host verifyProperty de-inflation) carries:
+
+```yaml
+regressions-allow:
+  count: 2500
+  reason: "... Stakeholder-directed UNMEASURED ceiling (2026-07-26) ..."
+```
+
+**2500 is not a measurement.** It was a stakeholder decision taken on 2026-07-26
+to land the de-inflation without waiting for a v12 merge_group run, after the
+tradeoff was stated explicitly: a ceiling that is too low re-parks, one that is
+too high **banks unmeasured regressions**.
+
+## Why no smaller number could be derived at the time
+
+The `ORACLE_VERSION` 11→12 bump **is itself the verdict-logic change**. At v12 the
+row classifications differ on **both sides** of the diff, so the prior v11 figures
+are not merely stale — they are a **different quantity** and cannot be arithmetically
+converted. Additionally the baseline moved four times in one evening
+(30,390 → 30,446 → 30,517 → 30,511), so the denominator was not stable either.
+
+For context only, **do not reuse as a ceiling**: at v11 against baseline `895058f`,
+two merge_group runs measured **1031–1033** honest regressions and **96–97** gross
+fixed (net −989 / −994).
+
+## Do this
+
+1. Take the **first v12 merge_group measurement** on #3635's merged state.
+2. Record, per the stakeholder ruling's condition (d), **gross-fixed and
+   honest-regressions separately — never a net**.
+3. Set `count:` to **measured + a documented margin**, showing the arithmetic.
+   Margin must cover at least the observed run-to-run spread (~2) plus baseline
+   drift. Never a round number.
+4. Note `regressionsWasmChange > count` hard-fails as "not a blank check", so the
+   ceiling is a real bound in both directions.
+
+## Related trap
+
+The declaration is honoured post-merge **only** when it carries a nested `tests:`
+list (`named-verified`); a bare `count:` + `reason:` without an oracle bump is
+classified `inert` and grants zero. See #3644 / #3660.

--- a/plan/issues/3660-trap-growth-allow-consumed-by-one-promote-run.md
+++ b/plan/issues/3660-trap-growth-allow-consumed-by-one-promote-run.md
@@ -1,0 +1,62 @@
+---
+id: 3660
+title: "trap-growth-allow is consumed by exactly ONE promote run — an unrelated failure of that run re-creates the wedge"
+status: ready
+created: 2026-07-26
+priority: medium
+horizon: m
+feasibility: medium
+area: ci
+goal: ci-hardening
+sprint: current
+related: [3644, 3639, 3634, 3370, 3189]
+---
+
+# #3660 — the allowance is single-shot, so recovery is not self-healing
+
+## Residual left open by #3644 / PR #3639
+
+#3639 fixes the deadlock where a declared `trap-growth-allow` never reached the
+post-merge promote job. That is the right fix and it prevents the wedge. **It does
+not make recovery self-healing**, and that gap should be recorded rather than
+assumed away.
+
+## The residual
+
+A change-scoped allowance is resolved from **the merge commit's change-set**, so it
+is available to **exactly one promote run** — the one for the merge that introduced
+it. If that specific run fails for **any unrelated reason** (a push race to the
+baselines repo, an artifact 403, a runner failure, a cancelled run), the
+declaration is gone from every later change-set. Subsequent pushes carry no
+declaration, the trap category is still elevated on main, and the promote refuses
+identically. **That is byte-for-byte the original wedge**, and clearing it again
+needs the blanket `BASELINE_TRAP_GROWTH_ALLOW` repo-variable valve.
+
+This matters because promote failures are exactly the class that already happens
+for unrelated reasons — see #3634, where the promote job failed on **six
+consecutive** pushes from a push race.
+
+## Second, independent residual (completeness)
+
+`evaluateTrapReclassification`'s completeness condition is **stricter than the
+ceiling**: it fails if **any** newly-trapping file in a growing category is
+unnamed, and `newlyTrapping[cat]` can exceed the net delta. So `count: 1` does not
+guarantee the promote succeeds if the merged state moves any *other* file into a
+trap category.
+
+## Options
+
+1. **Persist the granted ceiling alongside the baseline** so it survives a failed
+   run and is re-applied on retry, rather than living only in the change-set.
+2. **Detect the specific state** (baseline trap count < main's, with a matching
+   previously-declared allowance) and re-honour it rather than refusing.
+3. At minimum: **alert loudly** when a promote refuses on a trap category, naming
+   the declaration that would have covered it — today the failure is silent and
+   took ~9h to notice (#3634).
+
+## Shape rule to preserve
+
+Post-merge, an allowance is honoured only when the declaration carries a nested
+`tests:` list (`named-verified`). A bare `count:` + `reason:` with no oracle bump
+stays `inert` and grants zero. Future PRs declaring trap growth **must** include
+`tests:` or they wedge promote regardless of the count.


### PR DESCRIPTION
Three issue files, no source changes. Ids allocated via `claim-issue.mjs --allocate` and **independently verified free** against `origin/main` (highest was 3650) and all open PRs, per the #3636 allocator bug.

## #3658 — summary sync reports SUCCESS while committing nothing (high)

**This is the user-visible symptom, and it is NOT the promote deadlock.** That distinction cost real time last night: the deadlock was fixed, promotes have flowed since (22:43 → 22:46 → 23:02 → 00:06 → 00:37Z), and the report page **did not recover**.

`benchmarks/results/test262-current.json` on main is still `15:43:36Z / 30390-43098` while the promoted baseline reads **30,511/43,104**. The sync ran and reported **SUCCESS** at 18:29, 19:45, 21:27, 22:28 and **23:32Z** — the last with fresh 23:02Z data available — and committed on none of them.

Same shape as the `quality` fail-fast bug landed in #3652: **a green job is not evidence it did its work.** Acceptance includes failing loudly when new baseline data exists but no commit is produced.

## #3659 — ratchet #3603's `regressions-allow` down from 2500 (high)

2500 is **not a measurement**. It was a stakeholder decision to land the de-inflation without waiting for a v12 merge_group run, taken after the tradeoff was stated: too low re-parks, too high **banks unmeasured regressions**.

No smaller number was derivable at the time — the `ORACLE_VERSION` 11→12 bump **is itself the verdict-logic change**, so row classifications differ on *both* sides and the v11 figures are a **different quantity**, not merely stale. The baseline also moved four times in one evening. The v11 context (1031–1033 honest regressions, 96–97 gross fixed) is recorded explicitly **as context, not as a ceiling**.

## #3660 — `trap-growth-allow` is consumed by exactly ONE promote run (medium)

Residual left open by #3644 / PR #3639. That fix prevents the wedge but **does not make recovery self-healing**: the allowance is resolved from the merge commit's change-set, so if that one run fails for **any unrelated reason** — push race, artifact 403, cancelled run — the declaration is gone from every later change-set and the promote refuses identically.

That is not hypothetical: #3634 documents promote failing on **six consecutive** pushes from a push race. Also records the stricter completeness condition (any *unnamed* newly-trapping file in a growing category fails regardless of count) and the shape rule that only a nested `tests:` list is honoured post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXSXz9G2eZrfNeX3satN5X