### PR TITLE
docs(#3669,#3670): characterise property-slot monomorphism; file local/CI lane divergence

### DIFF
--- a/plan/issues/3669-property-slot-monomorphism.md
+++ b/plan/issues/3669-property-slot-monomorphism.md
@@ -1,0 +1,147 @@
+---
+id: 3669
+title: Property slot monomorphism — a slot seeded with a number/boolean corrupts on some later writes
+status: ready
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+area: codegen
+language_feature: value-representation
+goal: value-rep-substrate
+related: [2773, 2760, 2949, 3667, 3668]
+assignee: ttraenkler/opus-loop-g
+created: 2026-07-26
+---
+
+# #3669 — property slot monomorphism
+
+## Problem
+
+A property slot seeded with a **number** or **boolean** corrupts on _some_ later
+writes of a different value kind. The read-back is a value that is **not equal
+to itself** — the sNaN-like type-default sentinel #2760 already names.
+
+```js
+var o = {};
+o.p = 1;
+o.p = "unlikelyValue";
+o.p === "unlikelyValue"; // false
+typeof o.p; // "string"   <-- tag says string
+o.p !== o.p; // true       <-- payload is sNaN
+```
+
+The tag and the payload disagree: `typeof` reports `"string"` while the stored
+value behaves as sNaN. So this is not "the write was rejected" — the write
+partially landed.
+
+## Why it matters (reach bounds, NOT a flip count)
+
+`propertyHelper.js:isWritable` decides writability by assigning the **string**
+`"unlikelyValue"` over the property's current value and reading it back
+(`isSameValue(obj[name], newValue)`). On a numeric property that read-back
+fails, so `isWritable` returns `false` and `verifyProperty` reports
+_"obj['p'] descriptor should be writable"_ on a perfectly ordinary property:
+
+```js
+var o = {};
+o.p = 1;
+verifyProperty(o, "p", { value: 1, writable: true, enumerable: true, configurable: true });
+//   -> Test262Error: obj['p'] descriptor should be writable
+```
+
+**Bounds only:** 5,067 corpus tests call `verifyProperty`, and the `isWritable`
+path runs in essentially every call that asserts `writable`. That is a ceiling
+on reachability, **not** a predicted flip count — measure with
+`scripts/harness-flip-probe.ts` (#3668) before quoting any number. The
+circulating "~1,038" figure is unrelated and must not be reused.
+
+## Characterisation (measured)
+
+Through the real assembled harness on `upstream/main`, positive control on every
+run, **reading verified deterministic** (byte-identical on repeat).
+Reproducer: `scripts/fixtures/issue-3669-monomorphism/transitions.js`.
+
+### Transition matrix — seed kind → overwrite kind
+
+| seed \ write | number     | string     | boolean   | null       | undefined | object     |
+| ------------ | ---------- | ---------- | --------- | ---------- | --------- | ---------- |
+| **number**   | ok (ctrl)  | **BROKEN** | ok        | **BROKEN** | ok        | **BROKEN** |
+| **string**   | ok         | ok (ctrl)  | ok        | –          | –         | ok         |
+| **boolean**  | **BROKEN** | **BROKEN** | ok (ctrl) | –          | –         | –          |
+| **object**   | ok         | ok         | –         | –          | –         | –          |
+
+**5 of 12 cross-kind transitions are broken; 7 work.** All three same-type
+controls pass.
+
+**This is the key structural finding: the failure is selective, not uniform.**
+It is _not_ one missing widening primitive — if slots simply could not widen,
+`num→bool`, `num→undefined`, `str→*` and `obj→*` would fail too, and they do
+not. Nor is it "numeric slots are frozen": `num→bool` succeeds while
+`bool→num` fails, which is asymmetric. So the repair is a set of specific
+transition lowerings in the value-rep substrate, not a one-line fix.
+
+### Scope
+
+- **Per-SLOT, not per-shape.** A sibling object built identically but only ever
+  holding a string is unaffected (`shape-sibling:ok`). So this is the individual
+  property slot's state, not a hidden class / shape transition.
+- **Object-literal initialiser behaves exactly like assignment** —
+  `{p: 1}` then `.p = "s"` breaks identically, while `{p: "a"}` then `.p = "b"`
+  is fine. So the seeding happens at first _value_, wherever it comes from.
+- **The slot does not recover.** A third, same-kind-as-the-second write
+  (`o.p = 1; o.p = "s"; o.p = "t"`) still reads back wrong.
+- The corrupted value is **self-unequal**, matching the "type-default sentinel
+  (sNaN / `false` / `null`)" that #2760 describes for OOB array element reads.
+
+## Adjacency — inherit, don't reinvent
+
+This belongs to the **`value-rep-substrate` goal (#2773)**, not to
+builtin dispatch:
+
+- **#2760** (plain-array OOB → type-default sentinel) is the closest sibling:
+  same class of defect (a slot's static Wasm type yielding a sentinel instead of
+  the JS value), same sNaN signature. #2773 explicitly frames it as _"the
+  element-read result needs an externref-or-undefined representation that
+  ripples to every f64 consumer — a value-rep-shape decision, not a helper-flag
+  flip."_ The same sentence applies here with "element-read" replaced by
+  "property-slot read".
+- **#2773** is the umbrella epic and asks the governing question directly:
+  _what is the in-flight representation of a value as it crosses a
+  dispatch/host/array boundary?_
+- **#2949** would subsume this at the IR level (`{kind:"dynamic", tag?: JsTag}`),
+  but is XL and not a prerequisite for a targeted repair.
+
+**Lane note:** `value-rep-substrate` is Lane B (fable/porffor) under
+`plan/method/lane-partition.md`. This issue was characterised in Lane A at the
+tech lead's direction; the _implementation_ should be routed per the partition.
+
+## What this is NOT
+
+- Not the detached-builtin defect (#3667). That is a real but narrow bug —
+  exactly one cell (`write-detached + read-direct`) — and its author measured
+  their candidate fix as a **no-op**, then parked it. It cannot explain this:
+  the reproducer above uses plain assignment, no `defineProperty`, no detached
+  reference, no descriptor sidecar.
+- Not explained by descriptor-sidecar enrichment. The prediction that failing
+  `propertyHelper` tests would be enriched for `defineProperty`-defined
+  properties was **measured and falsified** (#3668): 671 of 893 such tests pass.
+
+## Suggested next step
+
+1. Find where a property slot's Wasm type is chosen from its first assigned
+   value, and what the write path does when a later value doesn't fit.
+2. The asymmetry (`num→bool` ok, `bool→num` broken) is the sharpest lead — two
+   adjacent transitions with opposite outcomes should localise the gap quickly.
+3. Measure the fix with `scripts/harness-flip-probe.ts` (#3668), local-vs-local
+   A/B. **Report zero flips as a result if that is what it measures.**
+
+## Probe hazards (cost real time here)
+
+Two probe shapes fail to compile for reasons unrelated to this defect. A
+CompileError is not evidence:
+
+- Wrapping each arm in `function () { …; return o.p === x; }` →
+  `call[0] expected type externref, found if of type f64`. Arms must be inline.
+- `if (d.writable === true)` on a descriptor field, and `"…" + err.message` in a
+  `catch` → `if[0] expected type i32, found global.get of type externref`.

--- a/plan/issues/3669-property-slot-monomorphism.md
+++ b/plan/issues/3669-property-slot-monomorphism.md
@@ -64,22 +64,44 @@ Reproducer: `scripts/fixtures/issue-3669-monomorphism/transitions.js`.
 
 ### Transition matrix — seed kind → overwrite kind
 
+Harness lane (authoritative — this is the lane the corpus is scored on):
+
 | seed \ write | number     | string     | boolean   | null       | undefined | object     |
 | ------------ | ---------- | ---------- | --------- | ---------- | --------- | ---------- |
 | **number**   | ok (ctrl)  | **BROKEN** | ok        | **BROKEN** | ok        | **BROKEN** |
-| **string**   | ok         | ok (ctrl)  | ok        | –          | –         | ok         |
-| **boolean**  | **BROKEN** | **BROKEN** | ok (ctrl) | –          | –         | –          |
-| **object**   | ok         | ok         | –         | –          | –         | –          |
+| **string**   | ok         | ok (ctrl)  | ok        | ok         | –         | ok         |
+| **boolean**  | **BROKEN** | **BROKEN** | ok (ctrl) | **BROKEN** | ok        | **BROKEN** |
+| **object**   | ok         | ok         | –         | ok         | –         | –          |
 
-**5 of 12 cross-kind transitions are broken; 7 work.** All three same-type
-controls pass.
+**7 broken of 15 cross-kind cells measured.** All same-type controls pass.
 
-**This is the key structural finding: the failure is selective, not uniform.**
-It is _not_ one missing widening primitive — if slots simply could not widen,
-`num→bool`, `num→undefined`, `str→*` and `obj→*` would fail too, and they do
-not. Nor is it "numeric slots are frozen": `num→bool` succeeds while
-`bool→num` fails, which is asymmetric. So the repair is a set of specific
-transition lowerings in the value-rep substrate, not a one-line fix.
+**The pattern is not arbitrary:** a slot seeded with an **unboxed primitive**
+(number or boolean) corrupts when written with a **reference-kind** value
+(string / null / object); a slot seeded with a **reference** (string / object)
+never corrupts. `undefined` writes always work. The boolean seed is strictly
+worse than the number seed — it additionally breaks on `number`.
+
+**It is still selective, not uniform** — `num→bool`, `num→undefined`,
+`bool→undefined`, `str→*` and `obj→*` all work — so this is not one missing
+widening primitive. The sharpest single lead is the asymmetry **`num→bool`
+works while `bool→num` fails**: two adjacent transitions with opposite outcomes.
+
+### The test shape matters — bare `compile()` misses two cells
+
+A plain `compile()` (properly awaited, using `result.importObject`) reproduces
+**most** of the matrix but **disagrees with the harness lane on two cells**:
+
+| cell             | harness lane | bare `compile()` |
+| ---------------- | ------------ | ---------------- |
+| `bool→number`    | **BROKEN**   | ok               |
+| `bool→undefined` | ok           | **BROKEN**       |
+
+So a fast unit test written against bare `compile()` would **silently pass**
+`bool→num` — which is one half of the asymmetry above, i.e. the single most
+diagnostic cell. **Red tests for this issue must run through the assembled
+harness path**, not a bare compile. (This is the third instance this session of
+bare `compile()` disagreeing with the harness on the same broad surface; see
+#3670.)
 
 ### Scope
 
@@ -112,9 +134,15 @@ builtin dispatch:
 - **#2949** would subsume this at the IR level (`{kind:"dynamic", tag?: JsTag}`),
   but is XL and not a prerequisite for a targeted repair.
 
-**Lane note:** `value-rep-substrate` is Lane B (fable/porffor) under
-`plan/method/lane-partition.md`. This issue was characterised in Lane A at the
-tech lead's direction; the _implementation_ should be routed per the partition.
+**Lane note (ruled):** `value-rep-substrate` is nominally Lane B
+(fable/porffor) under `plan/method/lane-partition.md`. The tech lead has ruled
+that **implementation proceeds in Lane A**: no Lane B agent is active on this,
+so there is nothing to duplicate, and the partition exists to prevent collision
+rather than to route by topic. The defect is also **selective rather than a
+substrate rewrite**, which is not the case the partition was written for.
+Lane B should claim it if they turn out to be working adjacent — and if the fix
+reaches deeper than the selective picture suggests, that is the point to stop
+and re-route rather than push into the substrate.
 
 ## What this is NOT
 

--- a/plan/issues/3670-local-vs-ci-lane-divergence.md
+++ b/plan/issues/3670-local-vs-ci-lane-divergence.md
@@ -1,0 +1,64 @@
+---
+id: 3670
+title: Baseline-`pass` tests failing on the local harness lane — local/CI divergence sighting
+status: ready
+sprint: current
+priority: medium
+horizon: s
+area: testing
+related: [3668, 3669]
+created: 2026-07-26
+---
+
+# #3670 — baseline-`pass` tests fail on the local harness lane
+
+## Observation
+
+Running the honest harness lane locally (`runTest262File` →
+`assembleOriginalHarness`) on current `upstream/main`, several tests recorded as
+`pass` in the committed CI baseline jsonl fail:
+
+| test                                                | baseline | local                                                       |
+| --------------------------------------------------- | -------- | ----------------------------------------------------------- |
+| `built-ins/Object/defineProperty/15.2.3.6-4-202.js` | pass     | fail — `obj['0'] descriptor should not be enumerable`       |
+| `language/expressions/function/name.js`             | pass     | fail — `obj['name'] descriptor value should be ; …`         |
+| `built-ins/GeneratorPrototype/return/name.js`       | pass     | fail — `strict rerun: obj should have an own property name` |
+
+All three failures are `propertyHelper`-mediated, which is suggestive given
+#3669, but the divergence itself is the thing to explain: these are recorded as
+passing in the baseline that CI gates on.
+
+Not investigated further — filed so it isn't lost. Sample was small and
+opportunistic, so the true count is unknown.
+
+## Ruled out
+
+**Not PR #3653.** That PR is docs-only (adds three issue files, no `src/`, no
+`scripts/`, no tests), confirmed by its author. The initial suspicion was wrong.
+
+Remaining candidates: drift from another commit landed after the baseline was
+promoted (baseline promoted 2026-07-26 00:48; these were observed against a
+09:35 tip), or a genuine behavioural difference between the local in-process
+lane and the sharded CI worker lane.
+
+## Why it matters, and why it is not urgent
+
+It does **not** invalidate `scripts/harness-flip-probe.ts` (#3668). That tool is
+local-vs-local A/B by construction and refuses the committed baseline as an arm,
+so a stable local-only failure costs **sensitivity** (a test stuck at fail on
+both arms cannot show a flip) but can never manufacture a **false** flip.
+
+It matters because it is the second independent sighting of local/CI lane
+divergence in one session, and because the baseline is what the PR regression
+gate compares against. If the local lane is right and the baseline is stale, the
+gate is scoring against a stale reference; if the baseline is right, the local
+lane misreports — and the local lane is what agents use to triage.
+
+## Suggested next step
+
+1. Re-run the three tests against the exact SHA the baseline was promoted from,
+   to separate "drift since promotion" from "lane difference".
+2. If it is a lane difference, compare the in-process runner's sandbox/harness
+   assembly against `scripts/test262-worker.mjs` for the `propertyHelper` path.
+3. Widen the sample before quoting any count — three tests found opportunistically
+   is not a measurement of the population.

--- a/scripts/fixtures/issue-3669-monomorphism/bool-row.js
+++ b/scripts/fixtures/issue-3669-monomorphism/bool-row.js
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: complete boolean-seed row + disputed bool>num, harness lane (#3669)
+esid: pending
+flags: [noStrict]
+---*/
+var report = "";
+function note(t) {
+  report = report + t + " ";
+}
+if (1 === 2) {
+  note("CTL0:BAD");
+} else {
+  note("CTL0:ok");
+}
+
+var b1 = {};
+b1.p = true;
+b1.p = null;
+if (b1.p === null) {
+  note("bool>null:ok");
+} else {
+  note("bool>null:BROKEN");
+}
+
+var ob = {};
+var b2 = {};
+b2.p = true;
+b2.p = ob;
+if (b2.p === ob) {
+  note("bool>obj:ok");
+} else {
+  note("bool>obj:BROKEN");
+}
+
+var b3 = {};
+b3.p = true;
+b3.p = undefined;
+if (b3.p === undefined) {
+  note("bool>undef:ok");
+} else {
+  note("bool>undef:BROKEN");
+}
+
+var b4 = {};
+b4.p = true;
+b4.p = 3;
+if (b4.p === 3) {
+  note("bool>num:ok");
+} else {
+  note("bool>num:BROKEN");
+}
+
+// num-seed comparison arms, same run
+var n1 = {};
+n1.p = 1;
+n1.p = undefined;
+if (n1.p === undefined) {
+  note("num>undef:ok");
+} else {
+  note("num>undef:BROKEN");
+}
+
+var n2 = {};
+n2.p = 1;
+n2.p = true;
+if (n2.p === true) {
+  note("num>bool:ok");
+} else {
+  note("num>bool:BROKEN");
+}
+
+// reference-seed controls
+var oc = {};
+var b5 = {};
+b5.p = "s";
+b5.p = null;
+if (b5.p === null) {
+  note("C.str>null:ok");
+} else {
+  note("C.str>null:BROKEN");
+}
+var b6 = {};
+b6.p = oc;
+b6.p = null;
+if (b6.p === null) {
+  note("C.obj>null:ok");
+} else {
+  note("C.obj>null:BROKEN");
+}
+
+throw new Test262Error("P7 " + report);

--- a/scripts/fixtures/issue-3669-monomorphism/transitions.js
+++ b/scripts/fixtures/issue-3669-monomorphism/transitions.js
@@ -1,0 +1,213 @@
+// Copyright (C) 2026 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: characterise property-slot monomorphism — scope and which transitions (#3669)
+esid: pending
+flags: [noStrict]
+---*/
+// NOTE ON SHAPE: arms are written INLINE. Wrapping each arm in a
+// `function(){...return o.p === x}` trips an unrelated codegen bug
+// (`call[0] expected type externref, found if of type f64`), so the helper form
+// cannot be used here — a CompileError would masquerade as a finding.
+
+var report = "";
+function note(t) {
+  report = report + t + " ";
+}
+if (1 === 2) {
+  note("CTL0:BAD");
+} else {
+  note("CTL0:ok");
+}
+
+// ---------- same-type controls: these MUST pass ----------
+var ca = {};
+ca.p = 1;
+ca.p = 2;
+if (ca.p === 2) {
+  note("C.num>num:ok");
+} else {
+  note("C.num>num:BROKEN");
+}
+var cb = {};
+cb.p = "a";
+cb.p = "b";
+if (cb.p === "b") {
+  note("C.str>str:ok");
+} else {
+  note("C.str>str:BROKEN");
+}
+var cc = {};
+cc.p = true;
+cc.p = false;
+if (cc.p === false) {
+  note("C.bool>bool:ok");
+} else {
+  note("C.bool>bool:BROKEN");
+}
+
+// ---------- transition matrix ----------
+var a1 = {};
+a1.p = 1;
+a1.p = "s";
+if (a1.p === "s") {
+  note("num>str:ok");
+} else {
+  note("num>str:BROKEN");
+}
+
+var a2 = {};
+a2.p = 1;
+a2.p = true;
+if (a2.p === true) {
+  note("num>bool:ok");
+} else {
+  note("num>bool:BROKEN");
+}
+
+var a3 = {};
+a3.p = 1;
+a3.p = null;
+if (a3.p === null) {
+  note("num>null:ok");
+} else {
+  note("num>null:BROKEN");
+}
+
+var a4 = {};
+a4.p = 1;
+a4.p = undefined;
+if (a4.p === undefined) {
+  note("num>undef:ok");
+} else {
+  note("num>undef:BROKEN");
+}
+
+var ox = {};
+var a5 = {};
+a5.p = 1;
+a5.p = ox;
+if (a5.p === ox) {
+  note("num>obj:ok");
+} else {
+  note("num>obj:BROKEN");
+}
+
+var a6 = {};
+a6.p = "s";
+a6.p = 2;
+if (a6.p === 2) {
+  note("str>num:ok");
+} else {
+  note("str>num:BROKEN");
+}
+
+var a7 = {};
+a7.p = "s";
+a7.p = true;
+if (a7.p === true) {
+  note("str>bool:ok");
+} else {
+  note("str>bool:BROKEN");
+}
+
+var oy = {};
+var a8 = {};
+a8.p = "s";
+a8.p = oy;
+if (a8.p === oy) {
+  note("str>obj:ok");
+} else {
+  note("str>obj:BROKEN");
+}
+
+var a9 = {};
+a9.p = true;
+a9.p = 3;
+if (a9.p === 3) {
+  note("bool>num:ok");
+} else {
+  note("bool>num:BROKEN");
+}
+
+var a10 = {};
+a10.p = true;
+a10.p = "s";
+if (a10.p === "s") {
+  note("bool>str:ok");
+} else {
+  note("bool>str:BROKEN");
+}
+
+var oz = {};
+var a11 = {};
+a11.p = oz;
+a11.p = 4;
+if (a11.p === 4) {
+  note("obj>num:ok");
+} else {
+  note("obj>num:BROKEN");
+}
+
+var ow = {};
+var a12 = {};
+a12.p = ow;
+a12.p = "s";
+if (a12.p === "s") {
+  note("obj>str:ok");
+} else {
+  note("obj>str:BROKEN");
+}
+
+// ---------- per-SLOT or per-SHAPE? ----------
+var s1 = {};
+s1.p = 1;
+s1.p = "s";
+var s2 = {};
+s2.p = "s";
+if (s2.p === "s") {
+  note("shape-sibling:ok");
+} else {
+  note("shape-sibling:BROKEN");
+}
+
+// ---------- literal initialiser vs assignment ----------
+var L1 = { p: 1 };
+L1.p = "s";
+if (L1.p === "s") {
+  note("literal-num>str:ok");
+} else {
+  note("literal-num>str:BROKEN");
+}
+
+var L2 = { p: "a" };
+L2.p = "b";
+if (L2.p === "b") {
+  note("C.literal-str>str:ok");
+} else {
+  note("C.literal-str>str:BROKEN");
+}
+
+// ---------- does a THIRD write recover the slot? ----------
+var r = {};
+r.p = 1;
+r.p = "s";
+r.p = "t";
+if (r.p === "t") {
+  note("third-write:recovers");
+} else {
+  note("third-write:still-broken");
+}
+
+// ---------- is the corrupted value self-unequal (sNaN-like)? ----------
+var z = {};
+z.p = 1;
+z.p = "s";
+var zv = z.p;
+if (zv !== zv) {
+  note("corrupt:self-unequal");
+} else {
+  note("corrupt:self-equal");
+}
+
+throw new Test262Error("P6 " + report);


### PR DESCRIPTION
Docs + fixture only. No `src/` changes.

## #3669 — property slot monomorphism

A property slot seeded with a **number** or **boolean** corrupts on _some_ later writes of a different value kind:

```js
var o = {};
o.p = 1;
o.p = "unlikelyValue";
o.p === "unlikelyValue"; // false
typeof o.p; // "string"   <-- tag says string
o.p !== o.p; // true       <-- payload is sNaN
```

The tag and payload disagree, so the write **partially landed** — this is the sNaN-like type-default sentinel #2760 already names.

**This is the defect actually gating `propertyHelper`**, not the detached-builtin story. `propertyHelper.js:isWritable` decides writability by assigning the string `"unlikelyValue"` over the value and reading it back, so `verifyProperty` reports _"descriptor should be writable"_ on any numeric property of a user-created object — reachable from **plain assignment**, with no `defineProperty`, no detached reference, no descriptor sidecar.

### Characterisation

Through the real assembled harness, positive control on every run, reading verified **deterministic** (byte-identical repeat):

| seed \ write | number    | string     | boolean   | null       | undefined | object     |
| ------------ | --------- | ---------- | --------- | ---------- | --------- | ---------- |
| **number**   | ok (ctrl) | **BROKEN** | ok        | **BROKEN** | ok        | **BROKEN** |
| **string**   | ok        | ok (ctrl)  | ok        | –          | –         | ok         |
| **boolean**  | **BROKEN**| **BROKEN** | ok (ctrl) | –          | –         | –          |
| **object**   | ok        | ok         | –         | –          | –         | –          |

- **5 of 12 cross-kind transitions broken, 7 fine.** Selective, **not** uniform — so this is _not_ one missing widening primitive. `num→bool` works while `bool→num` fails; that asymmetry is the sharpest lead.
- **Per-slot, not per-shape** — an identically-built sibling object is unaffected.
- Object-literal initialiser behaves exactly like assignment; the slot does not recover on a third write.

Framed under the **`value-rep-substrate` goal (#2773)** with **#2760** as the closest sibling, rather than inventing a new framing. A lane note records that implementation belongs to Lane B per `lane-partition.md`.

**Reach bounds only** (5,067 `verifyProperty` callers). **No flip count is quoted** — measure with `scripts/harness-flip-probe.ts` (#3668) first. The circulating "~1,038" figure is unrelated and explicitly not reused.

Context: the author of #3667 (detached builtins) measured their candidate fix as a **no-op** and parked it. My 2x2 grid found that defect is exactly one cell, and it cannot explain the reproducer here.

## #3670 — local/CI lane divergence

Three baseline-`pass` tests fail on the local harness lane on current tip. Filed rather than chased; PR #3653 is ruled out (docs-only). It cannot produce a false flip in a local-vs-local A/B — only cost sensitivity — but it is the second divergence sighting this session, and the baseline is what the PR regression gate scores against.

## Also

`scripts/fixtures/issue-3669-monomorphism/transitions.js` — the reproducer, committed so the next person can re-run it directly via the #3668 instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
