### PR TITLE
docs(acorn): file self-parse benchmark follow-ups

### DIFF
--- a/plan/issues/3673-compiled-acorn-selfparse-performance.md
+++ b/plan/issues/3673-compiled-acorn-selfparse-performance.md
@@ -1,0 +1,116 @@
+---
+id: 3673
+title: "Compiled Acorn self-parse is 1,300–1,500× slower than node-acorn"
+status: ready
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+task_type: performance
+area: compiler, codegen, runtime, observability
+language_feature: dynamic-dispatch
+goal: performance
+es_edition: n/a
+related: [1710, 1712, 2928, 3437, 3675]
+---
+
+# #3673 — Make compiled Acorn self-parse performance usable
+
+## Problem
+
+Acorn 8.16.0 compiled by js2wasm now produces exact ESTree for every tracked
+Test262 parser input (#1712), but parsing Acorn's own distribution is roughly
+three orders of magnitude slower than node-acorn. Correctness is complete for
+the JS-host artifact; performance is not production-ready.
+
+The measured input was the pinned `acorn@8.16.0` `dist/acorn.mjs`:
+
+- 230,975 UTF-8 bytes;
+- SHA-256
+  `efb0124a960b34d53f9928c4926bfcfd300bb6a3d7ab64ee949b3a8bed1c7e5f`;
+- options `{ ecmaVersion: 2025, sourceType: "module" }`;
+- compiler revision `2bf320a91f330727ac2b7d9cc05cf13aeb982bae`;
+- Node 24.4.1 on macOS arm64.
+
+The protocol used three warmups, fifteen measured samples, alternating lane
+order, and forced GC outside each timed sample.
+
+### Public `parse()` lane
+
+This lane calls the public parser export and materializes the complete AST on
+the host.
+
+| Metric     |  node-acorn | compiled Acorn |
+| ---------- | ----------: | -------------: |
+| median     |   19.745 ms |  25,914.072 ms |
+| p25        |   18.809 ms |  25,318.868 ms |
+| p75        |   24.724 ms |  28,138.480 ms |
+| mean       |   21.252 ms |  27,111.723 ms |
+| throughput | 11.698 MB/s |  0.008913 MB/s |
+
+The median slowdown is **1,312.451×** and the mean slowdown is **1,275.740×**.
+The compiled artifact is 681,946 bytes. js2wasm compilation took 8,351.925 ms,
+while native `WebAssembly.compile` and instantiation took 1.465 ms and
+16.270 ms respectively.
+
+### In-module body-length lane
+
+To separate parser execution from AST host marshalling, a second module calls
+Acorn internally and returns only `Program.body.length`.
+
+| Metric     |  node-acorn | compiled Acorn |
+| ---------- | ----------: | -------------: |
+| median     |   17.394 ms |  26,691.089 ms |
+| p25        |   13.810 ms |  26,254.397 ms |
+| p75        |   19.996 ms |  27,540.707 ms |
+| mean       |   17.068 ms |  27,869.387 ms |
+| throughput | 13.279 MB/s |  0.008654 MB/s |
+
+The median slowdown is **1,534.511×** and the mean slowdown is **1,632.884×**.
+The augmented module is 915,284 bytes. Its js2wasm compilation,
+`WebAssembly.compile`, and instantiation took 10,285.972 ms, 2.544 ms, and
+20.879 ms.
+
+Because the in-module lane is not faster than the public lane, AST host
+marshalling is not the dominant cost. The remaining cost is inside compiled
+parser execution and its runtime/dynamic-dispatch paths. A profile is required
+before assigning the cost to a particular call family.
+
+## Required investigation
+
+- Check in a repeatable benchmark with both the public-AST and in-module scalar
+  lanes, the pinned input hash, warmups, sample count, alternating order, and
+  percentile output.
+- Capture profiles/counters that separate generated parser work from runtime
+  method/property dispatch, string operations, RegExp operations, allocation,
+  and host bridge calls.
+- Identify the smallest set of hot paths responsible for at least 80% of
+  compiled wall time. Do not infer that AST marshalling is the bottleneck from
+  the public lane.
+- Optimize the measured hot path without replacing Acorn with a parser-specific
+  intrinsic or changing the public
+  `parse(nativeString, optionsObject) -> ESTree object` contract.
+
+## Acceptance criteria
+
+- The benchmark is reproducible from a clean checkout and emits
+  machine-readable raw samples plus median, p25, p75, mean, throughput, binary
+  size, compiler time, Wasm compile time, and instantiation time.
+- A before/after profile records the dominant cost centers and explains at
+  least 80% of the compiled execution time.
+- Both compiled lanes improve by at least **10×** from the measurements above
+  on the same machine/protocol, with no more than a 10% node-acorn control
+  drift. If host variability prevents that comparison, use paired sample
+  ratios and record the control distribution.
+- The required 23-input Acorn corpus, the exact full Test262 AST differential,
+  and the zero-import standalone scalar canaries remain green.
+- Any remaining gap above 10× native is split into measured, non-overlapping
+  follow-up issues before this issue closes.
+
+## Scope boundary
+
+This issue owns parser execution performance. The standalone full-source
+illegal cast is #3675. Oversized static string initialization is #3674.

--- a/plan/issues/3674-large-string-literal-array-new-fixed-limit.md
+++ b/plan/issues/3674-large-string-literal-array-new-fixed-limit.md
@@ -1,0 +1,79 @@
+---
+id: 3674
+title: "Large string literals emit array.new_fixed beyond V8's 10,000-element limit"
+status: ready
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: compiler, codegen, strings
+language_feature: string-literals
+goal: self-hosting-dogfood
+es_edition: n/a
+related: [1712, 2928, 3673, 3675]
+---
+
+# #3674 — Chunk large static string initialization
+
+## Problem
+
+Embedding Acorn's 230,975-byte distribution as one source literal in a
+standalone self-parse canary produces a Wasm module that V8 refuses to compile:
+
+```text
+WebAssembly.compile(): Compiling function "__module_init" failed:
+Requested length 230947 for array.new_fixed too large, maximum is 10000
+```
+
+The compiler emits the entire static string backing array through one
+`array.new_fixed`. V8 caps that instruction's immediate element count at
+10,000, so otherwise valid JavaScript source becomes invalid for an
+implementation-specific Wasm validation limit.
+
+Chunking the source into 8,000-character literals and joining the chunks before
+the parser call works around this validator failure. That workaround is useful
+for isolating #3675, but callers should not need to rewrite large literals to
+make compiler output valid.
+
+## Required change
+
+- Lower large static string backing data through bounded chunks or another
+  initialization path that never requests more than the engine-supported
+  element count in one `array.new_fixed`.
+- Preserve exact UTF-16 code units, including lone surrogates and non-BMP
+  characters; byte-oriented splitting must not corrupt JavaScript string
+  semantics.
+- Keep small literals on their current compact path where profitable.
+- Apply the bound from one shared lowering policy rather than an
+  Acorn-specific source rewrite.
+
+## Acceptance criteria
+
+- Standalone modules containing literals of 10,000, 10,001, and at least
+  230,975 UTF-16 code units validate and instantiate in V8.
+- Each literal round-trips exactly, including boundary cases with a surrogate
+  pair or lone surrogate across an internal chunk boundary.
+- The Acorn full-source wrapper compiles without manually splitting or joining
+  the source in user code and retains zero function imports.
+- Generated code contains no `array.new_fixed` whose immediate element count
+  exceeds the supported bound.
+- Existing small-string, native-string, and standalone Acorn canaries remain
+  green.
+
+## Test plan
+
+- Add the 10,000/10,001/230,975-code-unit and surrogate-boundary matrix to
+  `tests/issue-3674.test.ts`.
+- Extend `tests/dogfood/acorn-standalone-compile.mjs` with the direct,
+  unchunked-source wrapper so the real pinned Acorn input guards the lowering
+  path.
+
+## Scope boundary
+
+This issue owns static data lowering and Wasm validation only. The
+post-workaround runtime `illegal cast` while Acorn parses its full source is
+#3675; parser throughput is #3673.

--- a/plan/issues/3675-standalone-acorn-full-selfparse-illegal-cast.md
+++ b/plan/issues/3675-standalone-acorn-full-selfparse-illegal-cast.md
@@ -1,0 +1,107 @@
+---
+id: 3675
+title: "Standalone compiled Acorn traps parsing its full source at parseFloat/reset dispatch"
+status: ready
+sprint: current
+created: 2026-07-26
+updated: 2026-07-26
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, runtime, standalone
+language_feature: dynamic-dispatch
+goal: self-hosting-dogfood
+es_edition: n/a
+related: [1712, 2853, 2928, 3033, 3673, 3674]
+---
+
+# #3675 — Parse full Acorn source in a zero-import standalone artifact
+
+## Problem
+
+The merged Acorn acceptance gate proves exact JS-host AST parity and four
+zero-import standalone scalar canaries. The standalone artifact still does not
+parse Acorn's complete 230,975-byte distribution.
+
+After working around #3674 by joining 8,000-character chunks inside the module,
+standalone compilation and instantiation succeed with zero imports. Invoking
+the full-source self-parse traps:
+
+```text
+RuntimeError: illegal cast
+    at parseFloat
+    at __closure_575
+    at __call_fn_method_3
+    at __apply_closure
+    at __extern_method_call
+    at __call_m_reset_3
+    at __closure_673
+    at __call_fn_method_0
+    at __apply_closure
+    at __extern_method_call
+```
+
+The exact input and options are:
+
+- pinned `acorn@8.16.0` `dist/acorn.mjs`;
+- 230,975 UTF-8 bytes;
+- SHA-256
+  `efb0124a960b34d53f9928c4926bfcfd300bb6a3d7ab64ee949b3a8bed1c7e5f`;
+- `{ ecmaVersion: 2025, sourceType: "module" }`;
+- compiler revision `2bf320a91f330727ac2b7d9cc05cf13aeb982bae`.
+
+This is a size/shape-dependent runtime path, not evidence that the exported
+parser is generally broken. The 1,754,426-byte base standalone Acorn artifact
+still validates, has zero imports, and passes:
+
+- `parse("1 + 2", ...) -> body.length === 1`;
+- `parseExpressionAt(...)` scalar canary;
+- `tokenizer(...)` scalar canary;
+- `parse("function f(a,b) { return a + b; }", ...)` scalar canary.
+
+The JS-host artifact also remains exact across 53,259 Test262 files and 102,312
+script/module/strict variants.
+
+## Required investigation
+
+- Reduce the full source while preserving the `parseFloat` /
+  `__call_m_reset_3` illegal-cast path, or instrument carrier type identities at
+  the failing dispatch boundary.
+- Determine whether the wrong receiver, closure target, structural function
+  type, or reconstructed object crosses `__extern_method_call`.
+- Fix the shared carrier/dispatch rule. Do not special-case Acorn method names
+  or weaken a `ref.cast` without a proven compatible fallback.
+- Keep the parser and AST inside one standalone module for this gate; canonical
+  cross-module AST/string rec-group packaging remains separate E6/#2527 work.
+
+## Acceptance criteria
+
+- A zero-function-import standalone wrapper parses the pinned complete
+  `acorn.mjs` input with the options above and returns an in-module scalar
+  checksum or body-length result equal to node-acorn.
+- The full parse completes without `illegal cast`, host-satisfied imports, or a
+  parser-specific intrinsic.
+- A reduced regression fixture exercises the same receiver/callable carrier
+  transition that previously trapped.
+- The four existing standalone scalar canaries remain green.
+- The required 23-input JS-host corpus and exact full Test262 differential
+  remain green.
+- The final artifact's function-import count, byte size, compile time, and
+  self-parse time are recorded. Performance remediation is owned by #3673.
+
+## Test plan
+
+- Add the reduced carrier transition to `tests/issue-3675.test.ts`.
+- Extend `tests/dogfood/acorn-standalone-compile.mjs` with an opt-in full-source
+  self-parse gate that asserts zero function imports and compares the in-module
+  scalar result with node-acorn.
+- Keep `tests/dogfood/acorn.test.ts` and
+  `tests/issue-1712-acorn-context.test.ts` in the scoped regression run.
+
+## Scope boundary
+
+This issue does not own the static large-literal validator failure (#3674), the
+general parser performance gap (#3673), or the E6 cross-module rec-group/export
+ABI.


### PR DESCRIPTION
## Summary

- file #3673 for the measured 1,300–1,500× compiled-Acorn self-parse slowdown
- file #3674 for large static strings exceeding the V8 array.new_fixed element limit
- file #3675 for the zero-import standalone full-source parseFloat/reset illegal cast
- keep all three in the live budget window with sprint: current

Each issue records the pinned Acorn source/hash, measured evidence, a non-overlapping scope boundary, and quantitative acceptance criteria.

## Validation

- issue IDs reserved atomically on the assignment ledger
- live-main tree check confirms #3673/#3674/#3675 are free
- no duplicate staged/worktree issue IDs
- issue-spec coverage clean
- Prettier and git diff checks pass

## CLA

- [x] I have read and agree to the CLA