### PR TITLE
feat(test262): inventory reusable linked harness objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "check:loc-budget": "node scripts/check-loc-budget.mjs",
     "check:func-budget": "node scripts/check-func-budget.mjs",
     "check:harness-compile-budget": "npx tsx scripts/check-harness-compile-budget.ts",
+    "inventory:test262-linked-harness": "npx tsx scripts/test262-linked-harness-inventory.ts",
     "check:dead-exports": "node scripts/audit-legacy-reachability.mjs --check",
     "check:godfiles": "node scripts/profile-godfiles.mjs --check",
     "profile:godfiles": "node scripts/profile-godfiles.mjs",

--- a/plan/issues/3451-linked-harness-wasm-separate-compilation.md
+++ b/plan/issues/3451-linked-harness-wasm-separate-compilation.md
@@ -1,77 +1,268 @@
 ---
 id: 3451
-title: "arch(#1046/#33/#34): linked harness .wasm as the driving use case for separate compilation"
-status: backlog
-sprint: Backlog
+title: "Test262: compile and statically link reusable Wasm harness objects in both lanes"
+status: in-progress
+sprint: current
 created: 2026-07-19
-updated: 2026-07-19
-priority: low
+updated: 2026-07-26
+priority: high
 horizon: xl
 feasibility: hard
-reasoning_effort: high
-task_type: arch
-area: codegen
-language_feature: compiler-internals
-goal: standalone-mode
-depends_on: [1046, 33, 34]
+reasoning_effort: max
+task_type: perf
+area: test262-runner
+language_feature: module-linking
+goal: test262-conformance
+depends_on: [1046, 2527]
+related: [33, 34, 3433, 3450, 3461, 3491, 3625]
 ---
 
-# Linked harness .wasm as the driving use case for separate compilation (L4 / Spec F)
+# #3451 — reusable linked Test262 harness Wasm for both lanes
 
-> **Roadmap / XL.** This rides on the #1046 (separate ES-module compilation) / #33
-> (relocatable wasm object file) / #34 (multi-memory module linker) slices — it is
-> **not this-window CI work** and requires no CI change until the linker slice
-> exists. Endorsed end-state, filed so the test262 prelude is named as the
-> acceptance workload for the linker roadmap.
+## Decision
 
-Implements lever **L4** from `plan/ci-acceleration-review.md` (§3-L4, §5-F).
+Use the same **separate-compilation + static-linking architecture** for both the
+JS-host and standalone Test262 lanes:
+
+1. Compile the literal upstream harness prefix to a relocatable Wasm object.
+2. Compile only the test body for each sloppy/strict variant.
+3. Statically link the harness object + body object into **one final Wasm
+   module**.
+4. Instantiate a fresh final module for every test.
+
+Reuse immutable compiled code, never a live harness instance and never a prior
+test verdict. This preserves per-test realm isolation and prevents prototype,
+global, async, or harness state from poisoning later tests.
+
+This supersedes the original standalone-only framing of this issue. The host
+lane's native-V8 harness mode (#3450/#3461) remains a useful shadow oracle and
+short-term experiment, but linked Wasm is the preferred common end-state because
+the compiler remains authoritative for the literal harness in both lanes.
 
 ## Problem
 
-The standalone lane **cannot** host-execute the harness by definition — its whole
-point is host-free wasm, and #2961 / oracle v6 rejects binaries with host imports
-(`scripts/test262-worker.mjs:1399-1403`). So the L3 native-JS-harness win (#3450)
-is unavailable here: the harness must stay in-wasm.
+The authoritative runner currently prepends the real Test262 harness to every
+test and compiles the whole assembly. Passing tests commonly compile again for
+the strict rerun. Across ~43k tests this recompiles the same 6–18 KB prefix
+roughly ~73k times per full two-lane run.
 
-The dedup shape for standalone is therefore **separate compilation + linking**:
-compile the assembled prelude **once per (includes-set × strict × compiler-bundle)**
-into a harness module, then per test compile only the **body** and link it against
-that prelude module.
+#3433 removed the worst quadratic compiler rescans, but the remaining work is
+real linear parsing, checking, codegen, and emission of the repeated prefix. In
+the measured slow shard, compilation accounts for ~95% of compile time; runner
+setup and execution are comparatively small. Caching verdicts would be unsafe,
+whereas caching a compiler artifact and still compiling/linking/running every
+body preserves regression detection.
 
-The includes-set cardinality is small — **a few dozen** distinct prelude
-combinations cover all 43k tests — so when linking exists the per-run compile
-count collapses from **~73k prelude codegens → ~10²** prelude compiles + ~73k
-body-only compiles.
+The prefix combinations are much less numerous than the test bodies. The
+2026-07-26 inventory found exactly **64 strict-neutral harness sources** in
+43,287 eligible files. Therefore the desired compile shape is:
 
-## Why it is XL / roadmap, not a CI-window fix
+```text
+repeated full harness+body compilations
+        ↓
+64 harness objects per target lane
+        + body-only compilations
+        + cheap links and fresh executions
+```
 
-This is the #1046 separate-compilation / #33 relocatable-object / #34 module-linker
-path. #3433's roadmap already endorses it as the end-state and notes that slice-1's
-**scalar/externref boundary is insufficient** — the harness needs:
+## Artifact and execution model
 
-- **class identity** across modules (`Test262Error instanceof`),
-- **shared script globals**,
-- **closure-grade linkage** across the module boundary.
+### Harness-object key
 
-That is an XL compiler-roadmap item in which the harness becomes the *driving use
-case*, not a CI-window change. A cheaper interim (front-end-only prelude snapshot)
-was measured and rejected in #3433 — ceiling ≈ 13 %, not worth the diagnostics
-risk.
+Initially build one combined harness object per exact key:
+
+- compiler bundle/content hash,
+- target lane (`js-host` or `standalone`),
+- ordered metadata include set,
+- async helper presence,
+- upstream harness/runtime source hashes,
+- compiler options and runtime/canonical-rec-group ABI versions.
+
+Strictness is deliberately **not** part of the harness key: the harness prefix
+is strict-neutral and the `"use strict"` directive belongs at the beginning of
+the body compilation unit. `raw` tests bypass the harness object entirely.
+
+Use target-specific objects first. Host and standalone currently lower runtime
+operations differently, so they must not share bytes merely because their
+source prefix is identical. A later shared-runtime ABI may make more of the
+objects target-neutral.
+
+### Link shape
+
+```text
+harness-<lane>-<include-key>.o
+        + test-body-<variant>.o
+        ↓ static link
+one self-contained test.wasm
+        ↓
+fresh Store/Instance/realm for that test
+```
+
+Prefer a **single statically linked final module**, not two long-lived Wasm
+instances connected by a host bridge. The final module must share the same JS
+global environment, constructors, exception tags, closure/table state, and
+object identity between harness and body.
+
+### Memory and poisoning controls
+
+- Cache immutable object bytes/manifests, not mutable instances or globals.
+- Share the harness object bytes across the four workers in a shard job where
+  practical; otherwise use a small bounded per-worker LRU.
+- Never retain per-test final binaries, source programs, compiler contexts, or
+  instances after the row is written.
+- Keep the current realm-contamination canary and GC guards until RSS
+  measurements prove a safer replacement.
+- Instantiate a fresh final module and fresh import/async state for every test,
+  including both variants of a strict rerun.
+
+## Required compiler/linker work
+
+The repository has the foundations—#33 relocatable object emission, #34's
+linker, and #2527's canonical WasmGC rec-group identity work—but the current
+linker is not yet a production Test262 linker. This workload requires:
+
+1. **Harness interface manifest.** Body-only compilation must know the harness
+   globals and their types (`assert`, `Test262Error`, `$DONE`, `$ERROR`,
+   `verifyProperty`, include-defined helpers, and related constructors) and emit
+   linkable undefined symbols instead of host fallbacks or reference errors.
+2. **Script-global semantics.** Preserve Test262's same-realm separate-script
+   behavior, including top-level `var`/function visibility, lexical bindings,
+   duplicate function last-wins behavior, and exact initialization order:
+   async helper → metadata includes → runtime shim → `assert.js` → `sta.js` →
+   test body.
+3. **WasmGC/type identity.** Merge or canonicalize GC rec groups so strings,
+   vectors, boxed values, classes, and especially `Test262Error` keep identity.
+4. **Closures, tables, tags, and globals.** Relocate indirect calls, closure
+   environments, function tables, mutable globals, exception tags, element/data
+   segments, and module-init functions without duplicating runtime state.
+5. **Runtime helper deduplication.** Resolve identical helpers once in the final
+   module rather than linking two private copies whose identities or global
+   state can diverge.
+6. **Diagnostics/source maps.** Body diagnostics must remain anchored to the
+   untouched upstream test file. Harness/link failures must be separately
+   attributable.
+7. **Standalone purity.** The final standalone binary must retain the existing
+   post-link zero-host-import invariant.
+
+## Delivery slices
+
+1. **Corpus/ABI inventory — implemented 2026-07-26:** measure exact include-set
+   cardinality, declared and consumed harness symbols, duplicate declarations,
+   initialization effects, body-only split parity, and target-specific keys.
+2. **Minimal linked smoke:** compile/link `assert.js` + a body using
+   `assert.sameValue`, producing one valid executable module in both targets.
+3. **Shared-realm substrate:** add globals, constructors/class identity,
+   closures/tables, exception tags, and ordered module initialization; cover
+   `Test262Error instanceof`, `verifyProperty`, callbacks, and object identity.
+4. **Runner shadow mode:** add a non-authoritative `linked-wasm` oracle lane,
+   bounded harness-object cache, metrics, and row stamps without changing the
+   existing baselines.
+5. **Full-corpus parity and stress:** run current honest assembly and linked mode
+   on the same compiler commit in both targets; investigate every difference and
+   run order-randomized poisoning/OOM stress.
+6. **Authority flip:** after parity, give linked mode its own compatible
+   baseline/oracle version, make it authoritative for both lanes, and retain the
+   old honest assembly as a temporary scheduled audit until confidence is high.
+
+## Slice 1 implementation and measurements (2026-07-26)
+
+`assembleLinkedHarness` now exposes the authoritative source as an immutable,
+strict-neutral harness prefix plus a body-only unit. Strictness is keyed only by
+the body; raw tests bypass the object path. The source key includes ordered
+parts, async state, and the final prefix hash, and is namespaced by target lane.
+It is an inventory identity, not yet a production cache key; slice 4 must add
+the compiler/options/runtime ABI versions listed above.
+
+`pnpm run inventory:test262-linked-harness` walks the maintained corpus through
+the same discovery, metadata, filter, and harness assembly functions as the
+runner. It records declaration/initialization ABI facts and validates every
+split against the honest assembly.
+
+Measured on the local maintained checkout:
+
+- 48,088 discovered files; 43,287 eligible and 4,801 filtered;
+- 82,660 potential body variants, with **82,660/82,660 source-split parity
+  checks passing**;
+- 32 raw bypass tests, 5,377 async tests, and 504 fixture-graph candidates;
+- **64 unique harness sources**, or **128 target-specific objects**;
+- potential harness compilations per lane collapse **82,628 → 64**;
+- potential repeated harness source per lane collapses
+  **716,058,857 bytes → 1,141,693 bytes**;
+- 78 statically consumed harness symbols;
+- 14 keys contain duplicate top-level declarations that require the existing
+  last-wins rename/initialization contract.
+
+The inventory completed in roughly 14–15 seconds. This is not yet a shard speed
+measurement: the authoritative runner is intentionally unchanged until the
+linked smoke and shared-realm substrate pass. #3625's earlier measured
+**72.3% host compile-cost share for the harness prefix** remains the realistic
+performance target, while the inventory proves the reuse cardinality.
+
+### Authoritative-runner parity control
+
+A same-machine Test262 host-lane shard control (`chunk 1/57`, 836 rows,
+`COMPILER_POOL_SIZE=4`) compared `origin/main` with this slice. The normalized
+`file + strict + status` rows had the same SHA-256 digest, with identical totals:
+526 pass, 284 fail, and 26 compile errors. Poison retries were also identical at 17.
+
+The control took 189.81 seconds wall / 598,151 ms summed compile time; the
+candidate took 194.37 seconds wall / 614,837 ms summed compile time. That is a
+single-pair candidate slowdown of 2.4% wall / 2.8% summed compile time, within
+the existing Test262 runner noise and with no relevant execution-path change.
+This slice therefore claims **no runtime speedup**. It establishes exact
+source/verdict parity and the reusable-object cardinality; timing the linked
+path begins only after slice 2 can execute it.
+
+### Current blocker for slice 2
+
+The current object linker resolves scalar function/global imports and emits
+multiple isolated memories. Literal `assert.js` needs the opposite shape:
+WasmGC rec-group merging, one shared runtime/global environment, closure/table
+and tag relocation, ordered module initialization, data segments, and helper
+deduplication. Wiring linked mode into Test262 before those invariants exist
+would change verdicts rather than merely accelerate them.
 
 ## Acceptance criteria
 
-1. The **#1046 slice-2 spec** names the test262 prelude as its acceptance
-   workload: compile the assembled prelude once per (includes-set × strict), link
-   per-test bodies against it.
-2. Class identity (`Test262Error instanceof`) + shared script globals hold across
-   the module boundary in the linked output.
-3. Demonstrated: per-run prelude codegens collapse **~73k → ~10²** on the
-   standalone lane.
-4. No CI change lands under this issue until the linker slice exists; this issue
-   is the roadmap anchor + acceptance-workload definition.
+- [ ] Both `js-host` and `standalone` compile the harness separately and
+      statically link it with body-only objects into one final module per test.
+- [x] The exact harness-object cardinality, source-byte reuse, body split, and
+      initial ABI surface are measured reproducibly on the maintained corpus.
+- [ ] A full run reduces harness-prefix codegens from ~73k to
+      `O(distinct include keys × lanes × workers)`, with the exact before/after
+      counters recorded.
+- [ ] Sloppy, strict-only, noStrict, raw, async, negative, include-heavy, and
+      `_FIXTURE`/module-graph cases have explicit coverage (coordinate the last
+      category with #3491).
+- [ ] Full-corpus row-by-row parity holds against the existing authoritative
+      honest mode in each lane: status, expected error phase/type, assertion
+      count, async completion, and relevant error classification.
+- [ ] Cross-boundary identity tests cover `Test262Error instanceof`, reference
+      equality, descriptors/MOP operations, callbacks/closures, built-in
+      constructors/prototypes, and thrown values.
+- [ ] Randomized two-pass order testing and targeted prototype/global/$DONE
+      mutation probes produce identical results, proving no live-instance
+      poisoning.
+- [ ] Standalone linked outputs contain no forbidden host imports after the
+      final link.
+- [ ] Four-worker shard stress has no OOMs and does not materially increase peak
+      RSS versus the current honest runner; caches have explicit byte/entry
+      limits and expose hit/miss/eviction metrics.
+- [ ] Production merge-group measurements show at least a 2× reduction in
+      median `Run shard` time; target approximately 2–3 minute shards without
+      increasing end-to-end queue time.
+- [ ] Any authority/verdict-logic change bumps or separates the oracle version
+      before baseline comparison, so the merge queue cannot compare incompatible
+      rows.
 
 ## References
 
-- Review: `plan/ci-acceleration-review.md` §3-L4, §5-F, §2.1.
-- Depends on #1046 / #33 / #34. #2961 (standalone host-free contract),
-  #3433 (roadmap, 13 % snapshot ceiling, lane-asymmetric end-state).
+- `plan/ci-acceleration-review.md` §3-L4, §5-F, §2.1.
+- #3625: measured rejection of cross-target frontend/IR sharing and the 72.3%
+  host harness-prefix compile-cost share.
+- #3433: measured prelude dominance and compiled-prefix reuse recommendation.
+- #1046: separate compilation and consumer-facing symbol/interface work.
+- #33 / #34: relocatable object emitter and static linker foundations.
+- #2527 / #2514: core-Wasm shared-store and canonical WasmGC runtime ABI.
+- #3450 / #3461: native-host harness experiment and parity machinery.
+- #3491: static Test262 `_FIXTURE` module-graph linking.

--- a/plan/issues/3625-merge-test262-lane-compilation.md
+++ b/plan/issues/3625-merge-test262-lane-compilation.md
@@ -14,6 +14,7 @@ goal: maintainability
 related: [3431, 3433, 3450, 3461, 3462, 3470]
 created: 2026-07-25
 completed: 2026-07-25
+updated: 2026-07-26
 ---
 
 # Merge the two test262 lanes' compilation — MEASURED, recommend closing
@@ -54,6 +55,36 @@ The lever that _is_ real sits elsewhere and is already scoped: the assembled
 **harness prefix is ~72 % of host-lane compile cost** (independently reproduced
 here; matches #3433's "75–97 % of every compile"). That is #3450 / #3461 / #3462,
 parked on a stakeholder decision — roughly **5× larger** than the best case here.
+
+## 2026-07-26 follow-up: persistent language service
+
+#700 / PR #3650 changes one implementation fact below: the incremental compiler
+can now retain a versioned TypeScript Language Service, `Program`, checker, lib
+snapshots, and document registry across compilations. Identical input no longer
+requires intentionally rebuilding a fresh `Program` and checker on every call.
+
+That improvement does **not** change this issue's verdict:
+
+- host and standalone still hand different processed source to TypeScript in
+  87/90 measured files because the standalone-only pre-parse transforms remain;
+- the measured parse/program/bind share is still 1.94%, so sharing only the
+  unchanged front-end work has a ≤0.91% both-lane ceiling;
+- target-sensitive checker queries remain nested in generation, and IR/runtime
+  lowering is not target-neutral;
+- the CI target lanes still run concurrently and must keep independent failure
+  domains.
+
+The exact maintained shard-1/57 A/B performed for #700 also found that retaining
+the service past the old 100-test reset did not move aggregate compile time:
+summed `compile_ms` was 682,101 ms with the reset and 681,904 ms without it
+(0.03% lower, effectively identical). Wall time was noisy (reset-free mean 1.1%
+faster, with the paired ordering reversing), while all 836
+`file + strict + status` tuples were identical.
+
+The active follow-up is #3451: key and compile the repeated literal harness
+prefix separately, then link body-only objects after the linker can preserve the
+shared Test262 realm. Its 2026-07-26 corpus inventory found 64 strict-neutral
+harness sources, versus 82,628 potential harness-bearing variants per lane.
 
 ## Measurement
 
@@ -132,14 +163,14 @@ re-introduces the host-import registrations #3418 exists to remove — and
 standalone is a required gate with its own floor guard, #1897/#2097). Both are
 oracle-affecting changes far out of proportion to a ≤13 % compile saving.
 
-Even setting that aside, the 13.2 % ceiling additionally assumes a `ts.Program` /
-`ts.TypeChecker` shared across two lowerings. `IncrementalLanguageService.analyze`
-deliberately builds a **fresh Program and checker every call** (#973): structure
-reuse "carries forward internal symbol tables and type caches that leak stale type
-info between unrelated test compilations, causing ~400 false compile errors in the
-fork worker pool". Sharing a checker across two lowerings of the _same_ source is
-less dangerous than that, but it is the same mechanism that already produced a
-400-test false-failure incident.
+At measurement time, the 13.2% ceiling additionally assumed a `ts.Program` /
+`ts.TypeChecker` shared across two lowerings while
+`IncrementalLanguageService.analyze` built a fresh Program and checker every
+call (#973). #700 / PR #3650 has since replaced that behavior with versioned,
+persistent language-service state. As documented in the follow-up above, this
+removes the stale implementation objection but not the source-identity blocker:
+the two target snapshots still differ before TypeScript sees them, so one
+checked tree cannot represent both lanes.
 
 ### The blocker for design 3: the lanes already run concurrently
 

--- a/plan/issues/backlog/backlog.md
+++ b/plan/issues/backlog/backlog.md
@@ -2,6 +2,16 @@
 
 Lightweight pointer index for unscheduled issues that need sprint candidacy. Authoritative status lives in each issue file's frontmatter.
 
+## 2026-07-26 — Test262 linked-harness implementation
+
+- [#3451](../3451-linked-harness-wasm-separate-compilation.md) — **in progress,
+  high priority, hard, XL.** Slice 1 now provides the deterministic
+  strict-neutral harness/body split, target-specific content keys, and a
+  maintained-corpus inventory: 64 harness sources / 128 target objects versus
+  82,628 potential harness-bearing variants per lane, with 82,660 authoritative
+  split-parity checks. Next is the two-target `assert.sameValue` linked smoke,
+  gated on WasmGC/shared-realm linker substrate.
+
 ## 2026-07-17 - /harvest-errors (baselines run 20260717-151504, 32,139 pass)
 
 Harvested both lanes (default JS-host + standalone) from

--- a/scripts/test262-linked-harness-inventory.ts
+++ b/scripts/test262-linked-harness-inventory.ts
@@ -1,0 +1,483 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #3451 — inventory the literal Test262 harness/object-linking boundary.
+ *
+ * This is intentionally read-only. It derives every harness prefix through the
+ * same assembler used by the authoritative runner, then reports the immutable
+ * object-key cardinality and the script-global ABI the future linker must
+ * preserve. Run:
+ *
+ *   pnpm run inventory:test262-linked-harness
+ *   pnpm run inventory:test262-linked-harness -- --json
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ts } from "../src/ts-api.js";
+import {
+  assembleLinkedHarness,
+  assembleOriginalHarness,
+  type HarnessSourcePart,
+  type LinkedHarnessAssembly,
+  type LinkedHarnessVariant,
+  type OriginalHarnessVariant,
+} from "../tests/test262-original-harness.js";
+import { findTestFiles, matchesPathFilter, parseMeta, shouldSkip, TEST_CATEGORIES } from "../tests/test262-runner.js";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const TEST262_ROOT = fileURLToPath(new URL("../test262/", import.meta.url));
+const KEY_VERSION = 1;
+const TARGET_LANES = ["js-host", "standalone"] as const;
+
+interface DeclarationSite {
+  name: string;
+  part: string;
+}
+
+export interface HarnessAbiInventory {
+  declaredSymbols: string[];
+  duplicateDeclarations: Record<string, string[]>;
+  topLevelEffectStatements: number;
+}
+
+export interface HarnessObjectInventory extends HarnessAbiInventory {
+  sourceKey: string;
+  /** Target-namespaced inventory keys. Production cache keys must additionally
+   * include the compiler/options/runtime ABI versions described in #3451. */
+  targetSourceKeys: Record<(typeof TARGET_LANES)[number], string>;
+  prefixSha256: string;
+  prefixBytes: number;
+  orderedIncludes: string[];
+  async: boolean;
+  tests: number;
+  potentialVariants: number;
+  consumedHarnessSymbols: string[];
+}
+
+export interface LinkedHarnessInventoryReport {
+  schemaVersion: 1;
+  corpusRoot: string;
+  discoveredTests: number;
+  eligibleTests: number;
+  skippedTests: number;
+  rawTests: number;
+  asyncTests: number;
+  fixtureGraphTests: number;
+  potentialVariants: number;
+  potentialHarnessCompilationsPerLane: number;
+  potentialHarnessSourceBytesPerLane: number;
+  uniqueHarnessSourceBytesPerLane: number;
+  assemblyParityChecks: number;
+  uniqueHarnessSources: number;
+  targetSpecificHarnessObjects: number;
+  harnessObjects: HarnessObjectInventory[];
+}
+
+interface MutableHarnessObject extends HarnessObjectInventory {
+  consumed: Set<string>;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function bindingNames(name: ts.BindingName, out: string[]): void {
+  if (ts.isIdentifier(name)) {
+    out.push(name.text);
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isBindingElement(element)) bindingNames(element.name, out);
+  }
+}
+
+function statementDeclarations(source: string, part: string): DeclarationSite[] {
+  const file = ts.createSourceFile(part, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const sites: DeclarationSite[] = [];
+  for (const statement of file.statements) {
+    if (
+      (ts.isFunctionDeclaration(statement) ||
+        ts.isClassDeclaration(statement) ||
+        ts.isEnumDeclaration(statement) ||
+        ts.isModuleDeclaration(statement)) &&
+      statement.name
+    ) {
+      sites.push({ name: statement.name.text, part });
+      continue;
+    }
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        const names: string[] = [];
+        bindingNames(declaration.name, names);
+        for (const name of names) sites.push({ name, part });
+      }
+    }
+  }
+  return sites;
+}
+
+function topLevelEffectCount(source: string): number {
+  const file = ts.createSourceFile("harness.js", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  let effects = 0;
+  for (const statement of file.statements) {
+    if (
+      ts.isFunctionDeclaration(statement) ||
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement)
+    ) {
+      continue;
+    }
+    if (ts.isVariableStatement(statement)) {
+      if (statement.declarationList.declarations.some((declaration) => declaration.initializer !== undefined))
+        effects++;
+      continue;
+    }
+    // Classes evaluate `extends`, computed names, and static fields/blocks.
+    // All other script statements likewise participate in ordered initialization.
+    effects++;
+  }
+  return effects;
+}
+
+export function inventoryHarnessAbi(parts: readonly HarnessSourcePart[], finalPrefix: string): HarnessAbiInventory {
+  const originalSites = parts.flatMap((part) => statementDeclarations(part.source, part.name));
+  const byName = new Map<string, string[]>();
+  for (const site of originalSites) {
+    const sites = byName.get(site.name) ?? [];
+    sites.push(site.part);
+    byName.set(site.name, sites);
+  }
+
+  const finalDeclarations = statementDeclarations(finalPrefix, "linked-harness.js")
+    .map((site) => site.name)
+    .sort();
+  const duplicateDeclarations = Object.fromEntries(
+    [...byName]
+      .filter(([, sites]) => sites.length > 1)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, sites]) => [name, sites]),
+  );
+
+  return {
+    declaredSymbols: [...new Set(finalDeclarations)],
+    duplicateDeclarations,
+    topLevelEffectStatements: topLevelEffectCount(finalPrefix),
+  };
+}
+
+function isDeclarationName(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  return (
+    ((ts.isVariableDeclaration(parent) ||
+      ts.isParameter(parent) ||
+      ts.isFunctionDeclaration(parent) ||
+      ts.isFunctionExpression(parent) ||
+      ts.isClassDeclaration(parent) ||
+      ts.isClassExpression(parent) ||
+      ts.isBindingElement(parent)) &&
+      parent.name === node) ||
+    (ts.isPropertyAccessExpression(parent) && parent.name === node) ||
+    (ts.isPropertyAssignment(parent) && parent.name === node && !ts.isComputedPropertyName(parent.name)) ||
+    (ts.isMethodDeclaration(parent) && parent.name === node && !ts.isComputedPropertyName(parent.name)) ||
+    (ts.isPropertyDeclaration(parent) && parent.name === node && !ts.isComputedPropertyName(parent.name)) ||
+    ts.isLabeledStatement(parent) ||
+    ts.isBreakStatement(parent) ||
+    ts.isContinueStatement(parent)
+  );
+}
+
+function isLexicalScope(node: ts.Node): boolean {
+  return ts.isSourceFile(node) || ts.isFunctionLike(node) || ts.isBlock(node) || ts.isCatchClause(node);
+}
+
+function addBinding(scope: Set<string> | undefined, name: ts.BindingName | undefined): void {
+  if (!scope || !name) return;
+  const found: string[] = [];
+  bindingNames(name, found);
+  for (const entry of found) scope.add(entry);
+}
+
+function bodyScopeDeclarations(file: ts.SourceFile): Map<ts.Node, Set<string>> {
+  const declarations = new Map<ts.Node, Set<string>>();
+  const scopes: ts.Node[] = [];
+
+  const current = () => declarations.get(scopes.at(-1)!);
+  const nearestFunctionOrSource = () => {
+    for (let i = scopes.length - 1; i >= 0; i--) {
+      const scope = scopes[i]!;
+      if (ts.isSourceFile(scope) || ts.isFunctionLike(scope)) return declarations.get(scope);
+    }
+    return undefined;
+  };
+
+  const visit = (node: ts.Node): void => {
+    // Declarations bind in the containing scope, before a function introduces
+    // its own parameter/local scope.
+    if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) addBinding(current(), node.name);
+
+    const opensScope = isLexicalScope(node);
+    if (opensScope) {
+      declarations.set(node, new Set<string>());
+      scopes.push(node);
+    }
+
+    if (ts.isFunctionExpression(node) || ts.isClassExpression(node)) addBinding(current(), node.name);
+    if (ts.isFunctionLike(node)) {
+      for (const parameter of node.parameters) addBinding(current(), parameter.name);
+    }
+    if (ts.isCatchClause(node)) addBinding(current(), node.variableDeclaration?.name);
+    if (ts.isVariableDeclaration(node)) {
+      const declarationList = node.parent;
+      const blockScoped =
+        ts.isVariableDeclarationList(declarationList) && (declarationList.flags & ts.NodeFlags.BlockScoped) !== 0;
+      addBinding(blockScoped ? current() : nearestFunctionOrSource(), node.name);
+    }
+
+    ts.forEachChild(node, visit);
+    if (opensScope) scopes.pop();
+  };
+  visit(file);
+  return declarations;
+}
+
+/**
+ * Return the harness-declared identifier roots consumed by a body. The scan is
+ * syntax-aware (property names and declaration sites are excluded) and removes
+ * names shadowed by body declarations. It deliberately does not infer dynamic
+ * string/globalThis lookups; those remain runtime ABI requirements.
+ */
+export function consumedHarnessSymbols(body: string, declaredSymbols: readonly string[]): string[] {
+  const candidates = new Set(declaredSymbols);
+  const file = ts.createSourceFile("body.js", body, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+  const declarations = bodyScopeDeclarations(file);
+  const scopes: ts.Node[] = [];
+  const consumed = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    const opensScope = isLexicalScope(node);
+    if (opensScope) scopes.push(node);
+    const shadowed = (name: string) => scopes.some((scope) => declarations.get(scope)?.has(name) === true);
+    if (ts.isIdentifier(node) && candidates.has(node.text) && !shadowed(node.text) && !isDeclarationName(node)) {
+      consumed.add(node.text);
+    }
+    ts.forEachChild(node, visit);
+    if (opensScope) scopes.pop();
+  };
+  visit(file);
+  return [...consumed].sort();
+}
+
+export function harnessObjectSourceKey(assembly: LinkedHarnessAssembly): string {
+  if (assembly.raw) return "raw";
+  const orderedIncludes = assembly.harnessParts
+    .map((part) => part.name)
+    .filter((name) => !name.startsWith("__js2wasm_") && name !== "assert.js" && name !== "sta.js");
+  return sha256(
+    JSON.stringify({
+      version: KEY_VERSION,
+      async: assembly.async,
+      orderedIncludes,
+      prefixSha256: sha256(assembly.harnessPrefix),
+    }),
+  );
+}
+
+function newHarnessObject(assembly: LinkedHarnessAssembly): MutableHarnessObject {
+  const sourceKey = harnessObjectSourceKey(assembly);
+  const abi = inventoryHarnessAbi(assembly.harnessParts, assembly.harnessPrefix);
+  const orderedIncludes = assembly.harnessParts
+    .map((part) => part.name)
+    .filter(
+      (name) =>
+        !name.startsWith("__js2wasm_") &&
+        name !== "assert.js" &&
+        name !== "sta.js" &&
+        !(assembly.async && name === "doneprintHandle.js"),
+    );
+  return {
+    sourceKey,
+    targetSourceKeys: {
+      "js-host": `js-host:${sourceKey}`,
+      standalone: `standalone:${sourceKey}`,
+    },
+    prefixSha256: sha256(assembly.harnessPrefix),
+    prefixBytes: Buffer.byteLength(assembly.harnessPrefix),
+    orderedIncludes,
+    async: assembly.async,
+    tests: 0,
+    potentialVariants: 0,
+    consumedHarnessSymbols: [],
+    consumed: new Set<string>(),
+    ...abi,
+  };
+}
+
+function verifyVariantSplit(
+  body: string,
+  linkedPrefix: string,
+  linked: LinkedHarnessVariant,
+  original: OriginalHarnessVariant,
+  label: string,
+): void {
+  const directive = original.strict ? '"use strict";\n' : "";
+  const originalPrefix = original.source.slice(0, original.source.length - body.length);
+  const strictNeutralPrefix = original.strict ? originalPrefix.slice(directive.length) : originalPrefix;
+  if (strictNeutralPrefix !== linkedPrefix) {
+    throw new Error(`${label}: linked harness prefix differs from the authoritative assembly`);
+  }
+  if (linked.bodySource !== directive + body) {
+    throw new Error(`${label}: linked body unit differs from the authoritative body/strictness`);
+  }
+  if (linked.bodyLineOffset !== (original.strict ? 1 : 0)) {
+    throw new Error(`${label}: linked body line offset is inconsistent`);
+  }
+}
+
+function verifyAssemblySplit(
+  body: string,
+  meta: ReturnType<typeof parseMeta>,
+  linked: LinkedHarnessAssembly,
+  label: string,
+): number {
+  const original = assembleOriginalHarness(body, meta);
+  verifyVariantSplit(body, linked.harnessPrefix, linked.primary, original.primary, `${label} [primary]`);
+  if ((linked.strictRerun === undefined) !== (original.strictRerun === undefined)) {
+    throw new Error(`${label}: linked/original strict-rerun gating differs`);
+  }
+  if (linked.strictRerun && original.strictRerun) {
+    verifyVariantSplit(body, linked.harnessPrefix, linked.strictRerun, original.strictRerun, `${label} [strict]`);
+  }
+  return linked.strictRerun ? 2 : 1;
+}
+
+export function buildLinkedHarnessInventory(): LinkedHarnessInventoryReport {
+  const includeProposals = process.env.TEST262_INCLUDE_PROPOSALS === "1";
+  const seen = new Set<string>();
+  const objects = new Map<string, MutableHarnessObject>();
+  let discoveredTests = 0;
+  let eligibleTests = 0;
+  let skippedTests = 0;
+  let rawTests = 0;
+  let asyncTests = 0;
+  let fixtureGraphTests = 0;
+  let potentialVariants = 0;
+  let assemblyParityChecks = 0;
+
+  for (const category of TEST_CATEGORIES) {
+    for (const filePath of findTestFiles(category)) {
+      const relPath = relative(TEST262_ROOT, filePath);
+      if (seen.has(relPath)) continue;
+      seen.add(relPath);
+      discoveredTests++;
+      if (!matchesPathFilter(relPath)) continue;
+      if (!includeProposals && (relPath.startsWith("test/staging/") || relPath.startsWith("staging/"))) continue;
+
+      const body = readFileSync(filePath, "utf8");
+      const meta = parseMeta(body);
+      if (!meta.negative) {
+        const filter = shouldSkip(body, meta, filePath);
+        if (filter.skip) {
+          skippedTests++;
+          continue;
+        }
+      }
+
+      eligibleTests++;
+      const assembly = assembleLinkedHarness(body, meta);
+      const variants = assembly.strictRerun ? 2 : 1;
+      assemblyParityChecks += verifyAssemblySplit(body, meta, assembly, relPath);
+      potentialVariants += variants;
+      if (assembly.async) asyncTests++;
+      if (/(?:from\s*|import\s*\(|require\s*\()["'][^"']*_FIXTURE\.js["']/.test(body)) fixtureGraphTests++;
+      if (assembly.raw) {
+        rawTests++;
+        continue;
+      }
+
+      const key = harnessObjectSourceKey(assembly);
+      let object = objects.get(key);
+      if (!object) {
+        object = newHarnessObject(assembly);
+        objects.set(key, object);
+      }
+      object.tests++;
+      object.potentialVariants += variants;
+      for (const name of consumedHarnessSymbols(body, object.declaredSymbols)) object.consumed.add(name);
+    }
+  }
+
+  const harnessObjects = [...objects.values()]
+    .map(({ consumed, ...object }) => ({
+      ...object,
+      consumedHarnessSymbols: [...consumed].sort(),
+    }))
+    .sort((a, b) => b.tests - a.tests || a.sourceKey.localeCompare(b.sourceKey));
+  const potentialHarnessCompilationsPerLane = harnessObjects.reduce((sum, object) => sum + object.potentialVariants, 0);
+  const potentialHarnessSourceBytesPerLane = harnessObjects.reduce(
+    (sum, object) => sum + object.prefixBytes * object.potentialVariants,
+    0,
+  );
+  const uniqueHarnessSourceBytesPerLane = harnessObjects.reduce((sum, object) => sum + object.prefixBytes, 0);
+
+  return {
+    schemaVersion: 1,
+    corpusRoot: relative(ROOT, TEST262_ROOT) || "test262",
+    discoveredTests,
+    eligibleTests,
+    skippedTests,
+    rawTests,
+    asyncTests,
+    fixtureGraphTests,
+    potentialVariants,
+    potentialHarnessCompilationsPerLane,
+    potentialHarnessSourceBytesPerLane,
+    uniqueHarnessSourceBytesPerLane,
+    assemblyParityChecks,
+    uniqueHarnessSources: harnessObjects.length,
+    targetSpecificHarnessObjects: harnessObjects.length * TARGET_LANES.length,
+    harnessObjects,
+  };
+}
+
+function printSummary(report: LinkedHarnessInventoryReport): void {
+  const duplicateKeys = report.harnessObjects.filter(
+    (object) => Object.keys(object.duplicateDeclarations).length > 0,
+  ).length;
+  const consumed = new Set(report.harnessObjects.flatMap((object) => object.consumedHarnessSymbols));
+  const duplicates = new Set(report.harnessObjects.flatMap((object) => Object.keys(object.duplicateDeclarations)));
+  console.log("#3451 Test262 linked-harness inventory");
+  console.log(`discovered tests: ${report.discoveredTests}`);
+  console.log(`eligible tests: ${report.eligibleTests} (${report.skippedTests} filtered)`);
+  console.log(`potential body variants: ${report.potentialVariants}`);
+  console.log(`raw bypass tests: ${report.rawTests}`);
+  console.log(`async tests: ${report.asyncTests}`);
+  console.log(`fixture-graph tests: ${report.fixtureGraphTests}`);
+  console.log(`authoritative assembly split checks: ${report.assemblyParityChecks}`);
+  console.log(`unique strict-neutral harness sources: ${report.uniqueHarnessSources}`);
+  console.log(`target-specific harness objects (two lanes): ${report.targetSpecificHarnessObjects}`);
+  console.log(
+    `potential harness compiles per lane: ${report.potentialHarnessCompilationsPerLane} -> ` +
+      `${report.uniqueHarnessSources}`,
+  );
+  console.log(
+    `potential harness source bytes per lane: ${report.potentialHarnessSourceBytesPerLane} -> ` +
+      `${report.uniqueHarnessSourceBytesPerLane}`,
+  );
+  console.log(`keys with duplicate top-level declarations: ${duplicateKeys}`);
+  console.log(`duplicate declaration names: ${[...duplicates].sort().join(", ") || "(none)"}`);
+  console.log(`distinct consumed harness symbols: ${consumed.size}`);
+  console.log(`consumed harness symbols: ${[...consumed].sort().join(", ")}`);
+  console.log("largest harness keys:");
+  for (const object of report.harnessObjects.slice(0, 12)) {
+    console.log(
+      `  ${object.tests} tests / ${object.potentialVariants} variants / ${object.prefixBytes} bytes / ` +
+        `${object.orderedIncludes.join(",") || "(base harness)"}`,
+    );
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const report = buildLinkedHarnessInventory();
+  if (process.argv.includes("--json")) console.log(JSON.stringify(report, null, 2));
+  else printSummary(report);
+}

--- a/tests/issue-3451-linked-harness-inventory.test.ts
+++ b/tests/issue-3451-linked-harness-inventory.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import {
+  consumedHarnessSymbols,
+  harnessObjectSourceKey,
+  inventoryHarnessAbi,
+} from "../scripts/test262-linked-harness-inventory.js";
+import { assembleLinkedHarness, type HarnessSourcePart } from "./test262-original-harness.js";
+
+describe("#3451 linked-harness split and key", () => {
+  it("keeps the harness strict-neutral and puts strictness first in the body unit", () => {
+    const assembly = assembleLinkedHarness("assert.sameValue(1, 1);\n", { flags: [] });
+
+    expect(assembly.harnessPrefix.startsWith('"use strict"')).toBe(false);
+    expect(assembly.primary.bodySource).toBe("assert.sameValue(1, 1);\n");
+    expect(assembly.primary.bodyLineOffset).toBe(0);
+    expect(assembly.strictRerun?.bodySource).toBe('"use strict";\nassert.sameValue(1, 1);\n');
+    expect(assembly.strictRerun?.bodyLineOffset).toBe(1);
+  });
+
+  it("keys only the immutable harness input, not body text or strictness", () => {
+    const first = assembleLinkedHarness("assert.sameValue(1, 1);\n", { flags: [] });
+    const second = assembleLinkedHarness("assert.sameValue(2, 2);\n", { flags: ["onlyStrict"] });
+
+    expect(harnessObjectSourceKey(first)).toBe(harnessObjectSourceKey(second));
+  });
+
+  it("distinguishes ordered include sets", () => {
+    const a = assembleLinkedHarness("compareArray([], []);\n", {
+      includes: ["compareArray.js", "propertyHelper.js"],
+    });
+    const b = assembleLinkedHarness("compareArray([], []);\n", {
+      includes: ["propertyHelper.js", "compareArray.js"],
+    });
+
+    expect(harnessObjectSourceKey(a)).not.toBe(harnessObjectSourceKey(b));
+  });
+
+  it("makes raw tests bypass harness-object compilation", () => {
+    const assembly = assembleLinkedHarness("throw 0;\n", { flags: ["raw"] });
+
+    expect(assembly.harnessPrefix).toBe("");
+    expect(assembly.harnessParts).toEqual([]);
+    expect(assembly.strictRerun).toBeUndefined();
+    expect(harnessObjectSourceKey(assembly)).toBe("raw");
+  });
+});
+
+describe("#3451 harness ABI inventory", () => {
+  const parts: HarnessSourcePart[] = [
+    {
+      name: "first.js",
+      source: "function helper() {}\nvar assert = function () {};\nassert.sameValue = function () {};\n",
+    },
+    {
+      name: "second.js",
+      source: "function helper() {}\nclass Test262Error extends Error {}\nvar initialized = helper();\n",
+    },
+  ];
+  const finalPrefix =
+    "function helper$dup0() {}\n" +
+    "var assert = function () {};\n" +
+    "assert.sameValue = function () {};\n" +
+    "function helper() {}\n" +
+    "class Test262Error extends Error {}\n" +
+    "var initialized = helper();\n";
+
+  it("records final declarations, duplicate last-wins inputs, and ordered initialization", () => {
+    const inventory = inventoryHarnessAbi(parts, finalPrefix);
+
+    expect(inventory.declaredSymbols).toEqual(["Test262Error", "assert", "helper", "helper$dup0", "initialized"]);
+    expect(inventory.duplicateDeclarations).toEqual({
+      helper: ["first.js", "second.js"],
+    });
+    expect(inventory.topLevelEffectStatements).toBeGreaterThanOrEqual(4);
+  });
+
+  it("finds body-consumed harness roots but excludes properties and local shadows", () => {
+    expect(
+      consumedHarnessSymbols(
+        "assert.sameValue(1, 1); new Test262Error('x'); obj.helper; function f(assert) { assert(); }",
+        ["assert", "sameValue", "Test262Error", "helper"],
+      ),
+    ).toEqual(["Test262Error", "assert"]);
+  });
+});

--- a/tests/test262-original-harness.ts
+++ b/tests/test262-original-harness.ts
@@ -52,6 +52,47 @@ export interface NativeHarnessAssembly {
   raw: boolean;
 }
 
+/**
+ * One literal source file contributing to the Test262 harness prefix. Keeping
+ * the ordered parts visible lets the linked-harness inventory derive stable
+ * content keys and attribute duplicate declarations without reimplementing the
+ * authoritative assembly order.
+ */
+export interface HarnessSourcePart {
+  name: string;
+  source: string;
+}
+
+/**
+ * (#3451) One body-only compilation unit for the future static-link path.
+ * `bodySource` deliberately contains no host binding shim: unresolved harness
+ * names must eventually become linker symbols, not `globalThis` host accesses.
+ */
+export interface LinkedHarnessVariant {
+  /** Strict directive (when needed) followed by the untouched test body. */
+  bodySource: string;
+  /** Untouched upstream test body. */
+  body: string;
+  /** Lines prepended to `body` inside `bodySource`. */
+  bodyLineOffset: number;
+  strict: boolean;
+}
+
+/**
+ * (#3451) Deterministic split used by the inventory and, after the linker grows
+ * the required shared-realm substrate, by the linked Test262 runner.
+ */
+export interface LinkedHarnessAssembly {
+  /** Strict-neutral, de-duplicated literal harness source compiled once. */
+  harnessPrefix: string;
+  /** Ordered, pre-dedupe inputs used to build `harnessPrefix`. */
+  harnessParts: HarnessSourcePart[];
+  primary: LinkedHarnessVariant;
+  strictRerun?: LinkedHarnessVariant;
+  async: boolean;
+  raw: boolean;
+}
+
 const PROJECT_ROOT = join(import.meta.dirname ?? ".", "..");
 const HARNESS_ROOT = join(PROJECT_ROOT, "test262", "harness");
 const RUNTIME_PATH = join(PROJECT_ROOT, "scripts", "test262-fyi-runtime.js");
@@ -126,14 +167,22 @@ function dedupeTopLevelFunctionDeclarations(prefix: string): string {
  * byte-identical to deduping includes alone since the directive line contains no
  * function declaration).
  */
+export function harnessSourceParts(meta: HarnessMeta, async: boolean): HarnessSourcePart[] {
+  const parts: HarnessSourcePart[] = [];
+  if (async) parts.push({ name: "doneprintHandle.js", source: harnessSource("doneprintHandle.js") });
+  for (const include of meta.includes ?? []) {
+    parts.push({ name: include, source: harnessSource(include) });
+  }
+  parts.push({ name: "__js2wasm_test262_runtime__.js", source: cachedSource(RUNTIME_PATH) });
+  parts.push({ name: "assert.js", source: harnessSource("assert.js") });
+  parts.push({ name: "sta.js", source: harnessSource("sta.js") });
+  return parts;
+}
+
 function assemblePrefixIncludes(meta: HarnessMeta, async: boolean): string {
-  let prefix = "";
-  if (async) prefix += harnessSource("doneprintHandle.js");
-  for (const include of meta.includes ?? []) prefix += harnessSource(include);
-  prefix += cachedSource(RUNTIME_PATH);
-  prefix += harnessSource("assert.js");
-  prefix += harnessSource("sta.js");
-  return prefix;
+  return harnessSourceParts(meta, async)
+    .map((part) => part.source)
+    .join("");
 }
 
 function assembleVariant(
@@ -310,6 +359,43 @@ export function assembleNativeHarness(source: string, meta: HarnessMeta): Native
   return {
     primary: assembleNativeVariant(source, meta, onlyStrict, raw, async),
     ...(strictRerun ? { strictRerun: assembleNativeVariant(source, meta, true, raw, async) } : {}),
+    async,
+    raw,
+  };
+}
+
+function assembleLinkedVariant(source: string, strict: boolean): LinkedHarnessVariant {
+  const directive = strict ? '"use strict";\n' : "";
+  return {
+    bodySource: directive + source,
+    body: source,
+    bodyLineOffset: lineCount(directive),
+    strict,
+  };
+}
+
+/**
+ * (#3451) Split the authoritative Test262 assembly at the future static-link
+ * boundary while preserving its variant rules exactly.
+ *
+ * The harness object is strict-neutral: strictness belongs to the beginning of
+ * the body compilation unit, so primary and strict-rerun variants reuse the
+ * same immutable harness object. Raw tests have no harness and bypass linking.
+ */
+export function assembleLinkedHarness(source: string, meta: HarnessMeta): LinkedHarnessAssembly {
+  const flags = new Set(meta.flags ?? []);
+  const raw = flags.has("raw");
+  const async = flags.has("async");
+  const onlyStrict = flags.has("onlyStrict");
+  const strictRerun = !raw && !flags.has("module") && !onlyStrict && !flags.has("noStrict");
+  const harnessParts = raw ? [] : harnessSourceParts(meta, async);
+  const harnessPrefix = raw ? "" : dedupeTopLevelFunctionDeclarations(harnessParts.map((part) => part.source).join(""));
+
+  return {
+    harnessPrefix,
+    harnessParts,
+    primary: assembleLinkedVariant(source, onlyStrict),
+    ...(strictRerun ? { strictRerun: assembleLinkedVariant(source, true) } : {}),
     async,
     raw,
   };


### PR DESCRIPTION
## Summary

- expose the authoritative Test262 harness as ordered source parts plus a strict-neutral harness/body split
- add a maintained-corpus inventory command for reusable target-specific harness object identities and the required script-global ABI
- expand plan issue #3451 into the two-lane linked-harness delivery plan and update #3625 with the persistent language-service measurements

## Why

Cross-target frontend sharing has a measured maximum saving of 0.91% because the host and standalone lanes type-check different processed source. The repeated literal harness prefix is the larger target: it accounts for 72.3% of measured host compile cost.

This first #3451 slice establishes the correctness boundary and reuse cardinality before the linker can execute it. It does not change the authoritative Test262 execution path.

The maintained corpus contains:

- 43,287 eligible tests and 82,660 potential body variants
- 64 strict-neutral harness sources, or 128 target-specific planned objects
- 82,628 potential harness-bearing variants per lane
- 82,660/82,660 authoritative source-split parity checks

The next linked smoke remains gated on shared-realm linker support for WasmGC rec groups, globals, closures/tables/tags, ordered initialization, data segments, and runtime-helper deduplication.

## Validation

- `pnpm exec vitest run tests/issue-3451-linked-harness-inventory.test.ts tests/issue-3461-native-harness.test.ts tests/test262-harness-truth-table.test.ts --maxWorkers=1` — 73 passed
- `pnpm exec tsc --noEmit --pretty false`
- focused Biome lint and Prettier formatting
- issue integrity, done-status integrity, and branch issue-ID collision checks
- host Test262 shard 1/57 A/B, pool 4: all 836 normalized `file + strict + status` rows identical; 526 pass, 284 fail, 26 compile errors, and 17 poison retries in both runs
- paired timing control/candidate: 189.81s/194.37s wall and 598,151ms/614,837ms summed compile time; no speedup is claimed because this slice does not enable linked execution
- repository pre-push typecheck, lint, formatting, and issue-integrity hooks
